### PR TITLE
fix: PodAntiAffinity rule

### DIFF
--- a/pkg/specs/pods.go
+++ b/pkg/specs/pods.go
@@ -350,6 +350,13 @@ func CreateGeneratedAntiAffinity(clusterName string, config apiv1.AffinityConfig
 						clusterName,
 					},
 				},
+				{
+					Key:      utils.PodRoleLabelName,
+					Operator: metav1.LabelSelectorOpIn,
+					Values: []string{
+						string(utils.PodRoleInstance),
+					},
+				},
 			},
 		},
 		TopologyKey: topologyKey,

--- a/tests/e2e/affinity_test.go
+++ b/tests/e2e/affinity_test.go
@@ -1,0 +1,61 @@
+/*
+Copyright The CloudNativePG Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+	"github.com/cloudnative-pg/cloudnative-pg/tests"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("E2E Affinity", Serial, Label(tests.LabelPodScheduling), func() {
+	const (
+		clusterFile     = fixturesDir + "/affinity/cluster-affinity.yaml"
+		poolerFile      = fixturesDir + "/affinity/pooler-affinity.yaml"
+		clusterName     = "cluster-affinity"
+		namespacePrefix = "test-affinity"
+		level           = tests.Medium
+	)
+	var namespace string
+	var err error
+
+	BeforeEach(func() {
+		if testLevelEnv.Depth < int(level) {
+			Skip("Test depth is lower than the amount requested for this test")
+		}
+	})
+
+	It("can create a cluster with required affinity", func() {
+		namespace, err = env.CreateUniqueNamespace(namespacePrefix)
+		Expect(err).ToNot(HaveOccurred())
+		DeferCleanup(func() error {
+			if CurrentSpecReport().Failed() {
+				env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
+			}
+			return env.DeleteNamespace(namespace)
+		})
+
+		AssertCreateCluster(namespace, clusterName, clusterFile, env)
+		createAndAssertPgBouncerPoolerIsSetUp(namespace, poolerFile, 3)
+
+		_, _, err := utils.Run(fmt.Sprintf("kubectl scale --replicas=3 -n %v cluster/%v", namespace, clusterName))
+		Expect(err).ToNot(HaveOccurred())
+		AssertClusterIsReady(namespace, clusterName, 300, env)
+	})
+})

--- a/tests/e2e/fixtures/affinity/cluster-affinity.yaml
+++ b/tests/e2e/fixtures/affinity/cluster-affinity.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: cluster-affinity
+spec:
+  instances: 1
+
+  affinity:
+    podAntiAffinityType: required
+
+  storage:
+    size: 1Gi
+

--- a/tests/e2e/fixtures/affinity/pooler-affinity.yaml
+++ b/tests/e2e/fixtures/affinity/pooler-affinity.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Pooler
+metadata:
+  name: cluster-pooler-affinity
+spec:
+  cluster:
+    name: cluster-affinity
+
+  instances: 3
+
+  pgbouncer:
+    poolMode: session


### PR DESCRIPTION
# Summary

This PR fix an issue withPodAntiAffinity which is missing a podRole LabelSelector, therefore if other components such as Pooler saturates the Node availability and the PodAntiAffinity is set to required the cluster cannot be scaled/created.

Furthermore some tests have been added.

# Additional Info

This PR fix #4293