### PR TITLE
test(e2e): fix the pipeline after adding image catalog

### DIFF
--- a/config/olm-manifests/bases/cloudnative-pg.clusterserviceversion.yaml
+++ b/config/olm-manifests/bases/cloudnative-pg.clusterserviceversion.yaml
@@ -630,3 +630,36 @@ spec:
       - displayName: Last backup
         description: When the last backup was scheduled
         path: lastScheduleTime
+
+    - kind: ImageCatalog
+      name: imagecatalogs.postgresql.cnpg.io
+      displayName: Image Catalog
+      description: Some description
+      version: v1
+      resources:
+      - kind: ConfigMap
+        name: ''
+        version: v1
+      specDescriptors:
+      - path: images
+        displayName: Images
+        description: images
+      - path: images.image
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:text'
+    - kind: ClusterImageCatalog
+      name: clusterimagecatalogs.postgresql.cnpg.io
+      displayName: Cluster Image Catalog
+      description: some descirption
+      version: v1
+      resources:
+      - kind: ConfigMap
+        name: ''
+        version: v1
+      specDescriptors:
+      - path: images
+        displayName: images
+        description: images
+      - path: images.image
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:text'

--- a/config/olm-manifests/bases/cloudnative-pg.clusterserviceversion.yaml
+++ b/config/olm-manifests/bases/cloudnative-pg.clusterserviceversion.yaml
@@ -634,7 +634,7 @@ spec:
     - kind: ImageCatalog
       name: imagecatalogs.postgresql.cnpg.io
       displayName: Image Catalog
-      description: Some description
+      description: A catalog of PostgreSQL operand images
       version: v1
       resources:
       - kind: ConfigMap
@@ -650,7 +650,7 @@ spec:
     - kind: ClusterImageCatalog
       name: clusterimagecatalogs.postgresql.cnpg.io
       displayName: Cluster Image Catalog
-      description: some descirption
+      description: A cluster-wide catalog of PostgreSQL operand images
       version: v1
       resources:
       - kind: ConfigMap

--- a/config/olm-samples/kustomization.yaml
+++ b/config/olm-samples/kustomization.yaml
@@ -3,3 +3,5 @@ resources:
 - postgresql_v1_pooler.yaml
 - postgresql_v1_backup.yaml
 - postgresql_v1_scheduledbackup.yaml
+- postgresql_v1_imagecatalog.yaml
+- postgresql_v1_clusterimagecatalog.yaml

--- a/config/olm-samples/postgresql_v1_clusterimagecatalog.yaml
+++ b/config/olm-samples/postgresql_v1_clusterimagecatalog.yaml
@@ -1,0 +1,9 @@
+kind: ClusterImageCatalog
+metadata:
+  name: postgresql
+spec:
+  images:
+    - major: 15
+      image: ghcr.io/cloudnative-pg/postgresql:15.6
+    - major: 16
+      image: ghcr.io/cloudnative-pg/postgresql:16.2

--- a/config/olm-samples/postgresql_v1_imagecatalog.yaml
+++ b/config/olm-samples/postgresql_v1_imagecatalog.yaml
@@ -1,0 +1,10 @@
+kind: ImageCatalog
+metadata:
+  name: postgresql
+  namespace: default
+spec:
+  images:
+    - major: 15
+      image: ghcr.io/cloudnative-pg/postgresql:15.6
+    - major: 16
+      image: ghcr.io/cloudnative-pg/postgresql:16.2

--- a/tests/e2e/rolling_update_test.go
+++ b/tests/e2e/rolling_update_test.go
@@ -337,8 +337,9 @@ var _ = Describe("Rolling updates", Label(tests.LabelPostgresConfiguration), fun
 				Instances: instances,
 				ImageCatalogRef: &apiv1.ImageCatalogRef{
 					TypedLocalObjectReference: corev1.TypedLocalObjectReference{
-						Name: name,
-						Kind: "ImageCatalog",
+						APIGroup: &apiv1.GroupVersion.Group,
+						Name:     name,
+						Kind:     "ImageCatalog",
 					},
 					Major: major,
 				},

--- a/tests/e2e/rolling_update_test.go
+++ b/tests/e2e/rolling_update_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package e2e
 
 import (
-	"context"
 	"os"
 
 	corev1 "k8s.io/api/core/v1"
@@ -538,9 +537,6 @@ var _ = Describe("Rolling updates", Label(tests.LabelPostgresConfiguration), fun
 	})
 
 	Context("Image Catalogs", func() {
-		const (
-			clusterName = "image-catalog"
-		)
 		var storageClass string
 		var preRollingImg string
 		var updatedImageName string
@@ -563,6 +559,9 @@ var _ = Describe("Rolling updates", Label(tests.LabelPostgresConfiguration), fun
 		})
 
 		Context("ImageCatalog", func() {
+			const (
+				clusterName = "image-catalog"
+			)
 			Context("Three Instances", func() {
 				const (
 					namespacePrefix = "imagecatalog-cluster-rolling-e2e-three-instances"
@@ -614,7 +613,10 @@ var _ = Describe("Rolling updates", Label(tests.LabelPostgresConfiguration), fun
 				})
 			})
 		})
-		Context("ClusterImageCatalog", func() {
+		Context("ClusterImageCatalog", Serial, func() {
+			const (
+				clusterName = "cluster-image-catalog"
+			)
 			var catalog *apiv1.ClusterImageCatalog
 			BeforeEach(func() {
 				catalog = newClusterImageCatalog(clusterName, major, preRollingImg)
@@ -624,9 +626,9 @@ var _ = Describe("Rolling updates", Label(tests.LabelPostgresConfiguration), fun
 				Expect(err).ToNot(HaveOccurred())
 
 				// Wait until we really deleted it
-				Eventually(func(ctx context.Context) error {
-					return env.Client.Get(ctx, ctrl.ObjectKey{Name: catalog.Name}, catalog)
-				}).Should(MatchError(apierrs.IsNotFound))
+				Eventually(func() error {
+					return env.Client.Get(env.Ctx, ctrl.ObjectKey{Name: catalog.Name}, catalog)
+				}, 10).Should(MatchError(apierrs.IsNotFound))
 			})
 			Context("Three Instances", func() {
 				const (

--- a/tests/e2e/rolling_update_test.go
+++ b/tests/e2e/rolling_update_test.go
@@ -628,7 +628,7 @@ var _ = Describe("Rolling updates", Label(tests.LabelPostgresConfiguration), fun
 				// Wait until we really deleted it
 				Eventually(func() error {
 					return env.Client.Get(env.Ctx, ctrl.ObjectKey{Name: catalog.Name}, catalog)
-				}, 10).Should(MatchError(apierrs.IsNotFound))
+				}, 30).Should(MatchError(apierrs.IsNotFound, metav1.StatusReasonNotFound))
 			})
 			Context("Three Instances", func() {
 				const (


### PR DESCRIPTION
After merging the image catalogs patch, tests were failing. This patch fixes the OLM scorecard test and the E2E tests (by setting `imageCatalogRef` group).

Closes #4016 
