### PR TITLE
chore: add E2E test backup tools to Renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -261,6 +261,24 @@
       "depNameTemplate": "golangci/golangci-lint",
       "versioningTemplate": "loose",
       "extractVersionTemplate": "^v(?<version>\\d+\\.\\d+\\.\\d+)"
+    }, {
+      "fileMatch": ["^.github/workflows/continuous-delivery.yml",],
+      "matchStrings": [
+        "VELERO_VERSION: \"v(?<currentValue>.*?)\"",
+      ],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "vmware-tanzu/velero",
+      "versioningTemplate": "loose",
+      "extractVersionTemplate": "^(?<version>v\\d+\\.\\d+\\.\\d+)"
+    }, {
+      "fileMatch": ["^.github/workflows/continuous-delivery.yml",],
+      "matchStrings": [
+        "VELERO_AWS_PLUGIN_VERSION: \"v(?<currentValue>.*?)\"",
+      ],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "vmware-tanzu/velero-plugin-for-aws",
+      "versioningTemplate": "loose",
+      "extractVersionTemplate": "^(?<version>v\\d+\\.\\d+\\.\\d+)"
     }
   ],
   "packageRules": [
@@ -377,6 +395,14 @@
       ],
       "separateMajorMinor": "false",
       "pinDigests": false
+    }, {
+// PR group for backup test tools
+      "groupName": "backup test tools",
+      "matchPackagePrefixes": [
+        "vmware-tanzu",
+      ],
+      "separateMajorMinor": "false",
+      "pinDigests": false
     },
     {
 // PR group for all the operator framework related things
@@ -384,7 +410,7 @@
       "matchPackagePrefixes": [
         "operator-framework",
         "redhat-openshift-ecosystem",
-	"quay.io/operator-framework",
+        "quay.io/operator-framework",
       ],
       "separateMajorMinor": "false",
       "pinDigests": false

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -1341,8 +1341,8 @@ jobs:
         name: Setup Velero
         uses: nick-fields/retry@v3
         env:
-          VELERO_VERSION: v1.9.2
-          VELERO_AWS_PLUGIN_VERSION: v1.5.1
+          VELERO_VERSION: "v1.9.2"
+          VELERO_AWS_PLUGIN_VERSION: "v1.5.1"
         with:
           timeout_minutes: 10
           max_attempts: 3


### PR DESCRIPTION
Use renovate to automate the update of E2E test backup tools.