### PR TITLE
test: increase query timeout in replica switchover e2e

### DIFF
--- a/tests/e2e/replica_mode_cluster_test.go
+++ b/tests/e2e/replica_mode_cluster_test.go
@@ -674,7 +674,7 @@ var _ = Describe("Replica switchover", Label(tests.LabelReplication), Ordered, f
 				Consistently(func(g Gomega) {
 					pod, err := env.GetClusterPrimary(namespace, clusterBName)
 					g.Expect(err).ToNot(HaveOccurred())
-					stdOut, _, err := env.ExecCommand(env.Ctx, *pod, specs.PostgresContainerName, ptr.To(2*time.Second),
+					stdOut, _, err := env.ExecCommand(env.Ctx, *pod, specs.PostgresContainerName, ptr.To(time.Second*10),
 						"psql", "-U", "postgres", "postgres", "-tAc", "select pg_is_in_recovery();")
 					g.Expect(err).ToNot(HaveOccurred())
 					g.Expect(strings.Trim(stdOut, "\n")).To(Equal("t"))


### PR DESCRIPTION
Bumping a too short query timeout in replica switchover E2E that would produce the following error when running on cloud providers:

```
Summarizing Non-Ignorable Failure(s):

Spec Description:   when primaryUpdateMethod is set to restart
Error Description:  
                    Failed after 36.088s.
                    The function passed to Consistently failed at /home/runner/work/cloudnative-pg/cloudnative-pg/tests/e2e/replica_mode_cluster_test.go:678 with:
                    Unexpected error:
                        <*fmt.wrapError | 0xc012122aa0>: 
                        cmd: [psql -U postgres postgres -tAc select pg_is_in_recovery();]
                        error: context deadline exceeded
                        stdErr: 
                        {
                            msg: "cmd: [psql -U postgres postgres -tAc select pg_is_in_recovery();]\nerror: context deadline exceeded\nstdErr: ",
                            err: <context.deadlineExceededError>{},
                        }
                    occurred
Code Location:      /home/runner/work/cloudnative-pg/cloudnative-pg/tests/e2e/replica_mode_cluster_test.go:680
```