### PR TITLE
test: display the validation errors in the webhook test

### DIFF
--- a/tests/e2e/asserts_test.go
+++ b/tests/e2e/asserts_test.go
@@ -244,9 +244,9 @@ func AssertClusterDefault(namespace string, clusterName string,
 
 		validationErr := cluster.Validate()
 		if isExpectedToDefault {
-			Expect(len(validationErr)).Should(BeZero())
+			Expect(len(validationErr)).Should(BeZero(), validationErr)
 		} else {
-			Expect(len(validationErr)).ShouldNot(BeZero())
+			Expect(len(validationErr)).ShouldNot(BeZero(), validationErr)
 		}
 	})
 }


### PR DESCRIPTION
this code is necessary to reduce drift with the CNP repo.
There we have the webhook test failing massively in the nightly builds,
and is not reproducible neither locally nor on the feature branch.
This code will show which validation(s) are failing

Signed-off-by: Jaime Silvela <jaime.silvela@enterprisedb.com>