### PR TITLE
fix: avoid conflicts when registering phases

### DIFF
--- a/controllers/cluster_status.go
+++ b/controllers/cluster_status.go
@@ -715,7 +715,7 @@ func (r *ClusterReconciler) RegisterPhase(ctx context.Context,
 		cluster.Status.Conditions = []metav1.Condition{}
 	}
 
-	existingClusterStatus := cluster.Status
+	existingCluster := cluster.DeepCopy()
 	cluster.Status.Phase = phase
 	cluster.Status.PhaseReason = reason
 
@@ -737,8 +737,8 @@ func (r *ClusterReconciler) RegisterPhase(ctx context.Context,
 
 	meta.SetStatusCondition(&cluster.Status.Conditions, condition)
 
-	if !reflect.DeepEqual(existingClusterStatus, cluster.Status) {
-		if err := r.Status().Update(ctx, cluster); err != nil {
+	if !reflect.DeepEqual(existingCluster, cluster) {
+		if err := r.Status().Patch(ctx, cluster, client.MergeFrom(existingCluster)); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
In a few code paths of the operator, we are changing the phase multiple times.
This is generating a conflict that can avoided by patching the status instead of updating it.

Closes: #4636 