### PR TITLE
chore: improve operator logs in E2E tests

### DIFF
--- a/internal/controller/cluster_create.go
+++ b/internal/controller/cluster_create.go
@@ -743,7 +743,7 @@ func (r *ClusterReconciler) createOrPatchDefaultMetricsConfigmap(ctx context.Con
 	var sourceConfigmap corev1.ConfigMap
 	if err := r.Get(ctx,
 		client.ObjectKey{
-			Name:      "fooBar",
+			Name:      configuration.Current.MonitoringQueriesConfigmap,
 			Namespace: configuration.Current.OperatorNamespace,
 		}, &sourceConfigmap); err != nil {
 		if apierrs.IsNotFound(err) {

--- a/internal/controller/cluster_create.go
+++ b/internal/controller/cluster_create.go
@@ -743,7 +743,7 @@ func (r *ClusterReconciler) createOrPatchDefaultMetricsConfigmap(ctx context.Con
 	var sourceConfigmap corev1.ConfigMap
 	if err := r.Get(ctx,
 		client.ObjectKey{
-			Name:      configuration.Current.MonitoringQueriesConfigmap,
+			Name:      "fooBar",
 			Namespace: configuration.Current.OperatorNamespace,
 		}, &sourceConfigmap); err != nil {
 		if apierrs.IsNotFound(err) {

--- a/pkg/utils/logs/logs.go
+++ b/pkg/utils/logs/logs.go
@@ -35,9 +35,9 @@ type StreamingRequest struct {
 	Pod      *v1.Pod
 	Options  *v1.PodLogOptions
 	Previous bool `json:"previous,omitempty"`
-	// NOTE: the client argument may be omitted, but it is good practice to pass it
+	// NOTE: the Client argument may be omitted, but it is good practice to pass it
 	// Importantly, it makes the logging functions testable
-	client kubernetes.Interface
+	Client kubernetes.Interface
 }
 
 func (spl *StreamingRequest) getPodName() string {
@@ -63,14 +63,14 @@ func (spl *StreamingRequest) getLogOptions() *v1.PodLogOptions {
 }
 
 func (spl *StreamingRequest) getKubernetesClient() kubernetes.Interface {
-	if spl.client != nil {
-		return spl.client
+	if spl.Client != nil {
+		return spl.Client
 	}
 	conf := ctrl.GetConfigOrDie()
 
-	spl.client = kubernetes.NewForConfigOrDie(conf)
+	spl.Client = kubernetes.NewForConfigOrDie(conf)
 
-	return spl.client
+	return spl.Client
 }
 
 // getStreamToPod opens the REST request to the pod
@@ -125,7 +125,7 @@ func TailPodLogs(
 			Follow:     true,
 			SinceTime:  &now,
 		},
-		client: client,
+		Client: client,
 	}
 	return streamPodLog.Stream(ctx, writer)
 }
@@ -154,7 +154,7 @@ func GetPodLogs(
 		Pod:      &pod,
 		Previous: getPrevious,
 		Options:  &v1.PodLogOptions{},
-		client:   client,
+		Client:   client,
 	}
 	logsRequest := streamPodLog.getStreamToPod()
 

--- a/pkg/utils/logs/logs_test.go
+++ b/pkg/utils/logs/logs_test.go
@@ -56,7 +56,7 @@ var _ = Describe("Pod logging tests", func() {
 		streamPodLog := StreamingRequest{
 			Pod:     nil,
 			Options: podLogOptions,
-			client:  client,
+			Client:  client,
 		}
 		var logBuffer bytes.Buffer
 		err := streamPodLog.Stream(ctx, &logBuffer)
@@ -95,7 +95,7 @@ var _ = Describe("Pod logging tests", func() {
 			Pod:      pod,
 			Options:  podLogOptions,
 			Previous: false,
-			client:   client,
+			Client:   client,
 		}
 
 		var logBuffer bytes.Buffer

--- a/tests/e2e/affinity_test.go
+++ b/tests/e2e/affinity_test.go
@@ -47,10 +47,12 @@ var _ = Describe("E2E Affinity", Serial, Label(tests.LabelPodScheduling), func()
 		namespace, err = env.CreateUniqueNamespace(namespacePrefix)
 		Expect(err).ToNot(HaveOccurred())
 		DeferCleanup(func() error {
-			if CurrentSpecReport().Failed() {
-				env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
-			}
-			return env.DeleteNamespace(namespace)
+			return env.CleanupNamespace(
+				namespace,
+				CurrentSpecReport().LeafNodeText,
+				CurrentSpecReport().Failed(),
+				GinkgoWriter,
+			)
 		})
 
 		AssertCreateCluster(namespace, clusterName, clusterFile, env)

--- a/tests/e2e/apparmor_test.go
+++ b/tests/e2e/apparmor_test.go
@@ -51,10 +51,12 @@ var _ = Describe("AppArmor support", Serial, Label(tests.LabelNoOpenshift, tests
 		namespace, err = env.CreateUniqueNamespace(namespacePrefix)
 		Expect(err).ToNot(HaveOccurred())
 		DeferCleanup(func() error {
-			if CurrentSpecReport().Failed() {
-				env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
-			}
-			return env.DeleteNamespace(namespace)
+			return env.CleanupNamespace(
+				namespace,
+				CurrentSpecReport().LeafNodeText,
+				CurrentSpecReport().Failed(),
+				GinkgoWriter,
+			)
 		})
 
 		AssertCreateCluster(namespace, clusterName, clusterAppArmorFile, env)

--- a/tests/e2e/architecture_test.go
+++ b/tests/e2e/architecture_test.go
@@ -74,10 +74,12 @@ var _ = Describe("Available Architectures", Label(tests.LabelBasic), func() {
 		namespace, err := env.CreateUniqueNamespace(namespacePrefix)
 		Expect(err).ToNot(HaveOccurred())
 		DeferCleanup(func() error {
-			if CurrentSpecReport().Failed() {
-				env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
-			}
-			return env.DeleteNamespace(namespace)
+			return env.CleanupNamespace(
+				namespace,
+				CurrentSpecReport().LeafNodeText,
+				CurrentSpecReport().Failed(),
+				GinkgoWriter,
+			)
 		})
 
 		clusterName, err := env.GetResourceNameFromYAML(clusterManifest)

--- a/tests/e2e/asserts_test.go
+++ b/tests/e2e/asserts_test.go
@@ -1093,6 +1093,8 @@ func AssertDetachReplicaModeCluster(
 		Eventually(func(g Gomega) {
 			cluster, err := env.GetCluster(namespace, replicaClusterName)
 			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(cluster.Spec.ReplicaCluster.Enabled).NotTo(BeNil(), "replica.enabled was nil")
+			g.Expect(*cluster.Spec.ReplicaCluster.Enabled).To(BeFalse(), "replica.enabled still true")
 			condition, err := testsUtils.GetConditionsInClusterStatus(namespace, cluster.Name, env,
 				apiv1.ConditionClusterReady)
 			g.Expect(err).ToNot(HaveOccurred())

--- a/tests/e2e/asserts_test.go
+++ b/tests/e2e/asserts_test.go
@@ -1093,8 +1093,6 @@ func AssertDetachReplicaModeCluster(
 		Eventually(func(g Gomega) {
 			cluster, err := env.GetCluster(namespace, replicaClusterName)
 			g.Expect(err).ToNot(HaveOccurred())
-			g.Expect(cluster.Spec.ReplicaCluster.Enabled).NotTo(BeNil(), "replica.enabled was nil")
-			g.Expect(*cluster.Spec.ReplicaCluster.Enabled).To(BeFalse(), "replica.enabled still true")
 			condition, err := testsUtils.GetConditionsInClusterStatus(namespace, cluster.Name, env,
 				apiv1.ConditionClusterReady)
 			g.Expect(err).ToNot(HaveOccurred())

--- a/tests/e2e/backup_restore_test.go
+++ b/tests/e2e/backup_restore_test.go
@@ -79,7 +79,12 @@ var _ = Describe("Backup and restore", Label(tests.LabelBackupRestore), func() {
 			namespace, err = env.CreateUniqueNamespace(namespacePrefix)
 			Expect(err).ToNot(HaveOccurred())
 			DeferCleanup(func() error {
-				return env.DeleteNamespace(namespace)
+				return env.CleanupNamespace(
+					namespace,
+					CurrentSpecReport().LeafNodeText,
+					CurrentSpecReport().Failed(),
+					GinkgoWriter,
+				)
 			})
 
 			By("create the certificates for MinIO", func() {
@@ -533,7 +538,12 @@ var _ = Describe("Backup and restore", Label(tests.LabelBackupRestore), func() {
 			namespace, err = env.CreateUniqueNamespace(namespacePrefix)
 			Expect(err).ToNot(HaveOccurred())
 			DeferCleanup(func() error {
-				return env.DeleteNamespace(namespace)
+				return env.CleanupNamespace(
+					namespace,
+					CurrentSpecReport().LeafNodeText,
+					CurrentSpecReport().Failed(),
+					GinkgoWriter,
+				)
 			})
 
 			// The Azure Blob Storage should have been created ad-hoc for the test.
@@ -673,7 +683,12 @@ var _ = Describe("Backup and restore", Label(tests.LabelBackupRestore), func() {
 			namespace, err = env.CreateUniqueNamespace(namespacePrefix)
 			Expect(err).ToNot(HaveOccurred())
 			DeferCleanup(func() error {
-				return env.DeleteNamespace(namespace)
+				return env.CleanupNamespace(
+					namespace,
+					CurrentSpecReport().LeafNodeText,
+					CurrentSpecReport().Failed(),
+					GinkgoWriter,
+				)
 			})
 
 			// Create and assert ca and tls certificate secrets on Azurite
@@ -809,7 +824,12 @@ var _ = Describe("Clusters Recovery From Barman Object Store", Label(tests.Label
 			namespace, err = env.CreateUniqueNamespace(namespacePrefix)
 			Expect(err).ToNot(HaveOccurred())
 			DeferCleanup(func() error {
-				return env.DeleteNamespace(namespace)
+				return env.CleanupNamespace(
+					namespace,
+					CurrentSpecReport().LeafNodeText,
+					CurrentSpecReport().Failed(),
+					GinkgoWriter,
+				)
 			})
 
 			AssertStorageCredentialsAreCreated(namespace, "backup-storage-creds", "minio", "minio123")
@@ -968,7 +988,12 @@ var _ = Describe("Clusters Recovery From Barman Object Store", Label(tests.Label
 				namespace, err = env.CreateUniqueNamespace(namespacePrefix)
 				Expect(err).ToNot(HaveOccurred())
 				DeferCleanup(func() error {
-					return env.DeleteNamespace(namespace)
+					return env.CleanupNamespace(
+						namespace,
+						CurrentSpecReport().LeafNodeText,
+						CurrentSpecReport().Failed(),
+						GinkgoWriter,
+					)
 				})
 
 				// The Azure Blob Storage should have been created ad-hoc for the test.
@@ -1052,7 +1077,12 @@ var _ = Describe("Clusters Recovery From Barman Object Store", Label(tests.Label
 				namespace, err = env.CreateUniqueNamespace(namespacePrefix)
 				Expect(err).ToNot(HaveOccurred())
 				DeferCleanup(func() error {
-					return env.DeleteNamespace(namespace)
+					return env.CleanupNamespace(
+						namespace,
+						CurrentSpecReport().LeafNodeText,
+						CurrentSpecReport().Failed(),
+						GinkgoWriter,
+					)
 				})
 
 				// The Azure Blob Storage should have been created ad-hoc for the test,
@@ -1139,7 +1169,12 @@ var _ = Describe("Clusters Recovery From Barman Object Store", Label(tests.Label
 			namespace, err = env.CreateUniqueNamespace(namespacePrefix)
 			Expect(err).ToNot(HaveOccurred())
 			DeferCleanup(func() error {
-				return env.DeleteNamespace(namespace)
+				return env.CleanupNamespace(
+					namespace,
+					CurrentSpecReport().LeafNodeText,
+					CurrentSpecReport().Failed(),
+					GinkgoWriter,
+				)
 			})
 
 			// Create and assert ca and tls certificate secrets on Azurite

--- a/tests/e2e/certificates_test.go
+++ b/tests/e2e/certificates_test.go
@@ -91,7 +91,12 @@ var _ = Describe("Certificates", func() {
 			namespace, err = env.CreateUniqueNamespace(namespacePrefix)
 			Expect(err).ToNot(HaveOccurred())
 			DeferCleanup(func() error {
-				return env.DeleteNamespace(namespace)
+				return env.CleanupNamespace(
+					namespace,
+					CurrentSpecReport().LeafNodeText,
+					CurrentSpecReport().Failed(),
+					GinkgoWriter,
+				)
 			})
 			clusterName, err = env.GetResourceNameFromYAML(sampleFile)
 			Expect(err).ToNot(HaveOccurred())
@@ -254,7 +259,12 @@ var _ = Describe("Certificates", func() {
 			namespace, err = env.CreateUniqueNamespace(namespacePrefix)
 			Expect(err).ToNot(HaveOccurred())
 			DeferCleanup(func() error {
-				return env.DeleteNamespace(namespace)
+				return env.CleanupNamespace(
+					namespace,
+					CurrentSpecReport().LeafNodeText,
+					CurrentSpecReport().Failed(),
+					GinkgoWriter,
+				)
 			})
 			CreateAndAssertServerCertificatesSecrets(
 				namespace,
@@ -302,7 +312,12 @@ var _ = Describe("Certificates", func() {
 				namespace, err = env.CreateUniqueNamespace(namespacePrefix)
 				Expect(err).ToNot(HaveOccurred())
 				DeferCleanup(func() error {
-					return env.DeleteNamespace(namespace)
+					return env.CleanupNamespace(
+						namespace,
+						CurrentSpecReport().LeafNodeText,
+						CurrentSpecReport().Failed(),
+						GinkgoWriter,
+					)
 				})
 
 				// Create certificates secret for client
@@ -338,7 +353,12 @@ var _ = Describe("Certificates", func() {
 				namespace, err = env.CreateUniqueNamespace(namespacePrefix)
 				Expect(err).ToNot(HaveOccurred())
 				DeferCleanup(func() error {
-					return env.DeleteNamespace(namespace)
+					return env.CleanupNamespace(
+						namespace,
+						CurrentSpecReport().LeafNodeText,
+						CurrentSpecReport().Failed(),
+						GinkgoWriter,
+					)
 				})
 
 				// Create certificates secret for server

--- a/tests/e2e/cluster_microservice_test.go
+++ b/tests/e2e/cluster_microservice_test.go
@@ -77,7 +77,12 @@ var _ = Describe("Imports with Microservice Approach", Label(tests.LabelImportin
 		namespace, err = env.CreateUniqueNamespace(namespacePrefix)
 		Expect(err).ToNot(HaveOccurred())
 		DeferCleanup(func() error {
-			return env.DeleteNamespace(namespace)
+			return env.CleanupNamespace(
+				namespace,
+				CurrentSpecReport().LeafNodeText,
+				CurrentSpecReport().Failed(),
+				GinkgoWriter,
+			)
 		})
 		AssertCreateCluster(namespace, sourceClusterName, sourceSampleFile, env)
 		AssertCreateTestData(namespace, sourceClusterName, tableName, psqlClientPod)
@@ -101,7 +106,12 @@ var _ = Describe("Imports with Microservice Approach", Label(tests.LabelImportin
 		namespace, err = env.CreateUniqueNamespace(namespacePrefix)
 		Expect(err).ToNot(HaveOccurred())
 		DeferCleanup(func() error {
-			return env.DeleteNamespace(namespace)
+			return env.CleanupNamespace(
+				namespace,
+				CurrentSpecReport().LeafNodeText,
+				CurrentSpecReport().Failed(),
+				GinkgoWriter,
+			)
 		})
 		AssertCreateCluster(namespace, sourceClusterName, sourceSampleFile, env)
 		assertCreateTableWithDataOnSourceCluster(namespace, tableName, sourceClusterName)
@@ -120,7 +130,12 @@ var _ = Describe("Imports with Microservice Approach", Label(tests.LabelImportin
 		namespace, err = env.CreateUniqueNamespace(namespacePrefix)
 		Expect(err).ToNot(HaveOccurred())
 		DeferCleanup(func() error {
-			return env.DeleteNamespace(namespace)
+			return env.CleanupNamespace(
+				namespace,
+				CurrentSpecReport().LeafNodeText,
+				CurrentSpecReport().Failed(),
+				GinkgoWriter,
+			)
 		})
 		assertImportRenamesSelectedDatabase(namespace, sourceSampleFile,
 			importedClusterName, tableName, "")
@@ -136,7 +151,12 @@ var _ = Describe("Imports with Microservice Approach", Label(tests.LabelImportin
 		namespace, err = env.CreateUniqueNamespace(namespacePrefix)
 		Expect(err).ToNot(HaveOccurred())
 		DeferCleanup(func() error {
-			return env.DeleteNamespace(namespace)
+			return env.CleanupNamespace(
+				namespace,
+				CurrentSpecReport().LeafNodeText,
+				CurrentSpecReport().Failed(),
+				GinkgoWriter,
+			)
 		})
 		AssertCreateCluster(namespace, sourceClusterName, sourceSampleFile, env)
 
@@ -183,7 +203,12 @@ var _ = Describe("Imports with Microservice Approach", Label(tests.LabelImportin
 			namespace, err = env.CreateUniqueNamespace(namespacePrefix)
 			Expect(err).ToNot(HaveOccurred())
 			DeferCleanup(func() error {
-				return env.DeleteNamespace(namespace)
+				return env.CleanupNamespace(
+					namespace,
+					CurrentSpecReport().LeafNodeText,
+					CurrentSpecReport().Failed(),
+					GinkgoWriter,
+				)
 			})
 			assertImportRenamesSelectedDatabase(namespace, sourceSampleFile, importedClusterName,
 				tableName, targetImage)

--- a/tests/e2e/cluster_monolithic_test.go
+++ b/tests/e2e/cluster_monolithic_test.go
@@ -78,7 +78,12 @@ var _ = Describe("Imports with Monolithic Approach", Label(tests.LabelImportingD
 			namespace, err = env.CreateUniqueNamespace(namespacePrefix)
 			Expect(err).ToNot(HaveOccurred())
 			DeferCleanup(func() error {
-				return env.DeleteNamespace(namespace)
+				return env.CleanupNamespace(
+					namespace,
+					CurrentSpecReport().LeafNodeText,
+					CurrentSpecReport().Failed(),
+					GinkgoWriter,
+				)
 			})
 			AssertCreateCluster(namespace, sourceClusterName, sourceClusterFile, env)
 		})

--- a/tests/e2e/cluster_setup_test.go
+++ b/tests/e2e/cluster_setup_test.go
@@ -56,10 +56,12 @@ var _ = Describe("Cluster setup", Label(tests.LabelSmoke, tests.LabelBasic), fun
 		namespace, err = env.CreateUniqueNamespace(namespacePrefix)
 		Expect(err).ToNot(HaveOccurred())
 		DeferCleanup(func() error {
-			if CurrentSpecReport().Failed() {
-				env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
-			}
-			return env.DeleteNamespace(namespace)
+			return env.CleanupNamespace(
+				namespace,
+				CurrentSpecReport().LeafNodeText,
+				CurrentSpecReport().Failed(),
+				GinkgoWriter,
+			)
 		})
 
 		AssertCreateCluster(namespace, clusterName, sampleFile, env)
@@ -170,10 +172,12 @@ var _ = Describe("Cluster setup", Label(tests.LabelSmoke, tests.LabelBasic), fun
 		namespace, err = env.CreateUniqueNamespace(namespacePrefix)
 		Expect(err).ToNot(HaveOccurred())
 		DeferCleanup(func() error {
-			if CurrentSpecReport().Failed() {
-				env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
-			}
-			return env.DeleteNamespace(namespace)
+			return env.CleanupNamespace(
+				namespace,
+				CurrentSpecReport().LeafNodeText,
+				CurrentSpecReport().Failed(),
+				GinkgoWriter,
+			)
 		})
 
 		By(fmt.Sprintf("having a %v namespace", namespace), func() {

--- a/tests/e2e/config_support_test.go
+++ b/tests/e2e/config_support_test.go
@@ -122,7 +122,12 @@ var _ = Describe("Config support", Serial, Ordered, Label(tests.LabelDisruptive,
 		namespace, err = env.CreateUniqueNamespace(namespacePrefix)
 		Expect(err).ToNot(HaveOccurred())
 		DeferCleanup(func() error {
-			return env.DeleteNamespace(namespace)
+			return env.CleanupNamespace(
+				namespace,
+				CurrentSpecReport().LeafNodeText,
+				CurrentSpecReport().Failed(),
+				GinkgoWriter,
+			)
 		})
 
 		AssertCreateCluster(namespace, clusterName, clusterWithInheritedLabelsFile, env)

--- a/tests/e2e/configuration_update_test.go
+++ b/tests/e2e/configuration_update_test.go
@@ -138,7 +138,12 @@ var _ = Describe("Configuration update", Ordered, Label(tests.LabelClusterMetada
 			namespace, err = env.CreateUniqueNamespace(namespacePrefix)
 			Expect(err).ToNot(HaveOccurred())
 			DeferCleanup(func() error {
-				return env.DeleteNamespace(namespace)
+				return env.CleanupNamespace(
+					namespace,
+					CurrentSpecReport().LeafNodeText,
+					CurrentSpecReport().Failed(),
+					GinkgoWriter,
+				)
 			})
 			AssertCreateCluster(namespace, clusterName, sampleFile, env)
 		})
@@ -483,7 +488,12 @@ var _ = Describe("Configuration update with primaryUpdateMethod", Label(tests.La
 			namespace, err = env.CreateUniqueNamespace(namespacePrefix)
 			Expect(err).ToNot(HaveOccurred())
 			DeferCleanup(func() error {
-				return env.DeleteNamespace(namespace)
+				return env.CleanupNamespace(
+					namespace,
+					CurrentSpecReport().LeafNodeText,
+					CurrentSpecReport().Failed(),
+					GinkgoWriter,
+				)
 			})
 
 			clusterName, err = env.GetResourceNameFromYAML(clusterFileWithPrimaryUpdateRestart)

--- a/tests/e2e/connection_test.go
+++ b/tests/e2e/connection_test.go
@@ -85,7 +85,12 @@ var _ = Describe("Connection via services", Label(tests.LabelServiceConnectivity
 			namespace, err = env.CreateUniqueNamespace(namespacePrefix)
 			Expect(err).ToNot(HaveOccurred())
 			DeferCleanup(func() error {
-				return env.DeleteNamespace(namespace)
+				return env.CleanupNamespace(
+					namespace,
+					CurrentSpecReport().LeafNodeText,
+					CurrentSpecReport().Failed(),
+					GinkgoWriter,
+				)
 			})
 			AssertCreateCluster(namespace, clusterName, sampleFile, env)
 
@@ -137,7 +142,12 @@ var _ = Describe("Connection via services", Label(tests.LabelServiceConnectivity
 			namespace, err = env.CreateUniqueNamespace(namespacePrefix)
 			Expect(err).ToNot(HaveOccurred())
 			DeferCleanup(func() error {
-				return env.DeleteNamespace(namespace)
+				return env.CleanupNamespace(
+					namespace,
+					CurrentSpecReport().LeafNodeText,
+					CurrentSpecReport().Failed(),
+					GinkgoWriter,
+				)
 			})
 			AssertCreateCluster(namespace, clusterName, sampleFile, env)
 			AssertServices(namespace, clusterName, appDBName, appDBUser,

--- a/tests/e2e/declarative_hibernation_test.go
+++ b/tests/e2e/declarative_hibernation_test.go
@@ -53,10 +53,12 @@ var _ = Describe("Cluster declarative hibernation", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		DeferCleanup(func() error {
-			if CurrentSpecReport().Failed() {
-				env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
-			}
-			return env.DeleteNamespace(namespace)
+			return env.CleanupNamespace(
+				namespace,
+				CurrentSpecReport().LeafNodeText,
+				CurrentSpecReport().Failed(),
+				GinkgoWriter,
+			)
 		})
 
 		By("creating a new cluster", func() {

--- a/tests/e2e/disk_space_test.go
+++ b/tests/e2e/disk_space_test.go
@@ -193,10 +193,12 @@ var _ = Describe("Volume space unavailable", Label(tests.LabelStorage), func() {
 			namespace, err = env.CreateUniqueNamespace(namespacePrefix)
 			Expect(err).ToNot(HaveOccurred())
 			DeferCleanup(func() error {
-				if CurrentSpecReport().Failed() {
-					env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
-				}
-				return env.DeleteNamespace(namespace)
+				return env.CleanupNamespace(
+					namespace,
+					CurrentSpecReport().LeafNodeText,
+					CurrentSpecReport().Failed(),
+					GinkgoWriter,
+				)
 			})
 
 			clusterName, err := env.GetResourceNameFromYAML(sampleFile)

--- a/tests/e2e/drain_node_test.go
+++ b/tests/e2e/drain_node_test.go
@@ -112,7 +112,12 @@ var _ = Describe("E2E Drain Node", Serial, Label(tests.LabelDisruptive, tests.La
 			namespace, err = env.CreateUniqueNamespace(namespacePrefix)
 			Expect(err).ToNot(HaveOccurred())
 			DeferCleanup(func() error {
-				return env.DeleteNamespace(namespace)
+				return env.CleanupNamespace(
+					namespace,
+					CurrentSpecReport().LeafNodeText,
+					CurrentSpecReport().Failed(),
+					GinkgoWriter,
+				)
 			})
 			AssertCreateCluster(namespace, clusterName, sampleFile, env)
 
@@ -229,7 +234,12 @@ var _ = Describe("E2E Drain Node", Serial, Label(tests.LabelDisruptive, tests.La
 				namespace, err = env.CreateUniqueNamespace(namespacePrefix)
 				Expect(err).ToNot(HaveOccurred())
 				DeferCleanup(func() error {
-					return env.DeleteNamespace(namespace)
+					return env.CleanupNamespace(
+						namespace,
+						CurrentSpecReport().LeafNodeText,
+						CurrentSpecReport().Failed(),
+						GinkgoWriter,
+					)
 				})
 				AssertCreateCluster(namespace, clusterName, sampleFile, env)
 
@@ -358,7 +368,12 @@ var _ = Describe("E2E Drain Node", Serial, Label(tests.LabelDisruptive, tests.La
 			namespace, err = env.CreateUniqueNamespace(namespacePrefix)
 			Expect(err).ToNot(HaveOccurred())
 			DeferCleanup(func() error {
-				return env.DeleteNamespace(namespace)
+				return env.CleanupNamespace(
+					namespace,
+					CurrentSpecReport().LeafNodeText,
+					CurrentSpecReport().Failed(),
+					GinkgoWriter,
+				)
 			})
 			AssertCreateCluster(namespace, clusterName, sampleFile, env)
 
@@ -444,7 +459,12 @@ var _ = Describe("E2E Drain Node", Serial, Label(tests.LabelDisruptive, tests.La
 			namespace, err = env.CreateUniqueNamespace(namespacePrefix)
 			Expect(err).ToNot(HaveOccurred())
 			DeferCleanup(func() error {
-				return env.DeleteNamespace(namespace)
+				return env.CleanupNamespace(
+					namespace,
+					CurrentSpecReport().LeafNodeText,
+					CurrentSpecReport().Failed(),
+					GinkgoWriter,
+				)
 			})
 		})
 

--- a/tests/e2e/eviction_test.go
+++ b/tests/e2e/eviction_test.go
@@ -126,7 +126,12 @@ var _ = Describe("Pod eviction", Serial, Label(tests.LabelDisruptive), func() {
 			namespace, err = env.CreateUniqueNamespace(namespacePrefix)
 			Expect(err).ToNot(HaveOccurred())
 			DeferCleanup(func() error {
-				return env.DeleteNamespace(namespace)
+				return env.CleanupNamespace(
+					namespace,
+					CurrentSpecReport().LeafNodeText,
+					CurrentSpecReport().Failed(),
+					GinkgoWriter,
+				)
 			})
 			By("creating a cluster", func() {
 				// Create a cluster in a namespace we'll delete after the test
@@ -190,7 +195,12 @@ var _ = Describe("Pod eviction", Serial, Label(tests.LabelDisruptive), func() {
 			namespace, err = env.CreateUniqueNamespace(namespacePrefix)
 			Expect(err).ToNot(HaveOccurred())
 			DeferCleanup(func() error {
-				return env.DeleteNamespace(namespace)
+				return env.CleanupNamespace(
+					namespace,
+					CurrentSpecReport().LeafNodeText,
+					CurrentSpecReport().Failed(),
+					GinkgoWriter,
+				)
 			})
 			By("Creating a cluster with multiple instances", func() {
 				// Create a cluster in a namespace and shared in containers, we'll delete after the test

--- a/tests/e2e/failover_test.go
+++ b/tests/e2e/failover_test.go
@@ -217,10 +217,12 @@ var _ = Describe("Failover", Label(tests.LabelSelfHealing), func() {
 		namespace, err = env.CreateUniqueNamespace(namespacePrefix)
 		Expect(err).ToNot(HaveOccurred())
 		DeferCleanup(func() error {
-			if CurrentSpecReport().Failed() {
-				env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
-			}
-			return env.DeleteNamespace(namespace)
+			return env.CleanupNamespace(
+				namespace,
+				CurrentSpecReport().LeafNodeText,
+				CurrentSpecReport().Failed(),
+				GinkgoWriter,
+			)
 		})
 
 		clusterName, err := env.GetResourceNameFromYAML(sampleFile)
@@ -241,10 +243,12 @@ var _ = Describe("Failover", Label(tests.LabelSelfHealing), func() {
 		namespace, err = env.CreateUniqueNamespace(namespacePrefix)
 		Expect(err).ToNot(HaveOccurred())
 		DeferCleanup(func() error {
-			if CurrentSpecReport().Failed() {
-				env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
-			}
-			return env.DeleteNamespace(namespace)
+			return env.CleanupNamespace(
+				namespace,
+				CurrentSpecReport().LeafNodeText,
+				CurrentSpecReport().Failed(),
+				GinkgoWriter,
+			)
 		})
 
 		clusterName, err := env.GetResourceNameFromYAML(sampleFile)

--- a/tests/e2e/fastfailover_test.go
+++ b/tests/e2e/fastfailover_test.go
@@ -77,7 +77,12 @@ var _ = Describe("Fast failover", Serial, Label(tests.LabelPerformance, tests.La
 			namespace, err = env.CreateUniqueNamespace(namespacePrefix)
 			Expect(err).ToNot(HaveOccurred())
 			DeferCleanup(func() error {
-				return env.DeleteNamespace(namespace)
+				return env.CleanupNamespace(
+					namespace,
+					CurrentSpecReport().LeafNodeText,
+					CurrentSpecReport().Failed(),
+					GinkgoWriter,
+				)
 			})
 			AssertFastFailOver(namespace, sampleFileWithoutReplicationSlots, clusterName,
 				webTestFile, webTestJob, maxReattachTime, maxFailoverTime)
@@ -98,7 +103,12 @@ var _ = Describe("Fast failover", Serial, Label(tests.LabelPerformance, tests.La
 			namespace, err = env.CreateUniqueNamespace(namespacePrefix)
 			Expect(err).ToNot(HaveOccurred())
 			DeferCleanup(func() error {
-				return env.DeleteNamespace(namespace)
+				return env.CleanupNamespace(
+					namespace,
+					CurrentSpecReport().LeafNodeText,
+					CurrentSpecReport().Failed(),
+					GinkgoWriter,
+				)
 			})
 			AssertFastFailOver(namespace, sampleFileWithReplicationSlots,
 				clusterName, webTestFile, webTestJob, maxReattachTime, maxFailoverTime)
@@ -115,7 +125,12 @@ var _ = Describe("Fast failover", Serial, Label(tests.LabelPerformance, tests.La
 			namespace, err = env.CreateUniqueNamespace(namespacePrefix)
 			Expect(err).ToNot(HaveOccurred())
 			DeferCleanup(func() error {
-				return env.DeleteNamespace(namespace)
+				return env.CleanupNamespace(
+					namespace,
+					CurrentSpecReport().LeafNodeText,
+					CurrentSpecReport().Failed(),
+					GinkgoWriter,
+				)
 			})
 			AssertFastFailOver(
 				namespace, sampleFileSyncReplicas, clusterName, webTestSyncReplicas, webTestJob, maxReattachTime, maxFailoverTime)

--- a/tests/e2e/fastswitchover_test.go
+++ b/tests/e2e/fastswitchover_test.go
@@ -66,10 +66,12 @@ var _ = Describe("Fast switchover", Serial, Label(tests.LabelPerformance, tests.
 			namespace, err = env.CreateUniqueNamespace(namespacePrefix)
 			Expect(err).ToNot(HaveOccurred())
 			DeferCleanup(func() error {
-				if CurrentSpecReport().Failed() {
-					env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
-				}
-				return env.DeleteNamespace(namespace)
+				return env.CleanupNamespace(
+					namespace,
+					CurrentSpecReport().LeafNodeText,
+					CurrentSpecReport().Failed(),
+					GinkgoWriter,
+				)
 			})
 			assertFastSwitchover(namespace, sampleFileWithoutReplicationSlots, clusterName, webTestFile, webTestJob)
 		})
@@ -82,10 +84,12 @@ var _ = Describe("Fast switchover", Serial, Label(tests.LabelPerformance, tests.
 			namespace, err = env.CreateUniqueNamespace(namespacePrefix)
 			Expect(err).ToNot(HaveOccurred())
 			DeferCleanup(func() error {
-				if CurrentSpecReport().Failed() {
-					env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
-				}
-				return env.DeleteNamespace(namespace)
+				return env.CleanupNamespace(
+					namespace,
+					CurrentSpecReport().LeafNodeText,
+					CurrentSpecReport().Failed(),
+					GinkgoWriter,
+				)
 			})
 			assertFastSwitchover(namespace, sampleFileWithReplicationSlots, clusterName, webTestFile, webTestJob)
 			AssertClusterHAReplicationSlots(namespace, clusterName)

--- a/tests/e2e/fencing_test.go
+++ b/tests/e2e/fencing_test.go
@@ -256,7 +256,12 @@ var _ = Describe("Fencing", Label(tests.LabelPlugin), func() {
 			namespace, err = env.CreateUniqueNamespace(namespacePrefix)
 			Expect(err).ToNot(HaveOccurred())
 			DeferCleanup(func() error {
-				return env.DeleteNamespace(namespace)
+				return env.CleanupNamespace(
+					namespace,
+					CurrentSpecReport().LeafNodeText,
+					CurrentSpecReport().Failed(),
+					GinkgoWriter,
+				)
 			})
 			AssertCreateCluster(namespace, clusterName, sampleFile, env)
 		})
@@ -275,7 +280,12 @@ var _ = Describe("Fencing", Label(tests.LabelPlugin), func() {
 			namespace, err = env.CreateUniqueNamespace(namespacePrefix)
 			Expect(err).ToNot(HaveOccurred())
 			DeferCleanup(func() error {
-				return env.DeleteNamespace(namespace)
+				return env.CleanupNamespace(
+					namespace,
+					CurrentSpecReport().LeafNodeText,
+					CurrentSpecReport().Failed(),
+					GinkgoWriter,
+				)
 			})
 			AssertCreateCluster(namespace, clusterName, sampleFile, env)
 		})

--- a/tests/e2e/hibernation_test.go
+++ b/tests/e2e/hibernation_test.go
@@ -301,10 +301,12 @@ var _ = Describe("Cluster Hibernation with plugin", Label(tests.LabelPlugin), fu
 				namespace, err = env.CreateUniqueNamespace(namespacePrefix)
 				Expect(err).ToNot(HaveOccurred())
 				DeferCleanup(func() error {
-					if CurrentSpecReport().Failed() {
-						env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
-					}
-					return env.DeleteNamespace(namespace)
+					return env.CleanupNamespace(
+						namespace,
+						CurrentSpecReport().LeafNodeText,
+						CurrentSpecReport().Failed(),
+						GinkgoWriter,
+					)
 				})
 				AssertCreateCluster(namespace, clusterName, sampleFileClusterWithPGWalVolume, env)
 				assertHibernation(namespace, clusterName, tableName)
@@ -321,10 +323,12 @@ var _ = Describe("Cluster Hibernation with plugin", Label(tests.LabelPlugin), fu
 				namespace, err = env.CreateUniqueNamespace(namespacePrefix)
 				Expect(err).ToNot(HaveOccurred())
 				DeferCleanup(func() error {
-					if CurrentSpecReport().Failed() {
-						env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
-					}
-					return env.DeleteNamespace(namespace)
+					return env.CleanupNamespace(
+						namespace,
+						CurrentSpecReport().LeafNodeText,
+						CurrentSpecReport().Failed(),
+						GinkgoWriter,
+					)
 				})
 				AssertCreateCluster(namespace, clusterName, sampleFileClusterWithOutPGWalVolume, env)
 				// Write a table and some data on the "app" database
@@ -387,10 +391,12 @@ var _ = Describe("Cluster Hibernation with plugin", Label(tests.LabelPlugin), fu
 				namespace, err = env.CreateUniqueNamespace(namespacePrefix)
 				Expect(err).ToNot(HaveOccurred())
 				DeferCleanup(func() error {
-					if CurrentSpecReport().Failed() {
-						env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
-					}
-					return env.DeleteNamespace(namespace)
+					return env.CleanupNamespace(
+						namespace,
+						CurrentSpecReport().LeafNodeText,
+						CurrentSpecReport().Failed(),
+						GinkgoWriter,
+					)
 				})
 				AssertCreateCluster(namespace, clusterName, sampleFileClusterWithPGWalVolume, env)
 				AssertSwitchover(namespace, clusterName, env)

--- a/tests/e2e/initdb_test.go
+++ b/tests/e2e/initdb_test.go
@@ -91,10 +91,12 @@ var _ = Describe("InitDB settings", Label(tests.LabelSmoke, tests.LabelBasic), f
 			namespace, err = env.CreateUniqueNamespace(namespacePrefix)
 			Expect(err).ToNot(HaveOccurred())
 			DeferCleanup(func() error {
-				if CurrentSpecReport().Failed() {
-					env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
-				}
-				return env.DeleteNamespace(namespace)
+				return env.CleanupNamespace(
+					namespace,
+					CurrentSpecReport().LeafNodeText,
+					CurrentSpecReport().Failed(),
+					GinkgoWriter,
+				)
 			})
 
 			CreateResourceFromFile(namespace, postInitSQLSecretRef)
@@ -163,10 +165,12 @@ var _ = Describe("InitDB settings", Label(tests.LabelSmoke, tests.LabelBasic), f
 			namespace, err = env.CreateUniqueNamespace(namespacePrefix)
 			Expect(err).ToNot(HaveOccurred())
 			DeferCleanup(func() error {
-				if CurrentSpecReport().Failed() {
-					env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
-				}
-				return env.DeleteNamespace(namespace)
+				return env.CleanupNamespace(
+					namespace,
+					CurrentSpecReport().LeafNodeText,
+					CurrentSpecReport().Failed(),
+					GinkgoWriter,
+				)
 			})
 			AssertCreateCluster(namespace, clusterName, postInitSQLCluster, env)
 

--- a/tests/e2e/logs_test.go
+++ b/tests/e2e/logs_test.go
@@ -59,7 +59,12 @@ var _ = Describe("JSON log output", Label(tests.LabelObservability), func() {
 		namespace, namespaceErr = env.CreateUniqueNamespace(namespacePrefix)
 		Expect(namespaceErr).ToNot(HaveOccurred())
 		DeferCleanup(func() error {
-			return env.DeleteNamespace(namespace)
+			return env.CleanupNamespace(
+				namespace,
+				CurrentSpecReport().LeafNodeText,
+				CurrentSpecReport().Failed(),
+				GinkgoWriter,
+			)
 		})
 		AssertCreateCluster(namespace, clusterName, sampleFile, env)
 

--- a/tests/e2e/managed_roles_test.go
+++ b/tests/e2e/managed_roles_test.go
@@ -78,7 +78,12 @@ var _ = Describe("Managed roles tests", Label(tests.LabelSmoke, tests.LabelBasic
 			namespace, err = env.CreateUniqueNamespace(namespacePrefix)
 			Expect(err).ToNot(HaveOccurred())
 			DeferCleanup(func() error {
-				return env.DeleteNamespace(namespace)
+				return env.CleanupNamespace(
+					namespace,
+					CurrentSpecReport().LeafNodeText,
+					CurrentSpecReport().Failed(),
+					GinkgoWriter,
+				)
 			})
 
 			clusterName, err = env.GetResourceNameFromYAML(clusterManifest)

--- a/tests/e2e/managed_services_test.go
+++ b/tests/e2e/managed_services_test.go
@@ -60,9 +60,13 @@ var _ = Describe("Managed services tests", Label(tests.LabelSmoke, tests.LabelBa
 		const serviceName = "test-rw"
 		namespace, err := env.CreateUniqueNamespace(namespacePrefix)
 		Expect(err).ToNot(HaveOccurred())
-
 		DeferCleanup(func() error {
-			return env.DeleteNamespace(namespace)
+			return env.CleanupNamespace(
+				namespace,
+				CurrentSpecReport().LeafNodeText,
+				CurrentSpecReport().Failed(),
+				GinkgoWriter,
+			)
 		})
 
 		clusterName, err := env.GetResourceNameFromYAML(clusterManifest)
@@ -107,9 +111,13 @@ var _ = Describe("Managed services tests", Label(tests.LabelSmoke, tests.LabelBa
 
 		namespace, err := env.CreateUniqueNamespace(namespacePrefix)
 		Expect(err).ToNot(HaveOccurred())
-
 		DeferCleanup(func() error {
-			return env.DeleteNamespace(namespace)
+			return env.CleanupNamespace(
+				namespace,
+				CurrentSpecReport().LeafNodeText,
+				CurrentSpecReport().Failed(),
+				GinkgoWriter,
+			)
 		})
 
 		clusterName, err := env.GetResourceNameFromYAML(clusterManifest)
@@ -170,9 +178,13 @@ var _ = Describe("Managed services tests", Label(tests.LabelSmoke, tests.LabelBa
 		const serviceName = "test-rw"
 		namespace, err := env.CreateUniqueNamespace(namespacePrefix)
 		Expect(err).ToNot(HaveOccurred())
-
 		DeferCleanup(func() error {
-			return env.DeleteNamespace(namespace)
+			return env.CleanupNamespace(
+				namespace,
+				CurrentSpecReport().LeafNodeText,
+				CurrentSpecReport().Failed(),
+				GinkgoWriter,
+			)
 		})
 
 		clusterName, err := env.GetResourceNameFromYAML(clusterManifest)

--- a/tests/e2e/metrics_test.go
+++ b/tests/e2e/metrics_test.go
@@ -103,7 +103,12 @@ var _ = Describe("Metrics", Label(tests.LabelObservability), func() {
 		namespace, err = env.CreateUniqueNamespace(namespacePrefix)
 		Expect(err).ToNot(HaveOccurred())
 		DeferCleanup(func() error {
-			return env.DeleteNamespace(namespace)
+			return env.CleanupNamespace(
+				namespace,
+				CurrentSpecReport().LeafNodeText,
+				CurrentSpecReport().Failed(),
+				GinkgoWriter,
+			)
 		})
 
 		AssertCustomMetricsResourcesExist(namespace, fixturesDir+"/metrics/custom-queries.yaml", 2, 1)
@@ -141,7 +146,12 @@ var _ = Describe("Metrics", Label(tests.LabelObservability), func() {
 		namespace, err = env.CreateUniqueNamespace(namespacePrefix)
 		Expect(err).ToNot(HaveOccurred())
 		DeferCleanup(func() error {
-			return env.DeleteNamespace(namespace)
+			return env.CleanupNamespace(
+				namespace,
+				CurrentSpecReport().LeafNodeText,
+				CurrentSpecReport().Failed(),
+				GinkgoWriter,
+			)
 		})
 		AssertCustomMetricsResourcesExist(namespace, customQueriesSampleFile, 1, 1)
 
@@ -165,7 +175,12 @@ var _ = Describe("Metrics", Label(tests.LabelObservability), func() {
 		namespace, err = env.CreateUniqueNamespace(namespacePrefix)
 		Expect(err).ToNot(HaveOccurred())
 		DeferCleanup(func() error {
-			return env.DeleteNamespace(namespace)
+			return env.CleanupNamespace(
+				namespace,
+				CurrentSpecReport().LeafNodeText,
+				CurrentSpecReport().Failed(),
+				GinkgoWriter,
+			)
 		})
 
 		AssertCreateCluster(namespace, metricsClusterName, clusterWithDefaultMetricsFile, env)
@@ -193,7 +208,12 @@ var _ = Describe("Metrics", Label(tests.LabelObservability), func() {
 		namespace, err = env.CreateUniqueNamespace(namespacePrefix)
 		Expect(err).ToNot(HaveOccurred())
 		DeferCleanup(func() error {
-			return env.DeleteNamespace(namespace)
+			return env.CleanupNamespace(
+				namespace,
+				CurrentSpecReport().LeafNodeText,
+				CurrentSpecReport().Failed(),
+				GinkgoWriter,
+			)
 		})
 
 		AssertCustomMetricsResourcesExist(namespace, fixturesDir+"/metrics/custom-queries-with-predicate-query.yaml", 1, 0)
@@ -240,7 +260,12 @@ var _ = Describe("Metrics", Label(tests.LabelObservability), func() {
 		namespace, err = env.CreateUniqueNamespace(namespacePrefix)
 		Expect(err).ToNot(HaveOccurred())
 		DeferCleanup(func() error {
-			return env.DeleteNamespace(namespace)
+			return env.CleanupNamespace(
+				namespace,
+				CurrentSpecReport().LeafNodeText,
+				CurrentSpecReport().Failed(),
+				GinkgoWriter,
+			)
 		})
 
 		// Create the cluster
@@ -272,7 +297,12 @@ var _ = Describe("Metrics", Label(tests.LabelObservability), func() {
 		namespace, err = env.CreateUniqueNamespace(namespacePrefix)
 		Expect(err).ToNot(HaveOccurred())
 		DeferCleanup(func() error {
-			return env.DeleteNamespace(namespace)
+			return env.CleanupNamespace(
+				namespace,
+				CurrentSpecReport().LeafNodeText,
+				CurrentSpecReport().Failed(),
+				GinkgoWriter,
+			)
 		})
 
 		// Creating and verifying custom queries configmap

--- a/tests/e2e/monitoring_test.go
+++ b/tests/e2e/monitoring_test.go
@@ -56,10 +56,12 @@ var _ = Describe("PodMonitor support", Serial, Label(tests.LabelObservability), 
 		namespace, err = env.CreateUniqueNamespace(namespacePrefix)
 		Expect(err).ToNot(HaveOccurred())
 		DeferCleanup(func() error {
-			if CurrentSpecReport().Failed() {
-				env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
-			}
-			return env.DeleteNamespace(namespace)
+			return env.CleanupNamespace(
+				namespace,
+				CurrentSpecReport().LeafNodeText,
+				CurrentSpecReport().Failed(),
+				GinkgoWriter,
+			)
 		})
 
 		AssertCreateCluster(namespace, clusterDefaultName, clusterDefaultMonitoringFile, env)

--- a/tests/e2e/nodeselector_test.go
+++ b/tests/e2e/nodeselector_test.go
@@ -55,7 +55,12 @@ var _ = Describe("nodeSelector", Label(tests.LabelPodScheduling), func() {
 				namespace, err = env.CreateUniqueNamespace(namespacePrefix)
 				Expect(err).ToNot(HaveOccurred())
 				DeferCleanup(func() error {
-					return env.DeleteNamespace(namespace)
+					return env.CleanupNamespace(
+						namespace,
+						CurrentSpecReport().LeafNodeText,
+						CurrentSpecReport().Failed(),
+						GinkgoWriter,
+					)
 				})
 
 				// Creating a namespace should be quick
@@ -122,7 +127,12 @@ var _ = Describe("nodeSelector", Label(tests.LabelPodScheduling), func() {
 			namespace, err = env.CreateUniqueNamespace(namespacePrefix)
 			Expect(err).ToNot(HaveOccurred())
 			DeferCleanup(func() error {
-				return env.DeleteNamespace(namespace)
+				return env.CleanupNamespace(
+					namespace,
+					CurrentSpecReport().LeafNodeText,
+					CurrentSpecReport().Failed(),
+					GinkgoWriter,
+				)
 			})
 
 			// We label one node with the label we have defined in the cluster

--- a/tests/e2e/operator_ha_test.go
+++ b/tests/e2e/operator_ha_test.go
@@ -71,10 +71,12 @@ var _ = Describe("Operator High Availability", Serial,
 			namespace, err = env.CreateUniqueNamespace(namespacePrefix)
 			Expect(err).ToNot(HaveOccurred())
 			DeferCleanup(func() error {
-				if CurrentSpecReport().Failed() {
-					env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
-				}
-				return env.DeleteNamespace(namespace)
+				return env.CleanupNamespace(
+					namespace,
+					CurrentSpecReport().LeafNodeText,
+					CurrentSpecReport().Failed(),
+					GinkgoWriter,
+				)
 			})
 
 			// Create Cluster

--- a/tests/e2e/operator_unavailable_test.go
+++ b/tests/e2e/operator_unavailable_test.go
@@ -61,7 +61,12 @@ var _ = Describe("Operator unavailable", Serial, Label(tests.LabelDisruptive, te
 			namespace, err = env.CreateUniqueNamespace(namespacePrefix)
 			Expect(err).ToNot(HaveOccurred())
 			DeferCleanup(func() error {
-				return env.DeleteNamespace(namespace)
+				return env.CleanupNamespace(
+					namespace,
+					CurrentSpecReport().LeafNodeText,
+					CurrentSpecReport().Failed(),
+					GinkgoWriter,
+				)
 			})
 			AssertCreateCluster(namespace, clusterName, sampleFile, env)
 
@@ -152,7 +157,12 @@ var _ = Describe("Operator unavailable", Serial, Label(tests.LabelDisruptive, te
 			namespace, err = env.CreateUniqueNamespace(namespacePrefix)
 			Expect(err).ToNot(HaveOccurred())
 			DeferCleanup(func() error {
-				return env.DeleteNamespace(namespace)
+				return env.CleanupNamespace(
+					namespace,
+					CurrentSpecReport().LeafNodeText,
+					CurrentSpecReport().Failed(),
+					GinkgoWriter,
+				)
 			})
 			AssertCreateCluster(namespace, clusterName, sampleFile, env)
 

--- a/tests/e2e/pg_basebackup_test.go
+++ b/tests/e2e/pg_basebackup_test.go
@@ -54,7 +54,12 @@ var _ = Describe("Bootstrap with pg_basebackup", Label(tests.LabelRecovery), fun
 			namespace, err = env.CreateUniqueNamespace(namespacePrefix)
 			Expect(err).ToNot(HaveOccurred())
 			DeferCleanup(func() error {
-				return env.DeleteNamespace(namespace)
+				return env.CleanupNamespace(
+					namespace,
+					CurrentSpecReport().LeafNodeText,
+					CurrentSpecReport().Failed(),
+					GinkgoWriter,
+				)
 			})
 			// Create the source Cluster
 			srcClusterName, err = env.GetResourceNameFromYAML(srcCluster)

--- a/tests/e2e/pg_data_corruption_test.go
+++ b/tests/e2e/pg_data_corruption_test.go
@@ -47,7 +47,12 @@ var _ = Describe("PGDATA Corruption", Label(tests.LabelRecovery), Ordered, func(
 		namespace, err = env.CreateUniqueNamespace(namespacePrefix)
 		Expect(err).ToNot(HaveOccurred())
 		DeferCleanup(func() error {
-			return env.DeleteNamespace(namespace)
+			return env.CleanupNamespace(
+				namespace,
+				CurrentSpecReport().LeafNodeText,
+				CurrentSpecReport().Failed(),
+				GinkgoWriter,
+			)
 		})
 	})
 

--- a/tests/e2e/pg_wal_volume_test.go
+++ b/tests/e2e/pg_wal_volume_test.go
@@ -121,10 +121,12 @@ var _ = Describe("Separate pg_wal volume", Label(tests.LabelStorage), func() {
 		namespace, err = env.CreateUniqueNamespace(namespacePrefix)
 		Expect(err).ToNot(HaveOccurred())
 		DeferCleanup(func() error {
-			if CurrentSpecReport().Failed() {
-				env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
-			}
-			return env.DeleteNamespace(namespace)
+			return env.CleanupNamespace(
+				namespace,
+				CurrentSpecReport().LeafNodeText,
+				CurrentSpecReport().Failed(),
+				GinkgoWriter,
+			)
 		})
 		AssertCreateCluster(namespace, clusterName, sampleFileWithPgWal, env)
 		verifyPgWal(namespace)
@@ -137,10 +139,12 @@ var _ = Describe("Separate pg_wal volume", Label(tests.LabelStorage), func() {
 		namespace, err = env.CreateUniqueNamespace(namespacePrefix)
 		Expect(err).ToNot(HaveOccurred())
 		DeferCleanup(func() error {
-			if CurrentSpecReport().Failed() {
-				env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
-			}
-			return env.DeleteNamespace(namespace)
+			return env.CleanupNamespace(
+				namespace,
+				CurrentSpecReport().LeafNodeText,
+				CurrentSpecReport().Failed(),
+				GinkgoWriter,
+			)
 		})
 		AssertCreateCluster(namespace, clusterName, sampleFileWithoutPgWal, env)
 		By(fmt.Sprintf("adding pg_wal volume in existing cluster: %v", clusterName), func() {

--- a/tests/e2e/pgbouncer_metrics_test.go
+++ b/tests/e2e/pgbouncer_metrics_test.go
@@ -52,10 +52,12 @@ var _ = Describe("PGBouncer Metrics", Label(tests.LabelObservability), func() {
 			namespace, err = env.CreateUniqueNamespace(namespacePrefix)
 			Expect(err).ToNot(HaveOccurred())
 			DeferCleanup(func() error {
-				if CurrentSpecReport().Failed() {
-					env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
-				}
-				return env.DeleteNamespace(namespace)
+				return env.CleanupNamespace(
+					namespace,
+					CurrentSpecReport().LeafNodeText,
+					CurrentSpecReport().Failed(),
+					GinkgoWriter,
+				)
 			})
 
 			clusterName, err = env.GetResourceNameFromYAML(cnpgCluster)

--- a/tests/e2e/pgbouncer_test.go
+++ b/tests/e2e/pgbouncer_test.go
@@ -52,7 +52,12 @@ var _ = Describe("PGBouncer Connections", Label(tests.LabelServiceConnectivity),
 			namespace, err = env.CreateUniqueNamespace("pgbouncer-auth-no-user-certs")
 			Expect(err).ToNot(HaveOccurred())
 			DeferCleanup(func() error {
-				return env.DeleteNamespace(namespace)
+				return env.CleanupNamespace(
+					namespace,
+					CurrentSpecReport().LeafNodeText,
+					CurrentSpecReport().Failed(),
+					GinkgoWriter,
+				)
 			})
 			clusterName, err = env.GetResourceNameFromYAML(sampleFile)
 			Expect(err).ToNot(HaveOccurred())
@@ -151,7 +156,12 @@ var _ = Describe("PGBouncer Connections", Label(tests.LabelServiceConnectivity),
 			namespace, err = env.CreateUniqueNamespace("pgbouncer-separate-certificates")
 			Expect(err).ToNot(HaveOccurred())
 			DeferCleanup(func() error {
-				return env.DeleteNamespace(namespace)
+				return env.CleanupNamespace(
+					namespace,
+					CurrentSpecReport().LeafNodeText,
+					CurrentSpecReport().Failed(),
+					GinkgoWriter,
+				)
 			})
 			clusterName, err = env.GetResourceNameFromYAML(sampleFileWithCertificate)
 			Expect(err).ToNot(HaveOccurred())

--- a/tests/e2e/pgbouncer_types_test.go
+++ b/tests/e2e/pgbouncer_types_test.go
@@ -62,7 +62,12 @@ var _ = Describe("PGBouncer Types", Ordered, Label(tests.LabelServiceConnectivit
 		namespace, err = env.CreateUniqueNamespace("pgbouncer-types")
 		Expect(err).ToNot(HaveOccurred())
 		DeferCleanup(func() error {
-			return env.DeleteNamespace(namespace)
+			return env.CleanupNamespace(
+				namespace,
+				CurrentSpecReport().LeafNodeText,
+				CurrentSpecReport().Failed(),
+				GinkgoWriter,
+			)
 		})
 		clusterName, err = env.GetResourceNameFromYAML(sampleFile)
 		Expect(err).ToNot(HaveOccurred())

--- a/tests/e2e/pvc_deletion_test.go
+++ b/tests/e2e/pvc_deletion_test.go
@@ -51,10 +51,12 @@ var _ = Describe("PVC Deletion", Label(tests.LabelSelfHealing), func() {
 		namespace, err = env.CreateUniqueNamespace(namespacePrefix)
 		Expect(err).ToNot(HaveOccurred())
 		DeferCleanup(func() error {
-			if CurrentSpecReport().Failed() {
-				env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
-			}
-			return env.DeleteNamespace(namespace)
+			return env.CleanupNamespace(
+				namespace,
+				CurrentSpecReport().LeafNodeText,
+				CurrentSpecReport().Failed(),
+				GinkgoWriter,
+			)
 		})
 		AssertCreateCluster(namespace, clusterName, sampleFile, env)
 

--- a/tests/e2e/replica_mode_cluster_test.go
+++ b/tests/e2e/replica_mode_cluster_test.go
@@ -77,10 +77,12 @@ var _ = Describe("Replica Mode", Label(tests.LabelReplication), func() {
 			replicaNamespace, err := env.CreateUniqueNamespace(replicaNamespacePrefix)
 			Expect(err).ToNot(HaveOccurred())
 			DeferCleanup(func() error {
-				if CurrentSpecReport().Failed() {
-					env.DumpNamespaceObjects(replicaNamespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
-				}
-				return env.DeleteNamespace(replicaNamespace)
+				return env.CleanupNamespace(
+					replicaNamespace,
+					CurrentSpecReport().LeafNodeText,
+					CurrentSpecReport().Failed(),
+					GinkgoWriter,
+				)
 			})
 			AssertCreateCluster(replicaNamespace, srcClusterName, srcClusterSample, env)
 
@@ -116,10 +118,12 @@ var _ = Describe("Replica Mode", Label(tests.LabelReplication), func() {
 			replicaNamespace, err := env.CreateUniqueNamespace(replicaNamespacePrefix)
 			Expect(err).ToNot(HaveOccurred())
 			DeferCleanup(func() error {
-				if CurrentSpecReport().Failed() {
-					env.DumpNamespaceObjects(replicaNamespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
-				}
-				return env.DeleteNamespace(replicaNamespace)
+				return env.CleanupNamespace(
+					replicaNamespace,
+					CurrentSpecReport().LeafNodeText,
+					CurrentSpecReport().Failed(),
+					GinkgoWriter,
+				)
 			})
 			AssertCreateCluster(replicaNamespace, srcClusterName, srcClusterSample, env)
 
@@ -165,10 +169,12 @@ var _ = Describe("Replica Mode", Label(tests.LabelReplication), func() {
 			namespace, err := env.CreateUniqueNamespace("replica-promotion-demotion")
 			Expect(err).ToNot(HaveOccurred())
 			DeferCleanup(func() error {
-				if CurrentSpecReport().Failed() {
-					env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
-				}
-				return env.DeleteNamespace(namespace)
+				return env.CleanupNamespace(
+					namespace,
+					CurrentSpecReport().LeafNodeText,
+					CurrentSpecReport().Failed(),
+					GinkgoWriter,
+				)
 			})
 			AssertCreateCluster(namespace, clusterOneName, clusterOneFile, env)
 
@@ -255,10 +261,12 @@ var _ = Describe("Replica Mode", Label(tests.LabelReplication), func() {
 			replicaNamespace, err := env.CreateUniqueNamespace(replicaNamespacePrefix)
 			Expect(err).ToNot(HaveOccurred())
 			DeferCleanup(func() error {
-				if CurrentSpecReport().Failed() {
-					env.DumpNamespaceObjects(replicaNamespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
-				}
-				return env.DeleteNamespace(replicaNamespace)
+				return env.CleanupNamespace(
+					replicaNamespace,
+					CurrentSpecReport().LeafNodeText,
+					CurrentSpecReport().Failed(),
+					GinkgoWriter,
+				)
 			})
 			By("creating the credentials for minio", func() {
 				AssertStorageCredentialsAreCreated(replicaNamespace, "backup-storage-creds", "minio", "minio123")
@@ -318,7 +326,14 @@ var _ = Describe("Replica Mode", Label(tests.LabelReplication), func() {
 			var err error
 			namespace, err = env.CreateUniqueNamespace(namespacePrefix)
 			Expect(err).ToNot(HaveOccurred())
-			DeferCleanup(func() error { return env.DeleteNamespace(namespace) })
+			DeferCleanup(func() error {
+				return env.CleanupNamespace(
+					namespace,
+					CurrentSpecReport().LeafNodeText,
+					CurrentSpecReport().Failed(),
+					GinkgoWriter,
+				)
+			})
 
 			By("creating the credentials for minio", func() {
 				AssertStorageCredentialsAreCreated(namespace, "backup-storage-creds", "minio", "minio123")
@@ -534,10 +549,15 @@ var _ = Describe("Replica switchover", Label(tests.LabelReplication), Ordered, f
 			namespace, err = env.CreateUniqueNamespace(namespacePrefix)
 			Expect(err).ToNot(HaveOccurred())
 			DeferCleanup(func() error {
-				err := env.DeleteNamespaceAndWait(namespace, 120)
-				if err != nil {
-					return err
-				}
+				return env.CleanupNamespaceAndWait(
+					namespace,
+					CurrentSpecReport().LeafNodeText,
+					CurrentSpecReport().Failed(),
+					120,
+					GinkgoWriter,
+				)
+			})
+			DeferCleanup(func() error {
 				// Since we use multiple times the same cluster names for the same minio instance, we need to clean it up
 				// between tests
 				_, err = testUtils.CleanFilesOnMinio(minioEnv, path.Join("minio", "cluster-backups", clusterAName))

--- a/tests/e2e/replication_slot_test.go
+++ b/tests/e2e/replication_slot_test.go
@@ -50,10 +50,12 @@ var _ = Describe("Replication Slot", Label(tests.LabelReplication), func() {
 		namespace, err = env.CreateUniqueNamespace(namespacePrefix)
 		Expect(err).ToNot(HaveOccurred())
 		DeferCleanup(func() error {
-			if CurrentSpecReport().Failed() {
-				env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
-			}
-			return env.DeleteNamespace(namespace)
+			return env.CleanupNamespace(
+				namespace,
+				CurrentSpecReport().LeafNodeText,
+				CurrentSpecReport().Failed(),
+				GinkgoWriter,
+			)
 		})
 		AssertCreateCluster(namespace, clusterName, sampleFile, env)
 

--- a/tests/e2e/rolling_update_test.go
+++ b/tests/e2e/rolling_update_test.go
@@ -479,10 +479,12 @@ var _ = Describe("Rolling updates", Label(tests.LabelPostgresConfiguration), fun
 				namespace, err := env.CreateUniqueNamespace(namespacePrefix)
 				Expect(err).ToNot(HaveOccurred())
 				DeferCleanup(func() error {
-					if CurrentSpecReport().Failed() {
-						env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
-					}
-					return env.DeleteNamespace(namespace)
+					return env.CleanupNamespace(
+						namespace,
+						CurrentSpecReport().LeafNodeText,
+						CurrentSpecReport().Failed(),
+						GinkgoWriter,
+					)
 				})
 				clusterName, err := env.GetResourceNameFromYAML(sampleFile)
 				Expect(err).ToNot(HaveOccurred())
@@ -504,10 +506,12 @@ var _ = Describe("Rolling updates", Label(tests.LabelPostgresConfiguration), fun
 				namespace, err := env.CreateUniqueNamespace(namespacePrefix)
 				Expect(err).ToNot(HaveOccurred())
 				DeferCleanup(func() error {
-					if CurrentSpecReport().Failed() {
-						env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
-					}
-					return env.DeleteNamespace(namespace)
+					return env.CleanupNamespace(
+						namespace,
+						CurrentSpecReport().LeafNodeText,
+						CurrentSpecReport().Failed(),
+						GinkgoWriter,
+					)
 				})
 				clusterName, err := env.GetResourceNameFromYAML(sampleFile)
 				Expect(err).ToNot(HaveOccurred())
@@ -524,10 +528,12 @@ var _ = Describe("Rolling updates", Label(tests.LabelPostgresConfiguration), fun
 				namespace, err := env.CreateUniqueNamespace(namespacePrefix)
 				Expect(err).ToNot(HaveOccurred())
 				DeferCleanup(func() error {
-					if CurrentSpecReport().Failed() {
-						env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
-					}
-					return env.DeleteNamespace(namespace)
+					return env.CleanupNamespace(
+						namespace,
+						CurrentSpecReport().LeafNodeText,
+						CurrentSpecReport().Failed(),
+						GinkgoWriter,
+					)
 				})
 				clusterName, err := env.GetResourceNameFromYAML(sampleFile)
 				Expect(err).ToNot(HaveOccurred())
@@ -575,10 +581,12 @@ var _ = Describe("Rolling updates", Label(tests.LabelPostgresConfiguration), fun
 					namespace, err := env.CreateUniqueNamespace(namespacePrefix)
 					Expect(err).ToNot(HaveOccurred())
 					DeferCleanup(func() error {
-						if CurrentSpecReport().Failed() {
-							env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
-						}
-						return env.DeleteNamespace(namespace)
+						return env.CleanupNamespace(
+							namespace,
+							CurrentSpecReport().LeafNodeText,
+							CurrentSpecReport().Failed(),
+							GinkgoWriter,
+						)
 					})
 
 					// Create a new image catalog and a new cluster
@@ -601,10 +609,12 @@ var _ = Describe("Rolling updates", Label(tests.LabelPostgresConfiguration), fun
 					namespace, err := env.CreateUniqueNamespace(namespacePrefix)
 					Expect(err).ToNot(HaveOccurred())
 					DeferCleanup(func() error {
-						if CurrentSpecReport().Failed() {
-							env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
-						}
-						return env.DeleteNamespace(namespace)
+						return env.CleanupNamespace(
+							namespace,
+							CurrentSpecReport().LeafNodeText,
+							CurrentSpecReport().Failed(),
+							GinkgoWriter,
+						)
 					})
 
 					catalog := newImageCatalog(namespace, clusterName, major, preRollingImg)
@@ -643,10 +653,12 @@ var _ = Describe("Rolling updates", Label(tests.LabelPostgresConfiguration), fun
 					namespace, err := env.CreateUniqueNamespace(namespacePrefix)
 					Expect(err).ToNot(HaveOccurred())
 					DeferCleanup(func() error {
-						if CurrentSpecReport().Failed() {
-							env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
-						}
-						return env.DeleteNamespace(namespace)
+						return env.CleanupNamespace(
+							namespace,
+							CurrentSpecReport().LeafNodeText,
+							CurrentSpecReport().Failed(),
+							GinkgoWriter,
+						)
 					})
 
 					cluster := newImageCatalogCluster(namespace, clusterName, major, 3, storageClass)
@@ -667,10 +679,12 @@ var _ = Describe("Rolling updates", Label(tests.LabelPostgresConfiguration), fun
 					namespace, err := env.CreateUniqueNamespace(namespacePrefix)
 					Expect(err).ToNot(HaveOccurred())
 					DeferCleanup(func() error {
-						if CurrentSpecReport().Failed() {
-							env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
-						}
-						return env.DeleteNamespace(namespace)
+						return env.CleanupNamespace(
+							namespace,
+							CurrentSpecReport().LeafNodeText,
+							CurrentSpecReport().Failed(),
+							GinkgoWriter,
+						)
 					})
 
 					cluster := newImageCatalogCluster(namespace, clusterName, major, 1, storageClass)

--- a/tests/e2e/scaling_test.go
+++ b/tests/e2e/scaling_test.go
@@ -54,7 +54,6 @@ var _ = Describe("Cluster scale up and down", Serial, Label(tests.LabelReplicati
 					GinkgoWriter,
 				)
 			})
-
 			AssertCreateCluster(namespace, clusterName, sampleFileWithReplicationSlots, env)
 
 			AssertClusterHAReplicationSlots(clusterName, namespace)

--- a/tests/e2e/scaling_test.go
+++ b/tests/e2e/scaling_test.go
@@ -47,11 +47,14 @@ var _ = Describe("Cluster scale up and down", Serial, Label(tests.LabelReplicati
 			namespace, err := env.CreateUniqueNamespace(namespacePrefix)
 			Expect(err).ToNot(HaveOccurred())
 			DeferCleanup(func() error {
-				if CurrentSpecReport().Failed() {
-					env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
-				}
-				return env.DeleteNamespaceAndWait(namespace, 60)
+				return env.CleanupNamespace(
+					namespace,
+					CurrentSpecReport().LeafNodeText,
+					CurrentSpecReport().Failed(),
+					GinkgoWriter,
+				)
 			})
+
 			AssertCreateCluster(namespace, clusterName, sampleFileWithReplicationSlots, env)
 
 			AssertClusterHAReplicationSlots(clusterName, namespace)
@@ -89,10 +92,12 @@ var _ = Describe("Cluster scale up and down", Serial, Label(tests.LabelReplicati
 			namespace, err := env.CreateUniqueNamespace(namespacePrefix)
 			Expect(err).ToNot(HaveOccurred())
 			DeferCleanup(func() error {
-				if CurrentSpecReport().Failed() {
-					env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
-				}
-				return env.DeleteNamespaceAndWait(namespace, 60)
+				return env.CleanupNamespace(
+					namespace,
+					CurrentSpecReport().LeafNodeText,
+					CurrentSpecReport().Failed(),
+					GinkgoWriter,
+				)
 			})
 			AssertCreateCluster(namespace, clusterName, sampleFileWithoutReplicationSlots, env)
 

--- a/tests/e2e/storage_expansion_test.go
+++ b/tests/e2e/storage_expansion_test.go
@@ -64,10 +64,12 @@ var _ = Describe("Verify storage", Label(tests.LabelStorage), func() {
 			namespace, err = env.CreateUniqueNamespace(namespacePrefix)
 			Expect(err).ToNot(HaveOccurred())
 			DeferCleanup(func() error {
-				if CurrentSpecReport().Failed() {
-					env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
-				}
-				return env.DeleteNamespace(namespace)
+				return env.CleanupNamespace(
+					namespace,
+					CurrentSpecReport().LeafNodeText,
+					CurrentSpecReport().Failed(),
+					GinkgoWriter,
+				)
 			})
 			// Creating a cluster with three nodes
 			AssertCreateCluster(namespace, clusterName, sampleFile, env)
@@ -94,10 +96,12 @@ var _ = Describe("Verify storage", Label(tests.LabelStorage), func() {
 			namespace, err = env.CreateUniqueNamespace(namespacePrefix)
 			Expect(err).ToNot(HaveOccurred())
 			DeferCleanup(func() error {
-				if CurrentSpecReport().Failed() {
-					env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
-				}
-				return env.DeleteNamespace(namespace)
+				return env.CleanupNamespace(
+					namespace,
+					CurrentSpecReport().LeafNodeText,
+					CurrentSpecReport().Failed(),
+					GinkgoWriter,
+				)
 			})
 			AssertCreateCluster(namespace, clusterName, sampleFile, env)
 			By("update cluster for resizeInUseVolumes as false", func() {

--- a/tests/e2e/switchover_test.go
+++ b/tests/e2e/switchover_test.go
@@ -43,10 +43,12 @@ var _ = Describe("Switchover", Serial, Label(tests.LabelSelfHealing), func() {
 			namespace, err = env.CreateUniqueNamespace(namespacePrefix)
 			Expect(err).ToNot(HaveOccurred())
 			DeferCleanup(func() error {
-				if CurrentSpecReport().Failed() {
-					env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
-				}
-				return env.DeleteNamespace(namespace)
+				return env.CleanupNamespace(
+					namespace,
+					CurrentSpecReport().LeafNodeText,
+					CurrentSpecReport().Failed(),
+					GinkgoWriter,
+				)
 			})
 			clusterName, err := env.GetResourceNameFromYAML(sampleFileWithReplicationSlots)
 			Expect(err).ToNot(HaveOccurred())
@@ -65,10 +67,12 @@ var _ = Describe("Switchover", Serial, Label(tests.LabelSelfHealing), func() {
 			namespace, err = env.CreateUniqueNamespace(namespacePrefix)
 			Expect(err).ToNot(HaveOccurred())
 			DeferCleanup(func() error {
-				if CurrentSpecReport().Failed() {
-					env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
-				}
-				return env.DeleteNamespace(namespace)
+				return env.CleanupNamespace(
+					namespace,
+					CurrentSpecReport().LeafNodeText,
+					CurrentSpecReport().Failed(),
+					GinkgoWriter,
+				)
 			})
 			clusterName, err := env.GetResourceNameFromYAML(sampleFileWithoutReplicationSlots)
 			Expect(err).ToNot(HaveOccurred())

--- a/tests/e2e/syncreplicas_test.go
+++ b/tests/e2e/syncreplicas_test.go
@@ -91,10 +91,12 @@ var _ = Describe("Synchronous Replicas", Label(tests.LabelReplication), func() {
 			namespace, err := env.CreateUniqueNamespace(namespacePrefix)
 			Expect(err).ToNot(HaveOccurred())
 			DeferCleanup(func() error {
-				if CurrentSpecReport().Failed() {
-					env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
-				}
-				return env.DeleteNamespace(namespace)
+				return env.CleanupNamespace(
+					namespace,
+					CurrentSpecReport().LeafNodeText,
+					CurrentSpecReport().Failed(),
+					GinkgoWriter,
+				)
 			})
 			AssertCreateCluster(namespace, clusterName, sampleFile, env)
 
@@ -163,10 +165,12 @@ var _ = Describe("Synchronous Replicas", Label(tests.LabelReplication), func() {
 			namespace, err := env.CreateUniqueNamespace(namespacePrefix)
 			Expect(err).ToNot(HaveOccurred())
 			DeferCleanup(func() error {
-				if CurrentSpecReport().Failed() {
-					env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
-				}
-				return env.DeleteNamespace(namespace)
+				return env.CleanupNamespace(
+					namespace,
+					CurrentSpecReport().LeafNodeText,
+					CurrentSpecReport().Failed(),
+					GinkgoWriter,
+				)
 			})
 
 			AssertCreateCluster(namespace, clusterName, sampleFile, env)
@@ -192,10 +196,12 @@ var _ = Describe("Synchronous Replicas", Label(tests.LabelReplication), func() {
 			namespace, err := env.CreateUniqueNamespace(namespacePrefix)
 			Expect(err).ToNot(HaveOccurred())
 			DeferCleanup(func() error {
-				if CurrentSpecReport().Failed() {
-					env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
-				}
-				return env.DeleteNamespace(namespace)
+				return env.CleanupNamespace(
+					namespace,
+					CurrentSpecReport().LeafNodeText,
+					CurrentSpecReport().Failed(),
+					GinkgoWriter,
+				)
 			})
 			AssertCreateCluster(namespace, clusterName, sampleFile, env)
 

--- a/tests/e2e/tablespaces_test.go
+++ b/tests/e2e/tablespaces_test.go
@@ -124,7 +124,14 @@ var _ = Describe("Tablespaces tests", Label(tests.LabelTablespaces,
 			// Create a cluster in a namespace we'll delete after the test
 			namespace, err = env.CreateUniqueNamespace(namespacePrefix)
 			Expect(err).ToNot(HaveOccurred())
-
+			DeferCleanup(func() error {
+				return env.CleanupNamespace(
+					namespace,
+					CurrentSpecReport().LeafNodeText,
+					CurrentSpecReport().Failed(),
+					GinkgoWriter,
+				)
+			})
 			// We create the MinIO credentials required to login into the system
 			AssertStorageCredentialsAreCreated(namespace, "backup-storage-creds", "minio", "minio123")
 
@@ -133,9 +140,6 @@ var _ = Describe("Tablespaces tests", Label(tests.LabelTablespaces,
 				Expect(err).ToNot(HaveOccurred())
 			})
 
-			DeferCleanup(func() error {
-				return env.DeleteNamespace(namespace)
-			})
 			clusterSetup(clusterManifest)
 		})
 
@@ -391,7 +395,14 @@ var _ = Describe("Tablespaces tests", Label(tests.LabelTablespaces,
 			// Create a cluster in a namespace we'll delete after the test
 			namespace, err = env.CreateUniqueNamespace(namespacePrefix)
 			Expect(err).ToNot(HaveOccurred())
-
+			DeferCleanup(func() error {
+				return env.CleanupNamespace(
+					namespace,
+					CurrentSpecReport().LeafNodeText,
+					CurrentSpecReport().Failed(),
+					GinkgoWriter,
+				)
+			})
 			// We create the required credentials for MinIO
 			AssertStorageCredentialsAreCreated(namespace, "backup-storage-creds", "minio", "minio123")
 
@@ -400,9 +411,6 @@ var _ = Describe("Tablespaces tests", Label(tests.LabelTablespaces,
 				Expect(err).ToNot(HaveOccurred())
 			})
 
-			DeferCleanup(func() error {
-				return env.DeleteNamespace(namespace)
-			})
 			clusterSetup(clusterManifest)
 		})
 
@@ -631,7 +639,12 @@ var _ = Describe("Tablespaces tests", Label(tests.LabelTablespaces,
 			namespace, err = env.CreateUniqueNamespace(namespacePrefix)
 			Expect(err).ToNot(HaveOccurred())
 			DeferCleanup(func() error {
-				return env.DeleteNamespace(namespace)
+				return env.CleanupNamespace(
+					namespace,
+					CurrentSpecReport().LeafNodeText,
+					CurrentSpecReport().Failed(),
+					GinkgoWriter,
+				)
 			})
 			clusterSetup(clusterManifest)
 		})
@@ -769,7 +782,12 @@ var _ = Describe("Tablespaces tests", Label(tests.LabelTablespaces,
 			namespace, err = env.CreateUniqueNamespace(namespacePrefix)
 			Expect(err).ToNot(HaveOccurred())
 			DeferCleanup(func() error {
-				return env.DeleteNamespace(namespace)
+				return env.CleanupNamespace(
+					namespace,
+					CurrentSpecReport().LeafNodeText,
+					CurrentSpecReport().Failed(),
+					GinkgoWriter,
+				)
 			})
 			clusterSetup(clusterManifest)
 		})

--- a/tests/e2e/tolerations_test.go
+++ b/tests/e2e/tolerations_test.go
@@ -60,10 +60,12 @@ var _ = Describe("E2E Tolerations Node", Serial, Label(tests.LabelDisruptive, te
 		namespace, err = env.CreateUniqueNamespace(namespacePrefix)
 		Expect(err).ToNot(HaveOccurred())
 		DeferCleanup(func() error {
-			if CurrentSpecReport().Failed() {
-				env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
-			}
-			return env.DeleteNamespace(namespace)
+			return env.CleanupNamespace(
+				namespace,
+				CurrentSpecReport().LeafNodeText,
+				CurrentSpecReport().Failed(),
+				GinkgoWriter,
+			)
 		})
 
 		By("tainting all the nodes", func() {

--- a/tests/e2e/update_user_test.go
+++ b/tests/e2e/update_user_test.go
@@ -50,10 +50,12 @@ var _ = Describe("Update user and superuser password", Label(tests.LabelServiceC
 		namespace, err := env.CreateUniqueNamespace(namespacePrefix)
 		Expect(err).ToNot(HaveOccurred())
 		DeferCleanup(func() error {
-			if CurrentSpecReport().Failed() {
-				env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
-			}
-			return env.DeleteNamespace(namespace)
+			return env.CleanupNamespace(
+				namespace,
+				CurrentSpecReport().LeafNodeText,
+				CurrentSpecReport().Failed(),
+				GinkgoWriter,
+			)
 		})
 		clusterName, err := env.GetResourceNameFromYAML(sampleFile)
 		Expect(err).ToNot(HaveOccurred())
@@ -134,10 +136,12 @@ var _ = Describe("Enable superuser password", Label(tests.LabelServiceConnectivi
 		namespace, err := env.CreateUniqueNamespace(namespacePrefix)
 		Expect(err).ToNot(HaveOccurred())
 		DeferCleanup(func() error {
-			if CurrentSpecReport().Failed() {
-				env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
-			}
-			return env.DeleteNamespace(namespace)
+			return env.CleanupNamespace(
+				namespace,
+				CurrentSpecReport().LeafNodeText,
+				CurrentSpecReport().Failed(),
+				GinkgoWriter,
+			)
 		})
 		clusterName, err := env.GetResourceNameFromYAML(sampleFile)
 		Expect(err).ToNot(HaveOccurred())

--- a/tests/e2e/volume_snapshot_test.go
+++ b/tests/e2e/volume_snapshot_test.go
@@ -362,18 +362,14 @@ var _ = Describe("Verify Volume Snapshot",
 				namespace, err = env.CreateUniqueNamespace(namespacePrefix)
 				Expect(err).ToNot(HaveOccurred())
 				DeferCleanup(func() error {
+					_ = os.Unsetenv(snapshotDataEnv)
+					_ = os.Unsetenv(snapshotWalEnv)
 					return env.CleanupNamespace(
 						namespace,
 						CurrentSpecReport().LeafNodeText,
 						CurrentSpecReport().Failed(),
 						GinkgoWriter,
 					)
-				})
-				DeferCleanup(func() error {
-					if err := os.Unsetenv(snapshotDataEnv); err != nil {
-						return err
-					}
-					return os.Unsetenv(snapshotWalEnv)
 				})
 				clusterToBackupName, err = env.GetResourceNameFromYAML(clusterToBackupFilePath)
 				Expect(err).ToNot(HaveOccurred())

--- a/tests/e2e/volume_snapshot_test.go
+++ b/tests/e2e/volume_snapshot_test.go
@@ -83,10 +83,12 @@ var _ = Describe("Verify Volume Snapshot",
 				Expect(err).ToNot(HaveOccurred())
 
 				DeferCleanup(func() error {
-					if CurrentSpecReport().Failed() {
-						env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
-					}
-					return env.DeleteNamespace(namespace)
+					return env.CleanupNamespace(
+						namespace,
+						CurrentSpecReport().LeafNodeText,
+						CurrentSpecReport().Failed(),
+						GinkgoWriter,
+					)
 				})
 
 				// Creating a cluster with three nodes
@@ -171,10 +173,12 @@ var _ = Describe("Verify Volume Snapshot",
 				Expect(err).ToNot(HaveOccurred())
 
 				DeferCleanup(func() error {
-					if CurrentSpecReport().Failed() {
-						env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
-					}
-					return env.DeleteNamespace(namespace)
+					return env.CleanupNamespace(
+						namespace,
+						CurrentSpecReport().LeafNodeText,
+						CurrentSpecReport().Failed(),
+						GinkgoWriter,
+					)
 				})
 
 				By("create the certificates for MinIO", func() {
@@ -358,16 +362,18 @@ var _ = Describe("Verify Volume Snapshot",
 				namespace, err = env.CreateUniqueNamespace(namespacePrefix)
 				Expect(err).ToNot(HaveOccurred())
 				DeferCleanup(func() error {
-					if CurrentSpecReport().Failed() {
-						env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
-					}
+					return env.CleanupNamespace(
+						namespace,
+						CurrentSpecReport().LeafNodeText,
+						CurrentSpecReport().Failed(),
+						GinkgoWriter,
+					)
+				})
+				DeferCleanup(func() error {
 					if err := os.Unsetenv(snapshotDataEnv); err != nil {
 						return err
 					}
-					if err := os.Unsetenv(snapshotWalEnv); err != nil {
-						return err
-					}
-					return env.DeleteNamespace(namespace)
+					return os.Unsetenv(snapshotWalEnv)
 				})
 				clusterToBackupName, err = env.GetResourceNameFromYAML(clusterToBackupFilePath)
 				Expect(err).ToNot(HaveOccurred())
@@ -581,10 +587,12 @@ var _ = Describe("Verify Volume Snapshot",
 				Expect(err).ToNot(HaveOccurred())
 
 				DeferCleanup(func() error {
-					if CurrentSpecReport().Failed() {
-						env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
-					}
-					return env.DeleteNamespace(namespace)
+					return env.CleanupNamespace(
+						namespace,
+						CurrentSpecReport().LeafNodeText,
+						CurrentSpecReport().Failed(),
+						GinkgoWriter,
+					)
 				})
 
 				By("create the certificates for MinIO", func() {

--- a/tests/e2e/wal_restore_parallel_test.go
+++ b/tests/e2e/wal_restore_parallel_test.go
@@ -68,10 +68,12 @@ var _ = Describe("Wal-restore in parallel", Label(tests.LabelBackupRestore), fun
 		namespace, err = env.CreateUniqueNamespace(namespacePrefix)
 		Expect(err).ToNot(HaveOccurred())
 		DeferCleanup(func() error {
-			if CurrentSpecReport().Failed() {
-				env.DumpNamespaceObjects(namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
-			}
-			return env.DeleteNamespace(namespace)
+			return env.CleanupNamespace(
+				namespace,
+				CurrentSpecReport().LeafNodeText,
+				CurrentSpecReport().Failed(),
+				GinkgoWriter,
+			)
 		})
 
 		By("creating the credentials for minio", func() {

--- a/tests/e2e/webhook_test.go
+++ b/tests/e2e/webhook_test.go
@@ -84,10 +84,12 @@ var _ = Describe("webhook", Serial, Label(tests.LabelDisruptive, tests.LabelOper
 		webhookNamespace, err = env.CreateUniqueNamespace(webhookNamespacePrefix)
 		Expect(err).ToNot(HaveOccurred())
 		DeferCleanup(func() error {
-			if CurrentSpecReport().Failed() {
-				env.DumpNamespaceObjects(webhookNamespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
-			}
-			return env.DeleteNamespace(webhookNamespace)
+			return env.CleanupNamespace(
+				webhookNamespace,
+				CurrentSpecReport().LeafNodeText,
+				CurrentSpecReport().Failed(),
+				GinkgoWriter,
+			)
 		})
 		AssertCreateCluster(webhookNamespace, clusterName, sampleFile, env)
 		// Check if cluster is ready and the default values are populated
@@ -128,10 +130,12 @@ var _ = Describe("webhook", Serial, Label(tests.LabelDisruptive, tests.LabelOper
 		webhookNamespace, err = env.CreateUniqueNamespace(webhookNamespacePrefix)
 		Expect(err).ToNot(HaveOccurred())
 		DeferCleanup(func() error {
-			if CurrentSpecReport().Failed() {
-				env.DumpNamespaceObjects(webhookNamespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
-			}
-			return env.DeleteNamespace(webhookNamespace)
+			return env.CleanupNamespace(
+				webhookNamespace,
+				CurrentSpecReport().LeafNodeText,
+				CurrentSpecReport().Failed(),
+				GinkgoWriter,
+			)
 		})
 		AssertCreateCluster(webhookNamespace, clusterName, sampleFile, env)
 		// Check if cluster is ready and has no default value in the object

--- a/tests/utils/namespace.go
+++ b/tests/utils/namespace.go
@@ -62,7 +62,14 @@ func writeInlineOutput(linesToShow, bufferIdx, capLines int, lineBuffer []string
 // saveNamespaceLogs does 2 things:
 //   - displays the last `capLines` of error/warning logs on the `output` io.Writer (likely GinkgoWriter)
 //   - saves the full logs to a file
-func saveNamespaceLogs(buf *bytes.Buffer, logsType, specName, namespace string, output io.Writer, capLines int) {
+func saveNamespaceLogs(
+	buf *bytes.Buffer,
+	logsType string,
+	specName string,
+	namespace string,
+	output io.Writer,
+	capLines int,
+) {
 	scanner := bufio.NewScanner(buf)
 	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 	filename := fmt.Sprintf("out/%s_ns-%s_%s.log", logsType, namespace, specName)
@@ -108,11 +115,12 @@ func saveNamespaceLogs(buf *bytes.Buffer, logsType, specName, namespace string, 
 			}
 		}
 
-		// store the latest line of error or warning log to the slice
 		isImportant := func(js map[string]interface{}) bool {
 			return js["level"] == log.WarningLevelString || js["level"] == log.ErrorLevelString
 		}
 
+		// store the latest line of error or warning log to the slice,
+		// output every line to the file
 		if js["namespace"] == namespace {
 			// write every matching line to the file stream
 			_, err := fmt.Fprintln(f, lg)
@@ -140,7 +148,7 @@ func saveNamespaceLogs(buf *bytes.Buffer, logsType, specName, namespace string, 
 	}
 }
 
-// GetOperatorLogs is collects the operator logs
+// GetOperatorLogs collects the operator logs
 func (env TestingEnvironment) GetOperatorLogs(buf *bytes.Buffer) error {
 	operatorPod, err := env.GetOperatorPod()
 	if err != nil {
@@ -171,7 +179,8 @@ func (env TestingEnvironment) DumpNamespaceOperatorLogs(namespace, testName stri
 	saveNamespaceLogs(&buf, "operator_logs", sanitizedTestName, namespace, output, capLines)
 }
 
-// CleanupNamespace is cool
+// CleanupNamespace does cleanup duty related to the tear-down of a namespace,
+// and is intended to be called in a DeferCleanup clause
 func (env TestingEnvironment) CleanupNamespace(
 	namespace string,
 	testName string,
@@ -185,7 +194,8 @@ func (env TestingEnvironment) CleanupNamespace(
 	return env.DeleteNamespace(namespace)
 }
 
-// CleanupNamespaceAndWait is cool
+// CleanupNamespaceAndWait does cleanup just like CleanupNamespace, but waits for
+// the namespace to be deleted, with a timeout
 func (env TestingEnvironment) CleanupNamespaceAndWait(
 	namespace string,
 	testName string,

--- a/tests/utils/namespace.go
+++ b/tests/utils/namespace.go
@@ -19,7 +19,6 @@ package utils
 import (
 	"bufio"
 	"bytes"
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -163,7 +162,7 @@ func (env TestingEnvironment) GetOperatorLogs(buf *bytes.Buffer) error {
 		},
 		Client: env.Interface,
 	}
-	return streamPodLog.Stream(context.TODO(), buf)
+	return streamPodLog.Stream(env.Ctx, buf)
 }
 
 // DumpNamespaceOperatorLogs writes the operator logs related to a namespace into a writer


### PR DESCRIPTION
This patch improves the collection and display of operator logs on test failure.
Now the operator logs will be filtered to collect only those logs that were
affecting the namespace of the test.

# Release notes

NONE