### PR TITLE
feat: allow user to reduce the storage size that is equal to the PVC

### DIFF
--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -862,6 +862,8 @@ const (
 	ConditionBackup ClusterConditionType = "LastBackupSucceeded"
 	// ConditionClusterReady represents whether a cluster is Ready
 	ConditionClusterReady ClusterConditionType = "Ready"
+	// ConditionPVCResize represents whether a PVC resize is successful
+	ConditionPVCResize ClusterConditionType = "PVCResizeSucceeded"
 )
 
 // A Condition that can be used to communicate the Backup progress
@@ -933,6 +935,14 @@ const (
 	// ConditionReasonContinuousArchivingFailing means that the condition has changed because
 	// the WAL archiving is not working correctly
 	ConditionReasonContinuousArchivingFailing ConditionReason = "ContinuousArchivingFailing"
+
+	// ConditionReasonPVCResizeSuccess means that the condition changed because the
+	// PVC resizing was working correctly
+	ConditionReasonPVCResizeSuccess ConditionReason = "PVCResizeSuccess"
+
+	// ConditionReasonPVCResizeFailing means that the condition has changed because
+	// the PVC resizing is not working correctly
+	ConditionReasonPVCResizeFailing ConditionReason = "PVCResizeFailing"
 
 	// ClusterReady means that the condition changed because the cluster is ready and working properly
 	ClusterReady ConditionReason = "ClusterIsReady"

--- a/api/v1/cluster_webhook.go
+++ b/api/v1/cluster_webhook.go
@@ -371,7 +371,6 @@ func (r *Cluster) ValidateChanges(old *Cluster) (allErrs field.ErrorList) {
 	validations := []validationFunc{
 		r.validateImageChange,
 		r.validateConfigurationChange,
-		r.validateStorageChange,
 		r.validateWalStorageChange,
 		r.validateTablespacesChange,
 		r.validateReplicaModeChange,
@@ -1520,15 +1519,6 @@ func validateStorageConfigurationSize(
 	return result
 }
 
-// Validate a change in the storage
-func (r *Cluster) validateStorageChange(old *Cluster) field.ErrorList {
-	return validateStorageConfigurationChange(
-		field.NewPath("spec", "storage"),
-		old.Spec.StorageConfiguration,
-		r.Spec.StorageConfiguration,
-	)
-}
-
 func (r *Cluster) validateWalStorageChange(old *Cluster) field.ErrorList {
 	if old.Spec.WalStorage == nil {
 		return nil
@@ -1543,11 +1533,7 @@ func (r *Cluster) validateWalStorageChange(old *Cluster) field.ErrorList {
 		}
 	}
 
-	return validateStorageConfigurationChange(
-		field.NewPath("spec", "walStorage"),
-		*old.Spec.WalStorage,
-		*r.Spec.WalStorage,
-	)
+	return nil
 }
 
 // validateTablespacesChange checks that no tablespaces have been deleted, and that

--- a/api/v1/cluster_webhook_test.go
+++ b/api/v1/cluster_webhook_test.go
@@ -1499,64 +1499,6 @@ var _ = Describe("Number of synchronous replicas", func() {
 	})
 })
 
-var _ = Describe("storage configuration validation", func() {
-	It("complains if the size is being reduced", func() {
-		clusterOld := Cluster{
-			Spec: ClusterSpec{
-				StorageConfiguration: StorageConfiguration{
-					Size: "1G",
-				},
-			},
-		}
-
-		clusterNew := Cluster{
-			Spec: ClusterSpec{
-				StorageConfiguration: StorageConfiguration{
-					Size: "512M",
-				},
-			},
-		}
-
-		Expect(clusterNew.validateStorageChange(&clusterOld)).ToNot(BeEmpty())
-	})
-
-	It("does not complain if nothing has been changed", func() {
-		one := "one"
-		clusterOld := Cluster{
-			Spec: ClusterSpec{
-				StorageConfiguration: StorageConfiguration{
-					Size:         "1G",
-					StorageClass: &one,
-				},
-			},
-		}
-
-		clusterNew := clusterOld.DeepCopy()
-
-		Expect(clusterNew.validateStorageChange(&clusterOld)).To(BeEmpty())
-	})
-
-	It("works fine is the size is being enlarged", func() {
-		clusterOld := Cluster{
-			Spec: ClusterSpec{
-				StorageConfiguration: StorageConfiguration{
-					Size: "8G",
-				},
-			},
-		}
-
-		clusterNew := Cluster{
-			Spec: ClusterSpec{
-				StorageConfiguration: StorageConfiguration{
-					Size: "10G",
-				},
-			},
-		}
-
-		Expect(clusterNew.validateStorageChange(&clusterOld)).To(BeEmpty())
-	})
-})
-
 var _ = Describe("Cluster name validation", func() {
 	It("should be a valid DNS label", func() {
 		cluster := Cluster{

--- a/docs/src/troubleshooting.md
+++ b/docs/src/troubleshooting.md
@@ -455,6 +455,7 @@ event to occur instead of relying on the overall cluster health state. Available
 - LastBackupSucceeded
 - ContinuousArchiving
 - Ready
+- PVCResizeSucceeded
 
 `LastBackupSucceeded` is reporting the status of the latest backup. If set to `True` the
 last backup has been taken correctly, it is set to `False` otherwise.
@@ -465,6 +466,8 @@ last WAL archival process has been terminated correctly, it is set to `False` ot
 `Ready` is `True` when the cluster has the number of instances specified by the user
 and the primary instance is ready. This condition can be used in scripts to wait for
 the cluster to be created.
+
+`PVCResizeSucceeded` is `True` when the PVC resize operation has been completed successfully.
 
 ### How to wait for a particular condition
 
@@ -482,6 +485,12 @@ $ kubectl wait --for=condition=ContinuousArchiving cluster/<CLUSTER-NAME> -n <NA
 ```bash
 $ kubectl wait --for=condition=Ready cluster/<CLUSTER-NAME> -n <NAMESPACE>
 ```
+
+- PVCResize
+```bash 
+$ kubectl wait --for=condition=PVCResizeSucceeded cluster/<CLUSTER-NAME> -n <NAMESPACE>
+```
+
 Below is a snippet of a `cluster.status` that contains a failing condition.
 
 ```bash
@@ -506,8 +515,12 @@ $ kubectl get cluster/<cluster-name> -o yaml
       reason: ClusterIsNotReady
       status: "False"
       type: Ready
-
-
+      
+    - message: 'persistentvolumeclaims "<cluster>-1" is forbidden: only dynamically provisioned pvc can be resized and the storageclass that provisions the pvc must support resize'
+      reason: PVCResizeFailed
+      status: "False"
+      type: PVCResizeSucceeded
+      
 ```
 
 ## Networking


### PR DESCRIPTION
Closes #2829 

As the operator lacks sufficient information to determine whether a PVC resize is valid, the following changes have been made:

Removed validation of changes to storage.

Introduced a new type of condition called `PVCResizeSucceeded` to record the resize result
