### PR TITLE
tests: Add E2E for replication slots

### DIFF
--- a/tests/e2e/asserts_test.go
+++ b/tests/e2e/asserts_test.go
@@ -2476,18 +2476,10 @@ func AssertPvcHasLabels(
 // and that only the required slots exist in the target pod.
 func AssertRepSlotsOnPod(
 	namespace,
-	clusterName,
-	podName string,
+	clusterName string,
+	pod corev1.Pod,
 ) {
-	namespacedName := types.NamespacedName{
-		Namespace: namespace,
-		Name:      podName,
-	}
-	targetPod := &corev1.Pod{}
-	err := env.Client.Get(env.Ctx, namespacedName, targetPod)
-	Expect(err).ToNot(HaveOccurred())
-
-	expectedSlots, err := testsUtils.GetExpectedRepSlotsOnPod(namespace, clusterName, podName, env)
+	expectedSlots, err := testsUtils.GetExpectedRepSlotsOnPod(namespace, clusterName, pod.GetName(), env)
 	Expect(err).ToNot(HaveOccurred())
 
 	for _, slot := range expectedSlots {
@@ -2495,21 +2487,21 @@ func AssertRepSlotsOnPod(
 			"SELECT EXISTS (SELECT 1 FROM pg_replication_slots "+
 				"WHERE slot_name = '%v' "+
 				"AND temporary = 'f' AND slot_type = 'physical')", slot)
-		if specs.IsPodPrimary(*targetPod) {
+		if specs.IsPodPrimary(pod) {
 			query = fmt.Sprintf(
 				"SELECT EXISTS (SELECT 1 FROM pg_replication_slots "+
 					"WHERE slot_name = '%v' AND active = 't' "+
 					"AND temporary = 'f' AND slot_type = 'physical')", slot)
 		}
 		Eventually(func() (string, error) {
-			stdout, _, err := testsUtils.RunQueryFromPod(targetPod, testsUtils.PGLocalSocketDir,
+			stdout, _, err := testsUtils.RunQueryFromPod(&pod, testsUtils.PGLocalSocketDir,
 				"app", "postgres", "''", query, env)
 			return strings.TrimSpace(stdout), err
 		}, RetryTimeout).Should(BeEquivalentTo("t"))
 	}
 
 	Eventually(func() ([]string, error) {
-		currentSlots, err := testsUtils.GetRepSlotsOnPod(namespace, podName, env)
+		currentSlots, err := testsUtils.GetRepSlotsOnPod(namespace, pod.GetName(), env)
 		return currentSlots, err
 	}, RetryTimeout).Should(BeEquivalentTo(expectedSlots))
 }
@@ -2525,7 +2517,7 @@ func AssertClusterRepSlotsAligned(
 	Eventually(func() bool {
 		var lsnList []string
 		for _, pod := range podList.Items {
-			out, err := testsUtils.GetRepSlotsLsnOnPod(namespace, clusterName, pod.Name, env)
+			out, err := testsUtils.GetRepSlotsLsnOnPod(namespace, clusterName, pod, env)
 			Expect(err).ToNot(HaveOccurred())
 			lsnList = append(lsnList, out...)
 		}

--- a/tests/e2e/fixtures/replication_slot/cluster-pg-replication-slot.yaml.template
+++ b/tests/e2e/fixtures/replication_slot/cluster-pg-replication-slot.yaml.template
@@ -1,0 +1,32 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: cluster-pg-replication-slot
+spec:
+  instances: 3
+
+  postgresql:
+    parameters:
+      log_checkpoints: "on"
+      log_lock_waits: "on"
+      log_min_duration_statement: '1000'
+      log_statement: 'ddl'
+      log_temp_files: '1024'
+      log_autovacuum_min_duration: '1s'
+      log_replication_commands: 'on'
+
+  replicationSlots:
+    updateInterval: 15
+    highAvailability:
+      enabled: true
+      slotPrefix: _cnpg_
+
+  bootstrap:
+    initdb:
+      database: app
+      owner: app
+
+  # Persistent storage configuration
+  storage:
+    storageClass: ${E2E_DEFAULT_STORAGE_CLASS}
+    size: 1Gi

--- a/tests/e2e/replication_slot_test.go
+++ b/tests/e2e/replication_slot_test.go
@@ -1,0 +1,103 @@
+/*
+Copyright The CloudNativePG Contributors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+
+	testsUtils "github.com/cloudnative-pg/cloudnative-pg/tests/utils"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/cloudnative-pg/cloudnative-pg/tests"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = FDescribe("Replication Slot", func() {
+	const (
+		namespace   = "replication-slot-e2e"
+		sampleFile  = fixturesDir + "/replication_slot/cluster-pg-replication-slot.yaml.template"
+		clusterName = "cluster-pg-replication-slot"
+		level       = tests.High
+	)
+	BeforeEach(func() {
+		if testLevelEnv.Depth < int(level) {
+			Skip("Test depth is lower than the amount requested for this test")
+		}
+	})
+	JustAfterEach(func() {
+		if CurrentSpecReport().Failed() {
+			env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
+		}
+	})
+	AfterEach(func() {
+		err := env.DeleteNamespace(namespace)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("manage Replication slots for HA", func() {
+		// Create a cluster in a namespace we'll delete after the test
+		err := env.CreateNamespace(namespace)
+		Expect(err).ToNot(HaveOccurred())
+		AssertCreateCluster(namespace, clusterName, sampleFile, env)
+
+		// Gather the current primary
+		oldPrimaryPod, err := env.GetClusterPrimary(namespace, clusterName)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Checking Primary HA Slots exist and are active", func() {
+			AssertRepSlotsOnPod(namespace, clusterName, oldPrimaryPod.Name)
+		})
+		By("Checking Standbys HA Slots exist", func() {
+			replicaPods, err := env.GetClusterReplicas(namespace, clusterName)
+			Expect(len(replicaPods.Items), err).To(BeEquivalentTo(2))
+			for _, pod := range replicaPods.Items {
+				AssertRepSlotsOnPod(namespace, clusterName, pod.Name)
+			}
+		})
+		By("Checking all the slots restart_lsn's are aligned", func() {
+			AssertClusterRepSlotsAligned(namespace, clusterName)
+		})
+		By("Creating test data to advance streaming replication", func() {
+			tableName := "data"
+			AssertCreateTestData(namespace, clusterName, tableName)
+			// Generate some WAL load
+			query := fmt.Sprintf("INSERT INTO %v (SELECT generate_series(1,10000))",
+				tableName)
+			_, _, err = testsUtils.RunQueryFromPod(oldPrimaryPod, testsUtils.PGLocalSocketDir,
+				"app", "postgres", "''", query, env)
+			Expect(err).ToNot(HaveOccurred())
+			_ = switchWalAndGetLatestArchive(namespace, oldPrimaryPod.Name)
+		})
+		By("Deleting the primary pod", func() {
+			zero := int64(0)
+			timeout := 120
+			forceDelete := &ctrlclient.DeleteOptions{
+				GracePeriodSeconds: &zero,
+			}
+			err = env.DeletePod(namespace, oldPrimaryPod.Name, forceDelete)
+			Expect(err).ToNot(HaveOccurred())
+			AssertClusterIsReady(namespace, clusterName, timeout, env)
+		})
+		By("Checking that all the slots exist and are aligned", func() {
+			podList, err := env.GetClusterPodList(namespace, clusterName)
+			Expect(err).ToNot(HaveOccurred())
+			for _, pod := range podList.Items {
+				AssertRepSlotsOnPod(namespace, clusterName, pod.Name)
+			}
+			AssertClusterRepSlotsAligned(namespace, clusterName)
+		})
+	})
+})

--- a/tests/e2e/replication_slot_test.go
+++ b/tests/e2e/replication_slot_test.go
@@ -16,10 +16,10 @@ package e2e
 import (
 	"fmt"
 
-	testsUtils "github.com/cloudnative-pg/cloudnative-pg/tests/utils"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/cloudnative-pg/cloudnative-pg/tests"
+	testsUtils "github.com/cloudnative-pg/cloudnative-pg/tests/utils"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/tests/utils/cluster.go
+++ b/tests/utils/cluster.go
@@ -243,6 +243,22 @@ func (env TestingEnvironment) GetClusterPrimary(namespace string, clusterName st
 	return &corev1.Pod{}, err
 }
 
+// GetClusterReplicas gets a slice containing all the replica pods of a cluster
+func (env TestingEnvironment) GetClusterReplicas(namespace string, clusterName string) (*corev1.PodList, error) {
+	podList := &corev1.PodList{}
+	err := GetObjectList(&env, podList, client.InNamespace(namespace),
+		client.MatchingLabels{"postgresql": clusterName, "role": "replica"},
+	)
+	if err != nil {
+		return podList, err
+	}
+	if len(podList.Items) > 0 {
+		return podList, nil
+	}
+	err = fmt.Errorf("no replicas found")
+	return podList, err
+}
+
 // ScaleClusterSize scales a cluster to the requested size
 func (env TestingEnvironment) ScaleClusterSize(namespace, clusterName string, newClusterSize int) error {
 	cluster, err := env.GetCluster(namespace, clusterName)

--- a/tests/utils/replication_slots.go
+++ b/tests/utils/replication_slots.go
@@ -81,10 +81,7 @@ func GetRepSlotsOnPod(namespace, podName string, env *TestingEnvironment) ([]str
 		return nil, err
 	}
 
-	var slots []string
-	for _, slot := range strings.Split(strings.TrimSpace(stdout), "\n") {
-		slots = append(slots, slot)
-	}
+	slots := strings.Split(strings.TrimSpace(stdout), "\n")
 	sort.Strings(slots)
 	return slots, err
 }

--- a/tests/utils/replication_slots.go
+++ b/tests/utils/replication_slots.go
@@ -1,0 +1,122 @@
+/*
+Copyright The CloudNativePG Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/specs"
+)
+
+// CompareLsn returns true if all the LSN values inside a given list are the same
+func CompareLsn(lsnList []string) bool {
+	for _, lsn := range lsnList {
+		if lsn != lsnList[0] {
+			return false
+		}
+	}
+	return true
+}
+
+// GetExpectedRepSlotsOnPod returns a slice of replication slot names which should be present
+// in a given pod
+func GetExpectedRepSlotsOnPod(namespace, clusterName, podName string, env *TestingEnvironment) ([]string, error) {
+	podList, err := env.GetClusterPodList(namespace, clusterName)
+	if err != nil {
+		return nil, err
+	}
+
+	cluster, err := env.GetCluster(namespace, clusterName)
+	if err != nil {
+		return nil, err
+	}
+
+	var slots []string
+	for _, pod := range podList.Items {
+		if pod.Name != podName && !specs.IsPodPrimary(pod) {
+			repSlotName := cluster.GetSlotNameFromInstanceName(pod.Name)
+			slots = append(slots, repSlotName)
+		}
+	}
+	sort.Strings(slots)
+	return slots, err
+}
+
+// GetRepSlotsOnPod returns a slice containing the names of the current replication slots present in
+// a given pod
+func GetRepSlotsOnPod(namespace, podName string, env *TestingEnvironment) ([]string, error) {
+	namespacedName := types.NamespacedName{
+		Namespace: namespace,
+		Name:      podName,
+	}
+	targetPod := &corev1.Pod{}
+	err := env.Client.Get(env.Ctx, namespacedName, targetPod)
+	if err != nil {
+		return nil, err
+	}
+
+	stdout, _, err := RunQueryFromPod(targetPod, PGLocalSocketDir,
+		"app", "postgres", "''",
+		"SELECT slot_name FROM pg_replication_slots", env)
+	if err != nil {
+		return nil, err
+	}
+
+	var slots []string
+	for _, slot := range strings.Split(strings.TrimSpace(stdout), "\n") {
+		slots = append(slots, slot)
+	}
+	sort.Strings(slots)
+	return slots, err
+}
+
+// GetRepSlotsLsnOnPod returns a slice containing the current restart_lsn values of each
+// replication slot present in a given pod
+func GetRepSlotsLsnOnPod(namespace, clusterName, podName string, env *TestingEnvironment) ([]string, error) {
+	namespacedName := types.NamespacedName{
+		Namespace: namespace,
+		Name:      podName,
+	}
+	targetPod := &corev1.Pod{}
+	err := env.Client.Get(env.Ctx, namespacedName, targetPod)
+	if err != nil {
+		return nil, err
+	}
+
+	slots, err := GetExpectedRepSlotsOnPod(namespace, clusterName, podName, env)
+	if err != nil {
+		return nil, err
+	}
+
+	lsnList := make([]string, 0, len(slots))
+	for _, slot := range slots {
+		query := fmt.Sprintf("SELECT restart_lsn FROM pg_replication_slots WHERE slot_name = '%v'",
+			slot)
+		restartLsn, _, err := RunQueryFromPod(targetPod, PGLocalSocketDir,
+			"app", "postgres", "''", query, env)
+		if err != nil {
+			return nil, err
+		}
+		lsnList = append(lsnList, strings.TrimSpace(restartLsn))
+	}
+	return lsnList, err
+}

--- a/tests/utils/replication_slots.go
+++ b/tests/utils/replication_slots.go
@@ -91,18 +91,8 @@ func GetRepSlotsOnPod(namespace, podName string, env *TestingEnvironment) ([]str
 
 // GetRepSlotsLsnOnPod returns a slice containing the current restart_lsn values of each
 // replication slot present in a given pod
-func GetRepSlotsLsnOnPod(namespace, clusterName, podName string, env *TestingEnvironment) ([]string, error) {
-	namespacedName := types.NamespacedName{
-		Namespace: namespace,
-		Name:      podName,
-	}
-	targetPod := &corev1.Pod{}
-	err := env.Client.Get(env.Ctx, namespacedName, targetPod)
-	if err != nil {
-		return nil, err
-	}
-
-	slots, err := GetExpectedRepSlotsOnPod(namespace, clusterName, podName, env)
+func GetRepSlotsLsnOnPod(namespace, clusterName string, pod corev1.Pod, env *TestingEnvironment) ([]string, error) {
+	slots, err := GetExpectedRepSlotsOnPod(namespace, clusterName, pod.GetName(), env)
 	if err != nil {
 		return nil, err
 	}
@@ -111,7 +101,7 @@ func GetRepSlotsLsnOnPod(namespace, clusterName, podName string, env *TestingEnv
 	for _, slot := range slots {
 		query := fmt.Sprintf("SELECT restart_lsn FROM pg_replication_slots WHERE slot_name = '%v'",
 			slot)
-		restartLsn, _, err := RunQueryFromPod(targetPod, PGLocalSocketDir,
+		restartLsn, _, err := RunQueryFromPod(&pod, PGLocalSocketDir,
 			"app", "postgres", "''", query, env)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
First implementation of the E2E for replication slots.

E2E tests for #8.

Signed-off-by: Niccolò Fei <niccolo.fei@enterprisedb.com>