### PR TITLE
fix: ensure PGDATA permissions after initdb and restore

### DIFF
--- a/pkg/management/postgres/initdb.go
+++ b/pkg/management/postgres/initdb.go
@@ -135,8 +135,12 @@ func (info InitInfo) CreateDataDirectory() error {
 		"pgdata", info.PgData,
 		"initDbOptions", options)
 
-	initdbCmd := exec.Command(constants.InitdbName, options...) // #nosec
+	// Certain CSI drivers may add setgid permissions on newly created folders.
+	// A default umask is set to attempt to avoid this, by revoking group/other
+	// permission bits on the PGDATA
 	_ = os.FileMode(unix.Umask(0o077))
+
+	initdbCmd := exec.Command(constants.InitdbName, options...) // #nosec
 	err := execlog.RunBuffering(initdbCmd, constants.InitdbName)
 	if err != nil {
 		return fmt.Errorf("error while creating the PostgreSQL instance: %w", err)

--- a/pkg/management/postgres/initdb.go
+++ b/pkg/management/postgres/initdb.go
@@ -138,7 +138,7 @@ func (info InitInfo) CreateDataDirectory() error {
 	// Certain CSI drivers may add setgid permissions on newly created folders.
 	// A default umask is set to attempt to avoid this, by revoking group/other
 	// permission bits on the PGDATA
-	_ = os.FileMode(unix.Umask(0o077))
+	_ = unix.Umask(0o077)
 
 	initdbCmd := exec.Command(constants.InitdbName, options...) // #nosec
 	err := execlog.RunBuffering(initdbCmd, constants.InitdbName)

--- a/pkg/management/postgres/initdb.go
+++ b/pkg/management/postgres/initdb.go
@@ -30,6 +30,7 @@ import (
 	"sort"
 
 	"github.com/jackc/pgx/v5"
+	"golang.org/x/sys/unix"
 	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
@@ -135,6 +136,7 @@ func (info InitInfo) CreateDataDirectory() error {
 		"initDbOptions", options)
 
 	initdbCmd := exec.Command(constants.InitdbName, options...) // #nosec
+	_ = os.FileMode(unix.Umask(0o077))
 	err := execlog.RunBuffering(initdbCmd, constants.InitdbName)
 	if err != nil {
 		return fmt.Errorf("error while creating the PostgreSQL instance: %w", err)

--- a/pkg/management/postgres/instance.go
+++ b/pkg/management/postgres/instance.go
@@ -336,6 +336,12 @@ func (instance *Instance) Startup() error {
 
 	log.Info("Starting up instance", "pgdata", instance.PgData, "options", options)
 
+	// We need to make sure that the permissions are the right ones
+	// in some systems they may be messed up even if we fix them before
+	if err := fileutils.EnsurePgDataPerms(instance.PgData); err != nil {
+		return err
+	}
+
 	pgCtlCmd := exec.Command(pgCtlName, options...) // #nosec
 	pgCtlCmd.Env = instance.Env
 	err := execlog.RunStreaming(pgCtlCmd, pgCtlName)
@@ -462,6 +468,12 @@ func (instance *Instance) Run() (*execlog.StreamingCmd, error) {
 
 	options := []string{
 		"-D", instance.PgData,
+	}
+
+	// We need to make sure that the permissions are the right ones
+	// in some systems they may be messed up even if we fix them before
+	if err := fileutils.EnsurePgDataPerms(instance.PgData); err != nil {
+		return nil, err
 	}
 
 	postgresCmd := exec.Command(postgresName, options...) // #nosec


### PR DESCRIPTION
In some system the storage may add a suid to the directory when the `fsGroup` in the security context it's enable,
making impossible to PostgreSQL to start since the permissions required are 0700 or 0750 but the directory 
may ended up with 2770

Closes #1354 