### PR TITLE
feat: disable `postgres` super user access by default

### DIFF
--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -240,8 +240,8 @@ type ClusterSpec struct {
 	// not present, the operator will automatically create one). When this
 	// option is disabled, the operator will ignore the `SuperuserSecret` content, delete
 	// it when automatically created, and then blank the password of the `postgres`
-	// user by setting it to `NULL`. Enabled by default.
-	// +kubebuilder:default:=true
+	// user by setting it to `NULL`. Disabled by default.
+	// +kubebuilder:default:=false
 	// +optional
 	EnableSuperuserAccess *bool `json:"enableSuperuserAccess,omitempty"`
 

--- a/config/crd/bases/postgresql.cnpg.io_clusters.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_clusters.yaml
@@ -1687,13 +1687,13 @@ spec:
                 description: Description of this PostgreSQL cluster
                 type: string
               enableSuperuserAccess:
-                default: true
+                default: false
                 description: When this option is enabled, the operator will use the
                   `SuperuserSecret` to update the `postgres` user password (if the
                   secret is not present, the operator will automatically create one).
                   When this option is disabled, the operator will ignore the `SuperuserSecret`
                   content, delete it when automatically created, and then blank the
-                  password of the `postgres` user by setting it to `NULL`. Enabled
+                  password of the `postgres` user by setting it to `NULL`. Disabled
                   by default.
                 type: boolean
               env:

--- a/docs/src/cloudnative-pg.v1.md
+++ b/docs/src/cloudnative-pg.v1.md
@@ -1439,7 +1439,7 @@ to update the <code>postgres</code> user password (if the secret is
 not present, the operator will automatically create one). When this
 option is disabled, the operator will ignore the <code>SuperuserSecret</code> content, delete
 it when automatically created, and then blank the password of the <code>postgres</code>
-user by setting it to <code>NULL</code>. Enabled by default.</p>
+user by setting it to <code>NULL</code>. Disabled by default.</p>
 </td>
 </tr>
 <tr><td><code>certificates</code><br/>

--- a/docs/src/security.md
+++ b/docs/src/security.md
@@ -295,9 +295,19 @@ operand          | 5432         | PostgreSQL instance | `postgresql`        |  o
 ### PostgreSQL
 
 The current implementation of CloudNativePG automatically creates
-passwords and `.pgpass` files for the `postgres` superuser and the database owner.
+passwords and `.pgpass` files for the the database owner and, only
+if requested by setting `enableSuperuserAccess` to `true`, for the
+`postgres` superuser.
 
-As far as encryption of password is concerned, CloudNativePG follows
+!!! Warning
+    Prior to CloudNativePG 1.21, `enableSuperuserAccess` was set to `true` by
+    default. This change has been implemented to improve the security-by-default
+    posture of the operator, fostering a microservice approach where changes to
+    PostgreSQL are performed in a declarative way through the `spec` of the
+    `Cluster` resource, while providing developers with full powers inside the
+    database through the database owner user.
+
+As far as password encryption is concerned, CloudNativePG follows
 the default behavior of PostgreSQL: starting from PostgreSQL 14,
 `password_encryption` is by default set to `scram-sha-256`, while on earlier
 versions it is set to `md5`.
@@ -305,9 +315,6 @@ versions it is set to `md5`.
 !!! Important
     Please refer to the ["Password authentication"](https://www.postgresql.org/docs/current/auth-password.html)
     section in the PostgreSQL documentation for details.
-
-You can disable management of the `postgres` user password via secrets by setting
-`enableSuperuserAccess` to `false`.
 
 !!! Note
     The operator supports toggling the `enableSuperuserAccess` option. When you


### PR DESCRIPTION
IMPORTANT: Change the default value of `.spec.enableSuperuserAccess` to `false`, in order improve the security by default posture of CloudNativePG by disabling superuser access via the network.

The rationale behind this is to foster a microservice approach where changes to PostgreSQL are performed in a declarative way through the `spec` of the `Cluster` resource, while providing developers with full powers inside the database through the database owner user. At the same time, give the possibility to users to enable it by explicitly setting `.spec.enableSuperuserAccess: true`.

Closes #2899 