### PR TITLE
feat: adds hibernate status command

### DIFF
--- a/docs/src/cnpg-plugin.md
+++ b/docs/src/cnpg-plugin.md
@@ -613,3 +613,11 @@ A hibernated cluster can be resumed with:
 ```
 kubectl cnpg hibernate off <cluster-name>
 ```
+
+Once the cluster has been hibernated, it's possible to show the last
+configuration and the status that PostgreSQL had after it was shut down.
+That can be done with:
+
+```
+kubectl cnpg hibernate status <cluster-name>
+```

--- a/internal/cmd/plugin/hibernate/cmd.go
+++ b/internal/cmd/plugin/hibernate/cmd.go
@@ -17,6 +17,8 @@ limitations under the License.
 package hibernate
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 )
 
@@ -51,6 +53,32 @@ var (
 			return off.execute()
 		},
 	}
+
+	hibernateStatusCmd = &cobra.Command{
+		Use:   "status [cluster]",
+		Short: "Prints the hibernation status for the [cluster]",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clusterName := args[0]
+			rawOutput, err := cmd.Flags().GetString("output")
+			if err != nil {
+				return err
+			}
+
+			switch statusOutput(rawOutput) {
+			case jsonStatusOutput:
+				filePath, err := cmd.Flags().GetString("file")
+				if err != nil {
+					return err
+				}
+				return newStatusCommandJSONOutput(cmd.Context(), clusterName, filePath).execute()
+			case textStatusOutput:
+				return newStatusCommandTextOutput(cmd.Context(), clusterName).execute()
+			default:
+				return fmt.Errorf("output: %s is not supported by the hibernate CLI", rawOutput)
+			}
+		},
+	}
 )
 
 // NewCmd initializes the hibernate command
@@ -62,11 +90,25 @@ func NewCmd() *cobra.Command {
 
 	cmd.AddCommand(hibernateOnCmd)
 	cmd.AddCommand(hibernateOffCmd)
+	cmd.AddCommand(hibernateStatusCmd)
 
 	hibernateOnCmd.Flags().Bool(
 		"force",
 		false,
 		"Force the hibernation procedure even if the preconditions are not met")
+	hibernateStatusCmd.Flags().
+		StringP(
+			"output",
+			"o",
+			"text",
+			"Output format. One of text|json. json format also accepts file output",
+		)
+	hibernateStatusCmd.Flags().
+		StringP(
+			"file",
+			"f",
+			"status.json",
+			"the path/name of the output file if the output is json format")
 
 	return cmd
 }

