### PR TITLE
Load additional libraries when initializing database

### DIFF
--- a/pkg/management/postgres/initdb.go
+++ b/pkg/management/postgres/initdb.go
@@ -27,7 +27,6 @@ import (
 	"os/exec"
 	"path"
 	"sort"
-	"strings"
 
 	"github.com/lib/pq"
 	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
@@ -41,7 +40,6 @@ import (
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres/constants"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres/logicalimport"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres/pool"
-	postgresutils "github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres/utils"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/postgres"
 )
 
@@ -322,17 +320,29 @@ func (info InitInfo) Bootstrap(ctx context.Context) error {
 
 	instance := info.GetInstance()
 
-	if libs := strings.Join(cluster.Spec.PostgresConfiguration.AdditionalLibraries, ","); libs != "" {
-		libsConfig := fmt.Sprintf("%s='%s'", postgres.SharedPreloadLibraries, libs)
+	postgresVersion, err := cluster.GetPostgresqlVersion()
+	if err != nil {
+		return fmt.Errorf("while reading the PostgreSQL version: %w", err)
+	}
+
+	configurationInfo := postgres.ConfigurationInfo{
+		Settings:                         postgres.CnpgConfigurationSettings,
+		MajorVersion:                     postgresVersion,
+		UserSettings:                     cluster.Spec.PostgresConfiguration.Parameters,
+		AdditionalSharedPreloadLibraries: cluster.Spec.PostgresConfiguration.AdditionalLibraries,
+		IsReplicaCluster:                 cluster.IsReplica(),
+		IncludingSharedPreloadLibraries:  true,
+		PreserveFixedSettingsFromUser:    true,
+	}
+	postgresConfiguration := postgres.CreatePostgresqlConfiguration(configurationInfo)
+
+	sharedPreloadLibraries := postgresConfiguration.GetConfigurationParameters()[postgres.SharedPreloadLibraries]
+	if sharedPreloadLibraries != "" {
+		libsConfig := fmt.Sprintf("%s='%s'", postgres.SharedPreloadLibraries, sharedPreloadLibraries)
 		instance.StartupOptions = append(instance.StartupOptions, libsConfig)
 	}
 
-	majorVersion, err := postgresutils.GetMajorVersion(instance.PgData)
-	if err != nil {
-		return fmt.Errorf("while reading major version: %w", err)
-	}
-
-	if majorVersion >= 12 {
+	if postgresVersion >= 120000 {
 		primaryConnInfo := buildPrimaryConnInfo(info.ClusterName, info.PodName)
 		_, err = configurePostgresAutoConfFile(info.PgData, primaryConnInfo)
 		if err != nil {

--- a/pkg/management/postgres/initdb.go
+++ b/pkg/management/postgres/initdb.go
@@ -27,6 +27,7 @@ import (
 	"os/exec"
 	"path"
 	"sort"
+	"strings"
 
 	"github.com/lib/pq"
 	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
@@ -41,6 +42,7 @@ import (
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres/logicalimport"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres/pool"
 	postgresutils "github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres/utils"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/postgres"
 )
 
 // InitInfo contains all the info needed to bootstrap a new PostgreSQL instance
@@ -319,6 +321,11 @@ func (info InitInfo) Bootstrap(ctx context.Context) error {
 	}
 
 	instance := info.GetInstance()
+
+	if libs := strings.Join(cluster.Spec.PostgresConfiguration.AdditionalLibraries, ","); libs != "" {
+		libsConfig := fmt.Sprintf("%s='%s'", postgres.SharedPreloadLibraries, libs)
+		instance.StartupOptions = append(instance.StartupOptions, libsConfig)
+	}
 
 	majorVersion, err := postgresutils.GetMajorVersion(instance.PgData)
 	if err != nil {

--- a/pkg/management/postgres/instance.go
+++ b/pkg/management/postgres/instance.go
@@ -295,7 +295,7 @@ func (instance *Instance) Startup() error {
 		options = append(options, "-o", "-c "+opt)
 	}
 
-	log.Info("Starting up instance", "pgdata", instance.PgData)
+	log.Info("Starting up instance", "pgdata", instance.PgData, "options", options)
 
 	pgCtlCmd := exec.Command(pgCtlName, options...) // #nosec
 	pgCtlCmd.Env = instance.Env


### PR DESCRIPTION
This change makes `postInit*SQL` run on a instance with loaded additional libraries, which comes handy for `CREATE EXTENSION`  commands which can use features provided by additional libs.

Fixes: https://github.com/cloudnative-pg/cloudnative-pg/issues/649