### PR TITLE
fix: get latest WAL correctly for Postgres 15 in upgrade E2E test

### DIFF
--- a/tests/e2e/upgrade_test.go
+++ b/tests/e2e/upgrade_test.go
@@ -390,13 +390,12 @@ var _ = Describe("Upgrade", Label(tests.LabelUpgrade, tests.LabelNoOpenshift), O
 				findCmd := fmt.Sprintf(
 					"sh -c 'mc find minio --name %v.gz | wc -l'",
 					latestWAL)
-				out, stderr, err := testsUtils.RunUnchecked(fmt.Sprintf(
+				out, _, err := testsUtils.RunUnchecked(fmt.Sprintf(
 					"kubectl exec -n %v %v -- %v",
 					upgradeNamespace,
 					minioClientName,
 					findCmd))
 
-				Expect(stderr).Should(BeEmpty())
 				value, atoiErr := strconv.Atoi(strings.Trim(out, "\n"))
 				return value, err, atoiErr
 			}, 30).Should(BeEquivalentTo(1))


### PR DESCRIPTION
In the upgrade E2E tests, we get the latest WAL with two combined
commands: `CHECKPOINT; SELECT pg_walfile_name(pg_switch_wal())`
In Postgres15, by default all query command outputs are shown.
See https://github.com/postgres/postgres/commit/3a5130672296ed4e682403a77a9a3ad3d21cef75

When we then create a CLI string to check the last WAL file, the output
contains more than just the WAL number, and this breaks the construction
of the `minio` path for the test.

We fix this  by using the setting `SHOW_ALL_RESULTS=off`

Closes #420 

Signed-off-by: Jaime Silvela <jaime.silvela@enterprisedb.com>