### PR TITLE
fix: destroy command show meaningful message if pod not exists

### DIFF
--- a/internal/cmd/plugin/destroy/cmd.go
+++ b/internal/cmd/plugin/destroy/cmd.go
@@ -26,9 +26,9 @@ import (
 	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/plugin"
 )
 
-// NewCmd create the new "promote" subcommand
+// NewCmd create the new "destroy" subcommand
 func NewCmd() *cobra.Command {
-	promoteCmd := &cobra.Command{
+	destroyCmd := &cobra.Command{
 		Use:   "destroy [cluster] [node] ",
 		Short: "Destroy the instance named [cluster]-[node] or [node] with the associated PVC",
 		Args:  plugin.RequiresArguments(2),
@@ -45,8 +45,8 @@ func NewCmd() *cobra.Command {
 		},
 	}
 
-	promoteCmd.Flags().BoolP("keep-pvc", "k", false,
+	destroyCmd.Flags().BoolP("keep-pvc", "k", false,
 		"Keep the PVC but detach it from instance")
 
-	return promoteCmd
+	return destroyCmd
 }

--- a/internal/cmd/plugin/destroy/cmd.go
+++ b/internal/cmd/plugin/destroy/cmd.go
@@ -18,22 +18,30 @@ package destroy
 
 import (
 	"context"
+	"fmt"
+	"strconv"
 
 	"github.com/spf13/cobra"
+
+	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/plugin"
 )
 
 // NewCmd create the new "promote" subcommand
 func NewCmd() *cobra.Command {
 	promoteCmd := &cobra.Command{
-		Use:   "destroy [CLUSTER_NAME] [INSTANCE_ID]",
-		Short: "Destroy the instance named [CLUSTER_NAME] and [INSTANCE_ID] with the associated PVC",
-		Args:  cobra.ExactArgs(2),
+		Use:   "destroy [cluster] [node] ",
+		Short: "Destroy the instance named [cluster]-[node] or [node] with the associated PVC",
+		Args:  plugin.RequiresArguments(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 			clusterName := args[0]
-			instanceID := args[1]
+			node := args[1]
+			if _, err := strconv.Atoi(args[1]); err == nil {
+				node = fmt.Sprintf("%s-%s", clusterName, node)
+			}
+
 			keepPVC, _ := cmd.Flags().GetBool("keep-pvc")
-			return Destroy(ctx, clusterName, instanceID, keepPVC)
+			return Destroy(ctx, clusterName, node, keepPVC)
 		},
 	}
 

--- a/internal/cmd/plugin/destroy/cmd.go
+++ b/internal/cmd/plugin/destroy/cmd.go
@@ -29,7 +29,7 @@ import (
 // NewCmd create the new "destroy" subcommand
 func NewCmd() *cobra.Command {
 	destroyCmd := &cobra.Command{
-		Use:   "destroy [cluster] [node] ",
+		Use:   "destroy [cluster] [node]",
 		Short: "Destroy the instance named [cluster]-[node] or [node] with the associated PVC",
 		Args:  plugin.RequiresArguments(2),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/plugin/destroy/destroy.go
+++ b/internal/cmd/plugin/destroy/destroy.go
@@ -35,7 +35,7 @@ import (
 // Destroy implements destroy subcommand
 func Destroy(ctx context.Context, clusterName, instanceName string, keepPVC bool) error {
 	if err := ensurePodIsDeleted(ctx, instanceName, clusterName); err != nil {
-		return fmt.Errorf("error deleting instance %s: %v", instanceName, err)
+		return err
 	}
 
 	pvcs, err := persistentvolumeclaim.GetInstancePVCs(ctx, plugin.Client, instanceName, plugin.Namespace)
@@ -59,6 +59,10 @@ func Destroy(ctx context.Context, clusterName, instanceName string, keepPVC bool
 					clusterName, err)
 			}
 		}
+		fmt.Printf("Instance %s of cluster %s has been destroyed and the PVC was kept\n",
+			instanceName,
+			clusterName,
+		)
 		return nil
 	}
 
@@ -81,6 +85,8 @@ func Destroy(ctx context.Context, clusterName, instanceName string, keepPVC bool
 		}
 	}
 
+	fmt.Printf("Instance %s of cluster %s is destroyed\n", instanceName, clusterName)
+
 	return nil
 }
 
@@ -92,7 +98,7 @@ func ensurePodIsDeleted(ctx context.Context, instanceName, clusterName string) e
 		Name:      instanceName,
 	}, &pod)
 	if apierrs.IsNotFound(err) {
-		return fmt.Errorf("could not found instance %s in cluster %s: %v", instanceName, clusterName, err)
+		return fmt.Errorf("could not found instance %s in cluster %s", instanceName, clusterName)
 	}
 	if err != nil {
 		return err

--- a/internal/cmd/plugin/destroy/destroy.go
+++ b/internal/cmd/plugin/destroy/destroy.go
@@ -32,10 +32,8 @@ import (
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 )
 
-// Destroy implements the destroy subcommand
-func Destroy(ctx context.Context, clusterName, instanceID string, keepPVC bool) error {
-	instanceName := fmt.Sprintf("%s-%s", clusterName, instanceID)
-
+// Destroy implements destroy subcommand
+func Destroy(ctx context.Context, clusterName, instanceName string, keepPVC bool) error {
 	if err := ensurePodIsDeleted(ctx, instanceName, clusterName); err != nil {
 		return fmt.Errorf("error deleting instance %s: %v", instanceName, err)
 	}
@@ -94,7 +92,7 @@ func ensurePodIsDeleted(ctx context.Context, instanceName, clusterName string) e
 		Name:      instanceName,
 	}, &pod)
 	if apierrs.IsNotFound(err) {
-		return nil
+		return fmt.Errorf("could not found instance %s in cluster %s: %v", instanceName, clusterName, err)
 	}
 	if err != nil {
 		return err

--- a/internal/cmd/plugin/fence/cmd.go
+++ b/internal/cmd/plugin/fence/cmd.go
@@ -21,13 +21,15 @@ import (
 	"strconv"
 
 	"github.com/spf13/cobra"
+
+	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/plugin"
 )
 
 var (
 	fenceOnCmd = &cobra.Command{
 		Use:   "on [cluster] [node]",
 		Short: `Fence an instance named [cluster]-[node] or [node]`,
-		Args:  cobra.ExactArgs(2),
+		Args:  plugin.RequiresArguments(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			clusterName := args[0]
 			node := args[1]
@@ -42,7 +44,7 @@ var (
 	fenceOffCmd = &cobra.Command{
 		Use:   "off [cluster] [node]",
 		Short: `Remove fence for an instance named [cluster]-[node] or [node]`,
-		Args:  cobra.ExactArgs(2),
+		Args:  plugin.RequiresArguments(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			clusterName := args[0]
 			node := args[1]

--- a/internal/cmd/plugin/promote/cmd.go
+++ b/internal/cmd/plugin/promote/cmd.go
@@ -22,6 +22,8 @@ import (
 	"strconv"
 
 	"github.com/spf13/cobra"
+
+	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/plugin"
 )
 
 // NewCmd create the new "promote" subcommand
@@ -29,7 +31,7 @@ func NewCmd() *cobra.Command {
 	promoteCmd := &cobra.Command{
 		Use:   "promote [cluster] [node]",
 		Short: "Promote the pod named [cluster]-[node] or [node] to primary",
-		Args:  cobra.ExactArgs(2),
+		Args:  plugin.RequiresArguments(2),
 		RunE: func(_ *cobra.Command, args []string) error {
 			ctx := context.Background()
 			clusterName := args[0]


### PR DESCRIPTION
this patch enhance the destroy, fencing and promote plugin command to show
context help if argument number is not met. Also in this patch we make the destroy
command accept both node id and node name as the second parameter. 

Closes: #4266 