### PR TITLE
chore: make the postgres kind explicit in CI/CD

### DIFF
--- a/.github/e2e-matrix-generator.py
+++ b/.github/e2e-matrix-generator.py
@@ -114,6 +114,7 @@ class E2EJob(dict):
                 "id": name,
                 "k8s_version": k8s_version,
                 "postgres_version": postgres_version,
+                "postgres_kind": "PostgreSQL",
                 "postgres_img": f"{repo}:{postgres_version}",
                 "postgres_pre_img": f"{repo}:{postgres_version_pre}",
             }

--- a/.github/generate-test-artifacts.py
+++ b/.github/generate-test-artifacts.py
@@ -127,7 +127,6 @@ def create_artifact(matrix, name, state, error):
     branch = matrix["branch"]
     if branch == "":
         branch = matrix["refname"]
-    kind = "PostgreSQL"
 
     return {
         "name": name,
@@ -139,7 +138,7 @@ def create_artifact(matrix, name, state, error):
         "error_line": 0,
         "platform": matrix["runner"],
         "matrix_id": matrix["id"],
-        "postgres_kind": kind,
+        "postgres_kind": matrix["postgres_kind"],
         "postgres_version": matrix["postgres"],
         "k8s_version": matrix["kubernetes"],
         "workflow_id": matrix["runid"],

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -536,6 +536,7 @@ jobs:
 
       K8S_VERSION: "${{ matrix.k8s_version }}"
       POSTGRES_VERSION: ${{ matrix.postgres_version }}
+      POSTGRES_KIND: ${{ matrix.postgres_kind }}
       MATRIX: ${{ matrix.id }}
       POSTGRES_IMG: "${{ matrix.postgres_img }}"
       # The version of operator to upgrade FROM, in the rolling upgrade E2E test
@@ -629,16 +630,16 @@ jobs:
         if: (always() && !cancelled())
         run: |
           set +x
-          echo '{"runner": "local", "postgres": "${{env.POSTGRES_VERSION}}", "kubernetes": "${{env.K8S_VERSION}}", "runid": ${{ github.run_id }}, "id": "${{ env.MATRIX }}", "repo": "${{github.repository}}", "branch": "${{github.head_ref}}", "refname": "${{github.ref_name}}" }'
+          echo '{"runner": "local", "postgres": "${{env.POSTGRES_VERSION}}", "postgres_kind": "${{env.POSTGRES_KIND}}", "kubernetes": "${{env.K8S_VERSION}}", "runid": ${{ github.run_id }}, "id": "${{ env.MATRIX }}", "repo": "${{github.repository}}", "branch": "${{github.head_ref}}", "refname": "${{github.ref_name}}" }'
           python .github/generate-test-artifacts.py \
             -o testartifacts-${{ env.MATRIX }} \
             -f tests/e2e/out/report.json \
-            -m '{"runner": "local", "postgres": "${{env.POSTGRES_VERSION}}", "kubernetes": "${{env.K8S_VERSION}}", "runid": ${{ github.run_id }}, "id": "${{ env.MATRIX }}", "repo": "${{github.repository}}", "branch": "${{github.head_ref}}", "refname": "${{github.ref_name}}" }'
+            -m '{"runner": "local", "postgres": "${{env.POSTGRES_VERSION}}", "postgres_kind": "${{env.POSTGRES_KIND}}", "kubernetes": "${{env.K8S_VERSION}}", "runid": ${{ github.run_id }}, "id": "${{ env.MATRIX }}", "repo": "${{github.repository}}", "branch": "${{github.head_ref}}", "refname": "${{github.ref_name}}" }'
           if [ -f tests/e2e/out/upgrade_report.json ]; then
             python .github/generate-test-artifacts.py \
               -o testartifacts-${{ env.MATRIX }} \
               -f tests/e2e/out/upgrade_report.json \
-              -m '{"runner": "local", "postgres": "${{env.POSTGRES_VERSION}}", "kubernetes": "${{env.K8S_VERSION}}", "runid": ${{ github.run_id }}, "id": "${{ env.MATRIX }}", "repo": "${{github.repository}}", "branch": "${{github.head_ref}}", "refname": "${{github.ref_name}}" }'
+              -m '{"runner": "local", "postgres": "${{env.POSTGRES_VERSION}}", "postgres_kind": "${{env.POSTGRES_KIND}}", "kubernetes": "${{env.K8S_VERSION}}", "runid": ${{ github.run_id }}, "id": "${{ env.MATRIX }}", "repo": "${{github.repository}}", "branch": "${{github.head_ref}}", "refname": "${{github.ref_name}}" }'
           fi
       -
         name: Archive test artifacts


### PR DESCRIPTION
Adds proper detection of the Postgres KIND in the CI/CD - CIclops pipeline.
This makes flavor detection robust.