### PR TITLE
fix(plugin): pass context in `psql` command

### DIFF
--- a/internal/cmd/plugin/plugin.go
+++ b/internal/cmd/plugin/plugin.go
@@ -43,6 +43,9 @@ var (
 	// Namespace to operate in
 	Namespace string
 
+	// KubeContext to operate with
+	KubeContext string
+
 	// NamespaceExplicitlyPassed indicates if the namespace was passed manually
 	NamespaceExplicitlyPassed bool
 
@@ -95,6 +98,8 @@ func SetupKubernetesClient(configFlags *genericclioptions.ConfigFlags) error {
 	if err != nil {
 		return err
 	}
+
+	KubeContext = *configFlags.Context
 
 	ClientInterface = kubernetes.NewForConfigOrDie(Config)
 

--- a/internal/cmd/plugin/psql/cmd.go
+++ b/internal/cmd/plugin/psql/cmd.go
@@ -45,6 +45,7 @@ func NewCmd() *cobra.Command {
 			psqlOptions := CommandOptions{
 				Replica:     replica,
 				Namespace:   plugin.Namespace,
+				Context:     plugin.KubeContext,
 				AllocateTTY: allocateTTY,
 				PassStdin:   passStdin,
 				Args:        psqlArgs,

--- a/internal/cmd/plugin/psql/psql.go
+++ b/internal/cmd/plugin/psql/psql.go
@@ -59,6 +59,9 @@ type CommandOptions struct {
 	// The Namespace where we're working in
 	Namespace string
 
+	// The Context to execute the command
+	Context string
+
 	// Whether we should we allocate a TTY for psql
 	AllocateTTY bool
 
@@ -105,6 +108,10 @@ func NewCommand(
 func (psql *Command) getKubectlInvocation() ([]string, error) {
 	result := make([]string, 0, 13+len(psql.Args))
 	result = append(result, "kubectl", "exec")
+
+	if psql.Context != "" {
+		result = append(result, "--context", psql.Context)
+	}
 
 	if psql.AllocateTTY {
 		result = append(result, "-t")


### PR DESCRIPTION
We were not passing the context from the kubectl cnpg plugin call to
the kubectl command executed when calling psql, this PR fix that by
adding a new variable to the plugin that has the Kubernetes context
used to call the plugin.

Closes #6227 #4332 