### PR TITLE
tests: relax E2E timeouts and make SQL statements idempotent

### DIFF
--- a/tests/e2e/cluster_microservice_test.go
+++ b/tests/e2e/cluster_microservice_test.go
@@ -195,8 +195,9 @@ func assertCreateTableWithDataOnSourceCluster(
 		rwService := fmt.Sprintf("%v-rw.%v.svc", clusterName, namespace)
 		By("create user, insert record in new table, assign new user as owner "+
 			"and grant read only to app user", func() {
-			query := fmt.Sprintf("CREATE USER micro;CREATE TABLE %v AS VALUES (1), "+
-				"(2);ALTER TABLE %v OWNER TO micro;grant select on %v to app;", tableName, tableName, tableName)
+			query := fmt.Sprintf("DROP USER IF EXISTS micro; CREATE USER micro; "+
+				"CREATE TABLE IF NOT EXISTS %[1]v AS VALUES (1),(2); "+
+				"ALTER TABLE %[1]v OWNER TO micro;grant select on %[1]v to app;", tableName)
 			_, _, err = testsUtils.RunQueryFromPod(
 				psqlClientPod, rwService, "app", superUser, generatedSuperuserPassword, query, env)
 			Expect(err).ToNot(HaveOccurred())
@@ -294,7 +295,7 @@ func assertImportRenamesSelectedDatabase(
 		// create test data and insert records
 		_, _, err = testsUtils.RunQueryFromPod(psqlClientPod, rwService,
 			dbToImport, superUser, getSuperUserPassword,
-			fmt.Sprintf("CREATE TABLE %s AS VALUES (1),(2);", tableName), env)
+			fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s AS VALUES (1),(2);", tableName), env)
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/tests/e2e/cluster_monolithic_test.go
+++ b/tests/e2e/cluster_monolithic_test.go
@@ -143,7 +143,7 @@ var _ = Describe("Imports with Monolithic Approach", Label(tests.LabelImportingD
 
 			// create test data and insert some records in both databases
 			for _, database := range sourceDatabases {
-				query := fmt.Sprintf("CREATE TABLE %v AS VALUES (1), (2);", tableName)
+				query := fmt.Sprintf("CREATE TABLE IF NOT EXISTS %v AS VALUES (1),(2);", tableName)
 				_, _, err = testsUtils.RunQueryFromPod(
 					psqlClientPod,
 					sourceClusterHost,

--- a/tests/e2e/cluster_setup_test.go
+++ b/tests/e2e/cluster_setup_test.go
@@ -65,7 +65,7 @@ var _ = Describe("Cluster setup", Label(tests.LabelSmoke, tests.LabelBasic), fun
 		})
 
 		By("being able to restart a killed pod without losing it", func() {
-			aSecond := time.Second
+			commandTimeout := time.Second * 10
 			timeout := 120
 			podName := clusterName + "-1"
 			pod := &corev1.Pod{}
@@ -82,7 +82,7 @@ var _ = Describe("Cluster setup", Label(tests.LabelSmoke, tests.LabelBasic), fun
 			Expect(err).NotTo(HaveOccurred())
 			host, err := testsUtils.GetHostName(namespace, clusterName, env)
 			Expect(err).NotTo(HaveOccurred())
-			query := "CREATE TABLE test (id bigserial PRIMARY KEY, t text)"
+			query := "CREATE TABLE IF NOT EXISTS test (id bigserial PRIMARY KEY, t text);"
 			_, _, err = testsUtils.RunQueryFromPod(
 				psqlClientPod,
 				host,
@@ -103,7 +103,7 @@ var _ = Describe("Cluster setup", Label(tests.LabelSmoke, tests.LabelBasic), fun
 					restart = data.RestartCount
 				}
 			}
-			_, _, err = env.EventuallyExecCommand(env.Ctx, *pod, specs.PostgresContainerName, &aSecond,
+			_, _, err = env.EventuallyExecCommand(env.Ctx, *pod, specs.PostgresContainerName, &commandTimeout,
 				"sh", "-c", "kill 1")
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(func() (int32, error) {

--- a/tests/e2e/configuration_update_test.go
+++ b/tests/e2e/configuration_update_test.go
@@ -51,7 +51,7 @@ var _ = Describe("Configuration update", Ordered, Label(tests.LabelClusterMetada
 		Namespace: namespace,
 		Name:      clusterName,
 	}
-	commandTimeout := time.Second * 5
+	commandTimeout := time.Second * 10
 	postgresParams := map[string]string{
 		"work_mem":                    "8MB",
 		"max_connections":             "110",
@@ -501,7 +501,7 @@ var _ = Describe("Configuration update with primaryUpdateMethod", Label(tests.La
 				podList, err := env.GetClusterPodList(namespace, clusterName)
 				Expect(err).ToNot(HaveOccurred())
 
-				commandTimeout := time.Second * 5
+				commandTimeout := time.Second * 10
 				for _, pod := range podList.Items {
 					Eventually(func() (int, error, error) {
 						stdout, _, err := env.ExecCommand(env.Ctx, pod, specs.PostgresContainerName, &commandTimeout,
@@ -522,7 +522,7 @@ var _ = Describe("Configuration update with primaryUpdateMethod", Label(tests.La
 			})
 
 			By("verifying that old primary was actually restarted", func() {
-				commandTimeout := time.Second * 5
+				commandTimeout := time.Second * 10
 				pod := corev1.Pod{}
 				err := env.Client.Get(env.Ctx, types.NamespacedName{
 					Namespace: namespace,
@@ -546,7 +546,7 @@ var _ = Describe("Configuration update with primaryUpdateMethod", Label(tests.La
 
 		It("work_mem config change should not require a restart", func() {
 			const expectedNewValueForWorkMem = "10MB"
-			commandTimeout := time.Second * 5
+			commandTimeout := time.Second * 10
 
 			By("updating work mem ", func() {
 				var cluster apiv1.Cluster

--- a/tests/e2e/eviction_test.go
+++ b/tests/e2e/eviction_test.go
@@ -96,7 +96,7 @@ var _ = Describe("Pod eviction", Serial, Label(tests.LabelDisruptive, tests.Labe
 				}
 				return fmt.Errorf("pod %v has not been evicted", pod.Name)
 			},
-			retry.Delay(time.Second),
+			retry.Delay(2*time.Second),
 			retry.Attempts(timeoutSeconds),
 		)
 		return err

--- a/tests/e2e/failover_test.go
+++ b/tests/e2e/failover_test.go
@@ -77,7 +77,7 @@ var _ = Describe("Failover", Label(tests.LabelSelfHealing), func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// Get the walreceiver pid
-			timeout := time.Second * 5
+			timeout := time.Second * 10
 			query := "SELECT pid FROM pg_stat_activity WHERE backend_type = 'walreceiver'"
 			out, _, err := env.EventuallyExecCommand(
 				env.Ctx, pausedPod, specs.PostgresContainerName, &timeout,
@@ -206,7 +206,7 @@ var _ = Describe("Failover", Label(tests.LabelSelfHealing), func() {
 			pausedPod := corev1.Pod{}
 			err = env.Client.Get(env.Ctx, namespacedPausedPodName, &pausedPod)
 			Expect(err).ToNot(HaveOccurred())
-			commandTimeout := time.Second * 5
+			commandTimeout := time.Second * 10
 			_, _, err = env.EventuallyExecCommand(env.Ctx, pausedPod, specs.PostgresContainerName,
 				&commandTimeout, "sh", "-c", fmt.Sprintf("kill -CONT %v", pid))
 			Expect(err).ToNot(HaveOccurred())

--- a/tests/e2e/fastswitchover_test.go
+++ b/tests/e2e/fastswitchover_test.go
@@ -137,8 +137,8 @@ func assertFastSwitchover(namespace, sampleFile, clusterName, webTestFile, webTe
 	})
 	By("preparing the db for the test scenario", func() {
 		// Create the table used by the scenario
-		query := "CREATE SCHEMA tps; " +
-			"CREATE TABLE tps.tl ( " +
+		query := "CREATE SCHEMA IF NOT EXISTS tps; " +
+			"CREATE TABLE IF NOT EXISTS tps.tl ( " +
 			"id BIGSERIAL" +
 			", timeline TEXT DEFAULT (substring(pg_walfile_name(" +
 			"    pg_current_wal_lsn()), 1, 8))" +
@@ -147,7 +147,7 @@ func assertFastSwitchover(namespace, sampleFile, clusterName, webTestFile, webTe
 			", PRIMARY KEY (id)" +
 			")"
 
-		commandTimeout := time.Second * 5
+		commandTimeout := time.Second * 10
 		primaryPod := &corev1.Pod{}
 		primaryPodNamespacedName := types.NamespacedName{
 			Namespace: namespace,
@@ -173,7 +173,7 @@ func assertFastSwitchover(namespace, sampleFile, clusterName, webTestFile, webTe
 			" -f " + webTestJob)
 		Expect(err).ToNot(HaveOccurred())
 
-		commandTimeout := time.Second * 5
+		commandTimeout := time.Second * 10
 		timeout := 60
 		primaryPodNamespacedName := types.NamespacedName{
 			Namespace: namespace,

--- a/tests/e2e/fencing_test.go
+++ b/tests/e2e/fencing_test.go
@@ -75,7 +75,7 @@ var _ = Describe("Fencing", Label(tests.LabelPlugin), func() {
 	}
 
 	checkInstanceIsStreaming := func(instanceName, namespace string) {
-		timeout := time.Second
+		timeout := time.Second * 10
 		Eventually(func() (int, error) {
 			err := env.Client.Get(env.Ctx,
 				ctrlclient.ObjectKey{Namespace: namespace, Name: instanceName},
@@ -90,13 +90,13 @@ var _ = Describe("Fencing", Label(tests.LabelPlugin), func() {
 			}
 			value, atoiErr := strconv.Atoi(strings.Trim(out, "\n"))
 			return value, atoiErr
-		}, 60).Should(BeEquivalentTo(1))
+		}, 120).Should(BeEquivalentTo(1))
 	}
 
 	checkPostgresConnection := func(podName, namespace string) {
 		err := testUtils.GetObject(env, ctrlclient.ObjectKey{Namespace: namespace, Name: podName}, &pod)
 		Expect(err).ToNot(HaveOccurred())
-		timeout := time.Second * 5
+		timeout := time.Second * 10
 		dsn := fmt.Sprintf("host=%v user=%v dbname=%v password=%v sslmode=require",
 			testUtils.PGLocalSocketDir, "postgres", "postgres", "")
 		stdOut, stdErr, err := utils.ExecCommand(env.Ctx, env.Interface, env.RestClientConfig, pod,

--- a/tests/e2e/logs_test.go
+++ b/tests/e2e/logs_test.go
@@ -90,7 +90,7 @@ var _ = Describe("JSON log output", Label(tests.LabelObservability), func() {
 			for _, pod := range podList.Items {
 				var queryError error
 				// Run a wrong query and save its result
-				commandTimeout := time.Second * 5
+				commandTimeout := time.Second * 10
 				Eventually(func(g Gomega) error {
 					_, _, queryError = utils.ExecCommand(env.Ctx, env.Interface, env.RestClientConfig, pod,
 						specs.PostgresContainerName, &commandTimeout, "psql", "-U", "postgres", "app", "-tAc",
@@ -122,7 +122,7 @@ var _ = Describe("JSON log output", Label(tests.LabelObservability), func() {
 
 			var queryError error
 			// Run a wrong query on just the primary and save its result
-			commandTimeout := time.Second * 5
+			commandTimeout := time.Second * 10
 			Eventually(func() error {
 				_, _, queryError = utils.ExecCommand(env.Ctx, env.Interface, env.RestClientConfig,
 					*primaryPod, specs.PostgresContainerName,

--- a/tests/e2e/pg_data_corruption_test.go
+++ b/tests/e2e/pg_data_corruption_test.go
@@ -176,7 +176,7 @@ var _ = Describe("PGDATA Corruption", Label(tests.LabelRecovery), func() {
 			err = env.Client.Get(env.Ctx, newPodNamespacedName, newPod)
 			Expect(err).ToNot(HaveOccurred())
 			// check that pod should join as in recovery mode
-			commandTimeout := time.Second * 5
+			commandTimeout := time.Second * 10
 			Eventually(func() (string, error) {
 				stdOut, _, err := env.ExecCommand(env.Ctx, *newPod, specs.PostgresContainerName,
 					&commandTimeout, "psql", "-U", "postgres", "app", "-tAc", "select pg_is_in_recovery();")

--- a/tests/e2e/pg_wal_volume_test.go
+++ b/tests/e2e/pg_wal_volume_test.go
@@ -63,7 +63,7 @@ var _ = Describe("Separate pg_wal volume", Label(tests.LabelBackupRestore), func
 		})
 		By("checking that pg_wal is a symlink to the dedicated volume", func() {
 			for _, pod := range podList.Items {
-				commandTimeout := time.Second * 5
+				commandTimeout := time.Second * 10
 				out, _, err := env.EventuallyExecCommand(env.Ctx, pod, specs.PostgresContainerName, &commandTimeout,
 					"readlink", "-f", specs.PgWalPath)
 				Expect(strings.Trim(out, "\n"), err).To(BeEquivalentTo(specs.PgWalVolumePgWalPath))

--- a/tests/e2e/replica_mode_cluster_test.go
+++ b/tests/e2e/replica_mode_cluster_test.go
@@ -51,7 +51,7 @@ var _ = Describe("Replica Mode", Label(tests.LabelReplication), func() {
 
 	// Setting variables
 	var replicaClusterName, replicaNamespace string
-	replicaCommandTimeout := time.Second * 5
+	replicaCommandTimeout := time.Second * 10
 
 	Context("can bootstrap a replica cluster using TLS auth", func() {
 		const replicaClusterSampleTLS = fixturesDir + replicaModeClusterDir + "cluster-replica-tls.yaml.template"
@@ -119,7 +119,7 @@ var _ = Describe("Replica Mode", Label(tests.LabelReplication), func() {
 			})
 
 			By("verifying write operation on the replica cluster primary pod", func() {
-				query := "CREATE TABLE replica_cluster_primary AS VALUES (1), (2);"
+				query := "CREATE TABLE IF NOT EXISTS replica_cluster_primary AS VALUES (1),(2);"
 				// Expect write operation to succeed
 				Eventually(func() error {
 					// Get primary from replica cluster
@@ -193,7 +193,7 @@ var _ = Describe("Replica Mode", Label(tests.LabelReplication), func() {
 			primaryReplicaCluster, err := env.GetClusterPrimary(replicaNamespace, replicaClusterName)
 			Expect(err).ToNot(HaveOccurred())
 
-			commandTimeout := time.Second * 5
+			commandTimeout := time.Second * 10
 
 			By("verify archive mode is set to 'always on' designated primary", func() {
 				query := "show archive_mode;"

--- a/tests/e2e/syncreplicas_test.go
+++ b/tests/e2e/syncreplicas_test.go
@@ -116,7 +116,7 @@ var _ = Describe("Synchronous Replicas", Label(tests.LabelReplication), func() {
 			ExpectedValue := "ANY " + fmt.Sprint(cluster.Spec.MaxSyncReplicas) + " (\"" + strings.Join(podNames, "\",\"") + "\")"
 
 			// Verify the parameter has been updated in every pod
-			commandTimeout := time.Second * 5
+			commandTimeout := time.Second * 10
 			for _, pod := range podList.Items {
 				pod := pod // pin the variable
 				Eventually(func() (string, error) {

--- a/tests/e2e/update_user_test.go
+++ b/tests/e2e/update_user_test.go
@@ -93,7 +93,7 @@ var _ = Describe("Update user and superuser password", Label(tests.LabelServiceC
 
 			dsn := fmt.Sprintf("host=%v user=%v dbname=%v password=%v sslmode=require",
 				rwService, newUser, "app", newPassword)
-			timeout := time.Second * 5
+			timeout := time.Second * 10
 			_, _, err := utils.ExecCommand(env.Ctx, env.Interface, env.RestClientConfig,
 				pod, specs.PostgresContainerName, &timeout,
 				"psql", dsn, "-tAc", "SELECT 1")

--- a/tests/utils/environment.go
+++ b/tests/utils/environment.go
@@ -173,7 +173,7 @@ func (env TestingEnvironment) ExecCommandWithPsqlClient(
 	dbname string,
 	query string,
 ) (string, string, error) {
-	timeout := time.Second * 5
+	timeout := time.Second * 10
 	username, password, err := GetCredentials(clusterName, namespace, secretSuffix, &env)
 	if err != nil {
 		return "", "", err

--- a/tests/utils/postgres.go
+++ b/tests/utils/postgres.go
@@ -49,7 +49,7 @@ func RunQueryFromPod(
 	query string,
 	env *TestingEnvironment,
 ) (string, string, error) {
-	timeout := time.Second * 5
+	timeout := time.Second * 10
 	dsn := CreateDSN(host, user, dbname, password, Prefer, 5432)
 
 	stdout, stderr, err := env.EventuallyExecCommand(env.Ctx, *connectingPod, specs.PostgresContainerName, &timeout,
@@ -60,7 +60,7 @@ func RunQueryFromPod(
 // CountReplicas counts the number of replicas attached to an instance
 func CountReplicas(env *TestingEnvironment, pod *corev1.Pod) (int, error) {
 	query := "SELECT count(*) FROM pg_stat_replication"
-	commandTimeout := time.Second * 5
+	commandTimeout := time.Second * 10
 	stdOut, _, err := env.EventuallyExecCommand(env.Ctx, *pod, specs.PostgresContainerName,
 		&commandTimeout, "psql", "-U", "postgres", "app", "-tAc", query)
 	if err != nil {


### PR DESCRIPTION
Fixed a couple of misleading "1 second" timeouts which were sometimes failing to pass.
Bumped commandTimeouts from 5 to 10s to avoid the occasionally occurring "context deadline exceeded" errors.
Fixed SQL statements to make them idempotent when possible, otherwise changed them to be executed without retrying.