### PR TITLE
feat: add condition for a resuming cluster

### DIFF
--- a/pkg/reconciler/hibernation/reconciler.go
+++ b/pkg/reconciler/hibernation/reconciler.go
@@ -46,9 +46,10 @@ func Reconcile(
 	switch hibernationCondition.Reason {
 	case HibernationConditionReasonDeletingPods:
 		return reconcileDeletePods(ctx, c, instances)
-
 	case HibernationConditionReasonWaitingPodsDeletion:
 		return &ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+	case HibernationConditionReasonResumingPods:
+		return nil, nil
 
 	default:
 		return &ctrl.Result{}, nil


### PR DESCRIPTION
when a cluster is resuming from hibernated status, we remove the 
`cnpg.io/hibernation` condition at the first place, as the cluster at this 
time is in `healthy` phase, there is no way to distinguish a cluster resuming
from hibernated status and  a cluster doing the switchover.

this patch defer the removing of `cnpg.io/hibernation` condition. when 
cluster is been resumed, we change the hibernate condtion status to 
`false` and change the condtion reason to `ResumingPods`, when all 
pods are get resumed and ready, we then remove the hibernated condition. 

Closes: #3751 