### PR TITLE
fix: run the CRD check also when there's some changes in operator

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -292,7 +292,7 @@ jobs:
       needs.duplicate_runs.outputs.should_skip != 'true' &&
       (
         needs.change-triage.outputs.go-code-changed == 'true' ||
-        needs.change-triage.outputs.operator-changed == 'true
+        needs.change-triage.outputs.operator-changed == 'true'
       )
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -290,7 +290,8 @@ jobs:
     # Run make manifests if Go code have changed
     if: |
       needs.duplicate_runs.outputs.should_skip != 'true' &&
-      needs.change-triage.outputs.go-code-changed == 'true'
+      ( needs.change-triage.outputs.go-code-changed == 'true' ||
+      needs.change-triage.outputs.operator-changed == 'true )
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout code

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -290,8 +290,10 @@ jobs:
     # Run make manifests if Go code have changed
     if: |
       needs.duplicate_runs.outputs.should_skip != 'true' &&
-      ( needs.change-triage.outputs.go-code-changed == 'true' ||
-      needs.change-triage.outputs.operator-changed == 'true )
+      (
+        needs.change-triage.outputs.go-code-changed == 'true' ||
+        needs.change-triage.outputs.operator-changed == 'true
+      )
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout code


### PR DESCRIPTION
The CRD was not running because it was expecting only changes from `go-code-changed` in the `check-changes` job, now will also run if there's some changes in the `operator-changed` job.