### PR TITLE
chore: properly quote the values inside LDAP fields for pg_hba.conf

### DIFF
--- a/pkg/management/postgres/configuration.go
+++ b/pkg/management/postgres/configuration.go
@@ -171,7 +171,9 @@ func buildLDAPConfigString(cluster *apiv1.Cluster, ldapBindPassword string) stri
 
 		ldapConfigString += fmt.Sprintf(` ldapbasedn="%s" ldapbinddn="%s" ldapbindpasswd="%s"`,
 			ldapConfig.BindSearchAuth.BaseDN, ldapConfig.BindSearchAuth.BindDN,
-			strings.ReplaceAll(ldapBindPassword, "\n", "\\n"))
+			// if there is a newline, finsh the line with a backslash, and carry on
+			// in the next line. (see https://www.postgresql.org/docs/current/auth-pg-hba-conf.html)
+			strings.ReplaceAll(ldapBindPassword, "\n", "\\\n"))
 		if ldapConfig.BindSearchAuth.SearchFilter != "" {
 			ldapConfigString += fmt.Sprintf(` ldapsearchfilter="%s"`,
 				ldapConfig.BindSearchAuth.SearchFilter)

--- a/pkg/management/postgres/configuration.go
+++ b/pkg/management/postgres/configuration.go
@@ -171,7 +171,7 @@ func buildLDAPConfigString(cluster *apiv1.Cluster, ldapBindPassword string) stri
 
 		ldapConfigString += fmt.Sprintf(` ldapbasedn="%s" ldapbinddn="%s" ldapbindpasswd="%s"`,
 			ldapConfig.BindSearchAuth.BaseDN, ldapConfig.BindSearchAuth.BindDN,
-			strings.ReplaceAll(ldapBindPassword, "\n", "\\\n"))
+			strings.ReplaceAll(ldapBindPassword, "\n", "\\n"))
 		if ldapConfig.BindSearchAuth.SearchFilter != "" {
 			ldapConfigString += fmt.Sprintf(` ldapsearchfilter="%s"`,
 				ldapConfig.BindSearchAuth.SearchFilter)

--- a/pkg/management/postgres/configuration.go
+++ b/pkg/management/postgres/configuration.go
@@ -22,6 +22,7 @@ import (
 	"path"
 	"path/filepath"
 	"sort"
+	"strings"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/configfile"
@@ -136,14 +137,15 @@ func buildLDAPConfigString(cluster *apiv1.Cluster, ldapBindPassword string) stri
 	}
 	ldapConfig := cluster.Spec.PostgresConfiguration.LDAP
 
-	ldapConfigString += fmt.Sprintf("host all all 0.0.0.0/0 ldap ldapserver=%s", ldapConfig.Server)
+	ldapConfigString += fmt.Sprintf("host all all 0.0.0.0/0 ldap ldapserver=\"%s\"",
+		ldapConfig.Server)
 
 	if ldapConfig.Port != 0 {
-		ldapConfigString += fmt.Sprintf(" ldapport=%d", ldapConfig.Port)
+		ldapConfigString += fmt.Sprintf(" ldapport=\"%d\"", ldapConfig.Port)
 	}
 
 	if ldapConfig.Scheme != "" {
-		ldapConfigString += fmt.Sprintf(" ldapscheme=%s", ldapConfig.Scheme)
+		ldapConfigString += fmt.Sprintf(" ldapscheme=\"%s\"", ldapConfig.Scheme)
 	}
 
 	if ldapConfig.TLS {
@@ -155,8 +157,8 @@ func buildLDAPConfigString(cluster *apiv1.Cluster, ldapBindPassword string) stri
 			"server", ldapConfig.Server,
 			"prefix", ldapConfig.BindAsAuth.Prefix,
 			"suffix", ldapConfig.BindAsAuth.Suffix)
-		ldapConfigString += fmt.Sprintf(" ldapprefix=\"%s\" ldapsuffix=\"%s\"", ldapConfig.BindAsAuth.Prefix,
-			ldapConfig.BindAsAuth.Suffix)
+		ldapConfigString += fmt.Sprintf(" ldapprefix=\"%s\" ldapsuffix=\"%s\"",
+			ldapConfig.BindAsAuth.Prefix, ldapConfig.BindAsAuth.Suffix)
 	}
 
 	if ldapConfig.BindSearchAuth != nil {
@@ -167,13 +169,16 @@ func buildLDAPConfigString(cluster *apiv1.Cluster, ldapBindPassword string) stri
 			"search attribute", ldapConfig.BindSearchAuth.SearchAttribute,
 			"search filter", ldapConfig.BindSearchAuth.SearchFilter)
 
