### PR TITLE
feat: add support for `allow_alter_system` in PostgreSQL 17

### DIFF
--- a/api/v1/cluster_webhook.go
+++ b/api/v1/cluster_webhook.go
@@ -129,6 +129,7 @@ func (r *Cluster) setDefaults(preserveUserSettings bool) {
 			IsReplicaCluster:              r.IsReplica(),
 			PreserveFixedSettingsFromUser: preserveUserSettings,
 			IsWalArchivingDisabled:        utils.IsWalArchivingDisabled(&r.ObjectMeta),
+			IsAlterSystemEnabled:          r.Spec.PostgresConfiguration.EnableAlterSystem,
 		}
 		sanitizedParameters := postgres.CreatePostgresqlConfiguration(info).GetConfigurationParameters()
 		r.Spec.PostgresConfiguration.Parameters = sanitizedParameters
@@ -1072,6 +1073,7 @@ func (r *Cluster) validateConfiguration() field.ErrorList {
 		UserSettings:           r.Spec.PostgresConfiguration.Parameters,
 		IsReplicaCluster:       r.IsReplica(),
 		IsWalArchivingDisabled: utils.IsWalArchivingDisabled(&r.ObjectMeta),
+		IsAlterSystemEnabled:   r.Spec.PostgresConfiguration.EnableAlterSystem,
 	}
 	sanitizedParameters := postgres.CreatePostgresqlConfiguration(info).GetConfigurationParameters()
 

--- a/docs/src/postgresql_conf.md
+++ b/docs/src/postgresql_conf.md
@@ -470,11 +470,10 @@ exclusive method for altering the configuration of a PostgreSQL cluster. This
 approach guarantees coherence across the entire high-availability cluster and
 aligns with best practices for Infrastructure-as-Code.
 
-In CloudNativePG version 1.22 and onwards, the default configuration disables
-the use of `ALTER SYSTEM` on new Postgres clusters. This decision is rooted in
-the recognition of potential risks associated with this command. To enable the
-use of `ALTER SYSTEM`, you can explicitly set `.spec.postgresql.enableAlterSystem`
-to `true`.
+In CloudNativePG the default configuration disables the use of `ALTER SYSTEM`
+on new Postgres clusters. This decision is rooted in the recognition of
+potential risks associated with this command. To enable the use of `ALTER SYSTEM`,
+you can explicitly set `.spec.postgresql.enableAlterSystem` to `true`.
 
 !!! Warning
     Proceed with caution when utilizing `ALTER SYSTEM`. This command operates
@@ -482,9 +481,14 @@ to `true`.
     CloudNativePG assumes responsibility for certain fixed parameters and complete
     control over others, emphasizing the need for careful consideration.
 
