### PR TITLE
refactor: bring role reconciler Postgres functions in line with other reconcilers

### DIFF
--- a/internal/management/controller/roles/contract.go
+++ b/internal/management/controller/roles/contract.go
@@ -17,7 +17,6 @@ limitations under the License.
 package roles
 
 import (
-	"context"
 	"database/sql"
 	"reflect"
 	"sort"
@@ -120,31 +119,4 @@ func (d *DatabaseRole) isEquivalentTo(inSpec apiv1.RoleConfiguration) bool {
 	}
 
 	return reflect.DeepEqual(role, spec) && d.hasSameValidUntilAs(inSpec)
-}
-
-// RoleManager abstracts the functionality of reconciling with PostgreSQL roles
-type RoleManager interface {
-	// List the roles in the database
-	List(ctx context.Context, db *sql.DB) ([]DatabaseRole, error)
-	// Update the role in the database
-	Update(ctx context.Context, db *sql.DB, role DatabaseRole) error
-	// Create the role in the database
-	Create(ctx context.Context, db *sql.DB, role DatabaseRole) error
-	// Delete the role in the database
-	Delete(ctx context.Context, db *sql.DB, role DatabaseRole) error
-	// GetLastTransactionID returns the last TransactionID as the `xmin`
-	// from the database
-	// See https://www.postgresql.org/docs/current/datatype-oid.html for reference
-	GetLastTransactionID(ctx context.Context, db *sql.DB, role DatabaseRole) (int64, error)
-	// UpdateComment Update the comment of role in the database
-	UpdateComment(ctx context.Context, db *sql.DB, role DatabaseRole) error
-	// UpdateMembership Update the In Role membership of role in the database
-	UpdateMembership(
-		ctx context.Context,
-		db *sql.DB, role DatabaseRole,
-		rolesToGrant []string,
-		rolesToRevoke []string,
-	) error
-	// GetParentRoles returns the roles the given role is a member of
-	GetParentRoles(ctx context.Context, db *sql.DB, role DatabaseRole) ([]string, error)
 }

