### PR TITLE
chore: raises the default read timeout values of the instance manager

### DIFF
--- a/pkg/management/pgbouncer/metricsserver/metricsserver.go
+++ b/pkg/management/pgbouncer/metricsserver/metricsserver.go
@@ -65,8 +65,8 @@ func ListenAndServe() error {
 	server = &http.Server{
 		Addr:              fmt.Sprintf(":%d", url.PgBouncerMetricsPort),
 		Handler:           serveMux,
-		ReadTimeout:       webserver.DefaultReadTimeout,
-		ReadHeaderTimeout: webserver.DefaultReadHeaderTimeout,
+		ReadTimeout:       webserver.InstanceManagerDefaultReadTimeout,
+		ReadHeaderTimeout: webserver.InstanceManagerDefaultReadHeaderTimeout,
 	}
 	err := server.ListenAndServe()
 

--- a/pkg/management/postgres/webserver/local.go
+++ b/pkg/management/postgres/webserver/local.go
@@ -65,8 +65,8 @@ func NewLocalWebServer(instance *postgres.Instance) (*Webserver, error) {
 	server := &http.Server{
 		Addr:              fmt.Sprintf("localhost:%d", url.LocalPort),
 		Handler:           serveMux,
-		ReadHeaderTimeout: DefaultReadTimeout,
-		ReadTimeout:       DefaultReadTimeout,
+		ReadHeaderTimeout: InstanceManagerDefaultReadTimeout,
+		ReadTimeout:       InstanceManagerDefaultReadTimeout,
 	}
 
 	webserver := NewWebServer(instance, server)

--- a/pkg/management/postgres/webserver/metricserver/metrics.go
+++ b/pkg/management/postgres/webserver/metricserver/metrics.go
@@ -55,8 +55,8 @@ func New(serverInstance *postgres.Instance) (*MetricsServer, error) {
 	server := &http.Server{
 		Addr:              fmt.Sprintf(":%d", url.PostgresMetricsPort),
 		Handler:           serveMux,
-		ReadTimeout:       webserver.DefaultReadTimeout,
-		ReadHeaderTimeout: webserver.DefaultReadHeaderTimeout,
+		ReadTimeout:       webserver.InstanceManagerDefaultReadTimeout,
+		ReadHeaderTimeout: webserver.InstanceManagerDefaultReadHeaderTimeout,
 	}
 
 	metricServer := &MetricsServer{

--- a/pkg/management/postgres/webserver/remote.go
+++ b/pkg/management/postgres/webserver/remote.go
@@ -62,8 +62,8 @@ func NewRemoteWebServer(
 	server := &http.Server{
 		Addr:              fmt.Sprintf(":%d", url.StatusPort),
 		Handler:           serveMux,
-		ReadTimeout:       DefaultReadTimeout,
-		ReadHeaderTimeout: DefaultReadHeaderTimeout,
+		ReadTimeout:       InstanceManagerDefaultReadTimeout,
+		ReadHeaderTimeout: InstanceManagerDefaultReadHeaderTimeout,
 	}
 
 	return NewWebServer(instance, server), nil

--- a/pkg/management/postgres/webserver/webserver.go
+++ b/pkg/management/postgres/webserver/webserver.go
@@ -26,9 +26,14 @@ import (
 )
 
 const (
-	// DefaultReadTimeout is the default value to be used by the webservers
+	// InstanceManagerDefaultReadTimeout is the default value to be used by the webservers of the instance manager
+	InstanceManagerDefaultReadTimeout = 300 * time.Second
+	// InstanceManagerDefaultReadHeaderTimeout is the default value to be used by the webservers of the instance manager
+	InstanceManagerDefaultReadHeaderTimeout = 30 * time.Second
+
+	// DefaultReadTimeout is the default value to be used by the other webservers
 	DefaultReadTimeout = 20 * time.Second
-	// DefaultReadHeaderTimeout is the default value to be used by the webservers
+	// DefaultReadHeaderTimeout is the default value to be used by the other webservers
 	DefaultReadHeaderTimeout = 3 * time.Second
 )
 


### PR DESCRIPTION
This patch raises the webserver constants `DefaultReadTimeout` and `DefaultReadHeaderTimeout` to avoid network issues on slower Kubernetes clusters.

This is a temporary fix until further work is done to dynamically configure these parameters.

Closes #630

Signed-off-by: Armando Ruocco <armando.ruocco@enterprisedb.com>