### PR TITLE
fix: always use `RegisterPhase` to change the phase

### DIFF
--- a/internal/management/controller/instance_controller.go
+++ b/internal/management/controller/instance_controller.go
@@ -56,6 +56,7 @@ import (
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/postgres"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/promotiontoken"
 	externalcluster "github.com/cloudnative-pg/cloudnative-pg/pkg/reconciler/replicaclusterswitch"
+	clusterstatus "github.com/cloudnative-pg/cloudnative-pg/pkg/resources/status"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/system"
 	pkgUtils "github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 )
@@ -313,10 +314,14 @@ func (r *InstanceReconciler) restartPrimaryInplaceIfRequested(
 		); err != nil {
 			return true, err
 		}
-		oldCluster := cluster.DeepCopy()
-		cluster.Status.Phase = apiv1.PhaseHealthy
-		cluster.Status.PhaseReason = "Primary instance restarted in-place"
-		return true, r.client.Status().Patch(ctx, cluster, client.MergeFrom(oldCluster))
+
+		return true, clusterstatus.RegisterPhase(
+			ctx,
+			r.client,
+			cluster,
+			apiv1.PhaseHealthy,
+			"Primary instance restarted in-place",
+		)
 	}
 	return false, nil
 }
@@ -1026,10 +1031,7 @@ func (r *InstanceReconciler) processConfigReloadAndManageRestart(ctx context.Con
 		return nil
 	}
 
-	oldCluster := cluster.DeepCopy()
-	cluster.Status.Phase = phase
-	cluster.Status.PhaseReason = phaseReason
-	return r.client.Status().Patch(ctx, cluster, client.MergeFrom(oldCluster))
+	return clusterstatus.RegisterPhase(ctx, r.client, cluster, phase, phaseReason)
 }
 
 // refreshCertificateFilesFromSecret receive a secret and rewrite the file

--- a/pkg/resources/status/doc.go
+++ b/pkg/resources/status/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright The CloudNativePG Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package status contains all the function needed to interact properly with the resources status
+package status

--- a/pkg/resources/status/phase.go
+++ b/pkg/resources/status/phase.go
@@ -1,0 +1,86 @@
+/*
+Copyright The CloudNativePG Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package status
+
+import (
+	"context"
+	"reflect"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+)
+
+// RegisterPhase update phase in the status cluster with the
+// proper reason
+func RegisterPhase(
+	ctx context.Context,
+	cli client.Client,
+	cluster *apiv1.Cluster,
+	phase string,
+	reason string,
+) error {
+	existingCluster := cluster.DeepCopy()
+	return RegisterPhaseWithOrigCluster(ctx, cli, cluster, existingCluster, phase, reason)
+}
+
+// RegisterPhaseWithOrigCluster update phase in the status cluster with the
+// proper reason, it also receives an origCluster to preserve other modifications done to the status
+func RegisterPhaseWithOrigCluster(
+	ctx context.Context,
+	cli client.Client,
+	modifiedCluster *apiv1.Cluster,
+	origCluster *apiv1.Cluster,
+	phase string,
+	reason string,
+) error {
+	// we ensure that the modifiedCluster conditions aren't nil before operating
+	if modifiedCluster.Status.Conditions == nil {
+		modifiedCluster.Status.Conditions = []metav1.Condition{}
+	}
+
+	modifiedCluster.Status.Phase = phase
+	modifiedCluster.Status.PhaseReason = reason
+
+	condition := metav1.Condition{
+		Type:    string(apiv1.ConditionClusterReady),
+		Status:  metav1.ConditionFalse,
+		Reason:  string(apiv1.ClusterIsNotReady),
+		Message: "Cluster Is Not Ready",
+	}
+
+	if modifiedCluster.Status.Phase == apiv1.PhaseHealthy {
+		condition = metav1.Condition{
+			Type:    string(apiv1.ConditionClusterReady),
+			Status:  metav1.ConditionTrue,
+			Reason:  string(apiv1.ClusterReady),
+			Message: "Cluster is Ready",
+		}
+	}
+
+	meta.SetStatusCondition(&modifiedCluster.Status.Conditions, condition)
+
+	if !reflect.DeepEqual(origCluster, modifiedCluster) {
+		if err := cli.Status().Patch(ctx, modifiedCluster, client.MergeFrom(origCluster)); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
This patch aims to solve some rare cases in which the cluster phase and cluster readiness conditions are out of sync.

This can happen because in some parts of the code, we still directly set the phase instead of passing through the dedicated function `RegisterPhase`; this patch aims to solve that.

Closes #4209 

