### PR TITLE
chore(database): align field names with `initdb` section

### DIFF
--- a/.wordlist-en-custom.txt
+++ b/.wordlist-en-custom.txt
@@ -1,4 +1,3 @@
-
 AES
 API's
 APIs
@@ -645,6 +644,7 @@ cn
 cnp
 cnpg
 codeready
+collationVersion
 columnValue
 commandError
 commandOutput

--- a/api/v1/database_types.go
+++ b/api/v1/database_types.go
@@ -51,6 +51,9 @@ type DatabaseSpec struct {
 	// +kubebuilder:validation:XValidation:rule="self != 'postgres'",message="the name postgres is reserved"
 	// +kubebuilder:validation:XValidation:rule="self != 'template0'",message="the name template0 is reserved"
 	// +kubebuilder:validation:XValidation:rule="self != 'template1'",message="the name template1 is reserved"
+	// +kubebuilder:validation:XValidation:rule="!has(self.builtinLocale) || self.localeProvider == 'builtin'",message="builtinLocale is only available when localeProvider is set to `builtin`"
+	// +kubebuilder:validation:XValidation:rule="!has(self.icuLocale) || self.localeProvider == 'icu'",message="icuLocale is only available when localeProvider is set to `icu`"
+	// +kubebuilder:validation:XValidation:rule="!has(self.icuRules) || self.localeProvider == 'icu'",message="icuRules is only available when localeProvider is set to `icu`"
 	Name string `json:"name"`
 
 	// The owner
@@ -71,40 +74,40 @@ type DatabaseSpec struct {
 	// +optional
 	Locale string `json:"locale,omitempty"`
 
-	// The locale provider (cannot be changed)
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="locale_provider is immutable"
+	// This option sets the locale provider for the databases. (cannot be changed)
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="localeProvider is immutable"
 	// +optional
-	LocaleProvider string `json:"locale_provider,omitempty"`
+	LocaleProvider string `json:"localeProvider,omitempty"`
 
 	// The LC_COLLATE (cannot be changed)
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="lc_collate is immutable"
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="localeCollate is immutable"
 	// +optional
-	LcCollate string `json:"lc_collate,omitempty"`
+	LcCollate string `json:"localeCollate,omitempty"`
 
 	// The LC_CTYPE (cannot be changed)
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="lc_ctype is immutable"
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="localeCType is immutable"
 	// +optional
-	LcCtype string `json:"lc_ctype,omitempty"`
+	LcCtype string `json:"localeCType,omitempty"`
 
 	// The ICU_LOCALE (cannot be changed)
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="icu_locale is immutable"
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="icuLocale is immutable"
 	// +optional
-	IcuLocale string `json:"icu_locale,omitempty"`
+	IcuLocale string `json:"icuLocale,omitempty"`
 
 	// The ICU_RULES (cannot be changed)
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="icu_rules is immutable"
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="icuRules is immutable"
 	// +optional
-	IcuRules string `json:"icu_rules,omitempty"`
+	IcuRules string `json:"icuRules,omitempty"`
 
 	// The BUILTIN_LOCALE (cannot be changed)
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="builtin_locale is immutable"
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="builtinLocale is immutable"
 	// +optional
-	BuiltinLocale string `json:"builtin_locale,omitempty"`
+	BuiltinLocale string `json:"builtinLocale,omitempty"`
 
 	// The COLLATION_VERSION (cannot be changed)
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="collation_version is immutable"
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="collationVersion is immutable"
 	// +optional
-	CollationVersion string `json:"collation_version,omitempty"`
+	CollationVersion string `json:"collationVersion,omitempty"`
 
 	// True when the database is a template
 	// +optional

--- a/api/v1/database_types.go
+++ b/api/v1/database_types.go
@@ -36,6 +36,9 @@ const (
 )
 
 // DatabaseSpec is the specification of a Postgresql Database
+// +kubebuilder:validation:XValidation:rule="!has(self.builtinLocale) || self.localeProvider == 'builtin'",message="builtinLocale is only available when localeProvider is set to `builtin`"
+// +kubebuilder:validation:XValidation:rule="!has(self.icuLocale) || self.localeProvider == 'icu'",message="icuLocale is only available when localeProvider is set to `icu`"
+// +kubebuilder:validation:XValidation:rule="!has(self.icuRules) || self.localeProvider == 'icu'",message="icuRules is only available when localeProvider is set to `icu`"
 type DatabaseSpec struct {
 	// The corresponding cluster
 	ClusterRef corev1.LocalObjectReference `json:"cluster"`
@@ -51,9 +54,6 @@ type DatabaseSpec struct {
 	// +kubebuilder:validation:XValidation:rule="self != 'postgres'",message="the name postgres is reserved"
 	// +kubebuilder:validation:XValidation:rule="self != 'template0'",message="the name template0 is reserved"
 	// +kubebuilder:validation:XValidation:rule="self != 'template1'",message="the name template1 is reserved"
-	// +kubebuilder:validation:XValidation:rule="!has(self.builtinLocale) || self.localeProvider == 'builtin'",message="builtinLocale is only available when localeProvider is set to `builtin`"
-	// +kubebuilder:validation:XValidation:rule="!has(self.icuLocale) || self.localeProvider == 'icu'",message="icuLocale is only available when localeProvider is set to `icu`"
-	// +kubebuilder:validation:XValidation:rule="!has(self.icuRules) || self.localeProvider == 'icu'",message="icuRules is only available when localeProvider is set to `icu`"
 	Name string `json:"name"`
 
 	// The owner

--- a/api/v1/database_types.go
+++ b/api/v1/database_types.go
@@ -70,11 +70,14 @@ type DatabaseSpec struct {
 	Encoding string `json:"encoding,omitempty"`
 
 	// The locale (cannot be changed)
+	// Sets the default collation order and character classification in the new database.
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="locale is immutable"
 	// +optional
 	Locale string `json:"locale,omitempty"`
 
-	// This option sets the locale provider for the databases. (cannot be changed)
+	// The LOCALE_PROVIDER (cannot be changed)
+	// This option sets the locale provider for databases created in the new cluster.
+	// Available from PostgreSQL 16.
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="localeProvider is immutable"
 	// +optional
 	LocaleProvider string `json:"localeProvider,omitempty"`
@@ -90,16 +93,25 @@ type DatabaseSpec struct {
 	LcCtype string `json:"localeCType,omitempty"`
 
 	// The ICU_LOCALE (cannot be changed)
+	// Specifies the ICU locale when the ICU provider is used.
+	// This option requires `localeProvider` to be set to `icu`.
+	// Available from PostgreSQL 15.
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="icuLocale is immutable"
 	// +optional
 	IcuLocale string `json:"icuLocale,omitempty"`
 
 	// The ICU_RULES (cannot be changed)
+	// Specifies additional collation rules to customize the behavior of the default collation.
+	// This option requires `localeProvider` to be set to `icu`.
+	// Available from PostgreSQL 16.
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="icuRules is immutable"
 	// +optional
 	IcuRules string `json:"icuRules,omitempty"`
 
 	// The BUILTIN_LOCALE (cannot be changed)
+	// Specifies the locale name when the builtin provider is used.
+	// This option requires `localeProvider` to be set to `builtin`.
+	// Available from PostgreSQL 17.
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="builtinLocale is immutable"
 	// +optional
 	BuiltinLocale string `json:"builtinLocale,omitempty"`

--- a/config/crd/bases/postgresql.cnpg.io_databases.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_databases.yaml
@@ -61,11 +61,11 @@ spec:
               allowConnections:
                 description: True when connections to this database are allowed
                 type: boolean
-              builtin_locale:
+              builtinLocale:
                 description: The BUILTIN_LOCALE (cannot be changed)
                 type: string
                 x-kubernetes-validations:
-                - message: builtin_locale is immutable
+                - message: builtinLocale is immutable
                   rule: self == oldSelf
               cluster:
                 description: The corresponding cluster
@@ -81,11 +81,11 @@ spec:
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
-              collation_version:
+              collationVersion:
                 description: The COLLATION_VERSION (cannot be changed)
                 type: string
                 x-kubernetes-validations:
-                - message: collation_version is immutable
+                - message: collationVersion is immutable
                   rule: self == oldSelf
               connectionLimit:
                 description: |-
@@ -113,44 +113,45 @@ spec:
                 - present
                 - absent
                 type: string
-              icu_locale:
+              icuLocale:
                 description: The ICU_LOCALE (cannot be changed)
                 type: string
                 x-kubernetes-validations:
-                - message: icu_locale is immutable
+                - message: icuLocale is immutable
                   rule: self == oldSelf
-              icu_rules:
+              icuRules:
                 description: The ICU_RULES (cannot be changed)
                 type: string
                 x-kubernetes-validations:
-                - message: icu_rules is immutable
+                - message: icuRules is immutable
                   rule: self == oldSelf
               isTemplate:
                 description: True when the database is a template
                 type: boolean
-              lc_collate:
-                description: The LC_COLLATE (cannot be changed)
-                type: string
-                x-kubernetes-validations:
-                - message: lc_collate is immutable
-                  rule: self == oldSelf
-              lc_ctype:
-                description: The LC_CTYPE (cannot be changed)
-                type: string
-                x-kubernetes-validations:
-                - message: lc_ctype is immutable
-                  rule: self == oldSelf
               locale:
                 description: The locale (cannot be changed)
                 type: string
                 x-kubernetes-validations:
                 - message: locale is immutable
                   rule: self == oldSelf
-              locale_provider:
-                description: The locale provider (cannot be changed)
+              localeCType:
+                description: The LC_CTYPE (cannot be changed)
                 type: string
                 x-kubernetes-validations:
-                - message: locale_provider is immutable
+                - message: localeCType is immutable
+                  rule: self == oldSelf
+              localeCollate:
+                description: The LC_COLLATE (cannot be changed)
+                type: string
+                x-kubernetes-validations:
+                - message: localeCollate is immutable
+                  rule: self == oldSelf
+              localeProvider:
+                description: This option sets the locale provider for the databases.
+                  (cannot be changed)
+                type: string
+                x-kubernetes-validations:
+                - message: localeProvider is immutable
                   rule: self == oldSelf
               name:
                 description: The name inside PostgreSQL
@@ -164,6 +165,15 @@ spec:
                   rule: self != 'template0'
                 - message: the name template1 is reserved
                   rule: self != 'template1'
+                - message: builtinLocale is only available when localeProvider is
+                    set to `builtin`
+                  rule: '!has(self.builtinLocale) || self.localeProvider == ''builtin'''
+                - message: icuLocale is only available when localeProvider is set
+                    to `icu`
+                  rule: '!has(self.icuLocale) || self.localeProvider == ''icu'''
+                - message: icuRules is only available when localeProvider is set to
+                    `icu`
+                  rule: '!has(self.icuRules) || self.localeProvider == ''icu'''
               owner:
                 description: The owner
                 type: string

--- a/config/crd/bases/postgresql.cnpg.io_databases.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_databases.yaml
@@ -62,7 +62,11 @@ spec:
                 description: True when connections to this database are allowed
                 type: boolean
               builtinLocale:
-                description: The BUILTIN_LOCALE (cannot be changed)
+                description: |-
+                  The BUILTIN_LOCALE (cannot be changed)
+                  Specifies the locale name when the builtin provider is used.
+                  This option requires `localeProvider` to be set to `builtin`.
+                  Available from PostgreSQL 17.
                 type: string
                 x-kubernetes-validations:
                 - message: builtinLocale is immutable
@@ -114,13 +118,21 @@ spec:
                 - absent
                 type: string
               icuLocale:
-                description: The ICU_LOCALE (cannot be changed)
+                description: |-
+                  The ICU_LOCALE (cannot be changed)
+                  Specifies the ICU locale when the ICU provider is used.
+                  This option requires `localeProvider` to be set to `icu`.
+                  Available from PostgreSQL 15.
                 type: string
                 x-kubernetes-validations:
                 - message: icuLocale is immutable
                   rule: self == oldSelf
               icuRules:
-                description: The ICU_RULES (cannot be changed)
+                description: |-
+                  The ICU_RULES (cannot be changed)
+                  Specifies additional collation rules to customize the behavior of the default collation.
+                  This option requires `localeProvider` to be set to `icu`.
+                  Available from PostgreSQL 16.
                 type: string
                 x-kubernetes-validations:
                 - message: icuRules is immutable
@@ -129,7 +141,9 @@ spec:
                 description: True when the database is a template
                 type: boolean
               locale:
-                description: The locale (cannot be changed)
+                description: |-
+                  The locale (cannot be changed)
+                  Sets the default collation order and character classification in the new database.
                 type: string
                 x-kubernetes-validations:
                 - message: locale is immutable
@@ -147,8 +161,10 @@ spec:
                 - message: localeCollate is immutable
                   rule: self == oldSelf
               localeProvider:
-                description: This option sets the locale provider for the databases.
-                  (cannot be changed)
+                description: |-
+                  This option sets the locale provider for the databases. (cannot be changed)
+                  This option sets the locale provider for databases created in the new cluster.
+                  Available from PostgreSQL 16.
                 type: string
                 x-kubernetes-validations:
                 - message: localeProvider is immutable

--- a/config/crd/bases/postgresql.cnpg.io_databases.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_databases.yaml
@@ -165,15 +165,6 @@ spec:
                   rule: self != 'template0'
                 - message: the name template1 is reserved
                   rule: self != 'template1'
-                - message: builtinLocale is only available when localeProvider is
-                    set to `builtin`
-                  rule: '!has(self.builtinLocale) || self.localeProvider == ''builtin'''
-                - message: icuLocale is only available when localeProvider is set
-                    to `icu`
-                  rule: '!has(self.icuLocale) || self.localeProvider == ''icu'''
-                - message: icuRules is only available when localeProvider is set to
-                    `icu`
-                  rule: '!has(self.icuRules) || self.localeProvider == ''icu'''
               owner:
                 description: The owner
                 type: string
@@ -192,6 +183,14 @@ spec:
             - name
             - owner
             type: object
+            x-kubernetes-validations:
+            - message: builtinLocale is only available when localeProvider is set
+                to `builtin`
+              rule: '!has(self.builtinLocale) || self.localeProvider == ''builtin'''
+            - message: icuLocale is only available when localeProvider is set to `icu`
+              rule: '!has(self.icuLocale) || self.localeProvider == ''icu'''
+            - message: icuRules is only available when localeProvider is set to `icu`
+              rule: '!has(self.icuRules) || self.localeProvider == ''icu'''
           status:
             description: |-
               Most recently observed status of the Database. This data may not be up to

--- a/config/crd/bases/postgresql.cnpg.io_databases.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_databases.yaml
@@ -162,7 +162,7 @@ spec:
                   rule: self == oldSelf
               localeProvider:
                 description: |-
-                  This option sets the locale provider for the databases. (cannot be changed)
+                  The LOCALE_PROVIDER (cannot be changed)
                   This option sets the locale provider for databases created in the new cluster.
                   Available from PostgreSQL 16.
                 type: string

--- a/docs/src/cloudnative-pg.v1.md
+++ b/docs/src/cloudnative-pg.v1.md
@@ -2469,49 +2469,49 @@ PostgreSQL cluster from an existing storage</p>
    <p>The locale (cannot be changed)</p>
 </td>
 </tr>
-<tr><td><code>locale_provider</code><br/>
+<tr><td><code>localeProvider</code><br/>
 <i>string</i>
 </td>
 <td>
-   <p>The locale provider (cannot be changed)</p>
+   <p>This option sets the locale provider for the databases. (cannot be changed)</p>
 </td>
 </tr>
-<tr><td><code>lc_collate</code><br/>
+<tr><td><code>localeCollate</code><br/>
 <i>string</i>
 </td>
 <td>
    <p>The LC_COLLATE (cannot be changed)</p>
 </td>
 </tr>
-<tr><td><code>lc_ctype</code><br/>
+<tr><td><code>localeCType</code><br/>
 <i>string</i>
 </td>
 <td>
    <p>The LC_CTYPE (cannot be changed)</p>
 </td>
 </tr>
-<tr><td><code>icu_locale</code><br/>
+<tr><td><code>icuLocale</code><br/>
 <i>string</i>
 </td>
 <td>
    <p>The ICU_LOCALE (cannot be changed)</p>
 </td>
 </tr>
-<tr><td><code>icu_rules</code><br/>
+<tr><td><code>icuRules</code><br/>
 <i>string</i>
 </td>
 <td>
    <p>The ICU_RULES (cannot be changed)</p>
 </td>
 </tr>
-<tr><td><code>builtin_locale</code><br/>
+<tr><td><code>builtinLocale</code><br/>
 <i>string</i>
 </td>
 <td>
    <p>The BUILTIN_LOCALE (cannot be changed)</p>
 </td>
 </tr>
-<tr><td><code>collation_version</code><br/>
+<tr><td><code>collationVersion</code><br/>
 <i>string</i>
 </td>
 <td>

--- a/docs/src/cloudnative-pg.v1.md
+++ b/docs/src/cloudnative-pg.v1.md
@@ -2474,7 +2474,7 @@ Sets the default collation order and character classification in the new databas
 <i>string</i>
 </td>
 <td>
-   <p>This option sets the locale provider for the databases. (cannot be changed)
+   <p>The LOCALE_PROVIDER (cannot be changed)
 This option sets the locale provider for databases created in the new cluster.
 Available from PostgreSQL 16.</p>
 </td>

--- a/docs/src/cloudnative-pg.v1.md
+++ b/docs/src/cloudnative-pg.v1.md
@@ -2466,14 +2466,17 @@ PostgreSQL cluster from an existing storage</p>
 <i>string</i>
 </td>
 <td>
-   <p>The locale (cannot be changed)</p>
+   <p>The locale (cannot be changed)
+Sets the default collation order and character classification in the new database.</p>
 </td>
 </tr>
 <tr><td><code>localeProvider</code><br/>
 <i>string</i>
 </td>
 <td>
-   <p>This option sets the locale provider for the databases. (cannot be changed)</p>
+   <p>This option sets the locale provider for the databases. (cannot be changed)
+This option sets the locale provider for databases created in the new cluster.
+Available from PostgreSQL 16.</p>
 </td>
 </tr>
 <tr><td><code>localeCollate</code><br/>
@@ -2494,21 +2497,30 @@ PostgreSQL cluster from an existing storage</p>
 <i>string</i>
 </td>
 <td>
-   <p>The ICU_LOCALE (cannot be changed)</p>
+   <p>The ICU_LOCALE (cannot be changed)
+Specifies the ICU locale when the ICU provider is used.
+This option requires <code>localeProvider</code> to be set to <code>icu</code>.
+Available from PostgreSQL 15.</p>
 </td>
 </tr>
 <tr><td><code>icuRules</code><br/>
 <i>string</i>
 </td>
 <td>
-   <p>The ICU_RULES (cannot be changed)</p>
+   <p>The ICU_RULES (cannot be changed)
+Specifies additional collation rules to customize the behavior of the default collation.
+This option requires <code>localeProvider</code> to be set to <code>icu</code>.
+Available from PostgreSQL 16.</p>
 </td>
 </tr>
 <tr><td><code>builtinLocale</code><br/>
 <i>string</i>
 </td>
 <td>
-   <p>The BUILTIN_LOCALE (cannot be changed)</p>
+   <p>The BUILTIN_LOCALE (cannot be changed)
+Specifies the locale name when the builtin provider is used.
+This option requires <code>localeProvider</code> to be set to <code>builtin</code>.
+Available from PostgreSQL 17.</p>
 </td>
 </tr>
 <tr><td><code>collationVersion</code><br/>

--- a/docs/src/samples/database-example-icu.yaml
+++ b/docs/src/samples/database-example-icu.yaml
@@ -8,9 +8,9 @@ spec:
   name: declarative-icu
   owner: app
   encoding: UTF8
-  locale_provider: icu
-  icu_locale: en
-  icu_rules: fr
+  localeProvider: icu
+  icuLocale: en
+  icuRules: fr
   template: template0
   cluster:
     name: cluster-example

--- a/tests/e2e/fixtures/declarative_databases/database-with-delete-reclaim-policy.yaml.template
+++ b/tests/e2e/fixtures/declarative_databases/database-with-delete-reclaim-policy.yaml.template
@@ -5,8 +5,8 @@ metadata:
 spec:
   name: declarative
   owner: app
-  lc_ctype: C
-  lc_collate: C
+  localeCType: C
+  localeCollate: C
   encoding: UTF8
   databaseReclaimPolicy: delete
   cluster:

--- a/tests/e2e/fixtures/declarative_databases/database.yaml.template
+++ b/tests/e2e/fixtures/declarative_databases/database.yaml.template
@@ -5,8 +5,8 @@ metadata:
 spec:
   name: declarative
   owner: app
-  lc_ctype: "en_US.utf8"
-  lc_collate: C
+  localeCType: "en_US.utf8"
+  localeCollate: C
   encoding: SQL_ASCII
   template: template0
   cluster:


### PR DESCRIPTION
Closes #6244 