### PR TITLE
fix(linter): prepare code for golangci-lint 1.62.0

### DIFF
--- a/pkg/reconciler/persistentvolumeclaim/calculator_test.go
+++ b/pkg/reconciler/persistentvolumeclaim/calculator_test.go
@@ -98,7 +98,8 @@ var _ = Describe("pvc role test", func() {
 				Size: "5Gi",
 			}))
 		Expect(role.GetSource(nil)).To(BeNil())
-		Expect(role.GetSource(&StorageSource{})).Error().Should(HaveOccurred())
+		_, err := role.GetSource(&StorageSource{})
+		Expect(err).Should(HaveOccurred())
 		Expect(role.GetSource(&storageSource)).To(BeEquivalentTo(&walSource))
 	})
 
@@ -151,7 +152,8 @@ var _ = Describe("pvc role test", func() {
 				Size: "5Gi",
 			}))
 		Expect(role.GetSource(nil)).To(BeNil())
-		Expect(role.GetSource(&storageSource2)).Error().Should(HaveOccurred())
+		_, err := role.GetSource(&storageSource2)
+		Expect(err).Should(HaveOccurred())
 		Expect(role.GetSource(&storageSource1)).To(BeEquivalentTo(&corev1.TypedLocalObjectReference{Name: "test"}))
 	})
 })

--- a/tests/e2e/asserts_test.go
+++ b/tests/e2e/asserts_test.go
@@ -916,7 +916,7 @@ func AssertReplicaModeCluster(
 		Eventually(func() error {
 			primaryReplicaCluster, err = env.GetClusterPrimary(namespace, replicaClusterName)
 			return err
-		}, 30, 3).Should(BeNil())
+		}, 30, 3).Should(Succeed())
 		AssertPgRecoveryMode(primaryReplicaCluster, true)
 	})
 
@@ -1704,7 +1704,7 @@ func AssertSuspendScheduleBackups(namespace, scheduledBackupName string) {
 				return err
 			}
 			return nil
-		}, 60, 5).Should(BeNil())
+		}, 60, 5).Should(Succeed())
 		scheduledBackupNamespacedName := types.NamespacedName{
 			Namespace: namespace,
 			Name:      scheduledBackupName,
@@ -1752,7 +1752,7 @@ func AssertSuspendScheduleBackups(namespace, scheduledBackupName string) {
 				return err
 			}
 			return nil
-		}, 60, 5).Should(BeNil())
+		}, 60, 5).Should(Succeed())
 		scheduledBackupNamespacedName := types.NamespacedName{
 			Namespace: namespace,
 			Name:      scheduledBackupName,
@@ -2203,7 +2203,7 @@ func OnlineResizePVC(namespace, clusterName string) {
 			Eventually(func() error {
 				_, _, err := testsUtils.RunUnchecked(cmd)
 				return err
-			}, 60, 5).Should(BeNil())
+			}, 60, 5).Should(Succeed())
 		}
 	})
 	By("verifying Cluster storage is expanded", func() {
@@ -2259,7 +2259,7 @@ func OfflineResizePVC(namespace, clusterName string, timeout int) {
 			Eventually(func() error {
 				_, _, err := testsUtils.RunUnchecked(cmd)
 				return err
-			}, 60, 5).Should(BeNil())
+			}, 60, 5).Should(Succeed())
 		}
 	})
 	By("deleting Pod and PVCs, first replicas then the primary", func() {
@@ -2484,7 +2484,7 @@ func CreateResourcesFromFileWithError(namespace, sampleFilePath string) error {
 func CreateResourceFromFile(namespace, sampleFilePath string) {
 	Eventually(func() error {
 		return CreateResourcesFromFileWithError(namespace, sampleFilePath)
-	}, RetryTimeout, PollingTime).Should(BeNil())
+	}, RetryTimeout, PollingTime).Should(Succeed())
 }
 
 // GetYAMLContent opens a .yaml of .template file and returns its content

--- a/tests/e2e/certificates_test.go
+++ b/tests/e2e/certificates_test.go
@@ -135,7 +135,7 @@ var _ = Describe("Certificates", func() {
 					return err
 				}
 				return nil
-			}, 60, 5).Should(BeNil())
+			}, 60, 5).Should(Succeed())
 
 			Eventually(func() (bool, error) {
 				certUpdateStatus := false
@@ -176,7 +176,7 @@ var _ = Describe("Certificates", func() {
 					return err
 				}
 				return nil
-			}, 60, 5).Should(BeNil())
+			}, 60, 5).Should(Succeed())
 
 			Eventually(func() (bool, error) {
 				cluster, err := env.GetCluster(namespace, clusterName)
@@ -212,7 +212,7 @@ var _ = Describe("Certificates", func() {
 						return err
 					}
 					return nil
-				}, 60, 5).Should(BeNil())
+				}, 60, 5).Should(Succeed())
 
 				Eventually(func() (bool, error) {
 					cluster, err := env.GetCluster(namespace, clusterName)

--- a/tests/e2e/logs_test.go
+++ b/tests/e2e/logs_test.go
@@ -86,7 +86,7 @@ var _ = Describe("JSON log output", Label(tests.LabelObservability), func() {
 						specs.PostgresContainerName, &commandTimeout, "psql", "-U", "postgres", "app", "-tAc",
 						errorTestQuery)
 					return queryError
-				}, RetryTimeout, PollingTime).ShouldNot(BeNil())
+				}, RetryTimeout, PollingTime).ShouldNot(Succeed())
 
 				// Eventually the error log line will be logged
 				Eventually(func(g Gomega) bool {
@@ -118,7 +118,7 @@ var _ = Describe("JSON log output", Label(tests.LabelObservability), func() {
 					*primaryPod, specs.PostgresContainerName,
 					&commandTimeout, "psql", "-U", "postgres", "app", "-tAc", errorTestQuery)
 				return queryError
-			}, RetryTimeout, PollingTime).ShouldNot(BeNil())
+			}, RetryTimeout, PollingTime).ShouldNot(Succeed())
 
 			// Expect the query to be eventually logged on the primary
 			Eventually(func() (bool, error) {

--- a/tests/e2e/managed_services_test.go
+++ b/tests/e2e/managed_services_test.go
@@ -82,7 +82,7 @@ var _ = Describe("Managed services tests", Label(tests.LabelSmoke, tests.LabelBa
 				g.Expect(err).ToNot(HaveOccurred())
 				cluster.Spec.Managed.Services.Additional = []apiv1.ManagedService{}
 				return env.Client.Update(ctx, cluster)
-			}, RetryTimeout, PollingTime).Should(BeNil())
+			}, RetryTimeout, PollingTime).Should(Succeed())
 
 			AssertClusterIsReady(namespace, clusterName, testTimeouts[utils.ManagedServices], env)
 			Eventually(func(g Gomega) {
@@ -128,7 +128,7 @@ var _ = Describe("Managed services tests", Label(tests.LabelSmoke, tests.LabelBa
 				g.Expect(err).ToNot(HaveOccurred())
 				cluster.Spec.Managed.Services.DisabledDefaultServices = []apiv1.ServiceSelectorType{}
 				return env.Client.Update(ctx, cluster)
-			}, RetryTimeout, PollingTime).Should(BeNil())
+			}, RetryTimeout, PollingTime).Should(Succeed())
 
 			AssertClusterIsReady(namespace, clusterName, testTimeouts[utils.ManagedServices], env)
 
