### PR TITLE
docs: PostgreSQL parameters to be strings

### DIFF
--- a/docs/src/postgresql_conf.md
+++ b/docs/src/postgresql_conf.md
@@ -49,6 +49,7 @@ The `custom.conf` file will contain the user-defined settings in the
     Refer to the PostgreSQL documentation for
     [more information on the available parameters](https://www.postgresql.org/docs/current/runtime-config.html),
     also known as GUC (Grand Unified Configuration).
+    Please note that CNPG accept only strings for the PostgreSQL parameters.
 
 The content of `custom.conf` is automatically generated and maintained by the
 operator by applying the following sections in this order:

--- a/docs/src/postgresql_conf.md
+++ b/docs/src/postgresql_conf.md
@@ -49,7 +49,7 @@ The `custom.conf` file will contain the user-defined settings in the
     Refer to the PostgreSQL documentation for
     [more information on the available parameters](https://www.postgresql.org/docs/current/runtime-config.html),
     also known as GUC (Grand Unified Configuration).
-    Please note that CNPG accept only strings for the PostgreSQL parameters.
+    Please note that CloudNativePG accepts only strings for the PostgreSQL parameters.
 
 The content of `custom.conf` is automatically generated and maintained by the
 operator by applying the following sections in this order:


### PR DESCRIPTION
Small note reminding users that all PostgreSQL parameters in the YAML definition need to be declared as strings.