### PR TITLE
ci: devcontainer configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,5 +18,8 @@
   },
 
   // Needed by kind and k3s to enable kube-proxy's ipvs mode
-  "mounts":["type=bind,source=/lib/modules,target=/lib/modules"]
+  "mounts":["type=bind,source=/lib/modules,target=/lib/modules"],
+
+  // Enable kubectl short alias with completion
+  "postCreateCommand": "echo 'alias k=kubectl; complete -F __start_kubectl k' >> ~/.bash_aliases"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,6 +16,6 @@
     "ghcr.io/devcontainers-contrib/features/kubectx-kubens:1": {}
   },
 
-  // Needed by kind and k3s to enable pgproxy's ipvs mode
+  // Needed by kind and k3s to enable kube-proxy's ipvs mode
   "mounts":["type=bind,source=/lib/modules,target=/lib/modules"]
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,13 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/go",
+  "features": {
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {},
+    "ghcr.io/rio/features/k3d:1": {},
+    "ghcr.io/mpriscella/features/kind:1": {},
+    "ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {},
+    "ghcr.io/guiyomh/features/golangci-lint:0": {}
+  },
+
+  // Needed by kind and k3s to enable pgproxy's ipvs mode
+  "mounts":["type=bind,source=/lib/modules,target=/lib/modules"]
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,14 @@
     "ghcr.io/devcontainers/features/docker-in-docker:2": {},
     "ghcr.io/rio/features/k3d:1": {},
     "ghcr.io/mpriscella/features/kind:1": {},
-    "ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {},
+    "ghcr.io/rjfmachado/devcontainer-features/cloud-native:1": {
+      "kubectl": "latest",
+      "helm": "latest",
+      "kubelogin": "none",
+      "azwi": "none",
+      "flux": "none",
+      "cilium": "none"
+    },
     "ghcr.io/guiyomh/features/golangci-lint:0": {},
     "ghcr.io/devcontainers-contrib/features/kubectx-kubens:1": {}
   },

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,7 +13,8 @@
       "cilium": "none"
     },
     "ghcr.io/guiyomh/features/golangci-lint:0": {},
-    "ghcr.io/devcontainers-contrib/features/kubectx-kubens:1": {}
+    "ghcr.io/devcontainers-contrib/features/kubectx-kubens:1": {},
+    "ghcr.io/dhoeric/features/stern:1": {}
   },
 
   // Needed by kind and k3s to enable kube-proxy's ipvs mode

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "image": "mcr.microsoft.com/devcontainers/go",
+  "image": "mcr.microsoft.com/devcontainers/go:1",
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2": {},
     "ghcr.io/rio/features/k3d:1": {},

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,8 @@
     "ghcr.io/rio/features/k3d:1": {},
     "ghcr.io/mpriscella/features/kind:1": {},
     "ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {},
-    "ghcr.io/guiyomh/features/golangci-lint:0": {}
+    "ghcr.io/guiyomh/features/golangci-lint:0": {},
+    "ghcr.io/devcontainers-contrib/features/kubectx-kubens:1": {}
   },
 
   // Needed by kind and k3s to enable pgproxy's ipvs mode


### PR DESCRIPTION
This devcontainer configuration allows any user to instantly configure an environment capable of running all the tests (including E2E) and works well with [devpod](http://devpod.sh)