### PR TITLE
chore: add default seccompProfile to operator

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -83,6 +83,8 @@ spec:
           runAsGroup: 10001
           readOnlyRootFilesystem: true
           allowPrivilegeEscalation: false
+          seccompProfile:
+            type: RuntimeDefault
           capabilities:
             drop:
               - "ALL"


### PR DESCRIPTION
Adding a default seccompProfile set to RuntimeDefault to the operator deployment.

Closes #2925 