### PR TITLE
fix: avoid failovers when Pod readiness status is stale

### DIFF
--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -271,7 +271,7 @@ func (r *ClusterReconciler) reconcile(ctx context.Context, cluster *apiv1.Cluste
 	// readiness probe.
 	if instancesStatus.Len() > 0 {
 		isPostgresReady := instancesStatus.Items[0].IsPostgresqlReady()
-		isPodReady := instancesStatus.Items[0].IsReadinessProbePositive()
+		isPodReady := instancesStatus.Items[0].IsPodReady
 
 		if isPostgresReady && !isPodReady {
 			// The readiness probe status from the Kubelet is not updated, so

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -253,6 +253,39 @@ func (r *ClusterReconciler) reconcile(ctx context.Context, cluster *apiv1.Cluste
 		onlineUpdateEnabled = false
 	}
 
+	// The instance list is sorted and will present the primary as the first
+	// element, followed by the replicas, the most updated coming first.
+	// Pods that are not responding will be at the end of the list. We use
+	// the information reported by the instance manager to sort the
+	// instances. When we need to elect a new primary, we take the first item
+	// on this list.
+	//
+	// Here we check the readiness status of the first Pod as we can't
+	// promote an instance that is not ready from the Kubernetes
+	// point-of-view: the services will not forward traffic to it even if
+	// PostgreSQL is up and running.
+	//
+	// An instance can be up and running even if the readiness probe is
+	// negative: this is going to happen, i.e., when an instance is
+	// un-fenced, and the Kubelet still hasn't refreshed the status of the
+	// readiness probe.
+	if instancesStatus.Len() > 0 {
+		isPostgresReady := instancesStatus.Items[0].IsPostgresqlReady()
+		isPodReady := instancesStatus.Items[0].IsReadinessProbePositive()
+
+		if isPostgresReady && !isPodReady {
+			// The readiness probe status from the Kubelet is not updated, so
+			// we need to wait for it to be refreshed
+			contextLogger.Info(
+				"Waiting for the Kubelet to refresh the readiness probe",
+				"instanceName", instancesStatus.Items[0].Node,
+				"instanceStatus", instancesStatus.Items[0],
+				"isPostgresReady", isPostgresReady,
+				"isPodReady", isPodReady)
+			return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
+		}
+	}
+
 	// We have already updated the status in updateResourceStatus call,
 	// so we need to issue an extra update when the OnlineUpdateEnabled changes.
 	// It's okay because it should not change often.

--- a/controllers/cluster_status.go
+++ b/controllers/cluster_status.go
@@ -817,13 +817,6 @@ func (r *ClusterReconciler) extractInstancesStatus(
 
 	for idx := range activePods {
 		instanceStatus := r.getReplicaStatusFromPodViaHTTP(ctx, activePods[idx])
-
-		// IsReady is not populated by the instance manager, so we detect it from the
-		// Pod status
-		instanceStatus.IsReady = utils.IsPodReady(activePods[idx])
-		instanceStatus.Node = activePods[idx].Spec.NodeName
-		instanceStatus.Pod = activePods[idx]
-
 		result.Items = append(result.Items, instanceStatus)
 	}
 	return result
@@ -863,6 +856,8 @@ func (r *ClusterReconciler) getReplicaStatusFromPodViaHTTP(
 		result = rawInstanceStatusRequest(ctx, r.timeoutHTTPClient, pod)
 		return result.Error
 	})
+
+	result.AddPod(pod)
 
 	return result
 }

--- a/controllers/cluster_upgrade.go
+++ b/controllers/cluster_upgrade.go
@@ -226,7 +226,7 @@ func IsPodNeedingRollout(status postgres.PostgresqlStatus, cluster *apiv1.Cluste
 	inPlacePossible bool,
 	reason string,
 ) {
-	if !status.IsReady || cluster.IsInstanceFenced(status.Pod.Name) || status.MightBeUnavailable {
+	if !status.IsPodReady || cluster.IsInstanceFenced(status.Pod.Name) || status.MightBeUnavailable {
 		return false, false, ""
 	}
 

--- a/controllers/cluster_upgrade_test.go
+++ b/controllers/cluster_upgrade_test.go
@@ -78,7 +78,7 @@ var _ = Describe("Pod upgrade", func() {
 		Expect(inplacePossible).To(BeFalse())
 		Expect(reason).To(BeEmpty())
 
-		status.IsReady = true
+		status.IsPodReady = true
 		needRollout, inplacePossible, reason = IsPodNeedingRollout(status, &cluster)
 		Expect(needRollout).To(BeTrue())
 		Expect(inplacePossible).To(BeFalse())

--- a/controllers/replicas.go
+++ b/controllers/replicas.go
@@ -37,7 +37,7 @@ import (
 var ErrWalReceiversRunning = fmt.Errorf("wal receivers are still running")
 
 // updateTargetPrimaryFromPods sets the name of the target primary from the Pods status if needed
-// this function will returns the name of the new primary selected for promotion
+// this function will return the name of the new primary selected for promotion
 func (r *ClusterReconciler) updateTargetPrimaryFromPods(
 	ctx context.Context,
 	cluster *apiv1.Cluster,

--- a/controllers/replicas.go
+++ b/controllers/replicas.go
@@ -54,7 +54,7 @@ func (r *ClusterReconciler) updateTargetPrimaryFromPods(
 
 	// First step: check if the current primary is running in an unschedulable node
 	// and issue a switchover if that's the case
-	if primary := status.Items[0]; (primary.IsPrimary || (cluster.IsReplica() && primary.IsReady)) &&
+	if primary := status.Items[0]; (primary.IsPrimary || (cluster.IsReplica() && primary.IsPodReady)) &&
 		primary.Pod.Name == cluster.Status.CurrentPrimary &&
 		cluster.Status.TargetPrimary == cluster.Status.CurrentPrimary {
 		isPrimaryOnUnschedulableNode, err := r.isNodeUnschedulable(ctx, primary.Node)

--- a/pkg/postgres/status_test.go
+++ b/pkg/postgres/status_test.go
@@ -30,44 +30,41 @@ import (
 )
 
 var _ = Describe("PostgreSQL status", func() {
+	errCannotConnectToPostgres := fmt.Errorf("cannot connect to PostgreSQL")
+
 	list := PostgresqlStatusList{
 		Items: []PostgresqlStatus{
 			{
-				Pod:     corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "server-04"}},
-				Error:   fmt.Errorf("cannot find postgres container"),
-				IsReady: true,
+				Pod:   corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "server-04"}},
+				Error: errCannotConnectToPostgres,
 			},
 			{
 				Pod:         corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "server-06"}},
 				IsPrimary:   false,
 				ReceivedLsn: "1/23",
 				ReplayLsn:   "1/22",
-				IsReady:     false,
+				Error:       errCannotConnectToPostgres,
 			},
 			{
 				Pod:         corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "server-30"}},
 				IsPrimary:   false,
 				ReceivedLsn: "1/23",
 				ReplayLsn:   "1/22",
-				IsReady:     true,
 			},
 			{
 				Pod:         corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "server-20"}},
 				IsPrimary:   false,
 				ReceivedLsn: "1/21",
-				IsReady:     true,
 			},
 			{
 				Pod:       corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "server-10"}},
 				IsPrimary: true,
-				IsReady:   true,
 			},
 			{
 				Pod:         corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "server-40"}},
 				IsPrimary:   false,
 				ReceivedLsn: "1/23",
 				ReplayLsn:   "1/23",
-				IsReady:     true,
 			},
 		},
 	}
