### PR TITLE
fix: avoid considering old snapshots when creating a replica

### DIFF
--- a/pkg/reconciler/persistentvolumeclaim/storagesource.go
+++ b/pkg/reconciler/persistentvolumeclaim/storagesource.go
@@ -18,10 +18,10 @@ package persistentvolumeclaim
 
 import (
 	"context"
-	"time"
 
 	volumesnapshot "github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
@@ -89,7 +89,7 @@ func GetCandidateStorageSourceForReplica(
 
 	if result := getCandidateSourceFromBackupList(
 		ctx,
-		cluster.ObjectMeta.CreationTimestamp.Time,
+		cluster.ObjectMeta.CreationTimestamp,
 		backupList,
 	); result != nil {
 		return result
@@ -111,7 +111,7 @@ func GetCandidateStorageSourceForReplica(
 // given a backup list
 func getCandidateSourceFromBackupList(
 	ctx context.Context,
-	clusterCreationTime time.Time,
+	clusterCreationTime metav1.Time,
 	backupList apiv1.BackupList,
 ) *StorageSource {
 	contextLogger := log.FromContext(ctx)
@@ -126,7 +126,7 @@ func getCandidateSourceFromBackupList(
 			continue
 		}
 
-		if backup.ObjectMeta.CreationTimestamp.Time.Before(clusterCreationTime) {
+		if backup.ObjectMeta.CreationTimestamp.Before(&clusterCreationTime) {
 			contextLogger.Info(
 				"skipping backup as a potential recovery storage source candidate " +
 					"because if was created before the Cluster object")

--- a/pkg/reconciler/persistentvolumeclaim/storagesource_test.go
+++ b/pkg/reconciler/persistentvolumeclaim/storagesource_test.go
@@ -287,8 +287,23 @@ var _ = Describe("candidate backups", func() {
 		}
 		backupList.SortByReverseCreationTime()
 
-		source := getCandidateSourceFromBackupList(ctx, backupList)
+		source := getCandidateSourceFromBackupList(ctx, time.Now().Add(-1*time.Hour), backupList)
 		Expect(source).ToNot(BeNil())
 		Expect(source.DataSource.Name).To(Equal("completed-backup"))
+	})
+
+	It("will refuse to use automatically use snapshots if they are older than the Cluster", func(ctx context.Context) {
+		backupList := apiv1.BackupList{
+			Items: []apiv1.Backup{
+				objectStoreBackup,
+				nonCompletedBackup,
+				oldCompletedBackup,
+				completedBackup,
+			},
+		}
+		backupList.SortByReverseCreationTime()
+
+		source := getCandidateSourceFromBackupList(ctx, time.Now().Add(1*time.Hour), backupList)
+		Expect(source).To(BeNil())
 	})
 })

--- a/pkg/reconciler/persistentvolumeclaim/storagesource_test.go
+++ b/pkg/reconciler/persistentvolumeclaim/storagesource_test.go
@@ -287,7 +287,7 @@ var _ = Describe("candidate backups", func() {
 		}
 		backupList.SortByReverseCreationTime()
 
-		source := getCandidateSourceFromBackupList(ctx, time.Now().Add(-1*time.Hour), backupList)
+		source := getCandidateSourceFromBackupList(ctx, metav1.NewTime(time.Now().Add(-1*time.Hour)), backupList)
 		Expect(source).ToNot(BeNil())
 		Expect(source.DataSource.Name).To(Equal("completed-backup"))
 	})
@@ -303,7 +303,7 @@ var _ = Describe("candidate backups", func() {
 		}
 		backupList.SortByReverseCreationTime()
 
-		source := getCandidateSourceFromBackupList(ctx, time.Now().Add(1*time.Hour), backupList)
+		source := getCandidateSourceFromBackupList(ctx, metav1.NewTime(time.Now().Add(1*time.Hour)), backupList)
 		Expect(source).To(BeNil())
 	})
 })


### PR DESCRIPTION
This patch prevents CNPG from using backups that are older than the created Cluster when bootstrapping a new replica.

Closes: #3563 