### PR TITLE
fix(test): avoid checking permissions in cloud services

### DIFF
--- a/hack/install-config.yaml.template
+++ b/hack/install-config.yaml.template
@@ -31,3 +31,4 @@ platform:
 publish: External
 pullSecret: '${REDHAT_PULL}'
 sshKey: ${SSH_PUBLIC_KEY}
+credentialsMode: Mint


### PR DESCRIPTION
We set the cluster configuration of OpenShift to `credentialsMode: Mint`
to avoid checking the permissions when creating a new OpenShift instance.

Closes #6061 