### PR TITLE
chore: reconciling for validUntil option changed

### DIFF
--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -1684,6 +1684,7 @@ type RoleConfiguration struct {
 	// Date and time after which the role's password is no longer valid.
 	// When omitted, the password will never expire (default).
 	ValidUntil *metav1.Time `json:"validUntil,omitempty"`
+
 	// List of one or more existing roles to which this role will be
 	// immediately added as a new member. Default empty.
 	InRoles []string `json:"inRoles,omitempty"`

--- a/internal/management/controller/roles/contract_test.go
+++ b/internal/management/controller/roles/contract_test.go
@@ -1,6 +1,26 @@
+/*
+Copyright The CloudNativePG Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package roles
 
 import (
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -8,6 +28,8 @@ import (
 )
 
 var _ = Describe("DatabaseRole implementation test", func() {
+	fixedTime := time.Date(2023, 4, 4, 0, 0, 0, 0, time.UTC)
+	fixedTime2 := time.Date(2023, 4, 4, 1, 0, 0, 0, time.UTC)
 	It("should return true when the objects are equal", func() {
 		role := DatabaseRole{
 			Name:    "abc",
@@ -76,6 +98,82 @@ var _ = Describe("DatabaseRole implementation test", func() {
 			},
 		}
 		res := role.isInSameRolesAs(config)
+		Expect(res).To(BeFalse())
+	})
+
+	It("Detects that spec and db role have the same ValidUntil", func() {
+		role := DatabaseRole{
+			Name:       "abc",
+			ValidUntil: &fixedTime,
+		}
+		inSpec := apiv1.RoleConfiguration{
+			Name:       "abc",
+			ValidUntil: &metav1.Time{Time: fixedTime},
+			PasswordSecret: &apiv1.LocalObjectReference{
+				Name: "test",
+			},
+		}
+		res := role.hasSameValidUntilAs(inSpec)
+		Expect(res).To(BeTrue())
+	})
+
+	It("Detects both database and spec don't have a VALID UNTIL", func() {
+		role := DatabaseRole{
+			Name: "abc",
+		}
+		inSpec := apiv1.RoleConfiguration{
+			Name: "abc",
+			PasswordSecret: &apiv1.LocalObjectReference{
+				Name: "test",
+			},
+		}
+		res := role.hasSameValidUntilAs(inSpec)
+		Expect(res).To(BeTrue())
+	})
+
+	It("Detects the VALID UNTIL has drifted", func() {
+		role := DatabaseRole{
+			Name:       "abc",
+			ValidUntil: &fixedTime,
+		}
+		inSpec := apiv1.RoleConfiguration{
+			Name:       "abc",
+			ValidUntil: &metav1.Time{Time: fixedTime2},
+			PasswordSecret: &apiv1.LocalObjectReference{
+				Name: "test",
+			},
+		}
+		res := role.hasSameValidUntilAs(inSpec)
+		Expect(res).To(BeFalse())
+	})
+
+	It("Detects difference in VALID UNTIL if db has it but spec does not", func() {
+		role := DatabaseRole{
+			Name:       "abc",
+			ValidUntil: &fixedTime,
+		}
+		inSpec := apiv1.RoleConfiguration{
+			Name: "abc",
+			PasswordSecret: &apiv1.LocalObjectReference{
+				Name: "test",
+			},
+		}
+		res := role.hasSameValidUntilAs(inSpec)
+		Expect(res).To(BeFalse())
+	})
+
+	It("Detects difference in VALID UNTIL if spec has it but db does not", func() {
+		role := DatabaseRole{
+			Name: "abc",
+		}
+		inSpec := apiv1.RoleConfiguration{
+			Name:       "abc",
+			ValidUntil: &metav1.Time{Time: fixedTime2},
+			PasswordSecret: &apiv1.LocalObjectReference{
+				Name: "test",
+			},
+		}
+		res := role.hasSameValidUntilAs(inSpec)
 		Expect(res).To(BeFalse())
 	})
 

--- a/internal/management/controller/roles/postgres.go
+++ b/internal/management/controller/roles/postgres.go
@@ -141,8 +141,8 @@ func (sm PostgresRoleManager) Create(ctx context.Context, role DatabaseRole) err
 	query.WriteString(fmt.Sprintf("CREATE ROLE %s ", pgx.Identifier{role.Name}.Sanitize()))
 	appendRoleOptions(role, &query)
 	appendInRoleOptions(role, &query)
-	contextLog.Debug("Creating", "query", query.String())
 	appendPasswordOption(role, &query)
+	contextLog.Debug("Creating", "query", query.String())
 
 	// NOTE: defensively we might think of doing CREATE ... IF EXISTS
 	// but at least during development, we want to catch the error
@@ -357,7 +357,7 @@ func appendPasswordOption(role DatabaseRole,
 		query.WriteString(fmt.Sprintf(" PASSWORD %s", pq.QuoteLiteral(role.password.String)))
 	}
 
-	if role.password.Valid && role.ValidUntil != nil {
+	if role.ValidUntil != nil {
 		ts := string(pq.FormatTimestamp(*role.ValidUntil))
 		query.WriteString(fmt.Sprintf(" VALID UNTIL %s", pq.QuoteLiteral(ts)))
 	}

--- a/internal/management/controller/roles/postgres_test.go
+++ b/internal/management/controller/roles/postgres_test.go
@@ -54,7 +54,7 @@ var _ = Describe("Postgres RoleManager implementation test", func() {
 	}
 	wantedRoleExpectedCrtStmt := fmt.Sprintf(
 		"CREATE ROLE \"%s\" BYPASSRLS NOCREATEDB CREATEROLE NOINHERIT LOGIN NOREPLICATION "+
-			"NOSUPERUSER CONNECTION LIMIT 2 PASSWORD NULL",
+			"NOSUPERUSER CONNECTION LIMIT 2 PASSWORD NULL VALID UNTIL '2100-01-01 00:00:00Z'",
 		wantedRole.Name)
 
 	wantedRoleCommentStmt := fmt.Sprintf(


### PR DESCRIPTION
This patch makes sure validuntil option of managed role changing
can reflect to the role in database.

Closes #1840 