### PR TITLE
chore: remove useless code inside snapshot `finalize`

### DIFF
--- a/pkg/reconciler/backup/volumesnapshot/online.go
+++ b/pkg/reconciler/backup/volumesnapshot/online.go
@@ -69,12 +69,6 @@ func (o *onlineExecutor) finalize(
 		return nil, nil
 	}
 
-	if body.Error != nil {
-		return nil, fmt.Errorf(
-			"while processing the finalizing request, phase: %s, "+
-				"error message: %s, error code: %s", body.Data.Phase, body.Error.Message, body.Error.Code)
-	}
-
 	switch status.Phase {
 	case webserver.Started:
 		if err := o.backupClient.Stop(ctx,


### PR DESCRIPTION
The body error check within the `finalize` method of the volume snapshot backup has been removed. This check was redundant and unnecessary since we are already checking for errors inside the `EnsureDataIsPresent` function, and it would never be triggered.