### PR TITLE
docs(fix): add missing links to APIs machinery and barman-cloud

### DIFF
--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -24,6 +24,10 @@ externalPackages:
     target: https://pkg.go.dev/time#Duration
   - match: ^k8s\.io/(api|apimachinery/pkg/apis)/
     target: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#{{- lower .TypeIdentifier -}}-{{- arrIndex .PackageSegments -1 -}}-{{- arrIndex .PackageSegments -2 -}}
+  - match: ^github\.com/cloudnative-pg/machinery
+    target: https://pkg.go.dev/github.com/cloudnative-pg/machinery/pkg/api/#{{- .TypeIdentifier }}
+  - match: ^github\.com/cloudnative-pg/barman-cloud
+    target: https://pkg.go.dev/github.com/cloudnative-pg/barman-cloud/pkg/api/#{{- .TypeIdentifier }}
 
 hideTypePatterns:
   - "ParseError$"

--- a/docs/src/cloudnative-pg.v1.md
+++ b/docs/src/cloudnative-pg.v1.md
@@ -366,7 +366,7 @@ documentation</p>
 </td>
 </tr>
 <tr><td><code>barmanObjectStore</code><br/>
-<i>github.com/cloudnative-pg/barman-cloud/pkg/api.BarmanObjectStoreConfiguration</i>
+<a href="https://pkg.go.dev/github.com/cloudnative-pg/barman-cloud/pkg/api/#BarmanObjectStoreConfiguration"><i>github.com/cloudnative-pg/barman-cloud/pkg/api.BarmanObjectStoreConfiguration</i></a>
 </td>
 <td>
    <p>The configuration for the barman-cloud tool suite</p>
@@ -543,13 +543,13 @@ information that could be needed to correctly restore it.</p>
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>LocalObjectReference</code><br/>
-<i>github.com/cloudnative-pg/machinery/pkg/api.LocalObjectReference</i>
+<a href="https://pkg.go.dev/github.com/cloudnative-pg/machinery/pkg/api/#LocalObjectReference"><i>github.com/cloudnative-pg/machinery/pkg/api.LocalObjectReference</i></a>
 </td>
 <td>(Members of <code>LocalObjectReference</code> are embedded into this type.)
    <span class="text-muted">No description provided.</span></td>
 </tr>
 <tr><td><code>endpointCA</code><br/>
-<i>github.com/cloudnative-pg/machinery/pkg/api.SecretKeySelector</i>
+<a href="https://pkg.go.dev/github.com/cloudnative-pg/machinery/pkg/api/#SecretKeySelector"><i>github.com/cloudnative-pg/machinery/pkg/api.SecretKeySelector</i></a>
 </td>
 <td>
    <p>EndpointCA store the CA bundle of the barman endpoint.
@@ -575,7 +575,7 @@ errors with certificate issuer and barman-cloud-wal-archive.</p>
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>cluster</code> <B>[Required]</B><br/>
-<i>github.com/cloudnative-pg/machinery/pkg/api.LocalObjectReference</i>
+<a href="https://pkg.go.dev/github.com/cloudnative-pg/machinery/pkg/api/#LocalObjectReference"><i>github.com/cloudnative-pg/machinery/pkg/api.LocalObjectReference</i></a>
 </td>
 <td>
    <p>The cluster to backup</p>
@@ -643,14 +643,14 @@ Overrides the default settings specified in the cluster '.backup.volumeSnapshot.
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>BarmanCredentials</code><br/>
-<i>github.com/cloudnative-pg/barman-cloud/pkg/api.BarmanCredentials</i>
+<a href="https://pkg.go.dev/github.com/cloudnative-pg/barman-cloud/pkg/api/#BarmanCredentials"><i>github.com/cloudnative-pg/barman-cloud/pkg/api.BarmanCredentials</i></a>
 </td>
 <td>(Members of <code>BarmanCredentials</code> are embedded into this type.)
    <p>The potential credentials for each cloud provider</p>
 </td>
 </tr>
 <tr><td><code>endpointCA</code><br/>
-<i>github.com/cloudnative-pg/machinery/pkg/api.SecretKeySelector</i>
+<a href="https://pkg.go.dev/github.com/cloudnative-pg/machinery/pkg/api/#SecretKeySelector"><i>github.com/cloudnative-pg/machinery/pkg/api.SecretKeySelector</i></a>
 </td>
 <td>
    <p>EndpointCA store the CA bundle of the barman endpoint.
