### PR TITLE
fix: disable metrics from `pg_stat_bgwriter` in v17+

### DIFF
--- a/config/manager/default-monitoring.yaml
+++ b/config/manager/default-monitoring.yaml
@@ -202,6 +202,7 @@ data:
             description: "Time at which these statistics were last reset"
 
     pg_stat_bgwriter:
+      runonserver: "<17.0.0"
       query: |
         SELECT checkpoints_timed
           , checkpoints_req


### PR DESCRIPTION
PostgreSQL 17 removed some columns from `pg_stat_bgwriter`, moving them to the new `pg_stat_checkpointer` view. This patch disables the gathering of `pg_stat_bgwriter`
metrics in PostgreSQL v17+. A further patch will add support for the new format.

Workaround for #3411 