### PR TITLE
fix(plugin): check for empty pod list in "cnpg psql"

### DIFF
--- a/internal/cmd/plugin/psql/psql.go
+++ b/internal/cmd/plugin/psql/psql.go
@@ -83,6 +83,11 @@ func NewCommand(
 		return nil, err
 	}
 
+	// Check if the pod list is empty
+	if len(pods.Items) == 0 {
+		return nil, fmt.Errorf("cluster does not exist or is not accessible")
+	}
+
 	kubectlPath, err := exec.LookPath(kubectlCommand)
 	if err != nil {
 		return nil, fmt.Errorf("while getting kubectl path: %w", err)


### PR DESCRIPTION
This patch adds a check for an empty pod list in NewCommand function and raises an error if no pods are found.

Closes #5913 