### PR TITLE
feat: support startupProbe in instance pod

### DIFF
--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -982,7 +982,9 @@ const (
 	// It is greater than one year in seconds, big enough to simulate an infinite timeout
 	DefaultMaxSwitchoverDelay = 3600
 
-	// DefaultStartupDelay is the default value for startupDelay
+	// DefaultStartupDelay is the default value for startupDelay, startupDelay will be used to calculate the
+	// FailureThreshold of startupProbe, the formula is `FailureThreshold = ceiling(startDelay / periodSeconds)`,
+	// the minimum value is 1
 	DefaultStartupDelay = 3600
 )
 

--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -265,7 +265,7 @@ type ClusterSpec struct {
 	WalStorage *StorageConfiguration `json:"walStorage,omitempty"`
 
 	// The time in seconds that is allowed for a PostgreSQL instance to
-	// successfully start up (default 3600)
+	// successfully start up (default 3600).
 	// The startup probe failure threshold is derived from this value using the formula:
 	// ceiling(startDelay / 10).
 	// +kubebuilder:default:=3600

--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -266,6 +266,8 @@ type ClusterSpec struct {
 
 	// The time in seconds that is allowed for a PostgreSQL instance to
 	// successfully start up (default 3600)
+	// The startup probe failure threshold is derived from this value using the formula:
+	// ceiling(startDelay / 10).
 	// +kubebuilder:default:=3600
 	// +optional
 	MaxStartDelay int32 `json:"startDelay,omitempty"`

--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -265,8 +265,8 @@ type ClusterSpec struct {
 	WalStorage *StorageConfiguration `json:"walStorage,omitempty"`
 
 	// The time in seconds that is allowed for a PostgreSQL instance to
-	// successfully start up (default 30)
-	// +kubebuilder:default:=30
+	// successfully start up (default 3600)
+	// +kubebuilder:default:=3600
 	// +optional
 	MaxStartDelay int32 `json:"startDelay,omitempty"`
 
@@ -981,6 +981,9 @@ const (
 	// is gracefully shutdown during a switchover.
 	// It is greater than one year in seconds, big enough to simulate an infinite timeout
 	DefaultMaxSwitchoverDelay = 3600
+
+	// DefaultStartupDelay is the default value for startupDelay
+	DefaultStartupDelay = 3600
 )
 
 // PostgresConfiguration defines the PostgreSQL configuration
@@ -2381,7 +2384,7 @@ func (cluster *Cluster) GetMaxStartDelay() int32 {
 	if cluster.Spec.MaxStartDelay > 0 {
 		return cluster.Spec.MaxStartDelay
 	}
-	return 30
+	return DefaultStartupDelay
 }
 
 // GetMaxStopDelay get the amount of time PostgreSQL has to stop

--- a/config/crd/bases/postgresql.cnpg.io_clusters.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_clusters.yaml
@@ -3011,8 +3011,10 @@ spec:
                 type: object
               startDelay:
                 default: 3600
-                description: The time in seconds that is allowed for a PostgreSQL
-                  instance to successfully start up (default 3600)
+                description: 'The time in seconds that is allowed for a PostgreSQL
+                  instance to successfully start up (default 3600) The startup probe
+                  failure threshold is derived from this value using the formula:
+                  ceiling(startDelay / 10).'
                 format: int32
                 type: integer
               stopDelay:

--- a/config/crd/bases/postgresql.cnpg.io_clusters.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_clusters.yaml
@@ -3010,9 +3010,9 @@ spec:
                 - metadata
                 type: object
               startDelay:
-                default: 30
+                default: 3600
                 description: The time in seconds that is allowed for a PostgreSQL
-                  instance to successfully start up (default 30)
+                  instance to successfully start up (default 3600)
                 format: int32
                 type: integer
               stopDelay:

--- a/config/crd/bases/postgresql.cnpg.io_clusters.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_clusters.yaml
@@ -3012,7 +3012,7 @@ spec:
               startDelay:
                 default: 3600
                 description: 'The time in seconds that is allowed for a PostgreSQL
-                  instance to successfully start up (default 3600) The startup probe
+                  instance to successfully start up (default 3600). The startup probe
                   failure threshold is derived from this value using the formula:
                   ceiling(startDelay / 10).'
                 format: int32

--- a/docs/src/cloudnative-pg.v1.md
+++ b/docs/src/cloudnative-pg.v1.md
@@ -1451,7 +1451,7 @@ user by setting it to <code>NULL</code>. Enabled by default.</p>
 </td>
 <td>
    <p>The time in seconds that is allowed for a PostgreSQL instance to
-successfully start up (default 30)</p>
+successfully start up (default 3600)</p>
 </td>
 </tr>
 <tr><td><code>stopDelay</code><br/>

--- a/docs/src/cloudnative-pg.v1.md
+++ b/docs/src/cloudnative-pg.v1.md
@@ -1451,7 +1451,9 @@ user by setting it to <code>NULL</code>. Enabled by default.</p>
 </td>
 <td>
    <p>The time in seconds that is allowed for a PostgreSQL instance to
-successfully start up (default 3600)</p>
+successfully start up (default 3600)
+The startup probe failure threshold is derived from this value using the formula:
+ceiling(startDelay / 10).</p>
 </td>
 </tr>
 <tr><td><code>stopDelay</code><br/>

--- a/pkg/specs/pods.go
+++ b/pkg/specs/pods.go
@@ -21,6 +21,7 @@ package specs
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"reflect"
 	"strconv"
 
@@ -255,12 +256,12 @@ func createPostgresContainers(cluster apiv1.Cluster, envConfig EnvConfig) []core
 }
 
 // getStartupProbeFailureThreshold get the startup probe failure threshold
-// FAILURE_THRESHOLD = ceiling(startDelay / periodSeconds) and minimum value is 1
+// FAILURE_THRESHOLD = ceil(startDelay / periodSeconds) and minimum value is 1
 func getStartupProbeFailureThreshold(startupDelay int32) int32 {
 	if startupDelay <= StartupProbePeriod {
 		return 1
 	}
-	return startupDelay / StartupProbePeriod
+	return int32(math.Ceil(float64(startupDelay) / float64(StartupProbePeriod)))
 }
 
 // CreateAffinitySection creates the affinity sections for Pods, given the configuration

--- a/pkg/specs/pods.go
+++ b/pkg/specs/pods.go
@@ -81,6 +81,12 @@ const (
 
 	// ReadinessProbePeriod is the period set for the postgres instance readiness probe
 	ReadinessProbePeriod = 10
+
+	// StartupProbePeriod is the period set for the postgres instance startup probe
+	StartupProbePeriod = 10
+
+	// LivenessProbePeriod is the period set for the postgres instance liveness probe
+	LivenessProbePeriod = 10
 )
 
 // EnvConfig carries the environment configuration of a container
@@ -184,6 +190,18 @@ func createPostgresContainers(cluster apiv1.Cluster, envConfig EnvConfig) []core
 			Env:             envConfig.EnvVars,
 			EnvFrom:         envConfig.EnvFrom,
 			VolumeMounts:    createPostgresVolumeMounts(cluster),
+
+			StartupProbe: &corev1.Probe{
+				FailureThreshold: getStartupProbeFailureThreshold(cluster.GetMaxStartDelay()),
+				PeriodSeconds:    StartupProbePeriod,
+				TimeoutSeconds:   5,
+				ProbeHandler: corev1.ProbeHandler{
+					HTTPGet: &corev1.HTTPGetAction{
+						Path: url.PathHealth,
+						Port: intstr.FromInt(url.StatusPort),
+					},
+				},
+			},
 			ReadinessProbe: &corev1.Probe{
 				TimeoutSeconds: 5,
 				PeriodSeconds:  ReadinessProbePeriod,
@@ -194,14 +212,9 @@ func createPostgresContainers(cluster apiv1.Cluster, envConfig EnvConfig) []core
 					},
 				},
 			},
