### PR TITLE
chore: enable regional cluster for GKE test

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -1657,7 +1657,9 @@ jobs:
           set +e
           # We may go over the amount of API requests allowed
           # by Google when creating all the clusters at the same time.
-          # We give a few attempts at creating the cluster before giving up
+          # We give a few attempts at creating the cluster before giving up.
+          # The following command will create a 3 nodes cluster, with each
+          # node deployed in its own availability zone.
           for i in `seq 1 5`; do
             if gcloud container clusters create ${{ env.CLUSTER_NAME }} \
               --num-nodes=1 \

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -1590,7 +1590,7 @@ jobs:
       E2E_CSI_STORAGE_CLASS: standard-rwo
       E2E_DEFAULT_VOLUMESNAPSHOT_CLASS: pd-csi-snapclass
 
-      ZONE: europe-west3-a
+      REGION: europe-west3
       TEST_CLOUD_VENDOR: "gke"
 
     steps:
@@ -1662,7 +1662,7 @@ jobs:
             if gcloud container clusters create ${{ env.CLUSTER_NAME }} \
               --num-nodes=3 \
               --cluster-version=${{ env.K8S_VERSION }} \
-              --zone=${{ env.ZONE }} \
+              --region=${{ env.REGION }} \
               --disk-size=20 \
               --machine-type=e2-standard-2 \
               --labels=cluster=${{ env.CLUSTER_NAME }}
@@ -1679,7 +1679,7 @@ jobs:
         env:
           USE_GKE_GCLOUD_AUTH_PLUGIN: "True"
         run: |
-          gcloud container clusters get-credentials ${{ env.CLUSTER_NAME }} --zone ${{ env.ZONE }} --project ${{ secrets.GCP_PROJECT_ID }}
+          gcloud container clusters get-credentials ${{ env.CLUSTER_NAME }} --region ${{ env.REGION }} --project ${{ secrets.GCP_PROJECT_ID }}
       -
         name: Configure Storage
         run: |
@@ -1785,13 +1785,13 @@ jobs:
           attempt=1
           max_attempts=3
           while [ "${attempt}" -le "${max_attempts}" ]; do
-            gcloud container clusters delete ${{ env.CLUSTER_NAME }} --zone=${{ env.ZONE }} --quiet
+            gcloud container clusters delete ${{ env.CLUSTER_NAME }} --region=${{ env.REGION }} --quiet
             status=$?
             if [[ $status == 0 ]]; then
-                echo "GKS cluster ${{ env.CLUSTER_NAME }} deleted from zone ${{ env.ZONE }}"
+                echo "GKS cluster ${{ env.CLUSTER_NAME }} deleted from region ${{ env.REGION }}"
                 break
             fi
-            echo "Failed deleting cluster ${{ env.CLUSTER_NAME }} from zone ${{ env.ZONE }}, retrying"
+            echo "Failed deleting cluster ${{ env.CLUSTER_NAME }} from region ${{ env.REGION }}, retrying"
             sleep 5
             attempt=$((attempt+1))
           done
@@ -1803,7 +1803,7 @@ jobs:
           attempt=1
           max_attempts=3
           while [ "${attempt}" -le "${max_attempts}" ]; do
-            IDS=$(gcloud compute disks list --filter="labels.cluster=${{ env.CLUSTER_NAME }} AND zone:${{ env.ZONE }} AND -users:*" --format="value(id)")
+            IDS=$(gcloud compute disks list --filter="labels.cluster=${{ env.CLUSTER_NAME }} AND region:${{ env.REGION }} AND -users:*" --format="value(id)")
             amount="$(echo $IDS | awk '{print NF}')"
             if [[ "$amount" == 3 ]]; then
               echo -e "Found the 3 disks to be removed:\n$IDS"
@@ -1819,13 +1819,13 @@ jobs:
             attempt=1
             max_attempts=3
             while [ "${attempt}" -le "${max_attempts}" ]; do
-               gcloud compute disks delete --zone "${{ env.ZONE }}" --quiet "${ID}"
+               gcloud compute disks delete --region "${{ env.REGION }}" --quiet "${ID}"
                status=$?
                if [[ $status == 0 ]]; then
                   echo "computer disk ${ID} deleted"
                   break
                fi
-               echo "Failed deleting disk ${ID} from zone ${{ env.ZONE }}, retrying"
+               echo "Failed deleting disk ${ID} from region ${{ env.REGION }}, retrying"
                sleep 5
                attempt=$((attempt+1))
             done

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -1660,7 +1660,7 @@ jobs:
           # We give a few attempts at creating the cluster before giving up
           for i in `seq 1 5`; do
             if gcloud container clusters create ${{ env.CLUSTER_NAME }} \
-              --num-nodes=3 \
+              --num-nodes=1 \
               --cluster-version=${{ env.K8S_VERSION }} \
               --region=${{ env.REGION }} \
               --disk-size=20 \

