### PR TITLE
chore: remove the conversion webhook supporting functions

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -140,14 +140,6 @@ rules:
   - patch
   - update
 - apiGroups:
-  - apiextensions.k8s.io
-  resources:
-  - customresourcedefinitions
-  verbs:
-  - get
-  - list
-  - update
-- apiGroups:
   - apps
   resources:
   - deployments

--- a/internal/cmd/manager/controller/controller.go
+++ b/internal/cmd/manager/controller/controller.go
@@ -368,12 +368,7 @@ func ensurePKI(
 		OperatorNamespace:                  configuration.Current.OperatorNamespace,
 		MutatingWebhookConfigurationName:   MutatingWebhookConfigurationName,
 		ValidatingWebhookConfigurationName: ValidatingWebhookConfigurationName,
-		CustomResourceDefinitionsName: []string{
-			"backups.postgresql.cnpg.io",
-			"clusters.postgresql.cnpg.io",
-			"scheduledbackups.postgresql.cnpg.io",
-		},
-		OperatorDeploymentLabelSelector: "app.kubernetes.io/name=cloudnative-pg",
+		OperatorDeploymentLabelSelector:    "app.kubernetes.io/name=cloudnative-pg",
 	}
 	err := pkiConfig.Setup(ctx, kubeClient)
 	if err != nil {

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -94,7 +94,6 @@ var ErrNextLoop = utils.ErrNextLoop
 // Alphabetical order to not repeat or miss permissions
 // +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=mutatingwebhookconfigurations,verbs=get;update;list;patch
 // +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=validatingwebhookconfigurations,verbs=get;update;list;patch
-// +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;update;list
 // +kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;delete;patch;create;watch
 // +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;create;update
 // +kubebuilder:rbac:groups=monitoring.coreos.com,resources=podmonitors,verbs=get;create;list;watch;delete;patch

--- a/tests/utils/webhooks.go
+++ b/tests/utils/webhooks.go
@@ -23,7 +23,6 @@ import (
 
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
-	apiextensionv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -150,34 +149,6 @@ func CheckWebhookReady(env *TestingEnvironment, namespace string) error {
 		}
 	}
 
-	customResourceDefinitionsName := []string{
-		"backups.postgresql.cnpg.io",
-		"clusters.postgresql.cnpg.io",
-		"scheduledbackups.postgresql.cnpg.io",
-	}
-
-	ctx := context.Background()
-	for _, c := range customResourceDefinitionsName {
-		crd, err := env.APIExtensionClient.ApiextensionsV1().CustomResourceDefinitions().Get(
-			ctx, c, metav1.GetOptions{})
-		if err != nil {
-			return err
-		}
-
-		if crd.Spec.Conversion == nil {
-			continue
-		}
-
-		if crd.Spec.Conversion.Strategy == apiextensionv1.NoneConverter {
-			continue
-		}
-
-		if crd.Spec.Conversion.Webhook != nil && crd.Spec.Conversion.Webhook.ClientConfig != nil &&
-			!bytes.Equal(crd.Spec.Conversion.Webhook.ClientConfig.CABundle, ca) {
-			return fmt.Errorf("secret not match with ca bundle in %v; %v not equal to %v", c,
-				string(crd.Spec.Conversion.Webhook.ClientConfig.CABundle), string(ca))
-		}
-	}
 	return nil
 }
 


### PR DESCRIPTION
To migrate to the API v1 of the operator we create a conversion webhook
many years ago, the code deleted here was a code used in that time for
the conversion webhook and was used to insert into the CRDs the CA bundle
for the webhooks since we create our own certificates.

Closes #4896 