### PR TITLE
chore: replace deprecated configuration for golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -103,7 +103,6 @@ linters:
 
 run:
   timeout: 5m
-  skip-files: "zz_generated.*"
 
 issues:
   exclude-rules:
@@ -127,3 +126,4 @@ issues:
       text: "ST1016:"
       path: api/
   exclude-use-default: false
+  exclude-files: "zz_generated.*"


### PR DESCRIPTION
The configuration option `run.skip-files` is deprecated, now we need to use `issues.exclude-files`

Closes #4183 