### PR TITLE
fix: unit tests for `wal_level` configuration

### DIFF
--- a/api/v1/cluster_webhook.go
+++ b/api/v1/cluster_webhook.go
@@ -1087,7 +1087,7 @@ func (r *Cluster) validateConfiguration() field.ErrorList {
 			field.Invalid(
 				field.NewPath("spec", "postgresql", "parameters", postgres.WalLevelParameter),
 				walLevel,
-				fmt.Sprintf("unrecognized `wal_level` value  -allowed values: `%s`, `%s`, `%s`",
+				fmt.Sprintf("unrecognized `wal_level` value - allowed values: `%s`, `%s`, `%s`",
 					postgres.WalLevelValueLogical,
 					postgres.WalLevelValueReplica,
 					postgres.WalLevelValueMinimal,

--- a/api/v1/cluster_webhook_test.go
+++ b/api/v1/cluster_webhook_test.go
@@ -1187,7 +1187,7 @@ var _ = Describe("configuration change validation", func() {
 
 		errs := cluster.validateConfiguration()
 		Expect(errs).To(HaveLen(1))
-		Expect(errs[0].Detail).To(ContainSubstring("unknown wal_level value set"))
+		Expect(errs[0].Detail).To(ContainSubstring("unrecognized `wal_level` value - allowed values"))
 	})
 
 	It("should reject minimal if it is a replica cluster", func() {


### PR DESCRIPTION
Fix a regression introduced by me at the last minute while changing a string in PR #4020.