### PR TITLE
chore: add coredumpFilter annotation

### DIFF
--- a/.wordlist-en-custom.txt
+++ b/.wordlist-en-custom.txt
@@ -461,6 +461,7 @@ bindAsAuth
 bindDN
 bindPassword
 bindSearchAuth
+bitmask
 bool
 bootstrapconfiguration
 bootstrapinitdb
@@ -527,6 +528,8 @@ connectionParameters
 connectionString
 conninfo
 containerPort
+coredump
+coredumps
 coreos
 corev
 coverity

--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cloudnative-pg/cloudnative-pg/internal/configuration"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/log"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/postgres"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/system"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/versions"
 )
@@ -2842,6 +2843,15 @@ func (cluster *Cluster) GetSeccompProfile() *corev1.SeccompProfile {
 	return &corev1.SeccompProfile{
 		Type: corev1.SeccompProfileTypeRuntimeDefault,
 	}
+}
+
+// GetCoredumpFilter get the coredump filter value from the cluster annotation
+func (cluster *Cluster) GetCoredumpFilter() string {
+	value, ok := cluster.Annotations[utils.CoredumpFilter]
+	if ok {
+		return value
+	}
+	return system.DefaultCoredumpFilter
 }
 
 // IsInplaceRestartPhase returns true if the cluster is in a phase that handles the Inplace restart

--- a/docs/src/labels_annotations.md
+++ b/docs/src/labels_annotations.md
@@ -89,6 +89,9 @@ Below is a list of predefined annotations that are managed by CloudNativePG.
 :   Customize the coredump filter bitmask of Postgres processes.
     Set by default to `0x31` that excludes shared memory.
     See https://docs.kernel.org/filesystems/proc.html#proc-pid-coredump-filter-core-dump-filtering-settings
+    This setting only takes effect during Pod startup,
+    and changing it doesn't trigger any automatic rollout of the instances.
+
 
 ## Pre-requisites
 

