### PR TITLE
fix: PG instances anti-affinity configuration

### DIFF
--- a/docs/src/scheduling.md
+++ b/docs/src/scheduling.md
@@ -32,7 +32,8 @@ running in those nodes.
 This is technically known as **inter-pod affinity/anti-affinity**.
 
 CloudNativePG by default will configure the cluster's instances
-preferably on different nodes, resulting in the following `affinity` definition:
+preferably on different nodes, while pgBouncer may still run on the same nodes,
+resulting in the following `affinity` definition:
 
 ```yaml
 affinity:
@@ -41,10 +42,14 @@ affinity:
       - podAffinityTerm:
           labelSelector:
             matchExpressions:
-              - key: postgresql
+              - key: cnpg.io/cluster
                 operator: In
                 values:
                   - cluster-example
+              - key: cnpg.io/podRole
+                operator: In
+                values:
+                  - instance
           topologyKey: kubernetes.io/hostname
         weight: 100
 ```

--- a/pkg/specs/pods.go
+++ b/pkg/specs/pods.go
@@ -354,6 +354,13 @@ func CreateGeneratedAntiAffinity(clusterName string, config apiv1.AffinityConfig
 						clusterName,
 					},
 				},
+				{
+					Key:      utils.PodRoleLabelName,
+					Operator: metav1.LabelSelectorOpIn,
+					Values: []string{
+						string(utils.PodRoleInstance),
+					},
+				},
 			},
 		},
 		TopologyKey: topologyKey,

--- a/tests/e2e/affinity_test.go
+++ b/tests/e2e/affinity_test.go
@@ -1,0 +1,61 @@
+/*
+Copyright The CloudNativePG Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+	"github.com/cloudnative-pg/cloudnative-pg/tests"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("E2E Affinity", Serial, Label(tests.LabelPodScheduling), func() {
+	const (
+		clusterFile     = fixturesDir + "/affinity/cluster-affinity.yaml"
+		poolerFile      = fixturesDir + "/affinity/pooler-affinity.yaml"
+		clusterName     = "cluster-affinity"
+		namespacePrefix = "test-affinity"
+		level           = tests.Medium
+	)
+	var namespace string
+	var err error
+
+	BeforeEach(func() {
+		if testLevelEnv.Depth < int(level) {
+			Skip("Test depth is lower than the amount requested for this test")
+		}
+	})
+
+	It("can create a cluster with required affinity", func() {
+		namespace, err = env.CreateUniqueNamespace(namespacePrefix)
+		Expect(err).ToNot(HaveOccurred())
+		DeferCleanup(func() error {
+			if CurrentSpecReport().Failed() {
+				env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
+			}
+			return env.DeleteNamespace(namespace)
+		})
+
+		AssertCreateCluster(namespace, clusterName, clusterFile, env)
+		createAndAssertPgBouncerPoolerIsSetUp(namespace, poolerFile, 3)
+
+		_, _, err := utils.Run(fmt.Sprintf("kubectl scale --replicas=3 -n %v cluster/%v", namespace, clusterName))
+		Expect(err).ToNot(HaveOccurred())
+		AssertClusterIsReady(namespace, clusterName, 300, env)
+	})
+})

--- a/tests/e2e/affinity_test.go
+++ b/tests/e2e/affinity_test.go
@@ -18,8 +18,10 @@ package e2e
 
 import (
 	"fmt"
+
 	"github.com/cloudnative-pg/cloudnative-pg/tests"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -41,7 +43,7 @@ var _ = Describe("E2E Affinity", Serial, Label(tests.LabelPodScheduling), func()
 		}
 	})
 
-	It("can create a cluster with required affinity", func() {
+	It("can create a cluster and a pooler with required affinity", func() {
 		namespace, err = env.CreateUniqueNamespace(namespacePrefix)
 		Expect(err).ToNot(HaveOccurred())
 		DeferCleanup(func() error {

--- a/tests/e2e/fixtures/affinity/cluster-affinity.yaml
+++ b/tests/e2e/fixtures/affinity/cluster-affinity.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: cluster-affinity
+spec:
+  instances: 1
+
+  affinity:
+    podAntiAffinityType: required
+
+  storage:
+    size: 1Gi
+

--- a/tests/e2e/fixtures/affinity/pooler-affinity.yaml
+++ b/tests/e2e/fixtures/affinity/pooler-affinity.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Pooler
+metadata:
+  name: cluster-pooler-affinity
+spec:
+  cluster:
+    name: cluster-affinity
+
+  instances: 3
+
+  pgbouncer:
+    poolMode: session


### PR DESCRIPTION
This patch is fixing the PodAntiAffinity configuration for PostgreSQL Pods,
allowing PostgreSQL and PgBouncer to coexist on the same node when
the anti-affinity configuration is set to `required`.

Closes: #4293 