### PR TITLE
ci: avoid testing deprecated versions of AKS

### DIFF
--- a/.github/workflows/k8s-versions-check.yml
+++ b/.github/workflows/k8s-versions-check.yml
@@ -57,7 +57,7 @@ jobs:
         name: Get updated AKS versions
         run: |
           az aks get-versions --location westeurope  \
-            --query 'reverse(sort(values[? isPreview != `true`].patchVersions.keys(@)[]))' -o tsv | \
+            --query "reverse(sort(values[? isPreview != 'true' && contains(capabilities.supportPlan, 'KubernetesOfficial')].patchVersions.keys(@)[]))" -o tsv | \
             sort -urk 1,1.5 | \
             awk -vv=$MINIMAL_K8S '$0>=v {print $0}' | \
             jq -Rn '[inputs]' | tee .github/aks_versions.json


### PR DESCRIPTION
The last [release of AKS](https://github.com/Azure/AKS/releases/tag/2024-08-27) deprecated v1.27, meaning that now you need to [Enable the long-term support plan](https://learn.microsoft.com/en-gb/azure/aks/long-term-support#enable-long-term-support) to get access to this version.

Right now the cloud provider E2E test for AKS 1.27 are failing during the creation with:
```
ERROR: (K8sVersionNotSupported) Managed cluster ***-3482-aks1279PostgreSQL17rc1 is on version 1.27.9 which is not supported in this region. Please use [az aks get-versions] command to get the supported version list in this region. For more information, please check https://aka.ms/supported-version-list
Code: K8sVersionNotSupported
Message: Managed cluster ***-3482-aks1279PostgreSQL17rc1 is on version 1.27.9 which is not supported in this region. Please use [az aks get-versions] command to get the supported version list in this region. For more information, please check https://aka.ms/supported-version-list
```

This patch makes it so that we only test versions that are currently supported (e.g `KubernetesOfficial`), effectively excluding the ones that are only under `AKSLongTermSupport`.