### PR TITLE
test: enforce backup from primary in upgrade e2e

### DIFF
--- a/tests/e2e/fixtures/upgrade/backup1.yaml
+++ b/tests/e2e/fixtures/upgrade/backup1.yaml
@@ -3,5 +3,6 @@ kind: Backup
 metadata:
   name: cluster-backup
 spec:
+  target: primary
   cluster:
     name: cluster1

--- a/tests/e2e/fixtures/upgrade/scheduled-backup.yaml
+++ b/tests/e2e/fixtures/upgrade/scheduled-backup.yaml
@@ -4,5 +4,6 @@ metadata:
   name: scheduled-backup
 spec:
   schedule: "*/30 * * * * *"
+  target: primary
   cluster:
     name: cluster1


### PR DESCRIPTION
This patch enforce the e2e test case to backup from primary, to avoid the backup is waiting 
for checkpoint to start in standby