### PR TITLE
fix(permissions): add cluster role permissions for ClusterImageCatalogs

### DIFF
--- a/config/olm-rbac/role_global.yaml
+++ b/config/olm-rbac/role_global.yaml
@@ -12,3 +12,11 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+    - postgresql.cnpg.io
+  resources:
+    - clusterimagecatalogs
+  verbs:
+    - get
+    - list
+    - watch

--- a/docs/src/security.md
+++ b/docs/src/security.md
@@ -210,8 +210,8 @@ permission management.
 
 #### Why Are ClusterRole Permissions Needed?
 
-The operator currently requires `ClusterRole` permissions just to read `nodes`
-objects. All other permissions can be namespace-scoped (i.e., `Role`) or
+The operator currently requires `ClusterRole` permissions to read `nodes` and
+`ClusterImageCatalog` objects. All other permissions can be namespace-scoped (i.e., `Role`) or
 cluster-wide (i.e., `ClusterRole`).
 
 Even with these permissions, if someone gains access to the `ServiceAccount`,


### PR DESCRIPTION
The ClusterImageCatalog is a non-namespaced object that we create and
it should be readable by the operator, when using OLM and the operator is
installed in one namespace, this permissions was missing.

Closes #5029 