### PR TITLE
feat: liveness probe timeout configure

### DIFF
--- a/.wordlist-en-custom.txt
+++ b/.wordlist-en-custom.txt
@@ -208,6 +208,7 @@ Linkerd
 Linode
 ListMeta
 Liveness
+LivenessProbeTimeout
 LoadBalancer
 LocalObjectReference
 MAPPEDMETRIC
@@ -831,6 +832,7 @@ linux
 listmeta
 liveness
 livenessProbe
+livenessProbeTimeout
 lm
 localeCType
 localeCollate

--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -510,6 +510,14 @@ type ClusterSpec struct {
 	// The plugins configuration, containing
 	// any plugin to be loaded with the corresponding configuration
 	Plugins PluginConfigurationList `json:"plugins,omitempty"`
+
+	// LivenessProbeTimeout is the time in seconds that is allowed for a PostgreSQL instance
+	// to successfully respond to the liveness probe (default 30).
+	// The Liveness probe failure threshold is derived from this value using the formula:
+	// ceiling(livenessProbe / 10).
+	// +kubebuilder:default:=30
+	// +optional
+	LivenessProbeTimeout int32 `json:"livenessProbeTimeout,omitempty"`
 }
 
 // PluginConfigurationList represent a set of plugin with their
@@ -1330,6 +1338,12 @@ const (
 	// FailureThreshold of startupProbe, the formula is `FailureThreshold = ceiling(startDelay / periodSeconds)`,
 	// the minimum value is 1
 	DefaultStartupDelay = 3600
+
+	// DefaultLivenessProbeTimeout is the default value for livenessProbeTimeout, livenessProbeTimeout will be
+	// used to calculate the FailureThreshold of livenessProbe, the formula is
+	// `FailureThreshold = ceiling(livenessProbeTimeout / periodSeconds)`,
+	// the minimum value is 1
+	DefaultLivenessProbeTimeout = 30
 )
 
 // PostgresConfiguration defines the PostgreSQL configuration
@@ -2955,6 +2969,14 @@ func (cluster *Cluster) GetMaxSwitchoverDelay() int32 {
 		return cluster.Spec.MaxSwitchoverDelay
 	}
 	return DefaultMaxSwitchoverDelay
+}
+
+// GetLivenessProbeTimeout get the total allowed time before the liveness probe fail
+func (cluster *Cluster) GetLivenessProbeTimeout() int32 {
+	if cluster.Spec.LivenessProbeTimeout > 0 {
+		return cluster.Spec.LivenessProbeTimeout
+	}
+	return DefaultLivenessProbeTimeout
 }
 
 // GetPrimaryUpdateStrategy get the cluster primary update strategy,

