### PR TITLE
fix(docs): uncomment section about `--server-side` in upgrades

### DIFF
--- a/docs/src/installation_upgrade.md
+++ b/docs/src/installation_upgrade.md
@@ -233,12 +233,12 @@ removed before installing the new one. This won't affect user data but
 only the operator itself.
 
 <!--
-### Upgrading to 1.23.0, 1.22.2 or 1.21.4
+### Upgrading to 1.23.0, 1.22.3 or 1.21.5
 
 !!! Important
     We encourage all existing users of CloudNativePG to upgrade to version
     1.23.0 or at least to the latest stable version of the minor release you are
-    currently using (namely 1.22.2 or 1.21.4).
+    currently using (namely 1.22.3 or 1.21.5).
 
 !!! Warning
     Every time you are upgrading to a higher minor release, make sure you
@@ -279,6 +279,15 @@ use the following configuration:
       enabled: false
 ```
 
+-->
+
+### Upgrading to 1.22.2 or 1.21.4
+
+!!! Important
+    We encourage all existing users of CloudNativePG to upgrade to the latest
+    stable version of the minor release you are currently using (namely 1.22.2 or
+    1.21.4).
+
 #### Server-side apply of manifests
 
 To ensure compatibility with Kubernetes 1.29 and upcoming versions,
@@ -305,7 +314,6 @@ Henceforth, `kube-apiserver` will be automatically acknowledged as a recognized
 manager for the CRDs, eliminating the need for any further manual intervention
 on this matter.
 
--->
 
 ### Upgrading to 1.22 from a previous minor version
 

--- a/docs/src/supported_releases.md
+++ b/docs/src/supported_releases.md
@@ -65,7 +65,7 @@ Git tags for versions are prepended with `v`.
 
 | Version         | Currently supported  | Release date      | End of life         | Supported Kubernetes versions | Tested, but not supported | Supported Postgres versions |
 |-----------------|----------------------|-------------------|---------------------|-------------------------------|---------------------------|-----------------------------|
-| 1.22.x          | Yes                  | December 21, 2023 | ~ July/August, 2024 | 1.26, 1.27, 1.28              | 1.23, 1.24, 1.25          | 12 - 16                     |
+| 1.22.x          | Yes                  | December 21, 2023 | ~ July/August, 2024 | 1.26, 1.27, 1.28              | 1.23, 1.24, 1.25, 1.29    | 12 - 16                     |
 | 1.21.x          | Yes                  | October 12, 2023  | ~ May 23, 2024      | 1.25, 1.26, 1.27, 1.28        | 1.23, 1.24                | 12 - 16                     |
 | main            | No, development only |                   |                     |                               |                           | 11 - 16                     |
 


### PR DESCRIPTION
Also mention testing for Kubernetes 1.29

Closes #3747 