### PR TITLE
test: change minio client self-signed certification location in test case

### DIFF
--- a/tests/utils/minio.go
+++ b/tests/utils/minio.go
@@ -387,7 +387,7 @@ func MinioSSLClient(namespace string) corev1.Pod {
 	const (
 		minioServerCASecret = "minio-server-ca-secret" // #nosec
 		tlsVolumeName       = "secret-volume"
-		tlsVolumeMountPath  = "/root/.mc/certs/CAs"
+		tlsVolumeMountPath  = "/mc/.mc/certs/CAs"
 	)
 	var secretMode int32 = 0o600
 


### PR DESCRIPTION
The home location for minio changed, change the certification location 
accordingly for e2e test. 

closes: #909 
Signed-off-by: Tao Li <tao.li@enterprisedb.com>