### PR TITLE
feat: add `cnpg.io/instanceRole` label

### DIFF
--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -1106,6 +1106,7 @@ func (r *ClusterReconciler) mapNodeToClusters() handler.MapFunc {
 		err := r.List(ctx, &childPods,
 			client.MatchingFields{".spec.nodeName": node.Name},
 			client.MatchingLabels{
+				// TODO: eventually migrate to the new label
 				utils.ClusterRoleLabelName: specs.ClusterRoleLabelPrimary,
 				utils.PodRoleLabelName:     string(utils.PodRoleInstance),
 			},

--- a/controllers/cluster_restore.go
+++ b/controllers/cluster_restore.go
@@ -162,7 +162,9 @@ func getNodeSerialsFromPVCs(
 		if serial > highestSerial {
 			highestSerial = serial
 		}
-		if pvc.ObjectMeta.Labels[utils.ClusterRoleLabelName] == specs.ClusterRoleLabelPrimary {
+
+		instanceRole, _ := utils.GetInstanceRole(pvc.ObjectMeta.Labels)
+		if instanceRole == specs.ClusterRoleLabelPrimary {
 			primarySerial = serial
 		}
 	}

--- a/internal/cmd/plugin/psql/psql.go
+++ b/internal/cmd/plugin/psql/psql.go
@@ -130,7 +130,7 @@ func (psql *psqlCommand) getPodName() (string, error) {
 	}
 
 	for i := range psql.podList {
-		podRole := psql.podList[i].Labels[utils.ClusterRoleLabelName]
+		podRole, _ := utils.GetInstanceRole(psql.podList[i].Labels)
 		if podRole == targetPodRole {
 			return psql.podList[i].Name, nil
 		}

--- a/pkg/reconciler/instance/metadata.go
+++ b/pkg/reconciler/instance/metadata.go
@@ -182,18 +182,21 @@ func updateRoleLabels(
 		instance.Labels = make(map[string]string)
 	}
 
-	podRole, hasRole := utils.GetInstanceRole(instance.Labels)
+	podRole, hasRole := instance.ObjectMeta.Labels[utils.ClusterRoleLabelName]
+	newPodRole, newHasRole := instance.ObjectMeta.Labels[utils.ClusterInstanceRoleLabelName]
 
 	switch {
 	case instance.Name == cluster.Status.CurrentPrimary:
-		if !hasRole || podRole != specs.ClusterRoleLabelPrimary {
+		if !hasRole || podRole != specs.ClusterRoleLabelPrimary || !newHasRole ||
+			newPodRole != specs.ClusterRoleLabelPrimary {
 			contextLogger.Info("Setting primary label", "pod", instance.Name)
 			utils.SetInstanceRole(instance.ObjectMeta, specs.ClusterRoleLabelPrimary)
 			return true
 		}
 
 	default:
-		if !hasRole || podRole != specs.ClusterRoleLabelReplica {
+		if !hasRole || podRole != specs.ClusterRoleLabelReplica || !newHasRole ||
+			newPodRole != specs.ClusterRoleLabelReplica {
 			contextLogger.Info("Setting replica label", "pod", instance.Name)
 			utils.SetInstanceRole(instance.ObjectMeta, specs.ClusterRoleLabelReplica)
 			return true

--- a/pkg/reconciler/instance/metadata.go
+++ b/pkg/reconciler/instance/metadata.go
@@ -182,20 +182,20 @@ func updateRoleLabels(
 		instance.Labels = make(map[string]string)
 	}
 
-	podRole, hasRole := instance.ObjectMeta.Labels[utils.ClusterRoleLabelName]
+	podRole, hasRole := utils.GetInstanceRole(instance.Labels)
 
 	switch {
 	case instance.Name == cluster.Status.CurrentPrimary:
 		if !hasRole || podRole != specs.ClusterRoleLabelPrimary {
 			contextLogger.Info("Setting primary label", "pod", instance.Name)
-			instance.Labels[utils.ClusterRoleLabelName] = specs.ClusterRoleLabelPrimary
+			utils.SetInstanceRole(instance.ObjectMeta, specs.ClusterRoleLabelPrimary)
 			return true
 		}
 
 	default:
 		if !hasRole || podRole != specs.ClusterRoleLabelReplica {
 			contextLogger.Info("Setting replica label", "pod", instance.Name)
-			instance.Labels[utils.ClusterRoleLabelName] = specs.ClusterRoleLabelReplica
+			utils.SetInstanceRole(instance.ObjectMeta, specs.ClusterRoleLabelReplica)
 			return true
 		}
 	}

--- a/pkg/reconciler/instance/metadata_test.go
+++ b/pkg/reconciler/instance/metadata_test.go
@@ -59,10 +59,12 @@ var _ = Describe("object metadata test", func() {
 			Expect(updated).To(BeTrue())
 
 			Expect(primaryPod.Labels[utils.ClusterRoleLabelName]).To(Equal(specs.ClusterRoleLabelPrimary))
+			Expect(primaryPod.Labels[utils.ClusterInstanceRoleLabelName]).To(Equal(specs.ClusterRoleLabelPrimary))
 
 			updated = updateRoleLabels(context.Background(), cluster, replicaPod)
 			Expect(updated).To(BeTrue())
 			Expect(replicaPod.Labels[utils.ClusterRoleLabelName]).To(Equal(specs.ClusterRoleLabelReplica))
+			Expect(replicaPod.Labels[utils.ClusterInstanceRoleLabelName]).To(Equal(specs.ClusterRoleLabelReplica))
 		})
 
 		// nolint: dupl
@@ -77,7 +79,8 @@ var _ = Describe("object metadata test", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "newPrimaryPod",
 					Labels: map[string]string{
-						utils.ClusterRoleLabelName: specs.ClusterRoleLabelReplica,
+						utils.ClusterRoleLabelName:         specs.ClusterRoleLabelReplica,
+						utils.ClusterInstanceRoleLabelName: specs.ClusterRoleLabelReplica,
 					},
 				},
 			}
@@ -86,7 +89,8 @@ var _ = Describe("object metadata test", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "newReplicaPod",
 					Labels: map[string]string{
-						utils.ClusterRoleLabelName: specs.ClusterRoleLabelPrimary,
+						utils.ClusterRoleLabelName:         specs.ClusterRoleLabelPrimary,
+						utils.ClusterInstanceRoleLabelName: specs.ClusterRoleLabelPrimary,
 					},
 				},
 			}
@@ -94,10 +98,12 @@ var _ = Describe("object metadata test", func() {
 			updated := updateRoleLabels(context.Background(), cluster, newPrimaryPod)
 			Expect(updated).To(BeTrue())
 			Expect(newPrimaryPod.Labels[utils.ClusterRoleLabelName]).To(Equal(specs.ClusterRoleLabelPrimary))
+			Expect(newPrimaryPod.Labels[utils.ClusterInstanceRoleLabelName]).To(Equal(specs.ClusterRoleLabelPrimary))
 
 			updated = updateRoleLabels(context.Background(), cluster, newReplicaPod)
 			Expect(updated).To(BeTrue())
 			Expect(newReplicaPod.Labels[utils.ClusterRoleLabelName]).To(Equal(specs.ClusterRoleLabelReplica))
+			Expect(newReplicaPod.Labels[utils.ClusterInstanceRoleLabelName]).To(Equal(specs.ClusterRoleLabelReplica))
 		})
 
 		It("Should not perform role reconciliation when there is no current primary", func() {
@@ -105,25 +111,33 @@ var _ = Describe("object metadata test", func() {
 
 			oldPrimaryPod := &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:   "oldPrimaryPod",
-					Labels: map[string]string{utils.ClusterRoleLabelName: specs.ClusterRoleLabelPrimary},
+					Name: "oldPrimaryPod",
+					Labels: map[string]string{
+						utils.ClusterRoleLabelName:         specs.ClusterRoleLabelPrimary,
+						utils.ClusterInstanceRoleLabelName: specs.ClusterRoleLabelPrimary,
+					},
 				},
 			}
 
 			oldReplicaPod := &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:   "oldReplicaPod",
-					Labels: map[string]string{utils.ClusterRoleLabelName: specs.ClusterRoleLabelReplica},
+					Name: "oldReplicaPod",
+					Labels: map[string]string{
+						utils.ClusterRoleLabelName:         specs.ClusterRoleLabelReplica,
+						utils.ClusterInstanceRoleLabelName: specs.ClusterRoleLabelReplica,
+					},
 				},
 			}
 
 			updated := updateRoleLabels(context.Background(), cluster, oldPrimaryPod)
 			Expect(updated).To(BeFalse())
 			Expect(oldPrimaryPod.Labels[utils.ClusterRoleLabelName]).To(Equal(specs.ClusterRoleLabelPrimary))
+			Expect(oldPrimaryPod.Labels[utils.ClusterInstanceRoleLabelName]).To(Equal(specs.ClusterRoleLabelPrimary))
 
 			updated = updateRoleLabels(context.Background(), cluster, oldReplicaPod)
 			Expect(updated).To(BeFalse())
 			Expect(oldReplicaPod.Labels[utils.ClusterRoleLabelName]).To(Equal(specs.ClusterRoleLabelReplica))
+			Expect(oldReplicaPod.Labels[utils.ClusterInstanceRoleLabelName]).To(Equal(specs.ClusterRoleLabelReplica))
 		})
 
 		// nolint: dupl
@@ -136,25 +150,33 @@ var _ = Describe("object metadata test", func() {
 
 			primaryPod := &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:   "primaryPod",
-					Labels: map[string]string{utils.ClusterRoleLabelName: specs.ClusterRoleLabelPrimary},
+					Name: "primaryPod",
+					Labels: map[string]string{
+						utils.ClusterRoleLabelName:         specs.ClusterRoleLabelPrimary,
+						utils.ClusterInstanceRoleLabelName: specs.ClusterRoleLabelPrimary,
+					},
 				},
 			}
 
 			replicaPod := &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:   "replicaPod",
-					Labels: map[string]string{utils.ClusterRoleLabelName: specs.ClusterRoleLabelReplica},
+					Name: "replicaPod",
+					Labels: map[string]string{
+						utils.ClusterRoleLabelName:         specs.ClusterRoleLabelReplica,
+						utils.ClusterInstanceRoleLabelName: specs.ClusterRoleLabelReplica,
+					},
 				},
 			}
 
 			updated := updateRoleLabels(context.Background(), cluster, primaryPod)
 			Expect(updated).To(BeFalse())
 			Expect(primaryPod.Labels[utils.ClusterRoleLabelName]).To(Equal(specs.ClusterRoleLabelPrimary))
+			Expect(primaryPod.Labels[utils.ClusterInstanceRoleLabelName]).To(Equal(specs.ClusterRoleLabelPrimary))
 
 			updated = updateRoleLabels(context.Background(), cluster, replicaPod)
 			Expect(updated).To(BeFalse())
 			Expect(replicaPod.Labels[utils.ClusterRoleLabelName]).To(Equal(specs.ClusterRoleLabelReplica))
+			Expect(replicaPod.Labels[utils.ClusterInstanceRoleLabelName]).To(Equal(specs.ClusterRoleLabelReplica))
 		})
 	})
 
