### PR TITLE
refactor: allows the override of the default external secret directory

### DIFF
--- a/pkg/management/external/utils.go
+++ b/pkg/management/external/utils.go
@@ -27,18 +27,18 @@ import (
 )
 
 const (
-	// externalSecretsPath is the path where the cryptographic material
+	// defaultExternalSecretsPath is the default path where the cryptographic material
 	// needed to connect to an external cluster will be dumped
 	defaultExternalSecretsPath = "/controller/external" // #nosec
 )
 
-// CustomExternalSecretPath is the custom path where the cryptographic material
+// CustomExternalSecretsPath is the custom path where the cryptographic material
 // needed to connect to an external cluster will be dumped
-var CustomExternalSecretPath string
+var CustomExternalSecretsPath string
 
-func getSecretPath() string {
-	if CustomExternalSecretPath != "" {
-		return CustomExternalSecretPath
+func getExternalSecretsPath() string {
+	if CustomExternalSecretsPath != "" {
+		return CustomExternalSecretsPath
 	}
 
 	return defaultExternalSecretsPath
@@ -86,7 +86,7 @@ func DumpSecretKeyRefToFile(
 		return "", fmt.Errorf("missing key %v in secret %v", selector.Key, selector.Name)
 	}
 
-	directory := path.Join(getSecretPath(), serverName)
+	directory := path.Join(getExternalSecretsPath(), serverName)
 	if err := os.MkdirAll(directory, 0o700); err != nil {
 		return "", err
 	}
@@ -118,7 +118,7 @@ func CreatePgPassFile(serverName, password string) (string, error) {
 		"*", // username
 		password)
 
-	directory := path.Join(getSecretPath(), serverName)
+	directory := path.Join(getExternalSecretsPath(), serverName)
 	if err := os.MkdirAll(directory, 0o700); err != nil {
 		return "", err
 	}

--- a/pkg/management/external/utils.go
+++ b/pkg/management/external/utils.go
@@ -29,8 +29,20 @@ import (
 const (
 	// externalSecretsPath is the path where the cryptographic material
 	// needed to connect to an external cluster will be dumped
-	externalSecretsPath = "/controller/external" // #nosec
+	defaultExternalSecretsPath = "/controller/external" // #nosec
 )
+
+// CustomExternalSecretPath is the custom path where the cryptographic material
+// needed to connect to an external cluster will be dumped
+var CustomExternalSecretPath string
+
+func getSecretPath() string {
+	if CustomExternalSecretPath != "" {
+		return CustomExternalSecretPath
+	}
+
+	return defaultExternalSecretsPath
+}
 
 // ReadSecretKeyRef dumps a certain secret to a file inside a temporary folder
 // using 0600 as permission bits
@@ -74,7 +86,7 @@ func DumpSecretKeyRefToFile(
 		return "", fmt.Errorf("missing key %v in secret %v", selector.Key, selector.Name)
 	}
 
-	directory := path.Join(externalSecretsPath, serverName)
+	directory := path.Join(getSecretPath(), serverName)
 	if err := os.MkdirAll(directory, 0o700); err != nil {
 		return "", err
 	}
@@ -106,7 +118,7 @@ func CreatePgPassFile(serverName, password string) (string, error) {
 		"*", // username
 		password)
 
-	directory := path.Join(externalSecretsPath, serverName)
+	directory := path.Join(getSecretPath(), serverName)
 	if err := os.MkdirAll(directory, 0o700); err != nil {
 		return "", err
 	}

--- a/pkg/management/external/utils.go
+++ b/pkg/management/external/utils.go
@@ -33,7 +33,8 @@ const (
 )
 
 // CustomExternalSecretsPath is the custom path where the cryptographic material
-// needed to connect to an external cluster will be dumped
+// needed to connect to an external cluster will be dumped.
+// This will be used by the unit tests.
 var CustomExternalSecretsPath string
 
 func getExternalSecretsPath() string {


### PR DESCRIPTION
This patch allows the developer to specify the directory where the external cluster secrets will be saved.
This is needed to allow the unit testing of certain external cluster methods.

Closes #559

Signed-off-by: Armando Ruocco <armando.ruocco@enterprisedb.com>

As discussed with @jsilvela  @gbartolini  and @jlong49  this is a temporary fix until we properly refactor the whole chain call of functions