### PR TITLE
feat: add `cnpg.io/userType` label to generated secrets

### DIFF
--- a/docs/src/labels_annotations.md
+++ b/docs/src/labels_annotations.md
@@ -77,9 +77,11 @@ These predefined labels are managed by CloudNativePG.
 : Available on `ConfigMap` and `Secret` resources. When set to `true`,
   a change in the resource is automatically reloaded by the operator.
 
-`cnpg.io/user-role`
-: Available on `Secret` resources. Indicates the kind of user the Secret refers
-to, such as `superuser` or `default`.
+`cnpg.io/userType`
+: Specifies the type of PostgreSQL user associated with the
+  `Secret`, either `superuser` (Postgres superuser access) or `app`
+  (application-level user in CloudNativePG terminology), and is limited to the
+  default users created by CloudNativePG (typically `postgres` and `app`).
 
 `role` - **deprecated**
 :  Whether the instance running in a pod is a `primary` or a `replica`.

--- a/docs/src/labels_annotations.md
+++ b/docs/src/labels_annotations.md
@@ -77,6 +77,10 @@ These predefined labels are managed by CloudNativePG.
 : Available on `ConfigMap` and `Secret` resources. When set to `true`,
   a change in the resource is automatically reloaded by the operator.
 
+`cnpg.io/user-role`
+: Available on `Secret` resources. Indicates the kind of user the Secret refers
+to, such as `superuser` or `default`.
+
 `role` - **deprecated**
 :  Whether the instance running in a pod is a `primary` or a `replica`.
    This label is deprecated, you should use `cnpg.io/instanceRole` instead.

--- a/internal/controller/cluster_create.go
+++ b/internal/controller/cluster_create.go
@@ -218,7 +218,7 @@ func (r *ClusterReconciler) reconcileAppUserSecret(ctx context.Context, cluster 
 			cluster.GetApplicationDatabaseName(),
 			cluster.GetApplicationDatabaseOwner(),
 			appPassword,
-			"default")
+			"app")
 
 		cluster.SetInheritedDataAndOwnership(&appSecret.ObjectMeta)
 		return createOrPatchClusterCredentialSecret(ctx, r.Client, appSecret)

--- a/internal/controller/cluster_create.go
+++ b/internal/controller/cluster_create.go
@@ -176,7 +176,8 @@ func (r *ClusterReconciler) reconcileSuperuserSecret(ctx context.Context, cluste
 			cluster.GetServiceReadWriteName(),
 			"*",
 			"postgres",
-			postgresPassword)
+			postgresPassword,
+			"superuser")
 		cluster.SetInheritedDataAndOwnership(&postgresSecret.ObjectMeta)
 
 		return createOrPatchClusterCredentialSecret(ctx, r.Client, postgresSecret)
@@ -216,7 +217,8 @@ func (r *ClusterReconciler) reconcileAppUserSecret(ctx context.Context, cluster 
 			cluster.GetServiceReadWriteName(),
 			cluster.GetApplicationDatabaseName(),
 			cluster.GetApplicationDatabaseOwner(),
-			appPassword)
+			appPassword,
+			"default")
 
 		cluster.SetInheritedDataAndOwnership(&appSecret.ObjectMeta)
 		return createOrPatchClusterCredentialSecret(ctx, r.Client, appSecret)

--- a/internal/controller/cluster_create.go
+++ b/internal/controller/cluster_create.go
@@ -177,7 +177,7 @@ func (r *ClusterReconciler) reconcileSuperuserSecret(ctx context.Context, cluste
 			"*",
 			"postgres",
 			postgresPassword,
-			"superuser")
+			utils.UserTypeSuperuser)
 		cluster.SetInheritedDataAndOwnership(&postgresSecret.ObjectMeta)
 
 		return createOrPatchClusterCredentialSecret(ctx, r.Client, postgresSecret)
