### PR TITLE
chore: exclude pkg/versions from renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -9,7 +9,7 @@
 // The branches renovate should target
 // PLEASE UPDATE THIS WHEN RELEASING.
   "baseBranches": ["main","release-1.22", "release-1.23"],
-  "ignorePaths": ["docs/**", "releases/**", "contribute/**", "licenses/**"],
+  "ignorePaths": ["docs/**", "releases/**", "contribute/**", "licenses/**", "pkg/versions/**"],
   "postUpdateOptions": ["gomodTidy"],
   "semanticCommits": "enabled",
 // All PRs should have a label


### PR DESCRIPTION
Renovate detects the image inside pkg/versions/versions.go and tries to
update the image tag, we already have a script to cover this and all the
other files that need to be updated.