### PR TITLE
feat: add ephemeralVolumeSource option to cluster spec.

### DIFF
--- a/.wordlist-en-custom.txt
+++ b/.wordlist-en-custom.txt
@@ -126,6 +126,7 @@ EnterpriseDB's
 EnvFrom
 EnvFromSource
 EnvVar
+EphemeralVolumeSource
 EphemeralVolumesSizeLimit
 EphemeralVolumesSizeLimitConfiguration
 ExternalCluster
@@ -649,6 +650,7 @@ endpointURL
 enterprisedb
 env
 envFrom
+ephemeralVolumeSource
 ephemeralVolumesSizeLimit
 executables
 expirations

--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -338,6 +338,10 @@ type ClusterSpec struct {
 	// +optional
 	WalStorage *StorageConfiguration `json:"walStorage,omitempty"`
 
+	// EphemeralVolumeSource allows the user to configure the source of ephemeral volumes.
+	// +optional
+	EphemeralVolumeSource *corev1.EphemeralVolumeSource `json:"ephemeralVolumeSource,omitempty"`
+
 	// The time in seconds that is allowed for a PostgreSQL instance to
 	// successfully start up (default 3600).
 	// The startup probe failure threshold is derived from this value using the formula:

--- a/api/v1/cluster_webhook.go
+++ b/api/v1/cluster_webhook.go
@@ -309,6 +309,7 @@ func (r *Cluster) Validate() (allErrs field.ErrorList) {
 		r.validateMaxSyncReplicas,
 		r.validateStorageSize,
 		r.validateWalStorageSize,
+		r.validateEphemeralVolumeSource,
 		r.validateTablespaceStorageSize,
 		r.validateName,
 		r.validateTablespaceNames,
@@ -1470,6 +1471,19 @@ func (r *Cluster) validateWalStorageSize() field.ErrorList {
 	if r.ShouldCreateWalArchiveVolume() {
 		result = append(result,
 			validateStorageConfigurationSize(*field.NewPath("spec", "walStorage"), *r.Spec.WalStorage)...)
+	}
+
+	return result
+}
+
+func (r *Cluster) validateEphemeralVolumeSource() field.ErrorList {
+	var result field.ErrorList
+
+	if r.Spec.EphemeralVolumeSource != nil && (r.Spec.EphemeralVolumesSizeLimit != nil && r.Spec.EphemeralVolumesSizeLimit.TemporaryData != nil) {
+		result = append(result, field.Duplicate(
+			field.NewPath("spec", "ephemeralVolumeSource"),
+			"ephemeralVolumeSource and ephemeralVolumesSizeLimit.temporaryData are in conflict, set one only",
+		))
 	}
 
 	return result

--- a/api/v1/cluster_webhook.go
+++ b/api/v1/cluster_webhook.go
@@ -1479,10 +1479,10 @@ func (r *Cluster) validateWalStorageSize() field.ErrorList {
 func (r *Cluster) validateEphemeralVolumeSource() field.ErrorList {
 	var result field.ErrorList
 
-	if r.Spec.EphemeralVolumeSource != nil && (r.Spec.EphemeralVolumesSizeLimit != nil && r.Spec.EphemeralVolumesSizeLimit.TemporaryData != nil) {
+	if r.Spec.EphemeralVolumeSource != nil && r.Spec.EphemeralVolumesSizeLimit != nil {
 		result = append(result, field.Duplicate(
 			field.NewPath("spec", "ephemeralVolumeSource"),
-			"ephemeralVolumeSource and ephemeralVolumesSizeLimit.temporaryData are in conflict, set one only",
+			"Conflicting settings: provide either ephemeralVolumeSource or ephemeralVolumesSizeLimit, not both.",
 		))
 	}
 

--- a/api/v1/cluster_webhook.go
+++ b/api/v1/cluster_webhook.go
@@ -1483,7 +1483,8 @@ func (r *Cluster) validateEphemeralVolumeSource() field.ErrorList {
 		r.Spec.EphemeralVolumesSizeLimit.TemporaryData != nil) {
 		result = append(result, field.Duplicate(
 			field.NewPath("spec", "ephemeralVolumeSource"),
-			"Conflicting settings: provide either ephemeralVolumeSource or ephemeralVolumesSizeLimit, not both.",
+			"Conflicting settings: provide either ephemeralVolumeSource "+
+				"or ephemeralVolumesSizeLimit.TemporaryData, not both.",
 		))
 	}
 

--- a/api/v1/cluster_webhook.go
+++ b/api/v1/cluster_webhook.go
@@ -1479,7 +1479,8 @@ func (r *Cluster) validateWalStorageSize() field.ErrorList {
 func (r *Cluster) validateEphemeralVolumeSource() field.ErrorList {
 	var result field.ErrorList
 
-	if r.Spec.EphemeralVolumeSource != nil && r.Spec.EphemeralVolumesSizeLimit != nil {
+	if r.Spec.EphemeralVolumeSource != nil && (r.Spec.EphemeralVolumesSizeLimit != nil &&
+		r.Spec.EphemeralVolumesSizeLimit.TemporaryData != nil) {
 		result = append(result, field.Duplicate(
 			field.NewPath("spec", "ephemeralVolumeSource"),
 			"Conflicting settings: provide either ephemeralVolumeSource or ephemeralVolumesSizeLimit, not both.",

--- a/api/v1/cluster_webhook_test.go
+++ b/api/v1/cluster_webhook_test.go
@@ -2842,6 +2842,62 @@ var _ = Describe("Storage configuration validation", func() {
 	})
 })
 
+var _ = Describe("Ephemeral volume configuration validation", func() {
+	It("succeeds if no ephemeral configuration is present", func() {
+		cluster := Cluster{
+			Spec: ClusterSpec{},
+		}
+		Expect(cluster.validateEphemeralVolumeSource()).To(BeEmpty())
+	})
+
+	It("succeeds if ephemeralVolumeSource is set", func() {
+		cluster := Cluster{
+			Spec: ClusterSpec{
+				EphemeralVolumeSource: &corev1.EphemeralVolumeSource{},
+			},
+		}
+		Expect(cluster.validateEphemeralVolumeSource()).To(BeEmpty())
+	})
+
+	It("succeeds if ephemeralVolumesSizeLimit.temporaryData is set", func() {
+		onegi := resource.MustParse("1Gi")
+		cluster := Cluster{
+			Spec: ClusterSpec{
+				EphemeralVolumesSizeLimit: &EphemeralVolumesSizeLimitConfiguration{
+					TemporaryData: &onegi,
+				},
+			},
+		}
+		Expect(cluster.validateEphemeralVolumeSource()).To(BeEmpty())
+	})
+
+	It("succeeds if ephemeralVolumeSource and ephemeralVolumesSizeLimit.shm are set", func() {
+		onegi := resource.MustParse("1Gi")
+		cluster := Cluster{
+			Spec: ClusterSpec{
+				EphemeralVolumeSource: &corev1.EphemeralVolumeSource{},
+				EphemeralVolumesSizeLimit: &EphemeralVolumesSizeLimitConfiguration{
+					Shm: &onegi,
+				},
+			},
+		}
+		Expect(cluster.validateEphemeralVolumeSource()).To(BeEmpty())
+	})
+
+	It("produces one error if conflicting ephemeral storage options are set", func() {
+		onegi := resource.MustParse("1Gi")
+		cluster := Cluster{
+			Spec: ClusterSpec{
+				EphemeralVolumeSource: &corev1.EphemeralVolumeSource{},
+				EphemeralVolumesSizeLimit: &EphemeralVolumesSizeLimitConfiguration{
+					TemporaryData: &onegi,
+				},
+			},
+		}
+		Expect(cluster.validateEphemeralVolumeSource()).To(HaveLen(1))
+	})
+})
+
 var _ = Describe("Role management validation", func() {
 	It("should succeed if there is no management stanza", func() {
 		cluster := Cluster{

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -701,6 +701,11 @@ func (in *ClusterSpec) DeepCopyInto(out *ClusterSpec) {
 		*out = new(StorageConfiguration)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.EphemeralVolumeSource != nil {
+		in, out := &in.EphemeralVolumeSource, &out.EphemeralVolumeSource
+		*out = new(corev1.EphemeralVolumeSource)
+		(*in).DeepCopyInto(*out)
+	}
 	in.Affinity.DeepCopyInto(&out.Affinity)
 	if in.TopologySpreadConstraints != nil {
 		in, out := &in.TopologySpreadConstraints, &out.TopologySpreadConstraints

--- a/config/crd/bases/postgresql.cnpg.io_clusters.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_clusters.yaml
@@ -1913,6 +1913,254 @@ spec:
                       x-kubernetes-map-type: atomic
                   type: object
                 type: array
+              ephemeralVolumeSource:
+                description: EphemeralVolumeSource allows the user to configure the
+                  source of ephemeral volumes.
+                properties:
+                  volumeClaimTemplate:
+                    description: "Will be used to create a stand-alone PVC to provision
+                      the volume. The pod in which this EphemeralVolumeSource is embedded
+                      will be the owner of the PVC, i.e. the PVC will be deleted together
+                      with the pod.  The name of the PVC will be `<pod name>-<volume
+                      name>` where `<volume name>` is the name from the `PodSpec.Volumes`
+                      array entry. Pod validation will reject the pod if the concatenated
+                      name is not valid for a PVC (for example, too long). \n An existing
+                      PVC with that name that is not owned by the pod will *not* be
+                      used for the pod to avoid using an unrelated volume by mistake.
+                      Starting the pod is then blocked until the unrelated PVC is
+                      removed. If such a pre-created PVC is meant to be used by the
+                      pod, the PVC has to updated with an owner reference to the pod
+                      once the pod exists. Normally this should not be necessary,
+                      but it may be useful when manually reconstructing a broken cluster.
+                      \n This field is read-only and no changes will be made by Kubernetes
+                      to the PVC after it has been created. \n Required, must not
+                      be nil."
+                    properties:
+                      metadata:
+                        description: May contain labels and annotations that will
+                          be copied into the PVC when creating it. No other fields
+                          are allowed and will be rejected during validation.
+                        type: object
+                      spec:
+                        description: The specification for the PersistentVolumeClaim.
+                          The entire content is copied unchanged into the PVC that
+                          gets created from this template. The same fields as in a
+                          PersistentVolumeClaim are also valid here.
+                        properties:
+                          accessModes:
+                            description: 'accessModes contains the desired access
+                              modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                            items:
+                              type: string
+                            type: array
+                          dataSource:
+                            description: 'dataSource field can be used to specify
+                              either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                              * An existing PVC (PersistentVolumeClaim) If the provisioner
+                              or an external controller can support the specified
+                              data source, it will create a new volume based on the
+                              contents of the specified data source. When the AnyVolumeDataSource
+                              feature gate is enabled, dataSource contents will be
+                              copied to dataSourceRef, and dataSourceRef contents
+                              will be copied to dataSource when dataSourceRef.namespace
+                              is not specified. If the namespace is specified, then
+                              dataSourceRef will not be copied to dataSource.'
+                            properties:
+                              apiGroup:
+                                description: APIGroup is the group for the resource
+                                  being referenced. If APIGroup is not specified,
+                                  the specified Kind must be in the core API group.
+                                  For any other third-party types, APIGroup is required.
+                                type: string
+                              kind:
+                                description: Kind is the type of resource being referenced
+                                type: string
+                              name:
+                                description: Name is the name of resource being referenced
+                                type: string
+                            required:
+                            - kind
+                            - name
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          dataSourceRef:
+                            description: 'dataSourceRef specifies the object from
+                              which to populate the volume with data, if a non-empty
+                              volume is desired. This may be any object from a non-empty
+                              API group (non core object) or a PersistentVolumeClaim
+                              object. When this field is specified, volume binding
+                              will only succeed if the type of the specified object
+                              matches some installed volume populator or dynamic provisioner.
+                              This field will replace the functionality of the dataSource
+                              field and as such if both fields are non-empty, they
+                              must have the same value. For backwards compatibility,
+                              when namespace isn''t specified in dataSourceRef, both
+                              fields (dataSource and dataSourceRef) will be set to
+                              the same value automatically if one of them is empty
+                              and the other is non-empty. When namespace is specified
+                              in dataSourceRef, dataSource isn''t set to the same
+                              value and must be empty. There are three important differences
+                              between dataSource and dataSourceRef: * While dataSource
+                              only allows two specific types of objects, dataSourceRef
+                              allows any non-core object, as well as PersistentVolumeClaim
+                              objects. * While dataSource ignores disallowed values
+                              (dropping them), dataSourceRef preserves all values,
+                              and generates an error if a disallowed value is specified.
+                              * While dataSource only allows local objects, dataSourceRef
+                              allows objects in any namespaces. (Beta) Using this
+                              field requires the AnyVolumeDataSource feature gate
+                              to be enabled. (Alpha) Using the namespace field of
+                              dataSourceRef requires the CrossNamespaceVolumeDataSource
+                              feature gate to be enabled.'
+                            properties:
+                              apiGroup:
+                                description: APIGroup is the group for the resource
+                                  being referenced. If APIGroup is not specified,
+                                  the specified Kind must be in the core API group.
+                                  For any other third-party types, APIGroup is required.
+                                type: string
+                              kind:
+                                description: Kind is the type of resource being referenced
+                                type: string
+                              name:
+                                description: Name is the name of resource being referenced
+                                type: string
+                              namespace:
+                                description: Namespace is the namespace of resource
+                                  being referenced Note that when a namespace is specified,
+                                  a gateway.networking.k8s.io/ReferenceGrant object
+                                  is required in the referent namespace to allow that
+                                  namespace's owner to accept the reference. See the
+                                  ReferenceGrant documentation for details. (Alpha)
+                                  This field requires the CrossNamespaceVolumeDataSource
+                                  feature gate to be enabled.
+                                type: string
+                            required:
+                            - kind
+                            - name
+                            type: object
+                          resources:
+                            description: 'resources represents the minimum resources
+                              the volume should have. If RecoverVolumeExpansionFailure
+                              feature is enabled users are allowed to specify resource
+                              requirements that are lower than previous value but
+                              must still be higher than capacity recorded in the status
+                              field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                            properties:
+                              claims:
+                                description: "Claims lists the names of resources,
+                                  defined in spec.resourceClaims, that are used by
+                                  this container. \n This is an alpha field and requires
+                                  enabling the DynamicResourceAllocation feature gate.
+                                  \n This field is immutable. It can only be set for
+                                  containers."
+                                items:
+                                  description: ResourceClaim references one entry
+                                    in PodSpec.ResourceClaims.
+                                  properties:
+                                    name:
+                                      description: Name must match the name of one
+                                        entry in pod.spec.resourceClaims of the Pod
+                                        where this field is used. It makes that resource
+                                        available inside a container.
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Limits describes the maximum amount
+                                  of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Requests describes the minimum amount
+                                  of compute resources required. If Requests is omitted
+                                  for a container, it defaults to Limits if that is
+                                  explicitly specified, otherwise to an implementation-defined
+                                  value. Requests cannot exceed Limits. More info:
+                                  https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                type: object
+                            type: object
+                          selector:
+                            description: selector is a label query over volumes to
+                              consider for binding.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: A label selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values.
+                                        If the operator is In or NotIn, the values
+                                        array must be non-empty. If the operator is
+                                        Exists or DoesNotExist, the values array must
+                                        be empty. This array is replaced during a
+                                        strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: matchLabels is a map of {key,value} pairs.
+                                  A single {key,value} in the matchLabels map is equivalent
+                                  to an element of matchExpressions, whose key field
+                                  is "key", the operator is "In", and the values array
+                                  contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          storageClassName:
+                            description: 'storageClassName is the name of the StorageClass
+                              required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                            type: string
+                          volumeMode:
+                            description: volumeMode defines what type of volume is
+                              required by the claim. Value of Filesystem is implied
+                              when not included in claim spec.
+                            type: string
+                          volumeName:
+                            description: volumeName is the binding reference to the
+                              PersistentVolume backing this claim.
+                            type: string
+                        type: object
+                    required:
+                    - spec
+                    type: object
+                type: object
               ephemeralVolumesSizeLimit:
                 description: EphemeralVolumesSizeLimit allows the user to set the
                   limits for the ephemeral volumes

--- a/docs/src/cloudnative-pg.v1.md
+++ b/docs/src/cloudnative-pg.v1.md
@@ -1523,6 +1523,13 @@ user by setting it to <code>NULL</code>. Disabled by default.</p>
    <p>Configuration of the storage for PostgreSQL WAL (Write-Ahead Log)</p>
 </td>
 </tr>
+<tr><td><code>ephemeralVolumeSource</code><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#ephemeralvolumesource-v1-core"><i>core/v1.EphemeralVolumeSource</i></a>
+</td>
+<td>
+   <p>EphemeralVolumeSource allows the user to configure the source of ephemeral volumes.</p>
+</td>
+</tr>
 <tr><td><code>startDelay</code><br/>
 <i>int32</i>
 </td>

--- a/docs/src/cluster_conf.md
+++ b/docs/src/cluster_conf.md
@@ -47,13 +47,12 @@ CloudNativePG relies on [ephemeral volumes](https://kubernetes.io/docs/concepts/
 for part of the internal activities. Ephemeral volumes exist for the sole
 duration of a pod's life, without persisting across pod restarts.
 
-### Volume for temporary storage
+# Volume Claim Template for Temporary Storage
 
-An ephemeral volume used for temporary storage. By default an `emptyDir` volume is used. To configure
-the volume use the `.spec.ephemeralVolumeSource` field in the cluster spec.
+The operator uses  by default an `emptyDir` volume, which can be customized by using the `.spec.ephemeralVolumesSizeLimit field`.
+This can be overridden by specifying a volume claim template in the `.spec.ephemeralVolumeSource` field.
 
-This simple example shows how to set a `1Gi` ephemeral volume. Set the `storageClassName` to something
-available on your Kubernetes cluster.
+In the following example, a `1Gi` ephemeral volume is set.
 
 ```yaml
 apiVersion: postgresql.cnpg.io/v1
@@ -66,16 +65,14 @@ spec:
     volumeClaimTemplate:
       spec:
         accessModes: ["ReadWriteOnce"]
+        # example storageClassName, replace with one existing in your Kubernetes cluster
         storageClassName: "scratch-storage-class"
         resources:
           requests:
             storage: 1Gi
 ```
 
-Alternatively you can configure an upper bound on the default volume size using the `.spec.ephemeralVolumesSizeLimit.temporaryData`
-field in the cluster spec.
-
-Both `.spec.emphemeralVolumeSource` and `.spec.ephemeralVolumesSizeLimit.temporaryData` cannot be set.
+Both `.spec.emphemeralVolumeSource` and `.spec.ephemeralVolumesSizeLimit.temporaryData` cannot be specified simultaneously.
 
 ### Volume for shared memory
 

--- a/docs/src/cluster_conf.md
+++ b/docs/src/cluster_conf.md
@@ -49,9 +49,33 @@ duration of a pod's life, without persisting across pod restarts.
 
 ### Volume for temporary storage
 
-An ephemeral volume used for temporary storage. You can configure an upper
-bound on the size using the `.spec.ephemeralVolumesSizeLimit.temporaryData`
+An ephemeral volume used for temporary storage. By default an `emptyDir` volume is used. To configure
+the volume use the `.spec.ephemeralVolumeSource` field in the cluster spec.
+
+This simple example shows how to set a `1Gi` ephemeral volume. Set the `storageClassName` to something
+available on your Kubernetes cluster.
+
+```yaml
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: cluster-example-ephemeral-volume-source
+spec:
+  instances: 3
+  ephemeralVolumeSource:
+    volumeClaimTemplate:
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        storageClassName: "scratch-storage-class"
+        resources:
+          requests:
+            storage: 1Gi
+```
+
+Alternatively you can configure an upper bound on the default volume size using the `.spec.ephemeralVolumesSizeLimit.temporaryData`
 field in the cluster spec.
+
+Both `.spec.emphemeralVolumeSource` and `.spec.ephemeralVolumesSizeLimit.temporaryData` cannot be set.
 
 ### Volume for shared memory
 

--- a/pkg/specs/volumes.go
+++ b/pkg/specs/volumes.go
@@ -98,14 +98,7 @@ func createPostgresVolumes(cluster apiv1.Cluster, podName string) []corev1.Volum
 				},
 			},
 		},
-		{
-			Name: "scratch-data",
-			VolumeSource: corev1.VolumeSource{
-				EmptyDir: &corev1.EmptyDirVolumeSource{
-					SizeLimit: cluster.Spec.EphemeralVolumesSizeLimit.GetTemporaryDataLimit(),
-				},
-			},
-		},
+		createEphemeralVolume(cluster),
 		{
 			Name: "shm",
 			VolumeSource: corev1.VolumeSource{
@@ -323,6 +316,21 @@ func getSortedTablespaceList(cluster apiv1.Cluster) []string {
 	}
 	sort.Strings(tbsNames)
 	return tbsNames
+}
+
+func createEphemeralVolume(cluster apiv1.Cluster) corev1.Volume {
+	scratchVolumeSource := corev1.VolumeSource{}
+	if cluster.Spec.EphemeralVolumeSource != nil {
+		scratchVolumeSource.Ephemeral = cluster.Spec.EphemeralVolumeSource
+	} else {
+		scratchVolumeSource.EmptyDir = &corev1.EmptyDirVolumeSource{
+			SizeLimit: cluster.Spec.EphemeralVolumesSizeLimit.GetTemporaryDataLimit(),
+		}
+	}
+	return corev1.Volume{
+		Name:         "scratch-data",
+		VolumeSource: scratchVolumeSource,
+	}
 }
 
 func createProjectedVolume(cluster apiv1.Cluster) corev1.Volume {


### PR DESCRIPTION
Allow the user to optionally set the ephemeralStorage option in the cluster spec.

Closes #3677

Refs:
 - https://github.com/cloudnative-pg/cloudnative-pg/issues/3677
 - https://github.com/cloudnative-pg/cloudnative-pg/issues/317