### PR TITLE
feat(plugin): enable customizing the remote dbname in subscriptions and publications

### DIFF
--- a/internal/cmd/plugin/logical/externalcluster.go
+++ b/internal/cmd/plugin/logical/externalcluster.go
@@ -34,6 +34,7 @@ func GetConnectionString(
 	ctx context.Context,
 	clusterName string,
 	externalClusterName string,
+	databaseName string,
 ) (string, error) {
 	var cluster apiv1.Cluster
 	err := plugin.Client.Get(
@@ -53,5 +54,5 @@ func GetConnectionString(
 		return "", fmt.Errorf("external cluster not existent in the cluster definition")
 	}
 
-	return external.GetServerConnectionString(&externalCluster), nil
+	return external.GetServerConnectionString(&externalCluster, databaseName), nil
 }

--- a/internal/cmd/plugin/logical/publication/create/cmd.go
+++ b/internal/cmd/plugin/logical/publication/create/cmd.go
@@ -93,7 +93,7 @@ func NewCmd() *cobra.Command {
 			target := dbName
 			if len(externalClusterName) > 0 {
 				var err error
-				target, err = logical.GetConnectionString(cmd.Context(), clusterName, externalClusterName)
+				target, err = logical.GetConnectionString(cmd.Context(), clusterName, externalClusterName, dbName)
 				if err != nil {
 					return err
 				}

--- a/internal/cmd/plugin/logical/publication/drop/cmd.go
+++ b/internal/cmd/plugin/logical/publication/drop/cmd.go
@@ -69,7 +69,7 @@ func NewCmd() *cobra.Command {
 			target := dbName
 			if len(externalClusterName) > 0 {
 				var err error
-				target, err = logical.GetConnectionString(cmd.Context(), clusterName, externalClusterName)
+				target, err = logical.GetConnectionString(cmd.Context(), clusterName, externalClusterName, dbName)
 				if err != nil {
 					return err
 				}

--- a/internal/cmd/plugin/logical/subscription/create/cmd.go
+++ b/internal/cmd/plugin/logical/subscription/create/cmd.go
@@ -63,7 +63,12 @@ func NewCmd() *cobra.Command {
 					"the name of the database was not specified and there is no available application database")
 			}
 
-			connectionString, err := logical.GetConnectionString(cmd.Context(), clusterName, externalClusterName, publicationDBName)
+			connectionString, err := logical.GetConnectionString(
+				cmd.Context(),
+				clusterName,
+				externalClusterName,
+				publicationDBName,
+			)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/plugin/logical/subscription/create/cmd.go
+++ b/internal/cmd/plugin/logical/subscription/create/cmd.go
@@ -61,7 +61,7 @@ func NewCmd() *cobra.Command {
 					"the name of the database was not specified and there is no available application database")
 			}
 
-			connectionString, err := logical.GetConnectionString(cmd.Context(), clusterName, externalClusterName)
+			connectionString, err := logical.GetConnectionString(cmd.Context(), clusterName, externalClusterName, dbName)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/plugin/logical/subscription/create/cmd.go
+++ b/internal/cmd/plugin/logical/subscription/create/cmd.go
@@ -31,7 +31,8 @@ func NewCmd() *cobra.Command {
 	var externalClusterName string
 	var publicationName string
 	var subscriptionName string
-	var dbName string
+	var publicationDBName string
+	var subscriptionDBName string
 	var parameters string
 	var dryRun bool
 
@@ -47,21 +48,22 @@ func NewCmd() *cobra.Command {
 			externalClusterName := strings.TrimSpace(externalClusterName)
 			publicationName := strings.TrimSpace(publicationName)
 			subscriptionName := strings.TrimSpace(subscriptionName)
-			dbName := strings.TrimSpace(dbName)
+			publicationDBName := strings.TrimSpace(publicationDBName)
+			subscriptionDBName := strings.TrimSpace(subscriptionDBName)
 
-			if len(dbName) == 0 {
+			if len(subscriptionDBName) == 0 {
 				var err error
-				dbName, err = logical.GetApplicationDatabaseName(cmd.Context(), clusterName)
+				subscriptionDBName, err = logical.GetApplicationDatabaseName(cmd.Context(), clusterName)
 				if err != nil {
 					return err
 				}
 			}
-			if len(dbName) == 0 {
+			if len(subscriptionDBName) == 0 {
 				return fmt.Errorf(
 					"the name of the database was not specified and there is no available application database")
 			}
 
-			connectionString, err := logical.GetConnectionString(cmd.Context(), clusterName, externalClusterName, dbName)
+			connectionString, err := logical.GetConnectionString(cmd.Context(), clusterName, externalClusterName, publicationDBName)
 			if err != nil {
 				return err
 			}
@@ -79,7 +81,7 @@ func NewCmd() *cobra.Command {
 				return nil
 			}
 
-			return logical.RunSQL(cmd.Context(), clusterName, dbName, sqlCommand)
+			return logical.RunSQL(cmd.Context(), clusterName, subscriptionDBName, sqlCommand)
 		},
 	}
 
@@ -108,10 +110,17 @@ func NewCmd() *cobra.Command {
 	_ = subscriptionCreateCmd.MarkFlagRequired("subscription")
 
 	subscriptionCreateCmd.Flags().StringVar(
-		&dbName,
+		&subscriptionDBName,
 		"dbname",
 		"",
-		"The name of the application where to create the subscription. Defaults to the application database if available",
+		"The name of the database where to create the subscription. Defaults to the application database if available",
+	)
+	subscriptionCreateCmd.Flags().StringVar(
+		&publicationDBName,
+		"publication-dbname",
+		"",
+		"The name of the database containing the publication on the external cluster. "+
+			"Defaults to the one in the external cluster definition",
 	)
 	subscriptionCreateCmd.Flags().StringVar(
 		&parameters,

--- a/pkg/management/external/external.go
+++ b/pkg/management/external/external.go
@@ -31,6 +31,7 @@ import (
 // the required cryptographic material
 func GetServerConnectionString(
 	server *apiv1.ExternalCluster,
+	databaseName string,
 ) string {
 	connectionParameters := maps.Clone(server.ConnectionParameters)
 
@@ -52,6 +53,10 @@ func GetServerConnectionString(
 	if server.Password != nil {
 		pgpassfile := getPgPassFilePath(server.Name)
 		connectionParameters["passfile"] = pgpassfile
+	}
+
+	if databaseName != "" {
+		connectionParameters["dbname"] = databaseName
 	}
 
 	return configfile.CreateConnectionString(connectionParameters)


### PR DESCRIPTION
This update allows users to specify a database name when managing publications and subscriptions with an ExternalCluster. This feature is particularly useful for monolithic servers hosting multiple databases, ensuring commands function consistently across local and remote databases. The dbname specified in the external cluster configuration will be overridden if this argument is set. Additionally, the `--publication-dbname` flag is introduced for the `subscription create` command, allowing the customization of the source database containing the publication.

Closes #4140 