### PR TITLE
chore: Add Armando Ruocco (@armru) as a new maintainer

### DIFF
--- a/.wordlist-en-custom.txt
+++ b/.wordlist-en-custom.txt
@@ -8,6 +8,7 @@ AffinityConfiguration
 AntiAffinity
 AppArmor
 AppArmorProfile
+Armando
 AuthQuery
 AuthQuerySecret
 Autoscaler

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,4 +2,4 @@
 # responsible for code in a repository. For details, please refer to
 # https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/about-code-owners
 
-* @fcanovai @gbartolini @leonardoce @mnencia @phisco @sxd
+* @fcanovai @gbartolini @leonardoce @mnencia @phisco @sxd @armru

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ The current maintainers of the CloudNativePG project are:
 - Leonardo Cecchi (EDB)
 - Jonathan Gonzalez (EDB)
 - Marco Nenciarini (EDB)
+- Armando Ruocco (EDB)
 - Philippe Scorsolini (controlplane.io)
 
 They are listed in the [CODEOWNERS](CODEOWNERS) file.


### PR DESCRIPTION
The group of maintainers has unanimously approved Armando Ruocco as a
new maintainer of CloudNativePG, based on the current criteria of nomination.

Signed-off-by: Gabriele Bartolini <gabriele.bartolini@enterprisedb.com>