### PR TITLE
fix(initdb): ensure `primary_slot_name` is empty on a primary

### DIFF
--- a/pkg/management/postgres/configuration.go
+++ b/pkg/management/postgres/configuration.go
@@ -252,7 +252,9 @@ func UpdateReplicaConfiguration(pgData, primaryConnInfo, slotName string) (chang
 }
 
 // configurePostgresOverrideConfFile writes the content of override.conf file, including
-// replication information
+// replication information. The “primary_slot_name` parameter will be generated only when the parameter slotName is not
+// empty.
+// Returns a boolean indicating if any changes were done and any errors encountered
 func configurePostgresOverrideConfFile(pgData, primaryConnInfo, slotName string) (changed bool, err error) {
 	targetFile := path.Join(pgData, constants.PostgresqlOverrideConfigurationFile)
 	options := map[string]string{
@@ -260,8 +262,11 @@ func configurePostgresOverrideConfFile(pgData, primaryConnInfo, slotName string)
 			"/controller/manager wal-restore --log-destination %s/%s.json %%f %%p",
 			postgres.LogPath, postgres.LogFileName),
 		"recovery_target_timeline": "latest",
-		"primary_slot_name":        slotName,
 		"primary_conninfo":         primaryConnInfo,
+	}
+
+	if len(slotName) > 0 {
+		options["primary_slot_name"] = slotName
 	}
 
 	// Ensure that override.conf file contains just the above options

--- a/pkg/management/postgres/initdb.go
+++ b/pkg/management/postgres/initdb.go
@@ -430,7 +430,6 @@ func (info InitInfo) Bootstrap(ctx context.Context) error {
 
 	// Prepare the managed configuration file (override.conf)
 	primaryConnInfo := info.GetPrimaryConnInfo()
-	slotName := cluster.GetSlotNameFromInstanceName(info.PodName)
 
 	if isImportBootstrap {
 		// Write a special configuration for the import phase
@@ -439,7 +438,7 @@ func (info InitInfo) Bootstrap(ctx context.Context) error {
 		}
 	} else {
 		// Write standard replication configuration
-		if _, err = configurePostgresOverrideConfFile(info.PgData, primaryConnInfo, slotName); err != nil {
+		if _, err = configurePostgresOverrideConfFile(info.PgData, primaryConnInfo, ""); err != nil {
 			return fmt.Errorf("while configuring Postgres for replication: %w", err)
 		}
 	}
@@ -466,7 +465,7 @@ func (info InitInfo) Bootstrap(ctx context.Context) error {
 	// In case of import bootstrap, we restore the standard configuration file content
 	if isImportBootstrap {
 		/// Write standard replication configuration
-		if _, err = configurePostgresOverrideConfFile(info.PgData, primaryConnInfo, slotName); err != nil {
+		if _, err = configurePostgresOverrideConfFile(info.PgData, primaryConnInfo, ""); err != nil {
 			return fmt.Errorf("while configuring Postgres for replication: %w", err)
 		}
 


### PR DESCRIPTION
Remove `primary_slot_name` definition from the `override.conf` file on a primary.

Closes #6199 
