### PR TITLE
fix: include release candidate for OpenShift in the regexp

### DIFF
--- a/.github/workflows/k8s-versions-check.yml
+++ b/.github/workflows/k8s-versions-check.yml
@@ -111,7 +111,7 @@ jobs:
         run: |
           curl -s https://mirror.openshift.com/pub/openshift-v4/clients/ocp/ | \
           grep -e 'href.*"4\.1[2-9]\.[0-9].*"' | \
-          sed -e 's/\(.*\)href="\(4\.1[2-9]\)\(.*\)/\2/' | \
+          sed -E 's/.*href="(4\.1[2-9]\.[0-9]+(.*-rc.*[0-9]+)?).*/\1/' | \
           sort -Vru | \
           awk -vv="$MINIMAL_OCP" '$0>=v {print $0}' | \
           jq -Rn '[inputs]' | tee .github/openshift_versions.json


### PR DESCRIPTION
Updating the regexp that catch the versions to cover the following format "4.17.0-rc.6" 
with the new regexp this will also be catch