### PR TITLE
fix: remove spurious log line on walarchive failure

### DIFF
--- a/internal/cmd/manager/walarchive/cmd.go
+++ b/internal/cmd/manager/walarchive/cmd.go
@@ -66,7 +66,7 @@ func NewCmd() *cobra.Command {
 				} else {
 					contextLog.Error(err, logErrorMessage)
 				}
-				if reqErr := webserver.NewLocalClient().SetWALArchiveStatusCondition(ctx, err.Error()); err != nil {
+				if reqErr := webserver.NewLocalClient().SetWALArchiveStatusCondition(ctx, err.Error()); reqErr != nil {
 					contextLog.Error(reqErr, "while invoking the set wal archive condition endpoint")
 				}
 				return err


### PR DESCRIPTION
The implementation in #6066 introduced a regression where, in the event of a WAL archive failure, an additional incorrect error message was always logged:

"Error while invoking the set WAL archive condition endpoint."

This patch ensures the error messages are logged correctly without misleading additional errors.