### PR TITLE
test: get operator logs on failed specs

### DIFF
--- a/config/manager/env_override.yaml
+++ b/config/manager/env_override.yaml
@@ -17,5 +17,5 @@ spec:
         - --leader-elect
         - --config-map-name=$(OPERATOR_DEPLOYMENT_NAME)-config
         - --secret-name=$(OPERATOR_DEPLOYMENT_NAME)-config
-        - --log-level=info
+        - --log-level=debug
         - --pprof-server=true

--- a/config/manager/env_override.yaml
+++ b/config/manager/env_override.yaml
@@ -17,5 +17,6 @@ spec:
         - --leader-elect
         - --config-map-name=$(OPERATOR_DEPLOYMENT_NAME)-config
         - --secret-name=$(OPERATOR_DEPLOYMENT_NAME)-config
+        - --webhook-port=9443
         - --log-level=debug
         - --pprof-server=true

--- a/internal/cmd/plugin/report/logs.go
+++ b/internal/cmd/plugin/report/logs.go
@@ -33,6 +33,10 @@ import (
 
 const jobMatcherLabel = "job-name"
 
+var podLogOptions = &corev1.PodLogOptions{
+	Timestamps: true, // NOTE: when activated, lines are no longer JSON
+}
+
 // streamPodLogsToZip streams the pod logs to a new section in the ZIP
 func streamPodLogsToZip(ctx context.Context, pods []corev1.Pod,
 	dirname, name string, zipper *zip.Writer,
@@ -49,7 +53,7 @@ func streamPodLogsToZip(ctx context.Context, pods []corev1.Pod,
 		if zipperErr != nil {
 			return fmt.Errorf("could not add '%s' to zip: %w", path, zipperErr)
 		}
-		if err := logs.StreamPodLogs(ctx, pod, false, writer); err != nil {
+		if err := logs.StreamPodLogs(ctx, pod, writer, podLogOptions); err != nil {
 			return err
 		}
 	}
@@ -85,7 +89,7 @@ func streamClusterLogsToZip(ctx context.Context, clusterName, namespace string,
 				filepath.Join(logsdir, pod.Name), err)
 		}
 
-		err = logs.StreamPodLogs(ctx, pod, false, writer)
+		err = logs.StreamPodLogs(ctx, pod, writer, podLogOptions)
 		if err != nil {
 			return err
 		}
@@ -132,7 +136,7 @@ func streamClusterJobLogsToZip(ctx context.Context, clusterName, namespace strin
 					filepath.Join(logsdir, pod.Name), err)
 			}
 
-			err = logs.StreamPodLogs(ctx, pod, false, writer)
+			err = logs.StreamPodLogs(ctx, pod, writer, podLogOptions)
 			if err != nil {
 				return err
 			}

--- a/pkg/utils/logs/logs.go
+++ b/pkg/utils/logs/logs.go
@@ -57,8 +57,8 @@ func StreamPodLogs(ctx context.Context, pod corev1.Pod, getPrevious bool, writer
 	return err
 }
 
-// TailPodLogs streams the pod logs and shunts them to the `writer`, keeps waiting
-// for new logs to arrive, until the connection is closed
+// TailPodLogs streams the pod logs starting from the current time, and keeps
+// waiting for any new logs, until the  context is cancelled by the calling process
 func TailPodLogs(ctx context.Context, pod corev1.Pod, writer io.Writer) (err error) {
 	wrapErr := func(err error) error { return fmt.Errorf("in StreamPodLogs: %w", err) }
 	conf := ctrl.GetConfigOrDie()

--- a/pkg/utils/logs/logs.go
+++ b/pkg/utils/logs/logs.go
@@ -65,7 +65,7 @@ func TailPodLogs(ctx context.Context, pod corev1.Pod, writer io.Writer) (err err
 	pods := kubernetes.NewForConfigOrDie(conf).CoreV1().Pods(pod.Namespace)
 	now := metav1.Now()
 	logsRequest := pods.GetLogs(pod.Name, &corev1.PodLogOptions{
-		Timestamps: true,
+		Timestamps: false, // keep false so we get real JSON, and can parse/filter by level
 		Follow:     true,
 		SinceTime:  &now,
 	})

--- a/tests/e2e/asserts_test.go
+++ b/tests/e2e/asserts_test.go
@@ -224,7 +224,8 @@ func AssertClusterIsReady(namespace string, clusterName string, timeout int, env
 		}()
 		DeferCleanup(func(ctx SpecContext) {
 			if CurrentSpecReport().Failed() {
-				GinkgoWriter.Println("DUMPING Operator Logs. Failed Spec:", CurrentSpecReport().LeafNodeText)
+				GinkgoWriter.Println("DUMPING Operator Logs. Failed Spec:",
+					CurrentSpecReport().LeafNodeText)
 				_, _ = buf.WriteTo(GinkgoWriter)
 			}
 		})

--- a/tests/e2e/asserts_test.go
+++ b/tests/e2e/asserts_test.go
@@ -17,8 +17,6 @@ limitations under the License.
 package e2e
 
 import (
-	"bytes"
-	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -216,19 +214,6 @@ func AssertClusterIsReady(namespace string, clusterName string, timeout int, env
 			err := env.Client.Get(env.Ctx, namespacedName, cluster)
 			g.Expect(err).ToNot(HaveOccurred())
 		}).Should(Succeed())
-
-		// start recording operator logs, dump them if the spec fails
-		var buf bytes.Buffer
-		go func() {
-			_ = env.TailOperatorLogs(context.TODO(), &buf)
-		}()
-		DeferCleanup(func(ctx SpecContext) {
-			if CurrentSpecReport().Failed() {
-				GinkgoWriter.Println("DUMPING Operator Logs. Failed Spec:",
-					CurrentSpecReport().LeafNodeText)
-				_, _ = buf.WriteTo(GinkgoWriter)
-			}
-		})
 
 		start := time.Now()
 		Eventually(func() (string, error) {

--- a/tests/e2e/asserts_test.go
+++ b/tests/e2e/asserts_test.go
@@ -242,7 +242,7 @@ func AssertClusterIsReady(namespace string, clusterName string, timeout int, env
 			return fmt.Sprintf("Ready pod is not as expected. Spec Instances: %d, ready pods: %d \n",
 				cluster.Spec.Instances,
 				utils.CountReadyPods(podList.Items)), nil
-		}, 2, 2).Should(BeEquivalentTo(apiv1.PhaseHealthy),
+		}, timeout, 2).Should(BeEquivalentTo(apiv1.PhaseHealthy),
 			func() string {
 				cluster := testsUtils.PrintClusterResources(namespace, clusterName, env)
 				nodes, _ := env.DescribeKubernetesNodes()

--- a/tests/e2e/hibernation_test.go
+++ b/tests/e2e/hibernation_test.go
@@ -96,7 +96,8 @@ var _ = Describe("Cluster Hibernation with plugin", Label(tests.LabelPlugin), fu
 		verifySummaryInHibernationStatus := func(clusterName string, message hibernateSatusMessage) {
 			statusOut := getHibernationStatusInJSON(namespace, clusterName)
 			actualStatus := statusOut[string(summaryInStatus)].(map[string]interface{})["status"].(string)
-			Expect(strings.Contains(string(message), actualStatus)).Should(BeEquivalentTo(true), statusOut)
+			Expect(strings.Contains(string(message), actualStatus)).Should(BeEquivalentTo(true),
+				actualStatus+"\\not-contained-in\\"+string(message))
 		}
 		verifyClusterResources := func(namespace, clusterName string, roles []utils.PVCRole) {
 			By(fmt.Sprintf("verifying cluster resources are removed "+

--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -138,11 +138,11 @@ var _ = BeforeEach(func() {
 		}
 	}()
 	DeferCleanup(func(ctx SpecContext) {
-		// if CurrentSpecReport().Failed() {
-		GinkgoWriter.Println("DUMPING Operator Logs. Failed Spec:",
-			CurrentSpecReport().LeafNodeText)
-		saveOperatorLogs(buf, CurrentSpecReport().LeafNodeText)
-		// }
+		if CurrentSpecReport().Failed() {
+			GinkgoWriter.Println("DUMPING Operator Logs. Failed Spec:",
+				CurrentSpecReport().LeafNodeText)
+			saveOperatorLogs(buf, CurrentSpecReport().LeafNodeText)
+		}
 	})
 
 	if operatorPodWasRenamed {

--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -142,7 +142,7 @@ var _ = BeforeEach(func() {
 		}
 	}()
 	DeferCleanup(func(ctx SpecContext) {
-		if true {
+		if CurrentSpecReport().Failed() {
 			specName := CurrentSpecReport().FullText()
 			GinkgoWriter.Println("DUMPING tailed Operator Logs. Failed Spec:",
 				specName)

--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -138,11 +138,11 @@ var _ = BeforeEach(func() {
 		// get logs without timestamp parsing; for JSON parseability
 		err = logs.TailPodLogs(context.TODO(), operatorPod, &buf, false)
 		if err != nil {
-			_, _ = fmt.Fprintf(&buf, "Error dumping operator logs: %v\n", err)
+			_, _ = fmt.Fprintf(&buf, "Error tailing logs, dumping operator logs: %v\n", err)
 		}
 	}()
 	DeferCleanup(func(ctx SpecContext) {
-		if CurrentSpecReport().Failed() {
+		if true {
 			specName := CurrentSpecReport().FullText()
 			GinkgoWriter.Println("DUMPING tailed Operator Logs. Failed Spec:",
 				specName)

--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -17,15 +17,23 @@ limitations under the License.
 package e2e
 
 import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/onsi/ginkgo/v2/types"
 	"github.com/thoas/go-funk"
+	"golang.org/x/net/context"
 	k8sscheme "k8s.io/client-go/kubernetes/scheme"
 
 	// +kubebuilder:scaffold:imports
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils/logs"
 	"github.com/cloudnative-pg/cloudnative-pg/tests"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils"
 
@@ -62,6 +70,53 @@ var _ = BeforeSuite(func() {
 	_ = apiv1.AddToScheme(env.Scheme)
 })
 
+// saveOperatorLogs does 2 things:
+//   - displays the non-DEBUG operator logs as part of the Ginkgo output
+//   - saves the full logs to a file
+//
+// along the way it parses the timestamps for convenience, BUT the lines
+// of output are not legal JSON
+func saveOperatorLogs(buf bytes.Buffer, specName string) {
+	scanner := bufio.NewScanner(&buf)
+	filename := "out/operator_logs_" + specName + ".log"
+	f, err := os.Create(filepath.Clean(filename))
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer func() {
+		syncErr := f.Sync()
+		if syncErr != nil {
+			fmt.Fprintln(GinkgoWriter, "ERROR while flushing file:", syncErr)
+		}
+		closeErr := f.Close()
+		if closeErr != nil {
+			fmt.Fprintln(GinkgoWriter, "ERROR while closing file:", err)
+		}
+	}()
+	for scanner.Scan() {
+		lg := scanner.Text()
+		var js map[string]interface{}
+		err = json.Unmarshal([]byte(lg), &js)
+		if err != nil {
+			GinkgoWriter.Println("Error parsing log:", err, lg)
+		}
+		timestamp, ok := js["ts"].(float64)
+		if ok {
+			ts := time.UnixMicro(int64(timestamp * 1000000))
+			lg = ts.Format(time.Stamp) + " - " + lg
+		}
+
+		if js["level"] != "debug" {
+			fmt.Fprintln(GinkgoWriter, lg)
+		}
+		fmt.Fprintln(f, lg)
+	}
+	if err := scanner.Err(); err != nil {
+		fmt.Fprintln(GinkgoWriter, "ERROR while scanning:", err)
+	}
+}
+
 var _ = BeforeEach(func() {
 	labelsForTestsBreakingTheOperator := []string{"upgrade", "disruptive"}
 	breakingLabelsInCurrentTest := funk.Join(CurrentSpecReport().Labels(),
@@ -73,6 +128,22 @@ var _ = BeforeEach(func() {
 
 	operatorPod, err := env.GetOperatorPod()
 	Expect(err).ToNot(HaveOccurred())
+
+	GinkgoWriter.Println("Putting Tail on the operator log")
+	var buf bytes.Buffer
+	go func() {
+		err = logs.TailPodLogs(context.TODO(), operatorPod, &buf)
+		if err != nil {
+			_, _ = fmt.Fprintf(&buf, "Error dumping operator logs: %v\n", err)
+		}
+	}()
+	DeferCleanup(func(ctx SpecContext) {
+		// if CurrentSpecReport().Failed() {
+		GinkgoWriter.Println("DUMPING Operator Logs. Failed Spec:",
+			CurrentSpecReport().LeafNodeText)
+		saveOperatorLogs(buf, CurrentSpecReport().LeafNodeText)
+		// }
+	})
 
 	if operatorPodWasRenamed {
 		Skip("Skipping test. Operator was renamed")

--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -21,6 +21,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"testing"
@@ -103,7 +104,7 @@ func saveOperatorLogs(buf bytes.Buffer, specName string) {
 		}
 		timestamp, ok := js["ts"].(float64)
 		if ok {
-			ts := time.UnixMicro(int64(timestamp * 1000000))
+			ts := time.UnixMicro(int64(math.Floor(timestamp * 1000000)))
 			lg = ts.Format(time.Stamp) + " - " + lg
 		}
 
@@ -132,7 +133,8 @@ var _ = BeforeEach(func() {
 	GinkgoWriter.Println("Putting Tail on the operator log")
 	var buf bytes.Buffer
 	go func() {
-		err = logs.TailPodLogs(context.TODO(), operatorPod, &buf)
+		// get logs without timestamp parsing; for JSON parseability
+		err = logs.TailPodLogs(context.TODO(), operatorPod, &buf, false)
 		if err != nil {
 			_, _ = fmt.Fprintf(&buf, "Error dumping operator logs: %v\n", err)
 		}

--- a/tests/utils/cluster.go
+++ b/tests/utils/cluster.go
@@ -155,15 +155,15 @@ func (env TestingEnvironment) DumpOperatorLogs(getPrevious bool, requestedLineLe
 	return logs.GetPodLogs(env.Ctx, pod, getPrevious, f, requestedLineLength)
 }
 
-// TailOperatorLogs dumps the operator logs to a file, and returns the log lines
-// as a slice.
+// TailOperatorLogs gets Operator logs starting from the current time, and keeps
+// going until it is interrupted by the context
 func (env TestingEnvironment) TailOperatorLogs(ctx context.Context, writer io.Writer) error {
 	pod, err := env.GetOperatorPod()
 	if err != nil {
 		return err
 	}
 	_, _ = fmt.Fprintf(writer, "Dumping operator pod %v log\n", pod.Name)
-	return logs.TailPodLogs(env.Ctx, pod, writer)
+	return logs.TailPodLogs(ctx, pod, writer)
 }
 
 // DumpNamespaceObjects logs the clusters, pods, pvcs etc. found in a namespace as JSON sections

--- a/tests/utils/cluster.go
+++ b/tests/utils/cluster.go
@@ -19,8 +19,10 @@ package utils
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -130,6 +132,9 @@ func (env TestingEnvironment) DumpOperatorLogs(getPrevious bool, requestedLineLe
 	}
 
 	filename := "out/operator_report_" + pod.Name + ".log"
+	if getPrevious {
+		filename = "out/operator_report_previous_" + pod.Name + ".log"
+	}
 	f, err := os.Create(filepath.Clean(filename))
 	if err != nil {
 		fmt.Println(err)
@@ -148,6 +153,17 @@ func (env TestingEnvironment) DumpOperatorLogs(getPrevious bool, requestedLineLe
 
 	_, _ = fmt.Fprintf(f, "Dumping operator pod %v log\n", pod.Name)
 	return logs.GetPodLogs(env.Ctx, pod, getPrevious, f, requestedLineLength)
+}
+
+// TailOperatorLogs dumps the operator logs to a file, and returns the log lines
+// as a slice.
+func (env TestingEnvironment) TailOperatorLogs(ctx context.Context, writer io.Writer) error {
+	pod, err := env.GetOperatorPod()
+	if err != nil {
+		return err
+	}
+	_, _ = fmt.Fprintf(writer, "Dumping operator pod %v log\n", pod.Name)
+	return logs.TailPodLogs(env.Ctx, pod, writer)
 }
 
 // DumpNamespaceObjects logs the clusters, pods, pvcs etc. found in a namespace as JSON sections
@@ -404,8 +420,8 @@ func (env TestingEnvironment) DescribeKubernetesNodes() (string, error) {
 		if err != nil {
 			return "", err
 		}
-		report.WriteString(stdout)
 		report.WriteString("================================================\n")
+		report.WriteString(stdout)
 		report.WriteString("================================================\n")
 	}
 	return report.String(), nil

--- a/tests/utils/cluster.go
+++ b/tests/utils/cluster.go
@@ -19,10 +19,8 @@ package utils
 import (
 	"bufio"
 	"bytes"
-	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -153,17 +151,6 @@ func (env TestingEnvironment) DumpOperatorLogs(getPrevious bool, requestedLineLe
 
 	_, _ = fmt.Fprintf(f, "Dumping operator pod %v log\n", pod.Name)
 	return logs.GetPodLogs(env.Ctx, pod, getPrevious, f, requestedLineLength)
-}
-
-// TailOperatorLogs gets Operator logs starting from the current time, and keeps
-// going until it is interrupted by the context
-func (env TestingEnvironment) TailOperatorLogs(ctx context.Context, writer io.Writer) error {
-	pod, err := env.GetOperatorPod()
-	if err != nil {
-		return err
-	}
-	_, _ = fmt.Fprintf(writer, "Dumping operator pod %v log\n", pod.Name)
-	return logs.TailPodLogs(ctx, pod, writer)
 }
 
 // DumpNamespaceObjects logs the clusters, pods, pvcs etc. found in a namespace as JSON sections


### PR DESCRIPTION
To help investigate E2E test failures, we start tailing the operator
logs at the beginning of each spec, in a goroutine.
If the spec fails, we display the logs on Ginkgo and store them in a file.

Closes #960 

Signed-off-by: Jaime Silvela <jaime.silvela@enterprisedb.com>