### PR TITLE
✨ Add support for ICU locales in InitDB flags

### DIFF
--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -1683,6 +1683,14 @@ type BootstrapInitDB struct {
 	// +optional
 	LocaleCType string `json:"localeCType,omitempty"`
 
+	// The value to be passed as option `--locale-provider` for initdb (by default empty)
+	// +optional
+	LocaleProvider string `json:"localeProvider,omitempty"`
+
+	// The value to be passed as option `--icu-locale` for initdb (by default empty)
+	// +optional
+	ICULocale string `json:"icuLocale,omitempty"`
+
 	// The value in megabytes (1 to 1024) to be passed to the `--wal-segsize`
 	// option for initdb (default: empty, resulting in PostgreSQL default: 16MB)
 	// +kubebuilder:validation:Minimum=1

--- a/config/crd/bases/postgresql.cnpg.io_clusters.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_clusters.yaml
@@ -1514,6 +1514,10 @@ spec:
                         description: The value to be passed as option `--encoding`
                           for initdb (default:`UTF8`)
                         type: string
+                      icuLocale:
+                        description: The value to be passed as option `--icu-locale`
+                          for initdb (by default empty)
+                        type: string
                       import:
                         description: |-
                           Bootstraps the new cluster by importing data from an existing PostgreSQL
@@ -1571,6 +1575,10 @@ spec:
                       localeCollate:
                         description: The value to be passed as option `--lc-collate`
                           for initdb (default:`C`)
+                        type: string
+                      localeProvider:
+                        description: The value to be passed as option `--locale-provider`
+                          for initdb (by default empty)
                         type: string
                       options:
                         description: |-

--- a/docs/src/bootstrap.md
+++ b/docs/src/bootstrap.md
@@ -232,6 +232,19 @@ localeCType
     defined in ["Locale Support"](https://www.postgresql.org/docs/current/locale.html)
     from the PostgreSQL documentation (default: `C`).
 
+localeProvider
+:   When `localeProvider` is set to a value, CNPG passes it to the `--locale-provider` 
+    option in `initdb`. This option controls the locale provider, as defined in 
+    ["Locale Support"](https://www.postgresql.org/docs/current/locale.html) from the 
+    PostgreSQL documentation (default: empty, which means `libc` for PostgreSQL).
+
+icuLocale
+:   When `icuLocale` is set to a value, CNPG passes it to the `--icu-locale` option in 
+    `initdb`. This option controls the ICU locale, as defined in 
+    ["Locale Support"](https://www.postgresql.org/docs/current/locale.html) from the 
+    PostgreSQL documentation (default: empty).
+    Note that this option requires `localeProvider` to be set to `icu`.
+
 walSegmentSize
 :   When `walSegmentSize` is set to a value, CNPG passes it to the `--wal-segsize`
     option in `initdb` (default: not set - defined by PostgreSQL as 16 megabytes).

--- a/docs/src/samples/cluster-icu-localeprovider-initdb.yaml
+++ b/docs/src/samples/cluster-icu-localeprovider-initdb.yaml
@@ -1,0 +1,15 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: cluster-icu-localeprovider-initdb
+spec:
+  instances: 2
+
+  bootstrap:
+    initdb:
+      encoding: "UTF8"
+      localeProvider: "icu"
+      icuLocale: "und-x-icu"
+      icuRules: "&a < c < b < e < d"
+  storage:
+    size: 1Gi

--- a/pkg/specs/jobs.go
+++ b/pkg/specs/jobs.go
@@ -142,6 +142,12 @@ func buildInitDBFlags(cluster apiv1.Cluster) (initCommand []string) {
 	if localeCType := config.LocaleCType; localeCType != "" {
 		options = append(options, fmt.Sprintf("--lc-ctype=%s", localeCType))
 	}
+	if localeProvider := config.LocaleProvider; localeProvider != "" {
+		options = append(options, fmt.Sprintf("--locale-provider=%s", localeProvider))
+	}
+	if icuLocale := config.ICULocale; icuLocale != "" {
+		options = append(options, fmt.Sprintf("--icu-locale=%s", icuLocale))
+	}
 	if walSegmentSize := config.WalSegmentSize; walSegmentSize != 0 && utils.IsPowerOfTwo(walSegmentSize) {
 		options = append(options, fmt.Sprintf("--wal-segsize=%v", walSegmentSize))
 	}

--- a/tests/e2e/fixtures/initdb/cluster-icu-locale.yaml.template
+++ b/tests/e2e/fixtures/initdb/cluster-icu-locale.yaml.template
@@ -1,0 +1,34 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: p-icu-locale
+spec:
+  instances: 3
+
+  postgresql:
+    parameters:
+      work_mem: "8MB"
+      log_checkpoints: "on"
+      log_lock_waits: "on"
+      log_min_duration_statement: '1000'
+      log_statement: 'ddl'
+      log_temp_files: '1024'
+      log_autovacuum_min_duration: '1s'
+      log_replication_commands: 'on'
+    pg_hba:
+      - hostssl all all all cert
+
+  bootstrap:
+    initdb:
+      database: app
+      owner: app
+      encoding: UTF8
+      localeCollate: en_US.utf8
+      localeCType: en_US.utf8
+      localeProvider: icu
+      icuLocale: und-x-icu
+
+  # Persistent storage configuration
+  storage:
+    storageClass: ${E2E_DEFAULT_STORAGE_CLASS}
+    size: 1Gi


### PR DESCRIPTION
Postgres 15 introduced support for ICU locales.

This PR makes it possible to configure such locales via the initdb field of the cluster spec.