### PR TITLE
test: add e2e-test-local make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,9 @@ e2e-test-kind: ## Run e2e tests locally using kind.
 e2e-test-k3d: ## Run e2e tests locally using k3d.
 	hack/e2e/run-e2e-k3d.sh
 
+e2e-test-local: ## Run e2e tests locally using the default kubernetes context.
+	hack/e2e/run-e2e-local.sh
+
 ##@ Build
 build: generate fmt vet ## Build binaries.
 	go build -o bin/manager -ldflags ${LDFLAGS} ./cmd/manager

--- a/hack/e2e/run-e2e-local.sh
+++ b/hack/e2e/run-e2e-local.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+##
+## Copyright The CloudNativePG Contributors
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##     http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##
+
+# standard bash error handling
+set -eEuo pipefail
+
+if [ "${DEBUG-}" = true ]; then
+  set -x
+fi
+
+ROOT_DIR=$(realpath "$(dirname "$0")/../../")
+
+DEFAULT_STORAGE_CLASS=$(kubectl get storageclass -o json | jq  -r 'first(.items[] | select (.metadata.annotations["storageclass.kubernetes.io/is-default-class"] == "true") | .metadata.name)')
+export E2E_DEFAULT_STORAGE_CLASS=${E2E_DEFAULT_STORAGE_CLASS:-${DEFAULT_STORAGE_CLASS}}
+export POSTGRES_IMG=${POSTGRES_IMG:-$(grep 'DefaultImageName.*=' "${ROOT_DIR}/pkg/versions/versions.go" | cut -f 2 -d \")}
+
+# Unset DEBUG to prevent k8s from spamming messages
+unset DEBUG
+
+LABEL_FILTERS=""
+if [ "${FEATURE_TYPE-}" ]; then
+  LABEL_FILTERS="${FEATURE_TYPE//,/ || }"
+fi
+echo "E2E tests are running with the following filters: ${LABEL_FILTERS}"
+
+mkdir -p "${ROOT_DIR}/tests/e2e/out"
+RC_GINKGO=0
+export TEST_SKIP_UPGRADE=true
+ginkgo --nodes=4 --timeout 3h --poll-progress-after=1200s --poll-progress-interval=150s \
+       ${LABEL_FILTERS:+--label-filter "${LABEL_FILTERS}"} \
+       --output-dir "${ROOT_DIR}/tests/e2e/out/" \
+       --json-report  "report.json" -v "${ROOT_DIR}/tests/e2e/..." || RC_GINKGO=$?
+
+# Report if there are any tests that failed and did NOT have an "ignore-fails" label
+RC=0
+jq -e -c -f "${ROOT_DIR}/hack/e2e/test-report.jq" "${ROOT_DIR}/tests/e2e/out/report.json" || RC=$?
+
+# The exit code reported depends on the two `jq` filter calls. In case we have
+# FAIL in the Ginkgo, but the `jq` succeeds because the failures are ignorable,
+# we should add some explanation
+set +x
+if [[ $RC == 0 ]]; then
+  if [[ $RC_GINKGO != 0 ]]; then
+    printf "\033[0;32m%s\n" "SUCCESS. All the failures in Ginkgo are labelled 'ignore-fails'."
+    echo
+  fi
+fi

--- a/hack/e2e/run-e2e-local.sh
+++ b/hack/e2e/run-e2e-local.sh
@@ -20,6 +20,7 @@
 set -eEuo pipefail
 
 ROOT_DIR=$(realpath "$(dirname "$0")/../../")
+FEATURE_TYPE=${FEATURE_TYPE:-""}
 readonly ROOT_DIR
 
 if [ "${DEBUG-}" = true ]; then
@@ -40,15 +41,7 @@ export POSTGRES_IMG=${POSTGRES_IMG:-$(get_postgres_image)}
 # Unset DEBUG to prevent k8s from spamming messages
 unset DEBUG
 
-function get_label_filters() {
-  if [[ -n "${FEATURE_TYPE:-}" ]]; then
-    echo "${FEATURE_TYPE//,/ || }"
-  else
-    echo ""
-  fi
-}
-
-LABEL_FILTERS=$(get_label_filters)
+LABEL_FILTERS=${FEATURE_TYPE//,/ ||}
 readonly LABEL_FILTERS
 
 echo "E2E tests are running with the following filters: ${LABEL_FILTERS}"

--- a/tests/e2e/upgrade_test.go
+++ b/tests/e2e/upgrade_test.go
@@ -19,6 +19,7 @@ package e2e
 import (
 	"errors"
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -84,6 +85,9 @@ var _ = Describe("Upgrade", Label(tests.LabelUpgrade, tests.LabelNoOpenshift), O
 	)
 
 	BeforeEach(func() {
+		if os.Getenv("TEST_SKIP_UPGRADE") != "" {
+			Skip("Skipping upgrade test because TEST_SKIP_UPGRADE variable is defined")
+		}
 		if testLevelEnv.Depth < int(level) {
 			Skip("Test depth is lower than the amount requested for this test")
 		}


### PR DESCRIPTION
Invoking `make e2e-test-local` will run the E2E tests directly in the default Kubernetes cluster, assuming the operator is already deployed and configured.

It will run the tests using the default storage class (override it using E2E_DEFAULT_STORAGE_CLASS env variable) and the default operand in the current repository (override it using POSTGRES_IMG env variable).

Closes #2071 