--- a/internal/cmd/plugin/hibernate/cmd.go
+++ b/internal/cmd/plugin/hibernate/cmd.go
@@ -107,7 +107,7 @@ func NewCmd() *cobra.Command {
 		StringP(
 			"file",
 			"f",
-			"status.json",
+			"-",
 			"the path/name of the output file if the output is json format")
 
 	return cmd

--- a/internal/cmd/plugin/hibernate/cmd.go
+++ b/internal/cmd/plugin/hibernate/cmd.go
@@ -107,7 +107,7 @@ func NewCmd() *cobra.Command {
 		StringP(
 			"file",
 			"f",
-			"-",
+			outputFileStdout,
 			"the path/name of the output file if the output is json format")
 
 	return cmd

--- a/internal/cmd/plugin/hibernate/output.go
+++ b/internal/cmd/plugin/hibernate/output.go
@@ -1,0 +1,229 @@
+package hibernate
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/cheynewallace/tabby"
+	"github.com/logrusorgru/aurora/v3"
+	"gopkg.in/yaml.v3"
+	corev1 "k8s.io/api/core/v1"
+
+	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/plugin"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/fileutils"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/log"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
+)
+
+const (
+	// statusClusterManifestNotFound is an error message reported when no cluster manifest is not found
+	statusClusterManifestNotFound = "Cluster manifest not found"
+)
+
+// statusOutputManager is a type capable of executing a status output request
+type statusOutputManager interface {
+	addHibernationSummaryInformation(level statusLevel, statusMessage, clusterName string)
+	addClusterManifestInformation(cluster *apiv1.Cluster)
+	addPVCGroupInformation(pvcs []corev1.PersistentVolumeClaim)
+	// execute renders the output
+	execute() error
+}
+
+type textStatusOutputManager struct {
+	textPrinter  *tabby.Tabby
+	stdoutBuffer *bytes.Buffer
+}
+
+func newTextStatusOutputManager() *textStatusOutputManager {
+	buffer := &bytes.Buffer{}
+	return &textStatusOutputManager{
+		textPrinter:  tabby.NewCustom(tabwriter.NewWriter(buffer, 0, 0, 4, ' ', 0)),
+		stdoutBuffer: buffer,
+	}
+}
+
+func (t *textStatusOutputManager) getColor(level statusLevel) aurora.Color {
+	switch level {
+	case warningLevel:
+		return aurora.YellowFg
+	case errorLevel:
+		return aurora.RedFg
+	default:
+		return aurora.GreenFg
+	}
+}
+
+func (t *textStatusOutputManager) addHibernationSummaryInformation(
+	level statusLevel,
+	statusMessage string,
+	clusterName string,
+) {
+	t.textPrinter.AddHeader(aurora.Colorize("Hibernation Summary", t.getColor(level)))
+	t.textPrinter.AddLine("Hibernation status", statusMessage)
+	t.textPrinter.AddLine("Cluster Name", clusterName)
+	t.textPrinter.AddLine("Cluster Namespace", plugin.Namespace)
+	t.textPrinter.AddLine()
+}
+
+func (t *textStatusOutputManager) addClusterManifestInformation(
+	cluster *apiv1.Cluster,
+) {
+	if cluster == nil {
+		t.textPrinter.AddHeader(aurora.Red("Cluster Spec Information"))
+		t.textPrinter.AddLine(aurora.Red(statusClusterManifestNotFound))
+		return
+	}
+
+	t.textPrinter.AddHeader(aurora.Green("Cluster Spec Information"))
+	bytesArray, err := yaml.Marshal(cluster.Spec)
+	if err != nil {
+		const message = "Could not serialize the cluster manifest"
+		t.textPrinter.AddLine(aurora.Red(message))
+		return
+	}
+
+	t.textPrinter.AddLine(string(bytesArray))
+	t.textPrinter.AddLine()
+}
+
+func (t *textStatusOutputManager) addPVCGroupInformation(
+	pvcs []corev1.PersistentVolumeClaim,
+) {
+	if len(pvcs) == 0 {
+		return
+	}
+
+	// there is no need to iterate the pvc group, it is either all valid or none
+	value, ok := pvcs[0].Annotations[utils.HibernatePgControlDataAnnotationName]
+	if !ok {
+		return
+	}
+
+	t.textPrinter.AddHeader(aurora.Green("PG CONTROL DATA"))
+	t.textPrinter.AddLine(value)
+	t.textPrinter.AddLine()
+}
+
+func (t *textStatusOutputManager) execute() error {
+	// do not remove this is to flush the writer cache into the buffer
+	t.textPrinter.Print()
+	fmt.Println(t.stdoutBuffer)
+	return nil
+}
+
+type jsonStatusOutputManager struct {
+	mapToSerialize map[string]interface{}
+	jsonFilePath   string
+	ctx            context.Context
+}
+
+func newJSONOutputManager(ctx context.Context, jsonFilePath string) *jsonStatusOutputManager {
+	return &jsonStatusOutputManager{
+		mapToSerialize: map[string]interface{}{},
+		jsonFilePath:   jsonFilePath,
+		ctx:            ctx,
+	}
+}
+
+func (t *jsonStatusOutputManager) addHibernationSummaryInformation(
+	level statusLevel,
+	statusMessage string,
+	clusterName string,
+) {
+	t.mapToSerialize["summary"] = map[string]string{
+		"status":      statusMessage,
+		"clusterName": clusterName,
+		"namespace":   plugin.Namespace,
+		"level":       string(level),
+	}
+}
+
+func (t *jsonStatusOutputManager) addClusterManifestInformation(
+	cluster *apiv1.Cluster,
+) {
+	tmpMap := map[string]interface{}{}
+	defer func() {
+		t.mapToSerialize["cluster"] = tmpMap
+	}()
+
+	if cluster == nil {
+		tmpMap["error"] = statusClusterManifestNotFound
+		return
+	}
+
+	tmpMap["spec"] = cluster.Spec
+}
+
+func (t *jsonStatusOutputManager) addPVCGroupInformation(
+	pvcs []corev1.PersistentVolumeClaim,
+) {
+	contextLogger := log.FromContext(t.ctx)
+
+	// there is no need to iterate the pvc group, it is either all valid or none
+	value, ok := pvcs[0].Annotations[utils.HibernatePgControlDataAnnotationName]
+	if !ok {
+		return
+	}
+
+	tmp := map[string]string{}
+	rows := strings.Split(value, "\n")
+	for _, row := range rows {
+		// skip empty rows
+		if strings.Trim(row, " ") == "" {
+			continue
+		}
+
+		res := strings.SplitN(row, ":", 2)
+		if len(res) != 2 {
+			// bad row parsing, we skip it
+			contextLogger.Warning("skipping row because it was malformed", "row", row)
+			tmp["error"] = "one or more rows could not be parsed"
+			continue
+		}
+		tmp[res[0]] = strings.Trim(res[1], " ")
+	}
+
+	t.mapToSerialize["pgData"] = tmp
+}
+
+func (t *jsonStatusOutputManager) execute() error {
+	byteArray, err := json.Marshal(t.mapToSerialize)
+	if err != nil {
+		return err
+	}
+
+	if exists, _ := fileutils.FileExists(t.jsonFilePath); exists {
+		return fmt.Errorf("file already exist will not overwrite")
+	}
+
+	f, err := os.Create(t.jsonFilePath)
+	if err != nil {
+		return err
+	}
+
+	contextLogger := log.FromContext(t.ctx)
+	defer func() {
+		if closeErr := f.Close(); closeErr != nil {
+			contextLogger.Error(closeErr, "error while closing the file")
+		}
+	}()
+
+	_, err = f.Write(byteArray)
+	if err != nil {
+		return err
+	}
+
+	// JSON files should end with a newline
+	_, err = f.WriteString("\n")
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/cmd/plugin/hibernate/output.go
+++ b/internal/cmd/plugin/hibernate/output.go
@@ -119,7 +119,7 @@ func (t *textStatusOutputManager) addPVCGroupInformation(
 		return
 	}
 
-	t.textPrinter.AddHeader(aurora.Green("PG CONTROL DATA"))
+	t.textPrinter.AddHeader(aurora.Green("PostgreSQL instance control information"))
 	t.textPrinter.AddLine(value)
 }
 

--- a/internal/cmd/plugin/hibernate/output.go
+++ b/internal/cmd/plugin/hibernate/output.go
@@ -1,3 +1,19 @@
+/*
+Copyright The CloudNativePG Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package hibernate
 
 import (
@@ -11,8 +27,8 @@ import (
 
 	"github.com/cheynewallace/tabby"
 	"github.com/logrusorgru/aurora/v3"
-	"gopkg.in/yaml.v3"
 	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/yaml"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/plugin"
@@ -107,13 +123,12 @@ func (t *textStatusOutputManager) addPVCGroupInformation(
 
 	t.textPrinter.AddHeader(aurora.Green("PG CONTROL DATA"))
 	t.textPrinter.AddLine(value)
-	t.textPrinter.AddLine()
 }
 
 func (t *textStatusOutputManager) execute() error {
 	// do not remove this is to flush the writer cache into the buffer
 	t.textPrinter.Print()
-	fmt.Println(t.stdoutBuffer)
+	fmt.Print(t.stdoutBuffer)
 	return nil
 }
 
@@ -189,7 +204,7 @@ func (t *jsonStatusOutputManager) addPVCGroupInformation(
 		tmp[res[0]] = strings.Trim(res[1], " ")
 	}
 
-	t.mapToSerialize["pgData"] = tmp
+	t.mapToSerialize["pgControlData"] = tmp
 }
 
 func (t *jsonStatusOutputManager) execute() error {

--- a/internal/cmd/plugin/hibernate/status.go
+++ b/internal/cmd/plugin/hibernate/status.go
@@ -29,14 +29,6 @@ import (
 	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/plugin"
 )
 
-// statusOutput is a supported type of stdout for the status command
-type statusOutput string
-
-const (
-	jsonStatusOutput statusOutput = "json"
-	textStatusOutput statusOutput = "text"
-)
-
 // statusLevel describes if the output should communicate an ok,warning or error status
 type statusLevel string
 
@@ -52,9 +44,13 @@ type statusCommand struct {
 	clusterName   string
 }
 
-func newStatusCommandJSONOutput(ctx context.Context, clusterName string, jsonFilePath string) *statusCommand {
+func newStatusCommandStructuredOutput(
+	ctx context.Context,
+	clusterName string,
+	format plugin.OutputFormat,
+) *statusCommand {
 	return &statusCommand{
-		outputManager: newJSONOutputManager(ctx, jsonFilePath),
+		outputManager: newStructuredOutputManager(ctx, format),
 		ctx:           ctx,
 		clusterName:   clusterName,
 	}

--- a/internal/cmd/plugin/hibernate/status.go
+++ b/internal/cmd/plugin/hibernate/status.go
@@ -1,0 +1,127 @@
+/*
+Copyright The CloudNativePG Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hibernate
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/plugin"
+)
+
+// statusOutput is a supported type of stdout for the status command
+type statusOutput string
+
+const (
+	jsonStatusOutput statusOutput = "json"
+	textStatusOutput statusOutput = "text"
+)
+
+// statusLevel describes if the output should communicate an ok,warning or error status
+type statusLevel string
+
+const (
+	okLevel      statusLevel = "ok"
+	warningLevel statusLevel = "warning"
+	errorLevel   statusLevel = "error"
+)
+
+type statusCommand struct {
+	outputManager statusOutputManager
+	ctx           context.Context
+	clusterName   string
+}
+
+func newStatusCommandJSONOutput(ctx context.Context, clusterName string, jsonFilePath string) *statusCommand {
+	return &statusCommand{
+		outputManager: newJSONOutputManager(ctx, jsonFilePath),
+		ctx:           ctx,
+		clusterName:   clusterName,
+	}
+}
+
+func newStatusCommandTextOutput(ctx context.Context, clusterName string) *statusCommand {
+	return &statusCommand{
+		outputManager: newTextStatusOutputManager(),
+		ctx:           ctx,
+		clusterName:   clusterName,
+	}
+}
+
+func (cmd *statusCommand) execute() error {
+	isDeployed, err := cmd.isClusterDeployed()
+	if err != nil {
+		return err
+	}
+	if isDeployed {
+		return cmd.clusterIsAlreadyRunningOutput()
+	}
+
+	pvcs, err := getHibernatedPVCGroup(cmd.ctx, cmd.clusterName)
+	if errors.Is(err, errNoHibernatedPVCsFound) {
+		return cmd.noHibernatedPVCsOutput()
+	}
+	if err != nil {
+		return err
+	}
+
+	return cmd.clusterHibernatedOutput(pvcs)
+}
+
+func (cmd *statusCommand) clusterHibernatedOutput(pvcs []corev1.PersistentVolumeClaim) error {
+	clusterFromPVC, err := getClusterFromPVCAnnotation(pvcs[0])
+	if err != nil {
+		return err
+	}
+
+	cmd.outputManager.addHibernationSummaryInformation(okLevel, "Cluster Hibernated", cmd.clusterName)
+	cmd.outputManager.addClusterManifestInformation(&clusterFromPVC)
+	cmd.outputManager.addPVCGroupInformation(pvcs)
+
+	return cmd.outputManager.execute()
+}
+
+func (cmd *statusCommand) clusterIsAlreadyRunningOutput() error {
+	cmd.outputManager.addHibernationSummaryInformation(warningLevel, "No Hibernation. Cluster Deployed.", cmd.clusterName)
+	return cmd.outputManager.execute()
+}
+
+func (cmd *statusCommand) noHibernatedPVCsOutput() error {
+	cmd.outputManager.addHibernationSummaryInformation(errorLevel, "No hibernated PVCs found", cmd.clusterName)
+	return cmd.outputManager.execute()
+}
+
+func (cmd *statusCommand) isClusterDeployed() (bool, error) {
+	var cluster apiv1.Cluster
+
+	// Get the Cluster object
+	err := plugin.Client.Get(cmd.ctx, client.ObjectKey{Namespace: plugin.Namespace, Name: cmd.clusterName}, &cluster)
+	if apierrs.IsNotFound(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("error while fetching the cluster resource: %w", err)
+	}
+
+	return true, nil
+}

--- a/internal/cmd/plugin/printer.go
+++ b/internal/cmd/plugin/printer.go
@@ -37,6 +37,12 @@ func Print(o interface{}, format OutputFormat, writer io.Writer) error {
 			return err
 		}
 
+		// json.MarshalIndent doesn't add the final newline
+		_, err = io.WriteString(writer, "\n")
+		if err != nil {
+			return err
+		}
+
 	case OutputFormatYAML:
 		data, err := yaml.Marshal(o)
 		if err != nil {
@@ -47,12 +53,6 @@ func Print(o interface{}, format OutputFormat, writer io.Writer) error {
 		if err != nil {
 			return err
 		}
-	}
-
-	// Files should end with a newline
-	_, err := io.WriteString(writer, "\n")
-	if err != nil {
-		return err
 	}
 
 	return nil

--- a/internal/cmd/plugin/printer.go
+++ b/internal/cmd/plugin/printer.go
@@ -49,5 +49,11 @@ func Print(o interface{}, format OutputFormat, writer io.Writer) error {
 		}
 	}
 
+	// Files should end with a newline
+	_, err := io.WriteString(writer, "\n")
+	if err != nil {
+		return err
+	}
+
 	return nil
 }


### PR DESCRIPTION
This patch Introduces the `hibernate status` command, which reports the cluster hibernation status. 

It supports two outputs:
- `text`, which prints the hibernation status to stdout.
- `json` which outputs the data in a json format. This mode also supports the `--file` or `-f` flag to indicate in which `path/file` the generated json should be put, if not specified it prints the json in stdout. 

You can print the cluster hibernation status with:
```
kubectl cnpg hibernate status <cluster-name>
```

The command can detect three different statuses:

- The cluster already exists.
- The cluster doesn't exist and the PVC is hibernated.
- Neither the cluster nor the hibernated PVC exists.

Closes #789 