### PR TITLE
fix(tests): kubectl cnpg status unit tests

### DIFF
--- a/internal/cmd/plugin/status/status.go
+++ b/internal/cmd/plugin/status/status.go
@@ -1013,6 +1013,10 @@ func (fullStatus *PostgresqlStatus) printTablespacesStatus() {
 }
 
 func getPrimaryStartTime(cluster *apiv1.Cluster) string {
+	return getPrimaryStartTimeIdempotent(cluster, time.Now())
+}
+
+func getPrimaryStartTimeIdempotent(cluster *apiv1.Cluster, currentTime time.Time) string {
 	if len(cluster.Status.CurrentPrimaryTimestamp) == 0 {
 		return ""
 	}
@@ -1025,7 +1029,7 @@ func getPrimaryStartTime(cluster *apiv1.Cluster) string {
 		return aurora.Red("error: " + err.Error()).String()
 	}
 
-	uptime := time.Since(primaryInstanceTimestamp)
+	uptime := currentTime.Sub(primaryInstanceTimestamp)
 	return fmt.Sprintf(
 		"%s (uptime %s)",
 		primaryInstanceTimestamp.Round(time.Second),

--- a/internal/cmd/plugin/status/status_test.go
+++ b/internal/cmd/plugin/status/status_test.go
@@ -46,19 +46,19 @@ var _ = Describe("getPrimaryStartTime", func() {
 	})
 
 	Context("when CurrentPrimaryTimestamp is valid", func() {
-		BeforeEach(func() {
+		It("should return the formatted timestamp", func() {
 			now := time.Now()
+			uptime := 1 * time.Hour
+			currentPrimaryTimestamp := now.Add(-uptime)
+
 			cluster = &apiv1.Cluster{
 				Status: apiv1.ClusterStatus{
-					CurrentPrimaryTimestamp: now.Format(metav1.RFC3339Micro),
+					CurrentPrimaryTimestamp: currentPrimaryTimestamp.Format(metav1.RFC3339Micro),
 				},
 			}
-		})
 
-		It("should return the formatted timestamp", func() {
-			uptime := time.Since(time.Now()) // It won't be exactly zero, but close
-			expected := fmt.Sprintf("%s (uptime %s)", time.Now().Round(time.Second), uptime.Round(time.Second))
-			Expect(getPrimaryStartTime(cluster)).To(Equal(expected))
+			expected := fmt.Sprintf("%s (uptime %s)", currentPrimaryTimestamp.Round(time.Second), uptime)
+			Expect(getPrimaryStartTimeIdempotent(cluster, now)).To(Equal(expected))
 		})
 	})
 


### PR DESCRIPTION
The unit tests were failing sporadically because were using `time.Now` and were not idempotent. This patch fixes them.