### PR TITLE
fix(plugin): improve plugin errors

### DIFF
--- a/internal/cmd/plugin/hibernate/on.go
+++ b/internal/cmd/plugin/hibernate/on.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/cloudnative-pg/machinery/pkg/log"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
@@ -213,8 +214,9 @@ func (on *onCommand) rollbackFenceClusterIfNeeded() {
 
 // waitInstancesToBeFenced waits for all instances to be shut down
 func (on *onCommand) waitInstancesToBeFencedStep() error {
+	retryOnlyNonForbbiden := func(err error) bool { return !apierrors.IsForbidden(err) }
 	for _, instance := range on.managedInstances {
-		if err := retry.OnError(hibernationBackoff, resources.RetryAlways, func() error {
+		if err := retry.OnError(hibernationBackoff, retryOnlyNonForbbiden, func() error {
 			running, err := pluginresources.IsInstanceRunning(on.ctx, instance)
 			if err != nil {
 				return fmt.Errorf("error checking instance status (%v): %w", instance.Name, err)

--- a/internal/cmd/plugin/logical/database.go
+++ b/internal/cmd/plugin/logical/database.go
@@ -40,7 +40,7 @@ func GetApplicationDatabaseName(ctx context.Context, clusterName string) (string
 		&cluster,
 	)
 	if err != nil {
-		return "", fmt.Errorf("cluster %s not found in namespace %s", clusterName, plugin.Namespace)
+		return "", fmt.Errorf("cluster %s not found in namespace %s: %w", clusterName, plugin.Namespace, err)
 	}
 
 	return cluster.GetApplicationDatabaseName(), nil

--- a/internal/cmd/plugin/logical/externalcluster.go
+++ b/internal/cmd/plugin/logical/externalcluster.go
@@ -46,7 +46,7 @@ func GetConnectionString(
 		&cluster,
 	)
 	if err != nil {
-		return "", fmt.Errorf("cluster %s not found in namespace %s", clusterName, plugin.Namespace)
+		return "", fmt.Errorf("cluster %s not found in namespace %s: %w", clusterName, plugin.Namespace, err)
 	}
 
 	externalCluster, ok := cluster.ExternalCluster(externalClusterName)

--- a/internal/cmd/plugin/logical/subscription/syncsequences/cmd.go
+++ b/internal/cmd/plugin/logical/subscription/syncsequences/cmd.go
@@ -57,7 +57,8 @@ func NewCmd() *cobra.Command {
 				&cluster,
 			)
 			if err != nil {
-				return fmt.Errorf("cluster %s not found in namespace %s", clusterName, plugin.Namespace)
+				return fmt.Errorf("cluster %s not found in namespace %s: %w",
+					clusterName, plugin.Namespace, err)
 			}
 
 			if len(dbName) == 0 {

--- a/internal/cmd/plugin/maintenance/maintenance.go
+++ b/internal/cmd/plugin/maintenance/maintenance.go
@@ -83,7 +83,7 @@ func Maintenance(ctx context.Context,
 	for _, item := range clusterList.Items {
 		err := patchNodeMaintenanceWindow(ctx, item, setInProgressTo, reusePVC)
 		if err != nil {
-			return fmt.Errorf("unable to set progress to cluster %v in namespace %v", item.Name, item.Namespace)
+			return fmt.Errorf("unable to set progress to cluster %v in namespace %v: %w", item.Name, item.Namespace, err)
 		}
 	}
 

--- a/internal/cmd/plugin/pgbench/cmd.go
+++ b/internal/cmd/plugin/pgbench/cmd.go
@@ -88,7 +88,7 @@ func validateCommandArgs(cmd *cobra.Command, args []string) error {
 	}
 
 	if cmd.ArgsLenAtDash() > 1 {
-		return fmt.Errorf("pgBenchCommands should be passed after -- delimiter")
+		return fmt.Errorf("pgBenchCommands should be passed after the -- delimiter")
 	}
 
 	return nil

--- a/internal/cmd/plugin/promote/promote.go
+++ b/internal/cmd/plugin/promote/promote.go
@@ -37,7 +37,7 @@ func Promote(ctx context.Context, clusterName string, serverName string) error {
 	// Get the Cluster object
 	err := plugin.Client.Get(ctx, client.ObjectKey{Namespace: plugin.Namespace, Name: clusterName}, &cluster)
 	if err != nil {
-		return fmt.Errorf("cluster %s not found in namespace %s", clusterName, plugin.Namespace)
+		return fmt.Errorf("cluster %s not found in namespace %s: %w", clusterName, plugin.Namespace, err)
 	}
 
 	// If server name is equal to target primary, there is no need to promote
@@ -51,7 +51,7 @@ func Promote(ctx context.Context, clusterName string, serverName string) error {
 	var pod v1.Pod
 	err = plugin.Client.Get(ctx, client.ObjectKey{Namespace: plugin.Namespace, Name: serverName}, &pod)
 	if err != nil {
-		return fmt.Errorf("new primary node %s not found in namespace %s", serverName, plugin.Namespace)
+		return fmt.Errorf("new primary node %s not found in namespace %s: %w", serverName, plugin.Namespace, err)
 	}
 
 	// The Pod exists, let's update status fields

--- a/internal/cmd/plugin/psql/cmd.go
+++ b/internal/cmd/plugin/psql/cmd.go
@@ -92,7 +92,7 @@ func validatePsqlArgs(cmd *cobra.Command, args []string) error {
 	}
 
 	if cmd.ArgsLenAtDash() > 1 {
-		return fmt.Errorf("psqlArgs should be passed after -- delimitator")
+		return fmt.Errorf("psqlArgs should be passed after the -- delimiter")
 	}
 
 	return nil

--- a/internal/cmd/plugin/status/status.go
+++ b/internal/cmd/plugin/status/status.go
@@ -114,7 +114,8 @@ func Status(
 	// Get the Cluster object
 	err := plugin.Client.Get(ctx, client.ObjectKey{Namespace: plugin.Namespace, Name: clusterName}, &cluster)
 	if err != nil {
-		return err
+		return fmt.Errorf("while trying to get cluster %s in namespace %s: %w",
+			clusterName, plugin.Namespace, err)
 	}
 
 	status := extractPostgresqlStatus(ctx, cluster)

--- a/pkg/utils/fencing.go
+++ b/pkg/utils/fencing.go
@@ -192,7 +192,7 @@ func (fb *FencingMetadataExecutor) Execute(ctx context.Context, key types.Namesp
 		if name != FenceAllInstances {
 			var pod corev1.Pod
 			if err := fb.cli.Get(ctx, client.ObjectKey{Namespace: key.Namespace, Name: name}, &pod); err != nil {
-				return fmt.Errorf("node %s not found in namespace %s", name, key.Namespace)
+				return fmt.Errorf("node %s not found in namespace %s: %w", name, key.Namespace, err)
 			}
 		}
 	}


### PR DESCRIPTION
Some errors were hiding the real reason behind, most of them were exposed
when the user executing the command didn't have permissions to access the
requested resource, now, we also append the error from the API that show
explicitly the error when trying to access the resources.

Closes #5823 