### PR TITLE
feat: defaulting to jsonlog for pg15

### DIFF
--- a/pkg/management/postgres/configuration.go
+++ b/pkg/management/postgres/configuration.go
@@ -206,8 +206,8 @@ func configureRecoveryConfFile(pgData, primaryConnInfo, slotName string) (change
 	options := map[string]string{
 		"standby_mode": "on",
 		"restore_command": fmt.Sprintf(
-			"/controller/manager wal-restore --log-destination %s/%s.json %%f %%p",
-			postgres.LogPath, postgres.LogFileName),
+			"/controller/manager wal-restore --log-destination %s/%s %%f %%p",
+			postgres.LogPath, postgres.ManagerJSONLogFileName),
 		"recovery_target_timeline": "latest",
 	}
 
@@ -242,8 +242,8 @@ func configurePostgresAutoConfFile(pgData, primaryConnInfo, slotName string) (ch
 
 	options := map[string]string{
 		"restore_command": fmt.Sprintf(
-			"/controller/manager wal-restore --log-destination %s/%s.json %%f %%p",
-			postgres.LogPath, postgres.LogFileName),
+			"/controller/manager wal-restore --log-destination %s/%s %%f %%p",
+			postgres.LogPath, postgres.ManagerJSONLogFileName),
 		"recovery_target_timeline": "latest",
 		"primary_slot_name":        slotName,
 	}

