### PR TITLE
chore: golangci-lint 1.52 comes with a new version of revive linter

### DIFF
--- a/api/v1/backup_webhook.go
+++ b/api/v1/backup_webhook.go
@@ -55,7 +55,7 @@ func (r *Backup) ValidateCreate() error {
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
-func (r *Backup) ValidateUpdate(old runtime.Object) error {
+func (r *Backup) ValidateUpdate(_ runtime.Object) error {
 	backupLog.Info("validate update", "name", r.Name, "namespace", r.Namespace)
 	return nil
 }

--- a/api/v1/pooler_webhook.go
+++ b/api/v1/pooler_webhook.go
@@ -102,7 +102,7 @@ func (r *Pooler) ValidateCreate() error {
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
-func (r *Pooler) ValidateUpdate(old runtime.Object) error {
+func (r *Pooler) ValidateUpdate(_ runtime.Object) error {
 	var allErrs field.ErrorList
 	poolerLog.Info("validate update", "name", r.Name, "namespace", r.Namespace)
 

--- a/api/v1/scheduledbackup_webhook.go
+++ b/api/v1/scheduledbackup_webhook.go
@@ -69,7 +69,7 @@ func (r *ScheduledBackup) ValidateCreate() error {
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
-func (r *ScheduledBackup) ValidateUpdate(old runtime.Object) error {
+func (r *ScheduledBackup) ValidateUpdate(_ runtime.Object) error {
 	scheduledBackupLog.Info("validate update", "name", r.Name, "namespace", r.Namespace)
 	return nil
 }

--- a/config/crd/bases/postgresql.cnpg.io_clusters.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_clusters.yaml
@@ -2700,7 +2700,8 @@ spec:
                     description: "Claims lists the names of resources, defined in
                       spec.resourceClaims, that are used by this container. \n This
                       is an alpha field and requires enabling the DynamicResourceAllocation
-                      feature gate. \n This field is immutable."
+                      feature gate. \n This field is immutable. It can only be set
+                      for containers."
                     items:
                       description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                       properties:
@@ -2889,7 +2890,7 @@ spec:
                               in spec.resourceClaims, that are used by this container.
                               \n This is an alpha field and requires enabling the
                               DynamicResourceAllocation feature gate. \n This field
-                              is immutable."
+                              is immutable. It can only be set for containers."
                             items:
                               description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
@@ -3136,7 +3137,7 @@ spec:
                               in spec.resourceClaims, that are used by this container.
                               \n This is an alpha field and requires enabling the
                               DynamicResourceAllocation feature gate. \n This field
-                              is immutable."
+                              is immutable. It can only be set for containers."
                             items:
                               description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:

--- a/config/crd/bases/postgresql.cnpg.io_poolers.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_poolers.yaml
@@ -1863,7 +1863,8 @@ spec:
                                     defined in spec.resourceClaims, that are used
                                     by this container. \n This is an alpha field and
                                     requires enabling the DynamicResourceAllocation
-                                    feature gate. \n This field is immutable."
+                                    feature gate. \n This field is immutable. It can
+                                    only be set for containers."
                                   items:
                                     description: ResourceClaim references one entry
                                       in PodSpec.ResourceClaims.
@@ -3233,7 +3234,8 @@ spec:
                                     defined in spec.resourceClaims, that are used
                                     by this container. \n This is an alpha field and
                                     requires enabling the DynamicResourceAllocation
-                                    feature gate. \n This field is immutable."
+                                    feature gate. \n This field is immutable. It can
+                                    only be set for containers."
                                   items:
                                     description: ResourceClaim references one entry
                                       in PodSpec.ResourceClaims.
@@ -4636,7 +4638,8 @@ spec:
                                     defined in spec.resourceClaims, that are used
                                     by this container. \n This is an alpha field and
                                     requires enabling the DynamicResourceAllocation
-                                    feature gate. \n This field is immutable."
+                                    feature gate. \n This field is immutable. It can
+                                    only be set for containers."
                                   items:
                                     description: ResourceClaim references one entry
                                       in PodSpec.ResourceClaims.
@@ -6425,7 +6428,8 @@ spec:
                                                 that are used by this container. \n
                                                 This is an alpha field and requires
                                                 enabling the DynamicResourceAllocation
-                                                feature gate. \n This field is immutable."
+                                                feature gate. \n This field is immutable.
+                                                It can only be set for containers."
                                               items:
                                                 description: ResourceClaim references
                                                   one entry in PodSpec.ResourceClaims.

--- a/internal/cmd/manager/controller/controller.go
+++ b/internal/cmd/manager/controller/controller.go
@@ -326,7 +326,7 @@ func loadConfiguration(
 }
 
 // readinessProbeHandler is used to implement the readiness probe handler
-func readinessProbeHandler(w http.ResponseWriter, _r *http.Request) {
+func readinessProbeHandler(w http.ResponseWriter, _ *http.Request) {
 	_, _ = fmt.Fprint(w, "OK")
 }
 

--- a/internal/cmd/manager/instance/initdb/cmd.go
+++ b/internal/cmd/manager/instance/initdb/cmd.go
@@ -108,11 +108,7 @@ func NewCmd() *cobra.Command {
 				return err
 			}
 
-			if err := linkerd.TryInvokeShutdownEndpoint(cmd.Context()); err != nil {
-				return err
-			}
-
-			return nil
+			return linkerd.TryInvokeShutdownEndpoint(cmd.Context())
 		},
 	}
 

--- a/internal/cmd/manager/instance/join/cmd.go
+++ b/internal/cmd/manager/instance/join/cmd.go
@@ -76,11 +76,7 @@ func NewCmd() *cobra.Command {
 				return err
 			}
 
-			if err := linkerd.TryInvokeShutdownEndpoint(cmd.Context()); err != nil {
-				return err
-			}
-
-			return nil
+			return linkerd.TryInvokeShutdownEndpoint(cmd.Context())
 		},
 	}
 

--- a/internal/cmd/manager/instance/pgbasebackup/cmd.go
+++ b/internal/cmd/manager/instance/pgbasebackup/cmd.go
@@ -84,11 +84,7 @@ func NewCmd() *cobra.Command {
 				return err
 			}
 
-			if err := linkerd.TryInvokeShutdownEndpoint(cmd.Context()); err != nil {
-				return err
-			}
-
-			return nil
+			return linkerd.TryInvokeShutdownEndpoint(cmd.Context())
 		},
 	}
 

--- a/internal/cmd/manager/instance/restore/cmd.go
+++ b/internal/cmd/manager/instance/restore/cmd.go
@@ -64,11 +64,7 @@ func NewCmd() *cobra.Command {
 				return err
 			}
 
-			if err := linkerd.TryInvokeShutdownEndpoint(cmd.Context()); err != nil {
-				return err
-			}
-
-			return nil
+			return linkerd.TryInvokeShutdownEndpoint(cmd.Context())
 		},
 	}
 

