### PR TITLE
test(e2e): add coverage for multi-arch in-place update

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/manager/backup"
 	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/manager/bootstrap"
 	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/manager/controller"
+	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/manager/debug"
 	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/manager/instance"
 	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/manager/pgbouncer"
 	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/manager/show"
@@ -60,6 +61,7 @@ func main() {
 	cmd.AddCommand(walrestore.NewCmd())
 	cmd.AddCommand(versions.NewCmd())
 	cmd.AddCommand(pgbouncer.NewCmd())
+	cmd.AddCommand(debug.NewCmd())
 
 	if err := cmd.Execute(); err != nil {
 		os.Exit(1)

--- a/internal/cmd/manager/debug/architectures/cmd.go
+++ b/internal/cmd/manager/debug/architectures/cmd.go
@@ -48,8 +48,9 @@ func run() error {
 	if err := utils.DetectAvailableArchitectures(); err != nil {
 		return err
 	}
-	architectures := make([]string, 0, len(utils.GetAvailableArchitectures()))
-	for _, arch := range utils.GetAvailableArchitectures() {
+	availableArchitectures := utils.GetAvailableArchitectures()
+	architectures := make([]string, 0, len(availableArchitectures))
+	for _, arch := range availableArchitectures {
 		architectures = append(architectures, arch.GoArch)
 	}
 	val, err := json.MarshalIndent(architectures, "", "    ")

--- a/internal/cmd/manager/debug/architectures/cmd.go
+++ b/internal/cmd/manager/debug/architectures/cmd.go
@@ -1,0 +1,64 @@
+/*
+Copyright The CloudNativePG Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package architectures implement the show-architectures command
+package architectures
+
+import (
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/log"
+)
+
+// NewCmd creates the new cobra command
+func NewCmd() *cobra.Command {
+	cmd := cobra.Command{
+		Use:   "show-architectures",
+		Short: "Lists all the CPU architectures supported by this image",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			if err := run(); err != nil {
+				log.Error(err, "Error while extracting the list of supported architectures")
+			}
+
+			return nil
+		},
+	}
+
+	return &cmd
+}
+
+func run() error {
+	binaries, err := filepath.Glob("bin/manager_*")
+	if err != nil {
+		return err
+	}
+	architectures := make([]string, 0, len(binaries))
+	for _, b := range binaries {
+		goArch := strings.Split(filepath.Base(b), "manager_")[1]
+		architectures = append(architectures, goArch)
+	}
+	val, err := json.MarshalIndent(architectures, "", "    ")
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(val))
+	return nil
+}

--- a/internal/cmd/manager/debug/architectures/cmd.go
+++ b/internal/cmd/manager/debug/architectures/cmd.go
@@ -20,12 +20,11 @@ package architectures
 import (
 	"encoding/json"
 	"fmt"
-	"path/filepath"
-	"strings"
 
 	"github.com/spf13/cobra"
 
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/log"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 )
 
 // NewCmd creates the new cobra command

--- a/internal/cmd/manager/debug/architectures/cmd.go
+++ b/internal/cmd/manager/debug/architectures/cmd.go
@@ -46,14 +46,12 @@ func NewCmd() *cobra.Command {
 }
 
 func run() error {
-	binaries, err := filepath.Glob("bin/manager_*")
-	if err != nil {
+	if err := utils.DetectAvailableArchitectures(); err != nil {
 		return err
 	}
-	architectures := make([]string, 0, len(binaries))
-	for _, b := range binaries {
-		goArch := strings.Split(filepath.Base(b), "manager_")[1]
-		architectures = append(architectures, goArch)
+	architectures := make([]string, 0, len(utils.GetAvailableArchitectures()))
+	for _, arch := range utils.GetAvailableArchitectures() {
+		architectures = append(architectures, arch.GoArch)
 	}
 	val, err := json.MarshalIndent(architectures, "", "    ")
 	if err != nil {

--- a/internal/cmd/manager/debug/architectures/cmd.go
+++ b/internal/cmd/manager/debug/architectures/cmd.go
@@ -35,6 +35,7 @@ func NewCmd() *cobra.Command {
 		RunE: func(_ *cobra.Command, _ []string) error {
 			if err := run(); err != nil {
 				log.Error(err, "Error while extracting the list of supported architectures")
+				return err
 			}
 
 			return nil

--- a/internal/cmd/manager/debug/cmd.go
+++ b/internal/cmd/manager/debug/cmd.go
@@ -27,7 +27,7 @@ import (
 func NewCmd() *cobra.Command {
 	cmd := cobra.Command{
 		Use:           "debug [cmd]",
-		Short:         "Useful debug subfeatures",
+		Short:         "Command aimed to gather useful debug data",
 		SilenceErrors: true,
 	}
 

--- a/internal/cmd/manager/debug/cmd.go
+++ b/internal/cmd/manager/debug/cmd.go
@@ -1,0 +1,37 @@
+/*
+Copyright The CloudNativePG Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package debug implement the debug command subfeatures
+package debug
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/manager/debug/architectures"
+)
+
+// NewCmd creates the new cobra command
+func NewCmd() *cobra.Command {
+	cmd := cobra.Command{
+		Use:           "debug [cmd]",
+		Short:         "Useful debug subfeatures",
+		SilenceErrors: true,
+	}
+
+	cmd.AddCommand(architectures.NewCmd())
+
+	return &cmd
+}

--- a/tests/e2e/architecture_test.go
+++ b/tests/e2e/architecture_test.go
@@ -87,7 +87,7 @@ var _ = Describe("Available Architectures", Label(tests.LabelBasic), func() {
 		// Fetch the operator's available architectures
 		operatorPod, err := env.GetOperatorPod()
 		Expect(err).ToNot(HaveOccurred())
-		imageArchitectures, err := utils.GetOperatorArchitectures(operatorPod)
+		imageArchitectures, err := utils.GetOperatorArchitectures(&operatorPod)
 		Expect(err).ToNot(HaveOccurred())
 
 		// Fetch the Cluster status

--- a/tests/e2e/architecture_test.go
+++ b/tests/e2e/architecture_test.go
@@ -17,11 +17,9 @@ limitations under the License.
 package e2e
 
 import (
-	"os"
-	"strings"
-
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/tests"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -34,24 +32,9 @@ var _ = Describe("Available Architectures", Label(tests.LabelBasic), func() {
 		level           = tests.Low
 	)
 
-	// we assume the image to be built for just amd64 as default. We try to calculate other envs inside the beforeEach
-	// block
-	imageArchitectures := []string{"amd64"}
-
 	BeforeEach(func() {
 		if testLevelEnv.Depth < int(level) {
 			Skip("Test depth is lower than the amount requested for this test")
-		}
-
-		// TODO: instead of fetching the current architectures using the
-		// PLATFORMS env variable, we should have a manager command which
-		// returns all the architectures available in the current image.
-
-		// Fetch the current image architectures via the PLATFORMS env variable.
-		if architecturesFromUser, exist := os.LookupEnv("PLATFORMS"); exist {
-			s := strings.ReplaceAll(architecturesFromUser, "linux/", "")
-			arches := strings.Split(s, ",")
-			imageArchitectures = arches
 		}
 	})
 
@@ -100,6 +83,12 @@ var _ = Describe("Available Architectures", Label(tests.LabelBasic), func() {
 		clusterName, err := env.GetResourceNameFromYAML(clusterManifest)
 		Expect(err).ToNot(HaveOccurred())
 		AssertCreateCluster(namespace, clusterName, clusterManifest, env)
+
+		// Fetch the operator's available architectures
+		operatorPod, err := env.GetOperatorPod()
+		Expect(err).ToNot(HaveOccurred())
+		imageArchitectures, err := utils.GetOperatorArchitectures(operatorPod)
+		Expect(err).ToNot(HaveOccurred())
 
 		// Fetch the Cluster status
 		cluster, err := env.GetCluster(namespace, clusterName)

--- a/tests/utils/operator.go
+++ b/tests/utils/operator.go
@@ -301,3 +301,24 @@ func GetOperatorVersion(namespace, podName string) (string, error) {
 	ver := versionRegexp.FindStringSubmatch(strings.TrimSpace(out))[1]
 	return ver, nil
 }
+
+// GetOperatorArchitectures returns all the supported operator architectures
+func GetOperatorArchitectures(operatorPod corev1.Pod) ([]string, error) {
+	out, _, err := RunUnchecked(fmt.Sprintf(
+		"kubectl -n %v exec %v -c manager -- /manager debug show-architectures",
+		operatorPod.Namespace,
+		operatorPod.Name,
+	))
+	if err != nil {
+		return nil, err
+	}
+
+	// `debug show-architectures` will print a JSON object
+	var res []string
+	err = json.Unmarshal([]byte(out), &res)
+	if err != nil {
+		return nil, err
+	}
+
+	return res, err
+}

--- a/tests/utils/operator.go
+++ b/tests/utils/operator.go
@@ -303,7 +303,7 @@ func GetOperatorVersion(namespace, podName string) (string, error) {
 }
 
 // GetOperatorArchitectures returns all the supported operator architectures
-func GetOperatorArchitectures(operatorPod corev1.Pod) ([]string, error) {
+func GetOperatorArchitectures(operatorPod *corev1.Pod) ([]string, error) {
 	out, _, err := RunUnchecked(fmt.Sprintf(
 		"kubectl -n %v exec %v -c manager -- /manager debug show-architectures",
 		operatorPod.Namespace,


### PR DESCRIPTION
This patch adds end-to-end (E2E) coverage for the multi-architecture in-place update feature. A debug command was introduced to fetch available architectures in the operator container to facilitate this E2E testing in any environment.

Related To #3840 
Closes #3972 

