### PR TITLE
perf: avoid allocations with `(*regexp.Regexp).MatchString`

### DIFF
--- a/pkg/management/postgres/webserver/metricserver/pg_collector.go
+++ b/pkg/management/postgres/webserver/metricserver/pg_collector.go
@@ -547,7 +547,7 @@ func getSynchronousStandbysNumber(db *sql.DB) (int, error) {
 	if err != nil || syncReplicasFromConfig == "" {
 		return 0, err
 	}
-	if !synchronousStandbyNamesRegex.Match([]byte(syncReplicasFromConfig)) {
+	if !synchronousStandbyNamesRegex.MatchString(syncReplicasFromConfig) {
 		return 0, fmt.Errorf("not matching synchronous standby names regex: %s", syncReplicasFromConfig)
 	}
 	return strconv.Atoi(synchronousStandbyNamesRegex.FindStringSubmatch(syncReplicasFromConfig)[1])

--- a/pkg/utils/conditions.go
+++ b/pkg/utils/conditions.go
@@ -27,5 +27,5 @@ var conditionReasonRegexp = regexp.MustCompile(`^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z
 // IsConditionReasonValid checks if a certain condition reason is valid or not given the
 // Kubernetes API requirements
 func IsConditionReasonValid(conditionReason string) bool {
-	return conditionReasonRegexp.Match([]byte(conditionReason))
+	return conditionReasonRegexp.MatchString(conditionReason)
 }


### PR DESCRIPTION
We should use `(*regexp.Regexp).MatchString` instead of `(*regexp.Regexp).Match([]byte(...))` when matching string to avoid unnecessary `[]byte` conversions and reduce allocations. Although the improvement is not significant, it is a one-line change for free performance.

Example benchmark:

```go
func BenchmarkMatch(b *testing.B) {
	for i := 0; i < b.N; i++ {
		if match := conditionReasonRegexp.Match([]byte("NewReplicaSetAvailable")); !match {
			b.Fail()
		}
	}
}

func BenchmarkMatchString(b *testing.B) {
	for i := 0; i < b.N; i++ {
		if match := conditionReasonRegexp.MatchString("NewReplicaSetAvailable"); !match {
			b.Fail()
		}
	}
}
```

Result:

```
goos: linux
goarch: amd64
pkg: github.com/cloudnative-pg/cloudnative-pg/pkg/utils cpu: AMD Ryzen 7 PRO 4750U with Radeon Graphics
BenchmarkMatch-16          	 1573154	       801.2 ns/op	      24 B/op	       1 allocs/op
BenchmarkMatchString-16    	 2706096	       414.1 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/cloudnative-pg/cloudnative-pg/pkg/utils	3.652s
```