### PR TITLE
fix(pgaudit): support `pgaudit.log_rows`option

### DIFF
--- a/pkg/management/postgres/logpipe/CSVReadWriter.go
+++ b/pkg/management/postgres/logpipe/CSVReadWriter.go
@@ -37,17 +37,20 @@ type CSVRecordReadWriter struct {
 	allowedFieldsPerRecord []int
 }
 
-// Read reads a CSV record from the underlying reader
-func (r *CSVRecordReadWriter) Read() (record []string, err error) {
-	record, err = r.Reader.Read()
+// Read reads a CSV record from the underlying reader, returns the records or any error encountered
+func (r *CSVRecordReadWriter) Read() ([]string, error) {
+	record, err := r.Reader.Read()
+	if err == nil {
+		return record, nil
+	}
 
 	var parseError *csv.ParseError
 	if !errors.As(err, &parseError) {
-		return record, err
+		return nil, err
 	}
 
 	if !errors.Is(parseError.Err, csv.ErrFieldCount) {
-		return record, err
+		return nil, err
 	}
 
 	for _, allowedFields := range r.allowedFieldsPerRecord {
@@ -57,7 +60,7 @@ func (r *CSVRecordReadWriter) Read() (record []string, err error) {
 		}
 	}
 
-	return record, err
+	return nil, err
 }
 
 // NewCSVRecordReadWriter returns a new CSVRecordReadWriter which parses CSV lines

--- a/pkg/management/postgres/logpipe/CSVReadWriter.go
+++ b/pkg/management/postgres/logpipe/CSVReadWriter.go
@@ -19,6 +19,7 @@ package logpipe
 import (
 	"bytes"
 	"encoding/csv"
+	"errors"
 	"io"
 )
 
@@ -33,17 +34,54 @@ type CSVReadWriter interface {
 type CSVRecordReadWriter struct {
 	io.Writer
 	*csv.Reader
+	allowedFieldsPerRecord []int
+}
+
+// Read reads a CSV record from the underlying reader
+func (r *CSVRecordReadWriter) Read() (record []string, err error) {
+	record, err = r.Reader.Read()
+
+	var parseError *csv.ParseError
+	if !errors.As(err, &parseError) {
+		return record, err
+	}
+
+	if !errors.Is(parseError.Err, csv.ErrFieldCount) {
+		return record, err
+	}
+
+	for _, allowedFields := range r.allowedFieldsPerRecord {
+		if len(record) == allowedFields {
+			r.Reader.FieldsPerRecord = allowedFields
+			return record, nil
+		}
+	}
+
+	return record, err
 }
 
 // NewCSVRecordReadWriter returns a new CSVRecordReadWriter which parses CSV lines
 // with an expected number of fields. It uses a single record for memory efficiency.
-func NewCSVRecordReadWriter(fieldsPerRecord int) *CSVRecordReadWriter {
+// If no fieldsPerRecord are provided, it allows variable fields per record.
+// If fieldsPerRecord are provided, it will only allow those numbers of fields per record.
+func NewCSVRecordReadWriter(fieldsPerRecord ...int) *CSVRecordReadWriter {
 	recordBuffer := new(bytes.Buffer)
 	reader := csv.NewReader(recordBuffer)
 	reader.ReuseRecord = true
-	reader.FieldsPerRecord = fieldsPerRecord
+
+	if len(fieldsPerRecord) == 0 {
+		// Allow variable fields per record as we don't have an opinion
+		reader.FieldsPerRecord = -1
+	} else {
+		// We'll optimistically set the first value as the default, this way we'll get an error on the first line too.
+		// Leaving this to 0 would allow the first line to pass, setting the
+		// fields per record for all the following lines without us checking it.
+		reader.FieldsPerRecord = fieldsPerRecord[0]
+	}
+
 	return &CSVRecordReadWriter{
-		Writer: recordBuffer,
-		Reader: reader,
+		Writer:                 recordBuffer,
+		Reader:                 reader,
+		allowedFieldsPerRecord: fieldsPerRecord,
 	}
 }

--- a/pkg/management/postgres/logpipe/pgaudit.go
+++ b/pkg/management/postgres/logpipe/pgaudit.go
@@ -19,6 +19,10 @@ package logpipe
 // PgAuditFieldsPerRecord is the number of fields in a pgaudit log line
 const PgAuditFieldsPerRecord int = 9
 
+// PgAuditFieldsPerRecordWithRows is the number of fields in a pgaudit log line
+// when "pgaudit.log_rows" is set to "on"
+const PgAuditFieldsPerRecordWithRows int = 10
+
 // PgAuditRecordName is the value of the logger field for pgaudit
 const PgAuditRecordName = "pgaudit"
 
@@ -34,7 +38,7 @@ func NewPgAuditLoggingDecorator() *PgAuditLoggingDecorator {
 	return &PgAuditLoggingDecorator{
 		LoggingRecord: &LoggingRecord{},
 		Audit:         &PgAuditRecord{},
-		CSVReadWriter: NewCSVRecordReadWriter(PgAuditFieldsPerRecord),
+		CSVReadWriter: NewCSVRecordReadWriter(PgAuditFieldsPerRecord, PgAuditFieldsPerRecordWithRows),
 	}
 }
 
@@ -84,6 +88,11 @@ func (r *PgAuditRecord) fromCSV(auditContent []string) {
 	r.ObjectName = auditContent[6]
 	r.Statement = auditContent[7]
 	r.Parameter = auditContent[8]
+	if len(auditContent) >= PgAuditFieldsPerRecordWithRows {
+		r.Rows = auditContent[9]
+	} else {
+		r.Rows = ""
+	}
 }
 
 // PgAuditRecord stores all the fields of a pgaudit log line
@@ -97,4 +106,5 @@ type PgAuditRecord struct {
 	ObjectName     string `json:"object_name,omitempty"`
 	Statement      string `json:"statement,omitempty"`
 	Parameter      string `json:"parameter,omitempty"`
+	Rows           string `json:"rows,omitempty"`
 }

--- a/pkg/management/postgres/logpipe/pgaudit_test.go
+++ b/pkg/management/postgres/logpipe/pgaudit_test.go
@@ -51,7 +51,7 @@ var _ = Describe("pgAudit CSV log record", func() {
 })
 
 var _ = Describe("PgAudit CVS logging decorator", func() {
-	Context("Given a CSV record embedding pgAudit", func() {
+	Context("Given a CSV record embedding pgAudit without rows", func() {
 		It("fills the fields for PostgreSQL 13", func() { // nolint:dupl
 			values := make([]string, FieldsPerRecord12)
 			for i := range values {
@@ -155,6 +155,116 @@ var _ = Describe("PgAudit CVS logging decorator", func() {
 				ObjectName:     "A6",
 				Statement:      "A7",
 				Parameter:      "A8",
+			}))
+		})
+	})
+
+	Context("Given a CSV record embedding pgAudit with rows", func() {
+		It("fills the fields for PostgreSQL 13", func() { // nolint:dupl
+			values := make([]string, FieldsPerRecord12)
+			for i := range values {
+				values[i] = fmt.Sprintf("%d", i)
+			}
+			auditValues := make([]string, PgAuditFieldsPerRecordWithRows)
+			for i := range auditValues {
+				auditValues[i] = fmt.Sprintf("A%d", i)
+			}
+			values[13] = writePgAuditMessage(auditValues)
+			r := NewPgAuditLoggingDecorator()
+			result := r.FromCSV(values)
+			Expect(result.GetName()).To(Equal(PgAuditRecordName))
+			typedResult := result.(*PgAuditLoggingDecorator)
+			Expect(*typedResult.LoggingRecord).To(Equal(LoggingRecord{
+				LogTime:              "0",
+				Username:             "1",
+				DatabaseName:         "2",
+				ProcessID:            "3",
+				ConnectionFrom:       "4",
+				SessionID:            "5",
+				SessionLineNum:       "6",
+				CommandTag:           "7",
+				SessionStartTime:     "8",
+				VirtualTransactionID: "9",
+				TransactionID:        "10",
+				ErrorSeverity:        "11",
+				SQLStateCode:         "12",
+				Message:              "",
+				Detail:               "14",
+				Hint:                 "15",
+				InternalQuery:        "16",
+				InternalQueryPos:     "17",
+				Context:              "18",
+				Query:                "19",
+				QueryPos:             "20",
+				Location:             "21",
+				ApplicationName:      "22",
+				BackendType:          "",
+			}))
+			Expect(*typedResult.Audit).To(Equal(PgAuditRecord{
+				AuditType:      "A0",
+				StatementID:    "A1",
+				SubstatementID: "A2",
+				Class:          "A3",
+				Command:        "A4",
+				ObjectType:     "A5",
+				ObjectName:     "A6",
+				Statement:      "A7",
+				Parameter:      "A8",
+				Rows:           "A9",
+			}))
+		})
+
+		It("fills the fields for PostgreSQL 13", func() { // nolint:dupl
+			values := make([]string, FieldsPerRecord13)
+			for i := range values {
+				values[i] = fmt.Sprintf("%d", i)
+			}
+			auditValues := make([]string, PgAuditFieldsPerRecordWithRows)
+			for i := range auditValues {
+				auditValues[i] = fmt.Sprintf("A%d", i)
+			}
+			values[13] = writePgAuditMessage(auditValues)
+			r := NewPgAuditLoggingDecorator()
+			result := r.FromCSV(values)
+			Expect(result.GetName()).To(Equal(PgAuditRecordName))
+			typedResult := result.(*PgAuditLoggingDecorator)
+			Expect(*typedResult.LoggingRecord).To(Equal(LoggingRecord{
+				LogTime:              "0",
+				Username:             "1",
+				DatabaseName:         "2",
+				ProcessID:            "3",
+				ConnectionFrom:       "4",
+				SessionID:            "5",
+				SessionLineNum:       "6",
+				CommandTag:           "7",
+				SessionStartTime:     "8",
+				VirtualTransactionID: "9",
+				TransactionID:        "10",
+				ErrorSeverity:        "11",
+				SQLStateCode:         "12",
+				Message:              "",
+				Detail:               "14",
+				Hint:                 "15",
+				InternalQuery:        "16",
+				InternalQueryPos:     "17",
+				Context:              "18",
+				Query:                "19",
+				QueryPos:             "20",
+				Location:             "21",
+				ApplicationName:      "22",
+				BackendType:          "23",
+			}))
+			Expect(*typedResult.Audit).To(Equal(PgAuditRecord{
+				AuditType:      "A0",
+				StatementID:    "A1",
+				SubstatementID: "A2",
+				Class:          "A3",
+				Command:        "A4",
+				ObjectType:     "A5",
+				ObjectName:     "A6",
+				Statement:      "A7",
+				Parameter:      "A8",
+				Rows:           "A9",
 			}))
 		})
 	})
@@ -237,7 +347,7 @@ var _ = Describe("PgAudit CVS logging decorator", func() {
 })
 
 var _ = Describe("pgAudit parsing internals", func() {
-	When("a message contains a pgAudit formatted record", func() {
+	When("a message contains a pgAudit formatted record without rows", func() {
 		writer := NewCSVRecordReadWriter(PgAuditFieldsPerRecord)
 		pgAuditRecord := &PgAuditRecord{}
 		validRecords := []*LoggingRecord{
@@ -265,6 +375,44 @@ var _ = Describe("pgAudit parsing internals", func() {
 				Expect(content).NotTo(BeEmpty())
 				pgAuditRecord.fromCSV(content)
 				Expect(pgAuditRecord.AuditType).To(BeEquivalentTo("SESSION"))
+			}
+		})
+	})
+	When("a message contains a pgAudit formatted record with rows", func() {
+		writer := NewCSVRecordReadWriter(PgAuditFieldsPerRecord, PgAuditFieldsPerRecordWithRows)
+		pgAuditRecord := &PgAuditRecord{}
+		validRecords := []*LoggingRecord{
+			{Message: "AUDIT: SESSION,1,1,READ,SELECT,,,\"SELECT pg_last_wal_receive_lsn()," +
+				" pg_last_wal_replay_lsn(), pg_is_wal_replay_paused()\",<none>"},
+			{Message: "AUDIT: SESSION,1,1,DDL,CREATE TABLE,TABLE,public.account,\"create table account\n(" +
+				"\n    id int,\n    name text,\n    password text,\n    description text\n);\",<not logged>,2"},
+			{Message: "AUDIT: SESSION,1,1,READ,SELECT,,,\"SELECT pg_last_wal_receive_lsn()," +
+				" pg_last_wal_replay_lsn(), pg_is_wal_replay_paused()\",<none>"},
+		}
+		It("identifies the message as pgAudit generated", func() {
+			for _, record := range validRecords {
+				tag, content := getTagAndContent(record)
+				Expect(tag).To(BeEquivalentTo("AUDIT"))
+				Expect(content).NotTo(BeEmpty())
+			}
+		})
+		It("decodes the messages correctly switching between lengths as needed", func() {
+			for i, record := range validRecords {
+				tag, rawContent := getTagAndContent(record)
+				Expect(tag).To(BeEquivalentTo("AUDIT"))
+				n, err := writer.Write([]byte(rawContent))
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(n).To(BeEquivalentTo(len(rawContent)))
+				content, err := writer.Read()
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(content).NotTo(BeEmpty())
+				pgAuditRecord.fromCSV(content)
+				Expect(pgAuditRecord.AuditType).To(BeEquivalentTo("SESSION"))
+				if i == 1 {
+					Expect(pgAuditRecord.Rows).To(BeEquivalentTo("2"))
+				} else {
+					Expect(pgAuditRecord.Rows).To(BeEmpty())
+				}
 			}
 		})
 	})


### PR DESCRIPTION
Fixes #4386.

Turns out that with [pgaudit.log_rows](https://github.com/pgaudit/pgaudit?tab=readme-ov-file#pgauditlog_rows) enabled an additional field is appended at the end of the CSV row. 

In order to properly handle audit logs with `log_rows` enabled and switching it on and off I've extended the `CSVRecordReadWriter` to be able to handle more than one possible length and switching between them seamlessly. And added to `PgAuditRecord` the `Rows` field.

So now the following Cluster:
```yaml
apiVersion: postgresql.cnpg.io/v1
kind: Cluster
metadata:
  name: cluster-example
spec:
  instances: 3
  postgresql:
    parameters:
      pgaudit.log: "READ, WRITE, FUNCTION, DDL, ROLE"
      pgaudit.log_catalog: "off"
      pgaudit.log_parameter: "on"
      pgaudit.log_relation: "on"
      pgaudit.log_statement: "on"

      pgaudit.log_rows: "on"

  storage:
    size: 1Gi
```

Properly results in the following log:
```json
{
	"level": "info",
	"ts": "2024-04-28T11:07:05Z",
	"logger": "pgaudit",
	"msg": "record",
	"logging_pod": "cluster-example-2",
	"record": {
		"log_time": "2024-04-28 11:07:05.168 UTC",
		"user_name": "postgres",
		"database_name": "postgres",
		"process_id": "78",
		"connection_from": "[local]",
		"session_id": "662e2dd9.4e",
		"session_line_num": "1",
		"command_tag": "SELECT",
		"session_start_time": "2024-04-28 11:07:05 UTC",
		"virtual_transaction_id": "2/6",
		"transaction_id": "0",
		"error_severity": "LOG",
		"sql_state_code": "00000",
		"application_name": "cnpg-instance-manager",
		"backend_type": "client backend",
		"query_id": "0",
		"audit": {
			"audit_type": "SESSION",
			"statement_id": "1",
			"substatement_id": "1",
			"class": "READ",
			"command": "SELECT",
			"statement": "SELECT (SELECT timeline_id FROM pg_control_checkpoint()), COALESCE(pg_last_wal_receive_lsn()::varchar, ''), COALESCE(pg_last_wal_replay_lsn()::varchar, ''), pg_is_wal_replay_paused()",
			"parameter": "<none>",
			"rows": "1"
		}
	}
}
```

And switching to `pgaudit.log_rows: "off"` results in still logs being parsed correctly:
```json
{
	"level": "info",
	"ts": "2024-04-28T12:02:06Z",
	"logger": "pgaudit",
	"msg": "record",
	"logging_pod": "cluster-example-3",
	"record": {
		"log_time": "2024-04-28 12:02:06.189 UTC",
		"user_name": "postgres",
		"database_name": "postgres",
		"process_id": "436",
		"connection_from": "[local]",
		"session_id": "662e3abe.1b4",
		"session_line_num": "1",
		"command_tag": "BIND",
		"session_start_time": "2024-04-28 12:02:06 UTC",
		"virtual_transaction_id": "2/530",
		"transaction_id": "0",
		"error_severity": "LOG",
		"sql_state_code": "00000",
		"application_name": "cnpg-instance-manager",
		"backend_type": "client backend",
		"query_id": "0",
		"audit": {
			"audit_type": "SESSION",
			"statement_id": "1",
			"substatement_id": "1",
			"class": "READ",
			"command": "SELECT",
			"statement": "SELECT (SELECT timeline_id FROM pg_control_checkpoint()), COALESCE(pg_last_wal_receive_lsn()::varchar, ''), COALESCE(pg_last_wal_replay_lsn()::varchar, ''), pg_is_wal_replay_paused()",
			"parameter": "<none>"
		}
	}
}
```
