### PR TITLE
fix: search operator deployment from user namespace

### DIFF
--- a/docs/src/cnpg-plugin.md
+++ b/docs/src/cnpg-plugin.md
@@ -361,8 +361,14 @@ The command will generate a ZIP file containing various manifest in YAML format
 Use the `-f` flag to name a result file explicitly. If the `-f` flag is not used, a
 default time-stamped filename is created for the zip file.
 
+!!! Note
+    The report plugin obeys `kubectl` conventions, and will look for objects constrained
+    by namespace. The CNPG Operator will generally not be installed in the same
+    namespace as the clusters.
+    E.g. the default installation namespace is cnpg-system
+
 ``` shell
-kubectl cnpg report operator
+kubectl cnpg report operator -n <namespace>
 ```
 
 results in
@@ -374,7 +380,7 @@ Successfully written report to "report_operator_<TIMESTAMP>.zip" (format: "yaml"
 With the `-f` flag set:
 
 ```shell
-kubectl cnpg report operator -f reportRedacted.zip
+kubectl cnpg report operator -n <namespace> -f reportRedacted.zip
 ```
 
 Unzipping the file will produce a time-stamped top-level folder to keep the
@@ -422,7 +428,7 @@ metadata:
 With the `-S` (`--stopRedaction`) option activated, secrets are shown:
 
 ```shell
-kubectl cnpg report operator -f reportNonRedacted.zip -S
+kubectl cnpg report operator -n <namespace> -f reportNonRedacted.zip -S
 ```
 
 You'll get a reminder that you're about to view confidential information:

--- a/internal/cmd/plugin/report/operator_report.go
+++ b/internal/cmd/plugin/report/operator_report.go
@@ -112,7 +112,7 @@ func operator(ctx context.Context, format plugin.OutputFormat,
 		return fmt.Errorf("could not get operator pod: %w", err)
 	}
 
-	operatorSecrets, err := deployments.GetOperatorSecrets(ctx)
+	operatorSecrets, err := deployments.GetOperatorSecrets(ctx, operatorDeployment)
 	if err != nil {
 		return fmt.Errorf("could not get operator secrets: %w", err)
 	}
@@ -121,7 +121,7 @@ func operator(ctx context.Context, format plugin.OutputFormat,
 		secrets = append(secrets, namedObject{Name: ss.Name + "(secret)", Object: secretRedactor(ss)})
 	}
 
-	operatorConfigMaps, err := deployments.GetOperatorConfigMaps(ctx)
+	operatorConfigMaps, err := deployments.GetOperatorConfigMaps(ctx, operatorDeployment)
 	if err != nil {
 		return fmt.Errorf("could not get operator configmap: %w", err)
 	}

--- a/internal/cmd/plugin/report/operator_report.go
+++ b/internal/cmd/plugin/report/operator_report.go
@@ -112,7 +112,7 @@ func operator(ctx context.Context, format plugin.OutputFormat,
 		return fmt.Errorf("could not get operator pod: %w", err)
 	}
 
-	operatorSecrets, err := deployments.GetOperatorSecrets(ctx, operatorDeployment)
+	operatorSecrets, err := deployments.GetOperatorSecrets(ctx, *operatorDeployment)
 	if err != nil {
 		return fmt.Errorf("could not get operator secrets: %w", err)
 	}
@@ -121,7 +121,7 @@ func operator(ctx context.Context, format plugin.OutputFormat,
 		secrets = append(secrets, namedObject{Name: ss.Name + "(secret)", Object: secretRedactor(ss)})
 	}
 
-	operatorConfigMaps, err := deployments.GetOperatorConfigMaps(ctx, operatorDeployment)
+	operatorConfigMaps, err := deployments.GetOperatorConfigMaps(ctx, *operatorDeployment)
 	if err != nil {
 		return fmt.Errorf("could not get operator configmap: %w", err)
 	}
@@ -147,7 +147,7 @@ func operator(ctx context.Context, format plugin.OutputFormat,
 	}
 
 	rep := operatorReport{
-		deployment:              operatorDeployment,
+		deployment:              *operatorDeployment,
 		operatorPods:            operatorPods,
 		secrets:                 secrets,
 		configs:                 configs,


### PR DESCRIPTION
The fix includes two parts:

1. Reduce the times of function call for operator report function
2. Continue search operator deployment from user namespace

Closes #247  

Signed-off-by: Tao Li <tao.li@enterprisedb.com>