-		ldapConfigString += fmt.Sprintf(" ldapbasedn=\"%s\" ldapbinddn=\"%s\" "+
-			"ldapbindpasswd=%s", ldapConfig.BindSearchAuth.BaseDN, ldapConfig.BindSearchAuth.BindDN, ldapBindPassword)
+		ldapConfigString += fmt.Sprintf(" ldapbasedn=\"%s\" ldapbinddn=\"%s\" ldapbindpasswd=\"%s\"",
+			ldapConfig.BindSearchAuth.BaseDN, ldapConfig.BindSearchAuth.BindDN,
+			strings.ReplaceAll(ldapBindPassword, "\n", "\\\n"))
 		if ldapConfig.BindSearchAuth.SearchFilter != "" {
-			ldapConfigString += fmt.Sprintf(" ldapsearchfilter=%s", ldapConfig.BindSearchAuth.SearchFilter)
+			ldapConfigString += fmt.Sprintf(" ldapsearchfilter=\"%s\"",
+				ldapConfig.BindSearchAuth.SearchFilter)
 		}
 		if ldapConfig.BindSearchAuth.SearchAttribute != "" {
-			ldapConfigString += fmt.Sprintf(" ldapsearchattribute=%s", ldapConfig.BindSearchAuth.SearchAttribute)
+			ldapConfigString += fmt.Sprintf(" ldapsearchattribute=\"%s\"",
+				ldapConfig.BindSearchAuth.SearchAttribute)
 		}
 	}
 

--- a/pkg/management/postgres/configuration.go
+++ b/pkg/management/postgres/configuration.go
@@ -171,7 +171,7 @@ func buildLDAPConfigString(cluster *apiv1.Cluster, ldapBindPassword string) stri
 
 		ldapConfigString += fmt.Sprintf(` ldapbasedn="%s" ldapbinddn="%s" ldapbindpasswd="%s"`,
 			ldapConfig.BindSearchAuth.BaseDN, ldapConfig.BindSearchAuth.BindDN,
-			strings.ReplaceAll(ldapBindPassword, "\n", `\n`)) // escape newlines
+			strings.ReplaceAll(ldapBindPassword, "\n", "\\\n"))
 		if ldapConfig.BindSearchAuth.SearchFilter != "" {
 			ldapConfigString += fmt.Sprintf(` ldapsearchfilter="%s"`,
 				ldapConfig.BindSearchAuth.SearchFilter)

--- a/pkg/management/postgres/configuration.go
+++ b/pkg/management/postgres/configuration.go
@@ -137,15 +137,16 @@ func buildLDAPConfigString(cluster *apiv1.Cluster, ldapBindPassword string) stri
 	}
 	ldapConfig := cluster.Spec.PostgresConfiguration.LDAP
 
-	ldapConfigString += fmt.Sprintf(`host all all 0.0.0.0/0 ldap ldapserver="%s"`,
-		ldapConfig.Server)
+	ldapConfigString += fmt.Sprintf("host all all 0.0.0.0/0 ldap ldapserver=%s",
+		quoteHbaLiteral(ldapConfig.Server))
 
 	if ldapConfig.Port != 0 {
-		ldapConfigString += fmt.Sprintf(` ldapport="%d"`, ldapConfig.Port)
+		ldapConfigString += fmt.Sprintf(" ldapport=%d", ldapConfig.Port)
 	}
 
 	if ldapConfig.Scheme != "" {
-		ldapConfigString += fmt.Sprintf(` ldapscheme="%s"`, ldapConfig.Scheme)
+		ldapConfigString += fmt.Sprintf(" ldapscheme=%s",
+			quoteHbaLiteral(string(ldapConfig.Scheme)))
 	}
 
 	if ldapConfig.TLS {
@@ -157,8 +158,9 @@ func buildLDAPConfigString(cluster *apiv1.Cluster, ldapBindPassword string) stri
 			"server", ldapConfig.Server,
 			"prefix", ldapConfig.BindAsAuth.Prefix,
 			"suffix", ldapConfig.BindAsAuth.Suffix)
-		ldapConfigString += fmt.Sprintf(` ldapprefix="%s" ldapsuffix="%s"`,
-			ldapConfig.BindAsAuth.Prefix, ldapConfig.BindAsAuth.Suffix)
+		ldapConfigString += fmt.Sprintf(" ldapprefix=%s ldapsuffix=%s",
+			quoteHbaLiteral(ldapConfig.BindAsAuth.Prefix),
+			quoteHbaLiteral(ldapConfig.BindAsAuth.Suffix))
 	}
 
 	if ldapConfig.BindSearchAuth != nil {
@@ -169,22 +171,29 @@ func buildLDAPConfigString(cluster *apiv1.Cluster, ldapBindPassword string) stri
 			"search attribute", ldapConfig.BindSearchAuth.SearchAttribute,
 			"search filter", ldapConfig.BindSearchAuth.SearchFilter)
 
