### PR TITLE
test: CheckForExistingPostmaster implementation easier to test

### DIFF
--- a/pkg/management/postgres/instance.go
+++ b/pkg/management/postgres/instance.go
@@ -396,7 +396,7 @@ func (instance *Instance) Reload() error {
 // Run this instance returning an OS process needed
 // to control the instance execution
 func (instance Instance) Run() (*execlog.StreamingCmd, error) {
-	process, err := instance.CheckForExistingPostmaster()
+	process, err := instance.CheckForExistingPostmaster(postgresName)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
We weren't testing the positive case in our unit tests, that is when the
`postmaster` process actually exists.

In order to do that, the implementation of `CheckForExistingPostmaster`
had to be changed to allow the code to inject a custom process name.

Closes #369

Signed-off-by: Leonardo Cecchi <leonardo.cecchi@enterprisedb.com>