### PR TITLE
fix: allow `smartShutdownTimeout` to be set to 0

### DIFF
--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -384,7 +384,7 @@ type ClusterSpec struct {
 	// (that is: `stopDelay` - `smartShutdownTimeout`).
 	// +kubebuilder:default:=180
 	// +optional
-	SmartShutdownTimeout int32 `json:"smartShutdownTimeout,omitempty"`
+	SmartShutdownTimeout *int32 `json:"smartShutdownTimeout,omitempty"`
 
 	// The time in seconds that is allowed for a primary PostgreSQL instance
 	// to gracefully shutdown during a switchover.
@@ -3224,8 +3224,8 @@ func (cluster *Cluster) GetMaxStopDelay() int32 {
 
 // GetSmartShutdownTimeout is used to ensure that smart shutdown timeout is a positive integer
 func (cluster *Cluster) GetSmartShutdownTimeout() int32 {
-	if cluster.Spec.SmartShutdownTimeout > 0 {
-		return cluster.Spec.SmartShutdownTimeout
+	if cluster.Spec.SmartShutdownTimeout != nil {
+		return *cluster.Spec.SmartShutdownTimeout
 	}
 	return 180
 }

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -851,6 +851,11 @@ func (in *ClusterSpec) DeepCopyInto(out *ClusterSpec) {
 		*out = new(corev1.EphemeralVolumeSource)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.SmartShutdownTimeout != nil {
+		in, out := &in.SmartShutdownTimeout, &out.SmartShutdownTimeout
+		*out = new(int32)
+		**out = **in
+	}
 	if in.LivenessProbeTimeout != nil {
 		in, out := &in.LivenessProbeTimeout, &out.LivenessProbeTimeout
 		*out = new(int32)


### PR DESCRIPTION
Closes: #5338 

# Release Notes

Allow setting `smartShutdownTimeout` to zero, enabling users to skip the smart shutdown process and facilitate PostgreSQL Pod termination when needed.