### PR TITLE
feat: allow metric renaming

### DIFF
--- a/config/manager/default-monitoring.yaml
+++ b/config/manager/default-monitoring.yaml
@@ -247,6 +247,71 @@ data:
             usage: "COUNTER"
             description: "Number of buffers allocated"
 
+    pg_stat_bgwriter_17:
+      runonserver: ">=17.0.0"
+      name: pg_stat_bgwriter
+      query: |
+        SELECT buffers_clean
+          , maxwritten_clean
+          , buffers_alloc
+          , EXTRACT(EPOCH FROM stats_reset) AS stats_reset_time
+        FROM pg_catalog.pg_stat_bgwriter
+      metrics:
+        - buffers_clean:
+            usage: "COUNTER"
+            description: "Number of buffers written by the background writer"
+        - maxwritten_clean:
+            usage: "COUNTER"
+            description: "Number of times the background writer stopped a cleaning scan because it had written too many buffers"
+        - buffers_alloc:
+            usage: "COUNTER"
+            description: "Number of buffers allocated"
+        - stats_reset_time:
+            usage: "GAUGE"
+            description: "Time at which these statistics were last reset"
+
+    pg_stat_checkpointer:
+      runonserver: ">=17.0.0"
+      query: |
+        SELECT num_timed AS checkpoints_timed
+          , num_requested AS checkpoints_req
+          , restartpoints_timed
+          , restartpoints_req
+          , restartpoints_done
+          , write_time
+          , sync_time
+          , buffers_written
+          , EXTRACT(EPOCH FROM stats_reset) AS stats_reset_time
+        FROM pg_catalog.pg_stat_checkpointer
+      metrics:
+        - checkpoints_timed:
+            usage: "COUNTER"
+            description: "Number of scheduled checkpoints that have been performed"
+        - checkpoints_req:
+            usage: "COUNTER"
+            description: "Number of requested checkpoints that have been performed"
+        - restartpoints_timed:
+            usage: "COUNTER"
+            description: "Number of scheduled restartpoints due to timeout or after a failed attempt to perform it"
+        - restartpoints_req:
+            usage: "COUNTER"
+            description: "Number of requested restartpoints that have been performed"
+        - restartpoints_done:
+            usage: "COUNTER"
+            description: "Number of restartpoints that have been performed"
+        - write_time:
+            usage: "COUNTER"
+            description: "Total amount of time that has been spent in the portion of processing checkpoints and restartpoints where files are written to disk, in milliseconds"
+        - sync_time:
+            usage: "COUNTER"
+            description: "Total amount of time that has been spent in the portion of processing checkpoints and restartpoints where files are synchronized to disk, in milliseconds"
+        - buffers_written:
+            usage: "COUNTER"
+            description: "Number of buffers written during checkpoints and restartpoints"
+        - stats_reset_time:
+            usage: "GAUGE"
+            description: "Time at which these statistics were last reset"
+
     pg_stat_database:
       query: |
         SELECT datname

--- a/docs/src/monitoring.md
+++ b/docs/src/monitoring.md
@@ -561,6 +561,7 @@ Every custom query has the following basic structure:
 Here is a short description of all the available fields:
 
 - `<MetricName>`: the name of the Prometheus metric
+    - `name`: override `<MetricName>`, if defined
     - `query`: the SQL query to run on the target database to generate the metrics
     - `primary`: whether to run the query only on the primary instance
     - `master`: same as `primary` (for compatibility with the Prometheus PostgreSQL exporter's syntax - deprecated) <!-- wokeignore:rule=master -->
@@ -573,6 +574,7 @@ Here is a short description of all the available fields:
        The system evaluates the predicate and if `true` executes the `query`. 
     - `metrics`: section containing a list of all exported columns, defined as follows:
       - `<ColumnName>`: the name of the column returned by the query
+          - `name`: override the `ColumnName` of the column in the metric, if defined
           - `usage`: one of the values described below
           - `description`: the metric's description
           - `metrics_mapping`: the optional column mapping when `usage` is set to `MAPPEDMETRIC`

--- a/pkg/management/postgres/metrics/collector.go
+++ b/pkg/management/postgres/metrics/collector.go
@@ -288,8 +288,13 @@ func (q *QueriesCollector) ParseQueries(customQueries []byte) error {
 		}
 
 		q.userQueries[name] = query
+		// For the metric namespace, override the value included in the key with the query name, if it exists
+		metricMapNamespace := name
+		if query.Name != "" {
+			metricMapNamespace = query.Name
+		}
 		q.mappings[name], q.variableLabels[name] = query.ToMetricMap(
-			fmt.Sprintf("%v_%v", q.collectorName, name))
+			fmt.Sprintf("%v_%v", q.Name(), metricMapNamespace))
 	}
 
 	return nil
