### PR TITLE
feat: support --min-trunk-size option for barman-cloud-backup

### DIFF
--- a/.wordlist-en-custom.txt
+++ b/.wordlist-en-custom.txt
@@ -831,6 +831,7 @@ metricNameKS
 microservice
 microservices
 microsoft
+minChunkSize
 minSyncReplicas
 minikube
 minio

--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -2091,6 +2091,14 @@ type DataBackupConfiguration struct {
 	// possible. `false` by default.
 	// +optional
 	ImmediateCheckpoint bool `json:"immediateCheckpoint,omitempty"`
+
+	//  The minimum size of a single upload part when uploading to
+	//  cloud storage, if not specified, default: 5MB for aws-s3, 64KB for
+	//  azure-blob-storage, not applicable for google-cloud-storage.
+	//  More information see min-chunk-size option in
+	//  https://docs.pgbarman.org/release/3.10.0/barman-cloud-backup.1.html
+	//  +optional
+	MinChunkSize string `json:"minChunkSize,omitempty"`
 }
 
 // S3Credentials is the type for the credentials to be used to upload

--- a/api/v1/cluster_webhook.go
+++ b/api/v1/cluster_webhook.go
@@ -1979,6 +1979,25 @@ func (r *Cluster) validateBackupConfiguration() field.ErrorList {
 		}
 	}
 
+	if r.Spec.Backup.BarmanObjectStore.Data == nil {
+		return allErrors
+	}
+
+	dataConfiguration := r.Spec.Backup.BarmanObjectStore.Data
+	if dataConfiguration.MinChunkSize != "" {
+		if _, err := resource.ParseQuantity(dataConfiguration.MinChunkSize); err != nil {
+			allErrors = append(allErrors, field.Invalid(
+				field.NewPath(
+					"spec",
+					"backupConfiguration",
+					"barmanObjectStore",
+					"data",
+					"minChunkSize"),
+				r.Spec.Backup.BarmanObjectStore.Data.MinChunkSize,
+				"Size value isn't valid, should be a valid quantity"))
+		}
+	}
+
 	return allErrors
 }
 

--- a/api/v1/cluster_webhook_test.go
+++ b/api/v1/cluster_webhook_test.go
@@ -2302,6 +2302,90 @@ var _ = Describe("Backup validation", func() {
 		err := cluster.validateBackupConfiguration()
 		Expect(err).To(HaveLen(2))
 	})
