### PR TITLE
feat: adds logs during switchover, failover and demotion

### DIFF
--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -1933,6 +1933,7 @@ func (cluster *Cluster) LogTimestampsWithMessage(ctx context.Context, logMessage
 
 	var errs []string
 
+	// Elapsed time since the last request of promotion (TargetPrimaryTimestamp)
 	if diff, err := utils.DifferenceBetweenTimestamps(
 		currentTimestamp,
 		cluster.Status.TargetPrimaryTimestamp,
@@ -1946,6 +1947,7 @@ func (cluster *Cluster) LogTimestampsWithMessage(ctx context.Context, logMessage
 		errs = append(errs, err.Error())
 	}
 
+	// Elapsed time since the last promotion (CurrentPrimaryTimestamp)
 	if currentPrimaryDifference, err := utils.DifferenceBetweenTimestamps(
 		currentTimestamp,
 		cluster.Status.CurrentPrimaryTimestamp,
@@ -1959,6 +1961,10 @@ func (cluster *Cluster) LogTimestampsWithMessage(ctx context.Context, logMessage
 		errs = append(errs, err.Error())
 	}
 
+	// Difference between the last promotion and the last request of promotion
+	// When positive, it is the amount of time required in the last promotion
+	// of a standby to a primary. If negative, it means we have a failover/switchover
+	// in progress, and the value represents the last measured uptime of the primary.
 	if currentPrimaryTargetDifference, err := utils.DifferenceBetweenTimestamps(
 		cluster.Status.CurrentPrimaryTimestamp,
 		cluster.Status.TargetPrimaryTimestamp,

--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -1919,8 +1919,8 @@ func (cluster *Cluster) IsPodMonitorEnabled() bool {
 	return false
 }
 
-// LogTimestamps prints useful information about timestamps in stdout
-func (cluster *Cluster) LogTimestamps(ctx context.Context) {
+// LogTimestampsWithMessage prints useful information about timestamps in stdout
+func (cluster *Cluster) LogTimestampsWithMessage(ctx context.Context, logMessage string) {
 	contextLogger := log.FromContext(ctx)
 
 	currentTimestamp := utils.GetCurrentTimestamp()
@@ -1976,7 +1976,7 @@ func (cluster *Cluster) LogTimestamps(ctx context.Context) {
 		keysAndValues = append(keysAndValues, "timestampParsingErrors", errs)
 	}
 
-	contextLogger.Info("cluster timestamps information", keysAndValues...)
+	contextLogger.Info(logMessage, keysAndValues...)
 }
 
 // IsBarmanBackupConfigured returns true if one of the possible backup destination

--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1
 
 import (
+	"context"
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
@@ -1916,6 +1917,35 @@ func (cluster *Cluster) IsPodMonitorEnabled() bool {
 	}
 
 	return false
+}
+
+// LogTimestamps prints useful information about timestamps in stdout
+func (cluster *Cluster) LogTimestamps(ctx context.Context) {
+	contextLogger := log.FromContext(ctx)
+
+	currentTimestamp := utils.GetCurrentTimestamp()
+
+	targetPrimaryDifference, targetPrimaryDifferenceErr := utils.DifferenceBetweenTimestamps(
+		currentTimestamp,
+		cluster.Status.TargetPrimaryTimestamp,
+	)
+
+	currentPrimaryDifference, currentPrimaryDifferenceErr := utils.DifferenceBetweenTimestamps(
+		currentTimestamp,
+		cluster.Status.CurrentPrimaryTimestamp,
+	)
+
+	contextLogger.Info("cluster timestamps information",
+		"phase", cluster.Status.Phase,
+		"currentTimestamp", currentTimestamp,
+		"targetPrimaryTimestamp", cluster.Status.TargetPrimaryTimestamp,
+		"currentPrimaryTimestamp", cluster.Status.CurrentPrimaryTimestamp,
+		"secondsPassedSinceTargetPrimaryTimestamp", targetPrimaryDifference.Seconds(),
+		"secondsPassedSinceCurrentPrimaryTimestamp", currentPrimaryDifference.Seconds(),
+		// we report if there were any errors while parsing the timestamps
+		"errorEncounteredWhileParsingTimestamps", currentPrimaryDifferenceErr != nil,
+		"errorWhileParsingTargetPrimaryTimestamp", targetPrimaryDifferenceErr != nil,
+	)
 }
 
 // IsBarmanBackupConfigured returns true if one of the possible backup destination

--- a/internal/management/controller/instance_controller.go
+++ b/internal/management/controller/instance_controller.go
@@ -1033,7 +1033,8 @@ func (r *InstanceReconciler) reconcilePrimary(ctx context.Context, cluster *apiv
 
 	// if the currentPrimary doesn't match the PodName we set the correct value.
 	if cluster.Status.CurrentPrimary != r.instance.PodName {
-		// we log the timestamp information before overriding them
+		// we log the timestamp information before overriding them. This is useful to know how much time it took.
+		contextLogger.Info("printing timestamp info before setting myself as the current primary")
 		cluster.LogTimestamps(ctx)
 		contextLogger.Info("Setting myself as the current primary")
 		cluster.Status.CurrentPrimary = r.instance.PodName

--- a/internal/management/controller/instance_controller.go
+++ b/internal/management/controller/instance_controller.go
@@ -1022,6 +1022,7 @@ func (r *InstanceReconciler) reconcilePrimary(ctx context.Context, cluster *apiv
 
 	// If I'm not the primary, let's promote myself
 	if !isPrimary {
+		cluster.LogTimestampsWithMessage(ctx, "setting myself as primary")
 		if err := r.promoteAndWait(ctx, cluster); err != nil {
 			return false, err
 		}
@@ -1030,8 +1031,6 @@ func (r *InstanceReconciler) reconcilePrimary(ctx context.Context, cluster *apiv
 
 	// if the currentPrimary doesn't match the PodName we set the correct value.
 	if cluster.Status.CurrentPrimary != r.instance.PodName {
-		// we log the timestamp information before overriding them. This is useful to know how much time it took.
-		cluster.LogTimestampsWithMessage(ctx, "setting myself as primary")
 		cluster.Status.CurrentPrimary = r.instance.PodName
 		cluster.Status.CurrentPrimaryTimestamp = pkgUtils.GetCurrentTimestamp()
 		err := r.client.Status().Patch(ctx, cluster, client.MergeFrom(oldCluster))

--- a/internal/management/controller/instance_controller.go
+++ b/internal/management/controller/instance_controller.go
@@ -403,7 +403,7 @@ func (r *InstanceReconciler) reconcileOldPrimary(
 	// When the termination has been requested, this context will be cancelled.
 	<-ctx.Done()
 
-	cluster.LogTimestampsWithMessage(ctx, "old primary shutdown complete")
+	cluster.LogTimestampsWithMessage(ctx, "Old primary shutdown complete")
 
 	return true, nil
 }
@@ -1022,7 +1022,7 @@ func (r *InstanceReconciler) reconcilePrimary(ctx context.Context, cluster *apiv
 
 	// If I'm not the primary, let's promote myself
 	if !isPrimary {
-		cluster.LogTimestampsWithMessage(ctx, "setting myself as primary")
+		cluster.LogTimestampsWithMessage(ctx, "Setting myself as primary")
 		if err := r.promoteAndWait(ctx, cluster); err != nil {
 			return false, err
 		}
@@ -1037,7 +1037,7 @@ func (r *InstanceReconciler) reconcilePrimary(ctx context.Context, cluster *apiv
 		if err != nil {
 			return restarted, err
 		}
-		cluster.LogTimestampsWithMessage(ctx, "finished setting myself as primary")
+		cluster.LogTimestampsWithMessage(ctx, "Finished setting myself as primary")
 		return restarted, nil
 	}
 

--- a/pkg/utils/time.go
+++ b/pkg/utils/time.go
@@ -66,12 +66,12 @@ func ParseTargetTime(currentLocation *time.Location, targetTime string) (time.Ti
 
 // DifferenceBetweenTimestamps returns the time.Duration difference between two timestamps strings in time.RFC3339.
 func DifferenceBetweenTimestamps(first, second string) (time.Duration, error) {
-	parsedTimestamp, err := time.Parse(time.RFC3339, first)
+	parsedTimestamp, err := time.Parse(time.RFC3339Nano, first)
 	if err != nil {
 		return 0, err
 	}
 
-	parsedTimestampTwo, err := time.Parse(time.RFC3339, second)
+	parsedTimestampTwo, err := time.Parse(time.RFC3339Nano, second)
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/utils/time.go
+++ b/pkg/utils/time.go
@@ -63,3 +63,18 @@ func ParseTargetTime(currentLocation *time.Location, targetTime string) (time.Ti
 
 	return time.Parse("2006-01-02T15:04:05", targetTime)
 }
+
+// DifferenceBetweenTimestamps returns the time.Duration difference between two timestamps strings in time.RFC3339.
+func DifferenceBetweenTimestamps(first, second string) (time.Duration, error) {
+	parsedTimestamp, err := time.Parse(time.RFC3339, first)
+	if err != nil {
+		return 0, err
+	}
+
+	parsedTimestampTwo, err := time.Parse(time.RFC3339, second)
+	if err != nil {
+		return 0, err
+	}
+
+	return parsedTimestamp.Sub(parsedTimestampTwo), nil
+}

--- a/pkg/utils/time_test.go
+++ b/pkg/utils/time_test.go
@@ -63,4 +63,22 @@ var _ = Describe("Parsing targetTime", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(res.MarshalText()).To(BeEquivalentTo("2021-09-01T10:22:47Z"))
 	})
+	It("should calculate correctly the difference between two timestamps", func() {
+		By("having the first time bigger than the second", func() {
+			time1 := "2022-07-06T13:11:09Z"
+			time2 := "2022-07-06T13:11:07Z"
+			expectedSecondDifference := float64(2)
+			difference, err := DifferenceBetweenTimestamps(time1, time2)
+			Expect(err).To(BeNil())
+			Expect(difference.Seconds()).To(Equal(expectedSecondDifference))
+		})
+		By("having the first time smaller than the second", func() {
+			time1 := "2022-07-06T13:11:07Z"
+			time2 := "2022-07-06T13:11:09Z"
+			expectedSecondDifference := float64(-2)
+			difference, err := DifferenceBetweenTimestamps(time1, time2)
+			Expect(err).To(BeNil())
+			Expect(difference.Seconds()).To(Equal(expectedSecondDifference))
+		})
+	})
 })


### PR DESCRIPTION
This patch adds a new method for `cluster` that logs timestamp information to stdout, and uses it to log this information during the switchover, failover and demotion of a primary instance

Partially Closes #57


E2E tests will be handled by a different PR