### PR TITLE
fix: add proper labels to the `Pooler` deployment

### DIFF
--- a/pkg/specs/pgbouncer/deployments.go
+++ b/pkg/specs/pgbouncer/deployments.go
@@ -43,7 +43,7 @@ const (
 // Deployment create the deployment of pgbouncer, given
 // the configurations we have in the pooler specifications
 func Deployment(pooler *apiv1.Pooler, cluster *apiv1.Cluster) (*appsv1.Deployment, error) {
-	poolerHash, err := hash.ComputeVersionedHash(pooler.Spec, 1)
+	poolerHash, err := hash.ComputeVersionedHash(pooler.Spec, 2)
 	if err != nil {
 		return nil, err
 	}
@@ -121,9 +121,12 @@ func Deployment(pooler *apiv1.Pooler, cluster *apiv1.Cluster) (*appsv1.Deploymen
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      pooler.Name,
 			Namespace: pooler.Namespace,
+			Labels: map[string]string{
+				utils.ClusterLabelName:   cluster.Name,
+				utils.PgbouncerNameLabel: pooler.Name,
+			},
 			Annotations: map[string]string{
 				utils.PoolerSpecHashAnnotationName: poolerHash,
-				utils.ClusterLabelName:             cluster.Name,
 			},
 		},
 		Spec: appsv1.DeploymentSpec{

--- a/pkg/specs/pgbouncer/deployments_test.go
+++ b/pkg/specs/pgbouncer/deployments_test.go
@@ -75,7 +75,7 @@ var _ = Describe("Deployment", func() {
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(deployment).ToNot(BeNil())
 
-		expectedHash, err := hash.ComputeVersionedHash(pooler.Spec, 1)
+		expectedHash, err := hash.ComputeVersionedHash(pooler.Spec, 2)
 		Expect(err).ShouldNot(HaveOccurred())
 
 		// Check the computed hash
@@ -84,6 +84,8 @@ var _ = Describe("Deployment", func() {
 		// Check the metadata
 		Expect(deployment.ObjectMeta.Name).To(Equal(pooler.Name))
 		Expect(deployment.ObjectMeta.Namespace).To(Equal(pooler.Namespace))
+		Expect(deployment.Labels[utils.ClusterLabelName]).To(Equal(cluster.Name))
+		Expect(deployment.Labels[utils.PgbouncerNameLabel]).To(Equal(pooler.Name))
 
 		// Check the DeploymentSpec
 		Expect(*deployment.Spec.Replicas).To(Equal(pooler.Spec.Instances))


### PR DESCRIPTION
This patch ensures that we add the proper labels to the deployment. In a previous patch we ensured that the labels were present on the pods but not on the actual deployment.