### PR TITLE
chore(e2e): Separate forward connection from psql connection

### DIFF
--- a/tests/e2e/connection_test.go
+++ b/tests/e2e/connection_test.go
@@ -53,20 +53,18 @@ var _ = Describe("Connection via services", Label(tests.LabelServiceConnectivity
 		superuserPassword string,
 		env *utils.TestingEnvironment,
 	) {
-		primaryPod, err := env.GetClusterPrimary(namespace, clusterName)
-		Expect(err).ToNot(HaveOccurred())
 		// We test -rw, -ro and -r services with the app user and the superuser
-		rwService := fmt.Sprintf("%v-rw.%v.svc", clusterName, namespace)
-		rService := fmt.Sprintf("%v-r.%v.svc", clusterName, namespace)
-		roService := fmt.Sprintf("%v-ro.%v.svc", clusterName, namespace)
+		rwService := fmt.Sprintf("%v-rw", clusterName)
+		rService := fmt.Sprintf("%v-r", clusterName)
+		roService := fmt.Sprintf("%v-ro", clusterName)
 		services := []string{rwService, roService, rService}
 		for _, service := range services {
-			AssertConnection(service, "postgres", appDBName, superuserPassword, primaryPod, 10, env)
-			AssertConnection(service, appDBUser, appDBName, appPassword, primaryPod, 10, env)
+			AssertConnection(namespace, service, appDBName, utils.PostgresDBName, superuserPassword, env)
+			AssertConnection(namespace, service, appDBName, appDBUser, appPassword, env)
 		}
 
-		AssertWritesToReplicaFails(primaryPod, roService, appDBName, appDBUser, appPassword)
-		AssertWritesToPrimarySucceeds(primaryPod, rwService, appDBName, appDBUser, appPassword)
+		AssertWritesToReplicaFails(namespace, roService, appDBName, appDBUser, appPassword)
+		AssertWritesToPrimarySucceeds(namespace, rwService, appDBName, appDBUser, appPassword)
 	}
 
 	Context("Auto-generated passwords", func() {

--- a/tests/e2e/managed_roles_test.go
+++ b/tests/e2e/managed_roles_test.go
@@ -171,14 +171,10 @@ var _ = Describe("Managed roles tests", Label(tests.LabelSmoke, tests.LabelBasic
 			})
 
 			By("Verifying connectivity of new managed role", func() {
-				primaryPod, err := env.GetClusterPrimary(namespace, clusterName)
-				Expect(err).ToNot(HaveOccurred())
-
-				rwService := fmt.Sprintf("%v-rw.%v.svc", clusterName, namespace)
+				rwService := utils.GetReadWriteServiceName(clusterName)
 				// assert connectable use username and password defined in secrets
-				AssertConnection(rwService, username, "postgres", password, primaryPod, 30, env)
-
-				AssertConnection(rwService, userWithHashedPassword, "postgres", userWithHashedPassword, primaryPod, 30, env)
+				AssertConnection(namespace, rwService, utils.PostgresDBName, username, password, env)
+				AssertConnection(namespace, rwService, utils.PostgresDBName, userWithHashedPassword, userWithHashedPassword, env)
 			})
 
 			By("ensuring the app role has been granted createdb in the managed stanza", func() {
@@ -213,13 +209,10 @@ var _ = Describe("Managed roles tests", Label(tests.LabelSmoke, tests.LabelBasic
 				)
 				Expect(err).NotTo(HaveOccurred())
 
-				primaryPod, err := env.GetClusterPrimary(namespace, clusterName)
-				Expect(err).ToNot(HaveOccurred())
-
 				pass := string(appUserSecret.Data["password"])
-				rwService := fmt.Sprintf("%v-rw.%v.svc", clusterName, namespace)
+				rwService := utils.GetReadWriteServiceName(clusterName)
 				// assert connectable use username and password defined in secrets
-				AssertConnection(rwService, appUsername, "postgres", pass, primaryPod, 30, env)
+				AssertConnection(namespace, rwService, utils.PostgresDBName, appUsername, pass, env)
 			})
 
 			By("Verify show unrealizable role configurations in the status", func() {
@@ -302,9 +295,9 @@ var _ = Describe("Managed roles tests", Label(tests.LabelSmoke, tests.LabelBasic
 			})
 
 			By("the connectivity should be success again", func() {
-				rwService := fmt.Sprintf("%v-rw.%v.svc", clusterName, namespace)
+				rwService := utils.GetReadWriteServiceName(clusterName)
 				// assert connectable use username and password defined in secrets
-				AssertConnection(rwService, username, "postgres", password, primaryPod, 30, env)
+				AssertConnection(namespace, rwService, utils.PostgresDBName, username, password, env)
 			})
 		})
 
@@ -539,15 +532,15 @@ var _ = Describe("Managed roles tests", Label(tests.LabelSmoke, tests.LabelBasic
 			})
 
 			By("Verify connectivity using changed password in secret", func() {
-				primaryPod, err = env.GetClusterPrimary(namespace, clusterName)
-				Expect(err).ToNot(HaveOccurred())
-
-				rwService := fmt.Sprintf("%v-rw.%v.svc", clusterName, namespace)
+				rwService := utils.GetReadWriteServiceName(clusterName)
 				// assert connectable use username and password defined in secrets
-				AssertConnection(rwService, username, "postgres", newPassword, primaryPod, 30, env)
+				AssertConnection(namespace, rwService, utils.PostgresDBName, username, newPassword, env)
 			})
 
 			By("Update password in database", func() {
+				primaryPod, err = env.GetClusterPrimary(namespace, clusterName)
+				Expect(err).ToNot(HaveOccurred())
+
 				query := fmt.Sprintf("ALTER ROLE %s WITH PASSWORD %s",
 					username, pq.QuoteLiteral(newPassword))
 
@@ -562,8 +555,8 @@ var _ = Describe("Managed roles tests", Label(tests.LabelSmoke, tests.LabelBasic
 			})
 
 			By("Verify password in secrets could still valid", func() {
-				rwService := fmt.Sprintf("%v-rw.%v.svc", clusterName, namespace)
-				AssertConnection(rwService, username, "postgres", newPassword, primaryPod, 60, env)
+				rwService := utils.GetReadWriteServiceName(clusterName)
+				AssertConnection(namespace, rwService, utils.PostgresDBName, username, newPassword, env)
 			})
 		})
 

--- a/tests/e2e/pg_basebackup_test.go
+++ b/tests/e2e/pg_basebackup_test.go
@@ -71,12 +71,9 @@ var _ = Describe("Bootstrap with pg_basebackup", Label(tests.LabelRecovery), fun
 
 			secretName := dstClusterName + apiv1.ApplicationUserSecretSuffix
 
-			primaryPod, err := env.GetClusterPrimary(namespace, dstClusterName)
-			Expect(err).ToNot(HaveOccurred())
-
 			By("checking the dst cluster with auto generated app password connectable", func() {
 				AssertApplicationDatabaseConnection(namespace, dstClusterName,
-					appUser, utils.AppDBName, "", secretName, primaryPod)
+					appUser, utils.AppDBName, "", secretName)
 			})
 
 			By("update user application password for dst cluster and verify connectivity", func() {
@@ -88,8 +85,7 @@ var _ = Describe("Bootstrap with pg_basebackup", Label(tests.LabelRecovery), fun
 					appUser,
 					utils.AppDBName,
 					newPassword,
-					secretName,
-					primaryPod)
+					secretName)
 			})
 
 			By("checking data have been copied correctly", func() {

--- a/tests/utils/forwardconnection/doc.go
+++ b/tests/utils/forwardconnection/doc.go
@@ -1,0 +1,20 @@
+/*
+Copyright The CloudNativePG Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package forwardconnection provides an easy interface to create
+// a port forward from the local test to a services or pod
+// inside the testing k8s cluster
+package forwardconnection

--- a/tests/utils/forwardconnection/doc.go
+++ b/tests/utils/forwardconnection/doc.go
@@ -15,6 +15,6 @@ limitations under the License.
 */
 
 // Package forwardconnection provides an easy interface to create
-// a port forward from the local test to a services or pod
+// a port forward from the local test to a service or pod
 // inside the testing k8s cluster
 package forwardconnection

--- a/tests/utils/forwardconnection/forwardconnection.go
+++ b/tests/utils/forwardconnection/forwardconnection.go
@@ -128,7 +128,7 @@ func newForward(
 func (fc *ForwardConnection) StartAndWait() error {
 	var err error
 	go func() {
-		ginkgo.GinkgoWriter.Printf("Starting port-forward\n")
+		ginkgo.GinkgoWriter.Println("Starting port-forward")
 		err = fc.Forwarder.ForwardPorts()
 		if err != nil {
 			ginkgo.GinkgoWriter.Printf("port-forward failed with error %s\n", err.Error())
@@ -137,10 +137,10 @@ func (fc *ForwardConnection) StartAndWait() error {
 	}()
 	select {
 	case <-fc.readyChannel:
-		ginkgo.GinkgoWriter.Printf("port-forward ready\n")
+		ginkgo.GinkgoWriter.Println("port-forward ready")
 		return nil
 	case <-fc.stopChannel:
-		ginkgo.GinkgoWriter.Printf("port-forward closed\n")
+		ginkgo.GinkgoWriter.Println("port-forward closed")
 		return err
 	}
 }

--- a/tests/utils/forwardconnection/forwardconnection.go
+++ b/tests/utils/forwardconnection/forwardconnection.go
@@ -160,7 +160,7 @@ func getPodAndPortsFromService(
 	kubeInterface kubernetes.Interface,
 	namespace, service string,
 ) (string, []string, error) {
-	serviceObj, err := getServiceObject(kubeInterface, namespace, service)
+	serviceObj, err := getServiceObject(ctx, kubeInterface, namespace, service)
 	if err != nil {
 		return "", nil, err
 	}
@@ -179,10 +179,11 @@ func getPodAndPortsFromService(
 }
 
 func getServiceObject(
+	ctx context.Context,
 	kubeInterface kubernetes.Interface,
 	namespace, service string,
 ) (*corev1.Service, error) {
-	return kubeInterface.CoreV1().Services(namespace).Get(context.Background(), service, metav1.GetOptions{})
+	return kubeInterface.CoreV1().Services(namespace).Get(ctx, service, metav1.GetOptions{})
 }
 
 func getPodFromService(

--- a/tests/utils/forwardconnection/forwardconnection.go
+++ b/tests/utils/forwardconnection/forwardconnection.go
@@ -49,7 +49,8 @@ func NewDialerFromService(
 	ctx context.Context,
 	kubeInterface kubernetes.Interface,
 	config *rest.Config,
-	namespace, service string,
+	namespace,
+	service string,
 ) (dialer httpstream.Dialer, portMaps []string, err error) {
 	pod, portMap, err := getPodAndPortsFromService(ctx, kubeInterface, namespace, service)
 	if err != nil {
@@ -64,7 +65,7 @@ func NewDialerFromService(
 	return dial, portMap, nil
 }
 
-// NewForwardConnection returns a PortForwarder against the  pod specified
+// NewForwardConnection returns a PortForwarder against the pod specified
 func NewForwardConnection(
 	dialer httpstream.Dialer,
 	portMaps []string,
@@ -115,7 +116,7 @@ func NewDialer(
 	return dialer, nil
 }
 
-// StartAndWait beings the port forward and wait for it to be ready
+// StartAndWait begins the port-forwarding and waits until it's ready
 func (fc *ForwardConnection) StartAndWait() error {
 	var err error
 	go func() {
@@ -136,7 +137,7 @@ func (fc *ForwardConnection) StartAndWait() error {
 	}
 }
 
-// GetLocalPort will return the local port were the forward has started
+// GetLocalPort will return the local port where the forward has started
 func (fc *ForwardConnection) GetLocalPort() (string, error) {
 	ports, err := fc.Forwarder.GetPorts()
 	if err != nil {
@@ -145,8 +146,8 @@ func (fc *ForwardConnection) GetLocalPort() (string, error) {
 	return strconv.Itoa(int(ports[0].Local)), nil
 }
 
-// getPortMap takes the first port in the list of ports and return as a map
-// with a 0 as the local port for auto-assignment of the local port
+// getPortMap takes the first port between the list of ports exposed by the given service, and
+// returns a map with 0 as the local port for auto-assignment
 func getPortMap(serviceObj *corev1.Service) ([]string, error) {
 	if len(serviceObj.Spec.Ports) == 0 {
 		return []string{}, fmt.Errorf("service %s has no ports", serviceObj.Name)
@@ -158,7 +159,8 @@ func getPortMap(serviceObj *corev1.Service) ([]string, error) {
 func getPodAndPortsFromService(
 	ctx context.Context,
 	kubeInterface kubernetes.Interface,
-	namespace, service string,
+	namespace,
+	service string,
 ) (string, []string, error) {
 	serviceObj, err := getServiceObject(ctx, kubeInterface, namespace, service)
 	if err != nil {
@@ -181,7 +183,8 @@ func getPodAndPortsFromService(
 func getServiceObject(
 	ctx context.Context,
 	kubeInterface kubernetes.Interface,
-	namespace, service string,
+	namespace,
+	service string,
 ) (*corev1.Service, error) {
 	return kubeInterface.CoreV1().Services(namespace).Get(ctx, service, metav1.GetOptions{})
 }

--- a/tests/utils/forwardconnection/forwardconnection.go
+++ b/tests/utils/forwardconnection/forwardconnection.go
@@ -196,9 +196,13 @@ func getPodFromService(
 ) (*corev1.Pod, error) {
 	namespace := serviceObj.Namespace
 
-	labelSelector := metav1.LabelSelector{
+	labelSelector, err := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{
 		MatchLabels: serviceObj.Spec.Selector,
+	})
+	if err != nil {
+		return nil, err
 	}
+
 	podList, err := kubeInterface.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
 		LabelSelector: labelSelector.String(),
 	})

--- a/tests/utils/forwardconnection/forwardconnection.go
+++ b/tests/utils/forwardconnection/forwardconnection.go
@@ -1,0 +1,219 @@
+/*
+Copyright The CloudNativePG Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package forwardconnection
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+
+	"github.com/onsi/ginkgo/v2"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/portforward"
+	"k8s.io/client-go/transport/spdy"
+)
+
+// ForwardConnection holds the necessary information to manage a port-forward
+// against a service of pod inside Kubernetes
+type ForwardConnection struct {
+	Forwarder    *portforward.PortForwarder
+	stopChannel  chan struct{}
+	readyChannel chan struct{}
+}
+
+// NewServiceForward returns a PortForwarder against the service specified
+func NewServiceForward(
+	ctx context.Context,
+	kubeInterface kubernetes.Interface,
+	config *rest.Config,
+	namespace, service string,
+	outWriter, errWriter io.Writer,
+) (*ForwardConnection, error) {
+	return newForward(ctx, kubeInterface, config, namespace, service, "", "", outWriter, errWriter)
+}
+
+// NewPodForward returns a PortForwarder against the pod specified
+func NewPodForward(
+	ctx context.Context,
+	kubeInterface kubernetes.Interface,
+	config *rest.Config,
+	namespace, pod, podPort string,
+	outWriter, errWriter io.Writer,
+) (*ForwardConnection, error) {
+	return newForward(ctx, kubeInterface, config, namespace, "", pod, podPort, outWriter, errWriter)
+}
+
+// newForward returns a PortForwarder against the service or pod specified
+// in the giving namespace, service takes precedence over pod
+func newForward(
+	ctx context.Context,
+	kubeInterface kubernetes.Interface,
+	config *rest.Config,
+	namespace, service, pod, podPort string,
+	outWriter, errWriter io.Writer,
+) (*ForwardConnection, error) {
+	var err error
+	var portMaps []string
+
+	if service != "" {
+		pod, portMaps, err = getPodAndPortsFromService(ctx, kubeInterface, namespace, service)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Since pod is not empty we assume that we're passing the podPort, if that's not
+	// the case we should error out
+	if pod != "" {
+		if podPort == "" {
+			return nil, fmt.Errorf("podPort is required when pod is specified")
+		}
+		portMaps = []string{fmt.Sprintf("0:%s", podPort)}
+	}
+
+	req := kubeInterface.CoreV1().
+		RESTClient().
+		Post().
+		Resource("pods").
+		Namespace(namespace).
+		Name(pod).
+		SubResource("portforward")
+
+	transport, upgrader, err := spdy.RoundTripperFor(config)
+	if err != nil {
+		return nil, err
+	}
+	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: transport}, "POST", req.URL())
+
+	fc := &ForwardConnection{
+		stopChannel:  make(chan struct{}),
+		readyChannel: make(chan struct{}, 1),
+	}
+
+	fc.Forwarder, err = portforward.New(
+		dialer,
+		portMaps,
+		fc.stopChannel,
+		fc.readyChannel,
+		outWriter,
+		errWriter,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return fc, nil
+}
+
+// StartAndWait beings the port forward and wait for it to be ready
+func (fc *ForwardConnection) StartAndWait() error {
+	var err error
+	go func() {
+		ginkgo.GinkgoWriter.Printf("Starting port-forward\n")
+		err = fc.Forwarder.ForwardPorts()
+		if err != nil {
+			ginkgo.GinkgoWriter.Printf("port-forward failed with error %s\n", err.Error())
+			return
+		}
+	}()
+	select {
+	case <-fc.readyChannel:
+		ginkgo.GinkgoWriter.Printf("port-forward ready\n")
+		return nil
+	case <-fc.stopChannel:
+		ginkgo.GinkgoWriter.Printf("port-forward closed\n")
+		return err
+	}
+}
+
+// GetLocalPort will return the local port were the forward has started
+func (fc *ForwardConnection) GetLocalPort() (string, error) {
+	ports, err := fc.Forwarder.GetPorts()
+	if err != nil {
+		return "", err
+	}
+	return strconv.Itoa(int(ports[0].Local)), nil
+}
+
+// getPortMap takes the first port in the list of ports and return as a map
+// with a 0 as the local port for auto-assignment of the local port
+func getPortMap(serviceObj *corev1.Service) ([]string, error) {
+	if len(serviceObj.Spec.Ports) == 0 {
+		return []string{}, fmt.Errorf("service %s has no ports", serviceObj.Name)
+	}
+	port := serviceObj.Spec.Ports[0].Port
+	return []string{fmt.Sprintf("0:%d", port)}, nil
+}
+
+func getPodAndPortsFromService(
+	ctx context.Context,
+	kubeInterface kubernetes.Interface,
+	namespace, service string,
+) (string, []string, error) {
+	serviceObj, err := getServiceObject(kubeInterface, namespace, service)
+	if err != nil {
+		return "", nil, err
+	}
+
+	podObj, err := getPodFromService(ctx, kubeInterface, serviceObj)
+	if err != nil {
+		return "", nil, err
+	}
+
+	portMaps, err := getPortMap(serviceObj)
+	if err != nil {
+		return "", nil, err
+	}
+
+	return podObj.Name, portMaps, nil
+}
+
+func getServiceObject(
+	kubeInterface kubernetes.Interface,
+	namespace, service string,
+) (*corev1.Service, error) {
+	return kubeInterface.CoreV1().Services(namespace).Get(context.Background(), service, metav1.GetOptions{})
+}
+
+func getPodFromService(
+	ctx context.Context,
+	kubeInterface kubernetes.Interface,
+	serviceObj *corev1.Service,
+) (*corev1.Pod, error) {
+	namespace := serviceObj.Namespace
+
+	labelSelector := metav1.LabelSelector{
+		MatchLabels: serviceObj.Spec.Selector,
+	}
+	podList, err := kubeInterface.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: labelSelector.String(),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if len(podList.Items) == 0 {
+		return nil, fmt.Errorf("no pods found for service %s", serviceObj.Name)
+	}
+
+	return &podList.Items[0], nil
+}

--- a/tests/utils/psql_connection.go
+++ b/tests/utils/psql_connection.go
@@ -30,7 +30,7 @@ import (
 
 // PSQLForwardConnection manage the creation of a port forward to connect by psql client locally
 type PSQLForwardConnection struct {
-	pooler      *pool.ConnectionPool
+	pooler      pool.Pooler
 	portForward *portforward.PortForwarder
 }
 
@@ -40,7 +40,7 @@ func (psqlc *PSQLForwardConnection) Close() {
 }
 
 // GetPooler returns the connection Pooler
-func (psqlc *PSQLForwardConnection) GetPooler() *pool.ConnectionPool {
+func (psqlc *PSQLForwardConnection) GetPooler() pool.Pooler {
 	return psqlc.pooler
 }
 

--- a/tests/utils/psql_connection.go
+++ b/tests/utils/psql_connection.go
@@ -95,6 +95,7 @@ func ForwardPSQLConnectionWithCreds(
 	if err != nil {
 		return nil, nil, err
 	}
+
 	forwarder, err := forwardconnection.NewForwardConnection(
 		dialer,
 		[]string{forwardconnection.PostgresPortMap},

--- a/tests/utils/psql_connection.go
+++ b/tests/utils/psql_connection.go
@@ -83,7 +83,7 @@ func startForwardConnection(
 
 	connParameters := createConnectionParameters(userApp, passApp, localPort)
 
-	pooler := pool.NewPostgresqlConnectionPool(configfile.CreateConnectionString(connParameters))
+	pooler := pool.NewPgbouncerConnectionPool(configfile.CreateConnectionString(connParameters))
 
 	conn, err := pooler.Connection(dbname)
 	if err != nil {

--- a/tests/utils/psql_connection.go
+++ b/tests/utils/psql_connection.go
@@ -28,13 +28,13 @@ import (
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/forwardconnection"
 )
 
-// PSQLForwardConnection manage the creation of a port forward to connect by psql client locally
+// PSQLForwardConnection manages the creation of a port-forwarding to open a new database connection
 type PSQLForwardConnection struct {
 	pooler      pool.Pooler
 	portForward *portforward.PortForwarder
 }
 
-// Close will stop the forward and exit
+// Close will stop the port-forwarding and exit
 func (psqlc *PSQLForwardConnection) Close() {
 	psqlc.portForward.Close()
 }
@@ -44,8 +44,7 @@ func (psqlc *PSQLForwardConnection) GetPooler() pool.Pooler {
 	return psqlc.pooler
 }
 
-// createConnectionParameters return the parameters require to create a connection
-// to the current forwarded port
+// createConnectionParameters returns a map of parameters required to perform a connection
 func createConnectionParameters(user, password, localPort string) map[string]string {
 	return map[string]string{
 		"host":     "localhost",

--- a/tests/utils/psql_connection.go
+++ b/tests/utils/psql_connection.go
@@ -86,12 +86,20 @@ func ForwardPSQLConnectionWithCreds(
 		return nil, nil, err
 	}
 
-	forwarder, err := forwardconnection.NewPodForward(
-		env.Ctx,
+	dialer, err := forwardconnection.NewDialer(
 		env.Interface,
 		env.RestClientConfig,
-		namespace, cluster.Status.CurrentPrimary, "5432",
-		io.Discard, io.Discard,
+		namespace,
+		cluster.Status.CurrentPrimary,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+	forwarder, err := forwardconnection.NewForwardConnection(
+		dialer,
+		[]string{forwardconnection.PostgresPortMap},
+		io.Discard,
+		io.Discard,
 	)
 	if err != nil {
 		return nil, nil, err

--- a/tests/utils/service.go
+++ b/tests/utils/service.go
@@ -45,6 +45,20 @@ func GetReadWriteServiceName(clusterName string) string {
 	return fmt.Sprintf("%v%v", clusterName, apiv1.ServiceReadWriteSuffix)
 }
 
+// GetService gets a service given name and namespace
+func GetService(namespace, name string, env *TestingEnvironment) (*corev1.Service, error) {
+	namespacedName := types.NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	}
+	service := &corev1.Service{}
+	err := GetObject(env, namespacedName, service)
+	if err != nil {
+		return nil, err
+	}
+	return service, nil
+}
+
 // GetRwServiceObject return read write service object
 func GetRwServiceObject(namespace, clusterName string, env *TestingEnvironment) (*corev1.Service, error) {
 	svcName := GetReadWriteServiceName(clusterName)


### PR DESCRIPTION
Refactors the code to decouple the forward connection from the psql connection.
Prepares the forward connection for be reuse in other packages, such as MinIO.

Closes #5880 