### PR TITLE
chore: add support for alpha, beta and rc images

### DIFF
--- a/.github/postgres-versions-update.py
+++ b/.github/postgres-versions-update.py
@@ -21,7 +21,7 @@ import json
 min_supported_major = 10
 
 pg_repo_name = "cloudnative-pg/postgresql"
-pg_version_re = re.compile(r"^(\d+)(?:\.\d+)(-\d+)?$")
+pg_version_re = re.compile(r"^(\d+)(?:\.\d+|beta\d+|rc\d+|alpha\d+)(-\d+)?$")
 pg_versions_file = ".github/pg_versions.json"
 
 


### PR DESCRIPTION
The old regexp used to detect the version was only accepting versions
in the format `major.minor-revision`, now we also accept the format
with the beta `major(alphaN|betaN|rcN)-revision`

Closes #103

Signed-off-by: Jonathan Gonzalez V <jonathan.gonzalez@enterprisedb.com>