### PR TITLE
fix(plugin): handle empty response in sync-sequences plugin command

### DIFF
--- a/internal/cmd/plugin/logical/subscription/syncsequences/get.go
+++ b/internal/cmd/plugin/logical/subscription/syncsequences/get.go
@@ -72,6 +72,9 @@ func GetSequenceStatus(ctx context.Context, clusterName string, connectionString
 	if err != nil {
 		return nil, fmt.Errorf("while executing query: %w", err)
 	}
+	if len(output) == 0 {
+		return nil, nil
+	}
 
 	var records []SequenceStatus
 	if err := json.Unmarshal(output, &records); err != nil {

--- a/internal/cmd/plugin/logical/subscription/syncsequences/get.go
+++ b/internal/cmd/plugin/logical/subscription/syncsequences/get.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/jackc/pgx/v5"
 
@@ -72,7 +73,7 @@ func GetSequenceStatus(ctx context.Context, clusterName string, connectionString
 	if err != nil {
 		return nil, fmt.Errorf("while executing query: %w", err)
 	}
-	if len(output) == 0 {
+	if len(strings.TrimSpace(string(output))) == 0 {
 		return nil, nil
 	}
 


### PR DESCRIPTION
Fix the `kubectl-cnpg subscription sync-sequences` execution when the source or the destination database has no sequence.

Previously, the command was failing with the following error:

Error: while getting sequences status from the source database: while decoding JSON output: unexpected end of JSON input

Closes #4345 