### PR TITLE
fix(pooler): set libpq environment variables in PgBouncer pods

### DIFF
--- a/internal/cmd/manager/pgbouncer/cmd.go
+++ b/internal/cmd/manager/pgbouncer/cmd.go
@@ -19,10 +19,12 @@ package pgbouncer
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 
 	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/manager/pgbouncer/run"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/postgres"
 )
 
 // NewCmd creates the "instance" command
@@ -31,6 +33,9 @@ func NewCmd() *cobra.Command {
 		Use:           "pgbouncer",
 		Short:         "pgbouncer management subfeatures",
 		SilenceErrors: true,
+		PersistentPreRunE: func(_ *cobra.Command, _ []string) error {
+			return os.MkdirAll(postgres.TemporaryDirectory, 0o1777) //nolint:gosec
+		},
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return fmt.Errorf("missing subcommand")
 		},

--- a/pkg/specs/pgbouncer/deployments.go
+++ b/pkg/specs/pgbouncer/deployments.go
@@ -19,6 +19,8 @@ limitations under the License.
 package pgbouncer
 
 import (
+	"path"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -108,6 +110,13 @@ func Deployment(pooler *apiv1.Pooler, cluster *apiv1.Cluster) (*appsv1.Deploymen
 		}, true).
 		WithContainerEnv("pgbouncer", corev1.EnvVar{Name: "NAMESPACE", Value: pooler.Namespace}, true).
 		WithContainerEnv("pgbouncer", corev1.EnvVar{Name: "POOLER_NAME", Value: pooler.Name}, true).
+		WithContainerEnv("pgbouncer", corev1.EnvVar{Name: "PGUSER", Value: "pgbouncer"}, false).
+		WithContainerEnv("pgbouncer", corev1.EnvVar{Name: "PGDATABASE", Value: "pgbouncer"}, false).
+		WithContainerEnv("pgbouncer", corev1.EnvVar{Name: "PGHOST", Value: "/controller/run"}, false).
+		WithContainerEnv("pgbouncer", corev1.EnvVar{
+			Name:  "PSQL_HISTORY",
+			Value: path.Join(postgres.TemporaryDirectory, ".psql_history"),
+		}, false).
 		WithContainerSecurityContext("pgbouncer", specs.CreateContainerSecurityContext(cluster.GetSeccompProfile()), true).
 		WithServiceAccountName(pooler.Name, true).
 		WithReadinessProbe("pgbouncer", &corev1.Probe{


### PR DESCRIPTION
This patch configures the following environment variables in PgBouncer pods:  

- `PGUSER`  
- `PGDATABASE`  
- `PGHOST`  
- `PSQL_HISTORY`  

These variables enable seamless access to the PgBouncer administrative interface by allowing `psql` to connect directly from within the Pod without requiring additional command-line options.  

Fixes: #6242 