### PR TITLE
feat: enable configuration of `wal_log_hints`

### DIFF
--- a/api/v1/cluster_webhook.go
+++ b/api/v1/cluster_webhook.go
@@ -1201,7 +1201,7 @@ func (r *Cluster) validateConfiguration() field.ErrorList {
 			field.Invalid(
 				field.NewPath("spec", "postgresql", "parameters", postgres.ParameterWalLogHints),
 				r.Spec.PostgresConfiguration.Parameters[postgres.ParameterWalLogHints],
-				"`wal_log_hints` should be set to `on` when having replica instances"))
+				"`wal_log_hints` must be set to `on` when `instances` > 1"))
 	}
 
 	// verify the postgres setting min_wal_size < max_wal_size < volume size

--- a/api/v1/cluster_webhook.go
+++ b/api/v1/cluster_webhook.go
@@ -1195,6 +1195,15 @@ func (r *Cluster) validateConfiguration() field.ErrorList {
 		}
 	}
 
+	if r.Spec.Instances > 1 && r.Spec.PostgresConfiguration.Parameters[postgres.ParameterWalLogHints] == "off" {
+		result = append(
+			result,
+			field.Invalid(
+				field.NewPath("spec", "postgresql", "parameters", postgres.ParameterWalLogHints),
+				r.Spec.PostgresConfiguration.Parameters[postgres.ParameterWalLogHints],
+				"`wal_log_hints` should be set to `on` when having replica instances"))
+	}
+
 	// verify the postgres setting min_wal_size < max_wal_size < volume size
 	result = append(result, validateWalSizeConfiguration(
 		r.Spec.PostgresConfiguration, r.Spec.WalStorage.GetSizeOrNil())...)

--- a/api/v1/cluster_webhook_test.go
+++ b/api/v1/cluster_webhook_test.go
@@ -1326,6 +1326,84 @@ var _ = Describe("configuration change validation", func() {
 		}
 		Expect(cluster.validateWALLevelChange(&oldCluster)).To(BeEmpty())
 	})
