### PR TITLE
test(e2e): more precise wildcard to match wal file

### DIFF
--- a/tests/e2e/asserts_test.go
+++ b/tests/e2e/asserts_test.go
@@ -720,7 +720,8 @@ func minioPath(serverName, fileName string) string {
 	// the * regexes enable matching these typical paths:
 	// 	minio/backups/serverName/base/20220618T140300/data.tar
 	// 	minio/backups/serverName/wals/0000000100000000/000000010000000000000002.gz
-	return filepath.Join("*", serverName, "*", "*", fileName)
+	//  minio/backups/serverName/wals/00000002.history.gz
+	return filepath.Join("*", serverName, "*", fileName)
 }
 
 // CheckPointAndSwitchWalOnPrimary trigger a checkpoint and switch wal on primary pod and returns the latest WAL file

--- a/tests/e2e/backup_restore_test.go
+++ b/tests/e2e/backup_restore_test.go
@@ -497,7 +497,7 @@ var _ = Describe("Backup and restore", Label(tests.LabelBackupRestore), func() {
 
 		It("verify tags in backed files", func() {
 			AssertArchiveWalOnMinio(namespace, clusterName, clusterName)
-			tags, err := testUtils.GetFileTagsOnMinio(minioEnv, "*[0-9].gz")
+			tags, err := testUtils.GetFileTagsOnMinio(minioEnv, minioPath(clusterName, "*1.gz"))
 			Expect(err).ToNot(HaveOccurred())
 			Expect(tags.Tags).ToNot(BeEmpty())
 
@@ -513,7 +513,7 @@ var _ = Describe("Backup and restore", Label(tests.LabelBackupRestore), func() {
 
 			AssertNewPrimary(namespace, clusterName, oldPrimary)
 
-			tags, err = testUtils.GetFileTagsOnMinio(minioEnv, "*.history.gz")
+			tags, err = testUtils.GetFileTagsOnMinio(minioEnv, minioPath(clusterName, "*.history.gz"))
 			Expect(err).ToNot(HaveOccurred())
 			Expect(tags.Tags).ToNot(BeEmpty())
 		})

--- a/tests/utils/minio.go
+++ b/tests/utils/minio.go
@@ -575,7 +575,7 @@ func GetFileTagsOnMinio(minioEnv *MinioEnv, path string) (TagSet, error) {
 	var output TagSet
 	// Make sure we have a registered backup to access
 	out, _, err := RunUncheckedRetry(fmt.Sprintf(
-		"kubectl exec -n %v %v -- sh -c 'mc find minio --name %v | head -n1'",
+		"kubectl exec -n %v %v -- sh -c 'mc find minio --path %v | head -n1'",
 		minioEnv.Namespace,
 		minioEnv.Client.Name,
 		path))


### PR DESCRIPTION
close: #4267 