### PR TITLE
fix: avoid skipping log lines longer than 64k

### DIFF
--- a/internal/cmd/manager/pgbouncer/run/log.go
+++ b/internal/cmd/manager/pgbouncer/run/log.go
@@ -39,6 +39,7 @@ func (p *pgBouncerLogWriter) Write(in []byte) (n int, err error) {
 	currentLogLine := ""
 
 	sc := bufio.NewScanner(bytes.NewReader(in))
+	sc.Buffer(make([]byte, 0, 4096), 1024*1024)
 	for sc.Scan() {
 		logLine := sc.Text()
 		if strings.HasPrefix(logLine, "\t") {

--- a/pkg/fileutils/fileutils.go
+++ b/pkg/fileutils/fileutils.go
@@ -266,6 +266,7 @@ func ReadFileLines(fileName string) (lines []string, err error) {
 	}()
 
 	fileScanner := bufio.NewScanner(readFile)
+	fileScanner.Buffer(make([]byte, 0, 4096), 1024*1024)
 	fileScanner.Split(bufio.ScanLines)
 
 	for fileScanner.Scan() {

--- a/pkg/management/execlog/execlog.go
+++ b/pkg/management/execlog/execlog.go
@@ -139,6 +139,7 @@ func copyPipe(dst io.Writer, src io.ReadCloser, logger log.Logger) {
 	}()
 
 	scanner := bufio.NewScanner(src)
+	scanner.Buffer(make([]byte, 0, 4096), 1024*1024)
 
 	for scanner.Scan() {
 		line := scanner.Bytes()

--- a/pkg/management/postgres/logpipe/linelogpipe.go
+++ b/pkg/management/postgres/logpipe/linelogpipe.go
@@ -179,6 +179,7 @@ func (p *LineLogPipe) collectLogsFromFile(ctx context.Context) error {
 // decoded invalid line
 func (p *LineLogPipe) streamLogFromFile(ctx context.Context, reader io.Reader) error {
 	scanner := bufio.NewScanner(reader)
+	scanner.Buffer(make([]byte, 0, 4096), 1024*1024)
 	for scanner.Scan() {
 		line := scanner.Bytes()
 		p.handler(line)

--- a/pkg/utils/logs/logs.go
+++ b/pkg/utils/logs/logs.go
@@ -172,6 +172,7 @@ func GetPodLogs(
 	rd := bufio.NewReader(logStream)
 	teedReader := io.TeeReader(rd, writer)
 	scanner := bufio.NewScanner(teedReader)
+	scanner.Buffer(make([]byte, 0, 4096), 1024*1024)
 
 	if requestedLineLength <= 0 {
 		requestedLineLength = 10

--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -150,7 +150,7 @@ var _ = SynchronizedAfterSuite(func() {
 // of output are not legal JSON
 func saveLogs(buf *bytes.Buffer, logsType, specName string, output io.Writer, capLines int) {
 	scanner := bufio.NewScanner(buf)
-	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	scanner.Buffer(make([]byte, 0, 4096), 1024*1024)
 	filename := fmt.Sprintf("out/%s_%s.log", logsType, specName)
 	f, err := os.Create(filepath.Clean(filename))
 	if err != nil {

--- a/tests/utils/namespace.go
+++ b/tests/utils/namespace.go
@@ -90,7 +90,7 @@ func saveNamespaceLogs(
 	capLines int,
 ) {
 	scanner := bufio.NewScanner(buf)
-	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	scanner.Buffer(make([]byte, 0, 4096), 1024*1024)
 	filename := fmt.Sprintf("out/%s_ns-%s_%s.log", logsType, namespace, specName)
 	f, createErr := os.Create(filepath.Clean(filename))
 	if createErr != nil {


### PR DESCRIPTION
This patch increases the line buffer limit of every `bufio.Scanner` we use from 64k to 1MB. It also ensures the starting buffer is 4k to avoid wasting memory.

# Release Notes

Fixed an issue where log lines longer than 64k were skipped by increasing the buffer limit to 1MB.