### PR TITLE
fix(prometheus): add the cnpg_cluster label

### DIFF
--- a/docs/src/samples/monitoring/grafana-dashboard.json
+++ b/docs/src/samples/monitoring/grafana-dashboard.json
@@ -6343,7 +6343,7 @@
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 1,
-        "regex": "/\\bcluster\\b=\"(?<text>[^\"]+)/g",
+        "regex": "/\\bcnpg_cluster\\b=\"(?<text>[^\"]+)/g",
         "skipUrlSync": false,
         "sort": 1,
         "type": "query"

--- a/pkg/management/postgres/webserver/metricserver/pg_collector.go
+++ b/pkg/management/postgres/webserver/metricserver/pg_collector.go
@@ -117,7 +117,7 @@ func newMetrics() *metrics {
 			Subsystem: subsystem,
 			Name:      "up",
 			Help:      "1 if PostgreSQL is up, 0 otherwise.",
-		}, []string{"cluster"}),
+		}, []string{"cnpg_cluster"}),
 		CollectionDuration: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: PrometheusNamespace,
 			Subsystem: subsystem,
@@ -154,7 +154,7 @@ func newMetrics() *metrics {
 			Subsystem: subsystem,
 			Name:      "postgres_version",
 			Help:      "Postgres version",
-		}, []string{"full", "cluster"}),
+		}, []string{"full", "cnpg_cluster"}),
 		PgWALDirectory: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: PrometheusNamespace,
 			Subsystem: subsystem,


### PR DESCRIPTION
This PR adds a new label to PgVersion and PostgreSQLUp called cnpg_cluster The cluster label is commonly used to refer to the k8s cluster. That label can be removed in a later version.

Closes: #2501