### PR TITLE
feat(plugin): allow "plugin" backup method in kubectl cnpg backup

### DIFF
--- a/internal/cmd/plugin/backup/cmd.go
+++ b/internal/cmd/plugin/backup/cmd.go
@@ -107,13 +107,15 @@ func NewCmd() *cobra.Command {
 				return fmt.Errorf("backup-method: %s is not supported by the backup command", backupMethod)
 			}
 
-			if backupMethod != "plugin" {
+			if backupMethod != string(apiv1.BackupMethodPlugin) {
 				if len(pluginName) > 0 {
-					return fmt.Errorf("plugin-name is allowed only when backup method in 'plugin'")
+					return fmt.Errorf("plugin-name is allowed only when backup method in %s",
+						apiv1.BackupMethodPlugin)
 				}
 
 				if len(pluginParameters) > 0 {
-					return fmt.Errorf("plugin-parameters is allowed only when backup method in 'plugin'")
+					return fmt.Errorf("plugin-parameters is allowed only when backup method in %s",
+						apiv1.BackupMethodPlugin)
 				}
 			}
 
@@ -208,13 +210,14 @@ func NewCmd() *cobra.Command {
 	)
 
 	backupSubcommand.Flags().StringVar(&pluginName, "plugin-name", "",
-		"Sets the name of the plugin that should take the backup. This option "+
+		"The name of the plugin that should take the backup. This option "+
 			"is allowed only when the backup method is set to 'plugin'",
 	)
 
 	backupSubcommand.Flags().VarP(&pluginParameters, "plugin-parameters", "",
 		"The set of plugin parameters that should be passed to the backup plugin "+
-			" i.e. param-one=value,param-two=value",
+			" i.e. param-one=value,param-two=value. This option "+
+			"is allowed only when the backup method is set to 'plugin'",
 	)
 
 	return backupSubcommand

--- a/internal/cmd/plugin/backup/cmd.go
+++ b/internal/cmd/plugin/backup/cmd.go
@@ -44,6 +44,8 @@ type backupCommandOptions struct {
 	online              *bool
 	immediateCheckpoint *bool
 	waitForArchive      *bool
+	pluginName          string
+	pluginParameters    pluginParameters
 }
 
 func (options backupCommandOptions) getOnlineConfiguration() *apiv1.OnlineConfiguration {
@@ -59,7 +61,8 @@ func (options backupCommandOptions) getOnlineConfiguration() *apiv1.OnlineConfig
 
 // NewCmd creates the new "backup" subcommand
 func NewCmd() *cobra.Command {
-	var backupName, backupTarget, backupMethod, online, immediateCheckpoint, waitForArchive string
+	var backupName, backupTarget, backupMethod, online, immediateCheckpoint, waitForArchive, pluginName string
+	var pluginParameters pluginParameters
 
 	backupSubcommand := &cobra.Command{
 		Use:     "backup [cluster]",
@@ -95,9 +98,20 @@ func NewCmd() *cobra.Command {
 				"",
 				string(apiv1.BackupMethodBarmanObjectStore),
 				string(apiv1.BackupMethodVolumeSnapshot),
+				string(apiv1.BackupMethodPlugin),
 			}
 			if !slices.Contains(allowedBackupMethods, backupMethod) {
 				return fmt.Errorf("backup-method: %s is not supported by the backup command", backupMethod)
+			}
+
+			if backupMethod != "plugin" {
+				if len(pluginName) > 0 {
+					return fmt.Errorf("plugin-name is allowed only when backup method in 'plugin'")
+				}
+
+				if len(pluginParameters) > 0 {
+					return fmt.Errorf("plugin-parameters is allowed only when backup method in 'plugin'")
+				}
 			}
 
 			var cluster apiv1.Cluster
@@ -137,6 +151,8 @@ func NewCmd() *cobra.Command {
 					online:              parsedOnline,
 					immediateCheckpoint: parsedImmediateCheckpoint,
 					waitForArchive:      parsedWaitForArchive,
+					pluginName:          pluginName,
+					pluginParameters:    pluginParameters,
 				})
 		},
 	}
@@ -162,7 +178,7 @@ func NewCmd() *cobra.Command {
 		"m",
 		"",
 		"If present, will override the backup method defined in backup resource, "+
-			"valid values are volumeSnapshot and barmanObjectStore.",
+			"valid values are volumeSnapshot, barmanObjectStore and plugin.",
 	)
 
 	const optionalAcceptedValues = "Optional. Accepted values: true|false|\"\"."
@@ -188,6 +204,16 @@ func NewCmd() *cobra.Command {
 			optionalAcceptedValues,
 	)
 
+	backupSubcommand.Flags().StringVar(&pluginName, "plugin-name", "",
+		"Set the name of the plugin that should take the backup. This option "+
+			"is allowed only when the backup method is set to 'plugin'",
+	)
+
+	backupSubcommand.Flags().VarP(&pluginParameters, "plugin-parameters", "",
+		"The set of plugin parameters that should be passed to the backup plugin "+
+			" i.e. param-one=value,param-two=value",
+	)
+
 	return backupSubcommand
 }
 
