### PR TITLE
[docs] fix azure connection string

### DIFF
--- a/docs/src/appendixes/object_stores.md
+++ b/docs/src/appendixes/object_stores.md
@@ -191,7 +191,7 @@ kubectl create secret generic azure-creds \
   --from-literal=AZURE_STORAGE_ACCOUNT=<storage account name> \
   --from-literal=AZURE_STORAGE_KEY=<storage account key> \
   --from-literal=AZURE_STORAGE_SAS_TOKEN=<SAS token> \
-  --from-literal=AZURE_STORAGE_CONNECTION_STRING=<connection string>
+  --from-literal=AZURE_CONNECTION_STRING=<connection string>
 ```
 
 The credentials will be encrypted at rest, if this feature is enabled in the used


### PR DESCRIPTION
Minor doc issue when creating a secret. The secret key should be `AZURE_CONNECTION_STRING` instead of `AZURE_STORAGE_CONNECTION_STRING`