### PR TITLE
ci: collect apiserver audit logs

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -716,6 +716,8 @@ jobs:
           cat config/manager/env_override.yaml
       -
         name: Run Kind End-to-End tests
+        env:
+          ENABLE_APISERVER_AUDIT: true
         run:
           make e2e-test-kind
       -

--- a/hack/e2e/audit-policy.yaml
+++ b/hack/e2e/audit-policy.yaml
@@ -1,0 +1,6 @@
+apiVersion: audit.k8s.io/v1
+kind: Policy
+rules:
+- level: RequestResponse
+  resources:
+  - group: "postgresql.cnpg.io"

--- a/hack/e2e/run-e2e-kind.sh
+++ b/hack/e2e/run-e2e-kind.sh
@@ -34,6 +34,7 @@ export K8S_VERSION=${K8S_VERSION:-$KIND_NODE_DEFAULT_VERSION}
 export CLUSTER_ENGINE=kind
 export CLUSTER_NAME=pg-operator-e2e-${K8S_VERSION//./-}
 export LOG_DIR=${LOG_DIR:-$ROOT_DIR/_logs/}
+export ENABLE_APISERVER_AUDIT=${ENABLE_APISERVER_AUDIT:-false}
 
 export POSTGRES_IMG=${POSTGRES_IMG:-$(grep 'DefaultImageName.*=' "${ROOT_DIR}/pkg/versions/versions.go" | cut -f 2 -d \")}
 export E2E_PRE_ROLLING_UPDATE_IMG=${E2E_PRE_ROLLING_UPDATE_IMG:-${POSTGRES_IMG%.*}}


### PR DESCRIPTION
Add the ENABLE_APISERVER_AUDIT env variable to the kind e2e scripts. If set to true, kind will configure auditing for postgresql.cnpg.io resources and mount a local directory to write the audit logs on.

Closes #5873
