### PR TITLE
fix: add the operator image env

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -9,6 +9,7 @@ on:
     branches:
       - main
       - release-*
+      - dev/fix_operator_image_env
   # A pull request (from this repository or a forked one) which is labelled
   pull_request_target:
     types: [labeled]
@@ -174,6 +175,7 @@ jobs:
     #        'ready to test :elephant:'
     # OR     it's on main branch
     if: |
+      false &&
       needs.duplicate_runs.outputs.should_skip != 'true' &&
       (
         needs.change-triage.outputs.operator-changed == 'true' ||

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -9,7 +9,6 @@ on:
     branches:
       - main
       - release-*
-      - dev/fix_operator_image_env
   # A pull request (from this repository or a forked one) which is labelled
   pull_request_target:
     types: [labeled]
@@ -175,7 +174,6 @@ jobs:
     #        'ready to test :elephant:'
     # OR     it's on main branch
     if: |
-      false &&
       needs.duplicate_runs.outputs.should_skip != 'true' &&
       (
         needs.change-triage.outputs.operator-changed == 'true' ||

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -519,6 +519,7 @@ jobs:
         name: Generate manifest for operator deployment
         id: generate-manifest
         run: |
+          CONTROLLER_IMG=${{ steps.image-meta.outputs.image }}
           make generate-manifest
       -
         name: Upload the operator manifest as artifact in workflow

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -518,8 +518,9 @@ jobs:
       -
         name: Generate manifest for operator deployment
         id: generate-manifest
+        env:
+          CONTROLLER_IMG: ${{ steps.image-meta.outputs.image }}
         run: |
-          CONTROLLER_IMG=${{ steps.image-meta.outputs.image }}
           make generate-manifest
       -
         name: Upload the operator manifest as artifact in workflow


### PR DESCRIPTION
`CONTROLLER_IMG` need to be set in `generate-manifest` in case the value can't be correctly inferred when the branch name of the PR can't be parsed from the SHA value.

Signed-off-by: Hai He <hai.he@enterprisedb.com>