### PR TITLE
test(fix): increase the short timeout

### DIFF
--- a/.github/e2e_test_timeout.json
+++ b/.github/e2e_test_timeout.json
@@ -13,7 +13,8 @@
     "walsInMinio":               60,
     "minioInstallation":         300,
     "backupIsReady":             180,
-    "drainNode":                 900
+    "drainNode":                 900,
+    "short":                     5
   },
   "aks": {
     "failover":                  240,

--- a/.github/e2e_test_timeout.json
+++ b/.github/e2e_test_timeout.json
@@ -1,7 +1,7 @@
 {
   "local": {
-    "failover": 240,
-    "namespaceCreation": 30,
+    "failover":                  240,
+    "namespaceCreation":         30,
     "clusterIsReady":            600,
     "clusterIsReadyQuick":       300,
     "clusterIsReadySlow":        800,
@@ -16,8 +16,8 @@
     "drainNode":                 900
   },
   "aks": {
-    "failover": 240,
-    "namespaceCreation": 30,
+    "failover":                  240,
+    "namespaceCreation":         30,
     "clusterIsReady":            600,
     "clusterIsReadyQuick":       300,
     "clusterIsReadySlow":        800,
@@ -33,8 +33,8 @@
     "short":                     10
   },
   "eks": {
-    "failover": 240,
-    "namespaceCreation": 30,
+    "failover":                  240,
+    "namespaceCreation":         30,
     "clusterIsReady":            600,
     "clusterIsReadyQuick":       300,
     "clusterIsReadySlow":        800,
@@ -50,8 +50,8 @@
     "short":                     10
   },
   "gke": {
-    "failover": 240,
-    "namespaceCreation": 30,
+    "failover":                  240,
+    "namespaceCreation":         30,
     "clusterIsReady":            600,
     "clusterIsReadyQuick":       300,
     "clusterIsReadySlow":        800,
@@ -67,8 +67,8 @@
     "short":                     10
   },
   "openshift": {
-    "failover": 240,
-    "namespaceCreation": 30,
+    "failover":                  240,
+    "namespaceCreation":         30,
     "clusterIsReady":            600,
     "clusterIsReadyQuick":       300,
     "clusterIsReadySlow":        800,

--- a/.github/e2e_test_timeout.json
+++ b/.github/e2e_test_timeout.json
@@ -59,6 +59,7 @@
     "newPrimaryAfterFailover":   30,
     "newTargetOnFailover":       120,
     "operatorIsReady":           120,
+    "podRollout": 180,
     "largeObject":               300,
     "walsInMinio":               60,
     "minioInstallation":         300,

--- a/.github/e2e_test_timeout.json
+++ b/.github/e2e_test_timeout.json
@@ -29,7 +29,8 @@
     "walsInMinio":               60,
     "minioInstallation":         300,
     "backupIsReady":             180,
-    "drainNode":                 900
+    "drainNode":                 900,
+    "short": 10
   },
   "eks": {
     "failover": 240,
@@ -45,7 +46,8 @@
     "walsInMinio":               60,
     "minioInstallation":         300,
     "backupIsReady":             180,
-    "drainNode":                 900
+    "drainNode":                 900,
+    "short": 10
   },
   "gke": {
     "failover": 240,
@@ -61,7 +63,8 @@
     "walsInMinio":               60,
     "minioInstallation":         300,
     "backupIsReady":             180,
-    "drainNode":                 900
+    "drainNode":                 900,
+    "short": 10
   },
   "openshift": {
     "failover": 240,
@@ -77,6 +80,7 @@
     "walsInMinio":               60,
     "minioInstallation":         300,
     "backupIsReady":             180,
-    "drainNode":                 900
+    "drainNode":                 900,
+    "short": 10
   }
 }

--- a/.github/e2e_test_timeout.json
+++ b/.github/e2e_test_timeout.json
@@ -30,7 +30,7 @@
     "minioInstallation":         300,
     "backupIsReady":             180,
     "drainNode":                 900,
-    "short": 10
+    "short":                     10
   },
   "eks": {
     "failover": 240,
@@ -47,7 +47,7 @@
     "minioInstallation":         300,
     "backupIsReady":             180,
     "drainNode":                 900,
-    "short": 10
+    "short":                     10
   },
   "gke": {
     "failover": 240,
@@ -59,13 +59,12 @@
     "newPrimaryAfterFailover":   30,
     "newTargetOnFailover":       120,
     "operatorIsReady":           120,
-    "podRollout": 180,
     "largeObject":               300,
     "walsInMinio":               60,
     "minioInstallation":         300,
     "backupIsReady":             180,
     "drainNode":                 900,
-    "short": 10
+    "short":                     10
   },
   "openshift": {
     "failover": 240,
@@ -82,6 +81,6 @@
     "minioInstallation":         300,
     "backupIsReady":             180,
     "drainNode":                 900,
-    "short": 10
+    "short":                     10
   }
 }

