### PR TITLE
chore(deps): remove `golang.org/x/exp` dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,6 @@ require (
 	go.uber.org/atomic v1.11.0
 	go.uber.org/multierr v1.11.0
 	go.uber.org/zap v1.27.0
-	golang.org/x/exp v0.0.0-20240531132922-fd00a4e0eefc
 	golang.org/x/sys v0.20.0
 	google.golang.org/grpc v1.64.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -97,6 +96,7 @@ require (
 	github.com/xlab/treeprint v1.2.0 // indirect
 	go.starlark.net v0.0.0-20230525235612-a134d8f9ddca // indirect
 	golang.org/x/crypto v0.23.0 // indirect
+	golang.org/x/exp v0.0.0-20240531132922-fd00a4e0eefc // indirect
 	golang.org/x/net v0.25.0 // indirect
 	golang.org/x/oauth2 v0.18.0 // indirect
 	golang.org/x/sync v0.7.0 // indirect

--- a/internal/cmd/plugin/backup/cmd.go
+++ b/internal/cmd/plugin/backup/cmd.go
@@ -19,11 +19,11 @@ package backup
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strconv"
 	"time"
 
 	"github.com/spf13/cobra"
-	"golang.org/x/exp/slices"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/internal/controller/cluster_create.go
+++ b/internal/controller/cluster_create.go
@@ -20,12 +20,12 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"slices"
 	"time"
 
 	volumesnapshot "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/sethvargo/go-password/password"
-	"golang.org/x/exp/slices"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"

--- a/internal/controller/replicas.go
+++ b/internal/controller/replicas.go
@@ -19,9 +19,9 @@ package controller
 import (
 	"context"
 	"fmt"
+	"slices"
 	"time"
 
-	"golang.org/x/exp/slices"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 

--- a/pkg/reconciler/persistentvolumeclaim/instance.go
+++ b/pkg/reconciler/persistentvolumeclaim/instance.go
@@ -18,9 +18,9 @@ package persistentvolumeclaim
 
 import (
 	"context"
+	"slices"
 	"time"
 
-	"golang.org/x/exp/slices"
 	corev1 "k8s.io/api/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/pkg/specs/pods.go
+++ b/pkg/specs/pods.go
@@ -23,9 +23,9 @@ import (
 	"fmt"
 	"math"
 	"reflect"
+	"slices"
 	"strconv"
 
-	"golang.org/x/exp/slices"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"

--- a/pkg/specs/roles.go
+++ b/pkg/specs/roles.go
@@ -17,7 +17,8 @@ limitations under the License.
 package specs
 
 import (
-	"golang.org/x/exp/slices"
+	"slices"
+
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 

--- a/pkg/stringset/stringset.go
+++ b/pkg/stringset/stringset.go
@@ -18,7 +18,7 @@ limitations under the License.
 package stringset
 
 import (
-	"golang.org/x/exp/slices"
+	"slices"
 )
 
 // Data represent a set of strings

--- a/pkg/utils/math.go
+++ b/pkg/utils/math.go
@@ -16,26 +16,16 @@ limitations under the License.
 
 package utils
 
-// anySigned is a constraint that permits any signed integer type. This type
+// anyNumber is a constraint that permits any number type. This type
 // definition is copied rather than depending on x/exp/constraints since the
 // dependency is otherwise unneeded, the definition is relatively trivial and
 // static, and the Go language maintainers are not sure if/where these will live
 // in the standard library.
 //
 // Reference: https://github.com/golang/go/issues/61914
-type anySigned interface {
-	~int | ~int8 | ~int16 | ~int32 | ~int64
-}
-
-// anyFloat is a constraint that permits any floating-point type. This type
-// definition is copied rather than depending on x/exp/constraints since the
-// dependency is otherwise unneeded, the definition is relatively trivial and
-// static, and the Go language maintainers are not sure if/where these will live
-// in the standard library.
-//
-// Reference: https://github.com/golang/go/issues/61914
-type anyFloat interface {
-	~float32 | ~float64
+type anyNumber interface {
+	~int | ~int8 | ~int16 | ~int32 | ~int64 | ~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 | ~uintptr |
+		~float32 | ~float64
 }
 
 // IsPowerOfTwo calculates if a number is power of two or not
@@ -46,9 +36,9 @@ func IsPowerOfTwo(n int) bool {
 }
 
 // ToBytes converts an input value in MB to bytes
-// Input: value - an integer representing size in MB
+// Input: value - a number representing size in MB
 // Output: the size in bytes, calculated by multiplying the input value by 1024 * 1024
-func ToBytes[T anySigned | anyFloat](mb T) float64 {
+func ToBytes[T anyNumber](mb T) float64 {
 	multiplier := float64(1024)
 	return float64(mb) * multiplier * multiplier
 }

--- a/pkg/utils/math.go
+++ b/pkg/utils/math.go
@@ -16,9 +16,27 @@ limitations under the License.
 
 package utils
 
-import (
-	"golang.org/x/exp/constraints"
-)
+// anySigned is a constraint that permits any signed integer type. This type
+// definition is copied rather than depending on x/exp/constraints since the
+// dependency is otherwise unneeded, the definition is relatively trivial and
+// static, and the Go language maintainers are not sure if/where these will live
+// in the standard library.
+//
+// Reference: https://github.com/golang/go/issues/61914
+type anySigned interface {
+	~int | ~int8 | ~int16 | ~int32 | ~int64
+}
+
+// anyFloat is a constraint that permits any floating-point type. This type
+// definition is copied rather than depending on x/exp/constraints since the
+// dependency is otherwise unneeded, the definition is relatively trivial and
+// static, and the Go language maintainers are not sure if/where these will live
+// in the standard library.
+//
+// Reference: https://github.com/golang/go/issues/61914
+type anyFloat interface {
+	~float32 | ~float64
+}
 
 // IsPowerOfTwo calculates if a number is power of two or not
 // reference: https://github.com/golang/go/blob/master/src/strconv/itoa.go#L204 #wokeignore:rule=master
@@ -30,7 +48,7 @@ func IsPowerOfTwo(n int) bool {
 // ToBytes converts an input value in MB to bytes
 // Input: value - an integer representing size in MB
 // Output: the size in bytes, calculated by multiplying the input value by 1024 * 1024
-func ToBytes[T constraints.Signed | constraints.Float](mb T) float64 {
+func ToBytes[T anySigned | anyFloat](mb T) float64 {
 	multiplier := float64(1024)
 	return float64(mb) * multiplier * multiplier
 }

--- a/tests/e2e/managed_roles_test.go
+++ b/tests/e2e/managed_roles_test.go
@@ -18,11 +18,11 @@ package e2e
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
 	"github.com/lib/pq"
-	"golang.org/x/exp/slices"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"

--- a/tests/utils/logs.go
+++ b/tests/utils/logs.go
@@ -19,10 +19,9 @@ package utils
 import (
 	"encoding/json"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
-
-	"golang.org/x/exp/slices"
 )
 
 // ParseJSONLogs returns the pod's logs of a given pod name,


### PR DESCRIPTION
It was only used for the `constraints` and `slices` packages. The `slices` package is now part of the standard library, and the two definitions we use from constraints are trivial, concise, and static.