### PR TITLE
feat: allow users to disable ALTER SYSTEM

### DIFF
--- a/.wordlist-en-custom.txt
+++ b/.wordlist-en-custom.txt
@@ -634,6 +634,7 @@ dx
 ecdsa
 edb
 eks
+enableAlterSystem
 enablePodAntiAffinity
 enablePodMonitor
 enableSuperuserAccess

--- a/.wordlist-en-custom.txt
+++ b/.wordlist-en-custom.txt
@@ -859,6 +859,7 @@ olm
 ongoingBackups
 onlineConfiguration
 onlineUpdateEnabled
+onwards
 openldap
 openshift
 operability

--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -1181,7 +1181,8 @@ type PostgresConfiguration struct {
 	// If this parameter is true, the user will be able to invoke `ALTER SYSTEM`
 	// on this CNP Cluster.
 	// This should only be used for debugging and troubleshooting.
-	// Defaults to false.
+	// Defaults to true.
+	// +kubebuilder:default:=true
 	// +optional
 	EnableAlterSystem bool `json:"enableAlterSystem,omitempty"`
 }

--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -1177,6 +1177,13 @@ type PostgresConfiguration struct {
 	// big enough to simulate an infinite timeout
 	// +optional
 	PgCtlTimeoutForPromotion int32 `json:"promotionTimeout,omitempty"`
+
+	// If this parameter is true, the user will be able to invoke `ALTER SYSTEM`
+	// on this CNP Cluster.
+	// This should only be used for debugging and troubleshooting.
+	// Defaults to false.
+	// +optional
+	EnableAlterSystem bool `json:"enableAlterSystem,omitempty"`
 }
 
 // BootstrapConfiguration contains information about how to create the PostgreSQL

