### PR TITLE
fix: ensure backup command updates the resources status in case of errors

### DIFF
--- a/pkg/management/postgres/backup_test.go
+++ b/pkg/management/postgres/backup_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -17,12 +18,15 @@ import (
 )
 
 var _ = Describe("testing backup command", func() {
+	const namespace = "test"
+
 	var cluster *apiv1.Cluster
-	var backup BackupCommand
+	var backupCommand BackupCommand
+	var backup *apiv1.Backup
 
 	BeforeEach(func() {
 		cluster = &apiv1.Cluster{
-			ObjectMeta: metav1.ObjectMeta{Name: "test-cluster", Namespace: "test"},
+			ObjectMeta: metav1.ObjectMeta{Name: "test-cluster", Namespace: namespace},
 			Spec: apiv1.ClusterSpec{
 				Backup: &apiv1.BackupConfiguration{
 					BarmanObjectStore: &apiv1.BarmanObjectStoreConfiguration{
@@ -81,23 +85,24 @@ var _ = Describe("testing backup command", func() {
 				},
 			},
 		}
-		backup = BackupCommand{
-			Cluster: cluster,
-			Backup: &apiv1.Backup{
-				TypeMeta: metav1.TypeMeta{},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test",
-					Namespace: "test",
-				},
-				Spec: apiv1.BackupSpec{
-					Cluster: apiv1.LocalObjectReference{
-						Name: "test-cluster",
-					},
+		backup = &apiv1.Backup{
+			TypeMeta: metav1.TypeMeta{},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-backup",
+				Namespace: namespace,
+			},
+			Spec: apiv1.BackupSpec{
+				Cluster: apiv1.LocalObjectReference{
+					Name: "test-cluster",
 				},
 			},
+		}
+		backupCommand = BackupCommand{
+			Cluster: cluster,
+			Backup:  backup,
 			Client: fake.NewClientBuilder().
 				WithScheme(scheme.BuildWithAllKnownScheme()).
-				WithObjects(cluster).
+				WithObjects(cluster, backup).
 				Build(),
 			Recorder: &record.FakeRecorder{},
 			Env:      os.Environ(),
@@ -106,8 +111,15 @@ var _ = Describe("testing backup command", func() {
 		}
 	})
 
-	It("should fail and update cluster last failed backup", func() {
-		backup.run(context.Background())
+	It("should fail and update cluster and backup resource", func() {
+		backupCommand.run(context.Background())
 		Expect(cluster.Status.LastFailedBackup).ToNot(BeEmpty())
+
+		clusterCond := meta.FindStatusCondition(cluster.Status.Conditions, string(apiv1.ConditionBackup))
+		Expect(clusterCond.Status).To(Equal(metav1.ConditionFalse))
+		Expect(clusterCond.Message).ToNot(BeEmpty())
+		Expect(clusterCond.Reason).To(Equal(string(apiv1.ConditionReasonLastBackupFailed)))
+
+		Expect(backup.Status.Error).To(Equal(clusterCond.Message))
 	})
 })


### PR DESCRIPTION
This patch ensures that we always update the backup/cluster status in case of errors during the backup command execution.

Partially Closes #1523 