### PR TITLE
fix(pooler): ensure SA and RBAC are reconciled before deployment

### DIFF
--- a/internal/controller/pooler_update.go
+++ b/internal/controller/pooler_update.go
@@ -40,15 +40,15 @@ func (r *PoolerReconciler) updateOwnedObjects(
 	pooler *apiv1.Pooler,
 	resources *poolerManagedResources,
 ) error {
-	if err := r.updateDeployment(ctx, pooler, resources); err != nil {
-		return err
-	}
-
 	if err := r.updateServiceAccount(ctx, pooler, resources); err != nil {
 		return err
 	}
 
 	if err := r.updateRBAC(ctx, pooler, resources); err != nil {
+		return err
+	}
+
+	if err := r.updateDeployment(ctx, pooler, resources); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This patch ensures that we don't have a racing condition between the pod and the service account creation when an imagePullSecret is required. 

Closes #5300 

## Release Notes

The `Pooler` resource will reconcile the ServiceAccount and RBAC before proceeding to the Deployment creation, ensuring that the PODs will always have the proper permission to pull the image.