### PR TITLE
doc: cosmetic change to snapshot testing documentation

### DIFF
--- a/contribute/README.md
+++ b/contribute/README.md
@@ -54,9 +54,8 @@ If you want to test or evaluate the latest development snapshot of
 CloudNativePG before the next official patch release, you can simply run:
 
 ```sh
-curl -sSfL \
-  https://raw.githubusercontent.com/cloudnative-pg/artifacts/main/manifests/operator-manifest.yaml | \
-  kubectl apply -f -
+kubectl apply -f \
+  https://raw.githubusercontent.com/cloudnative-pg/artifacts/main/manifests/operator-manifest.yaml
 ```
 
 ---


### PR DESCRIPTION
Pass the URL of the manifest instead of using `curl` in the example included in the contribution guide.

Closes #898

Signed-off-by: Gabriele Bartolini <gabriele.bartolini@enterprisedb.com>