--- a/internal/cmd/manager/instance/run/cmd.go
+++ b/internal/cmd/manager/instance/run/cmd.go
@@ -90,11 +90,7 @@ func NewCmd() *cobra.Command {
 				return err
 			}
 
-			if err := linkerd.TryInvokeShutdownEndpoint(cmd.Context()); err != nil {
-				return err
-			}
-
-			return nil
+			return linkerd.TryInvokeShutdownEndpoint(cmd.Context())
 		},
 	}
 

--- a/internal/cmd/manager/instance/run/lifecycle/run.go
+++ b/internal/cmd/manager/instance/run/lifecycle/run.go
@@ -258,9 +258,5 @@ func verifyPgDataCoherence(ctx context.Context, instance *postgres.Instance) err
 		return err
 	}
 
-	if err := postgres.WritePostgresUserMaps(instance.PgData); err != nil {
-		return err
-	}
-
-	return nil
+	return postgres.WritePostgresUserMaps(instance.PgData)
 }

--- a/internal/cmd/plugin/fio/cmd.go
+++ b/internal/cmd/plugin/fio/cmd.go
@@ -32,7 +32,7 @@ func NewCmd() *cobra.Command {
 	fioCmd := &cobra.Command{
 		Use:     "fio [name]",
 		Short:   "Creates a fio deployment,pvc and configmap.",
-		Args:    validateCommandArgs,
+		Args:    cobra.MinimumNArgs(1),
 		Long:    `Creates a fio deployment that will execute a fio job on the specified pvc.`,
 		Example: jobExample,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -85,11 +85,4 @@ func NewCmd() *cobra.Command {
 	)
 
 	return fioCmd
-}
-
-func validateCommandArgs(cmd *cobra.Command, args []string) error {
-	if err := cobra.MinimumNArgs(1)(cmd, args); err != nil {
-		return err
-	}
-	return nil
 }

--- a/internal/cmd/plugin/fio/fio.go
+++ b/internal/cmd/plugin/fio/fio.go
@@ -85,10 +85,7 @@ func (cmd *fioCommand) execute(ctx context.Context) error {
 	deployment := cmd.generateFioDeployment(cmd.name)
 	objectList := []client.Object{pvc, configMap, deployment}
 
-	if err = plugin.CreateAndGenerateObjects(ctx, objectList, cmd.dryRun); err != nil {
-		return err
-	}
-	return nil
+	return plugin.CreateAndGenerateObjects(ctx, objectList, cmd.dryRun)
 }
 
 // CreatePVC creates spec of a PVC, given its name and the storage configuration

--- a/internal/management/controller/instance_controller.go
+++ b/internal/management/controller/instance_controller.go
@@ -80,7 +80,7 @@ type shoudRequeue bool
 //nolint:gocognit,gocyclo
 func (r *InstanceReconciler) Reconcile(
 	ctx context.Context,
-	request reconcile.Request,
+	_ reconcile.Request,
 ) (reconcile.Result, error) {
 	// set up a convenient contextLog object so we don't have to type request over and over again
 	contextLogger, ctx := log.SetupLogger(ctx)

--- a/internal/management/controller/instance_startup.go
+++ b/internal/management/controller/instance_startup.go
@@ -296,9 +296,5 @@ func (r *InstanceReconciler) ReconcileWalStorage(ctx context.Context) error {
 
 	// We moved all the files now we should create the proper symlink
 	contextLogger.Debug("Creating symlink", "from", specs.PgWalPath, "to", specs.PgWalVolumePgWalPath)
-	if err := os.Symlink(specs.PgWalVolumePgWalPath, specs.PgWalPath); err != nil {
-		return err
-	}
-
-	return nil
+	return os.Symlink(specs.PgWalVolumePgWalPath, specs.PgWalPath)
 }

--- a/internal/management/controller/slots/reconciler/replicationslot_test.go
+++ b/internal/management/controller/slots/reconciler/replicationslot_test.go
@@ -37,23 +37,23 @@ type fakeReplicationSlotManager struct {
 
 const slotPrefix = "_cnpg_"
 
-func (fk fakeReplicationSlotManager) Create(ctx context.Context, slot infrastructure.ReplicationSlot) error {
+func (fk fakeReplicationSlotManager) Create(_ context.Context, slot infrastructure.ReplicationSlot) error {
 	fk.replicationSlots[fakeSlot{name: slot.SlotName}] = true
 	return nil
 }
 
-func (fk fakeReplicationSlotManager) Delete(ctx context.Context, slot infrastructure.ReplicationSlot) error {
+func (fk fakeReplicationSlotManager) Delete(_ context.Context, slot infrastructure.ReplicationSlot) error {
 	delete(fk.replicationSlots, fakeSlot{name: slot.SlotName})
 	return nil
 }
 
-func (fk fakeReplicationSlotManager) Update(ctx context.Context, slot infrastructure.ReplicationSlot) error {
+func (fk fakeReplicationSlotManager) Update(_ context.Context, _ infrastructure.ReplicationSlot) error {
 	return nil
 }
 
 func (fk fakeReplicationSlotManager) List(
-	ctx context.Context,
-	config *apiv1.ReplicationSlotsConfiguration,
+	_ context.Context,
+	_ *apiv1.ReplicationSlotsConfiguration,
 ) (infrastructure.ReplicationSlotList, error) {
 	var slotList infrastructure.ReplicationSlotList
 	for slot := range fk.replicationSlots {

--- a/internal/management/controller/slots/runner/runner_test.go
+++ b/internal/management/controller/slots/runner/runner_test.go
@@ -40,8 +40,8 @@ type fakeSlotManager struct {
 }
 
 func (sm *fakeSlotManager) List(
-	ctx context.Context,
-	config *apiv1.ReplicationSlotsConfiguration,
+	_ context.Context,
+	_ *apiv1.ReplicationSlotsConfiguration,
 ) (infrastructure.ReplicationSlotList, error) {
 	var slotList infrastructure.ReplicationSlotList
 	for _, slot := range sm.slots {
@@ -55,7 +55,7 @@ func (sm *fakeSlotManager) List(
 	return slotList, nil
 }
 
-func (sm *fakeSlotManager) Update(ctx context.Context, slot infrastructure.ReplicationSlot) error {
+func (sm *fakeSlotManager) Update(_ context.Context, slot infrastructure.ReplicationSlot) error {
 	localSlot, found := sm.slots[slot.SlotName]
 	if !found {
 		return fmt.Errorf("while updating slot: Slot %s not found", slot.SlotName)
@@ -67,7 +67,7 @@ func (sm *fakeSlotManager) Update(ctx context.Context, slot infrastructure.Repli
 	return nil
 }
 
-func (sm *fakeSlotManager) Create(ctx context.Context, slot infrastructure.ReplicationSlot) error {
+func (sm *fakeSlotManager) Create(_ context.Context, slot infrastructure.ReplicationSlot) error {
 	if _, found := sm.slots[slot.SlotName]; found {
 		return fmt.Errorf("while creating slot: Slot %s already exists", slot.SlotName)
 	}
@@ -76,7 +76,7 @@ func (sm *fakeSlotManager) Create(ctx context.Context, slot infrastructure.Repli
 	return nil
 }
 
-func (sm *fakeSlotManager) Delete(ctx context.Context, slot infrastructure.ReplicationSlot) error {
+func (sm *fakeSlotManager) Delete(_ context.Context, slot infrastructure.ReplicationSlot) error {
 	if _, found := sm.slots[slot.SlotName]; !found {
 		return fmt.Errorf("while deleting slot: Slot %s not found", slot.SlotName)
 	}

--- a/pkg/management/postgres/logicalimport/database.go
+++ b/pkg/management/postgres/logicalimport/database.go
@@ -337,9 +337,6 @@ func (ds *databaseSnapshotter) dropExtensionsFromDatabase(
 				"extName", extName, "error", err)
 		}
 	}
-	if err = rows.Err(); err != nil {
-		return err
-	}
 
-	return nil
+	return rows.Err()
 }

--- a/pkg/management/postgres/logicalimport/microservice.go
+++ b/pkg/management/postgres/logicalimport/microservice.go
@@ -66,9 +66,5 @@ func Microservice(
 		return err
 	}
 
-	if err := ds.analyze(ctx, destination, []string{cluster.Spec.Bootstrap.InitDB.Database}); err != nil {
-		return err
-	}
-
-	return nil
+	return ds.analyze(ctx, destination, []string{cluster.Spec.Bootstrap.InitDB.Database})
 }

--- a/pkg/management/postgres/logicalimport/monolith.go
+++ b/pkg/management/postgres/logicalimport/monolith.go
@@ -64,9 +64,5 @@ func Monolith(
 		return err
 	}
 
-	if err := ds.analyze(ctx, destination, databases); err != nil {
-		return err
-	}
-
-	return nil
+	return ds.analyze(ctx, destination, databases)
 }

--- a/pkg/management/postgres/logicalimport/role.go
+++ b/pkg/management/postgres/logicalimport/role.go
@@ -68,11 +68,7 @@ func cloneRoles(
 		return err
 	}
 
-	if err := rs.importRoles(ctx, roles); err != nil {
-		return err
-	}
-
-	return nil
+	return rs.importRoles(ctx, roles)
 }
 
 func (rs *roleManager) importRoles(ctx context.Context, roles []Role) error {

--- a/pkg/management/postgres/probes.go
+++ b/pkg/management/postgres/probes.go
@@ -377,11 +377,7 @@ func (instance *Instance) fillReplicationSlotsStatus(result *postgres.Postgresql
 
 	result.ReplicationSlotsInfo = slots
 
-	if err := rows.Err(); err != nil {
-		return err
-	}
-
-	return nil
+	return rows.Err()
 }
 
 // fillWalStatus retrieves information about the WAL senders processes

--- a/pkg/management/postgres/restore.go
+++ b/pkg/management/postgres/restore.go
@@ -667,11 +667,7 @@ func (info *InitInfo) checkBackupDestination(
 	}
 
 	// Check if we're ok to archive in the desired destination
-	if err := walArchiver.CheckWalArchiveDestination(ctx, checkWalOptions); err != nil {
-		return err
-	}
-
-	return nil
+	return walArchiver.CheckWalArchiveDestination(ctx, checkWalOptions)
 }
 
 // waitUntilRecoveryFinishes periodically checks the underlying

--- a/pkg/management/postgres/webserver/remote.go
+++ b/pkg/management/postgres/webserver/remote.go
@@ -69,7 +69,7 @@ func NewRemoteWebServer(
 	return NewWebServer(instance, server), nil
 }
 
-func (ws *remoteWebserverEndpoints) isServerHealthy(w http.ResponseWriter, r *http.Request) {
+func (ws *remoteWebserverEndpoints) isServerHealthy(w http.ResponseWriter, _ *http.Request) {
 	// If `pg_rewind` is running the Pod is starting up.
 	// We need to report it healthy to avoid being killed by the kubelet.
 	// Same goes for instances with fencing on.
@@ -91,7 +91,7 @@ func (ws *remoteWebserverEndpoints) isServerHealthy(w http.ResponseWriter, r *ht
 }
 
 // This is the readiness probe
-func (ws *remoteWebserverEndpoints) isServerReady(w http.ResponseWriter, r *http.Request) {
+func (ws *remoteWebserverEndpoints) isServerReady(w http.ResponseWriter, _ *http.Request) {
 	if err := ws.instance.IsServerReady(); err != nil {
 		log.Info("Readiness probe failing", "err", err.Error())
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -103,7 +103,7 @@ func (ws *remoteWebserverEndpoints) isServerReady(w http.ResponseWriter, r *http
 }
 
 // This probe is for the instance status, including replication
-func (ws *remoteWebserverEndpoints) pgStatus(w http.ResponseWriter, r *http.Request) {
+func (ws *remoteWebserverEndpoints) pgStatus(w http.ResponseWriter, _ *http.Request) {
 	// Extract the status of the current instance
 	status, err := ws.instance.GetStatus()
 	if err != nil {

--- a/pkg/reconciler/persistentvolumeclaim/reconciler_test.go
+++ b/pkg/reconciler/persistentvolumeclaim/reconciler_test.go
@@ -50,14 +50,14 @@ type clientMock struct {
 }
 
 func (cm *clientMock) Patch(
-	ctx context.Context, obj client.Object,
-	patch client.Patch, opts ...client.PatchOption,
+	_ context.Context, _ client.Object,
+	_ client.Patch, _ ...client.PatchOption,
 ) error {
 	cm.timesCalled++
 	return nil
 }
 
-func (cm *clientMock) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+func (cm *clientMock) Create(_ context.Context, _ client.Object, _ ...client.CreateOption) error {
 	cm.timesCalled++
 	return nil
 }

--- a/pkg/resources/retry.go
+++ b/pkg/resources/retry.go
@@ -17,4 +17,4 @@ limitations under the License.
 package resources
 
 // RetryAlways is a function that always returns true on any error encountered
-func RetryAlways(err error) bool { return true }
+func RetryAlways(_ error) bool { return true }

--- a/pkg/utils/fencing.go
+++ b/pkg/utils/fencing.go
@@ -114,11 +114,7 @@ func AddFencedInstance(serverName string, object *metav1.ObjectMeta) error {
 		fencedInstances.Put(serverName)
 	}
 
-	if err := SetFencedInstances(object, fencedInstances); err != nil {
-		return err
-	}
-
-	return nil
+	return SetFencedInstances(object, fencedInstances)
 }
 
 // RemoveFencedInstance removes the given server name from the FencedInstanceAnnotation annotation

--- a/tests/e2e/asserts_test.go
+++ b/tests/e2e/asserts_test.go
@@ -2461,9 +2461,7 @@ func AssertPostgresNoPendingRestart(namespace, clusterName string, cmdTimeout ti
 				if err != nil {
 					return false, nil
 				}
-				if strings.Trim(stdout, "\n") == "f" {
-					continue
-				} else {
+				if strings.Trim(stdout, "\n") == "t" {
 					noPendingRestart = false
 					break
 				}

--- a/tests/e2e/asserts_test.go
+++ b/tests/e2e/asserts_test.go
@@ -2461,10 +2461,12 @@ func AssertPostgresNoPendingRestart(namespace, clusterName string, cmdTimeout ti
 				if err != nil {
 					return false, nil
 				}
-				if strings.Trim(stdout, "\n") == "t" {
-					noPendingRestart = false
-					break
+				if strings.Trim(stdout, "\n") == "f" {
+					continue
 				}
+
+				noPendingRestart = false
+				break
 			}
 			return noPendingRestart, nil
 		}, timeout, 2).Should(BeEquivalentTo(true),


### PR DESCRIPTION
The new version of revive linter founds a lot of issues that are handled in this commit, some of them are:

* Unused variables
* Unneeded conditions before a return
* Redundant else in functions