### PR TITLE
fix(CNPG-I): correctly evaluate the resource `Kind` inside `reconcilerHook`

### DIFF
--- a/internal/cnpi/plugin/client/reconciler.go
+++ b/internal/cnpi/plugin/client/reconciler.go
@@ -130,7 +130,7 @@ func reconcilerHook(
 	}
 
 	var kind reconciler.ReconcilerHooksCapability_Kind
-	switch cluster.GetObjectKind().GroupVersionKind().Kind {
+	switch object.GetObjectKind().GroupVersionKind().Kind {
 	case "Cluster":
 		kind = reconciler.ReconcilerHooksCapability_KIND_CLUSTER
 	case "Backup":


### PR DESCRIPTION
Currently, in our code, we evaluate the cluster resource kind instead of the passed resource kind in the `reconcileHook.`, leading to the cluster reconcile capability always being called in the reconcile hooks; this patch aims to fix that.
 
Closes #5153 

# Release notes

NONE
