### PR TITLE
docs: fix latest minor snapshot installation instructions

### DIFF
--- a/docs/src/installation_upgrade.md
+++ b/docs/src/installation_upgrade.md
@@ -72,7 +72,7 @@ specific minor release, you can just run:
 
 ```sh
 curl -sSfL \
-  https://raw.githubusercontent.com/cloudnative-pg/artifacts/main/manifests/operator-manifest.yaml | \
+  https://raw.githubusercontent.com/cloudnative-pg/artifacts/release-1.24/manifests/operator-manifest.yaml | \
   kubectl apply --server-side -f -
 ```
 


### PR DESCRIPTION
With this change, the release script will automatically update the URL during the release. We must backport this to 1.24 because it contains the same error.