### PR TITLE
doc: update architecture.md file

### DIFF
--- a/docs/src/architecture.md
+++ b/docs/src/architecture.md
@@ -87,8 +87,8 @@ only write inside a single Kubernetes cluster, at any time.
 
 !!! Tip
     If you are interested in a PostgreSQL architecture where all instances accept writes, 
-    please take a look at  [BDR (Bi-Directional Replication) by EDB](https://www.enterprisedb.com/docs/bdr/latest/). 
-    For Kubernetes, BDR will have its own Operator, expected later in 2022.
+    please take a look at  [EDB Distributed Postgres by EDB](https://www.enterprisedb.com/docs/pgd/latest/). 
+    For Kubernetes, EDB Distributed Postgres will have its own Operator, expected later in 2022.
 
 However, for business continuity objectives it is fundamental to:
 


### PR DESCRIPTION
Replacing the reference and link to BDR with reference and link to
EDB Postgres Distributed (pgd) because of the name-change at EDB.

Closes #261

Signed-off-by: Jan Karremans <jan.karremans@enterprisedb.com>