### PR TITLE
test: fix logging for EKS e2e runs

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -1367,16 +1367,6 @@ jobs:
               --secret-file ./credentials-velero \
               --wait
       -
-        name: Setup log archiving via fluentd and insights
-        uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 1
-          max_attempts: 3
-          command: |
-            curl https://raw.githubusercontent.com/aws-samples/amazon-cloudwatch-container-insights/latest/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluentd-quickstart.yaml \
-              | sed "s/{{cluster_name}}/${{ env.CLUSTER_NAME }}/;s/{{region_name}}/${{ env.AWS_REGION }}/" \
-              | kubectl apply -f -
-      -
         name: Prepare patch for customization
         env:
           ## the following variable all need be set if we use env_override_customized.yaml.template

--- a/hack/e2e/eks-cluster.yaml.template
+++ b/hack/e2e/eks-cluster.yaml.template
@@ -15,16 +15,21 @@ managedNodeGroups:
     desiredCapacity: 3
 
 addons:
-- name: vpc-cni
-  attachPolicyARNs:
-    - arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy
-- name: coredns
-  version: latest
-- name: kube-proxy
-  version: latest
-- name: aws-ebs-csi-driver
-  version: latest
-
-cloudWatch:
-    clusterLogging:
-        enableTypes: ["all"]
+  - name: vpc-cni
+    attachPolicyARNs:
+      - arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy
+  - name: coredns
+    version: latest
+  - name: kube-proxy
+    version: latest
+  - name: aws-ebs-csi-driver
+    version: latest
+  # Default configuration for CloudWatch agent enabled by the addon can be found here:
+  # https://raw.githubusercontent.com/aws-samples/amazon-cloudwatch-container-insights/latest/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluent-bit/fluent-bit.yaml
+  # There is no retention for the logs by default. You can override the FluentBit configuration to set
+  # log_retention_days, or use a lambda to set the retention period, like
+  # https://github.com/binxio/aws-cloudwatch-log-minder
+  - name: amazon-cloudwatch-observability
+    version: latest
+    attachPolicyARNs:
+      - arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy


### PR DESCRIPTION
Use the CloudWatch addon to save pod logs on EKS container insight. Ignore the controlplane logs, we've never used them.

Closes: #5050
