### PR TITLE
feat: Add support for logical replication slots with HA (#1962)

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -58,8 +58,8 @@ spec:
           value: $(DEFAULT_MONITORING_CONFIGMAP)
         resources:
           limits:
-            cpu: 100m
-            memory: 200Mi
+            cpu: 500m
+            memory: 512Mi
           requests:
             cpu: 100m
             memory: 100Mi

--- a/docs/src/replication.md
+++ b/docs/src/replication.md
@@ -212,16 +212,16 @@ primary and have lost their slot.
 
 CloudNativePG fills this gap by introducing the concept of cluster-managed
 replication slots, starting with high availability clusters. This feature
-automatically manages physical replication slots for each hot standby replica
+automatically manages replication slots for each hot standby replica
 in the High Availability cluster, both in the primary and the standby.
 
 In CloudNativePG, we use the terms:
 
-- **Primary HA slot**: a physical replication slot whose lifecycle is entirely
+- **Primary HA slot**: a replication slot whose lifecycle is entirely
   managed by the current primary of the cluster and whose purpose is to map to
   a specific standby in streaming replication. Such a slot lives on the primary
   only.
-- **Standby HA slot**: a physical replication slot for a standby whose
+- **Standby HA slot**: a replication slot for a standby whose
   lifecycle is entirely managed by another standby in the cluster, based on the
   content of the `pg_replication_slots` view in the primary, and updated at regular
   intervals using `pg_replication_slot_advance()`.

--- a/hack/e2e/run-e2e.sh
+++ b/hack/e2e/run-e2e.sh
@@ -44,7 +44,7 @@ export E2E_PRE_ROLLING_UPDATE_IMG=${E2E_PRE_ROLLING_UPDATE_IMG:-${POSTGRES_IMG%.
 export AZURE_STORAGE_ACCOUNT=${AZURE_STORAGE_ACCOUNT:-''}
 
 # Getting the operator images need a pull secret
-kubectl create namespace cnpg-system
+kubectl create namespace cnpg-system --dry-run=client -o yaml | kubectl apply -f -
 if [ -n "${DOCKER_SERVER-}" ] && [ -n "${DOCKER_USERNAME-}" ] && [ -n "${DOCKER_PASSWORD-}" ]; then
   kubectl create secret docker-registry \
     -n cnpg-system \

--- a/internal/management/controller/slots/infrastructure/contract.go
+++ b/internal/management/controller/slots/infrastructure/contract.go
@@ -27,10 +27,14 @@ import (
 type Manager interface {
 	// List the available replication slots
 	List(ctx context.Context, config *apiv1.ReplicationSlotsConfiguration) (ReplicationSlotList, error)
+	// ListLogical lists the available logical replication slots
+	ListLogical(ctx context.Context, config *apiv1.ReplicationSlotsConfiguration) (ReplicationSlotList, error)
 	// Update the replication slot
 	Update(ctx context.Context, slot ReplicationSlot) error
 	// Create the replication slot
 	Create(ctx context.Context, slot ReplicationSlot) error
 	// Delete the replication slot
 	Delete(ctx context.Context, slot ReplicationSlot) error
+	// GetState returns the raw state of a replication slot
+	GetState(ctx context.Context, slot ReplicationSlot) ([]byte, error)
 }

--- a/internal/management/controller/slots/infrastructure/postgresmanager.go
+++ b/internal/management/controller/slots/infrastructure/postgresmanager.go
@@ -19,6 +19,7 @@ package infrastructure
 import (
 	"context"
 	"database/sql"
+	"errors"
 
 	v1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/log"
@@ -46,7 +47,7 @@ func (sm PostgresManager) String() string {
 	return sm.pool.GetDsn("postgres")
 }
 
-// List the available replication slots
+// List the available managed physical replication slots
 func (sm PostgresManager) List(
 	ctx context.Context,
 	config *v1.ReplicationSlotsConfiguration,
@@ -92,6 +93,53 @@ func (sm PostgresManager) List(
 	return status, nil
 }
 
+// ListLogical lists the available logical replication slots
+func (sm PostgresManager) ListLogical(
+	ctx context.Context,
+	config *v1.ReplicationSlotsConfiguration,
+) (ReplicationSlotList, error) {
+	db, err := sm.pool.Connection("postgres")
+	if err != nil {
+		return ReplicationSlotList{}, err
+	}
+
+	rows, err := db.QueryContext(
+		ctx,
+		`SELECT slot_name, plugin, slot_type, active, coalesce(restart_lsn::TEXT, ''), two_phase AS restart_lsn FROM pg_replication_slots 
+		   WHERE NOT temporary AND slot_type = 'logical'`,
+	)
+	if err != nil {
+		return ReplicationSlotList{}, err
+	}
+	defer func() {
+		_ = rows.Close()
+	}()
+
+	var status ReplicationSlotList
+	for rows.Next() {
+		var slot ReplicationSlot
+		err := rows.Scan(
+			&slot.SlotName,
+			&slot.Plugin,
+			&slot.Type,
+			&slot.Active,
+			&slot.RestartLSN,
+			&slot.TwoPhase,
+		)
+		if err != nil {
+			return ReplicationSlotList{}, err
+		}
+
+		status.Items = append(status.Items, slot)
+	}
+
+	if rows.Err() != nil {
+		return ReplicationSlotList{}, rows.Err()
+	}
+
+	return status, nil
+}
+
 // Update the replication slot
 func (sm PostgresManager) Update(ctx context.Context, slot ReplicationSlot) error {
 	contextLog := log.FromContext(ctx).WithName("updateSlot")
@@ -118,9 +166,38 @@ func (sm PostgresManager) Create(ctx context.Context, slot ReplicationSlot) erro
 		return err
 	}
 
-	_, err = db.ExecContext(ctx, "SELECT pg_create_physical_replication_slot($1, $2)",
-		slot.SlotName, slot.RestartLSN != "")
+	switch slot.Type {
+	case SlotTypePhysical:
+		_, err = db.ExecContext(ctx, "SELECT pg_create_physical_replication_slot($1, $2)",
+			slot.SlotName, slot.RestartLSN != "")
+	case SlotTypeLogical:
+		_, err = db.ExecContext(ctx, "SELECT pg_create_logical_replication_slot($1, $2, $3, $4)",
+			slot.SlotName, slot.Plugin, false, slot.TwoPhase)
+	default:
+		return errors.New("unsupported replication slot type")
+	}
+
 	return err
+}
+
+// GetState returns the state of the replication slot
+func (sm PostgresManager) GetState(ctx context.Context, slot ReplicationSlot) ([]byte, error) {
+	contextLog := log.FromContext(ctx).WithName("createSlot")
+	contextLog.Trace("Invoked", "slot", slot)
+
+	db, err := sm.pool.Connection("postgres")
+	if err != nil {
+		return nil, err
+	}
+
+	var state []byte
+	err = db.QueryRowContext(
+		ctx,
+		`SELECT pg_catalog.pg_read_binary_file('pg_replslot/' || slot_name || '/state') FROM pg_catalog.pg_get_replication_slots() WHERE slot_name = $1`,
+		slot.SlotName,
+	).Scan(&state)
+
+	return state, err
 }
 
 // Delete the replication slot

--- a/internal/management/controller/slots/infrastructure/replicationslot.go
+++ b/internal/management/controller/slots/infrastructure/replicationslot.go
@@ -22,12 +22,17 @@ type SlotType string
 // SlotTypePhysical represents the physical replication slot
 const SlotTypePhysical SlotType = "physical"
 
+// SlotTypeLogical represents the logical replication slot
+const SlotTypeLogical SlotType = "logical"
+
 // ReplicationSlot represents a single replication slot
 type ReplicationSlot struct {
 	SlotName   string   `json:"slotName,omitempty"`
+	Plugin     string   `json:"plugin,omitempty"`
 	Type       SlotType `json:"type,omitempty"`
 	Active     bool     `json:"active"`
 	RestartLSN string   `json:"restartLSN,omitempty"`
+	TwoPhase   bool     `json:"twoPhase,omitempty"`
 }
 
 // ReplicationSlotList contains a list of replication slots

--- a/internal/management/controller/slots/reconciler/replicationslot_test.go
+++ b/internal/management/controller/slots/reconciler/replicationslot_test.go
@@ -28,6 +28,8 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+var _ infrastructure.Manager = (*fakeReplicationSlotManager)(nil)
+
 type fakeSlot struct {
 	name   string
 	active bool
@@ -67,6 +69,14 @@ func (fk fakeReplicationSlotManager) List(
 		})
 	}
 	return slotList, nil
+}
+
+func (fk fakeReplicationSlotManager) ListLogical(ctx context.Context, config *apiv1.ReplicationSlotsConfiguration) (infrastructure.ReplicationSlotList, error) {
+	return infrastructure.ReplicationSlotList{}, nil
+}
+
+func (fk fakeReplicationSlotManager) GetState(ctx context.Context, slot infrastructure.ReplicationSlot) ([]byte, error) {
+	return nil, nil
 }
 
 func makeClusterWithInstanceNames(instanceNames []string, primary string) apiv1.Cluster {


### PR DESCRIPTION
Implement support for cloning logical replication slots from primary to standbys and advancing the LSN in the same cadence as the current physical replication slots.

The cloning is performed by reading the logical replication slot state off the disk of the primary through the SQL layer, then restarting the standby instance to pick up the new logical replication slot. From PostgreSQL 16 it should be possible to [create the logical replication slots directly through SQL](https://bdrouvot.github.io/2023/04/19/postgres-16-highlight-logical-decoding-on-standby/), which is also supported in the PR.

The HA logical replication is an extension of the HA physical replication slots, and is therefore enabled through the `.spec.replicationSlots.highAvailability.enabled` property in the Cluster CRD.

Also in the PR;
* Bump manager limits to mitigate restarts in e2e tests due to failed health checks.
* Change run-e2e.sh to not fail if cnpg-system namespace is already created.

Closes #1962 