### PR TITLE
feat: add support for CNPG-I `SetStatusInCluster` capability

### DIFF
--- a/.wordlist-en-custom.txt
+++ b/.wordlist-en-custom.txt
@@ -407,7 +407,7 @@ ServiceSelectorType
 ServiceSpec
 ServiceTemplateSpec
 ServiceUpdateStrategy
-SetClusterStatus
+SetStatusInCluster
 ShutdownCheckpointToken
 Silvela
 Slonik

--- a/.wordlist-en-custom.txt
+++ b/.wordlist-en-custom.txt
@@ -407,6 +407,7 @@ ServiceSelectorType
 ServiceSpec
 ServiceTemplateSpec
 ServiceUpdateStrategy
+SetClusterStatus
 ShutdownCheckpointToken
 Silvela
 Slonik

--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -2695,7 +2695,7 @@ type PluginStatus struct {
 	// plugin regarding the Backup management
 	BackupCapabilities []string `json:"backupCapabilities,omitempty"`
 
-	// Status the internal status of the plugin
+	// Status contain the statuses of the registered plugins having the SET_CLUSTER_STATUS capability
 	Status string `json:"status,omitempty"`
 }
 

--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -2695,7 +2695,7 @@ type PluginStatus struct {
 	// plugin regarding the Backup management
 	BackupCapabilities []string `json:"backupCapabilities,omitempty"`
 
-	// Status contain the status reported by the plugin through the SetClusterStatus interface
+	// Status contain the status reported by the plugin through the SetStatusInCluster interface
 	Status string `json:"status,omitempty"`
 }
 

--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -2694,6 +2694,9 @@ type PluginStatus struct {
 	// BackupCapabilities are the list of capabilities of the
 	// plugin regarding the Backup management
 	BackupCapabilities []string `json:"backupCapabilities,omitempty"`
+
+	// Status the internal status of the plugin
+	Status string `json:"status,omitempty"`
 }
 
 // RoleConfiguration is the representation, in Kubernetes, of a PostgreSQL role

--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -2695,7 +2695,7 @@ type PluginStatus struct {
 	// plugin regarding the Backup management
 	BackupCapabilities []string `json:"backupCapabilities,omitempty"`
 
-	// Status contain the statuses of the registered plugins having the SET_CLUSTER_STATUS capability
+	// Status contain the status reported by the plugin through the SetClusterStatus interface
 	Status string `json:"status,omitempty"`
 }
 

--- a/config/crd/bases/postgresql.cnpg.io_clusters.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_clusters.yaml
@@ -6033,8 +6033,8 @@ spec:
                         type: string
                       type: array
                     status:
-                      description: Status contain the statuses of the registered plugins
-                        having the SET_CLUSTER_STATUS capability
+                      description: Status contain the status reported by the plugin
+                        through the SetClusterStatus interface
                       type: string
                     version:
                       description: |-

--- a/config/crd/bases/postgresql.cnpg.io_clusters.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_clusters.yaml
@@ -6034,7 +6034,7 @@ spec:
                       type: array
                     status:
                       description: Status contain the status reported by the plugin
-                        through the SetClusterStatus interface
+                        through the SetStatusInCluster interface
                       type: string
                     version:
                       description: |-

--- a/config/crd/bases/postgresql.cnpg.io_clusters.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_clusters.yaml
@@ -6033,7 +6033,8 @@ spec:
                         type: string
                       type: array
                     status:
-                      description: Status the internal status of the plugin
+                      description: Status contain the statuses of the registered plugins
+                        having the SET_CLUSTER_STATUS capability
                       type: string
                     version:
                       description: |-

--- a/config/crd/bases/postgresql.cnpg.io_clusters.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_clusters.yaml
@@ -6032,6 +6032,9 @@ spec:
                       items:
                         type: string
                       type: array
+                    status:
+                      description: Status the internal status of the plugin
+                      type: string
                     version:
                       description: |-
                         Version is the version of the plugin loaded by the

--- a/docs/src/cloudnative-pg.v1.md
+++ b/docs/src/cloudnative-pg.v1.md
@@ -3727,7 +3727,7 @@ plugin regarding the Backup management</p>
 <i>string</i>
 </td>
 <td>