--- a/tests/e2e/apparmor_test.go
+++ b/tests/e2e/apparmor_test.go
@@ -42,7 +42,7 @@ var _ = Describe("AppArmor support", Serial, Label(tests.LabelNoOpenshift, tests
 		if testLevelEnv.Depth < int(level) {
 			Skip("Test depth is lower than the amount requested for this test")
 		}
-		if !GetEnvProfile().CanRunAppArmor() {
+		if !MustGetEnvProfile().CanRunAppArmor() {
 			Skip("environment does not support AppArmor")
 		}
 	})

--- a/tests/e2e/commons_test.go
+++ b/tests/e2e/commons_test.go
@@ -18,7 +18,7 @@ package e2e
 
 import "github.com/cloudnative-pg/cloudnative-pg/tests/utils"
 
-func GetEnvProfile() utils.EnvProfile {
+func MustGetEnvProfile() utils.EnvProfile {
 	return utils.GetEnvProfile(*testCloudVendorEnv)
 }
 

--- a/tests/e2e/disk_space_test.go
+++ b/tests/e2e/disk_space_test.go
@@ -179,7 +179,7 @@ var _ = Describe("Volume space unavailable", Label(tests.LabelStorage), func() {
 		if testLevelEnv.Depth < int(level) {
 			Skip("Test depth is lower than the amount requested for this test")
 		}
-		if GetEnvProfile().UsesNodeDiskSpace() {
+		if MustGetEnvProfile().UsesNodeDiskSpace() {
 			// Local environments use the node disk space, running out of that space could cause multiple failures
 			Skip("this test might exhaust node storage")
 		}

--- a/tests/e2e/drain_node_test.go
+++ b/tests/e2e/drain_node_test.go
@@ -206,12 +206,6 @@ var _ = Describe("E2E Drain Node", Serial, Label(tests.LabelDisruptive, tests.La
 		// new node as there are none, the primary node can not be killed, therefore the drain fails.
 
 		When("the cluster allows moving PVCs between nodes", func() {
-			BeforeEach(func() {
-				// AKS using rook and the standard GKE StorageClass allow moving PVCs between nodes
-				if !GetEnvProfile().CanMovePVCAcrossNodes() {
-					Skip("This test case is only applicable on clusters where PVC can be moved")
-				}
-			})
 			It("can drain the primary pod's node with 3 pods on 1 nodes", func() {
 				const namespacePrefix = "drain-node-e2e-pvc-on-one-nodes"
 				var cordonNodes []string

--- a/tests/e2e/drain_node_test.go
+++ b/tests/e2e/drain_node_test.go
@@ -201,11 +201,17 @@ var _ = Describe("E2E Drain Node", Serial, Label(tests.LabelDisruptive, tests.La
 		// If PVCs can be moved: all the replicas will be killed and rescheduled to a different node,
 		// then a switchover will be triggered, and the old primary will be killed and moved too.
 		// The drain will succeed.
-		// We have skipped this scenario on the Local executors, Openshift, EKS, RKE
+		// We have skipped this scenario on the local executors, Openshift, EKS, GKE
 		// because here PVCs can not be moved, so this all replicas should be killed and can not be rescheduled on a
 		// new node as there are none, the primary node can not be killed, therefore the drain fails.
 
 		When("the cluster allows moving PVCs between nodes", func() {
+			BeforeEach(func() {
+				// AKS using rook allows moving PVCs between nodes
+				if !GetEnvProfile().CanMovePVCAcrossNodes() {
+					Skip("This test case is only applicable on clusters where PVC can be moved")
+				}
+			})
 			It("can drain the primary pod's node with 3 pods on 1 nodes", func() {
 				const namespacePrefix = "drain-node-e2e-pvc-on-one-nodes"
 				var cordonNodes []string

--- a/tests/e2e/drain_node_test.go
+++ b/tests/e2e/drain_node_test.go
@@ -208,7 +208,7 @@ var _ = Describe("E2E Drain Node", Serial, Label(tests.LabelDisruptive, tests.La
 		When("the cluster allows moving PVCs between nodes", func() {
 			BeforeEach(func() {
 				// AKS using rook allows moving PVCs between nodes
-				if !GetEnvProfile().CanMovePVCAcrossNodes() {
+				if !MustGetEnvProfile().CanMovePVCAcrossNodes() {
 					Skip("This test case is only applicable on clusters where PVC can be moved")
 				}
 			})
@@ -330,7 +330,7 @@ var _ = Describe("E2E Drain Node", Serial, Label(tests.LabelDisruptive, tests.La
 			// All GKE and AKS persistent disks are network storage located independently of the underlying Nodes, so
 			// they don't get deleted after a Drain. Hence, even when using "reusePVC off", all the pods will
 			// be recreated with the same name and will reuse the existing volume.
-			if GetEnvProfile().CanMovePVCAcrossNodes() {
+			if MustGetEnvProfile().CanMovePVCAcrossNodes() {
 				Skip("This test case is only applicable on clusters with local storage")
 			}
 		})

--- a/tests/e2e/operator_ha_test.go
+++ b/tests/e2e/operator_ha_test.go
@@ -42,7 +42,7 @@ var _ = Describe("Operator High Availability", Serial,
 			if testLevelEnv.Depth < int(level) {
 				Skip("Test depth is lower than the amount requested for this test")
 			}
-			if !GetEnvProfile().IsLeaderElectionEnabled() {
+			if !MustGetEnvProfile().IsLeaderElectionEnabled() {
 				Skip("Skip the scale test case if leader election is disabled")
 			}
 		})

--- a/tests/utils/cloud_vendor.go
+++ b/tests/utils/cloud_vendor.go
@@ -88,9 +88,7 @@ func GetEnvProfile(te TestEnvVendor) EnvProfile {
 		EKS: envProfile{
 			isLeaderElectionEnabled: true,
 		},
-		GKE: envProfile{
-			canMovePVCAcrossNodes: true,
-		},
+		GKE: envProfile{},
 		OCP: envProfile{
 			isLeaderElectionEnabled: true,
 		},


### PR DESCRIPTION
Creating a regional cluster allows us to have a multi-az cluster, allowing us to re-enable the drain test.

Closes #5040 
