### PR TITLE
fix: support custom cert-manager certificates (#2841)

### DIFF
--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -1276,21 +1276,21 @@ type CertificatesConfiguration struct {
 	// <br />
 	// - `ca.crt`: CA that should be used to validate the server certificate,
 	// used as `sslrootcert` in client connection strings.<br />
-	// - `ca.key`: key used to generate Server SSL certs, if ServerTLSSecret is provided,
+	// - `tls.key`: key used to generate Server SSL certs, if ServerTLSSecret is provided,
 	// this can be omitted.<br />
 	// +optional
 	ServerCASecret string `json:"serverCASecret,omitempty"`
 
 	// The secret of type kubernetes.io/tls containing the server TLS certificate and key that will be set as
 	// `ssl_cert_file` and `ssl_key_file` so that clients can connect to postgres securely.
-	// If not defined, ServerCASecret must provide also `ca.key` and a new secret will be
+	// If not defined, ServerCASecret must provide also `tls.key` and a new secret will be
 	// created using the provided CA.
 	// +optional
 	ServerTLSSecret string `json:"serverTLSSecret,omitempty"`
 
 	// The secret of type kubernetes.io/tls containing the client certificate to authenticate as
 	// the `streaming_replica` user.
-	// If not defined, ClientCASecret must provide also `ca.key`, and a new secret will be
+	// If not defined, ClientCASecret must provide also `tls.key`, and a new secret will be
 	// created using the provided CA.
 	// +optional
 	ReplicationTLSSecret string `json:"replicationTLSSecret,omitempty"`
@@ -1302,7 +1302,7 @@ type CertificatesConfiguration struct {
 	// <br />
 	// - `ca.crt`: CA that should be used to validate the client certificates,
 	// used as `ssl_ca_file` of all the instances.<br />
-	// - `ca.key`: key used to generate client certificates, if ReplicationTLSSecret is provided,
+	// - `tls.key`: key used to generate client certificates, if ReplicationTLSSecret is provided,
 	// this can be omitted.<br />
 	// +optional
 	ClientCASecret string `json:"clientCASecret,omitempty"`

--- a/config/crd/bases/postgresql.cnpg.io_clusters.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_clusters.yaml
@@ -1720,14 +1720,14 @@ spec:
                       CA and will be used to generate all the client certificates.<br
                       /> <br /> Contains:<br /> <br /> - `ca.crt`: CA that should
                       be used to validate the client certificates, used as `ssl_ca_file`
-                      of all the instances.<br /> - `ca.key`: key used to generate
+                      of all the instances.<br /> - `tls.key`: key used to generate
                       client certificates, if ReplicationTLSSecret is provided, this
                       can be omitted.<br />'
                     type: string
                   replicationTLSSecret:
                     description: The secret of type kubernetes.io/tls containing the
                       client certificate to authenticate as the `streaming_replica`
-                      user. If not defined, ClientCASecret must provide also `ca.key`,
+                      user. If not defined, ClientCASecret must provide also `tls.key`,
                       and a new secret will be created using the provided CA.
                     type: string
                   serverAltDNSNames:
@@ -1742,7 +1742,7 @@ spec:
                       CA and will be used to generate the TLS certificate ServerTLSSecret.<br
                       /> <br /> Contains:<br /> <br /> - `ca.crt`: CA that should
                       be used to validate the server certificate, used as `sslrootcert`
-                      in client connection strings.<br /> - `ca.key`: key used to
+                      in client connection strings.<br /> - `tls.key`: key used to
                       generate Server SSL certs, if ServerTLSSecret is provided, this
                       can be omitted.<br />'
                     type: string
@@ -1750,7 +1750,7 @@ spec:
                     description: The secret of type kubernetes.io/tls containing the
                       server TLS certificate and key that will be set as `ssl_cert_file`
                       and `ssl_key_file` so that clients can connect to postgres securely.
-                      If not defined, ServerCASecret must provide also `ca.key` and
+                      If not defined, ServerCASecret must provide also `tls.key` and
                       a new secret will be created using the provided CA.
                     type: string
                 type: object
@@ -4210,7 +4210,7 @@ spec:
                       CA and will be used to generate all the client certificates.<br
                       /> <br /> Contains:<br /> <br /> - `ca.crt`: CA that should
                       be used to validate the client certificates, used as `ssl_ca_file`
-                      of all the instances.<br /> - `ca.key`: key used to generate
+                      of all the instances.<br /> - `tls.key`: key used to generate
                       client certificates, if ReplicationTLSSecret is provided, this
                       can be omitted.<br />'
                     type: string
@@ -4222,7 +4222,7 @@ spec:
                   replicationTLSSecret:
                     description: The secret of type kubernetes.io/tls containing the
                       client certificate to authenticate as the `streaming_replica`
-                      user. If not defined, ClientCASecret must provide also `ca.key`,
+                      user. If not defined, ClientCASecret must provide also `tls.key`,
                       and a new secret will be created using the provided CA.
                     type: string
                   serverAltDNSNames:
@@ -4237,7 +4237,7 @@ spec:
                       CA and will be used to generate the TLS certificate ServerTLSSecret.<br
                       /> <br /> Contains:<br /> <br /> - `ca.crt`: CA that should
                       be used to validate the server certificate, used as `sslrootcert`
-                      in client connection strings.<br /> - `ca.key`: key used to
+                      in client connection strings.<br /> - `tls.key`: key used to
                       generate Server SSL certs, if ServerTLSSecret is provided, this
                       can be omitted.<br />'
                     type: string
@@ -4245,7 +4245,7 @@ spec:
                     description: The secret of type kubernetes.io/tls containing the
                       server TLS certificate and key that will be set as `ssl_cert_file`
                       and `ssl_key_file` so that clients can connect to postgres securely.
-                      If not defined, ServerCASecret must provide also `ca.key` and
+                      If not defined, ServerCASecret must provide also `tls.key` and
                       a new secret will be created using the provided CA.
                     type: string
                 type: object

--- a/controllers/cluster_pki.go
+++ b/controllers/cluster_pki.go
@@ -117,7 +117,7 @@ func (r *ClusterReconciler) ensureClientCASecret(ctx context.Context, cluster *a
 		return nil, err
 	}
 
-	// Validate also ca.key if needed
+	// Validate also tls.key if needed
 	if cluster.Spec.Certificates.ReplicationTLSSecret == "" {
 		_, err = certs.ParseCASecret(&secret)
 		if err != nil {
@@ -154,7 +154,7 @@ func (r *ClusterReconciler) ensureServerCASecret(ctx context.Context, cluster *a
 		return nil, err
 	}
 
-	// validate also ca.key if needed
+	// validate also tls.key if needed
 	if cluster.Spec.Certificates.ServerTLSSecret == "" {
 		_, err = certs.ParseCASecret(&secret)
 		if err != nil {

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -430,8 +430,8 @@ func generateFakeCASecret(c client.Client, name, namespace, domain string) (*cor
 			Namespace: namespace,
 		},
 		Data: map[string][]byte{
-			certs.CAPrivateKeyKey: keyPair.Private,
-			certs.CACertKey:       keyPair.Certificate,
+			certs.TLSPrivateKeyKey: keyPair.Private,
+			certs.CACertKey:        keyPair.Certificate,
 		},
 	}
 

--- a/docs/src/certificates.md
+++ b/docs/src/certificates.md
@@ -40,7 +40,7 @@ containing the following keys:
 
 - `ca.crt` – CA certificate used to validate the server certificate, used as
   `sslrootcert` in clients' connection strings.
-- `ca.key` – The key used to sign the server SSL certificate automatically.
+- `tls.key` – The key used to sign the server SSL certificate automatically.
 
 #### Server TLS secret
 

--- a/docs/src/cloudnative-pg.v1.md
+++ b/docs/src/cloudnative-pg.v1.md
@@ -1260,7 +1260,7 @@ Contains:<!-- raw HTML omitted -->
 <ul>
 <li><code>ca.crt</code>: CA that should be used to validate the server certificate,
 used as <code>sslrootcert</code> in client connection strings.<!-- raw HTML omitted --></li>
-<li><code>ca.key</code>: key used to generate Server SSL certs, if ServerTLSSecret is provided,
+<li><code>tls.key</code>: key used to generate Server SSL certs, if ServerTLSSecret is provided,
 this can be omitted.<!-- raw HTML omitted --></li>
 </ul>
 </td>
@@ -1271,7 +1271,7 @@ this can be omitted.<!-- raw HTML omitted --></li>
 <td>
    <p>The secret of type kubernetes.io/tls containing the server TLS certificate and key that will be set as
 <code>ssl_cert_file</code> and <code>ssl_key_file</code> so that clients can connect to postgres securely.
-If not defined, ServerCASecret must provide also <code>ca.key</code> and a new secret will be
+If not defined, ServerCASecret must provide also <code>tls.key</code> and a new secret will be
 created using the provided CA.</p>
 </td>
 </tr>
@@ -1281,7 +1281,7 @@ created using the provided CA.</p>
 <td>
    <p>The secret of type kubernetes.io/tls containing the client certificate to authenticate as
 the <code>streaming_replica</code> user.
-If not defined, ClientCASecret must provide also <code>ca.key</code>, and a new secret will be
+If not defined, ClientCASecret must provide also <code>tls.key</code>, and a new secret will be
 created using the provided CA.</p>
 </td>
 </tr>
@@ -1297,7 +1297,7 @@ Contains:<!-- raw HTML omitted -->
 <ul>
 <li><code>ca.crt</code>: CA that should be used to validate the client certificates,
 used as <code>ssl_ca_file</code> of all the instances.<!-- raw HTML omitted --></li>
-<li><code>ca.key</code>: key used to generate client certificates, if ReplicationTLSSecret is provided,
+<li><code>tls.key</code>: key used to generate client certificates, if ReplicationTLSSecret is provided,
 this can be omitted.<!-- raw HTML omitted --></li>
 </ul>
 </td>

--- a/docs/src/kubectl-plugin.md
+++ b/docs/src/kubectl-plugin.md
@@ -572,7 +572,7 @@ head cnpg-ca-secret.yaml
 ```yaml
 data:
   ca.crt: ""
-  ca.key: ""
+  tls.key: ""
 metadata:
   creationTimestamp: "2022-03-22T10:42:28Z"
   managedFields:
@@ -602,7 +602,7 @@ head cnpg-ca-secret.yaml
 ```yaml
 data:
   ca.crt: LS0tLS1CRUdJTiBD…
-  ca.key: LS0tLS1CRUdJTiBF…
+  tls.key: LS0tLS1CRUdJTiBF…
 metadata:
   creationTimestamp: "2022-03-22T10:42:28Z"
   managedFields:

--- a/pkg/certs/certs.go
+++ b/pkg/certs/certs.go
@@ -234,8 +234,8 @@ func (pair KeyPair) GenerateCASecret(namespace, name string) *v1.Secret {
 			Namespace: namespace,
 		},
 		Data: map[string][]byte{
-			CAPrivateKeyKey: pair.Private,
-			CACertKey:       pair.Certificate,
+			TLSPrivateKeyKey: pair.Private,
+			CACertKey:        pair.Certificate,
 		},
 		Type: v1.SecretTypeOpaque,
 	}
@@ -349,9 +349,14 @@ func CreateRootCA(commonName string, organizationalUnit string) (*KeyPair, error
 
 // ParseCASecret parse a CA secret to a key pair
 func ParseCASecret(secret *v1.Secret) (*KeyPair, error) {
-	privateKey, ok := secret.Data[CAPrivateKeyKey]
+	privateKey, ok := secret.Data[TLSPrivateKeyKey]
 	if !ok {
-		return nil, fmt.Errorf("missing %s secret data", CAPrivateKeyKey)
+		// check for backwards compatibility
+		privateKey, ok = secret.Data[CAPrivateKeyKey]
+		if !ok {
+			return nil, fmt.Errorf("found neither %s nor %s secret data", TLSPrivateKeyKey, CAPrivateKeyKey)
+
+		}
 	}
 
 	publicKey, ok := secret.Data[CACertKey]

--- a/pkg/certs/certs_test.go
+++ b/pkg/certs/certs_test.go
@@ -57,7 +57,7 @@ var _ = Describe("Keypair generation", func() {
 		Expect(secret.Namespace).To(Equal("namespace"))
 		Expect(secret.Name).To(Equal("name"))
 		Expect(secret.Data[CACertKey]).To(Equal(pair.Certificate))
-		Expect(secret.Data[CAPrivateKeyKey]).To(Equal(pair.Private))
+		Expect(secret.Data[TLSPrivateKeyKey]).To(Equal(pair.Private))
 	})
 
 	It("should be able to renew an existing CA certificate", func() {

--- a/tests/utils/secrets.go
+++ b/tests/utils/secrets.go
@@ -55,7 +55,7 @@ func CreateSecretCA(
 	caSecret := caPair.GenerateCASecret(namespace, caSecName)
 	// delete the key from the CA, as it is not needed in this case
 	if !includeCAPrivateKey {
-		delete(caSecret.Data, certs.CAPrivateKeyKey)
+		delete(caSecret.Data, certs.TLSPrivateKeyKey)
 	}
 	_, err = CreateObject(env, caSecret)
 	if err != nil {


### PR DESCRIPTION
This fixes #2841

At the moment cert-manager only supports the `kubernetes.io/tls` secrets and uses `tls.key` to store the private key. To make the integration work, i replaced the use of `ca.key` with `tls.key`. This will work for newly generated CAs.
To ensure it still keeps working with already generated CAs, it also added backwards compatibility by checking for `ca.key` before failing due to the missing private key. 