### PR TITLE
fix(plugin): restrict `cnpg destroy` job deletion to the specified namespace

### DIFF
--- a/internal/cmd/plugin/destroy/destroy.go
+++ b/internal/cmd/plugin/destroy/destroy.go
@@ -43,6 +43,7 @@ func Destroy(ctx context.Context, clusterName, instanceName string, keepPVC bool
 	if err := plugin.Client.List(
 		ctx,
 		&jobList,
+		client.InNamespace(plugin.Namespace),
 		client.MatchingLabels{
 			utils.InstanceNameLabelName: instanceName,
 		},


### PR DESCRIPTION
This update ensures the `destroy` command only deletes jobs within the targeted namespace, avoiding unintended deletions in other namespaces. Previously, the absence of a namespace clause could lead to jobs with matching names being deleted across different namespaces.

Closes: #5371 

# Release Notes

Fix `cnpg destroy` plugin command to ensure job deletion is limited to the specified namespace.