### PR TITLE
fix: reduce fencing window for snapshot backups

### DIFF
--- a/api/v1/backup_types.go
+++ b/api/v1/backup_types.go
@@ -43,6 +43,14 @@ const (
 	// BackupPhaseRunning means that the backup is now running
 	BackupPhaseRunning = "running"
 
+	// BackupPhaseFinalizing means that a consistent backup have been
+	// taken and the operator is waiting for it to be ready to be
+	// used to restore a cluster.
+	// This phase is used for VolumeSnapshot backups, when a
+	// VolumeSnapshotContent have already been provisioned, but it is
+	// still now waiting for the `readyToUse` flag to be true.
+	BackupPhaseFinalizing = "finalizing"
+
 	// BackupPhaseCompleted means that the backup is now completed
 	BackupPhaseCompleted = "completed"
 
@@ -278,6 +286,12 @@ func (backupStatus *BackupStatus) SetAsFailed(
 	} else {
 		backupStatus.Error = ""
 	}
+}
+
+// SetAsFinalizing marks a certain backup as finalizing
+func (backupStatus *BackupStatus) SetAsFinalizing() {
+	backupStatus.Phase = BackupPhaseFinalizing
+	backupStatus.Error = ""
 }
 
 // SetAsCompleted marks a certain backup as completed

--- a/controllers/backup_controller.go
+++ b/controllers/backup_controller.go
@@ -332,6 +332,8 @@ func (r *BackupReconciler) reconcileSnapshotBackup(
 		return &ctrl.Result{}, nil
 	}
 
+	ctx = log.IntoContext(ctx, contextLogger.WithValues("targetPod", targetPod))
+
 	// Validate we don't have other running backups
 	var clusterBackups apiv1.BackupList
 	if err := r.List(

--- a/pkg/reconciler/backup/volumesnapshot/reconciler.go
+++ b/pkg/reconciler/backup/volumesnapshot/reconciler.go
@@ -141,13 +141,13 @@ func (se *Reconciler) Execute(
 	targetPod *corev1.Pod,
 	pvcs []corev1.PersistentVolumeClaim,
 ) (*ctrl.Result, error) {
+	if cluster.Spec.Backup == nil || cluster.Spec.Backup.VolumeSnapshot == nil {
+		return nil, fmt.Errorf("cannot execute a VolumeSnapshot on a cluster without configuration")
+	}
+
 	volumeSnapshots, err := getBackupVolumeSnapshots(ctx, se.cli, cluster.Namespace, backup.Name)
 	if err != nil {
 		return nil, err
-	}
-
-	if cluster.Spec.Backup == nil || cluster.Spec.Backup.VolumeSnapshot == nil {
-		return nil, fmt.Errorf("cannot execute a VolumeSnapshot on a cluster without configuration")
 	}
 
 	// Step 1: backup preparation.

--- a/pkg/reconciler/backup/volumesnapshot/reconciler.go
+++ b/pkg/reconciler/backup/volumesnapshot/reconciler.go
@@ -256,8 +256,9 @@ func (se *Reconciler) prepareSnapshotBackupStep(
 		}
 	case status.Phase == webserver.Starting:
 		return &ctrl.Result{RequeueAfter: 5 * time.Second}, nil
-		// TODO: the other phases should return error
 	}
+
+	// TODO: make only webserver.started return nil,nil. The other phases should return error
 
 	return nil, nil
 }

--- a/pkg/reconciler/backup/volumesnapshot/reconciler.go
+++ b/pkg/reconciler/backup/volumesnapshot/reconciler.go
@@ -132,7 +132,7 @@ func (se *Reconciler) enrichSnapshot(
 }
 
 // Execute the volume snapshot of the given cluster instance
