### PR TITLE
fix: replica cluster should restart after promotion

### DIFF
--- a/internal/management/controller/instance_controller.go
+++ b/internal/management/controller/instance_controller.go
@@ -171,8 +171,8 @@ func (r *InstanceReconciler) Reconcile(
 		return reconcile.Result{RequeueAfter: time.Second}, nil
 	}
 
-	// If the instance is promoted, it will not automatically load the changed configuration files
-	// so promoted should not stop the instance reload requires
+	// Instance promotion will not automatically load the changed configuration files.
+	// Therefore it should not be counted as "a restart" to prevent instance restart.
 	if _, err := r.reconcilePrimary(ctx, cluster); err != nil {
 		return reconcile.Result{}, err
 	}

--- a/internal/management/controller/instance_controller.go
+++ b/internal/management/controller/instance_controller.go
@@ -172,7 +172,7 @@ func (r *InstanceReconciler) Reconcile(
 	}
 
 	// Instance promotion will not automatically load the changed configuration files.
-	// Therefore it should not be counted as "a restart" to prevent instance restart.
+	// Therefore it should not be counted as "a restart".
 	if err := r.reconcilePrimary(ctx, cluster); err != nil {
 		return reconcile.Result{}, err
 	}


### PR DESCRIPTION
When a replica cluster is promoted, the `archive_mode` is changed from
`always` to `on`. This change requires a restart because Postgres 
does not reload the configuration during the promotion.

Closes: #4172 