### PR TITLE
fix: escape reserved characters in pgpass fields (resolves #3712)

### DIFF
--- a/pkg/management/external/internal/pgpass/conninfo.go
+++ b/pkg/management/external/internal/pgpass/conninfo.go
@@ -16,8 +16,10 @@ limitations under the License.
 
 package pgpass
 
-import "fmt"
-import "strings"
+import (
+	"fmt"
+	"strings"
+)
 
 // ConnectionInfo contains the information identifying
 // a PostgreSQL server whom credentials need to be included

--- a/pkg/management/external/internal/pgpass/conninfo.go
+++ b/pkg/management/external/internal/pgpass/conninfo.go
@@ -56,16 +56,17 @@ func NewConnectionInfo(
 	return result
 }
 
-var fieldEscaper = strings.NewReplacer("\\", "\\\\", ":", "\\:")
+// Ref: https://www.postgresql.org/docs/current/libpq-pgpass.html
+var pgPassFieldEscaper = strings.NewReplacer("\\", "\\\\", ":", "\\:")
 
 // BuildLine builds a pgPass configuration file line
 func (info ConnectionInfo) BuildLine() string {
 	return fmt.Sprintf(
 		"%v:%v:%v:%v:%v",
-		fieldEscaper.Replace(info.host),
-		fieldEscaper.Replace(info.port),
-		fieldEscaper.Replace(info.dbname),
-		fieldEscaper.Replace(info.user),
-		fieldEscaper.Replace(info.password),
+		pgPassFieldEscaper.Replace(info.host),
+		pgPassFieldEscaper.Replace(info.port),
+		pgPassFieldEscaper.Replace(info.dbname),
+		pgPassFieldEscaper.Replace(info.user),
+		pgPassFieldEscaper.Replace(info.password),
 	)
 }

--- a/pkg/management/external/internal/pgpass/conninfo.go
+++ b/pkg/management/external/internal/pgpass/conninfo.go
@@ -17,6 +17,7 @@ limitations under the License.
 package pgpass
 
 import "fmt"
+import "strings"
 
 // ConnectionInfo contains the information identifying
 // a PostgreSQL server whom credentials need to be included
@@ -55,14 +56,16 @@ func NewConnectionInfo(
 	return result
 }
 
+var fieldEscaper = strings.NewReplacer("\\", "\\\\", ":", "\\:")
+
 // BuildLine builds a pgPass configuration file line
 func (info ConnectionInfo) BuildLine() string {
 	return fmt.Sprintf(
 		"%v:%v:%v:%v:%v",
-		info.host,
-		info.port,
-		info.dbname,
-		info.user,
-		info.password,
+		fieldEscaper.Replace(info.host),
+		fieldEscaper.Replace(info.port),
+		fieldEscaper.Replace(info.dbname),
+		fieldEscaper.Replace(info.user),
+		fieldEscaper.Replace(info.password),
 	)
 }

--- a/pkg/management/external/internal/pgpass/conninfo_test.go
+++ b/pkg/management/external/internal/pgpass/conninfo_test.go
@@ -38,4 +38,15 @@ var _ = Describe("pgpass lines generation", func() {
 			}, "password").BuildLine()).To(Equal("pgtest.com:5432:*:postgres:password"))
 		})
 	})
+
+	When("the connection string contains chars that need escaping", func() {
+		It("correctly generates the content", func() {
+			Expect(NewConnectionInfo(map[string]string{
+				"host":   "pgtest.com:\\",
+				"port":   "5432:\\",
+				"dbname": "postgres",
+				"user":   "postgres:\\",
+			}, "pass:wo\\rd").BuildLine()).To(Equal("pgtest.com\\:\\\\:5432\\:\\\\:*:postgres\\:\\\\:pass\\:wo\\\\rd"))
+		})
+	})
 })


### PR DESCRIPTION
Escape `:` and `\` characters according to pgpass file escaping rules.

Ref: https://www.postgresql.org/docs/current/libpq-pgpass.html

Fixes #3712 