### PR TITLE
chore: add `RoleManager` section to `cnpg status`

### DIFF
--- a/docs/src/declarative_role_management.md
+++ b/docs/src/declarative_role_management.md
@@ -240,17 +240,16 @@ in its `status` sub-command:
 
 ``` txt
 Managed roles status
-Irreconcilable Errors encountered:
-Role      Errors
-----      ------
-petrarca  could not perform UPDATE_MEMBERSHIPS on role petrarca: role "poets" does not exist
-
-Roles by status:
-status                  roles
+Status                  Roles
 ------                  -----
 pending-reconciliation  petrarca
 reconciled              app,dante
 reserved                postgres,streaming_replica
+
+Irreconcilable roles
+Role      Errors
+----      ------
+petrarca  could not perform UPDATE_MEMBERSHIPS on role petrarca: role "poets" does not exist
 ```
 
 !!! Important

--- a/docs/src/declarative_role_management.md
+++ b/docs/src/declarative_role_management.md
@@ -203,7 +203,8 @@ them in the cluster Status. Which segues into…
 
 ## Status of managed roles
 
-The CRD status includes a section for the managed roles' status, as shown below:
+The Cluster status includes a section for the managed roles' status, as shown
+below:
 
 ```yaml
 status:
@@ -233,6 +234,24 @@ CloudNativePG) cannot honor, and which require human intervention.
 This section covers roles reserved for operator use and those that are **not**
 under declarative management, providing a comprehensive view of the roles in
 the database instances.
+
+The [kubectl plugin](kubectl-plugin.md) also shows the status of managed roles
+in its `status` sub-command:
+
+``` txt
+Managed roles status
+Irreconcilable Errors encountered:
+Role      Errors
+----      ------
+petrarca  could not perform UPDATE_MEMBERSHIPS on role petrarca: role "poets" does not exist
+
+Roles by status:
+status                  roles
+------                  -----
+pending-reconciliation  petrarca
+reconciled              app,dante
+reserved                postgres,streaming_replica
+```
 
 !!! Important
     In terms of backward compatibility, declarative role management is designed

--- a/internal/cmd/plugin/status/status.go
+++ b/internal/cmd/plugin/status/status.go
@@ -890,8 +890,6 @@ func (fullStatus *PostgresqlStatus) printRoleManagerStatus() {
 		}
 		errorStatus.Print()
 		fmt.Println()
-	} else {
-		fmt.Println(aurora.Green("No Errors found"))
 	}
 
 	color := aurora.Green

--- a/internal/cmd/plugin/status/status.go
+++ b/internal/cmd/plugin/status/status.go
@@ -851,7 +851,7 @@ func (fullStatus *PostgresqlStatus) printBasebackupStatus() {
 }
 
 func (fullStatus *PostgresqlStatus) printRoleManagerStatus() {
-	const header = "RoleManager Status"
+	const header = "Managed roles status"
 
 	managedRolesStatus := fullStatus.Cluster.Status.ManagedRolesStatus
 	containsErrors := len(managedRolesStatus.CannotReconcile) > 0
@@ -896,7 +896,7 @@ func (fullStatus *PostgresqlStatus) printRoleManagerStatus() {
 	if containsWarnings() {
 		color = aurora.Yellow
 	}
-	fmt.Println(color("Role Reconciliation Status:"))
+	fmt.Println(color("Roles by status:"))
 
 	roleStatus := tabby.New()
 	roleStatus.AddHeader("status", "roles")


### PR DESCRIPTION
This PR aims to improve the user experience by integrating the `cnpg status` command with the RoleManager status data.