### PR TITLE
Use non-deprecated PodDisruptionBudget version

### DIFF
--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -29,7 +29,7 @@ import (
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -759,7 +759,7 @@ func (r *ClusterReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manag
 		Owns(&batchv1.Job{}).
 		Owns(&corev1.Service{}).
 		Owns(&corev1.PersistentVolumeClaim{}).
-		Owns(&policyv1beta1.PodDisruptionBudget{}).
+		Owns(&policyv1.PodDisruptionBudget{}).
 		Watches(
 			&source.Kind{Type: &corev1.ConfigMap{}},
 			handler.EnqueueRequestsFromMapFunc(r.mapConfigMapsToClusters(ctx)),

--- a/controllers/cluster_create.go
+++ b/controllers/cluster_create.go
@@ -26,7 +26,7 @@ import (
 	"github.com/sethvargo/go-password/password"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -313,13 +313,13 @@ func (r *ClusterReconciler) createPostgresServices(ctx context.Context, cluster 
 func (r *ClusterReconciler) createOrPatchOwnedPodDisruptionBudget(
 	ctx context.Context,
 	cluster *apiv1.Cluster,
-	pdb *v1beta1.PodDisruptionBudget,
+	pdb *policyv1.PodDisruptionBudget,
 ) error {
 	if pdb == nil {
 		return nil
 	}
 
-	var oldPdb v1beta1.PodDisruptionBudget
+	var oldPdb policyv1.PodDisruptionBudget
 
 	if err := r.Get(ctx, client.ObjectKey{Name: pdb.Name, Namespace: pdb.Namespace}, &oldPdb); err != nil {
 		if !apierrs.IsNotFound(err) {
@@ -373,7 +373,7 @@ func (r *ClusterReconciler) deletePodDisruptionBudget(
 	key types.NamespacedName,
 ) error {
 	// If we have a PDB, we need to delete it
-	var targetPdb v1beta1.PodDisruptionBudget
+	var targetPdb policyv1.PodDisruptionBudget
 	err := r.Get(ctx, key, &targetPdb)
 	if err != nil {
 		if !apierrs.IsNotFound(err) {

--- a/controllers/cluster_create_test.go
+++ b/controllers/cluster_create_test.go
@@ -20,7 +20,7 @@ import (
 	"context"
 
 	corev1 "k8s.io/api/core/v1"
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
@@ -184,12 +184,12 @@ var _ = Describe("cluster_create unit tests", func() {
 			expectResourceExistsWithDefaultClient(
 				pdbPrimaryName,
 				namespace,
-				&policyv1beta1.PodDisruptionBudget{},
+				&policyv1.PodDisruptionBudget{},
 			)
 			expectResourceExistsWithDefaultClient(
 				pdbReplicaName,
 				namespace,
-				&policyv1beta1.PodDisruptionBudget{},
+				&policyv1.PodDisruptionBudget{},
 			)
 		})
 
@@ -209,7 +209,7 @@ var _ = Describe("cluster_create unit tests", func() {
 			expectResourceDoesntExistWithDefaultClient(
 				pdbReplicaName,
 				namespace,
-				&policyv1beta1.PodDisruptionBudget{},
+				&policyv1.PodDisruptionBudget{},
 			)
 		})
 
@@ -226,12 +226,12 @@ var _ = Describe("cluster_create unit tests", func() {
 			expectResourceDoesntExistWithDefaultClient(
 				pdbPrimaryName,
 				namespace,
-				&policyv1beta1.PodDisruptionBudget{},
+				&policyv1.PodDisruptionBudget{},
 			)
 			expectResourceDoesntExistWithDefaultClient(
 				pdbReplicaName,
 				namespace,
-				&policyv1beta1.PodDisruptionBudget{},
+				&policyv1.PodDisruptionBudget{},
 			)
 		})
 	})

--- a/pkg/specs/poddisruptionbudget.go
+++ b/pkg/specs/poddisruptionbudget.go
@@ -17,7 +17,7 @@ limitations under the License.
 package specs
 
 import (
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
@@ -26,7 +26,7 @@ import (
 
 // BuildReplicasPodDisruptionBudget creates a pod disruption budget telling
 // K8s to avoid removing more than one replica at a time
-func BuildReplicasPodDisruptionBudget(cluster *apiv1.Cluster) *policyv1beta1.PodDisruptionBudget {
+func BuildReplicasPodDisruptionBudget(cluster *apiv1.Cluster) *policyv1.PodDisruptionBudget {
 	// We should ensure that in a cluster of n instances,
 	// with n-1 replicas, at least n-2 are always available
 	if cluster == nil || cluster.Spec.Instances < 3 {
@@ -35,12 +35,12 @@ func BuildReplicasPodDisruptionBudget(cluster *apiv1.Cluster) *policyv1beta1.Pod
 	minAvailableReplicas := cluster.Spec.Instances - 2
 	allReplicasButOne := intstr.FromInt(minAvailableReplicas)
 
-	return &policyv1beta1.PodDisruptionBudget{
+	return &policyv1.PodDisruptionBudget{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cluster.Name,
 			Namespace: cluster.Namespace,
 		},
-		Spec: policyv1beta1.PodDisruptionBudgetSpec{
+		Spec: policyv1.PodDisruptionBudgetSpec{
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					ClusterLabelName:     cluster.Name,
@@ -54,18 +54,18 @@ func BuildReplicasPodDisruptionBudget(cluster *apiv1.Cluster) *policyv1beta1.Pod
 
 // BuildPrimaryPodDisruptionBudget creates a pod disruption budget, telling
 // K8s to avoid removing more than one primary instance at a time
-func BuildPrimaryPodDisruptionBudget(cluster *apiv1.Cluster) *policyv1beta1.PodDisruptionBudget {
+func BuildPrimaryPodDisruptionBudget(cluster *apiv1.Cluster) *policyv1.PodDisruptionBudget {
 	if cluster == nil {
 		return nil
 	}
 	one := intstr.FromInt(1)
 
-	return &policyv1beta1.PodDisruptionBudget{
+	return &policyv1.PodDisruptionBudget{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cluster.Name + apiv1.PrimaryPodDisruptionBudgetSuffix,
 			Namespace: cluster.Namespace,
 		},
-		Spec: policyv1beta1.PodDisruptionBudgetSpec{
+		Spec: policyv1.PodDisruptionBudgetSpec{
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					ClusterLabelName:     cluster.Name,


### PR DESCRIPTION
PodDisruptionBudget version policyv1beta1 was dropped in Kubernetes v1.25.

Addresses #413 via option 2 presented there. I don't know how important 1.19/1.20 support is for CNPG, but if "not very" then this one possible fix.