### PR TITLE
chore: add documentation and E2E tests for Replica Clusters from VolumeSnapshot

### DIFF
--- a/docs/src/replica_cluster.md
+++ b/docs/src/replica_cluster.md
@@ -92,6 +92,8 @@ file and define the following parts accordingly:
   we need to do is to enable the replica mode through option `spec.replica.enabled`
   and set the `externalClusters` name in option `spec.replica.source`
 
+#### Example using pg_basebackup
+
 This **first example** defines a replica cluster using streaming replication in
 both bootstrap and continuous recovery. The replica cluster connects to the
 source cluster using TLS authentication.
@@ -134,6 +136,8 @@ in case the replica cluster is in a separate namespace.
       name: <MAIN-CLUSTER>-ca
       key: ca.crt
 ```
+
+#### Example using a Backup from an object store
 
 The **second example** defines a replica cluster that bootstraps from an object
 store using the `recovery` section and continuous recovery using both streaming
@@ -182,6 +186,18 @@ a backup of the source cluster has been created already.
     cluster, we need to make sure there is network connectivity between the two
     clusters, and that all the necessary secrets which hold passwords or
     certificates are properly created in advance.
+
+#### Example using a Volume Snapshot
+
+In case you are using volume snapshots, and your storage class provides
+cross-clusters availability of the snapshots, you can leaverage that to
+bootstrap a replica cluster through a volume snapshot of the source cluster.
+This **third example** defines a replica cluster that bootstraps from a volume
+snapshot using the `recovery` section. It uses both streaming replication
+(via basic authentication) and the object store to fetch the WAL files.
+
+You can check the [sample YAML](samples/cluster-example-replica-from-volume-snapshot.yaml)
+for it in the `samples/` subdirectory.
 
 ## Promoting the designated primary in the replica cluster
 

--- a/docs/src/replica_cluster.md
+++ b/docs/src/replica_cluster.md
@@ -189,12 +189,15 @@ a backup of the source cluster has been created already.
 
 #### Example using a Volume Snapshot
 
-In case you are using volume snapshots, and your storage class provides
-cross-clusters availability of the snapshots, you can leverage that to
-bootstrap a replica cluster through a volume snapshot of the source cluster.
-This **third example** defines a replica cluster that bootstraps from a volume
-snapshot using the `recovery` section. It uses both streaming replication
-(via basic authentication) and the object store to fetch the WAL files.
+If you use volume snapshots and your storage class provides
+snapshots cross-cluster availability, you can leverage that to
+bootstrap a replica cluster through a volume snapshot of the
+source cluster.
+
+The **third example** defines a replica cluster that bootstraps
+from a volume snapshot using the `recovery` section. It uses
+streaming replication (via basic authentication) and the object
+store to fetch the WAL files.
 
 You can check the [sample YAML](samples/cluster-example-replica-from-volume-snapshot.yaml)
 for it in the `samples/` subdirectory.

--- a/docs/src/replica_cluster.md
+++ b/docs/src/replica_cluster.md
@@ -190,7 +190,7 @@ a backup of the source cluster has been created already.
 #### Example using a Volume Snapshot
 
 In case you are using volume snapshots, and your storage class provides
-cross-clusters availability of the snapshots, you can leaverage that to
+cross-clusters availability of the snapshots, you can leverage that to
 bootstrap a replica cluster through a volume snapshot of the source cluster.
 This **third example** defines a replica cluster that bootstraps from a volume
 snapshot using the `recovery` section. It uses both streaming replication

--- a/docs/src/samples.md
+++ b/docs/src/samples.md
@@ -45,7 +45,7 @@ PostGIS example
 : [`postgis-example.yaml`](samples/postgis-example.yaml):
    an example of "PostGIS cluster" (see the [PostGIS section](postgis.md) for details.)
 
-Replica cluster via streaming
+Replica cluster via streaming (pg_basebackup)
 :   **Prerequisites**: [`cluster-example.yaml`](samples/cluster-example.yaml)
     applied and Healthy
 :   [`cluster-example-replica-streaming.yaml`](samples/cluster-example-replica-streaming.yaml): a replica cluster following `cluster-example` with streaming replication.
@@ -56,7 +56,7 @@ Simple cluster with backup configured
 :  [`cluster-example-with-backup.yaml`](samples/cluster-example-with-backup.yaml)
    a basic cluster with backups configured.
 
-Replica cluster via backup
+Replica cluster via Backup from an object store
 :   **Prerequisites**:
     [`cluster-storage-class-with-backup.yaml`](samples/cluster-storage-class-with-backup.yaml) applied and Healthy.
     And a backup
@@ -64,6 +64,15 @@ Replica cluster via backup
     applied and Completed.
 : [`cluster-example-replica-from-backup-simple.yaml`](samples/cluster-example-replica-from-backup-simple.yaml):
    a replica cluster following a cluster with backup configured.
+
+Replica cluster via Volume Snapshot
+:   **Prerequisites**:
+    [`cluster-example-with-volume-snapshot.yaml`](samples/cluster-example-with-volume-snapshot.yaml) applied and Healthy.
+    And a volume snapshot
+    [`backup-with-volume-snapshot.yaml`](samples/backup-with-volume-snapshot.yaml)
+    applied and Completed.
+: [`cluster-example-replica-from-volume-snapshot.yaml`](samples/cluster-example-replica-from-volume-snapshot.yaml):
+   a replica cluster following a cluster with volume snapshot configured.
 
 Bootstrap cluster with SQL files
 : [`cluster-example-initdb-sql-refs.yaml`](samples/cluster-example-initdb-sql-refs.yaml):

--- a/docs/src/samples/backup-with-volume-snapshot.yaml
+++ b/docs/src/samples/backup-with-volume-snapshot.yaml
@@ -1,0 +1,8 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Backup
+metadata:
+  name: backup-with-volume-snapshot
+spec:
+  method: volumeSnapshot
+  cluster:
+    name: cluster-example-with-volume-snapshot

--- a/docs/src/samples/cluster-example-replica-from-volume-snapshot.yaml
+++ b/docs/src/samples/cluster-example-replica-from-volume-snapshot.yaml
@@ -1,0 +1,54 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: cluster-example-replica-from-snapshot
+spec:
+  instances: 1
+
+  storage:
+    storageClass: csi-hostpath-sc
+    size: 1Gi
+  walStorage:
+    storageClass: csi-hostpath-sc
+    size: 1Gi
+
+  bootstrap:
+    recovery:
+      source: cluster-example-with-volume-snapshot
+      volumeSnapshots:
+        storage:
+          name: cluster-example-with-volume-snapshot-2-1692618163
+          kind: VolumeSnapshot
+          apiGroup: snapshot.storage.k8s.io
+        walStorage:
+          name: cluster-example-with-volume-snapshot-2-wal-1692618163
+          kind: VolumeSnapshot
+          apiGroup: snapshot.storage.k8s.io
+
+  replica:
+    enabled: true
+    source: cluster-example-with-volume-snapshot
+
+  externalClusters:
+    - name: cluster-example-with-volume-snapshot
+
+      connectionParameters:
+        host: cluster-example-with-volume-snapshot-rw.default.svc
+        user: postgres
+        dbname: postgres
+      password:
+        name: cluster-example-with-volume-snapshot-superuser
+        key: password
+
+      barmanObjectStore:
+        destinationPath: s3://backups/
+        endpointURL: http://minio:9000
+        s3Credentials:
+          accessKeyId:
+            name: minio
+            key: ACCESS_KEY_ID
+          secretAccessKey:
+            name: minio
+            key: ACCESS_SECRET_KEY
+        wal:
+          maxParallel: 8

--- a/docs/src/samples/cluster-example-replica-streaming.yaml
+++ b/docs/src/samples/cluster-example-replica-streaming.yaml
@@ -10,7 +10,7 @@ spec:
       source: cluster-example
 
   replica:
-    enabled: false
+    enabled: true
     source: cluster-example
 
   storage:

--- a/docs/src/samples/cluster-example-with-volume-snapshot.yaml
+++ b/docs/src/samples/cluster-example-with-volume-snapshot.yaml
@@ -1,0 +1,32 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: cluster-example-with-volume-snapshot
+spec:
+  instances: 3
+  primaryUpdateStrategy: unsupervised
+
+  # Persistent storage configuration
+  storage:
+    storageClass: csi-hostpath-sc
+    size: 1Gi
+  walStorage:
+    storageClass: csi-hostpath-sc
+    size: 1Gi
+
+  # Backup properties
+  backup:
+    volumeSnapshot:
+       className: csi-hostpath-snapclass
+    barmanObjectStore:
+      destinationPath: s3://backups/
+      endpointURL: http://minio:9000
+      s3Credentials:
+        accessKeyId:
+          name: minio
+          key: ACCESS_KEY_ID
+        secretAccessKey:
+          name: minio
+          key: ACCESS_SECRET_KEY
+      wal:
+        compression: gzip

--- a/tests/e2e/asserts_test.go
+++ b/tests/e2e/asserts_test.go
@@ -880,12 +880,11 @@ func AssertDetachReplicaModeCluster(
 	srcTableName string,
 ) {
 	var primaryReplicaCluster *corev1.Pod
-	var err error
 	replicaCommandTimeout := time.Second * 10
 
 	By("disabling the replica mode", func() {
 		Eventually(func(g Gomega) {
-			_, _, err = testsUtils.RunUnchecked(fmt.Sprintf(
+			_, _, err := testsUtils.RunUnchecked(fmt.Sprintf(
 				"kubectl patch cluster %v -n %v  -p '{\"spec\":{\"replica\":{\"enabled\":false}}}'"+
 					" --type='merge'",
 				replicaClusterName, namespace))
@@ -897,6 +896,8 @@ func AssertDetachReplicaModeCluster(
 		query := "CREATE TABLE IF NOT EXISTS replica_cluster_primary AS VALUES (1),(2);"
 		// Expect write operation to succeed
 		Eventually(func(g Gomega) {
+			var err error
+
 			// Get primary from replica cluster
 			primaryReplicaCluster, err = env.GetClusterPrimary(namespace, replicaClusterName)
 			g.Expect(err).ToNot(HaveOccurred())
@@ -906,7 +907,7 @@ func AssertDetachReplicaModeCluster(
 		}, 300, 15).Should(Succeed())
 	})
 
-	By("verifying the appTgt database doesn't exist in the replica cluster", func() {
+	By("verifying the replica database doesn't exist in the replica cluster", func() {
 		AssertDatabaseExists(namespace, primaryReplicaCluster.Name, replicaDatabaseName, false)
 	})
 

--- a/tests/e2e/fixtures/replica_mode_cluster/cluster-replica-from-backup.yaml.template
+++ b/tests/e2e/fixtures/replica_mode_cluster/cluster-replica-from-backup.yaml.template
@@ -1,0 +1,47 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: cluster-replica-from-backup
+spec:
+  instances: 1
+
+  # Persistent storage configuration
+  storage:
+    storageClass: ${E2E_DEFAULT_STORAGE_CLASS}
+    size: 1Gi
+  walStorage:
+    storageClass: ${E2E_DEFAULT_STORAGE_CLASS}
+    size: 1Gi
+
+  replica:
+    enabled: true
+    source: cluster-replica-src
+
+  bootstrap:
+    recovery:
+      source: cluster-replica-src
+
+  externalClusters:
+    - name: cluster-replica-src
+
+      connectionParameters:
+        host: cluster-replica-src-rw
+        user: postgres
+        dbname: postgres
+        port: "5432"
+      password:
+        name: cluster-replica-src-superuser
+        key: password
+
+      barmanObjectStore:
+        destinationPath: s3://cluster-backups/
+        endpointURL: http://minio-service:9000
+        s3Credentials:
+          accessKeyId:
+            name: backup-storage-creds
+            key: ID
+          secretAccessKey:
+            name: backup-storage-creds
+            key: KEY
+        wal:
+          compression: gzip

--- a/tests/e2e/fixtures/replica_mode_cluster/cluster-replica-from-snapshot.yaml.template
+++ b/tests/e2e/fixtures/replica_mode_cluster/cluster-replica-from-snapshot.yaml.template
@@ -1,0 +1,56 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: cluster-replica-from-snapshot
+spec:
+  instances: 1
+
+  # Persistent storage configuration
+  storage:
+    storageClass: ${E2E_CSI_STORAGE_CLASS}
+    size: 1Gi
+  walStorage:
+    storageClass: ${E2E_CSI_STORAGE_CLASS}
+    size: 1Gi
+
+  replica:
+    enabled: true
+    source: cluster-replica-src
+
+  bootstrap:
+    recovery:
+      source: cluster-replica-src
+      volumeSnapshots:
+        storage:
+          name: ${REPLICA_CLUSTER_SNAPSHOT_NAME_PGDATA}
+          kind: VolumeSnapshot
+          apiGroup: snapshot.storage.k8s.io
+        walStorage:
+          name: ${REPLICA_CLUSTER_SNAPSHOT_NAME_PGWAL}
+          kind: VolumeSnapshot
+          apiGroup: snapshot.storage.k8s.io
+
+  externalClusters:
+    - name: cluster-replica-src
+
+      connectionParameters:
+        host: cluster-replica-src-rw
+        user: postgres
+        dbname: postgres
+        port: "5432"
+      password:
+        name: cluster-replica-src-superuser
+        key: password
+
+      barmanObjectStore:
+        destinationPath: s3://cluster-backups/
+        endpointURL: http://minio-service:9000
+        s3Credentials:
+          accessKeyId:
+            name: backup-storage-creds
+            key: ID
+          secretAccessKey:
+            name: backup-storage-creds
+            key: KEY
+        wal:
+          compression: gzip

--- a/tests/e2e/fixtures/replica_mode_cluster/cluster-replica-src-with-backup.yaml.template
+++ b/tests/e2e/fixtures/replica_mode_cluster/cluster-replica-src-with-backup.yaml.template
@@ -1,0 +1,50 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: cluster-replica-src
+spec:
+  instances: 2
+
+  # Persistent storage configuration
+  storage:
+    storageClass: ${E2E_CSI_STORAGE_CLASS}
+    size: 1Gi
+  walStorage:
+    storageClass: ${E2E_CSI_STORAGE_CLASS}
+    size: 1Gi
+
+  bootstrap:
+    initdb:
+      database: appSrc
+      owner: userSrc
+
+  postgresql:
+    parameters:
+      log_checkpoints: "on"
+      log_lock_waits: "on"
+      log_min_duration_statement: '1000'
+      log_statement: 'ddl'
+      log_temp_files: '1024'
+      log_autovacuum_min_duration: '1s'
+      log_replication_commands: 'on'
+    pg_hba:
+      - host replication postgres all md5
+      - hostssl app streaming_replica all cert
+
+  backup:
+    volumeSnapshot:
+      className: ${E2E_DEFAULT_VOLUMESNAPSHOT_CLASS}
+    barmanObjectStore:
+      destinationPath: s3://cluster-backups/
+      endpointURL: http://minio-service:9000
+      s3Credentials:
+        accessKeyId:
+          name: backup-storage-creds
+          key: ID
+        secretAccessKey:
+          name: backup-storage-creds
+          key: KEY
+      wal:
+        compression: gzip
+      data:
+        immediateCheckpoint: true

--- a/tests/e2e/metrics_test.go
+++ b/tests/e2e/metrics_test.go
@@ -248,11 +248,13 @@ var _ = Describe("Metrics", Label(tests.LabelObservability), func() {
 			curlPodName = curlClient.GetName()
 		})
 
+		// Create the source Cluster
+		AssertCreateCluster(namespace, srcClusterName, srcClusterSampleFile, env)
+
+		// Create the replica Cluster
 		AssertReplicaModeCluster(
 			namespace,
 			srcClusterName,
-			srcClusterSampleFile,
-			replicaClusterName,
 			replicaClusterSampleFile,
 			checkQuery,
 			psqlClientPod)

--- a/tests/e2e/replica_mode_cluster_test.go
+++ b/tests/e2e/replica_mode_cluster_test.go
@@ -18,14 +18,19 @@ package e2e
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
-	corev1 "k8s.io/api/core/v1"
+	volumesnapshot "github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1"
+	"k8s.io/apimachinery/pkg/types"
+	k8client "sigs.k8s.io/controller-runtime/pkg/client"
 
+	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/specs"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 	"github.com/cloudnative-pg/cloudnative-pg/tests"
-	"github.com/cloudnative-pg/cloudnative-pg/tests/utils"
+	testUtils "github.com/cloudnative-pg/cloudnative-pg/tests/utils"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -46,18 +51,11 @@ var _ = Describe("Replica Mode", Label(tests.LabelReplication), func() {
 		}
 	})
 
-	// Setting variables
-	var replicaClusterName, replicaNamespace string
-	replicaCommandTimeout := time.Second * 10
-
 	Context("can bootstrap a replica cluster using TLS auth", func() {
-		const replicaClusterSampleTLS = fixturesDir + replicaModeClusterDir + "cluster-replica-tls.yaml.template"
-
 		It("should work", func() {
+			const replicaClusterSampleTLS = fixturesDir + replicaModeClusterDir + "cluster-replica-tls.yaml.template"
 			replicaNamespacePrefix := "replica-mode-tls-auth"
-			replicaClusterName = "cluster-replica-tls"
-			var err error
-			replicaNamespace, err = env.CreateUniqueNamespace(replicaNamespacePrefix)
+			replicaNamespace, err := env.CreateUniqueNamespace(replicaNamespacePrefix)
 			Expect(err).ToNot(HaveOccurred())
 			DeferCleanup(func() error {
 				if CurrentSpecReport().Failed() {
@@ -65,11 +63,10 @@ var _ = Describe("Replica Mode", Label(tests.LabelReplication), func() {
 				}
 				return env.DeleteNamespace(replicaNamespace)
 			})
+			AssertCreateCluster(replicaNamespace, srcClusterName, srcClusterSample, env)
 			AssertReplicaModeCluster(
 				replicaNamespace,
 				srcClusterName,
-				srcClusterSample,
-				replicaClusterName,
 				replicaClusterSampleTLS,
 				checkQuery,
 				psqlClientPod)
@@ -77,15 +74,12 @@ var _ = Describe("Replica Mode", Label(tests.LabelReplication), func() {
 	})
 
 	Context("can bootstrap a replica cluster using basic auth", func() {
-		const replicaClusterSampleBasicAuth = fixturesDir + replicaModeClusterDir + "cluster-replica-basicauth.yaml.template"
-
-		var primaryReplicaCluster *corev1.Pod
-		var err error
-
-		It("still works detached from remote server promoting the designated primary", func() {
+		It("can be detached from the source cluster", func() {
+			const replicaClusterSampleBasicAuth = fixturesDir + replicaModeClusterDir + "cluster-replica-basicauth.yaml.template"
+			replicaClusterName, err := env.GetResourceNameFromYAML(replicaClusterSampleBasicAuth)
+			Expect(err).ToNot(HaveOccurred())
 			replicaNamespacePrefix := "replica-mode-basic-auth"
-			replicaClusterName = "cluster-replica-basicauth"
-			replicaNamespace, err = env.CreateUniqueNamespace(replicaNamespacePrefix)
+			replicaNamespace, err := env.CreateUniqueNamespace(replicaNamespacePrefix)
 			Expect(err).ToNot(HaveOccurred())
 			DeferCleanup(func() error {
 				if CurrentSpecReport().Failed() {
@@ -93,65 +87,32 @@ var _ = Describe("Replica Mode", Label(tests.LabelReplication), func() {
 				}
 				return env.DeleteNamespace(replicaNamespace)
 			})
+			AssertCreateCluster(replicaNamespace, srcClusterName, srcClusterSample, env)
 			AssertReplicaModeCluster(
 				replicaNamespace,
 				srcClusterName,
-				srcClusterSample,
-				replicaClusterName,
 				replicaClusterSampleBasicAuth,
 				checkQuery,
 				psqlClientPod)
 
-			By("disabling the replica mode", func() {
-				Eventually(func() error {
-					_, _, err = utils.RunUnchecked(fmt.Sprintf(
-						"kubectl patch cluster %v -n %v  -p '{\"spec\":{\"replica\":{\"enabled\":false}}}'"+
-							" --type='merge'",
-						replicaClusterName, replicaNamespace))
-					if err != nil {
-						return err
-					}
-					return nil
-				}, 60, 5).Should(BeNil())
-			})
-
-			By("verifying write operation on the replica cluster primary pod", func() {
-				query := "CREATE TABLE IF NOT EXISTS replica_cluster_primary AS VALUES (1),(2);"
-				// Expect write operation to succeed
-				Eventually(func() error {
-					// Get primary from replica cluster
-					primaryReplicaCluster, err = env.GetClusterPrimary(replicaNamespace, replicaClusterName)
-					if err != nil {
-						return err
-					}
-					_, _, err = env.EventuallyExecCommand(env.Ctx, *primaryReplicaCluster, specs.PostgresContainerName,
-						&replicaCommandTimeout, "psql", "-U", "postgres", "appSrc", "-tAc", query)
-					return err
-				}, 300, 15).ShouldNot(HaveOccurred())
-			})
-
-			By("verifying the appTgt database not exist in replica cluster", func() {
-				AssertDatabaseExists(replicaNamespace, primaryReplicaCluster.Name, "appTgt", false)
-			})
-
-			By("writing some new data to the source cluster", func() {
-				insertRecordIntoTableWithDatabaseName(replicaNamespace, srcClusterName, "appSrc", "test_replica", 4, psqlClientPod)
-			})
-
-			By("verifying that replica cluster was not modified", func() {
-				AssertDataExpectedCountWithDatabaseName(replicaNamespace, primaryReplicaCluster.Name, "appSrc", "test_replica", 3)
-			})
+			AssertDetachReplicaModeCluster(
+				replicaNamespace,
+				srcClusterName,
+				replicaClusterName,
+				"appSrc",
+				"appTgt",
+				"test_replica")
 		})
 	})
 
 	Context("archive mode set to 'always' on designated primary", func() {
-		It("verify replica cluster can archive WALs from the designated primary", func() {
-			const replicaClusterSample = fixturesDir + replicaModeClusterDir +
-				"cluster-replica-archive-mode-always.yaml.template"
-
+		It("verifies replica cluster can archive WALs from the designated primary", func() {
+			const replicaClusterSample = fixturesDir +
+				replicaModeClusterDir + "cluster-replica-archive-mode-always.yaml.template"
+			replicaClusterName, err := env.GetResourceNameFromYAML(replicaClusterSample)
+			Expect(err).ToNot(HaveOccurred())
 			replicaNamespacePrefix := "replica-mode-archive"
-			var err error
-			replicaNamespace, err = env.CreateUniqueNamespace(replicaNamespacePrefix)
+			replicaNamespace, err := env.CreateUniqueNamespace(replicaNamespacePrefix)
 			Expect(err).ToNot(HaveOccurred())
 			DeferCleanup(func() error {
 				if CurrentSpecReport().Failed() {
@@ -159,30 +120,27 @@ var _ = Describe("Replica Mode", Label(tests.LabelReplication), func() {
 				}
 				return env.DeleteNamespace(replicaNamespace)
 			})
-			replicaClusterName, err := env.GetResourceNameFromYAML(replicaClusterSample)
-			Expect(err).ToNot(HaveOccurred())
 			By("creating the credentials for minio", func() {
 				AssertStorageCredentialsAreCreated(replicaNamespace, "backup-storage-creds", "minio", "minio123")
 			})
 			By("setting up minio", func() {
-				minio, err := utils.MinioDefaultSetup(replicaNamespace)
+				minio, err := testUtils.MinioDefaultSetup(replicaNamespace)
 				Expect(err).ToNot(HaveOccurred())
-				err = utils.InstallMinio(env, minio, uint(testTimeouts[utils.MinioInstallation]))
+				err = testUtils.InstallMinio(env, minio, uint(testTimeouts[testUtils.MinioInstallation]))
 				Expect(err).ToNot(HaveOccurred())
 			})
 			// Create the minio client pod and wait for it to be ready.
 			// We'll use it to check if everything is archived correctly
 			By("setting up minio client pod", func() {
-				minioClient := utils.MinioDefaultClient(replicaNamespace)
-				err := utils.PodCreateAndWaitForReady(env, &minioClient, 240)
+				minioClient := testUtils.MinioDefaultClient(replicaNamespace)
+				err := testUtils.PodCreateAndWaitForReady(env, &minioClient, 240)
 				Expect(err).ToNot(HaveOccurred())
 			})
 
+			AssertCreateCluster(replicaNamespace, srcClusterName, srcClusterSample, env)
 			AssertReplicaModeCluster(
 				replicaNamespace,
 				srcClusterName,
-				srcClusterSample,
-				replicaClusterName,
 				replicaClusterSample,
 				checkQuery,
 				psqlClientPod)
@@ -205,6 +163,148 @@ var _ = Describe("Replica Mode", Label(tests.LabelReplication), func() {
 				// only replica cluster has backup configure to minio,
 				// need the server name  be replica cluster name here
 				AssertArchiveWalOnMinio(replicaNamespace, srcClusterName, replicaClusterName)
+			})
+		})
+	})
+
+	Context("can bootstrap a replica cluster from a backup", func() {
+		const (
+			clusterSample   = fixturesDir + replicaModeClusterDir + "cluster-replica-src-with-backup.yaml.template"
+			namespacePrefix = "replica-cluster-from-backup"
+		)
+		var namespace, clusterName string
+		var err error
+
+		BeforeEach(func() {
+			namespace, err = env.CreateUniqueNamespace(namespacePrefix)
+			Expect(err).ToNot(HaveOccurred())
+			clusterName, err = env.GetResourceNameFromYAML(clusterSample)
+			Expect(err).ToNot(HaveOccurred())
+
+			DeferCleanup(func() error {
+				if CurrentSpecReport().Failed() {
+					env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
+				}
+				return env.DeleteNamespace(namespace)
+			})
+
+			By("creating the credentials for minio", func() {
+				AssertStorageCredentialsAreCreated(namespace, "backup-storage-creds", "minio", "minio123")
+			})
+
+			By("setting up minio", func() {
+				minio, err := testUtils.MinioDefaultSetup(namespace)
+				Expect(err).ToNot(HaveOccurred())
+				err = testUtils.InstallMinio(env, minio, uint(testTimeouts[testUtils.MinioInstallation]))
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			// Create the minio client pod and wait for it to be ready.
+			// We'll use it to check if everything is archived correctly
+			By("setting up minio client pod", func() {
+				minioClient := testUtils.MinioDefaultClient(namespace)
+				err := testUtils.PodCreateAndWaitForReady(env, &minioClient, 240)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			// Create the cluster
+			AssertCreateCluster(namespace, clusterName, clusterSample, env)
+		})
+
+		It("using a Backup from the object store", func() {
+			const replicaClusterSample = fixturesDir + replicaModeClusterDir + "cluster-replica-from-backup.yaml.template"
+
+			By("creating a backup and waiting until it's completed", func() {
+				backupName := fmt.Sprintf("%v-backup", clusterName)
+				backup, err := testUtils.CreateOnDemandBackup(
+					namespace,
+					clusterName,
+					backupName,
+					apiv1.BackupTargetStandby,
+					apiv1.BackupMethodBarmanObjectStore,
+					env)
+				Expect(err).ToNot(HaveOccurred())
+
+				Eventually(func() (apiv1.BackupPhase, error) {
+					err = env.Client.Get(env.Ctx, types.NamespacedName{
+						Namespace: namespace,
+						Name:      backupName,
+					}, backup)
+					return backup.Status.Phase, err
+				}, testTimeouts[testUtils.BackupIsReady]).Should(BeEquivalentTo(apiv1.BackupPhaseCompleted))
+			})
+
+			By("creating a replica cluster from the backup", func() {
+				AssertReplicaModeCluster(
+					namespace,
+					clusterName,
+					replicaClusterSample,
+					checkQuery,
+					psqlClientPod)
+			})
+		})
+
+		It("using a Volume Snapshot", func() {
+			const (
+				replicaClusterSample = fixturesDir + replicaModeClusterDir + "cluster-replica-from-snapshot.yaml.template"
+				snapshotDataEnv      = "REPLICA_CLUSTER_SNAPSHOT_NAME_PGDATA"
+				snapshotWalEnv       = "REPLICA_CLUSTER_SNAPSHOT_NAME_PGWAL"
+			)
+
+			DeferCleanup(func() error {
+				err := os.Unsetenv(snapshotDataEnv)
+				if err != nil {
+					return err
+				}
+				err = os.Unsetenv(snapshotWalEnv)
+				if err != nil {
+					return err
+				}
+				return nil
+			})
+
+			var backup *apiv1.Backup
+			By("creating a snapshot and waiting until it's completed", func() {
+				snapshotName := fmt.Sprintf("%v-snapshot", clusterName)
+				backup, err = testUtils.CreateOnDemandBackup(
+					namespace,
+					clusterName,
+					snapshotName,
+					apiv1.BackupTargetStandby,
+					apiv1.BackupMethodVolumeSnapshot,
+					env)
+				Expect(err).ToNot(HaveOccurred())
+
+				Eventually(func(g Gomega) {
+					err = env.Client.Get(env.Ctx, types.NamespacedName{
+						Namespace: namespace,
+						Name:      snapshotName,
+					}, backup)
+					g.Expect(err).ToNot(HaveOccurred())
+					g.Expect(backup.Status.BackupSnapshotStatus.Snapshots).To(HaveLen(2))
+					g.Expect(backup.Status.Phase).To(BeEquivalentTo(apiv1.BackupPhaseCompleted))
+				}, testTimeouts[testUtils.BackupIsReady]).Should(Succeed())
+			})
+
+			By("fetching the volume snapshots", func() {
+				snapshotList := volumesnapshot.VolumeSnapshotList{}
+				err := env.Client.List(env.Ctx, &snapshotList, k8client.MatchingLabels{
+					utils.ClusterLabelName: clusterName,
+				})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(snapshotList.Items).To(HaveLen(len(backup.Status.BackupSnapshotStatus.Snapshots)))
+
+				err = testUtils.SetSnapshotNameAsEnv(&snapshotList, snapshotDataEnv, snapshotWalEnv)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			By("creating a replica cluster from the snapshot", func() {
+				AssertReplicaModeCluster(
+					namespace,
+					clusterName,
+					replicaClusterSample,
+					checkQuery,
+					psqlClientPod)
 			})
 		})
 	})

--- a/tests/e2e/volume_snapshot_test.go
+++ b/tests/e2e/volume_snapshot_test.go
@@ -301,12 +301,10 @@ var _ = Describe("Verify Volume Snapshot",
 					if CurrentSpecReport().Failed() {
 						env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
 					}
-					err = os.Unsetenv(snapshotDataEnv)
-					if err != nil {
+					if err := os.Unsetenv(snapshotDataEnv); err != nil {
 						return err
 					}
-					err = os.Unsetenv(snapshotWalEnv)
-					if err != nil {
+					if err := os.Unsetenv(snapshotWalEnv); err != nil {
 						return err
 					}
 					return env.DeleteNamespace(namespace)

--- a/tests/utils/backup.go
+++ b/tests/utils/backup.go
@@ -511,3 +511,44 @@ func CreateVolumeSnapshotBackup(
 	_, _, err := Run(command)
 	return err
 }
+
+// CreateOnDemandBackup creates a Backup resource for a given cluster name
+func CreateOnDemandBackup(
+	namespace,
+	clusterName,
+	backupName string,
+	target apiv1.BackupTarget,
+	method apiv1.BackupMethod,
+	env *TestingEnvironment,
+) (*apiv1.Backup, error) {
+	targetBackup := &apiv1.Backup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      backupName,
+			Namespace: namespace,
+		},
+		Spec: apiv1.BackupSpec{
+			Cluster: apiv1.LocalObjectReference{
+				Name: clusterName,
+			},
+			Target: "",
+			Method: "",
+		},
+	}
+
+	if target != "" {
+		targetBackup.Spec.Target = target
+	}
+	if method != "" {
+		targetBackup.Spec.Method = method
+	}
+
+	obj, err := CreateObject(env, targetBackup)
+	if err != nil {
+		return nil, err
+	}
+	backup, ok := obj.(*apiv1.Backup)
+	if !ok {
+		return nil, fmt.Errorf("created object is not of Backup type: %T %v", obj, obj)
+	}
+	return backup, nil
+}

--- a/tests/utils/backup.go
+++ b/tests/utils/backup.go
@@ -530,8 +530,6 @@ func CreateOnDemandBackup(
 			Cluster: apiv1.LocalObjectReference{
 				Name: clusterName,
 			},
-			Target: "",
-			Method: "",
 		},
 	}
 

--- a/tests/utils/storage.go
+++ b/tests/utils/storage.go
@@ -17,9 +17,15 @@ limitations under the License.
 package utils
 
 import (
+	"fmt"
+	"os"
+
+	volumesnapshot "github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 )
 
 // GetStorageAllowExpansion returns the boolean value of the 'AllowVolumeExpansion' value of the storage class
@@ -81,4 +87,36 @@ func ObjectMatchesAnnotations(
 		}
 	}
 	return true
+}
+
+// SetSnapshotNameAsEnv sets the names of a PG_DATA and a PG_WAL snapshots from a given snapshotList
+// as env variables
+func SetSnapshotNameAsEnv(
+	snapshotList *volumesnapshot.VolumeSnapshotList,
+	dataSnapshotName,
+	walSnapshotName string,
+) error {
+	if len(snapshotList.Items) > 2 {
+		return fmt.Errorf("cannot handle a snapshotList with more than 2 snapshots")
+	}
+	for _, item := range snapshotList.Items {
+		switch utils.PVCRole(item.Labels[utils.PvcRoleLabelName]) {
+		case utils.PVCRolePgData:
+			err := os.Setenv(dataSnapshotName, item.Name)
+			if err != nil {
+				return err
+			}
+		case utils.PVCRolePgWal:
+			err := os.Setenv(walSnapshotName, item.Name)
+			if err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("unrecognized PVC snapshot role: %s, name: %s",
+				item.Labels[utils.PvcRoleLabelName],
+				item.Name,
+			)
+		}
+	}
+	return nil
 }

--- a/tests/utils/storage.go
+++ b/tests/utils/storage.go
@@ -99,6 +99,7 @@ func SetSnapshotNameAsEnv(
 	if len(snapshotList.Items) > 2 {
 		return fmt.Errorf("cannot handle a snapshotList with more than 2 snapshots")
 	}
+
 	for _, item := range snapshotList.Items {
 		switch utils.PVCRole(item.Labels[utils.PvcRoleLabelName]) {
 		case utils.PVCRolePgData:


### PR DESCRIPTION
This PR adds documentation on how to bootstrap a Replica Cluster from Volume Snapshots.
It also adds E2E tests to assert the bootstrap of Replica Clusters from either VolumeSnapshot or object store backup, and it slightly refactors the Replica Clusters E2Es

Closes #2388 