### PR TITLE
ci: use snapshot mode when no tags exist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,8 +120,14 @@ run: generate fmt vet manifests ## Run against the configured Kubernetes cluster
 	go run ./cmd/manager
 
 docker-build: go-releaser ## Build the docker image.
-	GOOS=linux GOARCH=${ARCH} GOPATH=$(go env GOPATH) DATE=${DATE} COMMIT=${COMMIT} VERSION=${VERSION} \
-	  $(GO_RELEASER) build --skip-validate --clean --single-target
+	if [ -z "${VERSION}" ] ; \
+	then \
+	  GOOS=linux GOARCH=${ARCH} GOPATH=$(go env GOPATH) DATE=${DATE} COMMIT=${COMMIT} VERSION=${VERSION} \
+		$(GO_RELEASER) build --clean --single-target --snapshot ;\
+	else \
+	  GOOS=linux GOARCH=${ARCH} GOPATH=$(go env GOPATH) DATE=${DATE} COMMIT=${COMMIT} VERSION=${VERSION} \
+		$(GO_RELEASER) build --skip-validate --clean --single-target ;\
+	fi ;\
 	DOCKER_BUILDKIT=1 docker build . -t ${CONTROLLER_IMG} --build-arg VERSION=${VERSION}
 
 docker-push: ## Push the docker image.

--- a/Makefile
+++ b/Makefile
@@ -120,14 +120,8 @@ run: generate fmt vet manifests ## Run against the configured Kubernetes cluster
 	go run ./cmd/manager
 
 docker-build: go-releaser ## Build the docker image.
-	if [ -z "${VERSION}" ] ; \
-	then \
-	  GOOS=linux GOARCH=${ARCH} GOPATH=$(go env GOPATH) DATE=${DATE} COMMIT=${COMMIT} VERSION=${VERSION} \
-		$(GO_RELEASER) build --clean --single-target --snapshot ;\
-	else \
-	  GOOS=linux GOARCH=${ARCH} GOPATH=$(go env GOPATH) DATE=${DATE} COMMIT=${COMMIT} VERSION=${VERSION} \
-		$(GO_RELEASER) build --skip-validate --clean --single-target ;\
-	fi ;\
+	GOOS=linux GOARCH=${ARCH} GOPATH=$(go env GOPATH) DATE=${DATE} COMMIT=${COMMIT} VERSION=${VERSION} \
+	  $(GO_RELEASER) build --skip-validate --clean --single-target $(if $(VERSION),,--snapshot)
 	DOCKER_BUILDKIT=1 docker build . -t ${CONTROLLER_IMG} --build-arg VERSION=${VERSION}
 
 docker-push: ## Push the docker image.


### PR DESCRIPTION
GoReleaser requires tags to create a release, which is not necessary true when running on a forked repo, this will fix that by checking the VERSION variable, which if is empty, means that there's not tag's on the current repo, in that case, we add the option `--snapshot` to the goreleaser command when doing `make docker-build`

Closes #2179  