### PR TITLE
feat: allow enforcing min sync replicas

### DIFF
--- a/.wordlist-en-custom.txt
+++ b/.wordlist-en-custom.txt
@@ -232,6 +232,8 @@ MetricType
 MiB
 Milsted
 MinIO
+MinSyncReplicasEnforcement
+MinSyncReplicasEnforcementType
 Minikube
 MonitoringConfiguration
 NFS
@@ -888,6 +890,7 @@ microservice
 microservices
 microsoft
 minSyncReplicas
+minSyncReplicasEnforcement
 minikube
 minio
 mmap

--- a/api/v1/cluster_configuration_test.go
+++ b/api/v1/cluster_configuration_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package v1
 
 import (
+	"k8s.io/utils/ptr"
+
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -64,7 +66,7 @@ var _ = Describe("ensuring the correctness of synchronous replica data calculati
 		Expect(names).To(Equal([]string{differentAZPod}))
 	})
 
-	It("should lower the synchronous replica number to enforce self-healing", func() {
+	It("should lower the synchronous replica number to enforce self-healing when minSyncReplicas is not enforced", func() {
 		cluster := createFakeCluster("exampleOnePod")
 		cluster.Status = ClusterStatus{
 			CurrentPrimary: "exampleOnePod-1",
@@ -80,7 +82,26 @@ var _ = Describe("ensuring the correctness of synchronous replica data calculati
 		Expect(cluster.Spec.MinSyncReplicas).To(Equal(1))
 	})
 
-	It("should behave correctly if there is no ready host", func() {
+	It("should list all the replicas when minSyncReplicas is enforced", func() {
+		cluster := createFakeCluster("exampleOnePod")
+		cluster.Spec.PostgresConfiguration.MinSyncReplicasEnforcement = ptr.To(
+			MinSyncReplicasEnforcementTypeRequired)
+		cluster.Status = ClusterStatus{
+			CurrentPrimary: "exampleOnePod-1",
+			InstancesStatus: map[utils.PodStatus][]string{
+				utils.PodHealthy: {"exampleOnePod-1"},
+				utils.PodFailed:  {"exampleOnePod-2", "exampleOnePod-3"},
+			},
+			InstanceNames: []string{"exampleOnePod-1", "exampleOnePod-2", "exampleOnePod-3"},
+		}
+		number, names := cluster.GetSyncReplicasData()
+
+		Expect(number).To(Equal(1))
+		Expect(names).To(HaveLen(2))
+		Expect(cluster.Spec.MinSyncReplicas).To(Equal(1))
+	})
+
+	It("should behave correctly if there is no ready host when minSyncReplicas is not enforced", func() {
 		cluster := createFakeCluster("exampleNoPods")
 		cluster.Status = ClusterStatus{
 			CurrentPrimary: "example-1",
@@ -92,5 +113,47 @@ var _ = Describe("ensuring the correctness of synchronous replica data calculati
 
 		Expect(number).To(BeZero())
 		Expect(names).To(BeEmpty())
+	})
+
+	It("should behave correctly if there is no ready host when minSyncReplicas is enforced", func() {
+		cluster := createFakeCluster("exampleNoPods")
+		cluster.Spec.PostgresConfiguration.MinSyncReplicasEnforcement = ptr.To(
+			MinSyncReplicasEnforcementTypeRequired)
+		cluster.Status = ClusterStatus{
+			CurrentPrimary: "exampleNoPods-1",
+			InstancesStatus: map[utils.PodStatus][]string{
+				utils.PodFailed: {"exampleNoPods-1", "exampleNoPods-2", "exampleNoPods-3"},
+			},
+			InstanceNames: []string{"exampleNoPods-1", "exampleNoPods-2", "exampleNoPods-3"},
+		}
+		number, names := cluster.GetSyncReplicasData()
+
+		Expect(number).To(Equal(1))
+		Expect(names).To(HaveLen(2))
+	})
+})
+
+var _ = Describe("should understand whether to consider non-ready replicas as synchronous candidates", func() {
+	When("when MinSyncReplicasEnforcement is not set", func() {
+		It("should retain the existing behavior", func() {
+			cluster := createFakeCluster("example")
+			Expect(cluster.Spec.PostgresConfiguration.IsMinSyncReplicasEnforcementRequired()).To(BeFalse())
+		})
+	})
+
+	When("when MinSyncReplicasEnforcement is set to preferred", func() {
+		It("should retain the existing behavior", func() {
+			cluster := createFakeCluster("example")
+			cluster.Spec.PostgresConfiguration.MinSyncReplicasEnforcement = ptr.To(MinSyncReplicasEnforcementTypePreferred)
+			Expect(cluster.Spec.PostgresConfiguration.IsMinSyncReplicasEnforcementRequired()).To(BeFalse())
+		})
+	})
+
+	When("when MinSyncReplicasEnforcement is set to required", func() {
+		It("should enforce unready replicas as synchronous", func() {
+			cluster := createFakeCluster("example")
+			cluster.Spec.PostgresConfiguration.MinSyncReplicasEnforcement = ptr.To(MinSyncReplicasEnforcementTypeRequired)
+			Expect(cluster.Spec.PostgresConfiguration.IsMinSyncReplicasEnforcementRequired()).To(BeTrue())
+		})
 	})
 })

--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -1403,6 +1403,17 @@ type PostgresConfiguration struct {
 	// +optional
 	SyncReplicaElectionConstraint SyncReplicaElectionConstraints `json:"syncReplicaElectionConstraint,omitempty"`
 
+	// MinSyncReplicasEnforcement describe how synchronous replication react
+	// to non-ready replicas. When not set or set to `preferred`, those
+	// replicas are not considered against the synchronous replication
+	// candidates, giving priority to the availability of the cluster.
+	// When set to `required`, non-ready replicas are considered
+	// synchronous replication candidates, giving priority to the
+	// consistency of the cluster over its availability.
+	// +kubebuilder:validation:Enum=preferred;required
+	// +optional
+	MinSyncReplicasEnforcement *MinSyncReplicasEnforcementType `json:"minSyncReplicasEnforcement,omitempty"`
+
 	// Lists of shared preload libraries to add to the default ones
 	// +optional
 	AdditionalLibraries []string `json:"shared_preload_libraries,omitempty"`
@@ -1424,6 +1435,19 @@ type PostgresConfiguration struct {
 	// +optional
 	EnableAlterSystem bool `json:"enableAlterSystem,omitempty"`
 }
+
+// MinSyncReplicasEnforcementType is the type of .spec.postgres.minSyncReplicasEnforcement
+type MinSyncReplicasEnforcementType string
+
+const (
+	// MinSyncReplicasEnforcementTypePreferred means the enforcement of minSyncReplicas
+	// is preferred and the actual number of ready replicas is taken into consideration
+	MinSyncReplicasEnforcementTypePreferred = MinSyncReplicasEnforcementType("preferred")
+
+	// MinSyncReplicasEnforcementTypeRequired means the enforcement of minSyncReplicas
+	// is required, being replicas actually ready or not
+	MinSyncReplicasEnforcementTypeRequired = MinSyncReplicasEnforcementType("required")
+)
 
 // BootstrapConfiguration contains information about how to create the PostgreSQL
 // cluster. Only a single bootstrap method can be defined among the supported

--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -1403,13 +1403,14 @@ type PostgresConfiguration struct {
 	// +optional
 	SyncReplicaElectionConstraint SyncReplicaElectionConstraints `json:"syncReplicaElectionConstraint,omitempty"`
 
-	// MinSyncReplicasEnforcement describe how synchronous replication react
-	// to non-ready replicas. When not set or set to `preferred`, those
-	// replicas are not considered against the synchronous replication
-	// candidates, giving priority to the availability of the cluster.
-	// When set to `required`, non-ready replicas are considered
-	// synchronous replication candidates, giving priority to the
-	// consistency of the cluster over its availability.
+	// MinSyncReplicasEnforcement describes how synchronous replication
+	// handles non-ready replicas. When this setting is either unset or set
+	// to `preferred`, non-ready replicas are excluded from the pool of
+	// synchronous replication candidates, prioritizing the cluster's
+	// availability.  When set to `required` — the typical expectation of a
+	// PostgreSQL DBA — non-ready replicas are included as synchronous
+	// replication candidates, prioritizing the cluster's consistency over
+	// its availability.
 	// +kubebuilder:validation:Enum=preferred;required
 	// +optional
 	MinSyncReplicasEnforcement *MinSyncReplicasEnforcementType `json:"minSyncReplicasEnforcement,omitempty"`

--- a/api/v1/suite_test.go
+++ b/api/v1/suite_test.go
@@ -44,6 +44,7 @@ func createFakeCluster(name string) *Cluster {
 			utils.PodHealthy: {primaryPod, fmt.Sprintf("%s-2", name), fmt.Sprintf("%s-3", name)},
 			utils.PodFailed:  {},
 		},
+		InstanceNames: []string{"exampleOnePod-1", "exampleOnePod-2", "exampleOnePod-3"},
 	}
 	return cluster
 }

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -2201,6 +2201,11 @@ func (in *PostgresConfiguration) DeepCopyInto(out *PostgresConfiguration) {
 		copy(*out, *in)
 	}
 	in.SyncReplicaElectionConstraint.DeepCopyInto(&out.SyncReplicaElectionConstraint)
+	if in.MinSyncReplicasEnforcement != nil {
+		in, out := &in.MinSyncReplicasEnforcement, &out.MinSyncReplicasEnforcement
+		*out = new(MinSyncReplicasEnforcementType)
+		**out = **in
+	}
 	if in.AdditionalLibraries != nil {
 		in, out := &in.AdditionalLibraries, &out.AdditionalLibraries
 		*out = make([]string, len(*in))

--- a/config/crd/bases/postgresql.cnpg.io_clusters.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_clusters.yaml
@@ -3906,13 +3906,14 @@ spec:
                     type: object
                   minSyncReplicasEnforcement:
                     description: |-
-                      MinSyncReplicasEnforcement describe how synchronous replication react
-                      to non-ready replicas. When not set or set to `preferred`, those
-                      replicas are not considered against the synchronous replication
-                      candidates, giving priority to the availability of the cluster.
-                      When set to `required`, non-ready replicas are considered
-                      synchronous replication candidates, giving priority to the
-                      consistency of the cluster over its availability.
+                      MinSyncReplicasEnforcement describes how synchronous replication
+                      handles non-ready replicas. When this setting is either unset or set
+                      to `preferred`, non-ready replicas are excluded from the pool of
+                      synchronous replication candidates, prioritizing the cluster's
+                      availability.  When set to `required` — the typical expectation of a
+                      PostgreSQL DBA — non-ready replicas are included as synchronous
+                      replication candidates, prioritizing the cluster's consistency over
+                      its availability.
                     enum:
                     - preferred
                     - required

--- a/config/crd/bases/postgresql.cnpg.io_clusters.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_clusters.yaml
@@ -3904,6 +3904,19 @@ spec:
                           is default
                         type: boolean
                     type: object
+                  minSyncReplicasEnforcement:
+                    description: |-
+                      MinSyncReplicasEnforcement describe how synchronous replication react
+                      to non-ready replicas. When not set or set to `preferred`, those
+                      replicas are not considered against the synchronous replication
+                      candidates, giving priority to the availability of the cluster.
+                      When set to `required`, non-ready replicas are considered
+                      synchronous replication candidates, giving priority to the
+                      consistency of the cluster over its availability.
+                    enum:
+                    - preferred
+                    - required
+                    type: string
                   parameters:
                     additionalProperties:
                       type: string

--- a/docs/src/cloudnative-pg.v1.md
+++ b/docs/src/cloudnative-pg.v1.md
@@ -4045,13 +4045,14 @@ set up.</p>
 <a href="#postgresql-cnpg-io-v1-MinSyncReplicasEnforcementType"><i>MinSyncReplicasEnforcementType</i></a>
 </td>
 <td>
-   <p>MinSyncReplicasEnforcement describe how synchronous replication react
-to non-ready replicas. When not set or set to <code>preferred</code>, those
-replicas are not considered against the synchronous replication
-candidates, giving priority to the availability of the cluster.
-When set to <code>required</code>, non-ready replicas are considered
-synchronous replication candidates, giving priority to the
-consistency of the cluster over its availability.</p>
+   <p>MinSyncReplicasEnforcement describes how synchronous replication
+handles non-ready replicas. When this setting is either unset or set
+to <code>preferred</code>, non-ready replicas are excluded from the pool of
+synchronous replication candidates, prioritizing the cluster's
+availability.  When set to <code>required</code> — the typical expectation of a
+PostgreSQL DBA — non-ready replicas are included as synchronous
+replication candidates, prioritizing the cluster's consistency over
+its availability.</p>
 </td>
 </tr>
 <tr><td><code>shared_preload_libraries</code><br/>

--- a/docs/src/cloudnative-pg.v1.md
+++ b/docs/src/cloudnative-pg.v1.md
@@ -3293,6 +3293,20 @@ More info: http://kubernetes.io/docs/user-guide/annotations</p>
 </tbody>
 </table>
 
+## MinSyncReplicasEnforcementType     {#postgresql-cnpg-io-v1-MinSyncReplicasEnforcementType}
+
+(Alias of `string`)
+
+**Appears in:**
+
+- [PostgresConfiguration](#postgresql-cnpg-io-v1-PostgresConfiguration)
+
+
+<p>MinSyncReplicasEnforcementType is the type of .spec.postgres.minSyncReplicasEnforcement</p>
+
+
+
+
 ## MonitoringConfiguration     {#postgresql-cnpg-io-v1-MonitoringConfiguration}
 
 
@@ -4025,6 +4039,19 @@ to the pg_ident.conf file)</p>
 <td>
    <p>Requirements to be met by sync replicas. This will affect how the &quot;synchronous_standby_names&quot; parameter will be
 set up.</p>
+</td>
+</tr>
+<tr><td><code>minSyncReplicasEnforcement</code><br/>
+<a href="#postgresql-cnpg-io-v1-MinSyncReplicasEnforcementType"><i>MinSyncReplicasEnforcementType</i></a>
+</td>
+<td>
+   <p>MinSyncReplicasEnforcement describe how synchronous replication react
+to non-ready replicas. When not set or set to <code>preferred</code>, those
+replicas are not considered against the synchronous replication
+candidates, giving priority to the availability of the cluster.
+When set to <code>required</code>, non-ready replicas are considered
+synchronous replication candidates, giving priority to the
+consistency of the cluster over its availability.</p>
 </td>
 </tr>
 <tr><td><code>shared_preload_libraries</code><br/>

--- a/docs/src/replication.md
+++ b/docs/src/replication.md
@@ -125,10 +125,13 @@ Where:
 - `pod1, pod2, ...` is the list of all PostgreSQL pods in the cluster
 
 !!! Warning
-    To provide self-healing capabilities, the operator can ignore
-    `minSyncReplicas` if such value is higher than the currently available
-    number of replicas. Synchronous replication is automatically disabled
-    when `readyReplicas` is `0`.
+    By default, CloudNativePG prioritizes self-healing over consistency by
+    ignoring `minSyncReplicas` if it exceeds the currently available number of
+    replicas. Synchronous replication is automatically disabled when
+    `readyReplicas` is `0`. This behavior differs from the expectations of a
+    typical PostgreSQL DBA, who prioritizes database consistency over
+    availability when synchronous replication is requested. In such cases, you
+    can set `.spec.postgresql.minSyncReplicasEnforcement` to `required`.
 
 As stated in the
 [PostgreSQL documentation](https://www.postgresql.org/docs/current/warm-standby.html#SYNCHRONOUS-REPLICATION),

--- a/docs/src/samples/cluster-example-syncreplicas.yaml
+++ b/docs/src/samples/cluster-example-syncreplicas.yaml
@@ -5,8 +5,11 @@ metadata:
 spec:
   instances: 5
 
-  minSyncReplicas: 1
-  maxSyncReplicas: 3
+  minSyncReplicas: 3
+  maxSyncReplicas: 4
+
+  postgresql:
+    minSyncReplicasEnforcement: required
 
   storage:
     size: 1G

--- a/tests/e2e/fixtures/sync_replicas/cluster-pgstatstatements-enforce.yaml.template
+++ b/tests/e2e/fixtures/sync_replicas/cluster-pgstatstatements-enforce.yaml.template
@@ -1,0 +1,25 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: cluster-pgstatstatements
+spec:
+  instances: 3
+
+  minSyncReplicas: 1
+  maxSyncReplicas: 1
+
+  postgresql:
+    minSyncReplicasEnforcement: required
+    parameters:
+      log_checkpoints: "on"
+      log_lock_waits: "on"
+      log_min_duration_statement: '1000'
+      log_statement: 'ddl'
+      log_temp_files: '1024'
+      log_autovacuum_min_duration: '1s'
+      'pg_stat_statements.max': '10000'
+      log_replication_commands: 'on'
+
+  storage:
+    storageClass: ${E2E_DEFAULT_STORAGE_CLASS}
+    size: 1G

--- a/tests/e2e/fixtures/sync_replicas/cluster-syncreplicas-enforce.yaml.template
+++ b/tests/e2e/fixtures/sync_replicas/cluster-syncreplicas-enforce.yaml.template
@@ -1,0 +1,24 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: cluster-syncreplicas
+spec:
+  instances: 3
+
+  minSyncReplicas: 1
+  maxSyncReplicas: 2
+
+  postgresql:
+    minSyncReplicasEnforcement: required
+    parameters:
+      log_checkpoints: "on"
+      log_lock_waits: "on"
+      log_min_duration_statement: '1000'
+      log_statement: 'ddl'
+      log_temp_files: '1024'
+      log_autovacuum_min_duration: '1s'
+      log_replication_commands: 'on'
+
+  storage:
+    storageClass: ${E2E_DEFAULT_STORAGE_CLASS}
+    size: 1G


### PR DESCRIPTION
Introduce the `.spec.postgresql.enforceMinSyncReplicas` field to control the enforcement of synchronous replicas.

- When set to `true`, the number of synchronous replicas specified in `minSyncReplicas` is enforced, even if the corresponding instances are not ready.
- When set to `false` or left unset (default), the system prioritizes self-healing over strict data consistency (the only behaviour currently available).

This enhancement provides better control over data replication strategies to meet specific requirements.

Closes #3969 
Relates #5000 