### PR TITLE
chore: stop testing on Kubernetes 1.23 and 1.24

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -68,7 +68,6 @@ body:
         - 1.27
         - 1.26
         - 1.25 (unsupported)
-        - 1.24 (unsupported)
         - other (unsupported)
     validations:
       required: true
@@ -127,4 +126,3 @@ body:
       options:
         - label: I agree to follow this project's Code of Conduct
           required: true
-

--- a/.github/k8s_versions_scope.json
+++ b/.github/k8s_versions_scope.json
@@ -1,10 +1,10 @@
 {
   "e2e_test": {
-    "KIND": {"min": "1.23", "max": ""},
-    "AKS": {"min": "1.23", "max": ""},
-    "EKS": {"min": "1.23", "max": ""},
-    "GKE": {"min": "1.23", "max": ""},
-    "OPENSHIFT": {"min":  "4.11", "max": ""}
+    "KIND": {"min": "1.25", "max": ""},
+    "AKS": {"min": "1.25", "max": ""},
+    "EKS": {"min": "1.25", "max": ""},
+    "GKE": {"min": "1.25", "max": ""},
+    "OPENSHIFT": {"min":  "4.12", "max": ""}
   },
-  "unit_test": {"min":  "1.23", "max":  "1.29"}
+  "unit_test": {"min":  "1.25", "max":  "1.29"}
 }

--- a/.github/workflows/public-cloud-k8s-versions-check.yml
+++ b/.github/workflows/public-cloud-k8s-versions-check.yml
@@ -26,7 +26,7 @@ defaults:
 
 env:
   # The minimal k8s version supported, k8s version smaller than this one will be removed from vendor
-  MINIMAL_K8S: "1.23"
+  MINIMAL_K8S: "1.25"
 
 jobs:
 

--- a/config/olm-manifests/bases/cloudnative-pg.clusterserviceversion.yaml
+++ b/config/olm-manifests/bases/cloudnative-pg.clusterserviceversion.yaml
@@ -95,7 +95,7 @@ spec:
   - cloudnativepg
   - cloudnative-pg
   - cnpg
-  minKubeVersion: 1.23.0
+  minKubeVersion: 1.25.0
   links:
   - name: CloudNativePG
     url: https://cloudnative-pg.io/

--- a/docs/src/e2e.md
+++ b/docs/src/e2e.md
@@ -5,7 +5,7 @@ commit via a suite of **End-to-end (E2E) tests** (or integration tests)
 which ensure that the operator correctly deploys and manages PostgreSQL
 clusters.
 
-Kubernetes versions 1.23 through 1.29, and PostgreSQL versions 12 through 16,
+Kubernetes versions 1.25 through 1.29, and PostgreSQL versions 12 through 16,
 are tested for each commit, helping detect bugs at an early stage of the
 development process.
 

--- a/docs/src/supported_releases.md
+++ b/docs/src/supported_releases.md
@@ -66,9 +66,9 @@ Git tags for versions are prepended with `v`.
 
 | Version         | Currently supported  | Release date      | End of life         | Supported Kubernetes versions | Tested, but not supported | Supported Postgres versions |
 |-----------------|----------------------|-------------------|---------------------|-------------------------------|---------------------------|-----------------------------|
-| 1.23.x          | Yes                  | April 24, 2024    | ~ October, 2024     | 1.27, 1.28, 1.29              | 1.23, 1.24, 1.25, 1.26    | 12 - 16                     |
-| 1.22.x          | Yes                  | December 21, 2023 | July 24, 2024       | 1.26, 1.27, 1.28              | 1.23, 1.24, 1.25, 1.29    | 12 - 16                     |
-| 1.21.x          | Yes                  | October 12, 2023  | May 24, 2024        | 1.25, 1.26, 1.27, 1.28        | 1.23, 1.24, 1.29          | 12 - 16                     |
+| 1.23.x          | Yes                  | April 24, 2024    | ~ October, 2024     | 1.27, 1.28, 1.29              | 1.25, 1.26                | 12 - 16                     |
+| 1.22.x          | Yes                  | December 21, 2023 | July 24, 2024       | 1.26, 1.27, 1.28              | 1.25, 1.29                | 12 - 16                     |
+| 1.21.x          | Yes                  | October 12, 2023  | May 24, 2024        | 1.25, 1.26, 1.27, 1.28        | 1.29                      | 12 - 16                     |
 | main            | No, development only |                   |                     |                               |                           | 12 - 16                     |
 
 The list of supported Kubernetes versions in the table depends on what


### PR DESCRIPTION
Since version 1.23 and 1.24 are way out of support we should remove those version from the test matrix and also from the tested versions.

Closes #4535 