### PR TITLE
doc: override table data css to wrap long sentences

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -4,6 +4,9 @@ docs_dir: src
 
 theme: readthedocs
 
+extra_css:
+  - css/override.css
+
 markdown_extensions:
   - admonition
   - def_list

--- a/docs/src/css/override.css
+++ b/docs/src/css/override.css
@@ -1,0 +1,3 @@
+.wy-table-responsive table td, .wy-table-responsive table th {
+    white-space: normal;
+}


### PR DESCRIPTION
Override the readthedocs css theme for td and th, changing the white-space value from nowrap to normal. Long descriptions will be wrapped instead of forcing the user to horizontally scroll, improving the readability of the API Reference page.