### PR TITLE
fix: sort results before printing in cnpg status plugin

### DIFF
--- a/internal/cmd/plugin/status/status.go
+++ b/internal/cmd/plugin/status/status.go
@@ -473,7 +473,7 @@ func getReplicaRole(instance postgres.PostgresqlStatus, fullStatus *PostgresqlSt
 	if instance.IsPrimary {
 		return "Primary"
 	}
-	if fullStatus.Cluster.IsReplica() && instance.ReplicationInfo != nil {
+	if fullStatus.Cluster.IsReplica() && len(instance.ReplicationInfo) > 0 {
 		return "Designated primary"
 	}
 

--- a/internal/cmd/plugin/status/status.go
+++ b/internal/cmd/plugin/status/status.go
@@ -300,7 +300,7 @@ func (fullStatus *PostgresqlStatus) printReplicaStatus() {
 		return
 	}
 
-	if primaryInstanceStatus.ReplicationInfo == nil {
+	if len(primaryInstanceStatus.ReplicationInfo) == 0 {
 		fmt.Println(aurora.Yellow("Not available yet").String())
 		fmt.Println()
 		return
@@ -323,7 +323,7 @@ func (fullStatus *PostgresqlStatus) printReplicaStatus() {
 
 	replicationInfo := primaryInstanceStatus.ReplicationInfo
 	sort.Sort(replicationInfo)
-	for _, replication := range replicationInfo.Items {
+	for _, replication := range replicationInfo {
 		status.AddLine(
 			replication.ApplicationName,
 			replication.SentLsn,
@@ -454,7 +454,7 @@ func (fullStatus *PostgresqlStatus) printCertificatesStatus() {
 
 func (fullStatus *PostgresqlStatus) tryGetPrimaryInstance() *postgres.PostgresqlStatus {
 	for idx, instanceStatus := range fullStatus.InstanceStatus.Items {
-		if instanceStatus.IsPrimary || instanceStatus.ReplicationInfo != nil {
+		if instanceStatus.IsPrimary || len(instanceStatus.ReplicationInfo) > 0 {
 			return &fullStatus.InstanceStatus.Items[idx]
 		}
 	}
@@ -496,7 +496,7 @@ func getReplicaRole(instance postgres.PostgresqlStatus, fullStatus *PostgresqlSt
 		return "Unknown"
 	}
 
-	for _, state := range primaryInstanceStatus.ReplicationInfo.Items {
+	for _, state := range primaryInstanceStatus.ReplicationInfo {
 		// todo: handle others states other than 'streaming'
 		if !(state.ApplicationName == instance.Pod.Name && state.State == "streaming") {
 			continue

--- a/pkg/management/postgres/probes.go
+++ b/pkg/management/postgres/probes.go
@@ -349,9 +349,9 @@ func (instance *Instance) fillWalStatus(result *postgres.PostgresqlStatus) error
 		if err != nil {
 			return err
 		}
-		replicationInfo.Items = append(replicationInfo.Items, pgr)
+		replicationInfo = append(replicationInfo, pgr)
 	}
-	result.ReplicationInfo = &replicationInfo
+	result.ReplicationInfo = replicationInfo
 
 	if err = rows.Err(); err != nil {
 		return err


### PR DESCRIPTION
Sort the results of `Certificates Status` and `Streaming Replication status`
before printing per `status` command of cnpg plugin.


Closes: #170 
Signed-off-by: Hai He <hai.he@enterprisedb.com>

