### PR TITLE
ci: fix the label/unlabel ok-to-merge precondition

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -749,7 +749,6 @@ jobs:
       - evaluate_options
     if: |
       success() && !cancelled() &&
-      github.event_name == 'issue_comment' &&
       needs.evaluate_options.outputs.test_level == '4'
     runs-on: ubuntu-20.04
     steps:
@@ -777,8 +776,7 @@ jobs:
       - e2e-local
       - evaluate_options
     if: |
-      needs.e2e-local.result == 'failure' &&
-      github.event_name == 'issue_comment'
+      needs.e2e-local.result == 'failure'
     runs-on: ubuntu-20.04
     steps:
       - name: Check preconditions


### PR DESCRIPTION
We could label/unlabel the `ok-to-merge` not only
in the case of `issue_comment`

Signed-off-by: Hai He <hai.he@enterprisedb.com>