### PR TITLE
feat: improve `PhaseUnknownPlugin`

### DIFF
--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -563,7 +563,7 @@ const (
 
 	// PhaseUnknownPlugin is triggered when the required CNPG-i plugin have not been
 	// loaded still
-	PhaseUnknownPlugin = "Unknown plugin"
+	PhaseUnknownPlugin = "Cluster cannot proceed to reconciliation due to an unknown plugin being required"
 
 	// PhaseImageCatalogError is triggered when the cluster cannot select the image to
 	// apply because of an invalid or incomplete catalog

--- a/internal/cnpi/plugin/repository/setup.go
+++ b/internal/cnpi/plugin/repository/setup.go
@@ -84,7 +84,10 @@ func (r *data) setPluginProtocol(name string, protocol connection.Protocol) erro
 			}
 		}()
 
-		constructorLogger := log.FromContext(ctx).WithValues("pluginName", name)
+		constructorLogger := log.
+			FromContext(ctx).
+			WithName("setPluginProtocol").
+			WithValues("pluginName", name)
 		ctx = log.IntoContext(ctx, constructorLogger)
 
 		if handler, err = protocol.Dial(ctx); err != nil {
@@ -98,7 +101,9 @@ func (r *data) setPluginProtocol(name string, protocol connection.Protocol) erro
 	destructor := func(res connection.Interface) {
 		err := res.Close()
 		if err != nil {
-			destructorLogger := log.FromContext(context.Background()).WithValues("pluginName", res.Name())
+			destructorLogger := log.FromContext(context.Background()).
+				WithName("setPluginProtocol").
+				WithValues("pluginName", res.Name())
 			destructorLogger.Warning("Error while closing plugin connection", "err", err)
 		}
 	}

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -164,7 +164,9 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 					ctx,
 					cluster,
 					apiv1.PhaseUnknownPlugin,
-					fmt.Sprintf("Unknown plugin %s", errUnknownPlugin.Name),
+					fmt.Sprintf("Unknown plugin: '%s'. "+
+						"This may be caused by the plugin not being loaded correctly by the operator. "+
+						"Check the operator and plugin logs for errors", errUnknownPlugin.Name),
 				)
 		}
 


### PR DESCRIPTION

Closes #5273  

## Release Notes

The Cluster `Unknown plugin` phase, triggered in case of missing plugins, has been replaced with a more descriptive one.
