### PR TITLE
chore: load helper images during cluster creation

### DIFF
--- a/hack/setup-cluster.sh
+++ b/hack/setup-cluster.sh
@@ -56,12 +56,12 @@ registry_name=registry.dev
 # HELPER_IMGS variable in the local container registry.
 # #########################################################################
 POSTGRES_IMG=${POSTGRES_IMG:-$(grep 'DefaultImageName.*=' "${ROOT_DIR}/pkg/versions/versions.go" | cut -f 2 -d \")}
-POSTGRES_UPDATE_IMG=${POSTGRES_UPDATE_IMG:-${POSTGRES_IMG%.*}}
+E2E_PRE_ROLLING_UPDATE_IMG=${E2E_PRE_ROLLING_UPDATE_IMG:-${POSTGRES_IMG%.*}}
 PGBOUNCER_IMG=${PGBOUNCER_IMG:-$(grep 'DefaultPgbouncerImage.*=' "${ROOT_DIR}/pkg/specs/pgbouncer/deployments.go" | cut -f 2 -d \")}
 MINIO_IMG=${MINIO_IMG:-$(grep 'minioImage.*=' "${ROOT_DIR}/tests/utils/minio.go"  | cut -f 2 -d \")}
 APACHE_IMG=${APACHE_IMG:-"httpd"}
 
-HELPER_IMGS=("$POSTGRES_IMG" "$POSTGRES_UPDATE_IMG" "$PGBOUNCER_IMG" "$MINIO_IMG" "$APACHE_IMG")
+HELPER_IMGS=("$POSTGRES_IMG" "$E2E_PRE_ROLLING_UPDATE_IMG" "$PGBOUNCER_IMG" "$MINIO_IMG" "$APACHE_IMG")
 # #########################################################################
 
 # Colors (only if using a terminal)
@@ -460,7 +460,22 @@ create() {
 
   deploy_fluentd
 
+  load_helper_images
+
   echo "${bright}Done creating ${ENGINE} cluster ${CLUSTER_NAME} with version ${K8S_VERSION}${reset}"
+}
+
+load_helper_images() {
+  echo "${bright}Loading helper images for tests on cluster ${CLUSTER_NAME}${reset}"
+
+  # Here we pre-load all the images defined in the HELPER_IMGS variable
+  # with the goal to speed up the runs.
+  for IMG in "${HELPER_IMGS[@]}"; do
+    docker pull "${IMG}"
+    "load_image_${ENGINE}" "${CLUSTER_NAME}" "${IMG}"
+  done
+
+  echo "${bright}Done loading helper images on cluster ${CLUSTER_NAME}${reset}"
 }
 
 load() {
@@ -478,17 +493,6 @@ load() {
   load_image "${CLUSTER_NAME}" "${CONTROLLER_IMG}"
 
   echo "${bright}Done loading new operator image on cluster ${CLUSTER_NAME}${reset}"
-
-  echo "${bright}Loading helper images for tests on cluster ${CLUSTER_NAME}${reset}"
-
-  # Here we pre-load all the images defined in the HELPER_IMGS variable
-  # with the goal to speed up the runs.
-  for IMG in "${HELPER_IMGS[@]}"; do
-    docker pull "${IMG}"
-    "load_image_${ENGINE}" "${CLUSTER_NAME}" "${IMG}"
-  done
-
-  echo "${bright}Done loading helper images on cluster ${CLUSTER_NAME}${reset}"
 }
 
 deploy() {


### PR DESCRIPTION
We were creating loading the helper images only when running in a local
run, this wasn't considering when running in the E2E tests, this will
fix that by loading the helper images during the cluster creation.

Closes #652

Signed-off-by: Jonathan Gonzalez V <jonathan.gonzalez@enterprisedb.com>