### PR TITLE
chore: refactor stream log functions to easy handle options

### DIFF
--- a/docs/src/cnpg-plugin.md
+++ b/docs/src/cnpg-plugin.md
@@ -525,7 +525,36 @@ Archive:  reportRedacted.zip
   inflating: report_operator_<TIMESTAMP>/manifests/cnpg-webhook-cert.yaml
 ```
 
-You can verify that the confidential information is REDACTED:
+If you activated the `--logs` option, you'd see an extra subdirectory:
+
+```shell
+Archive:  report_operator_<TIMESTAMP>.zip
+  <snipped …>
+  creating: report_operator_<TIMESTAMP>/operator-logs/
+  inflating: report_operator_<TIMESTAMP>/operator-logs/cnpg-controller-manager-66fb98dbc5-pxkmh-logs.jsonl
+```
+
+!!! Note
+    The plugin will try to get the PREVIOUS operator's logs, which is helpful
+    when investigating restarted operators.
+    In all cases, it will also try to get the CURRENT operator logs. If current
+    and previous logs are available, it will show them both.
+
+``` json
+====== Begin of Previous Log =====
+2023-03-28T12:56:41.251711811Z {"level":"info","ts":"2023-03-28T12:56:41Z","logger":"setup","msg":"Starting CloudNativePG Operator","version":"1.19.1","build":{"Version":"1.19.0+dev107","Commit":"cc9bab17","Date":"2023-03-28"}}
+2023-03-28T12:56:41.251851909Z {"level":"info","ts":"2023-03-28T12:56:41Z","logger":"setup","msg":"Starting pprof HTTP server","addr":"0.0.0.0:6060"}
+  <snipped …>
+
+====== End of Previous Log =====
+2023-03-28T12:57:09.854306024Z {"level":"info","ts":"2023-03-28T12:57:09Z","logger":"setup","msg":"Starting CloudNativePG Operator","version":"1.19.1","build":{"Version":"1.19.0+dev107","Commit":"cc9bab17","Date":"2023-03-28"}}
+2023-03-28T12:57:09.854363943Z {"level":"info","ts":"2023-03-28T12:57:09Z","logger":"setup","msg":"Starting pprof HTTP server","addr":"0.0.0.0:6060"}
+```
+
+If the operator hasn't been restarted, you'll still see the `====== Begin …`
+and  `====== End …` guards, with no content inside.
+
+You can verify that the confidential information is REDACTED by default:
 
 ```shell
 cd report_operator_<TIMESTAMP>/manifests/

