### PR TITLE
chore(ci): Avoid goreleaser-action warning

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -342,7 +342,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
-          version: latest
+          version: v2
           args: ${{ env.BUILD_MANAGER_RELEASE_ARGS }}
         env:
           DATE: ${{ env.DATE }}
@@ -463,7 +463,7 @@ jobs:
           needs.evaluate_options.outputs.test_level == '4'
         with:
           distribution: goreleaser
-          version: latest
+          version: v2
           args: ${{ env.BUILD_MANAGER_RELEASE_ARGS }}
         env:
           DATE: ${{ env.DATE }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -480,7 +480,7 @@ jobs:
           )
         with:
           distribution: goreleaser
-          version: latest
+          version: v2
           args: ${{ env.BUILD_PLUGIN_RELEASE_ARGS }}
         env:
           DATE: ${{ env.DATE }}
@@ -513,7 +513,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
-          version: latest
+          version: v2
           args: ${{ env.BUILD_MANAGER_RELEASE_ARGS }}
         env:
           DATE: ${{ env.DATE }}

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -148,7 +148,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
-          version: latest
+          version: v2
           args: release --clean --timeout 60m
         env:
           DATE: ${{ env.DATE }}


### PR DESCRIPTION
We were setting the goreleaser version to `latest` this was triggering a warning
saying going back to v2, now we set it to v2 to avoid any error or warning.