### PR TITLE
chore: avoid gosec when calling term.IsTerminal()

### DIFF
--- a/internal/cmd/plugin/color.go
+++ b/internal/cmd/plugin/color.go
@@ -62,7 +62,7 @@ func (e *colorConfiguration) Type() string {
 
 // ConfigureColor renews aurora.DefaultColorizer based on flags and TTY
 func ConfigureColor(cmd *cobra.Command) {
-	configureColor(cmd, term.IsTerminal(int(os.Stdout.Fd())))
+	configureColor(cmd, term.IsTerminal(int(os.Stdout.Fd()))) //nolint:gosec
 }
 
 func configureColor(cmd *cobra.Command, isTTY bool) {


### PR DESCRIPTION
The function IsTerminal() requires an integer as input, in this case,
the use is calling a file descriptor to "/dev/stdout", the problem is
that every file descriptor is a uintptr type, requiring a cast, this cast
from uintptr to int triggers the latest version of the gosec linter.

We avoid the warning by just ignoring the linter since this is the
know way to detect the terminal now.