### PR TITLE
chore: forbid `volumeSnapshot` backups when CRDs are missing

### DIFF
--- a/api/v1/backup_webhook.go
+++ b/api/v1/backup_webhook.go
@@ -85,7 +85,10 @@ func (r *Backup) validate() field.ErrorList {
 		return append(result, field.Invalid(
 			field.NewPath("spec", "method"),
 			r.Spec.Method,
-			"Cannot use volumeSnapshot backup method due to missing VolumeSnapshot CRD",
+			"Cannot use volumeSnapshot backup method due to missing "+
+				"VolumeSnapshot CRD. If you installed the CRD after having "+
+				"started the operator, please restart it to enable "+
+				"VolumeSnapshot support",
 		))
 	}
 

--- a/api/v1/backup_webhook.go
+++ b/api/v1/backup_webhook.go
@@ -17,12 +17,16 @@ limitations under the License.
 package v1
 
 import (
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/log"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 )
 
 // backupLog is for logging in this package.
@@ -52,17 +56,38 @@ var _ webhook.Validator = &Backup{}
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (r *Backup) ValidateCreate() (admission.Warnings, error) {
 	backupLog.Info("validate create", "name", r.Name, "namespace", r.Namespace)
-	return nil, nil
+	allErrs := r.validate()
+	if len(allErrs) == 0 {
+		return nil, nil
+	}
+
+	return nil, apierrors.NewInvalid(
+		schema.GroupKind{Group: "postgresql.cnpg.io", Kind: "Backup"},
+		r.Name, allErrs)
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (r *Backup) ValidateUpdate(_ runtime.Object) (admission.Warnings, error) {
 	backupLog.Info("validate update", "name", r.Name, "namespace", r.Namespace)
-	return nil, nil
+	return r.ValidateCreate()
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type
 func (r *Backup) ValidateDelete() (admission.Warnings, error) {
 	backupLog.Info("validate delete", "name", r.Name, "namespace", r.Namespace)
 	return nil, nil
+}
+
+func (r *Backup) validate() field.ErrorList {
+	var result field.ErrorList
+
+	if r.Spec.Method == BackupMethodVolumeSnapshot && !utils.HaveVolumeSnapshot() {
+		return append(result, field.Invalid(
+			field.NewPath("spec", "method"),
+			r.Spec.Method,
+			"Cannot use volumeSnapshot backup method due to missing VolumeSnapshot CRD",
+		))
+	}
+
+	return result
 }

--- a/api/v1/backup_webhook_test.go
+++ b/api/v1/backup_webhook_test.go
@@ -1,0 +1,33 @@
+package v1
+
+import (
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("", func() {
+	It("doesn't complain if VolumeSnapshot CRD is present", func() {
+		backup := &Backup{
+			Spec: BackupSpec{
+				Method: BackupMethodVolumeSnapshot,
+			},
+		}
+		utils.SetVolumeSnapshot(true)
+		result := backup.validate()
+		Expect(result).To(BeEmpty())
+	})
+
+	It("complains if VolumeSnapshot CRD is not present", func() {
+		backup := &Backup{
+			Spec: BackupSpec{
+				Method: BackupMethodVolumeSnapshot,
+			},
+		}
+		utils.SetVolumeSnapshot(false)
+		result := backup.validate()
+		Expect(result).To(HaveLen(1))
+		Expect(result[0].Field).To(Equal("spec.method"))
+	})
+})

--- a/api/v1/scheduledbackup_webhook.go
+++ b/api/v1/scheduledbackup_webhook.go
@@ -95,7 +95,10 @@ func (r *ScheduledBackup) validate() field.ErrorList {
 		result = append(result, field.Invalid(
 			field.NewPath("spec", "method"),
 			r.Spec.Method,
-			"Cannot use volumeSnapshot backup method due to missing VolumeSnapshot CRD",
+			"Cannot use volumeSnapshot backup method due to missing "+
+				"VolumeSnapshot CRD. If you installed the CRD after having "+
+				"started the operator, please restart it to enable "+
+				"VolumeSnapshot support",
 		))
 	}
 

--- a/api/v1/scheduledbackup_webhook.go
+++ b/api/v1/scheduledbackup_webhook.go
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/log"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 )
 
 // scheduledBackupLog is for logging in this package.
@@ -58,7 +59,7 @@ func (r *ScheduledBackup) ValidateCreate() (admission.Warnings, error) {
 	var allErrs field.ErrorList
 	scheduledBackupLog.Info("validate create", "name", r.Name, "namespace", r.Namespace)
 
-	allErrs = append(allErrs, r.validateSchedule()...)
+	allErrs = append(allErrs, r.validate()...)
 
 	if len(allErrs) == 0 {
 		return nil, nil
@@ -81,7 +82,7 @@ func (r *ScheduledBackup) ValidateDelete() (admission.Warnings, error) {
 	return nil, nil
 }
 
-func (r *ScheduledBackup) validateSchedule() field.ErrorList {
+func (r *ScheduledBackup) validate() field.ErrorList {
 	var result field.ErrorList
 
 	if _, err := cron.Parse(r.GetSchedule()); err != nil {
@@ -89,6 +90,13 @@ func (r *ScheduledBackup) validateSchedule() field.ErrorList {
 			field.Invalid(
 				field.NewPath("spec", "schedule"),
 				r.Spec.Schedule, err.Error()))
+	}
+	if r.Spec.Method == BackupMethodVolumeSnapshot && !utils.HaveVolumeSnapshot() {
+		result = append(result, field.Invalid(
+			field.NewPath("spec", "method"),
+			r.Spec.Method,
+			"Cannot use volumeSnapshot backup method due to missing VolumeSnapshot CRD",
+		))
 	}
 
 	return result

--- a/controllers/backup_controller.go
+++ b/controllers/backup_controller.go
@@ -135,6 +135,7 @@ func (r *BackupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		return ctrl.Result{}, nil
 	}
 
+	// This check is still needed for when the backup resource creation is forced through the webhook
 	if backup.Spec.Method == apiv1.BackupMethodVolumeSnapshot && !utils.HaveVolumeSnapshot() {
 		message := "cannot proceed with the backup as the Kubernetes cluster has no VolumeSnapshot support"
 		contextLogger.Warning(message)

--- a/controllers/scheduledbackup_controller.go
+++ b/controllers/scheduledbackup_controller.go
@@ -18,6 +18,7 @@ package controllers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"time"
@@ -78,6 +79,15 @@ func (r *ScheduledBackupReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, err
+	}
+
+	// This check is still needed for when the backup resource creation is forced through the webhook
+	if scheduledBackup.Spec.Method == apiv1.BackupMethodVolumeSnapshot && !utils.HaveVolumeSnapshot() {
+		contextLogger.Error(
+			errors.New("cannot execute due to missing VolumeSnapshot CRD"),
+			"While checking for VolumeSnapshot CRD",
+		)
+		return ctrl.Result{}, nil
 	}
 
 	if scheduledBackup.IsSuspended() {

--- a/controllers/scheduledbackup_controller.go
+++ b/controllers/scheduledbackup_controller.go
@@ -81,7 +81,7 @@ func (r *ScheduledBackupReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return ctrl.Result{}, err
 	}
 
-	// This check is still needed for when the backup resource creation is forced through the webhook
+	// This check is still needed for when the scheduled backup resource creation is forced through the webhook
 	if scheduledBackup.Spec.Method == apiv1.BackupMethodVolumeSnapshot && !utils.HaveVolumeSnapshot() {
 		contextLogger.Error(
 			errors.New("cannot execute due to missing VolumeSnapshot CRD"),

--- a/pkg/utils/discovery.go
+++ b/pkg/utils/discovery.go
@@ -106,6 +106,11 @@ func DetectVolumeSnapshotExist(client discovery.DiscoveryInterface) (err error) 
 	return nil
 }
 
+// SetVolumeSnapshot set the haveVolumeSnapshot variable to a specific value for testing purposes
+func SetVolumeSnapshot(value bool) {
+	haveVolumeSnapshot = value
+}
+
 // HaveVolumeSnapshot returns true if we're running under a system that implements
 // having the VolumeSnapshot CRD
 func HaveVolumeSnapshot() bool {

--- a/pkg/utils/discovery.go
+++ b/pkg/utils/discovery.go
@@ -107,6 +107,7 @@ func DetectVolumeSnapshotExist(client discovery.DiscoveryInterface) (err error) 
 }
 
 // SetVolumeSnapshot set the haveVolumeSnapshot variable to a specific value for testing purposes
+// IMPORTANT: use it only in the unit tests
 func SetVolumeSnapshot(value bool) {
 	haveVolumeSnapshot = value
 }


### PR DESCRIPTION
Improve UI of `VolumeSnapshot` support by preventing users from
creating `Backup` and `ScheduledBackup` resources with `volumeSnapshot`
as a `method` if the required CRDs are not installed in the underlying
Kubernetes cluster.