### PR TITLE
feat: cleanup pgdata directory if restore job failed

### DIFF
--- a/internal/cmd/manager/instance/restore/cmd.go
+++ b/internal/cmd/manager/instance/restore/cmd.go
@@ -89,6 +89,7 @@ func restoreSubCommand(ctx context.Context, info postgres.InitInfo) error {
 
 	err = info.Restore(ctx)
 	if err != nil {
+		log.Error(err, "Error while restoring a backup")
 		cleanupDataDirectoryIfNeeded(err, info.PgData)
 		return err
 	}

--- a/internal/cmd/manager/instance/restore/cmd.go
+++ b/internal/cmd/manager/instance/restore/cmd.go
@@ -19,6 +19,7 @@ package restore
 
 import (
 	"context"
+	"errors"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -26,7 +27,9 @@ import (
 
 	"github.com/cloudnative-pg/cloudnative-pg/internal/management/istio"
 	"github.com/cloudnative-pg/cloudnative-pg/internal/management/linkerd"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/fileutils"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/barman"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/log"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres"
 )
@@ -86,9 +89,28 @@ func restoreSubCommand(ctx context.Context, info postgres.InitInfo) error {
 
 	err = info.Restore(ctx)
 	if err != nil {
-		log.Error(err, "Error while restoring a backup")
+		cleanupDataDirectoryIfNeeded(err, info.PgData)
 		return err
 	}
 
 	return nil
+}
+
+func cleanupDataDirectoryIfNeeded(restoreError error, dataDirectory string) {
+	var barmanError *barman.CloudRestoreError
+	if !errors.As(restoreError, &barmanError) {
+		return
+	}
+
+	if !barmanError.IsRetriable() {
+		return
+	}
+
+	log.Info("Cleaning up data directory", "directory", dataDirectory)
+	if err := fileutils.RemoveDirectory(dataDirectory); err != nil && !os.IsNotExist(err) {
+		log.Error(
+			err,
+			"error occurred cleaning up data directory",
+			"directory", dataDirectory)
+	}
 }

--- a/pkg/fileutils/fileutils.go
+++ b/pkg/fileutils/fileutils.go
@@ -371,6 +371,19 @@ func RemoveFile(fileName string) error {
 	return err
 }
 
+// RemoveDirectory remove the directory and all its content
+func RemoveDirectory(dir string) error {
+	if exists, _ := FileExists(dir); exists {
+		if err := RemoveDirectoryContent(dir); err != nil {
+			return err
+		}
+		if err := RemoveFile(dir); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // GetDirectoryContent return a slice of string with the name of the files
 // in the dir directory
 func GetDirectoryContent(dir string) (files []string, err error) {

--- a/pkg/fileutils/fileutils.go
+++ b/pkg/fileutils/fileutils.go
@@ -373,15 +373,10 @@ func RemoveFile(fileName string) error {
 
 // RemoveDirectory remove the directory and all its content
 func RemoveDirectory(dir string) error {
-	if exists, _ := FileExists(dir); exists {
-		if err := RemoveDirectoryContent(dir); err != nil {
-			return err
-		}
-		if err := RemoveFile(dir); err != nil {
-			return err
-		}
+	if err := RemoveDirectoryContent(dir); err != nil {
+		return err
 	}
-	return nil
+	return RemoveFile(dir)
 }
 
 // GetDirectoryContent return a slice of string with the name of the files

--- a/pkg/fileutils/fileutils_test.go
+++ b/pkg/fileutils/fileutils_test.go
@@ -131,6 +131,29 @@ var _ = Describe("File copying functions", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(result).To(BeFalse())
 	})
+
+	It("removes the directory", func() {
+		var err error
+		var result bool
+
+		testDir, err := os.MkdirTemp(tempDir2, "testDir")
+		Expect(err).ToNot(HaveOccurred())
+
+		changed, err := WriteStringToFile(path.Join(testDir, "file.txt"), "this is a test file")
+		Expect(changed).To(BeTrue())
+		Expect(err).ToNot(HaveOccurred())
+
+		result, err = FileExists(path.Join(testDir, "file.txt"))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result).To(BeTrue())
+
+		err = RemoveDirectory(testDir)
+		Expect(err).ToNot(HaveOccurred())
+
+		result, err = FileExists(path.Join(testDir, "file.txt"))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result).To(BeFalse())
+	})
 })
 
 var _ = Describe("function GetDirectoryContent", func() {

--- a/pkg/fileutils/fileutils_test.go
+++ b/pkg/fileutils/fileutils_test.go
@@ -154,6 +154,11 @@ var _ = Describe("File copying functions", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(result).To(BeFalse())
 	})
+
+	It("fails when the directory to be removed doesn't exist", func() {
+		err := RemoveDirectory(path.Join(tempDir2, "not-existing"))
+		Expect(err).To(MatchError(os.IsNotExist, "is not exists"))
+	})
 })
 
 var _ = Describe("function GetDirectoryContent", func() {

--- a/pkg/management/barman/capabilities/detect.go
+++ b/pkg/management/barman/capabilities/detect.go
@@ -61,6 +61,8 @@ func detect(version *semver.Version) *Capabilities {
 		newCapabilities.HasErrorCodesForWALRestore = true
 		// azure-identity credential of type managed-identity added in Barman >= 2.18
 		newCapabilities.HasAzureManagedIdentity = true
+		// error codes for barman-cloud-restore command added in Barman >= 2.18
+		newCapabilities.HasErrorCodesForRestore = true
 		fallthrough
 	case version.GE(semver.Version{Major: 2, Minor: 14}):
 		// Retention policy support, added in Barman >= 2.14

--- a/pkg/management/barman/capabilities/detect_test.go
+++ b/pkg/management/barman/capabilities/detect_test.go
@@ -39,6 +39,7 @@ var _ = Describe("detect capabilities", func() {
 			HasCheckWalArchive:         true,
 			HasSnappy:                  true,
 			HasErrorCodesForWALRestore: true,
+			HasErrorCodesForRestore:    true,
 			HasAzureManagedIdentity:    true,
 		}))
 	})
@@ -57,6 +58,7 @@ var _ = Describe("detect capabilities", func() {
 			HasCheckWalArchive:         true,
 			HasSnappy:                  true,
 			HasErrorCodesForWALRestore: true,
+			HasErrorCodesForRestore:    true,
 			HasAzureManagedIdentity:    true,
 		}))
 	})
