### PR TITLE
fix: cleanup PGDATA before initializing a PVC

### DIFF
--- a/internal/cmd/manager/instance/initdb/cmd.go
+++ b/internal/cmd/manager/instance/initdb/cmd.go
@@ -148,7 +148,7 @@ func NewCmd() *cobra.Command {
 }
 
 func initSubCommand(ctx context.Context, info postgres.InitInfo) error {
-	err := info.CheckTargetDataDirectory(ctx, true)
+	err := info.CheckTargetDataDirectory(ctx)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/manager/instance/initdb/cmd.go
+++ b/internal/cmd/manager/instance/initdb/cmd.go
@@ -148,7 +148,7 @@ func NewCmd() *cobra.Command {
 }
 
 func initSubCommand(ctx context.Context, info postgres.InitInfo) error {
-	err := info.VerifyPGData()
+	err := info.CheckTargetDataDirectory(ctx, true)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/manager/instance/join/cmd.go
+++ b/internal/cmd/manager/instance/join/cmd.go
@@ -94,7 +94,7 @@ func NewCmd() *cobra.Command {
 }
 
 func joinSubCommand(ctx context.Context, instance *postgres.Instance, info postgres.InitInfo) error {
-	if err := info.CheckTargetDataDirectory(ctx, true); err != nil {
+	if err := info.CheckTargetDataDirectory(ctx); err != nil {
 		return err
 	}
 

--- a/internal/cmd/manager/instance/join/cmd.go
+++ b/internal/cmd/manager/instance/join/cmd.go
@@ -94,8 +94,7 @@ func NewCmd() *cobra.Command {
 }
 
 func joinSubCommand(ctx context.Context, instance *postgres.Instance, info postgres.InitInfo) error {
-	err := info.VerifyPGData()
-	if err != nil {
+	if err := info.CheckTargetDataDirectory(ctx, true); err != nil {
 		return err
 	}
 
@@ -109,27 +108,34 @@ func joinSubCommand(ctx context.Context, instance *postgres.Instance, info postg
 	if err != nil {
 		return err
 	}
-	// Let's download the crypto material from the cluster
-	// secrets.
-	reconciler := controller.NewInstanceReconciler(instance, client, metricServer)
-	if err != nil {
-		log.Error(err, "Error creating reconciler to download certificates")
-		return err
-	}
 
+	// Create a fake reconciler just to download the secrets and
+	// the cluster definition
+	reconciler := controller.NewInstanceReconciler(instance, client, metricServer)
+
+	// Download the cluster definition from the API server
 	var cluster apiv1.Cluster
-	err = reconciler.GetClient().Get(ctx,
+	if err := reconciler.GetClient().Get(ctx,
 		ctrl.ObjectKey{Namespace: instance.Namespace, Name: instance.ClusterName},
-		&cluster)
-	if err != nil {
+		&cluster,
+	); err != nil {
 		log.Error(err, "Error while getting cluster")
 		return err
 	}
 
+	// Since we're directly using the reconciler here, we cannot
+	// tell if the secrets were correctly downloaded or not.
+	// If they were the following "pg_basebackup" command will work, if
+	// they don't "pg_basebackup" with fail, complaining that the
+	// cryptographic material is not available.
+	// So it doesn't make a real difference.
+	//
+	// Besides this, we should improve this situation to have
+	// a real error handling.
 	reconciler.RefreshSecrets(ctx, &cluster)
 
-	err = info.Join(&cluster)
-	if err != nil {
+	// Run "pg_basebackup" to download the data directory from the primary
+	if err := info.Join(&cluster); err != nil {
 		log.Error(err, "Error joining node")
 		return err
 	}

--- a/internal/cmd/manager/instance/restore/cmd.go
+++ b/internal/cmd/manager/instance/restore/cmd.go
@@ -82,7 +82,7 @@ func NewCmd() *cobra.Command {
 }
 
 func restoreSubCommand(ctx context.Context, info postgres.InitInfo) error {
-	err := info.CheckTargetDataDirectory(ctx, true)
+	err := info.CheckTargetDataDirectory(ctx)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/manager/instance/restore/cmd.go
+++ b/internal/cmd/manager/instance/restore/cmd.go
@@ -82,7 +82,7 @@ func NewCmd() *cobra.Command {
 }
 
 func restoreSubCommand(ctx context.Context, info postgres.InitInfo) error {
-	err := info.VerifyPGData()
+	err := info.CheckTargetDataDirectory(ctx, true)
 	if err != nil {
 		return err
 	}

--- a/pkg/fileutils/fileutils.go
+++ b/pkg/fileutils/fileutils.go
@@ -99,6 +99,13 @@ func FileExists(fileName string) (bool, error) {
 	return true, nil
 }
 
+// FormatFriendlyTimestamp formats a timestamp in a filename-friendly
+// way.
+func FormatFriendlyTimestamp(t time.Time) string {
+	const friendlyFormatRFC3339 = "20060102T150405Z0700"
+	return t.UTC().Format(friendlyFormatRFC3339)
+}
+
 // CopyFile copy a file from a location to another one
 func CopyFile(source, destination string) (err error) {
 	// Ensure that the directory really exist

--- a/pkg/fileutils/fileutils_test.go
+++ b/pkg/fileutils/fileutils_test.go
@@ -24,6 +24,7 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -398,5 +399,13 @@ var _ = Describe("EnsureDirectoryExists", func() {
 		fileInfo, err := os.Stat(existingDir)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(fileInfo.Mode().Perm()).To(Equal(fs.FileMode(0o600)))
+	})
+})
+
+var _ = Describe("Filename-friendly timestamp", func() {
+	It("returns a nice timestamp", func() {
+		fakeNow := time.Date(2024, 7, 19, 12, 20, 23, 0, time.UTC)
+		ts := FormatFriendlyTimestamp(fakeNow)
+		Expect(ts).To(Equal("20240719T122023Z"))
 	})
 })


### PR DESCRIPTION
This commit addresses an issue in CloudNativePG where Kubernetes jobs are created to initialize new PVCs during replica addition and primary instance creation.

In case of initialization failure, the jobs are retried, but since the PGDATA directory already exists, subsequent initialization attempts fail.

The patch modifies the process to clean up the PGDATA directory before retrying initialization. If the existing directory is a valid PGDATA, it is moved to a backup location instead of being deleted to prevent accidental data loss in case of a pre-existing PGDATA mistakenly left by the user in the PV.

Closes: #3365 