### PR TITLE
ci: remove automatically e2e test run for push and pull request

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -3,8 +3,10 @@ name: continuous-delivery
 on:
   push:
     branches:
-      - '**'
+      - main
+      - 'dependabot/**'
   pull_request:
+    types: [ opened ]
   workflow_dispatch:
     inputs:
       depth:


### PR DESCRIPTION
This fix reduce the chance of e2e test automatically run. for push event, 
e2e test will only automatically run on main and dependabot/** branch. 
For pull request event, e2e test case will only automatically run when 
event type is opened. 

Closes #256 

Signed-off-by: Tao Li <tao.li@enterprisedb.com>
