### PR TITLE
feat: add support for `maxConcurrentReconciles`

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -38,6 +38,7 @@ spec:
         args:
         - controller
         - --leader-elect
+        - --max-concurrent-reconciles=10
         - --config-map-name=$(OPERATOR_DEPLOYMENT_NAME)-config
         - --secret-name=$(OPERATOR_DEPLOYMENT_NAME)-config
         - --webhook-port=9443

--- a/internal/cmd/manager/controller/cmd.go
+++ b/internal/cmd/manager/controller/cmd.go
@@ -34,6 +34,7 @@ func NewCmd() *cobra.Command {
 	var pprofHTTPServer bool
 	var leaderLeaseDuration int
 	var leaderRenewDeadline int
+	var maxConcurrentReconciles int
 
 	cmd := cobra.Command{
 		Use:           "controller [flags]",
@@ -50,6 +51,7 @@ func NewCmd() *cobra.Command {
 				},
 				pprofHTTPServer,
 				port,
+				maxConcurrentReconciles,
 				configuration.Current,
 			)
 		},
@@ -76,6 +78,12 @@ func NewCmd() *cobra.Command {
 		"pprof-server",
 		false,
 		"If true it will start a pprof debug http server on localhost:6060. Defaults to false.",
+	)
+	cmd.Flags().IntVar(
+		&maxConcurrentReconciles,
+		"max-concurrent-reconciles",
+		10,
+		"The maximum number of concurrent reconciles. Defaults to 10.",
 	)
 
 	return &cmd

--- a/internal/cmd/manager/controller/controller.go
+++ b/internal/cmd/manager/controller/controller.go
@@ -95,6 +95,7 @@ func RunController(
 	leaderConfig leaderElectionConfiguration,
 	pprofDebug bool,
 	port int,
+	maxConcurrentReconciles int,
 	conf *configuration.Data,
 ) error {
 	ctx := context.Background()
@@ -222,7 +223,7 @@ func RunController(
 		mgr,
 		discoveryClient,
 		pluginRepository,
-	).SetupWithManager(ctx, mgr); err != nil {
+	).SetupWithManager(ctx, mgr, maxConcurrentReconciles); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Cluster")
 		return err
 	}

--- a/internal/cmd/manager/controller/controller.go
+++ b/internal/cmd/manager/controller/controller.go
@@ -232,7 +232,7 @@ func RunController(
 		mgr,
 		discoveryClient,
 		pluginRepository,
-	).SetupWithManager(ctx, mgr, maxConcurrentReconciles); err != nil {
+	).SetupWithManager(ctx, mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Backup")
 		return err
 	}

--- a/internal/cmd/manager/controller/controller.go
+++ b/internal/cmd/manager/controller/controller.go
@@ -232,15 +232,13 @@ func RunController(
 		mgr,
 		discoveryClient,
 		pluginRepository,
-	).SetupWithManager(ctx, mgr); err != nil {
+	).SetupWithManager(ctx, mgr, maxConcurrentReconciles); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Backup")
 		return err
 	}
 
-	if err = controller.NewPluginReconciler(
-		mgr,
-		pluginRepository,
-	).SetupWithManager(mgr, configuration.Current.OperatorNamespace); err != nil {
+	if err = controller.NewPluginReconciler(mgr, pluginRepository).
+		SetupWithManager(mgr, configuration.Current.OperatorNamespace, maxConcurrentReconciles); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Plugin")
 		return err
 	}
@@ -249,7 +247,7 @@ func RunController(
 		Client:   mgr.GetClient(),
 		Scheme:   mgr.GetScheme(),
 		Recorder: mgr.GetEventRecorderFor("cloudnative-pg-scheduledbackup"),
-	}).SetupWithManager(ctx, mgr); err != nil {
+	}).SetupWithManager(ctx, mgr, maxConcurrentReconciles); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ScheduledBackup")
 		return err
 	}
@@ -259,7 +257,7 @@ func RunController(
 		DiscoveryClient: discoveryClient,
 		Scheme:          mgr.GetScheme(),
 		Recorder:        mgr.GetEventRecorderFor("cloudnative-pg-pooler"),
-	}).SetupWithManager(mgr); err != nil {
+	}).SetupWithManager(mgr, maxConcurrentReconciles); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Pooler")
 		return err
 	}

--- a/internal/controller/backup_controller.go
+++ b/internal/controller/backup_controller.go
@@ -643,7 +643,7 @@ func startInstanceManagerBackup(
 }
 
 // SetupWithManager sets up this controller given a controller manager
