### PR TITLE
chore: increase the timeout for failover test on OpenShift

### DIFF
--- a/tests/e2e/asserts_test.go
+++ b/tests/e2e/asserts_test.go
@@ -1134,7 +1134,6 @@ func AssertFastFailOver(
 		}
 		lm := clusterName + "-1"
 		err = env.DeletePod(namespace, lm, quickDelete)
-
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/tests/e2e/fastfailover_test.go
+++ b/tests/e2e/fastfailover_test.go
@@ -59,6 +59,12 @@ var _ = Describe("Fast failover", Serial, Label(tests.LabelPerformance, tests.La
 			maxReattachTime = 180
 			maxFailoverTime = 20
 		}
+
+		// OpenShift ha sa higher time to recover than a standard and simple Kubernetes cluster
+		if IsOpenshift() {
+			maxReattachTime = 120
+			maxFailoverTime = 20
+		}
 	})
 
 	JustAfterEach(func() {

--- a/tests/e2e/fastfailover_test.go
+++ b/tests/e2e/fastfailover_test.go
@@ -60,7 +60,7 @@ var _ = Describe("Fast failover", Serial, Label(tests.LabelPerformance, tests.La
 			maxFailoverTime = 20
 		}
 
-		// OpenShift ha sa higher time to recover than a standard and simple Kubernetes cluster
+		// OpenShift takes longer to recover than a standard and simple Kubernetes cluster
 		if IsOpenshift() {
 			maxReattachTime = 120
 			maxFailoverTime = 20


### PR DESCRIPTION
We need to increase the overall timeout since in this platform the test will take longer to run here.

Closes #4306 