### PR TITLE
fix: instance manager stuck if PostgreSQL doesn't start

### DIFF
--- a/internal/cmd/manager/instance/run/lifecycle/run.go
+++ b/internal/cmd/manager/instance/run/lifecycle/run.go
@@ -43,14 +43,10 @@ func (i *PostgresLifecycle) runPostgresAndWait(ctx context.Context) <-chan error
 		defer close(errChan)
 
 		var wg sync.WaitGroup
-		defer func() {
-			wg.Wait()
-		}()
+		defer wg.Wait()
 
 		postgresContext, postgresContextCancel := context.WithCancel(ctx)
-		defer func() {
-			postgresContextCancel()
-		}()
+		defer postgresContextCancel()
 
 		err := i.instance.VerifyPgDataCoherence(postgresContext)
 		if err != nil {

--- a/internal/cmd/manager/instance/run/lifecycle/run.go
+++ b/internal/cmd/manager/instance/run/lifecycle/run.go
@@ -49,7 +49,7 @@ func (i *PostgresLifecycle) runPostgresAndWait(ctx context.Context) <-chan error
 		// is ready to accept connection.
 		//
 		// This wait group ensures this goroutine to be finished when
-		// this funcion exits
+		// this function exits
 		var wg sync.WaitGroup
 		defer wg.Wait()
 
@@ -81,8 +81,8 @@ func (i *PostgresLifecycle) runPostgresAndWait(ctx context.Context) <-chan error
 		// following will be a no-op.
 		i.systemInitialization.Wait()
 
-		// The lifecycle loop will call us even when PostgreSQL is fenced. In
-		// that case there's no need to proceed.
+		// The lifecycle loop will call us even when PostgreSQL is fenced.
+		// In that case there's no need to proceed.
 		if i.instance.IsFenced() {
 			contextLogger.Info("Instance is fenced, won't start postgres right now")
 			return

--- a/internal/management/controller/instance_controller.go
+++ b/internal/management/controller/instance_controller.go
@@ -954,7 +954,7 @@ func (r *InstanceReconciler) reconcileCheckWalArchiveFile(cluster *apiv1.Cluster
 func (r *InstanceReconciler) processConfigReloadAndManageRestart(ctx context.Context, cluster *apiv1.Cluster) error {
 	contextLogger := log.FromContext(ctx)
 
-	status, err := r.instance.WaitForConfigReload()
+	status, err := r.instance.WaitForConfigReload(ctx)
 	if err != nil {
 		return err
 	}

--- a/internal/management/controller/instance_startup.go
+++ b/internal/management/controller/instance_startup.go
@@ -221,7 +221,7 @@ func (r *InstanceReconciler) verifyPgDataCoherenceForPrimary(ctx context.Context
 			"currentPrimary", cluster.Status.CurrentPrimary)
 
 		// Wait for the new primary to really accept connections
-		err := r.instance.WaitForPrimaryAvailable()
+		err := r.instance.WaitForPrimaryAvailable(ctx)
 		if err != nil {
 			return err
 		}
@@ -261,7 +261,7 @@ func (r *InstanceReconciler) verifyPgDataCoherenceForPrimary(ctx context.Context
 			// pg_rewind requires a clean shutdown of the old primary to work.
 			// The only way to do that is to start the server again
 			// and wait for it to be available again.
-			err = r.instance.CompleteCrashRecovery()
+			err = r.instance.CompleteCrashRecovery(ctx)
 			if err != nil {
 				return err
 			}

--- a/pkg/management/postgres/instance.go
+++ b/pkg/management/postgres/instance.go
@@ -750,7 +750,7 @@ func (instance *Instance) Demote(ctx context.Context, cluster *apiv1.Cluster) er
 }
 
 // WaitForPrimaryAvailable waits until we can connect to the primary
-func (instance *Instance) WaitForPrimaryAvailable() error {
+func (instance *Instance) WaitForPrimaryAvailable(ctx context.Context) error {
 	primaryConnInfo := instance.GetPrimaryConnInfo() + " dbname=postgres connect_timeout=5"
 
 	log.Info("Waiting for the new primary to be available",
@@ -764,43 +764,48 @@ func (instance *Instance) WaitForPrimaryAvailable() error {
 		_ = db.Close()
 	}()
 
-	return waitForConnectionAvailable(db)
+	return waitForConnectionAvailable(ctx, db)
 }
 
 // CompleteCrashRecovery temporary starts up the server and wait for it
 // to be fully available for queries. This will ensure that the crash recovery
 // is fully done.
 // Important: this function must be called only when the instance isn't started
-func (instance *Instance) CompleteCrashRecovery() error {
+func (instance *Instance) CompleteCrashRecovery(ctx context.Context) error {
 	log.Info("Waiting for server to complete crash recovery")
 
 	defer func() {
 		instance.ShutdownConnections()
 	}()
 
-	return instance.WithActiveInstance(instance.WaitForSuperuserConnectionAvailable)
+	return instance.WithActiveInstance(func() error {
+		return instance.WaitForSuperuserConnectionAvailable(ctx)
+	})
 }
 
 // WaitForSuperuserConnectionAvailable waits until we can connect to this
 // instance using the superuser account
-func (instance *Instance) WaitForSuperuserConnectionAvailable() error {
+func (instance *Instance) WaitForSuperuserConnectionAvailable(ctx context.Context) error {
 	db, err := instance.GetSuperUserDB()
 	if err != nil {
 		return err
 	}
 
-	return waitForConnectionAvailable(db)
+	return waitForConnectionAvailable(ctx, db)
 }
 
 // waitForConnectionAvailable waits until we can connect to the passed
 // sql.DB connection
-func waitForConnectionAvailable(db *sql.DB) error {
+func waitForConnectionAvailable(context context.Context, db *sql.DB) error {
 	errorIsRetryable := func(err error) bool {
+		if context.Err() != nil {
+			return false
+		}
 		return err != nil
 	}
 
 	return retry.OnError(RetryUntilServerAvailable, errorIsRetryable, func() error {
-		err := db.Ping()
+		err := db.PingContext(context)
 		if err != nil {
 			log.Info("DB not available, will retry", "err", err)
 		}
@@ -833,7 +838,7 @@ func (instance *Instance) waitUntilConfigShaMatches() error {
 }
 
 // WaitForConfigReload returns the postgresqlStatus and any error encountered
-func (instance *Instance) WaitForConfigReload() (*postgres.PostgresqlStatus, error) {
+func (instance *Instance) WaitForConfigReload(ctx context.Context) (*postgres.PostgresqlStatus, error) {
 	// This function could also be called while the server is being
 	// started up, so we are not sure that the server is really active.
 	// Let's wait for that.
@@ -841,7 +846,7 @@ func (instance *Instance) WaitForConfigReload() (*postgres.PostgresqlStatus, err
 		return nil, nil
 	}
 
-	err := instance.WaitForSuperuserConnectionAvailable()
+	err := instance.WaitForSuperuserConnectionAvailable(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("while applying new configuration: %w", err)
 	}


### PR DESCRIPTION
If a primary PostgreSQL instance fails to start after being stopped, the instance manager is indefinitely waiting for it to start running the configuration queries.

This patch creates a separate context for each postmaster process and runs the configuration queries in a parallel goroutine, canceling it as soon as the postmaster finishes.

Fixes: #4433 