### PR TITLE
fix: make operator backward compatible with 1.18

### DIFF
--- a/.wordlist-en-custom.txt
+++ b/.wordlist-en-custom.txt
@@ -1054,6 +1054,7 @@ sigs
 singlenamespace
 slotPrefix
 smartShutdownTimeout
+smartStopDelay
 snapshotBackupStatus
 snapshotOwnerReference
 snapshotted

--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -356,6 +356,13 @@ type ClusterSpec struct {
 	// +optional
 	MaxStopDelay int32 `json:"stopDelay,omitempty"`
 
+	// Deprecated: please use SmartShutdownTimeout instead
+	// The time in seconds that controls the window of time reserved for the smart shutdown of Postgres to complete.
+	// Make sure you reserve enough time for the operator to request a fast shutdown of Postgres
+	// (that is: `stopDelay` - `smartShutdownTimeout`).
+	// +optional
+	SmartStopDelay int32 `json:"smartStopDelay,omitempty"`
+
 	// The time in seconds that controls the window of time reserved for the smart shutdown of Postgres to complete.
 	// Make sure you reserve enough time for the operator to request a fast shutdown of Postgres
 	// (that is: `stopDelay` - `smartShutdownTimeout`).
@@ -2757,6 +2764,9 @@ func (cluster *Cluster) GetMaxStopDelay() int32 {
 func (cluster *Cluster) GetSmartShutdownTimeout() int32 {
 	if cluster.Spec.SmartShutdownTimeout > 0 {
 		return cluster.Spec.SmartShutdownTimeout
+	}
+	if cluster.Spec.SmartStopDelay > 0 {
+		return cluster.Spec.SmartStopDelay
 	}
 	return 180
 }

--- a/config/crd/bases/postgresql.cnpg.io_clusters.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_clusters.yaml
@@ -3547,6 +3547,14 @@ spec:
                   of Postgres (that is: `stopDelay` - `smartShutdownTimeout`).'
                 format: int32
                 type: integer
+              smartStopDelay:
+                description: 'Deprecated: please use SmartShutdownTimeout instead
+                  The time in seconds that controls the window of time reserved for
+                  the smart shutdown of Postgres to complete. Make sure you reserve
+                  enough time for the operator to request a fast shutdown of Postgres
+                  (that is: `stopDelay` - `smartShutdownTimeout`).'
+                format: int32
+                type: integer
               startDelay:
                 default: 3600
                 description: 'The time in seconds that is allowed for a PostgreSQL

--- a/docs/src/cloudnative-pg.v1.md
+++ b/docs/src/cloudnative-pg.v1.md
@@ -1548,6 +1548,16 @@ ceiling(startDelay / 10).</p>
 gracefully shutdown (default 1800)</p>
 </td>
 </tr>
+<tr><td><code>smartStopDelay</code><br/>
+<i>int32</i>
+</td>
+<td>
+   <p>Deprecated: please use SmartShutdownTimeout instead
+The time in seconds that controls the window of time reserved for the smart shutdown of Postgres to complete.
+Make sure you reserve enough time for the operator to request a fast shutdown of Postgres
+(that is: <code>stopDelay</code> - <code>smartShutdownTimeout</code>).</p>
+</td>
+</tr>
 <tr><td><code>smartShutdownTimeout</code><br/>
 <i>int32</i>
 </td>


### PR DESCRIPTION
The 1.18 release of the operator has a field that conflicts with the
API of later releases.
For users of 1.18 there is no migration path at the moment. This patch
adds support for the conflicting field, marks it as deprecated, and
ensures the operator logs any actions taken to respond to the
deprecation.

Closes #3821 
