### PR TITLE
chore: use a proxy to the pod instead of exec a command inside the pod

### DIFF
--- a/internal/cmd/plugin/status/status.go
+++ b/internal/cmd/plugin/status/status.go
@@ -104,7 +104,7 @@ func Status(ctx context.Context, clusterName string, verbose bool, format plugin
 		return err
 	}
 
-	status := ExtractPostgresqlStatus(ctx, cluster)
+	status := extractPostgresqlStatus(ctx, cluster)
 	err = plugin.Print(status, format, os.Stdout)
 	if err != nil || format != plugin.OutputFormatText {
 		return err
@@ -139,8 +139,8 @@ func Status(ctx context.Context, clusterName string, verbose bool, format plugin
 	return nil
 }
 
-// ExtractPostgresqlStatus gets the PostgreSQL status using the Kubernetes API
-func ExtractPostgresqlStatus(ctx context.Context, cluster apiv1.Cluster) *PostgresqlStatus {
+// extractPostgresqlStatus gets the PostgreSQL status using the Kubernetes API
+func extractPostgresqlStatus(ctx context.Context, cluster apiv1.Cluster) *PostgresqlStatus {
 	var errs []error
 
 	managedPods, primaryPod, err := resources.GetInstancePods(ctx, cluster.Name)
@@ -153,7 +153,7 @@ func ExtractPostgresqlStatus(ctx context.Context, cluster apiv1.Cluster) *Postgr
 		ctx,
 		plugin.Config,
 		managedPods,
-		specs.PostgresContainerName)
+	)
 	if len(errList) != 0 {
 		errs = append(errs, errList...)
 	}

--- a/internal/plugin/resources/instance.go
+++ b/internal/plugin/resources/instance.go
@@ -80,7 +80,7 @@ func ExtractInstancesStatus(
 	var errs []error
 
 	for idx := range filteredPods {
-		instanceStatus := getInstanceStatusFromPodViaExec(
+		instanceStatus := getInstanceStatusFromPod(
 			ctx, config, filteredPods[idx])
 		result.Items = append(result.Items, instanceStatus)
 		if instanceStatus.Error != nil {
@@ -91,7 +91,7 @@ func ExtractInstancesStatus(
 	return result, errs
 }
 
-func getInstanceStatusFromPodViaExec(
+func getInstanceStatusFromPod(
 	ctx context.Context,
 	config *rest.Config,
 	pod v1.Pod,

--- a/internal/plugin/resources/instance.go
+++ b/internal/plugin/resources/instance.go
@@ -24,17 +24,18 @@ import (
 	"strconv"
 	"time"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/util/exec"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	corev1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/plugin"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/log"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/url"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/postgres"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/resources/instance"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/specs"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 )
@@ -49,17 +50,17 @@ const (
 
 // GetInstancePods gets all the pods belonging to a given cluster
 // returns an array with all the instances, the primary instance and any error encountered.
-func GetInstancePods(ctx context.Context, clusterName string) ([]v1.Pod, v1.Pod, error) {
-	var pods v1.PodList
+func GetInstancePods(ctx context.Context, clusterName string) ([]corev1.Pod, corev1.Pod, error) {
+	var pods corev1.PodList
 	if err := plugin.Client.List(ctx, &pods, client.InNamespace(plugin.Namespace)); err != nil {
-		return nil, v1.Pod{}, err
+		return nil, corev1.Pod{}, err
 	}
 
-	var managedPods []v1.Pod
-	var primaryPod v1.Pod
+	var managedPods []corev1.Pod
+	var primaryPod corev1.Pod
 	for idx := range pods.Items {
 		for _, owner := range pods.Items[idx].ObjectMeta.OwnerReferences {
-			if owner.Kind == corev1.ClusterKind && owner.Name == clusterName {
+			if owner.Kind == apiv1.ClusterKind && owner.Name == clusterName {
 				managedPods = append(managedPods, pods.Items[idx])
 				if specs.IsPodPrimary(pods.Items[idx]) {
 					primaryPod = pods.Items[idx]
@@ -74,7 +75,7 @@ func GetInstancePods(ctx context.Context, clusterName string) ([]v1.Pod, v1.Pod,
 func ExtractInstancesStatus(
 	ctx context.Context,
 	config *rest.Config,
-	filteredPods []v1.Pod,
+	filteredPods []corev1.Pod,
 ) (postgres.PostgresqlStatusList, []error) {
 	var result postgres.PostgresqlStatusList
 	var errs []error
@@ -94,14 +95,20 @@ func ExtractInstancesStatus(
 func getInstanceStatusFromPod(
 	ctx context.Context,
 	config *rest.Config,
-	pod v1.Pod,
+	pod corev1.Pod,
 ) postgres.PostgresqlStatus {
 	var result postgres.PostgresqlStatus
 
 	statusResult, err := kubernetes.NewForConfigOrDie(config).
 		CoreV1().
 		Pods(pod.Namespace).
-		ProxyGet("https", pod.Name, strconv.Itoa(int(url.StatusPort)), url.PathPgStatus, map[string]string{}).
+		ProxyGet(
+			instance.GetStatusSchemeFromPod(&pod).ToString(),
+			pod.Name,
+			strconv.Itoa(int(url.StatusPort)),
+			url.PathPgStatus,
+			nil,
+		).
 		DoRaw(ctx)
 	if err != nil {
 		result.AddPod(pod)
@@ -121,7 +128,7 @@ func getInstanceStatusFromPod(
 // IsInstanceRunning returns a boolean indicating if the given instance is running and any error encountered
 func IsInstanceRunning(
 	ctx context.Context,
-	pod v1.Pod,
+	pod corev1.Pod,
 ) (bool, error) {
 	contextLogger := log.FromContext(ctx).WithName("plugin.IsInstanceRunning")
 	timeout := time.Second * 10


### PR DESCRIPTION
This patch employs a `pods/proxy` call to read the instance status,
eliminating the need to execute any command inside the pod.
This reduces the required permissions for the status plugin command.
The update ensures backward compatibility with previous versions of
the operator.

Closes #4941