@@ -74,6 +76,7 @@ var _ = Describe("detect capabilities", func() {
 			HasCheckWalArchive:         true,
 			HasSnappy:                  true,
 			HasErrorCodesForWALRestore: true,
+			HasErrorCodesForRestore:    true,
 			HasAzureManagedIdentity:    true,
 		}))
 	})

--- a/pkg/management/barman/capabilities/type.go
+++ b/pkg/management/barman/capabilities/type.go
@@ -36,6 +36,7 @@ type Capabilities struct {
 	HasCheckWalArchive         bool
 	HasSnappy                  bool
 	HasErrorCodesForWALRestore bool
+	HasErrorCodesForRestore    bool
 	HasAzureManagedIdentity    bool
 }
 

--- a/pkg/management/barman/errors.go
+++ b/pkg/management/barman/errors.go
@@ -71,7 +71,7 @@ func (err *CloudRestoreError) Error() string {
 // IsRetriable returns true whether the error is temporary, and
 // it could be a good idea to retry the restore later
 func (err *CloudRestoreError) IsRetriable() bool {
-	return err.ExitCode == networkErrorCode && err.HasRestoreErrorCodes
+	return (err.ExitCode == networkErrorCode || err.ExitCode == generalErrorCode) && err.HasRestoreErrorCodes
 }
 
 // UnmarshalBarmanCloudRestoreExitCode returns the correct error

--- a/pkg/management/barman/errors.go
+++ b/pkg/management/barman/errors.go
@@ -1,0 +1,101 @@
+/*
+Copyright The CloudNativePG Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package barman
+
+import (
+	"fmt"
+
+	barmanCapabilities "github.com/cloudnative-pg/cloudnative-pg/pkg/management/barman/capabilities"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/log"
+)
+
+const (
+	// Connectivity to csp was ok but operation still failed error code
+	// https://docs.pgbarman.org/release/3.10.0/barman-cloud-restore.1.html
+	operationErrorCode = 1
+
+	// Network related error
+	// https://docs.pgbarman.org/release/3.10.0/barman-cloud-restore.1.html
+	networkErrorCode = 2
+
+	// CLI related error
+	// https://docs.pgbarman.org/release/3.10.0/barman-cloud-restore.1.html
+	cliErrorCode = 3
+
+	// General barman cloud errors
+	// https://docs.pgbarman.org/release/3.10.0/barman-cloud-restore.1.html
+	generalErrorCode = 4
+)
+
+// errorDescriptions are the human descriptions of the error codes
+var errorDescriptions = map[int]string{
+	operationErrorCode: "Operation error",
+	networkErrorCode:   "Network error",
+	cliErrorCode:       "CLI argument parsing error",
+	generalErrorCode:   "General error",
+}
+
+// CloudRestoreError is raised when barman-cloud-restore fails
+type CloudRestoreError struct {
+	// The exit code returned by Barman
+	ExitCode int
+
+	// This is true when Barman can return significant error codes
+	HasRestoreErrorCodes bool
+}
+
+// Error implements the error interface
+func (err *CloudRestoreError) Error() string {
+	msg, ok := errorDescriptions[err.ExitCode]
+	if !ok {
+		msg = "Generic failure"
+	}
+
+	return fmt.Sprintf("%s (exit code %v)", msg, err.ExitCode)
+}
+
+// IsRetriable returns true whether the error is temporary, and
+// it could be a good idea to retry the restore later
+func (err *CloudRestoreError) IsRetriable() bool {
+	return err.ExitCode == networkErrorCode && err.HasRestoreErrorCodes
+}
+
+// UnmarshalBarmanCloudRestoreExitCode returns the correct error
+// for a certain barman-cloud-restore exit code
+func UnmarshalBarmanCloudRestoreExitCode(exitCode int) error {
+	if exitCode == 0 {
+		return nil
+	}
+
+	var currentCapabilities *barmanCapabilities.Capabilities
+	currentCapabilities, err := barmanCapabilities.CurrentCapabilities()
+	if err != nil {
+		log.Error(err, "error while detecting Barman capabilities")
+
+		// We default to old exit codes when we could not detect
+		// the Barman capabilities
+		return &CloudRestoreError{
+			ExitCode:             exitCode,
+			HasRestoreErrorCodes: false,
+		}
+	}
+
+	return &CloudRestoreError{
+		ExitCode:             exitCode,
+		HasRestoreErrorCodes: currentCapabilities.HasErrorCodesForRestore,
+	}
+}

--- a/pkg/management/postgres/backup_test.go
+++ b/pkg/management/postgres/backup_test.go
@@ -272,6 +272,7 @@ var _ = Describe("generate backup options", func() {
 		HasCheckWalArchive:         true,
 		HasSnappy:                  true,
 		HasErrorCodesForWALRestore: true,
+		HasErrorCodesForRestore:    true,
 		HasAzureManagedIdentity:    true,
 	}
 	cluster := &apiv1.Cluster{

--- a/pkg/management/postgres/backup_test.go
+++ b/pkg/management/postgres/backup_test.go
@@ -272,7 +272,6 @@ var _ = Describe("generate backup options", func() {
 		HasCheckWalArchive:         true,
 		HasSnappy:                  true,
 		HasErrorCodesForWALRestore: true,
-		HasErrorCodesForRestore:    true,
 		HasAzureManagedIdentity:    true,
 	}
 	cluster := &apiv1.Cluster{

--- a/pkg/management/postgres/restore.go
+++ b/pkg/management/postgres/restore.go
@@ -375,20 +375,8 @@ func (info InitInfo) restoreCustomWalDir(ctx context.Context) (bool, error) {
 }
 
 // restoreDataDir restores PGDATA from an existing backup
-func (info InitInfo) restoreDataDir(backup *apiv1.Backup, env []string) (err error) {
+func (info InitInfo) restoreDataDir(backup *apiv1.Backup, env []string) error {
 	var options []string
-	// The error code of barman-cloud-restore is retrieved from doc
-	// https://docs.pgbarman.org/release/3.10.0/barman-cloud-restore.1.html
-	const (
-		// connectivity to csp was ok but operation still failed error code
-		operationErrorCode = 1
-		// network related error code
-		networkErrorCode = 2
-		// cli related error code
-		cliErrorCode = 3
-		// general barman cloud errors
-		generalErrorCode = 4
-	)
 
 	if backup.Status.EndpointURL != "" {
 		options = append(options, "--endpoint-url", backup.Status.EndpointURL)
@@ -397,7 +385,7 @@ func (info InitInfo) restoreDataDir(backup *apiv1.Backup, env []string) (err err
 	options = append(options, backup.Status.ServerName)
 	options = append(options, backup.Status.BackupID)
 
-	options, err = barman.AppendCloudProviderOptionsFromBackup(options, backup)
+	options, err := barman.AppendCloudProviderOptionsFromBackup(options, backup)
 	if err != nil {
 		return err
 	}
@@ -410,40 +398,17 @@ func (info InitInfo) restoreDataDir(backup *apiv1.Backup, env []string) (err err
 	cmd := exec.Command(barmanCapabilities.BarmanCloudRestore, options...) // #nosec G204
 	cmd.Env = env
 	err = execlog.RunStreaming(cmd, barmanCapabilities.BarmanCloudRestore)
-	if err == nil {
-		log.Info("Restore completed")
-		return nil
-	}
-
-	var currentCapabilities *barmanCapabilities.Capabilities
-	var barmanError error
-	currentCapabilities, barmanError = barmanCapabilities.CurrentCapabilities()
-	if barmanError != nil {
-		return barmanError
-	}
-	var exitError *exec.ExitError
-	if !currentCapabilities.HasErrorCodesForRestore || !errors.As(err, &exitError) {
-		return fmt.Errorf("unexpected failure invoking %s: %w",
-			barmanCapabilities.BarmanCloudRestore, err)
-	}
-	exitCode := exitError.ExitCode()
-	switch exitCode {
-	case networkErrorCode, generalErrorCode:
-		if err := fileutils.RemoveDirectory(info.PgData); err != nil {
-			log.Error(err, "error occurred cleaning up directory", "directory", info.PgData)
+	if err != nil {
+		var exitError *exec.ExitError
+		if errors.As(err, &exitError) {
+			err = barman.UnmarshalBarmanCloudRestoreExitCode(exitError.ExitCode())
 		}
-		return fmt.Errorf("unexpected error with exit code: %d occurred invoking %s, will retry later: %w",
-			exitCode, barmanCapabilities.BarmanCloudRestore, err)
-	case operationErrorCode:
-		return fmt.Errorf("operation error occurred invoking %s, "+
-			"please ensure the remote backup is available: %w",
-			barmanCapabilities.BarmanCloudRestore, err)
-	case cliErrorCode:
-		return fmt.Errorf("input error occurred invoking %s: %w", barmanCapabilities.BarmanCloudRestore, err)
-	default:
-		return fmt.Errorf("encountered an unrecognized exit code error invoking %s: %w",
-			barmanCapabilities.BarmanCloudRestore, err)
+
+		log.Error(err, "Can't restore backup")
+		return err
 	}
+	log.Info("Restore completed")
+	return nil
 }
 
 // loadCluster loads the cluster definition from the API server


### PR DESCRIPTION
This patch clean up the pgdata directory if barman-cloud-restore is failed due
to network error or general error, so the next restore job can retry the restore work.

Closes: #4150 