### PR TITLE
feat(pooler): warn and log manual integration required

### DIFF
--- a/api/v1/pooler_types.go
+++ b/api/v1/pooler_types.go
@@ -166,7 +166,7 @@ type PgBouncerSpec struct {
 	Paused *bool `json:"paused,omitempty"`
 }
 
-// IsPaused returns whether all database should be paused or not
+// IsPaused returns whether all database should be paused or not.
 func (in PgBouncerSpec) IsPaused() bool {
 	return in.Paused != nil && *in.Paused
 }
@@ -273,4 +273,19 @@ func (in *Pooler) GetAuthQuery() string {
 	}
 
 	return DefaultPgBouncerPoolerAuthQuery
+}
+
+// IsAutomatedIntegration returns whether the Pooler integration with the
+// Cluster is automated or not.
+func (in *Pooler) IsAutomatedIntegration() bool {
+	if in.Spec.PgBouncer == nil {
+		return true
+	}
+	// If the user specified an AuthQuerySecret or an AuthQuery, the integration
+	// is not going to be handled by the operator.
+	if (in.Spec.PgBouncer.AuthQuerySecret != nil && in.Spec.PgBouncer.AuthQuerySecret.Name != "") ||
+		in.Spec.PgBouncer.AuthQuery != "" {
+		return false
+	}
+	return true
 }

--- a/controllers/cluster_status.go
+++ b/controllers/cluster_status.go
@@ -393,13 +393,6 @@ func (r *ClusterReconciler) getPoolerIntegrationsNeeded(ctx context.Context,
 	}
 
 	pgbouncerPoolerIntegrations, err := r.getPgbouncerIntegrationStatus(ctx, cluster, poolers)
-
-	for _, pooler := range poolers.Items {
-		if !slices.Contains(pgbouncerPoolerIntegrations.Secrets, pooler.Name) {
-			log.Info("pooler not automatically configured, manual configuration required",
-				"cluster", pooler.Spec.Cluster.Name, "pooler", pooler.Name)
-		}
-	}
 	if err != nil {
 		return nil, fmt.Errorf("while getting integration status for pgbouncer poolers in cluster %s: %w",
 			cluster.Name, err)
@@ -439,11 +432,7 @@ func (r *ClusterReconciler) getPgbouncerIntegrationStatus(
 		// We skip secrets which were directly setup by the user with
 		// the authQuery and authQuerySecret parameters inside the
 		// pooler
-		if pooler.Spec.PgBouncer.AuthQuery != "" {
-			continue
-		}
-
-		if pooler.Spec.PgBouncer.AuthQuerySecret != nil && pooler.Spec.PgBouncer.AuthQuerySecret.Name != "" {
+		if !pooler.IsAutomatedIntegration() {
 			continue
 		}
 


### PR DESCRIPTION
Closes #2479

Removes the noisy log, only logging on the Pooler creation or update (once) if needed and returning warning to user.

<img width="1247" alt="image" src="https://github.com/cloudnative-pg/cloudnative-pg/assets/5697904/53e047d5-0836-4500-826b-77772b707770">

```
cnpg-controller-manager-86cf7ff964-m5hp9 manager {"level":"info","ts":"2023-12-16T12:32:27Z","logger":"pooler-resource","msg":"Pooler not automatically configured, manual configuration required","version":"v1","name":"pooler-example-rw","namespace":"default","cluster":"cluster-example"}
```