### PR TITLE
fix: disable WAL archiving during import bootstrap

### DIFF
--- a/docs/src/database_import.md
+++ b/docs/src/database_import.md
@@ -240,3 +240,30 @@ There are a few things you need to be aware of when using the `monolith` type:
 - After the clone procedure is done, `ANALYZE VERBOSE` is executed for every
   database.
 - `postImportApplicationSQL` field is not supported
+
+## Import optimizations
+
+During the logical import of a database, CloudNativePG optimizes the
+configuration of PostgreSQL in order to prioritize speed versus data
+durability, by forcing:
+
+- `archive_mode` to `off`
+- `fsync` to `off`
+- `full_page_writes` to `off`
+- `wal_level` to `minimal`
+
+Before completing the import job, CloudNativePG restores the expected
+configuration, then runs `initdb --sync-only` to ensure that data is
+permanently written on disk.
+
+!!! Important
+    WAL archiving, if requested, and WAL level will be honored after the
+    database import process has completed. Similarly, replicas will be cloned
+    after the bootstrap phase, when the actual cluster resource starts.
+
+There are other optimizations you can do during the import phase. Although this
+topic is beyond the scope of CloudNativePG, we recommend that you reduce
+unnecessary writes in the checkpoint area by tuning Postgres GUCs like
+`shared_buffers`, `max_wal_size`, `checkpoint_timeout` directly in the
+`Cluster` configuration.
+

--- a/docs/src/database_import.md
+++ b/docs/src/database_import.md
@@ -267,4 +267,3 @@ topic is beyond the scope of CloudNativePG, we recommend that you reduce
 unnecessary writes in the checkpoint area by tuning Postgres GUCs like
 `shared_buffers`, `max_wal_size`, `checkpoint_timeout` directly in the
 `Cluster` configuration.
-

--- a/docs/src/database_import.md
+++ b/docs/src/database_import.md
@@ -250,6 +250,7 @@ durability, by forcing:
 - `archive_mode` to `off`
 - `fsync` to `off`
 - `full_page_writes` to `off`
+- `max_wal_senders` to `0`
 - `wal_level` to `minimal`
 
 Before completing the import job, CloudNativePG restores the expected

--- a/docs/src/samples/cluster-import-schema-only-basicauth.yaml
+++ b/docs/src/samples/cluster-import-schema-only-basicauth.yaml
@@ -20,8 +20,8 @@ spec:
     - name: cluster-example
       connectionParameters:
         host: cluster-example-rw.default.svc
-        user: postgres
-        dbname: postgres
+        user: app
+        dbname: app
       password:
-        name: cluster-example-superuser
+        name: cluster-example-app
         key: password

--- a/docs/src/samples/cluster-import-snapshot-basicauth.yaml
+++ b/docs/src/samples/cluster-import-snapshot-basicauth.yaml
@@ -19,8 +19,8 @@ spec:
     - name: cluster-example
       connectionParameters:
         host: cluster-example-rw.default.svc
-        user: postgres
-        dbname: postgres
+        user: app
+        dbname: app
       password:
-        name: cluster-example-superuser
+        name: cluster-example-app
         key: password

--- a/docs/src/samples/cluster-import-snapshot-tls.yaml
+++ b/docs/src/samples/cluster-import-snapshot-tls.yaml
@@ -1,15 +1,15 @@
 # IMPORTANT: this configuration requires an appropriate line
 # in the host-based access rules allowing replication connections
-# to the postgres user.
+# to the app user.
 #
 # The following line meet the requisites:
 #
 # pg_hba:
-#  - hostssl all postgres all cert
+#  - hostssl all app all cert
 
 # You can generate the required TLS certificate with
 #
-# ./bin/kubectl-cnp  certificate cluster-example-superuser-tls --cnp-cluster cluster-example --cnp-user postgres
+# ./bin/kubectl-cnpg  certificate cluster-example-app-tls --cnpg-cluster cluster-example --cnpg-user app
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
@@ -31,13 +31,13 @@ spec:
     - name: cluster-example
       connectionParameters:
         host: cluster-example-rw.default.svc
-        user: postgres
-        dbname: postgres
+        user: app
+        dbname: app
       sslKey:
