### PR TITLE
docs: clarify log storage is not in operator

### DIFF
--- a/docs/src/logging.md
+++ b/docs/src/logging.md
@@ -13,6 +13,13 @@ Each log entry has the following fields:
   `logger` type)
 - `logging_podName`: the pod where the log was created generated
 
+!!! Warning
+    Long-term storage and management of logs is outside the operator's purview,
+    and needs to be provided at the level of the Kubernetes installation. Please
+    refer to the
+    [Kubernetes Logging Architecture](https://kubernetes.io/docs/concepts/cluster-administration/logging/)
+    documentation.
+
 ## Operator log
 
 A log level can be specified in the cluster spec with the option `logLevel` and

--- a/docs/src/postgresql_conf.md
+++ b/docs/src/postgresql_conf.md
@@ -318,7 +318,7 @@ host all all all scram-sha-256 # (or md5 for PostgreSQL version <= 13)
 Refer to the PostgreSQL documentation for [more information on `pg_hba.conf`](https://www.postgresql.org/docs/current/auth-pg-hba-conf.html).
 
 Inside the cluster manifest, `pg_hba` lines are added as list items
-in `spec.postgresql.pg_hba`. e.g.:
+in `spec.postgresql.pg_hba`, as in the following excerpt:
 
 ``` yaml
   postgresql:

--- a/docs/src/postgresql_conf.md
+++ b/docs/src/postgresql_conf.md
@@ -326,6 +326,10 @@ in `spec.postgresql.pg_hba`, as in the following excerpt:
       - hostssl app app 10.244.0.0/16 md5
 ```
 
+In the above example we are enabling access for the `app` user to the `app`
+database using MD5 password authentication (you can use `scram-sha-256`
+if you prefer) via a secure channel (`hostssl`).
+
 ### LDAP Configuration
 
 Under the `postgres` section of the cluster spec there is an optional `ldap` section available to define an LDAP

--- a/docs/src/postgresql_conf.md
+++ b/docs/src/postgresql_conf.md
@@ -317,6 +317,15 @@ host all all all scram-sha-256 # (or md5 for PostgreSQL version <= 13)
 
 Refer to the PostgreSQL documentation for [more information on `pg_hba.conf`](https://www.postgresql.org/docs/current/auth-pg-hba-conf.html).
 
+Inside the operator manifest, `pg_hba` lines are added as list items
+in `spec.postgresql.pg_hba`. e.g.:
+
+``` yaml
+  postgresql:
+    pg_hba:
+      - host all all 10.244.0.0/16 md5
+```
+
 ### LDAP Configuration
 
 Under the `postgres` section of the cluster spec there is an optional `ldap` section available to define an LDAP

--- a/docs/src/postgresql_conf.md
+++ b/docs/src/postgresql_conf.md
@@ -317,7 +317,7 @@ host all all all scram-sha-256 # (or md5 for PostgreSQL version <= 13)
 
 Refer to the PostgreSQL documentation for [more information on `pg_hba.conf`](https://www.postgresql.org/docs/current/auth-pg-hba-conf.html).
 
-Inside the operator manifest, `pg_hba` lines are added as list items
+Inside the cluster manifest, `pg_hba` lines are added as list items
 in `spec.postgresql.pg_hba`. e.g.:
 
 ``` yaml

--- a/docs/src/postgresql_conf.md
+++ b/docs/src/postgresql_conf.md
@@ -323,7 +323,7 @@ in `spec.postgresql.pg_hba`, as in the following excerpt:
 ``` yaml
   postgresql:
     pg_hba:
-      - host all all 10.244.0.0/16 md5
+      - hostssl app app 10.244.0.0/16 md5
 ```
 
 ### LDAP Configuration


### PR DESCRIPTION
Add clarity that log storage is not in the purview of cnpg.

Closes #290 

Signed-off-by: Jaime Silvela <jaime.silvela@enterprisedb.com>