### PR TITLE
chore: turn on leader election and default values back for GKE test

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -1705,7 +1705,7 @@ jobs:
           LEADER_ELECTION: "true"
           LEADER_LEASE_DURATION: 20
           LEADER_RENEW_DEADLINE: 25
-          LIVENESS_PROBE_THRESHOLD: 3
+          LIVENESS_PROBE_THRESHOLD: 9
           LOG_LEVEL: ${{ needs.evaluate_options.outputs.log_level }}
         run: |
           LOG_LEVEL=${LOG_LEVEL:-info}

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -1702,10 +1702,10 @@ jobs:
         env:
           ## the following variable all need be set if we use env_override_customized.yaml.template
           ## this is customization for gke
-          LEADER_ELECTION: "false"
-          LEADER_LEASE_DURATION: 240
-          LEADER_RENEW_DEADLINE: 230
-          LIVENESS_PROBE_THRESHOLD: 9
+          LEADER_ELECTION: "true"
+          LEADER_LEASE_DURATION: 20
+          LEADER_RENEW_DEADLINE: 25
+          LIVENESS_PROBE_THRESHOLD: 3
           LOG_LEVEL: ${{ needs.evaluate_options.outputs.log_level }}
         run: |
           LOG_LEVEL=${LOG_LEVEL:-info}


### PR DESCRIPTION
A long time ago we added some options to disable the leader election on the GKE tests, this was affecting the test making some test to fail and we should enable the leader election, for some reason now it works.