### PR TITLE
feat: set cluster condition ready when the phase is healthy

### DIFF
--- a/.wordlist-en-custom.txt
+++ b/.wordlist-en-custom.txt
@@ -55,6 +55,7 @@ CloudNativePG's
 ClusterCondition
 ClusterConditionType
 ClusterIP
+ClusterIsNotReady
 ClusterList
 ClusterRole
 ClusterRole's
@@ -70,6 +71,7 @@ ConfigMapKeySelector
 ConfigMapResourceVersion
 ConfigMaps
 ContinuousArchiving
+ContinuousArchivingFailing
 Coverity
 Cron
 CronJobs
@@ -141,6 +143,8 @@ LDAPScheme
 LPV
 LSN
 LTS
+LastBackupFailed
+LastBackupSucceeded
 Lifecycle
 Linode
 ListMeta

--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -434,6 +434,8 @@ const (
 	ConditionContinuousArchiving ClusterConditionType = "ContinuousArchiving"
 	// ConditionBackup this condition looking backup status :owned by InstanceManager.
 	ConditionBackup ClusterConditionType = "LastBackupSucceeded"
+	// ConditionClusterReady this condition looking for cluster is to be ready
+	ConditionClusterReady ClusterConditionType = "Ready"
 )
 
 // ConditionStatus defines conditions of resources
@@ -473,6 +475,12 @@ const (
 	// ConditionReasonContinuousArchivingFailing means that the condition has changed because
 	// the WAL archiving is not working correctly
 	ConditionReasonContinuousArchivingFailing ConditionReason = "ContinuousArchivingFailing"
+
+	// ClusterReady means that the condition changed because the cluster to be ready and working properly
+	ClusterReady ConditionReason = "ClusterIsReady"
+
+	// ClusterIsNotReady means that the condition changed because the cluster is not ready
+	ClusterIsNotReady ConditionReason = "ClusterIsNotReady"
 )
 
 // ClusterConditionType is of string type

--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -427,14 +427,17 @@ type InstanceReportedState struct {
 	TimeLineID int `json:"timeLineID,omitempty"`
 }
 
+// ClusterConditionType defines types of cluster conditions
+type ClusterConditionType string
+
 // These are valid conditions of a Cluster, some of the conditions could be owned by
 // Instance Manager and some of them could be owned by reconciler.
 const (
-	// ConditionContinuousArchiving this condition archiving :owned by InstanceManager.
+	// ConditionContinuousArchiving represents whether WAL archiving is working
 	ConditionContinuousArchiving ClusterConditionType = "ContinuousArchiving"
-	// ConditionBackup this condition looking backup status :owned by InstanceManager.
+	// ConditionBackup represents the last backup's status
 	ConditionBackup ClusterConditionType = "LastBackupSucceeded"
-	// ConditionClusterReady this condition looking for cluster is to be ready
+	// ConditionClusterReady represents whether a cluster is Ready
 	ConditionClusterReady ClusterConditionType = "Ready"
 )
 
@@ -476,15 +479,12 @@ const (
 	// the WAL archiving is not working correctly
 	ConditionReasonContinuousArchivingFailing ConditionReason = "ContinuousArchivingFailing"
 
-	// ClusterReady means that the condition changed because the cluster to be ready and working properly
+	// ClusterReady means that the condition changed because the cluster is ready and working properly
 	ClusterReady ConditionReason = "ClusterIsReady"
 
 	// ClusterIsNotReady means that the condition changed because the cluster is not ready
 	ClusterIsNotReady ConditionReason = "ClusterIsNotReady"
 )
