### PR TITLE
fix: our implementation of hasName requires Barman 3.4

### DIFF
--- a/pkg/management/barman/capabilities/detect.go
+++ b/pkg/management/barman/capabilities/detect.go
@@ -48,6 +48,8 @@ func Detect() (*Capabilities, error) {
 
 	switch {
 	case version.GE(semver.Version{Major: 3, Minor: 4}):
+		// The --name flag was added to Barman in version 3.3 but we also require the
+		// barman-cloud-backup-show command which was not added until Barman version 3.4
 		newCapabilities.hasName = true
 		fallthrough
 	case version.GE(semver.Version{Major: 2, Minor: 18}):

--- a/pkg/management/barman/capabilities/detect.go
+++ b/pkg/management/barman/capabilities/detect.go
@@ -47,7 +47,7 @@ func Detect() (*Capabilities, error) {
 	newCapabilities.Version = version
 
 	switch {
-	case version.GE(semver.Version{Major: 3, Minor: 3}):
+	case version.GE(semver.Version{Major: 3, Minor: 4}):
 		newCapabilities.hasName = true
 		fallthrough
 	case version.GE(semver.Version{Major: 2, Minor: 18}):


### PR DESCRIPTION
The --name flag was added to Barman in version 3.3 but our implementation also requires the
barman-cloud-backup-show command which was not added until Barman version 3.4

Closes #1745