### PR TITLE
chore: add release 1.19 to backport workflow

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -27,6 +27,7 @@ jobs:
             backport-requested :arrow_backward:
             release-1.17
             release-1.18
+            release-1.19
       -
         name: Create comment
         uses: peter-evans/create-or-update-comment@v2
@@ -58,6 +59,7 @@ jobs:
         branch:
           -  release-1.17
           -  release-1.18
+          -  release-1.19
     env:
       PR: ${{ github.event.pull_request.number }}
     outputs:

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -57,6 +57,7 @@ jobs:
         branch:
           - release-1.17
           - release-1.18
+          - release-1.19
     steps:
       - name: Invoke workflow with inputs
         uses: benc-uk/workflow-dispatch@v121

--- a/contribute/release_procedure.md
+++ b/contribute/release_procedure.md
@@ -115,11 +115,12 @@ git push --set-upstream origin release-X.Y
 
 This procedure must happen immediately before starting the release.
 
-**IMPORTANT:** Now we backport merged pull request from main to release branches automatically,
-once a new release branch is created, submit a pull request to update the [backport workflow]
-(https://github.com/cloudnative-pg/cloudnative-pg/blob/main/.github/workflows/backport.yml) to 
-support the new release branch.
-
+**IMPORTANT:** Now we add support for the automatic backporting of merged pull requests from main to the new release branch.
+Once the new release branch is created, go back to `main` and submit a pull
+request to update the
+[backport](https://github.com/cloudnative-pg/cloudnative-pg/blob/main/.github/workflows/backport.yml)
+and [continuous delivery](https://github.com/cloudnative-pg/cloudnative-pg/blob/main/.github/workflows/continuous-delivery.yml)
+workflows to support the new release branch.
 
 ## Release steps
 


### PR DESCRIPTION
add the new minor release 1.19 to the backport workflow, and
clarify how to do this in the release documentation.

Signed-off-by: Jaime Silvela <jaime.silvela@enterprisedb.com>