--- a/docs/src/labels_annotations.md
+++ b/docs/src/labels_annotations.md
@@ -59,6 +59,12 @@ Below is a list of predefined annotations that are managed by CloudNativePG.
     See [AppArmor](security.md#restricting-pod-access-using-apparmor)
     documentation for details
 
+`cnpg.io/coredumpFilter`
+:   Filter to control the coredump of Postgres processes, expressed with a
+    bitmask. By default it is set to `0x31` in order to exclude shared memory
+    segments from the dump. Please refer to ["PostgreSQL core dumps"](troubleshooting.md#postgresql-core-dumps)
+    for more information.
+
 `cnpg.io/clusterManifest`
 :   Manifest of the `Cluster` owning this resource (such as a PVC) - this label
     replaces the old and deprecated `cnpg.io/hibernateClusterManifest` label
@@ -84,14 +90,6 @@ Below is a list of predefined annotations that are managed by CloudNativePG.
 :   When set to `true` on a `Cluster` resource, the operator disables the check
     that ensures that the WAL archive is empty before writing data. Use at your own
     risk.
-
-`cnpg.io/coredumpFilter`
-:   Customize the coredump filter bitmask of Postgres processes.
-    Set by default to `0x31` that excludes shared memory.
-    See https://docs.kernel.org/filesystems/proc.html#proc-pid-coredump-filter-core-dump-filtering-settings
-    This setting only takes effect during Pod startup,
-    and changing it doesn't trigger any automatic rollout of the instances.
-
 
 ## Pre-requisites
 

--- a/docs/src/labels_annotations.md
+++ b/docs/src/labels_annotations.md
@@ -85,6 +85,11 @@ Below is a list of predefined annotations that are managed by CloudNativePG.
     that ensures that the WAL archive is empty before writing data. Use at your own
     risk.
 
+`cnpg.io/coredumpFilter`
+:   Customize the coredump filter bitmask of Postgres processes.
+    Set by default to `0x31` that excludes shared memory.
+    See https://docs.kernel.org/filesystems/proc.html#proc-pid-coredump-filter-core-dump-filtering-settings
+
 ## Pre-requisites
 
 By default, no label or annotation defined in the cluster's metadata is

--- a/internal/cmd/manager/instance/pgbasebackup/cmd.go
+++ b/internal/cmd/manager/instance/pgbasebackup/cmd.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/external"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/log"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/system"
 )
 
 // CloneInfo is the structure containing all the information needed
@@ -103,6 +104,11 @@ func (env *CloneInfo) bootstrapUsingPgbasebackup(ctx context.Context) error {
 	var cluster apiv1.Cluster
 	err := env.client.Get(ctx, ctrl.ObjectKey{Namespace: env.info.Namespace, Name: env.info.ClusterName}, &cluster)
 	if err != nil {
+		return err
+	}
+
+	coredumpFilter := cluster.GetCoredumpFilter()
+	if err := system.SetCoredumpFilter(coredumpFilter); err != nil {
 		return err
 	}
 

--- a/internal/cmd/manager/instance/run/cmd.go
+++ b/internal/cmd/manager/instance/run/cmd.go
@@ -48,7 +48,6 @@ import (
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres/webserver"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres/webserver/metricserver"
 	pg "github.com/cloudnative-pg/cloudnative-pg/pkg/postgres"
-	"github.com/cloudnative-pg/cloudnative-pg/pkg/system"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/versions"
 )
 
@@ -146,27 +145,6 @@ func runSubCommand(ctx context.Context, instance *postgres.Instance) error {
 
 	metricsServer, err := metricserver.New(instance)
 	if err != nil {
-		return err
-	}
-
-	typedClient, err := management.NewControllerRuntimeClient()
-	if err != nil {
-		return err
-	}
-	var cluster apiv1.Cluster
-	if err := typedClient.Get(ctx,
-		client.ObjectKey{
-			Name:      instance.ClusterName,
-			Namespace: instance.Namespace,
-		},
-		&cluster); err != nil {
-		setupLog.Error(err, "unable to get cluster object")
-		return err
-	}
-
-	coredumpFilter := cluster.GetCoredumpFilter()
-	if err := system.SetCoredumpFilter(coredumpFilter); err != nil {
-		setupLog.Error(err, "unable to set coredump filter value")
 		return err
 	}
 

--- a/internal/management/controller/instance_controller.go
+++ b/internal/management/controller/instance_controller.go
@@ -53,6 +53,7 @@ import (
 	postgresutils "github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres/utils"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres/webserver/metricserver"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/postgres"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/system"
 	pkgUtils "github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 )
 
@@ -331,6 +332,10 @@ func (r *InstanceReconciler) initialize(ctx context.Context, cluster *apiv1.Clus
 	}
 
 	if err := r.verifyPgDataCoherenceForPrimary(ctx, cluster); err != nil {
+		return err
+	}
+
+	if err := system.SetCoredumpFilter(cluster.GetCoredumpFilter()); err != nil {
 		return err
 	}
 

--- a/pkg/management/postgres/initdb.go
+++ b/pkg/management/postgres/initdb.go
@@ -43,6 +43,7 @@ import (
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres/constants"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres/logicalimport"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres/pool"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/system"
 )
 
 // InitInfo contains all the info needed to bootstrap a new PostgreSQL instance
@@ -324,6 +325,11 @@ func (info InitInfo) Bootstrap(ctx context.Context) error {
 
 	cluster, err := info.loadCluster(ctx, typedClient)
 	if err != nil {
+		return err
+	}
+
+	coredumpFilter := cluster.GetCoredumpFilter()
+	if err := system.SetCoredumpFilter(coredumpFilter); err != nil {
 		return err
 	}
 

--- a/pkg/management/postgres/join.go
+++ b/pkg/management/postgres/join.go
@@ -23,6 +23,7 @@ import (
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/execlog"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/log"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/system"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 
 	// this is needed to correctly open the sql connection with the pgx driver
@@ -77,6 +78,11 @@ func ClonePgData(connectionString, targetPgData, walDir string) error {
 // Join creates a new instance joined to an existing PostgreSQL cluster
 func (info InitInfo) Join(cluster *apiv1.Cluster) error {
 	primaryConnInfo := buildPrimaryConnInfo(info.ParentNode, info.PodName) + " dbname=postgres connect_timeout=5"
+
+	coredumpFilter := cluster.GetCoredumpFilter()
+	if err := system.SetCoredumpFilter(coredumpFilter); err != nil {
+		return err
+	}
 
 	err := ClonePgData(primaryConnInfo, info.PgData, info.PgWal)
 	if err != nil {

--- a/pkg/management/postgres/restore.go
+++ b/pkg/management/postgres/restore.go
@@ -51,6 +51,7 @@ import (
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres/constants"
 	postgresutils "github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres/utils"
 	postgresSpec "github.com/cloudnative-pg/cloudnative-pg/pkg/postgres"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/system"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 )
 
@@ -81,6 +82,11 @@ var (
 func (info InitInfo) RestoreSnapshot(ctx context.Context, cli client.Client) error {
 	cluster, err := info.loadCluster(ctx, cli)
 	if err != nil {
+		return err
+	}
+
+	coredumpFilter := cluster.GetCoredumpFilter()
+	if err := system.SetCoredumpFilter(coredumpFilter); err != nil {
 		return err
 	}
 
@@ -195,6 +201,11 @@ func (info InitInfo) Restore(ctx context.Context) error {
 
 	cluster, err := info.loadCluster(ctx, typedClient)
 	if err != nil {
+		return err
+	}
+
+	coredumpFilter := cluster.GetCoredumpFilter()
+	if err := system.SetCoredumpFilter(coredumpFilter); err != nil {
 		return err
 	}
 

--- a/pkg/system/compatibility/darwin.go
+++ b/pkg/system/compatibility/darwin.go
@@ -1,5 +1,5 @@
-//go:build linux
-// +build linux
+//go:build darwin
+// +build darwin
 
 /*
 Copyright The CloudNativePG Contributors
@@ -20,12 +20,7 @@ limitations under the License.
 // Package compatibility provides a layer to cross-compile with other OS than Linux
 package compatibility
 
-import (
-	"os"
-)
-
-// SetCoredumpFilter set the value of /proc/self/coredump_filter
-func SetCoredumpFilter(coredumpFilter string) error {
-	coredumpFilterFile := "/proc/self/coredump_filter"
-	return os.WriteFile(coredumpFilterFile, []byte(coredumpFilter), 0o600)
+// SetCoredumpFilter for Windows compatibility
+func SetCoredumpFilter(_ string) error {
+	return nil
 }

--- a/pkg/system/compatibility/unix.go
+++ b/pkg/system/compatibility/unix.go
@@ -1,0 +1,31 @@
+//go:build linux || darwin
+// +build linux darwin
+
+/*
+Copyright The CloudNativePG Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package compatibility provides a layer to cross-compile with other OS than Linux
+package compatibility
+
+import (
+	"os"
+)
+
+// SetCoredumpFilter set the value of /proc/self/coredump_filter
+func SetCoredumpFilter(coredumpFilter string) error {
+	coredumpFilterFile := "/proc/self/coredump_filter"
+	return os.WriteFile(coredumpFilterFile, []byte(coredumpFilter), 0o600)
+}

--- a/pkg/system/compatibility/windows.go
+++ b/pkg/system/compatibility/windows.go
@@ -21,6 +21,6 @@ limitations under the License.
 package compatibility
 
 // SetCoredumpFilter for Windows compatibility
-func SetCoredumpFilter(coredumpFilter string) error {
+func SetCoredumpFilter(_ string) error {
 	return nil
 }

--- a/pkg/system/compatibility/windows.go
+++ b/pkg/system/compatibility/windows.go
@@ -1,0 +1,26 @@
+//go:build windows
+// +build windows
+
+/*
+Copyright The CloudNativePG Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package compatibility provides a layer to cross-compile with other OS than Linux
+package compatibility
+
+// SetCoredumpFilter for Windows compatibility
+func SetCoredumpFilter(coredumpFilter string) error {
+	return nil
+}

--- a/pkg/system/suite_test.go
+++ b/pkg/system/suite_test.go
@@ -1,0 +1,32 @@
+/*
+Copyright The CloudNativePG Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package system
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// These tests use Ginkgo (BDD-style Go testing framework). Refer to
+// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
+
+func TestExecPipe(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "System test suite")
+}

--- a/pkg/system/system.go
+++ b/pkg/system/system.go
@@ -1,0 +1,32 @@
+/*
+Copyright The CloudNativePG Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package system provides an interface with the operating system
+package system
+
+import (
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/system/compatibility"
+)
+
+const (
+	// DefaultCoredumpFilter it's the default value for the /proc/self/coredump_filter file
+	DefaultCoredumpFilter = "0x31"
+)
+
+// SetCoredumpFilter write the content of filter to coredump_filter of the current pid
+func SetCoredumpFilter(coredumpFilter string) error {
+	return compatibility.SetCoredumpFilter(coredumpFilter)
+}

--- a/pkg/system/system_test.go
+++ b/pkg/system/system_test.go
@@ -17,6 +17,7 @@ package system
 
 import (
 	"encoding/asn1"
+	"runtime"
 
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/fileutils"
 
@@ -26,6 +27,13 @@ import (
 
 var _ = Describe("Testing set coredump_filter", func() {
 	It("properly set the default value for a cluster", func() {
+		// Did not split the darwin out from windows as that is not necessary
+		// we just check in the test case. for most situation, we build in darwin and
+		// test in linux based docker
+		if runtime.GOOS != "linux" {
+			return
+		}
+
 		coredumpFilter := "0x31"
 		err := SetCoredumpFilter(coredumpFilter)
 		Expect(err).ToNot(HaveOccurred())

--- a/pkg/system/system_test.go
+++ b/pkg/system/system_test.go
@@ -16,8 +16,11 @@ limitations under the License.
 package system
 
 import (
-	"encoding/asn1"
+	"fmt"
+	"os"
 	"runtime"
+	"strconv"
+	"strings"
 
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/fileutils"
 
@@ -25,26 +28,45 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Testing set coredump_filter", func() {
-	It("properly set the default value for a cluster", func() {
+var _ = Describe("Testing set coredump_filter", Ordered, func() {
+	var origFilter string
+	BeforeAll(func() {
 		// Did not split the darwin out from windows as that is not necessary
 		// we just check in the test case. for most situation, we build in darwin and
 		// test in linux based docker
 		if runtime.GOOS != "linux" {
-			return
+			Skip("coredump_filter is supported only on linux systems")
 		}
 
+		filter, err := fileutils.ReadFile("/proc/self/coredump_filter")
+		Expect(err).ToNot(HaveOccurred())
+		origFilter, err = parseCoredumpFilter(filter)
+		Expect(err).ToNot(HaveOccurred())
+	})
+	AfterAll(func() {
+		if origFilter == "" {
+			return
+		}
+		err := os.WriteFile("/proc/self/coredump_filter", []byte(origFilter), 0o600)
+		Expect(err).ToNot(HaveOccurred())
+	})
+	It("properly set the default value for a cluster", func() {
 		coredumpFilter := "0x31"
 		err := SetCoredumpFilter(coredumpFilter)
 		Expect(err).ToNot(HaveOccurred())
 
 		content, err := fileutils.ReadFile("/proc/self/coredump_filter")
 		Expect(err).ToNot(HaveOccurred())
-		bit := asn1.BitString{Bytes: content, BitLength: 9}
-		// string 0x31 it's translated into bits 2 and 3 being on
-		// check https://docs.kernel.org/filesystems/proc.html#proc-pid-coredump-filter-core-dump-filtering-settings
-		// for more information on the subject
-		Expect(bit.At(2)).To(Equal(1))
-		Expect(bit.At(3)).To(Equal(1))
+		Expect(parseCoredumpFilter(content)).To(Equal(coredumpFilter))
 	})
 })
+
+func parseCoredumpFilter(content []byte) (string, error) {
+	filterInt, err := strconv.ParseInt(strings.TrimSpace(string(content)), 16, 0)
+	if err != nil {
+		return "", err
+	}
+
+	filterStr := fmt.Sprintf("0x%x", filterInt)
+	return filterStr, nil
+}

--- a/pkg/system/system_test.go
+++ b/pkg/system/system_test.go
@@ -1,0 +1,42 @@
+/*
+Copyright The CloudNativePG Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package system
+
+import (
+	"encoding/asn1"
+
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/fileutils"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Testing set coredump_filter", func() {
+	It("properly set the default value for a cluster", func() {
+		coredumpFilter := "0x31"
+		err := SetCoredumpFilter(coredumpFilter)
+		Expect(err).ToNot(HaveOccurred())
+
+		content, err := fileutils.ReadFile("/proc/self/coredump_filter")
+		Expect(err).ToNot(HaveOccurred())
+		bit := asn1.BitString{Bytes: content, BitLength: 9}
+		// string 0x31 it's translated into bits 2 and 3 being on
+		// check https://docs.kernel.org/filesystems/proc.html#proc-pid-coredump-filter-core-dump-filtering-settings
+		// for more information on the subject
+		Expect(bit.At(2)).To(Equal(1))
+		Expect(bit.At(3)).To(Equal(1))
+	})
+})

--- a/pkg/utils/labels_annotations.go
+++ b/pkg/utils/labels_annotations.go
@@ -83,6 +83,9 @@ const (
 
 	// skipEmptyWalArchiveCheck turns off the checks that ensure that the WAL archive is empty before writing data
 	skipEmptyWalArchiveCheck = "cnpg.io/skipEmptyWalArchiveCheck"
+
+	// CoredumpFilter stores the value defined by the user to set in /proc/self/coredump_filter
+	CoredumpFilter = "cnpg.io/coredumpFilter"
 )
 
 type annotationStatus string


### PR DESCRIPTION
Since it's useful to reduce the amount of memory used by a coredump when it's created we added this annotation to set the value for /proc/self/coredump_filter. The default value it's now set to 0x31 since it's look like the most used value.

The annotation can be set at cluster level and then will be passed in all the process that run any PostgreSQL command.

Closes #2696 