### PR TITLE
fix: add missing package `packaging`

### DIFF
--- a/.github/workflows/latest-postgres-version-check.yml
+++ b/.github/workflows/latest-postgres-version-check.yml
@@ -23,6 +23,8 @@ jobs:
 
       - name: Generate PostgreSQL JSON files
         run: |
+          pip3 install --upgrade pip-tools
+          pip3 install packaging
           python .github/postgres-versions-update.py
 
       - name: Get the latest version of PostgreSQL Docker image

--- a/.github/workflows/latest-postgres-version-check.yml
+++ b/.github/workflows/latest-postgres-version-check.yml
@@ -20,11 +20,14 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: 3.9
+          cache: 'pip'
+
+      - name: Install Python dependencies
+        run: |
+          pip install packaging
 
       - name: Generate PostgreSQL JSON files
         run: |
-          pip3 install --upgrade pip-tools
-          pip3 install packaging
           python .github/postgres-versions-update.py
 
       - name: Get the latest version of PostgreSQL Docker image


### PR DESCRIPTION
After fixing the detection of the pre-release PostgreSQL version
we forgot to add the install of one of the new packages required,
this package is `packaging`.

Closes #483 

Signed-off-by: Jonathan Gonzalez V <jonathan.gonzalez@enterprisedb.com>