### PR TITLE
feat: support the annotation `reconcilePodSpec` on Cluster

### DIFF
--- a/docs/src/connection_pooling.md
+++ b/docs/src/connection_pooling.md
@@ -88,8 +88,8 @@ deletion of the pooler, and vice versa.
     a single pooler, or clusters with several poolers, that is, one per application.
 
 !!! Important
-    When operator is upgraded, the pooler pod will rolling upgrade as the instance
-    manager in pooler pod need to be upgraded.
+    When the operator is upgraded, the pooler pods will start a rolling upgrade,
+    as the instance manager in the pooler pods needs to be upgraded.
 
 ## Security
 

--- a/docs/src/connection_pooling.md
+++ b/docs/src/connection_pooling.md
@@ -87,6 +87,10 @@ deletion of the pooler, and vice versa.
     possible architectures. You can have clusters without poolers, clusters with
     a single pooler, or clusters with several poolers, that is, one per application.
 
+!!! Important
+    When operator is upgraded, the pooler pod will rolling upgrade as the instance
+    manager in pooler pod need to be upgraded.
+
 ## Security
 
 Any PgBouncer pooler is transparently integrated with CloudNativePG support for

--- a/docs/src/connection_pooling.md
+++ b/docs/src/connection_pooling.md
@@ -88,8 +88,9 @@ deletion of the pooler, and vice versa.
     a single pooler, or clusters with several poolers, that is, one per application.
 
 !!! Important
-    When the operator is upgraded, the pooler pods will start a rolling upgrade,
-    as the instance manager in the pooler pods needs to be upgraded.
+    When the operator is upgraded, the pooler pods will undergo a rolling
+    upgrade. This is necessary to ensure that the instance manager within the
+    pooler pods is also upgraded.
 
 ## Security
 

--- a/docs/src/labels_annotations.md
+++ b/docs/src/labels_annotations.md
@@ -165,7 +165,7 @@ These predefined annotations are managed by CloudNativePG.
 :   Current status of the PVC: `initializing`, `ready`, or `detached`.
 
 `cnpg.io/reconcilePodSpec`
-:  Annotation is used on `Cluster` or `Pooler` for special purpose
+:  Annotation is used on `Cluster` or `Pooler` for the purpose of avoid restarts.
 
    When set to `disabled` on a `Cluster`, the operator prevents instances
    from being restarted in case of drift in the PodSpec.
@@ -175,9 +175,8 @@ These predefined annotations are managed by CloudNativePG.
      - Change of scheduler
      - Change to volumes or containers
 
-  When set to `disabled` on a `Pooler`, the operator will restrict changes to 
-  the deployment spec from being made by the Pooler, except the `spec.instances` 
-  changes. 
+  When set to `disabled` on a `Pooler`, the operator will restrain to do any change
+  to the deployment spec, except changing the value of `spec.instances`.
 
 `cnpg.io/reconciliationLoop`
 :   When set to `disabled` on a `Cluster`, the operator prevents the

--- a/docs/src/labels_annotations.md
+++ b/docs/src/labels_annotations.md
@@ -165,18 +165,17 @@ These predefined annotations are managed by CloudNativePG.
 :   Current status of the PVC: `initializing`, `ready`, or `detached`.
 
 `cnpg.io/reconcilePodSpec`
-:  Annotation is used on `Cluster` or `Pooler` for the purpose of avoid restarts.
+:  Annotation can be applied to a `Cluster` or `Pooler` to prevent restarts.
 
    When set to `disabled` on a `Cluster`, the operator prevents instances
-   from being restarted in case of drift in the PodSpec.
-   PodSpec drift could be due, for example, to:
+   from restarting due to changes in the PodSpec. This includes changes to:
 
-     - Changes to topology or affinity
-     - Change of scheduler
-     - Change to volumes or containers
+     - Topology or affinity
+     - Scheduler
+     - Volumes or containers
 
