### PR TITLE
Change jdbc-uri and uri in app secret

### DIFF
--- a/pkg/specs/secrets.go
+++ b/pkg/specs/secrets.go
@@ -27,7 +27,7 @@ import (
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 )
 
-// CreateSecret create a secret with the PostgreSQL and the owner passwords
+// CreateSecret creates a secret with the PostgreSQL and the owner passwords
 func CreateSecret(
 	name string,
 	namespace string,
@@ -36,7 +36,7 @@ func CreateSecret(
 	username string,
 	password string,
 ) *corev1.Secret {
-	uriBuilder := newConnectionStringBuilder(hostname, dbname, username, password)
+	uriBuilder := newConnectionStringBuilder(hostname, dbname, username, password, namespace)
 
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -68,18 +68,20 @@ func CreateSecret(
 }
 
 type connectionStringBuilder struct {
-	host     string
-	dbname   string
-	username string
-	password string
+	host      string
+	dbname    string
+	username  string
+	password  string
+	namespace string
 }
 
-func newConnectionStringBuilder(hostname, dbname, username, password string) *connectionStringBuilder {
+func newConnectionStringBuilder(hostname, dbname, username, password, namespace string) *connectionStringBuilder {
 	return &connectionStringBuilder{
-		host:     fmt.Sprintf("%s:%d", hostname, postgres.ServerPort),
-		dbname:   dbname,
-		username: username,
-		password: password,
+		host:      fmt.Sprintf("%s.%s:%d", hostname, namespace, postgres.ServerPort),
+		dbname:    dbname,
+		username:  username,
+		password:  password,
+		namespace: namespace,
 	}
 }
 

--- a/pkg/specs/secrets_test.go
+++ b/pkg/specs/secrets_test.go
@@ -34,10 +34,10 @@ var _ = Describe("Secret creation", func() {
 		Expect(secret.StringData["host"]).To(Equal("thishost"))
 		Expect(secret.StringData["port"]).To(Equal("5432"))
 		Expect(secret.StringData["uri"]).To(
-			Equal("postgresql://thisuser:thispassword@thishost:5432/thisdb"),
+			Equal("postgresql://thisuser:thispassword@thishost.namespace:5432/thisdb"),
 		)
 		Expect(secret.StringData["jdbc-uri"]).To(
-			Equal("jdbc:postgresql://thishost:5432/thisdb?password=thispassword&user=thisuser"),
+			Equal("jdbc:postgresql://thishost.namespace:5432/thisdb?password=thispassword&user=thisuser"),
 		)
 	})
 })


### PR DESCRIPTION
It fixes #4062 

```
kubectl get secret cluster-16-app -o jsonpath="{.data.jdbc-uri}" | base64 -d
jdbc:postgresql://cluster-16-rw.default:5432/app?password=Drg3Zy3AcFC6FzhiiVzpnOEoF8S6rlU7xgqcBkUWHmeTq35GmKmVD5gTNqah4FnZ&user=app

kubectl get secret cluster-16-app -o jsonpath="{.data.uri}" | base64 -d
postgresql://app:Drg3Zy3AcFC6FzhiiVzpnOEoF8S6rlU7xgqcBkUWHmeTq35GmKmVD5gTNqah4FnZ@cluster-16-rw.default:5432/app
```

