### PR TITLE
feat: spread Pod rollout

### DIFF
--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -496,6 +496,10 @@ const (
 	// PhaseUpgrade upgrade in process
 	PhaseUpgrade = "Upgrading cluster"
 
+	// PhaseUpgradeDelayed is set when a cluster need to be upgraded
+	// but the operation is being delayed by the operator configuration
+	PhaseUpgradeDelayed = "Cluster upgrade delayed"
+
 	// PhaseWaitingForUser set the status to wait for an action from the user
 	PhaseWaitingForUser = "Waiting for user action"
 

--- a/docs/src/installation_upgrade.md
+++ b/docs/src/installation_upgrade.md
@@ -152,13 +152,14 @@ by applying the manifest of the newer version for plain Kubernetes
 installations, or using the native package manager of the used distribution
 (please follow the instructions in the above sections).
 
-The second step is automatically executed after having updated the controller,
-by default triggering a rolling update of every deployed PostgreSQL instance to
-use the new instance manager. The rolling update procedure culminates with a
-switchover, which is controlled by the `primaryUpdateStrategy` option, by
-default set to `unsupervised`. When set to `supervised`, users need to complete
-the rolling update by manually promoting a new instance through the `cnpg`
-plugin for `kubectl`.
+
+The second step is automatically triggered after updating the controller. By
+default, this initiates a rolling update of every deployed PostgreSQL cluster,
+upgrading one instance at a time to use the new instance manager. The rolling
+update concludes with a switchover, which is governed by the
+`primaryUpdateStrategy` option. The default value, `unsupervised`, completes
+the switchover automatically. If set to `supervised`, the user must manually
+promote the new primary instance using the `cnpg` plugin for `kubectl`.
 
 !!! Seealso "Rolling updates"
     This process is discussed in-depth on the [Rolling Updates](rolling_update.md) page.
@@ -172,6 +173,21 @@ The default rolling update behavior can be replaced with in-place updates of
 the instance manager. This approach does not require a restart of the
 PostgreSQL instance, thereby avoiding a switchover within the cluster. This
 feature, which is disabled by default, is described in detail below.
+
+## Spread Upgrades
+
+By default, all PostgreSQL clusters are rolled out simultaneously, which may
+lead to a spike in resource usage, especially when managing multiple clusters.
+CloudNativePG provides two configuration options at the [operator level](operator_conf.md)
+that allow you to introduce delays between cluster rollouts or even between
+instances within the same cluster, helping to distribute resource usage over
+time:
+
+- `CLUSTERS_ROLLOUT_DELAY`: Defines the number of seconds to wait between
+  rollouts of different PostgreSQL clusters (default: `0`).
+- `INSTANCES_ROLLOUT_DELAY`: Defines the number of seconds to wait between
+  rollouts of individual instances within the same PostgreSQL cluster (default:
+  `0`).
 
 ### In-place updates of the instance manager
 

--- a/docs/src/installation_upgrade.md
+++ b/docs/src/installation_upgrade.md
@@ -179,14 +179,14 @@ feature, which is disabled by default, is described in detail below.
 By default, all PostgreSQL clusters are rolled out simultaneously, which may
 lead to a spike in resource usage, especially when managing multiple clusters.
 CloudNativePG provides two configuration options at the [operator level](operator_conf.md)
-that allow you to introduce delays between cluster rollouts or even between
+that allow you to introduce delays between cluster roll-outs or even between
 instances within the same cluster, helping to distribute resource usage over
 time:
 
 - `CLUSTERS_ROLLOUT_DELAY`: Defines the number of seconds to wait between
-  rollouts of different PostgreSQL clusters (default: `0`).
+  roll-outs of different PostgreSQL clusters (default: `0`).
 - `INSTANCES_ROLLOUT_DELAY`: Defines the number of seconds to wait between
-  rollouts of individual instances within the same PostgreSQL cluster (default:
+  roll-outs of individual instances within the same PostgreSQL cluster (default:
   `0`).
 
 ### In-place updates of the instance manager

--- a/docs/src/installation_upgrade.md
+++ b/docs/src/installation_upgrade.md
@@ -174,7 +174,7 @@ the instance manager. This approach does not require a restart of the
 PostgreSQL instance, thereby avoiding a switchover within the cluster. This
 feature, which is disabled by default, is described in detail below.
 
-## Spread Upgrades
+### Spread Upgrades
 
 By default, all PostgreSQL clusters are rolled out simultaneously, which may
 lead to a spike in resource usage, especially when managing multiple clusters.

--- a/docs/src/operator_capability_levels.md
+++ b/docs/src/operator_capability_levels.md
@@ -75,7 +75,7 @@ of the CloudNativePG deployment in your Kubernetes infrastructure.
 ### Self-contained instance manager
 
 Instead of relying on an external tool to
-coordinate PostgreSQL instances in the Kubernetes cluster pods, 
+coordinate PostgreSQL instances in the Kubernetes cluster pods,
 such as Patroni or Stolon, the operator
 injects the operator executable inside each pod, in a file named
 `/controller/manager`. The application is used to control the underlying
@@ -223,7 +223,7 @@ includes integration with cert-manager.
 
 ### Certificate authentication for streaming replication
 
-To authorize streaming replication connections from the standby servers, 
+To authorize streaming replication connections from the standby servers,
 the operator relies on TLS client certificate authentication. This method is used
 instead of relying on a password (and therefore a secret).
 
@@ -285,16 +285,20 @@ workload, in this case PostgreSQL servers. This includes PostgreSQL minor
 release updates (security and bug fixes normally) as well as major online
 upgrades.
 
-### Upgrade of the operator
+### Operator Upgrade
 
-You can upgrade the operator seamlessly as a new deployment. Because of the instance
-manager's injection, a change in the
-operator doesn't require a change in the operand. 
-The operator can manage older versions of the operand.
+Upgrading the operator is seamless and can be done as a new deployment. After
+upgrading the controller, a rolling update of all deployed PostgreSQL clusters
+is initiated. You can choose to update all clusters simultaneously or
+distribute their upgrades over time.
 
-CloudNativePG also supports [in-place updates of the instance manager](installation_upgrade.md#in-place-updates-of-the-instance-manager)
-following an upgrade of the operator. In-place updates don't require a rolling
-update (and subsequent switchover) of the cluster.
+Thanks to the instance manager's injection, upgrading the operator does not
+require changes to the operand, allowing the operator to manage older versions
+of it.
+
+Additionally, CloudNativePG supports [in-place updates of the instance manager](installation_upgrade.md#in-place-updates-of-the-instance-manager)
+following an operator upgrade. In-place updates do not require a rolling update
+or a subsequent switchover of the cluster.
 
 ### Upgrade of the managed workload
 
@@ -355,8 +359,8 @@ user action. The operator transparently sets
 the `archive_command` to rely on `barman-cloud-wal-archive` to ship WAL
 files to the defined endpoint. You can decide the compression algorithm,
 as well as the number of parallel jobs to concurrently upload WAL files
-in the archive. In addition, `Instance Manager` checks 
-the correctness of the archive destination by performing the `barman-cloud-check-wal-archive` 
+in the archive. In addition, `Instance Manager` checks
+the correctness of the archive destination by performing the `barman-cloud-check-wal-archive`
 command before beginning to ship the first set of WAL files.
 
 ### PostgreSQL backups
@@ -373,7 +377,7 @@ Base backups can be saved on:
 Base backups are defined at the cluster level, declaratively,
 through the `backup` parameter in the cluster definition.
 
-You can define base backups in two ways: 
+You can define base backups in two ways:
 
 - On-demand, through the `Backup` custom resource definition
 - Scheduled, through the `ScheduledBackup`custom resource definition, using a cron-like syntax

--- a/docs/src/operator_conf.md
+++ b/docs/src/operator_conf.md
@@ -36,7 +36,7 @@ The operator looks for the following environment variables to be defined in the 
 Name | Description
 ---- | -----------
 `CERTIFICATE_DURATION` | Determines the lifetime of the generated certificates in days. Default is 90.
-`CLUSTERS_ROLLOUT_DELAY` | The duration (in seconds) to wait between the rollouts of different clusters during an operator upgrade. This setting controls the timing of upgrades across clusters, spreading them out to reduce system impact. The default value is `0` which means no delay between PostgreSQL cluster upgrades.
+`CLUSTERS_ROLLOUT_DELAY` | The duration (in seconds) to wait between the roll-outs of different clusters during an operator upgrade. This setting controls the timing of upgrades across clusters, spreading them out to reduce system impact. The default value is `0` which means no delay between PostgreSQL cluster upgrades.
 `CREATE_ANY_SERVICE` | When set to `true`, will create `-any` service for the cluster. Default is `false`
 `ENABLE_AZURE_PVC_UPDATES` | Enables to delete Postgres pod if its PVC is stuck in Resizing condition. This feature is mainly for the Azure environment (default `false`)
 `ENABLE_INSTANCE_MANAGER_INPLACE_UPDATES` | When set to `true`, enables in-place updates of the instance manager after an update of the operator, avoiding rolling updates of the cluster (default `false`)
@@ -44,7 +44,7 @@ Name | Description
 `INCLUDE_PLUGINS` | A comma-separated list of plugins to be always included in the Cluster's reconciliation.
 `INHERITED_ANNOTATIONS` | List of annotation names that, when defined in a `Cluster` metadata, will be inherited by all the generated resources, including pods
 `INHERITED_LABELS` | List of label names that, when defined in a `Cluster` metadata, will be inherited by all the generated resources, including pods
-`INSTANCES_ROLLOUT_DELAY` | The duration (in seconds) to wait between rollouts of individual PostgreSQL instances within the same cluster during an operator upgrade. The default value is `0`, meaning no delay between upgrades of instances in the same PostgreSQL cluster.
+`INSTANCES_ROLLOUT_DELAY` | The duration (in seconds) to wait between roll-outs of individual PostgreSQL instances within the same cluster during an operator upgrade. The default value is `0`, meaning no delay between upgrades of instances in the same PostgreSQL cluster.
 `MONITORING_QUERIES_CONFIGMAP` | The name of a ConfigMap in the operator's namespace with a set of default queries (to be specified under the key `queries`) to be applied to all created Clusters
 `MONITORING_QUERIES_SECRET` | The name of a Secret in the operator's namespace with a set of default queries (to be specified under the key `queries`) to be applied to all created Clusters
 `PULL_SECRET_NAME` | Name of an additional pull secret to be defined in the operator's namespace and to be used to download images
@@ -162,7 +162,7 @@ Then on the edit page scroll down the container args and add `--pprof-server=tru
         - /manager
 ```
 
-Save the changes, the deployment now will execute a rollout and the new pod will have the PPROF server enabled.
+Save the changes, the deployment now will execute a roll-out and the new pod will have the PPROF server enabled.
 
 Once the pod is running you can exec inside the container by doing:
 

--- a/docs/src/operator_conf.md
+++ b/docs/src/operator_conf.md
@@ -35,17 +35,19 @@ The operator looks for the following environment variables to be defined in the 
 
 Name | Description
 ---- | -----------
-`INHERITED_ANNOTATIONS` | list of annotation names that, when defined in a `Cluster` metadata, will be inherited by all the generated resources, including pods
-`INHERITED_LABELS` | list of label names that, when defined in a `Cluster` metadata, will be inherited by all the generated resources, including pods
-`PULL_SECRET_NAME` | name of an additional pull secret to be defined in the operator's namespace and to be used to download images
+`CERTIFICATE_DURATION` | Determines the lifetime of the generated certificates in days. Default is 90.
+`CLUSTERS_ROLLOUT_DELAY` | The duration (in seconds) to wait between the rollouts of different clusters during an operator upgrade. This setting controls the timing of upgrades across clusters, spreading them out to reduce system impact. The default value is `0` which means no delay between PostgreSQL cluster upgrades.
+`CREATE_ANY_SERVICE` | When set to `true`, will create `-any` service for the cluster. Default is `false`
 `ENABLE_AZURE_PVC_UPDATES` | Enables to delete Postgres pod if its PVC is stuck in Resizing condition. This feature is mainly for the Azure environment (default `false`)
-`ENABLE_INSTANCE_MANAGER_INPLACE_UPDATES` | when set to `true`, enables in-place updates of the instance manager after an update of the operator, avoiding rolling updates of the cluster (default `false`)
+`ENABLE_INSTANCE_MANAGER_INPLACE_UPDATES` | When set to `true`, enables in-place updates of the instance manager after an update of the operator, avoiding rolling updates of the cluster (default `false`)
+`EXPIRING_CHECK_THRESHOLD` | Determines the threshold, in days, for identifying a certificate as expiring. Default is 7. 
+`INCLUDE_PLUGINS` | A comma-separated list of plugins to be always included in the Cluster's reconciliation.
+`INHERITED_ANNOTATIONS` | List of annotation names that, when defined in a `Cluster` metadata, will be inherited by all the generated resources, including pods
+`INHERITED_LABELS` | List of label names that, when defined in a `Cluster` metadata, will be inherited by all the generated resources, including pods
+`INSTANCES_ROLLOUT_DELAY` | The duration (in seconds) to wait between rollouts of individual PostgreSQL instances within the same cluster during an operator upgrade. The default value is `0`, meaning no delay between upgrades of instances in the same PostgreSQL cluster.
 `MONITORING_QUERIES_CONFIGMAP` | The name of a ConfigMap in the operator's namespace with a set of default queries (to be specified under the key `queries`) to be applied to all created Clusters
 `MONITORING_QUERIES_SECRET` | The name of a Secret in the operator's namespace with a set of default queries (to be specified under the key `queries`) to be applied to all created Clusters
-`CERTIFICATE_DURATION` | Determines the lifetime of the generated certificates in days. Default is 90.
-`EXPIRING_CHECK_THRESHOLD` | Determines the threshold, in days, for identifying a certificate as expiring. Default is 7. 
-`CREATE_ANY_SERVICE` | when set to `true`, will create `-any` service for the cluster. Default is `false`
-`INCLUDE_PLUGINS` | A comma-separated list of plugins to be always included in the Cluster's reconciliation.
+`PULL_SECRET_NAME` | Name of an additional pull secret to be defined in the operator's namespace and to be used to download images
 
 Values in `INHERITED_ANNOTATIONS` and `INHERITED_LABELS` support path-like wildcards. For example, the value `example.com/*` will match
 both the value `example.com/one` and `example.com/two`.

--- a/docs/src/operator_conf.md
+++ b/docs/src/operator_conf.md
@@ -76,11 +76,11 @@ metadata:
   name: cnpg-controller-manager-config
   namespace: cnpg-system
 data:
-  CLUSTERS_ROLLOUT_DELAY: 60
-  INSTANCES_ROLLOUT_DELAY: 10
+  CLUSTERS_ROLLOUT_DELAY: '60'
   ENABLE_INSTANCE_MANAGER_INPLACE_UPDATES: 'true'
   INHERITED_ANNOTATIONS: categories
   INHERITED_LABELS: environment, workload, app
+  INSTANCES_ROLLOUT_DELAY: '10'
 ```
 
 ## Defining an operator secret
@@ -100,11 +100,11 @@ metadata:
   namespace: cnpg-system
 type: Opaque
 stringData:
-  CLUSTERS_ROLLOUT_DELAY: 60
-  INSTANCES_ROLLOUT_DELAY: 10
+  CLUSTERS_ROLLOUT_DELAY: '60'
   ENABLE_INSTANCE_MANAGER_INPLACE_UPDATES: 'true'
   INHERITED_ANNOTATIONS: categories
   INHERITED_LABELS: environment, workload, app
+  INSTANCES_ROLLOUT_DELAY: '10'
 ```
 
 ## Restarting the operator to reload configs

--- a/docs/src/operator_conf.md
+++ b/docs/src/operator_conf.md
@@ -64,9 +64,10 @@ will ignore the configuration parameter.
 
 The example below customizes the behavior of the operator, by defining
 the label/annotation names to be inherited by the resources created by
-any `Cluster` object that is deployed at a later time, and by enabling
+any `Cluster` object that is deployed at a later time, by enabling
 [in-place updates for the instance
-manager](installation_upgrade.md#in-place-updates-of-the-instance-manager).
+manager](installation_upgrade.md#in-place-updates-of-the-instance-manager),
+and by spreading upgrades.
 
 ```yaml
 apiVersion: v1
@@ -75,9 +76,11 @@ metadata:
   name: cnpg-controller-manager-config
   namespace: cnpg-system
 data:
+  CLUSTERS_ROLLOUT_DELAY: 60
+  INSTANCES_ROLLOUT_DELAY: 10
+  ENABLE_INSTANCE_MANAGER_INPLACE_UPDATES: 'true'
   INHERITED_ANNOTATIONS: categories
   INHERITED_LABELS: environment, workload, app
-  ENABLE_INSTANCE_MANAGER_INPLACE_UPDATES: 'true'
 ```
 
 ## Defining an operator secret
@@ -86,7 +89,8 @@ The example below customizes the behavior of the operator, by defining
 the label/annotation names to be inherited by the resources created by
 any `Cluster` object that is deployed at a later time, and by enabling
 [in-place updates for the instance
-manager](installation_upgrade.md#in-place-updates-of-the-instance-manager).
+manager](installation_upgrade.md#in-place-updates-of-the-instance-manager),
+and by spreading upgrades.
 
 ```yaml
 apiVersion: v1
@@ -96,9 +100,11 @@ metadata:
   namespace: cnpg-system
 type: Opaque
 stringData:
+  CLUSTERS_ROLLOUT_DELAY: 60
+  INSTANCES_ROLLOUT_DELAY: 10
+  ENABLE_INSTANCE_MANAGER_INPLACE_UPDATES: 'true'
   INHERITED_ANNOTATIONS: categories
   INHERITED_LABELS: environment, workload, app
-  ENABLE_INSTANCE_MANAGER_INPLACE_UPDATES: 'true'
 ```
 
 ## Restarting the operator to reload configs

--- a/internal/configuration/configuration.go
+++ b/internal/configuration/configuration.go
@@ -21,6 +21,7 @@ package configuration
 import (
 	"path"
 	"strings"
+	"time"
 
 	"github.com/cloudnative-pg/machinery/pkg/log"
 
@@ -108,6 +109,12 @@ type Data struct {
 	// the <cluster-name>-any service. Defaults to false.
 	CreateAnyService bool `json:"createAnyService" env:"CREATE_ANY_SERVICE"`
 
+	// The amount of time to wait between rollouts of different clusters in seconds
+	ClustersRolloutDelay int `json:"clustersRolloutDelay" env:"CLUSTERS_ROLLOUT_DELAY"`
+
+	// The amount of time to wait between rollouts of instances of the same cluster in seconds
+	InstancesRolloutDelay int `json:"instancesRolloutDelay" env:"INSTANCES_ROLLOUT_DELAY"`
+
 	// IncludePlugins is a comma-separated list of plugins to always be
 	// included in the Cluster reconciliation
 	IncludePlugins string `json:"includePlugins" env:"INCLUDE_PLUGINS"`
@@ -152,6 +159,17 @@ func (config *Data) IsAnnotationInherited(name string) bool {
 // be inherited from the Cluster specification to the generated objects
 func (config *Data) IsLabelInherited(name string) bool {
 	return evaluateGlobPatterns(config.InheritedLabels, name)
+}
+
+// GetClustersRolloutDelay gets the delay between rollouts of different clusters
+func (config *Data) GetClustersRolloutDelay() time.Duration {
+	return time.Duration(config.ClustersRolloutDelay) * time.Second
+}
+
+// GetInstancesRolloutDelay gets the delay between rollouts of pods belonging
+// to the same cluster
+func (config *Data) GetInstancesRolloutDelay() time.Duration {
+	return time.Duration(config.InstancesRolloutDelay) * time.Second
 }
 
 // WatchedNamespaces get the list of additional watched namespaces.

--- a/internal/configuration/configuration.go
+++ b/internal/configuration/configuration.go
@@ -109,10 +109,17 @@ type Data struct {
 	// the <cluster-name>-any service. Defaults to false.
 	CreateAnyService bool `json:"createAnyService" env:"CREATE_ANY_SERVICE"`
 
-	// The amount of time to wait between rollouts of different clusters in seconds
+	// The duration (in seconds) to wait between the rollouts of different
+	// clusters during an operator upgrade. This setting controls the
+	// timing of upgrades across clusters, spreading them out to reduce
+	// system impact. The default value is 0, which means no delay between
+	// PostgreSQL cluster upgrades.
 	ClustersRolloutDelay int `json:"clustersRolloutDelay" env:"CLUSTERS_ROLLOUT_DELAY"`
 
-	// The amount of time to wait between rollouts of instances of the same cluster in seconds
+	// The duration (in seconds) to wait between rollouts of individual
+	// PostgreSQL instances within the same cluster during an operator
+	// upgrade. The default value is 0, meaning no delay between upgrades
+	// of instances in the same PostgreSQL cluster.
 	InstancesRolloutDelay int `json:"instancesRolloutDelay" env:"INSTANCES_ROLLOUT_DELAY"`
 
 	// IncludePlugins is a comma-separated list of plugins to always be

--- a/internal/configuration/configuration.go
+++ b/internal/configuration/configuration.go
@@ -109,14 +109,14 @@ type Data struct {
 	// the <cluster-name>-any service. Defaults to false.
 	CreateAnyService bool `json:"createAnyService" env:"CREATE_ANY_SERVICE"`
 
-	// The duration (in seconds) to wait between the rollouts of different
+	// The duration (in seconds) to wait between the roll-outs of different
 	// clusters during an operator upgrade. This setting controls the
 	// timing of upgrades across clusters, spreading them out to reduce
 	// system impact. The default value is 0, which means no delay between
 	// PostgreSQL cluster upgrades.
 	ClustersRolloutDelay int `json:"clustersRolloutDelay" env:"CLUSTERS_ROLLOUT_DELAY"`
 
-	// The duration (in seconds) to wait between rollouts of individual
+	// The duration (in seconds) to wait between roll-outs of individual
 	// PostgreSQL instances within the same cluster during an operator
 	// upgrade. The default value is 0, meaning no delay between upgrades
 	// of instances in the same PostgreSQL cluster.
@@ -168,12 +168,12 @@ func (config *Data) IsLabelInherited(name string) bool {
 	return evaluateGlobPatterns(config.InheritedLabels, name)
 }
 
-// GetClustersRolloutDelay gets the delay between rollouts of different clusters
+// GetClustersRolloutDelay gets the delay between roll-outs of different clusters
 func (config *Data) GetClustersRolloutDelay() time.Duration {
 	return time.Duration(config.ClustersRolloutDelay) * time.Second
 }
 
-// GetInstancesRolloutDelay gets the delay between rollouts of pods belonging
+// GetInstancesRolloutDelay gets the delay between roll-outs of pods belonging
 // to the same cluster
 func (config *Data) GetInstancesRolloutDelay() time.Duration {
 	return time.Duration(config.InstancesRolloutDelay) * time.Second

--- a/internal/configuration/configuration_test.go
+++ b/internal/configuration/configuration_test.go
@@ -153,9 +153,9 @@ var _ = Describe("Annotation and label inheritance", func() {
 		Expect(config.GetClustersRolloutDelay()).To(Equal(10 * time.Second))
 	})
 
-	It("returns zero delay for clusters rollout when not set", func() {
+	It("returns zero as default delay for clusters rollout when not set", func() {
 		config := Data{}
-		Expect(config.GetClustersRolloutDelay()).To(Equal(0 * time.Second))
+		Expect(config.GetClustersRolloutDelay()).To(BeZero())
 	})
 
 	It("returns correct delay for instances rollout", func() {
@@ -163,8 +163,8 @@ var _ = Describe("Annotation and label inheritance", func() {
 		Expect(config.GetInstancesRolloutDelay()).To(Equal(5 * time.Second))
 	})
 
-	It("returns zero delay for instances rollout when not set", func() {
+	It("returns zero as default delay for instances rollout when not set", func() {
 		config := Data{}
-		Expect(config.GetInstancesRolloutDelay()).To(Equal(0 * time.Second))
+		Expect(config.GetInstancesRolloutDelay()).To(BeZero())
 	})
 })

--- a/internal/configuration/configuration_test.go
+++ b/internal/configuration/configuration_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package configuration
 
 import (
+	"time"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -144,5 +146,25 @@ var _ = Describe("Annotation and label inheritance", func() {
 				IncludePlugins: "a,,,b , c",
 			}).GetIncludePlugins()).To(ContainElements("a", "b", "c"))
 		})
+	})
+
+	It("returns correct delay for clusters rollout", func() {
+		config := Data{ClustersRolloutDelay: 10}
+		Expect(config.GetClustersRolloutDelay()).To(Equal(10 * time.Second))
+	})
+
+	It("returns zero delay for clusters rollout when not set", func() {
+		config := Data{}
+		Expect(config.GetClustersRolloutDelay()).To(Equal(0 * time.Second))
+	})
+
+	It("returns correct delay for instances rollout", func() {
+		config := Data{InstancesRolloutDelay: 5}
+		Expect(config.GetInstancesRolloutDelay()).To(Equal(5 * time.Second))
+	})
+
+	It("returns zero delay for instances rollout when not set", func() {
+		config := Data{}
+		Expect(config.GetInstancesRolloutDelay()).To(Equal(0 * time.Second))
 	})
 })

--- a/internal/controller/cluster_upgrade_test.go
+++ b/internal/controller/cluster_upgrade_test.go
@@ -81,6 +81,8 @@ var _ = Describe("Pod upgrade", Ordered, func() {
 		rollout := isInstanceNeedingRollout(ctx, status, &cluster)
 		Expect(rollout.required).To(BeTrue())
 		Expect(rollout.reason).To(BeEquivalentTo("the instance is using a different image: postgres:13.10 -> postgres:13.11"))
+		Expect(rollout.needsChangeOperandImage).To(BeTrue())
+		Expect(rollout.needsChangeOperatorImage).To(BeFalse())
 	})
 
 	It("requires rollout when a restart annotation has been added to the cluster", func(ctx SpecContext) {
@@ -99,6 +101,8 @@ var _ = Describe("Pod upgrade", Ordered, func() {
 		Expect(rollout.required).To(BeTrue())
 		Expect(rollout.reason).To(Equal("cluster has been explicitly restarted via annotation"))
 		Expect(rollout.canBeInPlace).To(BeTrue())
+		Expect(rollout.needsChangeOperandImage).To(BeFalse())
+		Expect(rollout.needsChangeOperatorImage).To(BeFalse())
 
 		rollout = isInstanceNeedingRollout(ctx, status, &cluster)
 		Expect(rollout.required).To(BeFalse())
@@ -157,6 +161,8 @@ var _ = Describe("Pod upgrade", Ordered, func() {
 		rollout = isInstanceNeedingRollout(ctx, status, &cluster)
 		Expect(rollout.required).To(BeTrue())
 		Expect(rollout.reason).To(Equal("Postgres needs a restart to apply some configuration changes"))
+		Expect(rollout.needsChangeOperandImage).To(BeFalse())
+		Expect(rollout.needsChangeOperatorImage).To(BeFalse())
 	})
 
 	It("requires pod rollout if executable does not have a hash", func(ctx SpecContext) {
@@ -170,6 +176,8 @@ var _ = Describe("Pod upgrade", Ordered, func() {
 		Expect(rollout.required).To(BeTrue())
 		Expect(rollout.reason).To(Equal("pod 'test-1' is not reporting the executable hash"))
 		Expect(rollout.canBeInPlace).To(BeFalse())
+		Expect(rollout.needsChangeOperandImage).To(BeFalse())
+		Expect(rollout.needsChangeOperatorImage).To(BeTrue())
 	})
 
 	It("checkPodSpecIsOutdated should not return any error", func() {
@@ -202,6 +210,8 @@ var _ = Describe("Pod upgrade", Ordered, func() {
 		Expect(rollout.required).To(BeTrue())
 		Expect(rollout.reason).To(BeEquivalentTo("Postgres needs a restart to apply some configuration changes"))
 		Expect(rollout.canBeInPlace).To(BeTrue())
+		Expect(rollout.needsChangeOperandImage).To(BeFalse())
+		Expect(rollout.needsChangeOperatorImage).To(BeFalse())
 	})
 
 	When("the PodSpec annotation is not available", func() {
@@ -220,6 +230,8 @@ var _ = Describe("Pod upgrade", Ordered, func() {
 			rollout := isInstanceNeedingRollout(ctx, status, &cluster)
 			Expect(rollout.required).To(BeTrue())
 			Expect(rollout.reason).To(ContainSubstring("scheduler name changed"))
+			Expect(rollout.needsChangeOperandImage).To(BeFalse())
+			Expect(rollout.needsChangeOperatorImage).To(BeFalse())
 		})
 	})
 
@@ -242,6 +254,8 @@ var _ = Describe("Pod upgrade", Ordered, func() {
 		rollout := isInstanceNeedingRollout(ctx, status, &cluster)
 		Expect(rollout.required).To(BeTrue())
 		Expect(rollout.reason).To(ContainSubstring("scheduler-name"))
+		Expect(rollout.needsChangeOperandImage).To(BeFalse())
+		Expect(rollout.needsChangeOperatorImage).To(BeFalse())
 	})
 
 	When("cluster has resources specified", func() {
@@ -272,6 +286,8 @@ var _ = Describe("Pod upgrade", Ordered, func() {
 			Expect(rollout.required).To(BeTrue())
 			Expect(rollout.reason).To(ContainSubstring("original and target PodSpec differ in containers"))
 			Expect(rollout.reason).To(ContainSubstring("container postgres differs in resources"))
+			Expect(rollout.needsChangeOperandImage).To(BeFalse())
+			Expect(rollout.needsChangeOperatorImage).To(BeFalse())
 		})
 		It("should trigger a rollout when the cluster has Resources deleted from spec", func(ctx SpecContext) {
 			pod := specs.PodWithExistingStorage(clusterWithResources, 1)
@@ -288,6 +304,8 @@ var _ = Describe("Pod upgrade", Ordered, func() {
 			Expect(rollout.required).To(BeTrue())
 			Expect(rollout.reason).To(ContainSubstring("original and target PodSpec differ in containers"))
 			Expect(rollout.reason).To(ContainSubstring("container postgres differs in resources"))
+			Expect(rollout.needsChangeOperandImage).To(BeFalse())
+			Expect(rollout.needsChangeOperatorImage).To(BeFalse())
 		})
 	})
 
@@ -313,6 +331,8 @@ var _ = Describe("Pod upgrade", Ordered, func() {
 			rollout := isInstanceNeedingRollout(ctx, status, cluster)
 			Expect(rollout.required).To(BeTrue())
 			Expect(rollout.reason).To(Equal("environment variable configuration hash changed"))
+			Expect(rollout.needsChangeOperandImage).To(BeFalse())
+			Expect(rollout.needsChangeOperatorImage).To(BeFalse())
 		})
 
 		It("should not trigger a rollout on operator changes with inplace upgrades", func(ctx SpecContext) {
@@ -361,6 +381,8 @@ var _ = Describe("Pod upgrade", Ordered, func() {
 			rollout := isInstanceNeedingRollout(ctx, status, &cluster)
 			Expect(rollout.reason).To(ContainSubstring("the instance is using an old init container image"))
 			Expect(rollout.required).To(BeTrue())
+			Expect(rollout.needsChangeOperandImage).To(BeFalse())
+			Expect(rollout.needsChangeOperatorImage).To(BeTrue())
 		})
 	})
 
@@ -386,6 +408,8 @@ var _ = Describe("Pod upgrade", Ordered, func() {
 			Expect(rollout.required).To(BeTrue())
 			Expect(rollout.reason).To(ContainSubstring("original and target PodSpec differ in containers"))
 			Expect(rollout.reason).To(ContainSubstring("container postgres differs in environment"))
+			Expect(rollout.needsChangeOperandImage).To(BeFalse())
+			Expect(rollout.needsChangeOperatorImage).To(BeFalse())
 		})
 
 		It("should not trigger a rollout on operator changes with inplace upgrades", func(ctx SpecContext) {
@@ -432,6 +456,8 @@ var _ = Describe("Pod upgrade", Ordered, func() {
 			rollout := isInstanceNeedingRollout(ctx, status, &cluster)
 			Expect(rollout.reason).To(ContainSubstring("the instance is using an old init container image"))
 			Expect(rollout.required).To(BeTrue())
+			Expect(rollout.needsChangeOperandImage).To(BeFalse())
+			Expect(rollout.needsChangeOperatorImage).To(BeTrue())
 		})
 	})
 
@@ -532,6 +558,8 @@ var _ = Describe("Test pod rollout due to topology", func() {
 			rollout := isInstanceNeedingRollout(ctx, status, cluster)
 			Expect(rollout.reason).To(ContainSubstring("topology-spread-constraints"))
 			Expect(rollout.required).To(BeTrue())
+			Expect(rollout.needsChangeOperandImage).To(BeFalse())
+			Expect(rollout.needsChangeOperatorImage).To(BeFalse())
 		})
 
 		It("should require rollout when the LabelSelector maps are different", func(ctx SpecContext) {
@@ -547,6 +575,8 @@ var _ = Describe("Test pod rollout due to topology", func() {
 			rollout := isInstanceNeedingRollout(ctx, status, cluster)
 			Expect(rollout.reason).To(ContainSubstring("topology-spread-constraints"))
 			Expect(rollout.required).To(BeTrue())
+			Expect(rollout.needsChangeOperandImage).To(BeFalse())
+			Expect(rollout.needsChangeOperatorImage).To(BeFalse())
 		})
 
 		It("should require rollout when TopologySpreadConstraints is nil in one of the objects", func(ctx SpecContext) {
@@ -560,6 +590,8 @@ var _ = Describe("Test pod rollout due to topology", func() {
 			rollout := isInstanceNeedingRollout(ctx, status, cluster)
 			Expect(rollout.reason).To(ContainSubstring("topology-spread-constraints"))
 			Expect(rollout.required).To(BeTrue())
+			Expect(rollout.needsChangeOperandImage).To(BeFalse())
+			Expect(rollout.needsChangeOperatorImage).To(BeFalse())
 		})
 
 		It("should not require rollout if pod and spec both lack TopologySpreadConstraints", func(ctx SpecContext) {
@@ -575,6 +607,8 @@ var _ = Describe("Test pod rollout due to topology", func() {
 			rollout := isInstanceNeedingRollout(ctx, status, cluster)
 			Expect(rollout.reason).To(BeEmpty())
 			Expect(rollout.required).To(BeFalse())
+			Expect(rollout.needsChangeOperandImage).To(BeFalse())
+			Expect(rollout.needsChangeOperatorImage).To(BeFalse())
 		})
 	})
 
@@ -588,6 +622,8 @@ var _ = Describe("Test pod rollout due to topology", func() {
 			rollout := isInstanceNeedingRollout(ctx, status, cluster)
 			Expect(rollout.reason).To(BeEmpty())
 			Expect(rollout.required).To(BeFalse())
+			Expect(rollout.needsChangeOperandImage).To(BeFalse())
+			Expect(rollout.needsChangeOperatorImage).To(BeFalse())
 		})
 
 		It("should require rollout when the cluster and pod do not have "+
@@ -603,6 +639,8 @@ var _ = Describe("Test pod rollout due to topology", func() {
 			rollout := isInstanceNeedingRollout(ctx, status, cluster)
 			Expect(rollout.reason).To(ContainSubstring("does not have up-to-date TopologySpreadConstraints"))
 			Expect(rollout.required).To(BeTrue())
+			Expect(rollout.needsChangeOperandImage).To(BeFalse())
+			Expect(rollout.needsChangeOperatorImage).To(BeFalse())
 		})
 
 		It("should require rollout when the LabelSelector maps are different", func(ctx SpecContext) {
@@ -620,6 +658,8 @@ var _ = Describe("Test pod rollout due to topology", func() {
 			rollout := isInstanceNeedingRollout(ctx, status, cluster)
 			Expect(rollout.reason).To(ContainSubstring("does not have up-to-date TopologySpreadConstraints"))
 			Expect(rollout.required).To(BeTrue())
+			Expect(rollout.needsChangeOperandImage).To(BeFalse())
+			Expect(rollout.needsChangeOperatorImage).To(BeFalse())
 		})
 
 		It("should require rollout when TopologySpreadConstraints is nil in one of the objects", func(ctx SpecContext) {
@@ -635,6 +675,8 @@ var _ = Describe("Test pod rollout due to topology", func() {
 			rollout := isInstanceNeedingRollout(ctx, status, cluster)
 			Expect(rollout.reason).To(ContainSubstring("does not have up-to-date TopologySpreadConstraints"))
 			Expect(rollout.required).To(BeTrue())
+			Expect(rollout.needsChangeOperandImage).To(BeFalse())
+			Expect(rollout.needsChangeOperatorImage).To(BeFalse())
 		})
 
 		It("should not require rollout if pod and spec both lack TopologySpreadConstraints", func(ctx SpecContext) {
@@ -651,6 +693,8 @@ var _ = Describe("Test pod rollout due to topology", func() {
 			rollout := isInstanceNeedingRollout(ctx, status, cluster)
 			Expect(rollout.reason).To(BeEmpty())
 			Expect(rollout.required).To(BeFalse())
+			Expect(rollout.needsChangeOperandImage).To(BeFalse())
+			Expect(rollout.needsChangeOperatorImage).To(BeFalse())
 		})
 	})
 })

--- a/internal/controller/rollout/doc.go
+++ b/internal/controller/rollout/doc.go
@@ -1,0 +1,20 @@
+/*
+Copyright The CloudNativePG Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package rollout contains the rollout manager, allowing
+// CloudNative-PG to spread Pod rollouts depending on
+// the passed configuration
+package rollout

--- a/internal/controller/rollout/rollout.go
+++ b/internal/controller/rollout/rollout.go
@@ -1,0 +1,110 @@
+/*
+Copyright The CloudNativePG Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rollout
+
+import (
+	"sync"
+	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// The type of functions returning a moment in time
+type timeFunc func() time.Time
+
+// Manager is the rollout manager. It is safe to use
+// concurrently
+type Manager struct {
+	m sync.Mutex
+
+	// The amount of time we wait between rollouts of
+	// different clusters
+	clusterRolloutDelay time.Duration
+
+	// The amount of time we wait between instances of
+	// the same cluster
+	instanceRolloutDelay time.Duration
+
+	// This is used to get the current time. Mainly
+	// used by the unit tests to inject a fake time
+	timeProvider timeFunc
+
+	// The following data is relative to the the last
+	// rollout
+	lastInstance string
+	lastCluster  client.ObjectKey
+	lastUpdate   time.Time
+}
+
+// Result is the output of the rollout manager, telling the
+// operator how much time we need to wait to rollout a Pod
+type Result struct {
+	// This is true when the Pod can be rolled out immediately
+	RolloutAllowed bool
+
+	// This is set with the amount of time the operator need
+	// to wait to rollout that Pod
+	TimeToWait time.Duration
+}
+
+// New creates a new rollout manager with the passed configuration
+func New(clusterRolloutDelay, instancesRolloutDelay time.Duration) *Manager {
+	return &Manager{
+		timeProvider:         time.Now,
+		clusterRolloutDelay:  clusterRolloutDelay,
+		instanceRolloutDelay: instancesRolloutDelay,
+	}
+}
+
+// CoordinateRollout is called to check whether this rollout is allowed or not
+// by the manager
+func (manager *Manager) CoordinateRollout(
+	cluster client.ObjectKey,
+	instanceName string,
+) Result {
+	manager.m.Lock()
+	defer manager.m.Unlock()
+
+	if manager.lastCluster == cluster {
+		return manager.coordinateRolloutWithTime(cluster, instanceName, manager.instanceRolloutDelay)
+	}
+	return manager.coordinateRolloutWithTime(cluster, instanceName, manager.clusterRolloutDelay)
+}
+
+func (manager *Manager) coordinateRolloutWithTime(
+	cluster client.ObjectKey,
+	instanceName string,
+	t time.Duration,
+) Result {
+	now := manager.timeProvider()
+	timeSinceLastRollout := now.Sub(manager.lastUpdate)
+
+	if manager.lastUpdate.IsZero() || timeSinceLastRollout >= t {
+		manager.lastCluster = cluster
+		manager.lastInstance = instanceName
+		manager.lastUpdate = now
+		return Result{
+			RolloutAllowed: true,
+			TimeToWait:     0,
+		}
+	}
+
+	return Result{
+		RolloutAllowed: false,
+		TimeToWait:     t - timeSinceLastRollout,
+	}
+}

--- a/internal/controller/rollout/rollout_test.go
+++ b/internal/controller/rollout/rollout_test.go
@@ -1,0 +1,164 @@
+/*
+Copyright The CloudNativePG Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rollout
+
+import (
+	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Rollout manager", func() {
+	It("should coordinate rollouts when delays are set", func() {
+		startTime := time.Now()
+		currentTime := startTime
+
+		const (
+			clustersRolloutDelay  = 10 * time.Minute
+			instancesRolloutDelay = 5 * time.Minute
+		)
+
+		m := New(clustersRolloutDelay, instancesRolloutDelay)
+		m.timeProvider = func() time.Time {
+			return currentTime
+		}
+
+		By("allowing the first rollout immediately", func() {
+			result := m.CoordinateRollout(client.ObjectKey{
+				Namespace: "default",
+				Name:      "cluster-example",
+			}, "cluster-example-1")
+
+			Expect(result.RolloutAllowed).To(BeTrue())
+			Expect(result.TimeToWait).To(BeZero())
+		})
+
+		By("waiting for one minute", func() {
+			currentTime = currentTime.Add(1 * time.Minute)
+		})
+
+		By("checking that a rollout of an instance is not allowed", func() {
+			result := m.CoordinateRollout(client.ObjectKey{
+				Namespace: "default",
+				Name:      "cluster-example",
+			}, "cluster-example-2")
+
+			Expect(result.RolloutAllowed).To(BeFalse())
+			Expect(result.TimeToWait).To(Equal(4 * time.Minute))
+			Expect(m.lastUpdate).To(Equal(startTime))
+		})
+
+		By("checking that a rollout of a cluster is not allowed", func() {
+			result := m.CoordinateRollout(client.ObjectKey{
+				Namespace: "default",
+				Name:      "cluster-bis",
+			}, "cluster-bis-1")
+
+			Expect(result.RolloutAllowed).To(BeFalse())
+			Expect(result.TimeToWait).To(Equal(9 * time.Minute))
+			Expect(m.lastUpdate).To(Equal(startTime))
+		})
+
+		By("waiting for five minutes", func() {
+			currentTime = currentTime.Add(5 * time.Minute)
+		})
+
+		By("checking that a rollout of a cluster is still not allowed", func() {
+			result := m.CoordinateRollout(client.ObjectKey{
+				Namespace: "default",
+				Name:      "cluster-bis",
+			}, "cluster-bis-1")
+
+			Expect(result.RolloutAllowed).To(BeFalse())
+			Expect(result.TimeToWait).To(Equal(4 * time.Minute))
+			Expect(m.lastUpdate).To(Equal(startTime))
+		})
+
+		By("checking that a rollout of an instance is allowed", func() {
+			result := m.CoordinateRollout(client.ObjectKey{
+				Namespace: "default",
+				Name:      "cluster-example",
+			}, "cluster-example-2")
+
+			Expect(result.RolloutAllowed).To(BeTrue())
+			Expect(result.TimeToWait).To(BeZero())
+			Expect(m.lastUpdate).To(Equal(currentTime))
+		})
+
+		By("waiting for other eleven minutes", func() {
+			currentTime = currentTime.Add(11 * time.Minute)
+		})
+
+		By("checking that a rollout of a cluster is allowed", func() {
+			result := m.CoordinateRollout(client.ObjectKey{
+				Namespace: "default",
+				Name:      "cluster-bis",
+			}, "cluster-bis-1")
+
+			Expect(result.RolloutAllowed).To(BeTrue())
+			Expect(result.TimeToWait).To(BeZero())
+			Expect(m.lastUpdate).To(Equal(currentTime))
+		})
+	})
+
+	It("should allow all rollouts when delays are not set", func() {
+		m := New(0, 0)
+
+		By("allowing the first rollout immediately", func() {
+			result := m.CoordinateRollout(client.ObjectKey{
+				Namespace: "default",
+				Name:      "cluster-example",
+			}, "cluster-example-1")
+
+			Expect(result.RolloutAllowed).To(BeTrue())
+			Expect(result.TimeToWait).To(BeZero())
+		})
+
+		By("allowing a rollout of an instance", func() {
+			result := m.CoordinateRollout(client.ObjectKey{
+				Namespace: "default",
+				Name:      "cluster-example",
+			}, "cluster-example-2")
+
+			Expect(result.RolloutAllowed).To(BeTrue())
+			Expect(result.TimeToWait).To(BeZero())
+		})
+
+		By("allowing a rollout of an cluster", func() {
+			result := m.CoordinateRollout(client.ObjectKey{
+				Namespace: "default",
+				Name:      "cluster-bis",
+			}, "cluster-bis-1")
+
+			Expect(result.RolloutAllowed).To(BeTrue())
+			Expect(result.TimeToWait).To(BeZero())
+		})
+
+		By("allowing a rollout of another instance", func() {
+			result := m.CoordinateRollout(client.ObjectKey{
+				Namespace: "default",
+				Name:      "cluster-example",
+			}, "cluster-example-3")
+
+			Expect(result.RolloutAllowed).To(BeTrue())
+			Expect(result.TimeToWait).To(BeZero())
+		})
+	})
+})

--- a/internal/controller/rollout/suite_test.go
+++ b/internal/controller/rollout/suite_test.go
@@ -1,0 +1,30 @@
+/*
+Copyright The CloudNativePG Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rollout
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestCerts(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecs(t, "Rollout manager suite")
+}

--- a/tests/e2e/fixtures/configmap-support/configmap.yaml
+++ b/tests/e2e/fixtures/configmap-support/configmap.yaml
@@ -4,8 +4,8 @@ data:
   # wrong example2.com on purpose to check overwriting via secret works fine
   INHERITED_LABELS: environment, example2.com/*
   MONITORING_QUERIES_CONFIGMAP: ""
-  CLUSTERS_ROLLOUT_DELAY: 1
-  INSTANCES_ROLLOUT_DELAY: 1
+  CLUSTERS_ROLLOUT_DELAY: '1'
+  INSTANCES_ROLLOUT_DELAY: '1'
 kind: ConfigMap
 metadata:
   name: cnpg-controller-manager-config

--- a/tests/e2e/fixtures/configmap-support/configmap.yaml
+++ b/tests/e2e/fixtures/configmap-support/configmap.yaml
@@ -4,6 +4,8 @@ data:
   # wrong example2.com on purpose to check overwriting via secret works fine
   INHERITED_LABELS: environment, example2.com/*
   MONITORING_QUERIES_CONFIGMAP: ""
+  CLUSTERS_ROLLOUT_DELAY: 1
+  INSTANCES_ROLLOUT_DELAY: 1
 kind: ConfigMap
 metadata:
   name: cnpg-controller-manager-config


### PR DESCRIPTION
This patch adds two new parameters to the operator configuration:

- `CLUSTERS_ROLLOUT_DELAY`: Defines the number of seconds to wait between roll-outs of Pods of different PostgreSQL clusters (default: `0`).
- `INSTANCES_ROLLOUT_DELAY`: Defines the number of seconds to wait between roll-outs of Pods of individual instances within the same PostgreSQL cluster (default: `0`).

Using these two parameters, the operator can be confgured to spread the rollout of new versions of PostgreSQL and of the instance manager, easing the impact of upgrading the operator or the PostgreSQL version.

Closes: #5384
