### PR TITLE
refactor: removes GetKubernetesObject method

### DIFF
--- a/api/v1/backup_types.go
+++ b/api/v1/backup_types.go
@@ -18,7 +18,6 @@ package v1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // BackupPhase is the phase of the backup
@@ -208,11 +207,6 @@ func (backup *Backup) GetName() string {
 // GetNamespace get the backup namespace
 func (backup *Backup) GetNamespace() string {
 	return backup.Namespace
-}
-
-// GetKubernetesObject get the kubernetes object
-func (backup *Backup) GetKubernetesObject() client.Object {
-	return backup
 }
 
 func init() {

--- a/api/v1/scheduledbackup_types.go
+++ b/api/v1/scheduledbackup_types.go
@@ -18,7 +18,6 @@ package v1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/cloudnative-pg/cloudnative-pg/internal/configuration"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
@@ -131,11 +130,6 @@ func (scheduledBackup *ScheduledBackup) GetSchedule() string {
 // GetStatus gets the status that the caller may update
 func (scheduledBackup *ScheduledBackup) GetStatus() *ScheduledBackupStatus {
 	return &scheduledBackup.Status
-}
-
-// GetKubernetesObject gets the kubernetes object
-func (scheduledBackup *ScheduledBackup) GetKubernetesObject() client.Object {
-	return scheduledBackup
 }
 
 // CreateBackup creates a backup from this scheduled backup


### PR DESCRIPTION
This patch removes GetKubernetesObject method from the codebase.

This was used to normalize the data coming from apiv1beta1 and apiv1 structs.
Given that we removed apiv1beta from the codebase this is not anymore needed.

Closes #379 

Signed-off-by: Armando Ruocco <armando.ruocco@enterprisedb.com>