### PR TITLE
fix: align enableSuperuserAccess default

### DIFF
--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -3292,7 +3292,7 @@ func (cluster *Cluster) GetEnableSuperuserAccess() bool {
 		return *cluster.Spec.EnableSuperuserAccess
 	}
 
-	return true
+	return false
 }
 
 // LogTimestampsWithMessage prints useful information about timestamps in stdout

--- a/api/v1/cluster_types_test.go
+++ b/api/v1/cluster_types_test.go
@@ -41,7 +41,7 @@ var _ = Describe("PostgreSQL cluster type", func() {
 
 	It("correctly get if the superuser is enabled", func() {
 		postgresql.Spec.EnableSuperuserAccess = nil
-		Expect(postgresql.GetEnableSuperuserAccess()).To(BeTrue())
+		Expect(postgresql.GetEnableSuperuserAccess()).To(BeFalse())
 
 		falseValue := false
 		postgresql.Spec.EnableSuperuserAccess = &falseValue


### PR DESCRIPTION
Within the `GetEnableSuperuserAccess` function, the codebase defaulted to `true` while the `cluster.spec.enableSuperuserAccess` in the CRD was defaulted to `false`.

This discrepancy does not lead to any runtime issues because when the operator retrieves Custom Resources from the API server, the structure has already been populated with the correct values.

However, the problem can still surface during unit tests when utilizing a mock Kubernetes client.

Closes: #4211 