### PR TITLE
chore: use `contextLogger` in the instance when possible

### DIFF
--- a/internal/cmd/manager/instance/run/lifecycle/run.go
+++ b/internal/cmd/manager/instance/run/lifecycle/run.go
@@ -56,8 +56,8 @@ func (i *PostgresLifecycle) runPostgresAndWait(ctx context.Context) <-chan error
 			return
 		}
 
-		i.instance.LogPgControldata("postmaster start up")
-		defer i.instance.LogPgControldata("postmaster has exited")
+		i.instance.LogPgControldata(ctx, "postmaster start up")
+		defer i.instance.LogPgControldata(ctx, "postmaster has exited")
 
 		streamingCmd, err := i.instance.Run()
 		if err != nil {

--- a/internal/cmd/manager/instance/run/lifecycle/run.go
+++ b/internal/cmd/manager/instance/run/lifecycle/run.go
@@ -52,7 +52,7 @@ func (i *PostgresLifecycle) runPostgresAndWait(ctx context.Context) <-chan error
 
 		// if the instance is marked as fenced we don't need to start it at all
 		if i.instance.IsFenced() {
-			log.Info("Instance is fenced, won't start postgres right now")
+			contextLogger.Info("Instance is fenced, won't start postgres right now")
 			return
 		}
 
@@ -67,7 +67,7 @@ func (i *PostgresLifecycle) runPostgresAndWait(ctx context.Context) <-chan error
 		}
 
 		// once the database will be up we'll connect and setup everything required
