### PR TITLE
fix: makes VolumeSnapshot CRD optional

### DIFF
--- a/controllers/backup_controller.go
+++ b/controllers/backup_controller.go
@@ -137,7 +137,7 @@ func (r *BackupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 
 	if backup.Spec.Method == apiv1.BackupMethodVolumeSnapshot && !utils.HaveVolumeSnapshot() {
 		message := fmt.Sprintf(
-			"cannot proceed with the backup because Kubernetes cluster have no VolumeSnapshot support")
+			"cannot proceed with the backup as the Kubernetes cluster has no VolumeSnapshot support")
 		contextLogger.Warning(message)
 		r.Recorder.Event(&backup, "Warning", "ClusterHasNoVolumeSnapshotCRD", message)
 		tryFlagBackupAsFailed(ctx, r.Client, &backup, errors.New(message))

--- a/controllers/backup_controller.go
+++ b/controllers/backup_controller.go
@@ -27,6 +27,7 @@ import (
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/retry"
@@ -60,6 +61,8 @@ const clusterName = ".spec.cluster.name"
 // BackupReconciler reconciles a Backup object
 type BackupReconciler struct {
 	client.Client
+	DiscoveryClient discovery.DiscoveryInterface
+
 	Scheme   *runtime.Scheme
 	Recorder record.EventRecorder
 
@@ -67,9 +70,10 @@ type BackupReconciler struct {
 }
 
 // NewBackupReconciler properly initializes the BackupReconciler
-func NewBackupReconciler(mgr manager.Manager) *BackupReconciler {
+func NewBackupReconciler(mgr manager.Manager, discoveryClient *discovery.DiscoveryClient) *BackupReconciler {
 	return &BackupReconciler{
 		Client:               mgr.GetClient(),
+		DiscoveryClient:      discoveryClient,
 		Scheme:               mgr.GetScheme(),
 		Recorder:             mgr.GetEventRecorderFor("cloudnative-pg-backup"),
 		instanceStatusClient: instance.NewStatusClient(),
@@ -127,6 +131,15 @@ func (r *BackupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 			clusterName)
 		contextLogger.Warning(message)
 		r.Recorder.Event(&backup, "Warning", "ClusterHasNoBackupConfig", message)
+		tryFlagBackupAsFailed(ctx, r.Client, &backup, errors.New(message))
+		return ctrl.Result{}, nil
+	}
+
+	if backup.Spec.Method == apiv1.BackupMethodVolumeSnapshot && !utils.HaveVolumeSnapshot() {
+		message := fmt.Sprintf(
+			"cannot proceed with the backup because Kubernetes cluster have no VolumeSnapshot support")
+		contextLogger.Warning(message)
+		r.Recorder.Event(&backup, "Warning", "ClusterHasNoVolumeSnapshotCRD", message)
 		tryFlagBackupAsFailed(ctx, r.Client, &backup, errors.New(message))
 		return ctrl.Result{}, nil
 	}
@@ -562,19 +575,21 @@ func (r *BackupReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manage
 		return err
 	}
 
-	return ctrl.NewControllerManagedBy(mgr).
+	controllerBuilder := ctrl.NewControllerManagedBy(mgr).
 		For(&apiv1.Backup{}).
 		Watches(&apiv1.Cluster{},
 			handler.EnqueueRequestsFromMapFunc(r.mapClustersToBackup()),
 			builder.WithPredicates(clustersWithBackupPredicate),
-		).
-		Watches(
+		)
+	if utils.HaveVolumeSnapshot() {
+		controllerBuilder = controllerBuilder.Watches(
 			&storagesnapshotv1.VolumeSnapshot{},
 			handler.EnqueueRequestsFromMapFunc(r.mapVolumeSnapshotsToBackups()),
 			builder.WithPredicates(volumeSnapshotsPredicate),
-		).
-		WithOptions(controller.Options{MaxConcurrentReconciles: 5}).
-		Complete(r)
+		)
+	}
+	controllerBuilder = controllerBuilder.WithOptions(controller.Options{MaxConcurrentReconciles: 5})
+	return controllerBuilder.Complete(r)
 }
 
 func tryFlagBackupAsFailed(

--- a/internal/cmd/manager/controller/controller.go
+++ b/internal/cmd/manager/controller/controller.go
@@ -194,7 +194,7 @@ func RunController(
 		return err
 	}
 
-	// Detect if we are running under a system that implements Volume Snapshots
+	// Detect if we are running under a system that provides Volume Snapshots
 	if err = utils.DetectVolumeSnapshotExist(discoveryClient); err != nil {
 		setupLog.Error(err, "unable to detect the if the cluster have the VolumeSnapshot CRD installed")
 		return err

--- a/internal/cmd/manager/controller/controller.go
+++ b/internal/cmd/manager/controller/controller.go
@@ -194,6 +194,12 @@ func RunController(
 		return err
 	}
 
+	// Detect if we are running under a system that implements Volume Snapshots
+	if err = utils.DetectVolumeSnapshotExist(discoveryClient); err != nil {
+		setupLog.Error(err, "unable to detect the if the cluster have the VolumeSnapshot CRD installed")
+		return err
+	}
+
 	// Detect if we support SeccompProfile
 	if err = utils.DetectSeccompSupport(discoveryClient); err != nil {
 		setupLog.Error(err, "unable to detect SeccompProfile support")
@@ -209,7 +215,8 @@ func RunController(
 	setupLog.Info("Kubernetes system metadata",
 		"systemUID", utils.GetKubeSystemUID(),
 		"haveSCC", utils.HaveSecurityContextConstraints(),
-		"haveSeccompProfile", utils.HaveSeccompSupport())
+		"haveSeccompProfile", utils.HaveSeccompSupport(),
+		"haveVolumeSnapshot", utils.HaveVolumeSnapshot())
 
 	if err := ensurePKI(ctx, kubeClient, webhookServer.Options.CertDir); err != nil {
 		return err
@@ -220,7 +227,7 @@ func RunController(
 		return err
 	}
 
-	if err = controllers.NewBackupReconciler(mgr).SetupWithManager(ctx, mgr); err != nil {
+	if err = controllers.NewBackupReconciler(mgr, discoveryClient).SetupWithManager(ctx, mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Backup")
 		return err
 	}

--- a/pkg/utils/discovery.go
+++ b/pkg/utils/discovery.go
@@ -27,13 +27,16 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
-// This variable stores the result of the DetectSecurityContextConstraints check
+// haveSCC stores the result of the DetectSecurityContextConstraints check
 var haveSCC bool
 
-// This variable specifies whether we should set the SeccompProfile or not in the pods
+// haveVolumeSnapshot stores the result of the VolumeSnapshotExist function
+var haveVolumeSnapshot bool
+
+// supportSeccomp specifies whether we should set the SeccompProfile or not in the pods
 var supportSeccomp bool
 
-// `minorVersionRegexp` is used to extract the minor version from
+// minorVersionRegexp is used to extract the minor version from
 // the Kubernetes API server version. Some providers, like AWS,
 // append a "+" to the Kubernetes minor version to presumably
 // indicate that some maintenance patches have been back-ported
@@ -90,6 +93,23 @@ func DetectSecurityContextConstraints(client discovery.DiscoveryInterface) (err 
 // It panics if called before DetectSecurityContextConstraints
 func HaveSecurityContextConstraints() bool {
 	return haveSCC
+}
+
+// DetectVolumeSnapshotExist connects to the discovery API and find out if
+// the VolumeSnapshot CRD exist in the cluster
+func DetectVolumeSnapshotExist(client discovery.DiscoveryInterface) (err error) {
+	haveVolumeSnapshot, err = resourceExist(client, "snapshot.storage.k8s.io/v1", "volumesnapshots")
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// HaveVolumeSnapshot returns true if we're running under a system that implements
+// having the VolumeSnapshot CRD
+func HaveVolumeSnapshot() bool {
+	return haveVolumeSnapshot
 }
 
 // PodMonitorExist tries to find the PodMonitor resource in the current cluster

--- a/pkg/utils/discovery_test.go
+++ b/pkg/utils/discovery_test.go
@@ -127,4 +127,29 @@ var _ = Describe("Detect resources properly when", func() {
 
 		Expect(HaveSecurityContextConstraints()).To(BeTrue())
 	})
+
+	It("should not detect VolumeSnapshots", func() {
+		err := DetectVolumeSnapshotExist(client.Discovery())
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(HaveVolumeSnapshot()).To(BeFalse())
+	})
+
+	It("should detect VolumeSnapshots resource", func() {
+		resources := []*metav1.APIResourceList{
+			{
+				GroupVersion: "snapshot.storage.k8s.io/v1",
+				APIResources: []metav1.APIResource{
+					{
+						Name: "volumesnapshots",
+					},
+				},
+			},
+		}
+		fakeDiscovery.Resources = resources
+		err := DetectVolumeSnapshotExist(client.Discovery())
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(HaveVolumeSnapshot()).To(BeTrue())
+	})
 })


### PR DESCRIPTION
This patch uses the discovery API to tell whether the VolumeSnapshot CRD is installed. If it isn't, the operator will continue working correctly but VolumeSnapshots backups will error out.

Closes #2931