+
+	Describe("wal_log_hints", func() {
+		It("should allow wal_log_hints set to off for clusters having just one instance", func() {
+			cluster := Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						utils.SkipWalArchiving: "enabled",
+					},
+				},
+				Spec: ClusterSpec{
+					Instances: 1,
+					PostgresConfiguration: PostgresConfiguration{
+						Parameters: map[string]string{
+							"wal_log_hints": "off",
+						},
+					},
+				},
+			}
+			Expect(cluster.validateConfiguration()).To(BeEmpty())
+		})
+
+		It("should not allow wal_log_hints set to off for clusters having more than one instance", func() {
+			cluster := Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						utils.SkipWalArchiving: "enabled",
+					},
+				},
+				Spec: ClusterSpec{
+					Instances: 3,
+					PostgresConfiguration: PostgresConfiguration{
+						Parameters: map[string]string{
+							"wal_log_hints": "off",
+						},
+					},
+				},
+			}
+			Expect(cluster.validateConfiguration()).ToNot(BeEmpty())
+		})
+
+		It("should allow wal_log_hints set to on for clusters having just one instance", func() {
+			cluster := Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						utils.SkipWalArchiving: "enabled",
+					},
+				},
+				Spec: ClusterSpec{
+					Instances: 1,
+					PostgresConfiguration: PostgresConfiguration{
+						Parameters: map[string]string{
+							"wal_log_hints": "on",
+						},
+					},
+				},
+			}
+			Expect(cluster.validateConfiguration()).To(BeEmpty())
+		})
+
+		It("should not allow wal_log_hints set to on for clusters having more than one instance", func() {
+			cluster := Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						utils.SkipWalArchiving: "enabled",
+					},
+				},
+				Spec: ClusterSpec{
+					Instances: 3,
+					PostgresConfiguration: PostgresConfiguration{
+						Parameters: map[string]string{
+							"wal_log_hints": "on",
+						},
+					},
+				},
+			}
+			Expect(cluster.validateConfiguration()).To(BeEmpty())
+		})
+	})
 })
 
 var _ = Describe("validate image name change", func() {

--- a/docs/src/postgresql_conf.md
+++ b/docs/src/postgresql_conf.md
@@ -76,6 +76,7 @@ max_parallel_workers = '32'
 max_replication_slots = '32'
 max_worker_processes = '32'
 shared_memory_type = 'mmap' # for PostgreSQL >= 12 only
+wal_log_hints = 'on'
 wal_keep_size = '512MB' # for PostgreSQL >= 13 only
 wal_keep_segments = '32' # for PostgreSQL <= 12 only
 wal_level = 'logical'
@@ -121,7 +122,6 @@ ssl_cert_file = '/controller/certificates/server.crt'
 ssl_key_file = '/controller/certificates/server.key'
 unix_socket_directories = '/controller/run'
 wal_level = 'logical'
-wal_log_hints = 'on'
 ```
 
 Since the fixed parameters are added at the end, they can't be overridden by the

--- a/docs/src/postgresql_conf.md
+++ b/docs/src/postgresql_conf.md
@@ -64,6 +64,7 @@ operator by applying the following sections in this order:
 The **global default parameters** are:
 
 ```text
+archive_mode = 'on'
 dynamic_shared_memory_type = 'posix'
 logging_collector = 'on'
 log_destination = 'csvlog'
@@ -76,10 +77,10 @@ max_parallel_workers = '32'
 max_replication_slots = '32'
 max_worker_processes = '32'
 shared_memory_type = 'mmap' # for PostgreSQL >= 12 only
-wal_log_hints = 'on'
 wal_keep_size = '512MB' # for PostgreSQL >= 13 only
 wal_keep_segments = '32' # for PostgreSQL <= 12 only
 wal_level = 'logical'
+wal_log_hints = 'on'
 wal_sender_timeout = '5s'
 wal_receiver_timeout = '5s'
 ```
@@ -110,7 +111,6 @@ The following parameters are **fixed** and exclusively controlled by the operato
 
 ```text
 archive_command = '/controller/manager wal-archive %p'
-archive_mode = 'on'
 full_page_writes = 'on'
 hot_standby = 'true'
 listen_addresses = '*'
@@ -121,7 +121,6 @@ ssl_ca_file = '/controller/certificates/client-ca.crt'
 ssl_cert_file = '/controller/certificates/server.crt'
 ssl_key_file = '/controller/certificates/server.key'
 unix_socket_directories = '/controller/run'
-wal_level = 'logical'
 ```
 
 Since the fixed parameters are added at the end, they can't be overridden by the
@@ -638,5 +637,4 @@ Users are not allowed to set the following configuration parameters in the
 - `unix_socket_directories`
 - `unix_socket_group`
 - `unix_socket_permissions`
-- `wal_log_hints`
 

--- a/pkg/postgres/configuration.go
+++ b/pkg/postgres/configuration.go
@@ -37,6 +37,9 @@ const ParameterMaxWalSenders = "max_wal_senders"
 // ParameterArchiveMode the configuration key containing the archive_mode value
 const ParameterArchiveMode = "archive_mode"
 
+// ParameterWalLogHints the configuration key containing the wal_log_hints value
+const ParameterWalLogHints = "wal_log_hints"
+
 // An acceptable wal_level value
 const (
 	WalLevelValueLogical WalLevelValue = "logical"
@@ -400,7 +403,6 @@ var (
 		"unix_socket_directories":   blockedConfigurationParameter,
 		"unix_socket_group":         blockedConfigurationParameter,
 		"unix_socket_permissions":   blockedConfigurationParameter,
-		"wal_log_hints":             fixedConfigurationParameter,
 
 		// The following parameters need a reload to be applied
 		"archive_cleanup_command":                blockedConfigurationParameter,
@@ -454,6 +456,8 @@ var (
 			"dynamic_shared_memory_type": "posix",
 			"wal_sender_timeout":         "5s",
 			"wal_receiver_timeout":       "5s",
+			"wal_level":                  "logical",
+			"wal_log_hints":              "on",
 			// Workaround for PostgreSQL not behaving correctly when
 			// a default value is not explicit in the postgresql.conf and
 			// the parameter cannot be changed without a restart.
@@ -462,9 +466,6 @@ var (
 		DefaultSettings: map[MajorVersionRange]SettingsCollection{
 			{MajorVersionRangeUnlimited, 120000}: {
 				"wal_keep_segments": "32",
-			},
-			{MajorVersionRangeUnlimited, MajorVersionRangeUnlimited}: {
-				"wal_level": "logical",
 			},
 			{120000, 130000}: {
 				"wal_keep_segments":  "32",
@@ -487,7 +488,6 @@ var (
 				"/controller/manager wal-archive --log-destination %s/%s.json %%p",
 				LogPath, LogFileName),
 			"port":                fmt.Sprint(ServerPort),
-			"wal_log_hints":       "on",
 			"full_page_writes":    "on",
 			"ssl":                 "on",
 			"ssl_cert_file":       ServerCertificateLocation,


### PR DESCRIPTION
Enable setting `wal_log_hints` to `off` for clusters with a single instance.

Previously, `wal_log_hints` was fixed to `on` for every cluster due to `pg_rewind,` which is not required with single-instance clusters.

Closes: #4041 