### PR TITLE
feat: add `stringset.Eq` method

### DIFF
--- a/pkg/stringset/stringset.go
+++ b/pkg/stringset/stringset.go
@@ -70,3 +70,22 @@ func (set *Data) ToList() (result []string) {
 	}
 	return
 }
+
+// Eq compares two string sets for equality
+func (set *Data) Eq(other *Data) bool {
+	if set == nil || other == nil {
+		return false
+	}
+
+	if set.Len() != other.Len() {
+		return false
+	}
+
+	for key := range set.innerMap {
+		if !other.Has(key) {
+			return false
+		}
+	}
+
+	return true
+}

--- a/pkg/stringset/stringset_test.go
+++ b/pkg/stringset/stringset_test.go
@@ -50,4 +50,11 @@ var _ = Describe("String set", func() {
 	It("constructs a string slice given a set", func() {
 		Expect(From([]string{"one", "two"}).ToList()).To(ContainElements("one", "two"))
 	})
+
+	It("compares two string set for equality", func() {
+		Expect(From([]string{"one", "two"}).Eq(From([]string{"one", "two"}))).To(BeTrue())
+		Expect(From([]string{"one", "two"}).Eq(From([]string{"two", "three"}))).To(BeFalse())
+		Expect(From([]string{"one", "two"}).Eq(From([]string{"one", "two", "three"}))).To(BeFalse())
+		Expect(From([]string{"one", "two", "three"}).Eq(From([]string{"one", "two"}))).To(BeFalse())
+	})
 })


### PR DESCRIPTION
This patch instroduces a `stringset.Eq` method, which will be needed for the next commits.

Closes: #1069

Signed-off-by: Leonardo Cecchi <leonardo.cecchi@enterprisedb.com>