### PR TITLE
chore: add the release file to artifacts

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -26,7 +26,9 @@ jobs:
         name: Get tag
         run: |
           tag="${GITHUB_REF#refs/tags/v}"
+          version="{$tag#v}"
           echo "TAG=${tag}" >> $GITHUB_ENV
+          echo "VERSION=${version}" >> $GITHUB_ENV
       -
         name: Generate release notes
         run: |
@@ -41,6 +43,7 @@ jobs:
           body_path: release_notes.md
           draft: false
           name: Release ${{ env.TAG }}
+          files: releases/cnpg-${{ env.VERSION }}.yaml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
During the release process now we add the YAML file used to deploy
the operator in a vanilla Kubernetes, this is to provide an easy way
to find the YAML file for any user or external application that may
want to access the release YAML file.

Closes #201

Signed-off-by: Jonathan Gonzalez V <jonathan.gonzalez@enterprisedb.com>