--- a/internal/cmd/plugin/report/logs.go
+++ b/internal/cmd/plugin/report/logs.go
@@ -41,7 +41,8 @@ var podLogOptions = &corev1.PodLogOptions{
 func streamPodLogsToZip(
 	ctx context.Context,
 	pods []corev1.Pod,
-	dirName, name string,
+	dirName string,
+	name string,
 	zipper *zip.Writer,
 ) error {
 	logsDir := filepath.Join(dirName, name)
@@ -77,8 +78,12 @@ func streamPodLogsToZip(
 
 // streamClusterLogsToZip streams the logs from the pods in the cluster, one by
 // one, each in a new file, within  a folder
-func streamClusterLogsToZip(ctx context.Context, clusterName, namespace string,
-	dirname string, zipper *zip.Writer,
+func streamClusterLogsToZip(
+	ctx context.Context,
+	clusterName string,
+	namespace string,
+	dirname string,
+	zipper *zip.Writer,
 ) error {
 	logsdir := filepath.Join(dirname, "logs")
 	_, err := zipper.Create(logsdir + "/")

--- a/internal/cmd/plugin/report/logs.go
+++ b/internal/cmd/plugin/report/logs.go
@@ -59,16 +59,15 @@ func streamPodLogsToZip(
 
 		streamPodLogs := &logs.StreamingRequest{
 			Pod:      &pod,
-			Writer:   writer,
 			Options:  podLogOptions,
 			Previous: true,
 		}
-		fmt.Fprint(streamPodLogs.Writer, "\n====== Begin of Previous Log =====\n")
-		_ = streamPodLogs.Stream(ctx)
-		fmt.Fprint(streamPodLogs.Writer, "\n====== End of Previous Log =====\n")
+		fmt.Fprint(writer, "\n====== Begin of Previous Log =====\n")
+		_ = streamPodLogs.Stream(ctx, writer)
+		fmt.Fprint(writer, "\n====== End of Previous Log =====\n")
 
 		streamPodLogs.Previous = false
-		if err := streamPodLogs.Stream(ctx); err != nil {
+		if err := streamPodLogs.Stream(ctx, writer); err != nil {
 			return err
 		}
 	}
@@ -109,9 +108,8 @@ func streamClusterLogsToZip(ctx context.Context, clusterName, namespace string,
 		}
 		podPointer := pod
 		streamPodLogs.Pod = &podPointer
-		streamPodLogs.Writer = writer
 
-		err = streamPodLogs.Stream(ctx)
+		err = streamPodLogs.Stream(ctx, writer)
 		if err != nil {
 			return err
 		}
@@ -163,8 +161,7 @@ func streamClusterJobLogsToZip(ctx context.Context, clusterName, namespace strin
 			}
 			podPointer := pod
 			streamPodLogs.Pod = &podPointer
-			streamPodLogs.Writer = writer
-			err = streamPodLogs.Stream(ctx)
+			err = streamPodLogs.Stream(ctx, writer)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/plugin/report/logs.go
+++ b/internal/cmd/plugin/report/logs.go
@@ -57,18 +57,18 @@ func streamPodLogsToZip(
 			return fmt.Errorf("could not add '%s' to zip: %w", path, zipperErr)
 		}
 
-		streamPodLogs := &logs.StreamPodLog{
+		streamPodLogs := &logs.StreamingRequest{
 			Pod:      &pod,
 			Writer:   writer,
 			Options:  podLogOptions,
 			Previous: true,
 		}
 		fmt.Fprint(streamPodLogs.Writer, "\n====== Begin of Previous Log =====\n")
-		_ = streamPodLogs.StreamPodLogs(ctx)
+		_ = streamPodLogs.Stream(ctx)
 		fmt.Fprint(streamPodLogs.Writer, "\n====== End of Previous Log =====\n")
 
 		streamPodLogs.Previous = false
-		if err := streamPodLogs.StreamPodLogs(ctx); err != nil {
+		if err := streamPodLogs.Stream(ctx); err != nil {
 			return err
 		}
 	}
@@ -96,7 +96,7 @@ func streamClusterLogsToZip(ctx context.Context, clusterName, namespace string,
 	if err != nil {
 		return fmt.Errorf("could not get cluster pods: %w", err)
 	}
-	streamPodLogs := &logs.StreamPodLog{
+	streamPodLogs := &logs.StreamingRequest{
 		Options:  podLogOptions,
 		Previous: false,
 	}
@@ -111,7 +111,7 @@ func streamClusterLogsToZip(ctx context.Context, clusterName, namespace string,
 		streamPodLogs.Pod = &podPointer
 		streamPodLogs.Writer = writer
 
-		err = streamPodLogs.StreamPodLogs(ctx)
+		err = streamPodLogs.Stream(ctx)
 		if err != nil {
 			return err
 		}
@@ -151,7 +151,7 @@ func streamClusterJobLogsToZip(ctx context.Context, clusterName, namespace strin
 			return fmt.Errorf("could not get pods for job '%s': %w", job.Name, err)
 		}
 
-		streamPodLogs := &logs.StreamPodLog{
+		streamPodLogs := &logs.StreamingRequest{
 			Options:  podLogOptions,
 			Previous: false,
 		}
@@ -164,7 +164,7 @@ func streamClusterJobLogsToZip(ctx context.Context, clusterName, namespace strin
 			podPointer := pod
 			streamPodLogs.Pod = &podPointer
 			streamPodLogs.Writer = writer
-			err = streamPodLogs.StreamPodLogs(ctx)
+			err = streamPodLogs.Stream(ctx)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/plugin/report/logs.go
+++ b/internal/cmd/plugin/report/logs.go
@@ -63,9 +63,9 @@ func streamPodLogsToZip(
 			Options:  podLogOptions,
 			Previous: true,
 		}
-		fmt.Fprint(writer, "\n====== Begin of Previous Log =====\n")
+		fmt.Fprint(writer, "\n\"====== Begin of Previous Log =====\"\n")
 		_ = streamPodLogs.Stream(ctx, writer)
-		fmt.Fprint(writer, "\n====== End of Previous Log =====\n")
+		fmt.Fprint(writer, "\n\"====== End of Previous Log =====\"\n")
 
 		streamPodLogs.Previous = false
 		if err := streamPodLogs.Stream(ctx, writer); err != nil {

--- a/internal/cmd/plugin/report/operator_report.go
+++ b/internal/cmd/plugin/report/operator_report.go
@@ -170,7 +170,7 @@ func operator(ctx context.Context, format plugin.OutputFormat,
 
 	if includeLogs {
 		logZipper := func(zipper *zip.Writer, dirname string) error {
-			return streamPodLogsToZip(ctx, operatorPods, dirname, "operator-logs", zipper)
+			return streamOperatorLogsToZip(ctx, operatorPods, dirname, "operator-logs", zipper)
 		}
 		sections = append(sections, logZipper)
 	}

--- a/pkg/utils/logs/logs_test.go
+++ b/pkg/utils/logs/logs_test.go
@@ -1,0 +1,92 @@
+/*
+Copyright The CloudNativePG Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logs
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"io"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("StreamPodLog default options", func() {
+	podNamespace := "pod-test"
+	podName := "pod-name-test"
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: podNamespace,
+			Name:      podName,
+		},
+	}
+
+	podLogOptions := &v1.PodLogOptions{}
+	streamPodLog := StreamPodLog{
+		Pod:     pod,
+		Options: podLogOptions,
+	}
+
+	It("should return the proper podName", func() {
+		Expect(streamPodLog.getPodName()).To(BeEquivalentTo(podName))
+		Expect(streamPodLog.getPodNamespace()).To(BeEquivalentTo(podNamespace))
+	})
+
+	It("previous options must be false by default", func() {
+		Expect(streamPodLog.Previous).To(BeFalse())
+	})
+
+	It("get PodLogOptions properly when setting Previous", func() {
+		options := streamPodLog.getLogOptions()
+		Expect(options.Previous).To(BeFalse())
+
+		streamPodLog.Previous = true
+		options = streamPodLog.getLogOptions()
+		Expect(options.Previous).To(BeTrue())
+	})
+
+	It("it should provide the proper client", func() {
+		streamPodLog.Previous = false
+		client := fake.NewSimpleClientset(pod)
+		streamPodLog.client = client
+
+		logBuffer := new(bytes.Buffer)
+		writer := bufio.NewWriter(logBuffer)
+		streamPodLog.Writer = writer
+
+		pods := streamPodLog.getStreamLogPod()
+		err := streamPodLog.StreamPodLogs(context.TODO())
+		Expect(err).ToNot(HaveOccurred())
+		logs, err := pods.Stream(context.TODO())
+		Expect(err).ToNot(HaveOccurred())
+
+		rd := bufio.NewReader(logs)
+		fakeLog, err := rd.ReadString('\n')
+		Expect(err).To(BeEquivalentTo(io.EOF))
+		Expect(fakeLog).To(BeEquivalentTo("fake logs"))
+	})
+
+	It("stream logs with a non set length", func() {
+		_, err := streamPodLog.GetPodLogs(context.TODO())
+		Expect(err).ToNot(HaveOccurred())
+	})
+})

--- a/pkg/utils/logs/suite_test.go
+++ b/pkg/utils/logs/suite_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright The CloudNativePG Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logs
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestUtils(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Logs Stream")
+}

--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -33,7 +33,9 @@ import (
 	"github.com/thoas/go-funk"
 	"golang.org/x/net/context"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
 	k8sscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
 
 	// +kubebuilder:scaffold:imports
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
@@ -188,7 +190,9 @@ var _ = BeforeEach(func() {
 	var buf bytes.Buffer
 	go func() {
 		// get logs without timestamp parsing; for JSON parseability
-		err = logs.TailPodLogs(context.TODO(), operatorPod, &buf, false)
+		conf := ctrl.GetConfigOrDie()
+		client := kubernetes.NewForConfigOrDie(conf)
+		err = logs.TailPodLogs(context.TODO(), client, operatorPod, &buf, false)
 		if err != nil {
 			_, _ = fmt.Fprintf(&buf, "Error tailing logs, dumping operator logs: %v\n", err)
 		}

--- a/tests/utils/cluster.go
+++ b/tests/utils/cluster.go
@@ -150,7 +150,14 @@ func (env TestingEnvironment) DumpOperatorLogs(getPrevious bool, requestedLineLe
 	}()
 
 	_, _ = fmt.Fprintf(f, "Dumping operator pod %v log\n", pod.Name)
-	return logs.GetPodLogs(env.Ctx, pod, getPrevious, f, requestedLineLength)
+
+	streamPodLogs := &logs.StreamPodLog{
+		Pod:      &pod,
+		Writer:   f,
+		Previous: getPrevious,
+		Length:   requestedLineLength,
+	}
+	return streamPodLogs.GetPodLogs(env.Ctx)
 }
 
 // DumpNamespaceObjects logs the clusters, pods, pvcs etc. found in a namespace as JSON sections

--- a/tests/utils/cluster.go
+++ b/tests/utils/cluster.go
@@ -29,6 +29,8 @@ import (
 	"github.com/cheynewallace/tabby"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
@@ -150,14 +152,9 @@ func (env TestingEnvironment) DumpOperatorLogs(getPrevious bool, requestedLineLe
 	}()
 
 	_, _ = fmt.Fprintf(f, "Dumping operator pod %v log\n", pod.Name)
-
-	streamPodLogs := &logs.StreamPodLog{
-		Pod:      &pod,
-		Writer:   f,
-		Previous: getPrevious,
-		Length:   requestedLineLength,
-	}
-	return streamPodLogs.GetPodLogs(env.Ctx)
+	conf := ctrl.GetConfigOrDie()
+	client := kubernetes.NewForConfigOrDie(conf)
+	return logs.GetPodLogs(env.Ctx, client, pod, getPrevious, f, requestedLineLength)
 }
 
 // DumpNamespaceObjects logs the clusters, pods, pvcs etc. found in a namespace as JSON sections


### PR DESCRIPTION
Adding some improvement on how to get the previous logs of a pod including a small refactor on the stream logs functions to make easy to test

Closes #1801 