### PR TITLE
fix: primary is not switchover when adding wal storage

### DIFF
--- a/internal/controller/cluster_upgrade.go
+++ b/internal/controller/cluster_upgrade.go
@@ -235,8 +235,8 @@ func (r *ClusterReconciler) updateRestartAnnotation(
 type rollout struct {
 	required     bool
 	canBeInPlace bool
-	// if primaryForceRecreate is true, the old pod will be
-	// recreated no matter what primaryUpdateMethod is set
+	// primaryForceRecreate indicates if old primary will force recreate the pod instead
+	// of demote and switchover
 	primaryForceRecreate bool
 	reason               string
 }
@@ -497,8 +497,10 @@ func checkPodInitContainerIsOutdated(pod *corev1.Pod, _ *apiv1.Cluster) (rollout
 }
 
 func checkHasMissingPVCs(pod *corev1.Pod, cluster *apiv1.Cluster) (rollout, error) {
-	missingPVC, missingTbsPVC := persistentvolumeclaim.InstanceHasMissingMounts(cluster, pod)
-	if missingPVC {
+	if missingPVC, missingTbsPVC := persistentvolumeclaim.InstanceHasMissingMounts(
+		cluster,
+		pod,
+	); missingPVC {
 		return rollout{
 			required: true,
 			// we force the recreation of the primary pod if the tablespace PVC is missing


### PR DESCRIPTION
Under `primaryUpdateMethod=switchover` and add wal volume in cluster, 
after standby is restarted, the old primary pod is not doing a switchover but 
restart itself with primary role not changed.  The old primary should switchover first
then let podSpec decide if a recreate pod is needed. 

closes: #5484 