### PR TITLE
chore(logging): avoid creating multiple loggers

### DIFF
--- a/api/v1/cluster_funcs.go
+++ b/api/v1/cluster_funcs.go
@@ -118,7 +118,6 @@ func (st *ServiceAccountTemplate) MergeMetadata(sa *corev1.ServiceAccount) {
 // MatchesTopology checks if the two topologies have
 // the same label values (labels are specified in SyncReplicaElectionConstraints.NodeLabelsAntiAffinity)
 func (topologyLabels PodTopologyLabels) MatchesTopology(instanceTopology PodTopologyLabels) bool {
-	log.Debug("matching topology", "main", topologyLabels, "second", instanceTopology)
 	for mainLabelName, mainLabelValue := range topologyLabels {
 		if mainLabelValue != instanceTopology[mainLabelName] {
 			return false

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -40,6 +40,8 @@ import (
 )
 
 func main() {
+	cobra.EnableTraverseRunHooks = true
+
 	logFlags := &log.Flags{}
 
 	cmd := &cobra.Command{

--- a/docs/src/logging.md
+++ b/docs/src/logging.md
@@ -192,6 +192,7 @@ Therefore, all the possible `logger` values are the following:
 - `postgres`: from the `postgres` instance (having `msg` different than `record`)
 - `wal-archive`: from the `wal-archive` subcommand of the instance manager
 - `wal-restore`: from the `wal-restore` subcommand of the instance manager
+- `instance-manager`: from the [PostgreSQL instance manager](./instance_manager.md)
 
 Except for `postgres`, which has the aforementioned structures,
 all other possible values have `msg` set to the escaped message that's

--- a/internal/cmd/manager/bootstrap/cmd.go
+++ b/internal/cmd/manager/bootstrap/cmd.go
@@ -33,9 +33,10 @@ func NewCmd() *cobra.Command {
 		Use:  "bootstrap [target]",
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			contextLogger := log.FromContext(cmd.Context())
 			dest := args[0]
 
-			log.Info("Installing the manager executable",
+			contextLogger.Info("Installing the manager executable",
 				"destination", dest,
 				"version", versions.Version,
 				"build", versions.Info)
@@ -44,13 +45,13 @@ func NewCmd() *cobra.Command {
 				panic(err)
 			}
 
-			log.Info("Setting 0750 permissions")
+			contextLogger.Info("Setting 0750 permissions")
 			err = os.Chmod(dest, 0o750) // #nosec
 			if err != nil {
 				panic(err)
 			}
 
-			log.Info("Bootstrap completed")
+			contextLogger.Info("Bootstrap completed")
 
 			return nil
 		},

--- a/internal/cmd/manager/debug/architectures/cmd.go
+++ b/internal/cmd/manager/debug/architectures/cmd.go
@@ -32,9 +32,10 @@ func NewCmd() *cobra.Command {
 	cmd := cobra.Command{
 		Use:   "show-architectures",
 		Short: "Lists all the CPU architectures supported by this image",
-		RunE: func(_ *cobra.Command, _ []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			contextLogger := log.FromContext(cmd.Context())
 			if err := run(); err != nil {
-				log.Error(err, "Error while extracting the list of supported architectures")
+				contextLogger.Error(err, "Error while extracting the list of supported architectures")
 				return err
 			}
 

--- a/internal/cmd/manager/instance/initdb/cmd.go
+++ b/internal/cmd/manager/instance/initdb/cmd.go
@@ -60,28 +60,29 @@ func NewCmd() *cobra.Command {
 		},
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := cmd.Context()
+			contextLogger := log.FromContext(ctx)
 
 			initDBFlags, err := shellquote.Split(initDBFlagsString)
 			if err != nil {
-				log.Error(err, "Error while parsing initdb flags")
+				contextLogger.Error(err, "Error while parsing initdb flags")
 				return err
 			}
 
 			postInitSQL, err := shellquote.Split(postInitSQLStr)
 			if err != nil {
-				log.Error(err, "Error while parsing post init SQL queries")
+				contextLogger.Error(err, "Error while parsing post init SQL queries")
 				return err
 			}
 
 			postInitApplicationSQL, err := shellquote.Split(postInitApplicationSQLStr)
 			if err != nil {
-				log.Error(err, "Error while parsing post init template SQL queries")
+				contextLogger.Error(err, "Error while parsing post init template SQL queries")
 				return err
 			}
 
 			postInitTemplateSQL, err := shellquote.Split(postInitTemplateSQLStr)
 			if err != nil {
-				log.Error(err, "Error while parsing post init template SQL queries")
+				contextLogger.Error(err, "Error while parsing post init template SQL queries")
 				return err
 			}
 
@@ -148,6 +149,7 @@ func NewCmd() *cobra.Command {
 }
 
 func initSubCommand(ctx context.Context, info postgres.InitInfo) error {
+	contextLogger := log.FromContext(ctx)
 	err := info.CheckTargetDataDirectory(ctx)
 	if err != nil {
 		return err
@@ -155,7 +157,7 @@ func initSubCommand(ctx context.Context, info postgres.InitInfo) error {
 
 	err = info.Bootstrap(ctx)
 	if err != nil {
-		log.Error(err, "Error while bootstrapping data directory")
+		contextLogger.Error(err, "Error while bootstrapping data directory")
 		return err
 	}
 

--- a/internal/cmd/manager/instance/join/cmd.go
+++ b/internal/cmd/manager/instance/join/cmd.go
@@ -93,13 +93,15 @@ func NewCmd() *cobra.Command {
 }
 
 func joinSubCommand(ctx context.Context, instance *postgres.Instance, info postgres.InitInfo) error {
+	contextLogger := log.FromContext(ctx)
+
 	if err := info.CheckTargetDataDirectory(ctx); err != nil {
 		return err
 	}
 
 	client, err := management.NewControllerRuntimeClient()
 	if err != nil {
-		log.Error(err, "Error creating Kubernetes client")
+		contextLogger.Error(err, "Error creating Kubernetes client")
 		return err
 	}
 
@@ -114,7 +116,7 @@ func joinSubCommand(ctx context.Context, instance *postgres.Instance, info postg
 		ctrl.ObjectKey{Namespace: instance.GetNamespaceName(), Name: instance.GetClusterName()},
 		&cluster,
 	); err != nil {
-		log.Error(err, "Error while getting cluster")
+		contextLogger.Error(err, "Error while getting cluster")
 		return err
 	}
 
@@ -130,8 +132,8 @@ func joinSubCommand(ctx context.Context, instance *postgres.Instance, info postg
 	reconciler.RefreshSecrets(ctx, &cluster)
 
 	// Run "pg_basebackup" to download the data directory from the primary
-	if err := info.Join(&cluster); err != nil {
-		log.Error(err, "Error joining node")
+	if err := info.Join(ctx, &cluster); err != nil {
+		contextLogger.Error(err, "Error joining node")
 		return err
 	}
 

--- a/internal/cmd/manager/instance/restoresnapshot/cmd.go
+++ b/internal/cmd/manager/instance/restoresnapshot/cmd.go
@@ -55,6 +55,7 @@ func NewCmd() *cobra.Command {
 		},
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := cmd.Context()
+			contextLogger := log.FromContext(ctx)
 
 			info := postgres.InitInfo{
 				ClusterName: clusterName,
@@ -81,7 +82,7 @@ func NewCmd() *cobra.Command {
 
 			err := execute(ctx, info, immediate)
 			if err != nil {
-				log.Error(err, "Error while recovering Volume Snapshot backup")
+				contextLogger.Error(err, "Error while recovering Volume Snapshot backup")
 			}
 			return err
 		},

--- a/internal/cmd/manager/instance/run/lifecycle/run.go
+++ b/internal/cmd/manager/instance/run/lifecycle/run.go
@@ -98,7 +98,7 @@ func (i *PostgresLifecycle) runPostgresAndWait(ctx context.Context) <-chan error
 			return err
 		}
 
-		log.Info("postmaster started", "postMasterPID", postMasterPID)
+		contextLogger.Info("postmaster started", "postMasterPID", postMasterPID)
 
 		// Now we'll wait for PostgreSQL to accept connections, and setup everything required
 		// for replication and pg_rewind to work correctly.
@@ -116,7 +116,11 @@ func (i *PostgresLifecycle) runPostgresAndWait(ctx context.Context) <-chan error
 		defer i.instance.SetCanCheckReadiness(false)
 
 		postmasterExitStatus := streamingCmd.Wait()
-		log.Info("postmaster exited", "postmasterExitStatus", postmasterExitStatus, "postMasterPID", postMasterPID)
+		contextLogger.Info(
+			"postmaster exited",
+			"postmasterExitStatus", postmasterExitStatus,
+			"postMasterPID", postMasterPID,
+		)
 		return postmasterExitStatus
 	}
 

--- a/internal/cmd/manager/instance/status/cmd.go
+++ b/internal/cmd/manager/instance/status/cmd.go
@@ -49,15 +49,16 @@ func NewCmd() *cobra.Command {
 }
 
 func statusSubCommand(ctx context.Context) error {
+	contextLogger := log.FromContext(ctx)
 	cli, err := management.NewControllerRuntimeClient()
 	if err != nil {
-		log.Error(err, "while building the controller runtime client")
+		contextLogger.Error(err, "while building the controller runtime client")
 		return err
 	}
 
 	cluster, err := cacheClient.GetCluster()
 	if err != nil {
-		log.Error(err, "while loading the cluster from cache")
+		contextLogger.Error(err, "while loading the cluster from cache")
 		return err
 	}
 
@@ -67,7 +68,7 @@ func statusSubCommand(ctx context.Context) error {
 		cluster.GetServerCASecretObjectKey(),
 	)
 	if err != nil {
-		log.Error(err, "Error while building the TLS context")
+		contextLogger.Error(err, "Error while building the TLS context")
 		return err
 	}
 
@@ -76,14 +77,14 @@ func statusSubCommand(ctx context.Context) error {
 		resp, err = executeRequest(ctx, "http")
 	}
 	if err != nil {
-		log.Error(err, "Error while requesting instance status")
+		contextLogger.Error(err, "Error while requesting instance status")
 		return err
 	}
 
 	defer func() {
 		err = resp.Body.Close()
 		if err != nil {
-			log.Error(err, "Can't close the connection",
+			contextLogger.Error(err, "Can't close the connection",
 				"statusCode", resp.StatusCode,
 			)
 		}
@@ -91,14 +92,14 @@ func statusSubCommand(ctx context.Context) error {
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		log.Error(err, "Error while reading status response body",
+		contextLogger.Error(err, "Error while reading status response body",
 			"statusCode", resp.StatusCode,
 		)
 		return err
 	}
 
 	if resp.StatusCode != 200 {
-		log.Info(
+		contextLogger.Info(
 			"Error while extracting status",
 			"statusCode", resp.StatusCode,
 			"body", string(body),
@@ -108,7 +109,7 @@ func statusSubCommand(ctx context.Context) error {
 
 	_, err = os.Stdout.Write(body)
 	if err != nil {
-		log.Error(err, "Error while showing status info")
+		contextLogger.Error(err, "Error while showing status info")
 		return err
 	}
 
@@ -119,13 +120,15 @@ func executeRequest(ctx context.Context, scheme string) (*http.Response, error) 
 	const connectionTimeout = 2 * time.Second
 	const requestTimeout = 30 * time.Second
 
+	contextLogger := log.FromContext(ctx)
+
 	statusURL := url.Build(
 		scheme,
 		"localhost", url.PathPgStatus, url.StatusPort,
 	)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, statusURL, nil)
 	if err != nil {
-		log.Error(err, "Error while building the request")
+		contextLogger.Error(err, "Error while building the request")
 		return nil, err
 	}
 	httpClient := resources.NewHTTPClient(connectionTimeout, requestTimeout)

--- a/internal/cmd/manager/pgbouncer/run/cmd.go
+++ b/internal/cmd/manager/pgbouncer/run/cmd.go
@@ -54,9 +54,10 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:           "run",
 		SilenceErrors: true,
-		PreRunE: func(_ *cobra.Command, _ []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
+			contextLogger := log.FromContext(cmd.Context())
 			if poolerNamespacedName.Name == "" || poolerNamespacedName.Namespace == "" {
-				log.Info(
+				contextLogger.Info(
 					"pooler object key not set",
 					"poolerNamespacedName", poolerNamespacedName)
 				return errorMissingPoolerNamespacedName
@@ -64,8 +65,14 @@ func NewCmd() *cobra.Command {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			if err := runSubCommand(cmd.Context(), poolerNamespacedName); err != nil {
-				log.Error(err, "Error while running manager")
+			ctx := log.IntoContext(
+				cmd.Context(),
+				log.GetLogger().WithValues("logger", "pgbouncer-manager"),
+			)
+			contextLogger := log.FromContext(ctx)
+
+			if err := runSubCommand(ctx, poolerNamespacedName); err != nil {
+				contextLogger.Error(err, "Error while running manager")
 				return err
 			}
 			return nil
@@ -91,11 +98,12 @@ func NewCmd() *cobra.Command {
 func runSubCommand(ctx context.Context, poolerNamespacedName types.NamespacedName) error {
 	var err error
 
-	log.Info("Starting CloudNativePG PgBouncer Instance Manager",
+	contextLogger := log.FromContext(ctx)
+	contextLogger.Info("Starting CloudNativePG PgBouncer Instance Manager",
 		"version", versions.Version,
 		"build", versions.Info)
 
-	if err = startWebServer(); err != nil {
+	if err = startWebServer(ctx); err != nil {
 		return fmt.Errorf("while starting the web server: %w", err)
 	}
 
@@ -114,10 +122,10 @@ func runSubCommand(ctx context.Context, poolerNamespacedName types.NamespacedNam
 	pgBouncerIni := filepath.Join(config.ConfigsDir, config.PgBouncerIniFileName)
 	pgBouncerCmd := exec.Command(pgBouncerCommandName, pgBouncerIni) //nolint:gosec
 	stdoutWriter := &execlog.LogWriter{
-		Logger: log.WithValues(execlog.PipeKey, execlog.StdOut),
+		Logger: contextLogger.WithValues(execlog.PipeKey, execlog.StdOut),
 	}
 	stderrWriter := &pgBouncerLogWriter{
-		Logger: log.WithValues(execlog.PipeKey, execlog.StdErr),
+		Logger: contextLogger.WithValues(execlog.PipeKey, execlog.StdErr),
 	}
 	streamingCmd, err := execlog.RunStreamingNoWaitWithWriter(
 		pgBouncerCmd, pgBouncerCommandName, stdoutWriter, stderrWriter)
@@ -126,14 +134,14 @@ func runSubCommand(ctx context.Context, poolerNamespacedName types.NamespacedNam
 	}
 
 	startReconciler(ctx, reconciler)
-	registerSignalHandler(reconciler, pgBouncerCmd)
+	registerSignalHandler(ctx, reconciler, pgBouncerCmd)
 
 	if err = streamingCmd.Wait(); err != nil {
 		var exitError *exec.ExitError
 		if !errors.As(err, &exitError) {
-			log.Error(err, "Error waiting on pgbouncer process")
+			contextLogger.Error(err, "Error waiting on pgbouncer process")
 		} else {
-			log.Error(exitError, "pgbouncer process exited with errors")
+			contextLogger.Error(exitError, "pgbouncer process exited with errors")
 		}
 		return err
 	}
@@ -143,29 +151,30 @@ func runSubCommand(ctx context.Context, poolerNamespacedName types.NamespacedNam
 
 // registerSignalHandler handles signals from k8s, notifying postgres as
 // needed
-func registerSignalHandler(reconciler *controller.PgBouncerReconciler, command *exec.Cmd) {
+func registerSignalHandler(ctx context.Context, reconciler *controller.PgBouncerReconciler, command *exec.Cmd) {
+	contextLogger := log.FromContext(ctx)
 	signals := make(chan os.Signal, 1)
 	signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM)
 
 	go func() {
 		sig := <-signals
-		log.Info("Received termination signal", "signal", sig)
+		contextLogger.Info("Received termination signal", "signal", sig)
 
-		log.Info("Shutting down web server")
+		contextLogger.Info("Shutting down web server")
 		err := metricsserver.Shutdown()
 		if err != nil {
-			log.Error(err, "Error while shutting down the metrics server")
+			contextLogger.Error(err, "Error while shutting down the metrics server")
 		} else {
-			log.Info("Metrics server shut down")
+			contextLogger.Info("Metrics server shut down")
 		}
 
 		reconciler.Stop()
 
 		if command != nil {
-			log.Info("Shutting down pgbouncer instance")
+			contextLogger.Info("Shutting down pgbouncer instance")
 			err := command.Process.Signal(syscall.SIGINT)
 			if err != nil {
-				log.Error(err, "Unable to send SIGINT to pgbouncer instance")
+				contextLogger.Error(err, "Unable to send SIGINT to pgbouncer instance")
 			}
 		}
 	}()
@@ -173,15 +182,16 @@ func registerSignalHandler(reconciler *controller.PgBouncerReconciler, command *
 
 // startWebServer start the web server for handling probes given
 // a certain PostgreSQL instance
-func startWebServer() error {
-	if err := metricsserver.Setup(); err != nil {
+func startWebServer(ctx context.Context) error {
+	contextLogger := log.FromContext(ctx)
+	if err := metricsserver.Setup(ctx); err != nil {
 		return err
 	}
 
 	go func() {
 		err := metricsserver.ListenAndServe()
 		if err != nil {
-			log.Error(err, "Error while starting the metrics server")
+			contextLogger.Error(err, "Error while starting the metrics server")
 		}
 	}()
 

--- a/internal/cmd/manager/show/walarchivequeue/cmd.go
+++ b/internal/cmd/manager/show/walarchivequeue/cmd.go
@@ -32,9 +32,12 @@ func NewCmd() *cobra.Command {
 	cmd := cobra.Command{
 		Use:   "wal-archive-queue",
 		Short: "Lists all .ready wal files in " + specs.PgWalArchiveStatusPath,
-		RunE: func(_ *cobra.Command, _ []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			ctx := cmd.Context()
+			contextLogger := log.FromContext(ctx)
+
 			if err := run(); err != nil {
-				log.Error(err, "Error while extracting the list of .ready files")
+				contextLogger.Error(err, "Error while extracting the list of .ready files")
 			}
 
 			return nil

--- a/internal/cmd/manager/walarchive/cmd.go
+++ b/internal/cmd/manager/walarchive/cmd.go
@@ -97,7 +97,7 @@ func NewCmd() *cobra.Command {
 					Message: err.Error(),
 				}
 				if errCond := conditions.Patch(ctx, typedClient, cluster, &condition); errCond != nil {
-					log.Error(errCond, "Error changing wal archiving condition (wal archiving failed)")
+					contextLog.Error(errCond, "Error changing wal archiving condition (wal archiving failed)")
 				}
 				return err
 			}
@@ -110,7 +110,7 @@ func NewCmd() *cobra.Command {
 				Message: "Continuous archiving is working",
 			}
 			if errCond := conditions.Patch(ctx, typedClient, cluster, &condition); errCond != nil {
-				log.Error(errCond, "Error changing wal archiving condition (wal archiving succeeded)")
+				contextLog.Error(errCond, "Error changing wal archiving condition (wal archiving succeeded)")
 			}
 
 			return nil
@@ -162,7 +162,7 @@ func run(
 	// Request Barman Cloud to archive this WAL
 	if cluster.Spec.Backup == nil || cluster.Spec.Backup.BarmanObjectStore == nil {
 		// Backup not configured, skipping WAL
-		contextLog.Info("Backup not configured, skip WAL archiving via Barman Cloud",
+		contextLog.Debug("Backup not configured, skip WAL archiving via Barman Cloud",
 			"walName", walName,
 			"currentPrimary", cluster.Status.CurrentPrimary,
 			"targetPrimary", cluster.Status.TargetPrimary,
@@ -299,10 +299,11 @@ func checkWalArchive(
 	walArchiver *barmanArchiver.WALArchiver,
 	pgData string,
 ) error {
+	contextLogger := log.FromContext(ctx)
 	checkWalOptions, err := walArchiver.BarmanCloudCheckWalArchiveOptions(
 		ctx, cluster.Spec.Backup.BarmanObjectStore, cluster.Name)
 	if err != nil {
-		log.Error(err, "while getting barman-cloud-wal-archive options")
+		contextLogger.Error(err, "while getting barman-cloud-wal-archive options")
 		return err
 	}
 
@@ -311,7 +312,7 @@ func checkWalArchive(
 	}
 
 	if err := walArchiver.CheckWalArchiveDestination(ctx, checkWalOptions); err != nil {
-		log.Error(err, "while barman-cloud-check-wal-archive")
+		contextLogger.Error(err, "while barman-cloud-check-wal-archive")
 		return err
 	}
 

--- a/internal/cmd/manager/walrestore/cmd.go
+++ b/internal/cmd/manager/walrestore/cmd.go
@@ -81,7 +81,7 @@ func NewCmd() *cobra.Command {
 			case errors.Is(err, barmanRestorer.ErrWALNotFound):
 				// Nothing to log here. The failure has already been logged.
 			case errors.Is(err, ErrNoBackupConfigured):
-				contextLog.Info("tried restoring WALs, but no backup was configured")
+				contextLog.Debug("tried restoring WALs, but no backup was configured")
 			case errors.Is(err, ErrEndOfWALStreamReached):
 				contextLog.Info(
 					"end-of-wal-stream flag found." +

--- a/internal/controller/cluster_pki.go
+++ b/internal/controller/cluster_pki.go
@@ -83,7 +83,7 @@ func (r *ClusterReconciler) ensureClientCASecret(ctx context.Context, cluster *a
 		return nil, err
 	}
 
-	err = r.verifyCAValidity(secret, cluster)
+	err = r.verifyCAValidity(ctx, secret, cluster)
 	if err != nil {
 		return nil, err
 	}
@@ -120,7 +120,7 @@ func (r *ClusterReconciler) ensureServerCASecret(ctx context.Context, cluster *a
 		return nil, err
 	}
 
-	err = r.verifyCAValidity(secret, cluster)
+	err = r.verifyCAValidity(ctx, secret, cluster)
 	if err != nil {
 		return nil, err
 	}
@@ -139,7 +139,9 @@ func (r *ClusterReconciler) ensureServerCASecret(ctx context.Context, cluster *a
 	return &secret, nil
 }
 
-func (r *ClusterReconciler) verifyCAValidity(secret v1.Secret, cluster *apiv1.Cluster) error {
+func (r *ClusterReconciler) verifyCAValidity(ctx context.Context, secret v1.Secret, cluster *apiv1.Cluster) error {
+	contextLogger := log.FromContext(ctx)
+
 	// Verify validity of the CA and expiration (only ca.crt)
 	publicKey, ok := secret.Data[certs.CACertKey]
 	if !ok {
@@ -156,7 +158,7 @@ func (r *ClusterReconciler) verifyCAValidity(secret v1.Secret, cluster *apiv1.Cl
 	} else if isExpiring {
 		r.Recorder.Event(cluster, "Warning", "SecretIsExpiring",
 			"Checking expiring date of secret "+secret.Name)
-		log.Info("CA certificate is expiring or is already expired", "secret", secret.Name)
+		contextLogger.Info("CA certificate is expiring or is already expired", "secret", secret.Name)
 	}
 
 	return nil

--- a/internal/controller/cluster_status.go
+++ b/internal/controller/cluster_status.go
@@ -243,6 +243,7 @@ func (r *ClusterReconciler) updateResourceStatus(
 	cluster *apiv1.Cluster,
 	resources *managedResources,
 ) error {
+	contextLogger := log.FromContext(ctx)
 	// Retrieve the cluster key
 
 	existingClusterStatus := cluster.Status
@@ -317,7 +318,7 @@ func (r *ClusterReconciler) updateResourceStatus(
 	if poolerIntegrations, err := r.getPoolerIntegrationsNeeded(ctx, cluster); err == nil {
 		cluster.Status.PoolerIntegrations = poolerIntegrations
 	} else {
-		log.Error(err, "while checking pooler integrations were needed, ignored")
+		contextLogger.Error(err, "while checking pooler integrations were needed, ignored")
 	}
 
 	// Set the current hash code of the operator binary inside the status.

--- a/internal/management/controller/cache.go
+++ b/internal/management/controller/cache.go
@@ -47,13 +47,15 @@ func (r *InstanceReconciler) updateCacheFromCluster(ctx context.Context, cluster
 }
 
 func (r *InstanceReconciler) updateWALRestoreSettingsCache(ctx context.Context, cluster *apiv1.Cluster) {
+	contextLogger := log.FromContext(ctx)
+
 	_, env, barmanConfiguration, err := walrestore.GetRecoverConfiguration(cluster, r.instance.GetPodName())
 	if errors.Is(err, walrestore.ErrNoBackupConfigured) {
 		cache.Delete(cache.WALRestoreKey)
 		return
 	}
 	if err != nil {
-		log.Error(err, "while getting recover configuration")
+		contextLogger.Error(err, "while getting recover configuration")
 		return
 	}
 	env = append(env, os.Environ()...)
@@ -66,7 +68,7 @@ func (r *InstanceReconciler) updateWALRestoreSettingsCache(ctx context.Context, 
 		env,
 	)
 	if err != nil {
-		log.Error(err, "while getting recover credentials")
+		contextLogger.Error(err, "while getting recover credentials")
 	}
 	cache.Store(cache.WALRestoreKey, envRestore)
 }
@@ -79,6 +81,8 @@ func (r *InstanceReconciler) shouldUpdateWALArchiveSettingsCache(
 	ctx context.Context,
 	cluster *apiv1.Cluster,
 ) (shouldRetry bool) {
+	contextLogger := log.FromContext(ctx)
+
 	if cluster.Spec.Backup == nil || cluster.Spec.Backup.BarmanObjectStore == nil {
 		cache.Delete(cache.WALArchiveKey)
 		return false
@@ -92,12 +96,12 @@ func (r *InstanceReconciler) shouldUpdateWALArchiveSettingsCache(
 		cluster.Spec.Backup.BarmanObjectStore,
 		os.Environ())
 	if apierrors.IsForbidden(err) {
-		log.Info("backup credentials don't yet have access permissions. Will retry reconciliation loop")
+		contextLogger.Info("backup credentials don't yet have access permissions. Will retry reconciliation loop")
 		return true
 	}
 
 	if err != nil {
-		log.Error(err, "while getting backup credentials")
+		contextLogger.Error(err, "while getting backup credentials")
 		return false
 	}
 

--- a/internal/management/controller/database_controller.go
+++ b/internal/management/controller/database_controller.go
@@ -66,7 +66,7 @@ const databaseReconciliationInterval = 30 * time.Second
 
 // Reconcile is the database reconciliation loop
 func (r *DatabaseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	contextLogger, ctx := log.SetupLogger(ctx)
+	contextLogger := log.FromContext(ctx)
 
 	contextLogger.Debug("Reconciliation loop start")
 	defer func() {

--- a/internal/pgbouncer/management/controller/manager.go
+++ b/internal/pgbouncer/management/controller/manager.go
@@ -63,10 +63,12 @@ func NewPgBouncerReconciler(poolerNamespacedName types.NamespacedName) (*PgBounc
 
 // Run runs the reconciliation loop for this resource
 func (r *PgBouncerReconciler) Run(ctx context.Context) {
+	contextLogger := log.FromContext(ctx)
+
 	for {
 		// Retry with exponential back-off, unless it is a connection refused error
 		err := retry.OnError(retry.DefaultBackoff, func(err error) bool {
-			log.Error(err, "Error calling Watch")
+			contextLogger.Error(err, "Error calling Watch")
 			return !utilnet.IsConnectionRefused(err)
 		}, func() error {
 			return r.watch(ctx)
@@ -81,6 +83,8 @@ func (r *PgBouncerReconciler) Run(ctx context.Context) {
 
 // watch contains the main reconciler loop
 func (r *PgBouncerReconciler) watch(ctx context.Context) error {
+	contextLogger := log.FromContext(ctx)
+
 	var err error
 
 	r.poolerWatch, err = r.client.Watch(ctx, &apiv1.PoolerList{}, &ctrl.ListOptions{
@@ -98,7 +102,7 @@ func (r *PgBouncerReconciler) watch(ctx context.Context) error {
 			return r.Reconcile(ctx, &receivedEvent)
 		})
 		if err != nil {
-			log.Error(err, "Reconciliation error")
+			contextLogger.Error(err, "Reconciliation error")
 		}
 	}
 	return nil
@@ -118,7 +122,7 @@ func (r *PgBouncerReconciler) GetClient() ctrl.Client {
 
 // Reconcile is the main reconciliation loop for the pgbouncer instance
 func (r *PgBouncerReconciler) Reconcile(ctx context.Context, event *watch.Event) error {
-	contextLogger, _ := log.SetupLogger(ctx)
+	contextLogger := log.FromContext(ctx)
 	contextLogger.Debug(
 		"Reconciliation loop",
 		"eventType", event.Type,
@@ -205,7 +209,7 @@ func (r *PgBouncerReconciler) writePgBouncerConfig(ctx context.Context, pooler *
 		return false, fmt.Errorf("while generating pgbouncer configuration: %w", err)
 	}
 
-	return refreshConfigurationFiles(configFiles)
+	return refreshConfigurationFiles(ctx, configFiles)
 }
 
 // Init ensures that all PgBouncer requirement are met.
@@ -214,6 +218,8 @@ func (r *PgBouncerReconciler) writePgBouncerConfig(ctx context.Context, pooler *
 // 1. create the pgbouncer configuration and the required secrets
 // 2. ensure that every needed folder is existent
 func (r *PgBouncerReconciler) Init(ctx context.Context) error {
+	contextLogger := log.FromContext(ctx)
+
 	var pooler apiv1.Pooler
 
 	// Get the pooler from the API Server
@@ -228,7 +234,7 @@ func (r *PgBouncerReconciler) Init(ctx context.Context) error {
 
 	// Ensure we have the directory to store the controlling socket
 	if err := fileutils.EnsureDirectoryExists(config.PgBouncerSocketDir); err != nil {
-		log.Error(err, "while checking socket directory existed", "dir", config.PgBouncerSocketDir)
+		contextLogger.Error(err, "while checking socket directory existed", "dir", config.PgBouncerSocketDir)
 		return err
 	}
 

--- a/internal/pgbouncer/management/controller/refresh.go
+++ b/internal/pgbouncer/management/controller/refresh.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controller
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/cloudnative-pg/machinery/pkg/fileutils"
@@ -27,8 +28,10 @@ import (
 
 // refreshConfigurationFiles writes the configuration files, returning a
 // flag indicating if something is changed or not and an error status
-func refreshConfigurationFiles(files config.ConfigurationFiles) (bool, error) {
+func refreshConfigurationFiles(ctx context.Context, files config.ConfigurationFiles) (bool, error) {
 	var changed bool
+
+	contextLogger := log.FromContext(ctx)
 
 	for fileName, content := range files {
 		changedFile, err := fileutils.WriteFileAtomic(fileName, content, 0o600)
@@ -36,7 +39,7 @@ func refreshConfigurationFiles(files config.ConfigurationFiles) (bool, error) {
 			return false, fmt.Errorf("while recreating configs:%w", err)
 		}
 		if changedFile {
-			log.Info("updated configuration file", "name", fileName)
+			contextLogger.Info("updated configuration file", "name", fileName)
 			changed = true
 		}
 	}

--- a/internal/pgbouncer/management/controller/refresh_test.go
+++ b/internal/pgbouncer/management/controller/refresh_test.go
@@ -45,8 +45,8 @@ var _ = Describe("RefreshConfigurationFiles", func() {
 	})
 
 	Context("when no files are passed", func() {
-		It("should return false and no error", func() {
-			changed, err := refreshConfigurationFiles(files)
+		It("should return false and no error", func(ctx SpecContext) {
+			changed, err := refreshConfigurationFiles(ctx, files)
 			Expect(changed).To(BeFalse())
 			Expect(err).NotTo(HaveOccurred())
 		})
@@ -58,8 +58,8 @@ var _ = Describe("RefreshConfigurationFiles", func() {
 			files[filepath.Join(tmpDir, "config2")] = []byte("content2")
 		})
 
-		It("should write content to files and return true", func() {
-			changed, err := refreshConfigurationFiles(files)
+		It("should write content to files and return true", func(ctx SpecContext) {
+			changed, err := refreshConfigurationFiles(ctx, files)
 			Expect(changed).To(BeTrue())
 			Expect(err).NotTo(HaveOccurred())
 
@@ -76,8 +76,8 @@ var _ = Describe("RefreshConfigurationFiles", func() {
 			files["/proc/you-cannot-write-here.conf"] = []byte("content")
 		})
 
-		It("should return an error", func() {
-			_, err := refreshConfigurationFiles(files)
+		It("should return an error", func(ctx SpecContext) {
+			_, err := refreshConfigurationFiles(ctx, files)
 			Expect(err).To(HaveOccurred())
 		})
 	})

--- a/pkg/management/pgbouncer/metricsserver/metricsserver.go
+++ b/pkg/management/pgbouncer/metricsserver/metricsserver.go
@@ -45,10 +45,10 @@ var (
 
 // Setup configure the web statusServer for a certain PostgreSQL instance, and
 // must be invoked before starting the real web statusServer
-func Setup() error {
+func Setup(ctx context.Context) error {
 	// create the exporter and serve it on the /metrics endpoint
 	registry = prometheus.NewRegistry()
-	exporter = NewExporter()
+	exporter = NewExporter(ctx)
 	if err := registry.Register(exporter); err != nil {
 		return fmt.Errorf("while registering PgBouncer exporters: %w", err)
 	}

--- a/pkg/management/pgbouncer/metricsserver/metricsserver_test.go
+++ b/pkg/management/pgbouncer/metricsserver/metricsserver_test.go
@@ -29,8 +29,8 @@ var _ = Describe("MetricsServer", func() {
 			exporter = nil
 		})
 
-		It("should register exporters and collectors successfully", func() {
-			err := Setup()
+		It("should register exporters and collectors successfully", func(ctx SpecContext) {
+			err := Setup(ctx)
 			Expect(err).NotTo(HaveOccurred())
 
 			mfs, err := registry.Gather()

--- a/pkg/management/pgbouncer/metricsserver/pgbouncer_collector.go
+++ b/pkg/management/pgbouncer/metricsserver/pgbouncer_collector.go
@@ -18,6 +18,7 @@ limitations under the License.
 package metricsserver
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"time"
@@ -35,6 +36,7 @@ const PrometheusNamespace = "cnpg"
 
 // Exporter exports a set of metrics and collectors on a given postgres instance
 type Exporter struct {
+	ctx     context.Context
 	Metrics *metrics
 	pool    pool.Pooler
 }
@@ -53,8 +55,9 @@ type metrics struct {
 }
 
 // NewExporter creates an exporter
-func NewExporter() *Exporter {
+func NewExporter(ctx context.Context) *Exporter {
 	return &Exporter{
+		ctx:     ctx,
 		Metrics: newMetrics(),
 	}
 }
@@ -122,6 +125,8 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 }
 
 func (e *Exporter) collectPgBouncerMetrics(ch chan<- prometheus.Metric) {
+	contextLogger := log.FromContext(e.ctx)
+
 	e.Metrics.CollectionsTotal.Inc()
 	collectionStart := time.Now()
 	defer func() {
@@ -129,7 +134,7 @@ func (e *Exporter) collectPgBouncerMetrics(ch chan<- prometheus.Metric) {
 	}()
 	db, err := e.GetPgBouncerDB()
 	if err != nil {
-		log.Error(err, "Error opening connection to PostgreSQL")
+		contextLogger.Error(err, "Error opening connection to PostgreSQL")
 		e.Metrics.Error.Set(1)
 		return
 	}

--- a/pkg/management/pgbouncer/metricsserver/pools.go
+++ b/pkg/management/pgbouncer/metricsserver/pools.go
@@ -184,11 +184,13 @@ func NewShowPoolsMetrics(subsystem string) *ShowPoolsMetrics {
 }
 
 func (e *Exporter) collectShowPools(ch chan<- prometheus.Metric, db *sql.DB) {
+	contextLogger := log.FromContext(e.ctx)
+
 	e.Metrics.ShowPools.Reset()
 	// First, let's check the connection. No need to proceed if this fails.
 	rows, err := db.Query("SHOW POOLS;")
 	if err != nil {
-		log.Error(err, "Error while executing SHOW POOLS")
+		contextLogger.Error(err, "Error while executing SHOW POOLS")
 		e.Metrics.PgbouncerUp.Set(0)
 		e.Metrics.Error.Set(1)
 		return
@@ -199,7 +201,7 @@ func (e *Exporter) collectShowPools(ch chan<- prometheus.Metric, db *sql.DB) {
 	defer func() {
 		err = rows.Close()
 		if err != nil {
-			log.Error(err, "while closing rows for SHOW POOLS")
+			contextLogger.Error(err, "while closing rows for SHOW POOLS")
 		}
 	}()
 
@@ -234,7 +236,7 @@ func (e *Exporter) collectShowPools(ch chan<- prometheus.Metric, db *sql.DB) {
 
 	cols, err := rows.Columns()
 	if err != nil {
-		log.Error(err, "Error while getting number of columns")
+		contextLogger.Error(err, "Error while getting number of columns")
 		e.Metrics.PgbouncerUp.Set(0)
 		e.Metrics.Error.Set(1)
 		return
@@ -259,7 +261,7 @@ func (e *Exporter) collectShowPools(ch chan<- prometheus.Metric, db *sql.DB) {
 				&maxWaitUs,
 				&poolMode,
 			); err != nil {
-				log.Error(err, "Error while executing SHOW POOLS")
+				contextLogger.Error(err, "Error while executing SHOW POOLS")
 				e.Metrics.Error.Set(1)
 				e.Metrics.PgCollectionErrors.WithLabelValues(err.Error()).Inc()
 			}
@@ -277,7 +279,7 @@ func (e *Exporter) collectShowPools(ch chan<- prometheus.Metric, db *sql.DB) {
 				&maxWaitUs,
 				&poolMode,
 			); err != nil {
-				log.Error(err, "Error while executing SHOW POOLS")
+				contextLogger.Error(err, "Error while executing SHOW POOLS")
 				e.Metrics.Error.Set(1)
 				e.Metrics.PgCollectionErrors.WithLabelValues(err.Error()).Inc()
 			}

--- a/pkg/management/pgbouncer/metricsserver/pools_test.go
+++ b/pkg/management/pgbouncer/metricsserver/pools_test.go
@@ -53,7 +53,7 @@ var _ = Describe("Exporter", func() {
 		}
 	)
 
-	BeforeEach(func() {
+	BeforeEach(func(ctx SpecContext) {
 		var err error
 		db, mock, err = sqlmock.New()
 		Expect(err).ShouldNot(HaveOccurred())
@@ -61,6 +61,7 @@ var _ = Describe("Exporter", func() {
 		exp = &Exporter{
 			Metrics: newMetrics(),
 			pool:    fakePooler{db: db},
+			ctx:     ctx,
 		}
 
 		registry = prometheus.NewRegistry()

--- a/pkg/management/pgbouncer/metricsserver/stats.go
+++ b/pkg/management/pgbouncer/metricsserver/stats.go
@@ -190,11 +190,13 @@ func NewShowStatsMetrics(subsystem string) *ShowStatsMetrics {
 }
 
 func (e *Exporter) collectShowStats(ch chan<- prometheus.Metric, db *sql.DB) {
+	contextLogger := log.FromContext(e.ctx)
+
 	e.Metrics.ShowStats.Reset()
 	// First, let's check the connection. No need to proceed if this fails.
 	rows, err := db.Query("SHOW STATS;")
 	if err != nil {
-		log.Error(err, "Error while executing SHOW STATS")
+		contextLogger.Error(err, "Error while executing SHOW STATS")
 		e.Metrics.PgbouncerUp.Set(0)
 		e.Metrics.Error.Set(1)
 		return
@@ -205,7 +207,7 @@ func (e *Exporter) collectShowStats(ch chan<- prometheus.Metric, db *sql.DB) {
 	defer func() {
 		err = rows.Close()
 		if err != nil {
-			log.Error(err, "while closing rows for SHOW STATS")
+			contextLogger.Error(err, "while closing rows for SHOW STATS")
 		}
 	}()
 	var (
@@ -234,7 +236,7 @@ func (e *Exporter) collectShowStats(ch chan<- prometheus.Metric, db *sql.DB) {
 
 	statCols, err := rows.Columns()
 	if err != nil {
-		log.Error(err, "Error while reading SHOW STATS")
+		contextLogger.Error(err, "Error while reading SHOW STATS")
 		return
 	}
 
@@ -280,7 +282,7 @@ func (e *Exporter) collectShowStats(ch chan<- prometheus.Metric, db *sql.DB) {
 			)
 		}
 		if err != nil {
-			log.Error(err, "Error while executing SHOW STATS")
+			contextLogger.Error(err, "Error while executing SHOW STATS")
 			e.Metrics.Error.Set(1)
 			e.Metrics.PgCollectionErrors.WithLabelValues(err.Error()).Inc()
 		}

--- a/pkg/management/pgbouncer/metricsserver/stats_test.go
+++ b/pkg/management/pgbouncer/metricsserver/stats_test.go
@@ -40,7 +40,7 @@ var _ = Describe("MetricsServer", func() {
 		ch       chan prometheus.Metric
 	)
 
-	BeforeEach(func() {
+	BeforeEach(func(ctx SpecContext) {
 		var err error
 		db, mock, err = sqlmock.New()
 		Expect(err).NotTo(HaveOccurred())
@@ -48,6 +48,7 @@ var _ = Describe("MetricsServer", func() {
 		exp = &Exporter{
 			Metrics: newMetrics(),
 			pool:    fakePooler{db: db},
+			ctx:     ctx,
 		}
 		registry = prometheus.NewRegistry()
 		registry.MustRegister(exp.Metrics.Error)

--- a/pkg/management/postgres/backup.go
+++ b/pkg/management/postgres/backup.go
@@ -99,6 +99,7 @@ func NewBarmanBackupCommand(
 // Start initiates a backup for this instance using
 // barman-cloud-backup
 func (b *BackupCommand) Start(ctx context.Context) error {
+	contextLogger := log.FromContext(ctx)
 	if err := b.ensureCompatibility(); err != nil {
 		return err
 	}
@@ -111,7 +112,7 @@ func (b *BackupCommand) Start(ctx context.Context) error {
 	}
 
 	if err := ensureWalArchiveIsWorking(b.Instance); err != nil {
-		log.Warning("WAL archiving is not working", "err", err)
+		contextLogger.Warning("WAL archiving is not working", "err", err)
 		b.Backup.GetStatus().Phase = apiv1.BackupPhaseWalArchivingFailing
 		return PatchBackupStatusAndRetry(ctx, b.Client, b.Backup)
 	}
@@ -120,7 +121,7 @@ func (b *BackupCommand) Start(ctx context.Context) error {
 		b.Backup.GetStatus().Phase = apiv1.BackupPhaseRunning
 		err := PatchBackupStatusAndRetry(ctx, b.Client, b.Backup)
 		if err != nil {
-			log.Error(err, "can't set backup as WAL archiving failing")
+			contextLogger.Error(err, "can't set backup as WAL archiving failing")
 		}
 	}
 

--- a/pkg/management/postgres/configuration.go
+++ b/pkg/management/postgres/configuration.go
@@ -39,7 +39,9 @@ import (
 
 // InstallPgDataFileContent installs a file in PgData, returning true/false if
 // the file has been changed and an error state
-func InstallPgDataFileContent(pgdata, contents, destinationFile string) (bool, error) {
+func InstallPgDataFileContent(ctx context.Context, pgdata, contents, destinationFile string) (bool, error) {
+	contextLogger := log.FromContext(ctx)
+
 	targetFile := path.Join(pgdata, destinationFile)
 	result, err := fileutils.WriteStringToFile(targetFile, contents)
 	if err != nil {
@@ -47,7 +49,7 @@ func InstallPgDataFileContent(pgdata, contents, destinationFile string) (bool, e
 	}
 
 	if result {
-		log.Info(
+		contextLogger.Info(
 			"Installed configuration file",
 			"pgdata", pgdata,
 			"filename", destinationFile)
@@ -60,6 +62,7 @@ func InstallPgDataFileContent(pgdata, contents, destinationFile string) (bool, e
 // PostgreSQL configuration and rewrites the file in the PGDATA if needed. This
 // function will return "true" if the configuration has been really changed.
 func (instance *Instance) RefreshConfigurationFilesFromCluster(
+	ctx context.Context,
 	cluster *apiv1.Cluster,
 	preserveUserSettings bool,
 ) (bool, error) {
@@ -69,6 +72,7 @@ func (instance *Instance) RefreshConfigurationFilesFromCluster(
 	}
 
 	postgresConfigurationChanged, err := InstallPgDataFileContent(
+		ctx,
 		instance.PgData,
 		postgresConfiguration,
 		constants.PostgresqlCustomConfigurationFile)
@@ -111,7 +115,7 @@ func (instance *Instance) GeneratePostgresqlHBA(cluster *apiv1.Cluster, ldapBind
 }
 
 // RefreshPGHBA generates and writes down the pg_hba.conf file
-func (instance *Instance) RefreshPGHBA(cluster *apiv1.Cluster, ldapBindPassword string) (
+func (instance *Instance) RefreshPGHBA(ctx context.Context, cluster *apiv1.Cluster, ldapBindPassword string) (
 	postgresHBAChanged bool,
 	err error,
 ) {
@@ -121,6 +125,7 @@ func (instance *Instance) RefreshPGHBA(cluster *apiv1.Cluster, ldapBindPassword 
 		return false, nil
 	}
 	postgresHBAChanged, err = InstallPgDataFileContent(
+		ctx,
 		instance.PgData,
 		pgHBAContent,
 		constants.PostgresqlHBARulesFile)
@@ -213,13 +218,17 @@ func (instance *Instance) generatePostgresqlIdent(additionalLines []string) (str
 // RefreshPGIdent generates and writes down the pg_ident.conf file given
 // a set of additional pg_ident lines that is usually taken from the
 // Cluster configuration
-func (instance *Instance) RefreshPGIdent(additionalLines []string) (postgresIdentChanged bool, err error) {
+func (instance *Instance) RefreshPGIdent(
+	ctx context.Context,
+	additionalLines []string,
+) (postgresIdentChanged bool, err error) {
 	// Generate pg_ident.conf file
 	pgIdentContent, err := instance.generatePostgresqlIdent(additionalLines)
 	if err != nil {
 		return false, nil
 	}
 	postgresIdentChanged, err = InstallPgDataFileContent(
+		ctx,
 		instance.PgData,
 		pgIdentContent,
 		constants.PostgresqlIdentFile)

--- a/pkg/management/postgres/initdb.go
+++ b/pkg/management/postgres/initdb.go
@@ -144,7 +144,7 @@ func (info InitInfo) CheckTargetDataDirectory(ctx context.Context) error {
 
 	pgDataExists, err := fileutils.FileExists(info.PgData)
 	if err != nil {
-		log.Error(err, "Error while checking for an existing PGData")
+		contextLogger.Error(err, "Error while checking for an existing PGData")
 		return fmt.Errorf("while verifying is PGDATA exists: %w", err)
 	}
 	if !pgDataExists {
@@ -429,7 +429,7 @@ func (info InitInfo) Bootstrap(ctx context.Context) error {
 		cluster.Spec.Bootstrap.InitDB != nil &&
 		cluster.Spec.Bootstrap.InitDB.Import != nil
 
-	if applied, err := instance.RefreshConfigurationFilesFromCluster(cluster, true); err != nil {
+	if applied, err := instance.RefreshConfigurationFilesFromCluster(ctx, cluster, true); err != nil {
 		return fmt.Errorf("while writing the config: %w", err)
 	} else if !applied {
 		return fmt.Errorf("could not apply the config")


### PR DESCRIPTION
With the latest version of controller-runtime the current logger can be set in the base context and then inherited by all the controllers belonging to the same manager.

This patch removes the duplicate loggers in the PostgreSQL instances and in the PgBouncer Pods, reusing the appropriate one. This, in turn, allows for a more consistent logging across the instance manager.

Closes: #5782 