### PR TITLE
fix: check recovery backups/snapshots readiness before cluster bootstrap

### DIFF
--- a/controllers/cluster_create.go
+++ b/controllers/cluster_create.go
@@ -968,16 +968,11 @@ func (r *ClusterReconciler) createPrimaryInstance(
 		return ctrl.Result{}, nil
 	}
 
-	// Generate a new node serial
-	nodeSerial, err := r.generateNodeSerial(ctx, cluster)
-	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("cannot generate node serial: %w", err)
-	}
-
 	var backup *apiv1.Backup
 	if cluster.Spec.Bootstrap != nil &&
 		cluster.Spec.Bootstrap.Recovery != nil &&
 		cluster.Spec.Bootstrap.Recovery.Backup != nil {
+		var err error
 		backup, err = r.getOriginBackup(ctx, cluster)
 		if err != nil {
 			return ctrl.Result{}, err
@@ -999,6 +994,12 @@ func (r *ClusterReconciler) createPrimaryInstance(
 				RequeueAfter: time.Minute,
 			}, nil
 		}
+	}
+
+	// Generate a new node serial
+	nodeSerial, err := r.generateNodeSerial(ctx, cluster)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("cannot generate node serial: %w", err)
 	}
 
 	// Get the source storage from where to create the primary instance.

--- a/controllers/cluster_create.go
+++ b/controllers/cluster_create.go
@@ -983,6 +983,8 @@ func (r *ClusterReconciler) createPrimaryInstance(
 	}
 
 	// Generate a new node serial
+	// Move the node serial generation after the checkBootstrapFromRecovery to ensure
+	// the retry can continue without error when the cluster is bootstrapped from recovery
 	nodeSerial, err := r.generateNodeSerial(ctx, cluster)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("cannot generate node serial: %w", err)

--- a/controllers/cluster_create.go
+++ b/controllers/cluster_create.go
@@ -972,12 +972,10 @@ func (r *ClusterReconciler) createPrimaryInstance(
 		backup           *apiv1.Backup
 		recoverySnapshot *persistentvolumeclaim.StorageSource
 	)
-	// if the cluster is bootstrapping from recovery, it may do so from
+	// If the cluster is bootstrapping from recovery, it may do so from:
 	//  1 - a backup object, which may be done with volume snapshots or object storage
 	//  2 - volume snapshots
 	// We need to check that whichever alternative is used, the backup/snapshot is completed.
