### PR TITLE
chore(perf): Use controller-runtime pprof server

### DIFF
--- a/config/manager/env_override.yaml
+++ b/config/manager/env_override.yaml
@@ -20,3 +20,7 @@ spec:
         - --webhook-port=9443
         - --log-level=debug
         - --pprof-server=true
+        ports:
+          - containerPort: 6060
+            name: pprof
+            protocol: TCP

--- a/internal/cmd/manager/controller/controller.go
+++ b/internal/cmd/manager/controller/controller.go
@@ -19,10 +19,8 @@ package controller
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
-	"net/http/pprof"
 	"time"
 
 	"github.com/cloudnative-pg/machinery/pkg/log"
@@ -41,7 +39,6 @@ import (
 	"github.com/cloudnative-pg/cloudnative-pg/internal/controller"
 	schemeBuilder "github.com/cloudnative-pg/cloudnative-pg/internal/scheme"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/certs"
-	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres/webserver"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/multicache"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/versions"
@@ -101,13 +98,13 @@ func RunController(
 	conf *configuration.Data,
 ) error {
 	ctx := context.Background()
-
+	pprofAddress := ""
 	setupLog.Info("Starting CloudNativePG Operator",
 		"version", versions.Version,
 		"build", versions.Info)
 
 	if pprofDebug {
-		startPprofDebugServer(ctx)
+		pprofAddress = "0.0.0.0:6060"
 	}
 
 	managerOptions := ctrl.Options{
@@ -123,6 +120,7 @@ func RunController(
 			Port:    port,
 			CertDir: defaultWebhookCertDir,
 		}),
+		PprofBindAddress: pprofAddress,
 		// LeaderElectionReleaseOnCancel defines if the leader should step down voluntarily
 		// when the Manager ends. This requires the binary to immediately end when the
 		// Manager is stopped, otherwise, this setting is unsafe. Setting this significantly
@@ -462,41 +460,4 @@ func readSecret(
 	}
 
 	return data, nil
-}
-
-// startPprofDebugServer exposes pprof debug server if the pprof-server env variable is set to true
-func startPprofDebugServer(ctx context.Context) {
-	mux := http.NewServeMux()
-	mux.HandleFunc("/debug/pprof/", pprof.Index)
-	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
-	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
-	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
-	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
-
-	pprofServer := http.Server{
-		Addr:              "0.0.0.0:6060",
-		Handler:           mux,
-		ReadTimeout:       webserver.DefaultReadTimeout,
-		ReadHeaderTimeout: webserver.DefaultReadHeaderTimeout,
-	}
-
-	setupLog.Info("Starting pprof HTTP server", "addr", pprofServer.Addr)
-
-	go func() {
-		go func() {
-			<-ctx.Done()
-
-			setupLog.Info("shutting down pprof HTTP server")
-			ctx, cancelFunc := context.WithTimeout(context.Background(), 5*time.Second)
-			defer cancelFunc()
-
-			if err := pprofServer.Shutdown(ctx); err != nil {
-				setupLog.Error(err, "Failed to shutdown pprof HTTP server")
-			}
-		}()
-
-		if err := pprofServer.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {
-			setupLog.Error(err, "Failed to start pprof HTTP server")
-		}
-	}()
 }

--- a/internal/cmd/manager/controller/controller.go
+++ b/internal/cmd/manager/controller/controller.go
@@ -98,14 +98,9 @@ func RunController(
 	conf *configuration.Data,
 ) error {
 	ctx := context.Background()
-	pprofAddress := ""
 	setupLog.Info("Starting CloudNativePG Operator",
 		"version", versions.Version,
 		"build", versions.Info)
-
-	if pprofDebug {
-		pprofAddress = "0.0.0.0:6060"
-	}
 
 	managerOptions := ctrl.Options{
 		Scheme: scheme,
@@ -120,7 +115,7 @@ func RunController(
 			Port:    port,
 			CertDir: defaultWebhookCertDir,
 		}),
-		PprofBindAddress: pprofAddress,
+		PprofBindAddress: getPprofServerAddress(pprofDebug),
 		// LeaderElectionReleaseOnCancel defines if the leader should step down voluntarily
 		// when the Manager ends. This requires the binary to immediately end when the
 		// Manager is stopped, otherwise, this setting is unsafe. Setting this significantly
@@ -460,4 +455,12 @@ func readSecret(
 	}
 
 	return data, nil
+}
+
+func getPprofServerAddress(enabled bool) string {
+	if enabled {
+		return "0.0.0.0:6060"
+	}
+
+	return ""
 }


### PR DESCRIPTION
The controller-runtime provides a pprof server that we can just enable, 
this use that capability and remove the pprof server we used to have.

Closes #5999 