### PR TITLE
ci(fix): increase cpu requirements for the operator deployment

### DIFF
--- a/hack/e2e/env_override_customized.yaml.template
+++ b/hack/e2e/env_override_customized.yaml.template
@@ -24,3 +24,13 @@ spec:
         - --pprof-server=true
         livenessProbe:
           failureThreshold: ${LIVENESS_PROBE_THRESHOLD}
+        # The resources section is just something we should remove
+        # once the operator had a better way to handle the calculation
+        # of the hash of the binary files
+        resources:
+          limits:
+            cpu: 500m
+            memory: 200Mi
+          requests:
+            cpu: 500m
+            memory: 100Mi


### PR DESCRIPTION
This fix is temporary and only for the E2E tests.

This patch must be reverted before the next release,
once the operator has improved the hash calculation
of the binary files (see #4423)

