### PR TITLE
fix: avoid write-read concurrency on cached cluster

### DIFF
--- a/internal/management/cache/cache.go
+++ b/internal/management/cache/cache.go
@@ -67,7 +67,13 @@ func StoreCluster(cluster *apiv1.Cluster) {
 	cache.Store(ClusterKey, cluster.DeepCopy())
 }
 
-// LoadCluster loads a key from the local cache
+// LoadCluster retrieves a cluster from the local cache.
+// Warning:
+//
+//	The returned pointer can potentially be accessed concurrently.
+//	Only use this function for read-only operations. If you need to
+//	modify the cluster, always create a DeepCopy of the returned object
+//	before writing to it.
 func LoadCluster() (*apiv1.Cluster, error) {
 	value, ok := cache.Load(ClusterKey)
 	if !ok {

--- a/internal/management/cache/cache.go
+++ b/internal/management/cache/cache.go
@@ -59,6 +59,14 @@ func LoadEnv(c string) ([]string, error) {
 	return nil, ErrUnsupportedObject
 }
 
+// StoreCluster write a cluster object into the local cache
+func StoreCluster(cluster *apiv1.Cluster) {
+	// We need to make a copy of the cluster object, because
+	// the cluster object contains attribute with concurrent unsafe type
+	// such as map, slice, etc.
+	cache.Store(ClusterKey, cluster.DeepCopy())
+}
+
 // LoadCluster loads a key from the local cache
 func LoadCluster() (*apiv1.Cluster, error) {
 	value, ok := cache.Load(ClusterKey)

--- a/internal/management/cache/cache.go
+++ b/internal/management/cache/cache.go
@@ -67,14 +67,14 @@ func StoreCluster(cluster *apiv1.Cluster) {
 	cache.Store(ClusterKey, cluster.DeepCopy())
 }
 
-// LoadCluster retrieves a cluster from the local cache.
+// LoadClusterUnsafe retrieves a cluster from the local cache.
 // Warning:
 //
 //	The returned pointer can potentially be accessed concurrently.
 //	Only use this function for read-only operations. If you need to
 //	modify the cluster, always create a DeepCopy of the returned object
 //	before writing to it.
-func LoadCluster() (*apiv1.Cluster, error) {
+func LoadClusterUnsafe() (*apiv1.Cluster, error) {
 	value, ok := cache.Load(ClusterKey)
 	if !ok {
 		return nil, ErrCacheMiss

--- a/internal/management/controller/cache.go
+++ b/internal/management/controller/cache.go
@@ -36,7 +36,7 @@ import (
 func (r *InstanceReconciler) updateCacheFromCluster(
 	ctx context.Context, cluster *apiv1.Cluster,
 ) shoudRequeue {
-	cache.Store(cache.ClusterKey, cluster)
+	cache.StoreCluster(cluster)
 
 	var requeue shoudRequeue
 

--- a/internal/management/controller/cache.go
+++ b/internal/management/controller/cache.go
@@ -33,9 +33,7 @@ import (
 // updateCacheFromCluster will update the internal cache with the cluster
 //
 // returns true if the update was not total, and should be retried
-func (r *InstanceReconciler) updateCacheFromCluster(
-	ctx context.Context, cluster *apiv1.Cluster,
-) shoudRequeue {
+func (r *InstanceReconciler) updateCacheFromCluster(ctx context.Context, cluster *apiv1.Cluster) shoudRequeue {
 	cache.StoreCluster(cluster)
 
 	var requeue shoudRequeue
@@ -50,10 +48,7 @@ func (r *InstanceReconciler) updateCacheFromCluster(
 	return requeue
 }
 
-func (r *InstanceReconciler) updateWALRestoreSettingsCache(
-	ctx context.Context,
-	cluster *apiv1.Cluster,
-) {
+func (r *InstanceReconciler) updateWALRestoreSettingsCache(ctx context.Context, cluster *apiv1.Cluster) {
 	_, env, barmanConfiguration, err := walrestore.GetRecoverConfiguration(cluster, r.instance.PodName)
 	if errors.Is(err, walrestore.ErrNoBackupConfigured) {
 		cache.Delete(cache.WALRestoreKey)

--- a/pkg/management/postgres/webserver/local.go
+++ b/pkg/management/postgres/webserver/local.go
@@ -83,7 +83,7 @@ func (ws *localWebserverEndpoints) serveCache(w http.ResponseWriter, r *http.Req
 	var js []byte
 	switch requestedObject {
 	case cache.ClusterKey:
-		response, err := cache.LoadCluster()
+		response, err := cache.LoadClusterUnsafe()
 		if errors.Is(err, cache.ErrCacheMiss) {
 			w.WriteHeader(http.StatusNotFound)
 			return

--- a/pkg/management/postgres/webserver/metricserver/pg_collector.go
+++ b/pkg/management/postgres/webserver/metricserver/pg_collector.go
@@ -430,7 +430,7 @@ func (e *Exporter) setTimestampMetric(
 	errorLabel string,
 	getTimestampFunc func(cluster *apiv1.Cluster) string,
 ) {
-	cluster, err := cache.LoadCluster()
+	cluster, err := cache.LoadClusterUnsafe()
 	// there isn't a cached object yet
 	if errors.Is(err, cache.ErrCacheMiss) {
 		return
@@ -472,7 +472,7 @@ func (e *Exporter) setTimestampMetric(
 func (e *Exporter) collectNodesUsed() {
 	const notExtractedValue float64 = -1
 
-	cluster, err := cache.LoadCluster()
+	cluster, err := cache.LoadClusterUnsafe()
 	if err != nil {
 		log.Error(err, "unable to collect metrics")
 		e.Metrics.Error.Set(1)

--- a/pkg/management/postgres/webserver/metricserver/wal.go
+++ b/pkg/management/postgres/webserver/metricserver/wal.go
@@ -219,7 +219,7 @@ func collectPGWalSettings(exporter *Exporter, db *sql.DB) error {
 }
 
 func getWalVolumeSize() float64 {
-	cluster, err := cache.LoadCluster()
+	cluster, err := cache.LoadClusterUnsafe()
 	if err != nil || !cluster.ShouldCreateWalArchiveVolume() {
 		return 0
 	}


### PR DESCRIPTION
Closes: #2863 

I reviewed the instance manager log attached in #2860 and identified two significant points

```
goroutine 562 [running]:
reflect.mapiterinit(0x451652?, 0x1c0?, 0x1d96c40?)
	/opt/hostedtoolcache/go/1.20.6/x64/src/runtime/map.go:1375 +0x19
reflect.(*MapIter).Next(0x1c7fc60?)
	/opt/hostedtoolcache/go/1.20.6/x64/src/reflect/value.go:1919 +0x65
encoding/json.mapEncoder.encode({0xc00062d388?}, 0xc00048c280, {0x1c7fc60?, 0xc0004af678?, 0x800?}, {0xd?, 0x0?})
	/opt/hostedtoolcache/go/1.20.6/x64/src/encoding/json/encode.go:797 +0x33e
encoding/json.structEncoder.encode({{{0xc000b0fb00?, 0x79c025?, 0xc00062d490?}, 0xc0006d9ad0?}}, 0xc00048c280, {0x1e35ae0?, 0xc0004af678?, 0xd?}, {0x0, 0x1})
	/opt/hostedtoolcache/go/1.20.6/x64/src/encoding/json/encode.go:759 +0x1f4
encoding/json.structEncoder.encode({{{0xc0005d8c00?, 0x37?, 0xc00062d598?}, 0xc000683380?}}, 0xc00048c280, {0x1f460a0?, 0xc0004af608?, 0x7?}, {0x0, 0x1})
	/opt/hostedtoolcache/go/1.20.6/x64/src/encoding/json/encode.go:759 +0x1f4
encoding/json.structEncoder.encode({{{0xc000b0e480?, 0xc00062d690?, 0x40bbb6?}, 0xc000683bc0?}}, 0xc00048c280, {0x1e63b60?, 0xc0004af500?, 0x7a025a?}, {0x0, 0x1})
	/opt/hostedtoolcache/go/1.20.6/x64/src/encoding/json/encode.go:759 +0x1f4
encoding/json.ptrEncoder.encode({0x1?}, 0xc00048c280, {0x1f53e00?, 0xc0004af500?, 0x1f53e00?}, {0x8?, 0xd8?})
	/opt/hostedtoolcache/go/1.20.6/x64/src/encoding/json/encode.go:943 +0x21c
encoding/json.(*encodeState).reflectValue(0xc00048c280?, {0x1f53e00?, 0xc0004af500?, 0x40e1c7?}, {0x78?, 0x0?})
	/opt/hostedtoolcache/go/1.20.6/x64/src/encoding/json/encode.go:358 +0x78
encoding/json.(*encodeState).marshal(0xc00062d8f0?, {0x1f53e00?, 0xc0004af500?}, {0x20?, 0x60?})
	/opt/hostedtoolcache/go/1.20.6/x64/src/encoding/json/encode.go:330 +0xfa
encoding/json.Marshal({0x1f53e00, 0xc0004af500})
	/opt/hostedtoolcache/go/1.20.6/x64/src/encoding/json/encode.go:161 +0xe5
github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres/webserver.(*localWebserverEndpoints).serveCache(0x985a70?, {0x22618d0, 0xc000e4a000}, 0x50fb69?)
	pkg/management/postgres/webserver/local.go:96 +0x179
net/http.HandlerFunc.ServeHTTP(0xc00048c100?, {0x22618d0?, 0xc000e4a000?}, 0x40ddea?)
	/opt/hostedtoolcache/go/1.20.6/x64/src/net/http/server.go:2122 +0x2f
net/http.(*ServeMux).ServeHTTP(0x0?, {0x22618d0, 0xc000e4a000}, 0xc000e7a000)
	/opt/hostedtoolcache/go/1.20.6/x64/src/net/http/server.go:2500 +0x149
net/http.serverHandler.ServeHTTP({0xc0004224e0?}, {0x22618d0, 0xc000e4a000}, 0xc000e7a000)
	/opt/hostedtoolcache/go/1.20.6/x64/src/net/http/server.go:2936 +0x316
net/http.(*conn).serve(0xc00029e090, {0x2262830, 0xc0004b8180})
	/opt/hostedtoolcache/go/1.20.6/x64/src/net/http/server.go:1995 +0x612
created by net/http.(*Server).Serve
	/opt/hostedtoolcache/go/1.20.6/x64/src/net/http/server.go:3089 +0x5ed


goroutine 134 [runnable]:
reflect.Value.Addr({0x1d38640?, 0xc0004af7e8?, 0x195?})
	/opt/hostedtoolcache/go/1.20.6/x64/src/reflect/value.go:271 +0x7a
sigs.k8s.io/json/internal/golang/encoding/json.indirect({0x1d38640?, 0xc0004af7e8?, 0xc0004af698?}, 0x0)
	pkg/mod/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd/internal/golang/encoding/json/decode.go:473 +0xcf
sigs.k8s.io/json/internal/golang/encoding/json.(*decodeState).object(0xc000b809c0, {0x1d38640?, 0xc0004af7e8?, 0x1dd6c20?})
	pkg/mod/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd/internal/golang/encoding/json/decode.go:645 +0x69
sigs.k8s.io/json/internal/golang/encoding/json.(*decodeState).value(0xc000b809c0, {0x1d38640?, 0xc0004af7e8?, 0x6?})
	pkg/mod/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd/internal/golang/encoding/json/decode.go:401 +0x45
sigs.k8s.io/json/internal/golang/encoding/json.(*decodeState).object(0xc000b809c0, {0x1dd6c20?, 0xc0004af7e8?, 0x117c?})
	pkg/mod/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd/internal/golang/encoding/json/decode.go:867 +0x1310
sigs.k8s.io/json/internal/golang/encoding/json.(*decodeState).value(0xc000b809c0, {0x1dd6c20?, 0xc0004af7e8?, 0x9?})
	pkg/mod/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd/internal/golang/encoding/json/decode.go:401 +0x45
sigs.k8s.io/json/internal/golang/encoding/json.(*decodeState).object(0xc000b809c0, {0x1f460a0?, 0xc0004af608?, 0x24d3?})
	pkg/mod/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd/internal/golang/encoding/json/decode.go:867 +0x1310
sigs.k8s.io/json/internal/golang/encoding/json.(*decodeState).value(0xc000b809c0, {0x1f460a0?, 0xc0004af608?, 0x4?})
	pkg/mod/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd/internal/golang/encoding/json/decode.go:401 +0x45
sigs.k8s.io/json/internal/golang/encoding/json.(*decodeState).object(0xc000b809c0, {0x1f53e00?, 0xc0004af500?, 0x1f53e00?})
	pkg/mod/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd/internal/golang/encoding/json/decode.go:867 +0x1310
sigs.k8s.io/json/internal/golang/encoding/json.(*decodeState).value(0xc000b809c0, {0x1f53e00?, 0xc0004af500?, 0x7f14f6210a68?})
	pkg/mod/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd/internal/golang/encoding/json/decode.go:401 +0x45
sigs.k8s.io/json/internal/golang/encoding/json.(*decodeState).unmarshal(0xc000b809c0, {0x1f53e00?, 0xc0004af500?})
	pkg/mod/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd/internal/golang/encoding/json/decode.go:188 +0x168
sigs.k8s.io/json/internal/golang/encoding/json.Unmarshal({0xc0007f0000, 0x1d2c, 0x2500}, {0x1f53e00, 0xc0004af500}, {0xc000654c68, 0x2, 0xc000654c88?})
	pkg/mod/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd/internal/golang/encoding/json/decode.go:113 +0x159
sigs.k8s.io/json.UnmarshalCaseSensitivePreserveInts(...)
	pkg/mod/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd/json.go:62
k8s.io/apimachinery/pkg/runtime/serializer/json.(*Serializer).unmarshal(0xc0000561f8?, {0x224c7f0?, 0xc0004af500?}, {0xc0007f0000?, 0xc000d4a160?, 0x7?}, {0xc0007f0000?, 0xc00029a770?, 0x2247920?})
	pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/runtime/serializer/json/json.go:258 +0x39c
k8s.io/apimachinery/pkg/runtime/serializer/json.(*Serializer).Decode(0xc0000dc230, {0xc0007f0000, 0x1d2c, 0x2500}, 0x0, {0x224c7f0, 0xc0004af500?})
	pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/runtime/serializer/json/json.go:206 +0xa6a
k8s.io/apimachinery/pkg/runtime.WithoutVersionDecoder.Decode({{0x2247a00?, 0xc0000dc230?}}, {0xc0007f0000?, 0x199?, 0xc0004af500?}, 0x1e63b60?, {0x224c7f0?, 0xc0004af500?})
	pkg/mod/k8s.io/apimachinery@v0.27.4/pkg/runtime/helper.go:252 +0x55
sigs.k8s.io/controller-runtime/pkg/client/apiutil.targetZeroingDecoder.Decode({{0x224b200?, 0xc000b644e0?}}, {0xc0007f0000, 0x1d2c, 0x2500}, 0x0?, {0x224c7f0?, 0xc0004af500?})
	pkg/mod/sigs.k8s.io/controller-runtime@v0.15.0/pkg/client/apiutil/apimachinery.go:236 +0xb8
k8s.io/client-go/rest.Result.Into({{0xc0007f0000, 0x1d2c, 0x2500}, {0x0, 0x0, 0x0}, {0xc000b2c3b0, 0x10}, {0x0, 0x0}, ...}, ...)
	pkg/mod/k8s.io/client-go@v0.27.4/rest/request.go:1349 +0xad
sigs.k8s.io/controller-runtime/pkg/client.(*typedClient).PatchSubResource(0xc0005f8510, {0x2262830, 0xc000179da0}, {0x2286488?, 0xc0004af500}, {0x1f593e8, 0x6}, {0x2252e98, 0xc000400b40}, {0x0, ...})
	pkg/mod/sigs.k8s.io/controller-runtime@v0.15.0/pkg/client/typed_client.go:278 +0x505
sigs.k8s.io/controller-runtime/pkg/client.(*subResourceClient).Patch(0xc0003a0588, {0x2262830, 0xc000179da0}, {0x2286488?, 0xc0004af500}, {0x2252e98, 0xc000400b40}, {0x0, 0x0, 0x0})
	pkg/mod/sigs.k8s.io/controller-runtime@v0.15.0/pkg/client/client.go:585 +0x315
github.com/cloudnative-pg/cloudnative-pg/internal/management/controller.(*InstanceReconciler).reconcilePrimary(0xc000280e80, {0x2262830, 0xc000179da0}, 0xc0004af500)
	internal/management/controller/instance_controller.go:1066 +0x305
github.com/cloudnative-pg/cloudnative-pg/internal/management/controller.(*InstanceReconciler).Reconcile(0xc000280e80, {0x2262830?, 0xc000179a10?}, {{{0xc000179a10?, 0x0?}, {0xc000655d20?, 0x40e1c7?}}})
	internal/management/controller/instance_controller.go:188 +0x692
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile(0x2262830?, {0x2262830?, 0xc000179a10?}, {{{0xc0004315b0?, 0x1bb6d60?}, {0xc0006f4c48?, 0x224eac8?}}})
	pkg/mod/sigs.k8s.io/controller-runtime@v0.15.0/pkg/internal/controller/controller.go:118 +0xc8
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc0002fde00, {0x2262788, 0xc0000dc730}, {0x1d73540?, 0xc000415420?})
	pkg/mod/sigs.k8s.io/controller-runtime@v0.15.0/pkg/internal/controller/controller.go:314 +0x377
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc0002fde00, {0x2262788, 0xc0000dc730})
	pkg/mod/sigs.k8s.io/controller-runtime@v0.15.0/pkg/internal/controller/controller.go:265 +0x1d9
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2()
	pkg/mod/sigs.k8s.io/controller-runtime@v0.15.0/pkg/internal/controller/controller.go:226 +0x85
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2
	pkg/mod/sigs.k8s.io/controller-runtime@v0.15.0/pkg/internal/controller/controller.go:222 +0x587
```

 There are concurrent read/write on cluster object  

1. [serveCache](https://github.com/cloudnative-pg/cloudnative-pg/blob/main/pkg/management/postgres/webserver/local.go#L96) includes a read operation on cluster object when json marshal 
2. [reconcilePrimary](https://github.com/cloudnative-pg/cloudnative-pg/blob/main/internal/management/controller/instance_controller.go#L1072)  includes a write operation on cluster object when calling k8s client to perform a patch 

Note that the write operation on the function reconcilePrimary occurs on the case of switchover that is mentioned by the above dicussion
