### PR TITLE
feat: check the number of spec.schedule fields

### DIFF
--- a/api/v1/scheduledbackup_funcs_test.go
+++ b/api/v1/scheduledbackup_funcs_test.go
@@ -77,7 +77,8 @@ var _ = Describe("Scheduled backup", func() {
 				Schedule: "* * * * * *",
 			},
 		}
-		result := scheduledBackup.validate()
+		warnings, result := scheduledBackup.validate()
+		Expect(warnings).To(BeEmpty())
 		Expect(result).To(HaveLen(1))
 		Expect(result[0].Field).To(Equal("spec.online"))
 	})
@@ -90,7 +91,8 @@ var _ = Describe("Scheduled backup", func() {
 				Schedule:            "* * * * * *",
 			},
 		}
-		result := scheduledBackup.validate()
+		warnings, result := scheduledBackup.validate()
+		Expect(warnings).To(BeEmpty())
 		Expect(result).To(HaveLen(1))
 		Expect(result[0].Field).To(Equal("spec.onlineConfiguration"))
 	})

--- a/api/v1/scheduledbackup_webhook.go
+++ b/api/v1/scheduledbackup_webhook.go
@@ -28,6 +28,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
+	"strings"
 )
 
 // scheduledBackupLog is for logging in this package.
@@ -116,6 +117,15 @@ func (r *ScheduledBackup) validate() field.ErrorList {
 			r.Spec.OnlineConfiguration,
 			"OnlineConfiguration parameter can be specified only if the method is volumeSnapshot",
 		))
+	}
+	
+	if strings.Count(strings.Trim(r.Spec.Schedule," ")," ") != 5 {
+		result = append(result, field.Invalid(
+                        field.NewPath("spec", "schedule"),
+                        r.Spec.Schedule,
+                        "Schedule parameter has not the right number of arguments. Must be 6.",
+                ))
+
 	}
 
 	return result

--- a/api/v1/scheduledbackup_webhook.go
+++ b/api/v1/scheduledbackup_webhook.go
@@ -30,7 +30,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
-	"strings"
 )
 
 // scheduledBackupLog is for logging in this package.
@@ -125,15 +124,6 @@ func (r *ScheduledBackup) validate() (admission.Warnings, field.ErrorList) {
 			r.Spec.OnlineConfiguration,
 			"OnlineConfiguration parameter can be specified only if the method is volumeSnapshot",
 		))
-	}
-	
-	if strings.Count(strings.Trim(r.Spec.Schedule," ")," ") != 5 {
-		result = append(result, field.Invalid(
-                        field.NewPath("spec", "schedule"),
-                        r.Spec.Schedule,
-                        "Schedule parameter has not the right number of arguments. Must be 6.",
-                ))
-
 	}
 
 	return warnings, result

--- a/api/v1/scheduledbackup_webhook.go
+++ b/api/v1/scheduledbackup_webhook.go
@@ -17,6 +17,8 @@ limitations under the License.
 package v1
 
 import (
+	"strings"
+
 	"github.com/cloudnative-pg/machinery/pkg/log"
 	"github.com/robfig/cron"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -28,7 +30,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
-	"strings"
 )
 
 // scheduledBackupLog is for logging in this package.
