### PR TITLE
chore: ensure that `cnpg.io/instanceName` and `cnpg.io/podRole` are correctly reconciled on existing resources

### DIFF
--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -380,12 +380,21 @@ func (r *ClusterReconciler) reconcileResources(
 ) (ctrl.Result, error) {
 	contextLogger, ctx := log.SetupLogger(ctx)
 
+	// TODO: refactor how we handle label and annotation reconciliation.
+	// TODO: We should generate a fake pod containing the expected labels and annotations and compare it to the living pod
+
 	// Update the labels for the -rw service to work correctly
 	if err := r.updateRoleLabelsOnPods(ctx, cluster, resources.instances); err != nil {
 		return ctrl.Result{}, fmt.Errorf("cannot update role labels on pods: %w", err)
 	}
 
-	if err := r.updateClusterRoleLabelsOnPVCs(ctx, resources.instances, resources.pvcs); err != nil {
+	// updated any labels that are coming from the operator
+	if err := r.updateOperatorLabelsOnInstances(ctx, resources.instances); err != nil {
+		return ctrl.Result{}, fmt.Errorf("cannot update instance labels on pods: %w", err)
+	}
+
+	// updated any labels that are coming from the operator
+	if err := r.updateOperatorLabelsOnPVC(ctx, resources.instances, resources.pvcs); err != nil {
 		return ctrl.Result{}, fmt.Errorf("cannot update role labels on pvcs: %w", err)
 	}
 


### PR DESCRIPTION
This patch ensures that the labels:
- `"cnpg.io/instanceName` is present on both PVCs and instance pods
- `"cnpg.io/podRole"` on the instance pod

are correctly reconciled during the `reconcileResources` phase.

This will make sure that:
- those labels will be eventually present on  the pods and pvcs created on previous versions
- in case of accidental deletion they will be readded by the operator

Closes #679

Signed-off-by: Armando Ruocco <armando.ruocco@enterprisedb.com>