### PR TITLE
chore: add all the operator binary to the operator container

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,7 +15,7 @@ before:
 
 builds:
 - id: manager
-  binary: manager_{{ .Arch }}
+  binary: manager/manager_{{ .Arch }}
   main: cmd/manager/main.go
   no_unique_dist_dir: true
   gcflags:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,8 +15,9 @@ before:
 
 builds:
 - id: manager
-  binary: manager
+  binary: manager_{{ .Arch }}
   main: cmd/manager/main.go
+  no_unique_dist_dir: true
   gcflags:
     - all=-trimpath={{.Env.GOPATH}};{{.Env.PWD}}
   ldflags:

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,10 @@
 FROM gcr.io/distroless/static-debian11:debug-nonroot as builder
 ARG TARGETARCH
 
-COPY --chown=nonroot:nonroot --chmod=0755 dist/manager_* .
 SHELL ["/busybox/sh", "-c"]
-RUN ln -sf manager_${TARGETARCH} manager
+RUN mkdir bind
+COPY --chown=nonroot:nonroot --chmod=0755 dist/manager/* bin/
+RUN ln -sf bin/manager_${TARGETARCH} manager
 
 FROM gcr.io/distroless/static-debian11:nonroot
 ARG VERSION="dev"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # This builder stage it's only because we need a command
 # to create a symlink and reduce the size of the image
-FROM gcr.io/distroless/static:debug-nonroot as builder
+FROM gcr.io/distroless/static-debian11:debug-nonroot as builder
 ARG TARGETARCH
 
 COPY --chown=nonroot:nonroot --chmod=0755 dist/manager_* .

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,6 @@ FROM gcr.io/distroless/static-debian11:debug-nonroot as builder
 ARG TARGETARCH
 
 SHELL ["/busybox/sh", "-c"]
-RUN mkdir bin
 COPY --chown=nonroot:nonroot --chmod=0755 dist/manager/* bin/
 RUN ln -sf bin/manager_${TARGETARCH} manager
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM gcr.io/distroless/static-debian11:debug-nonroot as builder
 ARG TARGETARCH
 
 SHELL ["/busybox/sh", "-c"]
-RUN mkdir bind
+RUN mkdir bin
 COPY --chown=nonroot:nonroot --chmod=0755 dist/manager/* bin/
 RUN ln -sf bin/manager_${TARGETARCH} manager
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,12 @@
+# This builder stage it's only because we need a command
+# to create a symlink and reduce the size of the image
+FROM gcr.io/distroless/static:debug-nonroot as builder
+ARG TARGETARCH
+
+COPY --chown=nonroot:nonroot --chmod=0755 dist/manager_* .
+SHELL ["/busybox/sh", "-c"]
+RUN ln -sf manager_${TARGETARCH} manager
+
 FROM gcr.io/distroless/static-debian11:nonroot
 ARG VERSION="dev"
 ARG TARGETARCH
@@ -19,6 +28,8 @@ WORKDIR /
 
 USER nonroot:nonroot
 
-COPY --chown=nonroot:nonroot --chmod=0755 dist/manager_linux_${TARGETARCH}*/manager .
+# Needs to copy the entire content, otherwise, it will not
+# copy the symlink properly.
+COPY --from=builder /home/nonroot/ .
 
 ENTRYPOINT ["/manager"]


### PR DESCRIPTION
The idea it's to add all the binary that support both architetures arm64 and amd64 to the operator container for future use in an experimental feature

Closes #1512 