### PR TITLE
feat: make `full_page_writes` a configurable parameter

### DIFF
--- a/docs/src/postgresql_conf.md
+++ b/docs/src/postgresql_conf.md
@@ -66,6 +66,7 @@ The **global default parameters** are:
 ```text
 archive_mode = 'on'
 dynamic_shared_memory_type = 'posix'
+full_page_writes = 'on'
 logging_collector = 'on'
 log_destination = 'csvlog'
 log_directory = '/controller/log'
@@ -111,7 +112,6 @@ The following parameters are **fixed** and exclusively controlled by the operato
 
 ```text
 archive_command = '/controller/manager wal-archive %p'
-full_page_writes = 'on'
 hot_standby = 'true'
 listen_addresses = '*'
 port = '5432'
@@ -592,7 +592,6 @@ Users are not allowed to set the following configuration parameters in the
 - `data_sync_retry`
 - `event_source`
 - `external_pid_file`
-- `full_page_writes`
 - `hba_file`
 - `hot_standby`
 - `ident_file`
@@ -642,4 +641,3 @@ Users are not allowed to set the following configuration parameters in the
 - `unix_socket_directories`
 - `unix_socket_group`
 - `unix_socket_permissions`
-

--- a/pkg/postgres/configuration.go
+++ b/pkg/postgres/configuration.go
@@ -427,7 +427,6 @@ var (
 		// The following parameters need a reload to be applied
 		"archive_cleanup_command":                blockedConfigurationParameter,
 		"archive_command":                        fixedConfigurationParameter,
-		"full_page_writes":                       fixedConfigurationParameter,
 		"log_destination":                        blockedConfigurationParameter,
 		"log_directory":                          blockedConfigurationParameter,
 		"log_file_mode":                          blockedConfigurationParameter,
@@ -463,6 +462,7 @@ var (
 	CnpgConfigurationSettings = ConfigurationSettings{
 		GlobalDefaultSettings: SettingsCollection{
 			"archive_timeout":            "5min",
+			"full_page_writes":           "on",
 			"max_parallel_workers":       "32",
 			"max_worker_processes":       "32",
 			"max_replication_slots":      "32",
@@ -508,7 +508,6 @@ var (
 				"/controller/manager wal-archive --log-destination %s/%s.json %%p",
 				LogPath, LogFileName),
 			"port":                fmt.Sprint(ServerPort),
-			"full_page_writes":    "on",
 			"ssl":                 "on",
 			"ssl_cert_file":       ServerCertificateLocation,
 			"ssl_key_file":        ServerKeyLocation,


### PR DESCRIPTION
The default value will still be `full_page_writes = on` but from now
on users can modify this parameter, more information about when
to turn on/off can be found here https://wiki.postgresql.org/wiki/Full_page_writes#When_can_you_turn_it_off.3F

Closes #5506 