### PR TITLE
ci: removing unused rook env and k8s version 1.21 support from unit test

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -42,7 +42,6 @@ env:
   GOLANGCI_LINT_VERSION: "v1.50"
   KUBEBUILDER_VERSION: "2.3.1"
   KIND_VERSION: "v0.11.0"
-  ROOK_VERSION: "v1.6.8"
   CNPG_IMAGE_NAME: "ghcr.io/${{ github.repository }}-testing"
   FEATURE_TYPE: "${{github.event.inputs.feature_type}}"
 
@@ -200,7 +199,6 @@ jobs:
       matrix:
         # The Unit test is performed per multiple supported k8s versions (each job for each k8s version) as below:
         k8s-version:
-          - 1.21.x
           - 1.22.x
           - 1.23.x
           - 1.24.x

--- a/docs/src/e2e.md
+++ b/docs/src/e2e.md
@@ -11,7 +11,6 @@ helping detect bugs at an early stage of the development process:
 * 1.24
 * 1.23
 * 1.22
-* 1.21
 
 The following PostgreSQL versions are tested:
 


### PR DESCRIPTION
closes #1018 
Signed-off-by: Danish Khan <danish.khan@enterprisedb.com>