### PR TITLE
Verify candidate has active wal_receiver before targeting as primary

### DIFF
--- a/controllers/replicas.go
+++ b/controllers/replicas.go
@@ -232,6 +232,11 @@ func (r *ClusterReconciler) setPrimaryOnSchedulableNode(
 			continue
 		}
 
+		// If the candidate has not established a connection to the current primary, skip it
+		if !candidate.IsWalReceiverActive {
+			continue
+		}
+
 		// Set the current candidate as targetPrimary
 		contextLogger.Info("Current primary is running on unschedulable node, triggering a switchover",
 			"currentPrimary", primaryPod.Pod.Name, "currentPrimaryNode", primaryPod.Node,


### PR DESCRIPTION
**Problem** 
Current implementation does not take into consideration whether a target primary for a switchover has an active wal_receiver session.  This leads to potential situations where a pod can be selected as target primary even if it is in the process of running wal-restore to catch up.

**Context** 
We encountered this issue on a high-write postgres instance with two replicas. We were forced to bounce one replicas and after the join-job completed it began trying to catch up using wal-restore. The pod was ready and got targeted as primary due to k8s node maintenance trying to move the primary off an unschedulable node. 

Unluckily the pod running wal-restore was selected to be primary instead of the other replica which was up-to-date, leading to hours of write-downtime as wal-restore tried to finish before being able to be promoted. This could have been avoided if the replica with the active wal_receiver had been selected.