### PR TITLE
fix: switch to manual build mode in CodeQL action

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -62,13 +62,6 @@ jobs:
       contents: read
       security-events: write
 
-    strategy:
-      fail-fast: false
-      matrix:
-        language: [ 'go' ]
-        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
-        # Learn more about CodeQL language support at https://git.io/codeql-language-support
-
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
@@ -83,27 +76,21 @@ jobs:
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3
       with:
-        languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-        # queries: ./path/to/local/query, your-org/your-repo/queries@main
+        languages: "go"
+        build-mode: manual
+        config: |
+          paths-ignore:
+            - licenses/
+            - tests/
 
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v3
-
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 https://git.io/JvXDl
-
-    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
-    #    and modify them (or add more) to build your code if your project
-    #    uses a compiled language
-
-    #- run: |
-    #   make bootstrap
-    #   make release
+    # Even if we build manually the testing those will not be included in the CodeQL scan
+    # We will always have less files, this improves the speed of the test since it will
+    # not try to build running multiple commands.
+    - name: Build
+      run: |
+        make
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3
+      with:
+        category: "/language:go"


### PR DESCRIPTION
Switching to manual build process for the CodeQL action will increase the line of code that is scanned by CodeQL as is specified here: https://docs.github.com/en/code-security/code-scanning/troubleshooting-code-scanning/fewer-lines-scanned-than-expected

Closes #4633 