### PR TITLE
fix: cluster phase change should not interrupt the hibernation processing

### DIFF
--- a/api/v1/cluster_webhook.go
+++ b/api/v1/cluster_webhook.go
@@ -378,7 +378,7 @@ func (r *Cluster) Validate() (allErrs field.ErrorList) {
 		r.validateManagedRoles,
 		r.validateManagedExtensions,
 		r.validateResources,
-		r.validateHibernation,
+		r.validateHibernationAnnotation,
 	}
 
 	for _, validate := range validations {
@@ -2432,18 +2432,22 @@ func (r *Cluster) getMaintenanceWindowsAdmissionWarnings() admission.Warnings {
 }
 
 // validate whether the hibernation configuration is valid
-func (r *Cluster) validateHibernation() field.ErrorList {
+func (r *Cluster) validateHibernationAnnotation() field.ErrorList {
 	value, ok := r.Annotations[utils.HibernationAnnotationName]
-	if !ok || value == string(utils.HibernationOn) || value == string(utils.HibernationOff) {
+	isKnownValue := value == string(utils.HibernationAnnotationValueOn) ||
+		value == string(utils.HibernationAnnotationValueOff)
+	if !ok || isKnownValue {
 		return nil
 	}
 
-	var result field.ErrorList
-	result = append(result, field.Invalid(
-		field.NewPath("metadata", "annotations", utils.HibernationAnnotationName),
-		value,
-		fmt.Sprintf("Annotation value for hibernation should be %q or %q", utils.HibernationOn, utils.HibernationOff)),
-	)
-
-	return result
+	return field.ErrorList{
+		field.Invalid(
+			field.NewPath("metadata", "annotations", utils.HibernationAnnotationName),
+			value,
+			fmt.Sprintf("Annotation value for hibernation should be %q or %q",
+				utils.HibernationAnnotationValueOn,
+				utils.HibernationAnnotationValueOff,
+			),
+		),
+	}
 }

--- a/api/v1/cluster_webhook.go
+++ b/api/v1/cluster_webhook.go
@@ -2442,7 +2442,7 @@ func (r *Cluster) validateHibernation() field.ErrorList {
 	result = append(result, field.Invalid(
 		field.NewPath("metadata", "annotations", utils.HibernationAnnotationName),
 		value,
-		fmt.Sprintf("Invalid value. It should be %q or %q", utils.HibernationOn, utils.HibernationOff)),
+		fmt.Sprintf("Annotation value for hibernation should be %q or %q", utils.HibernationOn, utils.HibernationOff)),
 	)
 
 	return result

--- a/api/v1/cluster_webhook_test.go
+++ b/api/v1/cluster_webhook_test.go
@@ -4236,7 +4236,7 @@ var _ = Describe("Validate hibernation", func() {
 		Expect(cluster.validateHibernationAnnotation()).To(BeEmpty())
 	})
 
-	It("should failed if hibernation is set to a invalid value", func() {
+	It("should fail if hibernation is set to an invalid value", func() {
 		cluster := &Cluster{
 			ObjectMeta: metav1.ObjectMeta{
 				Annotations: map[string]string{

--- a/api/v1/cluster_webhook_test.go
+++ b/api/v1/cluster_webhook_test.go
@@ -4212,3 +4212,38 @@ var _ = Describe("Tablespaces validation", func() {
 		Expect(cluster.validateTablespaceBackupSnapshot()).To(HaveLen(1))
 	})
 })
+
+var _ = Describe("Validate hibernation", func() {
+	It("should succeed if hibernation is set to 'on'", func() {
+		cluster := &Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					utils.HibernationAnnotationName: string(utils.HibernationOn),
+				},
+			},
+		}
+		Expect(cluster.validateHibernation()).To(BeEmpty())
+	})
+
+	It("should succeed if hibernation is set to 'off'", func() {
+		cluster := &Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					utils.HibernationAnnotationName: string(utils.HibernationOff),
+				},
+			},
+		}
+		Expect(cluster.validateHibernation()).To(BeEmpty())
+	})
+
+	It("should failed if hibernation is set to a invalid value", func() {
+		cluster := &Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					utils.HibernationAnnotationName: "",
+				},
+			},
+		}
+		Expect(cluster.validateHibernation()).To(HaveLen(1))
+	})
+})

