### PR TITLE
chore: make cnpg plugin commands compatible with OLM

### DIFF
--- a/cmd/kubectl-cnpg/main.go
+++ b/cmd/kubectl-cnpg/main.go
@@ -66,14 +66,14 @@ func main() {
 		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
 			logFlags.ConfigureLogging()
 
-			plugin.ConfigureColor(cmd)
-
 			// If we're invoking the completion command we shouldn't try to create
 			// a Kubernetes client and we just let the Cobra flow to continue
 			if cmd.Name() == "completion" || cmd.Name() == "version" ||
 				cmd.HasParent() && cmd.Parent().Name() == "completion" {
 				return nil
 			}
+
+			plugin.ConfigureColor(cmd)
 
 			return plugin.SetupKubernetesClient(configFlags)
 		},

--- a/internal/cmd/plugin/fio/cmd.go
+++ b/internal/cmd/plugin/fio/cmd.go
@@ -64,7 +64,7 @@ func NewCmd() *cobra.Command {
 				fmt.Printf("To remove this test you need to delete the Deployment, ConfigMap "+
 					"and PVC with the name %v\n\nThe most simple way to do this is to re-run the command that was run"+
 					"to generate the deployment with the --dry-run flag and pipe that output to kubectl delete, e.g.:\n\n"+
-					"kubectl cnpg fio <fio-job-name> --dry-run | kubectl delete -f -", deploymentName)
+					"kubectl cnpg fio <fio-job-name> --dry-run | kubectl delete -f -\n", deploymentName)
 			}
 		},
 	}

--- a/internal/cmd/plugin/fio/fio.go
+++ b/internal/cmd/plugin/fio/fio.go
@@ -19,6 +19,7 @@ package fio
 
 import (
 	"context"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -181,9 +182,19 @@ func getSecurityContext() *corev1.SecurityContext {
 	return sc
 }
 
+func getPodSecurityContext() *corev1.PodSecurityContext {
+	if utils.HaveSecurityContextConstraints() {
+		return &corev1.PodSecurityContext{}
+	}
+	runAs := int64(10001)
+	return &corev1.PodSecurityContext{
+		FSGroup: &runAs,
+	}
+}
+
 // createFioDeployment creates spec of deployment.
 func (cmd *fioCommand) generateFioDeployment(deploymentName string) *appsv1.Deployment {
-	fioDeployment := &appsv1.Deployment{
+	return &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "apps/v1",
 			Kind:       "Deployment",
@@ -313,10 +324,9 @@ func (cmd *fioCommand) generateFioDeployment(deploymentName string) *appsv1.Depl
 						},
 					},
 					NodeSelector:    map[string]string{},
-					SecurityContext: &corev1.PodSecurityContext{},
+					SecurityContext: getPodSecurityContext(),
 				},
 			},
 		},
 	}
-	return fioDeployment
 }

--- a/internal/cmd/plugin/logical/psql.go
+++ b/internal/cmd/plugin/logical/psql.go
@@ -64,6 +64,8 @@ func getSQLCommand(
 ) (*psql.Command, error) {
 	psqlArgs := []string{
 		connectionString,
+		"-U",
+		"postgres",
 		"-c",
 		sqlCommand,
 	}

--- a/internal/cmd/plugin/plugin.go
+++ b/internal/cmd/plugin/plugin.go
@@ -98,7 +98,7 @@ func SetupKubernetesClient(configFlags *genericclioptions.ConfigFlags) error {
 
 	ClientInterface = kubernetes.NewForConfigOrDie(Config)
 
-	return nil
+	return utils.DetectSecurityContextConstraints(ClientInterface.Discovery())
 }
 
 func createClient(cfg *rest.Config) error {

--- a/internal/cmd/plugin/psql/psql.go
+++ b/internal/cmd/plugin/psql/psql.go
@@ -122,9 +122,8 @@ func (psql *Command) getKubectlInvocation() ([]string, error) {
 		return nil, err
 	}
 
-	// If we're running under OpenShift and the user didn't specify a user to connect
-	// we append the -U flag with the postgres user
-	if utils.HaveSecurityContextConstraints() && !slices.Contains(psql.Args, "-U") {
+	// Default to `postgres` if no-user has been specified
+	if !slices.Contains(psql.Args, "-U") {
 		psql.Args = append([]string{"-U", "postgres"}, psql.Args...)
 	}
 

--- a/internal/cmd/plugin/psql/psql_test.go
+++ b/internal/cmd/plugin/psql/psql_test.go
@@ -95,6 +95,8 @@ var _ = Describe("psql launcher", func() {
 			"cluster-example-1",
 			"--",
 			"psql",
+			"-U",
+			"postgres",
 		))
 	})
 
@@ -120,6 +122,8 @@ var _ = Describe("psql launcher", func() {
 			"cluster-example-1",
 			"--",
 			"psql",
+			"-U",
+			"postgres",
 			"-c",
 			"select 1",
 		))


### PR DESCRIPTION
Improve the plugins to run the commands fio, publication, subscription and
psql smoothly on OLM environments.

Closes #5824 