### PR TITLE
ci: early warning on bad DefaultImage

### DIFF
--- a/pkg/versions/versions.go
+++ b/pkg/versions/versions.go
@@ -23,7 +23,7 @@ const (
 	Version = "1.15.1"
 
 	// DefaultImageName is the default image used by the operator to create pods
-	DefaultImageName = "ghcr.io/cloudnative-pg/postgresql:14.6"
+	DefaultImageName = "ghcr.io/cloudnative-pg/postgresql:14.4"
 
 	// DefaultOperatorImageName is the default operator image used by the controller in the pods running PostgreSQL
 	DefaultOperatorImageName = "ghcr.io/cloudnative-pg/cloudnative-pg:1.15.1"

--- a/pkg/versions/versions.go
+++ b/pkg/versions/versions.go
@@ -23,7 +23,7 @@ const (
 	Version = "1.15.1"
 
 	// DefaultImageName is the default image used by the operator to create pods
-	DefaultImageName = "ghcr.io/cloudnative-pg/postgresql:14.4"
+	DefaultImageName = "ghcr.io/cloudnative-pg/postgresql:14.6"
 
 	// DefaultOperatorImageName is the default operator image used by the controller in the pods running PostgreSQL
 	DefaultOperatorImageName = "ghcr.io/cloudnative-pg/cloudnative-pg:1.15.1"

--- a/tests/utils/version_test.go
+++ b/tests/utils/version_test.go
@@ -17,6 +17,9 @@ limitations under the License.
 package utils
 
 import (
+	"bytes"
+	"os/exec"
+
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/versions"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -34,5 +37,14 @@ var _ = Describe("Guess the correct version of a postgres image", func() {
 		version, err := BumpPostgresImageMajorVersion(versions.DefaultImageName)
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(version).To(Equal(versions.DefaultImageName))
+	})
+
+	It("can pull the default image", func() {
+		var stderr bytes.Buffer
+		cmd := exec.Command("docker", "pull", versions.DefaultImageName) // #nosec G204
+		cmd.Stderr = &stderr
+		err := cmd.Run()
+		Expect(stderr.String()).To(BeEmpty(), "while pulling "+versions.DefaultImageName)
+		Expect(err).ShouldNot(HaveOccurred())
 	})
 })


### PR DESCRIPTION
When the default image cannot be pulled, this should result
in a clear alert.

Closes #397 

Signed-off-by: Jaime Silvela <jaime.silvela@enterprisedb.com>