### PR TITLE
test: fix regexp used in metrics collector test

### DIFF
--- a/tests/e2e/asserts_test.go
+++ b/tests/e2e/asserts_test.go
@@ -3098,7 +3098,7 @@ func assertIncludesMetrics(rawMetricsOutput string, expectedMetrics map[string]*
 	}
 
 	for key, valueRe := range expectedMetrics {
-		re := regexp.MustCompile(fmt.Sprintf("(?m)^( %s ).*$", key))
+		re := regexp.MustCompile(fmt.Sprintf("(?m)^(%s).*$", key))
 
 		// match a metric with the value of expectedMetrics key
 		match := re.FindString(rawMetricsOutput)


### PR DESCRIPTION
Due to the golangci-lint found an issue in the way we used the MustCompile()
function arguments, we were using Sprintf() but instead of passing the arguments
for a format string we used a `+` operator to concatenate the strings, this lead to
a leading space when the error was fixed producing the test fail due to the regexp
being wrong.