### PR TITLE
fix: add --force-conflicts options to kubectl apply

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,7 +180,7 @@ uninstall: manifests kustomize ## Uninstall CRDs from a cluster.
 	$(KUSTOMIZE) build config/crd | kubectl delete -f -
 
 deploy: generate-manifest ## Deploy controller in the configured Kubernetes cluster in ~/.kube/config.
-	kubectl apply --server-side -f ${OPERATOR_MANIFEST_PATH}
+	kubectl apply --server-side --force-conflicts -f ${OPERATOR_MANIFEST_PATH}
 
 generate-manifest: manifests kustomize ## Generate manifest used for deployment.
 	set -e ;\

--- a/tests/e2e/upgrade_test.go
+++ b/tests/e2e/upgrade_test.go
@@ -358,7 +358,7 @@ var _ = Describe("Upgrade", Label(tests.LabelUpgrade, tests.LabelNoOpenshift), O
 		By(fmt.Sprintf("applying manager manifest %s", operatorManifestFile), func() {
 			// Upgrade to the new version
 			_, stderr, err := testsUtils.Run(
-				fmt.Sprintf("kubectl apply --server-side -f %v", operatorManifestFile))
+				fmt.Sprintf("kubectl apply --server-side --force-conflicts -f %v", operatorManifestFile))
 			Expect(err).NotTo(HaveOccurred(), "stderr: "+stderr)
 		})
 

--- a/tests/utils/upgrade.go
+++ b/tests/utils/upgrade.go
@@ -73,7 +73,7 @@ func InstallLatestCNPGOperator(releaseTag string, env *TestingEnvironment) {
 	Eventually(func() error {
 		GinkgoWriter.Printf("installing: %s\n", mostRecentReleasePath)
 
-		_, stderr, err := RunUnchecked("kubectl apply --server-side -f " + mostRecentReleasePath)
+		_, stderr, err := RunUnchecked("kubectl apply --server-side --force-conflicts -f " + mostRecentReleasePath)
 		if err != nil {
 			GinkgoWriter.Printf("stderr: %s\n", stderr)
 		}


### PR DESCRIPTION
While doing the upgrade process if we don't add the `--force-conflicts` along side with the `--server-side` we can't apply the new manifest meaning that the upgrade test fails. Now we added this `--force-conflicts` option that we already documented in the upgrade process.

More information here https://kubernetes.io/docs/reference/using-api/server-side-apply/#conflicts

Closes #4000 