### PR TITLE
ci: support running full E2E tests on release-* branches

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -429,6 +429,8 @@ jobs:
       ( github.event_name == 'workflow_dispatch' ||
         github.head_ref == 'main' ||
         github.ref_name == 'main' ||
+        startsWith(github.head_ref, 'release-') ||
+        startsWith(github.ref_name, 'release-') ||
         startsWith(github.head_ref, 'dependabot/') ||
         startsWith(github.ref_name, 'dependabot/') ||
         (github.event_name == 'pull_request' && github.event.action == 'opened') ||


### PR DESCRIPTION
Running the continuous-delivery workflow on a release-* branch must
skip the detection of what changed in the last commit and run all the
tests, as it does on the main branch.

Closes #505 

Signed-off-by: Marco Nenciarini <marco.nenciarini@enterprisedb.com>