### PR TITLE
ci(fix): create operatorhub.io pr only on latest release

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -248,7 +248,8 @@ jobs:
       - release-binaries
     if: |
       (always() && !cancelled()) &&
-      needs.release-binaries.result == 'success'
+      needs.release-binaries.result == 'success' &&
+      needs.check-branch.outputs.is_latest == 'true'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -245,6 +245,7 @@ jobs:
     name: Create OLM bundle and catalog
     runs-on: ubuntu-22.04
     needs:
+      - check-branch
       - release-binaries
     if: |
       (always() && !cancelled()) &&


### PR DESCRIPTION
Since adding an old version into the stable-v1 channel is not possible, and we keep only one channel and always with the latest version, we should create the PR to the OperatorHub.io only on the latest release branch.

Closes #4843 