### PR TITLE
fix(failover): prevent double failover in case of lost connectivity

### DIFF
--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -70,6 +70,10 @@ const (
 
 var apiGVString = apiv1.GroupVersion.String()
 
+// errSplitBrainDetected happens when a Pod lost connectivity with
+// the API server and retains its previous role.
+var errSplitBrainDetected = errors.New("split brain detected")
+
 // ClusterReconciler reconciles a Cluster objects
 type ClusterReconciler struct {
 	client.Client
@@ -338,6 +342,27 @@ func (r *ClusterReconciler) reconcile(ctx context.Context, cluster *apiv1.Cluste
 			return ctrl.Result{Requeue: true}, nil
 		}
 		return ctrl.Result{}, fmt.Errorf("cannot update the instances status on the cluster: %w", err)
+	}
+
+	// If a Pod loses connectivity, the operator will fail over but the faulty
+	// Pod would not receive a change of its role from primary to replica.
+	//
+	// When the connectivity resumes the operator will find two primaries:
+	// the previously faulting one and the new primary that has been
+	// promoted. The operator should just wait for the Pods to get its
+	// current role from auto-healing to proceed. Without this safety
+	// measure, the operator would just fail back to the first primary of
+	// the list.
+	if primaryNames := instancesStatus.PrimaryNames(); len(primaryNames) > 1 {
+		contextLogger.Error(
+			errSplitBrainDetected,
+			"Multiple primary Pods have been detected, waiting for Pods to notice their role",
+			"primaryNames", primaryNames,
+		)
+		instancesStatus.LogStatus(ctx)
+		return ctrl.Result{
+			RequeueAfter: 5 * time.Second,
+		}, nil
 	}
 
 	if err := persistentvolumeclaim.ReconcileMetadata(

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -70,9 +70,10 @@ const (
 
 var apiGVString = apiv1.GroupVersion.String()
 
-// errSplitBrainDetected happens when a Pod lost connectivity with
-// the API server and retains its previous role.
-var errSplitBrainDetected = errors.New("split brain detected")
+// errOldPrimaryDetected occurs when a primary Pod loses connectivity with the
+// API server and, upon reconnection, attempts to retain its previous primary
+// role.
+var errOldPrimaryDetected = errors.New("old primary detected")
 
 // ClusterReconciler reconciles a Cluster objects
 type ClusterReconciler struct {
@@ -355,8 +356,8 @@ func (r *ClusterReconciler) reconcile(ctx context.Context, cluster *apiv1.Cluste
 	// the list.
 	if primaryNames := instancesStatus.PrimaryNames(); len(primaryNames) > 1 {
 		contextLogger.Error(
-			errSplitBrainDetected,
-			"Multiple primary Pods have been detected, waiting for Pods to notice their role",
+			errOldPrimaryDetected,
+			"An old primary pod has been detected. Awaiting its recognition of the new role",
 			"primaryNames", primaryNames,
 		)
 		instancesStatus.LogStatus(ctx)

--- a/pkg/postgres/status.go
+++ b/pkg/postgres/status.go
@@ -405,3 +405,17 @@ func (list PostgresqlStatusList) InstancesReportingStatus() int {
 
 	return n
 }
+
+// PrimaryNames get the names of each primary instance of this Cluster. Under
+// normal conditions, this list is composed by one and only one name.
+func (list PostgresqlStatusList) PrimaryNames() []string {
+	result := make([]string, 0, 1)
+
+	for _, item := range list.Items {
+		if item.IsPrimary {
+			result = append(result, item.Pod.Name)
+		}
+	}
+
+	return result
+}


### PR DESCRIPTION
This patch ensures the operator does not trigger two failovers when a primary Pod loses connectivity and fails to recognize its role change from primary to replica.

Previously, the first failover occurred when the operator detected that the primary Pod was no longer ready or present. A second failover could be triggered if the old primary Pod recovered before the Kubelet timeout, with the operator potentially promoting it to primary again based on the Pod list.

With this patch, the operator will wait for the recovered Pod to acknowledge its new role before taking further action, preventing unnecessary failovers.

Closes: #2513 

# Release notes

```
Prevent double failover in case of lost connectivity
```