### PR TITLE
fix: add the dash separation and lowercase to version

### DIFF
--- a/docs/src/release_notes/v1.24.md
+++ b/docs/src/release_notes/v1.24.md
@@ -6,7 +6,7 @@ For a complete list of changes, please refer to the
 [commits](https://github.com/cloudnative-pg/cloudnative-pg/commits/release-1.24)
 on the release branch in GitHub.
 
-## Version 1.24.0 RC1
+## Version 1.24.0-rc1
 
 **Release date:** Jul 30, 2024
 


### PR DESCRIPTION
The version in the release notes should be lowercase and dash separated