### PR TITLE
docs: add missing scheme for s3 endpoint example

### DIFF
--- a/docs/src/backup_recovery.md
+++ b/docs/src/backup_recovery.md
@@ -143,7 +143,7 @@ spec:
   backup:
     barmanObjectStore:
       destinationPath: "<destination path here>"
-      endpointURL: bucket.us-east1.linodeobjects.com
+      endpointURL: "https://bucket.us-east1.linodeobjects.com"
       s3Credentials:
         [...]
 ```


### PR DESCRIPTION
Add `https://` scheme to the S3-compatible example for Linode.

Using a value without scheme here will result in a failure with a log message:
```
ERROR: Barman cloud backup exception: Invalid endpoint: s3.example.com
``` 

All the other sample `endpointURL`s on this page already have a scheme.