### PR TITLE
chore: add two new fields to the plugin install generation process

### DIFF
--- a/internal/cmd/plugin/install/generate.go
+++ b/internal/cmd/plugin/install/generate.go
@@ -102,7 +102,7 @@ func newGenerateCmd() *cobra.Command {
 	cmd.Flags().Int32Var(
 		&replicas,
 		"replicas",
-		1,
+		0,
 		"Number of replicas in the deployment. Default is zero, meaning that no override is applied on the "+
 			"installation manifest (normally it is a single replica deployment)",
 	)
@@ -272,13 +272,16 @@ func (cmd *generateExecutor) getResourceFromDocument(document []byte) (installat
 }
 
 func (cmd *generateExecutor) reconcileOperatorDeployment(dep *appsv1.Deployment) error {
-	dep.Spec.Replicas = &cmd.replicas
-
 	args := dep.Spec.Template.Spec.Containers[0].Args
 	args = append(args, fmt.Sprintf("--log-field-level=%s", cmd.logFieldLevel))
 	args = append(args, fmt.Sprintf("--log-field-timestamp=%s", cmd.logFieldTimestamp))
 
 	dep.Spec.Template.Spec.Containers[0].Args = args
+
+	if cmd.replicas == 0 {
+		return nil
+	}
+	dep.Spec.Replicas = &cmd.replicas
 
 	return nil
 }

--- a/internal/cmd/plugin/install/generate.go
+++ b/internal/cmd/plugin/install/generate.go
@@ -53,10 +53,12 @@ type generateExecutor struct {
 	replicas             int32
 	userRequestedVersion string
 	postgresImage        string
+	logFieldLevel        string
+	logFieldTimestamp    string
 }
 
 func newGenerateCmd() *cobra.Command {
-	var version, watchNamespaces, postgresImage string
+	var version, watchNamespaces, postgresImage, logFieldLevel, logFieldTimestamp string
 	var replicas int32
 	cmd := &cobra.Command{
 		Use:   "generate",
@@ -75,6 +77,8 @@ func newGenerateCmd() *cobra.Command {
 				replicas:             replicas,
 				userRequestedVersion: version,
 				postgresImage:        postgresImage,
+				logFieldLevel:        logFieldLevel,
+				logFieldTimestamp:    logFieldTimestamp,
 			}
 			return command.execute()
 		},
@@ -98,7 +102,7 @@ func newGenerateCmd() *cobra.Command {
 	cmd.Flags().Int32Var(
 		&replicas,
 		"replicas",
-		0,
+		1,
 		"Number of replicas in the deployment. Default is zero, meaning that no override is applied on the "+
 			"installation manifest (normally it is a single replica deployment)",
 	)
@@ -108,6 +112,20 @@ func newGenerateCmd() *cobra.Command {
 		"image",
 		"",
 		"Optional flag to specify a PostgreSQL image to use. If not specified, the default image is used",
+	)
+
+	cmd.Flags().StringVar(
+		&logFieldLevel,
+		"log-field-level",
+		"level",
+		"JSON log field to report severity in (default: level)",
+	)
+
+	cmd.Flags().StringVar(
+		&logFieldTimestamp,
+		"log-field-timestamp",
+		"ts",
+		"JSON log field to report timestamp in (default: ts)",
 	)
 
 	return cmd
@@ -254,10 +272,14 @@ func (cmd *generateExecutor) getResourceFromDocument(document []byte) (installat
 }
 
 func (cmd *generateExecutor) reconcileOperatorDeployment(dep *appsv1.Deployment) error {
-	if cmd.replicas == 0 {
-		return nil
-	}
 	dep.Spec.Replicas = &cmd.replicas
+
+	args := dep.Spec.Template.Spec.Containers[0].Args
+	args = append(args, fmt.Sprintf("--log-field-level=%s", cmd.logFieldLevel))
+	args = append(args, fmt.Sprintf("--log-field-timestamp=%s", cmd.logFieldTimestamp))
+
+	dep.Spec.Template.Spec.Containers[0].Args = args
+
 	return nil
 }
 


### PR DESCRIPTION
We added to new fields to the command line:
* --log-field-level
* --log-field-timestamp

Both used to change the respective values in the operator deployment.

Closes #1309

Signed-off-by: Jonathan Gonzalez V <jonathan.gonzalez@enterprisedb.com>