### PR TITLE
chore: deprecating ubuntu-20.04 in favor of ubuntu-22.04 for GitHub actions

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -18,7 +18,7 @@ jobs:
     name: label the source pr
     if: github.event.pull_request.merged == false &&
         !contains(github.event.pull_request.labels.*.name, 'backport-requested')
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       -
         name: label the pull request
@@ -55,7 +55,7 @@ jobs:
           contains(github.event.pull_request.labels.*.name, 'backport-requested :arrow_backward:')
         ) &&
         !contains(github.event.pull_request.labels.*.name, 'do not backport')
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -129,7 +129,7 @@ jobs:
     env:
       PR: ${{ github.event.pull_request.number }}
       COMMIT: ${{ needs.back-porting-pr.outputs.commit }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: create ticket
         uses: dacbd/create-issue-action@v1

--- a/.github/workflows/chatops.yml
+++ b/.github/workflows/chatops.yml
@@ -14,7 +14,7 @@ jobs:
     if: |
         github.event.issue.pull_request &&
         startsWith(github.event.comment.body, '/ok-to-merge')
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check User Permission
         id: checkUser

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -32,7 +32,7 @@ on:
 
 jobs:
   duplicate_runs:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: Skip duplicate runs
     continue-on-error: true
     outputs:

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -593,11 +593,11 @@ jobs:
         name: Prepare the environment
         uses: nick-fields/retry@v2
         with:
-          timeout_seconds: 120
+          timeout_seconds: 300
           max_attempts: 3
           on_retry_command: |
             # Clear-ups before retries
-            rm -rf /usr/local/bin/kind /usr/local/bin/kubectl
+            sudo rm -rf /usr/local/bin/kind /usr/local/bin/kubectl
           command: |
             sudo apt-get update
             sudo apt-get install -y gettext-base

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -49,7 +49,7 @@ jobs:
   # Trigger the workflow on release-* branches for smoke testing whenever it's a scheduled run.
   # Note: this is a workaround since we can't directly schedule-run a workflow from a non default branch
   smoke_test_release_branches:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: smoke test release-* branches when it's a scheduled run
     if: github.event_name == 'schedule'
     strategy:
@@ -73,7 +73,7 @@ jobs:
       github.event.issue.pull_request &&
       startsWith(github.event.comment.body, '/test')
     name: Retrieve command
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       github_ref: ${{ steps.refs.outputs.head_sha }}
       depth: ${{ env.DEPTH }}
@@ -150,7 +150,7 @@ jobs:
     name: Parse arguments
     if: |
       github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       github_ref: ${{ github.ref }}
       depth: ${{ env.DEPTH }}
@@ -188,7 +188,7 @@ jobs:
     needs:
       - check_commenter
       - test_arguments
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: |
       (
         needs.check_commenter.result == 'success' ||
@@ -231,7 +231,7 @@ jobs:
     if: |
       always() && !cancelled() &&
       needs.evaluate_options.result == 'success'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     permissions:
       contents: read
       packages: write
@@ -431,7 +431,7 @@ jobs:
       needs.buildx.result == 'success' &&
       needs.buildx.outputs.upload_artifacts == 'true' &&
       github.repository_owner == 'cloudnative-pg'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       -
         name: Checkout artifact
@@ -497,7 +497,7 @@ jobs:
     if: |
       (always() && !cancelled()) &&
       needs.buildx.result == 'success'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       image: ${{ needs.buildx.outputs.image }}
       localMatrix: ${{ steps.generate-jobs.outputs.localMatrix }}
@@ -530,7 +530,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.generate-jobs.outputs.localMatrix) }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       # TEST_DEPTH determines the matrix of K8S_VERSION x POSTGRES_VERSION jobs where E2E tests will be executed
       TEST_DEPTH: ${{ needs.evaluate_options.outputs.test_level }}
@@ -701,7 +701,7 @@ jobs:
         needs.e2e-local.result == 'success' ||
         needs.e2e-local.result == 'failure'
       )
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Create a directory for the artifacts
         run: mkdir test-artifacts
@@ -761,7 +761,7 @@ jobs:
       needs.e2e-local.result == 'success' &&
       github.event_name == 'issue_comment' &&
       needs.evaluate_options.outputs.test_level == '4'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check preconditions
         id: get_pr_number_and_labels
