### PR TITLE
chore: detect PodSpec drift in pod rollout, and clarify rollout code

### DIFF
--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -725,7 +725,7 @@ func (r *ClusterReconciler) handleRollingUpdate(
 
 	// If we need to roll out a restart of any instance, this is the right moment
 	// Do I have to roll out a new image?
-	done, err := r.rolloutDueToCondition(ctx, cluster, &instancesStatus, IsPodNeedingRollout)
+	done, err := r.rolloutDueToCondition(ctx, cluster, &instancesStatus)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -725,7 +725,7 @@ func (r *ClusterReconciler) handleRollingUpdate(
 
 	// If we need to roll out a restart of any instance, this is the right moment
 	// Do I have to roll out a new image?
-	done, err := r.rolloutDueToCondition(ctx, cluster, &instancesStatus)
+	done, err := r.rolloutRequiredInstances(ctx, cluster, &instancesStatus)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -724,7 +724,6 @@ func (r *ClusterReconciler) handleRollingUpdate(
 	contextLogger := log.FromContext(ctx)
 
 	// If we need to roll out a restart of any instance, this is the right moment
-	// Do I have to roll out a new image?
 	done, err := r.rolloutRequiredInstances(ctx, cluster, &instancesStatus)
 	if err != nil {
 		return ctrl.Result{}, err

--- a/controllers/cluster_upgrade.go
+++ b/controllers/cluster_upgrade.go
@@ -377,21 +377,20 @@ func checkPodImageIsOutdated(
 	}
 
 	if pgCurrentImageName != targetImageName {
+		canUpgradeImage, err := postgres.CanUpgrade(pgCurrentImageName, targetImageName)
+		if err != nil {
+			return Rollout{}, err
+		}
+
+		if !canUpgradeImage {
+			return Rollout{}, nil
+		}
 		// We need to apply a different PostgreSQL version
 		return Rollout{
 			Required: true,
 			Reason: fmt.Sprintf("the instance is using an old image: %s -> %s",
 				pgCurrentImageName, targetImageName),
 		}, nil
-	}
-
-	canUpgradeImage, err := postgres.CanUpgrade(pgCurrentImageName, targetImageName)
-	if err != nil {
-		return Rollout{}, err
-	}
-
-	if !canUpgradeImage {
-		return Rollout{}, nil
 	}
 
 	return Rollout{}, nil

--- a/controllers/cluster_upgrade.go
+++ b/controllers/cluster_upgrade.go
@@ -42,7 +42,7 @@ import (
 
 type rolloutReason = string
 
-func (r *ClusterReconciler) rolloutDueToCondition(
+func (r *ClusterReconciler) rolloutRequiredInstances(
 	ctx context.Context,
 	cluster *apiv1.Cluster,
 	podList *postgres.PostgresqlStatusList,

--- a/controllers/cluster_upgrade.go
+++ b/controllers/cluster_upgrade.go
@@ -274,6 +274,7 @@ func isPodNeedingRollout(
 	if hasStoredPodSpec {
 		return rollout{}
 	}
+	// These checks are subsumed by the PodSpec checker
 	checkers = map[string]rolloutChecker{
 		"pod environment is outdated": checkPodEnvironmentIsOutdated,
 		"pod scheduler is outdated":   checkSchedulerIsOutdated,
@@ -546,13 +547,13 @@ func checkPodSpecIsOutdated(
 	status postgres.PostgresqlStatus,
 	cluster *apiv1.Cluster,
 ) (rollout, error) {
-	res, ok := status.Pod.ObjectMeta.Annotations[utils.PodSpecAnnotationName]
+	podSpecAnnotation, ok := status.Pod.ObjectMeta.Annotations[utils.PodSpecAnnotationName]
 	if !ok {
 		return rollout{}, nil
 	}
 
 	var storedPodSpec corev1.PodSpec
-	err := (&storedPodSpec).Unmarshal([]byte(res))
+	err := (&storedPodSpec).Unmarshal([]byte(podSpecAnnotation))
 	if err != nil {
 		return rollout{}, fmt.Errorf("while unmarshaling the pod resources annotation: %w", err)
 	}

--- a/controllers/cluster_upgrade.go
+++ b/controllers/cluster_upgrade.go
@@ -365,6 +365,18 @@ func checkProjectedVolumeIsOutdated(
 	}, nil
 }
 
+func getProjectedVolumeConfigurationFromPod(pod corev1.Pod) *corev1.ProjectedVolumeSource {
+	for _, volume := range pod.Spec.Volumes {
+		if volume.Name != "projected" {
+			continue
+		}
+
+		return volume.Projected
+	}
+
+	return nil
+}
+
 func checkPodImageIsOutdated(
 	status postgres.PostgresqlStatus,
 	cluster *apiv1.Cluster,
@@ -528,18 +540,6 @@ func checkResourcesAreOutdated(
 	}
 
 	return Rollout{}, nil
-}
-
-func getProjectedVolumeConfigurationFromPod(pod corev1.Pod) *corev1.ProjectedVolumeSource {
-	for _, volume := range pod.Spec.Volumes {
-		if volume.Name != "projected" {
-			continue
-		}
-
-		return volume.Projected
-	}
-
-	return nil
 }
 
 // upgradePod deletes a Pod to let the operator recreate it using an

--- a/controllers/cluster_upgrade.go
+++ b/controllers/cluster_upgrade.go
@@ -245,15 +245,15 @@ func isPodNeedingRollout(
 	}
 
 	checkers := map[string]rolloutChecker{
-		"missing executable hash":              checkHasExecutableHash,
-		"has PVC requiring resizing":           checkHasResizingPVC,
-		"projected volume is outdated":         checkProjectedVolumeIsOutdated,
-		"resources are outdated":               checkResourcesAreOutdated,
+		"instance is missing executable hash":  checkHasExecutableHash,
+		"pod has PVC requiring resizing":       checkHasResizingPVC,
+		"pod projected volume is outdated":     checkProjectedVolumeIsOutdated,
+		"pod resources are outdated":           checkResourcesAreOutdated,
 		"pod image is outdated":                checkPodImageIsOutdated,
 		"pod init container is outdated":       checkPodInitContainerIsOutdated,
-		"has missing PVCs":                     checkHasMissingPVCs,
+		"pod has missing PVCs":                 checkHasMissingPVCs,
 		"pod environment is outdated":          checkPodEnvironmentIsOutdated,
-		"scheduler is outdated":                checkSchedulerIsOutdated,
+		"pod scheduler is outdated":            checkSchedulerIsOutdated,
 		"cluster has newer restart annotation": checkClusterHasNewerRestartAnnotation,
 		"pod needs updated topology":           checkPodNeedsUpdatedTopology,
 	}

--- a/controllers/cluster_upgrade.go
+++ b/controllers/cluster_upgrade.go
@@ -249,13 +249,13 @@ func IsPodNeedingRollout(
 	checkers := []rolloutChecker{
 		checkHasExecutableHash,
 		checkHasResizingPVC,
-		checkProjectedVolumeNeedsUpdate,
-		checkPodImageNeedsUpdate,
-		checkPodInitContainerNeedsUpdate,
+		checkProjectedVolumeIsOutdated,
+		checkPodImageIsOutdated,
+		checkPodInitContainerIsOutdated,
 		checkHasMissingPVCs,
 		checkPodEnvironmentIsOutdated,
 		checkSchedulerIsOutdated,
-		checkPostgresCotainerConfigOutdated,
+		checkPostgresContainerIsOutdated,
 		checkClusterHasNewerRestartAnnotation,
 	}
 	for _, check := range checkers {
@@ -294,7 +294,7 @@ func checkHasResizingPVC(
 	return Rollout{}
 }
 
-func checkProjectedVolumeNeedsUpdate(
+func checkProjectedVolumeIsOutdated(
 	status postgres.PostgresqlStatus,
 	cluster *apiv1.Cluster,
 ) Rollout {
@@ -305,7 +305,7 @@ func checkProjectedVolumeNeedsUpdate(
 	return Rollout{}
 }
 
-func checkPodImageNeedsUpdate(
+func checkPodImageIsOutdated(
 	status postgres.PostgresqlStatus,
 	cluster *apiv1.Cluster,
 ) Rollout {
@@ -324,7 +324,7 @@ func checkPodImageNeedsUpdate(
 	return Rollout{}
 }
 
-func checkPodInitContainerNeedsUpdate(
+func checkPodInitContainerIsOutdated(
 	status postgres.PostgresqlStatus,
 	_ *apiv1.Cluster,
 ) Rollout {
@@ -377,7 +377,7 @@ func checkSchedulerIsOutdated(
 	return Rollout{}
 }
 
-func checkPostgresCotainerConfigOutdated(
+func checkPostgresContainerIsOutdated(
 	status postgres.PostgresqlStatus,
 	cluster *apiv1.Cluster,
 ) Rollout {

--- a/controllers/cluster_upgrade.go
+++ b/controllers/cluster_upgrade.go
@@ -558,7 +558,7 @@ func checkPodSpecIsOutdated(
 	}
 	envConfig := specs.CreatePodEnvConfig(*cluster, status.Pod.Name)
 	gracePeriod := int64(cluster.GetMaxStopDelay())
-	currentPodSpec := specs.CreateClusterSpec(status.Pod.Name, *cluster, envConfig, gracePeriod)
+	currentPodSpec := specs.CreateClusterPodSpec(status.Pod.Name, *cluster, envConfig, gracePeriod)
 
 	if currentPodSpec.SchedulerName != storedPodSpec.SchedulerName {
 		return rollout{

--- a/controllers/cluster_upgrade_test.go
+++ b/controllers/cluster_upgrade_test.go
@@ -63,6 +63,19 @@ var _ = Describe("Pod upgrade", Ordered, func() {
 		Expect(rollout.Reason).To(BeEquivalentTo("the instance is using an old image: postgres:13.10 -> postgres:13.11"))
 	})
 
+	It("does not ask for rollout when update is to a different major release", func(ctx SpecContext) {
+		pod := specs.PodWithExistingStorage(cluster, 1)
+		pod.Spec.Containers[0].Image = "postgres:12.15"
+		status := postgres.PostgresqlStatus{
+			Pod:            *pod,
+			IsPodReady:     true,
+			ExecutableHash: "test_hash",
+		}
+		rollout := IsPodNeedingRollout(ctx, status, &cluster)
+		Expect(rollout.Required).To(BeFalse())
+		Expect(rollout.Reason).To(BeEmpty())
+	})
+
 	It("requires rollout when a restart annotation has been added to the cluster", func(ctx SpecContext) {
 		pod := specs.PodWithExistingStorage(cluster, 1)
 		clusterRestart := cluster

--- a/controllers/cluster_upgrade_test.go
+++ b/controllers/cluster_upgrade_test.go
@@ -131,7 +131,7 @@ var _ = Describe("Pod upgrade", Ordered, func() {
 		}
 		rollout := isPodNeedingRollout(ctx, status, &cluster)
 		Expect(rollout.required).To(BeTrue())
-		Expect(rollout.reason).To(Equal("missing executable hash"))
+		Expect(rollout.reason).To(Equal("instance is missing executable hash"))
 		Expect(rollout.canBeInPlace).To(BeFalse())
 	})
 

--- a/controllers/cluster_upgrade_test.go
+++ b/controllers/cluster_upgrade_test.go
@@ -32,6 +32,9 @@ import (
 
 var _ = Describe("Pod upgrade", Ordered, func() {
 	cluster := apiv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test",
+		},
 		Spec: apiv1.ClusterSpec{
 			ImageName: "postgres:13.11",
 		},
@@ -120,7 +123,7 @@ var _ = Describe("Pod upgrade", Ordered, func() {
 		}
 		rollout = isPodNeedingRollout(ctx, status, &cluster)
 		Expect(rollout.required).To(BeTrue())
-		Expect(rollout.reason).To(Equal("configuration needs a restart to apply some configuration changes"))
+		Expect(rollout.reason).To(Equal("Postgres needs a restart to apply some configuration changes"))
 	})
 
 	It("requires pod rollout if executable does not have a hash", func(ctx SpecContext) {
@@ -132,7 +135,7 @@ var _ = Describe("Pod upgrade", Ordered, func() {
 		}
 		rollout := isPodNeedingRollout(ctx, status, &cluster)
 		Expect(rollout.required).To(BeTrue())
-		Expect(rollout.reason).To(Equal("instance is missing executable hash"))
+		Expect(rollout.reason).To(Equal("pod 'test-1' is not reporting the executable hash"))
 		Expect(rollout.canBeInPlace).To(BeFalse())
 	})
 
@@ -155,7 +158,7 @@ var _ = Describe("Pod upgrade", Ordered, func() {
 		}
 		rollout = isPodNeedingRollout(ctx, status, &cluster)
 		Expect(rollout.required).To(BeTrue())
-		Expect(rollout.reason).To(BeEquivalentTo("configuration needs a restart to apply some configuration changes"))
+		Expect(rollout.reason).To(BeEquivalentTo("Postgres needs a restart to apply some configuration changes"))
 		Expect(rollout.canBeInPlace).To(BeTrue())
 	})
 

--- a/pkg/specs/pods.go
+++ b/pkg/specs/pods.go
@@ -325,27 +325,12 @@ func CreatePodSecurityContext(seccompProfile *corev1.SeccompProfile, user, group
 	}
 }
 
-// ComputeInstaceHash creates a hash over the fields that will
-func ComputeInstaceHash(cluster apiv1.Cluster) (string, error) {
-	var instanceView struct {
-		targetImageName string
-		schedulerName   string
-		resources       corev1.ResourceRequirements
-	}
-	instanceView.targetImageName = cluster.GetImageName()
-	instanceView.schedulerName = cluster.Spec.SchedulerName
-	instanceView.resources = cluster.Spec.Resources
-
-	return hash.ComputeHash(instanceView)
-}
-
 // PodWithExistingStorage create a new instance with an existing storage
 func PodWithExistingStorage(cluster apiv1.Cluster, nodeSerial int) *corev1.Pod {
 	podName := GetInstanceName(cluster.Name, nodeSerial)
 	gracePeriod := int64(cluster.GetMaxStopDelay())
 
 	envConfig := CreatePodEnvConfig(cluster, podName)
-	instanceHash, _ := ComputeInstaceHash(cluster)
 
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -356,9 +341,8 @@ func PodWithExistingStorage(cluster apiv1.Cluster, nodeSerial int) *corev1.Pod {
 				utils.PodRoleLabelName:      string(utils.PodRoleInstance),
 			},
 			Annotations: map[string]string{
-				ClusterSerialAnnotationName:        strconv.Itoa(nodeSerial),
-				utils.PodEnvHashAnnotationName:     envConfig.Hash,
-				utils.PodContentHashAnnotationName: instanceHash,
+				ClusterSerialAnnotationName:    strconv.Itoa(nodeSerial),
+				utils.PodEnvHashAnnotationName: envConfig.Hash,
 			},
 			Name:      podName,
 			Namespace: cluster.Namespace,

--- a/pkg/specs/pods.go
+++ b/pkg/specs/pods.go
@@ -148,7 +148,12 @@ func CreatePodEnvConfig(cluster apiv1.Cluster, podName string) EnvConfig {
 }
 
 // CreateClusterPodSpec computes the PodSpec corresponding to a cluster
-func CreateClusterPodSpec(podName string, cluster apiv1.Cluster, envConfig EnvConfig, gracePeriod int64) corev1.PodSpec {
+func CreateClusterPodSpec(
+	podName string,
+	cluster apiv1.Cluster,
+	envConfig EnvConfig,
+	gracePeriod int64,
+) corev1.PodSpec {
 	return corev1.PodSpec{
 		Hostname: podName,
 		InitContainers: []corev1.Container{

--- a/pkg/specs/pods.go
+++ b/pkg/specs/pods.go
@@ -147,7 +147,8 @@ func CreatePodEnvConfig(cluster apiv1.Cluster, podName string) EnvConfig {
 	return config
 }
 
-func CreateClusterSpec(podName string, cluster apiv1.Cluster, envConfig EnvConfig, gracePeriod int64) corev1.PodSpec {
+// CreateClusterPodSpec computes the PodSpec corresponding to a cluster
+func CreateClusterPodSpec(podName string, cluster apiv1.Cluster, envConfig EnvConfig, gracePeriod int64) corev1.PodSpec {
 	return corev1.PodSpec{
 		Hostname: podName,
 		InitContainers: []corev1.Container{
@@ -354,7 +355,7 @@ func PodWithExistingStorage(cluster apiv1.Cluster, nodeSerial int) *corev1.Pod {
 
 	envConfig := CreatePodEnvConfig(cluster, podName)
 
-	podSpec := CreateClusterSpec(podName, cluster, envConfig, gracePeriod)
+	podSpec := CreateClusterPodSpec(podName, cluster, envConfig, gracePeriod)
 
 	podSpecMarshaled, err := podSpec.Marshal()
 	if err != nil {

--- a/pkg/specs/pods.go
+++ b/pkg/specs/pods.go
@@ -332,6 +332,10 @@ func PodWithExistingStorage(cluster apiv1.Cluster, nodeSerial int) *corev1.Pod {
 
 	envConfig := CreatePodEnvConfig(cluster, podName)
 
+	resources, err := cluster.Spec.Resources.Marshal()
+	if err != nil {
+		resources = []byte{}
+	}
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
@@ -341,8 +345,9 @@ func PodWithExistingStorage(cluster apiv1.Cluster, nodeSerial int) *corev1.Pod {
 				utils.PodRoleLabelName:      string(utils.PodRoleInstance),
 			},
 			Annotations: map[string]string{
-				ClusterSerialAnnotationName:    strconv.Itoa(nodeSerial),
-				utils.PodEnvHashAnnotationName: envConfig.Hash,
+				ClusterSerialAnnotationName:      strconv.Itoa(nodeSerial),
+				utils.PodEnvHashAnnotationName:   envConfig.Hash,
+				utils.PodResourcesAnnotationName: string(resources),
 			},
 			Name:      podName,
 			Namespace: cluster.Namespace,

--- a/pkg/utils/labels_annotations.go
+++ b/pkg/utils/labels_annotations.go
@@ -75,6 +75,10 @@ const (
 	// PodEnvHashAnnotationName is the name of the annotation containing the podEnvHash value
 	PodEnvHashAnnotationName = "cnpg.io/podEnvHash"
 
+	// PodResourcesAnnotationName is the name of the annotation with the cluster resources used
+	// when creating a Pod
+	PodResourcesAnnotationName = "cnpg.io/podResources"
+
 	// PodContentHashAnnotationName is the name of the annotation containing the podContentHash value
 	PodContentHashAnnotationName = "cnpg.io/podContentHash"
 

--- a/pkg/utils/labels_annotations.go
+++ b/pkg/utils/labels_annotations.go
@@ -73,11 +73,12 @@ const (
 	HibernatePgControlDataAnnotationName = "cnpg.io/hibernatePgControlData"
 
 	// PodEnvHashAnnotationName is the name of the annotation containing the podEnvHash value
+	// Deprecated: the PodSpec annotation covers the environment drift. This annotation is
+	// kept for backward compatibility
 	PodEnvHashAnnotationName = "cnpg.io/podEnvHash"
 
-	// PodResourcesAnnotationName is the name of the annotation with the cluster resources used
-	// when creating a Pod
-	PodResourcesAnnotationName = "cnpg.io/podResources"
+	// PodSpecAnnotationName is the name of the annotation with the PodSpec derived from the cluster
+	PodSpecAnnotationName = "cnpg.io/originalPodSpec"
 
 	// skipEmptyWalArchiveCheck turns off the checks that ensure that the WAL archive is empty before writing data
 	skipEmptyWalArchiveCheck = "cnpg.io/skipEmptyWalArchiveCheck"

--- a/pkg/utils/labels_annotations.go
+++ b/pkg/utils/labels_annotations.go
@@ -79,9 +79,6 @@ const (
 	// when creating a Pod
 	PodResourcesAnnotationName = "cnpg.io/podResources"
 
-	// PodContentHashAnnotationName is the name of the annotation containing the podContentHash value
-	PodContentHashAnnotationName = "cnpg.io/podContentHash"
-
 	// skipEmptyWalArchiveCheck turns off the checks that ensure that the WAL archive is empty before writing data
 	skipEmptyWalArchiveCheck = "cnpg.io/skipEmptyWalArchiveCheck"
 )

--- a/pkg/utils/labels_annotations.go
+++ b/pkg/utils/labels_annotations.go
@@ -75,6 +75,9 @@ const (
 	// PodEnvHashAnnotationName is the name of the annotation containing the podEnvHash value
 	PodEnvHashAnnotationName = "cnpg.io/podEnvHash"
 
+	// PodContentHashAnnotationName is the name of the annotation containing the podContentHash value
+	PodContentHashAnnotationName = "cnpg.io/podContentHash"
+
 	// skipEmptyWalArchiveCheck turns off the checks that ensure that the WAL archive is empty before writing data
 	skipEmptyWalArchiveCheck = "cnpg.io/skipEmptyWalArchiveCheck"
 )

--- a/pkg/utils/labels_annotations.go
+++ b/pkg/utils/labels_annotations.go
@@ -78,7 +78,7 @@ const (
 	PodEnvHashAnnotationName = "cnpg.io/podEnvHash"
 
 	// PodSpecAnnotationName is the name of the annotation with the PodSpec derived from the cluster
-	PodSpecAnnotationName = "cnpg.io/originalPodSpec"
+	PodSpecAnnotationName = "cnpg.io/podSpec"
 
 	// skipEmptyWalArchiveCheck turns off the checks that ensure that the WAL archive is empty before writing data
 	skipEmptyWalArchiveCheck = "cnpg.io/skipEmptyWalArchiveCheck"

--- a/pkg/utils/operations.go
+++ b/pkg/utils/operations.go
@@ -16,10 +16,6 @@ limitations under the License.
 
 package utils
 
-import (
-	corev1 "k8s.io/api/core/v1"
-)
-
 // CollectDifferencesFromMaps returns a map of the differences (as slice of strings) of the values of two given maps.
 // Map result values are added when a key is present just in one of the input maps, or if the values are different
 // given the same key
@@ -60,27 +56,6 @@ func isMapSubset(mapSet map[string]string, mapSubset map[string]string) bool {
 		mapValue := mapSet[subMapKey]
 
 		if mapValue != subMapValue {
-			return false
-		}
-	}
-
-	return true
-}
-
-// isResourceListSubset returns true if subResourceList is a subset of resourceList otherwise false
-func isResourceListSubset(resourceList, subResourceList corev1.ResourceList) bool {
-	if len(resourceList) < len(subResourceList) {
-		return false
-	}
-
-	if len(subResourceList) == 0 {
-		return true
-	}
-
-	for key, subValue := range subResourceList {
-		value := resourceList[key]
-
-		if !subValue.Equal(value) {
 			return false
 		}
 	}
@@ -136,10 +111,4 @@ func IsAnnotationSubset(
 	}
 
 	return isMapSubset(mapSet, mapToEvaluate)
-}
-
-// IsResourceSubset checks if some resource requirements are a subset of another
-func IsResourceSubset(resources, resourcesSubset corev1.ResourceRequirements) bool {
-	return isResourceListSubset(resources.Requests, resourcesSubset.Requests) &&
-		isResourceListSubset(resources.Limits, resourcesSubset.Limits)
 }


### PR DESCRIPTION
- Add pod annotation with original PodSpec to detect drift.
- Use a standard structure for the functions checking if
  rollout is needed.
- Fix logic that could allow a rollout with a Postgres image
  from a different major version.
