### PR TITLE
fix: correctly parse timescale/timescaledb image tag

### DIFF
--- a/pkg/postgres/version.go
+++ b/pkg/postgres/version.go
@@ -25,7 +25,7 @@ import (
 
 const firstMajorWithoutMinor = 10
 
-var semanticVersionRegex = regexp.MustCompile(`^(\d\.?)+`)
+var semanticVersionRegex = regexp.MustCompile(`^(?:pg)?(\d\.?)+`)
 
 // GetPostgresVersionFromTag parse a PostgreSQL version string returning
 // a major version ID. Example:

--- a/pkg/postgres/version_test.go
+++ b/pkg/postgres/version_test.go
@@ -41,6 +41,15 @@ var _ = Describe("PostgreSQL version handling", func() {
 			Expect(GetPostgresVersionFromTag("15beta1")).To(Equal(150000))
 		})
 
+		It("should parse timescale/timescaledb versions", func() {
+			Expect(GetPostgresVersionFromTag("pg16.2")).To(Equal(160002))
+			Expect(GetPostgresVersionFromTag("pg16.2-all")).To(Equal(160002))
+			Expect(GetPostgresVersionFromTag("pg16.2-all-oss")).To(Equal(160002))
+			Expect(GetPostgresVersionFromTag("pg16.2-ts2.14.2")).To(Equal(160002))
+			Expect(GetPostgresVersionFromTag("pg16.2-ts2.14.2-all")).To(Equal(160002))
+			Expect(GetPostgresVersionFromTag("pg16.2-ts2.14.2-all-oss")).To(Equal(160002))
+		})
+
 		It("should gracefully handle errors", func() {
 			_, err := GetPostgresVersionFromTag("")
 			Expect(err).To(HaveOccurred())


### PR DESCRIPTION
Allows using `timescale/timescaledb:pgX.Y-tsA.B.C` images with CloudNativePG  operator.