### PR TITLE
docs: yaml paths style fixes

### DIFF
--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -808,7 +808,7 @@ type ClusterStatus struct {
 	CurrentPrimaryTimestamp string `json:"currentPrimaryTimestamp,omitempty"`
 
 	// The timestamp when the primary was detected to be unhealthy
-	// This field is reported when spec.failoverDelay is populated or during online upgrades
+	// This field is reported when `.spec.failoverDelay` is populated or during online upgrades
 	// +optional
 	CurrentPrimaryFailingSinceTimestamp string `json:"currentPrimaryFailingSinceTimestamp,omitempty"`
 

--- a/config/crd/bases/postgresql.cnpg.io_clusters.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_clusters.yaml
@@ -4342,8 +4342,8 @@ spec:
                 type: string
               currentPrimaryFailingSinceTimestamp:
                 description: The timestamp when the primary was detected to be unhealthy
-                  This field is reported when spec.failoverDelay is populated or during
-                  online upgrades
+                  This field is reported when `.spec.failoverDelay` is populated or
+                  during online upgrades
                 type: string
               currentPrimaryTimestamp:
                 description: The timestamp when the last actual promotion to primary

--- a/docs/src/cloudnative-pg.v1.md
+++ b/docs/src/cloudnative-pg.v1.md
@@ -1966,7 +1966,7 @@ This field is calculated from the content of LastSuccessfulBackupByMethod</p>
 </td>
 <td>
    <p>The timestamp when the primary was detected to be unhealthy
-This field is reported when spec.failoverDelay is populated or during online upgrades</p>
+This field is reported when <code>.spec.failoverDelay</code> is populated or during online upgrades</p>
 </td>
 </tr>
 <tr><td><code>targetPrimaryTimestamp</code><br/>

--- a/docs/src/cluster_conf.md
+++ b/docs/src/cluster_conf.md
@@ -50,14 +50,14 @@ duration of a pod's life, without persisting across pod restarts.
 ### Volume for temporary storage
 
 An ephemeral volume used for temporary storage. You can configure an upper
-bound on the size using the `spec.ephemeralVolumesSizeLimit.temporaryData`
+bound on the size using the `.spec.ephemeralVolumesSizeLimit.temporaryData`
 field in the cluster spec.
 
 ### Volume for shared memory
 
 This volume is used as shared memory space for Postgres and as an ephemeral
 type but stored in memory. You can configure an upper bound on the size using
-the `spec.ephemeralVolumesSizeLimit.shm` field in the cluster spec.
+the `.spec.ephemeralVolumesSizeLimit.shm` field in the cluster spec.
 Use this field only in case of
 [PostgreSQL running with `posix` shared memory dynamic allocation](postgresql_conf.md#dynamic-shared-memory-settings).
 

--- a/docs/src/declarative_role_management.md
+++ b/docs/src/declarative_role_management.md
@@ -37,7 +37,7 @@ spec:
         - pg_signal_backend
 ```
 
-The role specification in `spec.managed.roles` adheres to the
+The role specification in `.spec.managed.roles` adheres to the
 [PostgreSQL structure and naming conventions](https://www.postgresql.org/docs/current/sql-createrole.html).
 Please refer to the [API reference](cloudnative-pg.v1.md#postgresql-cnpg-io-v1-RoleConfiguration) for
 the full list of attributes you can define for each role.

--- a/docs/src/failover.md
+++ b/docs/src/failover.md
@@ -1,7 +1,7 @@
 # Automated failover
 
 In the case of unexpected errors on the primary for longer than the
-`spec.failoverDelay` (by default `0` seconds), the cluster will go into
+`.spec.failoverDelay` (by default `0` seconds), the cluster will go into
 **failover mode**. This may happen, for example, when:
 
 - The primary pod has a disk failure
@@ -77,7 +77,7 @@ Failover may result in the service being impacted and/or data being lost:
 
 ## Delayed failover
 
-As anticipated above, the `spec.failoverDelay` option allows you to delay the start
+As anticipated above, the `.spec.failoverDelay` option allows you to delay the start
 of the failover procedure by a number of seconds after the primary has been
 detected to be unhealthy. By default, this setting is set to `0`, triggering the
 failover procedure immediately.

--- a/docs/src/faq.md
+++ b/docs/src/faq.md
@@ -410,7 +410,7 @@ documentation:
 Although time zones can even be used at session, transaction and even as part
 of a query in PostgreSQL, a very common way is to set them up globally. With
 CloudNativePG you can configure the cluster level time zone in the
-`spec.postgresql.parameters` section as in the following example:
+`.spec.postgresql.parameters` section as in the following example:
 
 ``` yaml
 apiVersion: postgresql.cnpg.io/v1

--- a/docs/src/postgresql_conf.md
+++ b/docs/src/postgresql_conf.md
@@ -358,7 +358,7 @@ host all all all scram-sha-256 # (or md5 for PostgreSQL version <= 13)
 Refer to the PostgreSQL documentation for [more information on `pg_hba.conf`](https://www.postgresql.org/docs/current/auth-pg-hba-conf.html).
 
 Inside the cluster manifest, `pg_hba` lines are added as list items
-in `spec.postgresql.pg_hba`, as in the following excerpt:
+in `.spec.postgresql.pg_hba`, as in the following excerpt:
 
 ``` yaml
   postgresql:
@@ -441,7 +441,7 @@ shm on /dev/shm type tmpfs (rw,nosuid,nodev,noexec,relatime,size=******)
 ```
 
 If you would like to set a maximum size for the `shm` volume, you can do so by
-setting the `spec.ephemeralVolumesSizeLimit.shm` field in the `Cluster` resource.
+setting the `.spec.ephemeralVolumesSizeLimit.shm` field in the `Cluster` resource.
 For example:
 
 ```yaml

--- a/docs/src/release_notes/edb-cloud-native-postgresql.md
+++ b/docs/src/release_notes/edb-cloud-native-postgresql.md
@@ -99,7 +99,7 @@ Fixes:
 - Fix a memory leak in code fetching status from Postgres pods
 - Disable PostgreSQL self-restart after a crash. The instance controller handles
   the lifecycle of the PostgreSQL instance
-- Prevent modification of `spec.postgresUID` and `spec.postgresGID` fields
+- Prevent modification of `.spec.postgresUID` and `.spec.postgresGID` fields
   in validation webhook. Changing these fields after Cluster creation makes PostgreSQL unable to start
 - Reduce the log verbosity from the backup and WAL archiving handling code
 - Correct a bug resulting in a Cluster being marked as `Healthy` when not initialized yet
@@ -470,7 +470,7 @@ Features:
 Security Enhancements:
 
 - Add the `.spec.certificates.clientCASecret` and
-  `spec.certificates.replicationTLSSecret` options to define custom client
+  `.spec.certificates.replicationTLSSecret` options to define custom client
   Certification Authority and certificate for the PostgreSQL server, to be used
   to authenticate client certificates and secure communication between PostgreSQL
   nodes

--- a/docs/src/replica_cluster.md
+++ b/docs/src/replica_cluster.md
@@ -88,9 +88,9 @@ file and define the following parts accordingly:
 - define the bootstrap part for the replica cluster. We can either bootstrap via
   streaming using the `pg_basebackup` section, or bootstrap from a volume snapshot
   or an object store using the `recovery` section
-- define the continuous recovery part (`spec.replica`) in the replica cluster. All
-  we need to do is to enable the replica mode through option `spec.replica.enabled`
-  and set the `externalClusters` name in option `spec.replica.source`
+- define the continuous recovery part (`.spec.replica`) in the replica cluster. All
+  we need to do is to enable the replica mode through option `.spec.replica.enabled`
+  and set the `externalClusters` name in option `.spec.replica.source`
 
 #### Example using pg_basebackup
 
@@ -206,7 +206,7 @@ for it in the `samples/` subdirectory.
 
 To promote the **designated primary** to **primary**, all we need to do is to
 disable the replica mode in the replica cluster through the option
-`spec.replica.enabled`
+`.spec.replica.enabled`
 
 ```yaml
  replica:

--- a/docs/src/replication.md
+++ b/docs/src/replication.md
@@ -172,7 +172,7 @@ the replicas are eligible for synchronous replication.
     (see ["Synchronous replication"](replication.md#synchronous-replication)).
 
 The example below shows how this can be done through the
-`syncReplicaElectionConstraint` section within `spec.postgresql`.
+`syncReplicaElectionConstraint` section within `.spec.postgresql`.
 `nodeLabelsAntiAffinity` allows you to specify those node labels that need to
 be evaluated to make sure that synchronous replication will be dynamically
 configured by the operator between the current primary and the replicas which


### PR DESCRIPTION
This patch ensures we coherently use the dot in front of
field paths in the documentation.