### PR TITLE
feat: allow configuring log-level TCP parameters for PgBouncer

### DIFF
--- a/api/v1/pooler_webhook.go
+++ b/api/v1/pooler_webhook.go
@@ -65,6 +65,11 @@ var (
 		"server_reset_query_always",
 		"server_round_robin",
 		"stats_period",
+		"tcp_keepalive",
+		"tcp_keepcnt",
+		"tcp_keepidle",
+		"tcp_keepintvl",
+		"tcp_user_timeout",
 		"verbose",
 	})
 )


### PR DESCRIPTION
Adding TCP parameters to allowed configurable parameters on webhook per discussion topic.  https://github.com/cloudnative-pg/cloudnative-pg/discussions/563  Please let me know if anything needs changed or added.