### PR TITLE
fix: reconcile `pdb` metadata

### DIFF
--- a/controllers/cluster_create.go
+++ b/controllers/cluster_create.go
@@ -396,7 +396,6 @@ func (r *ClusterReconciler) createOrPatchOwnedPodDisruptionBudget(
 		if !apierrs.IsNotFound(err) {
 			return fmt.Errorf("while getting PodDisruptionBudget: %w", err)
 		}
-		cluster.SetInheritedDataAndOwnership(&pdb.ObjectMeta)
 
 		r.Recorder.Event(cluster, "Normal", "CreatingPodDisruptionBudget",
 			fmt.Sprintf("Creating PodDisruptionBudget %s", pdb.Name))
@@ -406,7 +405,12 @@ func (r *ClusterReconciler) createOrPatchOwnedPodDisruptionBudget(
 		return nil
 	}
 
-	if reflect.DeepEqual(pdb.Spec, oldPdb.Spec) {
+	patchedPdb := oldPdb.DeepCopy()
+	patchedPdb.Spec = pdb.Spec
+	utils.MergeMap(patchedPdb.Annotations, pdb.Annotations)
+	utils.MergeMap(patchedPdb.Labels, pdb.Labels)
+
+	if reflect.DeepEqual(patchedPdb.Spec, oldPdb.Spec) && reflect.DeepEqual(patchedPdb.ObjectMeta, oldPdb.ObjectMeta) {
 		// Everything fine, the two pdbs are the same for us
 		return nil
 	}
@@ -414,10 +418,7 @@ func (r *ClusterReconciler) createOrPatchOwnedPodDisruptionBudget(
 	r.Recorder.Event(cluster, "Normal", "UpdatingPodDisruptionBudget",
 		fmt.Sprintf("Updating PodDisruptionBudget %s", pdb.Name))
 
-	patchedPdb := oldPdb
-	patchedPdb.Spec = pdb.Spec
-
-	if err := r.Patch(ctx, &patchedPdb, client.MergeFrom(&oldPdb)); err != nil {
+	if err := r.Patch(ctx, patchedPdb, client.MergeFrom(&oldPdb)); err != nil {
 		return fmt.Errorf("while patching PodDisruptionBudget: %w", err)
 	}
 

--- a/controllers/cluster_create_test.go
+++ b/controllers/cluster_create_test.go
@@ -25,9 +25,11 @@ import (
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/discovery"
 	fakediscovery "k8s.io/client-go/discovery/fake"
 	"k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
 	k8client "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -682,6 +684,109 @@ var _ = Describe("createOrPatchClusterCredentialSecret", func() {
 			err = cli.Get(ctx, types.NamespacedName{Name: secretName, Namespace: namespace}, &patchedSecret)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(originalSecret.Generation).To(Equal(originalSecret.Generation))
+		})
+	})
+})
+
+var _ = Describe("createOrPatchOwnedPodDisruptionBudget", func() {
+	var (
+		ctx        context.Context
+		fakeClient k8client.Client
+		reconciler *ClusterReconciler
+		cluster    *apiv1.Cluster
+		pdb        *policyv1.PodDisruptionBudget
+		err        error
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+
+		fakeClient = fake.NewClientBuilder().WithScheme(schemeBuilder.BuildWithAllKnownScheme()).Build()
+		reconciler = &ClusterReconciler{
+			Client:   fakeClient,
+			Recorder: record.NewFakeRecorder(10000),
+			Scheme:   schemeBuilder.BuildWithAllKnownScheme(),
+		}
+
+		cluster = &apiv1.Cluster{}
+		pdb = &policyv1.PodDisruptionBudget{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-pdb",
+				Namespace: "default",
+				Labels: map[string]string{
+					"test": "value",
+				},
+			},
+			Spec: policyv1.PodDisruptionBudgetSpec{
+				Selector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"app": "example"},
+				},
+				MinAvailable: &intstr.IntOrString{
+					Type:   intstr.Int,
+					IntVal: 1,
+				},
+			},
+		}
+	})
+
+	Context("when PodDisruptionBudget is nil", func() {
+		It("should return nil without error", func() {
+			pdb = nil
+			err = reconciler.createOrPatchOwnedPodDisruptionBudget(ctx, cluster, pdb)
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+	})
+
+	Context("when creating a new PodDisruptionBudget", func() {
+		It("should successfully create the PodDisruptionBudget", func() {
+			err = reconciler.createOrPatchOwnedPodDisruptionBudget(ctx, cluster, pdb)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			fetchedPdb := &policyv1.PodDisruptionBudget{}
+			err = fakeClient.Get(ctx, types.NamespacedName{Name: pdb.Name, Namespace: pdb.Namespace}, fetchedPdb)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(fetchedPdb.Name).To(Equal(pdb.Name))
+		})
+	})
+
+	Context("when the PodDisruptionBudget already exists", func() {
+		BeforeEach(func() {
+			_ = fakeClient.Create(ctx, pdb)
+		})
+
+		It("should update the existing PodDisruptionBudget if the metadata is different", func() {
+			pdb.ObjectMeta.Labels["newlabel"] = "newvalue"
+			err = reconciler.createOrPatchOwnedPodDisruptionBudget(ctx, cluster, pdb)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			fetchedPdb := &policyv1.PodDisruptionBudget{}
+			err = fakeClient.Get(ctx, types.NamespacedName{Name: pdb.Name, Namespace: pdb.Namespace}, fetchedPdb)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(fetchedPdb.Spec).To(Equal(pdb.Spec))
+			Expect(fetchedPdb.Labels).To(Equal(pdb.Labels))
+		})
+
+		It("should update the existing PodDisruptionBudget if the spec is different", func() {
+			pdb.Spec.MinAvailable = ptr.To(intstr.FromInt32(3))
+			err = reconciler.createOrPatchOwnedPodDisruptionBudget(ctx, cluster, pdb)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			fetchedPdb := &policyv1.PodDisruptionBudget{}
+			err = fakeClient.Get(ctx, types.NamespacedName{Name: pdb.Name, Namespace: pdb.Namespace}, fetchedPdb)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(fetchedPdb.Spec).To(Equal(pdb.Spec))
+			Expect(fetchedPdb.Labels).To(Equal(pdb.Labels))
+		})
+
+		It("should not update the PodDisruptionBudget if it is the same", func() {
+			err = reconciler.createOrPatchOwnedPodDisruptionBudget(ctx, cluster, pdb)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			fetchedPdb := &policyv1.PodDisruptionBudget{}
+			err = fakeClient.Get(ctx, types.NamespacedName{Name: pdb.Name, Namespace: pdb.Namespace}, fetchedPdb)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(fetchedPdb.Spec).To(Equal(pdb.Spec))
+			Expect(fetchedPdb.Labels).To(Equal(pdb.Labels))
 		})
 	})
 })

