### PR TITLE
doc: update Go and Kind version in contributing guide

### DIFF
--- a/contribute/development_environment/README.md
+++ b/contribute/development_environment/README.md
@@ -41,9 +41,9 @@ on your local workstation.
 Make sure you have the following executables available in the `PATH`
 environment variable:
 
-- Go 1.17+ compiler
+- Go 1.21+ compiler
 - GNU Make
-- [Kind](https://kind.sigs.k8s.io/) v0.11.x or greater
+- [Kind](https://kind.sigs.k8s.io/) v0.20.x or greater
 - [golangci-lint](https://github.com/golangci/golangci-lint)
 - [goreleaser](https://goreleaser.com/)
 - [Operator SDK CLI](https://sdk.operatorframework.io/)


### PR DESCRIPTION
Update the required version of Go from 1.17 to 1.21 and kind from v0.11.x to v0.20.x 

Closes: #3526 