### PR TITLE
chore: remove redudant storage validation webhook

### DIFF
--- a/api/v1/cluster_webhook.go
+++ b/api/v1/cluster_webhook.go
@@ -273,7 +273,6 @@ func (r *Cluster) Validate() (allErrs field.ErrorList) {
 		r.validateSuperuserSecret,
 		r.validateCerts,
 		r.validateBootstrapMethod,
-		r.validateStorageConfiguration,
 		r.validateImageName,
 		r.validateImagePullPolicy,
 		r.validateRecoveryTarget,
@@ -727,22 +726,6 @@ func (r *Cluster) validateBootstrapRecoverySource() field.ErrorList {
 	return result
 }
 
-// validateStorageConfiguration validates the size format it's correct
-func (r *Cluster) validateStorageConfiguration() field.ErrorList {
-	var result field.ErrorList
-
-	if _, err := resource.ParseQuantity(r.Spec.StorageConfiguration.Size); err != nil {
-		result = append(
-			result,
-			field.Invalid(
-				field.NewPath("spec", "storage", "size"),
-				r.Spec.StorageConfiguration.Size,
-				"Size value isn't valid"))
-	}
-
-	return result
-}
-
 // validateImageName validates the image name ensuring we aren't
 // using the "latest" tag
 func (r *Cluster) validateImageName() field.ErrorList {
@@ -1089,7 +1072,7 @@ func (r *Cluster) validateStorageSize() field.ErrorList {
 		result = append(result, field.Invalid(
 			field.NewPath("spec", "storage", "size"),
 			r.Spec.StorageConfiguration.Size,
-			err.Error()))
+			"Size value isn't valid"))
 	}
 
 	return result

--- a/api/v1/cluster_webhook_test.go
+++ b/api/v1/cluster_webhook_test.go
@@ -427,34 +427,6 @@ var _ = Describe("ImagePullPolicy validation", func() {
 	})
 })
 
-var _ = Describe("Storage validation", func() {
-	It("complains if the value isn't correct", func() {
-		cluster := Cluster{
-			Spec: ClusterSpec{
-				StorageConfiguration: StorageConfiguration{
-					Size: "X",
-				},
-			},
-		}
-
-		result := cluster.validateStorageConfiguration()
-		Expect(len(result)).To(Equal(1))
-	})
-
-	It("doesn't complain if value is correct", func() {
-		cluster := Cluster{
-			Spec: ClusterSpec{
-				StorageConfiguration: StorageConfiguration{
-					Size: "1Gi",
-				},
-			},
-		}
-
-		result := cluster.validateStorageConfiguration()
-		Expect(result).To(BeEmpty())
-	})
-})
-
 var _ = Describe("Defaulting webhook", func() {
 	It("should fill the image name if isn't already set", func() {
 		cluster := Cluster{}


### PR DESCRIPTION
This patch removes a duplicate webhook aimed at the storage size validation

Closes #514

Signed-off-by: Armando Ruocco <armando.ruocco@enterprisedb.com>