### PR TITLE
chore: take PostgreSQL image from the pkg/versions/versions.go

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ DIST_PATH := $(shell pwd)/dist
 OPERATOR_MANIFEST_PATH := ${DIST_PATH}/operator-manifest.yaml
 
 BUILD_IMAGE ?= true
-POSTGRES_IMAGE_NAME ?= ghcr.io/cloudnative-pg/postgresql:14
+POSTGRES_IMAGE_NAME ?= $(shell grep 'DefaultImageName.*=' "pkg/versions/versions.go" | cut -f 2 -d \")
 KUSTOMIZE_VERSION ?= v4.5.2
 KIND_CLUSTER_NAME ?= pg
 KIND_CLUSTER_VERSION ?= v1.25.0


### PR DESCRIPTION
Makefile was using a fixed container image to set as the default during the
deployment which was not doing any match with the default of the operator,
fixing this will align both the deployment default and the operator default
in the code.

Closes #916

Signed-off-by: Jonathan Gonzalez V <jonathan.gonzalez@enterprisedb.com>