### PR TITLE
fix(docs): add default rule for PgBouncer in `pg_hba`

### DIFF
--- a/docs/src/postgresql_conf.md
+++ b/docs/src/postgresql_conf.md
@@ -331,6 +331,7 @@ local all all peer
 
 hostssl postgres streaming_replica all cert
 hostssl replication streaming_replica all cert
+hostssl all cnpg_pooler_pgbouncer all cert
 ```
 
 Default rules:


### PR DESCRIPTION
Closes #6174