### PR TITLE
fix: make pooler instances a pointer

### DIFF
--- a/api/v1/pooler_types.go
+++ b/api/v1/pooler_types.go
@@ -65,7 +65,7 @@ type PoolerSpec struct {
 	// The number of replicas we want. Default: 1.
 	// +kubebuilder:default:=1
 	// +optional
-	Instances int32 `json:"instances,omitempty"`
+	Instances *int32 `json:"instances,omitempty"`
 
 	// The template of the Pod to be created
 	// +optional

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -1729,6 +1729,11 @@ func (in *PoolerSecrets) DeepCopy() *PoolerSecrets {
 func (in *PoolerSpec) DeepCopyInto(out *PoolerSpec) {
 	*out = *in
 	out.Cluster = in.Cluster
+	if in.Instances != nil {
+		in, out := &in.Instances, &out.Instances
+		*out = new(int32)
+		**out = **in
+	}
 	if in.Template != nil {
 		in, out := &in.Template, &out.Template
 		*out = new(PodTemplateSpec)

--- a/controllers/pooler_update_test.go
+++ b/controllers/pooler_update_test.go
@@ -73,7 +73,7 @@ var _ = Describe("unit test of pooler_update reconciliation logic", func() {
 			Expect(res.Deployment).ToNot(BeNil())
 
 			deployment := getPoolerDeployment(ctx, pooler)
-			Expect(*deployment.Spec.Replicas).To(Equal(pooler.Spec.Instances))
+			Expect(deployment.Spec.Replicas).To(Equal(pooler.Spec.Instances))
 		})
 
 		By("making sure that if the pooler.spec doesn't change the deployment isn't updated", func() {

--- a/controllers/pooler_update_test.go
+++ b/controllers/pooler_update_test.go
@@ -26,6 +26,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	k8client "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -90,7 +91,7 @@ var _ = Describe("unit test of pooler_update reconciliation logic", func() {
 		By("making sure that the deployments gets updated if the pooler.spec changes", func() {
 			const instancesNumber int32 = 3
 			poolerUpdate := pooler.DeepCopy()
-			poolerUpdate.Spec.Instances = instancesNumber
+			poolerUpdate.Spec.Instances = ptr.To(instancesNumber)
 
 			beforeDep := getPoolerDeployment(ctx, poolerUpdate)
 

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -37,6 +37,7 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 
@@ -142,7 +143,7 @@ func newFakePooler(cluster *apiv1.Cluster) *apiv1.Pooler {
 				Name: cluster.Name,
 			},
 			Type:      "rw",
-			Instances: 1,
+			Instances: ptr.To(int32(1)),
 			PgBouncer: &apiv1.PgBouncerSpec{
 				PoolMode: apiv1.PgBouncerPoolModeSession,
 			},

--- a/pkg/specs/pgbouncer/deployments.go
+++ b/pkg/specs/pgbouncer/deployments.go
@@ -132,7 +132,7 @@ func Deployment(pooler *apiv1.Pooler, cluster *apiv1.Cluster) (*appsv1.Deploymen
 			},
 		},
 		Spec: appsv1.DeploymentSpec{
-			Replicas: &pooler.Spec.Instances,
+			Replicas: pooler.Spec.Instances,
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					utils.PgbouncerNameLabel: pooler.Name,

--- a/pkg/specs/pgbouncer/deployments_test.go
+++ b/pkg/specs/pgbouncer/deployments_test.go
@@ -90,7 +90,7 @@ var _ = Describe("Deployment", func() {
 		Expect(deployment.Labels[utils.PodRoleLabelName]).To(BeEquivalentTo(utils.PodRolePooler))
 
 		// Check the DeploymentSpec
-		Expect(*deployment.Spec.Replicas).To(Equal(pooler.Spec.Instances))
+		Expect(deployment.Spec.Replicas).To(Equal(pooler.Spec.Instances))
 		Expect(deployment.Spec.Selector.MatchLabels[utils.PgbouncerNameLabel]).To(Equal(pooler.Name))
 
 		// Check the PodTemplateSpec
@@ -110,7 +110,7 @@ var _ = Describe("Deployment", func() {
 		deployment, err := Deployment(pooler, cluster)
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(deployment).ToNot(BeNil())
-		Expect(*deployment.Spec.Replicas).To(Equal(pooler.Spec.Instances))
+		Expect(deployment.Spec.Replicas).To(Equal(pooler.Spec.Instances))
 	})
 
 	It("sets the correct deployment strategy", func() {

--- a/pkg/specs/pgbouncer/deployments_test.go
+++ b/pkg/specs/pgbouncer/deployments_test.go
@@ -20,6 +20,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	pgBouncerConfig "github.com/cloudnative-pg/cloudnative-pg/pkg/management/pgbouncer/config"
@@ -47,7 +48,7 @@ var _ = Describe("Deployment", func() {
 			Spec: apiv1.PoolerSpec{
 				Cluster:   apiv1.LocalObjectReference{Name: "test-cluster"},
 				Type:      apiv1.PoolerTypeRW,
-				Instances: 1,
+				Instances: ptr.To(int32(1)),
 				Template:  &apiv1.PodTemplateSpec{},
 				PgBouncer: &apiv1.PgBouncerSpec{
 					PoolMode:  apiv1.PgBouncerPoolModeSession,
@@ -105,7 +106,7 @@ var _ = Describe("Deployment", func() {
 	})
 
 	It("sets the correct number of replicas", func() {
-		pooler.Spec.Instances = 3
+		pooler.Spec.Instances = ptr.To(int32(3))
 		deployment, err := Deployment(pooler, cluster)
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(deployment).ToNot(BeNil())

--- a/tests/e2e/fixtures/upgrade/pgbouncer.yaml
+++ b/tests/e2e/fixtures/upgrade/pgbouncer.yaml
@@ -1,0 +1,12 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Pooler
+metadata:
+  name: pgbouncer
+spec:
+  cluster:
+    name: cluster1
+
+  instances: 2
+  type: rw
+  pgbouncer:
+    poolMode: session

--- a/tests/e2e/upgrade_test.go
+++ b/tests/e2e/upgrade_test.go
@@ -19,7 +19,6 @@ package e2e
 import (
 	"errors"
 	"fmt"
-	"k8s.io/utils/ptr"
 	"os"
 	"strconv"
 	"strings"
@@ -31,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
+	"k8s.io/utils/ptr"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"


### PR DESCRIPTION
This patch ensures that the pooler can be scaled to zero.

Closes #3502
