### PR TITLE
feat: enhance cnpg_collector_pg_wal metrics for default exporter

### DIFF
--- a/docs/src/monitoring.md
+++ b/docs/src/monitoring.md
@@ -131,6 +131,7 @@ cnpg_collector_manual_switchover_required 0
 # HELP cnpg_collector_pg_wal Total size in bytes of WAL segments in the '/var/lib/postgresql/data/pgdata/pg_wal' directory  computed as (wal_segment_size * count)
 # TYPE cnpg_collector_pg_wal gauge
 cnpg_collector_pg_wal{value="count"} 9
+cnpg_collector_pg_wal{value="slots_max"} NaN
 cnpg_collector_pg_wal{value="keep"} 32
 cnpg_collector_pg_wal{value="max"} 64
 cnpg_collector_pg_wal{value="min"} 5

--- a/docs/src/monitoring.md
+++ b/docs/src/monitoring.md
@@ -130,8 +130,13 @@ cnpg_collector_manual_switchover_required 0
 
 # HELP cnpg_collector_pg_wal Total size in bytes of WAL segments in the '/var/lib/postgresql/data/pgdata/pg_wal' directory  computed as (wal_segment_size * count)
 # TYPE cnpg_collector_pg_wal gauge
-cnpg_collector_pg_wal{value="count"} 7
-cnpg_collector_pg_wal{value="size"} 1.17440512e+08
+cnpg_collector_pg_wal{value="count"} 9
+cnpg_collector_pg_wal{value="keep"} 32
+cnpg_collector_pg_wal{value="max"} 64
+cnpg_collector_pg_wal{value="min"} 5
+cnpg_collector_pg_wal{value="size"} 1.50994944e+08
+cnpg_collector_pg_wal{value="volume_max"} 128
+cnpg_collector_pg_wal{value="volume_size"} 2.147483648e+09
 
 # HELP cnpg_collector_pg_wal_archive_status Number of WAL segments in the '/var/lib/postgresql/data/pgdata/pg_wal/archive_status' directory (ready, done)
 # TYPE cnpg_collector_pg_wal_archive_status gauge

--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,7 @@ require (
 )
 
 require (
+	github.com/DATA-DOG/go-sqlmock v1.5.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/emicklei/go-restful/v3 v3.9.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,6 @@ require (
 )
 
 require (
-	github.com/DATA-DOG/go-sqlmock v1.5.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/emicklei/go-restful/v3 v3.9.0 // indirect

--- a/pkg/management/postgres/metrics/collector.go
+++ b/pkg/management/postgres/metrics/collector.go
@@ -339,10 +339,6 @@ func (c QueryCollector) collect(conn *sql.DB, ch chan<- prometheus.Metric) error
 			log.Warning("Error while closing metrics extraction",
 				"err", err.Error())
 		}
-		if err := rows.Err(); err != nil {
-			log.Warning("Error while loading metrics",
-				"err", err.Error())
-		}
 	}()
 
 	columns, err := rows.Columns()
@@ -373,6 +369,11 @@ func (c QueryCollector) collect(conn *sql.DB, ch chan<- prometheus.Metric) error
 		if done {
 			c.collectColumns(columns, columnData, labels, ch)
 		}
+	}
+	if err := rows.Err(); err != nil {
+		log.Warning("Error while loading metrics",
+			"err", err.Error())
+		return err
 	}
 	return nil
 }

--- a/pkg/management/postgres/webserver/metricserver/pg_collector.go
+++ b/pkg/management/postgres/webserver/metricserver/pg_collector.go
@@ -363,9 +363,9 @@ func (e *Exporter) collectPgMetrics(ch chan<- prometheus.Metric) {
 	}
 
 	if err := collectPGWalSettings(e, db); err != nil {
-		log.Error(err, "while collecting WAL metrics", "path", specs.PgWalPath)
+		log.Error(err, "while collecting WAL settings", "path", specs.PgWalPath)
 		e.Metrics.Error.Set(1)
-		e.Metrics.PgCollectionErrors.WithLabelValues("Collect.PgWALStats").Inc()
+		e.Metrics.PgCollectionErrors.WithLabelValues("Collect.PGWalSettings").Inc()
 		e.Metrics.PgWALDirectory.Reset()
 	}
 

