### PR TITLE
chore: add OpenShift annotations to the bundle metadata

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,6 +140,8 @@ olm-bundle: manifests kustomize operator-sdk ## Build the bundle for OLM install
 	($(KUSTOMIZE) build "$${CONFIG_TMP_DIR}/config/olm-manifests") | \
 	sed -e "s@\$${CREATED_AT}@$$(LANG=C date -Iseconds -u)@g" | \
 	$(OPERATOR_SDK) generate bundle --verbose --overwrite --manifests --metadata --package cloudnative-pg --channels stable-v1 --use-image-digests --default-channel stable-v1 --version "${VERSION}" ; \
+	echo -e "\n  # OpenShift annotations." >> bundle/metadata/annotations.yaml ;\
+	echo -e "  com.redhat.openshift.versions: v4.11-v4.13" >> bundle/metadata/annotations.yaml ;\
 	DOCKER_BUILDKIT=1 docker build --push --no-cache -f bundle.Dockerfile -t ${BUNDLE_IMG} . ;\
 	export BUNDLE_IMG="${BUNDLE_IMG}"
 

--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ olm-bundle: manifests kustomize operator-sdk ## Build the bundle for OLM install
 	sed -e "s@\$${CREATED_AT}@$$(LANG=C date -Iseconds -u)@g" | \
 	$(OPERATOR_SDK) generate bundle --verbose --overwrite --manifests --metadata --package cloudnative-pg --channels stable-v1 --use-image-digests --default-channel stable-v1 --version "${VERSION}" ; \
 	echo -e "\n  # OpenShift annotations." >> bundle/metadata/annotations.yaml ;\
-	echo -e "  com.redhat.openshift.versions: v4.11-v4.13" >> bundle/metadata/annotations.yaml ;\
+	echo -e "  com.redhat.openshift.versions: v4.11-v4.14" >> bundle/metadata/annotations.yaml ;\
 	DOCKER_BUILDKIT=1 docker build --push --no-cache -f bundle.Dockerfile -t ${BUNDLE_IMG} . ;\
 	export BUNDLE_IMG="${BUNDLE_IMG}"
 

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ GORELEASER_VERSION ?= v1.21.2
 SPELLCHECK_VERSION ?= 0.34.0
 WOKE_VERSION ?= 0.19.0
 OPERATOR_SDK_VERSION ?= 1.31.0
+OPENSHIFT_VERSIONS ?= v4.11-v4.14
 ARCH ?= amd64
 
 export CONTROLLER_IMG
@@ -141,7 +142,7 @@ olm-bundle: manifests kustomize operator-sdk ## Build the bundle for OLM install
 	sed -e "s@\$${CREATED_AT}@$$(LANG=C date -Iseconds -u)@g" | \
 	$(OPERATOR_SDK) generate bundle --verbose --overwrite --manifests --metadata --package cloudnative-pg --channels stable-v1 --use-image-digests --default-channel stable-v1 --version "${VERSION}" ; \
 	echo -e "\n  # OpenShift annotations." >> bundle/metadata/annotations.yaml ;\
-	echo -e "  com.redhat.openshift.versions: v4.11-v4.14" >> bundle/metadata/annotations.yaml ;\
+	echo -e "  com.redhat.openshift.versions: $(OPENSHIFT_VERSIONS)" >> bundle/metadata/annotations.yaml ;\
 	DOCKER_BUILDKIT=1 docker build --push --no-cache -f bundle.Dockerfile -t ${BUNDLE_IMG} . ;\
 	export BUNDLE_IMG="${BUNDLE_IMG}"
 


### PR DESCRIPTION
Adding this allow users using OLM bundle from OperatorHub.io to use the bundle manually in their OpenShift cluster allowing a secure upgrade if needed.

Closes #3191 