### PR TITLE
Fix typo in test

### DIFF
--- a/pkg/management/postgres/instance_test.go
+++ b/pkg/management/postgres/instance_test.go
@@ -214,7 +214,7 @@ var _ = Describe("check atomic bool", func() {
 		Expect(canBeChecked).To(BeTrue())
 	})
 
-	It("should recognize whether the instance might be unavailanle based on the setting", func() {
+	It("should recognize whether the instance might be unavailable based on the setting", func() {
 		instance.SetMightBeUnavailable(false)
 		unAvailable := instance.MightBeUnavailable()
 		Expect(unAvailable).To(BeFalse())


### PR DESCRIPTION
I'm troubleshooting a situation on Tembo cloud. I'm manually breaking an instance on purpose to check how error reporting will work.

I ran `ALTER SYSTEM SET shared_preload_libraries = 'oopsies';`, then restarted my instance using the restartedAt annotation. Now, my instance is stuck in readiness 0/1 but liveness probe is passing, however I expected liveness probe to fail because pg_isready is not success. I found liveness probe is passing because the condition "MightBeUnavailable" is true, but I don't know why that is yet, currently I suspect it's related to triggering a restart.

I noticed this typo in the test while reviewing how "MightBeUnavailable" works.