### PR TITLE
fix: Set the default datestyle to ISO

### DIFF
--- a/pkg/utils/db.go
+++ b/pkg/utils/db.go
@@ -40,5 +40,10 @@ func NewSimpleDBConnection(connectionString string) (*sql.DB, error) {
 	// the sanitization of the strings. Do not remove.
 	conf.RuntimeParams["client_encoding"] = "UTF8"
 
+	// Set the default datestyle in the connection helps to keep
+	// a standard date format for the operator to manage the dates
+	// when it's needed
+	conf.RuntimeParams["datestyle"] = "ISO"
+
 	return sql.Open("pgx", stdlib.RegisterConnConfig(conf))
 }


### PR DESCRIPTION
Setting the default datestyle variable for the PostgreSQL connection
helps to keep a known standard when parsing dates from the database.

Closes #694

Signed-off-by: Jonathan Gonzalez V <jonathan.gonzalez@enterprisedb.com>