### PR TITLE
fix: e2e tests looking for the wrong metric

### DIFF
--- a/tests/e2e/asserts_test.go
+++ b/tests/e2e/asserts_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -2834,5 +2835,50 @@ func assertPredicateClusterHasPhase(namespace, clusterName string, phase []strin
 		cluster, err := env.GetCluster(namespace, clusterName)
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(slices.Contains(phase, cluster.Status.Phase)).To(BeTrue())
+	}
+}
+
+// assertMetrics is a utility function used for asserting that specific metrics, defined by regular expressions in
+// the 'expectedMetrics' map, are present in the 'rawMetricsOutput' string.
+// It also checks whether the metrics match the expected format defined by their regular expressions.
+// If any assertion fails, it prints an error message to GinkgoWriter.
+//
+// Parameters:
+//   - rawMetricsOutput: The raw metrics data string to be checked.
+//   - expectedMetrics: A map of metric names to regular expressions that describe the expected format of the metrics.
+//
+// Example usage:
+//
+//	expectedMetrics := map[string]*regexp.Regexp{
+//	    "cpu_usage":   regexp.MustCompile(`^\d+\.\d+$`), // Example: "cpu_usage 0.25"
+//	    "memory_usage": regexp.MustCompile(`^\d+\s\w+$`), // Example: "memory_usage 512 MiB"
+//	}
+//	assertMetrics(rawMetricsOutput, expectedMetrics)
+//
+// The function will assert that the specified metrics exist in 'rawMetricsOutput' and match their expected formats.
+// If any assertion fails, it will print an error message with details about the failed metric collection.
+//
+// Note: This function is typically used in testing scenarios to validate metric collection behavior.
+func assertMetrics(rawMetricsOutput string, expectedMetrics map[string]*regexp.Regexp) {
+	debugDetails := fmt.Sprintf("Priting rawMetricsOutput:\n%s", rawMetricsOutput)
+	withDebugDetails := func(baseErrMessage string) string {
+		return fmt.Sprintf("%s\n%s\n", baseErrMessage, debugDetails)
+	}
+
+	for key, valueRe := range expectedMetrics {
+		re := regexp.MustCompile(fmt.Sprintf(`(?m)^(` + key + `).*$`))
+
+		// match a metric with the value of expectedMetrics key
+		match := re.FindString(rawMetricsOutput)
+		Expect(match).NotTo(BeEmpty(), withDebugDetails(fmt.Sprintf("Found no match for metric %s", key)))
+
+		// extract the value from the metric previously matched
+		value := strings.Fields(match)[1]
+		Expect(strings.Fields(match)[1]).NotTo(BeEmpty(),
+			withDebugDetails(fmt.Sprintf("Found no result for metric %s.Metric line: %s", key, match)))
+
+		// expect the expectedMetrics regexp to match the value of the metric
+		Expect(valueRe.MatchString(value)).To(BeTrue(),
+			withDebugDetails(fmt.Sprintf("Expected %s to have value %v but got %s", key, valueRe, value)))
 	}
 }

--- a/tests/e2e/fixtures/metrics/custom-queries.yaml
+++ b/tests/e2e/fixtures/metrics/custom-queries.yaml
@@ -58,7 +58,7 @@ data:
             description: "Disk space used by the database"
 
   additional-queries: |
-    pg_replication_slots:
+    pg_replication_slots_status:
       query: "SELECT count(*) AS inactive FROM pg_replication_slots WHERE NOT active"
       primary: false
       metrics:

--- a/tests/e2e/fixtures/metrics/custom-queries.yaml
+++ b/tests/e2e/fixtures/metrics/custom-queries.yaml
@@ -58,7 +58,7 @@ data:
             description: "Disk space used by the database"
 
   additional-queries: |
-    pg_replication_slots_status:
+    e2e_tests_replication_slots_status:
       query: "SELECT count(*) AS inactive FROM pg_replication_slots WHERE NOT active"
       primary: false
       metrics:

