### PR TITLE
test(e2e): add tests for metrics with TLS enabled

### DIFF
--- a/tests/e2e/asserts_test.go
+++ b/tests/e2e/asserts_test.go
@@ -1445,9 +1445,13 @@ func AssertMetricsData(namespace, targetOne, targetTwo, targetSecret string, clu
 	By("collect and verify metric being exposed with target databases", func() {
 		podList, err := env.GetClusterPodList(namespace, cluster.Name)
 		Expect(err).ToNot(HaveOccurred())
+		metricsSchema := "http"
+		if cluster.IsMetricsTLSEnabled() {
+			metricsSchema = "https"
+		}
 		for _, pod := range podList.Items {
 			podName := pod.GetName()
-			out, err := testsUtils.RetrieveMetricsFromInstance(env, namespace, podName)
+			out, err := testsUtils.RetrieveMetricsFromInstance(env, metricsSchema, pod)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(strings.Contains(out, fmt.Sprintf(`cnpg_some_query_rows{datname="%v"} 0`, targetOne))).Should(BeTrue(),
 				"Metric collection issues on %v.\nCollected metrics:\n%v", podName, out)
@@ -2604,7 +2608,7 @@ func DeleteTableUsingPgBouncerService(
 	Expect(err).ToNot(HaveOccurred())
 }
 
-func collectAndAssertDefaultMetricsPresentOnEachPod(namespace, clusterName string, expectPresent bool) {
+func collectAndAssertDefaultMetricsPresentOnEachPod(namespace, clusterName, metricSchema string, expectPresent bool) {
 	By("collecting and verifying a set of default metrics on each pod", func() {
 		defaultMetrics := []string{
 			"cnpg_pg_settings_setting",
@@ -2626,7 +2630,7 @@ func collectAndAssertDefaultMetricsPresentOnEachPod(namespace, clusterName strin
 		Expect(err).ToNot(HaveOccurred())
 		for _, pod := range podList.Items {
 			podName := pod.GetName()
-			out, err := testsUtils.RetrieveMetricsFromInstance(env, namespace, podName)
+			out, err := testsUtils.RetrieveMetricsFromInstance(env, metricSchema, pod)
 			Expect(err).ToNot(HaveOccurred())
 
 			// error should be zero on each pod metrics
@@ -2649,7 +2653,7 @@ func collectAndAssertDefaultMetricsPresentOnEachPod(namespace, clusterName strin
 }
 
 // collectAndAssertMetricsPresentOnEachPod verify a set of metrics is existed in each pod
-func collectAndAssertCollectorMetricsPresentOnEachPod(namespace, clusterName string) {
+func collectAndAssertCollectorMetricsPresentOnEachPod(cluster *apiv1.Cluster) {
 	cnpgCollectorMetrics := []string{
 		"cnpg_collector_collection_duration_seconds",
 		"cnpg_collector_fencing_on",
@@ -2678,11 +2682,17 @@ func collectAndAssertCollectorMetricsPresentOnEachPod(namespace, clusterName str
 		)
 	}
 	By("collecting and verify set of collector metrics on each pod", func() {
-		podList, err := env.GetClusterPodList(namespace, clusterName)
+		podList, err := env.GetClusterPodList(cluster.Namespace, cluster.Name)
 		Expect(err).ToNot(HaveOccurred())
+
+		metricsSchema := "http"
+		if cluster.IsMetricsTLSEnabled() {
+			metricsSchema = "https"
+		}
+
 		for _, pod := range podList.Items {
 			podName := pod.GetName()
-			out, err := testsUtils.RetrieveMetricsFromInstance(env, namespace, podName)
+			out, err := testsUtils.RetrieveMetricsFromInstance(env, metricsSchema, pod)
 			Expect(err).ToNot(HaveOccurred())
 
 			// error should be zero on each pod metrics

--- a/tests/e2e/backup_restore_test.go
+++ b/tests/e2e/backup_restore_test.go
@@ -75,7 +75,6 @@ var _ = Describe("Backup and restore", Label(tests.LabelBackupRestore), func() {
 			var err error
 			clusterName, err = env.GetResourceNameFromYAML(clusterWithMinioSampleFile)
 			Expect(err).ToNot(HaveOccurred())
-
 			namespace, err = env.CreateUniqueNamespace(namespacePrefix)
 			Expect(err).ToNot(HaveOccurred())
 			DeferCleanup(func() error {

--- a/tests/e2e/backup_restore_test.go
+++ b/tests/e2e/backup_restore_test.go
@@ -75,6 +75,7 @@ var _ = Describe("Backup and restore", Label(tests.LabelBackupRestore), func() {
 			var err error
 			clusterName, err = env.GetResourceNameFromYAML(clusterWithMinioSampleFile)
 			Expect(err).ToNot(HaveOccurred())
+
 			namespace, err = env.CreateUniqueNamespace(namespacePrefix)
 			Expect(err).ToNot(HaveOccurred())
 			DeferCleanup(func() error {

--- a/tests/e2e/config_support_test.go
+++ b/tests/e2e/config_support_test.go
@@ -23,7 +23,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
-	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/tests"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils"
 
@@ -44,8 +43,6 @@ var _ = Describe("Config support", Serial, Ordered, Label(tests.LabelDisruptive,
 		level                          = tests.Low
 	)
 	var operatorNamespace, namespace string
-	var cluster *apiv1.Cluster
-	var err error
 
 	BeforeEach(func() {
 		if testLevelEnv.Depth < int(level) {
@@ -137,7 +134,7 @@ var _ = Describe("Config support", Serial, Ordered, Label(tests.LabelDisruptive,
 	})
 
 	It("verify label's and annotation's inheritance when global config-map changed", func() {
-		cluster, err = env.GetCluster(namespace, clusterName)
+		cluster, err := env.GetCluster(namespace, clusterName)
 		Expect(err).NotTo(HaveOccurred())
 
 		By("checking the cluster has the requested labels", func() {
@@ -183,10 +180,9 @@ var _ = Describe("Config support", Serial, Ordered, Label(tests.LabelDisruptive,
 	// Setting MONITORING_QUERIES_CONFIGMAP: "" should disable monitoring
 	// queries on new cluster. We expect those metrics to be missing.
 	It("verify metrics details when updated default monitoring configMap queries parameter is set to be empty", func() {
-		metricSchema := "http"
-		if cluster.IsMetricsTLSEnabled() {
-			metricSchema = "https"
-		}
-		collectAndAssertDefaultMetricsPresentOnEachPod(namespace, clusterName, metricSchema, false)
+		cluster, err := env.GetCluster(namespace, clusterName)
+		Expect(err).NotTo(HaveOccurred())
+
+		collectAndAssertDefaultMetricsPresentOnEachPod(namespace, clusterName, cluster.IsMetricsTLSEnabled(), false)
 	})
 })

--- a/tests/e2e/config_support_test.go
+++ b/tests/e2e/config_support_test.go
@@ -23,6 +23,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
+	v1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/tests"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils"
 
@@ -43,7 +44,8 @@ var _ = Describe("Config support", Serial, Ordered, Label(tests.LabelDisruptive,
 		level                          = tests.Low
 	)
 	var operatorNamespace, namespace string
-
+	var cluster *v1.Cluster
+	var err error
 	BeforeEach(func() {
 		if testLevelEnv.Depth < int(level) {
 			Skip("Test depth is lower than the amount requested for this test")
@@ -134,7 +136,7 @@ var _ = Describe("Config support", Serial, Ordered, Label(tests.LabelDisruptive,
 	})
 
 	It("verify label's and annotation's inheritance when global config-map changed", func() {
-		cluster, err := env.GetCluster(namespace, clusterName)
+		cluster, err = env.GetCluster(namespace, clusterName)
 		Expect(err).NotTo(HaveOccurred())
 
 		By("checking the cluster has the requested labels", func() {
@@ -180,6 +182,10 @@ var _ = Describe("Config support", Serial, Ordered, Label(tests.LabelDisruptive,
 	// Setting MONITORING_QUERIES_CONFIGMAP: "" should disable monitoring
 	// queries on new cluster. We expect those metrics to be missing.
 	It("verify metrics details when updated default monitoring configMap queries parameter is set to be empty", func() {
-		collectAndAssertDefaultMetricsPresentOnEachPod(namespace, clusterName, false)
+		metricSchema := "http"
+		if cluster.IsMetricsTLSEnabled() {
+			metricSchema = "https"
+		}
+		collectAndAssertDefaultMetricsPresentOnEachPod(namespace, clusterName, metricSchema, false)
 	})
 })

--- a/tests/e2e/config_support_test.go
+++ b/tests/e2e/config_support_test.go
@@ -23,7 +23,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
-	v1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/tests"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils"
 
@@ -44,8 +44,9 @@ var _ = Describe("Config support", Serial, Ordered, Label(tests.LabelDisruptive,
 		level                          = tests.Low
 	)
 	var operatorNamespace, namespace string
-	var cluster *v1.Cluster
+	var cluster *apiv1.Cluster
 	var err error
+
 	BeforeEach(func() {
 		if testLevelEnv.Depth < int(level) {
 			Skip("Test depth is lower than the amount requested for this test")

--- a/tests/e2e/fixtures/metrics/cluster-metrics-tls.yaml.template
+++ b/tests/e2e/fixtures/metrics/cluster-metrics-tls.yaml.template
@@ -1,0 +1,51 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: postgresql-metrics
+spec:
+  instances: 3
+
+  postgresql:
+    parameters:
+      log_checkpoints: "on"
+      log_lock_waits: "on"
+      log_min_duration_statement: '1000'
+      log_statement: 'ddl'
+      log_temp_files: '1024'
+      log_autovacuum_min_duration: '1s'
+      log_replication_commands: 'on'
+
+  # Example of rolling update strategy:
+  # - unsupervised: automated update of the primary once all
+  #                 replicas have been upgraded (default)
+  # - supervised: requires manual supervision to perform
+  #               the switchover of the primary
+  primaryUpdateStrategy: unsupervised
+
+  bootstrap:
+    initdb:
+      database: app
+      owner: app
+
+  monitoring:
+    customQueriesConfigMap:
+      - name: monitoring-01
+        key: queries.yaml
+      - name: monitoring-01
+        key: additional-queries
+      - name: monitoring-02
+        key: queries.yaml
+      - name: monitoring-02
+        key: additional-queries
+    customQueriesSecret:
+      - name: monitoring-01
+        key: queries.yaml
+      - name: monitoring-01
+        key: additional-queries
+    tls:
+        enabled: true
+
+  # Persistent storage configuration
+  storage:
+    storageClass: ${E2E_DEFAULT_STORAGE_CLASS}
+    size: 1Gi

--- a/tests/e2e/metrics_test.go
+++ b/tests/e2e/metrics_test.go
@@ -335,8 +335,10 @@ var _ = Describe("Metrics", Label(tests.LabelObservability), func() {
 
 		// Create the cluster
 		AssertCreateCluster(namespace, metricsClusterName, defaultMonitoringQueriesDisableSampleFile, env)
+
 		cluster, err := env.GetCluster(namespace, metricsClusterName)
 		Expect(err).ToNot(HaveOccurred())
+
 		metricsSchema := "http"
 		if cluster.IsMetricsTLSEnabled() {
 			metricsSchema = "https"

--- a/tests/e2e/pgbouncer_metrics_test.go
+++ b/tests/e2e/pgbouncer_metrics_test.go
@@ -104,7 +104,7 @@ var _ = Describe("PGBouncer Metrics", Label(tests.LabelObservability), func() {
 
 			for _, pod := range podList.Items {
 				podName := pod.GetName()
-				out, err := utils.RetrieveMetricsFromPgBouncer(env, namespace, podName)
+				out, err := utils.RetrieveMetricsFromPgBouncer(env, pod)
 				Expect(err).ToNot(HaveOccurred())
 				matches := metricsRegexp.FindAllString(out, -1)
 				Expect(matches).To(

--- a/tests/utils/yaml.go
+++ b/tests/utils/yaml.go
@@ -28,7 +28,7 @@ import (
 )
 
 // ParseObjectsFromYAML parses a series of kubernetes objects defined in a YAML payload,
-// into the specified namespace
+// into the specified namespace.
 func ParseObjectsFromYAML(data []byte, namespace string) ([]client.Object, error) {
 	wrapErr := func(err error) error { return fmt.Errorf("while parsingObjectsFromYAML: %w", err) }
 	err := apiv1.AddToScheme(scheme.Scheme)


### PR DESCRIPTION
Add end-to-end tests to ensure monitoring metrics work correctly with TLS enabled.

Closes #5428 