### PR TITLE
fix: add support to dump logs of  multiple clusters in e2e.

### DIFF
--- a/tests/e2e/apparmor_test.go
+++ b/tests/e2e/apparmor_test.go
@@ -50,8 +50,7 @@ var _ = Describe("AppArmor support", Serial, Label(tests.LabelNoOpenshift), func
 
 	JustAfterEach(func() {
 		if CurrentSpecReport().Failed() {
-			env.DumpClusterEnv(namespace, clusterName,
-				"out/"+CurrentSpecReport().LeafNodeText+".log")
+			env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
 		}
 	})
 

--- a/tests/e2e/backup_restore_test.go
+++ b/tests/e2e/backup_restore_test.go
@@ -968,7 +968,9 @@ var _ = Describe("Backup and restore Safety", Label(tests.LabelBackupRestore), f
 	JustAfterEach(func() {
 		if CurrentSpecReport().Failed() {
 			env.DumpClusterEnv(namespace, clusterName,
-				"out/"+CurrentSpecReport().LeafNodeText+".log")
+				"out/"+namespace+CurrentSpecReport().LeafNodeText+".log")
+			env.DumpClusterEnv(namespace2, clusterName,
+				"out/"+namespace2+CurrentSpecReport().LeafNodeText+".log")
 		}
 	})
 	Context("using minio as object storage", Ordered, func() {

--- a/tests/e2e/backup_restore_test.go
+++ b/tests/e2e/backup_restore_test.go
@@ -54,8 +54,7 @@ var _ = Describe("Backup and restore", Label(tests.LabelBackupRestore), func() {
 
 	JustAfterEach(func() {
 		if CurrentSpecReport().Failed() {
-			env.DumpClusterEnv(namespace, clusterName,
-				"out/"+CurrentSpecReport().LeafNodeText+".log")
+			env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
 		}
 	})
 	Context("using minio as object storage for backup", Ordered, func() {
@@ -233,8 +232,7 @@ var _ = Describe("Backup and restore", Label(tests.LabelBackupRestore), func() {
 			// To also dump info. from `customClusterName` cluster after this spec gets executed
 			DeferCleanup(func() {
 				if CurrentSpecReport().Failed() {
-					env.DumpClusterEnv(namespace, customClusterName,
-						"out/"+CurrentSpecReport().LeafNodeText+".log")
+					env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
 				}
 			})
 
@@ -597,8 +595,7 @@ var _ = Describe("Clusters Recovery From Barman Object Store", Label(tests.Label
 
 	JustAfterEach(func() {
 		if CurrentSpecReport().Failed() {
-			env.DumpClusterEnv(namespace, clusterName,
-				"out/"+CurrentSpecReport().LeafNodeText+".log")
+			env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
 		}
 	})
 
@@ -967,10 +964,8 @@ var _ = Describe("Backup and restore Safety", Label(tests.LabelBackupRestore), f
 
 	JustAfterEach(func() {
 		if CurrentSpecReport().Failed() {
-			env.DumpClusterEnv(namespace, clusterName,
-				"out/"+namespace+CurrentSpecReport().LeafNodeText+".log")
-			env.DumpClusterEnv(namespace2, clusterName,
-				"out/"+namespace2+CurrentSpecReport().LeafNodeText+".log")
+			env.DumpNamespaceObjects(namespace, "out/"+namespace+CurrentSpecReport().LeafNodeText+".log")
+			env.DumpNamespaceObjects(namespace2, "out/"+namespace2+CurrentSpecReport().LeafNodeText+".log")
 		}
 	})
 	Context("using minio as object storage", Ordered, func() {

--- a/tests/e2e/cluster_objectmeta_test.go
+++ b/tests/e2e/cluster_objectmeta_test.go
@@ -30,7 +30,6 @@ var _ = Describe("Cluster objectmeta", func() {
 		clusterWithObjectMeta = fixturesDir + "/cluster_objectmeta/cluster-level-objectMeta.yaml"
 		namespace             = "objectmeta-inheritance"
 	)
-	var clusterName string
 
 	BeforeEach(func() {
 		if testLevelEnv.Depth < int(level) {
@@ -39,8 +38,7 @@ var _ = Describe("Cluster objectmeta", func() {
 	})
 	JustAfterEach(func() {
 		if CurrentSpecReport().Failed() {
-			env.DumpClusterEnv(namespace, clusterName,
-				"out/"+CurrentSpecReport().LeafNodeText+".log")
+			env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
 		}
 	})
 	AfterEach(func() {

--- a/tests/e2e/cluster_setup_test.go
+++ b/tests/e2e/cluster_setup_test.go
@@ -44,8 +44,7 @@ var _ = Describe("Cluster setup", func() {
 	})
 	JustAfterEach(func() {
 		if CurrentSpecReport().Failed() {
-			env.DumpClusterEnv(namespace, clusterName,
-				"out/"+CurrentSpecReport().LeafNodeText+".log")
+			env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
 		}
 	})
 	AfterEach(func() {

--- a/tests/e2e/cnpg_certificates_test.go
+++ b/tests/e2e/cnpg_certificates_test.go
@@ -62,8 +62,7 @@ var _ = Describe("Certificates", func() {
 	var namespace, clusterName string
 	JustAfterEach(func() {
 		if CurrentSpecReport().Failed() {
-			env.DumpClusterEnv(namespace, clusterName,
-				"out/"+CurrentSpecReport().LeafNodeText+".log")
+			env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
 		}
 	})
 

--- a/tests/e2e/config_support_test.go
+++ b/tests/e2e/config_support_test.go
@@ -55,8 +55,7 @@ var _ = Describe("Config support", Serial, Ordered, Label(tests.LabelDisruptive)
 	})
 	JustAfterEach(func() {
 		if CurrentSpecReport().Failed() {
-			env.DumpClusterEnv(namespace, clusterName,
-				"out/"+CurrentSpecReport().LeafNodeText+".log")
+			env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
 		}
 	})
 

--- a/tests/e2e/configuration_update_test.go
+++ b/tests/e2e/configuration_update_test.go
@@ -96,8 +96,7 @@ var _ = Describe("Configuration update", Ordered, func() {
 
 	JustAfterEach(func() {
 		if CurrentSpecReport().Failed() {
-			env.DumpClusterEnv(namespace, clusterName,
-				"out/"+CurrentSpecReport().LeafNodeText+".log")
+			env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
 		}
 	})
 
@@ -378,8 +377,7 @@ var _ = Describe("Configuration update with primaryUpdateMethod", func() {
 
 		JustAfterEach(func() {
 			if CurrentSpecReport().Failed() {
-				env.DumpClusterEnv(namespace, clusterName,
-					"out/"+CurrentSpecReport().LeafNodeText+".log")
+				env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
 			}
 		})
 

--- a/tests/e2e/connection_test.go
+++ b/tests/e2e/connection_test.go
@@ -84,8 +84,7 @@ var _ = Describe("Connection via services", func() {
 		const clusterName = "postgresql-auto-generated"
 		JustAfterEach(func() {
 			if CurrentSpecReport().Failed() {
-				env.DumpClusterEnv(namespace, clusterName,
-					"out/"+CurrentSpecReport().LeafNodeText+".log")
+				env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
 			}
 		})
 		AfterEach(func() {
@@ -133,8 +132,7 @@ var _ = Describe("Connection via services", func() {
 		const clusterName = "postgresql-user-supplied"
 		JustAfterEach(func() {
 			if CurrentSpecReport().Failed() {
-				env.DumpClusterEnv(namespace, clusterName,
-					"out/"+CurrentSpecReport().LeafNodeText+".log")
+				env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
 			}
 		})
 		AfterEach(func() {

--- a/tests/e2e/drain_node_test.go
+++ b/tests/e2e/drain_node_test.go
@@ -80,8 +80,7 @@ var _ = Describe("E2E Drain Node", Serial, Label(tests.LabelDisruptive), func() 
 
 		JustAfterEach(func() {
 			if CurrentSpecReport().Failed() {
-				env.DumpClusterEnv(namespace, clusterName,
-					"out/"+CurrentSpecReport().LeafNodeText+".log")
+				env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
 			}
 		})
 
@@ -322,8 +321,7 @@ var _ = Describe("E2E Drain Node", Serial, Label(tests.LabelDisruptive), func() 
 
 		JustAfterEach(func() {
 			if CurrentSpecReport().Failed() {
-				env.DumpClusterEnv(namespace, clusterName,
-					"out/"+CurrentSpecReport().LeafNodeText+".log")
+				env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
 			}
 		})
 		AfterEach(func() {

--- a/tests/e2e/eviction_test.go
+++ b/tests/e2e/eviction_test.go
@@ -111,11 +111,8 @@ var _ = Describe("Pod eviction", Serial, Label(tests.LabelDisruptive), func() {
 			}
 		})
 		JustAfterEach(func() {
-			clusterName, err := env.GetResourceNameFromYAML(singleInstanceSampleFile)
-			Expect(err).ToNot(HaveOccurred())
 			if CurrentSpecReport().Failed() {
-				env.DumpClusterEnv(namespace, clusterName,
-					"out/"+CurrentSpecReport().LeafNodeText+".log")
+				env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
 			}
 		})
 		BeforeAll(func() {
@@ -189,11 +186,8 @@ var _ = Describe("Pod eviction", Serial, Label(tests.LabelDisruptive), func() {
 			}
 		})
 		JustAfterEach(func() {
-			clusterName, err := env.GetResourceNameFromYAML(multiInstanceSampleFile)
-			Expect(err).ToNot(HaveOccurred())
 			if CurrentSpecReport().Failed() {
-				env.DumpClusterEnv(namespace, clusterName,
-					"out/"+CurrentSpecReport().LeafNodeText+".log")
+				env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
 			}
 		})
 		BeforeAll(func() {

--- a/tests/e2e/failover_test.go
+++ b/tests/e2e/failover_test.go
@@ -49,8 +49,7 @@ var _ = Describe("Failover", func() {
 	})
 	JustAfterEach(func() {
 		if CurrentSpecReport().Failed() {
-			env.DumpClusterEnv(namespace, clusterName,
-				"out/"+CurrentSpecReport().LeafNodeText+".log")
+			env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
 		}
 	})
 	AfterEach(func() {

--- a/tests/e2e/fastfailover_test.go
+++ b/tests/e2e/fastfailover_test.go
@@ -77,8 +77,7 @@ var _ = Describe("Fast failover", Serial, Label(tests.LabelPerformance), func() 
 
 	JustAfterEach(func() {
 		if CurrentSpecReport().Failed() {
-			env.DumpClusterEnv(namespace, clusterName,
-				"out/"+CurrentSpecReport().LeafNodeText+".log")
+			env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
 		}
 	})
 

--- a/tests/e2e/fastswitchover_test.go
+++ b/tests/e2e/fastswitchover_test.go
@@ -53,8 +53,7 @@ var _ = Describe("Fast switchover", Serial, Label(tests.LabelPerformance), func(
 	})
 	JustAfterEach(func() {
 		if CurrentSpecReport().Failed() {
-			env.DumpClusterEnv(namespace, clusterName,
-				"out/"+CurrentSpecReport().LeafNodeText+".log")
+			env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
 		}
 	})
 	AfterEach(func() {

--- a/tests/e2e/fencing_test.go
+++ b/tests/e2e/fencing_test.go
@@ -50,8 +50,7 @@ var _ = Describe("Fencing", func() {
 
 	JustAfterEach(func() {
 		if CurrentSpecReport().Failed() {
-			env.DumpClusterEnv(namespace, clusterName,
-				"out/"+CurrentSpecReport().LeafNodeText+".log")
+			env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
 		}
 	})
 

--- a/tests/e2e/initdb_test.go
+++ b/tests/e2e/initdb_test.go
@@ -50,8 +50,7 @@ var _ = Describe("InitDB settings", func() {
 		var namespace string
 		JustAfterEach(func() {
 			if CurrentSpecReport().Failed() {
-				env.DumpClusterEnv(namespace, clusterName,
-					"out/"+CurrentSpecReport().LeafNodeText+".log")
+				env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
 			}
 		})
 		AfterEach(func() {
@@ -118,8 +117,7 @@ var _ = Describe("InitDB settings", func() {
 		var namespace string
 		JustAfterEach(func() {
 			if CurrentSpecReport().Failed() {
-				env.DumpClusterEnv(namespace, clusterName,
-					"out/"+CurrentSpecReport().LeafNodeText+".log")
+				env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
 			}
 		})
 		AfterEach(func() {

--- a/tests/e2e/logs_test.go
+++ b/tests/e2e/logs_test.go
@@ -48,8 +48,7 @@ var _ = Describe("JSON log output", func() {
 
 	JustAfterEach(func() {
 		if CurrentSpecReport().Failed() {
-			env.DumpClusterEnv(namespace, clusterName,
-				"out/"+CurrentSpecReport().LeafNodeText+".log")
+			env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
 		}
 	})
 	AfterEach(func() {

--- a/tests/e2e/metrics_test.go
+++ b/tests/e2e/metrics_test.go
@@ -68,8 +68,7 @@ var _ = Describe("Metrics", func() {
 
 	JustAfterEach(func() {
 		if CurrentSpecReport().Failed() {
-			env.DumpClusterEnv(namespace, metricsClusterName,
-				"out/"+CurrentSpecReport().LeafNodeText+".log")
+			env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
 		}
 	})
 	AfterEach(func() {

--- a/tests/e2e/nodeselector_test.go
+++ b/tests/e2e/nodeselector_test.go
@@ -42,11 +42,9 @@ var _ = Describe("nodeSelector", func() {
 	Context("The label doesn't exist", func() {
 		const namespace = "nodeselector-e2e-missing-label"
 		const sampleFile = fixturesDir + "/nodeselector/nodeselector-label-not-exists.yaml"
-		const clusterName = "postgresql-nodeselector"
 		JustAfterEach(func() {
 			if CurrentSpecReport().Failed() {
-				env.DumpClusterEnv(namespace, clusterName,
-					"out/"+CurrentSpecReport().LeafNodeText+".log")
+				env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
 			}
 		})
 		AfterEach(func() {
@@ -111,8 +109,7 @@ var _ = Describe("nodeSelector", func() {
 		const clusterName = "postgresql-nodeselector"
 		JustAfterEach(func() {
 			if CurrentSpecReport().Failed() {
-				env.DumpClusterEnv(namespace, clusterName,
-					"out/"+CurrentSpecReport().LeafNodeText+".log")
+				env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
 			}
 		})
 		AfterEach(func() {

--- a/tests/e2e/operator_ha_test.go
+++ b/tests/e2e/operator_ha_test.go
@@ -48,8 +48,7 @@ var _ = Describe("Operator High Availability", Serial, Label(tests.LabelDisrupti
 
 	JustAfterEach(func() {
 		if CurrentSpecReport().Failed() {
-			env.DumpClusterEnv(namespace, clusterName,
-				"out/"+CurrentSpecReport().LeafNodeText+".log")
+			env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
 		}
 	})
 

--- a/tests/e2e/operator_unavailable_test.go
+++ b/tests/e2e/operator_unavailable_test.go
@@ -53,8 +53,7 @@ var _ = Describe("Operator unavailable", Serial, Label(tests.LabelDisruptive), f
 		const namespace = "op-unavailable-e2e-zero-replicas"
 		JustAfterEach(func() {
 			if CurrentSpecReport().Failed() {
-				env.DumpClusterEnv(namespace, clusterName,
-					"out/"+CurrentSpecReport().LeafNodeText+".log")
+				env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
 			}
 		})
 		AfterEach(func() {
@@ -167,8 +166,7 @@ var _ = Describe("Operator unavailable", Serial, Label(tests.LabelDisruptive), f
 		const namespace = "op-unavailable-e2e-delete-operator"
 		JustAfterEach(func() {
 			if CurrentSpecReport().Failed() {
-				env.DumpClusterEnv(namespace, clusterName,
-					"out/"+CurrentSpecReport().LeafNodeText+".log")
+				env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
 			}
 		})
 		AfterEach(func() {

--- a/tests/e2e/pg_basebackup_test.go
+++ b/tests/e2e/pg_basebackup_test.go
@@ -45,8 +45,7 @@ var _ = Describe("Bootstrap with pg_basebackup using basic auth", func() {
 
 	JustAfterEach(func() {
 		if CurrentSpecReport().Failed() {
-			env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+"-src.log")
-			env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+"-dst.log")
+			env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
 		}
 	})
 	AfterEach(func() {
@@ -117,8 +116,7 @@ var _ = Describe("Bootstrap with pg_basebackup using TLS auth", func() {
 
 	JustAfterEach(func() {
 		if CurrentSpecReport().Failed() {
-			env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+"-src.log")
-			env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+"-dst.log")
+			env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
 		}
 	})
 	AfterEach(func() {

--- a/tests/e2e/pg_basebackup_test.go
+++ b/tests/e2e/pg_basebackup_test.go
@@ -45,10 +45,8 @@ var _ = Describe("Bootstrap with pg_basebackup using basic auth", func() {
 
 	JustAfterEach(func() {
 		if CurrentSpecReport().Failed() {
-			env.DumpClusterEnv(namespace, srcClusterName,
-				"out/"+CurrentSpecReport().LeafNodeText+"-src.log")
-			env.DumpClusterEnv(namespace, dstClusterName,
-				"out/"+CurrentSpecReport().LeafNodeText+"-dst.log")
+			env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+"-src.log")
+			env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+"-dst.log")
 		}
 	})
 	AfterEach(func() {
@@ -119,10 +117,8 @@ var _ = Describe("Bootstrap with pg_basebackup using TLS auth", func() {
 
 	JustAfterEach(func() {
 		if CurrentSpecReport().Failed() {
-			env.DumpClusterEnv(namespace, srcClusterName,
-				"out/"+CurrentSpecReport().LeafNodeText+"-src.log")
-			env.DumpClusterEnv(namespace, dstClusterName,
-				"out/"+CurrentSpecReport().LeafNodeText+"-dst.log")
+			env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+"-src.log")
+			env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+"-dst.log")
 		}
 	})
 	AfterEach(func() {

--- a/tests/e2e/pg_data_corruption_test.go
+++ b/tests/e2e/pg_data_corruption_test.go
@@ -49,8 +49,7 @@ var _ = Describe("PGDATA Corruption", func() {
 
 	JustAfterEach(func() {
 		if CurrentSpecReport().Failed() {
-			env.DumpClusterEnv(namespace, clusterName,
-				"out/"+CurrentSpecReport().LeafNodeText+".log")
+			env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
 		}
 	})
 	AfterEach(func() {

--- a/tests/e2e/pgbouncer_metrics_test.go
+++ b/tests/e2e/pgbouncer_metrics_test.go
@@ -46,8 +46,7 @@ var _ = Describe("PGBouncer Metrics", func() {
 	})
 	JustAfterEach(func() {
 		if CurrentSpecReport().Failed() {
-			env.DumpClusterEnv(namespace, clusterName,
-				"out/"+CurrentSpecReport().LeafNodeText+".log")
+			env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
 		}
 	})
 	AfterEach(func() {

--- a/tests/e2e/pgbouncer_test.go
+++ b/tests/e2e/pgbouncer_test.go
@@ -40,8 +40,7 @@ var _ = Describe("PGBouncer Connections", func() {
 	})
 	JustAfterEach(func() {
 		if CurrentSpecReport().Failed() {
-			env.DumpClusterEnv(namespace, clusterName,
-				"out/"+CurrentSpecReport().LeafNodeText+".log")
+			env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
 			env.DumpPoolerResourcesInfo(namespace, CurrentSpecReport().LeafNodeText)
 		}
 	})

--- a/tests/e2e/pgbouncer_types_test.go
+++ b/tests/e2e/pgbouncer_types_test.go
@@ -52,8 +52,7 @@ var _ = Describe("PGBouncer Types", Ordered, func() {
 
 	JustAfterEach(func() {
 		if CurrentSpecReport().Failed() {
-			env.DumpClusterEnv(namespace, clusterName,
-				"out/"+CurrentSpecReport().LeafNodeText+".log")
+			env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
 		}
 	})
 

--- a/tests/e2e/pvc_deletion_test.go
+++ b/tests/e2e/pvc_deletion_test.go
@@ -45,8 +45,7 @@ var _ = Describe("PVC Deletion", func() {
 
 	JustAfterEach(func() {
 		if CurrentSpecReport().Failed() {
-			env.DumpClusterEnv(namespace, clusterName,
-				"out/"+CurrentSpecReport().LeafNodeText+".log")
+			env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
 		}
 	})
 	AfterEach(func() {

--- a/tests/e2e/replica_mode_cluster_test.go
+++ b/tests/e2e/replica_mode_cluster_test.go
@@ -54,10 +54,8 @@ var _ = Describe("Replica Mode", func() {
 
 	JustAfterEach(func() {
 		if CurrentSpecReport().Failed() {
-			env.DumpClusterEnv(replicaNamespace, srcClusterName,
-				"out/"+CurrentSpecReport().LeafNodeText+"-source-cluster.log")
-			env.DumpClusterEnv(replicaNamespace, replicaClusterName,
-				"out/"+CurrentSpecReport().LeafNodeText+"-replica-cluster.log")
+			env.DumpNamespaceObjects(replicaNamespace, "out/"+CurrentSpecReport().LeafNodeText+"-source-cluster.log")
+			env.DumpNamespaceObjects(replicaNamespace, "out/"+CurrentSpecReport().LeafNodeText+"-replica-cluster.log")
 		}
 	})
 	AfterEach(func() {

--- a/tests/e2e/replica_mode_cluster_test.go
+++ b/tests/e2e/replica_mode_cluster_test.go
@@ -54,8 +54,8 @@ var _ = Describe("Replica Mode", func() {
 
 	JustAfterEach(func() {
 		if CurrentSpecReport().Failed() {
-			env.DumpNamespaceObjects(replicaNamespace, "out/"+CurrentSpecReport().LeafNodeText+"-source-cluster.log")
-			env.DumpNamespaceObjects(replicaNamespace, "out/"+CurrentSpecReport().LeafNodeText+"-replica-cluster.log")
+			env.DumpNamespaceObjects(replicaNamespace,
+				"out/"+CurrentSpecReport().LeafNodeText+".log")
 		}
 	})
 	AfterEach(func() {

--- a/tests/e2e/rolling_update_test.go
+++ b/tests/e2e/rolling_update_test.go
@@ -297,8 +297,7 @@ var _ = Describe("Rolling updates", func() {
 		const clusterName = "postgresql-three-instances"
 		JustAfterEach(func() {
 			if CurrentSpecReport().Failed() {
-				env.DumpClusterEnv(namespace, clusterName,
-					"out/"+CurrentSpecReport().LeafNodeText+".log")
+				env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
 			}
 		})
 		AfterEach(func() {
@@ -323,8 +322,7 @@ var _ = Describe("Rolling updates", func() {
 		const clusterName = "postgresql-single-instance"
 		JustAfterEach(func() {
 			if CurrentSpecReport().Failed() {
-				env.DumpClusterEnv(namespace, clusterName,
-					"out/"+CurrentSpecReport().LeafNodeText+".log")
+				env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
 			}
 		})
 		AfterEach(func() {
@@ -349,8 +347,7 @@ var _ = Describe("Rolling updates", func() {
 
 		JustAfterEach(func() {
 			if CurrentSpecReport().Failed() {
-				env.DumpClusterEnv(namespace, clusterName,
-					"out/"+CurrentSpecReport().LeafNodeText+".log")
+				env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
 			}
 		})
 

--- a/tests/e2e/scaling_test.go
+++ b/tests/e2e/scaling_test.go
@@ -41,8 +41,7 @@ var _ = Describe("Cluster scale up and down", func() {
 
 	JustAfterEach(func() {
 		if CurrentSpecReport().Failed() {
-			env.DumpClusterEnv(namespace, clusterName,
-				"out/"+CurrentSpecReport().LeafNodeText+".log")
+			env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
 		}
 	})
 	AfterEach(func() {

--- a/tests/e2e/storage_expansion_test.go
+++ b/tests/e2e/storage_expansion_test.go
@@ -48,8 +48,7 @@ var _ = Describe("Verify storage", func() {
 
 	JustAfterEach(func() {
 		if CurrentSpecReport().Failed() {
-			env.DumpClusterEnv(namespace, clusterName,
-				"out/"+CurrentSpecReport().LeafNodeText+".log")
+			env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
 		}
 	})
 

--- a/tests/e2e/switchover_test.go
+++ b/tests/e2e/switchover_test.go
@@ -37,8 +37,7 @@ var _ = Describe("Switchover", func() {
 	})
 	JustAfterEach(func() {
 		if CurrentSpecReport().Failed() {
-			env.DumpClusterEnv(namespace, clusterName,
-				"out/"+CurrentSpecReport().LeafNodeText+".log")
+			env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
 		}
 	})
 	AfterEach(func() {

--- a/tests/e2e/syncreplicas_test.go
+++ b/tests/e2e/syncreplicas_test.go
@@ -45,8 +45,7 @@ var _ = Describe("Synchronous Replicas", func() {
 	})
 	JustAfterEach(func() {
 		if CurrentSpecReport().Failed() {
-			env.DumpClusterEnv(namespace, clusterName,
-				"out/"+CurrentSpecReport().LeafNodeText+".log")
+			env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
 		}
 	})
 	AfterEach(func() {

--- a/tests/e2e/tolerations_test.go
+++ b/tests/e2e/tolerations_test.go
@@ -46,8 +46,7 @@ var _ = Describe("E2E Tolerations Node", Serial, Label(tests.LabelDisruptive), f
 
 	JustAfterEach(func() {
 		if CurrentSpecReport().Failed() {
-			env.DumpClusterEnv(namespace, clusterName,
-				"out/"+CurrentSpecReport().LeafNodeText+".log")
+			env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
 		}
 	})
 

--- a/tests/e2e/update_user_test.go
+++ b/tests/e2e/update_user_test.go
@@ -51,8 +51,7 @@ var _ = Describe("Update user and superuser password", func() {
 
 	JustAfterEach(func() {
 		if CurrentSpecReport().Failed() {
-			env.DumpClusterEnv(namespace, clusterName,
-				"out/"+CurrentSpecReport().LeafNodeText+".log")
+			env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
 		}
 	})
 	AfterEach(func() {
@@ -123,8 +122,7 @@ var _ = Describe("Disabling superuser password", func() {
 
 	JustAfterEach(func() {
 		if CurrentSpecReport().Failed() {
-			env.DumpClusterEnv(namespace, clusterName,
-				"out/"+CurrentSpecReport().LeafNodeText+".log")
+			env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
 		}
 	})
 	AfterEach(func() {
@@ -232,8 +230,7 @@ var _ = Describe("Creating a cluster without superuser password", func() {
 
 	JustAfterEach(func() {
 		if CurrentSpecReport().Failed() {
-			env.DumpClusterEnv(namespace, clusterName,
-				"out/"+CurrentSpecReport().LeafNodeText+".log")
+			env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
 		}
 	})
 	AfterEach(func() {

--- a/tests/e2e/upgrade_test.go
+++ b/tests/e2e/upgrade_test.go
@@ -100,8 +100,7 @@ var _ = Describe("Upgrade", Label(tests.LabelUpgrade, tests.LabelNoOpenshift), O
 
 	JustAfterEach(func() {
 		if CurrentSpecReport().Failed() {
-			env.DumpClusterEnv(upgradeNamespace, clusterName1,
-				"out/"+CurrentSpecReport().LeafNodeText+".log")
+			env.DumpNamespaceObjects(upgradeNamespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
 			// Dump the operator namespace, as operator is changing too
 			env.DumpOperator(operatorNamespace,
 				"out/"+CurrentSpecReport().LeafNodeText+"operator.log")

--- a/tests/e2e/wal_restore_parallel_test.go
+++ b/tests/e2e/wal_restore_parallel_test.go
@@ -41,7 +41,7 @@ var _ = Describe("Wal-restore in parallel", Label(tests.LabelBackupRestore), fun
 		SpoolDirectory    = walrestore.SpoolDirectory
 	)
 
-	var namespace, clusterName string
+	var namespace string
 	var primary, standby, latestWAL, walFile1, walFile2, walFile3, walFile4, walFile5, walFile6 string
 
 	BeforeEach(func() {
@@ -55,8 +55,7 @@ var _ = Describe("Wal-restore in parallel", Label(tests.LabelBackupRestore), fun
 
 	JustAfterEach(func() {
 		if CurrentSpecReport().Failed() {
-			env.DumpClusterEnv(namespace, clusterName,
-				"out/"+CurrentSpecReport().LeafNodeText+".log")
+			env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
 		}
 	})
 

--- a/tests/e2e/webhook_test.go
+++ b/tests/e2e/webhook_test.go
@@ -58,8 +58,7 @@ var _ = Describe("webhook", Serial, Label(tests.LabelDisruptive), Ordered, func(
 
 	JustAfterEach(func() {
 		if CurrentSpecReport().Failed() {
-			env.DumpClusterEnv(webhookNamespace, clusterName,
-				"out/"+CurrentSpecReport().LeafNodeText+".log")
+			env.DumpNamespaceObjects(webhookNamespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
 		}
 	})
 	AfterEach(func() {

--- a/tests/utils/cluster.go
+++ b/tests/utils/cluster.go
@@ -116,8 +116,8 @@ func ClusterHasAnnotations(
 	return true
 }
 
-// DumpClusterEnv logs the JSON for the a cluster in a namespace, its pods and endpoints
-func (env TestingEnvironment) DumpClusterEnv(namespace string, clusterName string, filename string) {
+// DumpNamespaceObjects logs the clusters, pods, pvcs etc. found in a namespace as JSON sections
+func (env TestingEnvironment) DumpNamespaceObjects(namespace string, filename string) {
 	f, err := os.Create(filepath.Clean(filename))
 	if err != nil {
 		fmt.Println(err)


### PR DESCRIPTION
test: adding support to dump logs of  multiple clusters in case e2e fails.

closes #227 

Signed-off-by: Danish Khan <danish.khan@enterprisedb.com>