--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -400,6 +400,14 @@ type ClusterSpec struct {
 	// +optional
 	FailoverDelay int32 `json:"failoverDelay,omitempty"`
 
+	// LivenessProbeTimeout is the time in seconds that is allowed for a PostgreSQL instance
+	// to successfully respond to the liveness probe (default 30).
+	// The Liveness probe failure threshold is derived from this value using the formula:
+	// ceiling(livenessProbe / 10).
+	// +kubebuilder:default:=30
+	// +optional
+	LivenessProbeTimeout int32 `json:"livenessProbeTimeout,omitempty"`
+
 	// Affinity/Anti-affinity rules for Pods
 	// +optional
 	Affinity AffinityConfiguration `json:"affinity,omitempty"`
@@ -510,14 +518,6 @@ type ClusterSpec struct {
 	// The plugins configuration, containing
 	// any plugin to be loaded with the corresponding configuration
 	Plugins PluginConfigurationList `json:"plugins,omitempty"`
-
-	// LivenessProbeTimeout is the time in seconds that is allowed for a PostgreSQL instance
-	// to successfully respond to the liveness probe (default 30).
-	// The Liveness probe failure threshold is derived from this value using the formula:
-	// ceiling(livenessProbe / 10).
-	// +kubebuilder:default:=30
-	// +optional
-	LivenessProbeTimeout int32 `json:"livenessProbeTimeout,omitempty"`
 }
 
 // PluginConfigurationList represent a set of plugin with their

--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -400,13 +400,12 @@ type ClusterSpec struct {
 	// +optional
 	FailoverDelay int32 `json:"failoverDelay,omitempty"`
 
-	// LivenessProbeTimeout is the time in seconds that is allowed for a PostgreSQL instance
+	// LivenessProbeTimeout is the time (in seconds) that is allowed for a PostgreSQL instance
 	// to successfully respond to the liveness probe (default 30).
 	// The Liveness probe failure threshold is derived from this value using the formula:
 	// ceiling(livenessProbe / 10).
-	// +kubebuilder:default:=30
 	// +optional
-	LivenessProbeTimeout int32 `json:"livenessProbeTimeout,omitempty"`
+	LivenessProbeTimeout *int32 `json:"livenessProbeTimeout,omitempty"`
 
 	// Affinity/Anti-affinity rules for Pods
 	// +optional
@@ -1338,12 +1337,6 @@ const (
 	// FailureThreshold of startupProbe, the formula is `FailureThreshold = ceiling(startDelay / periodSeconds)`,
 	// the minimum value is 1
 	DefaultStartupDelay = 3600
-
-	// DefaultLivenessProbeTimeout is the default value for livenessProbeTimeout, livenessProbeTimeout will be
-	// used to calculate the FailureThreshold of livenessProbe, the formula is
-	// `FailureThreshold = ceiling(livenessProbeTimeout / periodSeconds)`,
-	// the minimum value is 1
-	DefaultLivenessProbeTimeout = 30
 )
 
 // PostgresConfiguration defines the PostgreSQL configuration
@@ -2969,14 +2962,6 @@ func (cluster *Cluster) GetMaxSwitchoverDelay() int32 {
 		return cluster.Spec.MaxSwitchoverDelay
 	}
 	return DefaultMaxSwitchoverDelay
-}
-
-// GetLivenessProbeTimeout get the total allowed time before the liveness probe fail
-func (cluster *Cluster) GetLivenessProbeTimeout() int32 {
-	if cluster.Spec.LivenessProbeTimeout > 0 {
-		return cluster.Spec.LivenessProbeTimeout
-	}
-	return DefaultLivenessProbeTimeout
 }
 
 // GetPrimaryUpdateStrategy get the cluster primary update strategy,

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -826,6 +826,11 @@ func (in *ClusterSpec) DeepCopyInto(out *ClusterSpec) {
 		*out = new(corev1.EphemeralVolumeSource)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.LivenessProbeTimeout != nil {
+		in, out := &in.LivenessProbeTimeout, &out.LivenessProbeTimeout
+		*out = new(int32)
+		**out = **in
+	}
 	in.Affinity.DeepCopyInto(&out.Affinity)
 	if in.TopologySpreadConstraints != nil {
 		in, out := &in.TopologySpreadConstraints, &out.TopologySpreadConstraints

--- a/config/crd/bases/postgresql.cnpg.io_clusters.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_clusters.yaml
@@ -2899,6 +2899,15 @@ spec:
                 description: Number of instances required in the cluster
                 minimum: 1
                 type: integer
+              livenessProbeTimeout:
+                default: 30
+                description: |-
+                  LivenessProbeTimeout is the time in seconds that is allowed for a PostgreSQL instance
+                  to successfully respond to the liveness probe (default 30).
+                  The Liveness probe failure threshold is derived from this value using the formula:
+                  ceiling(livenessProbe / 10).
+                format: int32
+                type: integer
               logLevel:
                 default: info
                 description: 'The instances'' log level, one of the following values:

--- a/config/crd/bases/postgresql.cnpg.io_clusters.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_clusters.yaml
@@ -2900,9 +2900,8 @@ spec:
                 minimum: 1
                 type: integer
               livenessProbeTimeout:
-                default: 30
                 description: |-
-                  LivenessProbeTimeout is the time in seconds that is allowed for a PostgreSQL instance
+                  LivenessProbeTimeout is the time (in seconds) that is allowed for a PostgreSQL instance
                   to successfully respond to the liveness probe (default 30).
                   The Liveness probe failure threshold is derived from this value using the formula:
                   ceiling(livenessProbe / 10).

--- a/docs/src/cloudnative-pg.v1.md
+++ b/docs/src/cloudnative-pg.v1.md
@@ -1910,6 +1910,16 @@ development/staging purposes.</p>
 any plugin to be loaded with the corresponding configuration</p>
 </td>
 </tr>
+<tr><td><code>livenessProbeTimeout</code><br/>
+<i>int32</i>
+</td>
+<td>
+   <p>LivenessProbeTimeout is the time in seconds that is allowed for a PostgreSQL instance
+to successfully respond to the liveness probe (default 30).
+The Liveness probe failure threshold is derived from this value using the formula:
+ceiling(livenessProbe / 10).</p>
+</td>
+</tr>
 </tbody>
 </table>
 

--- a/docs/src/cloudnative-pg.v1.md
+++ b/docs/src/cloudnative-pg.v1.md
@@ -1750,7 +1750,7 @@ to be unhealthy</p>
 <i>int32</i>
 </td>
 <td>
-   <p>LivenessProbeTimeout is the time in seconds that is allowed for a PostgreSQL instance
+   <p>LivenessProbeTimeout is the time (in seconds) that is allowed for a PostgreSQL instance
 to successfully respond to the liveness probe (default 30).
 The Liveness probe failure threshold is derived from this value using the formula:
 ceiling(livenessProbe / 10).</p>

--- a/docs/src/cloudnative-pg.v1.md
+++ b/docs/src/cloudnative-pg.v1.md
@@ -1746,6 +1746,16 @@ after the primary PostgreSQL instance in the cluster was detected
 to be unhealthy</p>
 </td>
 </tr>
+<tr><td><code>livenessProbeTimeout</code><br/>
+<i>int32</i>
+</td>
+<td>
+   <p>LivenessProbeTimeout is the time in seconds that is allowed for a PostgreSQL instance
+to successfully respond to the liveness probe (default 30).
+The Liveness probe failure threshold is derived from this value using the formula:
+ceiling(livenessProbe / 10).</p>
+</td>
+</tr>
 <tr><td><code>affinity</code><br/>
 <a href="#postgresql-cnpg-io-v1-AffinityConfiguration"><i>AffinityConfiguration</i></a>
 </td>
@@ -1908,16 +1918,6 @@ development/staging purposes.</p>
 <td>
    <p>The plugins configuration, containing
 any plugin to be loaded with the corresponding configuration</p>
-</td>
-</tr>
-<tr><td><code>livenessProbeTimeout</code><br/>
-<i>int32</i>
-</td>
-<td>
-   <p>LivenessProbeTimeout is the time in seconds that is allowed for a PostgreSQL instance
-to successfully respond to the liveness probe (default 30).
-The Liveness probe failure threshold is derived from this value using the formula:
-ceiling(livenessProbe / 10).</p>
 </td>
 </tr>
 </tbody>

--- a/docs/src/instance_manager.md
+++ b/docs/src/instance_manager.md
@@ -34,6 +34,10 @@ broken state and needs to be restarted. The value in `startDelay` is used
 to delay the probe's execution, preventing an
 instance with a long startup time from being restarted.
 
+The amount of time needed for a Pod to be classified as not alive is
+configurable in the `.spec.livenessProbeTimeout` parameter, that
+defaults to 30 seconds.
+
 The interval (in seconds) after the Pod has started before the liveness
 probe starts working is expressed in the `.spec.startDelay` parameter,
 which defaults to 3600 seconds. The correct value for your cluster is

--- a/pkg/specs/pods.go
+++ b/pkg/specs/pods.go
@@ -215,9 +215,8 @@ func createPostgresContainers(cluster apiv1.Cluster, envConfig EnvConfig, enable
 				},
 			},
 			LivenessProbe: &corev1.Probe{
-				FailureThreshold: getLivenessProbeFailureThreshold(cluster.GetLivenessProbeTimeout()),
-				PeriodSeconds:    LivenessProbePeriod,
-				TimeoutSeconds:   5,
+				PeriodSeconds:  LivenessProbePeriod,
+				TimeoutSeconds: 5,
 				ProbeHandler: corev1.ProbeHandler{
 					HTTPGet: &corev1.HTTPGetAction{
 						Path: url.PathHealth,
@@ -260,6 +259,12 @@ func createPostgresContainers(cluster apiv1.Cluster, envConfig EnvConfig, enable
 	}
 
 	addManagerLoggingOptions(cluster, &containers[0])
+
+	// by default, the failureThreshold for liveness probe is 3, we do not want
+	// to change it if the user has not set the liveness probe timeout
+	if getLivenessProbeFailureThreshold(cluster.GetLivenessProbeTimeout()) != 3 {
+		containers[0].LivenessProbe.FailureThreshold = getLivenessProbeFailureThreshold(cluster.GetLivenessProbeTimeout())
+	}
 
 	return containers
 }

--- a/pkg/specs/pods_test.go
+++ b/pkg/specs/pods_test.go
@@ -929,3 +929,13 @@ var _ = Describe("Compute startup probe failure threshold", func() {
 		Expect(getStartupProbeFailureThreshold(109)).To(BeNumerically("==", 11))
 	})
 })
+
+var _ = Describe("Compute liveness probe failure threshold", func() {
+	It("should take the minimum value 1", func() {
+		Expect(getLivenessProbeFailureThreshold(5)).To(BeNumerically("==", 1))
+	})
+
+	It("should take the value from 'startDelay / periodSeconds'", func() {
+		Expect(getLivenessProbeFailureThreshold(31)).To(BeNumerically("==", 4))
+	})
+})


### PR DESCRIPTION
This patch provides the configuration for the allowed time before the 
liveness probe failure, the livenessProbeFailureThreshold is caculated
 by this configuration using:
FAILURE_THRESHOLD = ceil(livenessProbeTimeout / 10)

closes: #4642 