### PR TITLE
ci: use global registry env variables

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -374,7 +374,7 @@ jobs:
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       -
-        name: Login to ghcr.io
+        name: Login into docker registry
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -823,7 +823,7 @@ jobs:
     if: |
       (always() && !cancelled()) &&
       needs.olm-bundle.result == 'success' &&
-      github.repository_owner == 'cloudnative-pg'
+      github.repository_owner == env.REPOSITORY_OWNER
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -823,7 +823,7 @@ jobs:
     if: |
       (always() && !cancelled()) &&
       needs.olm-bundle.result == 'success' &&
-      github.repository_owner == env.REPOSITORY_OWNER
+      github.repository_owner == 'cloudnative-pg'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -564,7 +564,7 @@ jobs:
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ env.REGISTRY_USER }}
-          password:  ${{ env.REGISTRY_PASSWORD }}
+          password: ${{ env.REGISTRY_PASSWORD }}
 
       - name: Build for scan distroless image
         uses: docker/build-push-action@v5
@@ -733,12 +733,12 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Login to ghcr.io
+      - name: Login into docker registry
         uses: docker/login-action@v3
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ env.REGISTRY_USER }}
+          password: ${{ env.REGISTRY_PASSWORD }}
 
       - name: Create bundle
         env:
@@ -842,12 +842,12 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Login to ghcr.io
+      - name: Login into docker registry
         uses: docker/login-action@v3
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ env.REGISTRY_USER }}
+          password: ${{ env.REGISTRY_PASSWORD }}
 
       - name: Install Go
         uses: actions/setup-go@v5
@@ -888,12 +888,12 @@ jobs:
           repository: k8s-operatorhub/community-operators
           persist-credentials: false
 
-      - name: Login to ghcr.io
+      - name: Login into docker registry
         uses: redhat-actions/podman-login@v1
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ env.REGISTRY_USER }}
+          password: ${{ env.REGISTRY_PASSWORD }}
 
       - name: Download the bundle
         uses: actions/download-artifact@v4


### PR DESCRIPTION
Let's use the globally instantiated env variables when possible instead of hardcoding the values.