### PR TITLE
fix: regression related to the arguments

### DIFF
--- a/internal/cmd/plugin/maintenance/cmd.go
+++ b/internal/cmd/plugin/maintenance/cmd.go
@@ -40,7 +40,7 @@ func NewCmd() *cobra.Command {
 		Short: "Sets maintenance mode",
 		Long: "This command will set maintenance mode on a single cluster or on all clusters " +
 			"in the current namespace if not specified differently through flags",
-		Args: plugin.RequiresArguments(1),
+		Args: cobra.MaximumNArgs(1),
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			return plugin.CompleteClusters(cmd.Context(), args, toComplete), cobra.ShellCompDirectiveNoFileComp
 		},
@@ -61,7 +61,7 @@ func NewCmd() *cobra.Command {
 		Short: "Removes maintenance mode",
 		Long: "This command will unset maintenance mode on a single cluster or on all clusters " +
 			"in the current namespace if not specified differently through flags",
-		Args: plugin.RequiresArguments(1),
+		Args: cobra.MaximumNArgs(1),
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			return plugin.CompleteClusters(cmd.Context(), args, toComplete), cobra.ShellCompDirectiveNoFileComp
 		},


### PR DESCRIPTION
When we added this regression with PR #3875 when we replaced MaxiumNArgs() function with RequiresArguments() which will actually enforce the number of arguments, but in this case, the maintenance command will work even without arguments just the `-A` flag.

Closes #4263 