### PR TITLE
Embed the version number in the header of the docs

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: CloudNativePG
+site_name: CloudNativePG<br/><sub>v1.20.2</sub>
 site_author: The CloudNativePG Contributors
 docs_dir: src
 


### PR DESCRIPTION
The current docs do not indicate what version the docs were created for (outside release notes). This small change must be manually updated. It embeds that information in the page header via the site_name configuration variable, which is only (according to the docs) used as the main title.