### PR TITLE
doc: note about postgresql.conf in `recovery`

### DIFF
--- a/docs/src/backup_recovery.md
+++ b/docs/src/backup_recovery.md
@@ -703,6 +703,12 @@ requested).
 For details and instructions on the `recovery` bootstrap method, please refer
 to the ["Bootstrap from a backup" section](bootstrap.md#bootstrap-from-a-backup-recovery).
 
+!!! Important
+    If you are not familiar with how [PostgreSQL PITR](https://www.postgresql.org/docs/current/continuous-archiving.html#BACKUP-PITR-RECOVERY)
+    works, we suggest that you configure the recovery cluster as the original
+    one when it comes to `.spec.postgresql.parameters`. Once the new cluster is
+    restored, you can then change the settings as desired.
+
 Under the hood, the operator will inject an init container in the first
 instance of the new cluster, and the init container will start recovering the
 backup from the object storage.

--- a/docs/src/bootstrap.md
+++ b/docs/src/bootstrap.md
@@ -344,7 +344,9 @@ There are two ways to achieve this result in CloudNativePG:
 Both recovery methods enable either full recovery (up to the last
 available WAL) or up to a [point in time](#point-in-time-recovery).
 When performing a full recovery, the cluster can also be started
-in replica mode.
+in replica mode. Also, make sure that the PostgreSQL configuration
+(`.spec.postgresql.parameters`) of the recovered cluster is
+compatible, from a physical replication standpoint, with the original one.
 
 !!! Note
     You can find more information about backup and recovery of a running cluster


### PR DESCRIPTION
Mention that `postgresql.parameters` must be compatible from a physical
replication point of view with the backed up cluster.

Closes #1189

Signed-off-by: Gabriele Bartolini <gabriele.bartolini@enterprisedb.com>