### PR TITLE
feat: add ready-to-test command and independent container registry

### DIFF
--- a/.github/e2e-matrix-generator.py
+++ b/.github/e2e-matrix-generator.py
@@ -189,6 +189,7 @@ ENGINE_MODES = {
     "local": {
         "push": build_push_include_local,
         "pull_request": build_pull_request_include_local,
+        "pull_request_target": build_main_include_local,
         "main": build_main_include_local,
         "schedule": build_schedule_include_local,
     },
@@ -202,7 +203,7 @@ if __name__ == "__main__":
         "-m",
         "--mode",
         type=str,
-        choices={"push", "pull_request", "main", "schedule"},
+        choices={"push", "pull_request", "main", "schedule", "pull_request_target"},
         default="push",
         help="set of tests to run",
     )

--- a/.github/workflows/chatops-dispatcher.yml
+++ b/.github/workflows/chatops-dispatcher.yml
@@ -10,12 +10,15 @@ jobs:
         github.event.issue.pull_request &&
         (
           startsWith(github.event.comment.body, '/test') ||
-          startsWith(github.event.comment.body, '/ok-to-merge')
+          startsWith(github.event.comment.body, '/ok-to-merge') ||
+          startsWith(github.event.comment.body, '/ready-to-test')
+
         )
     runs-on: ubuntu-20.04
     steps:
       - name: Run E2E on CNPG
         uses: peter-evans/slash-command-dispatch@v3
+        if: ${{ startsWith(github.event.comment.body, '/test') }}
         with:
           token: ${{ secrets.REPO_GHA_PAT }}
           issue-type: pull-request
@@ -25,9 +28,25 @@ jobs:
           static-args: |
             test_level=4
             depth=main
+
       - name: Add "ok to merge" label to CNPG PR
         uses: actions-ecosystem/action-add-labels@v1.1.3
         if: ${{ startsWith(github.event.comment.body, '/ok-to-merge') }}
         with:
            github_token: ${{ secrets.REPO_GHA_PAT }}
            labels: "ok to merge :ok_hand:"
+
+      - name: Remove "ready to test :elephant:" label if exists
+        uses: actions-ecosystem/action-remove-labels@v1.3.0
+        if: |
+          startsWith(github.event.comment.body, '/ready-to-test') &&
+          contains(github.event.pull_request.labels.*.name, 'ready to test :elephant:')
+        with:
+          github_token: ${{ secrets.REPO_GHA_PAT }}
+          labels: "ready to test :elephant:"
+
+      - name: Add "ready to test" label to CNPG PR
+        uses: actions-ecosystem/action-add-labels@v1.1.3
+        with:
+           github_token: ${{ secrets.REPO_GHA_PAT }}
+           labels: "ready to test :elephant:"

--- a/.github/workflows/chatops-dispatcher.yml
+++ b/.github/workflows/chatops-dispatcher.yml
@@ -47,6 +47,7 @@ jobs:
 
       - name: Add "ready to test" label to CNPG PR
         uses: actions-ecosystem/action-add-labels@v1.1.3
+        if: startsWith(github.event.comment.body, '/ready-to-test')
         with:
            github_token: ${{ secrets.REPO_GHA_PAT }}
            labels: "ready to test :elephant:"

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -110,6 +110,8 @@ jobs:
       -
         name: Checkout code
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       -
         name: Install Go
         uses: actions/setup-go@v3
@@ -155,7 +157,11 @@ jobs:
       ) &&
       (
         github.event.client_payload.slash_command != null ||
-        contains(github.event.pull_request.labels.*.name, 'ready to test :elephant:')
+        (
+           github.event_name == 'pull_request_target' &&
+           github.event.action == 'labeled' &&
+           contains(github.event.pull_request.labels.*.name, 'ready to test :elephant:')
+        )
       )
     runs-on: ubuntu-20.04
     strategy:
@@ -171,6 +177,8 @@ jobs:
       -
         name: Checkout code
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       -
         name: Install Go
         uses: actions/setup-go@v3
@@ -300,6 +308,7 @@ jobs:
         with:
           # To identify the commit we need the history and all the tags.
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
       -
         name: Install Go
         uses: actions/setup-go@v3
@@ -323,7 +332,7 @@ jobs:
           tags=''
           labels=''
           commit_sha=${{ github.event.pull_request.head.sha || github.sha }}
