### PR TITLE
fix: properly quote comment lines

### DIFF
--- a/pkg/postgres/configuration.go
+++ b/pkg/postgres/configuration.go
@@ -33,7 +33,7 @@ const (
 # FIXED RULES
 #
 
-# Grant local access (`local` user map)
+# Grant local access ('local' user map)
 local all all peer map=local
 
 # Require client certificate authentication for the streaming_replica user
@@ -69,7 +69,7 @@ host all all all {{.DefaultAuthenticationMethod}}
 # FIXED RULES
 #
 
-# Grant local access (`local` user map)
+# Grant local access ('local' user map)
 local {{.Username}} postgres
 
 #


### PR DESCRIPTION
This patch resolves a bug in the code execution caused by incorrect quoting introduced with PR #3534.
