### PR TITLE
fix: immediate backup not retried

### DIFF
--- a/internal/controller/scheduledbackup_controller.go
+++ b/internal/controller/scheduledbackup_controller.go
@@ -174,11 +174,13 @@ func ReconcileScheduledBackup(
 	now := time.Now()
 	origScheduled := scheduledBackup.DeepCopy()
 
+	if scheduledBackup.Status.LastCheckTime == nil && scheduledBackup.IsImmediate() {
+		// we populate the status (lastCheckTime...) by following the same rules of the scheduled backup
+		event.Eventf(scheduledBackup, "Normal", "BackupSchedule", "Scheduled immediate backup now: %v", now)
+		return createBackup(ctx, event, cli, scheduledBackup, now, now, schedule, true)
+	}
+
 	if scheduledBackup.Status.LastCheckTime == nil {
-		if scheduledBackup.IsImmediate() {
-			event.Eventf(scheduledBackup, "Normal", "BackupSchedule", "Scheduled immediate backup now: %v", now)
-			return createBackup(ctx, event, cli, scheduledBackup, now, now, schedule, true)
-		}
 		// This is the first time we check this schedule,
 		// let's wait until the first job will be actually
 		// scheduled

--- a/internal/controller/scheduledbackup_controller.go
+++ b/internal/controller/scheduledbackup_controller.go
@@ -172,7 +172,6 @@ func ReconcileScheduledBackup(
 	}
 
 	now := time.Now()
-	origScheduled := scheduledBackup.DeepCopy()
 
 	if scheduledBackup.Status.LastCheckTime == nil && scheduledBackup.IsImmediate() {
 		// we populate the status (lastCheckTime...) by following the same rules of the scheduled backup
@@ -181,6 +180,7 @@ func ReconcileScheduledBackup(
 	}
 
 	if scheduledBackup.Status.LastCheckTime == nil {
+		origScheduled := scheduledBackup.DeepCopy()
 		// This is the first time we check this schedule,
 		// let's wait until the first job will be actually
 		// scheduled


### PR DESCRIPTION
Avoid setting the `lastCheckTime` on `ScheduledBackup` before creating the immediate `Backup`. If the operation fails, the operator will skip it in the next, re-queued, reconciliation loop if it finds the `lastCheckTime` set in the status.

Moving the creation of the immediate `Backup` before the `lastCheckTime` status update, solves the issue. 

Closes #4981 
