### PR TITLE
ci: improve devcontainer environment

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -21,5 +21,5 @@
   "mounts":["type=bind,source=/lib/modules,target=/lib/modules"],
 
   // Enable kubectl short alias with completion
-  "postCreateCommand": "echo 'alias k=kubectl; complete -F __start_kubectl k' >> ~/.bash_aliases"
+  "postCreateCommand": "echo 'alias k=kubectl; complete -F __start_kubectl k' >> ~/.bash_aliases; git clone https://github.com/magicmonty/bash-git-prompt.git ~/.bash-git-prompt --depth=1; echo 'if [ -f \"$HOME/.bash-git-prompt/gitprompt.sh\" ]; then . \"$HOME/.bash-git-prompt/gitprompt.sh\"; fi' >> ~/.bashrc"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "image": "mcr.microsoft.com/devcontainers/go:1",
+  "image": "mcr.microsoft.com/devcontainers/go:1-bullseye",
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2": {},
     "ghcr.io/rio/features/k3d:1": {},


### PR DESCRIPTION
Improve the devcontainer environment by adding bash-git-prompt
and using bullseye instead of bookworm, which doesn't have 
the right support for Python and doesn't work on ARM64.
