### PR TITLE
fix: avoid shutting down the instance manager if it is not needed

### DIFF
--- a/internal/cmd/manager/instance/run/lifecycle/run.go
+++ b/internal/cmd/manager/instance/run/lifecycle/run.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"os"
 	"sync"
 
 	"github.com/jackc/pgx/v5"
@@ -148,7 +147,7 @@ func configureInstancePermissions(ctx context.Context, instance *postgres.Instan
 	err = instance.WaitForSuperuserConnectionAvailable(ctx)
 	if err != nil {
 		contextLogger.Error(err, "DB not available")
-		os.Exit(1)
+		return fmt.Errorf("while verifying DB connection: %w", err)
 	}
 
 	contextLogger.Debug("Validating DB configuration")

--- a/internal/cmd/manager/instance/run/lifecycle/run.go
+++ b/internal/cmd/manager/instance/run/lifecycle/run.go
@@ -144,10 +144,9 @@ func configureInstancePermissions(ctx context.Context, instance *postgres.Instan
 	}
 
 	contextLogger.Debug("Verifying connection to DB")
-	err = instance.WaitForSuperuserConnectionAvailable(ctx)
-	if err != nil {
+	if err := instance.WaitForSuperuserConnectionAvailable(ctx); err != nil {
 		contextLogger.Error(err, "DB not available")
-		return fmt.Errorf("while verifying DB connection: %w", err)
+		return fmt.Errorf("while verifying super user DB connection: %w", err)
 	}
 
 	contextLogger.Debug("Validating DB configuration")


### PR DESCRIPTION
If we restart PostgreSQL but don't manage to connect to it, we should proceed with the instance manager's shutdown logic instead of quitting immediately with exit code 1.

This is especially important when PG shuts down because of missing disk space and when PG is up but trying to reach a consistent state.

Closes: #4063 