### PR TITLE
fix: fix unlabel-ok-to-merge in workflow not work

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -745,10 +745,12 @@ jobs:
   ok-to-merge:
     name: Label the PR as "ok to merge :ok_hand:"
     needs:
-      - e2e-local
       - evaluate_options
+      - e2e-local
     if: |
-      success() && !cancelled() &&
+      always() && 
+      needs.e2e-local.result == 'success' && 
+      github.event_name == 'issue_comment' && 
       needs.evaluate_options.outputs.test_level == '4'
     runs-on: ubuntu-20.04
     steps:
@@ -773,10 +775,12 @@ jobs:
   unlabel-ok-to-merge:
     name: Remove the "ok to merge :ok_hand:" label from the PR
     needs:
-      - e2e-local
       - evaluate_options
+      - e2e-local
     if: |
-      needs.e2e-local.result == 'failure'
+      always() && 
+      needs.e2e-local.result == 'failure' && 
+      github.event_name == 'issue_comment'
     runs-on: ubuntu-20.04
     steps:
       - name: Check preconditions


### PR DESCRIPTION
Fix unlabel-ok-to-merge step not working in ci/cd workflow

Close #1322  
Signed-off-by: Tao Li <tao.li@enterprisedb.com>