### PR TITLE
chore: add a verification issue link verification

### DIFF
--- a/.github/workflows/pr_verify_linked_issue.yml
+++ b/.github/workflows/pr_verify_linked_issue.yml
@@ -1,0 +1,29 @@
+# This workflow will inspect a pull request to ensure there is a linked issue or a
+# valid issue is mentioned in the body. If neither is present it fails the check and adds
+# a comment alerting users of this missing requirement.
+name: VerifyIssue
+
+on:
+  pull_request:
+    branches-ignore:
+      - 'dependabot/**'
+    types:
+    - edited
+    - synchronize
+    - opened
+    - reopened
+    - labeled
+    - unlabeled
+
+jobs:
+  verify_linked_issue:
+    runs-on: ubuntu-latest
+    name: Ensure Pull Request has a linked issue.
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-issue') }}
+    steps:
+      - name: Verify Linked Issue
+        uses: hattan/verify-linked-issue-action@v1.1.5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+


### PR DESCRIPTION
A new action to check that every PRs contains a linked issue, the idea
is to avoid having PRs without a proper linked issue.

Closes #178 

Signed-off-by: Jonathan Gonzalez V <jonathan.gonzalez@enterprisedb.com>