### PR TITLE
chore: pre-load helper images in testing cluster

### DIFF
--- a/hack/setup-cluster.sh
+++ b/hack/setup-cluster.sh
@@ -43,6 +43,14 @@ trap 'rm -fr ${TEMP_DIR}' EXIT
 registry_volume=registry_dev_data
 registry_name=registry.dev
 
+# Helper images
+POSTGRES_IMG=${POSTGRES_IMG:-$(grep 'DefaultImageName.*=' "${ROOT_DIR}/pkg/versions/versions.go" | cut -f 2 -d \")}
+POSTGRES_UPDATE_IMG=${POSTGRES_UPDATE_IMG:-${POSTGRES_IMG%.*}}
+PGBOUNCER_IMG=${PGBOUNCER_IMG:-$(grep 'DefaultPgbouncerImage.*=' "${ROOT_DIR}/pkg/specs/pgbouncer/deployments.go" | cut -f 2 -d \")}
+MINIO_IMG=${MINIO_IMG:-$(grep 'minioImage.*=' "${ROOT_DIR}/tests/utils/minio.go"  | cut -f 2 -d \")}
+APACHE_IMG=${APACHE_IMG:-"httpd"}
+HELPER_IMGS=($POSTGRES_IMG $POSTGRES_UPDATE_IMG $PGBOUNCER_IMG $MINIO_IMG $APACHE_IMG)
+
 # Colors (only if using a terminal)
 bright=
 reset=
@@ -460,6 +468,15 @@ load() {
   load_image "${CLUSTER_NAME}" "${CONTROLLER_IMG}"
 
   echo "${bright}Done loading new operator image on cluster ${CLUSTER_NAME}${reset}"
+
+  echo "${bright}Loading helper images for tests on cluster ${CLUSTER_NAME}${reset}"
+
+  for IMG in ${HELPER_IMGS[@]}; do
+    docker pull "${IMG}"
+    "load_image_${ENGINE}" "${CLUSTER_NAME}" "${IMG}"
+  done
+
+  echo "${bright}Done loading helper images on cluster ${CLUSTER_NAME}${reset}"
 }
 
 deploy() {

--- a/hack/setup-cluster.sh
+++ b/hack/setup-cluster.sh
@@ -43,13 +43,19 @@ trap 'rm -fr ${TEMP_DIR}' EXIT
 registry_volume=registry_dev_data
 registry_name=registry.dev
 
-# Helper images
+# #########################################################################
+# IMPORTANT: here we build a catalog of images that will be needed in the
+# test run. The goal here is to pre-load all the images that are part of the
+# HELPER_IMGS variable in the local container registry.
+# #########################################################################
 POSTGRES_IMG=${POSTGRES_IMG:-$(grep 'DefaultImageName.*=' "${ROOT_DIR}/pkg/versions/versions.go" | cut -f 2 -d \")}
 POSTGRES_UPDATE_IMG=${POSTGRES_UPDATE_IMG:-${POSTGRES_IMG%.*}}
 PGBOUNCER_IMG=${PGBOUNCER_IMG:-$(grep 'DefaultPgbouncerImage.*=' "${ROOT_DIR}/pkg/specs/pgbouncer/deployments.go" | cut -f 2 -d \")}
 MINIO_IMG=${MINIO_IMG:-$(grep 'minioImage.*=' "${ROOT_DIR}/tests/utils/minio.go"  | cut -f 2 -d \")}
 APACHE_IMG=${APACHE_IMG:-"httpd"}
+
 HELPER_IMGS=($POSTGRES_IMG $POSTGRES_UPDATE_IMG $PGBOUNCER_IMG $MINIO_IMG $APACHE_IMG)
+# #########################################################################
 
 # Colors (only if using a terminal)
 bright=
@@ -471,6 +477,8 @@ load() {
 
   echo "${bright}Loading helper images for tests on cluster ${CLUSTER_NAME}${reset}"
 
+  # Here we pre-load all the images defined in the HELPER_IMGS variable
+  # with the goal to speed up the runs.
   for IMG in ${HELPER_IMGS[@]}; do
     docker pull "${IMG}"
     "load_image_${ENGINE}" "${CLUSTER_NAME}" "${IMG}"


### PR DESCRIPTION
Using the existing script `hack/setup-cluster.sh` to create the testing cluster
we should also use the existing functions `load_image_(kind|k3s)` to pre-load
the helper images needed by the test, this aim to improve the test speed.

Closes #574

Signed-off-by: Jonathan Gonzalez V <jonathan.gonzalez@enterprisedb.com>