### PR TITLE
fix: cold snapshot backup on primary leaves cluster stuck

### DIFF
--- a/controllers/backup_controller.go
+++ b/controllers/backup_controller.go
@@ -336,10 +336,6 @@ func (r *BackupReconciler) reconcileSnapshotBackup(
 		return &ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 	}
 
-	// TODO: at the moment, volume snapshot backups are cold and require fencing
-	// the target pod. This makes them unsuitable to run on the primary, so we
-	// mark the backup as failed and exit the reconciliation.
-	// When hot volume snapshots become available, this logic should be refined.
 	if targetPod.Name == cluster.Status.CurrentPrimary ||
 		targetPod.Name == cluster.Status.TargetPrimary {
 		contextLogger.Warning(

--- a/controllers/backup_controller_test.go
+++ b/controllers/backup_controller_test.go
@@ -18,13 +18,11 @@ package controllers
 
 import (
 	"context"
-	"errors"
 	"time"
 
 	volumesnapshot "github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
 	k8client "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -254,73 +252,6 @@ var _ = Describe("backup_controller volumeSnapshot unit tests", func() {
 			Expect(backupList.CanExecuteBackup("backup-1")).To(BeFalse())
 			Expect(backupList.CanExecuteBackup("backup-2")).To(BeTrue())
 			Expect(backupList.CanExecuteBackup("backup-3")).To(BeFalse())
-		})
-	})
-
-	When("cold snapshot backup has the primary as target", func() {
-		It("marks the backup as failed and exits the reconciliation with error", func(ctx SpecContext) {
-			namespace := "foo"
-			clusterName := "bar"
-			cluster := &apiv1.Cluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: namespace,
-					Name:      clusterName,
-				},
-				Spec: apiv1.ClusterSpec{
-					Backup: &apiv1.BackupConfiguration{
-						VolumeSnapshot: &apiv1.VolumeSnapshotConfiguration{
-							ClassName: "csi-hostpath-snapclass",
-						},
-					},
-				},
-				Status: apiv1.ClusterStatus{
-					TargetPrimary:  "targetPrimary",
-					CurrentPrimary: "currentPrimary",
-				},
-			}
-			primaryPod := &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: namespace,
-					Name:      "currentPrimary",
-				},
-			}
-			backup := &apiv1.Backup{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: namespace,
-					Name:      "theBackup",
-				},
-				Spec: apiv1.BackupSpec{
-					Cluster: apiv1.LocalObjectReference{
-						Name: cluster.Name,
-					},
-				},
-			}
-			backupList := apiv1.BackupList{
-				ListMeta: metav1.ListMeta{},
-				Items:    []apiv1.Backup{},
-			}
-
-			indexer := func(o k8client.Object) []string {
-				return []string{".spec.cluster.name"}
-			}
-			mockClient := fake.NewClientBuilder().
-				WithScheme(schemeBuilder.BuildWithAllKnownScheme()).
-				WithObjects(cluster, primaryPod, backup).
-				WithLists(&backupList).
-				WithIndex(&apiv1.Backup{}, ".spec.cluster.name", indexer).
-				Build()
-
-			fakeBackupReconciler := &BackupReconciler{
-				Client:   mockClient,
-				Scheme:   scheme,
-				Recorder: record.NewFakeRecorder(3),
-			}
-
-			res, err := fakeBackupReconciler.reconcileSnapshotBackup(ctx, primaryPod, cluster, backup)
-			Expect(backup.Status.Phase).To(BeEquivalentTo(apiv1.BackupPhaseFailed))
-			Expect(res).To(BeNil())
-			Expect(err).To(HaveOccurred())
-			Expect(errors.Is(err, errColdBackupOnPrimary)).To(BeTrue())
 		})
 	})
 })

--- a/pkg/reconciler/backup/volumesnapshot/reconciler.go
+++ b/pkg/reconciler/backup/volumesnapshot/reconciler.go
@@ -214,8 +214,7 @@ func (se *Reconciler) ensurePodIsFenced(
 		return errors.New("cannot execute volume snapshot on a cluster that has fenced instances")
 	}
 
-	if targetPodName == cluster.Status.CurrentPrimary ||
-		targetPodName == cluster.Status.TargetPrimary {
+	if targetPodName == cluster.Status.CurrentPrimary || targetPodName == cluster.Status.TargetPrimary {
 		contextLogger.Warning(
 			"Cold Snapshot Backup targets the primary. Primary will be fenced",
 			"targetBackup", backup.Name, "targetPod", targetPodName,

--- a/pkg/reconciler/backup/volumesnapshot/reconciler.go
+++ b/pkg/reconciler/backup/volumesnapshot/reconciler.go
@@ -214,6 +214,14 @@ func (se *Reconciler) ensurePodIsFenced(
 		return errors.New("cannot execute volume snapshot on a cluster that has fenced instances")
 	}
 
+	if targetPodName == cluster.Status.CurrentPrimary ||
+		targetPodName == cluster.Status.TargetPrimary {
+		contextLogger.Warning(
+			"Cold Snapshot Backup targets the primary. Primary will be fenced",
+			"targetBackup", backup.Name, "targetPod", targetPodName,
+		)
+	}
+
 	err = resources.ApplyFenceFunc(
 		ctx,
 		se.cli,

--- a/tests/e2e/fixtures/volume_snapshot/declarative-backup-on-primary.yaml.template
+++ b/tests/e2e/fixtures/volume_snapshot/declarative-backup-on-primary.yaml.template
@@ -1,0 +1,9 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Backup
+metadata:
+  name: cluster-declarative-backup-primary
+spec:
+  method: volumeSnapshot
+  target: primary
+  cluster:
+    name: cluster-declarative-backup


### PR DESCRIPTION
This patch fixes an error condition when a cold snapshot backup is taken
on a single-instance cluster, or  if the primary was the `target` for
the snapshot.
In such case, the primary would be fenced, the backup would be blocked
on recognizing the target pod is not ready, and the primary would never
un-fence.

Closes #2948 
