### PR TITLE
chore: allow one more connection to PostgreSQL from the instance manager

### DIFF
--- a/pkg/management/postgres/pool/pool.go
+++ b/pkg/management/postgres/pool/pool.go
@@ -106,7 +106,18 @@ func (pool *ConnectionPool) newConnection(dbname string) (*sql.DB, error) {
 		return nil, fmt.Errorf("cannot create connection connectionMap: %w", err)
 	}
 
-	db.SetMaxOpenConns(2)
+	// This is the list of long-running processes of the instance manager
+	// that need a PostgreSQL connection:
+	//
+	// * Declarative Role Management
+	// * Probes
+	// * Replication slots reconciler
+	// * Online VolumeSnapshot backup connection
+	//
+	// The latter will use an exclusive connection, that is required
+	// for the PostgreSQL Physical backup APIs
+
+	db.SetMaxOpenConns(3)
 	db.SetMaxIdleConns(0)
 
 	return db, nil


### PR DESCRIPTION
When taking an hot snapshot backup, we require an exclusive connection for the PostgreSQL Physical Backup API.

In that case, the number of available connections for the other instance manager runnables will be reduced to one. To avoid those other runnables to be stuck, we allow one more PostgreSQL connection.

Closes: #3275 