### PR TITLE
chore: introduce Pooler interface for improved unit testing

### DIFF
--- a/internal/management/controller/slots/infrastructure/postgresmanager.go
+++ b/internal/management/controller/slots/infrastructure/postgresmanager.go
@@ -18,25 +18,19 @@ package infrastructure
 
 import (
 	"context"
-	"database/sql"
 
 	v1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/log"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres/pool"
 )
-
-// pooler is an internal interface to pass a connection pooler to NewPostgresManager
-type pooler interface {
-	Connection(dbname string) (*sql.DB, error)
-	GetDsn(dbname string) string
-}
 
 // PostgresManager is a Manager for a database instance
 type PostgresManager struct {
-	pool pooler
+	pool pool.Pooler
 }
 
 // NewPostgresManager returns an implementation of Manager for postgres
-func NewPostgresManager(pool pooler) Manager {
+func NewPostgresManager(pool pool.Pooler) Manager {
 	return PostgresManager{
 		pool: pool,
 	}

--- a/internal/pgbouncer/management/controller/instance.go
+++ b/internal/pgbouncer/management/controller/instance.go
@@ -61,7 +61,7 @@ type pgBouncerInstance struct {
 
 	// This is the connection pool used to connect to pgbouncer
 	// using the administrative user and the administrative database
-	pool *pool.ConnectionPool
+	pool pool.Pooler
 }
 
 // Paused returns whether the pgbouncerInstance is paused or not, thread safe

--- a/internal/pgbouncer/management/controller/instance_test.go
+++ b/internal/pgbouncer/management/controller/instance_test.go
@@ -39,7 +39,7 @@ var _ = Describe("PgBouncerInstance", func() {
 	})
 
 	AfterEach(func() {
-		Expect(mock.ExpectationsWereMet()).ToNot(HaveOccurred())
+		Expect(mock.ExpectationsWereMet()).To(Succeed())
 	})
 
 	Context("when the instance is paused", func() {

--- a/internal/pgbouncer/management/controller/instance_test.go
+++ b/internal/pgbouncer/management/controller/instance_test.go
@@ -1,0 +1,106 @@
+/*
+Copyright The CloudNativePG Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"database/sql"
+	"sync"
+
+	"github.com/DATA-DOG/go-sqlmock"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("PgBouncerInstance", func() {
+	var (
+		db   *sql.DB
+		mock sqlmock.Sqlmock
+		err  error
+	)
+
+	BeforeEach(func() {
+		db, mock, err = sqlmock.New()
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		Expect(mock.ExpectationsWereMet()).ToNot(HaveOccurred())
+	})
+
+	Context("when the instance is paused", func() {
+		It("should not return an error", func() {
+			mock.ExpectExec("PAUSE").WillReturnResult(sqlmock.NewResult(1, 1))
+
+			pgBouncerInstance := &pgBouncerInstance{
+				mu:     &sync.RWMutex{},
+				paused: false,
+				pool:   &fakePooler{DB: db},
+			}
+
+			err := pgBouncerInstance.Pause()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(pgBouncerInstance.Paused()).To(BeTrue())
+		})
+	})
+
+	Context("when the instance is resumed", func() {
+		It("should not return an error", func() {
+			mock.ExpectExec("RESUME").WillReturnResult(sqlmock.NewResult(1, 1))
+
+			pgBouncerInstance := &pgBouncerInstance{
+				mu:     &sync.RWMutex{},
+				paused: true,
+				pool:   &fakePooler{DB: db},
+			}
+
+			err := pgBouncerInstance.Resume()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(pgBouncerInstance.Paused()).To(BeFalse())
+		})
+	})
+
+	Context("when the instance configuration is reloaded", func() {
+		It("should not return an error", func() {
+			mock.ExpectExec("RELOAD").WillReturnResult(sqlmock.NewResult(1, 1))
+
+			pgBouncerInstance := &pgBouncerInstance{
+				mu:     &sync.RWMutex{},
+				paused: false,
+				pool:   &fakePooler{DB: db},
+			}
+
+			err := pgBouncerInstance.Reload()
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+})
+
+type fakePooler struct {
+	DB *sql.DB
+}
+
+func (f *fakePooler) Connection(_ string) (*sql.DB, error) {
+	return f.DB, nil
+}
+
+func (f *fakePooler) GetDsn(_ string) string {
+	return "postgres://user:password@localhost:5432/testdb"
+}
+
+func (f *fakePooler) ShutdownConnections() {
+}

--- a/internal/pgbouncer/management/controller/refresh.go
+++ b/internal/pgbouncer/management/controller/refresh.go
@@ -36,8 +36,8 @@ func refreshConfigurationFiles(files config.ConfigurationFiles) (bool, error) {
 		}
 		if changedFile {
 			log.Info("updated configuration file", "name", fileName)
+			changed = true
 		}
-		changed = changed || changedFile
 	}
 
 	return changed, nil

--- a/internal/pgbouncer/management/controller/refresh_test.go
+++ b/internal/pgbouncer/management/controller/refresh_test.go
@@ -71,9 +71,9 @@ var _ = Describe("RefreshConfigurationFiles", func() {
 		})
 	})
 
-	Context("when error occurs while writing file", func() {
+	Context("when given an invalid file path", func() {
 		BeforeEach(func() {
-			files["/invalid/path"] = []byte("content")
+			files["/dev/null"] = []byte("content")
 		})
 
 		It("should return an error", func() {

--- a/internal/pgbouncer/management/controller/refresh_test.go
+++ b/internal/pgbouncer/management/controller/refresh_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright The CloudNativePG Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/pgbouncer/config"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("RefreshConfigurationFiles", func() {
+	var (
+		tmpDir string
+		files  config.ConfigurationFiles
+		err    error
+	)
+
+	BeforeEach(func() {
+		tmpDir, err = os.MkdirTemp("", "test")
+		Expect(err).NotTo(HaveOccurred())
+		files = make(config.ConfigurationFiles)
+	})
+
+	AfterEach(func() {
+		err = os.RemoveAll(tmpDir)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	Context("when no files are passed", func() {
+		It("should return false and no error", func() {
+			changed, err := refreshConfigurationFiles(files)
+			Expect(changed).To(BeFalse())
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Context("when files are passed", func() {
+		BeforeEach(func() {
+			files[filepath.Join(tmpDir, "config1")] = []byte("content1")
+			files[filepath.Join(tmpDir, "config2")] = []byte("content2")
+		})
+
+		It("should write content to files and return true", func() {
+			changed, err := refreshConfigurationFiles(files)
+			Expect(changed).To(BeTrue())
+			Expect(err).NotTo(HaveOccurred())
+
+			for filename, content := range files {
+				fileContent, err := os.ReadFile(filename) // nolint: gosec
+				Expect(err).NotTo(HaveOccurred())
+				Expect(fileContent).To(Equal(content))
+			}
+		})
+	})
+
+	Context("when error occurs while writing file", func() {
+		BeforeEach(func() {
+			files["/invalid/path"] = []byte("content")
+		})
+
+		It("should return an error", func() {
+			_, err := refreshConfigurationFiles(files)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+})

--- a/internal/pgbouncer/management/controller/secrets_test.go
+++ b/internal/pgbouncer/management/controller/secrets_test.go
@@ -1,0 +1,76 @@
+/*
+Copyright The CloudNativePG Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("getSecrets tests", func() {
+	var (
+		ctx    context.Context
+		client client.WithWatch
+		pooler *apiv1.Pooler
+	)
+
+	BeforeEach(func() {
+		ctx = context.TODO()
+		client, pooler = buildTestEnv()
+	})
+
+	Context("when status is not populated yet", func() {
+		It("should return error", func() {
+			pooler.Status.Secrets = nil
+
+			_, err := getSecrets(ctx, client, pooler)
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("status not populated yet"))
+		})
+	})
+
+	Context("when all secrets are found", func() {
+		It("should return secrets without error", func() {
+			res, err := getSecrets(ctx, client, pooler)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(res.ClientCA.Name).To(Equal(clientCAName))
+			Expect(res.Client.Name).To(Equal(serverTLSName))
+			Expect(res.ServerCA.Name).To(Equal(serverCAName))
+			Expect(res.AuthQuery.Name).To(Equal(authQueryName))
+		})
+	})
+
+	Context("when a secret is not found", func() {
+		BeforeEach(func() {
+			pooler.Status.Secrets.ServerCA = apiv1.SecretVersion{Name: "nonexistent"}
+		})
+
+		It("should return error", func() {
+			_, err := getSecrets(ctx, client, pooler)
+
+			Expect(err).To(HaveOccurred())
+		})
+	})
+})

--- a/internal/pgbouncer/management/controller/secrets_test.go
+++ b/internal/pgbouncer/management/controller/secrets_test.go
@@ -29,18 +29,16 @@ import (
 
 var _ = Describe("getSecrets tests", func() {
 	var (
-		ctx    context.Context
 		client client.WithWatch
 		pooler *apiv1.Pooler
 	)
 
 	BeforeEach(func() {
-		ctx = context.TODO()
 		client, pooler = buildTestEnv()
 	})
 
 	Context("when status is not populated yet", func() {
-		It("should return error", func() {
+		It("should return error", func(ctx context.Context) {
 			pooler.Status.Secrets = nil
 
 			_, err := getSecrets(ctx, client, pooler)
@@ -51,7 +49,7 @@ var _ = Describe("getSecrets tests", func() {
 	})
 
 	Context("when all secrets are found", func() {
-		It("should return secrets without error", func() {
+		It("should return secrets without error", func(ctx context.Context) {
 			res, err := getSecrets(ctx, client, pooler)
 
 			Expect(err).ToNot(HaveOccurred())
@@ -67,7 +65,7 @@ var _ = Describe("getSecrets tests", func() {
 			pooler.Status.Secrets.ServerCA = apiv1.SecretVersion{Name: "nonexistent"}
 		})
 
-		It("should return error", func() {
+		It("should return error", func(ctx context.Context) {
 			_, err := getSecrets(ctx, client, pooler)
 
 			Expect(err).To(HaveOccurred())

--- a/internal/pgbouncer/management/controller/suite_test.go
+++ b/internal/pgbouncer/management/controller/suite_test.go
@@ -1,0 +1,82 @@
+/*
+Copyright The CloudNativePG Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	"github.com/cloudnative-pg/cloudnative-pg/internal/scheme"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+const (
+	authQueryName = "authquery"
+	serverCAName  = "serverca"
+	serverTLSName = "servertls"
+	clientCAName  = "clientca"
+)
+
+func TestController(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "PGBouncer Controller Suite")
+}
+
+func buildTestEnv() (client.WithWatch, *apiv1.Pooler) {
+	authQuerySecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: authQueryName, Namespace: "default"},
+	}
+	serverCASecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: serverCAName, Namespace: "default"},
+	}
+	serverCertSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: serverTLSName, Namespace: "default"},
+	}
+	clientCASecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: clientCAName, Namespace: "default"},
+	}
+
+	pooler := &apiv1.Pooler{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pooler", Namespace: "default"},
+		Spec: apiv1.PoolerSpec{
+			PgBouncer: &apiv1.PgBouncerSpec{
+				AuthQuerySecret: &apiv1.LocalObjectReference{Name: authQueryName},
+			},
+			Cluster: apiv1.LocalObjectReference{
+				Name: "cluster",
+			},
+		},
+		Status: apiv1.PoolerStatus{
+			Secrets: &apiv1.PoolerSecrets{
+				ServerCA:  apiv1.SecretVersion{Name: serverCAName},
+				ServerTLS: apiv1.SecretVersion{Name: serverTLSName},
+				ClientCA:  apiv1.SecretVersion{Name: clientCAName},
+			},
+		},
+	}
+
+	return fake.NewClientBuilder().WithScheme(scheme.BuildWithAllKnownScheme()).
+		WithObjects(pooler, authQuerySecret, serverCASecret, serverCertSecret, clientCASecret).
+		Build(), pooler
+}

--- a/pkg/management/postgres/pool/pool.go
+++ b/pkg/management/postgres/pool/pool.go
@@ -28,6 +28,18 @@ import (
 	_ "github.com/jackc/pgx/v5/stdlib"
 )
 
+// Pooler represents an interface for a connection pooler.
+// It exposes functionalities for retrieving a connection, obtaining the Data Source Name (DSN),
+// and shutting down all active connections.
+type Pooler interface {
+	// Connection gets the connection for the given database
+	Connection(dbname string) (*sql.DB, error)
+	// GetDsn returns the connection string for a given database
+	GetDsn(dbname string) string
+	// ShutdownConnections closes every database connection
+	ShutdownConnections()
+}
+
 // ConnectionPool is a repository of DB connections, pointing to the same instance
 // given a base DSN without the "dbname" parameter
 type ConnectionPool struct {


### PR DESCRIPTION
This commit introduces a new Pooler interface, which is designed to be a substitute for the ConnectionPooler direct usage. This change facilitates more effective and reliable unit testing of the codebase.

Additionally, this commit includes unit tests for various use cases of the ConnectionPooler within the pgbouncer management controller. These added tests enhance our ability to examine, debug, and ensure the overall reliability of the system.

Closes #2362 