@@ -304,7 +309,7 @@ func (q *QueriesCollector) InjectUserQueries(defaultQueries UserQueries) {
 	for name, query := range defaultQueries {
 		q.userQueries[name] = query
 		q.mappings[name], q.variableLabels[name] = query.ToMetricMap(
-			fmt.Sprintf("%v_%v", q.collectorName, name))
+			fmt.Sprintf("%v_%v", q.Name(), name))
 	}
 }
 

--- a/pkg/management/postgres/metrics/collector_test.go
+++ b/pkg/management/postgres/metrics/collector_test.go
@@ -30,9 +30,6 @@ var _ = Describe("Set default queries", func() {
 		Expect(q.userQueries).To(BeEmpty())
 		Expect(q.mappings).To(BeEmpty())
 		Expect(q.variableLabels).To(BeEmpty())
-		Expect(q.userQueries).To(BeEmpty())
-		Expect(q.mappings).To(BeEmpty())
-		Expect(q.variableLabels).To(BeEmpty())
 	})
 
 	It("properly works", func() {

--- a/pkg/management/postgres/metrics/mapping_test.go
+++ b/pkg/management/postgres/metrics/mapping_test.go
@@ -108,6 +108,7 @@ var _ = Describe("ColumnMapping ToMetricMap", func() {
 			Expect(math.IsNaN(val)).To(BeTrue())
 		})
 	})
