### PR TITLE
fix: use patch while setting the new primary instance

### DIFF
--- a/internal/controller/cluster_status.go
+++ b/internal/controller/cluster_status.go
@@ -717,9 +717,10 @@ func (r *ClusterReconciler) setPrimaryInstance(
 	cluster *apiv1.Cluster,
 	podName string,
 ) error {
+	origCluster := cluster.DeepCopy()
 	cluster.Status.TargetPrimary = podName
 	cluster.Status.TargetPrimaryTimestamp = utils.GetCurrentTimestamp()
-	return r.Status().Update(ctx, cluster)
+	return r.Status().Patch(ctx, cluster, client.MergeFrom(origCluster))
 }
 
 // RegisterPhase update phase in the status cluster with the


### PR DESCRIPTION
## Note for reviewers

1. This patch removes an unnecessary update on the status sub-resource that could cause an error and a retry due to the latest observed generated version change (e.g., the instance manager could update the status while the reconciliation is running).

2. This sort of optimistic lock could be used for the operator to proper set the primary, in that case it is good that we discover the potential race condition while we execute this operation to further think how to fix it properly  
