### PR TITLE
ci: use full linter version for testing

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -260,7 +260,7 @@
       "datasourceTemplate": "github-releases",
       "depNameTemplate": "golangci/golangci-lint",
       "versioningTemplate": "loose",
-      "extractVersionTemplate": "^v(?<version>\\d+\\.\\d+)"
+      "extractVersionTemplate": "^v(?<version>\\d+\\.\\d+\\.\\d+)"
     }
   ],
   "packageRules": [

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -17,7 +17,7 @@ on:
 # set up environment variables to be used across all the jobs
 env:
   GOLANG_VERSION: "1.22.x"
-  GOLANGCI_LINT_VERSION: "v1.60"
+  GOLANGCI_LINT_VERSION: "v1.60.1"
   KUBEBUILDER_VERSION: "2.3.1"
   KIND_VERSION: "v0.24.0"
   OPERATOR_IMAGE_NAME: "ghcr.io/${{ github.repository }}-testing"


### PR DESCRIPTION
Before this, we were using only major.minor version to install and run the
golangci-lint, in the latest patch version, we found lot of new issues and this
started to appear in the linter due to the action was installing the latest
version available for the minor version, this fix that by using the full version
of the linter to install.