### PR TITLE
fix: renovate should create only one PR for CSI tools

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -337,8 +337,9 @@
 // PR group for Kubernetes CSI
       "groupName": "kubernetes CSI",
       "matchPackagePrefixes": [
-        "kubernetes-cs"
+        "kubernetes-csi"
       ],
+      "separateMajorMinor": "false",
       "pinDigests": false
     }
   ]


### PR DESCRIPTION
Previously we were creating a PR for minor and patch version and a different PR for major, this will lead to a temporary failure even in the PR because the major versions will not match, this will create only one PR for update major, minor and patch versions.