### PR TITLE
docs: upgrade instructions to 1.21.0, 1.20.3 and 1.19.5

### DIFF
--- a/.wordlist-en-custom.txt
+++ b/.wordlist-en-custom.txt
@@ -452,6 +452,7 @@ ba
 backend
 backends
 backport
+backported
 backupID
 backupId
 backupName

--- a/docs/src/installation_upgrade.md
+++ b/docs/src/installation_upgrade.md
@@ -300,6 +300,7 @@ If you want to retain the old behavior, you need to set explicitly:
 spec:
    ...
    stopDelay: 30
+   smartShutdownTimeout: 15
 ```
 
 #### Delay for PostgreSQL startup

--- a/docs/src/installation_upgrade.md
+++ b/docs/src/installation_upgrade.md
@@ -236,15 +236,22 @@ When versions are not directly upgradable, the old version needs to be
 removed before installing the new one. This won't affect user data but
 only the operator itself.
 
-### Upgrading to 1.21 from a previous minor version
+### Upgrading to 1.21.0, 1.20.3 or 1.19.5
 
 !!! Important
-    If you are upgrading from 1.19 or older, please read the
-    [instructions to upgrade to version 1.20](#upgrading-to-120-from-a-previous-minor-version)
-    first.
+    We encourage all existing users of CloudNativePG to upgrade to version
+    1.21.0 or at least to the latest stable version of the minor release you are
+    currently using (namely 1.20.3 or 1.19.5).
+
+!!! Warning
+    Everytime you are upgrading to a higher minor release, make sure you
+    go through the release notes and upgrade instructions of all the
+    intermediate minor releases. For example, if you want to move
+    from 1.19.x to 1.21, make sure you go through the release notes
+    and upgrade instructions for 1.20 and 1.21.
 
 With the goal to keep improving out-of-the-box the *convention over
-configuration* behavior of the operator, CloudNativePG 1.21 changes the default
+configuration* behavior of the operator, CloudNativePG changes the default
 value of several knobs in the following areas:
 
 - startup and shutdown control of the PostgreSQL instance
@@ -252,40 +259,61 @@ value of several knobs in the following areas:
 - security
 - labels
 
-Most of the changes will affect new PostgreSQL clusters only.
+Some of the above changes have been backported to 1.20.3 and 1.19.5, as
+detailed below. Most of the changes will affect new PostgreSQL clusters only.
 
 !!! Warning
     Please read carefully the list of changes below, and how to change the
     `Cluster` manifests to retain the existing behavior if you don't want to
-    disrupt your existing workloads. Alternatively, postpone the upgrade to 1.21
+    disrupt your existing workloads. Alternatively, postpone the upgrade to
     until you are sure. In general, we recommend adopting these default
     values unless you have valid reasons not to.
 
-If you want to keep the existing behavior of CloudNativePG explicitly,
-(we advise not indefinitely,) you need to set these values in all your `Cluster`
-definitions **before upgrading** to version 1.21:
+#### Superuser access disabled
+
+!!! Important
+    This change takes effect starting from CloudNativePG 1.21.0.
+
+Pushing towards *security-by-default*, CloudNativePG now disables access
+`postgres` superuser access via the network in all new clusters, unless
+explicitly enabled.
+
+If you want to ensure superuser access to the PostgreSQL cluster, regardless
+which version of CloudNativePG you are running, we advise you to explicitly
+declare it by setting:
 
 ```yaml
 spec:
    ...
-   startDelay: 30
-   stopDelay: 30
-   switchoverDelay: 40000000
    enableSuperuserAccess: true
