### PR TITLE
chore: simplify tablespaces interfaces for testing

### DIFF
--- a/internal/management/controller/tablespaces/actions.go
+++ b/internal/management/controller/tablespaces/actions.go
@@ -18,6 +18,7 @@ package tablespaces
 
 import (
 	"context"
+	"database/sql"
 
 	"github.com/cloudnative-pg/machinery/pkg/log"
 
@@ -27,7 +28,7 @@ import (
 
 type tablespaceReconcilerStep interface {
 	execute(ctx context.Context,
-		tbsManager infrastructure.TablespaceManager,
+		db *sql.DB,
 		tbsStorageManager tablespaceStorageManager,
 	) apiv1.TablespaceState
 }
@@ -38,7 +39,7 @@ type createTablespaceAction struct {
 
 func (r *createTablespaceAction) execute(
 	ctx context.Context,
-	tbsManager infrastructure.TablespaceManager,
+	db *sql.DB,
 	tbsStorageManager tablespaceStorageManager,
 ) apiv1.TablespaceState {
 	contextLog := log.FromContext(ctx).WithName("tbs_create_reconciler")
@@ -59,7 +60,7 @@ func (r *createTablespaceAction) execute(
 		Name:  r.tablespace.Name,
 		Owner: r.tablespace.Owner.Name,
 	}
-	err := tbsManager.Create(ctx, tablespace)
+	err := infrastructure.Create(ctx, db, tablespace)
 	if err != nil {
 		contextLog.Error(err, "while performing action", "tablespace", r.tablespace.Name)
 		return apiv1.TablespaceState{
@@ -83,7 +84,7 @@ type updateTablespaceAction struct {
 
 func (r *updateTablespaceAction) execute(
 	ctx context.Context,
-	tbsManager infrastructure.TablespaceManager,
+	db *sql.DB,
 	_ tablespaceStorageManager,
 ) apiv1.TablespaceState {
 	contextLog := log.FromContext(ctx).WithName("tbs_update_reconciler")
@@ -93,7 +94,7 @@ func (r *updateTablespaceAction) execute(
 		Name:  r.tablespace.Name,
 		Owner: r.tablespace.Owner.Name,
 	}
-	err := tbsManager.Update(ctx, tablespace)
+	err := infrastructure.Update(ctx, db, tablespace)
 	if err != nil {
 		contextLog.Error(
 			err, "while performing action",
@@ -119,7 +120,7 @@ type noopTablespaceAction struct {
 
 func (r *noopTablespaceAction) execute(
 	_ context.Context,
-	_ infrastructure.TablespaceManager,
+	_ *sql.DB,
 	_ tablespaceStorageManager,
 ) apiv1.TablespaceState {
 	return apiv1.TablespaceState{

--- a/internal/management/controller/tablespaces/controller_test.go
+++ b/internal/management/controller/tablespaces/controller_test.go
@@ -23,9 +23,12 @@ import (
 	"slices"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
-	"github.com/cloudnative-pg/cloudnative-pg/internal/management/controller/tablespaces/infrastructure"
+	schemeBuilder "github.com/cloudnative-pg/cloudnative-pg/internal/scheme"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -47,10 +50,16 @@ func (mst mockTablespaceStorageManager) getStorageLocation(tablespaceName string
 	return fmt.Sprintf("/%s", tablespaceName)
 }
 
+type fakeInstance struct {
+	*postgres.Instance
+	db *sql.DB
+}
+
+func (f fakeInstance) GetSuperUserDB() (*sql.DB, error) {
+	return f.db, nil
+}
+
 var _ = Describe("Tablespace synchronizer tests", func() {
-	tablespaceReconciler := TablespaceReconciler{
-		instance: postgres.NewInstance().WithNamespace("myPod"),
-	}
 	expectedListStmt := `
 	SELECT
 		pg_tablespace.spcname spcname,
@@ -65,14 +74,42 @@ var _ = Describe("Tablespace synchronizer tests", func() {
 	expectedUpdateStmt := "ALTER TABLESPACE \"%s\" OWNER TO \"%s\""
 
 	var (
-		dbMock sqlmock.Sqlmock
-		db     *sql.DB
-		err    error
+		dbMock               sqlmock.Sqlmock
+		db                   *sql.DB
+		err                  error
+		fakeClient           client.Client
+		cluster              *apiv1.Cluster
+		tablespaceReconciler TablespaceReconciler
+		instance             fakeInstance
 	)
+
+	tablespaceReconciler = TablespaceReconciler{
+		instance: postgres.NewInstance().WithNamespace("myPod"),
+	}
 
 	BeforeEach(func() {
 		db, dbMock, err = sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 		Expect(err).ToNot(HaveOccurred())
+		cluster = &apiv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "cluster-example",
+				Namespace: "default",
+			},
+		}
+		fakeClient = fake.NewClientBuilder().WithScheme(schemeBuilder.BuildWithAllKnownScheme()).
+			WithObjects(cluster).
+			WithStatusSubresource(&apiv1.Cluster{}).
+			Build()
+		instance = fakeInstance{
+			Instance: &postgres.Instance{
+				Namespace: "myPod",
+			},
+			db: db,
+		}
+		tablespaceReconciler = TablespaceReconciler{
+			instance: &instance,
+			client:   fakeClient,
+		}
 	})
 
 	AfterEach(func() {
@@ -81,7 +118,7 @@ var _ = Describe("Tablespace synchronizer tests", func() {
 
 	When("tablespace configurations are realizable", func() {
 		It("will do nothing if the DB contains the tablespaces in spec", func(ctx context.Context) {
-			tablespacesSpec := []apiv1.TablespaceConfiguration{
+			cluster.Spec.Tablespaces = []apiv1.TablespaceConfiguration{
 				{
 					Name: "foo",
 					Storage: apiv1.StorageConfiguration{
@@ -92,25 +129,34 @@ var _ = Describe("Tablespace synchronizer tests", func() {
 					},
 				},
 			}
+			// we expect the reconciler to list the tablespaces on the DB
 			rows := sqlmock.NewRows(
 				[]string{"spcname", "rolname"}).
 				AddRow("foo", "app")
 			dbMock.ExpectQuery(expectedListStmt).WithArgs("pg_").WillReturnRows(rows)
-			tbsInDatabase, err := infrastructure.List(ctx, db)
+
+			results, err := tablespaceReconciler.reconcile(ctx, cluster)
 			Expect(err).ShouldNot(HaveOccurred())
-			tbsSteps := evaluateNextSteps(ctx, tbsInDatabase, tablespacesSpec)
-			result := tablespaceReconciler.applySteps(ctx, db,
-				mockTablespaceStorageManager{}, tbsSteps)
-			Expect(result).To(ConsistOf(apiv1.TablespaceState{
-				Name:  "foo",
-				Owner: "app",
-				State: apiv1.TablespaceStatusReconciled,
-				Error: "",
-			}))
+			Expect(results).To(BeNil())
+
+			var updatedCluster apiv1.Cluster
+			err = fakeClient.Get(ctx, client.ObjectKey{
+				Namespace: cluster.Namespace,
+				Name:      cluster.Name,
+			}, &updatedCluster)
+			Expect(err).ToNot(HaveOccurred())
+			expectedTablespaceStatus := []apiv1.TablespaceState{
+				{
+					Name:  "foo",
+					Owner: "app",
+					State: "reconciled",
+				},
+			}
+			Expect(updatedCluster.Status.TablespacesStatus).To(Equal(expectedTablespaceStatus))
 		})
 
 		It("will change the owner when needed", func(ctx context.Context) {
-			tablespacesSpec := []apiv1.TablespaceConfiguration{
+			cluster.Spec.Tablespaces = []apiv1.TablespaceConfiguration{
 				{
 					Name: "foo",
 					Storage: apiv1.StorageConfiguration{
@@ -128,23 +174,29 @@ var _ = Describe("Tablespace synchronizer tests", func() {
 			stmt := fmt.Sprintf(expectedUpdateStmt, "foo", "new_user")
 			dbMock.ExpectExec(stmt).
 				WillReturnResult(sqlmock.NewResult(2, 1))
-			tbsInDatabase, err := infrastructure.List(ctx, db)
+
+			results, err := tablespaceReconciler.reconcile(ctx, cluster)
 			Expect(err).ShouldNot(HaveOccurred())
-			tbsByAction := evaluateNextSteps(ctx, tbsInDatabase, tablespacesSpec)
-			result := tablespaceReconciler.applySteps(ctx, db,
-				mockTablespaceStorageManager{}, tbsByAction)
-			Expect(result).To(ConsistOf(
-				apiv1.TablespaceState{
+			Expect(results).To(BeNil())
+
+			var updatedCluster apiv1.Cluster
+			err = fakeClient.Get(ctx, client.ObjectKey{
+				Namespace: cluster.Namespace,
+				Name:      cluster.Name,
+			}, &updatedCluster)
+			Expect(err).ToNot(HaveOccurred())
+			expectedTablespaceStatus := []apiv1.TablespaceState{
+				{
 					Name:  "foo",
 					Owner: "new_user",
-					State: apiv1.TablespaceStatusReconciled,
-					Error: "",
+					State: "reconciled",
 				},
-			))
+			}
+			Expect(updatedCluster.Status.TablespacesStatus).To(Equal(expectedTablespaceStatus))
 		})
 
-		It("will create a tablespace in spec that is missing from DB", func(ctx context.Context) {
-			tablespacesSpec := []apiv1.TablespaceConfiguration{
+		It("will create a tablespace in spec that is missing from DB if mount point exists", func(ctx context.Context) {
+			cluster.Spec.Tablespaces = []apiv1.TablespaceConfiguration{
 				{
 					Name: "foo",
 					Storage: apiv1.StorageConfiguration{
@@ -161,6 +213,9 @@ var _ = Describe("Tablespace synchronizer tests", func() {
 					},
 				},
 			}
+
+			// we expect the reconciler to list the tablespaces on DB, and to
+			// create a new tablespace
 			rows := sqlmock.NewRows(
 				[]string{"spcname", "rolname"}).
 				AddRow("foo", "")
@@ -168,27 +223,44 @@ var _ = Describe("Tablespace synchronizer tests", func() {
 			stmt := fmt.Sprintf(expectedCreateStmt, "bar", "new_user", "/var/lib/postgresql/tablespaces/bar/data")
 			dbMock.ExpectExec(stmt).
 				WillReturnResult(sqlmock.NewResult(2, 1))
-			tbsInDatabase, err := infrastructure.List(ctx, db)
+
+			tablespaceReconciler = TablespaceReconciler{
+				instance: instance,
+				client:   fakeClient,
+				storageManager: mockTablespaceStorageManager{
+					unavailableStorageLocations: []string{
+						"/foo",
+					},
+				},
+			}
+
+			results, err := tablespaceReconciler.reconcile(ctx, cluster)
 			Expect(err).ShouldNot(HaveOccurred())
-			tbsSteps := evaluateNextSteps(ctx, tbsInDatabase, tablespacesSpec)
-			result := tablespaceReconciler.applySteps(ctx, db,
-				mockTablespaceStorageManager{}, tbsSteps)
-			Expect(result).To(ConsistOf(
-				apiv1.TablespaceState{
+			Expect(results).To(BeNil())
+
+			var updatedCluster apiv1.Cluster
+			err = fakeClient.Get(ctx, client.ObjectKey{
+				Namespace: cluster.Namespace,
+				Name:      cluster.Name,
+			}, &updatedCluster)
+			Expect(err).ToNot(HaveOccurred())
+			expectedTablespaceStatus := []apiv1.TablespaceState{
+				{
 					Name:  "foo",
 					Owner: "",
-					State: apiv1.TablespaceStatusReconciled,
+					State: "reconciled",
 				},
-				apiv1.TablespaceState{
+				{
 					Name:  "bar",
 					Owner: "new_user",
-					State: apiv1.TablespaceStatusReconciled,
+					State: "reconciled",
 				},
-			))
+			}
+			Expect(updatedCluster.Status.TablespacesStatus).To(Equal(expectedTablespaceStatus))
 		})
 
 		It("will requeue the tablespace creation if the mount path doesn't exist", func(ctx context.Context) {
-			tablespacesSpec := []apiv1.TablespaceConfiguration{
+			cluster.Spec.Tablespaces = []apiv1.TablespaceConfiguration{
 				{
 					Name: "foo",
 					Storage: apiv1.StorageConfiguration{
@@ -199,23 +271,37 @@ var _ = Describe("Tablespace synchronizer tests", func() {
 			rows := sqlmock.NewRows(
 				[]string{"spcname", "rolname"})
 			dbMock.ExpectQuery(expectedListStmt).WithArgs("pg_").WillReturnRows(rows)
-			tbsInDatabase, err := infrastructure.List(ctx, db)
-			Expect(err).ShouldNot(HaveOccurred())
-			tbsByAction := evaluateNextSteps(ctx, tbsInDatabase, tablespacesSpec)
-			result := tablespaceReconciler.applySteps(ctx, db,
-				mockTablespaceStorageManager{
+
+			tablespaceReconciler = TablespaceReconciler{
+				instance: instance,
+				client:   fakeClient,
+				storageManager: mockTablespaceStorageManager{
 					unavailableStorageLocations: []string{
 						"/foo",
 					},
-				}, tbsByAction)
-			Expect(result).To(ConsistOf(
-				apiv1.TablespaceState{
+				},
+			}
+
+			results, err := tablespaceReconciler.reconcile(ctx, cluster)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(results).NotTo(BeNil())
+			Expect(results.RequeueAfter).NotTo(BeZero())
+
+			var updatedCluster apiv1.Cluster
+			err = fakeClient.Get(ctx, client.ObjectKey{
+				Namespace: cluster.Namespace,
+				Name:      cluster.Name,
+			}, &updatedCluster)
+			Expect(err).ToNot(HaveOccurred())
+			expectedTablespaceStatus := []apiv1.TablespaceState{
+				{
 					Name:  "foo",
 					Owner: "",
-					State: apiv1.TablespaceStatusPendingReconciliation,
+					State: "pending",
 					Error: "deferred until mount point is created",
 				},
-			))
+			}
+			Expect(updatedCluster.Status.TablespacesStatus).To(Equal(expectedTablespaceStatus))
 		})
 	})
 })

--- a/internal/management/controller/tablespaces/controller_test.go
+++ b/internal/management/controller/tablespaces/controller_test.go
@@ -134,13 +134,16 @@ func assertTablespaceReconciled(ctx context.Context, tt tablespaceTest) {
 		WithObjects(cluster).
 		WithStatusSubresource(&apiv1.Cluster{}).
 		Build()
+
+	pgInstance := postgres.NewInstance().
+		WithNamespace("default").
+		WithClusterName("cluster-example")
+
 	instance := fakeInstance{
-		Instance: &postgres.Instance{
-			Namespace:   "default",
-			ClusterName: "cluster-example",
-		},
-		db: db,
+		Instance: pgInstance,
+		db:       db,
 	}
+
 	tablespaceReconciler := TablespaceReconciler{
 		instance:       &instance,
 		client:         fakeClient,

--- a/internal/management/controller/tablespaces/controller_test.go
+++ b/internal/management/controller/tablespaces/controller_test.go
@@ -69,8 +69,8 @@ func (f fakeInstance) IsPrimary() (bool, error) {
 	return true, nil
 }
 
-var _ = Describe("Tablespace synchronizer tests", func() {
-	expectedListStmt := `
+const (
+	expectedListStmt = `
 	SELECT
 		pg_tablespace.spcname spcname,
 		COALESCE(pg_roles.rolname, '') rolname
@@ -78,337 +78,287 @@ var _ = Describe("Tablespace synchronizer tests", func() {
 	LEFT JOIN pg_roles ON pg_tablespace.spcowner = pg_roles.oid
 	WHERE spcname NOT LIKE $1
 	`
-	expectedCreateStmt := "CREATE TABLESPACE \"%s\" OWNER \"%s\" " +
+	expectedCreateStmt = "CREATE TABLESPACE \"%s\" OWNER \"%s\" " +
 		"LOCATION '%s'"
 
-	expectedUpdateStmt := "ALTER TABLESPACE \"%s\" OWNER TO \"%s\""
+	expectedUpdateStmt = "ALTER TABLESPACE \"%s\" OWNER TO \"%s\""
 
-	expectedReadinessCheck := `
+	expectedReadinessCheck = `
 		SELECT
 			NOT pg_is_in_recovery()
 			OR (SELECT coalesce(setting, '') = '' FROM pg_settings WHERE name = 'primary_conninfo')
 			OR pg_last_wal_replay_lsn() IS NOT NULL
 		`
+)
 
-	var (
-		dbMock               sqlmock.Sqlmock
-		db                   *sql.DB
-		err                  error
-		fakeClient           client.Client
-		cluster              *apiv1.Cluster
-		tablespaceReconciler TablespaceReconciler
-		instance             fakeInstance
-	)
+func getCluster(ctx context.Context, c client.Client, cluster *apiv1.Cluster) (*apiv1.Cluster, error) {
+	var updatedCluster apiv1.Cluster
+	err := c.Get(ctx, client.ObjectKey{
+		Namespace: cluster.Namespace,
+		Name:      cluster.Name,
+	}, &updatedCluster)
+	return &updatedCluster, err
+}
 
-	tablespaceReconciler = TablespaceReconciler{
-		instance: postgres.NewInstance().WithNamespace("myPod"),
+type tablespaceTest struct {
+	tablespacesInSpec        []apiv1.TablespaceConfiguration
+	postgresExpectations     func(sqlmock.Sqlmock)
+	shouldRequeue            bool
+	storageManager           tablespaceStorageManager
+	expectedTablespaceStatus []apiv1.TablespaceState
+}
+
+func assertTablespaceReconciled(ctx context.Context, tt tablespaceTest) {
+	db, dbMock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual), sqlmock.MonitorPingsOption(true))
+	Expect(err).ToNot(HaveOccurred())
+
+	cluster := &apiv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cluster-example",
+			Namespace: "default",
+		},
+	}
+	cluster.Spec.Tablespaces = tt.tablespacesInSpec
+
+	fakeClient := fake.NewClientBuilder().WithScheme(schemeBuilder.BuildWithAllKnownScheme()).
+		WithObjects(cluster).
+		WithStatusSubresource(&apiv1.Cluster{}).
+		Build()
+	instance := fakeInstance{
+		Instance: &postgres.Instance{
+			Namespace:   "default",
+			ClusterName: "cluster-example",
+		},
+		db: db,
+	}
+	tablespaceReconciler := TablespaceReconciler{
+		instance:       &instance,
+		client:         fakeClient,
+		storageManager: tt.storageManager,
 	}
 
-	BeforeEach(func() {
-		db, dbMock, err = sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual), sqlmock.MonitorPingsOption(true))
-		Expect(err).ToNot(HaveOccurred())
-		cluster = &apiv1.Cluster{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "cluster-example",
-				Namespace: "default",
-			},
-		}
-		fakeClient = fake.NewClientBuilder().WithScheme(schemeBuilder.BuildWithAllKnownScheme()).
-			WithObjects(cluster).
-			WithStatusSubresource(&apiv1.Cluster{}).
-			Build()
-		instance = fakeInstance{
-			Instance: &postgres.Instance{
-				Namespace:   "default",
-				ClusterName: "cluster-example",
-			},
-			db: db,
-		}
-		tablespaceReconciler = TablespaceReconciler{
-			instance: &instance,
-			client:   fakeClient,
-		}
+	// these bits happen because the reconciler checks for instance readiness
+	dbMock.ExpectPing()
+	expectedReadiness := sqlmock.NewRows([]string{""}).AddRow("t")
+	dbMock.ExpectQuery(expectedReadinessCheck).WillReturnRows(expectedReadiness)
 
-		// these bits happen since the reconciler checks for instance readiness
-		dbMock.ExpectPing()
-		expectedReadiness := sqlmock.NewRows([]string{""}).AddRow("t")
-		dbMock.ExpectQuery(expectedReadinessCheck).WillReturnRows(expectedReadiness)
-	})
+	tt.postgresExpectations(dbMock)
 
-	AfterEach(func() {
-		Expect(dbMock.ExpectationsWereMet()).To(Succeed())
-	})
+	results, err := tablespaceReconciler.Reconcile(ctx, reconcile.Request{})
+	Expect(err).ShouldNot(HaveOccurred())
+	if tt.shouldRequeue {
+		Expect(results).NotTo(BeZero())
+	} else {
+		Expect(results).To(BeZero())
+	}
 
+	updatedCluster, err := getCluster(ctx, fakeClient, cluster)
+	Expect(err).ToNot(HaveOccurred())
+	Expect(updatedCluster.Status.TablespacesStatus).To(Equal(tt.expectedTablespaceStatus))
+
+	Expect(dbMock.ExpectationsWereMet()).To(Succeed())
+}
+
+var _ = Describe("Tablespace synchronizer tests", func() {
 	When("tablespace configurations are realizable", func() {
 		It("will do nothing if the DB contains the tablespaces in spec", func(ctx context.Context) {
-			initialCluster := cluster.DeepCopy()
-			cluster.Spec.Tablespaces = []apiv1.TablespaceConfiguration{
-				{
-					Name: "foo",
-					Storage: apiv1.StorageConfiguration{
-						Size: "1Gi",
-					},
-					Owner: apiv1.DatabaseRoleRef{
-						Name: "app",
+			assertTablespaceReconciled(ctx, tablespaceTest{
+				tablespacesInSpec: []apiv1.TablespaceConfiguration{
+					{
+						Name: "foo",
+						Storage: apiv1.StorageConfiguration{
+							Size: "1Gi",
+						},
+						Owner: apiv1.DatabaseRoleRef{
+							Name: "app",
+						},
 					},
 				},
-			}
-			err := fakeClient.Patch(ctx, cluster, client.MergeFrom(initialCluster))
-			Expect(err).NotTo(HaveOccurred())
-
-			// we expect the reconciler to list the tablespaces on the DB
-			rows := sqlmock.NewRows(
-				[]string{"spcname", "rolname"}).
-				AddRow("foo", "app")
-			dbMock.ExpectQuery(expectedListStmt).WithArgs("pg_").WillReturnRows(rows)
-
-			results, err := tablespaceReconciler.Reconcile(ctx, reconcile.Request{})
-			Expect(err).ShouldNot(HaveOccurred())
-			Expect(results).To(BeZero())
-
-			var updatedCluster apiv1.Cluster
-			err = fakeClient.Get(ctx, client.ObjectKey{
-				Namespace: cluster.Namespace,
-				Name:      cluster.Name,
-			}, &updatedCluster)
-			Expect(err).ToNot(HaveOccurred())
-			expectedTablespaceStatus := []apiv1.TablespaceState{
-				{
-					Name:  "foo",
-					Owner: "app",
-					State: "reconciled",
+				postgresExpectations: func(mock sqlmock.Sqlmock) {
+					// we expect the reconciler to list the tablespaces on the DB
+					rows := sqlmock.NewRows(
+						[]string{"spcname", "rolname"}).
+						AddRow("foo", "app")
+					mock.ExpectQuery(expectedListStmt).WithArgs("pg_").WillReturnRows(rows)
 				},
-			}
-			Expect(updatedCluster.Status.TablespacesStatus).To(Equal(expectedTablespaceStatus))
+				shouldRequeue: false,
+				expectedTablespaceStatus: []apiv1.TablespaceState{
+					{
+						Name:  "foo",
+						Owner: "app",
+						State: "reconciled",
+					},
+				},
+			})
 		})
 
 		It("will change the owner when needed", func(ctx context.Context) {
-			initialCluster := cluster.DeepCopy()
-			cluster.Spec.Tablespaces = []apiv1.TablespaceConfiguration{
-				{
-					Name: "foo",
-					Storage: apiv1.StorageConfiguration{
-						Size: "1Gi",
-					},
-					Owner: apiv1.DatabaseRoleRef{
-						Name: "new_user",
+			assertTablespaceReconciled(ctx, tablespaceTest{
+				tablespacesInSpec: []apiv1.TablespaceConfiguration{
+					{
+						Name: "foo",
+						Storage: apiv1.StorageConfiguration{
+							Size: "1Gi",
+						},
+						Owner: apiv1.DatabaseRoleRef{
+							Name: "new_user",
+						},
 					},
 				},
-			}
-			err := fakeClient.Patch(ctx, cluster, client.MergeFrom(initialCluster))
-			Expect(err).NotTo(HaveOccurred())
-
-			rows := sqlmock.NewRows(
-				[]string{"spcname", "rolname"}).
-				AddRow("foo", "app")
-			dbMock.ExpectQuery(expectedListStmt).WithArgs("pg_").WillReturnRows(rows)
-			stmt := fmt.Sprintf(expectedUpdateStmt, "foo", "new_user")
-			dbMock.ExpectExec(stmt).
-				WillReturnResult(sqlmock.NewResult(2, 1))
-
-			results, err := tablespaceReconciler.Reconcile(ctx, reconcile.Request{})
-			Expect(err).ShouldNot(HaveOccurred())
-			Expect(results).To(BeZero())
-
-			var updatedCluster apiv1.Cluster
-			err = fakeClient.Get(ctx, client.ObjectKey{
-				Namespace: cluster.Namespace,
-				Name:      cluster.Name,
-			}, &updatedCluster)
-			Expect(err).ToNot(HaveOccurred())
-			expectedTablespaceStatus := []apiv1.TablespaceState{
-				{
-					Name:  "foo",
-					Owner: "new_user",
-					State: "reconciled",
+				postgresExpectations: func(mock sqlmock.Sqlmock) {
+					rows := sqlmock.NewRows(
+						[]string{"spcname", "rolname"}).
+						AddRow("foo", "app")
+					mock.ExpectQuery(expectedListStmt).WithArgs("pg_").WillReturnRows(rows)
+					stmt := fmt.Sprintf(expectedUpdateStmt, "foo", "new_user")
+					mock.ExpectExec(stmt).
+						WillReturnResult(sqlmock.NewResult(2, 1))
 				},
-			}
-			Expect(updatedCluster.Status.TablespacesStatus).To(Equal(expectedTablespaceStatus))
+				shouldRequeue: false,
+				expectedTablespaceStatus: []apiv1.TablespaceState{
+					{
+						Name:  "foo",
+						Owner: "new_user",
+						State: "reconciled",
+					},
+				},
+			})
 		})
 
 		It("will create a tablespace in spec that is missing from DB if mount point exists", func(ctx context.Context) {
-			initialCluster := cluster.DeepCopy()
-			cluster.Spec.Tablespaces = []apiv1.TablespaceConfiguration{
-				{
-					Name: "foo",
-					Storage: apiv1.StorageConfiguration{
-						Size: "1Gi",
+			assertTablespaceReconciled(ctx, tablespaceTest{
+				tablespacesInSpec: []apiv1.TablespaceConfiguration{
+					{
+						Name: "foo",
+						Storage: apiv1.StorageConfiguration{
+							Size: "1Gi",
+						},
+					},
+					{
+						Name: "bar",
+						Storage: apiv1.StorageConfiguration{
+							Size: "1Gi",
+						},
+						Owner: apiv1.DatabaseRoleRef{
+							Name: "new_user",
+						},
 					},
 				},
-				{
-					Name: "bar",
-					Storage: apiv1.StorageConfiguration{
-						Size: "1Gi",
-					},
-					Owner: apiv1.DatabaseRoleRef{
-						Name: "new_user",
-					},
+				postgresExpectations: func(mock sqlmock.Sqlmock) {
+					// we expect the reconciler to list the tablespaces on DB, and to
+					// create a new tablespace
+					rows := sqlmock.NewRows(
+						[]string{"spcname", "rolname"}).
+						AddRow("foo", "")
+					mock.ExpectQuery(expectedListStmt).WithArgs("pg_").WillReturnRows(rows)
+					stmt := fmt.Sprintf(expectedCreateStmt, "bar", "new_user", "/var/lib/postgresql/tablespaces/bar/data")
+					mock.ExpectExec(stmt).
+						WillReturnResult(sqlmock.NewResult(2, 1))
 				},
-			}
-			err := fakeClient.Patch(ctx, cluster, client.MergeFrom(initialCluster))
-			Expect(err).NotTo(HaveOccurred())
-
-			// we expect the reconciler to list the tablespaces on DB, and to
-			// create a new tablespace
-			rows := sqlmock.NewRows(
-				[]string{"spcname", "rolname"}).
-				AddRow("foo", "")
-			dbMock.ExpectQuery(expectedListStmt).WithArgs("pg_").WillReturnRows(rows)
-			stmt := fmt.Sprintf(expectedCreateStmt, "bar", "new_user", "/var/lib/postgresql/tablespaces/bar/data")
-			dbMock.ExpectExec(stmt).
-				WillReturnResult(sqlmock.NewResult(2, 1))
-
-			tablespaceReconciler = TablespaceReconciler{
-				instance: instance,
-				client:   fakeClient,
+				shouldRequeue: false,
 				storageManager: mockTablespaceStorageManager{
 					unavailableStorageLocations: []string{
 						"/foo",
 					},
 				},
-			}
-
-			results, err := tablespaceReconciler.Reconcile(ctx, reconcile.Request{})
-			Expect(err).ShouldNot(HaveOccurred())
-			Expect(results).To(BeZero())
-
-			var updatedCluster apiv1.Cluster
-			err = fakeClient.Get(ctx, client.ObjectKey{
-				Namespace: cluster.Namespace,
-				Name:      cluster.Name,
-			}, &updatedCluster)
-			Expect(err).ToNot(HaveOccurred())
-			expectedTablespaceStatus := []apiv1.TablespaceState{
-				{
-					Name:  "foo",
-					Owner: "",
-					State: "reconciled",
+				expectedTablespaceStatus: []apiv1.TablespaceState{
+					{
+						Name:  "foo",
+						Owner: "",
+						State: "reconciled",
+					},
+					{
+						Name:  "bar",
+						Owner: "new_user",
+						State: "reconciled",
+					},
 				},
-				{
-					Name:  "bar",
-					Owner: "new_user",
-					State: "reconciled",
-				},
-			}
-			Expect(updatedCluster.Status.TablespacesStatus).To(Equal(expectedTablespaceStatus))
+			})
 		})
 
 		It("will mark tablespace status as pending with error when the DB CREATE fails", func(ctx context.Context) {
-			initialCluster := cluster.DeepCopy()
-			cluster.Spec.Tablespaces = []apiv1.TablespaceConfiguration{
-				{
-					Name: "foo",
-					Storage: apiv1.StorageConfiguration{
-						Size: "1Gi",
+			assertTablespaceReconciled(ctx, tablespaceTest{
+				tablespacesInSpec: []apiv1.TablespaceConfiguration{
+					{
+						Name: "foo",
+						Storage: apiv1.StorageConfiguration{
+							Size: "1Gi",
+						},
+					},
+					{
+						Name: "bar",
+						Storage: apiv1.StorageConfiguration{
+							Size: "1Gi",
+						},
+						Owner: apiv1.DatabaseRoleRef{
+							Name: "new_user",
+						},
 					},
 				},
-				{
-					Name: "bar",
-					Storage: apiv1.StorageConfiguration{
-						Size: "1Gi",
-					},
-					Owner: apiv1.DatabaseRoleRef{
-						Name: "new_user",
-					},
+				postgresExpectations: func(mock sqlmock.Sqlmock) {
+					// we expect the reconciler to list the tablespaces on DB, and to
+					// create a new tablespace
+					rows := sqlmock.NewRows(
+						[]string{"spcname", "rolname"}).
+						AddRow("foo", "")
+					mock.ExpectQuery(expectedListStmt).WithArgs("pg_").WillReturnRows(rows)
+					// we simulate DB command failure
+					stmt := fmt.Sprintf(expectedCreateStmt, "bar", "new_user", "/var/lib/postgresql/tablespaces/bar/data")
+					mock.ExpectExec(stmt).
+						WillReturnError(errors.New("boom"))
 				},
-			}
-			err := fakeClient.Patch(ctx, cluster, client.MergeFrom(initialCluster))
-			Expect(err).NotTo(HaveOccurred())
-
-			// we expect the reconciler to list the tablespaces on DB, and to
-			// create a new tablespace
-			rows := sqlmock.NewRows(
-				[]string{"spcname", "rolname"}).
-				AddRow("foo", "")
-			dbMock.ExpectQuery(expectedListStmt).WithArgs("pg_").WillReturnRows(rows)
-			// we simulate DB command failure
-			stmt := fmt.Sprintf(expectedCreateStmt, "bar", "new_user", "/var/lib/postgresql/tablespaces/bar/data")
-			dbMock.ExpectExec(stmt).
-				WillReturnError(errors.New("boom"))
-
-			tablespaceReconciler = TablespaceReconciler{
-				instance: instance,
-				client:   fakeClient,
+				shouldRequeue: true,
 				storageManager: mockTablespaceStorageManager{
 					unavailableStorageLocations: []string{
 						"/foo",
 					},
 				},
-			}
-
-			results, err := tablespaceReconciler.Reconcile(ctx, reconcile.Request{})
-			Expect(err).ShouldNot(HaveOccurred())
-			Expect(results).NotTo(BeZero())
-
-			var updatedCluster apiv1.Cluster
-			err = fakeClient.Get(ctx, client.ObjectKey{
-				Namespace: cluster.Namespace,
-				Name:      cluster.Name,
-			}, &updatedCluster)
-			Expect(err).ToNot(HaveOccurred())
-			expectedTablespaceStatus := []apiv1.TablespaceState{
-				{
-					Name:  "foo",
-					Owner: "",
-					State: "reconciled",
+				expectedTablespaceStatus: []apiv1.TablespaceState{
+					{
+						Name:  "foo",
+						Owner: "",
+						State: "reconciled",
+					},
+					{
+						Name:  "bar",
+						Owner: "new_user",
+						State: "pending",
+						Error: "while creating tablespace bar: boom",
+					},
 				},
-				{
-					Name:  "bar",
-					Owner: "new_user",
-					State: "pending",
-					Error: "while creating tablespace bar: boom",
-				},
-			}
-			Expect(updatedCluster.Status.TablespacesStatus).To(Equal(expectedTablespaceStatus))
+			})
 		})
 
 		It("will requeue the tablespace creation if the mount path doesn't exist", func(ctx context.Context) {
-			initialCluster := cluster.DeepCopy()
-			cluster.Spec.Tablespaces = []apiv1.TablespaceConfiguration{
-				{
-					Name: "foo",
-					Storage: apiv1.StorageConfiguration{
-						Size: "1Gi",
+			assertTablespaceReconciled(ctx, tablespaceTest{
+				tablespacesInSpec: []apiv1.TablespaceConfiguration{
+					{
+						Name: "foo",
+						Storage: apiv1.StorageConfiguration{
+							Size: "1Gi",
+						},
 					},
 				},
-			}
-			err := fakeClient.Patch(ctx, cluster, client.MergeFrom(initialCluster))
-			Expect(err).NotTo(HaveOccurred())
-
-			rows := sqlmock.NewRows(
-				[]string{"spcname", "rolname"})
-			dbMock.ExpectQuery(expectedListStmt).WithArgs("pg_").WillReturnRows(rows)
-
-			tablespaceReconciler = TablespaceReconciler{
-				instance: instance,
-				client:   fakeClient,
+				postgresExpectations: func(mock sqlmock.Sqlmock) {
+					rows := sqlmock.NewRows(
+						[]string{"spcname", "rolname"})
+					mock.ExpectQuery(expectedListStmt).WithArgs("pg_").WillReturnRows(rows)
+				},
+				shouldRequeue: true,
 				storageManager: mockTablespaceStorageManager{
 					unavailableStorageLocations: []string{
 						"/foo",
 					},
 				},
-			}
-
-			results, err := tablespaceReconciler.Reconcile(ctx, reconcile.Request{})
-			Expect(err).ShouldNot(HaveOccurred())
-			Expect(results).NotTo(BeNil())
-			Expect(results.RequeueAfter).NotTo(BeZero())
-
-			var updatedCluster apiv1.Cluster
-			err = fakeClient.Get(ctx, client.ObjectKey{
-				Namespace: cluster.Namespace,
-				Name:      cluster.Name,
-			}, &updatedCluster)
-			Expect(err).ToNot(HaveOccurred())
-			expectedTablespaceStatus := []apiv1.TablespaceState{
-				{
-					Name:  "foo",
-					Owner: "",
-					State: "pending",
-					Error: "deferred until mount point is created",
+				expectedTablespaceStatus: []apiv1.TablespaceState{
+					{
+						Name:  "foo",
+						Owner: "",
+						State: "pending",
+						Error: "deferred until mount point is created",
+					},
 				},
-			}
-			Expect(updatedCluster.Status.TablespacesStatus).To(Equal(expectedTablespaceStatus))
+			})
 		})
 	})
 })

--- a/internal/management/controller/tablespaces/infrastructure/contract.go
+++ b/internal/management/controller/tablespaces/infrastructure/contract.go
@@ -16,8 +16,6 @@ limitations under the License.
 
 package infrastructure
 
-import "context"
-
 // Tablespace represents the tablespace information read from / written to the Database
 type Tablespace struct {
 	// Name is the name of the tablespace
@@ -25,16 +23,4 @@ type Tablespace struct {
 
 	// Owner is the owner of this tablespace
 	Owner string `json:"owner"`
-}
-
-// TablespaceManager abstracts the functionality of reconciling with PostgreSQL tablespaces
-type TablespaceManager interface {
-	// List the tablespace in the database
-	List(ctx context.Context) ([]Tablespace, error)
-
-	// Create the tablespace in the database
-	Create(ctx context.Context, tablespace Tablespace) error
-
-	// Update the tablespace in the database (change ownership)
-	Update(ctx context.Context, tablespace Tablespace) error
 }

--- a/internal/management/controller/tablespaces/infrastructure/postgres.go
+++ b/internal/management/controller/tablespaces/infrastructure/postgres.go
@@ -28,31 +28,14 @@ import (
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/specs"
 )
 
-// postgresTablespaceManager is a TablespaceManager for a database instance
-type postgresTablespaceManager struct {
-	superUserDB *sql.DB
-}
-
-// NewPostgresTablespaceManager returns an implementation of TablespaceManager for postgres
-func NewPostgresTablespaceManager(superDB *sql.DB) TablespaceManager {
-	return newPostgresTablespaceManager(superDB)
-}
-
-// NewPostgresTablespaceManager returns an implementation of TablespaceManager for postgres
-func newPostgresTablespaceManager(superDB *sql.DB) postgresTablespaceManager {
-	return postgresTablespaceManager{
-		superUserDB: superDB,
-	}
-}
-
 // List the tablespaces in the database
 // The content exclude pg_default and pg_global database
-func (tbsMgr postgresTablespaceManager) List(ctx context.Context) ([]Tablespace, error) {
+func List(ctx context.Context, db *sql.DB) ([]Tablespace, error) {
 	logger := log.FromContext(ctx).WithName("tbs_reconciler_list")
 	logger.Trace("Invoked list")
 	wrapErr := func(err error) error { return fmt.Errorf("while listing DB tablespaces: %w", err) }
 
-	rows, err := tbsMgr.superUserDB.QueryContext(
+	rows, err := db.QueryContext(
 		ctx,
 		`
 		SELECT
@@ -93,7 +76,7 @@ func (tbsMgr postgresTablespaceManager) List(ctx context.Context) ([]Tablespace,
 }
 
 // Create the tablespace in the database, if tablespace is temporary tablespace, need reload configure
-func (tbsMgr postgresTablespaceManager) Create(ctx context.Context, tbs Tablespace) error {
+func Create(ctx context.Context, db *sql.DB, tbs Tablespace) error {
 	contextLog := log.FromContext(ctx).WithName("tbs_reconciler_create")
 	tablespaceLocation := specs.LocationForTablespace(tbs.Name)
 
@@ -104,7 +87,7 @@ func (tbsMgr postgresTablespaceManager) Create(ctx context.Context, tbs Tablespa
 		return fmt.Errorf("while creating tablespace %s: %w", tbs.Name, err)
 	}
 	var err error
-	if _, err = tbsMgr.superUserDB.ExecContext(
+	if _, err = db.ExecContext(
 		ctx,
 		fmt.Sprintf(
 			"CREATE TABLESPACE %s OWNER %s LOCATION '%s'",
@@ -119,7 +102,7 @@ func (tbsMgr postgresTablespaceManager) Create(ctx context.Context, tbs Tablespa
 }
 
 // Update the tablespace in the database (change ownership)
-func (tbsMgr postgresTablespaceManager) Update(ctx context.Context, tbs Tablespace) error {
+func Update(ctx context.Context, db *sql.DB, tbs Tablespace) error {
 	contextLog := log.FromContext(ctx).WithName("tbs_reconciler_update")
 	tablespaceLocation := specs.LocationForTablespace(tbs.Name)
 
@@ -130,7 +113,7 @@ func (tbsMgr postgresTablespaceManager) Update(ctx context.Context, tbs Tablespa
 		return fmt.Errorf("while updating tablespace %s: %w", tbs.Name, err)
 	}
 	var err error
-	if _, err = tbsMgr.superUserDB.ExecContext(
+	if _, err = db.ExecContext(
 		ctx,
 		fmt.Sprintf(
 			"ALTER TABLESPACE %s OWNER TO %s",

--- a/internal/management/controller/tablespaces/infrastructure/postgres_test.go
+++ b/internal/management/controller/tablespaces/infrastructure/postgres_test.go
@@ -42,18 +42,21 @@ var _ = Describe("Postgres tablespaces functions test", func() {
 	It("should send the expected query to list tablespaces and parse the return", func(ctx SpecContext) {
 		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 		Expect(err).ToNot(HaveOccurred())
+		tbsName := "atablespace"
+		anotherTbsName := "anothertablespace"
+		ownerName := "postgres"
 
 		rows := sqlmock.NewRows(
 			[]string{"spcname", "rolname"}).
-			AddRow("atablespace", "postgres").
-			AddRow("anothertablespace", "postgres")
+			AddRow(tbsName, ownerName).
+			AddRow(anotherTbsName, ownerName)
 		mock.ExpectQuery(expectedListStmt).WithArgs("pg_").WillReturnRows(rows)
 		tbs, err := List(ctx, db)
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(tbs).To(HaveLen(2))
 		Expect(tbs).To(ConsistOf(
-			Tablespace{Name: "atablespace", Owner: "postgres"},
-			Tablespace{Name: "anothertablespace", Owner: "postgres"}))
+			Tablespace{Name: tbsName, Owner: ownerName},
+			Tablespace{Name: anotherTbsName, Owner: ownerName}))
 	})
 	It("should detect error if the list query returns error", func(ctx SpecContext) {
 		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
@@ -74,7 +77,7 @@ var _ = Describe("Postgres tablespaces functions test", func() {
 		stmt := fmt.Sprintf(expectedCreateStmt, tbsName, ownerName)
 		mock.ExpectExec(stmt).
 			WillReturnResult(sqlmock.NewResult(2, 1))
-		err = Create(ctx, db, Tablespace{Name: tbsName, Owner: "postgres"})
+		err = Create(ctx, db, Tablespace{Name: tbsName, Owner: ownerName})
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(mock.ExpectationsWereMet()).To(Succeed())
 	})
@@ -86,7 +89,7 @@ var _ = Describe("Postgres tablespaces functions test", func() {
 		stmt := fmt.Sprintf(expectedCreateStmt, tbsName, ownerName)
 		mock.ExpectExec(stmt).
 			WillReturnError(fmt.Errorf("boom"))
-		err = Create(ctx, db, Tablespace{Name: tbsName, Owner: "postgres"})
+		err = Create(ctx, db, Tablespace{Name: tbsName, Owner: ownerName})
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("boom"))
 		Expect(mock.ExpectationsWereMet()).To(Succeed())

--- a/internal/management/controller/tablespaces/infrastructure/postgres_test.go
+++ b/internal/management/controller/tablespaces/infrastructure/postgres_test.go
@@ -99,7 +99,7 @@ var _ = Describe("Postgres tablespaces functions test", func() {
 		stmt := fmt.Sprintf(expectedUpdateStmt, tbsName, ownerName)
 		mock.ExpectExec(stmt).
 			WillReturnResult(sqlmock.NewResult(2, 1))
-		err = Update(ctx, db, Tablespace{Name: tbsName, Owner: "postgres"})
+		err = Update(ctx, db, Tablespace{Name: tbsName, Owner: ownerName})
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(mock.ExpectationsWereMet()).To(Succeed())
 	})

--- a/internal/management/controller/tablespaces/infrastructure/postgres_test.go
+++ b/internal/management/controller/tablespaces/infrastructure/postgres_test.go
@@ -36,17 +36,19 @@ var _ = Describe("Postgres tablespaces functions test", func() {
 	`
 	expectedCreateStmt := "CREATE TABLESPACE \"%s\" OWNER \"%s\" " +
 		"LOCATION '/var/lib/postgresql/tablespaces/atablespace/data'"
+
+	expectedUpdateStmt := "ALTER TABLESPACE \"%s\" OWNER TO \"%s\""
+
 	It("should send the expected query to list tablespaces and parse the return", func(ctx SpecContext) {
 		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 		Expect(err).ToNot(HaveOccurred())
 
-		tbsManager := newPostgresTablespaceManager(db)
 		rows := sqlmock.NewRows(
 			[]string{"spcname", "rolname"}).
 			AddRow("atablespace", "postgres").
 			AddRow("anothertablespace", "postgres")
 		mock.ExpectQuery(expectedListStmt).WithArgs("pg_").WillReturnRows(rows)
-		tbs, err := tbsManager.List(ctx)
+		tbs, err := List(ctx, db)
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(tbs).To(HaveLen(2))
 		Expect(tbs).To(ConsistOf(
@@ -57,9 +59,8 @@ var _ = Describe("Postgres tablespaces functions test", func() {
 		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 		Expect(err).ToNot(HaveOccurred())
 
-		tbsManager := newPostgresTablespaceManager(db)
 		mock.ExpectQuery(expectedListStmt).WithArgs("pg_").WillReturnError(fmt.Errorf("boom"))
-		tbs, err := tbsManager.List(ctx)
+		tbs, err := List(ctx, db)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("boom"))
 		Expect(tbs).To(BeEmpty())
@@ -71,10 +72,9 @@ var _ = Describe("Postgres tablespaces functions test", func() {
 		tbsName := "atablespace"
 		ownerName := "postgres"
 		stmt := fmt.Sprintf(expectedCreateStmt, tbsName, ownerName)
-		tbsManager := newPostgresTablespaceManager(db)
 		mock.ExpectExec(stmt).
 			WillReturnResult(sqlmock.NewResult(2, 1))
-		err = tbsManager.Create(ctx, Tablespace{Name: tbsName, Owner: "postgres"})
+		err = Create(ctx, db, Tablespace{Name: tbsName, Owner: "postgres"})
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(mock.ExpectationsWereMet()).To(Succeed())
 	})
@@ -84,12 +84,23 @@ var _ = Describe("Postgres tablespaces functions test", func() {
 		tbsName := "atablespace"
 		ownerName := "postgres"
 		stmt := fmt.Sprintf(expectedCreateStmt, tbsName, ownerName)
-		tbsManager := newPostgresTablespaceManager(db)
 		mock.ExpectExec(stmt).
 			WillReturnError(fmt.Errorf("boom"))
-		err = tbsManager.Create(ctx, Tablespace{Name: tbsName, Owner: "postgres"})
+		err = Create(ctx, db, Tablespace{Name: tbsName, Owner: "postgres"})
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("boom"))
+		Expect(mock.ExpectationsWereMet()).To(Succeed())
+	})
+	It("should issue the expected command to update a tablespace", func(ctx SpecContext) {
+		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+		Expect(err).ToNot(HaveOccurred())
+		tbsName := "atablespace"
+		ownerName := "postgres"
+		stmt := fmt.Sprintf(expectedUpdateStmt, tbsName, ownerName)
+		mock.ExpectExec(stmt).
+			WillReturnResult(sqlmock.NewResult(2, 1))
+		err = Update(ctx, db, Tablespace{Name: tbsName, Owner: "postgres"})
+		Expect(err).ShouldNot(HaveOccurred())
 		Expect(mock.ExpectationsWereMet()).To(Succeed())
 	})
 })

--- a/internal/management/controller/tablespaces/manager.go
+++ b/internal/management/controller/tablespaces/manager.go
@@ -54,7 +54,7 @@ func (r *TablespaceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 // GetCluster gets the managed cluster through the client
 func (r *TablespaceReconciler) GetCluster(ctx context.Context) (*apiv1.Cluster, error) {
 	var cluster apiv1.Cluster
-	err := r.GetClient().Get(ctx,
+	err := r.client.Get(ctx,
 		types.NamespacedName{
 			Namespace: r.instance.GetNamespaceName(),
 			Name:      r.instance.GetClusterName(),
@@ -65,14 +65,4 @@ func (r *TablespaceReconciler) GetCluster(ctx context.Context) (*apiv1.Cluster, 
 	}
 
 	return &cluster, nil
-}
-
-// GetClient returns the dynamic client that is being used for a certain reconciler
-func (r *TablespaceReconciler) GetClient() client.Client {
-	return r.client
-}
-
-// Instance returns the PostgreSQL instance that this reconciler is working on
-func (r *TablespaceReconciler) Instance() *postgres.Instance {
-	return r.instance
 }

--- a/internal/management/controller/tablespaces/reconciler.go
+++ b/internal/management/controller/tablespaces/reconciler.go
@@ -97,7 +97,6 @@ func (r *TablespaceReconciler) reconcile(
 		return nil, fmt.Errorf("while reconcile tablespaces: %w", err)
 	}
 
-	tbsStorageManager := instanceTablespaceStorageManager{}
 	tbsInDatabase, err := infrastructure.List(ctx, superUserDB)
 	if err != nil {
 		return nil, fmt.Errorf("could not fetch tablespaces from database: %w", err)
@@ -107,7 +106,6 @@ func (r *TablespaceReconciler) reconcile(
 	result := r.applySteps(
 		ctx,
 		superUserDB,
-		tbsStorageManager,
 		steps,
 	)
 
@@ -133,13 +131,12 @@ func (r *TablespaceReconciler) reconcile(
 func (r *TablespaceReconciler) applySteps(
 	ctx context.Context,
 	db *sql.DB,
-	tbsStorageManager tablespaceStorageManager,
 	actions []tablespaceReconcilerStep,
 ) []apiv1.TablespaceState {
 	result := make([]apiv1.TablespaceState, len(actions))
 
 	for idx, step := range actions {
-		result[idx] = step.execute(ctx, db, tbsStorageManager)
+		result[idx] = step.execute(ctx, db, r.storageManager)
 	}
 
 	return result

--- a/internal/management/controller/tablespaces/storage.go
+++ b/internal/management/controller/tablespaces/storage.go
@@ -22,6 +22,8 @@ import (
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/specs"
 )
 
+// tablespaceStorageManager represents the required behavior in terms of storage
+// for the tablespace reconciler
 type tablespaceStorageManager interface {
 	getStorageLocation(tbsName string) string
 	storageExists(tbsName string) (bool, error)

--- a/pkg/management/postgres/readiness/readiness.go
+++ b/pkg/management/postgres/readiness/readiness.go
@@ -18,23 +18,28 @@ package readiness
 
 import (
 	"context"
+	"database/sql"
 	"errors"
-
-	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres"
 )
 
 // ErrStreamingReplicaNotConnected is raised for streaming replicas that never connected to its primary
 var ErrStreamingReplicaNotConnected = errors.New("streaming replica was never connected to the primary node")
 
+// instanceInterface represents the required behavior for use in the readiness probe
+type instanceInterface interface {
+	CanCheckReadiness() bool
+	GetSuperUserDB() (*sql.DB, error)
+}
+
 // Data is the readiness checker structure
 type Data struct {
-	instance *postgres.Instance
+	instance instanceInterface
 
 	streamingReplicaValidated bool
 }
 
 // ForInstance creates a readiness checker for a certain instance
-func ForInstance(instance *postgres.Instance) *Data {
+func ForInstance(instance instanceInterface) *Data {
 	return &Data{
 		instance: instance,
 	}


### PR DESCRIPTION
The tablespaces feature uses an unnecessary interface to mock the DB.
This ticket gets rid of it to use sqlmock instead, and improves the unit tests
by testing the top-level `Reconcile` rather than internals