@@ -218,7 +218,7 @@ func (r *ClusterReconciler) reconcileAppUserSecret(ctx context.Context, cluster 
 			cluster.GetApplicationDatabaseName(),
 			cluster.GetApplicationDatabaseOwner(),
 			appPassword,
-			"app")
+			utils.UserTypeApp)
 
 		cluster.SetInheritedDataAndOwnership(&appSecret.ObjectMeta)
 		return createOrPatchClusterCredentialSecret(ctx, r.Client, appSecret)

--- a/pkg/specs/secrets.go
+++ b/pkg/specs/secrets.go
@@ -35,7 +35,7 @@ func CreateSecret(
 	dbname string,
 	username string,
 	password string,
-	userrole string,
+	usertype string,
 ) *corev1.Secret {
 	uriBuilder := newConnectionStringBuilder(hostname, dbname, username, password, namespace)
 
@@ -44,7 +44,7 @@ func CreateSecret(
 			Name:      name,
 			Namespace: namespace,
 			Labels: map[string]string{
-				utils.UserRoleLabelName: userrole,
+				utils.UserTypeLabelName: usertype,
 				utils.WatchedLabelName:  "true",
 			},
 		},

--- a/pkg/specs/secrets.go
+++ b/pkg/specs/secrets.go
@@ -35,7 +35,7 @@ func CreateSecret(
 	dbname string,
 	username string,
 	password string,
-	usertype string,
+	usertype utils.UserType,
 ) *corev1.Secret {
 	uriBuilder := newConnectionStringBuilder(hostname, dbname, username, password, namespace)
 
@@ -44,7 +44,7 @@ func CreateSecret(
 			Name:      name,
 			Namespace: namespace,
 			Labels: map[string]string{
-				utils.UserTypeLabelName: usertype,
+				utils.UserTypeLabelName: string(usertype),
 				utils.WatchedLabelName:  "true",
 			},
 		},

--- a/pkg/specs/secrets.go
+++ b/pkg/specs/secrets.go
@@ -35,6 +35,7 @@ func CreateSecret(
 	dbname string,
 	username string,
 	password string,
+	userrole string,
 ) *corev1.Secret {
 	uriBuilder := newConnectionStringBuilder(hostname, dbname, username, password, namespace)
 
@@ -43,7 +44,8 @@ func CreateSecret(
 			Name:      name,
 			Namespace: namespace,
 			Labels: map[string]string{
-				utils.WatchedLabelName: "true",
+				utils.UserRoleLabelName: userrole,
+				utils.WatchedLabelName:  "true",
 			},
 		},
 		Type: corev1.SecretTypeBasicAuth,

--- a/pkg/specs/secrets_test.go
+++ b/pkg/specs/secrets_test.go
@@ -24,7 +24,7 @@ import (
 var _ = Describe("Secret creation", func() {
 	It("create a secret with the right user and password", func() {
 		secret := CreateSecret("name", "namespace",
-			"thishost", "thisdb", "thisuser", "thispassword")
+			"thishost", "thisdb", "thisuser", "thispassword", "default")
 		Expect(secret.Name).To(Equal("name"))
 		Expect(secret.Namespace).To(Equal("namespace"))
 		Expect(secret.StringData["username"]).To(Equal("thisuser"))

--- a/pkg/specs/secrets_test.go
+++ b/pkg/specs/secrets_test.go
@@ -24,7 +24,7 @@ import (
 var _ = Describe("Secret creation", func() {
 	It("create a secret with the right user and password", func() {
 		secret := CreateSecret("name", "namespace",
-			"thishost", "thisdb", "thisuser", "thispassword", "default")
+			"thishost", "thisdb", "thisuser", "thispassword", "app")
 		Expect(secret.Name).To(Equal("name"))
 		Expect(secret.Namespace).To(Equal("namespace"))
 		Expect(secret.StringData["username"]).To(Equal("thisuser"))

--- a/pkg/specs/secrets_test.go
+++ b/pkg/specs/secrets_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package specs
 
 import (
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -24,7 +26,7 @@ import (
 var _ = Describe("Secret creation", func() {
 	It("create a secret with the right user and password", func() {
 		secret := CreateSecret("name", "namespace",
-			"thishost", "thisdb", "thisuser", "thispassword", "app")
+			"thishost", "thisdb", "thisuser", "thispassword", utils.UserTypeApp)
 		Expect(secret.Name).To(Equal("name"))
 		Expect(secret.Namespace).To(Equal("namespace"))
 		Expect(secret.StringData["username"]).To(Equal("thisuser"))
@@ -39,5 +41,7 @@ var _ = Describe("Secret creation", func() {
 		Expect(secret.StringData["jdbc-uri"]).To(
 			Equal("jdbc:postgresql://thishost.namespace:5432/thisdb?password=thispassword&user=thisuser"),
 		)
+		Expect(secret.Labels).To(
+			HaveKeyWithValue(utils.UserTypeLabelName, string(utils.UserTypeApp)))
 	})
 })

--- a/pkg/utils/labels_annotations.go
+++ b/pkg/utils/labels_annotations.go
@@ -276,6 +276,19 @@ const (
 	HibernationAnnotationValueOn HibernationAnnotationValue = "on"
 )
 
+// UserType tells if a secret refers to a superuser database role
+// or an application one
+type UserType string
+
+const (
+	// UserTypeSuperuser is the type of a superuser database
+	// role
+	UserTypeSuperuser UserType = "superuser"
+
+	// UserTypeApp is the type of an application role
+	UserTypeApp UserType = "app"
+)
+
 // LabelClusterName labels the object with the cluster name
 func LabelClusterName(object *metav1.ObjectMeta, name string) {
 	if object.Labels == nil {

--- a/pkg/utils/labels_annotations.go
+++ b/pkg/utils/labels_annotations.go
@@ -71,12 +71,12 @@ const (
 	// scheduled backup if a backup is created by a scheduled backup
 	ParentScheduledBackupLabelName = MetadataNamespace + "/scheduled-backup"
 
-	// WatchedLabelName the name of the label which tell if a resource change will be automatically reloaded by instance
+	// WatchedLabelName the name of the label which tells if a resource change will be automatically reloaded by instance
 	// or not, use for Secrets or ConfigMaps
 	WatchedLabelName = MetadataNamespace + "/reload"
 
-	// UserRoleLabeName the name of the label which tell if a Secret refers to a superuser database role or a default one
-	UserRoleLabelName = MetadataNamespace + "/user-role"
+	// UserTypeLabelName the name of the label which tells if a Secret refers to a superuser database role or an application one
+	UserTypeLabelName = MetadataNamespace + "/userType"
 
 	// BackupTimelineLabelName is the name or the label where the timeline of a backup is kept
 	BackupTimelineLabelName = MetadataNamespace + "/backupTimeline"

--- a/pkg/utils/labels_annotations.go
+++ b/pkg/utils/labels_annotations.go
@@ -75,6 +75,9 @@ const (
 	// or not, use for Secrets or ConfigMaps
 	WatchedLabelName = MetadataNamespace + "/reload"
 
+	// UserRoleLabeName the name of the label which tell if a Secret refers to a superuser database role or a default one
+	UserRoleLabelName = MetadataNamespace + "/user-role"
+
 	// BackupTimelineLabelName is the name or the label where the timeline of a backup is kept
 	BackupTimelineLabelName = MetadataNamespace + "/backupTimeline"
 

--- a/pkg/utils/labels_annotations.go
+++ b/pkg/utils/labels_annotations.go
@@ -75,7 +75,8 @@ const (
 	// or not, use for Secrets or ConfigMaps
 	WatchedLabelName = MetadataNamespace + "/reload"
 
-	// UserTypeLabelName the name of the label which tells if a Secret refers to a superuser database role or an application one
+	// UserTypeLabelName the name of the label which tells if a Secret refers
+	// to a superuser database role or an application one
 	UserTypeLabelName = MetadataNamespace + "/userType"
 
 	// BackupTimelineLabelName is the name or the label where the timeline of a backup is kept


### PR DESCRIPTION
This patch adds a `cnpg.io/userType` label to the secrets containing users' credentials whose value tells whether the user is a superuser or an application role.

Support for this label is limited to users created by the operator.

Closes #2631 