+```
+
+#### Replication slots for HA
+
+!!! Important
+    This change takes effect starting from CloudNativePG 1.21.0.
+
+[As already anticipated in release 1.20](installation_upgrade.md#replication-slots-for-high-availability),
+replication slots for High Availability are now enabled by default.
+
+If you want to ensure replication slots are disabled, regardless of which
+version of CloudNativePG you are running, we advise you to explicitly declare
+it by setting:
+
+```yaml
+spec:
+   ...
    replicationSlots:
      highAvailability:
        enabled: false
 ```
 
-Once the upgrade is completed, also add:
-
-```yaml
-spec:
-   ...
-   smartShutdownTimeout: 15
-```
-
 #### Delay for PostgreSQL shutdown
+
+!!! Important
+    This change has been backported to all supported minor releases. As a
+    result, it will be available starting from versions 1.21.0, 1.20.3 and
+    1.19.5.
 
 Up to now, [the `stopDelay` parameter](instance_manager.md#shutdown-control)
 was set to 30 seconds. Despite the recommendations to change and tune this
@@ -296,11 +324,14 @@ The [new default value is 1800 seconds](https://github.com/cloudnative-pg/cloudn
 the equivalent of 30 minutes.
 
 The new `smartShutdownTimeout` parameter has been introduced to define
-the maximum time window within the `stopDelay` value, reserved to gracefully
-stop PostgreSQL using the `smart` shutdown procedure.  Once elapsed, the
-remaining time up to `stopDelay` will be reserved for PostgreSQL to complete
-its duties regarding WAL commitments with both the archive and the streaming
-replicas to ensure the cluster doesn't lose any data.
+the maximum time window within the `stopDelay` value reserved to complete
+the `smart` shutdown procedure in PostgreSQL. During this time, the
+Postgres servers denies any new connection while waiting for all regular
+sessions to terminate.
+
+Once elapsed, the remaining time up to `stopDelay` will be reserved for
+PostgreSQL to complete its duties regarding WAL commitments with both the
+archive and the streaming replicas to ensure the cluster doesn't lose any data.
 
 If you want to retain the old behavior, you need to set explicitly:
 
@@ -319,16 +350,17 @@ spec:
    smartShutdownTimeout: 15
 ```
 
-!!! Important
-    This change has been backported to all supported minor releases. As a
-    result, it will also be available in versions 1.20.3 and 1.19.5.
-
 #### Delay for PostgreSQL startup
 
