### PR TITLE
feat: enable debug option for initdb job

### DIFF
--- a/pkg/specs/jobs.go
+++ b/pkg/specs/jobs.go
@@ -110,6 +110,10 @@ func buildInitDBFlags(cluster apiv1.Cluster) (initCommand []string) {
 		*config.DataChecksums {
 		options = append(options, "-k")
 	}
+	if logLevel := cluster.Spec.LogLevel; log.DebugLevelString == logLevel ||
+		log.TraceLevelString == logLevel {
+		options = append(options, "-d")
+	}
 	if encoding := config.Encoding; encoding != "" {
 		options = append(options, fmt.Sprintf("--encoding=%s", encoding))
 	}


### PR DESCRIPTION
This patch enable the debug option for initdb process if the cluter.spec.logLevel is debug 
or more lower.

Closes: #1502 
Signed-off-by: Tao Li [tao.li@enterprisedb.com](mailto:tao.li@enterprisedb.com)

