### PR TITLE
Grafana Dashboard: add WAL pvc usage

### DIFF
--- a/docs/src/samples/monitoring/grafana-configmap.yaml
+++ b/docs/src/samples/monitoring/grafana-configmap.yaml
@@ -3937,7 +3937,17 @@ data:
                   "legendFormat": "{{persistentvolumeclaim}}",
                   "range": true,
                   "refId": "FREE_SPACE"
-                }
+                },
+                {
+                  "datasource": "${DS_PROMETHEUS}",
+                  "editorMode": "code",
+                  "expr": "max by(persistentvolumeclaim) (1 - kubelet_volume_stats_available_bytes{namespace=\"$namespace\", persistentvolumeclaim=~\"(${instances})-wal\"} / kubelet_volume_stats_capacity_bytes{namespace=\"$namespace\", persistentvolumeclaim=~\"(${instances})-wal\"})",
+                  "format": "time_series",
+                  "interval": "",
+                  "legendFormat": "{{persistentvolumeclaim}}",
+                  "range": true,
+                  "refId": "FREE_SPACE_WAL"
+                }                
               ],
               "title": "Volume Space Usage",
               "transformations": [],
@@ -4004,7 +4014,17 @@ data:
                   "legendFormat": "{{persistentvolumeclaim}}",
                   "range": true,
                   "refId": "FREE_INODES"
-                }
+                },
+                {
+                  "datasource": "${DS_PROMETHEUS}",
+                  "editorMode": "code",
+                  "expr": "max by(persistentvolumeclaim) (kubelet_volume_stats_inodes_used{namespace=\"$namespace\", persistentvolumeclaim=~\"(${instances})-wal\"} / kubelet_volume_stats_inodes{namespace=\"$namespace\", persistentvolumeclaim=~\"(${instances})-wal\"})",
+                  "format": "time_series",
+                  "interval": "",
+                  "legendFormat": "{{persistentvolumeclaim}}",
+                  "range": true,
+                  "refId": "FREE_INODES_WAL"
+                }                
               ],
               "title": "Volume Inode Usage",
               "transformations": [],

--- a/docs/src/samples/monitoring/grafana-configmap.yaml
+++ b/docs/src/samples/monitoring/grafana-configmap.yaml
@@ -2814,7 +2814,7 @@ data:
             {
               "datasource": "${DS_PROMETHEUS}",
               "exemplar": true,
-              "expr": "cnpg_pg_settings_setting{name=\"effective_cache_size\",namespace=~\"$namespace\",pod=~\"$instances\"}",
+              "expr": "max by (pod) (cnpg_pg_settings_setting{name=\"effective_cache_size\",namespace=~\"$namespace\",pod=~\"$instances\"}) * max by (pod) (cnpg_pg_settings_setting{name=\"block_size\",namespace=~\"$namespace\",pod=~\"$instances\"})",
               "instant": true,
               "interval": "",
               "legendFormat": "{{pod}}",

--- a/docs/src/samples/monitoring/grafana-configmap.yaml
+++ b/docs/src/samples/monitoring/grafana-configmap.yaml
@@ -617,10 +617,20 @@ data:
               "expr": "max(max by(persistentvolumeclaim) (1 - kubelet_volume_stats_available_bytes{namespace=\"$namespace\", persistentvolumeclaim=~\"$instances\"} / kubelet_volume_stats_capacity_bytes{namespace=\"$namespace\", persistentvolumeclaim=~\"$instances\"}))",
               "format": "time_series",
               "interval": "",
-              "legendFormat": "{{persistentvolumeclaim}}",
+              "legendFormat": "DATA",
               "range": true,
-              "refId": "FREE_SPACE"
-            }
+              "refId": "DATA"
+            },
+            {
+              "datasource": "${DS_PROMETHEUS}",
+              "editorMode": "code",
+              "expr": "max(max by(persistentvolumeclaim) (1 - kubelet_volume_stats_available_bytes{namespace=\"$namespace\", persistentvolumeclaim=~\"(${instances})-wal\"} / kubelet_volume_stats_capacity_bytes{namespace=\"$namespace\", persistentvolumeclaim=~\"(${instances})-wal\"}))",
+              "format": "time_series",
+              "interval": "",
+              "legendFormat": "WAL",
+              "range": true,
+              "refId": "WAL"
+            }            
           ],
           "title": "Volume Space Usage",
           "type": "gauge"

