### PR TITLE
fix: create renovate group for kubernetes CSI

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -333,6 +333,13 @@
         "action"
       ],
       "pinDigests": false
+    },{
+// PR group for Kubernetes CSI
+      "groupName": "kubernetes CSI",
+      "matchPackagePrefixes": [
+        "kubernetes-cs"
+      ],
+      "pinDigests": false
     }
   ]
 }


### PR DESCRIPTION
We create one group for the Kubernetes CSI updates, to update all the versions in the same PR

Closes #4229 