### PR TITLE
chore: add another group to renovate "operator framework"

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -360,7 +360,18 @@
 // PR group for Kubernetes CSI
       "groupName": "kubernetes CSI",
       "matchPackagePrefixes": [
-        "kubernetes-csi"
+        "kubernetes-csi",
+        "rook",
+      ],
+      "separateMajorMinor": "false",
+      "pinDigests": false
+    },
+    {
+// PR group for all the operator framework related things
+      "groupName": "operator framework",
+      "matchPackagePrefixes": [
+        "operator-framework",
+        "redhat-openshift-ecosystem",
       ],
       "separateMajorMinor": "false",
       "pinDigests": false


### PR DESCRIPTION
We have a couple of updates related to operator framework that happen at the same time, we should keep all of them in the same PR for easy management and less PRs to merge.

Also, added rook to the kubernetes csi group.