### PR TITLE
fix: ensure that the conditions contained in the cluster status are made compatible with metav1.Conditions struct

### DIFF
--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -402,6 +402,28 @@ const (
 	ConditionUnknown ConditionStatus = "Unknown"
 )
 
+// ConditionReason defines the reason why a certain
+// condition changed
+type ConditionReason string
+
+const (
+	// ConditionReasonLastBackupSucceeded means that the condition changed because the last backup
+	// has been taken successfully
+	ConditionReasonLastBackupSucceeded ConditionReason = "LastBackupSucceeded"
+
+	// ConditionReasonLastBackupFailed means that the condition changed because the last backup
+	// failed
+	ConditionReasonLastBackupFailed ConditionReason = "LastBackupFailed"
+
+	// ConditionReasonContinuousArchivingSuccess means that the condition changed because the
+	// WAL archiving was working correctly
+	ConditionReasonContinuousArchivingSuccess ConditionReason = "ContinuousArchivingSuccess"
+
+	// ConditionReasonContinuousArchivingFailing means that the condition has changed because
+	// the WAL archiving is not working correctly
+	ConditionReasonContinuousArchivingFailing ConditionReason = "ContinuousArchivingFailing"
+)
+
 // ClusterConditionType is of string type
 type ClusterConditionType string
 

--- a/controllers/cluster_status.go
+++ b/controllers/cluster_status.go
@@ -339,7 +339,7 @@ func (r *ClusterReconciler) updateResourceStatus(
 // removeConditionsWithInvalidReason will remove every condition which is not valid
 // anymore from the K8s API point-of-view
 func (r *ClusterReconciler) removeConditionsWithInvalidReason(ctx context.Context, cluster *apiv1.Cluster) error {
-	conditions := make([]metav1.Condition, 0, len(cluster.Status.Conditions))
+	conditions := make([]apiv1.ClusterCondition, 0, len(cluster.Status.Conditions))
 	for _, entry := range cluster.Status.Conditions {
 		if utils.IsConditionReasonValid(entry.Reason) {
 			conditions = append(conditions, entry)

--- a/internal/cmd/manager/walarchive/cmd.go
+++ b/internal/cmd/manager/walarchive/cmd.go
@@ -345,14 +345,14 @@ func buildArchiveCondition(err error) *apiv1.ClusterCondition {
 		return &apiv1.ClusterCondition{
 			Type:    apiv1.ConditionContinuousArchiving,
 			Status:  apiv1.ConditionFalse,
-			Reason:  "Continuous Archiving is Failing",
+			Reason:  string(apiv1.ConditionReasonContinuousArchivingFailing),
 			Message: err.Error(),
 		}
 	}
 	return &apiv1.ClusterCondition{
 		Type:    apiv1.ConditionContinuousArchiving,
 		Status:  apiv1.ConditionTrue,
-		Reason:  "Continuous Archiving is Working",
+		Reason:  string(apiv1.ConditionReasonContinuousArchivingSuccess),
 		Message: "",
 	}
 }

--- a/pkg/management/postgres/backup.go
+++ b/pkg/management/postgres/backup.go
@@ -481,14 +481,14 @@ func BuildBackupCondition(err error) *apiv1.ClusterCondition {
 		return &apiv1.ClusterCondition{
 			Type:    apiv1.ConditionBackup,
 			Status:  apiv1.ConditionFalse,
-			Reason:  "Last backup failed",
+			Reason:  string(apiv1.ConditionReasonLastBackupFailed),
 			Message: err.Error(),
 		}
 	}
 	return &apiv1.ClusterCondition{
 		Type:    apiv1.ConditionBackup,
 		Status:  apiv1.ConditionTrue,
-		Reason:  "Last backup succeeded",
+		Reason:  string(apiv1.ConditionReasonLastBackupSucceeded),
 		Message: "",
 	}
 }

--- a/pkg/utils/conditions.go
+++ b/pkg/utils/conditions.go
@@ -1,0 +1,28 @@
+/*
+Copyright The CloudNativePG Contributors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import "regexp"
+
+// conditionReasonRegexp is the regular expression that is used inside the Kubernetes API
+// to validate the condition reason.
+// Reference:
+// https://github.com/kubernetes/apimachinery/blob/e74e8a90/pkg/apis/meta/v1/types.go#L1501
+var conditionReasonRegexp = regexp.MustCompile(`^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$`)
+
+// IsConditionReasonValid checks if a certain condition reason is valid or not given the
+// Kubernetes API requirements
+func IsConditionReasonValid(conditionReason string) bool {
+	return conditionReasonRegexp.Match([]byte(conditionReason))
+}


### PR DESCRIPTION
This patch cherry-picks the PR containing the logic needed to sanitize the cluster conditions

Closes #719 

Signed-off-by: Armando Ruocco <armando.ruocco@enterprisedb.com>