### PR TITLE
fix: remove unused superuser and app secret volumes

### DIFF
--- a/pkg/specs/podspec_diff.go
+++ b/pkg/specs/podspec_diff.go
@@ -116,7 +116,12 @@ func compareMaps[V comparable](current, target map[string]V) (bool, string) {
 	return true, ""
 }
 
-func isCurrentVolumeToBeIgnored(name string) bool {
+// shoudlIgnoreCurrentVolume checks if a volume or mount is the superuser or app
+// mount, which had been added, superflously, in previous versions. If so, ignores
+// it for the PodSpec drift detector, to avoid unnecessary restarts
+//
+// TODO: delete this function after minor version 1.24 is discontinued
+func shoudlIgnoreCurrentVolume(name string) bool {
 	return name == "superuser-secret" || name == "app-secret"
 }
 
@@ -124,7 +129,7 @@ func compareVolumes(currentVolumes, targetVolumes []corev1.Volume) (bool, string
 	current := make(map[string]corev1.Volume)
 	target := make(map[string]corev1.Volume)
 	for _, vol := range currentVolumes {
-		if isCurrentVolumeToBeIgnored(vol.Name) {
+		if shoudlIgnoreCurrentVolume(vol.Name) {
 			continue
 		}
 		current[vol.Name] = vol
@@ -140,7 +145,7 @@ func compareVolumeMounts(currentMounts, targetMounts []corev1.VolumeMount) (bool
 	current := make(map[string]corev1.VolumeMount)
 	target := make(map[string]corev1.VolumeMount)
 	for _, mount := range currentMounts {
-		if isCurrentVolumeToBeIgnored(mount.Name) {
+		if shoudlIgnoreCurrentVolume(mount.Name) {
 			continue
 		}
 		current[mount.Name] = mount

--- a/pkg/specs/podspec_diff.go
+++ b/pkg/specs/podspec_diff.go
@@ -116,10 +116,17 @@ func compareMaps[V comparable](current, target map[string]V) (bool, string) {
 	return true, ""
 }
 
+func isCurrentVolumeToBeIgnored(name string) bool {
+	return name == "superuser-secret" || name == "app-secret"
+}
+
 func compareVolumes(currentVolumes, targetVolumes []corev1.Volume) (bool, string) {
 	current := make(map[string]corev1.Volume)
 	target := make(map[string]corev1.Volume)
 	for _, vol := range currentVolumes {
+		if isCurrentVolumeToBeIgnored(vol.Name) {
+			continue
+		}
 		current[vol.Name] = vol
 	}
 	for _, vol := range targetVolumes {
@@ -133,6 +140,9 @@ func compareVolumeMounts(currentMounts, targetMounts []corev1.VolumeMount) (bool
 	current := make(map[string]corev1.VolumeMount)
 	target := make(map[string]corev1.VolumeMount)
 	for _, mount := range currentMounts {
+		if isCurrentVolumeToBeIgnored(mount.Name) {
+			continue
+		}
 		current[mount.Name] = mount
 	}
 	for _, mount := range targetMounts {

--- a/pkg/specs/podspec_diff.go
+++ b/pkg/specs/podspec_diff.go
@@ -116,12 +116,12 @@ func compareMaps[V comparable](current, target map[string]V) (bool, string) {
 	return true, ""
 }
 
-// shoudlIgnoreCurrentVolume checks if a volume or mount is the superuser or app
+// shouldIgnoreCurrentVolume checks if a volume or mount is the superuser or app
 // mount, which had been added, superflously, in previous versions. If so, ignores
 // it for the PodSpec drift detector, to avoid unnecessary restarts
 //
 // TODO: delete this function after minor version 1.24 is discontinued
-func shoudlIgnoreCurrentVolume(name string) bool {
+func shouldIgnoreCurrentVolume(name string) bool {
 	return name == "superuser-secret" || name == "app-secret"
 }
 
@@ -129,7 +129,7 @@ func compareVolumes(currentVolumes, targetVolumes []corev1.Volume) (bool, string
 	current := make(map[string]corev1.Volume)
 	target := make(map[string]corev1.Volume)
 	for _, vol := range currentVolumes {
-		if shoudlIgnoreCurrentVolume(vol.Name) {
+		if shouldIgnoreCurrentVolume(vol.Name) {
 			continue
 		}
 		current[vol.Name] = vol
@@ -145,7 +145,7 @@ func compareVolumeMounts(currentMounts, targetMounts []corev1.VolumeMount) (bool
 	current := make(map[string]corev1.VolumeMount)
 	target := make(map[string]corev1.VolumeMount)
 	for _, mount := range currentMounts {
-		if shoudlIgnoreCurrentVolume(mount.Name) {
+		if shouldIgnoreCurrentVolume(mount.Name) {
 			continue
 		}
 		current[mount.Name] = mount

--- a/pkg/specs/podspec_diff_test.go
+++ b/pkg/specs/podspec_diff_test.go
@@ -1,0 +1,40 @@
+/*
+Copyright The CloudNativePG Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package specs
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("PodSpecDiff", func() {
+	It("returns true for superuser-secret volume", func() {
+		Expect(isCurrentVolumeToBeIgnored("superuser-secret")).To(BeTrue())
+	})
+
+	It("returns true for app-secret volume", func() {
+		Expect(isCurrentVolumeToBeIgnored("app-secret")).To(BeTrue())
+	})
+
+	It("returns false for other volumes", func() {
+		Expect(isCurrentVolumeToBeIgnored("other-volume")).To(BeFalse())
+	})
+
+	It("returns false for empty volume name", func() {
+		Expect(isCurrentVolumeToBeIgnored("")).To(BeFalse())
+	})
+})

--- a/pkg/specs/podspec_diff_test.go
+++ b/pkg/specs/podspec_diff_test.go
@@ -23,18 +23,18 @@ import (
 
 var _ = Describe("PodSpecDiff", func() {
 	It("returns true for superuser-secret volume", func() {
-		Expect(isCurrentVolumeToBeIgnored("superuser-secret")).To(BeTrue())
+		Expect(shouldIgnoreCurrentVolume("superuser-secret")).To(BeTrue())
 	})
 
 	It("returns true for app-secret volume", func() {
-		Expect(isCurrentVolumeToBeIgnored("app-secret")).To(BeTrue())
+		Expect(shouldIgnoreCurrentVolume("app-secret")).To(BeTrue())
 	})
 
 	It("returns false for other volumes", func() {
-		Expect(isCurrentVolumeToBeIgnored("other-volume")).To(BeFalse())
+		Expect(shouldIgnoreCurrentVolume("other-volume")).To(BeFalse())
 	})
 
 	It("returns false for empty volume name", func() {
-		Expect(isCurrentVolumeToBeIgnored("")).To(BeFalse())
+		Expect(shouldIgnoreCurrentVolume("")).To(BeFalse())
 	})
 })

--- a/pkg/specs/volumes.go
+++ b/pkg/specs/volumes.go
@@ -265,24 +265,6 @@ func createPostgresVolumeMounts(cluster apiv1.Cluster) []corev1.VolumeMount {
 		},
 	}
 
-	if cluster.GetEnableSuperuserAccess() {
-		volumeMounts = append(volumeMounts,
-			corev1.VolumeMount{
-				Name:      "superuser-secret",
-				MountPath: "/etc/superuser-secret",
-			},
-		)
-	}
-
-	if cluster.ShouldCreateApplicationDatabase() {
-		volumeMounts = append(volumeMounts,
-			corev1.VolumeMount{
-				Name:      "app-secret",
-				MountPath: "/etc/app-secret",
-			},
-		)
-	}
-
 	if cluster.ShouldCreateWalArchiveVolume() {
 		volumeMounts = append(volumeMounts,
 			corev1.VolumeMount{

--- a/pkg/specs/volumes.go
+++ b/pkg/specs/volumes.go
@@ -110,32 +110,6 @@ func createPostgresVolumes(cluster *apiv1.Cluster, podName string) []corev1.Volu
 		},
 	}
 
-	if cluster.GetEnableSuperuserAccess() {
-		result = append(result,
-			corev1.Volume{
-				Name: "superuser-secret",
-				VolumeSource: corev1.VolumeSource{
-					Secret: &corev1.SecretVolumeSource{
-						SecretName: cluster.GetSuperuserSecretName(),
-					},
-				},
-			},
-		)
-	}
-
-	if cluster.ShouldCreateApplicationDatabase() {
-		result = append(result,
-			corev1.Volume{
-				Name: "app-secret",
-				VolumeSource: corev1.VolumeSource{
-					Secret: &corev1.SecretVolumeSource{
-						SecretName: cluster.GetApplicationSecretName(),
-					},
-				},
-			},
-		)
-	}
-
 	if cluster.ShouldCreateWalArchiveVolume() {
 		result = append(result,
 			corev1.Volume{


### PR DESCRIPTION
This commit removes the unused superuser secret and app secret volumes, simplifying the pod definition. These volumes were never referenced in the code, and their removal prevents unnecessary instance restarts when enabling or disabling superuser access and when promoting a replica cluster.

# Release notes

Fix:
* Removed unused superuser secret and app secret volumes from Pods to prevent unnecessary instance restarts when enabling/disabling superuser access or promoting a replica cluster.