### PR TITLE
fix: reload certificates on configuration update

### DIFF
--- a/pkg/management/postgres/instance.go
+++ b/pkg/management/postgres/instance.go
@@ -559,6 +559,11 @@ func (instance *Instance) Reload(ctx context.Context) error {
 	contextLogger.Info("Requesting configuration reload",
 		"pgdata", instance.PgData)
 
+	// Need to reload certificates if they changed
+	if instance.primaryPool != nil {
+		instance.primaryPool.ShutdownConnections()
+	}
+
 	pgCtlCmd := exec.Command(pgCtlName, options...) // #nosec
 	err := execlog.RunStreaming(pgCtlCmd, pgCtlName)
 	if err != nil {


### PR DESCRIPTION
After a certificate expires the replicator will start printing error-logs:

```json
{
  "level": "info",
  "ts": "2024-01-16T11:30:58Z",
  "logger": "Replicator",
  "msg": "synchronizing replication slots",
  "logging_pod": "edge-ha-db-cnpg-3",
  "err": "getting replication slot status from primary: failed to connect to `host=edge-ha-db-cnpg-rw user=streaming_replica database=postgres`: failed to write startup message (write failed: x509: certificate has expired or is not yet valid: current time 2024-01-16T11:30:58Z is after 2024-01-16T11:30:45Z)"
}
```

This happens because certificates were read from disk the first time the connection was used and subsequently cached in the pool.

The errors are accompanied by the following error from the leader:

```json
{
  "level": "info",
  "ts": "2024-01-16T13:22:28Z",
  "logger": "postgres",
  "msg": "record",
  "logging_pod": "edge-ha-db-cnpg-1",
  "record": {
    "log_time": "2024-01-16 13:22:28.263 UTC",
    "process_id": "12756",
    "connection_from": "10.244.0.97:60832",
    "session_id": "65a68314.31d4",
    "session_line_num": "1",
    "session_start_time": "2024-01-16 13:22:28 UTC",
    "transaction_id": "0",
    "error_severity": "LOG",
    "sql_state_code": "08P01",
    "message": "could not accept SSL connection: sslv3 alert bad certificate"
  }
}
```

If in this scenario another primary is promoted the replica will print the following error:

```json
{
  "level": "info",
  "ts": "2024-01-16T13:32:59Z",
  "logger": "Replicator",
  "msg": "synchronizing replication slots",
  "logging_pod": "edge-ha-db-cnpg-2",
  "err": "getting replication slot status from primary: failed to connect to `host=edge-ha-db-cnpg-rw user=streaming_replica database=postgres`: failed to write startup message (write failed: x509: certificate signed by unknown authority)"
}
```

By stopping all connections on a configuration change the certificates will be read from disk again the next time a connection is needed.

# meta

- I'm not sure how to add a test-case for this and would love some directions

Closes #2276 