### PR TITLE
fix: defer WAL archiving during a recovery job

### DIFF
--- a/pkg/management/postgres/restore.go
+++ b/pkg/management/postgres/restore.go
@@ -585,10 +585,12 @@ func (info InitInfo) writeRecoveryConfiguration(recoveryFileContents string) err
 	}
 
 	log.Info("Generated recovery configuration", "configuration", recoveryFileContents)
-	// Disable archiving
+	// Temporarily suspend WAL archiving. We set it to `false` (which means failure
+	// of the archiver) in order to defer the decision about archiving to PostgreSQL
+	// itself once the recovery job is completed and the instance is regularly started.
 	err = fileutils.AppendStringToFile(
 		path.Join(info.PgData, constants.PostgresqlCustomConfigurationFile),
-		"archive_command = 'cd .'\n")
+		"archive_command = 'false'\n")
 	if err != nil {
 		return fmt.Errorf("cannot write recovery config: %w", err)
 	}


### PR DESCRIPTION
Up to now, the recovery job was discarding WAL files by setting `archive_command` to `cd .` (that is success). We now set it to `false`, so that we defer the decision about archiving a WAL file to when the instance is actually started as a regular pod.

Closes #3259 