### PR TITLE
fix: ensure HA slots don't hold xmin

### DIFF
--- a/internal/management/controller/slots/infrastructure/postgresmanager.go
+++ b/internal/management/controller/slots/infrastructure/postgresmanager.go
@@ -53,7 +53,9 @@ func (sm PostgresManager) List(
 
 	rows, err := db.QueryContext(
 		ctx,
-		`SELECT slot_name, slot_type, active, coalesce(restart_lsn::TEXT, '') AS restart_lsn FROM pg_replication_slots
+		`SELECT slot_name, slot_type, active, coalesce(restart_lsn::TEXT, '') AS restart_lsn,
+            xmin IS NOT NULL OR catalog_xmin IS NOT NULL AS holds_xmin
+            FROM pg_replication_slots
             WHERE NOT temporary AND slot_type = 'physical'`,
 	)
 	if err != nil {
@@ -71,6 +73,7 @@ func (sm PostgresManager) List(
 			&slot.Type,
 			&slot.Active,
 			&slot.RestartLSN,
+			&slot.HoldsXmin,
 		)
 		if err != nil {
 			return ReplicationSlotList{}, err

--- a/internal/management/controller/slots/infrastructure/postgresmanager_test.go
+++ b/internal/management/controller/slots/infrastructure/postgresmanager_test.go
@@ -87,9 +87,9 @@ var _ = Describe("PostgresManager", func() {
 		})
 
 		It("should successfully list replication slots", func() {
-			rows := sqlmock.NewRows([]string{"slot_name", "slot_type", "active", "restart_lsn"}).
-				AddRow("_cnpg_slot1", string(SlotTypePhysical), true, "lsn1").
-				AddRow("slot2", string(SlotTypePhysical), true, "lsn2")
+			rows := sqlmock.NewRows([]string{"slot_name", "slot_type", "active", "restart_lsn", "holds_xmin"}).
+				AddRow("_cnpg_slot1", string(SlotTypePhysical), true, "lsn1", false).
+				AddRow("slot2", string(SlotTypePhysical), true, "lsn2", false)
 
 			mock.ExpectQuery("^SELECT (.+) FROM pg_replication_slots").
 				WillReturnRows(rows)

--- a/internal/management/controller/slots/infrastructure/replicationslot.go
+++ b/internal/management/controller/slots/infrastructure/replicationslot.go
@@ -29,6 +29,7 @@ type ReplicationSlot struct {
 	Active     bool     `json:"active"`
 	RestartLSN string   `json:"restartLSN,omitempty"`
 	IsHA       bool     `json:"isHA,omitempty"`
+	HoldsXmin  bool     `json:"holdsXmin,omitempty"`
 }
 
 // ReplicationSlotList contains a list of replication slots

--- a/internal/management/controller/slots/runner/runner.go
+++ b/internal/management/controller/slots/runner/runner.go
@@ -180,7 +180,8 @@ func synchronizeReplicationSlots(
 		// Delete slots on standby with wrong state:
 		//  * slots not present on the primary
 		//  * the slot used by this node
-		//  * slots holding xmin (this can happen on a former primary)
+		//  * slots holding xmin (this can happen on a former primary, and will prevent VACUUM from
+		//      removing tuples deleted by any later transaction.)
 		if !slotsInPrimary.Has(slot.SlotName) || slot.SlotName == mySlotName || slot.HoldsXmin {
 			if err := localSlotManager.Delete(ctx, slot); err != nil {
 				return err

--- a/internal/management/controller/slots/runner/runner.go
+++ b/internal/management/controller/slots/runner/runner.go
@@ -177,8 +177,11 @@ func synchronizeReplicationSlots(
 		}
 	}
 	for _, slot := range slotsInLocal.Items {
-		// We delete the slots not present on the primary or old HA replication slots.
-		if !slotsInPrimary.Has(slot.SlotName) || slot.SlotName == mySlotName {
+		// Delete slots on standby with wrong state:
+		//  * slots not present on the primary
+		//  * the slot used by this node
+		//  * slots holding xmin (this can happen on a former primary)
+		if !slotsInPrimary.Has(slot.SlotName) || slot.SlotName == mySlotName || slot.HoldsXmin {
 			if err := localSlotManager.Delete(ctx, slot); err != nil {
 				return err
 			}


### PR DESCRIPTION
When `hot_standby_feedback` is enabled, an inactive replication slot
with `xmin` or `catalog_xmin` set to not NULL, could prevent the
autovacuum on the primary from cleaning the old tuples.
This issue may occur when a former primary rejoins the cluster after
a switchover.

This patch resolves the issue by recreating any HA replication slot on
a standby instance if it has `xmin` or `catalog_xmin` set.

Closes #4802 