### PR TITLE
feat: multi-arch in-place update of the operator

### DIFF
--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -684,6 +684,16 @@ type AvailableArchitecture struct {
 	Hash string `json:"hash"`
 }
 
+// GetAvailableArchitecture returns an AvailableArchitecture given it's name. It returns nil if it's not found.
+func (status *ClusterStatus) GetAvailableArchitecture(archName string) *AvailableArchitecture {
+	for _, architecture := range status.AvailableArchitectures {
+		if architecture.GoArch == archName {
+			return &architecture
+		}
+	}
+	return nil
+}
+
 // ClusterStatus defines the observed state of Cluster
 type ClusterStatus struct {
 	// The total number of PVC Groups detected in the cluster. It may differ from the number of existing instance pods.

--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -505,7 +505,7 @@ const (
 	PhaseUnrecoverable = "Cluster is in an unrecoverable state, needs manual intervention"
 
 	// PhaseArchitectureBinaryMissing is the error phase describing a missing architecture
-	PhaseArchitectureBinaryMissing = "Cluster cannot execute instance upgrade due to missing architecture binary"
+	PhaseArchitectureBinaryMissing = "Cluster cannot execute instance online upgrade due to missing architecture binary"
 
 	// PhaseWaitingForInstancesToBeActive is a waiting phase that is triggered when an instance pod is not active
 	PhaseWaitingForInstancesToBeActive = "Waiting for the instances to become active"

--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -504,6 +504,9 @@ const (
 	// PhaseUnrecoverable for an unrecoverable cluster
 	PhaseUnrecoverable = "Cluster is in an unrecoverable state, needs manual intervention"
 
+	// PhaseArchitectureBinaryMissing is the error phase describing a missing architecture
+	PhaseArchitectureBinaryMissing = "Cluster cannot execute instance upgrade due to missing architecture binary"
+
 	// PhaseWaitingForInstancesToBeActive is a waiting phase that is triggered when an instance pod is not active
 	PhaseWaitingForInstancesToBeActive = "Waiting for the instances to become active"
 

--- a/api/v1/cluster_types_test.go
+++ b/api/v1/cluster_types_test.go
@@ -1189,3 +1189,28 @@ var _ = Describe("SynchronizeReplicasConfiguration", func() {
 		})
 	})
 })
+
+var _ = Describe("AvailableArchitectures", func() {
+	cluster := Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "clustername",
+		},
+		Status: ClusterStatus{
+			AvailableArchitectures: []AvailableArchitecture{
+				{
+					GoArch: "amd64",
+					Hash:   "precalculatedHash",
+				},
+			},
+		},
+	}
+	It("returns an availableArchitecture given it's name", func() {
+		availableArch := cluster.Status.GetAvailableArchitecture("amd64")
+		Expect(availableArch.GoArch).To(BeEquivalentTo("amd64"))
+		Expect(availableArch.Hash).To(BeEquivalentTo("precalculatedHash"))
+	})
+	It("returns nil if an availableArchitecture is not found", func() {
+		availableArch := cluster.Status.GetAvailableArchitecture("arm64")
+		Expect(availableArch).To(BeNil())
+	})
+})

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -146,6 +146,9 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	if errors.Is(err, ErrNextLoop) {
 		return result, nil
 	}
+	if errors.Is(err, utils.ErrTerminateLoop) {
+		return ctrl.Result{}, nil
+	}
 	return result, err
 }
 

--- a/controllers/cluster_status.go
+++ b/controllers/cluster_status.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"runtime"
 	"sort"
 
 	batchv1 "k8s.io/api/batch/v1"
