### PR TITLE
fix(backup,plugin): keep plugin connection open while running a backup

### DIFF
--- a/api/v1/backup_funcs.go
+++ b/api/v1/backup_funcs.go
@@ -24,6 +24,7 @@ import (
 	volumesnapshot "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -228,6 +229,17 @@ func (backup *Backup) GetVolumeSnapshotConfiguration(
 	}
 
 	return config
+}
+
+// EnsureGVKIsPresent ensures that the GroupVersionKind (GVK) metadata is present in the Backup object.
+// This is necessary because informers do not automatically include metadata inside the object.
+// By setting the GVK, we ensure that components such as the plugins have enough metadata to typecheck the object.
+func (backup *Backup) EnsureGVKIsPresent() {
+	backup.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   GroupVersion.Group,
+		Version: GroupVersion.Version,
+		Kind:    BackupKind,
+	})
 }
 
 // IsEmpty checks if the plugin configuration is empty or not

--- a/pkg/management/postgres/webserver/local.go
+++ b/pkg/management/postgres/webserver/local.go
@@ -227,7 +227,5 @@ func (ws *localWebserverEndpoints) startPluginBackup(
 	cluster *apiv1.Cluster,
 	backup *apiv1.Backup,
 ) {
-	cmd := NewPluginBackupCommand(cluster, backup, ws.typedClient, ws.eventRecorder)
-	cmd.Start(ctx)
-	cmd.Close()
+	NewPluginBackupCommand(cluster, backup, ws.typedClient, ws.eventRecorder).Start(ctx)
 }

--- a/pkg/management/postgres/webserver/plugin_backup.go
+++ b/pkg/management/postgres/webserver/plugin_backup.go
@@ -23,7 +23,6 @@ import (
 	"github.com/cloudnative-pg/machinery/pkg/log"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -54,16 +53,7 @@ func NewPluginBackupCommand(
 	client client.Client,
 	recorder record.EventRecorder,
 ) *PluginBackupCommand {
-	// This backup object may come from an informers, and
-	// informers do not put their metadata inside the object.
-	// Let's ensure the plugin has enough metadata to typecheck
-	// the object.
-	// For more info: https://github.com/kubernetes/client-go/issues/308
-	backup.SetGroupVersionKind(schema.GroupVersionKind{
-		Group:   apiv1.GroupVersion.Group,
-		Version: apiv1.GroupVersion.Version,
-		Kind:    apiv1.BackupKind,
-	})
+	backup.EnsureGVKIsPresent()
 
 	return &PluginBackupCommand{
 		Cluster:  cluster,

--- a/pkg/management/postgres/webserver/plugin_backup.go
+++ b/pkg/management/postgres/webserver/plugin_backup.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cloudnative-pg/machinery/pkg/log"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -43,8 +44,6 @@ type PluginBackupCommand struct {
 	Backup   *apiv1.Backup
 	Client   client.Client
 	Recorder record.EventRecorder
-	Log      log.Logger
-	Plugins  repository.Interface
 }
 
 // NewPluginBackupCommand initializes a BackupCommand object, taking a physical
@@ -55,23 +54,22 @@ func NewPluginBackupCommand(
 	client client.Client,
 	recorder record.EventRecorder,
 ) *PluginBackupCommand {
-	logger := log.WithValues(
-		"pluginConfiguration", backup.Spec.PluginConfiguration,
-		"backupName", backup.Name,
-		"backupNamespace", backup.Name)
-
-	plugins := repository.New()
-	if err := plugins.RegisterUnixSocketPluginsInPath(configuration.Current.PluginSocketDir); err != nil {
-		logger.Error(err, "Error while discovering plugins")
-	}
+	// This backup object may come from an informers, and
+	// informers do not put their metadata inside the object.
+	// Let's ensure the plugin has enough metadata to typecheck
+	// the object.
+	// For more info: https://github.com/kubernetes/client-go/issues/308
+	backup.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   apiv1.GroupVersion.Group,
+		Version: apiv1.GroupVersion.Version,
+		Kind:    apiv1.BackupKind,
+	})
 
 	return &PluginBackupCommand{
 		Cluster:  cluster,
 		Backup:   backup,
 		Client:   client,
 		Recorder: recorder,
-		Log:      logger,
-		Plugins:  plugins,
 	}
 }
 
@@ -80,31 +78,33 @@ func (b *PluginBackupCommand) Start(ctx context.Context) {
 	go b.invokeStart(ctx)
 }
 
