### PR TITLE
fix(hibernate): evaluate `pg_ctl status` exit code to determine if an instance is running

### DIFF
--- a/pkg/utils/exec.go
+++ b/pkg/utils/exec.go
@@ -97,7 +97,7 @@ func ExecCommand(
 		Stderr: &stderr,
 	})
 	if err != nil {
-		return stdout.String(), stderr.String(), fmt.Errorf("%v - %v", err, stderr.String())
+		return stdout.String(), stderr.String(), fmt.Errorf("%w - %v", err, stderr.String())
 	}
 
 	return stdout.String(), stderr.String(), nil


### PR DESCRIPTION
This patch ensures that we rely only on the exit code to determine if an instance is stopped. 

This removes the previous behavior of checking the pg_ctl message which generated errors with languages different than English

Closes #934

Signed-off-by: Armando Ruocco <armando.ruocco@enterprisedb.com>