### PR TITLE
feat: declarative hibernation

### DIFF
--- a/.wordlist-en-custom.txt
+++ b/.wordlist-en-custom.txt
@@ -792,6 +792,9 @@ recoveryTarget
 recoverytarget
 recv
 redhat
+rehydrate
+rehydrated
+rehydration
 relatime
 replicationSlots
 replicationTLSSecret

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -46,6 +46,7 @@ import (
 	"github.com/cloudnative-pg/cloudnative-pg/internal/configuration"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/log"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/postgres"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/reconciler/hibernation"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/reconciler/persistentvolumeclaim"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/specs"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
@@ -270,6 +271,19 @@ func (r *ClusterReconciler) reconcile(ctx context.Context, cluster *apiv1.Cluste
 				"isPodReady", isPodReady)
 			return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
 		}
+	}
+
+	// If the user has requested to hibernate the cluster, we do that before
+	// ensuring the primary to be healthy. The hibernation starts from the
+	// primary Pod to ensure the replicas are in sync and doing it here avoids
+	// any unwanted switchovers.
+	if result, err := hibernation.Reconcile(
+		ctx,
+		r.Client,
+		cluster,
+		resources.instances.Items,
+	); result != nil || err != nil {
+		return *result, err
 	}
 
 	// We have already updated the status in updateResourceStatus call,

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -276,7 +276,7 @@ func (r *ClusterReconciler) reconcile(ctx context.Context, cluster *apiv1.Cluste
 	// If the user has requested to hibernate the cluster, we do that before
 	// ensuring the primary to be healthy. The hibernation starts from the
 	// primary Pod to ensure the replicas are in sync and doing it here avoids
-	// any unwanted switchovers.
+	// any unwanted switchover's.
 	if result, err := hibernation.Reconcile(
 		ctx,
 		r.Client,

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -276,7 +276,7 @@ func (r *ClusterReconciler) reconcile(ctx context.Context, cluster *apiv1.Cluste
 	// If the user has requested to hibernate the cluster, we do that before
 	// ensuring the primary to be healthy. The hibernation starts from the
 	// primary Pod to ensure the replicas are in sync and doing it here avoids
-	// any unwanted switchover's.
+	// any unwanted switchover.
 	if result, err := hibernation.Reconcile(
 		ctx,
 		r.Client,

--- a/controllers/cluster_status.go
+++ b/controllers/cluster_status.go
@@ -41,6 +41,7 @@ import (
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/log"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/url"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/postgres"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/reconciler/hibernation"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/reconciler/persistentvolumeclaim"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/versions"
@@ -265,6 +266,11 @@ func (r *ClusterReconciler) updateResourceStatus(
 		resources.instances.Items,
 		resources.jobs.Items,
 		resources.pvcs.Items,
+	)
+	hibernation.EnrichStatus(
+		ctx,
+		cluster,
+		resources.instances.Items,
 	)
 
 	// Count jobs

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -51,6 +51,7 @@ nav:
   - controller.md
   - samples.md
   - benchmarking.md
+  - declarative_hibernation.md
   - commercial_support.md
   - faq.md
   - api_reference.md

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -44,6 +44,7 @@ nav:
   - failover.md
   - troubleshooting.md
   - fencing.md
+  - declarative_hibernation.md
   - postgis.md
   - e2e.md
   - container_images.md
@@ -51,7 +52,6 @@ nav:
   - controller.md
   - samples.md
   - benchmarking.md
-  - declarative_hibernation.md
   - commercial_support.md
   - faq.md
   - api_reference.md

--- a/docs/src/declarative_hibernation.md
+++ b/docs/src/declarative_hibernation.md
@@ -42,8 +42,8 @@ $ kubectl get cluster <cluster-name> -o "jsonpath={.status.conditions[?(.type==\
 }
 ```
 
-The hibernation status can also be read with the `status` sub-command of the the
-kubectl-cnp plugin:
+The hibernation status can also be read with the `status` sub-command of the
+`cnpg` plugin for `kubectl`:
 
 ``` sh
 $ kubectl cnpg status <cluster-name>

--- a/docs/src/declarative_hibernation.md
+++ b/docs/src/declarative_hibernation.md
@@ -66,7 +66,7 @@ Time     2023-03-05 16:43:35 +0000 UTC
 To rehydrate a cluster, set the `cnpg.io/hibernation=off` annotation:
 
 ```
-$ kubectl annotate cluster <cluster-name> --overwrite cnpg.io/hibernation=on
+$ kubectl annotate cluster <cluster-name> --overwrite cnpg.io/hibernation=off
 ```
 
 The Pods will be recreated and the cluster operation will be resumed.

--- a/docs/src/declarative_hibernation.md
+++ b/docs/src/declarative_hibernation.md
@@ -65,10 +65,16 @@ Time     2023-03-05 16:43:35 +0000 UTC
 
 ## Rehydration
 
-To rehydrate a cluster, set the `cnpg.io/hibernation=off` annotation:
+To rehydrate a cluster, either set the `cnpg.io/hibernation` annotation to `off`:
 
 ```
 $ kubectl annotate cluster <cluster-name> --overwrite cnpg.io/hibernation=off
+```
+
+Or, just unset it altogether:
+
+```
+$ kubectl annotate cluster <cluster-name> cnpg.io/hibernation-
 ```
 
 The Pods will be recreated and the cluster will resume operation.

--- a/docs/src/declarative_hibernation.md
+++ b/docs/src/declarative_hibernation.md
@@ -24,7 +24,7 @@ A hibernated cluster won't have any running Pods, while the PVCs are retained
 so that the cluster can be rehydrated at a later time. Replica PVCs will be
 kept in addition to the primary's PVC.
 
-The hibernation procedure will delete the primary Pod and then the the replica
+The hibernation procedure will delete the primary Pod and then the replica
 Pods, avoiding switchover, to ensure the replicas are kept in sync.
 
 The hibernation status can be monitored by looking for the `cnpg.io/hibernation`

--- a/docs/src/declarative_hibernation.md
+++ b/docs/src/declarative_hibernation.md
@@ -1,0 +1,72 @@
+# Declarative hibernation
+
+CloudNativePG is designed to keep PostgreSQL cluster up, running and available
+anytime.
+
+There are some kind of workloads that require the database to be up only when
+the workload is active. Batch-driven solution are one of that kind.
+
+In that scenario, the database need only to be up when the batch procedure is
+running.
+
+The declarative hibernation feature enables saving CPU power by removing the
+database Pods while keeping the data PVCs.
+
+## Hibernation
+
+To hibernate a cluster, set the `cnpg.io/hibernation=on` annotation:
+
+```
+$ kubectl annotate cluster <cluster-name> --overwrite cnpg.io/hibernation=on
+```
+
+An hibernated cluster won't have any running Pods, while the PVCs are retained
+in order for the cluster be rehydrated. Replica PVCs will be kept too.
+
+The hibernation procedure will delete the primary Pod and the the replica Pods.
+This procedure allows the replicas to be kept in sync.
+
+The hibernation status can be monitored by looking for the `cnpg.io/hibernation`
+condition:
+
+```
+$ kubectl get cluster <cluster-name> -o "jsonpath={.status.conditions[?(.type==\"cnpg.io/hibernation\")]}" 
+
+{
+        "lastTransitionTime":"2023-03-05T16:43:35Z",
+        "message":"Cluster has been hibernated",
+        "reason":"Hibernated",
+        "status":"True",
+        "type":"cnpg.io/hibernation"
+}
+```
+
+Or the `status` command of the the kubectl-cnp plugin:
+
+```
+$ kubectl-cnpg status <cluster-name>
+Cluster Summary
+Name:              cluster-example
+Namespace:         default
+PostgreSQL Image:  ghcr.io/cloudnative-pg/postgresql:15.2
+Primary instance:  cluster-example-2
+Status:            Cluster in healthy state 
+Instances:         3
+Ready instances:   0
+
+Hibernation
+Status   Hibernated
+Message  Cluster has been hibernated
+Time     2023-03-05 16:43:35 +0000 UTC
+[..]
+```
+
+## Rehydration
+
+To rehydrate a cluster, set the `cnpg.io/hibernation=off` annotation:
+
+```
+$ kubectl annotate cluster <cluster-name> --overwrite cnpg.io/hibernation=on
+```
+
+The Pods will be recreated and the cluster operation will be resumed.

--- a/docs/src/declarative_hibernation.md
+++ b/docs/src/declarative_hibernation.md
@@ -1,35 +1,36 @@
 # Declarative hibernation
 
-CloudNativePG is designed to keep PostgreSQL cluster up, running and available
+CloudNativePG is designed to keep PostgreSQL clusters up, running and available
 anytime.
 
-There are some kind of workloads that require the database to be up only when
-the workload is active. Batch-driven solution are one of that kind.
+There are some kinds of workloads that require the database to be up only when
+the workload is active. Batch-driven solutions are one such case.
 
-In that scenario, the database need only to be up when the batch procedure is
-running.
+In batch-driven solutions, the database needs to be up only when the batch
+process is running.
 
 The declarative hibernation feature enables saving CPU power by removing the
-database Pods while keeping the data PVCs.
+database Pods, while keeping the data PVCs.
 
 ## Hibernation
 
 To hibernate a cluster, set the `cnpg.io/hibernation=on` annotation:
 
-```
+``` sh
 $ kubectl annotate cluster <cluster-name> --overwrite cnpg.io/hibernation=on
 ```
 
-An hibernated cluster won't have any running Pods, while the PVCs are retained
-in order for the cluster be rehydrated. Replica PVCs will be kept too.
+A hibernated cluster won't have any running Pods, while the PVCs are retained
+so that the cluster can be rehydrated at a later time. Replica PVCs will be
+kept in addition to the primary's PVC.
 
-The hibernation procedure will delete the primary Pod and the the replica Pods.
-This procedure allows the replicas to be kept in sync.
+The hibernation procedure will delete the primary Pod and then the the replica
+Pods, avoiding switchover, to ensure the replicas are kept in sync.
 
 The hibernation status can be monitored by looking for the `cnpg.io/hibernation`
 condition:
 
-```
+``` sh
 $ kubectl get cluster <cluster-name> -o "jsonpath={.status.conditions[?(.type==\"cnpg.io/hibernation\")]}" 
 
 {
@@ -41,10 +42,11 @@ $ kubectl get cluster <cluster-name> -o "jsonpath={.status.conditions[?(.type==\
 }
 ```
 
-Or the `status` command of the the kubectl-cnp plugin:
+The hibernation status can also be read with the `status` sub-command of the the
+kubectl-cnp plugin:
 
-```
-$ kubectl-cnpg status <cluster-name>
+``` sh
+$ kubectl cnpg status <cluster-name>
 Cluster Summary
 Name:              cluster-example
 Namespace:         default
@@ -69,4 +71,4 @@ To rehydrate a cluster, set the `cnpg.io/hibernation=off` annotation:
 $ kubectl annotate cluster <cluster-name> --overwrite cnpg.io/hibernation=off
 ```
 
-The Pods will be recreated and the cluster operation will be resumed.
+The Pods will be recreated and the cluster will resume operation.

--- a/docs/src/samples/cluster-example.yaml
+++ b/docs/src/samples/cluster-example.yaml
@@ -1,6 +1,8 @@
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
+  annotations:
+    cnpg.io/hibernation: "on"
   name: cluster-example
 spec:
   instances: 3

--- a/docs/src/samples/cluster-example.yaml
+++ b/docs/src/samples/cluster-example.yaml
@@ -1,8 +1,6 @@
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
-  annotations:
-    cnpg.io/hibernation: "on"
   name: cluster-example
 spec:
   instances: 3

--- a/pkg/reconciler/hibernation/doc.go
+++ b/pkg/reconciler/hibernation/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright The CloudNativePG Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package hibernation contains all the logic to hibernate a CNPG cluster
+package hibernation

--- a/pkg/reconciler/hibernation/reconciler.go
+++ b/pkg/reconciler/hibernation/reconciler.go
@@ -1,0 +1,87 @@
+/*
+Copyright The CloudNativePG Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hibernation
+
+import (
+	"context"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/log"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/specs"
+)
+
+// Reconcile reconciles the cluster hibernation status.
+func Reconcile(
+	ctx context.Context,
+	c client.Client,
+	cluster *apiv1.Cluster,
+	instances []corev1.Pod,
+) (*ctrl.Result, error) {
+	hibernationCondition := meta.FindStatusCondition(cluster.Status.Conditions, HibernationConditionType)
+	if hibernationCondition == nil {
+		// This means that hibernation has not been requested
+		return nil, nil
+	}
+
+	switch hibernationCondition.Reason {
+	case HibernationConditionReasonDeletingPods:
+		return reconcileDeletePods(ctx, c, instances)
+
+	case HibernationConditionReasonWaitingPodsDeletion:
+		return &ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+
+	default:
+		return &ctrl.Result{}, nil
+	}
+}
+
+func reconcileDeletePods(
+	ctx context.Context,
+	c client.Client,
+	instances []corev1.Pod,
+) (*ctrl.Result, error) {
+	contextLogger := log.FromContext(ctx)
+
+	if len(instances) == 0 {
+		return &ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+	}
+
+	var podToBeDeleted *corev1.Pod
+	for idx := range instances {
+		if specs.IsPodPrimary(instances[idx]) {
+			podToBeDeleted = &instances[idx]
+		}
+	}
+
+	if podToBeDeleted == nil {
+		// The primary Pod has already been deleted, we can
+		// delete the replicas
+		podToBeDeleted = &instances[0]
+	}
+
+	// The Pod list is sorted and the primary instance
+	// will always be the first one, if present
+	contextLogger.Info("Deleting Pod as requested by the hibernation procedure", "podName", podToBeDeleted.Name)
+	deletionResult := c.Delete(ctx, podToBeDeleted)
+	return &ctrl.Result{RequeueAfter: 5 * time.Second}, deletionResult
+}

--- a/pkg/reconciler/hibernation/reconciler_test.go
+++ b/pkg/reconciler/hibernation/reconciler_test.go
@@ -41,7 +41,7 @@ type clientMock struct {
 	deletedPods []string
 }
 
-func (cm *clientMock) Delete(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
+func (cm *clientMock) Delete(_ context.Context, obj client.Object, _ ...client.DeleteOption) error {
 	cm.deletedPods = append(cm.deletedPods, obj.GetName())
 	return nil
 }

--- a/pkg/reconciler/hibernation/reconciler_test.go
+++ b/pkg/reconciler/hibernation/reconciler_test.go
@@ -1,0 +1,193 @@
+/*
+Copyright The CloudNativePG Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hibernation
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/specs"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+type clientMock struct {
+	client.Reader
+	client.Writer
+	client.StatusClient
+	client.SubResourceClientConstructor
+
+	deletedPods []string
+}
+
+func (cm *clientMock) Delete(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
+	cm.deletedPods = append(cm.deletedPods, obj.GetName())
+	return nil
+}
+
+func (cm *clientMock) Scheme() *runtime.Scheme {
+	return &runtime.Scheme{}
+}
+
+func (cm *clientMock) RESTMapper() meta.RESTMapper {
+	return nil
+}
+
+var _ = Describe("Reconcile resources", func() {
+	It("let the reconciliation loop proceed when there's no hibernation annotation", func(ctx SpecContext) {
+		mock := &clientMock{}
+		cluster := apiv1.Cluster{}
+		Expect(Reconcile(ctx, mock, &cluster, nil)).To(BeZero())
+		Expect(mock.deletedPods).To(BeEmpty())
+	})
+
+	It("let the reconciliation loog stop if the cluster is already hibernated", func(ctx SpecContext) {
+		mock := &clientMock{}
+		cluster := apiv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					HibernationAnnotationName: HibernationOff,
+				},
+			},
+			Status: apiv1.ClusterStatus{
+				Conditions: []metav1.Condition{
+					{
+						Type:   HibernationConditionType,
+						Status: metav1.ConditionTrue,
+						Reason: HibernationConditionReasonHibernated,
+					},
+				},
+			},
+		}
+		Expect(Reconcile(ctx, mock, &cluster, nil)).ToNot(BeZero())
+		Expect(mock.deletedPods).To(BeEmpty())
+	})
+
+	It("waits if a Pod is being deleted", func(ctx SpecContext) {
+		mock := &clientMock{}
+		cluster := apiv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					HibernationAnnotationName: HibernationOff,
+				},
+			},
+			Status: apiv1.ClusterStatus{
+				Conditions: []metav1.Condition{
+					{
+						Type:   HibernationConditionType,
+						Status: metav1.ConditionTrue,
+						Reason: HibernationConditionReasonWaitingPodsDeletion,
+					},
+				},
+			},
+		}
+
+		now := metav1.Now()
+		pods := []corev1.Pod{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					DeletionTimestamp: &now,
+				},
+			},
+		}
+		Expect(Reconcile(ctx, mock, &cluster, pods)).ToNot(BeZero())
+		Expect(mock.deletedPods).To(BeEmpty())
+	})
+
+	It("delete the primary pod if available", func(ctx SpecContext) {
+		mock := &clientMock{}
+		cluster := apiv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					HibernationAnnotationName: HibernationOff,
+				},
+				Name: "cluster-example",
+			},
+			Status: apiv1.ClusterStatus{
+				Conditions: []metav1.Condition{
+					{
+						Type:   HibernationConditionType,
+						Status: metav1.ConditionTrue,
+						Reason: HibernationConditionReasonDeletingPods,
+					},
+				},
+			},
+		}
+
+		pods := fakePodListWithPrimary()
+		Expect(Reconcile(ctx, mock, &cluster, pods)).ToNot(BeZero())
+		Expect(mock.deletedPods).To(ConsistOf("cluster-example-2"))
+	})
+
+	It("delete the replicas if the primary pod have already been deleted", func(ctx SpecContext) {
+		mock := &clientMock{}
+		cluster := apiv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					HibernationAnnotationName: HibernationOff,
+				},
+				Name: "cluster-example",
+			},
+			Status: apiv1.ClusterStatus{
+				Conditions: []metav1.Condition{
+					{
+						Type:   HibernationConditionType,
+						Status: metav1.ConditionTrue,
+						Reason: HibernationConditionReasonDeletingPods,
+					},
+				},
+			},
+		}
+
+		pods := fakePodListWithoutPrimary()
+		Expect(Reconcile(ctx, mock, &cluster, pods)).ToNot(BeZero())
+		Expect(mock.deletedPods).To(ConsistOf("cluster-example-1"))
+	})
+})
+
+func fakePod(name string, role string) corev1.Pod {
+	return corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				specs.ClusterRoleLabelName: role,
+			},
+		},
+	}
+}
+
+func fakePodListWithoutPrimary() []corev1.Pod {
+	return []corev1.Pod{
+		fakePod("cluster-example-1", specs.ClusterRoleLabelReplica),
+		fakePod("cluster-example-2", specs.ClusterRoleLabelReplica),
+	}
+}
+
+func fakePodListWithPrimary() []corev1.Pod {
+	return []corev1.Pod{
+		fakePod("cluster-example-1", specs.ClusterRoleLabelReplica),
+		fakePod("cluster-example-2", specs.ClusterRoleLabelPrimary),
+		fakePod("cluster-example-3", specs.ClusterRoleLabelReplica),
+	}
+}

--- a/pkg/reconciler/hibernation/reconciler_test.go
+++ b/pkg/reconciler/hibernation/reconciler_test.go
@@ -62,7 +62,7 @@ var _ = Describe("Reconcile resources", func() {
 		Expect(mock.deletedPods).To(BeEmpty())
 	})
 
-	It("let the reconciliation loog stop if the cluster is already hibernated", func(ctx SpecContext) {
+	It("let the reconciliation loop stop if the cluster is already hibernated", func(ctx SpecContext) {
 		mock := &clientMock{}
 		cluster := apiv1.Cluster{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/reconciler/hibernation/status.go
+++ b/pkg/reconciler/hibernation/status.go
@@ -77,7 +77,7 @@ func (err *ErrInvalidHibernationValue) Error() string {
 
 // EnrichStatus obtains and classifies the hibernation status of the cluster
 func EnrichStatus(
-	ctx context.Context,
+	_ context.Context,
 	cluster *apiv1.Cluster,
 	podList []corev1.Pod,
 ) {

--- a/pkg/reconciler/hibernation/status.go
+++ b/pkg/reconciler/hibernation/status.go
@@ -1,0 +1,146 @@
+/*
+Copyright The CloudNativePG Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hibernation
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+)
+
+const (
+	// HibernationAnnotationName is the name of the hibernation annotation
+	HibernationAnnotationName = "cnpg.io/hibernation"
+
+	// HibernationOff is the value of hibernation annotation when the hibernation
+	// has been deactivated for the clusetr
+	HibernationOff = "off"
+
+	// HibernationOn is the value of hibernation annotation when the hibernation
+	// has been requested for the cluster
+	HibernationOn = "on"
+)
+
+const (
+	// HibernationConditionType is the name of the condition representing
+	// the hibernation status
+	HibernationConditionType = "cnpg.io/hibernation"
+
+	// HibernationConditionReasonWrongAnnotationValue is the value of the hibernation
+	// condition that is used when the value of the annotation is not correct
+	HibernationConditionReasonWrongAnnotationValue = "WrongAnnotationValue"
+
+	// HibernationConditionReasonHibernated is the value of the hibernation
+	// condition that is used when the cluster is hibernated
+	HibernationConditionReasonHibernated = "Hibernated"
+
+	// HibernationConditionReasonDeletingPods is the value of the hibernation
+	// condition that is used when the operator is deleting
+	// the cluster's Pod
+	HibernationConditionReasonDeletingPods = "DeletingPods"
+
+	// HibernationConditionReasonWaitingPodsDeletion is the value of the
+	// hibernation condition that is used when the operator is waiting for a Pod
+	// to be deleted
+	HibernationConditionReasonWaitingPodsDeletion = "WaitingPodsDeletion"
+)
+
+// ErrInvalidHibernationValue is raised when the hibernation annotation has
+// an invalid value
+type ErrInvalidHibernationValue struct {
+	value string
+}
+
+// Error implements the error interface
+func (err *ErrInvalidHibernationValue) Error() string {
+	return fmt.Sprintf("invalid annotation value: %s", err.value)
+}
+
+// EnrichStatus obtains and classifies the hibernation status of the cluster
+func EnrichStatus(
+	ctx context.Context,
+	cluster *apiv1.Cluster,
+	podList []corev1.Pod,
+) {
+	hibernationRequested, err := getHibernationAnnotationValue(cluster)
+	if err != nil {
+		meta.SetStatusCondition(&cluster.Status.Conditions, metav1.Condition{
+			Type:    HibernationConditionType,
+			Status:  metav1.ConditionFalse,
+			Reason:  HibernationConditionReasonWrongAnnotationValue,
+			Message: err.Error(),
+		})
+		return
+	}
+
+	if !hibernationRequested {
+		meta.RemoveStatusCondition(&cluster.Status.Conditions, HibernationConditionType)
+		return
+	}
+
+	if len(podList) == 0 {
+		meta.SetStatusCondition(&cluster.Status.Conditions, metav1.Condition{
+			Type:    HibernationConditionType,
+			Status:  metav1.ConditionTrue,
+			Reason:  HibernationConditionReasonHibernated,
+			Message: "Cluster has been hibernated",
+		})
+		return
+	}
+
+	for idx := range podList {
+		if podList[idx].DeletionTimestamp != nil {
+			meta.SetStatusCondition(&cluster.Status.Conditions, metav1.Condition{
+				Type:    HibernationConditionType,
+				Status:  metav1.ConditionFalse,
+				Reason:  HibernationConditionReasonWaitingPodsDeletion,
+				Message: fmt.Sprintf("Waiting for %s to be deleted", podList[idx].Name),
+			})
+			return
+		}
+	}
+
+	meta.SetStatusCondition(&cluster.Status.Conditions, metav1.Condition{
+		Type:    HibernationConditionType,
+		Status:  metav1.ConditionFalse,
+		Reason:  HibernationConditionReasonDeletingPods,
+		Message: "Hibernation is in progress",
+	})
+}
+
+func getHibernationAnnotationValue(cluster *apiv1.Cluster) (bool, error) {
+	value, ok := cluster.Annotations[HibernationAnnotationName]
+	if !ok {
+		return false, nil
+	}
+
+	switch value {
+	case HibernationOn:
+		return true, nil
+
+	case HibernationOff:
+		return false, nil
+
+	default:
+		return false, &ErrInvalidHibernationValue{value: value}
+	}
+}

--- a/pkg/reconciler/hibernation/status.go
+++ b/pkg/reconciler/hibernation/status.go
@@ -32,7 +32,7 @@ const (
 	HibernationAnnotationName = "cnpg.io/hibernation"
 
 	// HibernationOff is the value of hibernation annotation when the hibernation
-	// has been deactivated for the clusetr
+	// has been deactivated for the cluster
 	HibernationOff = "off"
 
 	// HibernationOn is the value of hibernation annotation when the hibernation

--- a/pkg/reconciler/hibernation/status.go
+++ b/pkg/reconciler/hibernation/status.go
@@ -99,7 +99,7 @@ func EnrichStatus(
 
 	// We proceed to hibernate the cluster only when it is ready.
 	// Hibernating a non-ready cluster may be dangerous since the PVCs
-	// won't to completely created.
+	// won't be completely created.
 	if cluster.Status.Phase != apiv1.PhaseHealthy {
 		return
 	}

--- a/pkg/reconciler/hibernation/status.go
+++ b/pkg/reconciler/hibernation/status.go
@@ -97,6 +97,13 @@ func EnrichStatus(
 		return
 	}
 
+	// We proceed to hibernate the cluster only when it is ready.
+	// Hibernating a non-ready cluster may be dangerous since the PVCs
+	// won't to completely created.
+	if cluster.Status.Phase != apiv1.PhaseHealthy {
+		return
+	}
+
 	if len(podList) == 0 {
 		meta.SetStatusCondition(&cluster.Status.Conditions, metav1.Condition{
 			Type:    HibernationConditionType,

--- a/pkg/reconciler/hibernation/status_test.go
+++ b/pkg/reconciler/hibernation/status_test.go
@@ -1,0 +1,164 @@
+/*
+Copyright The CloudNativePG Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hibernation
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Hibernation annotation management", func() {
+	It("classifies clusters with not annotation as not hibernated", func() {
+		cluster := apiv1.Cluster{}
+		Expect(getHibernationAnnotationValue(&cluster)).To(BeFalse())
+	})
+
+	It("correctly handle on/off values", func() {
+		cluster := apiv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					HibernationAnnotationName: HibernationOn,
+				},
+			},
+		}
+		Expect(getHibernationAnnotationValue(&cluster)).To(BeTrue())
+
+		cluster.ObjectMeta.Annotations[HibernationAnnotationName] = HibernationOff
+		Expect(getHibernationAnnotationValue(&cluster)).To(BeFalse())
+	})
+
+	It("fails when the value of the annotation is not correct", func() {
+		cluster := apiv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					HibernationAnnotationName: "not-correct",
+				},
+			},
+		}
+		_, err := getHibernationAnnotationValue(&cluster)
+		Expect(err).ToNot(Succeed())
+	})
+})
+
+var _ = Describe("Status enrichment", func() {
+	It("doesn't add a condition if hibernation has not been requested", func(ctx SpecContext) {
+		cluster := apiv1.Cluster{}
+		EnrichStatus(ctx, &cluster, nil)
+		Expect(cluster.Status.Conditions).To(BeEmpty())
+	})
+
+	It("adds an error condition when the hibernation annotation have a wrong value", func(ctx SpecContext) {
+		cluster := apiv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					HibernationAnnotationName: "not-correct",
+				},
+			},
+		}
+		EnrichStatus(ctx, &cluster, nil)
+
+		hibernationCondition := meta.FindStatusCondition(cluster.Status.Conditions, HibernationConditionType)
+		Expect(hibernationCondition).ToNot(BeNil())
+		Expect(hibernationCondition.Status).To(Equal(metav1.ConditionFalse))
+		Expect(hibernationCondition.Reason).To(Equal(HibernationConditionReasonWrongAnnotationValue))
+	})
+
+	It("removes the hibernation condition when not requested", func(ctx SpecContext) {
+		cluster := apiv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					HibernationAnnotationName: HibernationOff,
+				},
+			},
+			Status: apiv1.ClusterStatus{
+				Conditions: []metav1.Condition{
+					{
+						Type:   HibernationConditionType,
+						Status: metav1.ConditionTrue,
+					},
+				},
+			},
+		}
+
+		EnrichStatus(ctx, &cluster, nil)
+		hibernationCondition := meta.FindStatusCondition(cluster.Status.Conditions, HibernationConditionType)
+		Expect(hibernationCondition).To(BeNil())
+	})
+
+	It("set the cluster as hibernated when every Pod have been deleted", func(ctx SpecContext) {
+		cluster := apiv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					HibernationAnnotationName: HibernationOn,
+				},
+			},
+		}
+
+		EnrichStatus(ctx, &cluster, nil)
+		hibernationCondition := meta.FindStatusCondition(cluster.Status.Conditions, HibernationConditionType)
+		Expect(hibernationCondition).ToNot(BeNil())
+		Expect(hibernationCondition.Status).To(Equal(metav1.ConditionTrue))
+		Expect(hibernationCondition.Reason).To(Equal(HibernationConditionReasonHibernated))
+	})
+
+	It("set the cluster as not hibernated when at least Pod is still alive", func(ctx SpecContext) {
+		cluster := apiv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					HibernationAnnotationName: HibernationOn,
+				},
+			},
+		}
+
+		EnrichStatus(ctx, &cluster, []corev1.Pod{{}})
+		hibernationCondition := meta.FindStatusCondition(cluster.Status.Conditions, HibernationConditionType)
+		Expect(hibernationCondition).ToNot(BeNil())
+		Expect(hibernationCondition.Status).To(Equal(metav1.ConditionFalse))
+		Expect(hibernationCondition.Reason).To(Equal(HibernationConditionReasonDeletingPods))
+	})
+
+	It("waits for Pod to be deleted gracefully", func(ctx SpecContext) {
+		cluster := apiv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					HibernationAnnotationName: HibernationOn,
+				},
+			},
+		}
+
+		now := metav1.Now()
+		pods := []corev1.Pod{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					DeletionTimestamp: &now,
+				},
+			},
+		}
+		EnrichStatus(ctx, &cluster, pods)
+
+		hibernationCondition := meta.FindStatusCondition(cluster.Status.Conditions, HibernationConditionType)
+		Expect(hibernationCondition).ToNot(BeNil())
+		Expect(hibernationCondition.Status).To(Equal(metav1.ConditionFalse))
+		Expect(hibernationCondition.Reason).To(Equal(HibernationConditionReasonWaitingPodsDeletion))
+	})
+})

--- a/pkg/reconciler/hibernation/status_test.go
+++ b/pkg/reconciler/hibernation/status_test.go
@@ -28,12 +28,12 @@ import (
 )
 
 var _ = Describe("Hibernation annotation management", func() {
-	It("classifies clusters with not annotation as not hibernated", func() {
+	It("classifies clusters with no annotation as not hibernated", func() {
 		cluster := apiv1.Cluster{}
 		Expect(getHibernationAnnotationValue(&cluster)).To(BeFalse())
 	})
 
-	It("correctly handle on/off values", func() {
+	It("correctly handles on/off values", func() {
 		cluster := apiv1.Cluster{
 			ObjectMeta: metav1.ObjectMeta{
 				Annotations: map[string]string{
@@ -67,7 +67,7 @@ var _ = Describe("Status enrichment", func() {
 		Expect(cluster.Status.Conditions).To(BeEmpty())
 	})
 
-	It("adds an error condition when the hibernation annotation have a wrong value", func(ctx SpecContext) {
+	It("adds an error condition when the hibernation annotation has a wrong value", func(ctx SpecContext) {
 		cluster := apiv1.Cluster{
 			ObjectMeta: metav1.ObjectMeta{
 				Annotations: map[string]string{
@@ -86,7 +86,7 @@ var _ = Describe("Status enrichment", func() {
 		Expect(hibernationCondition.Reason).To(Equal(HibernationConditionReasonWrongAnnotationValue))
 	})
 
-	It("removes the hibernation condition when not requested", func(ctx SpecContext) {
+	It("removes the hibernation condition when hibernation is turned off", func(ctx SpecContext) {
 		cluster := apiv1.Cluster{
 			ObjectMeta: metav1.ObjectMeta{
 				Annotations: map[string]string{
@@ -109,7 +109,7 @@ var _ = Describe("Status enrichment", func() {
 		Expect(hibernationCondition).To(BeNil())
 	})
 
-	It("set the cluster as hibernated when every Pod have been deleted", func(ctx SpecContext) {
+	It("sets the cluster as hibernated when all Pods have been deleted", func(ctx SpecContext) {
 		cluster := apiv1.Cluster{
 			ObjectMeta: metav1.ObjectMeta{
 				Annotations: map[string]string{
@@ -128,7 +128,7 @@ var _ = Describe("Status enrichment", func() {
 		Expect(hibernationCondition.Reason).To(Equal(HibernationConditionReasonHibernated))
 	})
 
-	It("set the cluster as not hibernated when at least Pod is still alive", func(ctx SpecContext) {
+	It("sets the cluster as not hibernated when at least one Pod is present", func(ctx SpecContext) {
 		cluster := apiv1.Cluster{
 			ObjectMeta: metav1.ObjectMeta{
 				Annotations: map[string]string{
@@ -147,7 +147,7 @@ var _ = Describe("Status enrichment", func() {
 		Expect(hibernationCondition.Reason).To(Equal(HibernationConditionReasonDeletingPods))
 	})
 
-	It("doesn't work when the cluster is not ready", func(ctx SpecContext) {
+	It("doesn't enrich the status while the cluster is not ready", func(ctx SpecContext) {
 		cluster := apiv1.Cluster{
 			ObjectMeta: metav1.ObjectMeta{
 				Annotations: map[string]string{
@@ -164,7 +164,7 @@ var _ = Describe("Status enrichment", func() {
 		Expect(hibernationCondition).To(BeNil())
 	})
 
-	It("waits for Pod to be deleted gracefully", func(ctx SpecContext) {
+	It("waits for each Pod to be deleted gracefully", func(ctx SpecContext) {
 		cluster := apiv1.Cluster{
 			ObjectMeta: metav1.ObjectMeta{
 				Annotations: map[string]string{

--- a/pkg/reconciler/hibernation/suite_test.go
+++ b/pkg/reconciler/hibernation/suite_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright The CloudNativePG Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hibernation
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestHibernation(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Hibernation reconciler")
+}

--- a/tests/e2e/declarative_hibernation_test.go
+++ b/tests/e2e/declarative_hibernation_test.go
@@ -1,0 +1,110 @@
+package e2e
+
+import (
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/types"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/reconciler/hibernation"
+	"github.com/cloudnative-pg/cloudnative-pg/tests"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Cluster declarative hibernation", func() {
+	const (
+		sampleFileCluster = fixturesDir + "/base/cluster-storage-class.yaml.template"
+		level             = tests.Medium
+		tableName         = "test"
+	)
+
+	var namespace string
+	BeforeEach(func() {
+		if testLevelEnv.Depth < int(level) {
+			Skip("Test depth is lower than the amount requested for this test")
+		}
+	})
+
+	It("hibernates an existing cluster", func(ctx SpecContext) {
+		var cluster apiv1.Cluster
+
+		namespace = "declarative-hibernation"
+		clusterName, err := env.GetResourceNameFromYAML(sampleFileCluster)
+		Expect(err).ToNot(HaveOccurred())
+		// Create a cluster in a namespace we'll delete after the test
+		err = env.CreateNamespace(namespace)
+		Expect(err).ToNot(HaveOccurred())
+		namespacedName := types.NamespacedName{
+			Namespace: namespace,
+			Name:      clusterName,
+		}
+
+		DeferCleanup(func() error {
+			if CurrentSpecReport().Failed() {
+				env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
+			}
+			return env.DeleteNamespace(namespace)
+		})
+
+		By("creating a new cluster", func() {
+			AssertCreateCluster(namespace, clusterName, sampleFileCluster, env)
+			// Write a table and some data on the "app" database
+			AssertCreateTestData(namespace, clusterName, tableName, psqlClientPod)
+		})
+
+		By("hibernating the new cluster", func() {
+			Expect(env.Client.Get(ctx, namespacedName, &cluster)).To(Succeed())
+			if cluster.Annotations == nil {
+				cluster.Annotations = make(map[string]string)
+			}
+			originCluster := cluster.DeepCopy()
+			cluster.Annotations[hibernation.HibernationAnnotationName] = hibernation.HibernationOn
+
+			Expect(env.Client.Patch(ctx, &cluster, ctrlclient.MergeFrom(originCluster))).To(Succeed())
+		})
+
+		By("waiting for the cluster to be hibernated correctly", func() {
+			Eventually(func(g Gomega) {
+				g.Expect(env.Client.Get(ctx, namespacedName, &cluster)).To(Succeed())
+				g.Expect(meta.IsStatusConditionTrue(cluster.Status.Conditions, hibernation.HibernationConditionType)).To(BeTrue())
+			}, 300).Should(Succeed())
+		})
+
+		By("verifying that the Pods have been deleted for the cluster", func() {
+			podList, _ := env.GetClusterPodList(namespace, clusterName)
+			Expect(len(podList.Items)).Should(BeEquivalentTo(0))
+		})
+
+		By("rehydrating the cluster", func() {
+			Expect(env.Client.Get(ctx, namespacedName, &cluster)).To(Succeed())
+			if cluster.Annotations == nil {
+				cluster.Annotations = make(map[string]string)
+			}
+			originCluster := cluster.DeepCopy()
+			cluster.Annotations[hibernation.HibernationAnnotationName] = hibernation.HibernationOff
+			Expect(env.Client.Patch(ctx, &cluster, ctrlclient.MergeFrom(originCluster))).To(Succeed())
+		})
+
+		By("waiting for the condition to be removed", func() {
+			Eventually(func(g Gomega) {
+				g.Expect(env.Client.Get(ctx, namespacedName, &cluster)).To(Succeed())
+
+				condition := meta.FindStatusCondition(cluster.Status.Conditions, hibernation.HibernationConditionType)
+				g.Expect(condition).To(BeNil())
+			}, 300).Should(Succeed())
+		})
+
+		By("waiting for the Pods to be recreated", func() {
+			Eventually(func(g Gomega) {
+				podList, _ := env.GetClusterPodList(namespace, clusterName)
+				g.Expect(len(podList.Items)).Should(BeEquivalentTo(cluster.Spec.Instances))
+			}, 300).Should(Succeed())
+		})
+
+		By("verifying the data has been preserved", func() {
+			AssertDataExpectedCount(namespace, clusterName, tableName, 2, psqlClientPod)
+		})
+	})
+})


### PR DESCRIPTION
This patch adds a declarative hibernation feature allowing the user to temporarily suspend the execution of a PostgreSQL cluster to save CPU time.

Clusters can be hibernated annotating them with
`cnpg.io/hibernation=on`. They will be rehydrated when the annotation will be removed or set to `off`.