### PR TITLE
fix: avoid logging the entire primary pod object

### DIFF
--- a/controllers/replicas.go
+++ b/controllers/replicas.go
@@ -207,7 +207,7 @@ func (r *ClusterReconciler) setPrimaryOnSchedulableNode(
 			// e.g. we want all instances to be moved to a schedulable node before triggering the switchover
 			len(podsOnOtherNodes.Items) < cluster.Spec.Instances-1) {
 		contextLogger.Info("Current primary is running on unschedulable node and something is already in progress",
-			"currentPrimary", primaryPod,
+			"currentPrimary", primaryPod.Pod.Name,
 			"podsOnOtherNodes", len(podsOnOtherNodes.Items),
 			"instances", cluster.Spec.Instances,
 			"readyInstances", cluster.Status.ReadyInstances,


### PR DESCRIPTION
For an INFO level log we were logging the full pod object with all the 
information inside resulting in a big log that turns out to be totally 
useless since the main message was lost.

Closes #3856