### PR TITLE
fix: ensure pooler service template can override the default service

### DIFF
--- a/docs/src/connection_pooling.md
+++ b/docs/src/connection_pooling.md
@@ -283,6 +283,18 @@ spec:
       max_client_conn: "1000"
       default_pool_size: "10"
 ```
+The operator by default adds a `ServicePort` with the following data:
+```
+  ports:
+  - name: pgbouncer
+    port: 5432
+    protocol: TCP
+    targetPort: pgbouncer
+```
+
+!!! Warning
+    Specifying a `ServicePort` with the name `pgbouncer` or the port `5432`  will prevent the default `ServicePort` from being added.
+    This because `ServicePort` entries with the same `name` or `port` are not allowed on Kubernetes and result in errors.
 
 ## High availability (HA)
 

--- a/pkg/servicespec/builder.go
+++ b/pkg/servicespec/builder.go
@@ -88,9 +88,9 @@ func (builder *Builder) WithServicePort(value *corev1.ServicePort) *Builder {
 	return builder
 }
 
-// WithDefaultServicePort adds a default ServicePort to the current service if no ServicePort that matches the name
+// WithServicePortNoOverwrite adds a ServicePort to the current service if no ServicePort that matches the name
 // or port value is found
-func (builder *Builder) WithDefaultServicePort(value *corev1.ServicePort) *Builder {
+func (builder *Builder) WithServicePortNoOverwrite(value *corev1.ServicePort) *Builder {
 	for _, port := range builder.status.Spec.Ports {
 		if port.Name == value.Name || port.Port == value.Port {
 			return builder

--- a/pkg/servicespec/builder.go
+++ b/pkg/servicespec/builder.go
@@ -75,16 +75,29 @@ func (builder *Builder) WithServiceType(serviceType corev1.ServiceType, overwrit
 	return builder
 }
 
-// WithServicePort adds a port to the current status
+// WithServicePort adds a port to the current service
 func (builder *Builder) WithServicePort(value *corev1.ServicePort) *Builder {
 	for idx, port := range builder.status.Spec.Ports {
 		if port.Name == value.Name {
 			builder.status.Spec.Ports[idx] = *value
+			return builder
 		}
 	}
 
 	builder.status.Spec.Ports = append(builder.status.Spec.Ports, *value)
 	return builder
+}
+
+// WithDefaultServicePort adds a default ServicePort to the current service if no ServicePort that matches the name
+// or port value is found
+func (builder *Builder) WithDefaultServicePort(value *corev1.ServicePort) *Builder {
+	for _, port := range builder.status.Spec.Ports {
+		if port.Name == value.Name || port.Port == value.Port {
+			return builder
+		}
+	}
+
+	return builder.WithServicePort(value)
 }
 
 // SetPGBouncerSelector overwrites the selectors field with the PgbouncerNameLabel selector.

--- a/pkg/servicespec/builder_test.go
+++ b/pkg/servicespec/builder_test.go
@@ -105,7 +105,7 @@ var _ = Describe("Service template builder", func() {
 				},
 				Ports: []corev1.ServicePort{expectedPort},
 			},
-		}).WithDefaultServicePort(&corev1.ServicePort{
+		}).WithServicePortNoOverwrite(&corev1.ServicePort{
 			Name:       pgBouncerConfig.PgBouncerPortName,
 			Port:       pgBouncerConfig.PgBouncerPort,
 			TargetPort: intstr.FromString(pgBouncerConfig.PgBouncerPortName),
@@ -131,7 +131,7 @@ var _ = Describe("Service template builder", func() {
 				},
 				Ports: []corev1.ServicePort{expectedPort},
 			},
-		}).WithDefaultServicePort(&corev1.ServicePort{
+		}).WithServicePortNoOverwrite(&corev1.ServicePort{
 			Name:       pgBouncerConfig.PgBouncerPortName,
 			Port:       pgBouncerConfig.PgBouncerPort,
 			TargetPort: intstr.FromString(pgBouncerConfig.PgBouncerPortName),

--- a/pkg/servicespec/builder_test.go
+++ b/pkg/servicespec/builder_test.go
@@ -18,8 +18,10 @@ package servicespec
 
 import (
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	pgBouncerConfig "github.com/cloudnative-pg/cloudnative-pg/pkg/management/pgbouncer/config"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -86,5 +88,57 @@ var _ = Describe("Service template builder", func() {
 			},
 		}).SetPGBouncerSelector("otherservice").Build().Spec.Selector).
 			To(Equal(map[string]string{utils.PgbouncerNameLabel: "otherservice"}))
+	})
+
+	It("should not add the default ServicePort when a matching port is found", func() {
+		expectedPort := corev1.ServicePort{
+			Name:       "test-port",
+			Port:       pgBouncerConfig.PgBouncerPort,
+			TargetPort: intstr.FromString(pgBouncerConfig.PgBouncerPortName),
+			Protocol:   corev1.ProtocolTCP,
+			NodePort:   30000,
+		}
+		svc := NewFrom(&apiv1.ServiceTemplateSpec{
+			Spec: corev1.ServiceSpec{
+				Selector: map[string]string{
+					utils.PgbouncerNameLabel: "myservice",
+				},
+				Ports: []corev1.ServicePort{expectedPort},
+			},
+		}).WithDefaultServicePort(&corev1.ServicePort{
+			Name:       pgBouncerConfig.PgBouncerPortName,
+			Port:       pgBouncerConfig.PgBouncerPort,
+			TargetPort: intstr.FromString(pgBouncerConfig.PgBouncerPortName),
+			Protocol:   corev1.ProtocolTCP,
+		}).Build()
+
+		Expect(svc.Spec.Ports).To(HaveLen(1))
+		Expect(svc.Spec.Ports).To(HaveExactElements(expectedPort))
+	})
+
+	It("should not add the default ServicePort when a matching name is found", func() {
+		expectedPort := corev1.ServicePort{
+			Name:       pgBouncerConfig.PgBouncerPortName,
+			Port:       70000,
+			TargetPort: intstr.FromString(pgBouncerConfig.PgBouncerPortName),
+			Protocol:   corev1.ProtocolTCP,
+			NodePort:   30000,
+		}
+		svc := NewFrom(&apiv1.ServiceTemplateSpec{
+			Spec: corev1.ServiceSpec{
+				Selector: map[string]string{
+					utils.PgbouncerNameLabel: "myservice",
+				},
+				Ports: []corev1.ServicePort{expectedPort},
+			},
+		}).WithDefaultServicePort(&corev1.ServicePort{
+			Name:       pgBouncerConfig.PgBouncerPortName,
+			Port:       pgBouncerConfig.PgBouncerPort,
+			TargetPort: intstr.FromString(pgBouncerConfig.PgBouncerPortName),
+			Protocol:   corev1.ProtocolTCP,
+		}).Build()
+
+		Expect(svc.Spec.Ports).To(HaveLen(1))
+		Expect(svc.Spec.Ports).To(HaveExactElements(expectedPort))
 	})
 })

--- a/pkg/specs/pgbouncer/services.go
+++ b/pkg/specs/pgbouncer/services.go
@@ -42,7 +42,7 @@ func Service(pooler *apiv1.Pooler, cluster *apiv1.Cluster) (*corev1.Service, err
 		WithLabel(utils.PodRoleLabelName, string(utils.PodRolePooler)).
 		WithAnnotation(utils.PoolerSpecHashAnnotationName, poolerHash).
 		WithServiceType(corev1.ServiceTypeClusterIP, false).
-		WithDefaultServicePort(&corev1.ServicePort{
+		WithServicePortNoOverwrite(&corev1.ServicePort{
 			Name:       pgBouncerConfig.PgBouncerPortName,
 			Port:       pgBouncerConfig.PgBouncerPort,
 			TargetPort: intstr.FromString(pgBouncerConfig.PgBouncerPortName),

--- a/pkg/specs/pgbouncer/services.go
+++ b/pkg/specs/pgbouncer/services.go
@@ -42,7 +42,7 @@ func Service(pooler *apiv1.Pooler, cluster *apiv1.Cluster) (*corev1.Service, err
 		WithLabel(utils.PodRoleLabelName, string(utils.PodRolePooler)).
 		WithAnnotation(utils.PoolerSpecHashAnnotationName, poolerHash).
 		WithServiceType(corev1.ServiceTypeClusterIP, false).
-		WithServicePort(&corev1.ServicePort{
+		WithDefaultServicePort(&corev1.ServicePort{
 			Name:       pgBouncerConfig.PgBouncerPortName,
 			Port:       pgBouncerConfig.PgBouncerPort,
 			TargetPort: intstr.FromString(pgBouncerConfig.PgBouncerPortName),


### PR DESCRIPTION
This patch ensures that the default service is not created when the template definition contains a port or a name with the same value as the one in the default service.

Closes #4517 
