### PR TITLE
chore: replace `postgresql` with `cnpg.io/cluster` as service selector

### DIFF
--- a/pkg/specs/services.go
+++ b/pkg/specs/services.go
@@ -23,6 +23,7 @@ import (
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/postgres"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 )
 
 // CreateClusterAnyService create a service insisting on all the pods
@@ -37,14 +38,14 @@ func CreateClusterAnyService(cluster apiv1.Cluster) *corev1.Service {
 			PublishNotReadyAddresses: true,
 			Ports: []corev1.ServicePort{
 				{
-					Name:       "postgres",
+					Name:       PostgresContainerName,
 					Protocol:   corev1.ProtocolTCP,
 					TargetPort: intstr.FromInt(postgres.ServerPort),
 					Port:       postgres.ServerPort,
 				},
 			},
 			Selector: map[string]string{
-				"postgresql": cluster.Name,
+				utils.ClusterLabelName: cluster.Name,
 			},
 		},
 	}
@@ -61,14 +62,14 @@ func CreateClusterReadService(cluster apiv1.Cluster) *corev1.Service {
 			Type: corev1.ServiceTypeClusterIP,
 			Ports: []corev1.ServicePort{
 				{
-					Name:       "postgres",
+					Name:       PostgresContainerName,
 					Protocol:   corev1.ProtocolTCP,
 					TargetPort: intstr.FromInt(postgres.ServerPort),
 					Port:       postgres.ServerPort,
 				},
 			},
 			Selector: map[string]string{
-				"postgresql": cluster.Name,
+				utils.ClusterLabelName: cluster.Name,
 			},
 		},
 	}
@@ -85,15 +86,15 @@ func CreateClusterReadOnlyService(cluster apiv1.Cluster) *corev1.Service {
 			Type: corev1.ServiceTypeClusterIP,
 			Ports: []corev1.ServicePort{
 				{
-					Name:       "postgres",
+					Name:       PostgresContainerName,
 					Protocol:   corev1.ProtocolTCP,
 					TargetPort: intstr.FromInt(postgres.ServerPort),
 					Port:       postgres.ServerPort,
 				},
 			},
 			Selector: map[string]string{
-				"postgresql":         cluster.Name,
-				ClusterRoleLabelName: ClusterRoleLabelReplica,
+				utils.ClusterLabelName: cluster.Name,
+				ClusterRoleLabelName:   ClusterRoleLabelReplica,
 			},
 		},
 	}
@@ -110,15 +111,15 @@ func CreateClusterReadWriteService(cluster apiv1.Cluster) *corev1.Service {
 			Type: corev1.ServiceTypeClusterIP,
 			Ports: []corev1.ServicePort{
 				{
-					Name:       "postgres",
+					Name:       PostgresContainerName,
 					Protocol:   corev1.ProtocolTCP,
 					TargetPort: intstr.FromInt(postgres.ServerPort),
 					Port:       postgres.ServerPort,
 				},
 			},
 			Selector: map[string]string{
-				"postgresql":         cluster.Name,
-				ClusterRoleLabelName: ClusterRoleLabelPrimary,
+				utils.ClusterLabelName: cluster.Name,
+				ClusterRoleLabelName:   ClusterRoleLabelPrimary,
 			},
 		},
 	}

--- a/pkg/specs/services_test.go
+++ b/pkg/specs/services_test.go
@@ -20,6 +20,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -36,21 +37,21 @@ var _ = Describe("Services specification", func() {
 		service := CreateClusterAnyService(postgresql)
 		Expect(service.Name).To(Equal("clustername-any"))
 		Expect(service.Spec.PublishNotReadyAddresses).To(BeTrue())
-		Expect(service.Spec.Selector["postgresql"]).To(Equal("clustername"))
+		Expect(service.Spec.Selector[utils.ClusterLabelName]).To(Equal("clustername"))
 	})
 
 	It("create a configured -r service", func() {
 		service := CreateClusterReadService(postgresql)
 		Expect(service.Name).To(Equal("clustername-r"))
 		Expect(service.Spec.PublishNotReadyAddresses).To(BeFalse())
-		Expect(service.Spec.Selector["postgresql"]).To(Equal("clustername"))
+		Expect(service.Spec.Selector[utils.ClusterLabelName]).To(Equal("clustername"))
 	})
 
 	It("create a configured -ro service", func() {
 		service := CreateClusterReadOnlyService(postgresql)
 		Expect(service.Name).To(Equal("clustername-ro"))
 		Expect(service.Spec.PublishNotReadyAddresses).To(BeFalse())
-		Expect(service.Spec.Selector["postgresql"]).To(Equal("clustername"))
+		Expect(service.Spec.Selector[utils.ClusterLabelName]).To(Equal("clustername"))
 		Expect(service.Spec.Selector[ClusterRoleLabelName]).To(Equal(ClusterRoleLabelReplica))
 	})
 
@@ -58,7 +59,7 @@ var _ = Describe("Services specification", func() {
 		service := CreateClusterReadWriteService(postgresql)
 		Expect(service.Name).To(Equal("clustername-rw"))
 		Expect(service.Spec.PublishNotReadyAddresses).To(BeFalse())
-		Expect(service.Spec.Selector["postgresql"]).To(Equal("clustername"))
+		Expect(service.Spec.Selector[utils.ClusterLabelName]).To(Equal("clustername"))
 		Expect(service.Spec.Selector[ClusterRoleLabelName]).To(Equal(ClusterRoleLabelPrimary))
 	})
 })


### PR DESCRIPTION
Closes #1021 