--- a/api/v1/cluster_webhook_test.go
+++ b/api/v1/cluster_webhook_test.go
@@ -4218,22 +4218,22 @@ var _ = Describe("Validate hibernation", func() {
 		cluster := &Cluster{
 			ObjectMeta: metav1.ObjectMeta{
 				Annotations: map[string]string{
-					utils.HibernationAnnotationName: string(utils.HibernationOn),
+					utils.HibernationAnnotationName: string(utils.HibernationAnnotationValueOn),
 				},
 			},
 		}
-		Expect(cluster.validateHibernation()).To(BeEmpty())
+		Expect(cluster.validateHibernationAnnotation()).To(BeEmpty())
 	})
 
 	It("should succeed if hibernation is set to 'off'", func() {
 		cluster := &Cluster{
 			ObjectMeta: metav1.ObjectMeta{
 				Annotations: map[string]string{
-					utils.HibernationAnnotationName: string(utils.HibernationOff),
+					utils.HibernationAnnotationName: string(utils.HibernationAnnotationValueOff),
 				},
 			},
 		}
-		Expect(cluster.validateHibernation()).To(BeEmpty())
+		Expect(cluster.validateHibernationAnnotation()).To(BeEmpty())
 	})
 
 	It("should failed if hibernation is set to a invalid value", func() {
@@ -4244,6 +4244,6 @@ var _ = Describe("Validate hibernation", func() {
 				},
 			},
 		}
-		Expect(cluster.validateHibernation()).To(HaveLen(1))
+		Expect(cluster.validateHibernationAnnotation()).To(HaveLen(1))
 	})
 })

