### PR TITLE
fix(docs): Cron schedule expression in ScheduledBackup

### DIFF
--- a/docs/src/backup.md
+++ b/docs/src/backup.md
@@ -164,8 +164,9 @@ CloudNativePG. They are managed by the `ScheduledBackup` resource.
     Please refer to [`ScheduledBackupSpec`](cloudnative-pg.v1.md#postgresql-cnpg-io-v1-ScheduledBackupSpec)
     in the API reference for a full list of options.
 
-The `schedule` field allows you to define a *cron schedule* specification,
-expressed in the [Go `cron` package format](https://pkg.go.dev/github.com/robfig/cron#hdr-CRON_Expression_Format).
+The `schedule` field allows you to define a *six-term cron schedule* specification,
+which includes seconds, as expressed in
+the [Go `cron` package format](https://pkg.go.dev/github.com/robfig/cron#hdr-CRON_Expression_Format).
 
 !!! Warning
     Beware that this format accepts also the `seconds` field, and it is
@@ -185,7 +186,12 @@ spec:
     name: pg-backup
 ```
 
-The above example will schedule a backup every day at midnight.
+The above example will schedule a backup every day at midnight because the schedule
+specifies zero for the second, minute, and hour, while specifying wildcard, meaning all,
+for day of the month, month, and day of the week.
+
+In Kubernetes CronJobs, the equivalent expression is `0 0 * * *` because seconds
+are not included.
 
 !!! Hint
     Backup frequency might impact your recovery time object (RTO) after a


### PR DESCRIPTION
```
  kind: ScheduledBackup
....
  spec:
...
    # Kubernetes would interpret this as a daily backup at 6:42am
    schedule: 42 6 * * *
...
  status:
    # However, it is actually doing hourly backups at 6th minute, 42nd second
    lastCheckTime: "2023-08-17T18:06:42Z"
    lastScheduleTime: "2023-08-17T18:06:42Z"
    nextScheduleTime: "2023-08-17T19:06:42Z"
....
  ```
  
This seems like when I provide a five-term expression, we have the first term as seconds instead of minutes. In my opinion, it should either be interpreted like a kubernetes cron job, or have input validation error if there are only 5 terms.