### PR TITLE
test(e2e): prevent VolumeSnapshot E2E to fail because of "tar"

### DIFF
--- a/hack/setup-cluster.sh
+++ b/hack/setup-cluster.sh
@@ -383,6 +383,10 @@ deploy_csi_host_path() {
   ## create volumesnapshotclass
   kubectl apply -f "${CSI_BASE_URL}"/csi-driver-host-path/"${CSI_DRIVER_HOST_PATH_VERSION}"/deploy/kubernetes-1.27/hostpath/csi-hostpath-snapshotclass.yaml
 
+  ## Prevent VolumeSnapshot E2e test to fail when taking a
+  ## snapshot of a running PostgreSQL instance
+  kubectl patch volumesnapshotclass csi-hostpath-snapclass -p '{"parameters":{"ignoreFailedRead":"true"}}' --type merge
+
   ## create storage class
   kubectl apply -f "${CSI_BASE_URL}"/csi-driver-host-path/"${CSI_DRIVER_HOST_PATH_VERSION}"/examples/csi-storageclass.yaml
   kubectl annotate storageclass csi-hostpath-sc storage.kubernetes.io/default-snapshot-class=csi-hostpath-snapclass


### PR DESCRIPTION
E2e tests are using the CSI-hostpath implementation of VolumeSnapshots, which is based on `tar`.

When taking a snapshot of a running PostgreSQL instance, `tar` may download the content of a file that was present at the start of the process but removed later.

With this patch, the setup script is using the `ignoreFailedRead` VolumeSnapshotClass to prevent the VolumeSnapshot from failing because of that.

See: https://github.com/kubernetes-csi/csi-driver-host-path/pull/543