### PR TITLE
fix: ensure that restore snapshot cmd omits excluded files

### DIFF
--- a/docs/src/samples/cluster-restore-snapshot-full.yaml
+++ b/docs/src/samples/cluster-restore-snapshot-full.yaml
@@ -1,7 +1,7 @@
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
-  name: cluster-restore-pitr
+  name: cluster-restore-full
 spec:
   instances: 3
 
@@ -9,29 +9,10 @@ spec:
     size: 1Gi
     storageClass: csi-hostpath-sc
 
-  externalClusters:
-    - name: origin
-
-      barmanObjectStore:
-        serverName: cluster-example-with-backup
-        destinationPath: s3://backups/
-        endpointURL: http://minio:9000
-        s3Credentials:
-          accessKeyId:
-            name: minio
-            key: ACCESS_KEY_ID
-          secretAccessKey:
-            name: minio
-            key: ACCESS_SECRET_KEY
-        wal:
-          maxParallel: 8
-
   bootstrap:
     recovery:
-      source: origin
-
       volumeSnapshots:
         storage:
-          name: cluster-example-with-backup-3-1692618163
+          name: cluster-example-2-1695821489
           kind: VolumeSnapshot
           apiGroup: snapshot.storage.k8s.io

--- a/internal/cmd/manager/instance/restoresnapshot/cmd.go
+++ b/internal/cmd/manager/instance/restoresnapshot/cmd.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cloudnative-pg/cloudnative-pg/internal/management/istio"
 	"github.com/cloudnative-pg/cloudnative-pg/internal/management/linkerd"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/log"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres"
 )
 
@@ -56,7 +57,11 @@ func NewCmd() *cobra.Command {
 				PgWal:       pgWal,
 			}
 
