### PR TITLE
fix: add missing option to the AKS e2e tests

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -1092,6 +1092,7 @@ jobs:
         name: Clean up
         if: always()
         run: |
+          az extension add --allow-preview true --name monitor-control-service
           az account set --subscription ${{ secrets.AZURE_SUBSCRIPTION }}
           attempt=1
           max_attempts=3

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -827,7 +827,7 @@ jobs:
           timeout_minutes: 10
           max_attempts: 3
           command: |
-            az extension add --name aks-preview
+            az extension add --allow-preview true --name aks-preview
             az account set --subscription ${{ secrets.AZURE_SUBSCRIPTION }}
 
             AZURE_STORAGE_ACCOUNT="${{ github.run_number }}${{ env.E2E_SUFFIX }}"
@@ -938,7 +938,7 @@ jobs:
           timeout_minutes: 10
           max_attempts: 3
           command: |
-            az extension add --name aks-preview
+            az extension add --allow-preview true --name aks-preview
             az account set --subscription ${{ secrets.AZURE_SUBSCRIPTION }}
 
             # name of the AKS cluster


### PR DESCRIPTION
Since May 2024 a new option is required to create an AKS cluster

Closes #4450 