### PR TITLE
feat(pgadmin4): add support for specifying Docker image with `--image` flag

### DIFF
--- a/internal/cmd/plugin/pgadmin/cmd.go
+++ b/internal/cmd/plugin/pgadmin/cmd.go
@@ -72,6 +72,7 @@ kubectl cnpg pgadmin4 {{ .ClusterName }} --dry-run | kubectl delete -f -
 func NewCmd() *cobra.Command {
 	var dryRun bool
 	var mode string
+	var pgadminImage string
 
 	pgadminCmd := &cobra.Command{
 		Use:     "pgadmin4 [name]",
@@ -96,7 +97,7 @@ func NewCmd() *cobra.Command {
 				return fmt.Errorf("could not get cluster: %v", err)
 			}
 
-			pgAdminCmd, err := newCommand(&cluster, Mode(mode), dryRun)
+			pgAdminCmd, err := newCommand(&cluster, Mode(mode), dryRun, pgadminImage)
 			if err != nil {
 				return err
 			}
@@ -124,6 +125,13 @@ func NewCmd() *cobra.Command {
 		"mode",
 		"server",
 		"Chooses between 'server' and 'desktop' (insecure) mode.",
+	)
+
+	pgadminCmd.Flags().StringVar(
+		&pgadminImage,
+		"image",
+		"dpage/pgadmin4:latest",
+		"Specifes the pgadmin4 image to use, e.g. for internal registries.",
 	)
 
 	return pgadminCmd

--- a/internal/cmd/plugin/pgadmin/pgadmin.go
+++ b/internal/cmd/plugin/pgadmin/pgadmin.go
@@ -88,6 +88,7 @@ type command struct {
 	PgadminUsername string
 	PgadminPassword string
 	Mode            Mode
+	PgadminImage    string
 
 	dryRun bool
 }
@@ -97,6 +98,7 @@ func newCommand(
 	cluster *apiv1.Cluster,
 	mode Mode,
 	dryRun bool,
+	pgadminImage string,
 ) (*command, error) {
 	const defaultPgadminUsername = "user@pgadmin.com"
 
@@ -111,6 +113,7 @@ func newCommand(
 		ServiceName:                   fmt.Sprintf("%s-pgadmin4", clusterName),
 		SecretName:                    fmt.Sprintf("%s-pgadmin4", clusterName),
 		Mode:                          mode,
+		PgadminImage:                  pgadminImage,
 	}
 
 	pgadminPassword, err := password.Generate(32, 10, 0, false, true)
@@ -179,7 +182,6 @@ func (cmd *command) generateDeployment() *appsv1.Deployment {
 	const (
 		pgAdminCfgVolumeName      = "pgadmin-cfg"
 		pgAdminCfgVolumePath      = "/config"
-		pgAdminImage              = "dpage/pgadmin4:latest"
 		pgAdminPassFileVolumeName = "app-secret"
 		pgAdminPassFileVolumePath = "/secret"
 	)
@@ -214,7 +216,7 @@ func (cmd *command) generateDeployment() *appsv1.Deployment {
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
 						{
-							Image: pgAdminImage,
+							Image: cmd.PgadminImage,
 							Name:  "pgadmin4",
 							Ports: []corev1.ContainerPort{
 								{

--- a/internal/cmd/plugin/pgadmin/pgadmin_test.go
+++ b/internal/cmd/plugin/pgadmin/pgadmin_test.go
@@ -45,6 +45,7 @@ var _ = Describe("command methods", func() {
 			PgadminUsername:               "example-username",
 			PgadminPassword:               "example-password",
 			Mode:                          ModeServer, // or ModeDesktop for the desktop mode
+			PgadminImage:                  "example-image",
 		}
 	})
 
@@ -64,7 +65,7 @@ var _ = Describe("command methods", func() {
 		Expect(podTemplate.Spec.Containers).To(HaveLen(1))
 
 		container := podTemplate.Spec.Containers[0]
-		Expect(container.Image).To(Equal("dpage/pgadmin4:latest"))
+		Expect(container.Image).To(Equal("example-image"))
 		Expect(container.Name).To(Equal("pgadmin4"))
 		Expect(container.Ports).To(HaveLen(1))
 		Expect(container.Ports[0].Name).To(Equal("http"))


### PR DESCRIPTION
This commit introduces a new `--image` flag to the `pgadmin4` plugin subcommand, allowing users to define the Docker image for the pgAdmin4 deployment. This feature is particularly beneficial for environments utilizing a local container registry.

Closes #5515 