### PR TITLE
feat: add support for VolumeGroupSnapshots

### DIFF
--- a/.wordlist-en-custom.txt
+++ b/.wordlist-en-custom.txt
@@ -491,6 +491,7 @@ VOLNAME
 Valerio
 ValidationError
 VirtualBox
+VolumeGroupSnapshot
 VolumeSnapshot
 VolumeSnapshotClass
 VolumeSnapshotConfiguration
@@ -826,6 +827,7 @@ goroutines
 gosec
 govulncheck
 grafana
+groupSnapshot
 gzip
 hashicorp
 hba

--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -162,6 +162,11 @@ type VolumeSnapshotConfiguration struct {
 	// +kubebuilder:default:={waitForArchive:true,immediateCheckpoint:false}
 	// +optional
 	OnlineConfiguration OnlineConfiguration `json:"onlineConfiguration,omitempty"`
+
+	// GroupSnapshot makes the operator use a VolumeGroupSnapshot resource
+	// instead of individual snapshots
+	// +kubebuilder:default:=false
+	GroupSnapshot bool `json:"groupSnapshot,omitempty"`
 }
 
 // OnlineConfiguration contains the configuration parameters for the online volume snapshot

--- a/config/crd/bases/postgresql.cnpg.io_clusters.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_clusters.yaml
@@ -1426,6 +1426,12 @@ spec:
                           ClassName specifies the Snapshot Class to be used for PG_DATA PersistentVolumeClaim.
                           It is the default class for the other types if no specific class is present
                         type: string
+                      groupSnapshot:
+                        default: false
+                        description: |-
+                          GroupSnapshot makes the operator use a VolumeGroupSnapshot resource
+                          instead of individual snapshots
+                        type: boolean
                       labels:
                         additionalProperties:
                           type: string

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -38,6 +38,7 @@ rules:
   - ""
   resources:
   - nodes
+  - persistentvolumes
   verbs:
   - get
   - list
@@ -111,6 +112,24 @@ rules:
   - create
   - get
   - update
+- apiGroups:
+  - groupsnapshot.storage.k8s.io
+  resources:
+  - volumegroupsnapshotcontents
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - groupsnapshot.storage.k8s.io
+  resources:
+  - volumegroupsnapshots
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - watch
 - apiGroups:
   - monitoring.coreos.com
   resources:

--- a/docs/src/cloudnative-pg.v1.md
+++ b/docs/src/cloudnative-pg.v1.md
@@ -5950,5 +5950,13 @@ online/hot (<code>true</code>, default) or offline/cold (<code>false</code>)</p>
    <p>Configuration parameters to control the online/hot backup with volume snapshots</p>
 </td>
 </tr>
+<tr><td><code>groupSnapshot</code> <B>[Required]</B><br/>
+<i>bool</i>
+</td>
+<td>
+   <p>GroupSnapshot makes the operator use a VolumeGroupSnapshot resource
+instead of individual snapshots</p>
+</td>
+</tr>
 </tbody>
 </table>

--- a/docs/src/samples/cluster-example-with-volume-group-snapshot.yaml
+++ b/docs/src/samples/cluster-example-with-volume-group-snapshot.yaml
@@ -1,0 +1,33 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: cluster-example-with-volume-snapshot
+spec:
+  instances: 3
+  primaryUpdateStrategy: unsupervised
+
+  # Persistent storage configuration
+  storage:
+    storageClass: csi-hostpath-sc
+    size: 1Gi
+  walStorage:
+    storageClass: csi-hostpath-sc
+    size: 1Gi
+
+  # Backup properties
+  backup:
+    volumeSnapshot:
+       className: csi-hostpath-groupsnapclass
+       groupSnapshot: true
+    barmanObjectStore:
+      destinationPath: s3://backups/
+      endpointURL: http://minio:9000
+      s3Credentials:
+        accessKeyId:
+          name: minio
+          key: ACCESS_KEY_ID
+        secretAccessKey:
+          name: minio
+          key: ACCESS_SECRET_KEY
+      wal:
+        compression: gzip

