### PR TITLE
chore: use Apache benchmark instead of hey

### DIFF
--- a/tests/e2e/asserts_test.go
+++ b/tests/e2e/asserts_test.go
@@ -985,7 +985,7 @@ func AssertFastFailOver(
 	})
 
 	By("starting load", func() {
-		// We set up hey and webtest. Hey, a load generator,
+		// We set up Apache Benchmark and webtest. Apache Benchmark, a load generator,
 		// continuously calls the webtest api to execute inserts
 		// on the postgres primary. We make sure that the first
 		// records appear on the database before moving to the next

--- a/tests/e2e/fastfailover_test.go
+++ b/tests/e2e/fastfailover_test.go
@@ -31,7 +31,7 @@ var _ = Describe("Fast failover", Serial, Label(tests.LabelPerformance), func() 
 		sampleFileSyncReplicas = fixturesDir + "/fastfailover/cluster-syncreplicas-fast-failover.yaml"
 		webTestFile            = fixturesDir + "/fastfailover/webtest.yaml"
 		webTestSyncReplicas    = fixturesDir + "/fastfailover/webtest-syncreplicas.yaml"
-		webTestJob             = fixturesDir + "/fastfailover/hey-job-webtest.yaml"
+		webTestJob             = fixturesDir + "/fastfailover/apache-benchmark-webtest.yaml"
 		level                  = tests.Highest
 	)
 	var (

--- a/tests/e2e/fastswitchover_test.go
+++ b/tests/e2e/fastswitchover_test.go
@@ -39,7 +39,7 @@ var _ = Describe("Fast switchover", Serial, Label(tests.LabelPerformance), func(
 		namespace   = "primary-switchover-time"
 		sampleFile  = fixturesDir + "/fastswitchover/cluster-fast-switchover.yaml"
 		webTestFile = fixturesDir + "/fastswitchover/webtest.yaml"
-		webTestJob  = fixturesDir + "/fastswitchover/hey-job-webtest.yaml"
+		webTestJob  = fixturesDir + "/fastswitchover/apache-benchmark-webtest.yaml"
 		clusterName = "cluster-fast-switchover"
 		level       = tests.Highest
 	)

--- a/tests/e2e/fastswitchover_test.go
+++ b/tests/e2e/fastswitchover_test.go
@@ -141,7 +141,7 @@ var _ = Describe("Fast switchover", Serial, Label(tests.LabelPerformance), func(
 			Expect(err).ToNot(HaveOccurred())
 		})
 		By("starting load", func() {
-			// We set up hey and webtest. Hey, a load generator,
+			// We set up Apache Benchmark and webtest. Apache Benchmark, a load generator,
 			// continuously calls the webtest api to execute inserts
 			// on the postgres primary. We make sure that the first
 			// records appear on the database before moving to the next

--- a/tests/e2e/fixtures/fastfailover/apache-benchmark-webtest.yaml
+++ b/tests/e2e/fixtures/fastfailover/apache-benchmark-webtest.yaml
@@ -6,15 +6,13 @@ spec:
   template:
     spec:
       containers:
-      - name: hey
-        image: ricoli/hey
+      - name: apache-benchmark
+        image: httpd
         command:
-         - "/go/bin/hey"
-         - "-z"
-         - "2m"
+         - "/usr/local/apache2/bin/ab"
+         - "-t"
+         - "120"
          - "-c"
          - "5"
-         - "-m"
-         - "GET"
          - "http://webtest:8080/tx"
       restartPolicy: Never

--- a/tests/e2e/fixtures/fastswitchover/apache-benchmark-webtest.yaml
+++ b/tests/e2e/fixtures/fastswitchover/apache-benchmark-webtest.yaml
@@ -6,15 +6,13 @@ spec:
   template:
     spec:
       containers:
-      - name: hey
-        image: ricoli/hey
+      - name: apache-benchmark
+        image: httpd
         command:
-         - "/go/bin/hey"
-         - "-z"
-         - "2m"
+         - "/usr/local/apache2/bin/ab"
+         - "-t"
+         - "120"
          - "-c"
          - "5"
-         - "-m"
-         - "GET"
          - "http://webtest:8080/tx"
       restartPolicy: Never


### PR DESCRIPTION
The project hey is not building multiarch images which makes complicated
to test in different archquitectures. Now using Apache benchmark we will
have different architectures available in the httpd image from Docker Hub.

Closes #536

Signed-off-by: Jonathan Gonzalez V <jonathan.gonzalez@enterprisedb.com>