@@ -790,7 +790,7 @@ jobs:
       always() &&
       needs.e2e-local.result == 'failure' &&
       github.event_name == 'issue_comment'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check preconditions
         id: get_pr_number_and_labels

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -29,7 +29,7 @@ jobs:
   # Trigger the workflow on release-* branches for smoke testing whenever it's a scheduled run.
   # Note: this is a workaround since we can't directly schedule-run a workflow from a non default branch
   smoke_test_release_branches:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: smoke test release-* branches when it's a scheduled run
     if: github.event_name == 'schedule'
     strategy:
@@ -50,7 +50,7 @@ jobs:
   #   1. it's on 'main' branch
   #   2. it's triggered by events in the 'do_not_skip' list
   duplicate_runs:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: Skip duplicate runs
     continue-on-error: true
     outputs:
@@ -71,7 +71,7 @@ jobs:
     name: Check changed files
     needs: duplicate_runs
     if: ${{ needs.duplicate_runs.outputs.should_skip != 'true' }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       docs-changed: ${{ steps.filter.outputs.docs-changed }}
       operator-changed: ${{ steps.filter.outputs.operator-changed }}
@@ -126,7 +126,7 @@ jobs:
     if: |
       needs.duplicate_runs.outputs.should_skip != 'true' &&
       needs.change-triage.outputs.go-code-changed == 'true'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -157,7 +157,7 @@ jobs:
     if: |
       needs.duplicate_runs.outputs.should_skip != 'true' &&
       needs.change-triage.outputs.shell-script-changed == 'true'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
         SHELLCHECK_OPTS: -a -S style
     steps:
@@ -179,7 +179,7 @@ jobs:
         needs.change-triage.outputs.operator-changed == 'true' ||
         needs.change-triage.outputs.go-code-changed == 'true'
       )
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       k8sMatrix: ${{ steps.get-k8s-versions.outputs.k8s_versions }}
       latest_k8s_version: ${{ steps.get-k8s-versions.outputs.latest_k8s_version }}
@@ -218,7 +218,7 @@ jobs:
         needs.change-triage.outputs.operator-changed == 'true' ||
         needs.change-triage.outputs.go-code-changed == 'true'
       )
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         # The Unit test is performed per multiple supported k8s versions (each job for each k8s version) as below:
@@ -260,7 +260,7 @@ jobs:
         needs.change-triage.outputs.go-code-changed == 'true' ||
         needs.change-triage.outputs.docs-changed == 'true'
       )
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -291,7 +291,7 @@ jobs:
     if: |
       needs.duplicate_runs.outputs.should_skip != 'true' &&
       needs.change-triage.outputs.go-code-changed == 'true'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -343,7 +343,7 @@ jobs:
       (needs.tests.result == 'success' || needs.tests.result == 'skipped') &&
       (needs.apidoc.result == 'success' || needs.apidoc.result == 'skipped') &&
       (needs.crd.result == 'success' || needs.crd.result == 'skipped')
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     permissions:
       contents: read
       packages: read

--- a/.github/workflows/kind-k8s-versions-check.yml
+++ b/.github/workflows/kind-k8s-versions-check.yml
@@ -21,7 +21,7 @@ env:
 
 jobs:
   check-kind-k8s-versions:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       -
         name: Checkout code

--- a/.github/workflows/latest-postgres-version-check.yml
+++ b/.github/workflows/latest-postgres-version-check.yml
@@ -14,7 +14,7 @@ defaults:
 
 jobs:
   check-latest-postgres-version:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   pull-request:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       -
         name: Checkout

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
 
   release:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       -
         name: Checkout
@@ -51,7 +51,7 @@ jobs:
 
   release-binaries:
     name: Build containers
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       version: ${{ steps.build-meta.outputs.version }}
       digest: ${{ steps.build.outputs.digest }}

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   tag:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       -
         name: Checkout

