### PR TITLE
feat(plugin): add `logs pretty` command

### DIFF
--- a/docs/src/kubectl-plugin.md
+++ b/docs/src/kubectl-plugin.md
@@ -798,7 +798,7 @@ $ kubectl cnpg logs cluster cluster-example | kubectl cnpg logs pretty
 [...]
 ```
 
-Alternatively, it can be used in combination with other commands producing
+Alternatively, it can be used in combination with other commands that produce
 CNPG logs in JSON format, such as `stern`, or `kubectl logs`, as in the
 following example:
 

--- a/docs/src/kubectl-plugin.md
+++ b/docs/src/kubectl-plugin.md
@@ -175,6 +175,7 @@ kubectl cnpg <command> <args...>
     The plugin automatically detects if the standard output channel is connected to a terminal.
     In such cases, it may add ANSI colors to the command output. To disable colors, use the
     `--color=never` option with the command.
+
 ### Generation of installation manifests
 
 The `cnpg` plugin can be used to generate the YAML manifest for the
@@ -779,6 +780,41 @@ kubectl cnpg logs cluster cluster-example --output my-cluster.log
 
 Successfully written logs to "my-cluster.log"
 ```
+
+#### Pretty
+
+The `pretty` sub-command reads a log stream from the process standard input
+and decodes and formats it in a human-readable format.
+
+It is designed to be used in a pipeline with `kubectl cnpg logs cluster` like in
+the following example:
+
+```
+$ kubectl cnpg logs cluster cluster-example | kubectl cnpg logs pretty
+2024-10-09T07:05:41Z cluster-example-1 setup Starting CloudNativePG Instance Manager
+2024-10-09T07:05:41Z cluster-example-1 setup Checking for free disk space for WALs before starting PostgreSQL
+2024-10-09T07:05:41Z cluster-example-1 setup starting tablespace manager
+[...]
+```
+
+The `pretty` sub-commands also support log selection, allowing the user to
+filter out the logs of the selected pods, of the selected loggers, and less
+important than a specified level. The following examples gives a glimpse of how
+to achieve that:
+
+```
+$ kubectl cnpg logs cluster cluster-example | kubectl cnpg logs pretty --pods cluster-example-1 --loggers postgres --log-level info
+2024-10-09T07:05:41Z cluster-example-1 postgres 2024-10-09 07:05:41.458 UTC [31] LOG:  redirecting log output to logging collector process
+2024-10-09T07:05:41Z cluster-example-1 postgres 2024-10-09 07:05:41.458 UTC [31] HINT:  Future log output will appear in directory "/controller/log".
+2024-10-09T07:05:41Z cluster-example-1 postgres LOG: ending log output to stderr
+2024-10-09T07:05:41Z cluster-example-1 postgres LOG: starting PostgreSQL 17.0 (Debian 17.0-1.pgdg110+1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 10.2.1-6) 10.2.1 20210110, 64-bit
+2024-10-09T07:05:41Z cluster-example-1 postgres 2024-10-09 07:05:41.458 UTC [31] LOG:  ending log output to stderr
+2024-10-09T07:05:41Z cluster-example-1 postgres 2024-10-09 07:05:41.458 UTC [31] HINT:  Future log output will go to log destination "csvlog".
+[...]
+```
+
+The `-h` option can be used to get an explanation of all the available flags and
+their semantics.
 
 ### Destroy
 

--- a/docs/src/kubectl-plugin.md
+++ b/docs/src/kubectl-plugin.md
@@ -791,10 +791,10 @@ shown in the following example:
 
 ``` sh
 $ kubectl cnpg logs cluster cluster-example | kubectl cnpg logs pretty
-2024-10-10T16:36:18.668100649Z INFO cluster-example-1 instance-manager Starting CloudNativePG Instance Manager {"build":{"Commit":"953f0b2cf","Date":"2024-10-09","Version":"1.24.0-dev128"},"version":"1.24.0"}
-2024-10-10T16:36:18.668268413Z INFO cluster-example-1 instance-manager Checking for free disk space for WALs before starting PostgreSQL
-2024-10-10T16:36:18.686309469Z INFO cluster-example-1 instance-manager starting tablespace manager
-2024-10-10T16:36:18.686375141Z INFO cluster-example-1 instance-manager starting external server manager
+2024-10-15T17:35:00.336 INFO     cluster-example-1 instance-manager Starting CloudNativePG Instance Manager
+2024-10-15T17:35:00.336 INFO     cluster-example-1 instance-manager Checking for free disk space for WALs before starting PostgreSQL
+2024-10-15T17:35:00.347 INFO     cluster-example-1 instance-manager starting tablespace manager
+2024-10-15T17:35:00.347 INFO     cluster-example-1 instance-manager starting external server manager
 [...]
 ```
 
