### PR TITLE
test: E2E env configuration to support volumesnapshot in gke

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -1448,7 +1448,8 @@ jobs:
       DEBUG: "true"
       BUILD_IMAGE: "false"
       CONTROLLER_IMG: ${{ needs.generate-jobs.outputs.image }}
-      E2E_DEFAULT_STORAGE_CLASS: standard
+      E2E_DEFAULT_STORAGE_CLASS: standard-rwo
+      E2E_DEFAULT_VOLUMESNAPSHOT_CLASS: pd-csi-snapclass
 
       ZONE: europe-west3-a
       TEST_CLOUD_VENDOR: "gke"
@@ -1529,6 +1530,14 @@ jobs:
           USE_GKE_GCLOUD_AUTH_PLUGIN: "True"
         run: |
           gcloud container clusters get-credentials ${{ env.CLUSTER_NAME }} --zone ${{ env.ZONE }} --project ${{ secrets.GCP_PROJECT_ID }}
+      -
+        name: Configure Storage
+        run: |
+          # Install volume snapshot class
+          kubectl apply -f hack/e2e/volumesnapshotclass-pd-csi.yaml
+          # Change to use standard-rwo as default storage account
+          kubectl annotate storageclass ${{env.E2E_DEFAULT_STORAGE_CLASS}} storage.kubernetes.io/default-snapshot-class=${{env.E2E_DEFAULT_VOLUMESNAPSHOT_CLASS}} --overwrite
+          kubectl get storageclass
       -
         name: Prepare patch for customization
         env:

--- a/hack/e2e/volumesnapshotclass-pd-csi.yaml
+++ b/hack/e2e/volumesnapshotclass-pd-csi.yaml
@@ -1,0 +1,8 @@
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshotClass
+metadata:
+  name: pd-csi-snapclass
+  annotations:
+    snapshot.storage.kubernetes.io/is-default-class: "true"
+driver: pd.csi.storage.gke.io
+deletionPolicy: Delete


### PR DESCRIPTION
This patch contains the configuration for e2e cloud env support
for volumesnapshot. this patch include the workflow change for gke

closes: https://github.com/cloudnative-pg/cloudnative-pg/issues/2483