### PR TITLE
chore: improve OLM environment detection

### DIFF
--- a/internal/cmd/plugin/report/olm.go
+++ b/internal/cmd/plugin/report/olm.go
@@ -20,13 +20,14 @@ import (
 	"archive/zip"
 	"context"
 	"fmt"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"path/filepath"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/plugin"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/dynamic"
 )
 
 // getOlmResource gets the desired resource using the Dynamic Client
@@ -40,12 +41,14 @@ func getOlmResource(
 		Resource: item,
 	}
 
-	list, err := dynamicClient.Resource(resource).Namespace(namespace).List(ctx, metav1.ListOptions{LabelSelector: labelOperatorKeyPrefix + "openshift-operators"})
+	list, err := dynamicClient.Resource(resource).Namespace(namespace).
+		List(ctx, metav1.ListOptions{LabelSelector: labelOperatorKeyPrefix + "openshift-operators"})
 	if err != nil {
 		return nil, fmt.Errorf("could note get resource: %v, %v", resource, err)
 	}
 
-	list, err = dynamicClient.Resource(resource).Namespace(namespace).List(ctx, metav1.ListOptions{LabelSelector: labelOperatorKeyPrefix + plugin.Namespace})
+	list, err = dynamicClient.Resource(resource).Namespace(namespace).
+		List(ctx, metav1.ListOptions{LabelSelector: labelOperatorKeyPrefix + plugin.Namespace})
 	if err != nil {
 		return nil, fmt.Errorf("could note get resource: %v, %v", resource, err)
 	}

