### PR TITLE
fix: add missing `}` in chatops-receiver workflow

### DIFF
--- a/.github/workflows/chatops-receiver.yml
+++ b/.github/workflows/chatops-receiver.yml
@@ -31,7 +31,7 @@ jobs:
                   || github.event.client_payload.slash_command.args.named.depth }}",
             "test_level":"${{ github.event.client_payload.slash_command.args.named.tl
                   || github.event.client_payload.slash_command.args.named.level
-                  || github.event.client_payload.slash_command.args.named.test_level }}"
+                  || github.event.client_payload.slash_command.args.named.test_level }}"}
       - name: Create comment
         uses: peter-evans/create-or-update-comment@v2
         with:


### PR DESCRIPTION
Signed-off-by: Jonathan Gonzalez V <jonathan.gonzalez@enterprisedb.com>