### PR TITLE
test: reuse core functions to fetch clusters and execute commands

### DIFF
--- a/tests/e2e/asserts_test.go
+++ b/tests/e2e/asserts_test.go
@@ -135,12 +135,8 @@ func AssertSwitchover(namespace string, clusterName string, env *testsUtils.Test
 		Eventually(func() error {
 			count := 0
 			for _, pod := range pods {
-				out, _, err := testsUtils.Run(fmt.Sprintf(
-					"kubectl exec -n %v %v -- %v",
-					namespace,
-					pod,
-					"sh -c 'ls $PGDATA/pg_wal/*.history'"),
-				)
+				out, _, err := env.ExecCommandInPod(namespace, pod, nil,
+					"sh", "-c", "ls $PGDATA/pg_wal/*.history")
 				if err != nil {
 					return err
 				}
@@ -1366,12 +1362,8 @@ func AssertClusterRestoreWithApplicationDB(namespace, restoreClusterFile, tableN
 		AssertDataExpectedCount(namespace, restoredClusterName, tableName, 2, pod)
 
 		// Restored primary should be on timeline 2
-		cmd := "psql -U postgres app -tAc 'select substring(pg_walfile_name(pg_current_wal_lsn()), 1, 8)'"
-		out, _, err := testsUtils.Run(fmt.Sprintf(
-			"kubectl exec -n %v %v -- %v",
-			namespace,
-			primary,
-			cmd))
+		out, _, err := env.ExecSQLInPod(namespace, primary, "app",
+			"select substring(pg_walfile_name(pg_current_wal_lsn()), 1, 8)")
 		Expect(strings.Trim(out, "\n"), err).To(Equal("00000002"))
 
 		// Restored standby should be attached to restored primary
@@ -1422,12 +1414,8 @@ func AssertClusterRestore(namespace, restoreClusterFile, tableName string, pod *
 		AssertDataExpectedCount(namespace, restoredClusterName, tableName, 2, pod)
 
 		// Restored primary should be on timeline 2
-		cmd := "psql -U postgres app -tAc 'select substring(pg_walfile_name(pg_current_wal_lsn()), 1, 8)'"
-		out, _, err := testsUtils.Run(fmt.Sprintf(
-			"kubectl exec -n %v %v -- %v",
-			namespace,
-			primary,
-			cmd))
+		out, _, err := env.ExecSQLInPod(namespace, primary, "app",
+			"select substring(pg_walfile_name(pg_current_wal_lsn()), 1, 8)")
 		Expect(strings.Trim(out, "\n"), err).To(Equal("00000002"))
 
 		// Restored standby should be attached to restored primary
@@ -1714,18 +1702,12 @@ func AssertArchiveWalOnAzureBlob(namespace, clusterName, azStorageAccount, azSto
 
 // switchWalAndGetLatestArchive trigger a new wal and get the name of latest wal file
 func switchWalAndGetLatestArchive(namespace, podName string) string {
-	_, _, err := testsUtils.Run(fmt.Sprintf(
-		"kubectl exec -n %v %v -- %v",
-		namespace,
-		podName,
-		checkPointCmd))
+	_, _, err := env.ExecSQLInPod(namespace, podName, "postgres",
+		"CHECKPOINT;")
 	Expect(err).ToNot(HaveOccurred())
 
-	out, _, err := testsUtils.Run(fmt.Sprintf(
-		"kubectl exec -n %v %v -- %v",
-		namespace,
-		podName,
-		getLatestWalCmd))
+	out, _, err := env.ExecSQLInPod(namespace, podName, "postgres",
+		"SELECT pg_walfile_name(pg_switch_wal());")
 	Expect(err).ToNot(HaveOccurred())
 
 	return strings.TrimSpace(out)
@@ -2146,9 +2128,9 @@ func assertPGBouncerEndpointsContainsPodsIP(
 // assertPGBouncerHasServiceNameInsideHostParameter makes sure that the service name is contained inside the host file
 func assertPGBouncerHasServiceNameInsideHostParameter(namespace, serviceName string, podList *corev1.PodList) {
 	for _, pod := range podList.Items {
-		command := fmt.Sprintf("kubectl exec -n %s %s -- /bin/bash -c 'grep "+
-			" \"host=%s\" controller/configs/pgbouncer.ini'", namespace, pod.Name, serviceName)
-		out, _, err := testsUtils.Run(command)
+		out, _, err := env.ExecCommandInPod(namespace, pod.Name, nil,
+			"/bin/bash", "-c",
+			fmt.Sprintf("grep \"host=%s\" controller/configs/pgbouncer.ini", serviceName))
 		Expect(err).ToNot(HaveOccurred())
 		expectedContainedHost := fmt.Sprintf("host=%s", serviceName)
 		Expect(out).To(ContainSubstring(expectedContainedHost))

--- a/tests/e2e/asserts_test.go
+++ b/tests/e2e/asserts_test.go
@@ -187,10 +187,6 @@ func AssertCreateCluster(namespace string, clusterName string, sampleFile string
 // none of them are going to be deleted, and that the status is Healthy
 func AssertClusterIsReady(namespace string, clusterName string, timeout int, env *testsUtils.TestingEnvironment) {
 	By(fmt.Sprintf("having a Cluster %s with each instance in status ready", clusterName), func() {
-		namespacedName := types.NamespacedName{
-			Namespace: namespace,
-			Name:      clusterName,
-		}
 		// Eventually the number of ready instances should be equal to the
 		// amount of instances defined in the cluster and
 		// the cluster status should be in healthy state
@@ -214,7 +210,7 @@ func AssertClusterIsReady(namespace string, clusterName string, timeout int, env
 						return fmt.Sprintf("Pod '%s' is waiting for deletion", pod.Name), nil
 					}
 				}
-				err = env.Client.Get(env.Ctx, namespacedName, cluster)
+				cluster, err = env.GetCluster(namespace, clusterName)
 				return cluster.Status.Phase, err
 			}
 			return fmt.Sprintf("Ready pod is not as expected. Spec Instances: %d, ready pods: %d \n",

--- a/tests/e2e/backup_restore_test.go
+++ b/tests/e2e/backup_restore_test.go
@@ -206,24 +206,15 @@ var _ = Describe("Backup and restore", Label(tests.LabelBackupRestore), func() {
 					return testUtils.CountFilesOnMinio(namespace, minioClientName, latestTar)
 				}, 60).Should(BeEquivalentTo(1))
 				Eventually(func() (string, error) {
-					cluster := &apiv1.Cluster{}
-					err := env.Client.Get(env.Ctx,
-						ctrlclient.ObjectKey{Namespace: namespace, Name: clusterName},
-						cluster)
+					cluster, err := env.GetCluster(namespace, clusterName)
 					return cluster.Status.FirstRecoverabilityPoint, err
 				}, 30).ShouldNot(BeEmpty())
 				Eventually(func() (string, error) {
-					cluster := &apiv1.Cluster{}
-					err := env.Client.Get(env.Ctx,
-						ctrlclient.ObjectKey{Namespace: namespace, Name: clusterName},
-						cluster)
+					cluster, err := env.GetCluster(namespace, clusterName)
 					return cluster.Status.LastSuccessfulBackup, err
 				}, 30).ShouldNot(BeEmpty())
 				Eventually(func() (string, error) {
-					cluster := &apiv1.Cluster{}
-					err := env.Client.Get(env.Ctx,
-						ctrlclient.ObjectKey{Namespace: namespace, Name: clusterName},
-						cluster)
+					cluster, err := env.GetCluster(namespace, clusterName)
 					return cluster.Status.LastFailedBackup, err
 				}, 30).Should(BeEmpty())
 			})
@@ -255,10 +246,7 @@ var _ = Describe("Backup and restore", Label(tests.LabelBackupRestore), func() {
 					ctrlclient.ObjectKey{Namespace: namespace, Name: backupName},
 					backup)
 				Expect(err).ToNot(HaveOccurred())
-				cluster := &apiv1.Cluster{}
-				err = env.Client.Get(env.Ctx,
-					ctrlclient.ObjectKey{Namespace: namespace, Name: clusterName},
-					cluster)
+				cluster, err := env.GetCluster(namespace, clusterName)
 				Expect(err).ToNot(HaveOccurred())
 				// We know that our current images always contain the latest barman version
 				if cluster.ShouldForceLegacyBackup() {
@@ -271,10 +259,7 @@ var _ = Describe("Backup and restore", Label(tests.LabelBackupRestore), func() {
 			// Restore backup in a new cluster, also cover if no application database is configured
 			AssertClusterRestore(namespace, clusterRestoreSampleFile, tableName, psqlClientPod)
 
-			cluster := &apiv1.Cluster{}
-			err = env.Client.Get(env.Ctx,
-				ctrlclient.ObjectKey{Namespace: namespace, Name: restoredClusterName},
-				cluster)
+			cluster, err := env.GetCluster(namespace, restoredClusterName)
 			Expect(err).ToNot(HaveOccurred())
 			AssertMetricsData(namespace, curlPodName, targetDBOne, targetDBTwo, targetDBSecret, cluster)
 
@@ -338,10 +323,7 @@ var _ = Describe("Backup and restore", Label(tests.LabelBackupRestore), func() {
 					return testUtils.CountFilesOnMinio(namespace, minioClientName, latestTar)
 				}, 60).Should(BeEquivalentTo(1))
 				Eventually(func() (string, error) {
-					cluster := &apiv1.Cluster{}
-					err := env.Client.Get(env.Ctx,
-						ctrlclient.ObjectKey{Namespace: namespace, Name: targetClusterName},
-						cluster)
+					cluster, err := env.GetCluster(namespace, targetClusterName)
 					return cluster.Status.FirstRecoverabilityPoint, err
 				}, 30).ShouldNot(BeEmpty())
 			})
@@ -385,10 +367,7 @@ var _ = Describe("Backup and restore", Label(tests.LabelBackupRestore), func() {
 					return testUtils.CountFilesOnMinio(namespace, minioClientName, latestTar)
 				}, 60).Should(BeEquivalentTo(1))
 				Eventually(func() (string, error) {
-					cluster := &apiv1.Cluster{}
-					err := env.Client.Get(env.Ctx,
-						ctrlclient.ObjectKey{Namespace: namespace, Name: targetClusterName},
-						cluster)
+					cluster, err := env.GetCluster(namespace, targetClusterName)
 					return cluster.Status.FirstRecoverabilityPoint, err
 				}, 30).ShouldNot(BeEmpty())
 			})
@@ -449,10 +428,7 @@ var _ = Describe("Backup and restore", Label(tests.LabelBackupRestore), func() {
 					fmt.Sprintf("verify the number of backup %v is equals to 1", latestBaseTar))
 				// this is the second backup we take on the bucket
 				Eventually(func() (string, error) {
-					cluster := &apiv1.Cluster{}
-					err := env.Client.Get(env.Ctx,
-						ctrlclient.ObjectKey{Namespace: namespace, Name: customClusterName},
-						cluster)
+					cluster, err := env.GetCluster(namespace, customClusterName)
 					return cluster.Status.FirstRecoverabilityPoint, err
 				}, 30).ShouldNot(BeEmpty())
 			})
@@ -621,10 +597,7 @@ var _ = Describe("Backup and restore", Label(tests.LabelBackupRestore), func() {
 					return testUtils.CountFilesOnAzureBlobStorage(azStorageAccount, azStorageKey, clusterName, "data.tar")
 				}, 30).Should(BeNumerically(">=", 1))
 				Eventually(func() (string, error) {
-					cluster := &apiv1.Cluster{}
-					err := env.Client.Get(env.Ctx,
-						ctrlclient.ObjectKey{Namespace: namespace, Name: clusterName},
-						cluster)
+					cluster, err := env.GetCluster(namespace, clusterName)
 					return cluster.Status.FirstRecoverabilityPoint, err
 				}, 30).ShouldNot(BeEmpty())
 			})
@@ -956,10 +929,7 @@ var _ = Describe("Clusters Recovery From Barman Object Store", Label(tests.Label
 				}, 60).Should(BeEquivalentTo(1),
 					fmt.Sprintf("verify the number of backup %v is equals to 1", latestTar))
 				Eventually(func() (string, error) {
-					cluster := &apiv1.Cluster{}
-					err := env.Client.Get(env.Ctx,
-						ctrlclient.ObjectKey{Namespace: namespace, Name: clusterName},
-						cluster)
+					cluster, err := env.GetCluster(namespace, clusterName)
 					return cluster.Status.FirstRecoverabilityPoint, err
 				}, 30).ShouldNot(BeEmpty())
 			})

--- a/tests/e2e/configuration_update_test.go
+++ b/tests/e2e/configuration_update_test.go
@@ -62,47 +62,38 @@ var _ = Describe("Configuration update", Ordered, Label(tests.LabelClusterMetada
 		"wal_receiver_timeout":        "2s",
 	}
 	updateClusterPostgresParams := func(paramsMap map[string]string, namespace string) {
-		cluster := apiv1.Cluster{}
-		namespacedName := types.NamespacedName{
-			Namespace: namespace,
-			Name:      clusterName,
-		}
+		cluster := &apiv1.Cluster{}
 		err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-			err := utils.GetObject(env, namespacedName, &cluster)
+			var err error
+			cluster, err = env.GetCluster(namespace, clusterName)
 			Expect(err).ToNot(HaveOccurred())
 			cluster.Spec.PostgresConfiguration.Parameters = paramsMap
-			return env.Client.Update(env.Ctx, &cluster)
+			return env.Client.Update(env.Ctx, cluster)
 		})
 		Expect(err).ToNot(HaveOccurred())
 	}
 
 	updateClusterPostgresPgHBA := func(namespace string) {
-		cluster := apiv1.Cluster{}
-		namespacedName := types.NamespacedName{
-			Namespace: namespace,
-			Name:      clusterName,
-		}
+		cluster := &apiv1.Cluster{}
 		err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-			err := utils.GetObject(env, namespacedName, &cluster)
+			var err error
+			cluster, err = env.GetCluster(namespace, clusterName)
 			Expect(err).ToNot(HaveOccurred())
 			cluster.Spec.PostgresConfiguration.PgHBA = []string{"host all all all trust"}
-			return env.Client.Update(env.Ctx, &cluster)
+			return env.Client.Update(env.Ctx, cluster)
 		})
 		Expect(err).ToNot(HaveOccurred())
 	}
 
 	checkErrorOutFixedAndBlockedConfigurationParameter := func(params map[string]string, namespace string) {
 		// Update the configuration
-		cluster := apiv1.Cluster{}
-		namespacedName := types.NamespacedName{
-			Namespace: namespace,
-			Name:      clusterName,
-		}
+		cluster := &apiv1.Cluster{}
 		err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-			err := utils.GetObject(env, namespacedName, &cluster)
+			var err error
+			cluster, err = env.GetCluster(namespace, clusterName)
 			Expect(err).NotTo(HaveOccurred())
 			cluster.Spec.PostgresConfiguration.Parameters = params
-			return env.Client.Update(env.Ctx, &cluster)
+			return env.Client.Update(env.Ctx, cluster)
 		})
 		Expect(apierrors.IsInvalid(err)).To(BeTrue())
 

--- a/tests/e2e/configuration_update_test.go
+++ b/tests/e2e/configuration_update_test.go
@@ -226,12 +226,7 @@ var _ = Describe("Configuration update", Ordered, Label(tests.LabelClusterMetada
 		podList, err := env.GetClusterPodList(namespace, clusterName)
 		Expect(err).ToNot(HaveOccurred())
 
-		cluster := &apiv1.Cluster{}
-		namespacedName := types.NamespacedName{
-			Namespace: namespace,
-			Name:      clusterName,
-		}
-		err = env.Client.Get(env.Ctx, namespacedName, cluster)
+		cluster, err := env.GetCluster(namespace, clusterName)
 		Expect(cluster.Status.CurrentPrimary, err).To(BeEquivalentTo(cluster.Status.TargetPrimary))
 		oldPrimary := cluster.Status.CurrentPrimary
 
@@ -258,7 +253,7 @@ var _ = Describe("Configuration update", Ordered, Label(tests.LabelClusterMetada
 		By("verify that a switchover happened", func() {
 			// Check that a switchover happened
 			Eventually(func() (string, error) {
-				err := env.Client.Get(env.Ctx, namespacedName, cluster)
+				cluster, err := env.GetCluster(namespace, clusterName)
 				return cluster.Status.CurrentPrimary, err
 			}, timeout).ShouldNot(BeEquivalentTo(oldPrimary))
 		})
@@ -269,12 +264,7 @@ var _ = Describe("Configuration update", Ordered, Label(tests.LabelClusterMetada
 		podList, err := env.GetClusterPodList(namespace, clusterName)
 		Expect(err).ToNot(HaveOccurred())
 
-		cluster := &apiv1.Cluster{}
-		namespacedName := types.NamespacedName{
-			Namespace: namespace,
-			Name:      clusterName,
-		}
-		err = env.Client.Get(env.Ctx, namespacedName, cluster)
+		cluster, err := env.GetCluster(namespace, clusterName)
 		Expect(cluster.Status.CurrentPrimary, err).To(BeEquivalentTo(cluster.Status.TargetPrimary))
 		oldPrimary := cluster.Status.CurrentPrimary
 
@@ -309,7 +299,7 @@ var _ = Describe("Configuration update", Ordered, Label(tests.LabelClusterMetada
 		By("verify that a switchover happened", func() {
 			// Check that a switchover happened
 			Eventually(func() (string, error) {
-				err := env.Client.Get(env.Ctx, namespacedName, cluster)
+				cluster, err := env.GetCluster(namespace, clusterName)
 				return cluster.Status.CurrentPrimary, err
 			}, timeout).ShouldNot(BeEquivalentTo(oldPrimary))
 		})
@@ -335,12 +325,7 @@ var _ = Describe("Configuration update", Ordered, Label(tests.LabelClusterMetada
 			podList, err := env.GetClusterPodList(namespace, clusterName)
 			Expect(err).ToNot(HaveOccurred())
 
-			cluster := &apiv1.Cluster{}
-			namespacedName := types.NamespacedName{
-				Namespace: namespace,
-				Name:      clusterName,
-			}
-			err = env.Client.Get(env.Ctx, namespacedName, cluster)
+			cluster, err := env.GetCluster(namespace, clusterName)
 			Expect(cluster.Status.CurrentPrimary, err).To(BeEquivalentTo(cluster.Status.TargetPrimary))
 			oldPrimary := cluster.Status.CurrentPrimary
 
@@ -368,7 +353,7 @@ var _ = Describe("Configuration update", Ordered, Label(tests.LabelClusterMetada
 			By("verify that a switchover not happened", func() {
 				// Check that a switchover did not happen
 				Eventually(func() (string, error) {
-					err := env.Client.Get(env.Ctx, namespacedName, cluster)
+					cluster, err := env.GetCluster(namespace, clusterName)
 					return cluster.Status.CurrentPrimary, err
 				}, timeout).Should(BeEquivalentTo(oldPrimary))
 			})
@@ -383,12 +368,7 @@ var _ = Describe("Configuration update", Ordered, Label(tests.LabelClusterMetada
 			podList, err := env.GetClusterPodList(namespace, clusterName)
 			Expect(err).ToNot(HaveOccurred())
 
-			cluster := &apiv1.Cluster{}
-			namespacedName := types.NamespacedName{
-				Namespace: namespace,
-				Name:      clusterName,
-			}
-			err = env.Client.Get(env.Ctx, namespacedName, cluster)
+			cluster, err := env.GetCluster(namespace, clusterName)
 			Expect(cluster.Status.CurrentPrimary, err).To(BeEquivalentTo(cluster.Status.TargetPrimary))
 			oldPrimary := cluster.Status.CurrentPrimary
 
@@ -415,7 +395,7 @@ var _ = Describe("Configuration update", Ordered, Label(tests.LabelClusterMetada
 			By("verify that a switchover not happened", func() {
 				// Check that a switchover did not happen
 				Eventually(func() (string, error) {
-					err := env.Client.Get(env.Ctx, namespacedName, cluster)
+					cluster, err := env.GetCluster(namespace, clusterName)
 					return cluster.Status.CurrentPrimary, err
 				}, timeout).Should(BeEquivalentTo(oldPrimary))
 			})

--- a/tests/e2e/fastswitchover_test.go
+++ b/tests/e2e/fastswitchover_test.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
 
-	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/specs"
 	"github.com/cloudnative-pg/cloudnative-pg/tests"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils"
@@ -200,13 +199,8 @@ func assertFastSwitchover(namespace, sampleFile, clusterName, webTestFile, webTe
 
 	By("setting the TargetPrimary to node2 to trigger a switchover", func() {
 		targetPrimary = clusterName + "-2"
-		namespacedName := types.NamespacedName{
-			Namespace: namespace,
-			Name:      clusterName,
-		}
-		cluster := &apiv1.Cluster{}
 		err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-			err := env.Client.Get(env.Ctx, namespacedName, cluster)
+			cluster, err := env.GetCluster(namespace, clusterName)
 			Expect(err).ToNot(HaveOccurred())
 			cluster.Status.TargetPrimary = targetPrimary
 			return env.Client.Status().Update(env.Ctx, cluster)

--- a/tests/e2e/hibernation_test.go
+++ b/tests/e2e/hibernation_test.go
@@ -106,10 +106,7 @@ var _ = Describe("Cluster Hibernation with plugin", Label(tests.LabelPlugin), fu
 
 				By(fmt.Sprintf("verifying cluster %v is removed", clusterName), func() {
 					Eventually(func() (bool, apiv1.Cluster) {
-						cluster := &apiv1.Cluster{}
-						err := env.Client.Get(env.Ctx,
-							ctrlclient.ObjectKey{Namespace: namespace, Name: clusterName},
-							cluster)
+						cluster, err := env.GetCluster(namespace, clusterName)
 						if err != nil {
 							return true, apiv1.Cluster{}
 						}

--- a/tests/e2e/initdb_test.go
+++ b/tests/e2e/initdb_test.go
@@ -18,6 +18,7 @@ package e2e
 
 import (
 	"github.com/cloudnative-pg/cloudnative-pg/tests"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -69,33 +70,57 @@ var _ = Describe("InitDB settings", Label(tests.LabelSmoke, tests.LabelBasic), f
 			primaryDst := clusterName + "-1"
 
 			By("querying the tables via psql", func() {
-				_, _, err := env.ExecQueryInInstancePod(namespace, primaryDst, "postgres",
+				_, _, err := env.ExecQueryInInstancePod(
+					utils.PodLocator{
+						Namespace: namespace,
+						PodName:   primaryDst,
+					}, utils.DatabaseName("postgres"),
 					"SELECT count(*) FROM numbers")
 				Expect(err).ToNot(HaveOccurred())
 			})
 			By("querying the App database tables via psql", func() {
-				_, _, err := env.ExecQueryInInstancePod(namespace, primaryDst, "app",
+				_, _, err := env.ExecQueryInInstancePod(
+					utils.PodLocator{
+						Namespace: namespace,
+						PodName:   primaryDst,
+					}, utils.DatabaseName("app"),
 					"SELECT count(*) FROM application_numbers")
 				Expect(err).ToNot(HaveOccurred())
 			})
 			By("querying the App database tables defined by secretRefs", func() {
-				_, _, err := env.ExecQueryInInstancePod(namespace, primaryDst, "app",
+				_, _, err := env.ExecQueryInInstancePod(
+					utils.PodLocator{
+						Namespace: namespace,
+						PodName:   primaryDst,
+					}, utils.DatabaseName("app"),
 					"SELECT count(*) FROM secrets")
 				Expect(err).ToNot(HaveOccurred())
 			})
 			By("querying the App database tables defined by configMapRefs", func() {
-				_, _, err := env.ExecQueryInInstancePod(namespace, primaryDst, "app",
+				_, _, err := env.ExecQueryInInstancePod(
+					utils.PodLocator{
+						Namespace: namespace,
+						PodName:   primaryDst,
+					}, utils.DatabaseName("app"),
 					"SELECT count(*) FROM configmaps")
 				Expect(err).ToNot(HaveOccurred())
 			})
 			By("querying the database to ensure the installed extension is there", func() {
-				stdout, _, err := env.ExecQueryInInstancePod(namespace, primaryDst, "postgres",
+				stdout, _, err := env.ExecQueryInInstancePod(
+					utils.PodLocator{
+						Namespace: namespace,
+						PodName:   primaryDst,
+					}, utils.DatabaseName("postgres"),
 					"SELECT count(*) FROM pg_available_extensions WHERE name LIKE 'intarray'")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(stdout, err).To(Equal("1\n"))
 			})
 			By("checking inside the database the default locale", func() {
-				stdout, _, err := env.ExecQueryInInstancePod(namespace, primaryDst, "postgres",
+				stdout, _, err := env.ExecQueryInInstancePod(
+					utils.PodLocator{
+						Namespace: namespace,
+						PodName:   primaryDst,
+					}, utils.DatabaseName("postgres"),
 					"select datcollate from pg_database where datname='template0'")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(stdout, err).To(Equal("C\n"))
@@ -128,7 +153,11 @@ var _ = Describe("InitDB settings", Label(tests.LabelSmoke, tests.LabelBasic), f
 			primaryDst := clusterName + "-1"
 
 			By("checking inside the database", func() {
-				stdout, _, err := env.ExecQueryInInstancePod(namespace, primaryDst, "postgres",
+				stdout, _, err := env.ExecQueryInInstancePod(
+					utils.PodLocator{
+						Namespace: namespace,
+						PodName:   primaryDst,
+					}, utils.DatabaseName("postgres"),
 					"select datcollate from pg_database where datname='template0'")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(stdout, err).To(Equal("en_US.utf8\n"))

--- a/tests/e2e/initdb_test.go
+++ b/tests/e2e/initdb_test.go
@@ -69,33 +69,33 @@ var _ = Describe("InitDB settings", Label(tests.LabelSmoke, tests.LabelBasic), f
 			primaryDst := clusterName + "-1"
 
 			By("querying the tables via psql", func() {
-				_, _, err := env.ExecSQLInPod(namespace, primaryDst, "postgres",
+				_, _, err := env.ExecQueryInInstancePod(namespace, primaryDst, "postgres",
 					"SELECT count(*) FROM numbers")
 				Expect(err).ToNot(HaveOccurred())
 			})
 			By("querying the App database tables via psql", func() {
-				_, _, err := env.ExecSQLInPod(namespace, primaryDst, "app",
+				_, _, err := env.ExecQueryInInstancePod(namespace, primaryDst, "app",
 					"SELECT count(*) FROM application_numbers")
 				Expect(err).ToNot(HaveOccurred())
 			})
 			By("querying the App database tables defined by secretRefs", func() {
-				_, _, err := env.ExecSQLInPod(namespace, primaryDst, "app",
+				_, _, err := env.ExecQueryInInstancePod(namespace, primaryDst, "app",
 					"SELECT count(*) FROM secrets")
 				Expect(err).ToNot(HaveOccurred())
 			})
 			By("querying the App database tables defined by configMapRefs", func() {
-				_, _, err := env.ExecSQLInPod(namespace, primaryDst, "app",
+				_, _, err := env.ExecQueryInInstancePod(namespace, primaryDst, "app",
 					"SELECT count(*) FROM configmaps")
 				Expect(err).ToNot(HaveOccurred())
 			})
 			By("querying the database to ensure the installed extension is there", func() {
-				stdout, _, err := env.ExecSQLInPod(namespace, primaryDst, "postgres",
+				stdout, _, err := env.ExecQueryInInstancePod(namespace, primaryDst, "postgres",
 					"SELECT count(*) FROM pg_available_extensions WHERE name LIKE 'intarray'")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(stdout, err).To(Equal("1\n"))
 			})
 			By("checking inside the database the default locale", func() {
-				stdout, _, err := env.ExecSQLInPod(namespace, primaryDst, "postgres",
+				stdout, _, err := env.ExecQueryInInstancePod(namespace, primaryDst, "postgres",
 					"select datcollate from pg_database where datname='template0'")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(stdout, err).To(Equal("C\n"))
@@ -128,7 +128,7 @@ var _ = Describe("InitDB settings", Label(tests.LabelSmoke, tests.LabelBasic), f
 			primaryDst := clusterName + "-1"
 
 			By("checking inside the database", func() {
-				stdout, _, err := env.ExecSQLInPod(namespace, primaryDst, "postgres",
+				stdout, _, err := env.ExecQueryInInstancePod(namespace, primaryDst, "postgres",
 					"select datcollate from pg_database where datname='template0'")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(stdout, err).To(Equal("en_US.utf8\n"))

--- a/tests/e2e/initdb_test.go
+++ b/tests/e2e/initdb_test.go
@@ -17,10 +17,7 @@ limitations under the License.
 package e2e
 
 import (
-	"fmt"
-
 	"github.com/cloudnative-pg/cloudnative-pg/tests"
-	"github.com/cloudnative-pg/cloudnative-pg/tests/utils"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -72,58 +69,34 @@ var _ = Describe("InitDB settings", Label(tests.LabelSmoke, tests.LabelBasic), f
 			primaryDst := clusterName + "-1"
 
 			By("querying the tables via psql", func() {
-				cmd := "psql -U postgres postgres -tAc 'SELECT count(*) FROM numbers'"
-				_, _, err := utils.Run(fmt.Sprintf(
-					"kubectl exec -n %v %v -- %v",
-					namespace,
-					primaryDst,
-					cmd))
+				_, _, err := env.ExecSQLInPod(namespace, primaryDst, "postgres",
+					"SELECT count(*) FROM numbers")
 				Expect(err).ToNot(HaveOccurred())
 			})
 			By("querying the App database tables via psql", func() {
-				cmd := "psql -U postgres app -tAc 'SELECT count(*) FROM application_numbers'"
-				_, _, err := utils.Run(fmt.Sprintf(
-					"kubectl exec -n %v %v -- %v",
-					namespace,
-					primaryDst,
-					cmd))
+				_, _, err := env.ExecSQLInPod(namespace, primaryDst, "app",
+					"SELECT count(*) FROM application_numbers")
 				Expect(err).ToNot(HaveOccurred())
 			})
 			By("querying the App database tables defined by secretRefs", func() {
-				cmd := "psql -U postgres app -tAc 'SELECT count(*) FROM secrets'"
-				_, _, err := utils.Run(fmt.Sprintf(
-					"kubectl exec -n %v %v -- %v",
-					namespace,
-					primaryDst,
-					cmd))
+				_, _, err := env.ExecSQLInPod(namespace, primaryDst, "app",
+					"SELECT count(*) FROM secrets")
 				Expect(err).ToNot(HaveOccurred())
 			})
 			By("querying the App database tables defined by configMapRefs", func() {
-				cmd := "psql -U postgres app -tAc 'SELECT count(*) FROM configmaps'"
-				_, _, err := utils.Run(fmt.Sprintf(
-					"kubectl exec -n %v %v -- %v",
-					namespace,
-					primaryDst,
-					cmd))
+				_, _, err := env.ExecSQLInPod(namespace, primaryDst, "app",
+					"SELECT count(*) FROM configmaps")
 				Expect(err).ToNot(HaveOccurred())
 			})
 			By("querying the database to ensure the installed extension is there", func() {
-				cmd := `psql -U postgres postgres -tAc "SELECT count(*) FROM pg_available_extensions WHERE name LIKE 'intarray'"`
-				stdout, _, err := utils.Run(fmt.Sprintf(
-					"kubectl exec -n %v %v -- %v",
-					namespace,
-					primaryDst,
-					cmd))
+				stdout, _, err := env.ExecSQLInPod(namespace, primaryDst, "postgres",
+					"SELECT count(*) FROM pg_available_extensions WHERE name LIKE 'intarray'")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(stdout, err).To(Equal("1\n"))
 			})
 			By("checking inside the database the default locale", func() {
-				cmd := "psql -U postgres postgres -tAc \"select datcollate from pg_database where datname='template0'\""
-				stdout, _, err := utils.Run(fmt.Sprintf(
-					"kubectl exec -n %v %v -- %v",
-					namespace,
-					primaryDst,
-					cmd))
+				stdout, _, err := env.ExecSQLInPod(namespace, primaryDst, "postgres",
+					"select datcollate from pg_database where datname='template0'")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(stdout, err).To(Equal("C\n"))
 			})
@@ -155,12 +128,8 @@ var _ = Describe("InitDB settings", Label(tests.LabelSmoke, tests.LabelBasic), f
 			primaryDst := clusterName + "-1"
 
 			By("checking inside the database", func() {
-				cmd := "psql -U postgres postgres -tAc \"select datcollate from pg_database where datname='template0'\""
-				stdout, _, err := utils.Run(fmt.Sprintf(
-					"kubectl exec -n %v %v -- %v",
-					namespace,
-					primaryDst,
-					cmd))
+				stdout, _, err := env.ExecSQLInPod(namespace, primaryDst, "postgres",
+					"select datcollate from pg_database where datname='template0'")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(stdout, err).To(Equal("en_US.utf8\n"))
 			})

--- a/tests/e2e/logs_test.go
+++ b/tests/e2e/logs_test.go
@@ -22,10 +22,8 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres/logpipe"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/specs"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
@@ -184,13 +182,8 @@ var _ = Describe("JSON log output", Label(tests.LabelObservability), func() {
 
 			// Expect a new primary to be elected
 			timeout := 180
-			namespacedName := types.NamespacedName{
-				Namespace: namespace,
-				Name:      clusterName,
-			}
 			Eventually(func() (string, error) {
-				cluster := &apiv1.Cluster{}
-				err := env.Client.Get(env.Ctx, namespacedName, cluster)
+				cluster, err := env.GetCluster(namespace, clusterName)
 				if err != nil {
 					GinkgoWriter.Printf("Error reported while getting current primary %s\n", err.Error())
 					return "", err

--- a/tests/e2e/managed_roles_test.go
+++ b/tests/e2e/managed_roles_test.go
@@ -94,13 +94,8 @@ var _ = Describe("Managed roles tests", Label(tests.LabelSmoke, tests.LabelBasic
 		})
 
 		assertUserExists := func(namespace, primaryPod, username string, shouldExists bool) {
-			cmd := `psql -U postgres postgres -tAc '\du'`
 			Eventually(func(g Gomega) {
-				stdout, _, err := utils.Run(fmt.Sprintf(
-					"kubectl exec -n %v %v -- %v",
-					namespace,
-					primaryPod,
-					cmd))
+				stdout, _, err := env.ExecSQLInPod(namespace, primaryPod, "postgres", "\\du")
 				g.Expect(err).ToNot(HaveOccurred())
 				if shouldExists {
 					g.Expect(stdout).To(ContainSubstring(username))
@@ -121,12 +116,7 @@ var _ = Describe("Managed roles tests", Label(tests.LabelSmoke, tests.LabelBasic
 						FROM pg_auth_members GROUP BY member
 					) mem ON member = oid
 					WHERE rolname =` + pq.QuoteLiteral(roleName)
-				cmd := "psql -U postgres postgres -tAc " + fmt.Sprintf("\"%s\"", query)
-				stdout, _, err := utils.Run(fmt.Sprintf(
-					"kubectl exec -n %v %v -- %v",
-					namespace,
-					primaryPod,
-					cmd))
+				stdout, _, err := env.ExecSQLInPod(namespace, primaryPod, "postgres", query)
 				if err != nil {
 					return []string{ERROR}
 				}
@@ -153,18 +143,12 @@ var _ = Describe("Managed roles tests", Label(tests.LabelSmoke, tests.LabelBasic
 				assertUserExists(namespace, primaryPodInfo.Name, username, true)
 				assertUserExists(namespace, primaryPodInfo.Name, unrealizableUser, false)
 
-				cmd := fmt.Sprintf("psql -U postgres postgres -tAc "+
-					"\"SELECT 1 FROM pg_roles WHERE rolname='%s' and rolcanlogin=%v and rolsuper=%v "+
+				query := fmt.Sprintf("SELECT 1 FROM pg_roles WHERE rolname='%s' and rolcanlogin=%v and rolsuper=%v "+
 					"and rolcreatedb=%v and rolcreaterole=%v and rolinherit=%v and rolreplication=%v "+
-					"and rolbypassrls=%v and rolconnlimit=%v\"", username, rolCanLoginInSpec, rolSuperInSpec, rolCreateDBInSpec,
+					"and rolbypassrls=%v and rolconnlimit=%v", username, rolCanLoginInSpec, rolSuperInSpec, rolCreateDBInSpec,
 					rolCreateRoleInSpec, rolInheritInSpec, rolReplicationInSpec, rolByPassRLSInSpec, rolConnLimitInSpec)
 
-				stdout, _, err := utils.Run(fmt.Sprintf(
-					"kubectl exec -n %v %v -- %v",
-					namespace,
-					primaryPodInfo.Name,
-					cmd))
-
+				stdout, _, err := env.ExecSQLInPod(namespace, primaryPodInfo.Name, "postgres", query)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(stdout).To(Equal("1\n"))
 			})
@@ -181,15 +165,9 @@ var _ = Describe("Managed roles tests", Label(tests.LabelSmoke, tests.LabelBasic
 
 				assertUserExists(namespace, primaryPodInfo.Name, appUsername, true)
 
-				cmd := fmt.Sprintf("psql -U postgres postgres -tAc "+
-					"\"SELECT rolcreatedb FROM pg_roles WHERE rolname='%s'\"", appUsername)
+				query := fmt.Sprintf("SELECT rolcreatedb FROM pg_roles WHERE rolname='%s'", appUsername)
 
-				stdout, _, err := utils.Run(fmt.Sprintf(
-					"kubectl exec -n %v %v -- %v",
-					namespace,
-					primaryPodInfo.Name,
-					cmd))
-
+				stdout, _, err := env.ExecSQLInPod(namespace, primaryPodInfo.Name, "postgres", query)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(stdout).To(Equal("t\n"))
 			})
@@ -253,16 +231,11 @@ var _ = Describe("Managed roles tests", Label(tests.LabelSmoke, tests.LabelBasic
 				Expect(err).ToNot(HaveOccurred())
 
 				Eventually(func() string {
-					cmd := fmt.Sprintf("psql -U postgres postgres -tAc "+
-						"\"SELECT 1 FROM pg_roles WHERE rolname='%s' and rolcanlogin=%v "+
-						"and rolcreatedb=%v and rolcreaterole=%v and rolconnlimit=%v\"",
+					query := fmt.Sprintf("SELECT 1 FROM pg_roles WHERE rolname='%s' and rolcanlogin=%v "+
+						"and rolcreatedb=%v and rolcreaterole=%v and rolconnlimit=%v",
 						username, expectedLogin, expectedCreateDB, expectedCreateRole, expectedConnLmt)
 
-					stdout, _, err := utils.Run(fmt.Sprintf(
-						"kubectl exec -n %v %v -- %v",
-						namespace,
-						primaryPodInfo.Name,
-						cmd))
+					stdout, _, err := env.ExecSQLInPod(namespace, primaryPodInfo.Name, "postgres", query)
 					if err != nil {
 						return ""
 					}
@@ -323,19 +296,14 @@ var _ = Describe("Managed roles tests", Label(tests.LabelSmoke, tests.LabelBasic
 
 			By("Verify new_role exists with all attribute default", func() {
 				Eventually(func() string {
-					cmd := fmt.Sprintf("psql -U postgres postgres -tAc "+
-						"\"SELECT 1 FROM pg_roles WHERE rolname='%s' and rolcanlogin=%v and rolsuper=%v "+
+					query := fmt.Sprintf("SELECT 1 FROM pg_roles WHERE rolname='%s' and rolcanlogin=%v and rolsuper=%v "+
 						"and rolcreatedb=%v and rolcreaterole=%v and rolinherit=%v and rolreplication=%v "+
-						"and rolbypassrls=%v and rolconnlimit=%v\"", newUserName, defaultRolCanLogin,
+						"and rolbypassrls=%v and rolconnlimit=%v", newUserName, defaultRolCanLogin,
 						defaultRolSuper, defaultRolCreateDB,
 						defaultRolCreateRole, defaultRolInherit, defaultRolReplication,
 						defaultRolByPassRLS, defaultRolConnLimit)
 
-					stdout, _, err := utils.Run(fmt.Sprintf(
-						"kubectl exec -n %v %v -- %v",
-						namespace,
-						primaryPodInfo.Name,
-						cmd))
+					stdout, _, err := env.ExecSQLInPod(namespace, primaryPodInfo.Name, "postgres", query)
 					if err != nil {
 						return ""
 					}
@@ -367,16 +335,11 @@ var _ = Describe("Managed roles tests", Label(tests.LabelSmoke, tests.LabelBasic
 
 			By(fmt.Sprintf("Verify comments update in db for %s", newUserName), func() {
 				Eventually(func() string {
-					cmd := fmt.Sprintf("psql -U postgres postgres -tAc "+
-						"\"SELECT pg_catalog.shobj_description(oid, 'pg_authid') as comment"+
-						" FROM pg_catalog.pg_authid WHERE rolname='%s'\"",
+					query := fmt.Sprintf("SELECT pg_catalog.shobj_description(oid, 'pg_authid') as comment"+
+						" FROM pg_catalog.pg_authid WHERE rolname='%s'",
 						newUserName)
 
-					stdout, _, err := utils.Run(fmt.Sprintf(
-						"kubectl exec -n %v %v -- %v",
-						namespace,
-						primaryPodInfo.Name,
-						cmd))
+					stdout, _, err := env.ExecSQLInPod(namespace, primaryPodInfo.Name, "postgres", query)
 					if err != nil {
 						return ERROR
 					}
@@ -386,16 +349,11 @@ var _ = Describe("Managed roles tests", Label(tests.LabelSmoke, tests.LabelBasic
 
 			By(fmt.Sprintf("Verify comments update in db for %s", username), func() {
 				Eventually(func() string {
-					cmd := fmt.Sprintf("psql -U postgres postgres -tAc "+
-						"\"SELECT pg_catalog.shobj_description(oid, 'pg_authid') as comment"+
-						" FROM pg_catalog.pg_authid WHERE rolname='%s'\"",
+					query := fmt.Sprintf("SELECT pg_catalog.shobj_description(oid, 'pg_authid') as comment"+
+						" FROM pg_catalog.pg_authid WHERE rolname='%s'",
 						username)
 
-					stdout, _, err := utils.Run(fmt.Sprintf(
-						"kubectl exec -n %v %v -- %v",
-						namespace,
-						primaryPodInfo.Name,
-						cmd))
+					stdout, _, err := env.ExecSQLInPod(namespace, primaryPodInfo.Name, "postgres", query)
 					if err != nil {
 						return ERROR
 					}
@@ -528,15 +486,10 @@ var _ = Describe("Managed roles tests", Label(tests.LabelSmoke, tests.LabelBasic
 			By("Update password in database", func() {
 				primaryPodInfo, err := env.GetClusterPrimary(namespace, clusterName)
 				Expect(err).ToNot(HaveOccurred())
-				cmd := fmt.Sprintf("psql -U postgres postgres -tAc "+
-					"\"ALTER ROLE %s WITH PASSWORD %s\"",
+				query := fmt.Sprintf("ALTER ROLE %s WITH PASSWORD %s",
 					username, pq.QuoteLiteral(newPassword))
 
-				_, _, err = utils.Run(fmt.Sprintf(
-					"kubectl exec -n %v %v -- %v",
-					namespace,
-					primaryPodInfo.Name,
-					cmd))
+				_, _, err = env.ExecSQLInPod(namespace, primaryPodInfo.Name, "postgres", query)
 				Expect(err).To(BeNil())
 			})
 
@@ -573,16 +526,11 @@ var _ = Describe("Managed roles tests", Label(tests.LabelSmoke, tests.LabelBasic
 
 			By(fmt.Sprintf("Verify valid until is removed in db for %s", newUserName), func() {
 				Eventually(func() string {
-					cmd := fmt.Sprintf("psql -U postgres postgres -tAc "+
-						"\"SELECT 1 FROM pg_catalog.pg_authid"+
-						" WHERE rolname='%s' and (rolvaliduntil is NULL or rolevaliduntil='infinity')\"",
+					query := fmt.Sprintf("SELECT 1 FROM pg_catalog.pg_authid"+
+						" WHERE rolname='%s' and (rolvaliduntil is NULL or rolevaliduntil='infinity')",
 						newUserName)
 
-					stdout, _, err := utils.Run(fmt.Sprintf(
-						"kubectl exec -n %v %v -- %v",
-						namespace,
-						primaryPodInfo.Name,
-						cmd))
+					stdout, _, err := env.ExecSQLInPod(namespace, primaryPodInfo.Name, "postgres", query)
 					if err != nil {
 						return ERROR
 					}
@@ -592,16 +540,11 @@ var _ = Describe("Managed roles tests", Label(tests.LabelSmoke, tests.LabelBasic
 
 			By(fmt.Sprintf("Verify valid until update in db for %s", username), func() {
 				Eventually(func() string {
-					cmd := fmt.Sprintf("psql -U postgres postgres -tAc "+
-						"\"SELECT 1 FROM pg_catalog.pg_authid "+
-						" WHERE rolname='%s' and rolvaliduntil='%s'\"",
+					query := fmt.Sprintf("SELECT 1 FROM pg_catalog.pg_authid "+
+						" WHERE rolname='%s' and rolvaliduntil='%s'",
 						username, newValidUntilString)
 
-					stdout, _, err := utils.Run(fmt.Sprintf(
-						"kubectl exec -n %v %v -- %v",
-						namespace,
-						primaryPodInfo.Name,
-						cmd))
+					stdout, _, err := env.ExecSQLInPod(namespace, primaryPodInfo.Name, "postgres", query)
 					if err != nil {
 						return ERROR
 					}

--- a/tests/e2e/managed_roles_test.go
+++ b/tests/e2e/managed_roles_test.go
@@ -95,7 +95,7 @@ var _ = Describe("Managed roles tests", Label(tests.LabelSmoke, tests.LabelBasic
 
 		assertUserExists := func(namespace, primaryPod, username string, shouldExists bool) {
 			Eventually(func(g Gomega) {
-				stdout, _, err := env.ExecSQLInPod(namespace, primaryPod, "postgres", "\\du")
+				stdout, _, err := env.ExecQueryInInstancePod(namespace, primaryPod, "postgres", "\\du")
 				g.Expect(err).ToNot(HaveOccurred())
 				if shouldExists {
 					g.Expect(stdout).To(ContainSubstring(username))
@@ -116,7 +116,7 @@ var _ = Describe("Managed roles tests", Label(tests.LabelSmoke, tests.LabelBasic
 						FROM pg_auth_members GROUP BY member
 					) mem ON member = oid
 					WHERE rolname =` + pq.QuoteLiteral(roleName)
-				stdout, _, err := env.ExecSQLInPod(namespace, primaryPod, "postgres", query)
+				stdout, _, err := env.ExecQueryInInstancePod(namespace, primaryPod, "postgres", query)
 				if err != nil {
 					return []string{ERROR}
 				}
@@ -148,7 +148,7 @@ var _ = Describe("Managed roles tests", Label(tests.LabelSmoke, tests.LabelBasic
 					"and rolbypassrls=%v and rolconnlimit=%v", username, rolCanLoginInSpec, rolSuperInSpec, rolCreateDBInSpec,
 					rolCreateRoleInSpec, rolInheritInSpec, rolReplicationInSpec, rolByPassRLSInSpec, rolConnLimitInSpec)
 
-				stdout, _, err := env.ExecSQLInPod(namespace, primaryPodInfo.Name, "postgres", query)
+				stdout, _, err := env.ExecQueryInInstancePod(namespace, primaryPodInfo.Name, "postgres", query)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(stdout).To(Equal("1\n"))
 			})
@@ -167,7 +167,7 @@ var _ = Describe("Managed roles tests", Label(tests.LabelSmoke, tests.LabelBasic
 
 				query := fmt.Sprintf("SELECT rolcreatedb FROM pg_roles WHERE rolname='%s'", appUsername)
 
-				stdout, _, err := env.ExecSQLInPod(namespace, primaryPodInfo.Name, "postgres", query)
+				stdout, _, err := env.ExecQueryInInstancePod(namespace, primaryPodInfo.Name, "postgres", query)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(stdout).To(Equal("t\n"))
 			})
@@ -235,7 +235,7 @@ var _ = Describe("Managed roles tests", Label(tests.LabelSmoke, tests.LabelBasic
 						"and rolcreatedb=%v and rolcreaterole=%v and rolconnlimit=%v",
 						username, expectedLogin, expectedCreateDB, expectedCreateRole, expectedConnLmt)
 
-					stdout, _, err := env.ExecSQLInPod(namespace, primaryPodInfo.Name, "postgres", query)
+					stdout, _, err := env.ExecQueryInInstancePod(namespace, primaryPodInfo.Name, "postgres", query)
 					if err != nil {
 						return ""
 					}
@@ -303,7 +303,7 @@ var _ = Describe("Managed roles tests", Label(tests.LabelSmoke, tests.LabelBasic
 						defaultRolCreateRole, defaultRolInherit, defaultRolReplication,
 						defaultRolByPassRLS, defaultRolConnLimit)
 
-					stdout, _, err := env.ExecSQLInPod(namespace, primaryPodInfo.Name, "postgres", query)
+					stdout, _, err := env.ExecQueryInInstancePod(namespace, primaryPodInfo.Name, "postgres", query)
 					if err != nil {
 						return ""
 					}
@@ -339,7 +339,7 @@ var _ = Describe("Managed roles tests", Label(tests.LabelSmoke, tests.LabelBasic
 						" FROM pg_catalog.pg_authid WHERE rolname='%s'",
 						newUserName)
 
-					stdout, _, err := env.ExecSQLInPod(namespace, primaryPodInfo.Name, "postgres", query)
+					stdout, _, err := env.ExecQueryInInstancePod(namespace, primaryPodInfo.Name, "postgres", query)
 					if err != nil {
 						return ERROR
 					}
@@ -353,7 +353,7 @@ var _ = Describe("Managed roles tests", Label(tests.LabelSmoke, tests.LabelBasic
 						" FROM pg_catalog.pg_authid WHERE rolname='%s'",
 						username)
 
-					stdout, _, err := env.ExecSQLInPod(namespace, primaryPodInfo.Name, "postgres", query)
+					stdout, _, err := env.ExecQueryInInstancePod(namespace, primaryPodInfo.Name, "postgres", query)
 					if err != nil {
 						return ERROR
 					}
@@ -489,7 +489,7 @@ var _ = Describe("Managed roles tests", Label(tests.LabelSmoke, tests.LabelBasic
 				query := fmt.Sprintf("ALTER ROLE %s WITH PASSWORD %s",
 					username, pq.QuoteLiteral(newPassword))
 
-				_, _, err = env.ExecSQLInPod(namespace, primaryPodInfo.Name, "postgres", query)
+				_, _, err = env.ExecQueryInInstancePod(namespace, primaryPodInfo.Name, "postgres", query)
 				Expect(err).To(BeNil())
 			})
 
@@ -530,7 +530,7 @@ var _ = Describe("Managed roles tests", Label(tests.LabelSmoke, tests.LabelBasic
 						" WHERE rolname='%s' and (rolvaliduntil is NULL or rolevaliduntil='infinity')",
 						newUserName)
 
-					stdout, _, err := env.ExecSQLInPod(namespace, primaryPodInfo.Name, "postgres", query)
+					stdout, _, err := env.ExecQueryInInstancePod(namespace, primaryPodInfo.Name, "postgres", query)
 					if err != nil {
 						return ERROR
 					}
@@ -544,7 +544,7 @@ var _ = Describe("Managed roles tests", Label(tests.LabelSmoke, tests.LabelBasic
 						" WHERE rolname='%s' and rolvaliduntil='%s'",
 						username, newValidUntilString)
 
-					stdout, _, err := env.ExecSQLInPod(namespace, primaryPodInfo.Name, "postgres", query)
+					stdout, _, err := env.ExecQueryInInstancePod(namespace, primaryPodInfo.Name, "postgres", query)
 					if err != nil {
 						return ERROR
 					}

--- a/tests/e2e/managed_roles_test.go
+++ b/tests/e2e/managed_roles_test.go
@@ -95,7 +95,13 @@ var _ = Describe("Managed roles tests", Label(tests.LabelSmoke, tests.LabelBasic
 
 		assertUserExists := func(namespace, primaryPod, username string, shouldExists bool) {
 			Eventually(func(g Gomega) {
-				stdout, _, err := env.ExecQueryInInstancePod(namespace, primaryPod, "postgres", "\\du")
+				stdout, _, err := env.ExecQueryInInstancePod(
+					utils.PodLocator{
+						Namespace: namespace,
+						PodName:   primaryPod,
+					},
+					utils.DatabaseName("postgres"),
+					"\\du")
 				g.Expect(err).ToNot(HaveOccurred())
 				if shouldExists {
 					g.Expect(stdout).To(ContainSubstring(username))
@@ -116,7 +122,13 @@ var _ = Describe("Managed roles tests", Label(tests.LabelSmoke, tests.LabelBasic
 						FROM pg_auth_members GROUP BY member
 					) mem ON member = oid
 					WHERE rolname =` + pq.QuoteLiteral(roleName)
-				stdout, _, err := env.ExecQueryInInstancePod(namespace, primaryPod, "postgres", query)
+				stdout, _, err := env.ExecQueryInInstancePod(
+					utils.PodLocator{
+						Namespace: namespace,
+						PodName:   primaryPod,
+					},
+					utils.DatabaseName("postgres"),
+					query)
 				if err != nil {
 					return []string{ERROR}
 				}
@@ -148,7 +160,13 @@ var _ = Describe("Managed roles tests", Label(tests.LabelSmoke, tests.LabelBasic
 					"and rolbypassrls=%v and rolconnlimit=%v", username, rolCanLoginInSpec, rolSuperInSpec, rolCreateDBInSpec,
 					rolCreateRoleInSpec, rolInheritInSpec, rolReplicationInSpec, rolByPassRLSInSpec, rolConnLimitInSpec)
 
-				stdout, _, err := env.ExecQueryInInstancePod(namespace, primaryPodInfo.Name, "postgres", query)
+				stdout, _, err := env.ExecQueryInInstancePod(
+					utils.PodLocator{
+						Namespace: namespace,
+						PodName:   primaryPodInfo.Name,
+					},
+					utils.DatabaseName("postgres"),
+					query)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(stdout).To(Equal("1\n"))
 			})
@@ -167,7 +185,13 @@ var _ = Describe("Managed roles tests", Label(tests.LabelSmoke, tests.LabelBasic
 
 				query := fmt.Sprintf("SELECT rolcreatedb FROM pg_roles WHERE rolname='%s'", appUsername)
 
-				stdout, _, err := env.ExecQueryInInstancePod(namespace, primaryPodInfo.Name, "postgres", query)
+				stdout, _, err := env.ExecQueryInInstancePod(
+					utils.PodLocator{
+						Namespace: namespace,
+						PodName:   primaryPodInfo.Name,
+					},
+					utils.DatabaseName("postgres"),
+					query)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(stdout).To(Equal("t\n"))
 			})
@@ -235,7 +259,13 @@ var _ = Describe("Managed roles tests", Label(tests.LabelSmoke, tests.LabelBasic
 						"and rolcreatedb=%v and rolcreaterole=%v and rolconnlimit=%v",
 						username, expectedLogin, expectedCreateDB, expectedCreateRole, expectedConnLmt)
 
-					stdout, _, err := env.ExecQueryInInstancePod(namespace, primaryPodInfo.Name, "postgres", query)
+					stdout, _, err := env.ExecQueryInInstancePod(
+						utils.PodLocator{
+							Namespace: namespace,
+							PodName:   primaryPodInfo.Name,
+						},
+						utils.DatabaseName("postgres"),
+						query)
 					if err != nil {
 						return ""
 					}
@@ -303,7 +333,13 @@ var _ = Describe("Managed roles tests", Label(tests.LabelSmoke, tests.LabelBasic
 						defaultRolCreateRole, defaultRolInherit, defaultRolReplication,
 						defaultRolByPassRLS, defaultRolConnLimit)
 
-					stdout, _, err := env.ExecQueryInInstancePod(namespace, primaryPodInfo.Name, "postgres", query)
+					stdout, _, err := env.ExecQueryInInstancePod(
+						utils.PodLocator{
+							Namespace: namespace,
+							PodName:   primaryPodInfo.Name,
+						},
+						utils.DatabaseName("postgres"),
+						query)
 					if err != nil {
 						return ""
 					}
@@ -339,7 +375,13 @@ var _ = Describe("Managed roles tests", Label(tests.LabelSmoke, tests.LabelBasic
 						" FROM pg_catalog.pg_authid WHERE rolname='%s'",
 						newUserName)
 
-					stdout, _, err := env.ExecQueryInInstancePod(namespace, primaryPodInfo.Name, "postgres", query)
+					stdout, _, err := env.ExecQueryInInstancePod(
+						utils.PodLocator{
+							Namespace: namespace,
+							PodName:   primaryPodInfo.Name,
+						},
+						utils.DatabaseName("postgres"),
+						query)
 					if err != nil {
 						return ERROR
 					}
@@ -353,7 +395,13 @@ var _ = Describe("Managed roles tests", Label(tests.LabelSmoke, tests.LabelBasic
 						" FROM pg_catalog.pg_authid WHERE rolname='%s'",
 						username)
 
-					stdout, _, err := env.ExecQueryInInstancePod(namespace, primaryPodInfo.Name, "postgres", query)
+					stdout, _, err := env.ExecQueryInInstancePod(
+						utils.PodLocator{
+							Namespace: namespace,
+							PodName:   primaryPodInfo.Name,
+						},
+						utils.DatabaseName("postgres"),
+						query)
 					if err != nil {
 						return ERROR
 					}
@@ -489,7 +537,13 @@ var _ = Describe("Managed roles tests", Label(tests.LabelSmoke, tests.LabelBasic
 				query := fmt.Sprintf("ALTER ROLE %s WITH PASSWORD %s",
 					username, pq.QuoteLiteral(newPassword))
 
-				_, _, err = env.ExecQueryInInstancePod(namespace, primaryPodInfo.Name, "postgres", query)
+				_, _, err = env.ExecQueryInInstancePod(
+					utils.PodLocator{
+						Namespace: namespace,
+						PodName:   primaryPodInfo.Name,
+					},
+					utils.DatabaseName("postgres"),
+					query)
 				Expect(err).To(BeNil())
 			})
 
@@ -530,7 +584,13 @@ var _ = Describe("Managed roles tests", Label(tests.LabelSmoke, tests.LabelBasic
 						" WHERE rolname='%s' and (rolvaliduntil is NULL or rolevaliduntil='infinity')",
 						newUserName)
 
-					stdout, _, err := env.ExecQueryInInstancePod(namespace, primaryPodInfo.Name, "postgres", query)
+					stdout, _, err := env.ExecQueryInInstancePod(
+						utils.PodLocator{
+							Namespace: namespace,
+							PodName:   primaryPodInfo.Name,
+						},
+						utils.DatabaseName("postgres"),
+						query)
 					if err != nil {
 						return ERROR
 					}
@@ -544,7 +604,13 @@ var _ = Describe("Managed roles tests", Label(tests.LabelSmoke, tests.LabelBasic
 						" WHERE rolname='%s' and rolvaliduntil='%s'",
 						username, newValidUntilString)
 
-					stdout, _, err := env.ExecQueryInInstancePod(namespace, primaryPodInfo.Name, "postgres", query)
+					stdout, _, err := env.ExecQueryInInstancePod(
+						utils.PodLocator{
+							Namespace: namespace,
+							PodName:   primaryPodInfo.Name,
+						},
+						utils.DatabaseName("postgres"),
+						query)
 					if err != nil {
 						return ERROR
 					}

--- a/tests/e2e/metrics_test.go
+++ b/tests/e2e/metrics_test.go
@@ -138,10 +138,7 @@ var _ = Describe("Metrics", Label(tests.LabelObservability), func() {
 		AssertCreationOfTestDataForTargetDB(namespace, metricsClusterName, targetDBTwo, testTableName, psqlClientPod)
 		AssertCreationOfTestDataForTargetDB(namespace, metricsClusterName, targetDBSecret, testTableName, psqlClientPod)
 
-		cluster := &apiv1.Cluster{}
-		err = env.Client.Get(env.Ctx,
-			ctrlclient.ObjectKey{Namespace: namespace, Name: metricsClusterName},
-			cluster)
+		cluster, err := env.GetCluster(namespace, metricsClusterName)
 		Expect(err).ToNot(HaveOccurred())
 
 		AssertMetricsData(namespace, curlPodName, targetDBOne, targetDBTwo, targetDBSecret, cluster)

--- a/tests/e2e/pg_basebackup_test.go
+++ b/tests/e2e/pg_basebackup_test.go
@@ -85,7 +85,12 @@ var _ = Describe("Bootstrap with pg_basebackup using basic auth", Label(tests.La
 
 		By("checking data have been copied correctly", func() {
 			// Test data should be present on restored primary
-			out, _, err := env.ExecQueryInInstancePod(namespace, primaryDst, "app",
+			out, _, err := env.ExecQueryInInstancePod(
+				utils.PodLocator{
+					Namespace: namespace,
+					PodName:   primaryDst,
+				},
+				utils.DatabaseName("app"),
 				"SELECT count(*) FROM to_bootstrap")
 			Expect(strings.Trim(out, "\n"), err).To(BeEquivalentTo("2"))
 		})
@@ -95,7 +100,12 @@ var _ = Describe("Bootstrap with pg_basebackup using basic auth", Label(tests.La
 		})
 
 		By("checking the src cluster was not modified", func() {
-			out, _, err := env.ExecQueryInInstancePod(namespace, primarySrc, "app",
+			out, _, err := env.ExecQueryInInstancePod(
+				utils.PodLocator{
+					Namespace: namespace,
+					PodName:   primarySrc,
+				},
+				utils.DatabaseName("app"),
 				"SELECT count(*) FROM to_bootstrap")
 			Expect(strings.Trim(out, "\n"), err).To(BeEquivalentTo("2"))
 			Expect(err).ToNot(HaveOccurred())
@@ -135,7 +145,12 @@ var _ = Describe("Bootstrap with pg_basebackup using TLS auth", Label(tests.Labe
 
 		By("checking data have been copied correctly", func() {
 			// Test data should be present on restored primary
-			out, _, err := env.ExecQueryInInstancePod(namespace, primaryDst, "app",
+			out, _, err := env.ExecQueryInInstancePod(
+				utils.PodLocator{
+					Namespace: namespace,
+					PodName:   primaryDst,
+				},
+				utils.DatabaseName("app"),
 				"SELECT count(*) FROM to_bootstrap")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(strings.Trim(out, "\n"), err).To(BeEquivalentTo("2"))
@@ -146,7 +161,12 @@ var _ = Describe("Bootstrap with pg_basebackup using TLS auth", Label(tests.Labe
 		})
 
 		By("checking the src cluster was not modified", func() {
-			out, _, err := env.ExecQueryInInstancePod(namespace, primarySrc, "app",
+			out, _, err := env.ExecQueryInInstancePod(
+				utils.PodLocator{
+					Namespace: namespace,
+					PodName:   primarySrc,
+				},
+				utils.DatabaseName("app"),
 				"SELECT count(*) FROM to_bootstrap")
 			Expect(strings.Trim(out, "\n"), err).To(BeEquivalentTo("2"))
 			Expect(err).ToNot(HaveOccurred())

--- a/tests/e2e/pg_basebackup_test.go
+++ b/tests/e2e/pg_basebackup_test.go
@@ -85,7 +85,7 @@ var _ = Describe("Bootstrap with pg_basebackup using basic auth", Label(tests.La
 
 		By("checking data have been copied correctly", func() {
 			// Test data should be present on restored primary
-			out, _, err := env.ExecSQLInPod(namespace, primaryDst, "app",
+			out, _, err := env.ExecQueryInInstancePod(namespace, primaryDst, "app",
 				"SELECT count(*) FROM to_bootstrap")
 			Expect(strings.Trim(out, "\n"), err).To(BeEquivalentTo("2"))
 		})
@@ -95,7 +95,7 @@ var _ = Describe("Bootstrap with pg_basebackup using basic auth", Label(tests.La
 		})
 
 		By("checking the src cluster was not modified", func() {
-			out, _, err := env.ExecSQLInPod(namespace, primarySrc, "app",
+			out, _, err := env.ExecQueryInInstancePod(namespace, primarySrc, "app",
 				"SELECT count(*) FROM to_bootstrap")
 			Expect(strings.Trim(out, "\n"), err).To(BeEquivalentTo("2"))
 			Expect(err).ToNot(HaveOccurred())
@@ -135,7 +135,7 @@ var _ = Describe("Bootstrap with pg_basebackup using TLS auth", Label(tests.Labe
 
 		By("checking data have been copied correctly", func() {
 			// Test data should be present on restored primary
-			out, _, err := env.ExecSQLInPod(namespace, primaryDst, "app",
+			out, _, err := env.ExecQueryInInstancePod(namespace, primaryDst, "app",
 				"SELECT count(*) FROM to_bootstrap")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(strings.Trim(out, "\n"), err).To(BeEquivalentTo("2"))
@@ -146,7 +146,7 @@ var _ = Describe("Bootstrap with pg_basebackup using TLS auth", Label(tests.Labe
 		})
 
 		By("checking the src cluster was not modified", func() {
-			out, _, err := env.ExecSQLInPod(namespace, primarySrc, "app",
+			out, _, err := env.ExecQueryInInstancePod(namespace, primarySrc, "app",
 				"SELECT count(*) FROM to_bootstrap")
 			Expect(strings.Trim(out, "\n"), err).To(BeEquivalentTo("2"))
 			Expect(err).ToNot(HaveOccurred())

--- a/tests/e2e/pg_basebackup_test.go
+++ b/tests/e2e/pg_basebackup_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package e2e
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/cloudnative-pg/cloudnative-pg/tests"
@@ -86,11 +85,8 @@ var _ = Describe("Bootstrap with pg_basebackup using basic auth", Label(tests.La
 
 		By("checking data have been copied correctly", func() {
 			// Test data should be present on restored primary
-			out, _, err := utils.Run(fmt.Sprintf(
-				"kubectl exec -n %v %v -- %v",
-				namespace,
-				primaryDst,
-				checkQuery))
+			out, _, err := env.ExecSQLInPod(namespace, primaryDst, "app",
+				"SELECT count(*) FROM to_bootstrap")
 			Expect(strings.Trim(out, "\n"), err).To(BeEquivalentTo("2"))
 		})
 
@@ -99,11 +95,8 @@ var _ = Describe("Bootstrap with pg_basebackup using basic auth", Label(tests.La
 		})
 
 		By("checking the src cluster was not modified", func() {
-			out, _, err := utils.Run(fmt.Sprintf(
-				"kubectl exec -n %v %v -- %v",
-				namespace,
-				primarySrc,
-				checkQuery))
+			out, _, err := env.ExecSQLInPod(namespace, primarySrc, "app",
+				"SELECT count(*) FROM to_bootstrap")
 			Expect(strings.Trim(out, "\n"), err).To(BeEquivalentTo("2"))
 			Expect(err).ToNot(HaveOccurred())
 		})
@@ -119,7 +112,6 @@ var _ = Describe("Bootstrap with pg_basebackup using TLS auth", Label(tests.Labe
 	const dstCluster = fixturesDir + "/pg_basebackup/cluster-dst-tls.yaml.template"
 	const dstClusterName = "pg-basebackup-dst-tls-auth"
 
-	const checkQuery = "psql -U postgres app -tAc 'SELECT count(*) FROM to_bootstrap'"
 	var namespace string
 	It("can bootstrap with pg_basebackup using TLS auth", func() {
 		var err error
@@ -143,11 +135,8 @@ var _ = Describe("Bootstrap with pg_basebackup using TLS auth", Label(tests.Labe
 
 		By("checking data have been copied correctly", func() {
 			// Test data should be present on restored primary
-			out, _, err := utils.Run(fmt.Sprintf(
-				"kubectl exec -n %v %v -- %v",
-				namespace,
-				primaryDst,
-				checkQuery))
+			out, _, err := env.ExecSQLInPod(namespace, primaryDst, "app",
+				"SELECT count(*) FROM to_bootstrap")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(strings.Trim(out, "\n"), err).To(BeEquivalentTo("2"))
 		})
@@ -157,11 +146,8 @@ var _ = Describe("Bootstrap with pg_basebackup using TLS auth", Label(tests.Labe
 		})
 
 		By("checking the src cluster was not modified", func() {
-			out, _, err := utils.Run(fmt.Sprintf(
-				"kubectl exec -n %v %v -- %v",
-				namespace,
-				primarySrc,
-				checkQuery))
+			out, _, err := env.ExecSQLInPod(namespace, primarySrc, "app",
+				"SELECT count(*) FROM to_bootstrap")
 			Expect(strings.Trim(out, "\n"), err).To(BeEquivalentTo("2"))
 			Expect(err).ToNot(HaveOccurred())
 		})

--- a/tests/e2e/pg_data_corruption_test.go
+++ b/tests/e2e/pg_data_corruption_test.go
@@ -81,7 +81,7 @@ var _ = Describe("PGDATA Corruption", Label(tests.LabelRecovery), func() {
 		})
 
 		By("corrupting primary pod by removing PGDATA", func() {
-			_, _, err = env.ExecCommandInPod(namespace, oldPrimaryPodName, nil,
+			_, _, err = env.ExecCommandInInstancePod(namespace, oldPrimaryPodName, nil,
 				"/bin/bash", "-c", "rm -fr %v/base/*")
 			Expect(err).ToNot(HaveOccurred())
 		})

--- a/tests/e2e/pg_data_corruption_test.go
+++ b/tests/e2e/pg_data_corruption_test.go
@@ -82,7 +82,11 @@ var _ = Describe("PGDATA Corruption", Label(tests.LabelRecovery), func() {
 
 		By("corrupting primary pod by removing PGDATA", func() {
 			cmd := fmt.Sprintf("rm -fr %v/base/*", specs.PgDataPath)
-			_, _, err = env.ExecCommandInInstancePod(namespace, oldPrimaryPodName, nil,
+			_, _, err = env.ExecCommandInInstancePod(
+				testsUtils.PodLocator{
+					Namespace: namespace,
+					PodName:   oldPrimaryPodName,
+				}, nil,
 				"/bin/bash", "-c", cmd)
 			Expect(err).ToNot(HaveOccurred())
 		})

--- a/tests/e2e/pg_data_corruption_test.go
+++ b/tests/e2e/pg_data_corruption_test.go
@@ -81,18 +81,19 @@ var _ = Describe("PGDATA Corruption", Label(tests.LabelRecovery), func() {
 		})
 
 		By("corrupting primary pod by removing PGDATA", func() {
+			cmd := fmt.Sprintf("rm -fr %v/base/*", specs.PgDataPath)
 			_, _, err = env.ExecCommandInInstancePod(namespace, oldPrimaryPodName, nil,
-				"/bin/bash", "-c", "rm -fr %v/base/*")
+				"/bin/bash", "-c", cmd)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
 		By("verifying failover happened after the primary pod PGDATA got corrupted", func() {
-			Eventually(func() string {
+			Eventually(func() (string, error) {
 				newPrimaryPod, err := env.GetClusterPrimary(namespace, clusterName)
 				if err != nil {
-					return ""
+					return "", err
 				}
-				return newPrimaryPod.GetName()
+				return newPrimaryPod.GetName(), nil
 			}, 120, 5).ShouldNot(BeEquivalentTo(oldPrimaryPodName),
 				"operator did not perform the failover")
 		})

--- a/tests/e2e/pg_data_corruption_test.go
+++ b/tests/e2e/pg_data_corruption_test.go
@@ -81,9 +81,8 @@ var _ = Describe("PGDATA Corruption", Label(tests.LabelRecovery), func() {
 		})
 
 		By("corrupting primary pod by removing PGDATA", func() {
-			cmd := fmt.Sprintf("kubectl exec %v -n %v postgres -- /bin/bash -c 'rm -fr %v/base/*'",
-				oldPrimaryPodName, namespace, specs.PgDataPath)
-			_, _, err = testsUtils.Run(cmd)
+			_, _, err = env.ExecCommandInPod(namespace, oldPrimaryPodName, nil,
+				"/bin/bash", "-c", "rm -fr %v/base/*")
 			Expect(err).ToNot(HaveOccurred())
 		})
 

--- a/tests/e2e/pg_wal_volume_test.go
+++ b/tests/e2e/pg_wal_volume_test.go
@@ -72,17 +72,12 @@ var _ = Describe("Separate pg_wal volume", Label(tests.LabelBackupRestore), func
 		By("checking WALs are archived in the dedicated volume", func() {
 			for _, pod := range podList.Items {
 				cmd := fmt.Sprintf(
-					"sh -c 'find %v -maxdepth 1 -type f -regextype sed -regex %v -print | wc -l'",
+					"find %v -maxdepth 1 -type f -regextype sed -regex %v -print | wc -l",
 					specs.PgWalVolumePgWalPath,
 					".*[0-9]$")
 				timeout := 300
 				Eventually(func() (int, error, error) {
-					out, _, err := testsUtils.Run(fmt.Sprintf(
-						"kubectl exec -n %v %v -- %v",
-						namespace,
-						pod.GetName(),
-						cmd),
-					)
+					out, _, err := env.ExecCommandInPod(namespace, pod.GetName(), nil, "sh", "-c", cmd)
 					value, atoiErr := strconv.Atoi(strings.Trim(out, "\n"))
 					return value, err, atoiErr
 				}, timeout).Should(BeNumerically(">=", 1))

--- a/tests/e2e/pg_wal_volume_test.go
+++ b/tests/e2e/pg_wal_volume_test.go
@@ -77,7 +77,7 @@ var _ = Describe("Separate pg_wal volume", Label(tests.LabelBackupRestore), func
 					".*[0-9]$")
 				timeout := 300
 				Eventually(func() (int, error, error) {
-					out, _, err := env.ExecCommandInPod(namespace, pod.GetName(), nil, "sh", "-c", cmd)
+					out, _, err := env.ExecCommandInInstancePod(namespace, pod.GetName(), nil, "sh", "-c", cmd)
 					value, atoiErr := strconv.Atoi(strings.Trim(out, "\n"))
 					return value, err, atoiErr
 				}, timeout).Should(BeNumerically(">=", 1))

--- a/tests/e2e/pg_wal_volume_test.go
+++ b/tests/e2e/pg_wal_volume_test.go
@@ -77,7 +77,12 @@ var _ = Describe("Separate pg_wal volume", Label(tests.LabelBackupRestore), func
 					".*[0-9]$")
 				timeout := 300
 				Eventually(func() (int, error, error) {
-					out, _, err := env.ExecCommandInInstancePod(namespace, pod.GetName(), nil, "sh", "-c", cmd)
+					out, _, err := env.ExecCommandInInstancePod(
+						testsUtils.PodLocator{
+							Namespace: namespace,
+							PodName:   pod.GetName(),
+						}, nil,
+						"sh", "-c", cmd)
 					value, atoiErr := strconv.Atoi(strings.Trim(out, "\n"))
 					return value, err, atoiErr
 				}, timeout).Should(BeNumerically(">=", 1))

--- a/tests/e2e/rolling_update_test.go
+++ b/tests/e2e/rolling_update_test.go
@@ -80,13 +80,10 @@ var _ = Describe("Rolling updates", Label(tests.LabelPostgresConfiguration), fun
 
 		// We should be able to apply the conf containing the new
 		// image
-		cluster := &apiv1.Cluster{}
-		namespacedName := types.NamespacedName{
-			Namespace: namespace,
-			Name:      clusterName,
-		}
+		var cluster *apiv1.Cluster
 		Eventually(func(g Gomega) error {
-			err := env.Client.Get(env.Ctx, namespacedName, cluster)
+			var err error
+			cluster, err = env.GetCluster(namespace, clusterName)
 			g.Expect(err).ToNot(HaveOccurred())
 
 			cluster.Spec.ImageName = updatedImageName
@@ -244,12 +241,7 @@ var _ = Describe("Rolling updates", Label(tests.LabelPostgresConfiguration), fun
 
 		AssertCreateCluster(namespace, clusterName, sampleFile, env)
 		// Gather the number of instances in this Cluster
-		cluster := &apiv1.Cluster{}
-		namespacedName := types.NamespacedName{
-			Namespace: namespace,
-			Name:      clusterName,
-		}
-		err := env.Client.Get(env.Ctx, namespacedName, cluster)
+		cluster, err := env.GetCluster(namespace, clusterName)
 		Expect(err).ToNot(HaveOccurred())
 		clusterInstances := cluster.Spec.Instances
 

--- a/tests/e2e/syncreplicas_test.go
+++ b/tests/e2e/syncreplicas_test.go
@@ -164,10 +164,14 @@ var _ = Describe("Synchronous Replicas", Label(tests.LabelReplication), func() {
 
 		By("checking that synchronous_standby_names has the expected value on the primary", func() {
 			Eventually(func() string {
-				out, _, err := env.ExecQueryInInstancePod(namespace, clusterName, "postgres",
+				primary, err := env.GetClusterPrimary(namespace, clusterName)
+				if err != nil {
+					return err.Error()
+				}
+				out, stderr, err := env.ExecQueryInInstancePod(namespace, primary.GetName(), "postgres",
 					"select setting from pg_settings where name = 'synchronous_standby_names'")
 				if err != nil {
-					return ""
+					return stderr + " - " + err.Error()
 				}
 				return strings.Trim(out, "\n")
 			}, 30).Should(Equal("ANY 1 (\"cluster-pgstatstatements-2\",\"cluster-pgstatstatements-3\")"))

--- a/tests/e2e/syncreplicas_test.go
+++ b/tests/e2e/syncreplicas_test.go
@@ -164,7 +164,7 @@ var _ = Describe("Synchronous Replicas", Label(tests.LabelReplication), func() {
 
 		By("checking that synchronous_standby_names has the expected value on the primary", func() {
 			Eventually(func() string {
-				out, _, err := env.ExecSQLInPod(namespace, clusterName, "postgres",
+				out, _, err := env.ExecQueryInInstancePod(namespace, clusterName, "postgres",
 					"select setting from pg_settings where name = 'synchronous_standby_names'")
 				if err != nil {
 					return ""

--- a/tests/e2e/syncreplicas_test.go
+++ b/tests/e2e/syncreplicas_test.go
@@ -168,7 +168,12 @@ var _ = Describe("Synchronous Replicas", Label(tests.LabelReplication), func() {
 				if err != nil {
 					return err.Error()
 				}
-				out, stderr, err := env.ExecQueryInInstancePod(namespace, primary.GetName(), "postgres",
+				out, stderr, err := env.ExecQueryInInstancePod(
+					utils.PodLocator{
+						Namespace: namespace,
+						PodName:   primary.GetName(),
+					},
+					utils.DatabaseName("postgres"),
 					"select setting from pg_settings where name = 'synchronous_standby_names'")
 				if err != nil {
 					return stderr + " - " + err.Error()

--- a/tests/e2e/syncreplicas_test.go
+++ b/tests/e2e/syncreplicas_test.go
@@ -164,10 +164,8 @@ var _ = Describe("Synchronous Replicas", Label(tests.LabelReplication), func() {
 
 		By("checking that synchronous_standby_names has the expected value on the primary", func() {
 			Eventually(func() string {
-				out, _, err := utils.Run(
-					fmt.Sprintf("kubectl exec -n %v %v-1 -c postgres -- "+
-						"psql -U postgres -tAc \"select setting from pg_settings where name = 'synchronous_standby_names'\"",
-						namespace, clusterName))
+				out, _, err := env.ExecSQLInPod(namespace, clusterName, "postgres",
+					"select setting from pg_settings where name = 'synchronous_standby_names'")
 				if err != nil {
 					return ""
 				}

--- a/tests/e2e/update_user_test.go
+++ b/tests/e2e/update_user_test.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	clusterv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/specs"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 	"github.com/cloudnative-pg/cloudnative-pg/tests"
@@ -140,15 +139,10 @@ var _ = Describe("Disabling superuser password", Label(tests.LabelServiceConnect
 		AssertCreateCluster(namespace, clusterName, sampleFile, env)
 		// we use a pod in the cluster to have a psql client ready and
 		// internal access to the k8s cluster
-		namespacedName := types.NamespacedName{
-			Namespace: namespace,
-			Name:      clusterName,
-		}
 
 		By("disable superuser access", func() {
 			const secretName = clusterName + "-superuser"
-			cluster := &clusterv1.Cluster{}
-			err := env.Client.Get(env.Ctx, namespacedName, cluster)
+			_, err := env.GetCluster(namespace, clusterName)
 			Expect(err).ToNot(HaveOccurred())
 
 			Eventually(func() error {
@@ -160,7 +154,7 @@ var _ = Describe("Disabling superuser password", Label(tests.LabelServiceConnect
 
 			// Setting to false, now we should not have a secret or password
 			Eventually(func() error {
-				err := env.Client.Get(env.Ctx, namespacedName, cluster)
+				cluster, err := env.GetCluster(namespace, clusterName)
 				if err != nil {
 					return err
 				}
@@ -201,7 +195,7 @@ var _ = Describe("Disabling superuser password", Label(tests.LabelServiceConnect
 
 			// Setting to true, so we have a secret and a new password
 			Eventually(func() error {
-				err := env.Client.Get(env.Ctx, namespacedName, cluster)
+				cluster, err := env.GetCluster(namespace, clusterName)
 				if err != nil {
 					return err
 				}
@@ -240,7 +234,6 @@ var _ = Describe("Creating a cluster without superuser password", Label(tests.La
 
 	It("create a cluster without postgres password", func() {
 		var secret corev1.Secret
-		var cluster clusterv1.Cluster
 		var err error
 		const secretName = clusterName + "-superuser"
 
@@ -256,13 +249,9 @@ var _ = Describe("Creating a cluster without superuser password", Label(tests.La
 		AssertCreateCluster(namespace, clusterName, sampleFile, env)
 		// we use a pod in the cluster to have a psql client ready and
 		// internal access to the k8s cluster
-		namespacedName := types.NamespacedName{
-			Namespace: namespace,
-			Name:      clusterName,
-		}
 
 		By("ensuring no superuser secret is generated", func() {
-			err := env.Client.Get(env.Ctx, namespacedName, &cluster)
+			_, err := env.GetCluster(namespace, clusterName)
 			Expect(err).ToNot(HaveOccurred())
 
 			Eventually(func() bool {
@@ -277,11 +266,11 @@ var _ = Describe("Creating a cluster without superuser password", Label(tests.La
 			// Setting to true, now we should have a secret with the password
 			Eventually(func() error {
 				err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-					err := env.Client.Get(env.Ctx, namespacedName, &cluster)
+					cluster, err := env.GetCluster(namespace, clusterName)
 					Expect(err).ToNot(HaveOccurred())
 					trueValue := true
 					cluster.Spec.EnableSuperuserAccess = &trueValue
-					err = env.Client.Update(env.Ctx, &cluster)
+					err = env.Client.Update(env.Ctx, cluster)
 					if err != nil {
 						return err
 					}

--- a/tests/e2e/upgrade_test.go
+++ b/tests/e2e/upgrade_test.go
@@ -98,13 +98,13 @@ var _ = Describe("Upgrade", Label(tests.LabelUpgrade, tests.LabelNoOpenshift), O
 	// but a single scheduled backups during the check
 	AssertScheduledBackupsAreScheduled := func(upgradeNamespace string) {
 		By("verifying scheduled backups are still happening", func() {
-			out, _, err := env.ExecCommandInInstancePod(upgradeNamespace, minioClientName, nil,
+			out, _, err := env.ExecCommandInContainer(upgradeNamespace, minioClientName, "mc", nil,
 				"sh", "-c", "mc find minio --name data.tar.gz | wc -l")
 			Expect(err).ToNot(HaveOccurred())
 			currentBackups, err := strconv.Atoi(strings.Trim(out, "\n"))
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(func() (int, error) {
-				out, _, err := env.ExecCommandInInstancePod(upgradeNamespace, minioClientName, nil,
+				out, _, err := env.ExecCommandInContainer(upgradeNamespace, minioClientName, "mc", nil,
 					"sh", "-c", "mc find minio --name data.tar.gz | wc -l")
 				if err != nil {
 					return 0, err
@@ -391,7 +391,7 @@ var _ = Describe("Upgrade", Label(tests.LabelUpgrade, tests.LabelNoOpenshift), O
 				findCmd := fmt.Sprintf(
 					"mc find minio --name %v.gz | wc -l",
 					latestWAL)
-				out, _, err := env.ExecCommandInInstancePod(upgradeNamespace, minioClientName, nil,
+				out, _, err := env.ExecCommandInContainer(upgradeNamespace, minioClientName, "mc", nil,
 					"sh", "-c", findCmd)
 				value, atoiErr := strconv.Atoi(strings.Trim(out, "\n"))
 				return value, err, atoiErr
@@ -416,7 +416,7 @@ var _ = Describe("Upgrade", Label(tests.LabelUpgrade, tests.LabelNoOpenshift), O
 
 			// A file called data.tar.gz should be available on minio
 			Eventually(func() (int, error, error) {
-				out, _, err := env.ExecCommandInInstancePod(upgradeNamespace, minioClientName, nil,
+				out, _, err := env.ExecCommandInContainer(upgradeNamespace, minioClientName, "mc", nil,
 					"sh", "-c", "mc find minio --name data.tar.gz | wc -l")
 				value, atoiErr := strconv.Atoi(strings.Trim(out, "\n"))
 				return value, err, atoiErr

--- a/tests/e2e/upgrade_test.go
+++ b/tests/e2e/upgrade_test.go
@@ -140,8 +140,7 @@ var _ = Describe("Upgrade", Label(tests.LabelUpgrade, tests.LabelNoOpenshift), O
 				Namespace: upgradeNamespace,
 				Name:      clusterName,
 			}
-			cluster := &apiv1.Cluster{}
-			err = env.Client.Get(env.Ctx, namespacedName, cluster)
+			cluster, err := env.GetCluster(upgradeNamespace, clusterName)
 			Expect(cluster.Status.CurrentPrimary, err).To(BeEquivalentTo(cluster.Status.TargetPrimary))
 
 			oldPrimary := cluster.Status.CurrentPrimary

--- a/tests/e2e/upgrade_test.go
+++ b/tests/e2e/upgrade_test.go
@@ -140,10 +140,6 @@ var _ = Describe("Upgrade", Label(tests.LabelUpgrade, tests.LabelNoOpenshift), O
 			podList, err := env.GetClusterPodList(upgradeNamespace, clusterName)
 			Expect(err).ToNot(HaveOccurred())
 			// Gather current primary
-			namespacedName := types.NamespacedName{
-				Namespace: upgradeNamespace,
-				Name:      clusterName,
-			}
 			cluster, err := env.GetCluster(upgradeNamespace, clusterName)
 			Expect(cluster.Status.CurrentPrimary, err).To(BeEquivalentTo(cluster.Status.TargetPrimary))
 
@@ -181,8 +177,7 @@ var _ = Describe("Upgrade", Label(tests.LabelUpgrade, tests.LabelNoOpenshift), O
 			}
 			// Check that a switchover happened
 			Eventually(func() (bool, error) {
-				c := &apiv1.Cluster{}
-				err := env.Client.Get(env.Ctx, namespacedName, c)
+				c, err := env.GetCluster(upgradeNamespace, clusterName)
 				Expect(err).ToNot(HaveOccurred())
 
 				GinkgoWriter.Printf("Current Primary: %s, Current Primary timestamp: %s\n",

--- a/tests/e2e/upgrade_test.go
+++ b/tests/e2e/upgrade_test.go
@@ -98,13 +98,13 @@ var _ = Describe("Upgrade", Label(tests.LabelUpgrade, tests.LabelNoOpenshift), O
 	// but a single scheduled backups during the check
 	AssertScheduledBackupsAreScheduled := func(upgradeNamespace string) {
 		By("verifying scheduled backups are still happening", func() {
-			out, _, err := env.ExecCommandInPod(upgradeNamespace, minioClientName, nil,
+			out, _, err := env.ExecCommandInInstancePod(upgradeNamespace, minioClientName, nil,
 				"sh", "-c", "mc find minio --name data.tar.gz | wc -l")
 			Expect(err).ToNot(HaveOccurred())
 			currentBackups, err := strconv.Atoi(strings.Trim(out, "\n"))
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(func() (int, error) {
-				out, _, err := env.ExecCommandInPod(upgradeNamespace, minioClientName, nil,
+				out, _, err := env.ExecCommandInInstancePod(upgradeNamespace, minioClientName, nil,
 					"sh", "-c", "mc find minio --name data.tar.gz | wc -l")
 				if err != nil {
 					return 0, err
@@ -380,7 +380,7 @@ var _ = Describe("Upgrade", Label(tests.LabelUpgrade, tests.LabelNoOpenshift), O
 		// minio within a short time.
 		By("archiving WALs on minio", func() {
 			primary := clusterName1 + "-1"
-			out, _, err := env.ExecCommandInPod(upgradeNamespace, primary, nil,
+			out, _, err := env.ExecCommandInInstancePod(upgradeNamespace, primary, nil,
 				"psql", "-U", "postgres", "appdb", "-v", "SHOW_ALL_RESULTS=off", "-tAc",
 				"CHECKPOINT; SELECT pg_walfile_name(pg_switch_wal())")
 			Expect(err).ToNot(HaveOccurred())
@@ -391,7 +391,7 @@ var _ = Describe("Upgrade", Label(tests.LabelUpgrade, tests.LabelNoOpenshift), O
 				findCmd := fmt.Sprintf(
 					"mc find minio --name %v.gz | wc -l",
 					latestWAL)
-				out, _, err := env.ExecCommandInPod(upgradeNamespace, minioClientName, nil,
+				out, _, err := env.ExecCommandInInstancePod(upgradeNamespace, minioClientName, nil,
 					"sh", "-c", findCmd)
 				value, atoiErr := strconv.Atoi(strings.Trim(out, "\n"))
 				return value, err, atoiErr
@@ -416,7 +416,7 @@ var _ = Describe("Upgrade", Label(tests.LabelUpgrade, tests.LabelNoOpenshift), O
 
 			// A file called data.tar.gz should be available on minio
 			Eventually(func() (int, error, error) {
-				out, _, err := env.ExecCommandInPod(upgradeNamespace, minioClientName, nil,
+				out, _, err := env.ExecCommandInInstancePod(upgradeNamespace, minioClientName, nil,
 					"sh", "-c", "mc find minio --name data.tar.gz | wc -l")
 				value, atoiErr := strconv.Atoi(strings.Trim(out, "\n"))
 				return value, err, atoiErr
@@ -522,7 +522,7 @@ var _ = Describe("Upgrade", Label(tests.LabelUpgrade, tests.LabelNoOpenshift), O
 
 			// Test data should be present on restored primary
 			primary := restoredClusterName + "-1"
-			out, _, err := env.ExecSQLInPod(upgradeNamespace, primary, "appdb",
+			out, _, err := env.ExecQueryInInstancePod(upgradeNamespace, primary, "appdb",
 				"SELECT count(*) FROM to_restore")
 			Expect(strings.Trim(out, "\n"), err).To(BeEquivalentTo("2"))
 
@@ -530,7 +530,7 @@ var _ = Describe("Upgrade", Label(tests.LabelUpgrade, tests.LabelNoOpenshift), O
 			// we expect a promotion. We can't enforce "2" because the timeline
 			// ID will also depend on the history files existing in the cloud
 			// storage and we don't know the status of that.
-			out, _, err = env.ExecSQLInPod(upgradeNamespace, primary, "appdb",
+			out, _, err = env.ExecQueryInInstancePod(upgradeNamespace, primary, "appdb",
 				"select substring(pg_walfile_name(pg_current_wal_lsn()), 1, 8)")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(strconv.Atoi(strings.Trim(out, "\n"))).To(
@@ -538,7 +538,7 @@ var _ = Describe("Upgrade", Label(tests.LabelUpgrade, tests.LabelNoOpenshift), O
 
 			// Restored standbys should soon attach themselves to restored primary
 			Eventually(func() (string, error) {
-				out, _, err = env.ExecSQLInPod(upgradeNamespace, primary, "appdb",
+				out, _, err = env.ExecQueryInInstancePod(upgradeNamespace, primary, "appdb",
 					"SELECT count(*) FROM pg_stat_replication")
 				return strings.Trim(out, "\n"), err
 			}, 180).Should(BeEquivalentTo("2"))

--- a/tests/e2e/wal_restore_parallel_test.go
+++ b/tests/e2e/wal_restore_parallel_test.go
@@ -164,7 +164,7 @@ var _ = Describe("Wal-restore in parallel", Label(tests.LabelBackupRestore), fun
 		By("asserting the spool directory is empty on the standby", func() {
 			if !testUtils.TestDirectoryEmpty(namespace, standby, SpoolDirectory) {
 				purgeSpoolDirectoryCmd := "rm " + SpoolDirectory + "/*"
-				_, _, err := env.ExecCommandInPod(namespace, standby, nil, purgeSpoolDirectoryCmd)
+				_, _, err := env.ExecCommandInInstancePod(namespace, standby, nil, purgeSpoolDirectoryCmd)
 				Expect(err).ShouldNot(HaveOccurred())
 			}
 		})
@@ -174,7 +174,7 @@ var _ = Describe("Wal-restore in parallel", Label(tests.LabelBackupRestore), fun
 		// 		exit code 0, #1 is in the output location, #2 and #3 are in the spool directory.
 		// 		The flag is unset.
 		By("invoking the wal-restore command requesting #1 wal", func() {
-			_, _, err := env.ExecCommandInPod(namespace, standby, nil,
+			_, _, err := env.ExecCommandInInstancePod(namespace, standby, nil,
 				walRestoreCommand+" "+walFile1+" "+PgWalPath+"/"+walFile1)
 			Expect(err).ToNot(HaveOccurred(), "exit code should be 0")
 			Eventually(func() bool { return testUtils.TestFileExist(namespace, standby, PgWalPath, walFile1) }).
@@ -200,7 +200,7 @@ var _ = Describe("Wal-restore in parallel", Label(tests.LabelBackupRestore), fun
 		// 		exit code 0, #2 is in the output location, #3 is in the spool directory.
 		// 		The flag is unset.
 		By("invoking the wal-restore command requesting #2 wal", func() {
-			_, _, err := env.ExecCommandInPod(namespace, standby, nil,
+			_, _, err := env.ExecCommandInInstancePod(namespace, standby, nil,
 				walRestoreCommand+" "+walFile2+" "+PgWalPath+"/"+walFile2)
 			Expect(err).ToNot(HaveOccurred(), "exit code should be 0")
 			Eventually(func() bool { return testUtils.TestFileExist(namespace, standby, PgWalPath, walFile2) }).
@@ -222,7 +222,7 @@ var _ = Describe("Wal-restore in parallel", Label(tests.LabelBackupRestore), fun
 		// 		exit code 0, #3 is in the output location, spool directory is empty.
 		// 		The flag is unset.
 		By("invoking the wal-restore command requesting #3 wal", func() {
-			_, _, err := env.ExecCommandInPod(namespace, standby, nil,
+			_, _, err := env.ExecCommandInInstancePod(namespace, standby, nil,
 				walRestoreCommand+" "+walFile3+" "+PgWalPath+"/"+walFile3)
 			Expect(err).ToNot(HaveOccurred(), "exit code should be 0")
 			Eventually(func() bool { return testUtils.TestFileExist(namespace, standby, PgWalPath, walFile3) }).
@@ -240,7 +240,7 @@ var _ = Describe("Wal-restore in parallel", Label(tests.LabelBackupRestore), fun
 		// 		exit code 0, #4 is in the output location, #5 is in the spool directory.
 		// 		The flag is set because #6 file not present.
 		By("invoking the wal-restore command requesting #4 wal", func() {
-			_, _, err := env.ExecCommandInPod(namespace, standby, nil,
+			_, _, err := env.ExecCommandInInstancePod(namespace, standby, nil,
 				walRestoreCommand+" "+walFile4+" "+PgWalPath+"/"+walFile4)
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(func() bool { return testUtils.TestFileExist(namespace, standby, PgWalPath, walFile4) }).
@@ -268,7 +268,7 @@ var _ = Describe("Wal-restore in parallel", Label(tests.LabelBackupRestore), fun
 		// Expected outcome:
 		//		exit code 0, #5 is in the output location, no files in the spool directory. The flag is still present.
 		By("invoking the wal-restore command requesting #5 wal", func() {
-			_, _, err := env.ExecCommandInPod(namespace, standby, nil,
+			_, _, err := env.ExecCommandInInstancePod(namespace, standby, nil,
 				walRestoreCommand+" "+walFile5+" "+PgWalPath+"/"+walFile5)
 			Expect(err).ToNot(HaveOccurred(), "exit code should be 0")
 			Eventually(func() bool { return testUtils.TestFileExist(namespace, standby, PgWalPath, walFile5) }).
@@ -289,7 +289,7 @@ var _ = Describe("Wal-restore in parallel", Label(tests.LabelBackupRestore), fun
 		// Expected outcome:
 		//		exit code 1, output location untouched, no files in the spool directory. The flag is unset.
 		By("invoking the wal-restore command requesting #6 wal", func() {
-			_, _, err := env.ExecCommandInPod(namespace, standby, nil,
+			_, _, err := env.ExecCommandInInstancePod(namespace, standby, nil,
 				walRestoreCommand+" "+walFile6+" "+PgWalPath+"/"+walFile6)
 			Expect(err).To(HaveOccurred(),
 				"exit code should 1 since #6 wal is not in the output location or spool directory and flag is set")
@@ -308,7 +308,7 @@ var _ = Describe("Wal-restore in parallel", Label(tests.LabelBackupRestore), fun
 		//		exit code 0, #6 is in the output location, no files in the spool directory.
 		//		The flag is present again because #7 and #8 are unavailable.
 		By("invoking the wal-restore command requesting #6 wal again", func() {
-			_, _, err := env.ExecCommandInPod(namespace, standby, nil,
+			_, _, err := env.ExecCommandInInstancePod(namespace, standby, nil,
 				walRestoreCommand+" "+walFile6+" "+PgWalPath+"/"+walFile6)
 			Expect(err).ToNot(HaveOccurred(), "exit code should be 0")
 			Eventually(func() bool { return testUtils.TestFileExist(namespace, standby, PgWalPath, walFile6) }).

--- a/tests/e2e/wal_restore_parallel_test.go
+++ b/tests/e2e/wal_restore_parallel_test.go
@@ -34,10 +34,9 @@ import (
 
 var _ = Describe("Wal-restore in parallel", Label(tests.LabelBackupRestore), func() {
 	const (
-		level             = tests.High
-		walRestoreCommand = "/controller/manager wal-restore"
-		PgWalPath         = specs.PgWalPath
-		SpoolDirectory    = walrestore.SpoolDirectory
+		level          = tests.High
+		PgWalPath      = specs.PgWalPath
+		SpoolDirectory = walrestore.SpoolDirectory
 	)
 
 	var namespace string
@@ -175,7 +174,7 @@ var _ = Describe("Wal-restore in parallel", Label(tests.LabelBackupRestore), fun
 		// 		The flag is unset.
 		By("invoking the wal-restore command requesting #1 wal", func() {
 			_, _, err := env.ExecCommandInInstancePod(namespace, standby, nil,
-				walRestoreCommand+" "+walFile1+" "+PgWalPath+"/"+walFile1)
+				"/controller/manager", "wal-restore", walFile1, PgWalPath+"/"+walFile1)
 			Expect(err).ToNot(HaveOccurred(), "exit code should be 0")
 			Eventually(func() bool { return testUtils.TestFileExist(namespace, standby, PgWalPath, walFile1) }).
 				WithTimeout(RetryTimeout).
@@ -201,7 +200,7 @@ var _ = Describe("Wal-restore in parallel", Label(tests.LabelBackupRestore), fun
 		// 		The flag is unset.
 		By("invoking the wal-restore command requesting #2 wal", func() {
 			_, _, err := env.ExecCommandInInstancePod(namespace, standby, nil,
-				walRestoreCommand+" "+walFile2+" "+PgWalPath+"/"+walFile2)
+				"/controller/manager", "wal-restore", walFile2, PgWalPath+"/"+walFile2)
 			Expect(err).ToNot(HaveOccurred(), "exit code should be 0")
 			Eventually(func() bool { return testUtils.TestFileExist(namespace, standby, PgWalPath, walFile2) }).
 				WithTimeout(RetryTimeout).
@@ -223,7 +222,7 @@ var _ = Describe("Wal-restore in parallel", Label(tests.LabelBackupRestore), fun
 		// 		The flag is unset.
 		By("invoking the wal-restore command requesting #3 wal", func() {
 			_, _, err := env.ExecCommandInInstancePod(namespace, standby, nil,
-				walRestoreCommand+" "+walFile3+" "+PgWalPath+"/"+walFile3)
+				"/controller/manager", "wal-restore", walFile3, PgWalPath+"/"+walFile3)
 			Expect(err).ToNot(HaveOccurred(), "exit code should be 0")
 			Eventually(func() bool { return testUtils.TestFileExist(namespace, standby, PgWalPath, walFile3) }).
 				WithTimeout(RetryTimeout).
@@ -241,7 +240,7 @@ var _ = Describe("Wal-restore in parallel", Label(tests.LabelBackupRestore), fun
 		// 		The flag is set because #6 file not present.
 		By("invoking the wal-restore command requesting #4 wal", func() {
 			_, _, err := env.ExecCommandInInstancePod(namespace, standby, nil,
-				walRestoreCommand+" "+walFile4+" "+PgWalPath+"/"+walFile4)
+				"/controller/manager", "wal-restore", walFile4, PgWalPath+"/"+walFile4)
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(func() bool { return testUtils.TestFileExist(namespace, standby, PgWalPath, walFile4) }).
 				WithTimeout(RetryTimeout).
@@ -269,7 +268,7 @@ var _ = Describe("Wal-restore in parallel", Label(tests.LabelBackupRestore), fun
 		//		exit code 0, #5 is in the output location, no files in the spool directory. The flag is still present.
 		By("invoking the wal-restore command requesting #5 wal", func() {
 			_, _, err := env.ExecCommandInInstancePod(namespace, standby, nil,
-				walRestoreCommand+" "+walFile5+" "+PgWalPath+"/"+walFile5)
+				"/controller/manager", "wal-restore", walFile5, PgWalPath+"/"+walFile5)
 			Expect(err).ToNot(HaveOccurred(), "exit code should be 0")
 			Eventually(func() bool { return testUtils.TestFileExist(namespace, standby, PgWalPath, walFile5) }).
 				WithTimeout(RetryTimeout).
@@ -290,7 +289,7 @@ var _ = Describe("Wal-restore in parallel", Label(tests.LabelBackupRestore), fun
 		//		exit code 1, output location untouched, no files in the spool directory. The flag is unset.
 		By("invoking the wal-restore command requesting #6 wal", func() {
 			_, _, err := env.ExecCommandInInstancePod(namespace, standby, nil,
-				walRestoreCommand+" "+walFile6+" "+PgWalPath+"/"+walFile6)
+				"/controller/manager", "wal-restore", walFile6, PgWalPath+"/"+walFile6)
 			Expect(err).To(HaveOccurred(),
 				"exit code should 1 since #6 wal is not in the output location or spool directory and flag is set")
 			Eventually(func() bool { return testUtils.TestFileExist(namespace, standby, PgWalPath, walFile6) }).
@@ -309,7 +308,7 @@ var _ = Describe("Wal-restore in parallel", Label(tests.LabelBackupRestore), fun
 		//		The flag is present again because #7 and #8 are unavailable.
 		By("invoking the wal-restore command requesting #6 wal again", func() {
 			_, _, err := env.ExecCommandInInstancePod(namespace, standby, nil,
-				walRestoreCommand+" "+walFile6+" "+PgWalPath+"/"+walFile6)
+				"/controller/manager", "wal-restore", walFile6, PgWalPath+"/"+walFile6)
 			Expect(err).ToNot(HaveOccurred(), "exit code should be 0")
 			Eventually(func() bool { return testUtils.TestFileExist(namespace, standby, PgWalPath, walFile6) }).
 				WithTimeout(RetryTimeout).

--- a/tests/e2e/wal_restore_parallel_test.go
+++ b/tests/e2e/wal_restore_parallel_test.go
@@ -163,7 +163,12 @@ var _ = Describe("Wal-restore in parallel", Label(tests.LabelBackupRestore), fun
 		By("asserting the spool directory is empty on the standby", func() {
 			if !testUtils.TestDirectoryEmpty(namespace, standby, SpoolDirectory) {
 				purgeSpoolDirectoryCmd := "rm " + SpoolDirectory + "/*"
-				_, _, err := env.ExecCommandInInstancePod(namespace, standby, nil, purgeSpoolDirectoryCmd)
+				_, _, err := env.ExecCommandInInstancePod(
+					testUtils.PodLocator{
+						Namespace: namespace,
+						PodName:   standby,
+					}, nil,
+					purgeSpoolDirectoryCmd)
 				Expect(err).ShouldNot(HaveOccurred())
 			}
 		})
@@ -173,7 +178,11 @@ var _ = Describe("Wal-restore in parallel", Label(tests.LabelBackupRestore), fun
 		// 		exit code 0, #1 is in the output location, #2 and #3 are in the spool directory.
 		// 		The flag is unset.
 		By("invoking the wal-restore command requesting #1 wal", func() {
-			_, _, err := env.ExecCommandInInstancePod(namespace, standby, nil,
+			_, _, err := env.ExecCommandInInstancePod(
+				testUtils.PodLocator{
+					Namespace: namespace,
+					PodName:   standby,
+				}, nil,
 				"/controller/manager", "wal-restore", walFile1, PgWalPath+"/"+walFile1)
 			Expect(err).ToNot(HaveOccurred(), "exit code should be 0")
 			Eventually(func() bool { return testUtils.TestFileExist(namespace, standby, PgWalPath, walFile1) }).
@@ -199,7 +208,11 @@ var _ = Describe("Wal-restore in parallel", Label(tests.LabelBackupRestore), fun
 		// 		exit code 0, #2 is in the output location, #3 is in the spool directory.
 		// 		The flag is unset.
 		By("invoking the wal-restore command requesting #2 wal", func() {
-			_, _, err := env.ExecCommandInInstancePod(namespace, standby, nil,
+			_, _, err := env.ExecCommandInInstancePod(
+				testUtils.PodLocator{
+					Namespace: namespace,
+					PodName:   standby,
+				}, nil,
 				"/controller/manager", "wal-restore", walFile2, PgWalPath+"/"+walFile2)
 			Expect(err).ToNot(HaveOccurred(), "exit code should be 0")
 			Eventually(func() bool { return testUtils.TestFileExist(namespace, standby, PgWalPath, walFile2) }).
@@ -221,7 +234,11 @@ var _ = Describe("Wal-restore in parallel", Label(tests.LabelBackupRestore), fun
 		// 		exit code 0, #3 is in the output location, spool directory is empty.
 		// 		The flag is unset.
 		By("invoking the wal-restore command requesting #3 wal", func() {
-			_, _, err := env.ExecCommandInInstancePod(namespace, standby, nil,
+			_, _, err := env.ExecCommandInInstancePod(
+				testUtils.PodLocator{
+					Namespace: namespace,
+					PodName:   standby,
+				}, nil,
 				"/controller/manager", "wal-restore", walFile3, PgWalPath+"/"+walFile3)
 			Expect(err).ToNot(HaveOccurred(), "exit code should be 0")
 			Eventually(func() bool { return testUtils.TestFileExist(namespace, standby, PgWalPath, walFile3) }).
@@ -239,7 +256,11 @@ var _ = Describe("Wal-restore in parallel", Label(tests.LabelBackupRestore), fun
 		// 		exit code 0, #4 is in the output location, #5 is in the spool directory.
 		// 		The flag is set because #6 file not present.
 		By("invoking the wal-restore command requesting #4 wal", func() {
-			_, _, err := env.ExecCommandInInstancePod(namespace, standby, nil,
+			_, _, err := env.ExecCommandInInstancePod(
+				testUtils.PodLocator{
+					Namespace: namespace,
+					PodName:   standby,
+				}, nil,
 				"/controller/manager", "wal-restore", walFile4, PgWalPath+"/"+walFile4)
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(func() bool { return testUtils.TestFileExist(namespace, standby, PgWalPath, walFile4) }).
@@ -267,7 +288,11 @@ var _ = Describe("Wal-restore in parallel", Label(tests.LabelBackupRestore), fun
 		// Expected outcome:
 		//		exit code 0, #5 is in the output location, no files in the spool directory. The flag is still present.
 		By("invoking the wal-restore command requesting #5 wal", func() {
-			_, _, err := env.ExecCommandInInstancePod(namespace, standby, nil,
+			_, _, err := env.ExecCommandInInstancePod(
+				testUtils.PodLocator{
+					Namespace: namespace,
+					PodName:   standby,
+				}, nil,
 				"/controller/manager", "wal-restore", walFile5, PgWalPath+"/"+walFile5)
 			Expect(err).ToNot(HaveOccurred(), "exit code should be 0")
 			Eventually(func() bool { return testUtils.TestFileExist(namespace, standby, PgWalPath, walFile5) }).
@@ -288,7 +313,11 @@ var _ = Describe("Wal-restore in parallel", Label(tests.LabelBackupRestore), fun
 		// Expected outcome:
 		//		exit code 1, output location untouched, no files in the spool directory. The flag is unset.
 		By("invoking the wal-restore command requesting #6 wal", func() {
-			_, _, err := env.ExecCommandInInstancePod(namespace, standby, nil,
+			_, _, err := env.ExecCommandInInstancePod(
+				testUtils.PodLocator{
+					Namespace: namespace,
+					PodName:   standby,
+				}, nil,
 				"/controller/manager", "wal-restore", walFile6, PgWalPath+"/"+walFile6)
 			Expect(err).To(HaveOccurred(),
 				"exit code should 1 since #6 wal is not in the output location or spool directory and flag is set")
@@ -307,7 +336,11 @@ var _ = Describe("Wal-restore in parallel", Label(tests.LabelBackupRestore), fun
 		//		exit code 0, #6 is in the output location, no files in the spool directory.
 		//		The flag is present again because #7 and #8 are unavailable.
 		By("invoking the wal-restore command requesting #6 wal again", func() {
-			_, _, err := env.ExecCommandInInstancePod(namespace, standby, nil,
+			_, _, err := env.ExecCommandInInstancePod(
+				testUtils.PodLocator{
+					Namespace: namespace,
+					PodName:   standby,
+				}, nil,
 				"/controller/manager", "wal-restore", walFile6, PgWalPath+"/"+walFile6)
 			Expect(err).ToNot(HaveOccurred(), "exit code should be 0")
 			Eventually(func() bool { return testUtils.TestFileExist(namespace, standby, PgWalPath, walFile6) }).

--- a/tests/e2e/wal_restore_parallel_test.go
+++ b/tests/e2e/wal_restore_parallel_test.go
@@ -164,11 +164,7 @@ var _ = Describe("Wal-restore in parallel", Label(tests.LabelBackupRestore), fun
 		By("asserting the spool directory is empty on the standby", func() {
 			if !testUtils.TestDirectoryEmpty(namespace, standby, SpoolDirectory) {
 				purgeSpoolDirectoryCmd := "rm " + SpoolDirectory + "/*"
-				_, _, err := testUtils.Run(fmt.Sprintf(
-					"kubectl exec -n %v %v -- %v",
-					namespace,
-					standby,
-					purgeSpoolDirectoryCmd))
+				_, _, err := env.ExecCommandInPod(namespace, standby, nil, purgeSpoolDirectoryCmd)
 				Expect(err).ShouldNot(HaveOccurred())
 			}
 		})
@@ -178,11 +174,8 @@ var _ = Describe("Wal-restore in parallel", Label(tests.LabelBackupRestore), fun
 		// 		exit code 0, #1 is in the output location, #2 and #3 are in the spool directory.
 		// 		The flag is unset.
 		By("invoking the wal-restore command requesting #1 wal", func() {
-			_, _, err := testUtils.Run(fmt.Sprintf(
-				"kubectl exec -n %v %v -- %v",
-				namespace,
-				standby,
-				walRestoreCommand+" "+walFile1+" "+PgWalPath+"/"+walFile1))
+			_, _, err := env.ExecCommandInPod(namespace, standby, nil,
+				walRestoreCommand+" "+walFile1+" "+PgWalPath+"/"+walFile1)
 			Expect(err).ToNot(HaveOccurred(), "exit code should be 0")
 			Eventually(func() bool { return testUtils.TestFileExist(namespace, standby, PgWalPath, walFile1) }).
 				WithTimeout(RetryTimeout).
@@ -207,11 +200,8 @@ var _ = Describe("Wal-restore in parallel", Label(tests.LabelBackupRestore), fun
 		// 		exit code 0, #2 is in the output location, #3 is in the spool directory.
 		// 		The flag is unset.
 		By("invoking the wal-restore command requesting #2 wal", func() {
-			_, _, err := testUtils.Run(fmt.Sprintf(
-				"kubectl exec -n %v %v -- %v",
-				namespace,
-				standby,
-				walRestoreCommand+" "+walFile2+" "+PgWalPath+"/"+walFile2))
+			_, _, err := env.ExecCommandInPod(namespace, standby, nil,
+				walRestoreCommand+" "+walFile2+" "+PgWalPath+"/"+walFile2)
 			Expect(err).ToNot(HaveOccurred(), "exit code should be 0")
 			Eventually(func() bool { return testUtils.TestFileExist(namespace, standby, PgWalPath, walFile2) }).
 				WithTimeout(RetryTimeout).
@@ -232,11 +222,8 @@ var _ = Describe("Wal-restore in parallel", Label(tests.LabelBackupRestore), fun
 		// 		exit code 0, #3 is in the output location, spool directory is empty.
 		// 		The flag is unset.
 		By("invoking the wal-restore command requesting #3 wal", func() {
-			_, _, err := testUtils.Run(fmt.Sprintf(
-				"kubectl exec -n %v %v -- %v",
-				namespace,
-				standby,
-				walRestoreCommand+" "+walFile3+" "+PgWalPath+"/"+walFile3))
+			_, _, err := env.ExecCommandInPod(namespace, standby, nil,
+				walRestoreCommand+" "+walFile3+" "+PgWalPath+"/"+walFile3)
 			Expect(err).ToNot(HaveOccurred(), "exit code should be 0")
 			Eventually(func() bool { return testUtils.TestFileExist(namespace, standby, PgWalPath, walFile3) }).
 				WithTimeout(RetryTimeout).
@@ -253,11 +240,8 @@ var _ = Describe("Wal-restore in parallel", Label(tests.LabelBackupRestore), fun
 		// 		exit code 0, #4 is in the output location, #5 is in the spool directory.
 		// 		The flag is set because #6 file not present.
 		By("invoking the wal-restore command requesting #4 wal", func() {
-			_, _, err := testUtils.Run(fmt.Sprintf(
-				"kubectl exec -n %v %v -- %v",
-				namespace,
-				standby,
-				walRestoreCommand+" "+walFile4+" "+PgWalPath+"/"+walFile4))
+			_, _, err := env.ExecCommandInPod(namespace, standby, nil,
+				walRestoreCommand+" "+walFile4+" "+PgWalPath+"/"+walFile4)
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(func() bool { return testUtils.TestFileExist(namespace, standby, PgWalPath, walFile4) }).
 				WithTimeout(RetryTimeout).
@@ -284,11 +268,8 @@ var _ = Describe("Wal-restore in parallel", Label(tests.LabelBackupRestore), fun
 		// Expected outcome:
 		//		exit code 0, #5 is in the output location, no files in the spool directory. The flag is still present.
 		By("invoking the wal-restore command requesting #5 wal", func() {
-			_, _, err := testUtils.Run(fmt.Sprintf(
-				"kubectl exec -n %v %v -- %v",
-				namespace,
-				standby,
-				walRestoreCommand+" "+walFile5+" "+PgWalPath+"/"+walFile5))
+			_, _, err := env.ExecCommandInPod(namespace, standby, nil,
+				walRestoreCommand+" "+walFile5+" "+PgWalPath+"/"+walFile5)
 			Expect(err).ToNot(HaveOccurred(), "exit code should be 0")
 			Eventually(func() bool { return testUtils.TestFileExist(namespace, standby, PgWalPath, walFile5) }).
 				WithTimeout(RetryTimeout).
@@ -308,11 +289,8 @@ var _ = Describe("Wal-restore in parallel", Label(tests.LabelBackupRestore), fun
 		// Expected outcome:
 		//		exit code 1, output location untouched, no files in the spool directory. The flag is unset.
 		By("invoking the wal-restore command requesting #6 wal", func() {
-			_, _, err := testUtils.RunUnchecked(fmt.Sprintf(
-				"kubectl exec -n %v %v -- %v",
-				namespace,
-				standby,
-				walRestoreCommand+" "+walFile6+" "+PgWalPath+"/"+walFile6))
+			_, _, err := env.ExecCommandInPod(namespace, standby, nil,
+				walRestoreCommand+" "+walFile6+" "+PgWalPath+"/"+walFile6)
 			Expect(err).To(HaveOccurred(),
 				"exit code should 1 since #6 wal is not in the output location or spool directory and flag is set")
 			Eventually(func() bool { return testUtils.TestFileExist(namespace, standby, PgWalPath, walFile6) }).
@@ -330,11 +308,8 @@ var _ = Describe("Wal-restore in parallel", Label(tests.LabelBackupRestore), fun
 		//		exit code 0, #6 is in the output location, no files in the spool directory.
 		//		The flag is present again because #7 and #8 are unavailable.
 		By("invoking the wal-restore command requesting #6 wal again", func() {
-			_, _, err := testUtils.Run(fmt.Sprintf(
-				"kubectl exec -n %v %v -- %v",
-				namespace,
-				standby,
-				walRestoreCommand+" "+walFile6+" "+PgWalPath+"/"+walFile6))
+			_, _, err := env.ExecCommandInPod(namespace, standby, nil,
+				walRestoreCommand+" "+walFile6+" "+PgWalPath+"/"+walFile6)
 			Expect(err).ToNot(HaveOccurred(), "exit code should be 0")
 			Eventually(func() bool { return testUtils.TestFileExist(namespace, standby, PgWalPath, walFile6) }).
 				WithTimeout(RetryTimeout).

--- a/tests/utils/backup.go
+++ b/tests/utils/backup.go
@@ -65,9 +65,11 @@ func ExecuteBackup(
 		return backupStatus.BeginLSN, err
 	}, timeoutSeconds).ShouldNot(BeEmpty())
 
-	cluster := apiv1.Cluster{}
+	var cluster *apiv1.Cluster
 	Eventually(func() error {
-		return env.Client.Get(env.Ctx, types.NamespacedName{Name: backup.Spec.Cluster.Name, Namespace: namespace}, &cluster)
+		var err error
+		cluster, err = env.GetCluster(namespace, backup.Spec.Cluster.Name)
+		return err
 	}, timeoutSeconds).ShouldNot(HaveOccurred())
 
 	backupStatus := backup.GetStatus()

--- a/tests/utils/cluster.go
+++ b/tests/utils/cluster.go
@@ -331,12 +331,7 @@ func (env TestingEnvironment) ScaleClusterSize(namespace, clusterName string, ne
 
 // PrintClusterResources prints a summary of the cluster pods, jobs, pvcs etc.
 func PrintClusterResources(namespace, clusterName string, env *TestingEnvironment) string {
-	namespacedName := types.NamespacedName{
-		Namespace: namespace,
-		Name:      clusterName,
-	}
-	cluster := &apiv1.Cluster{}
-	err := GetObject(env, namespacedName, cluster)
+	cluster, err := env.GetCluster(namespace, clusterName)
 	if err != nil {
 		return fmt.Sprintf("Error while Getting Object %v", err)
 	}

--- a/tests/utils/pod.go
+++ b/tests/utils/pod.go
@@ -153,10 +153,17 @@ func (env TestingEnvironment) GetPod(namespace, podName string) (*corev1.Pod, er
 	return nil, wrapErr(errors.New("pod not found"))
 }
 
-// ExecCommandInInstancePod executes commands in a given instance pod, in the
+// ContainerLocator contains the necessary data to find a container on a pod
+type ContainerLocator struct {
+	Namespace string
+	PodName   string
+	Container string
+}
+
+// ExecCommandInContainer executes commands in a given instance pod, in the
 // postgres container
-func (env TestingEnvironment) ExecCommandInInstancePod(
-	namespace, podName string,
+func (env TestingEnvironment) ExecCommandInContainer(
+	namespace, podName, container string,
 	timeout *time.Duration,
 	command ...string,
 ) (string, string, error) {
@@ -167,8 +174,27 @@ func (env TestingEnvironment) ExecCommandInInstancePod(
 	if err != nil {
 		return "", "", wrapErr(err)
 	}
-	return env.ExecCommand(env.Ctx, *pod, specs.PostgresContainerName, timeout, command...)
+	return env.ExecCommand(env.Ctx, *pod, container, timeout, command...)
 }
+
+// PodLocator contains the necessary data to find a pod
+type PodLocator struct {
+	Namespace string
+	PodName   string
+}
+
+// ExecCommandInInstancePod executes commands in a given instance pod, in the
+// postgres container
+func (env TestingEnvironment) ExecCommandInInstancePod(
+	namespace, podName string,
+	timeout *time.Duration,
+	command ...string,
+) (string, string, error) {
+	return env.ExecCommandInContainer(namespace, podName, specs.PostgresContainerName, timeout, command...)
+}
+
+// DatabaseName is a special type for the database argument in an Exec call
+type DatabaseName string
 
 // ExecQueryInInstancePod executes a query in an instance pod, by connecting to the pod
 // and the postgres container, and using a local connection with the postgres user

--- a/tests/utils/pod.go
+++ b/tests/utils/pod.go
@@ -136,7 +136,7 @@ func (env TestingEnvironment) GetPodList(namespace string) (*corev1.PodList, err
 	return podList, err
 }
 
-// GetPod gets a pod
+// GetPod gets a pod by namespace and name
 func (env TestingEnvironment) GetPod(namespace, podName string) (*corev1.Pod, error) {
 	wrapErr := func(err error) error {
 		return fmt.Errorf("while getting pod '%s/%s': %w", namespace, podName, err)
@@ -153,8 +153,9 @@ func (env TestingEnvironment) GetPod(namespace, podName string) (*corev1.Pod, er
 	return nil, wrapErr(errors.New("pod not found"))
 }
 
-// ExecCommandInPod executes commands in a given pod
-func (env TestingEnvironment) ExecCommandInPod(
+// ExecCommandInInstancePod executes commands in a given instance pod, in the
+// postgres container
+func (env TestingEnvironment) ExecCommandInInstancePod(
 	namespace, podName string,
 	timeout *time.Duration,
 	command ...string,
@@ -169,13 +170,14 @@ func (env TestingEnvironment) ExecCommandInPod(
 	return env.ExecCommand(env.Ctx, *pod, specs.PostgresContainerName, timeout, command...)
 }
 
-// ExecSQLInPod matt damon
-func (env TestingEnvironment) ExecSQLInPod(
+// ExecQueryInInstancePod executes a query in an instance pod, by connecting to the pod
+// and the postgres container, and using a local connection with the postgres user
+func (env TestingEnvironment) ExecQueryInInstancePod(
 	namespace, podName string,
 	dbname string,
 	query string,
 ) (string, string, error) {
 	timeout := time.Second * 10
-	return env.ExecCommandInPod(namespace, podName,
+	return env.ExecCommandInInstancePod(namespace, podName,
 		&timeout, "psql", "-U", "postgres", dbname, "-tAc", query)
 }

--- a/tests/utils/storage.go
+++ b/tests/utils/storage.go
@@ -19,10 +19,7 @@ package utils
 import (
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 )
 
 // GetStorageAllowExpansion returns the boolean value of the 'AllowVolumeExpansion' value of the storage class
@@ -34,12 +31,7 @@ func GetStorageAllowExpansion(defaultStorageClass string, env *TestingEnvironmen
 
 // IsWalStorageEnabled returns true if 'WalStorage' is being used
 func IsWalStorageEnabled(namespace, clusterName string, env *TestingEnvironment) (bool, error) {
-	namespacedName := types.NamespacedName{
-		Namespace: namespace,
-		Name:      clusterName,
-	}
-	cluster := &apiv1.Cluster{}
-	err := env.Client.Get(env.Ctx, namespacedName, cluster)
+	cluster, err := env.GetCluster(namespace, clusterName)
 	if cluster.Spec.WalStorage == nil {
 		return false, err
 	}


### PR DESCRIPTION
Reuses the `GetCluster` function, introduces new functions to
centralize execution of commands on instance pods, and of
queries via local connection within the DB container