### PR TITLE
fix: wait for elected replica to be in streaming mode before a switchover

### DIFF
--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -772,17 +772,19 @@ func (r *ClusterReconciler) handleRollingUpdate(
 	cluster *apiv1.Cluster,
 	instancesStatus postgres.PostgresqlStatusList,
 ) (ctrl.Result, error) {
-	contextLogger := log.FromContext(ctx)
+	contextLogger := log.FromContext(ctx).WithName("handle_rolling_update")
 
 	// If we need to roll out a restart of any instance, this is the right moment
 	done, err := r.rolloutRequiredInstances(ctx, cluster, &instancesStatus)
 	switch {
 	case errors.Is(err, errLogShippingReplicaElected):
+		contextLogger.Warning(
+			"The primary needs to be restarted, but the chosen new primary is still " +
+				"not connected via streaming replication, waiting for 5 seconds",
+		)
 		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
-
 	case err != nil:
 		return ctrl.Result{}, err
-
 	case done:
 		// Rolling upgrade is in progress, let's avoid marking stuff as synchronized
 		return ctrl.Result{}, ErrNextLoop

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -777,7 +777,7 @@ func (r *ClusterReconciler) handleRollingUpdate(
 	// If we need to roll out a restart of any instance, this is the right moment
 	done, err := r.rolloutRequiredInstances(ctx, cluster, &instancesStatus)
 	switch {
-	case err == errLogShippingReplicaElected:
+	case errors.Is(err, errLogShippingReplicaElected):
 		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 
 	case err != nil:

--- a/controllers/cluster_upgrade.go
+++ b/controllers/cluster_upgrade.go
@@ -174,9 +174,9 @@ func (r *ClusterReconciler) updatePrimaryPod(
 		}
 
 		// Before promoting a replica, the instance manager will wait for the WAL receiver
-		// process to be down. We're doing that to avoid loosing data written on the primary.
+		// process to be down. We're doing that to avoid losing data written on the primary.
 		// This protection can work only when the streaming connection is active.
-		// Given that, we refuse promoting a replica when the streaming connection
+		// Given that, we refuse to promote a replica when the streaming connection
 		// is not active.
 		if !targetInstance.IsWalReceiverActive {
 			contextLogger.Info(

--- a/controllers/cluster_upgrade.go
+++ b/controllers/cluster_upgrade.go
@@ -179,7 +179,7 @@ func (r *ClusterReconciler) updatePrimaryPod(
 		// Given that, we refuse to promote a replica when the streaming connection
 		// is not active.
 		if !targetInstance.IsWalReceiverActive {
-			contextLogger.Warning(
+			contextLogger.Info(
 				"chosen new primary is still not connected via streaming replication, "+
 					"interrupting the primaryPodUpdate",
 				"updateReason", reason,

--- a/controllers/cluster_upgrade.go
+++ b/controllers/cluster_upgrade.go
@@ -179,13 +179,12 @@ func (r *ClusterReconciler) updatePrimaryPod(
 		// Given that, we refuse to promote a replica when the streaming connection
 		// is not active.
 		if !targetInstance.IsWalReceiverActive {
-			contextLogger.Info(
-				"The primary needs to be restarted, but the chosen new primary is still "+
-					"not connected via streaming replication, waiting for 5 seconds",
-				"reason", reason,
+			contextLogger.Warning(
+				"chosen new primary is still not connected via streaming replication, "+
+					"interrupting the primaryPodUpdate",
+				"updateReason", reason,
 				"currentPrimary", primaryPod.Name,
 				"targetPrimary", targetInstance.Pod.Name,
-				"podList", podList,
 			)
 			return false, errLogShippingReplicaElected
 		}

--- a/controllers/cluster_upgrade.go
+++ b/controllers/cluster_upgrade.go
@@ -40,6 +40,11 @@ import (
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 )
 
+// errLogShippingReplicaElected is raised when the pod update process need
+// to select a new primary before upgrading the old primary, but the chosen
+// instance is not connected via streaming replication
+var errLogShippingReplicaElected = errors.New("log shipping replica elected as a new post-switchover primary")
+
 type rolloutReason = string
 
 func (r *ClusterReconciler) rolloutRequiredInstances(
@@ -159,23 +164,40 @@ func (r *ClusterReconciler) updatePrimaryPod(
 		// as the pod list is sorted in the same order we use for switchover / failover.
 		// This may not be true for replica clusters, where every instance is a replica
 		// from the PostgreSQL point-of-view.
-		targetPrimary := podList.Items[1].Pod.Name
+		targetInstance := podList.Items[1]
 
 		// If this is a replica cluster, the target primary we chose may be
 		// the one we're trying to upgrade, as the list isn't sorted. In
 		// this case, we promote the first instance of the list
-		if targetPrimary == primaryPod.Name {
-			targetPrimary = podList.Items[0].Pod.Name
+		if targetInstance.Pod.Name == primaryPod.Name {
+			targetInstance = podList.Items[0]
+		}
+
+		// Before promoting a replica, the instance manager will wait for the WAL receiver
+		// process to be down. We're doing that to avoid loosing data written on the primary.
+		// This protection can work only when the streaming connection is active.
+		// Given that, we refuse promoting a replica when the streaming connection
+		// is not active.
+		if !targetInstance.IsWalReceiverActive {
+			contextLogger.Info(
+				"The primary needs to be restarted, but the chosen new primary is still "+
+					"not connected via streaming replication, waiting for 5 seconds",
+				"reason", reason,
+				"currentPrimary", primaryPod.Name,
+				"targetPrimary", targetInstance.Pod.Name,
+				"podList", podList,
+			)
+			return false, errLogShippingReplicaElected
 		}
 
 		contextLogger.Info("The primary needs to be restarted, we'll trigger a switchover to do that",
 			"reason", reason,
 			"currentPrimary", primaryPod.Name,
-			"targetPrimary", targetPrimary,
+			"targetPrimary", targetInstance.Pod.Name,
 			"podList", podList)
 		r.Recorder.Eventf(cluster, "Normal", "Switchover",
-			"Initiating switchover to %s to upgrade %s", targetPrimary, primaryPod.Name)
-		return true, r.setPrimaryInstance(ctx, cluster, targetPrimary)
+			"Initiating switchover to %s to upgrade %s", targetInstance.Pod.Name, primaryPod.Name)
+		return true, r.setPrimaryInstance(ctx, cluster, targetInstance.Pod.Name)
 	}
 
 	// if there is only one instance in the cluster, we should upgrade it even if it's a primary


### PR DESCRIPTION
Before switching over to a replica to apply a configuration change of the primary, we now wait for that replica to be connected in streaming replication.

We do that to ensure that the replica has all the data that is written on the primary.

Closes: #4285 