### PR TITLE
chore: rename `smartStopDelay` to `smartShutdownTimeout`

### DIFF
--- a/.wordlist-en-custom.txt
+++ b/.wordlist-en-custom.txt
@@ -1011,7 +1011,7 @@ sig
 sigs
 singlenamespace
 slotPrefix
-smartStopDelay
+smartShutdownTimeout
 snapshotBackupStatus
 snapshotOwnerReference
 snapshotted

--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -281,10 +281,10 @@ type ClusterSpec struct {
 
 	// The time in seconds that controls the window of time reserved for the smart shutdown of Postgres to complete.
 	// Make sure you reserve enough time for the operator to request a fast shutdown of Postgres
-	// (that is: `stopDelay` - `smartStopDelay`).
+	// (that is: `stopDelay` - `smartShutdownTimeout`).
 	// +kubebuilder:default:=180
 	// +optional
-	SmartStopDelay int32 `json:"smartStopDelay,omitempty"`
+	SmartShutdownTimeout int32 `json:"smartShutdownTimeout,omitempty"`
 
 	// The time in seconds that is allowed for a primary PostgreSQL instance
 	// to gracefully shutdown during a switchover.
@@ -2439,10 +2439,10 @@ func (cluster *Cluster) GetMaxStopDelay() int32 {
 	return 1800
 }
 
-// GetSmartStopDelay is used to compute the timeout of smart shutdown by the formula `stopDelay -  smartStopDelay`
-func (cluster *Cluster) GetSmartStopDelay() int32 {
-	if cluster.Spec.SmartStopDelay > 0 {
-		return cluster.Spec.SmartStopDelay
+// GetSmartShutdownTimeout is used to ensure that smart shutdown timeout is a positive integer
+func (cluster *Cluster) GetSmartShutdownTimeout() int32 {
+	if cluster.Spec.SmartShutdownTimeout > 0 {
+		return cluster.Spec.SmartShutdownTimeout
 	}
 	return 180
 }

--- a/config/crd/bases/postgresql.cnpg.io_clusters.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_clusters.yaml
@@ -3033,12 +3033,12 @@ spec:
                 required:
                 - metadata
                 type: object
-              smartStopDelay:
+              smartShutdownTimeout:
                 default: 180
-                description: The time in seconds that controls the window of time
-                  reserved for the smart shutdown of Postgres to complete. Please
-                  ensure that at least 15 seconds are left for the operator to request
-                  a fast shutdown of Postgres.
+                description: 'The time in seconds that controls the window of time
+                  reserved for the smart shutdown of Postgres to complete. Make sure
+                  you reserve enough time for the operator to request a fast shutdown
+                  of Postgres (that is: `stopDelay` - `smartShutdownTimeout`).'
                 format: int32
                 type: integer
               startDelay:

--- a/docs/src/cloudnative-pg.v1.md
+++ b/docs/src/cloudnative-pg.v1.md
@@ -1495,12 +1495,13 @@ ceiling(startDelay / 10).</p>
 gracefully shutdown (default 1800)</p>
 </td>
 </tr>
-<tr><td><code>smartStopDelay</code><br/>
+<tr><td><code>smartShutdownTimeout</code><br/>
 <i>int32</i>
 </td>
 <td>
    <p>The time in seconds that controls the window of time reserved for the smart shutdown of Postgres to complete.
-Make sure you reserve enough time for the operator to request a fast shutdown of Postgres.</p>
+Make sure you reserve enough time for the operator to request a fast shutdown of Postgres
+(that is: <code>stopDelay</code> - <code>smartShutdownTimeout</code>).</p>
 </td>
 </tr>
 <tr><td><code>switchoverDelay</code><br/>

--- a/docs/src/fencing.md
+++ b/docs/src/fencing.md
@@ -78,7 +78,7 @@ kubectl cnpg fencing off cluster-example "*"
 
 Once an instance is set for fencing, the procedure to shut down the
 `postmaster` process is initiated. This consists of an initial smart shutdown
-with a timeout set to `.spec.smartStopDelay`, followed by a fast shutdown if
+with a timeout set to `.spec.smartShutdownTimeout`, followed by a fast shutdown if
 required for up to `.spec.stopDelay` seconds. Then:
 
 - the Pod will be kept alive

--- a/docs/src/instance_manager.md
+++ b/docs/src/instance_manager.md
@@ -48,7 +48,7 @@ When a Pod running Postgres is deleted, either manually or by Kubernetes
 following a node drain operation, the kubelet will send a termination signal to the
 instance manager, and the instance manager will take care of shutting down
 PostgreSQL in an appropriate way.
-The `.spec.smartStopDelay` and `.spec.stopDelay` options, expressed in seconds,
+The `.spec.smartShutdownTimeout` and `.spec.stopDelay` options, expressed in seconds,
 control the amount of time given to PostgreSQL to shut down. The values default
 to 180 and 1800 seconds, respectively.
 
@@ -56,7 +56,7 @@ The shutdown procedure is composed of two steps:
 
 1. The instance manager requests a **smart** shut down, disallowing any
 new connection to PostgreSQL. This step will last for up to
-`.spec.smartStopDelay` seconds.
+`.spec.smartShutdownTimeout` seconds.
 
 2. If PostgreSQL is still up, the instance manager requests a **fast**
 shut down, terminating any existing connection and exiting promptly.

--- a/internal/management/controller/instance_controller.go
+++ b/internal/management/controller/instance_controller.go
@@ -889,7 +889,7 @@ func (r *InstanceReconciler) reconcileInstance(cluster *apiv1.Cluster) {
 	r.instance.PgCtlTimeoutForPromotion = cluster.GetPgCtlTimeoutForPromotion()
 	r.instance.MaxSwitchoverDelay = cluster.GetMaxSwitchoverDelay()
 	r.instance.MaxStopDelay = cluster.GetMaxStopDelay()
-	r.instance.SmartStopDelay = cluster.GetSmartStopDelay()
+	r.instance.SmartStopDelay = cluster.GetSmartShutdownTimeout()
 }
 
 func (r *InstanceReconciler) reconcileCheckWalArchiveFile(cluster *apiv1.Cluster) error {

--- a/pkg/management/postgres/instance.go
+++ b/pkg/management/postgres/instance.go
@@ -432,8 +432,8 @@ func (instance *Instance) TryShuttingDownSmartFast() error {
 
 	smartTimeout := instance.SmartStopDelay
 	if instance.MaxStopDelay <= instance.SmartStopDelay {
-		log.Warning("Ignoring smartStopDelay",
-			"smartStopDelay", instance.SmartStopDelay,
+		log.Warning("Ignoring maxStopDelay <= smartShutdownTimeout",
+			"smartShutdownTimeout", instance.SmartStopDelay,
 			"maxStopDelay", instance.MaxStopDelay,
 		)
 		smartTimeout = 0

--- a/tests/e2e/fixtures/fastfailover/cluster-fast-failover-with-repl-slots.yaml.template
+++ b/tests/e2e/fixtures/fastfailover/cluster-fast-failover-with-repl-slots.yaml.template
@@ -6,7 +6,7 @@ metadata:
 spec:
   instances: 3
   stopDelay: 210
-  smartStopDelay: 180
+  smartShutdownTimeout: 180
   postgresql:
     parameters:
       log_checkpoints: "on"

--- a/tests/e2e/fixtures/fastfailover/cluster-fast-failover.yaml.template
+++ b/tests/e2e/fixtures/fastfailover/cluster-fast-failover.yaml.template
@@ -6,7 +6,7 @@ metadata:
 spec:
   instances: 3
   stopDelay: 210
-  smartStopDelay: 180
+  smartShutdownTimeout: 180
   postgresql:
     parameters:
       log_checkpoints: "on"

--- a/tests/e2e/fixtures/fastfailover/cluster-syncreplicas-fast-failover.yaml.template
+++ b/tests/e2e/fixtures/fastfailover/cluster-syncreplicas-fast-failover.yaml.template
@@ -6,7 +6,7 @@ metadata:
 spec:
   instances: 3
   stopDelay: 210
-  smartStopDelay: 180
+  smartShutdownTimeout: 180
   minSyncReplicas: 1
   maxSyncReplicas: 2
   postgresql:


### PR DESCRIPTION
Rename the newly introduced `smartStopDelay` parameter (never released)
into a clearer one called `smartShutdownTimeout`, which exactly describes
the intention of that option: control for how long we wait for PostgreSQL
to execute a graceful shutdown when requested, before trying a fast one
(during shutdown or fencing, for example).

Closes #3027 