### PR TITLE
Use proper timezone in the timestamp received from barman-cloud-backup-list

### DIFF
--- a/pkg/management/catalog/catalog.go
+++ b/pkg/management/catalog/catalog.go
@@ -219,13 +219,15 @@ type BarmanBackup struct {
 	// The backup label
 	Label string `json:"backup_label"`
 
-	// The moment where the backup started
+	// The moment where the backup started, this value is retrieved from barman command output
+	// and is in the format "Mon Jan 2 15:04:05 2006" with the timezone being the local one
 	BeginTimeString string `json:"begin_time"`
 
-	// The moment where the backup ended
+	// The moment where the backup ended, his value is retrieved from barman command output
+	// and is in the format "Mon Jan 2 15:04:05 2006" with the timezone being the local one
 	EndTimeString string `json:"end_time"`
 
-	// The moment where the backup ended
+	// The moment where the backup started
 	BeginTime time.Time
 
 	// The moment where the backup ended
@@ -281,21 +283,19 @@ func (b *BarmanBackup) deserializeBackupTimeStrings() error {
 	const (
 		barmanTimeLayout = "Mon Jan 2 15:04:05 2006"
 	)
-
+	var err error
 	if b.BeginTimeString != "" {
-		ts, err := time.Parse(barmanTimeLayout, b.BeginTimeString)
+		b.BeginTime, err = time.ParseInLocation(barmanTimeLayout, b.BeginTimeString, time.Local)
 		if err != nil {
 			return err
 		}
-		b.BeginTime = time.Date(ts.Year(), ts.Month(), ts.Day(), ts.Hour(), ts.Minute(), ts.Second(), ts.Nanosecond(), time.Local)
 	}
 
 	if b.EndTimeString != "" {
-		ts, err := time.Parse(barmanTimeLayout, b.EndTimeString)
+		b.EndTime, err = time.ParseInLocation(barmanTimeLayout, b.EndTimeString, time.Local)
 		if err != nil {
 			return err
 		}
-		b.EndTime = time.Date(ts.Year(), ts.Month(), ts.Day(), ts.Hour(), ts.Minute(), ts.Second(), ts.Nanosecond(), time.Local)
 	}
 
 	return nil

--- a/pkg/management/catalog/catalog.go
+++ b/pkg/management/catalog/catalog.go
@@ -282,19 +282,20 @@ func (b *BarmanBackup) deserializeBackupTimeStrings() error {
 		barmanTimeLayout = "Mon Jan 2 15:04:05 2006"
 	)
 
-	var err error
 	if b.BeginTimeString != "" {
-		b.BeginTime, err = time.Parse(barmanTimeLayout, b.BeginTimeString)
+		ts, err := time.Parse(barmanTimeLayout, b.BeginTimeString)
 		if err != nil {
 			return err
 		}
+		b.BeginTime = time.Date(ts.Year(), ts.Month(), ts.Day(), ts.Hour(), ts.Minute(), ts.Second(), ts.Nanosecond(), time.Local)
 	}
 
 	if b.EndTimeString != "" {
-		b.EndTime, err = time.Parse(barmanTimeLayout, b.EndTimeString)
+		ts, err := time.Parse(barmanTimeLayout, b.EndTimeString)
 		if err != nil {
 			return err
 		}
+		b.EndTime = time.Date(ts.Year(), ts.Month(), ts.Day(), ts.Hour(), ts.Minute(), ts.Second(), ts.Nanosecond(), time.Local)
 	}
 
 	return nil

--- a/pkg/management/catalog/catalog_test.go
+++ b/pkg/management/catalog/catalog_test.go
@@ -250,4 +250,39 @@ var _ = Describe("barman-cloud-backup-show parsing", func() {
 		Expect(result.BeginTime.Location()).To(Equal(time.Now().Location()))
 		Expect(result.EndTime.Location()).To(Equal(time.Now().Location()))
 	})
+
+	It("parses valid begin and end time strings correctly", func() {
+		backup := &BarmanBackup{
+			BeginTimeString: "Mon Jan 2 15:04:05 2006",
+			EndTimeString:   "Tue Jan 3 15:04:05 2006",
+		}
+		err := backup.deserializeBackupTimeStrings()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(backup.BeginTime).To(Equal(time.Date(2006, time.January, 2, 15, 4, 5, 0, time.Local)))
+		Expect(backup.EndTime).To(Equal(time.Date(2006, time.January, 3, 15, 4, 5, 0, time.Local)))
+	})
+
+	It("returns an error for invalid begin time string", func() {
+		backup := &BarmanBackup{
+			BeginTimeString: "invalid time string",
+		}
+		err := backup.deserializeBackupTimeStrings()
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("returns an error for invalid end time string", func() {
+		backup := &BarmanBackup{
+			EndTimeString: "invalid time string",
+		}
+		err := backup.deserializeBackupTimeStrings()
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("handles empty begin and end time strings gracefully", func() {
+		backup := &BarmanBackup{}
+		err := backup.deserializeBackupTimeStrings()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(backup.BeginTime.IsZero()).To(BeTrue())
+		Expect(backup.EndTime.IsZero()).To(BeTrue())
+	})
 })

--- a/pkg/management/catalog/catalog_test.go
+++ b/pkg/management/catalog/catalog_test.go
@@ -245,5 +245,9 @@ var _ = Describe("barman-cloud-backup-show parsing", func() {
 		Expect(result.SystemID).To(Equal("6885668674852188181"))
 		Expect(result.BeginTimeString).To(Equal("Tue Jan 19 03:14:08 2038"))
 		Expect(result.EndTimeString).To(Equal("Tue Jan 19 04:14:08 2038"))
+
+		// Test timezone set in the parsed time is equal to local one
+		Expect(result.BeginTime.Location()).To(Equal(time.Now().Location()))
+		Expect(result.EndTime.Location()).To(Equal(time.Now().Location()))
 	})
 })


### PR DESCRIPTION
`barman-cloud-backup-list` utility returns timestamps in JSON in ctime format which is a naive format while cnpg parses it as UTC.

Closes #4688 