-// Close closes all the connections to the plugins
-func (b *PluginBackupCommand) Close() {
-	b.Plugins.Close()
-}
-
 func (b *PluginBackupCommand) invokeStart(ctx context.Context) {
-	backupLog := b.Log.WithValues(
+	contextLogger := log.FromContext(ctx).WithValues(
+		"pluginConfiguration", b.Backup.Spec.PluginConfiguration,
 		"backupName", b.Backup.Name,
 		"backupNamespace", b.Backup.Name)
 
-	cli, err := pluginClient.WithPlugins(ctx, b.Plugins, b.Cluster.Spec.Plugins.GetEnabledPluginNames()...)
+	plugins := repository.New()
+	if err := plugins.RegisterUnixSocketPluginsInPath(configuration.Current.PluginSocketDir); err != nil {
+		contextLogger.Error(err, "Error while discovering plugins")
+	}
+	defer plugins.Close()
+
+	cli, err := pluginClient.WithPlugins(ctx, plugins, b.Cluster.Spec.Plugins.GetEnabledPluginNames()...)
 	if err != nil {
 		b.markBackupAsFailed(ctx, err)
 		return
 	}
 
 	// record the backup beginning
-	backupLog.Info("Plugin backup started")
+	contextLogger.Info("Plugin backup started")
 	b.Recorder.Event(b.Backup, "Normal", "Starting", "Backup started")
 
 	// Update backup status in cluster conditions on startup
 	if err := b.retryWithRefreshedCluster(ctx, func() error {
 		return conditions.Patch(ctx, b.Client, b.Cluster, apiv1.BackupStartingCondition)
 	}); err != nil {
-		backupLog.Error(err, "Error changing backup condition (backup started)")
+		contextLogger.Error(err, "Error changing backup condition (backup started)")
 		// We do not terminate here because we could still have a good backup
 		// even if we are unable to communicate with the Kubernetes API server
 	}
@@ -120,7 +120,7 @@ func (b *PluginBackupCommand) invokeStart(ctx context.Context) {
 		return
 	}
 
-	backupLog.Info("Backup completed")
+	contextLogger.Info("Backup completed")
 	b.Recorder.Event(b.Backup, "Normal", "Completed", "Backup completed")
 
 	// Set the status to completed
@@ -146,28 +146,30 @@ func (b *PluginBackupCommand) invokeStart(ctx context.Context) {
 	}
 
 	if err := postgres.PatchBackupStatusAndRetry(ctx, b.Client, b.Backup); err != nil {
-		backupLog.Error(err, "Can't set backup status as completed")
+		contextLogger.Error(err, "Can't set backup status as completed")
 	}
 
 	// Update backup status in cluster conditions on backup completion
 	if err := b.retryWithRefreshedCluster(ctx, func() error {
 		return conditions.Patch(ctx, b.Client, b.Cluster, apiv1.BackupSucceededCondition)
 	}); err != nil {
-		b.Log.Error(err, "Can't update the cluster with the completed backup data")
+		contextLogger.Error(err, "Can't update the cluster with the completed backup data")
 	}
 }
 
 func (b *PluginBackupCommand) markBackupAsFailed(ctx context.Context, failure error) {
+	contextLogger := log.FromContext(ctx)
+
 	backupStatus := b.Backup.GetStatus()
 
 	// record the failure
-	b.Log.Error(failure, "Backup failed")
+	contextLogger.Error(failure, "Backup failed")
 	b.Recorder.Event(b.Backup, "Normal", "Failed", "Backup failed")
 
 	// update backup status as failed
 	backupStatus.SetAsFailed(failure)
 	if err := postgres.PatchBackupStatusAndRetry(ctx, b.Client, b.Backup); err != nil {
-		b.Log.Error(err, "Can't mark backup as failed")
+		contextLogger.Error(err, "Can't mark backup as failed")
 		// We do not terminate here because we still want to set the condition on the cluster.
 	}
 
@@ -180,7 +182,7 @@ func (b *PluginBackupCommand) markBackupAsFailed(ctx context.Context, failure er
 		b.Cluster.Status.LastFailedBackup = utils.GetCurrentTimestampWithFormat(time.RFC3339)
 		return b.Client.Status().Patch(ctx, b.Cluster, client.MergeFrom(origCluster))
 	}); failErr != nil {
-		b.Log.Error(failErr, "while setting cluster condition for failed backup")
+		contextLogger.Error(failErr, "while setting cluster condition for failed backup")
 	}
 }
 


### PR DESCRIPTION
This patch keeps the plugin connection pool open when a backup is running. Before, it was closed as soon as the backup request was correctly received.

# Release notes

```
The plugin connection is always kept open when a plugin is executing a backup.
```