### PR TITLE
feat: add support for ARMv8 and ARMv7

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -358,7 +358,7 @@ jobs:
         run: |
           # Keep in mind that adding more platforms (architectures) will increase the building
           # time even if we use the ghcache for the building process.
-          platforms="linux/amd64"
+          platforms="linux/amd64,linux/arm64,linux/arm/v7"
           echo "::set-output name=platforms::${platforms}"
       -
         name: Set up QEMU

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -131,7 +131,7 @@ jobs:
         run: |
           # Keep in mind that adding more platforms (architectures) will increase the building
           # time even if we use the ghcache for the building process.
-          platforms="linux/amd64"
+          platforms="linux/amd64,linux/arm64,linux/arm/v7"
           echo "::set-output name=platforms::${platforms}"
       -
         name: Set up QEMU

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -29,6 +29,8 @@ builds:
     - linux
   goarch:
     - amd64
+    - arm64
+    - arm
 
 - id: kubectl-cnpg
   binary: kubectl-cnpg


### PR DESCRIPTION
Now we build for ARMv8 (arm64) and ARMv7(arm) the operator manager, this
means that we can start the basic support for ARM architectures.

Closes #159 

Signed-off-by: Jonathan Gonzalez V <jonathan.gonzalez@enterprisedb.com>