### PR TITLE
ci: skip smoke test on EOLed version 1.16

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -55,7 +55,6 @@ jobs:
       fail-fast: false
       matrix:
         branch:
-          - release-1.16
           - release-1.17
           - release-1.18
     steps:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -36,7 +36,6 @@ jobs:
       fail-fast: false
       matrix:
         branch:
-          - release-1.16
           - release-1.17
           - release-1.18
     steps:


### PR DESCRIPTION
Skip the smoke test on branch release-1.16 for 
v1.16 has been EOLed since December 21, 2022

Signed-off-by: Hai He <hai.he@enterprisedb.com>