### PR TITLE
fix: prevent concurrent postmaster lifecycle loops

### DIFF
--- a/pkg/management/execlog/execlog.go
+++ b/pkg/management/execlog/execlog.go
@@ -22,6 +22,7 @@ import (
 	"bufio"
 	"bytes"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -90,6 +91,15 @@ func (se *StreamingCmd) Wait() error {
 	}
 
 	return nil
+}
+
+// Pid gets the PID of the embedded process when set
+func (se *StreamingCmd) Pid() (int, error) {
+	if se.process == nil {
+		return 0, fmt.Errorf("process not set")
+	}
+
+	return se.process.Pid, nil
 }
 
 // RunStreaming executes the command redirecting its stdout and stderr to the logger.


### PR DESCRIPTION
With the current implementation if was possible to have two concurrent
postmaster lifecycle loops: the first one could be waiting for the
instance permissions to be set up, the second one could be starting.

This resulted in a race condition in the flag that is enabling and
disabling the readiness probe, resulting in the second postmaster
running to be ready while the readiness probe was artificially forced to
false.

This condition is triggered by fencing a cluster and immediately lifting
the fencing.

Closes: #4916  