### PR TITLE
chore: Deprecate GoReleaser versions older than 1.14.0

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -66,16 +66,23 @@ builds:
     goarch: s390x
 
 archives:
-- name_template: kubectl-cnpg_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}
+- name_template: >-
+    kubectl-cnpg_
+    {{- .Os }}_
+    {{- if eq .Arch "amd64" }}x86_64
+    {{- else if eq .Arch "386" }}i386
+    {{- else }}{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}{{ end }}
   builds:
   - kubectl-cnpg
-  replacements:
-    386: i386
-    amd64: x86_64
 
 nfpms:
   - id: kubectl-cnpg
-    file_name_template: kubectl-cnpg_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}
+    file_name_template: >-
+      kubectl-cnpg_{{ .Version }}_
+      {{- .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}{{ end }}
     homepage: https://github.com/cloudnative-pg/cloudnative-pg
     bindir: /usr/local/bin
     maintainer: 'Marco Nenciarini <marco.nenciarini@enterprisedb.com>'
@@ -84,9 +91,6 @@ nfpms:
     formats:
       - rpm
       - deb
-    replacements:
-      386: i386
-      amd64: x86_64
 
 checksum:
   name_template: '{{ .ProjectName }}-{{ .Version }}-checksums.txt'

--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ run: generate fmt vet manifests ## Run against the configured Kubernetes cluster
 
 docker-build: go-releaser ## Build the docker image.
 	GOOS=linux GOARCH=${ARCH} DATE=${DATE} COMMIT=${COMMIT} VERSION=${VERSION} \
-	  $(GO_RELEASER) build --skip-validate --rm-dist --single-target
+	  $(GO_RELEASER) build --skip-validate --clean --single-target
 	DOCKER_BUILDKIT=1 docker build . -t ${CONTROLLER_IMG} --build-arg VERSION=${VERSION}
 
 docker-push: ## Push the docker image.


### PR DESCRIPTION
Added the new format of name_template to replace `replacements` during the archive process.
Added the new format in nfpms for `file_name_template`

Closes #1391