### PR TITLE
docs: ldap section is not under parameters

### DIFF
--- a/docs/src/postgresql_conf.md
+++ b/docs/src/postgresql_conf.md
@@ -358,16 +358,15 @@ This section filled out for search+bind could look as follows:
 
 ```yaml
 postgresql:
-  parameters:
-    ldap:
-      server: 'openldap.default.svc.cluster.local'
-      bindSearchAuth:
-        baseDN: 'ou=org,dc=example,dc=com'
-        bindDN: 'cn=admin,dc=example,dc=com'
-        bindPassword:
-          name: 'ldapBindPassword'
-          key: 'data'
-        searchAttribute: 'uid'
+  ldap:
+    server: 'openldap.default.svc.cluster.local'
+    bindSearchAuth:
+      baseDN: 'ou=org,dc=example,dc=com'
+      bindDN: 'cn=admin,dc=example,dc=com'
+      bindPassword:
+        name: 'ldapBindPassword'
+        key: 'data'
+      searchAttribute: 'uid'
 ```
 
 ## Changing configuration


### PR DESCRIPTION
Correct the example given for LDAP configuration - the `ldap` section is directly under `postgresql`, not under `parameters`

Fixes https://github.com/EnterpriseDB/docs/issues/2576
