### PR TITLE
test(e2e): ensure AssertSwitchoverWithHistory() waits for cluster readiness

### DIFF
--- a/tests/e2e/asserts_test.go
+++ b/tests/e2e/asserts_test.go
@@ -142,6 +142,11 @@ func AssertSwitchoverWithHistory(
 		}, timeout).Should(BeTrue())
 	})
 
+	// After we finish the switchover, we should wait for the cluster to be ready
+	// otherwise, anyone executing this may not wait and also, the following part of the function
+	// may fail because the switchover hasn't properly finish yet.
+	AssertClusterIsReady(namespace, clusterName, testTimeouts[testsUtils.ClusterIsReady], env)
+
 	if !isReplica {
 		By("confirming that the all postgres containers have *.history file after switchover", func() {
 			pods = []string{}

--- a/tests/e2e/replica_mode_cluster_test.go
+++ b/tests/e2e/replica_mode_cluster_test.go
@@ -101,8 +101,6 @@ var _ = Describe("Replica Mode", Label(tests.LabelReplication), func() {
 
 			AssertSwitchoverOnReplica(replicaNamespace, replicaName, env)
 
-			AssertClusterIsReady(replicaNamespace, replicaName, testTimeouts[testUtils.ClusterIsReady], env)
-
 			assertReplicaClusterTopology(replicaNamespace, replicaName)
 		})
 	})


### PR DESCRIPTION
Update the `AssertSwitchoverWithHistory()` function to include a wait until the cluster is fully ready after a switchover. This change addresses potential issues with test timing and execution by ensuring that tests do not proceed until the cluster is confirmed to be in a stable state.

Closes #5436 