-   <p>Status contain the status reported by the plugin through the SetClusterStatus interface</p>
+   <p>Status contain the status reported by the plugin through the SetStatusInCluster interface</p>
 </td>
 </tr>
 </tbody>

--- a/docs/src/cloudnative-pg.v1.md
+++ b/docs/src/cloudnative-pg.v1.md
@@ -3727,7 +3727,7 @@ plugin regarding the Backup management</p>
 <i>string</i>
 </td>
 <td>
-   <p>Status contain the statuses of the registered plugins having the SET_CLUSTER_STATUS capability</p>
+   <p>Status contain the status reported by the plugin through the SetClusterStatus interface</p>
 </td>
 </tr>
 </tbody>

--- a/docs/src/cloudnative-pg.v1.md
+++ b/docs/src/cloudnative-pg.v1.md
@@ -3727,7 +3727,7 @@ plugin regarding the Backup management</p>
 <i>string</i>
 </td>
 <td>
-   <p>Status the internal status of the plugin</p>
+   <p>Status contain the statuses of the registered plugins having the SET_CLUSTER_STATUS capability</p>
 </td>
 </tr>
 </tbody>

--- a/docs/src/cloudnative-pg.v1.md
+++ b/docs/src/cloudnative-pg.v1.md
@@ -3723,6 +3723,13 @@ plugin regarding the WAL management</p>
 plugin regarding the Backup management</p>
 </td>
 </tr>
+<tr><td><code>status</code> <B>[Required]</B><br/>
+<i>string</i>
+</td>
+<td>
+   <p>Status the internal status of the plugin</p>
+</td>
+</tr>
 </tbody>
 </table>
 

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/avast/retry-go/v4 v4.6.0
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/cheynewallace/tabby v1.1.1
-	github.com/cloudnative-pg/cnpg-i v0.0.0-20240806095732-9ea12e76a6ee
+	github.com/cloudnative-pg/cnpg-i v0.0.0-20240820123829-5844b833f4eb
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/evanphx/json-patch/v5 v5.9.0
 	github.com/go-logr/logr v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -23,8 +23,8 @@ github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWR
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/cloudnative-pg/cnpg-i v0.0.0-20240806095732-9ea12e76a6ee h1:ThaqhdK95kDSpLZi1+Qr66NjdBmCVkBakccZfIyVl7Q=
-github.com/cloudnative-pg/cnpg-i v0.0.0-20240806095732-9ea12e76a6ee/go.mod h1:UILpBDaWvXcYC5kY5DMaVEEQY5483CBApMuHIn0GJdg=
+github.com/cloudnative-pg/cnpg-i v0.0.0-20240820123829-5844b833f4eb h1:kZQk+KUCTHQMEgcH8j2/ypcG2HY58zKocmVUvX6c1IA=
+github.com/cloudnative-pg/cnpg-i v0.0.0-20240820123829-5844b833f4eb/go.mod h1:UILpBDaWvXcYC5kY5DMaVEEQY5483CBApMuHIn0GJdg=
 github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=

--- a/internal/cnpi/plugin/client/cluster.go
+++ b/internal/cnpi/plugin/client/cluster.go
@@ -124,7 +124,13 @@ func (data *data) SetClusterStatus(ctx context.Context, cluster client.Object) (
 		}
 
 		if len(response.JsonStatus) == 0 {
+			contextLogger.Trace("json status is empty, skipping it", "pluginName", plugin.Name())
 			continue
+		}
+		if err := json.Unmarshal(response.JsonStatus, &json.RawMessage{}); err != nil {
+			contextLogger.Error(err, "found a malformed json while evaluating SetClusterStatus response",
+				"pluginName", plugin.Name())
+			return nil, err
 		}
 
 		pluginStatuses[plugin.Name()] = string(response.JsonStatus)

--- a/internal/cnpi/plugin/client/cluster.go
+++ b/internal/cnpi/plugin/client/cluster.go
@@ -133,7 +133,7 @@ func (data *data) SetClusterStatus(ctx context.Context, cluster client.Object) (
 			contextLogger.Trace("json status is empty, skipping it", "pluginName", plugin.Name())
 			continue
 		}
