### PR TITLE
chore: use patch instead of update for Backup reconciler and command

### DIFF
--- a/controllers/backup_controller.go
+++ b/controllers/backup_controller.go
@@ -128,6 +128,8 @@ func (r *BackupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 
 	contextLogger.Debug("Found cluster for backup", "cluster", clusterName)
 
+	origBackup := backup.DeepCopy()
+
 	// Detect the pod where a backup will be executed
 	pod, err := r.getBackupTargetPod(ctx, cluster)
 	if err != nil {
@@ -137,7 +139,7 @@ func (r *BackupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 			contextLogger.Info("Couldn't find target pod, will retry in 30 seconds", "target",
 				cluster.Status.TargetPrimary)
 			backup.Status.Phase = apiv1.BackupPhasePending
-			return ctrl.Result{RequeueAfter: 30 * time.Second}, r.Status().Update(ctx, &backup)
+			return ctrl.Result{RequeueAfter: 30 * time.Second}, r.Status().Patch(ctx, &backup, client.MergeFrom(origBackup))
 		}
 		tryFlagBackupAsFailed(ctx, r.Client, &backup, fmt.Errorf("while getting pod: %w", err))
 		r.Recorder.Eventf(&backup, "Warning", "FindingPod", "Error getting target pod: %s",
@@ -151,7 +153,7 @@ func (r *BackupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		backup.Status.Phase = apiv1.BackupPhasePending
 		r.Recorder.Eventf(&backup, "Warning", "BackupPending", "Backup target pod not ready: %s",
 			cluster.Status.TargetPrimary)
-		return ctrl.Result{RequeueAfter: 30 * time.Second}, r.Status().Update(ctx, &backup)
+		return ctrl.Result{RequeueAfter: 30 * time.Second}, r.Status().Patch(ctx, &backup, client.MergeFrom(origBackup))
 	}
 
 	if backup.Status.Phase != "" && backup.Status.InstanceID != nil {
@@ -258,7 +260,7 @@ func StartBackup(
 	status := backup.GetStatus()
 	status.Phase = apiv1.BackupPhaseStarted
 	status.InstanceID = &apiv1.InstanceID{PodName: pod.Name, ContainerID: pod.Status.ContainerStatuses[0].ContainerID}
-	if err := postgres.UpdateBackupStatusAndRetry(ctx, client, backup); err != nil {
+	if err := postgres.PatchBackupStatusAndRetry(ctx, client, backup); err != nil {
 		return err
 	}
 	config := ctrl.GetConfigOrDie()
@@ -294,10 +296,10 @@ func StartBackup(
 			Reason:  string(apiv1.ConditionReasonLastBackupFailed),
 			Message: err.Error(),
 		}
-		if errCond := conditions.Update(ctx, client, cluster, &condition); errCond != nil {
+		if errCond := conditions.Patch(ctx, client, cluster, &condition); errCond != nil {
 			log.FromContext(ctx).Error(errCond, "Error while updating backup condition (backup failed)")
 		}
-		return postgres.UpdateBackupStatusAndRetry(ctx, client, backup)
+		return postgres.PatchBackupStatusAndRetry(ctx, client, backup)
 	}
 
 	return nil

--- a/internal/cmd/manager/walarchive/cmd.go
+++ b/internal/cmd/manager/walarchive/cmd.go
@@ -180,7 +180,7 @@ func run(ctx context.Context, podName, pgData string, args []string, client clie
 			Reason:  string(apiv1.ConditionReasonContinuousArchivingFailing),
 			Message: err.Error(),
 		}
-		if errCond := conditions.Update(ctx, client, cluster, &condition); errCond != nil {
+		if errCond := conditions.Patch(ctx, client, cluster, &condition); errCond != nil {
 			log.Error(errCond, "Error updating wal archiving condition (wal archiving failed)")
 		}
 		return err
@@ -205,7 +205,7 @@ func run(ctx context.Context, podName, pgData string, args []string, client clie
 		Reason:  string(apiv1.ConditionReasonContinuousArchivingSuccess),
 		Message: "Continuous archiving is working",
 	}
-	if errCond := conditions.Update(ctx, client, cluster, &condition); errCond != nil {
+	if errCond := conditions.Patch(ctx, client, cluster, &condition); errCond != nil {
 		log.Error(errCond, "Error while updating wal archiving condition (wal archiving succeeded)")
 	}
 	// We return only the first error to PostgreSQL, because the first error
@@ -370,7 +370,7 @@ func checkWalArchive(ctx context.Context,
 			Reason:  string(apiv1.ConditionReasonContinuousArchivingFailing),
 			Message: err.Error(),
 		}
-		if errCond := conditions.Update(ctx, client, cluster, &condition); errCond != nil {
+		if errCond := conditions.Patch(ctx, client, cluster, &condition); errCond != nil {
 			log.Error(errCond, "Error changing wal archiving condition (wal archiving failed)")
 		}
 		return err
@@ -389,7 +389,7 @@ func checkWalArchive(ctx context.Context,
 			Reason:  string(apiv1.ConditionReasonContinuousArchivingFailing),
 			Message: err.Error(),
 		}
-		if errCond := conditions.Update(ctx, client, cluster, &condition); errCond != nil {
+		if errCond := conditions.Patch(ctx, client, cluster, &condition); errCond != nil {
 			log.Error(errCond, "Error changing wal archiving condition (wal archiving failed)")
 		}
 		return err

--- a/internal/cmd/manager/walarchive/cmd.go
+++ b/internal/cmd/manager/walarchive/cmd.go
@@ -181,7 +181,7 @@ func run(ctx context.Context, podName, pgData string, args []string, client clie
 			Message: err.Error(),
 		}
 		if errCond := conditions.Patch(ctx, client, cluster, &condition); errCond != nil {
-			log.Error(errCond, "Error updating wal archiving condition (wal archiving failed)")
+			log.Error(errCond, "Error changing wal archiving condition (wal archiving failed)")
 		}
 		return err
 	}
@@ -206,7 +206,7 @@ func run(ctx context.Context, podName, pgData string, args []string, client clie
 		Message: "Continuous archiving is working",
 	}
 	if errCond := conditions.Patch(ctx, client, cluster, &condition); errCond != nil {
-		log.Error(errCond, "Error while updating wal archiving condition (wal archiving succeeded)")
+		log.Error(errCond, "Error changing wal archiving condition (wal archiving succeeded)")
 	}
 	// We return only the first error to PostgreSQL, because the first error
 	// is the one raised by the file that PostgreSQL has requested to archive.

--- a/pkg/conditions/conditions.go
+++ b/pkg/conditions/conditions.go
@@ -27,8 +27,8 @@ import (
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 )
 
-// Update will allow update a particular condition in cluster status.
-func Update(
+// Patch will patch a particular condition in cluster status.
+func Patch(
 	ctx context.Context,
 	c client.Client,
 	cluster *apiv1.Cluster,


### PR DESCRIPTION
This patch ensures that we use Patch instead of Update to commit backup changes to the API server.
This avoids conflicts that could generate from divergent resourceVersion given that the backup resource is pooled by multiple reconciliation loops.
    
Partially closes #1523 
    
Signed-off-by: Armando Ruocco <armando.ruocco@enterprisedb.com>