### PR TITLE
chore(plugin): organise plugin commands into groups

### DIFF
--- a/cmd/kubectl-cnpg/main.go
+++ b/cmd/kubectl-cnpg/main.go
@@ -83,22 +83,22 @@ func main() {
 	configFlags.AddFlags(rootCmd.PersistentFlags())
 
 	adminGroup := &cobra.Group{
-		ID:    "admin",
-		Title: "Administration tasks",
+		ID:    "cnpg-level",
+		Title: "CNPG Operator level Administration",
 	}
 	dbaGroup := &cobra.Group{
-		ID:    "dba",
-		Title: "Database Administrator",
+		ID:    "pg-cluster",
+		Title: "PostgreSQL Cluster Administration",
 	}
 
 	benchmarkGroup := &cobra.Group{
-		ID:    "benchmark",
-		Title: "Benchmarking Tools",
+		ID:    "pg-db",
+		Title: "PostgreSQL Database Administration",
 	}
 
 	toolsGroup := &cobra.Group{
-		ID:    "tools",
-		Title: "Tools",
+		ID:    "misc",
+		Title: "Miscellaneous",
 	}
 
 	rootCmd.AddGroup(adminGroup, dbaGroup, benchmarkGroup, toolsGroup)

--- a/cmd/kubectl-cnpg/main.go
+++ b/cmd/kubectl-cnpg/main.go
@@ -83,26 +83,31 @@ func main() {
 	configFlags.AddFlags(rootCmd.PersistentFlags())
 
 	adminGroup := &cobra.Group{
-		ID:    plugin.GroupIDCnpg,
-		Title: "CNPG Operator level Administration",
+		ID:    plugin.GroupIDAdmin,
+		Title: "Operator-level administration",
 	}
 
-	dbaGroup := &cobra.Group{
-		ID:    plugin.GroupIDPgCluster,
-		Title: "PostgreSQL Cluster Administration",
+	troubleshootingGroup := &cobra.Group{
+		ID:    plugin.GroupIDTroubleshooting,
+		Title: "Troubleshooting",
 	}
 
-	benchmarkGroup := &cobra.Group{
-		ID:    plugin.GroupIDPgDatabase,
-		Title: "PostgreSQL Database Administration",
+	pgClusterGroup := &cobra.Group{
+		ID:    plugin.GroupIDCluster,
+		Title: "Cluster administration",
 	}
 
-	toolsGroup := &cobra.Group{
+	pgDatabaseGroup := &cobra.Group{
+		ID:    plugin.GroupIDDatabase,
+		Title: "Database administration",
+	}
+
+	miscGroup := &cobra.Group{
 		ID:    plugin.GroupIDMiscellaneous,
 		Title: "Miscellaneous",
 	}
 
-	rootCmd.AddGroup(adminGroup, dbaGroup, benchmarkGroup, toolsGroup)
+	rootCmd.AddGroup(adminGroup, troubleshootingGroup, pgClusterGroup, pgDatabaseGroup, miscGroup)
 
 	subcommands := []*cobra.Command{
 		backup.NewCmd(),

--- a/cmd/kubectl-cnpg/main.go
+++ b/cmd/kubectl-cnpg/main.go
@@ -82,6 +82,27 @@ func main() {
 	logFlags.AddFlags(rootCmd.PersistentFlags())
 	configFlags.AddFlags(rootCmd.PersistentFlags())
 
+	adminGroup := &cobra.Group{
+		ID:    "admin",
+		Title: "Administration tasks",
+	}
+	dbaGroup := &cobra.Group{
+		ID:    "dba",
+		Title: "Database Administrator",
+	}
+
+	benchmarkGroup := &cobra.Group{
+		ID:    "benchmark",
+		Title: "Benchmarking Tools",
+	}
+
+	toolsGroup := &cobra.Group{
+		ID:    "tools",
+		Title: "Tools",
+	}
+
+	rootCmd.AddGroup(adminGroup, dbaGroup, benchmarkGroup, toolsGroup)
+
 	subcommands := []*cobra.Command{
 		backup.NewCmd(),
 		certificate.NewCmd(),

--- a/cmd/kubectl-cnpg/main.go
+++ b/cmd/kubectl-cnpg/main.go
@@ -83,21 +83,22 @@ func main() {
 	configFlags.AddFlags(rootCmd.PersistentFlags())
 
 	adminGroup := &cobra.Group{
-		ID:    "cnpg-level",
+		ID:    plugin.GroupIDCnpg,
 		Title: "CNPG Operator level Administration",
 	}
+
 	dbaGroup := &cobra.Group{
-		ID:    "pg-cluster",
+		ID:    plugin.GroupIDPgCluster,
 		Title: "PostgreSQL Cluster Administration",
 	}
 
 	benchmarkGroup := &cobra.Group{
-		ID:    "pg-db",
+		ID:    plugin.GroupIDPgDatabase,
 		Title: "PostgreSQL Database Administration",
 	}
 
 	toolsGroup := &cobra.Group{
-		ID:    "misc",
+		ID:    plugin.GroupIDMiscellaneous,
 		Title: "Miscellaneous",
 	}
 

--- a/internal/cmd/plugin/backup/cmd.go
+++ b/internal/cmd/plugin/backup/cmd.go
@@ -64,7 +64,7 @@ func NewCmd() *cobra.Command {
 	backupSubcommand := &cobra.Command{
 		Use:     "backup [cluster]",
 		Short:   "Request an on-demand backup for a PostgreSQL Cluster",
-		GroupID: plugin.GroupIDPgDatabase,
+		GroupID: plugin.GroupIDDatabase,
 		Args:    plugin.RequiresArguments(1),
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			return plugin.CompleteClusters(cmd.Context(), args, toComplete), cobra.ShellCompDirectiveNoFileComp

--- a/internal/cmd/plugin/backup/cmd.go
+++ b/internal/cmd/plugin/backup/cmd.go
@@ -64,7 +64,7 @@ func NewCmd() *cobra.Command {
 	backupSubcommand := &cobra.Command{
 		Use:     "backup [cluster]",
 		Short:   "Request an on-demand backup for a PostgreSQL Cluster",
-		GroupID: "admin",
+		GroupID: "pg-db",
 		Args:    plugin.RequiresArguments(1),
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			return plugin.CompleteClusters(cmd.Context(), args, toComplete), cobra.ShellCompDirectiveNoFileComp

--- a/internal/cmd/plugin/backup/cmd.go
+++ b/internal/cmd/plugin/backup/cmd.go
@@ -62,9 +62,10 @@ func NewCmd() *cobra.Command {
 	var backupName, backupTarget, backupMethod, online, immediateCheckpoint, waitForArchive string
 
 	backupSubcommand := &cobra.Command{
-		Use:   "backup [cluster]",
-		Short: "Request an on-demand backup for a PostgreSQL Cluster",
-		Args:  plugin.RequiresArguments(1),
+		Use:     "backup [cluster]",
+		Short:   "Request an on-demand backup for a PostgreSQL Cluster",
+		GroupID: "admin",
+		Args:    plugin.RequiresArguments(1),
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			return plugin.CompleteClusters(cmd.Context(), args, toComplete), cobra.ShellCompDirectiveNoFileComp
 		},

--- a/internal/cmd/plugin/backup/cmd.go
+++ b/internal/cmd/plugin/backup/cmd.go
@@ -64,7 +64,7 @@ func NewCmd() *cobra.Command {
 	backupSubcommand := &cobra.Command{
 		Use:     "backup [cluster]",
 		Short:   "Request an on-demand backup for a PostgreSQL Cluster",
-		GroupID: "pg-db",
+		GroupID: plugin.GroupIDPgDatabase,
 		Args:    plugin.RequiresArguments(1),
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			return plugin.CompleteClusters(cmd.Context(), args, toComplete), cobra.ShellCompDirectiveNoFileComp

--- a/internal/cmd/plugin/certificate/cmd.go
+++ b/internal/cmd/plugin/certificate/cmd.go
@@ -32,7 +32,7 @@ func NewCmd() *cobra.Command {
 		Long: `This command creates a new Kubernetes secret containing the crypto-material.
 This is needed to configure TLS with Certificate authentication access for an application to
 connect to the PostgreSQL cluster.`,
-		GroupID: "pg-db",
+		GroupID: plugin.GroupIDPgDatabase,
 		Args:    plugin.RequiresArguments(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()

--- a/internal/cmd/plugin/certificate/cmd.go
+++ b/internal/cmd/plugin/certificate/cmd.go
@@ -32,7 +32,7 @@ func NewCmd() *cobra.Command {
 		Long: `This command creates a new Kubernetes secret containing the crypto-material.
 This is needed to configure TLS with Certificate authentication access for an application to
 connect to the PostgreSQL cluster.`,
-		GroupID: "admin",
+		GroupID: "pg-db",
 		Args:    plugin.RequiresArguments(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()

--- a/internal/cmd/plugin/certificate/cmd.go
+++ b/internal/cmd/plugin/certificate/cmd.go
@@ -32,7 +32,7 @@ func NewCmd() *cobra.Command {
 		Long: `This command creates a new Kubernetes secret containing the crypto-material.
 This is needed to configure TLS with Certificate authentication access for an application to
 connect to the PostgreSQL cluster.`,
-		GroupID: plugin.GroupIDPgDatabase,
+		GroupID: plugin.GroupIDDatabase,
 		Args:    plugin.RequiresArguments(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()

--- a/internal/cmd/plugin/certificate/cmd.go
+++ b/internal/cmd/plugin/certificate/cmd.go
@@ -32,7 +32,8 @@ func NewCmd() *cobra.Command {
 		Long: `This command creates a new Kubernetes secret containing the crypto-material.
 This is needed to configure TLS with Certificate authentication access for an application to
 connect to the PostgreSQL cluster.`,
-		Args: plugin.RequiresArguments(1),
+		GroupID: "admin",
+		Args:    plugin.RequiresArguments(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 			secretName := args[0]

--- a/internal/cmd/plugin/color.go
+++ b/internal/cmd/plugin/color.go
@@ -32,9 +32,9 @@ type colorConfiguration string
 const (
 	// colorAlways configures the output to always be colorized
 	colorAlways colorConfiguration = "always"
-	// colorAuto configures the the output to be colorized only when attached to a terminal
+	// colorAuto configures the output to be colorized only when attached to a terminal
 	colorAuto colorConfiguration = "auto"
-	// colorNever configures the the output never to be colorized
+	// colorNever configures the output never to be colorized
 	colorNever colorConfiguration = "never"
 )
 

--- a/internal/cmd/plugin/destroy/cmd.go
+++ b/internal/cmd/plugin/destroy/cmd.go
@@ -31,7 +31,7 @@ func NewCmd() *cobra.Command {
 	destroyCmd := &cobra.Command{
 		Use:     "destroy [cluster] [node]",
 		Short:   "Destroy the instance named [cluster]-[node] or [node] with the associated PVC",
-		GroupID: plugin.GroupIDPgCluster,
+		GroupID: plugin.GroupIDCluster,
 		Args:    plugin.RequiresArguments(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()

--- a/internal/cmd/plugin/destroy/cmd.go
+++ b/internal/cmd/plugin/destroy/cmd.go
@@ -29,9 +29,10 @@ import (
 // NewCmd create the new "destroy" subcommand
 func NewCmd() *cobra.Command {
 	destroyCmd := &cobra.Command{
-		Use:   "destroy [cluster] [node]",
-		Short: "Destroy the instance named [cluster]-[node] or [node] with the associated PVC",
-		Args:  plugin.RequiresArguments(2),
+		Use:     "destroy [cluster] [node]",
+		Short:   "Destroy the instance named [cluster]-[node] or [node] with the associated PVC",
+		GroupID: "admin",
+		Args:    plugin.RequiresArguments(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 			clusterName := args[0]

--- a/internal/cmd/plugin/destroy/cmd.go
+++ b/internal/cmd/plugin/destroy/cmd.go
@@ -31,7 +31,7 @@ func NewCmd() *cobra.Command {
 	destroyCmd := &cobra.Command{
 		Use:     "destroy [cluster] [node]",
 		Short:   "Destroy the instance named [cluster]-[node] or [node] with the associated PVC",
-		GroupID: "pg-cluster",
+		GroupID: plugin.GroupIDPgCluster,
 		Args:    plugin.RequiresArguments(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()

--- a/internal/cmd/plugin/destroy/cmd.go
+++ b/internal/cmd/plugin/destroy/cmd.go
@@ -31,7 +31,7 @@ func NewCmd() *cobra.Command {
 	destroyCmd := &cobra.Command{
 		Use:     "destroy [cluster] [node]",
 		Short:   "Destroy the instance named [cluster]-[node] or [node] with the associated PVC",
-		GroupID: "admin",
+		GroupID: "pg-cluster",
 		Args:    plugin.RequiresArguments(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()

--- a/internal/cmd/plugin/fence/cmd.go
+++ b/internal/cmd/plugin/fence/cmd.go
@@ -59,8 +59,9 @@ var (
 // NewCmd creates the new "fencing" command
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "fencing",
-		Short: `Fencing related commands`,
+		Use:     "fencing",
+		Short:   `Fencing related commands`,
+		GroupID: "admin",
 	}
 	cmd.AddCommand(fenceOnCmd)
 	cmd.AddCommand(fenceOffCmd)

--- a/internal/cmd/plugin/fence/cmd.go
+++ b/internal/cmd/plugin/fence/cmd.go
@@ -61,7 +61,7 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "fencing",
 		Short:   `Fencing related commands`,
-		GroupID: plugin.GroupIDPgCluster,
+		GroupID: plugin.GroupIDCluster,
 	}
 	cmd.AddCommand(fenceOnCmd)
 	cmd.AddCommand(fenceOffCmd)

--- a/internal/cmd/plugin/fence/cmd.go
+++ b/internal/cmd/plugin/fence/cmd.go
@@ -61,7 +61,7 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "fencing",
 		Short:   `Fencing related commands`,
-		GroupID: "admin",
+		GroupID: "pg-cluster",
 	}
 	cmd.AddCommand(fenceOnCmd)
 	cmd.AddCommand(fenceOffCmd)

--- a/internal/cmd/plugin/fence/cmd.go
+++ b/internal/cmd/plugin/fence/cmd.go
@@ -61,7 +61,7 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "fencing",
 		Short:   `Fencing related commands`,
-		GroupID: "pg-cluster",
+		GroupID: plugin.GroupIDPgCluster,
 	}
 	cmd.AddCommand(fenceOnCmd)
 	cmd.AddCommand(fenceOffCmd)

--- a/internal/cmd/plugin/fio/cmd.go
+++ b/internal/cmd/plugin/fio/cmd.go
@@ -35,7 +35,7 @@ func NewCmd() *cobra.Command {
 		Args:    cobra.MinimumNArgs(1),
 		Long:    `Creates a fio deployment that will execute a fio job on the specified pvc.`,
 		Example: jobExample,
-		GroupID: "benchmark",
+		GroupID: "misc",
 		RunE: func(_ *cobra.Command, args []string) error {
 			ctx := context.Background()
 			fioArgs := args[1:]

--- a/internal/cmd/plugin/fio/cmd.go
+++ b/internal/cmd/plugin/fio/cmd.go
@@ -35,6 +35,7 @@ func NewCmd() *cobra.Command {
 		Args:    cobra.MinimumNArgs(1),
 		Long:    `Creates a fio deployment that will execute a fio job on the specified pvc.`,
 		Example: jobExample,
+		GroupID: "benchmark",
 		RunE: func(_ *cobra.Command, args []string) error {
 			ctx := context.Background()
 			fioArgs := args[1:]

--- a/internal/cmd/plugin/fio/cmd.go
+++ b/internal/cmd/plugin/fio/cmd.go
@@ -22,6 +22,8 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+
+	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/plugin"
 )
 
 // NewCmd initializes the fio command
@@ -35,7 +37,7 @@ func NewCmd() *cobra.Command {
 		Args:    cobra.MinimumNArgs(1),
 		Long:    `Creates a fio deployment that will execute a fio job on the specified pvc.`,
 		Example: jobExample,
-		GroupID: "misc",
+		GroupID: plugin.GroupIDMiscellaneous,
 		RunE: func(_ *cobra.Command, args []string) error {
 			ctx := context.Background()
 			fioArgs := args[1:]

--- a/internal/cmd/plugin/hibernate/cmd.go
+++ b/internal/cmd/plugin/hibernate/cmd.go
@@ -94,7 +94,7 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "hibernate",
 		Short:   `Hibernation related commands`,
-		GroupID: "admin",
+		GroupID: "pg-cluster",
 	}
 
 	cmd.AddCommand(hibernateOnCmd)

--- a/internal/cmd/plugin/hibernate/cmd.go
+++ b/internal/cmd/plugin/hibernate/cmd.go
@@ -94,7 +94,7 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "hibernate",
 		Short:   `Hibernation related commands`,
-		GroupID: "pg-cluster",
+		GroupID: plugin.GroupIDPgCluster,
 	}
 
 	cmd.AddCommand(hibernateOnCmd)

--- a/internal/cmd/plugin/hibernate/cmd.go
+++ b/internal/cmd/plugin/hibernate/cmd.go
@@ -94,7 +94,7 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "hibernate",
 		Short:   `Hibernation related commands`,
-		GroupID: plugin.GroupIDPgCluster,
+		GroupID: plugin.GroupIDCluster,
 	}
 
 	cmd.AddCommand(hibernateOnCmd)

--- a/internal/cmd/plugin/hibernate/cmd.go
+++ b/internal/cmd/plugin/hibernate/cmd.go
@@ -92,8 +92,9 @@ var (
 // NewCmd initializes the hibernate command
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "hibernate",
-		Short: `Hibernation related commands`,
+		Use:     "hibernate",
+		Short:   `Hibernation related commands`,
+		GroupID: "admin",
 	}
 
 	cmd.AddCommand(hibernateOnCmd)

--- a/internal/cmd/plugin/install/cmd.go
+++ b/internal/cmd/plugin/install/cmd.go
@@ -23,8 +23,9 @@ import (
 // NewCmd returns the installation root cmd
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "install",
-		Short: "CNPG installation commands",
+		Use:     "install",
+		Short:   "CNPG installation commands",
+		GroupID: "tools",
 	}
 	cmd.AddCommand(newGenerateCmd())
 

--- a/internal/cmd/plugin/install/cmd.go
+++ b/internal/cmd/plugin/install/cmd.go
@@ -27,7 +27,7 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "install",
 		Short:   "CloudNativePG installation-related commands",
-		GroupID: plugin.GroupIDCnpg,
+		GroupID: plugin.GroupIDAdmin,
 	}
 	cmd.AddCommand(newGenerateCmd())
 

--- a/internal/cmd/plugin/install/cmd.go
+++ b/internal/cmd/plugin/install/cmd.go
@@ -24,8 +24,8 @@ import (
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "install",
-		Short:   "CNPG installation commands",
-		GroupID: "tools",
+		Short:   "CloudNativePG installation-related commands",
+		GroupID: "cnpg-level",
 	}
 	cmd.AddCommand(newGenerateCmd())
 

--- a/internal/cmd/plugin/install/cmd.go
+++ b/internal/cmd/plugin/install/cmd.go
@@ -18,6 +18,8 @@ package install
 
 import (
 	"github.com/spf13/cobra"
+
+	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/plugin"
 )
 
 // NewCmd returns the installation root cmd
@@ -25,7 +27,7 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "install",
 		Short:   "CloudNativePG installation-related commands",
-		GroupID: "cnpg-level",
+		GroupID: plugin.GroupIDCnpg,
 	}
 	cmd.AddCommand(newGenerateCmd())
 

--- a/internal/cmd/plugin/logical/publication/cmd.go
+++ b/internal/cmd/plugin/logical/publication/cmd.go
@@ -26,8 +26,9 @@ import (
 // NewCmd initializes the publication command
 func NewCmd() *cobra.Command {
 	publicationCmd := &cobra.Command{
-		Use:   "publication",
-		Short: "Logical publication management commands",
+		Use:     "publication",
+		Short:   "Logical publication management commands",
+		GroupID: "dba",
 	}
 	publicationCmd.AddCommand(create.NewCmd())
 	publicationCmd.AddCommand(drop.NewCmd())

--- a/internal/cmd/plugin/logical/publication/cmd.go
+++ b/internal/cmd/plugin/logical/publication/cmd.go
@@ -19,6 +19,7 @@ package publication
 import (
 	"github.com/spf13/cobra"
 
+	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/plugin"
 	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/plugin/logical/publication/create"
 	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/plugin/logical/publication/drop"
 )
@@ -28,7 +29,7 @@ func NewCmd() *cobra.Command {
 	publicationCmd := &cobra.Command{
 		Use:     "publication",
 		Short:   "Logical publication management commands",
-		GroupID: "pg-db",
+		GroupID: plugin.GroupIDPgDatabase,
 	}
 	publicationCmd.AddCommand(create.NewCmd())
 	publicationCmd.AddCommand(drop.NewCmd())

--- a/internal/cmd/plugin/logical/publication/cmd.go
+++ b/internal/cmd/plugin/logical/publication/cmd.go
@@ -29,7 +29,7 @@ func NewCmd() *cobra.Command {
 	publicationCmd := &cobra.Command{
 		Use:     "publication",
 		Short:   "Logical publication management commands",
-		GroupID: plugin.GroupIDPgDatabase,
+		GroupID: plugin.GroupIDDatabase,
 	}
 	publicationCmd.AddCommand(create.NewCmd())
 	publicationCmd.AddCommand(drop.NewCmd())

--- a/internal/cmd/plugin/logical/publication/cmd.go
+++ b/internal/cmd/plugin/logical/publication/cmd.go
@@ -28,7 +28,7 @@ func NewCmd() *cobra.Command {
 	publicationCmd := &cobra.Command{
 		Use:     "publication",
 		Short:   "Logical publication management commands",
-		GroupID: "dba",
+		GroupID: "pg-db",
 	}
 	publicationCmd.AddCommand(create.NewCmd())
 	publicationCmd.AddCommand(drop.NewCmd())

--- a/internal/cmd/plugin/logical/subscription/cmd.go
+++ b/internal/cmd/plugin/logical/subscription/cmd.go
@@ -27,8 +27,9 @@ import (
 // NewCmd initializes the subscription command
 func NewCmd() *cobra.Command {
 	subscriptionCmd := &cobra.Command{
-		Use:   "subscription",
-		Short: "Logical subscription management commands",
+		Use:     "subscription",
+		Short:   "Logical subscription management commands",
+		GroupID: "dba",
 	}
 	subscriptionCmd.AddCommand(create.NewCmd())
 	subscriptionCmd.AddCommand(drop.NewCmd())

--- a/internal/cmd/plugin/logical/subscription/cmd.go
+++ b/internal/cmd/plugin/logical/subscription/cmd.go
@@ -19,6 +19,7 @@ package subscription
 import (
 	"github.com/spf13/cobra"
 
+	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/plugin"
 	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/plugin/logical/subscription/create"
 	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/plugin/logical/subscription/drop"
 	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/plugin/logical/subscription/syncsequences"
@@ -29,7 +30,7 @@ func NewCmd() *cobra.Command {
 	subscriptionCmd := &cobra.Command{
 		Use:     "subscription",
 		Short:   "Logical subscription management commands",
-		GroupID: "pg-db",
+		GroupID: plugin.GroupIDPgDatabase,
 	}
 	subscriptionCmd.AddCommand(create.NewCmd())
 	subscriptionCmd.AddCommand(drop.NewCmd())

--- a/internal/cmd/plugin/logical/subscription/cmd.go
+++ b/internal/cmd/plugin/logical/subscription/cmd.go
@@ -29,7 +29,7 @@ func NewCmd() *cobra.Command {
 	subscriptionCmd := &cobra.Command{
 		Use:     "subscription",
 		Short:   "Logical subscription management commands",
-		GroupID: "dba",
+		GroupID: "pg-db",
 	}
 	subscriptionCmd.AddCommand(create.NewCmd())
 	subscriptionCmd.AddCommand(drop.NewCmd())

--- a/internal/cmd/plugin/logical/subscription/cmd.go
+++ b/internal/cmd/plugin/logical/subscription/cmd.go
@@ -30,7 +30,7 @@ func NewCmd() *cobra.Command {
 	subscriptionCmd := &cobra.Command{
 		Use:     "subscription",
 		Short:   "Logical subscription management commands",
-		GroupID: plugin.GroupIDPgDatabase,
+		GroupID: plugin.GroupIDDatabase,
 	}
 	subscriptionCmd.AddCommand(create.NewCmd())
 	subscriptionCmd.AddCommand(drop.NewCmd())

--- a/internal/cmd/plugin/logs/cmd.go
+++ b/internal/cmd/plugin/logs/cmd.go
@@ -25,7 +25,7 @@ func NewCmd() *cobra.Command {
 	logsCmd := &cobra.Command{
 		Use:     "logs cluster",
 		Short:   "Collect cluster logs",
-		GroupID: "tools",
+		GroupID: "pg-db",
 	}
 
 	logsCmd.AddCommand(clusterCmd())

--- a/internal/cmd/plugin/logs/cmd.go
+++ b/internal/cmd/plugin/logs/cmd.go
@@ -27,7 +27,7 @@ func NewCmd() *cobra.Command {
 	logsCmd := &cobra.Command{
 		Use:     "logs cluster",
 		Short:   "Collect cluster logs",
-		GroupID: plugin.GroupIDPgDatabase,
+		GroupID: plugin.GroupIDTroubleshooting,
 	}
 
 	logsCmd.AddCommand(clusterCmd())

--- a/internal/cmd/plugin/logs/cmd.go
+++ b/internal/cmd/plugin/logs/cmd.go
@@ -23,8 +23,9 @@ import (
 // NewCmd creates the new "report" command
 func NewCmd() *cobra.Command {
 	logsCmd := &cobra.Command{
-		Use:   "logs cluster",
-		Short: "Collect cluster logs",
+		Use:     "logs cluster",
+		Short:   "Collect cluster logs",
+		GroupID: "tools",
 	}
 
 	logsCmd.AddCommand(clusterCmd())

--- a/internal/cmd/plugin/logs/cmd.go
+++ b/internal/cmd/plugin/logs/cmd.go
@@ -18,6 +18,8 @@ package logs
 
 import (
 	"github.com/spf13/cobra"
+
+	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/plugin"
 )
 
 // NewCmd creates the new "report" command
@@ -25,7 +27,7 @@ func NewCmd() *cobra.Command {
 	logsCmd := &cobra.Command{
 		Use:     "logs cluster",
 		Short:   "Collect cluster logs",
-		GroupID: "pg-db",
+		GroupID: plugin.GroupIDPgDatabase,
 	}
 
 	logsCmd.AddCommand(clusterCmd())

--- a/internal/cmd/plugin/maintenance/cmd.go
+++ b/internal/cmd/plugin/maintenance/cmd.go
@@ -33,7 +33,7 @@ func NewCmd() *cobra.Command {
 	maintenanceCmd := &cobra.Command{
 		Use:     "maintenance [set/unset]",
 		Short:   "Sets or removes maintenance mode from clusters",
-		GroupID: "admin",
+		GroupID: "pg-cluster",
 	}
 
 	maintenanceCmd.AddCommand(&cobra.Command{

--- a/internal/cmd/plugin/maintenance/cmd.go
+++ b/internal/cmd/plugin/maintenance/cmd.go
@@ -31,8 +31,9 @@ func NewCmd() *cobra.Command {
 		confirmationRequired bool
 
 	maintenanceCmd := &cobra.Command{
-		Use:   "maintenance [set/unset]",
-		Short: "Sets or removes maintenance mode from clusters",
+		Use:     "maintenance [set/unset]",
+		Short:   "Sets or removes maintenance mode from clusters",
+		GroupID: "admin",
 	}
 
 	maintenanceCmd.AddCommand(&cobra.Command{

--- a/internal/cmd/plugin/maintenance/cmd.go
+++ b/internal/cmd/plugin/maintenance/cmd.go
@@ -33,7 +33,7 @@ func NewCmd() *cobra.Command {
 	maintenanceCmd := &cobra.Command{
 		Use:     "maintenance [set/unset]",
 		Short:   "Sets or removes maintenance mode from clusters",
-		GroupID: "pg-cluster",
+		GroupID: plugin.GroupIDPgCluster,
 	}
 
 	maintenanceCmd.AddCommand(&cobra.Command{

--- a/internal/cmd/plugin/maintenance/cmd.go
+++ b/internal/cmd/plugin/maintenance/cmd.go
@@ -33,7 +33,7 @@ func NewCmd() *cobra.Command {
 	maintenanceCmd := &cobra.Command{
 		Use:     "maintenance [set/unset]",
 		Short:   "Sets or removes maintenance mode from clusters",
-		GroupID: plugin.GroupIDPgCluster,
+		GroupID: plugin.GroupIDCluster,
 	}
 
 	maintenanceCmd.AddCommand(&cobra.Command{

--- a/internal/cmd/plugin/pgadmin/cmd.go
+++ b/internal/cmd/plugin/pgadmin/cmd.go
@@ -76,9 +76,9 @@ func NewCmd() *cobra.Command {
 
 	pgadminCmd := &cobra.Command{
 		Use:     "pgadmin4 [name]",
-		Short:   "Creates a pgadmin deployment",
+		Short:   "Creates a pgAdmin deployment",
 		Args:    cobra.MinimumNArgs(1),
-		Long:    `Creates a pgadmin deployment configured to work with a CNPG Cluster.`,
+		Long:    `Creates a pgAdmin deployment configured to work with a CNPG Cluster.`,
 		GroupID: plugin.GroupIDMiscellaneous,
 		Example: pgadminExample,
 		RunE: func(_ *cobra.Command, args []string) error {

--- a/internal/cmd/plugin/pgadmin/cmd.go
+++ b/internal/cmd/plugin/pgadmin/cmd.go
@@ -79,7 +79,7 @@ func NewCmd() *cobra.Command {
 		Short:   "Creates a pgadmin deployment",
 		Args:    cobra.MinimumNArgs(1),
 		Long:    `Creates a pgadmin deployment configured to work with a CNPG Cluster.`,
-		GroupID: "misc",
+		GroupID: plugin.GroupIDMiscellaneous,
 		Example: pgadminExample,
 		RunE: func(_ *cobra.Command, args []string) error {
 			ctx := context.Background()

--- a/internal/cmd/plugin/pgadmin/cmd.go
+++ b/internal/cmd/plugin/pgadmin/cmd.go
@@ -79,6 +79,7 @@ func NewCmd() *cobra.Command {
 		Short:   "Creates a pgadmin deployment",
 		Args:    cobra.MinimumNArgs(1),
 		Long:    `Creates a pgadmin deployment configured to work with a CNPG Cluster.`,
+		GroupID: "tools",
 		Example: pgadminExample,
 		RunE: func(_ *cobra.Command, args []string) error {
 			ctx := context.Background()

--- a/internal/cmd/plugin/pgadmin/cmd.go
+++ b/internal/cmd/plugin/pgadmin/cmd.go
@@ -79,7 +79,7 @@ func NewCmd() *cobra.Command {
 		Short:   "Creates a pgadmin deployment",
 		Args:    cobra.MinimumNArgs(1),
 		Long:    `Creates a pgadmin deployment configured to work with a CNPG Cluster.`,
-		GroupID: "tools",
+		GroupID: "misc",
 		Example: pgadminExample,
 		RunE: func(_ *cobra.Command, args []string) error {
 			ctx := context.Background()

--- a/internal/cmd/plugin/pgbench/cmd.go
+++ b/internal/cmd/plugin/pgbench/cmd.go
@@ -31,7 +31,7 @@ func NewCmd() *cobra.Command {
 		Short:   "Creates a pgbench job",
 		Args:    validateCommandArgs,
 		Long:    "Creates a pgbench job to run against the specified Postgres Cluster.",
-		GroupID: "benchmark",
+		GroupID: "misc",
 		Example: jobExample,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			run.clusterName = args[0]

--- a/internal/cmd/plugin/pgbench/cmd.go
+++ b/internal/cmd/plugin/pgbench/cmd.go
@@ -31,6 +31,7 @@ func NewCmd() *cobra.Command {
 		Short:   "Creates a pgbench job",
 		Args:    validateCommandArgs,
 		Long:    "Creates a pgbench job to run against the specified Postgres Cluster.",
+		GroupID: "benchmark",
 		Example: jobExample,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			run.clusterName = args[0]

--- a/internal/cmd/plugin/pgbench/cmd.go
+++ b/internal/cmd/plugin/pgbench/cmd.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+
+	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/plugin"
 )
 
 // NewCmd initializes the pgBench command
@@ -31,7 +33,7 @@ func NewCmd() *cobra.Command {
 		Short:   "Creates a pgbench job",
 		Args:    validateCommandArgs,
 		Long:    "Creates a pgbench job to run against the specified Postgres Cluster.",
-		GroupID: "misc",
+		GroupID: plugin.GroupIDMiscellaneous,
 		Example: jobExample,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			run.clusterName = args[0]

--- a/internal/cmd/plugin/plugin.go
+++ b/internal/cmd/plugin/plugin.go
@@ -57,14 +57,18 @@ var (
 )
 
 const (
-	// GroupIDCnpg represents an ID to group up CNPG commands
-	GroupIDCnpg = "cnpg-level"
+	// GroupIDAdmin represents an ID to group up CNPG commands
+	GroupIDAdmin = "admin"
 
-	// GroupIDPgCluster represents an ID to group up Postgres Cluster commands
-	GroupIDPgCluster = "pg-cluster"
+	// GroupIDTroubleshooting represent an ID to group up troubleshooting
+	// commands
+	GroupIDTroubleshooting = "troubleshooting"
 
-	// GroupIDPgDatabase represents an ID to group up Postgres Database commands
-	GroupIDPgDatabase = "pg-db"
+	// GroupIDCluster represents an ID to group up Postgres Cluster commands
+	GroupIDCluster = "cluster"
+
+	// GroupIDDatabase represents an ID to group up Postgres Database commands
+	GroupIDDatabase = "db"
 
 	// GroupIDMiscellaneous represents an ID to group up miscellaneous commands
 	GroupIDMiscellaneous = "misc"

--- a/internal/cmd/plugin/plugin.go
+++ b/internal/cmd/plugin/plugin.go
@@ -56,6 +56,20 @@ var (
 	ClientInterface kubernetes.Interface
 )
 
+const (
+	// GroupIDCnpg represents an ID to group up CNPG commands
+	GroupIDCnpg = "cnpg-level"
+
+	// GroupIDPgCluster represents an ID to group up Postgres Cluster commands
+	GroupIDPgCluster = "pg-cluster"
+
+	// GroupIDPgDatabase represents an ID to group up Postgres Database commands
+	GroupIDPgDatabase = "pg-db"
+
+	// GroupIDMiscellaneous represents an ID to group up miscellaneous commands
+	GroupIDMiscellaneous = "misc"
+)
+
 // SetupKubernetesClient creates a k8s client to be used inside the kubectl-cnpg
 // utility
 func SetupKubernetesClient(configFlags *genericclioptions.ConfigFlags) error {

--- a/internal/cmd/plugin/promote/cmd.go
+++ b/internal/cmd/plugin/promote/cmd.go
@@ -31,7 +31,7 @@ func NewCmd() *cobra.Command {
 	promoteCmd := &cobra.Command{
 		Use:     "promote [cluster] [node]",
 		Short:   "Promote the pod named [cluster]-[node] or [node] to primary",
-		GroupID: "pg-cluster",
+		GroupID: plugin.GroupIDPgCluster,
 		Args:    plugin.RequiresArguments(2),
 		RunE: func(_ *cobra.Command, args []string) error {
 			ctx := context.Background()

--- a/internal/cmd/plugin/promote/cmd.go
+++ b/internal/cmd/plugin/promote/cmd.go
@@ -31,7 +31,7 @@ func NewCmd() *cobra.Command {
 	promoteCmd := &cobra.Command{
 		Use:     "promote [cluster] [node]",
 		Short:   "Promote the pod named [cluster]-[node] or [node] to primary",
-		GroupID: "admin",
+		GroupID: "pg-cluster",
 		Args:    plugin.RequiresArguments(2),
 		RunE: func(_ *cobra.Command, args []string) error {
 			ctx := context.Background()

--- a/internal/cmd/plugin/promote/cmd.go
+++ b/internal/cmd/plugin/promote/cmd.go
@@ -31,7 +31,7 @@ func NewCmd() *cobra.Command {
 	promoteCmd := &cobra.Command{
 		Use:     "promote [cluster] [node]",
 		Short:   "Promote the pod named [cluster]-[node] or [node] to primary",
-		GroupID: plugin.GroupIDPgCluster,
+		GroupID: plugin.GroupIDCluster,
 		Args:    plugin.RequiresArguments(2),
 		RunE: func(_ *cobra.Command, args []string) error {
 			ctx := context.Background()

--- a/internal/cmd/plugin/promote/cmd.go
+++ b/internal/cmd/plugin/promote/cmd.go
@@ -29,9 +29,10 @@ import (
 // NewCmd create the new "promote" subcommand
 func NewCmd() *cobra.Command {
 	promoteCmd := &cobra.Command{
-		Use:   "promote [cluster] [node]",
-		Short: "Promote the pod named [cluster]-[node] or [node] to primary",
-		Args:  plugin.RequiresArguments(2),
+		Use:     "promote [cluster] [node]",
+		Short:   "Promote the pod named [cluster]-[node] or [node] to primary",
+		GroupID: "admin",
+		Args:    plugin.RequiresArguments(2),
 		RunE: func(_ *cobra.Command, args []string) error {
 			ctx := context.Background()
 			clusterName := args[0]

--- a/internal/cmd/plugin/psql/cmd.go
+++ b/internal/cmd/plugin/psql/cmd.go
@@ -37,7 +37,8 @@ func NewCmd() *cobra.Command {
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			return plugin.CompleteClusters(cmd.Context(), args, toComplete), cobra.ShellCompDirectiveNoFileComp
 		},
-		Long: "This command will start an interactive psql session inside a PostgreSQL Pod created by CloudNativePG.",
+		Long:    "This command will start an interactive psql session inside a PostgreSQL Pod created by CloudNativePG.",
+		GroupID: "dba",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			clusterName := args[0]
 			psqlArgs := args[1:]

--- a/internal/cmd/plugin/psql/cmd.go
+++ b/internal/cmd/plugin/psql/cmd.go
@@ -38,7 +38,7 @@ func NewCmd() *cobra.Command {
 			return plugin.CompleteClusters(cmd.Context(), args, toComplete), cobra.ShellCompDirectiveNoFileComp
 		},
 		Long:    "This command will start an interactive psql session inside a PostgreSQL Pod created by CloudNativePG.",
-		GroupID: "misc",
+		GroupID: plugin.GroupIDMiscellaneous,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			clusterName := args[0]
 			psqlArgs := args[1:]

--- a/internal/cmd/plugin/psql/cmd.go
+++ b/internal/cmd/plugin/psql/cmd.go
@@ -38,7 +38,7 @@ func NewCmd() *cobra.Command {
 			return plugin.CompleteClusters(cmd.Context(), args, toComplete), cobra.ShellCompDirectiveNoFileComp
 		},
 		Long:    "This command will start an interactive psql session inside a PostgreSQL Pod created by CloudNativePG.",
-		GroupID: "dba",
+		GroupID: "misc",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			clusterName := args[0]
 			psqlArgs := args[1:]

--- a/internal/cmd/plugin/reload/cmd.go
+++ b/internal/cmd/plugin/reload/cmd.go
@@ -30,7 +30,7 @@ func NewCmd() *cobra.Command {
 		Use:     "reload [clusterName]",
 		Short:   `Reload a cluster`,
 		Long:    `Triggers a reconciliation loop for all the cluster's instances, rolling out new configurations if present.`,
-		GroupID: plugin.GroupIDPgCluster,
+		GroupID: plugin.GroupIDCluster,
 		Args:    plugin.RequiresArguments(1),
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			return plugin.CompleteClusters(cmd.Context(), args, toComplete), cobra.ShellCompDirectiveNoFileComp

--- a/internal/cmd/plugin/reload/cmd.go
+++ b/internal/cmd/plugin/reload/cmd.go
@@ -28,9 +28,9 @@ import (
 func NewCmd() *cobra.Command {
 	restartCmd := &cobra.Command{
 		Use:     "reload [clusterName]",
-		Short:   `Reload the cluster`,
+		Short:   `Reload a cluster`,
 		Long:    `Triggers a reconciliation loop for all the cluster's instances, rolling out new configurations if present.`,
-		GroupID: "admin",
+		GroupID: "pg-cluster",
 		Args:    plugin.RequiresArguments(1),
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			return plugin.CompleteClusters(cmd.Context(), args, toComplete), cobra.ShellCompDirectiveNoFileComp

--- a/internal/cmd/plugin/reload/cmd.go
+++ b/internal/cmd/plugin/reload/cmd.go
@@ -27,10 +27,11 @@ import (
 // NewCmd creates the new "reset" command
 func NewCmd() *cobra.Command {
 	restartCmd := &cobra.Command{
-		Use:   "reload [clusterName]",
-		Short: `Reload the cluster`,
-		Long:  `Triggers a reconciliation loop for all the cluster's instances, rolling out new configurations if present.`,
-		Args:  plugin.RequiresArguments(1),
+		Use:     "reload [clusterName]",
+		Short:   `Reload the cluster`,
+		Long:    `Triggers a reconciliation loop for all the cluster's instances, rolling out new configurations if present.`,
+		GroupID: "admin",
+		Args:    plugin.RequiresArguments(1),
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			return plugin.CompleteClusters(cmd.Context(), args, toComplete), cobra.ShellCompDirectiveNoFileComp
 		},

--- a/internal/cmd/plugin/reload/cmd.go
+++ b/internal/cmd/plugin/reload/cmd.go
@@ -30,7 +30,7 @@ func NewCmd() *cobra.Command {
 		Use:     "reload [clusterName]",
 		Short:   `Reload a cluster`,
 		Long:    `Triggers a reconciliation loop for all the cluster's instances, rolling out new configurations if present.`,
-		GroupID: "pg-cluster",
+		GroupID: plugin.GroupIDPgCluster,
 		Args:    plugin.RequiresArguments(1),
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			return plugin.CompleteClusters(cmd.Context(), args, toComplete), cobra.ShellCompDirectiveNoFileComp

--- a/internal/cmd/plugin/report/cmd.go
+++ b/internal/cmd/plugin/report/cmd.go
@@ -18,6 +18,8 @@ package report
 
 import (
 	"github.com/spf13/cobra"
+
+	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/plugin"
 )
 
 // NewCmd creates the new "report" command
@@ -25,7 +27,7 @@ func NewCmd() *cobra.Command {
 	reportCmd := &cobra.Command{
 		Use:     "report operator/cluster",
 		Short:   "Report on the operator or a cluster for troubleshooting",
-		GroupID: "cnpg-level",
+		GroupID: plugin.GroupIDCnpg,
 	}
 
 	reportCmd.AddCommand(operatorCmd())

--- a/internal/cmd/plugin/report/cmd.go
+++ b/internal/cmd/plugin/report/cmd.go
@@ -24,8 +24,8 @@ import (
 func NewCmd() *cobra.Command {
 	reportCmd := &cobra.Command{
 		Use:     "report operator/cluster",
-		Short:   "Report on the operator",
-		GroupID: "tools",
+		Short:   "Report on the operator or a cluster for troubleshooting",
+		GroupID: "cnpg-level",
 	}
 
 	reportCmd.AddCommand(operatorCmd())

--- a/internal/cmd/plugin/report/cmd.go
+++ b/internal/cmd/plugin/report/cmd.go
@@ -23,8 +23,9 @@ import (
 // NewCmd creates the new "report" command
 func NewCmd() *cobra.Command {
 	reportCmd := &cobra.Command{
-		Use:   "report operator/cluster",
-		Short: "Report on the operator",
+		Use:     "report operator/cluster",
+		Short:   "Report on the operator",
+		GroupID: "tools",
 	}
 
 	reportCmd.AddCommand(operatorCmd())

--- a/internal/cmd/plugin/report/cmd.go
+++ b/internal/cmd/plugin/report/cmd.go
@@ -27,7 +27,7 @@ func NewCmd() *cobra.Command {
 	reportCmd := &cobra.Command{
 		Use:     "report operator/cluster",
 		Short:   "Report on the operator or a cluster for troubleshooting",
-		GroupID: plugin.GroupIDCnpg,
+		GroupID: plugin.GroupIDTroubleshooting,
 	}
 
 	reportCmd.AddCommand(operatorCmd())

--- a/internal/cmd/plugin/restart/cmd.go
+++ b/internal/cmd/plugin/restart/cmd.go
@@ -33,7 +33,7 @@ rolling out new configurations if present.
 If a specific instance is specified, only that instance will be restarted, 
 in-place if it is a primary, deleting the pod if it is a replica.`,
 		Args:    cobra.RangeArgs(1, 2),
-		GroupID: "admin",
+		GroupID: "pg-cluster",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			clusterName := args[0]

--- a/internal/cmd/plugin/restart/cmd.go
+++ b/internal/cmd/plugin/restart/cmd.go
@@ -32,7 +32,8 @@ func NewCmd() *cobra.Command {
 rolling out new configurations if present.
 If a specific instance is specified, only that instance will be restarted, 
 in-place if it is a primary, deleting the pod if it is a replica.`,
-		Args: cobra.RangeArgs(1, 2),
+		Args:    cobra.RangeArgs(1, 2),
+		GroupID: "admin",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			clusterName := args[0]

--- a/internal/cmd/plugin/restart/cmd.go
+++ b/internal/cmd/plugin/restart/cmd.go
@@ -35,7 +35,7 @@ rolling out new configurations if present.
 If a specific instance is specified, only that instance will be restarted, 
 in-place if it is a primary, deleting the pod if it is a replica.`,
 		Args:    cobra.RangeArgs(1, 2),
-		GroupID: plugin.GroupIDPgCluster,
+		GroupID: plugin.GroupIDCluster,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			clusterName := args[0]

--- a/internal/cmd/plugin/restart/cmd.go
+++ b/internal/cmd/plugin/restart/cmd.go
@@ -21,6 +21,8 @@ import (
 	"strconv"
 
 	"github.com/spf13/cobra"
+
+	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/plugin"
 )
 
 // NewCmd creates the new "reset" command
@@ -33,7 +35,7 @@ rolling out new configurations if present.
 If a specific instance is specified, only that instance will be restarted, 
 in-place if it is a primary, deleting the pod if it is a replica.`,
 		Args:    cobra.RangeArgs(1, 2),
-		GroupID: "pg-cluster",
+		GroupID: plugin.GroupIDPgCluster,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			clusterName := args[0]

--- a/internal/cmd/plugin/snapshot/cmd.go
+++ b/internal/cmd/plugin/snapshot/cmd.go
@@ -31,7 +31,7 @@ func NewCmd() *cobra.Command {
 		Use:     "snapshot <cluster-name>",
 		Short:   "DEPRECATED (use `backup -m volumeSnapshot` instead)",
 		Long:    "Replaced by `kubectl cnpg backup <cluster-name> -m volumeSnapshot`",
-		GroupID: "pg-db",
+		GroupID: plugin.GroupIDPgDatabase,
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			return plugin.CompleteClusters(cmd.Context(), args, toComplete), cobra.ShellCompDirectiveNoFileComp
 		},

--- a/internal/cmd/plugin/snapshot/cmd.go
+++ b/internal/cmd/plugin/snapshot/cmd.go
@@ -28,9 +28,10 @@ import (
 // NewCmd implements the `snapshot` subcommand
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "snapshot <cluster-name>",
-		Short: "command removed",
-		Long:  "Replaced by `kubectl cnpg backup <cluster-name> -m volumeSnapshot`",
+		Use:     "snapshot <cluster-name>",
+		Short:   "command removed",
+		Long:    "Replaced by `kubectl cnpg backup <cluster-name> -m volumeSnapshot`",
+		GroupID: "admin",
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			return plugin.CompleteClusters(cmd.Context(), args, toComplete), cobra.ShellCompDirectiveNoFileComp
 		},

--- a/internal/cmd/plugin/snapshot/cmd.go
+++ b/internal/cmd/plugin/snapshot/cmd.go
@@ -29,9 +29,9 @@ import (
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "snapshot <cluster-name>",
-		Short:   "command removed",
+		Short:   "DEPRECATED (use `backup -m volumeSnapshot` instead)",
 		Long:    "Replaced by `kubectl cnpg backup <cluster-name> -m volumeSnapshot`",
-		GroupID: "admin",
+		GroupID: "pg-db",
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			return plugin.CompleteClusters(cmd.Context(), args, toComplete), cobra.ShellCompDirectiveNoFileComp
 		},

--- a/internal/cmd/plugin/snapshot/cmd.go
+++ b/internal/cmd/plugin/snapshot/cmd.go
@@ -31,7 +31,7 @@ func NewCmd() *cobra.Command {
 		Use:     "snapshot <cluster-name>",
 		Short:   "DEPRECATED (use `backup -m volumeSnapshot` instead)",
 		Long:    "Replaced by `kubectl cnpg backup <cluster-name> -m volumeSnapshot`",
-		GroupID: plugin.GroupIDPgDatabase,
+		GroupID: plugin.GroupIDDatabase,
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			return plugin.CompleteClusters(cmd.Context(), args, toComplete), cobra.ShellCompDirectiveNoFileComp
 		},

--- a/internal/cmd/plugin/status/cmd.go
+++ b/internal/cmd/plugin/status/cmd.go
@@ -31,7 +31,7 @@ func NewCmd() *cobra.Command {
 		Use:     "status [cluster]",
 		Short:   "Get the status of a PostgreSQL cluster",
 		Args:    plugin.RequiresArguments(1),
-		GroupID: "pg-db",
+		GroupID: plugin.GroupIDPgDatabase,
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			if strings.HasPrefix(toComplete, "-") {
 				fmt.Printf("%+v\n", toComplete)

--- a/internal/cmd/plugin/status/cmd.go
+++ b/internal/cmd/plugin/status/cmd.go
@@ -31,7 +31,7 @@ func NewCmd() *cobra.Command {
 		Use:     "status [cluster]",
 		Short:   "Get the status of a PostgreSQL cluster",
 		Args:    plugin.RequiresArguments(1),
-		GroupID: plugin.GroupIDPgDatabase,
+		GroupID: plugin.GroupIDDatabase,
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			if strings.HasPrefix(toComplete, "-") {
 				fmt.Printf("%+v\n", toComplete)

--- a/internal/cmd/plugin/status/cmd.go
+++ b/internal/cmd/plugin/status/cmd.go
@@ -28,9 +28,10 @@ import (
 // NewCmd create the new "status" subcommand
 func NewCmd() *cobra.Command {
 	statusCmd := &cobra.Command{
-		Use:   "status [cluster]",
-		Short: "Get the status of a PostgreSQL cluster",
-		Args:  plugin.RequiresArguments(1),
+		Use:     "status [cluster]",
+		Short:   "Get the status of a PostgreSQL cluster",
+		Args:    plugin.RequiresArguments(1),
+		GroupID: "tools",
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			if strings.HasPrefix(toComplete, "-") {
 				fmt.Printf("%+v\n", toComplete)

--- a/internal/cmd/plugin/status/cmd.go
+++ b/internal/cmd/plugin/status/cmd.go
@@ -31,7 +31,7 @@ func NewCmd() *cobra.Command {
 		Use:     "status [cluster]",
 		Short:   "Get the status of a PostgreSQL cluster",
 		Args:    plugin.RequiresArguments(1),
-		GroupID: "tools",
+		GroupID: "pg-db",
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			if strings.HasPrefix(toComplete, "-") {
 				fmt.Printf("%+v\n", toComplete)


### PR DESCRIPTION
Organise `cnpg` plugin commands into logical groups using the following categories:

- Operator-level administration
- Troubleshooting
- Cluster administration
- Database administration
- Miscellaneous

Closes #5795 