### PR TITLE
feat: use separate transactions to reconcile users' credentials

### DIFF
--- a/internal/management/controller/instance_controller.go
+++ b/internal/management/controller/instance_controller.go
@@ -27,8 +27,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/jackc/pgx/v5"
-	"github.com/lib/pq"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -1190,43 +1188,29 @@ func (r *InstanceReconciler) refreshCredentialsFromSecret(
 		return err
 	}
 
-	tx, err := db.Begin()
-	if err != nil {
-		return err
-	}
-	defer func() {
-		// This has no effect if the transaction
-		// is committed
-		_ = tx.Rollback()
-	}()
-
-	_, err = tx.Exec("SET LOCAL synchronous_commit to LOCAL")
-	if err != nil {
-		return err
-	}
-
 	if cluster.GetEnableSuperuserAccess() {
-		err = r.reconcileUser(ctx, "postgres", cluster.GetSuperuserSecretName(), tx)
+		err = r.reconcileUser(ctx, "postgres", cluster.GetSuperuserSecretName(), db)
 		if err != nil {
 			return err
 		}
 	} else {
-		err = r.disableSuperuserPassword(tx)
+		err = postgresutils.DisableSuperuserPassword(db)
 		if err != nil {
 			return err
 		}
 	}
 
 	if cluster.ShouldCreateApplicationDatabase() {
-		err = r.reconcileUser(ctx, cluster.GetApplicationDatabaseOwner(), cluster.GetApplicationSecretName(), tx)
+		err = r.reconcileUser(ctx, cluster.GetApplicationDatabaseOwner(), cluster.GetApplicationSecretName(), db)
 		if err != nil {
 			return err
 		}
 	}
-	return tx.Commit()
+
+	return nil
 }
 
