### PR TITLE
chore: check if there's any dirty change for go mod tidy

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -116,7 +116,7 @@ jobs:
               - '**/*.go'
               - '.golangci.yml'
 
-  golangci:
+  go-linters:
     name: Run linters
     needs:
       - duplicate_runs
@@ -134,6 +134,11 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GOLANG_VERSION }}
+
+      # Check if there's any dirty change for go mod tidy
+      - name: Check go mod
+        run: |
+          make go-mod-check
 
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v3
@@ -321,7 +326,7 @@ jobs:
   buildx:
     name: Build containers
     needs:
-      - golangci
+      - go-linters
       - shellcheck
       - tests
       - apidoc
@@ -343,7 +348,7 @@ jobs:
           needs.change-triage.outputs.go-code-changed == 'true'
         )
       ) &&
-      (needs.golangci.result == 'success' || needs.golangci.result == 'skipped') &&
+      (needs.go-linters.result == 'success' || needs.go-linters.result == 'skipped') &&
       (needs.shellcheck.result == 'success' || needs.shellcheck.result == 'skipped') &&
       (needs.tests.result == 'success' || needs.tests.result == 'skipped') &&
       (needs.apidoc.result == 'success' || needs.apidoc.result == 'skipped') &&

--- a/Makefile
+++ b/Makefile
@@ -178,7 +178,11 @@ wordlist-ordered: ## Order the wordlist using sort
 	LANG=C LC_ALL=C sort .wordlist-en-custom.txt > .wordlist-en-custom.txt.new && \
 	mv -f .wordlist-en-custom.txt.new .wordlist-en-custom.txt
 
-checks: generate manifests apidoc fmt spellcheck wordlist-ordered woke vet lint ## Runs all the checks on the project.
+go-mod-check: ## Check if there's any dirty change after `go mod tidy`
+	go mod tidy ;\
+	git diff --exit-code go.mod go.sum
+
+checks: go-mod-check generate manifests apidoc fmt spellcheck wordlist-ordered woke vet lint ## Runs all the checks on the project.
 
 ##@ Documentation
 


### PR DESCRIPTION
- Add a check in the continuous-integration workflow to 
  see if there's any dirty change for `go mod tidy`
- Also include the check in `make checks`

Closes #1273 

Signed-off-by: Hai He <hai.he@enterprisedb.com>