### PR TITLE
chore: add `Homebrew` to `.wordlist`

### DIFF
--- a/.wordlist-en-custom.txt
+++ b/.wordlist-en-custom.txt
@@ -165,6 +165,7 @@ Grafana
 HH
 HashiCorp
 HistoryTags
+Homebrew
 Huß
 IAM
 INPLACE


### PR DESCRIPTION
This patch fixes the current issue on `main` in the spellcheck stage by adding `Homebrew` to the allowed words.

Reference: https://github.com/cloudnative-pg/cloudnative-pg/actions/runs/9170976673/job/25214308743