### PR TITLE
fix: use correct size to update WAL PVC

### DIFF
--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -82,6 +82,10 @@ const (
 	// get the name of the pull secret
 	ClusterSecretSuffix = "-pull-secret"
 
+	// WalArchiveVolumeSuffix is the suffix appended to the instance name to
+	// get the name of the PVC dedicated to WAL files.
+	WalArchiveVolumeSuffix = "-wal"
+
 	// StreamingReplicationUser is the name of the user we'll use for
 	// streaming replication purposes
 	StreamingReplicationUser = "streaming_replica"
@@ -1977,7 +1981,7 @@ func (cluster *Cluster) ShouldCreateWalArchiveVolume() bool {
 
 // GetWalArchiveVolumeSuffix gets the wal archive volume name suffix
 func (cluster *Cluster) GetWalArchiveVolumeSuffix() string {
-	return "-wal"
+	return WalArchiveVolumeSuffix
 }
 
 // GetPostgresUID returns the UID that is being used for the "postgres"


### PR DESCRIPTION
Closes #1190 

Previously we were using the size of the main PVC to update the one dedicated to WAL storage. This led to "-wal" PVCs being created with the correct size at first, but then, in case the main PVC had a different size, to be resized to the main PVC's size.

Signed-off-by: Philippe Scorsolini <p.scorsolini@gmail.com>