### PR TITLE
Single replica breaking OCP upgrade

### DIFF
--- a/controllers/cluster_create.go
+++ b/controllers/cluster_create.go
@@ -103,7 +103,6 @@ func (r *ClusterReconciler) createPostgresClusterObjects(ctx context.Context, cl
 }
 
 func (r *ClusterReconciler) reconcilePodDisruptionBudget(ctx context.Context, cluster *apiv1.Cluster) error {
-
 	if cluster.Spec.Instances == 1 {
 		// If this a single-instance cluster, we need to delete
 		// the PodDisruptionBudget for the primary node too


### PR DESCRIPTION
When running a single replica  POC the PDB will not allow eviction. This means OCP cannot upgrade the cluster unless the it is in a maintenance window. The problem with this logic is OCP administration and Postgres administration may not be in sync.  The proposal is to separate the single replica logic  from the maintenance window logic. 

Signed-off-by: Aaron M. Cohen <amcohen@us.ibm.com>