+
+	It("complain if minChunkSize is not correct", func() {
+		cluster := &Cluster{
+			Spec: ClusterSpec{
+				Backup: &BackupConfiguration{
+					BarmanObjectStore: &BarmanObjectStoreConfiguration{
+						BarmanCredentials: BarmanCredentials{
+							AWS: &S3Credentials{
+								InheritFromIAMRole: true,
+							},
+						},
+						Data: &DataBackupConfiguration{
+							MinChunkSize: "5MB",
+						},
+					},
+				},
+			},
+		}
+		err := cluster.validateBackupConfiguration()
+		Expect(err).To(HaveLen(1))
+	})
+
+	It("not complain if minChunkSize is using integer", func() {
+		cluster := &Cluster{
+			Spec: ClusterSpec{
+				Backup: &BackupConfiguration{
+					BarmanObjectStore: &BarmanObjectStoreConfiguration{
+						BarmanCredentials: BarmanCredentials{
+							AWS: &S3Credentials{
+								InheritFromIAMRole: true,
+							},
+						},
+						Data: &DataBackupConfiguration{
+							MinChunkSize: "5",
+						},
+					},
+				},
+			},
+		}
+		err := cluster.validateBackupConfiguration()
+		Expect(err).To(BeEmpty())
+	})
+
+	It("not complain if minChunkSize is using 1000 based integer", func() {
+		cluster := &Cluster{
+			Spec: ClusterSpec{
+				Backup: &BackupConfiguration{
+					BarmanObjectStore: &BarmanObjectStoreConfiguration{
+						BarmanCredentials: BarmanCredentials{
+							AWS: &S3Credentials{
+								InheritFromIAMRole: true,
+							},
+						},
+						Data: &DataBackupConfiguration{
+							MinChunkSize: "5M",
+						},
+					},
+				},
+			},
+		}
+		err := cluster.validateBackupConfiguration()
+		Expect(err).To(BeEmpty())
+	})
+
+	It("not complain if minChunkSize is using 1024 based integer", func() {
+		cluster := &Cluster{
+			Spec: ClusterSpec{
+				Backup: &BackupConfiguration{
+					BarmanObjectStore: &BarmanObjectStoreConfiguration{
+						BarmanCredentials: BarmanCredentials{
+							AWS: &S3Credentials{
+								InheritFromIAMRole: true,
+							},
+						},
+						Data: &DataBackupConfiguration{
+							MinChunkSize: "5Ki",
+						},
+					},
+				},
+			},
+		}
+		err := cluster.validateBackupConfiguration()
+		Expect(err).To(BeEmpty())
+	})
 })
 
 var _ = Describe("Default monitoring queries", func() {

--- a/config/crd/bases/postgresql.cnpg.io_clusters.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_clusters.yaml
@@ -1059,6 +1059,13 @@ spec:
                             format: int32
                             minimum: 1
                             type: integer
+                          minChunkSize:
+                            description: 'The minimum size of a single upload part
+                              when uploading to cloud storage, if not specified, default:
+                              5MB for aws-s3, 64KB for azure-blob-storage, not applicable
+                              for google-cloud-storage. More information see min-chunk-size
+                              option in https://docs.pgbarman.org/release/3.10.0/barman-cloud-backup.1.html'
+                            type: string
                         type: object
                       destinationPath:
                         description: The path where to store the backup (i.e. s3://bucket/path/to/folder)
@@ -2293,6 +2300,13 @@ spec:
                               format: int32
                               minimum: 1
                               type: integer
+                            minChunkSize:
+                              description: 'The minimum size of a single upload part
+                                when uploading to cloud storage, if not specified,
+                                default: 5MB for aws-s3, 64KB for azure-blob-storage,
+                                not applicable for google-cloud-storage. More information
+                                see min-chunk-size option in https://docs.pgbarman.org/release/3.10.0/barman-cloud-backup.1.html'
+                              type: string
                           type: object
                         destinationPath:
                           description: The path where to store the backup (i.e. s3://bucket/path/to/folder)

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -1,10 +1,10 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
   name: manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: manager
 subjects:
 - kind: ServiceAccount

--- a/docs/src/cloudnative-pg.v1.md
+++ b/docs/src/cloudnative-pg.v1.md
@@ -2195,6 +2195,17 @@ used, meaning PostgreSQL will complete the checkpoint as soon as
 possible. <code>false</code> by default.</p>
 </td>
 </tr>
+<tr><td><code>minChunkSize</code><br/>
+<i>string</i>
+</td>
+<td>
+   <p>The minimum size of a single upload part when uploading to
+cloud storage, if not specified, default: 5M for aws-s3, 64K for
+azure-blob-storage, not applicable for google-cloud-storage.
+More information see min-chunk-size option in
+https://docs.pgbarman.org/release/3.10.0/barman-cloud-backup.1.html</p>
+</td>
+</tr>
 </tbody>
 </table>
 

--- a/pkg/management/barman/capabilities/detect.go
+++ b/pkg/management/barman/capabilities/detect.go
@@ -47,8 +47,12 @@ func Detect() (*Capabilities, error) {
 	newCapabilities.Version = version
 
 	switch {
+	case version.GE(semver.Version{Major: 3, Minor: 10}):
+		// The --min-chunk-size option was added to Barman in version 3.10
+		newCapabilities.HasMinChunkSize = true
+		fallthrough
 	case version.GE(semver.Version{Major: 3, Minor: 4}):
-		// The --name flag was added to Barman in version 3.3 but we also require the
+		// The --name flag was added to Barman in version 3.3, but we also require the
 		// barman-cloud-backup-show command which was not added until Barman version 3.4
 		newCapabilities.hasName = true
 		fallthrough

--- a/pkg/management/barman/capabilities/type.go
+++ b/pkg/management/barman/capabilities/type.go
@@ -37,6 +37,7 @@ type Capabilities struct {
 	HasSnappy                  bool
 	HasErrorCodesForWALRestore bool
 	HasAzureManagedIdentity    bool
+	HasMinChunkSize            bool
 }
 
 // ShouldExecuteBackupWithName returns true if the new backup logic should be executed

--- a/pkg/management/postgres/backup.go
+++ b/pkg/management/postgres/backup.go
@@ -134,6 +134,19 @@ func getDataConfiguration(
 			strconv.Itoa(int(*configuration.Data.Jobs)))
 	}
 
+	// barman-cloud-backup requires the min-chunk-size to be in format of number or number with unit (B, KB, MB, GB, TB)
+	if configuration.Data.MinChunkSize != "" {
+		if !capabilities.HasMinChunkSize {
+			return nil, fmt.Errorf("minChunkSize configuration is not supported in Barman %v",
+				capabilities.Version)
+		}
+
+		options = append(
+			options,
+			"--min-chunk-size",
+			fmt.Sprintf("%vB", configuration.Data.MinChunkSize))
+	}
+
 	return options, nil
 }
 

--- a/tests/e2e/fixtures/backup/azure_blob/cluster-with-backup-azure-blob.yaml.template
+++ b/tests/e2e/fixtures/backup/azure_blob/cluster-with-backup-azure-blob.yaml.template
@@ -46,3 +46,4 @@ spec:
         compression: gzip
       data:
         immediateCheckpoint: true
+        minChunkSize: 2M

--- a/tests/e2e/fixtures/backup/azurite/cluster-backup.yaml.template
+++ b/tests/e2e/fixtures/backup/azurite/cluster-backup.yaml.template
@@ -26,3 +26,4 @@ spec:
         compression: gzip
       data:
         immediateCheckpoint: true
+        minChunkSize: 64K

--- a/tests/e2e/fixtures/backup/backup_restore_safety/cluster-with-backup-minio.yaml.template
+++ b/tests/e2e/fixtures/backup/backup_restore_safety/cluster-with-backup-minio.yaml.template
@@ -56,6 +56,7 @@ spec:
           compression: gzip
         data:
           immediateCheckpoint: true
+          minChunkSize: 10M
         tags:
           retention: "30days"
         historyTags:

--- a/tests/e2e/fixtures/backup/minio/cluster-with-backup-minio.yaml.template
+++ b/tests/e2e/fixtures/backup/minio/cluster-with-backup-minio.yaml.template
@@ -63,6 +63,7 @@ spec:
           compression: gzip
         data:
           immediateCheckpoint: true
+          minChunkSize: 10M
         tags:
           retention: "30days"
         historyTags:


### PR DESCRIPTION
This patch expose the configuration of  `--min-trunk-size`, 
which will specify MIN_CHUNK_SIZE to barman-cloud-backup and
define the min size for the part file generated under temp directory. 
If not specified, 5MB for aws-s3, 64KB for azure-blob-storage, and 
not applicable for google-cloud-storage

Closes: #3863 