@@ -804,10 +804,10 @@ following example:
 
 ``` sh
 $ kubectl logs cluster-example-1 | kubectl cnpg logs pretty
-2024-10-10T16:36:18.668100649Z INFO cluster-example-1 instance-manager Starting CloudNativePG Instance Manager {"build":{"Commit":"953f0b2cf","Date":"2024-10-09","Version":"1.24.0-dev128"},"version":"1.24.0"}
-2024-10-10T16:36:18.668268413Z INFO cluster-example-1 instance-manager Checking for free disk space for WALs before starting PostgreSQL
-2024-10-10T16:36:18.686309469Z INFO cluster-example-1 instance-manager starting tablespace manager
-2024-10-10T16:36:18.686375141Z INFO cluster-example-1 instance-manager starting external server manager
+2024-10-15T17:35:00.336 INFO     cluster-example-1 instance-manager Starting CloudNativePG Instance Manager
+2024-10-15T17:35:00.336 INFO     cluster-example-1 instance-manager Checking for free disk space for WALs before starting PostgreSQL
+2024-10-15T17:35:00.347 INFO     cluster-example-1 instance-manager starting tablespace manager
+2024-10-15T17:35:00.347 INFO     cluster-example-1 instance-manager starting external server manager
 [...]
 ```
 
@@ -818,10 +818,10 @@ Here's an example:
 
 ``` sh
 $ kubectl cnpg logs cluster cluster-example | kubectl cnpg logs pretty --pods cluster-example-1 --loggers postgres --log-level info
-2024-10-10T16:36:18.853589475Z INFO cluster-example-1 postgres 2024-10-10 16:36:18.853 UTC [29] LOG:  redirecting log output to logging collector process {"pipe":"stderr"}
-2024-10-10T16:36:18.853641103Z INFO cluster-example-1 postgres 2024-10-10 16:36:18.853 UTC [29] HINT:  Future log output will appear in directory "/controller/log". {"pipe":"stderr"}
-2024-10-10T16:36:18.854004804Z INFO cluster-example-1 postgres 2024-10-10 16:36:18.853 UTC [29] LOG:  ending log output to stderr {"source":"/controller/log/postgres"}
-2024-10-10T16:36:18.854038757Z INFO cluster-example-1 postgres 2024-10-10 16:36:18.853 UTC [29] HINT:  Future log output will go to log destination "csvlog". {"source":"/controller/log/postgres"}
+2024-10-15T17:35:00.509 INFO     cluster-example-1 postgres         2024-10-15 17:35:00.509 UTC [29] LOG:  redirecting log output to logging collector process
+2024-10-15T17:35:00.509 INFO     cluster-example-1 postgres         2024-10-15 17:35:00.509 UTC [29] HINT:  Future log output will appear in directory "/controller/log"...
+2024-10-15T17:35:00.510 INFO     cluster-example-1 postgres         2024-10-15 17:35:00.509 UTC [29] LOG:  ending log output to stderr
+2024-10-15T17:35:00.510 INFO     cluster-example-1 postgres         ending log output to stderr
 [...]
 ```
 
@@ -834,18 +834,23 @@ each sorted group. The size of the grouping can be configured via the
 `--sorting-group-size` flag (default: 1000), as illustrated in the following example:
 
 ``` sh
-$ kubectl logs cluster-example-1 | kubectl cnpg logs pretty --sorting-group-size=3
-2024-10-15T13:50:53Z INFO     cluster-example-1 setup            Starting CloudNativePG Instance Manager
-2024-10-15T13:50:53Z INFO     cluster-example-1 setup            Checking for free disk space for WALs before starting PostgreSQL
-2024-10-15T13:50:53Z INFO     cluster-example-1 setup            starting tablespace manager
+$ kubectl cnpg logs cluster cluster-example | kubectl cnpg logs pretty --sorting-group-size=3
+2024-10-15T17:35:20.426 INFO     cluster-example-2 instance-manager Starting CloudNativePG Instance Manager
+2024-10-15T17:35:20.426 INFO     cluster-example-2 instance-manager Checking for free disk space for WALs before starting PostgreSQL
+2024-10-15T17:35:20.438 INFO     cluster-example-2 instance-manager starting tablespace manager
 ---
-2024-10-15T13:50:53Z INFO                       Starting EventSource
-2024-10-15T13:50:53Z INFO     cluster-example-1 setup            starting external server manager
+2024-10-15T17:35:20.438 INFO     cluster-example-2 instance-manager starting external server manager
+2024-10-15T17:35:20.438 INFO     cluster-example-2 instance-manager starting controller-runtime manager
+2024-10-15T17:35:20.439 INFO     cluster-example-2 instance-manager Starting EventSource
+---
 [...]
 ```
 
 To explore all available options, use the `-h` flag for detailed explanations
 of the supported flags and their usage.
+
+!!! Info
+    You can also increase the verbosity of the log by adding more `-v` options.
 
 ### Destroy
 

--- a/docs/src/kubectl-plugin.md
+++ b/docs/src/kubectl-plugin.md
@@ -783,38 +783,36 @@ Successfully written logs to "my-cluster.log"
 
 #### Pretty
 
-The `pretty` sub-command reads a log stream from the process standard input
-and decodes and formats it in a human-readable format.
+The `pretty` sub-command reads a log stream from standard input and formats it
+into a human-readable output, and attempts to sort the entries by timestamp.
 
