### PR TITLE
chore: drop support for `pg_rewind` in PostgreSQL 12

### DIFF
--- a/internal/management/controller/instance_startup.go
+++ b/internal/management/controller/instance_startup.go
@@ -270,23 +270,7 @@ func (r *InstanceReconciler) verifyPgDataCoherenceForPrimary(ctx context.Context
 		// retrying after having started up the instance.
 		err = r.instance.Rewind(ctx, pgVersion)
 		if err != nil {
-			contextLogger.Info(
-				"pg_rewind failed, starting the server to complete the crash recovery",
-				"err", err)
-
-			// pg_rewind requires a clean shutdown of the old primary to work.
-			// The only way to do that is to start the server again
-			// and wait for it to be available again.
-			err = r.instance.CompleteCrashRecovery(ctx)
-			if err != nil {
-				return err
-			}
-
-			// Then let's go back to the point of the new primary
-			err = r.instance.Rewind(ctx, pgVersion)
-			if err != nil {
-				return err
-			}
+			return fmt.Errorf("while exucuting pg_rewind: %w", err)
 		}
 
 		// Now I can demote myself

--- a/pkg/management/postgres/instance.go
+++ b/pkg/management/postgres/instance.go
@@ -829,22 +829,6 @@ func (instance *Instance) WaitForPrimaryAvailable(ctx context.Context) error {
 	return waitForConnectionAvailable(ctx, db)
 }
 
-// CompleteCrashRecovery temporary starts up the server and wait for it
-// to be fully available for queries. This will ensure that the crash recovery
-// is fully done.
-// Important: this function must be called only when the instance isn't started
-func (instance *Instance) CompleteCrashRecovery(ctx context.Context) error {
-	log.Info("Waiting for server to complete crash recovery")
-
-	defer func() {
-		instance.ShutdownConnections()
-	}()
-
-	return instance.WithActiveInstance(func() error {
-		return instance.WaitForSuperuserConnectionAvailable(ctx)
-	})
-}
-
 // WaitForSuperuserConnectionAvailable waits until we can connect to this
 // instance using the superuser account
 func (instance *Instance) WaitForSuperuserConnectionAvailable(ctx context.Context) error {


### PR DESCRIPTION
Starting with PostgreSQL 13 pg_rewind automatically handles crash recovery before starting, so it is not needed to manually the postmaster after the first invocation of pg_rewind failed.

Leveraging this feature, this patch removes the code that was manually handling the crash recovery process.

Closes: #6156 