### PR TITLE
fix: empty LSN handling in instance sorting

### DIFF
--- a/pkg/postgres/lsn.go
+++ b/pkg/postgres/lsn.go
@@ -31,12 +31,12 @@ type LSN string
 func (lsn LSN) Less(other LSN) bool {
 	p1, err := lsn.Parse()
 	if err != nil {
-		return false
+		p1 = 0
 	}
 
 	p2, err := other.Parse()
 	if err != nil {
-		return false
+		p2 = 0
 	}
 
 	return p1 < p2

--- a/pkg/postgres/lsn_test.go
+++ b/pkg/postgres/lsn_test.go
@@ -38,4 +38,18 @@ var _ = Describe("LSN handling functions", func() {
 			Expect(LSN("3BB/A9FFFBE8").Parse()).Should(Equal(int64(4104545893352)))
 		})
 	})
+
+	Describe("Less", func() {
+		It("handles errors in the same way as the zero LSN value", func() {
+			Expect(LSN("").Less("3/23")).To(BeTrue())
+			Expect(LSN("3/23").Less("")).To(BeFalse())
+		})
+
+		It("works correctly for good LSNs", func() {
+			Expect(LSN("1/23").Less(LSN("1/24"))).To(BeTrue())
+			Expect(LSN("1/24").Less(LSN("1/23"))).To(BeFalse())
+			Expect(LSN("1/23").Less(LSN("2/23"))).To(BeTrue())
+			Expect(LSN("2/23").Less(LSN("1/23"))).To(BeFalse())
+		})
+	})
 })


### PR DESCRIPTION
`receivedLSN` is empty for instances that have been never attached to streaming replication.

The instance sorting code considers this an error, and the `Less` implementation for LSNs is not antisymmetric, resulting in a non-stable sorting.

This could result in the operator preferring a replica that is never attached to streaming replication over a replica that is more advanced but attached to streaming replication.

Closes: #4284 