### PR TITLE
feat: defer immediate snapshot backup until cluster is Ready

### DIFF
--- a/controllers/scheduledbackup_controller.go
+++ b/controllers/scheduledbackup_controller.go
@@ -162,7 +162,7 @@ func ReconcileScheduledBackup(
 		if cluster.Status.Phase != apiv1.PhaseHealthy {
 			event.Eventf(
 				scheduledBackup,
-				"Normal",
+				"Warning",
 				"ClusterNotHealthy",
 				"Waiting for cluster to be healthy, was \"%v\"",
 				cluster.Status.Phase,


### PR DESCRIPTION
At this moment, volume snapshot backups are cold backups, requiring PostgreSQL to be down.

If an immediate scheduled backup is created before the corresponding cluster, the latter won't be able to start because the primary node will be immediately fenced.

This patch makes the operator wait until the cluster is ready to take an immediate backup with volume snapshots.

Closes #2935 