### PR TITLE
test: fix replica mode test failure

### DIFF
--- a/tests/e2e/asserts_test.go
+++ b/tests/e2e/asserts_test.go
@@ -1023,6 +1023,7 @@ func AssertDetachReplicaModeCluster(
 			referenceCondition, err := testsUtils.GetConditionsInClusterStatus(namespace, replicaClusterName, env,
 				apiv1.ConditionClusterReady)
 			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(referenceCondition.Status).To(BeEquivalentTo(corev1.ConditionTrue))
 			g.Expect(referenceCondition).ToNot(BeNil())
 			referenceTime = referenceCondition.LastTransitionTime.Time
 		}, 60, 5).Should(Succeed())
@@ -1047,7 +1048,7 @@ func AssertDetachReplicaModeCluster(
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(condition).ToNot(BeNil())
 			g.Expect(condition.Status).To(BeEquivalentTo(corev1.ConditionTrue))
-			g.Expect(condition.LastTransitionTime.Time).To(BeTemporally(">=", referenceTime))
+			g.Expect(condition.LastTransitionTime.Time).To(BeTemporally(">", referenceTime))
 		}).WithTimeout(60 * time.Second).Should(Succeed())
 		AssertClusterIsReady(namespace, replicaClusterName, testTimeouts[testsUtils.ClusterIsReady], env)
 	})

--- a/tests/e2e/asserts_test.go
+++ b/tests/e2e/asserts_test.go
@@ -1017,6 +1017,8 @@ func AssertDetachReplicaModeCluster(
 	var primaryReplicaCluster *corev1.Pod
 	replicaCommandTimeout := time.Second * 10
 
+	updateTime := time.Now().Truncate(time.Second)
+
 	By("disabling the replica mode", func() {
 		Eventually(func(g Gomega) {
 			_, _, err := testsUtils.RunUnchecked(fmt.Sprintf(
@@ -1025,6 +1027,20 @@ func AssertDetachReplicaModeCluster(
 				replicaClusterName, namespace))
 			g.Expect(err).ToNot(HaveOccurred())
 		}, 60, 5).Should(Succeed())
+	})
+
+	By("ensuring the replica cluster got promoted and restarted", func() {
+		Eventually(func(g Gomega) {
+			cluster, err := env.GetCluster(namespace, replicaClusterName)
+			g.Expect(err).ToNot(HaveOccurred())
+			condition, err := testsUtils.GetConditionsInClusterStatus(namespace, cluster.Name, env,
+				apiv1.ConditionClusterReady)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(condition).ToNot(BeNil())
+			g.Expect(condition.Status).To(BeEquivalentTo(corev1.ConditionTrue))
+			g.Expect(condition.LastTransitionTime.Time).To(BeTemporally(">=", updateTime))
+		}).WithTimeout(60 * time.Second).Should(Succeed())
+		AssertClusterIsReady(namespace, replicaClusterName, testTimeouts[testsUtils.ClusterIsReady], env)
 	})
 
 	By("verifying write operation on the replica cluster primary pod", func() {


### PR DESCRIPTION
Replica cluster promotion test could fail trying to run some queries during an expected restart. We wait for the restart to happen before proceeding with the test.

Closes: #5059 
