### PR TITLE
fix(docs): typo in before_you_start.md

### DIFF
--- a/docs/src/before_you_start.md
+++ b/docs/src/before_you_start.md
@@ -129,7 +129,7 @@ Superuser
 PVC group
 : A PVC group in CloudNativePG's terminology is a group of related PVCs
   belonging to the same PostgreSQL instance, namely the main volume containing
-  the PGDATA (`storage`) and the volume for WALs (`walStorage`).|
+  the PGDATA (`storage`) and the volume for WALs (`walStorage`).
 
 
 ## Cloud terminology


### PR DESCRIPTION
Typo on the webpage:
<img width="722" alt="image" src="https://github.com/user-attachments/assets/9cb1f536-71c7-4322-a139-0f3541b1ec6b">
https://cloudnative-pg.io/documentation/current/before_you_start/