### PR TITLE
feat(plugin): add options for database user an password in `pgbench` command

### DIFF
--- a/internal/cmd/plugin/pgbench/cmd.go
+++ b/internal/cmd/plugin/pgbench/cmd.go
@@ -61,6 +61,20 @@ func NewCmd() *cobra.Command {
 		"The name of the database that will be used by pgbench. Defaults to: app",
 	)
 
+	pgBenchCmd.Flags().StringVar(
+		&run.dbUser,
+		"db-user",
+		"app",
+		"The name of the database user that will be used by pgbench. Defaults to: app",
+	)
+
+	pgBenchCmd.Flags().StringVar(
+		&run.dbPassword,
+		"db-password",
+		"",
+		"The password of the database user that will be used by pgbench. Defaults to: Password in the clusters user secret.",
+	)
+
 	pgBenchCmd.Flags().BoolVar(
 		&run.dryRun,
 		"dry-run",

--- a/internal/cmd/plugin/pgbench/cmd_test.go
+++ b/internal/cmd/plugin/pgbench/cmd_test.go
@@ -41,6 +41,14 @@ var _ = Describe("NewCmd", func() {
 		Expect(dbNameFlag).ToNot(BeNil())
 		Expect(dbNameFlag.DefValue).To(Equal("app"))
 
+		dbUserFlag := cmd.Flag("db-user")
+		Expect(dbUserFlag).ToNot(BeNil())
+		Expect(dbUserFlag.DefValue).To(Equal("app"))
+
+		dbPasswordFlag := cmd.Flag("db-password")
+		Expect(dbPasswordFlag).ToNot(BeNil())
+		Expect(dbPasswordFlag.DefValue).To(Equal(""))
+
 		dryRunFlag := cmd.Flag("dry-run")
 		Expect(dryRunFlag).ToNot(BeNil())
 		Expect(dryRunFlag.DefValue).To(Equal("false"))
@@ -60,6 +68,8 @@ var _ = Describe("NewCmd", func() {
 		cmd.RunE = func(cmd *cobra.Command, args []string) error {
 			testRun.jobName, _ = cmd.Flags().GetString("job-name")
 			testRun.dbName, _ = cmd.Flags().GetString("db-name")
+			testRun.dbUser, _ = cmd.Flags().GetString("db-user")
+			testRun.dbPassword, _ = cmd.Flags().GetString("db-password")
 			testRun.dryRun, _ = cmd.Flags().GetBool("dry-run")
 			testRun.nodeSelector, _ = cmd.Flags().GetStringSlice("node-selector")
 
@@ -73,6 +83,8 @@ var _ = Describe("NewCmd", func() {
 			"mycluster",
 			"--job-name=myjob",
 			"--db-name=mydb",
+			"--db-user=myuser",
+			"--db-password=mypassword",
 			"--dry-run=true",
 			"--node-selector=label=value",
 			"arg1",
@@ -89,6 +101,8 @@ var _ = Describe("NewCmd", func() {
 		Expect(testRun.jobName).To(Equal("myjob"))
 		Expect(testRun.clusterName).To(Equal("mycluster"))
 		Expect(testRun.dbName).To(Equal("mydb"))
+		Expect(testRun.dbUser).To(Equal("myuser"))
+		Expect(testRun.dbPassword).To(Equal("mypassword"))
 		Expect(testRun.dryRun).To(BeTrue())
 		Expect(testRun.nodeSelector).To(Equal([]string{"label=value"}))
 		Expect(testRun.pgBenchCommandArgs).To(Equal([]string{"arg1", "arg2"}))

--- a/internal/cmd/plugin/pgbench/pgbench.go
+++ b/internal/cmd/plugin/pgbench/pgbench.go
@@ -37,6 +37,8 @@ type pgBenchRun struct {
 	jobName            string
 	clusterName        string
 	dbName             string
+	dbUser             string
+	dbPassword         string
 	nodeSelector       []string
 	pgBenchCommandArgs []string
 	dryRun             bool
@@ -179,17 +181,18 @@ func (cmd *pgBenchRun) buildEnvVariables() []corev1.EnvVar {
 			Value: "5432",
 		},
 		{
-			Name: "PGUSER",
-			ValueFrom: &corev1.EnvVarSource{
-				SecretKeyRef: &corev1.SecretKeySelector{
-					LocalObjectReference: corev1.LocalObjectReference{
-						Name: appSecreteName,
-					},
-					Key: "username",
-				},
-			},
+			Name:  "PGUSER",
+			Value: cmd.dbUser,
 		},
-		{
+	}
+
+	if cmd.dbPassword != "" {
+		envVar = append(envVar, corev1.EnvVar{
+			Name:  "PGPASSWORD",
+			Value: cmd.dbPassword,
+		})
+	} else {
+		envVar = append(envVar, corev1.EnvVar{
 			Name: "PGPASSWORD",
 			ValueFrom: &corev1.EnvVarSource{
 				SecretKeyRef: &corev1.SecretKeySelector{
@@ -199,7 +202,7 @@ func (cmd *pgBenchRun) buildEnvVariables() []corev1.EnvVar {
 					Key: "password",
 				},
 			},
-		},
+		})
 	}
 
 	return envVar


### PR DESCRIPTION
We want pgbench to run against a different DB/user. DB is already configurable. This MR allows to configure the user and password pgbench will use.