### PR TITLE
fix: increase the timeout for the failover/switchover tests

### DIFF
--- a/tests/e2e/fastfailover_test.go
+++ b/tests/e2e/fastfailover_test.go
@@ -51,7 +51,7 @@ var _ = Describe("Fast failover", Serial, Label(tests.LabelPerformance, tests.La
 		// on platforms like EKS, AKS, GKE and OpenShift
 		if !IsLocal() {
 			maxReattachTime = 180
-			maxFailoverTime = 20
+			maxFailoverTime = 30
 		}
 	})
 

--- a/tests/e2e/fastswitchover_test.go
+++ b/tests/e2e/fastswitchover_test.go
@@ -210,11 +210,11 @@ func assertFastSwitchover(namespace, sampleFile, clusterName, webTestFile, webTe
 	var maxReattachTime int32 = 60
 	var maxSwitchoverTime int32 = 20
 
-	// GKE has an higher kube-proxy timeout, and the connections could try
-	// using a service for which the routing table hasn't changed, getting
-	// stuck for a while. We raise the timeout, since we can't intervene
-	// on GKE configuration.
-	if IsGKE() {
+	// Due to the tcp_syn_retries having a default of 6, meaning that every connection
+	// will retry on a syn after 127 seconds, this will sometimes, delay the reconnection
+	// of the second instance waiting for a connection to be dead, this is specially happening
+	// on platforms like EKS, AKS, GKE and OpenShift
+	if !IsLocal() {
 		maxReattachTime = 180
 	}
 

--- a/tests/e2e/fastswitchover_test.go
+++ b/tests/e2e/fastswitchover_test.go
@@ -210,10 +210,12 @@ func assertFastSwitchover(namespace, sampleFile, clusterName, webTestFile, webTe
 	var maxReattachTime int32 = 60
 	var maxSwitchoverTime int32 = 20
 
-	// Due to the tcp_syn_retries having a default of 6, meaning that every connection
-	// will retry on a syn after 127 seconds, this will sometimes, delay the reconnection
-	// of the second instance waiting for a connection to be dead, this is specially happening
-	// on platforms like EKS, AKS, GKE and OpenShift
+		// The walreceiver of a standby that wasn't promoted may try to reconnect
+		// before the rw service endpoints are updated. In this case, the walreceiver
+		// can be stuck for waiting for the connection to be established for a time that
+		// depends on the tcp_syn_retries sysctl. Since by default
+		// net.ipv4.tcp_syn_retries=6, PostgreSQL can wait 2^7-1=127 seconds before
+		// restarting the walreceiver.
 	if !IsLocal() {
 		maxReattachTime = 180
 	}

--- a/tests/e2e/fastswitchover_test.go
+++ b/tests/e2e/fastswitchover_test.go
@@ -210,12 +210,12 @@ func assertFastSwitchover(namespace, sampleFile, clusterName, webTestFile, webTe
 	var maxReattachTime int32 = 60
 	var maxSwitchoverTime int32 = 20
 
-		// The walreceiver of a standby that wasn't promoted may try to reconnect
-		// before the rw service endpoints are updated. In this case, the walreceiver
-		// can be stuck for waiting for the connection to be established for a time that
-		// depends on the tcp_syn_retries sysctl. Since by default
-		// net.ipv4.tcp_syn_retries=6, PostgreSQL can wait 2^7-1=127 seconds before
-		// restarting the walreceiver.
+	// The walreceiver of a standby that wasn't promoted may try to reconnect
+	// before the rw service endpoints are updated. In this case, the walreceiver
+	// can be stuck for waiting for the connection to be established for a time that
+	// depends on the tcp_syn_retries sysctl. Since by default
+	// net.ipv4.tcp_syn_retries=6, PostgreSQL can wait 2^7-1=127 seconds before
+	// restarting the walreceiver.
 	if !IsLocal() {
 		maxReattachTime = 180
 	}


### PR DESCRIPTION
Since we know that we have a gap of 127 seconds max, between the connection
is dead and recreated on a second pod that needs to reattach, we should increase
the default timeout on any platform test that it's not local, this doesn't happens on KinD

Closes #4447 