### PR TITLE
fix: add the missing CRD examples for OLM build

### DIFF
--- a/config/olm-manifests/bases/cloudnative-pg.clusterserviceversion.yaml
+++ b/config/olm-manifests/bases/cloudnative-pg.clusterserviceversion.yaml
@@ -642,7 +642,6 @@ spec:
       - displayName: Last backup
         description: When the last backup was scheduled
         path: lastScheduleTime
-
     - kind: ImageCatalog
       name: imagecatalogs.postgresql.cnpg.io
       displayName: Image Catalog

--- a/config/olm-manifests/bases/cloudnative-pg.clusterserviceversion.yaml
+++ b/config/olm-manifests/bases/cloudnative-pg.clusterserviceversion.yaml
@@ -675,3 +675,25 @@ spec:
       - path: images.image
         x-descriptors:
           - 'urn:alm:descriptor:com.tectonic.ui:text'
+    - kind: Database
+      name: databases.postgresql.cnpg.io
+      displayName: Database management
+      description: Declarative database management
+      version: v1
+      resources:
+      - kind: Cluster
+        name: ''
+        version: v1
+      specDescriptors:
+      - path: databaseReclaimPolicy
+        displayName: Database reclaim policy
+        description: Database reclame policy
+      - path: cluster
+        displayName: Cluster requested to create the database
+        description: Cluster requested to create the database
+      - path: name
+        displayName: Database name
+        description: Database name
+      - path: owner
+        displayName: Database Owner
+        description: Database Owner

--- a/config/olm-samples/kustomization.yaml
+++ b/config/olm-samples/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
 - postgresql_v1_scheduledbackup.yaml
 - postgresql_v1_imagecatalog.yaml
 - postgresql_v1_clusterimagecatalog.yaml
+- postgresql_v1_database.yaml

--- a/config/olm-samples/postgresql_v1_database.yaml
+++ b/config/olm-samples/postgresql_v1_database.yaml
@@ -1,0 +1,9 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: db-two
+spec:
+  name: two
+  owner: app-two
+  cluster:
+    name: cluster-example

--- a/config/olm-samples/postgresql_v1_database.yaml
+++ b/config/olm-samples/postgresql_v1_database.yaml
@@ -1,9 +1,9 @@
 apiVersion: postgresql.cnpg.io/v1
 kind: Database
 metadata:
-  name: db-two
+  name: database-sample
 spec:
-  name: two
-  owner: app-two
+  name: database-sample
+  owner: app
   cluster:
-    name: cluster-example
+    name: cluster-sample


### PR DESCRIPTION
This update includes the missing CRD examples necessary for the OLM builds. It ensures that the new CRD for database management is incorporated into the OLM samples directory and the CSV resources.

Closes #5530 