### PR TITLE
feat: managed role should only grant role for missing in inRoles

### DIFF
--- a/internal/management/controller/roles/contract.go
+++ b/internal/management/controller/roles/contract.go
@@ -20,10 +20,10 @@ import (
 	"database/sql"
 	"reflect"
 
+	"github.com/cloudnative-pg/machinery/pkg/stringset"
 	"github.com/jackc/pgx/v5/pgtype"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
-	"github.com/cloudnative-pg/machinery/pkg/stringset"
 )
 
 // DatabaseRole represents the role information read from / written to the Database

--- a/internal/management/controller/roles/contract_test.go
+++ b/internal/management/controller/roles/contract_test.go
@@ -80,11 +80,29 @@ var _ = Describe("DatabaseRole implementation test", func() {
 				"Userrole2", "role1", "TestroleABC",
 			},
 		}
-		res := role.isInSameRolesAs(config)
+		res := role.isInRolesInDB(config)
 		Expect(res).To(BeTrue())
 	})
 
-	It("should return false when the in roles are not equal", func() {
+	It("should return true when the in roles in database is more than in spec", func() {
+		role := DatabaseRole{
+			Name:    "abc",
+			Inherit: true,
+			InRoles: []string{
+				"role1", "role2", "Userrole2", "TestroleABC",
+			},
+		}
+		config := apiv1.RoleConfiguration{
+			Name: "abc",
+			InRoles: []string{
+				"Userrole2", "role1", "TestroleABC",
+			},
+		}
+		res := role.isInRolesInDB(config)
+		Expect(res).To(BeTrue())
+	})
+
+	It("should return false when the in roles are not in database", func() {
 		role := DatabaseRole{
 			Name:    "abc",
 			Inherit: true,
@@ -98,7 +116,7 @@ var _ = Describe("DatabaseRole implementation test", func() {
 				"Userrole2", "role1x", "TestroleABC",
 			},
 		}
-		res := role.isInSameRolesAs(config)
+		res := role.isInRolesInDB(config)
 		Expect(res).To(BeFalse())
 	})
 

--- a/internal/management/controller/roles/roles.go
+++ b/internal/management/controller/roles/roles.go
@@ -156,7 +156,7 @@ func evaluateNextRoleActions(
 				RoleConfiguration: inSpec,
 			}
 			rolesByAction[roleSetComment] = append(rolesByAction[roleSetComment], internalRole)
-		case isInSpec && !role.isInSameRolesAs(inSpec):
+		case isInSpec && !role.isInRolesInDB(inSpec):
 			internalRole := roleConfigurationAdapter{
 				RoleConfiguration: inSpec,
 			}

--- a/internal/management/controller/roles/runnable_test.go
+++ b/internal/management/controller/roles/runnable_test.go
@@ -176,40 +176,6 @@ var _ = Describe("Role synchronizer tests", func() {
 			Expect(rolesWithErrors).To(BeEmpty())
 		})
 
-		It("it will call the necessary revokes to update membership", func(ctx context.Context) {
-			managedConf := apiv1.ManagedConfiguration{
-				Roles: []apiv1.RoleConfiguration{
-					{
-						Name:            "role_to_test2",
-						Superuser:       true,
-						Inherit:         ptr.To(true),
-						InRoles:         []string{},
-						Comment:         "This is a role to test with",
-						ConnectionLimit: -1,
-					},
-				},
-			}
-			rows := sqlmock.NewRows([]string{
-				"inroles",
-			}).
-				AddRow([]byte(`{"foo"}`))
-			mock.ExpectQuery(expectedMembershipStmt).WithArgs("role_to_test2").WillReturnRows(rows)
-			mock.ExpectBegin()
-
-			mock.ExpectExec(`REVOKE "foo" FROM "role_to_test2"`).
-				WillReturnResult(sqlmock.NewResult(2, 3))
-
-			mock.ExpectCommit()
-
-			_, rolesWithErrors, err := roleSynchronizer.synchronizeRoles(ctx, db, &managedConf, map[string]apiv1.PasswordState{
-				"role_to_test2": {
-					TransactionID: 11, // defined in the mock query to the DB above
-				},
-			})
-			Expect(err).ShouldNot(HaveOccurred())
-			Expect(rolesWithErrors).To(BeEmpty())
-		})
-
 		It("it will call the updateComment method", func(ctx context.Context) {
 			managedConf := apiv1.ManagedConfiguration{
 				Roles: []apiv1.RoleConfiguration{

--- a/tests/e2e/managed_roles_test.go
+++ b/tests/e2e/managed_roles_test.go
@@ -129,7 +129,7 @@ var _ = Describe("Managed roles tests", Label(tests.LabelSmoke, tests.LabelBasic
 				rolesInDB = strings.Split(strings.TrimSuffix(stdout, "\n"), ",")
 				slices.Sort(rolesInDB)
 				return rolesInDB
-			}, 30).Should(BeEquivalentTo(expectedRoles))
+			}, 30).Should(ContainElements(expectedRoles))
 		}
 
 		It("can create roles specified in the managed roles stanza", func() {
@@ -465,28 +465,6 @@ var _ = Describe("Managed roles tests", Label(tests.LabelSmoke, tests.LabelBasic
 					return len(cluster.Status.ManagedRolesStatus.CannotReconcile)
 				}, 30).Should(Equal(0))
 				assertInRoles(namespace, primaryPodInfo.Name, newUserName, []string{"postgres", username})
-			})
-
-			By("Remove parent role from InRole for role new_role and verify in database", func() {
-				cluster, err := env.GetCluster(namespace, clusterName)
-				Expect(err).ToNot(HaveOccurred())
-
-				updated := cluster.DeepCopy()
-				for i, r := range updated.Spec.Managed.Roles {
-					if r.Name == newUserName {
-						updated.Spec.Managed.Roles[i].InRoles = []string{
-							username,
-						}
-					}
-				}
-				err = env.Client.Patch(env.Ctx, updated, client.MergeFrom(cluster))
-				Expect(err).ToNot(HaveOccurred())
-				Eventually(func() int {
-					cluster, err := env.GetCluster(namespace, clusterName)
-					Expect(err).ToNot(HaveOccurred())
-					return len(cluster.Status.ManagedRolesStatus.CannotReconcile)
-				}, 30).Should(Equal(0))
-				assertInRoles(namespace, primaryPodInfo.Name, newUserName, []string{username})
 			})
 
 			By("Mock the error for unrealizable User and verify user in database", func() {


### PR DESCRIPTION
This match ensure that managed role only grant missing roles in database
for the user. If roles are missing in InRoles, managed role will not revoke the roles
from the declared user. This is for the changes in postgres 16
about [role enhancement](https://github.com/postgres/postgres/commit/e5b8a4c098ad6add39626a14475148872cd687e0)
When a non-super user Alice create a new role bob, Alice will be added as the member of
Bob.

Closes: #6024 

