### PR TITLE
fix: remove cluster wide permissions in OLM for namespaces

### DIFF
--- a/config/olm-rbac/role_global.yaml
+++ b/config/olm-rbac/role_global.yaml
@@ -7,14 +7,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - namespaces
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
   - nodes
   verbs:
   - get


### PR DESCRIPTION
This permission shouldn't be cluster wide all the time and needs to be
managed by OLM if needs to be cluster wide or not.

Closes #4736