### PR TITLE
test(e2e): prevent failures in the corruption test

### DIFF
--- a/tests/e2e/pg_data_corruption_test.go
+++ b/tests/e2e/pg_data_corruption_test.go
@@ -80,7 +80,7 @@ var _ = Describe("PGDATA Corruption", Label(tests.LabelRecovery), Ordered, func(
 		})
 
 		By("corrupting primary pod by removing PGDATA", func() {
-			cmd := fmt.Sprintf("rm -fr %v/base/*", specs.PgDataPath)
+			cmd := fmt.Sprintf("find %v/base/* -type f -delete", specs.PgDataPath)
 			_, _, err = env.ExecCommandInInstancePod(
 				testsUtils.PodLocator{
 					Namespace: namespace,


### PR DESCRIPTION
`rm -fr` fails when a file is created meanwhile the target directory is removed.

This patch replaces it with `find` that is not prone to that error.

# Release notes

NONE