### PR TITLE
feat(plugin): display `demotionToken` in `cnpg status`

### DIFF
--- a/docs/src/replica_cluster.md
+++ b/docs/src/replica_cluster.md
@@ -265,6 +265,10 @@ kubectl get cluster cluster-eu-south \
   -o jsonpath='{.status.demotionToken}'
 ```
 
+You can also get the `demotationToken` using `cnpg` plugin, by checking the 
+status of the cluster, the token is listed in `Demotion token` section.
+
+
 !!! Note
     The `demotionToken` obtained from `cluster-eu-south` will serve as the
     `promotionToken` for `cluster-eu-central`.

--- a/docs/src/replica_cluster.md
+++ b/docs/src/replica_cluster.md
@@ -265,9 +265,8 @@ kubectl get cluster cluster-eu-south \
   -o jsonpath='{.status.demotionToken}'
 ```
 
-You can also get the `demotationToken` using `cnpg` plugin, by checking the 
-status of the cluster, the token is listed in `Demotion token` section.
-
+You can obtain the `demotionToken` using the `cnpg` plugin by checking the
+cluster's status. The token is listed under the `Demotion token` section.
 
 !!! Note
     The `demotionToken` obtained from `cluster-eu-south` will serve as the

--- a/internal/cmd/plugin/status/status.go
+++ b/internal/cmd/plugin/status/status.go
@@ -311,11 +311,12 @@ func (fullStatus *PostgresqlStatus) printTokenStatus(token string) {
 	} else {
 		var systemIDCheck string
 
-		if primaryInstanceStatus == nil {
+		switch {
+		case primaryInstanceStatus == nil:
 			systemIDCheck = aurora.Red("(no primary have been found)").String()
-		} else if tokenContent.DatabaseSystemIdentifier != primaryInstanceStatus.SystemID {
+		case tokenContent.DatabaseSystemIdentifier != primaryInstanceStatus.SystemID:
 			systemIDCheck = aurora.Red("(invalid)").String()
-		} else {
+		default:
 			systemIDCheck = aurora.Green("(ok)").String()
 		}
 

--- a/internal/cmd/plugin/status/status.go
+++ b/internal/cmd/plugin/status/status.go
@@ -113,6 +113,8 @@ func Status(ctx context.Context, clusterName string, verbose bool, format plugin
 
 	status.printBasicInfo()
 	status.printHibernationInfo()
+	status.printDemotionTokenInfo()
+	status.printPromotionTokenInfo()
 	if verbose {
 		errs = append(errs, status.printPostgresConfiguration(ctx)...)
 	}
@@ -291,6 +293,88 @@ func (fullStatus *PostgresqlStatus) printHibernationInfo() {
 	fmt.Println(aurora.Green("Hibernation"))
 	hibernationStatus.Print()
 
+	fmt.Println()
+}
+
+func (fullStatus *PostgresqlStatus) printTokenStatus(token string) {
+	primaryInstanceStatus := fullStatus.tryGetPrimaryInstance()
+
+	tokenStatus := tabby.New()
+	if tokenContent, err := utils.ParsePgControldataToken(token); err != nil {
+		tokenStatus.AddLine(
+			"Token",
+			fmt.Sprintf("%s %s", token, aurora.Red(fmt.Sprintf("(invalid format: %s)", err.Error()))),
+		)
+	} else if err := tokenContent.IsValid(); err != nil {
+		tokenStatus.AddLine("Token", token)
+		tokenStatus.AddLine("Validity", aurora.Red(fmt.Sprintf("not valid: %s", err.Error())))
+	} else {
+		var systemIDCheck string
+
+		if primaryInstanceStatus == nil {
+			systemIDCheck = aurora.Red("(no primary have been found)").String()
+		} else if tokenContent.DatabaseSystemIdentifier != primaryInstanceStatus.SystemID {
+			systemIDCheck = aurora.Red("(invalid)").String()
+		} else {
+			systemIDCheck = aurora.Green("(ok)").String()
+		}
+
+		tokenStatus.AddLine(
+			"Token",
+			token)
+		tokenStatus.AddLine(
+			"Validity",
+			aurora.Green("valid"))
+		tokenStatus.AddLine(
+			"Latest checkpoint's TimeLineID",
+			tokenContent.LatestCheckpointTimelineID)
+		tokenStatus.AddLine(
+			"Latest checkpoint's REDO WAL file",
+			tokenContent.REDOWALFile)
+		tokenStatus.AddLine(
+			"Latest checkpoint's REDO location",
+			tokenContent.LatestCheckpointREDOLocation)
+		tokenStatus.AddLine(
+			"Database system identifier",
+			fmt.Sprintf("%s %s", tokenContent.DatabaseSystemIdentifier, systemIDCheck))
+		tokenStatus.AddLine(
+			"Time of latest checkpoint",
+			tokenContent.TimeOfLatestCheckpoint)
+		tokenStatus.AddLine(
+			"Version of the operator",
+			tokenContent.OperatorVersion)
+	}
+	tokenStatus.Print()
+}
+
+func (fullStatus *PostgresqlStatus) printDemotionTokenInfo() {
+	demotionToken := fullStatus.Cluster.Status.DemotionToken
+	if len(demotionToken) == 0 {
+		return
+	}
+
+	fmt.Println(aurora.Green("Demotion token"))
+	fullStatus.printTokenStatus(demotionToken)
+	fmt.Println()
+}
+
+func (fullStatus *PostgresqlStatus) printPromotionTokenInfo() {
+	if fullStatus.Cluster.Spec.ReplicaCluster == nil {
+		return
+	}
+
+	promotionToken := fullStatus.Cluster.Spec.ReplicaCluster.PromotionToken
+	if len(promotionToken) == 0 {
+		return
+	}
+
+	if promotionToken == fullStatus.Cluster.Status.LastPromotionToken {
+		// This token was already processed
+		return
+	}
+
+	fmt.Println(aurora.Green("Promotion token"))
+	fullStatus.printTokenStatus(promotionToken)
 	fmt.Println()
 }
 


### PR DESCRIPTION
The status subcommand now shows the demotion and promotion token encoded and decoded.

Closes: #5135 