--- a/pkg/management/postgres/webserver/metricserver/pg_collector.go
+++ b/pkg/management/postgres/webserver/metricserver/pg_collector.go
@@ -20,6 +20,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"math"
 	"os"
 	"regexp"
 	"strconv"
@@ -41,8 +42,10 @@ const PrometheusNamespace = "cnpg"
 
 var synchronousStandbyNamesRegex = regexp.MustCompile(`ANY ([0-9]+) \(.*\)`)
 
-// The wal_segment_size value in bytes
-var walSegmentSize *int
+// The wal_segment_size value in bytes and min_wal_size, max_wal_size value in megabytes
+var walSegmentSize, minWalSize, maxWalSize *int
+
+var walKeepSize, walVolumeSize *float64
 
 // Exporter exports a set of metrics and collectors on a given postgres instance
 type Exporter struct {
@@ -520,10 +523,39 @@ func collectPGWalMetric(exporter *Exporter, db *sql.DB) error {
 		return err
 	}
 	exporter.Metrics.PgWALDirectory.WithLabelValues("size").Set(float64(count * WALSegmentSize))
+
+	MINWalSize, err := getMinWalSize(db)
+	if err != nil {
+		return err
+	}
+	exporter.Metrics.PgWALDirectory.WithLabelValues("min").Set(float64(MINWalSize*1024*1024) / float64(WALSegmentSize))
+
+	MAXWalSize, err := getMaxWalSize(db)
+	if err != nil {
+		return err
+	}
+	exporter.Metrics.PgWALDirectory.WithLabelValues("max").Set(float64(MAXWalSize*1024*1024) / float64(WALSegmentSize))
+
+	version, _ := exporter.instance.GetPgVersion()
+	WALKeepSize, err := getWalKeepSize(db, version.Major, WALSegmentSize)
+	if err != nil {
+		return err
+	}
+	exporter.Metrics.PgWALDirectory.WithLabelValues("keep").Set(WALKeepSize)
+
+	WALVolumeSize := getWalVolumeSize()
+	if WALVolumeSize == 0 {
+		exporter.Metrics.PgWALDirectory.WithLabelValues("volume_size").Set(math.NaN())
+		exporter.Metrics.PgWALDirectory.WithLabelValues("volume_max").Set(math.NaN())
+	} else {
+		exporter.Metrics.PgWALDirectory.WithLabelValues("volume_size").Set(WALVolumeSize)
+		exporter.Metrics.PgWALDirectory.WithLabelValues("volume_max").Set(WALVolumeSize / float64(WALSegmentSize))
+	}
 	return nil
 }
 
 // We cache the value of wal_segment_size the first time we retrieve it from the database
