### PR TITLE
chore(logging): add logs to `pre` and `post` reconcile hooks

### DIFF
--- a/internal/cnpi/plugin/client/contracts.go
+++ b/internal/cnpi/plugin/client/contracts.go
@@ -77,9 +77,10 @@ type ClusterCapabilities interface {
 
 // ReconcilerHookResult is the result of a reconciliation loop
 type ReconcilerHookResult struct {
-	Result             ctrl.Result
-	Err                error
-	StopReconciliation bool
+	Result             ctrl.Result `json:"result"`
+	Err                error       `json:"err"`
+	StopReconciliation bool        `json:"stopReconciliation"`
+	Identifier         string      `json:"identifier"`
 }
 
 // ClusterReconcilerHooks decsribes a set of behavior needed to enhance

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -298,6 +298,8 @@ func (r *ClusterReconciler) reconcile(ctx context.Context, cluster *apiv1.Cluste
 
 	// Calls pre-reconcile hooks
 	if hookResult := preReconcilePluginHooks(ctx, cluster, cluster); hookResult.StopReconciliation {
+		contextLogger.Info("Pre-reconcile hook stopped the reconciliation loop",
+			"hookResult", hookResult)
 		return hookResult.Result, hookResult.Err
 	}
 
@@ -502,6 +504,8 @@ func (r *ClusterReconciler) reconcile(ctx context.Context, cluster *apiv1.Cluste
 	// Calls post-reconcile hooks
 	if hookResult := postReconcilePluginHooks(ctx, cluster, cluster); hookResult.Err != nil ||
 		!hookResult.Result.IsZero() {
+		contextLogger.Info("Post-reconcile hook stopped the reconciliation loop",
+			"hookResult", hookResult)
 		return hookResult.Result, hookResult.Err
 	}
 


### PR DESCRIPTION
Closes #5851 


## Release Notes

The operator now outputs logs when interrupting the reconciliation loop when requested by a plugin or encountering an error while invoking the plugins

## Note for reviewers

I don't think we should backport this, given that it isn't a bug fix