@@ -32,7 +33,6 @@ import (
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/certs"
-	"github.com/cloudnative-pg/cloudnative-pg/pkg/executablehash"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/log"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/postgres"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/reconciler/hibernation"
@@ -311,12 +311,13 @@ func (r *ClusterReconciler) updateResourceStatus(
 	// Set the current hash code of the operator binary inside the status.
 	// This is used by the instance manager to validate if a certain binary is
 	// valid or not
-	var err error
-	cluster.Status.OperatorHash, err = executablehash.Get()
+	currentArch, err := utils.GetAvailableArchitecture(runtime.GOARCH)
 	if err != nil {
 		return err
 	}
+	cluster.Status.OperatorHash = currentArch.GetHash()
 
+	// Set all the architectures available for this cluster inside the status.
 	architectures := utils.GetAvailableArchitectures()
 	availableArchitectures := make([]apiv1.AvailableArchitecture, 0, len(architectures))
 	for _, a := range architectures {

--- a/controllers/cluster_upgrade.go
+++ b/controllers/cluster_upgrade.go
@@ -688,12 +688,11 @@ func (r *ClusterReconciler) upgradeInstanceManager(
 	// We start upgrading the instance managers we have
 	for i := len(podList.Items) - 1; i >= 0; i-- {
 		postgresqlStatus := podList.Items[i]
-		instanceManagerArch := postgresqlStatus.InstanceArch
 		instanceManagerHash := postgresqlStatus.ExecutableHash
 		instanceManagerIsUpgrading := postgresqlStatus.IsInstanceManagerUpgrading
 
 		// Gather the hash of the operator's manager using the current pod architecture
-		targetManager, err := utils.GetAvailableArchitecture(instanceManagerArch)
+		targetManager, err := utils.GetAvailableArchitecture(postgresqlStatus.InstanceArch)
 		if err != nil {
 			return err
 		}
@@ -712,7 +711,7 @@ func (r *ClusterReconciler) upgradeInstanceManager(
 				}
 			}
 
-			err = upgradeInstanceManagerOnPod(ctx, *postgresqlStatus.Pod, targetManager)
+			err = upgradeInstanceManagerOnPod(ctx, postgresqlStatus.Pod, targetManager)
 			if err != nil {
 				enrichedError := fmt.Errorf("while upgrading instance manager on %s (hash: %s): %w",
 					postgresqlStatus.Pod.Name,
@@ -740,7 +739,7 @@ func (r *ClusterReconciler) upgradeInstanceManager(
 // upgradeInstanceManagerOnPod upgrades an instance manager of a Pod via an HTTP PUT request.
 func upgradeInstanceManagerOnPod(
 	ctx context.Context,
-	pod corev1.Pod,
+	pod *corev1.Pod,
 	targetManager *utils.AvailableArchitecture,
 ) error {
 	binaryFileStream, err := targetManager.FileStream()

--- a/controllers/cluster_upgrade.go
+++ b/controllers/cluster_upgrade.go
@@ -703,8 +703,8 @@ func (r *ClusterReconciler) upgradeInstanceManager(
 			if regErr := r.RegisterPhase(
 				ctx,
 				cluster,
-				apiv1.PhaseUnrecoverable,
-				"requested an invalid architecture, please schedule the instance on an available architecture",
+				apiv1.PhaseArchitectureBinaryMissing,
+				fmt.Sprintf("encountered an error while upgrading the instance manager: %s", err.Error()),
 			); regErr != nil {
 				return regErr
 			}

--- a/controllers/cluster_upgrade.go
+++ b/controllers/cluster_upgrade.go
@@ -691,7 +691,12 @@ func (r *ClusterReconciler) upgradeInstanceManager(
 		instanceManagerHash := postgresqlStatus.ExecutableHash
 		instanceManagerIsUpgrading := postgresqlStatus.IsInstanceManagerUpgrading
 
-		// Gather the hash of the operator's manager using the current pod architecture
+		// Gather the hash of the operator's manager using the current pod architecture.
+		// If one of the pods is requesting an architecture that's not present in the
+		// operator, that means we've upgraded to an image which doesn't support all
+		// the architectures currently being used by this cluster.
+		// In this case we force the reconciliation loop to stop, requiring manual
+		// intervention.
 		targetManager, err := utils.GetAvailableArchitecture(postgresqlStatus.InstanceArch)
 		if err != nil {
 			contextLogger.Error(err, "encountered an error while upgrading the instance manager")

--- a/controllers/cluster_upgrade.go
+++ b/controllers/cluster_upgrade.go
@@ -656,7 +656,7 @@ func (r *ClusterReconciler) upgradePod(
 	return nil
 }
 
-// upgradeInstanceManager upgrades the instance managers of the Pod running in this cluster
+// upgradeInstanceManager upgrades the instance managers of each Pod running in this cluster
 func (r *ClusterReconciler) upgradeInstanceManager(
 	ctx context.Context,
 	cluster *apiv1.Cluster,
@@ -670,7 +670,7 @@ func (r *ClusterReconciler) upgradeInstanceManager(
 	// 1. an instance manager which doesn't support automatic update
 	// 2. an instance manager which isn't working
 	//
-	// In both ways, we are skipping this automatic update and we rely
+	// In both ways, we are skipping this automatic update and relying
 	// on the rollout strategy
 	for i := len(podList.Items) - 1; i >= 0; i-- {
 		postgresqlStatus := podList.Items[i]

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -39,7 +39,7 @@ Please refer to the ["Supported releases"](supported_releases.md) page for detai
 
 ## Container images
 
-The [CloudNativePG community](https://github.com/cloudnative-pg)  maintains
+The [CloudNativePG community](https://github.com/cloudnative-pg) maintains
 container images for both the operator and the operand, that is PostgreSQL.
 
 The CloudNativePG operator container images are [distroless](https://github.com/GoogleContainerTools/distroless)
@@ -51,11 +51,6 @@ on multiple architectures, directly from the
 [`postgres-containers` project's GitHub Container Registry](https://github.com/cloudnative-pg/postgres-containers/pkgs/container/postgresql).
 
 Additionally, the Community provides images for the [PostGIS extension](postgis.md).
-
-!!! Warning
-    CloudNativePG requires that all nodes in a Kubernetes cluster have the
-    same CPU architecture, thus a hybrid CPU architecture Kubernetes cluster is not
-    supported.
 
 ## Main features
 

--- a/docs/src/installation_upgrade.md
+++ b/docs/src/installation_upgrade.md
@@ -204,10 +204,6 @@ The in-place upgrade process will not change the init container image inside the
 Pods. Therefore, the Pod definition will not reflect the current version of the
 operator.
 
-!!! Important
-    This feature requires that all pods (operators and operands) run on the
-    same platform/architecture (for example, all `linux/amd64`).
-
 ### Compatibility among versions
 
 CloudNativePG follows semantic versioning. Every release of the

--- a/pkg/executablehash/executablehash.go
+++ b/pkg/executablehash/executablehash.go
@@ -36,8 +36,8 @@ func Stream() (io.ReadCloser, error) {
 	return os.Open(processBinaryFileName) // #nosec
 }
 
-// streamByName opens a stream reading from an executable given its name
-func streamByName(name string) (io.ReadCloser, error) {
+// StreamByName opens a stream reading from an executable given its name
+func StreamByName(name string) (io.ReadCloser, error) {
 	return os.Open(name) // #nosec
 }
 
@@ -73,7 +73,7 @@ func Get() (string, error) {
 
 // GetByName gets the hashcode of a binary given its filename
 func GetByName(name string) (string, error) {
-	binaryFileStream, err := streamByName(name)
+	binaryFileStream, err := StreamByName(name)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/management/upgrade/suite_test.go
+++ b/pkg/management/upgrade/suite_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright The CloudNativePG Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package upgrade
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestCatalog(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "in-place upgrade test suite")
+}

--- a/pkg/management/upgrade/upgrade.go
+++ b/pkg/management/upgrade/upgrade.go
@@ -182,7 +182,7 @@ func validateInstanceManagerHash(
 
 // reloadInstanceManager gracefully stops the log collection process and then
 // replace this process with a new one executing the new binary.
-// This function never return in case of success.
+// This function never returns in case of success.
 func reloadInstanceManager() error {
 	log.Info("Replacing current instance")
 	err := syscall.Exec(os.Args[0], os.Args, os.Environ()) // #nosec

--- a/pkg/management/upgrade/upgrade.go
+++ b/pkg/management/upgrade/upgrade.go
@@ -69,14 +69,21 @@ func FromReader(
 				"name", updatedInstanceManager.Name(), "err", err)
 		}
 	}()
+	// Gather the status of the instance
+	instanceStatus, err := instance.GetStatus()
+	if err != nil {
+		return fmt.Errorf("while retrieving instance's status: %w", err)
+	}
 
 	// Read the new instance manager version
 	newHash, err := downloadAndCloseInstanceManagerBinary(updatedInstanceManager, r)
 	if err != nil {
 		return fmt.Errorf("while reading new instance manager binary: %w", err)
 	}
+
 	// Validate the hash of this instance manager
-	if err := validateInstanceManagerHash(typedClient, instance.ClusterName, instance.Namespace, newHash); err != nil {
+	if err := validateInstanceManagerHash(typedClient, instance.ClusterName, instance.Namespace,
+		instanceStatus.InstanceArch, newHash); err != nil {
 		return fmt.Errorf("while validating instance manager binary: %w", err)
 	}
 
@@ -144,9 +151,10 @@ func downloadAndCloseInstanceManagerBinary(dst *os.File, src io.Reader) (string,
 // It returns any errors during execution, or nil if the hash is fine
 func validateInstanceManagerHash(
 	typedClient client.Client,
-	clusterName string,
-	namespace string,
-	hashCode string,
+	clusterName,
+	namespace,
+	instanceArch,
+	newHashCode string,
 ) error {
 	var cluster apiv1.Cluster
 
@@ -158,9 +166,14 @@ func validateInstanceManagerHash(
 		return err
 	}
 
-	if cluster.Status.OperatorHash != hashCode {
+	availableArch := cluster.Status.GetAvailableArchitecture(instanceArch)
+	if availableArch == nil {
+		return fmt.Errorf("missing architecture %s", instanceArch)
+	}
+
+	if availableArch.Hash != newHashCode {
 		log.Warning("Received invalid version of the instance manager",
-			"hashCode", hashCode)
+			"hashCode", newHashCode)
 		return ErrorInvalidInstanceManagerBinary
 	}
 

--- a/pkg/management/upgrade/upgrade_test.go
+++ b/pkg/management/upgrade/upgrade_test.go
@@ -1,0 +1,100 @@
+/*
+Copyright The CloudNativePG Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package upgrade
+
+import (
+	"context"
+	"errors"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	schemeBuilder "github.com/cloudnative-pg/cloudnative-pg/internal/scheme"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("validateInstanceManagerHash", func() {
+	const (
+		clusterName  = "test-cluster"
+		namespace    = "test-namespace"
+		instanceArch = "amd64"
+		hash         = "precalculatedHash"
+	)
+	var (
+		ctx        context.Context
+		fakeClient client.Client
+		cluster    *apiv1.Cluster
+	)
+	BeforeEach(func() {
+		fakeClient = fake.NewClientBuilder().WithScheme(schemeBuilder.BuildWithAllKnownScheme()).Build()
+
+		cluster = &apiv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      clusterName,
+				Namespace: namespace,
+			},
+			Status: apiv1.ClusterStatus{
+				AvailableArchitectures: []apiv1.AvailableArchitecture{
+					{
+						GoArch: instanceArch,
+						Hash:   hash,
+					},
+				},
+			},
+		}
+		_ = fakeClient.Create(ctx, cluster)
+	})
+
+	It("succeeds", func() {
+		err := validateInstanceManagerHash(
+			fakeClient,
+			clusterName,
+			namespace,
+			instanceArch,
+			hash,
+		)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("fails when the requested arch is missing", func() {
+		err := validateInstanceManagerHash(
+			fakeClient,
+			clusterName,
+			namespace,
+			"arm64",
+			"arm64hash",
+		)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(Equal("missing architecture arm64"))
+	})
+
+	It("fails when the hash doesn't match", func() {
+		err := validateInstanceManagerHash(
+			fakeClient,
+			clusterName,
+			namespace,
+			instanceArch,
+			"differentHash",
+		)
+		Expect(err).To(HaveOccurred())
+		Expect(errors.Is(err, ErrorInvalidInstanceManagerBinary)).To(BeTrue())
+	})
+})

--- a/pkg/utils/discovery.go
+++ b/pkg/utils/discovery.go
@@ -18,6 +18,7 @@ package utils
 
 import (
 	"fmt"
+	"io"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -83,6 +84,11 @@ func (arch *AvailableArchitecture) calculateHash() {
 	}
 
 	arch.hash = hash
+}
+
+// FileStream opens a stream reading from the manager's binary
+func (arch *AvailableArchitecture) FileStream() (io.ReadCloser, error) {
+	return executablehash.StreamByName(arch.binaryPath)
 }
 
 // availableArchitectures stores the result of DetectAvailableArchitectures function
@@ -226,6 +232,16 @@ func DetectSeccompSupport(client discovery.DiscoveryInterface) (err error) {
 
 // GetAvailableArchitectures returns the available instance's architectures
 func GetAvailableArchitectures() []*AvailableArchitecture { return availableArchitectures }
+
+// GetAvailableArchitecture returns an available architecture given its goArch
+func GetAvailableArchitecture(goArch string) (*AvailableArchitecture, error) {
+	for _, a := range availableArchitectures {
+		if a.GoArch == goArch {
+			return a, nil
+		}
+	}
+	return nil, fmt.Errorf("invalid architecture: %s", goArch)
+}
 
 // detectAvailableArchitectures detects the architectures available in a given path
 func detectAvailableArchitectures(filepathGlob string) error {

--- a/pkg/utils/discovery_test.go
+++ b/pkg/utils/discovery_test.go
@@ -247,6 +247,7 @@ var _ = Describe("AvailableArchitecture", func() {
 
 		AfterEach(func() {
 			Expect(os.RemoveAll(tempDir)).To(Succeed())
+			availableArchitectures = nil
 		})
 
 		It("shouldn't find available architectures", func() {
@@ -256,6 +257,7 @@ var _ = Describe("AvailableArchitecture", func() {
 
 			err = detectAvailableArchitectures(filepath.Join(tempDir, "manager_*"))
 			Expect(err).ToNot(HaveOccurred())
+			Expect(availableArchitectures).To(BeNil())
 
 			architectures := GetAvailableArchitectures()
 			Expect(architectures).To(BeEmpty())
@@ -270,6 +272,7 @@ var _ = Describe("AvailableArchitecture", func() {
 
 			err = detectAvailableArchitectures(filepath.Join(tempDir, "manager_*"))
 			Expect(err).ToNot(HaveOccurred())
+			Expect(availableArchitectures).To(HaveLen(2))
 
 			Eventually(func(g Gomega) {
 				architectures := GetAvailableArchitectures()
@@ -279,6 +282,32 @@ var _ = Describe("AvailableArchitecture", func() {
 					g.Expect(a.GetHash()).ToNot(BeEmpty())
 				}
 			}).Should(Succeed())
+		})
+	})
+
+	Describe("GetAvailableArchitecture", Ordered, func() {
+		BeforeAll(func() {
+			tempDir, err := os.MkdirTemp("", "test")
+			Expect(err).NotTo(HaveOccurred())
+			DeferCleanup(func() {
+				Expect(os.RemoveAll(tempDir)).To(Succeed())
+				availableArchitectures = nil
+			})
+			Expect(os.WriteFile(filepath.Join(tempDir, "manager_amd64"), []byte("amd64"), 0o600)).To(Succeed())
+			err = detectAvailableArchitectures(filepath.Join(tempDir, "manager_*"))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(availableArchitectures).To(HaveLen(1))
+		})
+
+		It("should retrieve an existing available architecture", func() {
+			availableArch, err := GetAvailableArchitecture("amd64")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(availableArch.GoArch).To(BeEquivalentTo("amd64"))
+		})
+		It("should fail when retrieving an architecture that doesn't exist", func() {
+			availableArch, err := GetAvailableArchitecture("arm64")
+			Expect(err).To(HaveOccurred())
+			Expect(availableArch).To(BeNil())
 		})
 	})
 })

--- a/pkg/utils/reconciliation.go
+++ b/pkg/utils/reconciliation.go
@@ -23,3 +23,6 @@ import (
 // ErrNextLoop is not a real error. It forces the current reconciliation loop to stop
 // and return the associated Result object
 var ErrNextLoop = errors.New("stop this loop and return the associated Result object")
+
+// ErrTerminateLoop is not a real error. It forces the current reconciliation loop to stop
+var ErrTerminateLoop = errors.New("stop this loop and do not requeue")


### PR DESCRIPTION
From the catalog of all the available architectures contained in the running operator image, retrieve the matching architecture's binary during in-place updates, enabling the operator to inject the correct binary in any Pod having a supported architecture.

Closes #3868 
Closes #3717 