-func (r *InstanceReconciler) reconcileUser(ctx context.Context, username string, secretName string, tx *sql.Tx) error {
+func (r *InstanceReconciler) reconcileUser(ctx context.Context, username string, secretName string, db *sql.DB) error {
 	var secret corev1.Secret
 	err := r.GetClient().Get(
 		ctx,
@@ -1253,21 +1237,14 @@ func (r *InstanceReconciler) reconcileUser(ctx context.Context, username string,
 		return fmt.Errorf("wrong username '%v' in secret, expected '%v'", usernameFromSecret, username)
 	}
 
-	_, err = tx.Exec(fmt.Sprintf("ALTER ROLE %v WITH PASSWORD %v",
-		pgx.Identifier{username}.Sanitize(),
-		pq.QuoteLiteral(password)))
-	if err == nil {
-		r.secretVersions[secret.Name] = secret.ResourceVersion
-	} else {
-		err = fmt.Errorf("while running ALTER ROLE %v WITH PASSWORD", username)
+	err = postgresutils.SetUserPassword(username, password, db)
+	if err != nil {
+		return err
 	}
 
-	return err
-}
+	r.secretVersions[secret.Name] = secret.ResourceVersion
 
-func (r *InstanceReconciler) disableSuperuserPassword(tx *sql.Tx) error {
-	_, err := tx.Exec("ALTER ROLE postgres WITH PASSWORD NULL")
-	return err
+	return nil
 }
 
 func (r *InstanceReconciler) refreshPGHBA(ctx context.Context, cluster *apiv1.Cluster) (

--- a/pkg/management/postgres/utils/roles.go
+++ b/pkg/management/postgres/utils/roles.go
@@ -1,0 +1,77 @@
+/*
+Copyright The CloudNativePG Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"database/sql"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/lib/pq"
+)
+
+// DisableSuperuserPassword disables the password for the `postgres` user
+func DisableSuperuserPassword(db *sql.DB) error {
+	tx, err := db.Begin()
+	if err != nil {
+		return err
+	}
+	defer func() {
+		// This has no effect if the transaction
+		// is committed
+		_ = tx.Rollback()
+	}()
+
+	// we don't want to be stuck here if synchronous replicas are still not alive
+	// and kicking
+	_, err = tx.Exec("SET LOCAL synchronous_commit to LOCAL")
+	if err != nil {
+		return err
+	}
+
+	_, err = tx.Exec("ALTER ROLE postgres WITH PASSWORD NULL")
+	return err
+}
+
+// SetUserPassword change the password of a user in the PostgreSQL database
+func SetUserPassword(username string, password string, db *sql.DB) error {
+	tx, err := db.Begin()
+	if err != nil {
+		return err
+	}
+	defer func() {
+		// This has no effect if the transaction
+		// is committed
+		_ = tx.Rollback()
+	}()
+
+	// we don't want to be stuck here if synchronous replicas are still not alive
+	// and kicking
+	_, err = tx.Exec("SET LOCAL synchronous_commit to LOCAL")
+	if err != nil {
+		return err
+	}
+
+	_, err = tx.Exec(fmt.Sprintf("ALTER ROLE %v WITH PASSWORD %v",
+		pgx.Identifier{username}.Sanitize(),
+		pq.QuoteLiteral(password)))
+	if err != nil {
+		return fmt.Errorf("while running ALTER ROLE %v WITH PASSWORD: %w", username, err)
+	}
+
+	return tx.Commit()
+}

--- a/pkg/management/postgres/utils/roles.go
+++ b/pkg/management/postgres/utils/roles.go
@@ -44,7 +44,11 @@ func DisableSuperuserPassword(db *sql.DB) error {
 	}
 
 	_, err = tx.Exec("ALTER ROLE postgres WITH PASSWORD NULL")
-	return err
+	if err != nil {
+		return fmt.Errorf("while running ALTER ROLE %v WITH PASSWORD: %w", "postgres", err)
+	}
+
+	return tx.Commit()
 }
 
 // SetUserPassword change the password of a user in the PostgreSQL database

--- a/pkg/management/postgres/utils/roles_test.go
+++ b/pkg/management/postgres/utils/roles_test.go
@@ -36,6 +36,7 @@ var _ = Describe("Credentials management functions", func() {
 		mock.ExpectCommit()
 
 		Expect(DisableSuperuserPassword(db)).To(Succeed())
+		Expect(mock.ExpectationsWereMet()).To(Succeed())
 	})
 
 	It("can set the password for a PostgreSQL role", func() {
@@ -50,6 +51,7 @@ var _ = Describe("Credentials management functions", func() {
 		mock.ExpectCommit()
 
 		Expect(SetUserPassword("testuser", "testpassword", db)).To(Succeed())
+		Expect(mock.ExpectationsWereMet()).To(Succeed())
 	})
 
 	It("will correctly escape the password if needed", func() {
@@ -64,5 +66,6 @@ var _ = Describe("Credentials management functions", func() {
 		mock.ExpectCommit()
 
 		Expect(SetUserPassword("testuser", "this \"is\" weird but 'possible'", db)).To(Succeed())
+		Expect(mock.ExpectationsWereMet()).To(Succeed())
 	})
 })

--- a/pkg/management/postgres/utils/roles_test.go
+++ b/pkg/management/postgres/utils/roles_test.go
@@ -1,0 +1,68 @@
+/*
+Copyright The CloudNativePG Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"github.com/DATA-DOG/go-sqlmock"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Credentials management functions", func() {
+	It("can disable the password for the PostgreSQL user", func() {
+		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+		Expect(err).ToNot(HaveOccurred())
+
+		mock.ExpectBegin()
+		mock.ExpectExec("SET LOCAL synchronous_commit to LOCAL").
+			WillReturnResult(sqlmock.NewResult(0, 0))
+		mock.ExpectExec("ALTER ROLE postgres WITH PASSWORD NULL").
+			WillReturnResult(sqlmock.NewResult(0, 1))
+		mock.ExpectCommit()
+
+		Expect(DisableSuperuserPassword(db)).To(Succeed())
+	})
+
+	It("can set the password for a PostgreSQL role", func() {
+		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+		Expect(err).ToNot(HaveOccurred())
+
+		mock.ExpectBegin()
+		mock.ExpectExec("SET LOCAL synchronous_commit to LOCAL").
+			WillReturnResult(sqlmock.NewResult(0, 0))
+		mock.ExpectExec("ALTER ROLE \"testuser\" WITH PASSWORD 'testpassword'").
+			WillReturnResult(sqlmock.NewResult(0, 0))
+		mock.ExpectCommit()
+
+		Expect(SetUserPassword("testuser", "testpassword", db)).To(Succeed())
+	})
+
+	It("will correctly escape the password if needed", func() {
+		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+		Expect(err).ToNot(HaveOccurred())
+
+		mock.ExpectBegin()
+		mock.ExpectExec("SET LOCAL synchronous_commit to LOCAL").
+			WillReturnResult(sqlmock.NewResult(0, 0))
+		mock.ExpectExec("ALTER ROLE \"testuser\" WITH PASSWORD 'this \"is\" weird but ''possible'''").
+			WillReturnResult(sqlmock.NewResult(0, 0))
+		mock.ExpectCommit()
+
+		Expect(SetUserPassword("testuser", "this \"is\" weird but 'possible'", db)).To(Succeed())
+	})
+})

--- a/pkg/management/postgres/utils/suite_test.go
+++ b/pkg/management/postgres/utils/suite_test.go
@@ -1,0 +1,30 @@
+/*
+Copyright The CloudNativePG Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestPostgresUtils(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecs(t, "PostgreSQL Utils Test Suite")
+}


### PR DESCRIPTION
The operator codebase now uses separate transactions to reconcile the credentials of multiple users.

Before this patch, the operator used a single transaction for all roles. A failure in the synchronization of a role led to a failure in the synchronization of every role, being the transaction rolled back as a whole.

The patch also includes a few fixes in the unit tests of related functions.

See: #1881