### PR TITLE
fix: avoid panic while fencing postgres if cluster has no annotation

### DIFF
--- a/internal/cmd/plugin/fence/fence.go
+++ b/internal/cmd/plugin/fence/fence.go
@@ -76,7 +76,9 @@ func ApplyFenceFunc(
 	}
 
 	fencedCluster := cluster.DeepCopy()
-
+	if fencedCluster.Annotations == nil {
+		fencedCluster.Annotations = make(map[string]string)
+	}
 	if err = fenceFunc(serverName, fencedCluster.Annotations); err != nil {
 		return err
 	}


### PR DESCRIPTION
This patch fix the panic if fencing a cnp pod when cnp cluster 
has no annotation.

Closes #511 
Signed-off-by: Tao Li <tao.li@enterprisedb.com>