### PR TITLE
Fix PoolerTypeRO comment

### DIFF
--- a/api/v1/pooler_types.go
+++ b/api/v1/pooler_types.go
@@ -31,7 +31,7 @@ const (
 	// PoolerTypeRW means that the pooler involves only the primary server
 	PoolerTypeRW = PoolerType("rw")
 
-	// PoolerTypeRO means that the pooler involves every server
+	// PoolerTypeRO means that the pooler involves only the replicas
 	PoolerTypeRO = PoolerType("ro")
 
 	// DefaultPgBouncerPoolerAuthQuery is the default auth_query for PgBouncer


### PR DESCRIPTION
An "ro" PoolerType creates a pooler with the "ro" service as it's backend, which means it'll provide a connection pool over all replicas, excluding the primary.