### PR TITLE
fix: inherit labels/annotations from cluster without restart pod

### DIFF
--- a/controllers/replicas.go
+++ b/controllers/replicas.go
@@ -386,7 +386,8 @@ func (r *ClusterReconciler) updateClusterLabelsOnPods(
 
 		// if all the required labels are already set and with the correct value,
 		// we proceed to the next item
-		if utils.IsLabelSubset(pod.Labels, cluster.Labels, cluster.GetFixedInheritedLabels(), configuration.Current) {
+		if utils.IsLabelSubset(pod.Labels, cluster.Labels, cluster.GetFixedInheritedLabels(),
+			configuration.Current) {
 			contextLogger.Debug(
 				"Skipping cluster label reconciliation, because they are already present on pod",
 				"pod", pod.Name,

--- a/controllers/replicas.go
+++ b/controllers/replicas.go
@@ -343,8 +343,8 @@ func (r *ClusterReconciler) updateClusterAnnotationsOnPods(
 
 		// if all the required annotations are already set and with the correct value,
 		// we proceed to the next item
-		if utils.IsAnnotationSubset(pod.Annotations, cluster.Annotations, configuration.Current,
-			cluster.GetFixedInheritedAnnotations()) &&
+		if utils.IsAnnotationSubset(pod.Annotations, cluster.Annotations, cluster.GetFixedInheritedAnnotations(),
+			configuration.Current) &&
 			utils.IsAnnotationAppArmorPresentInObject(&pod.ObjectMeta, cluster.Annotations) {
 			contextLogger.Debug(
 				"Skipping cluster annotations reconciliation, because they are already present on pod",
@@ -386,7 +386,7 @@ func (r *ClusterReconciler) updateClusterLabelsOnPods(
 
 		// if all the required labels are already set and with the correct value,
 		// we proceed to the next item
-		if utils.IsLabelSubset(pod.Labels, cluster.Labels, configuration.Current, cluster.GetFixedInheritedLabels()) {
+		if utils.IsLabelSubset(pod.Labels, cluster.Labels, cluster.GetFixedInheritedLabels(), configuration.Current) {
 			contextLogger.Debug(
 				"Skipping cluster label reconciliation, because they are already present on pod",
 				"pod", pod.Name,

--- a/controllers/replicas.go
+++ b/controllers/replicas.go
@@ -343,7 +343,8 @@ func (r *ClusterReconciler) updateClusterAnnotationsOnPods(
 
 		// if all the required annotations are already set and with the correct value,
 		// we proceed to the next item
-		if utils.IsAnnotationSubset(pod.Annotations, cluster.Annotations, configuration.Current) &&
+		if utils.IsAnnotationSubset(pod.Annotations, cluster.Annotations, configuration.Current,
+			cluster.GetFixedInheritedAnnotations()) &&
 			utils.IsAnnotationAppArmorPresentInObject(&pod.ObjectMeta, cluster.Annotations) {
 			contextLogger.Debug(
 				"Skipping cluster annotations reconciliation, because they are already present on pod",
@@ -385,7 +386,7 @@ func (r *ClusterReconciler) updateClusterLabelsOnPods(
 
 		// if all the required labels are already set and with the correct value,
 		// we proceed to the next item
-		if utils.IsLabelSubset(pod.Labels, cluster.Labels, configuration.Current) {
+		if utils.IsLabelSubset(pod.Labels, cluster.Labels, configuration.Current, cluster.GetFixedInheritedLabels()) {
 			contextLogger.Debug(
 				"Skipping cluster label reconciliation, because they are already present on pod",
 				"pod", pod.Name,

--- a/pkg/utils/operations.go
+++ b/pkg/utils/operations.go
@@ -91,8 +91,13 @@ func isResourceListSubset(resourceList, subResourceList corev1.ResourceList) boo
 }
 
 // IsLabelSubset checks if a label map is a subset of another
-func IsLabelSubset(mapSet map[string]string, mapSubset map[string]string, configuration *config.Data) bool {
+func IsLabelSubset(mapSet map[string]string, mapSubset map[string]string, configuration *config.Data,
+	fixedLabels map[string]string,
+) bool {
 	mapToEvaluate := map[string]string{}
+	for key, value := range fixedLabels {
+		mapToEvaluate[key] = value
+	}
 	for key, value := range mapSubset {
 		if configuration.IsLabelInherited(key) {
 			mapToEvaluate[key] = value
@@ -103,8 +108,13 @@ func IsLabelSubset(mapSet map[string]string, mapSubset map[string]string, config
 }
 
 // IsAnnotationSubset checks if an annotation map is a subset of another
-func IsAnnotationSubset(mapSet map[string]string, mapSubset map[string]string, configuration *config.Data) bool {
+func IsAnnotationSubset(mapSet map[string]string, mapSubset map[string]string, configuration *config.Data,
+	fixedAnnotations map[string]string,
+) bool {
 	mapToEvaluate := map[string]string{}
+	for key, value := range fixedAnnotations {
+		mapToEvaluate[key] = value
+	}
 	for key, value := range mapSubset {
 		if configuration.IsAnnotationInherited(key) {
 			mapToEvaluate[key] = value

--- a/pkg/utils/operations.go
+++ b/pkg/utils/operations.go
@@ -116,8 +116,8 @@ func IsLabelSubset(mapSet, clusterLabels, fixedInheritedLabels map[string]string
 // IsAnnotationSubset checks if a collection of annotations is a subset of another
 //
 // NOTE: there are two parameters for the annotations to check. The `fixed` one
-// is for labels that certainly should be inherited (`inheritedMetadata` in the spec)
-// The other labels may or may not be inherited depending on the configuration
+// is for annotations that certainly should be inherited (`inheritedMetadata` in the spec)
+// The other annotations may or may not be inherited depending on the configuration
 func IsAnnotationSubset(mapSet, clusterAnnotations, fixedInheritedAnnotations map[string]string,
 	configuration *config.Data,
 ) bool {

--- a/pkg/utils/operations.go
+++ b/pkg/utils/operations.go
@@ -90,17 +90,21 @@ func isResourceListSubset(resourceList, subResourceList corev1.ResourceList) boo
 	return true
 }
 
-// IsLabelSubset checks if a label map is a subset of another
-func IsLabelSubset(mapSet map[string]string, mapSubset map[string]string, fixedLabels map[string]string,
+// IsLabelSubset checks if a collection of labels is a subset of another
+//
+// NOTE: there are two parameters for the labels to check. The `fixed` one
+// is for labels that certainly should be inherited (`inheritedMetadata` in the spec)
+// The other labels may or may not be inherited depending on the configuration
+func IsLabelSubset(mapSet, clusterLabels, fixedInheritedLabels map[string]string,
 	configuration *config.Data,
 ) bool {
 	mapToEvaluate := map[string]string{}
 
-	for key, value := range fixedLabels {
+	for key, value := range fixedInheritedLabels {
 		mapToEvaluate[key] = value
 	}
 
-	for key, value := range mapSubset {
+	for key, value := range clusterLabels {
 		if configuration.IsLabelInherited(key) {
 			mapToEvaluate[key] = value
 		}
@@ -109,17 +113,21 @@ func IsLabelSubset(mapSet map[string]string, mapSubset map[string]string, fixedL
 	return isMapSubset(mapSet, mapToEvaluate)
 }
 
-// IsAnnotationSubset checks if an annotation map is a subset of another
-func IsAnnotationSubset(mapSet map[string]string, mapSubset map[string]string, fixedAnnotations map[string]string,
+// IsAnnotationSubset checks if a collection of annotations is a subset of another
+//
+// NOTE: there are two parameters for the annotations to check. The `fixed` one
+// is for labels that certainly should be inherited (`inheritedMetadata` in the spec)
+// The other labels may or may not be inherited depending on the configuration
+func IsAnnotationSubset(mapSet, clusterAnnotations, fixedInheritedAnnotations map[string]string,
 	configuration *config.Data,
 ) bool {
 	mapToEvaluate := map[string]string{}
 
-	for key, value := range fixedAnnotations {
+	for key, value := range fixedInheritedAnnotations {
 		mapToEvaluate[key] = value
 	}
 
-	for key, value := range mapSubset {
+	for key, value := range clusterAnnotations {
 		if configuration.IsAnnotationInherited(key) {
 			mapToEvaluate[key] = value
 		}

--- a/pkg/utils/operations.go
+++ b/pkg/utils/operations.go
@@ -91,13 +91,15 @@ func isResourceListSubset(resourceList, subResourceList corev1.ResourceList) boo
 }
 
 // IsLabelSubset checks if a label map is a subset of another
-func IsLabelSubset(mapSet map[string]string, mapSubset map[string]string, configuration *config.Data,
-	fixedLabels map[string]string,
+func IsLabelSubset(mapSet map[string]string, mapSubset map[string]string, fixedLabels map[string]string,
+	configuration *config.Data,
 ) bool {
 	mapToEvaluate := map[string]string{}
+
 	for key, value := range fixedLabels {
 		mapToEvaluate[key] = value
 	}
+
 	for key, value := range mapSubset {
 		if configuration.IsLabelInherited(key) {
 			mapToEvaluate[key] = value
@@ -108,13 +110,15 @@ func IsLabelSubset(mapSet map[string]string, mapSubset map[string]string, config
 }
 
 // IsAnnotationSubset checks if an annotation map is a subset of another
-func IsAnnotationSubset(mapSet map[string]string, mapSubset map[string]string, configuration *config.Data,
-	fixedAnnotations map[string]string,
+func IsAnnotationSubset(mapSet map[string]string, mapSubset map[string]string, fixedAnnotations map[string]string,
+	configuration *config.Data,
 ) bool {
 	mapToEvaluate := map[string]string{}
+
 	for key, value := range fixedAnnotations {
 		mapToEvaluate[key] = value
 	}
+
 	for key, value := range mapSubset {
 		if configuration.IsAnnotationInherited(key) {
 			mapToEvaluate[key] = value

--- a/pkg/utils/operations_test.go
+++ b/pkg/utils/operations_test.go
@@ -59,28 +59,56 @@ var _ = Describe("Testing Annotations and labels subset", func() {
 	It("should make sure that a contained annotations subset is recognized", func() {
 		isSubset := IsAnnotationSubset(set, subSet, &config.Data{
 			InheritedAnnotations: []string{environment},
-		})
+		}, nil)
 		Expect(isSubset).To(BeTrue())
 	})
 
 	It("should make sure that a annotations non-subset is recognized", func() {
 		isSubset := IsAnnotationSubset(set, subSet, &config.Data{
 			InheritedAnnotations: []string{environment, department},
-		})
+		}, nil)
+		Expect(isSubset).To(BeFalse())
+	})
+
+	It("should make sure fixed annotation is considered in subset", func() {
+		isSubset := IsAnnotationSubset(set, subSet, &config.Data{
+			InheritedAnnotations: []string{environment},
+		}, map[string]string{"application": "game-history"})
+		Expect(isSubset).To(BeTrue())
+	})
+
+	It("should make sure fixed annotation is considered in non-subset", func() {
+		isSubset := IsAnnotationSubset(set, subSet, &config.Data{
+			InheritedAnnotations: []string{environment},
+		}, map[string]string{department: "finance"})
 		Expect(isSubset).To(BeFalse())
 	})
 
 	It("should make sure that a contained labels subset is recognized", func() {
 		isSubset := IsLabelSubset(set, subSet, &config.Data{
 			InheritedLabels: []string{environment},
-		})
+		}, nil)
 		Expect(isSubset).To(BeTrue())
 	})
 
 	It("should make sure that a labels non-subset is recognized", func() {
 		isSubset := IsLabelSubset(set, subSet, &config.Data{
 			InheritedLabels: []string{environment, department},
-		})
+		}, nil)
+		Expect(isSubset).To(BeFalse())
+	})
+
+	It("should make sure fixed label is considered in subset", func() {
+		isSubset := IsLabelSubset(set, subSet, &config.Data{
+			InheritedLabels: []string{environment},
+		}, map[string]string{"application": "game-history"})
+		Expect(isSubset).To(BeTrue())
+	})
+
+	It("should make sure fixed label is considered in non-subset", func() {
+		isSubset := IsLabelSubset(set, subSet, &config.Data{
+			InheritedLabels: []string{environment},
+		}, map[string]string{department: "finance"})
 		Expect(isSubset).To(BeFalse())
 	})
 })

--- a/pkg/utils/operations_test.go
+++ b/pkg/utils/operations_test.go
@@ -57,58 +57,62 @@ var _ = Describe("Testing Annotations and labels subset", func() {
 	}
 
 	It("should make sure that a contained annotations subset is recognized", func() {
-		isSubset := IsAnnotationSubset(set, subSet, &config.Data{
+		isSubset := IsAnnotationSubset(set, subSet, nil, &config.Data{
 			InheritedAnnotations: []string{environment},
-		}, nil)
+		})
 		Expect(isSubset).To(BeTrue())
 	})
 
 	It("should make sure that a annotations non-subset is recognized", func() {
-		isSubset := IsAnnotationSubset(set, subSet, &config.Data{
+		isSubset := IsAnnotationSubset(set, subSet, nil, &config.Data{
 			InheritedAnnotations: []string{environment, department},
-		}, nil)
+		})
 		Expect(isSubset).To(BeFalse())
 	})
 
 	It("should make sure fixed annotation is considered in subset", func() {
-		isSubset := IsAnnotationSubset(set, subSet, &config.Data{
-			InheritedAnnotations: []string{environment},
-		}, map[string]string{"application": "game-history"})
+		isSubset := IsAnnotationSubset(set, subSet,
+			map[string]string{"application": "game-history"}, &config.Data{
+				InheritedAnnotations: []string{environment},
+			})
 		Expect(isSubset).To(BeTrue())
 	})
 
 	It("should make sure fixed annotation is considered in non-subset", func() {
-		isSubset := IsAnnotationSubset(set, subSet, &config.Data{
-			InheritedAnnotations: []string{environment},
-		}, map[string]string{department: "finance"})
+		isSubset := IsAnnotationSubset(set, subSet,
+			map[string]string{department: "finance"}, &config.Data{
+				InheritedAnnotations: []string{environment},
+			})
 		Expect(isSubset).To(BeFalse())
 	})
 
 	It("should make sure that a contained labels subset is recognized", func() {
-		isSubset := IsLabelSubset(set, subSet, &config.Data{
+		isSubset := IsLabelSubset(set, subSet, nil, &config.Data{
 			InheritedLabels: []string{environment},
-		}, nil)
+		})
 		Expect(isSubset).To(BeTrue())
 	})
 
 	It("should make sure that a labels non-subset is recognized", func() {
-		isSubset := IsLabelSubset(set, subSet, &config.Data{
+		isSubset := IsLabelSubset(set, subSet, nil, &config.Data{
 			InheritedLabels: []string{environment, department},
-		}, nil)
+		})
 		Expect(isSubset).To(BeFalse())
 	})
 
 	It("should make sure fixed label is considered in subset", func() {
-		isSubset := IsLabelSubset(set, subSet, &config.Data{
-			InheritedLabels: []string{environment},
-		}, map[string]string{"application": "game-history"})
+		isSubset := IsLabelSubset(set, subSet,
+			map[string]string{"application": "game-history"}, &config.Data{
+				InheritedLabels: []string{environment},
+			})
 		Expect(isSubset).To(BeTrue())
 	})
 
 	It("should make sure fixed label is considered in non-subset", func() {
-		isSubset := IsLabelSubset(set, subSet, &config.Data{
-			InheritedLabels: []string{environment},
-		}, map[string]string{department: "finance"})
+		isSubset := IsLabelSubset(set, subSet,
+			map[string]string{department: "finance"}, &config.Data{
+				InheritedLabels: []string{environment},
+			})
 		Expect(isSubset).To(BeFalse())
 	})
 })


### PR DESCRIPTION
Now when labels or annotations are updated from cluster `spec.inheritedMetadata`
pod will reflect the change without a restart. 

Closes #163

Signed-off-by: tao <tao.li@enterprisedb.com>