-		err = configureInstancePermissions(i.instance)
+		err = configureInstancePermissions(ctx, i.instance)
 		if err != nil {
 			contextLogger.Error(err, "Unable to update PostgreSQL roles and permissions")
 			errChan <- err
@@ -86,7 +86,8 @@ func (i *PostgresLifecycle) runPostgresAndWait(ctx context.Context) <-chan error
 
 // ConfigureInstancePermissions creates the expected users and databases in a new
 // PostgreSQL instance
-func configureInstancePermissions(instance *postgres.Instance) error {
+func configureInstancePermissions(ctx context.Context, instance *postgres.Instance) error {
+	contextLogger := log.FromContext(ctx)
 	var err error
 	isPrimary, err := instance.IsPrimary()
 	if err != nil {
@@ -106,14 +107,14 @@ func configureInstancePermissions(instance *postgres.Instance) error {
 		return fmt.Errorf("while getting a connection to the instance: %w", err)
 	}
 
-	log.Debug("Verifying connection to DB")
+	contextLogger.Debug("Verifying connection to DB")
 	err = instance.WaitForSuperuserConnectionAvailable()
 	if err != nil {
-		log.Error(err, "DB not available")
+		contextLogger.Error(err, "DB not available")
 		os.Exit(1)
 	}
 
-	log.Debug("Validating DB configuration")
+	contextLogger.Debug("Validating DB configuration")
 
 	// A transaction is required to temporarily disable synchronous replication
 	tx, err := db.Begin()

--- a/internal/management/controller/instance_controller.go
+++ b/internal/management/controller/instance_controller.go
@@ -192,7 +192,7 @@ func (r *InstanceReconciler) Reconcile(
 
 	if reloadNeeded && !restarted {
 		contextLogger.Info("reloading the instance")
-		if err = r.instance.Reload(); err != nil {
+		if err = r.instance.Reload(ctx); err != nil {
 			return reconcile.Result{}, fmt.Errorf("while reloading the instance: %w", err)
 		}
 		if err = r.processConfigReloadAndManageRestart(ctx, cluster); err != nil {
@@ -1107,7 +1107,7 @@ func (r *InstanceReconciler) handlePromotion(ctx context.Context, cluster *apiv1
 
 	contextLogger.Info("I'm the target primary, applying WALs and promoting my instance")
 	// I must promote my instance here
-	err := r.instance.PromoteAndWait()
+	err := r.instance.PromoteAndWait(ctx)
 	if err != nil {
 		return fmt.Errorf("error promoting instance: %w", err)
 	}

--- a/internal/management/controller/instance_startup.go
+++ b/internal/management/controller/instance_startup.go
@@ -152,9 +152,7 @@ func (r *InstanceReconciler) refreshBarmanEndpointCA(ctx context.Context, cluste
 // verifyPgDataCoherenceForPrimary will abort the execution if the current server is a primary
 // one from the PGDATA viewpoint, but is not classified as the target nor the
 // current primary
-func (r *InstanceReconciler) verifyPgDataCoherenceForPrimary(
-	ctx context.Context, cluster *apiv1.Cluster,
-) error {
+func (r *InstanceReconciler) verifyPgDataCoherenceForPrimary(ctx context.Context, cluster *apiv1.Cluster) error {
 	isPrimary, err := r.instance.IsPrimary()
 	if err != nil {
 		return err
@@ -232,7 +230,7 @@ func (r *InstanceReconciler) verifyPgDataCoherenceForPrimary(
 		// The only way to check if we really need to start it up before
 		// invoking pg_rewind is to try using pg_rewind and, on failures,
 		// retrying after having started up the instance.
-		err = r.instance.Rewind(pgMajorVersion)
+		err = r.instance.Rewind(ctx, pgMajorVersion)
 		if err != nil {
 			contextLogger.Info(
 				"pg_rewind failed, starting the server to complete the crash recovery",
@@ -247,14 +245,14 @@ func (r *InstanceReconciler) verifyPgDataCoherenceForPrimary(
 			}
 
 			// Then let's go back to the point of the new primary
-			err = r.instance.Rewind(pgMajorVersion)
+			err = r.instance.Rewind(ctx, pgMajorVersion)
 			if err != nil {
 				return err
 			}
 		}
 
 		// Now I can demote myself
-		return r.instance.Demote(cluster)
+		return r.instance.Demote(ctx, cluster)
 	}
 }
 

--- a/pkg/management/postgres/instance.go
+++ b/pkg/management/postgres/instance.go
@@ -427,12 +427,14 @@ func (instance *Instance) Shutdown(options ShutdownOptions) error {
 // TryShuttingDownSmartFast first tries to shut down the instance with mode smart,
 // then in case of failure or the given timeout expiration,
 // it will issue a fast shutdown request and wait for it to complete.
-func (instance *Instance) TryShuttingDownSmartFast() error {
+func (instance *Instance) TryShuttingDownSmartFast(ctx context.Context) error {
+	contextLogger := log.FromContext(ctx)
+
 	var err error
 
 	smartTimeout := instance.SmartStopDelay
 	if instance.MaxStopDelay <= instance.SmartStopDelay {
-		log.Warning("Ignoring maxStopDelay <= smartShutdownTimeout",
+		contextLogger.Warning("Ignoring maxStopDelay <= smartShutdownTimeout",
 			"smartShutdownTimeout", instance.SmartStopDelay,
 			"maxStopDelay", instance.MaxStopDelay,
 		)
@@ -440,30 +442,30 @@ func (instance *Instance) TryShuttingDownSmartFast() error {
 	}
 
 	if smartTimeout > 0 {
-		log.Info("Requesting smart shutdown of the PostgreSQL instance")
+		contextLogger.Info("Requesting smart shutdown of the PostgreSQL instance")
 		err = instance.Shutdown(ShutdownOptions{
 			Mode:    ShutdownModeSmart,
 			Wait:    true,
 			Timeout: &smartTimeout,
 		})
 		if err != nil {
-			log.Warning("Error while handling the smart shutdown request", "err", err)
+			contextLogger.Warning("Error while handling the smart shutdown request", "err", err)
 		}
 	}
 
 	if err != nil || smartTimeout == 0 {
-		log.Info("Requesting fast shutdown of the PostgreSQL instance")
+		contextLogger.Info("Requesting fast shutdown of the PostgreSQL instance")
 		err = instance.Shutdown(ShutdownOptions{
 			Mode: ShutdownModeFast,
 			Wait: true,
 		})
 	}
 	if err != nil {
-		log.Error(err, "Error while shutting down the PostgreSQL instance")
+		contextLogger.Error(err, "Error while shutting down the PostgreSQL instance")
 		return err
 	}
 
-	log.Info("PostgreSQL instance shut down")
+	contextLogger.Info("PostgreSQL instance shut down")
 	return nil
 }
 
@@ -471,8 +473,10 @@ func (instance *Instance) TryShuttingDownSmartFast() error {
 // then in case of failure or the given timeout expiration,
 // it will issue an immediate shutdown request and wait for it to complete.
 // N.B. immediate shutdown can cause data loss.
-func (instance *Instance) TryShuttingDownFastImmediate() error {
-	log.Info("Requesting fast shutdown of the PostgreSQL instance")
+func (instance *Instance) TryShuttingDownFastImmediate(ctx context.Context) error {
+	contextLogger := log.FromContext(ctx)
+
+	contextLogger.Info("Requesting fast shutdown of the PostgreSQL instance")
 	err := instance.Shutdown(ShutdownOptions{
 		Mode:    ShutdownModeFast,
 		Wait:    true,
@@ -480,7 +484,7 @@ func (instance *Instance) TryShuttingDownFastImmediate() error {
 	})
 	var exitError *exec.ExitError
 	if errors.As(err, &exitError) {
-		log.Info("Graceful shutdown failed. Issuing immediate shutdown",
+		contextLogger.Info("Graceful shutdown failed. Issuing immediate shutdown",
 			"exitCode", exitError.ExitCode())
 		err = instance.Shutdown(ShutdownOptions{
 			Mode: ShutdownModeImmediate,
@@ -504,14 +508,16 @@ func (instance *Instance) isStatusRunning() bool {
 }
 
 // Reload makes a certain active instance reload the configuration
-func (instance *Instance) Reload() error {
+func (instance *Instance) Reload(ctx context.Context) error {
+	contextLogger := log.FromContext(ctx)
+
 	options := []string{
 		"-D",
 		instance.PgData,
 		"reload",
 	}
 
-	log.Info("Requesting configuration reload",
+	contextLogger.Info("Requesting configuration reload",
 		"pgdata", instance.PgData)
 
 	pgCtlCmd := exec.Command(pgCtlName, options...) // #nosec
@@ -686,8 +692,10 @@ func (instance *Instance) IsPrimary() (bool, error) {
 }
 
 // Demote demotes an existing PostgreSQL instance
-func (instance *Instance) Demote(cluster *apiv1.Cluster) error {
-	log.Info("Demoting instance", "pgpdata", instance.PgData)
+func (instance *Instance) Demote(ctx context.Context, cluster *apiv1.Cluster) error {
+	contextLogger := log.FromContext(ctx)
+
+	contextLogger.Info("Demoting instance", "pgpdata", instance.PgData)
 	slotName := cluster.GetSlotNameFromInstanceName(instance.PodName)
 	_, err := UpdateReplicaConfiguration(instance.PgData, instance.GetPrimaryConnInfo(), slotName)
 	return err
@@ -889,14 +897,16 @@ func (instance *Instance) removePgControlFileBackup() error {
 
 // Rewind uses pg_rewind to align this data directory with the contents of the primary node.
 // If postgres major version is >= 13, add "--restore-target-wal" option
-func (instance *Instance) Rewind(postgresMajorVersion int) error {
+func (instance *Instance) Rewind(ctx context.Context, postgresMajorVersion int) error {
+	contextLogger := log.FromContext(ctx)
+
 	// Signal the liveness probe that we are running pg_rewind before starting postgres
 	instance.PgRewindIsRunning = true
 	defer func() {
 		instance.PgRewindIsRunning = false
 	}()
 
-	instance.LogPgControldata("before pg_rewind")
+	instance.LogPgControldata(ctx, "before pg_rewind")
 
 	primaryConnInfo := instance.GetPrimaryConnInfo()
 	options := []string{
@@ -917,7 +927,7 @@ func (instance *Instance) Rewind(postgresMajorVersion int) error {
 		return err
 	}
 
-	log.Info("Starting up pg_rewind",
+	contextLogger.Info("Starting up pg_rewind",
 		"pgdata", instance.PgData,
 		"options", options)
 
@@ -925,7 +935,7 @@ func (instance *Instance) Rewind(postgresMajorVersion int) error {
 	pgRewindCmd.Env = instance.Env
 	err = execlog.RunStreaming(pgRewindCmd, pgRewindName)
 	if err != nil {
-		log.Error(err, "Failed to execute pg_rewind", "options", options)
+		contextLogger.Error(err, "Failed to execute pg_rewind", "options", options)
 		return fmt.Errorf("error executing pg_rewind: %w", err)
 	}
 
@@ -988,13 +998,15 @@ func (instance *Instance) buildPgControldataCommand() *exec.Cmd {
 }
 
 // LogPgControldata logs the content of PostgreSQL control data, for debugging and tracing
-func (instance *Instance) LogPgControldata(reason string) {
-	log.Info("Extracting pg_controldata information", "reason", reason)
+func (instance *Instance) LogPgControldata(ctx context.Context, reason string) {
+	contextLogger := log.FromContext(ctx)
+
+	contextLogger.Info("Extracting pg_controldata information", "reason", reason)
 
 	pgControlDataCmd := instance.buildPgControldataCommand()
 	err := execlog.RunBuffering(pgControlDataCmd, pgControlDataName)
 	if err != nil {
-		log.Error(err, "Error printing the control information of this PostgreSQL instance")
+		contextLogger.Error(err, "Error printing the control information of this PostgreSQL instance")
 	}
 }
 
@@ -1120,32 +1132,35 @@ func (instance *Instance) GetPrimaryConnInfo() string {
 // HandleInstanceCommandRequests execute a command requested by the reconciliation
 // loop.
 func (instance *Instance) HandleInstanceCommandRequests(
+	ctx context.Context,
 	req InstanceCommand,
 ) (restartNeeded bool, err error) {
+	contextLogger := log.FromContext(ctx)
+
 	if instance.IsFenced() {
 		switch req {
 		case fenceOff:
-			log.Info("Fence lifting request received, will proceed with restarting the instance if needed")
+			contextLogger.Info("Fence lifting request received, will proceed with restarting the instance if needed")
 			instance.SetFencing(false)
 			return true, nil
 		default:
-			log.Warning("Received request while fencing, ignored", "req", req)
+			contextLogger.Warning("Received request while fencing, ignored", "req", req)
 			return false, nil
 		}
 	}
 	switch req {
 	case fenceOn:
-		log.Info("Fencing request received, will proceed shutting down the instance")
+		contextLogger.Info("Fencing request received, will proceed shutting down the instance")
 		instance.SetFencing(true)
-		if err := instance.TryShuttingDownFastImmediate(); err != nil {
+		if err := instance.TryShuttingDownFastImmediate(ctx); err != nil {
 			return false, fmt.Errorf("while shutting down the instance to fence it: %w", err)
 		}
 		return false, nil
 	case restartSmartFast:
-		return true, instance.TryShuttingDownSmartFast()
+		return true, instance.TryShuttingDownSmartFast(ctx)
 	case shutDownFastImmediate:
-		if err := instance.TryShuttingDownFastImmediate(); err != nil {
-			log.Error(err, "error shutting down instance, proceeding")
+		if err := instance.TryShuttingDownFastImmediate(ctx); err != nil {
+			contextLogger.Error(err, "error shutting down instance, proceeding")
 		}
 		return false, nil
 	default:

--- a/pkg/management/postgres/instance_test.go
+++ b/pkg/management/postgres/instance_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package postgres
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -72,8 +73,8 @@ var _ = Describe("testing primary instance methods", Ordered, func() {
 		Expect(isPrimary).To(BeFalse())
 	})
 
-	It("should properly demote a primary", func() {
-		err := instance.Demote(&apiv1.Cluster{})
+	It("should properly demote a primary", func(ctx context.Context) {
+		err := instance.Demote(ctx, &apiv1.Cluster{})
 		Expect(err).ToNot(HaveOccurred())
 
 		assertFileExists(signalPath, "standby.signal")


### PR DESCRIPTION
Closes #3064 
