### PR TITLE
feat: refine stats in E2E summary

### DIFF
--- a/.github/summarize-test-results.py
+++ b/.github/summarize-test-results.py
@@ -164,7 +164,7 @@ def compute_test_summary(test_dir):
         "by_k8s": by_k8s,
         "by_platform": by_platform,
         "by_postgres": by_postgres,
-        "test_durations": test_dutrations,
+        "test_durations": test_durations,
     }
     """
     total_runs = 0
@@ -192,7 +192,7 @@ def compute_test_summary(test_dir):
         "failed": {}
     }
 
-    test_dutrations = {
+    test_durations = {
         "max": {},
         "min": {},
         "slowest_branch": {}
@@ -223,7 +223,7 @@ def compute_test_summary(test_dir):
             ## bucketing by platform
             count_bucketized_stats(test_results, by_platform, "platform")
 
-            track_time_taken(test_results, test_dutrations)
+            track_time_taken(test_results, test_durations)
 
 
 
@@ -235,7 +235,7 @@ def compute_test_summary(test_dir):
         "by_k8s": by_k8s,
         "by_platform": by_platform,
         "by_postgres": by_postgres,
-        "test_durations": test_dutrations,
+        "test_durations": test_durations,
     }
 
 def compile_overview(summary):
@@ -262,7 +262,7 @@ def compile_overview(summary):
     }
 
 def format_overview(summary, structure):
-    """print unbucketed test metrics"""
+    """print general test metrics"""
     print("## " + structure["title"])
     print()
     print("|" + " | ".join(structure["header"]) + "|")
@@ -278,7 +278,7 @@ def format_overview(summary, structure):
     print()
 
 def format_bucket_table(buckets, structure):
-    """print table with bucketed metrics, sorted by decreasing amount of faiulres.
+    """print table with bucketed metrics, sorted by decreasing amount of failures.
 
     The structure argument contains the layout directives. E.g.
     {
@@ -417,27 +417,29 @@ def format_test_summary(summary):
     """
 
     print(
-        """Note that there are several tables below: overview, bucketed
-by several parameters, timings.
-""")
+        "Note that there are several tables below: overview, bucketed " +
+        "by several parameters, timings.")
+    print()
     if summary["total_failed"] != 0:
         print(
-            """Index: [timing table](#user-content-timing) | [by test](#user-content-by_test) |
- [by k8s](#user-content-by_k8s) | [by postgres](#user-content-by_postgres) |
- [by platform](#user-content-by_platform)
-""")
+            "**Index**: [timing table](#user-content-timing) | [by test](#user-content-by_test) | " +
+            "[by k8s](#user-content-by_k8s) | [by postgres](#user-content-by_postgres) | " +
+            "[by platform](#user-content-by_platform)")
+        print()
 
     overview = compile_overview(summary)
 
     overview_section = {
         "title": "Overview",
         "header": ["failed", "out of", ""],
-        "rows": [["test combinations", "total_failed", "total_run"],
-                ["unique tests", "unique_failed", "unique_run"],
-                ["matrix branches", "matrix_failed", "matrix_run"],
-                ["k8s versions", "k8s_failed", "k8s_run"],
-                ["postgres versions", "postgres_failed", "postgres_run"],
-                ["platforms", "platform_failed", "platform_run"]],
+        "rows": [
+            ["test combinations", "total_failed", "total_run"],
+            ["unique tests", "unique_failed", "unique_run"],
+            ["matrix branches", "matrix_failed", "matrix_run"],
+            ["k8s versions", "k8s_failed", "k8s_run"],
+            ["postgres versions", "postgres_failed", "postgres_run"],
+            ["platforms", "platform_failed", "platform_run"]
+        ],
     }
 
     format_overview(overview, overview_section)

--- a/.github/summarize-test-results.py
+++ b/.github/summarize-test-results.py
@@ -50,9 +50,10 @@ a summary in Markdown, which can then be rendered in GitHub using
 """
 
 import argparse
+from datetime import datetime
 import json
 import os
-from datetime import datetime
+import pathlib
 
 def is_failed(e2e_test):
     """checks if the test failed. In ginkgo, the passing states are well defined
