### PR TITLE
chore: fix Dockerfile warning related to uppercase and lowercase mix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # This builder stage it's only because we need a command
 # to create a symlink and reduce the size of the image
-FROM gcr.io/distroless/static-debian12:debug-nonroot as builder
+FROM gcr.io/distroless/static-debian12:debug-nonroot AS builder
 ARG TARGETARCH
 
 SHELL ["/busybox/sh", "-c"]


### PR DESCRIPTION
From the docker documentation https://docs.docker.com/reference/build-checks/from-as-casing/
we shouldn't mix upper case FROM with a lowercase AS