### PR TITLE
chore: replace deprecated set-output command in workflow

### DIFF
--- a/.github/e2e-matrix-generator.py
+++ b/.github/e2e-matrix-generator.py
@@ -16,6 +16,7 @@
 
 import argparse
 import json
+import os
 import re
 import sys
 from operator import itemgetter
@@ -252,5 +253,6 @@ if __name__ == "__main__":
         for job in include:
             job["id"] = engine + "-" + job["id"]
             print(f"Generating {engine}: {job['id']}", file=sys.stderr)
-        print(f"::set-output name={engine}Matrix::" + json.dumps({"include": include}))
-        print(f"::set-output name={engine}Enabled::" + str(len(include) > 0))
+        with open(os.getenv("GITHUB_OUTPUT"), 'a') as env:
+            print(f"{engine}Matrix=" + json.dumps({"include": include}), file=env)
+            print(f"{engine}Enabled=" + str(len(include) > 0), file=env)

--- a/.github/workflows/chatops-receiver.yml
+++ b/.github/workflows/chatops-receiver.yml
@@ -42,7 +42,7 @@ jobs:
           if [[ "${{ github.event.client_payload.pull_request.head.ref }}" != "" ]]
           then
             ref=${{ github.event.client_payload.pull_request.head.ref }}
-            echo ::set-output name=ref::$ref
+            echo "REF=$ref" >> $GITHUB_ENV
           fi
       - name: Invoke workflow-dispatch
         id: trigger-workflow
@@ -50,7 +50,7 @@ jobs:
         with:
           workflow: continuous-delivery
           token: ${{ secrets.REPO_GHA_PAT }}
-          ref: ${{ steps.vars.outputs.ref }}
+          ref: ${{ env.REF }}
           display-workflow-run-url: true
           wait-for-completion: false
           inputs: >

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -406,18 +406,18 @@ jobs:
             upload_artifacts=true
           fi
 
-          echo "::set-output name=images::${images}"
-          echo "::set-output name=tags::${tags}"
-          echo "::set-output name=labels::${labels}"
-          echo "::set-output name=date::${commit_date}"
-          echo "::set-output name=version::${commit_version}"
-          echo "::set-output name=commit::${commit_short}"
-          echo "::set-output name=commit_sha::${commit_sha}"
-          echo "::set-output name=commit_msg::${commit_message}"
-          echo "::set-output name=author_name::${author_name}"
-          echo "::set-output name=author_email::${author_email}"
-          echo "::set-output name=branch_name::${branch_name}"
-          echo "::set-output name=upload_artifacts::${upload_artifacts}"
+          echo "IMAGES=${images}" >> $GITHUB_ENV
+          echo "TAGS=${tags}" >> $GITHUB_ENV
+          echo "LABELS=${labels}" >> $GITHUB_ENV
+          echo "DATE=${commit_date}" >> $GITHUB_ENV
+          echo "VERSION=${commit_version}" >> $GITHUB_ENV
+          echo "COMMIT=${commit_short}" >> $GITHUB_ENV
+          echo "commit_sha=${commit_sha}" >> $GITHUB_OUTPUT
+          echo "commit_msg=${commit_message}" >> $GITHUB_OUTPUT
+          echo "author_name=${author_name}" >> $GITHUB_OUTPUT
+          echo "author_email=${author_email}" >> $GITHUB_OUTPUT
+          echo "branch_name=${branch_name}" >> $GITHUB_OUTPUT
+          echo "upload_artifacts=${upload_artifacts}" >> $GITHUB_OUTPUT
       -
         name: Set GoReleaser environment
         run: |
@@ -433,9 +433,9 @@ jobs:
           version: latest
           args: build --skip-validate --rm-dist --id kubectl-cnpg
         env:
-          DATE: ${{ steps.build-meta.outputs.date }}
-          COMMIT: ${{ steps.build-meta.outputs.commit }}
-          VERSION: ${{ steps.build-meta.outputs.version }}
+          DATE: ${{ env.DATE }}
+          COMMIT: ${{ env.COMMIT }}
+          VERSION: ${{ env.VERSION }}
       # Send Slack notification once build including plugin kubectl-cnpg fails, we only report the scheduled run to avoid message overflow
       -
         name: Slack Notification
@@ -456,15 +456,15 @@ jobs:
           version: latest
           args: build --skip-validate --rm-dist --id manager
         env:
-          DATE: ${{ steps.build-meta.outputs.date }}
-          COMMIT: ${{ steps.build-meta.outputs.commit }}
-          VERSION: ${{ steps.build-meta.outputs.version }}
+          DATE: ${{ env.DATE }}
+          COMMIT: ${{ env.COMMIT }}
+          VERSION: ${{ env.VERSION }}
       -
         name: Docker meta
         id: docker-meta
         uses: docker/metadata-action@v4
         with:
