### PR TITLE
fix: correct encryption parameters in Barman commands

### DIFF
--- a/internal/cmd/manager/walrestore/cmd.go
+++ b/internal/cmd/manager/walrestore/cmd.go
@@ -346,15 +346,6 @@ func barmanCloudWalRestoreOptions(
 	clusterName string,
 ) ([]string, error) {
 	var options []string
-	if configuration.Wal != nil {
-		if len(configuration.Wal.Encryption) != 0 {
-			options = append(
-				options,
-				"-e",
-				string(configuration.Wal.Encryption))
-		}
-	}
-
 	if len(configuration.EndpointURL) > 0 {
 		options = append(
 			options,

--- a/pkg/management/barman/backupdelete.go
+++ b/pkg/management/barman/backupdelete.go
@@ -53,10 +53,6 @@ func DeleteBackupsByPolicy(backupConfig *v1.BackupConfiguration, serverName stri
 		options = append(options, "--endpoint-url", barmanConfiguration.EndpointURL)
 	}
 
-	if barmanConfiguration.Data != nil && barmanConfiguration.Data.Encryption != "" {
-		options = append(options, "-e", string(barmanConfiguration.Data.Encryption))
-	}
-
 	options, err = AppendCloudProviderOptionsFromConfiguration(options, barmanConfiguration)
 	if err != nil {
 		return err

--- a/pkg/management/barman/backuplist.go
+++ b/pkg/management/barman/backuplist.go
@@ -104,10 +104,6 @@ func GetBackupList(
 		options = append(options, "--endpoint-url", barmanConfiguration.EndpointURL)
 	}
 
-	if barmanConfiguration.Data != nil && barmanConfiguration.Data.Encryption != "" {
-		options = append(options, "-e", string(barmanConfiguration.Data.Encryption))
-	}
-
 	options, err := AppendCloudProviderOptionsFromConfiguration(options, barmanConfiguration)
 	if err != nil {
 		return nil, err

--- a/pkg/management/postgres/backup.go
+++ b/pkg/management/postgres/backup.go
@@ -104,7 +104,7 @@ func getDataConfiguration(
 	if len(configuration.Data.Encryption) != 0 {
 		options = append(
 			options,
-			"--encrypt",
+			"--encryption",
 			string(configuration.Data.Encryption))
 	}
 

--- a/pkg/management/postgres/restore.go
+++ b/pkg/management/postgres/restore.go
@@ -146,9 +146,6 @@ func (info InitInfo) restoreDataDir(backup *apiv1.Backup, env []string) error {
 	if backup.Status.EndpointURL != "" {
 		options = append(options, "--endpoint-url", backup.Status.EndpointURL)
 	}
-	if backup.Status.Encryption != "" {
-		options = append(options, "-e", backup.Status.Encryption)
-	}
 	options = append(options, backup.Status.DestinationPath)
 	options = append(options, backup.Status.ServerName)
 	options = append(options, backup.Status.BackupID)
@@ -326,9 +323,6 @@ func (info InitInfo) writeRestoreWalConfig(backup *apiv1.Backup, cluster *apiv1.
 	const barmanCloudWalRestoreName = "barman-cloud-wal-restore"
 
 	cmd := []string{barmanCloudWalRestoreName}
-	if backup.Status.Encryption != "" {
-		cmd = append(cmd, "-e", backup.Status.Encryption)
-	}
 	if backup.Status.EndpointURL != "" {
 		cmd = append(cmd, "--endpoint-url", backup.Status.EndpointURL)
 	}


### PR DESCRIPTION
Remove `-e` parameter not existing in most barman commands and fix ambiguous `--encrypt`

Closes #218

Signed-off-by: Francesco Canovai <francesco.canovai@enterprisedb.com>