### PR TITLE
test: ensure tabby writer cache is always flushed

### DIFF
--- a/tests/utils/cluster.go
+++ b/tests/utils/cluster.go
@@ -374,6 +374,10 @@ func NewClusterResourcePrinter(namespace, clusterName string, env *TestingEnviro
 			clusterInfo.AddLine("PVC phase", pvc.Status.Phase)
 			clusterInfo.AddLine("---", "---")
 		}
+
+		// do not remove, this is needed to ensure that the writer cache is always flushed.
+		clusterInfo.Print()
+
 		return buffer.String()
 	}
 }


### PR DESCRIPTION
This patch ensures that `NewClusterResourcePrinter` always returns a string that is complete by ensuring that the tabby writer cache is flushed.

Closes #767

Signed-off-by: Armando Ruocco <armando.ruocco@enterprisedb.com>