### PR TITLE
test(fix): improve readability of some errors during upgrade E2E test

### DIFF
--- a/tests/e2e/upgrade_test.go
+++ b/tests/e2e/upgrade_test.go
@@ -191,8 +191,15 @@ var _ = Describe("Upgrade", Label(tests.LabelUpgrade, tests.LabelNoOpenshift), O
 				Eventually(func() (int, error, error) {
 					stdout, _, err := env.ExecCommand(env.Ctx, pod, specs.PostgresContainerName, &commandTimeout,
 						"psql", "-U", "postgres", "-tAc", "show max_replication_slots")
-					value, atoiErr := strconv.Atoi(strings.Trim(stdout, "\n"))
-					return value, err, atoiErr
+					if err != nil {
+						return 0, err, nil
+					}
+					replicaSlot := strings.Trim(stdout, "\n")
+					if len(replicaSlot) > 0 {
+						value, atoiErr := strconv.Atoi(replicaSlot)
+						return value, err, atoiErr
+					}
+					return 0, fmt.Errorf("replica slot value empty"), nil
 				}, timeout).Should(BeEquivalentTo(16),
 					"Pod %v should have updated its config", pod.Name)
 


### PR DESCRIPTION
When there is a failure extracting the `max_replication_slots` from the instance, the Atoi invocations will return an obscure "invalid syntax".
With this patch, we display a meaningful message and any message printed on standard error.