### PR TITLE
chore: ensure to log error before exiting

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -64,6 +64,7 @@ func main() {
 	cmd.AddCommand(debug.NewCmd())
 
 	if err := cmd.Execute(); err != nil {
+		log.Error(err, "error while executing command", "error", err.Error())
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Closes #4157 

Note for the reviewers: This patch will double the logs in specific scenarios, but I see it as the lesser evil, given that it is essential to log the errors always.