### PR TITLE
docs: use the correct walStorage key

### DIFF
--- a/docs/src/bootstrap.md
+++ b/docs/src/bootstrap.md
@@ -502,8 +502,7 @@ bootstrap:
           kind: VolumeSnapshot
           apiGroup: snapshot.storage.k8s.io
 
-      walDataSource:
-        storage:
+        walStorage:
           name: <snapshot name>
           kind: VolumeSnapshot
           apiGroup: snapshot.storage.k8s.io


### PR DESCRIPTION
Fix the example for the use of volume snapshot in the bootstrap section of the documentation.

Close #2139 