### PR TITLE
ci: run govulncheck only if go code changed

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -189,7 +189,8 @@ jobs:
     needs:
       - duplicate_runs
       - change-triage
-    if: needs.duplicate_runs.outputs.should_skip != 'true'
+    if: needs.duplicate_runs.outputs.should_skip != 'true' &&
+      needs.change-triage.outputs.go-code-changed == 'true'
     runs-on: ubuntu-22.04
     steps:
       - name: Run govulncheck

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -189,8 +189,12 @@ jobs:
     needs:
       - duplicate_runs
       - change-triage
-    if: needs.duplicate_runs.outputs.should_skip != 'true' &&
-      needs.change-triage.outputs.go-code-changed == 'true'
+    if: |
+      needs.duplicate_runs.outputs.should_skip != 'true' &&
+      (
+        needs.change-triage.outputs.operator-changed == 'true' ||
+        needs.change-triage.outputs.go-code-changed == 'true'
+      )
     runs-on: ubuntu-22.04
     steps:
       - name: Run govulncheck


### PR DESCRIPTION
The CI pipeline is failing even for document-only PRs when
govulncheck finds issues.