-It is designed to be used in a pipeline with `kubectl cnpg logs cluster` like in
-the following example:
+It is intended to be used in combination with `kubectl cnpg logs cluster`, as
+shown in the following example:
 
 ```
 $ kubectl cnpg logs cluster cluster-example | kubectl cnpg logs pretty
-2024-10-09T07:05:41Z cluster-example-1 setup Starting CloudNativePG Instance Manager
-2024-10-09T07:05:41Z cluster-example-1 setup Checking for free disk space for WALs before starting PostgreSQL
-2024-10-09T07:05:41Z cluster-example-1 setup starting tablespace manager
+2024-10-10T16:36:18.668100649Z INFO cluster-example-1 instance-manager Starting CloudNativePG Instance Manager {"build":{"Commit":"953f0b2cf","Date":"2024-10-09","Version":"1.24.0-dev128"},"version":"1.24.0"}
+2024-10-10T16:36:18.668268413Z INFO cluster-example-1 instance-manager Checking for free disk space for WALs before starting PostgreSQL
+2024-10-10T16:36:18.686309469Z INFO cluster-example-1 instance-manager starting tablespace manager
+2024-10-10T16:36:18.686375141Z INFO cluster-example-1 instance-manager starting external server manager
 [...]
 ```
 
-The `pretty` sub-commands also support log selection, allowing the user to
-filter out the logs of the selected pods, of the selected loggers, and less
-important than a specified level. The following examples gives a glimpse of how
-to achieve that:
+The `pretty` sub-command also supports advanced log filtering, allowing users
+to display logs for specific pods, loggers, or filter logs by severity level.
+Here's an example:
 
 ```
 $ kubectl cnpg logs cluster cluster-example | kubectl cnpg logs pretty --pods cluster-example-1 --loggers postgres --log-level info
-2024-10-09T07:05:41Z cluster-example-1 postgres 2024-10-09 07:05:41.458 UTC [31] LOG:  redirecting log output to logging collector process
-2024-10-09T07:05:41Z cluster-example-1 postgres 2024-10-09 07:05:41.458 UTC [31] HINT:  Future log output will appear in directory "/controller/log".
-2024-10-09T07:05:41Z cluster-example-1 postgres LOG: ending log output to stderr
-2024-10-09T07:05:41Z cluster-example-1 postgres LOG: starting PostgreSQL 17.0 (Debian 17.0-1.pgdg110+1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 10.2.1-6) 10.2.1 20210110, 64-bit
-2024-10-09T07:05:41Z cluster-example-1 postgres 2024-10-09 07:05:41.458 UTC [31] LOG:  ending log output to stderr
-2024-10-09T07:05:41Z cluster-example-1 postgres 2024-10-09 07:05:41.458 UTC [31] HINT:  Future log output will go to log destination "csvlog".
+2024-10-10T16:36:18.853589475Z INFO cluster-example-1 postgres 2024-10-10 16:36:18.853 UTC [29] LOG:  redirecting log output to logging collector process {"pipe":"stderr"}
+2024-10-10T16:36:18.853641103Z INFO cluster-example-1 postgres 2024-10-10 16:36:18.853 UTC [29] HINT:  Future log output will appear in directory "/controller/log". {"pipe":"stderr"}
+2024-10-10T16:36:18.854004804Z INFO cluster-example-1 postgres 2024-10-10 16:36:18.853 UTC [29] LOG:  ending log output to stderr {"source":"/controller/log/postgres"}
+2024-10-10T16:36:18.854038757Z INFO cluster-example-1 postgres 2024-10-10 16:36:18.853 UTC [29] HINT:  Future log output will go to log destination "csvlog". {"source":"/controller/log/postgres"}
 [...]
 ```
 
-The `-h` option can be used to get an explanation of all the available flags and
-their semantics.
+To explore all available options, use the `-h` flag for detailed explanations
+of the supported flags and their usage.
 
 ### Destroy
 

--- a/docs/src/kubectl-plugin.md
+++ b/docs/src/kubectl-plugin.md
@@ -825,6 +825,25 @@ $ kubectl cnpg logs cluster cluster-example | kubectl cnpg logs pretty --pods cl
 [...]
 ```
 
+The `pretty` sub-command will try to sort the log stream,
+to make logs easier to reason about. In order to achieve this, it gathers the
+logs into groups, and within groups it sorts by timestamp. This is the only
+way to sort interactively, as `pretty` may be piped from a command in "follow"
+mode. The sub-command will add a group separator line, `---`, at the end of
+each sorted group. The size of the grouping can be configured via the
+`--sorting-group-size` flag, as illustrated in the following example:
+
+``` sh
+$ kubectl logs cluster-example-1 | kubectl cnpg logs pretty --sorting-group-size=3
+2024-10-15T13:50:53Z INFO     cluster-example-1 setup            Starting CloudNativePG Instance Manager
+2024-10-15T13:50:53Z INFO     cluster-example-1 setup            Checking for free disk space for WALs before starting PostgreSQL
+2024-10-15T13:50:53Z INFO     cluster-example-1 setup            starting tablespace manager
+---
+2024-10-15T13:50:53Z INFO                       Starting EventSource
+2024-10-15T13:50:53Z INFO     cluster-example-1 setup            starting external server manager
+[...]
+```
+
 To explore all available options, use the `-h` flag for detailed explanations
 of the supported flags and their usage.
 

--- a/docs/src/kubectl-plugin.md
+++ b/docs/src/kubectl-plugin.md
@@ -831,7 +831,7 @@ logs into groups, and within groups it sorts by timestamp. This is the only
 way to sort interactively, as `pretty` may be piped from a command in "follow"
 mode. The sub-command will add a group separator line, `---`, at the end of
 each sorted group. The size of the grouping can be configured via the
-`--sorting-group-size` flag, as illustrated in the following example:
+`--sorting-group-size` flag (default: 1000), as illustrated in the following example:
 
 ``` sh
 $ kubectl logs cluster-example-1 | kubectl cnpg logs pretty --sorting-group-size=3

