### PR TITLE
test: remove redundant test for cobra library functionality

### DIFF
--- a/internal/cmd/plugin/logs/cluster_test.go
+++ b/internal/cmd/plugin/logs/cluster_test.go
@@ -58,11 +58,6 @@ var _ = Describe("Test the command", func() {
 		WithScheme(scheme.BuildWithAllKnownScheme()).
 		WithObjects(cluster).
 		Build()
-	It("should get the command help", func() {
-		cmd := clusterCmd()
-		// A panic happens when a tested function returns with os.Exit(0)
-		Expect(func() { _ = cmd.Execute() }).Should(Panic())
-	})
 
 	It("should not fail, with cluster name as argument", func() {
 		cmd := clusterCmd()


### PR DESCRIPTION
This test does not verify our code; instead, it tests the functionality of the cobra library, which is outside our scope. Additionally, the test is unreliable as it inherits arguments from the test command line, causing unpredictable behavior. It also outputs the help text directly into the test results, leading to confusing and misleading test output. Removing this test will help maintain clarity and focus on our codebase.