+
 	Context("when usage is LABEL", func() {
 		It("should return expected MetricMapSet", func() {
 			columnMapping := ColumnMapping{
@@ -212,6 +213,23 @@ var _ = Describe("ColumnMapping ToMetricMap", func() {
 
 			_, ok := result[columnName].Conversion("unknown")
 			Expect(ok).To(BeFalse())
+		})
+	})
+
+	Context("when overriding the column name", func() {
+		It("should set the correct description", func() {
+			customColumnName := "custom_column"
+			columnName := "gauge_column"
+
+			columnMapping := ColumnMapping{
+				Name:  customColumnName,
+				Usage: "GAUGE",
+			}
+
+			result := columnMapping.ToMetricMap(columnName, namespace, variableLabels)
+			Expect(result[columnName].Desc.String()).To(Equal(prometheus.NewDesc(
+				fmt.Sprintf("%s_%s", namespace, customColumnName),
+				"", variableLabels, nil).String()))
 		})
 	})
 })

--- a/pkg/management/postgres/metrics/mappings.go
+++ b/pkg/management/postgres/metrics/mappings.go
@@ -94,6 +94,10 @@ func (columnMapping ColumnMapping) ToMetricMap(
 	columnName, namespace string, variableLabels []string,
 ) MetricMapSet {
 	result := make(MetricMapSet)
+	columnFQName := fmt.Sprintf("%s_%s", namespace, columnName)
+	if columnMapping.Name != "" {
+		columnFQName = fmt.Sprintf("%s_%s", namespace, columnMapping.Name)
+	}
 	// Determine how to convert the column based on its usage.
 	// nolint: dupl
 	switch columnMapping.Usage {
@@ -118,7 +122,7 @@ func (columnMapping ColumnMapping) ToMetricMap(
 			Name:  columnName,
 			Vtype: prometheus.CounterValue,
 			Desc: prometheus.NewDesc(
-				fmt.Sprintf("%s_%s", namespace, columnName),
+				columnFQName,
 				columnMapping.Description, variableLabels, nil),
 			Conversion: postgresutils.DBToFloat64,
 			Label:      false,
@@ -129,7 +133,7 @@ func (columnMapping ColumnMapping) ToMetricMap(
 			Name:  columnName,
 			Vtype: prometheus.GaugeValue,
 			Desc: prometheus.NewDesc(
-				fmt.Sprintf("%s_%s", namespace, columnName),
+				columnFQName,
 				columnMapping.Description, variableLabels, nil),
 			Conversion: postgresutils.DBToFloat64,
 			Label:      false,
@@ -141,7 +145,7 @@ func (columnMapping ColumnMapping) ToMetricMap(
 			Histogram: true,
 			Vtype:     prometheus.UntypedValue,
 			Desc: prometheus.NewDesc(
-				fmt.Sprintf("%s_%s", namespace, columnName),
+				columnFQName,
 				columnMapping.Description, variableLabels, nil),
 			Conversion: postgresutils.DBToFloat64,
 			Label:      false,
@@ -173,7 +177,7 @@ func (columnMapping ColumnMapping) ToMetricMap(
 			Name:  columnName,
 			Vtype: prometheus.GaugeValue,
 			Desc: prometheus.NewDesc(
-				fmt.Sprintf("%s_%s", namespace, columnName),
+				columnFQName,
 				columnMapping.Description, variableLabels, nil),
 			Conversion: func(in interface{}) (float64, bool) {
 				text, ok := in.(string)
@@ -195,7 +199,7 @@ func (columnMapping ColumnMapping) ToMetricMap(
 			Name:  columnName,
 			Vtype: prometheus.GaugeValue,
 			Desc: prometheus.NewDesc(
-				fmt.Sprintf("%s_%s_milliseconds", namespace, columnName),
+				fmt.Sprintf("%s_milliseconds", columnFQName),
 				columnMapping.Description, variableLabels, nil),
 			Conversion: func(in interface{}) (float64, bool) {
 				var durationString string

--- a/pkg/management/postgres/metrics/parser.go
+++ b/pkg/management/postgres/metrics/parser.go
@@ -38,6 +38,8 @@ type UserQuery struct {
 	CacheSeconds    uint64    `yaml:"cache_seconds"`
 	RunOnServer     string    `yaml:"runonserver"`
 	TargetDatabases []string  `yaml:"target_databases"`
+	// Name allows overriding the key name in the metric namespace
+	Name string `yaml:"name"`
 }
 
 // Mapping decide how a certain field, extracted from the query's result, should be used
@@ -53,6 +55,9 @@ type ColumnMapping struct {
 
 	// SupportedVersions are the semantic version ranges which are supported.
 	SupportedVersions string `yaml:"pg_version"`
+
+	// Name allows overriding the key name when naming the column
+	Name string `yaml:"name"`
 }
 
 // ColumnUsage represent how a certain column should be used

--- a/tests/e2e/asserts_test.go
+++ b/tests/e2e/asserts_test.go
@@ -2536,6 +2536,12 @@ func collectAndAssertDefaultMetricsPresentOnEachPod(namespace, clusterName, curl
 			"cnpg_pg_stat_database",
 		}
 
+		if env.PostgresVersion > 16 {
+			defaultMetrics = append(defaultMetrics,
+				"cnpg_pg_stat_checkpointer",
+			)
+		}
+
 		podList, err := env.GetClusterPodList(namespace, clusterName)
 		Expect(err).ToNot(HaveOccurred())
 		for _, pod := range podList.Items {

--- a/tests/e2e/asserts_test.go
+++ b/tests/e2e/asserts_test.go
@@ -2532,13 +2532,8 @@ func collectAndAssertDefaultMetricsPresentOnEachPod(namespace, clusterName, curl
 			"cnpg_pg_postmaster_start_time",
 			"cnpg_pg_replication",
 			"cnpg_pg_stat_archiver",
+			"cnpg_pg_stat_bgwriter",
 			"cnpg_pg_stat_database",
-		}
-
-		if env.PostgresVersion < 17 {
-			defaultMetrics = append(defaultMetrics,
-				"cnpg_pg_stat_bgwriter",
-			)
 		}
 
 		podList, err := env.GetClusterPodList(namespace, clusterName)


### PR DESCRIPTION
Allow overriding the metric name, for the query and the columns names, using a `name` key/value pair which can replace the name automatically inherited from the parent key,

An application of this is for the new pg17 `pg_stat_bgwriter`/`pg_stat_checkpointer` split. The default metric queries are changed to include a `pg_stat_bgwriter_17` metric to be run only on version >= 17, but keeping the same metric name `pg_stat_bgwriter`.

Closes #3411 
