### PR TITLE
fix: skip podSpec rollout checker if pod annotation is invalid

### DIFF
--- a/controllers/cluster_upgrade.go
+++ b/controllers/cluster_upgrade.go
@@ -277,8 +277,8 @@ func isPodNeedingRollout(
 		return podRollout
 	}
 
-	// If the pod has a stored PodSpec annotation, that's the final check.
-	// If not, we should perform additional checks
+	// If the pod has a valid PodSpec annotation, that's the final check.
+	// If not, we should perform additional legacy checks
 	if hasValidPodSpec(status) {
 		return applyCheckers(map[string]rolloutChecker{
 			"PodSpec is outdated": checkPodSpecIsOutdated,
@@ -300,7 +300,7 @@ func isPodNeedingRollout(
 	return rollout{}
 }
 
-// check if the pod has valid podSpec
+// check if the pod has a valid podSpec
 func hasValidPodSpec(status postgres.PostgresqlStatus) bool {
 	podSpecAnnotation, hasStoredPodSpec := status.Pod.ObjectMeta.Annotations[utils.PodSpecAnnotationName]
 	if !hasStoredPodSpec {

--- a/controllers/cluster_upgrade.go
+++ b/controllers/cluster_upgrade.go
@@ -279,8 +279,7 @@ func isPodNeedingRollout(
 
 	// If the pod has a stored PodSpec annotation, that's the final check.
 	// If not, we should perform additional checks
-	podSpecValid := hasValidPodSpec(status)
-	if podSpecValid {
+	if hasValidPodSpec(status) {
 		return applyCheckers(map[string]rolloutChecker{
 			"PodSpec is outdated": checkPodSpecIsOutdated,
 		})
@@ -307,8 +306,7 @@ func hasValidPodSpec(status postgres.PostgresqlStatus) bool {
 	if !hasStoredPodSpec {
 		return false
 	}
-	var storedPodSpec corev1.PodSpec
-	err := json.Unmarshal([]byte(podSpecAnnotation), &storedPodSpec)
+	err := json.Unmarshal([]byte(podSpecAnnotation), &corev1.PodSpec{})
 	return err == nil
 }
 


### PR DESCRIPTION
Fixes a bug where the PodSpec annotation was stored as Protobuf, but after
upgrade, was expected as JSON. This fix skips the PodSpec rollout check in
this case, defaulting to the pre-PodSpec rollout checkers.

Closes: #3273 