### PR TITLE
fix: allow setup-cluster.sh to work with containerd

### DIFF
--- a/hack/setup-cluster.sh
+++ b/hack/setup-cluster.sh
@@ -307,7 +307,9 @@ deploy_fluentd() {
   local FLUENTD_IMAGE=fluent/fluentd-kubernetes-daemonset:v1.14.3-debian-forward-1.0
   local FLUENTD_LOCAL_IMAGE="${registry_name}:5000/fluentd-kubernetes-daemonset:local"
 
-  docker pull "${FLUENTD_IMAGE}"
+  docker manifest inspect "${FLUENTD_IMAGE}" | \
+    jq -r '.manifests[].platform | .os + "/" + .architecture' | \
+    xargs -t -r -I X docker pull -q --platform=X "${FLUENTD_IMAGE}"
   docker tag "${FLUENTD_IMAGE}" "${FLUENTD_LOCAL_IMAGE}"
   load_image "${CLUSTER_NAME}" "${FLUENTD_LOCAL_IMAGE}"
 
@@ -377,7 +379,7 @@ load_image_registry() {
 
   local image_local_name=${image/${registry_name}/127.0.0.1}
   docker tag "${image}" "${image_local_name}"
-  docker push "${image_local_name}"
+  docker push -q "${image_local_name}"
 }
 
 load_image() {

--- a/tests/utils/version_test.go
+++ b/tests/utils/version_test.go
@@ -41,7 +41,7 @@ var _ = Describe("Guess the correct version of a postgres image", func() {
 
 	It("can pull the default image", func() {
 		var stderr bytes.Buffer
-		cmd := exec.Command("docker", "pull", versions.DefaultImageName) // #nosec G204
+		cmd := exec.Command("docker", "pull", "-q", versions.DefaultImageName) // #nosec G204
 		cmd.Stderr = &stderr
 		err := cmd.Run()
 		Expect(stderr.String()).To(BeEmpty(), "while pulling "+versions.DefaultImageName)


### PR DESCRIPTION
This fixes an error in `setup-cluster.sh create -r` when used with
the latest version of Docker Desktop and contained beta feature enabled.

```
$ docker push 127.0.0.1:5000/fluentd-kubernetes-daemonset:local
4f3d1761e838: Waiting
458526b2e326: Waiting
c783e3bff97b: Waiting
missing content: content digest sha256:458526b2e326a53cbb5e2b6ba41401f0d21d06cbefe8581252c61c73ebc98783: not found
Note: You're trying to push a manifest list/index which references multiple platform specific manifests, but not all of them are available locally or available to the remote repository.
Make sure you have all the referenced content and try again.
```