### PR TITLE
tests: ensure client certificate is always being created

### DIFF
--- a/tests/e2e/asserts_test.go
+++ b/tests/e2e/asserts_test.go
@@ -2793,8 +2793,8 @@ func AssertClusterRollingRestart(namespace, clusterName string) {
 		// waiting for cluster phase to end up in "Upgrading cluster" state after restarting the cluster.
 		Eventually(func() (bool, error) {
 			cluster, err := env.GetCluster(namespace, clusterName)
-			return ( cluster.Status.Phase == apiv1.PhaseUpgrade ) ||
-			 ( cluster.Status.Phase == apiv1.PhaseWaitingForInstancesToBeActive ), err
+			return (cluster.Status.Phase == apiv1.PhaseUpgrade) ||
+				(cluster.Status.Phase == apiv1.PhaseWaitingForInstancesToBeActive), err
 		}, 120, 3).Should(BeTrue())
 	})
 	AssertClusterIsReady(namespace, clusterName, testTimeouts[testsUtils.ClusterIsReadyQuick], env)

--- a/tests/e2e/certificates_test.go
+++ b/tests/e2e/certificates_test.go
@@ -96,6 +96,17 @@ var _ = Describe("Certificates", func() {
 			clusterName, err = env.GetResourceNameFromYAML(sampleFile)
 			Expect(err).ToNot(HaveOccurred())
 			AssertCreateCluster(namespace, clusterName, sampleFile, env)
+
+			// Create the client certificate
+			cluster, err := env.GetCluster(namespace, clusterName)
+			Expect(err).ToNot(HaveOccurred())
+			err = utils.CreateClientCertificatesViaKubectlPlugin(
+				*cluster,
+				kubectlCNPGClientCertSecretName,
+				"app",
+				env,
+			)
+			Expect(err).ToNot(HaveOccurred())
 		})
 		AfterEach(func() {
 			// deleting root CA certificates
@@ -104,26 +115,14 @@ var _ = Describe("Certificates", func() {
 
 		It("can authenticate using a Certificate that is generated from the 'kubectl-cnpg' plugin",
 			Label(tests.LabelPlugin), func() {
-				cluster, err := env.GetCluster(namespace, clusterName)
-				Expect(err).ToNot(HaveOccurred())
-				err = utils.CreateClientCertificatesViaKubectlPlugin(
-					*cluster,
-					kubectlCNPGClientCertSecretName,
-					"app",
-					env,
-				)
-				Expect(err).ToNot(HaveOccurred())
-
 				pod := utils.DefaultWebapp(namespace, "app-pod-cert-1",
 					defaultCASecretName, kubectlCNPGClientCertSecretName)
-				err = utils.PodCreateAndWaitForReady(env, &pod, 240)
+				err := utils.PodCreateAndWaitForReady(env, &pod, 240)
 				Expect(err).ToNot(HaveOccurred())
 				AssertSSLVerifyFullDBConnectionFromAppPod(namespace, clusterName, pod)
 			})
 
 		It("can authenticate after switching to user-supplied server certs", Label(tests.LabelServiceConnectivity), func() {
-			cluster, err := env.GetCluster(namespace, clusterName)
-			Expect(err).ToNot(HaveOccurred())
 			CreateAndAssertServerCertificatesSecrets(
 				namespace,
 				clusterName,
@@ -131,6 +130,8 @@ var _ = Describe("Certificates", func() {
 				serverCertSecretName,
 				false,
 			)
+
+			var err error
 			// Updating defaults certificates entries with user provided certificates,
 			// i.e server CA and TLS secrets inside the cluster
 			Eventually(func() error {
@@ -144,6 +145,7 @@ var _ = Describe("Certificates", func() {
 				}
 				return nil
 			}, 60, 5).Should(BeNil())
+
 			Eventually(func() (bool, error) {
 				certUpdateStatus := false
 				cluster, err := env.GetCluster(namespace, clusterName)
@@ -154,14 +156,6 @@ var _ = Describe("Certificates", func() {
 				}
 				return certUpdateStatus, err
 			}, 120).Should(BeTrue(), fmt.Sprintf("Error: %v", err))
-
-			err = utils.CreateClientCertificatesViaKubectlPlugin(
-				*cluster,
-				kubectlCNPGClientCertSecretName,
-				"app",
-				env,
-			)
-			Expect(err).ToNot(HaveOccurred())
 
 			pod := utils.DefaultWebapp(
 				namespace,

--- a/tests/e2e/certificates_test.go
+++ b/tests/e2e/certificates_test.go
@@ -122,7 +122,7 @@ var _ = Describe("Certificates", func() {
 			})
 
 		It("can authenticate after switching to user-supplied server certs", Label(tests.LabelServiceConnectivity), func() {
-			_, err := env.GetCluster(namespace, clusterName)
+			cluster, err := env.GetCluster(namespace, clusterName)
 			Expect(err).ToNot(HaveOccurred())
 			CreateAndAssertServerCertificatesSecrets(
 				namespace,
@@ -154,6 +154,14 @@ var _ = Describe("Certificates", func() {
 				}
 				return certUpdateStatus, err
 			}, 120).Should(BeTrue(), fmt.Sprintf("Error: %v", err))
+
+			err = utils.CreateClientCertificatesViaKubectlPlugin(
+				*cluster,
+				kubectlCNPGClientCertSecretName,
+				"app",
+				env,
+			)
+			Expect(err).ToNot(HaveOccurred())
 
 			pod := utils.DefaultWebapp(
 				namespace,


### PR DESCRIPTION
The connectivity test were failing due to a dependency of a previous test that should create the proper secret with the required certificate. Now, we create the certificate everytime in the test to keep the tests independent.