### PR TITLE
fix: respect configured pg-wal when restoring

### DIFF
--- a/internal/cmd/manager/instance/restore/cmd.go
+++ b/internal/cmd/manager/instance/restore/cmd.go
@@ -53,6 +53,7 @@ func NewCmd() *cobra.Command {
 				ClusterName: clusterName,
 				Namespace:   namespace,
 				PgData:      pgData,
+				PgWal:       pgWal,
 			}
 
 			return restoreSubCommand(ctx, info)


### PR DESCRIPTION
Closes #1210.

We forgot to properly propagate the pg-wal flag's value, if any, down in the recover subcommand. This meant that primary instances created from backups were not actually using the volume dedicated to wal files, even if specified.

Signed-off-by: Philippe Scorsolini <p.scorsolini@gmail.com>