### PR TITLE
fix: improve error handling in `EnsureDirectoryExists` function

### DIFF
--- a/pkg/fileutils/fileutils.go
+++ b/pkg/fileutils/fileutils.go
@@ -298,16 +298,21 @@ func EnsureParentDirectoryExist(fileName string) error {
 
 // EnsureDirectoryExists check if the passed directory exists or not, and if
 // it doesn't exist, create it using 0700 as permissions bits.
-// If the directory exists and its permissions are not 0700, that's fine
-func EnsureDirectoryExists(destinationDir string) (err error) {
-	if _, err = os.Stat(destinationDir); errors.Is(err, fs.ErrNotExist) {
-		err = os.MkdirAll(destinationDir, 0o700)
-		if err != nil {
-			return err
+// If the directory exists it doesn't change the permissions.
+func EnsureDirectoryExists(destinationDir string) error {
+	stat, err := os.Stat(destinationDir)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return os.MkdirAll(destinationDir, 0o700)
 		}
+		return err
 	}
 
-	return err
+	if !stat.IsDir() {
+		return fs.ErrInvalid
+	}
+
+	return nil
 }
 
 // MoveFile moves a file from a source path to its destination by copying

--- a/pkg/fileutils/fileutils.go
+++ b/pkg/fileutils/fileutils.go
@@ -22,8 +22,10 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -295,9 +297,10 @@ func EnsureParentDirectoryExist(fileName string) error {
 }
 
 // EnsureDirectoryExists check if the passed directory exists or not, and if
-// it doesn't exist, create it using 0700 as permissions bits
+// it doesn't exist, create it using 0700 as permissions bits.
+// If the directory exists and does not have 0700 as permissions, leave them set
 func EnsureDirectoryExists(destinationDir string) (err error) {
-	if _, err = os.Stat(destinationDir); os.IsNotExist(err) {
+	if _, err = os.Stat(destinationDir); errors.Is(err, fs.ErrNotExist) {
 		err = os.MkdirAll(destinationDir, 0o700)
 		if err != nil {
 			return err

--- a/pkg/fileutils/fileutils.go
+++ b/pkg/fileutils/fileutils.go
@@ -298,7 +298,7 @@ func EnsureParentDirectoryExist(fileName string) error {
 
 // EnsureDirectoryExists check if the passed directory exists or not, and if
 // it doesn't exist, create it using 0700 as permissions bits.
-// If the directory exists and does not have 0700 as permissions, leave them set
+// If the directory exists and its permissions are not 0700, that's fine
 func EnsureDirectoryExists(destinationDir string) (err error) {
 	if _, err = os.Stat(destinationDir); errors.Is(err, fs.ErrNotExist) {
 		err = os.MkdirAll(destinationDir, 0o700)

--- a/pkg/fileutils/fileutils.go
+++ b/pkg/fileutils/fileutils.go
@@ -296,15 +296,15 @@ func EnsureParentDirectoryExist(fileName string) error {
 
 // EnsureDirectoryExists check if the passed directory exists or not, and if
 // it doesn't exist, create it using 0700 as permissions bits
-func EnsureDirectoryExists(destinationDir string) error {
-	if _, err := os.Stat(destinationDir); os.IsNotExist(err) {
+func EnsureDirectoryExists(destinationDir string) (err error) {
+	if _, err = os.Stat(destinationDir); os.IsNotExist(err) {
 		err = os.MkdirAll(destinationDir, 0o700)
 		if err != nil {
 			return err
 		}
 	}
 
-	return nil
+	return err
 }
 
 // MoveFile moves a file from a source path to its destination by copying

--- a/pkg/fileutils/fileutils.go
+++ b/pkg/fileutils/fileutils.go
@@ -102,7 +102,7 @@ func FileExists(fileName string) (bool, error) {
 // CopyFile copy a file from a location to another one
 func CopyFile(source, destination string) (err error) {
 	// Ensure that the directory really exist
-	if err := EnsureParentDirectoryExist(destination); err != nil {
+	if err := EnsureParentDirectoryExists(destination); err != nil {
 		return err
 	}
 
@@ -183,7 +183,7 @@ func WriteFileAtomic(fileName string, contents []byte, perm os.FileMode) (bool, 
 	}
 
 	// Ensure that the directory really exist
-	if err := EnsureParentDirectoryExist(fileName); err != nil {
+	if err := EnsureParentDirectoryExists(fileName); err != nil {
 		return false, err
 	}
 
@@ -288,17 +288,17 @@ func CreateEmptyFile(fileName string) error {
 	return file.Close()
 }
 
-// EnsureParentDirectoryExist check if the directory containing a certain file
-// exist or not, and if is not existent will create the directory using
-// 0700 as permissions bits
-func EnsureParentDirectoryExist(fileName string) error {
+// EnsureParentDirectoryExists check whether the directory containing a certain file
+// exists, and if it does not exist, create it using 0700 as permissions bits.
+// No permissions check is performed if the directory already exists.
+func EnsureParentDirectoryExists(fileName string) error {
 	destinationDir := filepath.Dir(fileName)
 	return EnsureDirectoryExists(destinationDir)
 }
 
 // EnsureDirectoryExists check if the passed directory exists or not, and if
 // it doesn't exist, create it using 0700 as permissions bits.
-// If the directory exists it doesn't change the permissions.
+// No permissions check is performed if the directory already exists.
 func EnsureDirectoryExists(destinationDir string) error {
 	stat, err := os.Stat(destinationDir)
 	if err != nil {

--- a/pkg/fileutils/fileutils_test.go
+++ b/pkg/fileutils/fileutils_test.go
@@ -360,7 +360,10 @@ var _ = Describe("EnsureDirectoryExists", func() {
 	})
 
 	It("errors out when it cannot create the directory", func() {
-		err := EnsureDirectoryExists("/dev/foobar")
+		Expect(os.Chmod(tempDir, 0o500)).To(Succeed()) //#nosec G302 -- this is a directory in a test
+		newDir := filepath.Join(tempDir, "newDir")
+
+		err := EnsureDirectoryExists(newDir)
 		Expect(err).To(HaveOccurred())
 		Expect(errors.Is(err, fs.ErrPermission)).To(BeTrue())
 		var pathErr *os.PathError

--- a/pkg/fileutils/fileutils_test.go
+++ b/pkg/fileutils/fileutils_test.go
@@ -358,15 +358,15 @@ var _ = Describe("EnsureDirectoryExists", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(fileInfo2.Mode().Perm()).To(Equal(fs.FileMode(0o700)))
 	})
-	It("errors out when trying to make an unrealizable path", func() {
-		err := EnsureDirectoryExists("")
+	It("errors out when it cannot create the directory", func() {
+		err := EnsureDirectoryExists("/dev/foobar")
 		Expect(err).To(HaveOccurred())
-		Expect(errors.Is(err, fs.ErrNotExist)).To(BeTrue())
+		Expect(errors.Is(err, fs.ErrPermission)).To(BeTrue())
 		pathErr, ok := err.(*os.PathError)
 		Expect(ok).To(BeTrue())
 		Expect(pathErr.Op).To(Equal("mkdir"))
 	})
-	It("errors out when given an invalid unix path", func() {
+	It("errors out when Stat fails for other reasons", func() {
 		err := EnsureDirectoryExists("illegalchar\x00")
 		Expect(err).To(HaveOccurred())
 		pathErr, ok := err.(*os.PathError)

--- a/pkg/management/postgres/instance_test.go
+++ b/pkg/management/postgres/instance_test.go
@@ -84,7 +84,7 @@ var _ = Describe("testing primary instance methods", Ordered, func() {
 	It("should correctly restore pg_control from the pg_control.old file", func() {
 		data := []byte("pgControlFakeData")
 
-		err := fileutils.EnsureParentDirectoryExist(pgControlOld)
+		err := fileutils.EnsureParentDirectoryExists(pgControlOld)
 		Expect(err).ToNot(HaveOccurred())
 
 		err = os.WriteFile(pgControlOld, data, 0o600)
@@ -99,7 +99,7 @@ var _ = Describe("testing primary instance methods", Ordered, func() {
 	It("should properly remove pg_control file", func() {
 		data := []byte("pgControlFakeData")
 
-		err := fileutils.EnsureParentDirectoryExist(pgControlOld)
+		err := fileutils.EnsureParentDirectoryExists(pgControlOld)
 		Expect(err).ToNot(HaveOccurred())
 
 		err = os.WriteFile(pgControl, data, 0o600)
@@ -110,7 +110,7 @@ var _ = Describe("testing primary instance methods", Ordered, func() {
 	})
 
 	It("should fail if the pg_control file has issues", func() {
-		err := fileutils.EnsureParentDirectoryExist(pgControl)
+		err := fileutils.EnsureParentDirectoryExists(pgControl)
 		Expect(err).ToNot(HaveOccurred())
 
 		err = os.WriteFile(pgControl, nil, 0o600)

--- a/pkg/management/postgres/logpipe/linelogpipe.go
+++ b/pkg/management/postgres/logpipe/linelogpipe.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
 	"runtime/debug"
 	"time"
 
@@ -105,7 +104,7 @@ func (p *LineLogPipe) Start(ctx context.Context) error {
 			}
 
 			// check if the directory exists
-			if err := fileutils.EnsureDirectoryExists(filepath.Dir(p.fileName)); err != nil {
+			if err := fileutils.EnsureParentDirectoryExists(p.fileName); err != nil {
 				filenameLog.Error(err, "Error checking if the directory exists")
 				continue
 			}

--- a/pkg/management/postgres/logpipe/logpipe.go
+++ b/pkg/management/postgres/logpipe/logpipe.go
@@ -95,7 +95,7 @@ func (p *LogPipe) Start(ctx context.Context) error {
 			}
 
 			// check if the directory exists
-			if err := fileutils.EnsureDirectoryExists(filepath.Dir(p.fileName)); err != nil {
+			if err := fileutils.EnsureParentDirectoryExists(p.fileName); err != nil {
 				filenameLog.Error(err, "Error checking if the directory exists")
 				continue
 			}

--- a/pkg/management/postgres/restore.go
+++ b/pkg/management/postgres/restore.go
@@ -312,7 +312,7 @@ func (info InitInfo) ensureArchiveContainsLastCheckpointRedoWAL(
 		}
 	}()
 
-	if err := fileutils.EnsureParentDirectoryExist(testWALPath); err != nil {
+	if err := fileutils.EnsureParentDirectoryExists(testWALPath); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This update modifies the `EnsureDirectoryExists` function to propagate previously ignored unexpected errors.
The function also verifies that the target is a directory when it already exists.

Closes #4891 
