### PR TITLE
fix: `schemaOnly` import doesn't need a default value

### DIFF
--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -1300,14 +1300,14 @@ const (
 // Import contains the configuration to init a database from a logic snapshot of an externalCluster
 type Import struct {
 	// The source of the import
-	Source ImportSource `json:"source"`
+	Source ImportSource `json:"source,omitempty"`
 
 	// The import type. Can be `microservice` or `monolith`.
 	// +kubebuilder:validation:Enum=microservice;monolith
-	Type SnapshotType `json:"type"`
+	Type SnapshotType `json:"type,omitempty"`
 
 	// The databases to import
-	Databases []string `json:"databases"`
+	Databases []string `json:"databases,omitempty"`
 
 	// The roles to import
 	// +optional
@@ -1321,7 +1321,6 @@ type Import struct {
 
 	// When set to true, only the `pre-data` and `post-data` sections of
 	// `pg_restore` are invoked, avoiding data import. Default: `false`.
-	// +kubebuilder:default:=false
 	// +optional
 	SchemaOnly bool `json:"schemaOnly,omitempty"`
 }

--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -1300,14 +1300,14 @@ const (
 // Import contains the configuration to init a database from a logic snapshot of an externalCluster
 type Import struct {
 	// The source of the import
-	Source ImportSource `json:"source,omitempty"`
+	Source ImportSource `json:"source"`
 
 	// The import type. Can be `microservice` or `monolith`.
 	// +kubebuilder:validation:Enum=microservice;monolith
-	Type SnapshotType `json:"type,omitempty"`
+	Type SnapshotType `json:"type"`
 
 	// The databases to import
-	Databases []string `json:"databases,omitempty"`
+	Databases []string `json:"databases"`
 
 	// The roles to import
 	// +optional

--- a/config/crd/bases/postgresql.cnpg.io_clusters.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_clusters.yaml
@@ -1320,7 +1320,6 @@ spec:
                               type: string
                             type: array
                           schemaOnly:
-                            default: false
                             description: 'When set to true, only the `pre-data` and
                               `post-data` sections of `pg_restore` are invoked, avoiding
                               data import. Default: `false`.'
@@ -1342,10 +1341,6 @@ spec:
                             - microservice
                             - monolith
                             type: string
-                        required:
-                        - databases
-                        - source
-                        - type
                         type: object
                       localeCType:
                         description: The value to be passed as option `--lc-ctype`

--- a/config/crd/bases/postgresql.cnpg.io_clusters.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_clusters.yaml
@@ -1341,6 +1341,10 @@ spec:
                             - microservice
                             - monolith
                             type: string
+                        required:
+                        - databases
+                        - source
+                        - type
                         type: object
                       localeCType:
                         description: The value to be passed as option `--lc-ctype`


### PR DESCRIPTION
Remove the default value for `.spec.bootstrap.import.schemaOnly`
to fix the UI in the OLM Cluster creation interface.

Closes #3106 