### PR TITLE
doc: use minidocks/mkdocs image for mkdocs build and serve commands

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,16 +7,15 @@ in the `dist` directory:
 
 ``` bash
 docker run --rm -v "$(pwd):$(pwd)" -w "$(pwd)" \
-    quay.io/enterprisedb/cloud-native-docutils:mkdocs \
+    minidocks/mkdocs \
     mkdocs build -v -d dist
 ```
 
 You can locally test the documentation by executing
-the following command and pointing your browser
-to http://127.0.0.1:8000/
+the following command and pointing your browser to port 8000:
 
 ``` bash
 docker run --rm -v "$(pwd):$(pwd)" -w "$(pwd)" -p 8000:8000 \
-    quay.io/enterprisedb/cloud-native-docutils:mkdocs \
+    minidocks/mkdocs \
     mkdocs serve -a 0.0.0.0:8000
 ```


### PR DESCRIPTION
Closes #184

Signed-off-by: Gabriele Bartolini <gabriele.bartolini@enterprisedb.com>