### PR TITLE
fix: sensitive param decrease should not leads to switchover

### DIFF
--- a/controllers/cluster_upgrade.go
+++ b/controllers/cluster_upgrade.go
@@ -85,7 +85,13 @@ func (r *ClusterReconciler) rolloutDueToCondition(
 	if !shouldRestart {
 		return false, nil
 	}
-
+	// usually PendingRestartForDecrease status changed in instance reconcile and primary
+	// pod reach to this location has no pending restart for decrease.
+	// but sometime, the instance reconcile to handle the pending restart for decrease is slower
+	// than cluster reconcile, which will leads to switchover first.
+	if primaryPostgresqlStatus.IsPrimary && primaryPostgresqlStatus.PendingRestartForDecrease {
+		return false, nil
+	}
 	// we need to check whether a manual switchover is required
 	primaryPod := primaryPostgresqlStatus.Pod
 	contextLogger = contextLogger.WithValues("primaryPod", primaryPod.Name)

--- a/internal/management/controller/instance_controller.go
+++ b/internal/management/controller/instance_controller.go
@@ -865,9 +865,7 @@ func (r *InstanceReconciler) waitForConfigurationReload(ctx context.Context, clu
 	if status.IsPrimary && status.PendingRestartForDecrease {
 		if cluster.GetPrimaryUpdateStrategy() == apiv1.PrimaryUpdateStrategyUnsupervised {
 			contextLogger.Info("Restarting primary in-place due to hot standby sensible parameters decrease")
-			if err := r.Instance().RequestAndWaitRestartSmartFast(); err != nil {
-				return err
-			}
+			return r.Instance().RequestAndWaitRestartSmartFast()
 		}
 		reason := "decrease of hot standby sensitive parameters"
 		contextLogger.Info("Waiting for the user to request a restart of the primary instance or a switchover "+


### PR DESCRIPTION
Now when sensitive param like `max_connection` is decreased, 
fixed the problem that sometime switchover will happens. 

Closes https://github.com/cloudnative-pg/cloudnative-pg/issues/168
Signed-off-by: tao <tao.li@enterprisedb.com>