### PR TITLE
fix: support application database monitoring for replica clusters

### DIFF
--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -1463,6 +1463,9 @@ func (cluster *Cluster) GetApplicationSecretName() string {
 // GetApplicationDatabaseName get the name of the application database for a specific bootstrap
 func (cluster *Cluster) GetApplicationDatabaseName() string {
 	bootstrap := cluster.Spec.Bootstrap
+	if bootstrap == nil {
+		return ""
+	}
 
 	if bootstrap.Recovery != nil && bootstrap.Recovery.Database != "" {
 		return bootstrap.Recovery.Database
@@ -1482,6 +1485,9 @@ func (cluster *Cluster) GetApplicationDatabaseName() string {
 // GetApplicationDatabaseOwner get the owner user of the application database for a specific bootstrap
 func (cluster *Cluster) GetApplicationDatabaseOwner() string {
 	bootstrap := cluster.Spec.Bootstrap
+	if bootstrap == nil {
+		return ""
+	}
 
 	if bootstrap.Recovery != nil && bootstrap.Recovery.Owner != "" {
 		return bootstrap.Recovery.Owner

--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -1462,30 +1462,40 @@ func (cluster *Cluster) GetApplicationSecretName() string {
 
 // GetApplicationDatabaseName get the name of the application database for a specific bootstrap
 func (cluster *Cluster) GetApplicationDatabaseName() string {
-	switch {
-	case cluster.ShouldRecoveryCreateApplicationDatabase():
-		return cluster.Spec.Bootstrap.Recovery.Database
-	case cluster.ShouldPgBaseBackupCreateApplicationDatabase():
-		return cluster.Spec.Bootstrap.PgBaseBackup.Database
-	case cluster.ShouldInitDBCreateApplicationDatabase():
-		return cluster.Spec.Bootstrap.InitDB.Database
-	default:
-		return ""
+	bootstrap := cluster.Spec.Bootstrap
+
+	if bootstrap.Recovery != nil && bootstrap.Recovery.Database != "" {
+		return bootstrap.Recovery.Database
 	}
+
+	if bootstrap.PgBaseBackup != nil && bootstrap.PgBaseBackup.Database != "" {
+		return bootstrap.PgBaseBackup.Database
+	}
+
+	if bootstrap.InitDB != nil && bootstrap.InitDB.Database != "" {
+		return bootstrap.InitDB.Database
+	}
+
+	return ""
 }
 
 // GetApplicationDatabaseOwner get the owner user of the application database for a specific bootstrap
 func (cluster *Cluster) GetApplicationDatabaseOwner() string {
-	switch {
-	case cluster.ShouldRecoveryCreateApplicationDatabase():
-		return cluster.Spec.Bootstrap.Recovery.Owner
-	case cluster.ShouldPgBaseBackupCreateApplicationDatabase():
-		return cluster.Spec.Bootstrap.PgBaseBackup.Owner
-	case cluster.ShouldInitDBCreateApplicationDatabase():
-		return cluster.Spec.Bootstrap.InitDB.Owner
-	default:
-		return ""
+	bootstrap := cluster.Spec.Bootstrap
+
+	if bootstrap.Recovery != nil && bootstrap.Recovery.Owner != "" {
+		return bootstrap.Recovery.Owner
 	}
+
+	if bootstrap.PgBaseBackup != nil && bootstrap.PgBaseBackup.Owner != "" {
+		return bootstrap.PgBaseBackup.Owner
+	}
+
+	if bootstrap.InitDB != nil && bootstrap.InitDB.Owner != "" {
+		return bootstrap.InitDB.Owner
+	}
+
+	return ""
 }
 
 // GetServerCASecretName get the name of the secret containing the CA

--- a/docs/src/monitoring.md
+++ b/docs/src/monitoring.md
@@ -36,9 +36,12 @@ Queries, by default, are run against the *main database*, as defined by
 the specified `bootstrap` method of the `Cluster` resource, according
 to the following logic:
 
-- using `initdb`: queries will be run against the specified database by default, so the
-  value passed as `initdb.database` or defaulting to `app` if not specified.
-- not using `initdb`: queries will run against the `postgres` database, by default.
+- using `initdb`: queries will be run by default against the specified database
+  in `initdb.database`, or `app` if not specified
+- using `recovery`: queries will be run by default against the specified database
+  in `recovery.database`, or `postgres` if not specified
+- using `pg_basebackup`: queries will be run by default against the specified database
+  in `pg_basebackup.database`, or `postgres` if not specified
 
 The default database can always be overridden for a given user-defined metric,
 by specifying a list of one or more databases in the `target_databases` option.

--- a/internal/management/controller/instance_controller.go
+++ b/internal/management/controller/instance_controller.go
@@ -687,7 +687,7 @@ func (r *InstanceReconciler) reconcileMonitoringQueries(
 	contextLogger.Debug("Reconciling custom monitoring queries")
 
 	dbname := "postgres"
-	if cluster.ShouldCreateApplicationDatabase() {
+	if len(cluster.GetApplicationDatabaseName()) != 0 {
 		dbname = cluster.GetApplicationDatabaseName()
 	}
 


### PR DESCRIPTION
This patch enables CNPG to execute monitoring queries against the
application database for replica clusters, bootstrapped with the
`pgbasebackup` and the `recovery` bootstrap method.

We are fixing the behavior of `GetApplicationDatabaseName` too, directly
getting the database name (and owner) regardless of whenever the
application database need to be created or not.

Closes #345

Signed-off-by: Leonardo Cecchi <leonardo.cecchi@enterprisedb.com>