### PR TITLE
test: remove `envtest` from the controller package

### DIFF
--- a/controllers/backup_controller_test.go
+++ b/controllers/backup_controller_test.go
@@ -35,6 +35,11 @@ import (
 )
 
 var _ = Describe("backup_controller barmanObjectStore unit tests", func() {
+	var env *testingEnvironment
+	BeforeEach(func() {
+		env = buildTestEnvironment()
+	})
+
 	Context("isValidBackupRunning works correctly", func() {
 		const (
 			clusterPrimary = "cluster-example-1"
@@ -46,7 +51,7 @@ var _ = Describe("backup_controller barmanObjectStore unit tests", func() {
 		var pod *corev1.Pod
 
 		BeforeEach(func(ctx context.Context) {
-			namespace := newFakeNamespace()
+			namespace := newFakeNamespace(env.client)
 
 			cluster = &apiv1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{
@@ -91,7 +96,7 @@ var _ = Describe("backup_controller barmanObjectStore unit tests", func() {
 					},
 				},
 			}
-			err := backupReconciler.Create(ctx, pod)
+			err := env.backupReconciler.Create(ctx, pod)
 			Expect(err).ToNot(HaveOccurred())
 
 			pod.Status = corev1.PodStatus{
@@ -102,20 +107,20 @@ var _ = Describe("backup_controller barmanObjectStore unit tests", func() {
 					},
 				},
 			}
-			err = backupReconciler.Status().Update(ctx, pod)
+			err = env.backupReconciler.Status().Update(ctx, pod)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("returning true when a backup is in running phase (primary)", func(ctx context.Context) {
 			backup.Spec.Target = apiv1.BackupTargetPrimary
-			res, err := backupReconciler.isValidBackupRunning(ctx, backup, cluster)
+			res, err := env.backupReconciler.isValidBackupRunning(ctx, backup, cluster)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(res).To(BeTrue())
 		})
 
 		It("returning true when a backup is in running phase (standby)", func(ctx context.Context) {
 			backup.Spec.Target = apiv1.BackupTargetStandby
-			res, err := backupReconciler.isValidBackupRunning(ctx, backup, cluster)
+			res, err := env.backupReconciler.isValidBackupRunning(ctx, backup, cluster)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(res).To(BeTrue())
 		})
@@ -123,31 +128,31 @@ var _ = Describe("backup_controller barmanObjectStore unit tests", func() {
 		It("returning false when a backup has no Phase or InstanceID", func(ctx context.Context) {
 			backup.Status.Phase = ""
 			backup.Status.InstanceID = nil
-			res, err := backupReconciler.isValidBackupRunning(ctx, backup, cluster)
+			res, err := env.backupReconciler.isValidBackupRunning(ctx, backup, cluster)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(res).To(BeFalse())
 		})
 
 		It("returning false if the elected backup pod is inactive", func(ctx context.Context) {
 			pod.Status.Phase = corev1.PodFailed
-			err := backupReconciler.Status().Update(ctx, pod)
+			err := env.backupReconciler.Status().Update(ctx, pod)
 			Expect(err).NotTo(HaveOccurred())
 
-			res, err := backupReconciler.isValidBackupRunning(ctx, backup, cluster)
+			res, err := env.backupReconciler.isValidBackupRunning(ctx, backup, cluster)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(res).To(BeFalse())
 		})
 
 		It("returning false if the elected backup pod has been restarted", func(ctx context.Context) {
 			backup.Status.InstanceID.ContainerID = containerID + "-new"
-			res, err := backupReconciler.isValidBackupRunning(ctx, backup, cluster)
+			res, err := env.backupReconciler.isValidBackupRunning(ctx, backup, cluster)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(res).To(BeFalse())
 		})
 
 		It("returning an error when the backup target is wrong", func(ctx context.Context) {
 			backup.Spec.Target = "fakeTarget"
-			res, err := backupReconciler.isValidBackupRunning(ctx, backup, cluster)
+			res, err := env.backupReconciler.isValidBackupRunning(ctx, backup, cluster)
 			Expect(err).To(HaveOccurred())
 			Expect(res).To(BeFalse())
 		})
@@ -256,6 +261,7 @@ var _ = Describe("backup_controller volumeSnapshot unit tests", func() {
 
 var _ = Describe("update snapshot backup metadata", func() {
 	var (
+		env           *testingEnvironment
 		snapshots     volumesnapshot.VolumeSnapshotList
 		cluster       *apiv1.Cluster
 		now           = metav1.NewTime(time.Now().Local().Truncate(time.Second))
@@ -265,7 +271,8 @@ var _ = Describe("update snapshot backup metadata", func() {
 	)
 
 	BeforeEach(func() {
-		namespace := newFakeNamespace()
+		env = buildTestEnvironment()
+		namespace := newFakeNamespace(env.client)
 		cluster = &apiv1.Cluster{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "cluster-example",

--- a/controllers/cluster_create_test.go
+++ b/controllers/cluster_create_test.go
@@ -57,7 +57,6 @@ var _ = Describe("cluster_create unit tests", func() {
 		cluster := newFakeCNPGCluster(env.client, namespace)
 		pooler := newFakePooler(env.client, cluster)
 		poolerSecretName := pooler.Name
-		cluster.Spec.EnableSuperuserAccess = ptr.To(false)
 		cluster.Status.PoolerIntegrations = &apiv1.PoolerIntegrations{
 			PgBouncerIntegration: apiv1.PgBouncerIntegrationStatus{
 				Secrets: []string{poolerSecretName},

--- a/controllers/cluster_create_test.go
+++ b/controllers/cluster_create_test.go
@@ -542,6 +542,7 @@ var _ = Describe("check if bootstrap recovery can proceed from volume snapshot",
 		Expect(res).To(Or(BeNil(), Equal(reconcile.Result{})))
 	})
 
+	// nolint: dupl
 	It("should requeue if bootstrapping from an invalid volume snapshot", func(ctx SpecContext) {
 		snapshots := volumesnapshot.VolumeSnapshotList{
 			Items: []volumesnapshot.VolumeSnapshot{
@@ -578,6 +579,7 @@ var _ = Describe("check if bootstrap recovery can proceed from volume snapshot",
 		Expect(res).ToNot(Equal(reconcile.Result{}))
 	})
 
+	// nolint: dupl
 	It("should requeue if bootstrapping from a snapshot that isn't there", func(ctx SpecContext) {
 		snapshots := volumesnapshot.VolumeSnapshotList{
 			Items: []volumesnapshot.VolumeSnapshot{

--- a/controllers/cluster_create_test.go
+++ b/controllers/cluster_create_test.go
@@ -52,11 +52,12 @@ var _ = Describe("cluster_create unit tests", func() {
 		env = buildTestEnvironment()
 	})
 
-	It("should make sure that reconcilePostgresSecrets works correctly", func(ctx SpecContext) {
+	It("should NOT create EnableSuperuserAccess if it is disabled", func(ctx SpecContext) {
 		namespace := newFakeNamespace(env.client)
 		cluster := newFakeCNPGCluster(env.client, namespace)
 		pooler := newFakePooler(env.client, cluster)
 		poolerSecretName := pooler.Name
+		cluster.Spec.EnableSuperuserAccess = ptr.To(false)
 		cluster.Status.PoolerIntegrations = &apiv1.PoolerIntegrations{
 			PgBouncerIntegration: apiv1.PgBouncerIntegrationStatus{
 				Secrets: []string{poolerSecretName},
@@ -96,9 +97,9 @@ var _ = Describe("cluster_create unit tests", func() {
 				&appUser,
 			)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(string(appUser.Data["username"])).To(Equal("app"))
-			Expect(string(appUser.Data["password"])).To(HaveLen(64))
-			Expect(string(appUser.Data["dbname"])).To(Equal("app"))
+			Expect(appUser.StringData["username"]).To(Equal("app"))
+			Expect(appUser.StringData["password"]).To(HaveLen(64))
+			Expect(appUser.StringData["dbname"]).To(Equal("app"))
 		})
 
 		By("making sure that the pooler secrets has been created", func() {
@@ -130,9 +131,9 @@ var _ = Describe("cluster_create unit tests", func() {
 				&superUser,
 			)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(string(superUser.Data["username"])).To(Equal("postgres"))
-			Expect(string(superUser.Data["password"])).To(HaveLen(64))
-			Expect(string(superUser.Data["dbname"])).To(Equal("*"))
+			Expect(superUser.StringData["username"]).To(Equal("postgres"))
+			Expect(superUser.StringData["password"]).To(HaveLen(64))
+			Expect(superUser.StringData["dbname"]).To(Equal("*"))
 		})
 	})
 

--- a/controllers/cluster_create_test.go
+++ b/controllers/cluster_create_test.go
@@ -47,10 +47,15 @@ import (
 )
 
 var _ = Describe("cluster_create unit tests", func() {
+	var env *testingEnvironment
+	BeforeEach(func() {
+		env = buildTestEnvironment()
+	})
+
 	It("should make sure that reconcilePostgresSecrets works correctly", func(ctx SpecContext) {
-		namespace := newFakeNamespace()
-		cluster := newFakeCNPGCluster(namespace)
-		pooler := newFakePooler(cluster)
+		namespace := newFakeNamespace(env.client)
+		cluster := newFakeCNPGCluster(env.client, namespace)
+		pooler := newFakePooler(env.client, cluster)
 		poolerSecretName := pooler.Name
 		cluster.Status.PoolerIntegrations = &apiv1.PoolerIntegrations{
 			PgBouncerIntegration: apiv1.PgBouncerIntegrationStatus{
@@ -59,17 +64,22 @@ var _ = Describe("cluster_create unit tests", func() {
 		}
 
 		By("creating prerequisites", func() {
-			generateFakeCASecretWithDefaultClient(cluster.GetClientCASecretName(), namespace, "testdomain.com")
+			generateFakeCASecret(
+				env.client,
+				cluster.GetClientCASecretName(),
+				namespace,
+				"testdomain.com",
+			)
 		})
 
 		By("executing reconcilePostgresSecrets", func() {
-			err := clusterReconciler.reconcilePostgresSecrets(ctx, cluster)
+			err := env.clusterReconciler.reconcilePostgresSecrets(ctx, cluster)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
 		By("making sure that the superUser secret has not been created", func() {
 			superUser := corev1.Secret{}
-			err := k8sClient.Get(
+			err := env.client.Get(
 				ctx,
 				types.NamespacedName{Name: cluster.GetSuperuserSecretName(), Namespace: namespace},
 				&superUser,
@@ -80,7 +90,7 @@ var _ = Describe("cluster_create unit tests", func() {
 
 		By("making sure that the appUserSecret has been created", func() {
 			appUser := corev1.Secret{}
-			err := k8sClient.Get(
+			err := env.client.Get(
 				ctx,
 				types.NamespacedName{Name: cluster.GetApplicationSecretName(), Namespace: namespace},
 				&appUser,
@@ -93,7 +103,7 @@ var _ = Describe("cluster_create unit tests", func() {
 
 		By("making sure that the pooler secrets has been created", func() {
 			poolerSecret := corev1.Secret{}
-			err := k8sClient.Get(
+			err := env.client.Get(
 				ctx,
 				types.NamespacedName{Name: poolerSecretName, Namespace: namespace},
 				&poolerSecret,
@@ -103,18 +113,18 @@ var _ = Describe("cluster_create unit tests", func() {
 	})
 
 	It("should make sure that superUser secret is created if EnableSuperuserAccess is enabled", func(ctx SpecContext) {
-		namespace := newFakeNamespace()
-		cluster := newFakeCNPGCluster(namespace)
+		namespace := newFakeNamespace(env.client)
+		cluster := newFakeCNPGCluster(env.client, namespace)
 		cluster.Spec.EnableSuperuserAccess = ptr.To(true)
 
 		By("executing reconcilePostgresSecrets", func() {
-			err := clusterReconciler.reconcilePostgresSecrets(ctx, cluster)
+			err := env.clusterReconciler.reconcilePostgresSecrets(ctx, cluster)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
 		By("making sure that the superUser secret has been created correctly", func() {
 			superUser := corev1.Secret{}
-			err := k8sClient.Get(
+			err := env.client.Get(
 				ctx,
 				types.NamespacedName{Name: cluster.GetSuperuserSecretName(), Namespace: namespace},
 				&superUser,
@@ -127,44 +137,44 @@ var _ = Describe("cluster_create unit tests", func() {
 	})
 
 	It("should make sure that reconcilePostgresServices works correctly", func(ctx SpecContext) {
-		namespace := newFakeNamespace()
-		cluster := newFakeCNPGCluster(namespace)
+		namespace := newFakeNamespace(env.client)
+		cluster := newFakeCNPGCluster(env.client, namespace)
 
 		By("executing reconcilePostgresServices", func() {
-			err := clusterReconciler.reconcilePostgresServices(ctx, cluster)
+			err := env.clusterReconciler.reconcilePostgresServices(ctx, cluster)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
 		By("making sure that the services have been created", func() {
-			expectResourceExistsWithDefaultClient(cluster.GetServiceReadOnlyName(), namespace, &corev1.Service{})
-			expectResourceExistsWithDefaultClient(cluster.GetServiceReadWriteName(), namespace, &corev1.Service{})
-			expectResourceExistsWithDefaultClient(cluster.GetServiceReadName(), namespace, &corev1.Service{})
+			expectResourceExists(env.client, cluster.GetServiceReadOnlyName(), namespace, &corev1.Service{})
+			expectResourceExists(env.client, cluster.GetServiceReadWriteName(), namespace, &corev1.Service{})
+			expectResourceExists(env.client, cluster.GetServiceReadName(), namespace, &corev1.Service{})
 		})
 	})
 
 	It("should make sure that reconcilePostgresServices works correctly if create any service is enabled",
 		func(ctx SpecContext) {
-			namespace := newFakeNamespace()
-			cluster := newFakeCNPGCluster(namespace)
+			namespace := newFakeNamespace(env.client)
+			cluster := newFakeCNPGCluster(env.client, namespace)
 			configuration.Current.CreateAnyService = true
 
 			By("executing reconcilePostgresServices", func() {
-				err := clusterReconciler.reconcilePostgresServices(ctx, cluster)
+				err := env.clusterReconciler.reconcilePostgresServices(ctx, cluster)
 				Expect(err).ToNot(HaveOccurred())
 			})
 
 			By("making sure that the services have been created", func() {
-				expectResourceExistsWithDefaultClient(cluster.GetServiceAnyName(), namespace, &corev1.Service{})
-				expectResourceExistsWithDefaultClient(cluster.GetServiceReadOnlyName(), namespace, &corev1.Service{})
-				expectResourceExistsWithDefaultClient(cluster.GetServiceReadWriteName(), namespace, &corev1.Service{})
-				expectResourceExistsWithDefaultClient(cluster.GetServiceReadName(), namespace, &corev1.Service{})
+				expectResourceExists(env.client, cluster.GetServiceAnyName(), namespace, &corev1.Service{})
+				expectResourceExists(env.client, cluster.GetServiceReadOnlyName(), namespace, &corev1.Service{})
+				expectResourceExists(env.client, cluster.GetServiceReadWriteName(), namespace, &corev1.Service{})
+				expectResourceExists(env.client, cluster.GetServiceReadName(), namespace, &corev1.Service{})
 			})
 		})
 
 	It("should make sure that reconcilePostgresServices can update the selectors on existing services",
 		func(ctx SpecContext) {
-			namespace := newFakeNamespace()
-			cluster := newFakeCNPGCluster(namespace)
+			namespace := newFakeNamespace(env.client)
+			cluster := newFakeCNPGCluster(env.client, namespace)
 			configuration.Current.CreateAnyService = true
 
 			createOutdatedService := func(svc *corev1.Service) {
@@ -172,13 +182,13 @@ var _ = Describe("cluster_create unit tests", func() {
 				svc.Spec.Selector = map[string]string{
 					"outdated": "selector",
 				}
-				err := clusterReconciler.Client.Create(ctx, svc)
+				err := env.clusterReconciler.Client.Create(ctx, svc)
 				Expect(err).ToNot(HaveOccurred())
 			}
 
 			checkService := func(before *corev1.Service, expectedLabels map[string]string) {
 				var afterChangesService corev1.Service
-				err := clusterReconciler.Client.Get(ctx, types.NamespacedName{
+				err := env.clusterReconciler.Client.Get(ctx, types.NamespacedName{
 					Name:      before.Name,
 					Namespace: before.Namespace,
 				}, &afterChangesService)
@@ -217,7 +227,7 @@ var _ = Describe("cluster_create unit tests", func() {
 			})
 
 			By("executing reconcilePostgresServices", func() {
-				err := clusterReconciler.reconcilePostgresServices(ctx, cluster)
+				err := env.clusterReconciler.reconcilePostgresServices(ctx, cluster)
 				Expect(err).ToNot(HaveOccurred())
 			})
 
@@ -251,18 +261,18 @@ var _ = Describe("cluster_create unit tests", func() {
 		})
 
 	It("should make sure that createOrPatchServiceAccount works correctly", func(ctx SpecContext) {
-		namespace := newFakeNamespace()
-		cluster := newFakeCNPGCluster(namespace)
+		namespace := newFakeNamespace(env.client)
+		cluster := newFakeCNPGCluster(env.client, namespace)
 
 		By("executing createOrPatchServiceAccount (create)", func() {
-			err := clusterReconciler.createOrPatchServiceAccount(ctx, cluster)
+			err := env.clusterReconciler.createOrPatchServiceAccount(ctx, cluster)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
 		sa := &corev1.ServiceAccount{}
 
 		By("making sure that the serviceaccount has been created", func() {
-			expectResourceExistsWithDefaultClient(cluster.Name, namespace, sa)
+			expectResourceExists(env.client, cluster.Name, namespace, sa)
 		})
 
 		By("adding an annotation, a label and an image pull secret to the service account", func() {
@@ -271,18 +281,18 @@ var _ = Describe("cluster_create unit tests", func() {
 			sa.ImagePullSecrets = append(sa.ImagePullSecrets, corev1.LocalObjectReference{
 				Name: "sa-pullsecret",
 			})
-			err := k8sClient.Update(context.Background(), sa)
+			err := env.client.Update(context.Background(), sa)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
 		By("executing createOrPatchServiceAccount (no-patch)", func() {
-			err := clusterReconciler.createOrPatchServiceAccount(ctx, cluster)
+			err := env.clusterReconciler.createOrPatchServiceAccount(ctx, cluster)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
 		By("making sure that the serviceaccount is untouched because there is no change in the cluster", func() {
 			updatedSa := &corev1.ServiceAccount{}
-			expectResourceExistsWithDefaultClient(cluster.Name, namespace, updatedSa)
+			expectResourceExists(env.client, cluster.Name, namespace, updatedSa)
 			Expect(updatedSa).To(BeEquivalentTo(sa))
 		})
 
@@ -290,25 +300,25 @@ var _ = Describe("cluster_create unit tests", func() {
 			cluster.Spec.ImagePullSecrets = append(cluster.Spec.ImagePullSecrets, apiv1.LocalObjectReference{
 				Name: "cluster-pullsecret",
 			})
-			err := k8sClient.Update(context.Background(), cluster)
+			err := env.client.Update(context.Background(), cluster)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
 		By("executing createOrPatchServiceAccount (patch)", func() {
 			By("setting owner reference to nil", func() {
 				sa.ObjectMeta.OwnerReferences = nil
-				err := k8sClient.Update(context.Background(), sa)
+				err := env.client.Update(context.Background(), sa)
 				Expect(err).ToNot(HaveOccurred())
 			})
 
 			By("running patch", func() {
-				err := clusterReconciler.createOrPatchServiceAccount(ctx, cluster)
+				err := env.clusterReconciler.createOrPatchServiceAccount(ctx, cluster)
 				Expect(err).ToNot(HaveOccurred())
 			})
 
 			By("making sure that the serviceaccount is patched correctly", func() {
 				updatedSA := &corev1.ServiceAccount{}
-				expectResourceExistsWithDefaultClient(cluster.Name, namespace, updatedSA)
+				expectResourceExists(env.client, cluster.Name, namespace, updatedSA)
 				Expect(updatedSA.Annotations["test"]).To(BeEquivalentTo("annotation"))
 				Expect(updatedSA.Labels["test"]).To(BeEquivalentTo("label"))
 				Expect(updatedSA.ImagePullSecrets).To(ContainElements(corev1.LocalObjectReference{
@@ -323,12 +333,12 @@ var _ = Describe("cluster_create unit tests", func() {
 	})
 
 	It("should make sure that reconcilePodDisruptionBudget works correctly", func(ctx SpecContext) {
-		namespace := newFakeNamespace()
-		cluster := newFakeCNPGCluster(namespace)
+		namespace := newFakeNamespace(env.client)
+		cluster := newFakeCNPGCluster(env.client, namespace)
 		pdbReplicaName := specs.BuildReplicasPodDisruptionBudget(cluster).Name
 		pdbPrimaryName := specs.BuildPrimaryPodDisruptionBudget(cluster).Name
 		reconcilePDB := func() {
-			err := clusterReconciler.reconcilePodDisruptionBudget(ctx, cluster)
+			err := env.clusterReconciler.reconcilePodDisruptionBudget(ctx, cluster)
 			Expect(err).ToNot(HaveOccurred())
 		}
 
@@ -337,12 +347,14 @@ var _ = Describe("cluster_create unit tests", func() {
 		})
 
 		By("making sure PDB exists", func() {
-			expectResourceExistsWithDefaultClient(
+			expectResourceExists(
+				env.client,
 				pdbPrimaryName,
 				namespace,
 				&policyv1.PodDisruptionBudget{},
 			)
-			expectResourceExistsWithDefaultClient(
+			expectResourceExists(
+				env.client,
 				pdbReplicaName,
 				namespace,
 				&policyv1.PodDisruptionBudget{},
@@ -362,7 +374,8 @@ var _ = Describe("cluster_create unit tests", func() {
 		})
 
 		By("making sure that the replicas PDB are deleted", func() {
-			expectResourceDoesntExistWithDefaultClient(
+			expectResourceDoesntExist(
+				env.client,
 				pdbReplicaName,
 				namespace,
 				&policyv1.PodDisruptionBudget{},
@@ -379,12 +392,14 @@ var _ = Describe("cluster_create unit tests", func() {
 		})
 
 		By("making sure that both the replicas and main PDB are deleted", func() {
-			expectResourceDoesntExistWithDefaultClient(
+			expectResourceDoesntExist(
+				env.client,
 				pdbPrimaryName,
 				namespace,
 				&policyv1.PodDisruptionBudget{},
 			)
-			expectResourceDoesntExistWithDefaultClient(
+			expectResourceDoesntExist(
+				env.client,
 				pdbReplicaName,
 				namespace,
 				&policyv1.PodDisruptionBudget{},
@@ -394,10 +409,12 @@ var _ = Describe("cluster_create unit tests", func() {
 })
 
 var _ = Describe("check if bootstrap recovery can proceed", func() {
+	var env *testingEnvironment
 	var namespace, clusterName, name string
 
 	BeforeEach(func() {
-		namespace = newFakeNamespace()
+		env = buildTestEnvironment()
+		namespace = newFakeNamespace(env.client)
 		clusterName = "awesomeCluster"
 		name = "foo"
 	})
@@ -426,7 +443,7 @@ var _ = Describe("check if bootstrap recovery can proceed", func() {
 			}
 
 			ctx := context.Background()
-			res, err := clusterReconciler.checkReadyForRecovery(ctx, backup, cluster)
+			res, err := env.clusterReconciler.checkReadyForRecovery(ctx, backup, cluster)
 			Expect(err).ToNot(HaveOccurred())
 			if expectRequeue {
 				Expect(res).ToNot(BeNil())
@@ -457,11 +474,13 @@ var _ = Describe("check if bootstrap recovery can proceed", func() {
 })
 
 var _ = Describe("check if bootstrap recovery can proceed from volume snapshot", func() {
+	var env *testingEnvironment
 	var namespace, clusterName string
 	var cluster *apiv1.Cluster
 
 	BeforeEach(func() {
-		namespace = newFakeNamespace()
+		env = buildTestEnvironment()
+		namespace = newFakeNamespace(env.client)
 		clusterName = "awesomeCluster"
 		cluster = &apiv1.Cluster{
 			ObjectMeta: metav1.ObjectMeta{
@@ -512,9 +531,9 @@ var _ = Describe("check if bootstrap recovery can proceed from volume snapshot",
 
 		newClusterReconciler := &ClusterReconciler{
 			Client:          mockClient,
-			Scheme:          scheme,
+			Scheme:          env.scheme,
 			Recorder:        record.NewFakeRecorder(120),
-			DiscoveryClient: discoveryClient,
+			DiscoveryClient: env.discoveryClient,
 		}
 
 		res, err := newClusterReconciler.checkReadyForRecovery(ctx, nil, cluster)
@@ -547,9 +566,9 @@ var _ = Describe("check if bootstrap recovery can proceed from volume snapshot",
 
 		newClusterReconciler := &ClusterReconciler{
 			Client:          mockClient,
-			Scheme:          scheme,
+			Scheme:          env.scheme,
 			Recorder:        record.NewFakeRecorder(120),
-			DiscoveryClient: discoveryClient,
+			DiscoveryClient: env.discoveryClient,
 		}
 
 		res, err := newClusterReconciler.checkReadyForRecovery(ctx, nil, cluster)
@@ -583,9 +602,9 @@ var _ = Describe("check if bootstrap recovery can proceed from volume snapshot",
 
 		newClusterReconciler := &ClusterReconciler{
 			Client:          mockClient,
-			Scheme:          scheme,
+			Scheme:          env.scheme,
 			Recorder:        record.NewFakeRecorder(120),
-			DiscoveryClient: discoveryClient,
+			DiscoveryClient: env.discoveryClient,
 		}
 
 		res, err := newClusterReconciler.checkReadyForRecovery(ctx, nil, cluster)

--- a/controllers/cluster_scale_test.go
+++ b/controllers/cluster_scale_test.go
@@ -24,7 +24,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
@@ -37,43 +37,52 @@ import (
 )
 
 var _ = Describe("scale down", func() {
+	var env *testingEnvironment
+	BeforeEach(func() {
+		env = buildTestEnvironment()
+	})
+
 	When("there's no separate WAL storage", func() {
 		It("delete the PGDATA PVC", func() {
 			ctx := context.Background()
-			namespace := newFakeNamespace()
-			cluster := newFakeCNPGCluster(namespace)
+			namespace := newFakeNamespace(env.client)
+			cluster := newFakeCNPGCluster(env.client, namespace)
 
 			resources := &managedResources{
-				pvcs:      corev1.PersistentVolumeClaimList{Items: generateFakePVCWithDefaultClient(cluster)},
-				jobs:      batchv1.JobList{Items: generateFakeInitDBJobsWithDefaultClient(cluster)},
-				instances: corev1.PodList{Items: generateFakeClusterPodsWithDefaultClient(cluster, true)},
+				pvcs: corev1.PersistentVolumeClaimList{
+					Items: generateClusterPVC(env.client, cluster, persistentvolumeclaim.StatusReady),
+				},
+				jobs: batchv1.JobList{Items: generateFakeInitDBJobsWithDefaultClient(env.client, cluster)},
+				instances: corev1.PodList{
+					Items: generateFakeClusterPodsWithDefaultClient(env.client, cluster, true),
+				},
 			}
 
 			instanceName := findDeletableInstance(cluster, resources.instances.Items)
 			Expect(isResourceExisting(
 				ctx,
+				env.client,
 				&corev1.Pod{},
 				types.NamespacedName{Name: instanceName, Namespace: cluster.Namespace},
 			)).To(BeTrue())
 			Expect(isResourceExisting(
 				ctx,
+				env.client,
 				&corev1.PersistentVolumeClaim{},
 				types.NamespacedName{Name: instanceName, Namespace: cluster.Namespace},
 			)).To(BeTrue())
 
-			Expect(clusterReconciler.scaleDownCluster(
-				ctx,
-				cluster,
-				resources,
-			)).To(Succeed())
+			Expect(env.clusterReconciler.scaleDownCluster(ctx, cluster, resources)).To(Succeed())
 
 			Expect(isResourceExisting(
 				ctx,
+				env.client,
 				&corev1.Pod{},
 				types.NamespacedName{Name: instanceName, Namespace: cluster.Namespace},
 			)).To(BeFalse())
 			Expect(isResourceExisting(
 				ctx,
+				env.client,
 				&corev1.PersistentVolumeClaim{},
 				types.NamespacedName{Name: instanceName, Namespace: cluster.Namespace},
 			)).To(BeFalse())
@@ -83,34 +92,41 @@ var _ = Describe("scale down", func() {
 	When("WAL storage is separate", func() {
 		It("delete the PGDATA and WAL PVC", func() {
 			ctx := context.Background()
-			namespace := newFakeNamespace()
-			cluster := newFakeCNPGClusterWithPGWal(namespace)
+			namespace := newFakeNamespace(env.client)
+			cluster := newFakeCNPGClusterWithPGWal(env.client, namespace)
 
 			resources := &managedResources{
-				pvcs:      corev1.PersistentVolumeClaimList{Items: generateFakePVCWithDefaultClient(cluster)},
-				jobs:      batchv1.JobList{Items: generateFakeInitDBJobsWithDefaultClient(cluster)},
-				instances: corev1.PodList{Items: generateFakeClusterPodsWithDefaultClient(cluster, true)},
+				pvcs: corev1.PersistentVolumeClaimList{
+					Items: generateClusterPVC(env.client, cluster, persistentvolumeclaim.StatusReady),
+				},
+				jobs: batchv1.JobList{Items: generateFakeInitDBJobsWithDefaultClient(env.client, cluster)},
+				instances: corev1.PodList{
+					Items: generateFakeClusterPodsWithDefaultClient(env.client, cluster, true),
+				},
 			}
 
 			instanceName := findDeletableInstance(cluster, resources.instances.Items)
 			pvcWalName := persistentvolumeclaim.NewPgWalCalculator().GetName(instanceName)
 			Expect(isResourceExisting(
 				ctx,
+				env.client,
 				&corev1.Pod{},
 				types.NamespacedName{Name: instanceName, Namespace: cluster.Namespace},
 			)).To(BeTrue())
 			Expect(isResourceExisting(
 				ctx,
+				env.client,
 				&corev1.PersistentVolumeClaim{},
 				types.NamespacedName{Name: instanceName, Namespace: cluster.Namespace},
 			)).To(BeTrue())
 			Expect(isResourceExisting(
 				ctx,
+				env.client,
 				&corev1.PersistentVolumeClaim{},
 				types.NamespacedName{Name: pvcWalName, Namespace: cluster.Namespace},
 			)).To(BeTrue())
 
-			Expect(clusterReconciler.scaleDownCluster(
+			Expect(env.clusterReconciler.scaleDownCluster(
 				ctx,
 				cluster,
 				resources,
@@ -118,16 +134,19 @@ var _ = Describe("scale down", func() {
 
 			Expect(isResourceExisting(
 				ctx,
+				env.client,
 				&corev1.Pod{},
 				types.NamespacedName{Name: instanceName, Namespace: cluster.Namespace},
 			)).To(BeFalse())
 			Expect(isResourceExisting(
 				ctx,
+				env.client,
 				&corev1.PersistentVolumeClaim{},
 				types.NamespacedName{Name: instanceName, Namespace: cluster.Namespace},
 			)).To(BeFalse())
 			Expect(isResourceExisting(
 				ctx,
+				env.client,
 				&corev1.PersistentVolumeClaim{},
 				types.NamespacedName{Name: pvcWalName, Namespace: cluster.Namespace},
 			)).To(BeFalse())
@@ -137,7 +156,7 @@ var _ = Describe("scale down", func() {
 
 var _ = Describe("cluster scale pod and job deletion logic", func() {
 	var (
-		fakeClientSet ctrl.WithWatch
+		fakeClientSet client.WithWatch
 		reconciler    *ClusterReconciler
 		ctx           context.Context
 		cancel        context.CancelFunc
@@ -219,7 +238,12 @@ var _ = Describe("cluster scale pod and job deletion logic", func() {
 })
 
 // isResourceExisting check is a certain resource exists in the Kubernetes space and has not been deleted
-func isResourceExisting(ctx context.Context, store ctrl.Object, key ctrl.ObjectKey) (bool, error) {
+func isResourceExisting(
+	ctx context.Context,
+	k8sClient client.Client,
+	store client.Object,
+	key client.ObjectKey,
+) (bool, error) {
 	err := k8sClient.Get(ctx, key, store)
 	if err != nil && apierrors.IsNotFound(err) {
 		return false, nil

--- a/controllers/cluster_scale_test.go
+++ b/controllers/cluster_scale_test.go
@@ -72,7 +72,11 @@ var _ = Describe("scale down", func() {
 				types.NamespacedName{Name: instanceName, Namespace: cluster.Namespace},
 			)).To(BeTrue())
 
-			Expect(env.clusterReconciler.scaleDownCluster(ctx, cluster, resources)).To(Succeed())
+			Expect(env.clusterReconciler.scaleDownCluster(
+				ctx,
+				cluster,
+				resources,
+			)).To(Succeed())
 
 			Expect(isResourceExisting(
 				ctx,

--- a/controllers/pooler_predicates_test.go
+++ b/controllers/pooler_predicates_test.go
@@ -29,10 +29,15 @@ import (
 )
 
 var _ = Describe("pooler_predicates unit tests", func() {
+	var env *testingEnvironment
+	BeforeEach(func() {
+		env = buildTestEnvironment()
+	})
+
 	It("makes sure isUsefulPoolerSecret works correctly", func() {
-		namespace := newFakeNamespace()
-		cluster := newFakeCNPGCluster(namespace)
-		pooler := newFakePooler(cluster)
+		namespace := newFakeNamespace(env.client)
+		cluster := newFakeCNPGCluster(env.client, namespace)
+		pooler := newFakePooler(env.client, cluster)
 
 		By("making sure it returns true for owned secrets", func() {
 			secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: rand.String(10), Namespace: namespace}}
@@ -63,9 +68,9 @@ var _ = Describe("pooler_predicates unit tests", func() {
 	})
 
 	It("makes sure isOwnedByPoolerOrSatisfiesPredicate works correctly", func() {
-		namespace := newFakeNamespace()
-		cluster := newFakeCNPGCluster(namespace)
-		pooler := newFakePooler(cluster)
+		namespace := newFakeNamespace(env.client)
+		cluster := newFakeCNPGCluster(env.client, namespace)
+		pooler := newFakePooler(env.client, cluster)
 
 		secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: rand.String(10), Namespace: namespace}}
 		utils.SetAsOwnedBy(&secret.ObjectMeta, pooler.ObjectMeta, pooler.TypeMeta)

--- a/controllers/pooler_resources_test.go
+++ b/controllers/pooler_resources_test.go
@@ -30,6 +30,11 @@ import (
 )
 
 var _ = Describe("pooler_resources unit tests", func() {
+	var env *testingEnvironment
+	BeforeEach(func() {
+		env = buildTestEnvironment()
+	})
+
 	assertResourceIsCorrect := func(expected metav1.ObjectMeta, result metav1.ObjectMeta, err error) {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(result).ToNot(BeNil())
@@ -39,13 +44,13 @@ var _ = Describe("pooler_resources unit tests", func() {
 
 	It("should correctly fetch the deployment when it exists", func() {
 		ctx := context.Background()
-		namespace := newFakeNamespace()
-		cluster := newFakeCNPGCluster(namespace)
-		pooler := newFakePooler(cluster)
+		namespace := newFakeNamespace(env.client)
+		cluster := newFakeCNPGCluster(env.client, namespace)
+		pooler := newFakePooler(env.client, cluster)
 		objectKey := client.ObjectKey{Namespace: pooler.Namespace, Name: pooler.Name}
 
 		By("making sure that returns nil if the deployment doesn't exist", func() {
-			result, err := getDeploymentOrNil(ctx, poolerReconciler.Client, objectKey)
+			result, err := getDeploymentOrNil(ctx, env.poolerReconciler.Client, objectKey)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(result).To(BeNil())
 		})
@@ -54,37 +59,37 @@ var _ = Describe("pooler_resources unit tests", func() {
 			dep, err := pgbouncer.Deployment(pooler, cluster)
 			Expect(err).ToNot(HaveOccurred())
 
-			err = poolerReconciler.Create(ctx, dep)
+			err = env.poolerReconciler.Create(ctx, dep)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
 		By("making sure it returns the created deployment", func() {
-			result, err := getDeploymentOrNil(ctx, poolerReconciler.Client, objectKey)
+			result, err := getDeploymentOrNil(ctx, env.poolerReconciler.Client, objectKey)
 			assertResourceIsCorrect(pooler.ObjectMeta, result.ObjectMeta, err)
 		})
 	})
 
 	It("should correctly fetch the cluster when it exists", func() {
 		ctx := context.Background()
-		namespace := newFakeNamespace()
-		cluster := newFakeCNPGCluster(namespace)
+		namespace := newFakeNamespace(env.client)
+		cluster := newFakeCNPGCluster(env.client, namespace)
 		objectKey := client.ObjectKey{Namespace: cluster.Namespace, Name: cluster.Name}
 
 		By("making sure it returns the cluster object", func() {
-			result, err := getClusterOrNil(ctx, poolerReconciler.Client, objectKey)
+			result, err := getClusterOrNil(ctx, env.poolerReconciler.Client, objectKey)
 			assertResourceIsCorrect(cluster.ObjectMeta, result.ObjectMeta, err)
 		})
 	})
 
 	It("should correctly fetch the secret when it exists", func() {
 		ctx := context.Background()
-		namespace := newFakeNamespace()
-		cluster := newFakeCNPGCluster(namespace)
-		pooler := newFakePooler(cluster)
+		namespace := newFakeNamespace(env.client)
+		cluster := newFakeCNPGCluster(env.client, namespace)
+		pooler := newFakePooler(env.client, cluster)
 		objectKey := client.ObjectKey{Name: pooler.GetAuthQuerySecretName(), Namespace: pooler.Namespace}
 
 		By("making sure that returns nil if the secret doesn't exist", func() {
-			result, err := getSecretOrNil(ctx, poolerReconciler.Client, objectKey)
+			result, err := getSecretOrNil(ctx, env.poolerReconciler.Client, objectKey)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(result).To(BeNil())
 		})
@@ -93,12 +98,12 @@ var _ = Describe("pooler_resources unit tests", func() {
 			secret := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Name: pooler.GetAuthQuerySecretName(), Namespace: pooler.Namespace},
 			}
-			err := poolerReconciler.Create(ctx, secret)
+			err := env.poolerReconciler.Create(ctx, secret)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
 		By("making sure it returns the created secret", func() {
-			result, err := getSecretOrNil(ctx, poolerReconciler.Client, objectKey)
+			result, err := getSecretOrNil(ctx, env.poolerReconciler.Client, objectKey)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(result).ToNot(BeNil())
 			Expect(result.Name).To(Equal(pooler.GetAuthQuerySecretName()))
@@ -108,100 +113,100 @@ var _ = Describe("pooler_resources unit tests", func() {
 
 	It("should correctly fetch the service when it exists", func() {
 		ctx := context.Background()
-		namespace := newFakeNamespace()
-		cluster := newFakeCNPGCluster(namespace)
-		pooler := newFakePooler(cluster)
+		namespace := newFakeNamespace(env.client)
+		cluster := newFakeCNPGCluster(env.client, namespace)
+		pooler := newFakePooler(env.client, cluster)
 		objectKey := client.ObjectKey{Namespace: pooler.Namespace, Name: pooler.Name}
 
 		By("making sure that returns nil if the service doesn't exist", func() {
-			result, err := getServiceOrNil(ctx, poolerReconciler.Client, objectKey)
+			result, err := getServiceOrNil(ctx, env.poolerReconciler.Client, objectKey)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(result).To(BeNil())
 		})
 
 		By("creating the service", func() {
 			service := pgbouncer.Service(pooler, cluster)
-			err := poolerReconciler.Create(ctx, service)
+			err := env.poolerReconciler.Create(ctx, service)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
 		By("making sure it returns the created service", func() {
-			result, err := getServiceOrNil(ctx, poolerReconciler.Client, objectKey)
+			result, err := getServiceOrNil(ctx, env.poolerReconciler.Client, objectKey)
 			assertResourceIsCorrect(pooler.ObjectMeta, result.ObjectMeta, err)
 		})
 	})
 
 	It("should correctly fetch the role when it exists", func() {
 		ctx := context.Background()
-		namespace := newFakeNamespace()
-		cluster := newFakeCNPGCluster(namespace)
-		pooler := newFakePooler(cluster)
+		namespace := newFakeNamespace(env.client)
+		cluster := newFakeCNPGCluster(env.client, namespace)
+		pooler := newFakePooler(env.client, cluster)
 		objectKey := client.ObjectKey{Namespace: pooler.Namespace, Name: pooler.Name}
 
 		By("making sure that returns nil if the role doesn't exist", func() {
-			result, err := getRoleOrNil(ctx, poolerReconciler.Client, objectKey)
+			result, err := getRoleOrNil(ctx, env.poolerReconciler.Client, objectKey)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(result).To(BeNil())
 		})
 
 		By("creating the role", func() {
 			role := pgbouncer.Role(pooler)
-			err := poolerReconciler.Create(ctx, role)
+			err := env.poolerReconciler.Create(ctx, role)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
 		By("making sure it returns the created role", func() {
-			result, err := getRoleOrNil(ctx, poolerReconciler.Client, objectKey)
+			result, err := getRoleOrNil(ctx, env.poolerReconciler.Client, objectKey)
 			assertResourceIsCorrect(pooler.ObjectMeta, result.ObjectMeta, err)
 		})
 	})
 
 	It("should correctly fetch the roleBinding when it exists", func() {
 		ctx := context.Background()
-		namespace := newFakeNamespace()
-		cluster := newFakeCNPGCluster(namespace)
-		pooler := newFakePooler(cluster)
+		namespace := newFakeNamespace(env.client)
+		cluster := newFakeCNPGCluster(env.client, namespace)
+		pooler := newFakePooler(env.client, cluster)
 		objectKey := client.ObjectKey{Namespace: pooler.Namespace, Name: pooler.Name}
 
 		By("making sure that returns nil if the roleBinding doesn't exist", func() {
-			result, err := getRoleBindingOrNil(ctx, poolerReconciler.Client, objectKey)
+			result, err := getRoleBindingOrNil(ctx, env.poolerReconciler.Client, objectKey)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(result).To(BeNil())
 		})
 
 		By("creating the roleBinding", func() {
 			roleBinding := pgbouncer.RoleBinding(pooler)
-			err := poolerReconciler.Create(ctx, &roleBinding)
+			err := env.poolerReconciler.Create(ctx, &roleBinding)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
 		By("making sure it returns the created roleBinding", func() {
-			result, err := getRoleBindingOrNil(ctx, poolerReconciler.Client, objectKey)
+			result, err := getRoleBindingOrNil(ctx, env.poolerReconciler.Client, objectKey)
 			assertResourceIsCorrect(pooler.ObjectMeta, result.ObjectMeta, err)
 		})
 	})
 
 	It("should correctly fetch the SA when it exists", func() {
 		ctx := context.Background()
-		namespace := newFakeNamespace()
-		cluster := newFakeCNPGCluster(namespace)
-		pooler := newFakePooler(cluster)
+		namespace := newFakeNamespace(env.client)
+		cluster := newFakeCNPGCluster(env.client, namespace)
+		pooler := newFakePooler(env.client, cluster)
 		objectKey := client.ObjectKey{Namespace: pooler.Namespace, Name: pooler.Name}
 
 		By("making sure that returns nil if the SA doesn't exist", func() {
-			result, err := getServiceAccountOrNil(ctx, poolerReconciler.Client, objectKey)
+			result, err := getServiceAccountOrNil(ctx, env.poolerReconciler.Client, objectKey)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(result).To(BeNil())
 		})
 
 		By("creating the SA", func() {
 			serviceAccount := pgbouncer.ServiceAccount(pooler)
-			err := poolerReconciler.Create(ctx, serviceAccount)
+			err := env.poolerReconciler.Create(ctx, serviceAccount)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
 		By("making sure it returns the created SA", func() {
-			result, err := getServiceAccountOrNil(ctx, poolerReconciler.Client, objectKey)
+			result, err := getServiceAccountOrNil(ctx, env.poolerReconciler.Client, objectKey)
 			assertResourceIsCorrect(pooler.ObjectMeta, result.ObjectMeta, err)
 		})
 	})

--- a/controllers/pooler_resources_test.go
+++ b/controllers/pooler_resources_test.go
@@ -136,6 +136,7 @@ var _ = Describe("pooler_resources unit tests", func() {
 		})
 	})
 
+	// nolint: dupl
 	It("should correctly fetch the role when it exists", func() {
 		ctx := context.Background()
 		namespace := newFakeNamespace(env.client)
@@ -186,6 +187,7 @@ var _ = Describe("pooler_resources unit tests", func() {
 		})
 	})
 
+	// nolint: dupl
 	It("should correctly fetch the SA when it exists", func() {
 		ctx := context.Background()
 		namespace := newFakeNamespace(env.client)

--- a/controllers/pooler_status_test.go
+++ b/controllers/pooler_status_test.go
@@ -139,8 +139,7 @@ var _ = Describe("pooler_status unit tests", func() {
 			poolerAfter := &v1.Pooler{}
 			err = env.client.Get(ctx, poolerQuery, poolerAfter)
 			Expect(err).ToNot(HaveOccurred())
-
-			Expect(poolerAfter.ResourceVersion).To(Equal(poolerBefore.ResourceVersion))
+			Expect(poolerBefore.Status).To(BeEquivalentTo(poolerAfter.Status))
 		})
 	})
 })

--- a/controllers/pooler_status_test.go
+++ b/controllers/pooler_status_test.go
@@ -31,6 +31,11 @@ import (
 )
 
 var _ = Describe("pooler_status unit tests", func() {
+	var env *testingEnvironment
+	BeforeEach(func() {
+		env = buildTestEnvironment()
+	})
+
 	assertClusterInheritedStatus := func(pooler *v1.Pooler, cluster *v1.Cluster) {
 		Expect(pooler.Status.Secrets.ServerCA.Name).To(Equal(cluster.GetServerCASecretName()))
 		Expect(pooler.Status.Secrets.ServerTLS.Name).To(Equal(cluster.GetServerTLSSecretName()))
@@ -43,21 +48,21 @@ var _ = Describe("pooler_status unit tests", func() {
 
 	It("should correctly deduce the status inherited from the cluster resource", func() {
 		ctx := context.Background()
-		namespace := newFakeNamespace()
-		cluster := newFakeCNPGCluster(namespace)
-		pooler := newFakePooler(cluster)
+		namespace := newFakeNamespace(env.client)
+		cluster := newFakeCNPGCluster(env.client, namespace)
+		pooler := newFakePooler(env.client, cluster)
 		res := &poolerManagedResources{Deployment: nil, Cluster: cluster}
 
-		err := poolerReconciler.updatePoolerStatus(ctx, pooler, res)
+		err := env.poolerReconciler.updatePoolerStatus(ctx, pooler, res)
 		Expect(err).ToNot(HaveOccurred())
 		assertClusterInheritedStatus(pooler, cluster)
 	})
 
 	It("should correctly set the status for authUserSecret", func() {
 		ctx := context.Background()
-		namespace := newFakeNamespace()
-		cluster := newFakeCNPGCluster(namespace)
-		pooler := newFakePooler(cluster)
+		namespace := newFakeNamespace(env.client)
+		cluster := newFakeCNPGCluster(env.client, namespace)
+		pooler := newFakePooler(env.client, cluster)
 		authUserSecret := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:            pooler.GetAuthQuerySecretName(),
@@ -67,31 +72,31 @@ var _ = Describe("pooler_status unit tests", func() {
 		}
 		res := &poolerManagedResources{AuthUserSecret: authUserSecret, Cluster: cluster}
 
-		err := poolerReconciler.updatePoolerStatus(ctx, pooler, res)
+		err := env.poolerReconciler.updatePoolerStatus(ctx, pooler, res)
 		Expect(err).ToNot(HaveOccurred())
 		assertAuthUserStatus(pooler, authUserSecret)
 	})
 
 	It("should correctly set the deployment status", func() {
 		ctx := context.Background()
-		namespace := newFakeNamespace()
-		cluster := newFakeCNPGCluster(namespace)
-		pooler := newFakePooler(cluster)
+		namespace := newFakeNamespace(env.client)
+		cluster := newFakeCNPGCluster(env.client, namespace)
+		pooler := newFakePooler(env.client, cluster)
 		dep, err := pgbouncer.Deployment(pooler, cluster)
 		dep.Status.Replicas = *dep.Spec.Replicas
 		Expect(err).ToNot(HaveOccurred())
 		res := &poolerManagedResources{Deployment: dep, Cluster: cluster}
 
-		err = poolerReconciler.updatePoolerStatus(ctx, pooler, res)
+		err = env.poolerReconciler.updatePoolerStatus(ctx, pooler, res)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(pooler.Status.Instances).To(Equal(dep.Status.Replicas))
 	})
 
 	It("should correctly interact with the api server", func() {
 		ctx := context.Background()
-		namespace := newFakeNamespace()
-		cluster := newFakeCNPGCluster(namespace)
-		pooler := newFakePooler(cluster)
+		namespace := newFakeNamespace(env.client)
+		cluster := newFakeCNPGCluster(env.client, namespace)
+		pooler := newFakePooler(env.client, cluster)
 		poolerQuery := types.NamespacedName{Name: pooler.Name, Namespace: pooler.Namespace}
 		authUserSecret := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
@@ -107,14 +112,14 @@ var _ = Describe("pooler_status unit tests", func() {
 
 		By("making sure it updates the remote stored status when there are changes", func() {
 			poolerBefore := &v1.Pooler{}
-			err := k8sClient.Get(ctx, poolerQuery, poolerBefore)
+			err := env.client.Get(ctx, poolerQuery, poolerBefore)
 			Expect(err).ToNot(HaveOccurred())
 
-			err = poolerReconciler.updatePoolerStatus(ctx, pooler, res)
+			err = env.poolerReconciler.updatePoolerStatus(ctx, pooler, res)
 			Expect(err).ToNot(HaveOccurred())
 
 			poolerAfter := &v1.Pooler{}
-			err = k8sClient.Get(ctx, poolerQuery, poolerAfter)
+			err = env.client.Get(ctx, poolerQuery, poolerAfter)
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(poolerAfter.ResourceVersion).ToNot(Equal(poolerBefore.ResourceVersion))
@@ -125,14 +130,14 @@ var _ = Describe("pooler_status unit tests", func() {
 
 		By("making sure it doesn't update the remote stored status when there aren't changes", func() {
 			poolerBefore := &v1.Pooler{}
-			err := k8sClient.Get(ctx, poolerQuery, poolerBefore)
+			err := env.client.Get(ctx, poolerQuery, poolerBefore)
 			Expect(err).ToNot(HaveOccurred())
 
-			err = poolerReconciler.updatePoolerStatus(ctx, pooler, res)
+			err = env.poolerReconciler.updatePoolerStatus(ctx, pooler, res)
 			Expect(err).ToNot(HaveOccurred())
 
 			poolerAfter := &v1.Pooler{}
-			err = k8sClient.Get(ctx, poolerQuery, poolerAfter)
+			err = env.client.Get(ctx, poolerQuery, poolerAfter)
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(poolerAfter.ResourceVersion).To(Equal(poolerBefore.ResourceVersion))

--- a/controllers/pooler_update_test.go
+++ b/controllers/pooler_update_test.go
@@ -256,7 +256,7 @@ var _ = Describe("unit test of pooler_update reconciliation logic", func() {
 		})
 
 		By("making sure the svc doesn't get updated if there are not changes", func() {
-			previousResourceVersion := res.Service.ResourceVersion
+			previousService := res.Service.DeepCopy()
 			err := env.poolerReconciler.reconcileService(ctx, pooler, res)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -264,8 +264,8 @@ var _ = Describe("unit test of pooler_update reconciliation logic", func() {
 			expectedSVC := pgbouncer.Service(pooler, cluster)
 			err = env.client.Get(ctx, types.NamespacedName{Name: expectedSVC.Name, Namespace: expectedSVC.Namespace}, svc)
 			Expect(err).ToNot(HaveOccurred())
-
-			Expect(previousResourceVersion).To(Equal(svc.ResourceVersion))
+			Expect(previousService.Spec).To(BeEquivalentTo(svc.Spec))
+			Expect(previousService.Labels).To(BeEquivalentTo(svc.Labels))
 		})
 
 		By("making sure it reconciles if differences from the living and expected service are present", func() {

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -19,8 +19,6 @@ package controllers
 import (
 	"context"
 	"fmt"
-	"os"
-	"path/filepath"
 	"testing"
 	"time"
 
@@ -32,34 +30,22 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/client-go/discovery"
-	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/rest"
+	fakediscovery "k8s.io/client-go/discovery/fake"
+	k8stesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	// +kubebuilder:scaffold:imports
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	schemeBuilder "github.com/cloudnative-pg/cloudnative-pg/internal/scheme"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/certs"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/reconciler/persistentvolumeclaim"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/specs"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-)
-
-var (
-	cfg               *rest.Config
-	k8sClient         client.Client
-	testEnv           *envtest.Environment
-	poolerReconciler  *PoolerReconciler
-	clusterReconciler *ClusterReconciler
-	backupReconciler  *BackupReconciler
-	scheme            *runtime.Scheme
-	discoveryClient   discovery.DiscoveryInterface
 )
 
 func init() {
@@ -71,68 +57,75 @@ func TestAPIs(t *testing.T) {
 	RunSpecs(t, "Controllers Suite")
 }
 
-var _ = BeforeSuite(func() {
-	By("bootstrapping test environment")
-	testEnv = buildTestEnv()
+type testingEnvironment struct {
+	backupReconciler  *BackupReconciler
+	scheme            *runtime.Scheme
+	clusterReconciler *ClusterReconciler
+	poolerReconciler  *PoolerReconciler
+	discoveryClient   *fakediscovery.FakeDiscovery
+	client            client.WithWatch
+}
+
+func buildTestEnvironment() *testingEnvironment {
 	var err error
-	cfg, err = testEnv.Start()
-	Expect(err).ToNot(HaveOccurred())
-	Expect(cfg).ToNot(BeNil())
-
-	scheme = runtime.NewScheme()
-
-	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
-
-	utilruntime.Must(apiv1.AddToScheme(scheme))
-
-	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme})
 	Expect(err).ToNot(HaveOccurred())
 
-	discoveryClient, err = discovery.NewDiscoveryClientForConfig(cfg)
+	scheme := schemeBuilder.BuildWithAllKnownScheme()
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).
+		WithStatusSubresource(&apiv1.Cluster{}, &apiv1.Backup{}, &apiv1.Pooler{}, &corev1.Service{},
+			&corev1.ConfigMap{}, &corev1.Secret{}).
+		Build()
 	Expect(err).ToNot(HaveOccurred())
 
-	clusterReconciler = &ClusterReconciler{
+	discoveryClient := &fakediscovery.FakeDiscovery{
+		Fake: &k8stesting.Fake{
+			Resources: []*metav1.APIResourceList{
+				{
+					GroupVersion: "monitoring.coreos.com/v1",
+					APIResources: []metav1.APIResource{
+						{
+							Name:       "podmonitors",
+							Kind:       "PodMonitor",
+							Namespaced: true,
+						},
+					},
+				},
+			},
+		},
+	}
+	Expect(err).ToNot(HaveOccurred())
+
+	clusterReconciler := &ClusterReconciler{
 		Client:          k8sClient,
 		Scheme:          scheme,
 		Recorder:        record.NewFakeRecorder(120),
 		DiscoveryClient: discoveryClient,
 	}
 
-	poolerReconciler = &PoolerReconciler{
+	poolerReconciler := &PoolerReconciler{
 		Client:          k8sClient,
 		Scheme:          scheme,
 		Recorder:        record.NewFakeRecorder(120),
 		DiscoveryClient: discoveryClient,
 	}
 
-	backupReconciler = &BackupReconciler{
+	backupReconciler := &BackupReconciler{
 		Client:   k8sClient,
 		Scheme:   scheme,
 		Recorder: record.NewFakeRecorder(120),
 	}
-})
 
-var _ = AfterSuite(func() {
-	By("tearing down the test environment")
-	err := testEnv.Stop()
-	Expect(err).ToNot(HaveOccurred())
-})
-
-func buildTestEnv() *envtest.Environment {
-	const (
-		envUseExistingCluster = "USE_EXISTING_CLUSTER"
-	)
-
-	testEnvironment := &envtest.Environment{}
-	if os.Getenv(envUseExistingCluster) != "true" {
-		By("bootstrapping test environment")
-		testEnvironment.CRDDirectoryPaths = []string{filepath.Join("..", "config", "crd", "bases")}
+	return &testingEnvironment{
+		scheme:            scheme,
+		client:            k8sClient,
+		clusterReconciler: clusterReconciler,
+		backupReconciler:  backupReconciler,
+		poolerReconciler:  poolerReconciler,
+		discoveryClient:   discoveryClient,
 	}
-
-	return testEnvironment
 }
 
-func newFakePooler(cluster *apiv1.Cluster) *apiv1.Pooler {
+func newFakePooler(k8sClient client.Client, cluster *apiv1.Cluster) *apiv1.Pooler {
 	pooler := &apiv1.Pooler{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "pooler-" + rand.String(10),
@@ -162,7 +155,11 @@ func newFakePooler(cluster *apiv1.Cluster) *apiv1.Pooler {
 	return pooler
 }
 
-func newFakeCNPGCluster(namespace string, mutators ...func(cluster *apiv1.Cluster)) *apiv1.Cluster {
+func newFakeCNPGCluster(
+	k8sClient client.Client,
+	namespace string,
+	mutators ...func(cluster *apiv1.Cluster),
+) *apiv1.Cluster {
 	const instances int = 3
 	name := "cluster-" + rand.String(10)
 	caServer := fmt.Sprintf("%s-ca-server", name)
@@ -211,11 +208,10 @@ func newFakeCNPGCluster(namespace string, mutators ...func(cluster *apiv1.Cluste
 		mutator(cluster)
 	}
 
-	err = k8sClient.Status().Update(context.Background(), cluster)
-	Expect(err).ToNot(HaveOccurred())
 	err = k8sClient.Update(context.Background(), cluster)
 	Expect(err).ToNot(HaveOccurred())
-
+	err = k8sClient.Status().Update(context.Background(), cluster)
+	Expect(err).ToNot(HaveOccurred())
 	// upstream issue, go client cleans typemeta: https://github.com/kubernetes/client-go/issues/308
 	cluster.TypeMeta = metav1.TypeMeta{
 		Kind:       apiv1.ClusterKind,
@@ -225,7 +221,7 @@ func newFakeCNPGCluster(namespace string, mutators ...func(cluster *apiv1.Cluste
 	return cluster
 }
 
-func newFakeCNPGClusterWithPGWal(namespace string) *apiv1.Cluster {
+func newFakeCNPGClusterWithPGWal(k8sClient client.Client, namespace string) *apiv1.Cluster {
 	const instances int = 3
 	name := "cluster-" + rand.String(10)
 	caServer := fmt.Sprintf("%s-ca-server", name)
@@ -276,7 +272,7 @@ func newFakeCNPGClusterWithPGWal(namespace string) *apiv1.Cluster {
 	return cluster
 }
 
-func newFakeNamespace() string {
+func newFakeNamespace(k8sClient client.Client) string {
 	name := rand.String(10)
 
 	namespace := &corev1.Namespace{
@@ -292,7 +288,7 @@ func newFakeNamespace() string {
 	return name
 }
 
-func getPoolerDeployment(ctx context.Context, pooler *apiv1.Pooler) *appsv1.Deployment {
+func getPoolerDeployment(ctx context.Context, k8sClient client.Client, pooler *apiv1.Pooler) *appsv1.Deployment {
 	deployment := &appsv1.Deployment{}
 	err := k8sClient.Get(
 		ctx,
@@ -337,7 +333,11 @@ func generateFakeClusterPods(
 	return pods
 }
 
-func generateFakeClusterPodsWithDefaultClient(cluster *apiv1.Cluster, markAsReady bool) []corev1.Pod {
+func generateFakeClusterPodsWithDefaultClient(
+	k8sClient client.Client,
+	cluster *apiv1.Cluster,
+	markAsReady bool,
+) []corev1.Pod {
 	return generateFakeClusterPods(k8sClient, cluster, markAsReady)
 }
 
@@ -356,7 +356,7 @@ func generateFakeInitDBJobs(c client.Client, cluster *apiv1.Cluster) []batchv1.J
 	return jobs
 }
 
-func generateFakeInitDBJobsWithDefaultClient(cluster *apiv1.Cluster) []batchv1.Job {
+func generateFakeInitDBJobsWithDefaultClient(k8sClient client.Client, cluster *apiv1.Cluster) []batchv1.Job {
 	return generateFakeInitDBJobs(k8sClient, cluster)
 }
 
@@ -416,10 +416,6 @@ func newFakePVC(
 	return pvcGroup
 }
 
-func generateFakePVCWithDefaultClient(cluster *apiv1.Cluster) []corev1.PersistentVolumeClaim {
-	return generateClusterPVC(k8sClient, cluster, persistentvolumeclaim.StatusReady)
-}
-
 // generateFakeCASecret follows the conventions established by cert.GenerateCASecret
 func generateFakeCASecret(c client.Client, name, namespace, domain string) (*corev1.Secret, *certs.KeyPair) {
 	keyPair, err := certs.CreateRootCA(domain, namespace)
@@ -442,10 +438,6 @@ func generateFakeCASecret(c client.Client, name, namespace, domain string) (*cor
 	return secret, keyPair
 }
 
-func generateFakeCASecretWithDefaultClient(name, namespace, domain string) (*corev1.Secret, *certs.KeyPair) {
-	return generateFakeCASecret(k8sClient, name, namespace, domain)
-}
-
 func expectResourceExists(c client.Client, name, namespace string, resource client.Object) {
 	err := c.Get(
 		context.Background(),
@@ -455,10 +447,6 @@ func expectResourceExists(c client.Client, name, namespace string, resource clie
 	Expect(err).ToNot(HaveOccurred())
 }
 
-func expectResourceExistsWithDefaultClient(name, namespace string, resource client.Object) {
-	expectResourceExists(k8sClient, name, namespace, resource)
-}
-
 func expectResourceDoesntExist(c client.Client, name, namespace string, resource client.Object) {
 	err := c.Get(
 		context.Background(),
@@ -466,10 +454,6 @@ func expectResourceDoesntExist(c client.Client, name, namespace string, resource
 		resource,
 	)
 	Expect(apierrors.IsNotFound(err)).To(BeTrue())
-}
-
-func expectResourceDoesntExistWithDefaultClient(name, namespace string, resource client.Object) {
-	expectResourceDoesntExist(k8sClient, name, namespace, resource)
 }
 
 type (


### PR DESCRIPTION
This patch removes `envtest` from the controller packages. This is done for several reasons:
- is only used in a few of the controller package tests
- acts as a singleton, reducing the predictability of the unit tests
- makes it harder to use the debugger
- does not currently add any real benefit that isn't already covered by webhook unit tests and E2E tests

Note for the reviewers:
In my opinion, `envtest` could be reintroduced  as an integration testing layer with a different PR 