### PR TITLE
feat: make data durability configurable for sync replication

### DIFF
--- a/.wordlist-en-custom.txt
+++ b/.wordlist-en-custom.txt
@@ -118,7 +118,7 @@ DISA
 DNS
 DataBackupConfiguration
 DataBase
-DataDurabilityMethod
+DataDurabilityLevel
 DataSource
 DatabaseReclaimPolicy
 DatabaseRoleRef

--- a/.wordlist-en-custom.txt
+++ b/.wordlist-en-custom.txt
@@ -118,6 +118,7 @@ DISA
 DNS
 DataBackupConfiguration
 DataBase
+DataDurabilityMethod
 DataSource
 DatabaseReclaimPolicy
 DatabaseRoleRef
@@ -674,6 +675,7 @@ cyber
 dT
 danglingPVC
 dataChecksums
+dataDurability
 databackupconfiguration
 databaseReclaimPolicy
 datacenter

--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -1179,11 +1179,11 @@ type DataDurabilityMethod string
 
 const (
 	// DataDurabilityMethodRequired means that data durability is strictly enforced
-	DataDurabilityMethodRequired DataDurabilityMethod = DataDurabilityMethod("required")
+	DataDurabilityMethodRequired DataDurabilityMethod = "required"
 
 	// DataDurabilityMethodPreferred means that data durability is enforced
 	// only when healthy replicas are available
-	DataDurabilityMethodPreferred DataDurabilityMethod = DataDurabilityMethod("preferred")
+	DataDurabilityMethodPreferred DataDurabilityMethod = "preferred"
 )
 
 // SynchronousReplicaConfiguration contains the configuration of the

--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -1229,6 +1229,7 @@ type SynchronousReplicaConfiguration struct {
 	// This can only be set if both `standbyNamesPre` and `standbyNamesPost` are empty.
 	// +kubebuilder:validation:Enum=required;preferred
 	// +kubebuilder:default:=required
+	// +optional
 	DataDurability DataDurabilityMethod `json:"dataDurability,omitempty"`
 }
 

--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -1173,17 +1173,17 @@ const (
 	SynchronousReplicaConfigurationMethodAny = SynchronousReplicaConfigurationMethod("any")
 )
 
-// DataDurabilityMethod specifies how strictly to enforce synchronous replication
+// DataDurabilityLevel specifies how strictly to enforce synchronous replication
 // when cluster instances are unavailable. Options are `required` or `preferred`.
-type DataDurabilityMethod string
+type DataDurabilityLevel string
 
 const (
-	// DataDurabilityMethodRequired means that data durability is strictly enforced
-	DataDurabilityMethodRequired DataDurabilityMethod = "required"
+	// DataDurabilityLevelRequired means that data durability is strictly enforced
+	DataDurabilityLevelRequired DataDurabilityLevel = "required"
 
-	// DataDurabilityMethodPreferred means that data durability is enforced
+	// DataDurabilityLevelPreferred means that data durability is enforced
 	// only when healthy replicas are available
-	DataDurabilityMethodPreferred DataDurabilityMethod = "preferred"
+	DataDurabilityLevelPreferred DataDurabilityLevel = "preferred"
 )
 
 // SynchronousReplicaConfiguration contains the configuration of the
@@ -1230,7 +1230,7 @@ type SynchronousReplicaConfiguration struct {
 	// +kubebuilder:validation:Enum=required;preferred
 	// +kubebuilder:default:=required
 	// +optional
-	DataDurability DataDurabilityMethod `json:"dataDurability,omitempty"`
+	DataDurability DataDurabilityLevel `json:"dataDurability,omitempty"`
 }
 
 // PostgresConfiguration defines the PostgreSQL configuration

--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -1173,12 +1173,12 @@ const (
 	SynchronousReplicaConfigurationMethodAny = SynchronousReplicaConfigurationMethod("any")
 )
 
