### PR TITLE
fix(instance): increase timeout to get cluster from Kubernetes API server

### DIFF
--- a/.wordlist-en-custom.txt
+++ b/.wordlist-en-custom.txt
@@ -822,7 +822,6 @@ ipcs
 ips
 isPrimary
 issuecomment
-istio
 italy
 jdbc
 jobCount

--- a/.wordlist-en-custom.txt
+++ b/.wordlist-en-custom.txt
@@ -822,6 +822,7 @@ ipcs
 ips
 isPrimary
 issuecomment
+istio
 italy
 jdbc
 jobCount

--- a/docs/src/troubleshooting.md
+++ b/docs/src/troubleshooting.md
@@ -787,3 +787,15 @@ For example:
 Please remember that you must have enough hugepages memory available to schedule
 every Pod in the Cluster (in the example above, at least 512MiB per Pod must be
 free).
+
+
+### Bootstrap job hangs in running status 
+
+If your Cluster's initialization job hangs in running status with a 
+"error while waiting for the API server to be reachable", you probably have network issue
+to the kubernetes api server, initialization job (same for most of jobs) need access kubernetes 
+api during running. Please check if the kubernetes api server is reachable. 
+
+Another possible reason is you have sidecar injection configured, sidecar like istio make network 
+temporarily un-available during startup. In this case, try avoid sidecar injecting for pods of such 
+jobs. 

--- a/docs/src/troubleshooting.md
+++ b/docs/src/troubleshooting.md
@@ -788,14 +788,15 @@ Please remember that you must have enough hugepages memory available to schedule
 every Pod in the Cluster (in the example above, at least 512MiB per Pod must be
 free).
 
+### Bootstrap job hangs in running status
 
-### Bootstrap job hangs in running status 
+If your Cluster's initialization job hangs while in `Running` status with the
+message:
+"error while waiting for the API server to be reachable", you probably have
+a network issue preventing communication with the Kubernetes API server.
+Initialization jobs (like most of jobs) need to access the Kubernetes
+API. Please check your networking.
 
-If your Cluster's initialization job hangs in running status with a 
-"error while waiting for the API server to be reachable", you probably have network issue
-to the kubernetes api server, initialization job (same for most of jobs) need access kubernetes 
-api during running. Please check if the kubernetes api server is reachable. 
-
-Another possible reason is you have sidecar injection configured, sidecar like istio make network 
-temporarily un-available during startup. In this case, try avoid sidecar injecting for pods of such 
-jobs. 
+Another possible cause is when you have sidecar injection configured. Sidecars
+such as Istio may make the network temporarily unavailable during startup. If
+you have sidecar injection enabled, retry with injection disabled.

