### PR TITLE
chore: do not add label backport-requested to PRs created by renovate

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -16,14 +16,16 @@ jobs:
   # we backport everything, except those PR that are created or contain `do not backport` explicitly.
   label-source-pr:
     name: Add labels to PR
-    if: github.event.pull_request.merged == false &&
+    if: | 
+        github.event.pull_request.merged == false &&
         !contains(github.event.pull_request.labels.*.name, 'backport-requested') &&
         !contains(github.event.pull_request.labels.*.name, 'do not backport')
     runs-on: ubuntu-22.04
     steps:
       -
-        name: label the pull request
+        name: Label the pull request
         uses: actions-ecosystem/action-add-labels@v1
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'do not backport') }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           number:  ${{ github.event.pull_request.number }}
@@ -44,6 +46,15 @@ jobs:
             - To stop backporting this pr to a certain release branch, remove the specific branch label: release-x.y
 
           reactions: heart
+      -
+        name: Remove redundant labels
+        uses: actions-ecosystem/action-remove-labels@v1
+        if: ${{ contains(github.event.pull_request.labels.*.name, 'do not backport') }}
+        with:
+          labels: |
+            backport-requested :arrow_backward:
+            release-1.19
+            release-1.20
 
   ## backport pull request in condition when pr contains 'backport-requested' label and contains target branches labels
   back-porting-pr:


### PR DESCRIPTION
Previously the goal was to backport everything, and this works perfectly, but with renovate we create the PRs with the label do not backport which it's added because those PR will be replicated one per each release branch.

This is the further fix to avoid adding the backport-requested label when the PR is created by renovate