### PR TITLE
test(feat): Add executed command to error output

### DIFF
--- a/pkg/utils/exec.go
+++ b/pkg/utils/exec.go
@@ -102,7 +102,8 @@ func ExecCommand(
 		Stderr: &stderr,
 	})
 	if err != nil {
-		return stdout.String(), stderr.String(), fmt.Errorf("%w - %v", err, stderr.String())
+		retErr := fmt.Errorf("cmd: %s\nerror: %w\nstdErr: %v", command, err, stderr.String())
+		return stdout.String(), stderr.String(), retErr
 	}
 
 	return stdout.String(), stderr.String(), nil


### PR DESCRIPTION
The e2e tests make extensive use of the `ExecCommand` function, but when
this functions ends with an error, the output contains the stderr and the err
but not the executed command that failed, this makes more complicated to
debug which command caused the error, we just add the command to the
error output and this will be propagated to all the functions that use this.

Closes #4763 