### PR TITLE
feat!: change default value of `switchoverDelay` to `3600`

### DIFF
--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -278,9 +278,8 @@ type ClusterSpec struct {
 
 	// The time in seconds that is allowed for a primary PostgreSQL instance
 	// to gracefully shutdown during a switchover.
-	// Default value is 40000000, greater than one year in seconds,
-	// big enough to simulate an infinite delay
-	// +kubebuilder:default:=40000000
+	// Default value is 3600 seconds (1 hour).
+	// +kubebuilder:default:=3600
 	// +optional
 	MaxSwitchoverDelay int32 `json:"switchoverDelay,omitempty"`
 

--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -980,7 +980,7 @@ const (
 	// DefaultMaxSwitchoverDelay is the default for the pg_ctl timeout in seconds when a primary PostgreSQL instance
 	// is gracefully shutdown during a switchover.
 	// It is greater than one year in seconds, big enough to simulate an infinite timeout
-	DefaultMaxSwitchoverDelay = 40000000
+	DefaultMaxSwitchoverDelay = 3600
 )
 
 // PostgresConfiguration defines the PostgreSQL configuration

--- a/config/crd/bases/postgresql.cnpg.io_clusters.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_clusters.yaml
@@ -3260,11 +3260,10 @@ spec:
                 - name
                 type: object
               switchoverDelay:
-                default: 40000000
+                default: 3600
                 description: The time in seconds that is allowed for a primary PostgreSQL
                   instance to gracefully shutdown during a switchover. Default value
-                  is 40000000, greater than one year in seconds, big enough to simulate
-                  an infinite delay
+                  is 3600 seconds (1 hour).
                 format: int32
                 type: integer
               topologySpreadConstraints:

--- a/docs/src/cloudnative-pg.v1.md
+++ b/docs/src/cloudnative-pg.v1.md
@@ -1468,7 +1468,7 @@ gracefully shutdown (default 30)</p>
 <td>
    <p>The time in seconds that is allowed for a primary PostgreSQL instance
 to gracefully shutdown during a switchover.
-Default value is 3600</p>
+Default value is 3600 seconds (1 hour).</p>
 </td>
 </tr>
 <tr><td><code>failoverDelay</code><br/>

--- a/docs/src/cloudnative-pg.v1.md
+++ b/docs/src/cloudnative-pg.v1.md
@@ -1468,8 +1468,7 @@ gracefully shutdown (default 30)</p>
 <td>
    <p>The time in seconds that is allowed for a primary PostgreSQL instance
 to gracefully shutdown during a switchover.
-Default value is 40000000, greater than one year in seconds,
-big enough to simulate an infinite delay</p>
+Default value is 3600</p>
 </td>
 </tr>
 <tr><td><code>failoverDelay</code><br/>

--- a/docs/src/instance_manager.md
+++ b/docs/src/instance_manager.md
@@ -77,10 +77,7 @@ in order to ensure that all the data are available on the new primary.
 
 For this reason, the `.spec.switchoverDelay`, expressed in seconds, controls
 the  time given to the former primary to shut down gracefully and archive all 
-the WAL files.
-During this time frame, the primary instance does not accept connections.
-The value defaults is greater than one year in seconds, big enough to simulate
-an infinite delay and therefore preserve data durability.
+the WAL files. By default it is set to `3600` (1 hour).
 
 !!! Warning
     The `.spec.switchoverDelay` option affects the RPO and RTO of your


### PR DESCRIPTION
BREAKING CHANGE: The default value of `switchoverDelay` has now been changed to 3600 seconds, equivalent of 1 hour. Previously, it was set to 40000000 seconds.

Closes #2845 
