### PR TITLE
fix: skip deleting ha replicationslot when it is active

### DIFF
--- a/internal/management/controller/slots/reconciler/replicationslot.go
+++ b/internal/management/controller/slots/reconciler/replicationslot.go
@@ -101,6 +101,7 @@ func reconcilePrimaryReplicationSlots(
 				contextLogger.Trace("Skipping deletion of replication slot because it is active",
 					"slot", slot)
 				needToReschedule = true
+				continue
 			}
 			contextLogger.Trace("Attempt to delete replication slot",
 				"slot", slot)

--- a/internal/management/controller/slots/reconciler/replicationslot_test.go
+++ b/internal/management/controller/slots/reconciler/replicationslot_test.go
@@ -52,7 +52,7 @@ func (fk fakeReplicationSlotManager) Delete(_ context.Context, slot infrastructu
 	if fk.triggerDeleteError {
 		return errors.New("triggered delete error")
 	}
-	delete(fk.replicationSlots, fakeSlot{name: slot.SlotName})
+	delete(fk.replicationSlots, fakeSlot{name: slot.SlotName, active: slot.Active})
 	return nil
 }
 


### PR DESCRIPTION
This patch enfore when a HA replication slot is not the expected one, cnpg delete the 
replicationslot only when it changes to inacive status. 

Closes: #3739 