### PR TITLE
feat: allow configuration of `archive_timeout` setting

### DIFF
--- a/docs/src/backup_recovery.md
+++ b/docs/src/backup_recovery.md
@@ -529,6 +529,15 @@ PostgreSQL implements a sequential archiving scheme, where the
 `archive_command` will be executed sequentially for every WAL
 segment to be archived.
 
+!!! Important
+    By default, CloudNativePG sets `archive_timeout` to `5min`, ensuring
+    that WAL files, even in case of low workloads, are closed and archived
+    at least every 5 minutes, providing a deterministic time-based value for
+    your Recovery Point Objective (RPO). Even though you change the value
+    of the [`archive_timeout` setting in the PostgreSQL configuration](https://www.postgresql.org/docs/current/runtime-config-wal.html#GUC-ARCHIVE-TIMEOUT),
+    our experience suggests that the default value set by the operator is
+    suitable for most use cases.
+
 When the bandwidth between the PostgreSQL instance and the object
 store allows archiving more than one WAL file in parallel, you
 can use the parallel WAL archiving feature of the instance manager

--- a/docs/src/postgresql_conf.md
+++ b/docs/src/postgresql_conf.md
@@ -95,7 +95,6 @@ The following parameters are **fixed** and exclusively controlled by the operato
 ```text
 archive_command = '/controller/manager wal-archive %p'
 archive_mode = 'on'
-archive_timeout = '5min'
 full_page_writes = 'on'
 hot_standby = 'true'
 listen_addresses = '*'
@@ -436,7 +435,6 @@ Users are not allowed to set the following configuration parameters in the
 - `archive_cleanup_command`
 - `archive_command`
 - `archive_mode`
-- `archive_timeout`
 - `bonjour`
 - `bonjour_name`
 - `cluster_name`

--- a/pkg/postgres/configuration.go
+++ b/pkg/postgres/configuration.go
@@ -318,7 +318,6 @@ var (
 		// The following parameters need a reload to be applied
 		"archive_cleanup_command":                blockedConfigurationParameter,
 		"archive_command":                        fixedConfigurationParameter,
-		"archive_timeout":                        fixedConfigurationParameter,
 		"full_page_writes":                       fixedConfigurationParameter,
 		"log_destination":                        blockedConfigurationParameter,
 		"log_directory":                          blockedConfigurationParameter,
@@ -356,6 +355,7 @@ var (
 	// default and the mandatory behavior of CNP
 	CnpgConfigurationSettings = ConfigurationSettings{
 		GlobalDefaultSettings: SettingsCollection{
+			"archive_timeout":            "5min",
 			"max_parallel_workers":       "32",
 			"max_worker_processes":       "32",
 			"max_replication_slots":      "32",
@@ -397,7 +397,6 @@ var (
 			"port":                fmt.Sprint(ServerPort),
 			"wal_level":           "logical",
 			"wal_log_hints":       "on",
-			"archive_timeout":     "5min", // TODO support configurable archive timeout
 			"full_page_writes":    "on",
 			"ssl":                 "on",
 			"ssl_cert_file":       ServerCertificateLocation,


### PR DESCRIPTION
Make the `archive_timeout` setting configurable, with a default and
recommended value of 5 minutes.

Closes #86

Signed-off-by: Gabriele Bartolini <gabriele.bartolini@enterprisedb.com>