### PR TITLE
fix: only healthy pods are electable as synchronous replica

### DIFF
--- a/api/v1/cluster_configuration.go
+++ b/api/v1/cluster_configuration.go
@@ -66,11 +66,9 @@ func (cluster *Cluster) GetSyncReplicasData() (syncReplicas int, electableSyncRe
 // getElectableSyncReplicas computes the names of the instances that can be elected to sync replicas
 func (cluster *Cluster) getElectableSyncReplicas() []string {
 	var nonPrimaryInstances []string
-	for _, instances := range cluster.Status.InstancesStatus {
-		for _, instance := range instances {
-			if cluster.Status.CurrentPrimary != instance {
-				nonPrimaryInstances = append(nonPrimaryInstances, instance)
-			}
+	for _, instance := range cluster.Status.InstancesStatus[utils.PodHealthy] {
+		if cluster.Status.CurrentPrimary != instance {
+			nonPrimaryInstances = append(nonPrimaryInstances, instance)
 		}
 	}
 


### PR DESCRIPTION
Closes #339 

Signed-off-by: Armando Ruocco <armando.ruocco@enterprisedb.com>