--- a/internal/cmd/manager/instance/initdb/cmd.go
+++ b/internal/cmd/manager/instance/initdb/cmd.go
@@ -53,7 +53,7 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use: "init [options]",
 		PreRunE: func(cmd *cobra.Command, _ []string) error {
-			return management.WaitKubernetesAPIServer(cmd.Context(), ctrl.ObjectKey{
+			return management.WaitForGetCluster(cmd.Context(), ctrl.ObjectKey{
 				Name:      clusterName,
 				Namespace: namespace,
 			})

--- a/internal/cmd/manager/instance/join/cmd.go
+++ b/internal/cmd/manager/instance/join/cmd.go
@@ -46,7 +46,7 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use: "join [options]",
 		PreRunE: func(cmd *cobra.Command, _ []string) error {
-			return management.WaitKubernetesAPIServer(cmd.Context(), ctrl.ObjectKey{
+			return management.WaitForGetCluster(cmd.Context(), ctrl.ObjectKey{
 				Name:      clusterName,
 				Namespace: namespace,
 			})

--- a/internal/cmd/manager/instance/pgbasebackup/cmd.go
+++ b/internal/cmd/manager/instance/pgbasebackup/cmd.go
@@ -52,7 +52,7 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use: "pgbasebackup",
 		PreRunE: func(cmd *cobra.Command, _ []string) error {
-			return management.WaitKubernetesAPIServer(cmd.Context(), ctrl.ObjectKey{
+			return management.WaitForGetCluster(cmd.Context(), ctrl.ObjectKey{
 				Name:      clusterName,
 				Namespace: namespace,
 			})

--- a/internal/cmd/manager/instance/restore/cmd.go
+++ b/internal/cmd/manager/instance/restore/cmd.go
@@ -45,7 +45,7 @@ func NewCmd() *cobra.Command {
 		Use:           "restore [flags]",
 		SilenceErrors: true,
 		PreRunE: func(cmd *cobra.Command, _ []string) error {
-			return management.WaitKubernetesAPIServer(cmd.Context(), ctrl.ObjectKey{
+			return management.WaitForGetCluster(cmd.Context(), ctrl.ObjectKey{
 				Name:      clusterName,
 				Namespace: namespace,
 			})

--- a/internal/cmd/manager/instance/restoresnapshot/cmd.go
+++ b/internal/cmd/manager/instance/restoresnapshot/cmd.go
@@ -48,7 +48,7 @@ func NewCmd() *cobra.Command {
 		Use:           "restoresnapshot [flags]",
 		SilenceErrors: true,
 		PreRunE: func(cmd *cobra.Command, _ []string) error {
-			return management.WaitKubernetesAPIServer(cmd.Context(), ctrl.ObjectKey{
+			return management.WaitForGetCluster(cmd.Context(), ctrl.ObjectKey{
 				Name:      clusterName,
 				Namespace: namespace,
 			})

--- a/internal/cmd/manager/instance/run/cmd.go
+++ b/internal/cmd/manager/instance/run/cmd.go
@@ -81,7 +81,7 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use: "run [flags]",
 		PreRunE: func(cmd *cobra.Command, _ []string) error {
-			return management.WaitKubernetesAPIServer(cmd.Context(), client.ObjectKey{
+			return management.WaitForGetCluster(cmd.Context(), client.ObjectKey{
 				Name:      clusterName,
 				Namespace: namespace,
 			})

--- a/pkg/management/client.go
+++ b/pkg/management/client.go
@@ -147,7 +147,6 @@ func WaitKubernetesAPIServer(ctx context.Context, clusterObjectKey client.Object
 		}
 		return nil
 	})
-
 	if err != nil {
 		const message = "error while waiting for the API server to be reachable"
 		logger.Error(err, message)

--- a/pkg/management/client.go
+++ b/pkg/management/client.go
@@ -132,7 +132,7 @@ func NewEventRecorder() (record.EventRecorder, error) {
 // WaitKubernetesAPIServer will wait for the kubernetes API server to by ready.
 // Returns any error if it can't be reached.
 func WaitKubernetesAPIServer(ctx context.Context, clusterObjectKey client.ObjectKey) error {
-	logger := log.FromContext(ctx).WithName("kube-api-server-check")
+	logger := log.FromContext(ctx).WithName("wait-kubernetes-api-server")
 
 	cli, err := NewControllerRuntimeClient()
 	if err != nil {
@@ -142,7 +142,7 @@ func WaitKubernetesAPIServer(ctx context.Context, clusterObjectKey client.Object
 
 	err = retry.OnError(readinessCheckRetry, resources.RetryAlways, func() error {
 		if err := cli.Get(ctx, clusterObjectKey, &apiv1.Cluster{}); err != nil {
-			logger.Warning("The API server is currently unreachable. Will wait and retry")
+			logger.Warning("Encountered an error while executing get cluster. Will wait and retry", "error", err.Error())
 			return err
 		}
 		return nil

--- a/pkg/management/client.go
+++ b/pkg/management/client.go
@@ -129,10 +129,10 @@ func NewEventRecorder() (record.EventRecorder, error) {
 	return recorder, nil
 }
 
-// WaitKubernetesAPIServer will wait for the kubernetes API server to by ready.
-// Returns any error if it can't be reached.
-func WaitKubernetesAPIServer(ctx context.Context, clusterObjectKey client.ObjectKey) error {
-	logger := log.FromContext(ctx).WithName("wait-kubernetes-api-server")
+// WaitForGetCluster will wait for a successful get cluster to be executed.
+// Returns any error encountered.
+func WaitForGetCluster(ctx context.Context, clusterObjectKey client.ObjectKey) error {
+	logger := log.FromContext(ctx).WithName("wait-for-get-cluster")
 
 	cli, err := NewControllerRuntimeClient()
 	if err != nil {

--- a/pkg/management/client.go
+++ b/pkg/management/client.go
@@ -49,8 +49,8 @@ var (
 	// readinessCheckRetry is used to wait until the API server is reachable
 	readinessCheckRetry = wait.Backoff{
 		Steps:    5,
-		Duration: 10 * time.Millisecond,
-		Factor:   5.0,
+		Duration: 1 * time.Second,
+		Factor:   3.0,
 		Jitter:   0.1,
 	}
 )
@@ -141,6 +141,7 @@ func WaitKubernetesAPIServer(ctx context.Context, clusterObjectKey client.Object
 	}
 
 	if err := retry.OnError(readinessCheckRetry, resources.RetryAlways, func() (err error) {
+		logger.Info("attempting to reach the API server ...")
 		return cli.Get(ctx, clusterObjectKey, &apiv1.Cluster{})
 	}); err != nil {
 		const message = "error while waiting for the API server to be reachable"

--- a/pkg/management/client.go
+++ b/pkg/management/client.go
@@ -140,9 +140,9 @@ func WaitKubernetesAPIServer(ctx context.Context, clusterObjectKey client.Object
 		return err
 	}
 
-	err = retry.OnError(readinessCheckRetry, resources.RetryAlways, func() (err error) {
-		if err = cli.Get(ctx, clusterObjectKey, &apiv1.Cluster{}); err != nil {
-			logger.Info("The api server is currently unreachable, will wait and retry later")
+	err = retry.OnError(readinessCheckRetry, resources.RetryAlways, func() error {
+		if err := cli.Get(ctx, clusterObjectKey, &apiv1.Cluster{}); err != nil {
+			logger.Warning("The API server is currently unreachable. Will wait and retry")
 			return err
 		}
 		return nil


### PR DESCRIPTION
Increase the timeout for retrieving the cluster resource from the Kubernetes API server, improving reliability in cases of longer startup times, such as when Istio sidecar injection is enabled. This adjustment improves robustness and allows more time for the sidecar to become ready.

Closes #5382 

# Release notes

Increased timeout during instance startup for retrieving cluster resources, improving reliability in environments with longer startup times, such as with Istio sidecar injection.