### PR TITLE
fix: add SA ownerMetadata only during creation

### DIFF
--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -2527,10 +2527,14 @@ func (cluster *Cluster) LogTimestampsWithMessage(ctx context.Context, logMessage
 // SetInheritedDataAndOwnership sets the cluster as owner of the passed object and then
 // sets all the needed annotations and labels
 func (cluster *Cluster) SetInheritedDataAndOwnership(obj *metav1.ObjectMeta) {
+	cluster.SetInheritedData(obj)
+	utils.SetAsOwnedBy(obj, cluster.ObjectMeta, cluster.TypeMeta)
+}
+
+func (cluster *Cluster) SetInheritedData(obj *metav1.ObjectMeta) {
 	utils.InheritAnnotations(obj, cluster.Annotations, cluster.GetFixedInheritedAnnotations(), configuration.Current)
 	utils.InheritLabels(obj, cluster.Labels, cluster.GetFixedInheritedLabels(), configuration.Current)
 	utils.LabelClusterName(obj, cluster.GetName())
-	utils.SetAsOwnedBy(obj, cluster.ObjectMeta, cluster.TypeMeta)
 	utils.SetOperatorVersion(obj, versions.Version)
 }
 

--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -2531,6 +2531,7 @@ func (cluster *Cluster) SetInheritedDataAndOwnership(obj *metav1.ObjectMeta) {
 	utils.SetAsOwnedBy(obj, cluster.ObjectMeta, cluster.TypeMeta)
 }
 
+// SetInheritedData sets all the needed annotations and labels
 func (cluster *Cluster) SetInheritedData(obj *metav1.ObjectMeta) {
 	utils.InheritAnnotations(obj, cluster.Annotations, cluster.GetFixedInheritedAnnotations(), configuration.Current)
 	utils.InheritLabels(obj, cluster.Labels, cluster.GetFixedInheritedLabels(), configuration.Current)

--- a/controllers/cluster_create.go
+++ b/controllers/cluster_create.go
@@ -427,8 +427,8 @@ func (r *ClusterReconciler) createOrPatchServiceAccount(ctx context.Context, clu
 	if err != nil {
 		return fmt.Errorf("while generating service account: %w", err)
 	}
-
-	cluster.SetInheritedDataAndOwnership(&sa.ObjectMeta)
+	// we add the ownerMetadata only when creating the SA
+	cluster.SetInheritedData(&sa.ObjectMeta)
 	cluster.Spec.ServiceAccountTemplate.MergeMetadata(&sa)
 
 	if specs.IsServiceAccountAligned(ctx, origSa, generatedPullSecretNames, sa.ObjectMeta) {

--- a/controllers/cluster_create_test.go
+++ b/controllers/cluster_create_test.go
@@ -175,21 +175,30 @@ var _ = Describe("cluster_create unit tests", func() {
 		})
 
 		By("executing createOrPatchServiceAccount (patch)", func() {
-			err := clusterReconciler.createOrPatchServiceAccount(ctx, cluster)
-			Expect(err).ToNot(HaveOccurred())
-		})
+			By("setting owner reference to nil", func() {
+				sa.ObjectMeta.OwnerReferences = nil
+				err := k8sClient.Update(context.Background(), sa)
+				Expect(err).ToNot(HaveOccurred())
+			})
 
-		By("making sure that the serviceaccount is patched correctly", func() {
-			updatedSA := &corev1.ServiceAccount{}
-			expectResourceExistsWithDefaultClient(cluster.Name, namespace, updatedSA)
-			Expect(updatedSA.Annotations["test"]).To(BeEquivalentTo("annotation"))
-			Expect(updatedSA.Labels["test"]).To(BeEquivalentTo("label"))
-			Expect(updatedSA.ImagePullSecrets).To(ContainElements(corev1.LocalObjectReference{
-				Name: "cluster-pullsecret",
-			}))
-			Expect(updatedSA.ImagePullSecrets).To(ContainElements(corev1.LocalObjectReference{
-				Name: "sa-pullsecret",
-			}))
+			By("running patch", func() {
+				err := clusterReconciler.createOrPatchServiceAccount(ctx, cluster)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			By("making sure that the serviceaccount is patched correctly", func() {
+				updatedSA := &corev1.ServiceAccount{}
+				expectResourceExistsWithDefaultClient(cluster.Name, namespace, updatedSA)
+				Expect(updatedSA.Annotations["test"]).To(BeEquivalentTo("annotation"))
+				Expect(updatedSA.Labels["test"]).To(BeEquivalentTo("label"))
+				Expect(updatedSA.ImagePullSecrets).To(ContainElements(corev1.LocalObjectReference{
+					Name: "cluster-pullsecret",
+				}))
+				Expect(updatedSA.ImagePullSecrets).To(ContainElements(corev1.LocalObjectReference{
+					Name: "sa-pullsecret",
+				}))
+				Expect(updatedSA.OwnerReferences).To(BeNil())
+			})
 		})
 	})
 


### PR DESCRIPTION
This patch ensures that we are able to reconcile the SA that we do not own, this is done by adding ownerMetadata only during the  creation of the SA.

Closes #2461 
