### PR TITLE
fix(grafana): manage unavailable backups situations

### DIFF
--- a/docs/src/samples/monitoring/grafana-configmap.yaml
+++ b/docs/src/samples/monitoring/grafana-configmap.yaml
@@ -603,7 +603,7 @@ data:
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "cnpg_pg_replication_lag{namespace=~\"$namespace\",pod=~\"$instances\"}",
+              "expr": "max(cnpg_pg_replication_lag{namespace=~\"$namespace\",pod=~\"$instances\"})",
               "legendFormat": "__auto",
               "range": true,
               "refId": "A"

--- a/docs/src/samples/monitoring/grafana-configmap.yaml
+++ b/docs/src/samples/monitoring/grafana-configmap.yaml
@@ -953,7 +953,7 @@ data:
               },
               "editorMode": "code",
               "exemplar": true,
-              "expr": "(1 - cnpg_pg_replication_in_recovery{namespace=~\"$namespace\",pod=~\"$instances\"} + cnpg_pg_replication_is_wal_receiver_up{namespace=~\"$namespace\",pod=~\"$instances\"}) * (time() - timestamp(cnpg_pg_stat_archiver_seconds_since_last_archival{namespace=~\"$namespace\",pod=~\"$instances\"}) -\ncnpg_pg_stat_archiver_seconds_since_last_archival{namespace=~\"$namespace\",pod=~\"$instances\"})",
+              "expr": "min((1 - cnpg_pg_replication_in_recovery{namespace=~\"$namespace\",pod=~\"$instances\"} + cnpg_pg_replication_is_wal_receiver_up{namespace=~\"$namespace\",pod=~\"$instances\"}) * (time() - timestamp(cnpg_pg_stat_archiver_seconds_since_last_archival{namespace=~\"$namespace\",pod=~\"$instances\"}) -\ncnpg_pg_stat_archiver_seconds_since_last_archival{namespace=~\"$namespace\",pod=~\"$instances\"}))",
               "format": "time_series",
               "interval": "",
               "legendFormat": "__auto",

--- a/docs/src/samples/monitoring/grafana-configmap.yaml
+++ b/docs/src/samples/monitoring/grafana-configmap.yaml
@@ -1444,7 +1444,7 @@ data:
                     "0": {
                       "color": "red",
                       "index": 1,
-                      "text": "No backups"
+                      "text": "N/A"
                     }
                   },
                   "type": "value"

--- a/docs/src/samples/monitoring/grafana-configmap.yaml
+++ b/docs/src/samples/monitoring/grafana-configmap.yaml
@@ -801,7 +801,7 @@ data:
                     "result": {
                       "color": "red",
                       "index": 1,
-                      "text": "No backups"
+                      "text": "N/A"
                     },
                     "to": -1577847600
                   },

