### PR TITLE
fix: do not invoke `Setpgid` while compiling for windows architecture

### DIFF
--- a/pkg/management/postgres/compatibility/doc.go
+++ b/pkg/management/postgres/compatibility/doc.go
@@ -1,6 +1,3 @@
-//go:build windows
-// +build windows
-
 /*
 Copyright The CloudNativePG Contributors
 
@@ -17,12 +14,5 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package compatibility provides a layer to cross-compile with other OS than Linux
+// Package compatibility provides a layer to cross-compile with OS other than Linux
 package compatibility
-
-import "fmt"
-
-// CreateFifo fakes function for cross-compiling compatibility
-func CreateFifo(fileName string) error {
-	panic(fmt.Sprintf("function CreateFifo() should not be used in Windows"))
-}

--- a/pkg/management/postgres/compatibility/unix.go
+++ b/pkg/management/postgres/compatibility/unix.go
@@ -1,5 +1,5 @@
-//go:build windows
-// +build windows
+//go:build linux || darwin
+// +build linux darwin
 
 /*
 Copyright The CloudNativePG Contributors
@@ -17,12 +17,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package compatibility provides a layer to cross-compile with other OS than Linux
 package compatibility
 
-import "fmt"
+import (
+	"os/exec"
+	"syscall"
+)
 
-// CreateFifo fakes function for cross-compiling compatibility
-func CreateFifo(fileName string) error {
-	panic(fmt.Sprintf("function CreateFifo() should not be used in Windows"))
+// AddInstanceRunCommands adds specific OS commands to the postgres exec.Cmd
+func AddInstanceRunCommands(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Setpgid: true,
+	}
 }

--- a/pkg/management/postgres/compatibility/windows.go
+++ b/pkg/management/postgres/compatibility/windows.go
@@ -17,12 +17,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package compatibility provides a layer to cross-compile with other OS than Linux
 package compatibility
 
-import "fmt"
+import (
+	"os/exec"
+)
 
-// CreateFifo fakes function for cross-compiling compatibility
-func CreateFifo(fileName string) error {
-	panic(fmt.Sprintf("function CreateFifo() should not be used in Windows"))
+// AddInstanceRunCommands adds specific OS commands to the postgres exec.Cmd
+func AddInstanceRunCommands(cmd *exec.Cmd) {
+	return
 }

--- a/pkg/management/postgres/instance.go
+++ b/pkg/management/postgres/instance.go
@@ -26,7 +26,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strconv"
-	"syscall"
 	"time"
 
 	"github.com/blang/semver"
@@ -37,6 +36,7 @@ import (
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/fileutils"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/execlog"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/log"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres/compatibility"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres/logpipe"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres/pool"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres/utils"
@@ -428,9 +428,8 @@ func (instance *Instance) Run() (*execlog.StreamingCmd, error) {
 
 	postgresCmd := exec.Command(postgresName, options...) // #nosec
 	postgresCmd.Env = instance.Env
-	postgresCmd.SysProcAttr = &syscall.SysProcAttr{
-		Setpgid: true,
-	}
+	compatibility.AddInstanceRunCommands(postgresCmd)
+
 	streamingCmd, err := execlog.RunStreamingNoWait(postgresCmd, postgresName)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
The call to `Setpgid` would prevent us from compiling the plugin for windows architecture.
This patch ensures that we do not call `Setpgid` while compiling for windows.

Closes #699

Signed-off-by: Armando Ruocco <armando.ruocco@enterprisedb.com>