### PR TITLE
chore: change distroless/static image for distroless/static-debian11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/static:nonroot
+FROM gcr.io/distroless/static-debian11:nonroot
 ARG VERSION="dev"
 ARG TARGETARCH
 


### PR DESCRIPTION
The old image gcr.io/distroless/static:nonroot has been deprecated and is no longer support, because of that we should use the new and supported image gcr.io/distroless/static-debian11:nonroot

Documentation https://github.com/GoogleContainerTools/distroless#what-images-are-available

Closes: #1508