### PR TITLE
chore: added Snyk exclude rules

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,5 @@
+exclude:
+ global:
+   - releases/**
+   - tests/**
+   - docs/**


### PR DESCRIPTION
Since we were hitting so many false positive, this will exclude a long lists of files that must not be scanned.