### PR TITLE
test: avoid log flooding in switchover/failover tests

### DIFF
--- a/hack/install-config.yaml.template
+++ b/hack/install-config.yaml.template
@@ -6,13 +6,15 @@ compute:
   name: worker
   platform:
     aws:
-      type: m5.2xlarge
+      type: m6i.xlarge
   replicas: 3
 controlPlane:
   architecture: amd64
   hyperthreading: Enabled
   name: master
-  platform: {}
+  platform:
+    aws:
+      type: m6i.2xlarge
   replicas: 3
 metadata:
   name: ${CLUSTER_NAME}

--- a/hack/install-config.yaml.template
+++ b/hack/install-config.yaml.template
@@ -6,15 +6,13 @@ compute:
   name: worker
   platform:
     aws:
-      type: m6i.xlarge
+      type: m5.2xlarge
   replicas: 3
 controlPlane:
   architecture: amd64
   hyperthreading: Enabled
   name: master
-  platform:
-    aws:
-      type: m6i.2xlarge
+  platform: {}
   replicas: 3
 metadata:
   name: ${CLUSTER_NAME}

--- a/tests/e2e/fixtures/base/cluster-storage-class-with-rep-slots.yaml.template
+++ b/tests/e2e/fixtures/base/cluster-storage-class-with-rep-slots.yaml.template
@@ -9,7 +9,7 @@ spec:
     parameters:
       log_checkpoints: "on"
       log_lock_waits: "on"
-      log_min_duration_statement: '0'
+      log_min_duration_statement: '1000'
       log_temp_files: '1024'
       log_autovacuum_min_duration: '1s'
       log_replication_commands: 'on'

--- a/tests/e2e/fixtures/fastfailover/cluster-fast-failover-with-repl-slots.yaml.template
+++ b/tests/e2e/fixtures/fastfailover/cluster-fast-failover-with-repl-slots.yaml.template
@@ -11,7 +11,7 @@ spec:
     parameters:
       log_checkpoints: "on"
       log_lock_waits: "on"
-      log_min_duration_statement: '0'
+      log_min_duration_statement: '1000'
       log_temp_files: '1024'
       log_autovacuum_min_duration: '1s'
       log_replication_commands: 'on'

--- a/tests/e2e/fixtures/fastfailover/cluster-syncreplicas-fast-failover.yaml.template
+++ b/tests/e2e/fixtures/fastfailover/cluster-syncreplicas-fast-failover.yaml.template
@@ -18,6 +18,7 @@ spec:
       log_temp_files: '1024'
       log_autovacuum_min_duration: '1s'
       log_replication_commands: 'on'
+      wal_retrieve_retry_interval: '2s'
   bootstrap:
     initdb:
       database: app

--- a/tests/e2e/fixtures/fastswitchover/cluster-fast-switchover-with-repl-slots.yaml.template
+++ b/tests/e2e/fixtures/fastswitchover/cluster-fast-switchover-with-repl-slots.yaml.template
@@ -10,7 +10,7 @@ spec:
     parameters:
       log_checkpoints: "on"
       log_lock_waits: "on"
-      log_min_duration_statement: '0'
+      log_min_duration_statement: '1000'
       log_temp_files: '1024'
       log_autovacuum_min_duration: '1s'
       log_replication_commands: 'on'

--- a/tests/e2e/fixtures/replication_slot/cluster-pg-replication-slot-disable.yaml.template
+++ b/tests/e2e/fixtures/replication_slot/cluster-pg-replication-slot-disable.yaml.template
@@ -9,7 +9,7 @@ spec:
     parameters:
       log_checkpoints: "on"
       log_lock_waits: "on"
-      log_min_duration_statement: '0'
+      log_min_duration_statement: '1000'
       log_temp_files: '1024'
       log_autovacuum_min_duration: '1s'
       log_replication_commands: 'on'

--- a/tests/e2e/fixtures/switchover/cluster-switchover-with-rep-slots.yaml.template
+++ b/tests/e2e/fixtures/switchover/cluster-switchover-with-rep-slots.yaml.template
@@ -9,7 +9,7 @@ spec:
     parameters:
       log_checkpoints: "on"
       log_lock_waits: "on"
-      log_min_duration_statement: '0'
+      log_min_duration_statement: '1000'
       log_temp_files: '1024'
       log_autovacuum_min_duration: '1s'
       log_replication_commands: 'on'


### PR DESCRIPTION
We have this value set to `0` meaning that it was logging everything, with the following changes we now increase this value to 1000 avoiding logging everything on the clusters, therefore, we reduce the load on the disks for the stress tests improving the switchover

Closes #4447 