### PR TITLE
chore: fix linter errors in new version of golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,6 +8,9 @@ linters-settings:
       - prefix(github.com/cloudnative-pg/cloudnative-pg)
       - blank
       - dot
+  gosec:
+    excludes:
+      - G101 # remove this exclude when https://github.com/securego/gosec/issues/1001 is fixed
 
 linters:
   # please, do not use `enable-all`: it's deprecated and will be removed soon.

--- a/api/v1/cluster_webhook.go
+++ b/api/v1/cluster_webhook.go
@@ -1588,6 +1588,7 @@ func (r *Cluster) validateTolerations() field.ErrorList {
 	path := field.NewPath("spec", "affinity", "toleration")
 	allErrors := field.ErrorList{}
 	for i, toleration := range r.Spec.Affinity.Tolerations {
+		toleration := toleration
 		idxPath := path.Index(i)
 		// validate the toleration key
 		if len(toleration.Key) > 0 {

--- a/pkg/management/barman/backupdelete.go
+++ b/pkg/management/barman/backupdelete.go
@@ -134,6 +134,7 @@ func DeleteBackupsNotInCatalog(
 
 	var errors []error
 	for id, backup := range backups.Items {
+		backup := backup
 		if backup.Spec.Cluster.Name != cluster.GetName() ||
 			backup.Status.Phase != v1.BackupPhaseCompleted ||
 			!useSameBackupLocation(&backup.Status, cluster) {

--- a/pkg/management/postgres/restore.go
+++ b/pkg/management/postgres/restore.go
@@ -413,9 +413,7 @@ func (info InitInfo) writeRestoreWalConfig(backup *apiv1.Backup, cluster *apiv1.
 		return fmt.Errorf("cannot detect major version: %w", err)
 	}
 
-	const barmanCloudWalRestoreName = "barman-cloud-wal-restore"
-
-	cmd := []string{barmanCloudWalRestoreName}
+	cmd := []string{barmanCapabilities.BarmanCloudWalRestore}
 	if backup.Status.EndpointURL != "" {
 		cmd = append(cmd, "--endpoint-url", backup.Status.EndpointURL)
 	}


### PR DESCRIPTION
After upgrading to golangci-lint 1.54.2 some new linter errors were detected. Also the new version of gosec linter 2.17.0 comes with an error that makes it to detect any variable longer than 24 as possible problem for G101, declared here https://github.com/securego/gosec/issues/1001 hence, that linter was disabled for now.