### PR TITLE
fix: automatic PostgreSQL version update regexp

### DIFF
--- a/.github/workflows/latest-postgres-version-check.yml
+++ b/.github/workflows/latest-postgres-version-check.yml
@@ -63,7 +63,7 @@ jobs:
           sed -i '/DefaultImageName *=/s@".*"@"'"${LATEST_POSTGRES_VERSION_IMAGE}"'"@' pkg/versions/versions.go
 
           # Update docs directory (only .md and .yaml filename extensions)
-          find docs -type f \( -name '*.md' -o -name '*.yaml' \) -exec sed -i "s/${CURRENT_POSTGRES_VERSION//./\\.}/${LATEST_POSTGRES_VERSION}/g" {} +
+          find docs -type f \( -name '*.md' -o -name '*.yaml' \) \! -path '*release_notes*' -exec sed -i "/[ :]${CURRENT_POSTGRES_VERSION//./\\.}/s/${CURRENT_POSTGRES_VERSION//./\\.}/${LATEST_POSTGRES_VERSION}/g" {} +
 
       - name: Create PR to update PostgreSQL version
         if: env.LATEST_POSTGRES_VERSION_IMAGE != env.CURRENT_POSTGRES_VERSION_IMAGE


### PR DESCRIPTION
The regexp replacing the previous-latest version with the new one was updating not related versions, like the CNPG version 1.15.0 to 1.15.1

The regexp is now more precise and only updates places where a space or a colon character precedes the Postgres version.

We also exclude all the versions in the release notes.

Closes #997 