### PR TITLE
[plugin] use namespace to get the PodDisruptionBudgetList

### DIFF
--- a/internal/cmd/plugin/status/status.go
+++ b/internal/cmd/plugin/status/status.go
@@ -155,8 +155,8 @@ func ExtractPostgresqlStatus(ctx context.Context, clusterName string) (*Postgres
 		specs.PostgresContainerName)
 
 	var pdbl policyv1.PodDisruptionBudgetList
-	if err := plugin.Client.List(ctx, &pdbl, client.MatchingLabels{utils.ClusterLabelName: clusterName}); err != nil {
-		fmt.Println(err)
+	if err := plugin.Client.List(ctx, &pdbl, client.InNamespace(plugin.Namespace), client.MatchingLabels{utils.ClusterLabelName: clusterName}); err != nil {
+		return nil, fmt.Errorf("while extracting PodDisruptionBudgetList: %w", err)
 	}
 	// Extract the status from the instances
 	status := PostgresqlStatus{

--- a/internal/cmd/plugin/status/status.go
+++ b/internal/cmd/plugin/status/status.go
@@ -156,7 +156,7 @@ func ExtractPostgresqlStatus(ctx context.Context, clusterName string) (*Postgres
 
 	var pdbl policyv1.PodDisruptionBudgetList
 	if err := plugin.Client.List(ctx, &pdbl, client.MatchingLabels{utils.ClusterLabelName: clusterName}); err != nil {
-		return nil, fmt.Errorf("while extracting PodDisruptionBudgetList: %w", err)
+		fmt.Println(err)
 	}
 	// Extract the status from the instances
 	status := PostgresqlStatus{

--- a/internal/cmd/plugin/status/status.go
+++ b/internal/cmd/plugin/status/status.go
@@ -155,7 +155,8 @@ func ExtractPostgresqlStatus(ctx context.Context, clusterName string) (*Postgres
 		specs.PostgresContainerName)
 
 	var pdbl policyv1.PodDisruptionBudgetList
-	if err := plugin.Client.List(ctx, &pdbl, client.InNamespace(plugin.Namespace), client.MatchingLabels{utils.ClusterLabelName: clusterName}); err != nil {
+	if err := plugin.Client.List(ctx, &pdbl, client.InNamespace(plugin.Namespace),
+		client.MatchingLabels{utils.ClusterLabelName: clusterName}); err != nil {
 		return nil, fmt.Errorf("while extracting PodDisruptionBudgetList: %w", err)
 	}
 	// Extract the status from the instances

--- a/internal/cmd/plugin/status/status.go
+++ b/internal/cmd/plugin/status/status.go
@@ -155,8 +155,12 @@ func ExtractPostgresqlStatus(ctx context.Context, clusterName string) (*Postgres
 		specs.PostgresContainerName)
 
 	var pdbl policyv1.PodDisruptionBudgetList
-	if err := plugin.Client.List(ctx, &pdbl, client.InNamespace(plugin.Namespace),
-		client.MatchingLabels{utils.ClusterLabelName: clusterName}); err != nil {
+	if err := plugin.Client.List(
+		ctx,
+		&pdbl,
+		client.InNamespace(plugin.Namespace),
+		client.MatchingLabels{utils.ClusterLabelName: clusterName},
+	); err != nil {
 		return nil, fmt.Errorf("while extracting PodDisruptionBudgetList: %w", err)
 	}
 	// Extract the status from the instances


### PR DESCRIPTION
This PR mitigate the behavior of `kubectl cnpg status` when the user don't have sufficient rights to list  poddisruptionbudgets at the cluster scrope an error and the cnpg status output will be displayed. 


example output
```bash
❯ kubectl cnpg status -n db-test db-test  --as-group namespace-admin --as foobar
poddisruptionbudgets.policy is forbidden: User "foobar" cannot list resource "poddisruptionbudgets" in API group "policy" at the cluster scope
Cluster Summary
Name:                db-test
Namespace:           db-test
System ID:           7237111851009441825
PostgreSQL Image:    cloudnative-pg/postgresql:14.8-4
Primary instance:    db-test-1
Primary start time:  2024-04-25 16:11:26 +0000 UTC (uptime 451h23m46s)
Status:              Cluster in healthy state 
Instances:           2
Ready instances:     2
Current Write LSN:   0/31000000 (Timeline: 11 - WAL File: 0000000B0000000000000030)
<omit>
```

Fixes #4522 