### PR TITLE
fix(plugin): handle multiple containers in `kubectl cnpg logs`

### DIFF
--- a/pkg/utils/logs/cluster_logs.go
+++ b/pkg/utils/logs/cluster_logs.go
@@ -63,10 +63,13 @@ func (csr *ClusterStreamingRequest) getClusterNamespace() string {
 }
 
 func (csr *ClusterStreamingRequest) getLogOptions(containerName string) *corev1.PodLogOptions {
-	options := &corev1.PodLogOptions{}
-	if csr.Options != nil {
-		options = csr.Options.DeepCopy()
+	if csr.Options == nil {
+		return &corev1.PodLogOptions{
+			Container: containerName,
+			Previous:  csr.Previous,
+		}
 	}
+	options := csr.Options.DeepCopy()
 	options.Container = containerName
 	options.Previous = csr.Previous
 	return options

--- a/pkg/utils/logs/cluster_logs.go
+++ b/pkg/utils/logs/cluster_logs.go
@@ -25,7 +25,7 @@ import (
 	"sync"
 	"time"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -46,7 +46,7 @@ const DefaultFollowWaiting time.Duration = 1 * time.Second
 // streaming
 type ClusterStreamingRequest struct {
 	Cluster       *apiv1.Cluster
-	Options       *v1.PodLogOptions
+	Options       *corev1.PodLogOptions
 	Previous      bool `json:"previous,omitempty"`
 	FollowWaiting time.Duration
 	// NOTE: the Client argument may be omitted, but it is good practice to pass it
@@ -62,8 +62,8 @@ func (csr *ClusterStreamingRequest) getClusterNamespace() string {
 	return csr.Cluster.Namespace
 }
 
-func (csr *ClusterStreamingRequest) getLogOptions(containerName string) *v1.PodLogOptions {
-	options := &v1.PodLogOptions{}
+func (csr *ClusterStreamingRequest) getLogOptions(containerName string) *corev1.PodLogOptions {
+	options := &corev1.PodLogOptions{}
 	if csr.Options != nil {
 		options = csr.Options.DeepCopy()
 	}
@@ -173,7 +173,7 @@ func (csr *ClusterStreamingRequest) SingleStream(ctx context.Context, writer io.
 
 	for {
 		var (
-			podList *v1.PodList
+			podList *corev1.PodList
 			err     error
 		)
 		if isFirstScan || csr.Options.Follow {

--- a/pkg/utils/logs/cluster_logs_test.go
+++ b/pkg/utils/logs/cluster_logs_test.go
@@ -22,7 +22,7 @@ import (
 	"sync"
 	"time"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 
@@ -59,7 +59,7 @@ var _ = Describe("Cluster logging tests", func() {
 			Name:      clusterName,
 		},
 	}
-	pod := &v1.Pod{
+	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: clusterNamespace,
 			Name:      clusterName + "-1",
@@ -67,18 +67,18 @@ var _ = Describe("Cluster logging tests", func() {
 				utils.ClusterLabelName: clusterName,
 			},
 		},
-		Status: v1.PodStatus{
-			ContainerStatuses: []v1.ContainerStatus{
+		Status: corev1.PodStatus{
+			ContainerStatuses: []corev1.ContainerStatus{
 				{
 					Name: "postgresql",
-					State: v1.ContainerState{
-						Running: &v1.ContainerStateRunning{},
+					State: corev1.ContainerState{
+						Running: &corev1.ContainerStateRunning{},
 					},
 				},
 			},
 		},
 	}
-	podWithSidecars := &v1.Pod{
+	podWithSidecars := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: clusterNamespace,
 			Name:      clusterName + "-1",
@@ -86,18 +86,18 @@ var _ = Describe("Cluster logging tests", func() {
 				utils.ClusterLabelName: clusterName,
 			},
 		},
-		Status: v1.PodStatus{
-			ContainerStatuses: []v1.ContainerStatus{
+		Status: corev1.PodStatus{
+			ContainerStatuses: []corev1.ContainerStatus{
 				{
 					Name: "postgresql",
-					State: v1.ContainerState{
-						Running: &v1.ContainerStateRunning{},
+					State: corev1.ContainerState{
+						Running: &corev1.ContainerStateRunning{},
 					},
 				},
 				{
 					Name: "sidecar",
-					State: v1.ContainerState{
-						Running: &v1.ContainerStateRunning{},
+					State: corev1.ContainerState{
+						Running: &corev1.ContainerStateRunning{},
 					},
 				},
 			},
@@ -113,7 +113,7 @@ var _ = Describe("Cluster logging tests", func() {
 			defer wait.Done()
 			streamClusterLogs := ClusterStreamingRequest{
 				Cluster: cluster,
-				Options: &v1.PodLogOptions{
+				Options: &corev1.PodLogOptions{
 					Follow: false,
 				},
 				Client: client,
@@ -136,7 +136,7 @@ var _ = Describe("Cluster logging tests", func() {
 			defer wait.Done()
 			streamClusterLogs := ClusterStreamingRequest{
 				Cluster: cluster,
-				Options: &v1.PodLogOptions{
+				Options: &corev1.PodLogOptions{
 					Follow: false,
 				},
 				Client: client,
@@ -160,7 +160,7 @@ var _ = Describe("Cluster logging tests", func() {
 			defer GinkgoRecover()
 			streamClusterLogs := ClusterStreamingRequest{
 				Cluster: cluster,
-				Options: &v1.PodLogOptions{
+				Options: &corev1.PodLogOptions{
 					Follow: true,
 				},
 				FollowWaiting: followWaiting,


### PR DESCRIPTION
This patch fixes an issue in the `kubectl cnpg logs` command that leads to a failure if
the instance pod has more than one container.

Closes #5905 

## Release notes

Fix `kubectl cnpg logs` to prevent failures when the target pod has multiple containers.