-			// From K8s 1.17 and newer, startup probes will be available for
-			// all users and not just protected from feature gates. For now
-			// let's use the LivenessProbe. When we will drop support for K8s
-			// 1.16, we'll configure a StartupProbe and this will lead to a
-			// better LivenessProbe (without InitialDelaySeconds).
 			LivenessProbe: &corev1.Probe{
-				InitialDelaySeconds: cluster.GetMaxStartDelay(),
-				TimeoutSeconds:      5,
+				PeriodSeconds:  LivenessProbePeriod,
+				TimeoutSeconds: 5,
 				ProbeHandler: corev1.ProbeHandler{
 					HTTPGet: &corev1.HTTPGetAction{
 						Path: url.PathHealth,
@@ -239,6 +252,15 @@ func createPostgresContainers(cluster apiv1.Cluster, envConfig EnvConfig) []core
 	addManagerLoggingOptions(cluster, &containers[0])
 
 	return containers
+}
+
+// getStartupProbeFailureThreshold get the startup probe failure threshold
+// FAILURE_THRESHOLD = ceiling(startDelay / periodSeconds) and minimum value is 1
+func getStartupProbeFailureThreshold(startupDelay int32) int32 {
+	if startupDelay <= StartupProbePeriod {
+		return 1
+	}
+	return startupDelay / StartupProbePeriod
 }
 
 // CreateAffinitySection creates the affinity sections for Pods, given the configuration

--- a/pkg/specs/pods.go
+++ b/pkg/specs/pods.go
@@ -191,7 +191,6 @@ func createPostgresContainers(cluster apiv1.Cluster, envConfig EnvConfig) []core
 			Env:             envConfig.EnvVars,
 			EnvFrom:         envConfig.EnvFrom,
 			VolumeMounts:    createPostgresVolumeMounts(cluster),
-
 			StartupProbe: &corev1.Probe{
 				FailureThreshold: getStartupProbeFailureThreshold(cluster.GetMaxStartDelay()),
 				PeriodSeconds:    StartupProbePeriod,
@@ -199,7 +198,7 @@ func createPostgresContainers(cluster apiv1.Cluster, envConfig EnvConfig) []core
 				ProbeHandler: corev1.ProbeHandler{
 					HTTPGet: &corev1.HTTPGetAction{
 						Path: url.PathHealth,
-						Port: intstr.FromInt(url.StatusPort),
+						Port: intstr.FromInt32(int32(url.StatusPort)),
 					},
 				},
 			},

--- a/pkg/specs/pods_test.go
+++ b/pkg/specs/pods_test.go
@@ -829,3 +829,13 @@ var _ = Describe("PodSpec drift detection", func() {
 		Expect(specsMatch).To(BeFalse())
 	})
 })
+
+var _ = Describe("Compute startup probe failure threshold", func() {
+	It("should take the minimum value 1", func() {
+		Expect(getStartupProbeFailureThreshold(5)).To(BeNumerically("==", 1))
+	})
+
+	It("should take the value from 'startDelay / periodSeconds'", func() {
+		Expect(getStartupProbeFailureThreshold(109)).To(BeNumerically("==", 11))
+	})
+})


### PR DESCRIPTION
this patch provide the startupProbe support for postgres pod, 
the failureThreshold of startupProbe is calculated by startDelay / PeriodSeconds,
while PeriodSeconds is use default 10 seconds. startDelay by default is 3600

closes: #2843 