### PR TITLE
chore: improve `barman-cloud-wal-restore` error detection

### DIFF
--- a/pkg/management/barman/restorer/restorer.go
+++ b/pkg/management/barman/restorer/restorer.go
@@ -258,7 +258,8 @@ func (restorer *WALRestorer) Restore(walName, destinationPath string, baseOption
 
 	// nolint: lll
 	// source: https://github.com/EnterpriseDB/barman/blob/26ed480cd0268dfd3f8546cc97660d4bd827772a/tests/test_barman_cloud_wal_restore.py
-	switch exitError.ExitCode() {
+	exitCode := exitError.ExitCode()
+	switch exitCode {
 	case exitCodeBucketOrWalNotFound:
 		return fmt.Errorf("object storage or file not found %s: %w", walName, ErrWALNotFound)
 	case exitCodeConnectivityError:
@@ -270,7 +271,8 @@ func (restorer *WALRestorer) Restore(walName, destinationPath string, baseOption
 		return fmt.Errorf("generic error code encountered while executing %s",
 			barmanCapabilities.BarmanCloudWalRestore)
 	default:
-		return fmt.Errorf("unrecognized error exit code encountered while executing %s",
+		return fmt.Errorf("encountered an unrecognized exit code error: '%d' while executing %s",
+			exitCode,
 			barmanCapabilities.BarmanCloudWalRestore)
 	}
 }

--- a/pkg/management/barman/restorer/restorer.go
+++ b/pkg/management/barman/restorer/restorer.go
@@ -260,8 +260,7 @@ func (restorer *WALRestorer) Restore(walName, destinationPath string, baseOption
 	// source: https://github.com/EnterpriseDB/barman/blob/26ed480cd0268dfd3f8546cc97660d4bd827772a/tests/test_barman_cloud_wal_restore.py
 	switch exitError.ExitCode() {
 	case exitCodeBucketOrWalNotFound:
-		// TODO: this should be improved, can be both file not found or a bucket that doesn't exist
-		return fmt.Errorf("file not found %s: %w", walName, ErrWALNotFound)
+		return fmt.Errorf("object storage or file not found %s: %w", walName, ErrWALNotFound)
 	case exitCodeConnectivityError:
 		return fmt.Errorf("connectivity failure while executing %s, retrying",
 			barmanCapabilities.BarmanCloudWalRestore)


### PR DESCRIPTION
This patch improves the detection of the exit codes coming from `barman-cloud-wal-restore`.
