### PR TITLE
feat: fencing limitation removed

### DIFF
--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -216,17 +216,6 @@ func (r *ClusterReconciler) reconcile(ctx context.Context, cluster *apiv1.Cluste
 	// Get the replication status
 	instancesStatus := r.getStatusFromInstances(ctx, resources.pods)
 
-	// If at least one Pod reports a fenced status, we skip the
-	// reconcile loop.
-	//
-	// This is equivalent of a cluster-level fencing, but we should
-	// keep in mind that the logic handled by the instance manager
-	// is still working in the Pods which are not fenced.
-	if instancesStatus.ShouldSkipReconcile() {
-		contextLogger.Info("An instance asked to skip reconciliation, will retry")
-		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
-	}
-
 	// Verify the architecture of all the instances and update the OnlineUpdateEnabled
 	// field in the status
 	onlineUpdateEnabled := configuration.Current.EnableInstanceManagerInplaceUpdates
@@ -271,6 +260,12 @@ func (r *ClusterReconciler) handleSwitchover(
 	instancesStatus postgres.PostgresqlStatusList,
 ) (*ctrl.Result, error) {
 	contextLogger := log.FromContext(ctx)
+	if cluster.IsInstanceFenced(cluster.Status.CurrentPrimary) ||
+		instancesStatus.ReportingMightBeUnavailable(cluster.Status.CurrentPrimary) {
+		contextLogger.Info("The current primary instance is fenced or is still recovering from it," +
+			" we won't trigger a switchover")
+		return nil, nil
+	}
 	if cluster.Status.Phase == apiv1.PhaseInplaceDeletePrimaryRestart {
 		if cluster.Status.ReadyInstances != cluster.Spec.Instances {
 			contextLogger.Info("Waiting for the primary to be restarted without triggering a switchover")
@@ -428,7 +423,7 @@ func (r *ClusterReconciler) reconcileResources(
 	}
 
 	// If we still need more instances, we need to wait before setting healthy status
-	if cluster.Status.ReadyInstances != cluster.Spec.Instances {
+	if cluster.Status.ReadyInstances != cluster.Spec.Instances-instancesStatus.InstancesReportingMightBeUnavailable() {
 		return ctrl.Result{RequeueAfter: 1 * time.Second}, ErrNextLoop
 	}
 
@@ -577,7 +572,7 @@ func (r *ClusterReconciler) ReconcilePods(ctx context.Context, cluster *apiv1.Cl
 	// Work on the PVCs we currently have
 	pvcNeedingMaintenance := len(cluster.Status.DanglingPVC) + len(cluster.Status.InitializingPVC)
 	if pvcNeedingMaintenance > 0 {
-		return r.reconcilePVCs(ctx, cluster, resources)
+		return r.reconcilePVCs(ctx, cluster, resources, instancesStatus)
 	}
 
 	if err := r.ensureHealthyPVCsAnnotation(ctx, cluster, resources); err != nil {
@@ -601,14 +596,16 @@ func (r *ClusterReconciler) ReconcilePods(ctx context.Context, cluster *apiv1.Cl
 	// Stop acting here if there are non-ready Pods unless in maintenance reusing PVCs.
 	// The user have chosen to wait for the missing nodes to come up
 	if !(cluster.IsNodeMaintenanceWindowInProgress() && cluster.IsReusePVCEnabled()) &&
-		cluster.Status.ReadyInstances < cluster.Status.Instances {
+		cluster.Status.ReadyInstances+instancesStatus.InstancesReportingMightBeUnavailable() <
+			cluster.Status.Instances {
 		contextLogger.Debug("Waiting for Pods to be ready")
 		return ctrl.Result{RequeueAfter: 1 * time.Second}, ErrNextLoop
 	}
 
 	// Are there missing nodes? Let's create one
 	if cluster.Status.Instances < cluster.Spec.Instances &&
-		cluster.Status.ReadyInstances == cluster.Status.Instances {
+		cluster.Status.ReadyInstances+instancesStatus.InstancesReportingMightBeUnavailable() ==
+			cluster.Status.Instances {
 		newNodeSerial, err := r.generateNodeSerial(ctx, cluster)
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("cannot generate node serial: %w", err)

--- a/controllers/cluster_create.go
+++ b/controllers/cluster_create.go
@@ -1111,8 +1111,7 @@ func (r *ClusterReconciler) reconcilePVCs(
 	contextLogger := log.FromContext(ctx)
 
 	if !cluster.IsNodeMaintenanceWindowInProgress() &&
-		cluster.Status.Instances-cluster.Status.ReadyInstances !=
-			instancesStatus.InstancesReportingMightBeUnavailable() {
+		instancesStatus.InstancesReportingStatus() != cluster.Status.Instances {
 		// A pod is not ready, let's retry
 		contextLogger.Debug("Waiting for node to be ready before attaching PVCs")
 		return ctrl.Result{RequeueAfter: 1 * time.Second}, ErrNextLoop

--- a/controllers/cluster_create.go
+++ b/controllers/cluster_create.go
@@ -1106,10 +1106,13 @@ func (r *ClusterReconciler) reconcilePVCs(
 	ctx context.Context,
 	cluster *apiv1.Cluster,
 	resources *managedResources,
+	instancesStatus postgres.PostgresqlStatusList,
 ) (ctrl.Result, error) {
 	contextLogger := log.FromContext(ctx)
 
-	if !cluster.IsNodeMaintenanceWindowInProgress() && cluster.Status.ReadyInstances != cluster.Status.Instances {
+	if !cluster.IsNodeMaintenanceWindowInProgress() &&
+		cluster.Status.Instances-cluster.Status.ReadyInstances !=
+			instancesStatus.InstancesReportingMightBeUnavailable() {
 		// A pod is not ready, let's retry
 		contextLogger.Debug("Waiting for node to be ready before attaching PVCs")
 		return ctrl.Result{RequeueAfter: 1 * time.Second}, ErrNextLoop

--- a/controllers/cluster_status.go
+++ b/controllers/cluster_status.go
@@ -689,18 +689,18 @@ func (r *ClusterReconciler) RegisterPhase(ctx context.Context,
 // in the result list
 func (r *ClusterReconciler) extractInstancesStatus(
 	ctx context.Context,
-	filteredPods []corev1.Pod,
+	activePods []corev1.Pod,
 ) postgres.PostgresqlStatusList {
 	var result postgres.PostgresqlStatusList
 
-	for idx := range filteredPods {
-		instanceStatus := r.getReplicaStatusFromPodViaHTTP(ctx, filteredPods[idx])
+	for idx := range activePods {
+		instanceStatus := r.getReplicaStatusFromPodViaHTTP(ctx, activePods[idx])
 
 		// IsReady is not populated by the instance manager, so we detect it from the
 		// Pod status
-		instanceStatus.IsReady = utils.IsPodActive(filteredPods[idx]) && utils.IsPodReady(filteredPods[idx])
-		instanceStatus.Node = filteredPods[idx].Spec.NodeName
-		instanceStatus.Pod = filteredPods[idx]
+		instanceStatus.IsReady = utils.IsPodReady(activePods[idx])
+		instanceStatus.Node = activePods[idx].Spec.NodeName
+		instanceStatus.Pod = activePods[idx]
 
 		result.Items = append(result.Items, instanceStatus)
 	}

--- a/controllers/cluster_status.go
+++ b/controllers/cluster_status.go
@@ -698,7 +698,7 @@ func (r *ClusterReconciler) extractInstancesStatus(
 
 		// Here we need to have pod marked as ready even when they are fenced. We want this
 		// to avoid a fenced primary to cause a failover to a different Pod.
-		instanceStatus.IsReady = instanceStatus.IsReady || utils.IsPodReady(filteredPods[idx])
+		instanceStatus.IsReady = utils.IsPodReady(filteredPods[idx])
 		instanceStatus.Node = filteredPods[idx].Spec.NodeName
 		instanceStatus.Pod = filteredPods[idx]
 

--- a/controllers/cluster_status.go
+++ b/controllers/cluster_status.go
@@ -696,9 +696,9 @@ func (r *ClusterReconciler) extractInstancesStatus(
 	for idx := range filteredPods {
 		instanceStatus := r.getReplicaStatusFromPodViaHTTP(ctx, filteredPods[idx])
 
-		// Here we need to have pod marked as ready even when they are fenced. We want this
-		// to avoid a fenced primary to cause a failover to a different Pod.
-		instanceStatus.IsReady = utils.IsPodReady(filteredPods[idx])
+		// IsReady is not populated by the instance manager, so we detect it from the
+		// Pod status
+		instanceStatus.IsReady = utils.IsPodActive(filteredPods[idx]) && utils.IsPodReady(filteredPods[idx])
 		instanceStatus.Node = filteredPods[idx].Spec.NodeName
 		instanceStatus.Pod = filteredPods[idx]
 

--- a/docs/src/fencing.md
+++ b/docs/src/fencing.md
@@ -94,21 +94,12 @@ required. Then:
   set to 1
 
 !!! Warning
-    When at least one instance in a `Cluster` is fenced, failovers/switchovers for that
-    `Cluster` will be blocked until the fence is lifted, as the status of the `Cluster`
-    cannot be considered stable.
-
-    In particular, if a **primary instance** will be fenced, the postmaster process
-    will be shut down but no failover will happen, interrupting the operativity of
+    If a **primary instance** is fenced, its postmaster process
+    is shut down but no failover is performed, interrupting the operativity of
     the applications. When the fence will be lifted, the primary instance will be
-    started up again without any failover happening.
+    started up again without performing a failover.
 
-    Given that, we advise the user to fence only replica instances when possible.
-
-!!! Warning
-    If the primary is the only fenced instance in a `Cluster` and the pod is deleted, a
-    failover will be performed. When the fence on the old primary is lifted, that instance
-    is restarted as a standby (follower of the new primary).
+    Given that, we advise users to fence primary instances only if strictly required
 
 If a fenced instance is deleted, the pod will be recreated normally, but the
 postmaster won't be started. This can be extremely helpful when instances

--- a/docs/src/fencing.md
+++ b/docs/src/fencing.md
@@ -99,7 +99,7 @@ required. Then:
     the applications. When the fence will be lifted, the primary instance will be
     started up again without performing a failover.
 
-    Given that, we advise users to fence primary instances only if strictly required
+    Given that, we advise users to fence primary instances only if strictly required.
 
 If a fenced instance is deleted, the pod will be recreated normally, but the
 postmaster won't be started. This can be extremely helpful when instances

--- a/pkg/management/postgres/probes.go
+++ b/pkg/management/postgres/probes.go
@@ -85,8 +85,6 @@ func (instance *Instance) GetStatus() (result *postgres.PostgresqlStatus, err er
 		if err != nil {
 			return
 		}
-		// force the instance to be reported as ready
-		result.IsReady = true
 	}()
 
 	if instance.PgRewindIsRunning {

--- a/pkg/postgres/status.go
+++ b/pkg/postgres/status.go
@@ -18,6 +18,8 @@ package postgres
 
 import (
 	corev1 "k8s.io/api/core/v1"
+
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 )
 
 // PostgresqlStatus defines a status for every instance in the cluster
@@ -230,11 +232,11 @@ func (list PostgresqlStatusList) ReportingMightBeUnavailable(instance string) bo
 	return false
 }
 
-// InstancesReportingMightBeUnavailable returns the number of instances that might be unavailable
-func (list PostgresqlStatusList) InstancesReportingMightBeUnavailable() int32 {
-	var n int32
+// InstancesReportingStatus returns the number of instances that are Ready or MightBeUnavailable
+func (list PostgresqlStatusList) InstancesReportingStatus() int {
+	var n int
 	for _, item := range list.Items {
-		if item.MightBeUnavailable {
+		if utils.IsPodActive(item.Pod) && utils.IsPodReady(item.Pod) || item.MightBeUnavailable {
 			n++
 		}
 	}

--- a/pkg/postgres/status.go
+++ b/pkg/postgres/status.go
@@ -219,13 +219,25 @@ func (list PostgresqlStatusList) ArePodsWaitingForDecreasedSettings() bool {
 	return false
 }
 
-// ShouldSkipReconcile checks whether at least an instance is asking for the reconciliation loop to be skipped
-func (list PostgresqlStatusList) ShouldSkipReconcile() bool {
+// ReportingMightBeUnavailable checks whether the given instance might be unavailable
+func (list PostgresqlStatusList) ReportingMightBeUnavailable(instance string) bool {
 	for _, item := range list.Items {
-		if item.MightBeUnavailable {
+		if item.Pod.Name == instance && item.MightBeUnavailable {
 			return true
 		}
 	}
 
 	return false
+}
+
+// InstancesReportingMightBeUnavailable returns the number of instances that might be unavailable
+func (list PostgresqlStatusList) InstancesReportingMightBeUnavailable() int32 {
+	var n int32
+	for _, item := range list.Items {
+		if item.MightBeUnavailable {
+			n++
+		}
+	}
+
+	return n
 }

--- a/pkg/postgres/status_test.go
+++ b/pkg/postgres/status_test.go
@@ -128,9 +128,17 @@ var _ = Describe("PostgreSQL status", func() {
 				},
 			},
 		}
-		Expect(podList.ShouldSkipReconcile()).To(BeFalse())
+		Expect(podList.ReportingMightBeUnavailable(podList.Items[0].Pod.Name)).To(BeFalse())
+		Expect(podList.ReportingMightBeUnavailable(podList.Items[1].Pod.Name)).To(BeFalse())
+		Expect(podList.InstancesReportingMightBeUnavailable()).To(BeEquivalentTo(0))
+		podList.Items[1].MightBeUnavailable = true
+		Expect(podList.ReportingMightBeUnavailable(podList.Items[0].Pod.Name)).To(BeFalse())
+		Expect(podList.ReportingMightBeUnavailable(podList.Items[1].Pod.Name)).To(BeTrue())
+		Expect(podList.InstancesReportingMightBeUnavailable()).To(BeEquivalentTo(1))
 		podList.Items[0].MightBeUnavailable = true
-		Expect(podList.ShouldSkipReconcile()).To(BeTrue())
+		Expect(podList.ReportingMightBeUnavailable(podList.Items[0].Pod.Name)).To(BeTrue())
+		Expect(podList.ReportingMightBeUnavailable(podList.Items[1].Pod.Name)).To(BeTrue())
+		Expect(podList.InstancesReportingMightBeUnavailable()).To(BeEquivalentTo(2))
 	})
 
 	Describe("when sorted", func() {

--- a/pkg/postgres/status_test.go
+++ b/pkg/postgres/status_test.go
@@ -130,15 +130,15 @@ var _ = Describe("PostgreSQL status", func() {
 		}
 		Expect(podList.ReportingMightBeUnavailable(podList.Items[0].Pod.Name)).To(BeFalse())
 		Expect(podList.ReportingMightBeUnavailable(podList.Items[1].Pod.Name)).To(BeFalse())
-		Expect(podList.InstancesReportingMightBeUnavailable()).To(BeEquivalentTo(0))
+		Expect(podList.InstancesReportingStatus()).To(BeEquivalentTo(0))
 		podList.Items[1].MightBeUnavailable = true
 		Expect(podList.ReportingMightBeUnavailable(podList.Items[0].Pod.Name)).To(BeFalse())
 		Expect(podList.ReportingMightBeUnavailable(podList.Items[1].Pod.Name)).To(BeTrue())
-		Expect(podList.InstancesReportingMightBeUnavailable()).To(BeEquivalentTo(1))
+		Expect(podList.InstancesReportingStatus()).To(BeEquivalentTo(1))
 		podList.Items[0].MightBeUnavailable = true
 		Expect(podList.ReportingMightBeUnavailable(podList.Items[0].Pod.Name)).To(BeTrue())
 		Expect(podList.ReportingMightBeUnavailable(podList.Items[1].Pod.Name)).To(BeTrue())
-		Expect(podList.InstancesReportingMightBeUnavailable()).To(BeEquivalentTo(2))
+		Expect(podList.InstancesReportingStatus()).To(BeEquivalentTo(2))
 	})
 
 	Describe("when sorted", func() {


### PR DESCRIPTION
With this patch we push down the fencing condition, so that fencing a
single instance will not anymore imply the whole cluster being fenced.
This way if a follower instace is fenced, in case of falure of the
primary instance, failovers will still be performed. In case of
deletion of a fenced instance, the pod will be recreated, relabelled
according to the previous role and if it was a primary instance, the
operator will not perform a failover as before.

Closes #44 