### PR TITLE
fix: flip values for errors.Is() function

### DIFF
--- a/internal/cmd/manager/controller/controller.go
+++ b/internal/cmd/manager/controller/controller.go
@@ -495,7 +495,7 @@ func startPprofDebugServer(ctx context.Context) {
 			}
 		}()
 
-		if err := pprofServer.ListenAndServe(); !errors.Is(http.ErrServerClosed, err) {
+		if err := pprofServer.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {
 			setupLog.Error(err, "Failed to start pprof HTTP server")
 		}
 	}()

--- a/pkg/management/postgres/webserver/webserver.go
+++ b/pkg/management/postgres/webserver/webserver.go
@@ -98,7 +98,7 @@ func (ws *Webserver) Start(ctx context.Context) error {
 	// we exit with error code, potentially we could do a retry logic, but rarely a webserver that doesn't start will run
 	// on subsequent tries
 	case err := <-errChan:
-		if errors.Is(http.ErrServerClosed, err) {
+		if errors.Is(err, http.ErrServerClosed) {
 			log.Error(err, "Closing the web server", "address", ws.server.Addr)
 		} else {
 			log.Error(err, "Error while running the web server", "address", ws.server.Addr)


### PR DESCRIPTION
The expected order is, error and then the target error