### PR TITLE
test(fix): increase ginkgo timeout on upgrade test

### DIFF
--- a/hack/e2e/run-e2e.sh
+++ b/hack/e2e/run-e2e.sh
@@ -107,7 +107,7 @@ if [[ "${TEST_UPGRADE_TO_V1}" != "false" ]] && [[ "${TEST_CLOUD_VENDOR}" != "ocp
   # Unset DEBUG to prevent k8s from spamming messages
   unset DEBUG
   unset TEST_SKIP_UPGRADE
-  ginkgo --nodes=1 --poll-progress-after=1200s --poll-progress-interval=150s --label-filter "${LABEL_FILTERS}" \
+  ginkgo --nodes=1 --timeout 90m --poll-progress-after=1200s --poll-progress-interval=150s --label-filter "${LABEL_FILTERS}" \
    --focus-file "${ROOT_DIR}/tests/e2e/upgrade_test.go" --output-dir "${ROOT_DIR}/tests/e2e/out" \
    --json-report  "upgrade_report.json" -v "${ROOT_DIR}/tests/e2e/..." || RC_GINKGO1=$?
 


### PR DESCRIPTION
During the upgrade process, every test may take 15~ minutes to run and since we run 4 tests this could be up to 1 hour, which is the default timeout for the ginkgo suite https://onsi.github.io/ginkgo/#interrupting-aborting-and-timing-out-suites we increase this timeout to give it some time to not fail if the platform is being a bit slow

Closes #4605 