### PR TITLE
feat(plugin): command options for volume snapshots hot/cold backups

### DIFF
--- a/docs/src/kubectl-plugin.md
+++ b/docs/src/kubectl-plugin.md
@@ -910,8 +910,11 @@ backup/cluster-example-20230121002300 created
 By default, a newly created backup will use the backup target policy defined
 in the cluster to choose which instance to run on.
 However, you can override this policy with the `--backup-target` option.
-Additionally, you can use options such as `--online`, `--immediate-checkpoint`,
-and `--wait-for-archive` to further customize the backup process.
+
+In the case of volume snapshot backups, you can also use the `--online` option
+to request an online/hot backup or an offline/cold one: additionally, you can
+also tune online backups by explicitly setting the `--immediate-checkpoint` and
+`--wait-for-archive` options.
 
 The ["Backup" section](./backup.md#backup) contains more information about
 the configuration settings.

--- a/docs/src/kubectl-plugin.md
+++ b/docs/src/kubectl-plugin.md
@@ -907,10 +907,12 @@ kubectl cnpg backup cluster-example
 backup/cluster-example-20230121002300 created
 ```
 
-By default, a newly created backup will use the backup target policy defined
-in the cluster to choose which instance to run on. You can also use `--backup-target`
-option to override this policy. please refer to the ["Backup" section](backup.md)
-for more information about backup target.
+By default, a newly created backup will utilize the backup target policy defined in the cluster to determine which instance
+to run on.
+However, you can override this policy with the `--backup-target` option.
+Additionally, you can use options such as `--online`, `--immediate-checkpoint`, and `--wait-for-archive` to further customize
+the backup process. For a detailed understanding of these options and the relationship between the backup target and
+`--backup-target, please refer to the "Backup" section.
 
 ### Launching psql
 

--- a/docs/src/kubectl-plugin.md
+++ b/docs/src/kubectl-plugin.md
@@ -907,12 +907,14 @@ kubectl cnpg backup cluster-example
 backup/cluster-example-20230121002300 created
 ```
 
-By default, a newly created backup will utilize the backup target policy defined in the cluster to determine which instance
-to run on.
+By default, a newly created backup will use the backup target policy defined
+in the cluster to choose which instance to run on.
 However, you can override this policy with the `--backup-target` option.
-Additionally, you can use options such as `--online`, `--immediate-checkpoint`, and `--wait-for-archive` to further customize
-the backup process. For a detailed understanding of these options and the relationship between the backup target and
-`--backup-target, please refer to the "Backup" section.
+Additionally, you can use options such as `--online`, `--immediate-checkpoint`,
+and `--wait-for-archive` to further customize the backup process.
+
+The ["Backup" section](./backup.md#backup) contains more information about
+the configuration settings.
 
 ### Launching psql
 

--- a/internal/cmd/plugin/backup/cmd.go
+++ b/internal/cmd/plugin/backup/cmd.go
@@ -172,27 +172,25 @@ func NewCmd() *cobra.Command {
 			"valid values are volumeSnapshot and barmanObjectStore.",
 	)
 
+	const optionalAcceptedValues = "Optional. Accepted values: true|false|\"\"."
 	backupSubcommand.Flags().StringVar(&online, "online",
 		"",
 		"Configures the Online field of the volumeSnapshot backup. "+
 			"When not specified the backup will use the value specified in the cluster '.spec.backup.volumeSnapshot' stanza. "+
-			"Optional. "+
-			"Accepted values: true|false|\"\".")
+			optionalAcceptedValues)
 
 	backupSubcommand.Flags().StringVar(&immediateCheckpoint, "immediate-checkpoint", "",
 		"Configures the immediateCheckpoint field of the volumeSnapshot backup. "+
 			"When not specified the backup will use the value specified in the cluster "+
 			"'.spec.backup.volumeSnapshot.onlineConfiguration' stanza. "+
-			"Optional. "+
-			"Accepted values: true|false|\"\".",
+			optionalAcceptedValues,
 	)
 
 	backupSubcommand.Flags().StringVar(&waitForArchive, "wait-for-archive", "",
 		"Configures the wait-for-archive field of the volumeSnapshot backup. "+
 			"When not specified the backup will use the value specified in the cluster "+
 			"'.spec.backup.volumeSnapshot.onlineConfiguration' stanza. "+
-			"Optional. "+
-			"Accepted values: true|false|\"\".",
+			optionalAcceptedValues,
 	)
 
 	return backupSubcommand

--- a/internal/cmd/plugin/backup/doc.go
+++ b/internal/cmd/plugin/backup/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright The CloudNativePG Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package backup implements a command to request an on-demand backup
+// for a PostgreSQL cluster
+package backup


### PR DESCRIPTION
This patch introduces three new optional flags to the `backup` command of the `cnpg` plugin that control the online backup taken with the `volumeSnapshot` method. Those flags will be passed to the generated `Backup` resource.

Closes #3168
