### PR TITLE
fix: timeouts for restarts and switchovers

### DIFF
--- a/internal/cmd/manager/instance/run/lifecycle/lifecycle.go
+++ b/internal/cmd/manager/instance/run/lifecycle/lifecycle.go
@@ -182,9 +182,9 @@ func (i *PostgresLifecycle) handleInstanceCommandRequests(
 		}
 		return false, err
 	case postgres.RestartSmartFast:
-		return true, tryShuttingDownSmartFast(i.instance.MaxSwitchoverDelay, i.instance)
+		return true, tryShuttingDownSmartFast(i.instance.MaxStopDelay, i.instance)
 	case postgres.ShutDownFastImmediate:
-		if err := tryShuttingDownFastImmediate(i.instance.MaxStopDelay, i.instance); err != nil {
+		if err := tryShuttingDownFastImmediate(i.instance.MaxSwitchoverDelay, i.instance); err != nil {
 			log.Error(err, "error shutting down instance, proceeding")
 		}
 		return false, nil


### PR DESCRIPTION
This patch fix the timeouts that we were using during a restart and
during switchovers to use the right fields in the Cluster specification.

Closes #530

Signed-off-by: Leonardo Cecchi <leonardo.cecchi@enterprisedb.com>