### PR TITLE
feat: Add `pg_failover_slots` to managed extensions

### DIFF
--- a/api/v1/cluster_webhook.go
+++ b/api/v1/cluster_webhook.go
@@ -1994,19 +1994,23 @@ func (r *Cluster) validatePgFailoverSlots() field.ErrorList {
 				fmt.Sprintf("%s must be 'on' to use %s", hotStandbyFeedbackKey, pgFailoverSlots.Name)))
 	}
 
-	replicationSlotPath := field.NewPath("spec", "replicationSlots", "highAvailability", "enabled")
-	replicationSlotOut := fmt.Sprintf("High Availability replication slots must be enabled to use %s",
-		pgFailoverSlots.Name)
-	replicationSlots := r.Spec.ReplicationSlots
-	if replicationSlots == nil ||
-		replicationSlots.HighAvailability == nil ||
-		replicationSlots.HighAvailability.Enabled == nil {
-		result = append(result, field.Invalid(replicationSlotPath, nil, replicationSlotOut))
-	} else if !replicationSlots.HighAvailability.GetEnabled() {
-		result = append(result, field.Invalid(
-			replicationSlotPath,
-			replicationSlots.HighAvailability.GetEnabled(),
-			replicationSlotOut))
+	if r.Spec.ReplicationSlots == nil {
+		return append(result,
+			field.Invalid(
+				field.NewPath("spec", "replicationSlots"),
+				nil,
+				"replicationSlots must be enabled"),
+		)
+	}
+
+	if r.Spec.ReplicationSlots.HighAvailability == nil ||
+		!r.Spec.ReplicationSlots.HighAvailability.GetEnabled() {
+		return append(result,
+			field.Invalid(
+				field.NewPath("spec", "replicationSlots", "highAvailability"),
+				"nil or false",
+				"High Availability replication slots must be enabled"),
+		)
 	}
 
 	return result

--- a/api/v1/cluster_webhook_test.go
+++ b/api/v1/cluster_webhook_test.go
@@ -2888,6 +2888,79 @@ var _ = Describe("Role management validation", func() {
 	})
 })
 
