### PR TITLE
fix: correctly evaluate the request and response for the backup mode

### DIFF
--- a/controllers/backup_controller.go
+++ b/controllers/backup_controller.go
@@ -377,7 +377,7 @@ func (r *BackupReconciler) reconcileSnapshotBackup(
 		NewExecutorBuilder(r.Client, r.Recorder).
 		Build()
 
-	res, err := executor.Execute(ctx, cluster, backup, targetPod, pvcs)
+	res, err := executor.Reconcile(ctx, cluster, backup, targetPod, pvcs)
 	if isErrorRetryable(err) {
 		contextLogger.Error(err, "detected retryable error while executing snapshot backup, retrying...")
 		return &ctrl.Result{RequeueAfter: 5 * time.Second}, nil
@@ -393,7 +393,7 @@ func (r *BackupReconciler) reconcileSnapshotBackup(
 
 		r.Recorder.Eventf(backup, "Warning", "Error", "snapshot backup failed: %v", err)
 		tryFlagBackupAsFailed(ctx, r.Client, backup, fmt.Errorf("can't execute snapshot backup: %w", err))
-		return nil, executor.EnsurePodIsUnfenced(ctx, cluster, backup, targetPod)
+		return nil, volumesnapshot.EnsurePodIsUnfenced(ctx, r.Client, r.Recorder, cluster, backup, targetPod)
 	}
 
 	if res != nil {

--- a/controllers/backup_controller.go
+++ b/controllers/backup_controller.go
@@ -373,11 +373,11 @@ func (r *BackupReconciler) reconcileSnapshotBackup(
 		return nil, fmt.Errorf("cannot get PVCs: %w", err)
 	}
 
-	executor := volumesnapshot.
-		NewExecutorBuilder(r.Client, r.Recorder).
+	reconciler := volumesnapshot.
+		NewReconcilerBuilder(r.Client, r.Recorder).
 		Build()
 
-	res, err := executor.Reconcile(ctx, cluster, backup, targetPod, pvcs)
+	res, err := reconciler.Reconcile(ctx, cluster, backup, targetPod, pvcs)
 	if isErrorRetryable(err) {
 		contextLogger.Error(err, "detected retryable error while executing snapshot backup, retrying...")
 		return &ctrl.Result{RequeueAfter: 5 * time.Second}, nil

--- a/pkg/management/postgres/webserver/backup_client.go
+++ b/pkg/management/postgres/webserver/backup_client.go
@@ -64,21 +64,6 @@ func (c *BackupClient) StatusWithBodyErrors(ctx context.Context, podIP string) (
 	return executeRequestWithError[BackupResultData](ctx, c.cli, req, true)
 }
 
-// Status the current status of the backup. Returns empty BackupResultData struct if it is not running.
-func (c *BackupClient) Status(ctx context.Context, podIP string) (*BackupResultData, error) {
-	httpURL := url.Build(podIP, url.PathPgModeBackup, url.StatusPort)
-	req, err := http.NewRequestWithContext(ctx, "GET", httpURL, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	res, err := executeRequestWithError[BackupResultData](ctx, c.cli, req, false)
-	if err != nil {
-		return nil, err
-	}
-	return res.Data, err
-}
-
 // Start runs the pg_start_backup
 func (c *BackupClient) Start(
 	ctx context.Context,

--- a/pkg/management/postgres/webserver/backup_client.go
+++ b/pkg/management/postgres/webserver/backup_client.go
@@ -72,8 +72,11 @@ func (c *BackupClient) Status(ctx context.Context, podIP string) (*BackupResultD
 		return nil, err
 	}
 
-	_, err = executeRequestWithError[BackupResultData](ctx, c.cli, req, false)
-	return nil, err
+	res, err := executeRequestWithError[BackupResultData](ctx, c.cli, req, false)
+	if err != nil {
+		return nil, err
+	}
+	return res.Data, err
 }
 
 // Start runs the pg_start_backup

--- a/pkg/management/postgres/webserver/backup_client.go
+++ b/pkg/management/postgres/webserver/backup_client.go
@@ -84,29 +84,35 @@ func (c *BackupClient) Start(
 	ctx context.Context,
 	podIP string,
 	sbq StartBackupRequest,
-) (*struct{}, error) {
+) error {
 	httpURL := url.Build(podIP, url.PathPgModeBackup, url.StatusPort)
 
 	// Marshalling the payload to JSON
 	jsonBody, err := json.Marshal(sbq)
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal payload: %w", err)
+		return fmt.Errorf("failed to marshal start payload: %w", err)
 	}
 
 	req, err := http.NewRequestWithContext(ctx, "POST", httpURL, bytes.NewReader(jsonBody))
 	if err != nil {
-		return nil, err
+		return err
 	}
 	req.Header.Set("Content-Type", "application/json")
 
 	_, err = executeRequestWithError[struct{}](ctx, c.cli, req, false)
-	return nil, err
+	return err
 }
 
 // Stop runs the pg_stop_backup
-func (c *BackupClient) Stop(ctx context.Context, podIP string) error {
+func (c *BackupClient) Stop(ctx context.Context, podIP string, sbq StopBackupRequest) error {
 	httpURL := url.Build(podIP, url.PathPgModeBackup, url.StatusPort)
-	req, err := http.NewRequestWithContext(ctx, "DELETE", httpURL, nil)
+	// Marshalling the payload to JSON
+	jsonBody, err := json.Marshal(sbq)
+	if err != nil {
+		return fmt.Errorf("failed to marshal stop payload: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "PUT", httpURL, bytes.NewReader(jsonBody))
 	if err != nil {
 		return err
 	}

--- a/pkg/management/postgres/webserver/backup_connection.go
+++ b/pkg/management/postgres/webserver/backup_connection.go
@@ -48,7 +48,6 @@ const (
 	Starting  BackupConnectionPhase = "starting"
 	Started   BackupConnectionPhase = "started"
 	Closing   BackupConnectionPhase = "closing"
-	Failed    BackupConnectionPhase = "failed"
 	Completed BackupConnectionPhase = "completed"
 )
 
@@ -139,8 +138,6 @@ func (bc *backupConnection) startBackup(ctx context.Context) {
 		if bc.err == nil {
 			return
 		}
-		bc.data.Phase = Failed
-
 		contextLogger.Error(bc.err, "encountered error while starting backup")
 
 		if err := bc.conn.Close(); err != nil {
@@ -190,9 +187,6 @@ func (bc *backupConnection) stopBackup(ctx context.Context) {
 			}
 		}
 
-		if bc.err != nil {
-			bc.data.Phase = Failed
-		}
 	}()
 
 	if bc.err != nil {

--- a/pkg/management/postgres/webserver/remote.go
+++ b/pkg/management/postgres/webserver/remote.go
@@ -223,7 +223,7 @@ func (ws *remoteWebserverEndpoints) backup(w http.ResponseWriter, req *http.Requ
 	switch req.Method {
 	case http.MethodGet:
 		if ws.currentBackup == nil {
-			sendDataJSONData(w, 200, struct{}{})
+			sendJSONResponseWithData(w, 200, struct{}{})
 			return
 		}
 
@@ -275,7 +275,7 @@ func (ws *remoteWebserverEndpoints) backup(w http.ResponseWriter, req *http.Requ
 			return
 		}
 		go ws.currentBackup.startBackup(context.Background(), p.BackupName)
-		sendDataJSONData(w, 200, struct{}{})
+		sendJSONResponseWithData(w, 200, struct{}{})
 		return
 
 	case http.MethodPut:
@@ -302,7 +302,7 @@ func (ws *remoteWebserverEndpoints) backup(w http.ResponseWriter, req *http.Requ
 		}
 
 		if ws.currentBackup.data.Phase == Closing {
-			sendDataJSONData(w, 200, struct{}{})
+			sendJSONResponseWithData(w, 200, struct{}{})
 			return
 		}
 
@@ -319,12 +319,12 @@ func (ws *remoteWebserverEndpoints) backup(w http.ResponseWriter, req *http.Requ
 				}
 			}
 
-			sendDataJSONData(w, 200, struct{}{})
+			sendJSONResponseWithData(w, 200, struct{}{})
 			return
 		}
 		ws.currentBackup.setPhase(Closing, p.BackupName)
 		go ws.currentBackup.stopBackup(context.Background(), p.BackupName)
-		sendDataJSONData(w, 200, struct{}{})
+		sendJSONResponseWithData(w, 200, struct{}{})
 		return
 	}
 }

--- a/pkg/management/postgres/webserver/remote.go
+++ b/pkg/management/postgres/webserver/remote.go
@@ -257,7 +257,7 @@ func (ws *remoteWebserverEndpoints) backup(w http.ResponseWriter, req *http.Requ
 				sendUnprocessableEntityJSONResponse(w, "PROCESS_ALREADY_RUNNING", "")
 				return
 			}
-			if err := ws.currentBackup.conn.Close(); err != nil {
+			if err := ws.currentBackup.closeConnection(p.BackupName); err != nil {
 				if !errors.Is(err, sql.ErrConnDone) {
 					log.Error(err, "Error while closing backup connection (start)")
 				}
@@ -313,7 +313,7 @@ func (ws *remoteWebserverEndpoints) backup(w http.ResponseWriter, req *http.Requ
 		}
 
 		if ws.currentBackup.err != nil {
-			if err := ws.currentBackup.conn.Close(); err != nil {
+			if err := ws.currentBackup.closeConnection(p.BackupName); err != nil {
 				if !errors.Is(err, sql.ErrConnDone) {
 					log.Error(err, "Error while closing backup connection (stop)")
 				}

--- a/pkg/management/postgres/webserver/remote.go
+++ b/pkg/management/postgres/webserver/remote.go
@@ -247,7 +247,6 @@ func (ws *remoteWebserverEndpoints) backup(w http.ResponseWriter, req *http.Requ
 				sendUnprocessableEntityJSONResponse(w, "PROCESS_ALREADY_RUNNING", "")
 				return
 			}
-			ws.currentBackup.data.Phase = Failed
 			if err := ws.currentBackup.conn.Close(); err != nil {
 				if !errors.Is(err, sql.ErrConnDone) {
 					log.Error(err, "Error while closing backup connection (start)")
@@ -293,7 +292,6 @@ func (ws *remoteWebserverEndpoints) backup(w http.ResponseWriter, req *http.Requ
 				}
 			}
 
-			ws.currentBackup.data.Phase = Failed
 			sendDataJSONData(w, 200, struct{}{})
 			return
 		}

--- a/pkg/management/postgres/webserver/webserver.go
+++ b/pkg/management/postgres/webserver/webserver.go
@@ -113,7 +113,16 @@ func sendBadRequestJSONResponse(w http.ResponseWriter, errorCode string, message
 	})
 }
 
-func sendDataJSONResponse[T interface{}](w http.ResponseWriter, statusCode int, data T) {
+func sendUnprocessableEntityJSONResponse(w http.ResponseWriter, errorCode string, message string) {
+	sendJSONResponse(w, http.StatusUnprocessableEntity, Response[any]{
+		Error: &Error{
+			Code:    errorCode,
+			Message: message,
+		},
+	})
+}
+
+func sendDataJSONData[T interface{}](w http.ResponseWriter, statusCode int, data T) {
 	sendJSONResponse(w, statusCode, Response[T]{
 		Data: &data,
 	})

--- a/pkg/management/postgres/webserver/webserver.go
+++ b/pkg/management/postgres/webserver/webserver.go
@@ -62,7 +62,7 @@ func (body Response[T]) EnsureDataIsPresent() error {
 			body.Error.Code, body.Error.Message)
 	}
 
-	return fmt.Errorf("encounteered a unspecified error while preparing, body: %v", body)
+	return fmt.Errorf("encounteered an empty body while expecting it to not be empty")
 }
 
 // Webserver contains a server that interacts with postgres instance

--- a/pkg/management/postgres/webserver/webserver.go
+++ b/pkg/management/postgres/webserver/webserver.go
@@ -19,6 +19,7 @@ package webserver
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"time"
 
@@ -47,6 +48,21 @@ type Error struct {
 type Response[T interface{}] struct {
 	Data  *T     `json:"data,omitempty"`
 	Error *Error `json:"error,omitempty"`
+}
+
+// EnsureDataIsPresent returns an error if the data is field is nil
+func (body Response[T]) EnsureDataIsPresent() error {
+	status := body.Data
+	if status != nil {
+		return nil
+	}
+
+	if body.Error != nil {
+		return fmt.Errorf("encountered a body error while preparing, code: '%s', message: %s",
+			body.Error.Code, body.Error.Message)
+	}
+
+	return fmt.Errorf("encounteered a unspecified error while preparing, body: %v", body)
 }
 
 // Webserver contains a server that interacts with postgres instance

--- a/pkg/management/postgres/webserver/webserver.go
+++ b/pkg/management/postgres/webserver/webserver.go
@@ -138,7 +138,7 @@ func sendUnprocessableEntityJSONResponse(w http.ResponseWriter, errorCode string
 	})
 }
 
-func sendDataJSONData[T interface{}](w http.ResponseWriter, statusCode int, data T) {
+func sendJSONResponseWithData[T interface{}](w http.ResponseWriter, statusCode int, data T) {
 	sendJSONResponse(w, statusCode, Response[T]{
 		Data: &data,
 	})

--- a/pkg/reconciler/backup/volumesnapshot/offline.go
+++ b/pkg/reconciler/backup/volumesnapshot/offline.go
@@ -1,0 +1,150 @@
+/*
+Copyright The CloudNativePG Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package volumesnapshot
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/strings/slices"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/log"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/resources"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
+)
+
+type offlineExecutor struct {
+	cli      client.Client
+	recorder record.EventRecorder
+}
+
+func newOfflineExecutor(cli client.Client, recorder record.EventRecorder) *offlineExecutor {
+	return &offlineExecutor{cli: cli, recorder: recorder}
+}
+
+func (o offlineExecutor) finalize(
+	ctx context.Context,
+	cluster *apiv1.Cluster,
+	backup *apiv1.Backup,
+	targetPod *corev1.Pod,
+) (*ctrl.Result, error) {
+	return nil, EnsurePodIsUnfenced(ctx, o.cli, o.recorder, cluster, backup, targetPod)
+}
+
+func (o offlineExecutor) prepare(
+	ctx context.Context,
+	cluster *apiv1.Cluster,
+	backup *apiv1.Backup,
+	targetPod *corev1.Pod,
+) (*ctrl.Result, error) {
+	contextLogger := log.FromContext(ctx)
+
+	// Handle cold snapshots
+	contextLogger.Debug("Checking pre-requisites")
+	if err := o.ensurePodIsFenced(ctx, cluster, backup, targetPod.Name); err != nil {
+		return nil, err
+	}
+
+	if res, err := o.waitForPodToBeFenced(ctx, targetPod); res != nil || err != nil {
+		return res, err
+	}
+
+	return nil, nil
+}
+
+// waitForPodToBeFenced waits for the target Pod to be shut down
+func (o *offlineExecutor) waitForPodToBeFenced(
+	ctx context.Context,
+	targetPod *corev1.Pod,
+) (*ctrl.Result, error) {
+	contextLogger := log.FromContext(ctx)
+
+	var pod corev1.Pod
+	err := o.cli.Get(ctx, types.NamespacedName{Name: targetPod.Name, Namespace: targetPod.Namespace}, &pod)
+	if err != nil {
+		return nil, err
+	}
+	ready := utils.IsPodReady(pod)
+	if ready {
+		contextLogger.Info("Waiting for target Pod to not be ready, retrying", "podName", targetPod.Name)
+		return &ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+	}
+	return nil, nil
+}
+
+// ensurePodIsFenced checks if the preconditions for the execution of this step are
+// met or not. If they are not met, it will return an error
+func (o *offlineExecutor) ensurePodIsFenced(
+	ctx context.Context,
+	cluster *apiv1.Cluster,
+	backup *apiv1.Backup,
+	targetPodName string,
+) error {
+	contextLogger := log.FromContext(ctx)
+
+	fencedInstances, err := utils.GetFencedInstances(cluster.Annotations)
+	if err != nil {
+		return fmt.Errorf("could not check if cluster is fenced: %v", err)
+	}
+
+	if slices.Equal(fencedInstances.ToList(), []string{targetPodName}) {
+		// We already requested the target Pod to be fenced
+		return nil
+	}
+
+	if fencedInstances.Len() != 0 {
+		return errors.New("cannot execute volume snapshot on a cluster that has fenced instances")
+	}
+
+	if targetPodName == cluster.Status.CurrentPrimary || targetPodName == cluster.Status.TargetPrimary {
+		contextLogger.Warning(
+			"Cold Snapshot Backup targets the primary. Primary will be fenced",
+			"targetBackup", backup.Name, "targetPod", targetPodName,
+		)
+	}
+
+	err = resources.ApplyFenceFunc(
+		ctx,
+		o.cli,
+		cluster.Name,
+		cluster.Namespace,
+		targetPodName,
+		utils.AddFencedInstance,
+	)
+	if errors.Is(err, utils.ErrorServerAlreadyFenced) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	// The list of fenced instances is empty, so we need to request
+	// fencing for the target pod
+	contextLogger.Info("Fencing Pod", "podName", targetPodName)
+	o.recorder.Eventf(backup, "Normal", "FencePod",
+		"Fencing Pod %v", targetPodName)
+
+	return nil
+}

--- a/pkg/reconciler/backup/volumesnapshot/online.go
+++ b/pkg/reconciler/backup/volumesnapshot/online.go
@@ -102,12 +102,13 @@ func (o *onlineExecutor) prepare(
 		if _, err := o.backupClient.Start(ctx, targetPod.Status.PodIP, req); err != nil {
 			return nil, fmt.Errorf("while trying to start the backup: %w", err)
 		}
+		return &ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 	case status.Phase == webserver.Starting:
 		return &ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 	case status.Phase == webserver.Started:
 		return nil, nil
+	default:
+		return nil, fmt.Errorf("found the instance is an unexpected phase while preparing the snapshot: %s",
+			status.Phase)
 	}
-
-	return nil, fmt.Errorf("found the instance is an unexpected phase while preparing the snapshot: %s",
-		status.Phase)
 }

--- a/pkg/reconciler/backup/volumesnapshot/online.go
+++ b/pkg/reconciler/backup/volumesnapshot/online.go
@@ -77,7 +77,9 @@ func (o *onlineExecutor) finalize(
 
 	switch status.Phase {
 	case webserver.Started:
-		if err := o.backupClient.Stop(ctx, targetPod.Status.PodIP); err != nil {
+		if err := o.backupClient.Stop(ctx,
+			targetPod.Status.PodIP,
+			*webserver.NewStopBackupRequest(backup.Name)); err != nil {
 			return nil, fmt.Errorf("while stopping the backup client: %w", err)
 		}
 		return &ctrl.Result{RequeueAfter: time.Second * 5}, nil
@@ -118,7 +120,7 @@ func (o *onlineExecutor) prepare(
 			BackupName:          backup.Name,
 			Force:               true,
 		}
-		if _, err := o.backupClient.Start(ctx, targetPod.Status.PodIP, req); err != nil {
+		if err := o.backupClient.Start(ctx, targetPod.Status.PodIP, req); err != nil {
 			return nil, fmt.Errorf("while trying to start the backup: %w", err)
 		}
 		return &ctrl.Result{RequeueAfter: 5 * time.Second}, nil

--- a/pkg/reconciler/backup/volumesnapshot/online.go
+++ b/pkg/reconciler/backup/volumesnapshot/online.go
@@ -108,5 +108,6 @@ func (o *onlineExecutor) prepare(
 		return nil, nil
 	}
 
-	return nil, fmt.Errorf("found zero snapshot but the instance is in phase: %s", status.Phase)
+	return nil, fmt.Errorf("found the instance is an unexpected phase while preparing the snapshot: %s",
+		status.Phase)
 }

--- a/pkg/reconciler/backup/volumesnapshot/online.go
+++ b/pkg/reconciler/backup/volumesnapshot/online.go
@@ -1,0 +1,105 @@
+/*
+Copyright The CloudNativePG Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package volumesnapshot
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres/webserver"
+)
+
+type onlineExecutor struct {
+	backupClient *webserver.BackupClient
+}
+
+func newOnlineExecutor() *onlineExecutor {
+	return &onlineExecutor{backupClient: webserver.NewBackupClient()}
+}
+
+func (o *onlineExecutor) finalize(
+	ctx context.Context,
+	_ *apiv1.Cluster,
+	backup *apiv1.Backup,
+	targetPod *corev1.Pod,
+) (*ctrl.Result, error) {
+	status, err := o.backupClient.Status(ctx, targetPod.Status.PodIP)
+	if err != nil {
+		return nil, fmt.Errorf("while getting status: %w", err)
+	}
+
+	switch status.Phase {
+	case webserver.Started:
+		if err := o.backupClient.Stop(ctx, targetPod.Status.PodIP); err != nil {
+			return nil, fmt.Errorf("while stopping the backup client: %w", err)
+		}
+		return &ctrl.Result{RequeueAfter: time.Second * 5}, nil
+	case webserver.Closing:
+		return &ctrl.Result{RequeueAfter: time.Second * 5}, nil
+	case webserver.Completed:
+		backup.Status.BeginLSN = string(status.BeginLSN)
+		backup.Status.EndLSN = string(status.EndLSN)
+		backup.Status.TablespaceMapFile = status.SpcmapFile
+		backup.Status.BackupLabelFile = status.LabelFile
+
+		return nil, nil
+	default:
+		return nil, fmt.Errorf(
+			"found the instance in an unexpected state while finalizing the backup, phase: %s",
+			status.Phase,
+		)
+	}
+}
+
+func (o *onlineExecutor) prepare(
+	ctx context.Context,
+	cluster *apiv1.Cluster,
+	backup *apiv1.Backup,
+	targetPod *corev1.Pod,
+) (*ctrl.Result, error) {
+	volumeSnapshotConfig := backup.GetVolumeSnapshotConfiguration(*cluster.Spec.Backup.VolumeSnapshot)
+
+	// Handle hot snapshots
+	status, err := o.backupClient.Status(ctx, targetPod.Status.PodIP)
+	if err != nil {
+		return nil, fmt.Errorf("while getting status: %w", err)
+	}
+	switch {
+	// if the backupName doesn't match it means we have an old stuck pending backup that we have to force out.
+	case status.Phase == "", backup.Name != status.BackupName:
+		req := webserver.StartBackupRequest{
+			ImmediateCheckpoint: volumeSnapshotConfig.OnlineConfiguration.GetImmediateCheckpoint(),
+			WaitForArchive:      volumeSnapshotConfig.OnlineConfiguration.GetWaitForArchive(),
+			BackupName:          backup.Name,
+			Force:               true,
+		}
+		if _, err := o.backupClient.Start(ctx, targetPod.Status.PodIP, req); err != nil {
+			return nil, fmt.Errorf("while trying to start the backup: %w", err)
+		}
+	case status.Phase == webserver.Starting:
+		return &ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+	case status.Phase == webserver.Started:
+		return nil, nil
+	}
+
+	return nil, fmt.Errorf("found zero snapshot but the instance is in phase: %s", status.Phase)
+}

--- a/pkg/reconciler/backup/volumesnapshot/online.go
+++ b/pkg/reconciler/backup/volumesnapshot/online.go
@@ -42,7 +42,7 @@ func (o *onlineExecutor) finalize(
 	backup *apiv1.Backup,
 	targetPod *corev1.Pod,
 ) (*ctrl.Result, error) {
-	body, err := o.backupClient.StatusWithBodyErrors(ctx, targetPod.Status.PodIP)
+	body, err := o.backupClient.StatusWithErrors(ctx, targetPod.Status.PodIP)
 	if err != nil {
 		return nil, fmt.Errorf("while getting status while finalizing: %w", err)
 	}
@@ -102,7 +102,7 @@ func (o *onlineExecutor) prepare(
 	volumeSnapshotConfig := backup.GetVolumeSnapshotConfiguration(*cluster.Spec.Backup.VolumeSnapshot)
 
 	// Handle hot snapshots
-	body, err := o.backupClient.StatusWithBodyErrors(ctx, targetPod.Status.PodIP)
+	body, err := o.backupClient.StatusWithErrors(ctx, targetPod.Status.PodIP)
 	if err != nil {
 		return nil, fmt.Errorf("while getting status while preparing: %w", err)
 	}

--- a/pkg/reconciler/backup/volumesnapshot/online.go
+++ b/pkg/reconciler/backup/volumesnapshot/online.go
@@ -47,6 +47,13 @@ func (o *onlineExecutor) finalize(
 		return nil, fmt.Errorf("while getting status: %w", err)
 	}
 
+	if status.BackupName != backup.Name {
+		return nil, fmt.Errorf("trying to stop backup with name: %s, while reconciling backup with name: %s",
+			status.BackupName,
+			backup.Name,
+		)
+	}
+
 	switch status.Phase {
 	case webserver.Started:
 		if err := o.backupClient.Stop(ctx, targetPod.Status.PodIP); err != nil {

--- a/pkg/reconciler/backup/volumesnapshot/reconciler.go
+++ b/pkg/reconciler/backup/volumesnapshot/reconciler.go
@@ -53,8 +53,8 @@ type ExecutorBuilder struct {
 	executor Reconciler
 }
 
-// NewExecutorBuilder instantiates a new ExecutorBuilder with the minimum required data
-func NewExecutorBuilder(
+// NewReconcilerBuilder instantiates a new ExecutorBuilder with the minimum required data
+func NewReconcilerBuilder(
 	cli client.Client,
 	recorder record.EventRecorder,
 ) *ExecutorBuilder {

--- a/pkg/reconciler/backup/volumesnapshot/reconciler_test.go
+++ b/pkg/reconciler/backup/volumesnapshot/reconciler_test.go
@@ -143,7 +143,7 @@ var _ = Describe("Volumesnapshot reconciler", func() {
 
 		fakeRecorder := record.NewFakeRecorder(3)
 
-		executor := NewExecutorBuilder(mockClient, fakeRecorder).
+		executor := NewReconcilerBuilder(mockClient, fakeRecorder).
 			Build()
 
 		result, err := executor.Reconcile(ctx, cluster, backup, targetPod, pvcs)
@@ -199,7 +199,7 @@ var _ = Describe("Volumesnapshot reconciler", func() {
 			Build()
 		fakeRecorder := record.NewFakeRecorder(3)
 
-		executor := NewExecutorBuilder(mockClient, fakeRecorder).
+		executor := NewReconcilerBuilder(mockClient, fakeRecorder).
 			Build()
 
 		result, err := executor.Reconcile(ctx, cluster, backup, targetPod, pvcs)
@@ -269,7 +269,7 @@ var _ = Describe("Volumesnapshot reconciler", func() {
 			Build()
 		fakeRecorder := record.NewFakeRecorder(3)
 
-		executor := NewExecutorBuilder(mockClient, fakeRecorder).
+		executor := NewReconcilerBuilder(mockClient, fakeRecorder).
 			Build()
 
 		result, err := executor.Reconcile(ctx, cluster, backup, targetPod, pvcs)
@@ -345,7 +345,7 @@ var _ = Describe("Volumesnapshot reconciler", func() {
 			Build()
 		fakeRecorder := record.NewFakeRecorder(3)
 
-		executor := NewExecutorBuilder(mockClient, fakeRecorder).
+		executor := NewReconcilerBuilder(mockClient, fakeRecorder).
 			Build()
 
 		result, err := executor.Reconcile(ctx, cluster, backup, targetPod, pvcs)

--- a/pkg/reconciler/backup/volumesnapshot/reconciler_test.go
+++ b/pkg/reconciler/backup/volumesnapshot/reconciler_test.go
@@ -146,7 +146,7 @@ var _ = Describe("Volumesnapshot reconciler", func() {
 		executor := NewExecutorBuilder(mockClient, fakeRecorder).
 			Build()
 
-		result, err := executor.Execute(ctx, cluster, backup, targetPod, pvcs)
+		result, err := executor.Reconcile(ctx, cluster, backup, targetPod, pvcs)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(result).ToNot(BeNil())
 
@@ -202,7 +202,7 @@ var _ = Describe("Volumesnapshot reconciler", func() {
 		executor := NewExecutorBuilder(mockClient, fakeRecorder).
 			Build()
 
-		result, err := executor.Execute(ctx, cluster, backup, targetPod, pvcs)
+		result, err := executor.Reconcile(ctx, cluster, backup, targetPod, pvcs)
 		Expect(err).ToNot(HaveOccurred())
 		// we should have found snapshots that are not ready, and so we'd return to
 		// wait for them to be ready
@@ -272,7 +272,7 @@ var _ = Describe("Volumesnapshot reconciler", func() {
 		executor := NewExecutorBuilder(mockClient, fakeRecorder).
 			Build()
 
-		result, err := executor.Execute(ctx, cluster, backup, targetPod, pvcs)
+		result, err := executor.Reconcile(ctx, cluster, backup, targetPod, pvcs)
 		Expect(err).ToNot(HaveOccurred())
 		// we should have found snapshots that have been privisioned, so we need to
 		// wait until they are ready in a next reconciliation loop
@@ -348,7 +348,7 @@ var _ = Describe("Volumesnapshot reconciler", func() {
 		executor := NewExecutorBuilder(mockClient, fakeRecorder).
 			Build()
 
-		result, err := executor.Execute(ctx, cluster, backup, targetPod, pvcs)
+		result, err := executor.Reconcile(ctx, cluster, backup, targetPod, pvcs)
 		Expect(err).ToNot(HaveOccurred())
 		// we should have found snapshots that are ready, and so the result
 		// should be nil


### PR DESCRIPTION
In the old code for the status endpoint, we evaluated the body errors as an error response code. This needed to be corrected, given that this would lead the old code to an infinite stuck-on error response when the held backup connection contained an error.

With the new implementation, the caller determines if the returned body error is relevant to the backup that is trying to run.

The patch also ensures that requests for outdated backups aren't processed.
