### PR TITLE
feat: disable ALTER SYSTEM by default

### DIFF
--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -1181,8 +1181,7 @@ type PostgresConfiguration struct {
 	// If this parameter is true, the user will be able to invoke `ALTER SYSTEM`
 	// on this CloudNativePG Cluster.
 	// This should only be used for debugging and troubleshooting.
-	// Defaults to true.
-	// +kubebuilder:default:=true
+	// Defaults to false.
 	// +optional
 	EnableAlterSystem bool `json:"enableAlterSystem,omitempty"`
 }

--- a/config/crd/bases/postgresql.cnpg.io_clusters.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_clusters.yaml
@@ -2721,11 +2721,10 @@ spec:
                 description: Configuration of the PostgreSQL server
                 properties:
                   enableAlterSystem:
-                    default: true
                     description: If this parameter is true, the user will be able
                       to invoke `ALTER SYSTEM` on this CloudNativePG Cluster. This
                       should only be used for debugging and troubleshooting. Defaults
-                      to true.
+                      to false.
                     type: boolean
                   ldap:
                     description: Options to specify LDAP configuration

--- a/docs/src/cloudnative-pg.v1.md
+++ b/docs/src/cloudnative-pg.v1.md
@@ -3560,7 +3560,7 @@ big enough to simulate an infinite timeout</p>
    <p>If this parameter is true, the user will be able to invoke <code>ALTER SYSTEM</code>
 on this CloudNativePG Cluster.
 This should only be used for debugging and troubleshooting.
-Defaults to true.</p>
+Defaults to false.</p>
 </td>
 </tr>
 </tbody>

--- a/docs/src/installation_upgrade.md
+++ b/docs/src/installation_upgrade.md
@@ -250,9 +250,16 @@ only the operator itself.
     from 1.20.x to 1.22, make sure you go through the release notes
     and upgrade instructions for 1.21 and 1.22.
 
-CloudNativePG keeps following the *security-by-default* approach and, after
-disabling `postgres` superuser access via the network in all new clusters, it
-now disables by default the usage of the `ALTER SYSTEM` command.
+CloudNativePG continues to adhere to the security-by-default approach. As of
+version 1.22, the usage of the `ALTER SYSTEM` command is now disabled by
+default.
+
+The reason behind this choice is to ensure that, by default, changes to the
+PostgreSQL configuration in a database cluster controlled by CloudNativePG are
+allowed only through the Kubernetes API.
+
+At the same time, we are providing an option to enable `ALTER SYSTEM` if you
+need to use it, even temporarily.
 
 If you want to retain the existing behavior, you need to explicitly enable it
 by setting `.spec.postgresql.enableAlterSystem` to `true`, as in the following
@@ -265,12 +272,11 @@ excerpt:
 ...
 ```
 
-The reason behind this choice is to ensure that, by default, changes to the
-PostgreSQL configuration in a database cluster controlled by CloudNativePG are
-allowed only through the Kubernetes API.
-
-At the same time, we are providing an option to enable `ALTER SYSTEM` if you
-need to use it, even temporarily.
+!!! Important
+    You can execute this operation immediately following your upgrade to
+    version 1.22.0. Alternatively, you have the option to first upgrade to either
+    version 1.21.2 or 1.20.5 and then explicitly set it to true, as demonstrated in
+    the example above.
 
 ### Upgrading to 1.21 from a previous minor version
 


### PR DESCRIPTION
this patch make option `.spec.postgresql.enableAlterSystem` disable by default 
since 1.22.0 release. the option is introduced in through this [patch](https://github.com/cloudnative-pg/cloudnative-pg/pull/3535).
Closes #3544 