### PR TITLE
chore: lint the project with the latest `golangci-lint` version

### DIFF
--- a/cmd/kubectl-cnpg/main.go
+++ b/cmd/kubectl-cnpg/main.go
@@ -58,7 +58,7 @@ func main() {
 		Use:          "kubectl-cnpg",
 		Short:        "A plugin to manage your CloudNativePG clusters",
 		SilenceUsage: true,
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
 			logFlags.ConfigureLogging()
 
 			// If we're invoking the completion command we shouldn't try to create

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -44,7 +44,7 @@ func main() {
 	cmd := &cobra.Command{
 		Use:          "manager [cmd]",
 		SilenceUsage: true,
-		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		PersistentPreRun: func(_ *cobra.Command, _ []string) {
 			logFlags.ConfigureLogging()
 		},
 	}

--- a/controllers/backup_controller.go
+++ b/controllers/backup_controller.go
@@ -574,7 +574,6 @@ func startBarmanBackup(
 		)
 		return err
 	})
-
 	if err != nil {
 		log.FromContext(ctx).Error(err, "executing backup", "stdout", stdout, "stderr", stderr)
 		status.SetAsFailed(fmt.Errorf("can't execute backup: %w", err))

--- a/controllers/backup_predicates.go
+++ b/controllers/backup_predicates.go
@@ -129,7 +129,7 @@ var volumeSnapshotsPredicate = predicate.Funcs{
 }
 
 func (r *BackupReconciler) mapVolumeSnapshotsToBackups() handler.MapFunc {
-	return func(ctx context.Context, obj client.Object) []reconcile.Request {
+	return func(_ context.Context, obj client.Object) []reconcile.Request {
 		volumeSnapshot, ok := obj.(*storagesnapshotv1.VolumeSnapshot)
 		if !ok {
 			return nil

--- a/controllers/cluster_cleanup_test.go
+++ b/controllers/cluster_cleanup_test.go
@@ -37,7 +37,7 @@ var _ = Describe("cluster_cleanup", func() {
 		scheme *runtime.Scheme
 	)
 
-	BeforeEach(func(ctx SpecContext) {
+	BeforeEach(func() {
 		scheme = schemeBuilder.BuildWithAllKnownScheme()
 		r = ClusterReconciler{
 			Scheme: scheme,

--- a/controllers/cluster_predicates.go
+++ b/controllers/cluster_predicates.go
@@ -76,13 +76,13 @@ var (
 			newNode, newOk := e.ObjectNew.(*corev1.Node)
 			return oldOk && newOk && oldNode.Spec.Unschedulable != newNode.Spec.Unschedulable
 		},
-		CreateFunc: func(createEvent event.CreateEvent) bool {
+		CreateFunc: func(_ event.CreateEvent) bool {
 			return false
 		},
-		DeleteFunc: func(createEvent event.DeleteEvent) bool {
+		DeleteFunc: func(_ event.DeleteEvent) bool {
 			return false
 		},
-		GenericFunc: func(genericEvent event.GenericEvent) bool {
+		GenericFunc: func(_ event.GenericEvent) bool {
 			return false
 		},
 	}

--- a/controllers/cluster_upgrade_test.go
+++ b/controllers/cluster_upgrade_test.go
@@ -155,7 +155,7 @@ var _ = Describe("Pod upgrade", Ordered, func() {
 		Expect(rollout.canBeInPlace).To(BeFalse())
 	})
 
-	It("checkPodSpecIsOutdated should not return any error", func(ctx SpecContext) {
+	It("checkPodSpecIsOutdated should not return any error", func() {
 		pod := specs.PodWithExistingStorage(cluster, 1)
 		status := postgres.PostgresqlStatus{
 			Pod:            pod,

--- a/controllers/pooler_predicates_test.go
+++ b/controllers/pooler_predicates_test.go
@@ -69,7 +69,7 @@ var _ = Describe("pooler_predicates unit tests", func() {
 
 		secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: rand.String(10), Namespace: namespace}}
 		utils.SetAsOwnedBy(&secret.ObjectMeta, pooler.ObjectMeta, pooler.TypeMeta)
-		isOwnedByPoolerOrSatisfiesPredicate(secret, func(object client.Object) bool {
+		isOwnedByPoolerOrSatisfiesPredicate(secret, func(_ client.Object) bool {
 			return false
 		})
 	})

--- a/internal/cmd/manager/backup/cmd.go
+++ b/internal/cmd/manager/backup/cmd.go
@@ -33,7 +33,7 @@ import (
 func NewCmd() *cobra.Command {
 	cmd := cobra.Command{
 		Use: "backup [backup_name]",
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			backupURL := url.Local(url.PathPgBackup, url.LocalPort)
 			resp, err := http.Get(backupURL + "?name=" + args[0])
 			if err != nil {

--- a/internal/cmd/manager/controller/cmd.go
+++ b/internal/cmd/manager/controller/cmd.go
@@ -36,7 +36,7 @@ func NewCmd() *cobra.Command {
 	cmd := cobra.Command{
 		Use:           "controller [flags]",
 		SilenceErrors: true,
-		RunE: func(_ *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return RunController(
 				metricsAddr,
 				configMapName,

--- a/internal/cmd/manager/controller/cmd.go
+++ b/internal/cmd/manager/controller/cmd.go
@@ -36,7 +36,7 @@ func NewCmd() *cobra.Command {
 	cmd := cobra.Command{
 		Use:           "controller [flags]",
 		SilenceErrors: true,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			return RunController(
 				metricsAddr,
 				configMapName,

--- a/internal/cmd/manager/instance/cmd.go
+++ b/internal/cmd/manager/instance/cmd.go
@@ -36,7 +36,7 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "instance",
 		Short: "Instance management subfeatures",
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return fmt.Errorf("missing subcommand")
 		},
 	}

--- a/internal/cmd/manager/instance/initdb/cmd.go
+++ b/internal/cmd/manager/instance/initdb/cmd.go
@@ -50,13 +50,13 @@ func NewCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use: "init [options]",
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return management.WaitKubernetesAPIServer(cmd.Context(), ctrl.ObjectKey{
 				Name:      clusterName,
 				Namespace: namespace,
 			})
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := cmd.Context()
 
 			initDBFlags, err := shellquote.Split(initDBFlagsString)
@@ -103,7 +103,7 @@ func NewCmd() *cobra.Command {
 
 			return initSubCommand(ctx, info)
 		},
-		PostRunE: func(cmd *cobra.Command, args []string) error {
+		PostRunE: func(cmd *cobra.Command, _ []string) error {
 			if err := istio.TryInvokeQuitEndpoint(cmd.Context()); err != nil {
 				return err
 			}

--- a/internal/cmd/manager/instance/join/cmd.go
+++ b/internal/cmd/manager/instance/join/cmd.go
@@ -45,14 +45,14 @@ func NewCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use: "join [options]",
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return management.WaitKubernetesAPIServer(cmd.Context(), ctrl.ObjectKey{
 				Name:      clusterName,
 				Namespace: namespace,
 			})
 		},
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			ctx := context.Background()
+			ctx := cmd.Context()
 			instance := postgres.NewInstance()
 
 			// The following are needed to correctly
@@ -71,7 +71,7 @@ func NewCmd() *cobra.Command {
 
 			return joinSubCommand(ctx, instance, info)
 		},
-		PostRunE: func(cmd *cobra.Command, args []string) error {
+		PostRunE: func(cmd *cobra.Command, _ []string) error {
 			if err := istio.TryInvokeQuitEndpoint(cmd.Context()); err != nil {
 				return err
 			}

--- a/internal/cmd/manager/instance/join/cmd.go
+++ b/internal/cmd/manager/instance/join/cmd.go
@@ -51,7 +51,7 @@ func NewCmd() *cobra.Command {
 				Namespace: namespace,
 			})
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			instance := postgres.NewInstance()
 

--- a/internal/cmd/manager/instance/pgbasebackup/cmd.go
+++ b/internal/cmd/manager/instance/pgbasebackup/cmd.go
@@ -51,13 +51,13 @@ func NewCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use: "pgbasebackup",
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return management.WaitKubernetesAPIServer(cmd.Context(), ctrl.ObjectKey{
 				Name:      clusterName,
 				Namespace: namespace,
 			})
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			client, err := management.NewControllerRuntimeClient()
 			if err != nil {
 				return err
@@ -80,7 +80,7 @@ func NewCmd() *cobra.Command {
 			}
 			return err
 		},
-		PostRunE: func(cmd *cobra.Command, args []string) error {
+		PostRunE: func(cmd *cobra.Command, _ []string) error {
 			if err := istio.TryInvokeQuitEndpoint(cmd.Context()); err != nil {
 				return err
 			}

--- a/internal/cmd/manager/instance/pgbasebackup/cmd.go
+++ b/internal/cmd/manager/instance/pgbasebackup/cmd.go
@@ -57,7 +57,7 @@ func NewCmd() *cobra.Command {
 				Namespace: namespace,
 			})
 		},
-		RunE: func(cmd *cobra.Command, _ []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			client, err := management.NewControllerRuntimeClient()
 			if err != nil {
 				return err

--- a/internal/cmd/manager/instance/restore/cmd.go
+++ b/internal/cmd/manager/instance/restore/cmd.go
@@ -41,7 +41,7 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:           "restore [flags]",
 		SilenceErrors: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return management.WaitKubernetesAPIServer(cmd.Context(), ctrl.ObjectKey{
 				Name:      clusterName,
 				Namespace: namespace,

--- a/internal/cmd/manager/instance/restore/cmd.go
+++ b/internal/cmd/manager/instance/restore/cmd.go
@@ -47,7 +47,7 @@ func NewCmd() *cobra.Command {
 				Namespace: namespace,
 			})
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := cmd.Context()
 
 			info := postgres.InitInfo{
@@ -59,7 +59,7 @@ func NewCmd() *cobra.Command {
 
 			return restoreSubCommand(ctx, info)
 		},
-		PostRunE: func(cmd *cobra.Command, args []string) error {
+		PostRunE: func(cmd *cobra.Command, _ []string) error {
 			if err := istio.TryInvokeQuitEndpoint(cmd.Context()); err != nil {
 				return err
 			}

--- a/internal/cmd/manager/instance/restoresnapshot/cmd.go
+++ b/internal/cmd/manager/instance/restoresnapshot/cmd.go
@@ -47,13 +47,13 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:           "restoresnapshot [flags]",
 		SilenceErrors: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return management.WaitKubernetesAPIServer(cmd.Context(), ctrl.ObjectKey{
 				Name:      clusterName,
 				Namespace: namespace,
 			})
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := cmd.Context()
 
 			info := postgres.InitInfo{
@@ -85,7 +85,7 @@ func NewCmd() *cobra.Command {
 			}
 			return err
 		},
-		PostRunE: func(cmd *cobra.Command, args []string) error {
+		PostRunE: func(cmd *cobra.Command, _ []string) error {
 			if err := istio.TryInvokeQuitEndpoint(cmd.Context()); err != nil {
 				return err
 			}

--- a/internal/cmd/manager/instance/run/cmd.go
+++ b/internal/cmd/manager/instance/run/cmd.go
@@ -70,13 +70,13 @@ func NewCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use: "run [flags]",
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return management.WaitKubernetesAPIServer(cmd.Context(), client.ObjectKey{
 				Name:      clusterName,
 				Namespace: namespace,
 			})
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := log.IntoContext(cmd.Context(), log.GetLogger())
 			instance := postgres.NewInstance()
 
@@ -89,7 +89,7 @@ func NewCmd() *cobra.Command {
 				return runSubCommand(ctx, instance)
 			})
 		},
-		PostRunE: func(cmd *cobra.Command, args []string) error {
+		PostRunE: func(cmd *cobra.Command, _ []string) error {
 			if err := istio.TryInvokeQuitEndpoint(cmd.Context()); err != nil {
 				return err
 			}

--- a/internal/cmd/manager/instance/status/cmd.go
+++ b/internal/cmd/manager/instance/status/cmd.go
@@ -33,7 +33,7 @@ import (
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use: "status",
-		RunE: func(_ *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return statusSubCommand()
 		},
 	}

--- a/internal/cmd/manager/instance/status/cmd.go
+++ b/internal/cmd/manager/instance/status/cmd.go
@@ -33,7 +33,7 @@ import (
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use: "status",
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			return statusSubCommand()
 		},
 	}

--- a/internal/cmd/manager/pgbouncer/cmd.go
+++ b/internal/cmd/manager/pgbouncer/cmd.go
@@ -31,7 +31,7 @@ func NewCmd() *cobra.Command {
 		Use:           "pgbouncer",
 		Short:         "pgbouncer management subfeatures",
 		SilenceErrors: true,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return fmt.Errorf("missing subcommand")
 		},
 	}

--- a/internal/cmd/manager/pgbouncer/run/cmd.go
+++ b/internal/cmd/manager/pgbouncer/run/cmd.go
@@ -54,7 +54,7 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:           "run",
 		SilenceErrors: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(_ *cobra.Command, args []string) error {
 			if poolerNamespacedName.Name == "" || poolerNamespacedName.Namespace == "" {
 				log.Info(
 					"pooler object key not set",

--- a/internal/cmd/manager/pgbouncer/run/cmd.go
+++ b/internal/cmd/manager/pgbouncer/run/cmd.go
@@ -54,7 +54,7 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:           "run",
 		SilenceErrors: true,
-		PreRunE: func(_ *cobra.Command, args []string) error {
+		PreRunE: func(_ *cobra.Command, _ []string) error {
 			if poolerNamespacedName.Name == "" || poolerNamespacedName.Namespace == "" {
 				log.Info(
 					"pooler object key not set",
@@ -63,7 +63,7 @@ func NewCmd() *cobra.Command {
 			}
 			return nil
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			if err := runSubCommand(cmd.Context(), poolerNamespacedName); err != nil {
 				log.Error(err, "Error while running manager")
 				return err

--- a/internal/cmd/manager/show/walarchivequeue/cmd.go
+++ b/internal/cmd/manager/show/walarchivequeue/cmd.go
@@ -32,7 +32,7 @@ func NewCmd() *cobra.Command {
 	cmd := cobra.Command{
 		Use:   "wal-archive-queue",
 		Short: "Lists all .ready wal files in " + specs.PgWalArchiveStatusPath,
-		RunE: func(cobraCmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			if err := run(); err != nil {
 				log.Error(err, "Error while extracting the list of .ready files")
 			}

--- a/internal/cmd/plugin/fio/cmd.go
+++ b/internal/cmd/plugin/fio/cmd.go
@@ -35,14 +35,14 @@ func NewCmd() *cobra.Command {
 		Args:    cobra.MinimumNArgs(1),
 		Long:    `Creates a fio deployment that will execute a fio job on the specified pvc.`,
 		Example: jobExample,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			ctx := context.Background()
 			fioArgs := args[1:]
 			deploymentName = args[0]
 			fioCommand := newFioCommand(deploymentName, storageClassName, pvcSize, dryRun, fioArgs)
 			return fioCommand.execute(ctx)
 		},
-		PreRun: func(cmd *cobra.Command, args []string) {
+		PreRun: func(_ *cobra.Command, _ []string) {
 			if !dryRun {
 				fmt.Println("Running this directly to the cluster may produce a disruption in the service, " +
 					"are you sure you want to proceed? (y/n)")
@@ -56,7 +56,7 @@ func NewCmd() *cobra.Command {
 				}
 			}
 		},
-		PostRun: func(cmd *cobra.Command, args []string) {
+		PostRun: func(_ *cobra.Command, _ []string) {
 			if !dryRun {
 				fmt.Printf("To remove this test you need to delete the Deployment, ConfigMap "+
 					"and PVC with the name %v\n\nThe most simple way to do this is to re-run the command that was run"+

--- a/internal/cmd/plugin/install/generate.go
+++ b/internal/cmd/plugin/install/generate.go
@@ -64,7 +64,7 @@ func newGenerateCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "generate",
 		Short: "generates the YAML manifests needed to install the CloudNativePG operator",
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			// we consider the namespace only if explicitly passed for this command
 			namespace := ""
 			if plugin.NamespaceExplicitlyPassed {

--- a/internal/cmd/plugin/pgadmin/cmd.go
+++ b/internal/cmd/plugin/pgadmin/cmd.go
@@ -79,7 +79,7 @@ func NewCmd() *cobra.Command {
 		Args:    cobra.MinimumNArgs(1),
 		Long:    `Creates a pgadmin deployment configured to work with a CNPG Cluster.`,
 		Example: pgadminExample,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			ctx := context.Background()
 			clusterName := args[0]
 

--- a/internal/cmd/plugin/promote/cmd.go
+++ b/internal/cmd/plugin/promote/cmd.go
@@ -30,7 +30,7 @@ func NewCmd() *cobra.Command {
 		Use:   "promote [cluster] [node]",
 		Short: "Promote the pod named [cluster]-[node] or [node] to primary",
 		Args:  cobra.ExactArgs(2),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			ctx := context.Background()
 			clusterName := args[0]
 			node := args[1]

--- a/internal/cmd/plugin/reload/cmd.go
+++ b/internal/cmd/plugin/reload/cmd.go
@@ -29,7 +29,7 @@ func NewCmd() *cobra.Command {
 		Short: `Reload the cluster`,
 		Long:  `Triggers a reconciliation loop for all the cluster's instances, rolling out new configurations if present.`,
 		Args:  cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			ctx := context.Background()
 			clusterName := args[0]
 			return Reload(ctx, clusterName)

--- a/internal/cmd/plugin/report/operator.go
+++ b/internal/cmd/plugin/report/operator.go
@@ -37,7 +37,7 @@ func operatorCmd() *cobra.Command {
 		Use:   "operator",
 		Short: "Report operator deployment, pod, events, logs (opt-in)",
 		Long:  "Collects combined information on the operator in a Zip file",
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			now := time.Now().UTC()
 			if file == filePlaceholder {
 				file = reportName("operator", now) + ".zip"

--- a/internal/cmd/plugin/snapshot/cmd.go
+++ b/internal/cmd/plugin/snapshot/cmd.go
@@ -29,7 +29,7 @@ func NewCmd() *cobra.Command {
 		Use:   "snapshot <cluster-name>",
 		Short: "command removed",
 		Long:  "Replaced by `kubectl cnpg backup <cluster-name> -m volumeSnapshot`",
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			fmt.Println("This command was replaced by `kubectl cnpg backup <cluster-name> -m volumeSnapshot`")
 			fmt.Println("IMPORTANT: if you are using VolumeSnapshots on 1.20, you should upgrade to the latest minor release")
 			return errors.New("command removed")

--- a/internal/cmd/plugin/status/status.go
+++ b/internal/cmd/plugin/status/status.go
@@ -504,7 +504,7 @@ func (fullStatus *PostgresqlStatus) printReplicaStatus(verbose bool) {
 	fullStatus.printReplicaStatusTableHeader(status, verbose)
 
 	// print Replication Slots columns only if the cluster has replication slots enabled
-	addReplicationSlotsColumns := func(applicationName string, columns *[]interface{}) {}
+	addReplicationSlotsColumns := func(_ string, _ *[]interface{}) {}
 	if fullStatus.areReplicationSlotsEnabled() {
 		addReplicationSlotsColumns = func(applicationName string, columns *[]interface{}) {
 			fullStatus.addReplicationSlotsColumns(applicationName, columns, verbose)

--- a/internal/cmd/versions/cmd.go
+++ b/internal/cmd/versions/cmd.go
@@ -30,7 +30,7 @@ func NewCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "version",
 		Short: "Prints version, commit sha and date of the build",
-		Run: func(_ *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, _ []string) {
 			fmt.Printf("Build: %+v\n", versions.Info)
 		},
 	}

--- a/internal/cmd/versions/cmd.go
+++ b/internal/cmd/versions/cmd.go
@@ -30,7 +30,7 @@ func NewCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "version",
 		Short: "Prints version, commit sha and date of the build",
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, args []string) {
 			fmt.Printf("Build: %+v\n", versions.Info)
 		},
 	}

--- a/pkg/management/postgres/instance.go
+++ b/pkg/management/postgres/instance.go
@@ -1123,7 +1123,7 @@ func (instance *Instance) requestFencingOff() {
 // waitForInstanceRestarted waits until the instance reports being started
 // after the given time
 func (instance *Instance) waitForInstanceRestarted(after time.Time) error {
-	retryOnEveryError := func(err error) bool {
+	retryOnEveryError := func(_ error) bool {
 		return true
 	}
 	return retry.OnError(RetryUntilServerAvailable, retryOnEveryError, func() error {

--- a/pkg/reconciler/backup/volumesnapshot/online_test.go
+++ b/pkg/reconciler/backup/volumesnapshot/online_test.go
@@ -67,7 +67,7 @@ var _ = Describe("onlineExecutor prepare", func() {
 		backup  *apiv1.Backup
 		target  *corev1.Pod
 	)
-	BeforeEach(func(ctx SpecContext) {
+	BeforeEach(func(_ SpecContext) {
 		backup = &apiv1.Backup{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "online-backup",
@@ -246,7 +246,7 @@ var _ = Describe("onlineExecutor finalize", func() {
 		fakeClient *fakeBackupClient
 	)
 
-	BeforeEach(func(ctx SpecContext) {
+	BeforeEach(func(_ SpecContext) {
 		executor = &onlineExecutor{}
 		backup = &apiv1.Backup{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/utils/discovery_test.go
+++ b/pkg/utils/discovery_test.go
@@ -161,12 +161,12 @@ var _ = Describe("Detect resources properly when", func() {
 
 var _ = Describe("AvailableArchitecture", func() {
 	var (
-		mockHashCalculator func(name string) (hash string, err error)
+		mockHashCalculator func(_ string) (hash string, err error)
 		arch               *AvailableArchitecture
 	)
 
 	BeforeEach(func() {
-		mockHashCalculator = func(name string) (hash string, err error) {
+		mockHashCalculator = func(_ string) (hash string, err error) {
 			return "mockedHash", nil
 		}
 		arch = newAvailableArchitecture("amd64", filepath.Join("bin", "manager_amd64"))
@@ -203,6 +203,9 @@ var _ = Describe("AvailableArchitecture", func() {
 
 		Context("when hash is already calculated", func() {
 			BeforeEach(func() {
+				mockHashCalculator = func(_ string) (hash string, err error) {
+					return "should-not-return-this", nil
+				}
 				arch.hash = "precalculatedHash"
 			})
 
@@ -210,9 +213,7 @@ var _ = Describe("AvailableArchitecture", func() {
 				arch.calculateHash()
 				hash1 := arch.hash
 
-				arch.hashCalculator = func(name string) (hash string, err error) {
-					return "should-not-return-this", nil
-				}
+				arch.hashCalculator = mockHashCalculator
 
 				arch.calculateHash()
 				hash2 := arch.hash
@@ -223,7 +224,7 @@ var _ = Describe("AvailableArchitecture", func() {
 
 		Context("when hash calculation returns an error", func() {
 			BeforeEach(func() {
-				mockHashCalculator = func(name string) (hash string, err error) {
+				mockHashCalculator = func(_ string) (hash string, err error) {
 					return "", fmt.Errorf("fake error")
 				}
 				arch.hashCalculator = mockHashCalculator

--- a/tests/e2e/cluster_setup_test.go
+++ b/tests/e2e/cluster_setup_test.go
@@ -48,7 +48,7 @@ var _ = Describe("Cluster setup", Label(tests.LabelSmoke, tests.LabelBasic), fun
 		}
 	})
 
-	It("sets up a cluster", func(ctx SpecContext) {
+	It("sets up a cluster", func(_ SpecContext) {
 		const namespacePrefix = "cluster-storageclass-e2e"
 		var err error
 
@@ -74,7 +74,7 @@ var _ = Describe("Cluster setup", Label(tests.LabelSmoke, tests.LabelBasic), fun
 				_, _ = fmt.Fprintf(GinkgoWriter, "\nError tailing cluster logs: %v\n", err)
 			}
 		}()
-		DeferCleanup(func(ctx SpecContext) {
+		DeferCleanup(func(_ SpecContext) {
 			if CurrentSpecReport().Failed() {
 				specName := CurrentSpecReport().FullText()
 				capLines := 10

--- a/tests/e2e/logs_test.go
+++ b/tests/e2e/logs_test.go
@@ -90,7 +90,7 @@ var _ = Describe("JSON log output", Label(tests.LabelObservability), func() {
 				var queryError error
 				// Run a wrong query and save its result
 				commandTimeout := time.Second * 10
-				Eventually(func(g Gomega) error {
+				Eventually(func(_ Gomega) error {
 					_, _, queryError = utils.ExecCommand(env.Ctx, env.Interface, env.RestClientConfig, pod,
 						specs.PostgresContainerName, &commandTimeout, "psql", "-U", "postgres", "app", "-tAc",
 						errorTestQuery)

--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -209,7 +209,7 @@ var _ = BeforeEach(func() {
 			_, _ = fmt.Fprintf(&buf, "Error tailing logs, dumping operator logs: %v\n", err)
 		}
 	}()
-	DeferCleanup(func(ctx SpecContext) {
+	DeferCleanup(func(_ SpecContext) {
 		if CurrentSpecReport().Failed() {
 			specName := CurrentSpecReport().FullText()
 			capLines := 10

--- a/tests/e2e/tablespaces_test.go
+++ b/tests/e2e/tablespaces_test.go
@@ -95,7 +95,7 @@ var _ = Describe("Tablespaces tests", Label(tests.LabelTablespaces,
 			Expect(err).ToNot(HaveOccurred())
 		}()
 
-		DeferCleanup(func(ctx SpecContext) {
+		DeferCleanup(func(_ SpecContext) {
 			if CurrentSpecReport().Failed() {
 				specName := CurrentSpecReport().FullText()
 				capLines := 10


### PR DESCRIPTION
golangci-lint version `1.56.1` has improved the `revive` checks.
Running the linter now results in many `unused-parameter: parameter '<>' seems to be unused, consider removing or renaming it as _ (revive)`, this patch aims to fix those complaints