--- a/pkg/management/postgres/logpipe/logpipe_test.go
+++ b/pkg/management/postgres/logpipe/logpipe_test.go
@@ -51,7 +51,7 @@ var _ = Describe("CSV file reader", func() {
 			spy := SpyRecordWriter{}
 			p := LogPipe{
 				record:          &LoggingRecord{},
-				fieldsValidator: LogFieldValidator,
+				fieldsValidator: CSVLogFieldValidator,
 			}
 			Expect(p.streamLogFromCSVFile(ctx, f, &spy)).To(Succeed())
 			Expect(len(spy.records)).To(Equal(2))
@@ -67,7 +67,7 @@ var _ = Describe("CSV file reader", func() {
 			spy := SpyRecordWriter{}
 			p := LogPipe{
 				record:          &LoggingRecord{},
-				fieldsValidator: LogFieldValidator,
+				fieldsValidator: CSVLogFieldValidator,
 			}
 			Expect(p.streamLogFromCSVFile(ctx, f, &spy)).To(Succeed())
 			Expect(len(spy.records)).To(Equal(2))
@@ -83,7 +83,7 @@ var _ = Describe("CSV file reader", func() {
 			spy := SpyRecordWriter{}
 			p := LogPipe{
 				record:          &LoggingRecord{},
-				fieldsValidator: LogFieldValidator,
+				fieldsValidator: CSVLogFieldValidator,
 			}
 			Expect(p.streamLogFromCSVFile(ctx, f, &spy)).To(Succeed())
 			Expect(len(spy.records)).To(Equal(2))
@@ -99,7 +99,7 @@ var _ = Describe("CSV file reader", func() {
 			spy := SpyRecordWriter{}
 			p := LogPipe{
 				record:          NewPgAuditLoggingDecorator(),
-				fieldsValidator: LogFieldValidator,
+				fieldsValidator: CSVLogFieldValidator,
 			}
 			Expect(p.streamLogFromCSVFile(ctx, f, &spy)).To(Succeed())
 			Expect(len(spy.records)).To(Equal(2))
@@ -117,7 +117,7 @@ var _ = Describe("CSV file reader", func() {
 				reader := strings.NewReader(longerInput)
 				p := LogPipe{
 					record:          &LoggingRecord{},
-					fieldsValidator: LogFieldValidator,
+					fieldsValidator: CSVLogFieldValidator,
 				}
 				err := p.streamLogFromCSVFile(ctx, reader, &spy)
 				Expect(err).Should(HaveOccurred())
@@ -135,7 +135,7 @@ var _ = Describe("CSV file reader", func() {
 				reader := strings.NewReader(shorterInput)
 				p := LogPipe{
 					record:          &LoggingRecord{},
-					fieldsValidator: LogFieldValidator,
+					fieldsValidator: CSVLogFieldValidator,
 				}
 				err := p.streamLogFromCSVFile(ctx, reader, &spy)
 				Expect(err).Should(HaveOccurred())
@@ -153,7 +153,7 @@ var _ = Describe("CSV file reader", func() {
 				reader := strings.NewReader(trailingCommaInput)
 				p := LogPipe{
 					record:          &LoggingRecord{},
-					fieldsValidator: LogFieldValidator,
+					fieldsValidator: CSVLogFieldValidator,
 				}
 				err := p.streamLogFromCSVFile(ctx, reader, &spy)
 				Expect(err).Should(HaveOccurred())
@@ -171,7 +171,7 @@ var _ = Describe("CSV file reader", func() {
 				reader := strings.NewReader(longerInput)
 				p := LogPipe{
 					record:          &LoggingRecord{},
-					fieldsValidator: LogFieldValidator,
+					fieldsValidator: CSVLogFieldValidator,
 				}
 				err := p.streamLogFromCSVFile(ctx, reader, &spy)
 				Expect(err).Should(HaveOccurred())
@@ -187,7 +187,7 @@ var _ = Describe("CSV file reader", func() {
 			spy := SpyRecordWriter{}
 			p := LogPipe{
 				record:          &LoggingRecord{},
-				fieldsValidator: LogFieldValidator,
+				fieldsValidator: CSVLogFieldValidator,
 			}
 			Expect(p.streamLogFromCSVFile(ctx, strings.NewReader(""), &spy)).To(Succeed())
 			Expect(len(spy.records)).To(Equal(0))

--- a/pkg/management/postgres/logpipe/pgaudit_test.go
+++ b/pkg/management/postgres/logpipe/pgaudit_test.go
@@ -90,7 +90,6 @@ var _ = Describe("PgAudit CVS logging decorator", func() {
 				QueryPos:             "20",
 				Location:             "21",
 				ApplicationName:      "22",
-				BackendType:          "",
 			}))
 			Expect(*typedResult.Audit).To(Equal(PgAuditRecord{
 				AuditType:      "A0",
@@ -193,7 +192,6 @@ var _ = Describe("PgAudit CVS logging decorator", func() {
 				QueryPos:             "20",
 				Location:             "21",
 				ApplicationName:      "22",
-				BackendType:          "",
 			}))
 		})
 

--- a/pkg/management/postgres/logpipe/record.go
+++ b/pkg/management/postgres/logpipe/record.go
@@ -16,13 +16,14 @@ limitations under the License.
 
 package logpipe
 
-// CSVRecordParser is implemented by structs that can be filled when parsing a CSV line.
+// RecordParser is implemented by structs that can be filled when parsing a CSV line.
 // The FromCSV method just stores the CSV record fields inside the struct fields.
 // A validation check of the CSV fields should be performed by the caller.
 // Also handling recover from panic should be provided by the caller, in order to take care of runtime error,
 // e.g. index out of range because of CSV malformation
-type CSVRecordParser interface {
+type RecordParser interface {
 	FromCSV(content []string) NamedRecord
+	FromJSON(content []byte) (NamedRecord, error)
 	NamedRecord
 }
 

--- a/pkg/postgres/configuration.go
+++ b/pkg/postgres/configuration.go
@@ -135,6 +135,10 @@ host all all all {{.DefaultAuthenticationMethod}}
 	// `.csv` and `.log` as needed.
 	LogFileName = "postgres"
 
+	// ManagerJSONLogFileName is the name of the file produced by the manager
+	// itself when run as a subprocess (e.g. wal restore/backup subcommands issued by pg itself)
+	ManagerJSONLogFileName = "manager.json"
+
 	// CNPGConfigSha256 is the parameter to be used to inject the sha256 of the
 	// config in the custom.conf file
 	CNPGConfigSha256 = "cnpg.config_sha256"
@@ -356,7 +360,7 @@ var (
 			"max_worker_processes":       "32",
 			"max_replication_slots":      "32",
 			"logging_collector":          "on",
-			"log_destination":            "csvlog",
+			"log_destination":            "jsonlog",
 			"log_rotation_age":           "0",
 			"log_rotation_size":          "0",
 			"log_truncate_on_rotation":   "false",
@@ -381,6 +385,9 @@ var (
 			{130000, MajorVersionRangeUnlimited}: {
 				"wal_keep_size":      "512MB",
 				"shared_memory_type": "mmap",
+			},
+			{MajorVersionRangeUnlimited, 150000}: {
+				"log_destination": "csvlog",
 			},
 		},
 		MandatorySettings: SettingsCollection{

--- a/pkg/postgres/configuration_test.go
+++ b/pkg/postgres/configuration_test.go
@@ -113,6 +113,22 @@ var _ = Describe("PostgreSQL configuration creation", func() {
 		})
 	})
 
+	When("version is 15", func() {
+		It("will use appropriate settings", func() {
+			info := ConfigurationInfo{
+				Settings:              CnpgConfigurationSettings,
+				MajorVersion:          150000,
+				UserSettings:          settings,
+				IncludingMandatory:    true,
+				SyncReplicasElectable: nil,
+				SyncReplicas:          0,
+			}
+			config := CreatePostgresqlConfiguration(info)
+			Expect(config.GetConfig("wal_keep_size")).To(Equal("512MB"))
+			Expect(config.GetConfig("log_destination")).To(Equal("jsonlog"))
+		})
+	})
+
 	When("replica cluster is being configured", func() {
 		It("will set archive_mode to always", func() {
 			info := ConfigurationInfo{

--- a/tests/e2e/asserts_test.go
+++ b/tests/e2e/asserts_test.go
@@ -257,9 +257,9 @@ func AssertClusterDefault(namespace string, clusterName string,
 
 		validationErr := cluster.Validate()
 		if isExpectedToDefault {
-			Expect(len(validationErr)).Should(BeZero(), validationErr)
+			Expect(validationErr).NotTo(BeEmpty(), validationErr.ToAggregate().Error())
 		} else {
-			Expect(len(validationErr)).ShouldNot(BeZero(), validationErr)
+			Expect(validationErr).To(BeEmpty(), validationErr.ToAggregate().Error())
 		}
 	})
 }


### PR DESCRIPTION
PostgreSQL 15 intruduced a new possible value for `log_destination`, `jsonlog`. This patch sets it by default for PG >= 15 and then introduces a new log pipe to parse logs from json instead of csv, producing the same output log format as before (pgaudit included).

Closes #792 

Signed-off-by: Philippe Scorsolini <p.scorsolini@gmail.com>