### PR TITLE
Add readiness/liveness probe timeout options as well as startup initial delay

### DIFF
--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -364,6 +364,26 @@ type ClusterSpec struct {
 	// +optional
 	LivenessProbeTimeout *int32 `json:"livenessProbeTimeout,omitempty"`
 
+	// Number of seconds after the container has started before startup probes are initiated.
+	// More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+	// +optional
+	StartupProbeInitialDelaySeconds int32 `json:"startupProbeInitialDelaySeconds,omitempty"`
+
+	// Number of seconds after the container has started before startup probes are initiated.
+	// More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+	// +optional
+	StartupProbeTimeoutSeconds int32 `json:"startupProbeTimeoutSeconds,omitempty"`
+
+	// Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1.
+	// More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+	// +optional
+	LivenessProbeTimeoutSeconds int32 `json:"livenessProbeTimeoutSeconds,omitempty"`
+
+	// Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1.
+	// More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+	// +optional
+	ReadinessProbeTimeoutSeconds int32 `json:"readinessProbeTimeoutSeconds,omitempty"`
+
 	// Affinity/Anti-affinity rules for Pods
 	// +optional
 	Affinity AffinityConfiguration `json:"affinity,omitempty"`

--- a/config/crd/bases/postgresql.cnpg.io_clusters.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_clusters.yaml
@@ -3094,6 +3094,12 @@ spec:
                   ceiling(livenessProbe / 10).
                 format: int32
                 type: integer
+              livenessProbeTimeoutSeconds:
+                description: |-
+                  Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1.
+                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                format: int32
+                type: integer
               logLevel:
                 default: info
                 description: 'The instances'' log level, one of the following values:
@@ -4523,6 +4529,12 @@ spec:
                     type: array
                     x-kubernetes-list-type: atomic
                 type: object
+              readinessProbeTimeoutSeconds:
+                description: |-
+                  Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1.
+                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                format: int32
+                type: integer
               replica:
                 description: Replica cluster configuration
                 properties:
@@ -4764,6 +4776,18 @@ spec:
                   successfully start up (default 3600).
                   The startup probe failure threshold is derived from this value using the formula:
                   ceiling(startDelay / 10).
+                format: int32
+                type: integer
+              startupProbeInitialDelaySeconds:
+                description: |-
+                  Number of seconds after the container has started before startup probes are initiated.
+                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                format: int32
+                type: integer
+              startupProbeTimeoutSeconds:
+                description: |-
+                  Number of seconds after the container has started before startup probes are initiated.
+                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                 format: int32
                 type: integer
               stopDelay:

--- a/pkg/specs/pods.go
+++ b/pkg/specs/pods.go
@@ -199,9 +199,10 @@ func createPostgresContainers(cluster apiv1.Cluster, envConfig EnvConfig, enable
 			EnvFrom:         envConfig.EnvFrom,
 			VolumeMounts:    createPostgresVolumeMounts(cluster),
 			StartupProbe: &corev1.Probe{
-				FailureThreshold: getStartupProbeFailureThreshold(cluster.GetMaxStartDelay()),
-				PeriodSeconds:    StartupProbePeriod,
-				TimeoutSeconds:   5,
+				FailureThreshold:    getStartupProbeFailureThreshold(cluster.GetMaxStartDelay()),
+				PeriodSeconds:       StartupProbePeriod,
+				InitialDelaySeconds: cluster.Spec.StartupProbeInitialDelaySeconds,
+				TimeoutSeconds:      cluster.Spec.StartupProbeTimeoutSeconds,
 				ProbeHandler: corev1.ProbeHandler{
 					HTTPGet: &corev1.HTTPGetAction{
 						Path: url.PathHealth,
@@ -210,7 +211,7 @@ func createPostgresContainers(cluster apiv1.Cluster, envConfig EnvConfig, enable
 				},
 			},
 			ReadinessProbe: &corev1.Probe{
-				TimeoutSeconds: 5,
+				TimeoutSeconds: cluster.Spec.ReadinessProbeTimeoutSeconds,
 				PeriodSeconds:  ReadinessProbePeriod,
 				ProbeHandler: corev1.ProbeHandler{
 					HTTPGet: &corev1.HTTPGetAction{
@@ -221,7 +222,7 @@ func createPostgresContainers(cluster apiv1.Cluster, envConfig EnvConfig, enable
 			},
 			LivenessProbe: &corev1.Probe{
 				PeriodSeconds:  LivenessProbePeriod,
-				TimeoutSeconds: 5,
+				TimeoutSeconds: cluster.Spec.LivenessProbeTimeoutSeconds,
 				ProbeHandler: corev1.ProbeHandler{
 					HTTPGet: &corev1.HTTPGetAction{
 						Path: url.PathHealth,


### PR DESCRIPTION
resolves https://github.com/cloudnative-pg/cloudnative-pg/issues/4852

Tested with this:

```
apiVersion: postgresql.cnpg.io/v1
kind: Cluster
metadata:
  name: somecluster
spec:
  instances: 1
  startupProbeInitialDelaySeconds: 30
  startupProbeTimeoutSeconds: 10
  livenessProbeTimeoutSeconds: 10
  readinessProbeTimeoutSeconds: 10
  storage:
    size: 1Gi
```