### PR TITLE
test: add e2e test for recovery with custom serverName

### DIFF
--- a/tests/e2e/backup_restore_test.go
+++ b/tests/e2e/backup_restore_test.go
@@ -286,7 +286,7 @@ var _ = Describe("Backup and restore", Label(tests.LabelBackupRestore), func() {
 		It("backs up and restore a cluster with PITR MinIO", func() {
 			restoredClusterName := "restore-cluster-pitr-minio"
 
-			prepareClusterForPITROnMinio(namespace, clusterName, backupFile, 2, currentTimestamp)
+			prepareClusterForPITROnMinio(namespace, clusterName, backupFile, 3, currentTimestamp)
 
 			err := testUtils.CreateClusterFromBackupUsingPITR(namespace, restoredClusterName, backupFile, *currentTimestamp, env)
 			Expect(err).NotTo(HaveOccurred())

--- a/tests/e2e/backup_restore_test.go
+++ b/tests/e2e/backup_restore_test.go
@@ -210,15 +210,16 @@ var _ = Describe("Backup and restore", Label(tests.LabelBackupRestore), func() {
 			})
 		})
 
-		// We backup and restore a cluster, and verify some expected data to
-		// be there
+		// Test that the restore works if the source cluster has a custom
+		// backup.barmanObjectStore.serverName that is different than the cluster name
 		It("backs up and restores a cluster with custom backup serverName", func() {
 			const (
-				targetDBOne                      = "test"
-				targetDBTwo                      = "test1"
-				targetDBSecret                   = "secret_test"
-				testTableName                    = "test_table"
-				clusterRestoreSampleFile         = fixturesDir + "/backup/cluster-from-restore-custom.yaml"
+				targetDBOne              = "test"
+				targetDBTwo              = "test1"
+				targetDBSecret           = "secret_test"
+				testTableName            = "test_table"
+				clusterRestoreSampleFile = fixturesDir + "/backup/cluster-from-restore-custom.yaml"
+				// clusterWithMinioCustomSampleFile has metadata.name != backup.barmanObjectStore.serverName
 				clusterWithMinioCustomSampleFile = fixturesDir + "/backup/minio/cluster-with-backup-minio-custom-servername.yaml"
 				backupFileCustom                 = fixturesDir + "/backup/minio/backup-minio-custom-servername.yaml"
 			)

--- a/tests/e2e/backup_restore_test.go
+++ b/tests/e2e/backup_restore_test.go
@@ -227,13 +227,6 @@ var _ = Describe("Backup and restore", Label(tests.LabelBackupRestore), func() {
 			clusterName, err := env.GetResourceNameFromYAML(clusterWithMinioCustomSampleFile)
 			Expect(err).ToNot(HaveOccurred())
 
-			defer func() {
-				if CurrentSpecReport().Failed() {
-					env.DumpClusterEnv(namespace, clusterName,
-						"out/"+CurrentSpecReport().LeafNodeText+".log")
-				}
-			}()
-
 			// Create the cluster with custom serverName in the backup spec
 			AssertCreateCluster(namespace, clusterName, clusterWithMinioCustomSampleFile, env)
 

--- a/tests/e2e/fixtures/backup/cluster-from-restore-custom.yaml
+++ b/tests/e2e/fixtures/backup/cluster-from-restore-custom.yaml
@@ -1,0 +1,29 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: cluster-restore-custom
+spec:
+  instances: 2
+
+  postgresql:
+    parameters:
+      log_checkpoints: "on"
+      log_lock_waits: "on"
+      log_min_duration_statement: '1000'
+      log_statement: 'ddl'
+      log_temp_files: '1024'
+      log_autovacuum_min_duration: '1s'
+      log_replication_commands: 'on'
+
+  storage:
+    size: 1Gi
+    storageClass: 
+
+  bootstrap:
+    recovery:
+      backup:
+        name: cluster-backup-custom
+        endpointCA:
+          key: ca.crt
+          name: minio-server-ca-secret
+

--- a/tests/e2e/fixtures/backup/minio/backup-minio-custom-servername.yaml
+++ b/tests/e2e/fixtures/backup/minio/backup-minio-custom-servername.yaml
@@ -1,0 +1,7 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Backup
+metadata:
+  name: cluster-backup-custom
+spec:
+  cluster:
+    name: pg-backup-minio-custom

--- a/tests/e2e/fixtures/backup/minio/cluster-with-backup-minio-custom-servername.yaml.template
+++ b/tests/e2e/fixtures/backup/minio/cluster-with-backup-minio-custom-servername.yaml.template
@@ -1,0 +1,66 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: pg-backup-minio-custom
+spec:
+  instances: 2
+
+  postgresql:
+    parameters:
+      log_checkpoints: "on"
+      log_lock_waits: "on"
+      log_min_duration_statement: '1000'
+      log_statement: 'ddl'
+      log_temp_files: '1024'
+      log_autovacuum_min_duration: '1s'
+      log_replication_commands: 'on'
+
+  # Example of rolling update strategy:
+  # - unsupervised: automated update of the primary once all
+  #                 replicas have been upgraded (default)
+  # - supervised: requires manual supervision to perform
+  #               the switchover of the primary
+  primaryUpdateStrategy: unsupervised
+
+  # Persistent storage configuration
+  storage:
+    storageClass: ${E2E_DEFAULT_STORAGE_CLASS}
+    size: 1Gi
+
+  bootstrap:
+    initdb:
+      database: app
+      owner: app
+
+  monitoring:
+    customQueriesConfigMap:
+      - name: monitoring-01
+        key: additional-queries
+    customQueriesSecret:
+      - name: monitoring-01
+        key: additional-queries
+
+  backup:
+    barmanObjectStore:
+        destinationPath: s3://cluster-backups/
+        endpointURL: https://minio-service:9000
+        endpointCA:
+          key: ca.crt
+          name: minio-server-ca-secret
+        s3Credentials:
+          accessKeyId:
+            name: backup-storage-creds
+            key: ID
+          secretAccessKey:
+            name: backup-storage-creds
+            key: KEY
+        wal:
+          compression: gzip
+        data:
+          immediateCheckpoint: true
+        tags:
+          retention: "30days"
+        historyTags:
+          retention: "30days"
+        serverName: pg-backup-minio-Custom-Name
+    retentionPolicy: "30d"


### PR DESCRIPTION
adds E2E test to verify the patch fixing the recovery from a cluster
with a custom `serverName` in the backup configuration

Closes https://github.com/cloudnative-pg/cloudnative-pg/issues/220

Signed-off-by: Jaime Silvela <jaime.silvela@enterprisedb.com>