### PR TITLE
chore: remove k8s version 1.25 from unit test and e2e in release

### DIFF
--- a/.github/k8s_versions_scope.json
+++ b/.github/k8s_versions_scope.json
@@ -1,6 +1,6 @@
 {
   "e2e_test": {
-    "KIND": {"min": "1.22", "max": ""}
+    "KIND": {"min": "1.22", "max": "1.24"}
   },
-    "unit_test": {"min":  "1.22", "max":  "1.25"}
+    "unit_test": {"min":  "1.22", "max":  "1.24"}
 }


### PR DESCRIPTION
Having 1.25 in the list of kubernetes version to test was producing
errors since this version it's not supported for this release 1.17

Closes: #1102 

Signed-off-by: Tao Li <tao.li@enterprisedb.com>