-          images: ${{ steps.build-meta.outputs.images }}
+          images: ${{ env.IMAGES }}
           tags: |
             type=ref,event=branch
             type=ref,event=pr
@@ -475,13 +475,13 @@ jobs:
           # Keep in mind that adding more platforms (architectures) will increase the building
           # time even if we use the ghcache for the building process.
           platforms="linux/amd64,linux/arm64,linux/arm/v7"
-          echo "::set-output name=platforms::${platforms}"
+          echo "PLATFORMS=${platforms}" >> $GITHUB_ENV
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v2
         with:
           image: tonistiigi/binfmt:qemu-v6.1.0
-          platforms: ${{ steps.docker-platforms.outputs.platforms }}
+          platforms: ${{ env.PLATFORMS }}
       -
         name: Set up Docker Buildx
         id: buildx
@@ -497,13 +497,13 @@ jobs:
         name: Build and push
         uses: docker/build-push-action@v3.2.0
         with:
-          platforms: ${{ steps.docker-platforms.outputs.platforms }}
+          platforms: ${{ env.PLATFORMS }}
           context: .
           push: true
           build-args: |
-            VERSION=${{ steps.build-meta.outputs.version }}
+            VERSION=${{ env.VERSION }}
           tags: ${{ steps.docker-meta.outputs.tags }}
-          labels: ${{ steps.build-meta.outputs.labels }}
+          labels: ${{ env.LABELS }}
           secrets: GIT_AUTH_TOKEN=${{ secrets.GITHUB_TOKEN }}
       -
         name: Image Meta
@@ -514,7 +514,7 @@ jobs:
           # If there is more than one tag, take the first one
           # TAGS could be separated by newlines or commas
           image=$(sed -n '1{s/,.*//; p}' <<< "$TAGS")
-          echo "::set-output name=image::${image}"
+          echo "image=${image}" >> $GITHUB_OUTPUT
       -
         name: Generate manifest for operator deployment
         id: generate-manifest
@@ -656,13 +656,13 @@ jobs:
           test_level_from_input="${{ github.event.inputs.test_level }}"
           if [ -n "${test_level_from_input}" ]
           then
-            echo "::set-output name=testLevel::${test_level_from_input}"
+            echo "testLevel=${test_level_from_input}" >> $GITHUB_OUTPUT
             exit 0
           fi
           test_level_generated="${{ github.event.inputs.depth || github.event_name }}"
           if [ -n "${test_level_generated}" ]
           then
-            echo "::set-output name=testLevel::${events[${test_level_generated}]}"
+            echo "testLevel=${events[${test_level_generated}]}" >> $GITHUB_OUTPUT
           fi
 
   e2e-local:
@@ -895,18 +895,18 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           pr_number=$(gh pr view --json number -q .number 2>/dev/null || : )
-          echo "::set-output name=pr_number::${pr_number}"
+          echo "PR_NUMBER=${pr_number}" >> $GITHUB_ENV
           ok_label=$((gh pr view --json labels -q ".labels.[].name" 2>/dev/null || :) | grep "ok to merge")
-          echo "::set-output name=ok_label::${ok_label}"
+          echo "OK_LABEL=${ok_label}" >> $GITHUB_ENV
       -
         name: Label the PR as "ok to merge"
         if: |
-           steps.get_pr_number_and_labels.outputs.pr_number != '' &&
-           steps.get_pr_number_and_labels.outputs.ok_label == ''
+           env.PR_NUMBER != '' &&
+           env.OK_LABEL == ''
         uses: actions-ecosystem/action-add-labels@v1.1.3
         with:
           github_token: ${{ secrets.REPO_GHA_PAT }}
-          number: ${{ steps.get_pr_number_and_labels.outputs.pr_number }}
+          number: ${{ env.PR_NUMBER }}
           labels: "ok to merge :ok_hand:"
 
   # Remove the 'ok-to-merge' label if the E2E tests or previous steps failed
@@ -930,15 +930,15 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           pr_number=$(gh pr view --json number -q .number 2>/dev/null || : )
-          echo "::set-output name=pr_number::${pr_number}"
+          echo "PR_NUMBER=${pr_number}" >> $GITHUB_ENV
           ok_label=$((gh pr view --json labels -q ".labels.[].name" 2>/dev/null || :) | grep "ok to merge")
-          echo "::set-output name=ok_label::${ok_label}"
+          echo "OK_LABEL=${ok_label}" >> $GITHUB_ENV
       - name: Remove "ok to merge" label from PR
         if: |