@@ -154,17 +155,17 @@ def compute_test_summary(test_dir):
     """iterate over the JSON artifact files in `test_dir`, and
     bucket them for comprehension.
 
-    Produces a dictionary of dictionaries:
+    Returns a dictionary of dictionaries:
 
     {
         "total_run": 0,
         "total_failed": 0,
-        "by_test": by_test,
-        "by_matrix": by_matrix,
-        "by_k8s": by_k8s,
-        "by_platform": by_platform,
-        "by_postgres": by_postgres,
-        "test_durations": test_durations,
+        "by_test": { … },
+        "by_matrix": { … },
+        "by_k8s": { … },
+        "by_platform": { … },
+        "by_postgres": { … },
+        "test_durations": { … },
     }
     """
     total_runs = 0
@@ -200,6 +201,8 @@ def compute_test_summary(test_dir):
 
     dir_listing = os.listdir(test_dir)
     for f in dir_listing:
+        if pathlib.Path(f).suffix != ".json":
+            continue
         path = os.path.join(test_dir, f)
         with open(path) as json_file:
             test_results = combine_postgres_data(json.load(json_file))

--- a/.github/summarize-test-results.py
+++ b/.github/summarize-test-results.py
@@ -71,8 +71,16 @@ def track_time_taken(test_results, min_durations, max_durations, slowest_branche
     if (test_results["start_time"] == "0001-01-01T00:00:00Z" or
         test_results["start_time"] == "0001-01-01T00:00:00Z"):
         return
-    start_time = datetime.fromisoformat(test_results["start_time"])
-    end_time = datetime.fromisoformat(test_results["end_time"])
+    # chop of the nanoseconds part, which is too much for Python `fromisoformat`
+    start_frags = test_results["start_time"].split(".")
+    if len(start_frags) != 2:
+        return
+    end_frags = test_results["end_time"].split(".")
+    if len(end_frags) != 2:
+        return
+
+    start_time = datetime.fromisoformat(start_frags[0])
+    end_time = datetime.fromisoformat(end_frags[0])
     duration = end_time - start_time
     matrix_id = test_results["matrix_id"]
     if name not in max_durations:

--- a/.github/summarize-test-results.py
+++ b/.github/summarize-test-results.py
@@ -71,7 +71,7 @@ def track_time_taken(test_results, min_durations, max_durations, slowest_branche
     if (test_results["start_time"] == "0001-01-01T00:00:00Z" or
         test_results["start_time"] == "0001-01-01T00:00:00Z"):
         return
-    # chop of the nanoseconds part, which is too much for Python `fromisoformat`
+    # chop off the nanoseconds part, which is too much for Python `fromisoformat`
     start_frags = test_results["start_time"].split(".")
     if len(start_frags) != 2:
         return
@@ -117,9 +117,9 @@ def compute_bucketized_summary(failed_bucketized, total_bucketized):
     failed_buckets_count = 0
     total_buckets_count = 0
     for name in total_bucketized:
-        failed_buckets_count = 1 + failed_buckets_count
-    for name in failed_bucketized:
         total_buckets_count = 1 + total_buckets_count
+    for name in failed_bucketized:
+        failed_buckets_count = 1 + failed_buckets_count
     return failed_buckets_count, total_buckets_count
 
 def compute_test_summary(test_dir):
@@ -299,7 +299,7 @@ def format_duration(d):
 def format_durations_table(min_durations, max_durations, slowest_branches, structure):
     """print the table of durations per test
     """
-    print("## " + structure["title"])
+    print("<h2><a name=timing>" + structure["title"] + "</a></h2>")
     print()
     print("|" + " | ".join(structure["header"]) + "|")
     print("|" + "|".join(["---"] * len(structure["header"])) + "|")
@@ -360,7 +360,7 @@ def format_test_summary(summary):
         """Note that there are several tables below: overview, bucketed
 by test, bucketed by matrix branch, kubernetes, postgres…
 
-* [timing table](#Test-times)
+* [timing table](#timing)
 """
     )
     print()

--- a/.github/summarize-test-results.py
+++ b/.github/summarize-test-results.py
@@ -264,7 +264,9 @@ def format_bucket_table(buckets, structure):
         "header": ["failed tests", "total tests", "platform"],
     }
     """
-    print("## " + structure["title"])
+    print("<h2><a name={anchor}>{title}</a></h2>".format(
+        title=structure["title"],
+        anchor=structure["anchor"]))
     print()
     print("|" + " | ".join(structure["header"]) + "|")
     print("|" + "|".join(["---"] * len(structure["header"])) + "|")
@@ -287,7 +289,9 @@ def format_bucket_table(buckets, structure):
 def format_by_test(summary, structure):
     """print metrics bucketed by test class
     """
-    print("## " + structure["title"])
+    print("<h2><a name={anchor}>{title}</a></h2>".format(
+        title=structure["title"],
+        anchor=structure["anchor"]))
     print()
     print("|" + " | ".join(structure["header"]) + "|")
     print("|" + "|".join(["---"] * len(structure["header"])) + "|")
@@ -319,7 +323,9 @@ def format_duration(d):
 def format_durations_table(test_times, structure):
     """print the table of durations per test
     """
-    print("<h2><a name=timing>" + structure["title"] + "</a></h2>")
+    print("<h2><a name={anchor}>{title}</a></h2>".format(
+        title=structure["title"],
+        anchor=structure["anchor"]))
     print()
     print("|" + " | ".join(structure["header"]) + "|")
     print("|" + "|".join(["---"] * len(structure["header"])) + "|")
@@ -345,6 +351,7 @@ def format_test_failures(summary):
     """
     by_test_section = {
         "title": "Failures by test",
+        "anchor": "by_test",
         "header": ["failed runs", "total runs", "failed K8s", "failed PG", "test"],
     }
 
