### PR TITLE
fix(backup): add `BackupStartingCondition` condition to cluster while using the plugin method

### DIFF
--- a/pkg/management/postgres/backup.go
+++ b/pkg/management/postgres/backup.go
@@ -209,7 +209,6 @@ func (b *BackupCommand) takeBackup(ctx context.Context) error {
 
 	// Update backup status in cluster conditions on startup
 	if err := b.retryWithRefreshedCluster(ctx, func() error {
-		// TODO: this condition is set only here, never removed or handled?
 		return conditions.Patch(ctx, b.Client, b.Cluster, apiv1.BackupStartingCondition)
 	}); err != nil {
 		b.Log.Error(err, "Error changing backup condition (backup started)")


### PR DESCRIPTION
## Release Notes

The operator now correctly adds the `BackupStartingCondition` to the cluster resource while taking a backup with a plugin.

## Note for reviewers

Previously while taking a backup we only set the backup failed condition but we never communicated when the backup was starting, this patch aims to fix that