### PR TITLE
fix: allow raising replication parameters when restoring a backup

### DIFF
--- a/internal/management/controller/instance_controller.go
+++ b/internal/management/controller/instance_controller.go
@@ -394,30 +394,25 @@ func (r *InstanceReconciler) verifyParametersForFollower(cluster *apiv1.Cluster)
 		return err
 	}
 	log.Info("Found previous run flag", "filename", filename)
-	enforcedParams, err := postgresManagement.GetEnforcedParametersThroughPgControldata(r.instance.PgData)
+	controldataParams, err := postgresManagement.LoadEnforcedParametersFromPgControldata(r.instance.PgData)
+	if err != nil {
+		return err
+	}
+	clusterParams, err := postgresManagement.LoadEnforcedParametersFromCluster(cluster)
 	if err != nil {
 		return err
 	}
 
-	clusterParams := cluster.Spec.PostgresConfiguration.Parameters
 	options := make(map[string]string)
-	for key, enforcedparam := range enforcedParams {
+	for key, enforcedparam := range controldataParams {
 		clusterparam, found := clusterParams[key]
 		if !found {
 			continue
 		}
-		enforcedparamInt, err := strconv.Atoi(enforcedparam)
-		if err != nil {
-			return err
-		}
-		clusterparamInt, err := strconv.Atoi(clusterparam)
-		if err != nil {
-			return err
-		}
 		// if the values from `pg_controldata` are higher than the cluster spec,
 		// they are the safer choice, so set them in config
-		if enforcedparamInt > clusterparamInt {
-			options[key] = enforcedparam
+		if enforcedparam > clusterparam {
+			options[key] = strconv.Itoa(enforcedparam)
 		}
 	}
 	if len(options) == 0 {

--- a/pkg/management/postgres/restore.go
+++ b/pkg/management/postgres/restore.go
@@ -634,7 +634,12 @@ func (info InitInfo) writeRecoveryConfiguration(cluster *apiv1.Cluster, recovery
 		enforcedParams,
 	)
 	if changed {
-		log.Info("enforcing parameters found in pg_controldata and cluster spec", "parameters", enforcedParams)
+		log.Info(
+			"Aligned PostgreSQL configuration to satisfy both pg_controldata and cluster spec",
+			"enforcedParams", enforcedParams,
+			"controldataParams", controldataParams,
+			"clusterParams", clusterParams,
+		)
 	}
 	if err != nil {
 		return fmt.Errorf("cannot write recovery config for enforced parameters: %w", err)

--- a/pkg/management/postgres/restore.go
+++ b/pkg/management/postgres/restore.go
@@ -627,9 +627,7 @@ func (info InitInfo) writeRecoveryConfiguration(cluster *apiv1.Cluster, recovery
 	enforcedParams := make(map[string]string)
 	for _, param := range pgControldataSettingsToParamsMap {
 		value := max(clusterParams[param], controldataParams[param])
-		if value > 0 {
-			enforcedParams[param] = strconv.Itoa(value)
-		}
+		enforcedParams[param] = strconv.Itoa(value)
 	}
 	changed, err := configfile.UpdatePostgresConfigurationFile(
 		path.Join(info.PgData, constants.PostgresqlCustomConfigurationFile),

--- a/pkg/management/postgres/restore.go
+++ b/pkg/management/postgres/restore.go
@@ -698,9 +698,7 @@ func LoadEnforcedParametersFromPgControldata(pgData string) (map[string]int, err
 	return enforcedParams, nil
 }
 
-// LoadEnforcedParametersFromCluster will compare the values of the enforced parameters
-// given with the ones defined in cluster spec, choosing the higher value between the two and
-// returning the final map of enforced parameters
+// LoadEnforcedParametersFromCluster loads the enforced parameters which defined in cluster spec
 func LoadEnforcedParametersFromCluster(
 	cluster *apiv1.Cluster,
 ) (map[string]int, error) {

--- a/pkg/management/postgres/restore_test.go
+++ b/pkg/management/postgres/restore_test.go
@@ -149,15 +149,7 @@ var _ = Describe("testing restore InitInfo methods", func() {
 		Expect(chg).To(BeFalse())
 	})
 
-	It("should get higher enforced params", func() {
-		enforcedParamsInPGData := map[string]string{
-			"max_connections":           "100",
-			"max_wal_senders":           "10",
-			"max_worker_processes":      "8",
-			"max_prepared_transactions": "100",
-			"max_locks_per_transaction": "64",
-		}
-
+	It("should parse enforced params from cluster", func() {
 		cluster := &apiv1.Cluster{
 			Spec: apiv1.ClusterSpec{
 				PostgresConfiguration: apiv1.PostgresConfiguration{
@@ -170,25 +162,16 @@ var _ = Describe("testing restore InitInfo methods", func() {
 				},
 			},
 		}
-		err := updateEnforcedParametersWithUserSettings(cluster, enforcedParamsInPGData)
+		enforcedParamsInPGData, err := LoadEnforcedParametersFromCluster(cluster)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(enforcedParamsInPGData).To(HaveLen(5))
-		Expect(enforcedParamsInPGData["max_connections"]).To(Equal("200"))
-		Expect(enforcedParamsInPGData["max_wal_senders"]).To(Equal("20"))
-		Expect(enforcedParamsInPGData["max_worker_processes"]).To(Equal("18"))
-		Expect(enforcedParamsInPGData["max_prepared_transactions"]).To(Equal("100"))
-		Expect(enforcedParamsInPGData["max_locks_per_transaction"]).To(Equal("64"))
+		Expect(enforcedParamsInPGData).To(HaveLen(4))
+		Expect(enforcedParamsInPGData["max_connections"]).To(Equal(200))
+		Expect(enforcedParamsInPGData["max_wal_senders"]).To(Equal(20))
+		Expect(enforcedParamsInPGData["max_worker_processes"]).To(Equal(18))
+		Expect(enforcedParamsInPGData["max_prepared_transactions"]).To(Equal(50))
 	})
 
-	It("report error if user given one in incorrect format", func() {
-		enforcedParamsInPGData := map[string]string{
-			"max_connections":           "100",
-			"max_wal_senders":           "10",
-			"max_worker_processes":      "8",
-			"max_prepared_transactions": "100",
-			"max_locks_per_transaction": "64",
-		}
-
+	It("report error if user given one in incorrect value in the cluster", func() {
 		cluster := &apiv1.Cluster{
 			Spec: apiv1.ClusterSpec{
 				PostgresConfiguration: apiv1.PostgresConfiguration{
@@ -201,19 +184,11 @@ var _ = Describe("testing restore InitInfo methods", func() {
 				},
 			},
 		}
-		err := updateEnforcedParametersWithUserSettings(cluster, enforcedParamsInPGData)
+		_, err := LoadEnforcedParametersFromCluster(cluster)
 		Expect(err).To(HaveOccurred())
 	})
 
-	It("ingore the non-enforced params user give", func() {
-		enforcedParamsInPGData := map[string]string{
-			"max_connections":           "100",
-			"max_wal_senders":           "10",
-			"max_worker_processes":      "8",
-			"max_prepared_transactions": "100",
-			"max_locks_per_transaction": "64",
-		}
-
+	It("ignore the non-enforced params user give", func() {
 		cluster := &apiv1.Cluster{
 			Spec: apiv1.ClusterSpec{
 				PostgresConfiguration: apiv1.PostgresConfiguration{
@@ -224,13 +199,9 @@ var _ = Describe("testing restore InitInfo methods", func() {
 				},
 			},
 		}
-		err := updateEnforcedParametersWithUserSettings(cluster, enforcedParamsInPGData)
+		enforcedParamsInPGData, err := LoadEnforcedParametersFromCluster(cluster)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(enforcedParamsInPGData).To(HaveLen(5))
-		Expect(enforcedParamsInPGData["max_connections"]).To(Equal("200"))
-		Expect(enforcedParamsInPGData["max_wal_senders"]).To(Equal("10"))
-		Expect(enforcedParamsInPGData["max_worker_processes"]).To(Equal("8"))
-		Expect(enforcedParamsInPGData["max_prepared_transactions"]).To(Equal("100"))
-		Expect(enforcedParamsInPGData["max_locks_per_transaction"]).To(Equal("64"))
+		Expect(enforcedParamsInPGData).To(HaveLen(1))
+		Expect(enforcedParamsInPGData["max_connections"]).To(Equal(200))
 	})
 })


### PR DESCRIPTION
Ensure the PostgreSQL replication parameters are set to the higher value between
the ones specified in the cluster specification and the ones stored in the backup.

This will ensure that the backup will be restored correctly while allowing the users
to raise their value to accommodate changes in the configuration that have
happened after the backup was taken.

Partially closes #2478 #2337 