### PR TITLE
fix: collector panic when query rows returns a non nil error

### DIFF
--- a/pkg/management/postgres/metrics/collector.go
+++ b/pkg/management/postgres/metrics/collector.go
@@ -339,7 +339,7 @@ func (c QueryCollector) collect(conn *sql.DB, ch chan<- prometheus.Metric) error
 			log.Warning("Error while closing metrics extraction",
 				"err", err.Error())
 		}
-		if rows.Err() != nil {
+		if err := rows.Err(); err != nil {
 			log.Warning("Error while loading metrics",
 				"err", err.Error())
 		}


### PR DESCRIPTION
If `rows.Err()` returns a non nil error, the log tries to call `err.Error()` on the wrong `err` that might be nil causing a nil pointer dereference and crashing the whole controller.

Closes #395 