### PR TITLE
fix(cnpg-i): ensure instance manager invokes only the available plugins

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/cheynewallace/tabby v1.1.1
 	github.com/cloudnative-pg/barman-cloud v0.0.0-20240924124724-92831d48562a
 	github.com/cloudnative-pg/cnpg-i v0.0.0-20241001103001-7e24b2eccd50
-	github.com/cloudnative-pg/machinery v0.0.0-20241007093555-1e197af1f392
+	github.com/cloudnative-pg/machinery v0.0.0-20241010122207-5ac7af31ef72
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/evanphx/json-patch/v5 v5.9.0
 	github.com/go-logr/logr v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/cloudnative-pg/barman-cloud v0.0.0-20240924124724-92831d48562a h1:0v1
 github.com/cloudnative-pg/barman-cloud v0.0.0-20240924124724-92831d48562a/go.mod h1:Jm0tOp5oB7utpt8wz6RfSv31h1mThOtffjfyxVupriE=
 github.com/cloudnative-pg/cnpg-i v0.0.0-20241001103001-7e24b2eccd50 h1:Rm/bbC0GNCuWth5fHVMos99RzNczbWRVBdjubh3JMPs=
 github.com/cloudnative-pg/cnpg-i v0.0.0-20241001103001-7e24b2eccd50/go.mod h1:lTWPq8pluS0PSnRMwt0zShftbyssoRhTJ5zAip8unl8=
-github.com/cloudnative-pg/machinery v0.0.0-20241007093555-1e197af1f392 h1:DHaSe0PoLnIQFWIpRqB9RiBlNzbdLuVbiCtc9tN+FL0=
-github.com/cloudnative-pg/machinery v0.0.0-20241007093555-1e197af1f392/go.mod h1:bWp1Es5zlxElg4Z/c5f0RKOkDcyNvDHdYIvNcPQU4WM=
+github.com/cloudnative-pg/machinery v0.0.0-20241010122207-5ac7af31ef72 h1:3pgtSYhv3RDd+51bnlqICNrcVpWQQvriCOvkxtbZpaE=
+github.com/cloudnative-pg/machinery v0.0.0-20241010122207-5ac7af31ef72/go.mod h1:bWp1Es5zlxElg4Z/c5f0RKOkDcyNvDHdYIvNcPQU4WM=
 github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
 github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=

--- a/internal/cmd/manager/controller/controller.go
+++ b/internal/cmd/manager/controller/controller.go
@@ -219,7 +219,7 @@ func RunController(
 	}
 
 	pluginRepository := repository.New()
