### PR TITLE
feat(plugin): set `User-Agent` in HTTP requests

### DIFF
--- a/internal/cmd/plugin/plugin.go
+++ b/internal/cmd/plugin/plugin.go
@@ -90,8 +90,6 @@ func SetupKubernetesClient(configFlags *genericclioptions.ConfigFlags) error {
 		return err
 	}
 
-	Config.UserAgent = fmt.Sprintf("kubectl-cnpg/v%s (%s)", versions.Version, versions.Info.Commit)
-
 	err = createClient(Config)
 	if err != nil {
 		return err
@@ -111,10 +109,13 @@ func SetupKubernetesClient(configFlags *genericclioptions.ConfigFlags) error {
 
 func createClient(cfg *rest.Config) error {
 	var err error
+
 	scheme := runtime.NewScheme()
 	_ = clientgoscheme.AddToScheme(scheme)
 	_ = apiv1.AddToScheme(scheme)
 	_ = storagesnapshotv1.AddToScheme(scheme)
+
+	cfg.UserAgent = fmt.Sprintf("kubectl-cnpg/v%s (%s)", versions.Version, versions.Info.Commit)
 
 	Client, err = client.New(cfg, client.Options{Scheme: scheme})
 	if err != nil {

--- a/internal/cmd/plugin/plugin.go
+++ b/internal/cmd/plugin/plugin.go
@@ -37,6 +37,7 @@ import (
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/specs"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/versions"
 )
 
 var (
@@ -88,6 +89,8 @@ func SetupKubernetesClient(configFlags *genericclioptions.ConfigFlags) error {
 	if err != nil {
 		return err
 	}
+
+	Config.UserAgent = fmt.Sprintf("kubectl-cnpg/v%s (%s)", versions.Version, versions.Info.Commit)
 
 	err = createClient(Config)
 	if err != nil {

--- a/internal/cmd/plugin/plugin_test.go
+++ b/internal/cmd/plugin/plugin_test.go
@@ -18,7 +18,6 @@ package plugin
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
 	k8client "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -30,20 +29,17 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("create client", Ordered, func() {
+var _ = Describe("create client", func() {
 	It("with given configuration", func() {
+		// createClient is not a pure function and as a side effect
+		// it will:
+		// - set the Client global variable
+		// - set the UserAgent field inside cfg
 		err := createClient(cfg)
+
 		Expect(err).NotTo(HaveOccurred())
+		Expect(cfg.UserAgent).To(Equal("kubectl-cnpg/v" + versions.Version + " (" + versions.Info.Commit + ")"))
 		Expect(Client).NotTo(BeNil())
-	})
-
-	It("should set the UserAgent correctly", func() {
-		configFlags := genericclioptions.NewConfigFlags(true)
-
-		err := SetupKubernetesClient(configFlags)
-		Expect(err).ToNot(HaveOccurred())
-
-		Expect(Config.UserAgent).To(Equal("kubectl-cnpg/v" + versions.Version + " (" + versions.Info.Commit + ")"))
 	})
 })
 

--- a/internal/cmd/plugin/plugin_test.go
+++ b/internal/cmd/plugin/plugin_test.go
@@ -17,22 +17,86 @@ limitations under the License.
 package plugin
 
 import (
+	"context"
+	"fmt"
+	"io"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"net/http"
 	k8client "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"strings"
+
+	"k8s.io/client-go/rest"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/internal/scheme"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/versions"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
+
+type fakeRoundTripper struct {
+	fn func(*http.Request) (*http.Response, error)
+}
+
+func (f *fakeRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f.fn(req)
+}
 
 var _ = Describe("create client", func() {
 	It("with given configuration", func() {
 		err := createClient(cfg)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(Client).NotTo(BeNil())
+	})
+
+	It("should generate the correct UserAgent string", func() {
+		expectedUserAgent := fmt.Sprintf("kubectl-cnpg/v%s (%s)", versions.Version, versions.Info.Commit)
+
+		// Create a new rest.Config
+		config := &rest.Config{}
+
+		// Set the user agent
+		config.UserAgent = fmt.Sprintf("kubectl-cnpg/v%s (%s)", versions.Version, versions.Info.Commit)
+
+		// Verify it matches what we expect
+		Expect(config.UserAgent).To(Equal(expectedUserAgent))
+	})
+
+	It("should set the UserAgent correctly", func() {
+		// Create a test HTTP transport that captures the request headers
+		var capturedUserAgent string
+		testTransport := &fakeRoundTripper{
+			fn: func(req *http.Request) (*http.Response, error) {
+				capturedUserAgent = req.Header.Get("User-Agent")
+				// Return an empty 200 response
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader("{\"kind\":\"PodList\",\"apiVersion\":\"v1\",\"items\":[]}")),
+				}, nil
+			},
+		}
+
+		// Create a basic rest.Config
+		config := &rest.Config{
+			Host:      "https://fake-server",
+			UserAgent: fmt.Sprintf("kubectl-cnpg/v%s (%s)", versions.Version, versions.Info.Commit),
+			Transport: testTransport, // Set the transport directly
+		}
+
+		// Create the client with our config
+		client, err := kubernetes.NewForConfig(config)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Make a request
+		_, err = client.CoreV1().Pods("default").List(context.Background(), metav1.ListOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		// Verify the user agent was set correctly
+		expectedUserAgent := fmt.Sprintf("kubectl-cnpg/v%s (%s)", versions.Version, versions.Info.Commit)
+		Expect(capturedUserAgent).To(Equal(expectedUserAgent))
 	})
 })
 

--- a/internal/cmd/plugin/plugin_test.go
+++ b/internal/cmd/plugin/plugin_test.go
@@ -52,19 +52,6 @@ var _ = Describe("create client", func() {
 		Expect(Client).NotTo(BeNil())
 	})
 
-	It("should generate the correct UserAgent string", func() {
-		expectedUserAgent := fmt.Sprintf("kubectl-cnpg/v%s (%s)", versions.Version, versions.Info.Commit)
-
-		// Create a new rest.Config
-		config := &rest.Config{}
-
-		// Set the user agent
-		config.UserAgent = fmt.Sprintf("kubectl-cnpg/v%s (%s)", versions.Version, versions.Info.Commit)
-
-		// Verify it matches what we expect
-		Expect(config.UserAgent).To(Equal(expectedUserAgent))
-	})
-
 	It("should set the UserAgent correctly", func() {
 		// Create a test HTTP transport that captures the request headers
 		var capturedUserAgent string

--- a/internal/cmd/plugin/plugin_test.go
+++ b/internal/cmd/plugin/plugin_test.go
@@ -17,33 +17,18 @@ limitations under the License.
 package plugin
 
 import (
-	"context"
-	"fmt"
-	"io"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/versions"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
-	"net/http"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
 	k8client "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"strings"
-
-	"k8s.io/client-go/rest"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/internal/scheme"
-	"github.com/cloudnative-pg/cloudnative-pg/pkg/versions"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
-
-type fakeRoundTripper struct {
-	fn func(*http.Request) (*http.Response, error)
-}
-
-func (f *fakeRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	return f.fn(req)
-}
 
 var _ = Describe("create client", func() {
 	It("with given configuration", func() {
@@ -53,37 +38,12 @@ var _ = Describe("create client", func() {
 	})
 
 	It("should set the UserAgent correctly", func() {
-		// Create a test HTTP transport that captures the request headers
-		var capturedUserAgent string
-		testTransport := &fakeRoundTripper{
-			fn: func(req *http.Request) (*http.Response, error) {
-				capturedUserAgent = req.Header.Get("User-Agent")
-				// Return an empty 200 response
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(strings.NewReader("{\"kind\":\"PodList\",\"apiVersion\":\"v1\",\"items\":[]}")),
-				}, nil
-			},
-		}
+		configFlags := genericclioptions.NewConfigFlags(true)
 
-		// Create a basic rest.Config
-		config := &rest.Config{
-			Host:      "https://fake-server",
-			UserAgent: fmt.Sprintf("kubectl-cnpg/v%s (%s)", versions.Version, versions.Info.Commit),
-			Transport: testTransport, // Set the transport directly
-		}
+		err := SetupKubernetesClient(configFlags)
+		Expect(err).ToNot(HaveOccurred())
 
-		// Create the client with our config
-		client, err := kubernetes.NewForConfig(config)
-		Expect(err).NotTo(HaveOccurred())
-
-		// Make a request
-		_, err = client.CoreV1().Pods("default").List(context.Background(), metav1.ListOptions{})
-		Expect(err).NotTo(HaveOccurred())
-
-		// Verify the user agent was set correctly
-		expectedUserAgent := fmt.Sprintf("kubectl-cnpg/v%s (%s)", versions.Version, versions.Info.Commit)
-		Expect(capturedUserAgent).To(Equal(expectedUserAgent))
+		Expect(Config.UserAgent).To(Equal("kubectl-cnpg/v" + versions.Version + " (" + versions.Info.Commit + ")"))
 	})
 })
 

--- a/internal/cmd/plugin/plugin_test.go
+++ b/internal/cmd/plugin/plugin_test.go
@@ -30,7 +30,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("create client", func() {
+var _ = Describe("create client", Ordered, func() {
 	It("with given configuration", func() {
 		err := createClient(cfg)
 		Expect(err).NotTo(HaveOccurred())

--- a/internal/cmd/plugin/plugin_test.go
+++ b/internal/cmd/plugin/plugin_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package plugin
 
 import (
-	"github.com/cloudnative-pg/cloudnative-pg/pkg/versions"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	k8client "sigs.k8s.io/controller-runtime/pkg/client"
@@ -25,6 +24,7 @@ import (
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/internal/scheme"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/versions"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"


### PR DESCRIPTION
Properly set the `User-Agent` header in HTTP requests to the Kubernetes API server.

Closes #6038 