### PR TITLE
doc: fix some_query syntax

### DIFF
--- a/docs/src/monitoring.md
+++ b/docs/src/monitoring.md
@@ -408,7 +408,7 @@ in the returned labels, for example using the `current_database()` function
 as in the following example:
 
 ```yaml
-some_query:
+some_query: |
   query: |
     SELECT
      current_database() as datname,
@@ -440,7 +440,7 @@ runs on the `template1` database (otherwise not returned by the
 aforementioned query):
 
 ```yaml
-some_query:
+some_query: |
   query: |
     SELECT
      current_database() as datname,


### PR DESCRIPTION
@mnencia

this it the PR following the [Slack Thread](https://app.slack.com/client/T03BCEDRZL1/C03D68KGG65/thread/C03D68KGG65-1684924144.695639)  
so that the "some_query" query can be copy/pasted into the example-monitoring configMap

br
Daniel