### PR TITLE
feat: add `backup` command to the `cnpg` plugin

### DIFF
--- a/cmd/kubectl-cnpg/main.go
+++ b/cmd/kubectl-cnpg/main.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
 	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/plugin"
+	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/plugin/backup"
 	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/plugin/certificate"
 	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/plugin/destroy"
 	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/plugin/fence"
@@ -76,6 +77,7 @@ func main() {
 	rootCmd.AddCommand(restart.NewCmd())
 	rootCmd.AddCommand(status.NewCmd())
 	rootCmd.AddCommand(versions.NewCmd())
+	rootCmd.AddCommand(backup.NewCmd())
 
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)

--- a/docs/src/cnpg-plugin.md
+++ b/docs/src/cnpg-plugin.md
@@ -685,12 +685,12 @@ kubectl cnpg fio <fio-job-name> -n <namespace>
 
 Refer to the [Benchmarking fio section](benchmarking.md#fio) for more details.
 
-### Requesting a new backup
+### Requesting a new base backup
 
-The `kubectl cnpg backup` request a new backup for an existing CloudNativePG
-cluster by creating a Backup resource.
+The `kubectl cnpg backup` command requests a new physical base backup for
+an existing Postgres cluster by creating a new `Backup` resource.
 
-The following command will request a backup for a given cluster:
+The following example requests an on-demand backup for a given cluster:
 
 ```shell
 kubectl cnpg backup [cluster_name]
@@ -699,6 +699,6 @@ kubectl cnpg backup [cluster_name]
 The created backup will be named after the request time:
 
 ```shell
-kubectl-cnpg backup cluster-example
+kubectl cnpg backup cluster-example
 backup/cluster-example-20230121002300 created
 ```

--- a/docs/src/cnpg-plugin.md
+++ b/docs/src/cnpg-plugin.md
@@ -685,3 +685,20 @@ kubectl cnpg fio <fio-job-name> -n <namespace>
 
 Refer to the [Benchmarking fio section](benchmarking.md#fio) for more details.
 
+### Requesting a new backup
+
+The `kubectl cnpg backup` request a new backup for an existing CloudNativePG
+cluster by creating a Backup resource.
+
+The following command will request a backup for a given cluster:
+
+```shell
+kubectl cnpg backup [cluster_name]
+```
+
+The created backup will be named after the request time:
+
+```shell
+kubectl-cnpg backup cluster-example
+backup/cluster-example-20230121002300 created
+```

--- a/internal/cmd/plugin/backup/cmd.go
+++ b/internal/cmd/plugin/backup/cmd.go
@@ -1,0 +1,85 @@
+/*
+Copyright The CloudNativePG Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package backup implements a command to request an on-demand backup
+// for a PostgreSQL cluster
+package backup
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/plugin"
+)
+
+// NewCmd creates the new "backup" subcommand
+func NewCmd() *cobra.Command {
+	var backupName string
+
+	backupSubcommand := &cobra.Command{
+		Use:   "backup [cluster]",
+		Short: "Request an on-demand backup for a PostgreSQL Cluster",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clusterName := args[0]
+
+			if len(backupName) == 0 {
+				backupName = fmt.Sprintf(
+					"%s-%s",
+					clusterName,
+					time.Now().Format("20060102150400"))
+			}
+
+			return createBackup(cmd.Context(), backupName, clusterName)
+		},
+	}
+
+	backupSubcommand.Flags().StringVar(
+		&backupName,
+		"backup-name",
+		"",
+		"The name of the Backup resource that will be created, "+
+			"defaults to \"[cluster]-[current_timestamp]\"",
+	)
+
+	return backupSubcommand
+}
+
+// createBackup handles the Backup resource creation
+func createBackup(ctx context.Context, backupName, clusterName string) error {
+	backup := apiv1.Backup{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: plugin.Namespace,
+			Name:      backupName,
+		},
+		Spec: apiv1.BackupSpec{
+			Cluster: apiv1.LocalObjectReference{
+				Name: clusterName,
+			},
+		},
+	}
+
+	err := plugin.Client.Create(ctx, &backup)
+	if err == nil {
+		fmt.Printf("backup/%v created\n", backup.Name)
+	}
+	return err
+}


### PR DESCRIPTION
The `kubectl cnpg backup` command allows to user to request an on-demand backup for a PostgreSQL Cluster.

Closes: #950

Signed-off-by: Leonardo Cecchi <leonardo.cecchi@gmail.com>