### PR TITLE
feat(managed-services): add support for `updateStrategy`

### DIFF
--- a/.wordlist-en-custom.txt
+++ b/.wordlist-en-custom.txt
@@ -396,6 +396,7 @@ ServiceMonitor
 ServiceSelectorType
 ServiceSpec
 ServiceTemplateSpec
+ServiceUpdateStrategy
 ShutdownCheckpointToken
 Silvela
 Slonik
@@ -439,6 +440,7 @@ URIs
 UTF
 Uncomment
 Unrealizable
+UpdateStrategy
 VLDB
 VM
 VMs
@@ -1230,6 +1232,7 @@ unix
 unsetting
 unusablePVC
 updateInterval
+updateStrategy
 upgradable
 uptime
 uri

--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -2464,6 +2464,17 @@ const (
 	ServiceSelectorTypeRO ServiceSelectorType = "ro"
 )
 
+// ServiceUpdateStrategy describes how the changes to the managed service should be handled
+// +kubebuilder:validation:Enum=patch;replace
+type ServiceUpdateStrategy string
+
+const (
+	// ServiceUpdateStrategyPatch applies a patch deriving from the differences of the actual service and the expect one
+	ServiceUpdateStrategyPatch = "patch"
+	// ServiceUpdateStrategyReplace deletes the existing service and recreates it when a difference is detected
+	ServiceUpdateStrategyReplace = "replace"
+)
+
 // ManagedServices represents the services managed by the cluster.
 type ManagedServices struct {
 	// DisabledDefaultServices is a list of service types that are disabled by default.
@@ -2481,6 +2492,11 @@ type ManagedService struct {
 	// Valid values are "rw", "r", and "ro", representing read-write, read, and read-only services.
 	// +kubebuilder:validation:Enum=rw;r;ro
 	SelectorType ServiceSelectorType `json:"selectorType"`
+
+	// UpdateStrategy describes how the service differences should be reconciled
+	// +kubebuilder:default:="patch"
+	UpdateStrategy ServiceUpdateStrategy `json:"updateStrategy,omitempty"`
+
 	// ServiceTemplate is the template specification for the service.
 	ServiceTemplate ServiceTemplateSpec `json:"serviceTemplate"`
 }

--- a/config/crd/bases/postgresql.cnpg.io_clusters.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_clusters.yaml
@@ -3485,6 +3485,14 @@ spec:
                                       type: string
                                   type: object
                               type: object
+                            updateStrategy:
+                              default: patch
+                              description: UpdateStrategy describes how the service
+                                differences should be reconciled
+                              enum:
+                              - patch
+                              - replace
+                              type: string
                           required:
                           - selectorType
                           - serviceTemplate

--- a/docs/src/cloudnative-pg.v1.md
+++ b/docs/src/cloudnative-pg.v1.md
@@ -3193,6 +3193,13 @@ It includes the type of service and its associated template specification.</p>
 Valid values are &quot;rw&quot;, &quot;r&quot;, and &quot;ro&quot;, representing read-write, read, and read-only services.</p>
 </td>
 </tr>
+<tr><td><code>updateStrategy</code> <B>[Required]</B><br/>
+<a href="#postgresql-cnpg-io-v1-ServiceUpdateStrategy"><i>ServiceUpdateStrategy</i></a>
+</td>
+<td>
+   <p>UpdateStrategy describes how the service differences should be reconciled</p>
+</td>
+</tr>
 <tr><td><code>serviceTemplate</code> <B>[Required]</B><br/>
 <a href="#postgresql-cnpg-io-v1-ServiceTemplateSpec"><i>ServiceTemplateSpec</i></a>
 </td>
@@ -4912,6 +4919,20 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 </tr>
 </tbody>
 </table>
+
+## ServiceUpdateStrategy     {#postgresql-cnpg-io-v1-ServiceUpdateStrategy}
+
+(Alias of `string`)
+
+**Appears in:**
+
+- [ManagedService](#postgresql-cnpg-io-v1-ManagedService)
+
+
+<p>ServiceUpdateStrategy describes how the changes to the managed service should be handled</p>
+
+
+
 
 ## SnapshotOwnerReference     {#postgresql-cnpg-io-v1-SnapshotOwnerReference}
 

--- a/docs/src/service_management.md
+++ b/docs/src/service_management.md
@@ -62,7 +62,7 @@ managed:
 
 You can define a list of additional services through the
 [`managed.services.additional` stanza](cloudnative-pg.v1.md#postgresql-cnpg-io-v1-ManagedService)
-by specifying the service type (e.g., `rw`) in the `selectorType` field.
+by specifying the service type (e.g., `rw`) in the `selectorType` field and optionally the `updateStrategy`.
 
 The `serviceTemplate` field gives you access to the standard Kubernetes API for
 the network `Service` resource, allowing you to define both the `metadata` and

--- a/docs/src/service_management.md
+++ b/docs/src/service_management.md
@@ -62,7 +62,8 @@ managed:
 
 You can define a list of additional services through the
 [`managed.services.additional` stanza](cloudnative-pg.v1.md#postgresql-cnpg-io-v1-ManagedService)
-by specifying the service type (e.g., `rw`) in the `selectorType` field and optionally the `updateStrategy`.
+by specifying the service type (e.g., `rw`) in the `selectorType` field
+and optionally the `updateStrategy`.
 
 The `serviceTemplate` field gives you access to the standard Kubernetes API for
 the network `Service` resource, allowing you to define both the `metadata` and
@@ -77,6 +78,17 @@ field, as it is managed by the operator.
     responsibility on your end to ensure that services work as expected.
     CloudNativePG has no control over the service configuration, except honoring
     the selector.
+
+The `updateStrategy` field allows you to control how the operator
+updates a service definition. By default, the operator uses the `patch`
+strategy, applying changes directly to the service.
+Alternatively, the `recreate` strategy deletes the existing service and
+recreates it from the template.
+
+!!! Warning
+    The `recreate` strategy will cause a service disruption with every
+    change.  However, it may be necessary for modifying certain
+    parameters that can only be set during service creation.
 
 For example, if you want to have a single `LoadBalancer` service for your
 PostgreSQL database primary, you can use the following excerpt:

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -211,6 +211,10 @@ func (r *ClusterReconciler) reconcile(ctx context.Context, cluster *apiv1.Cluste
 
 	// Ensure we have the required global objects
 	if err := r.createPostgresClusterObjects(ctx, cluster); err != nil {
+		if errors.Is(err, ErrNextLoop) {
+			return ctrl.Result{}, err
+		}
+		contextLogger.Error(err, "while reconciling postgres cluster objects")
 		if regErr := r.RegisterPhase(ctx, cluster, apiv1.PhaseCannotCreateClusterObjects, err.Error()); regErr != nil {
 			contextLogger.Error(regErr, "unable to register phase", "outerErr", err.Error())
 		}

--- a/internal/controller/cluster_create.go
+++ b/internal/controller/cluster_create.go
@@ -366,7 +366,7 @@ func (r *ClusterReconciler) reconcileManagedServices(ctx context.Context, cluste
 			continue
 		}
 
-		// we ensure the services are deleted
+		// Ensure the service id not present
 		if err := r.serviceReconciler(ctx, cluster, &livingService, false); err != nil {
 			return err
 		}

--- a/internal/controller/cluster_create.go
+++ b/internal/controller/cluster_create.go
@@ -366,7 +366,7 @@ func (r *ClusterReconciler) reconcileManagedServices(ctx context.Context, cluste
 			continue
 		}
 
-		// Ensure the service id not present
+		// Ensure the service is not present
 		if err := r.serviceReconciler(ctx, cluster, &livingService, false); err != nil {
 			return err
 		}

--- a/pkg/specs/services.go
+++ b/pkg/specs/services.go
@@ -152,6 +152,7 @@ func BuildManagedServices(cluster apiv1.Cluster) ([]corev1.Service, error) {
 		builder := servicespec.NewFrom(&serviceConfiguration.ServiceTemplate).
 			WithServiceType(defaultService.Spec.Type, false).
 			WithLabel(utils.IsManagedLabelName, "true").
+			WithAnnotation(utils.UpdateStrategyAnnotation, string(serviceConfiguration.UpdateStrategy)).
 			SetSelectors(defaultService.Spec.Selector)
 
 		for idx := range defaultService.Spec.Ports {

--- a/pkg/utils/labels_annotations.go
+++ b/pkg/utils/labels_annotations.go
@@ -207,7 +207,7 @@ const (
 	ClusterRestartAnnotationName = "kubectl.kubernetes.io/restartedAt"
 
 	// UpdateStrategyAnnotation is the name of the annotation used to indicate how to update the given resource
-	UpdateStrategyAnnotation = MetadataNamespace + "updateStrategy"
+	UpdateStrategyAnnotation = MetadataNamespace + "/updateStrategy"
 )
 
 type annotationStatus string

--- a/pkg/utils/labels_annotations.go
+++ b/pkg/utils/labels_annotations.go
@@ -205,6 +205,9 @@ const (
 	// ClusterRestartAnnotationName is the name of the annotation containing the
 	// latest required restart time
 	ClusterRestartAnnotationName = "kubectl.kubernetes.io/restartedAt"
+
+	// UpdateStrategyAnnotation is the name of the annotation used to indicate how to update the given resource
+	UpdateStrategyAnnotation = MetadataNamespace + "updateStrategy"
 )
 
 type annotationStatus string

--- a/tests/e2e/fixtures/managed_services/cluster-managed-services-replace-strategy.yaml.template
+++ b/tests/e2e/fixtures/managed_services/cluster-managed-services-replace-strategy.yaml.template
@@ -1,0 +1,22 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: cluster-managed-services-rw
+spec:
+  instances: 1
+  imageName: "${POSTGRES_IMG}"
+  storage:
+    size: 1Gi
+    storageClass: ${E2E_DEFAULT_STORAGE_CLASS}
+  managed:
+    services:
+      additional:
+        - selectorType: rw
+          updateStrategy: replace
+          serviceTemplate:
+            metadata:
+              name: "test-rw"
+              labels:
+                test-label: "true"
+              annotations:
+                test-annotation: "true"


### PR DESCRIPTION
Introduce the `updateStrategy` field to control how the operator updates a service definition. By default, the operator uses the `patch` strategy, applying changes directly to the service. Alternatively, the `recreate` strategy deletes the existing service and recreates it from the template.

This is particularly useful to handle changes in cloud-based load balancers for DBaaS scenarios.

Closes #4922 