-// TODO: remove the nolint
+// TODO: remove the nolint, make two implementations: cold and hot that implement the same execute interface
 // nolint: gocognit
 func (se *Reconciler) Execute(
 	ctx context.Context,
@@ -316,7 +316,7 @@ func (se *Reconciler) finalizeSnapshotBackupStep(
 
 	if err := postgres.PatchBackupStatusAndRetry(ctx, se.cli, backup); err != nil {
 		contextLogger.Error(err, "while patching the backup status (finalized backup)")
-		return &ctrl.Result{RequeueAfter: 1 * time.Second}, err
+		return nil, err
 	}
 
 	return nil, nil
@@ -657,10 +657,10 @@ func (se *Reconciler) waitSnapshotToBeProvisionedAndAnnotate(
 	contextLogger := log.FromContext(ctx)
 
 	info := parseVolumeSnapshotInfo(snapshot)
-	if info.Error != nil {
-		return nil, info.Error
+	if info.error != nil {
+		return nil, info.error
 	}
-	if !info.Provisioned {
+	if !info.provisioned {
 		contextLogger.Info(
 			"Waiting for VolumeSnapshot to be provisioned",
 			"volumeSnapshotName", snapshot.Name)
@@ -693,10 +693,10 @@ func (se *Reconciler) waitSnapshotToBeReady(
 	contextLogger := log.FromContext(ctx)
 
 	info := parseVolumeSnapshotInfo(snapshot)
-	if info.Error != nil {
-		return nil, info.Error
+	if info.error != nil {
+		return nil, info.error
 	}
-	if !info.Ready {
+	if !info.ready {
 		contextLogger.Info(
 			"Waiting for VolumeSnapshot to be ready to use",
 			"volumeSnapshotName", snapshot.Name,

--- a/pkg/reconciler/backup/volumesnapshot/resources.go
+++ b/pkg/reconciler/backup/volumesnapshot/resources.go
@@ -28,19 +28,19 @@ import (
 
 // volumeSnapshotInfo host information about a volume snapshot
 type volumeSnapshotInfo struct {
-	// Error contains the raised error when the volume snapshot terminated
+	// error contains the raised error when the volume snapshot terminated
 	// with a failure
-	Error error
+	error error
 
-	// Provisioned is true when the volume snapshot have been cut and
+	// provisioned is true when the volume snapshot have been cut and
 	// provisioned. When this is true, the volume snapshot may not still
 	// be ready to be used as a source.
 	// Some implementations copy the snapshot in a different storage area.
-	Provisioned bool
+	provisioned bool
 
-	// Ready is true when the volume snapshot is complete and ready to
+	// ready is true when the volume snapshot is complete and ready to
 	// be used as a source for a PVC.
-	Ready bool
+	ready bool
 }
 
 // volumeSnapshotError is raised when a volume snapshot failed with
@@ -106,17 +106,17 @@ func getBackupVolumeSnapshots(
 func parseVolumeSnapshotInfo(snapshot *storagesnapshotv1.VolumeSnapshot) volumeSnapshotInfo {
 	if snapshot.Status == nil {
 		return volumeSnapshotInfo{
-			Error:       nil,
-			Provisioned: false,
-			Ready:       false,
+			error:       nil,
+			provisioned: false,
+			ready:       false,
 		}
 	}
 
 	if snapshot.Status.Error != nil {
 		return volumeSnapshotInfo{
-			Provisioned: false,
-			Ready:       false,
-			Error: &volumeSnapshotError{
+			provisioned: false,
+			ready:       false,
+			error: &volumeSnapshotError{
 				InternalError: *snapshot.Status.Error,
 				Name:          snapshot.Name,
 				Namespace:     snapshot.Namespace,
@@ -129,9 +129,9 @@ func parseVolumeSnapshotInfo(snapshot *storagesnapshotv1.VolumeSnapshot) volumeS
 		snapshot.Status.CreationTime == nil {
 		// The snapshot have not yet been provisioned
 		return volumeSnapshotInfo{
-			Provisioned: false,
-			Ready:       false,
-			Error:       nil,
+			provisioned: false,
+			ready:       false,
+			error:       nil,
 		}
 	}
 
@@ -139,16 +139,16 @@ func parseVolumeSnapshotInfo(snapshot *storagesnapshotv1.VolumeSnapshot) volumeS
 		// This volume snapshot have been provisioned but it
 		// still not be ready to be used as a source
 		return volumeSnapshotInfo{
-			Error:       nil,
-			Provisioned: true,
-			Ready:       false,
+			error:       nil,
+			provisioned: true,
+			ready:       false,
 		}
 	}
 
 	// We're done!
 	return volumeSnapshotInfo{
-		Error:       nil,
-		Provisioned: true,
-		Ready:       true,
+		error:       nil,
+		provisioned: true,
+		ready:       true,
 	}
 }

--- a/pkg/reconciler/backup/volumesnapshot/resources_test.go
+++ b/pkg/reconciler/backup/volumesnapshot/resources_test.go
@@ -1,0 +1,166 @@
+/*
+Copyright The CloudNativePG Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package volumesnapshot
+
+import (
+	"errors"
+
+	storagesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("parseVolumeSnapshotInfo", func() {
+	It("should not fail when the VolumeSnapshot CR have not been handled by the External Snapshotter operator", func() {
+		info := parseVolumeSnapshotInfo(&storagesnapshotv1.VolumeSnapshot{})
+		Expect(info).To(BeEquivalentTo(volumeSnapshotInfo{
+			Error:       nil,
+			Provisioned: false,
+			Ready:       false,
+		}))
+	})
+
+	It("should gracefully handle snapshot errors", func() {
+		volumeSnapshot := &storagesnapshotv1.VolumeSnapshot{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "snapshot",
+				Namespace: "default",
+			},
+			Status: &storagesnapshotv1.VolumeSnapshotStatus{
+				Error: &storagesnapshotv1.VolumeSnapshotError{
+					Time:    ptr.To(metav1.Now()),
+					Message: nil,
+				},
+			},
+		}
+		info := parseVolumeSnapshotInfo(volumeSnapshot)
+
+		Expect(info.Error).To(HaveOccurred())
+		Expect(info.Ready).To(BeFalse())
+		Expect(info.Provisioned).To(BeFalse())
+
+		var err *volumeSnapshotError
+		Expect(errors.As(info.Error, &err)).To(BeTrue())
+		Expect(err.InternalError).To(BeEquivalentTo(*volumeSnapshot.Status.Error))
+		Expect(err.Name).To(BeEquivalentTo("snapshot"))
+		Expect(err.Namespace).To(BeEquivalentTo("default"))
+	})
+
+	When("BoundVolumeSnapshotContentName is nil", func() {
+		It("should detect that a VolumeSnapshot is not provisioned", func() {
+			volumeSnapshot := &storagesnapshotv1.VolumeSnapshot{
+				Status: &storagesnapshotv1.VolumeSnapshotStatus{
+					Error:                          nil,
+					BoundVolumeSnapshotContentName: nil,
+				},
+			}
+			info := parseVolumeSnapshotInfo(volumeSnapshot)
+			Expect(info.Provisioned).To(BeFalse())
+		})
+	})
+
+	When("BoundVolumeSnapshotContentName is not nil", func() {
+		It("should detect that a VolumeSnapshot is not provisioned", func() {
+			volumeSnapshot := &storagesnapshotv1.VolumeSnapshot{
+				Status: &storagesnapshotv1.VolumeSnapshotStatus{
+					ReadyToUse:                     ptr.To(false),
+					Error:                          nil,
+					BoundVolumeSnapshotContentName: ptr.To(""),
+				},
+			}
+			info := parseVolumeSnapshotInfo(volumeSnapshot)
+			Expect(info.Provisioned).To(BeFalse())
+			Expect(info.Ready).To(BeFalse())
+		})
+
+		It("should detect that a VolumeSnapshot is not provisioned", func() {
+			volumeSnapshot := &storagesnapshotv1.VolumeSnapshot{
+				Status: &storagesnapshotv1.VolumeSnapshotStatus{
+					ReadyToUse:                     ptr.To(false),
+					Error:                          nil,
+					BoundVolumeSnapshotContentName: ptr.To("content-name"),
+				},
+			}
+			info := parseVolumeSnapshotInfo(volumeSnapshot)
+			Expect(info.Provisioned).To(BeFalse())
+			Expect(info.Ready).To(BeFalse())
+		})
+
+		It("should detect that a VolumeSnapshot is provisioned", func() {
+			volumeSnapshot := &storagesnapshotv1.VolumeSnapshot{
+				Status: &storagesnapshotv1.VolumeSnapshotStatus{
+					ReadyToUse:                     ptr.To(false),
+					Error:                          nil,
+					BoundVolumeSnapshotContentName: ptr.To("content-name"),
+					CreationTime:                   ptr.To(metav1.Now()),
+				},
+			}
+			info := parseVolumeSnapshotInfo(volumeSnapshot)
+			Expect(info.Provisioned).To(BeTrue())
+			Expect(info.Ready).To(BeFalse())
+		})
+	})
+
+	When("ReadyToUse is nil", func() {
+		It("should detect that a VolumeSnapshot is not ready to use", func() {
+			volumeSnapshot := &storagesnapshotv1.VolumeSnapshot{
+				Status: &storagesnapshotv1.VolumeSnapshotStatus{
+					ReadyToUse:                     nil,
+					Error:                          nil,
+					BoundVolumeSnapshotContentName: ptr.To("content-name"),
+					CreationTime:                   ptr.To(metav1.Now()),
+				},
+			}
+			info := parseVolumeSnapshotInfo(volumeSnapshot)
+			Expect(info.Provisioned).To(BeTrue())
+			Expect(info.Ready).To(BeFalse())
+		})
+	})
+
+	When("ReadyToUse is not nil", func() {
+		It("should detect that a VolumeSnapshot is not ready to use", func() {
+			volumeSnapshot := &storagesnapshotv1.VolumeSnapshot{
+				Status: &storagesnapshotv1.VolumeSnapshotStatus{
+					ReadyToUse:                     ptr.To(false),
+					Error:                          nil,
+					BoundVolumeSnapshotContentName: ptr.To("content-name"),
+					CreationTime:                   ptr.To(metav1.Now()),
+				},
+			}
+			info := parseVolumeSnapshotInfo(volumeSnapshot)
+			Expect(info.Provisioned).To(BeTrue())
+			Expect(info.Ready).To(BeFalse())
+		})
+
+		It("should detect that a VolumeSnapshot is ready to use", func() {
+			volumeSnapshot := &storagesnapshotv1.VolumeSnapshot{
+				Status: &storagesnapshotv1.VolumeSnapshotStatus{
+					ReadyToUse:                     ptr.To(true),
+					Error:                          nil,
+					BoundVolumeSnapshotContentName: ptr.To("content-name"),
+					CreationTime:                   ptr.To(metav1.Now()),
+				},
+			}
+			info := parseVolumeSnapshotInfo(volumeSnapshot)
+			Expect(info.Provisioned).To(BeTrue())
+			Expect(info.Ready).To(BeTrue())
+		})
+	})
+})

--- a/pkg/reconciler/backup/volumesnapshot/resources_test.go
+++ b/pkg/reconciler/backup/volumesnapshot/resources_test.go
@@ -31,9 +31,9 @@ var _ = Describe("parseVolumeSnapshotInfo", func() {
 	It("should not fail when the VolumeSnapshot CR have not been handled by the External Snapshotter operator", func() {
 		info := parseVolumeSnapshotInfo(&storagesnapshotv1.VolumeSnapshot{})
 		Expect(info).To(BeEquivalentTo(volumeSnapshotInfo{
-			Error:       nil,
-			Provisioned: false,
-			Ready:       false,
+			error:       nil,
+			provisioned: false,
+			ready:       false,
 		}))
 	})
 
@@ -52,12 +52,12 @@ var _ = Describe("parseVolumeSnapshotInfo", func() {
 		}
 		info := parseVolumeSnapshotInfo(volumeSnapshot)
 
-		Expect(info.Error).To(HaveOccurred())
-		Expect(info.Ready).To(BeFalse())
-		Expect(info.Provisioned).To(BeFalse())
+		Expect(info.error).To(HaveOccurred())
+		Expect(info.ready).To(BeFalse())
+		Expect(info.provisioned).To(BeFalse())
 
 		var err *volumeSnapshotError
-		Expect(errors.As(info.Error, &err)).To(BeTrue())
+		Expect(errors.As(info.error, &err)).To(BeTrue())
 		Expect(err.InternalError).To(BeEquivalentTo(*volumeSnapshot.Status.Error))
 		Expect(err.Name).To(BeEquivalentTo("snapshot"))
 		Expect(err.Namespace).To(BeEquivalentTo("default"))
@@ -72,7 +72,7 @@ var _ = Describe("parseVolumeSnapshotInfo", func() {
 				},
 			}
 			info := parseVolumeSnapshotInfo(volumeSnapshot)
-			Expect(info.Provisioned).To(BeFalse())
+			Expect(info.provisioned).To(BeFalse())
 		})
 	})
 
@@ -86,8 +86,8 @@ var _ = Describe("parseVolumeSnapshotInfo", func() {
 				},
 			}
 			info := parseVolumeSnapshotInfo(volumeSnapshot)
-			Expect(info.Provisioned).To(BeFalse())
-			Expect(info.Ready).To(BeFalse())
+			Expect(info.provisioned).To(BeFalse())
+			Expect(info.ready).To(BeFalse())
 		})
 
 		It("should detect that a VolumeSnapshot is not provisioned", func() {
@@ -99,8 +99,8 @@ var _ = Describe("parseVolumeSnapshotInfo", func() {
 				},
 			}
 			info := parseVolumeSnapshotInfo(volumeSnapshot)
-			Expect(info.Provisioned).To(BeFalse())
-			Expect(info.Ready).To(BeFalse())
+			Expect(info.provisioned).To(BeFalse())
+			Expect(info.ready).To(BeFalse())
 		})
 
 		It("should detect that a VolumeSnapshot is provisioned", func() {
@@ -113,8 +113,8 @@ var _ = Describe("parseVolumeSnapshotInfo", func() {
 				},
 			}
 			info := parseVolumeSnapshotInfo(volumeSnapshot)
-			Expect(info.Provisioned).To(BeTrue())
-			Expect(info.Ready).To(BeFalse())
+			Expect(info.provisioned).To(BeTrue())
+			Expect(info.ready).To(BeFalse())
 		})
 	})
 
@@ -129,8 +129,8 @@ var _ = Describe("parseVolumeSnapshotInfo", func() {
 				},
 			}
 			info := parseVolumeSnapshotInfo(volumeSnapshot)
-			Expect(info.Provisioned).To(BeTrue())
-			Expect(info.Ready).To(BeFalse())
+			Expect(info.provisioned).To(BeTrue())
+			Expect(info.ready).To(BeFalse())
 		})
 	})
 
@@ -145,8 +145,8 @@ var _ = Describe("parseVolumeSnapshotInfo", func() {
 				},
 			}
 			info := parseVolumeSnapshotInfo(volumeSnapshot)
-			Expect(info.Provisioned).To(BeTrue())
-			Expect(info.Ready).To(BeFalse())
+			Expect(info.provisioned).To(BeTrue())
+			Expect(info.ready).To(BeFalse())
 		})
 
 		It("should detect that a VolumeSnapshot is ready to use", func() {
@@ -159,8 +159,8 @@ var _ = Describe("parseVolumeSnapshotInfo", func() {
 				},
 			}
 			info := parseVolumeSnapshotInfo(volumeSnapshot)
-			Expect(info.Provisioned).To(BeTrue())
-			Expect(info.Ready).To(BeTrue())
+			Expect(info.provisioned).To(BeTrue())
+			Expect(info.ready).To(BeTrue())
 		})
 	})
 })


### PR DESCRIPTION
Since VolumeSnapshots are consistent and the existence of a VolumeSnapshotContent object is enough to declare the snapshot cut, we're lifting fencing directly as soon as a VolumeSnapshotContent have been provisioned.

Closes: #3200