-          steps.get_pr_number_and_labels.outputs.pr_number != '' &&
-          steps.get_pr_number_and_labels.outputs.ok_label != ''
+          env.PR_NUMBER != '' &&
+          env.OK_LABEL != ''
         uses: actions-ecosystem/action-remove-labels@v1.3.0
         with:
           github_token: ${{ secrets.REPO_GHA_PAT }}
-          number: ${{ steps.get_pr_number_and_labels.outputs.pr_number }}
+          number: ${{ env.PR_NUMBER }}
           labels: "ok to merge :ok_hand:"

--- a/.github/workflows/latest-postgres-version-check.yml
+++ b/.github/workflows/latest-postgres-version-check.yml
@@ -39,23 +39,23 @@ jobs:
         run: |
           LATEST_POSTGRES_VERSION=$(jq -r 'del(.[] | select(.[] | match("alpha|beta|rc"))) | .[keys | max][0]' < .github/pg_versions.json)
           LATEST_POSTGRES_VERSION_IMAGE="${IMAGE_REPO}:${LATEST_POSTGRES_VERSION}"
-          echo "::set-output name=LATEST_POSTGRES_VERSION::$LATEST_POSTGRES_VERSION"
-          echo "::set-output name=LATEST_POSTGRES_VERSION_IMAGE::$LATEST_POSTGRES_VERSION_IMAGE"
+          echo "LATEST_POSTGRES_VERSION=$LATEST_POSTGRES_VERSION" >> $GITHUB_ENV
+          echo "LATEST_POSTGRES_VERSION_IMAGE=$LATEST_POSTGRES_VERSION_IMAGE" >> $GITHUB_ENV
 
       - name: Get the current version of PostgreSQL
         id: current
         run: |
           CURRENT_POSTGRES_VERSION_IMAGE=$(awk -F '"' '/DefaultImageName *=/{print $2}' pkg/versions/versions.go)
           CURRENT_POSTGRES_VERSION=${CURRENT_POSTGRES_VERSION_IMAGE##*:}
-          echo "::set-output name=CURRENT_POSTGRES_VERSION::$CURRENT_POSTGRES_VERSION"
-          echo "::set-output name=CURRENT_POSTGRES_VERSION_IMAGE::$CURRENT_POSTGRES_VERSION_IMAGE"
+          echo "CURRENT_POSTGRES_VERSION=$CURRENT_POSTGRES_VERSION" >> $GITHUB_ENV
+          echo "CURRENT_POSTGRES_VERSION_IMAGE=$CURRENT_POSTGRES_VERSION_IMAGE" >> $GITHUB_ENV
 
       - name: Update files to match the latest version of PostgreSQL
-        if: steps.latest.outputs.LATEST_POSTGRES_VERSION_IMAGE != steps.current.outputs.CURRENT_POSTGRES_VERSION_IMAGE
+        if: env.LATEST_POSTGRES_VERSION_IMAGE != env.CURRENT_POSTGRES_VERSION_IMAGE
         env:
-          CURRENT_POSTGRES_VERSION: ${{ steps.current.outputs.CURRENT_POSTGRES_VERSION }}
-          LATEST_POSTGRES_VERSION: ${{ steps.latest.outputs.LATEST_POSTGRES_VERSION }}
-          LATEST_POSTGRES_VERSION_IMAGE: ${{ steps.latest.outputs.LATEST_POSTGRES_VERSION_IMAGE }}
+          CURRENT_POSTGRES_VERSION: ${{ env.CURRENT_POSTGRES_VERSION }}
+          LATEST_POSTGRES_VERSION: ${{ env.LATEST_POSTGRES_VERSION }}
+          LATEST_POSTGRES_VERSION_IMAGE: ${{ env.LATEST_POSTGRES_VERSION_IMAGE }}
         run: |
           echo "New PostgreSQL version detected ; updating!"
 
@@ -66,20 +66,20 @@ jobs:
           find docs -type f \( -name '*.md' -o -name '*.yaml' \) -exec sed -i "s/${CURRENT_POSTGRES_VERSION//./\\.}/${LATEST_POSTGRES_VERSION}/g" {} +
 
       - name: Create PR to update PostgreSQL version
-        if: steps.latest.outputs.LATEST_POSTGRES_VERSION_IMAGE != steps.current.outputs.CURRENT_POSTGRES_VERSION_IMAGE
+        if: env.LATEST_POSTGRES_VERSION_IMAGE != env.CURRENT_POSTGRES_VERSION_IMAGE
         uses: peter-evans/create-pull-request@v4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          title: "feat: update default PostgreSQL version to ${{ steps.latest.outputs.LATEST_POSTGRES_VERSION }}"
-          body: "Update default PostgreSQL version from ${{ steps.current.outputs.CURRENT_POSTGRES_VERSION }} to ${{ steps.latest.outputs.LATEST_POSTGRES_VERSION }}"
+          title: "feat: update default PostgreSQL version to ${{ env.LATEST_POSTGRES_VERSION }}"
+          body: "Update default PostgreSQL version from ${{ env.CURRENT_POSTGRES_VERSION }} to ${{ env.LATEST_POSTGRES_VERSION }}"
           branch: "postgres-versions-update"
           author: "postgres-versions-updater <postgres-versions-updater@users.noreply.github.com>"
-          commit-message: "feat: update default PostgreSQL version to ${{ steps.latest.outputs.LATEST_POSTGRES_VERSION }}"
+          commit-message: "feat: update default PostgreSQL version to ${{ env.LATEST_POSTGRES_VERSION }}"
           signoff: true
 
       - name: Create Pull Request if postgresql versions have been updated
-        if: steps.latest.outputs.LATEST_POSTGRES_VERSION_IMAGE == steps.current.outputs.CURRENT_POSTGRES_VERSION_IMAGE
+        if: env.LATEST_POSTGRES_VERSION_IMAGE == env.CURRENT_POSTGRES_VERSION_IMAGE
         uses: peter-evans/create-pull-request@v4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -95,11 +95,11 @@ jobs:
           # use git describe to get the nearest tag and use that to build the version (e.g. 1.4.0+dev24 or 1.4.0)
           commit_version=$(git describe --tags --match 'v*' "${commit_sha}"| sed -e 's/^v//; s/-g[0-9a-f]\+$//; s/-\([0-9]\+\)$/+dev\1/')
           commit_short=$(git rev-parse --short "${commit_sha}")
-          echo "::set-output name=images::${images}"
-          echo "::set-output name=date::${commit_date}"
-          echo "::set-output name=version::${commit_version}"
-          echo "::set-output name=commit::${commit_short}"
-          echo "::set-output name=skip_krew::${skip_krew}"
+          echo "IMAGES=${images}" >> $GITHUB_ENV
+          echo "DATE=${commit_date}" >> $GITHUB_ENV
+          echo "version=${commit_version}" >> $GITHUB_OUTPUT
+          echo "COMMIT=${commit_short}" >> $GITHUB_ENV
+          echo "SKIP_KREW=${skip_krew}" >> $GITHUB_ENV
       -
         name: Import GPG key
         id: import_gpg
@@ -120,14 +120,14 @@ jobs:
           version: latest
           args: release --rm-dist
         env:
-          DATE: ${{ steps.build-meta.outputs.date }}
-          COMMIT: ${{ steps.build-meta.outputs.commit }}
+          DATE: ${{ env.DATE }}
+          COMMIT: ${{ env.COMMIT }}
           VERSION: ${{ steps.build-meta.outputs.version }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
       -
         name: Publish Krew
-        if: ${{ steps.build-meta.outputs.skip_krew == 'false' }}
+        if: ${{ env.SKIP_KREW == 'false' }}
         uses: rajatjindal/krew-release-bot@v0.0.43
         with:
           krew_template_file: dist/cnpg.yaml
@@ -136,7 +136,7 @@ jobs:
         id: docker-meta
         uses: docker/metadata-action@v4
         with:
-          images: ${{ steps.build-meta.outputs.images }}
+          images: ${{ env.IMAGES }}
           tags: |
             type=semver,pattern={{version}}
       -
@@ -146,13 +146,13 @@ jobs:
           # Keep in mind that adding more platforms (architectures) will increase the building
           # time even if we use the ghcache for the building process.
           platforms="linux/amd64,linux/arm64,linux/arm/v7"
-          echo "::set-output name=platforms::${platforms}"
+          echo "PLATFORMS=${platforms}" >> $GITHUB_ENV
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v2
         with:
           image: tonistiigi/binfmt:qemu-v6.1.0
-          platforms: ${{ steps.docker-platforms.outputs.platforms }}
+          platforms: ${{ env.PLATFORMS }}
       -
         name: Set up Docker Buildx
         id: buildx
@@ -169,7 +169,7 @@ jobs:
         id: build
         uses: docker/build-push-action@v3.2.0
         with:
-          platforms: ${{ steps.docker-platforms.outputs.platforms }}
+          platforms: ${{ env.PLATFORMS }}
           context: .
           push: true
           build-args: |


### PR DESCRIPTION
This patch replace the deprecated set-output command used in workflow
with redirect the output to $GITHUB_ENV or $GITHUB_OUTPUT

closes: #874 
Signed-off-by: Tao Li <tao.li@enterprisedb.com>