### PR TITLE
feat: stop requiring namespace object permissions

### DIFF
--- a/config/olm-rbac/role_global.yaml
+++ b/config/olm-rbac/role_global.yaml
@@ -7,14 +7,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - namespaces
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
   - nodes
   verbs:
   - get

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -34,14 +34,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - namespaces
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
   - nodes
   verbs:
   - get

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -107,7 +107,6 @@ var ErrNextLoop = utils.ErrNextLoop
 // +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;watch;delete;patch
 // +kubebuilder:rbac:groups="",resources=configmaps/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
-// +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=nodes,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=get;list;create;watch;delete;patch
 // +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;delete;patch;create;watch
@@ -474,18 +473,6 @@ func (r *ClusterReconciler) getCluster(
 
 		// This is a real error, maybe the RBAC configuration is wrong?
 		return nil, fmt.Errorf("cannot get the managed resource: %w", err)
-	}
-
-	var namespace corev1.Namespace
-	if err := r.Get(ctx, client.ObjectKey{Namespace: "", Name: req.Namespace}, &namespace); err != nil {
-		// This is a real error, maybe the RBAC configuration is wrong?
-		return nil, fmt.Errorf("cannot get the containing namespace: %w", err)
-	}
-
-	if !namespace.DeletionTimestamp.IsZero() {
-		// This happens when you delete a namespace containing a Cluster resource. If that's the case,
-		// let's just wait for the Kubernetes to remove all object in the namespace.
-		return nil, nil
 	}
 
 	return cluster, nil


### PR DESCRIPTION
Remove the namespace deletion check at the start of the reconciliation
cycle and the permissions to read namespace definitions.

Closes #4752 