### PR TITLE
docs: provide sample for operator PodMonitor

### DIFF
--- a/docs/src/samples/monitoring/cnpg-operator-podmonitor.yaml
+++ b/docs/src/samples/monitoring/cnpg-operator-podmonitor.yaml
@@ -1,0 +1,10 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: cnpg-controller-manager
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: cloudnative-pg
+  podMetricsEndpoints:
+    - port: metrics


### PR DESCRIPTION
This clones the PodMonitor definition from the docs into a quick place folks can pull down to test out the monitoring features provided by the operator container.