### PR TITLE
fix: use full instance name for the destroy method

### DIFF
--- a/internal/cmd/plugin/destroy/destroy.go
+++ b/internal/cmd/plugin/destroy/destroy.go
@@ -98,7 +98,7 @@ func ensurePodIsDeleted(ctx context.Context, instanceName, clusterName string) e
 		Name:      instanceName,
 	}, &pod)
 	if apierrs.IsNotFound(err) {
-		return fmt.Errorf("could not found instance %s in cluster %s: %w", instanceName, clusterName, err)
+		return fmt.Errorf("could not found instance %s in cluster %s", instanceName, clusterName)
 	}
 	if err != nil {
 		return err

--- a/internal/cmd/plugin/destroy/destroy.go
+++ b/internal/cmd/plugin/destroy/destroy.go
@@ -98,7 +98,7 @@ func ensurePodIsDeleted(ctx context.Context, instanceName, clusterName string) e
 		Name:      instanceName,
 	}, &pod)
 	if apierrs.IsNotFound(err) {
-		return fmt.Errorf("could not found instance %s in cluster %s", instanceName, clusterName)
+		return fmt.Errorf("could not found instance %s in cluster %s: %w", instanceName, clusterName, err)
 	}
 	if err != nil {
 		return err

--- a/internal/cmd/plugin/hibernate/on.go
+++ b/internal/cmd/plugin/hibernate/on.go
@@ -267,7 +267,8 @@ func (on *onCommand) deleteResourcesStep() error {
 	if err := destroy.Destroy(
 		on.ctx,
 		on.cluster.Name,
-		strconv.Itoa(on.primaryInstanceSerial), true,
+		fmt.Sprintf("%s-%s", on.cluster.Name, strconv.Itoa(on.primaryInstanceSerial)),
+		true,
 	); err != nil {
 		return fmt.Errorf("error destroying primary instance: %w", err)
 	}


### PR DESCRIPTION
This patch fix the e2e failed caused by patch  https://github.com/cloudnative-pg/cloudnative-pg/pull/4280

Closes: #4329 