### PR TITLE
chore: ensures that `CreatePodMonitor` uses `LabelClusterName`

### DIFF
--- a/pkg/specs/podmonitor.go
+++ b/pkg/specs/podmonitor.go
@@ -26,23 +26,25 @@ import (
 
 // CreatePodMonitor create a new podmonitor for cluster
 func CreatePodMonitor(cluster *apiv1.Cluster) *monitoringv1.PodMonitor {
-	labels := make(map[string]string)
-	labels[utils.ClusterLabelName] = cluster.Name
+	meta := metav1.ObjectMeta{
+		Namespace: cluster.Namespace,
+		Name:      cluster.Name,
+	}
+	utils.LabelClusterName(&meta, cluster.Name)
+
+	spec := monitoringv1.PodMonitorSpec{
+		Selector: metav1.LabelSelector{
+			MatchLabels: meta.Labels,
+		},
+		PodMetricsEndpoints: []monitoringv1.PodMetricsEndpoint{
+			{
+				Port: "metrics",
+			},
+		},
+	}
 
 	return &monitoringv1.PodMonitor{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: cluster.Namespace,
-			Name:      cluster.Name,
-		},
-		Spec: monitoringv1.PodMonitorSpec{
-			Selector: metav1.LabelSelector{
-				MatchLabels: labels,
-			},
-			PodMetricsEndpoints: []monitoringv1.PodMetricsEndpoint{
-				{
-					Port: "metrics",
-				},
-			},
-		},
+		ObjectMeta: meta,
+		Spec:       spec,
 	}
 }

--- a/pkg/specs/podmonitor_test.go
+++ b/pkg/specs/podmonitor_test.go
@@ -1,0 +1,47 @@
+/*
+Copyright The CloudNativePG Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package specs
+
+import (
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("PodMonitor test", func() {
+	It("should create a valid monitoringv1.PodMonitor object", func() {
+		const (
+			clusterName      = "test"
+			clusterNamespace = "test-namespace"
+		)
+		cluster := v1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: clusterNamespace,
+				Name:      clusterName,
+			},
+		}
+		monitor := CreatePodMonitor(&cluster)
+		Expect(monitor.Labels[utils.ClusterLabelName]).To(Equal(clusterName))
+		Expect(monitor.Spec.Selector.MatchLabels[utils.ClusterLabelName]).To(Equal(clusterName))
+		Expect(monitor.Spec.PodMetricsEndpoints).To(ContainElement(monitoringv1.PodMetricsEndpoint{Port: "metrics"}))
+	})
+})


### PR DESCRIPTION
This patch makes sure that we avoid writing directly the `ClusterLabelName` annotation inside the CreatePodMonitor method. This removes the duplicated ClusterLabelName annotation writing logic.

Partially Closes #837

Signed-off-by: Armando Ruocco <armando.ruocco@enterprisedb.com>