--- a/contribute/e2e_testing_environment/README.md
+++ b/contribute/e2e_testing_environment/README.md
@@ -203,7 +203,7 @@ exported, it will select all medium test cases from the feature type provided.
 | `storage`                         |
 | `security`                        |
 | `maintenance`                     |
-| `prometheus`                      |
+| `tablespaces`                     |
 
 ex:
 ```shell

--- a/pkg/utils/logs/cluster_logs.go
+++ b/pkg/utils/logs/cluster_logs.go
@@ -19,12 +19,12 @@ package logs
 import (
 	"context"
 	"io"
-	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	"log"
 	"sync"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	ctrl "sigs.k8s.io/controller-runtime"

--- a/pkg/utils/logs/cluster_logs.go
+++ b/pkg/utils/logs/cluster_logs.go
@@ -224,8 +224,10 @@ func (csr *ClusterStreamingRequest) streamInGoroutine(
 		csr.getLogOptions())
 
 	logStream, err := logsRequest.Stream(ctx)
-	if err != nil && !apierrs.IsBadRequest(err) {
+	if err != nil {
 		log.Printf("error on streaming request, pod %s: %v", podName, err)
+		return
+	} else if apierrs.IsBadRequest(err) {
 		return
 	}
 	defer func() {

--- a/pkg/utils/logs/cluster_logs.go
+++ b/pkg/utils/logs/cluster_logs.go
@@ -19,6 +19,7 @@ package logs
 import (
 	"context"
 	"io"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	"log"
 	"sync"
 	"time"
@@ -223,7 +224,7 @@ func (csr *ClusterStreamingRequest) streamInGoroutine(
 		csr.getLogOptions())
 
 	logStream, err := logsRequest.Stream(ctx)
-	if err != nil {
+	if err != nil && !apierrs.IsBadRequest(err) {
 		log.Printf("error on streaming request, pod %s: %v", podName, err)
 		return
 	}

--- a/tests/utils/timeouts.go
+++ b/tests/utils/timeouts.go
@@ -73,7 +73,7 @@ var DefaultTestTimeouts = map[Timeout]int{
 	Short:                     5,
 }
 
-// Timeouts returns the map of timeouts, where each event gets the timeout specificed
+// Timeouts returns the map of timeouts, where each event gets the timeout specified
 // in the `TEST_TIMEOUTS` environment variable, or if not specified, takes the default
 // value
 func Timeouts() (map[Timeout]int, error) {

--- a/tests/utils/timeouts.go
+++ b/tests/utils/timeouts.go
@@ -62,7 +62,7 @@ var DefaultTestTimeouts = map[Timeout]int{
 	NewPrimaryAfterSwitchover: 45,
 	NewPrimaryAfterFailover:   30,
 	NewTargetOnFailover:       120,
-	PodRollout:                120,
+	PodRollout:                180,
 	OperatorIsReady:           120,
 	LargeObject:               300,
 	WalsInMinio:               60,


### PR DESCRIPTION
The short timeout that is only used on tablespaces tests it was by default set to
5 seconds, this is a bit too short and it was producing some failures in some of
the cloud environment tests.

Also, we stop logging errors that aren't errors at all while getting the pod logs.

Closes #4606 