--- a/docs/src/samples/monitoring/grafana-configmap.yaml
+++ b/docs/src/samples/monitoring/grafana-configmap.yaml
@@ -23,6 +23,85 @@ metadata:
 data:
   cnp.json: |-
     {
+      "__inputs": [
+        {
+          "name": "DS_PROMETHEUS",
+          "label": "Prometheus",
+          "description": "",
+          "type": "datasource",
+          "pluginId": "prometheus",
+          "pluginName": "Prometheus"
+        }
+      ],
+      "__elements": {},
+      "__requires": [
+        {
+          "type": "panel",
+          "id": "alertlist",
+          "name": "Alert list",
+          "version": ""
+        },
+        {
+          "type": "panel",
+          "id": "bargauge",
+          "name": "Bar gauge",
+          "version": ""
+        },
+        {
+          "type": "panel",
+          "id": "gauge",
+          "name": "Gauge",
+          "version": ""
+        },
+        {
+          "type": "grafana",
+          "id": "grafana",
+          "name": "Grafana",
+          "version": "9.5.1"
+        },
+        {
+          "type": "panel",
+          "id": "graph",
+          "name": "Graph (old)",
+          "version": ""
+        },
+        {
+          "type": "panel",
+          "id": "heatmap",
+          "name": "Heatmap",
+          "version": ""
+        },
+        {
+          "type": "datasource",
+          "id": "prometheus",
+          "name": "Prometheus",
+          "version": "1.0.0"
+        },
+        {
+          "type": "panel",
+          "id": "stat",
+          "name": "Stat",
+          "version": ""
+        },
+        {
+          "type": "panel",
+          "id": "table",
+          "name": "Table",
+          "version": ""
+        },
+        {
+          "type": "panel",
+          "id": "text",
+          "name": "Text",
+          "version": ""
+        },
+        {
+          "type": "panel",
+          "id": "timeseries",
+          "name": "Time series",
+          "version": ""
+        }
+      ],
       "annotations": {
         "list": [
           {
@@ -48,7 +127,7 @@ data:
       "editable": true,
       "fiscalYearStartMonth": 0,
       "graphTooltip": 1,
-      "id": 452,
+      "id": null,
       "links": [
         {
           "asDropdown": false,
@@ -68,7 +147,10 @@ data:
       "liveNow": false,
       "panels": [
         {
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "gridPos": {
             "h": 7,
             "w": 3,
@@ -98,7 +180,10 @@ data:
           "type": "alertlist"
         },
         {
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "gridPos": {
             "h": 1,
             "w": 15,
@@ -120,7 +205,10 @@ data:
           "type": "text"
         },
         {
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "gridPos": {
             "h": 1,
             "w": 3,
@@ -142,7 +230,10 @@ data:
           "type": "text"
         },
         {
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "gridPos": {
             "h": 1,
             "w": 3,
@@ -164,7 +255,10 @@ data:
           "type": "text"
         },
         {
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "description": "",
           "fieldConfig": {
             "defaults": {
@@ -210,7 +304,10 @@ data:
           "pluginVersion": "9.5.1",
           "targets": [
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "editorMode": "code",
               "exemplar": false,
               "expr": "max(cnpg_pg_postmaster_start_time{namespace=~\"$namespace\",pod=~\"$instances\"})*1000",
@@ -228,7 +325,10 @@ data:
           "type": "stat"
         },
         {
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -272,7 +372,10 @@ data:
           "pluginVersion": "9.5.1",
           "targets": [
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "editorMode": "code",
               "exemplar": true,
               "expr": "sum(rate(cnpg_pg_stat_database_xact_commit{namespace=~\"$namespace\",pod=~\"$instances\"}[$__interval])) + sum(rate(cnpg_pg_stat_database_xact_rollback{namespace=~\"$namespace\",pod=~\"$instances\"}[$__interval]))",
@@ -286,7 +389,10 @@ data:
           "type": "stat"
         },
         {
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "description": "CPU Utilisation from Requests",
           "fieldConfig": {
             "defaults": {
@@ -341,7 +447,10 @@ data:
           "pluginVersion": "9.5.1",
           "targets": [
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "editorMode": "code",
               "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{ namespace=\"$namespace\"}) / sum(kube_pod_container_resource_requests{job=\"kube-state-metrics\",  namespace=\"$namespace\", resource=\"cpu\"})",
               "format": "time_series",
@@ -354,7 +463,10 @@ data:
           "type": "gauge"
         },
         {
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "description": "Memory Utilisation from Requests",
           "fieldConfig": {
             "defaults": {
@@ -409,7 +521,10 @@ data:
           "pluginVersion": "9.5.1",
           "targets": [
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "editorMode": "code",
               "expr": "sum(container_memory_working_set_bytes{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", namespace=\"$namespace\",container!=\"\", image!=\"\"}) / sum(max by(pod) (kube_pod_container_resource_requests{job=\"kube-state-metrics\", namespace=\"$namespace\", resource=\"memory\"}))",
               "format": "time_series",
@@ -422,7 +537,10 @@ data:
           "type": "gauge"
         },
         {
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -480,7 +598,10 @@ data:
           "pluginVersion": "9.5.1",
           "targets": [
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "editorMode": "code",
               "expr": "cnpg_pg_replication_lag{namespace=~\"$namespace\",pod=~\"$instances\"}",
               "legendFormat": "__auto",
@@ -492,7 +613,10 @@ data:
           "type": "stat"
         },
         {
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -548,7 +672,10 @@ data:
           "pluginVersion": "9.5.1",
           "targets": [
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "editorMode": "code",
               "expr": "max(cnpg_pg_stat_replication_write_lag_seconds{namespace=~\"$namespace\",pod=~\"$instances\"})",
               "legendFormat": "__auto",
@@ -560,7 +687,10 @@ data:
           "type": "stat"
         },
         {
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -612,7 +742,10 @@ data:
           "pluginVersion": "9.5.1",
           "targets": [
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "editorMode": "code",
               "expr": "max(max by(persistentvolumeclaim) (1 - kubelet_volume_stats_available_bytes{namespace=\"$namespace\", persistentvolumeclaim=~\"$instances\"} / kubelet_volume_stats_capacity_bytes{namespace=\"$namespace\", persistentvolumeclaim=~\"$instances\"}))",
               "format": "time_series",
@@ -622,7 +755,10 @@ data:
               "refId": "DATA"
             },
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "editorMode": "code",
               "expr": "max(max by(persistentvolumeclaim) (1 - kubelet_volume_stats_available_bytes{namespace=\"$namespace\", persistentvolumeclaim=~\"(${instances})-wal\"} / kubelet_volume_stats_capacity_bytes{namespace=\"$namespace\", persistentvolumeclaim=~\"(${instances})-wal\"}))",
               "format": "time_series",
@@ -630,13 +766,16 @@ data:
               "legendFormat": "WAL",
               "range": true,
               "refId": "WAL"
-            }            
+            }
           ],
           "title": "Volume Space Usage",
           "type": "gauge"
         },
         {
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "description": "Elapsed time since the last successful base backup.",
           "fieldConfig": {
             "defaults": {
@@ -653,6 +792,18 @@ data:
                       "text": "Invalid date"
                     },
                     "to": 1e+42
+                  },
+                  "type": "range"
+                },
+                {
+                  "options": {
+                    "from": -2147483648,
+                    "result": {
+                      "color": "red",
+                      "index": 1,
+                      "text": "No backups"
+                    },
+                    "to": -1577847600
                   },
                   "type": "range"
                 }
@@ -710,7 +861,10 @@ data:
           "pluginVersion": "9.5.1",
           "targets": [
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "editorMode": "code",
               "expr": "-(time() - max(cnpg_collector_last_available_backup_timestamp{namespace=\"$namespace\",pod=~\"$instances\"}))",
               "legendFormat": "__auto",
@@ -722,7 +876,10 @@ data:
           "type": "stat"
         },
         {
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -790,7 +947,10 @@ data:
           "pluginVersion": "9.5.1",
           "targets": [
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "editorMode": "code",
               "exemplar": true,
               "expr": "(1 - cnpg_pg_replication_in_recovery{namespace=~\"$namespace\",pod=~\"$instances\"} + cnpg_pg_replication_is_wal_receiver_up{namespace=~\"$namespace\",pod=~\"$instances\"}) * (time() - timestamp(cnpg_pg_stat_archiver_seconds_since_last_archival{namespace=~\"$namespace\",pod=~\"$instances\"}) -\ncnpg_pg_stat_archiver_seconds_since_last_archival{namespace=~\"$namespace\",pod=~\"$instances\"})",
@@ -805,7 +965,10 @@ data:
           "type": "stat"
         },
         {
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "description": "",
           "fieldConfig": {
             "defaults": {
@@ -852,7 +1015,10 @@ data:
           "repeatDirection": "v",
           "targets": [
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "editorMode": "builder",
               "exemplar": false,
               "expr": "cnpg_collector_postgres_version{namespace=~\"$namespace\",pod=~\"$instances\"}",
@@ -871,7 +1037,10 @@ data:
           "type": "stat"
         },
         {
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -927,7 +1096,10 @@ data:
           "pluginVersion": "9.5.1",
           "targets": [
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "editorMode": "code",
               "expr": "max(cnpg_pg_stat_replication_flush_lag_seconds{namespace=~\"$namespace\",pod=~\"$cluster-[0-9]+$\"})",
               "legendFormat": "__auto",
@@ -939,7 +1111,10 @@ data:
           "type": "stat"
         },
         {
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -995,7 +1170,10 @@ data:
           "pluginVersion": "9.5.1",
           "targets": [
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "editorMode": "code",
               "expr": "max(cnpg_pg_stat_replication_replay_lag_seconds{namespace=~\"$namespace\",pod=~\"$cluster-[0-9]+$\"})",
               "legendFormat": "__auto",
@@ -1007,7 +1185,10 @@ data:
           "type": "stat"
         },
         {
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "description": "",
           "fieldConfig": {
             "defaults": {
@@ -1062,7 +1243,10 @@ data:
           "pluginVersion": "9.5.1",
           "targets": [
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "editorMode": "code",
               "exemplar": true,
               "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{ namespace=\"$namespace\"})",
@@ -1076,7 +1260,10 @@ data:
           "type": "stat"
         },
         {
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "description": "Excluding cache",
           "fieldConfig": {
             "defaults": {
@@ -1130,7 +1317,10 @@ data:
           "pluginVersion": "9.5.1",
           "targets": [
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "editorMode": "code",
               "exemplar": true,
               "expr": "sum(container_memory_working_set_bytes{pod=~\"$instances\", namespace=\"$namespace\", container!=\"\", image!=\"\"})",
@@ -1144,7 +1334,10 @@ data:
           "type": "stat"
         },
         {
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "description": "",
           "fieldConfig": {
             "defaults": {
@@ -1199,7 +1392,10 @@ data:
           "pluginVersion": "9.5.1",
           "targets": [
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "editorMode": "code",
               "exemplar": false,
               "expr": "cnpg_pg_database_size_bytes{namespace=\"$namespace\"}",
@@ -1233,13 +1429,26 @@ data:
           "type": "stat"
         },
         {
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "fieldConfig": {
             "defaults": {
               "color": {
                 "mode": "thresholds"
               },
               "mappings": [
+                {
+                  "options": {
+                    "0": {
+                      "color": "red",
+                      "index": 1,
+                      "text": "No backups"
+                    }
+                  },
+                  "type": "value"
+                },
                 {
                   "options": {
                     "match": "null",
@@ -1289,7 +1498,10 @@ data:
           "pluginVersion": "9.5.1",
           "targets": [
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "editorMode": "code",
               "exemplar": true,
               "expr": "max(cnpg_collector_first_recoverability_point{namespace=~\"$namespace\",pod=~\"$instances\"})*1000",
@@ -1328,7 +1540,10 @@ data:
           "type": "row"
         },
         {
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "gridPos": {
             "h": 1,
             "w": 3,
@@ -1349,7 +1564,10 @@ data:
           "repeatDirection": "v",
           "targets": [
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "exemplar": true,
               "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
               "instant": true,
@@ -1363,7 +1581,10 @@ data:
           "type": "text"
         },
         {
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "gridPos": {
             "h": 1,
             "w": 2,
@@ -1384,7 +1605,10 @@ data:
           "repeatDirection": "v",
           "targets": [
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "exemplar": true,
               "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
               "instant": true,
@@ -1397,7 +1621,10 @@ data:
           "type": "text"
         },
         {
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "gridPos": {
             "h": 1,
             "w": 3,
@@ -1418,7 +1645,10 @@ data:
           "repeatDirection": "v",
           "targets": [
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "exemplar": true,
               "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
               "instant": true,
@@ -1431,7 +1661,10 @@ data:
           "type": "text"
         },
         {
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "gridPos": {
             "h": 1,
             "w": 2,
@@ -1452,7 +1685,10 @@ data:
           "repeatDirection": "v",
           "targets": [
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "exemplar": true,
               "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
               "instant": true,
@@ -1465,7 +1701,10 @@ data:
           "type": "text"
         },
         {
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "gridPos": {
             "h": 1,
             "w": 4,
@@ -1486,7 +1725,10 @@ data:
           "repeatDirection": "v",
           "targets": [
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "exemplar": true,
               "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
               "instant": true,
@@ -1499,7 +1741,10 @@ data:
           "type": "text"
         },
         {
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "gridPos": {
             "h": 1,
             "w": 3,
@@ -1520,7 +1765,10 @@ data:
           "repeatDirection": "v",
           "targets": [
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "exemplar": true,
               "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
               "instant": true,
@@ -1533,7 +1781,10 @@ data:
           "type": "text"
         },
         {
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "description": "",
           "gridPos": {
             "h": 1,
@@ -1555,7 +1806,10 @@ data:
           "repeatDirection": "v",
           "targets": [
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "exemplar": true,
               "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
               "instant": true,
@@ -1568,7 +1822,10 @@ data:
           "type": "text"
         },
         {
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "gridPos": {
             "h": 1,
             "w": 2,
@@ -1589,7 +1846,10 @@ data:
           "repeatDirection": "v",
           "targets": [
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "exemplar": true,
               "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
               "instant": true,
@@ -1602,7 +1862,10 @@ data:
           "type": "text"
         },
         {
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "gridPos": {
             "h": 1,
             "w": 2,
@@ -1623,7 +1886,10 @@ data:
           "repeatDirection": "v",
           "targets": [
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "exemplar": true,
               "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
               "instant": true,
@@ -1636,7 +1902,10 @@ data:
           "type": "text"
         },
         {
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "gridPos": {
             "h": 3,
             "w": 3,
@@ -1658,7 +1927,10 @@ data:
           "repeatDirection": "v",
           "targets": [
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "exemplar": true,
               "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
               "instant": true,
@@ -1670,7 +1942,10 @@ data:
           "type": "text"
         },
         {
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1734,7 +2009,10 @@ data:
           "repeatDirection": "v",
           "targets": [
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "editorMode": "code",
               "exemplar": true,
               "expr": "min(kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"})",
@@ -1747,7 +2025,10 @@ data:
           "type": "stat"
         },
         {
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "description": "",
           "fieldConfig": {
             "defaults": {
@@ -1815,7 +2096,10 @@ data:
           "repeatDirection": "v",
           "targets": [
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "exemplar": true,
               "expr": "1 - cnpg_pg_replication_in_recovery{namespace=~\"$namespace\",pod=~\"$instances\"} + cnpg_pg_replication_is_wal_receiver_up{namespace=~\"$namespace\",pod=~\"$instances\"}",
               "instant": true,
@@ -1828,7 +2112,10 @@ data:
           "type": "stat"
         },
         {
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "description": "",
           "fieldConfig": {
             "defaults": {
@@ -1880,7 +2167,10 @@ data:
           "repeatDirection": "v",
           "targets": [
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "exemplar": true,
               "expr": "cnpg_pg_replication_streaming_replicas{namespace=~\"$namespace\",pod=~\"$instances\"}",
               "instant": true,
@@ -1893,7 +2183,10 @@ data:
           "type": "stat"
         },
         {
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "description": "This metric depends on exporting the: `topology.kubernetes.io/zone` label through kube-state-metrics (not enabled by default). Can be added by changing its configuration with:\n\n```yaml\nmetricLabelsAllowlist:\n  - nodes=[topology.kubernetes.io/zone]\n```",
           "fieldConfig": {
             "defaults": {
@@ -1942,7 +2235,10 @@ data:
           "repeatDirection": "v",
           "targets": [
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "editorMode": "code",
               "exemplar": true,
               "expr": "kube_pod_info{namespace=~\"$namespace\",pod=~\"$instances\"} * on(node,instance) group_left(label_topology_kubernetes_io_zone) kube_node_labels",
@@ -1957,7 +2253,10 @@ data:
           "type": "stat"
         },
         {
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1977,6 +2276,7 @@ data:
                   "tooltip": false,
                   "viz": false
                 },
+                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -2034,7 +2334,10 @@ data:
           "repeatDirection": "v",
           "targets": [
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "exemplar": true,
               "expr": "sum by (pod) (cnpg_backends_total{namespace=~\"$namespace\",pod=~\"$instances\"})",
               "instant": false,
@@ -2046,7 +2349,10 @@ data:
           "type": "timeseries"
         },
         {
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "description": "",
           "fieldConfig": {
             "defaults": {
@@ -2104,7 +2410,10 @@ data:
           "repeatDirection": "v",
           "targets": [
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "exemplar": true,
               "expr": "100 * sum by (pod) (cnpg_backends_total{namespace=~\"$namespace\",pod=~\"$instances\"}) / sum by (pod) (cnpg_pg_settings_setting{name=\"max_connections\",namespace=~\"$namespace\",pod=~\"$instances\"})",
               "instant": true,
@@ -2116,7 +2425,10 @@ data:
           "type": "gauge"
         },
         {
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -2174,7 +2486,10 @@ data:
           "repeatDirection": "v",
           "targets": [
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "exemplar": true,
               "expr": "max by (pod) (cnpg_pg_database_xid_age{namespace=~\"$namespace\",pod=~\"$instances\"})",
               "instant": true,
@@ -2186,7 +2501,10 @@ data:
           "type": "bargauge"
         },
         {
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "description": "",
           "fieldConfig": {
             "defaults": {
@@ -2234,7 +2552,10 @@ data:
           "repeatDirection": "v",
           "targets": [
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "exemplar": false,
               "expr": "cnpg_pg_postmaster_start_time{namespace=~\"$namespace\",pod=~\"$instances\"}*1000",
               "format": "time_series",
@@ -2250,7 +2571,10 @@ data:
           "type": "stat"
         },
         {
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "description": "",
           "fieldConfig": {
             "defaults": {
@@ -2298,7 +2622,10 @@ data:
           "repeatDirection": "v",
           "targets": [
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "editorMode": "code",
               "exemplar": false,
               "expr": "cnpg_collector_postgres_version{namespace=~\"$namespace\",pod=~\"$instances\"}",
@@ -2339,7 +2666,10 @@ data:
           "type": "row"
         },
         {
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "gridPos": {
             "h": 1,
             "w": 3,
@@ -2360,7 +2690,10 @@ data:
           "repeatDirection": "v",
           "targets": [
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "exemplar": true,
               "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
               "instant": true,
@@ -2374,7 +2707,10 @@ data:
           "type": "text"
         },
         {
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "gridPos": {
             "h": 1,
             "w": 3,
@@ -2395,7 +2731,10 @@ data:
           "repeatDirection": "v",
           "targets": [
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "exemplar": true,
               "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
               "instant": true,
@@ -2408,7 +2747,10 @@ data:
           "type": "text"
         },
         {
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "gridPos": {
             "h": 1,
             "w": 3,
@@ -2429,7 +2771,10 @@ data:
           "repeatDirection": "v",
           "targets": [
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "exemplar": true,
               "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
               "instant": true,
@@ -2442,7 +2787,10 @@ data:
           "type": "text"
         },
         {
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "gridPos": {
             "h": 1,
             "w": 3,
@@ -2463,7 +2811,10 @@ data:
           "repeatDirection": "v",
           "targets": [
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "exemplar": true,
               "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
               "instant": true,
@@ -2476,7 +2827,10 @@ data:
           "type": "text"
         },
         {
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "gridPos": {
             "h": 1,
             "w": 3,
@@ -2497,7 +2851,10 @@ data:
           "repeatDirection": "v",
           "targets": [
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "exemplar": true,
               "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
               "instant": true,
@@ -2510,7 +2867,10 @@ data:
           "type": "text"
         },
         {
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "gridPos": {
             "h": 1,
             "w": 3,
@@ -2531,7 +2891,10 @@ data:
           "repeatDirection": "v",
           "targets": [
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "exemplar": true,
               "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
               "instant": true,
@@ -2544,7 +2907,10 @@ data:
           "type": "text"
         },
         {
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "gridPos": {
             "h": 1,
             "w": 3,
@@ -2565,7 +2931,10 @@ data:
           "repeatDirection": "v",
           "targets": [
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "exemplar": true,
               "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
               "instant": true,
@@ -2578,7 +2947,10 @@ data:
           "type": "text"
         },
         {
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "gridPos": {
             "h": 1,
             "w": 3,
@@ -2599,7 +2971,10 @@ data:
           "repeatDirection": "v",
           "targets": [
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "exemplar": true,
               "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
               "instant": true,
@@ -2612,7 +2987,10 @@ data:
           "type": "text"
         },
         {
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "gridPos": {
             "h": 3,
             "w": 3,
@@ -2634,7 +3012,10 @@ data:
           "repeatDirection": "v",
           "targets": [
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "exemplar": true,
               "expr": "kube_pod_container_status_ready{container=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"}",
               "instant": true,
@@ -2646,7 +3027,10 @@ data:
           "type": "text"
         },
         {
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -2692,7 +3076,10 @@ data:
           "repeatDirection": "v",
           "targets": [
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "exemplar": true,
               "expr": "cnpg_pg_settings_setting{name=\"max_connections\",namespace=~\"$namespace\",pod=~\"$instances\"}",
               "instant": true,
@@ -2704,7 +3091,10 @@ data:
           "type": "stat"
         },
         {
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "description": "",
           "fieldConfig": {
             "defaults": {
@@ -2752,7 +3142,10 @@ data:
           "repeatDirection": "v",
           "targets": [
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "exemplar": true,
               "expr": "max by (pod) (cnpg_pg_settings_setting{name=\"shared_buffers\",namespace=~\"$namespace\",pod=~\"$instances\"}) * max by (pod) (cnpg_pg_settings_setting{name=\"block_size\",namespace=~\"$namespace\",pod=~\"$instances\"})",
               "instant": true,
@@ -2764,7 +3157,10 @@ data:
           "type": "stat"
         },
         {
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "description": "",
           "fieldConfig": {
             "defaults": {
@@ -2812,7 +3208,10 @@ data:
           "repeatDirection": "v",
           "targets": [
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "exemplar": true,
               "expr": "max by (pod) (cnpg_pg_settings_setting{name=\"effective_cache_size\",namespace=~\"$namespace\",pod=~\"$instances\"}) * max by (pod) (cnpg_pg_settings_setting{name=\"block_size\",namespace=~\"$namespace\",pod=~\"$instances\"})",
               "instant": true,
@@ -2824,7 +3223,10 @@ data:
           "type": "stat"
         },
         {
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "description": "",
           "fieldConfig": {
             "defaults": {
@@ -2872,7 +3274,10 @@ data:
           "repeatDirection": "v",
           "targets": [
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "exemplar": true,
               "expr": "cnpg_pg_settings_setting{name=\"work_mem\",namespace=~\"$namespace\",pod=~\"$instances\"} * 1024",
               "instant": true,
@@ -2884,7 +3289,10 @@ data:
           "type": "stat"
         },
         {
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -2931,7 +3339,10 @@ data:
           "repeatDirection": "v",
           "targets": [
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "exemplar": true,
               "expr": "cnpg_pg_settings_setting{name=\"maintenance_work_mem\",namespace=~\"$namespace\",pod=~\"$instances\"}",
               "instant": true,
@@ -2943,7 +3354,10 @@ data:
           "type": "stat"
         },
         {
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -2990,7 +3404,10 @@ data:
           "repeatDirection": "v",
           "targets": [
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "exemplar": true,
               "expr": "cnpg_pg_settings_setting{name=\"random_page_cost\",namespace=~\"$namespace\",pod=~\"$instances\"}",
               "instant": true,
@@ -3002,7 +3419,10 @@ data:
           "type": "stat"
         },
         {
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -3049,7 +3469,10 @@ data:
           "repeatDirection": "v",
           "targets": [
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "exemplar": true,
               "expr": "cnpg_pg_settings_setting{name=\"seq_page_cost\",namespace=~\"$namespace\",pod=~\"$instances\"}",
               "instant": true,
@@ -3061,7 +3484,10 @@ data:
           "type": "stat"
         },
         {
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -3112,7 +3538,10 @@ data:
           "repeatDirection": "v",
           "targets": [
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "exemplar": true,
               "expr": "cnpg_pg_settings_setting{namespace=~\"$namespace\",pod=~\"$instances\"}",
               "format": "table",
@@ -3195,7 +3624,10 @@ data:
               "bars": false,
               "dashLength": 10,
               "dashes": false,
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "fill": 1,
               "fillGradient": 0,
               "gridPos": {
@@ -3233,7 +3665,10 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "datasource": "${DS_PROMETHEUS}",
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${DS_PROMETHEUS}"
+                  },
                   "exemplar": true,
                   "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{pod=~\"$instances\", namespace=~\"$namespace\"}) by (pod)",
                   "format": "time_series",
@@ -3244,7 +3679,10 @@ data:
                   "step": 10
                 },
                 {
-                  "datasource": "${DS_PROMETHEUS}",
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${DS_PROMETHEUS}"
+                  },
                   "exemplar": true,
                   "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{pod=~\"$instances\", namespace=~\"$namespace\"})",
                   "hide": false,
@@ -3291,7 +3729,10 @@ data:
               "bars": false,
               "dashLength": 10,
               "dashes": false,
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "fill": 2,
               "fillGradient": 0,
               "gridPos": {
@@ -3352,7 +3793,10 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "datasource": "${DS_PROMETHEUS}",
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${DS_PROMETHEUS}"
+                  },
                   "exemplar": true,
                   "expr": "sum(container_memory_working_set_bytes{pod=~\"$instances\", namespace=\"$namespace\", container!=\"\", image!=\"\"}) by (pod)",
                   "format": "time_series",
@@ -3363,7 +3807,10 @@ data:
                   "step": 10
                 },
                 {
-                  "datasource": "${DS_PROMETHEUS}",
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${DS_PROMETHEUS}"
+                  },
                   "exemplar": true,
                   "expr": "sum(container_memory_working_set_bytes{pod=~\"$instances\", namespace=\"$namespace\", container!=\"\", image!=\"\"})",
                   "hide": false,
@@ -3406,7 +3853,10 @@ data:
               }
             },
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "description": "",
               "fieldConfig": {
                 "defaults": {
@@ -3476,7 +3926,10 @@ data:
               },
               "targets": [
                 {
-                  "datasource": "${DS_PROMETHEUS}",
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${DS_PROMETHEUS}"
+                  },
                   "exemplar": true,
                   "expr": "sum(cnpg_backends_total{namespace=~\"$namespace\",pod=~\"$instances\"}) by (pod)",
                   "hide": false,
@@ -3485,7 +3938,10 @@ data:
                   "refId": "B"
                 },
                 {
-                  "datasource": "${DS_PROMETHEUS}",
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${DS_PROMETHEUS}"
+                  },
                   "exemplar": true,
                   "expr": "sum(cnpg_backends_total{namespace=~\"$namespace\",pod=~\"$instances\"}) by (state, pod)",
                   "interval": "",
@@ -3497,7 +3953,10 @@ data:
               "type": "timeseries"
             },
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "fieldConfig": {
                 "defaults": {
                   "color": {
@@ -3570,7 +4029,10 @@ data:
               },
               "targets": [
                 {
-                  "datasource": "${DS_PROMETHEUS}",
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${DS_PROMETHEUS}"
+                  },
                   "exemplar": true,
                   "expr": "sum(rate(cnpg_pg_stat_database_xact_commit{namespace=~\"$namespace\",pod=~\"$instances\"}[5m])) by (pod)",
                   "interval": "",
@@ -3578,7 +4040,10 @@ data:
                   "refId": "A"
                 },
                 {
-                  "datasource": "${DS_PROMETHEUS}",
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${DS_PROMETHEUS}"
+                  },
                   "exemplar": true,
                   "expr": "sum(rate(cnpg_pg_stat_database_xact_rollback{namespace=~\"$namespace\",pod=~\"$instances\"}[5m])) by (pod)",
                   "hide": false,
@@ -3591,7 +4056,10 @@ data:
               "type": "timeseries"
             },
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "description": "",
               "fieldConfig": {
                 "defaults": {
@@ -3666,7 +4134,10 @@ data:
               },
               "targets": [
                 {
-                  "datasource": "${DS_PROMETHEUS}",
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${DS_PROMETHEUS}"
+                  },
                   "exemplar": true,
                   "expr": "max by (pod) (cnpg_backends_max_tx_duration_seconds{namespace=~\"$namespace\",pod=~\"$instances\"})",
                   "interval": "",
@@ -3678,7 +4149,10 @@ data:
               "type": "timeseries"
             },
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "description": "",
               "fieldConfig": {
                 "defaults": {
@@ -3752,7 +4226,10 @@ data:
               },
               "targets": [
                 {
-                  "datasource": "${DS_PROMETHEUS}",
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${DS_PROMETHEUS}"
+                  },
                   "exemplar": true,
                   "expr": "rate(cnpg_pg_stat_database_deadlocks{datname=\"\",namespace=~\"$namespace\",pod=~\"$instances\"}[5m])",
                   "hide": false,
@@ -3766,7 +4243,10 @@ data:
               "type": "timeseries"
             },
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "description": "",
               "fieldConfig": {
                 "defaults": {
@@ -3840,7 +4320,10 @@ data:
               },
               "targets": [
                 {
-                  "datasource": "${DS_PROMETHEUS}",
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${DS_PROMETHEUS}"
+                  },
                   "exemplar": true,
                   "expr": "cnpg_backends_waiting_total{namespace=~\"$namespace\",pod=~\"$instances\"}",
                   "interval": "",
@@ -3877,7 +4360,10 @@ data:
           "id": 35,
           "panels": [
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "fieldConfig": {
                 "defaults": {
                   "color": {
@@ -3929,7 +4415,10 @@ data:
               "pluginVersion": "9.4.7",
               "targets": [
                 {
-                  "datasource": "${DS_PROMETHEUS}",
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${DS_PROMETHEUS}"
+                  },
                   "editorMode": "code",
                   "expr": "max by(persistentvolumeclaim) (1 - kubelet_volume_stats_available_bytes{namespace=\"$namespace\", persistentvolumeclaim=~\"$instances\"} / kubelet_volume_stats_capacity_bytes{namespace=\"$namespace\", persistentvolumeclaim=~\"$instances\"})",
                   "format": "time_series",
@@ -3939,7 +4428,10 @@ data:
                   "refId": "FREE_SPACE"
                 },
                 {
-                  "datasource": "${DS_PROMETHEUS}",
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${DS_PROMETHEUS}"
+                  },
                   "editorMode": "code",
                   "expr": "max by(persistentvolumeclaim) (1 - kubelet_volume_stats_available_bytes{namespace=\"$namespace\", persistentvolumeclaim=~\"(${instances})-wal\"} / kubelet_volume_stats_capacity_bytes{namespace=\"$namespace\", persistentvolumeclaim=~\"(${instances})-wal\"})",
                   "format": "time_series",
@@ -3947,14 +4439,17 @@ data:
                   "legendFormat": "{{persistentvolumeclaim}}",
                   "range": true,
                   "refId": "FREE_SPACE_WAL"
-                }                
+                }
               ],
               "title": "Volume Space Usage",
               "transformations": [],
               "type": "gauge"
             },
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "fieldConfig": {
                 "defaults": {
                   "color": {
@@ -4006,7 +4501,10 @@ data:
               "pluginVersion": "9.4.7",
               "targets": [
                 {
-                  "datasource": "${DS_PROMETHEUS}",
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${DS_PROMETHEUS}"
+                  },
                   "editorMode": "code",
                   "expr": "max by(persistentvolumeclaim) (kubelet_volume_stats_inodes_used{namespace=\"$namespace\", persistentvolumeclaim=~\"$instances\"} / kubelet_volume_stats_inodes{namespace=\"$namespace\", persistentvolumeclaim=~\"$instances\"})",
                   "format": "time_series",
@@ -4016,7 +4514,10 @@ data:
                   "refId": "FREE_INODES"
                 },
                 {
-                  "datasource": "${DS_PROMETHEUS}",
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${DS_PROMETHEUS}"
+                  },
                   "editorMode": "code",
                   "expr": "max by(persistentvolumeclaim) (kubelet_volume_stats_inodes_used{namespace=\"$namespace\", persistentvolumeclaim=~\"(${instances})-wal\"} / kubelet_volume_stats_inodes{namespace=\"$namespace\", persistentvolumeclaim=~\"(${instances})-wal\"})",
                   "format": "time_series",
@@ -4024,14 +4525,17 @@ data:
                   "legendFormat": "{{persistentvolumeclaim}}",
                   "range": true,
                   "refId": "FREE_INODES_WAL"
-                }                
+                }
               ],
               "title": "Volume Inode Usage",
               "transformations": [],
               "type": "gauge"
             },
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "fieldConfig": {
                 "defaults": {
                   "color": {
@@ -4104,7 +4608,10 @@ data:
               },
               "targets": [
                 {
-                  "datasource": "${DS_PROMETHEUS}",
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${DS_PROMETHEUS}"
+                  },
                   "editorMode": "code",
                   "exemplar": true,
                   "expr": "sum(rate(cnpg_pg_stat_database_tup_deleted{datname=\"\",namespace=~\"$namespace\",pod=~\"$instances\"}[5m]))",
@@ -4114,7 +4621,10 @@ data:
                   "refId": "A"
                 },
                 {
-                  "datasource": "${DS_PROMETHEUS}",
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${DS_PROMETHEUS}"
+                  },
                   "editorMode": "code",
                   "exemplar": true,
                   "expr": "sum(rate(cnpg_pg_stat_database_tup_inserted{datname=\"\",namespace=~\"$namespace\",pod=~\"$instances\"}[5m]))",
@@ -4125,7 +4635,10 @@ data:
                   "refId": "B"
                 },
                 {
-                  "datasource": "${DS_PROMETHEUS}",
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${DS_PROMETHEUS}"
+                  },
                   "editorMode": "code",
                   "exemplar": true,
                   "expr": "sum(rate(cnpg_pg_stat_database_tup_fetched{datname=\"\",namespace=~\"$namespace\",pod=~\"$instances\"}[5m]))",
@@ -4136,7 +4649,10 @@ data:
                   "refId": "C"
                 },
                 {
-                  "datasource": "${DS_PROMETHEUS}",
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${DS_PROMETHEUS}"
+                  },
                   "editorMode": "code",
                   "exemplar": true,
                   "expr": "sum(rate(cnpg_pg_stat_database_tup_returned{datname=\"\",namespace=~\"$namespace\",pod=~\"$instances\"}[5m]))",
@@ -4147,7 +4663,10 @@ data:
                   "refId": "D"
                 },
                 {
-                  "datasource": "${DS_PROMETHEUS}",
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${DS_PROMETHEUS}"
+                  },
                   "editorMode": "code",
                   "exemplar": true,
                   "expr": "sum(rate(cnpg_pg_stat_database_tup_updated{datname=\"\",namespace=~\"$namespace\",pod=~\"$instances\"}[5m]))",
@@ -4162,7 +4681,10 @@ data:
               "type": "timeseries"
             },
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "fieldConfig": {
                 "defaults": {
                   "color": {
@@ -4235,7 +4757,10 @@ data:
               },
               "targets": [
                 {
-                  "datasource": "${DS_PROMETHEUS}",
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${DS_PROMETHEUS}"
+                  },
                   "editorMode": "code",
                   "exemplar": true,
                   "expr": "rate(cnpg_pg_stat_database_blks_hit{datname=\"\",namespace=~\"$namespace\",pod=~\"$instances\"}[5m])",
@@ -4245,7 +4770,10 @@ data:
                   "refId": "A"
                 },
                 {
-                  "datasource": "${DS_PROMETHEUS}",
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${DS_PROMETHEUS}"
+                  },
                   "editorMode": "code",
                   "exemplar": true,
                   "expr": "rate(cnpg_pg_stat_database_blks_read{datname=\"\",namespace=~\"$namespace\",pod=~\"$instances\"}[5m])",
@@ -4260,7 +4788,10 @@ data:
               "type": "timeseries"
             },
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "fieldConfig": {
                 "defaults": {
                   "color": {
@@ -4331,7 +4862,10 @@ data:
               "pluginVersion": "8.0.5",
               "targets": [
                 {
-                  "datasource": "${DS_PROMETHEUS}",
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${DS_PROMETHEUS}"
+                  },
                   "editorMode": "code",
                   "exemplar": true,
                   "expr": "max by (datname) (cnpg_pg_database_size_bytes{datname!~\"template.*\",datname!=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"})",
@@ -4345,7 +4879,10 @@ data:
               "type": "timeseries"
             },
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "fieldConfig": {
                 "defaults": {
                   "color": {
@@ -4419,7 +4956,10 @@ data:
               },
               "targets": [
                 {
-                  "datasource": "${DS_PROMETHEUS}",
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${DS_PROMETHEUS}"
+                  },
                   "exemplar": true,
                   "expr": "rate(cnpg_pg_stat_database_temp_bytes{datname=\"\",namespace=~\"$namespace\",pod=~\"$instances\"}[5m])",
                   "instant": false,
@@ -4457,7 +4997,10 @@ data:
           "id": 37,
           "panels": [
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "fieldConfig": {
                 "defaults": {
                   "color": {
@@ -4530,7 +5073,10 @@ data:
               },
               "targets": [
                 {
-                  "datasource": "${DS_PROMETHEUS}",
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${DS_PROMETHEUS}"
+                  },
                   "exemplar": true,
                   "expr": "cnpg_collector_pg_wal_archive_status{value=\"ready\",namespace=~\"$namespace\",pod=~\"$instances\"}",
                   "interval": "",
@@ -4538,7 +5084,10 @@ data:
                   "refId": "A"
                 },
                 {
-                  "datasource": "${DS_PROMETHEUS}",
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${DS_PROMETHEUS}"
+                  },
                   "exemplar": true,
                   "expr": "cnpg_collector_pg_wal_archive_status{value=\"done\",namespace=~\"$namespace\",pod=~\"$instances\"}",
                   "hide": false,
@@ -4551,7 +5100,10 @@ data:
               "type": "timeseries"
             },
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "fieldConfig": {
                 "defaults": {
                   "color": {
@@ -4624,7 +5176,10 @@ data:
               },
               "targets": [
                 {
-                  "datasource": "${DS_PROMETHEUS}",
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${DS_PROMETHEUS}"
+                  },
                   "exemplar": true,
                   "expr": "rate(cnpg_pg_stat_archiver_archived_count{namespace=~\"$namespace\",pod=~\"$instances\"}[5m])",
                   "interval": "",
@@ -4632,7 +5187,10 @@ data:
                   "refId": "A"
                 },
                 {
-                  "datasource": "${DS_PROMETHEUS}",
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${DS_PROMETHEUS}"
+                  },
                   "exemplar": true,
                   "expr": "rate(cnpg_pg_stat_archiver_failed_count{namespace=~\"$namespace\",pod=~\"$instances\"}[5m])",
                   "hide": false,
@@ -4645,7 +5203,10 @@ data:
               "type": "timeseries"
             },
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "description": "",
               "fieldConfig": {
                 "defaults": {
@@ -4720,7 +5281,10 @@ data:
               },
               "targets": [
                 {
-                  "datasource": "${DS_PROMETHEUS}",
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${DS_PROMETHEUS}"
+                  },
                   "exemplar": true,
                   "expr": "cnpg_pg_stat_archiver_seconds_since_last_archival{namespace=~\"$namespace\",pod=~\"$instances\"}",
                   "interval": "",
@@ -4757,7 +5321,10 @@ data:
           "id": 18,
           "panels": [
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "fieldConfig": {
                 "defaults": {
                   "color": {
@@ -4835,7 +5402,10 @@ data:
               },
               "targets": [
                 {
-                  "datasource": "${DS_PROMETHEUS}",
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${DS_PROMETHEUS}"
+                  },
                   "exemplar": true,
                   "expr": "cnpg_pg_replication_lag{namespace=~\"$namespace\",pod=~\"$instances\"}",
                   "instant": false,
@@ -4848,7 +5418,10 @@ data:
               "type": "timeseries"
             },
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "fieldConfig": {
                 "defaults": {
                   "color": {
@@ -4922,7 +5495,10 @@ data:
               },
               "targets": [
                 {
-                  "datasource": "${DS_PROMETHEUS}",
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${DS_PROMETHEUS}"
+                  },
                   "exemplar": true,
                   "expr": "cnpg_pg_stat_replication_write_lag_seconds{namespace=~\"$namespace\",pod=~\"$cluster-[0-9]+$\"}",
                   "instant": false,
@@ -4935,7 +5511,10 @@ data:
               "type": "timeseries"
             },
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "fieldConfig": {
                 "defaults": {
                   "color": {
@@ -5009,7 +5588,10 @@ data:
               },
               "targets": [
                 {
-                  "datasource": "${DS_PROMETHEUS}",
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${DS_PROMETHEUS}"
+                  },
                   "exemplar": true,
                   "expr": "cnpg_pg_stat_replication_flush_lag_seconds{namespace=~\"$namespace\",pod=~\"$cluster-[0-9]+$\"}",
                   "instant": false,
@@ -5022,7 +5604,10 @@ data:
               "type": "timeseries"
             },
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "description": "",
               "fieldConfig": {
                 "defaults": {
@@ -5097,7 +5682,10 @@ data:
               },
               "targets": [
                 {
-                  "datasource": "${DS_PROMETHEUS}",
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${DS_PROMETHEUS}"
+                  },
                   "exemplar": true,
                   "expr": "cnpg_pg_stat_replication_replay_lag_seconds{namespace=~\"$namespace\",pod=~\"$cluster-[0-9]+$\"}",
                   "interval": "",
@@ -5143,7 +5731,10 @@ data:
                 "mode": "spectrum"
               },
               "dataFormat": "timeseries",
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "fieldConfig": {
                 "defaults": {
                   "custom": {
@@ -5213,7 +5804,10 @@ data:
               "reverseYBuckets": false,
               "targets": [
                 {
-                  "datasource": "${DS_PROMETHEUS}",
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${DS_PROMETHEUS}"
+                  },
                   "exemplar": true,
                   "expr": "cnpg_collector_collection_duration_seconds{namespace=~\"$namespace\",pod=~\"$instances\"}",
                   "interval": "",
@@ -5238,7 +5832,10 @@ data:
               "yBucketBound": "auto"
             },
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "fieldConfig": {
                 "defaults": {
                   "color": {
@@ -5311,7 +5908,10 @@ data:
               },
               "targets": [
                 {
-                  "datasource": "${DS_PROMETHEUS}",
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${DS_PROMETHEUS}"
+                  },
                   "exemplar": true,
                   "expr": "cnpg_collector_last_collection_error{namespace=~\"$namespace\",pod=~\"$instances\"}",
                   "interval": "",
@@ -5348,7 +5948,10 @@ data:
           "id": 239,
           "panels": [
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "fieldConfig": {
                 "defaults": {
                   "color": {
@@ -5422,7 +6025,10 @@ data:
               },
               "targets": [
                 {
-                  "datasource": "${DS_PROMETHEUS}",
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${DS_PROMETHEUS}"
+                  },
                   "exemplar": true,
                   "expr": "cnpg_collector_first_recoverability_point{namespace=~\"$namespace\",pod=~\"$instances\"}*1000 > 0",
                   "format": "time_series",
@@ -5460,7 +6066,10 @@ data:
           "id": 293,
           "panels": [
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "description": "",
               "fieldConfig": {
                 "defaults": {
@@ -5536,7 +6145,10 @@ data:
               "pluginVersion": "8.2.1",
               "targets": [
                 {
-                  "datasource": "${DS_PROMETHEUS}",
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${DS_PROMETHEUS}"
+                  },
                   "exemplar": true,
                   "expr": "cnpg_pg_stat_bgwriter_checkpoints_req{namespace=~\"$namespace\",pod=~\"$instances\"}",
                   "format": "time_series",
@@ -5548,7 +6160,10 @@ data:
                   "refId": "B"
                 },
                 {
-                  "datasource": "${DS_PROMETHEUS}",
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${DS_PROMETHEUS}"
+                  },
                   "exemplar": true,
                   "expr": "cnpg_pg_stat_bgwriter_checkpoints_timed{namespace=~\"$namespace\",pod=~\"$instances\"}",
                   "format": "time_series",
@@ -5562,7 +6177,10 @@ data:
               "type": "timeseries"
             },
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "description": "",
               "fieldConfig": {
                 "defaults": {
@@ -5638,7 +6256,10 @@ data:
               "pluginVersion": "8.2.1",
               "targets": [
                 {
-                  "datasource": "${DS_PROMETHEUS}",
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${DS_PROMETHEUS}"
+                  },
                   "exemplar": true,
                   "expr": "cnpg_pg_stat_bgwriter_checkpoint_write_time{namespace=~\"$namespace\",pod=~\"$instances\"}",
                   "format": "time_series",
@@ -5650,7 +6271,10 @@ data:
                   "refId": "B"
                 },
                 {
-                  "datasource": "${DS_PROMETHEUS}",
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${DS_PROMETHEUS}"
+                  },
                   "exemplar": true,
                   "expr": "cnpg_pg_stat_bgwriter_checkpoint_sync_time{namespace=~\"$namespace\",pod=~\"$instances\"}",
                   "format": "time_series",
@@ -5705,11 +6329,7 @@ data:
             "type": "datasource"
           },
           {
-            "current": {
-              "selected": false,
-              "text": "database",
-              "value": "database"
-            },
+            "current": {},
             "datasource": {
               "type": "prometheus",
               "uid": "${DS_PROMETHEUS}"
@@ -5731,11 +6351,7 @@ data:
             "type": "query"
           },
           {
-            "current": {
-              "selected": false,
-              "text": "database-clustermarket-database",
-              "value": "database-clustermarket-database"
-            },
+            "current": {},
             "datasource": {
               "type": "prometheus",
               "uid": "${DS_PROMETHEUS}"
@@ -5757,15 +6373,7 @@ data:
             "type": "query"
           },
           {
-            "current": {
-              "selected": true,
-              "text": [
-                "All"
-              ],
-              "value": [
-                "$__all"
-              ]
-            },
+            "current": {},
             "datasource": {
               "type": "prometheus",
               "uid": "${DS_PROMETHEUS}"
@@ -5797,7 +6405,7 @@ data:
       },
       "timezone": "",
       "title": "CloudNativePG",
-      "uid": "z7FCA4Nnk",
-      "version": 9,
+      "uid": "cloudnative-pg",
+      "version": 1,
       "weekStart": ""
     }

--- a/docs/src/samples/monitoring/grafana-dashboard.json
+++ b/docs/src/samples/monitoring/grafana-dashboard.json
@@ -579,7 +579,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "cnpg_pg_replication_lag{namespace=~\"$namespace\",pod=~\"$instances\"}",
+          "expr": "max(cnpg_pg_replication_lag{namespace=~\"$namespace\",pod=~\"$instances\"})",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"

--- a/docs/src/samples/monitoring/grafana-dashboard.json
+++ b/docs/src/samples/monitoring/grafana-dashboard.json
@@ -777,7 +777,7 @@
                 "result": {
                   "color": "red",
                   "index": 1,
-                  "text": "No backups"
+                  "text": "N/A"
                 },
                 "to": -1577847600
               },

--- a/docs/src/samples/monitoring/grafana-dashboard.json
+++ b/docs/src/samples/monitoring/grafana-dashboard.json
@@ -929,7 +929,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "(1 - cnpg_pg_replication_in_recovery{namespace=~\"$namespace\",pod=~\"$instances\"} + cnpg_pg_replication_is_wal_receiver_up{namespace=~\"$namespace\",pod=~\"$instances\"}) * (time() - timestamp(cnpg_pg_stat_archiver_seconds_since_last_archival{namespace=~\"$namespace\",pod=~\"$instances\"}) -\ncnpg_pg_stat_archiver_seconds_since_last_archival{namespace=~\"$namespace\",pod=~\"$instances\"})",
+          "expr": "min((1 - cnpg_pg_replication_in_recovery{namespace=~\"$namespace\",pod=~\"$instances\"} + cnpg_pg_replication_is_wal_receiver_up{namespace=~\"$namespace\",pod=~\"$instances\"}) * (time() - timestamp(cnpg_pg_stat_archiver_seconds_since_last_archival{namespace=~\"$namespace\",pod=~\"$instances\"}) -\ncnpg_pg_stat_archiver_seconds_since_last_archival{namespace=~\"$namespace\",pod=~\"$instances\"}))",
           "format": "time_series",
           "interval": "",
           "legendFormat": "__auto",

--- a/docs/src/samples/monitoring/grafana-dashboard.json
+++ b/docs/src/samples/monitoring/grafana-dashboard.json
@@ -742,7 +742,7 @@
           "legendFormat": "WAL",
           "range": true,
           "refId": "WAL"
-        }        
+        }
       ],
       "title": "Volume Space Usage",
       "type": "gauge"
@@ -768,6 +768,18 @@
                   "text": "Invalid date"
                 },
                 "to": 1e+42
+              },
+              "type": "range"
+            },
+            {
+              "options": {
+                "from": -2147483648,
+                "result": {
+                  "color": "red",
+                  "index": 1,
+                  "text": "No backups"
+                },
+                "to": -1577847600
               },
               "type": "range"
             }
@@ -1403,6 +1415,16 @@
             "mode": "thresholds"
           },
           "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "red",
+                  "index": 1,
+                  "text": "No backups"
+                }
+              },
+              "type": "value"
+            },
             {
               "options": {
                 "match": "null",
@@ -2230,6 +2252,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -4392,7 +4415,7 @@
               "legendFormat": "{{persistentvolumeclaim}}",
               "range": true,
               "refId": "FREE_SPACE_WAL"
-            }            
+            }
           ],
           "title": "Volume Space Usage",
           "transformations": [],
@@ -4478,7 +4501,7 @@
               "legendFormat": "{{persistentvolumeclaim}}",
               "range": true,
               "refId": "FREE_INODES_WAL"
-            }            
+            }
           ],
           "title": "Volume Inode Usage",
           "transformations": [],
@@ -6358,7 +6381,7 @@
   },
   "timezone": "",
   "title": "CloudNativePG",
-  "uid": "z7FCA4Nnk",
-  "version": 9,
+  "uid": "cloudnative-pg",
+  "version": 1,
   "weekStart": ""
 }

--- a/docs/src/samples/monitoring/grafana-dashboard.json
+++ b/docs/src/samples/monitoring/grafana-dashboard.json
@@ -1420,7 +1420,7 @@
                 "0": {
                   "color": "red",
                   "index": 1,
-                  "text": "No backups"
+                  "text": "N/A"
                 }
               },
               "type": "value"


### PR DESCRIPTION
Fixes #2965.

In addition this fixes metric duplication for `Last Archived WAL` and `Replication Lag`.

Before:
![Screenshot from 2023-10-05 22-43-13](https://github.com/cloudnative-pg/cloudnative-pg/assets/2123767/fa08d319-5125-41a4-ba65-6855fcfd3a5b)
![image](https://github.com/cloudnative-pg/cloudnative-pg/assets/2123767/9fc8b88e-d9a1-4c14-8167-621f0dd0bf04)


After:
![image](https://github.com/cloudnative-pg/cloudnative-pg/assets/2123767/507fbae4-9976-40ab-81a9-549db76bd615)
![image](https://github.com/cloudnative-pg/cloudnative-pg/assets/2123767/40b9d912-dad2-4b69-923b-75fcd1a8e0a0)


Also I changed the UID of the dashboard to something non-random that makes your URL pretty:

![image](https://github.com/cloudnative-pg/cloudnative-pg/assets/2123767/23299c37-28cb-42da-aeac-58a552a76146)

P.S. It looks like the `ConfigMap` hasn't been updated even though the JSON file was. This PR fixes that and syncs up both files. 