### PR TITLE
fix(olm): improve scorecard test implementing suggestions

### DIFF
--- a/config/olm-manifests/bases/cloudnative-pg.clusterserviceversion.yaml
+++ b/config/olm-manifests/bases/cloudnative-pg.clusterserviceversion.yaml
@@ -897,10 +897,10 @@ spec:
       statusDescriptors:
       - path: applied
         displayName: Applied
-        description: Database applied
+        description: Applied is true if the database was reconciled correctly
       - path: message
         displayName: Message
-        description: Database message from the last reconciliation loop
+        description: Message is the reconciliation output message
     - kind: Publication
       name: publications.postgresql.cnpg.io
       displayName: Postgres Publication
@@ -929,10 +929,10 @@ spec:
       statusDescriptors:
       - path: applied
         displayName: Applied
-        description: Publication applied
+        description: Applied is true if the publication was reconciled correctly
       - path: message
         displayName: Message
-        description: Publication message from the last reconciliation loop
+        description: Message is the reconciliation output message
     - kind: Subscription
       name: subscriptions.postgresql.cnpg.io
       displayName: Postgres Subscription
@@ -967,7 +967,7 @@ spec:
       statusDescriptors:
       - path: applied
         displayName: Applied
-        description: Subscription applied
+        description: Applied is true if the subscription was reconciled correctly
       - path: message
         displayName: Message
-        description: Subscription message from the last reconciliation loop
+        description: Message is the reconciliation output message

--- a/config/olm-manifests/bases/cloudnative-pg.clusterserviceversion.yaml
+++ b/config/olm-manifests/bases/cloudnative-pg.clusterserviceversion.yaml
@@ -894,6 +894,13 @@ spec:
         x-descriptors:
           - 'urn:alm:descriptor:com.tectonic.ui:text'
           - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+      statusDescriptors:
+      - path: applied
+        displayName: Applied
+        description: Database applied
+      - path: message
+        displayName: Message
+        description: Database message from the last reconciliation loop
     - kind: Publication
       name: publications.postgresql.cnpg.io
       displayName: Postgres Publication
@@ -919,6 +926,13 @@ spec:
         - path: publicationReclaimPolicy
           displayName: Publication reclaim policy
           description: Specifies the action to take for the publication inside PostgreSQL when the associated object in Kubernetes is deleted. Options are to either delete the database or retain it for future management.
+      statusDescriptors:
+      - path: applied
+        displayName: Applied
+        description: Database applied
+      - path: message
+        displayName: Message
+        description: Database message from the last reconciliation loop
     - kind: Subscription
       name: subscriptions.postgresql.cnpg.io
       displayName: Postgres Subscription
@@ -950,3 +964,10 @@ spec:
         - path: subscriptionReclaimPolicy
           displayName: Subscription reclaim policy
           description: Specifies the action to take for the subscription inside PostgreSQL when the associated object in Kubernetes is deleted. Options are to either delete the database or retain it for future management.
+      statusDescriptors:
+      - path: applied
+        displayName: Applied
+        description: Database applied
+      - path: message
+        displayName: Message
+        description: Database message from the last reconciliation loop

--- a/config/olm-manifests/bases/cloudnative-pg.clusterserviceversion.yaml
+++ b/config/olm-manifests/bases/cloudnative-pg.clusterserviceversion.yaml
@@ -929,10 +929,10 @@ spec:
       statusDescriptors:
       - path: applied
         displayName: Applied
-        description: Database applied
+        description: Publication applied
       - path: message
         displayName: Message
-        description: Database message from the last reconciliation loop
+        description: Publication message from the last reconciliation loop
     - kind: Subscription
       name: subscriptions.postgresql.cnpg.io
       displayName: Postgres Subscription
@@ -967,7 +967,7 @@ spec:
       statusDescriptors:
       - path: applied
         displayName: Applied
-        description: Database applied
+        description: Subscription applied
       - path: message
         displayName: Message
-        description: Database message from the last reconciliation loop
+        description: Subscription message from the last reconciliation loop

--- a/config/olm-samples/postgresql_v1_backup.yaml
+++ b/config/olm-samples/postgresql_v1_backup.yaml
@@ -5,3 +5,5 @@ metadata:
 spec:
   cluster:
     name: cluster-sample
+status:
+  serverName:

--- a/config/olm-samples/postgresql_v1_cluster.yaml
+++ b/config/olm-samples/postgresql_v1_cluster.yaml
@@ -19,3 +19,5 @@ spec:
   walStorage:
     size: 1Gi
   logLevel: info
+status:
+  instances: 3

--- a/config/olm-samples/postgresql_v1_clusterimagecatalog.yaml
+++ b/config/olm-samples/postgresql_v1_clusterimagecatalog.yaml
@@ -1,3 +1,4 @@
+apiVersion: postgresql.cnpg.io/v1
 kind: ClusterImageCatalog
 metadata:
   name: postgresql

--- a/config/olm-samples/postgresql_v1_database.yaml
+++ b/config/olm-samples/postgresql_v1_database.yaml
@@ -7,3 +7,5 @@ spec:
   owner: app
   cluster:
     name: cluster-sample
+status:
+  applied: false

--- a/config/olm-samples/postgresql_v1_imagecatalog.yaml
+++ b/config/olm-samples/postgresql_v1_imagecatalog.yaml
@@ -1,3 +1,4 @@
+apiVersion: postgresql.cnpg.io/v1
 kind: ImageCatalog
 metadata:
   name: postgresql

--- a/config/olm-samples/postgresql_v1_pooler.yaml
+++ b/config/olm-samples/postgresql_v1_pooler.yaml
@@ -9,3 +9,5 @@ spec:
   type: rw
   pgbouncer:
     poolMode: session
+status:
+  instances: 1

--- a/config/olm-samples/postgresql_v1_publication.yaml
+++ b/config/olm-samples/postgresql_v1_publication.yaml
@@ -9,3 +9,5 @@ spec:
     name: cluster-sample
   target:
     allTables: true
+status:
+  applied: false

--- a/config/olm-samples/postgresql_v1_scheduledbackup.yaml
+++ b/config/olm-samples/postgresql_v1_scheduledbackup.yaml
@@ -6,3 +6,5 @@ spec:
   schedule: "0 0 0 * * *"
   cluster:
     name: cluster-sample
+status:
+  lastCheckTime:

--- a/config/olm-samples/postgresql_v1_subscription.yaml
+++ b/config/olm-samples/postgresql_v1_subscription.yaml
@@ -9,3 +9,5 @@ spec:
   cluster:
     name: cluster-sample-dest
   externalClusterName: cluster-sample
+status:
+  applied: false


### PR DESCRIPTION
This patch adds the missing status field in the `olm-samples` as reported in the
"Suggestions" section from olm-scorecard tests.

Closes #5710 