### PR TITLE
chore: stop testing on Kubernetes 1.26

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -66,7 +66,6 @@ body:
         - 1.29
         - 1.28
         - 1.27
-        - 1.26
         - other (unsupported)
     validations:
       required: true

--- a/.github/k8s_versions_scope.json
+++ b/.github/k8s_versions_scope.json
@@ -1,10 +1,10 @@
 {
   "e2e_test": {
-    "KIND": {"min": "1.26", "max": ""},
-    "AKS": {"min": "1.26", "max": ""},
-    "EKS": {"min": "1.26", "max": ""},
-    "GKE": {"min": "1.26", "max": ""},
+    "KIND": {"min": "1.27", "max": ""},
+    "AKS": {"min": "1.27", "max": ""},
+    "EKS": {"min": "1.27", "max": ""},
+    "GKE": {"min": "1.27", "max": ""},
     "OPENSHIFT": {"min":  "4.12", "max": ""}
   },
-  "unit_test": {"min":  "1.26", "max":  "1.29"}
+  "unit_test": {"min":  "1.27", "max":  "1.29"}
 }

--- a/.github/workflows/public-cloud-k8s-versions-check.yml
+++ b/.github/workflows/public-cloud-k8s-versions-check.yml
@@ -26,7 +26,7 @@ defaults:
 
 env:
   # The minimal k8s version supported, k8s version smaller than this one will be removed from vendor
-  MINIMAL_K8S: "1.26"
+  MINIMAL_K8S: "1.27"
 
 jobs:
 

--- a/contribute/e2e_testing_environment/README.md
+++ b/contribute/e2e_testing_environment/README.md
@@ -58,7 +58,7 @@ All flags have corresponding environment variables labeled `(Env:...` in the tab
 |-------|-------------------------------------------------------------------------------------------------------------------------------|
 | -r    |--registry                       | Enable local registry. (Env: `ENABLE_REGISTRY`)                                                                               |
 | -e    |--engine <CLUSTER_ENGINE>        | Use the provided ENGINE to run the cluster. Available options are 'kind' and 'k3d'. Default 'kind'. (Env: `CLUSTER_ENGINE`)   |
-| -k    |--k8s-version <K8S_VERSION>      | Use the specified Kubernetes full version number (e.g., `-k v1.26.0`). (Env: `K8S_VERSION`)                                   |
+| -k    |--k8s-version <K8S_VERSION>      | Use the specified Kubernetes full version number (e.g., `-k v1.30.0`). (Env: `K8S_VERSION`)                                   |
 | -n    |--nodes <NODES>                  | Create a cluster with the required number of nodes. Used only during "create" command. Default: 3 (Env: `NODES`)              |
 
 
@@ -287,7 +287,7 @@ the following ones can be defined:
   Default: `false`
 * `PRESERVE_NAMESPACES`: space separated list of namespace to be kept after
   the tests. Only useful if specified with `PRESERVE_CLUSTER=true`
-* `K8S_VERSION`: the version of K8s to run. Default: `v1.26.0`
+* `K8S_VERSION`: the version of K8s to run. Default: `v1.30.0`
 * `KIND_VERSION`: the version of `kind`. Defaults to the latest release
 * `BUILD_IMAGE`: true to build the Dockerfile and load it on kind,
   false to get the image from a registry. Default: `false`

--- a/docs/src/supported_releases.md
+++ b/docs/src/supported_releases.md
@@ -66,7 +66,7 @@ Git tags for versions are prepended with `v`.
 
 | Version         | Currently supported  | Release date      | End of life         | Supported Kubernetes versions | Tested, but not supported | Supported Postgres versions |
 |-----------------|----------------------|-------------------|---------------------|-------------------------------|---------------------------|-----------------------------|
-| 1.23.x          | Yes                  | April 24, 2024    | ~ October, 2024     | 1.27, 1.28, 1.29              | 1.26                      | 12 - 16                     |
+| 1.23.x          | Yes                  | April 24, 2024    | ~ October, 2024     | 1.27, 1.28, 1.29              |                           | 12 - 16                     |
 | 1.22.x          | Yes                  | December 21, 2023 | July 24, 2024       | 1.26, 1.27, 1.28              | 1.29                      | 12 - 16                     |
 | 1.21.x          | Yes                  | October 12, 2023  | May 24, 2024        | 1.25, 1.26, 1.27, 1.28        | 1.29                      | 12 - 16                     |
 | main            | No, development only |                   |                     |                               |                           | 12 - 16                     |


### PR DESCRIPTION
The version 1.26 is not supported anymore by the community

Closes #4537 