### PR TITLE
fix: reduce the time required for the tablespaces test

### DIFF
--- a/tests/e2e/backup_restore_test.go
+++ b/tests/e2e/backup_restore_test.go
@@ -891,6 +891,9 @@ var _ = Describe("Clusters Recovery From Barman Object Store", Label(tests.Label
 				testUtils.ExecuteBackup(namespace, sourceTakeFirstBackupFileMinio, false,
 					testTimeouts[testUtils.BackupIsReady], env)
 				AssertBackupConditionInClusterStatus(namespace, clusterName)
+
+				// TODO: this is to force a CHECKPOINT when we run the backup on standby.
+				// This should be better handled inside ExecuteBackup
 				AssertArchiveWalOnMinio(namespace, clusterName, clusterName)
 
 				latestTar := minioPath(clusterName, "data.tar")

--- a/tests/e2e/backup_restore_test.go
+++ b/tests/e2e/backup_restore_test.go
@@ -891,6 +891,8 @@ var _ = Describe("Clusters Recovery From Barman Object Store", Label(tests.Label
 				testUtils.ExecuteBackup(namespace, sourceTakeFirstBackupFileMinio, false,
 					testTimeouts[testUtils.BackupIsReady], env)
 				AssertBackupConditionInClusterStatus(namespace, clusterName)
+				AssertArchiveWalOnMinio(namespace, clusterName, clusterName)
+
 				latestTar := minioPath(clusterName, "data.tar")
 				Eventually(func() (int, error) {
 					return testUtils.CountFilesOnMinio(namespace, minioClientName, latestTar)

--- a/tests/e2e/tablespaces_test.go
+++ b/tests/e2e/tablespaces_test.go
@@ -306,6 +306,7 @@ var _ = Describe("Tablespaces tests", Label(tests.LabelTablespaces,
 					apiv1.ConditionBackup,
 					&backupCondition.LastTransitionTime,
 				)
+				AssertArchiveWalOnMinio(namespace, clusterName, clusterName)
 				AssertBackupConditionInClusterStatus(namespace, clusterName)
 			})
 
@@ -478,7 +479,7 @@ var _ = Describe("Tablespaces tests", Label(tests.LabelTablespaces,
 					apiv1.BackupMethodVolumeSnapshot,
 				)
 				Expect(err).ToNot(HaveOccurred())
-
+				AssertArchiveWalOnMinio(namespace, clusterName, clusterName)
 				Eventually(func(g Gomega) {
 					backupList, err := env.GetBackupList(namespace)
 					g.Expect(err).ToNot(HaveOccurred())

--- a/tests/e2e/tablespaces_test.go
+++ b/tests/e2e/tablespaces_test.go
@@ -306,7 +306,11 @@ var _ = Describe("Tablespaces tests", Label(tests.LabelTablespaces,
 					apiv1.ConditionBackup,
 					&backupCondition.LastTransitionTime,
 				)
+
+				// TODO: this is to force a CHECKPOINT when we run the backup on standby.
+				// This should be better handled inside ExecuteBackup
 				AssertArchiveWalOnMinio(namespace, clusterName, clusterName)
+
 				AssertBackupConditionInClusterStatus(namespace, clusterName)
 			})
 
@@ -479,7 +483,11 @@ var _ = Describe("Tablespaces tests", Label(tests.LabelTablespaces,
 					apiv1.BackupMethodVolumeSnapshot,
 				)
 				Expect(err).ToNot(HaveOccurred())
+
+				// TODO: this is to force a CHECKPOINT when we run the backup on standby.
+				// This should probably be moved elsewhere
 				AssertArchiveWalOnMinio(namespace, clusterName, clusterName)
+
 				Eventually(func(g Gomega) {
 					backupList, err := env.GetBackupList(namespace)
 					g.Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
With this patch, we make sure that the WAL files are all archived after we take
the backup; this will reduce the amount of time required by the restore process
when the backup is taken from standby, as it will not wait for the WAL files to
be archived on the primary.

The time is reduced from ~9m to ~4m

This patch is a quick fix to improve the time of our tests, but we need to
refactor it in a broader initiative about backup testing E2E test improvements.

Closes #3910 