### PR TITLE
fix: add operator-sdk to the renovate updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -92,6 +92,18 @@
       "versioningTemplate": "loose",
       "depNameTemplate": "getwoke/woke",
     }, {
+      // Update the oeprator-sdk in the Makefile
+      "fileMatch": [
+        "^Makefile$",
+      ],
+      "matchStrings": [
+        "OPERATOR_SDK_VERSION \\?= (?<currentValue>.*?)\\n"
+      ],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "operator-framework/operator-sdk",
+      "versioningTemplate": "loose",
+      "extractVersionTemplate": "^v(?<version>\\d+\\.\\d+\\.\\d+)"
+    },{
       // We want a PR to bump Default Container Images versions.
       "fileMatch": [
         "^pkg\\/versions\\/versions\\.go$",


### PR DESCRIPTION
We were missing operator-sdk in renovate so we were not updating the version to the latest one.

Closes #3866 