### PR TITLE
fix(plugin): collect sidecars' log from `kubectl cnpg logs cluster`

### DIFF
--- a/pkg/utils/logs/cluster_logs_test.go
+++ b/pkg/utils/logs/cluster_logs_test.go
@@ -110,7 +110,7 @@ var _ = Describe("Cluster logging tests", func() {
 	})
 
 	It("should catch the logs of the sidecar too", func(ctx context.Context) {
-		client := fake.NewSimpleClientset(podWithSidecars)
+		client := fake.NewClientset(podWithSidecars)
 		var logBuffer bytes.Buffer
 		var wait sync.WaitGroup
 		wait.Add(1)


### PR DESCRIPTION
`kubectl cnpg logs cluster` failed if an instance Pod had a sidecar.

This patch allows it to continue working and getting the sidecar's log too.

Closes: #5825 

# Release notes

```
`kubectl cnpg logs cluster` does not error out if a PG Pod has a sidecar and 
collects also its logs
```