### PR TITLE
chore: improve `TryInvokeQuitEndpoint` logging

### DIFF
--- a/internal/management/istio/istio.go
+++ b/internal/management/istio/istio.go
@@ -31,14 +31,16 @@ import (
 // the service exists
 func TryInvokeQuitEndpoint(ctx context.Context) error {
 	const endpoint = "http://localhost:15000/quitquitquit"
-	logger := log.FromContext(ctx)
+	logger := log.FromContext(ctx).WithName("try_invoke_quit_quit_endpoint")
 
 	clientHTTP := http.Client{Timeout: 5 * time.Second}
 	resp, err := clientHTTP.Post(endpoint, "", nil)
 	if errors.Is(err, syscall.ECONNREFUSED) || os.IsTimeout(err) {
+		logger.Debug("received ECONNREFUSED, ignoring the error", "endpoint", endpoint)
 		return nil
 	}
 	if err != nil {
+		logger.Error(err, "while invoking the /quitquitquit endpoint", "endpoint", endpoint)
 		return err
 	}
 	if closeErr := resp.Body.Close(); closeErr != nil {


### PR DESCRIPTION
Closes #5354 

## Release Notes

The commands that invoke istio `/quitquitquit` endpoint now provide a better log message in case of errors.