### PR TITLE
ci: re-establish cloud providers on scheduled E2Es

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -182,7 +182,7 @@ jobs:
           # Set the defaults for schedule dispatch
           if [[ ${{ github.event_name }} == 'schedule' ]]; then
             DEPTH="schedule"
-            LIMIT="local"
+            LIMIT=""
             TEST_LEVEL="4"
             FEATURE_TYPE=""
             LOG_LEVEL="debug"


### PR DESCRIPTION
We are limiting to local executors when running Scheduled E2Es, while instead we should be running the tests also on each supported cloud provider.