--- a/pkg/specs/poddisruptionbudget.go
+++ b/pkg/specs/poddisruptionbudget.go
@@ -36,7 +36,7 @@ func BuildReplicasPodDisruptionBudget(cluster *apiv1.Cluster) *policyv1.PodDisru
 	minAvailableReplicas := cluster.Spec.Instances - 2
 	allReplicasButOne := intstr.FromInt(minAvailableReplicas)
 
-	return &policyv1.PodDisruptionBudget{
+	pdb := &policyv1.PodDisruptionBudget{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cluster.Name,
 			Namespace: cluster.Namespace,
@@ -51,6 +51,10 @@ func BuildReplicasPodDisruptionBudget(cluster *apiv1.Cluster) *policyv1.PodDisru
 			MinAvailable: &allReplicasButOne,
 		},
 	}
+
+	cluster.SetInheritedDataAndOwnership(&pdb.ObjectMeta)
+
+	return pdb
 }
 
 // BuildPrimaryPodDisruptionBudget creates a pod disruption budget, telling
@@ -61,7 +65,7 @@ func BuildPrimaryPodDisruptionBudget(cluster *apiv1.Cluster) *policyv1.PodDisrup
 	}
 	one := intstr.FromInt(1)
 
-	return &policyv1.PodDisruptionBudget{
+	pdb := &policyv1.PodDisruptionBudget{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cluster.Name + apiv1.PrimaryPodDisruptionBudgetSuffix,
 			Namespace: cluster.Namespace,
@@ -76,4 +80,8 @@ func BuildPrimaryPodDisruptionBudget(cluster *apiv1.Cluster) *policyv1.PodDisrup
 			MinAvailable: &one,
 		},
 	}
+
+	cluster.SetInheritedDataAndOwnership(&pdb.ObjectMeta)
+
+	return pdb
 }


### PR DESCRIPTION
This patch ensures that we reconcile `pdb` metadata changes.

Without the proposed changes, the code doesn't for metadata changes and injects the cluster `SetInheritedDataAndOwnership` only during `pdb` creation.