### PR TITLE
test: upgrade tests should not pick RC versions as starting point

### DIFF
--- a/tests/utils/release.go
+++ b/tests/utils/release.go
@@ -19,6 +19,7 @@ package utils
 
 import (
 	"errors"
+	"io/fs"
 	"os"
 	"os/exec"
 	"sort"
@@ -60,17 +61,18 @@ func GetAvailableReleases(releasesPath string) ([]*semver.Version, error) {
 		return nil, err
 	}
 
-	for i, file := range fileInfo {
-		if !strings.HasSuffix(file.Name(), ".yaml") {
-			fileInfo = append(fileInfo[:i], fileInfo[i+1:]...)
+	validFiles := make([]fs.DirEntry, 0, len(fileInfo))
+	for _, file := range fileInfo {
+		if strings.HasSuffix(file.Name(), ".yaml") && !strings.Contains(file.Name(), "-rc") {
+			validFiles = append(validFiles, file)
 		}
 	}
 
-	versions := make([]*semver.Version, len(fileInfo))
+	versions := make([]*semver.Version, len(validFiles))
 
 	// build the array that contains the versions
 	// found in the releasePath directory
-	for i, file := range fileInfo {
+	for i, file := range validFiles {
 		tag := extractTag(file.Name())
 		versions[i] = semver.MustParse(tag)
 	}

--- a/tests/utils/release_test.go
+++ b/tests/utils/release_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package utils
 
 import (
-	"os"
 	"path/filepath"
 	"strings"
 
@@ -36,29 +35,31 @@ var _ = Describe("Release tag extraction", func() {
 
 var _ = Describe("Most recent tag", func() {
 	It("properly works with release branch", func() {
-		wd, err := os.Getwd()
+		releasesDir, err := filepath.Abs("../../releases")
 		Expect(err).ToNot(HaveOccurred())
-		releasesDir := filepath.Join(filepath.Dir(filepath.Dir(wd)), "releases")
+
 		versionList, err := GetAvailableReleases(releasesDir)
 		Expect(err).ToNot(HaveOccurred())
 		if len(versionList) < 2 {
 			Skip("because we need two or more releases")
 		}
-		err = os.Setenv("BRANCH_NAME", "release/v"+versions.Version)
-		Expect(err).ToNot(HaveOccurred())
+
+		GinkgoT().Setenv("BRANCH_NAME", "release/v"+versions.Version)
+
 		tag, err := GetMostRecentReleaseTag(releasesDir)
+		Expect(err).ToNot(HaveOccurred())
 		Expect(tag).To(Not(BeEmpty()))
 		Expect(tag).ToNot(BeEquivalentTo(versions.Version))
-		Expect(err).ToNot(HaveOccurred())
 	})
 
 	It("properly works with dev branch", func() {
-		wd, err := os.Getwd()
+		releasesDir, err := filepath.Abs("../../releases")
 		Expect(err).ToNot(HaveOccurred())
-		releasesDir := filepath.Join(filepath.Dir(filepath.Dir(wd)), "releases")
-		err = os.Setenv("BRANCH_NAME", "dev/"+versions.Version)
-		Expect(err).ToNot(HaveOccurred())
+
+		GinkgoT().Setenv("BRANCH_NAME", "dev/"+versions.Version)
+
 		tag, err := GetMostRecentReleaseTag(releasesDir)
+		Expect(err).ToNot(HaveOccurred())
 		Expect(tag).To(Not(BeEmpty()))
 		if strings.Contains(versions.Version, "-rc") {
 			// an RC release should not count as the most recent release
@@ -66,26 +67,22 @@ var _ = Describe("Most recent tag", func() {
 		} else {
 			Expect(tag).To(BeEquivalentTo(versions.Version))
 		}
-		Expect(err).ToNot(HaveOccurred())
 	})
 })
 
-var _ = Describe("Fail on no-existing releases", func() {
-	It("properly error out if the release directory doesn't exists", func() {
-		currentDir, err := os.Getwd()
-		Expect(err).ToNot(HaveOccurred())
-		releaseDir := filepath.Join(filepath.Dir(currentDir), "does-no-exist")
-		versionList, err := GetAvailableReleases(releaseDir)
+var _ = Describe("GetAvailableReleases fails on wrong release directory", func() {
+	It("properly errors out if the release directory doesn't exist", func() {
+		tmpDir := GinkgoT().TempDir()
+		nonexistent := filepath.Join(filepath.Dir(tmpDir), "nonexistent")
+
+		_, err := GetAvailableReleases(nonexistent)
 		Expect(err).To(HaveOccurred())
-		Expect(versionList).To(BeEmpty())
 	})
 
-	It("properly fail if there's no tag", func() {
-		releaseDir, err := os.Getwd()
-		Expect(err).ToNot(HaveOccurred())
+	It("properly fails if there's no release files in the directory", func() {
+		tmpDir := GinkgoT().TempDir()
 
-		tag, err := GetMostRecentReleaseTag(releaseDir)
+		_, err := GetMostRecentReleaseTag(tmpDir)
 		Expect(err).To(HaveOccurred())
-		Expect(tag).To(BeEmpty())
 	})
 })

--- a/tests/utils/release_test.go
+++ b/tests/utils/release_test.go
@@ -19,6 +19,7 @@ package utils
 import (
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/versions"
 
@@ -59,7 +60,12 @@ var _ = Describe("Most recent tag", func() {
 		Expect(err).ToNot(HaveOccurred())
 		tag, err := GetMostRecentReleaseTag(releasesDir)
 		Expect(tag).To(Not(BeEmpty()))
-		Expect(tag).To(BeEquivalentTo(versions.Version))
+		if strings.Contains(versions.Version, "-rc") {
+			// an RC release should not count as the most recent release
+			Expect(tag).NotTo(BeEquivalentTo(versions.Version))
+		} else {
+			Expect(tag).To(BeEquivalentTo(versions.Version))
+		}
 		Expect(err).ToNot(HaveOccurred())
 	})
 })

--- a/tests/utils/release_test.go
+++ b/tests/utils/release_test.go
@@ -69,3 +69,23 @@ var _ = Describe("Most recent tag", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 })
+
+var _ = Describe("Fail on no-existing releases", func() {
+	It("properly error out if the release directory doesn't exists", func() {
+		currentDir, err := os.Getwd()
+		Expect(err).ToNot(HaveOccurred())
+		releaseDir := filepath.Join(filepath.Dir(currentDir), "does-no-exist")
+		versionList, err := GetAvailableReleases(releaseDir)
+		Expect(err).To(HaveOccurred())
+		Expect(versionList).To(BeEmpty())
+	})
+
+	It("properly fail if there's no tag", func() {
+		releaseDir, err := os.Getwd()
+		Expect(err).ToNot(HaveOccurred())
+
+		tag, err := GetMostRecentReleaseTag(releaseDir)
+		Expect(err).To(HaveOccurred())
+		Expect(tag).To(BeEmpty())
+	})
+})


### PR DESCRIPTION
Make sure upgrade tests do not use any pre-release versions as the test starting point.

Partially closes #5331 

Split from #5297
