### PR TITLE
docs: clarify that `PodSecurityPolicy` is now deprecated

### DIFF
--- a/.wordlist-en-custom.txt
+++ b/.wordlist-en-custom.txt
@@ -279,6 +279,7 @@ PodAntiAffinityType
 PodDisruptionBudget
 PodMeta
 PodMonitor
+PodSecurityPolicy
 PodSpec
 PodStatus
 PodTemplateSpec

--- a/docs/src/security.md
+++ b/docs/src/security.md
@@ -215,6 +215,11 @@ CloudNativePG.
 
 ### Pod Security Policies
 
+!!! Important
+    PodSecurityPolicy was deprecated in Kubernetes v1.21 and fully removed in
+    Kubernetes v1.25, since the operator is still being tested in old versions we keep
+    this section, but versions older than 1.25 aren't supported by the community.
+
 A [Pod Security Policy](https://kubernetes.io/docs/concepts/policy/pod-security-policy/)
 is the Kubernetes way to define security rules and specifications that a pod needs to meet
 to run in a cluster.

--- a/docs/src/security.md
+++ b/docs/src/security.md
@@ -216,9 +216,11 @@ CloudNativePG.
 ### Pod Security Policies
 
 !!! Important
-    PodSecurityPolicy was deprecated in Kubernetes v1.21 and fully removed in
-    Kubernetes v1.25, since the operator is still being tested in old versions we keep
-    this section, but versions older than 1.25 aren't supported by the community.
+    Starting from Kubernetes v1.21, the use of `PodSecurityPolicy` has been
+    deprecated, and as of Kubernetes v1.25, it has been completely removed. Despite
+    this deprecation, we acknowledge that the operator is currently undergoing
+    testing in older and unsupported versions of Kubernetes. Therefore, this
+    section is retained for those specific scenarios.
 
 A [Pod Security Policy](https://kubernetes.io/docs/concepts/policy/pod-security-policy/)
 is the Kubernetes way to define security rules and specifications that a pod needs to meet


### PR DESCRIPTION
Addressing `PodSecurityPolicy` removal in Kubernetes v1.25. Explaining our reasons for keeping this section for now, even though it's slated for removal in the near future.

Closes #3991 