### PR TITLE
fix: permissions error on bootstrap

### DIFF
--- a/internal/cmd/manager/bootstrap/cmd.go
+++ b/internal/cmd/manager/bootstrap/cmd.go
@@ -44,7 +44,7 @@ func NewCmd() *cobra.Command {
 				panic(err)
 			}
 
-			log.Info("Setting 0755 permissions")
+			log.Info("Setting 0750 permissions")
 			err = os.Chmod(dest, 0o750) // #nosec
 			if err != nil {
 				panic(err)

--- a/internal/cmd/manager/bootstrap/cmd.go
+++ b/internal/cmd/manager/bootstrap/cmd.go
@@ -45,7 +45,7 @@ func NewCmd() *cobra.Command {
 			}
 
 			log.Info("Setting 0755 permissions")
-			err = os.Chmod(dest, 0o755) // #nosec
+			err = os.Chmod(dest, 0o750) // #nosec
 			if err != nil {
 				panic(err)
 			}


### PR DESCRIPTION
Fixes: https://github.com/cloudnative-pg/cloudnative-pg/issues/625

I was able to confirm this fix is indeed working by forcing `0750` permissions on my PVC right after the bootstrap process started

Signed-off-by: Devin Buhl <onedr0p@users.noreply.github.com>