### PR TITLE
Webhook only warns about nodeMaintenance window if used in PDB-disabling mode

### DIFF
--- a/api/v1/cluster_webhook.go
+++ b/api/v1/cluster_webhook.go
@@ -2618,7 +2618,12 @@ func (r *Cluster) getAdmissionWarnings() admission.Warnings {
 func (r *Cluster) getMaintenanceWindowsAdmissionWarnings() admission.Warnings {
 	var result admission.Warnings
 
-	if r.Spec.NodeMaintenanceWindow != nil {
+	// before .spec.enablePDB was added, PDBs could only be disabled by setting
+	// .spec.nodeMaintenanceWindow.inProgress = true and .spec.nodeMaintenanceWindow.reusePVC = true (default)
+	// recommend users towards .spec.enablePDB = false if they're using this configuration
+	if r.Spec.NodeMaintenanceWindow != nil &&
+		r.Spec.NodeMaintenanceWindow.InProgress &&
+		(r.Spec.NodeMaintenanceWindow.ReusePVC == nil || *r.Spec.NodeMaintenanceWindow.ReusePVC) {
 		result = append(
 			result,
 			"Consider using `.spec.enablePDB` instead of the node maintenance window feature")


### PR DESCRIPTION
nodeMaintenanceWindow is also used with reusePVC: false which does not disable PDBs, leading to an irrelevant warning emitted here.

Originally Introduced: bf4248a33d3ffcec2a99c9bb5b5e7f94bc80ce91 
Ref: https://github.com/cloudnative-pg/cloudnative-pg/issues/2570#issuecomment-1884962321