### PR TITLE
chore: improve logging of PGDATA cleanup after recovery

### DIFF
--- a/pkg/fileutils/fileutils.go
+++ b/pkg/fileutils/fileutils.go
@@ -351,10 +351,18 @@ func GetDirectoryContent(dir string) (files []string, err error) {
 // be removed. If a pattern does not end with "/*", then the files matching the
 // pattern will be removed.
 //
+// Parameters:
+// - ctx: A context used for logging
+// - basePath: The root directory where the filePaths are applied.
+// - filePaths: List of relative paths or patterns to be removed.
+//
+// Returns:
+// - error: Any error encountered during the removal process, or nil if the operation was successful.
+//
 // Example:
 // basePath: "/path/to/directory"
 // filePaths: ["file1.txt", "subdir/*"]
-// This would remove "/path/to/direct
+// This would remove "/path/to/directory/file1.txt" and the "path/to/directory/subdir" folder
 func RemoveFiles(ctx context.Context, basePath string, filePaths []string) error {
 	contextLogger := log.FromContext(ctx)
 
@@ -392,6 +400,7 @@ func RemoveFiles(ctx context.Context, basePath string, filePaths []string) error
 // It leverages the RemoveFiles function, using a predefined list of paths that are meant to be excluded.
 //
 // Parameters:
+// - ctx: A context used for logging.
 // - basePath: The root path from which the exclusions should be applied.
 //
 // Returns:

--- a/pkg/fileutils/fileutils_test.go
+++ b/pkg/fileutils/fileutils_test.go
@@ -224,9 +224,9 @@ var _ = Describe("RemoveFiles", func() {
 		Expect(os.RemoveAll(tempDir)).To(Succeed())
 	})
 
-	It("removes specified files and directories", func() {
+	It("removes specified files and directories", func(ctx SpecContext) {
 		// Use the RemoveFiles function
-		err := RemoveFiles(tempDir, []string{
+		err := RemoveFiles(ctx, tempDir, []string{
 			"file1.txt",
 			"dir1/*",
 			"non_existent_dir/*",
@@ -286,8 +286,8 @@ var _ = Describe("RemoveRestoreExcludedFiles", func() {
 		_ = os.RemoveAll(tempDir)
 	})
 
-	It("should correctly remove specified files and directories", func() {
-		Expect(RemoveRestoreExcludedFiles(tempDir)).To(Succeed())
+	It("should correctly remove specified files and directories", func(ctx SpecContext) {
+		Expect(RemoveRestoreExcludedFiles(ctx, tempDir)).To(Succeed())
 
 		for _, path := range excludedPathsFromRestore {
 			fullPath := filepath.Join(tempDir, path)

--- a/pkg/fileutils/fileutils_test.go
+++ b/pkg/fileutils/fileutils_test.go
@@ -214,6 +214,9 @@ var _ = Describe("RemoveFiles", func() {
 		Expect(os.WriteFile(filepath.Join(tempDir, "file2.txt"), []byte("test"), 0o600)).To(Succeed())
 		Expect(os.Mkdir(filepath.Join(tempDir, "dir1"), 0o750)).To(Succeed())
 		Expect(os.WriteFile(filepath.Join(tempDir, "dir1", "file3.txt"), []byte("test"), 0o600)).To(Succeed())
+		Expect(os.Mkdir(filepath.Join(tempDir, "pg_replslot"), 0o750)).To(Succeed())
+		Expect(os.Mkdir(filepath.Join(tempDir, "pg_replslot", "myrepslot"), 0o750)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(tempDir, "pg_replslot", "myrepslot", "state"), []byte("test"), 0o600)).To(Succeed())
 	})
 
 	AfterEach(func() {
@@ -227,6 +230,7 @@ var _ = Describe("RemoveFiles", func() {
 			"file1.txt",
 			"dir1/*",
 			"non_existent_dir/*",
+			"pg_replslot/*",
 		})
 		Expect(err).NotTo(HaveOccurred())
 
@@ -239,6 +243,12 @@ var _ = Describe("RemoveFiles", func() {
 
 		_, err = os.Stat(filepath.Join(tempDir, "dir1", "file3.txt"))
 		Expect(os.IsNotExist(err)).To(BeTrue(), "Expected dir1/file3.txt to be removed")
+
+		_, err = os.Stat(filepath.Join(tempDir, "pg_replslot", "myrepslot", "state"))
+		Expect(os.IsNotExist(err)).To(BeTrue(), "Expected pg_replslot/myrepslot/state to be removed")
+
+		_, err = os.Stat(filepath.Join(tempDir, "pg_replslot", "myrepslot"))
+		Expect(os.IsNotExist(err)).To(BeTrue(), "Expected pg_replslot/myrepslot directory to be removed")
 
 		_, err = os.Stat(filepath.Join(tempDir, "dir1"))
 		Expect(err).NotTo(HaveOccurred(), "Expected dir1 to not be removed")

--- a/pkg/management/postgres/restore.go
+++ b/pkg/management/postgres/restore.go
@@ -78,6 +78,8 @@ var (
 
 // RestoreSnapshot restores a PostgreSQL cluster from a volumeSnapshot
 func (info InitInfo) RestoreSnapshot(ctx context.Context, cli client.Client) error {
+	contextLogger := log.FromContext(ctx)
+
 	cluster, err := info.loadCluster(ctx, cli)
 	if err != nil {
 		return err
@@ -88,10 +90,11 @@ func (info InitInfo) RestoreSnapshot(ctx context.Context, cli client.Client) err
 		return err
 	}
 
-	log.Info("Recovering from volume snapshot",
+	contextLogger.Info("Recovering from volume snapshot",
 		"sourceName", cluster.Spec.Bootstrap.Recovery.Source)
 
-	if err := fileutils.RemoveRestoreExcludedFiles(info.PgData); err != nil {
+	contextLogger.Info("Cleaning up PGDATA from stale files")
+	if err := fileutils.RemoveRestoreExcludedFiles(ctx, info.PgData); err != nil {
 		return fmt.Errorf("error while cleaning up the recovered PGDATA: %w", err)
 	}
 


### PR DESCRIPTION
Properly log the cleanup phase of `PGDATA` in case of volume snapshot
recovery. Add a couple more unit tests.