-			return execute(ctx, info)
+			err := execute(ctx, info)
+			if err != nil {
+				log.Error(err, "Error while recovering Volume Snapshot backup")
+			}
+			return err
 		},
 		PostRunE: func(cmd *cobra.Command, args []string) error {
 			if err := istio.TryInvokeQuitEndpoint(cmd.Context()); err != nil {

--- a/pkg/fileutils/fileutils.go
+++ b/pkg/fileutils/fileutils.go
@@ -357,8 +357,14 @@ func RemoveFiles(basePath string, filePaths []string) error {
 	for _, pattern := range filePaths {
 		if len(pattern) >= 2 && pattern[len(pattern)-2:] == "/*" {
 			dirPath := filepath.Join(basePath, pattern[:len(pattern)-2])
-			if err := RemoveDirectoryContent(dirPath); err != nil {
+			dirExists, err := FileExists(dirPath)
+			if err != nil {
 				return err
+			}
+			if dirExists {
+				if err := RemoveDirectoryContent(dirPath); err != nil {
+					return err
+				}
 			}
 			continue
 		}

--- a/pkg/fileutils/fileutils.go
+++ b/pkg/fileutils/fileutils.go
@@ -30,11 +30,7 @@ import (
 
 // excludedPathsFromRestore contains a list of files that should not be included into the restore process
 var excludedPathsFromRestore = []string{
-	"/pg_log/*",
-	"/log/*",
-	"/pg_xlog/*",
-	"/pg_wal/*",
-	"/global/pg_control",
+	"core.*",
 	"pgsql_tmp*",
 	"postgresql.auto.conf.tmp",
 	"current_logfiles.tmp",
@@ -42,13 +38,16 @@ var excludedPathsFromRestore = []string{
 	"postmaster.pid",
 	"postmaster.opts",
 	"recovery.conf",
+	"recovery.signal",
 	"standby.signal",
+	"log/*",
 	"pg_dynshmem/*",
+	"pg_log/*",
 	"pg_notify/*",
 	"pg_replslot/*",
 	"pg_serial/*",
-	"pg_stat_tmp/*",
 	"pg_snapshots/*",
+	"pg_stat_tmp/*",
 	"pg_subtrans/*",
 }
 

--- a/pkg/fileutils/fileutils_test.go
+++ b/pkg/fileutils/fileutils_test.go
@@ -200,3 +200,93 @@ var _ = Describe("function MoveDirectoryContent", func() {
 		Expect(files).Should(BeEmpty())
 	})
 })
+
+var _ = Describe("RemoveFiles", func() {
+	var tempDir string
+
+	BeforeEach(func() {
+		var err error
+		tempDir, err = os.MkdirTemp("", "test")
+		Expect(err).NotTo(HaveOccurred())
+
+		// Create some sample files and directories
+		Expect(os.WriteFile(filepath.Join(tempDir, "file1.txt"), []byte("test"), 0o600)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(tempDir, "file2.txt"), []byte("test"), 0o600)).To(Succeed())
+		Expect(os.Mkdir(filepath.Join(tempDir, "dir1"), 0o750)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(tempDir, "dir1", "file3.txt"), []byte("test"), 0o600)).To(Succeed())
+	})
+
+	AfterEach(func() {
+		// Cleanup
+		Expect(os.RemoveAll(tempDir)).To(Succeed())
+	})
+
+	It("removes specified files and directories", func() {
+		// Use the RemoveFiles function
+		err := RemoveFiles(tempDir, []string{
+			"file1.txt",
+			"dir1/*",
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		// Assert files and directories are removed as expected
+		_, err = os.Stat(filepath.Join(tempDir, "file1.txt"))
+		Expect(os.IsNotExist(err)).To(BeTrue(), "Expected file1.txt to be removed")
+
+		_, err = os.Stat(filepath.Join(tempDir, "file2.txt"))
+		Expect(err).NotTo(HaveOccurred(), "Expected file2.txt to not be removed")
+
+		_, err = os.Stat(filepath.Join(tempDir, "dir1", "file3.txt"))
+		Expect(os.IsNotExist(err)).To(BeTrue(), "Expected dir1/file3.txt to be removed")
+
+		_, err = os.Stat(filepath.Join(tempDir, "dir1"))
+		Expect(err).NotTo(HaveOccurred(), "Expected dir1 to not be removed")
+	})
+})
+
+var _ = Describe("RemoveRestoreExcludedFiles", func() {
+	var tempDir string
+
+	BeforeEach(func() {
+		var err error
+		tempDir, err = os.MkdirTemp("", "test")
+		Expect(err).NotTo(HaveOccurred())
+
+		// Create temporary directories and files
+		for _, path := range excludedPathsFromRestore {
+			fullPath := filepath.Join(tempDir, path)
+			if len(path) >= 2 && path[len(path)-2:] == "/*" {
+				dirToCreate := fullPath[:len(fullPath)-2]
+				Expect(os.Mkdir(dirToCreate, 0o750)).To(Succeed())
+				Expect(os.WriteFile(filepath.Join(dirToCreate, "testfile.txt"), []byte("test"), 0o600)).To(Succeed())
+				continue
+			}
+			// Ensure directory exists before creating the file
+			dirOfTheFile := filepath.Dir(fullPath)
+			if _, err := os.Stat(dirOfTheFile); os.IsNotExist(err) {
+				Expect(os.MkdirAll(dirOfTheFile, 0o750)).To(Succeed())
+			}
+			Expect(os.WriteFile(fullPath, []byte("test"), 0o600)).To(Succeed())
+
+		}
+	})
+
+	AfterEach(func() {
+		_ = os.RemoveAll(tempDir)
+	})
+
+	It("should correctly remove specified files and directories", func() {
+		Expect(RemoveRestoreExcludedFiles(tempDir)).To(Succeed())
+
+		for _, path := range excludedPathsFromRestore {
+			fullPath := filepath.Join(tempDir, path)
+			if len(path) >= 2 && path[len(path)-2:] == "/*" {
+				_, err := os.Stat(filepath.Join(fullPath[:len(fullPath)-2], "testfile.txt"))
+				Expect(os.IsNotExist(err)).To(BeTrue(), "Expected directory contents to be removed: "+fullPath)
+			} else {
+				_, err := os.Stat(fullPath)
+				Expect(os.IsNotExist(err)).To(BeTrue(), "Expected file to be removed: "+fullPath)
+			}
+		}
+	})
+})

--- a/pkg/fileutils/fileutils_test.go
+++ b/pkg/fileutils/fileutils_test.go
@@ -226,6 +226,7 @@ var _ = Describe("RemoveFiles", func() {
 		err := RemoveFiles(tempDir, []string{
 			"file1.txt",
 			"dir1/*",
+			"non_existent_dir/*",
 		})
 		Expect(err).NotTo(HaveOccurred())
 

--- a/pkg/management/postgres/configuration.go
+++ b/pkg/management/postgres/configuration.go
@@ -281,19 +281,6 @@ func configurePostgresAutoConfFile(pgData, primaryConnInfo, slotName string) (ch
 	return changed, nil
 }
 
-// removeSignalFiles removes the PostgreSQL signal files to get
-// a cleanup up pgdata. This is useful after having restored
-// a PVC snapshot
-func removeSignalFiles(pgData string) error {
-	standbySignalFile := filepath.Join(pgData, "standby.signal")
-	if err := fileutils.RemoveFile(standbySignalFile); err != nil {
-		return err
-	}
-
-	recoverySignalFile := filepath.Join(pgData, "recovery.signal")
-	return fileutils.RemoveFile(recoverySignalFile)
-}
-
 // createStandbySignal creates a standby.signal file for PostgreSQL 12 and beyond
 func createStandbySignal(pgData string) error {
 	emptyFile, err := os.Create(filepath.Clean(filepath.Join(pgData, "standby.signal")))

--- a/pkg/management/postgres/restore.go
+++ b/pkg/management/postgres/restore.go
@@ -88,18 +88,18 @@ func (info InitInfo) RestoreSnapshot(ctx context.Context, cli client.Client) err
 		return err
 	}
 
-	if cluster.Spec.Bootstrap == nil || cluster.Spec.Bootstrap.Recovery == nil ||
-		cluster.Spec.Bootstrap.Recovery.Source == "" {
-		// We are recovering from an existing PVC snapshot, we
-		// don't need to invoke the recovery job
-		return nil
-	}
-
 	log.Info("Recovering from volume snapshot",
 		"sourceName", cluster.Spec.Bootstrap.Recovery.Source)
 
 	if err := fileutils.RemoveRestoreExcludedFiles(info.PgData); err != nil {
 		return fmt.Errorf("error while cleaning up the recovered PGDATA: %w", err)
+	}
+
+	if cluster.Spec.Bootstrap == nil || cluster.Spec.Bootstrap.Recovery == nil ||
+		cluster.Spec.Bootstrap.Recovery.Source == "" {
+		// We are recovering from an existing PVC snapshot, we
+		// don't need to invoke the recovery job
+		return nil
 	}
 
 	backup, env, err := info.createBackupObjectForSnapshotRestore(ctx, cli, cluster)

--- a/pkg/management/postgres/restore.go
+++ b/pkg/management/postgres/restore.go
@@ -97,8 +97,9 @@ func (info InitInfo) RestoreSnapshot(ctx context.Context, cli client.Client) err
 
 	log.Info("Recovering from volume snapshot",
 		"sourceName", cluster.Spec.Bootstrap.Recovery.Source)
-	if err := removeSignalFiles(info.PgData); err != nil {
-		return fmt.Errorf("error while cleaning up the signal files: %w", err)
+
+	if err := fileutils.RemoveRestoreExcludedFiles(info.PgData); err != nil {
+		return fmt.Errorf("error while cleaning up the recovered PGDATA: %w", err)
 	}
 
 	backup, env, err := info.createBackupObjectForSnapshotRestore(ctx, cli, cluster)
@@ -136,10 +137,6 @@ func (info InitInfo) RestoreSnapshot(ctx context.Context, cli client.Client) err
 	}
 
 	if err := info.writeRestoreWalConfig(backup, cluster); err != nil {
-		return err
-	}
-
-	if err := fileutils.RemoveRestoreExcludedFiles(info.PgData); err != nil {
 		return err
 	}
 

--- a/pkg/management/postgres/restore.go
+++ b/pkg/management/postgres/restore.go
@@ -139,6 +139,10 @@ func (info InitInfo) RestoreSnapshot(ctx context.Context, cli client.Client) err
 		return err
 	}
 
+	if err := fileutils.RemoveRestoreExcludedFiles(info.PgData); err != nil {
+		return err
+	}
+
 	return info.ConfigureInstanceAfterRestore(ctx, cluster, env)
 }
 


### PR DESCRIPTION
After the recovery process from a volume snapshot completes,
we need to cleanup the content of PGDATA, similarly to what
backup tools like Barman do. This is the list of files that we
remove from PGDATA:

- core.*
- pgsql_tmp*
- postgresql.auto.conf.tmp
- current_logfiles.tmp
- pg_internal.init
- postmaster.pid
- postmaster.opts
- recovery.conf
- recovery.signal
- standby.signal
- log/*
- pg_dynshmem/*
- pg_log/*
- pg_notify/*
- pg_replslot/*
- pg_serial/*
- pg_snapshots/*
- pg_stat_tmp/*
- pg_subtrans/*

Closes #2865 