### PR TITLE
fix:  missing ApiVersion and Kind in pgbench manifest using --dry-run and updating doc.

### DIFF
--- a/docs/src/benchmarking.md
+++ b/docs/src/benchmarking.md
@@ -10,8 +10,7 @@ Example usage:
 kubectl cnpg pgbench <cluster-name> --pgbench-job-name <pgbench-job> --db-name <db-name> -n <NAMESPACE> -- --time 30 --client 1 --jobs 1
 ```
 
-Example of how to run it against a Cluster named `cluster-example` and Namespace `pgbench`:
-```
+Example of how to run it against a `Cluster` named `cluster-example` in the `pgbench` namespace:
 kubectl cnpg pgbench cluster-example --pgbench-job-name pgbench-job -n pgbench -- --time 30 --client 1 --jobs 1
 ```
 

--- a/docs/src/benchmarking.md
+++ b/docs/src/benchmarking.md
@@ -15,10 +15,12 @@ kubectl cnpg pgbench \
 ```
 
 Example of how to run it against a `Cluster` named `cluster-example` in the `pgbench` namespace:
+```
 kubectl cnpg pgbench \
    -n pgbench cluster-example \
    --pgbench-job-name pgbench-job \
    -- --time 30 --client 1 --jobs 1
+
 ```
 
 Example of how to run it on an existing database by using the `--db-name` flag and
@@ -34,14 +36,12 @@ kubectl cnpg pgbench \
 The job status can be fetched by running:
 ```
 kubectl get job/pgbench-job -n <namespace>
-```
-```
+
 NAME               COMPLETIONS   DURATION   AGE
 pgbench-job-name   1/1           15s        41s
 ```
 
 Once the job is completed the results can be gathered by executing:
-
 ```
 kubectl logs job/pgbench-job -n <namespace>
 ```

--- a/docs/src/benchmarking.md
+++ b/docs/src/benchmarking.md
@@ -11,7 +11,10 @@ kubectl cnpg pgbench <cluster-name> --pgbench-job-name <pgbench-job> --db-name <
 ```
 
 Example of how to run it against a `Cluster` named `cluster-example` in the `pgbench` namespace:
-kubectl cnpg pgbench cluster-example --pgbench-job-name pgbench-job -n pgbench -- --time 30 --client 1 --jobs 1
+kubectl cnpg pgbench \
+   -n pgbench cluster-example \
+   --pgbench-job-name pgbench-job \
+   -- --time 30 --client 1 --jobs 1
 ```
 
 Example of how to run it on an existing database by using the `--db-name` flag and

--- a/docs/src/benchmarking.md
+++ b/docs/src/benchmarking.md
@@ -14,7 +14,8 @@ Example of how to run it against a `Cluster` named `cluster-example` in the `pgb
 kubectl cnpg pgbench cluster-example --pgbench-job-name pgbench-job -n pgbench -- --time 30 --client 1 --jobs 1
 ```
 
-Example of how to run it on an existing database by using the `--db-name` flag and Namespace `pgbench`:
+Example of how to run it on an existing database by using the `--db-name` flag and
+the `pgbench` namespace:
 ```
 kubectl cnpg pgbench cluster-example --db-name pgbench --pgbench-job-name pgbench-job -n pgbench -- --time 30 --client 1 --jobs 1
 ```

--- a/docs/src/benchmarking.md
+++ b/docs/src/benchmarking.md
@@ -7,22 +7,22 @@ The command also accepts the `--dry-run` command, this will output the job manif
 
 Example usage:
 ```
-kubectl cnpg pgbench <cluster-name> --pgbench-job-name <pgbench-job> --db-name <db-name> -- --time 30 --client 1 --jobs 1
+kubectl cnpg pgbench <cluster-name> --pgbench-job-name <pgbench-job> --db-name <db-name> -n <NAMESPACE> -- --time 30 --client 1 --jobs 1
 ```
 
