### PR TITLE
doc(backup_recovery.md): fix crontab

### DIFF
--- a/docs/src/backup_recovery.md
+++ b/docs/src/backup_recovery.md
@@ -554,7 +554,7 @@ kind: ScheduledBackup
 metadata:
   name: backup-example
 spec:
-  schedule: "0 0 0 * * *"
+  schedule: "0 0 * * *"
   backupOwnerReference: self
   cluster:
     name: pg-backup


### PR DESCRIPTION
There is an extra `0` in the crontab.