### PR TITLE
Avoid setting RunAsNonRoot to false explicitly

### DIFF
--- a/tests/utils/azurite.go
+++ b/tests/utils/azurite.go
@@ -150,7 +150,6 @@ func getAzuriteClientPod(namespace string) corev1.Pod {
 					SecurityContext: &corev1.SecurityContext{
 						AllowPrivilegeEscalation: pointer.Bool(false),
 						SeccompProfile:           &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
-						RunAsNonRoot:             pointer.Bool(false),
 					},
 				},
 			},
@@ -177,7 +176,6 @@ func getAzuriteClientPod(namespace string) corev1.Pod {
 				},
 			},
 			SecurityContext: &corev1.PodSecurityContext{
-				RunAsNonRoot:   pointer.Bool(false),
 				SeccompProfile: &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
 			},
 		},

--- a/tests/utils/curl.go
+++ b/tests/utils/curl.go
@@ -41,8 +41,6 @@ func CurlClient(namespace string) corev1.Pod {
 					SecurityContext: &corev1.SecurityContext{
 						AllowPrivilegeEscalation: pointer.Bool(false),
 						SeccompProfile:           &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
-						// Curl image doesn't have a numeric user, so it cannot have RunAsNonRoot set to true
-						RunAsNonRoot: pointer.Bool(false),
 					},
 				},
 			},
@@ -50,8 +48,6 @@ func CurlClient(namespace string) corev1.Pod {
 			RestartPolicy: corev1.RestartPolicyAlways,
 			SecurityContext: &corev1.PodSecurityContext{
 				SeccompProfile: &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
-				// Curl image doesn't have a numeric user, so it cannot have RunAsNonRoot set to true
-				RunAsNonRoot: pointer.Bool(false),
 			},
 		},
 	}

--- a/tests/utils/minio.go
+++ b/tests/utils/minio.go
@@ -190,12 +190,10 @@ func MinioDefaultDeployment(namespace string, minioPVC corev1.PersistentVolumeCl
 							SecurityContext: &corev1.SecurityContext{
 								AllowPrivilegeEscalation: pointer.Bool(false),
 								SeccompProfile:           &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
-								RunAsNonRoot:             pointer.Bool(false),
 							},
 						},
 					},
 					SecurityContext: &corev1.PodSecurityContext{
-						RunAsNonRoot:   pointer.Bool(false),
 						SeccompProfile: &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
 					},
 				},

--- a/tests/utils/webapp.go
+++ b/tests/utils/webapp.go
@@ -71,14 +71,12 @@ func DefaultWebapp(namespace string, name string, rootCASecretName string, tlsSe
 						},
 					},
 					SecurityContext: &corev1.SecurityContext{
-						RunAsNonRoot:             pointer.Bool(false),
 						AllowPrivilegeEscalation: pointer.Bool(false),
 						SeccompProfile:           &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
 					},
 				},
 			},
 			SecurityContext: &corev1.PodSecurityContext{
-				RunAsNonRoot:   pointer.Bool(false),
 				SeccompProfile: &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
 			},
 		},


### PR DESCRIPTION
Setting RunAsNonRoot explicitly to false is not only redundant, but it could trigger errors.

Closes #922 

Signed-off-by: Marco Nenciarini <marco.nenciarini@enterprisedb.com>
Signed-off-by: John Long <john.long@enterprisedb.com>
Co-authored-by: John Long <john.long@enterprisedb.com>