### PR TITLE
chore: Improve error output on snapshot command

### DIFF
--- a/internal/cmd/plugin/snapshot/cmd.go
+++ b/internal/cmd/plugin/snapshot/cmd.go
@@ -329,6 +329,10 @@ func (cmd *snapshotCommand) waitSnapshot(name string) error {
 			return fmt.Errorf("snapshot %s is not available: %w", name, err)
 		}
 
+		if snapshot.Status != nil && snapshot.Status.Error != nil {
+			return fmt.Errorf("snapshot %s is not ready to use.\nError: %v", name, snapshot.Status.Error.Message)
+		}
+
 		if snapshot.Status == nil || snapshot.Status.ReadyToUse == nil || !*snapshot.Status.ReadyToUse {
 			return fmt.Errorf("snapshot %s is not ready to use", name)
 		}


### PR DESCRIPTION
We were previously waiting for the snapshot to be not ready to use,
with this patch we check if there's an error inside the VolumeSnapshot
object and error out and let the user knows the error directly.