+// The unit for the value is byte
 func getWALSegmentSize(db *sql.DB) (int, error) {
 	if walSegmentSize != nil {
 		return *walSegmentSize, nil
@@ -537,6 +569,91 @@ func getWALSegmentSize(db *sql.DB) (int, error) {
 	}
 	walSegmentSize = &size
 	return *walSegmentSize, nil
+}
+
+// We cache the value of min_wal_size the first time we retrieve it from the database
+// The unit for the value is MB
+func getMinWalSize(db *sql.DB) (int, error) {
+	if minWalSize != nil {
+		return *minWalSize, nil
+	}
+	var size int
+	err := db.QueryRow("SELECT setting FROM pg_settings WHERE name='min_wal_size'").
+		Scan(&size)
+	if err != nil {
+		log.Error(err, "while getting the min_wal_size value from the database")
+		return 0, err
+	}
+	minWalSize = &size
+	return *minWalSize, nil
+}
+
+// We cache the value of max_wal_size the first time we retrieve it from the database
+// The unit for the value is MB
+func getMaxWalSize(db *sql.DB) (int, error) {
+	if maxWalSize != nil {
+		return *maxWalSize, nil
+	}
+	var size int
+	err := db.QueryRow("SELECT setting FROM pg_settings WHERE name='max_wal_size'").
+		Scan(&size)
+	if err != nil {
+		log.Error(err, "while getting the max_wal_size value from the database")
+		return 0, err
+	}
+	maxWalSize = &size
+	return *maxWalSize, nil
+}
+
+// retrieve and cache value for wal_keep_size / wal_segment_size (pg version >=13)
+// or wal_keep_segments (pg version 11&12)
+func getWalKeepSize(db *sql.DB, pgMajor uint64, walSegmentSize int) (float64, error) {
+	if walKeepSize != nil {
+		return *walKeepSize, nil
+	}
+	var size int
+	var result float64
+	if pgMajor >= 13 {
+		err := db.QueryRow("SELECT setting FROM pg_settings WHERE name='wal_keep_size'").
+			Scan(&size)
+		if err != nil {
+			log.Error(err, "while getting the wal_keep_size value from the database")
+			return 0, err
+		}
+		// wal_keep_size is in megabyte unit
+		result = float64(size*1024*1024) / float64(walSegmentSize)
+	} else {
+		err := db.QueryRow("SELECT setting FROM pg_settings WHERE name='wal_keep_segments'").
+			Scan(&size)
+		if err != nil {
+			log.Error(err, "while getting the wal_keep_segments value from the database")
+			return 0, err
+		}
+		result = float64(size)
+	}
+	walKeepSize = &result
+	return *walKeepSize, nil
+}
+
+func getWalVolumeSize() float64 {
+	if walVolumeSize != nil {
+		return *walVolumeSize
+	}
+	cluster, err := cache.LoadCluster()
+	// there isn't a cached object yet
+	if errors.Is(err, cache.ErrCacheMiss) {
+		return 0
+	}
+	var size float64
+	if cluster.ShouldCreateWalArchiveVolume() {
+		walSize := cluster.Spec.WalStorage.GetSizeOrNil()
+		if walSize != nil {
+			size = walSize.AsApproximateFloat64()
+			walVolumeSize = &size
+			return *walVolumeSize
+		}
+	}
+	return 0
 }
 
 func getSynchronousStandbysNumber(db *sql.DB) (int, error) {

--- a/pkg/management/postgres/webserver/metricserver/suite_test.go
+++ b/pkg/management/postgres/webserver/metricserver/suite_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright The CloudNativePG Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metricserver
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestMetricsServer(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Postgres Webserver MetricsServer test suite")
+}

--- a/pkg/management/postgres/webserver/metricserver/wal.go
+++ b/pkg/management/postgres/webserver/metricserver/wal.go
@@ -72,6 +72,10 @@ type walSettings struct {
 }
 
 func (s *walSettings) synchronize(db *sql.DB, configSha256 string) error {
+	if s.configSha256 == configSha256 {
+		return nil
+	}
+
 	rows, err := db.Query(`
 SELECT name, setting FROM pg_settings 
 WHERE pg_settings.name

--- a/pkg/management/postgres/webserver/metricserver/wal.go
+++ b/pkg/management/postgres/webserver/metricserver/wal.go
@@ -84,10 +84,6 @@ IN ('wal_segment_size', 'min_wal_size', 'max_wal_size', 'wal_keep_size', 'wal_ke
 		log.Error(err, "while fetching rows")
 		return err
 	}
-	if err := rows.Err(); err != nil {
-		log.Error(err, "while iterating over rows")
-		return err
-	}
 
 	defer func() {
 		err = rows.Close()
@@ -125,6 +121,11 @@ IN ('wal_segment_size', 'min_wal_size', 'max_wal_size', 'wal_keep_size', 'wal_ke
 		case "max_slot_wal_keep_size":
 			s.maxSlotWalKeepSize = normalizedSetting
 		}
+	}
+
+	if err := rows.Err(); err != nil {
+		log.Error(err, "while iterating over rows")
+		return err
 	}
 
 	if needsKeepSizeNormalization {

--- a/pkg/management/postgres/webserver/metricserver/wal.go
+++ b/pkg/management/postgres/webserver/metricserver/wal.go
@@ -1,0 +1,207 @@
+/*
+Copyright The CloudNativePG Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metricserver
+
+import (
+	"database/sql"
+	"errors"
+	"math"
+	"os"
+	"regexp"
+
+	"github.com/cloudnative-pg/cloudnative-pg/internal/management/cache"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/log"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/specs"
+)
+
+func collectPGWalArchiveMetric(exporter *Exporter) error {
+	ready, done, err := postgres.GetWALArchiveCounters()
+	if err != nil {
+		return err
+	}
+
+	exporter.Metrics.PgWALArchiveStatus.WithLabelValues("ready").Set(float64(ready))
+	exporter.Metrics.PgWALArchiveStatus.WithLabelValues("done").Set(float64(done))
+	return nil
+}
+
+func collectPGWALStat(e *Exporter) error {
+	walStat, err := e.instance.TryGetPgStatWAL()
+	if walStat == nil || err != nil {
+		return err
+	}
+	walMetrics := e.Metrics.PgStatWalMetrics
+	walMetrics.WalSync.WithLabelValues(walStat.StatsReset).Set(float64(walStat.WalSync))
+	walMetrics.WalSyncTime.WithLabelValues(walStat.StatsReset).Set(float64(walStat.WalSyncTime))
+	walMetrics.WALBuffersFull.WithLabelValues(walStat.StatsReset).Set(float64(walStat.WALBuffersFull))
+	walMetrics.WalFpi.WithLabelValues(walStat.StatsReset).Set(float64(walStat.WalFpi))
+	walMetrics.WalWrite.WithLabelValues(walStat.StatsReset).Set(float64(walStat.WalWrite))
+	walMetrics.WalBytes.WithLabelValues(walStat.StatsReset).Set(float64(walStat.WalBytes))
+	walMetrics.WalWriteTime.WithLabelValues(walStat.StatsReset).Set(float64(walStat.WalWriteTime))
+	walMetrics.WalRecords.WithLabelValues(walStat.StatsReset).Set(float64(walStat.WalRecords))
+
+	return nil
+}
+
+type walSettings struct {
+	// expressed in bytes
+	walSegmentSize int
+	// expressed in megabytes
+	minWalSize int
+	// expressed in megabytes
+	maxWalSize  int
+	walKeepSize int
+}
+
+var (
+	regexPGWalFileName   = regexp.MustCompile("^[0-9A-F]{24}")
+	lastKnownConfSHA     string
+	lastKnownWalSettings walSettings
+)
+
+func collectPGWalSettings(exporter *Exporter, db *sql.DB) error {
+	pgWalDir, err := os.Open(specs.PgWalPath)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = pgWalDir.Close()
+	}()
+	files, err := pgWalDir.Readdirnames(-1)
+	if err != nil {
+		return err
+	}
+	var count int
+	for _, file := range files {
+		if !regexPGWalFileName.MatchString(file) {
+			continue
+		}
+		count++
+	}
+
+	if lastKnownConfSHA != exporter.instance.ConfigSha256 {
+		lastKnownWalSettings, err = getWALSettings(db)
+		if err != nil {
+			return err
+		}
+	}
+
+	exporter.Metrics.PgWALDirectory.
+		WithLabelValues("count").
+		Set(float64(count))
+
+	exporter.Metrics.PgWALDirectory.
+		WithLabelValues("size").
+		Set(float64(count * lastKnownWalSettings.walSegmentSize))
+
+	exporter.Metrics.PgWALDirectory.
+		WithLabelValues("min").
+		Set(float64(lastKnownWalSettings.minWalSize*1024*1024) / float64(lastKnownWalSettings.walSegmentSize))
+
+	exporter.Metrics.PgWALDirectory.
+		WithLabelValues("max").
+		Set(float64(lastKnownWalSettings.maxWalSize*1024*1024) / float64(lastKnownWalSettings.walSegmentSize))
+
+	exporter.Metrics.PgWALDirectory.
+		WithLabelValues("keep").
+		Set(float64(lastKnownWalSettings.walKeepSize))
+
+	walVolumeSize := getWalVolumeSize()
+	if walVolumeSize == 0 {
+		exporter.Metrics.PgWALDirectory.
+			WithLabelValues("volume_size").
+			Set(math.NaN())
+		exporter.Metrics.PgWALDirectory.
+			WithLabelValues("volume_max").
+			Set(math.NaN())
+	} else {
+		exporter.Metrics.PgWALDirectory.
+			WithLabelValues("volume_size").
+			Set(walVolumeSize)
+		exporter.Metrics.PgWALDirectory.
+			WithLabelValues("volume_max").
+			Set(walVolumeSize / float64(lastKnownWalSettings.walSegmentSize))
+	}
+
+	lastKnownConfSHA = exporter.instance.ConfigSha256
+	return nil
+}
+
+func getWALSettings(db *sql.DB) (walSettings, error) {
+	settings := walSettings{}
+	rows, err := db.Query(`
+SELECT name, setting FROM pg_settings 
+WHERE pg_settings.name
+IN ('wal_segment_size', 'min_wal_size', 'max_wal_size', 'wal_keep_size', 'wal_keep_segments')`)
+	if err != nil {
+		return settings, err
+	}
+	if err := rows.Err(); err != nil {
+		log.Error(err, "while iterating over rows")
+		return settings, err
+	}
+
+	defer func() {
+		err = rows.Close()
+		if err != nil {
+			log.Error(err, "while closing rows for SHOW LISTS")
+		}
+	}()
+
+	for rows.Next() {
+		var name string
+		var setting *int
+		if err := rows.Scan(&name, &setting); err != nil {
+			log.Error(err, "while scanning values from the database")
+			return settings, err
+		}
+
+		var normalizedSetting int
+		if setting != nil {
+			normalizedSetting = *setting
+		}
+
+		switch name {
+		case "wal_segment_size":
+			settings.walSegmentSize = normalizedSetting
+		case "min_wal_size":
+			settings.minWalSize = normalizedSetting
+		case "max_wal_size":
+			settings.maxWalSize = normalizedSetting
+		case "wal_keep_size", "wal_keep_segments":
+			settings.walKeepSize = normalizedSetting
+		}
+	}
+
+	return settings, nil
+}
+
+func getWalVolumeSize() float64 {
+	cluster, err := cache.LoadCluster()
+	// there isn't a cached object yet
+	if errors.Is(err, cache.ErrCacheMiss) {
+		return 0
+	}
+	if cluster.ShouldCreateWalArchiveVolume() {
+		walSize := cluster.Spec.WalStorage.GetSizeOrNil()
+		if walSize != nil {
+			return walSize.AsApproximateFloat64()
+		}
+	}
+	return 0
+}

--- a/pkg/management/postgres/webserver/metricserver/wal_test.go
+++ b/pkg/management/postgres/webserver/metricserver/wal_test.go
@@ -1,0 +1,120 @@
+/*
+Copyright The CloudNativePG Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metricserver
+
+import (
+	"database/sql"
+	"strconv"
+
+	"github.com/DATA-DOG/go-sqlmock"
+
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("ensures walSettings works correctly", func() {
+	const (
+		sha256                     = "random-sha"
+		walSegmentSize     float64 = 16777216
+		walKeepSize        float64 = 512
+		minWalSize         float64 = 80
+		maxWalSize         float64 = 1024
+		maxSlotWalKeepSize float64 = -1
+		walKeepSegments    float64 = 25
+		query                      = `
+SELECT name, setting FROM pg_settings 
+WHERE pg_settings.name
+IN ('wal_segment_size', 'min_wal_size', 'max_wal_size', 'wal_keep_size', 'wal_keep_segments', 'max_slot_wal_keep_size')`
+	)
+	var (
+		walSegmentSizeStr     = strconv.FormatFloat(walSegmentSize, 'f', -1, 64)
+		walKeepSizeStr        = strconv.FormatFloat(walKeepSize, 'f', -1, 64)
+		minWalSizeStr         = strconv.FormatFloat(minWalSize, 'f', -1, 64)
+		maxWalSizeStr         = strconv.FormatFloat(maxWalSize, 'f', -1, 64)
+		maxSlotWalKeepSizeStr = strconv.FormatFloat(maxSlotWalKeepSize, 'f', -1, 64)
+		walKeepSegmentsStr    = strconv.FormatFloat(walKeepSegments, 'f', -1, 64)
+	)
+
+	var (
+		db             *sql.DB
+		mock           sqlmock.Sqlmock
+		err            error
+		pgSettingsRows *sqlmock.Rows
+	)
+
+	BeforeEach(func() {
+		pgSettingsRows = sqlmock.NewRows([]string{"name", "setting"}).
+			AddRow("wal_segment_size", walSegmentSizeStr).
+			AddRow("min_wal_size", minWalSizeStr).
+			AddRow("max_wal_size", maxWalSizeStr).
+			AddRow("max_slot_wal_keep_size", maxSlotWalKeepSizeStr)
+
+		db, mock, err = sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() {
+			_ = db.Close()
+		})
+	})
+
+	It("should not trigger a synchronize if the config sha256 is the same", func() {
+		mock.ExpectQuery(query)
+		settings := walSettings{configSha256: sha256}
+		err := settings.synchronize(db, sha256)
+		Expect(err).ToNot(HaveOccurred())
+
+		expected := walSettings{configSha256: sha256}
+		Expect(settings).To(Equal(expected))
+	})
+
+	It("it should execute the query and return the walSettings on a sha256 change. Postgres 13>=", func() {
+		pgSettingsRows.AddRow("wal_keep_size", walKeepSizeStr)
+
+		mock.ExpectQuery(query).
+			WillReturnRows(pgSettingsRows)
+
+		settings := walSettings{}
+		err := settings.synchronize(db, sha256)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(mock.ExpectationsWereMet()).To(Succeed())
+
+		Expect(settings.configSha256).To(Equal(sha256))
+		Expect(settings.walSegmentSize).To(Equal(walSegmentSize))
+		Expect(settings.walKeepSizeNormalized).To(Equal(utils.ToBytes(walKeepSize) / walSegmentSize))
+		Expect(settings.minWalSize).To(Equal(minWalSize))
+		Expect(settings.maxWalSize).To(Equal(maxWalSize))
+		Expect(settings.maxSlotWalKeepSize).To(Equal(maxSlotWalKeepSize))
+	})
+
+	It("it should execute the query and return the walSettings on a sha256 change. Postgres 13<", func() {
+		pgSettingsRows.AddRow("wal_keep_segments", walKeepSegmentsStr)
+		mock.ExpectQuery(query).WillReturnRows(pgSettingsRows)
+
+		settings := walSettings{}
+		err := settings.synchronize(db, sha256)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(mock.ExpectationsWereMet()).To(Succeed())
+
+		Expect(settings.configSha256).To(Equal(sha256))
+		Expect(settings.walSegmentSize).To(Equal(walSegmentSize))
+		Expect(settings.walKeepSizeNormalized).To(Equal(walKeepSegments))
+		Expect(settings.minWalSize).To(Equal(minWalSize))
+		Expect(settings.maxWalSize).To(Equal(maxWalSize))
+		Expect(settings.maxSlotWalKeepSize).To(Equal(maxSlotWalKeepSize))
+	})
+})

--- a/pkg/utils/math.go
+++ b/pkg/utils/math.go
@@ -16,9 +16,21 @@ limitations under the License.
 
 package utils
 
+import (
+	"golang.org/x/exp/constraints"
+)
+
 // IsPowerOfTwo calculates if a number is power of two or not
 // reference: https://github.com/golang/go/blob/master/src/strconv/itoa.go#L204 #wokeignore:rule=master
 // This function will return false if the number is zero
 func IsPowerOfTwo(n int) bool {
 	return (n != 0) && (n&(n-1) == 0)
+}
+
+// ToBytes converts an input value in MB to bytes
+// Input: value - an integer representing size in MB
+// Output: the size in bytes, calculated by multiplying the input value by 1024 * 1024
+func ToBytes[T constraints.Signed | constraints.Float](mb T) float64 {
+	multiplier := float64(1024)
+	return float64(mb) * multiplier * multiplier
 }


### PR DESCRIPTION
This feature provides more value for metrics cnpg_collector_pg_wal in default exporter, 
the goal is to provide an easy way to monitor the disk usage by relying on the WAL logic.

Closes: #1374 
Signed-off-by: Tao Li <tao.li@enterprisedb.com>