### PR TITLE
fix: affinity.nodeAffinity not properly propagated to pods

### DIFF
--- a/pkg/specs/pods.go
+++ b/pkg/specs/pods.go
@@ -221,7 +221,8 @@ func CreateAffinitySection(clusterName string, config apiv1.AffinityConfiguratio
 	affinity := CreateGeneratedAntiAffinity(clusterName, config)
 
 	if config.AdditionalPodAffinity == nil &&
-		config.AdditionalPodAntiAffinity == nil {
+		config.AdditionalPodAntiAffinity == nil &&
+		config.NodeAffinity == nil {
 		return affinity
 	}
 

--- a/pkg/specs/pods_test.go
+++ b/pkg/specs/pods_test.go
@@ -110,6 +110,36 @@ var _ = Describe("Create affinity section", func() {
 		Expect(affinity).To(BeNil())
 	})
 
+	It("sets node affinity if provided", func() {
+		config := v1.AffinityConfiguration{
+			NodeAffinity: &corev1.NodeAffinity{
+				RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+					NodeSelectorTerms: []corev1.NodeSelectorTerm{
+						{
+							MatchExpressions: []corev1.NodeSelectorRequirement{
+								{
+									Key:      "node-label",
+									Operator: corev1.NodeSelectorOpExists,
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		affinity := CreateAffinitySection(clusterName, config)
+		Expect(affinity).NotTo(BeNil())
+		Expect(affinity.NodeAffinity).ToNot(BeNil())
+		Expect(affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution).NotTo(BeNil())
+		Expect(affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution).To(
+			BeEquivalentTo(&corev1.NodeSelector{
+				NodeSelectorTerms: []corev1.NodeSelectorTerm{
+					{MatchExpressions: []corev1.NodeSelectorRequirement{{Key: "node-label", Operator: corev1.NodeSelectorOpExists}}},
+				},
+			}),
+		)
+	})
+
 	When("given additional affinity terms", func() {
 		When("generated pod anti-affinity is enabled", func() {
 			It("sets both pod affinity and anti-affinity correctly if passed and set to required", func() {


### PR DESCRIPTION
Bug Fix: When a user only specifies `affinity.nodeAffinity` no `affinity` section is set in database pods.

This is because of an early return from the `CreateAffinitySection` section that checks whether none of `AdditionalPodAffinity` or `AdditionalPodAntiAffinity` is set, but it doesn't do the same for `NodeAffinity`.

This patch adds an extra spec for this case and the fix to the early return in `pkg/specs/pods.go#CreateAffinitySection`.

P.S. I don't have much experience with Go and I am not sure if I've matched your code-style 100% as I don't completely understand it. Feel free to directly apply changes.

Closes #1662 