### PR TITLE
chore: add `lint-fix` to the Makefile commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -233,6 +233,9 @@ vet: ## Run go vet against code.
 lint: ## Run the linter.
 	golangci-lint run
 
+lint-fix: ## Run the linter with --fix.
+	golangci-lint run --fix
+
 shellcheck: ## Shellcheck for the hack directory.
 	@{ \
 	set -e ;\


### PR DESCRIPTION
Following the used of `make lint` usually is required to type a
different command to automatically fix the issues, this solve
the problem by having everything in the same make command prefix.