### PR TITLE
chore: prepare E2E tests for disabled superuser access

### DIFF
--- a/controllers/cluster_create_test.go
+++ b/controllers/cluster_create_test.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/client-go/discovery"
 	fakediscovery "k8s.io/client-go/discovery/fake"
 	"k8s.io/client-go/testing"
+	"k8s.io/utils/ptr"
 	k8client "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -62,17 +63,18 @@ var _ = Describe("cluster_create unit tests", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		By("making sure that the superUser secret have been created", func() {
+		By("making sure that the superUser secret has not been created", func() {
 			superUser := corev1.Secret{}
 			err := k8sClient.Get(
 				ctx,
 				types.NamespacedName{Name: cluster.GetSuperuserSecretName(), Namespace: namespace},
 				&superUser,
 			)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).To(HaveOccurred())
+			Expect(apierrs.IsNotFound(err)).To(BeTrue())
 		})
 
-		By("making sure that the appUserSecret have been created", func() {
+		By("making sure that the appUserSecret has been created", func() {
 			appUser := corev1.Secret{}
 			err := k8sClient.Get(
 				ctx,
@@ -80,9 +82,12 @@ var _ = Describe("cluster_create unit tests", func() {
 				&appUser,
 			)
 			Expect(err).ToNot(HaveOccurred())
+			Expect(string(appUser.Data["username"])).To(Equal("app"))
+			Expect(string(appUser.Data["password"])).To(HaveLen(64))
+			Expect(string(appUser.Data["dbname"])).To(Equal("app"))
 		})
 
-		By("making sure that the pooler secrets have been created", func() {
+		By("making sure that the pooler secrets has been created", func() {
 			poolerSecret := corev1.Secret{}
 			err := k8sClient.Get(
 				ctx,
@@ -90,6 +95,31 @@ var _ = Describe("cluster_create unit tests", func() {
 				&poolerSecret,
 			)
 			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	It("should make sure that superUser secret is created if EnableSuperuserAccess is enabled", func() {
+		ctx := context.Background()
+		namespace := newFakeNamespace()
+		cluster := newFakeCNPGCluster(namespace)
+		cluster.Spec.EnableSuperuserAccess = ptr.To(true)
+
+		By("executing reconcilePostgresSecrets", func() {
+			err := clusterReconciler.reconcilePostgresSecrets(ctx, cluster)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		By("making sure that the superUser secret has been created correctly", func() {
+			superUser := corev1.Secret{}
+			err := k8sClient.Get(
+				ctx,
+				types.NamespacedName{Name: cluster.GetSuperuserSecretName(), Namespace: namespace},
+				&superUser,
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(string(superUser.Data["username"])).To(Equal("postgres"))
+			Expect(string(superUser.Data["password"])).To(HaveLen(64))
+			Expect(string(superUser.Data["dbname"])).To(Equal("*"))
 		})
 	})
 

--- a/tests/e2e/asserts_test.go
+++ b/tests/e2e/asserts_test.go
@@ -356,7 +356,7 @@ func AssertCreateTestData(namespace, clusterName, tableName string, pod *corev1.
 			namespace,
 			clusterName,
 			pod,
-			apiv1.SuperUserSecretSuffix,
+			apiv1.ApplicationUserSecretSuffix,
 			testsUtils.AppDBName,
 			query,
 		)
@@ -369,7 +369,7 @@ func AssertCreateTestDataLargeObject(namespace, clusterName string, oid int, dat
 	By("creating large object", func() {
 		query := fmt.Sprintf("CREATE TABLE IF NOT EXISTS image (name text,raster oid); "+
 			"INSERT INTO image (name, raster) VALUES ('beautiful image', lo_from_bytea(%d, '%s'));", oid, data)
-		superUser, superUserPass, err := testsUtils.GetCredentials(clusterName, namespace, apiv1.SuperUserSecretSuffix, env)
+		appUser, appUserPass, err := testsUtils.GetCredentials(clusterName, namespace, apiv1.ApplicationUserSecretSuffix, env)
 		Expect(err).ToNot(HaveOccurred())
 		host, err := testsUtils.GetHostName(namespace, clusterName, env)
 		Expect(err).ToNot(HaveOccurred())
@@ -377,8 +377,8 @@ func AssertCreateTestDataLargeObject(namespace, clusterName string, oid int, dat
 			pod,
 			host,
 			testsUtils.AppDBName,
-			superUser,
-			superUserPass,
+			appUser,
+			appUserPass,
 			query,
 			env)
 		Expect(err).ToNot(HaveOccurred())
@@ -395,7 +395,7 @@ func insertRecordIntoTableWithDatabaseName(
 	pod *corev1.Pod,
 ) {
 	query := fmt.Sprintf("INSERT INTO %v VALUES (%v);", tableName, value)
-	superUser, superUserPass, err := testsUtils.GetCredentials(clusterName, namespace, apiv1.SuperUserSecretSuffix, env)
+	appUser, appUserPass, err := testsUtils.GetCredentials(clusterName, namespace, apiv1.ApplicationUserSecretSuffix, env)
 	Expect(err).ToNot(HaveOccurred())
 	host, err := testsUtils.GetHostName(namespace, clusterName, env)
 	Expect(err).ToNot(HaveOccurred())
@@ -403,8 +403,8 @@ func insertRecordIntoTableWithDatabaseName(
 		pod,
 		host,
 		databaseName,
-		superUser,
-		superUserPass,
+		appUser,
+		appUserPass,
 		query,
 		env)
 	Expect(err).ToNot(HaveOccurred())
@@ -417,7 +417,7 @@ func insertRecordIntoTable(namespace, clusterName, tableName string, value int, 
 		namespace,
 		clusterName,
 		pod,
-		apiv1.SuperUserSecretSuffix,
+		apiv1.ApplicationUserSecretSuffix,
 		testsUtils.AppDBName,
 		query,
 	)
@@ -478,7 +478,7 @@ func AssertDataExpectedCount(namespace, clusterName, tableName string, expectedV
 				namespace,
 				clusterName,
 				pod,
-				apiv1.SuperUserSecretSuffix,
+				apiv1.ApplicationUserSecretSuffix,
 				testsUtils.AppDBName,
 				query)
 			if err != nil {
@@ -496,7 +496,8 @@ func AssertLargeObjectValue(namespace, clusterName string, oid int, data string,
 		query := fmt.Sprintf("SELECT encode(lo_get(%v), 'escape');", oid)
 		Eventually(func() (string, error) {
 			// We keep getting the pod, since there could be a new pod with the same name
-			superUser, superUserPass, err := testsUtils.GetCredentials(clusterName, namespace, apiv1.SuperUserSecretSuffix, env)
+			appUser, appUserPass, err := testsUtils.GetCredentials(
+				clusterName, namespace, apiv1.ApplicationUserSecretSuffix, env)
 			Expect(err).ToNot(HaveOccurred())
 			host, err := testsUtils.GetHostName(namespace, clusterName, env)
 			Expect(err).ToNot(HaveOccurred())
@@ -504,8 +505,8 @@ func AssertLargeObjectValue(namespace, clusterName string, oid int, data string,
 				pod,
 				host,
 				testsUtils.AppDBName,
-				superUser,
-				superUserPass,
+				appUser,
+				appUserPass,
 				query,
 				env)
 			if err != nil {
@@ -801,8 +802,8 @@ func AssertReplicaModeCluster(
 
 	By("creating test data in source cluster", func() {
 		cmd := "CREATE TABLE IF NOT EXISTS test_replica AS VALUES (1),(2);"
-		superUser, superUserPass, err := testsUtils.GetCredentials(srcClusterName, namespace,
-			apiv1.SuperUserSecretSuffix, env)
+		appUser, appUserPass, err := testsUtils.GetCredentials(srcClusterName, namespace,
+			apiv1.ApplicationUserSecretSuffix, env)
 		Expect(err).ToNot(HaveOccurred())
 		host, err := testsUtils.GetHostName(namespace, srcClusterName, env)
 		Expect(err).ToNot(HaveOccurred())
@@ -810,8 +811,8 @@ func AssertReplicaModeCluster(
 			pod,
 			host,
 			"appSrc",
-			superUser,
-			superUserPass,
+			appUser,
+			appUserPass,
 			cmd,
 			env)
 		Expect(err).ToNot(HaveOccurred())
@@ -1042,20 +1043,16 @@ func AssertFastFailOver(
 			", PRIMARY KEY (id)" +
 			")"
 
-		commandTimeout := time.Second * 10
-		primaryPodName := clusterName + "-1"
-		primaryPod := &corev1.Pod{}
-
-		Eventually(func(g Gomega) {
-			err := env.Client.Get(env.Ctx, types.NamespacedName{
-				Namespace: namespace,
-				Name:      primaryPodName,
-			}, primaryPod)
-			g.Expect(err).ToNot(HaveOccurred())
-		}).Should(Succeed())
-
-		_, _, err = env.EventuallyExecCommand(env.Ctx, *primaryPod, specs.PostgresContainerName,
-			&commandTimeout, "psql", "-U", "postgres", "app", "-tAc", query)
+		primaryPod, err := env.GetClusterPrimary(namespace, clusterName)
+		Expect(err).ToNot(HaveOccurred())
+		_, _, err = env.ExecCommandWithPsqlClient(
+			namespace,
+			clusterName,
+			primaryPod,
+			apiv1.ApplicationUserSecretSuffix,
+			testsUtils.AppDBName,
+			query,
+		)
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -1143,18 +1140,22 @@ func AssertCreationOfTestDataForTargetDB(namespace, clusterName, targetDBName, t
 	By(fmt.Sprintf("creating target database '%v' and table '%v'", targetDBName, tableName), func() {
 		host, err := testsUtils.GetHostName(namespace, clusterName, env)
 		Expect(err).ToNot(HaveOccurred())
-		_, superUserPass, err := testsUtils.GetCredentials(clusterName, namespace, apiv1.SuperUserSecretSuffix, env)
+		appUser, appUserPass, err := testsUtils.GetCredentials(clusterName, namespace, apiv1.ApplicationUserSecretSuffix, env)
 		Expect(err).ToNot(HaveOccurred())
 
-		createDBQuery := fmt.Sprintf("CREATE DATABASE %v;", targetDBName)
+		// We need to gather the cluster primary to create the database via superuser
+		currentPrimary, err := env.GetClusterPrimary(namespace, clusterName)
+		Expect(err).ToNot(HaveOccurred())
+
 		// Create database
-		_, _, err = env.ExecCommandWithPsqlClient(
-			namespace,
-			clusterName,
-			pod,
-			apiv1.SuperUserSecretSuffix,
-			testsUtils.PostgresDBName,
-			createDBQuery,
+		commandTimeout := time.Second * 10
+		createDBQuery := fmt.Sprintf("CREATE DATABASE %v OWNER %v", targetDBName, appUser)
+		_, _, err = env.ExecCommand(
+			env.Ctx,
+			*currentPrimary,
+			specs.PostgresContainerName,
+			&commandTimeout,
+			"psql", "-U", "postgres", "-tAc", createDBQuery,
 		)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -1164,8 +1165,8 @@ func AssertCreationOfTestDataForTargetDB(namespace, clusterName, targetDBName, t
 			pod,
 			host,
 			targetDBName,
-			testsUtils.PostgresUser,
-			superUserPass,
+			appUser,
+			appUserPass,
 			createTableQuery,
 			env,
 		)
@@ -1177,8 +1178,8 @@ func AssertCreationOfTestDataForTargetDB(namespace, clusterName, targetDBName, t
 			pod,
 			host,
 			targetDBName,
-			testsUtils.PostgresUser,
-			superUserPass,
+			appUser,
+			appUserPass,
 			grantRoleQuery,
 			env,
 		)
@@ -1300,22 +1301,6 @@ func AssertSSLVerifyFullDBConnectionFromAppPod(namespace string, clusterName str
 	})
 }
 
-func AssertSetupPgBasebackup(namespace, srcClusterName, srcCluster string) string {
-	// Create the src Cluster
-	AssertCreateCluster(namespace, srcClusterName, srcCluster, env)
-
-	// Get Current Primary Pod
-	primaryPod, err := env.GetClusterPrimary(namespace, srcClusterName)
-	Expect(err).ToNot(HaveOccurred())
-
-	// Create test Data in the app database
-	query := "CREATE TABLE IF NOT EXISTS to_bootstrap AS VALUES (1),(2);"
-	_, _, err = testsUtils.RunQueryFromPod(primaryPod, testsUtils.PGLocalSocketDir,
-		"app", "postgres", "''", query, env)
-	Expect(err).ToNot(HaveOccurred())
-	return primaryPod.GetName()
-}
-
 func AssertCreateSASTokenCredentials(namespace string, id string, key string) {
 	// Adding 24 hours to the current time
 	date := time.Now().UTC().Add(time.Hour * 24)
@@ -1376,30 +1361,36 @@ func AssertClusterAsyncReplica(namespace, sourceClusterFile, restoreClusterFile,
 		AssertClusterIsReady(namespace, restoredClusterName, testTimeouts[testsUtils.ClusterIsReadySlow], env)
 
 		// Test data should be present on restored primary
-		primary, err := env.GetClusterPrimary(namespace, restoredClusterName)
+		// NOTE: We use the credentials from the `source-cluster` for the psql connection
+		// given that this is a replica cluster
+		restoredPrimary, err := env.GetClusterPrimary(namespace, restoredClusterName)
 		Expect(err).ToNot(HaveOccurred())
-
-		// Use `source-cluster` read write service and `superuser` credentials for psql connection.
-		superUser, superUserPass, err := testsUtils.GetCredentials(
-			sourceClusterName, namespace, apiv1.SuperUserSecretSuffix, env)
+		appUser, appUserPass, err := testsUtils.GetCredentials(
+			sourceClusterName, namespace, apiv1.ApplicationUserSecretSuffix, env)
 		Expect(err).ToNot(HaveOccurred())
-		rwService := testsUtils.CreateServiceFQDN(namespace, testsUtils.GetReadWriteServiceName(sourceClusterName))
-
+		rwService := testsUtils.CreateServiceFQDN(namespace, testsUtils.GetReadWriteServiceName(restoredClusterName))
 		query := "SELECT count(*) FROM " + tableName
 		out, _, err := testsUtils.RunQueryFromPod(
-			psqlClientPod, rwService, testsUtils.AppDBName, superUser, superUserPass, query, env)
+			restoredPrimary,
+			rwService,
+			testsUtils.AppDBName,
+			appUser,
+			appUserPass,
+			query,
+			env,
+		)
 		Expect(strings.Trim(out, "\n"), err).To(BeEquivalentTo("2"))
 
+		// Insert new data in the source cluster
 		insertRecordIntoTable(namespace, sourceClusterName, tableName, 3, pod)
 		AssertArchiveWalOnMinio(namespace, sourceClusterName, sourceClusterName)
-
 		AssertDataExpectedCount(namespace, sourceClusterName, tableName, 3, pod)
 
 		cluster, err := env.GetCluster(namespace, restoredClusterName)
 		Expect(err).ToNot(HaveOccurred())
 		expectedReplicas := cluster.Spec.Instances - 1
 		// Cascading replicas should be attached to primary replica
-		connectedReplicas, err := testsUtils.CountReplicas(env, primary)
+		connectedReplicas, err := testsUtils.CountReplicas(env, restoredPrimary)
 		Expect(connectedReplicas, err).To(BeEquivalentTo(expectedReplicas))
 	})
 }
@@ -1415,46 +1406,50 @@ func AssertClusterRestoreWithApplicationDB(namespace, restoreClusterFile, tableN
 		AssertClusterIsReady(namespace, restoredClusterName, testTimeouts[testsUtils.ClusterIsReadySlow], env)
 
 		// Test data should be present on restored primary
-		primary := restoredClusterName + "-1"
 		AssertDataExpectedCount(namespace, restoredClusterName, tableName, 2, pod)
-
-		// Restored primary should be on timeline 2
-		out, _, err := env.ExecQueryInInstancePod(
-			testsUtils.PodLocator{
-				Namespace: namespace,
-				PodName:   primary,
-			},
-			testsUtils.DatabaseName("app"),
-			"select substring(pg_walfile_name(pg_current_wal_lsn()), 1, 8)")
-		Expect(strings.Trim(out, "\n"), err).To(Equal("00000002"))
-
-		// Restored standby should be attached to restored primary
-		AssertClusterStandbysAreStreaming(namespace, restoredClusterName, 120)
 	})
 
+	By("Ensuring the restored cluster is on timeline 2", func() {
+		out, _, err := env.ExecCommandWithPsqlClient(
+			namespace,
+			restoredClusterName,
+			pod,
+			apiv1.ApplicationUserSecretSuffix,
+			testsUtils.AppDBName,
+			"select substring(pg_walfile_name(pg_current_wal_lsn()), 1, 8)",
+		)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(strings.Trim(out, "\n"), err).To(Equal("00000002"))
+	})
+
+	// Restored standby should be attached to restored primary
+	AssertClusterStandbysAreStreaming(namespace, restoredClusterName, 120)
+
+	// Gather Credentials
+	appUser, appUserPass, err := testsUtils.GetCredentials(restoredClusterName, namespace,
+		apiv1.ApplicationUserSecretSuffix, env)
+	Expect(err).ToNot(HaveOccurred())
+	secretName := restoredClusterName + apiv1.ApplicationUserSecretSuffix
+
 	By("checking the restored cluster with pre-defined app password connectable", func() {
-		// Get the app user password from the auto generated -app secret
-		const suppliedAppUserPassword = "4ls054f3"        // NOSONAR
-		const secretName = "postgresql-user-supplied-app" //nolint:gosec
 		AssertApplicationDatabaseConnection(
 			namespace,
 			restoredClusterName,
-			"appuser",
-			"appdb",
-			suppliedAppUserPassword,
+			appUser,
+			testsUtils.AppDBName,
+			appUserPass,
 			secretName,
 			pod)
 	})
 
 	By("update user application password for restored cluster and verify connectivity", func() {
-		const secretName = "postgresql-user-supplied-app" //nolint:gosec
-		const newPassword = "eeh2Zahohx"                  //nolint:gosec
+		const newPassword = "eeh2Zahohx" //nolint:gosec
 		AssertUpdateSecret("password", newPassword, secretName, namespace, restoredClusterName, 30, env)
 		AssertApplicationDatabaseConnection(
 			namespace,
 			restoredClusterName,
-			"appuser",
-			"appdb",
+			appUser,
+			testsUtils.AppDBName,
 			newPassword,
 			secretName,
 			pod)
@@ -1622,30 +1617,23 @@ func AssertSuspendScheduleBackups(namespace, scheduledBackupName string) {
 }
 
 func AssertClusterWasRestoredWithPITRAndApplicationDB(namespace, clusterName, tableName, lsn string, pod *corev1.Pod) {
-	primaryInfo := &corev1.Pod{}
-	var err error
+	// We give more time than the usual 600s, since the recovery is slower
+	AssertClusterIsReady(namespace, clusterName, testTimeouts[testsUtils.ClusterIsReadySlow], env)
 
-	By("restoring a backup cluster with PITR in a new cluster", func() {
-		// We give more time than the usual 600s, since the recovery is slower
-		AssertClusterIsReady(namespace, clusterName, testTimeouts[testsUtils.ClusterIsReadySlow], env)
+	// Gather the recovered cluster primary
+	primaryInfo, err := env.GetClusterPrimary(namespace, clusterName)
+	Expect(err).ToNot(HaveOccurred())
+	secretName := clusterName + apiv1.ApplicationUserSecretSuffix
 
-		primaryInfo, err = env.GetClusterPrimary(namespace, clusterName)
-		Expect(err).ToNot(HaveOccurred())
-
+	By("Ensuring the restored cluster is on timeline 3", func() {
 		// Restored primary should be on timeline 3
-		query := "select substring(pg_walfile_name(pg_current_wal_lsn()), 1, 8)"
-		host, err := testsUtils.GetHostName(namespace, clusterName, env)
-		Expect(err).ToNot(HaveOccurred())
-		superUser, superUserPass, err := testsUtils.GetCredentials(clusterName, namespace, apiv1.SuperUserSecretSuffix, env)
-		Expect(err).ToNot(HaveOccurred())
-		stdOut, _, err := testsUtils.RunQueryFromPod(
+		stdOut, _, err := env.ExecCommandWithPsqlClient(
+			namespace,
+			clusterName,
 			pod,
-			host,
+			apiv1.ApplicationUserSecretSuffix,
 			testsUtils.AppDBName,
-			superUser,
-			superUserPass,
-			query,
-			env,
+			"select substring(pg_walfile_name(pg_current_wal_lsn()), 1, 8)",
 		)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(strings.Trim(stdOut, "\n"), err).To(Equal(lsn))
@@ -1659,27 +1647,29 @@ func AssertClusterWasRestoredWithPITRAndApplicationDB(namespace, clusterName, ta
 		AssertDataExpectedCount(namespace, clusterName, tableName, 2, pod)
 	})
 
+	// Gather credentials
+	appUser, appUserPass, err := testsUtils.GetCredentials(clusterName, namespace, apiv1.ApplicationUserSecretSuffix, env)
+	Expect(err).ToNot(HaveOccurred())
+
 	By("checking the restored cluster with auto generated app password connectable", func() {
-		secretName := clusterName + "-app"
 		AssertApplicationDatabaseConnection(
 			namespace,
 			clusterName,
-			"appuser",
-			"appdb",
-			"",
+			appUser,
+			testsUtils.AppDBName,
+			appUserPass,
 			secretName,
 			pod)
 	})
 
 	By("update user application password for restored cluster and verify connectivity", func() {
-		secretName := clusterName + "-app"
 		const newPassword = "eeh2Zahohx" //nolint:gosec
 		AssertUpdateSecret("password", newPassword, secretName, namespace, clusterName, 30, env)
 		AssertApplicationDatabaseConnection(
 			namespace,
 			clusterName,
-			"appuser",
-			"appdb",
+			appUser,
+			testsUtils.AppDBName,
 			newPassword,
 			secretName,
 			pod)
@@ -1697,19 +1687,13 @@ func AssertClusterWasRestoredWithPITR(namespace, clusterName, tableName, lsn str
 		Expect(err).ToNot(HaveOccurred())
 
 		// Restored primary should be on timeline 3
-		query := "select substring(pg_walfile_name(pg_current_wal_lsn()), 1, 8)"
-		host, err := testsUtils.GetHostName(namespace, clusterName, env)
-		Expect(err).ToNot(HaveOccurred())
-		superUser, superUserPass, err := testsUtils.GetCredentials(clusterName, namespace, apiv1.SuperUserSecretSuffix, env)
-		Expect(err).ToNot(HaveOccurred())
-		stdOut, _, err := testsUtils.RunQueryFromPod(
+		stdOut, _, err := env.ExecCommandWithPsqlClient(
+			namespace,
+			clusterName,
 			pod,
-			host,
+			apiv1.ApplicationUserSecretSuffix,
 			testsUtils.AppDBName,
-			superUser,
-			superUserPass,
-			query,
-			env,
+			"select substring(pg_walfile_name(pg_current_wal_lsn()), 1, 8)",
 		)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(strings.Trim(stdOut, "\n"), err).To(Equal(lsn))

--- a/tests/e2e/backup_restore_test.go
+++ b/tests/e2e/backup_restore_test.go
@@ -962,7 +962,6 @@ var _ = Describe("Clusters Recovery From Barman Object Store", Label(tests.Label
 
 			AssertArchiveWalOnMinio(namespace, clusterName, clusterName)
 
-			// There should be a backup resource and
 			By("backing up a cluster and verifying it exists on minio", func() {
 				testUtils.ExecuteBackup(namespace, sourceTakeThirdBackupFileMinio, false,
 					testTimeouts[testUtils.BackupIsReady], env)

--- a/tests/e2e/cluster_microservice_test.go
+++ b/tests/e2e/cluster_microservice_test.go
@@ -20,12 +20,14 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	batchv1 "k8s.io/api/batch/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/postgres"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/specs"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/versions"
 	"github.com/cloudnative-pg/cloudnative-pg/tests"
@@ -203,54 +205,77 @@ func shouldSkip(postgresImage string) bool {
 	return currentImageVersion >= defaultImageVersion
 }
 
-// assertCreateTableWithDataOnSourceCluster creates a new user `micro` in the source cluster,
-// and uses the `postgres` superuser to generate a new table and assign ownership to `micro`
+// assertCreateTableWithDataOnSourceCluster will create on the source Cluster, as postgres superUser:
+// 1. a new user `micro`
+// 2. a new table with 2 records owned by `micro` in the `app` database
+// 3. grant select permission on the table to the `app` user (needed during the import)
 func assertCreateTableWithDataOnSourceCluster(
 	namespace,
 	tableName,
 	clusterName string,
 ) {
-	By("generate super user password,rw service name on source cluster", func() {
-		superUser, generatedSuperuserPassword, err := testsUtils.GetCredentials(
-			clusterName, namespace, apiv1.SuperUserSecretSuffix, env)
+	By("create user, insert record in new table, assign new user as owner "+
+		"and grant read only to app user", func() {
+		pod, err := env.GetClusterPrimary(namespace, clusterName)
 		Expect(err).ToNot(HaveOccurred())
-		rwService := fmt.Sprintf("%v-rw.%v.svc", clusterName, namespace)
-		By("create user, insert record in new table, assign new user as owner "+
-			"and grant read only to app user", func() {
-			query := fmt.Sprintf("DROP USER IF EXISTS micro; CREATE USER micro; "+
+		commandTimeout := time.Second * 10
+
+		query := fmt.Sprintf(
+			"DROP USER IF EXISTS micro; "+
+				"CREATE USER micro; "+
 				"CREATE TABLE IF NOT EXISTS %[1]v AS VALUES (1),(2); "+
-				"ALTER TABLE %[1]v OWNER TO micro;grant select on %[1]v to app;", tableName)
-			_, _, err = testsUtils.RunQueryFromPod(
-				psqlClientPod, rwService, "app", superUser, generatedSuperuserPassword, query, env)
-			Expect(err).ToNot(HaveOccurred())
-		})
+				"ALTER TABLE %[1]v OWNER TO micro; "+
+				"GRANT SELECT ON %[1]v TO app;",
+			tableName)
+
+		_, _, err = env.ExecCommand(
+			env.Ctx,
+			*pod,
+			specs.PostgresContainerName,
+			&commandTimeout,
+			"psql", "-U", "postgres", "app", "-tAc", query)
+		Expect(err).ToNot(HaveOccurred())
 	})
 }
 
-// assertTableAndDataOnImportedCluster  verifies the data created in source was imported
+// assertTableAndDataOnImportedCluster verifies the data created in source was imported
 func assertTableAndDataOnImportedCluster(
 	namespace,
 	tableName,
 	importedClusterName string,
 ) {
 	By("verifying presence of table and data from source in imported cluster", func() {
-		superUser, generatedSuperuserPassword, err := testsUtils.GetCredentials(importedClusterName,
-			namespace, apiv1.SuperUserSecretSuffix, env)
+		pod, err := env.GetClusterPrimary(namespace, importedClusterName)
 		Expect(err).ToNot(HaveOccurred())
-		importedrwService := fmt.Sprintf("%v-rw.%v.svc", importedClusterName, namespace)
-		By("Verifying imported table has owner app user", func() {
-			queryImported := fmt.Sprintf("select * from pg_tables where tablename = '%v' "+
-				"and tableowner = 'app';", tableName)
 
-			out, _, err := testsUtils.RunQueryFromPod(
-				psqlClientPod, importedrwService, "app", superUser,
-				generatedSuperuserPassword, queryImported, env)
+		By("Verifying imported table has owner app user", func() {
+			queryImported := fmt.Sprintf(
+				"select * from pg_tables where tablename = '%v' and tableowner = '%v'",
+				tableName,
+				testsUtils.AppUser,
+			)
+			out, _, err := env.ExecCommandWithPsqlClient(
+				namespace,
+				importedClusterName,
+				pod,
+				apiv1.ApplicationUserSecretSuffix,
+				testsUtils.AppDBName,
+				queryImported,
+			)
+			Expect(err).ToNot(HaveOccurred())
 			Expect(strings.Contains(out, tableName), err).Should(BeTrue())
 		})
+
 		By("verifying the user named 'micro' on source is not in imported database", func() {
-			outUser, _, err := testsUtils.RunQueryFromPod(
-				psqlClientPod, importedrwService, "app", superUser,
-				generatedSuperuserPassword, "\\du", env)
+			outUser, _, err := env.ExecCommandWithPsqlClient(
+				namespace,
+				importedClusterName,
+				pod,
+				apiv1.ApplicationUserSecretSuffix,
+				testsUtils.AppDBName,
+				"\\du",
+			)
+			Expect(err).ToNot(HaveOccurred())
 			Expect(strings.Contains(outUser, "micro"), err).Should(BeFalse())
 		})
 	})
@@ -272,52 +297,35 @@ func assertImportRenamesSelectedDatabase(
 	Expect(err).ToNot(HaveOccurred())
 
 	AssertCreateCluster(namespace, clusterName, sampleFile, env)
+	primaryPod, err := env.GetClusterPrimary(namespace, clusterName)
+	Expect(err).ToNot(HaveOccurred())
+	commandTimeout := time.Second * 10
 
 	By("creating multiple dbs on source and set ownership to app", func() {
-		rwService := testsUtils.CreateServiceFQDN(namespace, testsUtils.GetReadWriteServiceName(clusterName))
-		superUser, getSuperUserPassword, err := testsUtils.GetCredentials(
-			clusterName, namespace, apiv1.SuperUserSecretSuffix, env)
-		Expect(err).ToNot(HaveOccurred())
 		for _, db := range dbList {
 			// Create database
-			createDBQuery := fmt.Sprintf("create database %v;", db)
-			_, _, err = testsUtils.RunQueryFromPod(
-				psqlClientPod,
-				rwService,
-				testsUtils.PostgresDBName,
-				superUser,
-				getSuperUserPassword,
-				createDBQuery,
-				env)
-			Expect(err).ToNot(HaveOccurred())
-
-			AlterOwnerQuery := fmt.Sprintf("ALTER DATABASE %v OWNER TO app;", db)
-			_, _, err = testsUtils.RunQueryFromPod(
-				psqlClientPod,
-				rwService,
-				testsUtils.PostgresDBName,
-				testsUtils.PostgresUser,
-				getSuperUserPassword,
-				AlterOwnerQuery,
-				env)
+			createDBQuery := fmt.Sprintf("CREATE DATABASE %v OWNER app", db)
+			_, _, err = env.ExecCommand(
+				env.Ctx,
+				*primaryPod,
+				specs.PostgresContainerName,
+				&commandTimeout,
+				"psql", "-U", "postgres", "-tAc", createDBQuery)
 			Expect(err).ToNot(HaveOccurred())
 		}
 	})
 
 	By(fmt.Sprintf("creating table '%s' and insert records on selected db %v", tableName, dbToImport), func() {
-		superUser, getSuperUserPassword, err := testsUtils.GetCredentials(
-			clusterName, namespace, apiv1.SuperUserSecretSuffix, env)
-		Expect(err).ToNot(HaveOccurred())
-		rwService := testsUtils.CreateServiceFQDN(namespace, testsUtils.GetReadWriteServiceName(clusterName))
-		// set role app on db2
-		_, _, err = testsUtils.RunQueryFromPod(psqlClientPod, rwService,
-			dbToImport, superUser, getSuperUserPassword,
-			"set role app;", env)
-		Expect(err).ToNot(HaveOccurred())
-		// create test data and insert records
-		_, _, err = testsUtils.RunQueryFromPod(psqlClientPod, rwService,
-			dbToImport, superUser, getSuperUserPassword,
-			fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s AS VALUES (1),(2);", tableName), env)
+		// create a table with two records
+		query := fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s AS VALUES (1),(2);", tableName)
+		_, _, err := env.ExecCommandWithPsqlClient(
+			namespace,
+			clusterName,
+			primaryPod,
+			apiv1.ApplicationUserSecretSuffix,
+			dbToImport,
+			query,
+		)
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -334,15 +342,19 @@ func assertImportRenamesSelectedDatabase(
 	AssertDataExpectedCount(namespace, importedClusterName, tableName, 2, psqlClientPod)
 
 	By("verifying that only 'app' DB exists in the imported cluster", func() {
-		superUser, getSuperUserPassword, err := testsUtils.GetCredentials(
-			importedClusterName, namespace, apiv1.SuperUserSecretSuffix, env)
+		importedPrimaryPod, err := env.GetClusterPrimary(namespace, importedClusterName)
 		Expect(err).ToNot(HaveOccurred())
-		rwService := testsUtils.CreateServiceFQDN(namespace, testsUtils.GetReadWriteServiceName(importedClusterName))
-		dbList, _, err := testsUtils.RunQueryFromPod(psqlClientPod, rwService,
-			"postgres", superUser, getSuperUserPassword, "\\l", env)
+		out, _, err := env.ExecCommandWithPsqlClient(
+			namespace,
+			importedClusterName,
+			importedPrimaryPod,
+			apiv1.ApplicationUserSecretSuffix,
+			testsUtils.AppDBName,
+			"\\l",
+		)
 		Expect(err).ToNot(HaveOccurred(), err)
-		Expect(strings.Contains(dbList, "db2"), err).Should(BeFalse())
-		Expect(strings.Contains(dbList, "app"), err).Should(BeTrue())
+		Expect(strings.Contains(out, "db2"), err).Should(BeFalse())
+		Expect(strings.Contains(out, "app"), err).Should(BeTrue())
 	})
 
 	By("cleaning up the clusters", func() {

--- a/tests/e2e/cluster_monolithic_test.go
+++ b/tests/e2e/cluster_monolithic_test.go
@@ -40,7 +40,7 @@ import (
 var _ = Describe("Imports with Monolithic Approach", Label(tests.LabelImportingDatabases), func() {
 	const (
 		level             = tests.Medium
-		sourceClusterFile = fixturesDir + "/base/cluster-storage-class.yaml.template"
+		sourceClusterFile = fixturesDir + "/cluster_monolith/cluster-monolith.yaml.template"
 		targetClusterName = "cluster-target"
 		tableName         = "to_import"
 		databaseSuperUser = "testuserone" // one of the DB users should be a superuser

--- a/tests/e2e/cluster_setup_test.go
+++ b/tests/e2e/cluster_setup_test.go
@@ -103,9 +103,9 @@ var _ = Describe("Cluster setup", Label(tests.LabelSmoke, tests.LabelBasic), fun
 			err := env.Client.Get(env.Ctx, namespacedName, pod)
 			Expect(err).ToNot(HaveOccurred())
 
-			// Put something in the database. We'll check later if it
-			// still exists
-			superUser, superUserPass, err := testsUtils.GetCredentials(clusterName, namespace, apiv1.SuperUserSecretSuffix, env)
+			// Put something in the database. We'll check later if it still exists
+			appUser, appUserPass, err := testsUtils.GetCredentials(
+				clusterName, namespace, apiv1.ApplicationUserSecretSuffix, env)
 			Expect(err).NotTo(HaveOccurred())
 			host, err := testsUtils.GetHostName(namespace, clusterName, env)
 			Expect(err).NotTo(HaveOccurred())
@@ -114,8 +114,8 @@ var _ = Describe("Cluster setup", Label(tests.LabelSmoke, tests.LabelBasic), fun
 				psqlClientPod,
 				host,
 				testsUtils.AppDBName,
-				superUser,
-				superUserPass,
+				appUser,
+				appUserPass,
 				query,
 				env,
 			)
@@ -154,7 +154,7 @@ var _ = Describe("Cluster setup", Label(tests.LabelSmoke, tests.LabelBasic), fun
 					namespace,
 					clusterName,
 					psqlClientPod,
-					apiv1.SuperUserSecretSuffix,
+					apiv1.ApplicationUserSecretSuffix,
 					testsUtils.AppDBName,
 					query,
 				)

--- a/tests/e2e/configuration_update_test.go
+++ b/tests/e2e/configuration_update_test.go
@@ -445,7 +445,7 @@ var _ = Describe("Configuration update with primaryUpdateMethod", Label(tests.La
 
 				oldPrimaryPodName = primaryPodInfo.GetName()
 
-				superUser, superUserPass, err := utils.GetCredentials(clusterName, namespace, apiv1.SuperUserSecretSuffix, env)
+				appUser, appUserPass, err := utils.GetCredentials(clusterName, namespace, apiv1.ApplicationUserSecretSuffix, env)
 				Expect(err).ToNot(HaveOccurred())
 				host, err := utils.GetHostName(namespace, clusterName, env)
 				Expect(err).ToNot(HaveOccurred())
@@ -454,8 +454,8 @@ var _ = Describe("Configuration update with primaryUpdateMethod", Label(tests.La
 					psqlClientPod,
 					host,
 					utils.AppDBName,
-					superUser,
-					superUserPass,
+					appUser,
+					appUserPass,
 					query,
 					env)
 				Expect(cmdErr).ToNot(HaveOccurred())
@@ -467,8 +467,8 @@ var _ = Describe("Configuration update with primaryUpdateMethod", Label(tests.La
 					psqlClientPod,
 					host,
 					utils.AppDBName,
-					utils.PostgresUser,
-					superUserPass,
+					appUser,
+					appUserPass,
 					query,
 					env)
 				Expect(cmdErr).ToNot(HaveOccurred())

--- a/tests/e2e/connection_test.go
+++ b/tests/e2e/connection_test.go
@@ -53,17 +53,6 @@ var _ = Describe("Connection via services", Label(tests.LabelServiceConnectivity
 		superuserPassword string,
 		env *utils.TestingEnvironment,
 	) {
-		// we use a pod in the cluster to have a psql client ready and
-		// internal access to the k8s cluster
-		podName := clusterName + "-1"
-		pod := &corev1.Pod{}
-		namespacedName := types.NamespacedName{
-			Namespace: namespace,
-			Name:      podName,
-		}
-		err := env.Client.Get(env.Ctx, namespacedName, pod)
-		Expect(err).ToNot(HaveOccurred())
-
 		// We test -rw, -ro and -r services with the app user and the superuser
 		rwService := fmt.Sprintf("%v-rw.%v.svc", clusterName, namespace)
 		rService := fmt.Sprintf("%v-r.%v.svc", clusterName, namespace)
@@ -140,8 +129,8 @@ var _ = Describe("Connection via services", Label(tests.LabelServiceConnectivity
 		// If we have specified secrets, we test that we're able to use them
 		// to connect
 		It("can connect with user-supplied passwords", func() {
-			const suppliedSuperuserPassword = "v3ry54f3" // NOSONAR
-			const suppliedAppUserPassword = "4ls054f3"   // NOSONAR
+			const suppliedSuperuserPassword = "v3ry54f3"
+			const suppliedAppUserPassword = "4ls054f3"
 
 			// Create a cluster in a namespace we'll delete after the test
 			var err error

--- a/tests/e2e/fastfailover_test.go
+++ b/tests/e2e/fastfailover_test.go
@@ -67,7 +67,7 @@ var _ = Describe("Fast failover", Serial, Label(tests.LabelPerformance, tests.La
 		}
 	})
 
-	Context("with async replicas cluster", func() {
+	Context("with async replicas cluster (without HA Replication Slots)", func() {
 		// Confirm that a standby closely following the primary doesn't need more
 		// than 10 seconds to be promoted and be able to start inserting records.
 		// We test this setting up an application pointing to the rw service,

--- a/tests/e2e/fixtures/backup/azurite/cluster-from-restore.yaml.template
+++ b/tests/e2e/fixtures/backup/azurite/cluster-from-restore.yaml.template
@@ -20,20 +20,5 @@ spec:
 
   bootstrap:
     recovery:
-      database: appdb
-      owner: appuser
-      secret:
-        name: postgresql-user-supplied-app
       backup:
         name: cluster-backup
----
-apiVersion: v1
-data:
-  username: YXBwdXNlcg==
-  password: NGxzMDU0ZjM=
-kind: Secret
-metadata:
-  name: postgresql-user-supplied-app
-  labels:
-    cnpg.io/reload: ""
-type: kubernetes.io/basic-auth

--- a/tests/e2e/fixtures/backup/recovery_external_clusters/cluster-from-restore-sas.yaml.template
+++ b/tests/e2e/fixtures/backup/recovery_external_clusters/cluster-from-restore-sas.yaml.template
@@ -11,10 +11,6 @@ spec:
 
   bootstrap:
     recovery:
-      database: appdb
-      owner: appuser
-      secret:
-        name: postgresql-user-supplied-app
       source: clusterBackupSas
 
   externalClusters:
@@ -29,14 +25,3 @@ spec:
           storageSasToken:
             name: restore-storage-creds-sas
             key: KEY
----
-apiVersion: v1
-data:
-  username: YXBwdXNlcg==
-  password: NGxzMDU0ZjM=
-kind: Secret
-metadata:
-  name: postgresql-user-supplied-app
-  labels:
-    cnpg.io/reload: ""
-type: kubernetes.io/basic-auth

--- a/tests/e2e/fixtures/cluster_microservice/cluster-base.yaml.template
+++ b/tests/e2e/fixtures/cluster_microservice/cluster-base.yaml.template
@@ -22,6 +22,7 @@ spec:
       # Creates a fake plpgsql function to prove that restore works
       postInitApplicationSQL:
       - "CREATE FUNCTION one() RETURNS INT LANGUAGE plpgsql IMMUTABLE AS 'BEGIN RETURN 1; END;'"
+      - ALTER ROLE "app" REPLICATION
 
   # Persistent storage configuration
   storage:

--- a/tests/e2e/fixtures/cluster_microservice/cluster_microservice.yaml
+++ b/tests/e2e/fixtures/cluster_microservice/cluster_microservice.yaml
@@ -20,8 +20,8 @@ spec:
     - name: cluster-microservice
       connectionParameters:
         host: cluster-microservice-rw.microservice-error.svc
-        user: postgres
-        dbname: postgres
+        user: app
+        dbname: app
       password:
-        name: cluster-microservice-superuser
+        name: cluster-microservice-app
         key: password

--- a/tests/e2e/fixtures/cluster_monolith/cluster-monolith.yaml.template
+++ b/tests/e2e/fixtures/cluster_monolith/cluster-monolith.yaml.template
@@ -1,18 +1,21 @@
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
-  name: external-cluster-azurite
+  name: cluster-monolith
 spec:
-  instances: 2
+  instances: 3
+  enableSuperuserAccess: true
 
   postgresql:
     parameters:
+      max_connections: "110"
       log_checkpoints: "on"
       log_lock_waits: "on"
       log_min_duration_statement: '1000'
       log_statement: 'ddl'
       log_temp_files: '1024'
       log_autovacuum_min_duration: '1s'
+      log_replication_commands: 'on'
 
   # Example of rolling update strategy:
   # - unsupervised: automated update of the primary once all
@@ -20,27 +23,17 @@ spec:
   # - supervised: requires manual supervision to perform
   #               the switchover of the primary
   primaryUpdateStrategy: unsupervised
+  primaryUpdateMethod: switchover
+
+  bootstrap:
+    initdb:
+      database: app
+      owner: app
 
   # Persistent storage configuration
   storage:
     storageClass: ${E2E_DEFAULT_STORAGE_CLASS}
     size: 1Gi
-
-  bootstrap:
-    recovery:
-      # cluster name in source cluster
-      source: pg-backup-azurite
-
-  externalClusters:
-    - name: pg-backup-azurite
-      barmanObjectStore:
-        destinationPath: https://azurite:10000/storageaccountname/pg-backup-azurite
-        endpointCA:
-          key: ca.crt
-          name: azurite-ca-secret
-        azureCredentials:
-          connectionString:
-            name: azurite
-            key: AZURE_CONNECTION_STRING
-        wal:
-          compression: gzip
+  walStorage:
+    storageClass: ${E2E_DEFAULT_STORAGE_CLASS}
+    size: 1Gi

--- a/tests/e2e/fixtures/failover/cluster-failover-delay.yaml.template
+++ b/tests/e2e/fixtures/failover/cluster-failover-delay.yaml.template
@@ -5,6 +5,7 @@ metadata:
 spec:
   failoverDelay: 15
   instances: 3
+
   bootstrap:
     initdb:
       database: app

--- a/tests/e2e/fixtures/failover/cluster-failover.yaml.template
+++ b/tests/e2e/fixtures/failover/cluster-failover.yaml.template
@@ -1,14 +1,13 @@
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
-  name: cluster-no-postgres-pwd
+  name: failover
 spec:
   instances: 3
 
-  enableSuperuserAccess: false
-
   postgresql:
     parameters:
+      max_connections: "110"
       log_checkpoints: "on"
       log_lock_waits: "on"
       log_min_duration_statement: '1000'
@@ -17,6 +16,15 @@ spec:
       log_autovacuum_min_duration: '1s'
       log_replication_commands: 'on'
 
+  bootstrap:
+    initdb:
+      database: app
+      owner: app
+
+  # Persistent storage configuration
   storage:
-    size: 1Gi
     storageClass: ${E2E_DEFAULT_STORAGE_CLASS}
+    size: 1Gi
+  walStorage:
+    storageClass: ${E2E_DEFAULT_STORAGE_CLASS}
+    size: 1Gi

--- a/tests/e2e/fixtures/fastfailover/cluster-fast-failover.yaml.template
+++ b/tests/e2e/fixtures/fastfailover/cluster-fast-failover.yaml.template
@@ -16,6 +16,11 @@ spec:
       log_temp_files: '1024'
       log_autovacuum_min_duration: '1s'
       log_replication_commands: 'on'
+
+  replicationSlots:
+    highAvailability:
+      enabled: false
+
   bootstrap:
     initdb:
       database: app

--- a/tests/e2e/fixtures/fastfailover/webtest-syncreplicas.yaml
+++ b/tests/e2e/fixtures/fastfailover/webtest-syncreplicas.yaml
@@ -22,12 +22,12 @@ spec:
             - name: PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: cluster-syncreplicas-fast-failover-superuser
+                  name: cluster-syncreplicas-fast-failover-app
                   key: password
             - name: USER
               valueFrom:
                 secretKeyRef:
-                  name: cluster-syncreplicas-fast-failover-superuser
+                  name: cluster-syncreplicas-fast-failover-app
                   key: username
             - name: DATABASE_URL
               value: "postgres://$(USER):$(PASSWORD)@cluster-syncreplicas-fast-failover-rw/app?sslmode=require&connect_timeout=2"

--- a/tests/e2e/fixtures/fastfailover/webtest.yaml
+++ b/tests/e2e/fixtures/fastfailover/webtest.yaml
@@ -22,12 +22,12 @@ spec:
             - name: PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: cluster-fast-failover-superuser
+                  name: cluster-fast-failover-app
                   key: password
             - name: USER
               valueFrom:
                 secretKeyRef:
-                  name: cluster-fast-failover-superuser
+                  name: cluster-fast-failover-app
                   key: username
             - name: DATABASE_URL
               value: "postgres://$(USER):$(PASSWORD)@cluster-fast-failover-rw/app?sslmode=require&connect_timeout=2"

--- a/tests/e2e/fixtures/fastswitchover/cluster-fast-switchover.yaml.template
+++ b/tests/e2e/fixtures/fastswitchover/cluster-fast-switchover.yaml.template
@@ -16,6 +16,11 @@ spec:
       log_autovacuum_min_duration: '1s'
       log_replication_commands: 'on'
       wal_receiver_timeout: '2s'
+
+  replicationSlots:
+    highAvailability:
+      enabled: false
+
   bootstrap:
     initdb:
       database: app

--- a/tests/e2e/fixtures/fastswitchover/webtest.yaml
+++ b/tests/e2e/fixtures/fastswitchover/webtest.yaml
@@ -22,12 +22,12 @@ spec:
             - name: PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: cluster-fast-switchover-superuser
+                  name: cluster-fast-switchover-app
                   key: password
             - name: USER
               valueFrom:
                 secretKeyRef:
-                  name: cluster-fast-switchover-superuser
+                  name: cluster-fast-switchover-app
                   key: username
             - name: DATABASE_URL
               value: "postgres://$(USER):$(PASSWORD)@cluster-fast-switchover-rw/app?sslmode=require&connect_timeout=2"

--- a/tests/e2e/fixtures/pg_basebackup/cluster-dst-basic-auth.yaml.template
+++ b/tests/e2e/fixtures/pg_basebackup/cluster-dst-basic-auth.yaml.template
@@ -32,9 +32,9 @@ spec:
     - name: pg-basebackup-src
       connectionParameters:
         host: pg-basebackup-src-rw
-        user: postgres
+        user: appuser
         port: "5432"
         dbname: app
       password:
-        name: pg-basebackup-src-superuser
+        name: pg-basebackup-src-app
         key: password

--- a/tests/e2e/fixtures/pg_basebackup/cluster-dst-tls.yaml.template
+++ b/tests/e2e/fixtures/pg_basebackup/cluster-dst-tls.yaml.template
@@ -24,6 +24,8 @@ spec:
 
   bootstrap:
     pg_basebackup:
+      database: app
+      owner: appuser
       source: pg-basebackup-src
 
   externalClusters:

--- a/tests/e2e/fixtures/pg_basebackup/cluster-src.yaml.template
+++ b/tests/e2e/fixtures/pg_basebackup/cluster-src.yaml.template
@@ -15,12 +15,14 @@ spec:
       log_autovacuum_min_duration: '1s'
       log_replication_commands: 'on'
     pg_hba:
-      - host replication postgres all md5
-      - hostssl app streaming_replica all cert
+      - host replication appuser all md5
+
   bootstrap:
     initdb:
       database: app
       owner: appuser
+      postInitApplicationSQL:
+        - ALTER ROLE "appuser" REPLICATION
 
   storage:
     size: 1Gi

--- a/tests/e2e/fixtures/pgbouncer/pgbouncer-pooler-basic-auth-ro.yaml
+++ b/tests/e2e/fixtures/pgbouncer/pgbouncer-pooler-basic-auth-ro.yaml
@@ -18,5 +18,5 @@ spec:
   pgbouncer:
     poolMode: session
     authQuerySecret:
-      name: cluster-pgbouncer-superuser
+      name: cluster-pgbouncer-app
     authQuery: SELECT usename, passwd FROM pg_shadow WHERE usename=$1

--- a/tests/e2e/fixtures/pgbouncer/pgbouncer-pooler-basic-auth-rw.yaml
+++ b/tests/e2e/fixtures/pgbouncer/pgbouncer-pooler-basic-auth-rw.yaml
@@ -11,5 +11,5 @@ spec:
   pgbouncer:
     poolMode: session
     authQuerySecret:
-      name: cluster-pgbouncer-superuser
+      name: cluster-pgbouncer-app
     authQuery: SELECT usename, passwd FROM pg_shadow WHERE usename=$1

--- a/tests/e2e/fixtures/replica_mode_cluster/cluster-replica-archive-mode-always.yaml.template
+++ b/tests/e2e/fixtures/replica_mode_cluster/cluster-replica-archive-mode-always.yaml.template
@@ -23,11 +23,11 @@ spec:
   - name: cluster-replica-src
     connectionParameters:
       host: cluster-replica-src-rw
-      user: postgres
-      dbname: postgres
+      user: userSrc
+      dbname: appSrc
       port: "5432"
     password:
-      name: cluster-replica-src-superuser
+      name: cluster-replica-src-app
       key: password
 
     barmanObjectStore:

--- a/tests/e2e/fixtures/replica_mode_cluster/cluster-replica-basicauth.yaml.template
+++ b/tests/e2e/fixtures/replica_mode_cluster/cluster-replica-basicauth.yaml.template
@@ -23,9 +23,9 @@ spec:
   - name: cluster-replica-src
     connectionParameters:
       host: cluster-replica-src-rw
-      user: postgres
-      dbname: postgres
+      user: userSrc
+      dbname: appSrc
       port: "5432"
     password:
-      name: cluster-replica-src-superuser
+      name: cluster-replica-src-app
       key: password

--- a/tests/e2e/fixtures/replica_mode_cluster/cluster-replica-from-backup.yaml.template
+++ b/tests/e2e/fixtures/replica_mode_cluster/cluster-replica-from-backup.yaml.template
@@ -26,11 +26,11 @@ spec:
 
       connectionParameters:
         host: cluster-replica-src-rw
-        user: postgres
-        dbname: postgres
+        user: userSrc
+        dbname: appSrc
         port: "5432"
       password:
-        name: cluster-replica-src-superuser
+        name: cluster-replica-src-app
         key: password
 
       barmanObjectStore:

--- a/tests/e2e/fixtures/replica_mode_cluster/cluster-replica-from-snapshot.yaml.template
+++ b/tests/e2e/fixtures/replica_mode_cluster/cluster-replica-from-snapshot.yaml.template
@@ -35,11 +35,11 @@ spec:
 
       connectionParameters:
         host: cluster-replica-src-rw
-        user: postgres
-        dbname: postgres
+        user: userSrc
+        dbname: appSrc
         port: "5432"
       password:
-        name: cluster-replica-src-superuser
+        name: cluster-replica-src-app
         key: password
 
       barmanObjectStore:

--- a/tests/e2e/fixtures/replica_mode_cluster/cluster-replica-src-with-backup.yaml.template
+++ b/tests/e2e/fixtures/replica_mode_cluster/cluster-replica-src-with-backup.yaml.template
@@ -17,6 +17,8 @@ spec:
     initdb:
       database: appSrc
       owner: userSrc
+      postInitApplicationSQL:
+        - ALTER ROLE "userSrc" REPLICATION
 
   postgresql:
     parameters:
@@ -28,8 +30,7 @@ spec:
       log_autovacuum_min_duration: '1s'
       log_replication_commands: 'on'
     pg_hba:
-      - host replication postgres all md5
-      - hostssl app streaming_replica all cert
+      - host replication userSrc all md5
 
   backup:
     volumeSnapshot:

--- a/tests/e2e/fixtures/replica_mode_cluster/cluster-replica-src.yaml.template
+++ b/tests/e2e/fixtures/replica_mode_cluster/cluster-replica-src.yaml.template
@@ -15,13 +15,14 @@ spec:
       log_autovacuum_min_duration: '1s'
       log_replication_commands: 'on'
     pg_hba:
-      - host replication postgres all md5
-      - hostssl app streaming_replica all cert
+      - host replication userSrc all md5
 
   bootstrap:
     initdb:
       database: appSrc
       owner: userSrc
+      postInitApplicationSQL:
+        - ALTER ROLE "userSrc" REPLICATION
 
   storage:
     size: 1Gi

--- a/tests/e2e/fixtures/secrets/cluster-auto-generated.yaml.template
+++ b/tests/e2e/fixtures/secrets/cluster-auto-generated.yaml.template
@@ -4,6 +4,7 @@ metadata:
   name: postgresql-auto-generated
 spec:
   instances: 3
+  enableSuperuserAccess: true
 
   postgresql:
     parameters:

--- a/tests/e2e/fixtures/secrets/cluster-secrets.yaml
+++ b/tests/e2e/fixtures/secrets/cluster-secrets.yaml
@@ -1,9 +1,9 @@
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
-  name: cluster-basic
+  name: cluster-secrets
 spec:
-  instances: 3
+  instances: 1
 
   storage:
     size: 1Gi

--- a/tests/e2e/fixtures/secrets/cluster-user-supplied.yaml.template
+++ b/tests/e2e/fixtures/secrets/cluster-user-supplied.yaml.template
@@ -4,6 +4,7 @@ metadata:
   name: postgresql-user-supplied
 spec:
   instances: 3
+  enableSuperuserAccess: true
 
   postgresql:
     parameters:

--- a/tests/e2e/metrics_test.go
+++ b/tests/e2e/metrics_test.go
@@ -286,7 +286,7 @@ var _ = Describe("Metrics", Label(tests.LabelObservability), func() {
 
 		By("grant select permission for test_replica table to pg_monitor", func() {
 			cmd := "GRANT SELECT ON test_replica TO pg_monitor"
-			superUser, superUserPass, err := utils.GetCredentials(srcClusterName, namespace, apiv1.SuperUserSecretSuffix, env)
+			appUser, appUserPass, err := utils.GetCredentials(srcClusterName, namespace, apiv1.ApplicationUserSecretSuffix, env)
 			Expect(err).ToNot(HaveOccurred())
 			host, err := utils.GetHostName(namespace, srcClusterName, env)
 			Expect(err).ToNot(HaveOccurred())
@@ -294,8 +294,8 @@ var _ = Describe("Metrics", Label(tests.LabelObservability), func() {
 				psqlClientPod,
 				host,
 				"appSrc",
-				superUser,
-				superUserPass,
+				appUser,
+				appUserPass,
 				cmd,
 				env)
 			Expect(err).ToNot(HaveOccurred())

--- a/tests/utils/backup.go
+++ b/tests/utils/backup.go
@@ -199,9 +199,7 @@ func CreateClusterFromExternalClusterBackupWithPITROnAzure(
 
 			Bootstrap: &apiv1.BootstrapConfiguration{
 				Recovery: &apiv1.BootstrapRecovery{
-					Database: "appdb",
-					Owner:    "appuser",
-					Source:   sourceClusterName,
+					Source: sourceClusterName,
 					RecoveryTarget: &apiv1.RecoveryTarget{
 						TargetTime: targetTime,
 					},
@@ -283,9 +281,7 @@ func CreateClusterFromExternalClusterBackupWithPITROnMinio(
 
 			Bootstrap: &apiv1.BootstrapConfiguration{
 				Recovery: &apiv1.BootstrapRecovery{
-					Database: "appdb",
-					Owner:    "appuser",
-					Source:   sourceClusterName,
+					Source: sourceClusterName,
 					RecoveryTarget: &apiv1.RecoveryTarget{
 						TargetTime: targetTime,
 					},
@@ -375,9 +371,7 @@ func CreateClusterFromExternalClusterBackupWithPITROnAzurite(
 
 			Bootstrap: &apiv1.BootstrapConfiguration{
 				Recovery: &apiv1.BootstrapRecovery{
-					Database: "appdb",
-					Owner:    "appuser",
-					Source:   sourceClusterName,
+					Source: sourceClusterName,
 					RecoveryTarget: &apiv1.RecoveryTarget{
 						TargetTime: targetTime,
 					},

--- a/tests/utils/import_db.go
+++ b/tests/utils/import_db.go
@@ -22,12 +22,15 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 )
 
 // ImportDatabaseMicroservice creates a cluster, starting from an external cluster
 // using microservice approach
+// NOTE: the application user on the source Cluster needs to be granted with
+// REPLICATION permissions, which are not set by default
 func ImportDatabaseMicroservice(
 	namespace,
 	sourceClusterName,
@@ -40,8 +43,11 @@ func ImportDatabaseMicroservice(
 		imageName = os.Getenv("POSTGRES_IMG")
 	}
 	storageClassName := os.Getenv("E2E_DEFAULT_STORAGE_CLASS")
-	host := fmt.Sprintf("%v-rw.%v.svc", sourceClusterName, namespace)
-	superUserSecretName := fmt.Sprintf("%v-superuser", sourceClusterName)
+	host, err := GetHostName(namespace, sourceClusterName, env)
+	if err != nil {
+		return nil, err
+	}
+	appUserSecretName := sourceClusterName + apiv1.ApplicationUserSecretSuffix
 	restoreCluster := &apiv1.Cluster{
 		ObjectMeta: v1.ObjectMeta{
 			Name:      importedClusterName,
@@ -71,11 +77,15 @@ func ImportDatabaseMicroservice(
 
 			ExternalClusters: []apiv1.ExternalCluster{
 				{
-					Name:                 sourceClusterName,
-					ConnectionParameters: map[string]string{"host": host, "user": "postgres", "dbname": "postgres"},
+					Name: sourceClusterName,
+					ConnectionParameters: map[string]string{
+						"host":   host,
+						"user":   AppUser,
+						"dbname": AppDBName,
+					},
 					Password: &corev1.SecretKeySelector{
 						LocalObjectReference: corev1.LocalObjectReference{
-							Name: superUserSecretName,
+							Name: appUserSecretName,
 						},
 						Key: "password",
 					},
@@ -98,6 +108,7 @@ func ImportDatabaseMicroservice(
 // ImportDatabasesMonolith creates a new cluster spec importing from a sourceCluster
 // using the Monolith approach.
 // Imports all the specified `databaseNames` and `roles` from the source cluster
+// NOTE: enableSuperuserAccess needs to be enabled
 func ImportDatabasesMonolith(
 	namespace,
 	sourceClusterName,
@@ -111,16 +122,20 @@ func ImportDatabasesMonolith(
 		imageName = os.Getenv("POSTGRES_IMG")
 	}
 	storageClassName := os.Getenv("E2E_DEFAULT_STORAGE_CLASS")
-	host := fmt.Sprintf("%v-rw.%v.svc", sourceClusterName, namespace)
-	superUserSecretName := fmt.Sprintf("%v-superuser", sourceClusterName)
+	host, err := GetHostName(namespace, sourceClusterName, env)
+	if err != nil {
+		return nil, err
+	}
+	superUserSecretName := sourceClusterName + apiv1.SuperUserSecretSuffix
 	targetCluster := &apiv1.Cluster{
 		ObjectMeta: v1.ObjectMeta{
 			Name:      importedClusterName,
 			Namespace: namespace,
 		},
 		Spec: apiv1.ClusterSpec{
-			Instances: 3,
-			ImageName: imageName,
+			Instances:             3,
+			ImageName:             imageName,
+			EnableSuperuserAccess: ptr.To(true),
 
 			StorageConfiguration: apiv1.StorageConfiguration{
 				Size:         "1Gi",
@@ -141,8 +156,12 @@ func ImportDatabasesMonolith(
 			},
 			ExternalClusters: []apiv1.ExternalCluster{
 				{
-					Name:                 sourceClusterName,
-					ConnectionParameters: map[string]string{"host": host, "user": "postgres", "dbname": "postgres"},
+					Name: sourceClusterName,
+					ConnectionParameters: map[string]string{
+						"host":   host,
+						"user":   PostgresUser,
+						"dbname": PostgresDBName,
+					},
 					Password: &corev1.SecretKeySelector{
 						LocalObjectReference: corev1.LocalObjectReference{
 							Name: superUserSecretName,

--- a/tests/utils/time.go
+++ b/tests/utils/time.go
@@ -30,7 +30,7 @@ func GetCurrentTimestamp(namespace, clusterName string, env *TestingEnvironment,
 	if err != nil {
 		return "", err
 	}
-	superUser, superUserPass, err := GetCredentials(clusterName, namespace, apiv1.SuperUserSecretSuffix, env)
+	appUser, appUserPass, err := GetCredentials(clusterName, namespace, apiv1.ApplicationUserSecretSuffix, env)
 	if err != nil {
 		return "", err
 	}
@@ -39,8 +39,8 @@ func GetCurrentTimestamp(namespace, clusterName string, env *TestingEnvironment,
 		podName,
 		host,
 		AppDBName,
-		superUser,
-		superUserPass,
+		appUser,
+		appUserPass,
 		query,
 		env,
 	)


### PR DESCRIPTION
Rewrite E2E tests so that they request superuser access only if truly needed. This is in preparation for the change of default that disables superuser access (#2899).

Closes #3015