### PR TITLE
tests: avoid failures if FEATURE_TYPE is not set

### DIFF
--- a/hack/e2e/run-e2e.sh
+++ b/hack/e2e/run-e2e.sh
@@ -122,9 +122,9 @@ LABEL_FILTERS="!(upgrade)"
 if [ ! -z "${FEATURE_TYPE+x}" ]; then
   ADDITIONAL_FILTERS="${FEATURE_TYPE//,/ || }"
   LABEL_FILTERS="!(upgrade) && ${ADDITIONAL_FILTERS}"
-  echo "E2E tests are running with the following filters: ${LABEL_FILTERS}"
 fi
 
+echo "E2E tests are running with the following filters: ${LABEL_FILTERS}"
 ginkgo --nodes=4 --timeout 3h --slow-spec-threshold 5m --label-filter "${LABEL_FILTERS}" \
        --output-dir "${ROOT_DIR}/tests/e2e/out/"  --json-report  "report.json" \
        -v "${ROOT_DIR}/tests/e2e/..." || RC_GINKGO2=$?

--- a/hack/e2e/run-e2e.sh
+++ b/hack/e2e/run-e2e.sh
@@ -119,12 +119,12 @@ mkdir -p "${ROOT_DIR}/tests/e2e/out"
 # would create CPUs-1 nodes and saturate the testing server
 RC_GINKGO2=0
 LABEL_FILTERS="!(upgrade)"
-if [ "${FEATURE_TYPE}" ]; then
+if [ ! -z "${FEATURE_TYPE+x}" ]; then
   ADDITIONAL_FILTERS="${FEATURE_TYPE//,/ || }"
   LABEL_FILTERS="!(upgrade) && ${ADDITIONAL_FILTERS}"
+  echo "E2E tests are running with the following filters: ${LABEL_FILTERS}"
 fi
 
-echo "E2E tests are running with the following filters: ${LABEL_FILTERS}"
 ginkgo --nodes=4 --timeout 3h --slow-spec-threshold 5m --label-filter "${LABEL_FILTERS}" \
        --output-dir "${ROOT_DIR}/tests/e2e/out/"  --json-report  "report.json" \
        -v "${ROOT_DIR}/tests/e2e/..." || RC_GINKGO2=$?


### PR DESCRIPTION
When running E2E tests on a local kind cluster via `./hack/e2e/run-e2e.sh`, the script would exit abruptly in case FEATURE_TYPE is not set:
```
./hack/e2e/run-e2e.sh: line 122: FEATURE_TYPE: unbound variable
```
Avoid failing in case the variable is not set (all the tests will be executed in case FEATURE_TYPE is not specified at all or set to an empty variable). 
Also make the script print out the filters only if additional filters besides to default `!(upgrade)` have been defined.  


Signed-off-by: Niccolò Fei <niccolo.fei@enterprisedb.com>