@@ -352,6 +359,7 @@ def format_test_failures(summary):
 
     by_matrix_section = {
         "title": "Failures by matrix branch",
+        "anchor": "by_matrix",
         "header": ["failed tests", "total tests", "matrix branch"],
     }
 
@@ -359,6 +367,7 @@ def format_test_failures(summary):
 
     by_k8s_section = {
         "title": "Failures by kubernetes version",
+        "anchor": "by_k8s",
         "header": ["failed tests", "total tests", "kubernetes version"],
     }
 
@@ -366,6 +375,7 @@ def format_test_failures(summary):
 
     by_postgres_section = {
         "title": "Failures by postgres version",
+        "anchor": "by_postgres",
         "header": ["failed tests", "total tests", "postgres version"],
     }
 
@@ -373,6 +383,7 @@ def format_test_failures(summary):
 
     by_platform_section = {
         "title": "Failures by platform",
+        "anchor": "by_platform",
         "header": ["failed tests", "total tests", "platform"],
     }
 
@@ -387,7 +398,8 @@ def format_test_summary(summary):
         """Note that there are several tables below: overview, bucketed
 by test, bucketed by matrix branch, kubernetes, postgres…
 
-* [timing table](#user-content-timing)
+Index: [timing table](#user-content-timing) | [by test](#user-content-by_test) |
+  [by k8s](#user-content-by_k8s) | [by postgres](#user-content-by_pg) |  [by platform](#user-content-by_platform)
 """
     )
     print()
@@ -410,6 +422,7 @@ by test, bucketed by matrix branch, kubernetes, postgres…
 
     timing_section = {
         "title": "Test times",
+        "anchor": "timing",
         "header": ["longest taken", "shortest taken", "slowest branch", "test"],
     }
 

--- a/.github/summarize-test-results.py
+++ b/.github/summarize-test-results.py
@@ -360,7 +360,7 @@ def format_test_summary(summary):
         """Note that there are several tables below: overview, bucketed
 by test, bucketed by matrix branch, kubernetes, postgres…
 
-* [timing table](#timing)
+* [timing table](#user-content-timing)
 """
     )
     print()

