### PR TITLE
chore: switch to dl.k8s.io on the E2E tests

### DIFF
--- a/hack/setup-cluster.sh
+++ b/hack/setup-cluster.sh
@@ -299,7 +299,7 @@ install_kubectl() {
 
   local binary="${bindir}/kubectl"
 
-  curl -sL "https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION#v}/bin/${OS}/${ARCH}/kubectl" -o "${binary}"
+  curl -sL "https://dl.k8s.io/release/v${KUBECTL_VERSION#v}/bin/${OS}/${ARCH}/kubectl" -o "${binary}"
   chmod +x "${binary}"
 }
 


### PR DESCRIPTION
Following this https://github.com/kubernetes/k8s.io/issues/2396 we
should have moved away a long time ago, now this change happened
and the E2E tests are failing due to a wrong link to download the kubectl client.