### PR TITLE
chore: add scorecard-test image to the renovate updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -216,14 +216,16 @@
       "extractVersionTemplate": "^(?<version>\\d+\\.\\d+\\.\\d+)"
     }, {
       "fileMatch": [
-        "config/olm-scorecard/**",
+        "^config\\/olm-scorecard\\/patches\\/basic\\.config\\.yaml$",
+        "^config\\/olm-scorecard\\/patches\\/olm\\.config\\.yaml$",
       ],
       "matchStrings": [
         "image: quay.io/operator-framework/scorecard-test:(?<currentValue>.*?)\\n",
       ],
       "datasourceTemplate": "docker",
       "versioningTemplate": "loose",
-      "depNameTemplate": "quay.io/operator-framework/scorecard-test"
+      "depNameTemplate": "quay.io/operator-framework/scorecard-test",
+      "extractVersionTemplate": "^(?<version>v\\d+\\.\\d+\\.\\d+)"
     },{
       // We want a PR to bump Default Container Images versions.
       "fileMatch": [

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -9,7 +9,7 @@
 // The branches renovate should target
 // PLEASE UPDATE THIS WHEN RELEASING.
   "baseBranches": ["main","release-1.22", "release-1.23"],
-  "ignorePaths": ["docs/**", "config/**", "releases/**", "contribute/**", "config/**", "licenses/**"],
+  "ignorePaths": ["docs/**", "releases/**", "contribute/**", "licenses/**"],
   "postUpdateOptions": ["gomodTidy"],
   "semanticCommits": "enabled",
 // All PRs should have a label
@@ -214,6 +214,16 @@
       "depNameTemplate": "redhat-openshift-ecosystem/openshift-preflight",
       "versioningTemplate": "loose",
       "extractVersionTemplate": "^(?<version>\\d+\\.\\d+\\.\\d+)"
+    }, {
+      "fileMatch": [
+        "config/olm-scorecard/**",
+      ],
+      "matchStrings": [
+        "image: quay.io/operator-framework/scorecard-test:(?<currentValue>.*?)\\n",
+      ],
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "loose",
+      "depNameTemplate": "quay.io/operator-framework/scorecard-test"
     },{
       // We want a PR to bump Default Container Images versions.
       "fileMatch": [


### PR DESCRIPTION
The image quay.io/operator-framework/scorecard-test should be updated every time making sure that we always use the latest one available.

Closes #4881 