### PR TITLE
fix: evaluate `IsEmptyWalArchiveCheckEnabled` during restore

### DIFF
--- a/docs/src/recovery.md
+++ b/docs/src/recovery.md
@@ -581,3 +581,10 @@ in the storage buckets could be overwritten by the new cluster.
     The pod logs will show:
     `ERROR: WAL archive check failed for server recoveredCluster: Expected empty archive`
 
+!!! Important
+    If you set the `cnpg.io/skipEmptyWalArchiveCheck` annotation to `enabled` in
+    the recovered cluster, you can skip the above check. This is not recommended
+    as for the general use case the above check works fine. Please don't do
+    this unless you are familiar with PostgreSQL recovery system, as this can lead
+    you to severe data loss.
+

--- a/pkg/management/postgres/restore.go
+++ b/pkg/management/postgres/restore.go
@@ -51,6 +51,7 @@ import (
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres/constants"
 	postgresutils "github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres/utils"
 	postgresSpec "github.com/cloudnative-pg/cloudnative-pg/pkg/postgres"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 )
 
 var (
@@ -836,7 +837,11 @@ func (info *InitInfo) checkBackupDestination(
 	}
 
 	// Check if we're ok to archive in the desired destination
-	return walArchiver.CheckWalArchiveDestination(ctx, checkWalOptions)
+	if utils.IsEmptyWalArchiveCheckEnabled(&cluster.ObjectMeta) {
+		return walArchiver.CheckWalArchiveDestination(ctx, checkWalOptions)
+	}
+
+	return nil
 }
 
 // waitUntilRecoveryFinishes periodically checks the underlying


### PR DESCRIPTION
Closes #2730 