-  When set to `disabled` on a `Pooler`, the operator will restrain to do any change
-  to the deployment spec, except changing the value of `spec.instances`.
+  When set to `disabled` on a `Pooler`, the operator restricts any modifications
+  to the deployment specification, except for changes to `spec.instances`.
 
 `cnpg.io/reconciliationLoop`
 :   When set to `disabled` on a `Cluster`, the operator prevents the

--- a/docs/src/labels_annotations.md
+++ b/docs/src/labels_annotations.md
@@ -164,6 +164,21 @@ These predefined annotations are managed by CloudNativePG.
 `cnpg.io/pvcStatus`
 :   Current status of the PVC: `initializing`, `ready`, or `detached`.
 
+`cnpg.io/reconcilePodSpec`
+:  Annotation is used on `Cluster` or `Pooler` for special purpose
+
+   When set to `disabled` on a `Cluster`, the operator prevents instances
+   from being restarted in case of drift in the PodSpec.
+   PodSpec drift could be due, for example, to:
+
+     - Changes to topology or affinity
+     - Change of scheduler
+     - Change to volumes or containers
+
+  When set to `disabled` on a `Pooler`, the operator will restrict changes to 
+  the deployment spec from being made by the Pooler, except the `spec.instances` 
+  changes. 
+
 `cnpg.io/reconciliationLoop`
 :   When set to `disabled` on a `Cluster`, the operator prevents the
     reconciliation loop from running.

--- a/internal/controller/cluster_upgrade.go
+++ b/internal/controller/cluster_upgrade.go
@@ -323,6 +323,12 @@ func isPodNeedingRollout(
 		return podRollout
 	}
 
+	// If the cluster is annotated with `cnpg.io/reconcilePodSpec: disabled`,
+	// we avoid to check the PodSpec
+	if utils.IsPodSpecReconciliationDisabled(&cluster.ObjectMeta) {
+		return rollout{}
+	}
+
 	// If the pod has a valid PodSpec annotation, that's the final check.
 	// If not, we should perform additional legacy checks
 	if hasValidPodSpec(pod) {

--- a/internal/controller/cluster_upgrade.go
+++ b/internal/controller/cluster_upgrade.go
@@ -324,7 +324,7 @@ func isPodNeedingRollout(
 	}
 
 	// If the cluster is annotated with `cnpg.io/reconcilePodSpec: disabled`,
-	// we avoid to check the PodSpec
+	// we avoid checking the PodSpec
 	if utils.IsPodSpecReconciliationDisabled(&cluster.ObjectMeta) {
 		return rollout{}
 	}

--- a/internal/controller/cluster_upgrade_test.go
+++ b/internal/controller/cluster_upgrade_test.go
@@ -667,7 +667,9 @@ var _ = Describe("Cluster upgrade with podSpec reconciliation disabled", func() 
 	BeforeEach(func() {
 		cluster = apiv1.Cluster{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "test",
+				Name:        "test",
+				Annotations: map[string]string{},
+				Labels:      map[string]string{},
 			},
 			Spec: apiv1.ClusterSpec{
 				ImageName: "postgres:13.11",
@@ -677,10 +679,6 @@ var _ = Describe("Cluster upgrade with podSpec reconciliation disabled", func() 
 	})
 
 	It("skips the rollout if the annotation that disables PodSpec reconciliation is set", func(ctx SpecContext) {
-		// set annotation inside cluster
-		if cluster.ObjectMeta.Annotations == nil {
-			cluster.ObjectMeta.Annotations = make(map[string]string)
-		}
 		cluster.ObjectMeta.Annotations[utils.ReconcilePodSpecAnnotationName] = "disabled"
 
 		pod := specs.PodWithExistingStorage(cluster, 1)
@@ -698,8 +696,5 @@ var _ = Describe("Cluster upgrade with podSpec reconciliation disabled", func() 
 		Expect(rollout.required).To(BeFalse())
 		Expect(rollout.canBeInPlace).To(BeFalse())
 		Expect(rollout.reason).To(BeEmpty())
-
-		// cleanup annotation
-		delete(cluster.ObjectMeta.Annotations, utils.ReconcilePodSpecAnnotationName)
 	})
 })

--- a/internal/controller/cluster_upgrade_test.go
+++ b/internal/controller/cluster_upgrade_test.go
@@ -694,7 +694,7 @@ var _ = Describe("Cluster upgrade with podSpec reconciliation disabled", func() 
 			ExecutableHash: "test_hash",
 		}
 
-		rollout := isPodNeedingRollout(ctx, status, &cluster)
+		rollout := isInstanceNeedingRollout(ctx, status, &cluster)
 		Expect(rollout.required).To(BeFalse())
 		Expect(rollout.canBeInPlace).To(BeFalse())
 		Expect(rollout.reason).To(BeEmpty())

--- a/internal/controller/cluster_upgrade_test.go
+++ b/internal/controller/cluster_upgrade_test.go
@@ -660,3 +660,46 @@ var _ = Describe("hasValidPodSpec", func() {
 		})
 	})
 })
