### PR TITLE
feat: improve compatibility with linkerd

### DIFF
--- a/.wordlist-en-custom.txt
+++ b/.wordlist-en-custom.txt
@@ -160,6 +160,7 @@ LTS
 LastBackupFailed
 LastBackupSucceeded
 Lifecycle
+Linkerd
 Linode
 ListMeta
 Liveness

--- a/internal/cmd/manager/instance/initdb/cmd.go
+++ b/internal/cmd/manager/instance/initdb/cmd.go
@@ -26,6 +26,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/cloudnative-pg/cloudnative-pg/internal/management/istio"
+	"github.com/cloudnative-pg/cloudnative-pg/internal/management/linkerd"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/log"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres"
@@ -103,7 +104,15 @@ func NewCmd() *cobra.Command {
 			return initSubCommand(ctx, info)
 		},
 		PostRunE: func(cmd *cobra.Command, args []string) error {
-			return istio.TryInvokeQuitEndpoint(cmd.Context())
+			if err := istio.TryInvokeQuitEndpoint(cmd.Context()); err != nil {
+				return err
+			}
+
+			if err := linkerd.TryInvokeShutdownEndpoint(cmd.Context()); err != nil {
+				return err
+			}
+
+			return nil
 		},
 	}
 

--- a/internal/cmd/manager/instance/join/cmd.go
+++ b/internal/cmd/manager/instance/join/cmd.go
@@ -27,6 +27,7 @@ import (
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/internal/management/controller"
 	"github.com/cloudnative-pg/cloudnative-pg/internal/management/istio"
+	"github.com/cloudnative-pg/cloudnative-pg/internal/management/linkerd"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/log"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres"
@@ -71,7 +72,15 @@ func NewCmd() *cobra.Command {
 			return joinSubCommand(ctx, instance, info)
 		},
 		PostRunE: func(cmd *cobra.Command, args []string) error {
-			return istio.TryInvokeQuitEndpoint(cmd.Context())
+			if err := istio.TryInvokeQuitEndpoint(cmd.Context()); err != nil {
+				return err
+			}
+
+			if err := linkerd.TryInvokeShutdownEndpoint(cmd.Context()); err != nil {
+				return err
+			}
+
+			return nil
 		},
 	}
 

--- a/internal/cmd/manager/instance/pgbasebackup/cmd.go
+++ b/internal/cmd/manager/instance/pgbasebackup/cmd.go
@@ -27,6 +27,7 @@ import (
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/internal/management/istio"
+	"github.com/cloudnative-pg/cloudnative-pg/internal/management/linkerd"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/external"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/log"
@@ -79,7 +80,15 @@ func NewCmd() *cobra.Command {
 			return err
 		},
 		PostRunE: func(cmd *cobra.Command, args []string) error {
-			return istio.TryInvokeQuitEndpoint(cmd.Context())
+			if err := istio.TryInvokeQuitEndpoint(cmd.Context()); err != nil {
+				return err
+			}
+
+			if err := linkerd.TryInvokeShutdownEndpoint(cmd.Context()); err != nil {
+				return err
+			}
+
+			return nil
 		},
 	}
 

--- a/internal/cmd/manager/instance/restore/cmd.go
+++ b/internal/cmd/manager/instance/restore/cmd.go
@@ -25,6 +25,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/cloudnative-pg/cloudnative-pg/internal/management/istio"
+	"github.com/cloudnative-pg/cloudnative-pg/internal/management/linkerd"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/log"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres"
@@ -59,7 +60,15 @@ func NewCmd() *cobra.Command {
 			return restoreSubCommand(ctx, info)
 		},
 		PostRunE: func(cmd *cobra.Command, args []string) error {
-			return istio.TryInvokeQuitEndpoint(cmd.Context())
+			if err := istio.TryInvokeQuitEndpoint(cmd.Context()); err != nil {
+				return err
+			}
+
+			if err := linkerd.TryInvokeShutdownEndpoint(cmd.Context()); err != nil {
+				return err
+			}
+
+			return nil
 		},
 	}
 

--- a/internal/cmd/manager/instance/run/cmd.go
+++ b/internal/cmd/manager/instance/run/cmd.go
@@ -38,6 +38,7 @@ import (
 	"github.com/cloudnative-pg/cloudnative-pg/internal/management/controller"
 	"github.com/cloudnative-pg/cloudnative-pg/internal/management/controller/slots/runner"
 	"github.com/cloudnative-pg/cloudnative-pg/internal/management/istio"
+	"github.com/cloudnative-pg/cloudnative-pg/internal/management/linkerd"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/concurrency"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/log"
@@ -85,7 +86,15 @@ func NewCmd() *cobra.Command {
 			})
 		},
 		PostRunE: func(cmd *cobra.Command, args []string) error {
-			return istio.TryInvokeQuitEndpoint(cmd.Context())
+			if err := istio.TryInvokeQuitEndpoint(cmd.Context()); err != nil {
+				return err
+			}
+
+			if err := linkerd.TryInvokeShutdownEndpoint(cmd.Context()); err != nil {
+				return err
+			}
+
+			return nil
 		},
 	}
 

--- a/internal/management/linkerd/doc.go
+++ b/internal/management/linkerd/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright The CloudNativePG Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package linkerd implements functions needed to integrate with linkerd-proxy
+package linkerd

--- a/internal/management/linkerd/linkerd.go
+++ b/internal/management/linkerd/linkerd.go
@@ -1,0 +1,52 @@
+/*
+Copyright The CloudNativePG Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package linkerd
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"os"
+	"syscall"
+	"time"
+
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/log"
+)
+
+// TryInvokeShutdownEndpoint executes a post request on the /shutdown endpoint. Returns any errors encountered if
+// the service exists
+func TryInvokeShutdownEndpoint(ctx context.Context) error {
+	const endpoint = "http://localhost:4191/shutdown"
+	logger := log.FromContext(ctx)
+
+	clientHTTP := http.Client{Timeout: 5 * time.Second}
+	resp, err := clientHTTP.Post(endpoint, "", nil)
+
+	if errors.Is(err, syscall.ECONNREFUSED) || os.IsTimeout(err) {
+		return nil
+	}
+
+	if err != nil {
+		return err
+	}
+
+	if closeErr := resp.Body.Close(); closeErr != nil {
+		logger.Error(closeErr, "unable to close the response body", "endpoint", endpoint)
+	}
+
+	return nil
+}


### PR DESCRIPTION
Addresses the issue when the job's primary container is completed, while the pod which the Linkerd Proxy has injected in, won't be marked as completed since the sidecar keeps running.

Closes #1678 