### PR TITLE
chore: Implement internal log constructor to handle SetLogger error

### DIFF
--- a/pkg/management/log/flags.go
+++ b/pkg/management/log/flags.go
@@ -44,6 +44,16 @@ var (
 	}
 )
 
+// NewFlags creates a new instance of Flags
+func NewFlags(options zap.Options) Flags {
+	return Flags{zapOptions: options}
+}
+
+// SetLogLevel sets manually the logLevel
+func SetLogLevel(level string) {
+	logLevel = level
+}
+
 // AddFlags binds manager configuration flags to a given flagset
 func (l *Flags) AddFlags(flags *pflag.FlagSet) {
 	loggingFlagSet := &flag.FlagSet{}

--- a/tests/utils/environment.go
+++ b/tests/utils/environment.go
@@ -27,16 +27,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/log"
-
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-
-	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
-	"github.com/cloudnative-pg/cloudnative-pg/pkg/postgres"
-	"github.com/cloudnative-pg/cloudnative-pg/pkg/specs"
-	"github.com/cloudnative-pg/cloudnative-pg/pkg/specs/pgbouncer"
-	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
-	"github.com/cloudnative-pg/cloudnative-pg/pkg/versions"
 	"github.com/go-logr/logr"
 	"github.com/thoas/go-funk"
 	appsv1 "k8s.io/api/apps/v1"
@@ -53,6 +43,15 @@ import (
 	"k8s.io/utils/strings/slices"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/log"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/postgres"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/specs"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/specs/pgbouncer"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/versions"
 
 	// Import the client auth plugin package to allow use gke or ake to run tests
 	_ "k8s.io/client-go/plugin/pkg/client/auth"

--- a/tests/utils/environment.go
+++ b/tests/utils/environment.go
@@ -107,7 +107,10 @@ func NewTestingEnvironment() (*TestingEnvironment, error) {
 	env.APIExtensionClient = apiextensionsclientset.NewForConfigOrDie(env.RestClientConfig)
 	env.Ctx = context.Background()
 	env.Scheme = runtime.NewScheme()
+
 	env.Log = ctrl.Log.WithName("e2e")
+	ctrl.SetLogger(env.Log)
+
 	env.createdNamespaces = &uniqueStringSlice{}
 
 	postgresImage := versions.DefaultImageName


### PR DESCRIPTION
This commit addresses an issue where the log.SetLogger method was not being called, leading to an absence of displayed logs. The solution involves the creation and utilization of an internal logger constructor, which enhances reusability and ensures the proper function of the logging process.

Changes are made primarily in 'tests/utils/environment.go' and 'pkg/management/log/flags.go'. 

In 'tests/utils/environment.go', we configure and retrieve a logger instance and set this instance as the default logger. This setup manages the logger for the testing environment effectively.

In 'pkg/management/log/flags.go', new functions are introduced to create a new Flags instance and to manually set the log level, providing more flexibility and control over the logging process.

This change aims to improve our testing setup by ensuring proper logging, and it paves the way for more robust and informative testing outcomes.


Closes #2281 