### PR TITLE
chore(lint): use coopyloopvar instead of exportloopref

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -23,7 +23,7 @@ linters:
     - dupl
     - durationcheck
     - errcheck
-    - exportloopref
+    - copyloopvar
     - gci
     - gocognit
     - goconst

--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -3805,7 +3805,6 @@ func (cluster *Cluster) IsInplaceRestartPhase() bool {
 // otherwise return nil
 func (cluster *Cluster) GetTablespaceConfiguration(name string) *TablespaceConfiguration {
 	for _, tbsConfig := range cluster.Spec.Tablespaces {
-		tbsConfig := tbsConfig
 		if name == tbsConfig.Name {
 			return &tbsConfig
 		}

--- a/api/v1/cluster_webhook.go
+++ b/api/v1/cluster_webhook.go
@@ -1594,7 +1594,6 @@ func (r *Cluster) validateTablespaceStorageSize() field.ErrorList {
 	var result field.ErrorList
 
 	for idx, tablespaceConf := range r.Spec.Tablespaces {
-		tablespaceConf := tablespaceConf
 		result = append(result,
 			validateStorageConfigurationSize(
 				*field.NewPath("spec", "tablespaces").Index(idx),
@@ -2031,7 +2030,6 @@ func (r *Cluster) validateTolerations() field.ErrorList {
 	path := field.NewPath("spec", "affinity", "toleration")
 	allErrors := field.ErrorList{}
 	for i, toleration := range r.Spec.Affinity.Tolerations {
-		toleration := toleration
 		idxPath := path.Index(i)
 		// validate the toleration key
 		if len(toleration.Key) > 0 {

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -1328,7 +1328,6 @@ func (r *ClusterReconciler) markPVCReadyForCompletedJobs(
 
 	for _, job := range completeJobs {
 		for _, pvc := range resources.pvcs.Items {
-			pvc := pvc
 			if !persistentvolumeclaim.IsUsedByPodSpec(job.Spec.Template.Spec, pvc.Name) {
 				continue
 			}

--- a/internal/management/controller/tablespaces/reconciler.go
+++ b/internal/management/controller/tablespaces/reconciler.go
@@ -139,7 +139,6 @@ func (r *TablespaceReconciler) applySteps(
 	result := make([]apiv1.TablespaceState, len(actions))
 
 	for idx, step := range actions {
-		step := step
 		result[idx] = step.execute(ctx, tbsManager, tbsStorageManager)
 	}
 

--- a/internal/management/controller/tablespaces/tablespaces.go
+++ b/internal/management/controller/tablespaces/tablespaces.go
@@ -43,7 +43,6 @@ func evaluateNextSteps(
 	// we go through all the tablespaces in spec and create them if missing in DB
 	// NOTE: we do not at the moment support Dropping tablespaces
 	for idx, tbsInSpec := range tablespaceInSpecSlice {
-		tbsInSpec := tbsInSpec
 		dbTablespace, isTbsInDB := tbsInDBNamed[tbsInSpec.Name]
 
 		switch {

--- a/pkg/management/barman/backupdelete.go
+++ b/pkg/management/barman/backupdelete.go
@@ -134,7 +134,6 @@ func DeleteBackupsNotInCatalog(
 
 	var errors []error
 	for id, backup := range backups.Items {
-		backup := backup
 		if backup.Spec.Cluster.Name != cluster.GetName() ||
 			backup.Status.Phase != v1.BackupPhaseCompleted ||
 			!useSameBackupLocation(&backup.Status, cluster) {

--- a/pkg/reconciler/persistentvolumeclaim/calculator.go
+++ b/pkg/reconciler/persistentvolumeclaim/calculator.go
@@ -266,7 +266,6 @@ func (r pgTablespaceCalculator) GetName(instanceName string) string {
 func (r pgTablespaceCalculator) GetStorageConfiguration(cluster *apiv1.Cluster) (apiv1.StorageConfiguration, error) {
 	var storageConfiguration *apiv1.StorageConfiguration
 	for _, tbsConfig := range cluster.Spec.Tablespaces {
-		tbsConfig := tbsConfig
 		if tbsConfig.Name == r.tablespaceName {
 			storageConfiguration = &tbsConfig.Storage
 			break

--- a/tests/e2e/asserts_test.go
+++ b/tests/e2e/asserts_test.go
@@ -2809,7 +2809,6 @@ func AssertPostgresNoPendingRestart(namespace, clusterName string, cmdTimeout ti
 		Eventually(func() (bool, error) {
 			noPendingRestart := true
 			for _, pod := range podList.Items {
-				pod := pod
 				stdout, _, err := env.ExecCommand(env.Ctx, pod, specs.PostgresContainerName, &cmdTimeout,
 					"psql", "-U", "postgres", "-tAc", "SELECT EXISTS(SELECT 1 FROM pg_settings WHERE pending_restart)")
 				if err != nil {

--- a/tests/e2e/configuration_update_test.go
+++ b/tests/e2e/configuration_update_test.go
@@ -169,7 +169,6 @@ var _ = Describe("Configuration update", Ordered, Label(tests.LabelClusterMetada
 		By("verify that work_mem result as expected", func() {
 			// Check that the parameter has been modified in every pod
 			for _, pod := range podList.Items {
-				pod := pod // pin the variable
 				Eventually(func() (int, error, error) {
 					stdout, _, err := env.ExecCommand(env.Ctx, pod, specs.PostgresContainerName, &commandTimeout,
 						"psql", "-U", "postgres", "-tAc", "show work_mem")
@@ -209,7 +208,6 @@ var _ = Describe("Configuration update", Ordered, Label(tests.LabelClusterMetada
 		By("verify that connection should success after pg_hba_reload", func() {
 			// The new pg_hba rule should be present in every pod
 			for _, pod := range podList.Items {
-				pod := pod // pin the variable
 				Eventually(func() (string, error) {
 					stdout, _, err := env.ExecCommand(env.Ctx, pod, specs.PostgresContainerName, &commandTimeout,
 						"psql", "-U", "postgres", "-tAc",
@@ -248,7 +246,6 @@ var _ = Describe("Configuration update", Ordered, Label(tests.LabelClusterMetada
 		By("verify that shared_buffers setting changed", func() {
 			// Check that the new parameter has been modified in every pod
 			for _, pod := range podList.Items {
-				pod := pod
 				Eventually(func() (int, error, error) {
 					stdout, _, err := env.ExecCommand(env.Ctx, pod, specs.PostgresContainerName, &commandTimeout,
 						"psql", "-U", "postgres", "-tAc", "show shared_buffers")
@@ -287,7 +284,6 @@ var _ = Describe("Configuration update", Ordered, Label(tests.LabelClusterMetada
 		By("verify that both parameters have been modified in each pod", func() {
 			// Check that both parameters have been modified in each pod
 			for _, pod := range podList.Items {
-				pod := pod // pin the variable
 				Eventually(func() (int, error, error) {
 					stdout, _, err := env.ExecCommand(env.Ctx, pod, specs.PostgresContainerName, &commandTimeout,
 						"psql", "-U", "postgres", "-tAc", "show max_replication_slots")
@@ -348,7 +344,6 @@ var _ = Describe("Configuration update", Ordered, Label(tests.LabelClusterMetada
 			By("verify that max_connections has been decreased in every pod", func() {
 				// Check that the new parameter has been modified in every pod
 				for _, pod := range podList.Items {
-					pod := pod
 					Eventually(func() (int, error, error) {
 						stdout, _, err := env.ExecCommand(env.Ctx, pod, specs.PostgresContainerName, &commandTimeout,
 							"psql", "-U", "postgres", "-tAc", "show max_connections")
@@ -390,7 +385,6 @@ var _ = Describe("Configuration update", Ordered, Label(tests.LabelClusterMetada
 			By("verify that the max_connections has been set to default in every pod", func() {
 				// Check that the new parameter has been modified in every pod
 				for _, pod := range podList.Items {
-					pod := pod
 					Eventually(func() (int, error, error) {
 						stdout, _, err := env.ExecCommand(env.Ctx, pod, specs.PostgresContainerName, &commandTimeout,
 							"psql", "-U", "postgres", "-tAc", "show max_connections")
@@ -420,7 +414,6 @@ var _ = Describe("Configuration update", Ordered, Label(tests.LabelClusterMetada
 
 		By("check that there is only one entry in pg_ident_file_mappings", func() {
 			for _, pod := range podList.Items {
-				pod := pod // pin the variable
 				if psqlHasIdentView {
 					Eventually(func() (string, error) {
 						stdout, _, err := env.ExecCommand(env.Ctx, pod, specs.PostgresContainerName, &commandTimeout,
@@ -440,7 +433,6 @@ var _ = Describe("Configuration update", Ordered, Label(tests.LabelClusterMetada
 
 		By("verify that there are now two entries in pg_ident_file_mappings", func() {
 			for _, pod := range podList.Items {
-				pod := pod // pin the variable
 				if psqlHasIdentView {
 					Eventually(func() (string, error) {
 						stdout, _, err := env.ExecCommand(env.Ctx, pod, specs.PostgresContainerName, &commandTimeout,
@@ -629,7 +621,6 @@ var _ = Describe("Configuration update with primaryUpdateMethod", Label(tests.La
 
 				// Check that the parameter has been modified in every pod
 				for _, pod := range podList.Items {
-					pod := pod // pin the variable
 					Eventually(func() (int, error, error) {
 						stdout, _, err := env.ExecCommand(env.Ctx, pod, specs.PostgresContainerName, &commandTimeout,
 							"psql", "-U", "postgres", "-tAc", "show work_mem")

--- a/tests/e2e/replica_mode_cluster_test.go
+++ b/tests/e2e/replica_mode_cluster_test.go
@@ -671,7 +671,6 @@ var _ = Describe("Replica switchover", Label(tests.LabelReplication), Ordered, f
 				podList, err := env.GetClusterPodList(namespace, clusterAName)
 				Expect(err).ToNot(HaveOccurred())
 				for _, pod := range podList.Items {
-					pod := pod
 					AssertPgRecoveryMode(&pod, true)
 				}
 			})
@@ -736,7 +735,6 @@ var _ = Describe("Replica switchover", Label(tests.LabelReplication), Ordered, f
 				podList, err := env.GetClusterReplicas(namespace, clusterBName)
 				Expect(err).ToNot(HaveOccurred())
 				for _, pod := range podList.Items {
-					pod := pod
 					AssertPgRecoveryMode(&pod, true)
 				}
 			})

--- a/tests/e2e/tablespaces_test.go
+++ b/tests/e2e/tablespaces_test.go
@@ -495,7 +495,6 @@ var _ = Describe("Tablespaces tests", Label(tests.LabelTablespaces,
 					backupList, err := env.GetBackupList(namespace)
 					g.Expect(err).ToNot(HaveOccurred())
 					for _, backup := range backupList.Items {
-						backup := backup
 						if backup.Name != backupName {
 							continue
 						}

--- a/tests/e2e/upgrade_test.go
+++ b/tests/e2e/upgrade_test.go
@@ -187,7 +187,6 @@ var _ = Describe("Upgrade", Label(tests.LabelUpgrade, tests.LabelNoOpenshift), O
 			commandTimeout := time.Second * 10
 			// Check that both parameters have been modified in each pod
 			for _, pod := range podList.Items {
-				pod := pod // pin the variable
 				Eventually(func() (int, error) {
 					stdout, stderr, err := env.ExecCommand(env.Ctx, pod, specs.PostgresContainerName, &commandTimeout,
 						"psql", "-U", "postgres", "-tAc", "show max_replication_slots")

--- a/tests/utils/openshift.go
+++ b/tests/utils/openshift.go
@@ -201,7 +201,6 @@ func DeleteCSV(env *TestingEnvironment) error {
 		return err
 	}
 	for _, o := range ol.Items {
-		o := o
 		err = DeleteObject(env, &o)
 		if err != nil {
 			if apierrors.IsNotFound(err) {


### PR DESCRIPTION
With the latest version of Go 1.23, the exportloopref linter doesn't
make sense and shouldn't be used, in replace for this, we should
use copyloopvar.

This is also part to add support for Go 1.23 and golangci-lint 1.60.3