### PR TITLE
Improve compatibility with go 1.19

### DIFF
--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -991,9 +991,10 @@ type StorageConfiguration struct {
 
 // SyncReplicaElectionConstraints contains the constraints for sync replicas election.
 //
-// For anti-affinity parameters two instances are considered in the same location if all the labels values match
+// For anti-affinity parameters two instances are considered in the same location
+// if all the labels values match.
 //
-// In future synchronous replica election restriction by name will be supported
+// In future synchronous replica election restriction by name will be supported.
 type SyncReplicaElectionConstraints struct {
 	// This flag enabled the constraints for sync replicas
 	Enabled bool `json:"enabled"`

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -1096,8 +1096,8 @@ func (r *ClusterReconciler) markPVCReadyForCompletedJobs(
 }
 
 // TODO: only required to cleanup custom monitoring queries configmaps from older versions (v1.10 and v1.11)
-// 		 that could have been copied with the source configmap name instead of the new default one.
-// 		 Should be removed in future releases.
+// that could have been copied with the source configmap name instead of the new default one.
+// Should be removed in future releases.
 func (r *ClusterReconciler) deleteOldCustomQueriesConfigmap(ctx context.Context, cluster *apiv1.Cluster) {
 	contextLogger := log.FromContext(ctx)
 

--- a/controllers/cluster_status.go
+++ b/controllers/cluster_status.go
@@ -21,7 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"reflect"
@@ -891,7 +891,7 @@ func rawInstanceStatusRequest(
 		}
 	}()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		result.Error = err
 		return result

--- a/controllers/cluster_upgrade.go
+++ b/controllers/cluster_upgrade.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	neturl "net/url"
 
@@ -486,7 +485,7 @@ func upgradeInstanceManagerOnPod(ctx context.Context, pod v1.Pod) error {
 	}
 
 	var body []byte
-	body, err = ioutil.ReadAll(resp.Body)
+	body, err = io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}

--- a/controllers/pooler_update.go
+++ b/controllers/pooler_update.go
@@ -55,8 +55,9 @@ func (r *PoolerReconciler) updateOwnedObjects(
 	return r.updateService(ctx, pooler, resources)
 }
 
-//nolint:dupl
 // updateDeployment update the deployment or create it when needed
+//
+//nolint:dupl
 func (r *PoolerReconciler) updateDeployment(
 	ctx context.Context,
 	pooler *apiv1.Pooler,
@@ -116,8 +117,9 @@ func (r *PoolerReconciler) updateDeployment(
 	return nil
 }
 
-//nolint:dupl
 // updateService update or create the pgbouncer service as needed
+//
+//nolint:dupl
 func (r *PoolerReconciler) updateService(
 	ctx context.Context,
 	pooler *apiv1.Pooler,
@@ -191,8 +193,8 @@ func (r *PoolerReconciler) updateRBAC(
 // updateServiceAccount update or create the pgbouncer ServiceAccount
 // The goal of this method is to make sure that:
 //
-//   * the ServiceAccount exits
-//   * it contains the ImagePullSecret if required
+//   - the ServiceAccount exits
+//   - it contains the ImagePullSecret if required
 //
 // Any other property of the ServiceAccount is preserved
 func (r *PoolerReconciler) updateServiceAccount(

--- a/docs/src/api_reference.md
+++ b/docs/src/api_reference.md
@@ -930,9 +930,9 @@ Name               | Description                                                
 
 SyncReplicaElectionConstraints contains the constraints for sync replicas election.
 
-For anti-affinity parameters two instances are considered in the same location if all the labels values match
+For anti-affinity parameters two instances are considered in the same location if all the labels values match.
 
-In future synchronous replica election restriction by name will be supported
+In future synchronous replica election restriction by name will be supported.
 
 Name                   | Description                                                                                                    | Type    
 ---------------------- | -------------------------------------------------------------------------------------------------------------- | --------

--- a/internal/cmd/manager/backup/cmd.go
+++ b/internal/cmd/manager/backup/cmd.go
@@ -19,7 +19,7 @@ package backup
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 
@@ -51,7 +51,7 @@ func NewCmd() *cobra.Command {
 				}
 			}()
 
-			body, err := ioutil.ReadAll(resp.Body)
+			body, err := io.ReadAll(resp.Body)
 			if err != nil {
 				log.Error(err, "Error while reading backup response body",
 					"backupURL", backupURL,

--- a/internal/cmd/manager/instance/run/lifecycle/reaper.go
+++ b/internal/cmd/manager/instance/run/lifecycle/reaper.go
@@ -36,9 +36,8 @@ import (
 // We are running as PID 1 in our container and we may receive SIGCHLD for
 // the following reasons:
 //
-// 1 - a child process we manually executed via `exec.Cmd` (i.e. the postmaster)
-//     exited
-// 2 - an postmaster worker process terminated after the postmaster itself
+// 1 - a child process we manually executed via `exec.Cmd` (i.e. the postmaster) exited
+// 2 - a postmaster worker process terminated after the postmaster itself
 //
 // The second condition may seem unlikely but it unfortunately happens everytime
 // the postmaster ends, even if just for the logging collector subprocess.

--- a/internal/cmd/manager/instance/status/cmd.go
+++ b/internal/cmd/manager/instance/status/cmd.go
@@ -19,7 +19,7 @@ package status
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 
@@ -59,7 +59,7 @@ func statusSubCommand() error {
 		}
 	}()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		log.Error(err, "Error while reading status response body",
 			"statusURL", statusURL,

--- a/internal/cmd/plugin/report/cluster_report.go
+++ b/internal/cmd/plugin/report/cluster_report.go
@@ -72,11 +72,11 @@ func (cr clusterReport) writeToZip(zipper *zip.Writer, format plugin.OutputForma
 
 // cluster implements the "report cluster" subcommand
 // Produces a zip file containing
-//  - cluster pod and job definitions
-//  - cluster resource (same content as `kubectl get cluster -o yaml`)
-//  - events in the cluster namespace
-//  - logs from the cluster pods (optional - activated with `includeLogs`)
-//  - logs from the cluster jobs (optional - activated with `includeLogs`)
+//   - cluster pod and job definitions
+//   - cluster resource (same content as `kubectl get cluster -o yaml`)
+//   - events in the cluster namespace
+//   - logs from the cluster pods (optional - activated with `includeLogs`)
+//   - logs from the cluster jobs (optional - activated with `includeLogs`)
 func cluster(ctx context.Context, clusterName, namespace string, format plugin.OutputFormat,
 	file string, includeLogs bool, timestamp time.Time,
 ) error {

--- a/internal/cmd/plugin/report/operator_report.go
+++ b/internal/cmd/plugin/report/operator_report.go
@@ -85,12 +85,12 @@ func (or operatorReport) writeToZip(zipper *zip.Writer, format plugin.OutputForm
 
 // operator implements the "report operator" subcommand
 // Produces a zip file containing
-//  - operator deployment
-//  - operator pod definition
-//  - operator configuration Configmap and Secret key (if any)
-//  - events in the operator namespace
-//  - operator's Validating/MutatingWebhookConfiguration and their associated services
-//  - operator pod's logs (if `includeLogs` is true)
+//   - operator deployment
+//   - operator pod definition
+//   - operator configuration Configmap and Secret key (if any)
+//   - events in the operator namespace
+//   - operator's Validating/MutatingWebhookConfiguration and their associated services
+//   - operator pod's logs (if `includeLogs` is true)
 func operator(ctx context.Context, format plugin.OutputFormat,
 	file string, stopRedaction, includeLogs bool, now time.Time,
 ) error {

--- a/internal/cmd/plugin/report/output.go
+++ b/internal/cmd/plugin/report/output.go
@@ -41,8 +41,8 @@ func reportName(kind string, timestamp time.Time, objName ...string) string {
 type zipFileWriter func(zipper *zip.Writer, dirname string) error
 
 // writerZippedReport writes a zip with the various report parts to file s
-//  - file: the name of the zip file
-//  - folder: the top-level folder created in the zip to contain all sections
+//   - file: the name of the zip file
+//   - folder: the top-level folder created in the zip to contain all sections
 func writeZippedReport(sections []zipFileWriter, file, folder string) (err error) {
 	if exists, _ := fileutils.FileExists(file); exists {
 		return fmt.Errorf("file already exist will not overwrite")

--- a/internal/management/cache/client/client.go
+++ b/internal/management/cache/client/client.go
@@ -20,7 +20,7 @@ package client
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"k8s.io/client-go/util/retry"
@@ -92,7 +92,7 @@ func get(urlPath string) ([]byte, error) {
 		return nil, cache.ErrCacheMiss
 	}
 
-	bytes, err := ioutil.ReadAll(resp.Body)
+	bytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/management/controller/instance_controller.go
+++ b/internal/management/controller/instance_controller.go
@@ -70,6 +70,7 @@ type shoudRequeue bool
 
 // Reconcile is the main reconciliation loop for the instance
 // TODO this function needs to be refactor
+//
 //nolint:gocognit
 func (r *InstanceReconciler) Reconcile(
 	ctx context.Context,
@@ -774,16 +775,16 @@ func (r *InstanceReconciler) reconcileMonitoringQueries(
 // user cannot easily tell if the operation has been done completely.
 // The rationale behind this is:
 //
-// 1. when invoked at the startup of the instance manager, PostgreSQL
-//    is not up. If this raise an error, then PostgreSQL won't
-//    be able to start correctly (TLS certs are missing, i.e.),
-//    making no difference between returning an error or not
+//  1. when invoked at the startup of the instance manager, PostgreSQL
+//     is not up. If this raise an error, then PostgreSQL won't
+//     be able to start correctly (TLS certs are missing, i.e.),
+//     making no difference between returning an error or not
 //
-// 2. when invoked inside the reconciliation loop, if the operation
-//    raise an error, it's pointless to retry. The only way to recover
-//    from such an error is wait for the CNPG operator to refresh the
-//    resource version of the secrets to be used, and in that case a
-//    reconciliation loop will be started again.
+//  2. when invoked inside the reconciliation loop, if the operation
+//     raise an error, it's pointless to retry. The only way to recover
+//     from such an error is wait for the CNPG operator to refresh the
+//     resource version of the secrets to be used, and in that case a
+//     reconciliation loop will be started again.
 func (r *InstanceReconciler) RefreshSecrets(
 	ctx context.Context,
 	cluster *apiv1.Cluster,

--- a/pkg/certs/k8s_test.go
+++ b/pkg/certs/k8s_test.go
@@ -18,7 +18,6 @@ package certs
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"time"
 
@@ -306,7 +305,7 @@ var _ = Describe("TLS certificates injection", func() {
 
 var _ = Describe("Webhook environment creation", func() {
 	It("should setup the certificates and the webhooks", func() {
-		tempDirName, err := ioutil.TempDir("/tmp", "cert_*")
+		tempDirName, err := os.MkdirTemp("/tmp", "cert_*")
 		Expect(err).To(BeNil())
 		defer func() {
 			err = os.RemoveAll(tempDirName)

--- a/pkg/configfile/configfile_test.go
+++ b/pkg/configfile/configfile_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package configfile
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -32,7 +31,7 @@ var _ = Describe("update Postgres configuration files", func() {
 
 	_ = BeforeEach(func() {
 		var err error
-		tmpDir, err = ioutil.TempDir("", "configuration-test-")
+		tmpDir, err = os.MkdirTemp("", "configuration-test-")
 		Expect(err).NotTo(HaveOccurred())
 	})
 

--- a/pkg/configparser/configparser.go
+++ b/pkg/configparser/configparser.go
@@ -18,10 +18,10 @@ limitations under the License.
 Package configparser contains the code required to fill a Go structure
 representing the configuration information from several sources like:
 
-1. a struct containing the default values
-2. a map from string to strings (e.g. the one that can be extracted for a Kubernetes ConfigMap)
-3. an environment source like the system environment variables or a "fake"
-   one suitable for testing.
+ 1. a struct containing the default values
+ 2. a map from string to strings (e.g. the one that can be extracted for a Kubernetes ConfigMap)
+ 3. an environment source like the system environment variables or a "fake"
+    one suitable for testing.
 
 To map the struct fields with the sources, the "env" tag is being
 used like in the following example:

--- a/pkg/fileutils/fileutils.go
+++ b/pkg/fileutils/fileutils.go
@@ -23,7 +23,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -130,7 +129,7 @@ func WriteFileAtomic(fileName string, contents []byte, perm os.FileMode) (bool, 
 	}
 	if exist {
 		var previousContents []byte
-		previousContents, err = ioutil.ReadFile(fileName) // #nosec
+		previousContents, err = os.ReadFile(fileName) // #nosec
 		if err != nil {
 			err = fmt.Errorf("while reading previous file contents: %w", err)
 			return false, err
@@ -188,7 +187,7 @@ func ReadFile(fileName string) ([]byte, error) {
 		return nil, nil
 	}
 
-	content, err := ioutil.ReadFile(fileName) // #nosec
+	content, err := os.ReadFile(fileName) // #nosec
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/fileutils/fileutils_test.go
+++ b/pkg/fileutils/fileutils_test.go
@@ -18,7 +18,7 @@ package fileutils
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path"
 	"path/filepath"
 
@@ -136,7 +136,7 @@ var _ = Describe("function GetDirectoryContent", func() {
 		for i := 0; i < 10; i++ {
 			testFiles[i] = fmt.Sprintf("test_file_%v", i)
 			file := filepath.Join(tempDir3, testFiles[i])
-			err := ioutil.WriteFile(file, []byte("fake_content"), 0o400)
+			err := os.WriteFile(file, []byte("fake_content"), 0o400)
 			Expect(err).ShouldNot(HaveOccurred())
 		}
 		files, err := GetDirectoryContent(tempDir3)

--- a/pkg/fileutils/suite_test.go
+++ b/pkg/fileutils/suite_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package fileutils
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -38,11 +37,11 @@ func TestConfigFile(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	var err error
-	tempDir1, err = ioutil.TempDir(os.TempDir(), "fileutils1_")
+	tempDir1, err = os.MkdirTemp(os.TempDir(), "fileutils1_")
 	Expect(err).To(BeNil())
-	tempDir2, err = ioutil.TempDir(os.TempDir(), "fileutils2_")
+	tempDir2, err = os.MkdirTemp(os.TempDir(), "fileutils2_")
 	Expect(err).To(BeNil())
-	tempDir3, err = ioutil.TempDir(os.TempDir(), "fileutils3_")
+	tempDir3, err = os.MkdirTemp(os.TempDir(), "fileutils3_")
 	Expect(err).To(BeNil())
 })
 

--- a/pkg/management/barman/spool/spool_test.go
+++ b/pkg/management/barman/spool/spool_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package spool
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 
@@ -34,10 +33,10 @@ var _ = Describe("Spool", func() {
 
 	_ = BeforeEach(func() {
 		var err error
-		tmpDir, err = ioutil.TempDir("", "spool-test-")
+		tmpDir, err = os.MkdirTemp("", "spool-test-")
 		Expect(err).NotTo(HaveOccurred())
 
-		tmpDir2, err = ioutil.TempDir("", "spool-test-tmp-")
+		tmpDir2, err = os.MkdirTemp("", "spool-test-tmp-")
 		Expect(err).NotTo(HaveOccurred())
 
 		spool, err = New(tmpDir)

--- a/pkg/management/postgres/instance_test.go
+++ b/pkg/management/postgres/instance_test.go
@@ -18,7 +18,6 @@ package postgres
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -30,7 +29,7 @@ import (
 )
 
 var _ = Describe("testing primary instance methods", Ordered, func() {
-	tempDir, err := ioutil.TempDir("", "primary")
+	tempDir, err := os.MkdirTemp("", "primary")
 	Expect(err).ToNot(HaveOccurred())
 
 	instance := Instance{
@@ -138,7 +137,7 @@ var _ = Describe("testing primary instance methods", Ordered, func() {
 })
 
 var _ = Describe("testing replica instance methods", Ordered, func() {
-	tempDir, err := ioutil.TempDir("", "primary")
+	tempDir, err := os.MkdirTemp("", "primary")
 	Expect(err).ToNot(HaveOccurred())
 
 	instance := Instance{

--- a/pkg/management/postgres/logpipe/linelogpipe.go
+++ b/pkg/management/postgres/logpipe/linelogpipe.go
@@ -90,6 +90,7 @@ func NewRawLineLogPipe(fileName, name string) *LineLogPipe {
 // from a process logging raw strings to a file and redirecting its content to stdout in JSON format.
 // The goroutine is started just once for a given file.
 // All successive calls, that are referencing the same filename, will just check its existence
+//
 //nolint:dupl
 func (p *LineLogPipe) Start(ctx context.Context) error {
 	filenameLog := log.FromContext(ctx).WithValues("fileName", p.fileName)

--- a/pkg/management/postgres/logpipe/logpipe.go
+++ b/pkg/management/postgres/logpipe/logpipe.go
@@ -80,6 +80,7 @@ func (p *LogPipe) GetExitedCondition() *concurrency.Executed {
 // from a process logging in CSV to a file and redirecting its content to stdout in JSON format.
 // The goroutine is started just once for a given file.
 // All successive calls, that are referencing the same filename, will just check its existence
+//
 //nolint:dupl
 func (p *LogPipe) Start(ctx context.Context) error {
 	filenameLog := log.FromContext(ctx).WithValues("fileName", p.fileName)

--- a/pkg/management/postgres/logpipe/logpipe_test.go
+++ b/pkg/management/postgres/logpipe/logpipe_test.go
@@ -19,7 +19,6 @@ package logpipe
 import (
 	"context"
 	"errors"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -107,7 +106,7 @@ var _ = Describe("CSV file reader", func() {
 		})
 
 		When("correctly handles a record with an invalid number of fields", func() {
-			inputBuffer, err := ioutil.ReadFile("testdata/one_line.csv")
+			inputBuffer, err := os.ReadFile("testdata/one_line.csv")
 			Expect(err).ShouldNot(HaveOccurred())
 			input := strings.TrimRight(string(inputBuffer), " \n")
 

--- a/pkg/management/postgres/pidfile_test.go
+++ b/pkg/management/postgres/pidfile_test.go
@@ -18,7 +18,6 @@ package postgres
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -36,9 +35,9 @@ var _ = Describe("the detection of a postmaster process using the pid file", fun
 
 	_ = BeforeEach(func() {
 		var err error
-		pgdata, err = ioutil.TempDir("", "cleanup-stale-pid-file-pgdata-")
+		pgdata, err = os.MkdirTemp("", "cleanup-stale-pid-file-pgdata-")
 		Expect(err).NotTo(HaveOccurred())
-		socketDir, err = ioutil.TempDir("", "cleanup-stale-pid-file-socketdir-")
+		socketDir, err = os.MkdirTemp("", "cleanup-stale-pid-file-socketdir-")
 		Expect(err).NotTo(HaveOccurred())
 	})
 
@@ -62,11 +61,11 @@ var _ = Describe("the detection of a postmaster process using the pid file", fun
 		instance.SocketDirectory = socketDir
 
 		pidFile := filepath.Join(pgdata, PostgresqlPidFile)
-		err := ioutil.WriteFile(pidFile, []byte("1234"), 0o400)
+		err := os.WriteFile(pidFile, []byte("1234"), 0o400)
 		Expect(err).ShouldNot(HaveOccurred())
 
 		lockFile := filepath.Join(socketDir, PostgresqlPidFile)
-		err = ioutil.WriteFile(filepath.Join(socketDir, ".s.PGSQL.5432.lock"), []byte("1234"), 0o400)
+		err = os.WriteFile(filepath.Join(socketDir, ".s.PGSQL.5432.lock"), []byte("1234"), 0o400)
 		Expect(err).ShouldNot(HaveOccurred())
 
 		process, err := instance.CheckForExistingPostmaster(postgresName)
@@ -87,7 +86,7 @@ var _ = Describe("the detection of a postmaster process using the pid file", fun
 		instance := NewInstance()
 		instance.PgData = pgdata
 		instance.SocketDirectory = socketDir
-		err := ioutil.WriteFile(
+		err := os.WriteFile(
 			filepath.Join(pgdata, PostgresqlPidFile),
 			[]byte(fmt.Sprintf("%v", myPid)), 0o400)
 		Expect(err).ShouldNot(HaveOccurred())

--- a/pkg/management/postgres/restore.go
+++ b/pkg/management/postgres/restore.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"io/ioutil"
 	"math"
 	"os"
 	"os/exec"
@@ -423,7 +422,7 @@ func (info InitInfo) writeRestoreWalConfig(backup *apiv1.Backup, cluster *apiv1.
 			return fmt.Errorf("cannot write recovery config: %w", err)
 		}
 
-		err = ioutil.WriteFile(
+		err = os.WriteFile(
 			path.Join(info.PgData, "postgresql.auto.conf"),
 			[]byte(""),
 			0o600)
@@ -432,14 +431,14 @@ func (info InitInfo) writeRestoreWalConfig(backup *apiv1.Backup, cluster *apiv1.
 		}
 
 		// Create recovery signal file
-		return ioutil.WriteFile(
+		return os.WriteFile(
 			path.Join(info.PgData, "recovery.signal"),
 			[]byte(""),
 			0o600)
 	}
 
 	// We need to generate a recovery.conf
-	return ioutil.WriteFile(
+	return os.WriteFile(
 		path.Join(info.PgData, "recovery.conf"),
 		[]byte(recoveryFileContents),
 		0o600)
@@ -486,7 +485,7 @@ func (info InitInfo) WriteInitialPostgresqlConf(cluster *apiv1.Cluster) error {
 		return err
 	}
 
-	tempDataDir, err := ioutil.TempDir(postgresSpec.RecoveryTemporaryDirectory, "datadir_")
+	tempDataDir, err := os.MkdirTemp(postgresSpec.RecoveryTemporaryDirectory, "datadir_")
 	if err != nil {
 		return fmt.Errorf("while creating a temporary data directory: %w", err)
 	}

--- a/pkg/management/postgres/restore_test.go
+++ b/pkg/management/postgres/restore_test.go
@@ -18,7 +18,6 @@ package postgres
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path"
 
@@ -32,7 +31,7 @@ import (
 )
 
 var _ = Describe("testing restore InitInfo methods", func() {
-	tempDir, err := ioutil.TempDir("", "restore")
+	tempDir, err := os.MkdirTemp("", "restore")
 	Expect(err).ToNot(HaveOccurred())
 
 	pgData := path.Join(tempDir, "postgres", "data", "pgdata")

--- a/pkg/management/postgres/utils/version.go
+++ b/pkg/management/postgres/utils/version.go
@@ -18,7 +18,7 @@ package utils
 
 import (
 	"database/sql"
-	"io/ioutil"
+	"os"
 	"path"
 	"strconv"
 	"strings"
@@ -53,7 +53,7 @@ func parseVersionNum(versionNum string) (*semver.Version, error) {
 // GetMajorVersion read the PG_VERSION file in the data directory
 // returning the major version of the database
 func GetMajorVersion(pgData string) (int, error) {
-	content, err := ioutil.ReadFile(path.Join(pgData, "PG_VERSION")) // #nosec
+	content, err := os.ReadFile(path.Join(pgData, "PG_VERSION")) // #nosec
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/postgres/configuration.go
+++ b/pkg/postgres/configuration.go
@@ -529,7 +529,7 @@ func CreatePostgresqlConfiguration(info ConfigurationInfo) *PgConfiguration {
 	return configuration
 }
 
-//  setDefaultConfigurations sets all default configurations into the configuration map
+// setDefaultConfigurations sets all default configurations into the configuration map
 // from the provided info
 func setDefaultConfigurations(info ConfigurationInfo, configuration *PgConfiguration) {
 	// start from the global default settings

--- a/pkg/postgres/version.go
+++ b/pkg/postgres/version.go
@@ -32,9 +32,9 @@ var semanticVersionRegex = regexp.MustCompile(`^(\d\.?)+`)
 // GetPostgresVersionFromTag parse a PostgreSQL version string returning
 // a major version ID. Example:
 //
-//     GetPostgresVersionFromTag("9.5.3") == 90503
-//     GetPostgresVersionFromTag("10.2") == 100002
-//     GetPostgresVersionFromTag("15beta1") == 150000
+//	GetPostgresVersionFromTag("9.5.3") == 90503
+//	GetPostgresVersionFromTag("10.2") == 100002
+//	GetPostgresVersionFromTag("15beta1") == 150000
 func GetPostgresVersionFromTag(version string) (int, error) {
 	if !semanticVersionRegex.MatchString(version) {
 		return 0,
@@ -102,8 +102,8 @@ func GetPostgresMajorVersionFromTag(version string) (int, error) {
 // GetPostgresMajorVersion gets only the Major version from a PostgreSQL version string.
 // Example:
 //
-//     GetPostgresMajorVersion("90503") == 90500
-//     GetPostgresMajorVersion("100002") == 100000
+//	GetPostgresMajorVersion("90503") == 90500
+//	GetPostgresMajorVersion("100002") == 100000
 func GetPostgresMajorVersion(parsedVersion int) int {
 	return parsedVersion - parsedVersion%100
 }

--- a/pkg/utils/hash/hash.go
+++ b/pkg/utils/hash/hash.go
@@ -21,8 +21,7 @@ limitations under the License.
 // The code in this package is adapted from:
 //
 // https://github.com/kubernetes/kubernetes/blob/master/pkg/util/hash/hash.go   // wokeignore:rule=master
-// https://github.com/kubernetes/kubernetes/blob/ea0764452222146c47ec826977f49d7001b0ea8c/
-//   pkg/controller/controller_utils.go#L1189
+// https://github.com/kubernetes/kubernetes/blob/ea07644/pkg/controller/controller_utils.go#L1189
 package hash
 
 import (

--- a/pkg/utils/imagename.go
+++ b/pkg/utils/imagename.go
@@ -80,9 +80,8 @@ func NewReference(name string) *Reference {
 // GetImageTag gets the image tag from a full image string.
 // Example:
 //
-//     GetImageTag("postgres") == "latest"
-//     GetImageTag("ghcr.io/cloudnative-pg/postgresql:12.3") == "12.3"
-//
+//	GetImageTag("postgres") == "latest"
+//	GetImageTag("ghcr.io/cloudnative-pg/postgresql:12.3") == "12.3"
 func GetImageTag(imageName string) string {
 	ref := NewReference(imageName)
 	return ref.Tag

--- a/pkg/utils/pod_conditions.go
+++ b/pkg/utils/pod_conditions.go
@@ -56,7 +56,7 @@ func IsPodReady(pod corev1.Pod) bool {
 }
 
 // IsPodActive checks if a pod is active, copied from:
-//nolint:lll // https://github.com/kubernetes/kubernetes/blob/1bd00776b5d78828a065b5c21e7003accc308a06/test/e2e/framework/pod/resource.go#L664
+// https://github.com/kubernetes/kubernetes/blob/1bd0077/test/e2e/framework/pod/resource.go#L664
 func IsPodActive(p corev1.Pod) bool {
 	return corev1.PodSucceeded != p.Status.Phase &&
 		corev1.PodPending != p.Status.Phase &&

--- a/tests/utils/environment.go
+++ b/tests/utils/environment.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -255,7 +254,7 @@ func (env TestingEnvironment) IsIBM() bool {
 
 // GetResourceNamespacedNameFromYAML returns the NamespacedName representing a resource in a YAML file
 func (env TestingEnvironment) GetResourceNamespacedNameFromYAML(path string) (types.NamespacedName, error) {
-	data, err := ioutil.ReadFile(filepath.Clean(path))
+	data, err := os.ReadFile(filepath.Clean(path))
 	if err != nil {
 		return types.NamespacedName{}, err
 	}

--- a/tests/utils/release.go
+++ b/tests/utils/release.go
@@ -19,7 +19,6 @@ package utils
 
 import (
 	"errors"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"sort"
@@ -56,7 +55,7 @@ func GetMostRecentReleaseTag(releasesPath string) (string, error) {
 // GetAvailableReleases retrieves all the available releases from
 // the list of YAML files in the top-level `releases/` directory.
 func GetAvailableReleases(releasesPath string) ([]*semver.Version, error) {
-	fileInfo, err := ioutil.ReadDir(releasesPath)
+	fileInfo, err := os.ReadDir(releasesPath)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This commit updates our code to use the new doc comments format
[introduced in 1.19](https://tip.golang.org/doc/go1.19#go-doc).

This patch also removes the use of [deprecated ioutils
package](https://github.com/go-critic/go-critic/issues/1019) that is
reported as an error in the latest golangci-lint version.

Closes #636 