### PR TITLE
fix(pooler): enhance rollout control during operator upgrade

### DIFF
--- a/internal/controller/pooler_update.go
+++ b/internal/controller/pooler_update.go
@@ -101,8 +101,6 @@ func (r *PoolerReconciler) updateDeployment(
 		deployment := resources.Deployment.DeepCopy()
 		deployment.Spec.Replicas = generatedDeployment.Spec.Replicas
 
-		// If the Pooler is annotated with `cnpg.io/reconcilePodSpec: disabled`,
-		// we keep the original Deployment spec to avoid rollouts
 		if !utils.IsPodSpecReconciliationDisabled(&pooler.ObjectMeta) {
 			deployment.Spec = generatedDeployment.Spec
 		}

--- a/pkg/specs/pgbouncer/deployments_test.go
+++ b/pkg/specs/pgbouncer/deployments_test.go
@@ -23,11 +23,11 @@ import (
 	"k8s.io/utils/ptr"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	config "github.com/cloudnative-pg/cloudnative-pg/internal/configuration"
 	pgBouncerConfig "github.com/cloudnative-pg/cloudnative-pg/pkg/management/pgbouncer/config"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/postgres"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/specs"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
-	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils/hash"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -76,7 +76,7 @@ var _ = Describe("Deployment", func() {
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(deployment).ToNot(BeNil())
 
-		expectedHash, err := hash.ComputeVersionedHash(pooler.Spec, 3)
+		expectedHash, err := computeTemplateHash(pooler, config.Current.OperatorImageName)
 		Expect(err).ShouldNot(HaveOccurred())
 
 		// Check the computed hash

--- a/pkg/utils/hash/hash.go
+++ b/pkg/utils/hash/hash.go
@@ -41,16 +41,15 @@ func DeepHashObject(hasher hash.Hash, objectToWrite interface{}) error {
 	return err
 }
 
-// ComputeHash returns a hash value calculated from pod template and
-// a collisionCount to avoid hash collision. The hash will be safe encoded to
-// avoid bad words.
+// ComputeHash returns a hash value calculated from the provided object.
+// The hash will be safe encoded to avoid bad words.
 func ComputeHash(object interface{}) (string, error) {
-	podTemplateSpecHasher := fnv.New32a()
-	if err := DeepHashObject(podTemplateSpecHasher, object); err != nil {
+	hasher := fnv.New32a()
+	if err := DeepHashObject(hasher, object); err != nil {
 		return "", err
 	}
 
-	return rand.SafeEncodeString(fmt.Sprint(podTemplateSpecHasher.Sum32())), nil
+	return rand.SafeEncodeString(fmt.Sprint(hasher.Sum32())), nil
 }
 
 // ComputeVersionedHash follows the same rules of ComputeHash with the exception that accepts also a epoc value.

--- a/pkg/utils/labels_annotations.go
+++ b/pkg/utils/labels_annotations.go
@@ -107,6 +107,9 @@ const (
 	// the status of the reconciliation loop for the cluster
 	ReconciliationLoopAnnotationName = MetadataNamespace + "/reconciliationLoop"
 
+	// ReconcilePodSpecAnnotationName is the name of the annotation that prevents the pod spec to be reconciled
+	ReconcilePodSpecAnnotationName = MetadataNamespace + "/reconcilePodSpec"
+
 	// HibernateClusterManifestAnnotationName contains the hibernated cluster manifest
 	// Deprecated. Replaced by: ClusterManifestAnnotationName. This annotation is
 	// kept for backward compatibility
@@ -390,6 +393,14 @@ func AnnotateAppArmor(object *metav1.ObjectMeta, spec *corev1.PodSpec, annotatio
 // IsReconciliationDisabled checks if the reconciliation loop is disabled on the given resource
 func IsReconciliationDisabled(object *metav1.ObjectMeta) bool {
 	return object.Annotations[ReconciliationLoopAnnotationName] == string(annotationStatusDisabled)
+}
+
+// IsPodSpecReconciliationDisabled checks if the pod spec reconciliation is disabled
+func IsPodSpecReconciliationDisabled(object *metav1.ObjectMeta) bool {
+	if object.Annotations == nil {
+		return false
+	}
+	return object.Annotations[ReconcilePodSpecAnnotationName] == string(annotationStatusDisabled)
 }
 
 // IsEmptyWalArchiveCheckEnabled returns a boolean indicating if we should run the logic that checks if the WAL archive


### PR DESCRIPTION
This update clarifies Pooler pods' restart behavior. Previously, the operator image name was excluded from the configuration hash calculation, so an operator upgrade would not have generated a rollout until anything else in the spec changed, even if that change did not require a rollout. This behavior was surprising for the user.

To remove surprises, we now include the operator image in the configuration hash, so every upgrade triggers a rollout.

Additionally, for users who prefer more control over rollouts, we've introduced the annotation `cnpg.io/reconcilePodSpec: disabled`. This annotation prevents any updates to the Pooler deployment, except for changes to the number of replicas.

Closes #4999 