### PR TITLE
test(e2e): introduce a common interface for test environment capabilities

### DIFF
--- a/tests/e2e/apparmor_test.go
+++ b/tests/e2e/apparmor_test.go
@@ -42,8 +42,8 @@ var _ = Describe("AppArmor support", Serial, Label(tests.LabelNoOpenshift, tests
 		if testLevelEnv.Depth < int(level) {
 			Skip("Test depth is lower than the amount requested for this test")
 		}
-		if !IsAKS() {
-			Skip("This test is only run on AKS clusters")
+		if !GetEnvProfile().CanRunAppArmor() {
+			Skip("environment does not support AppArmor")
 		}
 	})
 

--- a/tests/e2e/backup_restore_test.go
+++ b/tests/e2e/backup_restore_test.go
@@ -69,7 +69,7 @@ var _ = Describe("Backup and restore", Label(tests.LabelBackupRestore), func() {
 
 		BeforeAll(func() {
 			if !IsLocal() {
-				Skip("This test is only run on local cluster")
+				Skip("This test is only run on local clusters")
 			}
 			const namespacePrefix = "cluster-backup-minio"
 			var err error

--- a/tests/e2e/commons_test.go
+++ b/tests/e2e/commons_test.go
@@ -18,6 +18,10 @@ package e2e
 
 import "github.com/cloudnative-pg/cloudnative-pg/tests/utils"
 
+func GetEnvProfile() utils.EnvProfile {
+	return utils.GetEnvProfile(*testCloudVendorEnv)
+}
+
 // IsAKS checks if the running cluster is on AKS
 func IsAKS() bool {
 	return *testCloudVendorEnv == utils.AKS

--- a/tests/e2e/disk_space_test.go
+++ b/tests/e2e/disk_space_test.go
@@ -179,9 +179,9 @@ var _ = Describe("Volume space unavailable", Label(tests.LabelStorage), func() {
 		if testLevelEnv.Depth < int(level) {
 			Skip("Test depth is lower than the amount requested for this test")
 		}
-		if IsLocal() {
+		if GetEnvProfile().UsesNodeDiskSpace() {
 			// Local environments use the node disk space, running out of that space could cause multiple failures
-			Skip("This test is not executed on local environments")
+			Skip("this test might exhaust node storage")
 		}
 	})
 

--- a/tests/e2e/drain_node_test.go
+++ b/tests/e2e/drain_node_test.go
@@ -208,7 +208,7 @@ var _ = Describe("E2E Drain Node", Serial, Label(tests.LabelDisruptive, tests.La
 		When("the cluster allows moving PVCs between nodes", func() {
 			BeforeEach(func() {
 				// AKS using rook and the standard GKE StorageClass allow moving PVCs between nodes
-				if !(IsAKS() || IsGKE()) {
+				if !GetEnvProfile().CanMovePVCAcrossNodes() {
 					Skip("This test case is only applicable on clusters where PVC can be moved")
 				}
 			})
@@ -330,7 +330,7 @@ var _ = Describe("E2E Drain Node", Serial, Label(tests.LabelDisruptive, tests.La
 			// All GKE and AKS persistent disks are network storage located independently of the underlying Nodes, so
 			// they don't get deleted after a Drain. Hence, even when using "reusePVC off", all the pods will
 			// be recreated with the same name and will reuse the existing volume.
-			if IsAKS() || IsGKE() {
+			if GetEnvProfile().CanMovePVCAcrossNodes() {
 				Skip("This test case is only applicable on clusters with local storage")
 			}
 		})

--- a/tests/e2e/operator_ha_test.go
+++ b/tests/e2e/operator_ha_test.go
@@ -42,8 +42,8 @@ var _ = Describe("Operator High Availability", Serial,
 			if testLevelEnv.Depth < int(level) {
 				Skip("Test depth is lower than the amount requested for this test")
 			}
-			if IsGKE() {
-				Skip("Skip the scale test case in GKE as in GKE we disable the leader election")
+			if !GetEnvProfile().IsLeaderElectionEnabled() {
+				Skip("Skip the scale test case if leader election is disabled")
 			}
 		})
 

--- a/tests/e2e/operator_ha_test.go
+++ b/tests/e2e/operator_ha_test.go
@@ -42,6 +42,9 @@ var _ = Describe("Operator High Availability", Serial,
 			if testLevelEnv.Depth < int(level) {
 				Skip("Test depth is lower than the amount requested for this test")
 			}
+			if IsGKE() {
+				Skip("Skip the scale test case in GKE as in GKE we disable the leader election")
+			}
 		})
 
 		It("can work as HA mode", func() {

--- a/tests/e2e/volume_snapshot_test.go
+++ b/tests/e2e/volume_snapshot_test.go
@@ -163,10 +163,6 @@ var _ = Describe("Verify Volume Snapshot",
 					Skip("Test depth is lower than the amount requested for this test")
 				}
 
-				if !(IsLocal() || IsGKE()) {
-					Skip("This test is only executed on gke and local")
-				}
-
 				var err error
 				clusterToSnapshotName, err = env.GetResourceNameFromYAML(clusterToSnapshot)
 				Expect(err).ToNot(HaveOccurred())
@@ -356,10 +352,6 @@ var _ = Describe("Verify Volume Snapshot",
 			BeforeAll(func() {
 				if testLevelEnv.Depth < int(level) {
 					Skip("Test depth is lower than the amount requested for this test")
-				}
-
-				if !(IsLocal() || IsGKE()) {
-					Skip("This test is only executed on gke and local")
 				}
 
 				var err error
@@ -576,10 +568,6 @@ var _ = Describe("Verify Volume Snapshot",
 			BeforeAll(func() {
 				if testLevelEnv.Depth < int(level) {
 					Skip("Test depth is lower than the amount requested for this test")
-				}
-
-				if !(IsLocal() || IsGKE()) {
-					Skip("This test is only executed on gke and local")
 				}
 
 				var err error

--- a/tests/e2e/volume_snapshot_test.go
+++ b/tests/e2e/volume_snapshot_test.go
@@ -164,7 +164,7 @@ var _ = Describe("Verify Volume Snapshot",
 				}
 
 				if !(IsLocal() || IsGKE()) {
-					Skip("This test is only executed on gke, openshift and local")
+					Skip("This test is only executed on gke and local")
 				}
 
 				var err error
@@ -359,7 +359,7 @@ var _ = Describe("Verify Volume Snapshot",
 				}
 
 				if !(IsLocal() || IsGKE()) {
-					Skip("This test is only executed on gke, openshift and local")
+					Skip("This test is only executed on gke and local")
 				}
 
 				var err error
@@ -579,7 +579,7 @@ var _ = Describe("Verify Volume Snapshot",
 				}
 
 				if !(IsLocal() || IsGKE()) {
-					Skip("This test is only executed on gke, openshift and local")
+					Skip("This test is only executed on gke and local")
 				}
 
 				var err error

--- a/tests/utils/cloud_vendor.go
+++ b/tests/utils/cloud_vendor.go
@@ -76,11 +76,24 @@ type EnvProfile interface {
 // GetEnvProfile returns a cloud environment's capablities envProfile
 func GetEnvProfile(te TestEnvVendor) EnvProfile {
 	profileMap := map[TestEnvVendor]EnvProfile{
-		LOCAL: envProfile{isLeaderElectionEnabled: true, usesNodeDiskSpace: true},
-		AKS:   envProfile{canMovePVCAcrossNodes: true, isLeaderElectionEnabled: true, canRunAppArmor: true},
-		EKS:   envProfile{isLeaderElectionEnabled: true},
-		GKE:   envProfile{canMovePVCAcrossNodes: true},
-		OCP:   envProfile{isLeaderElectionEnabled: true},
+		LOCAL: envProfile{
+			isLeaderElectionEnabled: true,
+			usesNodeDiskSpace:       true,
+		},
+		AKS: envProfile{
+			canMovePVCAcrossNodes:   true,
+			isLeaderElectionEnabled: true,
+			canRunAppArmor:          true,
+		},
+		EKS: envProfile{
+			isLeaderElectionEnabled: true,
+		},
+		GKE: envProfile{
+			canMovePVCAcrossNodes: true,
+		},
+		OCP: envProfile{
+			isLeaderElectionEnabled: true,
+		},
 	}
 
 	profile, found := profileMap[te]

--- a/tests/utils/cloud_vendor.go
+++ b/tests/utils/cloud_vendor.go
@@ -64,3 +64,64 @@ func TestCloudVendor() (*TestEnvVendor, error) {
 	// if none above, it is a local
 	return &LOCAL, nil
 }
+
+// EnvProfile represents the capabilities of different cloud environments for testing
+type EnvProfile interface {
+	CanMovePVCAcrossNodes() bool
+	IsLeaderElectionEnabled() bool
+	CanRunAppArmor() bool
+	UsesNodeDiskSpace() bool
+}
+
+// GetEnvProfile returns a cloud environment's capablities profile
+func GetEnvProfile(te TestEnvVendor) EnvProfile {
+	profileMap := map[TestEnvVendor]EnvProfile{
+		LOCAL: localProfile{},
+		AKS:   aksProfile{},
+		EKS:   eksProfile{},
+		GKE:   gkeProfile{},
+		OCP:   ocpProfile{},
+	}
+
+	profile, found := profileMap[te]
+	if !found {
+		return localProfile{}
+	}
+
+	return profile
+}
+
+type localProfile struct{}
+
+func (e localProfile) CanMovePVCAcrossNodes() bool   { return false }
+func (e localProfile) IsLeaderElectionEnabled() bool { return true }
+func (e localProfile) CanRunAppArmor() bool          { return false }
+func (e localProfile) UsesNodeDiskSpace() bool       { return true }
+
+type aksProfile struct{}
+
+func (e aksProfile) CanMovePVCAcrossNodes() bool   { return true }
+func (e aksProfile) IsLeaderElectionEnabled() bool { return true }
+func (e aksProfile) CanRunAppArmor() bool          { return true }
+func (e aksProfile) UsesNodeDiskSpace() bool       { return false }
+
+type eksProfile struct{}
+
+func (e eksProfile) CanMovePVCAcrossNodes() bool   { return false }
+func (e eksProfile) IsLeaderElectionEnabled() bool { return true }
+func (e eksProfile) CanRunAppArmor() bool          { return false }
+func (e eksProfile) UsesNodeDiskSpace() bool       { return false }
+
+type gkeProfile struct{}
+
+func (e gkeProfile) CanMovePVCAcrossNodes() bool   { return true }
+func (e gkeProfile) IsLeaderElectionEnabled() bool { return false }
+func (e gkeProfile) CanRunAppArmor() bool          { return false }
+func (e gkeProfile) UsesNodeDiskSpace() bool       { return false }
+
+type ocpProfile struct{}
+
+func (e ocpProfile) CanMovePVCAcrossNodes() bool   { return false }
+func (e ocpProfile) IsLeaderElectionEnabled() bool { return true }
+func (e ocpProfile) CanRunAppArmor() bool          { return false }
+func (e ocpProfile) UsesNodeDiskSpace() bool       { return false }

--- a/tests/utils/cloud_vendor.go
+++ b/tests/utils/cloud_vendor.go
@@ -73,7 +73,7 @@ type EnvProfile interface {
 	UsesNodeDiskSpace() bool
 }
 
-// GetEnvProfile returns a cloud environment's capablities envProfile
+// GetEnvProfile returns a cloud environment's capabilities envProfile
 func GetEnvProfile(te TestEnvVendor) EnvProfile {
 	profileMap := map[TestEnvVendor]EnvProfile{
 		LOCAL: envProfile{

--- a/tests/utils/cloud_vendor.go
+++ b/tests/utils/cloud_vendor.go
@@ -73,55 +73,32 @@ type EnvProfile interface {
 	UsesNodeDiskSpace() bool
 }
 
-// GetEnvProfile returns a cloud environment's capablities profile
+// GetEnvProfile returns a cloud environment's capablities envProfile
 func GetEnvProfile(te TestEnvVendor) EnvProfile {
 	profileMap := map[TestEnvVendor]EnvProfile{
-		LOCAL: localProfile{},
-		AKS:   aksProfile{},
-		EKS:   eksProfile{},
-		GKE:   gkeProfile{},
-		OCP:   ocpProfile{},
+		LOCAL: envProfile{isLeaderElectionEnabled: true, usesNodeDiskSpace: true},
+		AKS:   envProfile{canMovePVCAcrossNodes: true, isLeaderElectionEnabled: true, canRunAppArmor: true},
+		EKS:   envProfile{isLeaderElectionEnabled: true},
+		GKE:   envProfile{canMovePVCAcrossNodes: true},
+		OCP:   envProfile{isLeaderElectionEnabled: true},
 	}
 
 	profile, found := profileMap[te]
 	if !found {
-		return localProfile{}
+		return envProfile{}
 	}
 
 	return profile
 }
 
-type localProfile struct{}
+type envProfile struct {
+	canMovePVCAcrossNodes   bool
+	isLeaderElectionEnabled bool
+	canRunAppArmor          bool
+	usesNodeDiskSpace       bool
+}
 
-func (e localProfile) CanMovePVCAcrossNodes() bool   { return false }
-func (e localProfile) IsLeaderElectionEnabled() bool { return true }
-func (e localProfile) CanRunAppArmor() bool          { return false }
-func (e localProfile) UsesNodeDiskSpace() bool       { return true }
-
-type aksProfile struct{}
-
-func (e aksProfile) CanMovePVCAcrossNodes() bool   { return true }
-func (e aksProfile) IsLeaderElectionEnabled() bool { return true }
-func (e aksProfile) CanRunAppArmor() bool          { return true }
-func (e aksProfile) UsesNodeDiskSpace() bool       { return false }
-
-type eksProfile struct{}
-
-func (e eksProfile) CanMovePVCAcrossNodes() bool   { return false }
-func (e eksProfile) IsLeaderElectionEnabled() bool { return true }
-func (e eksProfile) CanRunAppArmor() bool          { return false }
-func (e eksProfile) UsesNodeDiskSpace() bool       { return false }
-
-type gkeProfile struct{}
-
-func (e gkeProfile) CanMovePVCAcrossNodes() bool   { return true }
-func (e gkeProfile) IsLeaderElectionEnabled() bool { return false }
-func (e gkeProfile) CanRunAppArmor() bool          { return false }
-func (e gkeProfile) UsesNodeDiskSpace() bool       { return false }
-
-type ocpProfile struct{}
-
-func (e ocpProfile) CanMovePVCAcrossNodes() bool   { return false }
-func (e ocpProfile) IsLeaderElectionEnabled() bool { return true }
-func (e ocpProfile) CanRunAppArmor() bool          { return false }
-func (e ocpProfile) UsesNodeDiskSpace() bool       { return false }
+func (p envProfile) CanMovePVCAcrossNodes() bool   { return p.canMovePVCAcrossNodes }
+func (p envProfile) IsLeaderElectionEnabled() bool { return p.isLeaderElectionEnabled }
+func (p envProfile) CanRunAppArmor() bool          { return p.canRunAppArmor }
+func (p envProfile) UsesNodeDiskSpace() bool       { return p.usesNodeDiskSpace }


### PR DESCRIPTION
* introducing a common interface for test environment capabilities
* avoid running Operator HA test in environments where the operator is deployed with leader election disabled
* lifting volume snapshot cloud provider restrictions

Closes #4954 