### PR TITLE
docs: fix x-mark inaccessibility

### DIFF
--- a/docs/src/backup.md
+++ b/docs/src/backup.md
@@ -140,13 +140,13 @@ available methods for storing physical base backups.
 |                                   | Object store |   Volume Snapshots   |
 |-----------------------------------|:------------:|:--------------------:|
 | **WAL archiving**                 |   Required   |    Recommended (1)   |
-| **Cold backup**                   |      𐄂       |           ✓          |
-| **Hot backup**                    |       ✓      |           ✓          |
-| **Incremental copy**              |      𐄂       |         ✓  (2)       |
-| **Differential copy**             |      𐄂       |         ✓  (2)       |
-| **Backup from a standby**         |       ✓      |           ✓          |
-| **Snapshot recovery**             |    𐄂 (3)     |           ✓          |
-| **Point In Time Recovery (PITR)** |       ✓      | Requires WAL archive |
+| **Cold backup**                   |      ✗       |           ✓          |
+| **Hot backup**                    |      ✓       |           ✓          |
+| **Incremental copy**              |      ✗       |         ✓  (2)       |
+| **Differential copy**             |      ✗       |         ✓  (2)       |
+| **Backup from a standby**         |      ✓       |           ✓          |
+| **Snapshot recovery**             |    ✗ (3)     |           ✓          |
+| **Point In Time Recovery (PITR)** |      ✓       | Requires WAL archive |
 | **Underlying technology**         | Barman Cloud |   Kubernetes API     |
 
 


### PR DESCRIPTION
In the documentation, we were using the unicode
U+10102	AEGEAN CHECK MARK
to denote an "x mark" in a feature table. It is not rendered
in Windows (not included in the Segoe UI Symbols font).

This PR uses instead the more standard
U+2717	BALLOT X (cross)
which has wider support

Closes #3361 
