### PR TITLE
fix(monitoring): run `pg_replication_slots` metric on primary only

### DIFF
--- a/config/manager/default-monitoring.yaml
+++ b/config/manager/default-monitoring.yaml
@@ -130,6 +130,7 @@ data:
             description: "Number of streaming replicas connected to the instance"
 
     pg_replication_slots:
+      primary: true
       query: |
         SELECT slot_name,
           slot_type,


### PR DESCRIPTION
The `pg_replication_slots` metric that is shipped by default with the operator is consistently failing on the replicas due to calls to WAL functions that are not available in the recovery phase. The metric is now run only on the primary.

Closes #2377
Closes #2552