### PR TITLE
chore: use the new webtest location

### DIFF
--- a/docs/src/ssl_connections.md
+++ b/docs/src/ssl_connections.md
@@ -83,7 +83,7 @@ spec:
         app: webtest
     spec:
       containers:
-        - image: quay.io/leonardoce/webtest:1.3.0
+        - image: ghcr.io/cloudnative-pg/webtest:1.6.0
           name: cert-test
           volumeMounts:
             - name: secret-volume-root-ca

--- a/tests/e2e/fixtures/fastfailover/webtest-syncreplicas.yaml
+++ b/tests/e2e/fixtures/fastfailover/webtest-syncreplicas.yaml
@@ -16,7 +16,7 @@ spec:
         app: webtest
     spec:
       containers:
-        - image: quay.io/leonardoce/webtest:1.3.0
+        - image: ghcr.io/cloudnative-pg/webtest:1.6.0
           name: webtest
           env:
             - name: PASSWORD

--- a/tests/e2e/fixtures/fastfailover/webtest.yaml
+++ b/tests/e2e/fixtures/fastfailover/webtest.yaml
@@ -16,7 +16,7 @@ spec:
         app: webtest
     spec:
       containers:
-        - image: quay.io/leonardoce/webtest:1.3.0
+        - image: ghcr.io/cloudnative-pg/webtest:1.6.0
           name: webtest
           env:
             - name: PASSWORD

--- a/tests/e2e/fixtures/fastswitchover/webtest.yaml
+++ b/tests/e2e/fixtures/fastswitchover/webtest.yaml
@@ -16,7 +16,7 @@ spec:
         app: webtest
     spec:
       containers:
-        - image: quay.io/leonardoce/webtest:1.3.0
+        - image: ghcr.io/cloudnative-pg/webtest:1.6.0
           name: webtest
           env:
             - name: PASSWORD

--- a/tests/utils/webapp.go
+++ b/tests/utils/webapp.go
@@ -53,7 +53,7 @@ func DefaultWebapp(namespace string, name string, rootCASecretName string, tlsSe
 			Containers: []corev1.Container{
 				{
 					Name:  name,
-					Image: "quay.io/leonardoce/webtest:1.3.0",
+					Image: "ghcr.io/cloudnative-pg/webtest:1.6.0",
 					Ports: []corev1.ContainerPort{
 						{
 							ContainerPort: 8080,


### PR DESCRIPTION
The project webtest was migrated to the cloudnative-pg organization and
so was the registry, this patch aims to point the image to the new
location in ghcr.io

Closes #532

Signed-off-by: Jonathan Gonzalez V <jonathan.gonzalez@enterprisedb.com>