--- a/hack/setup-cluster.sh
+++ b/hack/setup-cluster.sh
@@ -419,6 +419,9 @@ deploy_csi_host_path() {
   kubectl apply -f "${CSI_BASE_URL}"/external-snapshotter/"${EXTERNAL_SNAPSHOTTER_VERSION}"/client/config/crd/snapshot.storage.k8s.io_volumesnapshotclasses.yaml
   kubectl apply -f "${CSI_BASE_URL}"/external-snapshotter/"${EXTERNAL_SNAPSHOTTER_VERSION}"/client/config/crd/snapshot.storage.k8s.io_volumesnapshotcontents.yaml
   kubectl apply -f "${CSI_BASE_URL}"/external-snapshotter/"${EXTERNAL_SNAPSHOTTER_VERSION}"/client/config/crd/snapshot.storage.k8s.io_volumesnapshots.yaml
+  kubectl apply -f "${CSI_BASE_URL}"/external-snapshotter/"${EXTERNAL_SNAPSHOTTER_VERSION}"/client/config/crd/groupsnapshot.storage.k8s.io_volumegroupsnapshotclasses.yaml
+  kubectl apply -f "${CSI_BASE_URL}"/external-snapshotter/"${EXTERNAL_SNAPSHOTTER_VERSION}"/client/config/crd/groupsnapshot.storage.k8s.io_volumegroupsnapshotcontents.yaml
+  kubectl apply -f "${CSI_BASE_URL}"/external-snapshotter/"${EXTERNAL_SNAPSHOTTER_VERSION}"/client/config/crd/groupsnapshot.storage.k8s.io_volumegroupsnapshots.yaml
   kubectl apply -f "${CSI_BASE_URL}"/external-snapshotter/"${EXTERNAL_SNAPSHOTTER_VERSION}"/deploy/kubernetes/snapshot-controller/rbac-snapshot-controller.yaml
   kubectl apply -f "${CSI_BASE_URL}"/external-snapshotter/"${EXTERNAL_SNAPSHOTTER_VERSION}"/deploy/kubernetes/snapshot-controller/setup-snapshot-controller.yaml
   kubectl apply -f "${CSI_BASE_URL}"/external-snapshotter/"${EXTERNAL_SNAPSHOTTER_VERSION}"/deploy/kubernetes/csi-snapshotter/rbac-csi-snapshotter.yaml

--- a/internal/controller/backup_controller.go
+++ b/internal/controller/backup_controller.go
@@ -94,9 +94,12 @@ func NewBackupReconciler(
 // +kubebuilder:rbac:groups=postgresql.cnpg.io,resources=backups/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=postgresql.cnpg.io,resources=clusters,verbs=get
 // +kubebuilder:rbac:groups=snapshot.storage.k8s.io,resources=volumesnapshots,verbs=get;create;watch;list;patch
+// +kubebuilder:rbac:groups=groupsnapshot.storage.k8s.io,resources=volumegroupsnapshots,verbs=get;create;watch;list;patch
+// +kubebuilder:rbac:groups=groupsnapshot.storage.k8s.io,resources=volumegroupsnapshotcontents,verbs=get;watch;list
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 // +kubebuilder:rbac:groups="",resources=pods/exec,verbs=get;list;delete;patch;create;watch
 // +kubebuilder:rbac:groups="",resources=pods,verbs=get
+// +kubebuilder:rbac:groups="",resources=persistentvolumes,verbs=get;list;watch
 
 // Reconcile is the main reconciliation loop
 // nolint: gocognit,gocyclo

--- a/internal/scheme/scheme.go
+++ b/internal/scheme/scheme.go
@@ -17,6 +17,7 @@ limitations under the License.
 package scheme
 
 import (
+	storagegroupsnapshotv1beta1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumegroupsnapshot/v1beta1"
 	storagesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -67,6 +68,7 @@ func (b *Builder) WithAPIExtensionV1() *Builder {
 // WithStorageSnapshotV1 adds storagesnapshotv1
 func (b *Builder) WithStorageSnapshotV1() *Builder {
 	_ = storagesnapshotv1.AddToScheme(b.scheme)
+	_ = storagegroupsnapshotv1beta1.AddToScheme(b.scheme)
 
 	return b
 }

--- a/pkg/reconciler/backup/volumesnapshot/group.go
+++ b/pkg/reconciler/backup/volumesnapshot/group.go
@@ -1,0 +1,224 @@
+/*
+Copyright The CloudNativePG Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package volumesnapshot
+
+import (
+	"context"
+	"fmt"
+
+	storagegroupsnapshotv1beta1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumegroupsnapshot/v1beta1"
+	storagesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
+)
+
+// createVolumeGroupSnapshot creates a volume group snapshot for a given cluster
+func (se *Reconciler) createVolumeGroupSnapshot(
+	ctx context.Context,
+	cluster *apiv1.Cluster,
+	backup *apiv1.Backup,
+	targetPod *corev1.Pod,
+	pvcs []corev1.PersistentVolumeClaim,
+) error {
+	snapshotConfig := backup.GetVolumeSnapshotConfiguration(*cluster.Spec.Backup.VolumeSnapshot)
+
+	var snapshotClassName *string
+	if len(snapshotConfig.ClassName) > 0 {
+		snapshotClassName = &snapshotConfig.ClassName
+	}
+
+	snapshot := storagegroupsnapshotv1beta1.VolumeGroupSnapshot{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      backup.Name,
+			Namespace: backup.Namespace,
+		},
+		Spec: storagegroupsnapshotv1beta1.VolumeGroupSnapshotSpec{
+			Source: storagegroupsnapshotv1beta1.VolumeGroupSnapshotSource{
+				Selector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						utils.InstanceNameLabelName: targetPod.Name,
+					},
+				},
+			},
+			VolumeGroupSnapshotClassName: snapshotClassName,
+		},
+	}
+	if snapshot.Labels == nil {
+		snapshot.Labels = map[string]string{}
+	}
+	if snapshot.Annotations == nil {
+		snapshot.Annotations = map[string]string{}
+	}
+	if err := se.enrichSnapshot(ctx, &snapshot.ObjectMeta, backup, cluster, targetPod); err != nil {
+		return err
+	}
+
+	if err := se.cli.Create(ctx, &snapshot); err != nil {
+		if !apierrs.IsAlreadyExists(err) {
+			return fmt.Errorf("while creating VolumeGroupSnapshot %s: %w", snapshot.Name, err)
+		}
+
+		return se.enrichVolumeGroupSnapshot(ctx, cluster, backup, pvcs)
+	}
+
+	return nil
+}
+
+// enrichVolumeGroupSnapshot enriches the VolumeSnapshots resources
+// created by the VolumeGroupSnapshot object with all the required
+// metadata
+func (se *Reconciler) enrichVolumeGroupSnapshot(
+	ctx context.Context,
+	cluster *apiv1.Cluster,
+	backup *apiv1.Backup,
+	pvcs []corev1.PersistentVolumeClaim,
+) error {
+	var groupSnapshot storagegroupsnapshotv1beta1.VolumeGroupSnapshot
+	if err := se.cli.Get(
+		ctx,
+		client.ObjectKey{Namespace: backup.Namespace, Name: backup.Name},
+		&groupSnapshot,
+	); err != nil {
+		if apierrs.IsNotFound(err) {
+			return nil
+		}
+
+		return err
+	}
+
+	// The volume group snapshot is still not bound
+	if groupSnapshot.Status.BoundVolumeGroupSnapshotContentName == nil ||
+		len(*groupSnapshot.Status.BoundVolumeGroupSnapshotContentName) == 0 {
+		return nil
+	}
+
+	// Find the snapshot members using the ownership
+	memberSnapshots, err := se.findGroupSnapshotMembers(ctx, &groupSnapshot)
+	if err != nil {
+		return err
+	}
+
+	// Wait for the common snapshot controller to create the volume
+	// snapshots members
+	if len(memberSnapshots) != len(pvcs) {
+		return nil
+	}
+
+	// Enrich the volume snapshots
+	for i := range memberSnapshots {
+		if err := se.enrichVolumeGroupSnapshotMember(
+			ctx,
+			cluster,
+			backup,
+			&groupSnapshot,
+			&memberSnapshots[i],
+		); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// findGroupSnapshotMembers looks up for the member snapshots the passed
+// snapshot group
+func (se *Reconciler) findGroupSnapshotMembers(
+	ctx context.Context,
+	vgs *storagegroupsnapshotv1beta1.VolumeGroupSnapshot,
+) ([]storagesnapshotv1.VolumeSnapshot, error) {
+	var snapshotList storagesnapshotv1.VolumeSnapshotList
+
+	if err := se.cli.List(ctx, &snapshotList, client.InNamespace(vgs.Namespace)); err != nil {
+		return nil, err
+	}
+
+	result := make([]storagesnapshotv1.VolumeSnapshot, 0, len(snapshotList.Items))
+	for idx := range snapshotList.Items {
+		snapshot := &snapshotList.Items[idx]
+		if len(snapshot.ObjectMeta.OwnerReferences) != 1 {
+			continue
+		}
+
+		owner := snapshot.ObjectMeta.OwnerReferences[0]
+		if owner.Kind != "VolumeGroupSnapshot" {
+			continue
+		}
+
+		if owner.Name != vgs.Name {
+			continue
+		}
+
+		result = append(result, *snapshot)
+	}
+
+	return result, nil
+}
+
+// enrichVolumeSnapshot enriches a Volume Snapshot created by a VolumeGroupSnapshot
+func (se *Reconciler) enrichVolumeGroupSnapshotMember(
+	ctx context.Context,
+	cluster *apiv1.Cluster,
+	backup *apiv1.Backup,
+	groupSnapshot *storagegroupsnapshotv1beta1.VolumeGroupSnapshot,
+	snapshot *storagesnapshotv1.VolumeSnapshot,
+) error {
+	var pvc corev1.PersistentVolumeClaim
+
+	if snapshot.Spec.Source.PersistentVolumeClaimName == nil {
+		return fmt.Errorf("missing persistent volume claim name in snapshot %q", snapshot.Name)
+	}
+
+	if err := se.cli.Get(
+		ctx,
+		client.ObjectKey{
+			Namespace: cluster.Namespace,
+			Name:      *snapshot.Spec.Source.PersistentVolumeClaimName,
+		},
+		&pvc,
+	); err != nil {
+		if apierrs.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+
+	snapshotConfig := backup.GetVolumeSnapshotConfiguration(*cluster.Spec.Backup.VolumeSnapshot)
+
+	if snapshot.Labels == nil {
+		snapshot.Labels = make(map[string]string)
+	}
+	if snapshot.Annotations == nil {
+		snapshot.Annotations = make(map[string]string)
+	}
+
+	origSnapshot := snapshot.DeepCopy()
+
+	utils.MergeMap(snapshot.Labels, groupSnapshot.Labels)
+	utils.MergeMap(snapshot.Labels, pvc.Labels)
+	utils.MergeMap(snapshot.Labels, snapshotConfig.Labels)
+	utils.MergeMap(snapshot.Annotations, groupSnapshot.Annotations)
+	utils.MergeMap(snapshot.Annotations, pvc.Annotations)
+	utils.MergeMap(snapshot.Annotations, snapshotConfig.Annotations)
+	transferLabelsToAnnotations(snapshot.Labels, snapshot.Annotations)
+
+	return se.cli.Patch(ctx, snapshot, client.MergeFrom(origSnapshot))
+}

--- a/pkg/reconciler/backup/volumesnapshot/reconciler.go
+++ b/pkg/reconciler/backup/volumesnapshot/reconciler.go
@@ -73,7 +73,7 @@ func (e *ExecutorBuilder) Build() *Reconciler {
 
 func (se *Reconciler) enrichSnapshot(
 	ctx context.Context,
-	vs *storagesnapshotv1.VolumeSnapshot,
+	vs *metav1.ObjectMeta,
 	backup *apiv1.Backup,
 	cluster *apiv1.Cluster,
 	targetPod *corev1.Pod,
@@ -81,46 +81,49 @@ func (se *Reconciler) enrichSnapshot(
 	contextLogger := log.FromContext(ctx)
 	snapshotConfig := backup.GetVolumeSnapshotConfiguration(*cluster.Spec.Backup.VolumeSnapshot)
 
-	vs.Labels[utils.BackupNameLabelName] = backup.Name
+	labels := vs.GetLabels()
+	annotations := vs.GetAnnotations()
+
+	labels[utils.BackupNameLabelName] = backup.Name
 
 	switch snapshotConfig.SnapshotOwnerReference {
 	case apiv1.SnapshotOwnerReferenceCluster:
-		cluster.SetInheritedDataAndOwnership(&vs.ObjectMeta)
+		cluster.SetInheritedDataAndOwnership(vs)
 	case apiv1.SnapshotOwnerReferenceBackup:
-		utils.SetAsOwnedBy(&vs.ObjectMeta, backup.ObjectMeta, backup.TypeMeta)
+		utils.SetAsOwnedBy(vs, backup.ObjectMeta, backup.TypeMeta)
 	default:
 		break
 	}
 
 	// we grab the pg_controldata just before creating the snapshot
 	if data, err := se.instanceStatusClient.GetPgControlDataFromInstance(ctx, targetPod); err == nil {
-		vs.Annotations[utils.PgControldataAnnotationName] = data
+		annotations[utils.PgControldataAnnotationName] = data
 		pgControlData := utils.ParsePgControldataOutput(data)
 		timelineID, ok := pgControlData[utils.PgControlDataKeyLatestCheckpointTimelineID]
 		if ok {
-			vs.Labels[utils.BackupTimelineLabelName] = timelineID
+			labels[utils.BackupTimelineLabelName] = timelineID
 		}
 		startWal, ok := pgControlData[utils.PgControlDataKeyREDOWALFile]
 		if ok {
-			vs.Annotations[utils.BackupStartWALAnnotationName] = startWal
+			annotations[utils.BackupStartWALAnnotationName] = startWal
 			// TODO: once we have online volumesnapshot backups, this should change
-			vs.Annotations[utils.BackupEndWALAnnotationName] = startWal
+			annotations[utils.BackupEndWALAnnotationName] = startWal
 		}
 	} else {
 		contextLogger.Error(err, "while querying for pg_controldata")
 	}
 
-	vs.Labels[utils.BackupDateLabelName] = time.Now().Format("20060102")
-	vs.Labels[utils.BackupMonthLabelName] = time.Now().Format("200601")
-	vs.Labels[utils.BackupYearLabelName] = strconv.Itoa(time.Now().Year())
-	vs.Annotations[utils.IsOnlineBackupLabelName] = strconv.FormatBool(backup.Status.GetOnline())
+	labels[utils.BackupDateLabelName] = time.Now().Format("20060102")
+	labels[utils.BackupMonthLabelName] = time.Now().Format("200601")
+	labels[utils.BackupYearLabelName] = strconv.Itoa(time.Now().Year())
+	annotations[utils.IsOnlineBackupLabelName] = strconv.FormatBool(backup.Status.GetOnline())
 
 	rawCluster, err := json.Marshal(cluster)
 	if err != nil {
 		return err
 	}
 
-	vs.Annotations[utils.ClusterManifestAnnotationName] = string(rawCluster)
+	annotations[utils.ClusterManifestAnnotationName] = string(rawCluster)
 
 	return nil
 }
@@ -369,6 +372,11 @@ func (se *Reconciler) createSnapshotPVCGroupStep(
 	backup *apiv1.Backup,
 	targetPod *corev1.Pod,
 ) error {
+	volumeSnapshotConfig := backup.GetVolumeSnapshotConfiguration(*cluster.Spec.Backup.VolumeSnapshot)
+	if volumeSnapshotConfig.GroupSnapshot {
+		return se.createVolumeGroupSnapshot(ctx, cluster, backup, targetPod, pvcs)
+	}
+
 	for i := range pvcs {
 		se.recorder.Eventf(backup, "Normal", "CreateSnapshot",
 			"Creating VolumeSnapshot for PVC %v", pvcs[i].Name)
@@ -461,7 +469,7 @@ func (se *Reconciler) createSnapshot(
 		snapshot.Annotations = map[string]string{}
 	}
 
-	if err := se.enrichSnapshot(ctx, &snapshot, backup, cluster, targetPod); err != nil {
+	if err := se.enrichSnapshot(ctx, &snapshot.ObjectMeta, backup, cluster, targetPod); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
VolumeGroupSnapshot is a Kubernetes API that allows users to take a crash consistent snapshot of multiple volumes together, at the sime point in time, with write order consistency.

This patch add support for the VolumeGroupSnapshots API when we are taking a volume snapshot backup.

Closes #4680 