### PR TITLE
feat: enable configuration of `huge_pages` for PostgreSQL

### DIFF
--- a/docs/src/postgresql_conf.md
+++ b/docs/src/postgresql_conf.md
@@ -459,7 +459,6 @@ Users are not allowed to set the following configuration parameters in the
 - `full_page_writes`
 - `hba_file`
 - `hot_standby`
-- `huge_pages`
 - `ident_file`
 - `jit_provider`
 - `listen_addresses`

--- a/pkg/postgres/configuration.go
+++ b/pkg/postgres/configuration.go
@@ -288,7 +288,6 @@ var (
 		"external_pid_file":         blockedConfigurationParameter,
 		"hba_file":                  blockedConfigurationParameter,
 		"hot_standby":               blockedConfigurationParameter,
-		"huge_pages":                blockedConfigurationParameter,
 		"ident_file":                blockedConfigurationParameter,
 		"jit_provider":              blockedConfigurationParameter,
 		"listen_addresses":          blockedConfigurationParameter,


### PR DESCRIPTION
Up to now, `huge_pages` was a blocked configuration option for PostgreSQL
and users were not allowed to change it. We have removed this block,
leaving the option to the default value defined by the PostgreSQL server
in the operand images (normally at compile time).

Closed #428

Signed-off-by: Gabriele Bartolini <gabriele.bartolini@enterprisedb.com>