### PR TITLE
chore: gather spellchecks PRs into one

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -375,6 +375,16 @@
       ],
       "separateMajorMinor": "false",
       "pinDigests": false
+    },
+    {
+// PR group for spellcheck
+      "groupName": "spellcheck",
+      "matchPackagePrefixes": [
+        "jonasbn/github-action-spellcheck",
+        "rojopolis/spellcheck-github-actions",
+      ],
+      "separateMajorMinor": "false",
+      "pinDigests": false,
     }
   ]
 }


### PR DESCRIPTION
There's two components that are the same, the action and the docker tag
for spellcheck package, this should go into one PR since are basically the
same and for testing purposes should be both together.