### PR TITLE
fix: use app labels for affinity policy (#3339)

### DIFF
--- a/docs/src/scheduling.md
+++ b/docs/src/scheduling.md
@@ -32,7 +32,8 @@ running in those nodes.
 This is technically known as **inter-pod affinity/anti-affinity**.
 
 CloudNativePG by default will configure the cluster's instances
-preferably on different nodes, resulting in the following `affinity` definition:
+preferably on different nodes, while pgBouncer may still run on the same nodes,
+resulting in the following `affinity` definition:
 
 ```yaml
 affinity:
@@ -41,10 +42,14 @@ affinity:
       - podAffinityTerm:
           labelSelector:
             matchExpressions:
-              - key: postgresql
+              - key: cnpg.io/cluster
                 operator: In
                 values:
                   - cluster-example
+              - key: cnpg.io/podRole
+                operator: In
+                values:
+                  - instance
           topologyKey: kubernetes.io/hostname
         weight: 100
 ```

--- a/pkg/specs/pods.go
+++ b/pkg/specs/pods.go
@@ -326,6 +326,13 @@ func CreateGeneratedAntiAffinity(clusterName string, config apiv1.AffinityConfig
 						clusterName,
 					},
 				},
+				{
+					Key:      utils.PodRoleLabelName,
+					Operator: metav1.LabelSelectorOpIn,
+					Values: []string{
+						string(utils.PodRoleInstance),
+					},
+				},
 			},
 		},
 		TopologyKey: topologyKey,


### PR DESCRIPTION
This resolves the issue described in #3339 by adding a label `cnpg.io/app` as suggested and use it in the anti affinity policy, to distinguish between postgresql itself and the pgbouncer pods. 