### PR TITLE
feat(kubectl-cnpg): add pgdump command

### DIFF
--- a/cmd/kubectl-cnpg/main.go
+++ b/cmd/kubectl-cnpg/main.go
@@ -36,6 +36,7 @@ import (
 	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/plugin/logs"
 	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/plugin/maintenance"
 	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/plugin/pgbench"
+	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/plugin/pgdump"
 	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/plugin/promote"
 	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/plugin/psql"
 	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/plugin/reload"

--- a/internal/cmd/plugin/pgdump/cmd.go
+++ b/internal/cmd/plugin/pgdump/cmd.go
@@ -1,0 +1,86 @@
+/*
+Copyright The CloudNativePG Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pgdump
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/plugin"
+)
+
+// NewCmd creates the "pgdump" command
+func NewCmd() *cobra.Command {
+	var replica bool
+	var allocateTTY bool
+	var passStdin bool
+
+	cmd := &cobra.Command{
+		Use:   "pgdump [cluster] [-- pgdumpArgs...]",
+		Short: "Start a pgdump comment targeting a CloudNativePG cluster",
+		Args:  validatePgdumpArgs,
+		Long:  "This command will start an pgdump command inside a PostgreSQL Pod created by CloudNativePG.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clusterName := args[0]
+			pgdumpArgs := args[1:]
+			pgdumpOptions := pgdumpCommandOptions{
+				replica:     replica,
+				namespace:   plugin.Namespace,
+				passStdin:   passStdin,
+				args:        pgdumpArgs,
+				name:        clusterName,
+			}
+
+			pgdumpCommand, err := newPgdumpCommand(cmd.Context(), pgdumpOptions)
+			if err != nil {
+				return err
+			}
+
+			return pgdumpCommand.exec()
+		},
+	}
+
+	cmd.Flags().BoolVar(
+		&replica,
+		"replica",
+		false,
+		"Connects to the first replica on the pod list (by default connects to the primary)",
+	)
+
+	cmd.Flags().BoolVarP(
+		&passStdin,
+		"stdin",
+		"i",
+		true,
+		"Whether to pass stdin to the container",
+	)
+
+	return cmd
+}
+
+func validatePgdumpArgs(cmd *cobra.Command, args []string) error {
+	if err := cobra.MinimumNArgs(1)(cmd, args); err != nil {
+		return err
+	}
+
+	if cmd.ArgsLenAtDash() > 1 {
+		return fmt.Errorf("pgdumpArgs should be passed after -- delimitator")
+	}
+
+	return nil
+}

--- a/internal/cmd/plugin/pgdump/doc.go
+++ b/internal/cmd/plugin/pgdump/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright The CloudNativePG Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package pgdump implements the `kubectl cnpg pgdump` command
+package pgdump

--- a/internal/cmd/plugin/pgdump/pgdump.go
+++ b/internal/cmd/plugin/pgdump/pgdump.go
@@ -1,0 +1,160 @@
+/*
+Copyright The CloudNativePG Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pgdump
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"syscall"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/plugin"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/specs"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
+)
+
+const (
+	// kubectlCommand is used to execute a command inside a Pod
+	kubectlCommand = "kubectl"
+)
+
+// pgdumpCommand is the launcher of `pgdump` with `kubectl exec`
+type pgdumpCommand struct {
+	pgdumpCommandOptions
+
+	// The list of possible pods where to launch pgdump
+	podList []corev1.Pod
+
+	// The path of kubectl
+	kubectlPath string
+}
+
+// pgdumpCommandOptions are the options required to start pgdump
+type pgdumpCommandOptions struct {
+	// Require a connection to a replica
+	replica bool
+
+	// The cluster name
+	name string
+
+	// The namespace where we're working in
+	namespace string
+
+	// Whether we should we pass stdin to pgdump
+	passStdin bool
+
+	// Arguments to pass to pgdump
+	args []string
+}
+
+// newPgdumpCommand creates a new pgdump command
+func newPgdumpCommand(
+	ctx context.Context,
+	options pgdumpCommandOptions,
+) (*pgdumpCommand, error) {
+	var pods corev1.PodList
+	if err := plugin.Client.List(
+		ctx,
+		&pods,
+		client.MatchingLabels{utils.ClusterLabelName: options.name},
+		client.InNamespace(plugin.Namespace),
+	); err != nil {
+		return nil, err
+	}
+
+	kubectlPath, err := exec.LookPath(kubectlCommand)
+	if err != nil {
+		return nil, fmt.Errorf("while getting kubectl path: %w", err)
+	}
+
+	return &pgdumpCommand{
+		pgdumpCommandOptions: options,
+		podList:            pods.Items,
+		kubectlPath:        kubectlPath,
+	}, nil
+}
+
+// getKubectlInvocation gets the kubectl command to be executed
+func (pgdump *pgdumpCommand) getKubectlInvocation() ([]string, error) {
+	result := make([]string, 0, 11+len(pgdump.args))
+	result = append(result, "kubectl", "exec")
+
+	if pgdump.passStdin {
+		result = append(result, "-i")
+	}
+	if len(pgdump.namespace) > 0 {
+		result = append(result, "-n", pgdump.namespace)
+	}
+	result = append(result, "-c", specs.PostgresContainerName)
+
+	podName, err := pgdump.getPodName()
+	if err != nil {
+		return nil, err
+	}
+
+	result = append(result, podName)
+	result = append(result, "--", "pgdump")
+	result = append(result, pgdump.args...)
+	return result, nil
+}
+
+// getPodName get the first Pod name with the required role
+func (pgdump *pgdumpCommand) getPodName() (string, error) {
+	targetPodRole := specs.ClusterRoleLabelPrimary
+	if pgdump.replica {
+		targetPodRole = specs.ClusterRoleLabelReplica
+	}
+
+	for i := range pgdump.podList {
+		podRole, _ := utils.GetInstanceRole(pgdump.podList[i].Labels)
+		if podRole == targetPodRole {
+			return pgdump.podList[i].Name, nil
+		}
+	}
+
+	return "", &ErrMissingPod{role: targetPodRole}
+}
+
+// exec replaces the current process with a `kubectl exec` invocation.
+// This function won't return
+func (pgdump *pgdumpCommand) exec() error {
+	kubectlExec, err := pgdump.getKubectlInvocation()
+	if err != nil {
+		return err
+	}
+
+	err = syscall.Exec(pgdump.kubectlPath, kubectlExec, os.Environ()) // #nosec
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ErrMissingPod is raised when we can't find a Pod having the desired role
+type ErrMissingPod struct {
+	role string
+}
+
+// Error implements the error interface
+func (err *ErrMissingPod) Error() string {
+	return fmt.Sprintf("cannot find Pod with role \"%s\"", err.role)
+}

--- a/internal/cmd/plugin/pgdump/pgdump_test.go
+++ b/internal/cmd/plugin/pgdump/pgdump_test.go
@@ -1,0 +1,139 @@
+/*
+Copyright The CloudNativePG Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pgdump
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/specs"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("pgdump launcher", func() {
+	podList := []corev1.Pod{
+		fakePod("cluster-example-1", specs.ClusterRoleLabelReplica),
+		fakePod("cluster-example-2", specs.ClusterRoleLabelPrimary),
+		fakePod("cluster-example-3", specs.ClusterRoleLabelReplica),
+	}
+
+	It("selects the correct Pod when looking for a primary", func() {
+		cmd := pgdumpCommand{
+			pgdumpCommandOptions: pgdumpCommandOptions{
+				replica: false,
+			},
+			podList: podList,
+		}
+		Expect(cmd.getPodName()).To(Equal("cluster-example-2"))
+	})
+
+	It("selects the correct Pod when looking for a replica", func() {
+		cmd := pgdumpCommand{
+			pgdumpCommandOptions: pgdumpCommandOptions{
+				replica: true,
+			},
+			podList: podList,
+		}
+		Expect(cmd.getPodName()).To(Equal("cluster-example-1"))
+	})
+
+	It("raises an error when a Pod cannot be found", func() {
+		fakePodList := []corev1.Pod{
+			fakePod("cluster-example-1", "guitar"),
+			fakePod("cluster-example-2", "piano"),
+			fakePod("cluster-example-3", "oboe"),
+		}
+
+		cmd := pgdumpCommand{
+			pgdumpCommandOptions: pgdumpCommandOptions{
+				replica: false,
+			},
+			podList: fakePodList,
+		}
+
+		_, err := cmd.getPodName()
+		Expect(err).To(HaveOccurred())
+		Expect(err.(*ErrMissingPod)).ToNot(BeNil())
+	})
+
+	It("correctly composes a kubectl exec command line", func() {
+		cmd := pgdumpCommand{
+			pgdumpCommandOptions: pgdumpCommandOptions{
+				replica:     true,
+				allocateTTY: true,
+				passStdin:   true,
+				namespace:   "default",
+			},
+			podList: podList,
+		}
+		Expect(cmd.getKubectlInvocation()).To(ConsistOf(
+			"kubectl",
+			"exec",
+			"-t",
+			"-i",
+			"-n",
+			"default",
+			"-c",
+			"postgres",
+			"cluster-example-1",
+			"--",
+			"pgdump",
+		))
+	})
+
+	It("correctly composes a kubectl exec command line with pgdump args", func() {
+		cmd := pgdumpCommand{
+			pgdumpCommandOptions: pgdumpCommandOptions{
+				replica:   true,
+				namespace: "default",
+				args: []string{
+					"-n",
+					"schema1",
+				},
+			},
+			podList: podList,
+		}
+		Expect(cmd.getKubectlInvocation()).To(ConsistOf(
+			"kubectl",
+			"exec",
+			"-n",
+			"default",
+			"-c",
+			"postgres",
+			"cluster-example-1",
+			"--",
+			"pgdump",
+			"-n",
+			"schema1",
+		))
+	})
+})
+
+func fakePod(name, role string) corev1.Pod {
+	return corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+			Labels: map[string]string{
+				utils.ClusterRoleLabelName: role,
+			},
+		},
+	}
+}

--- a/internal/cmd/plugin/pgdump/suite_test.go
+++ b/internal/cmd/plugin/pgdump/suite_test.go
@@ -1,0 +1,33 @@
+/*
+Copyright The CloudNativePG Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pgdump
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// These tests use Ginkgo (BDD-style Go testing framework). Refer to
+// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
+
+func TestPgdump(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecs(t, "pgdump test suite")
+}


### PR DESCRIPTION
Dumb copy of the psql plugin to add a pgdump plugin. not sure if the psql `allocateTTY` is necessary in this case

expected usage : `kubectl cnpg pgdump -c -d mydb > backup.dump`

Also, should it be `pg_dump` or `pgdump` ?