### PR TITLE
feat: kubectl-cnpg psql subcommand

### DIFF
--- a/cmd/kubectl-cnpg/main.go
+++ b/cmd/kubectl-cnpg/main.go
@@ -36,6 +36,7 @@ import (
 	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/plugin/maintenance"
 	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/plugin/pgbench"
 	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/plugin/promote"
+	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/plugin/psql"
 	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/plugin/reload"
 	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/plugin/report"
 	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/plugin/restart"
@@ -78,6 +79,7 @@ func main() {
 	rootCmd.AddCommand(status.NewCmd())
 	rootCmd.AddCommand(versions.NewCmd())
 	rootCmd.AddCommand(backup.NewCmd())
+	rootCmd.AddCommand(psql.NewCmd())
 
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)

--- a/docs/src/cnpg-plugin.md
+++ b/docs/src/cnpg-plugin.md
@@ -800,6 +800,7 @@ By default, the command will connect to the primary instance. The user can
 select to work against a replica by using the `--replica` option:
 
 ```shell
+kubectl cnpg psql --replica cluster-example
 psql (15.2 (Debian 15.2-1.pgdg110+1))
 
 Type "help" for help.

--- a/docs/src/cnpg-plugin.md
+++ b/docs/src/cnpg-plugin.md
@@ -797,7 +797,7 @@ postgres=#
 ```
 
 By default, the command will connect to the primary instance. The user can
-select to work against a replica by using the `--role` flag:
+select to work against a replica by using the `--replica` option:
 
 ```shell
 psql (15.2 (Debian 15.2-1.pgdg110+1))

--- a/docs/src/cnpg-plugin.md
+++ b/docs/src/cnpg-plugin.md
@@ -814,4 +814,4 @@ postgres=# \q
 ```
 
 This command will start `kubectl exec`, and the `kubectl` executable must be
-reachable in PATH to correctly work.
+reachable in your `PATH` variable to correctly work.

--- a/docs/src/cnpg-plugin.md
+++ b/docs/src/cnpg-plugin.md
@@ -779,8 +779,13 @@ for more information about backup target.
 
 ### Launching psql
 
-The `kubectl cnpg psql` command start a new PostgreSQL interactive front-end
-process (psql) connected to an existing Postgres cluster.
+The `kubectl cnpg psql` command starts a new PostgreSQL interactive front-end
+process (psql) connected to an existing Postgres cluster, as if you were running
+it from the actual pod. This means that you will be using the `postgres` user.
+
+!!! Important
+    As you will be connecting as `postgres` user, in production environments this
+    method should be used with extreme care, by authorized personnel only.
 
 ```shell
 kubectl cnpg psql cluster-example

--- a/docs/src/cnpg-plugin.md
+++ b/docs/src/cnpg-plugin.md
@@ -776,3 +776,37 @@ By default, new created backup will use the backup target policy defined
 in cluster to choose which instance to run on. You can also use `--backup-target` 
 option to override this policy. please refer to [Backup and Recovery](backup_recovery.md)
 for more information about backup target.
+
+### Launching psql
+
+The `kubectl cnpg psql` command start a new PostgreSQL interactive front-end
+process (psql) connected to an existing Postgres cluster.
+
+```shell
+kubectl cnpg psql cluster-example
+
+psql (15.2 (Debian 15.2-1.pgdg110+1))
+Type "help" for help.
+
+postgres=#
+```
+
+By default, the command will connect to the primary instance. The user can
+select to work against a replica by using the `--role` flag:
+
+```shell
+psql (15.2 (Debian 15.2-1.pgdg110+1))
+
+Type "help" for help.
+
+postgres=# select pg_is_in_recovery();
+ pg_is_in_recovery
+-------------------
+ t
+(1 row)
+
+postgres=# \q
+```
+
+This command will start `kubectl exec`, and the `kubectl` executable must be
+reachable in PATH to correctly work.

--- a/internal/cmd/plugin/psql/cmd.go
+++ b/internal/cmd/plugin/psql/cmd.go
@@ -60,7 +60,7 @@ func NewCmd() *cobra.Command {
 		&replica,
 		"replica",
 		false,
-		"Connect to a replica (defaults to connecting to a primary)",
+		"Connects to the first replica on the pod list (by default connects to the primary)",
 	)
 
 	cmd.Flags().BoolVarP(

--- a/internal/cmd/plugin/psql/cmd.go
+++ b/internal/cmd/plugin/psql/cmd.go
@@ -1,0 +1,102 @@
+/*
+Copyright The CloudNativePG Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package psql
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/plugin"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/specs"
+)
+
+// NewCmd creates the "psql" command
+func NewCmd() *cobra.Command {
+	var role string
+	var allocateTTY bool
+	var passStdin bool
+
+	cmd := &cobra.Command{
+		Use:   "psql [cluster] [-- psqlArgs...]",
+		Short: "Start a psql session targeting a CloudNativePG cluster",
+		Args:  validatePsqlArgs,
+		Long:  "This command will start an interactive psql session inside a PostgreSQL Pod created by CloudNativePG.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clusterName := args[0]
+			psqlArgs := args[1:]
+
+			if role != specs.ClusterRoleLabelPrimary && role != specs.ClusterRoleLabelReplica {
+				return fmt.Errorf("invalid pod role")
+			}
+
+			psqlOptions := psqlCommandOptions{
+				role:        role,
+				namespace:   plugin.Namespace,
+				allocateTTY: allocateTTY,
+				passStdin:   passStdin,
+				args:        psqlArgs,
+				name:        clusterName,
+			}
+
+			psqlCommand, err := newPsqlCommand(cmd.Context(), psqlOptions)
+			if err != nil {
+				return err
+			}
+
+			return psqlCommand.exec()
+		},
+	}
+
+	cmd.Flags().StringVarP(
+		&role,
+		"role",
+		"r",
+		"primary",
+		"The role of the Pod to connect to. Valid values are 'primary' and 'replica'",
+	)
+
+	cmd.Flags().BoolVarP(
+		&allocateTTY,
+		"tty",
+		"t",
+		true,
+		"Whether to allocate a TTY for the psql process",
+	)
+
+	cmd.Flags().BoolVarP(
+		&passStdin,
+		"stdin",
+		"i",
+		true,
+		"Whether to pass stdin to the container",
+	)
+
+	return cmd
+}
+
+func validatePsqlArgs(cmd *cobra.Command, args []string) error {
+	if err := cobra.MinimumNArgs(1)(cmd, args); err != nil {
+		return err
+	}
+
+	if cmd.ArgsLenAtDash() > 1 {
+		return fmt.Errorf("psqlArgs should be passed after -- delimitator")
+	}
+
+	return nil
+}

--- a/internal/cmd/plugin/psql/cmd.go
+++ b/internal/cmd/plugin/psql/cmd.go
@@ -22,12 +22,11 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/plugin"
-	"github.com/cloudnative-pg/cloudnative-pg/pkg/specs"
 )
 
 // NewCmd creates the "psql" command
 func NewCmd() *cobra.Command {
-	var role string
+	var replica bool
 	var allocateTTY bool
 	var passStdin bool
 
@@ -39,13 +38,8 @@ func NewCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			clusterName := args[0]
 			psqlArgs := args[1:]
-
-			if role != specs.ClusterRoleLabelPrimary && role != specs.ClusterRoleLabelReplica {
-				return fmt.Errorf("invalid pod role")
-			}
-
 			psqlOptions := psqlCommandOptions{
-				role:        role,
+				replica:     replica,
 				namespace:   plugin.Namespace,
 				allocateTTY: allocateTTY,
 				passStdin:   passStdin,
@@ -62,12 +56,11 @@ func NewCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(
-		&role,
-		"role",
-		"r",
-		"primary",
-		"The role of the Pod to connect to. Valid values are 'primary' and 'replica'",
+	cmd.Flags().BoolVar(
+		&replica,
+		"replica",
+		false,
+		"Connect to a replica (defaults to connecting to a primary)",
 	)
 
 	cmd.Flags().BoolVarP(

--- a/internal/cmd/plugin/psql/doc.go
+++ b/internal/cmd/plugin/psql/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright The CloudNativePG Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package psql implements the `kubectl cnpg psql` command
+package psql

--- a/internal/cmd/plugin/psql/psql.go
+++ b/internal/cmd/plugin/psql/psql.go
@@ -1,0 +1,161 @@
+/*
+Copyright The CloudNativePG Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package psql
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"syscall"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/plugin"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/specs"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
+)
+
+const (
+	// kubectlCommand is used to execute a command inside a Pod
+	kubectlCommand = "kubectl"
+)
+
+// psqlCommand is the launcher of `psql` with `kubectl exec`
+type psqlCommand struct {
+	psqlCommandOptions
+
+	// The list of possible pods where to launch psql
+	podList []corev1.Pod
+
+	// The path of kubectl
+	kubectlPath string
+}
+
+// psqlCommandOptions are the options required to start psql
+type psqlCommandOptions struct {
+	// The role of the pod where we should launch psql
+	role string
+
+	// The cluster name
+	name string
+
+	// The namespace where we're working in
+	namespace string
+
+	// Whether we should we allocate a TTY for psql
+	allocateTTY bool
+
+	// Whether we should we pass stdin to psql
+	passStdin bool
+
+	// Arguments to pass to psql
+	args []string
+}
+
+// newPsqlCommand creates a new psql command
+func newPsqlCommand(
+	ctx context.Context,
+	options psqlCommandOptions,
+) (*psqlCommand, error) {
+	var pods corev1.PodList
+	if err := plugin.Client.List(
+		ctx,
+		&pods,
+		client.MatchingLabels{utils.ClusterLabelName: options.name},
+		client.InNamespace(plugin.Namespace),
+	); err != nil {
+		return nil, err
+	}
+
+	kubectlPath, err := exec.LookPath(kubectlCommand)
+	if err != nil {
+		return nil, fmt.Errorf("while getting kubectl path: %w", err)
+	}
+
+	return &psqlCommand{
+		psqlCommandOptions: options,
+		podList:            pods.Items,
+		kubectlPath:        kubectlPath,
+	}, nil
+}
+
+// getKubectlInvocation gets the kubectl command to be executed
+func (psql *psqlCommand) getKubectlInvocation() ([]string, error) {
+	result := make([]string, 0, 11+len(psql.args))
+	result = append(result, "kubectl", "exec")
+
+	if psql.allocateTTY {
+		result = append(result, "-t")
+	}
+	if psql.passStdin {
+		result = append(result, "-i")
+	}
+	if len(psql.namespace) > 0 {
+		result = append(result, "-n", psql.namespace)
+	}
+	result = append(result, "-c", specs.PostgresContainerName)
+
+	podName, err := psql.getPodName()
+	if err != nil {
+		return nil, err
+	}
+
+	result = append(result, podName)
+	result = append(result, "--", "psql")
+	result = append(result, psql.args...)
+	return result, nil
+}
+
+// getPodName get the first Pod name with the required role
+func (psql *psqlCommand) getPodName() (string, error) {
+	for i := range psql.podList {
+		podRole := psql.podList[i].Labels[specs.ClusterRoleLabelName]
+		if podRole == psql.role {
+			return psql.podList[i].Name, nil
+		}
+	}
+
+	return "", &ErrMissingPod{role: psql.role}
+}
+
+// exec replaces the current process with a `kubectl exec` invocation.
+// This function won't return
+func (psql *psqlCommand) exec() error {
+	kubectlExec, err := psql.getKubectlInvocation()
+	if err != nil {
+		return err
+	}
+
+	err = syscall.Exec(psql.kubectlPath, kubectlExec, os.Environ()) // #nosec
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ErrMissingPod is raised when we can't find a Pod having the desired role
+type ErrMissingPod struct {
+	role string
+}
+
+// Error implements the error interface
+func (err *ErrMissingPod) Error() string {
+	return fmt.Sprintf("cannot find Pod with role \"%s\"", err.role)
+}

--- a/internal/cmd/plugin/psql/psql_test.go
+++ b/internal/cmd/plugin/psql/psql_test.go
@@ -1,0 +1,132 @@
+/*
+Copyright The CloudNativePG Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package psql
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/specs"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("psql launcher", func() {
+	podList := []corev1.Pod{
+		fakePod("cluster-example-1", specs.ClusterRoleLabelReplica),
+		fakePod("cluster-example-2", specs.ClusterRoleLabelPrimary),
+		fakePod("cluster-example-3", specs.ClusterRoleLabelReplica),
+	}
+
+	It("selects the correct Pod when looking for a primary", func() {
+		cmd := psqlCommand{
+			psqlCommandOptions: psqlCommandOptions{
+				role: specs.ClusterRoleLabelPrimary,
+			},
+			podList: podList,
+		}
+		Expect(cmd.getPodName()).To(Equal("cluster-example-2"))
+	})
+
+	It("selects the correct Pod when looking for a replica", func() {
+		cmd := psqlCommand{
+			psqlCommandOptions: psqlCommandOptions{
+				role: specs.ClusterRoleLabelReplica,
+			},
+			podList: podList,
+		}
+		Expect(cmd.getPodName()).To(Equal("cluster-example-1"))
+	})
+
+	It("raises an error when a Pod cannot be found", func() {
+		cmd := psqlCommand{
+			psqlCommandOptions: psqlCommandOptions{
+				role: "non-existing-role",
+			},
+			podList: podList,
+		}
+
+		_, err := cmd.getPodName()
+		Expect(err).ToNot(BeNil())
+		Expect(err.(*ErrMissingPod)).ToNot(BeNil())
+	})
+
+	It("correctly composes a kubectl exec command line", func() {
+		cmd := psqlCommand{
+			psqlCommandOptions: psqlCommandOptions{
+				role:        specs.ClusterRoleLabelReplica,
+				allocateTTY: true,
+				passStdin:   true,
+				namespace:   "default",
+			},
+			podList: podList,
+		}
+		Expect(cmd.getKubectlInvocation()).To(ConsistOf(
+			"kubectl",
+			"exec",
+			"-t",
+			"-i",
+			"-n",
+			"default",
+			"-c",
+			"postgres",
+			"cluster-example-1",
+			"--",
+			"psql",
+		))
+	})
+
+	It("correctly composes a kubectl exec command line with psql args", func() {
+		cmd := psqlCommand{
+			psqlCommandOptions: psqlCommandOptions{
+				role:      specs.ClusterRoleLabelReplica,
+				namespace: "default",
+				args: []string{
+					"-c",
+					"select 1",
+				},
+			},
+			podList: podList,
+		}
+		Expect(cmd.getKubectlInvocation()).To(ConsistOf(
+			"kubectl",
+			"exec",
+			"-n",
+			"default",
+			"-c",
+			"postgres",
+			"cluster-example-1",
+			"--",
+			"psql",
+			"-c",
+			"select 1",
+		))
+	})
+})
+
+func fakePod(name, role string) corev1.Pod {
+	return corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+			Labels: map[string]string{
+				specs.ClusterRoleLabelName: role,
+			},
+		},
+	}
+}

--- a/internal/cmd/plugin/psql/psql_test.go
+++ b/internal/cmd/plugin/psql/psql_test.go
@@ -36,7 +36,7 @@ var _ = Describe("psql launcher", func() {
 	It("selects the correct Pod when looking for a primary", func() {
 		cmd := psqlCommand{
 			psqlCommandOptions: psqlCommandOptions{
-				role: specs.ClusterRoleLabelPrimary,
+				replica: false,
 			},
 			podList: podList,
 		}
@@ -46,7 +46,7 @@ var _ = Describe("psql launcher", func() {
 	It("selects the correct Pod when looking for a replica", func() {
 		cmd := psqlCommand{
 			psqlCommandOptions: psqlCommandOptions{
-				role: specs.ClusterRoleLabelReplica,
+				replica: true,
 			},
 			podList: podList,
 		}
@@ -54,11 +54,17 @@ var _ = Describe("psql launcher", func() {
 	})
 
 	It("raises an error when a Pod cannot be found", func() {
+		fakePodList := []corev1.Pod{
+			fakePod("cluster-example-1", "guitar"),
+			fakePod("cluster-example-2", "piano"),
+			fakePod("cluster-example-3", "oboe"),
+		}
+
 		cmd := psqlCommand{
 			psqlCommandOptions: psqlCommandOptions{
-				role: "non-existing-role",
+				replica: false,
 			},
-			podList: podList,
+			podList: fakePodList,
 		}
 
 		_, err := cmd.getPodName()
@@ -69,7 +75,7 @@ var _ = Describe("psql launcher", func() {
 	It("correctly composes a kubectl exec command line", func() {
 		cmd := psqlCommand{
 			psqlCommandOptions: psqlCommandOptions{
-				role:        specs.ClusterRoleLabelReplica,
+				replica:     true,
 				allocateTTY: true,
 				passStdin:   true,
 				namespace:   "default",
@@ -94,7 +100,7 @@ var _ = Describe("psql launcher", func() {
 	It("correctly composes a kubectl exec command line with psql args", func() {
 		cmd := psqlCommand{
 			psqlCommandOptions: psqlCommandOptions{
-				role:      specs.ClusterRoleLabelReplica,
+				replica:   true,
 				namespace: "default",
 				args: []string{
 					"-c",

--- a/internal/cmd/plugin/psql/suite_test.go
+++ b/internal/cmd/plugin/psql/suite_test.go
@@ -1,0 +1,33 @@
+/*
+Copyright The CloudNativePG Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package psql
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// These tests use Ginkgo (BDD-style Go testing framework). Refer to
+// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
+
+func TestPsql(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecs(t, "psql test suite")
+}


### PR DESCRIPTION
With `kubectl cnpg psql` the user can start a `psql` connected to a
CloudNativePG cluster.

The user can select a role and additional parameters to be passed
to `psql`.

Closes: #1667 