### PR TITLE
chore: create renovate groups for cnpg dependencies

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -361,7 +361,8 @@
       "excludePackagePrefixes": [
         "k8s.io",
         "sigs.k8s.io",
-        "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring"
+        "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring",
+        "github.com/cloudnative-pg/"
       ],
       "matchUpdateTypes": [
         "minor",
@@ -424,6 +425,15 @@
       ],
       "separateMajorMinor": "false",
       "pinDigests": false,
-    }
+    },
+    {
+// PR group for CNPG dependencies
+      "groupName": "cnpg",
+      "matchPackageNames": [
+        "github.com/cloudnative-pg/",
+      ],
+      "separateMajorMinor": "false",
+      "pinDigests": false,
+    },
   ]
 }


### PR DESCRIPTION
To update all at once in only one group we create only a group for
all the dependencies like machinery, barman-cloud and cnpg-i