### PR TITLE
fix: check for nil value in the pod status

### DIFF
--- a/internal/management/controller/instance_controller.go
+++ b/internal/management/controller/instance_controller.go
@@ -900,7 +900,7 @@ func (r *InstanceReconciler) processConfigReloadAndManageRestart(ctx context.Con
 		return err
 	}
 
-	if !status.PendingRestart {
+	if status == nil || !status.PendingRestart {
 		// Everything fine
 		return nil
 	}


### PR DESCRIPTION
When getting the status of a pod and there's no sha256 in the status this could be nil, leading to a panic in the code while trying to check if there is a pending restart.

Closes #2389 