### PR TITLE
feat: adding security context to e2e test pods

### DIFF
--- a/tests/utils/azurite.go
+++ b/tests/utils/azurite.go
@@ -22,6 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/pointer"
 
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/certs"
 )
@@ -139,9 +140,9 @@ func getAzuriteClientPod(namespace string) corev1.Pod {
 						},
 					},
 					SecurityContext: &corev1.SecurityContext{
-						AllowPrivilegeEscalation: boolPtr(false),
+						AllowPrivilegeEscalation: pointer.Bool(false),
 						SeccompProfile:           &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
-						RunAsNonRoot:             boolPtr(false),
+						RunAsNonRoot:             pointer.Bool(true),
 					},
 				},
 			},
@@ -160,6 +161,10 @@ func getAzuriteClientPod(namespace string) corev1.Pod {
 						},
 					},
 				},
+			},
+			SecurityContext: &corev1.PodSecurityContext{
+				RunAsNonRoot:   pointer.Bool(true),
+				SeccompProfile: &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
 			},
 		},
 	}

--- a/tests/utils/azurite.go
+++ b/tests/utils/azurite.go
@@ -138,6 +138,11 @@ func getAzuriteClientPod(namespace string) corev1.Pod {
 							MountPath: "/etc/ssl/certs",
 						},
 					},
+					SecurityContext: &corev1.SecurityContext{
+						AllowPrivilegeEscalation: boolPtr(false),
+						SeccompProfile:           &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
+						RunAsNonRoot:             boolPtr(false),
+					},
 				},
 			},
 			Volumes: []corev1.Volume{

--- a/tests/utils/commons.go
+++ b/tests/utils/commons.go
@@ -135,3 +135,8 @@ func GetObject(env *TestingEnvironment, objectKey client.ObjectKey, object clien
 	)
 	return err
 }
+
+// boolPtr takes a bool and returns a pointer to that value
+func boolPtr(value bool) *bool {
+	return &value
+}

--- a/tests/utils/commons.go
+++ b/tests/utils/commons.go
@@ -135,8 +135,3 @@ func GetObject(env *TestingEnvironment, objectKey client.ObjectKey, object clien
 	)
 	return err
 }
-
-// boolPtr takes a bool and returns a pointer to that value
-func boolPtr(value bool) *bool {
-	return &value
-}

--- a/tests/utils/curl.go
+++ b/tests/utils/curl.go
@@ -18,6 +18,7 @@ package utils
 
 import (
 	"fmt"
+	"k8s.io/utils/pointer"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -37,10 +38,19 @@ func CurlClient(namespace string) corev1.Pod {
 					Name:    "curl",
 					Image:   "curlimages/curl:7.82.0",
 					Command: []string{"sleep", "3600"},
+					SecurityContext: &corev1.SecurityContext{
+						AllowPrivilegeEscalation: pointer.Bool(false),
+						SeccompProfile:           &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
+						RunAsNonRoot:             pointer.Bool(true),
+					},
 				},
 			},
 			DNSPolicy:     corev1.DNSClusterFirst,
 			RestartPolicy: corev1.RestartPolicyAlways,
+			SecurityContext: &corev1.PodSecurityContext{
+				SeccompProfile: &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
+				RunAsNonRoot:   pointer.Bool(true),
+			},
 		},
 	}
 	return curlPod

--- a/tests/utils/minio.go
+++ b/tests/utils/minio.go
@@ -19,6 +19,7 @@ package utils
 import (
 	"encoding/json"
 	"fmt"
+	"k8s.io/utils/pointer"
 	"os"
 	"strconv"
 	"strings"
@@ -186,7 +187,16 @@ func MinioDefaultDeployment(namespace string, minioPVC corev1.PersistentVolumeCl
 								},
 								InitialDelaySeconds: 30,
 							},
+							SecurityContext: &corev1.SecurityContext{
+								AllowPrivilegeEscalation: pointer.Bool(false),
+								SeccompProfile:           &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
+								RunAsNonRoot:             pointer.Bool(true),
+							},
 						},
+					},
+					SecurityContext: &corev1.PodSecurityContext{
+						RunAsNonRoot:   pointer.Bool(true),
+						SeccompProfile: &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
 					},
 				},
 			},

--- a/tests/utils/webapp.go
+++ b/tests/utils/webapp.go
@@ -19,6 +19,7 @@ package utils
 import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
 )
 
 // DefaultWebapp returns a struct representing a
@@ -70,11 +71,15 @@ func DefaultWebapp(namespace string, name string, rootCASecretName string, tlsSe
 						},
 					},
 					SecurityContext: &corev1.SecurityContext{
-						RunAsNonRoot:             boolPtr(false),
-						AllowPrivilegeEscalation: boolPtr(false),
+						RunAsNonRoot:             pointer.Bool(true),
+						AllowPrivilegeEscalation: pointer.Bool(false),
 						SeccompProfile:           &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
 					},
 				},
+			},
+			SecurityContext: &corev1.PodSecurityContext{
+				RunAsNonRoot:   pointer.Bool(true),
+				SeccompProfile: &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
 			},
 		},
 	}

--- a/tests/utils/webapp.go
+++ b/tests/utils/webapp.go
@@ -69,6 +69,11 @@ func DefaultWebapp(namespace string, name string, rootCASecretName string, tlsSe
 							MountPath: "/etc/secrets/tls",
 						},
 					},
+					SecurityContext: &corev1.SecurityContext{
+						RunAsNonRoot:             boolPtr(false),
+						AllowPrivilegeEscalation: boolPtr(false),
+						SeccompProfile:           &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
For security reasons we should specify at least the following options:

* allowPrivilegeEscalation
* secCompProfile
* runAsNonRoot

All of these in the SecurityContext section of the pods

Signed-off-by: Jonathan Gonzalez V <jonathan.gonzalez@enterprisedb.com>