### PR TITLE
fix: drop stale replica cluster connections

### DIFF
--- a/internal/management/controller/instance_controller.go
+++ b/internal/management/controller/instance_controller.go
@@ -259,7 +259,10 @@ func (r *InstanceReconciler) Reconcile(
 	}
 
 	if res, err := r.dropStaleReplicationConnections(ctx, cluster); err != nil || !res.IsZero() {
-		return res, fmt.Errorf("while dropping stale replica connections: %w", err)
+		if err != nil {
+			return reconcile.Result{}, fmt.Errorf("while dropping stale replica connections: %w", err)
+		}
+		return res, nil
 	}
 
 	if err := r.reconcileDatabases(ctx, cluster); err != nil {

--- a/internal/management/controller/instance_controller.go
+++ b/internal/management/controller/instance_controller.go
@@ -313,6 +313,10 @@ func (r *InstanceReconciler) restartPrimaryInplaceIfRequested(
 	if err != nil {
 		return false, err
 	}
+
+	// Restart both the designated primary and actual primary
+	isPrimary = isPrimary || (cluster.IsReplica() && cluster.Status.CurrentPrimary == r.instance.PodName)
+
 	restartRequested := isPrimary && cluster.Status.Phase == apiv1.PhaseInplacePrimaryRestart
 	if restartRequested {
 		restartTimeout := cluster.GetRestartTimeout()

--- a/internal/management/controller/instance_controller.go
+++ b/internal/management/controller/instance_controller.go
@@ -1472,6 +1472,10 @@ func (r *InstanceReconciler) dropStaleReplicationConnections(
 		return ctrl.Result{}, fmt.Errorf("while dropping connections: %w", err)
 	}
 
+	// There is a possibility that when connections are dropped at the first time,
+	// the pod of the designated primary has not yet been labeled as primary.
+	// As a result, the standbys might reconnect to the old primary by the Service `<cluster>-rw`
+	// To avoid this issue, attempt to drop the connections again after 5s.
 	terminatedConnections, err := result.RowsAffected()
 	if err != nil {
 		return ctrl.Result{}, err

--- a/tests/e2e/asserts_test.go
+++ b/tests/e2e/asserts_test.go
@@ -178,16 +178,14 @@ func AssertSwitchoverWithHistory(
 				return nil
 			}, timeout).ShouldNot(HaveOccurred())
 		})
-	}
-
-	if isReplica {
+	} else {
 		By("verifying that the all standbys are streaming from the new primary", func() {
 			timeout := 120
 			commandTimeout := time.Second * 10
 			Eventually(func(g Gomega) {
 				podList, err := env.GetClusterPodList(namespace, clusterName)
 				g.Expect(err).ToNot(HaveOccurred())
-
+				g.Expect(podList.Items).To(HaveLen(oldPodListLength))
 				var standbys []interface{}
 				for _, pod := range podList.Items {
 					if specs.IsPodStandby(pod) {
@@ -219,7 +217,6 @@ func AssertSwitchoverWithHistory(
 						)
 					}
 				}
-
 			}, timeout).ShouldNot(HaveOccurred())
 		})
 	}

--- a/tests/e2e/asserts_test.go
+++ b/tests/e2e/asserts_test.go
@@ -178,47 +178,6 @@ func AssertSwitchoverWithHistory(
 				return nil
 			}, timeout).ShouldNot(HaveOccurred())
 		})
