### PR TITLE
fix: enable CSV logpipe inside WithActiveInstance function

### DIFF
--- a/pkg/management/postgres/instance.go
+++ b/pkg/management/postgres/instance.go
@@ -17,6 +17,7 @@ limitations under the License.
 package postgres
 
 import (
+	"context"
 	"database/sql"
 	"errors"
 	"fmt"
@@ -37,6 +38,7 @@ import (
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/fileutils"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/execlog"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/log"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres/logpipe"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres/pool"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/postgres"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/specs"
@@ -447,10 +449,22 @@ func (instance Instance) WithActiveInstance(inner func() error) error {
 	if err != nil {
 		return fmt.Errorf("while activating instance: %w", err)
 	}
+
+	ctx, ctxCancel := context.WithCancel(context.Background())
+	csvPipe := logpipe.NewLogPipe()
+
+	go func() {
+		if err := csvPipe.Start(ctx); err != nil {
+			log.Info("csv pipeline encountered an error", "err", err)
+		}
+	}()
+
 	defer func() {
 		if err := instance.Shutdown(DefaultShutdownOptions); err != nil {
 			log.Info("Error while deactivating instance", "err", err)
 		}
+		ctxCancel()
+		csvPipe.GetExitedCondition().Wait()
 	}()
 
 	return inner()

--- a/pkg/management/postgres/instance.go
+++ b/pkg/management/postgres/instance.go
@@ -450,6 +450,7 @@ func (instance Instance) WithActiveInstance(inner func() error) error {
 		return fmt.Errorf("while activating instance: %w", err)
 	}
 
+	// Start the CSV logpipe to redirect log to stdout
 	ctx, ctxCancel := context.WithCancel(context.Background())
 	csvPipe := logpipe.NewLogPipe()
 

--- a/pkg/management/postgres/logpipe/logpipe.go
+++ b/pkg/management/postgres/logpipe/logpipe.go
@@ -71,7 +71,7 @@ func (p *LogPipe) GetInitializedCondition() *concurrency.Executed {
 }
 
 // GetExitedCondition returns the condition that can be checked in order to
-// be sure initialization has been done
+// be sure the process has been executed
 func (p *LogPipe) GetExitedCondition() *concurrency.Executed {
 	return p.exited
 }


### PR DESCRIPTION
This patch ensures that we can collect the Postgres log files when we start the instance with the WithActiveInstance function.

It does that by starting a CSV logpipe process with the instance and terminating it before terminating the WithActiveInstance function.


Closes #130

Signed-off-by: Armando Ruocco <armando.ruocco@enterprisedb.com>