### PR TITLE
fix: halt the failover if status extraction has failed

### DIFF
--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -256,17 +256,17 @@ func (r *ClusterReconciler) reconcile(ctx context.Context, cluster *apiv1.Cluste
 	// un-fenced, and the Kubelet still hasn't refreshed the status of the
 	// readiness probe.
 	if instancesStatus.Len() > 0 {
-		podStatus := instancesStatus.Items[0]
-		hasHTTPStatus := podStatus.HasHTTPStatus()
-		isPodReady := podStatus.IsPodReady
+		mostAdvancedInstance := instancesStatus.Items[0]
+		hasHTTPStatus := mostAdvancedInstance.HasHTTPStatus()
+		isPodReady := mostAdvancedInstance.IsPodReady
 
 		if hasHTTPStatus && !isPodReady {
 			// The readiness probe status from the Kubelet is not updated, so
 			// we need to wait for it to be refreshed
 			contextLogger.Info(
 				"Waiting for the Kubelet to refresh the readiness probe",
-				"instanceName", podStatus.Node,
-				"instanceStatus", podStatus,
+				"mostAdvancedInstanceName", mostAdvancedInstance.Node,
+				"mostAdvancedInstanceStatus", mostAdvancedInstance,
 				"hasHTTPStatus", hasHTTPStatus,
 				"isPodReady", isPodReady)
 			return ctrl.Result{RequeueAfter: 1 * time.Second}, nil

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -230,16 +230,16 @@ func (r *ClusterReconciler) reconcile(ctx context.Context, cluster *apiv1.Cluste
 		return ctrl.Result{}, fmt.Errorf("cannot update the instances status on the cluster: %w", err)
 	}
 
-	if !instancesStatus.HasExtractedStatusFromReadyInstances() {
+	if !instancesStatus.AllReadyInstancesStatusExtracted() {
 		contextLogger.Warning(
-			"The operator has encountered an error while extracting the instances status, requeuing",
+			"Failed to extract instance status from ready instances. Attempting requeue...",
 		)
 		registerPhaseErr := r.RegisterPhase(
 			ctx,
 			cluster,
-			"Unable to extract instance status via HTTP",
-			"The operator did not receive the status from one or more ready instances. "+
-				"Ensure that there are no network restrictions (ex: NetworkPolicy).",
+			"Instance Status Extraction Error: HTTP communication issue",
+			"Communication issue detected: The operator was unable to receive the status from one or more ready instances. "+
+				"This may be due to network restrictions such as NetworkPolicy settings. Please verify your network configuration.",
 		)
 		return ctrl.Result{RequeueAfter: 10 * time.Second}, registerPhaseErr
 	}

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -232,14 +232,15 @@ func (r *ClusterReconciler) reconcile(ctx context.Context, cluster *apiv1.Cluste
 
 	if instancesStatus.AllReadyInstancesStatusUnreachable() {
 		contextLogger.Warning(
-			"Failed to extract instance status from ready instances. Attempting requeue...",
+			"Failed to extract instance status from ready instances. Attempting to requeue...",
 		)
 		registerPhaseErr := r.RegisterPhase(
 			ctx,
 			cluster,
 			"Instance Status Extraction Error: HTTP communication issue",
 			"Communication issue detected: The operator was unable to receive the status from all the ready instances. "+
-				"This may be due to network restrictions such as NetworkPolicy settings. Please verify your network configuration.",
+				"This may be due to network restrictions such as NetworkPolicy and/or any other network plugin setting. "+
+				"Please verify your network configuration.",
 		)
 		return ctrl.Result{RequeueAfter: 10 * time.Second}, registerPhaseErr
 	}

--- a/controllers/replicas.go
+++ b/controllers/replicas.go
@@ -106,20 +106,8 @@ func (r *ClusterReconciler) updateTargetPrimaryFromPodsPrimaryCluster(
 	}
 
 	// If the first pod of the list has no reported status, it means that we weren't able to fetch any status.
+	// This is a programmatic error as the reconciliation cycle should not have reached this function.
 	if !mostAdvancedInstance.HasHTTPStatus() {
-		contextLogger.Warning(
-			"Failed to extract instance status from ready instances. Attempting requeue...",
-		)
-		if err := r.RegisterPhase(
-			ctx,
-			cluster,
-			"Instance Status Extraction Error: HTTP communication issue",
-			"Communication issue detected: The operator was unable to receive the status from one or more ready instances. "+
-				"This may be due to network restrictions such as NetworkPolicy settings. Please verify your network configuration.",
-		); err != nil {
-			return "", fmt.Errorf("while registering phase: %w", err)
-		}
-
 		return "", fmt.Errorf("unable to evaluate failover logic, unable to fetch the instances status")
 	}
 

--- a/controllers/replicas.go
+++ b/controllers/replicas.go
@@ -100,13 +100,13 @@ func (r *ClusterReconciler) updateTargetPrimaryFromPodsPrimaryCluster(
 
 	// If the first pod in the sorted list is already the targetPrimary,
 	// we have nothing to do here.
-	primaryStatus := status.Items[0]
-	if cluster.Status.TargetPrimary == primaryStatus.Pod.Name {
+	mostAdvancedInstance := status.Items[0]
+	if cluster.Status.TargetPrimary == mostAdvancedInstance.Pod.Name {
 		return "", nil
 	}
 
-	// if the first pod of the list has no reported status it means that we weren't able to fetch any status.
-	if !primaryStatus.HasHTTPStatus() {
+	// If the first pod of the list has no reported status, it means that we weren't able to fetch any status.
+	if !mostAdvancedInstance.HasHTTPStatus() {
 		contextLogger.Warning(
 			"Failed to extract instance status from ready instances. Attempting requeue...",
 		)
@@ -157,32 +157,33 @@ func (r *ClusterReconciler) updateTargetPrimaryFromPodsPrimaryCluster(
 	// This may be tha last step of a failover if target primary is set to apiv1.PendingFailoverMarker
 	// or change the target primary if the current one is not valid anymore.
 	if cluster.Status.TargetPrimary == apiv1.PendingFailoverMarker {
-		contextLogger.Info("Failing over", "newPrimary", primaryStatus.Pod.Name)
+		contextLogger.Info("Failing over", "newPrimary", mostAdvancedInstance.Pod.Name)
 		status.LogStatus(ctx)
 		contextLogger.Debug("Cluster status before failover", "instances", resources.instances)
 		r.Recorder.Eventf(cluster, "Normal", "FailoverTarget",
 			"Failing over from %v to %v",
-			cluster.Status.CurrentPrimary, primaryStatus.Pod.Name)
+			cluster.Status.CurrentPrimary, mostAdvancedInstance.Pod.Name)
 		if err := r.RegisterPhase(ctx, cluster, apiv1.PhaseFailOver,
-			fmt.Sprintf("Failing over from %v to %v", cluster.Status.CurrentPrimary, primaryStatus.Pod.Name)); err != nil {
+			fmt.Sprintf("Failing over from %v to %v", cluster.Status.CurrentPrimary, mostAdvancedInstance.Pod.Name),
+		); err != nil {
 			return "", err
 		}
 	} else {
 		contextLogger.Info("Target primary isn't healthy, switching target",
-			"newPrimary", primaryStatus.Pod.Name)
+			"newPrimary", mostAdvancedInstance.Pod.Name)
 		status.LogStatus(ctx)
 		contextLogger.Debug("Cluster status before switching target", "instances", resources.instances)
 		r.Recorder.Eventf(cluster, "Normal", "FailingOver",
 			"Target primary isn't healthy, switching target from %v to %v",
-			cluster.Status.TargetPrimary, primaryStatus.Pod.Name)
+			cluster.Status.TargetPrimary, mostAdvancedInstance.Pod.Name)
 		if err := r.RegisterPhase(ctx, cluster, apiv1.PhaseSwitchover,
-			fmt.Sprintf("Switching over to %v", primaryStatus.Pod.Name)); err != nil {
+			fmt.Sprintf("Switching over to %v", mostAdvancedInstance.Pod.Name)); err != nil {
 			return "", err
 		}
 	}
 
 	// Set the first pod in the sorted list as the new targetPrimary
-	return primaryStatus.Pod.Name, r.setPrimaryInstance(ctx, cluster, primaryStatus.Pod.Name)
+	return mostAdvancedInstance.Pod.Name, r.setPrimaryInstance(ctx, cluster, mostAdvancedInstance.Pod.Name)
 }
 
 // isNodeUnschedulable checks whether a node is set to unschedulable

--- a/pkg/postgres/status.go
+++ b/pkg/postgres/status.go
@@ -358,6 +358,23 @@ func (list PostgresqlStatusList) ReportingMightBeUnavailable(instance string) bo
 	return false
 }
 
+// AllReadyInstancesStatusUnreachable checks whether the operator has successfully extracted
+// the status of at least a ready instances via HTTP request.
+// It iterates through the list of PostgreSQL Instances statuses,
+// verifying if the associated active and ready pods are free of errors.
+// Returns true if at least a ready instances have their status extracted successfully, false otherwise.
+func (list PostgresqlStatusList) AllReadyInstancesStatusUnreachable() bool {
+	for _, item := range list.Items {
+		podIsActiveAndReady := utils.IsPodActive(item.Pod) && utils.IsPodReady(item.Pod)
+		if podIsActiveAndReady && item.Error == nil {
+			// If a pod is active, ready and correctly reporting its status, return false.
+			return false
+		}
+	}
+	// All active and ready pods fail to report their status.
+	return true
+}
+
 // InstancesReportingStatus returns the number of instances that are Ready or MightBeUnavailable
 func (list PostgresqlStatusList) InstancesReportingStatus() int {
 	var n int

--- a/pkg/postgres/status.go
+++ b/pkg/postgres/status.go
@@ -358,15 +358,19 @@ func (list PostgresqlStatusList) ReportingMightBeUnavailable(instance string) bo
 	return false
 }
 
-// HasExtractedStatusFromReadyInstances reports if the operator has extracted the status of the ready instances by
-// executing the HTTP request
-func (list PostgresqlStatusList) HasExtractedStatusFromReadyInstances() bool {
+// AllReadyInstancesStatusExtracted checks whether the operator has successfully extracted
+// the status of all ready instances via HTTP request. It iterates through the list of PostgreSQL Instances
+// statuses, verifying if the associated active and ready pods are free of errors.
+// Returns true if all ready instances have their status extracted successfully, false otherwise.
+func (list PostgresqlStatusList) AllReadyInstancesStatusExtracted() bool {
 	for _, item := range list.Items {
-		if utils.IsPodActive(item.Pod) && utils.IsPodReady(item.Pod) && item.Error != nil {
+		podIsActiveAndReady := utils.IsPodActive(item.Pod) && utils.IsPodReady(item.Pod)
+		if podIsActiveAndReady && item.Error != nil {
+			// If a pod is active and ready but an error occurred while extracting its status, return false.
 			return false
 		}
 	}
-
+	// All active and ready pods had their status extracted successfully.
 	return true
 }
 

--- a/pkg/postgres/status.go
+++ b/pkg/postgres/status.go
@@ -73,7 +73,7 @@ type PostgresqlStatus struct {
 	// not still invoked the readiness probe.
 	//
 	// If you want to check the latest detected status of PostgreSQL, you
-	// need to call IsPostgresqlReady().
+	// need to call HasHTTPStatus().
 	//
 	// This field is never populated in the instance manager.
 	IsPodReady bool `json:"isPodReady"`
@@ -115,13 +115,13 @@ func (status *PostgresqlStatus) AddPod(pod corev1.Pod) {
 	status.Node = pod.Spec.NodeName
 }
 
-// IsPostgresqlReady checks if the instance manager is reporting this
+// HasHTTPStatus checks if the instance manager is reporting this
 // instance as ready.
 //
 // The result represents the state of PostgreSQL at the moment of the
 // collection of the instance status and is more up-to-date than
 // IsPodReady field, which is updated asynchronously.
-func (status PostgresqlStatus) IsPostgresqlReady() bool {
+func (status PostgresqlStatus) HasHTTPStatus() bool {
 	// To load the status of this instance, we use the `/pg/status` endpoint
 	// of the instance manager. PostgreSQL is ready and running if the
 	// endpoint returns success, and the Error field will be nil.
@@ -356,22 +356,6 @@ func (list PostgresqlStatusList) ReportingMightBeUnavailable(instance string) bo
 	}
 
 	return false
-}
-
-// AllReadyInstancesStatusExtracted checks whether the operator has successfully extracted
-// the status of all ready instances via HTTP request. It iterates through the list of PostgreSQL Instances
-// statuses, verifying if the associated active and ready pods are free of errors.
-// Returns true if all ready instances have their status extracted successfully, false otherwise.
-func (list PostgresqlStatusList) AllReadyInstancesStatusExtracted() bool {
-	for _, item := range list.Items {
-		podIsActiveAndReady := utils.IsPodActive(item.Pod) && utils.IsPodReady(item.Pod)
-		if podIsActiveAndReady && item.Error != nil {
-			// If a pod is active and ready but an error occurred while extracting its status, return false.
-			return false
-		}
-	}
-	// All active and ready pods had their status extracted successfully.
-	return true
 }
 
 // InstancesReportingStatus returns the number of instances that are Ready or MightBeUnavailable

--- a/pkg/postgres/status.go
+++ b/pkg/postgres/status.go
@@ -364,6 +364,10 @@ func (list PostgresqlStatusList) ReportingMightBeUnavailable(instance string) bo
 // verifying if the associated active and ready pods are free of errors.
 // Returns true if at least a ready instances have their status extracted successfully, false otherwise.
 func (list PostgresqlStatusList) AllReadyInstancesStatusUnreachable() bool {
+	if len(list.Items) == 0 {
+		return false
+	}
+
 	for _, item := range list.Items {
 		podIsActiveAndReady := utils.IsPodActive(item.Pod) && utils.IsPodReady(item.Pod)
 		if podIsActiveAndReady && item.Error == nil {

--- a/pkg/postgres/status.go
+++ b/pkg/postgres/status.go
@@ -358,6 +358,18 @@ func (list PostgresqlStatusList) ReportingMightBeUnavailable(instance string) bo
 	return false
 }
 
+// HasExtractedStatusFromReadyInstances reports if the operator has extracted the status of the ready instances by
+// executing the HTTP request
+func (list PostgresqlStatusList) HasExtractedStatusFromReadyInstances() bool {
+	for _, item := range list.Items {
+		if utils.IsPodActive(item.Pod) && utils.IsPodReady(item.Pod) && item.Error != nil {
+			return false
+		}
+	}
+
+	return true
+}
+
 // InstancesReportingStatus returns the number of instances that are Ready or MightBeUnavailable
 func (list PostgresqlStatusList) InstancesReportingStatus() int {
 	var n int

--- a/pkg/postgres/status.go
+++ b/pkg/postgres/status.go
@@ -358,25 +358,24 @@ func (list PostgresqlStatusList) ReportingMightBeUnavailable(instance string) bo
 	return false
 }
 
-// AllReadyInstancesStatusUnreachable checks whether the operator has successfully extracted
-// the status of at least a ready instances via HTTP request.
-// It iterates through the list of PostgreSQL Instances statuses,
-// verifying if the associated active and ready pods are free of errors.
-// Returns true if at least a ready instances have their status extracted successfully, false otherwise.
+// AllReadyInstancesStatusUnreachable returns true if all the
+// ready instances are unreachable from the operator via HTTP request.
 func (list PostgresqlStatusList) AllReadyInstancesStatusUnreachable() bool {
-	if len(list.Items) == 0 {
-		return false
-	}
-
+	hasActiveAndReady := false
 	for _, item := range list.Items {
 		podIsActiveAndReady := utils.IsPodActive(item.Pod) && utils.IsPodReady(item.Pod)
-		if podIsActiveAndReady && item.Error == nil {
-			// If a pod is active, ready and correctly reporting its status, return false.
+
+		if !podIsActiveAndReady {
+			continue
+		}
+
+		hasActiveAndReady = true
+		if item.Error == nil {
 			return false
 		}
 	}
-	// All active and ready pods fail to report their status.
-	return true
+
+	return hasActiveAndReady
 }
 
 // InstancesReportingStatus returns the number of instances that are Ready or MightBeUnavailable


### PR DESCRIPTION
This commit addresses an issue where the failover process would continue even if the operator failed to extract status from the instances, potentially due to network connectivity issues. 

The operator now checks if the status has been successfully extracted from the instances before proceeding with the failover. If status extraction fails, the operator logs an error message, halts the current failover attempt, and reschedules another attempt after a delay.

Closes #2144 
