### PR TITLE
fix: ensures that the Pooler deployment has the securityContext populated

### DIFF
--- a/pkg/podspec/builder.go
+++ b/pkg/podspec/builder.go
@@ -80,6 +80,18 @@ func (builder *Builder) WithVolume(volume *corev1.Volume) *Builder {
 	return builder
 }
 
+// WithSecurityContext adds a securityContext to the current podTemplate is nil.
+// If `overwrite` is true the securityContext is overwritten even when it's not empty
+func (builder *Builder) WithSecurityContext(
+	securityCtx *corev1.PodSecurityContext,
+	overwrite bool,
+) *Builder {
+	if overwrite || builder.status.Spec.SecurityContext == nil {
+		builder.status.Spec.SecurityContext = securityCtx
+	}
+	return builder
+}
+
 // WithContainer ensures that in the current status there is a container
 // with the passed name
 func (builder *Builder) WithContainer(name string) *Builder {
@@ -249,6 +261,28 @@ func (builder *Builder) WithContainerPort(name string, value *corev1.ContainerPo
 	return builder
 }
 
+// WithContainerSecurityContext ensures that, if in the current status there is
+// a container with the passed name and the securityContext is empty, the securityContext will be
+// set to the one passed.
+// If `overwrite` is true the command is overwritten even when it's not empty
+func (builder *Builder) WithContainerSecurityContext(
+	name string,
+	ctx *corev1.SecurityContext,
+	overwrite bool,
+) *Builder {
+	builder.WithContainer(name)
+
+	for idx, value := range builder.status.Spec.Containers {
+		if value.Name == name {
+			if overwrite || value.SecurityContext == nil {
+				builder.status.Spec.Containers[idx].SecurityContext = ctx
+			}
+		}
+	}
+
+	return builder
+}
+
 // WithInitContainer ensures that in the current status there is an init container
 // with the passed name
 func (builder *Builder) WithInitContainer(name string) *Builder {
@@ -325,6 +359,27 @@ func (builder *Builder) WithInitContainerCommand(name string, command []string, 
 		}
 	}
 
+	return builder
+}
+
+// WithInitContainerSecurityContext ensures that, if in the current status there is
+// an init container with the passed name and the securityContext is empty, the securityContext will be
+// set to the one passed.
+// If `overwrite` is true the securityContext is overwritten even when it's not empty
+func (builder *Builder) WithInitContainerSecurityContext(
+	name string,
+	ctx *corev1.SecurityContext,
+	overwrite bool,
+) *Builder {
+	builder.WithInitContainer(name)
+
+	for idx, value := range builder.status.Spec.InitContainers {
+		if value.Name == name {
+			if overwrite || value.SecurityContext == nil {
+				builder.status.Spec.InitContainers[idx].SecurityContext = ctx
+			}
+		}
+	}
 	return builder
 }
 

--- a/pkg/specs/jobs.go
+++ b/pkg/specs/jobs.go
@@ -210,7 +210,7 @@ func createPrimaryJob(cluster apiv1.Cluster, nodeSerial int, role string, initCo
 						},
 					},
 					Volumes:            createPostgresVolumes(cluster, podName),
-					SecurityContext:    CreatePostgresSecurityContext(cluster.GetPostgresUID(), cluster.GetPostgresGID()),
+					SecurityContext:    CreatePodSecurityContext(cluster.GetPostgresUID(), cluster.GetPostgresGID()),
 					Affinity:           CreateAffinitySection(cluster.Name, cluster.Spec.Affinity),
 					Tolerations:        cluster.Spec.Affinity.Tolerations,
 					ServiceAccountName: cluster.Name,

--- a/pkg/specs/pgbouncer/deployments.go
+++ b/pkg/specs/pgbouncer/deployments.go
@@ -74,6 +74,7 @@ func Deployment(pooler *apiv1.Pooler,
 				},
 			},
 		}).
