### PR TITLE
chore: always push a new image after merging on main

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -374,10 +374,11 @@ jobs:
           echo "DATE=${commit_date}" >> $GITHUB_ENV
           echo "VERSION=${commit_version}" >> $GITHUB_ENV
           echo "COMMIT=${commit_short}" >> $GITHUB_ENV
-          echo "PUSH=false" >> $GITHUB_ENV
           if [[ "${GITHUB_REF#refs/heads/}" =~ ^(main|release-) ]]
           then
             echo "PUSH=true" >> $GITHUB_ENV
+          else
+            echo "PUSH=false" >> $GITHUB_ENV
           fi
 
       - name: Check PR label conditions

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -375,6 +375,10 @@ jobs:
           echo "VERSION=${commit_version}" >> $GITHUB_ENV
           echo "COMMIT=${commit_short}" >> $GITHUB_ENV
           echo "PUSH=false" >> $GITHUB_ENV
+          if [[ "${GITHUB_REF#refs/heads/}" =~ ^(main|release-) ]]
+          then
+            echo "PUSH=true" >> $GITHUB_ENV
+          fi
 
       - name: Check PR label conditions
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
The continuous-integration was only actually pushing images when a PR was labeled with "always push images".
But we should also produce the images whenever a new commit is pushed on main or a release branch.
This will ensure that the `ghcr.io/cloudnative-pg/cloudnative-pg-testing` main and release-* images are updated as soon as a new commit is pushed (up until now it was done only once per day via the continuos-delivery workflow)