### PR TITLE
fix: use only stable release to change version

### DIFF
--- a/.github/workflows/latest-postgres-version-check.yml
+++ b/.github/workflows/latest-postgres-version-check.yml
@@ -30,7 +30,7 @@ jobs:
         env:
           IMAGE_REPO: ghcr.io/cloudnative-pg/postgresql
         run: |
-          LATEST_POSTGRES_VERSION=$(jq -r '.[keys | max][0]' < .github/pg_versions.json)
+          LATEST_POSTGRES_VERSION=$(jq -r 'del(.[] | select(.[] | match("alpha|beta|rc"))) | .[keys | max][0]' < .github/pg_versions.json)
           LATEST_POSTGRES_VERSION_IMAGE="${IMAGE_REPO}:${LATEST_POSTGRES_VERSION}"
           echo "::set-output name=LATEST_POSTGRES_VERSION::$LATEST_POSTGRES_VERSION"
           echo "::set-output name=LATEST_POSTGRES_VERSION_IMAGE::$LATEST_POSTGRES_VERSION_IMAGE"


### PR DESCRIPTION
After we added the posibility to test alpha, beta and rc versions of
PostgreSQL, we also modified the script that updates the latest stable
version of PostgreSQL in the operator, this patch fix that by
excluding any alpha, beta or rc version from the list used to compare.

Closes #239

Signed-off-by: Jonathan Gonzalez V <jonathan.gonzalez@enterprisedb.com>