@@ -209,6 +235,13 @@ func createBackup(ctx context.Context, options backupCommandOptions) error {
 		},
 	}
 	utils.LabelClusterName(&backup.ObjectMeta, options.clusterName)
+
+	if len(options.pluginName) > 0 {
+		backup.Spec.PluginConfiguration = &apiv1.BackupPluginConfiguration{
+			Name:       options.pluginName,
+			Parameters: options.pluginParameters,
+		}
+	}
 
 	err := plugin.Client.Create(ctx, &backup)
 	if err == nil {

--- a/internal/cmd/plugin/backup/parameters.go
+++ b/internal/cmd/plugin/backup/parameters.go
@@ -1,0 +1,53 @@
+/*
+Copyright The CloudNativePG Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package backup
+
+import (
+	"strings"
+
+	"github.com/cloudnative-pg/machinery/pkg/stringset"
+)
+
+// pluginParameters is a set of parameters to be passed
+// to the plugin when taking a backup
+type pluginParameters map[string]string
+
+// String implements the pflag.Value interface
+func (e pluginParameters) String() string {
+	return strings.Join(stringset.FromKeys(e).ToList(), ",")
+}
+
+// Type implements the pflag.Value interface
+func (e pluginParameters) Type() string {
+	return "map[string]string"
+}
+
+// Set implements the pflag.Value interface
+func (e *pluginParameters) Set(val string) error {
+	entries := strings.Split(val, ",")
+	result := make(map[string]string, len(entries))
+	for _, entry := range entries {
+		if len(entry) == 0 {
+			continue
+		}
+
+		before, after, _ := strings.Cut(entry, "=")
+		result[before] = after
+	}
+	*e = result
+	return nil
+}

--- a/internal/cmd/plugin/backup/parameters_test.go
+++ b/internal/cmd/plugin/backup/parameters_test.go
@@ -1,0 +1,53 @@
+/*
+Copyright The CloudNativePG Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package backup
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("plugin parameters parsing", func() {
+	DescribeTable(
+		"plugin parameters and values table",
+		func(value string, expectedParams pluginParameters) {
+			var params pluginParameters
+			Expect(params.Set(value)).ToNot(HaveOccurred())
+			Expect(params).To(HaveLen(len(expectedParams)))
+			for k, v := range expectedParams {
+				Expect(params).To(HaveKeyWithValue(k, v))
+			}
+		},
+		Entry("empty value", "", nil),
+		Entry("singleton", "a=b", map[string]string{
+			"a": "b",
+		}),
+		Entry("singleton without value", "a", map[string]string{
+			"a": "",
+		}),
+		Entry("set", "a=b,c=d", map[string]string{
+			"a": "b",
+			"c": "d",
+		}),
+		Entry("set with elements without value", "a=b,c,d=,e=f", map[string]string{
+			"a": "b",
+			"c": "",
+			"d": "",
+			"e": "f",
+		}),
+	)
+})

--- a/internal/cmd/plugin/backup/suite_test.go
+++ b/internal/cmd/plugin/backup/suite_test.go
@@ -1,0 +1,30 @@
+/*
+Copyright The CloudNativePG Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package backup
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestCerts(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecs(t, "CNPG Backup subcommand tests")
+}


### PR DESCRIPTION
This patch adds the following features to The `kubectl cnpg backup` subcommand:

* the `plugin` backup method is now allowed

* a new `plugin-name` option allows the user to specify the plugin that should manage the backup

* a new `plugin-parameters` option allows the user to specify a set of parameters to be passed to the plugin while tacking a backup of a cluster.