### PR TITLE
fix: synchronous replication self-healing for terminating Pods

### DIFF
--- a/pkg/utils/pod_conditions.go
+++ b/pkg/utils/pod_conditions.go
@@ -124,7 +124,7 @@ func ListStatusPods(podList []corev1.Pod) map[PodStatus][]string {
 	podsNames := make(map[PodStatus][]string)
 
 	for _, pod := range podList {
-		if pod.DeletionTimestamp != nil {
+		if !pod.DeletionTimestamp.IsZero() {
 			continue
 		}
 		switch {

--- a/pkg/utils/pod_conditions.go
+++ b/pkg/utils/pod_conditions.go
@@ -124,6 +124,9 @@ func ListStatusPods(podList []corev1.Pod) map[PodStatus][]string {
 	podsNames := make(map[PodStatus][]string)
 
 	for _, pod := range podList {
+		if pod.DeletionTimestamp != nil {
+			continue
+		}
 		switch {
 		case IsPodReady(pod):
 			podsNames[PodHealthy] = append(podsNames[PodHealthy], pod.Name)

--- a/pkg/utils/pod_conditions_test.go
+++ b/pkg/utils/pod_conditions_test.go
@@ -162,4 +162,106 @@ var _ = Describe("Pod conditions test suite", func() {
 		}
 		Expect(IsPodUnschedulable(pod)).To(BeFalse())
 	})
+
+	Describe("Properly builds ListStatusPods", func() {
+		healthyPod := corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "healthyPod",
+			},
+			Status: corev1.PodStatus{
+				Conditions: []corev1.PodCondition{
+					{
+						Type:   corev1.ContainersReady,
+						Status: corev1.ConditionTrue,
+					},
+				},
+			},
+		}
+		activePod := corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "activePod",
+			},
+			Status: corev1.PodStatus{
+				Phase: corev1.PodRunning,
+				Conditions: []corev1.PodCondition{
+					{
+						Type:   corev1.ContainersReady,
+						Status: corev1.ConditionFalse,
+					},
+				},
+			},
+		}
+		failedPod := corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "failedPod",
+			},
+			Status: corev1.PodStatus{
+				Phase: corev1.PodFailed,
+				Conditions: []corev1.PodCondition{
+					{
+						Type:   corev1.ContainersReady,
+						Status: corev1.ConditionFalse,
+					},
+				},
+			},
+		}
+
+		now := metav1.Now()
+		terminatingPod := corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "terminatingPod",
+				DeletionTimestamp: &now,
+			},
+			Status: corev1.PodStatus{
+				Phase: corev1.PodRunning,
+				Conditions: []corev1.PodCondition{
+					{
+						Type:   corev1.ContainersReady,
+						Status: corev1.ConditionTrue,
+					},
+				},
+			},
+		}
+
+		It("Detects healthy pods", func() {
+			podList := []corev1.Pod{healthyPod, healthyPod}
+			expectedStatus := map[PodStatus][]string{
+				PodHealthy: {"healthyPod", "healthyPod"},
+			}
+			podStatus := ListStatusPods(podList)
+			Expect(podStatus).To(BeEquivalentTo(expectedStatus))
+		})
+
+		It("Detects active pods", func() {
+			podList := []corev1.Pod{healthyPod, activePod}
+			expectedStatus := map[PodStatus][]string{
+				PodHealthy:     {"healthyPod"},
+				PodReplicating: {"activePod"},
+			}
+			podStatus := ListStatusPods(podList)
+			Expect(podStatus).To(BeEquivalentTo(expectedStatus))
+		})
+
+		It("Detects failed pods", func() {
+			podList := []corev1.Pod{healthyPod, activePod, failedPod}
+			expectedStatus := map[PodStatus][]string{
+				PodHealthy:     {"healthyPod"},
+				PodReplicating: {"activePod"},
+				PodFailed:      {"failedPod"},
+			}
+			podStatus := ListStatusPods(podList)
+			Expect(podStatus).To(BeEquivalentTo(expectedStatus))
+		})
+
+		It("Excludes terminating pods", func() {
+			podList := []corev1.Pod{healthyPod, activePod, failedPod, terminatingPod}
+			expectedStatus := map[PodStatus][]string{
+				PodHealthy:     {"healthyPod"},
+				PodReplicating: {"activePod"},
+				PodFailed:      {"failedPod"},
+			}
+			podStatus := ListStatusPods(podList)
+			Expect(podStatus).To(BeEquivalentTo(expectedStatus))
+		})
+	})
 })


### PR DESCRIPTION
This patch modifies the `cluster.Status.InstancesStatus` list to exclude Pods with a `deletionTimestamp`.

As a result, terminated Pods are treated as not ready when generating the list of healthy instances for synchronous replication.

Closes #5208 

# Release notes

Synchronous replication self-healing checks now exclude terminated pods, focusing only on active and functional pods.