+var _ = Describe("Managed Extensions validation", func() {
+	It("should succeed if no extension is enabled", func() {
+		cluster := Cluster{
+			Spec: ClusterSpec{},
+		}
+		Expect(cluster.validateManagedExtensions()).To(BeEmpty())
+	})
+
+	It("should succeed if pg_failover_slots and its prerequisites are enabled", func() {
+		cluster := &Cluster{
+			Spec: ClusterSpec{
+				ReplicationSlots: &ReplicationSlotsConfiguration{
+					HighAvailability: &ReplicationSlotsHAConfiguration{
+						Enabled: pointer.Bool(true),
+					},
+				},
+				PostgresConfiguration: PostgresConfiguration{
+					Parameters: map[string]string{
+						"hot_standby_feedback":                     "on",
+						"pg_failover_slots.synchronize_slot_names": "my_slot",
+					},
+				},
+			},
+		}
+		Expect(cluster.validatePgFailoverSlots()).To(BeEmpty())
+	})
+
+	It("should produce two errors if pg_failover_slots is enabled and its prerequisites are disabled", func() {
+		cluster := &Cluster{
+			Spec: ClusterSpec{
+				PostgresConfiguration: PostgresConfiguration{
+					Parameters: map[string]string{
+						"pg_failover_slots.synchronize_slot_names": "my_slot",
+					},
+				},
+			},
+		}
+		Expect(cluster.validatePgFailoverSlots()).To(HaveLen(2))
+	})
+
+	It("should produce an error if pg_failover_slots is enabled and HA slots are disabled", func() {
+		cluster := &Cluster{
+			Spec: ClusterSpec{
+				PostgresConfiguration: PostgresConfiguration{
+					Parameters: map[string]string{
+						"hot_standby_feedback":                     "on",
+						"pg_failover_slots.synchronize_slot_names": "my_slot",
+					},
+				},
+			},
+		}
+		Expect(cluster.validatePgFailoverSlots()).To(HaveLen(1))
+	})
+
+	It("should produce an error if pg_failover_slots is enabled and hot_standby_feedback is disabled", func() {
+		cluster := &Cluster{
+			Spec: ClusterSpec{
+				ReplicationSlots: &ReplicationSlotsConfiguration{
+					HighAvailability: &ReplicationSlotsHAConfiguration{
+						Enabled: pointer.Bool(true),
+					},
+				},
+				PostgresConfiguration: PostgresConfiguration{
+					Parameters: map[string]string{
+						"pg_failover_slots.synchronize_slot_names": "my_slot",
+					},
+				},
+			},
+		}
+		Expect(cluster.validatePgFailoverSlots()).To(HaveLen(1))
+	})
+})
+
 var _ = Describe("Recovery from volume snapshot validation", func() {
 	clusterFromRecovery := func(recovery *BootstrapRecovery) *Cluster {
 		return &Cluster{

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -70,8 +70,8 @@ Additionally, the Community provides images for the [PostGIS extension](postgis.
 * Definition of the *read-write* service, to connect your applications to the only primary server of the cluster
 * Definition of the *read-only* service, to connect your applications to any of the instances for reading workloads
 * Declarative management of PostgreSQL configuration, including certain popular
-  Postgres extensions through the cluster `spec`: `pg_audit`, `auto_explain`,
-  and `pg_stat_statements`
+  Postgres extensions through the cluster `spec`: `pgaudit`, `auto_explain`,
+  `pg_stat_statements`, and `pg_failover_slots`
 * Declarative management of Postgres roles, users and groups
 * Support for Local Persistent Volumes with PVC templates
 * Reuse of Persistent Volumes storage in Pods

--- a/docs/src/operator_capability_levels.md
+++ b/docs/src/operator_capability_levels.md
@@ -533,7 +533,7 @@ CloudNativePG transparently and natively supports:
 - the [`pg_failover_slots` extension](https://github.com/EnterpriseDB/pg_failover_slots),
   which makes logical replication slots usable across a physical failover,
   ensuring resilience in change data capture (CDC) contexts based on PostgreSQL's
-  native logical replication.
+  native logical replication;
 
 ### Audit
 

--- a/docs/src/operator_capability_levels.md
+++ b/docs/src/operator_capability_levels.md
@@ -525,11 +525,15 @@ CloudNativePG transparently and natively supports:
 
 - the essential [`pg_stat_statements` extension](https://www.postgresql.org/docs/current/pgstatstatements.html),
   which enables tracking of planning and execution statistics of all SQL
-  statements executed by a PostgreSQL server.
+  statements executed by a PostgreSQL server;
 - the [`auto_explain` extension](https://www.postgresql.org/docs/current/auto-explain.html),
   which provides a means for logging execution plans of slow statements
   automatically, without having to manually run `EXPLAIN` (helpful for tracking
-  down un-optimized queries).
+  down un-optimized queries);
+- the [`pg_failover_slots` extension](https://github.com/EnterpriseDB/pg_failover_slots),
+  which makes logical replication slots usable across a physical failover,
+  ensuring resilience in change data capture (CDC) contexts based on PostgreSQL's
+  native logical replication.
 
 ### Audit
 

--- a/docs/src/postgresql_conf.md
+++ b/docs/src/postgresql_conf.md
@@ -292,6 +292,17 @@ transparently manage the `pg_failover_slots` entry in the
 Please refer to [`the `pg_failover_slots` documentation`](https://www.postgresql.org/docs/current/auto-explain.html)
 for details on this extension.
 
+Additionally, for each database that you intend to you use with `pg_failover_slots`
+you need to add an entry in the `pg_hba` section that enables each replica to
+connect to the primary.
+For example, suppose that you want to use the `app` database with `pg_failover_slots`,
+you need to add this entry in the `pg_hba` section:
+
+``` yaml
+  postgresql:
+    pg_hba:
+      - hostssl app streaming_replica all cert
+
 ## The `pg_hba` section
 
 `pg_hba` is a list of PostgreSQL Host Based Authentication rules

--- a/docs/src/postgresql_conf.md
+++ b/docs/src/postgresql_conf.md
@@ -289,7 +289,7 @@ that starts with `pg_failover_slots.`: as explained above, the operator will
 transparently manage the `pg_failover_slots` entry in the
 `shared_preload_libraries` option depending on this.
 
-Please refer to [`the `pg_failover_slots` documentation`](https://www.postgresql.org/docs/current/auto-explain.html)
+Please refer to [`the `pg_failover_slots` documentation`](https://www.enterprisedb.com/docs/pg_extensions/pg_failover_slots)
 for details on this extension.
 
 Additionally, for each database that you intend to you use with `pg_failover_slots`

--- a/docs/src/postgresql_conf.md
+++ b/docs/src/postgresql_conf.md
@@ -191,6 +191,7 @@ supported extensions. The current list includes:
 - `auto_explain`
 - `pg_stat_statements`
 - `pgaudit`
+- `pg_failover_slots`
 
 Some of these libraries also require additional objects in a database before
 using them, normally views and/or functions managed via the `CREATE EXTENSION`
@@ -275,6 +276,21 @@ postgresql:
     pgaudit.log_relation: "on"
 #
 ```
+
+#### Enabling `auto_explain`
+
+The [`pg_failover_slots`](https://github.com/EnterpriseDB/pg_failover_slots)
+extension by EDB ensures that logical replication slots can survive a
+failover scenario. Failovers are normally implemented using physical
+streaming replication, like in the case of CloudNativePG.
+
+You can enable `pg_failover_slots` by adding to the configuration a parameter
+that starts with `pg_failover_slots.`: as explained above, the operator will
+transparently manage the `pg_failover_slots` entry in the
+`shared_preload_libraries` option depending on this.
+
+Please refer to [`the `pg_failover_slots`  documentation`](https://www.postgresql.org/docs/current/auto-explain.html)
+for details on this extension.
 
 ## The `pg_hba` section
 

--- a/docs/src/postgresql_conf.md
+++ b/docs/src/postgresql_conf.md
@@ -277,7 +277,7 @@ postgresql:
 #
 ```
 
-#### Enabling `auto_explain`
+#### Enabling `pg_failover_slots`
 
 The [`pg_failover_slots`](https://github.com/EnterpriseDB/pg_failover_slots)
 extension by EDB ensures that logical replication slots can survive a
@@ -289,7 +289,7 @@ that starts with `pg_failover_slots.`: as explained above, the operator will
 transparently manage the `pg_failover_slots` entry in the
 `shared_preload_libraries` option depending on this.
 
-Please refer to [`the `pg_failover_slots`  documentation`](https://www.postgresql.org/docs/current/auto-explain.html)
+Please refer to [`the `pg_failover_slots` documentation`](https://www.postgresql.org/docs/current/auto-explain.html)
 for details on this extension.
 
 ## The `pg_hba` section

--- a/pkg/postgres/configuration.go
+++ b/pkg/postgres/configuration.go
@@ -273,6 +273,12 @@ var (
 			Namespaces:             []string{"auto_explain"},
 			SharedPreloadLibraries: []string{"auto_explain"},
 		},
+		{
+			Name:                   "pg_failover_slots",
+			SkipCreateExtension:    true,
+			Namespaces:             []string{"pg_failover_slots"},
+			SharedPreloadLibraries: []string{"pg_failover_slots"},
+		},
 	}
 
 	// FixedConfigurationParameters contains the parameters that can't be

--- a/pkg/postgres/configuration.go
+++ b/pkg/postgres/configuration.go
@@ -33,7 +33,7 @@ const (
 local all all peer map=local
 
 # Require client certificate authentication for the streaming_replica user
-hostssl postgres streaming_replica all cert
+hostssl all streaming_replica all cert
 hostssl replication streaming_replica all cert
 hostssl all cnpg_pooler_pgbouncer all cert
 
@@ -331,6 +331,7 @@ var (
 		"log_rotation_age":                       blockedConfigurationParameter,
 		"log_rotation_size":                      blockedConfigurationParameter,
 		"log_truncate_on_rotation":               blockedConfigurationParameter,
+		"pg_failover_slots.primary_dsn":          fixedConfigurationParameter,
 		"promote_trigger_file":                   blockedConfigurationParameter,
 		"recovery_end_command":                   blockedConfigurationParameter,
 		"recovery_min_apply_delay":               blockedConfigurationParameter,

--- a/pkg/postgres/configuration.go
+++ b/pkg/postgres/configuration.go
@@ -33,7 +33,7 @@ const (
 local all all peer map=local
 
 # Require client certificate authentication for the streaming_replica user
-hostssl all streaming_replica all cert
+hostssl postgres streaming_replica all cert
 hostssl replication streaming_replica all cert
 hostssl all cnpg_pooler_pgbouncer all cert
 

--- a/pkg/postgres/configuration_test.go
+++ b/pkg/postgres/configuration_test.go
@@ -250,7 +250,8 @@ var _ = Describe("pg_hba.conf generation", func() {
 
 var _ = Describe("pgaudit", func() {
 	var pgaudit *ManagedExtension
-	It("manages pgaudit", func() {
+	BeforeEach(func() {
+		pgaudit = nil
 		for i, ext := range ManagedExtensions {
 			if ext.Name == "pgaudit" {
 				pgaudit = &ManagedExtensions[i]
@@ -259,15 +260,18 @@ var _ = Describe("pgaudit", func() {
 		}
 		Expect(pgaudit).ToNot(BeNil())
 	})
+
 	It("is enabled", func() {
 		userConfigsWithPgAudit := make(map[string]string, 1)
 		userConfigsWithPgAudit["pgaudit.xxx"] = "test"
 		Expect(pgaudit.IsUsed(userConfigsWithPgAudit)).To(BeTrue())
 	})
+
 	It("is not enabled", func() {
 		userConfigsWithNoPgAudit := make(map[string]string, 1)
 		Expect(pgaudit.IsUsed(userConfigsWithNoPgAudit)).To(BeFalse())
 	})
+
 	It("adds pgaudit to shared_preload_library", func() {
 		info := ConfigurationInfo{
 			Settings:                        CnpgConfigurationSettings,
@@ -285,6 +289,7 @@ var _ = Describe("pgaudit", func() {
 		Expect(libraries).ToNot(ContainElement(""))
 		Expect(libraries).To(ContainElements("pgaudit", "other_library"))
 	})
+
 	It("adds pg_stat_statements to shared_preload_library", func() {
 		info := ConfigurationInfo{
 			Settings:                        CnpgConfigurationSettings,
@@ -302,6 +307,7 @@ var _ = Describe("pgaudit", func() {
 		Expect(libraries).ToNot(ContainElement(""))
 		Expect(libraries).To(ContainElements("pg_stat_statements", "other_library"))
 	})
+
 	It("adds pg_stat_statements and pgaudit to shared_preload_library", func() {
 		info := ConfigurationInfo{
 			Settings:     CnpgConfigurationSettings,

--- a/pkg/postgres/configuration_test.go
+++ b/pkg/postgres/configuration_test.go
@@ -327,3 +327,21 @@ var _ = Describe("pgaudit", func() {
 		Expect(libraries).To(ContainElements("pg_stat_statements", "pgaudit"))
 	})
 })
+
+var _ = Describe("pg_failover_slots", func() {
+	It("adds pg_failover_slots to shared_preload_library", func() {
+		info := ConfigurationInfo{
+			Settings:                        CnpgConfigurationSettings,
+			MajorVersion:                    130000,
+			UserSettings:                    map[string]string{"pg_failover_slots.something": "something"},
+			IncludingMandatory:              true,
+			IncludingSharedPreloadLibraries: true,
+			SyncReplicas:                    0,
+		}
+		config := CreatePostgresqlConfiguration(info)
+		libraries := strings.Split(config.GetConfig(SharedPreloadLibraries), ",")
+		Expect(len(libraries)).To(BeNumerically("==", 1))
+		Expect(libraries).ToNot(ContainElement(""))
+		Expect(libraries).To(ContainElements("pg_failover_slots"))
+	})
+})

--- a/pkg/postgres/configuration_test.go
+++ b/pkg/postgres/configuration_test.go
@@ -302,7 +302,7 @@ var _ = Describe("pgaudit", func() {
 		Expect(libraries).ToNot(ContainElement(""))
 		Expect(libraries).To(ContainElements("pg_stat_statements", "other_library"))
 	})
-	It("adds pg_stat_statements and pg_audit to shared_preload_library", func() {
+	It("adds pg_stat_statements and pgaudit to shared_preload_library", func() {
 		info := ConfigurationInfo{
 			Settings:     CnpgConfigurationSettings,
 			MajorVersion: 130000,


### PR DESCRIPTION
Closes #2042 

Add [pg_failover_slots](https://github.com/EnterpriseDB/pg_failover_slots),
which was recently released by EDB under the PostgreSQL license,
to the list of extensions managed by the operator.

When a user adds a pg_failover_slots.* option in the Postgres configuration
file, CloudNativePG automatically manage the `shared_preload_libraries` entry.