### PR TITLE
chore: add names to controllers

### DIFF
--- a/internal/cmd/manager/instance/run/cmd.go
+++ b/internal/cmd/manager/instance/run/cmd.go
@@ -193,7 +193,7 @@ func runSubCommand(ctx context.Context, instance *postgres.Instance) error {
 	reconciler := controller.NewInstanceReconciler(instance, mgr.GetClient(), metricsExporter)
 	err = ctrl.NewControllerManagedBy(mgr).
 		For(&apiv1.Cluster{}).
-		Named("cluster-instance").
+		Named("instance-cluster").
 		Complete(reconciler)
 	if err != nil {
 		setupLog.Error(err, "unable to create instance controller")
@@ -203,11 +203,7 @@ func runSubCommand(ctx context.Context, instance *postgres.Instance) error {
 
 	// database reconciler
 	dbReconciler := controller.NewDatabaseReconciler(mgr, instance)
-	err = ctrl.NewControllerManagedBy(mgr).
-		For(&apiv1.Database{}).
-		Named("database-instance").
-		Complete(dbReconciler)
-	if err != nil {
+	if err := dbReconciler.SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create database controller")
 		return err
 	}

--- a/internal/cmd/manager/instance/run/cmd.go
+++ b/internal/cmd/manager/instance/run/cmd.go
@@ -193,6 +193,7 @@ func runSubCommand(ctx context.Context, instance *postgres.Instance) error {
 	reconciler := controller.NewInstanceReconciler(instance, mgr.GetClient(), metricsExporter)
 	err = ctrl.NewControllerManagedBy(mgr).
 		For(&apiv1.Cluster{}).
+		Named("cluster-instance").
 		Complete(reconciler)
 	if err != nil {
 		setupLog.Error(err, "unable to create instance controller")
@@ -204,6 +205,7 @@ func runSubCommand(ctx context.Context, instance *postgres.Instance) error {
 	dbReconciler := controller.NewDatabaseReconciler(mgr, instance)
 	err = ctrl.NewControllerManagedBy(mgr).
 		For(&apiv1.Database{}).
+		Named("database-instance").
 		Complete(dbReconciler)
 	if err != nil {
 		setupLog.Error(err, "unable to create database controller")

--- a/internal/controller/backup_controller.go
+++ b/internal/controller/backup_controller.go
@@ -664,6 +664,7 @@ func (r *BackupReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manage
 
 	controllerBuilder := ctrl.NewControllerManagedBy(mgr).
 		For(&apiv1.Backup{}).
+		Named("backup").
 		Watches(&apiv1.Cluster{},
 			handler.EnqueueRequestsFromMapFunc(r.mapClustersToBackup()),
 			builder.WithPredicates(clustersWithBackupPredicate),

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -989,6 +989,7 @@ func (r *ClusterReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manag
 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&apiv1.Cluster{}).
+		Named("cluster").
 		Owns(&corev1.Pod{}).
 		Owns(&batchv1.Job{}).
 		Owns(&corev1.Service{}).

--- a/internal/controller/plugin_controller.go
+++ b/internal/controller/plugin_controller.go
@@ -225,6 +225,7 @@ func (r *PluginReconciler) SetupWithManager(mgr ctrl.Manager, operatorNamespace 
 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&corev1.Service{}).
+		Named("plugin").
 		WithEventFilter(pluginServicesPredicate).
 		Complete(r)
 }

--- a/internal/controller/pooler_controller.go
+++ b/internal/controller/pooler_controller.go
@@ -129,6 +129,7 @@ func (r *PoolerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 func (r *PoolerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&apiv1.Pooler{}).
+		Named("pooler").
 		Owns(&v1.Deployment{}).
 		Owns(&corev1.Service{}).
 		Owns(&corev1.ServiceAccount{}).

--- a/internal/controller/scheduledbackup_controller.go
+++ b/internal/controller/scheduledbackup_controller.go
@@ -353,5 +353,6 @@ func (r *ScheduledBackupReconciler) SetupWithManager(ctx context.Context, mgr ct
 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&apiv1.ScheduledBackup{}).
+		Named("scheduled-backup").
 		Complete(r)
 }

--- a/internal/management/controller/database_controller.go
+++ b/internal/management/controller/database_controller.go
@@ -237,6 +237,7 @@ func NewDatabaseReconciler(
 func (r *DatabaseReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&apiv1.Database{}).
+		Named("database-instance").
 		Complete(r)
 }
 

--- a/internal/management/controller/database_controller.go
+++ b/internal/management/controller/database_controller.go
@@ -237,7 +237,7 @@ func NewDatabaseReconciler(
 func (r *DatabaseReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&apiv1.Database{}).
-		Named("database-instance").
+		Named("instance-database").
 		Complete(r)
 }
 

--- a/internal/management/controller/externalservers/manager.go
+++ b/internal/management/controller/externalservers/manager.go
@@ -46,7 +46,7 @@ func NewReconciler(instance *postgres.Instance, client client.Client) *Reconcile
 func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&apiv1.Cluster{}).
-		Named("cluster-external-server").
+		Named("instance-external-server").
 		Complete(r)
 }
 

--- a/internal/management/controller/externalservers/manager.go
+++ b/internal/management/controller/externalservers/manager.go
@@ -46,6 +46,7 @@ func NewReconciler(instance *postgres.Instance, client client.Client) *Reconcile
 func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&apiv1.Cluster{}).
+		Named("cluster-external-server").
 		Complete(r)
 }
 

--- a/internal/management/controller/tablespaces/manager.go
+++ b/internal/management/controller/tablespaces/manager.go
@@ -47,7 +47,7 @@ func NewTablespaceReconciler(instance *postgres.Instance, client client.Client) 
 func (r *TablespaceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&apiv1.Cluster{}).
-		Named("cluster-tablespaces").
+		Named("instance-tablespaces").
 		Complete(r)
 }
 

--- a/internal/management/controller/tablespaces/manager.go
+++ b/internal/management/controller/tablespaces/manager.go
@@ -47,6 +47,7 @@ func NewTablespaceReconciler(instance *postgres.Instance, client client.Client) 
 func (r *TablespaceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&apiv1.Cluster{}).
+		Named("cluster-tablespaces").
 		Complete(r)
 }
 


### PR DESCRIPTION
Controller-runtime v0.19.0 errors when a controller manager detects multiple controllers with the same name; this is done to improve the clarity of the log messages. For more information, see the attached PR.

This patch adds a name for every controller in the operator, complying with this rule.

See: https://github.com/kubernetes-sigs/controller-runtime/pull/2902
Closes #5640 