@@ -440,6 +462,8 @@ var _ = Describe("metadata reconciliation test", func() {
 				Expect(pod.Labels[utils.InstanceNameLabelName]).To(Equal(pod.Name))
 				Expect(pod.Labels[utils.ClusterRoleLabelName]).To(Or(Equal(specs.ClusterRoleLabelPrimary),
 					Equal(specs.ClusterRoleLabelReplica)))
+				Expect(pod.Labels[utils.ClusterInstanceRoleLabelName]).To(Or(Equal(specs.ClusterRoleLabelPrimary),
+					Equal(specs.ClusterRoleLabelReplica)))
 				Expect(pod.Labels["label1"]).To(Equal("value1"))
 				Expect(pod.Annotations["annotation1"]).To(Equal("value1"))
 			}
@@ -486,6 +510,7 @@ var _ = Describe("metadata update functions", func() {
 			modified := updateRoleLabels(ctx, cluster, instance)
 			Expect(modified).To(BeTrue())
 			Expect(instance.Labels[utils.ClusterRoleLabelName]).To(Equal(specs.ClusterRoleLabelPrimary))
+			Expect(instance.Labels[utils.ClusterInstanceRoleLabelName]).To(Equal(specs.ClusterRoleLabelPrimary))
 		})
 
 		It("Should updateOperatorLabels correctly", func() {

--- a/pkg/reconciler/instance/metadata_test.go
+++ b/pkg/reconciler/instance/metadata_test.go
@@ -178,6 +178,41 @@ var _ = Describe("object metadata test", func() {
 			Expect(replicaPod.Labels[utils.ClusterRoleLabelName]).To(Equal(specs.ClusterRoleLabelReplica))
 			Expect(replicaPod.Labels[utils.ClusterInstanceRoleLabelName]).To(Equal(specs.ClusterRoleLabelReplica))
 		})
+
+		It("should update existing instances with the new role label", func() {
+			cluster := &apiv1.Cluster{
+				Status: apiv1.ClusterStatus{
+					CurrentPrimary: "primaryPod",
+				},
+			}
+
+			primaryPod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "primaryPod",
+					Labels: map[string]string{
+						utils.ClusterRoleLabelName: specs.ClusterRoleLabelPrimary,
+					},
+				},
+			}
+
+			replicaPod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "replicaPod",
+					Labels: map[string]string{
+						utils.ClusterRoleLabelName: specs.ClusterRoleLabelReplica,
+					},
+				},
+			}
+			updated := updateRoleLabels(context.Background(), cluster, primaryPod)
+			Expect(updated).To(BeTrue())
+			Expect(primaryPod.Labels[utils.ClusterRoleLabelName]).To(Equal(specs.ClusterRoleLabelPrimary))
+			Expect(primaryPod.Labels[utils.ClusterInstanceRoleLabelName]).To(Equal(specs.ClusterRoleLabelPrimary))
+
+			updated = updateRoleLabels(context.Background(), cluster, replicaPod)
+			Expect(updated).To(BeTrue())
+			Expect(replicaPod.Labels[utils.ClusterRoleLabelName]).To(Equal(specs.ClusterRoleLabelReplica))
+			Expect(replicaPod.Labels[utils.ClusterInstanceRoleLabelName]).To(Equal(specs.ClusterRoleLabelReplica))
+		})
 	})
 
 	Context("updateOperatorLabelsOnInstances", func() {

--- a/pkg/specs/pg_pods.go
+++ b/pkg/specs/pg_pods.go
@@ -49,7 +49,7 @@ func IsPodPrimary(pod corev1.Pod) bool {
 
 // IsPrimary check if a certain resource belongs to a primary
 func IsPrimary(meta metav1.ObjectMeta) bool {
-	role, hasRole := meta.Labels[utils.ClusterRoleLabelName]
+	role, hasRole := utils.GetInstanceRole(meta.Labels)
 	if !hasRole {
 		return false
 	}

--- a/pkg/specs/pods.go
+++ b/pkg/specs/pods.go
@@ -52,6 +52,7 @@ const (
 	ClusterReloadAnnotationName = utils.ClusterReloadAnnotationName
 
 	// ClusterRoleLabelName label is applied to Pods to mark primary ones
+	// Deprecated: Use utils.ClusterInstanceRoleLabelName
 	ClusterRoleLabelName = utils.ClusterRoleLabelName
 
 	// WatchedLabelName label is for Secrets or ConfigMaps that needs to be reloaded

--- a/pkg/specs/services.go
+++ b/pkg/specs/services.go
@@ -85,7 +85,8 @@ func CreateClusterReadOnlyService(cluster apiv1.Cluster) *corev1.Service {
 			Type:  corev1.ServiceTypeClusterIP,
 			Ports: buildInstanceServicePorts(),
 			Selector: map[string]string{
-				utils.ClusterLabelName:     cluster.Name,
+				utils.ClusterLabelName: cluster.Name,
+				// TODO: eventually migrate to the new label
 				utils.ClusterRoleLabelName: ClusterRoleLabelReplica,
 			},
 		},

--- a/pkg/utils/labels_annotations.go
+++ b/pkg/utils/labels_annotations.go
@@ -53,7 +53,11 @@ const (
 	PgbouncerNameLabel = MetadataNamespace + "/poolerName"
 
 	// ClusterRoleLabelName is the name of label applied to instances to mark primary/replica
+	// Deprecated: Use ClusterInstanceRoleLabelName.
 	ClusterRoleLabelName = "role"
+
+	// ClusterInstanceRoleLabelName is the name of label applied to instances to mark primary/replica
+	ClusterInstanceRoleLabelName = MetadataNamespace + "/instanceRole"
 
 	// ImmediateBackupLabelName is the name of the label applied to backups to tell if the first scheduled backup is
 	// taken immediately or not
@@ -360,4 +364,25 @@ func MergeMap(receiver, giver map[string]string) {
 	for key, value := range giver {
 		receiver[key] = value
 	}
+}
+
+// GetInstanceRole tries to fetch the ClusterRoleLabelName andClusterInstanceRoleLabelName value from a given labels map
+func GetInstanceRole(labels map[string]string) (string, bool) {
+	if value := labels[ClusterRoleLabelName]; value != "" {
+		return value, true
+	}
+	if value := labels[ClusterInstanceRoleLabelName]; value != "" {
+		return value, true
+	}
+
+	return "", false
+}
+
+// SetInstanceRole sets both ClusterRoleLabelName and ClusterInstanceRoleLabelName on the given ObjectMeta
+func SetInstanceRole(meta metav1.ObjectMeta, role string) {
+	if meta.Labels == nil {
+		meta.Labels = map[string]string{}
+	}
+	meta.Labels[ClusterRoleLabelName] = role
+	meta.Labels[ClusterInstanceRoleLabelName] = role
 }

--- a/tests/e2e/asserts_test.go
+++ b/tests/e2e/asserts_test.go
@@ -2686,9 +2686,10 @@ func AssertPvcHasLabels(
 					ExpectedPvcRole = "PG_WAL"
 				}
 				expectedLabels := map[string]string{
-					utils.ClusterLabelName: clusterName,
-					utils.PvcRoleLabelName: ExpectedPvcRole,
-					"role":                 ExpectedRole,
+					utils.ClusterLabelName:             clusterName,
+					utils.PvcRoleLabelName:             ExpectedPvcRole,
+					utils.ClusterRoleLabelName:         ExpectedRole,
+					utils.ClusterInstanceRoleLabelName: ExpectedRole,
 				}
 				g.Expect(testsUtils.PvcHasLabels(pvc, expectedLabels)).To(BeTrue(),
 					fmt.Sprintf("expectedLabels: %v and found actualLabels on pvc: %v",

--- a/tests/utils/cluster.go
+++ b/tests/utils/cluster.go
@@ -275,7 +275,7 @@ func (env TestingEnvironment) GetClusterPodList(namespace string, clusterName st
 func (env TestingEnvironment) GetClusterPrimary(namespace string, clusterName string) (*corev1.Pod, error) {
 	podList := &corev1.PodList{}
 	err := GetObjectList(&env, podList, client.InNamespace(namespace),
-		client.MatchingLabels{utils.ClusterLabelName: clusterName, "role": "primary"},
+		client.MatchingLabels{utils.ClusterLabelName: clusterName, utils.ClusterInstanceRoleLabelName: "primary"},
 	)
 	if err != nil {
 		return &corev1.Pod{}, err


### PR DESCRIPTION
This patch adds `cnpg.io/instanceRole` and deprecates the existing `role` label.

This new addition results from an ongoing effort to use only namespaced labels/annotations for uniformity and to avoid potential name clashes with other domains.

The deprecated `role` label will be removed in a future release.

Closes #2825 
