### PR TITLE
feat: set finalizers on the PVC-initialization jobs

### DIFF
--- a/internal/controller/cluster_cleanup.go
+++ b/internal/controller/cluster_cleanup.go
@@ -45,9 +45,9 @@ func (r *ClusterReconciler) cleanupCompletedJobs(
 			continue
 		}
 
-		contextLogger.Debug("Removing finalizer from job", "job", job.Name)
 		jobWithoutFinalizer := job.DeepCopy()
 		if controllerutil.RemoveFinalizer(jobWithoutFinalizer, utils.JobFinalizerName) {
+			contextLogger.Debug("Removing finalizer from job", "job", job.Name)
 			if err := r.Patch(ctx, jobWithoutFinalizer, client.MergeFrom(job)); err != nil {
 				contextLogger.Error(
 					err,

--- a/pkg/utils/labels_annotations.go
+++ b/pkg/utils/labels_annotations.go
@@ -38,6 +38,10 @@ const (
 	// the value could be import, initdb, join
 	JobRoleLabelName = MetadataNamespace + "/jobRole"
 
+	// JobFinalizerName is the name of the finalizer that is used by the operator
+	// to collect the status of a completed job
+	JobFinalizerName = MetadataNamespace + "/jobFinalizer"
+
 	// PvcRoleLabelName is the name of the label containing the purpose of the pvc
 	PvcRoleLabelName = MetadataNamespace + "/pvcRole"
 


### PR DESCRIPTION
The operator is using a few jobs to initialize the PVC before starting PostgreSQL on them.

To ensure that the final status of the Jobs can be collected by the operator, the code is now setting a finalizer on them and removing it before deleting the Job.