### PR TITLE
Append namespace in backup path

### DIFF
--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -2203,6 +2203,12 @@ type BarmanObjectStoreConfiguration struct {
 	// +kubebuilder:validation:MinLength=1
 	DestinationPath string `json:"destinationPath"`
 
+	// Include the namespace that the cluster exists in the name used on the object storage.
+	// The namespace will be appended to the end of the destinationPath.
+	// It empty, if defaults to false.
+	// +optional
+	IncludeNamespace bool `json:"includeNamespace"`
+
 	// The server name on S3, the cluster name is used if this
 	// parameter is omitted
 	// +optional

--- a/config/crd/bases/postgresql.cnpg.io_clusters.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_clusters.yaml
@@ -1245,6 +1245,12 @@ spec:
                           HistoryTags is a list of key value pairs that will be passed to the
                           Barman --history-tags option.
                         type: object
+                      includeNamespace:
+                        description: |-
+                          Include the namespace that the cluster exists in the name used on the object storage.
+                          The namespace will be appended to the end of the destinationPath.
+                          It empty, if defaults to false.
+                        type: boolean
                       s3Credentials:
                         description: The credentials to use to upload data to S3
                         properties:
@@ -2709,6 +2715,12 @@ spec:
                             HistoryTags is a list of key value pairs that will be passed to the
                             Barman --history-tags option.
                           type: object
+                        includeNamespace:
+                          description: |-
+                            Include the namespace that the cluster exists in the name used on the object storage.
+                            The namespace will be appended to the end of the destinationPath.
+                            It empty, if defaults to false.
+                          type: boolean
                         s3Credentials:
                           description: The credentials to use to upload data to S3
                           properties:

--- a/docs/src/backup_barmanobjectstore.md
+++ b/docs/src/backup_barmanobjectstore.md
@@ -199,3 +199,22 @@ spec:
         - "--max-concurrency=1"
         - "--read-timeout=60"
 ```
+
+## Unique naming for same name clusters in different namespaces
+
+In some cases users have the same name cluster but in different namespaces. You can automatically append the namespace to the end of
+the path for these clusters backup location by adding the `includeNamespace` option.
+
+For example with this config you have your cluster in namespace `app-dev1`. Your path will come out as `s3://bucket-name/app-dev1`.
+
+```yaml
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+[...]
+spec:
+  backup:
+    barmanObjectStore:
+      destinationPath: "s3://bucket-name/"
+      includeNamespace: true
+```
+

--- a/internal/cmd/manager/walarchive/cmd.go
+++ b/internal/cmd/manager/walarchive/cmd.go
@@ -402,9 +402,19 @@ func barmanCloudWalArchiveOptions(
 	if len(configuration.ServerName) != 0 {
 		serverName = configuration.ServerName
 	}
+
+	dstPath := configuration.DestinationPath
+	if configuration.IncludeNamespace {
+		ns := cluster.Namespace
+		if string(dstPath[len(dstPath)-1]) != "/" {
+			ns = "/" + ns
+		}
+		dstPath = dstPath + ns
+	}
+
 	options = append(
 		options,
-		configuration.DestinationPath,
+		dstPath,
 		serverName)
 	return options, nil
 }

--- a/internal/cmd/manager/walarchive/cmd_test.go
+++ b/internal/cmd/manager/walarchive/cmd_test.go
@@ -81,4 +81,15 @@ var _ = Describe("barmanCloudWalArchiveOptions", func() {
 						"-vv --immediate-checkpoint=false s3://bucket-name/ test-cluster",
 				))
 	})
+
+	It("should generate a path with the namespace", func() {
+		cluster.Spec.Backup.BarmanObjectStore.IncludeNamespace = true
+		options, err := barmanCloudWalArchiveOptions(cluster, "test-cluster")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(strings.Join(options, " ")).
+			To(
+				ContainSubstring(
+					"s3://bucket-name/test test-cluster",
+				))
+	})
 })


### PR DESCRIPTION
This PR is an attempt to solve issue #5216.

This adds in an option on the configuration of the backup path to include the namespace by appending it to the end of the path. This makes the path unique to the cluster even if the name is the same as another one in a different namespace.