### PR TITLE
chore: increase waiting for a mounted secret timeout

### DIFF
--- a/pkg/certs/k8s.go
+++ b/pkg/certs/k8s.go
@@ -46,7 +46,7 @@ var (
 	errSecretsMountNotRefreshed = errors.New("secrets mount still not refreshed")
 
 	mountedSecretCheckBackoff = wait.Backoff{
-		Duration: 10 * time.Millisecond,
+		Duration: 60 * time.Millisecond,
 		Jitter:   0.1,
 		Factor:   2,
 		Steps:    10,


### PR DESCRIPTION
Increase the timeout the operator waits for the Kubelet to
refresh a mounted secret from ~10 to ~60 sec to better cope with
busy Kubernetes clusters.

This timeout is used during certificate maintenance and when it expires
the operator will retry after the configured time (default one day).

Closes:  #4075