--- a/pkg/reconciler/hibernation/status.go
+++ b/pkg/reconciler/hibernation/status.go
@@ -29,13 +29,11 @@ import (
 )
 
 const (
-	// HibernationOff is the value of hibernation annotation when the hibernation
-	// has been deactivated for the cluster
-	HibernationOff = "off"
+	// HibernationOff is the shadow of utils.HibernationOff, for compatibility
+	HibernationOff = string(utils.HibernationOff)
 
-	// HibernationOn is the value of hibernation annotation when the hibernation
-	// has been requested for the cluster
-	HibernationOn = "on"
+	// HibernationOn is the shadow of utils.HibernationOn, for compatibility
+	HibernationOn = string(utils.HibernationOn)
 )
 
 const (

--- a/pkg/reconciler/hibernation/status.go
+++ b/pkg/reconciler/hibernation/status.go
@@ -85,9 +85,9 @@ func EnrichStatus(
 	// We proceed to hibernate the cluster only when it is ready.
 	// Hibernating a non-ready cluster may be dangerous since the PVCs
 	// won't be completely created.
-	// For the hibernation is in progress(the condition is present), continue to hibernate the cluster
-	condition := meta.FindStatusCondition(cluster.Status.Conditions, HibernationConditionType)
-	if condition == nil && cluster.Status.Phase != apiv1.PhaseHealthy {
+	// Once the hibernation is in progressing, even the cluster is not healthy, we should not
+	// stop the hibernation process here
+	if cluster.Status.Phase != apiv1.PhaseHealthy && !isHibernationInProcessing(cluster) {
 		return
 	}
 
@@ -123,4 +123,9 @@ func EnrichStatus(
 
 func isEnabledHibernation(cluster *apiv1.Cluster) bool {
 	return cluster.Annotations[utils.HibernationAnnotationName] == HibernationOn
+}
+
+// isHibernationInProcessing check if the cluster is doing the hibernation process
+func isHibernationInProcessing(cluster *apiv1.Cluster) bool {
+	return meta.FindStatusCondition(cluster.Status.Conditions, HibernationConditionType) != nil
 }

--- a/pkg/reconciler/hibernation/status_test.go
+++ b/pkg/reconciler/hibernation/status_test.go
@@ -31,7 +31,7 @@ import (
 var _ = Describe("Hibernation annotation management", func() {
 	It("classifies clusters with no annotation as not hibernated", func() {
 		cluster := apiv1.Cluster{}
-		Expect(isEnabledHibernation(&cluster)).To(BeFalse())
+		Expect(isHibernationEnabled(&cluster)).To(BeFalse())
 	})
 
 	It("correctly handles on/off values", func() {
@@ -42,10 +42,10 @@ var _ = Describe("Hibernation annotation management", func() {
 				},
 			},
 		}
-		Expect(isEnabledHibernation(&cluster)).To(BeTrue())
+		Expect(isHibernationEnabled(&cluster)).To(BeTrue())
 
 		cluster.ObjectMeta.Annotations[utils.HibernationAnnotationName] = HibernationOff
-		Expect(isEnabledHibernation(&cluster)).To(BeFalse())
+		Expect(isHibernationEnabled(&cluster)).To(BeFalse())
 	})
 })
 

--- a/pkg/reconciler/hibernation/status_test.go
+++ b/pkg/reconciler/hibernation/status_test.go
@@ -56,25 +56,6 @@ var _ = Describe("Status enrichment", func() {
 		Expect(cluster.Status.Conditions).To(BeEmpty())
 	})
 
-	It("adds an error condition when the hibernation annotation has a wrong value", func(ctx SpecContext) {
-		cluster := apiv1.Cluster{
-			ObjectMeta: metav1.ObjectMeta{
-				Annotations: map[string]string{
-					utils.HibernationAnnotationName: "not-correct",
-				},
-			},
-			Status: apiv1.ClusterStatus{
-				Phase: apiv1.PhaseHealthy,
-			},
-		}
-		EnrichStatus(ctx, &cluster, nil)
-
-		hibernationCondition := meta.FindStatusCondition(cluster.Status.Conditions, HibernationConditionType)
-		Expect(hibernationCondition).ToNot(BeNil())
-		Expect(hibernationCondition.Status).To(Equal(metav1.ConditionFalse))
-		Expect(hibernationCondition.Reason).To(Equal(HibernationConditionReasonWrongAnnotationValue))
-	})
-
 	It("removes the hibernation condition when hibernation is turned off", func(ctx SpecContext) {
 		cluster := apiv1.Cluster{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/reconciler/hibernation/status_test.go
+++ b/pkg/reconciler/hibernation/status_test.go
@@ -31,7 +31,7 @@ import (
 var _ = Describe("Hibernation annotation management", func() {
 	It("classifies clusters with no annotation as not hibernated", func() {
 		cluster := apiv1.Cluster{}
-		Expect(getHibernationAnnotationValue(&cluster)).To(BeFalse())
+		Expect(isEnabledHibernation(&cluster)).To(BeFalse())
 	})
 
 	It("correctly handles on/off values", func() {
@@ -42,22 +42,10 @@ var _ = Describe("Hibernation annotation management", func() {
 				},
 			},
 		}
-		Expect(getHibernationAnnotationValue(&cluster)).To(BeTrue())
+		Expect(isEnabledHibernation(&cluster)).To(BeTrue())
 
 		cluster.ObjectMeta.Annotations[utils.HibernationAnnotationName] = HibernationOff
-		Expect(getHibernationAnnotationValue(&cluster)).To(BeFalse())
-	})
-
-	It("fails when the value of the annotation is not correct", func() {
-		cluster := apiv1.Cluster{
-			ObjectMeta: metav1.ObjectMeta{
-				Annotations: map[string]string{
-					utils.HibernationAnnotationName: "not-correct",
-				},
-			},
-		}
-		_, err := getHibernationAnnotationValue(&cluster)
-		Expect(err).ToNot(Succeed())
+		Expect(isEnabledHibernation(&cluster)).To(BeFalse())
 	})
 })
 

--- a/pkg/utils/labels_annotations.go
+++ b/pkg/utils/labels_annotations.go
@@ -233,17 +233,17 @@ const (
 	PVCRolePgTablespace PVCRole = "PG_TABLESPACE"
 )
 
-// HibernationStatus describes the status of the hibernation
-type HibernationStatus string
+// HibernationAnnotationValue describes the status of the hibernation
+type HibernationAnnotationValue string
 
 const (
-	// HibernationOff is the value of hibernation annotation when the hibernation
+	// HibernationAnnotationValueOff is the value of hibernation annotation when the hibernation
 	// has been deactivated for the cluster
-	HibernationOff HibernationStatus = "off"
+	HibernationAnnotationValueOff HibernationAnnotationValue = "off"
 
-	// HibernationOn is the value of hibernation annotation when the hibernation
+	// HibernationAnnotationValueOn is the value of hibernation annotation when the hibernation
 	// has been requested for the cluster
-	HibernationOn HibernationStatus = "on"
+	HibernationAnnotationValueOn HibernationAnnotationValue = "on"
 )
 
 // LabelClusterName labels the object with the cluster name

--- a/pkg/utils/labels_annotations.go
+++ b/pkg/utils/labels_annotations.go
@@ -233,6 +233,19 @@ const (
 	PVCRolePgTablespace PVCRole = "PG_TABLESPACE"
 )
 
+// HibernationStatus describes the status of the hibernation
+type HibernationStatus string
+
+const (
+	// HibernationOff is the value of hibernation annotation when the hibernation
+	// has been deactivated for the cluster
+	HibernationOff HibernationStatus = "off"
+
+	// HibernationOn is the value of hibernation annotation when the hibernation
+	// has been requested for the cluster
+	HibernationOn HibernationStatus = "on"
+)
+
 // LabelClusterName labels the object with the cluster name
 func LabelClusterName(object *metav1.ObjectMeta, name string) {
 	if object.Labels == nil {


### PR DESCRIPTION
This patch fix a corner case that during hibernation, instance pod has
been deleted but cluster status still have hibernation condition 
`k8s.enterprisedb.io/hibernation` set to state=false.  Also in this patch, 
we enfored the hibernation annotation `k8s.enterprisedb.io/hibernation` 
can only accept `on` and `off` value in webhook.
 

closes #3965  