### PR TITLE
test(e2e): refactor assertions to create, insert and validate data

### DIFF
--- a/tests/e2e/backup_restore_test.go
+++ b/tests/e2e/backup_restore_test.go
@@ -123,7 +123,13 @@ var _ = Describe("Backup and restore", Label(tests.LabelBackupRestore), func() {
 			AssertCreationOfTestDataForTargetDB(env, namespace, clusterName, targetDBSecret, testTableName)
 
 			// Write a table and some data on the "app" database
-			AssertCreateTestData(env, namespace, clusterName, tableName)
+			tableLocator := TableLocator{
+				Namespace:    namespace,
+				ClusterName:  clusterName,
+				DatabaseName: testUtils.AppDBName,
+				TableName:    tableName,
+			}
+			AssertCreateTestData(env, tableLocator)
 
 			AssertArchiveWalOnMinio(namespace, clusterName, clusterName)
 			latestTar := minioPath(clusterName, "data.tar")
@@ -269,7 +275,13 @@ var _ = Describe("Backup and restore", Label(tests.LabelBackupRestore), func() {
 			AssertCreationOfTestDataForTargetDB(env, namespace, targetClusterName, targetDBSecret, testTableName)
 
 			// Write a table and some data on the "app" database
-			AssertCreateTestData(env, namespace, targetClusterName, tableName)
+			tableLocator := TableLocator{
+				Namespace:    namespace,
+				ClusterName:  targetClusterName,
+				DatabaseName: testUtils.AppDBName,
+				TableName:    tableName,
+			}
+			AssertCreateTestData(env, tableLocator)
 
 			AssertArchiveWalOnMinio(namespace, targetClusterName, targetClusterName)
 			latestTar := minioPath(targetClusterName, "data.tar")
@@ -313,7 +325,13 @@ var _ = Describe("Backup and restore", Label(tests.LabelBackupRestore), func() {
 			AssertCreationOfTestDataForTargetDB(env, namespace, targetClusterName, targetDBSecret, testTableName)
 
 			// Write a table and some data on the "app" database
-			AssertCreateTestData(env, namespace, targetClusterName, tableName)
+			tableLocator := TableLocator{
+				Namespace:    namespace,
+				ClusterName:  targetClusterName,
+				DatabaseName: testUtils.AppDBName,
+				TableName:    tableName,
+			}
+			AssertCreateTestData(env, tableLocator)
 
 			AssertArchiveWalOnMinio(namespace, targetClusterName, targetClusterName)
 			latestTar := minioPath(targetClusterName, "data.tar")
@@ -366,7 +384,13 @@ var _ = Describe("Backup and restore", Label(tests.LabelBackupRestore), func() {
 			AssertCreationOfTestDataForTargetDB(env, namespace, customClusterName, targetDBSecret, testTableName)
 
 			// Write a table and some data on the "app" database
-			AssertCreateTestData(env, namespace, customClusterName, tableName)
+			tableLocator := TableLocator{
+				Namespace:    namespace,
+				ClusterName:  customClusterName,
+				DatabaseName: testUtils.AppDBName,
+				TableName:    tableName,
+			}
+			AssertCreateTestData(env, tableLocator)
 
 			AssertArchiveWalOnMinio(namespace, customClusterName, clusterServerName)
 
@@ -539,7 +563,13 @@ var _ = Describe("Backup and restore", Label(tests.LabelBackupRestore), func() {
 		// be there
 		It("backs up and restore a cluster", func() {
 			// Write a table and some data on the "app" database
-			AssertCreateTestData(env, namespace, clusterName, tableName)
+			tableLocator := TableLocator{
+				Namespace:    namespace,
+				ClusterName:  clusterName,
+				DatabaseName: testUtils.AppDBName,
+				TableName:    tableName,
+			}
+			AssertCreateTestData(env, tableLocator)
 			AssertArchiveWalOnAzureBlob(namespace, clusterName, env.AzureConfiguration)
 			By("uploading a backup", func() {
 				// We create a backup
@@ -821,7 +851,13 @@ var _ = Describe("Clusters Recovery From Barman Object Store", Label(tests.Label
 			Expect(err).ToNot(HaveOccurred())
 
 			// Write a table and some data on the "app" database
-			AssertCreateTestData(env, namespace, clusterName, tableName)
+			tableLocator := TableLocator{
+				Namespace:    namespace,
+				ClusterName:  clusterName,
+				DatabaseName: testUtils.AppDBName,
+				TableName:    tableName,
+			}
+			AssertCreateTestData(env, tableLocator)
 
 			AssertArchiveWalOnMinio(namespace, clusterName, clusterName)
 
@@ -854,7 +890,13 @@ var _ = Describe("Clusters Recovery From Barman Object Store", Label(tests.Label
 			AssertClusterRestore(namespace, externalClusterFileMinio, tableName)
 
 			// verify test data on restored external cluster
-			AssertDataExpectedCount(env, namespace, externalClusterName, tableName, 2)
+			tableLocator = TableLocator{
+				Namespace:    namespace,
+				ClusterName:  externalClusterName,
+				DatabaseName: testUtils.AppDBName,
+				TableName:    tableName,
+			}
+			AssertDataExpectedCount(env, tableLocator, 2)
 
 			By("deleting the restored cluster", func() {
 				err = DeleteResourcesFromFile(namespace, externalClusterFileMinio)
@@ -882,6 +924,7 @@ var _ = Describe("Clusters Recovery From Barman Object Store", Label(tests.Label
 					apiv1.ApplicationUserSecretSuffix,
 				)
 				defer func() {
+					_ = conn.Close()
 					forward.Close()
 				}()
 				Expect(err).ToNot(HaveOccurred())
@@ -919,7 +962,13 @@ var _ = Describe("Clusters Recovery From Barman Object Store", Label(tests.Label
 
 		It("restore cluster from barman object using replica option in spec", func() {
 			// Write a table and some data on the "app" database
-			AssertCreateTestData(env, namespace, clusterName, "for_restore_repl")
+			tableLocator := TableLocator{
+				Namespace:    namespace,
+				ClusterName:  clusterName,
+				DatabaseName: testUtils.AppDBName,
+				TableName:    "for_restore_repl",
+			}
+			AssertCreateTestData(env, tableLocator)
 
 			AssertArchiveWalOnMinio(namespace, clusterName, clusterName)
 
@@ -974,7 +1023,13 @@ var _ = Describe("Clusters Recovery From Barman Object Store", Label(tests.Label
 
 			It("restores a cluster from barman object using 'barmanObjectStore' option in 'externalClusters' section", func() {
 				// Write a table and some data on the "app" database
-				AssertCreateTestData(env, namespace, clusterName, tableName)
+				tableLocator := TableLocator{
+					Namespace:    namespace,
+					ClusterName:  clusterName,
+					DatabaseName: testUtils.AppDBName,
+					TableName:    tableName,
+				}
+				AssertCreateTestData(env, tableLocator)
 				AssertArchiveWalOnAzureBlob(namespace, clusterName, env.AzureConfiguration)
 
 				By("backing up a cluster and verifying it exists on azure blob storage", func() {
@@ -1060,7 +1115,13 @@ var _ = Describe("Clusters Recovery From Barman Object Store", Label(tests.Label
 
 			It("restores cluster from barman object using 'barmanObjectStore' option in 'externalClusters' section", func() {
 				// Write a table and some data on the "app" database
-				AssertCreateTestData(env, namespace, clusterName, tableName)
+				tableLocator := TableLocator{
+					Namespace:    namespace,
+					ClusterName:  clusterName,
+					DatabaseName: testUtils.AppDBName,
+					TableName:    tableName,
+				}
+				AssertCreateTestData(env, tableLocator)
 
 				// Create a WAL on the primary and check if it arrives in the
 				// Azure Blob Storage within a short time

--- a/tests/e2e/cluster_monolithic_test.go
+++ b/tests/e2e/cluster_monolithic_test.go
@@ -84,6 +84,7 @@ var _ = Describe("Imports with Monolithic Approach", Label(tests.LabelImportingD
 				apiv1.SuperUserSecretSuffix,
 			)
 			defer func() {
+				_ = conn.Close()
 				forward.Close()
 			}()
 			Expect(err).ToNot(HaveOccurred())

--- a/tests/e2e/cluster_setup_test.go
+++ b/tests/e2e/cluster_setup_test.go
@@ -131,6 +131,7 @@ var _ = Describe("Cluster setup", Label(tests.LabelSmoke, tests.LabelBasic), fun
 				apiv1.ApplicationUserSecretSuffix,
 			)
 			defer func() {
+				_ = conn.Close()
 				forward.Close()
 			}()
 			Expect(err).NotTo(HaveOccurred())

--- a/tests/e2e/declarative_hibernation_test.go
+++ b/tests/e2e/declarative_hibernation_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/reconciler/hibernation"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 	"github.com/cloudnative-pg/cloudnative-pg/tests"
+	testsUtils "github.com/cloudnative-pg/cloudnative-pg/tests/utils"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -55,7 +56,13 @@ var _ = Describe("Cluster declarative hibernation", func() {
 		By("creating a new cluster", func() {
 			AssertCreateCluster(namespace, clusterName, sampleFileCluster, env)
 			// Write a table and some data on the "app" database
-			AssertCreateTestData(env, namespace, clusterName, tableName)
+			tableLocator := TableLocator{
+				Namespace:    namespace,
+				ClusterName:  clusterName,
+				DatabaseName: testsUtils.AppDBName,
+				TableName:    tableName,
+			}
+			AssertCreateTestData(env, tableLocator)
 		})
 
 		By("hibernating the new cluster", func() {
@@ -114,7 +121,13 @@ var _ = Describe("Cluster declarative hibernation", func() {
 		})
 
 		By("verifying the data has been preserved", func() {
-			AssertDataExpectedCount(env, namespace, clusterName, tableName, 2)
+			tableLocator := TableLocator{
+				Namespace:    namespace,
+				ClusterName:  clusterName,
+				DatabaseName: testsUtils.AppDBName,
+				TableName:    tableName,
+			}
+			AssertDataExpectedCount(env, tableLocator, 2)
 		})
 	})
 })

--- a/tests/e2e/disk_space_test.go
+++ b/tests/e2e/disk_space_test.go
@@ -73,22 +73,22 @@ var _ = Describe("Volume space unavailable", Label(tests.LabelStorage), func() {
 		By("writing something when no space is available", func() {
 			// Create the table used by the scenario
 			query := "CREATE TABLE diskspace AS SELECT generate_series(1, 1000000);"
-			_, _, err := env.ExecCommandWithPsqlClient(
-				namespace,
-				clusterName,
-				primaryPod,
-				apiv1.ApplicationUserSecretSuffix,
+			_, _, err := env.ExecQueryInInstancePod(
+				testsUtils.PodLocator{
+					Namespace: primaryPod.Namespace,
+					PodName:   primaryPod.Name,
+				},
 				testsUtils.AppDBName,
-				query,
-			)
+				query)
 			Expect(err).To(HaveOccurred())
+
 			query = "CHECKPOINT; SELECT pg_switch_wal(); CHECKPOINT"
 			_, _, err = env.ExecQueryInInstancePod(
 				testsUtils.PodLocator{
 					Namespace: primaryPod.Namespace,
 					PodName:   primaryPod.Name,
 				},
-				testsUtils.DatabaseName("postgres"),
+				testsUtils.PostgresDBName,
 				query)
 			Expect(err).To(HaveOccurred())
 		})
@@ -171,7 +171,7 @@ var _ = Describe("Volume space unavailable", Label(tests.LabelStorage), func() {
 					Namespace: primaryPod.Namespace,
 					PodName:   primaryPod.Name,
 				},
-				testsUtils.DatabaseName("postgres"),
+				testsUtils.PostgresDBName,
 				query)
 			Expect(err).NotTo(HaveOccurred())
 		})

--- a/tests/e2e/drain_node_test.go
+++ b/tests/e2e/drain_node_test.go
@@ -118,7 +118,13 @@ var _ = Describe("E2E Drain Node", Serial, Label(tests.LabelDisruptive, tests.La
 
 			// Load test data
 			oldPrimary := clusterName + "-1"
-			AssertCreateTestData(env, namespace, clusterName, "test")
+			tableLocator := TableLocator{
+				Namespace:    namespace,
+				ClusterName:  clusterName,
+				DatabaseName: testsUtils.AppDBName,
+				TableName:    "test",
+			}
+			AssertCreateTestData(env, tableLocator)
 
 			// We create a mapping between the pod names and the UIDs of
 			// their volumes. We do not expect the UIDs to change.
@@ -178,10 +184,7 @@ var _ = Describe("E2E Drain Node", Serial, Label(tests.LabelDisruptive, tests.La
 				}
 			})
 
-			// Expect the (previously created) test data to be available
-			primary, err := env.GetClusterPrimary(namespace, clusterName)
-			Expect(err).ToNot(HaveOccurred())
-			AssertDataExpectedCountWithDatabaseName(namespace, primary.Name, "app", "test", 2)
+			AssertDataExpectedCount(env, tableLocator, 2)
 			AssertClusterStandbysAreStreaming(namespace, clusterName, 120)
 		})
 
@@ -230,7 +233,13 @@ var _ = Describe("E2E Drain Node", Serial, Label(tests.LabelDisruptive, tests.La
 
 				// Load test data
 				oldPrimary := clusterName + "-1"
-				AssertCreateTestData(env, namespace, clusterName, "test")
+				tableLocator := TableLocator{
+					Namespace:    namespace,
+					ClusterName:  clusterName,
+					DatabaseName: testsUtils.AppDBName,
+					TableName:    "test",
+				}
+				AssertCreateTestData(env, tableLocator)
 
 				// We create a mapping between the pod names and the UIDs of
 				// their volumes. We do not expect the UIDs to change.
@@ -294,10 +303,7 @@ var _ = Describe("E2E Drain Node", Serial, Label(tests.LabelDisruptive, tests.La
 					}
 				})
 
-				// Expect the (previously created) test data to be available
-				primary, err := env.GetClusterPrimary(namespace, clusterName)
-				Expect(err).ToNot(HaveOccurred())
-				AssertDataExpectedCountWithDatabaseName(namespace, primary.Name, "app", "test", 2)
+				AssertDataExpectedCount(env, tableLocator, 2)
 				AssertClusterStandbysAreStreaming(namespace, clusterName, 120)
 			})
 		})
@@ -360,7 +366,13 @@ var _ = Describe("E2E Drain Node", Serial, Label(tests.LabelDisruptive, tests.La
 			})
 
 			// Load test data
-			AssertCreateTestData(env, namespace, clusterName, "test")
+			tableLocator := TableLocator{
+				Namespace:    namespace,
+				ClusterName:  clusterName,
+				DatabaseName: testsUtils.AppDBName,
+				TableName:    "test",
+			}
+			AssertCreateTestData(env, tableLocator)
 
 			// We uncordon a cordoned node. New pods can go there.
 			By("uncordon node for pod failover", func() {
@@ -396,10 +408,7 @@ var _ = Describe("E2E Drain Node", Serial, Label(tests.LabelDisruptive, tests.La
 				}, timeout).Should(Succeed())
 			})
 
-			// Expect the (previously created) test data to be available
-			primary, err := env.GetClusterPrimary(namespace, clusterName)
-			Expect(err).ToNot(HaveOccurred())
-			AssertDataExpectedCountWithDatabaseName(namespace, primary.Name, "app", "test", 2)
+			AssertDataExpectedCount(env, tableLocator, 2)
 			AssertClusterStandbysAreStreaming(namespace, clusterName, 120)
 			err = nodes.UncordonAllNodes(env)
 			Expect(err).ToNot(HaveOccurred())
@@ -433,9 +442,13 @@ var _ = Describe("E2E Drain Node", Serial, Label(tests.LabelDisruptive, tests.La
 				})
 
 				// Load test data
-				primary, err := env.GetClusterPrimary(namespace, clusterName)
-				Expect(err).ToNot(HaveOccurred())
-				AssertCreateTestData(env, namespace, clusterName, "test")
+				tableLocator := TableLocator{
+					Namespace:    namespace,
+					ClusterName:  clusterName,
+					DatabaseName: testsUtils.AppDBName,
+					TableName:    "test",
+				}
+				AssertCreateTestData(env, tableLocator)
 
 				// Drain the node containing the primary pod and store the list of running pods
 				_ = nodes.DrainPrimaryNode(namespace, clusterName,
@@ -458,7 +471,8 @@ var _ = Describe("E2E Drain Node", Serial, Label(tests.LabelDisruptive, tests.La
 					Expect(err).ToNot(HaveOccurred())
 				})
 
-				AssertDataExpectedCountWithDatabaseName(namespace, primary.Name, "app", "test", 2)
+				AssertClusterIsReady(namespace, clusterName, testTimeouts[testsUtils.ClusterIsReady], env)
+				AssertDataExpectedCount(env, tableLocator, 2)
 			})
 		})
 

--- a/tests/e2e/failover_test.go
+++ b/tests/e2e/failover_test.go
@@ -79,9 +79,15 @@ var _ = Describe("Failover", Label(tests.LabelSelfHealing), func() {
 
 			// Get the walreceiver pid
 			query := "SELECT pid FROM pg_stat_activity WHERE backend_type = 'walreceiver'"
-			out, _, err := env.EventuallyExecCommand(
-				env.Ctx, *pausedPod, specs.PostgresContainerName, &commandTimeout,
-				"psql", "-U", "postgres", "-tAc", query)
+			out, _, err := env.EventuallyExecQueryInInstancePod(
+				utils.PodLocator{
+					Namespace: pausedPod.Namespace,
+					PodName:   pausedPod.Name,
+				}, utils.PostgresDBName,
+				query,
+				RetryTimeout,
+				PollingTime,
+			)
 			Expect(err).ToNot(HaveOccurred())
 			pid = strings.Trim(out, "\n")
 
@@ -94,9 +100,15 @@ var _ = Describe("Failover", Label(tests.LabelSelfHealing), func() {
 			// We don't want to wait for the replication timeout.
 			query = fmt.Sprintf("SELECT pg_terminate_backend(pid) FROM pg_stat_replication "+
 				"WHERE application_name = '%v'", pausedReplica)
-			_, _, err = env.EventuallyExecCommand(
-				env.Ctx, *primaryPod, specs.PostgresContainerName, &commandTimeout,
-				"psql", "-U", "postgres", "-tAc", query)
+			_, _, err = env.EventuallyExecQueryInInstancePod(
+				utils.PodLocator{
+					Namespace: primaryPod.Namespace,
+					PodName:   primaryPod.Name,
+				}, utils.PostgresDBName,
+				query,
+				RetryTimeout,
+				PollingTime,
+			)
 			Expect(err).ToNot(HaveOccurred())
 
 			// Expect the primary to have lost connection with the stopped standby
@@ -114,28 +126,46 @@ var _ = Describe("Failover", Label(tests.LabelSelfHealing), func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// Gather the current WAL LSN
-			initialLSN, _, err := env.EventuallyExecCommand(
-				env.Ctx, *primaryPod, specs.PostgresContainerName, &commandTimeout,
-				"psql", "-U", "postgres", "-tAc", "SELECT pg_current_wal_lsn()")
+			initialLSN, _, err := env.EventuallyExecQueryInInstancePod(
+				utils.PodLocator{
+					Namespace: primaryPod.Namespace,
+					PodName:   primaryPod.Name,
+				}, utils.PostgresDBName,
+				"SELECT pg_current_wal_lsn()",
+				RetryTimeout,
+				PollingTime,
+			)
 			Expect(err).ToNot(HaveOccurred())
 
 			// Execute a checkpoint
-			_, _, err = env.EventuallyExecCommand(
-				env.Ctx, *primaryPod, specs.PostgresContainerName, &commandTimeout,
-				"psql", "-U", "postgres", "-tAc", "CHECKPOINT")
+			_, _, err = env.EventuallyExecQueryInInstancePod(
+				utils.PodLocator{
+					Namespace: primaryPod.Namespace,
+					PodName:   primaryPod.Name,
+				}, utils.PostgresDBName,
+				"CHECKPOINT",
+				RetryTimeout,
+				PollingTime,
+			)
 			Expect(err).ToNot(HaveOccurred())
 
+			query := fmt.Sprintf("SELECT true FROM pg_stat_replication "+
+				"WHERE application_name = '%v' AND replay_lsn > '%v'",
+				targetPrimary, strings.Trim(initialLSN, "\n"))
 			// The replay_lsn of the targetPrimary should be ahead
 			// of the one before the checkpoint
 			Eventually(func() (string, error) {
 				primaryPod, err = env.GetPod(namespace, currentPrimary)
 				Expect(err).ToNot(HaveOccurred())
-				query := fmt.Sprintf("SELECT true FROM pg_stat_replication "+
-					"WHERE application_name = '%v' AND replay_lsn > '%v'",
-					targetPrimary, strings.Trim(initialLSN, "\n"))
-				out, _, err := env.EventuallyExecCommand(
-					env.Ctx, *primaryPod, specs.PostgresContainerName, &commandTimeout,
-					"psql", "-U", "postgres", "-tAc", query)
+				out, _, err := env.EventuallyExecQueryInInstancePod(
+					utils.PodLocator{
+						Namespace: primaryPod.Namespace,
+						PodName:   primaryPod.Name,
+					}, utils.PostgresDBName,
+					query,
+					RetryTimeout,
+					PollingTime,
+				)
 				return strings.TrimSpace(out), err
 			}, RetryTimeout).Should(BeEquivalentTo("t"))
 		})

--- a/tests/e2e/fencing_test.go
+++ b/tests/e2e/fencing_test.go
@@ -70,7 +70,7 @@ var _ = Describe("Fencing", Label(tests.LabelPlugin), func() {
 	}
 
 	checkInstanceIsStreaming := func(instanceName, namespace string) {
-		timeout := time.Second * 10
+		query := "SELECT count(*) FROM pg_stat_wal_receiver"
 		Eventually(func() (int, error) {
 			err := env.Client.Get(env.Ctx,
 				ctrlclient.ObjectKey{Namespace: namespace, Name: instanceName},
@@ -78,8 +78,13 @@ var _ = Describe("Fencing", Label(tests.LabelPlugin), func() {
 			if err != nil {
 				return 0, err
 			}
-			out, _, err := env.ExecCommand(env.Ctx, pod, specs.PostgresContainerName, &timeout,
-				"psql", "-U", "postgres", "-tAc", "SELECT count(*) FROM pg_stat_wal_receiver")
+			out, _, err := env.ExecQueryInInstancePod(
+				testUtils.PodLocator{
+					Namespace: pod.Namespace,
+					PodName:   pod.Name,
+				},
+				testUtils.PostgresDBName,
+				query)
 			if err != nil {
 				return 0, err
 			}

--- a/tests/e2e/hibernation_test.go
+++ b/tests/e2e/hibernation_test.go
@@ -225,7 +225,13 @@ var _ = Describe("Cluster Hibernation with plugin", Label(tests.LabelPlugin), fu
 			var beforeHibernationPgDataPvcUID types.UID
 
 			// Write a table and some data on the "app" database
-			AssertCreateTestData(env, namespace, clusterName, tableName)
+			tableLocator := TableLocator{
+				Namespace:    namespace,
+				ClusterName:  clusterName,
+				DatabaseName: testsUtils.AppDBName,
+				TableName:    tableName,
+			}
+			AssertCreateTestData(env, tableLocator)
 			clusterManifest, currentPrimary := getPrimaryAndClusterManifest(namespace, clusterName)
 
 			By("collecting pgWal pvc details of current primary", func() {
@@ -289,7 +295,7 @@ var _ = Describe("Cluster Hibernation with plugin", Label(tests.LabelPlugin), fu
 
 			AssertClusterIsReady(namespace, clusterName, testTimeouts[testsUtils.ClusterIsReady], env)
 			// Test data should be present after hibernation off
-			AssertDataExpectedCount(env, namespace, clusterName, tableName, 2)
+			AssertDataExpectedCount(env, tableLocator, 2)
 		}
 
 		When("cluster setup with PG-WAL volume", func() {
@@ -316,7 +322,13 @@ var _ = Describe("Cluster Hibernation with plugin", Label(tests.LabelPlugin), fu
 				Expect(err).ToNot(HaveOccurred())
 				AssertCreateCluster(namespace, clusterName, sampleFileClusterWithOutPGWalVolume, env)
 				// Write a table and some data on the "app" database
-				AssertCreateTestData(env, namespace, clusterName, tableName)
+				tableLocator := TableLocator{
+					Namespace:    namespace,
+					ClusterName:  clusterName,
+					DatabaseName: testsUtils.AppDBName,
+					TableName:    tableName,
+				}
+				AssertCreateTestData(env, tableLocator)
 				clusterManifest, currentPrimary := getPrimaryAndClusterManifest(namespace,
 					clusterName)
 
@@ -363,7 +375,7 @@ var _ = Describe("Cluster Hibernation with plugin", Label(tests.LabelPlugin), fu
 
 				AssertClusterIsReady(namespace, clusterName, testTimeouts[testsUtils.ClusterIsReady], env)
 				// Test data should be present after hibernation off
-				AssertDataExpectedCount(env, namespace, clusterName, tableName, 2)
+				AssertDataExpectedCount(env, tableLocator, 2)
 			})
 		})
 		When("cluster hibernation after switchover", func() {

--- a/tests/e2e/managed_roles_test.go
+++ b/tests/e2e/managed_roles_test.go
@@ -94,7 +94,7 @@ var _ = Describe("Managed roles tests", Label(tests.LabelSmoke, tests.LabelBasic
 						Namespace: namespace,
 						PodName:   primaryPod,
 					},
-					utils.DatabaseName("postgres"),
+					utils.PostgresDBName,
 					"\\du")
 				g.Expect(err).ToNot(HaveOccurred())
 				if shouldExists {
@@ -121,7 +121,7 @@ var _ = Describe("Managed roles tests", Label(tests.LabelSmoke, tests.LabelBasic
 						Namespace: namespace,
 						PodName:   primaryPod,
 					},
-					utils.DatabaseName("postgres"),
+					utils.PostgresDBName,
 					query)
 				if err != nil {
 					return []string{ERROR}
@@ -163,7 +163,7 @@ var _ = Describe("Managed roles tests", Label(tests.LabelSmoke, tests.LabelBasic
 							Namespace: namespace,
 							PodName:   primaryPodInfo.Name,
 						},
-						utils.DatabaseName("postgres"),
+						utils.PostgresDBName,
 						q)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(stdout).To(Equal("t\n"))
@@ -195,7 +195,7 @@ var _ = Describe("Managed roles tests", Label(tests.LabelSmoke, tests.LabelBasic
 						Namespace: namespace,
 						PodName:   primaryPodInfo.Name,
 					},
-					utils.DatabaseName("postgres"),
+					utils.PostgresDBName,
 					query)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(stdout).To(Equal("t\n"))
@@ -274,7 +274,7 @@ var _ = Describe("Managed roles tests", Label(tests.LabelSmoke, tests.LabelBasic
 							Namespace: namespace,
 							PodName:   primaryPod.Name,
 						},
-						utils.DatabaseName("postgres"),
+						utils.PostgresDBName,
 						query)
 					if err != nil {
 						return ""
@@ -348,7 +348,7 @@ var _ = Describe("Managed roles tests", Label(tests.LabelSmoke, tests.LabelBasic
 							Namespace: namespace,
 							PodName:   primaryPodInfo.Name,
 						},
-						utils.DatabaseName("postgres"),
+						utils.PostgresDBName,
 						query)
 					if err != nil {
 						return ""
@@ -390,7 +390,7 @@ var _ = Describe("Managed roles tests", Label(tests.LabelSmoke, tests.LabelBasic
 							Namespace: namespace,
 							PodName:   primaryPodInfo.Name,
 						},
-						utils.DatabaseName("postgres"),
+						utils.PostgresDBName,
 						query)
 					if err != nil {
 						return ERROR
@@ -410,7 +410,7 @@ var _ = Describe("Managed roles tests", Label(tests.LabelSmoke, tests.LabelBasic
 							Namespace: namespace,
 							PodName:   primaryPodInfo.Name,
 						},
-						utils.DatabaseName("postgres"),
+						utils.PostgresDBName,
 						query)
 					if err != nil {
 						return ERROR
@@ -556,7 +556,7 @@ var _ = Describe("Managed roles tests", Label(tests.LabelSmoke, tests.LabelBasic
 						Namespace: namespace,
 						PodName:   primaryPod.Name,
 					},
-					utils.DatabaseName("postgres"),
+					utils.PostgresDBName,
 					query)
 				Expect(err).ToNot(HaveOccurred())
 			})
@@ -603,7 +603,7 @@ var _ = Describe("Managed roles tests", Label(tests.LabelSmoke, tests.LabelBasic
 							Namespace: namespace,
 							PodName:   primaryPodInfo.Name,
 						},
-						utils.DatabaseName("postgres"),
+						utils.PostgresDBName,
 						query)
 					if err != nil {
 						return ERROR
@@ -623,7 +623,7 @@ var _ = Describe("Managed roles tests", Label(tests.LabelSmoke, tests.LabelBasic
 							Namespace: namespace,
 							PodName:   primaryPodInfo.Name,
 						},
-						utils.DatabaseName("postgres"),
+						utils.PostgresDBName,
 						query)
 					if err != nil {
 						return ERROR

--- a/tests/e2e/metrics_test.go
+++ b/tests/e2e/metrics_test.go
@@ -298,6 +298,7 @@ var _ = Describe("Metrics", Label(tests.LabelObservability), func() {
 				apiv1.ApplicationUserSecretSuffix,
 			)
 			defer func() {
+				_ = conn.Close()
 				forward.Close()
 			}()
 			Expect(err).ToNot(HaveOccurred())

--- a/tests/e2e/operator_unavailable_test.go
+++ b/tests/e2e/operator_unavailable_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/specs"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 	"github.com/cloudnative-pg/cloudnative-pg/tests"
+	testsUtils "github.com/cloudnative-pg/cloudnative-pg/tests/utils"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -59,7 +60,13 @@ var _ = Describe("Operator unavailable", Serial, Label(tests.LabelDisruptive, te
 
 			// Load test data
 			currentPrimary := clusterName + "-1"
-			AssertCreateTestData(env, namespace, clusterName, "test")
+			tableLocator := TableLocator{
+				Namespace:    namespace,
+				ClusterName:  clusterName,
+				DatabaseName: testsUtils.AppDBName,
+				TableName:    "test",
+			}
+			AssertCreateTestData(env, tableLocator)
 
 			By("scaling down operator replicas to zero", func() {
 				err := env.ScaleOperatorDeployment(0)
@@ -120,10 +127,7 @@ var _ = Describe("Operator unavailable", Serial, Label(tests.LabelDisruptive, te
 					return specs.IsPodStandby(pod), err
 				}, timeout).Should(BeTrue())
 			})
-			// Expect the test data previously created to be available
-			primary, err := env.GetClusterPrimary(namespace, clusterName)
-			Expect(err).ToNot(HaveOccurred())
-			AssertDataExpectedCountWithDatabaseName(namespace, primary.Name, "app", "test", 2)
+			AssertDataExpectedCount(env, tableLocator, 2)
 		})
 	})
 
@@ -140,7 +144,13 @@ var _ = Describe("Operator unavailable", Serial, Label(tests.LabelDisruptive, te
 
 			// Load test data
 			currentPrimary := clusterName + "-1"
-			AssertCreateTestData(env, namespace, clusterName, "test")
+			tableLocator := TableLocator{
+				Namespace:    namespace,
+				ClusterName:  clusterName,
+				DatabaseName: testsUtils.AppDBName,
+				TableName:    "test",
+			}
+			AssertCreateTestData(env, tableLocator)
 
 			operatorNamespace, err := env.GetOperatorNamespaceName()
 			Expect(err).ToNot(HaveOccurred())
@@ -211,10 +221,7 @@ var _ = Describe("Operator unavailable", Serial, Label(tests.LabelDisruptive, te
 					return specs.IsPodStandby(pod), err
 				}, timeout).Should(BeTrue())
 			})
-			// Expect the test data previously created to be available
-			primary, err := env.GetClusterPrimary(namespace, clusterName)
-			Expect(err).ToNot(HaveOccurred())
-			AssertDataExpectedCountWithDatabaseName(namespace, primary.Name, "app", "test", 2)
+			AssertDataExpectedCount(env, tableLocator, 2)
 		})
 	})
 })

--- a/tests/e2e/pg_basebackup_test.go
+++ b/tests/e2e/pg_basebackup_test.go
@@ -52,7 +52,13 @@ var _ = Describe("Bootstrap with pg_basebackup", Label(tests.LabelRecovery), fun
 			srcClusterName, err = env.GetResourceNameFromYAML(srcCluster)
 			Expect(err).ToNot(HaveOccurred())
 			AssertCreateCluster(namespace, srcClusterName, srcCluster, env)
-			AssertCreateTestData(env, namespace, srcClusterName, tableName)
+			tableLocator := TableLocator{
+				Namespace:    namespace,
+				ClusterName:  srcClusterName,
+				DatabaseName: utils.AppDBName,
+				TableName:    tableName,
+			}
+			AssertCreateTestData(env, tableLocator)
 		})
 
 		It("using basic authentication", func() {
@@ -87,7 +93,13 @@ var _ = Describe("Bootstrap with pg_basebackup", Label(tests.LabelRecovery), fun
 			})
 
 			By("checking data have been copied correctly", func() {
-				AssertDataExpectedCount(env, namespace, dstClusterName, tableName, 2)
+				tableLocator := TableLocator{
+					Namespace:    namespace,
+					ClusterName:  dstClusterName,
+					DatabaseName: utils.AppDBName,
+					TableName:    tableName,
+				}
+				AssertDataExpectedCount(env, tableLocator, 2)
 			})
 
 			By("writing some new data to the dst cluster", func() {
@@ -99,6 +111,7 @@ var _ = Describe("Bootstrap with pg_basebackup", Label(tests.LabelRecovery), fun
 					apiv1.ApplicationUserSecretSuffix,
 				)
 				defer func() {
+					_ = conn.Close()
 					forward.Close()
 				}()
 				Expect(err).ToNot(HaveOccurred())
@@ -106,7 +119,13 @@ var _ = Describe("Bootstrap with pg_basebackup", Label(tests.LabelRecovery), fun
 			})
 
 			By("checking the src cluster was not modified", func() {
-				AssertDataExpectedCount(env, namespace, srcClusterName, tableName, 2)
+				tableLocator := TableLocator{
+					Namespace:    namespace,
+					ClusterName:  srcClusterName,
+					DatabaseName: utils.AppDBName,
+					TableName:    tableName,
+				}
+				AssertDataExpectedCount(env, tableLocator, 2)
 			})
 		})
 
@@ -119,7 +138,13 @@ var _ = Describe("Bootstrap with pg_basebackup", Label(tests.LabelRecovery), fun
 			AssertClusterIsReady(namespace, dstClusterName, testTimeouts[utils.ClusterIsReadySlow], env)
 
 			By("checking data have been copied correctly", func() {
-				AssertDataExpectedCount(env, namespace, dstClusterName, tableName, 2)
+				tableLocator := TableLocator{
+					Namespace:    namespace,
+					ClusterName:  dstClusterName,
+					DatabaseName: utils.AppDBName,
+					TableName:    tableName,
+				}
+				AssertDataExpectedCount(env, tableLocator, 2)
 			})
 
 			By("writing some new data to the dst cluster", func() {
@@ -131,6 +156,7 @@ var _ = Describe("Bootstrap with pg_basebackup", Label(tests.LabelRecovery), fun
 					apiv1.ApplicationUserSecretSuffix,
 				)
 				defer func() {
+					_ = conn.Close()
 					forward.Close()
 				}()
 				Expect(err).ToNot(HaveOccurred())
@@ -138,7 +164,13 @@ var _ = Describe("Bootstrap with pg_basebackup", Label(tests.LabelRecovery), fun
 			})
 
 			By("checking the src cluster was not modified", func() {
-				AssertDataExpectedCount(env, namespace, srcClusterName, tableName, 2)
+				tableLocator := TableLocator{
+					Namespace:    namespace,
+					ClusterName:  srcClusterName,
+					DatabaseName: utils.AppDBName,
+					TableName:    tableName,
+				}
+				AssertDataExpectedCount(env, tableLocator, 2)
 			})
 		})
 	})

--- a/tests/e2e/pg_data_corruption_test.go
+++ b/tests/e2e/pg_data_corruption_test.go
@@ -58,7 +58,13 @@ var _ = Describe("PGDATA Corruption", Label(tests.LabelRecovery), Ordered, func(
 		clusterName, err := env.GetResourceNameFromYAML(sampleFile)
 		Expect(err).ToNot(HaveOccurred())
 		AssertCreateCluster(namespace, clusterName, sampleFile, env)
-		AssertCreateTestData(env, namespace, clusterName, tableName)
+		tableLocator := TableLocator{
+			Namespace:    namespace,
+			ClusterName:  clusterName,
+			DatabaseName: testsUtils.AppDBName,
+			TableName:    tableName,
+		}
+		AssertCreateTestData(env, tableLocator)
 
 		By("gathering current primary pod and pvc", func() {
 			oldPrimaryPod, err := env.GetClusterPrimary(namespace, clusterName)
@@ -187,7 +193,7 @@ var _ = Describe("PGDATA Corruption", Label(tests.LabelRecovery), Ordered, func(
 			}, 300).Should(BeTrue())
 		})
 		AssertClusterIsReady(namespace, clusterName, testTimeouts[testsUtils.ClusterIsReadyQuick], env)
-		AssertDataExpectedCount(env, namespace, clusterName, tableName, 2)
+		AssertDataExpectedCount(env, tableLocator, 2)
 		AssertClusterStandbysAreStreaming(namespace, clusterName, 120)
 	}
 

--- a/tests/e2e/replication_slot_test.go
+++ b/tests/e2e/replication_slot_test.go
@@ -109,10 +109,14 @@ var _ = Describe("Replication Slot", Label(tests.LabelReplication), func() {
 			primaryPod, err := env.GetClusterPrimary(namespace, clusterName)
 			Expect(err).ToNot(HaveOccurred())
 
-			_, _, err = testsUtils.RunQueryFromPod(primaryPod, testsUtils.PGLocalSocketDir,
-				"app", "postgres", "''",
-				fmt.Sprintf("SELECT pg_create_physical_replication_slot('%s');", userPhysicalSlot),
-				env)
+			query := fmt.Sprintf("SELECT pg_create_physical_replication_slot('%s');", userPhysicalSlot)
+			_, _, err = env.ExecQueryInInstancePod(
+				testsUtils.PodLocator{
+					Namespace: primaryPod.Namespace,
+					PodName:   primaryPod.Name,
+				},
+				testsUtils.PostgresDBName,
+				query)
 			Expect(err).ToNot(HaveOccurred())
 		})
 

--- a/tests/e2e/volume_snapshot_test.go
+++ b/tests/e2e/volume_snapshot_test.go
@@ -242,7 +242,13 @@ var _ = Describe("Verify Volume Snapshot",
 
 				By("inserting test data and creating WALs on the cluster to be snapshotted", func() {
 					// Create a "test" table with values 1,2
-					AssertCreateTestData(env, namespace, clusterToSnapshotName, tableName)
+					tableLocator := TableLocator{
+						Namespace:    namespace,
+						ClusterName:  clusterToSnapshotName,
+						DatabaseName: testUtils.AppDBName,
+						TableName:    tableName,
+					}
+					AssertCreateTestData(env, tableLocator)
 
 					// Because GetCurrentTimestamp() rounds down to the second and is executed
 					// right after the creation of the test data, we wait for 1s to avoid not
@@ -262,6 +268,7 @@ var _ = Describe("Verify Volume Snapshot",
 						apiv1.ApplicationUserSecretSuffix,
 					)
 					defer func() {
+						_ = conn.Close()
 						forward.Close()
 					}()
 					Expect(err).ToNot(HaveOccurred())
@@ -282,7 +289,13 @@ var _ = Describe("Verify Volume Snapshot",
 				})
 
 				By("verifying the correct data exists in the restored cluster", func() {
-					AssertDataExpectedCount(env, namespace, clusterToRestoreName, tableName, 2)
+					tableLocator := TableLocator{
+						Namespace:    namespace,
+						ClusterName:  clusterToRestoreName,
+						DatabaseName: testUtils.AppDBName,
+						TableName:    tableName,
+					}
+					AssertDataExpectedCount(env, tableLocator, 2)
 				})
 			})
 		})
@@ -366,7 +379,13 @@ var _ = Describe("Verify Volume Snapshot",
 
 			It("can create a declarative cold backup and restoring using it", func() {
 				By("inserting test data", func() {
-					AssertCreateTestData(env, namespace, clusterToBackupName, tableName)
+					tableLocator := TableLocator{
+						Namespace:    namespace,
+						ClusterName:  clusterToBackupName,
+						DatabaseName: testUtils.AppDBName,
+						TableName:    tableName,
+					}
+					AssertCreateTestData(env, tableLocator)
 				})
 
 				backupName, err := env.GetResourceNameFromYAML(backupFileFilePath)
@@ -426,7 +445,13 @@ var _ = Describe("Verify Volume Snapshot",
 				})
 
 				By("checking that the data is present on the restored cluster", func() {
-					AssertDataExpectedCount(env, namespace, clusterToRestoreName, tableName, 2)
+					tableLocator := TableLocator{
+						Namespace:    namespace,
+						ClusterName:  clusterToRestoreName,
+						DatabaseName: testUtils.AppDBName,
+						TableName:    tableName,
+					}
+					AssertDataExpectedCount(env, tableLocator, 2)
 				})
 			})
 			It("can take a snapshot targeting the primary", func() {
@@ -615,11 +640,18 @@ var _ = Describe("Verify Volume Snapshot",
 						apiv1.ApplicationUserSecretSuffix,
 					)
 					defer func() {
+						_ = conn.Close()
 						forward.Close()
 					}()
 					Expect(err).ToNot(HaveOccurred())
 					// Create a "test" table with values 1,2
-					AssertCreateTestData(env, namespace, clusterToSnapshotName, tableName)
+					tableLocator := TableLocator{
+						Namespace:    namespace,
+						ClusterName:  clusterToSnapshotName,
+						DatabaseName: testUtils.AppDBName,
+						TableName:    tableName,
+					}
+					AssertCreateTestData(env, tableLocator)
 
 					// Insert 2 more rows which we expect not to be present at the end of the recovery
 					insertRecordIntoTable(tableName, 3, conn)
@@ -684,7 +716,13 @@ var _ = Describe("Verify Volume Snapshot",
 				})
 
 				By("verifying the correct data exists in the restored cluster", func() {
-					AssertDataExpectedCount(env, namespace, clusterToRestoreName, tableName, 4)
+					tableLocator := TableLocator{
+						Namespace:    namespace,
+						ClusterName:  clusterToRestoreName,
+						DatabaseName: testUtils.AppDBName,
+						TableName:    tableName,
+					}
+					AssertDataExpectedCount(env, tableLocator, 4)
 				})
 			})
 
@@ -700,6 +738,7 @@ var _ = Describe("Verify Volume Snapshot",
 						apiv1.ApplicationUserSecretSuffix,
 					)
 					defer func() {
+						_ = conn.Close()
 						forward.Close()
 					}()
 					Expect(err).ToNot(HaveOccurred())
@@ -740,8 +779,13 @@ var _ = Describe("Verify Volume Snapshot",
 					podList, err := env.GetClusterReplicas(namespace, clusterToSnapshotName)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(podList.Items).To(HaveLen(2))
-					AssertDataExpectedCount(env, namespace, clusterToSnapshotName, tableName, 6)
-					AssertDataExpectedCount(env, namespace, clusterToSnapshotName, tableName, 6)
+					tableLocator := TableLocator{
+						Namespace:    namespace,
+						ClusterName:  clusterToSnapshotName,
+						DatabaseName: testUtils.AppDBName,
+						TableName:    tableName,
+					}
+					AssertDataExpectedCount(env, tableLocator, 6)
 				})
 			})
 		})

--- a/tests/utils/environment.go
+++ b/tests/utils/environment.go
@@ -48,7 +48,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
-	"github.com/cloudnative-pg/cloudnative-pg/pkg/specs"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/versions"
 
@@ -202,31 +201,6 @@ func (env TestingEnvironment) ExecCommand(
 ) (string, string, error) {
 	return utils.ExecCommand(ctx, env.Interface, env.RestClientConfig,
 		pod, containerName, timeout, command...)
-}
-
-// ExecCommandWithPsqlClient wraps the utils.ExecCommand pre-setting values and
-// run query on psql client pod with rw service as host.
-func (env TestingEnvironment) ExecCommandWithPsqlClient(
-	namespace,
-	clusterName string,
-	pod *corev1.Pod,
-	secretSuffix string,
-	dbname string,
-	query string,
-) (string, string, error) {
-	timeout := time.Second * 10
-	username, password, err := GetCredentials(clusterName, namespace, secretSuffix, &env)
-	if err != nil {
-		return "", "", err
-	}
-	rwService, err := GetRwServiceObject(namespace, clusterName, &env)
-	if err != nil {
-		return "", "", err
-	}
-	host := CreateServiceFQDN(namespace, rwService.GetName())
-	dsn := CreateDSN(host, username, dbname, password, Prefer, 5432)
-	return utils.ExecCommand(env.Ctx, env.Interface, env.RestClientConfig,
-		*pod, specs.PostgresContainerName, &timeout, "psql", dsn, "-tAc", query)
 }
 
 // GetPVCList gathers the current list of PVCs in a namespace

--- a/tests/utils/psql_connection.go
+++ b/tests/utils/psql_connection.go
@@ -200,7 +200,7 @@ func ForwardPSQLConnectionWithCreds(
 	return forward, conn, err
 }
 
-// RunQueryRowOverForward runs QueryRow with a given query, returning the result Row
+// RunQueryRowOverForward runs QueryRow with a given query, returning the Row of the SQL command
 func RunQueryRowOverForward(
 	env *TestingEnvironment,
 	namespace,
@@ -220,8 +220,36 @@ func RunQueryRowOverForward(
 		return nil, err
 	}
 	defer func() {
+		_ = conn.Close()
 		forward.Close()
 	}()
 
 	return conn.QueryRow(query), nil
+}
+
+// RunExecOverForward runs Exec with a given query, returning the Result of the SQL command
+func RunExecOverForward(
+	env *TestingEnvironment,
+	namespace,
+	clusterName,
+	dbname,
+	secretSuffix,
+	query string,
+) (sql.Result, error) {
+	forward, conn, err := ForwardPSQLConnection(
+		env,
+		namespace,
+		clusterName,
+		dbname,
+		secretSuffix,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = conn.Close()
+		forward.Close()
+	}()
+
+	return conn.Exec(query)
 }

--- a/tests/utils/replication_slots.go
+++ b/tests/utils/replication_slots.go
@@ -54,13 +54,14 @@ func PrintReplicationSlots(
 		}
 		m := make(map[string]string)
 		for _, slot := range slots {
-			restartLsn, _, err := RunQueryFromPod(
-				&podList.Items[i], PGLocalSocketDir,
-				"app",
-				"postgres",
-				"''",
-				fmt.Sprintf("SELECT restart_lsn FROM pg_replication_slots WHERE slot_name = '%v'", slot),
-				env)
+			query := fmt.Sprintf("SELECT restart_lsn FROM pg_replication_slots WHERE slot_name = '%v'", slot)
+			restartLsn, _, err := env.ExecQueryInInstancePod(
+				PodLocator{
+					Namespace: podList.Items[i].Namespace,
+					PodName:   podList.Items[i].Name,
+				},
+				AppDBName,
+				query)
 			if err != nil {
 				output.WriteString(fmt.Sprintf("Couldn't retrieve restart_lsn for slot %v: %v\n", slot, err))
 			}
@@ -125,9 +126,14 @@ func GetReplicationSlotsOnPod(namespace, podName string, env *TestingEnvironment
 		return nil, err
 	}
 
-	stdout, _, err := RunQueryFromPod(targetPod, PGLocalSocketDir,
-		"app", "postgres", "''",
-		"SELECT slot_name FROM pg_replication_slots  WHERE temporary = 'f' AND slot_type = 'physical'", env)
+	query := "SELECT slot_name FROM pg_replication_slots WHERE temporary = 'f' AND slot_type = 'physical'"
+	stdout, _, err := env.ExecQueryInInstancePod(
+		PodLocator{
+			Namespace: targetPod.Namespace,
+			PodName:   targetPod.Name,
+		},
+		AppDBName,
+		query)
 	if err != nil {
 		return nil, err
 	}
@@ -157,8 +163,13 @@ func GetReplicationSlotLsnsOnPod(
 	for _, slot := range slots {
 		query := fmt.Sprintf("SELECT restart_lsn FROM pg_replication_slots WHERE slot_name = '%v'",
 			slot)
-		restartLsn, _, err := RunQueryFromPod(&pod, PGLocalSocketDir,
-			"app", "postgres", "''", query, env)
+		restartLsn, _, err := env.ExecQueryInInstancePod(
+			PodLocator{
+				Namespace: pod.Namespace,
+				PodName:   pod.Name,
+			},
+			AppDBName,
+			query)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Closes: #5713

Refactors:

- Unify AssertCreateTestData,AssertCreateTestDataWithDatabaseName,AssertCreateTestDataInTablespace
- Unify insertRecordIntoTable,insertRecordIntoTableWithDatabaseName
- Unify AssertDataExpectedCount,AssertDataExpectedCountWithDatabaseName
- Remove ExecCommandWithPsqlClient given that we previously removed the psqlCLient
- Remove RunQueryFromPod, which is not needed anymore since now we can connect directly using port-forwarding
- Convert ExecCommand usages that were connecting locally to run a query to instead use ExecQueryInInstancePod
- Convert EventuallyExecCommand usages that were connecting locally to run a query to instead use EventuallyExecQueryInInstancePod
- Add RunExecOverForward which allows running queries that don't return any rows via port-forwarding

Fixes:

- Client should close the connection when it is done. This improves timings on switchover/failover because we rely on smartShutdown by default

E2E fixes:

- Drain with PDB disabled: actually wait for the Cluster to be back
- Replica Mode: synchronize secret value in the Replica Cluster before connecting
- Configuration update: simplify pg_ident assertion