### PR TITLE
fix: avoid PodMonitor reconcile on no Prometheus

### DIFF
--- a/controllers/cluster_create.go
+++ b/controllers/cluster_create.go
@@ -771,10 +771,12 @@ func (r *ClusterReconciler) createOrPatchPodMonitor(ctx context.Context, cluster
 		return err
 	}
 
-	// If the PodMonitor CRD does not exist, but the cluster has monitoring enabled,
-	// the controller cannot do anything until the CRD is installed
-	if !havePodMonitorCRD && cluster.IsPodMonitorEnabled() {
-		contextLogger.Warning("PodMonitor CRD not present. Cannot create the PodMonitor object")
+	if !havePodMonitorCRD {
+		if cluster.IsPodMonitorEnabled() {
+			// If the PodMonitor CRD does not exist, but the cluster has monitoring enabled,
+			// the controller cannot do anything until the CRD is installed
+			contextLogger.Warning("PodMonitor CRD not present. Cannot create the PodMonitor object")
+		}
 		return nil
 	}
 


### PR DESCRIPTION
On PR https://github.com/cloudnative-pg/cloudnative-pg/pull/1213/
I over-fixed the logic, and can allow to proceed with the reconciliation
of PodMonitor, even if we know the Prometheus CRD are not installed

Signed-off-by: Jaime Silvela <jaime.silvela@enterprisedb.com>