--- a/docs/src/samples/monitoring/grafana-dashboard.json
+++ b/docs/src/samples/monitoring/grafana-dashboard.json
@@ -4379,7 +4379,20 @@
               "legendFormat": "{{persistentvolumeclaim}}",
               "range": true,
               "refId": "FREE_SPACE"
-            }
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "max by(persistentvolumeclaim) (1 - kubelet_volume_stats_available_bytes{namespace=\"$namespace\", persistentvolumeclaim=~\"(${instances})-wal\"} / kubelet_volume_stats_capacity_bytes{namespace=\"$namespace\", persistentvolumeclaim=~\"(${instances})-wal\"})",
+              "format": "time_series",
+              "interval": "",
+              "legendFormat": "{{persistentvolumeclaim}}",
+              "range": true,
+              "refId": "FREE_SPACE_WAL"
+            }            
           ],
           "title": "Volume Space Usage",
           "transformations": [],
@@ -4452,7 +4465,20 @@
               "legendFormat": "{{persistentvolumeclaim}}",
               "range": true,
               "refId": "FREE_INODES"
-            }
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "max by(persistentvolumeclaim) (kubelet_volume_stats_inodes_used{namespace=\"$namespace\", persistentvolumeclaim=~\"(${instances})-wal\"} / kubelet_volume_stats_inodes{namespace=\"$namespace\", persistentvolumeclaim=~\"(${instances})-wal\"})",
+              "format": "time_series",
+              "interval": "",
+              "legendFormat": "{{persistentvolumeclaim}}",
+              "range": true,
+              "refId": "FREE_INODES_WAL"
+            }            
           ],
           "title": "Volume Inode Usage",
           "transformations": [],

--- a/docs/src/samples/monitoring/grafana-dashboard.json
+++ b/docs/src/samples/monitoring/grafana-dashboard.json
@@ -726,10 +726,23 @@
           "expr": "max(max by(persistentvolumeclaim) (1 - kubelet_volume_stats_available_bytes{namespace=\"$namespace\", persistentvolumeclaim=~\"$instances\"} / kubelet_volume_stats_capacity_bytes{namespace=\"$namespace\", persistentvolumeclaim=~\"$instances\"}))",
           "format": "time_series",
           "interval": "",
-          "legendFormat": "{{persistentvolumeclaim}}",
+          "legendFormat": "DATA",
           "range": true,
-          "refId": "FREE_SPACE"
-        }
+          "refId": "DATA"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "max(max by(persistentvolumeclaim) (1 - kubelet_volume_stats_available_bytes{namespace=\"$namespace\", persistentvolumeclaim=~\"(${instances})-wal\"} / kubelet_volume_stats_capacity_bytes{namespace=\"$namespace\", persistentvolumeclaim=~\"(${instances})-wal\"}))",
+          "format": "time_series",
+          "interval": "",
+          "legendFormat": "WAL",
+          "range": true,
+          "refId": "WAL"
+        }        
       ],
       "title": "Volume Space Usage",
       "type": "gauge"

--- a/docs/src/samples/monitoring/grafana-dashboard.json
+++ b/docs/src/samples/monitoring/grafana-dashboard.json
@@ -3166,7 +3166,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": true,
-          "expr": "cnpg_pg_settings_setting{name=\"effective_cache_size\",namespace=~\"$namespace\",pod=~\"$instances\"}",
+          "expr": "max by (pod) (cnpg_pg_settings_setting{name=\"effective_cache_size\",namespace=~\"$namespace\",pod=~\"$instances\"}) * max by (pod) (cnpg_pg_settings_setting{name=\"block_size\",namespace=~\"$namespace\",pod=~\"$instances\"})",
           "instant": true,
           "interval": "",
           "legendFormat": "{{pod}}",


### PR DESCRIPTION
For the default Grafana dashboard,
- adds a new size gauge for WAL PVCs, and
- fixes the computation of the cache size

Closes #2836
Closes #2914

Signed-off-by: Daniel Chambre <smiyc@pm.me>