--- a/docs/src/kubectl-plugin.md
+++ b/docs/src/kubectl-plugin.md
@@ -783,13 +783,13 @@ Successfully written logs to "my-cluster.log"
 
 #### Pretty
 
-The `pretty` sub-command reads a log stream from standard input and formats it
+The `pretty` sub-command reads a log stream from standard input, formats it
 into a human-readable output, and attempts to sort the entries by timestamp.
 
-It is intended to be used in combination with `kubectl cnpg logs cluster`, as
+It can be used in combination with `kubectl cnpg logs cluster`, as
 shown in the following example:
 
-```
+``` sh
 $ kubectl cnpg logs cluster cluster-example | kubectl cnpg logs pretty
 2024-10-10T16:36:18.668100649Z INFO cluster-example-1 instance-manager Starting CloudNativePG Instance Manager {"build":{"Commit":"953f0b2cf","Date":"2024-10-09","Version":"1.24.0-dev128"},"version":"1.24.0"}
 2024-10-10T16:36:18.668268413Z INFO cluster-example-1 instance-manager Checking for free disk space for WALs before starting PostgreSQL
@@ -798,11 +798,25 @@ $ kubectl cnpg logs cluster cluster-example | kubectl cnpg logs pretty
 [...]
 ```
 
+Alternatively, it can be used in combination with other commands producing
+CNPG logs in JSON format, such as `stern`, or `kubectl logs`, as in the
+following example:
+
+``` sh
+$ kubectl logs cluster-example-1 | kubectl cnpg logs pretty
+2024-10-10T16:36:18.668100649Z INFO cluster-example-1 instance-manager Starting CloudNativePG Instance Manager {"build":{"Commit":"953f0b2cf","Date":"2024-10-09","Version":"1.24.0-dev128"},"version":"1.24.0"}
+2024-10-10T16:36:18.668268413Z INFO cluster-example-1 instance-manager Checking for free disk space for WALs before starting PostgreSQL
+2024-10-10T16:36:18.686309469Z INFO cluster-example-1 instance-manager starting tablespace manager
+2024-10-10T16:36:18.686375141Z INFO cluster-example-1 instance-manager starting external server manager
+[...]
+```
+
 The `pretty` sub-command also supports advanced log filtering, allowing users
-to display logs for specific pods, loggers, or filter logs by severity level.
+to display logs for specific pods or loggers, or to filter logs by severity
+level.
 Here's an example:
 
-```
+``` sh
 $ kubectl cnpg logs cluster cluster-example | kubectl cnpg logs pretty --pods cluster-example-1 --loggers postgres --log-level info
 2024-10-10T16:36:18.853589475Z INFO cluster-example-1 postgres 2024-10-10 16:36:18.853 UTC [29] LOG:  redirecting log output to logging collector process {"pipe":"stderr"}
 2024-10-10T16:36:18.853641103Z INFO cluster-example-1 postgres 2024-10-10 16:36:18.853 UTC [29] HINT:  Future log output will appear in directory "/controller/log". {"pipe":"stderr"}

--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 	github.com/thoas/go-funk v0.9.3
 	go.uber.org/atomic v1.11.0
 	go.uber.org/multierr v1.11.0
+	go.uber.org/zap v1.27.0
 	golang.org/x/term v0.24.0
 	google.golang.org/grpc v1.67.1
 	gopkg.in/yaml.v3 v3.0.1
@@ -102,7 +103,6 @@ require (
 	github.com/x448/float16 v0.8.4 // indirect
 	github.com/xlab/treeprint v1.2.0 // indirect
 	go.starlark.net v0.0.0-20240411212711-9b43f0afd521 // indirect
-	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/crypto v0.27.0 // indirect
 	golang.org/x/exp v0.0.0-20240909161429-701f63a606c0 // indirect
 	golang.org/x/net v0.29.0 // indirect

--- a/internal/cmd/plugin/logs/cmd.go
+++ b/internal/cmd/plugin/logs/cmd.go
@@ -23,11 +23,11 @@ import (
 	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/plugin/logs/pretty"
 )
 
-// NewCmd creates the new "report" command
+// NewCmd creates the new "logs" command
 func NewCmd() *cobra.Command {
 	logsCmd := &cobra.Command{
 		Use:     "logs",
-		Short:   "Collect cluster logs",
+		Short:   "Logging utilities",
 		GroupID: plugin.GroupIDTroubleshooting,
 	}
 

--- a/internal/cmd/plugin/logs/cmd_test.go
+++ b/internal/cmd/plugin/logs/cmd_test.go
@@ -24,7 +24,7 @@ import (
 var _ = Describe("Get the proper command", func() {
 	It("get the proper command", func() {
 		logsCmd := NewCmd()
-		Expect(logsCmd.Use).To(BeEquivalentTo("logs cluster"))
-		Expect(logsCmd.Short).To(BeEquivalentTo("Collect cluster logs"))
+		Expect(logsCmd.Use).To(BeEquivalentTo("logs"))
+		Expect(logsCmd.Short).To(BeEquivalentTo("Logging utilities"))
 	})
 })

--- a/internal/cmd/plugin/logs/pretty/doc.go
+++ b/internal/cmd/plugin/logs/pretty/doc.go
@@ -14,25 +14,5 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package logs
-
-import (
-	"github.com/spf13/cobra"
-
-	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/plugin"
-	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/plugin/logs/pretty"
-)
-
-// NewCmd creates the new "report" command
-func NewCmd() *cobra.Command {
-	logsCmd := &cobra.Command{
-		Use:     "logs",
-		Short:   "Collect cluster logs",
-		GroupID: plugin.GroupIDTroubleshooting,
-	}
-
-	logsCmd.AddCommand(clusterCmd())
-	logsCmd.AddCommand(pretty.NewCmd())
-
-	return logsCmd
-}
+// Package pretty contains the implementation of `kubectl cnpg logs pretty`
+package pretty

--- a/internal/cmd/plugin/logs/pretty/log_level.go
+++ b/internal/cmd/plugin/logs/pretty/log_level.go
@@ -1,0 +1,83 @@
+/*
+Copyright The CloudNativePG Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pretty
+
+import (
+	"errors"
+
+	"github.com/cloudnative-pg/machinery/pkg/log"
+	"go.uber.org/zap/zapcore"
+)
+
+// ErrUnknownLogLevel is returned when an unknown string representation
+// of a log level is used
+var ErrUnknownLogLevel = errors.New("unknown log level")
+
+// LogLevel represent a log level such as error, warning, info, debug, or trace.
+type LogLevel string
+
+// Less return true when the received event is less than
+// the passed one
+func (l LogLevel) Less(o LogLevel) bool {
+	return l.toInt() < o.toInt()
+}
+
+// String is the string representation of this level
+func (l LogLevel) String() string {
+	return string(l)
+}
+
+// Type is the data type to be used for this type
+// when used as a flag
+func (l LogLevel) Type() string {
+	return "string"
+}
+
+// Set sets a log level given its string representation
+func (l *LogLevel) Set(val string) error {
+	switch val {
+	case log.ErrorLevelString, log.WarningLevelString, log.InfoLevelString, log.DebugLevelString, log.TraceLevelString:
+		*l = LogLevel(val)
+		return nil
+
+	default:
+		return ErrUnknownLogLevel
+	}
+}
+
+// toInt returns the corresponding zapcore level
+func (l LogLevel) toInt() zapcore.Level {
+	switch l {
+	case log.ErrorLevelString:
+		return log.ErrorLevel
+
+	case log.WarningLevelString:
+		return log.WarningLevel
+
+	case log.InfoLevelString:
+		return log.InfoLevel
+
+	case log.DebugLevelString:
+		return log.DebugLevel
+
+	case log.TraceLevelString:
+		return log.TraceLevel
+
+	default:
+		return log.ErrorLevel
+	}
+}

--- a/internal/cmd/plugin/logs/pretty/log_level.go
+++ b/internal/cmd/plugin/logs/pretty/log_level.go
@@ -27,10 +27,10 @@ import (
 // of a log level is used
 var ErrUnknownLogLevel = errors.New("unknown log level")
 
-// LogLevel represent a log level such as error, warning, info, debug, or trace.
+// LogLevel represents a log level such as error, warning, info, debug, or trace.
 type LogLevel string
 
-// Less return true when the received event is less than
+// Less returns true when the received event is less than
 // the passed one
 func (l LogLevel) Less(o LogLevel) bool {
 	return l.toInt() < o.toInt()

--- a/internal/cmd/plugin/logs/pretty/log_record.go
+++ b/internal/cmd/plugin/logs/pretty/log_record.go
@@ -31,7 +31,6 @@ import (
 var colorizers = []func(any) aurora.Value{
 	aurora.Red,
 	aurora.Green,
-	aurora.Blue,
 	aurora.Magenta,
 	aurora.Cyan,
 	aurora.Yellow,
@@ -130,8 +129,8 @@ func (record *logRecord) print(writer io.Writer) error {
 
 	_, err := fmt.Fprintln(
 		writer,
-		aurora.Green(record.TS),
-		strings.ToUpper(level),
+		record.TS,
+		aurora.Blue(strings.ToUpper(level)),
 		colorizers[colorIdx](record.LoggingPod),
 		aurora.Blue(record.Logger),
 		message,

--- a/internal/cmd/plugin/logs/pretty/log_record.go
+++ b/internal/cmd/plugin/logs/pretty/log_record.go
@@ -36,7 +36,7 @@ var colorizers = []func(any) aurora.Value{
 	aurora.Yellow,
 }
 
-// logRecord is the portion of the structure of a CNPG logging
+// logRecord is the portion of the structure of a CNPG log
 // that is handled by the beautifier
 type logRecord struct {
 	Level      LogLevel `json:"level"`
@@ -78,6 +78,8 @@ func newLogRecordFromBytes(bytes []byte) (*logRecord, error) {
 	return &record, nil
 }
 
+// normalize converts the error_severity into one of the acceptable
+// LogLevel values
 func (record *logRecord) normalize() {
 	message := record.Msg
 	level := string(record.Level)
@@ -107,7 +109,7 @@ func (record *logRecord) normalize() {
 	record.Level = LogLevel(level)
 }
 
-// prints dumps the formatted record to the specified writer
+// print dumps the formatted record to the specified writer
 func (record *logRecord) print(writer io.Writer) error {
 	message := record.Msg
 	level := string(record.Level)

--- a/internal/cmd/plugin/logs/pretty/log_record.go
+++ b/internal/cmd/plugin/logs/pretty/log_record.go
@@ -1,0 +1,141 @@
+/*
+Copyright The CloudNativePG Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pretty
+
+import (
+	"encoding/json"
+	"fmt"
+	"hash/fnv"
+	"io"
+	"strings"
+
+	"github.com/logrusorgru/aurora/v4"
+)
+
+// colorizers is a list of functions that can be used to decorate
+// pod names
+var colorizers = []func(any) aurora.Value{
+	aurora.Red,
+	aurora.Green,
+	aurora.Blue,
+	aurora.Magenta,
+	aurora.Cyan,
+	aurora.Yellow,
+}
+
+// logRecord is the portion of the structure of a CNPG logging
+// that is handled by the beautifier
+type logRecord struct {
+	Level      LogLevel `json:"level"`
+	Msg        string   `json:"msg"`
+	Logger     string   `json:"logger"`
+	TS         string   `json:"ts"`
+	LoggingPod string   `json:"logging_pod"`
+	Record     struct {
+		ErrorSeverity string `json:"error_severity"`
+		Message       string `json:"message"`
+	} `json:"record,omitempty"`
+
+	AdditionalFields map[string]any
+}
+
+func newLogRecordFromBytes(bytes []byte) (*logRecord, error) {
+	var record logRecord
+
+	if err := json.Unmarshal(bytes, &record); err != nil {
+		return nil, fmt.Errorf("decoding log record: %w", err)
+	}
+
+	extraFields := make(map[string]any)
+	if err := json.Unmarshal(bytes, &extraFields); err != nil {
+		return nil, fmt.Errorf("decoding extra fields: %w", err)
+	}
+
+	delete(extraFields, "level")
+	delete(extraFields, "msg")
+	delete(extraFields, "logger")
+	delete(extraFields, "ts")
+	delete(extraFields, "logging_pod")
+	delete(extraFields, "record")
+	delete(extraFields, "controllerGroup")
+	delete(extraFields, "controllerKind")
+	delete(extraFields, "Cluster")
+
+	record.AdditionalFields = extraFields
+	return &record, nil
+}
+
+func (record *logRecord) normalize() {
+	message := record.Msg
+	level := string(record.Level)
+
+	if record.Msg == "record" {
+		switch record.Record.ErrorSeverity {
+		case "DEBUG1", "DEBUG2", "DEBUG3", "DEBUG4", "DEBUG5":
+			level = "trace"
+
+		case "INFO", "NOTICE", "LOG":
+			level = "info"
+
+		case "WARNING":
+			level = "warning"
+
+		case "ERROR", "FATAL", "PANIC":
+			level = "error"
+
+		default:
+			level = "info"
+		}
+
+		message = record.Record.Message
+	}
+
+	record.Msg = message
+	record.Level = LogLevel(level)
+}
+
+// prints dumps the formatted record to the specified writer
+func (record *logRecord) print(writer io.Writer) error {
+	message := record.Msg
+	level := string(record.Level)
+
+	if record.Msg == "record" {
+		level = record.Record.ErrorSeverity
+		message = record.Record.Message
+	}
+
+	additionalFields := ""
+	if len(record.AdditionalFields) > 0 {
+		v, _ := json.Marshal(record.AdditionalFields)
+		additionalFields = string(v)
+	}
+
+	hasher := fnv.New32a()
+	_, _ = hasher.Write([]byte(record.LoggingPod))
+	colorIdx := int(hasher.Sum32()) % len(colorizers)
+
+	_, err := fmt.Fprintln(
+		writer,
+		aurora.Green(record.TS),
+		strings.ToUpper(level),
+		colorizers[colorIdx](record.LoggingPod),
+		aurora.Blue(record.Logger),
+		message,
+		additionalFields,
+	)
+	return err
+}

--- a/internal/cmd/plugin/logs/pretty/log_record.go
+++ b/internal/cmd/plugin/logs/pretty/log_record.go
@@ -129,9 +129,16 @@ func (record *logRecord) print(writer io.Writer) error {
 	_, _ = hasher.Write([]byte(record.LoggingPod))
 	colorIdx := int(hasher.Sum32()) % len(colorizers)
 
+	// truncate the timestamp to microsecond
+	// precision
+	ts := record.TS
+	if len(ts) > 23 {
+		ts = record.TS[:23]
+	}
+
 	_, err := fmt.Fprintln(
 		writer,
-		record.TS,
+		ts,
 		aurora.Blue(strings.ToUpper(level)),
 		colorizers[colorIdx](record.LoggingPod),
 		aurora.Blue(record.Logger),

--- a/internal/cmd/plugin/logs/pretty/pretty.go
+++ b/internal/cmd/plugin/logs/pretty/pretty.go
@@ -44,7 +44,7 @@ type prettyCmd struct {
 // NewCmd creates a new `kubectl cnpg logs pretty` command
 func NewCmd() *cobra.Command {
 	var loggers, pods []string
-	var groupSize, verbosity int
+	var sortingGroupSize, verbosity int
 	bf := prettyCmd{}
 
 	cmd := &cobra.Command{
@@ -58,7 +58,7 @@ func NewCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			bf.loggers = stringset.From(loggers)
 			bf.pods = stringset.From(pods)
-			bf.groupSize = groupSize
+			bf.groupSize = sortingGroupSize
 			bf.verbosity = verbosity
 
 			recordChannel := make(chan logRecord)
@@ -89,8 +89,8 @@ func NewCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().IntVar(&groupSize, "group-size", 200,
-		"The maximum size of the log section to be sorted")
+	cmd.Flags().IntVar(&sortingGroupSize, "sorting-group-size", 200,
+		"The maximum size of the window where logs are collected for sorting")
 	cmd.Flags().StringSliceVar(&loggers, "loggers", nil,
 		"The list of loggers to receive. Defaults to all.")
 	cmd.Flags().StringSliceVar(&pods, "pods", nil,

--- a/internal/cmd/plugin/logs/pretty/pretty.go
+++ b/internal/cmd/plugin/logs/pretty/pretty.go
@@ -47,7 +47,7 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "pretty",
 		Short: "Prettify CNPG logs",
-		Long:  "Reads CNPG logs from the standard input and pretty-print them for human consumption",
+		Long:  "Reads CNPG logs from standard input and pretty-prints them for human consumption",
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			return plugin.CompleteClusters(cmd.Context(), args, toComplete), cobra.ShellCompDirectiveNoFileComp
 		},
@@ -95,7 +95,7 @@ Should be empty or one of error, warning, info, debug, or trace.`)
 	return cmd
 }
 
