### PR TITLE
fix: remove `pg_database_size` from status probe

### DIFF
--- a/internal/cmd/plugin/status/status.go
+++ b/internal/cmd/plugin/status/status.go
@@ -66,6 +66,9 @@ type PostgresqlStatus struct {
 
 	// ErrorList store the possible errors while getting the PostgreSQL status
 	ErrorList []error
+
+	// The size of the cluster
+	TotalClusterSize string
 }
 
 func (fullStatus *PostgresqlStatus) getReplicationSlotList() postgres.PgReplicationSlotList {
@@ -99,6 +102,10 @@ func getPrintableIntegerPointer(i *int) string {
 func Status(ctx context.Context, clusterName string, verbose bool, format plugin.OutputFormat) error {
 	var cluster apiv1.Cluster
 	var errs []error
+
+	// Create a Kubernetes client suitable for calling the "Exec" subresource
+	clientInterface := kubernetes.NewForConfigOrDie(plugin.Config)
+
 	// Get the Cluster object
 	err := plugin.Client.Get(ctx, client.ObjectKey{Namespace: plugin.Namespace, Name: clusterName}, &cluster)
 	if err != nil {
@@ -112,12 +119,12 @@ func Status(ctx context.Context, clusterName string, verbose bool, format plugin
 	}
 	errs = append(errs, status.ErrorList...)
 
-	status.printBasicInfo()
+	status.printBasicInfo(ctx, clientInterface)
 	status.printHibernationInfo()
 	status.printDemotionTokenInfo()
 	status.printPromotionTokenInfo()
 	if verbose {
-		errs = append(errs, status.printPostgresConfiguration(ctx)...)
+		errs = append(errs, status.printPostgresConfiguration(ctx, clientInterface)...)
 	}
 	status.printCertificatesStatus()
 	status.printBackupStatus()
@@ -188,8 +195,32 @@ func listFencedInstances(fencedInstances *stringset.Data) string {
 	return strings.Join(fencedInstances.ToList(), ", ")
 }
 
-func (fullStatus *PostgresqlStatus) printBasicInfo() {
+func (fullStatus *PostgresqlStatus) getClusterSize(ctx context.Context, client kubernetes.Interface) (string, error) {
+	timeout := time.Second * 10
+
+	// Read PostgreSQL configuration from custom.conf
+	output, _, err := utils.ExecCommand(
+		ctx,
+		client,
+		plugin.Config,
+		fullStatus.PrimaryPod,
+		specs.PostgresContainerName,
+		&timeout,
+		"du",
+		"-sLh",
+		specs.PgDataPath)
+	if err != nil {
+		return "", err
+	}
+
+	size, _, _ := strings.Cut(output, "\t")
+	return size, nil
+}
+
+func (fullStatus *PostgresqlStatus) printBasicInfo(ctx context.Context, client kubernetes.Interface) {
 	summary := tabby.New()
+
+	clusterSize, clusterSizeErr := fullStatus.getClusterSize(ctx, client)
 
 	cluster := fullStatus.Cluster
 
@@ -214,6 +245,7 @@ func (fullStatus *PostgresqlStatus) printBasicInfo() {
 
 	summary.AddLine("Name:", cluster.Name)
 	summary.AddLine("Namespace:", cluster.Namespace)
+
 	if primaryInstanceStatus != nil {
 		summary.AddLine("System ID:", primaryInstanceStatus.SystemID)
 	}
@@ -257,6 +289,13 @@ func (fullStatus *PostgresqlStatus) printBasicInfo() {
 			fmt.Println(aurora.Red("Switchover in progress"))
 		}
 	}
+
+	if clusterSizeErr != nil {
+		summary.AddLine("Size:", aurora.Red(clusterSizeErr.Error()))
+	} else {
+		summary.AddLine("Size:", clusterSize)
+	}
+
 	if !cluster.IsReplica() && primaryInstanceStatus != nil {
 		lsnInfo := fmt.Sprintf(
 			"%s (Timeline: %d - WAL File: %s)",
@@ -395,9 +434,8 @@ func (fullStatus *PostgresqlStatus) getStatus(isPrimaryFenced bool, cluster *api
 	}
 }
 
-func (fullStatus *PostgresqlStatus) printPostgresConfiguration(ctx context.Context) []error {
+func (fullStatus *PostgresqlStatus) printPostgresConfiguration(ctx context.Context, clientInterface kubernetes.Interface) []error {
 	timeout := time.Second * 10
-	clientInterface := kubernetes.NewForConfigOrDie(plugin.Config)
 	var errs []error
 
 	// Read PostgreSQL configuration from custom.conf
@@ -662,7 +700,6 @@ func (fullStatus *PostgresqlStatus) printInstancesStatus() {
 	fmt.Println(aurora.Green("Instances status"))
 	status.AddHeader(
 		"Name",
-		"Database Size",
 		"Current LSN", // For standby use "Replay LSN"
 		"Replication role",
 		"Status",
@@ -693,7 +730,6 @@ func (fullStatus *PostgresqlStatus) printInstancesStatus() {
 		replicaRole := getReplicaRole(instance, fullStatus)
 		status.AddLine(
 			instance.Pod.Name,
-			instance.TotalInstanceSize,
 			getCurrentLSN(instance),
 			replicaRole,
 			statusMsg,

--- a/internal/cmd/plugin/status/status.go
+++ b/internal/cmd/plugin/status/status.go
@@ -198,7 +198,7 @@ func listFencedInstances(fencedInstances *stringset.Data) string {
 func (fullStatus *PostgresqlStatus) getClusterSize(ctx context.Context, client kubernetes.Interface) (string, error) {
 	timeout := time.Second * 10
 
-	// Read PostgreSQL configuration from custom.conf
+	// Compute the disk space through `du`
 	output, _, err := utils.ExecCommand(
 		ctx,
 		client,

--- a/internal/cmd/plugin/status/status.go
+++ b/internal/cmd/plugin/status/status.go
@@ -434,12 +434,15 @@ func (fullStatus *PostgresqlStatus) getStatus(isPrimaryFenced bool, cluster *api
 	}
 }
 
-func (fullStatus *PostgresqlStatus) printPostgresConfiguration(ctx context.Context, clientInterface kubernetes.Interface) []error {
+func (fullStatus *PostgresqlStatus) printPostgresConfiguration(
+	ctx context.Context,
+	client kubernetes.Interface,
+) []error {
 	timeout := time.Second * 10
 	var errs []error
 
 	// Read PostgreSQL configuration from custom.conf
-	customConf, _, err := utils.ExecCommand(ctx, clientInterface, plugin.Config, fullStatus.PrimaryPod,
+	customConf, _, err := utils.ExecCommand(ctx, client, plugin.Config, fullStatus.PrimaryPod,
 		specs.PostgresContainerName,
 		&timeout,
 		"cat",
@@ -449,7 +452,7 @@ func (fullStatus *PostgresqlStatus) printPostgresConfiguration(ctx context.Conte
 	}
 
 	// Read PostgreSQL HBA Rules from pg_hba.conf
-	pgHBAConf, _, err := utils.ExecCommand(ctx, clientInterface, plugin.Config, fullStatus.PrimaryPod,
+	pgHBAConf, _, err := utils.ExecCommand(ctx, client, plugin.Config, fullStatus.PrimaryPod,
 		specs.PostgresContainerName,
 		&timeout, "cat", path.Join(specs.PgDataPath, constants.PostgresqlHBARulesFile))
 	if err != nil {

--- a/pkg/management/postgres/probes.go
+++ b/pkg/management/postgres/probes.go
@@ -92,10 +92,8 @@ func (instance *Instance) GetStatus() (result *postgres.PostgresqlStatus, err er
 			-- True if this is a primary instance
 			NOT pg_is_in_recovery() as primary,
 			-- True if at least one column requires a restart
-			EXISTS(SELECT 1 FROM pg_settings WHERE pending_restart),
-			-- The size of database in human readable format
-			(SELECT pg_size_pretty(SUM(pg_database_size(oid))) FROM pg_database)`)
-	err = row.Scan(&result.SystemID, &result.IsPrimary, &result.PendingRestart, &result.TotalInstanceSize)
+			EXISTS(SELECT 1 FROM pg_settings WHERE pending_restart)`)
+	err = row.Scan(&result.SystemID, &result.IsPrimary, &result.PendingRestart)
 	if err != nil {
 		return result, err
 	}

--- a/pkg/postgres/status.go
+++ b/pkg/postgres/status.go
@@ -43,7 +43,6 @@ type PostgresqlStatus struct {
 	IsArchivingWAL            bool        `json:"isArchivingWAL,omitempty"`
 	Node                      string      `json:"node"`
 	Pod                       *corev1.Pod `json:"pod"`
-	TotalInstanceSize         string      `json:"totalInstanceSize"`
 	// populated when MightBeUnavailable reported a healthy status even if it found an error
 	MightBeUnavailableMaskedError string `json:"mightBeUnavailableMaskedError,omitempty"`
 


### PR DESCRIPTION
The instance manager status probe was using `pg_database_size` which scans the whole PGDATA to compute the current size of every database.

Instead of doing that in the status probe, causing a scan in each reconciliation loop, we now do that only when requested by the `kubectl cnpg status` plugin.

Closes: #5686 