### PR TITLE
fix: grafana sample dashboard incorrect db size

### DIFF
--- a/docs/src/samples/monitoring/grafana-configmap.yaml
+++ b/docs/src/samples/monitoring/grafana-configmap.yaml
@@ -706,7 +706,7 @@ data:
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "cnpg_pg_database_size_bytes{namespace=\"$namespace\"}",
+              "expr": "cnpg_pg_database_size_bytes{datname!~\"template.*|postgres.*\", namespace=~\"$namespace\", pod=~\"$instances\"}",
               "format": "table",
               "instant": true,
               "legendFormat": "__auto",

--- a/docs/src/samples/monitoring/grafana-dashboard.json
+++ b/docs/src/samples/monitoring/grafana-dashboard.json
@@ -682,7 +682,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "cnpg_pg_database_size_bytes{namespace=\"$namespace\"}",
+          "expr": "cnpg_pg_database_size_bytes{datname!~\"template.*|postgres.*\", namespace=~\"$namespace\", pod=~\"$instances\"}",
           "format": "table",
           "instant": true,
           "legendFormat": "__auto",


### PR DESCRIPTION
The sample dashboard currently reports a wrong db size.
Instead of displaying the actual db size it displays the sum of all dbs.
[Original Slack Thread](https://cloudnativepg.slack.com/archives/C03AX0J5P29/p1704283655293379)