-// decode progressively decode the logs
+// decode progressively decodes the logs
 func (bf *prettyCmd) decode(ctx context.Context, reader io.Reader, recordChannel chan<- logRecord) {
 	scanner := bufio.NewScanner(reader)
 
@@ -174,7 +174,7 @@ logLoop:
 	close(groupChannel)
 }
 
-// write write the logs on the output
+// write writes the logs on the output
 func (bf *prettyCmd) write(ctx context.Context, recordGroupChannel <-chan []logRecord, writer io.Writer) {
 	logRecordComparison := func(l1, l2 logRecord) int {
 		if l1.TS < l2.TS {
@@ -219,7 +219,7 @@ logLoop:
 	}
 }
 
-// isRelevant is true when the passed log record is matched
+// isRecordRelevant is true when the passed log record is matched
 // by the filters set by the user
 func (bf *prettyCmd) isRecordRelevant(record *logRecord) bool {
 	if bf.loggers.Len() > 0 && !bf.loggers.Has(record.Logger) {

--- a/internal/cmd/plugin/logs/pretty/pretty.go
+++ b/internal/cmd/plugin/logs/pretty/pretty.go
@@ -1,0 +1,242 @@
+/*
+Copyright The CloudNativePG Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pretty
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"slices"
+	"sync"
+	"time"
+
+	"github.com/cloudnative-pg/machinery/pkg/stringset"
+	"github.com/logrusorgru/aurora/v4"
+	"github.com/spf13/cobra"
+
+	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/plugin"
+)
+
+type prettyCmd struct {
+	loggers  *stringset.Data
+	pods     *stringset.Data
+	minLevel LogLevel
+}
+
+// NewCmd creates a new `kubectl cnpg logs pretty` command
+func NewCmd() *cobra.Command {
+	var loggers, pods []string
+	bf := prettyCmd{}
+
+	cmd := &cobra.Command{
+		Use:   "pretty",
+		Short: "Prettify CNPG logs",
+		Long:  "Reads CNPG logs from the standard input and pretty-print them for human consumption",
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return plugin.CompleteClusters(cmd.Context(), args, toComplete), cobra.ShellCompDirectiveNoFileComp
+		},
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			bf.loggers = stringset.From(loggers)
+			bf.pods = stringset.From(pods)
+
+			recordChannel := make(chan logRecord)
+			recordGroupsChannel := make(chan []logRecord)
+
+			var wait sync.WaitGroup
+
+			wait.Add(1)
+			go func() {
+				bf.decode(cmd.Context(), os.Stdin, recordChannel)
+				wait.Done()
+			}()
+
+			wait.Add(1)
+			go func() {
+				bf.group(cmd.Context(), recordChannel, recordGroupsChannel)
+				wait.Done()
+			}()
+
+			wait.Add(1)
+			go func() {
+				bf.write(cmd.Context(), recordGroupsChannel, os.Stdout)
+				wait.Done()
+			}()
+
+			wait.Wait()
+			return nil
+		},
+	}
+
+	cmd.Flags().StringSliceVar(&loggers, "loggers", nil,
+		"The list of loggers to receive. Defaults to all.")
+	cmd.Flags().StringSliceVar(&pods, "pods", nil,
+		"The list of pods to receive from. Defaults to all.")
+	cmd.Flags().Var(&bf.minLevel, "min-level",
+		`Hides the messages whose log level is less important than the specified one.
+Should be empty or one of error, warning, info, debug, or trace.`)
+
+	return cmd
+}
+
+// decode progressively decode the logs
+func (bf *prettyCmd) decode(ctx context.Context, reader io.Reader, recordChannel chan<- logRecord) {
+	scanner := bufio.NewScanner(reader)
+
+	for scanner.Scan() {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
+		record, err := newLogRecordFromBytes(scanner.Bytes())
+		if err != nil {
+			_, _ = fmt.Fprintln(
+				os.Stderr,
+				aurora.Red(fmt.Sprintf("JSON syntax error (%s)", err.Error())),
+				scanner.Text())
+			continue
+		}
+
+		record.normalize()
+
+		if !bf.isRecordRelevant(record) {
+			continue
+		}
+
+		recordChannel <- *record
+	}
+
+	close(recordChannel)
+}
+
+// group transforms a stream of logs in a stream of log groups
+func (bf *prettyCmd) group(ctx context.Context, logChannel <-chan logRecord, groupChannel chan<- []logRecord) {
+	const bufferMaxEntries = 200
+	var bufferArray [bufferMaxEntries]logRecord
+
+	buffer := bufferArray[0:0]
+
+	pushLogGroup := func() {
+		if len(buffer) == 0 {
+			return
+		}
+
+		bufferCopy := make([]logRecord, len(buffer))
+		copy(bufferCopy, buffer)
+		groupChannel <- bufferCopy
+
+		buffer = bufferArray[0:0]
+	}
+
+logLoop:
+	for {
+		timer := time.NewTimer(1 * time.Second)
+		defer timer.Stop()
+
+		select {
+		case <-ctx.Done():
+			break logLoop
+
+		case <-timer.C:
+			pushLogGroup()
+
+		case logRecord, ok := <-logChannel:
+			if !ok {
+				break logLoop
+			}
+
+			buffer = append(buffer, logRecord)
+			if len(buffer) == bufferMaxEntries {
+				pushLogGroup()
+			}
+		}
+	}
+
+	pushLogGroup()
+	close(groupChannel)
+}
+
+// write write the logs on the output
+func (bf *prettyCmd) write(ctx context.Context, recordGroupChannel <-chan []logRecord, writer io.Writer) {
+	logRecordComparison := func(l1, l2 logRecord) int {
+		if l1.TS < l2.TS {
+			return -1
+		} else if l1.TS > l2.TS {
+			return 1
+		}
+
+		if l1.LoggingPod < l2.LoggingPod {
+			return -1
+		} else if l1.LoggingPod == l2.LoggingPod {
+			return 0
+		}
+
+		return 1
+	}
+	firstGroup := true
+
+logLoop:
+	for {
+		select {
+		case <-ctx.Done():
+			break logLoop
+
+		case logGroupRecord, ok := <-recordGroupChannel:
+			if !ok {
+				break logLoop
+			}
+
+			slices.SortFunc(logGroupRecord, logRecordComparison)
+
+			if !firstGroup {
+				_, _ = writer.Write([]byte("---\n"))
+			}
+			for _, record := range logGroupRecord {
+				if err := record.print(writer); err != nil {
+					bf.emergencyLog(err, "Dumping a log entry")
+				}
+			}
+			firstGroup = false
+		}
+	}
+}
+
+// isRelevant is true when the passed log record is matched
+// by the filters set by the user
+func (bf *prettyCmd) isRecordRelevant(record *logRecord) bool {
+	if bf.loggers.Len() > 0 && !bf.loggers.Has(record.Logger) {
+		return false
+	}
+
+	if bf.pods.Len() > 0 && !bf.pods.Has(record.LoggingPod) {
+		return false
+	}
+
+	if bf.minLevel != "" && record.Level.Less(bf.minLevel) {
+		return false
+	}
+
+	return true
+}
+
+func (bf *prettyCmd) emergencyLog(err error, msg string) {
+	fmt.Println(aurora.Red("ERROR"), err.Error(), msg)
+}

--- a/internal/cmd/plugin/logs/pretty/pretty.go
+++ b/internal/cmd/plugin/logs/pretty/pretty.go
@@ -136,7 +136,7 @@ func (bf *prettyCmd) decode(ctx context.Context, reader io.Reader, recordChannel
 	close(recordChannel)
 }
 
-// group transforms a stream of logs in a stream of log groups, so that the groups
+// group transforms a stream of logs into a stream of log groups, so that the groups
 // can then be sorted
 func (bf *prettyCmd) group(ctx context.Context, logChannel <-chan logRecord, groupChannel chan<- []logRecord) {
 	bufferArray := make([]logRecord, bf.groupSize)

--- a/internal/cmd/plugin/logs/pretty/pretty.go
+++ b/internal/cmd/plugin/logs/pretty/pretty.go
@@ -89,7 +89,7 @@ func NewCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().IntVar(&sortingGroupSize, "sorting-group-size", 200,
+	cmd.Flags().IntVar(&sortingGroupSize, "sorting-group-size", 1000,
 		"The maximum size of the window where logs are collected for sorting")
 	cmd.Flags().StringSliceVar(&loggers, "loggers", nil,
 		"The list of loggers to receive. Defaults to all.")

--- a/internal/cmd/plugin/logs/pretty/pretty.go
+++ b/internal/cmd/plugin/logs/pretty/pretty.go
@@ -136,7 +136,8 @@ func (bf *prettyCmd) decode(ctx context.Context, reader io.Reader, recordChannel
 	close(recordChannel)
 }
 
-// group transforms a stream of logs in a stream of log groups
+// group transforms a stream of logs in a stream of log groups, so that the groups
+// can then be sorted
 func (bf *prettyCmd) group(ctx context.Context, logChannel <-chan logRecord, groupChannel chan<- []logRecord) {
 	bufferArray := make([]logRecord, bf.groupSize)
 


### PR DESCRIPTION
This commit introduces the `logs pretty` command to the `cnpg` plugin. The command reads a log stream from standard input and outputs a human-readable format to standard output.

Key features:

- Allows filtering logs by specific pods or loggers.
- Supports excluding logs below a specified severity level.

This enhancement provides users with better log readability and more granular control over the logs they wish to view.

Closes: #5770 

# Release notes

```
Add the `logs pretty` command to the `cnpg` plugin to read a log stream from standard input and output a human-readable format, with options to filter log entries.
```