### PR TITLE
Use single database for pgbouncer authentication queries

### DIFF
--- a/internal/management/controller/instance_controller.go
+++ b/internal/management/controller/instance_controller.go
@@ -574,6 +574,12 @@ func (r *InstanceReconciler) reconcileDatabases(ctx context.Context, cluster *ap
 					fmt.Errorf("could not reconcile extensions for database %s: %w", databaseName, err))
 			}
 		}
+		if databaseName != "postgres" {
+			// We create reconcile pooler access only for 'postgres' database since
+			// it is set as 'auth_dbname' in pgbouncer for 'auth_query' purposes (for any database).
+			// TODO: pick the value from spec?
+			continue;
+		}
 		if err = r.reconcilePoolers(ctx, db, databaseName, cluster.Status.PoolerIntegrations); err != nil {
 			errors = append(errors,
 				fmt.Errorf("could not reconcile extensions for database %s: %w", databaseName, err))

--- a/pkg/management/pgbouncer/config/config.go
+++ b/pkg/management/pgbouncer/config/config.go
@@ -77,6 +77,7 @@ const (
 pool_mode = {{ .Pooler.Spec.PgBouncer.PoolMode }}
 auth_user = {{ .AuthQueryUser }}
 auth_query = {{ .AuthQuery }}
+auth_dbname = {{ .AuthQueryDb }}
 
 {{ .Parameters -}}
 `
@@ -187,12 +188,15 @@ func BuildConfigurationFiles(pooler *apiv1.Pooler, secrets *Secrets) (Configurat
 		AuthQuery         string
 		AuthQueryUser     string
 		AuthQueryPassword string
+		AuthQueryDb 	  string
 		Parameters        string
 		PgHba             []string
 	}{
 		Pooler:            pooler,
 		AuthQuery:         pooler.GetAuthQuery(),
 		AuthQueryUser:     authQueryUser,
+		// TODO: control from `pooler.Spec.PgBouncer.AuthQueryDb`
+		AuthQueryDb: 	   "postgres",
 		AuthQueryPassword: authQueryPassword,
 		// We are not directly passing the map of parameters inside the template
 		// because the iteration order of the entries inside a map is undefined


### PR DESCRIPTION
I propose to add the `AuthQueryDb` setting that enables the use of PgBouncer `auth_dbname` setting:

> Database name in the [database] section to be used for authentication purposes. This option can be either global or overridden in the connection string if this parameter is specified.

The issue with the current approach is that users might accidentally delete or revoke access to the `public.user_search()` function, which could lock them out of a specific database. By placing this access function in a designated database (e.g., 'postgres'), it becomes easier to manage this behavior and reduce the risk of being locked out.

However, I am unsure where exactly this setting should belong, as it influences both the Pooler and Postgres behavior. I have uploaded a proof-of-concept code with a fixed database ('postgres'). If the community finds this feature valuable, I am willing to update the PR with the required logic.