### PR TITLE
chore: disable logLevel trace on E2E tests using replication slots

### DIFF
--- a/tests/e2e/fixtures/base/cluster-storage-class-with-rep-slots.yaml.template
+++ b/tests/e2e/fixtures/base/cluster-storage-class-with-rep-slots.yaml.template
@@ -14,8 +14,6 @@ spec:
       log_autovacuum_min_duration: '1s'
       log_replication_commands: 'on'
 
-  logLevel: trace
-
   replicationSlots:
     updateInterval: 10
     highAvailability:

--- a/tests/e2e/fixtures/fastfailover/cluster-fast-failover-with-repl-slots.yaml.template
+++ b/tests/e2e/fixtures/fastfailover/cluster-fast-failover-with-repl-slots.yaml.template
@@ -15,8 +15,6 @@ spec:
       log_autovacuum_min_duration: '1s'
       log_replication_commands: 'on'
 
-  logLevel: trace
-
   replicationSlots:
     updateInterval: 10
     highAvailability:

--- a/tests/e2e/fixtures/fastswitchover/cluster-fast-switchover-with-repl-slots.yaml.template
+++ b/tests/e2e/fixtures/fastswitchover/cluster-fast-switchover-with-repl-slots.yaml.template
@@ -16,8 +16,6 @@ spec:
       log_replication_commands: 'on'
       wal_receiver_timeout: '2s'
 
-  logLevel: trace
-
   replicationSlots:
     updateInterval: 10
     highAvailability:

--- a/tests/e2e/fixtures/replication_slot/cluster-pg-replication-slot-disable.yaml.template
+++ b/tests/e2e/fixtures/replication_slot/cluster-pg-replication-slot-disable.yaml.template
@@ -15,8 +15,6 @@ spec:
       log_replication_commands: 'on'
       wal_receiver_timeout: '2s'
 
-  logLevel: trace
-
   replicationSlots:
     updateInterval: 10
     highAvailability:

--- a/tests/e2e/fixtures/switchover/cluster-switchover-with-rep-slots.yaml.template
+++ b/tests/e2e/fixtures/switchover/cluster-switchover-with-rep-slots.yaml.template
@@ -15,8 +15,6 @@ spec:
       log_replication_commands: 'on'
       wal_receiver_timeout: '2s'
 
-  logLevel: trace
-
   replicationSlots:
     updateInterval: 10
     highAvailability:

--- a/tests/utils/import_db.go
+++ b/tests/utils/import_db.go
@@ -99,6 +99,9 @@ func ImportDatabasesMonolith(
 	roles []string,
 	env *TestingEnvironment,
 ) error {
+	if imageName == "" {
+		imageName = os.Getenv("POSTGRES_IMG")
+	}
 	storageClassName := os.Getenv("E2E_DEFAULT_STORAGE_CLASS")
 	host := fmt.Sprintf("%v-rw.%v.svc", sourceClusterName, namespace)
 	superUserSecretName := fmt.Sprintf("%v-superuser", sourceClusterName)


### PR DESCRIPTION
Disabling logLevel `trace` on certain E2Es. It was previously added for debug purposes but it's not needed anymore.
Also adding a missing fallback for the `imageName` inside `ImportDatabasesMonolith()`