### PR TITLE
fix: skip immutable databases in pg_database default-monitoring query

### DIFF
--- a/config/manager/default-monitoring.yaml
+++ b/config/manager/default-monitoring.yaml
@@ -76,14 +76,14 @@ data:
             usage: "GAUGE"
             description: "Total number of backends that are currently waiting on other queries"
 
-    pg_database_frozen_xid:
+    pg_database:
       query: |
         SELECT datname
           , pg_catalog.pg_database_size(datname) AS size_bytes
           , pg_catalog.age(datfrozenxid) AS xid_age
           , pg_catalog.mxid_age(datminmxid) AS mxid_age
         FROM pg_catalog.pg_database
-          WHERE datname not in ('template0','template1')
+          WHERE datallowconn = 't'
       metrics:
         - datname:
             usage: "LABEL"

--- a/config/manager/default-monitoring.yaml
+++ b/config/manager/default-monitoring.yaml
@@ -83,7 +83,7 @@ data:
           , pg_catalog.age(datfrozenxid) AS xid_age
           , pg_catalog.mxid_age(datminmxid) AS mxid_age
         FROM pg_catalog.pg_database
-          WHERE datallowconn = 't'
+        WHERE datallowconn
       metrics:
         - datname:
             usage: "LABEL"

--- a/config/manager/default-monitoring.yaml
+++ b/config/manager/default-monitoring.yaml
@@ -76,13 +76,14 @@ data:
             usage: "GAUGE"
             description: "Total number of backends that are currently waiting on other queries"
 
-    pg_database:
+    pg_database_frozen_xid:
       query: |
         SELECT datname
           , pg_catalog.pg_database_size(datname) AS size_bytes
           , pg_catalog.age(datfrozenxid) AS xid_age
           , pg_catalog.mxid_age(datminmxid) AS mxid_age
         FROM pg_catalog.pg_database
+          WHERE datname not in ('template0','template1')
       metrics:
         - datname:
             usage: "LABEL"

--- a/docs/src/samples/monitoring/prometheusrule.yaml
+++ b/docs/src/samples/monitoring/prometheusrule.yaml
@@ -24,7 +24,7 @@ spec:
       for: 1m
       labels:
         severity: warning
-    - alert: PGDatabase
+    - alert: PGDatabaseFrozenXid
       annotations:
         description: Over 150,000,000 transactions from frozen xid on pod {{ $labels.pod  }}
         summary: Number of transactions from the frozen XID to the current one

--- a/docs/src/samples/monitoring/prometheusrule.yaml
+++ b/docs/src/samples/monitoring/prometheusrule.yaml
@@ -24,7 +24,7 @@ spec:
       for: 1m
       labels:
         severity: warning
-    - alert: PGDatabaseFrozenXid
+    - alert: PGDatabaseXidAge
       annotations:
         description: Over 150,000,000 transactions from frozen xid on pod {{ $labels.pod  }}
         summary: Number of transactions from the frozen XID to the current one


### PR DESCRIPTION
This patch excludes immutable databases (databases not allowing connections) from monitoring and alerting. Specifically, the `template0` database is immutable and should not trigger the `PGDatabaseXidAge` alert (formerly known as `PGDatabase`), as all its content is frozen.

Closes #4978 