-		ldapConfigString += fmt.Sprintf(` ldapbasedn="%s" ldapbinddn="%s" ldapbindpasswd="%s"`,
-			ldapConfig.BindSearchAuth.BaseDN, ldapConfig.BindSearchAuth.BindDN,
-			// if there is a newline, finsh the line with a backslash, and carry on
-			// in the next line. (see https://www.postgresql.org/docs/current/auth-pg-hba-conf.html)
-			strings.ReplaceAll(ldapBindPassword, "\n", "\\\n"))
+		ldapConfigString += fmt.Sprintf(" ldapbasedn=%s ldapbinddn=%s ldapbindpasswd=%s",
+			quoteHbaLiteral(ldapConfig.BindSearchAuth.BaseDN),
+			quoteHbaLiteral(ldapConfig.BindSearchAuth.BindDN),
+			quoteHbaLiteral(ldapBindPassword))
 		if ldapConfig.BindSearchAuth.SearchFilter != "" {
-			ldapConfigString += fmt.Sprintf(` ldapsearchfilter="%s"`,
-				ldapConfig.BindSearchAuth.SearchFilter)
+			ldapConfigString += fmt.Sprintf(" ldapsearchfilter=%s",
+				quoteHbaLiteral(ldapConfig.BindSearchAuth.SearchFilter))
 		}
 		if ldapConfig.BindSearchAuth.SearchAttribute != "" {
-			ldapConfigString += fmt.Sprintf(` ldapsearchattribute="%s"`,
-				ldapConfig.BindSearchAuth.SearchAttribute)
+			ldapConfigString += fmt.Sprintf(" ldapsearchattribute=%s",
+				quoteHbaLiteral(ldapConfig.BindSearchAuth.SearchAttribute))
 		}
 	}
 
 	return ldapConfigString
+}
+
+// quoteHbaLiteral quotes a string according to pg_hba.conf rules
+// (see https://www.postgresql.org/docs/current/auth-pg-hba-conf.html)
+func quoteHbaLiteral(literal string) string {
+	literal = strings.ReplaceAll(literal, `"`, `""`)
+	literal = strings.ReplaceAll(literal, "\n", "\\\n")
+	return fmt.Sprintf(`"%s"`, literal)
 }
 
 // UpdateReplicaConfiguration updates the postgresql.auto.conf or recovery.conf file for the proper version