+		WithSecurityContext(specs.CreatePodSecurityContext(998, 996), true).
 		WithContainerImage("pgbouncer", DefaultPgbouncerImage, false).
 		WithContainerCommand("pgbouncer", []string{
 			"/controller/manager",
@@ -92,6 +93,9 @@ func Deployment(pooler *apiv1.Pooler,
 		WithInitContainerCommand(specs.BootstrapControllerContainerName,
 			[]string{"/manager", "bootstrap", "/controller/manager"},
 			true).
+		WithInitContainerSecurityContext(specs.BootstrapControllerContainerName,
+			specs.CreateContainerSecurityContext(),
+			true).
 		WithVolume(&corev1.Volume{
 			Name: "scratch-data",
 			VolumeSource: corev1.VolumeSource{
@@ -108,6 +112,7 @@ func Deployment(pooler *apiv1.Pooler,
 		}, true).
 		WithContainerEnv("pgbouncer", corev1.EnvVar{Name: "NAMESPACE", Value: pooler.Namespace}, true).
 		WithContainerEnv("pgbouncer", corev1.EnvVar{Name: "POOLER_NAME", Value: pooler.Name}, true).
+		WithContainerSecurityContext("pgbouncer", specs.CreateContainerSecurityContext(), true).
 		WithServiceAccountName(pooler.Name, true).
 		WithReadinessProbe("pgbouncer", &corev1.Probe{
 			TimeoutSeconds: 5,

--- a/pkg/specs/pods.go
+++ b/pkg/specs/pods.go
@@ -273,9 +273,8 @@ func CreateGeneratedAntiAffinity(clusterName string, config apiv1.AffinityConfig
 	return affinity
 }
 
-// CreatePostgresSecurityContext defines the security context under which
-// the PostgreSQL containers are running
-func CreatePostgresSecurityContext(postgresUser, postgresGroup int64) *corev1.PodSecurityContext {
+// CreatePodSecurityContext defines the security context under which the containers are running
+func CreatePodSecurityContext(user, group int64) *corev1.PodSecurityContext {
 	// Under Openshift we inherit SecurityContext from the restricted security context constraint
 	if utils.HaveSecurityContextConstraints() {
 		return nil
@@ -284,9 +283,9 @@ func CreatePostgresSecurityContext(postgresUser, postgresGroup int64) *corev1.Po
 	trueValue := true
 	return &corev1.PodSecurityContext{
 		RunAsNonRoot: &trueValue,
-		RunAsUser:    &postgresUser,
-		RunAsGroup:   &postgresGroup,
-		FSGroup:      &postgresGroup,
+		RunAsUser:    &user,
+		RunAsGroup:   &group,
+		FSGroup:      &group,
 	}
 }
 
@@ -315,7 +314,7 @@ func PodWithExistingStorage(cluster apiv1.Cluster, nodeSerial int) *corev1.Pod {
 			},
 			Containers:                    createPostgresContainers(cluster, podName),
 			Volumes:                       createPostgresVolumes(cluster, podName),
-			SecurityContext:               CreatePostgresSecurityContext(cluster.GetPostgresUID(), cluster.GetPostgresGID()),
+			SecurityContext:               CreatePodSecurityContext(cluster.GetPostgresUID(), cluster.GetPostgresGID()),
 			Affinity:                      CreateAffinitySection(cluster.Name, cluster.Spec.Affinity),
 			Tolerations:                   cluster.Spec.Affinity.Tolerations,
 			ServiceAccountName:            cluster.Name,

--- a/pkg/specs/pods_test.go
+++ b/pkg/specs/pods_test.go
@@ -47,7 +47,7 @@ var (
 )
 
 var _ = Describe("The PostgreSQL security context", func() {
-	securityContext := CreatePostgresSecurityContext(26, 26)
+	securityContext := CreatePodSecurityContext(26, 26)
 
 	It("allows the container to create its own PGDATA", func() {
 		Expect(securityContext.RunAsUser).To(Equal(securityContext.FSGroup))


### PR DESCRIPTION
This patch ensures that the generated Pooler deployment has the securityContexts populated

Closes #479

Signed-off-by: Armando Ruocco <armando.ruocco@enterprisedb.com>