### PR TITLE
doc: add pg_hba configuration to ssl connections document

### DIFF
--- a/docs/src/samples.md
+++ b/docs/src/samples.md
@@ -69,5 +69,8 @@ Bootstrap cluster with SQL files
 : [`cluster-example-initdb-sql-refs.yaml`](samples/cluster-example-initdb-sql-refs.yaml):
    a cluster example that will execute a set of queries defined in a Secret and a ConfigMap right after the database is created.
 
+Sample cluster with customized pg_hba configuration
+: [`cluster-example-pg-hba.yaml`](samples/cluster-example-pg-hba.yaml):
+  a basic cluster that enable user `app` to authenticate using certificates
 
 For a list of available options, please refer to the ["API Reference" page](api_reference.md).

--- a/docs/src/samples/cluster-example-pg-hba.yaml
+++ b/docs/src/samples/cluster-example-pg-hba.yaml
@@ -1,0 +1,17 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: cluster-example
+spec:
+  instances: 3
+  postgresql:
+    pg_hba:
+      - hostssl app all all cert
+
+  bootstrap:
+    initdb:
+      database: app
+      owner: app
+
+  storage:
+    size: 1Gi

--- a/docs/src/ssl_connections.md
+++ b/docs/src/ssl_connections.md
@@ -10,10 +10,10 @@ Authority (CA) to create and sign TLS client certificates. Through the `cnpg` pl
 issue a new TLS client certificate which can be used to authenticate a user instead of using passwords.
 
 Please refer to the following steps to authenticate via TLS/SSL certificates, which assume you have
-installed a cluster using the [cluster-example.yaml](samples/cluster-example.yaml) deployment manifest.
-According to the convention over configuration paradigm, that file automatically creates an `app` database
-which is owned by a user called `app` (you can change this convention through the `initdb` configuration
-in the `bootstrap` section).
+installed a cluster using the [cluster-example-pg-hba.yaml](samples/cluster-example-pg-hba.yaml) deployment 
+manifest. According to the convention over configuration paradigm, that file automatically creates an `app` 
+database which is owned by a user called `app` (you can change this convention through the `initdb` 
+configuration in the `bootstrap` section).
 
 ## Issuing a new certificate
 


### PR DESCRIPTION
Update the sample used in ssl_connection.md, add pg_hba configurate 
to allow use app to access cluster through certification
Closes #527 
Signed-off-by: Tao Li <tao.li@enterprisedb.com>