### PR TITLE
chore: improve operator deployment security

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -29,7 +29,9 @@ spec:
     spec:
       serviceAccountName: manager
       securityContext:
-        runAsUser: 1001
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -77,8 +79,13 @@ spec:
           - mountPath: /run/secrets/cnpg.io/webhook
             name: webhook-certificates
         securityContext:
+          runAsUser: 10001
+          runAsGroup: 10001
           readOnlyRootFilesystem: true
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - "ALL"
       volumes:
         - name: scratch-data
           emptyDir: {}


### PR DESCRIPTION
After running trivy to diagnose the operator deployment we found a couple
of security issues fixed here:

* securityContext.capabilities.drop: ALL
* securityContext.runAsNonRoot: true
* securityContext.runAsUser: 10001
* securityContext.runAsGroup: 10001
* securityContext.seccompProfile.type: RuntimeDefault

All of these issues are fixed in the manager deployment and will not affect
the code itself.

Closes #541

Signed-off-by: Jonathan Gonzalez V <jonathan.gonzalez@enterprisedb.com>