### PR TITLE
test(fix): setting the default tier to `default` on AKS test

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -957,6 +957,7 @@ jobs:
             # create and login to the AKS cluster
             az aks create --resource-group ${{ secrets.AZURE_RESOURCEGROUP }} \
               --name ${AZURE_AKS} \
+              --tier standard \
               --node-count 3 -k v${K8S_VERSION} --generate-ssh-keys --enable-addons monitoring \
               --workspace-resource-id ${{ secrets.AZURE_WORKSPACE_RESOURCE_ID }} \
               --aks-custom-headers EnableAzureDiskFileCSIDriver=true


### PR DESCRIPTION
Starting on version 2.47.0 of `az aks` command a new option was added `--tier`
which is used to specify the tier for the cluster being created, more information
here: https://learn.microsoft.com/en-us/azure/aks/free-standard-pricing-tiers

Closes #4708 