### PR TITLE
fix: add the OCP version to the cluster name when creating for testing

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -1902,7 +1902,7 @@ jobs:
       -
         name: Set cluster name
         run: |
-          echo "CLUSTER_NAME=ocp-${{ github.run_number}}-$( echo ${{ matrix.k8s_version }} | tr -d '.' )" >> $GITHUB_ENV
+          echo "CLUSTER_NAME=${{ env.E2E_SUFFIX }}-ocp-${{ github.run_number}}-$( echo ${{ matrix.k8s_version }} | tr -d '.' )" >> $GITHUB_ENV
       -
         name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -1902,7 +1902,7 @@ jobs:
       -
         name: Set cluster name
         run: |
-          echo "CLUSTER_NAME=ocp-${{ github.run_number}}" >> $GITHUB_ENV
+          echo "CLUSTER_NAME=ocp-${{ github.run_number}}-$( echo ${{ matrix.k8s_version }} | tr -d '.' )" >> $GITHUB_ENV
       -
         name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Previously we were using only the run number from the GitHub action which was unique, meaning that all the cluster were being created with the same hostname, now, we add the OCP version to the domain to avoid these kind of issues

Closes #3799 