### PR TITLE
test: make the test for replica detach more reliable

### DIFF
--- a/tests/e2e/asserts_test.go
+++ b/tests/e2e/asserts_test.go
@@ -1093,6 +1093,8 @@ func AssertDetachReplicaModeCluster(
 		Eventually(func(g Gomega) {
 			cluster, err := env.GetCluster(namespace, replicaClusterName)
 			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(cluster.Spec.ReplicaCluster.Enabled).NotTo(BeNil(), "replica.enabled was nil")
+			g.Expect(*cluster.Spec.ReplicaCluster.Enabled).To(BeFalse(), "replica.enabled still true")
 			condition, err := testsUtils.GetConditionsInClusterStatus(namespace, cluster.Name, env,
 				apiv1.ConditionClusterReady)
 			g.Expect(err).ToNot(HaveOccurred())

--- a/tests/e2e/asserts_test.go
+++ b/tests/e2e/asserts_test.go
@@ -1095,6 +1095,10 @@ func AssertDetachReplicaModeCluster(
 		}, 20, 1).Should(Succeed())
 	})
 
+	By("checking the cluster recovers", func() {
+		AssertClusterIsReady(namespace, replicaClusterName, testTimeouts[testsUtils.ClusterIsReady], env)
+	})
+
 	By("verifying write operation on the replica cluster primary pod", func() {
 		query := "CREATE TABLE IF NOT EXISTS replica_cluster_primary AS VALUES (1),(2);"
 		// Expect write operation to succeed


### PR DESCRIPTION
The replica detach test is flaky, failing about 5-10% of the time.
E.g. https://github.com/cloudnative-pg/cloudnative-pg/actions/runs/10269046932/job/28413809548

This PR rewrites the test to consider the cluster Phase, rather than
relying on the transition time of the Ready condition.