@@ -912,7 +912,7 @@ by applications. Defaults to the value of the <code>database</code> key.</p>
 </td>
 </tr>
 <tr><td><code>secret</code><br/>
-<i>github.com/cloudnative-pg/machinery/pkg/api.LocalObjectReference</i>
+<a href="https://pkg.go.dev/github.com/cloudnative-pg/machinery/pkg/api/#LocalObjectReference"><i>github.com/cloudnative-pg/machinery/pkg/api.LocalObjectReference</i></a>
 </td>
 <td>
    <p>Name of the secret containing the initial credentials for the
@@ -1082,7 +1082,7 @@ by applications. Defaults to the value of the <code>database</code> key.</p>
 </td>
 </tr>
 <tr><td><code>secret</code><br/>
-<i>github.com/cloudnative-pg/machinery/pkg/api.LocalObjectReference</i>
+<a href="https://pkg.go.dev/github.com/cloudnative-pg/machinery/pkg/api/#LocalObjectReference"><i>github.com/cloudnative-pg/machinery/pkg/api.LocalObjectReference</i></a>
 </td>
 <td>
    <p>Name of the secret containing the initial credentials for the
@@ -1178,7 +1178,7 @@ by applications. Defaults to the value of the <code>database</code> key.</p>
 </td>
 </tr>
 <tr><td><code>secret</code><br/>
-<i>github.com/cloudnative-pg/machinery/pkg/api.LocalObjectReference</i>
+<a href="https://pkg.go.dev/github.com/cloudnative-pg/machinery/pkg/api/#LocalObjectReference"><i>github.com/cloudnative-pg/machinery/pkg/api.LocalObjectReference</i></a>
 </td>
 <td>
    <p>Name of the secret containing the initial credentials for the
@@ -1490,7 +1490,7 @@ Undefined or 0 disable synchronous replication.</p>
 </td>
 </tr>
 <tr><td><code>superuserSecret</code><br/>
-<i>github.com/cloudnative-pg/machinery/pkg/api.LocalObjectReference</i>
+<a href="https://pkg.go.dev/github.com/cloudnative-pg/machinery/pkg/api/#LocalObjectReference"><i>github.com/cloudnative-pg/machinery/pkg/api.LocalObjectReference</i></a>
 </td>
 <td>
    <p>The secret containing the superuser password. If not defined a new
@@ -1517,7 +1517,7 @@ user by setting it to <code>NULL</code>. Disabled by default.</p>
 </td>
 </tr>
 <tr><td><code>imagePullSecrets</code><br/>
-<i>[]github.com/cloudnative-pg/machinery/pkg/api.LocalObjectReference</i>
+<a href="https://pkg.go.dev/github.com/cloudnative-pg/machinery/pkg/api/#LocalObjectReference"><i>[]github.com/cloudnative-pg/machinery/pkg/api.LocalObjectReference</i></a>
 </td>
 <td>
    <p>The list of pull secrets to be used to pull the images</p>
@@ -2577,7 +2577,7 @@ secure and efficient password management for external clusters.</p>
 </td>
 </tr>
 <tr><td><code>barmanObjectStore</code><br/>
-<i>github.com/cloudnative-pg/barman-cloud/pkg/api.BarmanObjectStoreConfiguration</i>
+<a href="https://pkg.go.dev/github.com/cloudnative-pg/barman-cloud/pkg/api/#BarmanObjectStoreConfiguration"><i>github.com/cloudnative-pg/barman-cloud/pkg/api.BarmanObjectStoreConfiguration</i></a>
 </td>
 <td>
    <p>The configuration for the barman-cloud tool suite</p>
@@ -3167,14 +3167,14 @@ Default: false.</p>
 </td>
 </tr>
 <tr><td><code>customQueriesConfigMap</code><br/>
-<i>[]github.com/cloudnative-pg/machinery/pkg/api.ConfigMapKeySelector</i>
+<a href="https://pkg.go.dev/github.com/cloudnative-pg/machinery/pkg/api/#ConfigMapKeySelector"><i>[]github.com/cloudnative-pg/machinery/pkg/api.ConfigMapKeySelector</i></a>
 </td>
 <td>
    <p>The list of config maps containing the custom queries</p>
 </td>
 </tr>
 <tr><td><code>customQueriesSecret</code><br/>
