### PR TITLE
fix: filter out replicas and jobs from nodeToClusters map

### DIFF
--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -1098,8 +1098,10 @@ func (r *ClusterReconciler) mapNodeToClusters(ctx context.Context) handler.MapFu
 		// get all the pods handled by the operator on that node
 		err := r.List(ctx, &childPods,
 			client.MatchingFields{".spec.nodeName": node.Name},
-			client.MatchingLabels{specs.ClusterRoleLabelName: specs.ClusterRoleLabelPrimary},
-			client.HasLabels{utils.ClusterLabelName},
+			client.MatchingLabels{
+				specs.ClusterRoleLabelName: specs.ClusterRoleLabelPrimary,
+				utils.PodRoleLabelName:     string(utils.PodRoleInstance),
+			},
 		)
 		if err != nil {
 			log.FromContext(ctx).Error(err, "while getting primary instances for node")


### PR DESCRIPTION
fixes the filtering applied to map nodes to CNPG clusters when a node
is cordoned, to create reconciliations only from primary instance pods

Closes #1193 

Signed-off-by: Jaime Silvela <jaime.silvela@enterprisedb.com>