### PR TITLE
fix: timeout when restarting PostgreSQL and while lifting fencing

### DIFF
--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -2939,6 +2939,12 @@ func (cluster *Cluster) GetSmartShutdownTimeout() int32 {
 	return 180
 }
 
+// GetRestartTimeout is used to have a timeout for operations that involve
+// a restart of a PostgreSQL instance
+func (cluster *Cluster) GetRestartTimeout() int32 {
+	return cluster.GetMaxStopDelay() + cluster.GetMaxStartDelay()
+}
+
 // GetMaxSwitchoverDelay get the amount of time PostgreSQL has to stop before switchover
 func (cluster *Cluster) GetMaxSwitchoverDelay() int32 {
 	if cluster.Spec.MaxSwitchoverDelay > 0 {

--- a/internal/management/controller/instance_controller.go
+++ b/internal/management/controller/instance_controller.go
@@ -156,7 +156,7 @@ func (r *InstanceReconciler) Reconcile(
 
 	r.systemInitialization.Broadcast()
 
-	if result := r.reconcileFencing(cluster); result != nil {
+	if result := r.reconcileFencing(ctx, cluster); result != nil {
 		contextLogger.Info("Fencing status changed, will not proceed with the reconciliation loop")
 		return *result, nil
 	}
@@ -272,9 +272,15 @@ func (r *InstanceReconciler) restartPrimaryInplaceIfRequested(
 	if err != nil {
 		return false, err
 	}
+
 	restartRequested := isPrimary && cluster.Status.Phase == apiv1.PhaseInplacePrimaryRestart
 	if restartRequested {
-		if err := r.instance.RequestAndWaitRestartSmartFast(); err != nil {
+		restartTimeout := cluster.GetRestartTimeout()
+
+		if err := r.instance.RequestAndWaitRestartSmartFast(
+			ctx,
+			time.Duration(restartTimeout)*time.Second,
+		); err != nil {
 			return true, err
 		}
 		oldCluster := cluster.DeepCopy()
@@ -316,7 +322,7 @@ func (r *InstanceReconciler) refreshConfigurationFiles(
 	return reloadNeeded, nil
 }
 
-func (r *InstanceReconciler) reconcileFencing(cluster *apiv1.Cluster) *reconcile.Result {
+func (r *InstanceReconciler) reconcileFencing(ctx context.Context, cluster *apiv1.Cluster) *reconcile.Result {
 	fencingRequired := cluster.IsInstanceFenced(r.instance.PodName)
 	isFenced := r.instance.IsFenced()
 	switch {
@@ -326,7 +332,8 @@ func (r *InstanceReconciler) reconcileFencing(cluster *apiv1.Cluster) *reconcile
 		return &reconcile.Result{}
 	case isFenced && !fencingRequired:
 		// fencing enabled and not required anymore, request to disable fencing and continue
-		err := r.instance.RequestAndWaitFencingOff()
+		timeout := time.Second * time.Duration(cluster.GetMaxStartDelay())
+		err := r.instance.RequestAndWaitFencingOff(ctx, timeout)
 		if err != nil {
 			log.Error(err, "while waiting for the instance to be restarted after lifting the fence")
 		}
@@ -972,7 +979,8 @@ func (r *InstanceReconciler) processConfigReloadAndManageRestart(ctx context.Con
 	if status.IsPrimary && status.PendingRestartForDecrease {
 		if cluster.GetPrimaryUpdateStrategy() == apiv1.PrimaryUpdateStrategyUnsupervised {
 			contextLogger.Info("Restarting primary in-place due to hot standby sensible parameters decrease")
-			return r.Instance().RequestAndWaitRestartSmartFast()
+			restartTimeout := time.Duration(cluster.GetRestartTimeout()) * time.Second
+			return r.Instance().RequestAndWaitRestartSmartFast(ctx, restartTimeout)
 		}
 		reason := "decrease of hot standby sensitive parameters"
 		contextLogger.Info("Waiting for the user to request a restart of the primary instance or a switchover "+

--- a/internal/management/controller/instance_controller.go
+++ b/internal/management/controller/instance_controller.go
@@ -272,7 +272,6 @@ func (r *InstanceReconciler) restartPrimaryInplaceIfRequested(
 	if err != nil {
 		return false, err
 	}
-
 	restartRequested := isPrimary && cluster.Status.Phase == apiv1.PhaseInplacePrimaryRestart
 	if restartRequested {
 		restartTimeout := cluster.GetRestartTimeout()

--- a/pkg/management/postgres/instance.go
+++ b/pkg/management/postgres/instance.go
@@ -1159,11 +1159,11 @@ func (instance *Instance) requestFencingOff() {
 // waitForInstanceRestarted waits until the instance reports being started
 // after the given time
 func (instance *Instance) waitForInstanceRestarted(ctx context.Context, after time.Time) error {
-	retryOnEveryError := func(_ error) bool {
+	retryUntilContextCancelled := func(_ error) bool {
 		return ctx.Err() == nil
 	}
 
-	return retry.OnError(RetryUntilServerAvailable, retryOnEveryError, func() error {
+	return retry.OnError(RetryUntilServerAvailable, retryUntilContextCancelled, func() error {
 		db, err := instance.GetSuperUserDB()
 		if err != nil {
 			return err

--- a/pkg/management/postgres/instance.go
+++ b/pkg/management/postgres/instance.go
@@ -1088,13 +1088,19 @@ func (instance *Instance) RequestFastImmediateShutdown() {
 
 // RequestAndWaitRestartSmartFast requests the lifecycle manager to
 // restart the postmaster, and wait for the postmaster to be restarted
-func (instance *Instance) RequestAndWaitRestartSmartFast() error {
+func (instance *Instance) RequestAndWaitRestartSmartFast(ctx context.Context, timeout time.Duration) error {
 	instance.SetMightBeUnavailable(true)
 	defer instance.SetMightBeUnavailable(false)
+
+	restartCtx, cancel := context.WithTimeoutCause(
+		ctx,
+		timeout,
+		fmt.Errorf("timeout while restarting PostgreSQL"))
+	defer cancel()
+
 	now := time.Now()
 	instance.requestRestartSmartFast()
-	err := instance.waitForInstanceRestarted(now)
-	if err != nil {
+	if err := instance.waitForInstanceRestarted(restartCtx, now); err != nil {
 		return fmt.Errorf("while waiting for instance restart: %w", err)
 	}
 
@@ -1114,13 +1120,29 @@ func (instance *Instance) RequestFencingOn() {
 
 // RequestAndWaitFencingOff will request to remove the fencing
 // and wait for the instance to be restarted
-func (instance *Instance) RequestAndWaitFencingOff() error {
-	defer instance.SetMightBeUnavailable(false)
-	now := time.Now()
-	instance.requestFencingOff()
-	err := instance.waitForInstanceRestarted(now)
-	if err != nil {
-		return fmt.Errorf("while waiting for instance restart: %w", err)
+func (instance *Instance) RequestAndWaitFencingOff(ctx context.Context, timeout time.Duration) error {
+	liftFencing := func() error {
+		ctxWithTimeout, cancel := context.WithTimeoutCause(
+			ctx,
+			timeout,
+			fmt.Errorf("timeout while resuming PostgreSQL from fencing"),
+		)
+		defer cancel()
+
+		defer instance.SetMightBeUnavailable(false)
+		now := time.Now()
+		instance.requestFencingOff()
+		err := instance.waitForInstanceRestarted(ctxWithTimeout, now)
+		if err != nil {
+			return fmt.Errorf("while waiting for instance restart: %w", err)
+		}
+
+		return nil
+	}
+
+	// let PostgreSQL start up
+	if err := liftFencing(); err != nil {
+		return err
 	}
 
 	// sleep enough for the pod to be ready again
@@ -1136,17 +1158,18 @@ func (instance *Instance) requestFencingOff() {
 
 // waitForInstanceRestarted waits until the instance reports being started
 // after the given time
-func (instance *Instance) waitForInstanceRestarted(after time.Time) error {
+func (instance *Instance) waitForInstanceRestarted(ctx context.Context, after time.Time) error {
 	retryOnEveryError := func(_ error) bool {
-		return true
+		return ctx.Err() == nil
 	}
+
 	return retry.OnError(RetryUntilServerAvailable, retryOnEveryError, func() error {
 		db, err := instance.GetSuperUserDB()
 		if err != nil {
 			return err
 		}
 		var startTime time.Time
-		row := db.QueryRow("SELECT pg_postmaster_start_time()")
+		row := db.QueryRowContext(ctx, "SELECT pg_postmaster_start_time()")
 		err = row.Scan(&startTime)
 		if err != nil {
 			return err


### PR DESCRIPTION
The instance manager starts PostgreSQL:

1. when it starts up
2. when configuration changes are being applied (after stopping it)
3. when fencing is lifted.

In the second and third examples, the operator is requested by the embedded cluster reconciler loop, and performed without any timeout.

If PostgreSQL won't start up again because of a wrong configuration or missing disk space, the reconciler loop will be stuck waiting for a dead postmaster to be up.

This patch handles this condition by using a combination of the timeout parameters that are already set in the cluster.

Fixes: #4501 