### PR TITLE
fix(alerts): refine LastFailedArchiveTime to not trigger if a new backup has been successful in the meantime

### DIFF
--- a/docs/src/samples/monitoring/alerts.yaml
+++ b/docs/src/samples/monitoring/alerts.yaml
@@ -40,9 +40,9 @@ groups:
   - alert: LastFailedArchiveTime 
     annotations:
       description: Archiving failed for {{ $labels.pod }}
-      summary: Checks the last time archiving failed. Will be -1 when it has not failed.
+      summary: Checks the last time archiving failed. Will be < 0 when it has not failed.
     expr: |-
-      cnpg_pg_stat_archiver_last_failed_time > 1
+      (cnpg_pg_stat_archiver_last_failed_time - cnpg_pg_stat_archiver_last_archived_time) > 1
     for: 1m
     labels:
       severity: warning

--- a/docs/src/samples/monitoring/cnpg-prometheusrule.yaml
+++ b/docs/src/samples/monitoring/cnpg-prometheusrule.yaml
@@ -45,9 +45,9 @@ spec:
     - alert: LastFailedArchiveTime 
       annotations:
         description: Archiving failed for {{ $labels.pod }}
-        summary: Checks the last time archiving failed. Will be -1 when it has not failed.
+        summary: Checks the last time archiving failed. Will be < 0 when it has not failed.
       expr: |-
-        cnpg_pg_stat_archiver_last_failed_time > 1
+        (cnpg_pg_stat_archiver_last_failed_time - cnpg_pg_stat_archiver_last_archived_time) > 1
       for: 1m
       labels:
         severity: warning


### PR DESCRIPTION
The current setup only checked the `cnpg_pg_stat_archiver_last_failed_time`, meaning if any backup failed at least once in the complete database life, this alert stays forever. The current implementation is simple and just compare the previous value to the last_archived_time.