-<i>[]github.com/cloudnative-pg/machinery/pkg/api.SecretKeySelector</i>
+<a href="https://pkg.go.dev/github.com/cloudnative-pg/machinery/pkg/api/#SecretKeySelector"><i>[]github.com/cloudnative-pg/machinery/pkg/api.SecretKeySelector</i></a>
 </td>
 <td>
    <p>The list of secrets containing the custom queries</p>
@@ -3409,7 +3409,7 @@ by pgbouncer</p>
 </td>
 </tr>
 <tr><td><code>authQuerySecret</code><br/>
-<i>github.com/cloudnative-pg/machinery/pkg/api.LocalObjectReference</i>
+<a href="https://pkg.go.dev/github.com/cloudnative-pg/machinery/pkg/api/#LocalObjectReference"><i>github.com/cloudnative-pg/machinery/pkg/api.LocalObjectReference</i></a>
 </td>
 <td>
    <p>The credentials of the user that need to be used for the authentication
@@ -3707,7 +3707,7 @@ part for now.</p>
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>cluster</code> <B>[Required]</B><br/>
-<i>github.com/cloudnative-pg/machinery/pkg/api.LocalObjectReference</i>
+<a href="https://pkg.go.dev/github.com/cloudnative-pg/machinery/pkg/api/#LocalObjectReference"><i>github.com/cloudnative-pg/machinery/pkg/api.LocalObjectReference</i></a>
 </td>
 <td>
    <p>This is the cluster reference on which the Pooler will work.
@@ -4205,7 +4205,7 @@ Reference: https://www.postgresql.org/docs/current/sql-createrole.html</p>
 </td>
 </tr>
 <tr><td><code>passwordSecret</code><br/>
-<i>github.com/cloudnative-pg/machinery/pkg/api.LocalObjectReference</i>
+<a href="https://pkg.go.dev/github.com/cloudnative-pg/machinery/pkg/api/#LocalObjectReference"><i>github.com/cloudnative-pg/machinery/pkg/api.LocalObjectReference</i></a>
 </td>
 <td>
    <p>Secret containing the password of the role (if present)
@@ -4332,14 +4332,14 @@ in their respective arrays.</p>
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>secretRefs</code><br/>
-<i>[]github.com/cloudnative-pg/machinery/pkg/api.SecretKeySelector</i>
+<a href="https://pkg.go.dev/github.com/cloudnative-pg/machinery/pkg/api/#SecretKeySelector"><i>[]github.com/cloudnative-pg/machinery/pkg/api.SecretKeySelector</i></a>
 </td>
 <td>
    <p>SecretRefs holds a list of references to Secrets</p>
 </td>
 </tr>
 <tr><td><code>configMapRefs</code><br/>
-<i>[]github.com/cloudnative-pg/machinery/pkg/api.ConfigMapKeySelector</i>
+<a href="https://pkg.go.dev/github.com/cloudnative-pg/machinery/pkg/api/#ConfigMapKeySelector"><i>[]github.com/cloudnative-pg/machinery/pkg/api.ConfigMapKeySelector</i></a>
 </td>
 <td>
    <p>ConfigMapRefs holds a list of references to ConfigMaps</p>
@@ -4386,7 +4386,7 @@ see https://pkg.go.dev/github.com/robfig/cron#hdr-CRON_Expression_Format</p>
 </td>
 </tr>
 <tr><td><code>cluster</code> <B>[Required]</B><br/>
-<i>github.com/cloudnative-pg/machinery/pkg/api.LocalObjectReference</i>
+<a href="https://pkg.go.dev/github.com/cloudnative-pg/machinery/pkg/api/#LocalObjectReference"><i>github.com/cloudnative-pg/machinery/pkg/api.LocalObjectReference</i></a>
 </td>
 <td>
    <p>The cluster to backup</p>


### PR DESCRIPTION
Running the `make apidoc` was throwing the following error: 
`External link source for` this is related to a missing configuration
to properly point the URLs in the documentation, this will add the
proper URLs for the machinery and barman-cloud APIs