### PR TITLE
Revert "ci: remove automatically e2e test run for push and pull request"

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -3,10 +3,8 @@ name: continuous-delivery
 on:
   push:
     branches:
-      - main
-      - 'dependabot/**'
+      - '**'
   pull_request:
-    types: [ opened ]
   workflow_dispatch:
     inputs:
       depth:


### PR DESCRIPTION
Reverts cloudnative-pg/cloudnative-pg#257

I reverted because with this comment is impossible to merge any PR due to the lack of required testing steps.