### PR TITLE
fix(rbac): not adding `resourceNames` for `s3Credentials` `region` & `sessionToken`

### DIFF
--- a/pkg/specs/roles.go
+++ b/pkg/specs/roles.go
@@ -304,6 +304,14 @@ func s3CredentialsSecrets(s3Credentials *apiv1.S3Credentials) []string {
 		secrets = append(secrets, s3Credentials.SecretAccessKeyReference.Name)
 	}
 
+	if s3Credentials.RegionReference != nil {
+		secrets = append(secrets, s3Credentials.RegionReference.Name)
+	}
+
+	if s3Credentials.SessionToken != nil {
+		secrets = append(secrets, s3Credentials.SessionToken.Name)
+	}
+
 	return secrets
 }
 

--- a/pkg/specs/roles_test.go
+++ b/pkg/specs/roles_test.go
@@ -146,6 +146,16 @@ var _ = Describe("Roles", func() {
 							Name: "testS3Access",
 						},
 					},
+					RegionReference: &apiv1.SecretKeySelector{
+						LocalObjectReference: apiv1.LocalObjectReference{
+							Name: "testS3Region",
+						},
+					},
+					SessionToken: &apiv1.SecretKeySelector{
+						LocalObjectReference: apiv1.LocalObjectReference{
+							Name: "testS3Session",
+						},
+					},
 				},
 			},
 		},
@@ -174,6 +184,8 @@ var _ = Describe("Roles", func() {
 			"testSecretKeySelector",
 			"testS3Secret",
 			"testS3Access",
+			"testS3Region",
+			"testS3Session",
 			"testAzureStorageAccount",
 			"testAzureStorageKey",
 			"testAzureStorageSasToken",
@@ -246,6 +258,12 @@ var _ = Describe("Secrets", func() {
 							AccessKeyIDReference: &apiv1.SecretKeySelector{
 								LocalObjectReference: apiv1.LocalObjectReference{Name: "test-access"},
 							},
+							RegionReference: &apiv1.SecretKeySelector{
+								LocalObjectReference: apiv1.LocalObjectReference{Name: "test-region"},
+							},
+							SessionToken: &apiv1.SecretKeySelector{
+								LocalObjectReference: apiv1.LocalObjectReference{Name: "test-session"},
+							},
 						},
 					},
 					EndpointCA: &apiv1.SecretKeySelector{
@@ -256,7 +274,7 @@ var _ = Describe("Secrets", func() {
 			},
 		}
 		secrets = backupSecrets(cluster, nil)
-		Expect(secrets).To(ConsistOf("test-secret", "test-access", "test-endpoint-ca-name"))
+		Expect(secrets).To(ConsistOf("test-secret", "test-access", "test-region", "test-session", "test-endpoint-ca-name"))
 	})
 
 	It("should contain default secrets only", func() {


### PR DESCRIPTION
This PR fixes a bug where backups were failing because of missing RBAC `resourceNames` on the `Role` object.

The bug only occurs when using other secrets for `region` and `sessionToken` than in `accessKeyId` or `secretAccessKey`.