### PR TITLE
ci: add ghcr login in preflight test in ci workflow

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -781,6 +781,13 @@ jobs:
       - name: Setup tools
         run: |
           make operator-sdk preflight
+      
+      - name: Login to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run preflight container test
         env:


### PR DESCRIPTION
The patch fix the potential failure in preflight test due to permission issue.

Closes: #4378 