### PR TITLE
fix(tests): update the way we check the EKS versions

### DIFF
--- a/.github/workflows/k8s-versions-check.yml
+++ b/.github/workflows/k8s-versions-check.yml
@@ -42,8 +42,8 @@ jobs:
         # There is no command to get EKS k8s versions, we have to parse the documentation
         name: Get updated EKS versions
         run: |
-          DOC_URL="https://raw.githubusercontent.com/awsdocs/amazon-eks-user-guide/main/doc_source/kubernetes-versions.md"
-          curl --silent "${DOC_URL}" | grep -E '^\+ `[0-9]\.[0-9]{2}`$' | sed -e 's/[\ +`]//g' | \
+          DOC_URL="https://raw.githubusercontent.com/awsdocs/amazon-eks-user-guide/mainline/latest/ug/clusters/kubernetes-versions-standard.adoc"
+          curl --silent "${DOC_URL}" | sed -e 's/.*`Kubernetes` \([0-9].[0-9][0-9]\).*/\1/;/^[0-9]\./!d' | uniq | \
             awk -vv=$MINIMAL_K8S '$0>=v {print $0}' | \
             jq -Rn '[inputs]' | tee .github/eks_versions.json
         if: github.event.inputs.limit == null || github.event.inputs.limit == 'eks'


### PR DESCRIPTION
AWS changed the entire format and content of the documentation for EKS
and the way we detected the supported versions was not working, now we
use the new format and the new path to get the versions.

Closes #6100 