### PR TITLE
fix: wrong type in 'exclude-files' field in golangci.yml configuration

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -126,4 +126,5 @@ issues:
       text: "ST1016:"
       path: api/
   exclude-use-default: false
-  exclude-files: "zz_generated.*"
+  exclude-files:
+    - zz_generated.*


### PR DESCRIPTION
Closes #5339 