--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -1179,7 +1179,7 @@ type PostgresConfiguration struct {
 	PgCtlTimeoutForPromotion int32 `json:"promotionTimeout,omitempty"`
 
 	// If this parameter is true, the user will be able to invoke `ALTER SYSTEM`
-	// on this CNP Cluster.
+	// on this CloudNativePG Cluster.
 	// This should only be used for debugging and troubleshooting.
 	// Defaults to true.
 	// +kubebuilder:default:=true

--- a/config/crd/bases/postgresql.cnpg.io_clusters.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_clusters.yaml
@@ -2717,8 +2717,9 @@ spec:
                   enableAlterSystem:
                     default: true
                     description: If this parameter is true, the user will be able
-                      to invoke `ALTER SYSTEM` on this CNP Cluster. This should only
-                      be used for debugging and troubleshooting. Defaults to true.
+                      to invoke `ALTER SYSTEM` on this CloudNativePG Cluster. This
+                      should only be used for debugging and troubleshooting. Defaults
+                      to true.
                     type: boolean
                   ldap:
                     description: Options to specify LDAP configuration

--- a/config/crd/bases/postgresql.cnpg.io_clusters.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_clusters.yaml
@@ -2715,9 +2715,10 @@ spec:
                 description: Configuration of the PostgreSQL server
                 properties:
                   enableAlterSystem:
+                    default: true
                     description: If this parameter is true, the user will be able
                       to invoke `ALTER SYSTEM` on this CNP Cluster. This should only
-                      be used for debugging and troubleshooting. Defaults to false.
+                      be used for debugging and troubleshooting. Defaults to true.
                     type: boolean
                   ldap:
                     description: Options to specify LDAP configuration

--- a/config/crd/bases/postgresql.cnpg.io_clusters.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_clusters.yaml
@@ -2714,6 +2714,11 @@ spec:
               postgresql:
                 description: Configuration of the PostgreSQL server
                 properties:
+                  enableAlterSystem:
+                    description: If this parameter is true, the user will be able
+                      to invoke `ALTER SYSTEM` on this CNP Cluster. This should only
+                      be used for debugging and troubleshooting. Defaults to false.
+                    type: boolean
                   ldap:
                     description: Options to specify LDAP configuration
                     properties:

--- a/docs/src/cloudnative-pg.v1.md
+++ b/docs/src/cloudnative-pg.v1.md
@@ -3552,7 +3552,7 @@ big enough to simulate an infinite timeout</p>
 </td>
 <td>
    <p>If this parameter is true, the user will be able to invoke <code>ALTER SYSTEM</code>
-on this CNP Cluster.
+on this CloudNativePG Cluster.
 This should only be used for debugging and troubleshooting.
 Defaults to true.</p>
 </td>

--- a/docs/src/cloudnative-pg.v1.md
+++ b/docs/src/cloudnative-pg.v1.md
@@ -3554,7 +3554,7 @@ big enough to simulate an infinite timeout</p>
    <p>If this parameter is true, the user will be able to invoke <code>ALTER SYSTEM</code>
 on this CNP Cluster.
 This should only be used for debugging and troubleshooting.
-Defaults to false.</p>
+Defaults to true.</p>
 </td>
 </tr>
 </tbody>

--- a/docs/src/cloudnative-pg.v1.md
+++ b/docs/src/cloudnative-pg.v1.md
@@ -3547,6 +3547,16 @@ Default value is 40000000, greater than one year in seconds,
 big enough to simulate an infinite timeout</p>
 </td>
 </tr>
+<tr><td><code>enableAlterSystem</code><br/>
+<i>bool</i>
+</td>
+<td>
+   <p>If this parameter is true, the user will be able to invoke <code>ALTER SYSTEM</code>
+on this CNP Cluster.
+This should only be used for debugging and troubleshooting.
+Defaults to false.</p>
+</td>
+</tr>
 </tbody>
 </table>
 

--- a/docs/src/postgresql_conf.md
+++ b/docs/src/postgresql_conf.md
@@ -1,7 +1,7 @@
 # PostgreSQL Configuration
 
-Users that are familiar with PostgreSQL are aware of the existence of the following two files
-to configure an instance:
+Users that are familiar with PostgreSQL are aware of the existence of the
+following two files to configure an instance:
 
 - `postgresql.conf`: main run-time configuration file of PostgreSQL
 - `pg_hba.conf`: clients authentication file
@@ -20,6 +20,7 @@ These settings are the same across all instances.
     that are normally controlled by the operator might indeed lead to an
     unpredictable/unrecoverable state of the cluster.
     Moreover, `ALTER SYSTEM` changes are not replicated across the cluster.
+    See ["Enabling ALTER SYSTEM"](#enabling-alter-system) below for details.
 
 A reference for custom settings usage is included in the samples, see
 [`cluster-example-custom.yaml`](samples/cluster-example-custom.yaml).
@@ -407,6 +408,34 @@ After the change, the cluster instances will immediately reload the
 configuration to apply the changes.
 If the change involves a parameter requiring a restart, the operator will
 perform a rolling upgrade.
+
+## Enabling `ALTER SYSTEM`
+
+CloudNativePG strongly advocates employing the Cluster manifest as the
+exclusive method for altering the configuration of a PostgreSQL cluster. This
+approach guarantees coherence across the entire high-availability cluster and
+aligns with best practices for Infrastructure-as-Code.
+
+In CloudNativePG version 1.22 and onwards, the default configuration disables
+the use of `ALTER SYSTEM` on new Postgres clusters. This decision is rooted in
+the recognition of potential risks associated with this command. To enable the
+use of `ALTER SYSTEM`, you can explicitly set `.spec.postgresql.enableAlterSystem`
+to `true`.
+
+!!! Warning
+    Proceed with caution when utilizing `ALTER SYSTEM`. This command operates
+    directly on the connected instance and does not undergo replication.
+    CloudNativePG assumes responsibility for certain fixed parameters and complete
+    control over others, emphasizing the need for careful consideration.
+
+When `.spec.postgresql.enableAlterSystem` is configured as `false`, any attempt
+to execute `ALTER SYSTEM` will result in an error. The error message might
+resemble the following:
+
+``` output
+ERROR:  could not open file "postgresql.auto.conf": Permission denied
+```
+
 
 ## Dynamic Shared Memory settings
 

--- a/docs/src/postgresql_conf.md
+++ b/docs/src/postgresql_conf.md
@@ -436,7 +436,6 @@ resemble the following:
 ERROR:  could not open file "postgresql.auto.conf": Permission denied
 ```
 
-
 ## Dynamic Shared Memory settings
 
 PostgreSQL supports a few implementations for dynamic shared memory

--- a/internal/management/controller/instance_controller.go
+++ b/internal/management/controller/instance_controller.go
@@ -111,9 +111,6 @@ func (r *InstanceReconciler) Reconcile(
 	// Reconcile PostgreSQL instance parameters
 	r.reconcileInstance(cluster)
 
-	// Reconcile postgresql.auto.conf file
-	r.reconcileAutoConf(ctx, cluster)
-
 	// Takes care of the `.check-empty-wal-archive` file
 	if err := r.reconcileCheckWalArchiveFile(cluster); err != nil {
 		return reconcile.Result{}, err
@@ -135,6 +132,9 @@ func (r *InstanceReconciler) Reconcile(
 		return reconcile.Result{}, err
 	}
 	reloadNeeded = reloadNeeded || reloadConfigNeeded
+
+	// Reconcile postgresql.auto.conf file
+	r.reconcileAutoConf(ctx, cluster)
 
 	// here we execute initialization tasks that need to be executed only on the first reconciliation loop
 	if !r.firstReconcileDone.Load() {

--- a/pkg/management/postgres/instance.go
+++ b/pkg/management/postgres/instance.go
@@ -21,9 +21,11 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"io/fs"
 	"math"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"strconv"
 	"time"
@@ -193,6 +195,19 @@ type Instance struct {
 
 	// tablespaceSynchronizerChan is used to send tablespace configuration to the tablespace synchronizer
 	tablespaceSynchronizerChan chan map[string]apiv1.TablespaceConfiguration
+}
+
+// SetAlterSystemEnabled allows or deny writes to the
+// `postgresql.auto.conf` file in PGDATA, allowing and denying the
+// usage of the ALTER SYSTEM SQL command
+func (instance *Instance) SetAlterSystemEnabled(enabled bool) error {
+	autoConfFileName := path.Join(instance.PgData, "postgresql.auto.conf")
+
+	mode := fs.FileMode(0o600)
+	if !enabled {
+		mode = 0o400
+	}
+	return os.Chmod(autoConfFileName, mode)
 }
 
 // IsFenced checks whether the instance is marked as fenced

--- a/pkg/management/postgres/instance_test.go
+++ b/pkg/management/postgres/instance_test.go
@@ -225,3 +225,40 @@ var _ = Describe("check atomic bool", func() {
 		Expect(unAvailable).To(BeTrue())
 	})
 })
+
+var _ = Describe("ALTER SYSTEM enable and disable", func() {
+	var instance Instance
+	var autoConfFile string
+
+	BeforeEach(func() {
+		tmpDir := GinkgoT().TempDir()
+		instance.PgData = tmpDir
+
+		autoConfFile = filepath.Join(tmpDir, "postgresql.auto.conf")
+		f, err := os.Create(autoConfFile) // nolint: gosec
+		Expect(err).ToNot(HaveOccurred())
+
+		err = f.Close()
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("should be able to enable ALTER SYSTEM", func() {
+		err := instance.SetAlterSystemEnabled(true)
+		Expect(err).ToNot(HaveOccurred())
+
+		info, err := os.Stat(autoConfFile)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(info.Mode()).To(BeEquivalentTo(0o600))
+	})
+
+	It("should be able to disable ALTER SYSTEM", func() {
+		err := instance.SetAlterSystemEnabled(false)
+		Expect(err).ToNot(HaveOccurred())
+
+		info, err := os.Stat(autoConfFile)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(info.Mode()).To(BeEquivalentTo(0o400))
+	})
+})


### PR DESCRIPTION
Introduce the `.spec.postgresql.enableAlterSystem` to enable/disable the usage of the `ALTER SYSTEM` command for a PostgreSQL instance. Internally, the operator disables writes on the `$PGDATA/postgresql.auto.conf` file when `.spec.postgresql.enableAlterSystem` is set to `false`.

For back compatibility, the default is `true`.

Closes: #2725 