### PR TITLE
fix: possible race in AvailableArchitecture.GetHash() function

### DIFF
--- a/pkg/utils/discovery.go
+++ b/pkg/utils/discovery.go
@@ -61,21 +61,16 @@ func newAvailableArchitecture(goArch, binaryPath string) *AvailableArchitecture 
 
 // GetHash retrieves the hash for a given AvailableArchitecture
 func (arch *AvailableArchitecture) GetHash() string {
-	if arch.hash == "" {
-		arch.calculateHash()
-	}
-	arch.mx.Lock()
-	defer arch.mx.Unlock()
-	return arch.hash
+	return arch.calculateHash()
 }
 
 // calculateHash calculates the hash for a given AvailableArchitecture
-func (arch *AvailableArchitecture) calculateHash() {
+func (arch *AvailableArchitecture) calculateHash() string {
 	arch.mx.Lock()
 	defer arch.mx.Unlock()
 
 	if arch.hash != "" {
-		return
+		return arch.hash
 	}
 
 	hash, err := arch.hashCalculator(arch.binaryPath)
@@ -84,6 +79,7 @@ func (arch *AvailableArchitecture) calculateHash() {
 	}
 
 	arch.hash = hash
+	return hash
 }
 
 // FileStream opens a stream reading from the manager's binary

--- a/pkg/utils/discovery_test.go
+++ b/pkg/utils/discovery_test.go
@@ -192,7 +192,9 @@ var _ = Describe("AvailableArchitecture", func() {
 			})
 
 			It("should panic with an error", func() {
-				Expect(arch.calculateHash).To(Panic())
+				Expect(func() {
+					arch.calculateHash()
+				}).To(Panic())
 			})
 		})
 	})


### PR DESCRIPTION
Fix a minor race condition in AvailableArchitecture.GetHash(). Although hard to trigger and low impact due to single-write initialization and atomic pointer assignment on most platforms, this update ensures thread safety and consistent behavior.

Closes #5423 

Split from #5297
