### PR TITLE
chore: split retry timeout for client and commands

### DIFF
--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -34,11 +34,9 @@ import (
 )
 
 const (
-	fixturesDir = "./fixtures"
-	// RetryTimeout retry time when client api call or kubectl cli request get failed
-	RetryTimeout = 60
-	// PollingTime polling between retry
-	PollingTime = 5
+	fixturesDir  = "./fixtures"
+	RetryTimeout = utils.RetryTimeout
+	PollingTime  = utils.PollingTime
 )
 
 var (

--- a/tests/utils/backup.go
+++ b/tests/utils/backup.go
@@ -39,7 +39,7 @@ func ExecuteBackup(namespace string, backupFile string, env *TestingEnvironment)
 			return err
 		}
 		return nil
-	}, RetryTimeout, PollingTime).Should(BeNil())
+	}, RetryTimeoutClient, PollingTime).Should(BeNil())
 
 	// After a while the Backup should be completed
 	timeout := 180

--- a/tests/utils/backup.go
+++ b/tests/utils/backup.go
@@ -39,7 +39,7 @@ func ExecuteBackup(namespace string, backupFile string, env *TestingEnvironment)
 			return err
 		}
 		return nil
-	}, RetryTimeoutClient, PollingTime).Should(BeNil())
+	}, RetryTimeout, PollingTime).Should(BeNil())
 
 	// After a while the Backup should be completed
 	timeout := 180

--- a/tests/utils/commons.go
+++ b/tests/utils/commons.go
@@ -81,7 +81,7 @@ func CreateObject(env *TestingEnvironment, object client.Object, opts ...client.
 			return nil
 		},
 		retry.Delay(PollingTime*time.Second),
-		retry.Attempts(RetryTimeout),
+		retry.Attempts(RetryTimeoutClient),
 		retry.DelayType(retry.FixedDelay),
 		retry.RetryIf(func(err error) bool { return !apierrs.IsAlreadyExists(err) }),
 	)
@@ -95,7 +95,7 @@ func DeleteObject(env *TestingEnvironment, object client.Object, opts ...client.
 			return env.Client.Delete(env.Ctx, object, opts...)
 		},
 		retry.Delay(PollingTime*time.Second),
-		retry.Attempts(RetryTimeout),
+		retry.Attempts(RetryTimeoutClient),
 		retry.DelayType(retry.FixedDelay),
 		retry.RetryIf(func(err error) bool { return !apierrs.IsNotFound(err) }),
 	)
@@ -113,7 +113,7 @@ func GetObjectList(env *TestingEnvironment, objectList client.ObjectList, opts .
 			return nil
 		},
 		retry.Delay(PollingTime*time.Second),
-		retry.Attempts(RetryTimeout),
+		retry.Attempts(RetryTimeoutClient),
 		retry.DelayType(retry.FixedDelay),
 	)
 	return err
@@ -130,7 +130,7 @@ func GetObject(env *TestingEnvironment, objectKey client.ObjectKey, object clien
 			return nil
 		},
 		retry.Delay(PollingTime*time.Second),
-		retry.Attempts(RetryTimeout),
+		retry.Attempts(RetryTimeoutClient),
 		retry.DelayType(retry.FixedDelay),
 	)
 	return err