-        name: cluster-example-superuser-tls
+        name: cluster-example-app-tls
         key: tls.key
       sslCert:
-        name: cluster-example-superuser-tls
+        name: cluster-example-app-tls
         key: tls.crt
       sslRootCert:
         name: cluster-example-ca

--- a/pkg/configfile/configfile.go
+++ b/pkg/configfile/configfile.go
@@ -95,6 +95,19 @@ func UpdateConfigurationContents(lines []string, options map[string]string) ([]s
 	return lines, nil
 }
 
+// WritePostgresConfigurationFile replaces the content of a Postgres configuration file
+// with the provide options
+func WritePostgresConfigurationFile(
+	fileName string,
+	options map[string]string,
+) (changed bool, err error) {
+	lines, err := UpdateConfigurationContents(nil, options)
+	if err != nil {
+		return false, fmt.Errorf("error while writing configuration to %v: %w", fileName, err)
+	}
+	return fileutils.WriteLinesToFile(fileName, lines)
+}
+
 // RemoveOptionsFromConfigurationContents deletes all the lines containing one of the given options
 // from the provided configuration content
 func RemoveOptionsFromConfigurationContents(lines []string, options ...string) []string {

--- a/pkg/fileutils/fileutils.go
+++ b/pkg/fileutils/fileutils.go
@@ -286,12 +286,6 @@ func CreateEmptyFile(fileName string) error {
 	return file.Close()
 }
 
-// TruncateFile create an empty file or truncate it if exists
-func TruncateFile(fileName string) error {
-	_, err := WriteFileAtomic(fileName, []byte{}, 0o600)
-	return err
-}
-
 // EnsureParentDirectoryExist check if the directory containing a certain file
 // exist or not, and if is not existent will create the directory using
 // 0700 as permissions bits

--- a/pkg/fileutils/fileutils.go
+++ b/pkg/fileutils/fileutils.go
@@ -286,6 +286,12 @@ func CreateEmptyFile(fileName string) error {
 	return file.Close()
 }
 
+// TruncateFile create an empty file or truncate it if exists
+func TruncateFile(fileName string) error {
+	_, err := WriteFileAtomic(fileName, []byte{}, 0o600)
+	return err
+}
+
 // EnsureParentDirectoryExist check if the directory containing a certain file
 // exist or not, and if is not existent will create the directory using
 // 0700 as permissions bits

--- a/pkg/management/postgres/configuration.go
+++ b/pkg/management/postgres/configuration.go
@@ -280,8 +280,8 @@ func configureRecoveryConfFile(pgData, primaryConnInfo, slotName string) (change
 	return changed, nil
 }
 
-// configurePostgresOverrideConfFile configures replication in the override.conf file
-// for PostgreSQL 12 and newer
+// configurePostgresOverrideConfFile writes the content of override.conf file, including
+// replication information
 func configurePostgresOverrideConfFile(pgData, primaryConnInfo, slotName string) (changed bool, err error) {
 	targetFile := path.Join(pgData, constants.PostgresqlOverrideConfigurationFile)
 
@@ -304,7 +304,7 @@ func configurePostgresOverrideConfFile(pgData, primaryConnInfo, slotName string)
 		}
 	}
 
