### PR TITLE
fix: panic in serviceReconciler

### DIFF
--- a/controllers/cluster_create.go
+++ b/controllers/cluster_create.go
@@ -322,6 +322,14 @@ func (r *ClusterReconciler) serviceReconciler(ctx context.Context, proposed *cor
 		shouldUpdate = true
 	}
 
+	// we ensure we've some space to store the labels and the annotations
+	if livingService.Labels == nil {
+		livingService.Labels = make(map[string]string)
+	}
+	if livingService.Annotations == nil {
+		livingService.Annotations = make(map[string]string)
+	}
+
 	// we preserve existing labels/annotation that could be added by third parties
 	if !utils.IsMapSubset(livingService.Labels, proposed.Labels) {
 		utils.MergeMap(livingService.Labels, proposed.Labels)


### PR DESCRIPTION
This panic was happening when updating services created by really old versions of the operator, that was not generating any pre-defined labels and annotations.

Closes #2974