--- a/tests/e2e/metrics_test.go
+++ b/tests/e2e/metrics_test.go
@@ -59,7 +59,6 @@ var _ = Describe("Metrics", Label(tests.LabelObservability), func() {
 	metricsList := `cnpg_pg_postmaster_start_time_seconds \d+\.\d+|` + // wokeignore:rule=master
 		`cnpg_pg_wal_files_total \d+|` +
 		`cnpg_pg_database_size_bytes{datname="app"} [0-9e\+\.]+|` +
-		`cnpg_pg_replication_slots_inactive 0|` +
 		`cnpg_pg_stat_archiver_archived_count \d+|` +
 		`cnpg_pg_stat_archiver_failed_count \d+|` +
 		`cnpg_pg_locks_blocked_queries 0|` +

--- a/tests/e2e/metrics_test.go
+++ b/tests/e2e/metrics_test.go
@@ -83,7 +83,7 @@ var _ = Describe("Metrics", Label(tests.LabelObservability), func() {
 			// match a metric with the value of expectedMetrics key
 			match := re.FindString(metrics)
 			if match == "" {
-				_, _ = fmt.Fprintf(GinkgoWriter, collectionError)
+				_, _ = fmt.Fprint(GinkgoWriter, collectionError)
 			}
 			Expect(match).NotTo(BeEmpty(),
 				"\nFound no match for metric %v\n", key)
@@ -91,7 +91,7 @@ var _ = Describe("Metrics", Label(tests.LabelObservability), func() {
 			// extract the value from the metric previously matched
 			value := strings.Fields(match)[1]
 			if value == "" {
-				_, _ = fmt.Fprintf(GinkgoWriter, collectionError)
+				_, _ = fmt.Fprint(GinkgoWriter, collectionError)
 			}
 			Expect(value).NotTo(BeEmpty(),
 				"\nFound no result for metric %v.\nMetric line: %v\n", key, match)
@@ -99,7 +99,7 @@ var _ = Describe("Metrics", Label(tests.LabelObservability), func() {
 			// expect the expectedMetrics regexp to match the value of the metric
 			result := valueRe.MatchString(value)
 			if result != true {
-				_, _ = fmt.Fprintf(GinkgoWriter, collectionError)
+				_, _ = fmt.Fprint(GinkgoWriter, collectionError)
 			}
 			Expect(result).To(BeTrue(),
 				"\nExpected %v to have value %v but got %v\n", key, valueRe, value)

--- a/tests/e2e/metrics_test.go
+++ b/tests/e2e/metrics_test.go
@@ -48,7 +48,7 @@ var _ = Describe("Metrics", Label(tests.LabelObservability), func() {
 	)
 
 	buildExpectedMetrics := func(cluster *apiv1.Cluster, isReplicaPod bool) map[string]*regexp.Regexp {
-		const replicationSlotsStatus = "cnpg_pg_replication_slots_status_inactive"
+		const replicationSlotsStatus = "cnpg_e2e_tests_replication_slots_status_inactive"
 
 		// We define a few metrics in the tests. We check that all of them exist and
 		// there are no errors during the collection.

--- a/tests/e2e/metrics_test.go
+++ b/tests/e2e/metrics_test.go
@@ -47,6 +47,31 @@ var _ = Describe("Metrics", Label(tests.LabelObservability), func() {
 		level                          = tests.Low
 	)
 
+	buildExpectedMetrics := func(cluster *apiv1.Cluster, isReplicaPod bool) map[string]*regexp.Regexp {
+		const replicationSlotsStatus = "cnpg_pg_replication_slots_status_inactive"
+
+		// We define a few metrics in the tests. We check that all of them exist and
+		// there are no errors during the collection.
+		expectedMetrics := map[string]*regexp.Regexp{
+			"cnpg_pg_postmaster_start_time_seconds":        regexp.MustCompile(`\d+\.\d+`), // wokeignore:rule=master
+			"cnpg_pg_wal_files_total":                      regexp.MustCompile(`\d+`),
+			"cnpg_pg_database_size_bytes{datname=\"app\"}": regexp.MustCompile(`[0-9e+.]+`),
+			"cnpg_pg_stat_archiver_archived_count":         regexp.MustCompile(`\d+`),
+			"cnpg_pg_stat_archiver_failed_count":           regexp.MustCompile(`\d+`),
+			"cnpg_pg_locks_blocked_queries":                regexp.MustCompile(`0`),
+			"cnpg_runonserver_match_fixed":                 regexp.MustCompile(`42`),
+			"cnpg_collector_last_collection_error":         regexp.MustCompile(`0`),
+			replicationSlotsStatus:                         regexp.MustCompile("0"),
+		}
+
+		if isReplicaPod {
+			inactiveSlots := strconv.Itoa(cluster.Spec.Instances - 2)
+			expectedMetrics[replicationSlotsStatus] = regexp.MustCompile(inactiveSlots)
+		}
+
+		return expectedMetrics
+	}
+
 	BeforeEach(func() {
 		if testLevelEnv.Depth < int(level) {
 			Skip("Test depth is lower than the amount requested for this test")
@@ -56,77 +81,6 @@ var _ = Describe("Metrics", Label(tests.LabelObservability), func() {
 	// Cluster identifiers
 	var namespace, metricsClusterName, curlPodName string
 	var err error
-
-	// We define a few metrics in the tests. We check that all of them exist and
-	// there are no errors during the collection.
-	metricsMap := map[string]*regexp.Regexp{
-		"cnpg_pg_postmaster_start_time_seconds":        regexp.MustCompile(`\d+\.\d+`), // wokeignore:rule=master
-		"cnpg_pg_wal_files_total":                      regexp.MustCompile(`\d+`),
-		"cnpg_pg_database_size_bytes{datname=\"app\"}": regexp.MustCompile(`[0-9e+.]+`),
-		"cnpg_pg_stat_archiver_archived_count":         regexp.MustCompile(`\d+`),
-		"cnpg_pg_stat_archiver_failed_count":           regexp.MustCompile(`\d+`),
-		"cnpg_pg_locks_blocked_queries":                regexp.MustCompile(`0`),
-		"cnpg_runonserver_match_fixed":                 regexp.MustCompile(`42`),
-		"cnpg_collector_last_collection_error":         regexp.MustCompile(`0`),
-	}
-
-	AssertMetrics := func(metrics string, expectedMetrics map[string]*regexp.Regexp, podName string) {
-		collectionError := fmt.Sprintf(
-			"\nMetric collection issues on %v.\nPrinting metrics:\n%v\n",
-			podName,
-			metrics,
-		)
-
-		for key, valueRe := range expectedMetrics {
-			re := regexp.MustCompile(fmt.Sprintf(`(?m)^(` + key + `).*$`))
-
-			// match a metric with the value of expectedMetrics key
-			match := re.FindString(metrics)
-			if match == "" {
-				_, _ = fmt.Fprint(GinkgoWriter, collectionError)
-			}
-			Expect(match).NotTo(BeEmpty(),
-				"\nFound no match for metric %v\n", key)
-
-			// extract the value from the metric previously matched
-			value := strings.Fields(match)[1]
-			if value == "" {
-				_, _ = fmt.Fprint(GinkgoWriter, collectionError)
-			}
-			Expect(value).NotTo(BeEmpty(),
-				"\nFound no result for metric %v.\nMetric line: %v\n", key, match)
-
-			// expect the expectedMetrics regexp to match the value of the metric
-			result := valueRe.MatchString(value)
-			if result != true {
-				_, _ = fmt.Fprint(GinkgoWriter, collectionError)
-			}
-			Expect(result).To(BeTrue(),
-				"\nExpected %v to have value %v but got %v\n", key, valueRe, value)
-		}
-	}
-
-	buildMetrics := func(
-		expectedMetrics map[string]*regexp.Regexp,
-		namespace,
-		clusterName string,
-		pod corev1.Pod,
-	) (map[string]*regexp.Regexp, error) {
-		cluster, err := env.GetCluster(namespace, clusterName)
-		if err != nil {
-			return nil, err
-		}
-
-		inactiveSlots := cluster.Spec.Instances - 2
-
-		if specs.IsPodPrimary(pod) {
-			expectedMetrics["cnpg_pg_replication_slots_status_inactive"] = regexp.MustCompile("0")
-		} else {
-			expectedMetrics["cnpg_pg_replication_slots_status_inactive"] = regexp.MustCompile(strconv.Itoa(inactiveSlots))
-		}
-
-		return expectedMetrics, nil
-	}
 
 	JustAfterEach(func() {
 		if CurrentSpecReport().Failed() {
@@ -158,17 +112,21 @@ var _ = Describe("Metrics", Label(tests.LabelObservability), func() {
 		// Create the cluster
 		AssertCreateCluster(namespace, metricsClusterName, clusterMetricsFile, env)
 
-		By("collecting metrics on each pod", func() {
+		By("ensuring metrics are correct on each pod", func() {
+			metricsCluster, err := env.GetCluster(namespace, metricsClusterName)
+			Expect(err).ToNot(HaveOccurred())
+
 			podList, err := env.GetClusterPodList(namespace, metricsClusterName)
 			Expect(err).ToNot(HaveOccurred())
+
 			// Gather metrics in each pod
 			for _, pod := range podList.Items {
-				podIP := pod.Status.PodIP
-				out, err := utils.CurlGetMetrics(namespace, curlPodName, podIP, 9187)
-				Expect(err).ToNot(HaveOccurred())
-				expectedMetrics, err := buildMetrics(metricsMap, namespace, metricsClusterName, pod)
-				Expect(err).ToNot(HaveOccurred())
-				AssertMetrics(out, expectedMetrics, pod.GetName())
+				By(fmt.Sprintf("checking metrics for pod: %s", pod.Name), func() {
+					out, err := utils.CurlGetMetrics(namespace, curlPodName, pod.Status.PodIP, 9187)
+					Expect(err).ToNot(HaveOccurred(), "while getting pod metrics")
+					expectedMetrics := buildExpectedMetrics(metricsCluster, !specs.IsPodPrimary(pod))
+					assertMetrics(out, expectedMetrics)
+				})
 			}
 		})
 


### PR DESCRIPTION
Since replication slot it's now a default the Metrics tests were looking for the metric `cnpg_pg_replication_slots_inactive` which it's not true anymore.

Closes #2968 