--- a/.github/workflows/require-labels.yml
+++ b/.github/workflows/require-labels.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   require-labels:
     name: Require labels
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Require labels
         uses: docker://agilepathway/pull-request-label-checker:v1.4.30

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -8,7 +8,7 @@ jobs:
   # Check code for non-inclusive language
   woke:
     name: Run woke
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -22,7 +22,7 @@ jobs:
   # Enforce en-us spell check
   spellcheck:
     name: Run spellcheck
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/tests/e2e/operator_unavailable_test.go
+++ b/tests/e2e/operator_unavailable_test.go
@@ -225,7 +225,13 @@ var _ = Describe("Operator unavailable", Serial, Label(tests.LabelDisruptive, te
 						ctrlclient.MatchingLabels{utils.ClusterLabelName: "operator-unavailable"},
 					)
 					Expect(err).ToNot(HaveOccurred())
-					return int32(len(podList.Items))
+					count := int32(0)
+					for _, pod := range podList.Items {
+						if pod.DeletionTimestamp == nil {
+							count++
+						}
+					}
+					return count
 				}, 120).Should(BeEquivalentTo(2))
 			})
 

--- a/tests/e2e/operator_unavailable_test.go
+++ b/tests/e2e/operator_unavailable_test.go
@@ -225,13 +225,7 @@ var _ = Describe("Operator unavailable", Serial, Label(tests.LabelDisruptive, te
 						ctrlclient.MatchingLabels{utils.ClusterLabelName: "operator-unavailable"},
 					)
 					Expect(err).ToNot(HaveOccurred())
-					count := int32(0)
-					for _, pod := range podList.Items {
-						if pod.DeletionTimestamp == nil {
-							count++
-						}
-					}
-					return count
+					return int32(len(utils.FilterActivePods(podList.Items)))
 				}, 120).Should(BeEquivalentTo(2))
 			})
 

--- a/tests/utils/cluster.go
+++ b/tests/utils/cluster.go
@@ -285,7 +285,14 @@ func (env TestingEnvironment) GetClusterPrimary(namespace string, clusterName st
 		return &corev1.Pod{}, err
 	}
 	if len(podList.Items) > 0 {
-		return &(podList.Items[0]), nil
+		// if there are multiple, get the one without deletion timestamp
+		for _, pod := range podList.Items {
+			if pod.DeletionTimestamp == nil {
+				return &pod, nil
+			}
+		}
+		err = fmt.Errorf("all pod with primary role has deletion timestamp")
+		return &(podList.Items[0]), err
 	}
 	err = fmt.Errorf("no primary found")
 	return &corev1.Pod{}, err

--- a/tests/utils/operator.go
+++ b/tests/utils/operator.go
@@ -156,13 +156,14 @@ func (env TestingEnvironment) GetOperatorPod() (corev1.Pod, error) {
 		&env, podList, ctrlclient.MatchingLabels{"app.kubernetes.io/name": "cloudnative-pg"}); err != nil {
 		return corev1.Pod{}, err
 	}
+	activePods := utils.FilterActivePods(podList.Items)
 	switch {
-	case len(podList.Items) > 1:
-		err := fmt.Errorf("number of running operator pods greater than 1: %v pods running", len(podList.Items))
+	case len(activePods) > 1:
+		err := fmt.Errorf("number of running operator pods greater than 1: %v pods running", len(activePods))
 		return corev1.Pod{}, err
 
-	case len(podList.Items) == 1:
-		return podList.Items[0], nil
+	case len(activePods) == 1:
+		return activePods[0], nil
 	}
 
 	operatorNamespace, err := env.GetOperatorNamespaceName()
@@ -178,8 +179,9 @@ func (env TestingEnvironment) GetOperatorPod() (corev1.Pod, error) {
 		ctrlclient.InNamespace(operatorNamespace)); err != nil {
 		return corev1.Pod{}, err
 	}
-	if len(podList.Items) != 1 {
-		err := fmt.Errorf("number of running operator different than 1: %v pods running", len(podList.Items))
+	activePods = utils.FilterActivePods(podList.Items)
+	if len(activePods) != 1 {
+		err := fmt.Errorf("number of running operator different than 1: %v pods running", len(activePods))
 		return corev1.Pod{}, err
 	}
 


### PR DESCRIPTION
The version 20.04 of the ubuntu runners it's about to go end of life, and we should start using the latest version 22.04