-func (r *BackupReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
+func (r *BackupReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, maxConcurrentReconciles int) error {
 	if err := mgr.GetFieldIndexer().IndexField(
 		ctx,
 		&apiv1.Backup{},
@@ -663,6 +663,7 @@ func (r *BackupReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manage
 	}
 
 	controllerBuilder := ctrl.NewControllerManagedBy(mgr).
+		WithOptions(controller.Options{MaxConcurrentReconciles: maxConcurrentReconciles}).
 		For(&apiv1.Backup{}).
 		Named("backup").
 		Watches(&apiv1.Cluster{},

--- a/internal/controller/backup_controller.go
+++ b/internal/controller/backup_controller.go
@@ -643,7 +643,7 @@ func startInstanceManagerBackup(
 }
 
 // SetupWithManager sets up this controller given a controller manager
-func (r *BackupReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, maxConcurrentReconciles int) error {
+func (r *BackupReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
 	if err := mgr.GetFieldIndexer().IndexField(
 		ctx,
 		&apiv1.Backup{},
@@ -663,7 +663,6 @@ func (r *BackupReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manage
 	}
 
 	controllerBuilder := ctrl.NewControllerManagedBy(mgr).
-		WithOptions(controller.Options{MaxConcurrentReconciles: maxConcurrentReconciles}).
 		For(&apiv1.Backup{}).
 		Named("backup").
 		Watches(&apiv1.Cluster{},

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -37,6 +37,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -1021,13 +1022,16 @@ func (r *ClusterReconciler) handleRollingUpdate(
 }
 
 // SetupWithManager creates a ClusterReconciler
-func (r *ClusterReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
+func (r *ClusterReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, maxConcurrentReconciles int) error {
 	err := r.createFieldIndexes(ctx, mgr)
 	if err != nil {
 		return err
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).
+		WithOptions(controller.Options{
+			MaxConcurrentReconciles: maxConcurrentReconciles,
+		}).
 		For(&apiv1.Cluster{}).
 		Named("cluster").
 		Owns(&corev1.Pod{}).

--- a/internal/controller/plugin_controller.go
+++ b/internal/controller/plugin_controller.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -207,7 +208,11 @@ func (r *PluginReconciler) getSecret(
 }
 
 // SetupWithManager adds this PluginReconciler to the passed controller manager
-func (r *PluginReconciler) SetupWithManager(mgr ctrl.Manager, operatorNamespace string) error {
+func (r *PluginReconciler) SetupWithManager(
+	mgr ctrl.Manager,
+	operatorNamespace string,
+	maxConcurrentReconciles int,
+) error {
 	pluginServicesPredicate := predicate.Funcs{
 		CreateFunc: func(e event.CreateEvent) bool {
 			return isPluginService(e.Object, operatorNamespace)
@@ -224,6 +229,7 @@ func (r *PluginReconciler) SetupWithManager(mgr ctrl.Manager, operatorNamespace 
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).
+		WithOptions(controller.Options{MaxConcurrentReconciles: maxConcurrentReconciles}).
 		For(&corev1.Service{}).
 		Named("plugin").
 		WithEventFilter(pluginServicesPredicate).

--- a/internal/controller/pooler_controller.go
+++ b/internal/controller/pooler_controller.go
@@ -35,6 +35,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -126,8 +127,9 @@ func (r *PoolerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 }
 
 // SetupWithManager setup this controller inside the controller manager
-func (r *PoolerReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *PoolerReconciler) SetupWithManager(mgr ctrl.Manager, maxConcurrentReconciles int) error {
 	return ctrl.NewControllerManagedBy(mgr).
+		WithOptions(controller.Options{MaxConcurrentReconciles: maxConcurrentReconciles}).
 		For(&apiv1.Pooler{}).
 		Named("pooler").
 		Owns(&v1.Deployment{}).

--- a/internal/controller/scheduledbackup_controller.go
+++ b/internal/controller/scheduledbackup_controller.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
@@ -326,7 +327,11 @@ func (r *ScheduledBackupReconciler) GetChildBackups(
 }
 
 // SetupWithManager install this controller in the controller manager
-func (r *ScheduledBackupReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
+func (r *ScheduledBackupReconciler) SetupWithManager(
+	ctx context.Context,
+	mgr ctrl.Manager,
+	maxConcurrentReconciles int,
+) error {
 	// Create a new indexed field on backups. This field will be used to easily
 	// find all the backups created by this controller
 	if err := mgr.GetFieldIndexer().IndexField(
@@ -353,6 +358,7 @@ func (r *ScheduledBackupReconciler) SetupWithManager(ctx context.Context, mgr ct
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).
+		WithOptions(controller.Options{MaxConcurrentReconciles: maxConcurrentReconciles}).
 		For(&apiv1.ScheduledBackup{}).
 		Named("scheduled-backup").
 		Complete(r)


### PR DESCRIPTION
Support the `maxConcurrentReconciles` parameter for improved concurrency management, except for backup operations. By default, the value is set to 10, enabling the operator to handle larger deployments efficiently out of the box.  

This enhancement provides greater flexibility for tuning reconciliation behaviour to suit diverse workloads and deployment sizes.  

Closes #5687  