### PR TITLE
feat: add support for http proxies

### DIFF
--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -1527,6 +1527,30 @@ func (cluster *Cluster) GetImageName() string {
 	return configuration.Current.PostgresImageName
 }
 
+// SetEnvProxies to pass proxies defined for operator to clusters
+func (cluster *Cluster) SetEnvProxies(envvar []corev1.EnvVar) []corev1.EnvVar {
+
+	if configuration.Current.EnvHttpProxy != "" {
+		envvar = append(envvar, corev1.EnvVar{
+			Name:  "HTTP_PROXY",
+			Value: configuration.Current.EnvHttpProxy,
+		})
+	}
+	if configuration.Current.EnvHttpsProxy != "" {
+		envvar = append(envvar, corev1.EnvVar{
+			Name:  "HTTPS_PROXY",
+			Value: configuration.Current.EnvHttpProxy,
+		})
+	}
+	if configuration.Current.EnvNoProxy != "" {
+		envvar = append(envvar, corev1.EnvVar{
+			Name:  "NO_PROXY",
+			Value: configuration.Current.EnvNoProxy,
+		})
+	}
+	return envvar
+}
+
 // GetPostgresqlVersion gets the PostgreSQL image version detecting it from the
 // image name.
 // Example:

--- a/internal/configuration/configuration.go
+++ b/internal/configuration/configuration.go
@@ -48,9 +48,9 @@ type Data struct {
 	EnablePodDebugging bool `json:"enablePodDebugging" env:"POD_DEBUG"`
 
 	// Proxies variable
-	EnvHttpProxy  string `env:"HTTP_PROXY"`
-	EnvHttpsProxy string `env:"HTTPS_PROXY"`
-	EnvNoProxy    string `env:"NO_PROXY"`
+	EnvHttpProxy  string `json:"envHttpProxy" env:"HTTP_PROXY"`
+	EnvHttpsProxy string `json:"envHttpsProxy" env:"HTTPS_PROXY"`
+	EnvNoProxy    string `json:"envNoProxy" env:"NO_PROXY"`
 
 	// OperatorNamespace is the namespace where the operator is installed
 	OperatorNamespace string `json:"operatorNamespace" env:"OPERATOR_NAMESPACE"`

--- a/internal/configuration/configuration.go
+++ b/internal/configuration/configuration.go
@@ -47,6 +47,11 @@ type Data struct {
 	// EnablePodDebugging enable debugging mode in new generated pods
 	EnablePodDebugging bool `json:"enablePodDebugging" env:"POD_DEBUG"`
 
+	// Proxies variable
+	EnvHttpProxy  string `env:"HTTP_PROXY"`
+	EnvHttpsProxy string `env:"HTTPS_PROXY"`
+	EnvNoProxy    string `env:"NO_PROXY"`
+
 	// OperatorNamespace is the namespace where the operator is installed
 	OperatorNamespace string `json:"operatorNamespace" env:"OPERATOR_NAMESPACE"`
 

--- a/pkg/specs/pods.go
+++ b/pkg/specs/pods.go
@@ -117,7 +117,9 @@ func createEnvVarPostgresContainer(cluster apiv1.Cluster, podName string) []core
 		},
 	}
 
-	return envVar
+	proxiedEnvVar := cluster.SetEnvProxies(envVar)
+
+	return proxiedEnvVar
 }
 
 // createPostgresContainers create the PostgreSQL containers that are


### PR DESCRIPTION
One of my cloud providers expects me to manage proxies to go outside of the Kubernetes cluster, especially for S3 storage.

Here is a proposal to take common proxies environment variables at operator install and push them to child clusters at creation time.

Example:

Environment added at operator install:

```yaml
    - name: HTTP_PROXY
      value: http://someproxy:8080
    - name: HTTPS_PROXY
      value: http://someproxy:8080
    - name: NO_PROXY
      value: .cluster.local,.svc,10.128.0.0/14,127.0.0.0/8,127.0.0.1,localhost
```

Without patch, environment for a pod of a Cluster:

```yaml
    env:
    - name: PGDATA
      value: /var/lib/postgresql/data/pgdata
    - name: POD_NAME
      value: pgcluster-1
    - name: NAMESPACE
      value: somenamespace
    - name: CLUSTER_NAME
      value: pgcluster
    - name: PGPORT
      value: "5432"
    - name: PGHOST
      value: /controller/run
```

With patch, environment for a pod of a Cluster:

```yaml
    env:
    - name: PGDATA
      value: /var/lib/postgresql/data/pgdata
    - name: POD_NAME
      value: pgcluster-1
    - name: NAMESPACE
      value: somenamespace
    - name: CLUSTER_NAME
      value: pgcluster
    - name: PGPORT
      value: "5432"
    - name: PGHOST
      value: /controller/run
    - name: HTTP_PROXY
      value: http://someproxy:8080
    - name: HTTPS_PROXY
      value: http://someproxy:8080
    - name: NO_PROXY
      value: .cluster.local,.svc,10.128.0.0/14,127.0.0.0/8,127.0.0.1,localhost
```