### PR TITLE
fix: add `PhaseUnrecoverable` in case of no pvc left

### DIFF
--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -523,7 +523,7 @@ const (
 	PhaseImageCatalogError = "Cluster has incomplete or invalid image catalog"
 
 	// PhaseUnrecoverable for an unrecoverable cluster
-	PhaseUnrecoverable = "Cluster is in an unrecoverable state, needs manual intervention"
+	PhaseUnrecoverable = "Cluster is unrecoverable and needs manual intervention"
 
 	// PhaseArchitectureBinaryMissing is the error phase describing a missing architecture
 	PhaseArchitectureBinaryMissing = "Cluster cannot execute instance online upgrade due to missing architecture binary"

--- a/internal/controller/cluster_create.go
+++ b/internal/controller/cluster_create.go
@@ -1065,7 +1065,7 @@ func (r *ClusterReconciler) createPrimaryInstance(
 
 		if err := r.RegisterPhase(ctx, cluster,
 			apiv1.PhaseUnrecoverable,
-			"One or more instances were previously created, but no PersistentVolumeClaims (PVCs) exist."+
+			"One or more instances were previously created, but no PersistentVolumeClaims (PVCs) exist. "+
 				"The cluster is in an unrecoverable state. To resolve this, restore the cluster from a recent backup.",
 		); err != nil {
 			return ctrl.Result{}, fmt.Errorf("while registering the unrecoverable phase: %w", err)

--- a/internal/controller/cluster_create.go
+++ b/internal/controller/cluster_create.go
@@ -1062,6 +1062,14 @@ func (r *ClusterReconciler) createPrimaryInstance(
 		// reconciliation loop is started by the informers.
 		contextLogger.Info("refusing to create the primary instance while the latest generated serial is not zero",
 			"latestGeneratedNode", cluster.Status.LatestGeneratedNode)
+
+		if err := r.RegisterPhase(ctx, cluster,
+			apiv1.PhaseUnrecoverable,
+			"One or more nodes were previously generated but no PersistentVolumeClaims are found."+
+				"This is in an unrecoverable state. Restore the cluster from a backup if possible.",
+		); err != nil {
+			return ctrl.Result{}, fmt.Errorf("while registering the unrecoverable phase: %w", err)
+		}
 		return ctrl.Result{}, nil
 	}
 

--- a/internal/controller/cluster_create.go
+++ b/internal/controller/cluster_create.go
@@ -1065,8 +1065,8 @@ func (r *ClusterReconciler) createPrimaryInstance(
 
 		if err := r.RegisterPhase(ctx, cluster,
 			apiv1.PhaseUnrecoverable,
-			"One or more nodes were previously generated but no PersistentVolumeClaims are found."+
-				"This is in an unrecoverable state. Restore the cluster from a backup if possible.",
+			"One or more instances were previously created, but no PersistentVolumeClaims (PVCs) exist."+
+				"The cluster is in an unrecoverable state. To resolve this, restore the cluster from a recent backup.",
 		); err != nil {
 			return ctrl.Result{}, fmt.Errorf("while registering the unrecoverable phase: %w", err)
 		}


### PR DESCRIPTION
Closes #5912
Closes #3819

# Release Notes

The operator sets the phase to `Unrecoverable` when previously generated `PersistentVolumeClaims` are no longer present.

# Note for reviewers

We should decide if it needs to be backported or not