### PR TITLE
chore: stop mergning into branch release-1.16

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -26,7 +26,6 @@ jobs:
           number:  ${{ github.event.pull_request.number }}
           labels: |
             backport-requested :arrow_backward:
-            release-1.16
             release-1.17
             release-1.18
       -
@@ -58,7 +57,6 @@ jobs:
       fail-fast: false
       matrix:
         branch:
-          -  release-1.16
           -  release-1.17
           -  release-1.18
     env:


### PR DESCRIPTION
We do not mantain the version 1.16 and to keep this branch clean this stop merging stuff into that.

Closes #1239

Signed-off-by: Jonathan Gonzalez V <jonathan.gonzalez@enterprisedb.com>