### PR TITLE
fix(metrics): handle FIRST keyword in synchronousStandbyNames parsing

### DIFF
--- a/pkg/management/postgres/webserver/metricserver/pg_collector.go
+++ b/pkg/management/postgres/webserver/metricserver/pg_collector.go
@@ -40,7 +40,7 @@ import (
 // or the operator
 const PrometheusNamespace = "cnpg"
 
-var synchronousStandbyNamesRegex = regexp.MustCompile(`(ANY|FIRST) ([0-9]+) \(.*\)`)
+var synchronousStandbyNamesRegex = regexp.MustCompile(`(?:ANY|FIRST) ([0-9]+) \(.*\)`)
 
 // Exporter exports a set of metrics and collectors on a given postgres instance
 type Exporter struct {
@@ -547,7 +547,7 @@ func collectPGVersion(e *Exporter) error {
 }
 
 // getRequestedSynchronousStandbysNumber returns the number of requested synchronous standbys
-// Example: ANY 2 (node1,node2) will return 2, ANY 4 (node1) will return 4.
+// Example: FIRST 2 (node1,node2) will return 2, ANY 4 (node1) will return 4.
 // If the query fails, it will return 0 and an error.
 func getRequestedSynchronousStandbysNumber(db *sql.DB) (int, error) {
 	var syncReplicasFromConfig string
@@ -559,9 +559,7 @@ func getRequestedSynchronousStandbysNumber(db *sql.DB) (int, error) {
 	if !synchronousStandbyNamesRegex.MatchString(syncReplicasFromConfig) {
 		return 0, fmt.Errorf("not matching synchronous standby names regex: %s", syncReplicasFromConfig)
 	}
-	// since we know the regex was matched, and it contains two sub-matches, we know
-	// that 3 strings were returned, so [2] is safe
-	return strconv.Atoi(synchronousStandbyNamesRegex.FindStringSubmatch(syncReplicasFromConfig)[2])
+	return strconv.Atoi(synchronousStandbyNamesRegex.FindStringSubmatch(syncReplicasFromConfig)[1])
 }
 
 // PgCollector is the interface for all the collectors that need to do queries

--- a/pkg/management/postgres/webserver/metricserver/pg_collector.go
+++ b/pkg/management/postgres/webserver/metricserver/pg_collector.go
@@ -556,6 +556,8 @@ func getSynchronousStandbysNumber(db *sql.DB) (int, error) {
 	if !synchronousStandbyNamesRegex.MatchString(syncReplicasFromConfig) {
 		return 0, fmt.Errorf("not matching synchronous standby names regex: %s", syncReplicasFromConfig)
 	}
+	// since we know the regex was matched, and it contains two sub-matches, we know
+	// that 3 strings were returned, so [2] is safe
 	return strconv.Atoi(synchronousStandbyNamesRegex.FindStringSubmatch(syncReplicasFromConfig)[2])
 }
 

--- a/pkg/management/postgres/webserver/metricserver/pg_collector.go
+++ b/pkg/management/postgres/webserver/metricserver/pg_collector.go
@@ -40,7 +40,7 @@ import (
 // or the operator
 const PrometheusNamespace = "cnpg"
 
-var synchronousStandbyNamesRegex = regexp.MustCompile(`ANY ([0-9]+) \(.*\)`)
+var synchronousStandbyNamesRegex = regexp.MustCompile(`(ANY|FIRST) ([0-9]+) \(.*\)`)
 
 // Exporter exports a set of metrics and collectors on a given postgres instance
 type Exporter struct {

--- a/pkg/management/postgres/webserver/metricserver/pg_collector.go
+++ b/pkg/management/postgres/webserver/metricserver/pg_collector.go
@@ -517,7 +517,7 @@ func (e *Exporter) collectFromPrimaryFirstPointOnTimeRecovery() {
 }
 
 func (e *Exporter) collectFromPrimarySynchronousStandbysNumber(db *sql.DB) {
-	nStandbys, err := getSynchronousStandbysNumber(db)
+	nStandbys, err := getRequestedSynchronousStandbysNumber(db)
 	if err != nil {
 		log.Error(err, "unable to collect metrics")
 		e.Metrics.Error.Set(1)
@@ -546,7 +546,10 @@ func collectPGVersion(e *Exporter) error {
 	return nil
 }
 
-func getSynchronousStandbysNumber(db *sql.DB) (int, error) {
+// getRequestedSynchronousStandbysNumber returns the number of requested synchronous standbys
+// Example: ANY 2 (node1,node2) will return 2, ANY 4 (node1) will return 4.
+// If the query fails, it will return 0 and an error.
+func getRequestedSynchronousStandbysNumber(db *sql.DB) (int, error) {
 	var syncReplicasFromConfig string
 	err := db.QueryRow(fmt.Sprintf("SHOW %s", postgresconf.SynchronousStandbyNames)).
 		Scan(&syncReplicasFromConfig)

--- a/pkg/management/postgres/webserver/metricserver/pg_collector.go
+++ b/pkg/management/postgres/webserver/metricserver/pg_collector.go
@@ -556,7 +556,7 @@ func getSynchronousStandbysNumber(db *sql.DB) (int, error) {
 	if !synchronousStandbyNamesRegex.MatchString(syncReplicasFromConfig) {
 		return 0, fmt.Errorf("not matching synchronous standby names regex: %s", syncReplicasFromConfig)
 	}
-	return strconv.Atoi(synchronousStandbyNamesRegex.FindStringSubmatch(syncReplicasFromConfig)[1])
+	return strconv.Atoi(synchronousStandbyNamesRegex.FindStringSubmatch(syncReplicasFromConfig)[2])
 }
 
 // PgCollector is the interface for all the collectors that need to do queries

--- a/pkg/management/postgres/webserver/metricserver/pg_collector_test.go
+++ b/pkg/management/postgres/webserver/metricserver/pg_collector_test.go
@@ -102,7 +102,7 @@ var _ = Describe("test metrics parsing", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		rows := sqlmock.NewRows([]string{"synchronous_standby_names"}).
-			AddRow("ANY 2 ( \"cluster-example-2\",\"cluster-example-3\")")
+			AddRow(`ANY 2 ( "cluster-example-2","cluster-example-3")`)
 		mock.ExpectQuery(fmt.Sprintf("SHOW %s", postgresconf.SynchronousStandbyNames)).WillReturnRows(rows)
 
 		exporter.collectFromPrimarySynchronousStandbysNumber(db)
@@ -122,7 +122,7 @@ var _ = Describe("test metrics parsing", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		rows := sqlmock.NewRows([]string{"synchronous_standby_names"}).
-			AddRow("FIRST 2 ( \"cluster-example-2\",\"cluster-example-3\")")
+			AddRow(`FIRST 2 ( "cluster-example-2","cluster-example-3")`)
 		mock.ExpectQuery(fmt.Sprintf("SHOW %s", postgresconf.SynchronousStandbyNames)).WillReturnRows(rows)
 
 		exporter.collectFromPrimarySynchronousStandbysNumber(db)
@@ -168,7 +168,7 @@ var _ = Describe("test metrics parsing", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		rows := sqlmock.NewRows([]string{"synchronous_standby_names"}).
-			AddRow("( \"cluster-example-2\",\"cluster-example-3\")")
+			AddRow(`( "cluster-example-2","cluster-example-3")`)
 		mock.ExpectQuery(fmt.Sprintf("SHOW %s", postgresconf.SynchronousStandbyNames)).WillReturnRows(rows)
 
 		exporter.collectFromPrimarySynchronousStandbysNumber(db)

--- a/pkg/management/postgres/webserver/metricserver/pg_collector_test.go
+++ b/pkg/management/postgres/webserver/metricserver/pg_collector_test.go
@@ -33,7 +33,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("ensure timestamp metric it's set properly", func() {
+var _ = Describe("ensure timestamp metric is set properly", func() {
 	var exporter *Exporter
 
 	BeforeEach(func() {
@@ -97,7 +97,7 @@ var _ = Describe("ensure timestamp metric it's set properly", func() {
 		}
 	})
 
-	It("It correctly parse the sync replicas", func() {
+	It("correctly parses the number of sync replicas when quorum-based", func() {
 		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 		Expect(err).ToNot(HaveOccurred())
 
@@ -117,7 +117,7 @@ var _ = Describe("ensure timestamp metric it's set properly", func() {
 		}
 	})
 
-	It("It correctly parses the sync replicas when preferential", func() {
+	It("correctly parses the number of sync replicas when preferential", func() {
 		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 		Expect(err).ToNot(HaveOccurred())
 
@@ -137,7 +137,7 @@ var _ = Describe("ensure timestamp metric it's set properly", func() {
 		}
 	})
 
-	It("register -1 in case it can't parse the sync replicas string", func() {
+	It("sets the number of sync replicas as -1 if it can't parse the sync replicas string", func() {
 		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 		Expect(err).ToNot(HaveOccurred())
 

--- a/pkg/management/postgres/webserver/metricserver/pg_collector_test.go
+++ b/pkg/management/postgres/webserver/metricserver/pg_collector_test.go
@@ -33,7 +33,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("ensure timestamp metric is set properly", func() {
+var _ = Describe("test metrics parsing", func() {
 	var exporter *Exporter
 
 	BeforeEach(func() {


### PR DESCRIPTION
This patch corrects a bug where the metrics collector fails to parse the `synchronous_standby_names` configurations when `.spec.postgresql.synchronous.method` is set to `first`.

Closes #5538 