--- a/tests/utils/commons.go
+++ b/tests/utils/commons.go
@@ -49,7 +49,7 @@ func ForgeArchiveWalOnMinio(namespace, clusterName, miniClientPodName, existingW
 func TestFileExist(namespace, podName, directoryPath, fileName string) bool {
 	filePath := directoryPath + "/" + fileName
 	testFileExistCommand := "test -f " + filePath
-	_, _, err := RunUncheckedRetry(fmt.Sprintf(
+	_, _, err := RunUnchecked(fmt.Sprintf(
 		"kubectl exec -n %v %v -- %v",
 		namespace,
 		podName,
@@ -61,7 +61,7 @@ func TestFileExist(namespace, podName, directoryPath, fileName string) bool {
 // TestDirectoryEmpty tests if a directory `directoryPath` exists on pod `podName` in namespace `namespace`
 func TestDirectoryEmpty(namespace, podName, directoryPath string) bool {
 	testDirectoryEmptyCommand := "test \"$(ls -A" + directoryPath + ")\""
-	_, _, err := RunUncheckedRetry(fmt.Sprintf(
+	_, _, err := RunUnchecked(fmt.Sprintf(
 		"kubectl exec -n %v %v -- %v",
 		namespace,
 		podName,
@@ -81,7 +81,7 @@ func CreateObject(env *TestingEnvironment, object client.Object, opts ...client.
 			return nil
 		},
 		retry.Delay(PollingTime*time.Second),
-		retry.Attempts(RetryTimeoutClient),
+		retry.Attempts(RetryTimeout),
 		retry.DelayType(retry.FixedDelay),
 		retry.RetryIf(func(err error) bool { return !apierrs.IsAlreadyExists(err) }),
 	)
@@ -95,7 +95,7 @@ func DeleteObject(env *TestingEnvironment, object client.Object, opts ...client.
 			return env.Client.Delete(env.Ctx, object, opts...)
 		},
 		retry.Delay(PollingTime*time.Second),
-		retry.Attempts(RetryTimeoutClient),
+		retry.Attempts(RetryTimeout),
 		retry.DelayType(retry.FixedDelay),
 		retry.RetryIf(func(err error) bool { return !apierrs.IsNotFound(err) }),
 	)
@@ -113,7 +113,7 @@ func GetObjectList(env *TestingEnvironment, objectList client.ObjectList, opts .
 			return nil
 		},
 		retry.Delay(PollingTime*time.Second),
-		retry.Attempts(RetryTimeoutClient),
+		retry.Attempts(RetryTimeout),
 		retry.DelayType(retry.FixedDelay),
 	)
 	return err
@@ -130,7 +130,7 @@ func GetObject(env *TestingEnvironment, objectKey client.ObjectKey, object clien
 			return nil
 		},
 		retry.Delay(PollingTime*time.Second),
-		retry.Attempts(RetryTimeoutClient),
+		retry.Attempts(RetryTimeout),
 		retry.DelayType(retry.FixedDelay),
 	)
 	return err

--- a/tests/utils/environment.go
+++ b/tests/utils/environment.go
@@ -53,8 +53,11 @@ import (
 )
 
 const (
-	// RetryTimeout retry time when client api call or kubectl cli request get failed
-	RetryTimeout = 60
+	// RetryTimeoutClient retry time when client api call or kubectl cli request get failed
+	RetryTimeoutClient = 60
+	// RetryTimeoutCommand retry time out when command fails
+	RetryTimeoutCommand = 5
+
 	// PollingTime polling between retry
 	PollingTime = 5
 )
@@ -112,7 +115,7 @@ func (env TestingEnvironment) EventuallyExecCommand(
 			return err
 		}
 		return nil
-	}, RetryTimeout, PollingTime).Should(BeNil())
+	}, RetryTimeoutClient, PollingTime).Should(BeNil())
 	return stdOut, stdErr, err
 }
 

--- a/tests/utils/environment.go
+++ b/tests/utils/environment.go
@@ -53,12 +53,11 @@ import (
 )
 
 const (
-	// RetryTimeoutClient retry time when client api call or kubectl cli request get failed
-	RetryTimeoutClient = 60
-	// RetryTimeoutCommand retry time out when command fails
-	RetryTimeoutCommand = 5
-
-	// PollingTime polling between retry
+	// RetryTimeout retry timeout (in seconds) when a client api call or kubectl cli request get failed
+	RetryTimeout = 60
+	// RetryAttempts maximum number of attempts when it fails in `retry`. Mainly used in `RunUncheckedRetry`
+	RetryAttempts = 5
+	// PollingTime polling interval (in seconds) between retries
 	PollingTime = 5
 )
 
@@ -115,7 +114,7 @@ func (env TestingEnvironment) EventuallyExecCommand(
 			return err
 		}
 		return nil
-	}, RetryTimeoutClient, PollingTime).Should(BeNil())
+	}, RetryTimeout, PollingTime).Should(BeNil())
 	return stdOut, stdErr, err
 }
 

--- a/tests/utils/run.go
+++ b/tests/utils/run.go
@@ -65,7 +65,7 @@ func RunUncheckedRetry(command string) (stdout string, stderr string, err error)
 			return nil
 		},
 		retry.Delay(PollingTime*time.Second),
-		retry.Attempts(RetryTimeout),
+		retry.Attempts(RetryTimeoutCommand),
 		retry.DelayType(retry.FixedDelay),
 	)
 	stdout = outBuffer.String()

--- a/tests/utils/run.go
+++ b/tests/utils/run.go
@@ -65,7 +65,7 @@ func RunUncheckedRetry(command string) (stdout string, stderr string, err error)
 			return nil
 		},
 		retry.Delay(PollingTime*time.Second),
-		retry.Attempts(RetryTimeoutCommand),
+		retry.Attempts(RetryAttempts),
 		retry.DelayType(retry.FixedDelay),
 	)
 	stdout = outBuffer.String()


### PR DESCRIPTION
Before we were having only one `RetryTimeout` for the API calls and for
the commands execution, nonetheless, we need a different value for commands
since these can fail quicker and API calls.

This will fix any test that was waiting one minutes before even start a
retry.

Closes #580

Signed-off-by: Jonathan Gonzalez V <jonathan.gonzalez@enterprisedb.com>