### PR TITLE
ci: k8s-versions-checker should exclude alpha versions before sorting

### DIFF
--- a/.github/workflows/public-cloud-k8s-versions-check.yml
+++ b/.github/workflows/public-cloud-k8s-versions-check.yml
@@ -97,8 +97,8 @@ jobs:
           # and write them to a file, starting from the MINIMAL_K8S
           for baseversion in $(seq $MINIMAL_K8S 0.01 99); do
             URL="https://registry.hub.docker.com/v2/repositories/kindest/node/tags?name=${baseversion}&ordering=last_updated"
-            v=$(curl -SsL "${URL}" | jq -rc '.results[].name' | sort -Vr | head -n1)
-            if [[ -z "${v}" ]] || [[ "${v}" =~ "alpha" ]]; then
+            v=$(curl -SsL "${URL}" | jq -rc '.results[].name' | grep -v "alpha" | sort -Vr | head -n1)
+            if [[ -z "${v}" ]]; then
                break
             fi
             echo "${v}"


### PR DESCRIPTION
Closes #4541 