### PR TITLE
fix(plugin): handle errors during the `status` command execution

### DIFF
--- a/internal/cmd/plugin/status/status.go
+++ b/internal/cmd/plugin/status/status.go
@@ -19,7 +19,6 @@ package status
 import (
 	"context"
 	"fmt"
-	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	"os"
 	"path"
 	"sort"
@@ -31,6 +30,7 @@ import (
 	"github.com/logrusorgru/aurora/v4"
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -59,7 +59,7 @@ type PostgresqlStatus struct {
 	// PrimaryPod contains the primary Pod
 	PrimaryPod corev1.Pod
 
-	// podDisruptionBudgetList prints every PDB that matches against the cluster
+	// PodDisruptionBudgetList prints every PDB that matches against the cluster
 	// with the label selector
 	PodDisruptionBudgetList policyv1.PodDisruptionBudgetList
 
@@ -126,7 +126,7 @@ func Status(ctx context.Context, clusterName string, verbose bool, format plugin
 	status.printPodDisruptionBudgetStatus()
 	status.printInstancesStatus()
 
-	if len(errs) != 0 {
+	if len(errs) > 0 {
 		fmt.Println()
 
 		errors := tabby.New()

--- a/internal/cmd/plugin/status/status.go
+++ b/internal/cmd/plugin/status/status.go
@@ -128,7 +128,7 @@ func Status(ctx context.Context, clusterName string, verbose bool, format plugin
 	status.printUnmanagedReplicationSlotStatus()
 	status.printRoleManagerStatus()
 	status.printTablespacesStatus()
-	status.printPodDisruptionBudgetStatus()
+	status.printPodDisruptionBudgetStatus(verbose)
 	status.printInstancesStatus()
 
 	if nonFatalError != nil {
@@ -815,7 +815,7 @@ func (fullStatus *PostgresqlStatus) printUnmanagedReplicationSlotStatus() {
 	fmt.Println()
 }
 
-func (fullStatus *PostgresqlStatus) printPodDisruptionBudgetStatus() {
+func (fullStatus *PostgresqlStatus) printPodDisruptionBudgetStatus(verbose bool) {
 	const header = "Pod Disruption Budgets status"
 	pdbErr := fullStatus.podDisruptionBudgetList.err
 	if pdbErr != nil {
@@ -824,8 +824,14 @@ func (fullStatus *PostgresqlStatus) printPodDisruptionBudgetStatus() {
 			fmt.Println(aurora.Red("Unable to fetch PodDisruptionBudgetList due to a lack of permissions"))
 			return
 		}
+		if verbose {
+			fmt.Println(aurora.Red(
+				fmt.Sprintf("encountered an error while fetching PodDisruptionBudgetList: %s", pdbErr.Error()),
+			))
+			return
+		}
 		fmt.Println(aurora.Red(
-			fmt.Sprintf("encountered an error while fetching PodDisruptionBudgetList: %s", pdbErr.Error()),
+			"encountered an error while fetching PodDisruptionBudgetList, set verbose to true for additional details.",
 		))
 		return
 	}


### PR DESCRIPTION
This patch ensures that we continue the `status` command execution even if we encounter an error while trying to fetch the status of the instances.

Closes #4847 