-	// If not completed, we requeue.
-	// If completed, we know that either backup or recoverySnapshot (perhaps both) are non-nil
 	if cluster.Spec.Bootstrap != nil &&
 		cluster.Spec.Bootstrap.Recovery != nil {
 		var err error
@@ -1016,7 +1014,6 @@ func (r *ClusterReconciler) createPrimaryInstance(
 
 	isBootstrappingFromRecovery := cluster.Spec.Bootstrap != nil && cluster.Spec.Bootstrap.Recovery != nil
 	isBootstrappingFromBaseBackup := cluster.Spec.Bootstrap != nil && cluster.Spec.Bootstrap.PgBaseBackup != nil
-
 	switch {
 	case isBootstrappingFromRecovery && recoverySnapshot != nil:
 		var snapshot volumesnapshot.VolumeSnapshot

--- a/controllers/cluster_create.go
+++ b/controllers/cluster_create.go
@@ -972,12 +972,12 @@ func (r *ClusterReconciler) createPrimaryInstance(
 		backup           *apiv1.Backup
 		recoverySnapshot *persistentvolumeclaim.StorageSource
 	)
-	// if the cluster is bootstrapping in recovery, it may do so from
+	// if the cluster is bootstrapping from recovery, it may do so from
 	//  1 - a backup object, which may be done with volume snapshots or object storage
 	//  2 - volume snapshots
 	// We need to check that whichever alternative is used, the backup/snapshot is completed.
 	// If not completed, we requeue.
-	// If completed, we are sure that either backup or recoverySnapshot (perhaps both) are non-nil
+	// If completed, we know that either backup or recoverySnapshot (perhaps both) are non-nil
 	if cluster.Spec.Bootstrap != nil &&
 		cluster.Spec.Bootstrap.Recovery != nil {
 		var err error

--- a/controllers/cluster_create_test.go
+++ b/controllers/cluster_create_test.go
@@ -44,8 +44,7 @@ import (
 )
 
 var _ = Describe("cluster_create unit tests", func() {
-	It("should make sure that reconcilePostgresSecrets works correctly", func() {
-		ctx := context.Background()
+	It("should make sure that reconcilePostgresSecrets works correctly", func(ctx SpecContext) {
 		namespace := newFakeNamespace()
 		cluster := newFakeCNPGCluster(namespace)
 		pooler := newFakePooler(cluster)
@@ -100,8 +99,7 @@ var _ = Describe("cluster_create unit tests", func() {
 		})
 	})
 
-	It("should make sure that superUser secret is created if EnableSuperuserAccess is enabled", func() {
-		ctx := context.Background()
+	It("should make sure that superUser secret is created if EnableSuperuserAccess is enabled", func(ctx SpecContext) {
 		namespace := newFakeNamespace()
 		cluster := newFakeCNPGCluster(namespace)
 		cluster.Spec.EnableSuperuserAccess = ptr.To(true)
@@ -125,8 +123,7 @@ var _ = Describe("cluster_create unit tests", func() {
 		})
 	})
 
-	It("should make sure that reconcilePostgresServices works correctly", func() {
-		ctx := context.Background()
+	It("should make sure that reconcilePostgresServices works correctly", func(ctx SpecContext) {
 		namespace := newFakeNamespace()
 		cluster := newFakeCNPGCluster(namespace)
 
@@ -142,116 +139,115 @@ var _ = Describe("cluster_create unit tests", func() {
 		})
 	})
 
-	It("should make sure that reconcilePostgresServices works correctly if create any service is enabled", func() {
-		ctx := context.Background()
-		namespace := newFakeNamespace()
-		cluster := newFakeCNPGCluster(namespace)
-		configuration.Current.CreateAnyService = true
+	It("should make sure that reconcilePostgresServices works correctly if create any service is enabled",
+		func(ctx SpecContext) {
+			namespace := newFakeNamespace()
+			cluster := newFakeCNPGCluster(namespace)
+			configuration.Current.CreateAnyService = true
 
-		By("executing reconcilePostgresServices", func() {
-			err := clusterReconciler.reconcilePostgresServices(ctx, cluster)
-			Expect(err).ToNot(HaveOccurred())
+			By("executing reconcilePostgresServices", func() {
+				err := clusterReconciler.reconcilePostgresServices(ctx, cluster)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			By("making sure that the services have been created", func() {
+				expectResourceExistsWithDefaultClient(cluster.GetServiceAnyName(), namespace, &corev1.Service{})
+				expectResourceExistsWithDefaultClient(cluster.GetServiceReadOnlyName(), namespace, &corev1.Service{})
+				expectResourceExistsWithDefaultClient(cluster.GetServiceReadWriteName(), namespace, &corev1.Service{})
+				expectResourceExistsWithDefaultClient(cluster.GetServiceReadName(), namespace, &corev1.Service{})
+			})
 		})
 
-		By("making sure that the services have been created", func() {
-			expectResourceExistsWithDefaultClient(cluster.GetServiceAnyName(), namespace, &corev1.Service{})
-			expectResourceExistsWithDefaultClient(cluster.GetServiceReadOnlyName(), namespace, &corev1.Service{})
-			expectResourceExistsWithDefaultClient(cluster.GetServiceReadWriteName(), namespace, &corev1.Service{})
-			expectResourceExistsWithDefaultClient(cluster.GetServiceReadName(), namespace, &corev1.Service{})
-		})
-	})
+	It("should make sure that reconcilePostgresServices can update the selectors on existing services",
+		func(ctx SpecContext) {
+			namespace := newFakeNamespace()
+			cluster := newFakeCNPGCluster(namespace)
+			configuration.Current.CreateAnyService = true
 
-	It("should make sure that reconcilePostgresServices can update the selectors on existing services", func() {
-		ctx := context.Background()
-		namespace := newFakeNamespace()
-		cluster := newFakeCNPGCluster(namespace)
-		configuration.Current.CreateAnyService = true
-
-		createOutdatedService := func(svc *corev1.Service) {
-			cluster.SetInheritedDataAndOwnership(&svc.ObjectMeta)
-			svc.Spec.Selector = map[string]string{
-				"outdated": "selector",
+			createOutdatedService := func(svc *corev1.Service) {
+				cluster.SetInheritedDataAndOwnership(&svc.ObjectMeta)
+				svc.Spec.Selector = map[string]string{
+					"outdated": "selector",
+				}
+				err := clusterReconciler.Client.Create(ctx, svc)
+				Expect(err).ToNot(HaveOccurred())
 			}
-			err := clusterReconciler.Client.Create(ctx, svc)
-			Expect(err).ToNot(HaveOccurred())
-		}
 
-		checkService := func(before *corev1.Service, expectedLabels map[string]string) {
-			var afterChangesService corev1.Service
-			err := clusterReconciler.Client.Get(ctx, types.NamespacedName{
-				Name:      before.Name,
-				Namespace: before.Namespace,
-			}, &afterChangesService)
-			Expect(err).ToNot(HaveOccurred())
+			checkService := func(before *corev1.Service, expectedLabels map[string]string) {
+				var afterChangesService corev1.Service
+				err := clusterReconciler.Client.Get(ctx, types.NamespacedName{
+					Name:      before.Name,
+					Namespace: before.Namespace,
+				}, &afterChangesService)
+				Expect(err).ToNot(HaveOccurred())
 
-			Expect(afterChangesService.Spec.Selector).ToNot(Equal(before.Spec.Selector))
-			Expect(afterChangesService.Spec.Selector).To(Equal(expectedLabels))
-			Expect(afterChangesService.Labels).To(Equal(before.Labels))
-			Expect(afterChangesService.Annotations).To(Equal(before.Annotations))
-		}
+				Expect(afterChangesService.Spec.Selector).ToNot(Equal(before.Spec.Selector))
+				Expect(afterChangesService.Spec.Selector).To(Equal(expectedLabels))
+				Expect(afterChangesService.Labels).To(Equal(before.Labels))
+				Expect(afterChangesService.Annotations).To(Equal(before.Annotations))
+			}
 
-		var readOnlyService, readWriteService, readService, anyService *corev1.Service
-		By("creating the resources with outdated selectors", func() {
-			By("creating any service", func() {
-				svc := specs.CreateClusterAnyService(*cluster)
-				createOutdatedService(svc)
-				anyService = svc.DeepCopy()
+			var readOnlyService, readWriteService, readService, anyService *corev1.Service
+			By("creating the resources with outdated selectors", func() {
+				By("creating any service", func() {
+					svc := specs.CreateClusterAnyService(*cluster)
+					createOutdatedService(svc)
+					anyService = svc.DeepCopy()
+				})
+
+				By("creating read service", func() {
+					svc := specs.CreateClusterReadService(*cluster)
+					createOutdatedService(svc)
+					readService = svc.DeepCopy()
+				})
+
+				By("creating read-write service", func() {
+					svc := specs.CreateClusterReadWriteService(*cluster)
+					createOutdatedService(svc)
+					readWriteService = svc.DeepCopy()
+				})
+				By("creating read only service", func() {
+					svc := specs.CreateClusterReadOnlyService(*cluster)
+					createOutdatedService(svc)
+					readOnlyService = svc.DeepCopy()
+				})
 			})
 
-			By("creating read service", func() {
-				svc := specs.CreateClusterReadService(*cluster)
-				createOutdatedService(svc)
-				readService = svc.DeepCopy()
+			By("executing reconcilePostgresServices", func() {
+				err := clusterReconciler.reconcilePostgresServices(ctx, cluster)
+				Expect(err).ToNot(HaveOccurred())
 			})
 
-			By("creating read-write service", func() {
-				svc := specs.CreateClusterReadWriteService(*cluster)
-				createOutdatedService(svc)
-				readWriteService = svc.DeepCopy()
+			By("checking any service", func() {
+				checkService(anyService, map[string]string{
+					"cnpg.io/podRole": "instance",
+					"cnpg.io/cluster": cluster.Name,
+				})
 			})
-			By("creating read only service", func() {
-				svc := specs.CreateClusterReadOnlyService(*cluster)
-				createOutdatedService(svc)
-				readOnlyService = svc.DeepCopy()
+
+			By("checking read-write service", func() {
+				checkService(readWriteService, map[string]string{
+					"cnpg.io/cluster": cluster.Name,
+					"role":            "primary",
+				})
 			})
-		})
 
-		By("executing reconcilePostgresServices", func() {
-			err := clusterReconciler.reconcilePostgresServices(ctx, cluster)
-			Expect(err).ToNot(HaveOccurred())
-		})
-
-		By("checking any service", func() {
-			checkService(anyService, map[string]string{
-				"cnpg.io/podRole": "instance",
-				"cnpg.io/cluster": cluster.Name,
+			By("checking read service", func() {
+				checkService(readService, map[string]string{
+					"cnpg.io/cluster": cluster.Name,
+					"cnpg.io/podRole": "instance",
+				})
 			})
-		})
 
-		By("checking read-write service", func() {
-			checkService(readWriteService, map[string]string{
-				"cnpg.io/cluster": cluster.Name,
-				"role":            "primary",
-			})
-		})
-
-		By("checking read service", func() {
-			checkService(readService, map[string]string{
-				"cnpg.io/cluster": cluster.Name,
-				"cnpg.io/podRole": "instance",
-			})
-		})
-
-		By("checking read only service", func() {
-			checkService(readOnlyService, map[string]string{
-				"cnpg.io/cluster": cluster.Name,
-				"role":            "replica",
+			By("checking read only service", func() {
+				checkService(readOnlyService, map[string]string{
+					"cnpg.io/cluster": cluster.Name,
+					"role":            "replica",
+				})
 			})
 		})
-	})
 
-	It("should make sure that createOrPatchServiceAccount works correctly", func() {
-		ctx := context.Background()
+	It("should make sure that createOrPatchServiceAccount works correctly", func(ctx SpecContext) {
 		namespace := newFakeNamespace()
 		cluster := newFakeCNPGCluster(namespace)
 
@@ -323,8 +319,7 @@ var _ = Describe("cluster_create unit tests", func() {
 		})
 	})
 
-	It("should make sure that reconcilePodDisruptionBudget works correctly", func() {
-		ctx := context.Background()
+	It("should make sure that reconcilePodDisruptionBudget works correctly", func(ctx SpecContext) {
 		namespace := newFakeNamespace()
 		cluster := newFakeCNPGCluster(namespace)
 		pdbReplicaName := specs.BuildReplicasPodDisruptionBudget(cluster).Name

--- a/controllers/cluster_create_test.go
+++ b/controllers/cluster_create_test.go
@@ -19,7 +19,7 @@ package controllers
 import (
 	"context"
 
-	volumesnapshot "github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1"
+	volumesnapshot "github.com/kubernetes-csi/external-snapshotter/client/v7/apis/volumesnapshot/v1"
 	v1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"

--- a/controllers/cluster_create_test.go
+++ b/controllers/cluster_create_test.go
@@ -400,7 +400,6 @@ var _ = Describe("check if bootstrap recovery can proceed", func() {
 		namespace = newFakeNamespace()
 		clusterName = "awesomeCluster"
 		name = "foo"
-
 	})
 
 	_ = DescribeTable("from backup",
@@ -456,6 +455,7 @@ var _ = Describe("check if bootstrap recovery can proceed", func() {
 			nil, true),
 	)
 })
+
 var _ = Describe("check if bootstrap recovery can proceed from volume snapshot", func() {
 	var namespace, clusterName string
 	var cluster *apiv1.Cluster

--- a/pkg/reconciler/persistentvolumeclaim/instance.go
+++ b/pkg/reconciler/persistentvolumeclaim/instance.go
@@ -81,6 +81,7 @@ func reconcileSingleInstanceMissingPVCs(
 	var shouldReconcile bool
 	instanceName := specs.GetInstanceName(cluster.Name, serial)
 	for _, expectedPVC := range getExpectedPVCsFromCluster(cluster, instanceName) {
+		// if the pvcs arg contains the expectedPVC, done for this iteration
 		if slices.ContainsFunc(pvcs, func(pvc corev1.PersistentVolumeClaim) bool { return expectedPVC.name == pvc.Name }) {
 			continue
 		}

--- a/pkg/reconciler/persistentvolumeclaim/instance.go
+++ b/pkg/reconciler/persistentvolumeclaim/instance.go
@@ -81,7 +81,7 @@ func reconcileSingleInstanceMissingPVCs(
 	var shouldReconcile bool
 	instanceName := specs.GetInstanceName(cluster.Name, serial)
 	for _, expectedPVC := range getExpectedPVCsFromCluster(cluster, instanceName) {
-		// if the pvcs arg contains the expectedPVC, done for this iteration
+		// Continue if the expectedPVC is in present in the current PVC list
 		if slices.ContainsFunc(pvcs, func(pvc corev1.PersistentVolumeClaim) bool { return expectedPVC.name == pvc.Name }) {
 			continue
 		}

--- a/pkg/reconciler/persistentvolumeclaim/storagesource.go
+++ b/pkg/reconciler/persistentvolumeclaim/storagesource.go
@@ -169,15 +169,9 @@ func getCandidateSourceFromBackup(backup *apiv1.Backup) *StorageSource {
 // from a Cluster definition, taking into consideration the backup that the
 // cluster has been bootstrapped from
 func getCandidateSourceFromClusterDefinition(cluster *apiv1.Cluster) *StorageSource {
-	if cluster.Spec.Bootstrap == nil {
-		return nil
-	}
-
-	if cluster.Spec.Bootstrap.Recovery == nil {
-		return nil
-	}
-
-	if cluster.Spec.Bootstrap.Recovery.VolumeSnapshots == nil {
+	if cluster.Spec.Bootstrap == nil ||
+		cluster.Spec.Bootstrap.Recovery == nil ||
+		cluster.Spec.Bootstrap.Recovery.VolumeSnapshots == nil {
 		return nil
 	}
 


### PR DESCRIPTION
Fix bootstrapping error loop by ensuring recovery backups/snapshots
readiness before Cluster construction starts.

This patch addresses an issue where Clusters bootstrapping from
recovery could enter an error loop if the backups or snapshots were
not prepared at the time of cluster creation. It modifies the
bootstrapping process to delay the construction of the first instance
until the necessary recovery backups or snapshots are fully ready,
thus preventing the error loop.

Closes #3654
