### PR TITLE
feat: volume snapshot validation

### DIFF
--- a/api/v1/cluster_webhook.go
+++ b/api/v1/cluster_webhook.go
@@ -878,7 +878,7 @@ func validateVolumeSnapshotSource(
 	case apiGroup == storagesnapshotv1.GroupName && value.Kind == "VolumeSnapshot":
 	default:
 		return field.ErrorList{
-			field.Invalid(path, value, "Only VolumeSnapshots and PersistentVolumeClaims are supported"),
+			field.Invalid(path, value, "Only VolumeSnapshots are supported"),
 		}
 	}
 

--- a/api/v1/cluster_webhook.go
+++ b/api/v1/cluster_webhook.go
@@ -876,7 +876,6 @@ func validateVolumeSnapshotSource(
 
 	switch {
 	case apiGroup == storagesnapshotv1.GroupName && value.Kind == "VolumeSnapshot":
-	case apiGroup == "" && value.Kind == "PersistentVolumeClaim":
 	default:
 		return field.ErrorList{
 			field.Invalid(path, value, "Only VolumeSnapshots and PersistentVolumeClaims are supported"),

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -114,6 +114,7 @@ var ErrNextLoop = utils.ErrNextLoop
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=create;list;get;watch;delete
 // +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=create;patch;update;list;watch;get
 // +kubebuilder:rbac:groups="",resources=services,verbs=get;create;delete;update;patch;list;watch
+// +kubebuilder:rbac:groups=snapshot.storage.k8s.io,resources=volumesnapshots,verbs=get;create;watch;list;patch
 
 // Reconcile is the operator reconcile loop
 func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {

--- a/controllers/cluster_create.go
+++ b/controllers/cluster_create.go
@@ -998,7 +998,7 @@ func (r *ClusterReconciler) createPrimaryInstance(
 			if err != nil {
 				return ctrl.Result{}, err
 			}
-			if !status.IsOk() {
+			if status.ContainsErrors() {
 				contextLogger.Warning(
 					"Volume snapshots verification failed, retrying",
 					"status", status)
@@ -1007,7 +1007,7 @@ func (r *ClusterReconciler) createPrimaryInstance(
 					RequeueAfter: 5 * time.Second,
 				}, nil
 			}
-			if !status.IsEmpty() {
+			if status.ContainsWarnings() {
 				contextLogger.Warning("Volume snapshots verification warnings",
 					"status", status)
 			}

--- a/controllers/cluster_create.go
+++ b/controllers/cluster_create.go
@@ -923,6 +923,7 @@ func (r *ClusterReconciler) generateNodeSerial(ctx context.Context, cluster *api
 	return cluster.Status.LatestGeneratedNode, nil
 }
 
+// nolint: gocognit
 func (r *ClusterReconciler) createPrimaryInstance(
 	ctx context.Context,
 	cluster *apiv1.Cluster,
@@ -992,6 +993,25 @@ func (r *ClusterReconciler) createPrimaryInstance(
 
 		volumeSnapshotsRecovery := cluster.Spec.Bootstrap.Recovery.VolumeSnapshots
 		if volumeSnapshotsRecovery != nil {
+			status, err := persistentvolumeclaim.VerifyDataSourceCoherence(
+				ctx, r.Client, cluster.Namespace, volumeSnapshotsRecovery)
+			if err != nil {
+				return ctrl.Result{}, err
+			}
+			if !status.IsOk() {
+				contextLogger.Warning(
+					"Volume snapshots verification failed, retrying",
+					"status", status)
+				return ctrl.Result{
+					Requeue:      true,
+					RequeueAfter: 5 * time.Second,
+				}, nil
+			}
+			if !status.IsEmpty() {
+				contextLogger.Warning("Volume snapshots verification warnings",
+					"status", status)
+			}
+
 			var snapshot volumesnapshot.VolumeSnapshot
 			if err := r.Client.Get(ctx,
 				types.NamespacedName{Name: volumeSnapshotsRecovery.Storage.Name, Namespace: cluster.Namespace},

--- a/docs/src/security.md
+++ b/docs/src/security.md
@@ -126,6 +126,11 @@ namespaced resources.
   manages. For more details, please see the
   [Kubernetes documentation](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/).
 
+`volumesnapshots`
+: The operator needs to generate `VolumeSnapshots` objects in order to take
+  backups of a PostgreSQL server. VolumeSnapshots are read too in order to
+  validate them before starting the restore process.
+
 `nodes`
 : The operator needs to get the labels for Affinity and AntiAffinity, so it can
   decide in which nodes a pod can be scheduled preventing the replicas to be

--- a/pkg/reconciler/persistentvolumeclaim/validation.go
+++ b/pkg/reconciler/persistentvolumeclaim/validation.go
@@ -1,0 +1,185 @@
+/*
+Copyright The CloudNativePG Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package persistentvolumeclaim
+
+import (
+	"context"
+	"fmt"
+
+	volumesnapshot "github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
+)
+
+// ValidationStatus is the result of the validation of a cluster
+// datasource
+type ValidationStatus struct {
+	// Errors is the list of blocking errors
+	Errors []ValidationMessage `json:"errors"`
+
+	// Warnings is the list of warnings that are not blocking
+	Warnings []ValidationMessage `json:"warnings"`
+}
+
+// ValidationMessage is a message about a snapshot
+type ValidationMessage struct {
+	ObjectName string `json:"objectName"`
+	Message    string `json:"message"`
+}
+
+// IsOk returns true if the validation result
+// have no blocking errors
+func (status *ValidationStatus) IsOk() bool {
+	return len(status.Errors) == 0
+}
+
+// IsEmpty returns true when there are no validation messages
+func (status *ValidationStatus) IsEmpty() bool {
+	return len(status.Errors) == 0 && len(status.Warnings) == 0
+}
+
+// AddError adds an error message to the validation status
+func (status *ValidationStatus) addErrorf(name string, format string, args ...interface{}) {
+	status.Errors = append(
+		status.Errors,
+		ValidationMessage{
+			ObjectName: name,
+			Message:    fmt.Sprintf(format, args...),
+		},
+	)
+}
+
+// AddWarning adds an error message to the validation status
+func (status *ValidationStatus) addWarningf(name string, format string, args ...interface{}) {
+	status.Warnings = append(
+		status.Warnings,
+		ValidationMessage{
+			ObjectName: name,
+			Message:    fmt.Sprintf(format, args...),
+		},
+	)
+}
+
+// validateVolumeSnapshot validates the label of a volume snapshot,
+// adding the result to the status
+func (status *ValidationStatus) validateVolumeSnapshot(
+	name string,
+	snapshot *volumesnapshot.VolumeSnapshot,
+	expectedRole utils.PVCRole,
+) {
+	if snapshot == nil {
+		status.addErrorf(name, "VolumeSnapshot doesn't exist")
+		return
+	}
+
+	pvcRoleLabel := snapshot.GetAnnotations()[utils.PvcRoleLabelName]
+	if len(pvcRoleLabel) == 0 {
+		status.addWarningf(name, "Empty PVC role annotation")
+	} else if pvcRoleLabel != string(expectedRole) {
+		status.addErrorf(
+			name,
+			"Expected role '%s', found '%s'",
+			utils.PVCRolePgData,
+			pvcRoleLabel)
+	}
+
+	backupNameLabel := snapshot.GetLabels()[utils.BackupNameLabelName]
+	if len(backupNameLabel) == 0 {
+		status.addWarningf(
+			name,
+			"Empty backup name label",
+		)
+	}
+}
+
+// VerifyDataSourceCoherence verifies if th specified data source that we should
+// use when creating a new cluster is coherent. We check for:
+//
+//   - role of the volume snapshot is coherent with the requested section
+//     (being storage or walStorage)
+//
+//   - the specified snapshots all belong to the same cluster and backupName
+func VerifyDataSourceCoherence(
+	ctx context.Context,
+	c client.Client,
+	namespace string,
+	source *apiv1.DataSource,
+) (ValidationStatus, error) {
+	var result ValidationStatus
+
+	if source == nil {
+		return result, nil
+	}
+
+	pgDataSnapshot, err := getVolumeShapshotOrNil(
+		ctx,
+		c,
+		client.ObjectKey{Namespace: namespace, Name: source.Storage.Name})
+	if err != nil {
+		return result, err
+	}
+	result.validateVolumeSnapshot(source.Storage.Name, pgDataSnapshot, utils.PVCRolePgData)
+
+	var pgWalSnapshot *volumesnapshot.VolumeSnapshot
+	if source.WalStorage != nil {
+		pgWalSnapshot, err = getVolumeShapshotOrNil(
+			ctx,
+			c,
+			client.ObjectKey{Namespace: namespace, Name: source.WalStorage.Name})
+		if err != nil {
+			return result, err
+		}
+		result.validateVolumeSnapshot(source.WalStorage.Name, pgWalSnapshot, utils.PVCRolePgWal)
+	}
+
+	if pgDataSnapshot != nil && pgWalSnapshot != nil {
+		pgDataBackupName := pgDataSnapshot.GetLabels()[utils.BackupNameLabelName]
+		pgWalBackupName := pgWalSnapshot.GetLabels()[utils.BackupNameLabelName]
+
+		if pgDataBackupName != pgWalBackupName {
+			result.addErrorf(
+				source.Storage.Name,
+				"Non coherent backup names: '%s' and '%s'",
+				pgDataBackupName,
+				pgWalBackupName)
+		}
+	}
+
+	return result, nil
+}
+
+// getVolumeShapshotOrNil gets a volume snapshot with a specified name.
+// If the volume snapshot don't exist, returns nil
+func getVolumeShapshotOrNil(
+	ctx context.Context,
+	c client.Client,
+	name client.ObjectKey,
+) (*volumesnapshot.VolumeSnapshot, error) {
+	var result volumesnapshot.VolumeSnapshot
+	if err := c.Get(ctx, name, &result); err != nil {
+		if apierrs.IsNotFound(err) {
+			return nil, nil
+		}
+
+		return nil, err
+	}
+
+	return &result, nil
+}

--- a/pkg/reconciler/persistentvolumeclaim/validation.go
+++ b/pkg/reconciler/persistentvolumeclaim/validation.go
@@ -44,37 +44,29 @@ type ValidationMessage struct {
 	Message    string `json:"message"`
 }
 
-// IsOk returns true if the validation result
-// have no blocking errors
-func (status *ValidationStatus) IsOk() bool {
-	return len(status.Errors) == 0
+func newValidationMessage(objectName string, message string) ValidationMessage {
+	return ValidationMessage{ObjectName: objectName, Message: message}
 }
 
-// IsEmpty returns true when there are no validation messages
-func (status *ValidationStatus) IsEmpty() bool {
-	return len(status.Errors) == 0 && len(status.Warnings) == 0
+// ContainsErrors returns true if the validation result
+// has any blocking errors.
+func (status *ValidationStatus) ContainsErrors() bool {
+	return len(status.Errors) > 0
+}
+
+// ContainsWarnings returns true if there are any validation warnings.
+func (status *ValidationStatus) ContainsWarnings() bool {
+	return len(status.Warnings) > 0
 }
 
 // AddError adds an error message to the validation status
 func (status *ValidationStatus) addErrorf(name string, format string, args ...interface{}) {
-	status.Errors = append(
-		status.Errors,
-		ValidationMessage{
-			ObjectName: name,
-			Message:    fmt.Sprintf(format, args...),
-		},
-	)
+	status.Errors = append(status.Errors, newValidationMessage(name, fmt.Sprintf(format, args...)))
 }
 
 // AddWarning adds an error message to the validation status
 func (status *ValidationStatus) addWarningf(name string, format string, args ...interface{}) {
-	status.Warnings = append(
-		status.Warnings,
-		ValidationMessage{
-			ObjectName: name,
-			Message:    fmt.Sprintf(format, args...),
-		},
-	)
+	status.Warnings = append(status.Warnings, newValidationMessage(name, fmt.Sprintf(format, args...)))
 }
 
 // validateVolumeSnapshot validates the label of a volume snapshot,

--- a/pkg/reconciler/persistentvolumeclaim/validation_test.go
+++ b/pkg/reconciler/persistentvolumeclaim/validation_test.go
@@ -52,7 +52,8 @@ var _ = Describe("Volume Snapshot validation", func() {
 				},
 			},
 		}))
-		Expect(status.IsOk()).To(BeTrue())
+		Expect(status.ContainsErrors()).To(BeFalse())
+		Expect(status.ContainsWarnings()).To(BeTrue())
 	})
 
 	It("Fails when the snapshot doesn't exist", func() {
@@ -66,7 +67,7 @@ var _ = Describe("Volume Snapshot validation", func() {
 				},
 			},
 		}))
-		Expect(status.IsOk()).To(BeFalse())
+		Expect(status.ContainsErrors()).To(BeTrue())
 	})
 
 	It("Fails when the snapshot have the pvcRole annotation, but the value is not correct", func() {
@@ -94,7 +95,7 @@ var _ = Describe("Volume Snapshot validation", func() {
 				},
 			},
 		}))
-		Expect(status.IsOk()).To(BeFalse())
+		Expect(status.ContainsErrors()).To(BeTrue())
 	})
 
 	It("Verifies the coherence of multiple volumeSnapshot backups", func(ctx SpecContext) {
@@ -195,7 +196,7 @@ var _ = Describe("Volume Snapshot validation", func() {
 
 		status, err := VerifyDataSourceCoherence(ctx, mockClient, "default", &dataSource)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(status.IsOk()).To(BeTrue())
+		Expect(status.ContainsErrors()).To(BeFalse())
 	})
 
 	It("doesn't complain if we only have the pgdata snapshot", func(ctx SpecContext) {
@@ -227,7 +228,7 @@ var _ = Describe("Volume Snapshot validation", func() {
 
 		status, err := VerifyDataSourceCoherence(ctx, mockClient, "default", &dataSource)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(status.IsOk()).To(BeTrue())
+		Expect(status.ContainsErrors()).To(BeFalse())
 	})
 
 	It("complains if we referenced a snapshot which we don't have", func(ctx SpecContext) {
@@ -262,7 +263,7 @@ var _ = Describe("Volume Snapshot validation", func() {
 
 		status, err := VerifyDataSourceCoherence(ctx, mockClient, "default", &dataSource)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(status.IsOk()).To(BeFalse())
+		Expect(status.ContainsErrors()).To(BeTrue())
 		Expect(status).To(Equal(ValidationStatus{
 			Errors: []ValidationMessage{
 				{

--- a/pkg/reconciler/persistentvolumeclaim/validation_test.go
+++ b/pkg/reconciler/persistentvolumeclaim/validation_test.go
@@ -1,0 +1,275 @@
+/*
+Copyright The CloudNativePG Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package persistentvolumeclaim
+
+import (
+	volumesnapshot "github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	"github.com/cloudnative-pg/cloudnative-pg/internal/scheme"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Volume Snapshot validation", func() {
+	It("Complains with warnings when the labels are missing", func() {
+		snapshot := volumesnapshot.VolumeSnapshot{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{},
+			},
+		}
+
+		var status ValidationStatus
+		status.validateVolumeSnapshot("pgdata", &snapshot, utils.PVCRolePgData)
+		Expect(status).To(Equal(ValidationStatus{
+			Warnings: []ValidationMessage{
+				{
+					ObjectName: "pgdata",
+					Message:    "Empty PVC role annotation",
+				},
+				{
+					ObjectName: "pgdata",
+					Message:    "Empty backup name label",
+				},
+			},
+		}))
+		Expect(status.IsOk()).To(BeTrue())
+	})
+
+	It("Fails when the snapshot doesn't exist", func() {
+		var status ValidationStatus
+		status.validateVolumeSnapshot("pgdata", nil, utils.PVCRolePgData)
+		Expect(status).To(Equal(ValidationStatus{
+			Errors: []ValidationMessage{
+				{
+					ObjectName: "pgdata",
+					Message:    "VolumeSnapshot doesn't exist",
+				},
+			},
+		}))
+		Expect(status.IsOk()).To(BeFalse())
+	})
+
+	It("Fails when the snapshot have the pvcRole annotation, but the value is not correct", func() {
+		snapshot := volumesnapshot.VolumeSnapshot{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					utils.PvcRoleLabelName: "test",
+				},
+			},
+		}
+
+		var status ValidationStatus
+		status.validateVolumeSnapshot("pgdata", &snapshot, utils.PVCRolePgData)
+		Expect(status).To(Equal(ValidationStatus{
+			Errors: []ValidationMessage{
+				{
+					ObjectName: "pgdata",
+					Message:    "Expected role 'PG_DATA', found 'test'",
+				},
+			},
+			Warnings: []ValidationMessage{
+				{
+					ObjectName: "pgdata",
+					Message:    "Empty backup name label",
+				},
+			},
+		}))
+		Expect(status.IsOk()).To(BeFalse())
+	})
+
+	It("Verifies the coherence of multiple volumeSnapshot backups", func(ctx SpecContext) {
+		snapshots := volumesnapshot.VolumeSnapshotList{
+			Items: []volumesnapshot.VolumeSnapshot{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pgdata",
+						Namespace: "default",
+						Labels: map[string]string{
+							utils.BackupNameLabelName: "backup-one",
+						},
+						Annotations: map[string]string{
+							utils.PvcRoleLabelName: string(utils.PVCRolePgData),
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pgwal",
+						Namespace: "default",
+						Labels: map[string]string{
+							utils.BackupNameLabelName: "backup-two",
+						},
+						Annotations: map[string]string{
+							utils.PvcRoleLabelName: string(utils.PVCRolePgWal),
+						},
+					},
+				},
+			},
+		}
+		dataSource := apiv1.DataSource{
+			Storage: corev1.TypedLocalObjectReference{
+				Name: "pgdata",
+			},
+			WalStorage: &corev1.TypedLocalObjectReference{
+				Name: "pgwal",
+			},
+		}
+		mockClient := fake.NewClientBuilder().
+			WithScheme(scheme.BuildWithAllKnownScheme()).
+			WithLists(&snapshots).
+			Build()
+
+		status, err := VerifyDataSourceCoherence(ctx, mockClient, "default", &dataSource)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(status).To(Equal(ValidationStatus{
+			Errors: []ValidationMessage{
+				{
+					ObjectName: "pgdata",
+					Message:    "Non coherent backup names: 'backup-one' and 'backup-two'",
+				},
+			},
+		}))
+	})
+
+	It("doesn't complain if the snapshots are correct", func(ctx SpecContext) {
+		snapshots := volumesnapshot.VolumeSnapshotList{
+			Items: []volumesnapshot.VolumeSnapshot{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pgdata",
+						Namespace: "default",
+						Labels: map[string]string{
+							utils.BackupNameLabelName: "backup-one",
+						},
+						Annotations: map[string]string{
+							utils.PvcRoleLabelName: string(utils.PVCRolePgData),
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pgwal",
+						Namespace: "default",
+						Labels: map[string]string{
+							utils.BackupNameLabelName: "backup-one",
+						},
+						Annotations: map[string]string{
+							utils.PvcRoleLabelName: string(utils.PVCRolePgWal),
+						},
+					},
+				},
+			},
+		}
+		dataSource := apiv1.DataSource{
+			Storage: corev1.TypedLocalObjectReference{
+				Name: "pgdata",
+			},
+			WalStorage: &corev1.TypedLocalObjectReference{
+				Name: "pgwal",
+			},
+		}
+		mockClient := fake.NewClientBuilder().
+			WithScheme(scheme.BuildWithAllKnownScheme()).
+			WithLists(&snapshots).
+			Build()
+
+		status, err := VerifyDataSourceCoherence(ctx, mockClient, "default", &dataSource)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(status.IsOk()).To(BeTrue())
+	})
+
+	It("doesn't complain if we only have the pgdata snapshot", func(ctx SpecContext) {
+		snapshots := volumesnapshot.VolumeSnapshotList{
+			Items: []volumesnapshot.VolumeSnapshot{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pgdata",
+						Namespace: "default",
+						Labels: map[string]string{
+							utils.BackupNameLabelName: "backup-one",
+						},
+						Annotations: map[string]string{
+							utils.PvcRoleLabelName: string(utils.PVCRolePgData),
+						},
+					},
+				},
+			},
+		}
+		dataSource := apiv1.DataSource{
+			Storage: corev1.TypedLocalObjectReference{
+				Name: "pgdata",
+			},
+		}
+		mockClient := fake.NewClientBuilder().
+			WithScheme(scheme.BuildWithAllKnownScheme()).
+			WithLists(&snapshots).
+			Build()
+
+		status, err := VerifyDataSourceCoherence(ctx, mockClient, "default", &dataSource)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(status.IsOk()).To(BeTrue())
+	})
+
+	It("complains if we referenced a snapshot which we don't have", func(ctx SpecContext) {
+		snapshots := volumesnapshot.VolumeSnapshotList{
+			Items: []volumesnapshot.VolumeSnapshot{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pgdata",
+						Namespace: "default",
+						Labels: map[string]string{
+							utils.BackupNameLabelName: "backup-one",
+						},
+						Annotations: map[string]string{
+							utils.PvcRoleLabelName: string(utils.PVCRolePgData),
+						},
+					},
+				},
+			},
+		}
+		dataSource := apiv1.DataSource{
+			Storage: corev1.TypedLocalObjectReference{
+				Name: "pgdata",
+			},
+			WalStorage: &corev1.TypedLocalObjectReference{
+				Name: "pgwal",
+			},
+		}
+		mockClient := fake.NewClientBuilder().
+			WithScheme(scheme.BuildWithAllKnownScheme()).
+			WithLists(&snapshots).
+			Build()
+
+		status, err := VerifyDataSourceCoherence(ctx, mockClient, "default", &dataSource)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(status.IsOk()).To(BeFalse())
+		Expect(status).To(Equal(ValidationStatus{
+			Errors: []ValidationMessage{
+				{
+					ObjectName: "pgwal",
+					Message:    "VolumeSnapshot doesn't exist",
+				},
+			},
+		}))
+	})
+})


### PR DESCRIPTION
Before recovering from a set of VolumeSnapshots, the operator will validate if the labels are there and are coherent with the requested recovery settings.

Closes: #2980 