### PR TITLE
fix: encode podSpec annotation in JSON

### DIFF
--- a/controllers/cluster_upgrade.go
+++ b/controllers/cluster_upgrade.go
@@ -18,6 +18,7 @@ package controllers
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -569,7 +570,7 @@ func checkPodSpecIsOutdated(
 	}
 
 	var storedPodSpec corev1.PodSpec
-	err := (&storedPodSpec).Unmarshal([]byte(podSpecAnnotation))
+	err := json.Unmarshal([]byte(podSpecAnnotation), &storedPodSpec)
 	if err != nil {
 		return rollout{}, fmt.Errorf("while unmarshaling the pod resources annotation: %w", err)
 	}

--- a/pkg/specs/pods.go
+++ b/pkg/specs/pods.go
@@ -19,6 +19,7 @@ limitations under the License.
 package specs
 
 import (
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"strconv"
@@ -380,7 +381,7 @@ func PodWithExistingStorage(cluster apiv1.Cluster, nodeSerial int) *corev1.Pod {
 		Spec: podSpec,
 	}
 
-	if podSpecMarshaled, err := podSpec.Marshal(); err == nil {
+	if podSpecMarshaled, err := json.Marshal(podSpec); err == nil {
 		pod.Annotations[utils.PodSpecAnnotationName] = string(podSpecMarshaled)
 	}
 


### PR DESCRIPTION
In #2243 we encoded the podSpec annotation using the PB protocol. This commit changes the encoding to JSON.