### PR TITLE
fix: drop misleading metadata from examples

### DIFF
--- a/docs/src/samples/monitoring/cnpg-prometheusrule.yaml
+++ b/docs/src/samples/monitoring/cnpg-prometheusrule.yaml
@@ -2,13 +2,6 @@ apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: cnpg-default-alerts
-  labels:
-    grafana_dashboard: "1"
-    app.kubernetes.io/instance: prometheus-community
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: grafana
-    app.kubernetes.io/version: 9.1.7
-    helm.sh/chart: grafana-6.40.4
 spec:
   groups:
   - name: cnp-default.rules

--- a/docs/src/samples/monitoring/grafana-configmap.yaml
+++ b/docs/src/samples/monitoring/grafana-configmap.yaml
@@ -20,11 +20,6 @@ metadata:
   name: test-cnp-dashboard
   labels:
     grafana_dashboard: "1"
-    app.kubernetes.io/instance: prometheus-community
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: grafana
-    app.kubernetes.io/version: 9.1.7
-    helm.sh/chart: grafana-6.40.4
 data:
   cnp.json: |-
     {


### PR DESCRIPTION
The example files shouldn't include helm metadata since they are not provided by helm.

Additionally, the PrometheusRule doesn't require the `grafana_dashboard` label as it isn't a dashboard.

I don't believe this requires backporting, but I'm unable to edit the labels.

Closes: #1981