### PR TITLE
fix: adding the SCC checks to 1.17

### DIFF
--- a/tests/utils/environment.go
+++ b/tests/utils/environment.go
@@ -103,6 +103,11 @@ func NewTestingEnvironment() (*TestingEnvironment, error) {
 		return nil, fmt.Errorf("could not detect SeccompProfile support: %w", err)
 	}
 
+	err = utils.DetectSecurityContextConstraints(clientDiscovery)
+	if err != nil {
+		return nil, fmt.Errorf("could not detect SeccompProfile support: %w", err)
+	}
+
 	return &env, nil
 }
 

--- a/tests/utils/psql_client.go
+++ b/tests/utils/psql_client.go
@@ -69,7 +69,7 @@ func createPsqlClient(namespace string, env *TestingEnvironment) (*corev1.Pod, e
 	seccompProfile := &corev1.SeccompProfile{
 		Type: corev1.SeccompProfileTypeRuntimeDefault,
 	}
-	if !utils.HaveSeccompSupport() {
+	if !utils.HaveSeccompSupport() || utils.HaveSecurityContextConstraints() {
 		seccompProfile = nil
 	}
 


### PR DESCRIPTION
Previously we were not detecting the SCC so if for some reason the 
Kubernetes cluster is using SecurityContextConstraints the `psql` pod
was going to fail since it will set a SecurityContext that shouldn't be there.

Signed-off-by: John Long <john.long@enterprisedb.com>