### PR TITLE
ci: move image scan to cd workflow

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -243,7 +243,6 @@ jobs:
       needs.evaluate_options.result == 'success'
     runs-on: ubuntu-22.04
     permissions:
-      actions: read
       contents: read
       packages: write
       pull-requests: read
@@ -367,40 +366,6 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ env.REGISTRY_USER }}
           password: ${{ env.REGISTRY_PASSWORD }}
-      -
-        name: Build for scan
-        uses: docker/build-push-action@v5
-        with:
-          platforms: "linux/amd64"
-          context: .
-          push: false
-          load: true
-          build-args: |
-            VERSION=${{ env.VERSION }}
-          tags: ${{ steps.docker-meta.outputs.tags }}
-      -
-        name: Dockle scan
-        uses: erzz/dockle-action@v1
-        with:
-          image: ${{ steps.docker-meta.outputs.tags }}
-          exit-code: '1'
-          failure-threshold: WARN
-          accept-keywords: key
-      -
-        name: Run Snyk to check Docker image for vulnerabilities
-        uses: snyk/actions/docker@master
-        continue-on-error: true
-        env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-        with:
-          image: ${{ steps.docker-meta.outputs.tags }}
-          args: --severity-threshold=high --file=Dockerfile
-      -
-        name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
-        with:
-          sarif_file: snyk.sarif
-
       -
         name: Build and push
         uses: docker/build-push-action@v5

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -243,6 +243,7 @@ jobs:
       needs.evaluate_options.result == 'success'
     runs-on: ubuntu-22.04
     permissions:
+      actions: read
       contents: read
       packages: write
       pull-requests: read
@@ -366,6 +367,40 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ env.REGISTRY_USER }}
           password: ${{ env.REGISTRY_PASSWORD }}
+      -
+        name: Build for scan
+        uses: docker/build-push-action@v5
+        with:
+          platforms: "linux/amd64"
+          context: .
+          push: false
+          load: true
+          build-args: |
+            VERSION=${{ env.VERSION }}
+          tags: ${{ steps.docker-meta.outputs.tags }}
+      -
+        name: Dockle scan
+        uses: erzz/dockle-action@v1
+        with:
+          image: ${{ steps.docker-meta.outputs.tags }}
+          exit-code: '1'
+          failure-threshold: WARN
+          accept-keywords: key
+      -
+        name: Run Snyk to check Docker image for vulnerabilities
+        uses: snyk/actions/docker@master
+        continue-on-error: true
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          image: ${{ steps.docker-meta.outputs.tags }}
+          args: --severity-threshold=high --file=Dockerfile
+      -
+        name: Upload result to GitHub Code Scanning
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: snyk.sarif
+
       -
         name: Build and push
         uses: docker/build-push-action@v5

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -560,6 +560,7 @@ jobs:
 
       - name: Run Snyk to check Docker image for vulnerabilities
         uses: snyk/actions/docker@master
+        if: ${{ !github.event.pull_request.head.repo.fork }}
         continue-on-error: true
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
@@ -570,7 +571,8 @@ jobs:
       - name: Upload result to GitHub Code Scanning
         uses: github/codeql-action/upload-sarif@v2
         if: |
-          github.repository_owner == 'cloudnative-pg'
+          github.repository_owner == 'cloudnative-pg' &&
+          !github.event.pull_request.head.repo.fork
         with:
           sarif_file: snyk.sarif
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -560,7 +560,9 @@ jobs:
 
       - name: Run Snyk to check Docker image for vulnerabilities
         uses: snyk/actions/docker@master
-        if: ${{ !github.event.pull_request.head.repo.fork }}
+        if: |
+          github.repository_owner == 'cloudnative-pg' &&
+          !github.event.pull_request.head.repo.fork
         continue-on-error: true
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -381,8 +381,10 @@ jobs:
       (needs.crd.result == 'success' || needs.crd.result == 'skipped')
     runs-on: ubuntu-22.04
     permissions:
+      actions: read
       contents: read
       packages: write
+      security-events: write
     outputs:
       commit_version: ${{ env.VERSION }}
       commit: ${{ env.COMMIT_SHA }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -381,10 +381,8 @@ jobs:
       (needs.crd.result == 'success' || needs.crd.result == 'skipped')
     runs-on: ubuntu-22.04
     permissions:
-      actions: read
       contents: read
       packages: write
-      security-events: write
     outputs:
       commit_version: ${{ env.VERSION }}
       commit: ${{ env.COMMIT_SHA }}


### PR DESCRIPTION
This patch move the snyk scan to cd workflow, as this scan require
secrets in cloudnative-pg repository

Closes: #3451 