### PR TITLE
chore: do not add label `backport-requested` to `do not backport` PRs

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,4 +1,4 @@
-name: pull_request_backport
+name: Backport Pull Request
 on:
   pull_request_target:
     types:
@@ -15,7 +15,7 @@ jobs:
   # Label the source pull request with 'backport-requested' and all supported releases label, the goal is, by default
   # we backport everything, except those PR that are created or contain `do not backport` explicitly.
   label-source-pr:
-    name: label the source pr
+    name: Add labels to PR
     if: github.event.pull_request.merged == false &&
         !contains(github.event.pull_request.labels.*.name, 'backport-requested') &&
         !contains(github.event.pull_request.labels.*.name, 'do not backport')
@@ -47,7 +47,7 @@ jobs:
 
   ## backport pull request in condition when pr contains 'backport-requested' label and contains target branches labels
   back-porting-pr:
-    name: backport to release branches
+    name: Backport to release branches
     if: |
         github.event.pull_request.merged == true &&
         (
@@ -119,7 +119,7 @@ jobs:
           git push
 
   create-tickets:
-    name: create tickets for failure
+    name: Create tickets for failures
     needs:
       - back-porting-pr
     if: |

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -13,11 +13,12 @@ env:
 
 jobs:
   # Label the source pull request with 'backport-requested' and all supported releases label, the goal is, by default
-  # we backport everything
+  # we backport everything, except those PR that are created or contain `do not backport` explicitly.
   label-source-pr:
     name: label the source pr
     if: github.event.pull_request.merged == false &&
-        !contains(github.event.pull_request.labels.*.name, 'backport-requested')
+        !contains(github.event.pull_request.labels.*.name, 'backport-requested') &&
+        !contains(github.event.pull_request.labels.*.name, 'do not backport')
     runs-on: ubuntu-22.04
     steps:
       -


### PR DESCRIPTION
Previously the goal was to backport everything, and this works perfectly, but with renovate we create the PRs with the label `do not backport` which it's added because those PR will be replicated one per each release branch.

Now, we avoid adding the `backport-requested` label when the PR contains the `do not backport`