### PR TITLE
chore(goreleaser): change deprecated variable in GoReleaser template

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -98,7 +98,7 @@ checksum:
   name_template: '{{ .ProjectName }}-{{ .Version }}-checksums.txt'
 
 snapshot:
-  name_template: "{{ .Tag }}-next"
+  version_template: "{{ .Tag }}-next"
 
 changelog:
   disable: true


### PR DESCRIPTION
Since version 2.2 of GoReleaser the snapshot.name_template was deprecated
and replace by snapshot.version_template. More information about this issue here: https://goreleaser.com/deprecations/#snapshotname_template

Closes #5446 