### PR TITLE
fix(PDB): remove replicas PDB when scaling down to 2 instances

### DIFF
--- a/docs/src/kubernetes_upgrade.md
+++ b/docs/src/kubernetes_upgrade.md
@@ -55,8 +55,8 @@ ahead of the drain. Once the instance in the node is downgraded to replica, the
 draining can resume.
 For single-instance clusters, a switchover is not possible, so CloudNativePG
 will prevent draining the node where the instance is housed.
-Additionally, in multi-instance clusters, CloudNativePG guarantees that only
-one replica at a time is gracefully shut down during a drain operation.
+Additionally, in clusters with 3 or more instances, CloudNativePG guarantees that
+only one replica at a time is gracefully shut down during a drain operation.
 
 Each PostgreSQL `Cluster` is equipped with two associated `PodDisruptionBudget`
 resources - you can easily confirm it with the `kubectl get pdb` command.

--- a/internal/controller/cluster_create.go
+++ b/internal/controller/cluster_create.go
@@ -108,50 +108,43 @@ func (r *ClusterReconciler) createPostgresClusterObjects(ctx context.Context, cl
 
 func (r *ClusterReconciler) reconcilePodDisruptionBudget(ctx context.Context, cluster *apiv1.Cluster) error {
 	if !cluster.GetEnablePDB() {
-		return r.deletePodDisruptionBudgetIfExists(ctx, cluster)
+		return r.deletePodDisruptionBudgetsIfExist(ctx, cluster)
 	}
 
-	// The PDB should not be enforced if we are inside a maintenance
-	// window, and we chose to avoid allocating more storage space.
+	primaryPDB := specs.BuildPrimaryPodDisruptionBudget(cluster)
+	replicaPDB := specs.BuildReplicasPodDisruptionBudget(cluster)
+
 	if cluster.IsNodeMaintenanceWindowInProgress() && cluster.IsReusePVCEnabled() {
-		if err := r.deleteReplicasPodDisruptionBudget(ctx, cluster); err != nil {
+		// The replica PDB should not be enforced if we are inside a maintenance
+		// window, and we chose to avoid allocating more storage space.
+		replicaPDB = nil
+
+		// If this a single-instance cluster, we need to delete
+		// the PodDisruptionBudget for the primary node too
+		// otherwise the user won't be able to drain the workloads
+		// from the underlying node.
+		if cluster.Spec.Instances == 1 {
+			primaryPDB = nil
+		}
+	}
+
+	if primaryPDB != nil {
+		if err := r.createOrPatchOwnedPodDisruptionBudget(ctx, cluster, primaryPDB); err != nil {
 			return err
 		}
-
-		if cluster.Spec.Instances == 1 {
-			// If this a single-instance cluster, we need to delete
-			// the PodDisruptionBudget for the primary node too
-			// otherwise the user won't be able to drain the workloads
-			// from the underlying node.
-			return r.deletePrimaryPodDisruptionBudget(ctx, cluster)
-		}
-
-		// Make sure that if the cluster was scaled down and scaled up
-		// we create the primary PDB even if we're under a maintenance window
-		return r.createOrPatchOwnedPodDisruptionBudget(ctx,
-			cluster,
-			specs.BuildPrimaryPodDisruptionBudget(cluster),
-		)
-	}
-
-	// Reconcile the primary PDB
-	err := r.createOrPatchOwnedPodDisruptionBudget(ctx,
-		cluster,
-		specs.BuildPrimaryPodDisruptionBudget(cluster),
-	)
-	if err != nil {
+	} else if err := r.deletePrimaryPodDisruptionBudgetIfExists(ctx, cluster); err != nil {
 		return err
 	}
 
-	replicaPDB := specs.BuildReplicasPodDisruptionBudget(cluster)
-	if replicaPDB == nil {
-		return r.deleteReplicasPodDisruptionBudget(ctx, cluster)
+	if replicaPDB != nil {
+		if err := r.createOrPatchOwnedPodDisruptionBudget(ctx, cluster, replicaPDB); err != nil {
+			return err
+		}
+	} else if err := r.deleteReplicasPodDisruptionBudgetIfExists(ctx, cluster); err != nil {
+		return err
 	}
 
-	return r.createOrPatchOwnedPodDisruptionBudget(ctx,
-		cluster,
-		replicaPDB,
-	)
+	return nil
 }
 
 func (r *ClusterReconciler) reconcilePostgresSecrets(ctx context.Context, cluster *apiv1.Cluster) error {
@@ -510,33 +503,40 @@ func (r *ClusterReconciler) createOrPatchOwnedPodDisruptionBudget(
 	return nil
 }
 
-func (r *ClusterReconciler) deletePodDisruptionBudgetIfExists(ctx context.Context, cluster *apiv1.Cluster) error {
-	if err := r.deletePrimaryPodDisruptionBudget(ctx, cluster); err != nil && !apierrs.IsNotFound(err) {
-		return fmt.Errorf("unable to retrieve primary PodDisruptionBudget: %w", err)
+func (r *ClusterReconciler) deletePodDisruptionBudgetsIfExist(ctx context.Context, cluster *apiv1.Cluster) error {
+	if err := r.deletePrimaryPodDisruptionBudgetIfExists(ctx, cluster); err != nil {
+		return err
 	}
 
-	if err := r.deleteReplicasPodDisruptionBudget(ctx, cluster); err != nil && !apierrs.IsNotFound(err) {
-		return fmt.Errorf("unable to retrieve replica PodDisruptionBudget: %w", err)
+	if err := r.deleteReplicasPodDisruptionBudgetIfExists(ctx, cluster); err != nil {
+		return err
 	}
 
 	return nil
 }
 
-// deleteReplicasPodDisruptionBudget ensures that we delete the PDB requiring to remove one node at a time
-func (r *ClusterReconciler) deletePrimaryPodDisruptionBudget(ctx context.Context, cluster *apiv1.Cluster) error {
-	return r.deletePodDisruptionBudget(
+func (r *ClusterReconciler) deletePrimaryPodDisruptionBudgetIfExists(
+	ctx context.Context,
+	cluster *apiv1.Cluster,
+) error {
+	return r.deletePodDisruptionBudgetIfExists(
 		ctx,
 		cluster,
 		client.ObjectKey{Name: cluster.Name + apiv1.PrimaryPodDisruptionBudgetSuffix, Namespace: cluster.Namespace})
 }
 
-// deleteReplicasPodDisruptionBudget ensures that we delete the PDB requiring to remove one node at a time
-func (r *ClusterReconciler) deleteReplicasPodDisruptionBudget(ctx context.Context, cluster *apiv1.Cluster) error {
-	return r.deletePodDisruptionBudget(ctx, cluster, client.ObjectKey{Name: cluster.Name, Namespace: cluster.Namespace})
+func (r *ClusterReconciler) deleteReplicasPodDisruptionBudgetIfExists(
+	ctx context.Context,
+	cluster *apiv1.Cluster,
+) error {
+	return r.deletePodDisruptionBudgetIfExists(
+		ctx,
+		cluster,
+		client.ObjectKey{Name: cluster.Name, Namespace: cluster.Namespace},
+	)
 }
 
-// deleteReplicasPodDisruptionBudget ensures that we delete the PDB requiring to remove one node at a time
-func (r *ClusterReconciler) deletePodDisruptionBudget(
+func (r *ClusterReconciler) deletePodDisruptionBudgetIfExists(
 	ctx context.Context,
 	cluster *apiv1.Cluster,
 	key types.NamespacedName,

--- a/internal/controller/cluster_create.go
+++ b/internal/controller/cluster_create.go
@@ -143,9 +143,14 @@ func (r *ClusterReconciler) reconcilePodDisruptionBudget(ctx context.Context, cl
 		return err
 	}
 
+	replicaPDB := specs.BuildReplicasPodDisruptionBudget(cluster)
+	if replicaPDB == nil {
+		return r.deleteReplicasPodDisruptionBudget(ctx, cluster)
+	}
+
 	return r.createOrPatchOwnedPodDisruptionBudget(ctx,
 		cluster,
-		specs.BuildReplicasPodDisruptionBudget(cluster),
+		replicaPDB,
 	)
 }
 

--- a/internal/controller/cluster_create_test.go
+++ b/internal/controller/cluster_create_test.go
@@ -1042,7 +1042,7 @@ var _ = Describe("createOrPatchOwnedPodDisruptionBudget", func() {
 	})
 })
 
-var _ = Describe("deletePodDisruptionBudgetIfExists", func() {
+var _ = Describe("deletePodDisruptionBudgetsIfExist", func() {
 	const namespace = "default"
 
 	var (
@@ -1116,7 +1116,7 @@ var _ = Describe("deletePodDisruptionBudgetIfExists", func() {
 		err = fakeClient.Get(ctx, k8client.ObjectKeyFromObject(pdbPrimary), &policyv1.PodDisruptionBudget{})
 		Expect(err).ToNot(HaveOccurred())
 
-		err = reconciler.deletePodDisruptionBudgetIfExists(ctx, cluster)
+		err = reconciler.deletePodDisruptionBudgetsIfExist(ctx, cluster)
 		Expect(err).ToNot(HaveOccurred())
 
 		err = fakeClient.Get(ctx, k8client.ObjectKeyFromObject(pdbPrimary), &policyv1.PodDisruptionBudget{})
@@ -1140,7 +1140,7 @@ var _ = Describe("deletePodDisruptionBudgetIfExists", func() {
 		err := fakeClient.Get(ctx, k8client.ObjectKeyFromObject(pdbPrimary), &policyv1.PodDisruptionBudget{})
 		Expect(apierrs.IsNotFound(err)).To(BeTrue())
 
-		err = reconciler.deletePodDisruptionBudgetIfExists(ctx, cluster)
+		err = reconciler.deletePodDisruptionBudgetsIfExist(ctx, cluster)
 		Expect(err).ToNot(HaveOccurred())
 
 		err = fakeClient.Get(ctx, k8client.ObjectKeyFromObject(pdb), &policyv1.PodDisruptionBudget{})

--- a/internal/controller/cluster_create_test.go
+++ b/internal/controller/cluster_create_test.go
@@ -361,6 +361,30 @@ var _ = Describe("cluster_create unit tests", func() {
 			)
 		})
 
+		By("scaling the instances to 2", func() {
+			cluster.Spec.Instances = 2
+			cluster.Status.Instances = 2
+		})
+
+		By("reconciling pdb with two nodes", func() {
+			reconcilePDB()
+		})
+
+		By("making sure that only the replicas PDB has been deleted", func() {
+			expectResourceExists(
+				env.client,
+				pdbPrimaryName,
+				namespace,
+				&policyv1.PodDisruptionBudget{},
+			)
+			expectResourceDoesntExist(
+				env.client,
+				pdbReplicaName,
+				namespace,
+				&policyv1.PodDisruptionBudget{},
+			)
+		})
+
 		By("enabling the cluster maintenance mode", func() {
 			reusePVC := true
 			cluster.Spec.NodeMaintenanceWindow = &apiv1.NodeMaintenanceWindow{
@@ -373,7 +397,13 @@ var _ = Describe("cluster_create unit tests", func() {
 			reconcilePDB()
 		})
 
-		By("making sure that the replicas PDB are deleted", func() {
+		By("making sure that only the replicas PDB has been deleted", func() {
+			expectResourceExists(
+				env.client,
+				pdbPrimaryName,
+				namespace,
+				&policyv1.PodDisruptionBudget{},
+			)
 			expectResourceDoesntExist(
 				env.client,
 				pdbReplicaName,


### PR DESCRIPTION
In clusters with only 2 instances, the replica PodDisruptionBudget (PDB) is omitted to allow maintenance on the node containing the replica. However, when scaling down from a cluster initially created with more than 2 instances, the replica PDB wasn't removed, leading to failures during node draining.

This patch fixes the issue by ensuring the replica PDB is properly deleted during the scale-down process.

Closes #5467 

# Release notes

Fixes an issue where the replica PodDisruptionBudget (PDB) was not removed when scaling down clusters to 2 instances.
