### PR TITLE
Follow current pod security standards for pgbench job

### DIFF
--- a/internal/cmd/plugin/pgbench/pgbench.go
+++ b/internal/cmd/plugin/pgbench/pgbench.go
@@ -27,6 +27,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
@@ -151,9 +152,25 @@ func (cmd *pgBenchRun) buildJob(cluster *apiv1.Cluster) *batchv1.Job {
 							Env:             cmd.buildEnvVariables(),
 							Command:         []string{pgBenchKeyWord},
 							Args:            cmd.pgBenchCommandArgs,
+							SecurityContext: &corev1.SecurityContext{
+								AllowPrivilegeEscalation: ptr.To[bool](false),
+								Privileged:               ptr.To[bool](false),
+								Capabilities: &corev1.Capabilities{
+									Drop: []corev1.Capability{
+										"ALL",
+									},
+								},
+							},
 						},
 					},
 					NodeSelector: cmd.buildNodeSelector(),
+					SecurityContext: &corev1.PodSecurityContext{
+						RunAsNonRoot: ptr.To[bool](true),
+						RunAsUser:    ptr.To[int64](1000),
+						SeccompProfile: &corev1.SeccompProfile{
+							Type: corev1.SeccompProfileTypeRuntimeDefault,
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
We run our cluster with restricted [pod security standards](https://kubernetes.io/docs/concepts/security/pod-security-standards/) making the pgbench job fail due to missing security context configuration and similar. I feel they're a good idea for any setup, thus this MR implements them by default.