### PR TITLE
feat: add `--no-partial` option to Barman WAL restore command

### DIFF
--- a/pkg/management/barman/capabilities/detect.go
+++ b/pkg/management/barman/capabilities/detect.go
@@ -41,6 +41,11 @@ func detect(version *semver.Version) *Capabilities {
 	newCapabilities.Version = version
 
 	switch {
+	case version.GE(semver.Version{Major: 3, Minor: 10, Patch: 1}):
+		// The --no-partial option to `barman-cloud-wal-restore` was introduced
+		// in version 3.10.1
+		newCapabilities.HasNoPartialWalRestore = true
+		fallthrough
 	case version.GE(semver.Version{Major: 3, Minor: 4}):
 		// The --name flag was added to Barman in version 3.3 but we also require the
 		// barman-cloud-backup-show command which was not added until Barman version 3.4

--- a/pkg/management/barman/capabilities/detect_test.go
+++ b/pkg/management/barman/capabilities/detect_test.go
@@ -24,6 +24,27 @@ import (
 )
 
 var _ = Describe("detect capabilities", func() {
+	It("ensures that all capabilities are true for the 3.10.1 version", func() {
+		version, err := semver.ParseTolerant("3.10.1")
+		Expect(err).ToNot(HaveOccurred())
+		capabilities := detect(&version)
+		Expect(capabilities).To(Equal(&Capabilities{
+			Version:                    &version,
+			hasName:                    true,
+			HasAzure:                   true,
+			HasS3:                      true,
+			HasGoogle:                  true,
+			HasRetentionPolicy:         true,
+			HasTags:                    true,
+			HasCheckWalArchive:         true,
+			HasSnappy:                  true,
+			HasErrorCodesForWALRestore: true,
+			HasErrorCodesForRestore:    true,
+			HasAzureManagedIdentity:    true,
+			HasNoPartialWalRestore:     true,
+		}))
+	})
+
 	It("ensures that all capabilities are true for the 3.4 version", func() {
 		version, err := semver.ParseTolerant("3.4.0")
 		Expect(err).ToNot(HaveOccurred())

--- a/pkg/management/barman/capabilities/type.go
+++ b/pkg/management/barman/capabilities/type.go
@@ -38,6 +38,7 @@ type Capabilities struct {
 	HasErrorCodesForWALRestore bool
 	HasErrorCodesForRestore    bool
 	HasAzureManagedIdentity    bool
+	HasNoPartialWalRestore     bool
 }
 
 // ShouldExecuteBackupWithName returns true if the new backup logic should be executed

--- a/pkg/management/barman/commandbuilder.go
+++ b/pkg/management/barman/commandbuilder.go
@@ -76,14 +76,6 @@ func appendCloudProviderOptions(options []string, credentials v1.BarmanCredentia
 		return nil, err
 	}
 
-	// TODO: evaluate whether to add a separate function for this
-	// if supported (Barman 3.10.1 or above) specify `--no-partial` by default
-	if !capabilities.HasNoPartialWalRestore {
-		options = append(
-			options,
-			"--no-partial")
-	}
-
 	switch {
 	case credentials.AWS != nil:
 		if capabilities.HasS3 {

--- a/pkg/management/barman/commandbuilder.go
+++ b/pkg/management/barman/commandbuilder.go
@@ -76,6 +76,14 @@ func appendCloudProviderOptions(options []string, credentials v1.BarmanCredentia
 		return nil, err
 	}
 
+	// TODO: evaluate whether to add a separate function for this
+	// if supported (Barman 3.10.1 or above) specify `--no-partial` by default
+	if !capabilities.HasNoPartialWalRestore {
+		options = append(
+			options,
+			"--no-partial")
+	}
+
 	switch {
 	case credentials.AWS != nil:
 		if capabilities.HasS3 {

--- a/pkg/management/barman/restorer/restorer.go
+++ b/pkg/management/barman/restorer/restorer.go
@@ -49,7 +49,7 @@ type WALRestorer struct {
 	// The spool of WAL files to be archived in parallel
 	spool *spool.WALSpool
 
-	// The environment that should be used to invoke barman-cloud-wal-archive
+	// The environment that should be used to invoke barman-cloud-wal-restore
 	env []string
 }
 
@@ -64,10 +64,10 @@ type Result struct {
 	// If not nil, this is the error that has been detected
 	Err error
 
-	// The time when we started barman-cloud-wal-archive
+	// The time when we started barman-cloud-wal-restore
 	StartTime time.Time
 
-	// The time when end barman-cloud-wal-archive ended
+	// The time when end barman-cloud-wal-restore ended
 	EndTime time.Time
 }
 
@@ -238,6 +238,14 @@ func (restorer *WALRestorer) Restore(walName, destinationPath string, baseOption
 	}
 	options := make([]string, optionsLength, optionsLength+2)
 	copy(options, baseOptions)
+
+	// If supported (Barman 3.10.1 or above) specify `--no-partial`
+	if !currentCapabilities.HasNoPartialWalRestore {
+		options = append(
+			options,
+			"--no-partial")
+	}
+
 	options = append(options, walName, destinationPath)
 
 	barmanCloudWalRestoreCmd := exec.Command(


### PR DESCRIPTION
Barman 3.10.1 introduces the `--no-partial` option, which prevents the download of `.partial` WAL files if the full WAL file does not exist. This enhancement is particularly useful for controlled switchover operations in Kubernetes clusters.

Closes #4850 