### PR TITLE
ci: do not update the install latest code link

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -91,9 +91,6 @@ sed -i -e "/Version *= *.*/Is/\".*\"/\"${release_version}\"/" \
 sed -i "s/cnpg-[0-9.]*.yaml/cnpg-${release_version}.yaml/g" \
     docs/src/installation_upgrade.md
 
-sed -i "s/\/\(release-[0-9.]*\|main\)\//\/${branch}\//g" \
-    docs/src/installation_upgrade.md
-
 CONFIG_TMP_DIR=$(mktemp -d)
 cp -r config/* "${CONFIG_TMP_DIR}"
 (


### PR DESCRIPTION
During the release procedure, we update the link to install the latest snapshot of the operator together with the other. That link should always point to the latest snapshot from the main branch.