@@ -189,7 +189,7 @@ var _ = Describe("Managed services tests", Label(tests.LabelSmoke, tests.LabelBa
 				g.Expect(err).ToNot(HaveOccurred())
 				cluster.Spec.Managed.Services.Additional[0].ServiceTemplate.ObjectMeta.Labels["new-label"] = "new"
 				return env.Client.Update(ctx, cluster)
-			}, RetryTimeout, PollingTime).Should(BeNil())
+			}, RetryTimeout, PollingTime).Should(Succeed())
 		})
 
 		By("expecting the service to be recreated", func() {

--- a/tests/e2e/replica_mode_cluster_test.go
+++ b/tests/e2e/replica_mode_cluster_test.go
@@ -188,7 +188,7 @@ var _ = Describe("Replica Mode", Label(tests.LabelReplication), func() {
 				Eventually(func() error {
 					clusterOnePrimary, err = env.GetClusterPrimary(namespace, clusterOneName)
 					return err
-				}, 30, 3).Should(BeNil())
+				}, 30, 3).Should(Succeed())
 				AssertPgRecoveryMode(clusterOnePrimary, true)
 			})
 
@@ -206,7 +206,7 @@ var _ = Describe("Replica Mode", Label(tests.LabelReplication), func() {
 				Eventually(func() error {
 					clusterTwoPrimary, err = env.GetClusterPrimary(namespace, clusterTwoName)
 					return err
-				}, 30, 3).Should(BeNil())
+				}, 30, 3).Should(Succeed())
 				AssertPgRecoveryMode(clusterTwoPrimary, false)
 			})
 

--- a/tests/e2e/rolling_update_test.go
+++ b/tests/e2e/rolling_update_test.go
@@ -118,7 +118,7 @@ var _ = Describe("Rolling updates", Label(tests.LabelPostgresConfiguration), fun
 
 			cluster.Spec.ImageName = updatedImageName
 			return env.Client.Update(env.Ctx, cluster)
-		}, RetryTimeout, PollingTime).Should(BeNil())
+		}, RetryTimeout, PollingTime).Should(Succeed())
 
 		// All the postgres containers should have the updated image
 		AssertPodsRunOnImage(namespace, clusterName, updatedImageName, cluster.Spec.Instances, timeout)
