### PR TITLE
fix: stop logging about missing sync replicas when not required

### DIFF
--- a/api/v1/cluster_configuration.go
+++ b/api/v1/cluster_configuration.go
@@ -30,6 +30,12 @@ func (cluster *Cluster) GetSyncReplicasData() (syncReplicas int, electableSyncRe
 	// Formula: 1 <= minSyncReplicas <= SyncReplicas <= maxSyncReplicas < readyReplicas
 	readyReplicas := len(cluster.Status.InstancesStatus[utils.PodHealthy]) - 1
 
+	// If the number of ready replicas is negative,
+	// there are no healthy Pods so no sync replica can be configured
+	if readyReplicas < 0 {
+		return 0, nil
+	}
+
 	// Initially set it to the max sync replicas requested by user
 	syncReplicas = cluster.Spec.MaxSyncReplicas
 

--- a/api/v1/cluster_configuration_test.go
+++ b/api/v1/cluster_configuration_test.go
@@ -79,4 +79,18 @@ var _ = Describe("ensuring the correctness of synchronous replica data calculati
 		Expect(names).To(BeEmpty())
 		Expect(cluster.Spec.MinSyncReplicas).To(Equal(1))
 	})
+
+	It("should behave correctly if there is no ready host", func() {
+		cluster := createFakeCluster("example")
+		cluster.Status = ClusterStatus{
+			CurrentPrimary: "example-1",
+			InstancesStatus: map[utils.PodStatus][]string{
+				utils.PodFailed: {"example-1", "example-2", "example-3"},
+			},
+		}
+		number, names := cluster.GetSyncReplicasData()
+
+		Expect(number).To(BeZero())
+		Expect(names).To(BeEmpty())
+	})
 })

--- a/api/v1/cluster_configuration_test.go
+++ b/api/v1/cluster_configuration_test.go
@@ -33,12 +33,12 @@ var _ = Describe("ensuring the correctness of synchronous replica data calculati
 
 	It("should return only the pod in the different AZ", func() {
 		const (
-			primaryPod     = "example-1"
-			sameZonePod    = "example-2"
-			differentAZPod = "example-3"
+			primaryPod     = "exampleAntiAffinity-1"
+			sameZonePod    = "exampleAntiAffinity-2"
+			differentAZPod = "exampleAntiAffinity-3"
 		)
 
-		cluster := createFakeCluster("example")
+		cluster := createFakeCluster("exampleAntiAffinity")
 		cluster.Spec.PostgresConfiguration.SyncReplicaElectionConstraint = SyncReplicaElectionConstraints{
 			Enabled:                true,
 			NodeLabelsAntiAffinity: []string{"az"},
@@ -65,12 +65,12 @@ var _ = Describe("ensuring the correctness of synchronous replica data calculati
 	})
 
 	It("should lower the synchronous replica number to enforce self-healing", func() {
-		cluster := createFakeCluster("example")
+		cluster := createFakeCluster("exampleOnePod")
 		cluster.Status = ClusterStatus{
-			CurrentPrimary: "example-1",
+			CurrentPrimary: "exampleOnePod-1",
 			InstancesStatus: map[utils.PodStatus][]string{
-				utils.PodHealthy: {"example-1"},
-				utils.PodFailed:  {"example-2", "example-3"},
+				utils.PodHealthy: {"exampleOnePod-1"},
+				utils.PodFailed:  {"exampleOnePod-2", "exampleOnePod-3"},
 			},
 		}
 		number, names := cluster.GetSyncReplicasData()
@@ -81,11 +81,11 @@ var _ = Describe("ensuring the correctness of synchronous replica data calculati
 	})
 
 	It("should behave correctly if there is no ready host", func() {
-		cluster := createFakeCluster("example")
+		cluster := createFakeCluster("exampleNoPods")
 		cluster.Status = ClusterStatus{
 			CurrentPrimary: "example-1",
 			InstancesStatus: map[utils.PodStatus][]string{
-				utils.PodFailed: {"example-1", "example-2", "example-3"},
+				utils.PodFailed: {"exampleNoPods-1", "exampleNoPods-2", "exampleNoPods-3"},
 			},
 		}
 		number, names := cluster.GetSyncReplicasData()


### PR DESCRIPTION
Closes #4634 