+
+var _ = Describe("Cluster upgrade with podSpec reconciliation disabled", func() {
+	var cluster apiv1.Cluster
+
+	BeforeEach(func() {
+		cluster = apiv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test",
+			},
+			Spec: apiv1.ClusterSpec{
+				ImageName: "postgres:13.11",
+			},
+		}
+		configuration.Current = configuration.NewConfiguration()
+	})
+
+	It("skips the rollout if the annotation that disables PodSpec reconciliation is set", func(ctx SpecContext) {
+		// set annotation inside cluster
+		if cluster.ObjectMeta.Annotations == nil {
+			cluster.ObjectMeta.Annotations = make(map[string]string)
+		}
+		cluster.ObjectMeta.Annotations[utils.ReconcilePodSpecAnnotationName] = "disabled"
+
+		pod := specs.PodWithExistingStorage(cluster, 1)
+		cluster.Spec.SchedulerName = "newScheduler"
+		delete(pod.Annotations, utils.PodSpecAnnotationName)
+
+		status := postgres.PostgresqlStatus{
+			Pod:            pod,
+			PendingRestart: false,
+			IsPodReady:     true,
+			ExecutableHash: "test_hash",
+		}
+
+		rollout := isPodNeedingRollout(ctx, status, &cluster)
+		Expect(rollout.required).To(BeFalse())
+		Expect(rollout.canBeInPlace).To(BeFalse())
+		Expect(rollout.reason).To(BeEmpty())
+
+		// cleanup annotation
+		delete(cluster.ObjectMeta.Annotations, utils.ReconcilePodSpecAnnotationName)
+	})
+})

