### PR TITLE
test: fix go-sqlmock v1.5.1 compatibility

### DIFF
--- a/internal/management/controller/roles/postgres_test.go
+++ b/internal/management/controller/roles/postgres_test.go
@@ -395,7 +395,7 @@ var _ = Describe("Postgres RoleManager implementation test", func() {
 			"inroles",
 		}).
 			AddRow([]byte(`{"role1","role2"}`))
-		mock.ExpectQuery(expectedMembershipStmt).WillReturnRows(rows)
+		mock.ExpectQuery(expectedMembershipStmt).WithArgs("foo").WillReturnRows(rows)
 
 		roles, err := prm.GetParentRoles(ctx, DatabaseRole{Name: "foo"})
 		Expect(err).ShouldNot(HaveOccurred())
@@ -408,7 +408,7 @@ var _ = Describe("Postgres RoleManager implementation test", func() {
 		Expect(err).ToNot(HaveOccurred())
 		prm := NewPostgresRoleManager(db)
 
-		mock.ExpectQuery(expectedMembershipStmt).WillReturnError(fmt.Errorf("kaboom"))
+		mock.ExpectQuery(expectedMembershipStmt).WithArgs("foo").WillReturnError(fmt.Errorf("kaboom"))
 		roles, err := prm.GetParentRoles(ctx, DatabaseRole{Name: "foo"})
 		Expect(err).Should(HaveOccurred())
 		Expect(roles).To(BeEmpty())
@@ -537,16 +537,16 @@ var _ = Describe("Postgres RoleManager implementation test", func() {
 		lastTransactionQuery := "SELECT xmin FROM pg_catalog.pg_authid WHERE rolname = $1"
 		dbRole := roleConfigurationAdapter{RoleConfiguration: wantedRole}.toDatabaseRole()
 
-		mock.ExpectQuery(lastTransactionQuery).WillReturnError(errors.New("Kaboom"))
+		mock.ExpectQuery(lastTransactionQuery).WithArgs("foo").WillReturnError(errors.New("Kaboom"))
 		_, err = prm.GetLastTransactionID(context.TODO(), dbRole)
 		Expect(err).To(HaveOccurred())
 
-		mock.ExpectQuery(lastTransactionQuery).WillReturnError(sql.ErrNoRows)
+		mock.ExpectQuery(lastTransactionQuery).WithArgs("foo").WillReturnError(sql.ErrNoRows)
 		_, err = prm.GetLastTransactionID(context.TODO(), dbRole)
 		Expect(err).To(HaveOccurred())
 
 		rows.AddRow("1321")
-		mock.ExpectQuery(lastTransactionQuery).WillReturnRows(rows)
+		mock.ExpectQuery(lastTransactionQuery).WithArgs("foo").WillReturnRows(rows)
 		transID, err := prm.GetLastTransactionID(context.TODO(), dbRole)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(transID).To(BeEquivalentTo(1321))

--- a/pkg/management/postgres/logicalimport/database_test.go
+++ b/pkg/management/postgres/logicalimport/database_test.go
@@ -67,7 +67,8 @@ var _ = Describe("databaseSnapshotter methods test", func() {
 		var expectedQuery *sqlmock.ExpectedQuery
 		BeforeEach(func() {
 			expectedQuery = mock.
-				ExpectQuery("SELECT EXISTS(SELECT datname FROM pg_catalog.pg_database WHERE datname = $1)")
+				ExpectQuery("SELECT EXISTS(SELECT datname FROM pg_catalog.pg_database WHERE datname = $1)").
+				WithArgs("test")
 		})
 
 		It("should return true when the db exists", func() {

--- a/pkg/management/postgres/probes_test.go
+++ b/pkg/management/postgres/probes_test.go
@@ -55,7 +55,8 @@ var _ = Describe("probes", func() {
 				coalesce(sync_state, ''),
 				coalesce(sync_priority, 0)
 			FROM pg_catalog.pg_stat_replication
-			WHERE application_name ~ $1 AND usename = $2`)).WithArgs("-[0-9]+$", "streaming_replica").WillReturnError(errFailedQuery)
+			WHERE application_name ~ $1 AND usename = $2`),
+		).WithArgs("-[0-9]+$", "streaming_replica").WillReturnError(errFailedQuery)
 
 		err = instance.fillWalStatusFromConnection(status, db)
 		Expect(err).To(Equal(errFailedQuery))

--- a/pkg/management/postgres/probes_test.go
+++ b/pkg/management/postgres/probes_test.go
@@ -55,7 +55,7 @@ var _ = Describe("probes", func() {
 				coalesce(sync_state, ''),
 				coalesce(sync_priority, 0)
 			FROM pg_catalog.pg_stat_replication
-			WHERE application_name ~ $1 AND usename = $2`)).WillReturnError(errFailedQuery)
+			WHERE application_name ~ $1 AND usename = $2`)).WithArgs("-[0-9]+$", "streaming_replica").WillReturnError(errFailedQuery)
 
 		err = instance.fillWalStatusFromConnection(status, db)
 		Expect(err).To(Equal(errFailedQuery))


### PR DESCRIPTION
In version 1.5.1, the go-sqlmock module became stricter about missing
parameters in query expectations. This patch adds a few missing
parameters to our unit tests.