### PR TITLE
fix: retry when external-snapshotter controller failed on a conflict

### DIFF
--- a/pkg/reconciler/backup/volumesnapshot/reconciler.go
+++ b/pkg/reconciler/backup/volumesnapshot/reconciler.go
@@ -659,6 +659,13 @@ func (se *Reconciler) waitSnapshotToBeProvisionedAndAnnotate(
 
 	info := parseVolumeSnapshotInfo(snapshot)
 	if info.error != nil {
+		if info.error.isRetryable() {
+			contextLogger.Error(info.error,
+				"Retryable snapshot provisioning error, trying again",
+				"volumeSnapshotName", snapshot.Name)
+			return &ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+		}
+
 		return nil, info.error
 	}
 	if !info.provisioned {
@@ -695,6 +702,13 @@ func (se *Reconciler) waitSnapshotToBeReady(
 
 	info := parseVolumeSnapshotInfo(snapshot)
 	if info.error != nil {
+		if info.error.isRetryable() {
+			contextLogger.Error(info.error,
+				"Retryable snapshot provisioning error, trying again",
+				"volumeSnapshotName", snapshot.Name)
+			return &ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+		}
+
 		return nil, info.error
 	}
 	if !info.ready {

--- a/pkg/reconciler/backup/volumesnapshot/resources.go
+++ b/pkg/reconciler/backup/volumesnapshot/resources.go
@@ -78,9 +78,17 @@ func (err volumeSnapshotError) isRetryable() bool {
 	// We're trying to handle the cases where the external-snapshotter
 	// controller failed on a conflict with the following error:
 	//
-	// the object has been modified; please apply your changes to the latest version and try again
+	// > the object has been modified; please apply your changes to the
+	// > latest version and try again
 
-	return strings.Contains(*err.InternalError.Message, "try again")
+	// TODO: instead of blindingly retry on matching errors, we
+	// should enhance our CRD with a configurable deadline. After
+	// the deadline have been met on err.InternalError.CreatedAt
+	// the backup can be marked as failed
+
+	return strings.Contains(
+		*err.InternalError.Message,
+		"the object has been modified")
 }
 
 // slice represents a slice of []storagesnapshotv1.VolumeSnapshot


### PR DESCRIPTION
Closes #3272 
