### PR TITLE
chore(olm): downgrade minKubeVersion to 1.23

### DIFF
--- a/config/olm-manifests/bases/cloudnative-pg.clusterserviceversion.yaml
+++ b/config/olm-manifests/bases/cloudnative-pg.clusterserviceversion.yaml
@@ -95,7 +95,10 @@ spec:
   - cloudnativepg
   - cloudnative-pg
   - cnpg
-  minKubeVersion: 1.25.0
+  # This version should be keep as low as this one or at least satisfy the version
+  # that we have here https://github.com/redhat-openshift-ecosystem/community-operators-pipeline/blob/ci/latest/ci/scripts/opp.sh#L19
+  # If we change this, the kiwi test will fail
+  minKubeVersion: 1.23.0
   links:
   - name: CloudNativePG
     url: https://cloudnative-pg.io/


### PR DESCRIPTION
The kiwi test use a fixed version of Kind set to 1.23.17, hence, if we set the version to something greater than 1.23 the test will fail, setting the version of the kiwi test to something greater may fix this issue but we don't know if there will be another test or certification that has this fixed value making everything fail.