### PR TITLE
fix: cleans up the resources lists in the generated Role

### DIFF
--- a/pkg/specs/roles_test.go
+++ b/pkg/specs/roles_test.go
@@ -186,13 +186,47 @@ var _ = Describe("Roles", func() {
 })
 
 var _ = Describe("Secrets", func() {
-	var cluster apiv1.Cluster
+	var (
+		cluster apiv1.Cluster
+		backup  apiv1.Backup
+	)
 
 	BeforeEach(func() {
 		cluster = apiv1.Cluster{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "thisTest",
 				Namespace: "default",
+			},
+		}
+		backup = apiv1.Backup{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "testBackup",
+				Namespace: "default",
+			},
+			Status: apiv1.BackupStatus{
+				BarmanCredentials: apiv1.BarmanCredentials{
+					AWS: &apiv1.S3Credentials{
+						AccessKeyIDReference: &apiv1.SecretKeySelector{
+							LocalObjectReference: apiv1.LocalObjectReference{
+								Name: "aws-status-secret-test",
+							},
+						},
+					},
+					Azure: &apiv1.AzureCredentials{
+						StorageKey: &apiv1.SecretKeySelector{
+							LocalObjectReference: apiv1.LocalObjectReference{
+								Name: "azure-storage-key-secret-test",
+							},
+						},
+					},
+					Google: &apiv1.GoogleCredentials{
+						ApplicationCredentials: &apiv1.SecretKeySelector{
+							LocalObjectReference: apiv1.LocalObjectReference{
+								Name: "google-application-secret-test",
+							},
+						},
+					},
+				},
 			},
 		}
 	})
@@ -227,6 +261,19 @@ var _ = Describe("Secrets", func() {
 
 	It("should contain default secrets only", func() {
 		Expect(getInvolvedSecretNames(cluster, nil)).To(Equal([]string{
+			"thisTest-app",
+			"thisTest-ca",
+			"thisTest-replication",
+			"thisTest-server",
+			"thisTest-superuser",
+		}))
+	})
+
+	It("should created an ordered string list with the backup secrets", func() {
+		Expect(getInvolvedSecretNames(cluster, &backup)).To(Equal([]string{
+			"aws-status-secret-test",
+			"azure-storage-key-secret-test",
+			"google-application-secret-test",
 			"thisTest-app",
 			"thisTest-ca",
 			"thisTest-replication",

--- a/pkg/specs/roles_test.go
+++ b/pkg/specs/roles_test.go
@@ -186,12 +186,16 @@ var _ = Describe("Roles", func() {
 })
 
 var _ = Describe("Secrets", func() {
-	cluster := apiv1.Cluster{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "thisTest",
-			Namespace: "default",
-		},
-	}
+	var cluster apiv1.Cluster
+
+	BeforeEach(func() {
+		cluster = apiv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "thisTest",
+				Namespace: "default",
+			},
+		}
+	})
 
 	It("are properly backed up", func() {
 		secrets := backupSecrets(cluster, nil)
@@ -219,6 +223,17 @@ var _ = Describe("Secrets", func() {
 		}
 		secrets = backupSecrets(cluster, nil)
 		Expect(secrets).To(ConsistOf("test-secret", "test-access", "test-endpoint-ca-name"))
+	})
+
+	It("should contain default secrets only", func() {
+		Expect(secretResourceNames(cluster, nil)).To(Equal([]string{
+			cluster.GetReplicationSecretName(),
+			cluster.GetClientCASecretName(),
+			cluster.GetServerCASecretName(),
+			cluster.GetServerTLSSecretName(),
+			cluster.GetApplicationSecretName(),
+			cluster.GetSuperuserSecretName(),
+		}))
 	})
 })
 

--- a/pkg/specs/roles_test.go
+++ b/pkg/specs/roles_test.go
@@ -226,13 +226,12 @@ var _ = Describe("Secrets", func() {
 	})
 
 	It("should contain default secrets only", func() {
-		Expect(secretResourceNames(cluster, nil)).To(Equal([]string{
-			cluster.GetReplicationSecretName(),
-			cluster.GetClientCASecretName(),
-			cluster.GetServerCASecretName(),
-			cluster.GetServerTLSSecretName(),
-			cluster.GetApplicationSecretName(),
-			cluster.GetSuperuserSecretName(),
+		Expect(getInvolvedSecretNames(cluster, nil)).To(Equal([]string{
+			"thisTest-app",
+			"thisTest-ca",
+			"thisTest-replication",
+			"thisTest-server",
+			"thisTest-superuser",
 		}))
 	})
 })

--- a/pkg/stringset/stringset.go
+++ b/pkg/stringset/stringset.go
@@ -17,6 +17,10 @@ limitations under the License.
 // Package stringset implements a basic set of strings
 package stringset
 
+import (
+	"golang.org/x/exp/slices"
+)
+
 // Data represent a set of strings
 type Data struct {
 	innerMap map[string]struct{}
@@ -50,7 +54,7 @@ func (set *Data) Delete(key string) {
 	delete(set.innerMap, key)
 }
 
-// Has check if a string is in the set or not
+// Has checks if a string is in the set or not
 func (set *Data) Has(key string) bool {
 	_, ok := set.innerMap[key]
 	return ok
@@ -69,6 +73,14 @@ func (set *Data) ToList() (result []string) {
 		result = append(result, key)
 	}
 	return
+}
+
+// ToSortedList returns the string container in this set
+// as a sorted string slice
+func (set *Data) ToSortedList() []string {
+	result := set.ToList()
+	slices.Sort(result)
+	return result
 }
 
 // Eq compares two string sets for equality

--- a/pkg/stringset/stringset_test.go
+++ b/pkg/stringset/stringset_test.go
@@ -57,4 +57,10 @@ var _ = Describe("String set", func() {
 		Expect(From([]string{"one", "two"}).Eq(From([]string{"one", "two", "three"}))).To(BeFalse())
 		Expect(From([]string{"one", "two", "three"}).Eq(From([]string{"one", "two"}))).To(BeFalse())
 	})
+
+	It("constructs a sorted string slice given a set", func() {
+		Expect(From([]string{"one", "two", "three", "four"}).ToSortedList()).To(
+			HaveExactElements("four", "one", "three", "two"))
+		Expect(New().ToList()).To(BeEmpty())
+	})
 })


### PR DESCRIPTION
Closes: #2861 

The empty string mentioned by #2861 comes from LADP secret name, refer to https://github.com/cloudnative-pg/cloudnative-pg/blob/main/api/v1/cluster_types.go#L2220-L2227. 
