### PR TITLE
ci: raise goreleaser cnpg plugin build timeout

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -402,7 +402,7 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: build --skip-validate --rm-dist --id kubectl-cnpg
+          args: build --skip-validate --rm-dist --id kubectl-cnpg --timeout 60m
         env:
           DATE: ${{ env.DATE }}
           COMMIT: ${{ env.COMMIT }}


### PR DESCRIPTION
should fix this issue in the CI/CD: https://github.com/cloudnative-pg/cloudnative-pg/commit/6b41d6cedda5f79580fe948fee46996cf90ae442/checks