### PR TITLE
fix: add the missing clusterPermissions to OLM deployment

### DIFF
--- a/config/olm-manifests/kustomization.yaml
+++ b/config/olm-manifests/kustomization.yaml
@@ -3,5 +3,6 @@ resources:
 - ../olm-default
 - ../olm-samples
 - ../olm-scorecard
+- ../olm-rbac
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/config/olm-rbac/kustomization.yaml
+++ b/config/olm-rbac/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- role_global.yaml
+- role_binding_global.yaml

--- a/config/olm-rbac/role_binding_global.yaml
+++ b/config/olm-rbac/role_binding_global.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: manager
+subjects:
+- kind: ServiceAccount
+  name: cnpg-manager
+  namespace: cnpg-system

--- a/config/olm-rbac/role_global.yaml
+++ b/config/olm-rbac/role_global.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: manager
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch


### PR DESCRIPTION
Since the fix we applied on #3854 we changed all the `clusterPermissions` section to `permissions` meaning that we also moved the permissions required to get `nodes` and `namespaces` information, which is required by the operator even if is deployed at namespace level.

Closes #3989