--- a/.github/summarize_test_results.py
+++ b/.github/summarize_test_results.py
@@ -460,7 +460,7 @@ def format_test_summary(summary):
 
     overview_section = {
         "title": "Overview",
-        "header": ["failed", "out of", ""],
+        "header": ["", "failed", "out of"],
         "rows": [
             ["test combinations", "total_failed", "total_run"],
             ["unique tests", "unique_failed", "unique_run"],
@@ -474,6 +474,7 @@ def format_test_summary(summary):
     format_overview(overview, overview_section)
 
     if summary["total_failed"] == 0:
+        print()
         print(
             "No failures, no failure stats shown. "
             "It's not easy being green."

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -720,6 +720,10 @@ jobs:
       - name: Display the structure of the artifact folder
         run: ls -R test-artifacts
 
+      - name: Install Summarize dependencies
+        run: |
+          pip install prettytable
+
       - name: Compute the E2E test summary
         run: |
           python .github/summarize_test_results.py --dir test-artifacts >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -722,7 +722,8 @@ jobs:
 
       - name: Compute the E2E test summary
         run: |
-          python .github/summarize-test-results.py --dir test-artifacts >> $GITHUB_STEP_SUMMARY
+          python .github/summarize_test_results.py --dir test-artifacts >> $GITHUB_STEP_SUMMARY
+
       - name: Delete the downloaded files
         run: rm -rf test-artifacts
 

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -709,17 +709,27 @@ jobs:
       - name: Download all artifacts to the directory
         uses: actions/download-artifact@v3
         with:
-          name: testartifacts-local
           path: test-artifacts
+
+      - name: Flatten all artifacts onto directory
+        # The download-artifact action, since we did not give it a name,
+        # downloads all artifacts and creates a new folder for each.
+        # In this step we bring all the JSONs to a single folder
+        run: mv test-artifacts/*/*.json test-artifacts
+
+      - name: Display the structure of the artifact folder
+        run: ls -R test-artifacts
 
       - name: Compute the E2E test summary
         run: |
           python .github/summarize-test-results.py --dir test-artifacts >> $GITHUB_STEP_SUMMARY
+      - name: Delete the downloaded files
+        run: rm -rf test-artifacts
 
-  # Adds the 'ok-to-merge' label to workflows that have run successfully and
-  # have adequate test and matrix coverage.
-  # This label is a prerequisite to be able to merge a PR.
-  # Also see to 'require-labels.yml'
+# Adds the 'ok-to-merge' label to workflows that have run successfully and
+# have adequate test and matrix coverage.
+# This label is a prerequisite to be able to merge a PR.
+# Also see to 'require-labels.yml'
   ok-to-merge:
     name: Label the PR as "ok to merge"
     needs:

--- a/tests/e2e/initdb_test.go
+++ b/tests/e2e/initdb_test.go
@@ -80,7 +80,7 @@ var _ = Describe("InitDB settings", func() {
 					namespace,
 					primaryDst,
 					cmd))
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).To(HaveOccurred())
 			})
 			By("querying the App database tables via psql", func() {
 				cmd := "psql -U postgres app -tAc 'SELECT count(*) FROM application_numbers'"

--- a/tests/e2e/initdb_test.go
+++ b/tests/e2e/initdb_test.go
@@ -80,7 +80,7 @@ var _ = Describe("InitDB settings", func() {
 					namespace,
 					primaryDst,
 					cmd))
-				Expect(err).To(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 			})
 			By("querying the App database tables via psql", func() {
 				cmd := "psql -U postgres app -tAc 'SELECT count(*) FROM application_numbers'"


### PR DESCRIPTION
Improve the E2E Summary Step:

1. Add a timing table with max / min time taken per test, sorted by slowest
2. Add tables bucketing the results by K8s version, PG version, platform
3. Add rows to the overview for failed vs total K8s versions, PG versions, platforms
5. Add a navbar, and clarify that we have several tables

Closes #548 

Signed-off-by: Jaime Silvela <jaime.silvela@enterprisedb.com>