### PR TITLE
chore: add DCO action on pull_request only

### DIFF
--- a/.github/workflows/dco.yaml
+++ b/.github/workflows/dco.yaml
@@ -1,0 +1,8 @@
+name: DCO Check
+
+on:
+  pull_request:
+
+jobs:
+  dco:
+    runs-on: ubuntu-20.04


### PR DESCRIPTION
Based on https://github.com/marketplace/actions/actions-dco to
enforce the Developer Certificate of Origin (DCO)

Closes #40