### PR TITLE
fix: do not patch when object doesn't change

### DIFF
--- a/internal/cnpi/plugin/operatorclient/client.go
+++ b/internal/cnpi/plugin/operatorclient/client.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"reflect"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/cloudnative-pg/cloudnative-pg/internal/cnpi/plugin"
@@ -99,7 +100,7 @@ func (e *extendedClient) Delete(
 		return err
 	}
 	if !reflect.DeepEqual(origObj, obj) {
-		if err := e.Client.Patch(ctx, obj, client.MergeFrom(origObj)); err != nil {
+		if err := e.Client.Patch(ctx, obj, client.MergeFrom(origObj)); err != nil && !apierrors.IsNotFound(err) {
 			contextLogger.Error(err, "while patching before delete")
 			return err
 		}

--- a/internal/cnpi/plugin/operatorclient/client.go
+++ b/internal/cnpi/plugin/operatorclient/client.go
@@ -18,6 +18,7 @@ package operatorclient
 
 import (
 	"context"
+	"reflect"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -97,10 +98,13 @@ func (e *extendedClient) Delete(
 	if err != nil {
 		return err
 	}
-	if err := e.Client.Patch(ctx, obj, client.MergeFrom(origObj)); err != nil {
-		contextLogger.Error(err, "while patching before delete")
-		return err
+	if !reflect.DeepEqual(origObj, obj) {
+		if err := e.Client.Patch(ctx, obj, client.MergeFrom(origObj)); err != nil {
+			contextLogger.Error(err, "while patching before delete")
+			return err
+		}
 	}
+
 	return e.Client.Delete(ctx, obj, opts...)
 }
 


### PR DESCRIPTION
Previously we were patching the object even if this didn't change, this was triggering a patch over an object that was already patched and deleted.

Closes #4301 