### PR TITLE
fix(ci): do not consider alpha version of KinD

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -68,6 +68,7 @@
       ],
       "datasourceTemplate": "docker",
       "versioningTemplate": "loose",
+      "allowedVersions": "!/alpha/",
       "depNameTemplate": "kindest/node",
     }, {
       // We want a PR to bump spellcheck version in the Makefile

--- a/.github/workflows/public-cloud-k8s-versions-check.yml
+++ b/.github/workflows/public-cloud-k8s-versions-check.yml
@@ -98,7 +98,7 @@ jobs:
           for baseversion in $(seq $MINIMAL_K8S 0.01 99); do
             URL="https://registry.hub.docker.com/v2/repositories/kindest/node/tags?name=${baseversion}&ordering=last_updated"
             v=$(curl -SsL "${URL}" | jq -rc '.results[].name' | sort -Vr | head -n1)
-            if [[ -z "${v}" ]]; then
+            if [[ -z "${v}" ]] || [[ "${v}" =~ "alpha" ]]; then
                break
             fi
             echo "${v}"


### PR DESCRIPTION
We were updating even alpha version of KinD which is not desired, from now on,
we exclude any kindest/node image that contains the "alpha" string on it