### PR TITLE
fix: version upgrade logic in patch #198

### DIFF
--- a/api/v1/cluster_webhook.go
+++ b/api/v1/cluster_webhook.go
@@ -25,7 +25,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/validation"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -76,19 +75,6 @@ func (r *Cluster) Default() {
 	clusterLog.Info("default", "name", r.Name, "namespace", r.Namespace)
 
 	r.setDefaults(true)
-}
-
-// removeConditionsWithInvalidReason will remove every condition which is not valid
-// anymore from the K8s API point-of-view
-func (r *Cluster) removeConditionsWithInvalidReason() {
-	conditions := make([]metav1.Condition, 0, len(r.Status.Conditions))
-	for _, entry := range r.Status.Conditions {
-		if utils.IsConditionReasonValid(entry.Reason) {
-			conditions = append(conditions, entry)
-		}
-	}
-
-	r.Status.Conditions = conditions
 }
 
 // SetDefaults apply the defaults to undefined values in a Cluster
@@ -147,20 +133,6 @@ func (r *Cluster) setDefaults(preserveUserSettings bool) {
 	if !r.Spec.Monitoring.AreDefaultQueriesDisabled() {
 		r.defaultMonitoringQueries(configuration.Current)
 	}
-
-	// IMPORTANT: the following functions are not really setting any
-	// default value of the Cluster, but will just migrate the CNP
-	// definition from the one using the customized Condition structure
-	// from the one using the K8s ones.
-	//
-	// We need do to this because we were using invalid condition reasons.
-	// We are doing this here method because this code is going to be called
-	// in the underlying mutating webhook implementation.
-	//
-	// What about the conditions which are going to be deleted? They are
-	// going to be recreated at the next reconciliation loop by the
-	// operator and by the instance manager
-	r.removeConditionsWithInvalidReason()
 }
 
 // defaultMonitoringQueries adds the default monitoring queries configMap

--- a/controllers/cluster_status.go
+++ b/controllers/cluster_status.go
@@ -31,7 +31,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/utils/strings/slices"
@@ -365,6 +365,24 @@ func (r *ClusterReconciler) updateResourceStatus(
 	return nil
 }
 
+// removeConditionsWithInvalidReason will remove every condition which is not valid
+// anymore from the K8s API point-of-view
+func (r *ClusterReconciler) removeConditionsWithInvalidReason(ctx context.Context, cluster *apiv1.Cluster) error {
+	conditions := make([]metav1.Condition, 0, len(cluster.Status.Conditions))
+	for _, entry := range cluster.Status.Conditions {
+		if utils.IsConditionReasonValid(entry.Reason) {
+			conditions = append(conditions, entry)
+		}
+	}
+
+	if !reflect.DeepEqual(cluster.Status.Conditions, conditions) {
+		cluster.Status.Conditions = conditions
+		return r.Status().Update(ctx, cluster)
+	}
+
+	return nil
+}
+
 // updateOnlineUpdateEnabled updates the `OnlineUpdateEnabled` value in the cluster status
 func (r *ClusterReconciler) updateOnlineUpdateEnabled(
 	ctx context.Context, cluster *apiv1.Cluster, onlineUpdateEnabled bool,
@@ -380,7 +398,7 @@ func (r *ClusterReconciler) updateOnlineUpdateEnabled(
 
 // SetClusterOwnerAnnotationsAndLabels sets the cluster as owner of the passed object and then
 // sets all the needed annotations and labels
-func SetClusterOwnerAnnotationsAndLabels(obj *v1.ObjectMeta, cluster *apiv1.Cluster) {
+func SetClusterOwnerAnnotationsAndLabels(obj *metav1.ObjectMeta, cluster *apiv1.Cluster) {
 	utils.InheritAnnotations(obj, cluster.Annotations, cluster.GetFixedInheritedAnnotations(), configuration.Current)
 	utils.InheritLabels(obj, cluster.Labels, cluster.GetFixedInheritedLabels(), configuration.Current)
 	utils.LabelClusterName(obj, cluster.GetName())


### PR DESCRIPTION
The part of pull request #198 regarding the upgrade from a version
setting reasons containing space is wrong because it is impossible to
update the status in a defaulting webhook or with a simple Update
call. Moreover, the setDefault function misses the difference because
it only compares the content of the spec section.

In most cases, the previous code works anyway because the Cluster
reconciliation loop must update the status after an operator
upgrade. However, in rare cases, it could lead to a cluster that is
impossible to upgrade.

This patch fixes the issue by moving the upgrade code from the webhook
to the main controller reconciliation loop.

Closes #329

Signed-off-by: Marco Nenciarini <marco.nenciarini@enterprisedb.com>