-          commit_date=$(git log -1 --pretty=format:'%ad' --date short "${commit_sha}")
+          commit_date=$(git log -1 --pretty=format:'%ad' --date short "${commit_sha}" || : )
           # use git describe to get the nearest tag and use that to build the version (e.g. 1.4.0+dev24 or 1.4.0)
           commit_version=$(git describe --tags --match 'v*' "${commit_sha}"| sed -e 's/^v//; s/-g[0-9a-f]\+$//; s/-\([0-9]\+\)$/+dev\1/')
           commit_short=$(git rev-parse --short "${commit_sha}")
@@ -396,6 +405,7 @@ jobs:
             VERSION=${{ steps.build-meta.outputs.version }}
           tags: ${{ steps.docker-meta.outputs.tags }}
           labels: ${{ steps.build-meta.outputs.labels }}
+          secrets: GIT_AUTH_TOKEN=${{ secrets.GITHUB_TOKEN }}
       -
         name: Image Meta
         id: image-meta
@@ -421,7 +431,8 @@ jobs:
         github.ref_name == 'main' ||
         startsWith(github.head_ref, 'dependabot/') ||
         startsWith(github.ref_name, 'dependabot/') ||
-        (github.event_name == 'pull_request' && github.event.action == 'opened')
+        (github.event_name == 'pull_request' && github.event.action == 'opened') ||
+        (github.event_name == 'pull_request_target' &&  github.event.action == 'labeled')
        )
     runs-on: ubuntu-20.04
     outputs:
@@ -456,7 +467,7 @@ jobs:
         id: evaluate-test-level
         run: |
           declare -A events
-          events=([push]=0 [pull_request]=2 [main]=3 [schedule]=4)
+          events=([push]=0 [pull_request]=2 [main]=3 [schedule]=4 [pull_request_target]=3)
           test_level_from_input="${{ github.event.inputs.test_level }}"
           if [ -n "${test_level_from_input}" ]
           then
@@ -703,7 +714,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          pr_number=$(gh pr view --json number -q .number || : )
+          pr_number=$(gh pr view --json number -q .number 2>/dev/null || : )
           echo "::set-output name=pr_number::${pr_number}"
           ok_label=$(gh pr view --json labels -q ".labels.[].name" 2>/dev/null || : | grep "ok to merge")
           echo "::set-output name=ok_label::${ok_label}"

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - '**'
   pull_request:
+  pull_request_target:
+    types: [labeled]
   workflow_dispatch:
     inputs:
       depth:
@@ -23,6 +25,7 @@ env:
   KUBEBUILDER_VERSION: "2.3.1"
   KIND_VERSION: "v0.11.0"
   ROOK_VERSION: "v1.6.8"
+  CNPG_IMAGE_NAME: "ghcr.io/${{ github.repository }}-testing"
 
 defaults:
   run:
@@ -149,6 +152,10 @@ jobs:
       (
         needs.change-triage.outputs.operator-changed == 'true' ||
         needs.change-triage.outputs.go-code-changed == 'true'
+      ) &&
+      (
+        github.event.client_payload.slash_command != null ||
+        contains(github.event.pull_request.labels.*.name, 'ready to test :elephant:')
       )
     runs-on: ubuntu-20.04
     strategy:
@@ -312,7 +319,7 @@ jobs:
         name: Build meta
         id: build-meta
         run: |
-          images='ghcr.io/cloudnative-pg/cloudnative-pg-testing'
+          images='${{ env.CNPG_IMAGE_NAME }}'
           tags=''
           labels=''
           commit_sha=${{ github.event.pull_request.head.sha || github.sha }}


### PR DESCRIPTION
We introduce a new behaviour in this commit:

1.- The commits now can run in the forked repo, using the external
    user registry to push the image and the run the E2E.
2.- A new command `ready-to-test` that use the `pull_request_target`
    event to run the test and run the E2E test on the PR, this will
    allow the forked repo to run test from the PR when a user allows it.

Previously we were not able to run the E2E on PR from forked repo
due to the fixed use of the cloudnative-pg repo and since the
`pull_request` event doesn't provide a GitHub token with write permissions
for packages.

We still allow running E2E test from internal branch only when the `test`
command is used, since it will trigger the event dispatch with the client
payload and is used to verify that comes from the internal repo.

Closes #426 

Signed-off-by: Jonathan Gonzalez V <jonathan.gonzalez@enterprisedb.com>