### PR TITLE
feat(initdb): add support for ICU and built-in locale providers

### DIFF
--- a/.wordlist-en-custom.txt
+++ b/.wordlist-en-custom.txt
@@ -601,6 +601,7 @@ bootstrapinitdb
 bootstraprecovery
 br
 bs
+builtinLocale
 bw
 byStatus
 bypassrls
@@ -833,6 +834,8 @@ httpGet
 https
 hugepages
 icu
+icuLocale
+icuRules
 ident
 imageCatalogRef
 imageName
@@ -921,6 +924,7 @@ livenessProbeTimeout
 lm
 localeCType
 localeCollate
+localeProvider
 localhost
 localobjectreference
 locktype

--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -1471,6 +1471,10 @@ type BootstrapInitDB struct {
 	// +optional
 	LocaleCType string `json:"localeCType,omitempty"`
 
+	// Sets the default collation order and character classification in the new database.
+	// +optional
+	Locale string `json:"locale,omitempty"`
+
 	// This option sets the locale provider for databases created in the new cluster.
 	// Available from PostgreSQL 16.
 	// +optional

--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -1469,21 +1469,25 @@ type BootstrapInitDB struct {
 	LocaleCType string `json:"localeCType,omitempty"`
 
 	// This option sets the locale provider for databases created in the new cluster.
+	// Available from PostgreSQL 16.
 	// +optional
 	LocaleProvider string `json:"localeProvider,omitempty"`
 
 	// Specifies the ICU locale when the ICU provider is used.
 	// This option requires `localeProvider` to be set to `icu`.
+	// Available from PostgreSQL 15.
 	// +optional
 	IcuLocale string `json:"icuLocale,omitempty"`
 
 	// Specifies additional collation rules to customize the behavior of the default collation.
 	// This option requires `localeProvider` to be set to `icu`.
+	// Available from PostgreSQL 16.
 	// +optional
 	IcuRules string `json:"icuRules,omitempty"`
 
 	// Specifies the locale name when the builtin provider is used.
 	// This option requires `localeProvider` to be set to `builtin`.
+	// Available from PostgreSQL 17.
 	// +optional
 	BuiltinLocale string `json:"builtinLocale,omitempty"`
 

--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -1428,6 +1428,9 @@ type CertificatesStatus struct {
 // BootstrapInitDB is the configuration of the bootstrap process when
 // initdb is used
 // Refer to the Bootstrap page of the documentation for more information.
+// +kubebuilder:validation:XValidation:rule="!has(self.builtinLocale) || self.localeProvider == 'builtin'",message="builtinLocale is only available when localeProvider is set to `builtin`"
+// +kubebuilder:validation:XValidation:rule="!has(self.icuLocale) || self.localeProvider == 'icu'",message="icuLocale is only available when localeProvider is set to `icu`"
+// +kubebuilder:validation:XValidation:rule="!has(self.icuRules) || self.localeProvider == 'icu'",message="icuRules is only available when localeProvider is set to `icu`"
 type BootstrapInitDB struct {
 	// Name of the database used by the application. Default: `app`.
 	// +optional

--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -1468,6 +1468,23 @@ type BootstrapInitDB struct {
 	// +optional
 	LocaleCType string `json:"localeCType,omitempty"`
 
+	// This option sets the locale provider for databases created in the new cluster.
+	// +optional
+	LocaleProvider string `json:"localeProvider,omitempty"`
+
+	// Specifies the ICU locale when the ICU provider is used.
+	// +optional
+	IcuLocale string `json:"icuLocale,omitempty"`
+
+	// Specifies additional collation rules to customize the behavior of the default collation.
+	// This is supported for ICU only.
+	// +optional
+	IcuRules string `json:"icuRules,omitempty"`
+
+	// Specifies the locale name when the builtin provider is used.
+	// +optional
+	BuiltinLocale string `json:"builtinLocale,omitempty"`
+
 	// The value in megabytes (1 to 1024) to be passed to the `--wal-segsize`
 	// option for initdb (default: empty, resulting in PostgreSQL default: 16MB)
 	// +kubebuilder:validation:Minimum=1

--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -1473,15 +1473,17 @@ type BootstrapInitDB struct {
 	LocaleProvider string `json:"localeProvider,omitempty"`
 
 	// Specifies the ICU locale when the ICU provider is used.
+	// This option requires `localeProvider` to be set to `icu`.
 	// +optional
 	IcuLocale string `json:"icuLocale,omitempty"`
 
 	// Specifies additional collation rules to customize the behavior of the default collation.
-	// This is supported for ICU only.
+	// This option requires `localeProvider` to be set to `icu`.
 	// +optional
 	IcuRules string `json:"icuRules,omitempty"`
 
 	// Specifies the locale name when the builtin provider is used.
+	// This option requires `localeProvider` to be set to `builtin`.
 	// +optional
 	BuiltinLocale string `json:"builtinLocale,omitempty"`
 

--- a/config/crd/bases/postgresql.cnpg.io_clusters.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_clusters.yaml
@@ -1815,13 +1815,13 @@ spec:
                     x-kubernetes-validations:
                     - message: builtinLocale is only available when localeProvider
                         is set to `builtin`
-                      rule: '!has(self.builtinLocale) || self.localeProvider == ''builtin'')'
+                      rule: '!has(self.builtinLocale) || self.localeProvider == ''builtin'''
                     - message: icuLocale is only available when localeProvider is
                         set to `icu`
-                      rule: '!has(self.icuLocale) || self.localeProvider == ''icu'')'
+                      rule: '!has(self.icuLocale) || self.localeProvider == ''icu'''
                     - message: icuRules is only available when localeProvider is set
                         to `icu`
-                      rule: '!has(self.icuRules) || self.localeProvider == ''icu'')'
+                      rule: '!has(self.icuRules) || self.localeProvider == ''icu'''
                   pg_basebackup:
                     description: |-
                       Bootstrap the cluster taking a physical backup of another compatible

--- a/config/crd/bases/postgresql.cnpg.io_clusters.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_clusters.yaml
@@ -1812,6 +1812,16 @@ spec:
                         minimum: 1
                         type: integer
                     type: object
+                    x-kubernetes-validations:
+                    - message: builtinLocale is only available when localeProvider
+                        is set to `builtin`
+                      rule: '!has(self.builtinLocale) || self.localeProvider == ''builtin'')'
+                    - message: icuLocale is only available when localeProvider is
+                        set to `icu`
+                      rule: '!has(self.icuLocale) || self.localeProvider == ''icu'')'
+                    - message: icuRules is only available when localeProvider is set
+                        to `icu`
+                      rule: '!has(self.icuRules) || self.localeProvider == ''icu'')'
                   pg_basebackup:
                     description: |-
                       Bootstrap the cluster taking a physical backup of another compatible

--- a/config/crd/bases/postgresql.cnpg.io_clusters.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_clusters.yaml
@@ -1495,6 +1495,10 @@ spec:
                   initdb:
                     description: Bootstrap the cluster via initdb
                     properties:
+                      builtinLocale:
+                        description: Specifies the locale name when the builtin provider
+                          is used.
+                        type: string
                       dataChecksums:
                         description: |-
                           Whether the `-k` option should be passed to initdb,
@@ -1507,6 +1511,15 @@ spec:
                       encoding:
                         description: The value to be passed as option `--encoding`
                           for initdb (default:`UTF8`)
+                        type: string
+                      icuLocale:
+                        description: Specifies the ICU locale when the ICU provider
+                          is used.
+                        type: string
+                      icuRules:
+                        description: |-
+                          Specifies additional collation rules to customize the behavior of the default collation.
+                          This is supported for ICU only.
                         type: string
                       import:
                         description: |-
@@ -1583,6 +1596,10 @@ spec:
                       localeCollate:
                         description: The value to be passed as option `--lc-collate`
                           for initdb (default:`C`)
+                        type: string
+                      localeProvider:
+                        description: This option sets the locale provider for databases
+                          created in the new cluster.
                         type: string
                       options:
                         description: |-

--- a/config/crd/bases/postgresql.cnpg.io_clusters.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_clusters.yaml
@@ -1594,6 +1594,10 @@ spec:
                         - source
                         - type
                         type: object
+                      locale:
+                        description: Sets the default collation order and character
+                          classification in the new database.
+                        type: string
                       localeCType:
                         description: The value to be passed as option `--lc-ctype`
                           for initdb (default:`C`)

--- a/config/crd/bases/postgresql.cnpg.io_clusters.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_clusters.yaml
@@ -1496,8 +1496,10 @@ spec:
                     description: Bootstrap the cluster via initdb
                     properties:
                       builtinLocale:
-                        description: Specifies the locale name when the builtin provider
-                          is used.
+                        description: |-
+                          Specifies the locale name when the builtin provider is used.
+                          This option requires `localeProvider` to be set to `builtin`.
+                          Available from PostgreSQL 17.
                         type: string
                       dataChecksums:
                         description: |-
@@ -1513,13 +1515,16 @@ spec:
                           for initdb (default:`UTF8`)
                         type: string
                       icuLocale:
-                        description: Specifies the ICU locale when the ICU provider
-                          is used.
+                        description: |-
+                          Specifies the ICU locale when the ICU provider is used.
+                          This option requires `localeProvider` to be set to `icu`.
+                          Available from PostgreSQL 15.
                         type: string
                       icuRules:
                         description: |-
                           Specifies additional collation rules to customize the behavior of the default collation.
-                          This is supported for ICU only.
+                          This option requires `localeProvider` to be set to `icu`.
+                          Available from PostgreSQL 16.
                         type: string
                       import:
                         description: |-
@@ -1598,8 +1603,9 @@ spec:
                           for initdb (default:`C`)
                         type: string
                       localeProvider:
-                        description: This option sets the locale provider for databases
-                          created in the new cluster.
+                        description: |-
+                          This option sets the locale provider for databases created in the new cluster.
+                          Available from PostgreSQL 16.
                         type: string
                       options:
                         description: |-

--- a/docs/src/bootstrap.md
+++ b/docs/src/bootstrap.md
@@ -224,7 +224,7 @@ parameters:
 
 builtinLocale
 :   When `builtinLocale` is set to a value, CloudNativePG passes it to the
-    `--builtin-locale` option in `initdb`. This option controls the ICU locale, as
+    `--builtin-locale` option in `initdb`. This option controls the builtin locale, as
     defined in ["Locale Support"](https://www.postgresql.org/docs/current/locale.html)
     from the PostgreSQL documentation (default: empty). Note that this option requires
     `localeProvider` to be set to `builtin`. Available from PostgreSQL 17.

--- a/docs/src/bootstrap.md
+++ b/docs/src/bootstrap.md
@@ -211,6 +211,14 @@ The actual PostgreSQL data directory is created via an invocation of the
 (i.e., to change the `locale` used for the template databases or to add data
 checksums), you can use the following parameters:
 
+builtinLocale
+:   When `builtinLocale` is set to a value, CNPG passes it to the `--builtin-locale`
+option in `initdb`. This option controls the ICU locale, as defined in
+["Locale Support"](https://www.postgresql.org/docs/current/locale.html) from the
+PostgreSQL documentation (default: empty).
+Note that this option requires `localeProvider` to be set to `builtin`.
+Available from PostgreSQL 17.
+
 dataChecksums
 :   When `dataChecksums` is set to `true`, CNPG invokes the `-k` option in
     `initdb` to enable checksums on data pages and help detect corruption by the
@@ -219,6 +227,22 @@ dataChecksums
 encoding
 :   When `encoding` set to a value, CNPG passes it to the `--encoding` option in `initdb`,
     which selects the encoding of the template database (default: `UTF8`).
+
+icuLocale
+:   When `icuLocale` is set to a value, CNPG passes it to the `--icu-locale` option in
+`initdb`. This option controls the ICU locale, as defined in
+["Locale Support"](https://www.postgresql.org/docs/current/locale.html) from the
+PostgreSQL documentation (default: empty).
+Note that this option requires `localeProvider` to be set to `icu`.
+Available from PostgreSQL 15.
+
+icuRules
+:   When `icuRules` is set to a value, CNPG passes it to the `--icu-rules` option in
+`initdb`. This option controls the ICU locale, as defined in
+["Locale Support"](https://www.postgresql.org/docs/current/locale.html) from the
+PostgreSQL documentation (default: empty).
+Note that this option requires `localeProvider` to be set to `icu`.
+Available from PostgreSQL 16.
 
 localeCollate
 :   When `localeCollate` is set to a value, CNPG passes it to the `--lc-collate`
@@ -237,27 +261,7 @@ localeProvider
 option in `initdb`. This option controls the locale provider, as defined in
 ["Locale Support"](https://www.postgresql.org/docs/current/locale.html) from the
 PostgreSQL documentation (default: empty, which means `libc` for PostgreSQL).
-
-icuLocale
-:   When `icuLocale` is set to a value, CNPG passes it to the `--icu-locale` option in
-`initdb`. This option controls the ICU locale, as defined in
-["Locale Support"](https://www.postgresql.org/docs/current/locale.html) from the
-PostgreSQL documentation (default: empty).
-Note that this option requires `localeProvider` to be set to `icu`.
-
-icuRules
-:   When `icuRules` is set to a value, CNPG passes it to the `--icu-rules` option in
-`initdb`. This option controls the ICU locale, as defined in
-["Locale Support"](https://www.postgresql.org/docs/current/locale.html) from the
-PostgreSQL documentation (default: empty).
-Note that this option requires `localeProvider` to be set to `icu`.
-
-builtinLocale
-:   When `builtinLocale` is set to a value, CNPG passes it to the `--builtin-locale`
-option in `initdb`. This option controls the ICU locale, as defined in
-["Locale Support"](https://www.postgresql.org/docs/current/locale.html) from the
-PostgreSQL documentation (default: empty).
-Note that this option requires `localeProvider` to be set to `builtin`.
+Available from PostgreSQL 15.
 
 walSegmentSize
 :   When `walSegmentSize` is set to a value, CNPG passes it to the `--wal-segsize`

--- a/docs/src/bootstrap.md
+++ b/docs/src/bootstrap.md
@@ -24,7 +24,7 @@ For more detailed information about this feature, please refer to the
     CloudNativePG requires both the `postgres` user and database to
     always exists. Using the local Unix Domain Socket, it needs to connect
     as `postgres` user to the `postgres` database via `peer` authentication in
-    order to perform administrative tasks on the cluster.  
+    order to perform administrative tasks on the cluster.
     **DO NOT DELETE** the `postgres` user or the `postgres` database!!!
 
 !!! Info
@@ -204,13 +204,23 @@ The user that owns the database defaults to the database name instead.
 The application user is not used internally by the operator, which instead
 relies on the superuser to reconcile the cluster with the desired status.
 
-### Passing options to `initdb`
+### Passing Options to `initdb`
 
-The actual PostgreSQL data directory is created via an invocation of the
+The PostgreSQL data directory is initialized using the
 [`initdb` PostgreSQL command](https://www.postgresql.org/docs/current/app-initdb.html).
-If you need to add custom options to that command (i.e., to change the `locale`
-used for the template databases or to add data checksums), you can use the
-following parameters:
+
+CloudNativePG enables you to customize the behavior of `initdb` to modify
+settings such as default locale configurations and data checksums.
+
+!!! Warning
+    CloudNativePG acts only as a direct proxy to `initdb` for locale-related
+    options, due to the ongoing and significant enhancements in PostgreSQL's locale
+    support. It is your responsibility to ensure that the correct options are
+    provided, following the PostgreSQL documentation, and to verify that the
+    bootstrap process completes successfully.
+
+To include custom options in the `initdb` command, you can use the following
+parameters:
 
 builtinLocale
 :   When `builtinLocale` is set to a value, CNPG passes it to the `--builtin-locale`
@@ -273,13 +283,6 @@ Available from PostgreSQL 15.
 walSegmentSize
 :   When `walSegmentSize` is set to a value, CNPG passes it to the `--wal-segsize`
     option in `initdb` (default: not set - defined by PostgreSQL as 16 megabytes).
-
-!!! Warning  
-    CloudNativePG provides only a direct proxy to `initdb` for locale-related
-    options, due to the rapid and extensive changes in PostgreSQL's locale support.
-    It is your responsibility to ensure that the correct options are used in
-    accordance with the PostgreSQL documentation and to verify that the bootstrap
-    phase completes successfully.
 
 !!! Note
     The only two locale options that CloudNativePG implements during

--- a/docs/src/bootstrap.md
+++ b/docs/src/bootstrap.md
@@ -232,6 +232,33 @@ localeCType
     defined in ["Locale Support"](https://www.postgresql.org/docs/current/locale.html)
     from the PostgreSQL documentation (default: `C`).
 
+localeProvider
+:   When `localeProvider` is set to a value, CNPG passes it to the `--locale-provider`
+option in `initdb`. This option controls the locale provider, as defined in
+["Locale Support"](https://www.postgresql.org/docs/current/locale.html) from the
+PostgreSQL documentation (default: empty, which means `libc` for PostgreSQL).
+
+icuLocale
+:   When `icuLocale` is set to a value, CNPG passes it to the `--icu-locale` option in
+`initdb`. This option controls the ICU locale, as defined in
+["Locale Support"](https://www.postgresql.org/docs/current/locale.html) from the
+PostgreSQL documentation (default: empty).
+Note that this option requires `localeProvider` to be set to `icu`.
+
+icuRules
+:   When `icuRules` is set to a value, CNPG passes it to the `--icu-rules` option in
+`initdb`. This option controls the ICU locale, as defined in
+["Locale Support"](https://www.postgresql.org/docs/current/locale.html) from the
+PostgreSQL documentation (default: empty).
+Note that this option requires `localeProvider` to be set to `icu`.
+
+builtinLocale
+:   When `builtinLocale` is set to a value, CNPG passes it to the `--builtin-locale`
+option in `initdb`. This option controls the ICU locale, as defined in
+["Locale Support"](https://www.postgresql.org/docs/current/locale.html) from the
+PostgreSQL documentation (default: empty).
+Note that this option requires `localeProvider` to be set to `builtin`.
+
 walSegmentSize
 :   When `walSegmentSize` is set to a value, CNPG passes it to the `--wal-segsize`
     option in `initdb` (default: not set - defined by PostgreSQL as 16 megabytes).

--- a/docs/src/bootstrap.md
+++ b/docs/src/bootstrap.md
@@ -256,6 +256,12 @@ localeCType
     defined in ["Locale Support"](https://www.postgresql.org/docs/current/locale.html)
     from the PostgreSQL documentation (default: `C`).
 
+locale
+:   When `locale` is set to a value, CNPG passes it to the `--locale`
+option in `initdb`. This option controls the locale, as defined in
+["Locale Support"](https://www.postgresql.org/docs/current/locale.html) from the
+PostgreSQL documentation (default: empty).
+
 localeProvider
 :   When `localeProvider` is set to a value, CNPG passes it to the `--locale-provider`
 option in `initdb`. This option controls the locale provider, as defined in

--- a/docs/src/bootstrap.md
+++ b/docs/src/bootstrap.md
@@ -207,9 +207,10 @@ relies on the superuser to reconcile the cluster with the desired status.
 ### Passing options to `initdb`
 
 The actual PostgreSQL data directory is created via an invocation of the
-`initdb` PostgreSQL command. If you need to add custom options to that command
-(i.e., to change the `locale` used for the template databases or to add data
-checksums), you can use the following parameters:
+[`initdb` PostgreSQL command](https://www.postgresql.org/docs/current/app-initdb.html).
+If you need to add custom options to that command (i.e., to change the `locale`
+used for the template databases or to add data checksums), you can use the
+following parameters:
 
 builtinLocale
 :   When `builtinLocale` is set to a value, CNPG passes it to the `--builtin-locale`
@@ -244,6 +245,12 @@ PostgreSQL documentation (default: empty).
 Note that this option requires `localeProvider` to be set to `icu`.
 Available from PostgreSQL 16.
 
+locale
+:   When `locale` is set to a value, CNPG passes it to the `--locale`
+option in `initdb`. This option controls the locale, as defined in
+["Locale Support"](https://www.postgresql.org/docs/current/locale.html) from the
+PostgreSQL documentation (default: empty).
+
 localeCollate
 :   When `localeCollate` is set to a value, CNPG passes it to the `--lc-collate`
     option in `initdb`. This option controls the collation order (`LC_COLLATE`
@@ -256,12 +263,6 @@ localeCType
     defined in ["Locale Support"](https://www.postgresql.org/docs/current/locale.html)
     from the PostgreSQL documentation (default: `C`).
 
-locale
-:   When `locale` is set to a value, CNPG passes it to the `--locale`
-option in `initdb`. This option controls the locale, as defined in
-["Locale Support"](https://www.postgresql.org/docs/current/locale.html) from the
-PostgreSQL documentation (default: empty).
-
 localeProvider
 :   When `localeProvider` is set to a value, CNPG passes it to the `--locale-provider`
 option in `initdb`. This option controls the locale provider, as defined in
@@ -272,6 +273,13 @@ Available from PostgreSQL 15.
 walSegmentSize
 :   When `walSegmentSize` is set to a value, CNPG passes it to the `--wal-segsize`
     option in `initdb` (default: not set - defined by PostgreSQL as 16 megabytes).
+
+!!! Warning  
+    CloudNativePG provides only a direct proxy to `initdb` for locale-related
+    options, due to the rapid and extensive changes in PostgreSQL's locale support.
+    It is your responsibility to ensure that the correct options are used in
+    accordance with the PostgreSQL documentation and to verify that the bootstrap
+    phase completes successfully.
 
 !!! Note
     The only two locale options that CloudNativePG implements during

--- a/docs/src/bootstrap.md
+++ b/docs/src/bootstrap.md
@@ -223,65 +223,68 @@ To include custom options in the `initdb` command, you can use the following
 parameters:
 
 builtinLocale
-:   When `builtinLocale` is set to a value, CNPG passes it to the `--builtin-locale`
-option in `initdb`. This option controls the ICU locale, as defined in
-["Locale Support"](https://www.postgresql.org/docs/current/locale.html) from the
-PostgreSQL documentation (default: empty).
-Note that this option requires `localeProvider` to be set to `builtin`.
-Available from PostgreSQL 17.
+:   When `builtinLocale` is set to a value, CloudNativePG passes it to the
+    `--builtin-locale` option in `initdb`. This option controls the ICU locale, as
+    defined in ["Locale Support"](https://www.postgresql.org/docs/current/locale.html)
+    from the PostgreSQL documentation (default: empty). Note that this option requires
+    `localeProvider` to be set to `builtin`. Available from PostgreSQL 17.
 
 dataChecksums
-:   When `dataChecksums` is set to `true`, CNPG invokes the `-k` option in
+:   When `dataChecksums` is set to `true`, CloudNativePG invokes the `-k` option in
     `initdb` to enable checksums on data pages and help detect corruption by the
     I/O system - that would otherwise be silent (default: `false`).
 
 encoding
-:   When `encoding` set to a value, CNPG passes it to the `--encoding` option in `initdb`,
-    which selects the encoding of the template database (default: `UTF8`).
+:   When `encoding` set to a value, CloudNativePG passes it to the `--encoding`
+    option in `initdb`, which selects the encoding of the template database
+    (default: `UTF8`).
 
 icuLocale
-:   When `icuLocale` is set to a value, CNPG passes it to the `--icu-locale` option in
-`initdb`. This option controls the ICU locale, as defined in
-["Locale Support"](https://www.postgresql.org/docs/current/locale.html) from the
-PostgreSQL documentation (default: empty).
-Note that this option requires `localeProvider` to be set to `icu`.
-Available from PostgreSQL 15.
+:   When `icuLocale` is set to a value, CloudNativePG passes it to the
+    `--icu-locale` option in `initdb`. This option controls the ICU locale, as
+    defined in ["Locale Support"](https://www.postgresql.org/docs/current/locale.html)
+    from the PostgreSQL documentation (default: empty).
+    Note that this option requires `localeProvider` to be set to `icu`.
+    Available from PostgreSQL 15.
 
 icuRules
-:   When `icuRules` is set to a value, CNPG passes it to the `--icu-rules` option in
-`initdb`. This option controls the ICU locale, as defined in
-["Locale Support"](https://www.postgresql.org/docs/current/locale.html) from the
-PostgreSQL documentation (default: empty).
-Note that this option requires `localeProvider` to be set to `icu`.
-Available from PostgreSQL 16.
+:   When `icuRules` is set to a value, CloudNativePG passes it to the
+    `--icu-rules` option in `initdb`. This option controls the ICU locale, as
+    defined in ["Locale
+    Support"](https://www.postgresql.org/docs/current/locale.html) from the
+    PostgreSQL documentation (default: empty). Note that this option requires
+    `localeProvider` to be set to `icu`. Available from PostgreSQL 16.
 
 locale
-:   When `locale` is set to a value, CNPG passes it to the `--locale`
-option in `initdb`. This option controls the locale, as defined in
-["Locale Support"](https://www.postgresql.org/docs/current/locale.html) from the
-PostgreSQL documentation (default: empty).
+:   When `locale` is set to a value, CloudNativePG passes it to the `--locale`
+    option in `initdb`. This option controls the locale, as defined in
+    ["Locale Support"](https://www.postgresql.org/docs/current/locale.html) from
+    the PostgreSQL documentation. By default, the locale parameter is empty. In
+    this case, environment variables such as `LANG` are used to determine the
+    locale. Be aware that these variables can vary between container images,
+    potentially leading to inconsistent behavior.
 
 localeCollate
-:   When `localeCollate` is set to a value, CNPG passes it to the `--lc-collate`
+:   When `localeCollate` is set to a value, CloudNativePG passes it to the `--lc-collate`
     option in `initdb`. This option controls the collation order (`LC_COLLATE`
     subcategory), as defined in ["Locale Support"](https://www.postgresql.org/docs/current/locale.html)
     from the PostgreSQL documentation (default: `C`).
 
 localeCType
-:   When `localeCType` is set to a value, CNPG passes it to the `--lc-ctype` option in
+:   When `localeCType` is set to a value, CloudNativePG passes it to the `--lc-ctype` option in
     `initdb`. This option controls the collation order (`LC_CTYPE` subcategory), as
     defined in ["Locale Support"](https://www.postgresql.org/docs/current/locale.html)
     from the PostgreSQL documentation (default: `C`).
 
 localeProvider
-:   When `localeProvider` is set to a value, CNPG passes it to the `--locale-provider`
+:   When `localeProvider` is set to a value, CloudNativePG passes it to the `--locale-provider`
 option in `initdb`. This option controls the locale provider, as defined in
 ["Locale Support"](https://www.postgresql.org/docs/current/locale.html) from the
 PostgreSQL documentation (default: empty, which means `libc` for PostgreSQL).
 Available from PostgreSQL 15.
 
 walSegmentSize
-:   When `walSegmentSize` is set to a value, CNPG passes it to the `--wal-segsize`
+:   When `walSegmentSize` is set to a value, CloudNativePG passes it to the `--wal-segsize`
     option in `initdb` (default: not set - defined by PostgreSQL as 16 megabytes).
 
 !!! Note

--- a/docs/src/cloudnative-pg.v1.md
+++ b/docs/src/cloudnative-pg.v1.md
@@ -1079,6 +1079,13 @@ enabling checksums on data pages (default: <code>false</code>)</p>
    <p>The value to be passed as option <code>--lc-ctype</code> for initdb (default:<code>C</code>)</p>
 </td>
 </tr>
+<tr><td><code>locale</code><br/>
+<i>string</i>
+</td>
+<td>
+   <p>Sets the default collation order and character classification in the new database.</p>
+</td>
+</tr>
 <tr><td><code>localeProvider</code><br/>
 <i>string</i>
 </td>

--- a/docs/src/cloudnative-pg.v1.md
+++ b/docs/src/cloudnative-pg.v1.md
@@ -1083,14 +1083,17 @@ enabling checksums on data pages (default: <code>false</code>)</p>
 <i>string</i>
 </td>
 <td>
-   <p>This option sets the locale provider for databases created in the new cluster.</p>
+   <p>This option sets the locale provider for databases created in the new cluster.
+Available from PostgreSQL 16.</p>
 </td>
 </tr>
 <tr><td><code>icuLocale</code><br/>
 <i>string</i>
 </td>
 <td>
-   <p>Specifies the ICU locale when the ICU provider is used.</p>
+   <p>Specifies the ICU locale when the ICU provider is used.
+This option requires <code>localeProvider</code> to be set to <code>icu</code>.
+Available from PostgreSQL 15.</p>
 </td>
 </tr>
 <tr><td><code>icuRules</code><br/>
@@ -1098,14 +1101,17 @@ enabling checksums on data pages (default: <code>false</code>)</p>
 </td>
 <td>
    <p>Specifies additional collation rules to customize the behavior of the default collation.
-This is supported for ICU only.</p>
+This option requires <code>localeProvider</code> to be set to <code>icu</code>.
+Available from PostgreSQL 16.</p>
 </td>
 </tr>
 <tr><td><code>builtinLocale</code><br/>
 <i>string</i>
 </td>
 <td>
-   <p>Specifies the locale name when the builtin provider is used.</p>
+   <p>Specifies the locale name when the builtin provider is used.
+This option requires <code>localeProvider</code> to be set to <code>builtin</code>.
+Available from PostgreSQL 17.</p>
 </td>
 </tr>
 <tr><td><code>walSegmentSize</code><br/>

--- a/docs/src/cloudnative-pg.v1.md
+++ b/docs/src/cloudnative-pg.v1.md
@@ -1079,6 +1079,35 @@ enabling checksums on data pages (default: <code>false</code>)</p>
    <p>The value to be passed as option <code>--lc-ctype</code> for initdb (default:<code>C</code>)</p>
 </td>
 </tr>
+<tr><td><code>localeProvider</code><br/>
+<i>string</i>
+</td>
+<td>
+   <p>This option sets the locale provider for databases created in the new cluster.</p>
+</td>
+</tr>
+<tr><td><code>icuLocale</code><br/>
+<i>string</i>
+</td>
+<td>
+   <p>Specifies the ICU locale when the ICU provider is used.</p>
+</td>
+</tr>
+<tr><td><code>icuRules</code><br/>
+<i>string</i>
+</td>
+<td>
+   <p>Specifies additional collation rules to customize the behavior of the default collation.
+This is supported for ICU only.</p>
+</td>
+</tr>
+<tr><td><code>builtinLocale</code><br/>
+<i>string</i>
+</td>
+<td>
+   <p>Specifies the locale name when the builtin provider is used.</p>
+</td>
+</tr>
 <tr><td><code>walSegmentSize</code><br/>
 <i>int</i>
 </td>

--- a/docs/src/samples/cluster-example-initdb-icu.yaml
+++ b/docs/src/samples/cluster-example-initdb-icu.yaml
@@ -1,0 +1,19 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: cluster-example-initdb-icu
+spec:
+  instances: 3
+
+  bootstrap:
+    initdb:
+      encoding: UTF8
+      localeCollate: en_US.UTF8
+      localeCType: en_US.UTF8
+      localeProvider: icu
+      icuLocale: en-US
+      # we want to order g and G after A (and before b)
+      icuRules: '&A < g <<< G'
+      
+  storage:
+    size: 1Gi

--- a/pkg/specs/jobs.go
+++ b/pkg/specs/jobs.go
@@ -142,6 +142,18 @@ func buildInitDBFlags(cluster apiv1.Cluster) (initCommand []string) {
 	if localeCType := config.LocaleCType; localeCType != "" {
 		options = append(options, fmt.Sprintf("--lc-ctype=%s", localeCType))
 	}
+	if localeProvider := config.LocaleProvider; localeProvider != "" {
+		options = append(options, fmt.Sprintf("--locale-provider=%s", localeProvider))
+	}
+	if icuLocale := config.IcuLocale; icuLocale != "" {
+		options = append(options, fmt.Sprintf("--icu-locale=%s", icuLocale))
+	}
+	if icuRules := config.IcuRules; icuRules != "" {
+		options = append(options, fmt.Sprintf("--icu-rules=%s", icuRules))
+	}
+	if builtinLocale := config.BuiltinLocale; builtinLocale != "" {
+		options = append(options, fmt.Sprintf("--builtin-locale=%s", builtinLocale))
+	}
 	if walSegmentSize := config.WalSegmentSize; walSegmentSize != 0 && utils.IsPowerOfTwo(walSegmentSize) {
 		options = append(options, fmt.Sprintf("--wal-segsize=%v", walSegmentSize))
 	}

--- a/pkg/specs/jobs.go
+++ b/pkg/specs/jobs.go
@@ -142,6 +142,9 @@ func buildInitDBFlags(cluster apiv1.Cluster) (initCommand []string) {
 	if localeCType := config.LocaleCType; localeCType != "" {
 		options = append(options, fmt.Sprintf("--lc-ctype=%s", localeCType))
 	}
+	if locale := config.LocaleProvider; locale != "" {
+		options = append(options, fmt.Sprintf("--locale=%s", locale))
+	}
 	if localeProvider := config.LocaleProvider; localeProvider != "" {
 		options = append(options, fmt.Sprintf("--locale-provider=%s", localeProvider))
 	}

--- a/pkg/specs/jobs.go
+++ b/pkg/specs/jobs.go
@@ -142,7 +142,7 @@ func buildInitDBFlags(cluster apiv1.Cluster) (initCommand []string) {
 	if localeCType := config.LocaleCType; localeCType != "" {
 		options = append(options, fmt.Sprintf("--lc-ctype=%s", localeCType))
 	}
-	if locale := config.LocaleProvider; locale != "" {
+	if locale := config.Locale; locale != "" {
 		options = append(options, fmt.Sprintf("--locale=%s", locale))
 	}
 	if localeProvider := config.LocaleProvider; localeProvider != "" {

--- a/pkg/specs/jobs_test.go
+++ b/pkg/specs/jobs_test.go
@@ -17,9 +17,10 @@ limitations under the License.
 package specs
 
 import (
-	v1 "k8s.io/api/batch/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"slices"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 
@@ -37,8 +38,8 @@ var _ = Describe("Barman endpoint CA", func() {
 			},
 		}
 
-		job := v1.Job{
-			Spec: v1.JobSpec{
+		job := batchv1.Job{
+			Spec: batchv1.JobSpec{
 				Template: corev1.PodTemplateSpec{
 					Spec: corev1.PodSpec{
 						Containers: []corev1.Container{{}},
@@ -80,8 +81,8 @@ var _ = Describe("Barman endpoint CA", func() {
 			},
 		}
 
-		job := v1.Job{
-			Spec: v1.JobSpec{
+		job := batchv1.Job{
+			Spec: batchv1.JobSpec{
 				Template: corev1.PodTemplateSpec{
 					Spec: corev1.PodSpec{
 						Containers: []corev1.Container{
@@ -118,8 +119,8 @@ var _ = Describe("Barman endpoint CA", func() {
 			},
 		}}
 
-		job := v1.Job{
-			Spec: v1.JobSpec{
+		job := batchv1.Job{
+			Spec: batchv1.JobSpec{
 				Template: corev1.PodTemplateSpec{
 					Spec: corev1.PodSpec{
 						Containers: []corev1.Container{
@@ -164,5 +165,29 @@ var _ = Describe("Job created via InitDB", func() {
 		Expect(job.Spec.Template.Spec.Containers[0].Command).Should(ContainElement("testPostInitApplicationSql"))
 		Expect(job.Spec.Template.Spec.Containers[0].Command).Should(ContainElement(
 			postInitApplicationSQLRefsFolder.toString()))
+	})
+
+	It("contains icu configuration", func() {
+		cluster := apiv1.Cluster{
+			Spec: apiv1.ClusterSpec{
+				Bootstrap: &apiv1.BootstrapConfiguration{
+					InitDB: &apiv1.BootstrapInitDB{
+						Encoding:       "UTF-8",
+						LocaleProvider: "icu",
+						IcuLocale:      "und",
+						IcuRules:       "&A < z <<< Z",
+					},
+				},
+			},
+		}
+		job := CreatePrimaryJobViaInitdb(cluster, 0)
+
+		jobCommand := job.Spec.Template.Spec.Containers[0].Command
+		Expect(jobCommand).Should(ContainElement("--initdb-flags"))
+		initdbFlags := jobCommand[slices.Index(jobCommand, "--initdb-flags")+1]
+		Expect(initdbFlags).Should(ContainSubstring("--encoding=UTF-8"))
+		Expect(initdbFlags).Should(ContainSubstring("--locale-provider=icu"))
+		Expect(initdbFlags).Should(ContainSubstring("--icu-locale=und"))
+		Expect(initdbFlags).Should(ContainSubstring("'--icu-rules=&A < z <<< Z'"))
 	})
 })

--- a/pkg/specs/jobs_test.go
+++ b/pkg/specs/jobs_test.go
@@ -189,6 +189,7 @@ var _ = Describe("Job created via InitDB", func() {
 		Expect(initdbFlags).Should(ContainSubstring("--encoding=UTF-8"))
 		Expect(initdbFlags).Should(ContainSubstring("--locale-provider=icu"))
 		Expect(initdbFlags).Should(ContainSubstring("--icu-locale=und"))
+		Expect(initdbFlags).ShouldNot(ContainSubstring("--locale="))
 		Expect(initdbFlags).Should(ContainSubstring("'--icu-rules=&A < z <<< Z'"))
 	})
 })

--- a/pkg/specs/jobs_test.go
+++ b/pkg/specs/jobs_test.go
@@ -17,10 +17,11 @@ limitations under the License.
 package specs
 
 import (
+	"slices"
+
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"slices"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 


### PR DESCRIPTION
This patch enhances the PostgreSQL database initialization process (`initdb`) by introducing support for the ICU locale provider (available since PostgreSQL 16) and the built-in locale provider (available since PostgreSQL 17). Users can now specify the desired locale provider when initializing a new PostgreSQL cluster, offering improved localization flexibility.

Closes #5386 

## Release Notes

Add support for ICU and built-in locale providers during cluster initialization.