-// DataDurabilityMethod specifies how to enforce synchronous replication when cluster instances
-// are unavailable. Options are `required` or `preferred`.
+// DataDurabilityMethod specifies how strictly to enforce synchronous replication
+// when cluster instances are unavailable. Options are `required` or `preferred`.
 type DataDurabilityMethod string
 
 const (
-	// DataDurabilityMethodRequired means that data durability is enforced always
+	// DataDurabilityMethodRequired means that data durability is strictly enforced
 	DataDurabilityMethodRequired DataDurabilityMethod = DataDurabilityMethod("required")
 
 	// DataDurabilityMethodPreferred means that data durability is enforced

--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -1173,8 +1173,8 @@ const (
 	SynchronousReplicaConfigurationMethodAny = SynchronousReplicaConfigurationMethod("any")
 )
 
-// DataDurabilityMethod can be `required` or `preferred` and allows the user to
-// relax strict enforcement
+// DataDurabilityMethod specifies how to enforce synchronous replication when cluster instances
+// are unavailable. Options are `required` or `preferred`.
 type DataDurabilityMethod string
 
 const (
@@ -1221,13 +1221,12 @@ type SynchronousReplicaConfiguration struct {
 	// +optional
 	StandbyNamesPost []string `json:"standbyNamesPost,omitempty"`
 
-	// If "required", strict enforcement of data durability is enforced and
-	// write operations with synchronous commit set to `on`, `remote_write`
-	// or `remote_apply` will hang if there are no sufficient number of
-	// healthy replicas.
-	// If "preferred" data durability will be enforced whenever healthy
-	// replicas are available. This can only be set if both
-	// `standbyNamesPre` and `standbyNamesPost` are empty.
+	// If "required", data durability is strictly enforced. Write operations with
+	// synchronous commit set to `on`, `remote_write`, or `remote_apply` will hang
+	// if there are not enough healthy replicas.
+	// If "preferred", data durability is enforced when healthy replicas are available.
+	// The required number of instances is reduced if there are not enough healthy replicas.
+	// This can only be set if both `standbyNamesPre` and `standbyNamesPost` are empty.
 	// +kubebuilder:validation:Enum=required;preferred
 	// +kubebuilder:default:=required
 	DataDurability DataDurabilityMethod `json:"dataDurability,omitempty"`

--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -1221,12 +1221,14 @@ type SynchronousReplicaConfiguration struct {
 	// +optional
 	StandbyNamesPost []string `json:"standbyNamesPost,omitempty"`
 
-	// If "required", data durability is strictly enforced. Write operations with
-	// synchronous commit set to `on`, `remote_write`, or `remote_apply` will hang
-	// if there are not enough healthy replicas.
-	// If "preferred", data durability is enforced when healthy replicas are available.
-	// The required number of instances is reduced if there are not enough healthy replicas.
-	// This can only be set if both `standbyNamesPre` and `standbyNamesPost` are empty.
+	// If set to "required", data durability is strictly enforced. Write operations
+	// with synchronous commit settings (`on`, `remote_write`, or `remote_apply`) will
+	// block if there are insufficient healthy replicas, ensuring data persistence.
+	// If set to "preferred", data durability is maintained when healthy replicas
+	// are available, but the required number of instances will adjust dynamically
+	// if replicas become unavailable. This setting relaxes strict durability enforcement
+	// to allow for operational continuity. This setting is only applicable if both
+	// `standbyNamesPre` and `standbyNamesPost` are unset (empty).
 	// +kubebuilder:validation:Enum=required;preferred
 	// +kubebuilder:default:=required
 	// +optional

--- a/config/crd/bases/postgresql.cnpg.io_clusters.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_clusters.yaml
@@ -4061,13 +4061,12 @@ spec:
                       dataDurability:
                         default: required
                         description: |-
-                          If "required", strict enforcement of data durability is enforced and
-                          write operations with synchronous commit set to `on`, `remote_write`
-                          or `remote_apply` will hang if there are no sufficient number of
-                          healthy replicas.
-                          If "preferred" data durability will be enforced whenever healthy
-                          replicas are available. This can only be set if both
-                          `standbyNamesPre` and `standbyNamesPost` are empty.
+                          If "required", data durability is strictly enforced. Write operations with
+                          synchronous commit set to `on`, `remote_write`, or `remote_apply` will hang
+                          if there are not enough healthy replicas.
+                          If "preferred", data durability is enforced when healthy replicas are available.
+                          The required number of instances is reduced if there are not enough healthy replicas.
+                          This can only be set if both `standbyNamesPre` and `standbyNamesPost` are empty.
                         enum:
                         - required
                         - preferred

--- a/config/crd/bases/postgresql.cnpg.io_clusters.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_clusters.yaml
@@ -4061,12 +4061,14 @@ spec:
                       dataDurability:
                         default: required
                         description: |-
-                          If "required", data durability is strictly enforced. Write operations with
-                          synchronous commit set to `on`, `remote_write`, or `remote_apply` will hang
-                          if there are not enough healthy replicas.
-                          If "preferred", data durability is enforced when healthy replicas are available.
-                          The required number of instances is reduced if there are not enough healthy replicas.
-                          This can only be set if both `standbyNamesPre` and `standbyNamesPost` are empty.
+                          If set to "required", data durability is strictly enforced. Write operations
+                          with synchronous commit settings (`on`, `remote_write`, or `remote_apply`) will
+                          block if there are insufficient healthy replicas, ensuring data persistence.
+                          If set to "preferred", data durability is maintained when healthy replicas
+                          are available, but the required number of instances will adjust dynamically
+                          if replicas become unavailable. This setting relaxes strict durability enforcement
+                          to allow for operational continuity. This setting is only applicable if both
+                          `standbyNamesPre` and `standbyNamesPost` are unset (empty).
                         enum:
                         - required
                         - preferred

--- a/config/crd/bases/postgresql.cnpg.io_clusters.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_clusters.yaml
@@ -4058,6 +4058,20 @@ spec:
                     description: Configuration of the PostgreSQL synchronous replication
                       feature
                     properties:
+                      dataDurability:
+                        default: required
+                        description: |-
+                          If "required", strict enforcement of data durability is enforced and
+                          write operations with synchronous commit set to `on`, `remote_write`
+                          or `remote_apply` will hang if there are no sufficient number of
+                          healthy replicas.
+                          If "preferred" data durability will be enforced whenever healthy
+                          replicas are available. This can only be set if both
+                          `standbyNamesPre` and `standbyNamesPost` are empty.
+                        enum:
+                        - required
+                        - preferred
+                        type: string
                       maxStandbyNamesFromCluster:
                         description: |-
                           Specifies the maximum number of local cluster pods that can be
@@ -4102,6 +4116,12 @@ spec:
                     - method
                     - number
                     type: object
+                    x-kubernetes-validations:
+                    - message: dataDurability set to 'preferred' requires empty 'standbyNamesPre'
+                        and empty 'standbyNamesPost'
+                      rule: self.dataDurability!='preferred' || ((!has(self.standbyNamesPre)
+                        || self.standbyNamesPre.size()==0) && (!has(self.standbyNamesPost)
+                        || self.standbyNamesPost.size()==0))
                 type: object
               primaryUpdateMethod:
                 default: restart

--- a/docs/src/cloudnative-pg.v1.md
+++ b/docs/src/cloudnative-pg.v1.md
@@ -2199,6 +2199,21 @@ Map keys are the config map names, map values are the versions</p>
 </tbody>
 </table>
 
+## DataDurabilityMethod     {#postgresql-cnpg-io-v1-DataDurabilityMethod}
+
+(Alias of `string`)
+
+**Appears in:**
+
+- [SynchronousReplicaConfiguration](#postgresql-cnpg-io-v1-SynchronousReplicaConfiguration)
+
+
+<p>DataDurabilityMethod can be <code>required</code> or <code>preferred</code> and allows the user to
+relax strict enforcement</p>
+
+
+
+
 ## DataSource     {#postgresql-cnpg-io-v1-DataSource}
 
 
@@ -4989,6 +5004,19 @@ only useful for priority-based synchronous replication).</p>
    <p>A user-defined list of application names to be added to
 <code>synchronous_standby_names</code> after local cluster pods (the order is
 only useful for priority-based synchronous replication).</p>
+</td>
+</tr>
+<tr><td><code>dataDurability</code> <B>[Required]</B><br/>
+<a href="#postgresql-cnpg-io-v1-DataDurabilityMethod"><i>DataDurabilityMethod</i></a>
+</td>
+<td>
+   <p>If &quot;required&quot;, strict enforcement of data durability is enforced and
+write operations with synchronous commit set to <code>on</code>, <code>remote_write</code>
+or <code>remote_apply</code> will hang if there are no sufficient number of
+healthy replicas.
+If &quot;preferred&quot; data durability will be enforced whenever healthy
+replicas are available. This can only be set if both
+<code>standbyNamesPre</code> and <code>standbyNamesPost</code> are empty.</p>
 </td>
 </tr>
 </tbody>

--- a/docs/src/cloudnative-pg.v1.md
+++ b/docs/src/cloudnative-pg.v1.md
@@ -2208,8 +2208,8 @@ Map keys are the config map names, map values are the versions</p>
 - [SynchronousReplicaConfiguration](#postgresql-cnpg-io-v1-SynchronousReplicaConfiguration)
 
 
-<p>DataDurabilityMethod specifies how to enforce synchronous replication when cluster instances
-are unavailable. Options are <code>required</code> or <code>preferred</code>.</p>
+<p>DataDurabilityMethod specifies how strictly to enforce synchronous replication
+when cluster instances are unavailable. Options are <code>required</code> or <code>preferred</code>.</p>
 
 
 

--- a/docs/src/cloudnative-pg.v1.md
+++ b/docs/src/cloudnative-pg.v1.md
@@ -5006,7 +5006,7 @@ only useful for priority-based synchronous replication).</p>
 only useful for priority-based synchronous replication).</p>
 </td>
 </tr>
-<tr><td><code>dataDurability</code> <B>[Required]</B><br/>
+<tr><td><code>dataDurability</code><br/>
 <a href="#postgresql-cnpg-io-v1-DataDurabilityMethod"><i>DataDurabilityMethod</i></a>
 </td>
 <td>

--- a/docs/src/cloudnative-pg.v1.md
+++ b/docs/src/cloudnative-pg.v1.md
@@ -5010,12 +5010,14 @@ only useful for priority-based synchronous replication).</p>
 <a href="#postgresql-cnpg-io-v1-DataDurabilityLevel"><i>DataDurabilityLevel</i></a>
 </td>
 <td>
-   <p>If &quot;required&quot;, data durability is strictly enforced. Write operations with
-synchronous commit set to <code>on</code>, <code>remote_write</code>, or <code>remote_apply</code> will hang
-if there are not enough healthy replicas.
-If &quot;preferred&quot;, data durability is enforced when healthy replicas are available.
-The required number of instances is reduced if there are not enough healthy replicas.
-This can only be set if both <code>standbyNamesPre</code> and <code>standbyNamesPost</code> are empty.</p>
+   <p>If set to &quot;required&quot;, data durability is strictly enforced. Write operations
+with synchronous commit settings (<code>on</code>, <code>remote_write</code>, or <code>remote_apply</code>) will
+block if there are insufficient healthy replicas, ensuring data persistence.
+If set to &quot;preferred&quot;, data durability is maintained when healthy replicas
+are available, but the required number of instances will adjust dynamically
+if replicas become unavailable. This setting relaxes strict durability enforcement
+to allow for operational continuity. This setting is only applicable if both
+<code>standbyNamesPre</code> and <code>standbyNamesPost</code> are unset (empty).</p>
 </td>
 </tr>
 </tbody>

--- a/docs/src/cloudnative-pg.v1.md
+++ b/docs/src/cloudnative-pg.v1.md
@@ -2199,7 +2199,7 @@ Map keys are the config map names, map values are the versions</p>
 </tbody>
 </table>
 
-## DataDurabilityMethod     {#postgresql-cnpg-io-v1-DataDurabilityMethod}
+## DataDurabilityLevel     {#postgresql-cnpg-io-v1-DataDurabilityLevel}
 
 (Alias of `string`)
 
@@ -2208,7 +2208,7 @@ Map keys are the config map names, map values are the versions</p>
 - [SynchronousReplicaConfiguration](#postgresql-cnpg-io-v1-SynchronousReplicaConfiguration)
 
 
-<p>DataDurabilityMethod specifies how strictly to enforce synchronous replication
+<p>DataDurabilityLevel specifies how strictly to enforce synchronous replication
 when cluster instances are unavailable. Options are <code>required</code> or <code>preferred</code>.</p>
 
 
@@ -5007,7 +5007,7 @@ only useful for priority-based synchronous replication).</p>
 </td>
 </tr>
 <tr><td><code>dataDurability</code><br/>
-<a href="#postgresql-cnpg-io-v1-DataDurabilityMethod"><i>DataDurabilityMethod</i></a>
+<a href="#postgresql-cnpg-io-v1-DataDurabilityLevel"><i>DataDurabilityLevel</i></a>
 </td>
 <td>
    <p>If &quot;required&quot;, data durability is strictly enforced. Write operations with

--- a/docs/src/cloudnative-pg.v1.md
+++ b/docs/src/cloudnative-pg.v1.md
@@ -2208,8 +2208,8 @@ Map keys are the config map names, map values are the versions</p>
 - [SynchronousReplicaConfiguration](#postgresql-cnpg-io-v1-SynchronousReplicaConfiguration)
 
 
-<p>DataDurabilityMethod can be <code>required</code> or <code>preferred</code> and allows the user to
-relax strict enforcement</p>
+<p>DataDurabilityMethod specifies how to enforce synchronous replication when cluster instances
+are unavailable. Options are <code>required</code> or <code>preferred</code>.</p>
 
 
 
@@ -5010,13 +5010,12 @@ only useful for priority-based synchronous replication).</p>
 <a href="#postgresql-cnpg-io-v1-DataDurabilityMethod"><i>DataDurabilityMethod</i></a>
 </td>
 <td>
-   <p>If &quot;required&quot;, strict enforcement of data durability is enforced and
-write operations with synchronous commit set to <code>on</code>, <code>remote_write</code>
-or <code>remote_apply</code> will hang if there are no sufficient number of
-healthy replicas.
-If &quot;preferred&quot; data durability will be enforced whenever healthy
-replicas are available. This can only be set if both
-<code>standbyNamesPre</code> and <code>standbyNamesPost</code> are empty.</p>
+   <p>If &quot;required&quot;, data durability is strictly enforced. Write operations with
+synchronous commit set to <code>on</code>, <code>remote_write</code>, or <code>remote_apply</code> will hang
+if there are not enough healthy replicas.
+If &quot;preferred&quot;, data durability is enforced when healthy replicas are available.
+The required number of instances is reduced if there are not enough healthy replicas.
+This can only be set if both <code>standbyNamesPre</code> and <code>standbyNamesPost</code> are empty.</p>
 </td>
 </tr>
 </tbody>

--- a/docs/src/replication.md
+++ b/docs/src/replication.md
@@ -116,7 +116,7 @@ CloudNativePG supports both
     unavailable. This behavior prioritizes data durability and aligns with
     PostgreSQL DBA best practices. However, if self-healing is a higher priority
     than strict data durability in your setup, this setting can be adjusted. For
-    details on managing this behavior, refer to the [Data Durability and Synchronous Replication](##data-durability-and-synchronous-replication)
+    details on managing this behavior, refer to the [Data Durability and Synchronous Replication](#data-durability-and-synchronous-replication)
     section.
 
 Direct configuration of the `synchronous_standby_names` option is not

--- a/docs/src/replication.md
+++ b/docs/src/replication.md
@@ -1,46 +1,46 @@
 # Replication
 
 Physical replication is one of the strengths of PostgreSQL and one of the
-reasons why some of the largest organizations in the world have chosen
-it for the management of their data in business continuity contexts.
-Primarily used to achieve high availability, physical replication also allows
-scale-out of read-only workloads and offloading of some work from the primary.
+reasons why some of the largest organizations in the world have chosen it for
+the management of their data in business continuity contexts. Primarily used to
+achieve high availability, physical replication also allows scale-out of
+read-only workloads and offloading of some work from the primary.
 
 !!! Important
     This section is about replication within the same `Cluster` resource
     managed in the same Kubernetes cluster. For information about how to
     replicate with another Postgres `Cluster` resource, even across different
-    Kubernetes clusters, please refer to the ["Replica clusters"](replica_cluster.md)
-    section.
+    Kubernetes clusters, please refer to the
+    ["Replica clusters"](replica_cluster.md) section.
 
 ## Application-level replication
 
-Having contributed throughout the years to the replication feature in PostgreSQL,
-we have decided to build high availability in CloudNativePG on top of
-the native physical replication technology, and integrate it
-directly in the Kubernetes API.
+Having contributed throughout the years to the replication feature in
+PostgreSQL, we have decided to build high availability in CloudNativePG on top
+of the native physical replication technology, and integrate it directly in the
+Kubernetes API.
 
-In Kubernetes terms, this is referred to as **application-level replication**, in
-contrast with *storage-level replication*.
+In Kubernetes terms, this is referred to as **application-level replication**,
+in contrast with *storage-level replication*.
 
 ## A very mature technology
 
 PostgreSQL has a very robust and mature native framework for replicating data
-from the primary instance to one or more replicas, built around the
-concept of transactional changes continuously stored in the WAL (Write Ahead Log).
+from the primary instance to one or more replicas, built around the concept of
+transactional changes continuously stored in the WAL (Write Ahead Log).
 
 Started as the evolution of crash recovery and point in time recovery
 technologies, physical replication was first introduced in PostgreSQL 8.2
-(2006) through WAL shipping from the primary to a warm standby in
-continuous recovery.
+(2006) through WAL shipping from the primary to a warm standby in continuous
+recovery.
 
 PostgreSQL 9.0 (2010) introduced WAL streaming and read-only replicas through
 *hot standby*. In 2011, PostgreSQL 9.1 brought synchronous replication at the
-transaction level, supporting RPO=0 clusters. Cascading replication was added
-in PostgreSQL 9.2 (2012). The foundations for logical replication were
-established in PostgreSQL 9.4 (2014), and version 10 (2017) introduced native
-support for the publisher/subscriber pattern to replicate data from an origin
-to a destination. The table below summarizes these milestones.
+transaction level, supporting RPO=0 clusters. Cascading replication was added in
+PostgreSQL 9.2 (2012). The foundations for logical replication were established
+in PostgreSQL 9.4 (2014), and version 10 (2017) introduced native support for
+the publisher/subscriber pattern to replicate data from an origin to a
+destination. The table below summarizes these milestones.
 
 | Version | Year | Feature                                                               |
 |:-------:|:----:|-----------------------------------------------------------------------|
@@ -56,9 +56,9 @@ versions.
 
 ## Streaming replication support
 
-At the moment, CloudNativePG natively and transparently manages
-physical streaming replicas within a cluster in a declarative way, based on
-the number of provided `instances` in the `spec`:
+At the moment, CloudNativePG natively and transparently manages physical
+streaming replicas within a cluster in a declarative way, based on the number of
+provided `instances` in the `spec`:
 
 ```
 replicas = instances - 1 (where  instances > 0)
@@ -69,13 +69,13 @@ called `streaming_replica` as follows:
 
 ```sql
 CREATE USER streaming_replica WITH REPLICATION;
-   -- NOSUPERUSER INHERIT NOCREATEROLE NOCREATEDB NOBYPASSRLS
+-- NOSUPERUSER INHERIT NOCREATEROLE NOCREATEDB NOBYPASSRLS
 ```
 
 Out of the box, the operator automatically sets up streaming replication within
 the cluster over an encrypted channel and enforces TLS client certificate
-authentication for the `streaming_replica` user - as highlighted by the following
-excerpt taken from `pg_hba.conf`:
+authentication for the `streaming_replica` user - as highlighted by the
+following excerpt taken from `pg_hba.conf`:
 
 ```
 # Require client certificate authentication for the streaming_replica user
@@ -101,9 +101,9 @@ the primary's storage, even after a failover or switchover.
 ### Continuous backup integration
 
 In case continuous backup is configured in the cluster, CloudNativePG
-transparently configures replicas to take advantage of `restore_command` when
-in continuous recovery. As a result, PostgreSQL can use the WAL archive
-as a fallback option whenever pulling WALs via streaming replication fails.
+transparently configures replicas to take advantage of `restore_command` when in
+continuous recovery. As a result, PostgreSQL can use the WAL archive as a
+fallback option whenever pulling WALs via streaming replication fails.
 
 ## Synchronous Replication
 
@@ -114,10 +114,11 @@ CloudNativePG supports both
     Please be aware that synchronous replication by default will halt your write
     operations if the required number of standby nodes to replicate WAL data for
     transaction commits is unavailable. In such cases, write operations for your
-    applications will hang. This behavior differs from the previous implementation
-    in CloudNativePG but aligns with the expectations of a PostgreSQL DBA for this
-    capability. See the ["Data Durability"](#data-durability) section to learn
-    how to control this behavior.
+    applications will hang. This behavior differs from the previous
+    implementation in CloudNativePG but aligns with the expectations of a
+    PostgreSQL DBA for this capability. See the
+    ["Data Durability"](#data-durability) section to learn how to control this
+    behavior.
 
 While direct configuration of the `synchronous_standby_names` option is
 prohibited, CloudNativePG allows you to customize its content and extend
@@ -133,9 +134,9 @@ defined). When defined, two options are mandatory:
 
 ### Quorum-based Synchronous Replication
 
-PostgreSQL's quorum-based synchronous replication makes transaction commits
-wait until their WAL records are replicated to at least a certain number of
-standbys. To use this method, set `method` to `any`.
+PostgreSQL's quorum-based synchronous replication makes transaction commits wait
+until their WAL records are replicated to at least a certain number of standbys.
+To use this method, set `method` to `any`.
 
 #### Migrating from the Deprecated Synchronous Replication Implementation
 
@@ -217,9 +218,9 @@ the PostgreSQL cluster. You can customize the content of
 
 !!! Warning
     You are responsible for ensuring the correct names in `standbyNamesPre` and
-    `standbyNamesPost`. CloudNativePG expects that you manage any standby with an
-    `application_name` listed here, ensuring their high availability. Incorrect
-    entries can jeopardize your PostgreSQL database uptime.
+    `standbyNamesPost`. CloudNativePG expects that you manage any standby with
+    an `application_name` listed here, ensuring their high availability.
+    Incorrect entries can jeopardize your PostgreSQL database uptime.
 
 ### Examples
 
@@ -306,36 +307,36 @@ default value is `required`. `preferred` is only available when
 `standbyNamesPre` and `standbyNamesPost` are not set.
 
 - **required**: when `dataDurability` is set to `required`, PostgreSQL ensures
-    that transactions are only considered committed when the WAL (Write-Ahead Log)
-    records are replicated to the specified number of synchronous standbys. This
-    setting prioritizes data safety over availability, meaning that if the
-    required number of synchronous standbys is not available, write operations
-    will be blocked until the condition is met. This guarantees zero data loss (
-    RPO=0) but may impact the availability of the database during network
-    partitions or standby failures.
+  that transactions are only considered committed when the WAL (Write-Ahead Log)
+  records are replicated to the specified number of synchronous standbys. This
+  setting prioritizes data safety over availability, meaning that if the
+  required number of synchronous standbys is not available, write operations
+  will be blocked until the condition is met. This guarantees zero data loss (
+  RPO=0) but may impact the availability of the database during network
+  partitions or standby failures.
 
-    The names of the synchronous standbys from the cluster are populated by in the
-    following order:
+  The names of the synchronous standbys from the cluster are populated by in the
+  following order:
 
     - healthy instances
     - unhealthy instances
     - primary
 
-    and then cut off at `maxStandbyNamesFromCluster` if the value is set. This
-    allows prioritizing healthy instances when choosing synchronous standbys and
-    guarantees that `synchronous_standby_names` is always populated.
+  and then cut off at `maxStandbyNamesFromCluster` if the value is set. This
+  allows prioritizing healthy instances when choosing synchronous standbys and
+  guarantees that `synchronous_standby_names` is always populated.
 
 - **preferred**: when `dataDurability` is set to `preferred`, the operator will
-    change the requested number of synchronous instances depending on the number
-    of available instances. This means that PostgreSQL attempts to replicate WAL
-    records to the specified number of synchronous standbys, but it won't
-    block write operations if amount of available standbys is less than the
-    requested number. This setting provides a balance between data safety and
-    availability, allowing write operations to continue even if some synchronous
-    standbys are temporarily unavailable. However, this may result in potential
-    data loss when no standbys are available.
+  change the requested number of synchronous instances depending on the number
+  of available instances. This means that PostgreSQL attempts to replicate WAL
+  records to the specified number of synchronous standbys, but it won't block
+  write operations if amount of available standbys is less than the requested
+  number. This setting provides a balance between data safety and availability,
+  allowing write operations to continue even if some synchronous standbys are
+  temporarily unavailable. However, this may result in potential data loss when
+  no standbys are available.
 
-    Only healthy standbys are included in the `synchronous_standby_names` option.
+  Only healthy standbys are included in the `synchronous_standby_names` option.
 
 #### Examples
 
@@ -373,14 +374,15 @@ spec:
     ANY 1 ("foo-2","foo-3","foo-1")
     ```
 
-    At this point no write operations will be allowed until at least one of the
-    standbys is available again.
+   At this point no write operations will be allowed until at least one of the
+   standbys is available again.
 
-4. When the standbys are available again, the `synchronous_standby_names` will be
-    back to the initial state.
+4. When the standbys are available again, the `synchronous_standby_names` will
+   be back to the initial state.
 
-Let's see a similar example with `dataDurability: preferred`. For the sake of the example,
-we will consider a cluster with 5 instances, and 2 synchronous standbys:
+Let's see a similar example with `dataDurability: preferred`. For the sake of
+the example, we will consider a cluster with 5 instances, and 2 synchronous
+standbys:
 
 ```yaml
 apiVersion: postgresql.cnpg.io/v1
@@ -409,27 +411,27 @@ spec:
     ```
 
 3. `bar-4` also becomes unavailable. It gets removed from the list. Since the
-    number of available standbys is less than the requested number, the
-    requested amount gets reduced:
+   number of available standbys is less than the requested number, the requested
+   amount gets reduced:
 
     ```
     ANY 1 ("bar-5")
     ```
 
 4. `bar-5` also becomes unavailable. `synchronous_standby_names` becomes empty,
-disabling synchronous replication completely. Write operations will continue,
-but with the risk of potential data loss in case of a primary failure.
-5. When the standbys are back, the `synchronous_standby_names` will be back to the
-initial state.
+   disabling synchronous replication completely. Write operations will continue,
+   but with the risk of potential data loss in case of a primary failure.
+5. When the standbys are back, the `synchronous_standby_names` will be back to
+   the initial state.
 
 ## Synchronous Replication (Deprecated)
 
 !!! Warning
     Prior to CloudNativePG 1.24, only the quorum-based synchronous replication
-    implementation was supported. Although this method is now deprecated, it will
-    not be removed anytime soon.
-    The new method prioritizes data durability over self-healing and offers
-    more robust features, including priority-based synchronous replication and full
+    implementation was supported. Although this method is now deprecated, it
+    will not be removed anytime soon.
+    The new method prioritizes data durability over self-healing and offers more
+    robust features, including priority-based synchronous replication and full
     control over the `synchronous_standby_names` option.
     It is recommended to gradually migrate to the new configuration method for
     synchronous replication, as explained in the previous paragraph.
@@ -500,12 +502,13 @@ Postgres pod are.
     legacy implementation of synchronous replication
     (see ["Synchronous Replication (Deprecated)"](replication.md#synchronous-replication-deprecated)).
 
-As an example use-case for this feature: in a cluster with a single sync replica,
-we would be able to ensure the sync replica will be in a different availability
-zone from the primary instance, usually identified by the `topology.kubernetes.io/zone`
+As an example use-case for this feature: in a cluster with a single sync
+replica, we would be able to ensure the sync replica will be in a different
+availability zone from the primary instance, usually identified by
+the `topology.kubernetes.io/zone`
 [label on a node](https://kubernetes.io/docs/reference/labels-annotations-taints/#topologykubernetesiozone).
-This would increase the robustness of the cluster in case of an outage in a single
-availability zone, especially in terms of recovery point objective (RPO).
+This would increase the robustness of the cluster in case of an outage in a
+single availability zone, especially in terms of recovery point objective (RPO).
 
 The idea of anti-affinity is to ensure that sync replicas that participate in
 the quorum are chosen from pods running on nodes that have different values for
@@ -520,8 +523,8 @@ the replicas are eligible for synchronous replication.
 
 The example below shows how this can be done through the
 `syncReplicaElectionConstraint` section within `.spec.postgresql`.
-`nodeLabelsAntiAffinity` allows you to specify those node labels that need to
-be evaluated to make sure that synchronous replication will be dynamically
+`nodeLabelsAntiAffinity` allows you to specify those node labels that need to be
+evaluated to make sure that synchronous replication will be dynamically
 configured by the operator between the current primary and the replicas which
 are located on nodes having a value of the availability zone label different
 from that of the node where the primary is:
@@ -546,22 +549,24 @@ as storage, CPU, or memory.
 [Replication slots](https://www.postgresql.org/docs/current/warm-standby.html#STREAMING-REPLICATION-SLOTS)
 are a native PostgreSQL feature introduced in 9.4 that provides an automated way
 to ensure that the primary does not remove WAL segments until all the attached
-streaming replication clients have received them, and that the primary
-does not remove rows which could cause a recovery conflict even when the
-standby is (temporarily) disconnected.
+streaming replication clients have received them, and that the primary does not
+remove rows which could cause a recovery conflict even when the standby is (
+temporarily) disconnected.
 
 A replication slot exists solely on the instance that created it, and PostgreSQL
-does not replicate it on the standby servers. As a result, after a failover
-or a switchover, the new primary does not contain the replication slot from
-the old primary. This can create problems for the streaming replication clients
-that were connected to the old primary and have lost their slot.
+does not replicate it on the standby servers. As a result, after a failover or a
+switchover, the new primary does not contain the replication slot from the old
+primary. This can create problems for the streaming replication clients that
+were connected to the old primary and have lost their slot.
 
 CloudNativePG provides a turn-key solution to synchronize the content of
 physical replication slots from the primary to each standby, addressing two use
 cases:
 
 - the replication slots automatically created for the High Availability of the
-  Postgres cluster (see ["Replication slots for High Availability" below](#replication-slots-for-high-availability) for details)
+  Postgres cluster (
+  see ["Replication slots for High Availability" below](#replication-slots-for-high-availability)
+  for details)
 - [user-defined replication slots](#user-defined-replication-slots) created on
   the primary
 
@@ -569,22 +574,22 @@ cases:
 
 CloudNativePG fills this gap by introducing the concept of cluster-managed
 replication slots, starting with high availability clusters. This feature
-automatically manages physical replication slots for each hot standby replica
-in the High Availability cluster, both in the primary and the standby.
+automatically manages physical replication slots for each hot standby replica in
+the High Availability cluster, both in the primary and the standby.
 
 In CloudNativePG, we use the terms:
 
 - **Primary HA slot**: a physical replication slot whose lifecycle is entirely
-  managed by the current primary of the cluster and whose purpose is to map to
-  a specific standby in streaming replication. Such a slot lives on the primary
+  managed by the current primary of the cluster and whose purpose is to map to a
+  specific standby in streaming replication. Such a slot lives on the primary
   only.
-- **Standby HA slot**: a physical replication slot for a standby whose
-  lifecycle is entirely managed by another standby in the cluster, based on the
-  content of the `pg_replication_slots` view in the primary, and updated at regular
+- **Standby HA slot**: a physical replication slot for a standby whose lifecycle
+  is entirely managed by another standby in the cluster, based on the content of
+  the `pg_replication_slots` view in the primary, and updated at regular
   intervals using `pg_replication_slot_advance()`.
 
-This feature is enabled by default and can be disabled via configuration.
-For details, please refer to the
+This feature is enabled by default and can be disabled via configuration. For
+details, please refer to the
 ["replicationSlots" section in the API reference](cloudnative-pg.v1.md#postgresql-cnpg-io-v1-ReplicationSlotsConfiguration).
 Here follows a brief description of the main options:
 
@@ -592,13 +597,13 @@ Here follows a brief description of the main options:
 : if `true`, the feature is enabled (`true` is the default)
 
 `.spec.replicationSlots.highAvailability.slotPrefix`
-: the prefix that identifies replication slots managed by the operator
-  for this feature (default: `_cnpg_`)
+: the prefix that identifies replication slots managed by the operator for this
+feature (default: `_cnpg_`)
 
 `.spec.replicationSlots.updateInterval`
 : how often the standby synchronizes the position of the local copy of the
-  replication slots with the position on the current primary, expressed in
-  seconds (default: 30)
+replication slots with the position on the current primary, expressed in
+seconds (default: 30)
 
 Although it is not recommended, if you desire a different behavior, you can
 customize the above options.
@@ -700,18 +705,18 @@ spec:
 
 ### Capping the WAL size retained for replication slots
 
-When replication slots is enabled, you might end up running out of disk
-space due to PostgreSQL trying to retain WAL files requested by a replication
-slot. This might happen due to a standby that is (temporarily?) down, or
-lagging, or simply an orphan replication slot.
+When replication slots is enabled, you might end up running out of disk space
+due to PostgreSQL trying to retain WAL files requested by a replication slot.
+This might happen due to a standby that is (temporarily?) down, or lagging, or
+simply an orphan replication slot.
 
 Starting with PostgreSQL 13, you can take advantage of the
 [`max_slot_wal_keep_size`](https://www.postgresql.org/docs/current/runtime-config-replication.html#GUC-MAX-SLOT-WAL-KEEP-SIZE)
 configuration option controlling the maximum size of WAL files that replication
-slots are allowed to retain in the `pg_wal` directory at checkpoint time.
-By default, in PostgreSQL `max_slot_wal_keep_size` is set to `-1`, meaning that
-replication slots may retain an unlimited amount of WAL files.
-As a result, our recommendation is to explicitly set `max_slot_wal_keep_size`
+slots are allowed to retain in the `pg_wal` directory at checkpoint time. By
+default, in PostgreSQL `max_slot_wal_keep_size` is set to `-1`, meaning that
+replication slots may retain an unlimited amount of WAL files. As a result, our
+recommendation is to explicitly set `max_slot_wal_keep_size`
 when replication slots support is enabled. For example:
 
 ```ini

--- a/docs/src/replication.md
+++ b/docs/src/replication.md
@@ -110,9 +110,16 @@ as a fallback option whenever pulling WALs via streaming replication fails.
 CloudNativePG supports both
 [quorum-based and priority-based synchronous replication for PostgreSQL](https://www.postgresql.org/docs/current/warm-standby.html#SYNCHRONOUS-REPLICATION).
 
+The field `dataDurability` in the `.spec.postgresql.synchronous` stanza allows
+configuring how strictly to enforce synchronous replication.
+The default value, `required`, enforces synchronous replication strictly,
+as standard in PostgreSQL. The value `preferred` allows to prioritize
+self-healing, in line with expectations in some cloud-native use cases.
+
 !!! Warning
-    Please be aware that synchronous replication will halt your write
-    operations if the required number of standby nodes to replicate WAL data for
+    Please be aware that with `dataDurability` set to `required` (the default
+    value), synchronous replication will halt your write operations if the
+    required number of standby nodes to replicate WAL data for
     transaction commits is unavailable. In such cases, write operations for your
     applications will hang. This behavior differs from the previous implementation
     in CloudNativePG but aligns with the expectations of a PostgreSQL DBA for this

--- a/docs/src/replication.md
+++ b/docs/src/replication.md
@@ -111,14 +111,13 @@ CloudNativePG supports both
 [quorum-based and priority-based synchronous replication for PostgreSQL](https://www.postgresql.org/docs/current/warm-standby.html#SYNCHRONOUS-REPLICATION).
 
 !!! Warning
-    Please be aware that synchronous replication by default will halt your write
-    operations if the required number of standby nodes to replicate WAL data for
-    transaction commits is unavailable. In such cases, write operations for your
-    applications will hang. This behavior differs from the previous
-    implementation in CloudNativePG but aligns with the expectations of a
-    PostgreSQL DBA for this capability. See the
-    ["Data Durability"](#data-durability) section to learn how to control this
-    behavior.
+    By default, synchronous replication will pause write operations if the
+    necessary number of standby nodes for WAL replication during transaction
+    commits is unavailable. This behavior ensures data durability and aligns with
+    the expectations of PostgreSQL DBAs. However, if your priority is self-healing
+    over strict data durability, you can adjust this setting.
+    Refer to the ["Data Durability"](#data-durability) section for guidance on
+    how to manage this behavior.
 
 While direct configuration of the `synchronous_standby_names` option is
 prohibited, CloudNativePG allows you to customize its content and extend
@@ -138,13 +137,13 @@ PostgreSQL's quorum-based synchronous replication makes transaction commits wait
 until their WAL records are replicated to at least a certain number of standbys.
 To use this method, set `method` to `any`.
 
-#### Migrating from the Deprecated Synchronous Replication Implementation
+#### Migrating from Deprecated Synchronous Replication Implementation
 
-This section provides instructions on migrating your existing quorum-based
-synchronous replication, defined using the deprecated form, to the new and more
-robust capability in CloudNativePG.
+This section outlines how to migrate from the deprecated quorum-based
+synchronous replication format to the newer, more robust implementation in
+CloudNativePG.
 
-Suppose you have the following manifest:
+Given the following manifest:
 
 ```yaml
 apiVersion: postgresql.cnpg.io/v1
@@ -153,7 +152,6 @@ metadata:
   name: angus
 spec:
   instances: 3
-
   minSyncReplicas: 1
   maxSyncReplicas: 1
 
@@ -161,7 +159,7 @@ spec:
     size: 1G
 ```
 
-You can convert it to the new quorum-based format as follows:
+You can update it to the new format as follows:
 
 ```yaml
 apiVersion: postgresql.cnpg.io/v1
@@ -180,6 +178,9 @@ spec:
       number: 1
       dataDurability: required
 ```
+
+To prioritize self-healing over strict data durability, set `dataDurability`
+to `preferred` instead.
 
 ### Priority-based Synchronous Replication
 

--- a/pkg/postgres/replication/explicit.go
+++ b/pkg/postgres/replication/explicit.go
@@ -46,8 +46,7 @@ func explicitSynchronousStandbyNamesDataDurabilityRequired(cluster *apiv1.Cluste
 	// Create the list of pod names
 	clusterInstancesList := getSortedInstanceNames(cluster)
 
-	// Cap the number of standby names using the configuration on the
-	// cluster
+	// Cap the number of standby names using the configuration on the cluster
 	if config.MaxStandbyNamesFromCluster != nil && len(clusterInstancesList) > *config.MaxStandbyNamesFromCluster {
 		clusterInstancesList = clusterInstancesList[:*config.MaxStandbyNamesFromCluster]
 	}
@@ -85,11 +84,10 @@ func explicitSynchronousStandbyNamesDataDurabilityRequired(cluster *apiv1.Cluste
 func explicitSynchronousStandbyNamesDataDurabilityPreferred(cluster *apiv1.Cluster) string {
 	config := cluster.Spec.PostgresConfiguration.Synchronous
 
-	// Create the list of pod names
-	instancesList := getSortedNonPrimaryInstanceNames(cluster)
+	// Create the list of healthy replicas
+	instancesList := getSortedNonPrimaryHealthyInstanceNames(cluster)
 
-	// Cap the number of standby names using the configuration on the
-	// cluster
+	// Cap the number of standby names using the configuration on the cluster
 	if config.MaxStandbyNamesFromCluster != nil && len(instancesList) > *config.MaxStandbyNamesFromCluster {
 		instancesList = instancesList[:*config.MaxStandbyNamesFromCluster]
 	}

--- a/pkg/postgres/replication/explicit.go
+++ b/pkg/postgres/replication/explicit.go
@@ -31,19 +31,36 @@ import (
 const placeholderInstanceNameSuffix = "-placeholder"
 
 func explicitSynchronousStandbyNames(cluster *apiv1.Cluster) string {
+	switch cluster.Spec.PostgresConfiguration.Synchronous.DataDurability {
+	case apiv1.DataDurabilityMethodPreferred:
+		return explicitSynchronousStandbyNamesDataDurabilityPreferred(cluster)
+
+	default:
+		return explicitSynchronousStandbyNamesDataDurabilityRequired(cluster)
+	}
+}
+
+func explicitSynchronousStandbyNamesDataDurabilityRequired(cluster *apiv1.Cluster) string {
 	config := cluster.Spec.PostgresConfiguration.Synchronous
 
 	// Create the list of pod names
 	clusterInstancesList := getSortedInstanceNames(cluster)
+
+	// Cap the number of standby names using the configuration on the
+	// cluster
 	if config.MaxStandbyNamesFromCluster != nil && len(clusterInstancesList) > *config.MaxStandbyNamesFromCluster {
 		clusterInstancesList = clusterInstancesList[:*config.MaxStandbyNamesFromCluster]
 	}
 
 	// Add prefix and suffix
-	instancesList := config.StandbyNamesPre
+	instancesList := make([]string, 0, len(clusterInstancesList)+len(config.StandbyNamesPre)+len(config.StandbyNamesPost))
+	instancesList = append(instancesList, config.StandbyNamesPre...)
 	instancesList = append(instancesList, clusterInstancesList...)
 	instancesList = append(instancesList, config.StandbyNamesPost...)
 
+	// An empty instances list would generate a PostgreSQL syntax error
+	// because configuring synchronous replication with an empty replica
+	// list is not allowed.
 	if len(instancesList) == 0 {
 		instancesList = []string{
 			cluster.Name + placeholderInstanceNameSuffix,
@@ -60,6 +77,43 @@ func explicitSynchronousStandbyNames(cluster *apiv1.Cluster) string {
 		"%s %v (%v)",
 		config.Method.ToPostgreSQLConfigurationKeyword(),
 		config.Number,
+		strings.Join(escapedReplicas, ","))
+}
+
+func explicitSynchronousStandbyNamesDataDurabilityPreferred(cluster *apiv1.Cluster) string {
+	config := cluster.Spec.PostgresConfiguration.Synchronous
+
+	// Create the list of pod names
+	instancesList := getReadyReplicasNames(cluster)
+
+	// Cap the number of standby names using the configuration on the
+	// cluster
+	if config.MaxStandbyNamesFromCluster != nil && len(instancesList) > *config.MaxStandbyNamesFromCluster {
+		instancesList = instancesList[:*config.MaxStandbyNamesFromCluster]
+	}
+
+	// Escape the pod list
+	escapedReplicas := make([]string, len(instancesList))
+	for idx, name := range instancesList {
+		escapedReplicas[idx] = escapePostgresConfLiteral(name)
+	}
+
+	// If data durability is not enforced, we cap the number of synchronous
+	// replicas to be required to the number or available replicas.
+	syncReplicaNumber := config.Number
+	if syncReplicaNumber > len(instancesList) {
+		syncReplicaNumber = len(instancesList)
+	}
+
+	// An empty instances list is not allowed in synchronous_standby_names
+	if len(instancesList) == 0 {
+		return ""
+	}
+
+	return fmt.Sprintf(
+		"%s %v (%v)",
+		config.Method.ToPostgreSQLConfigurationKeyword(),
+		syncReplicaNumber,
 		strings.Join(escapedReplicas, ","))
 }
 
@@ -112,5 +166,24 @@ func getSortedInstanceNames(cluster *apiv1.Cluster) []string {
 		result = append(result, primaryInstance)
 	}
 
+	return result
+}
+
+// getReadyReplicasNames gets a list of all the known PostgreSQL replicas that
+// are ready.
+// This is used to create the list in synchronous_standby_names when data
+// durability is not enforced.
+//
+// Important: non-ready replicas are not included and the name of the current
+// primary is not included.
+func getReadyReplicasNames(cluster *apiv1.Cluster) []string {
+	result := make([]string, 0, cluster.Spec.Instances)
+	for _, instance := range cluster.Status.InstancesStatus[apiv1.PodHealthy] {
+		if cluster.Status.CurrentPrimary != instance {
+			result = append(result, instance)
+		}
+	}
+
+	sort.Strings(result)
 	return result
 }

--- a/pkg/postgres/replication/explicit.go
+++ b/pkg/postgres/replication/explicit.go
@@ -32,7 +32,7 @@ const placeholderInstanceNameSuffix = "-placeholder"
 
 func explicitSynchronousStandbyNames(cluster *apiv1.Cluster) string {
 	switch cluster.Spec.PostgresConfiguration.Synchronous.DataDurability {
-	case apiv1.DataDurabilityMethodPreferred:
+	case apiv1.DataDurabilityLevelPreferred:
 		return explicitSynchronousStandbyNamesDataDurabilityPreferred(cluster)
 
 	default:

--- a/pkg/postgres/replication/explicit_test.go
+++ b/pkg/postgres/replication/explicit_test.go
@@ -26,112 +26,231 @@ import (
 )
 
 var _ = Describe("synchronous replica configuration with the new API", func() {
-	It("creates configuration with the ANY clause", func() {
-		cluster := createFakeCluster("example")
-		cluster.Spec.PostgresConfiguration.Synchronous = &apiv1.SynchronousReplicaConfiguration{
-			Method:                     apiv1.SynchronousReplicaConfigurationMethodAny,
-			Number:                     2,
-			MaxStandbyNamesFromCluster: nil,
-			StandbyNamesPre:            []string{},
-			StandbyNamesPost:           []string{},
-		}
-		cluster.Status = apiv1.ClusterStatus{
-			CurrentPrimary: "one",
-			InstancesStatus: map[apiv1.PodStatus][]string{
-				apiv1.PodHealthy: {"one", "two", "three"},
-			},
-		}
+	When("data durability is required", func() {
+		It("creates configuration with the ANY clause", func() {
+			cluster := createFakeCluster("example")
+			cluster.Spec.PostgresConfiguration.Synchronous = &apiv1.SynchronousReplicaConfiguration{
+				Method:                     apiv1.SynchronousReplicaConfigurationMethodAny,
+				Number:                     2,
+				MaxStandbyNamesFromCluster: nil,
+				StandbyNamesPre:            []string{},
+				StandbyNamesPost:           []string{},
+			}
+			cluster.Status = apiv1.ClusterStatus{
+				CurrentPrimary: "one",
+				InstancesStatus: map[apiv1.PodStatus][]string{
+					apiv1.PodHealthy: {"one", "two", "three"},
+				},
+			}
 
-		Expect(explicitSynchronousStandbyNames(cluster)).To(Equal("ANY 2 (\"three\",\"two\",\"one\")"))
+			Expect(explicitSynchronousStandbyNames(cluster)).To(Equal("ANY 2 (\"three\",\"two\",\"one\")"))
+		})
+
+		It("creates configuration with the FIRST clause", func() {
+			cluster := createFakeCluster("example")
+			cluster.Spec.PostgresConfiguration.Synchronous = &apiv1.SynchronousReplicaConfiguration{
+				Method:                     apiv1.SynchronousReplicaConfigurationMethodFirst,
+				Number:                     2,
+				MaxStandbyNamesFromCluster: nil,
+				StandbyNamesPre:            []string{},
+				StandbyNamesPost:           []string{},
+			}
+			cluster.Status = apiv1.ClusterStatus{
+				CurrentPrimary: "one",
+				InstancesStatus: map[apiv1.PodStatus][]string{
+					apiv1.PodHealthy: {"one", "two", "three"},
+				},
+			}
+
+			Expect(explicitSynchronousStandbyNames(cluster)).To(Equal("FIRST 2 (\"three\",\"two\",\"one\")"))
+		})
+
+		It("considers the maximum number of standby names", func() {
+			cluster := createFakeCluster("example")
+			cluster.Spec.PostgresConfiguration.Synchronous = &apiv1.SynchronousReplicaConfiguration{
+				Method:                     apiv1.SynchronousReplicaConfigurationMethodFirst,
+				Number:                     2,
+				MaxStandbyNamesFromCluster: ptr.To(1),
+				StandbyNamesPre:            []string{},
+				StandbyNamesPost:           []string{},
+			}
+			cluster.Status = apiv1.ClusterStatus{
+				CurrentPrimary: "one",
+				InstancesStatus: map[apiv1.PodStatus][]string{
+					apiv1.PodHealthy: {"one", "two", "three"},
+				},
+			}
+
+			Expect(explicitSynchronousStandbyNames(cluster)).To(Equal("FIRST 2 (\"three\")"))
+		})
+
+		It("prepends the prefix and append the suffix", func() {
+			cluster := createFakeCluster("example")
+			cluster.Spec.PostgresConfiguration.Synchronous = &apiv1.SynchronousReplicaConfiguration{
+				Method:                     apiv1.SynchronousReplicaConfigurationMethodFirst,
+				Number:                     2,
+				MaxStandbyNamesFromCluster: ptr.To(1),
+				StandbyNamesPre:            []string{"prefix", "here"},
+				StandbyNamesPost:           []string{"suffix", "there"},
+			}
+			cluster.Status = apiv1.ClusterStatus{
+				CurrentPrimary: "one",
+				InstancesStatus: map[apiv1.PodStatus][]string{
+					apiv1.PodHealthy: {"one", "two", "three"},
+				},
+			}
+
+			Expect(explicitSynchronousStandbyNames(cluster)).To(
+				Equal("FIRST 2 (\"prefix\",\"here\",\"three\",\"suffix\",\"there\")"))
+		})
+
+		It("enforce synchronous replication even if there are no healthy replicas", func() {
+			cluster := createFakeCluster("example")
+			cluster.Spec.PostgresConfiguration.Synchronous = &apiv1.SynchronousReplicaConfiguration{
+				Method:                     apiv1.SynchronousReplicaConfigurationMethodFirst,
+				Number:                     2,
+				MaxStandbyNamesFromCluster: ptr.To(1),
+			}
+			cluster.Status = apiv1.ClusterStatus{}
+
+			Expect(explicitSynchronousStandbyNames(cluster)).To(
+				Equal("FIRST 2 (\"example-placeholder\")"))
+		})
+
+		It("includes pods that do not report the status", func() {
+			cluster := createFakeCluster("example")
+			cluster.Spec.PostgresConfiguration.Synchronous = &apiv1.SynchronousReplicaConfiguration{
+				Method:                     apiv1.SynchronousReplicaConfigurationMethodFirst,
+				Number:                     2,
+				MaxStandbyNamesFromCluster: nil,
+				StandbyNamesPre:            []string{},
+				StandbyNamesPost:           []string{},
+			}
+			cluster.Status = apiv1.ClusterStatus{
+				CurrentPrimary: "one",
+				InstancesStatus: map[apiv1.PodStatus][]string{
+					apiv1.PodHealthy: {"one", "three"},
+				},
+				InstanceNames: []string{"one", "two", "three"},
+			}
+			Expect(explicitSynchronousStandbyNames(cluster)).To(Equal("FIRST 2 (\"three\",\"two\",\"one\")"))
+		})
 	})
 
-	It("creates configuration with the FIRST clause", func() {
-		cluster := createFakeCluster("example")
-		cluster.Spec.PostgresConfiguration.Synchronous = &apiv1.SynchronousReplicaConfiguration{
-			Method:                     apiv1.SynchronousReplicaConfigurationMethodFirst,
-			Number:                     2,
-			MaxStandbyNamesFromCluster: nil,
-			StandbyNamesPre:            []string{},
-			StandbyNamesPost:           []string{},
-		}
-		cluster.Status = apiv1.ClusterStatus{
-			CurrentPrimary: "one",
-			InstancesStatus: map[apiv1.PodStatus][]string{
-				apiv1.PodHealthy: {"one", "two", "three"},
-			},
-		}
+	When("Data durability is preferred", func() {
+		It("creates configuration with the ANY clause", func() {
+			cluster := createFakeCluster("example")
+			cluster.Spec.PostgresConfiguration.Synchronous = &apiv1.SynchronousReplicaConfiguration{
+				DataDurability:             apiv1.DataDurabilityMethodPreferred,
+				Method:                     apiv1.SynchronousReplicaConfigurationMethodAny,
+				Number:                     2,
+				MaxStandbyNamesFromCluster: nil,
+				StandbyNamesPre:            []string{},
+				StandbyNamesPost:           []string{},
+			}
+			cluster.Status = apiv1.ClusterStatus{
+				CurrentPrimary: "one",
+				InstancesStatus: map[apiv1.PodStatus][]string{
+					apiv1.PodHealthy: {"one", "two", "three"},
+				},
+			}
 
-		Expect(explicitSynchronousStandbyNames(cluster)).To(Equal("FIRST 2 (\"three\",\"two\",\"one\")"))
-	})
+			// Important: the name of the primary is not included in the list
+			Expect(explicitSynchronousStandbyNames(cluster)).To(Equal("ANY 2 (\"three\",\"two\")"))
+		})
 
-	It("considers the maximum number of standby names", func() {
-		cluster := createFakeCluster("example")
-		cluster.Spec.PostgresConfiguration.Synchronous = &apiv1.SynchronousReplicaConfiguration{
-			Method:                     apiv1.SynchronousReplicaConfigurationMethodFirst,
-			Number:                     2,
-			MaxStandbyNamesFromCluster: ptr.To(1),
-			StandbyNamesPre:            []string{},
-			StandbyNamesPost:           []string{},
-		}
-		cluster.Status = apiv1.ClusterStatus{
-			CurrentPrimary: "one",
-			InstancesStatus: map[apiv1.PodStatus][]string{
-				apiv1.PodHealthy: {"one", "two", "three"},
-			},
-		}
+		It("creates configuration with the FIRST clause", func() {
+			cluster := createFakeCluster("example")
+			cluster.Spec.PostgresConfiguration.Synchronous = &apiv1.SynchronousReplicaConfiguration{
+				DataDurability:             apiv1.DataDurabilityMethodPreferred,
+				Method:                     apiv1.SynchronousReplicaConfigurationMethodFirst,
+				Number:                     2,
+				MaxStandbyNamesFromCluster: nil,
+				StandbyNamesPre:            []string{},
+				StandbyNamesPost:           []string{},
+			}
+			cluster.Status = apiv1.ClusterStatus{
+				CurrentPrimary: "one",
+				InstancesStatus: map[apiv1.PodStatus][]string{
+					apiv1.PodHealthy: {"one", "two", "three"},
+				},
+			}
 
-		Expect(explicitSynchronousStandbyNames(cluster)).To(Equal("FIRST 2 (\"three\")"))
-	})
+			// Important: the name of the primary is not included in the list
+			Expect(explicitSynchronousStandbyNames(cluster)).To(Equal("FIRST 2 (\"three\",\"two\")"))
+		})
 
-	It("prepends the prefix and append the suffix", func() {
-		cluster := createFakeCluster("example")
-		cluster.Spec.PostgresConfiguration.Synchronous = &apiv1.SynchronousReplicaConfiguration{
-			Method:                     apiv1.SynchronousReplicaConfigurationMethodFirst,
-			Number:                     2,
-			MaxStandbyNamesFromCluster: ptr.To(1),
-			StandbyNamesPre:            []string{"prefix", "here"},
-			StandbyNamesPost:           []string{"suffix", "there"},
-		}
-		cluster.Status = apiv1.ClusterStatus{
-			CurrentPrimary: "one",
-			InstancesStatus: map[apiv1.PodStatus][]string{
-				apiv1.PodHealthy: {"one", "two", "three"},
-			},
-		}
+		It("considers the maximum number of standby names", func() {
+			cluster := createFakeCluster("example")
+			cluster.Spec.PostgresConfiguration.Synchronous = &apiv1.SynchronousReplicaConfiguration{
+				DataDurability:             apiv1.DataDurabilityMethodPreferred,
+				Method:                     apiv1.SynchronousReplicaConfigurationMethodFirst,
+				Number:                     2,
+				MaxStandbyNamesFromCluster: ptr.To(1),
+				StandbyNamesPre:            []string{},
+				StandbyNamesPost:           []string{},
+			}
+			cluster.Status = apiv1.ClusterStatus{
+				CurrentPrimary: "a-primary",
+				InstancesStatus: map[apiv1.PodStatus][]string{
+					apiv1.PodHealthy: {"a-primary", "two", "three"},
+				},
+			}
 
-		Expect(explicitSynchronousStandbyNames(cluster)).To(
-			Equal("FIRST 2 (\"prefix\",\"here\",\"three\",\"suffix\",\"there\")"))
-	})
+			Expect(explicitSynchronousStandbyNames(cluster)).To(Equal("FIRST 1 (\"three\")"))
+		})
 
-	It("returns an empty value when no instance is available", func() {
-		cluster := createFakeCluster("example")
-		cluster.Spec.PostgresConfiguration.Synchronous = &apiv1.SynchronousReplicaConfiguration{
-			Method:                     apiv1.SynchronousReplicaConfigurationMethodFirst,
-			Number:                     2,
-			MaxStandbyNamesFromCluster: ptr.To(1),
-		}
-		cluster.Status = apiv1.ClusterStatus{}
+		It("ignores the prefix and the suffix", func() {
+			cluster := createFakeCluster("example")
+			cluster.Spec.PostgresConfiguration.Synchronous = &apiv1.SynchronousReplicaConfiguration{
+				DataDurability:   apiv1.DataDurabilityMethodPreferred,
+				Method:           apiv1.SynchronousReplicaConfigurationMethodFirst,
+				Number:           2,
+				StandbyNamesPre:  []string{"prefix", "here"},
+				StandbyNamesPost: []string{"suffix", "there"},
+			}
+			cluster.Status = apiv1.ClusterStatus{
+				CurrentPrimary: "one",
+				InstancesStatus: map[apiv1.PodStatus][]string{
+					apiv1.PodHealthy: {"one", "two", "three"},
+				},
+			}
 
-		Expect(explicitSynchronousStandbyNames(cluster)).To(
-			Equal("FIRST 2 (\"example-placeholder\")"))
-	})
+			Expect(explicitSynchronousStandbyNames(cluster)).To(
+				Equal("FIRST 2 (\"three\",\"two\")"))
+		})
 
-	It("includes pods that do not report the status", func() {
-		cluster := createFakeCluster("example")
-		cluster.Spec.PostgresConfiguration.Synchronous = &apiv1.SynchronousReplicaConfiguration{
-			Method:                     apiv1.SynchronousReplicaConfigurationMethodFirst,
-			Number:                     2,
-			MaxStandbyNamesFromCluster: nil,
-			StandbyNamesPre:            []string{},
-			StandbyNamesPost:           []string{},
-		}
-		cluster.Status = apiv1.ClusterStatus{
-			CurrentPrimary: "one",
-			InstancesStatus: map[apiv1.PodStatus][]string{
-				apiv1.PodHealthy: {"one", "three"},
-			},
-			InstanceNames: []string{"one", "two", "three"},
-		}
-		Expect(explicitSynchronousStandbyNames(cluster)).To(Equal("FIRST 2 (\"three\",\"two\",\"one\")"))
+		It("disables synchronous replication when no instance is available", func() {
+			cluster := createFakeCluster("example")
+			cluster.Spec.PostgresConfiguration.Synchronous = &apiv1.SynchronousReplicaConfiguration{
+				DataDurability:             apiv1.DataDurabilityMethodPreferred,
+				Method:                     apiv1.SynchronousReplicaConfigurationMethodFirst,
+				Number:                     2,
+				MaxStandbyNamesFromCluster: ptr.To(1),
+			}
+			cluster.Status = apiv1.ClusterStatus{}
+
+			Expect(explicitSynchronousStandbyNames(cluster)).To(Equal(""))
+		})
+
+		It("does not include pods that do not report the status", func() {
+			cluster := createFakeCluster("example")
+			cluster.Spec.PostgresConfiguration.Synchronous = &apiv1.SynchronousReplicaConfiguration{
+				DataDurability:             apiv1.DataDurabilityMethodPreferred,
+				Method:                     apiv1.SynchronousReplicaConfigurationMethodFirst,
+				Number:                     2,
+				MaxStandbyNamesFromCluster: nil,
+				StandbyNamesPre:            []string{},
+				StandbyNamesPost:           []string{},
+			}
+			cluster.Status = apiv1.ClusterStatus{
+				CurrentPrimary: "one",
+				InstancesStatus: map[apiv1.PodStatus][]string{
+					apiv1.PodHealthy: {"one", "three"},
+				},
+				InstanceNames: []string{"one", "two", "three"},
+			}
+			Expect(explicitSynchronousStandbyNames(cluster)).To(Equal("FIRST 1 (\"three\")"))
+		})
 	})
 })

--- a/pkg/postgres/replication/explicit_test.go
+++ b/pkg/postgres/replication/explicit_test.go
@@ -141,7 +141,7 @@ var _ = Describe("synchronous replica configuration with the new API", func() {
 		It("creates configuration with the ANY clause", func() {
 			cluster := createFakeCluster("example")
 			cluster.Spec.PostgresConfiguration.Synchronous = &apiv1.SynchronousReplicaConfiguration{
-				DataDurability:             apiv1.DataDurabilityMethodPreferred,
+				DataDurability:             apiv1.DataDurabilityLevelPreferred,
 				Method:                     apiv1.SynchronousReplicaConfigurationMethodAny,
 				Number:                     2,
 				MaxStandbyNamesFromCluster: nil,
@@ -162,7 +162,7 @@ var _ = Describe("synchronous replica configuration with the new API", func() {
 		It("creates configuration with the FIRST clause", func() {
 			cluster := createFakeCluster("example")
 			cluster.Spec.PostgresConfiguration.Synchronous = &apiv1.SynchronousReplicaConfiguration{
-				DataDurability:             apiv1.DataDurabilityMethodPreferred,
+				DataDurability:             apiv1.DataDurabilityLevelPreferred,
 				Method:                     apiv1.SynchronousReplicaConfigurationMethodFirst,
 				Number:                     2,
 				MaxStandbyNamesFromCluster: nil,
@@ -183,7 +183,7 @@ var _ = Describe("synchronous replica configuration with the new API", func() {
 		It("considers the maximum number of standby names", func() {
 			cluster := createFakeCluster("example")
 			cluster.Spec.PostgresConfiguration.Synchronous = &apiv1.SynchronousReplicaConfiguration{
-				DataDurability:             apiv1.DataDurabilityMethodPreferred,
+				DataDurability:             apiv1.DataDurabilityLevelPreferred,
 				Method:                     apiv1.SynchronousReplicaConfigurationMethodFirst,
 				Number:                     2,
 				MaxStandbyNamesFromCluster: ptr.To(1),
@@ -203,7 +203,7 @@ var _ = Describe("synchronous replica configuration with the new API", func() {
 		It("ignores the prefix and the suffix", func() {
 			cluster := createFakeCluster("example")
 			cluster.Spec.PostgresConfiguration.Synchronous = &apiv1.SynchronousReplicaConfiguration{
-				DataDurability:   apiv1.DataDurabilityMethodPreferred,
+				DataDurability:   apiv1.DataDurabilityLevelPreferred,
 				Method:           apiv1.SynchronousReplicaConfigurationMethodFirst,
 				Number:           2,
 				StandbyNamesPre:  []string{"prefix", "here"},
@@ -223,7 +223,7 @@ var _ = Describe("synchronous replica configuration with the new API", func() {
 		It("disables synchronous replication when no instance is available", func() {
 			cluster := createFakeCluster("example")
 			cluster.Spec.PostgresConfiguration.Synchronous = &apiv1.SynchronousReplicaConfiguration{
-				DataDurability:             apiv1.DataDurabilityMethodPreferred,
+				DataDurability:             apiv1.DataDurabilityLevelPreferred,
 				Method:                     apiv1.SynchronousReplicaConfigurationMethodFirst,
 				Number:                     2,
 				MaxStandbyNamesFromCluster: ptr.To(1),
@@ -236,7 +236,7 @@ var _ = Describe("synchronous replica configuration with the new API", func() {
 		It("does not include pods that do not report the status", func() {
 			cluster := createFakeCluster("example")
 			cluster.Spec.PostgresConfiguration.Synchronous = &apiv1.SynchronousReplicaConfiguration{
-				DataDurability:             apiv1.DataDurabilityMethodPreferred,
+				DataDurability:             apiv1.DataDurabilityLevelPreferred,
 				Method:                     apiv1.SynchronousReplicaConfigurationMethodFirst,
 				Number:                     2,
 				MaxStandbyNamesFromCluster: nil,

--- a/pkg/postgres/replication/legacy.go
+++ b/pkg/postgres/replication/legacy.go
@@ -95,7 +95,7 @@ func getSyncReplicasData(cluster *apiv1.Cluster) (syncReplicas int, electableSyn
 
 // getElectableSyncReplicas computes the names of the instances that can be elected to sync replicas
 func getElectableSyncReplicas(cluster *apiv1.Cluster) []string {
-	nonPrimaryInstances := getSortedNonPrimaryInstanceNames(cluster)
+	nonPrimaryInstances := getSortedNonPrimaryHealthyInstanceNames(cluster)
 
 	topology := cluster.Status.Topology
 	// We need to include every replica inside the list of possible synchronous standbys if we have no constraints
@@ -145,7 +145,7 @@ func getElectableSyncReplicas(cluster *apiv1.Cluster) []string {
 	return electableReplicas
 }
 
-func getSortedNonPrimaryInstanceNames(cluster *apiv1.Cluster) []string {
+func getSortedNonPrimaryHealthyInstanceNames(cluster *apiv1.Cluster) []string {
 	var nonPrimaryInstances []string
 	for _, instance := range cluster.Status.InstancesStatus[apiv1.PodHealthy] {
 		if cluster.Status.CurrentPrimary != instance {

--- a/tests/e2e/fixtures/sync_replicas/preferred.yaml.template
+++ b/tests/e2e/fixtures/sync_replicas/preferred.yaml.template
@@ -1,0 +1,24 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: cluster-sync-replica
+spec:
+  instances: 3
+
+  postgresql:
+    synchronous:
+      method: any
+      number: 2
+      dataDurability: preferred
+    parameters:
+      log_checkpoints: "on"
+      log_lock_waits: "on"
+      log_min_duration_statement: '1000'
+      log_statement: 'ddl'
+      log_temp_files: '1024'
+      log_autovacuum_min_duration: '1s'
+      log_replication_commands: 'on'
+
+  storage:
+    storageClass: ${E2E_DEFAULT_STORAGE_CLASS}
+    size: 1G

--- a/tests/e2e/syncreplicas_test.go
+++ b/tests/e2e/syncreplicas_test.go
@@ -233,7 +233,7 @@ var _ = Describe("Synchronous Replicas", Label(tests.LabelReplication), func() {
 		})
 
 		Context("data durability is preferred", func() {
-			FIt("will decrease the number of sync replicas to the number of available replicas", func() {
+			It("will decrease the number of sync replicas to the number of available replicas", func() {
 				const (
 					namespacePrefix = "sync-replicas-preferred"
 					sampleFile      = fixturesDir + "/sync_replicas/preferred.yaml.template"

--- a/tests/e2e/syncreplicas_test.go
+++ b/tests/e2e/syncreplicas_test.go
@@ -20,10 +20,12 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	"k8s.io/utils/ptr"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/specs"
 	"github.com/cloudnative-pg/cloudnative-pg/tests"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils"
 
@@ -110,7 +112,8 @@ var _ = Describe("Synchronous Replicas", Label(tests.LabelReplication), func() {
 				}, RetryTimeout, 5).Should(BeNil())
 
 				// Scale the cluster down to 2 pods
-				_, _, err := utils.Run(fmt.Sprintf("kubectl scale --replicas=2 -n %v cluster/%v", namespace, clusterName))
+				_, _, err := utils.Run(fmt.Sprintf("kubectl scale --replicas=2 -n %v cluster/%v", namespace,
+					clusterName))
 				Expect(err).ToNot(HaveOccurred())
 				timeout := 120
 				// Wait for pod 3 to be completely terminated
@@ -226,6 +229,56 @@ var _ = Describe("Synchronous Replicas", Label(tests.LabelReplication), func() {
 				}, RetryTimeout, 5).Should(BeNil())
 				compareSynchronousStandbyNames(namespace, clusterName, "FIRST 1 (\"preSyncReplica\"")
 				compareSynchronousStandbyNames(namespace, clusterName, "\"postSyncReplica\")")
+			})
+		})
+
+		Context("data durability is preferred", func() {
+			FIt("will decrease the number of sync replicas to the number of available replicas", func() {
+				const (
+					namespacePrefix = "sync-replicas-preferred"
+					sampleFile      = fixturesDir + "/sync_replicas/preferred.yaml.template"
+				)
+				clusterName, err := env.GetResourceNameFromYAML(sampleFile)
+				Expect(err).ToNot(HaveOccurred())
+
+				namespace, err = env.CreateUniqueTestNamespace(namespacePrefix)
+				Expect(err).ToNot(HaveOccurred())
+				AssertCreateCluster(namespace, clusterName, sampleFile, env)
+
+				By("verifying we have 2 quorum-based replicas", func() {
+					getSyncReplicationCount(namespace, clusterName, "quorum", 2)
+					compareSynchronousStandbyNames(namespace, clusterName, "ANY 2")
+				})
+
+				By("fencing a replica and verifying we have only 1 quorum-based replica", func() {
+					Expect(utils.FencingOn(env, fmt.Sprintf("%v-3", clusterName),
+						namespace, clusterName, utils.UsingAnnotation)).Should(Succeed())
+					getSyncReplicationCount(namespace, clusterName, "quorum", 1)
+					compareSynchronousStandbyNames(namespace, clusterName, "ANY 1")
+				})
+				By("fencing the second replica and verifying we unset synchronous_standby_names", func() {
+					Expect(utils.FencingOn(env, fmt.Sprintf("%v-2", clusterName),
+						namespace, clusterName, utils.UsingAnnotation)).Should(Succeed())
+					Eventually(func() string {
+						commandTimeout := time.Second * 10
+						primary, err := env.GetClusterPrimary(namespace, clusterName)
+						Expect(err).ToNot(HaveOccurred())
+
+						stdout, _, err := env.ExecCommand(env.Ctx, *primary, specs.PostgresContainerName,
+							&commandTimeout,
+							"psql", "-U", "postgres", "-tAc", "show synchronous_standby_names")
+						Expect(err).ToNot(HaveOccurred())
+						return strings.Trim(stdout, "\n")
+					}, 160).Should(BeEmpty())
+				})
+				By("unfenicing the replicas and verifying we have 2 quorum-based replicas", func() {
+					Expect(utils.FencingOff(env, fmt.Sprintf("%v-3", clusterName),
+						namespace, clusterName, utils.UsingAnnotation)).Should(Succeed())
+					Expect(utils.FencingOff(env, fmt.Sprintf("%v-2", clusterName),
+						namespace, clusterName, utils.UsingAnnotation)).Should(Succeed())
+					getSyncReplicationCount(namespace, clusterName, "quorum", 2)
+					compareSynchronousStandbyNames(namespace, clusterName, "ANY 2")
+				})
 			})
 		})
 	})


### PR DESCRIPTION
This patch introduces an option to relax strict data durability requirements within the new synchronous replication interface. By setting `.spec.postgresql.synchronous.dataDurability` to `preferred`, the operator limits the required number of synchronous standby replicas to match the number of available instances, prioritizing self-healing over strict data durability.

This configuration requires both `standbyNamesPre` and `standbyNamesPost` to be empty.

Closes: #5793 