### PR TITLE
fix: prune `override.conf` settings from `postgresql.auto.conf`

### DIFF
--- a/docs/src/release_notes/v1.21.md
+++ b/docs/src/release_notes/v1.21.md
@@ -34,6 +34,8 @@ Fixes:
 - Properly escape reserved characters in `pgpass` connection fields (#3713)
 - Prevent systematic rollout of pods due to considering zero and nil different
   values in `.spec.projectedVolumeTemplate.sources` (#3647)
+- Ensure configuration coherence by pruning from `postgresql.auto.conf` any
+  options now incorporated into `override.conf` (#3773)
 
 ## Version 1.21.2
 

--- a/docs/src/release_notes/v1.22.md
+++ b/docs/src/release_notes/v1.22.md
@@ -35,6 +35,8 @@ Fixes:
 - Properly escape reserved characters in `pgpass` connection fields (#3713)
 - Prevent systematic rollout of pods due to considering zero and nil different
   values in `.spec.projectedVolumeTemplate.sources` (#3647)
+- Ensure configuration coherence by pruning from `postgresql.auto.conf` any
+  options now incorporated into `override.conf` (#3773)
 
 ## Version 1.22.0
 

--- a/pkg/management/postgres/configuration.go
+++ b/pkg/management/postgres/configuration.go
@@ -373,6 +373,9 @@ func migratePostgresAutoConfFile(ctx context.Context, instance *Instance) (bool,
 		"options", options,
 	)
 
+	// We create the override.conf file only if it doesn't exist (first-time migration).
+	// The instance manager manages the content of this file, and it will be overwritten
+	// later during the configuration update. We create it here just as a precaution.
 	if !targetFileExists {
 		_, err = fileutils.WriteLinesToFile(targetFile, options)
 		if err != nil {

--- a/pkg/management/postgres/configuration.go
+++ b/pkg/management/postgres/configuration.go
@@ -362,13 +362,13 @@ func (instance *Instance) migratePostgresAutoConfFile(ctx context.Context) (bool
 		return false, fmt.Errorf("error while reading postgresql.auto.conf file: %w", readLinesErr)
 	}
 
+	overrideConfExists, _ := fileutils.FileExists(overrideConfPath)
 	options := configfile.ReadLinesFromConfigurationContents(autoConfContent, migrateAutoConfOptions...)
-	if len(options) == 0 {
+	if len(options) == 0 && overrideConfExists {
 		contextLogger.Trace("no action taken, options slice is empty")
 		return false, nil
 	}
 
-	overrideConfExists, _ := fileutils.FileExists(overrideConfPath)
 	contextLogger.Info("Start to migrate replication settings",
 		"filename", constants.PostgresqlOverrideConfigurationFile,
 		"targetFileExists", overrideConfExists,

--- a/pkg/management/postgres/instance_replica.go
+++ b/pkg/management/postgres/instance_replica.go
@@ -37,7 +37,7 @@ func (instance *Instance) RefreshReplicaConfiguration(
 	// TODO: Remove this code when enough time has passed since 1.21 release
 	//       This is due to the operator switching from postgresql.auto.conf
 	//       to override.conf for coordinating replication configuration
-	changed, err = migratePostgresAutoConfFile(ctx, instance, false)
+	changed, err = migratePostgresAutoConfFile(ctx, instance)
 	if err != nil {
 		return changed, err
 	}

--- a/pkg/management/postgres/instance_replica.go
+++ b/pkg/management/postgres/instance_replica.go
@@ -37,7 +37,7 @@ func (instance *Instance) RefreshReplicaConfiguration(
 	// TODO: Remove this code when enough time has passed since 1.21 release
 	//       This is due to the operator switching from postgresql.auto.conf
 	//       to override.conf for coordinating replication configuration
-	changed, err = migratePostgresAutoConfFile(ctx, instance)
+	changed, err = instance.migratePostgresAutoConfFile(ctx)
 	if err != nil {
 		return changed, err
 	}

--- a/pkg/management/postgres/restore.go
+++ b/pkg/management/postgres/restore.go
@@ -263,7 +263,7 @@ func (info InitInfo) Restore(ctx context.Context) error {
 	// we recover from a base which has postgresql.auto.conf
 	// the override.conf and include statement is present, what we need to do is to
 	// migrate the content
-	if _, err := migratePostgresAutoConfFile(ctx, info.GetInstance(), true); err != nil {
+	if _, err := migratePostgresAutoConfFile(ctx, info.GetInstance()); err != nil {
 		return err
 	}
 	if cluster.IsReplica() {

--- a/pkg/management/postgres/restore.go
+++ b/pkg/management/postgres/restore.go
@@ -263,7 +263,7 @@ func (info InitInfo) Restore(ctx context.Context) error {
 	// we recover from a base which has postgresql.auto.conf
 	// the override.conf and include statement is present, what we need to do is to
 	// migrate the content
-	if _, err := migratePostgresAutoConfFile(ctx, info.GetInstance()); err != nil {
+	if _, err := info.GetInstance().migratePostgresAutoConfFile(ctx); err != nil {
 		return err
 	}
 	if cluster.IsReplica() {


### PR DESCRIPTION
Postgres always parses `postgresql.auto.conf` as the last configuration file. This file contains settings dynamically changed through the `ALTER SYSTEM` SQL command.

When CloudNativePG introduced the `enableAlterSystem` parameter, the content from `postgresql.auto.conf` was migrated into `override.conf` at startup.

This patch improves the check by making it idempotent and by running it in the reconciler, ensuring that no option contained in `override.conf` is in `postgresql.auto.conf`.

Closes #3588 