### PR TITLE
fix: use `RetryOnConflict` to update resources

### DIFF
--- a/pkg/certs/k8s.go
+++ b/pkg/certs/k8s.go
@@ -410,10 +410,8 @@ func (pki PublicKeyInfrastructure) injectPublicKeyIntoMutatingWebhook(
 	ctx context.Context, client kubernetes.Interface, tlsSecret *v1.Secret,
 ) error {
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
-
 		config, err := client.AdmissionregistrationV1().MutatingWebhookConfigurations().Get(
 			ctx, pki.MutatingWebhookConfigurationName, metav1.GetOptions{})
-
 		if err != nil {
 			return err
 		}

--- a/pkg/certs/k8s.go
+++ b/pkg/certs/k8s.go
@@ -420,9 +420,16 @@ func (pki PublicKeyInfrastructure) injectPublicKeyIntoMutatingWebhook(
 			return nil
 		}
 
+		oldConfig := config.DeepCopy()
+
 		for idx := range config.Webhooks {
 			config.Webhooks[idx].ClientConfig.CABundle = tlsSecret.Data["tls.crt"]
 		}
+
+		if reflect.DeepEqual(oldConfig.Webhooks, config.Webhooks) {
+			return nil
+		}
+
 		_, err = client.AdmissionregistrationV1().
 			MutatingWebhookConfigurations().
 			Update(ctx, config, metav1.UpdateOptions{})
@@ -446,8 +453,14 @@ func (pki PublicKeyInfrastructure) injectPublicKeyIntoValidatingWebhook(
 			return nil
 		}
 
+		oldConfig := config.DeepCopy()
+
 		for idx := range config.Webhooks {
 			config.Webhooks[idx].ClientConfig.CABundle = tlsSecret.Data["tls.crt"]
+		}
+
+		if reflect.DeepEqual(oldConfig.Webhooks, config.Webhooks) {
+			return nil
 		}
 
 		_, err = client.AdmissionregistrationV1().


### PR DESCRIPTION
Add `RetryOnConflict` in func `injectPublicKeyIntoValidatingWebhook` and `injectPublicKeyIntoMutatingWebhook` to retry updating in case of conflict failures.

Closes #546 

Signed-off-by: Hai He <hai.he@enterprisedb.com>