### PR TITLE
fix: define a `TMPDIR` environment

### DIFF
--- a/internal/cmd/manager/instance/cmd.go
+++ b/internal/cmd/manager/instance/cmd.go
@@ -19,6 +19,7 @@ package instance
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 
@@ -29,6 +30,7 @@ import (
 	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/manager/instance/restoresnapshot"
 	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/manager/instance/run"
 	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/manager/instance/status"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/postgres"
 )
 
 // NewCmd creates the "instance" command
@@ -38,6 +40,9 @@ func NewCmd() *cobra.Command {
 		Short: "Instance management subfeatures",
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return fmt.Errorf("missing subcommand")
+		},
+		PersistentPreRunE: func(_ *cobra.Command, _ []string) error {
+			return os.MkdirAll(postgres.TemporaryDirectory, 0o1777) //nolint:gosec
 		},
 	}
 

--- a/pkg/postgres/configuration.go
+++ b/pkg/postgres/configuration.go
@@ -146,6 +146,10 @@ local {{.Username}} postgres
 	// ScratchDataDirectory is the directory to be used for scratch data
 	ScratchDataDirectory = "/controller"
 
+	// TemporaryDirectory is the directory that is used to create
+	// temporary files, and configured as TMPDIR in PostgreSQL Pods
+	TemporaryDirectory = "/controller/tmp"
+
 	// SpoolDirectory is the directory where we spool the WAL files that
 	// were pre-archived in parallel
 	SpoolDirectory = ScratchDataDirectory + "/wal-archive-spool"

--- a/pkg/specs/pods.go
+++ b/pkg/specs/pods.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"path"
 	"reflect"
 	"slices"
 	"strconv"
@@ -132,6 +133,10 @@ func CreatePodEnvConfig(cluster apiv1.Cluster, podName string) EnvConfig {
 				Value: cluster.Name,
 			},
 			{
+				Name:  "PSQL_HISTORY",
+				Value: path.Join(postgres.TemporaryDirectory, ".psql_history"),
+			},
+			{
 				Name:  "PGPORT",
 				Value: strconv.Itoa(postgres.ServerPort),
 			},
@@ -141,7 +146,7 @@ func CreatePodEnvConfig(cluster apiv1.Cluster, podName string) EnvConfig {
 			},
 			{
 				Name:  "TMPDIR",
-				Value: postgres.ScratchDataDirectory,
+				Value: postgres.TemporaryDirectory,
 			},
 		},
 		EnvFrom: cluster.Spec.EnvFrom,

--- a/pkg/specs/pods.go
+++ b/pkg/specs/pods.go
@@ -139,6 +139,10 @@ func CreatePodEnvConfig(cluster apiv1.Cluster, podName string) EnvConfig {
 				Name:  "PGHOST",
 				Value: postgres.SocketDirectory,
 			},
+			{
+				Name:  "TMPDIR",
+				Value: postgres.ScratchDataDirectory,
+			},
 		},
 		EnvFrom: cluster.Spec.EnvFrom,
 	}

--- a/pkg/specs/pods_test.go
+++ b/pkg/specs/pods_test.go
@@ -333,6 +333,10 @@ var _ = Describe("EnvConfig", func() {
 						Value: cluster.Name,
 					},
 					{
+						Name:  "PSQL_HISTORY",
+						Value: postgres.TemporaryDirectory + "/.psql_history",
+					},
+					{
 						Name:  "PGPORT",
 						Value: strconv.Itoa(postgres.ServerPort),
 					},
@@ -342,7 +346,7 @@ var _ = Describe("EnvConfig", func() {
 					},
 					{
 						Name:  "TMPDIR",
-						Value: "/controller",
+						Value: postgres.TemporaryDirectory,
 					},
 					{
 						Name:  "TEST_ENV",
@@ -391,7 +395,7 @@ var _ = Describe("EnvConfig", func() {
 					},
 					{
 						Name:  "TMPDIR",
-						Value: "/controller",
+						Value: postgres.TemporaryDirectory,
 					},
 					{
 						Name:  "TEST_ENV",

--- a/pkg/specs/pods_test.go
+++ b/pkg/specs/pods_test.go
@@ -341,6 +341,10 @@ var _ = Describe("EnvConfig", func() {
 						Value: postgres.SocketDirectory,
 					},
 					{
+						Name:  "TMPDIR",
+						Value: "/controller",
+					},
+					{
 						Name:  "TEST_ENV",
 						Value: "EXPECTED",
 					},
@@ -384,6 +388,10 @@ var _ = Describe("EnvConfig", func() {
 					{
 						Name:  "PGHOST",
 						Value: postgres.SocketDirectory,
+					},
+					{
+						Name:  "TMPDIR",
+						Value: "/controller",
 					},
 					{
 						Name:  "TEST_ENV",


### PR DESCRIPTION
Tools like `barman` crash when `tempfile.mkdtemp` cannot find any writeable directory amongst the list of "usual suspects" (`/tmp`, `/var/tmp`, `/usr/tmp`, etc), as I've described in #5420 

```
File "/usr/lib/python3.11/tempfile.py", line 454, in gettempdir
    return _os.fsdecode(_gettempdir())
                        ^^^^^^^^^^^^^
  File "/usr/lib/python3.11/tempfile.py", line 447, in _gettempdir
    tempdir = _get_default_tempdir()
              ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/tempfile.py", line 362, in _get_default_tempdir
    raise FileNotFoundError(_errno.ENOENT,
FileNotFoundError: [Errno 2] No usable temporary directory found in ['/tmp', '/var/tmp', '/usr/tmp', '/srv/app']
```

As the operator creates the PG pods with `ReadOnlyRootFilesystem` set to `true`, setting this environment variable will allow barman to write its temporary files under `/controller` (we could argue it could be `/run`, as the same volume is mounted to both mountpoints). This is due to CPyhon considering on this [environment variable](https://github.com/python/cpython/blob/main/Lib/tempfile.py#L163-L165) to add potential temporary directories to try when running `mkdtemp` or `mktemp`.

```python
postgres@postgresql-test-2:/srv/app$ python3
Python 3.11.2 (main, May  2 2024, 11:59:08) [GCC 12.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import os
>>> os.getenv('TMPDIR')
>>> import tempfile
>>> tempfile.mkdtemp()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3.11/tempfile.py", line 512, in mkdtemp
    prefix, suffix, dir, output_type = _sanitize_params(prefix, suffix, dir)
                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/tempfile.py", line 265, in _sanitize_params
    dir = gettempdir()
          ^^^^^^^^^^^^
  File "/usr/lib/python3.11/tempfile.py", line 454, in gettempdir
    return _os.fsdecode(_gettempdir())
                        ^^^^^^^^^^^^^
  File "/usr/lib/python3.11/tempfile.py", line 447, in _gettempdir
    tempdir = _get_default_tempdir()
              ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/tempfile.py", line 362, in _get_default_tempdir
    raise FileNotFoundError(_errno.ENOENT,
FileNotFoundError: [Errno 2] No usable temporary directory found in ['/tmp', '/var/tmp', '/usr/tmp', '/srv/app']
>>>
postgres@postgresql-test-2:/srv/app$ export TMPDIR=/controller
postgres@postgresql-test-2:/srv/app$ python3
Python 3.11.2 (main, May  2 2024, 11:59:08) [GCC 12.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import tempfile
>>> tempfile.mkdtemp()
'/controller/tmpvn9860lm'
```

I've also opted to to not adding it to the list of reserved variables, as it does not have anything to do with PG itself, and thus could be overriden from the chart, but this is really not out of strong conviction.

Closes #5420 