### PR TITLE
fix: Migrate recovery_target_timeline to prevent restarting

### DIFF
--- a/pkg/management/postgres/configuration.go
+++ b/pkg/management/postgres/configuration.go
@@ -294,23 +294,23 @@ func createStandbySignal(pgData string) error {
 
 var migrateAutoConfOptions = []string{
 	"archive_mode",
-	"primary_slot_name",
 	"primary_conninfo",
-	"restore_command",
+	"primary_slot_name",
 	"recovery_target_timeline",
+	"restore_command",
 }
 
 var cleanupAutoConfOptions = []string{
 	"archive_mode",
-	"primary_slot_name",
 	"primary_conninfo",
+	"primary_slot_name",
 	"recovery_target",
-	"recovery_target_xid",
-	"recovery_target_name",
+	"recovery_target_inclusive",
 	"recovery_target_lsn",
+	"recovery_target_name",
 	"recovery_target_time",
 	"recovery_target_timeline",
-	"recovery_target_inclusive",
+	"recovery_target_xid",
 	"restore_command",
 }
 

--- a/pkg/management/postgres/configuration.go
+++ b/pkg/management/postgres/configuration.go
@@ -297,6 +297,7 @@ var migrateAutoConfOptions = []string{
 	"primary_slot_name",
 	"primary_conninfo",
 	"restore_command",
+	"recovery_target_timeline",
 }
 
 var cleanupAutoConfOptions = []string{


### PR DESCRIPTION
In the [pull request](https://github.com/cloudnative-pg/cloudnative-pg/pull/2812), we migrated settings from `postgresql.auto.conf` to `override.conf`. During this migration, we overlooked the `recovery_target_timeline` setting. As a result, the reloaded configuration file does not include `recovery_target_timeline`, leading to a PostgreSQL restart.

closes: #3221