### PR TITLE
chore: change NodesUsed, PVCCount and JobCount to int

### DIFF
--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -673,7 +673,7 @@ type Topology struct {
 	// be the same as the number of instances in the Postgres HA cluster, implying
 	// shared nothing architecture on the compute side.
 	// +optional
-	NodesUsed int32 `json:"nodesUsed,omitempty"`
+	NodesUsed int `json:"nodesUsed,omitempty"`
 
 	// SuccessfullyExtracted indicates if the topology data was extract. It is useful to enact fallback behaviors
 	// in synchronous replica election in case of failures
@@ -821,11 +821,11 @@ type ClusterStatus struct {
 
 	// How many PVCs have been created by this cluster
 	// +optional
-	PVCCount int32 `json:"pvcCount,omitempty"`
+	PVCCount int `json:"pvcCount,omitempty"`
 
 	// How many Jobs have been created by this cluster
 	// +optional
-	JobCount int32 `json:"jobCount,omitempty"`
+	JobCount int `json:"jobCount,omitempty"`
 
 	// List of all the PVCs created by this cluster and still available
 	// which are not attached to a Pod

--- a/config/crd/bases/postgresql.cnpg.io_clusters.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_clusters.yaml
@@ -5929,7 +5929,6 @@ spec:
                 type: object
               jobCount:
                 description: How many Jobs have been created by this cluster
-                format: int32
                 type: integer
               lastFailedBackup:
                 description: Stored as a date in RFC3339 format
@@ -6068,7 +6067,6 @@ spec:
                 type: object
               pvcCount:
                 description: How many PVCs have been created by this cluster
-                format: int32
                 type: integer
               readService:
                 description: Current list of read pods
@@ -6200,7 +6198,6 @@ spec:
                       implying the absence of High Availability (HA). Ideally, this value should
                       be the same as the number of instances in the Postgres HA cluster, implying
                       shared nothing architecture on the compute side.
-                    format: int32
                     type: integer
                   successfullyExtracted:
                     description: |-

--- a/internal/controller/cluster_status.go
+++ b/internal/controller/cluster_status.go
@@ -250,7 +250,7 @@ func (r *ClusterReconciler) updateResourceStatus(
 	)
 
 	// Count jobs
-	newJobs := int32(len(resources.jobs.Items))
+	newJobs := len(resources.jobs.Items)
 	cluster.Status.JobCount = newJobs
 
 	cluster.Status.Topology = getPodsTopology(
@@ -784,7 +784,7 @@ func getPodsTopology(
 		}
 	}
 
-	return apiv1.Topology{SuccessfullyExtracted: true, Instances: data, NodesUsed: int32(len(nodesMap))}
+	return apiv1.Topology{SuccessfullyExtracted: true, Instances: data, NodesUsed: len(nodesMap)}
 }
 
 // isWALSpaceAvailableOnPod check if a Pod terminated because it has no

--- a/pkg/reconciler/persistentvolumeclaim/status.go
+++ b/pkg/reconciler/persistentvolumeclaim/status.go
@@ -141,7 +141,7 @@ func EnrichStatus(
 	cluster.Status.ReadyInstances = utils.CountReadyPods(filteredPods)
 	cluster.Status.InstancesStatus = utils.ListStatusPods(runningInstances)
 
-	cluster.Status.PVCCount = int32(len(managedPVCs))
+	cluster.Status.PVCCount = len(managedPVCs)
 	cluster.Status.InitializingPVC = result.getSorted(initializing)
 	cluster.Status.ResizingPVC = result.getSorted(resizing)
 	cluster.Status.DanglingPVC = result.getSorted(dangling)

--- a/pkg/specs/poddisruptionbudget.go
+++ b/pkg/specs/poddisruptionbudget.go
@@ -17,6 +17,8 @@ limitations under the License.
 package specs
 
 import (
+	"fmt"
+
 	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -33,8 +35,8 @@ func BuildReplicasPodDisruptionBudget(cluster *apiv1.Cluster) *policyv1.PodDisru
 	if cluster == nil || cluster.Spec.Instances < 3 {
 		return nil
 	}
-	minAvailableReplicas := int32(cluster.Spec.Instances - 2)
-	allReplicasButOne := intstr.FromInt32(minAvailableReplicas)
+	minAvailableReplicas := cluster.Spec.Instances - 2
+	allReplicasButOne := intstr.FromString(fmt.Sprintf("%d", minAvailableReplicas))
 
 	pdb := &policyv1.PodDisruptionBudget{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
The variables NodesUsed, PVCCount and JobCount in the status section
of the Cluster type were fixed to int32, this was triggering the gosec
linter due to casting from int to int32 when it's not needed, all the
operations are coming and process as int.