### PR TITLE
chore: add a new check `run-govulncheck`

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -148,6 +148,19 @@ jobs:
         run: |
           make go-mod-check
 
+  go-vulncheck:
+    name: Run govulncheck
+    needs:
+      - duplicate_runs
+      - change-triage
+    if: needs.duplicate_runs.outputs.should_skip != 'true'
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Run govulncheck
+        uses: golang/govulncheck-action@v1
+        with:
+          go-version-input: ${{ env.GOLANG_VERSION }}
+
   shellcheck:
     name: Run shellcheck linter
     needs:

--- a/Makefile
+++ b/Makefile
@@ -237,7 +237,10 @@ go-mod-check: ## Check if there's any dirty change after `go mod tidy`
 	go mod tidy ;\
 	git diff --exit-code go.mod go.sum
 
-checks: go-mod-check generate manifests apidoc fmt spellcheck wordlist-ordered woke vet lint ## Runs all the checks on the project.
+run-govulncheck: govulncheck ## Check if there's any vulnerability with the current Go version
+	govulncheck ./...
+
+checks: go-mod-check generate manifests apidoc fmt spellcheck wordlist-ordered woke vet lint run-govulncheck ## Runs all the checks on the project.
 
 ##@ Documentation
 
@@ -349,3 +352,7 @@ OPM=$(GOBIN)/opm
 else
 OPM=$(shell which opm)
 endif
+
+.PHONY: govulncheck
+govulncheck: ## Download and install govulncheck
+	go install golang.org/x/vuln/cmd/govulncheck@latest

--- a/Makefile
+++ b/Makefile
@@ -357,4 +357,3 @@ OPM=$(GOBIN)/opm
 else
 OPM=$(shell which opm)
 endif
-

--- a/Makefile
+++ b/Makefile
@@ -237,8 +237,8 @@ go-mod-check: ## Check if there's any dirty change after `go mod tidy`
 	go mod tidy ;\
 	git diff --exit-code go.mod go.sum
 
-run-govulncheck: govulncheck ## Check if there's any vulnerability with the current Go version
-	govulncheck ./...
+run-govulncheck: govulncheck ## Check if there's any known vulnerabilities with the currently installed Go modules
+	$(GOVULNCHECK) ./...
 
 checks: go-mod-check generate manifests apidoc fmt spellcheck wordlist-ordered woke vet lint run-govulncheck ## Runs all the checks on the project.
 
@@ -303,6 +303,11 @@ GO_RELEASER = $(LOCALBIN)/goreleaser
 go-releaser: ## Download go-releaser locally if necessary.
 	$(call go-install-tool,$(GO_RELEASER),github.com/goreleaser/goreleaser@$(GORELEASER_VERSION))
 
+.PHONY: govulncheck
+GOVULNCHECK = $(LOCALBIN)/govulncheck
+govulncheck: ## Download govulncheck locally if necessary.
+	$(call go-install-tool,$(GOVULNCHECK),golang.org/x/vuln/cmd/govulncheck@latest)
+
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
 # go-install-tool will 'go install' any package $2 and install it to $1.
 define go-install-tool
@@ -353,6 +358,3 @@ else
 OPM=$(shell which opm)
 endif
 
-.PHONY: govulncheck
-govulncheck: ## Download and install govulncheck
-	go install golang.org/x/vuln/cmd/govulncheck@latest


### PR DESCRIPTION
Adding this new check from https://go.dev/security/vuln/ allows to detect any vulnerability locally using the Go vulnerability database which is faster and will work locally integrated inside the checks list.

Closes #3126 