### PR TITLE
chore(tests): split backup tests into file per backend

### DIFF
--- a/hack/setup-cluster.sh
+++ b/hack/setup-cluster.sh
@@ -83,7 +83,7 @@ registry_name=registry.dev
 POSTGRES_IMG=${POSTGRES_IMG:-$(grep 'DefaultImageName.*=' "${ROOT_DIR}/pkg/versions/versions.go" | cut -f 2 -d \")}
 E2E_PRE_ROLLING_UPDATE_IMG=${E2E_PRE_ROLLING_UPDATE_IMG:-${POSTGRES_IMG%.*}}
 PGBOUNCER_IMG=${PGBOUNCER_IMG:-$(grep 'DefaultPgbouncerImage.*=' "${ROOT_DIR}/pkg/specs/pgbouncer/deployments.go" | cut -f 2 -d \")}
-MINIO_IMG=${MINIO_IMG:-$(grep 'minioImage.*=' "${ROOT_DIR}/tests/utils/minio.go"  | cut -f 2 -d \")}
+MINIO_IMG=${MINIO_IMG:-$(grep 'minioImage.*=' "${ROOT_DIR}/tests/utils/minio/minio.go"  | cut -f 2 -d \")}
 APACHE_IMG=${APACHE_IMG:-"httpd"}
 
 HELPER_IMGS=("$POSTGRES_IMG" "$E2E_PRE_ROLLING_UPDATE_IMG" "$PGBOUNCER_IMG" "$MINIO_IMG" "$APACHE_IMG")

--- a/tests/e2e/asserts_test.go
+++ b/tests/e2e/asserts_test.go
@@ -174,7 +174,8 @@ func AssertSwitchoverWithHistory(
 					}
 
 					numHistory := len(strings.Split(strings.TrimSpace(out), "\n"))
-					GinkgoWriter.Printf("count %d: pod: %s, the number of history file in pg_wal: %d\n", count, pod, numHistory)
+					GinkgoWriter.Printf("count %d: pod: %s, the number of history file in pg_wal: %d\n", count, pod,
+						numHistory)
 					count++
 					if numHistory > 0 {
 						continue
@@ -292,8 +293,11 @@ func AssertClusterIsReady(namespace string, clusterName string, timeout int, env
 	})
 }
 
-func AssertClusterDefault(namespace string, clusterName string,
-	isExpectedToDefault bool, env *testsUtils.TestingEnvironment,
+func AssertClusterDefault(
+	namespace string,
+	clusterName string,
+	isExpectedToDefault bool,
+	env *testsUtils.TestingEnvironment,
 ) {
 	By("having a Cluster object populated with default values", func() {
 		// Eventually the number of ready instances should be equal to the
@@ -335,8 +339,14 @@ func AssertWebhookEnabled(env *testsUtils.TestingEnvironment, mutating, validati
 }
 
 // Update the secrets and verify cluster reference the updated resource version of secrets
-func AssertUpdateSecret(field string, value string, secretName string, namespace string,
-	clusterName string, timeout int, env *testsUtils.TestingEnvironment,
+func AssertUpdateSecret(
+	field string,
+	value string,
+	secretName string,
+	namespace string,
+	clusterName string,
+	timeout int,
+	env *testsUtils.TestingEnvironment,
 ) {
 	var secret corev1.Secret
 	Eventually(func(g Gomega) {
@@ -377,8 +387,14 @@ func AssertUpdateSecret(field string, value string, secretName string, namespace
 
 // AssertConnection is used if a connection from a pod to a postgresql
 // database works
-func AssertConnection(host string, user string, dbname string,
-	password string, queryingPod *corev1.Pod, timeout int, env *testsUtils.TestingEnvironment,
+func AssertConnection(
+	host string,
+	user string,
+	dbname string,
+	password string,
+	queryingPod *corev1.Pod,
+	timeout int,
+	env *testsUtils.TestingEnvironment,
 ) {
 	By(fmt.Sprintf("connecting to the %v service as %v", host, user), func() {
 		Eventually(func() string {
@@ -793,7 +809,7 @@ func AssertArchiveWalOnMinio(namespace, clusterName string, serverName string) {
 	By(fmt.Sprintf("verify the existence of WAL %v in minio", latestWALPath), func() {
 		Eventually(func() (int, error) {
 			// WALs are compressed with gzip in the fixture
-			return minio.CountFilesOnMinio(minioEnv, latestWALPath)
+			return minio.CountFiles(minioEnv, latestWALPath)
 		}, testTimeouts[testsUtils.WalsInMinio]).Should(BeEquivalentTo(1))
 	})
 }
@@ -1381,9 +1397,11 @@ func AssertMetricsData(namespace, targetOne, targetTwo, targetSecret string, clu
 			podName := pod.GetName()
 			out, err := testsUtils.RetrieveMetricsFromInstance(env, pod, cluster.IsMetricsTLSEnabled())
 			Expect(err).ToNot(HaveOccurred())
-			Expect(strings.Contains(out, fmt.Sprintf(`cnpg_some_query_rows{datname="%v"} 0`, targetOne))).Should(BeTrue(),
+			Expect(strings.Contains(out,
+				fmt.Sprintf(`cnpg_some_query_rows{datname="%v"} 0`, targetOne))).Should(BeTrue(),
 				"Metric collection issues on %v.\nCollected metrics:\n%v", podName, out)
-			Expect(strings.Contains(out, fmt.Sprintf(`cnpg_some_query_rows{datname="%v"} 0`, targetTwo))).Should(BeTrue(),
+			Expect(strings.Contains(out,
+				fmt.Sprintf(`cnpg_some_query_rows{datname="%v"} 0`, targetTwo))).Should(BeTrue(),
 				"Metric collection issues on %v.\nCollected metrics:\n%v", podName, out)
 			Expect(strings.Contains(out, fmt.Sprintf(`cnpg_some_query_test_rows{datname="%v"} 1`,
 				targetSecret))).Should(BeTrue(),
@@ -1865,7 +1883,8 @@ func AssertClusterWasRestoredWithPITRAndApplicationDB(namespace, clusterName, ta
 	})
 
 	// Gather credentials
-	appUser, appUserPass, err := testsUtils.GetCredentials(clusterName, namespace, apiv1.ApplicationUserSecretSuffix, env)
+	appUser, appUserPass, err := testsUtils.GetCredentials(clusterName, namespace, apiv1.ApplicationUserSecretSuffix,
+		env)
 	Expect(err).ToNot(HaveOccurred())
 
 	primaryPod, err := env.GetClusterPrimary(namespace, clusterName)
@@ -2880,7 +2899,8 @@ func AssertClusterHAReplicationSlots(namespace, clusterName string) {
 		podList, err := env.GetClusterPodList(namespace, clusterName)
 		Expect(err).ToNot(HaveOccurred())
 		for _, pod := range podList.Items {
-			expectedSlots, err := testsUtils.GetExpectedHAReplicationSlotsOnPod(namespace, clusterName, pod.GetName(), env)
+			expectedSlots, err := testsUtils.GetExpectedHAReplicationSlotsOnPod(namespace, clusterName, pod.GetName(),
+				env)
 			Expect(err).ToNot(HaveOccurred())
 			AssertReplicationSlotsOnPod(namespace, clusterName, pod, expectedSlots, true, false)
 		}

--- a/tests/e2e/asserts_test.go
+++ b/tests/e2e/asserts_test.go
@@ -773,15 +773,6 @@ func AssertStorageCredentialsAreCreated(namespace string, name string, id string
 	}, 60, 5).Should(BeNil())
 }
 
-// minioPath gets the MinIO file string for WAL/backup objects in a configured bucket
-func minioPath(serverName, fileName string) string {
-	// the * regexes enable matching these typical paths:
-	// 	minio/backups/serverName/base/20220618T140300/data.tar
-	// 	minio/backups/serverName/wals/0000000100000000/000000010000000000000002.gz
-	//  minio/backups/serverName/wals/00000002.history.gz
-	return filepath.Join("*", serverName, "*", fileName)
-}
-
 // CheckPointAndSwitchWalOnPrimary trigger a checkpoint and switch wal on primary pod and returns the latest WAL file
 func CheckPointAndSwitchWalOnPrimary(namespace, clusterName string) string {
 	var latestWAL string
@@ -803,7 +794,7 @@ func AssertArchiveWalOnMinio(namespace, clusterName string, serverName string) {
 		Expect(err).ToNot(HaveOccurred())
 		primary := pod.GetName()
 		latestWAL := switchWalAndGetLatestArchive(namespace, primary)
-		latestWALPath = minioPath(serverName, latestWAL+".gz")
+		latestWALPath = minio.GetFilePath(serverName, latestWAL+".gz")
 	})
 
 	By(fmt.Sprintf("verify the existence of WAL %v in minio", latestWALPath), func() {

--- a/tests/e2e/backup_restore_azure_test.go
+++ b/tests/e2e/backup_restore_azure_test.go
@@ -66,12 +66,14 @@ var _ = Describe("Azure - Backup and restore", Label(tests.LabelBackupRestore), 
 			// The credentials are retrieved from the environment variables, as we can't create
 			// a fixture for them
 			By("creating the Azure Blob Storage credentials", func() {
-				AssertStorageCredentialsAreCreated(
+				_, err = testUtils.CreateObjectStorageSecret(
 					namespace,
 					"backup-storage-creds",
 					env.AzureConfiguration.StorageAccount,
 					env.AzureConfiguration.StorageKey,
+					env,
 				)
+				Expect(err).ToNot(HaveOccurred())
 			})
 
 			// Create the cluster
@@ -231,8 +233,13 @@ var _ = Describe("Azure - Clusters Recovery From Barman Object Store", Label(tes
 				// The credentials are retrieved from the environment variables, as we can't create
 				// a fixture for them
 				By("creating the Azure Blob Storage credentials", func() {
-					AssertStorageCredentialsAreCreated(namespace, "backup-storage-creds",
-						env.AzureConfiguration.StorageAccount, env.AzureConfiguration.StorageKey)
+					_, err = testUtils.CreateObjectStorageSecret(
+						namespace,
+						"backup-storage-creds",
+						env.AzureConfiguration.StorageAccount,
+						env.AzureConfiguration.StorageKey,
+						env)
+					Expect(err).ToNot(HaveOccurred())
 				})
 
 				// Create the cluster
@@ -323,8 +330,13 @@ var _ = Describe("Azure - Clusters Recovery From Barman Object Store", Label(tes
 				// we get the credentials from the environment variables as we can't create
 				// a fixture for them
 				By("creating the Azure Blob Container SAS Token credentials", func() {
-					AssertCreateSASTokenCredentials(namespace, env.AzureConfiguration.StorageAccount,
-						env.AzureConfiguration.StorageKey)
+					err = testUtils.CreateSASTokenCredentials(
+						namespace,
+						env.AzureConfiguration.StorageAccount,
+						env.AzureConfiguration.StorageKey,
+						env,
+					)
+					Expect(err).ToNot(HaveOccurred())
 				})
 
 				// Create the Cluster

--- a/tests/e2e/backup_restore_azure_test.go
+++ b/tests/e2e/backup_restore_azure_test.go
@@ -1,0 +1,380 @@
+/*
+Copyright The CloudNativePG Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"github.com/cloudnative-pg/cloudnative-pg/tests"
+	testUtils "github.com/cloudnative-pg/cloudnative-pg/tests/utils"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Azure - Backup and restore", Label(tests.LabelBackupRestore), func() {
+	const (
+		tableName = "to_restore"
+	)
+
+	BeforeEach(func() {
+		if testLevelEnv.Depth < int(tests.High) {
+			Skip("Test depth is lower than the amount requested for this test")
+		}
+		if !IsAKS() {
+			Skip("This test is only run on AKS clusters")
+		}
+	})
+
+	Context("using azure blobs as object storage with storage account access authentication", Ordered, func() {
+		// We must be careful here. All the clusters use the same remote storage
+		// and that means that we must use different cluster names otherwise
+		// we risk mixing WALs and backups
+		const azureBlobSampleFile = fixturesDir + "/backup/azure_blob/cluster-with-backup-azure-blob.yaml.template"
+		const clusterRestoreSampleFile = fixturesDir + "/backup/azure_blob/cluster-from-restore.yaml.template"
+		const scheduledBackupSampleFile = fixturesDir +
+			"/backup/scheduled_backup_immediate/scheduled-backup-immediate-azure-blob.yaml"
+		backupFile := fixturesDir + "/backup/azure_blob/backup-azure-blob.yaml"
+		var namespace, clusterName string
+
+		BeforeAll(func() {
+			const namespacePrefix = "cluster-backup-azure-blob"
+			var err error
+			clusterName, err = env.GetResourceNameFromYAML(azureBlobSampleFile)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Create a cluster in a namespace we'll delete after the test
+			namespace, err = env.CreateUniqueTestNamespace(namespacePrefix)
+			Expect(err).ToNot(HaveOccurred())
+
+			// The Azure Blob Storage should have been created ad-hoc for the tests.
+			// The credentials are retrieved from the environment variables, as we can't create
+			// a fixture for them
+			By("creating the Azure Blob Storage credentials", func() {
+				AssertStorageCredentialsAreCreated(
+					namespace,
+					"backup-storage-creds",
+					env.AzureConfiguration.StorageAccount,
+					env.AzureConfiguration.StorageKey,
+				)
+			})
+
+			// Create the cluster
+			AssertCreateCluster(namespace, clusterName, azureBlobSampleFile, env)
+		})
+
+		// We back up and restore a cluster, and verify some expected data to
+		// be there
+		It("backs up and restore a cluster", func() {
+			// Write a table and some data on the "app" database
+			AssertCreateTestData(env, namespace, clusterName, tableName)
+			AssertArchiveWalOnAzureBlob(namespace, clusterName, env.AzureConfiguration)
+			By("uploading a backup", func() {
+				// We create a backup
+				testUtils.ExecuteBackup(namespace, backupFile, false, testTimeouts[testUtils.BackupIsReady], env)
+				testUtils.AssertBackupConditionInClusterStatus(env, namespace, clusterName)
+
+				// Verifying file called data.tar should be available on Azure blob storage
+				Eventually(func() (int, error) {
+					return testUtils.CountFilesOnAzureBlobStorage(env.AzureConfiguration, clusterName, "data.tar")
+				}, 30).Should(BeNumerically(">=", 1))
+				Eventually(func() (string, error) {
+					cluster, err := env.GetCluster(namespace, clusterName)
+					return cluster.Status.FirstRecoverabilityPoint, err
+				}, 30).ShouldNot(BeEmpty())
+			})
+
+			// Restore backup in a new cluster
+			AssertClusterRestore(namespace, clusterRestoreSampleFile, tableName)
+
+			By("deleting the restored cluster", func() {
+				err := DeleteResourcesFromFile(namespace, clusterRestoreSampleFile)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		// Create a scheduled backup with the 'immediate' option enabled. We expect the backup to be available
+		It("immediately starts a backup using ScheduledBackups 'immediate' option", func() {
+			scheduledBackupName, err := env.GetResourceNameFromYAML(scheduledBackupSampleFile)
+			Expect(err).ToNot(HaveOccurred())
+
+			AssertScheduledBackupsImmediate(namespace, scheduledBackupSampleFile, scheduledBackupName)
+
+			// Only one data.tar files should be present
+			Eventually(func() (int, error) {
+				return testUtils.CountFilesOnAzureBlobStorage(env.AzureConfiguration,
+					clusterName, "data.tar")
+			}, 30).Should(BeNumerically("==", 2))
+		})
+
+		It("backs up and restore a cluster with PITR", func() {
+			restoredClusterName := "restore-cluster-azure-pitr"
+			currentTimestamp := new(string)
+
+			prepareClusterForPITROnAzureBlob(
+				namespace,
+				clusterName,
+				backupFile,
+				env.AzureConfiguration,
+				2,
+				currentTimestamp,
+			)
+
+			AssertArchiveWalOnAzureBlob(namespace, clusterName, env.AzureConfiguration)
+
+			cluster, err := testUtils.CreateClusterFromBackupUsingPITR(
+				namespace,
+				restoredClusterName,
+				backupFile,
+				*currentTimestamp,
+				env,
+			)
+			Expect(err).ToNot(HaveOccurred())
+			AssertClusterIsReady(namespace, restoredClusterName, testTimeouts[testUtils.ClusterIsReady], env)
+
+			// Restore backup in a new cluster, also cover if no application database is configured
+			AssertClusterWasRestoredWithPITR(namespace, restoredClusterName, tableName, "00000002")
+			By("deleting the restored cluster", func() {
+				Expect(testUtils.DeleteObject(env, cluster)).To(Succeed())
+			})
+		})
+
+		// We create a cluster, create a scheduled backup, patch it to suspend its
+		// execution. We verify that the number of backups does not increase.
+		// We then patch it again back to its initial state and verify that
+		// the amount of backups keeps increasing again
+		It("verifies that scheduled backups can be suspended", func() {
+			const scheduledBackupSampleFile = fixturesDir +
+				"/backup/scheduled_backup_suspend/scheduled-backup-suspend-azure-blob.yaml"
+			scheduledBackupName, err := env.GetResourceNameFromYAML(scheduledBackupSampleFile)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("scheduling backups", func() {
+				AssertScheduledBackupsAreScheduled(namespace, scheduledBackupSampleFile, 480)
+
+				// AssertScheduledBackupsImmediate creates at least two backups, we should find
+				// their base backups
+				Eventually(func() (int, error) {
+					return testUtils.CountFilesOnAzureBlobStorage(env.AzureConfiguration,
+						clusterName, "data.tar")
+				}, 60).Should(BeNumerically(">=", 2))
+			})
+			AssertSuspendScheduleBackups(namespace, scheduledBackupName)
+		})
+	})
+})
+
+var _ = Describe("Azure - Clusters Recovery From Barman Object Store", Label(tests.LabelBackupRestore), func() {
+	const (
+		fixturesBackupDir            = fixturesDir + "/backup/recovery_external_clusters/"
+		sourceBackupFileAzure        = fixturesBackupDir + "backup-azure-blob-02.yaml"
+		clusterSourceFileAzure       = fixturesBackupDir + "source-cluster-azure-blob-01.yaml.template"
+		externalClusterFileAzure     = fixturesBackupDir + "external-clusters-azure-blob-03.yaml.template"
+		sourceBackupFileAzurePITR    = fixturesBackupDir + "backup-azure-blob-pitr.yaml"
+		tableName                    = "to_restore"
+		clusterSourceFileAzureSAS    = fixturesBackupDir + "cluster-with-backup-azure-blob-sas.yaml.template"
+		clusterRestoreFileAzureSAS   = fixturesBackupDir + "cluster-from-restore-sas.yaml.template"
+		sourceBackupFileAzureSAS     = fixturesBackupDir + "backup-azure-blob-sas.yaml"
+		sourceBackupFileAzurePITRSAS = fixturesBackupDir + "backup-azure-blob-pitr-sas.yaml"
+		level                        = tests.High
+	)
+
+	currentTimestamp := new(string)
+
+	BeforeEach(func() {
+		if testLevelEnv.Depth < int(level) {
+			Skip("Test depth is lower than the amount requested for this test")
+		}
+		if !IsAKS() {
+			Skip("This test is only executed on AKS clusters")
+		}
+	})
+
+	// Restore cluster using a recovery object store, that is a backup of another cluster,
+	// created by Barman Cloud, and defined via the barmanObjectStore option in the externalClusters section
+
+	Context("using azure blobs as object storage", func() {
+		Context("storage account access authentication", Ordered, func() {
+			var namespace, clusterName string
+			BeforeAll(func() {
+				const namespacePrefix = "recovery-barman-object-azure"
+				var err error
+				clusterName, err = env.GetResourceNameFromYAML(clusterSourceFileAzure)
+				Expect(err).ToNot(HaveOccurred())
+
+				// Create a cluster in a namespace we'll delete after the test
+				namespace, err = env.CreateUniqueTestNamespace(namespacePrefix)
+				Expect(err).ToNot(HaveOccurred())
+
+				// The Azure Blob Storage should have been created ad-hoc for the tests.
+				// The credentials are retrieved from the environment variables, as we can't create
+				// a fixture for them
+				By("creating the Azure Blob Storage credentials", func() {
+					AssertStorageCredentialsAreCreated(namespace, "backup-storage-creds",
+						env.AzureConfiguration.StorageAccount, env.AzureConfiguration.StorageKey)
+				})
+
+				// Create the cluster
+				AssertCreateCluster(namespace, clusterName, clusterSourceFileAzure, env)
+			})
+
+			It("restores a cluster from barman object using 'barmanObjectStore' option in 'externalClusters' section", func() {
+				// Write a table and some data on the "app" database
+				AssertCreateTestData(env, namespace, clusterName, tableName)
+				AssertArchiveWalOnAzureBlob(namespace, clusterName, env.AzureConfiguration)
+
+				By("backing up a cluster and verifying it exists on azure blob storage", func() {
+					// Create the backup
+					testUtils.ExecuteBackup(namespace, sourceBackupFileAzure, false, testTimeouts[testUtils.BackupIsReady], env)
+					testUtils.AssertBackupConditionInClusterStatus(env, namespace, clusterName)
+					// Verifying file called data.tar should be available on Azure blob storage
+					Eventually(func() (int, error) {
+						return testUtils.CountFilesOnAzureBlobStorage(env.AzureConfiguration, clusterName, "data.tar")
+					}, 30).Should(BeNumerically(">=", 1))
+				})
+
+				// Restoring cluster using a recovery barman object store, which is defined
+				// in the externalClusters section
+				AssertClusterRestore(namespace, externalClusterFileAzure, tableName)
+			})
+
+			It("restores a cluster with 'PITR' from barman object using "+
+				"'barmanObjectStore' option in 'externalClusters' section", func() {
+				externalClusterName := "external-cluster-azure-pitr"
+
+				prepareClusterForPITROnAzureBlob(
+					namespace,
+					clusterName,
+					sourceBackupFileAzurePITR,
+					env.AzureConfiguration,
+					1,
+					currentTimestamp,
+				)
+
+				restoredCluster, err := testUtils.CreateClusterFromExternalClusterBackupWithPITROnAzure(
+					namespace,
+					externalClusterName,
+					clusterName,
+					*currentTimestamp,
+					"backup-storage-creds",
+					env.AzureConfiguration.StorageAccount,
+					env.AzureConfiguration.BlobContainer,
+					env)
+				Expect(err).ToNot(HaveOccurred())
+
+				// Restoring cluster using a recovery barman object store, which is defined
+				// in the externalClusters section
+				AssertClusterWasRestoredWithPITRAndApplicationDB(
+					namespace,
+					externalClusterName,
+					tableName,
+					"00000002",
+				)
+
+				By("delete restored cluster", func() {
+					Expect(testUtils.DeleteObject(env, restoredCluster)).To(Succeed())
+				})
+			})
+		})
+
+		Context("storage account SAS Token authentication", Ordered, func() {
+			var namespace, clusterName string
+			BeforeAll(func() {
+				if !IsAKS() {
+					Skip("This test is only executed on AKS clusters")
+				}
+				const namespacePrefix = "cluster-backup-azure-blob-sas"
+				var err error
+				clusterName, err = env.GetResourceNameFromYAML(clusterSourceFileAzureSAS)
+				Expect(err).ToNot(HaveOccurred())
+
+				// Create a cluster in a namespace we'll delete after the test
+				namespace, err = env.CreateUniqueTestNamespace(namespacePrefix)
+				Expect(err).ToNot(HaveOccurred())
+
+				// The Azure Blob Storage should have been created ad-hoc for the tests,
+				// we get the credentials from the environment variables as we can't create
+				// a fixture for them
+				By("creating the Azure Blob Container SAS Token credentials", func() {
+					AssertCreateSASTokenCredentials(namespace, env.AzureConfiguration.StorageAccount,
+						env.AzureConfiguration.StorageKey)
+				})
+
+				// Create the Cluster
+				AssertCreateCluster(namespace, clusterName, clusterSourceFileAzureSAS, env)
+			})
+
+			It("restores cluster from barman object using 'barmanObjectStore' option in 'externalClusters' section", func() {
+				// Write a table and some data on the "app" database
+				AssertCreateTestData(env, namespace, clusterName, tableName)
+
+				// Create a WAL on the primary and check if it arrives in the
+				// Azure Blob Storage within a short time
+				AssertArchiveWalOnAzureBlob(namespace, clusterName, env.AzureConfiguration)
+
+				By("backing up a cluster and verifying it exists on azure blob storage", func() {
+					// We create a Backup
+					testUtils.ExecuteBackup(namespace, sourceBackupFileAzureSAS, false, testTimeouts[testUtils.BackupIsReady], env)
+					testUtils.AssertBackupConditionInClusterStatus(env, namespace, clusterName)
+					// Verifying file called data.tar should be available on Azure blob storage
+					Eventually(func() (int, error) {
+						return testUtils.CountFilesOnAzureBlobStorage(env.AzureConfiguration, clusterName, "data.tar")
+					}, 30).Should(BeNumerically(">=", 1))
+				})
+
+				// Restore backup in a new cluster
+				AssertClusterRestoreWithApplicationDB(namespace, clusterRestoreFileAzureSAS, tableName)
+			})
+
+			It("restores a cluster with 'PITR' from barman object using "+
+				"'barmanObjectStore' option in 'externalClusters' section", func() {
+				externalClusterName := "external-cluster-azure-pitr"
+
+				prepareClusterForPITROnAzureBlob(
+					namespace,
+					clusterName,
+					sourceBackupFileAzurePITRSAS,
+					env.AzureConfiguration,
+					1,
+					currentTimestamp,
+				)
+
+				restoredCluster, err := testUtils.CreateClusterFromExternalClusterBackupWithPITROnAzure(
+					namespace,
+					externalClusterName,
+					clusterName,
+					*currentTimestamp,
+					"backup-storage-creds-sas",
+					env.AzureConfiguration.StorageAccount,
+					env.AzureConfiguration.BlobContainer,
+					env)
+				Expect(err).ToNot(HaveOccurred())
+
+				// Restoring cluster using a recovery barman object store, which is defined
+				// in the externalClusters section
+				AssertClusterWasRestoredWithPITRAndApplicationDB(
+					namespace,
+					externalClusterName,
+					tableName,
+					"00000002",
+				)
+
+				By("delete restored cluster", func() {
+					Expect(testUtils.DeleteObject(env, restoredCluster)).To(Succeed())
+				})
+			})
+		})
+	})
+})

--- a/tests/e2e/backup_restore_azure_test.go
+++ b/tests/e2e/backup_restore_azure_test.go
@@ -79,7 +79,13 @@ var _ = Describe("Azure - Backup and restore", Label(tests.LabelBackupRestore), 
 		// be there
 		It("backs up and restore a cluster", func() {
 			// Write a table and some data on the "app" database
-			AssertCreateTestData(env, namespace, clusterName, tableName)
+			tableLocator := TableLocator{
+				Namespace:    namespace,
+				ClusterName:  clusterName,
+				DatabaseName: testUtils.AppDBName,
+				TableName:    tableName,
+			}
+			AssertCreateTestData(env, tableLocator)
 			AssertArchiveWalOnAzureBlob(namespace, clusterName, env.AzureConfiguration)
 			By("uploading a backup", func() {
 				// We create a backup
@@ -232,7 +238,13 @@ var _ = Describe("Azure - Clusters Recovery From Barman Object Store", Label(tes
 
 			It("restores a cluster from barman object using 'barmanObjectStore' option in 'externalClusters' section", func() {
 				// Write a table and some data on the "app" database
-				AssertCreateTestData(env, namespace, clusterName, tableName)
+				tableLocator := TableLocator{
+					Namespace:    namespace,
+					ClusterName:  clusterName,
+					DatabaseName: testUtils.AppDBName,
+					TableName:    tableName,
+				}
+				AssertCreateTestData(env, tableLocator)
 				AssertArchiveWalOnAzureBlob(namespace, clusterName, env.AzureConfiguration)
 
 				By("backing up a cluster and verifying it exists on azure blob storage", func() {
@@ -318,7 +330,13 @@ var _ = Describe("Azure - Clusters Recovery From Barman Object Store", Label(tes
 
 			It("restores cluster from barman object using 'barmanObjectStore' option in 'externalClusters' section", func() {
 				// Write a table and some data on the "app" database
-				AssertCreateTestData(env, namespace, clusterName, tableName)
+				tableLocator := TableLocator{
+					Namespace:    namespace,
+					ClusterName:  clusterName,
+					DatabaseName: testUtils.AppDBName,
+					TableName:    tableName,
+				}
+				AssertCreateTestData(env, tableLocator)
 
 				// Create a WAL on the primary and check if it arrives in the
 				// Azure Blob Storage within a short time

--- a/tests/e2e/backup_restore_azurite_test.go
+++ b/tests/e2e/backup_restore_azurite_test.go
@@ -1,0 +1,341 @@
+/*
+Copyright The CloudNativePG Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+
+	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	"github.com/cloudnative-pg/cloudnative-pg/tests"
+	testUtils "github.com/cloudnative-pg/cloudnative-pg/tests/utils"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Azurite - Backup and restore", Label(tests.LabelBackupRestore), func() {
+	const (
+		tableName             = "to_restore"
+		azuriteBlobSampleFile = fixturesDir + "/backup/azurite/cluster-backup.yaml.template"
+	)
+	BeforeEach(func() {
+		if testLevelEnv.Depth < int(tests.High) {
+			Skip("Test depth is lower than the amount requested for this test")
+		}
+
+		if !(IsLocal() || IsGKE() || IsOpenshift()) {
+			Skip("This test is only executed on gke, openshift and local")
+		}
+	})
+
+	Context("using Azurite blobs as object storage", Ordered, func() {
+		// This is a set of tests using an Azurite server deployed in the same
+		// namespace as the cluster. Since each cluster is installed in its
+		// own namespace, they can share the configuration file
+		const (
+			clusterRestoreSampleFile  = fixturesDir + "/backup/azurite/cluster-from-restore.yaml.template"
+			scheduledBackupSampleFile = fixturesDir +
+				"/backup/scheduled_backup_suspend/scheduled-backup-suspend-azurite.yaml"
+			scheduledBackupImmediateSampleFile = fixturesDir +
+				"/backup/scheduled_backup_immediate/scheduled-backup-immediate-azurite.yaml"
+			backupFile        = fixturesDir + "/backup/azurite/backup.yaml"
+			azuriteCaSecName  = "azurite-ca-secret"
+			azuriteTLSSecName = "azurite-tls-secret"
+		)
+		var namespace, clusterName string
+
+		BeforeAll(func() {
+			const namespacePrefix = "cluster-backup-azurite"
+			var err error
+			clusterName, err = env.GetResourceNameFromYAML(azuriteBlobSampleFile)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Create a cluster in a namespace we'll delete after the test
+			namespace, err = env.CreateUniqueTestNamespace(namespacePrefix)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Create and assert ca and tls certificate secrets on Azurite
+			By("creating ca and tls certificate secrets", func() {
+				err := testUtils.CreateCertificateSecretsOnAzurite(namespace, clusterName,
+					azuriteCaSecName, azuriteTLSSecName, env)
+				Expect(err).ToNot(HaveOccurred())
+			})
+			// Setup Azurite and az cli along with Postgresql cluster
+			prepareClusterBackupOnAzurite(namespace, clusterName, azuriteBlobSampleFile, backupFile, tableName)
+		})
+
+		It("restores a backed up cluster", func() {
+			// Restore backup in a new cluster
+			AssertClusterRestoreWithApplicationDB(namespace, clusterRestoreSampleFile, tableName)
+		})
+
+		// Create a scheduled backup with the 'immediate' option enabled.
+		// We expect the backup to be available
+		It("immediately starts a backup using ScheduledBackups immediate option", func() {
+			scheduledBackupName, err := env.GetResourceNameFromYAML(scheduledBackupImmediateSampleFile)
+			Expect(err).ToNot(HaveOccurred())
+
+			AssertScheduledBackupsImmediate(namespace, scheduledBackupImmediateSampleFile, scheduledBackupName)
+
+			// AssertScheduledBackupsImmediate creates at least two backups, we should find
+			// their base backups
+			Eventually(func() (int, error) {
+				return testUtils.CountFilesOnAzuriteBlobStorage(namespace, clusterName, "data.tar")
+			}, 30).Should(BeNumerically("==", 2))
+		})
+
+		It("backs up and restore a cluster with PITR Azurite", func() {
+			const (
+				restoredClusterName = "restore-cluster-pitr-azurite"
+				backupFilePITR      = fixturesDir + "/backup/azurite/backup-pitr.yaml"
+			)
+			currentTimestamp := new(string)
+
+			prepareClusterForPITROnAzurite(namespace, clusterName, backupFilePITR, currentTimestamp)
+
+			cluster, err := testUtils.CreateClusterFromBackupUsingPITR(
+				namespace,
+				restoredClusterName,
+				backupFilePITR,
+				*currentTimestamp,
+				env,
+			)
+			Expect(err).NotTo(HaveOccurred())
+			AssertClusterIsReady(namespace, restoredClusterName, testTimeouts[testUtils.ClusterIsReady], env)
+
+			// Restore backup in a new cluster, also cover if no application database is configured
+			AssertClusterWasRestoredWithPITR(namespace, restoredClusterName, tableName, "00000002")
+
+			By("deleting the restored cluster", func() {
+				Expect(testUtils.DeleteObject(env, cluster)).To(Succeed())
+			})
+		})
+
+		// We create a cluster, create a scheduled backup, patch it to suspend its
+		// execution. We verify that the number of backups does not increase.
+		// We then patch it again back to its initial state and verify that
+		// the amount of backups keeps increasing again
+		It("verifies that scheduled backups can be suspended", func() {
+			scheduledBackupName, err := env.GetResourceNameFromYAML(scheduledBackupSampleFile)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("scheduling backups", func() {
+				AssertScheduledBackupsAreScheduled(namespace, scheduledBackupSampleFile, 300)
+				Eventually(func() (int, error) {
+					return testUtils.CountFilesOnAzuriteBlobStorage(namespace, clusterName, "data.tar")
+				}, 60).Should(BeNumerically(">=", 3))
+			})
+
+			AssertSuspendScheduleBackups(namespace, scheduledBackupName)
+		})
+	})
+})
+
+var _ = Describe("Clusters Recovery From Barman Object Store", Label(tests.LabelBackupRestore), func() {
+	const (
+		fixturesBackupDir          = fixturesDir + "/backup/recovery_external_clusters/"
+		azuriteBlobSampleFile      = fixturesDir + "/backup/azurite/cluster-backup.yaml.template"
+		backupFileAzurite          = fixturesBackupDir + "backup-azurite-02.yaml"
+		externalClusterFileAzurite = fixturesBackupDir + "external-clusters-azurite-03.yaml.template"
+
+		azuriteCaSecName  = "azurite-ca-secret"
+		azuriteTLSSecName = "azurite-tls-secret"
+		tableName         = "to_restore"
+	)
+	Context("using Azurite blobs as object storage", Ordered, func() {
+		var namespace, clusterName string
+		BeforeAll(func() {
+			if IsAKS() {
+				Skip("This test is not run on AKS")
+			}
+			const namespacePrefix = "recovery-barman-object-azurite"
+			var err error
+			clusterName, err = env.GetResourceNameFromYAML(azuriteBlobSampleFile)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Create a cluster in a namespace we'll delete after the test
+			namespace, err = env.CreateUniqueTestNamespace(namespacePrefix)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Create and assert ca and tls certificate secrets on Azurite
+			By("creating ca and tls certificate secrets", func() {
+				err := testUtils.CreateCertificateSecretsOnAzurite(
+					namespace,
+					clusterName,
+					azuriteCaSecName,
+					azuriteTLSSecName,
+					env)
+				Expect(err).ToNot(HaveOccurred())
+			})
+			// Setup Azurite and az cli along with PostgreSQL cluster
+			prepareClusterBackupOnAzurite(
+				namespace,
+				clusterName,
+				azuriteBlobSampleFile,
+				backupFileAzurite,
+				tableName,
+			)
+		})
+
+		It("restore cluster from barman object using 'barmanObjectStore' option in 'externalClusters' section", func() {
+			// Restore backup in a new cluster
+			AssertClusterRestoreWithApplicationDB(namespace, externalClusterFileAzurite, tableName)
+		})
+
+		It("restores a cluster with 'PITR' from barman object using 'barmanObjectStore' "+
+			" option in 'externalClusters' section", func() {
+			const (
+				externalClusterRestoreName = "restore-external-cluster-pitr"
+				backupFileAzuritePITR      = fixturesBackupDir + "backup-azurite-pitr.yaml"
+			)
+			currentTimestamp := new(string)
+			prepareClusterForPITROnAzurite(namespace, clusterName, backupFileAzuritePITR, currentTimestamp)
+
+			//  Create a cluster from a particular time using external backup.
+			restoredCluster, err := testUtils.CreateClusterFromExternalClusterBackupWithPITROnAzurite(
+				namespace, externalClusterRestoreName, clusterName, *currentTimestamp, env)
+			Expect(err).NotTo(HaveOccurred())
+
+			AssertClusterWasRestoredWithPITRAndApplicationDB(
+				namespace,
+				externalClusterRestoreName,
+				tableName,
+				"00000002",
+			)
+
+			By("delete restored cluster", func() {
+				Expect(testUtils.DeleteObject(env, restoredCluster)).To(Succeed())
+			})
+		})
+	})
+})
+
+func prepareClusterOnAzurite(namespace, clusterName, clusterSampleFile string) {
+	By("creating the Azurite storage credentials", func() {
+		err := testUtils.CreateStorageCredentialsOnAzurite(namespace, env)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	By("setting up Azurite to hold the backups", func() {
+		// Deploying azurite for blob storage
+		err := testUtils.InstallAzurite(namespace, env)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	By("setting up az-cli", func() {
+		// This is required as we have a service of Azurite running locally.
+		// In order to connect, we need az cli inside the namespace
+		err := testUtils.InstallAzCli(namespace, env)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	// Creating cluster
+	AssertCreateCluster(namespace, clusterName, clusterSampleFile, env)
+
+	AssertArchiveConditionMet(namespace, clusterName, "5m")
+}
+
+func prepareClusterBackupOnAzurite(
+	namespace,
+	clusterName,
+	clusterSampleFile,
+	backupFile,
+	tableName string,
+) {
+	// Setting up Azurite and az cli along with Postgresql cluster
+	prepareClusterOnAzurite(namespace, clusterName, clusterSampleFile)
+	// Write a table and some data on the "app" database
+	AssertCreateTestData(env, namespace, clusterName, tableName)
+	AssertArchiveWalOnAzurite(namespace, clusterName)
+
+	By("backing up a cluster and verifying it exists on azurite", func() {
+		// We create a Backup
+		testUtils.ExecuteBackup(namespace, backupFile, false, testTimeouts[testUtils.BackupIsReady], env)
+		// Verifying file called data.tar should be available on Azurite blob storage
+		Eventually(func() (int, error) {
+			return testUtils.CountFilesOnAzuriteBlobStorage(namespace, clusterName, "data.tar")
+		}, 30).Should(BeNumerically(">=", 1))
+		Eventually(func() (string, error) {
+			cluster, err := env.GetCluster(namespace, clusterName)
+			Expect(err).ToNot(HaveOccurred())
+			return cluster.Status.FirstRecoverabilityPoint, err
+		}, 30).ShouldNot(BeEmpty())
+	})
+	testUtils.AssertBackupConditionInClusterStatus(env, namespace, clusterName)
+}
+
+func prepareClusterForPITROnAzurite(
+	namespace,
+	clusterName,
+	backupSampleFile string,
+	currentTimestamp *string,
+) {
+	By("backing up a cluster and verifying it exists on azurite", func() {
+		// We create a Backup
+		testUtils.ExecuteBackup(namespace, backupSampleFile, false, testTimeouts[testUtils.BackupIsReady], env)
+		// Verifying file called data.tar should be available on Azurite blob storage
+		Eventually(func() (int, error) {
+			return testUtils.CountFilesOnAzuriteBlobStorage(namespace, clusterName, "data.tar")
+		}, 30).Should(BeNumerically(">=", 1))
+		Eventually(func() (string, error) {
+			cluster, err := env.GetCluster(namespace, clusterName)
+			Expect(err).ToNot(HaveOccurred())
+			return cluster.Status.FirstRecoverabilityPoint, err
+		}, 30).ShouldNot(BeEmpty())
+	})
+
+	// Write a table and insert 2 entries on the "app" database
+	AssertCreateTestData(env, namespace, clusterName, "for_restore")
+
+	By("getting currentTimestamp", func() {
+		ts, err := testUtils.GetCurrentTimestamp(namespace, clusterName, env)
+		*currentTimestamp = ts
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	By(fmt.Sprintf("writing 3rd entry into test table '%v'", "for_restore"), func() {
+		forward, conn, err := testUtils.ForwardPSQLConnection(
+			env,
+			namespace,
+			clusterName,
+			testUtils.AppDBName,
+			apiv1.ApplicationUserSecretSuffix,
+		)
+		defer func() {
+			forward.Close()
+		}()
+		Expect(err).ToNot(HaveOccurred())
+		insertRecordIntoTable("for_restore", 3, conn)
+	})
+	AssertArchiveWalOnAzurite(namespace, clusterName)
+}
+
+func AssertArchiveWalOnAzurite(namespace, clusterName string) {
+	// Create a WAL on the primary and check if it arrives at the Azure Blob Storage within a short time
+	By("archiving WALs and verifying they exist", func() {
+		primary := clusterName + "-1"
+		latestWAL := switchWalAndGetLatestArchive(namespace, primary)
+		// verifying on blob storage using az
+		// Define what file we are looking for in Azurite.
+		// Escapes are required since az expects forward slashes to be escaped
+		path := fmt.Sprintf("%v\\/wals\\/0000000100000000\\/%v.gz", clusterName, latestWAL)
+		// verifying on blob storage using az
+		Eventually(func() (int, error) {
+			return testUtils.CountFilesOnAzuriteBlobStorage(namespace, clusterName, path)
+		}, 60).Should(BeEquivalentTo(1))
+	})
+}

--- a/tests/e2e/backup_restore_azurite_test.go
+++ b/tests/e2e/backup_restore_azurite_test.go
@@ -259,7 +259,13 @@ func prepareClusterBackupOnAzurite(
 	// Setting up Azurite and az cli along with Postgresql cluster
 	prepareClusterOnAzurite(namespace, clusterName, clusterSampleFile)
 	// Write a table and some data on the "app" database
-	AssertCreateTestData(env, namespace, clusterName, tableName)
+	tableLocator := TableLocator{
+		Namespace:    namespace,
+		ClusterName:  clusterName,
+		DatabaseName: testUtils.AppDBName,
+		TableName:    tableName,
+	}
+	AssertCreateTestData(env, tableLocator)
 	AssertArchiveWalOnAzurite(namespace, clusterName)
 
 	By("backing up a cluster and verifying it exists on azurite", func() {
@@ -299,7 +305,13 @@ func prepareClusterForPITROnAzurite(
 	})
 
 	// Write a table and insert 2 entries on the "app" database
-	AssertCreateTestData(env, namespace, clusterName, "for_restore")
+	tableLocator := TableLocator{
+		Namespace:    namespace,
+		ClusterName:  clusterName,
+		DatabaseName: testUtils.AppDBName,
+		TableName:    "for_restore",
+	}
+	AssertCreateTestData(env, tableLocator)
 
 	By("getting currentTimestamp", func() {
 		ts, err := testUtils.GetCurrentTimestamp(namespace, clusterName, env)

--- a/tests/e2e/backup_restore_azurite_test.go
+++ b/tests/e2e/backup_restore_azurite_test.go
@@ -266,7 +266,7 @@ func prepareClusterBackupOnAzurite(
 		TableName:    tableName,
 	}
 	AssertCreateTestData(env, tableLocator)
-	AssertArchiveWalOnAzurite(namespace, clusterName)
+	assertArchiveWalOnAzurite(namespace, clusterName)
 
 	By("backing up a cluster and verifying it exists on azurite", func() {
 		// We create a Backup
@@ -333,10 +333,10 @@ func prepareClusterForPITROnAzurite(
 		Expect(err).ToNot(HaveOccurred())
 		insertRecordIntoTable("for_restore", 3, conn)
 	})
-	AssertArchiveWalOnAzurite(namespace, clusterName)
+	assertArchiveWalOnAzurite(namespace, clusterName)
 }
 
-func AssertArchiveWalOnAzurite(namespace, clusterName string) {
+func assertArchiveWalOnAzurite(namespace, clusterName string) {
 	// Create a WAL on the primary and check if it arrives at the Azure Blob Storage within a short time
 	By("archiving WALs and verifying they exist", func() {
 		primary := clusterName + "-1"

--- a/tests/e2e/backup_restore_minio_test.go
+++ b/tests/e2e/backup_restore_minio_test.go
@@ -72,7 +72,14 @@ var _ = Describe("MinIO - Backup and restore", Label(tests.LabelBackupRestore), 
 			})
 
 			By("creating the credentials for minio", func() {
-				AssertStorageCredentialsAreCreated(namespace, "backup-storage-creds", "minio", "minio123")
+				_, err = testUtils.CreateObjectStorageSecret(
+					namespace,
+					"backup-storage-creds",
+					"minio",
+					"minio123",
+					env,
+				)
+				Expect(err).ToNot(HaveOccurred())
 			})
 
 			// Create ConfigMap and secrets to verify metrics for target database after backup restore
@@ -550,7 +557,16 @@ var _ = Describe("MinIO - Clusters Recovery from Barman Object Store", Label(tes
 			namespace, err = env.CreateUniqueTestNamespace(namespacePrefix)
 			Expect(err).ToNot(HaveOccurred())
 
-			AssertStorageCredentialsAreCreated(namespace, "backup-storage-creds", "minio", "minio123")
+			By("creating the credentials for minio", func() {
+				_, err = testUtils.CreateObjectStorageSecret(
+					namespace,
+					"backup-storage-creds",
+					"minio",
+					"minio123",
+					env,
+				)
+				Expect(err).ToNot(HaveOccurred())
+			})
 
 			By("create the certificates for MinIO", func() {
 				err := minioEnv.CreateCaSecret(env, namespace)

--- a/tests/e2e/backup_restore_minio_test.go
+++ b/tests/e2e/backup_restore_minio_test.go
@@ -125,7 +125,7 @@ var _ = Describe("MinIO - Backup and restore", Label(tests.LabelBackupRestore), 
 			AssertCreateTestData(env, tableLocator)
 
 			AssertArchiveWalOnMinio(namespace, clusterName, clusterName)
-			latestTar := minioPath(clusterName, "data.tar")
+			latestTar := minio.GetFilePath(clusterName, "data.tar")
 
 			// There should be a backup resource and
 			By(fmt.Sprintf("backing up a cluster and verifying it exists on minio, backup path is %v", latestTar),
@@ -195,7 +195,7 @@ var _ = Describe("MinIO - Backup and restore", Label(tests.LabelBackupRestore), 
 				Expect(err).ToNot(HaveOccurred())
 				// create a second backup
 				testUtils.ExecuteBackup(namespace, backupFile, false, testTimeouts[testUtils.BackupIsReady], env)
-				latestTar = minioPath(clusterName, "data.tar")
+				latestTar = minio.GetFilePath(clusterName, "data.tar")
 				Eventually(func() (int, error) {
 					return minio.CountFiles(minioEnv, latestTar)
 				}, 60).Should(BeEquivalentTo(2))
@@ -279,7 +279,7 @@ var _ = Describe("MinIO - Backup and restore", Label(tests.LabelBackupRestore), 
 			AssertCreateTestData(env, tableLocator)
 
 			AssertArchiveWalOnMinio(namespace, targetClusterName, targetClusterName)
-			latestTar := minioPath(targetClusterName, "data.tar")
+			latestTar := minio.GetFilePath(targetClusterName, "data.tar")
 
 			// There should be a backup resource and
 			By(fmt.Sprintf("backing up a cluster from standby and verifying it exists on minio, backup path is %v",
@@ -329,7 +329,7 @@ var _ = Describe("MinIO - Backup and restore", Label(tests.LabelBackupRestore), 
 			AssertCreateTestData(env, tableLocator)
 
 			AssertArchiveWalOnMinio(namespace, targetClusterName, targetClusterName)
-			latestTar := minioPath(targetClusterName, "data.tar")
+			latestTar := minio.GetFilePath(targetClusterName, "data.tar")
 
 			// There should be a backup resource and
 			By(fmt.Sprintf("backing up a cluster from standby (defined in backup file) and verifying it exists on minio,"+
@@ -394,7 +394,7 @@ var _ = Describe("MinIO - Backup and restore", Label(tests.LabelBackupRestore), 
 			By("backing up a cluster and verifying it exists on minio", func() {
 				testUtils.ExecuteBackup(namespace, backupFileCustom, false, testTimeouts[testUtils.BackupIsReady], env)
 				testUtils.AssertBackupConditionInClusterStatus(env, namespace, customClusterName)
-				latestBaseTar := minioPath(clusterServerName, "data.tar")
+				latestBaseTar := minio.GetFilePath(clusterServerName, "data.tar")
 				Eventually(func() (int, error) {
 					return minio.CountFiles(minioEnv, latestBaseTar)
 				}, 60).Should(BeEquivalentTo(1),
@@ -428,7 +428,7 @@ var _ = Describe("MinIO - Backup and restore", Label(tests.LabelBackupRestore), 
 			Expect(err).ToNot(HaveOccurred())
 
 			AssertScheduledBackupsImmediate(namespace, scheduledBackupSampleFile, scheduledBackupName)
-			latestBaseTar := minioPath(clusterName, "data.tar")
+			latestBaseTar := minio.GetFilePath(clusterName, "data.tar")
 			// AssertScheduledBackupsImmediate creates at least two backups, we should find
 			// their base backups
 			Eventually(func() (int, error) {
@@ -481,7 +481,7 @@ var _ = Describe("MinIO - Backup and restore", Label(tests.LabelBackupRestore), 
 
 			By("scheduling backups", func() {
 				AssertScheduledBackupsAreScheduled(namespace, scheduledBackupSampleFile, 300)
-				latestTar := minioPath(clusterName, "data.tar")
+				latestTar := minio.GetFilePath(clusterName, "data.tar")
 				Eventually(func() (int, error) {
 					return minio.CountFiles(minioEnv, latestTar)
 				}, 60).Should(BeNumerically(">=", 2),
@@ -493,7 +493,7 @@ var _ = Describe("MinIO - Backup and restore", Label(tests.LabelBackupRestore), 
 
 		It("verify tags in backed files", func() {
 			AssertArchiveWalOnMinio(namespace, clusterName, clusterName)
-			tags, err := minio.GetFileTags(minioEnv, minioPath(clusterName, "*1.gz"))
+			tags, err := minio.GetFileTags(minioEnv, minio.GetFilePath(clusterName, "*1.gz"))
 			Expect(err).ToNot(HaveOccurred())
 			Expect(tags.Tags).ToNot(BeEmpty())
 
@@ -509,7 +509,7 @@ var _ = Describe("MinIO - Backup and restore", Label(tests.LabelBackupRestore), 
 
 			AssertNewPrimary(namespace, clusterName, oldPrimary)
 
-			tags, err = minio.GetFileTags(minioEnv, minioPath(clusterName, "*.history.gz"))
+			tags, err = minio.GetFileTags(minioEnv, minio.GetFilePath(clusterName, "*.history.gz"))
 			Expect(err).ToNot(HaveOccurred())
 			Expect(tags.Tags).ToNot(BeEmpty())
 		})
@@ -600,7 +600,7 @@ var _ = Describe("MinIO - Clusters Recovery from Barman Object Store", Label(tes
 					// This should be better handled inside ExecuteBackup
 					AssertArchiveWalOnMinio(namespace, clusterName, clusterName)
 
-					latestTar := minioPath(clusterName, "data.tar")
+					latestTar := minio.GetFilePath(clusterName, "data.tar")
 					Eventually(func() (int, error) {
 						return minio.CountFiles(minioEnv, latestTar)
 					}, 60).Should(BeEquivalentTo(1),
@@ -666,7 +666,7 @@ var _ = Describe("MinIO - Clusters Recovery from Barman Object Store", Label(tes
 				testUtils.ExecuteBackup(namespace, sourceTakeSecondBackupFileMinio, false,
 					testTimeouts[testUtils.BackupIsReady], env)
 				testUtils.AssertBackupConditionInClusterStatus(env, namespace, clusterName)
-				latestTar := minioPath(clusterName, "data.tar")
+				latestTar := minio.GetFilePath(clusterName, "data.tar")
 				Eventually(func() (int, error) {
 					return minio.CountFiles(minioEnv, latestTar)
 				}, 60).Should(BeEquivalentTo(2),
@@ -706,7 +706,7 @@ var _ = Describe("MinIO - Clusters Recovery from Barman Object Store", Label(tes
 				testUtils.ExecuteBackup(namespace, sourceTakeThirdBackupFileMinio, false,
 					testTimeouts[testUtils.BackupIsReady], env)
 				testUtils.AssertBackupConditionInClusterStatus(env, namespace, clusterName)
-				latestTar := minioPath(clusterName, "data.tar")
+				latestTar := minio.GetFilePath(clusterName, "data.tar")
 				Eventually(func() (int, error) {
 					return minio.CountFiles(minioEnv, latestTar)
 				}, 60).Should(BeEquivalentTo(3),
@@ -735,7 +735,7 @@ func prepareClusterForPITROnMinio(
 
 	By("backing up a cluster and verifying it exists on minio", func() {
 		testUtils.ExecuteBackup(namespace, backupSampleFile, false, testTimeouts[testUtils.BackupIsReady], env)
-		latestTar := minioPath(clusterName, "data.tar")
+		latestTar := minio.GetFilePath(clusterName, "data.tar")
 		Eventually(func() (int, error) {
 			return minio.CountFiles(minioEnv, latestTar)
 		}, 60).Should(BeNumerically(">=", expectedVal),

--- a/tests/e2e/replica_mode_cluster_test.go
+++ b/tests/e2e/replica_mode_cluster_test.go
@@ -256,8 +256,16 @@ var _ = Describe("Replica Mode", Label(tests.LabelReplication), func() {
 			Expect(err).ToNot(HaveOccurred())
 			replicaNamespace, err := env.CreateUniqueTestNamespace(replicaNamespacePrefix)
 			Expect(err).ToNot(HaveOccurred())
+
 			By("creating the credentials for minio", func() {
-				AssertStorageCredentialsAreCreated(replicaNamespace, "backup-storage-creds", "minio", "minio123")
+				_, err = testUtils.CreateObjectStorageSecret(
+					replicaNamespace,
+					"backup-storage-creds",
+					"minio",
+					"minio123",
+					env,
+				)
+				Expect(err).ToNot(HaveOccurred())
 			})
 
 			By("create the certificates for MinIO", func() {
@@ -314,7 +322,14 @@ var _ = Describe("Replica Mode", Label(tests.LabelReplication), func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			By("creating the credentials for minio", func() {
-				AssertStorageCredentialsAreCreated(namespace, "backup-storage-creds", "minio", "minio123")
+				_, err = testUtils.CreateObjectStorageSecret(
+					namespace,
+					"backup-storage-creds",
+					"minio",
+					"minio123",
+					env,
+				)
+				Expect(err).ToNot(HaveOccurred())
 			})
 
 			By("create the certificates for MinIO", func() {
@@ -538,7 +553,14 @@ var _ = Describe("Replica switchover", Label(tests.LabelReplication), Ordered, f
 			DeferCleanup(func() { close(stopLoad) })
 
 			By("creating the credentials for minio", func() {
-				AssertStorageCredentialsAreCreated(namespace, "backup-storage-creds", "minio", "minio123")
+				_, err = testUtils.CreateObjectStorageSecret(
+					namespace,
+					"backup-storage-creds",
+					"minio",
+					"minio123",
+					env,
+				)
+				Expect(err).ToNot(HaveOccurred())
 			})
 
 			By("create the certificates for MinIO", func() {

--- a/tests/e2e/replica_mode_cluster_test.go
+++ b/tests/e2e/replica_mode_cluster_test.go
@@ -523,11 +523,11 @@ var _ = Describe("Replica switchover", Label(tests.LabelReplication), Ordered, f
 			DeferCleanup(func() error {
 				// Since we use multiple times the same cluster names for the same minio instance, we need to clean it up
 				// between tests
-				_, err = minio.CleanFilesOnMinio(minioEnv, path.Join("minio", "cluster-backups", clusterAName))
+				_, err = minio.CleanFiles(minioEnv, path.Join("minio", "cluster-backups", clusterAName))
 				if err != nil {
 					return err
 				}
-				_, err = minio.CleanFilesOnMinio(minioEnv, path.Join("minio", "cluster-backups", clusterBName))
+				_, err = minio.CleanFiles(minioEnv, path.Join("minio", "cluster-backups", clusterBName))
 				if err != nil {
 					return err
 				}

--- a/tests/e2e/replica_mode_cluster_test.go
+++ b/tests/e2e/replica_mode_cluster_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 	"github.com/cloudnative-pg/cloudnative-pg/tests"
 	testUtils "github.com/cloudnative-pg/cloudnative-pg/tests/utils"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/minio"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -522,11 +523,11 @@ var _ = Describe("Replica switchover", Label(tests.LabelReplication), Ordered, f
 			DeferCleanup(func() error {
 				// Since we use multiple times the same cluster names for the same minio instance, we need to clean it up
 				// between tests
-				_, err = testUtils.CleanFilesOnMinio(minioEnv, path.Join("minio", "cluster-backups", clusterAName))
+				_, err = minio.CleanFilesOnMinio(minioEnv, path.Join("minio", "cluster-backups", clusterAName))
 				if err != nil {
 					return err
 				}
-				_, err = testUtils.CleanFilesOnMinio(minioEnv, path.Join("minio", "cluster-backups", clusterBName))
+				_, err = minio.CleanFilesOnMinio(minioEnv, path.Join("minio", "cluster-backups", clusterBName))
 				if err != nil {
 					return err
 				}

--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -36,6 +36,7 @@ import (
 	cnpgUtils "github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 	"github.com/cloudnative-pg/cloudnative-pg/tests"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/minio"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/sternmultitailer"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -57,7 +58,7 @@ var (
 	operatorWasRestarted    bool
 	quickDeletionPeriod     = int64(1)
 	testTimeouts            map[utils.Timeout]int
-	minioEnv                = &utils.MinioEnv{
+	minioEnv                = &minio.Env{
 		Namespace:    "minio",
 		ServiceName:  "minio-service.minio",
 		CaSecretName: "minio-server-ca-secret",
@@ -98,7 +99,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 		Expect(err).ToNot(HaveOccurred())
 	})
 	minioEnv.Timeout = uint(testTimeouts[utils.MinioInstallation])
-	minioClient, err := utils.MinioDeploy(minioEnv, env)
+	minioClient, err := minio.Deploy(minioEnv, env)
 	Expect(err).ToNot(HaveOccurred())
 
 	caSecret := minioEnv.CaPair.GenerateCASecret(minioEnv.Namespace, minioEnv.CaSecretName)

--- a/tests/e2e/tablespaces_test.go
+++ b/tests/e2e/tablespaces_test.go
@@ -110,7 +110,16 @@ var _ = Describe("Tablespaces tests", Label(tests.LabelTablespaces,
 			Expect(err).ToNot(HaveOccurred())
 
 			// We create the MinIO credentials required to login into the system
-			AssertStorageCredentialsAreCreated(namespace, "backup-storage-creds", "minio", "minio123")
+			By("creating the credentials for minio", func() {
+				_, err = testUtils.CreateObjectStorageSecret(
+					namespace,
+					"backup-storage-creds",
+					"minio",
+					"minio123",
+					env,
+				)
+				Expect(err).ToNot(HaveOccurred())
+			})
 
 			By("create the certificates for MinIO", func() {
 				err := minioEnv.CreateCaSecret(env, namespace)
@@ -370,7 +379,16 @@ var _ = Describe("Tablespaces tests", Label(tests.LabelTablespaces,
 			Expect(err).ToNot(HaveOccurred())
 
 			// We create the required credentials for MinIO
-			AssertStorageCredentialsAreCreated(namespace, "backup-storage-creds", "minio", "minio123")
+			By("creating the credentials for minio", func() {
+				_, err = testUtils.CreateObjectStorageSecret(
+					namespace,
+					"backup-storage-creds",
+					"minio",
+					"minio123",
+					env,
+				)
+				Expect(err).ToNot(HaveOccurred())
+			})
 
 			By("create the certificates for MinIO", func() {
 				err := minioEnv.CreateCaSecret(env, namespace)

--- a/tests/e2e/tablespaces_test.go
+++ b/tests/e2e/tablespaces_test.go
@@ -169,7 +169,8 @@ var _ = Describe("Tablespaces tests", Label(tests.LabelTablespaces,
 			Expect(err).ToNot(HaveOccurred())
 
 			By(fmt.Sprintf("creating backup %s and verifying backup is ready", backupName), func() {
-				testUtils.ExecuteBackup(namespace, clusterBackupManifest, false, testTimeouts[testUtils.BackupIsReady], env)
+				testUtils.ExecuteBackup(namespace, clusterBackupManifest, false, testTimeouts[testUtils.BackupIsReady],
+					env)
 				testUtils.AssertBackupConditionInClusterStatus(env, namespace, clusterName)
 			})
 
@@ -1215,7 +1216,7 @@ func latestBaseBackupContainsExpectedTars(
 		// we list the backup.info files to get the listing of base backups
 		// directories in minio
 		backupInfoFiles := filepath.Join("*", clusterName, "base", "*", "*.info")
-		ls, err := minio.ListFilesOnMinio(minioEnv, backupInfoFiles)
+		ls, err := minio.ListFiles(minioEnv, backupInfoFiles)
 		g.Expect(err).ShouldNot(HaveOccurred())
 		frags := strings.Split(ls, "\n")
 		slices.Sort(frags)
@@ -1223,10 +1224,10 @@ func latestBaseBackupContainsExpectedTars(
 		g.Expect(frags).To(HaveLen(numBackups), report)
 		latestBaseBackup := filepath.Dir(frags[numBackups-1])
 		tarsInLastBackup := strings.TrimPrefix(filepath.Join(latestBaseBackup, "*.tar"), "minio/")
-		listing, err := minio.ListFilesOnMinio(minioEnv, tarsInLastBackup)
+		listing, err := minio.ListFiles(minioEnv, tarsInLastBackup)
 		g.Expect(err).ShouldNot(HaveOccurred())
 		report += fmt.Sprintf("tar listing:\n%s\n", listing)
-		numTars, err := minio.CountFilesOnMinio(minioEnv, tarsInLastBackup)
+		numTars, err := minio.CountFiles(minioEnv, tarsInLastBackup)
 		g.Expect(err).ShouldNot(HaveOccurred())
 		g.Expect(numTars).To(Equal(expectedTars), report)
 	}, 120).Should(Succeed())

--- a/tests/e2e/upgrade_test.go
+++ b/tests/e2e/upgrade_test.go
@@ -481,7 +481,14 @@ var _ = Describe("Upgrade", Label(tests.LabelUpgrade, tests.LabelNoOpenshift), O
 			CreateResourceFromFile(upgradeNamespace, pgSecrets)
 		})
 		By("creating the cloud storage credentials", func() {
-			AssertStorageCredentialsAreCreated(upgradeNamespace, "aws-creds", "minio", "minio123")
+			_, err := testsUtils.CreateObjectStorageSecret(
+				upgradeNamespace,
+				"aws-creds",
+				"minio",
+				"minio123",
+				env,
+			)
+			Expect(err).NotTo(HaveOccurred())
 		})
 		By("create the certificates for MinIO", func() {
 			err := minioEnv.CreateCaSecret(env, upgradeNamespace)

--- a/tests/e2e/upgrade_test.go
+++ b/tests/e2e/upgrade_test.go
@@ -147,10 +147,10 @@ var _ = Describe("Upgrade", Label(tests.LabelUpgrade, tests.LabelNoOpenshift), O
 	AssertScheduledBackupsAreScheduled := func(serverName string) {
 		By("verifying scheduled backups are still happening", func() {
 			latestTar := minioPath(serverName, "data.tar.gz")
-			currentBackups, err := minio.CountFilesOnMinio(minioEnv, latestTar)
+			currentBackups, err := minio.CountFiles(minioEnv, latestTar)
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(func() (int, error) {
-				return minio.CountFilesOnMinio(minioEnv, latestTar)
+				return minio.CountFiles(minioEnv, latestTar)
 			}, 120).Should(BeNumerically(">", currentBackups))
 		})
 	}
@@ -355,7 +355,9 @@ var _ = Describe("Upgrade", Label(tests.LabelUpgrade, tests.LabelNoOpenshift), O
 	// assertExpectedMatchingPodUIDs checks that the UID of each pod of a Cluster matches with a given list of UIDs.
 	// expectedMatches defines how many times, when comparing the elements of the 2 lists, you are expected to have
 	// common values
-	assertExpectedMatchingPodUIDs := func(namespace, clusterName string, podUIDs []types.UID, expectedMatches int) error {
+	assertExpectedMatchingPodUIDs := func(
+		namespace, clusterName string, podUIDs []types.UID, expectedMatches int,
+	) error {
 		backoffCheckingPodRestarts := wait.Backoff{
 			Duration: 10 * time.Second,
 			Steps:    30,
@@ -398,11 +400,11 @@ var _ = Describe("Upgrade", Label(tests.LabelUpgrade, tests.LabelNoOpenshift), O
 			return fmt.Errorf("could not cleanup, failed to delete operator namespace: %v", err)
 		}
 
-		if _, err := minio.CleanFilesOnMinio(minioEnv, minioPath1); err != nil {
+		if _, err := minio.CleanFiles(minioEnv, minioPath1); err != nil {
 			return fmt.Errorf("encountered an error while cleaning up minio: %v", err)
 		}
 
-		if _, err := minio.CleanFilesOnMinio(minioEnv, minioPath2); err != nil {
+		if _, err := minio.CleanFiles(minioEnv, minioPath2); err != nil {
 			return fmt.Errorf("encountered an error while cleaning up minio: %v", err)
 		}
 
@@ -657,7 +659,8 @@ var _ = Describe("Upgrade", Label(tests.LabelUpgrade, tests.LabelNoOpenshift), O
 		By("restoring the backup taken from the first Cluster in a new cluster", func() {
 			restoredClusterName := "cluster-restore"
 			CreateResourceFromFile(upgradeNamespace, restoreFile)
-			AssertClusterIsReady(upgradeNamespace, restoredClusterName, testTimeouts[testsUtils.ClusterIsReadySlow], env)
+			AssertClusterIsReady(upgradeNamespace, restoredClusterName, testTimeouts[testsUtils.ClusterIsReadySlow],
+				env)
 
 			// Test data should be present on restored primary
 			primary := restoredClusterName + "-1"

--- a/tests/e2e/upgrade_test.go
+++ b/tests/e2e/upgrade_test.go
@@ -146,7 +146,7 @@ var _ = Describe("Upgrade", Label(tests.LabelUpgrade, tests.LabelNoOpenshift), O
 	// but a single scheduled backups during the check
 	AssertScheduledBackupsAreScheduled := func(serverName string) {
 		By("verifying scheduled backups are still happening", func() {
-			latestTar := minioPath(serverName, "data.tar.gz")
+			latestTar := minio.GetFilePath(serverName, "data.tar.gz")
 			currentBackups, err := minio.CountFiles(minioEnv, latestTar)
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(func() (int, error) {

--- a/tests/e2e/upgrade_test.go
+++ b/tests/e2e/upgrade_test.go
@@ -37,6 +37,7 @@ import (
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/tests"
 	testsUtils "github.com/cloudnative-pg/cloudnative-pg/tests/utils"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/minio"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -146,10 +147,10 @@ var _ = Describe("Upgrade", Label(tests.LabelUpgrade, tests.LabelNoOpenshift), O
 	AssertScheduledBackupsAreScheduled := func(serverName string) {
 		By("verifying scheduled backups are still happening", func() {
 			latestTar := minioPath(serverName, "data.tar.gz")
-			currentBackups, err := testsUtils.CountFilesOnMinio(minioEnv, latestTar)
+			currentBackups, err := minio.CountFilesOnMinio(minioEnv, latestTar)
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(func() (int, error) {
-				return testsUtils.CountFilesOnMinio(minioEnv, latestTar)
+				return minio.CountFilesOnMinio(minioEnv, latestTar)
 			}, 120).Should(BeNumerically(">", currentBackups))
 		})
 	}
@@ -397,11 +398,11 @@ var _ = Describe("Upgrade", Label(tests.LabelUpgrade, tests.LabelNoOpenshift), O
 			return fmt.Errorf("could not cleanup, failed to delete operator namespace: %v", err)
 		}
 
-		if _, err := testsUtils.CleanFilesOnMinio(minioEnv, minioPath1); err != nil {
+		if _, err := minio.CleanFilesOnMinio(minioEnv, minioPath1); err != nil {
 			return fmt.Errorf("encountered an error while cleaning up minio: %v", err)
 		}
 
-		if _, err := testsUtils.CleanFilesOnMinio(minioEnv, minioPath2); err != nil {
+		if _, err := minio.CleanFilesOnMinio(minioEnv, minioPath2); err != nil {
 			return fmt.Errorf("encountered an error while cleaning up minio: %v", err)
 		}
 

--- a/tests/e2e/volume_snapshot_test.go
+++ b/tests/e2e/volume_snapshot_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 	"github.com/cloudnative-pg/cloudnative-pg/tests"
 	testUtils "github.com/cloudnative-pg/cloudnative-pg/tests/utils"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/minio"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -190,7 +191,7 @@ var _ = Describe("Verify Volume Snapshot",
 					primaryPod, err := env.GetClusterPrimary(namespace, clusterToSnapshotName)
 					Expect(err).ToNot(HaveOccurred())
 					Eventually(func() (bool, error) {
-						connectionStatus, err := testUtils.MinioTestConnectivityUsingBarmanCloudWalArchive(
+						connectionStatus, err := minio.TestConnectivityUsingBarmanCloudWalArchive(
 							namespace, clusterToSnapshotName, primaryPod.GetName(), "minio", "minio123", minioEnv.ServiceName)
 						if err != nil {
 							return false, err
@@ -405,7 +406,7 @@ var _ = Describe("Verify Volume Snapshot",
 							"Backup should be completed correctly, error message is '%s'",
 							backup.Status.Error)
 					}, testTimeouts[testUtils.VolumeSnapshotIsReady]).Should(Succeed())
-					AssertBackupConditionInClusterStatus(namespace, clusterToBackupName)
+					testUtils.AssertBackupConditionInClusterStatus(env, namespace, clusterToBackupName)
 				})
 
 				By("checking that the backup status is correctly populated", func() {
@@ -473,7 +474,7 @@ var _ = Describe("Verify Volume Snapshot",
 							"Backup should be completed correctly, error message is '%s'",
 							backup.Status.Error)
 					}, testTimeouts[testUtils.VolumeSnapshotIsReady]).Should(Succeed())
-					AssertBackupConditionInClusterStatus(namespace, clusterToBackupName)
+					testUtils.AssertBackupConditionInClusterStatus(env, namespace, clusterToBackupName)
 				})
 
 				By("checking that the backup status is correctly populated", func() {
@@ -540,7 +541,7 @@ var _ = Describe("Verify Volume Snapshot",
 							"Backup should be completed correctly, error message is '%s'",
 							backup.Status.Error)
 					}, testTimeouts[testUtils.VolumeSnapshotIsReady]).Should(Succeed())
-					AssertBackupConditionInClusterStatus(namespace, clusterToBackupName)
+					testUtils.AssertBackupConditionInClusterStatus(env, namespace, clusterToBackupName)
 				})
 
 				By("checking that the backup status is correctly populated", func() {
@@ -612,7 +613,7 @@ var _ = Describe("Verify Volume Snapshot",
 					primaryPod, err := env.GetClusterPrimary(namespace, clusterToSnapshotName)
 					Expect(err).ToNot(HaveOccurred())
 					Eventually(func() (bool, error) {
-						connectionStatus, err := testUtils.MinioTestConnectivityUsingBarmanCloudWalArchive(
+						connectionStatus, err := minio.TestConnectivityUsingBarmanCloudWalArchive(
 							namespace, clusterToSnapshotName, primaryPod.GetName(), "minio", "minio123", minioEnv.ServiceName)
 						if err != nil {
 							return false, err

--- a/tests/e2e/volume_snapshot_test.go
+++ b/tests/e2e/volume_snapshot_test.go
@@ -168,7 +168,13 @@ var _ = Describe("Verify Volume Snapshot",
 					Expect(err).ToNot(HaveOccurred())
 				})
 
-				AssertStorageCredentialsAreCreated(namespace, "backup-storage-creds", "minio", "minio123")
+				_, err = testUtils.CreateObjectStorageSecret(
+					namespace,
+					"backup-storage-creds",
+					"minio",
+					"minio123",
+					env)
+				Expect(err).ToNot(HaveOccurred())
 			})
 
 			It("correctly executes PITR with a cold snapshot", func() {
@@ -603,7 +609,16 @@ var _ = Describe("Verify Volume Snapshot",
 					Expect(err).ToNot(HaveOccurred())
 				})
 
-				AssertStorageCredentialsAreCreated(namespace, "backup-storage-creds", "minio", "minio123")
+				By("creating the credentials for minio", func() {
+					_, err = testUtils.CreateObjectStorageSecret(
+						namespace,
+						"backup-storage-creds",
+						"minio",
+						"minio123",
+						env,
+					)
+					Expect(err).ToNot(HaveOccurred())
+				})
 
 				By("creating the cluster to snapshot", func() {
 					AssertCreateCluster(namespace, clusterToSnapshotName, clusterToSnapshot, env)

--- a/tests/e2e/wal_restore_parallel_test.go
+++ b/tests/e2e/wal_restore_parallel_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/specs"
 	"github.com/cloudnative-pg/cloudnative-pg/tests"
 	testUtils "github.com/cloudnative-pg/cloudnative-pg/tests/utils"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/minio"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -107,7 +108,7 @@ var _ = Describe("Wal-restore in parallel", Label(tests.LabelBackupRestore), fun
 			latestWALPath := minioPath(clusterName, latestWAL+".gz")
 			Eventually(func() (int, error) {
 				// WALs are compressed with gzip in the fixture
-				return testUtils.CountFilesOnMinio(minioEnv, latestWALPath)
+				return minio.CountFilesOnMinio(minioEnv, latestWALPath)
 			}, RetryTimeout).Should(BeEquivalentTo(1),
 				fmt.Sprintf("verify the existence of WAL %v in minio", latestWALPath))
 		})

--- a/tests/e2e/wal_restore_parallel_test.go
+++ b/tests/e2e/wal_restore_parallel_test.go
@@ -108,7 +108,7 @@ var _ = Describe("Wal-restore in parallel", Label(tests.LabelBackupRestore), fun
 			latestWALPath := minioPath(clusterName, latestWAL+".gz")
 			Eventually(func() (int, error) {
 				// WALs are compressed with gzip in the fixture
-				return minio.CountFilesOnMinio(minioEnv, latestWALPath)
+				return minio.CountFiles(minioEnv, latestWALPath)
 			}, RetryTimeout).Should(BeEquivalentTo(1),
 				fmt.Sprintf("verify the existence of WAL %v in minio", latestWALPath))
 		})
@@ -119,15 +119,20 @@ var _ = Describe("Wal-restore in parallel", Label(tests.LabelBackupRestore), fun
 			walFile3 = "0000000100000000000000F3"
 			walFile4 = "0000000100000000000000F4"
 			walFile5 = "0000000100000000000000F5"
-			Expect(testUtils.ForgeArchiveWalOnMinio(minioEnv.Namespace, clusterName, minioEnv.Client.Name, latestWAL, walFile1)).
+			Expect(testUtils.ForgeArchiveWalOnMinio(minioEnv.Namespace, clusterName, minioEnv.Client.Name, latestWAL,
+				walFile1)).
 				ShouldNot(HaveOccurred())
-			Expect(testUtils.ForgeArchiveWalOnMinio(minioEnv.Namespace, clusterName, minioEnv.Client.Name, latestWAL, walFile2)).
+			Expect(testUtils.ForgeArchiveWalOnMinio(minioEnv.Namespace, clusterName, minioEnv.Client.Name, latestWAL,
+				walFile2)).
 				ShouldNot(HaveOccurred())
-			Expect(testUtils.ForgeArchiveWalOnMinio(minioEnv.Namespace, clusterName, minioEnv.Client.Name, latestWAL, walFile3)).
+			Expect(testUtils.ForgeArchiveWalOnMinio(minioEnv.Namespace, clusterName, minioEnv.Client.Name, latestWAL,
+				walFile3)).
 				ShouldNot(HaveOccurred())
-			Expect(testUtils.ForgeArchiveWalOnMinio(minioEnv.Namespace, clusterName, minioEnv.Client.Name, latestWAL, walFile4)).
+			Expect(testUtils.ForgeArchiveWalOnMinio(minioEnv.Namespace, clusterName, minioEnv.Client.Name, latestWAL,
+				walFile4)).
 				ShouldNot(HaveOccurred())
-			Expect(testUtils.ForgeArchiveWalOnMinio(minioEnv.Namespace, clusterName, minioEnv.Client.Name, latestWAL, walFile5)).
+			Expect(testUtils.ForgeArchiveWalOnMinio(minioEnv.Namespace, clusterName, minioEnv.Client.Name, latestWAL,
+				walFile5)).
 				ShouldNot(HaveOccurred())
 		})
 
@@ -168,7 +173,10 @@ var _ = Describe("Wal-restore in parallel", Label(tests.LabelBackupRestore), fun
 				WithTimeout(RetryTimeout).
 				Should(BeTrue(),
 					"#3 wal is in the spool directory")
-			Eventually(func() bool { return testUtils.TestFileExist(namespace, standby, SpoolDirectory, "end-of-wal-stream") }).
+			Eventually(func() bool {
+				return testUtils.TestFileExist(namespace, standby, SpoolDirectory,
+					"end-of-wal-stream")
+			}).
 				WithTimeout(RetryTimeout).
 				Should(BeFalse(),
 					"end-of-wal-stream flag is unset")
@@ -194,7 +202,10 @@ var _ = Describe("Wal-restore in parallel", Label(tests.LabelBackupRestore), fun
 				WithTimeout(RetryTimeout).
 				Should(BeTrue(),
 					"#3 wal is in the spool directory")
-			Eventually(func() bool { return testUtils.TestFileExist(namespace, standby, SpoolDirectory, "end-of-wal-stream") }).
+			Eventually(func() bool {
+				return testUtils.TestFileExist(namespace, standby, SpoolDirectory,
+					"end-of-wal-stream")
+			}).
 				WithTimeout(RetryTimeout).
 				Should(BeFalse(),
 					"end-of-wal-stream flag is unset")
@@ -242,7 +253,10 @@ var _ = Describe("Wal-restore in parallel", Label(tests.LabelBackupRestore), fun
 				WithTimeout(RetryTimeout).
 				Should(BeTrue(),
 					"#5 wal is in the spool directory")
-			Eventually(func() bool { return testUtils.TestFileExist(namespace, standby, SpoolDirectory, "end-of-wal-stream") }).
+			Eventually(func() bool {
+				return testUtils.TestFileExist(namespace, standby, SpoolDirectory,
+					"end-of-wal-stream")
+			}).
 				WithTimeout(RetryTimeout).
 				Should(BeTrue(),
 					"end-of-wal-stream flag is set for #6 wal is not present")
@@ -251,7 +265,8 @@ var _ = Describe("Wal-restore in parallel", Label(tests.LabelBackupRestore), fun
 		// Generate a new wal file; the archive also contains WAL #6.
 		By("forging a new wal file, the #6 wal", func() {
 			walFile6 = "0000000100000000000000F6"
-			Expect(testUtils.ForgeArchiveWalOnMinio(minioEnv.Namespace, clusterName, minioEnv.Client.Name, latestWAL, walFile6)).
+			Expect(testUtils.ForgeArchiveWalOnMinio(minioEnv.Namespace, clusterName, minioEnv.Client.Name, latestWAL,
+				walFile6)).
 				ShouldNot(HaveOccurred())
 		})
 
@@ -274,7 +289,10 @@ var _ = Describe("Wal-restore in parallel", Label(tests.LabelBackupRestore), fun
 				WithTimeout(RetryTimeout).
 				Should(BeFalse(),
 					"no wal files exist in the spool directory")
-			Eventually(func() bool { return testUtils.TestFileExist(namespace, standby, SpoolDirectory, "end-of-wal-stream") }).
+			Eventually(func() bool {
+				return testUtils.TestFileExist(namespace, standby, SpoolDirectory,
+					"end-of-wal-stream")
+			}).
 				WithTimeout(RetryTimeout).
 				Should(BeTrue(),
 					"end-of-wal-stream flag is still there")
@@ -322,7 +340,10 @@ var _ = Describe("Wal-restore in parallel", Label(tests.LabelBackupRestore), fun
 				WithTimeout(RetryTimeout).
 				Should(BeFalse(),
 					"no wals in the spool directory")
-			Eventually(func() bool { return testUtils.TestFileExist(namespace, standby, SpoolDirectory, "end-of-wal-stream") }).
+			Eventually(func() bool {
+				return testUtils.TestFileExist(namespace, standby, SpoolDirectory,
+					"end-of-wal-stream")
+			}).
 				WithTimeout(RetryTimeout).
 				Should(BeTrue(),
 					"end-of-wal-stream flag is set for #7 and #8 wal is not present")

--- a/tests/e2e/wal_restore_parallel_test.go
+++ b/tests/e2e/wal_restore_parallel_test.go
@@ -70,7 +70,14 @@ var _ = Describe("Wal-restore in parallel", Label(tests.LabelBackupRestore), fun
 		Expect(err).ToNot(HaveOccurred())
 
 		By("creating the credentials for minio", func() {
-			AssertStorageCredentialsAreCreated(namespace, "backup-storage-creds", "minio", "minio123")
+			_, err = testUtils.CreateObjectStorageSecret(
+				namespace,
+				"backup-storage-creds",
+				"minio",
+				"minio123",
+				env,
+			)
+			Expect(err).ToNot(HaveOccurred())
 		})
 
 		By("create the certificates for MinIO", func() {

--- a/tests/e2e/wal_restore_parallel_test.go
+++ b/tests/e2e/wal_restore_parallel_test.go
@@ -105,7 +105,7 @@ var _ = Describe("Wal-restore in parallel", Label(tests.LabelBackupRestore), fun
 			Expect(err).ToNot(HaveOccurred())
 			primary := pod.GetName()
 			latestWAL = switchWalAndGetLatestArchive(namespace, primary)
-			latestWALPath := minioPath(clusterName, latestWAL+".gz")
+			latestWALPath := minio.GetFilePath(clusterName, latestWAL+".gz")
 			Eventually(func() (int, error) {
 				// WALs are compressed with gzip in the fixture
 				return minio.CountFiles(minioEnv, latestWALPath)

--- a/tests/utils/azurite.go
+++ b/tests/utils/azurite.go
@@ -27,12 +27,9 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	v1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/certs"
-	"github.com/cloudnative-pg/cloudnative-pg/pkg/specs"
-	utils2 "github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 )
 
 const (
@@ -575,31 +572,4 @@ func CountFilesOnAzuriteBlobStorage(
 	var arr []string
 	err = json.Unmarshal([]byte(out), &arr)
 	return len(arr), err
-}
-
-// GetClusterPrimary gets the primary pod of a cluster
-func (env TestingEnvironment) GetClusterPrimary(namespace string, clusterName string) (*corev1.Pod, error) {
-	podList := &corev1.PodList{}
-
-	err := GetObjectList(&env, podList, client.InNamespace(namespace),
-		client.MatchingLabels{
-			utils2.ClusterLabelName:             clusterName,
-			utils2.ClusterInstanceRoleLabelName: specs.ClusterRoleLabelPrimary,
-		},
-	)
-	if err != nil {
-		return &corev1.Pod{}, err
-	}
-	if len(podList.Items) > 0 {
-		// if there are multiple, get the one without deletion timestamp
-		for _, pod := range podList.Items {
-			if pod.DeletionTimestamp == nil {
-				return &pod, nil
-			}
-		}
-		err = fmt.Errorf("all pod with primary role has deletion timestamp")
-		return &(podList.Items[0]), err
-	}
-	err = fmt.Errorf("no primary found")
-	return &corev1.Pod{}, err
 }

--- a/tests/utils/backup.go
+++ b/tests/utils/backup.go
@@ -17,8 +17,8 @@ limitations under the License.
 package utils
 
 import (
-	"encoding/json"
 	"fmt"
+	"github.com/onsi/ginkgo/v2"
 	"os"
 
 	volumesnapshot "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
@@ -159,93 +159,6 @@ func CreateClusterFromBackupUsingPITR(
 	return cluster, nil
 }
 
-// CreateClusterFromExternalClusterBackupWithPITROnAzure creates a cluster on Azure, starting from an external cluster
-// backup with PITR
-func CreateClusterFromExternalClusterBackupWithPITROnAzure(
-	namespace,
-	externalClusterName,
-	sourceClusterName,
-	targetTime,
-	storageCredentialsSecretName,
-	azStorageAccount,
-	azBlobContainer string,
-	env *TestingEnvironment,
-) (*apiv1.Cluster, error) {
-	storageClassName := os.Getenv("E2E_DEFAULT_STORAGE_CLASS")
-	destinationPath := fmt.Sprintf("https://%v.blob.core.windows.net/%v/",
-		azStorageAccount, azBlobContainer)
-
-	restoreCluster := &apiv1.Cluster{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      externalClusterName,
-			Namespace: namespace,
-		},
-		Spec: apiv1.ClusterSpec{
-			Instances: 3,
-
-			StorageConfiguration: apiv1.StorageConfiguration{
-				Size:         "1Gi",
-				StorageClass: &storageClassName,
-			},
-
-			PostgresConfiguration: apiv1.PostgresConfiguration{
-				Parameters: map[string]string{
-					"log_checkpoints":             "on",
-					"log_lock_waits":              "on",
-					"log_min_duration_statement":  "1000",
-					"log_statement":               "ddl",
-					"log_temp_files":              "1024",
-					"log_autovacuum_min_duration": "1s",
-					"log_replication_commands":    "on",
-				},
-			},
-
-			Bootstrap: &apiv1.BootstrapConfiguration{
-				Recovery: &apiv1.BootstrapRecovery{
-					Source: sourceClusterName,
-					RecoveryTarget: &apiv1.RecoveryTarget{
-						TargetTime: targetTime,
-					},
-				},
-			},
-
-			ExternalClusters: []apiv1.ExternalCluster{
-				{
-					Name: sourceClusterName,
-					BarmanObjectStore: &apiv1.BarmanObjectStoreConfiguration{
-						DestinationPath: destinationPath,
-						BarmanCredentials: apiv1.BarmanCredentials{
-							Azure: &apiv1.AzureCredentials{
-								StorageAccount: &apiv1.SecretKeySelector{
-									LocalObjectReference: apiv1.LocalObjectReference{
-										Name: storageCredentialsSecretName,
-									},
-									Key: "ID",
-								},
-								StorageKey: &apiv1.SecretKeySelector{
-									LocalObjectReference: apiv1.LocalObjectReference{
-										Name: storageCredentialsSecretName,
-									},
-									Key: "KEY",
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-	obj, err := CreateObject(env, restoreCluster)
-	if err != nil {
-		return nil, err
-	}
-	cluster, ok := obj.(*apiv1.Cluster)
-	if !ok {
-		return nil, fmt.Errorf("created object is not of type cluster: %T, %v", obj, obj)
-	}
-	return cluster, nil
-}
-
 // CreateClusterFromExternalClusterBackupWithPITROnMinio creates a cluster on Minio, starting from an external cluster
 // backup with PITR
 func CreateClusterFromExternalClusterBackupWithPITROnMinio(
@@ -333,143 +246,6 @@ func CreateClusterFromExternalClusterBackupWithPITROnMinio(
 		return nil, fmt.Errorf("created object is not of type cluster: %T, %v", obj, obj)
 	}
 	return cluster, nil
-}
-
-// CreateClusterFromExternalClusterBackupWithPITROnAzurite creates a cluster with Azurite, starting from an external
-// cluster backup with PITR
-func CreateClusterFromExternalClusterBackupWithPITROnAzurite(
-	namespace,
-	externalClusterName,
-	sourceClusterName,
-	targetTime string,
-	env *TestingEnvironment,
-) (*apiv1.Cluster, error) {
-	storageClassName := os.Getenv("E2E_DEFAULT_STORAGE_CLASS")
-	DestinationPath := fmt.Sprintf("https://azurite:10000/storageaccountname/%v", sourceClusterName)
-
-	restoreCluster := &apiv1.Cluster{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      externalClusterName,
-			Namespace: namespace,
-		},
-		Spec: apiv1.ClusterSpec{
-			Instances: 3,
-
-			StorageConfiguration: apiv1.StorageConfiguration{
-				Size:         "1Gi",
-				StorageClass: &storageClassName,
-			},
-
-			PostgresConfiguration: apiv1.PostgresConfiguration{
-				Parameters: map[string]string{
-					"log_checkpoints":             "on",
-					"log_lock_waits":              "on",
-					"log_min_duration_statement":  "1000",
-					"log_statement":               "ddl",
-					"log_temp_files":              "1024",
-					"log_autovacuum_min_duration": "1s",
-					"log_replication_commands":    "on",
-				},
-			},
-
-			Bootstrap: &apiv1.BootstrapConfiguration{
-				Recovery: &apiv1.BootstrapRecovery{
-					Source: sourceClusterName,
-					RecoveryTarget: &apiv1.RecoveryTarget{
-						TargetTime: targetTime,
-					},
-				},
-			},
-
-			ExternalClusters: []apiv1.ExternalCluster{
-				{
-					Name: sourceClusterName,
-					BarmanObjectStore: &apiv1.BarmanObjectStoreConfiguration{
-						DestinationPath: DestinationPath,
-						EndpointCA: &apiv1.SecretKeySelector{
-							LocalObjectReference: apiv1.LocalObjectReference{
-								Name: "azurite-ca-secret",
-							},
-							Key: "ca.crt",
-						},
-						BarmanCredentials: apiv1.BarmanCredentials{
-							Azure: &apiv1.AzureCredentials{
-								ConnectionString: &apiv1.SecretKeySelector{
-									LocalObjectReference: apiv1.LocalObjectReference{
-										Name: "azurite",
-									},
-									Key: "AZURE_CONNECTION_STRING",
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-	obj, err := CreateObject(env, restoreCluster)
-	if err != nil {
-		return nil, err
-	}
-	cluster, ok := obj.(*apiv1.Cluster)
-	if !ok {
-		return nil, fmt.Errorf("created object is not of type cluster: %T, %v", obj, obj)
-	}
-	return cluster, nil
-}
-
-// ComposeAzBlobListAzuriteCmd builds the Azure storage blob list command for Azurite
-func ComposeAzBlobListAzuriteCmd(clusterName, path string) string {
-	return fmt.Sprintf("az storage blob list --container-name %v --query \"[?contains(@.name, \\`%v\\`)].name\" "+
-		"--connection-string $AZURE_CONNECTION_STRING",
-		clusterName, path)
-}
-
-// ComposeAzBlobListCmd builds the Azure storage blob list command
-func ComposeAzBlobListCmd(
-	configuration AzureConfiguration,
-	clusterName,
-	path string,
-) string {
-	return fmt.Sprintf("az storage blob list --account-name %v  "+
-		"--account-key %v  "+
-		"--container-name %v  "+
-		"--prefix %v/  "+
-		"--query \"[?contains(@.name, \\`%v\\`)].name\"",
-		configuration.StorageAccount, configuration.StorageKey, configuration.BlobContainer, clusterName, path)
-}
-
-// CountFilesOnAzureBlobStorage counts files on Azure Blob storage
-func CountFilesOnAzureBlobStorage(
-	configuration AzureConfiguration,
-	clusterName,
-	path string,
-) (int, error) {
-	azBlobListCmd := ComposeAzBlobListCmd(configuration, clusterName, path)
-	out, _, err := RunUnchecked(azBlobListCmd)
-	if err != nil {
-		return -1, err
-	}
-	var arr []string
-	err = json.Unmarshal([]byte(out), &arr)
-	return len(arr), err
-}
-
-// CountFilesOnAzuriteBlobStorage counts files on Azure Blob storage. using Azurite
-func CountFilesOnAzuriteBlobStorage(
-	namespace,
-	clusterName,
-	path string,
-) (int, error) {
-	azBlobListCmd := ComposeAzBlobListAzuriteCmd(clusterName, path)
-	out, _, err := RunUnchecked(fmt.Sprintf("kubectl exec -n %v az-cli "+
-		"-- /bin/bash -c '%v'", namespace, azBlobListCmd))
-	if err != nil {
-		return -1, err
-	}
-	var arr []string
-	err = json.Unmarshal([]byte(out), &arr)
-	return len(arr), err
 }
 
 // GetConditionsInClusterStatus get conditions values as given type from cluster object status
@@ -592,4 +368,17 @@ func (env TestingEnvironment) GetVolumeSnapshot(
 		return nil, err
 	}
 	return volumeSnapshot, nil
+}
+
+func AssertBackupConditionInClusterStatus(env *TestingEnvironment, namespace, clusterName string) {
+	ginkgo.By(fmt.Sprintf("waiting for backup condition status in cluster '%v'", clusterName), func() {
+		Eventually(func() (string, error) {
+			getBackupCondition, err := GetConditionsInClusterStatus(
+				namespace, clusterName, env, apiv1.ConditionBackup)
+			if err != nil {
+				return "", err
+			}
+			return string(getBackupCondition.Status), nil
+		}, 300, 5).Should(BeEquivalentTo("True"))
+	})
 }

--- a/tests/utils/backup.go
+++ b/tests/utils/backup.go
@@ -18,7 +18,6 @@ package utils
 
 import (
 	"fmt"
-	"github.com/onsi/ginkgo/v2"
 	"os"
 
 	volumesnapshot "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
@@ -27,7 +26,8 @@ import (
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 
-	. "github.com/onsi/gomega" // nolint
+	. "github.com/onsi/ginkgo/v2" // nolint
+	. "github.com/onsi/gomega"    // nolint
 )
 
 // ExecuteBackup performs a backup and checks the backup status
@@ -370,8 +370,10 @@ func (env TestingEnvironment) GetVolumeSnapshot(
 	return volumeSnapshot, nil
 }
 
+// AssertBackupConditionInClusterStatus check that the backup condition in the Cluster's Status
+// eventually returns true
 func AssertBackupConditionInClusterStatus(env *TestingEnvironment, namespace, clusterName string) {
-	ginkgo.By(fmt.Sprintf("waiting for backup condition status in cluster '%v'", clusterName), func() {
+	By(fmt.Sprintf("waiting for backup condition status in cluster '%v'", clusterName), func() {
 		Eventually(func() (string, error) {
 			getBackupCondition, err := GetConditionsInClusterStatus(
 				namespace, clusterName, env, apiv1.ConditionBackup)

--- a/tests/utils/cluster.go
+++ b/tests/utils/cluster.go
@@ -238,33 +238,6 @@ func (env TestingEnvironment) GetClusterPodList(namespace string, clusterName st
 	return podList, err
 }
 
-// GetClusterPrimary gets the primary pod of a cluster
-func (env TestingEnvironment) GetClusterPrimary(namespace string, clusterName string) (*corev1.Pod, error) {
-	podList := &corev1.PodList{}
-
-	err := GetObjectList(&env, podList, client.InNamespace(namespace),
-		client.MatchingLabels{
-			utils.ClusterLabelName:             clusterName,
-			utils.ClusterInstanceRoleLabelName: specs.ClusterRoleLabelPrimary,
-		},
-	)
-	if err != nil {
-		return &corev1.Pod{}, err
-	}
-	if len(podList.Items) > 0 {
-		// if there are multiple, get the one without deletion timestamp
-		for _, pod := range podList.Items {
-			if pod.DeletionTimestamp == nil {
-				return &pod, nil
-			}
-		}
-		err = fmt.Errorf("all pod with primary role has deletion timestamp")
-		return &(podList.Items[0]), err
-	}
-	err = fmt.Errorf("no primary found")
-	return &corev1.Pod{}, err
-}
-
 // GetClusterReplicas gets a slice containing all the replica pods of a cluster
 func (env TestingEnvironment) GetClusterReplicas(namespace string, clusterName string) (*corev1.PodList, error) {
 	podList := &corev1.PodList{}

--- a/tests/utils/cluster.go
+++ b/tests/utils/cluster.go
@@ -238,6 +238,33 @@ func (env TestingEnvironment) GetClusterPodList(namespace string, clusterName st
 	return podList, err
 }
 
+// GetClusterPrimary gets the primary pod of a cluster
+func (env TestingEnvironment) GetClusterPrimary(namespace string, clusterName string) (*corev1.Pod, error) {
+	podList := &corev1.PodList{}
+
+	err := GetObjectList(&env, podList, client.InNamespace(namespace),
+		client.MatchingLabels{
+			utils.ClusterLabelName:             clusterName,
+			utils.ClusterInstanceRoleLabelName: specs.ClusterRoleLabelPrimary,
+		},
+	)
+	if err != nil {
+		return &corev1.Pod{}, err
+	}
+	if len(podList.Items) > 0 {
+		// if there are multiple, get the one without deletion timestamp
+		for _, pod := range podList.Items {
+			if pod.DeletionTimestamp == nil {
+				return &pod, nil
+			}
+		}
+		err = fmt.Errorf("all pod with primary role has deletion timestamp")
+		return &(podList.Items[0]), err
+	}
+	err = fmt.Errorf("no primary found")
+	return &corev1.Pod{}, err
+}
+
 // GetClusterReplicas gets a slice containing all the replica pods of a cluster
 func (env TestingEnvironment) GetClusterReplicas(namespace string, clusterName string) (*corev1.PodList, error) {
 	podList := &corev1.PodList{}

--- a/tests/utils/minio/minio.go
+++ b/tests/utils/minio/minio.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -635,4 +636,13 @@ func CleanFiles(minioEnv *Env, path string) (string, error) {
 		return "", err
 	}
 	return strings.Trim(stdout, "\n"), nil
+}
+
+// GetFilePath gets the MinIO file string for WAL/backup objects in a configured bucket
+func GetFilePath(serverName, fileName string) string {
+	// the * regexes enable matching these typical paths:
+	// 	minio/backups/serverName/base/20220618T140300/data.tar
+	// 	minio/backups/serverName/wals/0000000100000000/000000010000000000000002.gz
+	//  minio/backups/serverName/wals/00000002.history.gz
+	return filepath.Join("*", serverName, "*", fileName)
 }

--- a/tests/utils/secrets.go
+++ b/tests/utils/secrets.go
@@ -21,6 +21,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -100,4 +101,31 @@ func GetCredentials(
 	username := string(secret.Data["username"])
 	password := string(secret.Data["password"])
 	return username, password, nil
+}
+
+// CreateObjectStorageSecret generates an Opaque Secret with a given ID and Key
+func CreateObjectStorageSecret(
+	namespace string,
+	secretName string,
+	id string,
+	key string,
+	env *TestingEnvironment,
+) (*corev1.Secret, error) {
+	targetSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: namespace,
+		},
+		StringData: map[string]string{
+			"ID":  id,
+			"KEY": key,
+		},
+		Type: corev1.SecretTypeOpaque,
+	}
+	obj, err := CreateObject(env, targetSecret)
+	if err != nil {
+		return nil, err
+	}
+
+	return obj.(*corev1.Secret), nil
 }


### PR DESCRIPTION
The backup and restore tests were living in the same file for all the
different backend (minio, azurite, azure) therefore we had a big
confusing file, now, every backend has is own file with is own
functions to work with.

Closes #5632 