### PR TITLE
chore: correct typo in the documentation

### DIFF
--- a/docs/src/connection_pooling.md
+++ b/docs/src/connection_pooling.md
@@ -259,7 +259,7 @@ spec:
 ## Service Template
 
 Sometimes, your pooler will require some different labels, annotations, or even change
-the type of the service, you can achive that by using the `serviceTemplate` field:
+the type of the service, you can achieve that by using the `serviceTemplate` field:
 
 ```yaml
 apiVersion: postgresql.cnpg.io/v1


### PR DESCRIPTION
This patch aims to fix a typo in our documentation that fails the spellcheck step.