### PR TITLE
fix: correctly manage `plpgsql` in database import

### DIFF
--- a/pkg/management/postgres/logicalimport/database.go
+++ b/pkg/management/postgres/logicalimport/database.go
@@ -305,14 +305,16 @@ func (ds *databaseSnapshotter) dropExtensionsFromDatabase(
 	database string,
 ) error {
 	contextLogger := log.FromContext(ctx)
-	contextLogger.Info("dropping extensions from the target (empty) database")
+	contextLogger.Info("dropping user-defined extensions from the target (empty) database")
 
 	db, err := target.Connection(database)
 	if err != nil {
 		return err
 	}
 
-	rows, err := db.QueryContext(ctx, "SELECT extname FROM pg_extension")
+	// In Postgres, OID 16384 is the first non system ID that can be used in the database
+	// catalog, as defined in the `FirstNormalObjectId` constant (src/include/access/transam.h)
+	rows, err := db.QueryContext(ctx, "SELECT extname FROM pg_extension WHERE oid >= 16384")
 	if err != nil {
 		return err
 	}

--- a/tests/e2e/fixtures/cluster_microservice/cluster-base.yaml.template
+++ b/tests/e2e/fixtures/cluster_microservice/cluster-base.yaml.template
@@ -19,7 +19,7 @@ spec:
     initdb:
       database: app
       owner: app
-      # Creates a dummy plpgsql function to prove that restore works
+      # Creates a fake plpgsql function to prove that restore works
       postInitApplicationSQL:
       - "CREATE FUNCTION one() RETURNS INT LANGUAGE plpgsql IMMUTABLE AS 'BEGIN RETURN 1; END;'"
 

--- a/tests/e2e/fixtures/cluster_microservice/cluster-base.yaml.template
+++ b/tests/e2e/fixtures/cluster_microservice/cluster-base.yaml.template
@@ -15,17 +15,13 @@ spec:
       log_autovacuum_min_duration: '1s'
       log_replication_commands: 'on'
 
-  # Example of rolling update strategy:
-  # - unsupervised: automated update of the primary once all
-  #                 replicas have been upgraded (default)
-  # - supervised: requires manual supervision to perform
-  #               the switchover of the primary
-  primaryUpdateStrategy: unsupervised
-
   bootstrap:
     initdb:
       database: app
       owner: app
+      # Creates a dummy plpgsql function to prove that restore works
+      postInitApplicationSQL:
+      - "CREATE FUNCTION one() RETURNS INT LANGUAGE plpgsql IMMUTABLE AS 'BEGIN RETURN 1; END;'"
 
   # Persistent storage configuration
   storage:


### PR DESCRIPTION
Limit the extensions to be removed in the logical import bootstrap phase to the user-defined ones. This way, the default provided `plpgsql` extension is not dropped before the restore phase is started.

Closes #869
Closes #970

Signed-off-by: Gabriele Bartolini <gabriele.bartolini@enterprisedb.com>