### PR TITLE
ci: Make the operator log level configurable in e2e test suite

### DIFF
--- a/.github/workflows/chatops-dispatcher.yml
+++ b/.github/workflows/chatops-dispatcher.yml
@@ -43,6 +43,7 @@ jobs:
             test_level=4
             depth=push
             plugin=false
+            log_level=info
 
       - name: Add "ok to merge :ok_hand:" label to CNPG PR
         uses: actions-ecosystem/action-add-labels@v1.1.3

--- a/.github/workflows/chatops-receiver.yml
+++ b/.github/workflows/chatops-receiver.yml
@@ -59,6 +59,8 @@ jobs:
             "test_level":"${{ github.event.client_payload.slash_command.args.named.tl
                   || github.event.client_payload.slash_command.args.named.level
                   || github.event.client_payload.slash_command.args.named.test_level }}",
+            "log_level":"${{ github.event.client_payload.slash_command.args.named.ll
+                  || github.event.client_payload.slash_command.args.named.log_level }}",
             "build_plugin":"${{ github.event.client_payload.slash_command.args.named.p
                   || github.event.client_payload.slash_command.args.named.plugin }}"}
       - name: Create comment

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -28,7 +28,7 @@ on:
         cluster-metadata, recovery, importing-databases, storage, security, maintenance)'
         required: false
       log_level:
-        description: 'cluster log level (error, warning, info(default), debug, trace)'
+        description: 'Log level for operator (error, warning, info(default), debug, trace)'
         required: false
       build_plugin:
         type: boolean

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -27,6 +27,9 @@ on:
         backup-restore, operator, observability, replication, plugin, postgres-configuration, pod-scheduling,
         cluster-metadata, recovery, importing-databases, storage, security, maintenance)'
         required: false
+      log_level:
+        description: 'cluster log level (error, warning, info(default), debug, trace)'
+        required: false
       build_plugin:
         type: boolean
         required: false
@@ -780,6 +783,19 @@ jobs:
             sudo apt-get update
             sudo apt-get install -y gettext-base
             sudo hack/setup-cluster.sh prepare /usr/local/bin
+      -
+        name: Prepare patch for customization
+        env:
+          ## the following variable all need be set if we use env_override_customized.yaml.template
+          LEADER_ELECTION: "true"
+          LEADER_LEASE_DURATION: 15
+          LEADER_RENEW_DEADLINE: 10
+          LIVENESS_PROBE_THRESHOLD: 3
+          LOG_LEVEL: ${{ github.event.inputs.log_level }}
+        run: |
+          LOG_LEVEL=${LOG_LEVEL:-info}
+          envsubst < hack/e2e/env_override_customized.yaml.template > config/manager/env_override.yaml
+          cat config/manager/env_override.yaml
       -
         name: Run Kind End-to-End tests
         run:

--- a/hack/e2e/env_override_customized.yaml.template
+++ b/hack/e2e/env_override_customized.yaml.template
@@ -1,0 +1,26 @@
+# This patch merges the environment with the values read from the controller-manager-env config map
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        envFrom:
+        - configMapRef:
+            name: controller-manager-env
+        args:
+        - controller
+        - --leader-elect=${LEADER_ELECTION}
+        - --leader-lease-duration=${LEADER_LEASE_DURATION}
+        - --leader-renew-deadline=${LEADER_RENEW_DEADLINE}
+        - --config-map-name=$(OPERATOR_DEPLOYMENT_NAME)-config
+        - --secret-name=$(OPERATOR_DEPLOYMENT_NAME)-config
+        - --webhook-port=9443
+        - --log-level=${LOG_LEVEL}
+        - --pprof-server=true
+        livenessProbe:
+          failureThreshold: ${LIVENESS_PROBE_THRESHOLD}


### PR DESCRIPTION
This patch make the operator log level configurable in e2e test suite, and 
expose the configuration into workflow dispatch and /test slash command options

Closes: #1086 
Signed-off-by: Tao Li <tao.li@enterprisedb.com> 