### PR TITLE
chore: mute gosec linter in some cases

### DIFF
--- a/internal/controller/cluster_status.go
+++ b/internal/controller/cluster_status.go
@@ -260,7 +260,7 @@ func (r *ClusterReconciler) updateResourceStatus(
 	)
 
 	// Count jobs
-	newJobs := int32(len(resources.jobs.Items))
+	newJobs := int32(len(resources.jobs.Items)) //nolint:gosec
 	cluster.Status.JobCount = newJobs
 
 	cluster.Status.Topology = getPodsTopology(
@@ -794,7 +794,7 @@ func getPodsTopology(
 		}
 	}
 
-	return apiv1.Topology{SuccessfullyExtracted: true, Instances: data, NodesUsed: int32(len(nodesMap))}
+	return apiv1.Topology{SuccessfullyExtracted: true, Instances: data, NodesUsed: int32(len(nodesMap))} //nolint:gosec
 }
 
 // isWALSpaceAvailableOnPod check if a Pod terminated because it has no

--- a/pkg/management/postgres/metrics/histogram/histogram.go
+++ b/pkg/management/postgres/metrics/histogram/histogram.go
@@ -91,7 +91,7 @@ func NewFromRawData(values []interface{}, columns []string, name string) (*Value
 		if i >= len(histogramValue.Values) {
 			break
 		}
-		histogramValue.Buckets[key] = uint64(histogramValue.Values[i])
+		histogramValue.Buckets[key] = uint64(histogramValue.Values[i]) //nolint:gosec
 	}
 
 	return histogramValue, nil

--- a/pkg/management/postgres/utils/utils.go
+++ b/pkg/management/postgres/utils/utils.go
@@ -72,11 +72,11 @@ func DBToUint64(t interface{}) (uint64, bool) {
 	case uint64:
 		return v, true
 	case int64:
-		return uint64(v), true
+		return uint64(v), true //nolint:gosec
 	case float64:
 		return uint64(v), true
 	case time.Time:
-		return uint64(v.Unix()), true
+		return uint64(v.Unix()), true //nolint:gosec
 	case []byte:
 		// Try and convert to string and then parse to a uint64
 		strV := string(v)

--- a/pkg/management/postgres/utils/version.go
+++ b/pkg/management/postgres/utils/version.go
@@ -44,9 +44,9 @@ func parseVersionNum(versionNum string) (*semver.Version, error) {
 	}
 
 	return &semver.Version{
-		Major: uint64(versionInt / 10000),
-		Minor: uint64((versionInt / 100) % 100),
-		Patch: uint64(versionInt % 100),
+		Major: uint64(versionInt / 10000),       //nolint:gosec
+		Minor: uint64((versionInt / 100) % 100), //nolint:gosec
+		Patch: uint64(versionInt % 100),         //nolint:gosec
 	}, nil
 }
 

--- a/pkg/postgres/wal.go
+++ b/pkg/postgres/wal.go
@@ -154,7 +154,7 @@ func WalSegmentsPerFile(walSegmentSize int64) int32 {
 	// Given that segment section is represented by 8 hex characters,
 	// we compute the number of wal segments in a file, by dividing
 	// the "max segment number" by the wal segment size.
-	return int32(0xFFFFFFFF / walSegmentSize)
+	return int32(0xFFFFFFFF / walSegmentSize) //nolint:gosec
 }
 
 // NextSegments generate the list of all possible segment names starting

--- a/pkg/reconciler/persistentvolumeclaim/status.go
+++ b/pkg/reconciler/persistentvolumeclaim/status.go
@@ -141,7 +141,7 @@ func EnrichStatus(
 	cluster.Status.ReadyInstances = utils.CountReadyPods(filteredPods)
 	cluster.Status.InstancesStatus = utils.ListStatusPods(runningInstances)
 
-	cluster.Status.PVCCount = int32(len(managedPVCs))
+	cluster.Status.PVCCount = int32(len(managedPVCs)) //nolint:gosec
 	cluster.Status.InitializingPVC = result.getSorted(initializing)
 	cluster.Status.ResizingPVC = result.getSorted(resizing)
 	cluster.Status.DanglingPVC = result.getSorted(dangling)

--- a/pkg/specs/poddisruptionbudget.go
+++ b/pkg/specs/poddisruptionbudget.go
@@ -33,7 +33,7 @@ func BuildReplicasPodDisruptionBudget(cluster *apiv1.Cluster) *policyv1.PodDisru
 	if cluster == nil || cluster.Spec.Instances < 3 {
 		return nil
 	}
-	minAvailableReplicas := int32(cluster.Spec.Instances - 2)
+	minAvailableReplicas := int32(cluster.Spec.Instances - 2) //nolint:gosec
 	allReplicasButOne := intstr.FromInt32(minAvailableReplicas)
 
 	pdb := &policyv1.PodDisruptionBudget{


### PR DESCRIPTION
The latest version of golangci-lint comes with a new version of gosec linter
that detects the conversions of int to int32 and int64 to uint64 as a possible
overflow, in some cases is will not be the case since we know the values
can't produce an overflow.