### PR TITLE
fix(monitoring): improve accuracy of replica lag

### DIFF
--- a/config/manager/default-monitoring.yaml
+++ b/config/manager/default-monitoring.yaml
@@ -107,14 +107,16 @@ data:
             description: "Time at which postgres started (based on epoch)"
 
     pg_replication:
-      query: "SELECT CASE WHEN NOT pg_catalog.pg_is_in_recovery()
+      query: "SELECT CASE WHEN (
+                NOT pg_catalog.pg_is_in_recovery()
+                OR pg_catalog.pg_last_wal_receive_lsn() = pg_catalog.pg_last_wal_replay_lsn())
               THEN 0
               ELSE GREATEST (0,
                 EXTRACT(EPOCH FROM (now() - pg_catalog.pg_last_xact_replay_timestamp())))
               END AS lag,
               pg_catalog.pg_is_in_recovery() AS in_recovery,
               EXISTS (TABLE pg_stat_wal_receiver) AS is_wal_receiver_up,
-              (SELECT count(*) FROM pg_stat_replication) AS streaming_replicas"
+              (SELECT count(*) FROM pg_catalog.pg_stat_replication) AS streaming_replicas"
       metrics:
         - lag:
             usage: "GAUGE"

--- a/docs/src/samples/cluster-example-monitoring.yaml
+++ b/docs/src/samples/cluster-example-monitoring.yaml
@@ -25,40 +25,6 @@ metadata:
     cnpg.io/reload: ""
 data:
   custom-queries: |
-    pg_replication:
-      query: "SELECT CASE WHEN (
-                NOT pg_is_in_recovery()
-                OR pg_last_wal_receive_lsn() = pg_last_wal_replay_lsn())
-              THEN 0
-              ELSE GREATEST (0,
-                EXTRACT(EPOCH FROM (now() - pg_last_xact_replay_timestamp())))
-              END AS lag,
-              pg_is_in_recovery() AS in_recovery,
-              EXISTS (TABLE pg_stat_wal_receiver) AS is_wal_receiver_up,
-              (SELECT count(*) FROM pg_stat_replication) AS streaming_replicas"
-
-      metrics:
-        - lag:
-            usage: "GAUGE"
-            description: "Replication lag behind primary in seconds"
-        - in_recovery:
-            usage: "GAUGE"
-            description: "Whether the instance is in recovery"
-        - is_wal_receiver_up:
-            usage: "GAUGE"
-            description: "Whether the instance wal_receiver is up"
-        - streaming_replicas:
-            usage: "GAUGE"
-            description: "Number of streaming replicas connected to the instance"
-
-    pg_postmaster:
-      query: "SELECT pg_postmaster_start_time as start_time from pg_postmaster_start_time()"
-      primary: true
-      metrics:
-        - start_time:
-            usage: "GAUGE"
-            description: "Time at which postgres started"
-
     pg_stat_user_tables:
       target_databases:
       - "*"


### PR DESCRIPTION
This patch overrides the previous patch which only covered the documentation samples. From a deeper analysis, we noticed that some examples had already been introduced in the default monitoring config map, thus have been removed from the docs.

The default configmap now fixes the `pg_replication` metric to use the `pg_last_wal_receive_lsn()` and `pg_last_wal_replay_lsn()` functions to better estimate the lag of a replica, and avoid the increase of the lag on inactive systems.

Closes #1814