@@ -599,7 +599,7 @@ var _ = Describe("Rolling updates", Label(tests.LabelPostgresConfiguration), fun
 				// Wait until we really deleted it
 				Eventually(func() error {
 					return env.Client.Get(env.Ctx, ctrl.ObjectKey{Name: catalog.Name}, catalog)
-				}, 30).Should(MatchError(apierrs.IsNotFound, metav1.StatusReasonNotFound))
+				}, 30).Should(MatchError(apierrs.IsNotFound, string(metav1.StatusReasonNotFound)))
 			})
 			Context("Three Instances", func() {
 				const (

--- a/tests/e2e/storage_expansion_test.go
+++ b/tests/e2e/storage_expansion_test.go
@@ -98,7 +98,7 @@ var _ = Describe("Verify storage", Label(tests.LabelStorage), func() {
 						return err
 					}
 					return nil
-				}, 60, 5).Should(BeNil())
+				}, 60, 5).Should(Succeed())
 			})
 			OfflineResizePVC(namespace, clusterName, 600)
 		})

--- a/tests/e2e/syncreplicas_test.go
+++ b/tests/e2e/syncreplicas_test.go
@@ -109,7 +109,7 @@ var _ = Describe("Synchronous Replicas", Label(tests.LabelReplication), func() {
 
 					cluster.Spec.MaxSyncReplicas = 1
 					return env.Client.Update(env.Ctx, cluster)
-				}, RetryTimeout, 5).Should(BeNil())
+				}, RetryTimeout, 5).Should(Succeed())
 
 				// Scale the cluster down to 2 pods
 				_, _, err := utils.Run(fmt.Sprintf("kubectl scale --replicas=2 -n %v cluster/%v", namespace,
@@ -200,7 +200,7 @@ var _ = Describe("Synchronous Replicas", Label(tests.LabelReplication), func() {
 					cluster.Spec.PostgresConfiguration.Synchronous.MaxStandbyNamesFromCluster = ptr.To(1)
 					cluster.Spec.PostgresConfiguration.Synchronous.Number = 1
 					return env.Client.Update(env.Ctx, cluster)
-				}, RetryTimeout, 5).Should(BeNil())
+				}, RetryTimeout, 5).Should(Succeed())
 
 				getSyncReplicationCount(namespace, clusterName, "quorum", 1)
 				compareSynchronousStandbyNames(namespace, clusterName, "ANY 1")
@@ -212,7 +212,7 @@ var _ = Describe("Synchronous Replicas", Label(tests.LabelReplication), func() {
 					g.Expect(err).ToNot(HaveOccurred())
 					cluster.Spec.PostgresConfiguration.Synchronous.Method = apiv1.SynchronousReplicaConfigurationMethodFirst
 					return env.Client.Update(env.Ctx, cluster)
-				}, RetryTimeout, 5).Should(BeNil())
+				}, RetryTimeout, 5).Should(Succeed())
 
 				getSyncReplicationCount(namespace, clusterName, "sync", 1)
 				compareSynchronousStandbyNames(namespace, clusterName, "FIRST 1")
@@ -226,7 +226,7 @@ var _ = Describe("Synchronous Replicas", Label(tests.LabelReplication), func() {
 					cluster.Spec.PostgresConfiguration.Synchronous.StandbyNamesPre = []string{"preSyncReplica"}
 					cluster.Spec.PostgresConfiguration.Synchronous.StandbyNamesPost = []string{"postSyncReplica"}
 					return env.Client.Update(env.Ctx, cluster)
-				}, RetryTimeout, 5).Should(BeNil())
+				}, RetryTimeout, 5).Should(Succeed())
 				compareSynchronousStandbyNames(namespace, clusterName, "FIRST 1 (\"preSyncReplica\"")
 				compareSynchronousStandbyNames(namespace, clusterName, "\"postSyncReplica\")")
 			})

--- a/tests/utils/backup.go
+++ b/tests/utils/backup.go
@@ -46,7 +46,7 @@ func ExecuteBackup(
 			return fmt.Errorf("could not create backup.\nStdErr: %v\nError: %v", stderr, err)
 		}
 		return nil
-	}, RetryTimeout, PollingTime).Should(BeNil())
+	}, RetryTimeout, PollingTime).Should(Succeed())
 	backupNamespacedName := types.NamespacedName{
 		Namespace: namespace,
 		Name:      backupName,

--- a/tests/utils/environment.go
+++ b/tests/utils/environment.go
@@ -186,7 +186,7 @@ func (env TestingEnvironment) EventuallyExecCommand(
 			return err
 		}
 		return nil
-	}, RetryTimeout, PollingTime).Should(BeNil())
+	}, RetryTimeout, PollingTime).Should(Succeed())
 	return stdOut, stdErr, err
 }
 

--- a/tests/utils/pod.go
+++ b/tests/utils/pod.go
@@ -266,11 +266,8 @@ func (env TestingEnvironment) EventuallyExecQueryInInstancePod(
 				Namespace: podLocator.Namespace,
 				PodName:   podLocator.PodName,
 			}, dbname, query)
-		if err != nil {
-			return err
-		}
-		return nil
-	}, retryTimeout, pollingTime).Should(BeNil())
+		return err
+	}, retryTimeout, pollingTime).Should(Succeed())
 
 	return stdOut, stdErr, err
 }


### PR DESCRIPTION
The new linter found new stuff that should have fix before merging the new version into the checks.

One of the main changes is ginkgo-linter that now recommends use Succeed() instead of BeNil()