### PR TITLE
docs: provide a link to the list of CSI drivers

### DIFF
--- a/docs/src/backup.md
+++ b/docs/src/backup.md
@@ -44,6 +44,11 @@ On the other hand, CloudNativePG supports two ways to store physical base backup
     you take some time to familiarize with some basic concepts, like WAL archive,
     hot and cold backups.
 
+!!! Important
+    Please refer to the official Kubernetes documentation for a list of all
+    the supported [Container Storage Interface (CSI) drivers](https://kubernetes-csi.github.io/docs/drivers.html)
+    that provide snapshotting capabilities.
+
 ## WAL archive
 
 The WAL archive in PostgreSQL is at the heart of **continuous backup**, and it

--- a/docs/src/storage.md
+++ b/docs/src/storage.md
@@ -50,6 +50,11 @@ Since CloudNativePG supports volume snapshots for both backup and recovery,
 we recommend that you also consider this aspect when you choose your storage
 solution, especially if you manage very large databases.
 
+!!! Important
+    Please refer to the official Kubernetes documentation for a list of all
+    the supported [Container Storage Interface (CSI) drivers](https://kubernetes-csi.github.io/docs/drivers.html)
+    that provide snapshotting capabilities.
+
 ## Benchmarking CloudNativePG
 
 We recommend that you benchmark CloudNativePG in a controlled Kubernetes


### PR DESCRIPTION
Provide a link to the official Kubernetes documentation that lists the supported Container Storage Interface (CSI) drivers - showing which ones provide volume snapshotting capabilities.

Closes #3084