### PR TITLE
test: fix misplaced parenthesis in unit tests

### DIFF
--- a/pkg/postgres/configuration_test.go
+++ b/pkg/postgres/configuration_test.go
@@ -158,7 +158,7 @@ var _ = Describe("PostgreSQL configuration creation", func() {
 		libraries := strings.Split(config.GetConfig(SharedPreloadLibraries), ",")
 		Expect(len(info.AdditionalSharedPreloadLibraries)).To(BeNumerically(">", len(libraries)))
 		Expect(libraries).Should(SatisfyAll(
-			ContainElements("some_library", "another_library")), Not(ContainElement("")))
+			ContainElements("some_library", "another_library"), Not(ContainElement(""))))
 	})
 
 	When("we are using synchronous replication", func() {


### PR DESCRIPTION
The latest version of ginkgo highlighted a parenthesis misplacement
in one of our unit tests.

Closes: #747 

Signed-off-by: Tao Li <tao.li@enterprisedb.com>