### PR TITLE
docs: `ClusterImageCatalog` for `postgresql` and `postgis` images

### DIFF
--- a/docs/src/image_catalog.md
+++ b/docs/src/image_catalog.md
@@ -11,12 +11,12 @@ a `major` field indicating the major version of the image.
 
 !!! Warning
     The operator places trust in the user-defined major version and refrains
-    from conducting any PostgreSQL version detection. It falls upon your
+    from conducting any PostgreSQL version detection. It is the user's
     responsibility to ensure alignment between the declared major version in
     the catalog and the PostgreSQL image.
 
 The `major` field's value must remain unique within a catalog, preventing
-duplication across images. Distinct catalogs, however, have the flexibility to
+duplication across images. Distinct catalogs, however, may
 expose different images under the same `major` value.
 
 **Example of a Namespaced `ImageCatalog`:**
@@ -74,10 +74,12 @@ Any alterations to the images within a catalog trigger automatic updates for
 
 ## CloudNativePG Catalogs
 
-The CloudNativePG project maintains `ClusterImageCatalogs` for the images it provides. These catalogs are regularly
-updated with the latest images for each major version. By applying the `ClusterImageCatalog.yaml` file from the
-CloudNativePG project's GitHub repositories, cluster administrators can ensure that their clusters are automatically
-updated to the latest version within the specified major release.
+The CloudNativePG project maintains `ClusterImageCatalogs` for the images it
+provides. These catalogs are regularly updated with the latest images for each
+major version. By applying the `ClusterImageCatalog.yaml` file from the
+CloudNativePG project's GitHub repositories, cluster administrators can ensure
+that their clusters are automatically updated to the latest version within the
+specified major release.
 
 * [cloudnative-pg/postgres-containers](https://github.com/cloudnative-pg/postgres-containers):
   ```shell

--- a/docs/src/image_catalog.md
+++ b/docs/src/image_catalog.md
@@ -71,3 +71,19 @@ spec:
 Clusters utilizing these catalogs maintain continuous monitoring.
 Any alterations to the images within a catalog trigger automatic updates for
 **all associated clusters** referencing that specific entry.
+
+## CloudNativePG Catalogs
+
+The CloudNativePG project maintains `ClusterImageCatalogs` for the images it provides. These catalogs are regularly
+updated with the latest images for each major version. By applying the `ClusterImageCatalog.yaml` file from the
+CloudNativePG project's GitHub repositories, cluster administrators can ensure that their clusters are automatically
+updated to the latest version within the specified major release.
+
+* [cloudnative-pg/postgres-containers](https://github.com/cloudnative-pg/postgres-containers):
+  ```shell
+  kubectl apply -f https://raw.githubusercontent.com/cloudnative-pg/postgres-containers/main/Debian/ClusterImageCatalog.yaml
+  ```
+* [cloudnative-pg/postgis-containers](https://github.com/cloudnative-pg/postgis-containers)
+  ```shell
+  kubectl apply -f https://raw.githubusercontent.com/cloudnative-pg/postgis-containers/main/PostGIS/ClusterImageCatalog.yaml
+  ```

--- a/docs/src/image_catalog.md
+++ b/docs/src/image_catalog.md
@@ -22,6 +22,7 @@ expose different images under the same `major` value.
 **Example of a Namespaced `ImageCatalog`:**
 
 ```yaml
+apiVersion: postgresql.cnpg.io/v1
 kind: ImageCatalog
 metadata:
   name: postgresql
@@ -85,7 +86,7 @@ specified major release.
   ```shell
   kubectl apply -f https://raw.githubusercontent.com/cloudnative-pg/postgres-containers/main/Debian/ClusterImageCatalog.yaml
   ```
-* [cloudnative-pg/postgis-containers](https://github.com/cloudnative-pg/postgis-containers)
+* [cloudnative-pg/postgis-containers](https://github.com/cloudnative-pg/postgis-containers):
   ```shell
   kubectl apply -f https://raw.githubusercontent.com/cloudnative-pg/postgis-containers/main/PostGIS/ClusterImageCatalog.yaml
   ```

--- a/docs/src/image_catalog.md
+++ b/docs/src/image_catalog.md
@@ -82,11 +82,26 @@ CloudNativePG project's GitHub repositories, cluster administrators can ensure
 that their clusters are automatically updated to the latest version within the
 specified major release.
 
-* [cloudnative-pg/postgres-containers](https://github.com/cloudnative-pg/postgres-containers):
-  ```shell
-  kubectl apply -f https://raw.githubusercontent.com/cloudnative-pg/postgres-containers/main/Debian/ClusterImageCatalog.yaml
-  ```
-* [cloudnative-pg/postgis-containers](https://github.com/cloudnative-pg/postgis-containers):
-  ```shell
-  kubectl apply -f https://raw.githubusercontent.com/cloudnative-pg/postgis-containers/main/PostGIS/ClusterImageCatalog.yaml
-  ```
+### PostgreSQL Container Images
+
+You can install the
+[latest version of the cluster catalog for the PostgreSQL Container Images](https://raw.githubusercontent.com/cloudnative-pg/postgres-containers/main/Debian/ClusterImageCatalog.yaml)
+([cloudnative-pg/postgres-containers](https://github.com/cloudnative-pg/postgres-containers) repository)
+with:
+
+```shell
+kubectl apply \
+  -f https://raw.githubusercontent.com/cloudnative-pg/postgres-containers/main/Debian/ClusterImageCatalog.yaml
+```
+
+### PostgreSQL Container Images
+
+You can install the
+[latest version of the cluster catalog for the PostGIS Container Images](https://raw.githubusercontent.com/cloudnative-pg/postgis-containers/main/PostGIS/ClusterImageCatalog.yaml)
+([cloudnative-pg/postgis-containers](https://github.com/cloudnative-pg/postgis-containers) repository)
+with:
+
+```shell
+kubectl apply \
+  -f https://raw.githubusercontent.com/cloudnative-pg/postgis-containers/main/PostGIS/ClusterImageCatalog.yaml
+```

--- a/docs/src/rolling_update.md
+++ b/docs/src/rolling_update.md
@@ -10,6 +10,8 @@ Rolling upgrades are started when:
 
 - the user changes the `imageName` attribute of the cluster specification;
 
+- the [image catalog](image_catalog.md) is updated with a new image for the major used by the cluster;
+
 - a change in the PostgreSQL configuration requires a restart to be
   applied;
 


### PR DESCRIPTION
Provide instructions on how to update the `ClusterImageCatalog` resources for PostgreSQL and PostGIS images supported by the Community.

Closes #4320
