### PR TITLE
feat: Add support for logical replication slots with HA (#1962)

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -58,11 +58,11 @@ spec:
           value: $(DEFAULT_MONITORING_CONFIGMAP)
         resources:
           limits:
-            cpu: 100m
-            memory: 200Mi
+            cpu: 500m
+            memory: 512Mi
           requests:
-            cpu: 100m
-            memory: 100Mi
+            cpu: 250m
+            memory: 256Mi
         livenessProbe:
           httpGet:
             port: 9443

--- a/docs/src/replication.md
+++ b/docs/src/replication.md
@@ -212,16 +212,16 @@ primary and have lost their slot.
 
 CloudNativePG fills this gap by introducing the concept of cluster-managed
 replication slots, starting with high availability clusters. This feature
-automatically manages physical replication slots for each hot standby replica
+automatically manages replication slots for each hot standby replica
 in the High Availability cluster, both in the primary and the standby.
 
 In CloudNativePG, we use the terms:
 
-- **Primary HA slot**: a physical replication slot whose lifecycle is entirely
+- **Primary HA slot**: a replication slot whose lifecycle is entirely
   managed by the current primary of the cluster and whose purpose is to map to
   a specific standby in streaming replication. Such a slot lives on the primary
   only.
-- **Standby HA slot**: a physical replication slot for a standby whose
+- **Standby HA slot**: a replication slot for a standby whose
   lifecycle is entirely managed by another standby in the cluster, based on the
   content of the `pg_replication_slots` view in the primary, and updated at regular
   intervals using `pg_replication_slot_advance()`.

--- a/hack/e2e/run-e2e.sh
+++ b/hack/e2e/run-e2e.sh
@@ -44,7 +44,7 @@ export E2E_PRE_ROLLING_UPDATE_IMG=${E2E_PRE_ROLLING_UPDATE_IMG:-${POSTGRES_IMG%.
 export AZURE_STORAGE_ACCOUNT=${AZURE_STORAGE_ACCOUNT:-''}
 
 # Getting the operator images need a pull secret
-kubectl create namespace cnpg-system
+kubectl create namespace cnpg-system --dry-run=client -o yaml | kubectl apply -f -
 if [ -n "${DOCKER_SERVER-}" ] && [ -n "${DOCKER_USERNAME-}" ] && [ -n "${DOCKER_PASSWORD-}" ]; then
   kubectl create secret docker-registry \
     -n cnpg-system \

--- a/internal/management/controller/slots/infrastructure/contract.go
+++ b/internal/management/controller/slots/infrastructure/contract.go
@@ -27,10 +27,14 @@ import (
 type Manager interface {
 	// List the available replication slots
 	List(ctx context.Context, config *apiv1.ReplicationSlotsConfiguration) (ReplicationSlotList, error)
+	// ListLogical lists the available logical replication slots
+	ListLogical(ctx context.Context, config *apiv1.ReplicationSlotsConfiguration) (ReplicationSlotList, error)
 	// Update the replication slot
 	Update(ctx context.Context, slot ReplicationSlot) error
 	// Create the replication slot
 	Create(ctx context.Context, slot ReplicationSlot) error
 	// Delete the replication slot
 	Delete(ctx context.Context, slot ReplicationSlot) error
+	// GetState returns the raw state of a replication slot
+	GetState(ctx context.Context, slot ReplicationSlot) ([]byte, error)
 }

--- a/internal/management/controller/slots/infrastructure/replicationslot.go
+++ b/internal/management/controller/slots/infrastructure/replicationslot.go
@@ -22,12 +22,17 @@ type SlotType string
 // SlotTypePhysical represents the physical replication slot
 const SlotTypePhysical SlotType = "physical"
 
+// SlotTypeLogical represents the physical replication slot
+const SlotTypeLogical SlotType = "logical"
+
 // ReplicationSlot represents a single replication slot
 type ReplicationSlot struct {
 	SlotName   string   `json:"slotName,omitempty"`
+	Plugin     string   `json:"plugin,omitempty"`
 	Type       SlotType `json:"type,omitempty"`
 	Active     bool     `json:"active"`
 	RestartLSN string   `json:"restartLSN,omitempty"`
+	TwoPhase   bool     `json:"twoPhase,omitempty"`
 }
 
 // ReplicationSlotList contains a list of replication slots

--- a/internal/management/controller/slots/infrastructure/replicationslot.go
+++ b/internal/management/controller/slots/infrastructure/replicationslot.go
@@ -22,7 +22,7 @@ type SlotType string
 // SlotTypePhysical represents the physical replication slot
 const SlotTypePhysical SlotType = "physical"
 
-// SlotTypeLogical represents the physical replication slot
+// SlotTypeLogical represents the logical replication slot
 const SlotTypeLogical SlotType = "logical"
 
 // ReplicationSlot represents a single replication slot

--- a/internal/management/controller/slots/reconciler/replicationslot_test.go
+++ b/internal/management/controller/slots/reconciler/replicationslot_test.go
@@ -28,6 +28,8 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+var _ infrastructure.Manager = (*fakeReplicationSlotManager)(nil)
+
 type fakeSlot struct {
 	name   string
 	active bool
@@ -43,7 +45,6 @@ func (fk fakeReplicationSlotManager) Create(_ context.Context, slot infrastructu
 	fk.replicationSlots[fakeSlot{name: slot.SlotName}] = true
 	return nil
 }
-
 func (fk fakeReplicationSlotManager) Delete(_ context.Context, slot infrastructure.ReplicationSlot) error {
 	delete(fk.replicationSlots, fakeSlot{name: slot.SlotName})
 	return nil
@@ -67,6 +68,14 @@ func (fk fakeReplicationSlotManager) List(
 		})
 	}
 	return slotList, nil
+}
+
+func (fk fakeReplicationSlotManager) ListLogical(ctx context.Context, config *apiv1.ReplicationSlotsConfiguration) (infrastructure.ReplicationSlotList, error) {
+	return infrastructure.ReplicationSlotList{}, nil
+}
+
+func (fk fakeReplicationSlotManager) GetState(ctx context.Context, slot infrastructure.ReplicationSlot) ([]byte, error) {
+	return nil, nil
 }
 
 func makeClusterWithInstanceNames(instanceNames []string, primary string) apiv1.Cluster {


### PR DESCRIPTION
Implement support for cloning logical replication slots from primary to standbys and advancing the LSN in the same cadence as physical replication slots. Aimed at solving issue #1962.

Is enabled through the `.spec.replicationSlots.highAvailability.enabled` property in the Cluster CRD.

Also;
* Bump manager limits to mitigate restarts in e2e tests due to failed health checks.
* Change `run-e2e.sh` to not fail if cnpg-system namespace is already created.