### PR TITLE
fix: ensure we have a WAL to archive for every newly created cluster

### DIFF
--- a/controllers/scheduledbackup_controller.go
+++ b/controllers/scheduledbackup_controller.go
@@ -87,7 +87,7 @@ func (r *ScheduledBackupReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	}
 
 	// We are supposed to start a new backup. Let's extract
-	// the list of backups we already taken to see if anything
+	// the list of backups we have already taken to see if anything
 	// is running now
 	childBackups, err := r.GetChildBackups(ctx, scheduledBackup)
 	if err != nil {
@@ -97,7 +97,7 @@ func (r *ScheduledBackupReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	}
 
 	// We are supposed to start a new backup. Let's extract
-	// the list of backups we already taken to see if anything
+	// the list of backups we have already taken to see if anything
 	// is running now
 	for _, backup := range childBackups {
 		if backup.GetStatus().IsInProgress() {

--- a/pkg/management/postgres/initdb.go
+++ b/pkg/management/postgres/initdb.go
@@ -256,14 +256,6 @@ func (info InitInfo) ConfigureNewInstance(instance *Instance) error {
 		return fmt.Errorf("could not create %v file: %w", filePath, err)
 	}
 
-	// We make sure we have a new WAL to archive
-	if _, err := dbSuperUser.Exec("CHECKPOINT"); err != nil {
-		return fmt.Errorf("error while requiring a checkpoint: %w", err)
-	}
-
-	if _, err := dbSuperUser.Exec("SELECT pg_switch_wal()"); err != nil {
-		return fmt.Errorf("error while switching to a new WAL: %w", err)
-	}
 	return nil
 }
 

--- a/pkg/management/postgres/initdb.go
+++ b/pkg/management/postgres/initdb.go
@@ -256,6 +256,14 @@ func (info InitInfo) ConfigureNewInstance(instance *Instance) error {
 		return fmt.Errorf("could not create %v file: %w", filePath, err)
 	}
 
+	// We make sure we have a new WAL to archive
+	if _, err := dbSuperUser.Exec("CHECKPOINT"); err != nil {
+		return fmt.Errorf("error while requiring a checkpoint: %w", err)
+	}
+
+	if _, err := dbSuperUser.Exec("SELECT pg_switch_wal()"); err != nil {
+		return fmt.Errorf("error while switching to a new WAL: %w", err)
+	}
 	return nil
 }
 


### PR DESCRIPTION
We require WAL archiving to be working before taking every backup, and we control that by checking the archival status of the latest archived WAL.

For this check to pass, we need to have a WAL to archive, which is not always true for new clusters.

For PostgreSQL 14 and older, this condition was granted by the `archive_timeout` setting, but since PostgreSQL 15, the instance won't mark the first WAL as ready to archive if there is no database activity.

With this patch, we switch to a new WAL when a backup is requested, and Postgres never attempted archiving a WAL file.

Closes: #896 
