### PR TITLE
fix(monitoring): improve accuracy of replica lag

### DIFF
--- a/docs/src/samples/cluster-example-monitoring.yaml
+++ b/docs/src/samples/cluster-example-monitoring.yaml
@@ -26,7 +26,9 @@ metadata:
 data:
   custom-queries: |
     pg_replication:
-      query: "SELECT CASE WHEN NOT pg_is_in_recovery()
+      query: "SELECT CASE WHEN (
+                NOT pg_is_in_recovery()
+                OR pg_last_wal_receive_lsn() = pg_last_wal_replay_lsn())
               THEN 0
               ELSE GREATEST (0, 
                 EXTRACT(EPOCH FROM (now() - pg_last_xact_replay_timestamp()))) 

--- a/docs/src/samples/cluster-example-monitoring.yaml
+++ b/docs/src/samples/cluster-example-monitoring.yaml
@@ -30,9 +30,9 @@ data:
                 NOT pg_is_in_recovery()
                 OR pg_last_wal_receive_lsn() = pg_last_wal_replay_lsn())
               THEN 0
-              ELSE GREATEST (0, 
-                EXTRACT(EPOCH FROM (now() - pg_last_xact_replay_timestamp()))) 
-              END AS lag, 
+              ELSE GREATEST (0,
+                EXTRACT(EPOCH FROM (now() - pg_last_xact_replay_timestamp())))
+              END AS lag,
               pg_is_in_recovery() AS in_recovery,
               EXISTS (TABLE pg_stat_wal_receiver) AS is_wal_receiver_up,
               (SELECT count(*) FROM pg_stat_replication) AS streaming_replicas"


### PR DESCRIPTION
Fix the `pg_replication` metric to use the `pg_last_wal_receive_lsn()` and `pg_last_wal_replay_lsn()` functions to better estimate the lag of a replica, and avoid the increase of the lag on inactive systems.

Closes #1814