-
-// ClusterConditionType is of string type
-type ClusterConditionType string
 
 // EmbeddedObjectMetadata contains metadata to be inherited by all resources related to a Cluster
 type EmbeddedObjectMetadata struct {

--- a/controllers/cluster_status.go
+++ b/controllers/cluster_status.go
@@ -31,6 +31,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
@@ -358,6 +359,9 @@ func (r *ClusterReconciler) updateResourceStatus(
 	if err := r.refreshConfigMapResourceVersions(ctx, cluster); err != nil {
 		return err
 	}
+
+	// set cluster conditions in cluster status
+	r.SetClusterConditionsInStatus(ctx, cluster)
 
 	if !reflect.DeepEqual(existingClusterStatus, cluster.Status) {
 		return r.Status().Update(ctx, cluster)
@@ -908,4 +912,36 @@ func getPodsTopology(
 	}
 
 	return apiv1.Topology{SuccessfullyExtracted: true, Instances: data}
+}
+
+// SetClusterConditionsInStatus is update condition in cluster status section,
+// it is based on number of pods in <cluster.spec.instance> is equal to cluster up/ready pods
+// then it will update condition type `Ready` with status `True` otherwise
+// with status `False`.
+func (r *ClusterReconciler) SetClusterConditionsInStatus(
+	ctx context.Context,
+	cluster *apiv1.Cluster,
+) {
+	contextLogger := log.FromContext(ctx)
+	podList, err := r.getManagedPods(ctx, cluster)
+	if err != nil {
+		contextLogger.Error(err, "pods are not found, skipping to set cluster conditions")
+	}
+	var conditions metav1.Condition
+	if cluster.Spec.Instances == utils.CountReadyPods(podList.Items) {
+		conditions = metav1.Condition{
+			Type:    string(apiv1.ConditionClusterReady),
+			Status:  metav1.ConditionTrue,
+			Reason:  string(apiv1.ClusterReady),
+			Message: "Cluster is Ready",
+		}
+	} else {
+		conditions = metav1.Condition{
+			Type:    string(apiv1.ConditionClusterReady),
+			Status:  metav1.ConditionFalse,
+			Reason:  string(apiv1.ClusterIsNotReady),
+			Message: "Cluster Is Not Ready",
+		}
+	}
+	meta.SetStatusCondition(&cluster.Status.Conditions, conditions)
 }

--- a/docs/src/troubleshooting.md
+++ b/docs/src/troubleshooting.md
@@ -398,6 +398,7 @@ event to occur instead of relying on the overall cluster health state. Available
 
 - LastBackupSucceeded
 - ContinuousArchiving
+- Ready
 
 ### How to wait for a particular condition
 
@@ -411,6 +412,10 @@ $ kubectl wait --for=condition=LastBackupSucceeded cluster/<CLUSTER-NAME> -n <NA
 $ kubectl wait --for=condition=ContinuousArchiving cluster/<CLUSTER-NAME> -n <NAMESPACE>
 ```
 
+- Ready (Cluster is ready or not):
+```bash
+$ kubectl wait --for=condition=Ready cluster/<CLUSTER-NAME> -n <NAMESPACE>
+```
 Below is a snippet of a `cluster.status` that contains a failing condition.
 
 ```bash
@@ -422,14 +427,21 @@ $ kubectl get cluster/<cluster-name> -o yaml
     conditions:
     - message: 'unexpected failure invoking barman-cloud-wal-archive: exit status
         2'
-      reason: Continuous Archiving is Failing
+      reason: ContinuousArchivingFailing
       status: "False"
       type: ContinuousArchiving
 
     - message: exit status 2
-      reason: Backup is failed
+      reason: LastBackupFailed
       status: "False"
       type: LastBackupSucceeded
+
+    - message: Cluster Is Not Ready
+      reason: ClusterIsNotReady
+      status: "False"
+      type: Ready
+
+
 ```
 
 ## Some common issues

--- a/docs/src/troubleshooting.md
+++ b/docs/src/troubleshooting.md
@@ -400,6 +400,16 @@ event to occur instead of relying on the overall cluster health state. Available
 - ContinuousArchiving
 - Ready
 
+`LastBackupSucceeded` is reporting the status of the latest backup. If set to `True` the
+last backup has been taken correctly, it is set to `False` otherwise.
+
+`ContinuousArchiving` is reporting the status of the WAL archiving. If set to `True` the
+last WAL archival process has been terminated correctly, it is set to `False` otherwise.
+
+`Ready` is `True` when the cluster has the number of instances specified by the user
+and the primary instance is ready. This condition can be used in scripts to wait for
+the cluster to be created.
+
 ### How to wait for a particular condition
 
 - Backup:

--- a/tests/e2e/asserts_test.go
+++ b/tests/e2e/asserts_test.go
@@ -2284,3 +2284,22 @@ func AssertBackupConditionInClusterStatus(namespace, clusterName string) {
 		}, 300, 5).Should(BeEquivalentTo("True"))
 	})
 }
+
+func AssertClusterConditionIsReadyOrNot(
+	namespace,
+	clusterName string,
+	conditionStatus apiv1.ConditionStatus,
+	timeout int,
+	env *testsUtils.TestingEnvironment,
+) {
+	By(fmt.Sprintf("waiting for cluster condition status in cluster '%v'", clusterName), func() {
+		Eventually(func() (string, error) {
+			clusterCondition, err := testsUtils.GetConditionsInClusterStatus(
+				namespace, clusterName, env, apiv1.ConditionClusterReady)
+			if err != nil {
+				return "", err
+			}
+			return string(clusterCondition.Status), nil
+		}, timeout, 2).Should(BeEquivalentTo(conditionStatus))
+	})
+}

--- a/tests/e2e/asserts_test.go
+++ b/tests/e2e/asserts_test.go
@@ -2285,7 +2285,7 @@ func AssertBackupConditionInClusterStatus(namespace, clusterName string) {
 	})
 }
 
-func AssertClusterConditionIsReadyOrNot(
+func AssertClusterReadinessStatusIsReached(
 	namespace,
 	clusterName string,
 	conditionStatus apiv1.ConditionStatus,

--- a/tests/e2e/cluster_setup_test.go
+++ b/tests/e2e/cluster_setup_test.go
@@ -131,7 +131,7 @@ var _ = Describe("Cluster setup", func() {
 		})
 	})
 
-	It("cluster conditions should work", func() {
+	It("tests cluster readiness conditions work", func() {
 		namespace = "cluster-conditions"
 		err := env.CreateNamespace(namespace)
 		Expect(err).ToNot(HaveOccurred())
@@ -154,24 +154,23 @@ var _ = Describe("Cluster setup", func() {
 			CreateResourceFromFile(namespace, sampleFile)
 		})
 
-		By("verifying cluster conditions is ready", func() {
-			AssertClusterConditionIsReadyOrNot(namespace, clusterName, apiv1.ConditionTrue, 600, env)
+		By("verifying cluster reaches ready condition", func() {
+			AssertClusterReadinessStatusIsReached(namespace, clusterName, apiv1.ConditionTrue, 600, env)
 		})
 
-		// Add more replicas to the cluster and verify that while scaling up the cluster then conditions working
-		// as expected
+		// scale up the cluster to verify if the cluster remains in Ready
 		By("scaling up the cluster size", func() {
 			err := env.ScaleClusterSize(namespace, clusterName, 5)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		By("verify cluster condition is not ready just after scale up the cluster", func() {
+		By("verifying cluster readiness condition is false just after scale-up", func() {
 			// Just after scale up the cluster, the condition status set to be `False` and cluster is not ready state.
-			AssertClusterConditionIsReadyOrNot(namespace, clusterName, apiv1.ConditionFalse, 180, env)
+			AssertClusterReadinessStatusIsReached(namespace, clusterName, apiv1.ConditionFalse, 180, env)
 		})
 
-		By("verify cluster condition is ready after scale up cluster", func() {
-			AssertClusterConditionIsReadyOrNot(namespace, clusterName, apiv1.ConditionTrue, 180, env)
+		By("verifying cluster reaches ready condition after additional waiting", func() {
+			AssertClusterReadinessStatusIsReached(namespace, clusterName, apiv1.ConditionTrue, 180, env)
 		})
 	})
 })

--- a/tests/e2e/cluster_setup_test.go
+++ b/tests/e2e/cluster_setup_test.go
@@ -20,10 +20,10 @@ import (
 	"fmt"
 	"time"
 
-	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 
+	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/specs"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 	"github.com/cloudnative-pg/cloudnative-pg/tests"

--- a/tests/e2e/cluster_setup_test.go
+++ b/tests/e2e/cluster_setup_test.go
@@ -17,8 +17,10 @@ limitations under the License.
 package e2e
 
 import (
+	"fmt"
 	"time"
 
+	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -32,11 +34,11 @@ import (
 
 var _ = Describe("Cluster setup", func() {
 	const (
-		namespace   = "cluster-storageclass-e2e"
 		sampleFile  = fixturesDir + "/base/cluster-storage-class.yaml"
 		clusterName = "postgresql-storage-class"
 		level       = tests.Highest
 	)
+	var namespace string
 	BeforeEach(func() {
 		if testLevelEnv.Depth < int(level) {
 			Skip("Test depth is lower than the amount requested for this test")
@@ -51,7 +53,9 @@ var _ = Describe("Cluster setup", func() {
 		err := env.DeleteNamespace(namespace)
 		Expect(err).ToNot(HaveOccurred())
 	})
+
 	It("sets up a cluster", func() {
+		namespace = "cluster-storageclass-e2e"
 		// Create a cluster in a namespace we'll delete after the test
 		err := env.CreateNamespace(namespace)
 		Expect(err).ToNot(HaveOccurred())
@@ -124,6 +128,50 @@ var _ = Describe("Cluster setup", func() {
 					"psql", "-U", "postgres", "app", "-tAc", query)
 				return err == nil, err
 			}, timeout).Should(BeTrue())
+		})
+	})
+
+	It("cluster conditions should work", func() {
+		namespace = "cluster-conditions"
+		err := env.CreateNamespace(namespace)
+		Expect(err).ToNot(HaveOccurred())
+
+		By(fmt.Sprintf("having a %v namespace", namespace), func() {
+			// Creating a namespace should be quick
+			timeout := 20
+			namespacedName := types.NamespacedName{
+				Namespace: namespace,
+				Name:      namespace,
+			}
+			Eventually(func() (string, error) {
+				namespaceResource := &corev1.Namespace{}
+				err := env.Client.Get(env.Ctx, namespacedName, namespaceResource)
+				return namespaceResource.GetName(), err
+			}, timeout).Should(BeEquivalentTo(namespace))
+		})
+
+		By(fmt.Sprintf("creating a Cluster in the %v namespace", namespace), func() {
+			CreateResourceFromFile(namespace, sampleFile)
+		})
+
+		By("verifying cluster conditions is ready", func() {
+			AssertClusterConditionIsReadyOrNot(namespace, clusterName, apiv1.ConditionTrue, 600, env)
+		})
+
+		// Add more replicas to the cluster and verify that while scaling up the cluster then conditions working
+		// as expected
+		By("scaling up the cluster size", func() {
+			err := env.ScaleClusterSize(namespace, clusterName, 5)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		By("verify cluster condition is not ready just after scale up the cluster", func() {
+			// Just after scale up the cluster, the condition status set to be `False` and cluster is not ready state.
+			AssertClusterConditionIsReadyOrNot(namespace, clusterName, apiv1.ConditionFalse, 180, env)
+		})
+
+		By("verify cluster condition is ready after scale up cluster", func() {
+			AssertClusterConditionIsReadyOrNot(namespace, clusterName, apiv1.ConditionTrue, 180, env)
 		})
 	})
 })

--- a/tests/utils/cluster.go
+++ b/tests/utils/cluster.go
@@ -242,3 +242,18 @@ func (env TestingEnvironment) GetClusterPrimary(namespace string, clusterName st
 	err = fmt.Errorf("no primary found")
 	return &corev1.Pod{}, err
 }
+
+// ScaleClusterSize is scale cluster as given require size
+func (env TestingEnvironment) ScaleClusterSize(namespace, clusterName string, newClusterSize int) error {
+	cluster, err := env.GetCluster(namespace, clusterName)
+	if err != nil {
+		return err
+	}
+	originalCluster := cluster.DeepCopy()
+	cluster.Spec.Instances = newClusterSize
+	err = env.Client.Patch(env.Ctx, cluster, client.MergeFrom(originalCluster))
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/tests/utils/cluster.go
+++ b/tests/utils/cluster.go
@@ -243,7 +243,7 @@ func (env TestingEnvironment) GetClusterPrimary(namespace string, clusterName st
 	return &corev1.Pod{}, err
 }
 
-// ScaleClusterSize is scale cluster as given require size
+// ScaleClusterSize scales a cluster to the requested size
 func (env TestingEnvironment) ScaleClusterSize(namespace, clusterName string, newClusterSize int) error {
 	cluster, err := env.GetCluster(namespace, clusterName)
 	if err != nil {


### PR DESCRIPTION
This PR has introduces cluster conditions and adding cluster is ready or not in cluster status like:

```
status:

  conditions:
    - lastTransitionTime: "2022-07-22T10:03:02Z"
      reason: ClusterIsReady
      status: "True"
      type: Ready
      message: Cluster is Ready
  
  - lastTransitionTime: "2022-07-22T10:02:02Z"
      reason: ClusterIsNotReady
      status: "False"
      type: Ready
      message: Cluster Is Not Ready
```

Closes #84  

Signed-off-by: Jitendra Wadle <jitendra.wadle@enterprisedb.com>