@@ -79,12 +76,10 @@ var _ = Describe("PostgreSQL status", func() {
 					Pod:         corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "server-20"}},
 					IsPrimary:   false,
 					ReceivedLsn: "1/21",
-					IsReady:     true,
 				},
 				{
 					Pod:       corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "server-10"}},
 					IsPrimary: true,
-					IsReady:   true,
 				},
 			},
 		}
@@ -100,12 +95,10 @@ var _ = Describe("PostgreSQL status", func() {
 					Pod:         corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "server-20"}},
 					IsPrimary:   false,
 					ReceivedLsn: "1/21",
-					IsReady:     true,
 				},
 				{
 					Pod:       corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "server-10"}},
 					IsPrimary: true,
-					IsReady:   true,
 				},
 			},
 		}
@@ -120,12 +113,10 @@ var _ = Describe("PostgreSQL status", func() {
 				{
 					Pod:       corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "server-20"}},
 					IsPrimary: false,
-					IsReady:   true,
 				},
 				{
 					Pod:       corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "server-10"}},
 					IsPrimary: true,
-					IsReady:   true,
 				},
 			},
 		}


### PR DESCRIPTION
The operator was relying on the readiness status of the Pod to determine if the current primary was healthy of not, but sometimes this will be different from the real PostgreSQL status since it's checked every `periodSeconds` by the Kubelet.

This can happen when lifting fencing from the primary node and the Kubelet still haven't marked the Pod as ready, leading for a failover to happen immediately after the event.

With this patch, we are using the status collected from the instance manager to elect the new primary, and we'll wait for the Kubelet to refresh the readiness probe status when PostgreSQL is up and running but the Pod is still marked as non ready.

Closes: #889

Signed-off-by: Leonardo Cecchi <leonardo.cecchi@enterprisedb.com>