### PR TITLE
fix(webserver): use manager client and recorder

### DIFF
--- a/internal/cmd/manager/instance/run/cmd.go
+++ b/internal/cmd/manager/instance/run/cmd.go
@@ -166,8 +166,8 @@ func runSubCommand(ctx context.Context, instance *postgres.Instance) error {
 				DisableFor: []client.Object{
 					&corev1.Secret{},
 					&corev1.ConfigMap{},
-					// we don't have the permission to cache backups given that the SA doesn't have watch permission
-					// on the object.
+					// we don't have the permissions to cache backups, as the ServiceAccount
+					// doesn't have watch permission on the backup status
 					&apiv1.Backup{},
 				},
 			},

--- a/internal/cmd/manager/instance/run/cmd.go
+++ b/internal/cmd/manager/instance/run/cmd.go
@@ -166,6 +166,9 @@ func runSubCommand(ctx context.Context, instance *postgres.Instance) error {
 				DisableFor: []client.Object{
 					&corev1.Secret{},
 					&corev1.ConfigMap{},
+					// we don't have the permission to cache backups given that the SA doesn't have watch permission
+					// on the object.
+					&apiv1.Backup{},
 				},
 			},
 		},
@@ -261,7 +264,11 @@ func runSubCommand(ctx context.Context, instance *postgres.Instance) error {
 		return err
 	}
 
-	localSrv, err := webserver.NewLocalWebServer(instance)
+	localSrv, err := webserver.NewLocalWebServer(
+		instance,
+		mgr.GetClient(),
+		mgr.GetEventRecorderFor("local-webserver"),
+	)
 	if err != nil {
 		return err
 	}

--- a/pkg/management/postgres/webserver/local.go
+++ b/pkg/management/postgres/webserver/local.go
@@ -30,7 +30,6 @@ import (
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/internal/management/cache"
-	"github.com/cloudnative-pg/cloudnative-pg/pkg/management"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/log"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/url"
@@ -43,20 +42,15 @@ type localWebserverEndpoints struct {
 }
 
 // NewLocalWebServer returns a webserver that allows connection only from localhost
-func NewLocalWebServer(instance *postgres.Instance) (*Webserver, error) {
-	typedClient, err := management.NewControllerRuntimeClient()
-	if err != nil {
-		return nil, fmt.Errorf("creating controller-runtine client: %v", err)
-	}
-	eventRecorder, err := management.NewEventRecorder()
-	if err != nil {
-		return nil, fmt.Errorf("creating kubernetes event recorder: %v", err)
-	}
-
+func NewLocalWebServer(
+	instance *postgres.Instance,
+	cli client.Client,
+	recorder record.EventRecorder,
+) (*Webserver, error) {
 	endpoints := localWebserverEndpoints{
-		typedClient:   typedClient,
+		typedClient:   cli,
 		instance:      instance,
-		eventRecorder: eventRecorder,
+		eventRecorder: recorder,
 	}
 
 	serveMux := http.NewServeMux()


### PR DESCRIPTION
Update the local webserver to use the event recorder and client created by the manager instead of initializing separate instances.

Closes #5398 

## Release Notes

The local webserver now uses the event recorder and client instantiated by the manager, improving the instance manager's overall performance.


## Notes for the reviewers

This is labeled as a fix given that initializing a new client and event recorder for the local webserver was never intended 