### PR TITLE
chore: give feedback on ignored fields if DB exists

### DIFF
--- a/api/v1/database_types.go
+++ b/api/v1/database_types.go
@@ -81,6 +81,20 @@ type DatabaseSpec struct {
 	ReclaimPolicy DatabaseReclaimPolicy `json:"databaseReclaimPolicy,omitempty"`
 }
 
+// HasImmutableFields returns the list of fields in database spec that cannot
+// be set in an ALTER statement in Postgres
+func (db DatabaseSpec) HasImmutableFields() []string {
+	var fields []string
+	if db.Encoding != "" {
+		fields = append(fields, "encoding")
+	}
+	if db.Template != "" {
+		fields = append(fields, "template")
+	}
+
+	return fields
+}
+
 // DatabaseStatus defines the observed state of Database
 type DatabaseStatus struct {
 	// A sequence number representing the latest
@@ -93,6 +107,10 @@ type DatabaseStatus struct {
 
 	// Error is the reconciliation error message
 	Error string `json:"error,omitempty"`
+
+	// Comments contains information that may arise during object reconciliation
+	// that will make things more explicit to the user
+	Comments string `json:"comments,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/config/crd/bases/postgresql.cnpg.io_databases.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_databases.yaml
@@ -126,6 +126,11 @@ spec:
               date. Populated by the system. Read-only.
               More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
             properties:
+              comments:
+                description: |-
+                  Comments contains information that may arise during object reconciliation
+                  that will make things more explicit to the user
+                type: string
               error:
                 description: Error is the reconciliation error message
                 type: string

--- a/docs/src/cloudnative-pg.v1.md
+++ b/docs/src/cloudnative-pg.v1.md
@@ -2389,6 +2389,14 @@ desired state that was synchronized</p>
    <p>Error is the reconciliation error message</p>
 </td>
 </tr>
+<tr><td><code>comments</code> <B>[Required]</B><br/>
+<i>string</i>
+</td>
+<td>
+   <p>Comments contains information that may arise during object reconciliation
+that will make things more explicit to the user</p>
+</td>
+</tr>
 </tbody>
 </table>
 

--- a/internal/management/controller/database_controller_test.go
+++ b/internal/management/controller/database_controller_test.go
@@ -146,9 +146,10 @@ var _ = Describe("Managed Database status", func() {
 	})
 
 	It("properly marks the status on a succeeded reconciliation", func(ctx SpecContext) {
-		_, err := r.succeededReconciliation(ctx, database)
+		_, err := r.succeededReconciliation(ctx, database, "this is a comment")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(database.Status.Ready).To(BeTrue())
+		Expect(database.Status.Comments).NotTo(BeEmpty())
 		Expect(database.Status.Error).To(BeEmpty())
 	})
 


### PR DESCRIPTION
Closes #5696 

```yaml
spec:
  cluster:
    name: cluster-example
  databaseReclaimPolicy: retain
  encoding: SQL_ASCII
  name: existing-db
  owner: app
status:
  comments: the database 'existing-db' already exists. The following fields cannot be enforced
    and will be ignored: encoding
  observedGeneration: 1
  ready: true
```