### PR TITLE
fix: set PVC default `AccessModes` in the template only when unspecified

### DIFF
--- a/pkg/reconciler/persistentvolumeclaim/build.go
+++ b/pkg/reconciler/persistentvolumeclaim/build.go
@@ -58,7 +58,7 @@ func Build(
 		EndMetadata().
 		WithSpec(configuration.Storage.PersistentVolumeClaimTemplate).
 		WithSource(configuration.Source).
-		WithAccessModes(corev1.ReadWriteOnce)
+		WithDefaultAccessMode(corev1.ReadWriteOnce)
 
 	// If the customer specified a storage class, let's use it
 	if configuration.Storage.StorageClass != nil {

--- a/pkg/reconciler/persistentvolumeclaim/build_test.go
+++ b/pkg/reconciler/persistentvolumeclaim/build_test.go
@@ -150,7 +150,7 @@ var _ = Describe("PVC Creation", func() {
 		Expect(pvc.Labels[utils.TablespaceNameLabelName]).To(Equal(tbsName))
 	})
 
-	It("should not add the default access mode when the PVC template specifies at least a value", func() {
+	It("should not add the default access mode when the PVC template specifies at least one value", func() {
 		cluster := &apiv1.Cluster{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "test",

--- a/pkg/resources/persistentvolumeclaim.go
+++ b/pkg/resources/persistentvolumeclaim.go
@@ -69,23 +69,18 @@ func (b *PersistentVolumeClaimBuilder) WithRequests(rl corev1.ResourceList) *Per
 	return b
 }
 
-// WithAccessModes adds the access modes to the object being build
-func (b *PersistentVolumeClaimBuilder) WithAccessModes(
-	accessModes ...corev1.PersistentVolumeAccessMode,
-) *PersistentVolumeClaimBuilder {
-	b.pvc.Spec.AccessModes = append(b.pvc.Spec.AccessModes, accessModes...)
-	return b
-}
-
 // WithDefaultAccessMode adds the access mode only if it was not present in the initial PersistentVolumeSpec
 func (b *PersistentVolumeClaimBuilder) WithDefaultAccessMode(
-	accessModes ...corev1.PersistentVolumeAccessMode,
+	accessMode corev1.PersistentVolumeAccessMode,
 ) *PersistentVolumeClaimBuilder {
 	if len(b.pvc.Spec.AccessModes) > 0 {
 		return b
 	}
 
-	return b.WithAccessModes(accessModes...)
+	b.pvc.Spec.AccessModes = []corev1.PersistentVolumeAccessMode{
+		accessMode,
+	}
+	return b
 }
 
 // BeginMetadata gets the metadata builder

--- a/pkg/resources/persistentvolumeclaim.go
+++ b/pkg/resources/persistentvolumeclaim.go
@@ -77,6 +77,17 @@ func (b *PersistentVolumeClaimBuilder) WithAccessModes(
 	return b
 }
 
+// WithDefaultAccessMode adds the access mode only if it was not present in the initial PersistentVolumeSpec
+func (b *PersistentVolumeClaimBuilder) WithDefaultAccessMode(
+	accessModes ...corev1.PersistentVolumeAccessMode,
+) *PersistentVolumeClaimBuilder {
+	if len(b.pvc.Spec.AccessModes) > 0 {
+		return b
+	}
+
+	return b.WithAccessModes(accessModes...)
+}
+
 // BeginMetadata gets the metadata builder
 func (b *PersistentVolumeClaimBuilder) BeginMetadata() *ResourceMetadataBuilder[*PersistentVolumeClaimBuilder] {
 	return NewResourceMetadataBuilder(&b.pvc.ObjectMeta, b)


### PR DESCRIPTION
This patch ensures that we only add the default `AccessModes` value when the template don't contain any value

Closes #4621 