--- a/internal/cmd/plugin/report/olm.go
+++ b/internal/cmd/plugin/report/olm.go
@@ -23,7 +23,6 @@ import (
 	"path/filepath"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -31,50 +30,29 @@ import (
 	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/plugin"
 )
 
-// getOlmResource gets the desired resource using the Dynamic Client
+// getOlmResourceList gets the desired resource using the Dynamic Client
 // to avoid code dependencies on the OLM libraries
-func getOlmResource(
+func getOlmResourceList(
 	ctx context.Context,
 	dynamicClient dynamic.Interface,
 	namespace, resource string,
 ) (client.ObjectList, error) {
-	isContained := func(item unstructured.Unstructured, list []unstructured.Unstructured) bool {
-		for _, element := range list {
-			if element.GetName() == item.GetName() {
-				return true
-			}
-		}
-		return false
-	}
-
 	gvr := schema.GroupVersionResource{
 		Group:    "operators.coreos.com",
 		Version:  "v1alpha1",
 		Resource: resource,
 	}
 
-	listFromLabelOpenshift, err := dynamicClient.Resource(gvr).Namespace(namespace).
-		List(ctx, metav1.ListOptions{LabelSelector: labelOpenshiftOperators})
-	if err != nil {
-		return nil, fmt.Errorf("could note get resource: %v, %v", gvr, err)
-	}
-
-	listFromLabelNamespace, err := dynamicClient.Resource(gvr).Namespace(namespace).
+	resourceList, err := dynamicClient.Resource(gvr).Namespace(namespace).
 		List(ctx, metav1.ListOptions{LabelSelector: getLabelOperatorsNamespace()})
 	if err != nil {
 		return nil, fmt.Errorf("could note get resource: %v, %v", gvr, err)
 	}
 
-	for _, item := range listFromLabelNamespace.Items {
-		if !isContained(item, listFromLabelOpenshift.Items) {
-			listFromLabelOpenshift.Items = append(listFromLabelOpenshift.Items, item)
-		}
-	}
-
-	return listFromLabelOpenshift, err
+	return resourceList, nil
 }
 
-// olmOperatorReport contains the operator data in Oolm
+// olmOperatorReport contains the operator data in OLM
 // to be printed by the `report operator` plugin
 type olmOperatorReport map[string]client.ObjectList
 
@@ -89,12 +67,13 @@ func getOlmReport(ctx context.Context, namespace string) (olmOperatorReport, err
 	}
 
 	for _, item := range resources {
-		resource, err := getOlmResource(ctx, cli, namespace, item)
+		resource, err := getOlmResourceList(ctx, cli, namespace, item)
 		if err != nil {
 			return nil, fmt.Errorf("could not build report. Failed on item %s: %w", item, err)
 		}
 		report[item] = resource
 	}
+
 	return report, nil
 }
 

--- a/internal/cmd/plugin/report/olm.go
+++ b/internal/cmd/plugin/report/olm.go
@@ -65,9 +65,8 @@ func getOlmResource(
 		return nil, fmt.Errorf("could note get resource: %v, %v", gvr, err)
 	}
 
-	for idx := range listFromLabelOpenshift.Items {
-		item := listFromLabelOpenshift.Items[idx]
-		if !isContained(item, listFromLabelNamespace.Items) {
+	for _, item := range listFromLabelNamespace.Items {
+		if !isContained(item, listFromLabelOpenshift.Items) {
 			listFromLabelOpenshift.Items = append(listFromLabelOpenshift.Items, item)
 		}
 	}

--- a/internal/cmd/plugin/report/olm.go
+++ b/internal/cmd/plugin/report/olm.go
@@ -42,13 +42,13 @@ func getOlmResource(
 	}
 
 	list, err := dynamicClient.Resource(resource).Namespace(namespace).
-		List(ctx, metav1.ListOptions{LabelSelector: labelOperatorKeyPrefix + "openshift-operators"})
+		List(ctx, metav1.ListOptions{LabelSelector: labelOpenshiftOperators})
 	if err != nil {
 		return nil, fmt.Errorf("could note get resource: %v, %v", resource, err)
 	}
 
 	list, err = dynamicClient.Resource(resource).Namespace(namespace).
-		List(ctx, metav1.ListOptions{LabelSelector: labelOperatorKeyPrefix + plugin.Namespace})
+		List(ctx, metav1.ListOptions{LabelSelector: getLabelOperatorsNamespace()})
 	if err != nil {
 		return nil, fmt.Errorf("could note get resource: %v, %v", resource, err)
 	}

--- a/internal/cmd/plugin/report/olm.go
+++ b/internal/cmd/plugin/report/olm.go
@@ -1,0 +1,97 @@
+/*
+Copyright The CloudNativePG Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package report
+
+import (
+	"archive/zip"
+	"context"
+	"fmt"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"path/filepath"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/plugin"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+)
+
+// getOlmResource gets the desired resource using the Dynamic Client
+// to avoid code dependencies on the OLM libraries
+func getOlmResource(
+	ctx context.Context, dynamicClient dynamic.Interface, namespace, item string,
+) (client.ObjectList, error) {
+	resource := schema.GroupVersionResource{
+		Group:    "operators.coreos.com",
+		Version:  "v1alpha1",
+		Resource: item,
+	}
+
+	list, err := dynamicClient.Resource(resource).Namespace(namespace).List(ctx, metav1.ListOptions{LabelSelector: labelOperatorKeyPrefix + "openshift-operators"})
+	if err != nil {
+		return nil, fmt.Errorf("could note get resource: %v, %v", resource, err)
+	}
+
+	list, err = dynamicClient.Resource(resource).Namespace(namespace).List(ctx, metav1.ListOptions{LabelSelector: labelOperatorKeyPrefix + plugin.Namespace})
+	if err != nil {
+		return nil, fmt.Errorf("could note get resource: %v, %v", resource, err)
+	}
+	return list, err
+}
+
+// olmOperatorReport contains the operator data in Oolm
+// to be printed by the `report operator` plugin
+type olmOperatorReport map[string]client.ObjectList
+
+// getOlmReport builds the olm operator report
+func getOlmReport(ctx context.Context, namespace string) (olmOperatorReport, error) {
+	items := []string{"clusterserviceversions", "installplans", "subscriptions"}
+	operatorReport := make(olmOperatorReport)
+
+	client, err := dynamic.NewForConfig(plugin.Config)
+	if err != nil {
+		return nil, fmt.Errorf("could not get dynamic client: %w", err)
+	}
+
+	for _, item := range items {
+		resource, err := getOlmResource(ctx, client, namespace, item)
+		if err != nil {
+			return nil, fmt.Errorf("could not build report. Failed on item %s: %w", item, err)
+		}
+		operatorReport[item] = resource
+	}
+	return operatorReport, nil
+}
+
+// writeToZip makes a new section in the ZIP file, and adds in it various
+// Kubernetes object manifests
+func (olmReport olmOperatorReport) writeToZip(
+	zipper *zip.Writer, format plugin.OutputFormat, folder string,
+) error {
+	newFolder := filepath.Join(folder, "olm")
+	_, err := zipper.Create(newFolder + "/")
+	if err != nil {
+		return err
+	}
+
+	for key, value := range olmReport {
+		err = addContentToZip(value, key, newFolder, format, zipper)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/cmd/plugin/report/operator_objects.go
+++ b/internal/cmd/plugin/report/operator_objects.go
@@ -39,7 +39,6 @@ const (
 	labelOperatorNameKey    = "app.kubernetes.io/name"
 	labelOperatorName       = "cloudnative-pg"
 	labelOperatorKeyPrefix  = "operators.coreos.com/cloudnative-pg."
-	labelOpenshiftOperators = labelOperatorKeyPrefix + "openshift-operators"
 )
 
 var errNoOperatorDeployment = fmt.Errorf("no deployment found")
@@ -53,27 +52,8 @@ func getOperatorDeployment(ctx context.Context) (appsv1.Deployment, error) {
 	deployment, err := tryGetOperatorDeployment(ctx,
 		ctrlclient.MatchingLabels{labelOperatorNameKey: labelOperatorName},
 		ctrlclient.InNamespace(plugin.Namespace))
-	if err != errNoOperatorDeployment {
-		return deployment, err
-	}
-
-	deployment, err = tryGetOperatorDeployment(ctx,
-		ctrlclient.HasLabels{labelOpenshiftOperators},
-		ctrlclient.InNamespace(plugin.Namespace))
-	if err != errNoOperatorDeployment {
-		return deployment, err
-	}
-
-	deployment, err = tryGetOperatorDeployment(ctx,
-		ctrlclient.HasLabels{getLabelOperatorsNamespace()},
-		ctrlclient.InNamespace(plugin.Namespace))
-	if err == errNoOperatorDeployment {
-		return appsv1.Deployment{},
-			fmt.Errorf("could not get operator in namespace '%s': %w",
-				plugin.Namespace, err)
-	}
 	if err != nil {
-		return appsv1.Deployment{}, err
+		return deployment, fmt.Errorf("could not get operator in namespace '%s': %w", plugin.Namespace, err)
 	}
 
 	return deployment, nil

--- a/internal/cmd/plugin/report/operator_objects.go
+++ b/internal/cmd/plugin/report/operator_objects.go
@@ -49,14 +49,9 @@ func getLabelOperatorsNamespace() string {
 
 // getOperatorDeployment returns the operator Deployment if there is a single one running, error otherwise
 func getOperatorDeployment(ctx context.Context) (appsv1.Deployment, error) {
-	deployment, err := tryGetOperatorDeployment(ctx,
+	return tryGetOperatorDeployment(ctx,
 		ctrlclient.MatchingLabels{labelOperatorNameKey: labelOperatorName},
 		ctrlclient.InNamespace(plugin.Namespace))
-	if err != nil {
-		return deployment, fmt.Errorf("could not get operator in namespace '%s': %w", plugin.Namespace, err)
-	}
-
-	return deployment, nil
 }
 
 // tryGetOperatorDeployment tries to fetch the operator deployment from the
@@ -66,11 +61,17 @@ func tryGetOperatorDeployment(ctx context.Context, options ...ctrlclient.ListOpt
 	deploymentList := &appsv1.DeploymentList{}
 
 	if err := plugin.Client.List(ctx, deploymentList, options...); err != nil {
-		return appsv1.Deployment{}, err
+		return appsv1.Deployment{},
+			fmt.Errorf("could not get operator in namespace '%s': %w",
+				plugin.Namespace,
+				err,
+			)
 	}
 	// We check if we have one or more deployments
 	if len(deploymentList.Items) > 1 {
-		return appsv1.Deployment{}, fmt.Errorf("number of operator deployments bigger than 1")
+		return appsv1.Deployment{},
+			fmt.Errorf("could not get operator in namespace '%s': number of operator deployments bigger than 1",
+				plugin.Namespace)
 	}
 
 	if len(deploymentList.Items) == 1 {

--- a/internal/cmd/plugin/report/operator_objects.go
+++ b/internal/cmd/plugin/report/operator_objects.go
@@ -39,9 +39,14 @@ const (
 	labelOperatorNameKey    = "app.kubernetes.io/name"
 	labelOperatorName       = "cloudnative-pg"
 	labelOperatorKeyPrefix  = "operators.coreos.com/cloudnative-pg."
+	labelOpenshiftOperators = labelOperatorKeyPrefix + "openshift-operators"
 )
 
 var errNoOperatorDeployment = fmt.Errorf("no deployment found")
+
+func getLabelOperatorsNamespace() string {
+	return labelOperatorKeyPrefix + plugin.Namespace
+}
 
 // getOperatorDeployment returns the operator Deployment if there is a single one running, error otherwise
 func getOperatorDeployment(ctx context.Context) (appsv1.Deployment, error) {
@@ -53,14 +58,14 @@ func getOperatorDeployment(ctx context.Context) (appsv1.Deployment, error) {
 	}
 
 	deployment, err = tryGetOperatorDeployment(ctx,
-		ctrlclient.HasLabels{labelOperatorKeyPrefix + "openshift-operators"},
+		ctrlclient.HasLabels{labelOpenshiftOperators},
 		ctrlclient.InNamespace(plugin.Namespace))
 	if err != errNoOperatorDeployment {
 		return deployment, err
 	}
 
 	deployment, err = tryGetOperatorDeployment(ctx,
-		ctrlclient.HasLabels{labelOperatorKeyPrefix + plugin.Namespace},
+		ctrlclient.HasLabels{getLabelOperatorsNamespace()},
 		ctrlclient.InNamespace(plugin.Namespace))
 	if err == errNoOperatorDeployment {
 		return appsv1.Deployment{},

--- a/pkg/utils/discovery.go
+++ b/pkg/utils/discovery.go
@@ -39,6 +39,9 @@ var haveSCC bool
 // haveVolumeSnapshot stores the result of the VolumeSnapshotExist function
 var haveVolumeSnapshot bool
 
+// olmPlatform specifies whethere we are running on a platform with OLM support
+var olmPlatform bool
+
 // AvailableArchitecture is a struct containing info about an available architecture
 type AvailableArchitecture struct {
 	GoArch         string
@@ -227,4 +230,17 @@ func detectAvailableArchitectures(filepathGlob string) error {
 // DetectAvailableArchitectures detects the architectures available in the cluster
 func DetectAvailableArchitectures() error {
 	return detectAvailableArchitectures("bin/manager_*")
+}
+
+// DetectOLM looks for the operators.coreos.com operators resource in the current
+// Kubernetes cluster
+func DetectOLM(client discovery.DiscoveryInterface) (err error) {
+	olmPlatform = false
+	olmPlatform, err = resourceExist(client, "operators.coreos.com/v1", "operators")
+	return
+}
+
+// RunningOnOLM returns if we're running over a Kubernetes cluster with OLM support
+func RunningOnOLM() bool {
+	return olmPlatform
 }

--- a/pkg/utils/discovery.go
+++ b/pkg/utils/discovery.go
@@ -39,7 +39,7 @@ var haveSCC bool
 // haveVolumeSnapshot stores the result of the VolumeSnapshotExist function
 var haveVolumeSnapshot bool
 
-// olmPlatform specifies whethere we are running on a platform with OLM support
+// olmPlatform specifies whether we are running on a platform with OLM support
 var olmPlatform bool
 
 // AvailableArchitecture is a struct containing info about an available architecture


### PR DESCRIPTION
As far as now, we were relying on the detection of the SecurityContextConstraint to know that we were running on an OLM environment but this is not a secure way since an OLM environment may or may not have a SCC inside, that's why we should look at the `operators.coreos.com/v1` resources and check that  it exists, if this is the case, we're in an OLM environment.

This helps us to improve the plugin report and properly retrieve more useful information.

Closes #3764
