### PR TITLE
test: replace temp directory handling with GinkgoT().TempDir()

### DIFF
--- a/pkg/executablehash/executablehash_test.go
+++ b/pkg/executablehash/executablehash_test.go
@@ -34,14 +34,8 @@ var _ = Describe("Executable hash detection", func() {
 	It("retrieves a hash from a given filename", func() {
 		const expectedHash = "d6672ee3a93d0d6e3c30bdef89f310799c2f3ab781098a9792040d5541ce3ed3"
 		const fileName = "test-hash"
-		var tempDir string
 
-		DeferCleanup(func() {
-			Expect(os.RemoveAll(tempDir)).To(Succeed())
-		})
-
-		tempDir, err := os.MkdirTemp("", "test")
-		Expect(err).NotTo(HaveOccurred())
+		tempDir := GinkgoT().TempDir()
 		Expect(os.WriteFile(filepath.Join(tempDir, fileName), []byte(fileName), 0o600)).To(Succeed())
 
 		result, err := GetByName(filepath.Join(tempDir, fileName))

--- a/pkg/utils/discovery_test.go
+++ b/pkg/utils/discovery_test.go
@@ -256,16 +256,14 @@ var _ = Describe("AvailableArchitecture", func() {
 		})
 
 		It("should retrieve an existing available architecture", func() {
-			tempDir, err := os.MkdirTemp("", "test")
-			Expect(err).NotTo(HaveOccurred())
+			tempDir := GinkgoT().TempDir()
 			DeferCleanup(func() {
-				Expect(os.RemoveAll(tempDir)).To(Succeed())
 				availableArchitectures = nil
 			})
 
 			// Create a sample file
 			Expect(os.WriteFile(filepath.Join(tempDir, "manager_amd64"), []byte("amd64"), 0o600)).To(Succeed())
-			err = detectAvailableArchitectures(filepath.Join(tempDir, "manager_*"))
+			err := detectAvailableArchitectures(filepath.Join(tempDir, "manager_*"))
 			Expect(err).ToNot(HaveOccurred())
 			Expect(availableArchitectures).To(HaveLen(1))
 

--- a/tests/e2e/upgrade_test.go
+++ b/tests/e2e/upgrade_test.go
@@ -507,7 +507,8 @@ var _ = Describe("Upgrade", Label(tests.LabelUpgrade, tests.LabelNoOpenshift), O
 				// trigger any Pod restart. We still test that the operator
 				// is upgraded in this case too.
 				_, stderr, err := testsUtils.Run(
-					fmt.Sprintf("kubectl annotate -n %s cluster/%s cnpg.io/reconcilePodSpec=disabled", upgradeNamespace, clusterName1))
+					fmt.Sprintf("kubectl annotate -n %s cluster/%s cnpg.io/reconcilePodSpec=disabled",
+						upgradeNamespace, clusterName1))
 				Expect(err).NotTo(HaveOccurred(), "stderr: "+stderr)
 			}
 		})


### PR DESCRIPTION
This change updates the test suite to use `GinkgoT().TempDir()` for managing temporary directories.