--- a/internal/management/controller/roles/contract.go
+++ b/internal/management/controller/roles/contract.go
@@ -125,21 +125,26 @@ func (d *DatabaseRole) isEquivalentTo(inSpec apiv1.RoleConfiguration) bool {
 // RoleManager abstracts the functionality of reconciling with PostgreSQL roles
 type RoleManager interface {
 	// List the roles in the database
-	List(ctx context.Context) ([]DatabaseRole, error)
+	List(ctx context.Context, db *sql.DB) ([]DatabaseRole, error)
 	// Update the role in the database
-	Update(ctx context.Context, role DatabaseRole) error
+	Update(ctx context.Context, db *sql.DB, role DatabaseRole) error
 	// Create the role in the database
-	Create(ctx context.Context, role DatabaseRole) error
+	Create(ctx context.Context, db *sql.DB, role DatabaseRole) error
 	// Delete the role in the database
-	Delete(ctx context.Context, role DatabaseRole) error
+	Delete(ctx context.Context, db *sql.DB, role DatabaseRole) error
 	// GetLastTransactionID returns the last TransactionID as the `xmin`
 	// from the database
 	// See https://www.postgresql.org/docs/current/datatype-oid.html for reference
-	GetLastTransactionID(ctx context.Context, role DatabaseRole) (int64, error)
+	GetLastTransactionID(ctx context.Context, db *sql.DB, role DatabaseRole) (int64, error)
 	// UpdateComment Update the comment of role in the database
-	UpdateComment(ctx context.Context, role DatabaseRole) error
+	UpdateComment(ctx context.Context, db *sql.DB, role DatabaseRole) error
 	// UpdateMembership Update the In Role membership of role in the database
-	UpdateMembership(ctx context.Context, role DatabaseRole, rolesToGrant []string, rolesToRevoke []string) error
+	UpdateMembership(
+		ctx context.Context,
+		db *sql.DB, role DatabaseRole,
+		rolesToGrant []string,
+		rolesToRevoke []string,
+	) error
 	// GetParentRoles returns the roles the given role is a member of
-	GetParentRoles(ctx context.Context, role DatabaseRole) ([]string, error)
+	GetParentRoles(ctx context.Context, db *sql.DB, role DatabaseRole) ([]string, error)
 }

--- a/internal/management/controller/roles/postgres.go
+++ b/internal/management/controller/roles/postgres.go
@@ -46,7 +46,9 @@ func (sm PostgresRoleManager) List(
 	db *sql.DB,
 ) ([]DatabaseRole, error) {
 	logger := log.FromContext(ctx).WithName("roles_reconciler")
-	wrapErr := func(err error) error { return fmt.Errorf("while listing DB roles for DRM: %w", err) }
+	wrapErr := func(err error) error {
+		return fmt.Errorf("while listing DB roles for role reconciler: %w", err)
+	}
 
 	rows, err := db.QueryContext(
 		ctx,
@@ -114,7 +116,7 @@ func (sm PostgresRoleManager) Update(ctx context.Context, db *sql.DB, role Datab
 	contextLog := log.FromContext(ctx).WithName("roles_reconciler")
 	contextLog.Trace("Invoked", "role", role)
 	wrapErr := func(err error) error {
-		return fmt.Errorf("while updating role %s with DRM: %w", role.Name, err)
+		return fmt.Errorf("while updating role %s with role reconciler: %w", role.Name, err)
 	}
 	var query strings.Builder
 
@@ -138,7 +140,7 @@ func (sm PostgresRoleManager) Create(ctx context.Context, db *sql.DB, role Datab
 	contextLog := log.FromContext(ctx).WithName("roles_reconciler")
 	contextLog.Trace("Invoked", "role", role)
 	wrapErr := func(err error) error {
-		return fmt.Errorf("while creating role %s with DRM: %w", role.Name, err)
+		return fmt.Errorf("while creating role %s with role reconciler: %w", role.Name, err)
 	}
 
 	var query strings.Builder
@@ -173,7 +175,7 @@ func (sm PostgresRoleManager) Delete(ctx context.Context, db *sql.DB, role Datab
 	contextLog := log.FromContext(ctx).WithName("roles_reconciler")
 	contextLog.Trace("Invoked", "role", role)
 	wrapErr := func(err error) error {
-		return fmt.Errorf("while deleting role %s with DRM: %w", role.Name, err)
+		return fmt.Errorf("while deleting role %s with role reconciler: %w", role.Name, err)
 	}
 
 	query := fmt.Sprintf("DROP ROLE %s", pgx.Identifier{role.Name}.Sanitize())
@@ -192,7 +194,7 @@ func (sm PostgresRoleManager) GetLastTransactionID(ctx context.Context, db *sql.
 	contextLog := log.FromContext(ctx).WithName("roles_reconciler")
 	contextLog.Trace("Invoked", "role", role)
 	wrapErr := func(err error) error {
-		return fmt.Errorf("while getting last xmin for role %s with DRM: %w", role.Name, err)
+		return fmt.Errorf("while getting last xmin for role %s with role reconciler: %w", role.Name, err)
 	}
 
 	var xmin int64
@@ -214,7 +216,7 @@ func (sm PostgresRoleManager) UpdateComment(ctx context.Context, db *sql.DB, rol
 	contextLog := log.FromContext(ctx).WithName("roles_reconciler")
 	contextLog.Trace("Invoked", "role", role)
 	wrapErr := func(err error) error {
-		return fmt.Errorf("while updating comment for role %s with DRM: %w", role.Name, err)
+		return fmt.Errorf("while updating comment for role %s with role reconciler: %w", role.Name, err)
 	}
 
 	query := fmt.Sprintf("COMMENT ON ROLE %s IS %s",
@@ -243,7 +245,7 @@ func (sm PostgresRoleManager) UpdateMembership(
 	contextLog := log.FromContext(ctx).WithName("roles_reconciler")
 	contextLog.Trace("Invoked", "role", role)
 	wrapErr := func(err error) error {
-		return fmt.Errorf("while updating memberships for role %s with DRM: %w", role.Name, err)
+		return fmt.Errorf("while updating memberships for role %s with role reconciler: %w", role.Name, err)
 	}
 	if len(rolesToRevoke)+len(rolesToGrant) == 0 {
 		contextLog.Debug("No membership change query to execute for role")
@@ -293,7 +295,7 @@ func (sm PostgresRoleManager) GetParentRoles(
 	contextLog := log.FromContext(ctx).WithName("roles_reconciler")
 	contextLog.Trace("Invoked", "role", role)
 	wrapErr := func(err error) error {
-		return fmt.Errorf("while getting parents for role %s with DRM: %w", role.Name, err)
+		return fmt.Errorf("while getting parents for role %s with role reconciler: %w", role.Name, err)
 	}
 	query := `SELECT mem.inroles 
 		FROM pg_catalog.pg_authid as auth

--- a/internal/management/controller/roles/postgres.go
+++ b/internal/management/controller/roles/postgres.go
@@ -28,20 +28,8 @@ import (
 	"github.com/lib/pq"
 )
 
-// PostgresRoleManager is a RoleManager for a database instance
-type PostgresRoleManager struct {
-	superUserDB *sql.DB
-}
-
-// NewPostgresRoleManager returns an implementation of RoleManager for postgres
-func NewPostgresRoleManager(superDB *sql.DB) RoleManager {
-	return PostgresRoleManager{
-		superUserDB: superDB,
-	}
-}
-
 // List the available roles excluding all the roles that start with `pg_`
-func (sm PostgresRoleManager) List(
+func List(
 	ctx context.Context,
 	db *sql.DB,
 ) ([]DatabaseRole, error) {
@@ -112,7 +100,7 @@ func (sm PostgresRoleManager) List(
 }
 
 // Update the role
-func (sm PostgresRoleManager) Update(ctx context.Context, db *sql.DB, role DatabaseRole) error {
+func Update(ctx context.Context, db *sql.DB, role DatabaseRole) error {
 	contextLog := log.FromContext(ctx).WithName("roles_reconciler")
 	contextLog.Trace("Invoked", "role", role)
 	wrapErr := func(err error) error {
@@ -136,7 +124,7 @@ func (sm PostgresRoleManager) Update(ctx context.Context, db *sql.DB, role Datab
 
 // Create the role
 // TODO: do we give the role any database-level permissions?
-func (sm PostgresRoleManager) Create(ctx context.Context, db *sql.DB, role DatabaseRole) error {
+func Create(ctx context.Context, db *sql.DB, role DatabaseRole) error {
 	contextLog := log.FromContext(ctx).WithName("roles_reconciler")
 	contextLog.Trace("Invoked", "role", role)
 	wrapErr := func(err error) error {
@@ -171,7 +159,7 @@ func (sm PostgresRoleManager) Create(ctx context.Context, db *sql.DB, role Datab
 }
 
 // Delete the role
-func (sm PostgresRoleManager) Delete(ctx context.Context, db *sql.DB, role DatabaseRole) error {
+func Delete(ctx context.Context, db *sql.DB, role DatabaseRole) error {
 	contextLog := log.FromContext(ctx).WithName("roles_reconciler")
 	contextLog.Trace("Invoked", "role", role)
 	wrapErr := func(err error) error {
@@ -190,7 +178,7 @@ func (sm PostgresRoleManager) Delete(ctx context.Context, db *sql.DB, role Datab
 
 // GetLastTransactionID get the last xmin for the role, to help keep track of
 // whether the role has been changed in on the Database since last reconciliation
-func (sm PostgresRoleManager) GetLastTransactionID(ctx context.Context, db *sql.DB, role DatabaseRole) (int64, error) {
+func GetLastTransactionID(ctx context.Context, db *sql.DB, role DatabaseRole) (int64, error) {
 	contextLog := log.FromContext(ctx).WithName("roles_reconciler")
 	contextLog.Trace("Invoked", "role", role)
 	wrapErr := func(err error) error {
@@ -212,7 +200,7 @@ func (sm PostgresRoleManager) GetLastTransactionID(ctx context.Context, db *sql.
 }
 
 // UpdateComment of the role
-func (sm PostgresRoleManager) UpdateComment(ctx context.Context, db *sql.DB, role DatabaseRole) error {
+func UpdateComment(ctx context.Context, db *sql.DB, role DatabaseRole) error {
 	contextLog := log.FromContext(ctx).WithName("roles_reconciler")
 	contextLog.Trace("Invoked", "role", role)
 	wrapErr := func(err error) error {
@@ -235,7 +223,7 @@ func (sm PostgresRoleManager) UpdateComment(ctx context.Context, db *sql.DB, rol
 // IMPORTANT: the various REVOKE and GRANT commands that may be required to
 // reconcile the role will be done in a single transaction. So, if any one
 // of them fails, the role will not get updated
-func (sm PostgresRoleManager) UpdateMembership(
+func UpdateMembership(
 	ctx context.Context,
 	db *sql.DB,
 	role DatabaseRole,
@@ -287,7 +275,7 @@ func (sm PostgresRoleManager) UpdateMembership(
 }
 
 // GetParentRoles get the in roles of this role
-func (sm PostgresRoleManager) GetParentRoles(
+func GetParentRoles(
 	ctx context.Context,
 	db *sql.DB,
 	role DatabaseRole,

--- a/internal/management/controller/roles/postgres_test.go
+++ b/internal/management/controller/roles/postgres_test.go
@@ -36,29 +36,6 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-const (
-	expectedSelStmt = `SELECT rolname, rolsuper, rolinherit, rolcreaterole, rolcreatedb, 
-		rolcanlogin, rolreplication, rolconnlimit, rolpassword, rolvaliduntil, rolbypassrls,
-		pg_catalog.shobj_description(auth.oid, 'pg_authid') as comment, auth.xmin,
-		mem.inroles
-	FROM pg_catalog.pg_authid as auth
-	LEFT JOIN (
-		SELECT array_agg(pg_get_userbyid(roleid)) as inroles, member
-		FROM pg_auth_members GROUP BY member
-	) mem ON member = oid
-	WHERE rolname not like 'pg\_%'`
-
-	expectedMembershipStmt = `SELECT mem.inroles 
-	FROM pg_catalog.pg_authid as auth
-	LEFT JOIN (
-		SELECT array_agg(pg_get_userbyid(roleid)) as inroles, member
-		FROM pg_auth_members GROUP BY member
-	) mem ON member = oid
-	WHERE rolname = $1`
-
-	wantedRoleCommentTpl = "COMMENT ON ROLE \"%s\" IS %s"
-)
-
 var _ = Describe("Postgres RoleManager implementation test", func() {
 	falseValue := false
 	validUntil := metav1.Date(2100, 0o1, 0o1, 0o0, 0o0, 0o0, 0o0, time.UTC)

--- a/internal/management/controller/roles/reconciler.go
+++ b/internal/management/controller/roles/reconciler.go
@@ -57,7 +57,7 @@ func Reconcile(
 
 	contextLogger.Debug("getting the managed roles status")
 	roleManager := NewPostgresRoleManager(db)
-	rolesInDB, err := roleManager.List(ctx)
+	rolesInDB, err := roleManager.List(ctx, db)
 	if err != nil {
 		return reconcile.Result{}, err
 	}

--- a/internal/management/controller/roles/reconciler.go
+++ b/internal/management/controller/roles/reconciler.go
@@ -56,8 +56,7 @@ func Reconcile(
 	}
 
 	contextLogger.Debug("getting the managed roles status")
-	roleManager := NewPostgresRoleManager(db)
-	rolesInDB, err := roleManager.List(ctx, db)
+	rolesInDB, err := List(ctx, db)
 	if err != nil {
 		return reconcile.Result{}, err
 	}

--- a/internal/management/controller/roles/reconciler_test.go
+++ b/internal/management/controller/roles/reconciler_test.go
@@ -53,7 +53,7 @@ var _ = Describe("Role reconciler test", func() {
 				},
 			},
 		}
-		pgStringError := "while listing DB roles for DRM: " +
+		pgStringError := "while listing DB roles for role reconciler: " +
 			"failed to connect to `user=postgres database=postgres`: " +
 			"/controller/run/.s.PGSQL.5432 (/controller/run): " +
 			"dial error: dial unix /controller/run/.s.PGSQL.5432: connect: no such file or directory"

--- a/internal/management/controller/roles/runnable.go
+++ b/internal/management/controller/roles/runnable.go
@@ -19,7 +19,6 @@ package roles
 import (
 	"context"
 	"database/sql"
-	"errors"
 	"fmt"
 	"strings"
 
@@ -308,7 +307,7 @@ func getRoleMembershipDiff(
 	dbRole DatabaseRole,
 ) ([]string, []string, error) {
 	inRoleInDB, err := GetParentRoles(ctx, db, dbRole)
-	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+	if err != nil {
 		return nil, nil, err
 	}
 	rolesToGrant := getRolesToGrant(inRoleInDB, role.InRoles)

--- a/internal/management/controller/roles/runnable.go
+++ b/internal/management/controller/roles/runnable.go
@@ -153,7 +153,7 @@ func (sr *RoleSynchronizer) reconcile(ctx context.Context, config *apiv1.Managed
 	}
 	superUserDB, err := sr.instance.GetSuperUserDB()
 	if err != nil {
-		return fmt.Errorf("while reconciling managed roles: %w", err)
+		return fmt.Errorf("while getting superuser connection: %w", err)
 	}
 	appliedState, irreconcilableRoles, err := sr.synchronizeRoles(ctx, superUserDB, config, rolePasswords)
 	if err != nil {
@@ -196,7 +196,6 @@ func (sr *RoleSynchronizer) synchronizeRoles(
 	if err != nil {
 		return nil, nil, err
 	}
-
 	rolesInDB, err := List(ctx, db)
 	if err != nil {
 		return nil, nil, err
@@ -204,11 +203,7 @@ func (sr *RoleSynchronizer) synchronizeRoles(
 	rolesByAction := evaluateNextRoleActions(
 		ctx, config, rolesInDB, storedPasswordState, latestSecretResourceVersion)
 
-	passwordStates, irreconcilableRoles, err := sr.applyRoleActions(
-		ctx,
-		db,
-		rolesByAction,
-	)
+	passwordStates, irreconcilableRoles, err := sr.applyRoleActions(ctx, db, rolesByAction)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/management/controller/roles/runnable.go
+++ b/internal/management/controller/roles/runnable.go
@@ -184,7 +184,7 @@ func getRoleNames(roles []roleConfigurationAdapter) []string {
 // It returns
 //   - the PasswordState for any updated roles
 //   - any roles that had expectable postgres errors
-//   - any unexpeted error
+//   - any unexpected error
 func (sr *RoleSynchronizer) synchronizeRoles(
 	ctx context.Context,
 	db *sql.DB,

--- a/internal/management/controller/roles/runnable_test.go
+++ b/internal/management/controller/roles/runnable_test.go
@@ -18,6 +18,7 @@ package roles
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 
 	"github.com/jackc/pgx/v5/pgconn"
@@ -40,7 +41,7 @@ type mockRoleManager struct {
 	callHistory []funcCall
 }
 
-func (m *mockRoleManager) List(_ context.Context) ([]DatabaseRole, error) {
+func (m *mockRoleManager) List(_ context.Context, _ *sql.DB) ([]DatabaseRole, error) {
 	m.callHistory = append(m.callHistory, funcCall{"list", ""})
 	re := make([]DatabaseRole, len(m.roles))
 	i := 0
@@ -52,7 +53,7 @@ func (m *mockRoleManager) List(_ context.Context) ([]DatabaseRole, error) {
 }
 
 func (m *mockRoleManager) Update(
-	_ context.Context, role DatabaseRole,
+	_ context.Context, _ *sql.DB, role DatabaseRole,
 ) error {
 	m.callHistory = append(m.callHistory, funcCall{"update", role.Name})
 	_, found := m.roles[role.Name]
@@ -64,7 +65,7 @@ func (m *mockRoleManager) Update(
 }
 
 func (m *mockRoleManager) UpdateComment(
-	_ context.Context, role DatabaseRole,
+	_ context.Context, _ *sql.DB, role DatabaseRole,
 ) error {
 	m.callHistory = append(m.callHistory, funcCall{"updateComment", role.Name})
 	_, found := m.roles[role.Name]
@@ -76,7 +77,7 @@ func (m *mockRoleManager) UpdateComment(
 }
 
 func (m *mockRoleManager) Create(
-	_ context.Context, role DatabaseRole,
+	_ context.Context, _ *sql.DB, role DatabaseRole,
 ) error {
 	m.callHistory = append(m.callHistory, funcCall{"create", role.Name})
 	_, found := m.roles[role.Name]
@@ -88,7 +89,7 @@ func (m *mockRoleManager) Create(
 }
 
 func (m *mockRoleManager) Delete(
-	_ context.Context, role DatabaseRole,
+	_ context.Context, _ *sql.DB, role DatabaseRole,
 ) error {
 	m.callHistory = append(m.callHistory, funcCall{"delete", role.Name})
 	_, found := m.roles[role.Name]
@@ -99,12 +100,13 @@ func (m *mockRoleManager) Delete(
 	return nil
 }
 
-func (m *mockRoleManager) GetLastTransactionID(_ context.Context, _ DatabaseRole) (int64, error) {
+func (m *mockRoleManager) GetLastTransactionID(_ context.Context, _ *sql.DB, _ DatabaseRole) (int64, error) {
 	return 0, nil
 }
 
 func (m *mockRoleManager) UpdateMembership(
 	_ context.Context,
+	_ *sql.DB,
 	role DatabaseRole,
 	_ []string,
 	_ []string,
@@ -118,7 +120,7 @@ func (m *mockRoleManager) UpdateMembership(
 	return nil
 }
 
-func (m *mockRoleManager) GetParentRoles(_ context.Context, role DatabaseRole) ([]string, error) {
+func (m *mockRoleManager) GetParentRoles(_ context.Context, _ *sql.DB, role DatabaseRole) ([]string, error) {
 	m.callHistory = append(m.callHistory, funcCall{"getParentRoles", role.Name})
 	_, found := m.roles[role.Name]
 	if !found {
@@ -136,7 +138,7 @@ type mockRoleManagerWithError struct {
 	callHistory []funcCall
 }
 
-func (m *mockRoleManagerWithError) List(_ context.Context) ([]DatabaseRole, error) {
+func (m *mockRoleManagerWithError) List(_ context.Context, _ *sql.DB) ([]DatabaseRole, error) {
 	m.callHistory = append(m.callHistory, funcCall{"list", ""})
 	re := make([]DatabaseRole, len(m.roles))
 	i := 0
@@ -148,7 +150,7 @@ func (m *mockRoleManagerWithError) List(_ context.Context) ([]DatabaseRole, erro
 }
 
 func (m *mockRoleManagerWithError) Update(
-	_ context.Context, role DatabaseRole,
+	_ context.Context, _ *sql.DB, role DatabaseRole,
 ) error {
 	m.callHistory = append(m.callHistory, funcCall{"update", role.Name})
 	_, found := m.roles[role.Name]
@@ -160,7 +162,7 @@ func (m *mockRoleManagerWithError) Update(
 }
 
 func (m *mockRoleManagerWithError) UpdateComment(
-	_ context.Context, role DatabaseRole,
+	_ context.Context, _ *sql.DB, role DatabaseRole,
 ) error {
 	m.callHistory = append(m.callHistory, funcCall{"updateComment", role.Name})
 	_, found := m.roles[role.Name]
@@ -172,7 +174,7 @@ func (m *mockRoleManagerWithError) UpdateComment(
 }
 
 func (m *mockRoleManagerWithError) Create(
-	_ context.Context, role DatabaseRole,
+	_ context.Context, _ *sql.DB, role DatabaseRole,
 ) error {
 	m.callHistory = append(m.callHistory, funcCall{"create", role.Name})
 	_, found := m.roles[role.Name]
@@ -184,7 +186,7 @@ func (m *mockRoleManagerWithError) Create(
 }
 
 func (m *mockRoleManagerWithError) Delete(
-	_ context.Context, role DatabaseRole,
+	_ context.Context, _ *sql.DB, role DatabaseRole,
 ) error {
 	m.callHistory = append(m.callHistory, funcCall{"delete", role.Name})
 	_, found := m.roles[role.Name]
@@ -198,12 +200,13 @@ func (m *mockRoleManagerWithError) Delete(
 		})
 }
 
-func (m *mockRoleManagerWithError) GetLastTransactionID(_ context.Context, _ DatabaseRole) (int64, error) {
+func (m *mockRoleManagerWithError) GetLastTransactionID(_ context.Context, _ *sql.DB, _ DatabaseRole) (int64, error) {
 	return 0, nil
 }
 
 func (m *mockRoleManagerWithError) UpdateMembership(
 	_ context.Context,
+	_ *sql.DB,
 	role DatabaseRole,
 	_ []string,
 	_ []string,
@@ -217,7 +220,7 @@ func (m *mockRoleManagerWithError) UpdateMembership(
 	return &pgconn.PgError{Code: "42704", Message: "unknown role 'blah'"}
 }
 
-func (m *mockRoleManagerWithError) GetParentRoles(_ context.Context, role DatabaseRole) ([]string, error) {
+func (m *mockRoleManagerWithError) GetParentRoles(_ context.Context, _ *sql.DB, role DatabaseRole) ([]string, error) {
 	m.callHistory = append(m.callHistory, funcCall{"getParentRoles", role.Name})
 	_, found := m.roles[role.Name]
 	if !found {
@@ -591,10 +594,11 @@ var _ = Describe("Role synchronizer tests", func() {
 })
 
 var _ = DescribeTable("Role status getter tests",
-	func(spec *apiv1.ManagedConfiguration, db mockRoleManager, expected map[string]apiv1.RoleStatus) {
+	func(spec *apiv1.ManagedConfiguration, rm mockRoleManager, expected map[string]apiv1.RoleStatus) {
 		ctx := context.TODO()
 
-		roles, err := db.List(ctx)
+		db := &sql.DB{}
+		roles, err := rm.List(ctx, db)
 		Expect(err).ToNot(HaveOccurred())
 
 		statusMap := evaluateNextRoleActions(ctx, spec, roles, map[string]apiv1.PasswordState{

--- a/internal/management/controller/roles/runnable_test.go
+++ b/internal/management/controller/roles/runnable_test.go
@@ -152,7 +152,8 @@ var _ = Describe("Role synchronizer tests", func() {
 					},
 				},
 			}
-			mock.ExpectQuery(expectedMembershipStmt).WithArgs("role_to_test1").WillReturnError(sql.ErrNoRows)
+			noParents := sqlmock.NewRows([]string{"inroles"}).AddRow([]byte(`{}`))
+			mock.ExpectQuery(expectedMembershipStmt).WithArgs("role_to_test1").WillReturnRows(noParents)
 			mock.ExpectBegin()
 			expectedMembershipExecs := []string{
 				`GRANT "role1" TO "role_to_test1"`,
@@ -333,7 +334,8 @@ var _ = Describe("Role synchronizer tests", func() {
 				},
 			}
 
-			mock.ExpectQuery(expectedMembershipStmt).WithArgs("role_to_test1").WillReturnError(sql.ErrNoRows)
+			noParents := sqlmock.NewRows([]string{"inroles"}).AddRow([]byte(`{}`))
+			mock.ExpectQuery(expectedMembershipStmt).WithArgs("role_to_test1").WillReturnRows(noParents)
 			mock.ExpectBegin()
 
 			mock.ExpectExec(`GRANT "role1" TO "role_to_test1"`).

--- a/internal/management/controller/roles/runnable_test.go
+++ b/internal/management/controller/roles/runnable_test.go
@@ -20,10 +20,15 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"time"
 
+	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/lib/pq"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
@@ -133,144 +138,97 @@ func (m *mockRoleManager) GetParentRoles(_ context.Context, _ *sql.DB, role Data
 // mock.ExpectExec(unWantedRoleExpectedDelStmt).
 // WillReturnError(&pgconn.PgError{Code: "2BP01"})
 
-type mockRoleManagerWithError struct {
-	roles       map[string]DatabaseRole
-	callHistory []funcCall
+type fakeInstanceData struct {
+	*postgres.Instance
+	db *sql.DB
 }
 
-func (m *mockRoleManagerWithError) List(_ context.Context, _ *sql.DB) ([]DatabaseRole, error) {
-	m.callHistory = append(m.callHistory, funcCall{"list", ""})
-	re := make([]DatabaseRole, len(m.roles))
-	i := 0
-	for _, r := range m.roles {
-		re[i] = r
-		i++
-	}
-	return re, nil
-}
-
-func (m *mockRoleManagerWithError) Update(
-	_ context.Context, _ *sql.DB, role DatabaseRole,
-) error {
-	m.callHistory = append(m.callHistory, funcCall{"update", role.Name})
-	_, found := m.roles[role.Name]
-	if !found {
-		return fmt.Errorf("tring to update unknown role: %s", role.Name)
-	}
-	m.roles[role.Name] = role
-	return nil
-}
-
-func (m *mockRoleManagerWithError) UpdateComment(
-	_ context.Context, _ *sql.DB, role DatabaseRole,
-) error {
-	m.callHistory = append(m.callHistory, funcCall{"updateComment", role.Name})
-	_, found := m.roles[role.Name]
-	if !found {
-		return fmt.Errorf("tring to update comment of unknown role: %s", role.Name)
-	}
-	m.roles[role.Name] = role
-	return nil
-}
-
-func (m *mockRoleManagerWithError) Create(
-	_ context.Context, _ *sql.DB, role DatabaseRole,
-) error {
-	m.callHistory = append(m.callHistory, funcCall{"create", role.Name})
-	_, found := m.roles[role.Name]
-	if found {
-		return fmt.Errorf("tring to create existing role: %s", role.Name)
-	}
-	m.roles[role.Name] = role
-	return nil
-}
-
-func (m *mockRoleManagerWithError) Delete(
-	_ context.Context, _ *sql.DB, role DatabaseRole,
-) error {
-	m.callHistory = append(m.callHistory, funcCall{"delete", role.Name})
-	_, found := m.roles[role.Name]
-	if !found {
-		return fmt.Errorf("tring to delete unknown role: %s", role.Name)
-	}
-	return fmt.Errorf("could not delete role 'foo': %w",
-		&pgconn.PgError{
-			Code: "2BP01", Detail: "owner of database edbDatabase",
-			Message: `role "dante" cannot be dropped because some objects depend on it`,
-		})
-}
-
-func (m *mockRoleManagerWithError) GetLastTransactionID(_ context.Context, _ *sql.DB, _ DatabaseRole) (int64, error) {
-	return 0, nil
-}
-
-func (m *mockRoleManagerWithError) UpdateMembership(
-	_ context.Context,
-	_ *sql.DB,
-	role DatabaseRole,
-	_ []string,
-	_ []string,
-) error {
-	m.callHistory = append(m.callHistory, funcCall{"updateMembership", role.Name})
-	_, found := m.roles[role.Name]
-	if !found {
-		return fmt.Errorf("trying to update Role Members of unknown role: %s", role.Name)
-	}
-	m.roles[role.Name] = role
-	return &pgconn.PgError{Code: "42704", Message: "unknown role 'blah'"}
-}
-
-func (m *mockRoleManagerWithError) GetParentRoles(_ context.Context, _ *sql.DB, role DatabaseRole) ([]string, error) {
-	m.callHistory = append(m.callHistory, funcCall{"getParentRoles", role.Name})
-	_, found := m.roles[role.Name]
-	if !found {
-		return nil, fmt.Errorf("trying to get parent of unknown role: %s", role.Name)
-	}
-	m.roles[role.Name] = role
-	return nil, nil
+func (f *fakeInstanceData) GetSuperUserDB() (*sql.DB, error) {
+	return f.db, nil
 }
 
 var _ = Describe("Role synchronizer tests", func() {
-	roleSynchronizer := RoleSynchronizer{
-		instance: postgres.NewInstance().WithNamespace("myPod"),
-	}
+	var (
+		db               *sql.DB
+		mock             sqlmock.Sqlmock
+		err              error
+		roleSynchronizer RoleSynchronizer
+	)
+
+	BeforeEach(func() {
+		db, mock, err = sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+		Expect(err).ToNot(HaveOccurred())
+		DeferCleanup(func() {
+			Expect(mock.ExpectationsWereMet()).To(Succeed())
+		})
+
+		testDate := time.Date(2023, 4, 4, 0, 0, 0, 0, time.UTC)
+
+		rows := sqlmock.NewRows([]string{
+			"rolname", "rolsuper", "rolinherit", "rolcreaterole", "rolcreatedb",
+			"rolcanlogin", "rolreplication", "rolconnlimit", "rolpassword", "rolvaliduntil", "rolbypassrls", "comment",
+			"xmin", "inroles",
+		}).
+			AddRow("postgres", true, false, true, true, true, false, -1, []byte("12345"),
+				nil, false, []byte("This is postgres user"), 11, []byte("{}")).
+			AddRow("streaming_replica", false, false, true, true, false, true, 10, []byte("54321"),
+				pgtype.Timestamp{
+					Valid:            true,
+					Time:             testDate,
+					InfinityModifier: pgtype.Finite,
+				}, false, []byte("This is streaming_replica user"), 22, []byte(`{"role1","role2"}`)).
+			AddRow("ignored_role", true, false, true, true, true, false, -1, []byte("12345"),
+				nil, false, []byte("This is a custom role in the DB"), 11, []byte("{}")).
+			AddRow("role_to_update", true, true, false, false, false, false, -1, []byte("12345"),
+				nil, false, []byte("This is a role to test with"), 11, []byte("{}"))
+		expectedSelStmt := `SELECT rolname, rolsuper, rolinherit, rolcreaterole, rolcreatedb, 
+				rolcanlogin, rolreplication, rolconnlimit, rolpassword, rolvaliduntil, rolbypassrls,
+			 pg_catalog.shobj_description(auth.oid, 'pg_authid') as comment, auth.xmin,
+			 mem.inroles
+	 FROM pg_catalog.pg_authid as auth
+	 LEFT JOIN (
+		 SELECT array_agg(pg_get_userbyid(roleid)) as inroles, member
+		 FROM pg_auth_members GROUP BY member
+	 ) mem ON member = oid
+	 WHERE rolname not like 'pg\_%'`
+		mock.ExpectQuery(expectedSelStmt).WillReturnRows(rows)
+
+		roleSynchronizer = RoleSynchronizer{
+			instance: &fakeInstanceData{
+				Instance: postgres.NewInstance().WithNamespace("myPod"),
+				db:       db,
+			},
+		}
+	})
 
 	When("role configurations are realizable", func() {
 		It("it will Create ensure:present roles in spec missing from DB", func(ctx context.Context) {
+			prm := NewPostgresRoleManager(db)
+
+			mock.ExpectExec("CREATE ROLE \"foo_bar\" NOBYPASSRLS NOCREATEDB NOCREATEROLE INHERIT " +
+				"NOLOGIN NOREPLICATION NOSUPERUSER CONNECTION LIMIT 0").
+				WillReturnResult(sqlmock.NewResult(11, 1))
 			managedConf := apiv1.ManagedConfiguration{
 				Roles: []apiv1.RoleConfiguration{
-					{
-						Name:   "edb_test",
-						Ensure: apiv1.EnsurePresent,
-					},
 					{
 						Name:   "foo_bar",
 						Ensure: apiv1.EnsurePresent,
 					},
 				},
 			}
-			rm := mockRoleManager{
-				roles: map[string]DatabaseRole{
-					"postgres": {
-						Name:      "postgres",
-						Superuser: true,
-					},
-				},
-			}
-			_, _, err := roleSynchronizer.synchronizeRoles(ctx, &rm, &managedConf, map[string]apiv1.PasswordState{})
+			rows := mock.NewRows([]string{"xmin"}).AddRow("12")
+			lastTransactionQuery := "SELECT xmin FROM pg_catalog.pg_authid WHERE rolname = $1"
+			mock.ExpectQuery(lastTransactionQuery).WithArgs("foo_bar").WillReturnRows(rows)
+			passwordState, rolesWithErrors, err := roleSynchronizer.synchronizeRoles(ctx, prm, &managedConf,
+				map[string]apiv1.PasswordState{})
 			Expect(err).ShouldNot(HaveOccurred())
-			Expect(rm.callHistory).To(ConsistOf(
-				[]funcCall{
-					{"list", ""},
-					{"create", "edb_test"},
-					{"create", "foo_bar"},
+			Expect(rolesWithErrors).To(BeEmpty())
+			Expect(passwordState).To(BeEquivalentTo(map[string]apiv1.PasswordState{
+				"foo_bar": {
+					TransactionID:         12,
+					SecretResourceVersion: "",
 				},
-			))
-			Expect(rm.callHistory).To(ConsistOf(
-				funcCall{"list", ""},
-				funcCall{"create", "edb_test"},
-				funcCall{"create", "foo_bar"},
-			))
+			}))
 		})
 
 		It("it will ignore ensure:absent roles in spec missing from DB", func(ctx context.Context) {
@@ -282,313 +240,228 @@ var _ = Describe("Role synchronizer tests", func() {
 					},
 				},
 			}
-			rm := mockRoleManager{
-				roles: map[string]DatabaseRole{
-					"postgres": {
-						Name:      "postgres",
-						Superuser: true,
-					},
-				},
-			}
+			prm := NewPostgresRoleManager(db)
 
-			_, _, err := roleSynchronizer.synchronizeRoles(ctx, &rm, &managedConf, map[string]apiv1.PasswordState{})
+			_, _, err := roleSynchronizer.synchronizeRoles(ctx, prm, &managedConf, map[string]apiv1.PasswordState{})
 			Expect(err).ShouldNot(HaveOccurred())
-			Expect(rm.callHistory).To(ConsistOf(funcCall{"list", ""}))
 		})
 
-		It("it will ignore DB roles that are not in spec", func(ctx context.Context) {
+		It("it will call the necessary grants to update membership", func(ctx context.Context) {
 			managedConf := apiv1.ManagedConfiguration{
 				Roles: []apiv1.RoleConfiguration{
 					{
-						Name:   "edb_test",
-						Ensure: apiv1.EnsureAbsent,
-					},
-				},
-			}
-			rm := mockRoleManager{
-				roles: map[string]DatabaseRole{
-					"postgres": {
-						Name:      "postgres",
+						Name:      "role_to_update",
 						Superuser: true,
-					},
-					"ignorezMoi": {
-						Name:      "ignorezMoi",
-						Superuser: true,
-					},
-				},
-			}
-			_, _, err := roleSynchronizer.synchronizeRoles(ctx, &rm, &managedConf, map[string]apiv1.PasswordState{})
-			Expect(err).ShouldNot(HaveOccurred())
-			Expect(rm.callHistory).To(ConsistOf(funcCall{"list", ""}))
-		})
-
-		It("it will call the updateMembership method", func(ctx context.Context) {
-			trueValue := true
-			managedConf := apiv1.ManagedConfiguration{
-				Roles: []apiv1.RoleConfiguration{
-					{
-						Name:      "edb_test",
-						Superuser: true,
-						Inherit:   &trueValue,
+						Inherit:   ptr.To(true),
 						InRoles: []string{
 							"role1",
 							"role2",
 						},
+						Comment:         "This is a role to test with",
+						ConnectionLimit: -1,
 					},
 				},
 			}
-			rm := mockRoleManager{
-				roles: map[string]DatabaseRole{
-					"edb_test": {
-						Name:      "edb_test",
-						Superuser: true,
-						Inherit:   true,
-					},
-				},
+			mock.ExpectQuery(expectedMembershipStmt).WithArgs("role_to_update").WillReturnError(sql.ErrNoRows)
+			mock.ExpectBegin()
+			expectedMembershipExecs := []string{
+				`GRANT "role1" TO "role_to_update"`,
+				`GRANT "role2" TO "role_to_update"`,
 			}
-			_, _, err := roleSynchronizer.synchronizeRoles(ctx, &rm, &managedConf, map[string]apiv1.PasswordState{})
+
+			for _, ex := range expectedMembershipExecs {
+				mock.ExpectExec(ex).
+					WillReturnResult(sqlmock.NewResult(2, 3))
+			}
+
+			mock.ExpectCommit()
+
+			prm := NewPostgresRoleManager(db)
+			_, rolesWithErrors, err := roleSynchronizer.synchronizeRoles(ctx, prm, &managedConf, map[string]apiv1.PasswordState{
+				"role_to_update": {
+					TransactionID: 11, // defined in the mock query to the DB above
+				},
+			})
 			Expect(err).ShouldNot(HaveOccurred())
-			Expect(rm.callHistory).To(ConsistOf(funcCall{"list", ""},
-				funcCall{"getParentRoles", "edb_test"},
-				funcCall{"updateMembership", "edb_test"}))
+			Expect(rolesWithErrors).To(BeEmpty())
 		})
 
 		It("it will call the updateComment method", func(ctx context.Context) {
-			trueValue := true
 			managedConf := apiv1.ManagedConfiguration{
 				Roles: []apiv1.RoleConfiguration{
 					{
-						Name:      "edb_test",
-						Superuser: true,
-						Inherit:   &trueValue,
-						Comment:   "my comment",
+						Name:            "role_to_update",
+						Superuser:       true,
+						Inherit:         ptr.To(true),
+						Comment:         "my comment",
+						ConnectionLimit: -1,
 					},
 				},
 			}
-			rm := mockRoleManager{
-				roles: map[string]DatabaseRole{
-					"edb_test": {
-						Name:      "edb_test",
-						Superuser: true,
-						Inherit:   true,
-						Comment:   "my tailor is rich",
-					},
+			wantedRoleCommentStmt := fmt.Sprintf(
+				wantedRoleCommentTpl,
+				managedConf.Roles[0].Name, pq.QuoteLiteral(managedConf.Roles[0].Comment))
+			mock.ExpectExec(wantedRoleCommentStmt).WillReturnResult(sqlmock.NewResult(2, 3))
+			prm := NewPostgresRoleManager(db)
+			_, _, err := roleSynchronizer.synchronizeRoles(ctx, prm, &managedConf, map[string]apiv1.PasswordState{
+				"role_to_update": {
+					TransactionID: 11, // defined in the mock query to the DB above
 				},
-			}
-			_, _, err := roleSynchronizer.synchronizeRoles(ctx, &rm, &managedConf, map[string]apiv1.PasswordState{})
+			})
 			Expect(err).ShouldNot(HaveOccurred())
-			Expect(rm.callHistory).To(ConsistOf(funcCall{"list", ""},
-				funcCall{"updateComment", "edb_test"}))
 		})
 
 		It("it will no-op if the roles are reconciled", func(ctx context.Context) {
-			trueValue := true
 			managedConf := apiv1.ManagedConfiguration{
 				Roles: []apiv1.RoleConfiguration{
 					{
-						Name:      "edb_test",
-						Superuser: true,
-						Inherit:   &trueValue,
+						Name:            "role_to_update",
+						Superuser:       true,
+						Inherit:         ptr.To(true),
+						Comment:         "This is a role to test with",
+						ConnectionLimit: -1,
 					},
 				},
 			}
-			rm := mockRoleManager{
-				roles: map[string]DatabaseRole{
-					"edb_test": {
-						Name:      "edb_test",
-						Superuser: true,
-						Inherit:   true,
-					},
+			prm := NewPostgresRoleManager(db)
+			_, _, err := roleSynchronizer.synchronizeRoles(ctx, prm, &managedConf, map[string]apiv1.PasswordState{
+				"role_to_update": {
+					TransactionID: 11, // defined in the mock query to the DB above
 				},
-			}
-			_, _, err := roleSynchronizer.synchronizeRoles(ctx, &rm, &managedConf, map[string]apiv1.PasswordState{})
+			})
 			Expect(err).ShouldNot(HaveOccurred())
-			Expect(rm.callHistory).To(ConsistOf(
-				funcCall{"list", ""}))
 		})
 
 		It("it will Delete ensure:absent roles that are in the DB", func(ctx context.Context) {
 			managedConf := apiv1.ManagedConfiguration{
 				Roles: []apiv1.RoleConfiguration{
 					{
-						Name:   "edb_test",
+						Name:   "role_to_update",
 						Ensure: apiv1.EnsureAbsent,
 					},
 				},
 			}
-			rm := mockRoleManager{
-				roles: map[string]DatabaseRole{
-					"postgres": {
-						Name:      "postgres",
-						Superuser: true,
-					},
-					"edb_test": {
-						Name:      "edb_test",
-						Superuser: true,
-					},
+			roleDeletionStmt := fmt.Sprintf("DROP ROLE \"%s\"", "role_to_update")
+			mock.ExpectExec(roleDeletionStmt).WillReturnResult(sqlmock.NewResult(2, 3))
+			prm := NewPostgresRoleManager(db)
+			_, _, err := roleSynchronizer.synchronizeRoles(ctx, prm, &managedConf, map[string]apiv1.PasswordState{
+				"role_to_update": {
+					TransactionID: 11, // defined in the mock query to the DB above
 				},
-			}
-			_, _, err := roleSynchronizer.synchronizeRoles(ctx, &rm, &managedConf, map[string]apiv1.PasswordState{})
+			})
 			Expect(err).ShouldNot(HaveOccurred())
-			Expect(rm.callHistory).To(ConsistOf(
-				funcCall{"list", ""},
-				funcCall{"delete", "edb_test"},
-			))
 		})
 
 		It("it will Update ensure:present roles that are in the DB but have different fields", func(ctx context.Context) {
 			managedConf := apiv1.ManagedConfiguration{
 				Roles: []apiv1.RoleConfiguration{
 					{
-						Name:      "edb_test",
-						Ensure:    apiv1.EnsurePresent,
-						CreateDB:  true,
-						BypassRLS: true,
+						Name:            "role_to_update",
+						Superuser:       false,
+						Inherit:         ptr.To(false),
+						Comment:         "This is a role to test with",
+						BypassRLS:       true,
+						CreateRole:      true,
+						Login:           true,
+						ConnectionLimit: 2,
 					},
 				},
 			}
-			rm := mockRoleManager{
-				roles: map[string]DatabaseRole{
-					"postgres": {
-						Name:      "postgres",
-						Superuser: true,
+			alterStmt := fmt.Sprintf(
+				"ALTER ROLE \"%s\" BYPASSRLS NOCREATEDB CREATEROLE NOINHERIT LOGIN NOREPLICATION NOSUPERUSER CONNECTION LIMIT 2 ",
+				"role_to_update")
+			mock.ExpectExec(alterStmt).WillReturnResult(sqlmock.NewResult(2, 3))
+			rows := mock.NewRows([]string{"xmin"}).AddRow("12")
+			lastTransactionQuery := "SELECT xmin FROM pg_catalog.pg_authid WHERE rolname = $1"
+			mock.ExpectQuery(lastTransactionQuery).WithArgs("role_to_update").WillReturnRows(rows)
+			prm := NewPostgresRoleManager(db)
+			passwordState, rolesWithErrors, err := roleSynchronizer.synchronizeRoles(ctx, prm, &managedConf,
+				map[string]apiv1.PasswordState{
+					"role_to_update": {
+						TransactionID: 11, // defined in the mock query to the DB above
 					},
-					"edb_test": {
-						Name:      "edb_test",
-						Superuser: true,
-					},
-				},
-			}
-			_, _, err := roleSynchronizer.synchronizeRoles(ctx, &rm, &managedConf, map[string]apiv1.PasswordState{})
+				})
 			Expect(err).ShouldNot(HaveOccurred())
-			Expect(rm.callHistory).To(ConsistOf(
-				funcCall{"list", ""},
-				funcCall{"update", "edb_test"},
-			))
+			Expect(rolesWithErrors).To(BeEmpty())
+			Expect(passwordState).To(BeEquivalentTo(map[string]apiv1.PasswordState{
+				"role_to_update": {
+					TransactionID:         12,
+					SecretResourceVersion: "",
+				},
+			}))
 		})
 	})
 
 	When("role configurations are unrealizable", func() {
 		It("it will record that updateMembership could not succeed", func(ctx context.Context) {
-			trueValue := true
 			managedConf := apiv1.ManagedConfiguration{
 				Roles: []apiv1.RoleConfiguration{
 					{
-						Name:      "edb_test",
+						Name:      "role_to_update",
 						Superuser: true,
-						Inherit:   &trueValue,
+						Inherit:   ptr.To(true),
 						InRoles: []string{
 							"role1",
 							"role2",
 						},
+						Comment:         "This is a role to test with",
+						ConnectionLimit: -1,
 					},
 				},
 			}
-			rm := mockRoleManagerWithError{
-				roles: map[string]DatabaseRole{
-					"edb_test": {
-						Name:      "edb_test",
-						Superuser: true,
-						Inherit:   true,
-					},
-				},
+
+			mock.ExpectQuery(expectedMembershipStmt).WithArgs("role_to_update").WillReturnError(sql.ErrNoRows)
+			mock.ExpectBegin()
+
+			mock.ExpectExec(`GRANT "role1" TO "role_to_update"`).
+				WillReturnResult(sqlmock.NewResult(2, 3))
+
+			postgresExpectedError := pgconn.PgError{
+				Code:    "0LP01", // 0LP01 -> invalid_grant_operation
+				Message: "unknown role 'role2'",
 			}
-			_, unrealizable, err := roleSynchronizer.synchronizeRoles(ctx, &rm, &managedConf, map[string]apiv1.PasswordState{})
+			mock.ExpectExec(`GRANT "role2" TO "role_to_update"`).
+				WillReturnError(&postgresExpectedError)
+
+			mock.ExpectRollback()
+
+			prm := NewPostgresRoleManager(db)
+			_, unrealizable, err := roleSynchronizer.synchronizeRoles(ctx, prm, &managedConf, map[string]apiv1.PasswordState{
+				"role_to_update": {
+					TransactionID: 11, // defined in the mock query to the DB above
+				},
+			})
+
 			Expect(err).ShouldNot(HaveOccurred())
-			Expect(rm.callHistory).To(ConsistOf(funcCall{"list", ""},
-				funcCall{"getParentRoles", "edb_test"},
-				funcCall{"updateMembership", "edb_test"}))
 			Expect(unrealizable).To(HaveLen(1))
-			Expect(unrealizable["edb_test"]).To(HaveLen(1))
-			Expect(unrealizable["edb_test"][0]).To(BeEquivalentTo(
-				"could not perform UPDATE_MEMBERSHIPS on role edb_test: unknown role 'blah'"))
+			Expect(unrealizable["role_to_update"]).To(HaveLen(1))
+			Expect(unrealizable["role_to_update"][0]).To(BeEquivalentTo(
+				"could not perform UPDATE_MEMBERSHIPS on role role_to_update: unknown role 'role2'"))
 		})
 
 		It("it will record that Delete could not succeed", func(ctx context.Context) {
 			managedConf := apiv1.ManagedConfiguration{
 				Roles: []apiv1.RoleConfiguration{
 					{
-						Name:   "edb_test",
+						Name:   "role_to_update",
 						Ensure: apiv1.EnsureAbsent,
 					},
 				},
 			}
-			rm := mockRoleManagerWithError{
-				roles: map[string]DatabaseRole{
-					"postgres": {
-						Name:      "postgres",
-						Superuser: true,
-					},
-					"edb_test": {
-						Name:      "edb_test",
-						Superuser: true,
-					},
-				},
+			postgresExpectedError := pgconn.PgError{
+				Code:   "2BP01", // 2BP01 -> dependent_objects_still_exist
+				Detail: "owner of database edbDatabase",
 			}
-			_, unrealizable, err := roleSynchronizer.synchronizeRoles(ctx, &rm, &managedConf, map[string]apiv1.PasswordState{})
-			Expect(err).ShouldNot(HaveOccurred())
-			Expect(rm.callHistory).To(ConsistOf(
-				funcCall{"list", ""},
-				funcCall{"delete", "edb_test"},
-			))
-			Expect(unrealizable).To(HaveLen(1))
-			Expect(unrealizable["edb_test"]).To(HaveLen(1))
-			Expect(unrealizable["edb_test"][0]).To(BeEquivalentTo(
-				"could not perform DELETE on role edb_test: owner of database edbDatabase"))
-		})
 
-		It("it will continue the synchronization even if it finds errors", func(ctx context.Context) {
-			trueValue := true
-			managedConf := apiv1.ManagedConfiguration{
-				Roles: []apiv1.RoleConfiguration{
-					{
-						Name:   "edb_test",
-						Ensure: apiv1.EnsureAbsent,
-					},
-					{
-						Name:      "another_test",
-						Ensure:    apiv1.EnsurePresent,
-						Superuser: true,
-						Inherit:   &trueValue,
-						InRoles: []string{
-							"role1",
-							"role2",
-						},
-					},
-				},
-			}
-			rm := mockRoleManagerWithError{
-				roles: map[string]DatabaseRole{
-					"postgres": {
-						Name:      "postgres",
-						Superuser: true,
-					},
-					"edb_test": {
-						Name:      "edb_test",
-						Superuser: true,
-					},
-					"another_test": {
-						Name:      "another_test",
-						Superuser: true,
-						Inherit:   true,
-					},
-				},
-			}
-			_, unrealizable, err := roleSynchronizer.synchronizeRoles(ctx, &rm, &managedConf, map[string]apiv1.PasswordState{})
+			roleDeletionStmt := fmt.Sprintf("DROP ROLE \"%s\"", "role_to_update")
+			mock.ExpectExec(roleDeletionStmt).WillReturnError(&postgresExpectedError)
+			prm := NewPostgresRoleManager(db)
+			_, unrealizable, err := roleSynchronizer.synchronizeRoles(ctx, prm, &managedConf, map[string]apiv1.PasswordState{})
 			Expect(err).ShouldNot(HaveOccurred())
-			Expect(rm.callHistory).To(ConsistOf(
-				funcCall{"list", ""},
-				funcCall{"delete", "edb_test"},
-				funcCall{"getParentRoles", "another_test"},
-				funcCall{"updateMembership", "another_test"},
-			))
-			Expect(unrealizable).To(HaveLen(2))
-			Expect(unrealizable["edb_test"]).To(HaveLen(1))
-			Expect(unrealizable["edb_test"][0]).To(BeEquivalentTo(
-				"could not perform DELETE on role edb_test: owner of database edbDatabase"))
-			Expect(unrealizable["another_test"]).To(HaveLen(1))
-			Expect(unrealizable["another_test"][0]).To(BeEquivalentTo(
-				"could not perform UPDATE_MEMBERSHIPS on role another_test: unknown role 'blah'"))
+			Expect(unrealizable).To(HaveLen(1))
+			Expect(unrealizable["role_to_update"]).To(HaveLen(1))
+			Expect(unrealizable["role_to_update"][0]).To(BeEquivalentTo(
+				"could not perform DELETE on role role_to_update: owner of database edbDatabase"))
 		})
 	})
 })


### PR DESCRIPTION
- Use an instance interface rather than a `postgres.Instance` in the
  Reconcile, to make it testable
- Rewrite the Postgres-facing functions to take a `sql.DB` parameter
- Discard the custom mocks and use sqlmock for unit tests
- Do proper error propagation on unexpected errors when
  reconciling with the DB

Closes #5957  
