### PR TITLE
fix: avoid reloading Postgres when unnecessary

### DIFF
--- a/pkg/configfile/configfile.go
+++ b/pkg/configfile/configfile.go
@@ -75,7 +75,7 @@ func UpdateConfigurationContents(lines []string, options map[string]string) ([]s
 			}
 
 			foundKeys.Put(key)
-			lines[index] = key + " = " + pq.QuoteLiteral(value)
+			lines[index] = fmt.Sprintf("%s = %s", key, pq.QuoteLiteral(value))
 			index++
 			continue
 		}

--- a/pkg/configfile/configfile.go
+++ b/pkg/configfile/configfile.go
@@ -90,7 +90,7 @@ func UpdateConfigurationContents(lines []string, options map[string]string) ([]s
 	for _, key := range keysList {
 		if !foundKeys.Has(key) {
 			value := options[key]
-			lines = append(lines, key+" = "+pq.QuoteLiteral(value))
+			lines = append(lines, fmt.Sprintf("%s = %s", key, pq.QuoteLiteral(value)))
 		}
 	}
 

--- a/pkg/configfile/configfile.go
+++ b/pkg/configfile/configfile.go
@@ -97,8 +97,8 @@ func UpdateConfigurationContents(lines []string, options map[string]string) ([]s
 	return lines, nil
 }
 
-// WritePostgresConfiguration replaces the content of a Postgres configuration file
-// with the options provided
+// WritePostgresConfiguration replaces the content of a PostgreSQL configuration
+// file with the provided options
 func WritePostgresConfiguration(
 	fileName string,
 	options map[string]string,

--- a/pkg/configfile/configfile.go
+++ b/pkg/configfile/configfile.go
@@ -86,8 +86,10 @@ func UpdateConfigurationContents(lines []string, options map[string]string) ([]s
 	lines = lines[:index]
 
 	// Append missing options to the end of the file
-	for key, value := range options {
+	keysList := stringset.FromKeys(options).ToSortedList()
+	for _, key := range keysList {
 		if !foundKeys.Has(key) {
+			value := options[key]
 			lines = append(lines, key+" = "+pq.QuoteLiteral(value))
 		}
 	}
@@ -95,9 +97,9 @@ func UpdateConfigurationContents(lines []string, options map[string]string) ([]s
 	return lines, nil
 }
 
-// WritePostgresConfigurationFile replaces the content of a Postgres configuration file
-// with the provide options
-func WritePostgresConfigurationFile(
+// WritePostgresConfiguration replaces the content of a Postgres configuration file
+// with the options provided
+func WritePostgresConfiguration(
 	fileName string,
 	options map[string]string,
 ) (changed bool, err error) {

--- a/pkg/management/postgres/configuration.go
+++ b/pkg/management/postgres/configuration.go
@@ -306,7 +306,7 @@ func configurePostgresOverrideConfFile(pgData, primaryConnInfo, slotName string)
 	}
 
 	// Ensure that override.conf file contains just the above options
-	changed, err = configfile.WritePostgresConfigurationFile(targetFile, options)
+	changed, err = configfile.WritePostgresConfiguration(targetFile, options)
 	if err != nil {
 		return false, err
 	}
@@ -474,7 +474,7 @@ func configurePostgresForImport(ctx context.Context, pgData string) (changed boo
 	}
 
 	// Ensure that override.conf file contains just the above options
-	changed, err = configfile.WritePostgresConfigurationFile(targetFile, options)
+	changed, err = configfile.WritePostgresConfiguration(targetFile, options)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/stringset/stringset.go
+++ b/pkg/stringset/stringset.go
@@ -43,6 +43,16 @@ func From(strings []string) *Data {
 	return result
 }
 
+// FromKeys create a string set from the
+// keys of a map
+func FromKeys[T any](v map[string]T) *Data {
+	result := New()
+	for key := range v {
+		result.Put(key)
+	}
+	return result
+}
+
 // Put a string in the set
 func (set *Data) Put(key string) {
 	set.innerMap[key] = struct{}{}

--- a/pkg/stringset/stringset_test.go
+++ b/pkg/stringset/stringset_test.go
@@ -63,4 +63,14 @@ var _ = Describe("String set", func() {
 			HaveExactElements("four", "one", "three", "two"))
 		Expect(New().ToList()).To(BeEmpty())
 	})
+
+	It("constructs a string set from a map having string as keys", func() {
+		Expect(FromKeys(map[string]int{
+			"one":   1,
+			"two":   2,
+			"three": 3,
+		}).ToSortedList()).To(
+			HaveExactElements("one", "three", "two"),
+		)
+	})
 })


### PR DESCRIPTION
The instance manager stores the PostgreSQL configuration inside a dictionary, mapping GUC names to their actual value.

When writing the configuration file, the code is iterating over a map. Since the iteration order is not defined, the configuration file was re-written even when the parameters didn't change.

This made the instance manager SIGHUP the postmaster every time, even if this was not needed.

This patch fixes the issue by writing the configuration file in lexicographic order.

Closes: #4529 