### PR TITLE
fix(webhook): validate the number of `synchronous` replicas

### DIFF
--- a/api/v1/cluster_webhook.go
+++ b/api/v1/cluster_webhook.go
@@ -1088,8 +1088,8 @@ func (r *Cluster) validateSynchronousReplicaConfiguration() field.ErrorList {
 		err := field.Invalid(
 			field.NewPath("spec", "postgresql", "synchronous"),
 			r.Spec.PostgresConfiguration.Synchronous,
-			"synchronous configuration incorrect - number of synchronous replicas must be less than the total "+
-				"number of instances and user specified standbys",
+			"Invalid synchronous configuration: the number of synchronous replicas must be less than the "+
+				"total number of instances and the provided standby names.",
 		)
 		result = append(result, err)
 	}

--- a/api/v1/cluster_webhook.go
+++ b/api/v1/cluster_webhook.go
@@ -356,6 +356,7 @@ func (r *Cluster) Validate() (allErrs field.ErrorList) {
 		r.validateBackupConfiguration,
 		r.validateRetentionPolicy,
 		r.validateConfiguration,
+		r.validateSynchronousReplicaConfiguration,
 		r.validateLDAP,
 		r.validateReplicationSlots,
 		r.validateEnv,
@@ -1069,6 +1070,21 @@ func (r *Cluster) validateResources() field.ErrorList {
 				"Ephemeral storage request is greater than the limit",
 			))
 		}
+	}
+
+	return result
+}
+
+func (r *Cluster) validateSynchronousReplicaConfiguration() field.ErrorList {
+	var result field.ErrorList
+
+	if r.Spec.Instances <= 1 && r.Spec.PostgresConfiguration.Synchronous != nil {
+		err := field.Invalid(
+			field.NewPath("spec", "postgresql", "synchronous"),
+			r.Spec.PostgresConfiguration.Synchronous,
+			"synchronous configuration is not allowed when instances is set to 1 or less",
+		)
+		result = append(result, err)
 	}
 
 	return result

--- a/api/v1/cluster_webhook_test.go
+++ b/api/v1/cluster_webhook_test.go
@@ -1940,6 +1940,48 @@ var _ = Describe("Number of synchronous replicas", func() {
 	})
 })
 
+var _ = Describe("validateSynchronousReplicaConfiguration", func() {
+	It("returns an error when instances is 1 and synchronous configuration is set", func() {
+		cluster := &Cluster{
+			Spec: ClusterSpec{
+				Instances: 1,
+				PostgresConfiguration: PostgresConfiguration{
+					Synchronous: &SynchronousReplicaConfiguration{},
+				},
+			},
+		}
+		errors := cluster.validateSynchronousReplicaConfiguration()
+		Expect(errors).To(HaveLen(1))
+		Expect(errors[0].Detail).To(Equal("synchronous configuration is not allowed when instances is set to 1"))
+	})
+
+	It("returns no error when instances is greater than 1 and synchronous configuration is set", func() {
+		cluster := &Cluster{
+			Spec: ClusterSpec{
+				Instances: 2,
+				PostgresConfiguration: PostgresConfiguration{
+					Synchronous: &SynchronousReplicaConfiguration{},
+				},
+			},
+		}
+		errors := cluster.validateSynchronousReplicaConfiguration()
+		Expect(errors).To(BeEmpty())
+	})
+
+	It("returns no error when instances is 1 and synchronous configuration is not set", func() {
+		cluster := &Cluster{
+			Spec: ClusterSpec{
+				Instances: 1,
+				PostgresConfiguration: PostgresConfiguration{
+					Synchronous: nil,
+				},
+			},
+		}
+		errors := cluster.validateSynchronousReplicaConfiguration()
+		Expect(errors).To(BeEmpty())
+	})
+})
+
 var _ = Describe("storage configuration validation", func() {
 	It("complains if the size is being reduced", func() {
 		clusterOld := Cluster{

--- a/api/v1/cluster_webhook_test.go
+++ b/api/v1/cluster_webhook_test.go
@@ -1969,8 +1969,8 @@ var _ = Describe("validateSynchronousReplicaConfiguration", func() {
 		errors := cluster.validateSynchronousReplicaConfiguration()
 		Expect(errors).To(HaveLen(1))
 		Expect(errors[0].Detail).To(
-			Equal("synchronous configuration incorrect - number of synchronous replicas must be less than the " +
-				"total number of instances and user specified standbys"))
+			Equal("Invalid synchronous configuration: the number of synchronous replicas must be less than the " +
+				"total number of instances and the provided standby names."))
 	})
 
 	It("returns an error when number of synchronous replicas is equal to total instances and standbys", func() {
@@ -1988,8 +1988,8 @@ var _ = Describe("validateSynchronousReplicaConfiguration", func() {
 		}
 		errors := cluster.validateSynchronousReplicaConfiguration()
 		Expect(errors).To(HaveLen(1))
-		Expect(errors[0].Detail).To(Equal("synchronous configuration incorrect - number of synchronous replicas " +
-			"must be less than the total number of instances and user specified standbys"))
+		Expect(errors[0].Detail).To(Equal("Invalid synchronous configuration: the number of synchronous replicas " +
+			"must be less than the total number of instances and the provided standby names."))
 	})
 
 	It("returns no error when number of synchronous replicas is less than total instances and standbys", func() {


### PR DESCRIPTION
Closes #5964 


## Release Notes

Fixed a bug where the user could specify one or fewer instances along with the `synchronous` stanza. When specified together, these parameters would generate an incorrect replica configuration. 

## Note for the reviewers

While this could have been done with kubebuilder rule, I opted for the code solution given that it is easy to unit-test.
