### PR TITLE
fix: correctly populate barman google capabilities

### DIFF
--- a/pkg/management/barman/capabilities/detect.go
+++ b/pkg/management/barman/capabilities/detect.go
@@ -52,6 +52,10 @@ func Detect() (*Capabilities, error) {
 		// barman-cloud-backup-show command which was not added until Barman version 3.4
 		newCapabilities.hasName = true
 		fallthrough
+	case version.GE(semver.Version{Major: 2, Minor: 19}):
+		// Google Cloud Storage support, added in Barman >= 2.19
+		newCapabilities.HasGoogle = true
+		fallthrough
 	case version.GE(semver.Version{Major: 2, Minor: 18}):
 		// Tags, added in Barman >= 2.18
 		newCapabilities.HasTags = true
@@ -72,10 +76,6 @@ func Detect() (*Capabilities, error) {
 		// Cloud providers support, added in Barman >= 2.13
 		newCapabilities.HasAzure = true
 		newCapabilities.HasS3 = true
-		fallthrough
-	case version.GE(semver.Version{Major: 2, Minor: 19}):
-		// Google Cloud Storage support, added in Barman >= 2.19
-		newCapabilities.HasGoogle = true
 	}
 
 	log.Debug("Detected Barman installation", "newCapabilities", newCapabilities)

--- a/pkg/management/barman/capabilities/detect.go
+++ b/pkg/management/barman/capabilities/detect.go
@@ -31,11 +31,11 @@ var capabilities *Capabilities
 
 // detect barman-cloud executables presence and store the Capabilities
 // of the barman-cloud version it finds
-func detect(version *semver.Version) (*Capabilities, error) {
+func detect(version *semver.Version) *Capabilities {
 	newCapabilities := new(Capabilities)
 	if version == nil {
 		log.Info("Missing Barman Cloud installation in the operand image")
-		return newCapabilities, nil
+		return newCapabilities
 	}
 
 	newCapabilities.Version = version
@@ -74,7 +74,7 @@ func detect(version *semver.Version) (*Capabilities, error) {
 
 	log.Debug("Detected Barman installation", "newCapabilities", newCapabilities)
 
-	return newCapabilities, nil
+	return newCapabilities
 }
 
 // barmanCloudVersionRegex is a regular expression to parse the output of
@@ -117,11 +117,7 @@ func CurrentCapabilities() (*Capabilities, error) {
 		if err != nil {
 			return nil, err
 		}
-		capabilities, err = detect(version)
-		if err != nil {
-			log.Error(err, "Failed to detect Barman capabilities")
-			return nil, err
-		}
+		capabilities = detect(version)
 	}
 
 	return capabilities, nil

--- a/pkg/management/barman/capabilities/detect.go
+++ b/pkg/management/barman/capabilities/detect.go
@@ -31,14 +31,8 @@ var capabilities *Capabilities
 
 // Detect barman-cloud executables presence and store the Capabilities
 // of the barman-cloud version it finds
-func Detect() (*Capabilities, error) {
-	version, err := getBarmanCloudVersion(BarmanCloudWalArchive)
-	if err != nil {
-		return nil, err
-	}
-
+func Detect(version *semver.Version) (*Capabilities, error) {
 	newCapabilities := new(Capabilities)
-
 	if version == nil {
 		log.Info("Missing Barman Cloud installation in the operand image")
 		return newCapabilities, nil
@@ -119,7 +113,11 @@ func getBarmanCloudVersion(command string) (*semver.Version, error) {
 func CurrentCapabilities() (*Capabilities, error) {
 	if capabilities == nil {
 		var err error
-		capabilities, err = Detect()
+		version, err := getBarmanCloudVersion(BarmanCloudWalArchive)
+		if err != nil {
+			return nil, err
+		}
+		capabilities, err = Detect(version)
 		if err != nil {
 			log.Error(err, "Failed to detect Barman capabilities")
 			return nil, err

--- a/pkg/management/barman/capabilities/detect.go
+++ b/pkg/management/barman/capabilities/detect.go
@@ -29,9 +29,9 @@ import (
 // capabilities stores the current Barman capabilities
 var capabilities *Capabilities
 
-// Detect barman-cloud executables presence and store the Capabilities
+// detect barman-cloud executables presence and store the Capabilities
 // of the barman-cloud version it finds
-func Detect(version *semver.Version) (*Capabilities, error) {
+func detect(version *semver.Version) (*Capabilities, error) {
 	newCapabilities := new(Capabilities)
 	if version == nil {
 		log.Info("Missing Barman Cloud installation in the operand image")
@@ -117,7 +117,7 @@ func CurrentCapabilities() (*Capabilities, error) {
 		if err != nil {
 			return nil, err
 		}
-		capabilities, err = Detect(version)
+		capabilities, err = detect(version)
 		if err != nil {
 			log.Error(err, "Failed to detect Barman capabilities")
 			return nil, err

--- a/pkg/management/barman/capabilities/detect_test.go
+++ b/pkg/management/barman/capabilities/detect_test.go
@@ -1,0 +1,119 @@
+/*
+Copyright The CloudNativePG Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package capabilities
+
+import (
+	"github.com/blang/semver"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Correct detecting the barman capabilities", func() {
+	It("All version support in 3.4 and above", func() {
+		version, err := semver.ParseTolerant("3.4.0")
+		Expect(err).ToNot(HaveOccurred())
+		capabilities, _ := Detect(&version)
+		Expect(capabilities).To(Equal(&Capabilities{
+			Version:                    &version,
+			hasName:                    true,
+			HasAzure:                   true,
+			HasS3:                      true,
+			HasGoogle:                  true,
+			HasRetentionPolicy:         true,
+			HasTags:                    true,
+			HasCheckWalArchive:         true,
+			HasSnappy:                  true,
+			HasErrorCodesForWALRestore: true,
+			HasAzureManagedIdentity:    true,
+		}))
+	})
+
+	It("test barman version below 3.4 should has no name backup", func() {
+		version, err := semver.ParseTolerant("3.0.0")
+		Expect(err).ToNot(HaveOccurred())
+		capabilities, _ := Detect(&version)
+		Expect(capabilities).To(Equal(&Capabilities{
+			Version:                    &version,
+			HasAzure:                   true,
+			HasS3:                      true,
+			HasGoogle:                  true,
+			HasRetentionPolicy:         true,
+			HasTags:                    true,
+			HasCheckWalArchive:         true,
+			HasSnappy:                  true,
+			HasErrorCodesForWALRestore: true,
+			HasAzureManagedIdentity:    true,
+		}))
+	})
+
+	It("test barman version below 2.19.0 should has no google credentials ", func() {
+		version, err := semver.ParseTolerant("2.18.0")
+		Expect(err).ToNot(HaveOccurred())
+		capabilities, _ := Detect(&version)
+		Expect(capabilities).To(Equal(&Capabilities{
+			Version:                    &version,
+			HasAzure:                   true,
+			HasS3:                      true,
+			HasRetentionPolicy:         true,
+			HasTags:                    true,
+			HasCheckWalArchive:         true,
+			HasSnappy:                  true,
+			HasErrorCodesForWALRestore: true,
+			HasAzureManagedIdentity:    true,
+		}))
+	})
+
+	// 2.17.0 should NOT support following
+	// google credentials
+	// tag
+	// HasCheckWalArchive
+	// HasSnappy
+	// HasErrorCodesForWALRestore
+	// HasAzureManagedIdentity
+	It("test barman version below 2.18 should not support various options", func() {
+		version, err := semver.ParseTolerant("2.17.0")
+		Expect(err).ToNot(HaveOccurred())
+		capabilities, _ := Detect(&version)
+		Expect(capabilities).To(Equal(&Capabilities{
+			Version:            &version,
+			HasAzure:           true,
+			HasS3:              true,
+			HasRetentionPolicy: true,
+		}))
+	})
+
+	It("test barman version below 2.14.0 should has no HasRetentionPolicy ", func() {
+		version, err := semver.ParseTolerant("2.13.0")
+		Expect(err).ToNot(HaveOccurred())
+		capabilities, _ := Detect(&version)
+		Expect(capabilities).To(Equal(&Capabilities{
+			Version:  &version,
+			HasAzure: true,
+			HasS3:    true,
+		}))
+	})
+
+	It("test barman version below 2.13.0 should has no aws and azure credentials ", func() {
+		version, err := semver.ParseTolerant("2.12.0")
+		Expect(err).ToNot(HaveOccurred())
+		capabilities, _ := Detect(&version)
+		Expect(capabilities).To(Equal(&Capabilities{
+			Version: &version,
+		}))
+	})
+})

--- a/pkg/management/barman/capabilities/detect_test.go
+++ b/pkg/management/barman/capabilities/detect_test.go
@@ -23,11 +23,11 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Correct detecting the barman capabilities", func() {
-	It("All version support in 3.4 and above", func() {
+var _ = Describe("detect capabilities", func() {
+	It("ensures that all capabilities are true for the 3.4 version", func() {
 		version, err := semver.ParseTolerant("3.4.0")
 		Expect(err).ToNot(HaveOccurred())
-		capabilities, _ := detect(&version)
+		capabilities := detect(&version)
 		Expect(capabilities).To(Equal(&Capabilities{
 			Version:                    &version,
 			hasName:                    true,
@@ -43,10 +43,10 @@ var _ = Describe("Correct detecting the barman capabilities", func() {
 		}))
 	})
 
-	It("test barman version below 3.4 should has no name backup", func() {
+	It("ensures that barman versions below 3.4 should has no name backup", func() {
 		version, err := semver.ParseTolerant("3.0.0")
 		Expect(err).ToNot(HaveOccurred())
-		capabilities, _ := detect(&version)
+		capabilities := detect(&version)
 		Expect(capabilities).To(Equal(&Capabilities{
 			Version:                    &version,
 			HasAzure:                   true,
@@ -61,10 +61,10 @@ var _ = Describe("Correct detecting the barman capabilities", func() {
 		}))
 	})
 
-	It("test barman version below 2.19.0 should has no google credentials ", func() {
+	It("test barman versions below 2.19.0 should has no google credentials ", func() {
 		version, err := semver.ParseTolerant("2.18.0")
 		Expect(err).ToNot(HaveOccurred())
-		capabilities, _ := detect(&version)
+		capabilities := detect(&version)
 		Expect(capabilities).To(Equal(&Capabilities{
 			Version:                    &version,
 			HasAzure:                   true,
@@ -78,29 +78,22 @@ var _ = Describe("Correct detecting the barman capabilities", func() {
 		}))
 	})
 
-	// 2.17.0 should NOT support following
-	// google credentials
-	// tag
-	// HasCheckWalArchive
-	// HasSnappy
-	// HasErrorCodesForWALRestore
-	// HasAzureManagedIdentity
-	It("test barman version below 2.18 should not support various options", func() {
+	It("ensures that barmans versions below 2.18.0 only return the expected capabilities", func() {
 		version, err := semver.ParseTolerant("2.17.0")
 		Expect(err).ToNot(HaveOccurred())
-		capabilities, _ := detect(&version)
+		capabilities := detect(&version)
 		Expect(capabilities).To(Equal(&Capabilities{
 			Version:            &version,
 			HasAzure:           true,
 			HasS3:              true,
 			HasRetentionPolicy: true,
-		}))
+		}), "unexpected capabilities set to true")
 	})
 
-	It("test barman version below 2.14.0 should has no HasRetentionPolicy ", func() {
+	It("ensures that barman version below 2.14.0 have no HasRetentionPolicy ", func() {
 		version, err := semver.ParseTolerant("2.13.0")
 		Expect(err).ToNot(HaveOccurred())
-		capabilities, _ := detect(&version)
+		capabilities := detect(&version)
 		Expect(capabilities).To(Equal(&Capabilities{
 			Version:  &version,
 			HasAzure: true,
@@ -108,10 +101,10 @@ var _ = Describe("Correct detecting the barman capabilities", func() {
 		}))
 	})
 
-	It("test barman version below 2.13.0 should has no aws and azure credentials ", func() {
+	It("ensures that barman version below 2.13.0 should have no aws and azure credentials", func() {
 		version, err := semver.ParseTolerant("2.12.0")
 		Expect(err).ToNot(HaveOccurred())
-		capabilities, _ := detect(&version)
+		capabilities := detect(&version)
 		Expect(capabilities).To(Equal(&Capabilities{
 			Version: &version,
 		}))

--- a/pkg/management/barman/capabilities/detect_test.go
+++ b/pkg/management/barman/capabilities/detect_test.go
@@ -61,7 +61,7 @@ var _ = Describe("detect capabilities", func() {
 		}))
 	})
 
-	It("test barman versions below 2.19.0 should has no google credentials ", func() {
+	It("ensures that the barman versions below 2.19.0 have no google credentials support", func() {
 		version, err := semver.ParseTolerant("2.18.0")
 		Expect(err).ToNot(HaveOccurred())
 		capabilities := detect(&version)

--- a/pkg/management/barman/capabilities/detect_test.go
+++ b/pkg/management/barman/capabilities/detect_test.go
@@ -43,7 +43,7 @@ var _ = Describe("detect capabilities", func() {
 		}))
 	})
 
-	It("ensures that barman versions below 3.4 should has no name backup", func() {
+	It("ensures that barman versions below 3.4 have no named backup capabilities", func() {
 		version, err := semver.ParseTolerant("3.0.0")
 		Expect(err).ToNot(HaveOccurred())
 		capabilities := detect(&version)

--- a/pkg/management/barman/capabilities/detect_test.go
+++ b/pkg/management/barman/capabilities/detect_test.go
@@ -27,7 +27,7 @@ var _ = Describe("Correct detecting the barman capabilities", func() {
 	It("All version support in 3.4 and above", func() {
 		version, err := semver.ParseTolerant("3.4.0")
 		Expect(err).ToNot(HaveOccurred())
-		capabilities, _ := Detect(&version)
+		capabilities, _ := detect(&version)
 		Expect(capabilities).To(Equal(&Capabilities{
 			Version:                    &version,
 			hasName:                    true,
@@ -46,7 +46,7 @@ var _ = Describe("Correct detecting the barman capabilities", func() {
 	It("test barman version below 3.4 should has no name backup", func() {
 		version, err := semver.ParseTolerant("3.0.0")
 		Expect(err).ToNot(HaveOccurred())
-		capabilities, _ := Detect(&version)
+		capabilities, _ := detect(&version)
 		Expect(capabilities).To(Equal(&Capabilities{
 			Version:                    &version,
 			HasAzure:                   true,
@@ -64,7 +64,7 @@ var _ = Describe("Correct detecting the barman capabilities", func() {
 	It("test barman version below 2.19.0 should has no google credentials ", func() {
 		version, err := semver.ParseTolerant("2.18.0")
 		Expect(err).ToNot(HaveOccurred())
-		capabilities, _ := Detect(&version)
+		capabilities, _ := detect(&version)
 		Expect(capabilities).To(Equal(&Capabilities{
 			Version:                    &version,
 			HasAzure:                   true,
@@ -88,7 +88,7 @@ var _ = Describe("Correct detecting the barman capabilities", func() {
 	It("test barman version below 2.18 should not support various options", func() {
 		version, err := semver.ParseTolerant("2.17.0")
 		Expect(err).ToNot(HaveOccurred())
-		capabilities, _ := Detect(&version)
+		capabilities, _ := detect(&version)
 		Expect(capabilities).To(Equal(&Capabilities{
 			Version:            &version,
 			HasAzure:           true,
@@ -100,7 +100,7 @@ var _ = Describe("Correct detecting the barman capabilities", func() {
 	It("test barman version below 2.14.0 should has no HasRetentionPolicy ", func() {
 		version, err := semver.ParseTolerant("2.13.0")
 		Expect(err).ToNot(HaveOccurred())
-		capabilities, _ := Detect(&version)
+		capabilities, _ := detect(&version)
 		Expect(capabilities).To(Equal(&Capabilities{
 			Version:  &version,
 			HasAzure: true,
@@ -111,7 +111,7 @@ var _ = Describe("Correct detecting the barman capabilities", func() {
 	It("test barman version below 2.13.0 should has no aws and azure credentials ", func() {
 		version, err := semver.ParseTolerant("2.12.0")
 		Expect(err).ToNot(HaveOccurred())
-		capabilities, _ := Detect(&version)
+		capabilities, _ := detect(&version)
 		Expect(capabilities).To(Equal(&Capabilities{
 			Version: &version,
 		}))

--- a/pkg/management/barman/capabilities/suite_test.go
+++ b/pkg/management/barman/capabilities/suite_test.go
@@ -25,5 +25,5 @@ import (
 
 func TestCatalog(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Spool test suite")
+	RunSpecs(t, "Barman capabilities test suite")
 }

--- a/pkg/management/barman/capabilities/suite_test.go
+++ b/pkg/management/barman/capabilities/suite_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright The CloudNativePG Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package capabilities
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestCatalog(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Spool test suite")
+}


### PR DESCRIPTION
This patch ensures that we correctly detect barman google capability. 
It also adds unit tests coverage for barman capabilities discovery.

Closes #3929 