-		if err := json.Unmarshal(response.JsonStatus, &json.RawMessage{}); err != nil {
+		if err := json.Unmarshal(response.JsonStatus, &map[string]interface{}{}); err != nil {
 			contextLogger.Error(err, "found a malformed json while evaluating SetClusterStatus response",
 				"pluginName", plugin.Name())
 			return nil, fmt.Errorf("%w: %w", errInvalidJSON, err)

--- a/internal/cnpi/plugin/client/cluster_test.go
+++ b/internal/cnpi/plugin/client/cluster_test.go
@@ -29,7 +29,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("SetClusterStatus", func() {
+var _ = Describe("SetStatusInCluster", func() {
 	const pluginName = "fake-plugin"
 	const pluginName2 = "fake-plugin2"
 
@@ -47,7 +47,7 @@ var _ = Describe("SetClusterStatus", func() {
 				newFakeClusterClient(pluginName, payload),
 			},
 		}
-		values, err := d.SetClusterStatus(ctx, cluster)
+		values, err := d.SetStatusInCluster(ctx, cluster)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(values[pluginName]).To(BeEquivalentTo(string(payload)))
 	})
@@ -56,7 +56,7 @@ var _ = Describe("SetClusterStatus", func() {
 		d := data{
 			plugins: []connection.Interface{newFakeClusterClient(pluginName, nil)},
 		}
-		values, err := d.SetClusterStatus(ctx, cluster)
+		values, err := d.SetStatusInCluster(ctx, cluster)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(values).To(BeEquivalentTo(map[string]string{}))
 	})
@@ -76,7 +76,7 @@ var _ = Describe("SetClusterStatus", func() {
 				newFakeClusterClient(pluginName2, payload2),
 			},
 		}
-		values, err := d.SetClusterStatus(ctx, cluster)
+		values, err := d.SetStatusInCluster(ctx, cluster)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(values).To(BeEquivalentTo(map[string]string{
 			pluginName:  string(payload1),
@@ -90,21 +90,21 @@ var _ = Describe("SetClusterStatus", func() {
 				newFakeClusterClient(pluginName, []byte("random")),
 			},
 		}
-		_, err := d.SetClusterStatus(ctx, cluster)
+		_, err := d.SetStatusInCluster(ctx, cluster)
 		Expect(err).To(HaveOccurred())
 		Expect(err).To(MatchError(errInvalidJSON))
 	})
 
-	It("should report an error in case of an error returned by the underlying SetClusterStatus", func(ctx SpecContext) {
+	It("should report an error in case of an error returned by the underlying SetStatusInCluster", func(ctx SpecContext) {
 		cli := newFakeClusterClient(pluginName, []byte("random"))
 		expectedErr := errors.New("bad request")
-		cli.operatorClient.errSetClusterStatus = expectedErr
+		cli.operatorClient.errSetStatusInCluster = expectedErr
 		d := data{
 			plugins: []connection.Interface{cli},
 		}
-		_, err := d.SetClusterStatus(ctx, cluster)
+		_, err := d.SetStatusInCluster(ctx, cluster)
 		Expect(err).To(HaveOccurred())
-		Expect(err).To(MatchError(errSetClusterStatus))
+		Expect(err).To(MatchError(errSetStatusInCluster))
 		Expect(err).To(MatchError(expectedErr))
 	})
 })
@@ -118,7 +118,7 @@ func newFakeClusterClient(name string, jsonStatus []byte) *fakeConnection {
 					{
 						Type: &operator.OperatorCapability_Rpc{
 							Rpc: &operator.OperatorCapability_RPC{
-								Type: operator.OperatorCapability_RPC_TYPE_SET_CLUSTER_STATUS,
+								Type: operator.OperatorCapability_RPC_TYPE_SET_STATUS_IN_CLUSTER,
 							},
 						},
 					},

--- a/internal/cnpi/plugin/client/cluster_test.go
+++ b/internal/cnpi/plugin/client/cluster_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright The CloudNativePG Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package client
 
 import (

--- a/internal/cnpi/plugin/client/cluster_test.go
+++ b/internal/cnpi/plugin/client/cluster_test.go
@@ -1,0 +1,115 @@
+package client
+
+import (
+	"encoding/json"
+	"errors"
+
+	"github.com/cloudnative-pg/cnpg-i/pkg/operator"
+
+	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	"github.com/cloudnative-pg/cloudnative-pg/internal/cnpi/plugin/connection"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("SetClusterStatus", func() {
+	const pluginName = "fake-plugin"
+	const pluginName2 = "fake-plugin2"
+
+	var cluster *apiv1.Cluster
+	BeforeEach(func() {
+		cluster = &apiv1.Cluster{}
+	})
+
+	It("should correctly set the status of a single plugin", func(ctx SpecContext) {
+		pluginStatus := map[string]string{"key": "value"}
+		payload, err := json.Marshal(pluginStatus)
+		Expect(err).ToNot(HaveOccurred())
+		d := data{
+			plugins: []connection.Interface{
+				newFakeClusterClient(pluginName, payload),
+			},
+		}
+		values, err := d.SetClusterStatus(ctx, cluster)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(values[pluginName]).To(BeEquivalentTo(string(payload)))
+	})
+
+	It("should report an empty map given that the plugin doesn't send a json back", func(ctx SpecContext) {
+		d := data{
+			plugins: []connection.Interface{newFakeClusterClient(pluginName, nil)},
+		}
+		values, err := d.SetClusterStatus(ctx, cluster)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(values).To(BeEquivalentTo(map[string]string{}))
+	})
+
+	It("should be able to set multiple plugins statuses", func(ctx SpecContext) {
+		pluginStatus1 := map[string]string{"key": "value"}
+		payload1, err := json.Marshal(pluginStatus1)
+		Expect(err).ToNot(HaveOccurred())
+
+		pluginStatus2 := map[string]string{"key1": "value1"}
+		payload2, err := json.Marshal(pluginStatus2)
+		Expect(err).ToNot(HaveOccurred())
+
+		d := data{
+			plugins: []connection.Interface{
+				newFakeClusterClient(pluginName, payload1),
+				newFakeClusterClient(pluginName2, payload2),
+			},
+		}
+		values, err := d.SetClusterStatus(ctx, cluster)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(values).To(BeEquivalentTo(map[string]string{
+			pluginName:  string(payload1),
+			pluginName2: string(payload2),
+		}))
+	})
+
+	It("should report an error in case of an invalid json", func(ctx SpecContext) {
+		d := data{
+			plugins: []connection.Interface{
+				newFakeClusterClient(pluginName, []byte("random")),
+			},
+		}
+		_, err := d.SetClusterStatus(ctx, cluster)
+		Expect(err).To(HaveOccurred())
+		Expect(err).To(MatchError(errInvalidJSON))
+	})
+
+	It("should report an error in case of an error returned by the underlying SetClusterStatus", func(ctx SpecContext) {
+		cli := newFakeClusterClient(pluginName, []byte("random"))
+		expectedErr := errors.New("bad request")
+		cli.operatorClient.errSetClusterStatus = expectedErr
+		d := data{
+			plugins: []connection.Interface{cli},
+		}
+		_, err := d.SetClusterStatus(ctx, cluster)
+		Expect(err).To(HaveOccurred())
+		Expect(err).To(MatchError(errSetClusterStatus))
+		Expect(err).To(MatchError(expectedErr))
+	})
+})
+
+func newFakeClusterClient(name string, jsonStatus []byte) *fakeConnection {
+	fc := &fakeConnection{
+		name: name,
+		operatorClient: &fakeOperatorClient{
+			capabilities: &operator.OperatorCapabilitiesResult{
+				Capabilities: []*operator.OperatorCapability{
+					{
+						Type: &operator.OperatorCapability_Rpc{
+							Rpc: &operator.OperatorCapability_RPC{
+								Type: operator.OperatorCapability_RPC_TYPE_SET_CLUSTER_STATUS,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	fc.setStatusResponse(jsonStatus)
+	return fc
+}

--- a/internal/cnpi/plugin/client/contracts.go
+++ b/internal/cnpi/plugin/client/contracts.go
@@ -67,9 +67,12 @@ type ClusterCapabilities interface {
 	// be changed from a value to another
 	ValidateClusterUpdate(
 		ctx context.Context,
-		oldObject client.Object,
-		newObject client.Object,
+		cluster client.Object,
+		mutatedCluster client.Object,
 	) (field.ErrorList, error)
+
+	// SetClusterStatus returns a map of [pluginName]: statuses to be assigned to the cluster
+	SetClusterStatus(ctx context.Context, cluster client.Object) (map[string]string, error)
 }
 
 // ReconcilerHookResult is the result of a reconciliation loop

--- a/internal/cnpi/plugin/client/contracts.go
+++ b/internal/cnpi/plugin/client/contracts.go
@@ -71,8 +71,8 @@ type ClusterCapabilities interface {
 		mutatedCluster client.Object,
 	) (field.ErrorList, error)
 
-	// SetClusterStatus returns a map of [pluginName]: statuses to be assigned to the cluster
-	SetClusterStatus(ctx context.Context, cluster client.Object) (map[string]string, error)
+	// SetStatusInCluster returns a map of [pluginName]: statuses to be assigned to the cluster
+	SetStatusInCluster(ctx context.Context, cluster client.Object) (map[string]string, error)
 }
 
 // ReconcilerHookResult is the result of a reconciliation loop

--- a/internal/cnpi/plugin/client/lifecycle_test.go
+++ b/internal/cnpi/plugin/client/lifecycle_test.go
@@ -21,12 +21,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/cloudnative-pg/cnpg-i/pkg/backup"
-	"github.com/cloudnative-pg/cnpg-i/pkg/identity"
 	"github.com/cloudnative-pg/cnpg-i/pkg/lifecycle"
-	"github.com/cloudnative-pg/cnpg-i/pkg/operator"
-	"github.com/cloudnative-pg/cnpg-i/pkg/reconciler"
-	"github.com/cloudnative-pg/cnpg-i/pkg/wal"
 	"google.golang.org/grpc"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -41,72 +36,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
-
-type fakeConnection struct {
-	lifecycleClient       lifecycle.OperatorLifecycleClient
-	lifecycleCapabilities []*lifecycle.OperatorLifecycleCapabilities
-	name                  string
-}
-
-func (f fakeConnection) Name() string {
-	return f.name
-}
-
-func (f fakeConnection) Metadata() connection.Metadata {
-	panic("not implemented") // TODO: Implement
-}
-
-func (f fakeConnection) LifecycleClient() lifecycle.OperatorLifecycleClient {
-	return f.lifecycleClient
-}
-
-func (f fakeConnection) OperatorClient() operator.OperatorClient {
-	panic("not implemented") // TODO: Implement
-}
-
-func (f fakeConnection) WALClient() wal.WALClient {
-	panic("not implemented") // TODO: Implement
-}
-
-func (f fakeConnection) BackupClient() backup.BackupClient {
-	panic("not implemented") // TODO: Implement
-}
-
-func (f fakeConnection) ReconcilerHooksClient() reconciler.ReconcilerHooksClient {
-	panic("not implemented") // TODO: Implement
-}
-
-func (f fakeConnection) PluginCapabilities() []identity.PluginCapability_Service_Type {
-	panic("not implemented") // TODO: Implement
-}
-
-func (f fakeConnection) OperatorCapabilities() []operator.OperatorCapability_RPC_Type {
-	panic("not implemented") // TODO: Implement
-}
-
-func (f fakeConnection) WALCapabilities() []wal.WALCapability_RPC_Type {
-	panic("not implemented") // TODO: Implement
-}
-
-func (f fakeConnection) LifecycleCapabilities() []*lifecycle.OperatorLifecycleCapabilities {
-	return f.lifecycleCapabilities
-}
-
-func (f fakeConnection) BackupCapabilities() []backup.BackupCapability_RPC_Type {
-	panic("not implemented") // TODO: Implement
-}
-
-func (f fakeConnection) ReconcilerCapabilities() []reconciler.ReconcilerHooksCapability_Kind {
-	panic("not implemented") // TODO: Implement
-}
-
-func (f fakeConnection) Ping(_ context.Context) error {
-	panic("not implemented") // TODO: Implement
-}
-
-func (f fakeConnection) Close() error {
-	panic("not implemented") // TODO: Implement
-}
 
 type fakeLifecycleClient struct {
 	capabilitiesError  error

--- a/internal/cnpi/plugin/client/suite_test.go
+++ b/internal/cnpi/plugin/client/suite_test.go
@@ -88,6 +88,14 @@ func (f *fakeOperatorClient) SetClusterStatus(
 	return f.status, nil
 }
 
+func (f *fakeOperatorClient) Deregister(
+	_ context.Context,
+	_ *operator.DeregisterRequest,
+	_ ...grpc.CallOption,
+) (*operator.DeregisterResponse, error) {
+	panic("implement me")
+}
+
 type fakeConnection struct {
 	lifecycleClient       lifecycle.OperatorLifecycleClient
 	lifecycleCapabilities []*lifecycle.OperatorLifecycleCapabilities

--- a/internal/cnpi/plugin/client/suite_test.go
+++ b/internal/cnpi/plugin/client/suite_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright The CloudNativePG Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package client
 
 import (

--- a/internal/cnpi/plugin/client/suite_test.go
+++ b/internal/cnpi/plugin/client/suite_test.go
@@ -40,9 +40,9 @@ func TestClient(t *testing.T) {
 }
 
 type fakeOperatorClient struct {
-	capabilities        *operator.OperatorCapabilitiesResult
-	status              *operator.SetClusterStatusResponse
-	errSetClusterStatus error
+	capabilities          *operator.OperatorCapabilitiesResult
+	status                *operator.SetStatusInClusterResponse
+	errSetStatusInCluster error
 }
 
 func (f *fakeOperatorClient) GetCapabilities(
@@ -77,13 +77,13 @@ func (f *fakeOperatorClient) MutateCluster(
 	panic("implement me")
 }
 
-func (f *fakeOperatorClient) SetClusterStatus(
+func (f *fakeOperatorClient) SetStatusInCluster(
 	_ context.Context,
-	_ *operator.SetClusterStatusRequest,
+	_ *operator.SetStatusInClusterRequest,
 	_ ...grpc.CallOption,
-) (*operator.SetClusterStatusResponse, error) {
-	if f.errSetClusterStatus != nil {
-		return nil, f.errSetClusterStatus
+) (*operator.SetStatusInClusterResponse, error) {
+	if f.errSetStatusInCluster != nil {
+		return nil, f.errSetStatusInCluster
 	}
 	return f.status, nil
 }
@@ -104,7 +104,7 @@ type fakeConnection struct {
 }
 
 func (f *fakeConnection) setStatusResponse(status []byte) {
-	f.operatorClient.status = &operator.SetClusterStatusResponse{
+	f.operatorClient.status = &operator.SetStatusInClusterResponse{
 		JsonStatus: status,
 	}
 }

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -462,7 +462,7 @@ func (r *ClusterReconciler) reconcile(ctx context.Context, cluster *apiv1.Cluste
 		return hookResult.Result, hookResult.Err
 	}
 
-	return setStatusPluginHook(ctx, r.Client, cluster)
+	return setStatusPluginHook(ctx, r.Client, getPluginClientFromContext(ctx), cluster)
 }
 
 func (r *ClusterReconciler) ensureNoFailoverOnFullDisk(

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -457,8 +457,12 @@ func (r *ClusterReconciler) reconcile(ctx context.Context, cluster *apiv1.Cluste
 	}
 
 	// Calls post-reconcile hooks
-	hookResult := postReconcilePluginHooks(ctx, cluster, cluster)
-	return hookResult.Result, hookResult.Err
+	if hookResult := postReconcilePluginHooks(ctx, cluster, cluster); hookResult.Err != nil ||
+		!hookResult.Result.IsZero() {
+		return hookResult.Result, hookResult.Err
+	}
+
+	return setStatusPluginHook(ctx, r.Client, cluster)
 }
 
 func (r *ClusterReconciler) ensureNoFailoverOnFullDisk(

--- a/internal/controller/plugins.go
+++ b/internal/controller/plugins.go
@@ -59,9 +59,9 @@ func setStatusPluginHook(
 	contextLogger := log.FromContext(ctx).WithName("set_status_plugin_hook")
 
 	origCluster := cluster.DeepCopy()
-	statuses, err := pluginClient.SetClusterStatus(ctx, cluster)
+	statuses, err := pluginClient.SetStatusInCluster(ctx, cluster)
 	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("while calling SetClusterStatus: %w", err)
+		return ctrl.Result{}, fmt.Errorf("while calling SetStatusInCluster: %w", err)
 	}
 	if len(statuses) == 0 {
 		return ctrl.Result{}, nil

--- a/internal/controller/plugins_test.go
+++ b/internal/controller/plugins_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright The CloudNativePG Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package controller
 
 import (

--- a/internal/controller/plugins_test.go
+++ b/internal/controller/plugins_test.go
@@ -1,0 +1,71 @@
+package controller
+
+import (
+	"context"
+	"encoding/json"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8client "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	pluginClient "github.com/cloudnative-pg/cloudnative-pg/internal/cnpi/plugin/client"
+	"github.com/cloudnative-pg/cloudnative-pg/internal/scheme"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+type fakePluginClient struct {
+	pluginClient.Client
+	setClusterStatus map[string]string
+}
+
+func (f *fakePluginClient) SetClusterStatus(
+	_ context.Context,
+	_ k8client.Object,
+) (map[string]string, error) {
+	return f.setClusterStatus, nil
+}
+
+var _ = Describe("setStatusPluginHook", func() {
+	const pluginName = "test1_plugin"
+	var (
+		cluster   *apiv1.Cluster
+		cli       k8client.Client
+		pluginCli *fakePluginClient
+	)
+
+	BeforeEach(func() {
+		cluster = &apiv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: "test-suite",
+			},
+			Status: apiv1.ClusterStatus{
+				PluginStatus: []apiv1.PluginStatus{
+					{
+						Name: pluginName,
+					},
+				},
+			},
+		}
+		cli = fake.NewClientBuilder().
+			WithObjects(cluster).
+			WithScheme(scheme.BuildWithAllKnownScheme()).
+			WithStatusSubresource(&apiv1.Cluster{}).
+			Build()
+
+		pluginCli = &fakePluginClient{}
+	})
+
+	It("should properly populated the plugin status", func(ctx SpecContext) {
+		content, err := json.Marshal(map[string]string{"key": "value"})
+		Expect(err).ToNot(HaveOccurred())
+		pluginCli.setClusterStatus = map[string]string{pluginName: string(content)}
+		res, err := setStatusPluginHook(ctx, cli, pluginCli, cluster)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(res).ToNot(BeNil())
+		Expect(cluster.Status.PluginStatus[0].Status).To(BeEquivalentTo(string(content)))
+	})
+})

--- a/internal/controller/plugins_test.go
+++ b/internal/controller/plugins_test.go
@@ -37,7 +37,7 @@ type fakePluginClient struct {
 	setClusterStatus map[string]string
 }
 
-func (f *fakePluginClient) SetClusterStatus(
+func (f *fakePluginClient) SetStatusInCluster(
 	_ context.Context,
 	_ k8client.Object,
 ) (map[string]string, error) {


### PR DESCRIPTION
This patch adds support for the CNPG-I capability [SetStatusInCluster](https://github.com/cloudnative-pg/cnpg-i/blob/5844b833f4eb1104110cd856d13f45d42d7828a6/proto/operator.proto#L22), allowing the plugins that implement this new capability to store their state as a raw JSON string inside the `Cluster` status.


Note for the reviewers:
- No issue has opened for this PR, given that CNPG-I is in active development and not yet v1.0.
- No backport.

## Release notes

CNPG Operator now supports the CNPG-I capability [SetStatusInCluster](https://github.com/cloudnative-pg/cnpg-i/blob/5844b833f4eb1104110cd856d13f45d42d7828a6/proto/operator.proto#L22)