--- a/pkg/management/postgres/configuration.go
+++ b/pkg/management/postgres/configuration.go
@@ -133,19 +133,19 @@ func (instance *Instance) RefreshPGHBA(cluster *apiv1.Cluster, ldapBindPassword 
 func buildLDAPConfigString(cluster *apiv1.Cluster, ldapBindPassword string) string {
 	var ldapConfigString string
 	if !cluster.GetEnableLDAPAuth() {
-		return ldapConfigString
+		return ""
 	}
 	ldapConfig := cluster.Spec.PostgresConfiguration.LDAP
 
-	ldapConfigString += fmt.Sprintf("host all all 0.0.0.0/0 ldap ldapserver=\"%s\"",
+	ldapConfigString += fmt.Sprintf(`host all all 0.0.0.0/0 ldap ldapserver="%s"`,
 		ldapConfig.Server)
 
 	if ldapConfig.Port != 0 {
-		ldapConfigString += fmt.Sprintf(" ldapport=\"%d\"", ldapConfig.Port)
+		ldapConfigString += fmt.Sprintf(` ldapport="%d"`, ldapConfig.Port)
 	}
 
 	if ldapConfig.Scheme != "" {
-		ldapConfigString += fmt.Sprintf(" ldapscheme=\"%s\"", ldapConfig.Scheme)
+		ldapConfigString += fmt.Sprintf(` ldapscheme="%s"`, ldapConfig.Scheme)
 	}
 
 	if ldapConfig.TLS {
@@ -157,7 +157,7 @@ func buildLDAPConfigString(cluster *apiv1.Cluster, ldapBindPassword string) stri
 			"server", ldapConfig.Server,
 			"prefix", ldapConfig.BindAsAuth.Prefix,
 			"suffix", ldapConfig.BindAsAuth.Suffix)
-		ldapConfigString += fmt.Sprintf(" ldapprefix=\"%s\" ldapsuffix=\"%s\"",
+		ldapConfigString += fmt.Sprintf(` ldapprefix="%s" ldapsuffix="%s"`,
 			ldapConfig.BindAsAuth.Prefix, ldapConfig.BindAsAuth.Suffix)
 	}
 
@@ -169,15 +169,15 @@ func buildLDAPConfigString(cluster *apiv1.Cluster, ldapBindPassword string) stri
 			"search attribute", ldapConfig.BindSearchAuth.SearchAttribute,
 			"search filter", ldapConfig.BindSearchAuth.SearchFilter)
 
-		ldapConfigString += fmt.Sprintf(" ldapbasedn=\"%s\" ldapbinddn=\"%s\" ldapbindpasswd=\"%s\"",
+		ldapConfigString += fmt.Sprintf(` ldapbasedn="%s" ldapbinddn="%s" ldapbindpasswd="%s"`,
 			ldapConfig.BindSearchAuth.BaseDN, ldapConfig.BindSearchAuth.BindDN,
-			strings.ReplaceAll(ldapBindPassword, "\n", "\\\n"))
+			strings.ReplaceAll(ldapBindPassword, "\n", `\n`)) // escape newlines
 		if ldapConfig.BindSearchAuth.SearchFilter != "" {
-			ldapConfigString += fmt.Sprintf(" ldapsearchfilter=\"%s\"",
+			ldapConfigString += fmt.Sprintf(` ldapsearchfilter="%s"`,
 				ldapConfig.BindSearchAuth.SearchFilter)
 		}
 		if ldapConfig.BindSearchAuth.SearchAttribute != "" {
-			ldapConfigString += fmt.Sprintf(" ldapsearchattribute=\"%s\"",
+			ldapConfigString += fmt.Sprintf(` ldapsearchattribute="%s"`,
 				ldapConfig.BindSearchAuth.SearchAttribute)
 		}
 	}

--- a/pkg/management/postgres/configuration_test.go
+++ b/pkg/management/postgres/configuration_test.go
@@ -83,7 +83,7 @@ var _ = Describe("testing the building of the ldap config string", func() {
 	It("correctly builds a bindSearchAuth string", func() {
 		str := buildLDAPConfigString(&cluster, ldapPassword)
 		fmt.Printf("here %s\n", str)
-		Expect(str).To(Equal(fmt.Sprintf(`host all all 0.0.0.0/0 ldap ldapserver="%s" ldapport="%d" `+
+		Expect(str).To(Equal(fmt.Sprintf(`host all all 0.0.0.0/0 ldap ldapserver="%s" ldapport=%d `+
 			`ldapscheme="%s" ldaptls=1 ldapbasedn="%s" ldapbinddn="%s" `+
 			`ldapbindpasswd="%s" ldapsearchfilter="%s" ldapsearchattribute="%s"`,
 			ldapServer, ldapPort, ldapScheme, ldapBaseDN,
@@ -98,15 +98,15 @@ var _ = Describe("testing the building of the ldap config string", func() {
 		}
 		str := buildLDAPConfigString(baaCluster, ldapPassword)
 		Expect(str).To(Equal(fmt.Sprintf(`host all all 0.0.0.0/0 ldap ldapserver="%s" `+
-			`ldapport="%d" ldapscheme="%s" ldaptls=1 ldapprefix="%s" ldapsuffix="%s"`,
+			`ldapport=%d ldapscheme="%s" ldaptls=1 ldapprefix="%s" ldapsuffix="%s"`,
 			ldapServer, ldapPort, ldapScheme, ldapPrefix, ldapSuffix)))
 	})
 	It("if password contains a newline, ends the line with a backslash and carries on", func() {
-		str := buildLDAPConfigString(&cluster, "nasty\npass")
+		str := buildLDAPConfigString(&cluster, "really\"nasty\npass")
 		Expect(strings.Split(str, "\n")).To(HaveLen(2))
 		Expect(str).To(Equal(fmt.Sprintf(`host all all 0.0.0.0/0 ldap ldapserver="%s" `+
-			`ldapport="%d" ldapscheme="%s" ldaptls=1 ldapbasedn="%s" `+
-			`ldapbinddn="%s" ldapbindpasswd="nasty\`+
+			`ldapport=%d ldapscheme="%s" ldaptls=1 ldapbasedn="%s" `+
+			`ldapbinddn="%s" ldapbindpasswd="really""nasty\`+
 			"\n"+
 			`pass" ldapsearchfilter="%s" ldapsearchattribute="%s"`,
 			ldapServer, ldapPort, ldapScheme, ldapBaseDN, ldapBindDN,

--- a/pkg/management/postgres/configuration_test.go
+++ b/pkg/management/postgres/configuration_test.go
@@ -81,10 +81,12 @@ var _ = Describe("testing the building of the ldap config string", func() {
 	})
 	It("correctly builds a bindSearchAuth string", func() {
 		str := buildLDAPConfigString(&cluster, ldapPassword)
-		Expect(str).To(Equal(fmt.Sprintf("host all all 0.0.0.0/0 ldap ldapserver=%s ldapport=%d "+
-			"ldapscheme=%s ldaptls=1 ldapbasedn=\"%s\" ldapbinddn=\"%s\" "+
-			"ldapbindpasswd=%s ldapsearchfilter=%s ldapsearchattribute=%s", ldapServer, ldapPort, ldapScheme,
-			ldapBaseDN, ldapBindDN, ldapPassword, ldapSearchFilter, ldapSearchAttribute)))
+		fmt.Printf("here %s\n", str)
+		Expect(str).To(Equal(fmt.Sprintf("host all all 0.0.0.0/0 ldap ldapserver=\"%s\" ldapport=\"%d\" "+
+			"ldapscheme=\"%s\" ldaptls=1 ldapbasedn=\"%s\" ldapbinddn=\"%s\" "+
+			"ldapbindpasswd=\"%s\" ldapsearchfilter=\"%s\" ldapsearchattribute=\"%s\"",
+			ldapServer, ldapPort, ldapScheme, ldapBaseDN,
+			ldapBindDN, ldapPassword, ldapSearchFilter, ldapSearchAttribute)))
 	})
 	It("correctly builds a bindAsAuth string", func() {
 		baaCluster := cluster.DeepCopy()
@@ -94,7 +96,8 @@ var _ = Describe("testing the building of the ldap config string", func() {
 			Suffix: ldapSuffix,
 		}
 		str := buildLDAPConfigString(baaCluster, ldapPassword)
-		Expect(str).To(Equal(fmt.Sprintf("host all all 0.0.0.0/0 ldap ldapserver=%s ldapport=%d ldapscheme=%s "+
-			"ldaptls=1 ldapprefix=\"%s\" ldapsuffix=\"%s\"", ldapServer, ldapPort, ldapScheme, ldapPrefix, ldapSuffix)))
+		Expect(str).To(Equal(fmt.Sprintf("host all all 0.0.0.0/0 ldap ldapserver=\"%s\" "+
+			"ldapport=\"%d\" ldapscheme=\"%s\" ldaptls=1 ldapprefix=\"%s\" ldapsuffix=\"%s\"",
+			ldapServer, ldapPort, ldapScheme, ldapPrefix, ldapSuffix)))
 	})
 })

--- a/pkg/management/postgres/configuration_test.go
+++ b/pkg/management/postgres/configuration_test.go
@@ -101,13 +101,14 @@ var _ = Describe("testing the building of the ldap config string", func() {
 			`ldapport="%d" ldapscheme="%s" ldaptls=1 ldapprefix="%s" ldapsuffix="%s"`,
 			ldapServer, ldapPort, ldapScheme, ldapPrefix, ldapSuffix)))
 	})
-	It("does not generate a newline if ldapBindPasswd contains one", func() {
+	It("if password contains a newline, ends the line with a backslash and carries on", func() {
 		str := buildLDAPConfigString(&cluster, "nasty\npass")
-		Expect(strings.Split(str, "\n")).To(HaveLen(1))
+		Expect(strings.Split(str, "\n")).To(HaveLen(2))
 		Expect(str).To(Equal(fmt.Sprintf(`host all all 0.0.0.0/0 ldap ldapserver="%s" `+
 			`ldapport="%d" ldapscheme="%s" ldaptls=1 ldapbasedn="%s" `+
-			`ldapbinddn="%s" ldapbindpasswd="nasty\npass" `+
-			`ldapsearchfilter="%s" ldapsearchattribute="%s"`,
+			`ldapbinddn="%s" ldapbindpasswd="nasty\`+
+			"\n"+
+			`pass" ldapsearchfilter="%s" ldapsearchattribute="%s"`,
 			ldapServer, ldapPort, ldapScheme, ldapBaseDN, ldapBindDN,
 			ldapSearchFilter, ldapSearchAttribute)))
 	})


### PR DESCRIPTION
Only some of the values quoted meaning that that could lead to some issues with the pg_hba.conf parser in PostgreSQL. Also, there was an issue with secrets containing a new line at the end, now we add a `\` before the newline so PostgreSQL will read it only as one line.

Closes #2688
