### PR TITLE
fix: restrict read service to instance pods only

### DIFF
--- a/pkg/specs/services.go
+++ b/pkg/specs/services.go
@@ -67,6 +67,7 @@ func CreateClusterReadService(cluster apiv1.Cluster) *corev1.Service {
 			Ports: buildInstanceServicePorts(),
 			Selector: map[string]string{
 				utils.ClusterLabelName: cluster.Name,
+				utils.PodRoleLabelName: string(utils.PodRoleInstance),
 			},
 		},
 	}

--- a/pkg/specs/services.go
+++ b/pkg/specs/services.go
@@ -50,6 +50,7 @@ func CreateClusterAnyService(cluster apiv1.Cluster) *corev1.Service {
 			Ports:                    buildInstanceServicePorts(),
 			Selector: map[string]string{
 				utils.ClusterLabelName: cluster.Name,
+				utils.PodRoleLabelName: string(utils.PodRoleInstance),
 			},
 		},
 	}

--- a/pkg/specs/services_test.go
+++ b/pkg/specs/services_test.go
@@ -45,6 +45,7 @@ var _ = Describe("Services specification", func() {
 		Expect(service.Name).To(Equal("clustername-r"))
 		Expect(service.Spec.PublishNotReadyAddresses).To(BeFalse())
 		Expect(service.Spec.Selector[utils.ClusterLabelName]).To(Equal("clustername"))
+		Expect(service.Spec.Selector[utils.PodRoleLabelName]).To(Equal(string(utils.PodRoleInstance)))
 	})
 
 	It("create a configured -ro service", func() {

--- a/pkg/specs/services_test.go
+++ b/pkg/specs/services_test.go
@@ -38,6 +38,7 @@ var _ = Describe("Services specification", func() {
 		Expect(service.Name).To(Equal("clustername-any"))
 		Expect(service.Spec.PublishNotReadyAddresses).To(BeTrue())
 		Expect(service.Spec.Selector[utils.ClusterLabelName]).To(Equal("clustername"))
+		Expect(service.Spec.Selector[utils.PodRoleLabelName]).To(Equal(string(utils.PodRoleInstance)))
 	})
 
 	It("create a configured -r service", func() {


### PR DESCRIPTION
Addresses the issue where the -r service would be backed by the init and join pods.

Closes  #2335 