### PR TITLE
Prevent creating Kubernetes client when calling completion command

### DIFF
--- a/cmd/kubectl-cnpg/main.go
+++ b/cmd/kubectl-cnpg/main.go
@@ -57,6 +57,14 @@ func main() {
 		SilenceUsage: true,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			logFlags.ConfigureLogging()
+
+			// If we're invoking the completion command we shouldn't try to create
+			// a Kubernetes client and we just let the Cobra flow to continue
+			if cmd.Name() == "completion" || cmd.Name() == "version" ||
+				cmd.Parent().Name() == "completion" {
+				return nil
+			}
+
 			return plugin.SetupKubernetesClient(configFlags)
 		},
 	}

--- a/cmd/kubectl-cnpg/main.go
+++ b/cmd/kubectl-cnpg/main.go
@@ -61,7 +61,7 @@ func main() {
 			// If we're invoking the completion command we shouldn't try to create
 			// a Kubernetes client and we just let the Cobra flow to continue
 			if cmd.Name() == "completion" || cmd.Name() == "version" ||
-				cmd.Parent().Name() == "completion" {
+				cmd.HasParent() && cmd.Parent().Name() == "completion" {
 				return nil
 			}
 


### PR DESCRIPTION
When the `completion` command was called while it was used inside the
`~/.basrc` file or a `~/.profile` this was useless since we were not able to output
the completion becase we were trying to create a Kubernetes client all the time,
which it's not the case during the load of a profile configuration, since this could
happen even before there's any Kubernetes cluster configured in place.

Closes #1932 