-When `.spec.postgresql.enableAlterSystem` is configured as `false`, any attempt
-to execute `ALTER SYSTEM` will result in an error. The error message might
-resemble the following:
+Starting from PostgreSQL 17, the `.spec.postgresql.enableAlterSystem` setting
+directly controls the [`allow_alter_system` GUC in PostgreSQL](https://www.postgresql.org/docs/17/runtime-config-compatible.html#GUC-ALLOW-ALTER-SYSTEM)
+— a feature directly contributed by CloudNativePG to PostgreSQL.
+
+Prior to PostgreSQL 17, when `.spec.postgresql.enableAlterSystem` is set to
+`false`, the `postgresql.auto.conf` file is made read-only. Consequently, any
+attempt to execute the `ALTER SYSTEM` command will result in an error. The
+error message might look like this:
 
 ``` output
 ERROR:  could not open file "postgresql.auto.conf": Permission denied
@@ -575,6 +579,7 @@ operator. The operator prevents the user from setting them using a webhook.
 Users are not allowed to set the following configuration parameters in the
 `postgresql` section:
 
+- `allow_alter_system`
 - `allow_system_table_mods`
 - `archive_cleanup_command`
 - `archive_command`

--- a/internal/management/controller/instance_controller.go
+++ b/internal/management/controller/instance_controller.go
@@ -261,10 +261,10 @@ func (r *InstanceReconciler) Reconcile(
 		return reconcile.Result{}, fmt.Errorf("cannot reconcile database configurations: %w", err)
 	}
 
-	// Reconcile postgresql.auto.conf file
+	// Reconcile postgresql.auto.conf file permissions (< PG 17)
 	// IMPORTANT: this needs a database connection to determine
 	// the PostgreSQL major version
-	r.reconcileAutoConf(ctx, cluster)
+	r.reconcilePostgreSQLAutoConfFilePermissions(ctx, cluster)
 
 	// EXTREMELY IMPORTANT
 	//
@@ -955,9 +955,9 @@ func (r *InstanceReconciler) reconcileInstance(cluster *apiv1.Cluster) {
 	r.instance.RequiresDesignatedPrimaryTransition = detectRequiresDesignatedPrimaryTransition()
 }
 
-// reconcileAutoConf reconciles the permissions bit of `postgresql.auto.conf`
+// PostgreSQLAutoConfWritable reconciles the permissions bit of `postgresql.auto.conf`
 // given the relative setting in `.spec.postgresql.enableAlterSystem`
-func (r *InstanceReconciler) reconcileAutoConf(ctx context.Context, cluster *apiv1.Cluster) {
+func (r *InstanceReconciler) reconcilePostgreSQLAutoConfFilePermissions(ctx context.Context, cluster *apiv1.Cluster) {
 	contextLogger := log.FromContext(ctx)
 	version, err := r.instance.GetPgVersion()
 	if err != nil {

--- a/internal/management/controller/instance_controller.go
+++ b/internal/management/controller/instance_controller.go
@@ -961,7 +961,7 @@ func (r *InstanceReconciler) reconcileAutoConf(ctx context.Context, cluster *api
 	contextLogger := log.FromContext(ctx)
 	version, err := r.instance.GetPgVersion()
 	if err != nil {
-		contextLogger.Error(err, "while getting postgres version")
+		contextLogger.Error(err, "while getting Postgres version")
 		return
 	}
 

--- a/pkg/management/postgres/configuration.go
+++ b/pkg/management/postgres/configuration.go
@@ -433,6 +433,7 @@ func createPostgresqlConfiguration(cluster *apiv1.Cluster, preserveUserSettings 
 		AdditionalSharedPreloadLibraries: cluster.Spec.PostgresConfiguration.AdditionalLibraries,
 		IsReplicaCluster:                 cluster.IsReplica(),
 		IsWalArchivingDisabled:           utils.IsWalArchivingDisabled(&cluster.ObjectMeta),
+		IsAlterSystemEnabled:             cluster.Spec.PostgresConfiguration.EnableAlterSystem,
 	}
 
 	if preserveUserSettings {

--- a/pkg/management/postgres/instance.go
+++ b/pkg/management/postgres/instance.go
@@ -209,12 +209,6 @@ type Instance struct {
 	ServerCertificate *tls.Certificate
 }
 
-// SetAlterSystemEnabled allows or deny the usage of the
-// ALTER SYSTEM SQL command
-func (instance *Instance) SetAlterSystemEnabled(enabled bool) error {
-	return instance.SetPostgreSQLAutoConfWritable(enabled)
-}
-
 // SetPostgreSQLAutoConfWritable allows or deny writes to the
 // `postgresql.auto.conf` file in PGDATA
 func (instance *Instance) SetPostgreSQLAutoConfWritable(writeable bool) error {

--- a/pkg/management/postgres/instance_test.go
+++ b/pkg/management/postgres/instance_test.go
@@ -226,7 +226,7 @@ var _ = Describe("check atomic bool", func() {
 	})
 })
 
-var _ = Describe("ALTER SYSTEM enable and disable", func() {
+var _ = Describe("ALTER SYSTEM enable and disable in PostgreSQL <17", func() {
 	var instance Instance
 	var autoConfFile string
 
@@ -243,7 +243,7 @@ var _ = Describe("ALTER SYSTEM enable and disable", func() {
 	})
 
 	It("should be able to enable ALTER SYSTEM", func() {
-		err := instance.SetAlterSystemEnabled(true)
+		err := instance.SetPostgreSQLAutoConfWritable(true)
 		Expect(err).ToNot(HaveOccurred())
 
 		info, err := os.Stat(autoConfFile)
@@ -253,7 +253,7 @@ var _ = Describe("ALTER SYSTEM enable and disable", func() {
 	})
 
 	It("should be able to disable ALTER SYSTEM", func() {
-		err := instance.SetAlterSystemEnabled(false)
+		err := instance.SetPostgreSQLAutoConfWritable(false)
 		Expect(err).ToNot(HaveOccurred())
 
 		info, err := os.Stat(autoConfFile)

--- a/pkg/postgres/configuration.go
+++ b/pkg/postgres/configuration.go
@@ -382,6 +382,7 @@ var (
 	// changed by the user
 	FixedConfigurationParameters = map[string]string{
 		// The following parameters need a restart to be applied
+		"allow_alter_system":        fixedConfigurationParameter,
 		"allow_system_table_mods":   blockedConfigurationParameter,
 		"archive_mode":              fixedConfigurationParameter,
 		"bonjour":                   blockedConfigurationParameter,

--- a/pkg/postgres/configuration.go
+++ b/pkg/postgres/configuration.go
@@ -382,7 +382,6 @@ var (
 	// changed by the user
 	FixedConfigurationParameters = map[string]string{
 		// The following parameters need a restart to be applied
-		"allow_alter_system":        fixedConfigurationParameter,
 		"allow_system_table_mods":   blockedConfigurationParameter,
 		"archive_mode":              fixedConfigurationParameter,
 		"bonjour":                   blockedConfigurationParameter,
@@ -634,6 +633,12 @@ func CreatePostgresqlConfiguration(info ConfigurationInfo) *PgConfiguration {
 		for key, value := range info.Settings.MandatorySettings {
 			configuration.OverwriteConfig(key, value)
 		}
+
+		// IMPORTANT: yes, this field is called MajorVersion but actually
+		// it's just the PostgreSQL version number
+		if info.MajorVersion >= 170000 {
+			configuration.OverwriteConfig("allow_alter_system", info.getAlterSystemEnabledValue())
+		}
 	}
 
 	// Apply the correct archive_mode
@@ -662,10 +667,6 @@ func CreatePostgresqlConfiguration(info ConfigurationInfo) *PgConfiguration {
 	// Apply the list of temporary tablespaces
 	if len(info.TemporaryTablespaces) > 0 {
 		configuration.OverwriteConfig("temp_tablespaces", strings.Join(info.TemporaryTablespaces, ","))
-	}
-
-	if info.MajorVersion >= 17 {
-		configuration.OverwriteConfig("allow_alter_system", info.getAlterSystemEnabledValue())
 	}
 
 	return configuration

--- a/pkg/postgres/configuration.go
+++ b/pkg/postgres/configuration.go
@@ -309,6 +309,18 @@ type ConfigurationInfo struct {
 
 	// IsWalArchivingDisabled is true when user requested to disable WAL archiving
 	IsWalArchivingDisabled bool
+
+	// IsAlterSystemEnabled is true when 'allow_alter_system' should be set to on
+	IsAlterSystemEnabled bool
+}
+
+// getAlterSystemEnabledValue returns a config compatible value for IsAlterSystemEnabled
+func (c ConfigurationInfo) getAlterSystemEnabledValue() string {
+	if c.IsAlterSystemEnabled {
+		return "on"
+	}
+
+	return "off"
 }
 
 // ManagedExtension defines all the information about a managed extension
@@ -649,6 +661,10 @@ func CreatePostgresqlConfiguration(info ConfigurationInfo) *PgConfiguration {
 	// Apply the list of temporary tablespaces
 	if len(info.TemporaryTablespaces) > 0 {
 		configuration.OverwriteConfig("temp_tablespaces", strings.Join(info.TemporaryTablespaces, ","))
+	}
+
+	if info.MajorVersion >= 17 {
+		configuration.OverwriteConfig("allow_alter_system", info.getAlterSystemEnabledValue())
 	}
 
 	return configuration

--- a/pkg/postgres/configuration_test.go
+++ b/pkg/postgres/configuration_test.go
@@ -227,11 +227,12 @@ var _ = Describe("PostgreSQL configuration creation", func() {
 	})
 
 	Context("allow_alter_system", func() {
-		When("postgres >=17", func() {
+		When("PostgreSQL >= 17", func() {
 			It("can properly set allow_alter_system to on", func() {
 				info := ConfigurationInfo{
 					IsAlterSystemEnabled: true,
-					MajorVersion:         17,
+					MajorVersion:         170000,
+					IncludingMandatory:   true,
 				}
 				config := CreatePostgresqlConfiguration(info)
 				Expect(config.GetConfig("allow_alter_system")).To(Equal("on"))
@@ -240,18 +241,20 @@ var _ = Describe("PostgreSQL configuration creation", func() {
 			It("can properly set allow_alter_system to off", func() {
 				info := ConfigurationInfo{
 					IsAlterSystemEnabled: false,
-					MajorVersion:         18,
+					MajorVersion:         180000,
+					IncludingMandatory:   true,
 				}
 				config := CreatePostgresqlConfiguration(info)
 				Expect(config.GetConfig("allow_alter_system")).To(Equal("off"))
 			})
 		})
 
-		When("postgres <17", func() {
+		When("PostgreSQL <17", func() {
 			It("should not set allow_alter_system", func() {
 				info := ConfigurationInfo{
 					IsAlterSystemEnabled: false,
-					MajorVersion:         14,
+					MajorVersion:         140000,
+					IncludingMandatory:   true,
 				}
 				config := CreatePostgresqlConfiguration(info)
 				value, ok := config.configs["allow_alter_system"]
@@ -261,7 +264,8 @@ var _ = Describe("PostgreSQL configuration creation", func() {
 			It("should not set allow_alter_system", func() {
 				info := ConfigurationInfo{
 					IsAlterSystemEnabled: true,
-					MajorVersion:         14,
+					MajorVersion:         140000,
+					IncludingMandatory:   true,
 				}
 				config := CreatePostgresqlConfiguration(info)
 				value, ok := config.configs["allow_alter_system"]

--- a/pkg/postgres/configuration_test.go
+++ b/pkg/postgres/configuration_test.go
@@ -225,6 +225,51 @@ var _ = Describe("PostgreSQL configuration creation", func() {
 			Expect(config.GetConfig("recovery_target_name")).To(Equal(""))
 		})
 	})
+
+	Context("allow_alter_system", func() {
+		When("postgres >=17", func() {
+			It("can properly set allow_alter_system to on", func() {
+				info := ConfigurationInfo{
+					IsAlterSystemEnabled: true,
+					MajorVersion:         17,
+				}
+				config := CreatePostgresqlConfiguration(info)
+				Expect(config.GetConfig("allow_alter_system")).To(Equal("on"))
+			})
+
+			It("can properly set allow_alter_system to off", func() {
+				info := ConfigurationInfo{
+					IsAlterSystemEnabled: false,
+					MajorVersion:         18,
+				}
+				config := CreatePostgresqlConfiguration(info)
+				Expect(config.GetConfig("allow_alter_system")).To(Equal("off"))
+			})
+		})
+
+		When("postgres <17", func() {
+			It("should not set allow_alter_system", func() {
+				info := ConfigurationInfo{
+					IsAlterSystemEnabled: false,
+					MajorVersion:         14,
+				}
+				config := CreatePostgresqlConfiguration(info)
+				value, ok := config.configs["allow_alter_system"]
+				Expect(ok).To(BeFalse())
+				Expect(value).To(BeEmpty())
+			})
+			It("should not set allow_alter_system", func() {
+				info := ConfigurationInfo{
+					IsAlterSystemEnabled: true,
+					MajorVersion:         14,
+				}
+				config := CreatePostgresqlConfiguration(info)
+				value, ok := config.configs["allow_alter_system"]
+				Expect(ok).To(BeFalse())
+				Expect(value).To(BeEmpty())
+			})
+		})
+	})
 })
 
 var _ = Describe("pg_hba.conf generation", func() {


### PR DESCRIPTION
In PostgreSQL 17, the new `allow_alter_system` GUC parameter enables or disables the `ALTER SYSTEM` command.

This patch makes the `.spec.postgresql.enableAlterSystem` rely on this new parameter instead of making the `postgresql.auto.conf` file read-only, as done with previous PostgreSQL versions.

Closes #4244
