### PR TITLE
docs: fixing typo in object_stores.md

### DIFF
--- a/.spellcheck.yaml
+++ b/.spellcheck.yaml
@@ -2,7 +2,7 @@ matrix:
 - name: markdown
   sources:
   - 'docs/src/*.md'
-  - 'docs/src/release_notes/*.md'
+  - 'docs/src/*/*.md'
   default_encoding: utf-8
   aspell:
     lang: en

--- a/docs/src/appendixes/object_stores.md
+++ b/docs/src/appendixes/object_stores.md
@@ -155,7 +155,7 @@ spec:
 ## Azure Blob Storage
 
 [Azure Blob Storage](https://azure.microsoft.com/en-us/services/storage/blobs/) is the
-obect storage service provided by Microsoft.
+object storage service provided by Microsoft.
 
 In order to access your storage account for backup and recovery of
 CloudNativePG managed databases, you will need one of the following


### PR DESCRIPTION
This patch ensures the spell check workflow covers all markdown 
files under the `docs/src` folder and also corrects one missing typo
which we did not catch before.