### PR TITLE
fix: use correct endpointURL in Linode example (#2629)

### DIFF
--- a/docs/src/appendixes/object_stores.md
+++ b/docs/src/appendixes/object_stores.md
@@ -110,8 +110,8 @@ kind: Cluster
 spec:
   backup:
     barmanObjectStore:
-      destinationPath: "<destination path here>"
-      endpointURL: "https://bucket.us-east1.linodeobjects.com"
+      destinationPath: "s3://bucket/"
+      endpointURL: "https://us-east1.linodeobjects.com"
       s3Credentials:
         [...]
 ```


### PR DESCRIPTION
Updates the endpointURL for the Linode example in object_stores.md so that it does not include the bucket name and moves the bucket name into the S3 URL provided to destinationPath.

This is based on the recommendations in the current Linode documentation at:

    https://www.linode.com/docs/products/storage/object-storage/guides/urls/#cluster-url-s3-endpoint

Closes #2629