### PR TITLE
fix: use `postgres` user while running pg_restore

### DIFF
--- a/pkg/management/postgres/logicalimport/database.go
+++ b/pkg/management/postgres/logicalimport/database.go
@@ -198,6 +198,7 @@ func (ds *databaseSnapshotter) importDatabaseContent(
 		)
 
 		options := []string{
+			"-U", "postgres",
 			"--no-owner",
 			"--no-privileges",
 			fmt.Sprintf("--role=%s", owner),


### PR DESCRIPTION
We where missing the `-U` argument for the pg_restore while running
importing the database from a file.

Closes #410 

Signed-off-by: Jonathan Gonzalez V <jonathan.gonzalez@enterprisedb.com>