### PR TITLE
fix: seccomp detection is failing when minor version is not an integer

### DIFF
--- a/pkg/utils/discovery.go
+++ b/pkg/utils/discovery.go
@@ -33,11 +33,11 @@ var haveSCC bool
 // This variable specifies whether we should set the SeccompProfile or not in the pods
 var supportSeccomp bool
 
-// minorVersionRegexp is used to extract the minor version from
+// `minorVersionRegexp` is used to extract the minor version from
 // the Kubernetes API server version. Some providers, like AWS,
-// append a "+" to the Kubernetes minor version indicated that
-// there's some maintenance backport patch over the standard
-// release beyond its end-of-life.
+// append a "+" to the Kubernetes minor version to presumably
+// indicate that some maintenance patches have been back-ported
+// beyond the standard end-of-life of the release.
 var minorVersionRegexp = regexp.MustCompile(`^([0-9]+)\+?$`)
 
 // GetDiscoveryClient creates a discovery client or return error

--- a/pkg/utils/discovery.go
+++ b/pkg/utils/discovery.go
@@ -108,8 +108,8 @@ func HaveSeccompSupport() bool {
 	return supportSeccomp
 }
 
-// extractK8sMinorVersion extracts and parse the Kubernetes minor version from
-// the version info as detected by discovery client
+// extractK8sMinorVersion extracts and parses the Kubernetes minor version from
+// the version info that's been  detected by discovery client
 func extractK8sMinorVersion(info *version.Info) (int, error) {
 	matches := minorVersionRegexp.FindStringSubmatch(info.Minor)
 	if matches == nil {

--- a/pkg/utils/discovery.go
+++ b/pkg/utils/discovery.go
@@ -17,9 +17,12 @@ limitations under the License.
 package utils
 
 import (
+	"fmt"
+	"regexp"
 	"strconv"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/discovery"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
@@ -29,6 +32,13 @@ var haveSCC bool
 
 // This variable specifies whether we should set the SeccompProfile or not in the pods
 var supportSeccomp bool
+
+// minorVersionRegexp is used to extract the minor version from
+// the Kubernetes API server version. Some providers, like AWS,
+// append a "+" to the Kubernetes minor version indicated that
+// there's some maintenance backport patch over the standard
+// release beyond its end-of-life.
+var minorVersionRegexp = regexp.MustCompile(`^([0-9]+)\+?$`)
 
 // GetDiscoveryClient creates a discovery client or return error
 func GetDiscoveryClient() (*discovery.DiscoveryClient, error) {
@@ -98,6 +108,18 @@ func HaveSeccompSupport() bool {
 	return supportSeccomp
 }
 
+// extractK8sMinorVersion extracts and parse the Kubernetes minor version from
+// the version info as detected by discovery client
+func extractK8sMinorVersion(info *version.Info) (int, error) {
+	matches := minorVersionRegexp.FindStringSubmatch(info.Minor)
+	if matches == nil {
+		// we couldn't detect the minor version of Kubernetes
+		return 0, fmt.Errorf("invalid Kubernetes minor version: %s", info.Minor)
+	}
+
+	return strconv.Atoi(matches[1])
+}
+
 // DetectSeccompSupport checks the version of Kubernetes in the cluster to determine
 // whether Seccomp is supported
 func DetectSeccompSupport(client *discovery.DiscoveryClient) (err error) {
@@ -107,7 +129,7 @@ func DetectSeccompSupport(client *discovery.DiscoveryClient) (err error) {
 		return err
 	}
 
-	minor, err := strconv.Atoi(kubernetesVersion.Minor)
+	minor, err := extractK8sMinorVersion(kubernetesVersion)
 	if err != nil {
 		return err
 	}

--- a/pkg/utils/discovery_test.go
+++ b/pkg/utils/discovery_test.go
@@ -1,0 +1,35 @@
+/*
+Copyright The CloudNativePG Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"k8s.io/apimachinery/pkg/version"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = DescribeTable("Kubernetes minor version detection",
+	func(info *version.Info, detectedMinorVersion int, shouldSucceed bool) {
+		result, err := extractK8sMinorVersion(info)
+		Expect(result).To(Equal(detectedMinorVersion))
+		Expect(err == nil).To(Equal(shouldSucceed))
+	},
+	Entry("When minor version is an integer", &version.Info{Minor: "25"}, 25, true),
+	Entry("When minor version indicate backported patches", &version.Info{Minor: "21+"}, 21, true),
+	Entry("When minor version is wrong", &version.Info{Minor: "c3p0"}, 0, false),
+)


### PR DESCRIPTION
When the reported minor version is not an integer (i.e. `21+`) the seccomp detection is failing and will prevent the operator from starting correctly.

Closes: #946

This patch makes that function more resilient.

Signed-off-by: Leonardo Cecchi <leonardo.cecchi@enterprisedb.com>