### PR TITLE
chore: improve "ok to merge" label

### DIFF
--- a/.github/workflows/chatops-dispatcher.yml
+++ b/.github/workflows/chatops-dispatcher.yml
@@ -30,4 +30,4 @@ jobs:
         if: ${{ startsWith(github.event.comment.body, '/ok-to-merge') }}
         with:
            github_token: ${{ secrets.REPO_GHA_PAT }}
-           labels: ok to merge
+           labels: "ok to merge :ok_hand:"

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -637,7 +637,7 @@ jobs:
         with:
           github_token: ${{ secrets.REPO_GHA_PAT }}
           number: ${{ steps.get_pr_number.outputs.pr_number }}
-          labels: ok to merge
+          labels: "ok to merge :ok_hand:"
 
   unlabel-ok-to-merge:
     name: Remove the "ok to merge" label from the PR
@@ -666,4 +666,4 @@ jobs:
         with:
           github_token: ${{ secrets.REPO_GHA_PAT }}
           number: ${{ steps.get_pr_number.outputs.pr_number }}
-          labels: ok to merge
+          labels: "ok to merge :ok_hand:"

--- a/.github/workflows/require-labels.yml
+++ b/.github/workflows/require-labels.yml
@@ -18,6 +18,6 @@ jobs:
       - name: Require labels
         uses: docker://agilepathway/pull-request-label-checker:v1.0.104
         with:
-          any_of: ok to merge
+          any_of: "ok to merge :ok_hand:"
           none_of: do not merge
           repo_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds an emoji to the "ok to merge" label, the `:ok_hand:` just to
improve the visual on the PR list.

Signed-off-by: Jonathan Gonzalez V <jonathan.gonzalez@enterprisedb.com>