### PR TITLE
fix(docs): example `xid_age` alert

### DIFF
--- a/docs/src/samples/monitoring/alerts.yaml
+++ b/docs/src/samples/monitoring/alerts.yaml
@@ -21,10 +21,10 @@ groups:
       severity: warning
   - alert: PGDatabase
     annotations:
-      description: Over 150,000,000 transactions from frozen xid on pod {{ $labels.pod  }}
+      description: Over 300,000,000 transactions from frozen xid on pod {{ $labels.pod  }}
       summary: Number of transactions from the frozen XID to the current one
     expr: |-
-      cnpg_pg_database_xid_age > 150000000
+      cnpg_pg_database_xid_age > 300000000
     for: 1m
     labels:
       severity: warning


### PR DESCRIPTION
Because autovacuum_freeze_max_age defaults to 200 million, autovacuum generally does not advance the oldest xid on tables and databases until they reach this age. Accordingly, any alert less than 200 million is not useful. A more reasonable default alert would be something like 300 million. Note that vacuum_failsafe_age doesn't start until 1.6 billion by default. If someone is decreasing the failsafe age (for example to under a billion) then it might even make sense to raise the alarming threshold above the failsafe age.