### PR TITLE
fix(plugin): avoid jamming JSON logs with `logs` command

### DIFF
--- a/pkg/utils/logs/cluster_logs.go
+++ b/pkg/utils/logs/cluster_logs.go
@@ -17,6 +17,7 @@ limitations under the License.
 package logs
 
 import (
+	"bufio"
 	"context"
 	"io"
 	"log"
@@ -237,9 +238,25 @@ func (csr *ClusterStreamingRequest) streamInGoroutine(
 		}
 	}()
 
-	_, err = io.Copy(output, logStream)
-	if err != nil {
-		log.Printf("error sending logs to writer, pod %s: %v", podName, err)
-		return
+	scanner := bufio.NewScanner(logStream)
+	bufferedOutput := bufio.NewWriter(output)
+
+readLoop:
+	for scanner.Scan() {
+		select {
+		case <-ctx.Done():
+			break readLoop
+		default:
+			data := scanner.Text()
+			if _, err := bufferedOutput.Write([]byte(data)); err != nil {
+				log.Printf("error writing log line to output: %v", err)
+			}
+			if err := bufferedOutput.WriteByte('\n'); err != nil {
+				log.Printf("error writing newline to output: %v", err)
+			}
+			if err := bufferedOutput.Flush(); err != nil {
+				log.Printf("error flushing output: %v", err)
+			}
+		}
 	}
 }

--- a/pkg/utils/logs/cluster_logs.go
+++ b/pkg/utils/logs/cluster_logs.go
@@ -239,6 +239,7 @@ func (csr *ClusterStreamingRequest) streamInGoroutine(
 	}()
 
 	scanner := bufio.NewScanner(logStream)
+	scanner.Buffer(make([]byte, 0, 4096), 1024*1024)
 	bufferedOutput := bufio.NewWriter(output)
 
 readLoop:

--- a/pkg/utils/logs/cluster_logs_test.go
+++ b/pkg/utils/logs/cluster_logs_test.go
@@ -71,7 +71,7 @@ var _ = Describe("Cluster logging tests", func() {
 		}()
 		ctx.Done()
 		wait.Wait()
-		Expect(logBuffer.String()).To(BeEquivalentTo("fake logs"))
+		Expect(logBuffer.String()).To(BeEquivalentTo("fake logs\n"))
 	})
 
 	It("should catch extra logs if given the follow option", func(ctx context.Context) {
@@ -98,6 +98,6 @@ var _ = Describe("Cluster logging tests", func() {
 		time.Sleep(350 * time.Millisecond)
 		cancel()
 		// the fake pod will be seen twice
-		Expect(logBuffer.String()).To(BeEquivalentTo("fake logsfake logs"))
+		Expect(logBuffer.String()).To(BeEquivalentTo("fake logs\nfake logs\n"))
 	})
 })


### PR DESCRIPTION
`kubectl cnpg logs cluster` collects the log stream of all the Pods belonging to the selected cluster and forwards their output to a final destination stream with no coordination besides basic locking at the byte level.

This resulted in multiple JSON objects being written at the same time, which made the output garbled. Tools relying on the JSON-stream format cannot parse that too.

With this patch, we coordinate the reading process, scan the stream line by line, and write every separate line for the final stream.

Closes: #5769 