### PR TITLE
Remove docs reference to future functionality

### DIFF
--- a/docs/src/bootstrap.md
+++ b/docs/src/bootstrap.md
@@ -942,12 +942,3 @@ before migrating to the target database in Kubernetes.
     and the applications. In particular, it is fundamental that you run the migration
     procedure as many times as needed to systematically measure the downtime of your
     applications in production. Feel free to contact EDB for assistance.
-
-Future versions of CloudNativePG will enable users to control
-PostgreSQL's continuous recovery mechanism via Write-Ahead Log (WAL) shipping
-by creating a new cluster that is a replica of another PostgreSQL instance.
-This will open up two main use cases:
-
-- replication over different Kubernetes clusters in CloudNativePG
-- *0 cutover time* migrations to CloudNativePG with the `pg_basebackup`
-  bootstrap method


### PR DESCRIPTION
I believe the documentation references "future" functionality that is fully implemented.

I have tested continuous recovery (replica clusters) from both pg_basebackup (streaming WALs) and barmanObjectStore. They both work as described in the documentation. As such, this paragraph should either be changed to refer to existing functionality and point to the replica clusters section, or removed entirely.