-Example of how to run it against a Cluster named `cluster-example`:
+Example of how to run it against a Cluster named `cluster-example` and Namespace `pgbench`:
 ```
-kubectl cnpg pgbench cluster-example --pgbench-job-name pgbench-job -- --time 30 --client 1 --jobs 1 -n NAMESPACE
+kubectl cnpg pgbench cluster-example --pgbench-job-name pgbench-job -n pgbench -- --time 30 --client 1 --jobs 1
 ```
 
-Example of how to run it on an existing database by using the `--db-name` flag:
+Example of how to run it on an existing database by using the `--db-name` flag and Namespace `pgbench`:
 ```
-kubectl cnpg pgbench cluster-example --db-name pgbench --pgbench-job-name pgbench-job -- --time 30 --client 1 --jobs 1 -n NAMESPACE
+kubectl cnpg pgbench cluster-example --db-name pgbench --pgbench-job-name pgbench-job -n pgbench -- --time 30 --client 1 --jobs 1
 ```
 
 The job status can be fetched by running:
 ```
-kubectl get job/pgbench-job -n NAMESPACE
+kubectl get job/pgbench-job -n <namespace>
 ```
 ```
 NAME               COMPLETIONS   DURATION   AGE
@@ -32,5 +32,5 @@ pgbench-job-name   1/1           15s        41s
 Once the job is completed the results can be gathered by executing:
 
 ```
-kubectl logs job/pgbench-job -n NAMESPACE
+kubectl logs job/pgbench-job -n <namespace>
 ```

--- a/docs/src/benchmarking.md
+++ b/docs/src/benchmarking.md
@@ -17,7 +17,11 @@ kubectl cnpg pgbench cluster-example --pgbench-job-name pgbench-job -n pgbench -
 Example of how to run it on an existing database by using the `--db-name` flag and
 the `pgbench` namespace:
 ```
-kubectl cnpg pgbench cluster-example --db-name pgbench --pgbench-job-name pgbench-job -n pgbench -- --time 30 --client 1 --jobs 1
+kubectl cnpg pgbench \
+  -n pgbench cluster-example \
+  --db-name pgbench \
+  --pgbench-job-name pgbench-job \
+  -- --time 30 --client 1 --jobs 1
 ```
 
 The job status can be fetched by running:

--- a/docs/src/benchmarking.md
+++ b/docs/src/benchmarking.md
@@ -7,7 +7,11 @@ The command also accepts the `--dry-run` command, this will output the job manif
 
 Example usage:
 ```
-kubectl cnpg pgbench <cluster-name> --pgbench-job-name <pgbench-job> --db-name <db-name> -n <NAMESPACE> -- --time 30 --client 1 --jobs 1
+kubectl cnpg pgbench \
+  -n <namespace> <cluster-name> \
+  --pgbench-job-name <pgbench-job> \
+  --db-name <db-name> \
+  -- --time 30 --client 1 --jobs 1
 ```
 
 Example of how to run it against a `Cluster` named `cluster-example` in the `pgbench` namespace:

--- a/internal/cmd/plugin/pgbench/pgbench.go
+++ b/internal/cmd/plugin/pgbench/pgbench.go
@@ -119,6 +119,11 @@ func (cmd *pgBenchCommand) buildJob(cluster apiv1.Cluster) *batchv1.Job {
 		"pbBenchJob": cluster.Name,
 	}
 	return &batchv1.Job{
+		// To ensure we have manifest with Kind and APi in --dry-run
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "batch/v1",
+			Kind:       "Job",
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cmd.jobName,
 			Namespace: cluster.Namespace,


### PR DESCRIPTION
- missing ApiVersion and Kind in pgbench manifest using --dry-run.
- Updating doc for NAMESPACE placement in pgbench under BenchMarking.

closes #1078

Signed-off-by: Danish Khan <danish.khan@enterprisedb.com>