### PR TITLE
fix: reconcile `Pooler` service and add labels.

### DIFF
--- a/controllers/pooler_resources_test.go
+++ b/controllers/pooler_resources_test.go
@@ -120,7 +120,7 @@ var _ = Describe("pooler_resources unit tests", func() {
 		})
 
 		By("creating the service", func() {
-			service := pgbouncer.Service(pooler)
+			service := pgbouncer.Service(pooler, cluster)
 			err := poolerReconciler.Create(ctx, service)
 			Expect(err).ToNot(HaveOccurred())
 		})

--- a/pkg/specs/pgbouncer/services.go
+++ b/pkg/specs/pgbouncer/services.go
@@ -28,11 +28,15 @@ import (
 
 // Service create the specification for the service of
 // pgbouncer
-func Service(pooler *apiv1.Pooler) *corev1.Service {
+func Service(pooler *apiv1.Pooler, cluster *apiv1.Cluster) *corev1.Service {
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      pooler.Name,
 			Namespace: pooler.Namespace,
+			Labels: map[string]string{
+				utils.PgbouncerNameLabel: pooler.Name,
+				utils.ClusterLabelName:   cluster.Name,
+			},
 		},
 		Spec: corev1.ServiceSpec{
 			Type: corev1.ServiceTypeClusterIP,

--- a/pkg/specs/pgbouncer/services_test.go
+++ b/pkg/specs/pgbouncer/services_test.go
@@ -30,7 +30,10 @@ import (
 )
 
 var _ = Describe("Pooler Service", func() {
-	var pooler *apiv1.Pooler
+	var (
+		pooler  *apiv1.Pooler
+		cluster *apiv1.Cluster
+	)
 
 	BeforeEach(func() {
 		pooler = &apiv1.Pooler{
@@ -39,13 +42,21 @@ var _ = Describe("Pooler Service", func() {
 				Namespace: "test-namespace",
 			},
 		}
+		cluster = &apiv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-cluster",
+				Namespace: "test-namespace",
+			},
+		}
 	})
 
 	Context("when creating a Service", func() {
 		It("returns the correct Service", func() {
-			service := Service(pooler)
+			service := Service(pooler, cluster)
 			Expect(service.Name).To(Equal(pooler.Name))
 			Expect(service.Namespace).To(Equal(pooler.Namespace))
+			Expect(service.Labels[utils.ClusterLabelName]).To(Equal(cluster.Name))
+			Expect(service.Labels[utils.PgbouncerNameLabel]).To(Equal(pooler.Name))
 			Expect(service.Spec.Type).To(Equal(corev1.ServiceTypeClusterIP))
 			Expect(service.Spec.Ports).To(ConsistOf(corev1.ServicePort{
 				Name:       "pgbouncer",


### PR DESCRIPTION
This patch fixes two issues that we currently have with the Pooler service.

a) we never reconcile the service once is created
b) we don't add the proper labels to the created service

