### PR TITLE
chore: allow proxy utility function to decide the schema

### DIFF
--- a/tests/e2e/asserts_test.go
+++ b/tests/e2e/asserts_test.go
@@ -1442,7 +1442,7 @@ func AssertMetricsData(namespace, targetOne, targetTwo, targetSecret string, clu
 		Expect(err).ToNot(HaveOccurred())
 		for _, pod := range podList.Items {
 			podName := pod.GetName()
-			out, err := testsUtils.RetrieveMetricsFromInstance(env, namespace, podName)
+			out, err := testsUtils.RetrieveMetricsFromInstance(env, namespace, &pod)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(strings.Contains(out, fmt.Sprintf(`cnpg_some_query_rows{datname="%v"} 0`, targetOne))).Should(BeTrue(),
 				"Metric collection issues on %v.\nCollected metrics:\n%v", podName, out)
@@ -2621,7 +2621,7 @@ func collectAndAssertDefaultMetricsPresentOnEachPod(namespace, clusterName strin
 		Expect(err).ToNot(HaveOccurred())
 		for _, pod := range podList.Items {
 			podName := pod.GetName()
-			out, err := testsUtils.RetrieveMetricsFromInstance(env, namespace, podName)
+			out, err := testsUtils.RetrieveMetricsFromInstance(env, namespace, &pod)
 			Expect(err).ToNot(HaveOccurred())
 
 			// error should be zero on each pod metrics
@@ -2677,7 +2677,7 @@ func collectAndAssertCollectorMetricsPresentOnEachPod(namespace, clusterName str
 		Expect(err).ToNot(HaveOccurred())
 		for _, pod := range podList.Items {
 			podName := pod.GetName()
-			out, err := testsUtils.RetrieveMetricsFromInstance(env, namespace, podName)
+			out, err := testsUtils.RetrieveMetricsFromInstance(env, namespace, &pod)
 			Expect(err).ToNot(HaveOccurred())
 
 			// error should be zero on each pod metrics

--- a/tests/e2e/metrics_test.go
+++ b/tests/e2e/metrics_test.go
@@ -126,7 +126,7 @@ var _ = Describe("Metrics", Label(tests.LabelObservability), func() {
 			// Gather metrics in each pod
 			for _, pod := range podList.Items {
 				By(fmt.Sprintf("checking metrics for pod: %s", pod.Name), func() {
-					out, err := utils.RetrieveMetricsFromInstance(env, namespace, pod.Name)
+					out, err := utils.RetrieveMetricsFromInstance(env, namespace, &pod)
 					Expect(err).ToNot(HaveOccurred(), "while getting pod metrics")
 					expectedMetrics := buildExpectedMetrics(metricsCluster, !specs.IsPodPrimary(pod))
 					assertIncludesMetrics(out, expectedMetrics)
@@ -241,7 +241,7 @@ var _ = Describe("Metrics", Label(tests.LabelObservability), func() {
 			// Gather metrics in each pod
 			for _, pod := range podList.Items {
 				By(fmt.Sprintf("checking metrics for pod: %s", pod.Name), func() {
-					out, err := utils.RetrieveMetricsFromInstance(env, namespace, pod.Name)
+					out, err := utils.RetrieveMetricsFromInstance(env, namespace, &pod)
 					Expect(err).ToNot(HaveOccurred(), "while getting pod metrics")
 					assertIncludesMetrics(out, expectedMetrics)
 					assertExcludesMetrics(out, nonCollectableMetrics)
@@ -343,7 +343,7 @@ var _ = Describe("Metrics", Label(tests.LabelObservability), func() {
 			// Gather metrics in each pod
 			expectedMetric := fmt.Sprintf("cnpg_%v_row_count 3", testTableName)
 			for _, pod := range podList.Items {
-				out, err := utils.RetrieveMetricsFromInstance(env, namespace, pod.Name)
+				out, err := utils.RetrieveMetricsFromInstance(env, namespace, &pod)
 				Expect(err).Should(Not(HaveOccurred()))
 				Expect(strings.Split(out, "\n")).Should(ContainElement(expectedMetric))
 			}

--- a/tests/e2e/pgbouncer_metrics_test.go
+++ b/tests/e2e/pgbouncer_metrics_test.go
@@ -104,7 +104,7 @@ var _ = Describe("PGBouncer Metrics", Label(tests.LabelObservability), func() {
 
 			for _, pod := range podList.Items {
 				podName := pod.GetName()
-				out, err := utils.RetrieveMetricsFromPgBouncer(env, namespace, podName)
+				out, err := utils.RetrieveMetricsFromPgBouncer(env, namespace, &pod)
 				Expect(err).ToNot(HaveOccurred())
 				matches := metricsRegexp.FindAllString(out, -1)
 				Expect(matches).To(

--- a/tests/utils/proxy.go
+++ b/tests/utils/proxy.go
@@ -19,15 +19,19 @@ package utils
 import (
 	"strconv"
 
+
+	corev1 "k8s.io/api/core/v1"
+
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/url"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/resources/instance"
 )
 
 // runProxyRequest makes a GET call on the pod interface proxy, and returns the raw response
-func runProxyRequest(env *TestingEnvironment, namespace, podName, path string, port int) ([]byte, error) {
+func runProxyRequest(env *TestingEnvironment, pod *corev1.Pod, namespace, path string, port int) ([]byte, error) {
 	portString := strconv.Itoa(port)
 
 	req := env.Interface.CoreV1().Pods(namespace).ProxyGet(
-		"http", podName, portString, path, map[string]string{})
+		instance.GetStatusSchemeFromPod(pod).ToString(), pod.Name, portString, path, map[string]string{})
 
 	return req.DoRaw(env.Ctx)
 }
@@ -36,9 +40,10 @@ func runProxyRequest(env *TestingEnvironment, namespace, podName, path string, p
 // using a GET request on the pod interface proxy
 func RetrieveMetricsFromInstance(
 	env *TestingEnvironment,
-	namespace, podName string,
+	namespace string,
+	pod *corev1.Pod,
 ) (string, error) {
-	body, err := runProxyRequest(env, namespace, podName, url.PathMetrics, int(url.PostgresMetricsPort))
+	body, err := runProxyRequest(env, pod, namespace, url.PathMetrics, int(url.PostgresMetricsPort))
 	return string(body), err
 }
 
@@ -46,8 +51,9 @@ func RetrieveMetricsFromInstance(
 // using a GET request on the pod interface proxy
 func RetrieveMetricsFromPgBouncer(
 	env *TestingEnvironment,
-	namespace, podName string,
+	namespace string,
+	pod *corev1.Pod,
 ) (string, error) {
-	body, err := runProxyRequest(env, namespace, podName, url.PathMetrics, int(url.PgBouncerMetricsPort))
+	body, err := runProxyRequest(env, pod, namespace, url.PathMetrics, int(url.PgBouncerMetricsPort))
 	return string(body), err
 }


### PR DESCRIPTION
The function to retrieve the metrics, status, etc in the utility was
using a fixed schema, this didn't allow to query pods with HTTPS enabled.

Split from #5297