### PR TITLE
fix: avoid cluttering `VolumeSnapshots` with labels

### DIFF
--- a/tests/utils/storage.go
+++ b/tests/utils/storage.go
@@ -101,7 +101,7 @@ func SetSnapshotNameAsEnv(
 	}
 
 	for _, item := range snapshotList.Items {
-		switch utils.PVCRole(item.Labels[utils.PvcRoleLabelName]) {
+		switch utils.PVCRole(item.Annotations[utils.PvcRoleLabelName]) {
 		case utils.PVCRolePgData:
 			err := os.Setenv(dataSnapshotName, item.Name)
 			if err != nil {
@@ -114,7 +114,7 @@ func SetSnapshotNameAsEnv(
 			}
 		default:
 			return fmt.Errorf("unrecognized PVC snapshot role: %s, name: %s",
-				item.Labels[utils.PvcRoleLabelName],
+				item.Annotations[utils.PvcRoleLabelName],
 				item.Name,
 			)
 		}


### PR DESCRIPTION
This patch ensures we only add meaningful labels to the created `VolumeSnapshots` resources.
The non-meaningful values are moved inside the annotations map.

Closes #3148 
