### PR TITLE
chore: setup credentials for preflight check test

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -758,13 +758,19 @@ jobs:
         run: |
           make operator-sdk preflight
 
+      - name: Setup credentials 
+        run: |
+          AUTH=$(echo -n "${{ env.REGISTRY_USER }}:${{ env.REGISTRY_PASSWORD }}" | base64 -w 0)
+          echo -n '{"auths": {"'${{ env.REGISTRY }}'": {"auth": "'"$AUTH"'"}}}' > config.json
+
       - name: Run preflight container test
         env:
           CONTROLLER_IMG: ${{ needs.buildx.outputs.controller_img_ubi8 }}
           PFLT_ARTIFACTS: "preflight_results"
         run: |
-          bin/preflight check container ${CONTROLLER_IMG}
-
+          bin/preflight check container ${CONTROLLER_IMG} \
+          --docker-config config.json
+          
       - name: Archive the preflight results
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -770,7 +770,7 @@ jobs:
         run: |
           bin/preflight check container ${CONTROLLER_IMG} \
           --docker-config config.json
-          
+
       - name: Archive the preflight results
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -758,10 +758,12 @@ jobs:
         run: |
           make operator-sdk preflight
 
-      - name: Setup credentials 
-        run: |
-          AUTH=$(echo -n "${{ env.REGISTRY_USER }}:${{ env.REGISTRY_PASSWORD }}" | base64 -w 0)
-          echo -n '{"auths": {"'${{ env.REGISTRY }}'": {"auth": "'"$AUTH"'"}}}' > config.json
+      - name: Loging to container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ env.REGISTRY_USER }}
+          password: ${{ env.REGISTRY_PASSWORD }}
 
       - name: Run preflight container test
         env:
@@ -769,7 +771,7 @@ jobs:
           PFLT_ARTIFACTS: "preflight_results"
         run: |
           bin/preflight check container ${CONTROLLER_IMG} \
-          --docker-config config.json
+          --docker-config $HOME/.docker/config.json
 
       - name: Archive the preflight results
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
If the registry is not public, preflight test in ci workflow 
need credentials to pull the images, add the credentials step
in ci workflow.

Closes: #4382 