### PR TITLE
chores: add infrastructure feature annotations to olm bundle

### DIFF
--- a/config/olm-manifests/bases/cloudnative-pg.clusterserviceversion.yaml
+++ b/config/olm-manifests/bases/cloudnative-pg.clusterserviceversion.yaml
@@ -13,6 +13,13 @@ metadata:
     repository: https://github.com/cloudnative-pg/cloudnative-pg
     support: Community
     olm.skipRange: '>= 1.18.0 < ${VERSION}'
+    features.operators.openshift.io/disconnected: "true"
+    features.operators.openshift.io/fips-compliant: "false"
+    features.operators.openshift.io/proxy-aware: ""
+    features.operators.openshift.io/tls-profiles: ""
+    features.operators.openshift.io/token-auth-aws: "false"
+    features.operators.openshift.io/token-auth-azure: "false"
+    features.operators.openshift.io/token-auth-gcp: "false"
   labels:
     operatorframework.io/arch.amd64: supported
   name: cloudnative-pg.v0.0.0

--- a/config/olm-manifests/bases/cloudnative-pg.clusterserviceversion.yaml
+++ b/config/olm-manifests/bases/cloudnative-pg.clusterserviceversion.yaml
@@ -15,8 +15,8 @@ metadata:
     olm.skipRange: '>= 1.18.0 < ${VERSION}'
     features.operators.openshift.io/disconnected: "true"
     features.operators.openshift.io/fips-compliant: "false"
-    features.operators.openshift.io/proxy-aware: ""
-    features.operators.openshift.io/tls-profiles: ""
+    features.operators.openshift.io/proxy-aware: "false"
+    features.operators.openshift.io/tls-profiles: "false"
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"


### PR DESCRIPTION
This patch add a group of `features.operators.openshift.io` annotations
to olm bundle.

Closes: #4177 