### PR TITLE
feat: enable replications slots for HA by default

### DIFF
--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -865,14 +865,13 @@ func (r *ReplicationSlotsConfiguration) GetUpdateInterval() time.Duration {
 // when a streaming client (in this specific case a replica that
 // is part of the HA cluster) gets disconnected.
 type ReplicationSlotsHAConfiguration struct {
-	// If enabled, the operator will automatically manage replication slots
+	// If enabled (default), the operator will automatically manage replication slots
 	// on the primary instance and use them in streaming replication
 	// connections with all the standby instances that are part of the HA
-	// cluster. If disabled (default), the operator will not take advantage
+	// cluster. If disabled, the operator will not take advantage
 	// of replication slots in streaming connections with the replicas.
 	// This feature also controls replication slots in replica cluster,
-	// from the designated primary to its cascading replicas. This can only
-	// be set at creation time.
+	// from the designated primary to its cascading replicas.
 	// +optional
 	// +kubebuilder:default:=false
 	Enabled *bool `json:"enabled,omitempty"`
@@ -911,12 +910,12 @@ func (r *ReplicationSlotsHAConfiguration) GetSlotNameFromInstanceName(instanceNa
 	return sanitizedName
 }
 
-// GetEnabled returns true if replication slots are enabled, default is false
+// GetEnabled returns false if replication slots are disabled, default is true
 func (r *ReplicationSlotsHAConfiguration) GetEnabled() bool {
 	if r != nil && r.Enabled != nil {
 		return *r.Enabled
 	}
-	return false
+	return true
 }
 
 // KubernetesUpgradeStrategy tells the operator if the user want to

--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -218,6 +218,7 @@ type ClusterSpec struct {
 	PostgresConfiguration PostgresConfiguration `json:"postgresql,omitempty"`
 
 	// Replication slots management configuration
+	// +kubebuilder:default:={"highAvailability":{"enabled":true}}
 	// +optional
 	ReplicationSlots *ReplicationSlotsConfiguration `json:"replicationSlots,omitempty"`
 
@@ -837,6 +838,7 @@ const DefaultReplicationSlotsHASlotPrefix = "_cnpg_"
 // of replication slots
 type ReplicationSlotsConfiguration struct {
 	// Replication slots for high availability configuration
+	// +kubebuilder:default:={"enabled": true}
 	// +optional
 	HighAvailability *ReplicationSlotsHAConfiguration `json:"highAvailability,omitempty"`
 
@@ -873,7 +875,7 @@ type ReplicationSlotsHAConfiguration struct {
 	// This feature also controls replication slots in replica cluster,
 	// from the designated primary to its cascading replicas.
 	// +optional
-	// +kubebuilder:default:=false
+	// +kubebuilder:default:=true
 	Enabled *bool `json:"enabled,omitempty"`
 
 	// Prefix for replication slots managed by the operator for HA.

--- a/api/v1/cluster_webhook.go
+++ b/api/v1/cluster_webhook.go
@@ -145,7 +145,7 @@ func (r *Cluster) setDefaults(preserveUserSettings bool) {
 		r.defaultMonitoringQueries(configuration.Current)
 	}
 
-	// If the API or validation webhooks are disable we set the replicationSlots to true if nil
+	// If the ReplicationSlots or HighAvailability stanzas are nil, we create them and enable slots
 	if r.Spec.ReplicationSlots == nil {
 		r.Spec.ReplicationSlots = &ReplicationSlotsConfiguration{}
 	}

--- a/api/v1/cluster_webhook_test.go
+++ b/api/v1/cluster_webhook_test.go
@@ -2623,10 +2623,47 @@ var _ = Describe("validation of replication slots configuration", func() {
 		Expect(result).To(BeEmpty())
 	})
 
+	It("set replicationSlots by default", func() {
+		cluster := &Cluster{
+			Spec: ClusterSpec{
+				ImageName: versions.DefaultImageName,
+			},
+		}
+		cluster.Default()
+		Expect(cluster.Spec.ReplicationSlots).ToNot(BeNil())
+		Expect(cluster.Spec.ReplicationSlots.HighAvailability).ToNot(BeNil())
+		Expect(cluster.Spec.ReplicationSlots.HighAvailability.Enabled).To(HaveValue(BeTrue()))
+
+		result := cluster.validateReplicationSlots()
+		Expect(result).To(BeEmpty())
+	})
+
+	It("set replicationSlots.highAvailability by default", func() {
+		cluster := &Cluster{
+			Spec: ClusterSpec{
+				ImageName: versions.DefaultImageName,
+				ReplicationSlots: &ReplicationSlotsConfiguration{
+					UpdateInterval: 30,
+				},
+			},
+		}
+		cluster.Default()
+		Expect(cluster.Spec.ReplicationSlots.HighAvailability).ToNot(BeNil())
+		Expect(cluster.Spec.ReplicationSlots.HighAvailability.Enabled).To(HaveValue(BeTrue()))
+
+		result := cluster.validateReplicationSlots()
+		Expect(result).To(BeEmpty())
+	})
+
 	It("allows enabling replication slots on the fly", func() {
 		oldCluster := &Cluster{
 			Spec: ClusterSpec{
 				ImageName: versions.DefaultImageName,
+				ReplicationSlots: &ReplicationSlotsConfiguration{
+					HighAvailability: &ReplicationSlotsHAConfiguration{
+						Enabled: ptr.To(false),
+					},
+				},
 			},
 		}
 		oldCluster.Default()
@@ -2643,13 +2680,12 @@ var _ = Describe("validation of replication slots configuration", func() {
 	})
 
 	It("prevents changing the slot prefix while replication slots are enabled", func() {
-		trueValue := true
 		oldCluster := &Cluster{
 			Spec: ClusterSpec{
 				ImageName: versions.DefaultImageName,
 				ReplicationSlots: &ReplicationSlotsConfiguration{
 					HighAvailability: &ReplicationSlotsHAConfiguration{
-						Enabled:    &trueValue,
+						Enabled:    ptr.To(true),
 						SlotPrefix: "_test_",
 					},
 				},

--- a/config/crd/bases/postgresql.cnpg.io_clusters.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_clusters.yaml
@@ -2879,15 +2879,14 @@ spec:
                     properties:
                       enabled:
                         default: false
-                        description: If enabled, the operator will automatically manage
-                          replication slots on the primary instance and use them in
-                          streaming replication connections with all the standby instances
-                          that are part of the HA cluster. If disabled (default),
+                        description: If enabled (default), the operator will automatically
+                          manage replication slots on the primary instance and use
+                          them in streaming replication connections with all the standby
+                          instances that are part of the HA cluster. If disabled,
                           the operator will not take advantage of replication slots
                           in streaming connections with the replicas. This feature
                           also controls replication slots in replica cluster, from
-                          the designated primary to its cascading replicas. This can
-                          only be set at creation time.
+                          the designated primary to its cascading replicas.
                         type: boolean
                       slotPrefix:
                         default: _cnpg_

--- a/config/crd/bases/postgresql.cnpg.io_clusters.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_clusters.yaml
@@ -2872,13 +2872,18 @@ spec:
                 - source
                 type: object
               replicationSlots:
+                default:
+                  highAvailability:
+                    enabled: true
                 description: Replication slots management configuration
                 properties:
                   highAvailability:
+                    default:
+                      enabled: true
                     description: Replication slots for high availability configuration
                     properties:
                       enabled:
-                        default: false
+                        default: true
                         description: If enabled (default), the operator will automatically
                           manage replication slots on the primary instance and use
                           them in streaming replication connections with all the standby

--- a/docs/src/cloudnative-pg.v1.md
+++ b/docs/src/cloudnative-pg.v1.md
@@ -3499,14 +3499,13 @@ is part of the HA cluster) gets disconnected.</p>
 <i>bool</i>
 </td>
 <td>
-   <p>If enabled, the operator will automatically manage replication slots
+   <p>If enabled (default), the operator will automatically manage replication slots
 on the primary instance and use them in streaming replication
 connections with all the standby instances that are part of the HA
-cluster. If disabled (default), the operator will not take advantage
+cluster. If disabled, the operator will not take advantage
 of replication slots in streaming connections with the replicas.
 This feature also controls replication slots in replica cluster,
-from the designated primary to its cascading replicas. This can only
-be set at creation time.</p>
+from the designated primary to its cascading replicas.</p>
 </td>
 </tr>
 <tr><td><code>slotPrefix</code><br/>

--- a/docs/src/replication.md
+++ b/docs/src/replication.md
@@ -232,7 +232,7 @@ can be disabled via configuration. For details, please refer to the
 Here follows a brief description of the main options:
 
 `.spec.replicationSlots.highAvailability.enabled`
-: if true, the feature is enabled (`true` is the default - since 1.21)
+: if true, the feature is enabled (`true` is the default since 1.21)
 
 `.spec.replicationSlots.highAvailability.slotPrefix`
 : the prefix that identifies replication slots managed by the operator
@@ -257,8 +257,8 @@ Here follows a brief description of the main options:
 Although it is not recommended, if you desire a different behavior, you can
 customize the above options.
 
-For example, the following manifest will create a cluster without replication
-slots enabled.
+For example, the following manifest will create a cluster with replication
+slots disabled.
 
 ```yaml
 apiVersion: postgresql.cnpg.io/v1

--- a/docs/src/replication.md
+++ b/docs/src/replication.md
@@ -232,7 +232,7 @@ can be disabled via configuration. For details, please refer to the
 Here follows a brief description of the main options:
 
 `.spec.replicationSlots.highAvailability.enabled`
-: if true, the feature is enabled (`true` is the default - since 1.20)
+: if true, the feature is enabled (`true` is the default - since 1.21)
 
 `.spec.replicationSlots.highAvailability.slotPrefix`
 : the prefix that identifies replication slots managed by the operator


### PR DESCRIPTION
IMPORTANT: the `.spec.replicationSlots.highAvailability.enabled` parameter is now by default set to `true`. This change was already anticipated in the upgrade instructions of CloudNativePG 1.20.

Closes #2673
