### PR TITLE
fix(plugin): `status` to display `Fenced` status in `Replication role`

### DIFF
--- a/internal/cmd/plugin/status/status.go
+++ b/internal/cmd/plugin/status/status.go
@@ -552,7 +552,8 @@ func (fullStatus *PostgresqlStatus) printInstancesStatus() {
 	//      	print "Standby (file based)"
 	//    	else:
 	//  		if pg_rewind is running, print "Standby (pg_rewind)"  - #liveness OK, readiness Not OK
-	//    		else print "Standby (starting up)"  - #liveness OK, readiness Not OK
+	//    		else if fenced, print "Fenced" - #liveness OK, readiness Not OK
+	//		else print "Standby (starting up)"
 	//  else:
 	//  	if it is paused, print "Standby (paused)"
 	//  	else if SyncState = sync/quorum print "Standby (sync)"
@@ -682,6 +683,9 @@ func getReplicaRole(instance postgres.PostgresqlStatus, fullStatus *PostgresqlSt
 	if fullStatus.isReplicaClusterDesignatedPrimary(instance) {
 		return "Designated primary"
 	}
+	//if instance.IsFenced {
+		//return "Fenced"
+	//}
 
 	if !instance.IsWalReceiverActive {
 		if utils.IsPodReady(*instance.Pod) {

--- a/internal/cmd/plugin/status/status.go
+++ b/internal/cmd/plugin/status/status.go
@@ -553,7 +553,7 @@ func (fullStatus *PostgresqlStatus) printInstancesStatus() {
 	//      	print "Standby (file based)"
 	//    	else:
 	//  		if pg_rewind is running, print "Standby (pg_rewind)"  - #liveness OK, readiness Not OK
-	//		    else print "Standby (starting up)"
+	//              else print "Standby (starting up)"
 	//  else:
 	//  	if it is paused, print "Standby (paused)"
 	//  	else if SyncState = sync/quorum print "Standby (sync)"


### PR DESCRIPTION
If an instance is fenced, the `cnpg status` command now reports `Fenced` as `Replication role` instead of `Standby (starting up)`.

Closes #2994