### PR TITLE
fix: put sample password expiry 30 years from now

### DIFF
--- a/docs/src/samples/cluster-example-with-roles.yaml
+++ b/docs/src/samples/cluster-example-with-roles.yaml
@@ -20,7 +20,7 @@ spec:
       replication: false
       bypassrls: false
       connectionLimit: 4
-      validUntil: "2023-04-12T15:04:05Z"
+      validUntil: "2053-04-12T15:04:05Z"
       inRoles:
         - pg_monitor
         - pg_signal_backend

--- a/tests/e2e/fixtures/managed_roles/cluster-managed-roles.yaml.template
+++ b/tests/e2e/fixtures/managed_roles/cluster-managed-roles.yaml.template
@@ -22,7 +22,7 @@ spec:
       replication: false
       bypassrls: false
       connectionLimit: 4
-      validUntil: "2023-04-12T15:04:05Z"
+      validUntil: "2053-04-12T15:04:05Z"
       inRoles:
         - pg_monitor
         - pg_signal_backend


### PR DESCRIPTION
the E2E were failing because the fixture YAML had expired password.