+!!! Important
+    This change has been backported to all supported minor releases. As a
+    result, it will be available starting from versions 1.21.0, 1.20.3 and
+    1.19.5.
+
 Until now, [the `startDelay` parameter](instance_manager.md#startup-liveness-and-readiness-probes)
-was set to 30 seconds, and CloudNativePG was using this parameter as the initial
-delay for the Kubernetes liveness probe. Given that all the supported Kubernetes
-releases provide [startup probes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-startup-probes),
+was set to 30 seconds, and CloudNativePG used this parameter as
+`initialDelaySeconds` for the Kubernetes liveness probe. Given that all the
+supported Kubernetes releases provide [startup probes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-startup-probes),
 version 1.21 has adopted this approach as well (`startDelay` is now
 automatically divided into periods of 10 seconds of duration  each).
 
@@ -346,8 +378,8 @@ never to reach a consistent recovery state and be restarted indefinitely.
 For this reason, `startDelay` has been [raised by default to 3600 seconds](https://github.com/cloudnative-pg/cloudnative-pg/commit/4f4cd96bc6f8e284a200705c11a2b41652d58146),
 the equivalent of 1 hour.
 
-You can achieve similar behavior using the startup probe instead of
-liveness probes with an initial delay by explicitly setting:
+If you want to retain the existing behavior using the new implementation, you
+can do that by explicitly setting:
 
 ```yaml
 spec:
@@ -355,11 +387,12 @@ spec:
    startDelay: 30
 ```
 
+#### Delay for PostgreSQL switchover
+
 !!! Important
     This change has been backported to all supported minor releases. As a
-    result, it will also be available in versions 1.20.3 and 1.19.5.
-
-#### Delay for PostgreSQL switchover
+    result, it will be available starting from versions 1.21.0, 1.20.3 and
+    1.19.5.
 
 Up to now, [the `switchoverDelay` parameter](instance_manager.md#shutdown-of-the-primary-during-a-switchover)
 was set by default to 40000000 seconds (over 15 months) to simulate a very long
@@ -376,30 +409,12 @@ spec:
    switchoverDelay: 40000000
 ```
 
+#### Labels
+
 !!! Important
     This change has been backported to all supported minor releases. As a
-    result, it will also be available in versions 1.20.3 and 1.19.5.
-
-#### Superuser access disabled
-
-Pushing towards *security-by-default*, CloudNativePG now disables
-superuser access (`postgres` user) via the network in all new clusters,
-unless explicitly enabled.
-
-If you want to restore the previous behavior, you need to set explicitly:
-
-```yaml
-spec:
-   ...
-   enableSuperuserAccess: true
-```
-
-#### Replication slots for HA
-
-[As already anticipated in release 1.20](installation_upgrade.md#replication-slots-for-high-availability),
-replication slots for High Availability are now enabled by default.
-
-#### Labels
+    result, it will be available starting from versions 1.21.0, 1.20.3 and
+    1.19.5.
 
 In version 1.18, we deprecated the `postgresql` label in pods to identify the
 name of the cluster and replaced it with the more canonical `cnpg.io/cluster`
@@ -408,6 +423,34 @@ label. The `postgresql` label is no longer maintained.
 Similarly, from this version, the `role` label is deprecated. The new label
 `cnpg.io/instanceRole` is now set, and will entirely replace the `role` label
 in a future release.
+
+#### Shortcut for keeping the existing behavior
+
+If you want to explicitly keep the existing behavior of CloudNativePG
+(we advise not to), you need to set these values in all your `Cluster`
+definitions **before upgrading** to version 1.21.0, 1.20.3 or 1.19.5:
+
+```yaml
+spec:
+   ...
+   # Changed in 1.21.0, 1.20.3 and 1.19.5
+   startDelay: 30
+   stopDelay: 30
+   switchoverDelay: 40000000
+   # Changed in 1.21.0 only
+   enableSuperuserAccess: true
+   replicationSlots:
+     highAvailability:
+       enabled: false
+```
+
+Once the upgrade is completed, also add:
+
+```yaml
+spec:
+   ...
+   smartShutdownTimeout: 15
+```
 
 ### Upgrading to 1.20 from a previous minor version
 

--- a/docs/src/installation_upgrade.md
+++ b/docs/src/installation_upgrade.md
@@ -282,7 +282,7 @@ Once the upgrade is completed, also add:
 ```yaml
 spec:
    ...
-   smartShutdownTimeout: 30
+   smartShutdownTimeout: 15
 ```
 
 #### Delay for PostgreSQL shutdown

--- a/docs/src/installation_upgrade.md
+++ b/docs/src/installation_upgrade.md
@@ -243,7 +243,7 @@ only the operator itself.
     [instructions to upgrade to version 1.20](#upgrading-to-120-from-a-previous-minor-version)
     first.
 
-With the goal to keep improving out-of-the box the *convention over
+With the goal to keep improving out-of-the-box the *convention over
 configuration* behavior of the operator, CloudNativePG 1.21 changes the default
 value of several knobs in the following areas:
 
@@ -258,10 +258,10 @@ Most of the changes will affect new PostgreSQL clusters only.
     Please read carefully the list of changes below and how to change the
     `Cluster` manifests to retain the existing behavior, in case you don't want to
     disrupt your existing workloads. Alternatively, postpone the upgrade to 1.21
-    until you are sure. In general, we recommend the you adopt these default
-    values, unless you have valid reasons not to.
+    until you are sure. In general, we recommend adopting these default
+    values unless you have valid reasons not to.
 
-If you want to explicitly keep the existing behavior of CloudNativePG,
+If you want to keep the existing behavior of CloudNativePG explicitly,
 preferably just temporarily, you need to set these values in all your `Cluster`
 definitions **before upgrading** to version 1.21:
 
@@ -287,14 +287,14 @@ community issues show that this value is left unchanged.
 The [new value is set to 1800 seconds](https://github.com/cloudnative-pg/cloudnative-pg/commit/9f7f18c5b9d9103423a53d180c0e2f2189e71c3c),
 the equivalent of 30 minutes.
 
-A new parameter has been introduced to define the maximum time window, within
+A new parameter has been introduced to define the maximum time window within
 the `stopDelay` one, reserved to gracefully stop PostgreSQL using the `smart`
 shutdown procedure. Once completed, the remaining time up to `stopDelay` will
-be reserved for PostgreSQL to complete its duties in terms of WAL commitments
-with both the archive and the streaming replicas, in order to ensure the cluster
+be reserved for PostgreSQL to complete its duties regarding WAL commitments
+with both the archive and the streaming replicas to ensure the cluster
 doesn't lose any data.
 
-If you want to retain the old behavior, you need to explicitly set:
+If you want to retain the old behavior, you need to set explicitly:
 
 ```yaml
 spec:

--- a/docs/src/installation_upgrade.md
+++ b/docs/src/installation_upgrade.md
@@ -326,7 +326,7 @@ the equivalent of 30 minutes.
 The new `smartShutdownTimeout` parameter has been introduced to define
 the maximum time window within the `stopDelay` value reserved to complete
 the `smart` shutdown procedure in PostgreSQL. During this time, the
-Postgres servers rejects any new connection while waiting for all regular
+Postgres server rejects any new connections while waiting for all regular
 sessions to terminate.
 
 Once elapsed, the remaining time up to `stopDelay` will be reserved for
@@ -417,11 +417,11 @@ spec:
     1.19.5.
 
 In version 1.18, we deprecated the `postgresql` label in pods to identify the
-name of the cluster and replaced it with the more canonical `cnpg.io/cluster`
+name of the cluster, and replaced it with the more canonical `cnpg.io/cluster`
 label. The `postgresql` label is no longer maintained.
 
 Similarly, from this version, the `role` label is deprecated. The new label
-`cnpg.io/instanceRole` is now set, and will entirely replace the `role` label
+`cnpg.io/instanceRole` is now used, and will entirely replace the `role` label
 in a future release.
 
 #### Shortcut for keeping the existing behavior

--- a/docs/src/installation_upgrade.md
+++ b/docs/src/installation_upgrade.md
@@ -244,7 +244,7 @@ only the operator itself.
     currently using (namely 1.20.3 or 1.19.5).
 
 !!! Warning
-    Everytime you are upgrading to a higher minor release, make sure you
+    Every time you are upgrading to a higher minor release, make sure you
     go through the release notes and upgrade instructions of all the
     intermediate minor releases. For example, if you want to move
     from 1.19.x to 1.21, make sure you go through the release notes
@@ -263,7 +263,7 @@ Some of the above changes have been backported to 1.20.3 and 1.19.5, as
 detailed below. Most of the changes will affect new PostgreSQL clusters only.
 
 !!! Warning
-    Please read carefully the list of changes below, and how to change the
+    Please read carefully the list of changes below, and how to modify the
     `Cluster` manifests to retain the existing behavior if you don't want to
     disrupt your existing workloads. Alternatively, postpone the upgrade to
     until you are sure. In general, we recommend adopting these default

--- a/docs/src/installation_upgrade.md
+++ b/docs/src/installation_upgrade.md
@@ -305,11 +305,11 @@ spec:
 #### Delay for PostgreSQL startup
 
 Until now, [the `startDelay` parameter](instance_manager.md#startup-liveness-and-readiness-probes)
-was set to 30 seconds and CloudNativePG was using this parameter as initial
-delay for the Kubernetes liveness probe. Given that all Kubernetes supported
+was set to 30 seconds, and CloudNativePG was using this parameter as the initial
+delay for the Kubernetes liveness probe. Given that all the supported Kubernetes
 releases provide [startup probes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-startup-probes),
 version 1.21 has adopted this approach as well (`startDelay` is now
-automatically divided in periods of the duration of 10 seconds each).
+automatically divided into periods of the duration of 10 seconds each).
 
 !!! Important
     In order to add the `startupProbe`, each pod needs to be restarted.
@@ -319,14 +319,14 @@ automatically divided in periods of the duration of 10 seconds each).
 Despite the recommendations to change and tune this value, almost all the cases
 we have examined during support incidents or community issues show that this
 value is left unchanged. Given that this parameter influences the startup of
-a PostgreSQL instance, a low value of `startDelay` would cause Postgres to
-never reach a consistent recovery state and be restarted indefinitely.
+a PostgreSQL instance, a low value of `startDelay` would cause Postgres
+never to reach a consistent recovery state and be restarted indefinitely.
 
 For this reason, `startDelay` has been [raised by default to 3600 seconds](https://github.com/cloudnative-pg/cloudnative-pg/commit/4f4cd96bc6f8e284a200705c11a2b41652d58146),
 the equivalent of 1 hour.
 
-You can restore a similar behavior, based on startup probes instead of
-initially delayed liveness probes, by explicitly setting:
+You can achieve similar behavior using the startup probe instead of
+liveness probes with an initial delay by explicitly setting:
 
 ```yaml
 spec:
@@ -337,13 +337,13 @@ spec:
 #### Delay for PostgreSQL switchover
 
 Up to now, [the `switchoverDelay` parameter](instance_manager.md#shutdown-of-the-primary-during-a-switchover)
-was set to 40000000 seconds (over 15 months), in order to simulate a very long
+was set to 40000000 seconds (over 15 months) to simulate a very long
 interval.
 
 The [new value has been lowered to 3600 seconds](https://github.com/cloudnative-pg/cloudnative-pg/commit/9565f9f2ebab8bc648d9c361198479974664c322),
 the equivalent of 1 hour.
 
-If you want to retain the old behavior, you need to explicitly set:
+If you want to retain the old behavior, you need to set explicitly:
 
 ```yaml
 spec:
@@ -353,11 +353,11 @@ spec:
 
 #### Superuser access disabled
 
-Pushing towards *security-by-default*, all new clusters created with
-CloudNativePG don't enable superuser access (`postgres` user) via the network,
+Pushing towards *security-by-default*, CloudNativePG now disables
+superuser access (`postgres` user) via the network in all new clusters
 unless explicitly requested.
 
-If you want to restore this behavior, you need to explicitly set:
+If you want to restore the previous behavior, you need to set explicitly:
 
 ```yaml
 spec:
@@ -372,11 +372,11 @@ replication slots for High Availability are now enabled by default.
 
 #### Labels
 
-In version 1.18 we deprecated the `postgresql` label in pods to identify the
-name of the cluster, and replaced it with the more canonical `cnpg.io/cluster`
+In version 1.18, we deprecated the `postgresql` label in pods to identify the
+name of the cluster and replaced it with the more canonical `cnpg.io/cluster`
 label. Such a label is no longer maintained.
 
-Similarly, from this version the `role` label is deprecated. The new label
+Similarly, from this version, the `role` label is deprecated. The new label
 `cnpg.io/instanceRole` is now set and will entirely replace the `role` one in a
 future release.
 

--- a/docs/src/installation_upgrade.md
+++ b/docs/src/installation_upgrade.md
@@ -277,6 +277,14 @@ spec:
        enabled: false
 ```
 
+Once the upgrade is completed, also add:
+
+```yaml
+spec:
+   ...
+   smartShutdownTimeout: 30
+```
+
 #### Delay for PostgreSQL shutdown
 
 Up to now, [the `stopDelay` parameter](instance_manager.md#shutdown-control)
@@ -300,8 +308,13 @@ If you want to retain the old behavior, you need to set explicitly:
 spec:
    ...
    stopDelay: 30
+   # IMPORTANT: add `smartShutdownTimeout` only after you've upgraded
    smartShutdownTimeout: 15
 ```
+
+!!! Important
+    This change has been backported to all supported minor releases. As a
+    result, it will also be available in versions 1.20.3 and 1.19.5.
 
 #### Delay for PostgreSQL startup
 
@@ -335,6 +348,10 @@ spec:
    startDelay: 30
 ```
 
+!!! Important
+    This change has been backported to all supported minor releases. As a
+    result, it will also be available in versions 1.20.3 and 1.19.5.
+
 #### Delay for PostgreSQL switchover
 
 Up to now, [the `switchoverDelay` parameter](instance_manager.md#shutdown-of-the-primary-during-a-switchover)
@@ -351,6 +368,10 @@ spec:
    ...
    switchoverDelay: 40000000
 ```
+
+!!! Important
+    This change has been backported to all supported minor releases. As a
+    result, it will also be available in versions 1.20.3 and 1.19.5.
 
 #### Superuser access disabled
 

--- a/docs/src/installation_upgrade.md
+++ b/docs/src/installation_upgrade.md
@@ -287,12 +287,12 @@ community issues show that this value is left unchanged.
 The [new value is set to 1800 seconds](https://github.com/cloudnative-pg/cloudnative-pg/commit/9f7f18c5b9d9103423a53d180c0e2f2189e71c3c),
 the equivalent of 30 minutes.
 
-A new parameter has been introduced to define the maximum time window within
-the `stopDelay` one, reserved to gracefully stop PostgreSQL using the `smart`
-shutdown procedure. Once completed, the remaining time up to `stopDelay` will
-be reserved for PostgreSQL to complete its duties regarding WAL commitments
-with both the archive and the streaming replicas to ensure the cluster
-doesn't lose any data.
+The new `smartShutdownTimeout` parameter has been introduced to define
+the maximum time window within the `stopDelay` value, reserved to gracefully
+stop PostgreSQL using the `smart` shutdown procedure.  Once completed, the
+remaining time up to `stopDelay` will be reserved for PostgreSQL to complete
+its duties regarding WAL commitments with both the archive and the streaming
+replicas to ensure the cluster doesn't lose any data.
 
 If you want to retain the old behavior, you need to set explicitly:
 

--- a/docs/src/installation_upgrade.md
+++ b/docs/src/installation_upgrade.md
@@ -326,7 +326,7 @@ the equivalent of 30 minutes.
 The new `smartShutdownTimeout` parameter has been introduced to define
 the maximum time window within the `stopDelay` value reserved to complete
 the `smart` shutdown procedure in PostgreSQL. During this time, the
-Postgres servers denies any new connection while waiting for all regular
+Postgres servers rejects any new connection while waiting for all regular
 sessions to terminate.
 
 Once elapsed, the remaining time up to `stopDelay` will be reserved for

--- a/docs/src/instance_manager.md
+++ b/docs/src/instance_manager.md
@@ -40,9 +40,9 @@ which defaults to 3600 seconds. The correct value for your cluster is
 related to the time needed by PostgreSQL to start.
 
 !!! Warning
-   If `.spec.startDelay` is too low, the liveness probe will start working
-   before the PostgreSQL startup, and the Pod could be restarted
-   inappropriately.
+    If `.spec.startDelay` is too low, the liveness probe will start working
+    before the PostgreSQL startup, and the Pod could be restarted
+    inappropriately.
 
 ## Shutdown control
 

--- a/docs/src/instance_manager.md
+++ b/docs/src/instance_manager.md
@@ -34,7 +34,7 @@ broken state and needs to be restarted. The value in `startDelay` is used
 to delay the probe's execution, preventing an
 instance with a long startup time from being restarted.
 
-The number of seconds after the Pod has started before the liveness
+The interval (in seconds) after the Pod has started before the liveness
 probe starts working is expressed in the `.spec.startDelay` parameter,
 which defaults to 3600 seconds. The correct value for your cluster is
 related to the time needed by PostgreSQL to start.
@@ -42,7 +42,7 @@ related to the time needed by PostgreSQL to start.
 !!! Warning
     If `.spec.startDelay` is too low, the liveness probe will start working
     before the PostgreSQL startup is complete, and the Pod could be restarted
-    inappropriately.
+    prematurely.
 
 ## Shutdown control
 
@@ -80,7 +80,7 @@ general case. Indeed, the operator requires the former primary to issue a
 in order to ensure that all the data are available on the new primary.
 
 For this reason, the `.spec.switchoverDelay`, expressed in seconds, controls
-the  time given to the former primary to shut down gracefully and archive all 
+the  time given to the former primary to shut down gracefully and archive all
 the WAL files. By default it is set to `3600` (1 hour).
 
 !!! Warning

--- a/docs/src/instance_manager.md
+++ b/docs/src/instance_manager.md
@@ -17,17 +17,17 @@ of the Pod, the instance manager acts as a backend to handle the
 
 ## Startup, liveness and readiness probes
 
-The startup and liveness probe relies on `pg_isready`, while the readiness
+The startup and liveness probes rely on `pg_isready`, while the readiness
 probe checks if the database is up and able to accept connections using the
 superuser credentials.
 
 The readiness probe is positive when the Pod is ready to accept traffic.
-The liveness probe controls when to restart the container immediately
-after the startup probe interval.
+The liveness probe controls when to restart the container once
+the startup probe interval has elapsed.
 
 !!! Important
     The liveness and readiness probes will report a failure if the probe command
-    fails three times with a 10-seconds interval between each check.
+    fails three times with a 10-second interval between each check.
 
 The liveness probe detects if the PostgreSQL instance is in a
 broken state and needs to be restarted. The value in `startDelay` is used
@@ -41,7 +41,7 @@ related to the time needed by PostgreSQL to start.
 
 !!! Warning
     If `.spec.startDelay` is too low, the liveness probe will start working
-    before the PostgreSQL startup, and the Pod could be restarted
+    before the PostgreSQL startup is complete, and the Pod could be restarted
     inappropriately.
 
 ## Shutdown control

--- a/docs/src/instance_manager.md
+++ b/docs/src/instance_manager.md
@@ -22,16 +22,16 @@ probe checks if the database is up and able to accept connections using the
 superuser credentials.
 
 The readiness probe is positive when the Pod is ready to accept traffic.
-The liveness probe controls when to restart the container, immediately
+The liveness probe controls when to restart the container immediately
 after the startup probe interval.
 
 !!! Important
     The liveness and readiness probes will report a failure if the probe command
-    fails 3 times with a 10 seconds interval between each check.
+    fails three times with a 10-seconds interval between each check.
 
-The liveness probe is used to detect if the PostgreSQL instance is in a
+The liveness probe detects if the PostgreSQL instance is in a
 broken state and needs to be restarted. The value in `startDelay` is used
-to delay the probe's execution, which is used to prevent an
+to delay the probe's execution, preventing an
 instance with a long startup time from being restarted.
 
 The number of seconds after the Pod has started before the liveness

--- a/docs/src/instance_manager.md
+++ b/docs/src/instance_manager.md
@@ -12,21 +12,22 @@ The field `.spec.instances` specifies how many instances to create.
 
 Each Pod will start the instance manager as the parent process (PID 1) for the
 main container, which in turn runs the PostgreSQL instance. During the lifetime
-of the Pod, the instance manager acts as a backend to handle the [liveness and
-readiness probes](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes).
+of the Pod, the instance manager acts as a backend to handle the
+[startup, liveness and readiness probes](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes).
 
-## Liveness and readiness probes
+## Startup, liveness and readiness probes
 
-The liveness probe relies on `pg_isready`, while the readiness probe checks if
-the database is up and able to accept connections using the superuser
-credentials.
+The startup and liveness probe relies on `pg_isready`, while the readiness
+probe checks if the database is up and able to accept connections using the
+superuser credentials.
+
 The readiness probe is positive when the Pod is ready to accept traffic.
-The liveness probe controls when to restart the container.
+The liveness probe controls when to restart the container, immediately
+after the startup probe interval.
 
-> The two probes will report a failure if the probe command fails 3 times with a 10 seconds interval between each check.
-
-For now, the operator doesn't configure a `startupProbe` on the Pods, since
-startup probes have been introduced only in Kubernetes 1.17.
+!!! Important
+    The liveness and readiness probes will report a failure if the probe command
+    fails 3 times with a 10 seconds interval between each check.
 
 The liveness probe is used to detect if the PostgreSQL instance is in a
 broken state and needs to be restarted. The value in `startDelay` is used
@@ -35,12 +36,13 @@ instance with a long startup time from being restarted.
 
 The number of seconds after the Pod has started before the liveness
 probe starts working is expressed in the `.spec.startDelay` parameter,
-which defaults to 30 seconds. The correct value for your cluster is
+which defaults to 3600 seconds. The correct value for your cluster is
 related to the time needed by PostgreSQL to start.
 
-If `.spec.startDelay` is too low, the liveness probe will start working
-before the PostgreSQL startup, and the Pod could be restarted
-inappropriately.
+!!! Warning
+   If `.spec.startDelay` is too low, the liveness probe will start working
+   before the PostgreSQL startup, and the Pod could be restarted
+   inappropriately.
 
 ## Shutdown control
 


### PR DESCRIPTION
List all the significant changes applied to the default values in 1.21.0, 1.20.3, and 1.19.5, while providing instructions on how to keep the existing behavior on new clusters too.

Closes #2988 