### PR TITLE
ci: ensure branches missing Gingko report are accounted

### DIFF
--- a/.github/generate-test-artifacts.py
+++ b/.github/generate-test-artifacts.py
@@ -21,6 +21,7 @@ import os
 import hashlib
 from datetime import *
 
+
 def flatten(arr):
     """flatten an array of arrays"""
     out = []
@@ -94,6 +95,7 @@ def convert_ginkgo_test(t, matrix):
     }
     return x
 
+
 def write_artifact(artifact, matrix):
     """writes an artifact to local storage as a JSON file
 
@@ -115,6 +117,7 @@ def write_artifact(artifact, matrix):
     with open(filename, "w") as f:
         f.write(json.dumps(artifact))
 
+
 def create_artifact(matrix, name, state, error):
     """creates an artifact with a given name, state and error,
     with the metadata provided by the `matrix` argument.
@@ -132,6 +135,8 @@ def create_artifact(matrix, name, state, error):
         "start_time": datetime.now().isoformat(),
         "end_time": datetime.now().isoformat(),  # NOTE: Grafana will need a default timestamp field. This is a good candidate
         "error": error,
+        "error_file": "no-file",
+        "error_line": 0,
         "platform": matrix["runner"],
         "matrix_id": matrix["id"],
         "postgres_kind": kind,
@@ -141,6 +146,7 @@ def create_artifact(matrix, name, state, error):
         "repo": matrix["repo"],
         "branch": branch,
     }
+
 
 if __name__ == "__main__":
 
@@ -184,10 +190,12 @@ if __name__ == "__main__":
         # we still want to get an entry in the E2E Dashboard for workflows that even
         # failed to run the ginkgo suite or failed to produce a JSON report.
         # We create a custom Artifact with a `failed` status for the Dashboard
-        artifact = create_artifact(matrix,
-            "[report missing] Generate artifacts from Ginkgo report",
+        artifact = create_artifact(
+            matrix,
+            "Open Ginkgo report",
             "failed",
-            "ginkgo Report Not Found: " + args.file)
+            "ginkgo Report Not Found: " + args.file,
+        )
         write_artifact(artifact, matrix)
         exit(0)
 
@@ -202,8 +210,7 @@ if __name__ == "__main__":
                     write_artifact(test1, matrix)
     except Exception as e:
         # Reflect any unexpected failure in an artifact
-        artifact = create_artifact(matrix,
-            "Generate artifacts from Ginkgo report",
-            "failed",
-            f"{e}")
+        artifact = create_artifact(
+            matrix, "Generate artifacts from Ginkgo report", "failed", f"{e}"
+        )
         write_artifact(artifact, matrix)

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -735,7 +735,7 @@ jobs:
         run: ls -R test-artifacts/data
 
       - name: Compute the E2E test summary
-        uses: cloudnative-pg/ciclops@main
+        uses: cloudnative-pg/ciclops@v1.1.0
         with:
           artifact_directory: test-artifacts/data
           output_file: test-summary.md

--- a/tests/e2e/scaling_test.go
+++ b/tests/e2e/scaling_test.go
@@ -71,7 +71,7 @@ var _ = Describe("Cluster scale up and down", Serial, Label(tests.LabelReplicati
 			By("removing an instance from the cluster", func() {
 				_, _, err := utils.Run(fmt.Sprintf("kubectl scale --replicas=3 -n %v cluster/%v", namespace, clusterName))
 				Expect(err).ToNot(HaveOccurred())
-				timeout := 60
+				timeout := 61
 				AssertClusterIsReady(namespace, clusterName, timeout, env)
 			})
 			AssertClusterReplicationSlots(clusterName, namespace)

--- a/tests/e2e/scaling_test.go
+++ b/tests/e2e/scaling_test.go
@@ -71,7 +71,7 @@ var _ = Describe("Cluster scale up and down", Serial, Label(tests.LabelReplicati
 			By("removing an instance from the cluster", func() {
 				_, _, err := utils.Run(fmt.Sprintf("kubectl scale --replicas=3 -n %v cluster/%v", namespace, clusterName))
 				Expect(err).ToNot(HaveOccurred())
-				timeout := 61
+				timeout := 60
 				AssertClusterIsReady(namespace, clusterName, timeout, env)
 			})
 			AssertClusterReplicationSlots(clusterName, namespace)


### PR DESCRIPTION
CIclops will ignore any JSON file that does not match the expected schema.
Two fields were missing in the "Report missing" artifacts, so they were ignored.