### PR TITLE
fix: ciclops unable to slack for alerts

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -1766,8 +1766,6 @@ jobs:
         uses: rtCamp/action-slack-notify@v2
         if: |
           steps.generate-summary.outputs.alerts &&
-          github.organization == 'cloudnative-pg' &&
-          github.ref == 'refs/heads/main'
         env:
           SLACK_COLOR: "danger"
           SLACK_ICON: https://avatars.githubusercontent.com/u/85171364?size=48

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -1754,8 +1754,11 @@ jobs:
         with:
           artifact_directory: test-artifacts/data
 
+      - name: If there are alerts, echo them
+        run: echo "ALERT ${ steps.generate-summary.outputs.alerts }"
+
       - name: If there is an overflow summary, archive it
-        if: steps.generate-summary.outputs.Overflow
+        if: always() && steps.generate-summary.outputs.Overflow
         uses: actions/upload-artifact@v3
         with:
           name: ${{ steps.generate-summary.outputs.Overflow }}

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -1755,7 +1755,7 @@ jobs:
           artifact_directory: test-artifacts/data
 
       - name: If there is an overflow summary, archive it
-        if: always() && steps.generate-summary.outputs.Overflow
+        if: steps.generate-summary.outputs.Overflow
         uses: actions/upload-artifact@v3
         with:
           name: ${{ steps.generate-summary.outputs.Overflow }}
@@ -1765,8 +1765,8 @@ jobs:
       - name: If there are alerts, send them over Slack
         uses: rtCamp/action-slack-notify@v2
         if: |
-          always() &&
-          steps.generate-summary.outputs.alerts
+          steps.generate-summary.outputs.alerts &&
+          github.ref == 'refs/heads/main'
         env:
           SLACK_COLOR: "danger"
           SLACK_ICON: https://avatars.githubusercontent.com/u/85171364?size=48

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -1765,7 +1765,8 @@ jobs:
       - name: If there are alerts, send them over Slack
         uses: rtCamp/action-slack-notify@v2
         if: |
-          steps.generate-summary.outputs.alerts &&
+          always() &&
+          steps.generate-summary.outputs.alerts
         env:
           SLACK_COLOR: "danger"
           SLACK_ICON: https://avatars.githubusercontent.com/u/85171364?size=48

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -1766,6 +1766,7 @@ jobs:
         uses: rtCamp/action-slack-notify@v2
         if: |
           steps.generate-summary.outputs.alerts &&
+          github.repository_owner == 'cloudnative-pg' &&
           github.ref == 'refs/heads/main'
         env:
           SLACK_COLOR: "danger"

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -1754,9 +1754,6 @@ jobs:
         with:
           artifact_directory: test-artifacts/data
 
-      - name: If there are alerts, echo them
-        run: echo "ALERT ${ steps.generate-summary.outputs.alerts }"
-
       - name: If there is an overflow summary, archive it
         if: always() && steps.generate-summary.outputs.Overflow
         uses: actions/upload-artifact@v3

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -414,7 +414,7 @@ jobs:
         uses: rtCamp/action-slack-notify@v2
         if: |
           failure() &&
-          github.organization == 'cloudnative-pg' &&
+          github.repository_owner == 'cloudnative-pg' &&
           (
             github.event_name == 'schedule' ||
             (

--- a/tests/e2e/initdb_test.go
+++ b/tests/e2e/initdb_test.go
@@ -113,7 +113,7 @@ var _ = Describe("InitDB settings", Label(tests.LabelSmoke, tests.LabelBasic), f
 					}, utils.DatabaseName("postgres"),
 					"SELECT count(*) FROM pg_available_extensions WHERE name LIKE 'intarray'")
 				Expect(err).ToNot(HaveOccurred())
-				Expect(stdout, err).To(Equal("1\n"))
+				Expect(stdout, err).To(Equal("100\n"))
 			})
 			By("checking inside the database the default locale", func() {
 				stdout, _, err := env.ExecQueryInInstancePod(

--- a/tests/e2e/initdb_test.go
+++ b/tests/e2e/initdb_test.go
@@ -113,7 +113,7 @@ var _ = Describe("InitDB settings", Label(tests.LabelSmoke, tests.LabelBasic), f
 					}, utils.DatabaseName("postgres"),
 					"SELECT count(*) FROM pg_available_extensions WHERE name LIKE 'intarray'")
 				Expect(err).ToNot(HaveOccurred())
-				Expect(stdout, err).To(Equal("100\n"))
+				Expect(stdout, err).To(Equal("1\n"))
 			})
 			By("checking inside the database the default locale", func() {
 				stdout, _, err := env.ExecQueryInInstancePod(


### PR DESCRIPTION
Fixes the use of CIclops in the continuous delivery pipeline.
CIclops has been detecting systematic failures in `main`, but
was unable to send an alert via slackops