### PR TITLE
chore: use the PAT token when adding or checking labels

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions-ecosystem/action-add-labels@v1
         if: ${{ !contains(github.event.pull_request.labels.*.name, 'do not backport') }}
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.REPO_GHA_PAT }}
           number:  ${{ github.event.pull_request.number }}
           labels: |
             backport-requested :arrow_backward:

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -51,6 +51,7 @@ jobs:
         uses: actions-ecosystem/action-remove-labels@v1
         if: ${{ contains(github.event.pull_request.labels.*.name, 'do not backport') }}
         with:
+          github_token: ${{ secrets.REPO_GHA_PAT }}
           labels: |
             backport-requested :arrow_backward:
             release-1.22

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -2151,7 +2151,7 @@ jobs:
       - name: Check preconditions
         id: get_pr_number_and_labels
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.REPO_GHA_PAT }}
         run: |
           ok_label=$(gh pr view "${{ github.event.issue.number }}" --json labels -q ".labels.[].name" 2>/dev/null | grep "ok to merge :ok_hand:" || :)
           echo "OK_LABEL=${ok_label}" >> $GITHUB_ENV
@@ -2161,7 +2161,7 @@ jobs:
           env.OK_LABEL == ''
         uses: actions-ecosystem/action-add-labels@v1.1.3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.REPO_GHA_PAT }}
           number: ${{ github.event.issue.number }}
           labels: "ok to merge :ok_hand:"
 
@@ -2180,7 +2180,7 @@ jobs:
       - name: Check preconditions
         id: get_pr_number_and_labels
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.REPO_GHA_PAT }}
         run: |
           ok_label=$(gh pr view "${{ github.event.issue.number }}" --json labels -q ".labels.[].name" 2>/dev/null | grep "ok to merge :ok_hand:" || :)
           echo "OK_LABEL=${ok_label}" >> $GITHUB_ENV
@@ -2190,6 +2190,6 @@ jobs:
           env.OK_LABEL != ''
         uses: actions-ecosystem/action-remove-labels@v1.3.0
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.REPO_GHA_PAT }}
           number: ${{ github.event.issue.number }}
           labels: "ok to merge :ok_hand:"

--- a/.github/workflows/latest-postgres-version-check.yml
+++ b/.github/workflows/latest-postgres-version-check.yml
@@ -69,7 +69,7 @@ jobs:
         if: env.LATEST_POSTGRES_VERSION_IMAGE != env.CURRENT_POSTGRES_VERSION_IMAGE
         uses: peter-evans/create-pull-request@v6
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.REPO_GHA_PAT }}
         with:
           title: "feat: update default PostgreSQL version to ${{ env.LATEST_POSTGRES_VERSION }}"
           body: "Update default PostgreSQL version from ${{ env.CURRENT_POSTGRES_VERSION }} to ${{ env.LATEST_POSTGRES_VERSION }}"
@@ -82,7 +82,7 @@ jobs:
         if: env.LATEST_POSTGRES_VERSION_IMAGE == env.CURRENT_POSTGRES_VERSION_IMAGE
         uses: peter-evans/create-pull-request@v6
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.REPO_GHA_PAT }}
         with:
           title: "test: Updated Postgres versions used in E2E tests"
           body: "Update the Postgres versions used in E2E tests"

--- a/.github/workflows/public-cloud-k8s-versions-check.yml
+++ b/.github/workflows/public-cloud-k8s-versions-check.yml
@@ -108,7 +108,7 @@ jobs:
         name: Create Pull Request if versions have been updated
         uses: peter-evans/create-pull-request@v6
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.REPO_GHA_PAT }}
           title: "feat: Public Cloud K8S versions update"
           body: "Update the versions used to test the operator on public cloud providers"
           branch: "k8s-cloud-versions-update"


### PR DESCRIPTION
We used the GITHUB_TOKEN before, but it didn't trigger any other workflow, resulting in outdated labels and test status.
Now, we use a Personal Access Token, which triggers all the checks and the other maintenance workflows.

Closes #4829 