### PR TITLE
chore: avoid uselessly patching the ContinuousArchivingSuccess condition

### DIFF
--- a/pkg/conditions/conditions.go
+++ b/pkg/conditions/conditions.go
@@ -18,7 +18,6 @@ package conditions
 
 import (
 	"context"
-	"reflect"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -37,10 +36,9 @@ func Patch(
 	if cluster == nil || condition == nil {
 		return nil
 	}
-	existingCluster := cluster.DeepCopy()
-	meta.SetStatusCondition(&cluster.Status.Conditions, *condition)
 
-	if !reflect.DeepEqual(existingCluster.Status.Conditions, cluster.Status.Conditions) {
+	existingCluster := cluster.DeepCopy()
+	if changed := meta.SetStatusCondition(&cluster.Status.Conditions, *condition); changed {
 		// To avoid conflict using patch instead of update
 		if err := c.Status().Patch(ctx, cluster, client.MergeFrom(existingCluster)); err != nil {
 			return err


### PR DESCRIPTION
The `archive_command` callback is keeping updated the `ContinuousArchivingSuccess` condition using the result of `barman-cloud-wal-archive` or the corresponding CNPG-i plugin.

This change makes the instance manager deterministically hit the API server when the condition changes instead of using `reflect.DeepEqual`, avoiding false positives.

See also: #5366 