### PR TITLE
chore(security): use a known path to execute manager

### DIFF
--- a/pkg/management/upgrade/upgrade.go
+++ b/pkg/management/upgrade/upgrade.go
@@ -185,7 +185,7 @@ func validateInstanceManagerHash(
 // This function never returns in case of success.
 func reloadInstanceManager() error {
 	log.Info("Replacing current instance")
-	err := syscall.Exec(os.Args[0], os.Args, os.Environ()) // #nosec
+	err := syscall.Exec(InstanceManagerPath, os.Args, os.Environ()) // #nosec G204
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
We were using the `os.Args[0]` to execute the command, but this could
lead to execute a different command if this is replaced in memory or
if we write a different file than the one that was executed, hence we should
use the known path of the manager to be executed.

Closes #5157 