### PR TITLE
chore: stop testing on Kubernetes 1.25

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -67,7 +67,6 @@ body:
         - 1.28
         - 1.27
         - 1.26
-        - 1.25 (unsupported)
         - other (unsupported)
     validations:
       required: true

--- a/.github/k8s_versions_scope.json
+++ b/.github/k8s_versions_scope.json
@@ -1,10 +1,10 @@
 {
   "e2e_test": {
-    "KIND": {"min": "1.25", "max": ""},
-    "AKS": {"min": "1.25", "max": ""},
-    "EKS": {"min": "1.25", "max": ""},
-    "GKE": {"min": "1.25", "max": ""},
+    "KIND": {"min": "1.26", "max": ""},
+    "AKS": {"min": "1.26", "max": ""},
+    "EKS": {"min": "1.26", "max": ""},
+    "GKE": {"min": "1.26", "max": ""},
     "OPENSHIFT": {"min":  "4.12", "max": ""}
   },
-  "unit_test": {"min":  "1.25", "max":  "1.29"}
+  "unit_test": {"min":  "1.26", "max":  "1.29"}
 }

--- a/.github/workflows/public-cloud-k8s-versions-check.yml
+++ b/.github/workflows/public-cloud-k8s-versions-check.yml
@@ -26,7 +26,7 @@ defaults:
 
 env:
   # The minimal k8s version supported, k8s version smaller than this one will be removed from vendor
-  MINIMAL_K8S: "1.25"
+  MINIMAL_K8S: "1.26"
 
 jobs:
 

--- a/docs/src/supported_releases.md
+++ b/docs/src/supported_releases.md
@@ -66,8 +66,8 @@ Git tags for versions are prepended with `v`.
 
 | Version         | Currently supported  | Release date      | End of life         | Supported Kubernetes versions | Tested, but not supported | Supported Postgres versions |
 |-----------------|----------------------|-------------------|---------------------|-------------------------------|---------------------------|-----------------------------|
-| 1.23.x          | Yes                  | April 24, 2024    | ~ October, 2024     | 1.27, 1.28, 1.29              | 1.25, 1.26                | 12 - 16                     |
-| 1.22.x          | Yes                  | December 21, 2023 | July 24, 2024       | 1.26, 1.27, 1.28              | 1.25, 1.29                | 12 - 16                     |
+| 1.23.x          | Yes                  | April 24, 2024    | ~ October, 2024     | 1.27, 1.28, 1.29              | 1.26                      | 12 - 16                     |
+| 1.22.x          | Yes                  | December 21, 2023 | July 24, 2024       | 1.26, 1.27, 1.28              | 1.29                      | 12 - 16                     |
 | 1.21.x          | Yes                  | October 12, 2023  | May 24, 2024        | 1.25, 1.26, 1.27, 1.28        | 1.29                      | 12 - 16                     |
 | main            | No, development only |                   |                     |                               |                           | 12 - 16                     |
 


### PR DESCRIPTION
The version 1.25 is not supported anymore by the community

Closes #4536 