-	// Truncate the override file
+	// Ensure that override.conf file contains just the above options
 	err = fileutils.TruncateFile(targetFile)
 	if err != nil {
 		return false, err
@@ -470,6 +470,11 @@ func configurePostgresForImport(ctx context.Context, pgData string) (changed boo
 		"max_wal_senders":  "0",
 	}
 
+	// Ensure that override.conf file contains just the above options
+	err = fileutils.TruncateFile(targetFile)
+	if err != nil {
+		return false, err
+	}
 	changed, err = configfile.UpdatePostgresConfigurationFile(targetFile, options)
 	if err != nil {
 		return false, err

--- a/pkg/management/postgres/configuration.go
+++ b/pkg/management/postgres/configuration.go
@@ -305,11 +305,7 @@ func configurePostgresOverrideConfFile(pgData, primaryConnInfo, slotName string)
 	}
 
 	// Ensure that override.conf file contains just the above options
-	err = fileutils.TruncateFile(targetFile)
-	if err != nil {
-		return false, err
-	}
-	changed, err = configfile.UpdatePostgresConfigurationFile(targetFile, options)
+	changed, err = configfile.WritePostgresConfigurationFile(targetFile, options)
 	if err != nil {
 		return false, err
 	}
@@ -471,11 +467,7 @@ func configurePostgresForImport(ctx context.Context, pgData string) (changed boo
 	}
 
 	// Ensure that override.conf file contains just the above options
-	err = fileutils.TruncateFile(targetFile)
-	if err != nil {
-		return false, err
-	}
-	changed, err = configfile.UpdatePostgresConfigurationFile(targetFile, options)
+	changed, err = configfile.WritePostgresConfigurationFile(targetFile, options)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/management/postgres/configuration.go
+++ b/pkg/management/postgres/configuration.go
@@ -460,6 +460,7 @@ func configurePostgresForImport(ctx context.Context, pgData string) (changed boo
 		"fsync":            "off",
 		"wal_level":        "minimal",
 		"full_page_writes": "off",
+		"max_wal_senders":  "0",
 	}
 
 	changed, err = configfile.UpdatePostgresConfigurationFile(targetFile, options)

--- a/pkg/management/postgres/initdb.go
+++ b/pkg/management/postgres/initdb.go
@@ -353,22 +353,26 @@ func (info InitInfo) Bootstrap(ctx context.Context) error {
 
 	instance := info.GetInstance()
 
+	// Detect an initdb bootstrap with import
+	isImportBootstrap := cluster.Spec.Bootstrap != nil &&
+		cluster.Spec.Bootstrap.InitDB != nil &&
+		cluster.Spec.Bootstrap.InitDB.Import != nil
+
 	if applied, err := instance.RefreshConfigurationFilesFromCluster(cluster, true); err != nil {
 		return fmt.Errorf("while writing the config: %w", err)
 	} else if !applied {
 		return fmt.Errorf("could not apply the config")
 	}
 
-	postgresVersion, err := cluster.GetPostgresqlVersion()
-	if err != nil {
-		return fmt.Errorf("while reading the PostgreSQL version: %w", err)
-	}
-
-	if postgresVersion >= 120000 {
-		primaryConnInfo := info.GetPrimaryConnInfo()
-		slotName := cluster.GetSlotNameFromInstanceName(info.PodName)
-		_, err = configurePostgresOverrideConfFile(info.PgData, primaryConnInfo, slotName)
-		if err != nil {
+	primaryConnInfo := info.GetPrimaryConnInfo()
+	slotName := cluster.GetSlotNameFromInstanceName(info.PodName)
+	// Write a special configuration for the import phase
+	if isImportBootstrap {
+		if _, err := configurePostgresForImport(info.PgData); err != nil {
+			return fmt.Errorf("while configuring Postgres for import: %w", err)
+		}
+	} else {
+		if _, err = configurePostgresOverrideConfFile(info.PgData, primaryConnInfo, slotName); err != nil {
 			return fmt.Errorf("while configuring replica: %w", err)
 		}
 	}
@@ -379,12 +383,17 @@ func (info InitInfo) Bootstrap(ctx context.Context) error {
 			return fmt.Errorf("while configuring new instance: %w", err)
 		}
 
-		if cluster.Spec.Bootstrap != nil &&
-			cluster.Spec.Bootstrap.InitDB != nil &&
-			cluster.Spec.Bootstrap.InitDB.Import != nil {
-			err = executeLogicalImport(ctx, typedClient, instance, cluster)
-			if err != nil {
+		if isImportBootstrap {
+			if err := executeLogicalImport(ctx, typedClient, instance, cluster); err != nil {
 				return fmt.Errorf("while executing logical import: %w", err)
+			}
+			// Restore the configuration file
+			if _, err = configurePostgresOverrideConfFile(info.PgData, primaryConnInfo, slotName); err != nil {
+				return fmt.Errorf("while removing Postgres configuration for import: %w", err)
+			}
+			// Run fsync
+			if err := info.initdbSyncOnly(); err != nil {
+				return err
 			}
 		}
 
@@ -444,3 +453,21 @@ func getConnectionPoolerForExternalCluster(
 
 	return pool.NewPostgresqlConnectionPool(sourceDBConnectionString), nil
 }
+
+// initdbSyncOnly Run initdb with --sync-only option after a database import
+func (info InitInfo) initdbSyncOnly() error {
+	// Invoke initdb to generate a data directory
+	options := []string{
+		"-D",
+		info.PgData,
+		"--sync-only",
+	}
+	log.Info("Running initdb --sync-only",
+		"pgdata", info.PgData)
+	initdbCmd := exec.Command(constants.InitdbName, options...) // #nosec
+	if err := execlog.RunBuffering(initdbCmd, constants.InitdbName); err != nil {
+		return fmt.Errorf("error while running initdb --sync-only: %w", err)
+	}
+	return nil
+}
+

--- a/pkg/management/postgres/restore.go
+++ b/pkg/management/postgres/restore.go
@@ -783,14 +783,9 @@ func (info InitInfo) ConfigureInstanceAfterRestore(ctx context.Context, cluster 
 		return err
 	}
 
-	majorVersion, err := postgresutils.GetMajorVersion(info.PgData)
-	if err != nil {
-		return fmt.Errorf("cannot detect major version: %w", err)
-	}
-
 	// This will start the recovery of WALs taken during the backup
 	// and, after that, the server will start in a new timeline
-	if err = instance.WithActiveInstance(func() error {
+	if err := instance.WithActiveInstance(func() error {
 		db, err := instance.GetSuperUserDB()
 		if err != nil {
 			return err
@@ -807,13 +802,11 @@ func (info InitInfo) ConfigureInstanceAfterRestore(ctx context.Context, cluster 
 		return err
 	}
 
-	if majorVersion >= 12 {
-		primaryConnInfo := info.GetPrimaryConnInfo()
-		slotName := cluster.GetSlotNameFromInstanceName(info.PodName)
-		_, err = configurePostgresOverrideConfFile(info.PgData, primaryConnInfo, slotName)
-		if err != nil {
-			return fmt.Errorf("while configuring replica: %w", err)
-		}
+	primaryConnInfo := info.GetPrimaryConnInfo()
+	slotName := cluster.GetSlotNameFromInstanceName(info.PodName)
+	_, err := configurePostgresOverrideConfFile(info.PgData, primaryConnInfo, slotName)
+	if err != nil {
+		return fmt.Errorf("while configuring replica: %w", err)
 	}
 
 	if info.ApplicationUser == "" || info.ApplicationDatabase == "" {

--- a/pkg/management/postgres/restore.go
+++ b/pkg/management/postgres/restore.go
@@ -804,8 +804,7 @@ func (info InitInfo) ConfigureInstanceAfterRestore(ctx context.Context, cluster 
 
 	primaryConnInfo := info.GetPrimaryConnInfo()
 	slotName := cluster.GetSlotNameFromInstanceName(info.PodName)
-	_, err := configurePostgresOverrideConfFile(info.PgData, primaryConnInfo, slotName)
-	if err != nil {
+	if _, err := configurePostgresOverrideConfFile(info.PgData, primaryConnInfo, slotName); err != nil {
 		return fmt.Errorf("while configuring replica: %w", err)
 	}
 
@@ -816,8 +815,7 @@ func (info InitInfo) ConfigureInstanceAfterRestore(ctx context.Context, cluster 
 
 	// Configure the application database information for restored instance
 	return instance.WithActiveInstance(func() error {
-		err = info.ConfigureNewInstance(instance)
-		if err != nil {
+		if err := info.ConfigureNewInstance(instance); err != nil {
 			return fmt.Errorf("while configuring restored instance: %w", err)
 		}
 


### PR DESCRIPTION
When using the import facility of the initdb bootstrap method in a job, optimize the PostgreSQL instance for the sole duration of the job, by setting the following GUCs:

- `archive_mode` to `off`
- `fsync` to `off`
- `full_page_writes` to `off`
- `max_wal_senders` to `0`
- `wal_level` to `minimal`

Then, restore the configuration and invoke `initdb --sync-only` before the end of the import job.

This avoids unnecessary and systematic piling of WAL files during any import job.

Closes #3741 