### PR TITLE
fix: set pgpass host to * to match all hostnames a client might use

### DIFF
--- a/pkg/specs/secrets.go
+++ b/pkg/specs/secrets.go
@@ -55,8 +55,7 @@ func CreateSecret(
 			"host":     hostname,
 			"port":     fmt.Sprintf("%d", postgres.ServerPort),
 			"pgpass": fmt.Sprintf(
-				"%v:%v:%v:%v:%v\n",
-				hostname,
+				"*:%v:%v:%v:%v\n",
 				postgres.ServerPort,
 				dbname,
 				username,


### PR DESCRIPTION
In the app secret we only set the `-rw` endpoint, resulting in no match if any of the other endpoints is used, I think we can safely switch to `*` instead.