### PR TITLE
fix(e2e): avoid uploading multiple artifacts with same name

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -659,7 +659,7 @@ jobs:
         if: (always() && !cancelled())
         uses: actions/upload-artifact@v4
         with:
-          name: testartifacts-local
+          name: testartifacts-${{ env.MATRIX }}
           path: testartifacts-${{ env.MATRIX }}/
           retention-days: 7
       -


### PR DESCRIPTION
This is needed to support upload-artifact and download-artifact v4.