### PR TITLE
test: pitr restore failed with invalid timestamp

### DIFF
--- a/tests/utils/time.go
+++ b/tests/utils/time.go
@@ -34,7 +34,7 @@ func GetCurrentTimestamp(namespace, clusterName string, env *TestingEnvironment,
 	if err != nil {
 		return "", err
 	}
-	query := "select CURRENT_TIMESTAMP;"
+	query := "select TO_CHAR(CURRENT_TIMESTAMP,'YYYY-MM-DD HH24:MI:SS');"
 	stdOut, _, err := RunQueryFromPod(
 		podName,
 		host,


### PR DESCRIPTION
This patch fix the failure about invalid time format in e2e test about PITR restore 

closes: #2665 