--- a/internal/controller/pooler_update.go
+++ b/internal/controller/pooler_update.go
@@ -101,6 +101,8 @@ func (r *PoolerReconciler) updateDeployment(
 		deployment := resources.Deployment.DeepCopy()
 		deployment.Spec.Replicas = generatedDeployment.Spec.Replicas
 
+		// If the pooler is annotated with `cnpg.io/reconcilePodSpec: disabled`,
+		// we avoid to patch the deployment spec change, except the number replicas
 		if !utils.IsPodSpecReconciliationDisabled(&pooler.ObjectMeta) {
 			deployment.Spec = generatedDeployment.Spec
 		}

--- a/internal/controller/pooler_update.go
+++ b/internal/controller/pooler_update.go
@@ -101,8 +101,8 @@ func (r *PoolerReconciler) updateDeployment(
 		deployment := resources.Deployment.DeepCopy()
 		deployment.Spec.Replicas = generatedDeployment.Spec.Replicas
 
-		// If the pooler is annotated with `cnpg.io/reconcilePodSpec: disabled`,
-		// we avoid to patch the deployment spec change, except the number replicas
+		// If the Pooler is annotated with `cnpg.io/reconcilePodSpec: disabled`,
+		// we avoid patching the deployment spec, except the number replicas
 		if !utils.IsPodSpecReconciliationDisabled(&pooler.ObjectMeta) {
 			deployment.Spec = generatedDeployment.Spec
 		}

--- a/internal/controller/pooler_update_test.go
+++ b/internal/controller/pooler_update_test.go
@@ -297,12 +297,7 @@ var _ = Describe("unit test of pooler_update reconciliation logic", func() {
 		pooler := newFakePooler(env.client, cluster)
 		res := &poolerManagedResources{Deployment: nil, Cluster: cluster}
 		By("setting the reconcilePodSpec annotation to disabled on the pooler ", func() {
-			// set annotation inside cluster
-			if pooler.ObjectMeta.Annotations == nil {
-				pooler.ObjectMeta.Annotations = make(map[string]string)
-			}
 			pooler.ObjectMeta.Annotations[utils.ReconcilePodSpecAnnotationName] = "disabled"
-
 			pooler.Spec.Template = &apiv1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
 					TerminationGracePeriodSeconds: ptr.To(int64(100)),

--- a/internal/controller/pooler_update_test.go
+++ b/internal/controller/pooler_update_test.go
@@ -289,6 +289,80 @@ var _ = Describe("unit test of pooler_update reconciliation logic", func() {
 			Expect(expectedSVC.Labels[utils.ClusterLabelName]).To(Equal(cluster.Name))
 		})
 	})
+
+	It("should not reconcile if pooler has podSpec reconciliation disabled", func() {
+		ctx := context.Background()
+		namespace := newFakeNamespace(env.client)
+		cluster := newFakeCNPGCluster(env.client, namespace)
+		pooler := newFakePooler(env.client, cluster)
+		res := &poolerManagedResources{Deployment: nil, Cluster: cluster}
+		By("set reconcilePodSpec annotation to disabled to pooler ", func() {
+			// set annotation inside cluster
+			if pooler.ObjectMeta.Annotations == nil {
+				pooler.ObjectMeta.Annotations = make(map[string]string)
+			}
+			pooler.ObjectMeta.Annotations[utils.ReconcilePodSpecAnnotationName] = "disabled"
+
+			pooler.Spec.Template = &apiv1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					TerminationGracePeriodSeconds: ptr.To(int64(100)),
+				},
+			}
+		})
+
+		By("making sure that updateDeployment creates the deployment", func() {
+			err := env.poolerReconciler.updateDeployment(ctx, pooler, res)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(res.Deployment).ToNot(BeNil())
+
+			deployment := getPoolerDeployment(ctx, env.client, pooler)
+			Expect(deployment.Spec.Replicas).To(Equal(pooler.Spec.Instances))
+		})
+
+		By("making sure pooler change is not update to deployment", func() {
+			beforeDep := getPoolerDeployment(ctx, env.client, pooler)
+			pooler.Spec.Template.Spec.TerminationGracePeriodSeconds = ptr.To(int64(200))
+			err := env.poolerReconciler.updateDeployment(ctx, pooler, res)
+			Expect(err).ToNot(HaveOccurred())
+
+			afterDep := getPoolerDeployment(ctx, env.client, pooler)
+			Expect(afterDep.Spec.Template.Spec.TerminationGracePeriodSeconds).To(
+				Equal(beforeDep.Spec.Template.Spec.TerminationGracePeriodSeconds))
+			Expect(beforeDep.Annotations[utils.PoolerSpecHashAnnotationName]).
+				NotTo(Equal(afterDep.Annotations[utils.PoolerSpecHashAnnotationName]))
+		})
+
+		By("making sure that the deployments gets updated if the pooler.spec changes", func() {
+			const instancesNumber int32 = 3
+			poolerUpdate := pooler.DeepCopy()
+			poolerUpdate.Spec.Instances = ptr.To(instancesNumber)
+
+			beforeDep := getPoolerDeployment(ctx, env.client, poolerUpdate)
+
+			err := env.poolerReconciler.updateDeployment(ctx, poolerUpdate, res)
+			Expect(err).ToNot(HaveOccurred())
+
+			afterDep := getPoolerDeployment(ctx, env.client, poolerUpdate)
+			Expect(beforeDep.Annotations[utils.PoolerSpecHashAnnotationName]).
+				ToNot(Equal(afterDep.Annotations[utils.PoolerSpecHashAnnotationName]))
+			Expect(*afterDep.Spec.Replicas).To(Equal(instancesNumber))
+		})
+
+		By("enable again, making sure pooler change is update to deployment", func() {
+			delete(pooler.ObjectMeta.Annotations, utils.ReconcilePodSpecAnnotationName)
+			beforeDep := getPoolerDeployment(ctx, env.client, pooler)
+			pooler.Spec.Template.Spec.TerminationGracePeriodSeconds = ptr.To(int64(300))
+			err := env.poolerReconciler.updateDeployment(ctx, pooler, res)
+			Expect(err).ToNot(HaveOccurred())
+
+			afterDep := getPoolerDeployment(ctx, env.client, pooler)
+			Expect(afterDep.Spec.Template.Spec.TerminationGracePeriodSeconds).NotTo(
+				Equal(beforeDep.Spec.Template.Spec.TerminationGracePeriodSeconds))
+			Expect(afterDep.Spec.Template.Spec.TerminationGracePeriodSeconds).To(Equal(ptr.To(int64(300))))
+			Expect(beforeDep.Annotations[utils.PoolerSpecHashAnnotationName]).
+				NotTo(Equal(afterDep.Annotations[utils.PoolerSpecHashAnnotationName]))
+		})
+	})
 })
 
 var _ = Describe("ensureServiceAccountPullSecret", func() {

--- a/internal/controller/pooler_update_test.go
+++ b/internal/controller/pooler_update_test.go
@@ -296,7 +296,7 @@ var _ = Describe("unit test of pooler_update reconciliation logic", func() {
 		cluster := newFakeCNPGCluster(env.client, namespace)
 		pooler := newFakePooler(env.client, cluster)
 		res := &poolerManagedResources{Deployment: nil, Cluster: cluster}
-		By("set reconcilePodSpec annotation to disabled to pooler ", func() {
+		By("setting the reconcilePodSpec annotation to disabled on the pooler ", func() {
 			// set annotation inside cluster
 			if pooler.ObjectMeta.Annotations == nil {
 				pooler.ObjectMeta.Annotations = make(map[string]string)
@@ -319,7 +319,7 @@ var _ = Describe("unit test of pooler_update reconciliation logic", func() {
 			Expect(deployment.Spec.Replicas).To(Equal(pooler.Spec.Instances))
 		})
 
-		By("making sure pooler change is not update to deployment", func() {
+		By("making sure pooler change does not update the deployment", func() {
 			beforeDep := getPoolerDeployment(ctx, env.client, pooler)
 			pooler.Spec.Template.Spec.TerminationGracePeriodSeconds = ptr.To(int64(200))
 			err := env.poolerReconciler.updateDeployment(ctx, pooler, res)
@@ -348,7 +348,7 @@ var _ = Describe("unit test of pooler_update reconciliation logic", func() {
 			Expect(*afterDep.Spec.Replicas).To(Equal(instancesNumber))
 		})
 
-		By("enable again, making sure pooler change is update to deployment", func() {
+		By("enable again, making sure pooler change updates the deployment", func() {
 			delete(pooler.ObjectMeta.Annotations, utils.ReconcilePodSpecAnnotationName)
 			beforeDep := getPoolerDeployment(ctx, env.client, pooler)
 			pooler.Spec.Template.Spec.TerminationGracePeriodSeconds = ptr.To(int64(300))

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -128,8 +128,10 @@ func buildTestEnvironment() *testingEnvironment {
 func newFakePooler(k8sClient client.Client, cluster *apiv1.Cluster) *apiv1.Pooler {
 	pooler := &apiv1.Pooler{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "pooler-" + rand.String(10),
-			Namespace: cluster.Namespace,
+			Name:        "pooler-" + rand.String(10),
+			Namespace:   cluster.Namespace,
+			Annotations: map[string]string{},
+			Labels:      map[string]string{},
 		},
 		Spec: apiv1.PoolerSpec{
 			Cluster: apiv1.LocalObjectReference{

--- a/pkg/utils/labels_annotations_test.go
+++ b/pkg/utils/labels_annotations_test.go
@@ -158,22 +158,22 @@ var _ = Describe("Annotate pods management", func() {
 })
 
 var _ = Describe("Pod spec reconciliation", func() {
-	objectMeta := metav1.ObjectMeta{}
+	var objectMeta *metav1.ObjectMeta
+	BeforeEach(func() {
+		objectMeta = &metav1.ObjectMeta{Annotations: map[string]string{}}
+	})
 
 	It("is not disabled if annotation map is empty", func() {
-		objectMeta.Annotations = make(map[string]string)
-		Expect(IsPodSpecReconciliationDisabled(&objectMeta)).To(BeFalse())
+		Expect(IsPodSpecReconciliationDisabled(objectMeta)).To(BeFalse())
 	})
 
 	It("is not disabled if annotation exists and its value is not 'disabled'", func() {
-		objectMeta.Annotations = make(map[string]string)
 		objectMeta.Annotations[ReconcilePodSpecAnnotationName] = string(annotationStatusEnabled)
-		Expect(IsPodSpecReconciliationDisabled(&objectMeta)).To(BeFalse())
+		Expect(IsPodSpecReconciliationDisabled(objectMeta)).To(BeFalse())
 	})
 
 	It("is disabled if annotation exists and its value is 'disabled'", func() {
-		objectMeta.Annotations = make(map[string]string)
 		objectMeta.Annotations[ReconcilePodSpecAnnotationName] = string(annotationStatusDisabled)
-		Expect(IsPodSpecReconciliationDisabled(&objectMeta)).To(BeTrue())
+		Expect(IsPodSpecReconciliationDisabled(objectMeta)).To(BeTrue())
 	})
 })

--- a/pkg/utils/labels_annotations_test.go
+++ b/pkg/utils/labels_annotations_test.go
@@ -156,3 +156,24 @@ var _ = Describe("Annotate pods management", func() {
 		Expect(isPresent).To(BeFalse())
 	})
 })
+
+var _ = Describe("Pod spec reconciliation", func() {
+	objectMeta := metav1.ObjectMeta{}
+
+	It("is not disabled if annotation map is empty", func() {
+		objectMeta.Annotations = make(map[string]string)
+		Expect(IsPodSpecReconciliationDisabled(&objectMeta)).To(BeFalse())
+	})
+
+	It("is not disabled if annotation exists and its value is not 'disabled'", func() {
+		objectMeta.Annotations = make(map[string]string)
+		objectMeta.Annotations[ReconcilePodSpecAnnotationName] = string(annotationStatusEnabled)
+		Expect(IsPodSpecReconciliationDisabled(&objectMeta)).To(BeFalse())
+	})
+
+	It("is disabled if annotation exists and its value is 'disabled'", func() {
+		objectMeta.Annotations = make(map[string]string)
+		objectMeta.Annotations[ReconcilePodSpecAnnotationName] = string(annotationStatusDisabled)
+		Expect(IsPodSpecReconciliationDisabled(&objectMeta)).To(BeTrue())
+	})
+})


### PR DESCRIPTION
This patch make the `reconcilePodSpec` supports both both
cluster and pooler, and update doc accordingly.

Closes: #5068 