### PR TITLE
fix(doc): indentation of example in `recovery.md`

### DIFF
--- a/docs/src/recovery.md
+++ b/docs/src/recovery.md
@@ -129,8 +129,8 @@ metadata:
   name: cluster-restore
 spec:
   [...]
-
-bootstrap:
+    
+  bootstrap:
     recovery:
       volumeSnapshots:
         storage:
@@ -150,7 +150,7 @@ metadata:
 spec:
   [...]
 
-bootstrap:
+  bootstrap:
     recovery:
       volumeSnapshots:
         storage:

--- a/docs/src/recovery.md
+++ b/docs/src/recovery.md
@@ -74,7 +74,7 @@ spec:
   
   superuserSecret:
     name: superuser-secret
-    
+
   bootstrap:
     recovery:
       source: clusterBackup

--- a/docs/src/recovery.md
+++ b/docs/src/recovery.md
@@ -74,7 +74,7 @@ spec:
   
   superuserSecret:
     name: superuser-secret
-
+    
   bootstrap:
     recovery:
       source: clusterBackup
@@ -129,7 +129,7 @@ metadata:
   name: cluster-restore
 spec:
   [...]
-    
+
   bootstrap:
     recovery:
       volumeSnapshots:


### PR DESCRIPTION
Some examples in the documentation page `recovery.md` have the wrong indentation:
The `bootstrap` block is at the same indentation level as the spec block, when it should belong to the `spec` block according to the API documentation: https://cloudnative-pg.io/documentation/1.21/cloudnative-pg.v1/#postgresql-cnpg-io-v1-ClusterSpec