### PR TITLE
Docs: Fix a couple of links and one heading level

### DIFF
--- a/docs/src/cluster_conf.md
+++ b/docs/src/cluster_conf.md
@@ -47,7 +47,7 @@ CloudNativePG relies on [ephemeral volumes](https://kubernetes.io/docs/concepts/
 for part of the internal activities. Ephemeral volumes exist for the sole
 duration of a pod's life, without persisting across pod restarts.
 
-# Volume Claim Template for Temporary Storage
+### Volume Claim Template for Temporary Storage
 
 The operator uses  by default an `emptyDir` volume, which can be customized by using the `.spec.ephemeralVolumesSizeLimit field`.
 This can be overridden by specifying a volume claim template in the `.spec.ephemeralVolumeSource` field.


### PR DESCRIPTION
Just a few minor things that cropped up as I was going through the docs:

- heading level out of order in cluster_conf
- broken link in backup_barmanobjectstore.md (content was formerly in backup.md and thus fragment link was relative)
- broken link in wal_archiving.md (case issue; may not affect all clients but worth being consistent)