### PR TITLE
chore: adds instanceName and clusterName labels on jobs, pods, pvcs

### DIFF
--- a/controllers/cluster_create.go
+++ b/controllers/cluster_create.go
@@ -897,7 +897,7 @@ func (r *ClusterReconciler) createPrimaryInstance(
 		return ctrl.Result{}, fmt.Errorf("cannot generate node serial: %w", err)
 	}
 
-	pvcSpec, err := specs.CreatePVC(cluster.Spec.StorageConfiguration, cluster.Name, cluster.Namespace, nodeSerial)
+	pvcSpec, err := specs.CreatePVC(cluster, cluster.Spec.StorageConfiguration, nodeSerial)
 	if err != nil {
 		if err == specs.ErrorInvalidSize {
 			// This error should have been caught by the validating
@@ -1072,7 +1072,7 @@ func (r *ClusterReconciler) joinReplicaInstance(
 		return ctrl.Result{}, err
 	}
 
-	pvcSpec, err := specs.CreatePVC(cluster.Spec.StorageConfiguration, cluster.Name, cluster.Namespace, nodeSerial)
+	pvcSpec, err := specs.CreatePVC(cluster, cluster.Spec.StorageConfiguration, nodeSerial)
 	if err != nil {
 		if err == specs.ErrorInvalidSize {
 			// This error should have been caught by the validating

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -283,7 +283,7 @@ func generateFakePVC(c client.Client, cluster *apiv1.Cluster) []corev1.Persisten
 	for idx < cluster.Spec.Instances {
 		idx++
 
-		pvc, err := specs.CreatePVC(cluster.Spec.StorageConfiguration, cluster.Name, cluster.Namespace, idx)
+		pvc, err := specs.CreatePVC(cluster, cluster.Spec.StorageConfiguration, idx)
 		Expect(err).To(BeNil())
 		SetClusterOwnerAnnotationsAndLabels(&pvc.ObjectMeta, cluster)
 

--- a/pkg/specs/jobs.go
+++ b/pkg/specs/jobs.go
@@ -200,9 +200,19 @@ func createPrimaryJob(cluster apiv1.Cluster, nodeSerial int, role string, initCo
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      jobName,
 			Namespace: cluster.Namespace,
+			Labels: map[string]string{
+				utils.InstanceLabelName: podName,
+				utils.ClusterLabelName:  cluster.Name,
+			},
 		},
 		Spec: batchv1.JobSpec{
 			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						utils.InstanceLabelName: podName,
+						utils.ClusterLabelName:  cluster.Name,
+					},
+				},
 				Spec: corev1.PodSpec{
 					Hostname:  jobName,
 					Subdomain: cluster.GetServiceAnyName(),

--- a/pkg/specs/pods.go
+++ b/pkg/specs/pods.go
@@ -297,8 +297,9 @@ func PodWithExistingStorage(cluster apiv1.Cluster, nodeSerial int) *corev1.Pod {
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
-				ClusterLabelName:       cluster.Name,
-				utils.ClusterLabelName: cluster.Name,
+				ClusterLabelName:        cluster.Name,
+				utils.ClusterLabelName:  cluster.Name,
+				utils.InstanceLabelName: podName,
 			},
 			Annotations: map[string]string{
 				ClusterSerialAnnotationName: strconv.Itoa(nodeSerial),

--- a/pkg/specs/pvcs.go
+++ b/pkg/specs/pvcs.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 )
 
 const (
@@ -64,17 +65,20 @@ type PVCUsageStatus struct {
 
 // CreatePVC create spec of a PVC, given its name and the storage configuration
 func CreatePVC(
+	cluster *apiv1.Cluster,
 	storageConfiguration apiv1.StorageConfiguration,
-	name string,
-	namespace string,
 	nodeSerial int,
 ) (*corev1.PersistentVolumeClaim, error) {
-	pvcName := fmt.Sprintf("%s-%v", name, nodeSerial)
+	pvcName := fmt.Sprintf("%s-%v", cluster.Name, nodeSerial)
 
 	result := &corev1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      pvcName,
-			Namespace: namespace,
+			Namespace: cluster.Namespace,
+			Labels: map[string]string{
+				utils.InstanceLabelName: pvcName,
+				utils.ClusterLabelName:  cluster.Name,
+			},
 			Annotations: map[string]string{
 				ClusterSerialAnnotationName: strconv.Itoa(nodeSerial),
 				PVCStatusAnnotationName:     PVCStatusInitializing,

--- a/pkg/utils/labels_annotations.go
+++ b/pkg/utils/labels_annotations.go
@@ -32,6 +32,9 @@ const (
 	// JobRoleLabelName is the name of the label containing the purpose of the executed job
 	JobRoleLabelName = "cnpg.io/jobRole"
 
+	// InstanceLabelName is the name of the label containing the instance name
+	InstanceLabelName = "cnpg.io/instanceName"
+
 	// OperatorVersionAnnotationName is the name of the annotation containing
 	// the version of the operator that generated a certain object
 	OperatorVersionAnnotationName = "cnpg.io/operatorVersion"


### PR DESCRIPTION
This patch adds the instanceName label and clusterName to several resources. 
This will help us to interact with them in an easy manner both inside our codebase and outside.

Closes #520 

Signed-off-by: Armando Ruocco <armando.ruocco@enterprisedb.com>

Notes:
- This patch does not aim to address the issue of 'how' we want to patch the existing resources on previous version clusters. I think this is a different topic that deserves an ad hoc discussion.