-	if err := pluginRepository.RegisterUnixSocketPluginsInPath(
+	if _, err := pluginRepository.RegisterUnixSocketPluginsInPath(
 		conf.PluginSocketDir,
 	); err != nil {
 		setupLog.Error(err, "Unable to load sidecar CNPG-i plugins, skipping")

--- a/internal/cmd/manager/walarchive/cmd.go
+++ b/internal/cmd/manager/walarchive/cmd.go
@@ -251,12 +251,13 @@ func archiveWALViaPlugins(
 	contextLogger := log.FromContext(ctx)
 
 	plugins := repository.New()
-	if err := plugins.RegisterUnixSocketPluginsInPath(configuration.Current.PluginSocketDir); err != nil {
+	pluginNames, err := plugins.RegisterUnixSocketPluginsInPath(configuration.Current.PluginSocketDir)
+	if err != nil {
 		contextLogger.Error(err, "Error while loading local plugins")
 	}
 	defer plugins.Close()
 
-	client, err := pluginClient.WithAvailablePlugins(ctx, plugins, cluster.Spec.Plugins.GetEnabledPluginNames()...)
+	client, err := pluginClient.WithPlugins(ctx, plugins, pluginNames...)
 	if err != nil {
 		contextLogger.Error(err, "Error while loading required plugins")
 		return err

--- a/internal/cmd/manager/walarchive/cmd.go
+++ b/internal/cmd/manager/walarchive/cmd.go
@@ -256,7 +256,7 @@ func archiveWALViaPlugins(
 	}
 	defer plugins.Close()
 
-	client, err := pluginClient.WithPlugins(ctx, plugins, cluster.Spec.Plugins.GetEnabledPluginNames()...)
+	client, err := pluginClient.WithAvailablePlugins(ctx, plugins, cluster.Spec.Plugins.GetEnabledPluginNames()...)
 	if err != nil {
 		contextLogger.Error(err, "Error while loading required plugins")
 		return err

--- a/internal/cmd/manager/walarchive/cmd.go
+++ b/internal/cmd/manager/walarchive/cmd.go
@@ -29,6 +29,7 @@ import (
 	barmanArchiver "github.com/cloudnative-pg/barman-cloud/pkg/archiver"
 	"github.com/cloudnative-pg/machinery/pkg/fileutils"
 	"github.com/cloudnative-pg/machinery/pkg/log"
+	"github.com/cloudnative-pg/machinery/pkg/stringset"
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -42,7 +43,6 @@ import (
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management"
 	pgManagement "github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/postgres"
-	"github.com/cloudnative-pg/cloudnative-pg/pkg/stringset"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 )
 

--- a/internal/cmd/manager/walrestore/cmd.go
+++ b/internal/cmd/manager/walrestore/cmd.go
@@ -38,6 +38,7 @@ import (
 	"github.com/cloudnative-pg/cloudnative-pg/internal/management/cache"
 	cacheClient "github.com/cloudnative-pg/cloudnative-pg/internal/management/cache/client"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/postgres"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/stringset"
 )
 
 var (
@@ -247,13 +248,20 @@ func restoreWALViaPlugins(
 	contextLogger := log.FromContext(ctx)
 
 	plugins := repository.New()
-	pluginNames, err := plugins.RegisterUnixSocketPluginsInPath(configuration.Current.PluginSocketDir)
+	availablePluginNames, err := plugins.RegisterUnixSocketPluginsInPath(configuration.Current.PluginSocketDir)
 	if err != nil {
 		contextLogger.Error(err, "Error while loading local plugins")
 	}
 	defer plugins.Close()
 
-	client, err := pluginClient.WithPlugins(ctx, plugins, pluginNames...)
+	availablePluginNamesSet := stringset.From(availablePluginNames)
+	enabledPluginNamesSet := stringset.From(cluster.Spec.Plugins.GetEnabledPluginNames())
+
+	client, err := pluginClient.WithPlugins(
+		ctx,
+		plugins,
+		availablePluginNamesSet.Intersect(enabledPluginNamesSet).ToList()...,
+	)
 	if err != nil {
 		contextLogger.Error(err, "Error while loading required plugins")
 		return err

--- a/internal/cmd/manager/walrestore/cmd.go
+++ b/internal/cmd/manager/walrestore/cmd.go
@@ -252,7 +252,7 @@ func restoreWALViaPlugins(
 	}
 	defer plugins.Close()
 
-	client, err := pluginClient.WithPlugins(ctx, plugins, cluster.Spec.Plugins.GetEnabledPluginNames()...)
+	client, err := pluginClient.WithAvailablePlugins(ctx, plugins, cluster.Spec.Plugins.GetEnabledPluginNames()...)
 	if err != nil {
 		contextLogger.Error(err, "Error while loading required plugins")
 		return err

--- a/internal/cmd/manager/walrestore/cmd.go
+++ b/internal/cmd/manager/walrestore/cmd.go
@@ -29,6 +29,7 @@ import (
 	barmanCommand "github.com/cloudnative-pg/barman-cloud/pkg/command"
 	barmanRestorer "github.com/cloudnative-pg/barman-cloud/pkg/restorer"
 	"github.com/cloudnative-pg/machinery/pkg/log"
+	"github.com/cloudnative-pg/machinery/pkg/stringset"
 	"github.com/spf13/cobra"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
@@ -38,7 +39,6 @@ import (
 	"github.com/cloudnative-pg/cloudnative-pg/internal/management/cache"
 	cacheClient "github.com/cloudnative-pg/cloudnative-pg/internal/management/cache/client"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/postgres"
-	"github.com/cloudnative-pg/cloudnative-pg/pkg/stringset"
 )
 
 var (

--- a/internal/cmd/manager/walrestore/cmd.go
+++ b/internal/cmd/manager/walrestore/cmd.go
@@ -247,12 +247,13 @@ func restoreWALViaPlugins(
 	contextLogger := log.FromContext(ctx)
 
 	plugins := repository.New()
-	if err := plugins.RegisterUnixSocketPluginsInPath(configuration.Current.PluginSocketDir); err != nil {
+	pluginNames, err := plugins.RegisterUnixSocketPluginsInPath(configuration.Current.PluginSocketDir)
+	if err != nil {
 		contextLogger.Error(err, "Error while loading local plugins")
 	}
 	defer plugins.Close()
 
-	client, err := pluginClient.WithAvailablePlugins(ctx, plugins, cluster.Spec.Plugins.GetEnabledPluginNames()...)
+	client, err := pluginClient.WithPlugins(ctx, plugins, pluginNames...)
 	if err != nil {
 		contextLogger.Error(err, "Error while loading required plugins")
 		return err

--- a/internal/cnpi/plugin/client/client.go
+++ b/internal/cnpi/plugin/client/client.go
@@ -18,7 +18,6 @@ package client
 
 import (
 	"context"
-	"errors"
 
 	"github.com/cloudnative-pg/machinery/pkg/log"
 
@@ -43,27 +42,9 @@ func (data *data) getPlugin(pluginName string) (connection.Interface, error) {
 	return nil, ErrPluginNotLoaded
 }
 
-// load loads the plugins with the specified name
 func (data *data) load(ctx context.Context, names ...string) error {
 	for _, name := range names {
 		pluginData, err := data.repository.GetConnection(ctx, name)
-		if err != nil {
-			return err
-		}
-
-		data.plugins = append(data.plugins, pluginData)
-	}
-	return nil
-}
-
-// loadAvailable loads only the plugins that are actually available, matching the names
-func (data *data) loadAvailable(ctx context.Context, names ...string) error {
-	for _, name := range names {
-		pluginData, err := data.repository.GetConnection(ctx, name)
-		var unknownPluginErr *repository.ErrUnknownPlugin
-		if errors.As(err, &unknownPluginErr) {
-			continue
-		}
 		if err != nil {
 			return err
 		}
@@ -103,20 +84,6 @@ func WithPlugins(ctx context.Context, repository repository.Interface, names ...
 		repository: repository,
 	}
 	if err := result.load(ctx, names...); err != nil {
-		return nil, err
-	}
-
-	return result, nil
-}
-
-// WithAvailablePlugins creates a new CNP-I client for plugins in a certain repository,
-// loading the available plugins with the specified name. If a plugin is not available,
-// it will be skipped.
-func WithAvailablePlugins(ctx context.Context, repository repository.Interface, names ...string) (Client, error) {
-	result := &data{
-		repository: repository,
-	}
-	if err := result.loadAvailable(ctx, names...); err != nil {
 		return nil, err
 	}
 

--- a/pkg/management/postgres/webserver/plugin_backup.go
+++ b/pkg/management/postgres/webserver/plugin_backup.go
@@ -55,6 +55,16 @@ func NewPluginBackupCommand(
 ) *PluginBackupCommand {
 	backup.EnsureGVKIsPresent()
 
+	logger := log.WithValues(
+		"pluginConfiguration", backup.Spec.PluginConfiguration,
+		"backupName", backup.Name,
+		"backupNamespace", backup.Name)
+
+	plugins := repository.New()
+	if _, err := plugins.RegisterUnixSocketPluginsInPath(configuration.Current.PluginSocketDir); err != nil {
+		logger.Error(err, "Error while discovering plugins")
+	}
+
 	return &PluginBackupCommand{
 		Cluster:  cluster,
 		Backup:   backup,
@@ -75,7 +85,7 @@ func (b *PluginBackupCommand) invokeStart(ctx context.Context) {
 		"backupNamespace", b.Backup.Name)
 
 	plugins := repository.New()
-	if err := plugins.RegisterUnixSocketPluginsInPath(configuration.Current.PluginSocketDir); err != nil {
+	if _, err := plugins.RegisterUnixSocketPluginsInPath(configuration.Current.PluginSocketDir); err != nil {
 		contextLogger.Error(err, "Error while discovering plugins")
 	}
 	defer plugins.Close()


### PR DESCRIPTION
The instance manager should try to load only available plugins, as some of them declared in the Cluster spec might be available only to the operator.

closes #5648 