### PR TITLE
fix: ensures that the promoted standby active connections are dropped after promotion

### DIFF
--- a/internal/management/controller/instance_controller.go
+++ b/internal/management/controller/instance_controller.go
@@ -1034,10 +1034,15 @@ func (r *InstanceReconciler) reconcilePrimary(ctx context.Context, cluster *apiv
 	if cluster.Status.CurrentPrimary != r.instance.PodName {
 		cluster.Status.CurrentPrimary = r.instance.PodName
 		cluster.Status.CurrentPrimaryTimestamp = pkgUtils.GetCurrentTimestamp()
-		err := r.client.Status().Patch(ctx, cluster, client.MergeFrom(oldCluster))
-		if err != nil {
+
+		if err := r.client.Status().Patch(ctx, cluster, client.MergeFrom(oldCluster)); err != nil {
 			return restarted, err
 		}
+
+		if err := r.instance.DropConnections(); err != nil {
+			return restarted, err
+		}
+
 		cluster.LogTimestampsWithMessage(ctx, "Finished setting myself as primary")
 		return restarted, nil
 	}

--- a/pkg/management/postgres/instance.go
+++ b/pkg/management/postgres/instance.go
@@ -901,3 +901,22 @@ func (instance *Instance) waitForInstanceRestarted(after time.Time) error {
 		return nil
 	})
 }
+
+// DropConnections drops all the connections of backend_type 'client backend'
+func (instance *Instance) DropConnections() error {
+	conn, err := instance.GetSuperUserDB()
+	if err != nil {
+		return err
+	}
+
+	if _, err := conn.Exec(
+		`SELECT pg_terminate_backend(pid)
+			   FROM pg_stat_activity
+			   WHERE pid <> pg_backend_pid()
+			     AND backend_type = 'client backend';`,
+	); err != nil {
+		return fmt.Errorf("while dropping connections: %w", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
This patch drops all the connections made before the standby promotion are dropped.

Closes #736

Signed-off-by: Armando Ruocco <armando.ruocco@enterprisedb.com>