### PR TITLE
fix: correctly compare zero and nil `.spec.projectedVolumeTemplate.sources`

### DIFF
--- a/controllers/cluster_upgrade.go
+++ b/controllers/cluster_upgrade.go
@@ -385,15 +385,16 @@ func checkProjectedVolumeIsOutdated(
 	status postgres.PostgresqlStatus,
 	cluster *apiv1.Cluster,
 ) (rollout, error) {
+	isNilOrZero := func(vs *corev1.ProjectedVolumeSource) bool {
+		return vs == nil || len(vs.Sources) == 0
+	}
+
 	// Check if there is a change in the projected volume configuration
 	currentProjectedVolumeConfiguration := getProjectedVolumeConfigurationFromPod(*status.Pod)
 	desiredProjectedVolumeConfiguration := cluster.Spec.ProjectedVolumeTemplate.DeepCopy()
 
-	// In the pod specification, setting the projected volume source as a zero-length slice
-	// results in it remaining null. Therefore, we consider a nil value to be equivalent to a zero-length slice.
-	// we do not need to raise a rollout if the desired and current projected volume source is zero-length or nil
-	if (desiredProjectedVolumeConfiguration == nil || len(desiredProjectedVolumeConfiguration.Sources) == 0) &&
-		(currentProjectedVolumeConfiguration == nil || len(currentProjectedVolumeConfiguration.Sources) == 0) {
+	// we do not need to raise a rollout if the desired and current projected volume source equal to zero-length or nil
+	if isNilOrZero(desiredProjectedVolumeConfiguration) && isNilOrZero(currentProjectedVolumeConfiguration) {
 		return rollout{}, nil
 	}
 

--- a/controllers/cluster_upgrade.go
+++ b/controllers/cluster_upgrade.go
@@ -394,6 +394,14 @@ func checkProjectedVolumeIsOutdated(
 		desiredProjectedVolumeConfiguration.DefaultMode = &defaultMode
 	}
 
+	// In the pod specification, setting the projected volume source as a zero-length slice
+	// results in it remaining null. Therefore, we consider a nil value to be equivalent to a zero-length slice.
+	// we do not need to raise a rollout if the desired and current projected volume source is zero-length or nil
+	if (desiredProjectedVolumeConfiguration == nil || len(desiredProjectedVolumeConfiguration.Sources) == 0) &&
+		(currentProjectedVolumeConfiguration == nil || len(currentProjectedVolumeConfiguration.Sources) == 0) {
+		desiredProjectedVolumeConfiguration = currentProjectedVolumeConfiguration
+	}
+
 	if reflect.DeepEqual(currentProjectedVolumeConfiguration, desiredProjectedVolumeConfiguration) {
 		return rollout{}, nil
 	}

--- a/controllers/cluster_upgrade.go
+++ b/controllers/cluster_upgrade.go
@@ -387,19 +387,19 @@ func checkProjectedVolumeIsOutdated(
 ) (rollout, error) {
 	// Check if there is a change in the projected volume configuration
 	currentProjectedVolumeConfiguration := getProjectedVolumeConfigurationFromPod(*status.Pod)
-
 	desiredProjectedVolumeConfiguration := cluster.Spec.ProjectedVolumeTemplate.DeepCopy()
-	if desiredProjectedVolumeConfiguration != nil && desiredProjectedVolumeConfiguration.DefaultMode == nil {
-		defaultMode := corev1.ProjectedVolumeSourceDefaultMode
-		desiredProjectedVolumeConfiguration.DefaultMode = &defaultMode
-	}
 
 	// In the pod specification, setting the projected volume source as a zero-length slice
 	// results in it remaining null. Therefore, we consider a nil value to be equivalent to a zero-length slice.
 	// we do not need to raise a rollout if the desired and current projected volume source is zero-length or nil
 	if (desiredProjectedVolumeConfiguration == nil || len(desiredProjectedVolumeConfiguration.Sources) == 0) &&
 		(currentProjectedVolumeConfiguration == nil || len(currentProjectedVolumeConfiguration.Sources) == 0) {
-		desiredProjectedVolumeConfiguration = currentProjectedVolumeConfiguration
+		return rollout{}, nil
+	}
+
+	if desiredProjectedVolumeConfiguration != nil && desiredProjectedVolumeConfiguration.DefaultMode == nil {
+		defaultMode := corev1.ProjectedVolumeSourceDefaultMode
+		desiredProjectedVolumeConfiguration.DefaultMode = &defaultMode
 	}
 
 	if reflect.DeepEqual(currentProjectedVolumeConfiguration, desiredProjectedVolumeConfiguration) {

--- a/controllers/cluster_upgrade_test.go
+++ b/controllers/cluster_upgrade_test.go
@@ -421,6 +421,57 @@ var _ = Describe("Pod upgrade", Ordered, func() {
 			Expect(rollout.required).To(BeTrue())
 		})
 	})
+
+	When("The projected volume changed", func() {
+		It("should not require rollout if projected volume is 0 length slice in cluster",
+			func(ctx SpecContext) {
+				cluster.Spec.ProjectedVolumeTemplate = &corev1.ProjectedVolumeSource{
+					Sources: []corev1.VolumeProjection{},
+				}
+				pod := specs.PodWithExistingStorage(cluster, 1)
+				status := postgres.PostgresqlStatus{
+					Pod:            pod,
+					IsPodReady:     true,
+					ExecutableHash: "test",
+				}
+
+				rollout := isPodNeedingRollout(ctx, status, &cluster)
+				Expect(rollout.reason).To(BeEmpty())
+				Expect(rollout.required).To(BeFalse())
+			})
+
+		It("should not require rollout if projected volume source is nil",
+			func(ctx SpecContext) {
+				cluster.Spec.ProjectedVolumeTemplate = &corev1.ProjectedVolumeSource{
+					Sources: nil,
+				}
+				pod := specs.PodWithExistingStorage(cluster, 1)
+				status := postgres.PostgresqlStatus{
+					Pod:            pod,
+					IsPodReady:     true,
+					ExecutableHash: "test",
+				}
+
+				rollout := isPodNeedingRollout(ctx, status, &cluster)
+				Expect(rollout.reason).To(BeEmpty())
+				Expect(rollout.required).To(BeFalse())
+			})
+
+		It("should not require rollout if projected volume  is nil",
+			func(ctx SpecContext) {
+				cluster.Spec.ProjectedVolumeTemplate = nil
+				pod := specs.PodWithExistingStorage(cluster, 1)
+				status := postgres.PostgresqlStatus{
+					Pod:            pod,
+					IsPodReady:     true,
+					ExecutableHash: "test",
+				}
+
+				rollout := isPodNeedingRollout(ctx, status, &cluster)
+				Expect(rollout.reason).To(BeEmpty())
+				Expect(rollout.required).To(BeFalse())
+			})
+	})
 })
 
 var _ = Describe("Test pod rollout due to topology", func() {


### PR DESCRIPTION
This patch prevents the rollout of the pod in case the current and expected `.spec.projectedVolumeTemplate.sources` use different semantics to describe a  volume source not being present.

Previously, we required a strict equivalence between the current and expected values of `.spec.projectedVolumeTemplate.sources`, which resulted in the operator initiating rollouts even when comparing zero and nil values.

Closes: #3623 