### PR TITLE
fix: wait for postmaster to shut down before restarting

### DIFF
--- a/internal/cmd/manager/instance/run/lifecycle/lifecycle.go
+++ b/internal/cmd/manager/instance/run/lifecycle/lifecycle.go
@@ -78,9 +78,7 @@ func (i *PostgresLifecycle) Start(ctx context.Context) error {
 
 	signalLoop:
 		for {
-			contextLogger.Debug("starting signal loop")
-			select {
-			case err := <-postMasterErrChan:
+			pgStopHandler := func(pgExitStatus error) {
 				// The postmaster error channel will send an error value, possibly being nil,
 				// corresponding to the postmaster exit status.
 				// Having done that, it will be closed.
@@ -98,17 +96,24 @@ func (i *PostgresLifecycle) Start(ctx context.Context) error {
 				//
 				// In this case we want to terminate the instance manager and let the Kubelet
 				// restart the Pod.
-				if err != nil {
+				if pgExitStatus != nil {
 					var exitError *exec.ExitError
-					if !errors.As(err, &exitError) {
-						contextLogger.Error(err, "Error waiting on the PostgreSQL process")
+					if !errors.As(pgExitStatus, &exitError) {
+						contextLogger.Error(pgExitStatus, "Error waiting on the PostgreSQL process")
 					} else {
 						contextLogger.Error(exitError, "PostgreSQL process exited with errors")
 					}
 				}
+			}
+
+			contextLogger.Debug("starting signal loop")
+			select {
+			case err := <-postMasterErrChan:
+				pgStopHandler(err)
 				if !i.instance.MightBeUnavailable() {
 					return err
 				}
+
 			case <-ctx.Done():
 				// The controller manager asked us to terminate our operations.
 				// We shut down PostgreSQL and terminate using the smart
@@ -149,7 +154,12 @@ func (i *PostgresLifecycle) Start(ctx context.Context) error {
 					contextLogger.Error(err, "while handling instance command request")
 				}
 				if restartNeeded {
-					contextLogger.Info("Restarting the instance")
+					contextLogger.Info("Instance restart requested, waiting for PostgreSQL to shut down")
+					if postMasterErrChan != nil {
+						err := <-postMasterErrChan
+						pgStopHandler(err)
+					}
+					contextLogger.Info("PostgreSQL is shut down, starting the postmaster")
 					break signalLoop
 				}
 			}


### PR DESCRIPTION
This patch ensures the postmaster is terminated before restarting it by checking for it.

Closes: #4916 