@@ -57,13 +58,11 @@ var _ webhook.Validator = &ScheduledBackup{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (r *ScheduledBackup) ValidateCreate() (admission.Warnings, error) {
-	var allErrs field.ErrorList
 	scheduledBackupLog.Info("validate create", "name", r.Name, "namespace", r.Namespace)
 
-	allErrs = append(allErrs, r.validate()...)
-
+	warnings, allErrs := r.validate()
 	if len(allErrs) == 0 {
-		return nil, nil
+		return warnings, nil
 	}
 
 	return nil, apierrors.NewInvalid(
@@ -83,15 +82,23 @@ func (r *ScheduledBackup) ValidateDelete() (admission.Warnings, error) {
 	return nil, nil
 }
 
-func (r *ScheduledBackup) validate() field.ErrorList {
+func (r *ScheduledBackup) validate() (admission.Warnings, field.ErrorList) {
 	var result field.ErrorList
+	var warnings admission.Warnings
 
 	if _, err := cron.Parse(r.GetSchedule()); err != nil {
 		result = append(result,
 			field.Invalid(
 				field.NewPath("spec", "schedule"),
 				r.Spec.Schedule, err.Error()))
+	} else if len(strings.Fields(r.Spec.Schedule)) != 6 {
+		warnings = append(
+			warnings,
+			"Schedule parameter may not have the right number of arguments "+
+				"(usually six arguments are needed)",
+		)
 	}
+
 	if r.Spec.Method == BackupMethodVolumeSnapshot && !utils.HaveVolumeSnapshot() {
 		result = append(result, field.Invalid(
 			field.NewPath("spec", "method"),
@@ -118,15 +125,6 @@ func (r *ScheduledBackup) validate() field.ErrorList {
 			"OnlineConfiguration parameter can be specified only if the method is volumeSnapshot",
 		))
 	}
-	
-	if strings.Count(strings.Trim(r.Spec.Schedule," ")," ") != 5 {
-		result = append(result, field.Invalid(
-                        field.NewPath("spec", "schedule"),
-                        r.Spec.Schedule,
-                        "Schedule parameter has not the right number of arguments. Must be 6.",
-                ))
 
-	}
-
-	return result
+	return warnings, result
 }

--- a/api/v1/scheduledbackup_webhook.go
+++ b/api/v1/scheduledbackup_webhook.go
@@ -30,6 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
+	"strings"
 )
 
 // scheduledBackupLog is for logging in this package.
@@ -124,6 +125,15 @@ func (r *ScheduledBackup) validate() (admission.Warnings, field.ErrorList) {
 			r.Spec.OnlineConfiguration,
 			"OnlineConfiguration parameter can be specified only if the method is volumeSnapshot",
 		))
+	}
+	
+	if strings.Count(strings.Trim(r.Spec.Schedule," ")," ") != 5 {
+		result = append(result, field.Invalid(
+                        field.NewPath("spec", "schedule"),
+                        r.Spec.Schedule,
+                        "Schedule parameter has not the right number of arguments. Must be 6.",
+                ))
+
 	}
 
 	return warnings, result

--- a/api/v1/scheduledbackup_webhook_test.go
+++ b/api/v1/scheduledbackup_webhook_test.go
@@ -48,17 +48,6 @@ var _ = Describe("Validate schedule", func() {
 		Expect(result).To(BeEmpty())
 	})
 
-	It("complain with a wrong number of arguments", func() {
-		schedule := &ScheduledBackup{
-			Spec: ScheduledBackupSpec{
-				Schedule: "1 2 3 4 5",
-			},
-		}
-
-		result := schedule.validate()
-		Expect(result).To(HaveLen(1))
-	})
-
 	It("complain with a wrong time", func() {
 		schedule := &ScheduledBackup{
 			Spec: ScheduledBackupSpec{

--- a/api/v1/scheduledbackup_webhook_test.go
+++ b/api/v1/scheduledbackup_webhook_test.go
@@ -35,6 +35,17 @@ var _ = Describe("Validate schedule", func() {
 		Expect(result).To(BeEmpty())
 	})
 
+	It("complain with a wrong number of arguments", func() {
+		schedule := &ScheduledBackup{
+			Spec: ScheduledBackupSpec{
+				Schedule: "1 2 3 4 5",
+			},
+		}
+
+		result := schedule.validate()
+		Expect(result).To(HaveLen(1))
+	})
+
 	It("complain with a wrong time", func() {
 		schedule := &ScheduledBackup{
 			Spec: ScheduledBackupSpec{

--- a/api/v1/scheduledbackup_webhook_test.go
+++ b/api/v1/scheduledbackup_webhook_test.go
@@ -31,19 +31,21 @@ var _ = Describe("Validate schedule", func() {
 			},
 		}
 
-		result := schedule.validate()
+		warnings, result := schedule.validate()
+		Expect(warnings).To(BeEmpty())
 		Expect(result).To(BeEmpty())
 	})
 
-	It("complain with a wrong number of arguments", func() {
+	It("warn the user if the schedule has a wrong number of arguments", func() {
 		schedule := &ScheduledBackup{
 			Spec: ScheduledBackupSpec{
 				Schedule: "1 2 3 4 5",
 			},
 		}
 
-		result := schedule.validate()
-		Expect(result).To(HaveLen(1))
+		warnings, result := schedule.validate()
+		Expect(warnings).To(HaveLen(1))
+		Expect(result).To(BeEmpty())
 	})
 
 	It("complain with a wrong time", func() {
@@ -53,7 +55,8 @@ var _ = Describe("Validate schedule", func() {
 			},
 		}
 
-		result := schedule.validate()
+		warnings, result := schedule.validate()
+		Expect(warnings).To(BeEmpty())
 		Expect(result).To(HaveLen(1))
 	})
 
@@ -65,7 +68,9 @@ var _ = Describe("Validate schedule", func() {
 			},
 		}
 		utils.SetVolumeSnapshot(true)
-		result := schedule.validate()
+
+		warnings, result := schedule.validate()
+		Expect(warnings).To(BeEmpty())
 		Expect(result).To(BeEmpty())
 	})
 
@@ -77,7 +82,8 @@ var _ = Describe("Validate schedule", func() {
 			},
 		}
 		utils.SetVolumeSnapshot(false)
-		result := schedule.validate()
+		warnings, result := schedule.validate()
+		Expect(warnings).To(BeEmpty())
 		Expect(result).To(HaveLen(1))
 		Expect(result[0].Field).To(Equal("spec.method"))
 	})

--- a/api/v1/scheduledbackup_webhook_test.go
+++ b/api/v1/scheduledbackup_webhook_test.go
@@ -48,6 +48,17 @@ var _ = Describe("Validate schedule", func() {
 		Expect(result).To(BeEmpty())
 	})
 
+	It("complain with a wrong number of arguments", func() {
+		schedule := &ScheduledBackup{
+			Spec: ScheduledBackupSpec{
+				Schedule: "1 2 3 4 5",
+			},
+		}
+
+		result := schedule.validate()
+		Expect(result).To(HaveLen(1))
+	})
+
 	It("complain with a wrong time", func() {
 		schedule := &ScheduledBackup{
 			Spec: ScheduledBackupSpec{


### PR DESCRIPTION
The `schedule` field of `scheduledbackup.spec` can have 5 or 6 parameters as defined by the [Go cron package
format](https://pkg.go.dev/github.com/robfig/cron#hdr-CRON_Expression_Format)
This syntax may be misleading when using just 5 parameters, as the `seconds` field is not included.

This patch improves the webhook to raise a warning when a schedule specification has just 5 fields, while retaining compatibility.

Closes #5380 