### PR TITLE
chore: use cluster reference while creating instance volumes

### DIFF
--- a/pkg/specs/jobs.go
+++ b/pkg/specs/jobs.go
@@ -334,7 +334,7 @@ func createPrimaryJob(cluster apiv1.Cluster, nodeSerial int, role jobRole, initC
 							SecurityContext: CreateContainerSecurityContext(cluster.GetSeccompProfile()),
 						},
 					},
-					Volumes: createPostgresVolumes(cluster, instanceName),
+					Volumes: createPostgresVolumes(&cluster, instanceName),
 					SecurityContext: CreatePodSecurityContext(
 						cluster.GetSeccompProfile(),
 						cluster.GetPostgresUID(),

--- a/pkg/specs/pods.go
+++ b/pkg/specs/pods.go
@@ -167,7 +167,7 @@ func CreateClusterPodSpec(
 		},
 		SchedulerName: cluster.Spec.SchedulerName,
 		Containers:    createPostgresContainers(cluster, envConfig),
-		Volumes:       createPostgresVolumes(cluster, podName),
+		Volumes:       createPostgresVolumes(&cluster, podName),
 		SecurityContext: CreatePodSecurityContext(
 			cluster.GetSeccompProfile(),
 			cluster.GetPostgresUID(),

--- a/pkg/specs/volumes.go
+++ b/pkg/specs/volumes.go
@@ -88,7 +88,7 @@ func SnapshotBackupNameForTablespace(backupName, tablespaceName string) string {
 	return backupName + apiv1.TablespaceVolumeInfix + convertPostgresIDToK8sName(tablespaceName)
 }
 
-func createPostgresVolumes(cluster apiv1.Cluster, podName string) []corev1.Volume {
+func createPostgresVolumes(cluster *apiv1.Cluster, podName string) []corev1.Volume {
 	result := []corev1.Volume{
 		{
 			Name: "pgdata",
@@ -293,7 +293,7 @@ func createPostgresVolumeMounts(cluster apiv1.Cluster) []corev1.VolumeMount {
 	// we should create volumeMounts in fixed sequence as podSpec will store it in annotation and
 	// later it will be  retrieved to do deepEquals
 	if cluster.ContainsTablespaces() {
-		tbsNames := getSortedTablespaceList(cluster)
+		tbsNames := getSortedTablespaceList(&cluster)
 		for i := range tbsNames {
 			volumeMounts = append(volumeMounts,
 				corev1.VolumeMount{
@@ -306,7 +306,7 @@ func createPostgresVolumeMounts(cluster apiv1.Cluster) []corev1.VolumeMount {
 	return volumeMounts
 }
 
-func getSortedTablespaceList(cluster apiv1.Cluster) []string {
+func getSortedTablespaceList(cluster *apiv1.Cluster) []string {
 	// Try to get a fix order of name
 	tbsNames := make([]string, len(cluster.Spec.Tablespaces))
 	i := 0
@@ -318,7 +318,7 @@ func getSortedTablespaceList(cluster apiv1.Cluster) []string {
 	return tbsNames
 }
 
-func createEphemeralVolume(cluster apiv1.Cluster) corev1.Volume {
+func createEphemeralVolume(cluster *apiv1.Cluster) corev1.Volume {
 	scratchVolumeSource := corev1.VolumeSource{}
 	if cluster.Spec.EphemeralVolumeSource != nil {
 		scratchVolumeSource.Ephemeral = cluster.Spec.EphemeralVolumeSource
@@ -333,7 +333,7 @@ func createEphemeralVolume(cluster apiv1.Cluster) corev1.Volume {
 	}
 }
 
-func createProjectedVolume(cluster apiv1.Cluster) corev1.Volume {
+func createProjectedVolume(cluster *apiv1.Cluster) corev1.Volume {
 	return corev1.Volume{
 		Name: "projected",
 		VolumeSource: corev1.VolumeSource{

--- a/pkg/specs/volumes_test.go
+++ b/pkg/specs/volumes_test.go
@@ -386,7 +386,7 @@ var _ = DescribeTable("test creation of volume mounts",
 
 var _ = DescribeTable("test creation of volumes",
 	func(cluster apiv1.Cluster, volumes []corev1.Volume) {
-		vols := createPostgresVolumes(cluster, "pod-1")
+		vols := createPostgresVolumes(&cluster, "pod-1")
 		Expect(vols).NotTo(BeEmpty())
 		for _, v := range volumes {
 			Expect(vols).To(ContainElement(v))
@@ -483,7 +483,7 @@ var _ = Describe("createEphemeralVolume", func() {
 	})
 
 	It("should create an emptyDir volume by default", func() {
-		ephemeralVolume := createEphemeralVolume(cluster)
+		ephemeralVolume := createEphemeralVolume(&cluster)
 		Expect(ephemeralVolume.Name).To(Equal("scratch-data"))
 		Expect(ephemeralVolume.VolumeSource.EmptyDir).NotTo(BeNil())
 	})
@@ -498,7 +498,7 @@ var _ = Describe("createEphemeralVolume", func() {
 			},
 		}
 
-		ephemeralVolume := createEphemeralVolume(cluster)
+		ephemeralVolume := createEphemeralVolume(&cluster)
 
 		Expect(ephemeralVolume.Name).To(Equal("scratch-data"))
 		Expect(ephemeralVolume.EmptyDir).To(BeNil())
@@ -512,7 +512,7 @@ var _ = Describe("createEphemeralVolume", func() {
 			TemporaryData: &quantity,
 		}
 
-		ephemeralVolume := createEphemeralVolume(cluster)
+		ephemeralVolume := createEphemeralVolume(&cluster)
 
 		Expect(ephemeralVolume.Name).To(Equal("scratch-data"))
 		Expect(*ephemeralVolume.VolumeSource.EmptyDir.SizeLimit).To(Equal(quantity))


### PR DESCRIPTION
This patch aims to reduce memory consumption by using the cluster reference instead of value.