### PR TITLE
fix: don't look for PodMonitor when not needed

### DIFF
--- a/controllers/cluster_create.go
+++ b/controllers/cluster_create.go
@@ -771,12 +771,10 @@ func (r *ClusterReconciler) createOrPatchPodMonitor(ctx context.Context, cluster
 		return err
 	}
 
-	// If the PodMonitor CRD does not exist, and the cluster has monitoring enabled,
+	// If the PodMonitor CRD does not exist, but the cluster has monitoring enabled,
 	// the controller cannot do anything until the CRD is installed
-	if !havePodMonitorCRD {
-		if cluster.IsPodMonitorEnabled() {
-			contextLogger.Warning("PodMonitor CRD not present. Cannot create the PodMonitor object")
-		}
+	if !havePodMonitorCRD && cluster.IsPodMonitorEnabled() {
+		contextLogger.Warning("PodMonitor CRD not present. Cannot create the PodMonitor object")
 		return nil
 	}
 

--- a/controllers/cluster_create.go
+++ b/controllers/cluster_create.go
@@ -765,18 +765,17 @@ func (r *ClusterReconciler) createOrPatchDefaultMetrics(ctx context.Context, clu
 func (r *ClusterReconciler) createOrPatchPodMonitor(ctx context.Context, cluster *apiv1.Cluster) error {
 	contextLogger := log.FromContext(ctx)
 
-	// Checking for the PodMonitor resource in the cluster
-	havePodMonitor, err := utils.PodMonitorExist(r.DiscoveryClient)
+	// Checking for the PodMonitor Custom Resource Definition in the Kubernetes cluster
+	havePodMonitorCRD, err := utils.PodMonitorExist(r.DiscoveryClient)
 	if err != nil {
 		return err
 	}
 
-	// If the PodMonitor does not exist then check in cluster if it is present, log the  warning.
-	// If it is not enabled in the cluster then no need to continue.
-	if !havePodMonitor {
+	// If the PodMonitor CRD does not exist, and the cluster has monitoring enabled,
+	// the controller cannot do anything until the CRD is installed
+	if !havePodMonitorCRD {
 		if cluster.IsPodMonitorEnabled() {
-			contextLogger.Warning("Kind PodMonitor not detected, " +
-				"Please create after enabling PodMonitor in cluster")
+			contextLogger.Warning("PodMonitor CRD not present. Cannot create the PodMonitor object")
 		}
 		return nil
 	}

--- a/controllers/cluster_create.go
+++ b/controllers/cluster_create.go
@@ -763,6 +763,10 @@ func (r *ClusterReconciler) createOrPatchDefaultMetrics(ctx context.Context, clu
 
 // createOrPatchPodMonitor
 func (r *ClusterReconciler) createOrPatchPodMonitor(ctx context.Context, cluster *apiv1.Cluster) error {
+	// If the PodMonitor it's not enabled in the cluster, no need to continue
+	if !cluster.IsPodMonitorEnabled() {
+		return nil
+	}
 	contextLogger := log.FromContext(ctx)
 
 	// Checking for the PodMonitor resource in the cluster

--- a/docs/src/quickstart.md
+++ b/docs/src/quickstart.md
@@ -274,7 +274,7 @@ kubectl port-forward svc/prometheus-community-kube-prometheus 9090
 
 Then access the Prometheus console locally at: [`http://localhost:9090/`](http://localhost:9090/)
 
-Assuming that the monitoring stack was successfully deployed, and you have a Cluster with `enablePodMonitoring: true` 
+Assuming that the monitoring stack was successfully deployed, and you have a Cluster with `enablePodMonitor: true`
 you should find a series of metrics relating to CloudNativePG clusters. Again, please
 refer to the [*monitoring section*](monitoring.md) for more information.
 

--- a/docs/src/samples/cluster-example-monitoring.yaml
+++ b/docs/src/samples/cluster-example-monitoring.yaml
@@ -9,6 +9,7 @@ spec:
     size: 1Gi
 
   monitoring:
+    enablePodMonitor: true
     customQueriesConfigMap:
       - name: example-monitoring
         key: custom-queries


### PR DESCRIPTION
Since we know that the cluster doesn't have the option `enablePodMonitor` set to `true` there's no need to continue and ask every time to the Kubernetes API for this type of resource.

Closes #1212 

Signed-off-by: Jonathan Gonzalez V <jonathan.gonzalez@enterprisedb.com>