### PR TITLE
fix: continue on error for Snyk

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -624,6 +624,7 @@ jobs:
         if: |
           !github.event.repository.fork && 
           !github.event.pull_request.head.repo.fork
+        continue-on-error: true
         with:
           sarif_file: snyk.sarif
 


### PR DESCRIPTION
Since we enabled Snyk for everyone, this will allow to continue the
test even if you don't have the Snyk token in your fork.