### PR TITLE
fix: ensure pods with no ownership are deleted during cluster restore

### DIFF
--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -202,7 +202,10 @@ func (r *ClusterReconciler) reconcile(ctx context.Context, cluster *apiv1.Cluste
 	}
 
 	// Ensure we reconcile the orphan resources if present when we reconcile for the first time a cluster
-	if err := r.reconcileRestoredCluster(ctx, cluster); err != nil {
+	if res, err := r.reconcileRestoredCluster(ctx, cluster); res != nil || err != nil {
+		if res != nil {
+			return *res, nil
+		}
 		return ctrl.Result{}, fmt.Errorf("cannot reconcile restored Cluster: %w", err)
 	}
 


### PR DESCRIPTION
At present, during the cluster restore from orphan PVCs , it is not possible for the operator to bring back a cluster to a functional state if any orphan pods are present.

This is because the existing pods will linger indefenetly and won't be be recreated with the correct data. To address this issue, this patch ensures that no orphan pods are present during the cluster restore from PVCs by deleting them.