### PR TITLE
chore: centralize instance corev1.ServicePort generation logic

### DIFF
--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -1093,7 +1093,7 @@ func (r *ClusterReconciler) mapNodeToClusters(ctx context.Context) handler.MapFu
 		err := r.List(ctx, &childPods,
 			client.MatchingFields{".spec.nodeName": node.Name},
 			client.MatchingLabels{specs.ClusterRoleLabelName: specs.ClusterRoleLabelPrimary},
-			client.HasLabels{specs.ClusterLabelName},
+			client.HasLabels{utils.ClusterLabelName},
 		)
 		if err != nil {
 			log.FromContext(ctx).Error(err, "while getting primary instances for node")

--- a/docs/src/monitoring.md
+++ b/docs/src/monitoring.md
@@ -76,7 +76,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      postgresql: cluster-example
+      "cnpg.io/cluster": cluster-example
   podMetricsEndpoints:
   - port: metrics
 ```

--- a/pkg/specs/poddisruptionbudget.go
+++ b/pkg/specs/poddisruptionbudget.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 )
 
 // BuildReplicasPodDisruptionBudget creates a pod disruption budget telling
@@ -43,8 +44,8 @@ func BuildReplicasPodDisruptionBudget(cluster *apiv1.Cluster) *policyv1.PodDisru
 		Spec: policyv1.PodDisruptionBudgetSpec{
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					ClusterLabelName:     cluster.Name,
-					ClusterRoleLabelName: ClusterRoleLabelReplica,
+					utils.ClusterLabelName: cluster.Name,
+					ClusterRoleLabelName:   ClusterRoleLabelReplica,
 				},
 			},
 			MinAvailable: &allReplicasButOne,
@@ -68,8 +69,8 @@ func BuildPrimaryPodDisruptionBudget(cluster *apiv1.Cluster) *policyv1.PodDisrup
 		Spec: policyv1.PodDisruptionBudgetSpec{
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					ClusterLabelName:     cluster.Name,
-					ClusterRoleLabelName: ClusterRoleLabelPrimary,
+					utils.ClusterLabelName: cluster.Name,
+					ClusterRoleLabelName:   ClusterRoleLabelPrimary,
 				},
 			},
 			MinAvailable: &one,

--- a/pkg/specs/pods.go
+++ b/pkg/specs/pods.go
@@ -240,7 +240,7 @@ func CreateGeneratedAntiAffinity(clusterName string, config apiv1.AffinityConfig
 		LabelSelector: &metav1.LabelSelector{
 			MatchExpressions: []metav1.LabelSelectorRequirement{
 				{
-					Key:      ClusterLabelName,
+					Key:      utils.ClusterLabelName,
 					Operator: metav1.LabelSelectorOpIn,
 					Values: []string{
 						clusterName,

--- a/pkg/specs/services.go
+++ b/pkg/specs/services.go
@@ -26,6 +26,17 @@ import (
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 )
 
+func buildInstanceServicePorts() []corev1.ServicePort {
+	return []corev1.ServicePort{
+		{
+			Name:       PostgresContainerName,
+			Protocol:   corev1.ProtocolTCP,
+			TargetPort: intstr.FromInt(postgres.ServerPort),
+			Port:       postgres.ServerPort,
+		},
+	}
+}
+
 // CreateClusterAnyService create a service insisting on all the pods
 func CreateClusterAnyService(cluster apiv1.Cluster) *corev1.Service {
 	return &corev1.Service{
@@ -36,14 +47,7 @@ func CreateClusterAnyService(cluster apiv1.Cluster) *corev1.Service {
 		Spec: corev1.ServiceSpec{
 			Type:                     corev1.ServiceTypeClusterIP,
 			PublishNotReadyAddresses: true,
-			Ports: []corev1.ServicePort{
-				{
-					Name:       PostgresContainerName,
-					Protocol:   corev1.ProtocolTCP,
-					TargetPort: intstr.FromInt(postgres.ServerPort),
-					Port:       postgres.ServerPort,
-				},
-			},
+			Ports:                    buildInstanceServicePorts(),
 			Selector: map[string]string{
 				utils.ClusterLabelName: cluster.Name,
 			},
@@ -59,15 +63,8 @@ func CreateClusterReadService(cluster apiv1.Cluster) *corev1.Service {
 			Namespace: cluster.Namespace,
 		},
 		Spec: corev1.ServiceSpec{
-			Type: corev1.ServiceTypeClusterIP,
-			Ports: []corev1.ServicePort{
-				{
-					Name:       PostgresContainerName,
-					Protocol:   corev1.ProtocolTCP,
-					TargetPort: intstr.FromInt(postgres.ServerPort),
-					Port:       postgres.ServerPort,
-				},
-			},
+			Type:  corev1.ServiceTypeClusterIP,
+			Ports: buildInstanceServicePorts(),
 			Selector: map[string]string{
 				utils.ClusterLabelName: cluster.Name,
 			},
@@ -83,15 +80,8 @@ func CreateClusterReadOnlyService(cluster apiv1.Cluster) *corev1.Service {
 			Namespace: cluster.Namespace,
 		},
 		Spec: corev1.ServiceSpec{
-			Type: corev1.ServiceTypeClusterIP,
-			Ports: []corev1.ServicePort{
-				{
-					Name:       PostgresContainerName,
-					Protocol:   corev1.ProtocolTCP,
-					TargetPort: intstr.FromInt(postgres.ServerPort),
-					Port:       postgres.ServerPort,
-				},
-			},
+			Type:  corev1.ServiceTypeClusterIP,
+			Ports: buildInstanceServicePorts(),
 			Selector: map[string]string{
 				utils.ClusterLabelName: cluster.Name,
 				ClusterRoleLabelName:   ClusterRoleLabelReplica,
@@ -108,15 +98,8 @@ func CreateClusterReadWriteService(cluster apiv1.Cluster) *corev1.Service {
 			Namespace: cluster.Namespace,
 		},
 		Spec: corev1.ServiceSpec{
-			Type: corev1.ServiceTypeClusterIP,
-			Ports: []corev1.ServicePort{
-				{
-					Name:       PostgresContainerName,
-					Protocol:   corev1.ProtocolTCP,
-					TargetPort: intstr.FromInt(postgres.ServerPort),
-					Port:       postgres.ServerPort,
-				},
-			},
+			Type:  corev1.ServiceTypeClusterIP,
+			Ports: buildInstanceServicePorts(),
 			Selector: map[string]string{
 				utils.ClusterLabelName: cluster.Name,
 				ClusterRoleLabelName:   ClusterRoleLabelPrimary,


### PR DESCRIPTION
Some refactor has been done on how ports are created using only one function
for the ports in the service creation. 

Closes #1021

Signed-off-by: Armando Ruocco <armando.ruocco@enterprisedb.com>
Signed-off-by: Tao Li <tao.li@enterprisedb.com>
Signed-off-by: Jonathan Gonzalez V <jonathan.gonzalez@enterprisedb.com>