### PR TITLE
fix: set wal_sender_timeout to 5min when joining through pg_basebackup

### DIFF
--- a/pkg/management/postgres/join.go
+++ b/pkg/management/postgres/join.go
@@ -70,18 +70,26 @@ func ClonePgData(connectionString, targetPgData, walDir string) error {
 
 // Join creates a new instance joined to an existing PostgreSQL cluster
 func (info InitInfo) Join(cluster *apiv1.Cluster) error {
-	// We explicitly set a high-enough wal_sender_timeout for join-related pg_basebackup executions.
-	// A short timeout could not be enough in case the instance is slow to send data, like when the I/O is overloaded.
-	primaryConnInfo := buildPrimaryConnInfo(info.ParentNode, info.PodName) +
-		" dbname=postgres connect_timeout=5 options='-c wal_sender_timeout=300s'"
+	primaryConnInfo := buildPrimaryConnInfo(info.ParentNode, info.PodName) + " dbname=postgres connect_timeout=5"
+
+	pgVersion, err := cluster.GetPostgresqlVersion()
+	if err != nil {
+		log.Warning(
+			"Error while parsing PostgreSQL server version, defaulting to PostgreSQL 11",
+			"imageName", cluster.GetImageName(),
+			"err", err)
+	} else if pgVersion >= 120000 {
+		// We explicitly set a high-enough wal_sender_timeout for join-related pg_basebackup executions.
+		// A short timeout could not be enough in case the instance is slow to send data, like when the I/O is overloaded.
+		primaryConnInfo += " options='-c wal_sender_timeout=300s'"
+	}
 
 	coredumpFilter := cluster.GetCoredumpFilter()
 	if err := system.SetCoredumpFilter(coredumpFilter); err != nil {
 		return err
 	}
 
-	err := ClonePgData(primaryConnInfo, info.PgData, info.PgWal)
-	if err != nil {
+	if err = ClonePgData(primaryConnInfo, info.PgData, info.PgWal); err != nil {
 		return err
 	}
 

--- a/pkg/management/postgres/join.go
+++ b/pkg/management/postgres/join.go
@@ -75,7 +75,7 @@ func (info InitInfo) Join(cluster *apiv1.Cluster) error {
 	pgVersion, err := cluster.GetPostgresqlVersion()
 	if err != nil {
 		log.Warning(
-			"Error while parsing PostgreSQL server version, defaulting to PostgreSQL 11",
+			"Error while parsing PostgreSQL server version to define connection options, defaulting to PostgreSQL 11",
 			"imageName", cluster.GetImageName(),
 			"err", err)
 	} else if pgVersion >= 120000 {

--- a/pkg/management/postgres/join.go
+++ b/pkg/management/postgres/join.go
@@ -79,9 +79,10 @@ func (info InitInfo) Join(cluster *apiv1.Cluster) error {
 			"imageName", cluster.GetImageName(),
 			"err", err)
 	} else if pgVersion >= 120000 {
-		// We explicitly set a high-enough wal_sender_timeout for join-related pg_basebackup executions.
-		// A short timeout could not be enough in case the instance is slow to send data, like when the I/O is overloaded.
-		primaryConnInfo += " options='-c wal_sender_timeout=300s'"
+		// We explicitly disable wal_sender_timeout for join-related pg_basebackup executions.
+		// A short timeout could not be enough in case the instance is slow to send data,
+		// like when the I/O is overloaded.
+		primaryConnInfo += " options='-c wal_sender_timeout=0s'"
 	}
 
 	coredumpFilter := cluster.GetCoredumpFilter()


### PR DESCRIPTION
We explicitly set a high-enough wal_sender_timeout for join-related pg_basebackup executions. A short timeout could not be enough in case the instance is slow to send data, like when the I/O is overloaded.

Fixes #3337 