### PR TITLE
test(E2E): Use only one MinIO service for all the tests

### DIFF
--- a/tests/e2e/asserts_test.go
+++ b/tests/e2e/asserts_test.go
@@ -738,7 +738,7 @@ func AssertArchiveWalOnMinio(namespace, clusterName string, serverName string) {
 	By(fmt.Sprintf("verify the existence of WAL %v in minio", latestWALPath), func() {
 		Eventually(func() (int, error) {
 			// WALs are compressed with gzip in the fixture
-			return testsUtils.CountFilesOnMinio(namespace, minioClientName, latestWALPath)
+			return testsUtils.CountFilesOnMinio(minioEnv, latestWALPath)
 		}, testTimeouts[testsUtils.WalsInMinio]).Should(BeEquivalentTo(1))
 	})
 }
@@ -1812,7 +1812,7 @@ func prepareClusterForPITROnMinio(
 		testsUtils.ExecuteBackup(namespace, backupSampleFile, false, testTimeouts[testsUtils.BackupIsReady], env)
 		latestTar := minioPath(clusterName, "data.tar")
 		Eventually(func() (int, error) {
-			return testsUtils.CountFilesOnMinio(namespace, minioClientName, latestTar)
+			return testsUtils.CountFilesOnMinio(minioEnv, latestTar)
 		}, 60).Should(BeNumerically(">=", expectedVal),
 			fmt.Sprintf("verify the number of backups %v is greater than or equal to %v", latestTar,
 				expectedVal))

--- a/tests/e2e/backup_restore_test.go
+++ b/tests/e2e/backup_restore_test.go
@@ -19,6 +19,7 @@ package e2e
 import (
 	"fmt"
 	"path/filepath"
+
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"

--- a/tests/e2e/backup_restore_test.go
+++ b/tests/e2e/backup_restore_test.go
@@ -19,14 +19,9 @@ package e2e
 import (
 	"fmt"
 	"path/filepath"
-	"strings"
-
-	"github.com/thoas/go-funk"
-	corev1 "k8s.io/api/core/v1"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
-	"github.com/cloudnative-pg/cloudnative-pg/pkg/certs"
 	"github.com/cloudnative-pg/cloudnative-pg/tests"
 	testUtils "github.com/cloudnative-pg/cloudnative-pg/tests/utils"
 
@@ -67,20 +62,11 @@ var _ = Describe("Backup and restore", Label(tests.LabelBackupRestore), func() {
 		const (
 			backupFile              = fixturesDir + "/backup/minio/backup-minio.yaml"
 			customQueriesSampleFile = fixturesDir + "/metrics/custom-queries-with-target-databases.yaml"
-			minioCaSecName          = "minio-server-ca-secret"
-			minioTLSSecName         = "minio-server-tls-secret"
 		)
 
 		clusterWithMinioSampleFile := fixturesDir + "/backup/minio/cluster-with-backup-minio.yaml.template"
 
 		BeforeAll(func() {
-			//
-			// IMPORTANT: this is to ensure that we test the old backup system too
-			//
-			if funk.RandomInt(0, 100) < 50 {
-				GinkgoWriter.Println("---- Testing barman backups without the name flag ----")
-				clusterWithMinioSampleFile = fixturesDir + "/backup/minio/cluster-with-backup-minio-legacy.yaml.template"
-			}
 			if !IsLocal() {
 				Skip("This test is only run on local cluster")
 			}
@@ -95,38 +81,13 @@ var _ = Describe("Backup and restore", Label(tests.LabelBackupRestore), func() {
 				return env.DeleteNamespace(namespace)
 			})
 
-			By("creating ca and tls certificate secrets", func() {
-				// create CA certificates
-				_, caPair, err := testUtils.CreateSecretCA(namespace, clusterName, minioCaSecName, true, env)
-				Expect(err).ToNot(HaveOccurred())
-
-				// sign and create secret using CA certificate and key
-				serverPair, err := caPair.CreateAndSignPair("minio-service", certs.CertTypeServer,
-					[]string{"minio-service.internal.mydomain.net, minio-service.default.svc, minio-service.default,"},
-				)
-				Expect(err).ToNot(HaveOccurred())
-				serverSecret := serverPair.GenerateCertificateSecret(namespace, minioTLSSecName)
-				err = env.Client.Create(env.Ctx, serverSecret)
+			By("create the certificates for MinIO", func() {
+				err := minioEnv.CreateCaSecret(env, namespace)
 				Expect(err).ToNot(HaveOccurred())
 			})
 
 			By("creating the credentials for minio", func() {
 				AssertStorageCredentialsAreCreated(namespace, "backup-storage-creds", "minio", "minio123")
-			})
-
-			By("setting up minio", func() {
-				setup, err := testUtils.MinioSSLSetup(namespace)
-				Expect(err).ToNot(HaveOccurred())
-				err = testUtils.InstallMinio(env, setup, uint(testTimeouts[testUtils.MinioInstallation]))
-				Expect(err).ToNot(HaveOccurred())
-			})
-
-			// Create the minio client pod and wait for it to be ready.
-			// We'll use it to check if everything is archived correctly
-			By("setting up minio client pod", func() {
-				minioClient := testUtils.MinioSSLClient(namespace)
-				err := testUtils.PodCreateAndWaitForReady(env, &minioClient, 240)
-				Expect(err).ToNot(HaveOccurred())
 			})
 
 			// Create the curl client pod and wait for it to be ready.
@@ -148,7 +109,7 @@ var _ = Describe("Backup and restore", Label(tests.LabelBackupRestore), func() {
 				Expect(err).ToNot(HaveOccurred())
 				Eventually(func() (bool, error) {
 					connectionStatus, err := testUtils.MinioTestConnectivityUsingBarmanCloudWalArchive(
-						namespace, clusterName, primaryPod.GetName(), "minio", "minio123")
+						namespace, clusterName, primaryPod.GetName(), "minio", "minio123", minioEnv.ServiceName)
 					if err != nil {
 						return false, err
 					}
@@ -188,18 +149,27 @@ var _ = Describe("Backup and restore", Label(tests.LabelBackupRestore), func() {
 				backup = testUtils.ExecuteBackup(namespace, backupFile, false, testTimeouts[testUtils.BackupIsReady], env)
 				AssertBackupConditionInClusterStatus(namespace, clusterName)
 				Eventually(func() (int, error) {
-					return testUtils.CountFilesOnMinio(namespace, minioClientName, latestTar)
+					return testUtils.CountFilesOnMinio(minioEnv, latestTar)
 				}, 60).Should(BeEquivalentTo(1))
 				Eventually(func() (string, error) {
 					cluster, err := env.GetCluster(namespace, clusterName)
+					if err != nil {
+						return "", err
+					}
 					return cluster.Status.FirstRecoverabilityPoint, err
 				}, 30).ShouldNot(BeEmpty())
 				Eventually(func() (string, error) {
 					cluster, err := env.GetCluster(namespace, clusterName)
+					if err != nil {
+						return "", err
+					}
 					return cluster.Status.LastSuccessfulBackup, err
 				}, 30).ShouldNot(BeEmpty())
 				Eventually(func() (string, error) {
 					cluster, err := env.GetCluster(namespace, clusterName)
+					if err != nil {
+						return "", err
+					}
 					return cluster.Status.LastFailedBackup, err
 				}, 30).Should(BeEmpty())
 			})
@@ -227,7 +197,7 @@ var _ = Describe("Backup and restore", Label(tests.LabelBackupRestore), func() {
 
 			By("executing a second backup and verifying the number of backups on minio", func() {
 				Eventually(func() (int, error) {
-					return testUtils.CountFilesOnMinio(namespace, minioClientName, latestTar)
+					return testUtils.CountFilesOnMinio(minioEnv, latestTar)
 				}, 60).Should(BeEquivalentTo(1))
 
 				// delete the first backup and create a second backup
@@ -242,7 +212,7 @@ var _ = Describe("Backup and restore", Label(tests.LabelBackupRestore), func() {
 				testUtils.ExecuteBackup(namespace, backupFile, false, testTimeouts[testUtils.BackupIsReady], env)
 				latestTar = minioPath(clusterName, "data.tar")
 				Eventually(func() (int, error) {
-					return testUtils.CountFilesOnMinio(namespace, minioClientName, latestTar)
+					return testUtils.CountFilesOnMinio(minioEnv, latestTar)
 				}, 60).Should(BeEquivalentTo(2))
 			})
 
@@ -273,7 +243,7 @@ var _ = Describe("Backup and restore", Label(tests.LabelBackupRestore), func() {
 			latestGZ := filepath.Join("*", clusterName, "*", "*.history.gz")
 			By(fmt.Sprintf("checking the previous number of .history files in minio, history file name is %v",
 				latestGZ), func() {
-				previous, err = testUtils.CountFilesOnMinio(namespace, minioClientName, latestGZ)
+				previous, err = testUtils.CountFilesOnMinio(minioEnv, latestGZ)
 				Expect(err).ToNot(HaveOccurred())
 			})
 
@@ -281,7 +251,7 @@ var _ = Describe("Backup and restore", Label(tests.LabelBackupRestore), func() {
 
 			By("checking the number of .history after switchover", func() {
 				Eventually(func() (int, error) {
-					return testUtils.CountFilesOnMinio(namespace, minioClientName, latestGZ)
+					return testUtils.CountFilesOnMinio(minioEnv, latestGZ)
 				}, 60).Should(BeNumerically(">", previous))
 			})
 
@@ -326,7 +296,7 @@ var _ = Describe("Backup and restore", Label(tests.LabelBackupRestore), func() {
 				testUtils.ExecuteBackup(namespace, backupStandbyFile, true, testTimeouts[testUtils.BackupIsReady], env)
 				AssertBackupConditionInClusterStatus(namespace, targetClusterName)
 				Eventually(func() (int, error) {
-					return testUtils.CountFilesOnMinio(namespace, minioClientName, latestTar)
+					return testUtils.CountFilesOnMinio(minioEnv, latestTar)
 				}, 60).Should(BeEquivalentTo(1))
 				Eventually(func() (string, error) {
 					cluster, err := env.GetCluster(namespace, targetClusterName)
@@ -370,7 +340,7 @@ var _ = Describe("Backup and restore", Label(tests.LabelBackupRestore), func() {
 				testUtils.ExecuteBackup(namespace, backupWithTargetFile, true, testTimeouts[testUtils.BackupIsReady], env)
 				AssertBackupConditionInClusterStatus(namespace, targetClusterName)
 				Eventually(func() (int, error) {
-					return testUtils.CountFilesOnMinio(namespace, minioClientName, latestTar)
+					return testUtils.CountFilesOnMinio(minioEnv, latestTar)
 				}, 60).Should(BeEquivalentTo(1))
 				Eventually(func() (string, error) {
 					cluster, err := env.GetCluster(namespace, targetClusterName)
@@ -429,7 +399,7 @@ var _ = Describe("Backup and restore", Label(tests.LabelBackupRestore), func() {
 				AssertBackupConditionInClusterStatus(namespace, customClusterName)
 				latestBaseTar := minioPath(clusterServerName, "data.tar")
 				Eventually(func() (int, error) {
-					return testUtils.CountFilesOnMinio(namespace, minioClientName, latestBaseTar)
+					return testUtils.CountFilesOnMinio(minioEnv, latestBaseTar)
 				}, 60).Should(BeEquivalentTo(1),
 					fmt.Sprintf("verify the number of backup %v is equals to 1", latestBaseTar))
 				// this is the second backup we take on the bucket
@@ -465,7 +435,7 @@ var _ = Describe("Backup and restore", Label(tests.LabelBackupRestore), func() {
 			// AssertScheduledBackupsImmediate creates at least two backups, we should find
 			// their base backups
 			Eventually(func() (int, error) {
-				return testUtils.CountFilesOnMinio(namespace, minioClientName, latestBaseTar)
+				return testUtils.CountFilesOnMinio(minioEnv, latestBaseTar)
 			}, 60).Should(BeNumerically(">=", 2),
 				fmt.Sprintf("verify the number of backup %v is >= 2", latestBaseTar))
 		})
@@ -516,7 +486,7 @@ var _ = Describe("Backup and restore", Label(tests.LabelBackupRestore), func() {
 				AssertScheduledBackupsAreScheduled(namespace, scheduledBackupSampleFile, 300)
 				latestTar := minioPath(clusterName, "data.tar")
 				Eventually(func() (int, error) {
-					return testUtils.CountFilesOnMinio(namespace, minioClientName, latestTar)
+					return testUtils.CountFilesOnMinio(minioEnv, latestTar)
 				}, 60).Should(BeNumerically(">=", 2),
 					fmt.Sprintf("verify the number of backup %v is great than 2", latestTar))
 			})
@@ -526,7 +496,7 @@ var _ = Describe("Backup and restore", Label(tests.LabelBackupRestore), func() {
 
 		It("verify tags in backed files", func() {
 			AssertArchiveWalOnMinio(namespace, clusterName, clusterName)
-			tags, err := testUtils.GetFileTagsOnMinio(namespace, minioClientName, "*[0-9].gz")
+			tags, err := testUtils.GetFileTagsOnMinio(minioEnv, "*[0-9].gz")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(tags.Tags).ToNot(BeEmpty())
 
@@ -542,7 +512,7 @@ var _ = Describe("Backup and restore", Label(tests.LabelBackupRestore), func() {
 
 			AssertNewPrimary(namespace, clusterName, oldPrimary)
 
-			tags, err = testUtils.GetFileTagsOnMinio(namespace, minioClientName, "*.history.gz")
+			tags, err = testUtils.GetFileTagsOnMinio(minioEnv, "*.history.gz")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(tags.Tags).ToNot(BeEmpty())
 		})
@@ -849,37 +819,10 @@ var _ = Describe("Clusters Recovery From Barman Object Store", Label(tests.Label
 				return env.DeleteNamespace(namespace)
 			})
 
-			By("creating ca and tls certificate secrets", func() {
-				// create CA certificate
-				_, caPair, err := testUtils.CreateSecretCA(namespace, clusterName, minioCaSecName, true, env)
-				Expect(err).ToNot(HaveOccurred())
+			AssertStorageCredentialsAreCreated(namespace, "backup-storage-creds", "minio", "minio123")
 
-				// sign and create secret using CA certificate and key
-				serverPair, err := caPair.CreateAndSignPair("minio-service", certs.CertTypeServer,
-					[]string{"minio-service.internal.mydomain.net, minio-service.default.svc, minio-service.default,"},
-				)
-				Expect(err).ToNot(HaveOccurred())
-				serverSecret := serverPair.GenerateCertificateSecret(namespace, minioTLSSecName)
-				err = env.Client.Create(env.Ctx, serverSecret)
-				Expect(err).ToNot(HaveOccurred())
-			})
-
-			By("creating the credentials for minio", func() {
-				AssertStorageCredentialsAreCreated(namespace, "backup-storage-creds", "minio", "minio123")
-			})
-
-			By("setting up minio", func() {
-				setup, err := testUtils.MinioSSLSetup(namespace)
-				Expect(err).ToNot(HaveOccurred())
-				err = testUtils.InstallMinio(env, setup, uint(testTimeouts[testUtils.MinioInstallation]))
-				Expect(err).ToNot(HaveOccurred())
-			})
-
-			// Create the minio client pod and wait for it to be ready.
-			// We'll use it to check if everything is archived correctly
-			By("setting up minio client pod", func() {
-				minioClient := testUtils.MinioSSLClient(namespace)
-				err := testUtils.PodCreateAndWaitForReady(env, &minioClient, 240)
+			By("create the certificates for MinIO", func() {
+				err := minioEnv.CreateCaSecret(env, namespace)
 				Expect(err).ToNot(HaveOccurred())
 			})
 
@@ -891,7 +834,7 @@ var _ = Describe("Clusters Recovery From Barman Object Store", Label(tests.Label
 				Expect(err).ToNot(HaveOccurred())
 				Eventually(func() (bool, error) {
 					connectionStatus, err := testUtils.MinioTestConnectivityUsingBarmanCloudWalArchive(
-						namespace, clusterName, primaryPod.GetName(), "minio", "minio123")
+						namespace, clusterName, primaryPod.GetName(), "minio", "minio123", minioEnv.ServiceName)
 					if err != nil {
 						return false, err
 					}
@@ -921,11 +864,14 @@ var _ = Describe("Clusters Recovery From Barman Object Store", Label(tests.Label
 
 				latestTar := minioPath(clusterName, "data.tar")
 				Eventually(func() (int, error) {
-					return testUtils.CountFilesOnMinio(namespace, minioClientName, latestTar)
+					return testUtils.CountFilesOnMinio(minioEnv, latestTar)
 				}, 60).Should(BeEquivalentTo(1),
 					fmt.Sprintf("verify the number of backup %v is equals to 1", latestTar))
 				Eventually(func() (string, error) {
 					cluster, err := env.GetCluster(namespace, clusterName)
+					if err != nil {
+						return "", err
+					}
 					return cluster.Status.FirstRecoverabilityPoint, err
 				}, 30).ShouldNot(BeEmpty())
 			})
@@ -965,7 +911,7 @@ var _ = Describe("Clusters Recovery From Barman Object Store", Label(tests.Label
 				AssertBackupConditionInClusterStatus(namespace, clusterName)
 				latestTar := minioPath(clusterName, "data.tar")
 				Eventually(func() (int, error) {
-					return testUtils.CountFilesOnMinio(namespace, minioClientName, latestTar)
+					return testUtils.CountFilesOnMinio(minioEnv, latestTar)
 				}, 60).Should(BeEquivalentTo(2),
 					fmt.Sprintf("verify the number of backup %v is equals to 2", latestTar))
 			})
@@ -999,7 +945,7 @@ var _ = Describe("Clusters Recovery From Barman Object Store", Label(tests.Label
 				AssertBackupConditionInClusterStatus(namespace, clusterName)
 				latestTar := minioPath(clusterName, "data.tar")
 				Eventually(func() (int, error) {
-					return testUtils.CountFilesOnMinio(namespace, minioClientName, latestTar)
+					return testUtils.CountFilesOnMinio(minioEnv, latestTar)
 				}, 60).Should(BeEquivalentTo(3),
 					fmt.Sprintf("verify the number of backup %v is great than 3", latestTar))
 			})
@@ -1256,7 +1202,7 @@ var _ = Describe("Clusters Recovery From Barman Object Store", Label(tests.Label
 	})
 })
 
-var _ = Describe("Backup and restore Safety", Label(tests.LabelBackupRestore), func() {
+/*var _ = Describe("Backup and restore Safety", Label(tests.LabelBackupRestore), func() {
 	const (
 		level = tests.High
 
@@ -1266,6 +1212,10 @@ var _ = Describe("Backup and restore Safety", Label(tests.LabelBackupRestore), f
 	)
 
 	var namespace, clusterName, namespace2 string
+
+	BeforeAll(func() {
+		Skip("Disabled by now - check issue #3967")
+	})
 
 	BeforeEach(func() {
 		if testLevelEnv.Depth < int(level) {
@@ -1279,8 +1229,8 @@ var _ = Describe("Backup and restore Safety", Label(tests.LabelBackupRestore), f
 			env.DumpNamespaceObjects(namespace2, "out/"+namespace2+CurrentSpecReport().LeafNodeText+".log")
 		}
 	})
-	Context("using minio as object storage", Ordered, func() {
-		// This is a set of tests using a minio server to ensure backup and safet
+	FContext("using minio as object storage", Ordered, func() {
+		// This is a set of tests using a minio server to ensure backup and safety
 		// in case user configures the same destination path for more backups
 
 		const (
@@ -1313,25 +1263,13 @@ var _ = Describe("Backup and restore Safety", Label(tests.LabelBackupRestore), f
 				return env.DeleteNamespace(namespace2)
 			})
 
+			caSecret, err := minioEnv.GetCaSecret(env, namespace)
+			Expect(err).ToNot(HaveOccurred())
+			_, err = testUtils.CreateObject(env, caSecret)
+			Expect(err).ToNot(HaveOccurred())
+
 			By("creating the credentials for minio", func() {
 				AssertStorageCredentialsAreCreated(namespace, "backup-storage-creds", "minio", "minio123")
-			})
-
-			// setting up default minio
-			By("setting up minio", func() {
-				minio, err := testUtils.MinioDefaultSetup(namespace)
-				Expect(err).ToNot(HaveOccurred())
-
-				err = testUtils.InstallMinio(env, minio, uint(testTimeouts[testUtils.MinioInstallation]))
-				Expect(err).ToNot(HaveOccurred())
-			})
-
-			// Create the minio client pod and wait for it to be ready.
-			// We'll use it to check if everything is archived correctly
-			By("setting up minio client pod", func() {
-				minioClient := testUtils.MinioDefaultClient(namespace)
-				err := testUtils.PodCreateAndWaitForReady(env, &minioClient, 240)
-				Expect(err).ToNot(HaveOccurred())
 			})
 
 			// Creates the cluster
@@ -1489,3 +1427,4 @@ var _ = Describe("Backup and restore Safety", Label(tests.LabelBackupRestore), f
 		})
 	})
 })
+*/

--- a/tests/e2e/commons_test.go
+++ b/tests/e2e/commons_test.go
@@ -18,12 +18,6 @@ package e2e
 
 import "github.com/cloudnative-pg/cloudnative-pg/tests/utils"
 
-const (
-	minioClientName = "mc"
-	checkPointCmd   = "psql -U postgres postgres -tAc 'CHECKPOINT;'"
-	getLatestWalCmd = "psql -U postgres postgres -tAc 'SELECT pg_walfile_name(pg_switch_wal());'"
-)
-
 // IsAKS checks if the running cluster is on AKS
 func IsAKS() bool {
 	return *testCloudVendorEnv == utils.AKS

--- a/tests/e2e/fixtures/backup/backup_restore_safety/external-clusters-minio-2.yaml.template
+++ b/tests/e2e/fixtures/backup/backup_restore_safety/external-clusters-minio-2.yaml.template
@@ -35,7 +35,7 @@ spec:
     target: primary
     barmanObjectStore:
       destinationPath: s3://cluster-backups/test/
-      endpointURL: http://minio-service:9000
+      endpointURL: http://minio-service.minio:9000
       s3Credentials:
         accessKeyId:
           name: backup-storage-creds
@@ -57,7 +57,7 @@ spec:
     - name: pg-backup-minio
       barmanObjectStore:
         destinationPath: s3://cluster-backups/
-        endpointURL: http://minio-service:9000
+        endpointURL: http://minio-service.minio:9000
         s3Credentials:
           accessKeyId:
             name: backup-storage-creds

--- a/tests/e2e/fixtures/backup/backup_restore_safety/external-clusters-minio-2.yaml.template
+++ b/tests/e2e/fixtures/backup/backup_restore_safety/external-clusters-minio-2.yaml.template
@@ -36,6 +36,9 @@ spec:
     barmanObjectStore:
       destinationPath: s3://cluster-backups/test/
       endpointURL: https://minio-service.minio:9000
+      endpointCA:
+        key: ca.crt
+        name: minio-server-ca-secret
       s3Credentials:
         accessKeyId:
           name: backup-storage-creds
@@ -58,6 +61,9 @@ spec:
       barmanObjectStore:
         destinationPath: s3://cluster-backups/
         endpointURL: https://minio-service.minio:9000
+        endpointCA:
+          key: ca.crt
+          name: minio-server-ca-secret
         s3Credentials:
           accessKeyId:
             name: backup-storage-creds

--- a/tests/e2e/fixtures/backup/backup_restore_safety/external-clusters-minio-2.yaml.template
+++ b/tests/e2e/fixtures/backup/backup_restore_safety/external-clusters-minio-2.yaml.template
@@ -35,7 +35,7 @@ spec:
     target: primary
     barmanObjectStore:
       destinationPath: s3://cluster-backups/test/
-      endpointURL: http://minio-service.minio:9000
+      endpointURL: https://minio-service.minio:9000
       s3Credentials:
         accessKeyId:
           name: backup-storage-creds
@@ -57,7 +57,7 @@ spec:
     - name: pg-backup-minio
       barmanObjectStore:
         destinationPath: s3://cluster-backups/
-        endpointURL: http://minio-service.minio:9000
+        endpointURL: https://minio-service.minio:9000
         s3Credentials:
           accessKeyId:
             name: backup-storage-creds

--- a/tests/e2e/fixtures/backup/backup_restore_safety/external-clusters-minio-3.yaml.template
+++ b/tests/e2e/fixtures/backup/backup_restore_safety/external-clusters-minio-3.yaml.template
@@ -35,7 +35,7 @@ spec:
     target: primary
     barmanObjectStore:
       destinationPath: s3://cluster-backups/
-      endpointURL: http://minio-service.minio:9000
+      endpointURL: https://minio-service.minio:9000
       s3Credentials:
         accessKeyId:
           name: backup-storage-creds
@@ -57,7 +57,7 @@ spec:
     - name: external-cluster-minio-1
       barmanObjectStore:
         destinationPath: s3://cluster-backups/pg-backup-minio/
-        endpointURL: http://minio-service.minio:9000
+        endpointURL: https://minio-service.minio:9000
         s3Credentials:
           accessKeyId:
             name: backup-storage-creds

--- a/tests/e2e/fixtures/backup/backup_restore_safety/external-clusters-minio-3.yaml.template
+++ b/tests/e2e/fixtures/backup/backup_restore_safety/external-clusters-minio-3.yaml.template
@@ -36,6 +36,9 @@ spec:
     barmanObjectStore:
       destinationPath: s3://cluster-backups/
       endpointURL: https://minio-service.minio:9000
+      endpointCA:
+        key: ca.crt
+        name: minio-server-ca-secret
       s3Credentials:
         accessKeyId:
           name: backup-storage-creds
@@ -58,6 +61,9 @@ spec:
       barmanObjectStore:
         destinationPath: s3://cluster-backups/pg-backup-minio/
         endpointURL: https://minio-service.minio:9000
+        endpointCA:
+          key: ca.crt
+          name: minio-server-ca-secret
         s3Credentials:
           accessKeyId:
             name: backup-storage-creds

--- a/tests/e2e/fixtures/backup/backup_restore_safety/external-clusters-minio-3.yaml.template
+++ b/tests/e2e/fixtures/backup/backup_restore_safety/external-clusters-minio-3.yaml.template
@@ -35,7 +35,7 @@ spec:
     target: primary
     barmanObjectStore:
       destinationPath: s3://cluster-backups/
-      endpointURL: http://minio-service:9000
+      endpointURL: http://minio-service.minio:9000
       s3Credentials:
         accessKeyId:
           name: backup-storage-creds
@@ -57,7 +57,7 @@ spec:
     - name: external-cluster-minio-1
       barmanObjectStore:
         destinationPath: s3://cluster-backups/pg-backup-minio/
-        endpointURL: http://minio-service:9000
+        endpointURL: http://minio-service.minio:9000
         s3Credentials:
           accessKeyId:
             name: backup-storage-creds

--- a/tests/e2e/fixtures/backup/backup_restore_safety/external-clusters-minio-4.yaml.template
+++ b/tests/e2e/fixtures/backup/backup_restore_safety/external-clusters-minio-4.yaml.template
@@ -57,7 +57,7 @@ spec:
     - name: pg-backup-minio
       barmanObjectStore:
         destinationPath: s3://cluster-backups/
-        endpointURL: http://minio-service.minio:9000
+        endpointURL: https://minio-service.minio:9000
         s3Credentials:
           accessKeyId:
             name: backup-storage-creds

--- a/tests/e2e/fixtures/backup/backup_restore_safety/external-clusters-minio-4.yaml.template
+++ b/tests/e2e/fixtures/backup/backup_restore_safety/external-clusters-minio-4.yaml.template
@@ -57,7 +57,7 @@ spec:
     - name: pg-backup-minio
       barmanObjectStore:
         destinationPath: s3://cluster-backups/
-        endpointURL: http://minio-service:9000
+        endpointURL: http://minio-service.minio:9000
         s3Credentials:
           accessKeyId:
             name: backup-storage-creds

--- a/tests/e2e/fixtures/backup/backup_restore_safety/external-clusters-minio-4.yaml.template
+++ b/tests/e2e/fixtures/backup/backup_restore_safety/external-clusters-minio-4.yaml.template
@@ -58,6 +58,9 @@ spec:
       barmanObjectStore:
         destinationPath: s3://cluster-backups/
         endpointURL: https://minio-service.minio:9000
+        endpointCA:
+          key: ca.crt
+          name: minio-server-ca-secret
         s3Credentials:
           accessKeyId:
             name: backup-storage-creds

--- a/tests/e2e/fixtures/backup/minio/cluster-with-backup-minio-custom-servername.yaml.template
+++ b/tests/e2e/fixtures/backup/minio/cluster-with-backup-minio-custom-servername.yaml.template
@@ -46,8 +46,8 @@ spec:
   backup:
     target: primary
     barmanObjectStore:
-        destinationPath: s3://cluster-backups/
-        endpointURL: https://minio-service:9000
+        destinationPath: s3://pg-backup-minio-custom/
+        endpointURL: https://minio-service.minio:9000
         endpointCA:
           key: ca.crt
           name: minio-server-ca-secret

--- a/tests/e2e/fixtures/backup/minio/cluster-with-backup-minio-primary.yaml.template
+++ b/tests/e2e/fixtures/backup/minio/cluster-with-backup-minio-primary.yaml.template
@@ -47,7 +47,7 @@ spec:
     target: primary
     barmanObjectStore:
         destinationPath: s3://cluster-backups-standby/
-        endpointURL: https://minio-service:9000
+        endpointURL: https://minio-service.minio:9000
         endpointCA:
           key: ca.crt
           name: minio-server-ca-secret

--- a/tests/e2e/fixtures/backup/minio/cluster-with-backup-minio-standby.yaml.template
+++ b/tests/e2e/fixtures/backup/minio/cluster-with-backup-minio-standby.yaml.template
@@ -47,7 +47,7 @@ spec:
     target: prefer-standby
     barmanObjectStore:
         destinationPath: s3://cluster-backups-standby/
-        endpointURL: https://minio-service:9000
+        endpointURL: https://minio-service.minio:9000
         endpointCA:
           key: ca.crt
           name: minio-server-ca-secret

--- a/tests/e2e/fixtures/backup/minio/cluster-with-backup-minio-with-wal-max-parallel.yaml.template
+++ b/tests/e2e/fixtures/backup/minio/cluster-with-backup-minio-with-wal-max-parallel.yaml.template
@@ -1,7 +1,7 @@
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
-  name: cluster-backup-minio-wal-max-parallel
+  name: backup-wal-max-parallel
 spec:
   instances: 2
 
@@ -38,8 +38,11 @@ spec:
   backup:
     target: primary
     barmanObjectStore:
-      destinationPath: s3://cluster-backups/
-      endpointURL: http://minio-service:9000
+      destinationPath: s3://backup-wal-max-parallel/
+      endpointURL: https://minio-service.minio:9000/
+      endpointCA:
+        key: ca.crt
+        name: minio-server-ca-secret
       s3Credentials:
         accessKeyId:
           name: backup-storage-creds

--- a/tests/e2e/fixtures/backup/minio/cluster-with-backup-minio.yaml.template
+++ b/tests/e2e/fixtures/backup/minio/cluster-with-backup-minio.yaml.template
@@ -47,8 +47,8 @@ spec:
   backup:
     target: primary
     barmanObjectStore:
-        destinationPath: s3://cluster-backups/
-        endpointURL: https://minio-service:9000
+        destinationPath: s3://pg-backup-minio/
+        endpointURL: https://minio-service.minio:9000
         endpointCA:
           key: ca.crt
           name: minio-server-ca-secret

--- a/tests/e2e/fixtures/backup/recovery_external_clusters/external-clusters-minio-03.yaml.template
+++ b/tests/e2e/fixtures/backup/recovery_external_clusters/external-clusters-minio-03.yaml.template
@@ -36,7 +36,7 @@ spec:
     - name: source-cluster-minio
       barmanObjectStore:
         destinationPath: s3://cluster-backups/
-        endpointURL: https://minio-service:9000
+        endpointURL: https://minio-service.minio:9000
         endpointCA:
           key: ca.crt
           name: minio-server-ca-secret

--- a/tests/e2e/fixtures/backup/recovery_external_clusters/external-clusters-minio-replica-04.yaml.template
+++ b/tests/e2e/fixtures/backup/recovery_external_clusters/external-clusters-minio-replica-04.yaml.template
@@ -39,7 +39,7 @@ spec:
     - name: source-cluster-minio
       barmanObjectStore:
         destinationPath: s3://cluster-backups/
-        endpointURL: https://minio-service:9000
+        endpointURL: https://minio-service.minio:9000
         endpointCA:
           key: ca.crt
           name: minio-server-ca-secret

--- a/tests/e2e/fixtures/backup/recovery_external_clusters/source-cluster-minio-01.yaml.template
+++ b/tests/e2e/fixtures/backup/recovery_external_clusters/source-cluster-minio-01.yaml.template
@@ -36,7 +36,7 @@ spec:
     target: primary
     barmanObjectStore:
         destinationPath: s3://cluster-backups/
-        endpointURL: https://minio-service:9000
+        endpointURL: https://minio-service.minio:9000
         endpointCA:
           key: ca.crt
           name: minio-server-ca-secret

--- a/tests/e2e/fixtures/replica_mode_cluster/cluster-replica-archive-mode-always.yaml.template
+++ b/tests/e2e/fixtures/replica_mode_cluster/cluster-replica-archive-mode-always.yaml.template
@@ -32,7 +32,10 @@ spec:
 
     barmanObjectStore:
       destinationPath: s3://replica-cluster/
-      endpointURL: http://minio-service:9000
+      endpointURL: https://minio-service.minio:9000
+      endpointCA:
+        key: ca.crt
+        name: minio-server-ca-secret
       s3Credentials:
         accessKeyId:
           name: backup-storage-creds
@@ -48,7 +51,10 @@ spec:
   backup:
     barmanObjectStore:
       destinationPath: s3://replica-cluster/
-      endpointURL: http://minio-service:9000
+      endpointURL: https://minio-service.minio:9000
+      endpointCA:
+        key: ca.crt
+        name: minio-server-ca-secret
       s3Credentials:
         accessKeyId:
           name: backup-storage-creds

--- a/tests/e2e/fixtures/replica_mode_cluster/cluster-replica-from-backup.yaml.template
+++ b/tests/e2e/fixtures/replica_mode_cluster/cluster-replica-from-backup.yaml.template
@@ -35,7 +35,10 @@ spec:
 
       barmanObjectStore:
         destinationPath: s3://cluster-backups/
-        endpointURL: http://minio-service:9000
+        endpointURL: https://minio-service.minio:9000
+        endpointCA:
+          key: ca.crt
+          name: minio-server-ca-secret
         s3Credentials:
           accessKeyId:
             name: backup-storage-creds

--- a/tests/e2e/fixtures/replica_mode_cluster/cluster-replica-from-snapshot.yaml.template
+++ b/tests/e2e/fixtures/replica_mode_cluster/cluster-replica-from-snapshot.yaml.template
@@ -44,7 +44,10 @@ spec:
 
       barmanObjectStore:
         destinationPath: s3://cluster-backups/
-        endpointURL: http://minio-service:9000
+        endpointURL: https://minio-service.minio:9000
+        endpointCA:
+          key: ca.crt
+          name: minio-server-ca-secret
         s3Credentials:
           accessKeyId:
             name: backup-storage-creds

--- a/tests/e2e/fixtures/replica_mode_cluster/cluster-replica-src-with-backup.yaml.template
+++ b/tests/e2e/fixtures/replica_mode_cluster/cluster-replica-src-with-backup.yaml.template
@@ -37,7 +37,10 @@ spec:
       className: ${E2E_DEFAULT_VOLUMESNAPSHOT_CLASS}
     barmanObjectStore:
       destinationPath: s3://cluster-backups/
-      endpointURL: http://minio-service:9000
+      endpointURL: https://minio-service.minio:9000
+      endpointCA:
+        key: ca.crt
+        name: minio-server-ca-secret
       s3Credentials:
         accessKeyId:
           name: backup-storage-creds

--- a/tests/e2e/fixtures/tablespaces/cluster-volume-snapshot-tablespaces-pitr.yaml.template
+++ b/tests/e2e/fixtures/tablespaces/cluster-volume-snapshot-tablespaces-pitr.yaml.template
@@ -50,8 +50,8 @@ spec:
   externalClusters:
   - name: cluster-tablespaces-volume-snapshot
     barmanObjectStore:
-      destinationPath: s3://cluster-backups/
-      endpointURL: https://minio-service:9000
+      destinationPath: s3://cluster-tablespaces-volume-snapshot/
+      endpointURL: https://minio-service.minio:9000
       endpointCA:
         key: ca.crt
         name: minio-server-ca-secret

--- a/tests/e2e/fixtures/tablespaces/cluster-volume-snapshot-tablespaces.yaml.template
+++ b/tests/e2e/fixtures/tablespaces/cluster-volume-snapshot-tablespaces.yaml.template
@@ -33,8 +33,8 @@ spec:
       className: ${E2E_DEFAULT_VOLUMESNAPSHOT_CLASS}
       snapshotOwnerReference: cluster
     barmanObjectStore:
-      destinationPath: s3://cluster-backups/
-      endpointURL: https://minio-service:9000
+      destinationPath: s3://cluster-tablespaces-volume-snapshot/
+      endpointURL: https://minio-service.minio:9000
       endpointCA:
         key: ca.crt
         name: minio-server-ca-secret

--- a/tests/e2e/fixtures/tablespaces/cluster-with-tablespaces.yaml.template
+++ b/tests/e2e/fixtures/tablespaces/cluster-with-tablespaces.yaml.template
@@ -52,8 +52,8 @@ spec:
 
   backup:
     barmanObjectStore:
-      destinationPath: s3://cluster-backups/
-      endpointURL: https://minio-service:9000
+      destinationPath: s3://cluster-tablespaces/
+      endpointURL: https://minio-service.minio:9000
       endpointCA:
         key: ca.crt
         name: minio-server-ca-secret

--- a/tests/e2e/fixtures/upgrade/cluster1.yaml.template
+++ b/tests/e2e/fixtures/upgrade/cluster1.yaml.template
@@ -40,6 +40,9 @@ spec:
     barmanObjectStore:
       destinationPath: s3://cluster-full-backup/
       endpointURL: https://minio-service.minio:9000
+      endpointCA:
+        key: ca.crt
+        name: minio-server-ca-secret
       s3Credentials:
         accessKeyId:
           name: aws-creds

--- a/tests/e2e/fixtures/upgrade/cluster1.yaml.template
+++ b/tests/e2e/fixtures/upgrade/cluster1.yaml.template
@@ -39,7 +39,7 @@ spec:
     target: primary
     barmanObjectStore:
       destinationPath: s3://cluster-full-backup/
-      endpointURL: http://minio-service:9000
+      endpointURL: http://minio-service.minio:9000
       s3Credentials:
         accessKeyId:
           name: aws-creds

--- a/tests/e2e/fixtures/upgrade/cluster1.yaml.template
+++ b/tests/e2e/fixtures/upgrade/cluster1.yaml.template
@@ -39,7 +39,7 @@ spec:
     target: primary
     barmanObjectStore:
       destinationPath: s3://cluster-full-backup/
-      endpointURL: http://minio-service.minio:9000
+      endpointURL: https://minio-service.minio:9000
       s3Credentials:
         accessKeyId:
           name: aws-creds

--- a/tests/e2e/fixtures/upgrade/cluster2.yaml.template
+++ b/tests/e2e/fixtures/upgrade/cluster2.yaml.template
@@ -39,7 +39,7 @@ spec:
     target: primary
     barmanObjectStore:
       destinationPath: s3://cluster2-full-backup/
-      endpointURL: http://minio-service.minio:9000
+      endpointURL: https://minio-service.minio:9000
       s3Credentials:
         accessKeyId:
           name: aws-creds

--- a/tests/e2e/fixtures/upgrade/cluster2.yaml.template
+++ b/tests/e2e/fixtures/upgrade/cluster2.yaml.template
@@ -39,7 +39,7 @@ spec:
     target: primary
     barmanObjectStore:
       destinationPath: s3://cluster2-full-backup/
-      endpointURL: http://minio-service:9000
+      endpointURL: http://minio-service.minio:9000
       s3Credentials:
         accessKeyId:
           name: aws-creds

--- a/tests/e2e/fixtures/upgrade/cluster2.yaml.template
+++ b/tests/e2e/fixtures/upgrade/cluster2.yaml.template
@@ -40,6 +40,9 @@ spec:
     barmanObjectStore:
       destinationPath: s3://cluster2-full-backup/
       endpointURL: https://minio-service.minio:9000
+      endpointCA:
+        key: ca.crt
+        name: minio-server-ca-secret
       s3Credentials:
         accessKeyId:
           name: aws-creds

--- a/tests/e2e/fixtures/volume_snapshot/cluster-pvc-hot-restore.yaml.template
+++ b/tests/e2e/fixtures/volume_snapshot/cluster-pvc-hot-restore.yaml.template
@@ -17,7 +17,7 @@ spec:
 
   bootstrap:
     recovery:
-      source: cluster-pvc-snapshot
+      source: cluster-pvc-hot-snapshot
       volumeSnapshots:
         storage:
           name: ${SNAPSHOT_PITR_PGDATA}
@@ -30,10 +30,10 @@ spec:
 
 
   externalClusters:
-    - name: cluster-pvc-snapshot
+    - name: cluster-pvc-hot-snapshot
       barmanObjectStore:
-        destinationPath: s3://cluster-backups/
-        endpointURL: https://minio-service:9000
+        destinationPath: s3://cluster-pvc-hot-snapshot/
+        endpointURL: https://minio-service.minio:9000
         endpointCA:
           key: ca.crt
           name: minio-server-ca-secret

--- a/tests/e2e/fixtures/volume_snapshot/cluster-pvc-hot-snapshot.yaml.template
+++ b/tests/e2e/fixtures/volume_snapshot/cluster-pvc-hot-snapshot.yaml.template
@@ -1,7 +1,7 @@
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
-  name: cluster-pvc-snapshot
+  name: cluster-pvc-hot-snapshot
 spec:
   instances: 2
   primaryUpdateStrategy: unsupervised
@@ -23,8 +23,8 @@ spec:
         immediateCheckpoint: true
         waitForArchive: true
     barmanObjectStore:
-        destinationPath: s3://cluster-backups/
-        endpointURL: https://minio-service:9000
+        destinationPath: s3://cluster-pvc-hot-snapshot/
+        endpointURL: https://minio-service.minio:9000
         endpointCA:
           key: ca.crt
           name: minio-server-ca-secret

--- a/tests/e2e/fixtures/volume_snapshot/cluster-pvc-snapshot-restore.yaml.template
+++ b/tests/e2e/fixtures/volume_snapshot/cluster-pvc-snapshot-restore.yaml.template
@@ -32,8 +32,8 @@ spec:
   externalClusters:
     - name: cluster-pvc-snapshot
       barmanObjectStore:
-        destinationPath: s3://cluster-backups/
-        endpointURL: https://minio-service:9000
+        destinationPath: s3://cluster-pvc-snapshot/
+        endpointURL: https://minio-service.minio:9000
         endpointCA:
           key: ca.crt
           name: minio-server-ca-secret

--- a/tests/e2e/fixtures/volume_snapshot/cluster-pvc-snapshot.yaml.template
+++ b/tests/e2e/fixtures/volume_snapshot/cluster-pvc-snapshot.yaml.template
@@ -18,8 +18,8 @@ spec:
     volumeSnapshot:
       className: ${E2E_DEFAULT_VOLUMESNAPSHOT_CLASS}
     barmanObjectStore:
-        destinationPath: s3://cluster-backups/
-        endpointURL: https://minio-service:9000
+        destinationPath: s3://cluster-pvc-snapshot/
+        endpointURL: https://minio-service.minio:9000
         endpointCA:
           key: ca.crt
           name: minio-server-ca-secret

--- a/tests/e2e/replica_mode_cluster_test.go
+++ b/tests/e2e/replica_mode_cluster_test.go
@@ -134,17 +134,9 @@ var _ = Describe("Replica Mode", Label(tests.LabelReplication), func() {
 			By("creating the credentials for minio", func() {
 				AssertStorageCredentialsAreCreated(replicaNamespace, "backup-storage-creds", "minio", "minio123")
 			})
-			By("setting up minio", func() {
-				minio, err := testUtils.MinioDefaultSetup(replicaNamespace)
-				Expect(err).ToNot(HaveOccurred())
-				err = testUtils.InstallMinio(env, minio, uint(testTimeouts[testUtils.MinioInstallation]))
-				Expect(err).ToNot(HaveOccurred())
-			})
-			// Create the minio client pod and wait for it to be ready.
-			// We'll use it to check if everything is archived correctly
-			By("setting up minio client pod", func() {
-				minioClient := testUtils.MinioDefaultClient(replicaNamespace)
-				err := testUtils.PodCreateAndWaitForReady(env, &minioClient, 240)
+
+			By("create the certificates for MinIO", func() {
+				err := minioEnv.CreateCaSecret(env, replicaNamespace)
 				Expect(err).ToNot(HaveOccurred())
 			})
 
@@ -203,18 +195,8 @@ var _ = Describe("Replica Mode", Label(tests.LabelReplication), func() {
 				AssertStorageCredentialsAreCreated(namespace, "backup-storage-creds", "minio", "minio123")
 			})
 
-			By("setting up minio", func() {
-				minio, err := testUtils.MinioDefaultSetup(namespace)
-				Expect(err).ToNot(HaveOccurred())
-				err = testUtils.InstallMinio(env, minio, uint(testTimeouts[testUtils.MinioInstallation]))
-				Expect(err).ToNot(HaveOccurred())
-			})
-
-			// Create the minio client pod and wait for it to be ready.
-			// We'll use it to check if everything is archived correctly
-			By("setting up minio client pod", func() {
-				minioClient := testUtils.MinioDefaultClient(namespace)
-				err := testUtils.PodCreateAndWaitForReady(env, &minioClient, 240)
+			By("create the certificates for MinIO", func() {
+				err := minioEnv.CreateCaSecret(env, namespace)
 				Expect(err).ToNot(HaveOccurred())
 			})
 

--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -34,7 +34,6 @@ import (
 	"github.com/thoas/go-funk"
 	corev1 "k8s.io/api/core/v1"
 	k8sscheme "k8s.io/client-go/kubernetes/scheme"
-
 	// +kubebuilder:scaffold:imports
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/log"
@@ -64,6 +63,12 @@ var (
 	operatorLogDumped       bool
 	quickDeletionPeriod     = int64(1)
 	testTimeouts            map[utils.Timeout]int
+	minioEnv                = &utils.MinioEnv{
+		Namespace:    "minio",
+		ServiceName:  "minio-service.minio",
+		CaSecretName: "minio-server-ca-secret",
+		TLSSecret:    "minio-server-tls-secret",
+	}
 )
 
 var _ = SynchronizedBeforeSuite(func() []byte {
@@ -71,40 +76,67 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	env, err = utils.NewTestingEnvironment()
 	Expect(err).ShouldNot(HaveOccurred())
 
-	pod, err := utils.GetPsqlClient(psqlClientNamespace, env)
+	psqlPod, err := utils.GetPsqlClient(psqlClientNamespace, env)
 	Expect(err).ShouldNot(HaveOccurred())
 	DeferCleanup(func() {
 		err := env.DeleteNamespaceAndWait(psqlClientNamespace, 300)
 		Expect(err).ToNot(HaveOccurred())
 	})
-	// here we serialized psql client pod object info and will be
-	// accessible to all nodes (specs)
-	psqlPodJSONObj, err := json.Marshal(pod)
+
+	// Setup a global MinIO service on his own namespace
+	err = env.CreateNamespace(minioEnv.Namespace)
+	Expect(err).ToNot(HaveOccurred())
+	DeferCleanup(func() {
+		err := env.DeleteNamespaceAndWait(minioEnv.Namespace, 300)
+		Expect(err).ToNot(HaveOccurred())
+	})
+	minioEnv.Timeout = uint(testTimeouts[utils.MinioInstallation])
+	minioClient, err := utils.MinioDeploy(minioEnv, env)
+	Expect(err).ToNot(HaveOccurred())
+
+	caSecret := minioEnv.CaPair.GenerateCASecret(minioEnv.Namespace, minioEnv.CaSecretName)
+	minioEnv.CaSecretObj = *caSecret
+	objs := map[string]corev1.Pod{
+		"psql":  *psqlPod,
+		"minio": *minioClient,
+	}
+
+	jsonObjs, err := json.Marshal(objs)
 	if err != nil {
 		panic(err)
 	}
-	return psqlPodJSONObj
-}, func(data []byte) {
+
+	return jsonObjs
+}, func(jsonObjs []byte) {
 	var err error
 	// We are creating new testing env object again because above testing env can not serialize and
 	// accessible to all nodes (specs)
 	if env, err = utils.NewTestingEnvironment(); err != nil {
 		panic(err)
 	}
+
 	_ = k8sscheme.AddToScheme(env.Scheme)
 	_ = apiv1.AddToScheme(env.Scheme)
+
 	if testLevelEnv, err = tests.TestLevel(); err != nil {
 		panic(err)
 	}
+
 	if testTimeouts, err = utils.Timeouts(); err != nil {
 		panic(err)
 	}
+
 	if testCloudVendorEnv, err = utils.TestCloudVendor(); err != nil {
 		panic(err)
 	}
-	if err := json.Unmarshal(data, &psqlClientPod); err != nil {
+
+	var objs map[string]*corev1.Pod
+	if err := json.Unmarshal(jsonObjs, &objs); err != nil {
 		panic(err)
 	}
+
+	psqlClientPod = objs["psql"]
+	minioEnv.Client = objs["minio"]
 })
 
 var _ = SynchronizedAfterSuite(func() {

--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/thoas/go-funk"
 	corev1 "k8s.io/api/core/v1"
 	k8sscheme "k8s.io/client-go/kubernetes/scheme"
+
 	// +kubebuilder:scaffold:imports
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/log"

--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -84,7 +84,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	// Setup a global MinIO service on his own namespace
+	// Set up a global MinIO service on his own namespace
 	err = env.CreateNamespace(minioEnv.Namespace)
 	Expect(err).ToNot(HaveOccurred())
 	DeferCleanup(func() {

--- a/tests/e2e/upgrade_test.go
+++ b/tests/e2e/upgrade_test.go
@@ -324,7 +324,15 @@ var _ = Describe("Upgrade", Label(tests.LabelUpgrade, tests.LabelNoOpenshift), O
 		}
 		// Delete the operator's namespace in case that the previous test make corrupted changes to
 		// the operator's namespace so that affects subsequent test
-		return env.DeleteNamespaceAndWait(operatorNamespace, 60)
+		if err := env.DeleteNamespaceAndWait(operatorNamespace, 60); err != nil {
+			return err
+		}
+
+		if _, err := testsUtils.CleanFilesOnMinio(minioEnv, "cluster-backups"); err != nil {
+			return err
+		}
+
+		return nil
 	}
 
 	assertCreateNamespace := func(namespacePrefix string) string {

--- a/tests/e2e/upgrade_test.go
+++ b/tests/e2e/upgrade_test.go
@@ -389,7 +389,10 @@ var _ = Describe("Upgrade", Label(tests.LabelUpgrade, tests.LabelNoOpenshift), O
 		By("creating the cloud storage credentials", func() {
 			AssertStorageCredentialsAreCreated(upgradeNamespace, "aws-creds", "minio", "minio123")
 		})
-
+		By("create the certificates for MinIO", func() {
+			err := minioEnv.CreateCaSecret(env, upgradeNamespace)
+			Expect(err).ToNot(HaveOccurred())
+		})
 		// Create the cluster. Since it will take a while, we'll do more stuff
 		// in parallel and check for it to be up later.
 		By(fmt.Sprintf("creating a Cluster in the '%v' upgradeNamespace",

--- a/tests/e2e/upgrade_test.go
+++ b/tests/e2e/upgrade_test.go
@@ -440,11 +440,12 @@ var _ = Describe("Upgrade", Label(tests.LabelUpgrade, tests.LabelNoOpenshift), O
 		// minio within a short time.
 		var latestWAL string
 		By("create a WAL on primary", func() {
-			primary := clusterName1 + "-1"
+			primary, err := env.GetClusterPrimary(upgradeNamespace, clusterName1)
+			Expect(err).ToNot(HaveOccurred())
 			out, _, err := env.ExecCommandInInstancePod(
 				testsUtils.PodLocator{
 					Namespace: upgradeNamespace,
-					PodName:   primary,
+					PodName:   primary.Name,
 				}, nil,
 				"psql", "-U", "postgres", "appdb", "-v", "SHOW_ALL_RESULTS=off", "-tAc",
 				"CHECKPOINT; SELECT pg_walfile_name(pg_switch_wal())")

--- a/tests/e2e/upgrade_test.go
+++ b/tests/e2e/upgrade_test.go
@@ -328,8 +328,12 @@ var _ = Describe("Upgrade", Label(tests.LabelUpgrade, tests.LabelNoOpenshift), O
 			return err
 		}
 
-		if _, err := testsUtils.CleanFilesOnMinio(minioEnv, "cluster-backups"); err != nil {
-			return err
+		if _, err := testsUtils.CleanFilesOnMinio(minioEnv, "cluster-full-backup"); err != nil {
+			GinkgoWriter.Printf("Error cleaning up minio: %v\n", err)
+		}
+
+		if _, err := testsUtils.CleanFilesOnMinio(minioEnv, "cluster2-full-backup"); err != nil {
+			GinkgoWriter.Printf("Error cleaning up minio: %v\n", err)
 		}
 
 		return nil

--- a/tests/e2e/upgrade_test.go
+++ b/tests/e2e/upgrade_test.go
@@ -313,6 +313,8 @@ var _ = Describe("Upgrade", Label(tests.LabelUpgrade, tests.LabelNoOpenshift), O
 		GinkgoWriter.Println("cleaning up")
 		if CurrentSpecReport().Failed() {
 			env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
+			// Dump the minio namespace when failed
+			env.DumpNamespaceObjects(minioEnv.Namespace, "out/"+CurrentSpecReport().LeafNodeText+"minio.log")
 			// Dump the operator namespace, as operator is changing too
 			env.DumpOperator(operatorNamespace,
 				"out/"+CurrentSpecReport().LeafNodeText+"operator.log")

--- a/tests/e2e/volume_snapshot_test.go
+++ b/tests/e2e/volume_snapshot_test.go
@@ -29,7 +29,6 @@ import (
 	k8client "sigs.k8s.io/controller-runtime/pkg/client"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
-	"github.com/cloudnative-pg/cloudnative-pg/pkg/certs"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 	"github.com/cloudnative-pg/cloudnative-pg/tests"
 	testUtils "github.com/cloudnative-pg/cloudnative-pg/tests/utils"
@@ -146,11 +145,6 @@ var _ = Describe("Verify Volume Snapshot",
 				snapshotWalEnv        = "SNAPSHOT_PITR_PGWAL"
 				recoveryTargetTimeEnv = "SNAPSHOT_PITR"
 			)
-			// minio constants
-			const (
-				minioCaSecName  = "minio-server-ca-secret"
-				minioTLSSecName = "minio-server-tls-secret"
-			)
 			// file constants
 			const (
 				clusterToSnapshot          = filesDir + "/cluster-pvc-snapshot.yaml.template"
@@ -185,39 +179,12 @@ var _ = Describe("Verify Volume Snapshot",
 					return env.DeleteNamespace(namespace)
 				})
 
-				By("creating ca and tls certificate secrets", func() {
-					// create CA certificates
-					_, caPair, err := testUtils.CreateSecretCA(namespace, clusterToSnapshotName, minioCaSecName, true, env)
-					Expect(err).ToNot(HaveOccurred())
-
-					// sign and create secret using CA certificate and key
-					serverPair, err := caPair.CreateAndSignPair("minio-service", certs.CertTypeServer,
-						[]string{"minio-service.internal.mydomain.net, minio-service.default.svc, minio-service.default,"},
-					)
-					Expect(err).ToNot(HaveOccurred())
-					serverSecret := serverPair.GenerateCertificateSecret(namespace, minioTLSSecName)
-					err = env.Client.Create(env.Ctx, serverSecret)
+				By("create the certificates for MinIO", func() {
+					err := minioEnv.CreateCaSecret(env, namespace)
 					Expect(err).ToNot(HaveOccurred())
 				})
 
-				By("creating the credentials for minio", func() {
-					AssertStorageCredentialsAreCreated(namespace, "backup-storage-creds", "minio", "minio123")
-				})
-
-				By("setting up minio", func() {
-					setup, err := testUtils.MinioSSLSetup(namespace)
-					Expect(err).ToNot(HaveOccurred())
-					err = testUtils.InstallMinio(env, setup, uint(testTimeouts[testUtils.MinioInstallation]))
-					Expect(err).ToNot(HaveOccurred())
-				})
-
-				// Create the minio client pod and wait for it to be ready.
-				// We'll use it to check if everything is archived correctly
-				By("setting up minio client pod", func() {
-					minioClient := testUtils.MinioSSLClient(namespace)
-					err := testUtils.PodCreateAndWaitForReady(env, &minioClient, 240)
-					Expect(err).ToNot(HaveOccurred())
-				})
+				AssertStorageCredentialsAreCreated(namespace, "backup-storage-creds", "minio", "minio123")
 			})
 
 			It("correctly executes PITR with a cold snapshot", func() {
@@ -241,7 +208,7 @@ var _ = Describe("Verify Volume Snapshot",
 					Expect(err).ToNot(HaveOccurred())
 					Eventually(func() (bool, error) {
 						connectionStatus, err := testUtils.MinioTestConnectivityUsingBarmanCloudWalArchive(
-							namespace, clusterToSnapshotName, primaryPod.GetName(), "minio", "minio123")
+							namespace, clusterToSnapshotName, primaryPod.GetName(), "minio", "minio123", minioEnv.ServiceName)
 						if err != nil {
 							return false, err
 						}
@@ -596,11 +563,6 @@ var _ = Describe("Verify Volume Snapshot",
 				snapshotDataEnv = "SNAPSHOT_PITR_PGDATA"
 				snapshotWalEnv  = "SNAPSHOT_PITR_PGWAL"
 			)
-			// minio constants
-			const (
-				minioCaSecName  = "minio-server-ca-secret"
-				minioTLSSecName = "minio-server-tls-secret"
-			)
 			// file constants
 			const (
 				clusterToSnapshot = filesDir + "/cluster-pvc-hot-snapshot.yaml.template"
@@ -630,39 +592,12 @@ var _ = Describe("Verify Volume Snapshot",
 					return env.DeleteNamespace(namespace)
 				})
 
-				By("creating ca and tls certificate secrets", func() {
-					// create CA certificates
-					_, caPair, err := testUtils.CreateSecretCA(namespace, clusterToSnapshotName, minioCaSecName, true, env)
-					Expect(err).ToNot(HaveOccurred())
-
-					// sign and create secret using CA certificate and key
-					serverPair, err := caPair.CreateAndSignPair("minio-service", certs.CertTypeServer,
-						[]string{"minio-service.internal.mydomain.net, minio-service.default.svc, minio-service.default,"},
-					)
-					Expect(err).ToNot(HaveOccurred())
-					serverSecret := serverPair.GenerateCertificateSecret(namespace, minioTLSSecName)
-					err = env.Client.Create(env.Ctx, serverSecret)
+				By("create the certificates for MinIO", func() {
+					err := minioEnv.CreateCaSecret(env, namespace)
 					Expect(err).ToNot(HaveOccurred())
 				})
 
-				By("creating the credentials for minio", func() {
-					AssertStorageCredentialsAreCreated(namespace, "backup-storage-creds", "minio", "minio123")
-				})
-
-				By("setting up minio", func() {
-					setup, err := testUtils.MinioSSLSetup(namespace)
-					Expect(err).ToNot(HaveOccurred())
-					err = testUtils.InstallMinio(env, setup, uint(testTimeouts[testUtils.MinioInstallation]))
-					Expect(err).ToNot(HaveOccurred())
-				})
-
-				// Create the minio client pod and wait for it to be ready.
-				// We'll use it to check if everything is archived correctly
-				By("setting up minio client pod", func() {
-					minioClient := testUtils.MinioSSLClient(namespace)
-					err := testUtils.PodCreateAndWaitForReady(env, &minioClient, 240)
-					Expect(err).ToNot(HaveOccurred())
-				})
+				AssertStorageCredentialsAreCreated(namespace, "backup-storage-creds", "minio", "minio123")
 
 				By("creating the cluster to snapshot", func() {
 					AssertCreateCluster(namespace, clusterToSnapshotName, clusterToSnapshot, env)
@@ -673,7 +608,7 @@ var _ = Describe("Verify Volume Snapshot",
 					Expect(err).ToNot(HaveOccurred())
 					Eventually(func() (bool, error) {
 						connectionStatus, err := testUtils.MinioTestConnectivityUsingBarmanCloudWalArchive(
-							namespace, clusterToSnapshotName, primaryPod.GetName(), "minio", "minio123")
+							namespace, clusterToSnapshotName, primaryPod.GetName(), "minio", "minio123", minioEnv.ServiceName)
 						if err != nil {
 							return false, err
 						}

--- a/tests/utils/backup.go
+++ b/tests/utils/backup.go
@@ -296,7 +296,7 @@ func CreateClusterFromExternalClusterBackupWithPITROnMinio(
 					Name: sourceClusterName,
 					BarmanObjectStore: &apiv1.BarmanObjectStoreConfiguration{
 						DestinationPath: "s3://cluster-backups/",
-						EndpointURL:     "https://minio-service:9000",
+						EndpointURL:     "https://minio-service.minio:9000",
 						EndpointCA: &apiv1.SecretKeySelector{
 							LocalObjectReference: apiv1.LocalObjectReference{
 								Name: "minio-server-ca-secret",

--- a/tests/utils/commons.go
+++ b/tests/utils/commons.go
@@ -31,7 +31,7 @@ import (
 // be a real WAL archive name in an idle postgresql.
 func ForgeArchiveWalOnMinio(namespace, clusterName, miniClientPodName, existingWALName, newWALName string) error {
 	// Forge a WAL archive by copying and renaming the 1st WAL archive
-	minioWALBasePath := "minio/cluster-backups/" + clusterName + "/wals/0000000100000000"
+	minioWALBasePath := "minio/" + clusterName + "/" + clusterName + "/wals/0000000100000000"
 	existingWALPath := minioWALBasePath + "/" + existingWALName + ".gz"
 	newWALNamePath := minioWALBasePath + "/" + newWALName
 	forgeWALOnMinioCmd := "mc cp " + existingWALPath + " " + newWALNamePath

--- a/tests/utils/minio.go
+++ b/tests/utils/minio.go
@@ -19,7 +19,6 @@ package utils
 import (
 	"encoding/json"
 	"fmt"
-	"k8s.io/apimachinery/pkg/types"
 	"os"
 	"strconv"
 	"strings"
@@ -30,6 +29,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/tests/utils/minio.go
+++ b/tests/utils/minio.go
@@ -560,6 +560,11 @@ func composeListFilesMinio(path string, serviceName string) string {
 	return fmt.Sprintf("sh -c 'mc find %v --path %v'", serviceName, path)
 }
 
+// composeListFilesMinio builds the Minio command to list the filenames matching a given path
+func composeCleanFilesMinio(serviceName string) string {
+	return fmt.Sprintf("sh -c 'mc rm --force --recursive minio/%v'", serviceName)
+}
+
 // composeFindMinioCmd builds the Minio find command
 func composeFindMinioCmd(path string, serviceName string) string {
 	return fmt.Sprintf("sh -c 'mc find %v --path %v | wc -l'", serviceName, path)
@@ -620,4 +625,18 @@ func MinioTestConnectivityUsingBarmanCloudWalArchive(
 		return false, err
 	}
 	return true, nil
+}
+
+// CleanFilesOnMinio clean files on minio for a given path
+func CleanFilesOnMinio(minioEnv *MinioEnv, path string) (string, error) {
+	var stdout string
+	stdout, _, err := RunUnchecked(fmt.Sprintf(
+		"kubectl exec -n %v %v -- %v",
+		minioEnv.Namespace,
+		minioEnv.Client.Name,
+		composeCleanFilesMinio(path)))
+	if err != nil {
+		return "", err
+	}
+	return strings.Trim(stdout, "\n"), nil
 }

--- a/tests/utils/minio.go
+++ b/tests/utils/minio.go
@@ -19,6 +19,7 @@ package utils
 import (
 	"encoding/json"
 	"fmt"
+	"k8s.io/apimachinery/pkg/types"
 	"os"
 	"strconv"
 	"strings"
@@ -33,6 +34,7 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/certs"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/postgres"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 )
@@ -41,6 +43,19 @@ const (
 	minioImage       = "minio/minio:RELEASE.2022-06-20T23-13-45Z"
 	minioClientImage = "minio/mc:RELEASE.2022-06-11T21-10-36Z"
 )
+
+// MinioEnv contains all the information related or required by MinIO deployment and
+// used by the functions on every test
+type MinioEnv struct {
+	Client       *corev1.Pod
+	CaPair       *certs.KeyPair
+	CaSecretObj  corev1.Secret
+	ServiceName  string
+	Namespace    string
+	CaSecretName string
+	TLSSecret    string
+	Timeout      uint
+}
 
 // MinioSetup contains the resources needed for a working minio server deployment:
 // a PersistentVolumeClaim, a Deployment and a Service
@@ -361,11 +376,11 @@ func MinioDefaultClient(namespace string) corev1.Pod {
 					Env: []corev1.EnvVar{
 						{
 							Name:  "MC_HOST_minio",
-							Value: "http://minio:minio123@minio-service:9000",
+							Value: "http://minio:minio123@minio-service.minio:9000",
 						},
 						{
 							Name:  "MC_URL",
-							Value: "https://minio-service:9000",
+							Value: "https://minio-service.minio:9000",
 						},
 						{
 							Name:  "HOME",
@@ -435,19 +450,88 @@ func MinioSSLClient(namespace string) corev1.Pod {
 			MountPath: tlsVolumeMountPath,
 		},
 	)
-	minioClient.Spec.Containers[0].Env[0].Value = "https://minio:minio123@minio-service:9000"
+	minioClient.Spec.Containers[0].Env[0].Value = "https://minio:minio123@minio-service.minio:9000"
 
 	return minioClient
 }
 
+// MinioDeploy will create a full MinIO deployment defined inthe minioEnv variable
+func MinioDeploy(minioEnv *MinioEnv, env *TestingEnvironment) (*corev1.Pod, error) {
+	var err error
+	minioEnv.CaPair, err = certs.CreateRootCA(minioEnv.Namespace, "minio")
+	if err != nil {
+		return nil, err
+	}
+
+	minioEnv.CaSecretObj = *minioEnv.CaPair.GenerateCASecret(minioEnv.Namespace, minioEnv.CaSecretName)
+	if _, err = CreateObject(env, &minioEnv.CaSecretObj); err != nil {
+		return nil, err
+	}
+
+	// sign and create secret using CA certificate and key
+	serverPair, err := minioEnv.CaPair.CreateAndSignPair("minio-service", certs.CertTypeServer,
+		[]string{"minio.useless.domain.not.verified", "minio-service.minio"},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	serverSecret := serverPair.GenerateCertificateSecret(minioEnv.Namespace, minioEnv.TLSSecret)
+	if err = env.Client.Create(env.Ctx, serverSecret); err != nil {
+		return nil, err
+	}
+
+	setup, err := MinioSSLSetup(minioEnv.Namespace)
+	if err != nil {
+		return nil, err
+	}
+	if err = InstallMinio(env, setup, minioEnv.Timeout); err != nil {
+		return nil, err
+	}
+
+	minioClient := MinioSSLClient(minioEnv.Namespace)
+
+	return &minioClient, PodCreateAndWaitForReady(env, &minioClient, 240)
+}
+
+func (m *MinioEnv) getCaSecret(env *TestingEnvironment, namespace string) (*corev1.Secret, error) {
+	var certSecret corev1.Secret
+	if err := env.Client.Get(env.Ctx,
+		types.NamespacedName{
+			Namespace: m.Namespace,
+			Name:      m.CaSecretName,
+		}, &certSecret); err != nil {
+		return nil, err
+	}
+
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      m.CaSecretName,
+			Namespace: namespace,
+		},
+		Data: certSecret.Data,
+		Type: certSecret.Type,
+	}, nil
+}
+
+// CreateCaSecret creates the certificates required to authenticate against the the MinIO service
+func (m *MinioEnv) CreateCaSecret(env *TestingEnvironment, namespace string) error {
+	caSecret, err := m.getCaSecret(env, namespace)
+	if err != nil {
+		return err
+	}
+	_, err = CreateObject(env, caSecret)
+	return err
+}
+
 // CountFilesOnMinio uses the minioClient in the given `namespace` to count  the
 // amount of files matching the given `path`
-func CountFilesOnMinio(namespace string, minioClientName string, path string) (value int, err error) {
+func CountFilesOnMinio(minioEnv *MinioEnv, path string) (value int, err error) {
 	var stdout string
 	stdout, _, err = RunUnchecked(fmt.Sprintf(
 		"kubectl exec -n %v %v -- %v",
-		namespace,
-		minioClientName,
+		minioEnv.Namespace,
+		minioEnv.Client.Name,
 		composeFindMinioCmd(path, "minio")))
 	if err != nil {
 		return -1, err
@@ -458,12 +542,12 @@ func CountFilesOnMinio(namespace string, minioClientName string, path string) (v
 
 // ListFilesOnMinio uses the minioClient in the given `namespace` to list the
 // paths matching the given `path`
-func ListFilesOnMinio(namespace string, minioClientName string, path string) (string, error) {
+func ListFilesOnMinio(minioEnv *MinioEnv, path string) (string, error) {
 	var stdout string
 	stdout, _, err := RunUnchecked(fmt.Sprintf(
 		"kubectl exec -n %v %v -- %v",
-		namespace,
-		minioClientName,
+		minioEnv.Namespace,
+		minioEnv.Client.Name,
 		composeListFilesMinio(path, "minio")))
 	if err != nil {
 		return "", err
@@ -482,13 +566,13 @@ func composeFindMinioCmd(path string, serviceName string) string {
 }
 
 // GetFileTagsOnMinio will use the minioClient to retrieve the tags in a specified path
-func GetFileTagsOnMinio(namespace, minioClientName, path string) (TagSet, error) {
+func GetFileTagsOnMinio(minioEnv *MinioEnv, path string) (TagSet, error) {
 	var output TagSet
 	// Make sure we have a registered backup to access
 	out, _, err := RunUncheckedRetry(fmt.Sprintf(
 		"kubectl exec -n %v %v -- sh -c 'mc find minio --name %v | head -n1'",
-		namespace,
-		minioClientName,
+		minioEnv.Namespace,
+		minioEnv.Client.Name,
 		path))
 	if err != nil {
 		return output, err
@@ -498,8 +582,8 @@ func GetFileTagsOnMinio(namespace, minioClientName, path string) (TagSet, error)
 
 	stdout, _, err := RunUncheckedRetry(fmt.Sprintf(
 		"kubectl exec -n %v %v -- sh -c 'mc --json tag list %v'",
-		namespace,
-		minioClientName,
+		minioEnv.Namespace,
+		minioEnv.Client.Name,
 		walFile))
 	if err != nil {
 		return output, err
@@ -513,9 +597,14 @@ func GetFileTagsOnMinio(namespace, minioClientName, path string) (TagSet, error)
 }
 
 // MinioTestConnectivityUsingBarmanCloudWalArchive returns true if test connection is successful else false
-func MinioTestConnectivityUsingBarmanCloudWalArchive(namespace, clusterName, podName, id, key string) (bool, error) {
-	minioSvc := MinioDefaultSVC(namespace)
-	minioSvcName := minioSvc.GetName()
+func MinioTestConnectivityUsingBarmanCloudWalArchive(
+	namespace,
+	clusterName,
+	podName,
+	id,
+	key string,
+	minioSvcName string,
+) (bool, error) {
 	// test connectivity should work with valid sample "000000010000000000000000" wal file
 	// using barman-cloud-wal-archive script
 	cmd := fmt.Sprintf("export AWS_CA_BUNDLE=%s;export AWS_ACCESS_KEY_ID=%s;export AWS_SECRET_ACCESS_KEY=%s;"+

--- a/tests/utils/pod.go
+++ b/tests/utils/pod.go
@@ -192,6 +192,9 @@ func (env TestingEnvironment) ExecCommandInContainer(
 	if err != nil {
 		return "", "", wrapErr(err)
 	}
+	if !pkgutils.IsPodReady(*pod) {
+		return "", "", fmt.Errorf("pod not ready. Namespace: %v, Name: %v", pod.Namespace, pod.Name)
+	}
 	return env.ExecCommand(env.Ctx, *pod, container.ContainerName, timeout, command...)
 }
 


### PR DESCRIPTION
Currently, we set up a dedicated MinIO service for each E2E test that needs an object store; this consumes RAM, CPU, and a lot of time.

With this patch, we use only one global MinIO service for all the tests.

Closes #3951 