### PR TITLE
fix: ensure orphan services are reconciled after restoring a cluster

### DIFF
--- a/internal/controller/cluster_restore.go
+++ b/internal/controller/cluster_restore.go
@@ -114,11 +114,27 @@ func ensureOrphanServicesAreNotPresent(ctx context.Context, cli client.Client, c
 			return err
 		}
 	}
+
 	if cluster.IsReadServiceEnabled() {
 		if err := ensureOrphanServiceIsNotPresent(
 			ctx,
 			cli,
 			client.ObjectKey{Name: cluster.GetServiceReadName(), Namespace: cluster.Namespace},
+			cluster.Name,
+		); err != nil {
+			return err
+		}
+	}
+
+	managedServices, err := specs.BuildManagedServices(*cluster)
+	if err != nil {
+		return err
+	}
+	for idx := range managedServices {
+		if err := ensureOrphanServiceIsNotPresent(
+			ctx,
+			cli,
+			client.ObjectKey{Name: managedServices[idx].Name, Namespace: cluster.Namespace},
 			cluster.Name,
 		); err != nil {
 			return err

--- a/internal/controller/cluster_restore.go
+++ b/internal/controller/cluster_restore.go
@@ -137,7 +137,7 @@ func ensureOrphanServiceIsNotPresent(
 	contextLogger := log.FromContext(ctx).WithName("ensure_orphan_service_is_not_present")
 	var svc corev1.Service
 	err := cli.Get(ctx, objKey, &svc)
-	if !apierrs.IsNotFound(err) {
+	if apierrs.IsNotFound(err) {
 		return nil
 	}
 	if err != nil {

--- a/internal/controller/cluster_restore.go
+++ b/internal/controller/cluster_restore.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
@@ -79,6 +80,11 @@ func (r *ClusterReconciler) reconcileRestoredCluster(
 		return nil, err
 	}
 
+	contextLogger.Debug("proceeding to remove orphan services if present")
+	if err := ensureOrphanServicesAreNotPresent(ctx, r.Client, cluster); err != nil {
+		return nil, err
+	}
+
 	contextLogger.Debug("proceeding to restore the cluster status")
 	if err := restoreClusterStatus(ctx, r.Client, cluster, highestSerial, primarySerial); err != nil {
 		return nil, err
@@ -86,6 +92,65 @@ func (r *ClusterReconciler) reconcileRestoredCluster(
 
 	contextLogger.Debug("restored the cluster status, proceeding to restore the orphan PVCS")
 	return nil, restoreOrphanPVCs(ctx, r.Client, cluster, pvcs)
+}
+
+func ensureOrphanServicesAreNotPresent(ctx context.Context, cli client.Client, cluster *apiv1.Cluster) error {
+	if err := ensureOrphanServiceIsNotPresent(
+		ctx,
+		cli,
+		client.ObjectKey{Name: cluster.GetServiceReadWriteName(), Namespace: cluster.Namespace},
+	); err != nil {
+		return err
+	}
+
+	if cluster.IsReadOnlyServiceEnabled() {
+		if err := ensureOrphanServiceIsNotPresent(ctx, cli, client.ObjectKey{
+			Name:      cluster.GetServiceReadOnlyName(),
+			Namespace: cluster.Namespace,
+		}); err != nil {
+			return err
+		}
+	}
+	if cluster.IsReadServiceEnabled() {
+		if err := ensureOrphanServiceIsNotPresent(
+			ctx,
+			cli,
+			client.ObjectKey{Name: cluster.GetServiceReadName(), Namespace: cluster.Namespace},
+		); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func ensureOrphanServiceIsNotPresent(
+	ctx context.Context,
+	cli client.Client,
+	objKey client.ObjectKey,
+) error {
+	contextLogger := log.FromContext(ctx).WithName("ensure_orphan_service_is_not_present")
+	var svc corev1.Service
+	err := cli.Get(ctx, objKey, &svc)
+	if !apierrs.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	if len(svc.OwnerReferences) > 0 {
+		contextLogger.Error(err, "while trying to ensure orphan services are deleted",
+			"serviceName", svc.Name, "ownerReferences", svc.OwnerReferences,
+		)
+		return errors.New("service has owner references and it is not orphan")
+	}
+
+	if err := cli.Delete(ctx, &svc); err != nil && !apierrs.IsNotFound(err) {
+		return err
+	}
+
+	return nil
 }
 
 // ensureClusterRestoreCanStart is a function where the plugins can inject their custom logic to tell the

--- a/internal/controller/cluster_restore_test.go
+++ b/internal/controller/cluster_restore_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8client "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -297,5 +298,164 @@ var _ = Describe("getOrphanPVCs", func() {
 			Expect(pvc.OwnerReferences).ToNot(BeEmpty())
 			Expect(pvc.Annotations[utils.PVCStatusAnnotationName]).To(Equal(persistentvolumeclaim.StatusReady))
 		}
+	})
+})
+
+var _ = Describe("ensureOrphanServicesAreNotPresent", func() {
+	var (
+		mockCli k8client.Client
+		cluster *apiv1.Cluster
+	)
+
+	BeforeEach(func() {
+		cluster = &apiv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-cluster",
+				Namespace: "default",
+			},
+		}
+		mockCli = fake.NewClientBuilder().
+			WithScheme(k8scheme.BuildWithAllKnownScheme()).
+			WithObjects(cluster).
+			Build()
+	})
+
+	Context("when no orphan services are present", func() {
+		It("should not return an error", func(ctx SpecContext) {
+			err := ensureOrphanServicesAreNotPresent(ctx, mockCli, cluster)
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	Context("when orphan services are present", func() {
+		BeforeEach(func() {
+			svc := &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      cluster.GetServiceReadWriteName(),
+					Namespace: cluster.Namespace,
+				},
+			}
+			mockCli = fake.NewClientBuilder().
+				WithScheme(k8scheme.BuildWithAllKnownScheme()).
+				WithObjects(cluster, svc).
+				Build()
+		})
+
+		It("should delete the orphan services", func(ctx SpecContext) {
+			err := ensureOrphanServicesAreNotPresent(ctx, mockCli, cluster)
+			Expect(err).ToNot(HaveOccurred())
+
+			var svc corev1.Service
+			err = mockCli.Get(ctx,
+				k8client.ObjectKey{Name: cluster.GetServiceReadWriteName(), Namespace: cluster.Namespace},
+				&svc,
+			)
+			Expect(apierrs.IsNotFound(err)).To(BeTrue())
+		})
+
+		Context("when orphan read services are present", func() {
+			BeforeEach(func() {
+				svc := &corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      cluster.GetServiceReadName(),
+						Namespace: cluster.Namespace,
+					},
+				}
+				mockCli = fake.NewClientBuilder().
+					WithScheme(k8scheme.BuildWithAllKnownScheme()).
+					WithObjects(cluster, svc).
+					Build()
+			})
+
+			It("should delete the orphan read services", func(ctx SpecContext) {
+				err := ensureOrphanServicesAreNotPresent(ctx, mockCli, cluster)
+				Expect(err).ToNot(HaveOccurred())
+
+				var svc corev1.Service
+				err = mockCli.Get(ctx,
+					k8client.ObjectKey{Name: cluster.GetServiceReadName(), Namespace: cluster.Namespace},
+					&svc,
+				)
+				Expect(apierrs.IsNotFound(err)).To(BeTrue())
+			})
+		})
+
+		Context("when orphan read-only services are present", func() {
+			BeforeEach(func() {
+				svc := &corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      cluster.GetServiceReadOnlyName(),
+						Namespace: cluster.Namespace,
+					},
+				}
+				mockCli = fake.NewClientBuilder().
+					WithScheme(k8scheme.BuildWithAllKnownScheme()).
+					WithObjects(cluster, svc).
+					Build()
+			})
+
+			It("should delete the orphan read-only services", func(ctx SpecContext) {
+				err := ensureOrphanServicesAreNotPresent(ctx, mockCli, cluster)
+				Expect(err).ToNot(HaveOccurred())
+
+				var svc corev1.Service
+				err = mockCli.Get(ctx,
+					k8client.ObjectKey{Name: cluster.GetServiceReadOnlyName(), Namespace: cluster.Namespace},
+					&svc,
+				)
+				Expect(apierrs.IsNotFound(err)).To(BeTrue())
+			})
+		})
+	})
+
+	Context("when services have owner references", func() {
+		BeforeEach(func() {
+			svc := &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      cluster.GetServiceReadWriteName(),
+					Namespace: cluster.Namespace,
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Name:       "some-controller",
+							Kind:       "any-kind",
+							UID:        "3241",
+							APIVersion: "v1",
+						},
+					},
+				},
+			}
+			mockCli = fake.NewClientBuilder().
+				WithScheme(k8scheme.BuildWithAllKnownScheme()).
+				WithObjects(cluster, svc).
+				Build()
+		})
+
+		It("should return an error", func(ctx SpecContext) {
+			err := ensureOrphanServicesAreNotPresent(ctx, mockCli, cluster)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("service has owner references and it is not orphan"))
+		})
+	})
+
+	Context("when services are owned by the cluster", func() {
+		BeforeEach(func() {
+			svc := &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      cluster.GetServiceReadWriteName(),
+					Namespace: cluster.Namespace,
+				},
+			}
+			cluster.TypeMeta = metav1.TypeMeta{Kind: apiv1.ClusterKind, APIVersion: apiv1.GroupVersion.String()}
+			cluster.SetInheritedDataAndOwnership(&svc.ObjectMeta)
+			mockCli = fake.NewClientBuilder().
+				WithScheme(k8scheme.BuildWithAllKnownScheme()).
+				WithObjects(cluster, svc).
+				Build()
+		})
+
+		It("should not return an error", func(ctx SpecContext) {
+			err := ensureOrphanServicesAreNotPresent(ctx, mockCli, cluster)
+			Expect(err).ToNot(HaveOccurred())
+		})
 	})
 })


### PR DESCRIPTION
This patch ensures that the service manifests restored through a backup/restore tool are correctly reconciled and not left over as orphans. This is done by deleting the orphan services so they can be recreated with the proper ownership by the operator.

Before this patch, this caused an error because the reconcileRestoredCluster refused to reconcile services that the operator didn't own.

Closes #5373 

## Release Notes
After a cluster restoration, the operator recreates any enabled managed service with empty owerReference.