### PR TITLE
test(e2e): fix backup failures for replica mode

### DIFF
--- a/tests/e2e/asserts_test.go
+++ b/tests/e2e/asserts_test.go
@@ -868,22 +868,20 @@ func getScheduledBackupCompleteBackupsCount(namespace string, scheduledBackupNam
 // AssertPgRecoveryMode verifies if the postgres recovery mode is enabled or disabled
 func AssertPgRecoveryMode(namespace, clusterName string, expectedValue bool) {
 	By(fmt.Sprintf("verifying that postgres recovery mode is %v", expectedValue), func() {
-		var stringExpectedValue string
+		stringExpectedValue := "f"
 		if expectedValue {
 			stringExpectedValue = "t"
-		} else {
-			stringExpectedValue = "f"
 		}
 
-		var err error
 		var primaryPod *corev1.Pod
 		Eventually(func() error {
+			var err error
 			primaryPod, err = env.GetClusterPrimary(namespace, clusterName)
 			return err
 		}, 180, 10).Should(BeNil())
 
-		commandTimeout := time.Second * 10
 		Eventually(func() (string, error) {
+			commandTimeout := time.Second * 10
 			stdOut, _, err := env.ExecCommand(env.Ctx, *primaryPod, specs.PostgresContainerName, &commandTimeout,
 				"psql", "-U", "postgres", "postgres", "-tAc", "select pg_is_in_recovery();")
 			return strings.Trim(stdOut, "\n"), err

--- a/tests/e2e/fixtures/metrics/custom-queries-for-replica-cluster.yaml
+++ b/tests/e2e/fixtures/metrics/custom-queries-for-replica-cluster.yaml
@@ -6,11 +6,11 @@ metadata:
     e2e: metrics
 data:
   queries.yaml: |
-    replica_test:
+    metrics_replica_mode:
       query: |
-        SELECT count(*) as row_count FROM test_replica
+        SELECT count(*) as row_count FROM metrics_replica_mode
       primary: false
       metrics:
         - row_count:
             usage: "GAUGE"
-            description: "Number of rows present in test_replica table"
+            description: "Number of rows present in metrics_replica_mode table"

--- a/tests/e2e/metrics_test.go
+++ b/tests/e2e/metrics_test.go
@@ -331,13 +331,11 @@ var _ = Describe("Metrics", Label(tests.LabelObservability), func() {
 		AssertCreateCluster(namespace, srcClusterName, srcClusterSampleFile, env)
 
 		// Create the replica Cluster
-		checkQuery := fmt.Sprintf("SELECT count(*) FROM %v", testTableName)
 		AssertReplicaModeCluster(
 			namespace,
 			srcClusterName,
 			srcClusterDatabaseName,
 			replicaClusterSampleFile,
-			checkQuery,
 			testTableName,
 			psqlClientPod)
 

--- a/tests/e2e/metrics_test.go
+++ b/tests/e2e/metrics_test.go
@@ -292,14 +292,14 @@ var _ = Describe("Metrics", Label(tests.LabelObservability), func() {
 
 	It("execute custom queries against the application database on replica clusters", func() {
 		const (
+			namespacePrefix          = "metrics-with-replica-mode"
 			replicaModeClusterDir    = "/replica_mode_cluster/"
 			replicaClusterSampleFile = fixturesDir + "/metrics/cluster-replica-tls-with-metrics.yaml.template"
 			srcClusterSampleFile     = fixturesDir + replicaModeClusterDir + "cluster-replica-src.yaml.template"
+			srcClusterDatabaseName   = "appSrc"
 			configMapFIle            = fixturesDir + "/metrics/custom-queries-for-replica-cluster.yaml"
-			checkQuery               = "SELECT count(*) FROM test_replica"
+			testTableName            = "metrics_replica_mode"
 		)
-
-		const namespacePrefix = "metrics-with-replica-mode"
 
 		// Fetching the source cluster name
 		srcClusterName, err := env.GetResourceNameFromYAML(srcClusterSampleFile)
@@ -331,15 +331,18 @@ var _ = Describe("Metrics", Label(tests.LabelObservability), func() {
 		AssertCreateCluster(namespace, srcClusterName, srcClusterSampleFile, env)
 
 		// Create the replica Cluster
+		checkQuery := fmt.Sprintf("SELECT count(*) FROM %v", testTableName)
 		AssertReplicaModeCluster(
 			namespace,
 			srcClusterName,
+			srcClusterDatabaseName,
 			replicaClusterSampleFile,
 			checkQuery,
+			testTableName,
 			psqlClientPod)
 
-		By("grant select permission for test_replica table to pg_monitor", func() {
-			cmd := "GRANT SELECT ON test_replica TO pg_monitor"
+		By(fmt.Sprintf("grant select permission for %v table to pg_monitor", testTableName), func() {
+			cmd := fmt.Sprintf("GRANT SELECT ON %v TO pg_monitor", testTableName)
 			appUser, appUserPass, err := utils.GetCredentials(srcClusterName, namespace, apiv1.ApplicationUserSecretSuffix, env)
 			Expect(err).ToNot(HaveOccurred())
 			host, err := utils.GetHostName(namespace, srcClusterName, env)
@@ -347,7 +350,7 @@ var _ = Describe("Metrics", Label(tests.LabelObservability), func() {
 			_, _, err = utils.RunQueryFromPod(
 				psqlClientPod,
 				host,
-				"appSrc",
+				srcClusterDatabaseName,
 				appUser,
 				appUserPass,
 				cmd,
@@ -359,11 +362,12 @@ var _ = Describe("Metrics", Label(tests.LabelObservability), func() {
 			podList, err := env.GetClusterPodList(namespace, replicaClusterName)
 			Expect(err).ToNot(HaveOccurred())
 			// Gather metrics in each pod
+			expectedMetric := fmt.Sprintf("cnpg_%v_row_count 3", testTableName)
 			for _, pod := range podList.Items {
 				podIP := pod.Status.PodIP
 				out, err := utils.CurlGetMetrics(namespace, curlPodName, podIP, 9187)
 				Expect(err).Should(Not(HaveOccurred()))
-				Expect(strings.Split(out, "\n")).Should(ContainElement("cnpg_replica_test_row_count 3"))
+				Expect(strings.Split(out, "\n")).Should(ContainElement(expectedMetric))
 			}
 		})
 		collectAndAssertDefaultMetricsPresentOnEachPod(namespace, replicaClusterName, curlPodName, true)

--- a/tests/e2e/replica_mode_cluster_test.go
+++ b/tests/e2e/replica_mode_cluster_test.go
@@ -81,13 +81,11 @@ var _ = Describe("Replica Mode", Label(tests.LabelReplication), func() {
 			})
 			AssertCreateCluster(replicaNamespace, srcClusterName, srcClusterSample, env)
 
-			checkQuery := fmt.Sprintf("SELECT count(*) FROM %v", testTableName)
 			AssertReplicaModeCluster(
 				replicaNamespace,
 				srcClusterName,
 				sourceDBName,
 				replicaClusterSampleTLS,
-				checkQuery,
 				testTableName,
 				psqlClientPod)
 		})
@@ -113,13 +111,11 @@ var _ = Describe("Replica Mode", Label(tests.LabelReplication), func() {
 			})
 			AssertCreateCluster(replicaNamespace, srcClusterName, srcClusterSample, env)
 
-			checkQuery := fmt.Sprintf("SELECT count(*) FROM %v", testTableName)
 			AssertReplicaModeCluster(
 				replicaNamespace,
 				srcClusterName,
 				sourceDBName,
 				replicaClusterSampleBasicAuth,
-				checkQuery,
 				testTableName,
 				psqlClientPod)
 
@@ -164,13 +160,11 @@ var _ = Describe("Replica Mode", Label(tests.LabelReplication), func() {
 			})
 			AssertCreateCluster(namespace, clusterOneName, clusterOneFile, env)
 
-			checkQuery := fmt.Sprintf("SELECT count(*) FROM %v", testTableName)
 			AssertReplicaModeCluster(
 				namespace,
 				clusterOneName,
 				sourceDBName,
 				clusterTwoFile,
-				checkQuery,
 				testTableName,
 				psqlClientPod)
 
@@ -254,13 +248,11 @@ var _ = Describe("Replica Mode", Label(tests.LabelReplication), func() {
 
 			AssertCreateCluster(replicaNamespace, srcClusterName, srcClusterSample, env)
 
-			checkQuery := fmt.Sprintf("SELECT count(*) FROM %v", testTableName)
 			AssertReplicaModeCluster(
 				replicaNamespace,
 				srcClusterName,
 				sourceDBName,
 				replicaClusterSample,
-				checkQuery,
 				testTableName,
 				psqlClientPod)
 
@@ -347,13 +339,11 @@ var _ = Describe("Replica Mode", Label(tests.LabelReplication), func() {
 			})
 
 			By("creating a replica cluster from the backup", func() {
-				checkQuery := fmt.Sprintf("SELECT count(*) FROM %v", testTableName)
 				AssertReplicaModeCluster(
 					namespace,
 					clusterName,
 					sourceDBName,
 					replicaClusterSample,
-					checkQuery,
 					testTableName,
 					psqlClientPod)
 			})
@@ -420,13 +410,11 @@ var _ = Describe("Replica Mode", Label(tests.LabelReplication), func() {
 			})
 
 			By("creating a replica cluster from the snapshot", func() {
-				checkQuery := fmt.Sprintf("SELECT count(*) FROM %v", testTableName)
 				AssertReplicaModeCluster(
 					namespace,
 					clusterName,
 					sourceDBName,
 					replicaClusterSample,
-					checkQuery,
 					testTableName,
 					psqlClientPod)
 			})

--- a/tests/e2e/replica_mode_cluster_test.go
+++ b/tests/e2e/replica_mode_cluster_test.go
@@ -184,8 +184,13 @@ var _ = Describe("Replica Mode", Label(tests.LabelReplication), func() {
 					g.Expect(condition).ToNot(BeNil())
 					g.Expect(condition.Status).To(Equal(metav1.ConditionTrue))
 				}).Should(Succeed())
-				clusterOnePrimary, err = env.GetClusterPrimary(namespace, clusterOneName)
-				Expect(err).ToNot(HaveOccurred())
+			})
+
+			By("checking that src cluster is now a replica cluster", func() {
+				Eventually(func() error {
+					clusterOnePrimary, err = env.GetClusterPrimary(namespace, clusterOneName)
+					return err
+				}, 30, 3).Should(BeNil())
 				AssertPgRecoveryMode(clusterOnePrimary, true)
 			})
 
@@ -197,8 +202,13 @@ var _ = Describe("Replica Mode", Label(tests.LabelReplication), func() {
 				err = env.Client.Update(ctx, cluster)
 				Expect(err).ToNot(HaveOccurred())
 				AssertClusterIsReady(namespace, clusterTwoName, testTimeouts[testUtils.ClusterIsReady], env)
-				clusterTwoPrimary, err = env.GetClusterPrimary(namespace, clusterTwoName)
-				Expect(err).ToNot(HaveOccurred())
+			})
+
+			By("checking that dst cluster has been promoted", func() {
+				Eventually(func() error {
+					clusterTwoPrimary, err = env.GetClusterPrimary(namespace, clusterTwoName)
+					return err
+				}, 30, 3).Should(BeNil())
 				AssertPgRecoveryMode(clusterTwoPrimary, false)
 			})
 


### PR DESCRIPTION
1. Changed `Context("can bootstrap a replica cluster from a backup")` tests so that both object store and volume snapshot subtests can make use of the same source Cluster. This will save time and will fix the issue of Backups being stuck in "started" state.
2. Changed `AssertReplicaModeCluster()` to allow passing a name for the test table that will be created, so that it can be used multiple time against the same source Cluster.
3. Changed `AssertDetachReplicaModeCluster()` to add a new check to verify the non existence of the replica cluster's user. This assertion now also works standalone, and not only in conjunction with `AssertReplicaModeCluster()`.

Closes #4646 