### PR TITLE
fix: replace version is not generated in make file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ endif
 COMMIT := $(shell git rev-parse --short HEAD || echo unknown)
 DATE := $(shell git log -1 --pretty=format:'%ad' --date short)
 VERSION := $(shell git describe --tags --match 'v*' | sed -e 's/^v//; s/-g[0-9a-f]\+$$//; s/-\([0-9]\+\)$$/-dev\1/')
-REPLACE_VERSION := $(shell git describe --tags --abbrev=0 $(git describe --tags --match 'v*' --abbrev=0)^)
+REPLACE_VERSION := $(shell git describe --tags --abbrev=0 `git describe --tags --match 'v*' --abbrev=0`^)
 LDFLAGS= "-X github.com/cloudnative-pg/cloudnative-pg/pkg/versions.buildVersion=${VERSION} $\
 -X github.com/cloudnative-pg/cloudnative-pg/pkg/versions.buildCommit=${COMMIT} $\
 -X github.com/cloudnative-pg/cloudnative-pg/pkg/versions.buildDate=${DATE}"


### PR DESCRIPTION
In patch #4196 , we introduce the REPLACE_VERSION in make file, 
which is not work well when run make in mac/OS,  this patch fix the 
problem.

Closes: #4317 