### PR TITLE
chore: add webhook validation for the `resources` stanza

### DIFF
--- a/api/v1/cluster_webhook.go
+++ b/api/v1/cluster_webhook.go
@@ -944,24 +944,28 @@ func (r *Cluster) validateImagePullPolicy() field.ErrorList {
 func (r *Cluster) validateResources() field.ErrorList {
 	var result field.ErrorList
 
-	cpuPopulated := r.Spec.Resources.Requests.Cpu() != nil && r.Spec.Resources.Limits.Cpu() != nil
-	cpuRequestGtThanLimit := r.Spec.Resources.Requests.Cpu().Cmp(*r.Spec.Resources.Limits.Cpu()) > 0
-	if cpuPopulated && cpuRequestGtThanLimit {
-		result = append(result, field.Invalid(
-			field.NewPath("spec", "resources", "requests", "cpu"),
-			r.Spec.Resources.Requests.Cpu().String(),
-			"CPU request is greater than the limit",
-		))
+	cpuPopulated := !r.Spec.Resources.Requests.Cpu().IsZero() && !r.Spec.Resources.Limits.Cpu().IsZero()
+	if cpuPopulated {
+		cpuRequestGtThanLimit := r.Spec.Resources.Requests.Cpu().Cmp(*r.Spec.Resources.Limits.Cpu()) > 0
+		if cpuRequestGtThanLimit {
+			result = append(result, field.Invalid(
+				field.NewPath("spec", "resources", "requests", "cpu"),
+				r.Spec.Resources.Requests.Cpu().String(),
+				"CPU request is greater than the limit",
+			))
+		}
 	}
 
-	memoryPopulated := r.Spec.Resources.Requests.Memory() != nil && r.Spec.Resources.Limits.Memory() != nil
-	memoryRequestGtThanLimit := r.Spec.Resources.Requests.Memory().Cmp(*r.Spec.Resources.Limits.Memory()) > 0
-	if memoryPopulated && memoryRequestGtThanLimit {
-		result = append(result, field.Invalid(
-			field.NewPath("spec", "resources", "requests", "memory"),
-			r.Spec.Resources.Requests.Memory().String(),
-			"Memory request is greater than the limit",
-		))
+	memoryPopulated := !r.Spec.Resources.Requests.Memory().IsZero() && !r.Spec.Resources.Limits.Memory().IsZero()
+	if memoryPopulated {
+		memoryRequestGtThanLimit := r.Spec.Resources.Requests.Memory().Cmp(*r.Spec.Resources.Limits.Memory()) > 0
+		if memoryRequestGtThanLimit {
+			result = append(result, field.Invalid(
+				field.NewPath("spec", "resources", "requests", "memory"),
+				r.Spec.Resources.Requests.Memory().String(),
+				"Memory request is greater than the limit",
+			))
+		}
 	}
 
 	return result

--- a/api/v1/cluster_webhook_test.go
+++ b/api/v1/cluster_webhook_test.go
@@ -3204,4 +3204,28 @@ var _ = Describe("validateResources", func() {
 		errors := cluster.validateResources()
 		Expect(errors).To(BeEmpty())
 	})
+
+	It("returns no errors when CPU request is set but limit is nil", func() {
+		cluster.Spec.Resources.Requests["cpu"] = resource.MustParse("1")
+		errors := cluster.validateResources()
+		Expect(errors).To(BeEmpty())
+	})
+
+	It("returns no errors when CPU limit is set but request is nil", func() {
+		cluster.Spec.Resources.Limits["cpu"] = resource.MustParse("1")
+		errors := cluster.validateResources()
+		Expect(errors).To(BeEmpty())
+	})
+
+	It("returns no errors when Memory request is set but limit is nil", func() {
+		cluster.Spec.Resources.Requests["memory"] = resource.MustParse("1Gi")
+		errors := cluster.validateResources()
+		Expect(errors).To(BeEmpty())
+	})
+
+	It("returns no errors when Memory limit is set but request is nil", func() {
+		cluster.Spec.Resources.Limits["memory"] = resource.MustParse("1Gi")
+		errors := cluster.validateResources()
+		Expect(errors).To(BeEmpty())
+	})
 })


### PR DESCRIPTION
This patch ensures we validate the `resources` stanza before creating the Cluster resources.

This will prevent the operator from indefinitely waiting for the jobs/pods to come online.

Closes #2661 

