### PR TITLE
fix: e2e in metrics collection with runonserver query created by user

### DIFF
--- a/tests/e2e/fixtures/metrics/custom-queries.yaml
+++ b/tests/e2e/fixtures/metrics/custom-queries.yaml
@@ -22,17 +22,17 @@ data:
             usage: "GAUGE"
             description: "Total no. of WAL files on disk"
     runonserver_match:
-      query: "SELECT 42"
+      query: "SELECT 42 as fixed"
       primary: false
-      runonserver: ">=10 <99"
+      runonserver: ">=10.0.0"
       metrics:
         - fixed:
             usage: "GAUGE"
             description: "Always 42, used to test runonserver"
     runonserver_nomatch:
-      query: "SELECT 99"
+      query: "SELECT 99 as fixed"
       primary: false
-      runonserver: "<10"
+      runonserver: "<10.0.0"
       metrics:
         - fixed:
             usage: "GAUGE"

--- a/tests/e2e/metrics_test.go
+++ b/tests/e2e/metrics_test.go
@@ -65,7 +65,7 @@ var _ = Describe("Metrics", func() {
 			`cnpg_pg_stat_archiver_archived_count \d+|` +
 			`cnpg_pg_stat_archiver_failed_count \d+|` +
 			`cnpg_pg_locks_blocked_queries 0|` +
-			`cnpg_runonserver_match 42|` +
+			`cnpg_runonserver_match_fixed 42|` +
 			`cnpg_collector_last_collection_error 0)` +
 			`$)`)
 
@@ -109,7 +109,7 @@ var _ = Describe("Metrics", func() {
 				podIP := pod.Status.PodIP
 				out, err := utils.CurlGetMetrics(namespace, curlPodName, podIP, 9187)
 				matches := metricsRegexp.FindAllString(out, -1)
-				Expect(matches, err).To(HaveLen(8), "Metric collection issues on %v.\nCollected metrics:\n%v", pod.GetName(), out)
+				Expect(matches, err).To(HaveLen(9), "Metric collection issues on %v.\nCollected metrics:\n%v", pod.GetName(), out)
 			}
 		})
 	})

--- a/tests/e2e/metrics_test.go
+++ b/tests/e2e/metrics_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package e2e
 
 import (
+	"fmt"
 	"regexp"
 	"strings"
 	"time"
@@ -56,18 +57,20 @@ var _ = Describe("Metrics", func() {
 	var err error
 	// We define a few metrics in the tests. We check that all of them exist and
 	// there are no errors during the collection.
-	metricsRegexp := regexp.MustCompile(
-		`(?m:^(` +
-			`cnpg_pg_postmaster_start_time_seconds \d+\.\d+|` + // wokeignore:rule=master
-			`cnpg_pg_wal_files_total \d+|` +
-			`cnpg_pg_database_size_bytes{datname="app"} [0-9e\+\.]+|` +
-			`cnpg_pg_replication_slots_inactive 0|` +
-			`cnpg_pg_stat_archiver_archived_count \d+|` +
-			`cnpg_pg_stat_archiver_failed_count \d+|` +
-			`cnpg_pg_locks_blocked_queries 0|` +
-			`cnpg_runonserver_match_fixed 42|` +
-			`cnpg_collector_last_collection_error 0)` +
-			`$)`)
+	metricsList := []interface{}{
+		"cnpg_pg_postmaster_start_time_seconds \\d+\\.\\d+|", // wokeignore:rule=master
+		"cnpg_pg_wal_files_total \\d+|",
+		"cnpg_pg_database_size_bytes{datname=\"app\"} [0-9e\\+\\.]+|",
+		"cnpg_pg_replication_slots_inactive 0|",
+		"cnpg_pg_stat_archiver_archived_count \\d+|",
+		"cnpg_pg_stat_archiver_failed_count \\d+|",
+		"cnpg_pg_locks_blocked_queries 0|",
+		"cnpg_runonserver_match_fixed 42|",
+		"cnpg_collector_last_collection_error 0)",
+	}
+
+	metricsRegexp := regexp.MustCompile(fmt.Sprintf(`(?m:^(`+`%v`+`%v`+`%v`+`%v`+`%v`+`%v`+`%v`+`%v`+`%v`+`$)`,
+		metricsList...))
 
 	JustAfterEach(func() {
 		if CurrentSpecReport().Failed() {
@@ -109,7 +112,8 @@ var _ = Describe("Metrics", func() {
 				podIP := pod.Status.PodIP
 				out, err := utils.CurlGetMetrics(namespace, curlPodName, podIP, 9187)
 				matches := metricsRegexp.FindAllString(out, -1)
-				Expect(matches, err).To(HaveLen(9), "Metric collection issues on %v.\nCollected metrics:\n%v", pod.GetName(), out)
+				Expect(matches, err).To(HaveLen(len(metricsList)),
+					"Metric collection issues on %v.\nCollected metrics:\n%v", pod.GetName(), out)
 			}
 		})
 	})

--- a/tests/e2e/metrics_test.go
+++ b/tests/e2e/metrics_test.go
@@ -90,7 +90,7 @@ var _ = Describe("Metrics", func() {
 
 		AssertCustomMetricsResourcesExist(namespace, fixturesDir+"/metrics/custom-queries.yaml", 2, 1)
 
-		//Create the curl client pod and wait for it to be ready.
+		// Create the curl client pod and wait for it to be ready.
 		By("setting up curl client pod", func() {
 			curlClient := utils.CurlClient(namespace)
 			err := utils.PodCreateAndWaitForReady(env, &curlClient, 240)


### PR DESCRIPTION
This PR has been fixed following issues in metrics collection tests:

- `semantic version` range to limit the versions of PostgreSQL to run query on (`>=10.0.0`) in custom query configMap file.
-   regex keyword value length fix from `8 to 9` in metrics E2E. 

Closes: #366
Closes: #365 

Signed-off-by: Jitendra Wadle <jitendra.wadle@enterprisedb.com>