### PR TITLE
fix(plugin): evaluate `.status.Image` inside plugin `status` command

### DIFF
--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -2657,9 +2657,9 @@ func (secretResourceVersion *SecretsResourceVersion) SetExternalClusterSecretVer
 	secretResourceVersion.ExternalClusterSecretVersions[secretName] = *version
 }
 
-// GetImageName get the name of the image that should be used
+// getImageName get the name of the image that should be used
 // to create the pods
-func (cluster *Cluster) GetImageName() string {
+func (cluster *Cluster) getImageName() string {
 	// If the image is specified in the status, use that one
 	// It should be there since the first reconciliation
 	if len(cluster.Status.Image) > 0 {
@@ -2689,7 +2689,7 @@ func (cluster *Cluster) GetPostgresqlVersion() (int, error) {
 		return postgres.GetPostgresVersionFromTag(strconv.Itoa(cluster.Spec.ImageCatalogRef.Major))
 	}
 
-	image := cluster.GetImageName()
+	image := cluster.getImageName()
 	tag := utils.GetImageTag(image)
 	return postgres.GetPostgresVersionFromTag(tag)
 }

--- a/internal/cmd/manager/instance/pgbasebackup/cmd.go
+++ b/internal/cmd/manager/instance/pgbasebackup/cmd.go
@@ -132,7 +132,7 @@ func (env *CloneInfo) bootstrapUsingPgbasebackup(ctx context.Context) error {
 	if err != nil {
 		log.Warning(
 			"Error while parsing PostgreSQL server version to define connection options, defaulting to PostgreSQL 11",
-			"imageName", cluster.GetImageName(),
+			"imageName", cluster.Status.Image,
 			"err", err)
 	} else if pgVersion >= 120000 {
 		// We explicitly disable wal_sender_timeout for join-related pg_basebackup executions.

--- a/internal/cmd/plugin/status/status.go
+++ b/internal/cmd/plugin/status/status.go
@@ -209,7 +209,7 @@ func (fullStatus *PostgresqlStatus) printBasicInfo() {
 	if primaryInstanceStatus != nil {
 		summary.AddLine("System ID:", primaryInstanceStatus.SystemID)
 	}
-	summary.AddLine("PostgreSQL Image:", cluster.GetImageName())
+	summary.AddLine("PostgreSQL Image:", cluster.Status.Image)
 	if cluster.IsReplica() {
 		summary.AddLine("Designated primary:", primaryInstance)
 		summary.AddLine("Source cluster: ", cluster.Spec.ReplicaCluster.Source)

--- a/internal/controller/cluster_upgrade.go
+++ b/internal/controller/cluster_upgrade.go
@@ -450,7 +450,7 @@ func checkPodImageIsOutdated(
 	status postgres.PostgresqlStatus,
 	cluster *apiv1.Cluster,
 ) (rollout, error) {
-	targetImageName := cluster.GetImageName()
+	targetImageName := cluster.Status.Image
 
 	pgCurrentImageName, err := specs.GetPostgresImageName(*status.Pod)
 	if err != nil {

--- a/internal/controller/cluster_upgrade_test.go
+++ b/internal/controller/cluster_upgrade_test.go
@@ -35,7 +35,8 @@ import (
 
 var _ = Describe("Pod upgrade", Ordered, func() {
 	const (
-		newOperatorImage = "ghcr.io/cloudnative-pg/cloudnative-pg:next"
+		newOperatorImage  = "ghcr.io/cloudnative-pg/cloudnative-pg:next"
+		postgresImageName = "postgres:13.11"
 	)
 
 	var cluster apiv1.Cluster
@@ -46,8 +47,9 @@ var _ = Describe("Pod upgrade", Ordered, func() {
 				Name: "test",
 			},
 			Spec: apiv1.ClusterSpec{
-				ImageName: "postgres:13.11",
+				ImageName: postgresImageName,
 			},
+			Status: apiv1.ClusterStatus{Image: postgresImageName},
 		}
 		configuration.Current = configuration.NewConfiguration()
 	})
@@ -200,7 +202,7 @@ var _ = Describe("Pod upgrade", Ordered, func() {
 	It("should trigger a rollout when the scheduler changes", func(ctx SpecContext) {
 		cluster := apiv1.Cluster{
 			Spec: apiv1.ClusterSpec{
-				ImageName: "postgres:13.11",
+				ImageName: postgresImageName,
 			},
 		}
 		pod := specs.PodWithExistingStorage(cluster, 1)
@@ -292,7 +294,7 @@ var _ = Describe("Pod upgrade", Ordered, func() {
 		It("should not trigger a rollout on operator changes with inplace upgrades", func(ctx SpecContext) {
 			cluster := apiv1.Cluster{
 				Spec: apiv1.ClusterSpec{
-					ImageName: "postgres:13.11",
+					ImageName: postgresImageName,
 				},
 			}
 			pod := specs.PodWithExistingStorage(cluster, 1)
@@ -316,7 +318,7 @@ var _ = Describe("Pod upgrade", Ordered, func() {
 		It("should trigger an explicit rollout if operator changes without inplace upgrades", func(ctx SpecContext) {
 			cluster := apiv1.Cluster{
 				Spec: apiv1.ClusterSpec{
-					ImageName: "postgres:13.11",
+					ImageName: postgresImageName,
 				},
 			}
 			pod := specs.PodWithExistingStorage(cluster, 1)
@@ -365,7 +367,7 @@ var _ = Describe("Pod upgrade", Ordered, func() {
 		It("should not trigger a rollout on operator changes with inplace upgrades", func(ctx SpecContext) {
 			cluster := apiv1.Cluster{
 				Spec: apiv1.ClusterSpec{
-					ImageName: "postgres:13.11",
+					ImageName: postgresImageName,
 				},
 			}
 			pod := specs.PodWithExistingStorage(cluster, 1)
@@ -388,7 +390,7 @@ var _ = Describe("Pod upgrade", Ordered, func() {
 		It("should trigger an explicit rollout if operator changes without inplace upgrades", func(ctx SpecContext) {
 			cluster := apiv1.Cluster{
 				Spec: apiv1.ClusterSpec{
-					ImageName: "postgres:13.11",
+					ImageName: postgresImageName,
 				},
 			}
 			pod := specs.PodWithExistingStorage(cluster, 1)

--- a/pkg/management/postgres/join.go
+++ b/pkg/management/postgres/join.go
@@ -76,7 +76,7 @@ func (info InitInfo) Join(cluster *apiv1.Cluster) error {
 	if err != nil {
 		log.Warning(
 			"Error while parsing PostgreSQL server version to define connection options, defaulting to PostgreSQL 11",
-			"imageName", cluster.GetImageName(),
+			"imageName", cluster.Status.Image,
 			"err", err)
 	} else if pgVersion >= 120000 {
 		// We explicitly disable wal_sender_timeout for join-related pg_basebackup executions.

--- a/pkg/specs/jobs.go
+++ b/pkg/specs/jobs.go
@@ -324,7 +324,7 @@ func createPrimaryJob(cluster apiv1.Cluster, nodeSerial int, role jobRole, initC
 					Containers: []corev1.Container{
 						{
 							Name:            string(role),
-							Image:           cluster.GetImageName(),
+							Image:           cluster.Status.Image,
 							ImagePullPolicy: cluster.Spec.ImagePullPolicy,
 							Env:             envConfig.EnvVars,
 							EnvFrom:         envConfig.EnvFrom,

--- a/pkg/specs/pg_pods_test.go
+++ b/pkg/specs/pg_pods_test.go
@@ -32,6 +32,9 @@ var _ = Describe("Extract the used image name", func() {
 			Name:      "clusterName",
 			Namespace: "default",
 		},
+		Status: apiv1.ClusterStatus{
+			Image: configuration.Current.PostgresImageName,
+		},
 	}
 	pod := PodWithExistingStorage(cluster, 1)
 

--- a/pkg/specs/pods.go
+++ b/pkg/specs/pods.go
@@ -188,7 +188,7 @@ func createPostgresContainers(cluster apiv1.Cluster, envConfig EnvConfig, enable
 	containers := []corev1.Container{
 		{
 			Name:            PostgresContainerName,
-			Image:           cluster.GetImageName(),
+			Image:           cluster.Status.Image,
 			ImagePullPolicy: cluster.Spec.ImagePullPolicy,
 			Env:             envConfig.EnvVars,
 			EnvFrom:         envConfig.EnvFrom,


### PR DESCRIPTION
This patch fixes several bugs inside the code that we don't consider in the reconciled image in the plugin. 

Closes #4387 