-	} else {
-		By("verifying that the all standbys are streaming from the new primary", func() {
-			timeout := 120
-			commandTimeout := time.Second * 10
-			Eventually(func(g Gomega) {
-				podList, err := env.GetClusterPodList(namespace, clusterName)
-				g.Expect(err).ToNot(HaveOccurred())
-				g.Expect(podList.Items).To(HaveLen(oldPodListLength))
-				var standbys []interface{}
-				for _, pod := range podList.Items {
-					if specs.IsPodStandby(pod) {
-						standbys = append(standbys, pod.Name)
-					}
-				}
-
-				for _, pod := range podList.Items {
-					stdout, _, err := env.ExecCommand(
-						env.Ctx,
-						pod,
-						specs.PostgresContainerName,
-						&commandTimeout,
-						"psql", "-U", "postgres", "-tAc",
-						"select string_agg(application_name, ',')  from pg_stat_replication;",
-					)
-					g.Expect(err).ToNot(HaveOccurred())
-
-					if specs.IsPrimary(pod.ObjectMeta) {
-						appNames := strings.Split(strings.TrimSpace(stdout), ",")
-						g.Expect(appNames).To(
-							ContainElements(standbys...),
-							"not all standbys are streaming from the new primary "+pod.Name,
-						)
-					} else {
-						g.Expect(strings.TrimSpace(stdout)).To(
-							BeEmpty(),
-							fmt.Sprintf("the standby %s should not stream to any other instance", pod.Name),
-						)
-					}
-				}
-			}, timeout).ShouldNot(HaveOccurred())
-		})
 	}
 }
 

--- a/tests/e2e/fixtures/replica_mode_cluster/cluster-replica-tls.yaml.template
+++ b/tests/e2e/fixtures/replica_mode_cluster/cluster-replica-tls.yaml.template
@@ -3,7 +3,7 @@ kind: Cluster
 metadata:
   name: cluster-replica-tls
 spec:
-  instances: 1
+  instances: 3
 
   bootstrap:
     pg_basebackup:

--- a/tests/e2e/replica_mode_cluster_test.go
+++ b/tests/e2e/replica_mode_cluster_test.go
@@ -90,6 +90,10 @@ var _ = Describe("Replica Mode", Label(tests.LabelReplication), func() {
 				replicaClusterSampleTLS,
 				testTableName,
 				psqlClientPod)
+
+			replicaName, err := env.GetResourceNameFromYAML(replicaClusterSampleTLS)
+			Expect(err).ToNot(HaveOccurred())
+			AssertSwitchoverOnReplica(replicaNamespace, replicaName, env)
 		})
 	})
 

--- a/tests/e2e/replica_mode_cluster_test.go
+++ b/tests/e2e/replica_mode_cluster_test.go
@@ -37,7 +37,6 @@ import (
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 	"github.com/cloudnative-pg/cloudnative-pg/tests"
 	testUtils "github.com/cloudnative-pg/cloudnative-pg/tests/utils"
-	testsUtils "github.com/cloudnative-pg/cloudnative-pg/tests/utils"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -754,7 +753,7 @@ func assertReplicaClusterTopology(namespace, clusterName string) {
 
 	getStreamingInfo := func(podName string) ([]string, error) {
 		stdout, _, err := env.ExecCommandInInstancePod(
-			testsUtils.PodLocator{
+			testUtils.PodLocator{
 				Namespace: namespace,
 				PodName:   podName,
 			},
@@ -798,7 +797,7 @@ func assertReplicaClusterTopology(namespace, clusterName string) {
 	By("verifying that the new primary is streaming from the source cluster", func() {
 		Eventually(func(g Gomega) {
 			stdout, _, err := env.ExecCommandInInstancePod(
-				testsUtils.PodLocator{
+				testUtils.PodLocator{
 					Namespace: namespace,
 					PodName:   primary,
 				},


### PR DESCRIPTION
This patch makes the instance manager terminate all existing operator-related replication connections following a role change in a replica cluster.

For context, demoting a PostgreSQL instance involves shutting it down, adjusting the necessary signal files and configuration, and then restarting it, which inherently disconnects all existing connections.

In a replica cluster, demotion is unnecessary since it comprises replicas only. In this scenario, only the primary_conninfo parameter needs to be modified, which doesn't require a shutdown. However, this also implies that replicas receiving data from the old primary won't have their connections terminated.

Consequently, high-availability replicas connected to the previous primary will remain connected, necessitating manual intervention to terminate those connections and re-establish them with the new endpoint.

Closes: #5197 

## Release notes

The instance manager will now terminate all existing operator-related replication connections following a role change in a replica cluster.