### PR TITLE
chore: document usage of hashed passwords

### DIFF
--- a/docs/src/declarative_role_management.md
+++ b/docs/src/declarative_role_management.md
@@ -159,6 +159,23 @@ never expires, mirroring the behavior of PostgreSQL. Specifically:
     had been previously created. In 1.20.0, doing this might inadvertently
     result in setting existing passwords to `NULL`.
 
+### Password hashed
+
+You can also provide pre-encrypted passwords by specifiy the password in MD5/SCRAM-SHA-256 hash format:
+
+``` yaml
+kind: Secret
+type: kubernetes.io/basic-auth
+metadata:
+  name: cluster-example-cavalcanti
+  labels:
+    cnpg.io/reload: "true"
+apiVersion: v1
+stringData:
+  username: cavalcanti
+  password: SCRAM-SHA-256$<iteration count>:<salt>$<StoredKey>:<ServerKey>
+```
+
 ## Unrealizable role configurations
 
 In PostgreSQL, in some cases, commands cannot be honored by the database and

--- a/docs/src/declarative_role_management.md
+++ b/docs/src/declarative_role_management.md
@@ -161,7 +161,8 @@ never expires, mirroring the behavior of PostgreSQL. Specifically:
 
 ### Password hashed
 
-You can also provide pre-encrypted passwords by specifiy the password in MD5/SCRAM-SHA-256 hash format:
+You can also provide pre-encrypted passwords by specifying the password
+in MD5/SCRAM-SHA-256 hash format:
 
 ``` yaml
 kind: Secret

--- a/tests/e2e/fixtures/managed_roles/cluster-managed-roles.yaml.template
+++ b/tests/e2e/fixtures/managed_roles/cluster-managed-roles.yaml.template
@@ -44,6 +44,10 @@ spec:
     - name: app
       createdb: true
       login: true
+    - name: cavalcanti
+      login: true
+      passwordSecret:
+        name: cluster-example-cavalcanti
 
 ---
 apiVersion: v1
@@ -53,6 +57,18 @@ data:
 kind: Secret
 metadata:
   name: cluster-example-dante
+  labels:
+    cnpg.io/reload: "true"
+type: kubernetes.io/basic-auth
+
+---
+apiVersion: v1
+data:
+  username: Y2F2YWxjYW50aQo=
+  password: U0NSQU0tU0hBLTI1NiQ0MDk2OlkyRjJZV3hqWVc1MGFRPT0kZUNJeW8yUUVadndsY01UaG0xendRRFBudzBqT0hsQ2FwQ0UrUUZwSHNHcz06WUtoU0VjZDRRaVgzU0J6bXRUT0hIQS85eWFUQkdKV0FNTXc3KzkyT3lITT0K
+kind: Secret
+metadata:
+  name: cluster-example-cavalcanti
   labels:
     cnpg.io/reload: "true"
 type: kubernetes.io/basic-auth

--- a/tests/e2e/managed_roles_test.go
+++ b/tests/e2e/managed_roles_test.go
@@ -55,13 +55,14 @@ var _ = Describe("Managed roles tests", Label(tests.LabelSmoke, tests.LabelBasic
 
 	Context("plain vanilla cluster", Ordered, func() {
 		const (
-			namespacePrefix       = "managed-roles"
-			username              = "dante"
-			appUsername           = "app"
-			password              = "dante"
-			newUserName           = "new_role"
-			unrealizableUser      = "petrarca"
-			userWithPerpetualPass = "boccaccio"
+			namespacePrefix        = "managed-roles"
+			username               = "dante"
+			appUsername            = "app"
+			password               = "dante"
+			newUserName            = "new_role"
+			unrealizableUser       = "petrarca"
+			userWithPerpetualPass  = "boccaccio"
+			userWithHashedPassword = "cavalcanti"
 		)
 		var clusterName, secretName, namespace string
 		var secretNameSpacedName *types.NamespacedName
@@ -155,6 +156,7 @@ var _ = Describe("Managed roles tests", Label(tests.LabelSmoke, tests.LabelBasic
 
 				assertUserExists(namespace, primaryPodInfo.Name, username, true)
 				assertUserExists(namespace, primaryPodInfo.Name, userWithPerpetualPass, true)
+				assertUserExists(namespace, primaryPodInfo.Name, userWithHashedPassword, true)
 				assertUserExists(namespace, primaryPodInfo.Name, unrealizableUser, false)
 
 				query := fmt.Sprintf("SELECT true FROM pg_roles WHERE rolname='%s' and rolcanlogin=%v and rolsuper=%v "+
@@ -180,6 +182,8 @@ var _ = Describe("Managed roles tests", Label(tests.LabelSmoke, tests.LabelBasic
 				rwService := fmt.Sprintf("%v-rw.%v.svc", clusterName, namespace)
 				// assert connectable use username and password defined in secrets
 				AssertConnection(rwService, username, "postgres", password, *psqlClientPod, 30, env)
+
+				AssertConnection(rwService, userWithHashedPassword, "postgres", userWithHashedPassword, *psqlClientPod, 30, env)
 			})
 
 			By("ensuring the app role has been granted createdb in the managed stanza", func() {


### PR DESCRIPTION
We didn't like to store the password in plain text and tried to specify the password hash. It worked. So here is some documentation and an e2e test :) 