### PR TITLE
fix: remove `LoadClusterUnsafe`

### DIFF
--- a/internal/management/cache/cache.go
+++ b/internal/management/cache/cache.go
@@ -20,8 +20,6 @@ package cache
 
 import (
 	"sync"
-
-	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 )
 
 const (
@@ -53,34 +51,6 @@ func LoadEnv(c string) ([]string, error) {
 	}
 
 	if v, ok := value.([]string); ok {
-		return v, nil
-	}
-
-	return nil, ErrUnsupportedObject
-}
-
-// StoreCluster write a cluster object into the local cache
-func StoreCluster(cluster *apiv1.Cluster) {
-	// We need to make a copy of the cluster object, because
-	// the cluster object contains attribute with concurrent unsafe type
-	// such as map, slice, etc.
-	cache.Store(ClusterKey, cluster.DeepCopy())
-}
-
-// LoadClusterUnsafe retrieves a cluster from the local cache.
-// Warning:
-//
-//	The returned pointer can potentially be accessed concurrently.
-//	Only use this function for read-only operations. If you need to
-//	modify the cluster, always create a DeepCopy of the returned object
-//	before writing to it.
-func LoadClusterUnsafe() (*apiv1.Cluster, error) {
-	value, ok := cache.Load(ClusterKey)
-	if !ok {
-		return nil, ErrCacheMiss
-	}
-
-	if v, ok := value.(*apiv1.Cluster); ok {
 		return v, nil
 	}
 

--- a/internal/management/cache/client/client.go
+++ b/internal/management/cache/client/client.go
@@ -20,6 +20,8 @@ package client
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
 	"io"
 	"net/http"
 
@@ -88,8 +90,15 @@ func get(urlPath string) ([]byte, error) {
 		_ = resp.Body.Close()
 	}()
 
-	if resp.StatusCode != http.StatusOK {
+	switch resp.StatusCode {
+	case http.StatusOK:
+		break
+	case http.StatusNotFound:
 		return nil, cache.ErrCacheMiss
+	case http.StatusInternalServerError:
+		return nil, errors.New("encountered an internal server error while fetching cluster cache")
+	default:
+		return nil, fmt.Errorf("encountered an unexpected status code while fetching cluster cache: %d", resp.StatusCode)
 	}
 
 	bytes, err := io.ReadAll(resp.Body)

--- a/internal/management/controller/cache.go
+++ b/internal/management/controller/cache.go
@@ -34,8 +34,6 @@ import (
 //
 // returns true if the update was not total, and should be retried
 func (r *InstanceReconciler) updateCacheFromCluster(ctx context.Context, cluster *apiv1.Cluster) shoudRequeue {
-	cache.StoreCluster(cluster)
-
 	var missingPermissions shoudRequeue
 
 	// Populate the cache with the backup configuration

--- a/pkg/management/postgres/webserver/metricserver/pg_collector.go
+++ b/pkg/management/postgres/webserver/metricserver/pg_collector.go
@@ -28,6 +28,7 @@ import (
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/internal/management/cache"
+	cacheClient "github.com/cloudnative-pg/cloudnative-pg/internal/management/cache/client"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/log"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres"
 	m "github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres/metrics"
@@ -430,7 +431,7 @@ func (e *Exporter) setTimestampMetric(
 	errorLabel string,
 	getTimestampFunc func(cluster *apiv1.Cluster) string,
 ) {
-	cluster, err := cache.LoadClusterUnsafe()
+	cluster, err := cacheClient.GetCluster()
 	// there isn't a cached object yet
 	if errors.Is(err, cache.ErrCacheMiss) {
 		return
@@ -472,7 +473,7 @@ func (e *Exporter) setTimestampMetric(
 func (e *Exporter) collectNodesUsed() {
 	const notExtractedValue float64 = -1
 
-	cluster, err := cache.LoadClusterUnsafe()
+	cluster, err := cacheClient.GetCluster()
 	if err != nil {
 		log.Error(err, "unable to collect metrics")
 		e.Metrics.Error.Set(1)

--- a/pkg/management/postgres/webserver/metricserver/pg_collector_test.go
+++ b/pkg/management/postgres/webserver/metricserver/pg_collector_test.go
@@ -70,8 +70,10 @@ var _ = Describe("ensure timestamp metric it's set properly", func() {
 				LastFailedBackup:         "2023-02-16T22:44:56Z",
 			},
 		}
-		cache.Store(cache.ClusterKey, cluster)
 
+		exporter.getCluster = func() (*apiv1.Cluster, error) {
+			return cluster, nil
+		}
 		exporter.collectFromPrimaryFirstPointOnTimeRecovery()
 		exporter.collectFromPrimaryLastAvailableBackupTimestamp()
 		exporter.collectFromPrimaryLastFailedBackupTimestamp()
@@ -176,7 +178,9 @@ var _ = Describe("ensure timestamp metric it's set properly", func() {
 					},
 				},
 			}
-			cache.Store(cache.ClusterKey, cluster)
+			exporter.getCluster = func() (*apiv1.Cluster, error) {
+				return cluster, nil
+			}
 
 			exporter.collectNodesUsed()
 
@@ -212,7 +216,9 @@ var _ = Describe("ensure timestamp metric it's set properly", func() {
 					},
 				},
 			}
-			cache.Store(cache.ClusterKey, cluster)
+			exporter.getCluster = func() (*apiv1.Cluster, error) {
+				return cluster, nil
+			}
 
 			exporter.collectNodesUsed()
 

--- a/pkg/management/postgres/webserver/metricserver/wal.go
+++ b/pkg/management/postgres/webserver/metricserver/wal.go
@@ -22,7 +22,7 @@ import (
 	"os"
 	"regexp"
 
-	"github.com/cloudnative-pg/cloudnative-pg/internal/management/cache"
+	cacheClient "github.com/cloudnative-pg/cloudnative-pg/internal/management/cache/client"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/log"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/specs"
@@ -219,7 +219,7 @@ func collectPGWalSettings(exporter *Exporter, db *sql.DB) error {
 }
 
 func getWalVolumeSize() float64 {
-	cluster, err := cache.LoadClusterUnsafe()
+	cluster, err := cacheClient.GetCluster()
 	if err != nil || !cluster.ShouldCreateWalArchiveVolume() {
 		return 0
 	}


### PR DESCRIPTION
Closes #5400


## Note for reviewers
- Given that LoadClusterUnsafe generates issues because we operate on an outdated cluster I'm labeling this PR as a fix
- I don't think this specific commit deserves a release note, given that we already have #5387 
