### PR TITLE
chore: make clear which Dockerfile use every build process

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -386,6 +386,7 @@ jobs:
         with:
           platforms: ${{ env.PLATFORMS }}
           context: .
+          file: Dockerfile
           push: true
           build-args: |
             VERSION=${{ env.VERSION }}
@@ -484,6 +485,7 @@ jobs:
         with:
           platforms: ${{ env.PLATFORMS }}
           context: .
+          file: Dockerfile
           push: true
           build-args: |
             VERSION=${{ env.VERSION }}-prime

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -573,14 +573,36 @@ jobs:
           load: true
           build-args: |
             VERSION=${{ env.VERSION }}
-          tags: ${{ steps.docker-meta.outputs.tags }}
+          tags: ${{ steps.docker-meta-ubi8.outputs.tags }}
 
       - name: Dockle scan UBI8 image
         uses: erzz/dockle-action@v1
         env:
           DOCKLE_IGNORES: CIS-DI-0009
         with:
-          image: ${{ steps.docker-meta.outputs.tags }}
+          image: ${{ steps.docker-meta-ubi8.outputs.tags }}
+          exit-code: '1'
+          failure-threshold: WARN
+          accept-keywords: key
+
+      - name: Build for scan UBI9 image
+        uses: docker/build-push-action@v5
+        with:
+          platforms: "linux/amd64"
+          context: .
+          file: Dockerfile-ubi9
+          push: false
+          load: true
+          build-args: |
+            VERSION=${{ env.VERSION }}
+          tags: ${{ steps.docker-meta-ubi9.outputs.tags }}
+
+      - name: Dockle scan UBI9 image
+        uses: erzz/dockle-action@v1
+        env:
+          DOCKLE_IGNORES: CIS-DI-0009
+        with:
+          image: ${{ steps.docker-meta-ubi9.outputs.tags }}
           exit-code: '1'
           failure-threshold: WARN
           accept-keywords: key

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -543,19 +543,42 @@ jobs:
           username: ${{ env.REGISTRY_USER }}
           password:  ${{ env.REGISTRY_PASSWORD }}
 
-      - name: Build for scan
+      - name: Build for scan distroless image
         uses: docker/build-push-action@v5
         with:
           platforms: "linux/amd64"
           context: .
+          file: Dockerfile
           push: false
           load: true
           build-args: |
             VERSION=${{ env.VERSION }}
           tags: ${{ steps.docker-meta.outputs.tags }}
 
-      - name: Dockle scan
+      - name: Dockle scan distroless image
         uses: erzz/dockle-action@v1
+        with:
+          image: ${{ steps.docker-meta.outputs.tags }}
+          exit-code: '1'
+          failure-threshold: WARN
+          accept-keywords: key
+
+      - name: Build for scan UBI8 image
+        uses: docker/build-push-action@v5
+        with:
+          platforms: "linux/amd64"
+          context: .
+          file: Dockerfile-ubi8
+          push: false
+          load: true
+          build-args: |
+            VERSION=${{ env.VERSION }}
+          tags: ${{ steps.docker-meta.outputs.tags }}
+
+      - name: Dockle scan UBI8 image
+        uses: erzz/dockle-action@v1
+        env:
+          DOCKLE_IGNORES: CIS-DI-0009
         with:
           image: ${{ steps.docker-meta.outputs.tags }}
           exit-code: '1'
@@ -587,6 +610,7 @@ jobs:
         with:
           platforms: ${{ env.PLATFORMS }}
           context: .
+          file: Dockerfile
           push: ${{ env.PUSH }}
           build-args: |
             VERSION=${{ env.VERSION }}

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -181,6 +181,7 @@ jobs:
         with:
           platforms: ${{ env.PLATFORMS }}
           context: .
+          file: Dockerfile
           push: true
           build-args: |
             VERSION=${{ steps.build-meta.outputs.version }}


### PR DESCRIPTION
Until now, we were supposing that we were using Dockerfile by default and just specify when we wanted to use Dockerfile-ubi8, now, we're explicitly on which file we use, this is for in the future, avoid making mistakes of which file we're using to build the container images.

And since we're using more than one Dockerfile to build image, we also added a new stop to build that image and run the Dockle scan process on that one.

Closes #3811