### PR TITLE
chore: increase the timeout for the fastfailover test

### DIFF
--- a/tests/e2e/fastfailover_test.go
+++ b/tests/e2e/fastfailover_test.go
@@ -62,7 +62,7 @@ var _ = Describe("Fast failover", Serial, Label(tests.LabelPerformance, tests.La
 
 		// OpenShift takes longer to recover than a standard and simple Kubernetes cluster
 		if IsOpenshift() {
-			maxReattachTime = 120
+			maxReattachTime = 240
 			maxFailoverTime = 20
 		}
 	})


### PR DESCRIPTION
Increasing the timeout in the fastfailover test for OLM tests.