### PR TITLE
fix: triggers a renconciliation loop if the RBAC for backups is not yet created

### DIFF
--- a/internal/management/controller/cache.go
+++ b/internal/management/controller/cache.go
@@ -1,3 +1,19 @@
+/*
+Copyright The CloudNativePG Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package controller
 
 import (

--- a/internal/management/controller/cache.go
+++ b/internal/management/controller/cache.go
@@ -1,0 +1,90 @@
+package controller
+
+import (
+	"context"
+	"errors"
+	"os"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/manager/walrestore"
+	"github.com/cloudnative-pg/cloudnative-pg/internal/management/cache"
+	barmanCredentials "github.com/cloudnative-pg/cloudnative-pg/pkg/management/barman/credentials"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/log"
+)
+
+// reconcileCacheFromCluster refreshes the reconciler internal cache using the provided cluster
+func (r *InstanceReconciler) reconcileCacheFromCluster(ctx context.Context, cluster *apiv1.Cluster) *ctrl.Result {
+	cache.Store(cache.ClusterKey, cluster)
+
+	// Populate the cache with the backup configuration
+	if result := r.reconcileWALArchiveSettingsCache(ctx, cluster); result != nil {
+		return result
+	}
+
+	// Populate the cache with the recover configuration
+	return r.reconcileWALRestoreSettingsCache(ctx, cluster)
+}
+
+func (r *InstanceReconciler) reconcileWALRestoreSettingsCache(
+	ctx context.Context,
+	cluster *apiv1.Cluster,
+) *ctrl.Result {
+	_, env, barmanConfiguration, err := walrestore.GetRecoverConfiguration(cluster, r.instance.PodName)
+	if errors.Is(err, walrestore.ErrNoBackupConfigured) {
+		cache.Delete(cache.WALRestoreKey)
+		return nil
+	}
+	if err != nil {
+		log.Error(err, "while getting recover configuration")
+		return nil
+	}
+	env = append(env, os.Environ()...)
+
+	envRestore, err := barmanCredentials.EnvSetBackupCloudCredentials(
+		ctx,
+		r.GetClient(),
+		cluster.Namespace,
+		barmanConfiguration,
+		env,
+	)
+	if err != nil {
+		log.Error(err, "while getting recover credentials")
+	}
+	cache.Store(cache.WALRestoreKey, envRestore)
+
+	return nil
+}
+
+func (r *InstanceReconciler) reconcileWALArchiveSettingsCache(
+	ctx context.Context,
+	cluster *apiv1.Cluster,
+) *ctrl.Result {
+	if cluster.Spec.Backup == nil || cluster.Spec.Backup.BarmanObjectStore == nil {
+		cache.Delete(cache.WALArchiveKey)
+		return nil
+	}
+
+	// Populate the cache with the backup configuration
+	envArchive, err := barmanCredentials.EnvSetBackupCloudCredentials(
+		ctx,
+		r.GetClient(),
+		cluster.Namespace,
+		cluster.Spec.Backup.BarmanObjectStore,
+		os.Environ())
+	if apierrors.IsForbidden(err) {
+		log.Info("backup secret not yet ready, running another reconciliation loop")
+		return &ctrl.Result{RequeueAfter: 5 * time.Second}
+	}
+
+	if err != nil {
+		log.Error(err, "while getting backup credentials")
+		return nil
+	}
+
+	cache.Store(cache.WALArchiveKey, envArchive)
+	return nil
+}

--- a/internal/management/controller/cache.go
+++ b/internal/management/controller/cache.go
@@ -33,7 +33,9 @@ import (
 // shouldUpdateCacheFromCluster will update the internal cache with the cluster
 //
 // returns true if the update was not total, and should be retried
-func (r *InstanceReconciler) shouldUpdateCacheFromCluster(ctx context.Context, cluster *apiv1.Cluster) (shouldRequeue bool) {
+func (r *InstanceReconciler) shouldUpdateCacheFromCluster(
+	ctx context.Context, cluster *apiv1.Cluster,
+) (shouldRequeue bool) {
 	cache.Store(cache.ClusterKey, cluster)
 
 	// Populate the cache with the backup configuration

--- a/internal/management/controller/cache.go
+++ b/internal/management/controller/cache.go
@@ -30,22 +30,24 @@ import (
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/log"
 )
 
-// shouldUpdateCacheFromCluster will update the internal cache with the cluster
+// updateCacheFromCluster will update the internal cache with the cluster
 //
 // returns true if the update was not total, and should be retried
-func (r *InstanceReconciler) shouldUpdateCacheFromCluster(
+func (r *InstanceReconciler) updateCacheFromCluster(
 	ctx context.Context, cluster *apiv1.Cluster,
-) (shouldRequeue bool) {
+) shoudRequeue {
 	cache.Store(cache.ClusterKey, cluster)
+
+	var requeue shoudRequeue
 
 	// Populate the cache with the backup configuration
 	if r.shouldUpdateWALArchiveSettingsCache(ctx, cluster) {
-		shouldRequeue = true
+		requeue = true
 	}
 
 	// Populate the cache with the recover configuration
 	r.updateWALRestoreSettingsCache(ctx, cluster)
-	return
+	return requeue
 }
 
 func (r *InstanceReconciler) updateWALRestoreSettingsCache(

--- a/internal/management/controller/instance_controller.go
+++ b/internal/management/controller/instance_controller.go
@@ -102,9 +102,7 @@ func (r *InstanceReconciler) Reconcile(
 	r.reconcileInstance(cluster)
 
 	// Refresh the cache
-	if res := r.reconcileCacheFromCluster(ctx, cluster); res != nil {
-		return *res, nil
-	}
+	shouldRequeue := r.shouldUpdateCacheFromCluster(ctx, cluster)
 
 	// Reconcile monitoring section
 	r.reconcileMetrics(cluster)
@@ -185,6 +183,10 @@ func (r *InstanceReconciler) Reconcile(
 
 	if err := r.reconcileDatabases(ctx, cluster); err != nil {
 		return reconcile.Result{}, fmt.Errorf("cannot reconcile database configurations: %w", err)
+	}
+
+	if shouldRequeue {
+		return reconcile.Result{RequeueAfter: 30 * time.Second}, nil
 	}
 
 	return reconcile.Result{}, nil

--- a/internal/management/controller/instance_controller.go
+++ b/internal/management/controller/instance_controller.go
@@ -22,15 +22,12 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"os"
 	"path"
 	"strconv"
 	"time"
 
-	"github.com/cloudnative-pg/cloudnative-pg/pkg/configfile"
-	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres/constants"
-
 	"github.com/lib/pq"
+
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
@@ -41,14 +38,13 @@ import (
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/controllers"
-	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/manager/walrestore"
-	"github.com/cloudnative-pg/cloudnative-pg/internal/management/cache"
 	"github.com/cloudnative-pg/cloudnative-pg/internal/management/utils"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/certs"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/configfile"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/fileutils"
-	barmanCredentials "github.com/cloudnative-pg/cloudnative-pg/pkg/management/barman/credentials"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/log"
 	postgresManagement "github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres/constants"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres/metrics"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres/webserver/metricserver"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/postgres"
@@ -106,7 +102,9 @@ func (r *InstanceReconciler) Reconcile(
 	r.reconcileInstance(cluster)
 
 	// Refresh the cache
-	r.updateCacheFromCluster(ctx, cluster)
+	if res := r.reconcileCacheFromCluster(ctx, cluster); res != nil {
+		return *res, nil
+	}
 
 	// Reconcile monitoring section
 	r.reconcileMetrics(cluster)
@@ -403,52 +401,6 @@ func (r *InstanceReconciler) IsDBUp(ctx context.Context) error {
 		return err
 	}
 	return nil
-}
-
-// updateCacheFromCluster refreshes the reconciler internal cache using the provided cluster
-func (r *InstanceReconciler) updateCacheFromCluster(ctx context.Context, cluster *apiv1.Cluster) {
-	cache.Store(cache.ClusterKey, cluster)
-
-	// Populate the cache with the backup configuration
-	if cluster.Spec.Backup != nil && cluster.Spec.Backup.BarmanObjectStore != nil {
-		envArchive, err := barmanCredentials.EnvSetBackupCloudCredentials(
-			ctx,
-			r.GetClient(),
-			cluster.Namespace,
-			cluster.Spec.Backup.BarmanObjectStore,
-			os.Environ())
-		if err != nil {
-			log.Error(err, "while getting backup credentials")
-		} else {
-			cache.Store(cache.WALArchiveKey, envArchive)
-		}
-	} else {
-		cache.Delete(cache.WALArchiveKey)
-	}
-
-	// Populate the cache with the recover configuration
-	_, env, barmanConfiguration, err := walrestore.GetRecoverConfiguration(cluster, r.instance.PodName)
-	if errors.Is(err, walrestore.ErrNoBackupConfigured) {
-		cache.Delete(cache.WALRestoreKey)
-		return
-	}
-	if err != nil {
-		log.Error(err, "while getting recover configuration")
-		return
-	}
-	env = append(env, os.Environ()...)
-
-	envRestore, err := barmanCredentials.EnvSetBackupCloudCredentials(
-		ctx,
-		r.GetClient(),
-		cluster.Namespace,
-		barmanConfiguration,
-		env,
-	)
-	if err != nil {
-		log.Error(err, "while getting recover credentials")
-	}
-	cache.Store(cache.WALRestoreKey, envRestore)
 }
 
 // reconcileDatabases reconciles all the existing databases

--- a/internal/management/controller/instance_controller.go
+++ b/internal/management/controller/instance_controller.go
@@ -65,6 +65,9 @@ var RetryUntilWalReceiverDown = wait.Backoff{
 	Steps: math.MaxInt32,
 }
 
+// shouldRequeue specifies whether a new reconciliation loop should be triggered
+type shoudRequeue bool
+
 // Reconcile is the main reconciliation loop for the instance
 // TODO this function needs to be refactor
 //nolint:gocognit
@@ -102,7 +105,7 @@ func (r *InstanceReconciler) Reconcile(
 	r.reconcileInstance(cluster)
 
 	// Refresh the cache
-	shouldRequeue := r.shouldUpdateCacheFromCluster(ctx, cluster)
+	requeue := r.updateCacheFromCluster(ctx, cluster)
 
 	// Reconcile monitoring section
 	r.reconcileMetrics(cluster)
@@ -185,7 +188,7 @@ func (r *InstanceReconciler) Reconcile(
 		return reconcile.Result{}, fmt.Errorf("cannot reconcile database configurations: %w", err)
 	}
 
-	if shouldRequeue {
+	if requeue {
 		return reconcile.Result{RequeueAfter: 30 * time.Second}, nil
 	}
 


### PR DESCRIPTION
It could happen that the RBAC for the secrets needed by backup could not yet be created during an instance manager reconciliation loop, this would generate a `forbidden` error type that was ignored by the process leaving the instance manager cache in an inconsistent state.

To avoid being stuck in an inconsistent state we queue a new reconciliation loop if the error is encountered.

This PR also includes a better organization of the cache reconciliation logic.

closes #85 

Signed-off-by: Armando Ruocco <armando.ruocco@enterprisedb.com>