### PR TITLE
test: create backups with kubectl apply for safety

### DIFF
--- a/tests/utils/backup.go
+++ b/tests/utils/backup.go
@@ -40,9 +40,9 @@ func ExecuteBackup(
 	backupName, err := env.GetResourceNameFromYAML(backupFile)
 	Expect(err).ToNot(HaveOccurred())
 	Eventually(func() error {
-		_, stderr, err := RunUnchecked("kubectl create -n " + namespace + " -f " + backupFile)
+		_, stderr, err := RunUnchecked("kubectl apply -n " + namespace + " -f " + backupFile)
 		if err != nil {
-			return fmt.Errorf("failed to create backup\nstderr: %v\nerror:%v", stderr, err)
+			return fmt.Errorf("could not create backup.\nStdErr: %v\nError: %v", stderr, err)
 		}
 		return nil
 	}, RetryTimeout, PollingTime).Should(BeNil())


### PR DESCRIPTION
we were creating backups in tests with `kubectl create`. In some cases
the backup could be created but not return success in time, and then
another `create` would be attempted and fail. This PR uses `apply`.