### PR TITLE
feat: adds hibernate off

### DIFF
--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -194,6 +194,11 @@ func (r *ClusterReconciler) reconcile(ctx context.Context, cluster *apiv1.Cluste
 		return ctrl.Result{}, err
 	}
 
+	// Ensure we reconcile the orphan resources if present when we reconcile for the first time a cluster
+	if err := r.reconcileRestoredCluster(ctx, cluster); err != nil {
+		return ctrl.Result{}, fmt.Errorf("cannot reconcile restored Cluster: %w", err)
+	}
+
 	// Ensure we have the required global objects
 	if err := r.createPostgresClusterObjects(ctx, cluster); err != nil {
 		return ctrl.Result{}, fmt.Errorf("cannot create Cluster auxiliary objects: %w", err)

--- a/controllers/cluster_restore.go
+++ b/controllers/cluster_restore.go
@@ -1,0 +1,164 @@
+/*
+Copyright The CloudNativePG Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/log"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/specs"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
+)
+
+// reconcileRestoredCluster ensures that we own again any orphan resources when cluster gets reconciled for
+// the first time
+func (r *ClusterReconciler) reconcileRestoredCluster(ctx context.Context, cluster *apiv1.Cluster) error {
+	if cluster.Status.LatestGeneratedNode != 0 {
+		return nil
+	}
+	pvcs, err := getOrphanPVCs(ctx, r.Client, cluster)
+	if err != nil {
+		return err
+	}
+
+	contextLogger := log.FromContext(ctx)
+	if len(pvcs) == 0 {
+		contextLogger.Info("no orphan PVCs found, skipping the restored cluster reconciliation")
+		return nil
+	}
+
+	contextLogger.Debug("found orphan pvcs, trying to restore the cluster")
+	highestSerial, primarySerial, err := getNodeSerialsFromPVCs(pvcs)
+	if err != nil {
+		return err
+	}
+	if primarySerial == 0 {
+		contextLogger.Info("no primary serial found, assigning the highest serial as the primary")
+		primarySerial = highestSerial
+	}
+	contextLogger.Debug("proceeding to restore the cluster status")
+	if err := restoreClusterStatus(ctx, r.Client, cluster, highestSerial, primarySerial); err != nil {
+		return err
+	}
+
+	contextLogger.Debug("restored the cluster status, proceeding to restore the orphan PVCS")
+	return restoreOrphanPVCs(ctx, r.Client, cluster, pvcs)
+}
+
+// restoreClusterStatus bootstraps the status needed to make the restored cluster work
+func restoreClusterStatus(
+	ctx context.Context,
+	c client.Client,
+	cluster *apiv1.Cluster,
+	latestNodeSerial int,
+	targetPrimaryNodeSerial int,
+) error {
+	clusterOrig := cluster.DeepCopy()
+	cluster.Status.LatestGeneratedNode = latestNodeSerial
+	cluster.Status.TargetPrimary = specs.GetInstanceName(cluster.Name, targetPrimaryNodeSerial)
+
+	return c.Status().Patch(ctx, cluster, client.MergeFrom(clusterOrig))
+}
+
+func getOrphanPVCs(
+	ctx context.Context,
+	c client.Client,
+	cluster *apiv1.Cluster,
+) ([]corev1.PersistentVolumeClaim, error) {
+	contextLogger := log.FromContext(ctx).WithValues("step", "get_orphan_pvcs")
+
+	var pvcList corev1.PersistentVolumeClaimList
+	if err := c.List(
+		ctx,
+		&pvcList,
+		client.MatchingLabels{utils.ClusterLabelName: cluster.Name},
+	); err != nil {
+		return nil, err
+	}
+
+	var orphanPVCs []corev1.PersistentVolumeClaim // nolint
+	for _, pvc := range pvcList.Items {
+		if len(pvc.OwnerReferences) != 0 {
+			contextLogger.Warning("skipping pvc because it has owner metadata",
+				"pvcName", pvc.Name)
+			continue
+		}
+		if _, ok := pvc.Annotations[specs.ClusterSerialAnnotationName]; !ok {
+			contextLogger.Warning("skipping pvc because it doesn't have serial annotation",
+				"pvcName", pvc.Name)
+			continue
+		}
+
+		orphanPVCs = append(orphanPVCs, pvc)
+	}
+
+	return orphanPVCs, nil
+}
+
+// getNodeSerialsFromPVCs tries to obtain the highestSerial and the primary serial from a group of PVCs
+func getNodeSerialsFromPVCs(
+	pvcs []corev1.PersistentVolumeClaim,
+) (int, int, error) {
+	var highestSerial int
+	var primarySerial int
+	for _, pvc := range pvcs {
+		serial, err := specs.GetNodeSerial(pvc.ObjectMeta)
+		if err != nil {
+			return 0, 0, err
+		}
+		if serial > highestSerial {
+			highestSerial = serial
+		}
+		if pvc.ObjectMeta.Labels[specs.ClusterRoleLabelName] == specs.ClusterRoleLabelPrimary {
+			primarySerial = serial
+		}
+	}
+
+	return highestSerial, primarySerial, nil
+}
+
+// restoreOrphanPVCs sets the owner metadata and re-actives the orphan pvcs
+func restoreOrphanPVCs(
+	ctx context.Context,
+	c client.Client,
+	cluster *apiv1.Cluster,
+	pvcs []corev1.PersistentVolumeClaim,
+) error {
+	for i := range pvcs {
+		pvc := pvcs[i]
+		if pvc.Annotations == nil {
+			pvc.Annotations = map[string]string{}
+		}
+
+		pvcOrig := pvc.DeepCopy()
+		SetClusterOwnerAnnotationsAndLabels(&pvc.ObjectMeta, cluster)
+		pvc.Annotations[specs.PVCStatusAnnotationName] = specs.PVCStatusReady
+		// we clean hibernation metadata if it exists
+		delete(pvc.Annotations, utils.HibernateClusterManifestAnnotationName)
+		delete(pvc.Annotations, utils.HibernatePgControlDataAnnotationName)
+
+		if err := c.Patch(ctx, &pvc, client.MergeFrom(pvcOrig)); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/controllers/cluster_restore.go
+++ b/controllers/cluster_restore.go
@@ -99,7 +99,7 @@ func getOrphanPVCs(
 		return nil, err
 	}
 
-	orphanPVCs := make([]corev1.PersistentVolumeClaim, 0, len(pvcList.Items)) // nolint
+	orphanPVCs := make([]corev1.PersistentVolumeClaim, 0, len(pvcList.Items))
 	for _, pvc := range pvcList.Items {
 		if len(pvc.OwnerReferences) != 0 {
 			contextLogger.Warning("skipping pvc because it has owner metadata",
@@ -148,7 +148,7 @@ func restoreOrphanPVCs(
 	pvcs []corev1.PersistentVolumeClaim,
 ) error {
 	for i := range pvcs {
-		pvc := pvcs[i]
+		pvc := &pvcs[i]
 		if pvc.Annotations == nil {
 			pvc.Annotations = map[string]string{}
 		}
@@ -160,7 +160,7 @@ func restoreOrphanPVCs(
 		delete(pvc.Annotations, utils.HibernateClusterManifestAnnotationName)
 		delete(pvc.Annotations, utils.HibernatePgControlDataAnnotationName)
 
-		if err := c.Patch(ctx, &pvc, client.MergeFrom(pvcOrig)); err != nil {
+		if err := c.Patch(ctx, pvc, client.MergeFrom(pvcOrig)); err != nil {
 			return err
 		}
 	}

--- a/internal/cmd/plugin/hibernate/cmd.go
+++ b/internal/cmd/plugin/hibernate/cmd.go
@@ -47,7 +47,8 @@ var (
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			clusterName := args[0]
-			return hibernateOff(cmd.Context(), clusterName)
+			off := newOffCommand(cmd.Context(), clusterName)
+			return off.execute()
 		},
 	}
 )

--- a/internal/cmd/plugin/hibernate/off.go
+++ b/internal/cmd/plugin/hibernate/off.go
@@ -16,8 +16,162 @@ limitations under the License.
 
 package hibernate
 
-import "context"
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/strings/slices"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	v1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/plugin"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/specs"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
+)
+
+// errNoHibernatedPVCsFound indicates that no PVCs were found. This is also used by the status command
+var errNoHibernatedPVCsFound = fmt.Errorf("no hibernated PVCs to reactivate found")
 
 func hibernateOff(ctx context.Context, clusterName string) error {
+	fmt.Println("cluster reactivation starting")
+	if err := ensureClusterDoesNotExist(ctx, clusterName); err != nil {
+		return err
+	}
+
+	pvcGroup, err := getHibernatedPVCGroup(ctx, clusterName)
+	if err != nil {
+		return err
+	}
+
+	if err := recreateClusterFromHibernatedPVC(ctx, pvcGroup[0]); err != nil {
+		return err
+	}
+
+	fmt.Println("cluster reactivation completed")
+	return nil
+}
+
+func recreateClusterFromHibernatedPVC(ctx context.Context, pvc corev1.PersistentVolumeClaim) error {
+	clusterFromPVC, err := getClusterFromPVCAnnotation(pvc)
+	if err != nil {
+		return err
+	}
+
+	return createClusterWithoutRuntimeData(ctx, clusterFromPVC)
+}
+
+func getHibernatedPVCGroup(ctx context.Context, clusterName string) ([]corev1.PersistentVolumeClaim, error) {
+	pvcs, err := getClusterPVCs(ctx, clusterName)
+	if err != nil {
+		return nil, err
+	}
+	if len(pvcs) == 0 {
+		return nil, errNoHibernatedPVCsFound
+	}
+	if err := ensurePVCsArePartOfAPVCGroup(pvcs); err != nil {
+		return nil, err
+	}
+
+	return pvcs, nil
+}
+
+func getClusterPVCs(ctx context.Context, clusterName string) ([]corev1.PersistentVolumeClaim, error) {
+	var pvcList corev1.PersistentVolumeClaimList
+	if err := plugin.Client.List(
+		ctx,
+		&pvcList,
+		client.MatchingLabels{utils.ClusterLabelName: clusterName},
+	); err != nil {
+		return nil, err
+	}
+
+	return pvcList.Items, nil
+}
+
+func createClusterWithoutRuntimeData(ctx context.Context, clusterFromPVC v1.Cluster) error {
+	cluster := clusterFromPVC.DeepCopy()
+	// remove any runtime kubernetes metadata
+	cluster.ObjectMeta.ResourceVersion = ""
+	cluster.ObjectMeta.ManagedFields = nil
+	cluster.ObjectMeta.UID = ""
+	cluster.ObjectMeta.Generation = 0
+	cluster.ObjectMeta.CreationTimestamp = metav1.Time{}
+	// remove cluster status
+	cluster.Status = v1.ClusterStatus{}
+
+	// remove any runtime kubernetes annotations
+	delete(cluster.Annotations, corev1.LastAppliedConfigAnnotation)
+
+	// remove the cluster fencing
+	delete(cluster.Annotations, utils.FencedInstanceAnnotation)
+
+	// create cluster
+	return plugin.Client.Create(ctx, cluster)
+
+}
+
+func getClusterFromPVCAnnotation(pvc corev1.PersistentVolumeClaim) (v1.Cluster, error) {
+	var clusterFromPVC v1.Cluster
+	// get the cluster manifest
+	clusterJSON := pvc.Annotations[utils.HibernateClusterManifestAnnotationName]
+	if err := json.Unmarshal([]byte(clusterJSON), &clusterFromPVC); err != nil {
+		return v1.Cluster{}, err
+	}
+	return clusterFromPVC, nil
+}
+
+func ensurePVCsArePartOfAPVCGroup(pvcs []corev1.PersistentVolumeClaim) error {
+	// ensure all the pvcs belong to the same node serial and are hibernated
+	var nodeSerial []string
+	for _, pvc := range pvcs {
+		if err := ensureAnnotationsExists(
+			pvc,
+			utils.HibernateClusterManifestAnnotationName,
+			utils.HibernatePgControlDataAnnotationName,
+			specs.ClusterSerialAnnotationName,
+		); err != nil {
+			return err
+		}
+
+		serial := pvc.Annotations[specs.ClusterSerialAnnotationName]
+		if !slices.Contains(nodeSerial, serial) {
+			nodeSerial = append(nodeSerial, serial)
+		}
+	}
+	if len(nodeSerial) != 1 {
+		return fmt.Errorf("hibernate pvcs belong to different instances of the cluster, cannot proceed")
+	}
+
+	return nil
+}
+
+func ensureClusterDoesNotExist(ctx context.Context, clusterName string) error {
+	var cluster v1.Cluster
+	err := plugin.Client.Get(
+		ctx,
+		types.NamespacedName{Name: clusterName, Namespace: plugin.Namespace},
+		&cluster,
+	)
+	if err == nil {
+		return fmt.Errorf("cluster already exist, cannot proceed with reactivation")
+	}
+	if !apierrs.IsNotFound(err) {
+		return err
+	}
+	return nil
+}
+
+func ensureAnnotationsExists(volume corev1.PersistentVolumeClaim, annotationNames ...string) error {
+	for _, annotationName := range annotationNames {
+		if _, ok := volume.Annotations[annotationName]; !ok {
+			return fmt.Errorf("missing %s annotation, from pvcs: %s", annotationName, volume.Name)
+		}
+	}
+
 	return nil
 }

--- a/internal/cmd/plugin/hibernate/off.go
+++ b/internal/cmd/plugin/hibernate/off.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/strings/slices"
 
-	v1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/plugin"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/log"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/specs"
@@ -94,7 +94,7 @@ func (off *offCommand) execute() error {
 // ensureClusterDoesNotExistStep checks if this cluster exist or not, ensuring
 // that it is not present
 func (off *offCommand) ensureClusterDoesNotExistStep() error {
-	var cluster v1.Cluster
+	var cluster apiv1.Cluster
 	err := plugin.Client.Get(
 		off.ctx,
 		types.NamespacedName{Name: off.clusterName, Namespace: plugin.Namespace},
@@ -136,7 +136,7 @@ func (off *offCommand) ensurePVCsArePartOfAPVCGroupStep(pvcs []corev1.Persistent
 }
 
 // createClusterWithoutRuntimeDataStep recreate the original cluster back into Kubernetes
-func (off *offCommand) createClusterWithoutRuntimeDataStep(clusterFromPVC v1.Cluster) error {
+func (off *offCommand) createClusterWithoutRuntimeDataStep(clusterFromPVC apiv1.Cluster) error {
 	cluster := clusterFromPVC.DeepCopy()
 	// remove any runtime kubernetes metadata
 	cluster.ObjectMeta.ResourceVersion = ""
@@ -145,7 +145,7 @@ func (off *offCommand) createClusterWithoutRuntimeDataStep(clusterFromPVC v1.Clu
 	cluster.ObjectMeta.Generation = 0
 	cluster.ObjectMeta.CreationTimestamp = metav1.Time{}
 	// remove cluster status
-	cluster.Status = v1.ClusterStatus{}
+	cluster.Status = apiv1.ClusterStatus{}
 
 	// remove any runtime kubernetes annotations
 	delete(cluster.Annotations, corev1.LastAppliedConfigAnnotation)

--- a/internal/cmd/plugin/hibernate/off.go
+++ b/internal/cmd/plugin/hibernate/off.go
@@ -18,7 +18,6 @@ package hibernate
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
@@ -77,7 +76,7 @@ func (off *offCommand) execute() error {
 	pvc := pvcGroup[0]
 
 	// We get the original cluster resource from the annotation
-	clusterFromPVC, err := off.getClusterFromPVCAnnotationStep(pvc)
+	clusterFromPVC, err := getClusterFromPVCAnnotation(pvc)
 	if err != nil {
 		return err
 	}
@@ -134,17 +133,6 @@ func (off *offCommand) ensurePVCsArePartOfAPVCGroupStep(pvcs []corev1.Persistent
 	}
 
 	return nil
-}
-
-// getClusterFromPVCAnnotationStep reads the original cluster resource from the chosen PVC
-func (off *offCommand) getClusterFromPVCAnnotationStep(pvc corev1.PersistentVolumeClaim) (v1.Cluster, error) {
-	var clusterFromPVC v1.Cluster
-	// get the cluster manifest
-	clusterJSON := pvc.Annotations[utils.HibernateClusterManifestAnnotationName]
-	if err := json.Unmarshal([]byte(clusterJSON), &clusterFromPVC); err != nil {
-		return v1.Cluster{}, err
-	}
-	return clusterFromPVC, nil
 }
 
 // createClusterWithoutRuntimeDataStep recreate the original cluster back into Kubernetes

--- a/internal/cmd/plugin/hibernate/resources.go
+++ b/internal/cmd/plugin/hibernate/resources.go
@@ -18,8 +18,10 @@ package hibernate
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
+	v1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -46,4 +48,15 @@ func getHibernatedPVCGroup(ctx context.Context, clusterName string) ([]corev1.Pe
 	}
 
 	return pvcList.Items, nil
+}
+
+// getClusterFromPVCAnnotation reads the original cluster resource from the chosen PVC
+func getClusterFromPVCAnnotation(pvc corev1.PersistentVolumeClaim) (v1.Cluster, error) {
+	var clusterFromPVC v1.Cluster
+	// get the cluster manifest
+	clusterJSON := pvc.Annotations[utils.HibernateClusterManifestAnnotationName]
+	if err := json.Unmarshal([]byte(clusterJSON), &clusterFromPVC); err != nil {
+		return v1.Cluster{}, err
+	}
+	return clusterFromPVC, nil
 }

--- a/internal/cmd/plugin/hibernate/resources.go
+++ b/internal/cmd/plugin/hibernate/resources.go
@@ -1,0 +1,49 @@
+/*
+Copyright The CloudNativePG Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hibernate
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/plugin"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
+)
+
+// errNoHibernatedPVCsFound indicates that no PVCs were found.
+var errNoHibernatedPVCsFound = fmt.Errorf("no hibernated PVCs to reactivate found")
+
+// getHibernatedPVCGroupStep gets the PVC group resulting from the hibernation process
+func getHibernatedPVCGroup(ctx context.Context, clusterName string) ([]corev1.PersistentVolumeClaim, error) {
+	// Get the list of PVCs belonging to this group
+	var pvcList corev1.PersistentVolumeClaimList
+	if err := plugin.Client.List(
+		ctx,
+		&pvcList,
+		client.MatchingLabels{utils.ClusterLabelName: clusterName},
+	); err != nil {
+		return nil, err
+	}
+	if len(pvcList.Items) == 0 {
+		return nil, errNoHibernatedPVCsFound
+	}
+
+	return pvcList.Items, nil
+}

--- a/internal/cmd/plugin/hibernate/resources.go
+++ b/internal/cmd/plugin/hibernate/resources.go
@@ -21,10 +21,10 @@ import (
 	"encoding/json"
 	"fmt"
 
-	v1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/plugin"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 )
@@ -51,12 +51,12 @@ func getHibernatedPVCGroup(ctx context.Context, clusterName string) ([]corev1.Pe
 }
 
 // getClusterFromPVCAnnotation reads the original cluster resource from the chosen PVC
-func getClusterFromPVCAnnotation(pvc corev1.PersistentVolumeClaim) (v1.Cluster, error) {
-	var clusterFromPVC v1.Cluster
+func getClusterFromPVCAnnotation(pvc corev1.PersistentVolumeClaim) (apiv1.Cluster, error) {
+	var clusterFromPVC apiv1.Cluster
 	// get the cluster manifest
 	clusterJSON := pvc.Annotations[utils.HibernateClusterManifestAnnotationName]
 	if err := json.Unmarshal([]byte(clusterJSON), &clusterFromPVC); err != nil {
-		return v1.Cluster{}, err
+		return apiv1.Cluster{}, err
 	}
 	return clusterFromPVC, nil
 }

--- a/pkg/specs/jobs.go
+++ b/pkg/specs/jobs.go
@@ -212,7 +212,7 @@ func buildCommonInitJobFlags(cluster apiv1.Cluster) []string {
 // createPrimaryJob create a job that executes the provided command.
 // The role should describe the purpose of the executed job
 func createPrimaryJob(cluster apiv1.Cluster, nodeSerial int, role string, initCommand []string) *batchv1.Job {
-	instanceName := fmt.Sprintf("%s-%v", cluster.Name, nodeSerial)
+	instanceName := GetInstanceName(cluster.Name, nodeSerial)
 	jobName := fmt.Sprintf("%s-%v-%s", cluster.Name, nodeSerial, role)
 
 	job := &batchv1.Job{

--- a/pkg/specs/jobs.go
+++ b/pkg/specs/jobs.go
@@ -213,7 +213,7 @@ func buildCommonInitJobFlags(cluster apiv1.Cluster) []string {
 // The role should describe the purpose of the executed job
 func createPrimaryJob(cluster apiv1.Cluster, nodeSerial int, role string, initCommand []string) *batchv1.Job {
 	instanceName := GetInstanceName(cluster.Name, nodeSerial)
-	jobName := fmt.Sprintf("%s-%v-%s", cluster.Name, nodeSerial, role)
+	jobName := GetJobName(cluster.Name, nodeSerial, role)
 
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
@@ -279,4 +279,9 @@ func createPrimaryJob(cluster apiv1.Cluster, nodeSerial int, role string, initCo
 	}
 
 	return job
+}
+
+// GetJobName returns a string indicating the job name
+func GetJobName(clusterName string, nodeSerial int, role string) string {
+	return fmt.Sprintf("%s-%v-%s", clusterName, nodeSerial, role)
 }

--- a/pkg/specs/pods.go
+++ b/pkg/specs/pods.go
@@ -291,7 +291,7 @@ func CreatePodSecurityContext(user, group int64) *corev1.PodSecurityContext {
 
 // PodWithExistingStorage create a new instance with an existing storage
 func PodWithExistingStorage(cluster apiv1.Cluster, nodeSerial int) *corev1.Pod {
-	podName := fmt.Sprintf("%s-%v", cluster.Name, nodeSerial)
+	podName := GetInstanceName(cluster.Name, nodeSerial)
 	gracePeriod := int64(cluster.GetMaxStopDelay())
 
 	pod := &corev1.Pod{
@@ -329,6 +329,11 @@ func PodWithExistingStorage(cluster apiv1.Cluster, nodeSerial int) *corev1.Pod {
 		utils.AnnotateAppArmor(&pod.ObjectMeta, cluster.Annotations)
 	}
 	return pod
+}
+
+// GetInstanceName returns a string indicating the instance name
+func GetInstanceName(clusterName string, nodeSerial int) string {
+	return fmt.Sprintf("%s-%v", clusterName, nodeSerial)
 }
 
 // AddBarmanEndpointCAToPodSpec adds the required volumes and env variables needed by barman to work correctly

--- a/pkg/specs/pvcs.go
+++ b/pkg/specs/pvcs.go
@@ -81,7 +81,7 @@ func CreatePVC(
 	nodeSerial int,
 	role utils.PVCRole,
 ) (*corev1.PersistentVolumeClaim, error) {
-	instanceName := fmt.Sprintf("%s-%v", cluster.Name, nodeSerial)
+	instanceName := GetInstanceName(cluster.Name, nodeSerial)
 	pvcName := GetPVCName(cluster, instanceName, role)
 
 	result := &corev1.PersistentVolumeClaim{


### PR DESCRIPTION
This patch Introduces the `hibernate off` command and the needed reconciliation logic, which restores the cluster resource starting from the hibernated primary instance PVC Group.

You can reactivate a cluster with:

```
kubectl cnpg hibernate off <cluster-name>
```

This will:

1. fetch the hibernated PVC Group and select one of them (if multiple PVCs were created for a single instance)
2. extract the cluster manifest from the  `cnpg.io/hibernateClusterManifest` PVC annotation
3. clean the cluster manifest from any runtime data.
4. create the cluster resource 
5. the operator will detect the freshly created cluster having orphan PVCs
6. the operator will reassign the existing PVC to the cluster and recreate the primary instance

A future commit will implement the `hibernate status` command to check the status of the hibernation.


Closes #783 