### PR TITLE
chore: improve the operator deployment detection 

### DIFF
--- a/tests/e2e/eviction_test.go
+++ b/tests/e2e/eviction_test.go
@@ -52,7 +52,7 @@ import (
 // so we choose to use patch and drain to simulate the eviction. The patch status issued one problem,
 // when evicting the primary pod of multiple clusters.
 
-var _ = Describe("Pod eviction", Serial, Label(tests.LabelDisruptive, tests.LabelOperator), func() {
+var _ = Describe("Pod eviction", Serial, Label(tests.LabelDisruptive), func() {
 	const (
 		level                    = tests.Low
 		singleInstanceSampleFile = fixturesDir + "/eviction/single-instance-cluster.yaml.template"

--- a/tests/e2e/operator_deployment_test.go
+++ b/tests/e2e/operator_deployment_test.go
@@ -37,9 +37,9 @@ var _ = Describe("PostgreSQL operator deployment", Label(tests.LabelBasic, tests
 			AssertOperatorIsReady()
 		})
 		By("having a deployment for the operator in state ready", func() {
-			deployment, err := env.GetOperatorDeployment()
-			Expect(err).ShouldNot(HaveOccurred())
-			Expect(deployment.Status.ReadyReplicas).Should(BeEquivalentTo(1))
+			ready, err := env.IsOperatorDeploymentReady()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ready).To(BeTrue())
 		})
 	})
 })

--- a/tests/e2e/operator_ha_test.go
+++ b/tests/e2e/operator_ha_test.go
@@ -45,6 +45,10 @@ var _ = Describe("Operator High Availability", Serial,
 		})
 
 		It("can work as HA mode", func() {
+			// Make sure there's at least one pod of the operator
+			err := env.ScaleOperatorDeployment(1)
+			Expect(err).ToNot(HaveOccurred())
+
 			// Get Operator Pod name
 			operatorPodName, err := env.GetOperatorPod()
 			Expect(err).ToNot(HaveOccurred())

--- a/tests/e2e/webhook_test.go
+++ b/tests/e2e/webhook_test.go
@@ -71,9 +71,13 @@ var _ = Describe("webhook", Serial, Label(tests.LabelDisruptive, tests.LabelOper
 		webhookNamespacePrefix := "webhook-test"
 		clusterIsDefaulted = true
 		By("having a deployment for the operator in state ready", func() {
-			deployment, err := env.GetOperatorDeployment()
+			// Make sure that we have at least one operator already working
+			err := env.ScaleOperatorDeployment(1)
+			Expect(err).ToNot(HaveOccurred())
+
+			ready, err := env.IsOperatorDeploymentReady()
 			Expect(err).ShouldNot(HaveOccurred())
-			Expect(deployment.Status.ReadyReplicas).Should(BeEquivalentTo(1))
+			Expect(ready).To(BeTrue())
 		})
 
 		// Create a basic PG cluster
@@ -135,9 +139,9 @@ var _ = Describe("webhook", Serial, Label(tests.LabelDisruptive, tests.LabelOper
 
 		// Make sure the operator is intact and not crashing
 		By("having a deployment for the operator in state ready", func() {
-			deployment, err := env.GetOperatorDeployment()
+			ready, err := env.IsOperatorDeploymentReady()
 			Expect(err).ShouldNot(HaveOccurred())
-			Expect(deployment.Status.ReadyReplicas).Should(BeEquivalentTo(1))
+			Expect(ready).To(BeTrue())
 		})
 
 		By("by cleaning up the webhook configurations", func() {

--- a/tests/utils/operator.go
+++ b/tests/utils/operator.go
@@ -247,7 +247,8 @@ func (env *TestingEnvironment) IsOperatorDeploymentReady() (bool, error) {
 		return false, err
 	}
 
-	if operatorDeployment.Status.ReadyReplicas != operatorDeployment.Status.Replicas {
+	if operatorDeployment.Spec.Replicas != nil &&
+		operatorDeployment.Status.ReadyReplicas != *operatorDeployment.Spec.Replicas {
 		return false, fmt.Errorf("deployment not ready %v of %v ready",
 			operatorDeployment.Status.ReadyReplicas, operatorDeployment.Status.ReadyReplicas)
 	}


### PR DESCRIPTION
Using the Deployment object from the Kubernetes environment we can get all the information for the deployment more accurate than just listing and counting pods, which it's an issue when you have another pod in the same namespace.

Closes #4426 