### PR TITLE
fix: old primary pod need restart when rolling update tablespace chan…

### DIFF
--- a/pkg/reconciler/persistentvolumeclaim/resources.go
+++ b/pkg/reconciler/persistentvolumeclaim/resources.go
@@ -159,10 +159,8 @@ func getExpectedPVCsFromCluster(cluster *apiv1.Cluster, instanceName string) []e
 		roles = append(roles, utils.PVCRolePgWal)
 	}
 
-	if cluster.ShouldCreateTablespaces() {
-		roles = append(roles, utils.PVCRolePgTablespace)
-	}
-
+	// TODO: The PVC's for tablespaces need more info than the role, so they
+	// are built in the following function call. This structure should be improved
 	return buildExpectedPVCs(cluster, instanceName, roles)
 }
 

--- a/pkg/reconciler/persistentvolumeclaim/resources.go
+++ b/pkg/reconciler/persistentvolumeclaim/resources.go
@@ -159,6 +159,10 @@ func getExpectedPVCsFromCluster(cluster *apiv1.Cluster, instanceName string) []e
 		roles = append(roles, utils.PVCRolePgWal)
 	}
 
+	if cluster.ShouldCreateTablespaces() {
+		roles = append(roles, utils.PVCRolePgTablespace)
+	}
+
 	return buildExpectedPVCs(cluster, instanceName, roles)
 }
 


### PR DESCRIPTION
this patch merge to feature branch, make sure when primaryUpdateMethod 
is switchover, add a tablespace, the old primary will restart to get the new volume
mounted. 