### PR TITLE
chore: remove seccomp detection, drop support of k8s < 1.25

### DIFF
--- a/internal/cmd/manager/controller/controller.go
+++ b/internal/cmd/manager/controller/controller.go
@@ -200,12 +200,6 @@ func RunController(
 		return err
 	}
 
-	// Detect if we support SeccompProfile
-	if err = utils.DetectSeccompSupport(discoveryClient); err != nil {
-		setupLog.Error(err, "unable to detect SeccompProfile support")
-		return err
-	}
-
 	// Detect the available architectures
 	if err = utils.DetectAvailableArchitectures(); err != nil {
 		setupLog.Error(err, "unable to detect the available instance's architectures")
@@ -214,7 +208,6 @@ func RunController(
 
 	setupLog.Info("Kubernetes system metadata",
 		"haveSCC", utils.HaveSecurityContextConstraints(),
-		"haveSeccompProfile", utils.HaveSeccompSupport(),
 		"haveVolumeSnapshot", utils.HaveVolumeSnapshot(),
 		"availableArchitectures", utils.GetAvailableArchitectures(),
 	)

--- a/pkg/specs/containers.go
+++ b/pkg/specs/containers.go
@@ -24,7 +24,6 @@ import (
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/internal/configuration"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/log"
-	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 )
 
 // createBootstrapContainer creates the init container bootstrapping the operator
@@ -62,10 +61,6 @@ func addManagerLoggingOptions(cluster apiv1.Cluster, container *corev1.Container
 func CreateContainerSecurityContext(seccompProfile *corev1.SeccompProfile) *corev1.SecurityContext {
 	trueValue := true
 	falseValue := false
-
-	if !utils.HaveSeccompSupport() {
-		seccompProfile = nil
-	}
 
 	return &corev1.SecurityContext{
 		Capabilities: &corev1.Capabilities{

--- a/pkg/specs/containers_test.go
+++ b/pkg/specs/containers_test.go
@@ -21,8 +21,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
-	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -56,25 +54,11 @@ var _ = Describe("Bootstrap Container creation", func() {
 })
 
 var _ = Describe("Container Security Context creation", func() {
-	It("with nil SeccompProfile", func() {
-		cluster := &apiv1.Cluster{}
-		utils.SetSeccompSupport(false)
-		securityContext := CreateContainerSecurityContext(cluster.GetSeccompProfile())
-
-		Expect(*securityContext.RunAsNonRoot).To(BeTrue())
-		Expect(*securityContext.AllowPrivilegeEscalation).To(BeFalse())
-		Expect(*securityContext.Privileged).To(BeFalse())
-		Expect(*securityContext.ReadOnlyRootFilesystem).To(BeTrue())
-
-		Expect(securityContext.SeccompProfile).To(BeNil())
-	})
-
 	It("with valid SeccompProfile", func() {
 		cluster := &apiv1.Cluster{}
 		runtimeProfile := &corev1.SeccompProfile{
 			Type: corev1.SeccompProfileTypeRuntimeDefault,
 		}
-		utils.SetSeccompSupport(true)
 		securityContext := CreateContainerSecurityContext(cluster.GetSeccompProfile())
 
 		Expect(securityContext.SeccompProfile).ToNot(BeNil())
@@ -91,7 +75,6 @@ var _ = Describe("Container Security Context creation", func() {
 			SeccompProfile: localhostProfile,
 		}}
 
-		utils.SetSeccompSupport(true)
 		securityContext := CreateContainerSecurityContext(cluster.GetSeccompProfile())
 		Expect(securityContext.SeccompProfile).ToNot(BeNil())
 		Expect(securityContext.SeccompProfile).To(BeEquivalentTo(localhostProfile))

--- a/pkg/specs/containers_test.go
+++ b/pkg/specs/containers_test.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )

--- a/pkg/specs/pods.go
+++ b/pkg/specs/pods.go
@@ -384,10 +384,6 @@ func CreatePodSecurityContext(seccompProfile *corev1.SeccompProfile, user, group
 		return nil
 	}
 
-	if !utils.HaveSeccompSupport() {
-		seccompProfile = nil
-	}
-
 	trueValue := true
 	return &corev1.PodSecurityContext{
 		RunAsNonRoot:   &trueValue,

--- a/pkg/specs/pods_test.go
+++ b/pkg/specs/pods_test.go
@@ -26,8 +26,6 @@ import (
 
 	v1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/postgres"
-	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -61,24 +59,9 @@ var (
 	}
 )
 
-var _ = Describe("The PostgreSQL security context with nil SeccompProfile", func() {
-	cluster := v1.Cluster{}
-	utils.SetSeccompSupport(false)
-	securityContext := CreatePodSecurityContext(cluster.GetSeccompProfile(), 26, 26)
-
-	It("allows the container to create its own PGDATA", func() {
-		Expect(securityContext.RunAsUser).To(Equal(securityContext.FSGroup))
-	})
-
-	It("by default it should be nil", func() {
-		Expect(securityContext.SeccompProfile).To(BeNil())
-	})
-})
-
 var _ = Describe("The PostgreSQL security context with", func() {
 	It("default RuntimeDefault profile", func() {
 		cluster := v1.Cluster{}
-		utils.SetSeccompSupport(true)
 		securityContext := CreatePodSecurityContext(cluster.GetSeccompProfile(), 26, 26)
 
 		Expect(securityContext.SeccompProfile).ToNot(BeNil())
@@ -92,7 +75,6 @@ var _ = Describe("The PostgreSQL security context with", func() {
 			LocalhostProfile: &profilePath,
 		}
 		cluster := v1.Cluster{Spec: v1.ClusterSpec{SeccompProfile: localhostProfile}}
-		utils.SetSeccompSupport(true)
 		securityContext := CreatePodSecurityContext(cluster.GetSeccompProfile(), 26, 26)
 
 		Expect(securityContext.SeccompProfile).ToNot(BeNil())

--- a/pkg/specs/pods_test.go
+++ b/pkg/specs/pods_test.go
@@ -26,6 +26,7 @@ import (
 
 	v1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/postgres"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )

--- a/pkg/utils/discovery.go
+++ b/pkg/utils/discovery.go
@@ -39,9 +39,6 @@ var haveSCC bool
 // haveVolumeSnapshot stores the result of the VolumeSnapshotExist function
 var haveVolumeSnapshot bool
 
-// supportSeccomp specifies whether we should set the SeccompProfile or not in the pods
-var supportSeccomp bool
-
 // AvailableArchitecture is a struct containing info about an available architecture
 type AvailableArchitecture struct {
 	GoArch         string
@@ -186,17 +183,6 @@ func PodMonitorExist(client discovery.DiscoveryInterface) (bool, error) {
 	return exist, nil
 }
 
-// HaveSeccompSupport returns true if Seccomp is supported. If it is, we should
-// set the SeccompProfile in the pods
-func HaveSeccompSupport() bool {
-	return supportSeccomp
-}
-
-// SetSeccompSupport set the supportSeccomp variable to a specific value for testing purposes
-func SetSeccompSupport(value bool) {
-	supportSeccomp = value
-}
-
 // extractK8sMinorVersion extracts and parses the Kubernetes minor version from
 // the version info that's been  detected by discovery client
 func extractK8sMinorVersion(info *version.Info) (int, error) {
@@ -207,27 +193,6 @@ func extractK8sMinorVersion(info *version.Info) (int, error) {
 	}
 
 	return strconv.Atoi(matches[1])
-}
-
-// DetectSeccompSupport checks the version of Kubernetes in the cluster to determine
-// whether Seccomp is supported
-func DetectSeccompSupport(client discovery.DiscoveryInterface) (err error) {
-	supportSeccomp = false
-	kubernetesVersion, err := client.ServerVersion()
-	if err != nil {
-		return err
-	}
-
-	minor, err := extractK8sMinorVersion(kubernetesVersion)
-	if err != nil {
-		return err
-	}
-
-	if minor >= 24 {
-		supportSeccomp = true
-	}
-
-	return
 }
 
 // GetAvailableArchitectures returns the available instance's architectures

--- a/pkg/utils/discovery_test.go
+++ b/pkg/utils/discovery_test.go
@@ -42,45 +42,6 @@ var _ = DescribeTable("Kubernetes minor version detection",
 	Entry("When minor version is wrong", &version.Info{Minor: "c3p0"}, 0, false),
 )
 
-var _ = Describe("Set and unset Seccomp support", func() {
-	It("should have seccomp support", func() {
-		SetSeccompSupport(true)
-		Expect(HaveSeccompSupport()).To(BeTrue())
-	})
-
-	It("should not have seccomp support", func() {
-		SetSeccompSupport(false)
-		Expect(HaveSeccompSupport()).To(BeFalse())
-	})
-})
-
-var _ = Describe("Detect Seccomp support depending on", func() {
-	client := fakeClient.NewSimpleClientset()
-	fakeDiscovery := client.Discovery().(*discoveryFake.FakeDiscovery)
-
-	It("version 1.22 not supported", func() {
-		fakeDiscovery.FakedServerVersion = &version.Info{
-			Major: "1",
-			Minor: "22",
-		}
-
-		err := DetectSeccompSupport(client.Discovery())
-		Expect(err).ToNot(HaveOccurred())
-		Expect(HaveSeccompSupport()).To(BeFalse())
-	})
-
-	It("version 1.26 supported", func() {
-		fakeDiscovery.FakedServerVersion = &version.Info{
-			Major: "1",
-			Minor: "26",
-		}
-
-		err := DetectSeccompSupport(client.Discovery())
-		Expect(err).ToNot(HaveOccurred())
-		Expect(HaveSeccompSupport()).To(BeTrue())
-	})
-})
-
 var _ = Describe("Detect resources properly when", func() {
 	client := fakeClient.NewSimpleClientset()
 	fakeDiscovery := client.Discovery().(*discoveryFake.FakeDiscovery)

--- a/tests/utils/azurite.go
+++ b/tests/utils/azurite.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/utils/ptr"
 
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/certs"
-	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 )
 
 const (
@@ -124,9 +123,6 @@ func InstallAzCli(namespace string, env *TestingEnvironment) error {
 func getAzuriteClientPod(namespace string) corev1.Pod {
 	seccompProfile := &corev1.SeccompProfile{
 		Type: corev1.SeccompProfileTypeRuntimeDefault,
-	}
-	if !utils.HaveSeccompSupport() {
-		seccompProfile = nil
 	}
 
 	cliClientPod := corev1.Pod{
@@ -237,9 +233,6 @@ func getAzuriteDeployment(namespace string) apiv1.Deployment {
 	replicas := int32(1)
 	seccompProfile := &corev1.SeccompProfile{
 		Type: corev1.SeccompProfileTypeRuntimeDefault,
-	}
-	if !utils.HaveSeccompSupport() {
-		seccompProfile = nil
 	}
 
 	azuriteDeployment := apiv1.Deployment{

--- a/tests/utils/environment.go
+++ b/tests/utils/environment.go
@@ -160,11 +160,6 @@ func NewTestingEnvironment() (*TestingEnvironment, error) {
 		return nil, fmt.Errorf("could not get the discovery client: %w", err)
 	}
 
-	err = utils.DetectSeccompSupport(clientDiscovery)
-	if err != nil {
-		return nil, fmt.Errorf("could not detect SeccompProfile support: %w", err)
-	}
-
 	err = utils.DetectSecurityContextConstraints(clientDiscovery)
 	if err != nil {
 		return nil, fmt.Errorf("could not detect SeccompProfile support: %w", err)

--- a/tests/utils/minio.go
+++ b/tests/utils/minio.go
@@ -36,7 +36,6 @@ import (
 
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/certs"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/postgres"
-	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 )
 
 const (
@@ -131,9 +130,6 @@ func MinioDefaultSetup(namespace string) (MinioSetup, error) {
 func MinioDefaultDeployment(namespace string, minioPVC corev1.PersistentVolumeClaim) appsv1.Deployment {
 	seccompProfile := &corev1.SeccompProfile{
 		Type: corev1.SeccompProfileTypeRuntimeDefault,
-	}
-	if !utils.HaveSeccompSupport() {
-		seccompProfile = nil
 	}
 
 	minioDeployment := appsv1.Deployment{
@@ -349,9 +345,6 @@ func MinioSSLSetup(namespace string) (MinioSetup, error) {
 func MinioDefaultClient(namespace string) corev1.Pod {
 	seccompProfile := &corev1.SeccompProfile{
 		Type: corev1.SeccompProfileTypeRuntimeDefault,
-	}
-	if !utils.HaveSeccompSupport() {
-		seccompProfile = nil
 	}
 
 	minioClient := corev1.Pod{

--- a/tests/utils/psql_client.go
+++ b/tests/utils/psql_client.go
@@ -17,13 +17,13 @@ limitations under the License.
 package utils
 
 import (
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/specs"
-	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/versions"
 )
 
@@ -52,7 +52,7 @@ func createPsqlClient(namespace string, env *TestingEnvironment) (*corev1.Pod, e
 	seccompProfile := &corev1.SeccompProfile{
 		Type: corev1.SeccompProfileTypeRuntimeDefault,
 	}
-	if !utils.HaveSeccompSupport() || utils.HaveSecurityContextConstraints() {
+	if utils.HaveSecurityContextConstraints() {
 		seccompProfile = nil
 	}
 

--- a/tests/utils/psql_client.go
+++ b/tests/utils/psql_client.go
@@ -17,13 +17,13 @@ limitations under the License.
 package utils
 
 import (
-	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/specs"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/versions"
 )
 

--- a/tests/utils/psql_client.go
+++ b/tests/utils/psql_client.go
@@ -23,7 +23,6 @@ import (
 	"k8s.io/utils/ptr"
 
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/specs"
-	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/versions"
 )
 
@@ -51,9 +50,6 @@ func GetPsqlClient(namespace string, env *TestingEnvironment) (*corev1.Pod, erro
 func createPsqlClient(namespace string, env *TestingEnvironment) (*corev1.Pod, error) {
 	seccompProfile := &corev1.SeccompProfile{
 		Type: corev1.SeccompProfileTypeRuntimeDefault,
-	}
-	if utils.HaveSecurityContextConstraints() {
-		seccompProfile = nil
 	}
 
 	psqlPod := &corev1.Pod{

--- a/tests/utils/webapp.go
+++ b/tests/utils/webapp.go
@@ -20,8 +20,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
-
-	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 )
 
 // DefaultWebapp returns a struct representing a
@@ -29,9 +27,6 @@ func DefaultWebapp(namespace string, name string, rootCASecretName string, tlsSe
 	var secretMode int32 = 0o600
 	seccompProfile := &corev1.SeccompProfile{
 		Type: corev1.SeccompProfileTypeRuntimeDefault,
-	}
-	if !utils.HaveSeccompSupport() {
-		seccompProfile = nil
 	}
 
 	return corev1.Pod{


### PR DESCRIPTION
The Seccomp profile was dropped on Kubernetes 1.25 and we stop supporting this
version since 1.21 of our operator, also, this is adding time to the operator startup
by calling the API, which in some cases, could be a couple of seconds depending on
how slow is the API server responding, from now on, this drop the support of
older Kubernetes versions and also reduce the amount of time for the operator
to startup.

Closes #5028 
