### PR TITLE
test(e2e): skip Drain E2E with reusePVC set to off on GKE

### DIFF
--- a/tests/e2e/drain_node_test.go
+++ b/tests/e2e/drain_node_test.go
@@ -326,6 +326,14 @@ var _ = Describe("E2E Drain Node", Serial, Label(tests.LabelDisruptive, tests.La
 		const clusterName = "cluster-drain-node"
 
 		var namespace string
+		BeforeEach(func() {
+			// All GKE persistent disks are network storage located independently of the underlying Nodes, so
+			// they don't get deleted after a Drain. Hence, even when using "reusePVC off", all the pods will
+			// be recreated with the same name and will reuse the existing volume.
+			if IsGKE() {
+				Skip("This test case is only applicable on clusters with local storage")
+			}
+		})
 		JustAfterEach(func() {
 			if CurrentSpecReport().Failed() {
 				env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")

--- a/tests/e2e/drain_node_test.go
+++ b/tests/e2e/drain_node_test.go
@@ -327,10 +327,10 @@ var _ = Describe("E2E Drain Node", Serial, Label(tests.LabelDisruptive, tests.La
 
 		var namespace string
 		BeforeEach(func() {
-			// All GKE persistent disks are network storage located independently of the underlying Nodes, so
+			// All GKE and AKS persistent disks are network storage located independently of the underlying Nodes, so
 			// they don't get deleted after a Drain. Hence, even when using "reusePVC off", all the pods will
 			// be recreated with the same name and will reuse the existing volume.
-			if IsGKE() {
+			if IsAKS() || IsGKE() {
 				Skip("This test case is only applicable on clusters with local storage")
 			}
 		})


### PR DESCRIPTION
Closes #4711 