### PR TITLE
fix(docs): Standardize the clusterName in kubectl cnpg plugin

### DIFF
--- a/docs/src/kubectl-plugin.md
+++ b/docs/src/kubectl-plugin.md
@@ -397,10 +397,10 @@ The `kubectl cnpg restart` command can be used in two cases:
 
 ```sh
 # this command will restart a whole cluster in a rollout fashion
-kubectl cnpg restart [clusterName]
+kubectl cnpg restart CLUSTER
 
 # this command will restart a single instance, according to the policy above
-kubectl cnpg restart [clusterName] [pod]
+kubectl cnpg restart CLUSTER INSTANCE
 ```
 
 If the in-place restart is requested but the change cannot be applied without

--- a/internal/cmd/plugin/backup/cmd.go
+++ b/internal/cmd/plugin/backup/cmd.go
@@ -72,8 +72,8 @@ func NewCmd() *cobra.Command {
 	}
 
 	backupSubcommand := &cobra.Command{
-		Use:     "backup [cluster]",
-		Short:   "Request an on-demand backup for a PostgreSQL Cluster",
+		Use:     "backup CLUSTER",
+		Short:   "Request an on-demand backup for the PostgreSQL Cluster named CLUSTER",
 		GroupID: plugin.GroupIDDatabase,
 		Args:    plugin.RequiresArguments(1),
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/internal/cmd/plugin/destroy/cmd.go
+++ b/internal/cmd/plugin/destroy/cmd.go
@@ -29,8 +29,8 @@ import (
 // NewCmd create the new "destroy" subcommand
 func NewCmd() *cobra.Command {
 	destroyCmd := &cobra.Command{
-		Use:     "destroy CLUSTER NODE",
-		Short:   "Destroy the instance named CLUSTER-NODE with the associated PVC",
+		Use:     "destroy CLUSTER INSTANCE",
+		Short:   "Destroy the instance named CLUSTER-INSTANCE with the associated PVC",
 		GroupID: plugin.GroupIDCluster,
 		Args:    plugin.RequiresArguments(2),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/plugin/destroy/cmd.go
+++ b/internal/cmd/plugin/destroy/cmd.go
@@ -29,8 +29,8 @@ import (
 // NewCmd create the new "destroy" subcommand
 func NewCmd() *cobra.Command {
 	destroyCmd := &cobra.Command{
-		Use:     "destroy [cluster] [node]",
-		Short:   "Destroy the instance named [cluster]-[node] or [node] with the associated PVC",
+		Use:     "destroy CLUSTER NODE",
+		Short:   "Destroy the instance named CLUSTER-NODE with the associated PVC",
 		GroupID: plugin.GroupIDCluster,
 		Args:    plugin.RequiresArguments(2),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/plugin/fence/cmd.go
+++ b/internal/cmd/plugin/fence/cmd.go
@@ -27,8 +27,8 @@ import (
 
 var (
 	fenceOnCmd = &cobra.Command{
-		Use:   "on [cluster] [node]",
-		Short: `Fence an instance named [cluster]-[node] or [node]`,
+		Use:   "on CLUSTER NODE",
+		Short: `Fence an instance named CLUSTER-NODE`,
 		Args:  plugin.RequiresArguments(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			clusterName := args[0]
@@ -42,8 +42,8 @@ var (
 	}
 
 	fenceOffCmd = &cobra.Command{
-		Use:   "off [cluster] [node]",
-		Short: `Remove fence for an instance named [cluster]-[node] or [node]`,
+		Use:   "off CLUSTER NODE",
+		Short: `Remove fence for an instance named CLUSTER-NODE`,
 		Args:  plugin.RequiresArguments(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			clusterName := args[0]

--- a/internal/cmd/plugin/fence/cmd.go
+++ b/internal/cmd/plugin/fence/cmd.go
@@ -27,8 +27,8 @@ import (
 
 var (
 	fenceOnCmd = &cobra.Command{
-		Use:   "on CLUSTER NODE",
-		Short: `Fence an instance named CLUSTER-NODE`,
+		Use:   "on CLUSTER INSTANCE",
+		Short: `Fence an instance named CLUSTER-INSTANCE`,
 		Args:  plugin.RequiresArguments(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			clusterName := args[0]
@@ -42,8 +42,8 @@ var (
 	}
 
 	fenceOffCmd = &cobra.Command{
-		Use:   "off CLUSTER NODE",
-		Short: `Remove fence for an instance named CLUSTER-NODE`,
+		Use:   "off CLUSTER INSTANCE",
+		Short: `Remove fence for an instance named CLUSTER-INSTANCE`,
 		Args:  plugin.RequiresArguments(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			clusterName := args[0]

--- a/internal/cmd/plugin/hibernate/cmd.go
+++ b/internal/cmd/plugin/hibernate/cmd.go
@@ -26,8 +26,8 @@ import (
 
 var (
 	hibernateOnCmd = &cobra.Command{
-		Use:   "on [cluster]",
-		Short: "Hibernates the cluster named [cluster]",
+		Use:   "on CLUSTER",
+		Short: "Hibernates the cluster named CLUSTER",
 		Args:  plugin.RequiresArguments(1),
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			return plugin.CompleteClusters(cmd.Context(), args, toComplete), cobra.ShellCompDirectiveNoFileComp
@@ -49,8 +49,8 @@ var (
 	}
 
 	hibernateOffCmd = &cobra.Command{
-		Use:   "off [cluster]",
-		Short: "Bring the cluster named [cluster] back from hibernation",
+		Use:   "off CLUSTER",
+		Short: "Bring the cluster named CLUSTER back from hibernation",
 		Args:  plugin.RequiresArguments(1),
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			return plugin.CompleteClusters(cmd.Context(), args, toComplete), cobra.ShellCompDirectiveNoFileComp
@@ -63,8 +63,8 @@ var (
 	}
 
 	hibernateStatusCmd = &cobra.Command{
-		Use:   "status [cluster]",
-		Short: "Prints the hibernation status for the [cluster]",
+		Use:   "status CLUSTER",
+		Short: "Prints the hibernation status for the CLUSTER",
 		Args:  plugin.RequiresArguments(1),
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			return plugin.CompleteClusters(cmd.Context(), args, toComplete), cobra.ShellCompDirectiveNoFileComp

--- a/internal/cmd/plugin/logical/publication/create/cmd.go
+++ b/internal/cmd/plugin/logical/publication/create/cmd.go
@@ -38,7 +38,7 @@ func NewCmd() *cobra.Command {
 	var dryRun bool
 
 	publicationCreateCmd := &cobra.Command{
-		Use:  "create cluster_name",
+		Use:  "create clusterName",
 		Args: plugin.RequiresArguments(1),
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			return plugin.CompleteClusters(cmd.Context(), args, toComplete), cobra.ShellCompDirectiveNoFileComp

--- a/internal/cmd/plugin/logical/publication/create/cmd.go
+++ b/internal/cmd/plugin/logical/publication/create/cmd.go
@@ -38,7 +38,7 @@ func NewCmd() *cobra.Command {
 	var dryRun bool
 
 	publicationCreateCmd := &cobra.Command{
-		Use:  "create clusterName",
+		Use:  "create CLUSTER",
 		Args: plugin.RequiresArguments(1),
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			return plugin.CompleteClusters(cmd.Context(), args, toComplete), cobra.ShellCompDirectiveNoFileComp

--- a/internal/cmd/plugin/logical/publication/drop/cmd.go
+++ b/internal/cmd/plugin/logical/publication/drop/cmd.go
@@ -35,7 +35,7 @@ func NewCmd() *cobra.Command {
 	var dryRun bool
 
 	publicationDropCmd := &cobra.Command{
-		Use:  "drop clusterName",
+		Use:  "drop CLUSTER",
 		Args: plugin.RequiresArguments(1),
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			return plugin.CompleteClusters(cmd.Context(), args, toComplete), cobra.ShellCompDirectiveNoFileComp

--- a/internal/cmd/plugin/logical/publication/drop/cmd.go
+++ b/internal/cmd/plugin/logical/publication/drop/cmd.go
@@ -35,7 +35,7 @@ func NewCmd() *cobra.Command {
 	var dryRun bool
 
 	publicationDropCmd := &cobra.Command{
-		Use:  "drop cluster_name",
+		Use:  "drop clusterName",
 		Args: plugin.RequiresArguments(1),
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			return plugin.CompleteClusters(cmd.Context(), args, toComplete), cobra.ShellCompDirectiveNoFileComp

--- a/internal/cmd/plugin/logical/subscription/create/cmd.go
+++ b/internal/cmd/plugin/logical/subscription/create/cmd.go
@@ -37,7 +37,7 @@ func NewCmd() *cobra.Command {
 	var dryRun bool
 
 	subscriptionCreateCmd := &cobra.Command{
-		Use:   "create cluster_name",
+		Use:   "create clusterName",
 		Short: "create a logical replication subscription",
 		Args:  plugin.RequiresArguments(1),
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/internal/cmd/plugin/logical/subscription/create/cmd.go
+++ b/internal/cmd/plugin/logical/subscription/create/cmd.go
@@ -37,7 +37,7 @@ func NewCmd() *cobra.Command {
 	var dryRun bool
 
 	subscriptionCreateCmd := &cobra.Command{
-		Use:   "create clusterName",
+		Use:   "create CLUSTER",
 		Short: "create a logical replication subscription",
 		Args:  plugin.RequiresArguments(1),
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/internal/cmd/plugin/logical/subscription/drop/cmd.go
+++ b/internal/cmd/plugin/logical/subscription/drop/cmd.go
@@ -34,7 +34,7 @@ func NewCmd() *cobra.Command {
 	var dryRun bool
 
 	subscriptionDropCmd := &cobra.Command{
-		Use:  "drop cluster_name",
+		Use:  "drop clusterName",
 		Args: plugin.RequiresArguments(1),
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			return plugin.CompleteClusters(cmd.Context(), args, toComplete), cobra.ShellCompDirectiveNoFileComp

--- a/internal/cmd/plugin/logical/subscription/drop/cmd.go
+++ b/internal/cmd/plugin/logical/subscription/drop/cmd.go
@@ -34,7 +34,7 @@ func NewCmd() *cobra.Command {
 	var dryRun bool
 
 	subscriptionDropCmd := &cobra.Command{
-		Use:  "drop clusterName",
+		Use:  "drop CLUSTER",
 		Args: plugin.RequiresArguments(1),
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			return plugin.CompleteClusters(cmd.Context(), args, toComplete), cobra.ShellCompDirectiveNoFileComp

--- a/internal/cmd/plugin/logical/subscription/syncsequences/cmd.go
+++ b/internal/cmd/plugin/logical/subscription/syncsequences/cmd.go
@@ -36,7 +36,7 @@ func NewCmd() *cobra.Command {
 	var offset int
 
 	syncSequencesCmd := &cobra.Command{
-		Use:   "sync-sequences clusterName",
+		Use:   "sync-sequences CLUSTER",
 		Short: "synchronize the sequences from the source database",
 		Args:  plugin.RequiresArguments(1),
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/internal/cmd/plugin/logical/subscription/syncsequences/cmd.go
+++ b/internal/cmd/plugin/logical/subscription/syncsequences/cmd.go
@@ -36,7 +36,7 @@ func NewCmd() *cobra.Command {
 	var offset int
 
 	syncSequencesCmd := &cobra.Command{
-		Use:   "sync-sequences cluster_name",
+		Use:   "sync-sequences clusterName",
 		Short: "synchronize the sequences from the source database",
 		Args:  plugin.RequiresArguments(1),
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/internal/cmd/plugin/logs/cluster.go
+++ b/internal/cmd/plugin/logs/cluster.go
@@ -26,7 +26,7 @@ func clusterCmd() *cobra.Command {
 	cl := clusterLogs{}
 
 	cmd := &cobra.Command{
-		Use:   "cluster <clusterName>",
+		Use:   "cluster CLUSTER",
 		Short: "Logs for cluster's pods",
 		Long:  "Collects the logs for all pods in a cluster into a single stream or outputFile",
 		Args:  plugin.RequiresArguments(1),

--- a/internal/cmd/plugin/maintenance/cmd.go
+++ b/internal/cmd/plugin/maintenance/cmd.go
@@ -37,7 +37,7 @@ func NewCmd() *cobra.Command {
 	}
 
 	maintenanceCmd.AddCommand(&cobra.Command{
-		Use:   "set [cluster]",
+		Use:   "set CLUSTER",
 		Short: "Sets maintenance mode",
 		Long: "This command will set maintenance mode on a single cluster or on all clusters " +
 			"in the current namespace if not specified differently through flags",
@@ -58,7 +58,7 @@ func NewCmd() *cobra.Command {
 	})
 
 	maintenanceCmd.AddCommand(&cobra.Command{
-		Use:   "unset [cluster]",
+		Use:   "unset CLUSTER",
 		Short: "Removes maintenance mode",
 		Long: "This command will unset maintenance mode on a single cluster or on all clusters " +
 			"in the current namespace if not specified differently through flags",

--- a/internal/cmd/plugin/pgbench/cmd.go
+++ b/internal/cmd/plugin/pgbench/cmd.go
@@ -29,7 +29,7 @@ func NewCmd() *cobra.Command {
 	run := &pgBenchRun{}
 
 	pgBenchCmd := &cobra.Command{
-		Use:     "pgbench [cluster] [-- pgBenchCommandArgs...]",
+		Use:     "pgbench CLUSTER [-- pgBenchCommandArgs...]",
 		Short:   "Creates a pgbench job",
 		Args:    validateCommandArgs,
 		Long:    "Creates a pgbench job to run against the specified Postgres Cluster.",

--- a/internal/cmd/plugin/pgbench/cmd.go
+++ b/internal/cmd/plugin/pgbench/cmd.go
@@ -29,7 +29,7 @@ func NewCmd() *cobra.Command {
 	run := &pgBenchRun{}
 
 	pgBenchCmd := &cobra.Command{
-		Use:     "pgbench CLUSTER [-- pgBenchCommandArgs...]",
+		Use:     "pgbench CLUSTER [-- PGBENCH_COMMAND_ARGS...]",
 		Short:   "Creates a pgbench job",
 		Args:    validateCommandArgs,
 		Long:    "Creates a pgbench job to run against the specified Postgres Cluster.",
@@ -47,14 +47,14 @@ func NewCmd() *cobra.Command {
 		&run.jobName,
 		"job-name",
 		"",
-		"Name of the job, defaulting to: <clusterName>-pgbench-xxxx",
+		"Name of the job, defaulting to: CLUSTER-pgbench-xxxx",
 	)
 
 	pgBenchCmd.Flags().StringVar(
 		&run.jobName,
 		"pgbench-job-name",
 		"",
-		"Name of the job, defaulting to: <clusterName>-pgbench-xxxx",
+		"Name of the job, defaulting to: CLUSTER-pgbench-xxxx",
 	)
 
 	pgBenchCmd.Flags().StringVar(
@@ -88,7 +88,7 @@ func validateCommandArgs(cmd *cobra.Command, args []string) error {
 	}
 
 	if cmd.ArgsLenAtDash() > 1 {
-		return fmt.Errorf("pgBenchCommands should be passed after the -- delimiter")
+		return fmt.Errorf("PGBENCH_COMMAND_ARGS should be passed after the -- delimiter")
 	}
 
 	return nil

--- a/internal/cmd/plugin/promote/cmd.go
+++ b/internal/cmd/plugin/promote/cmd.go
@@ -29,8 +29,8 @@ import (
 // NewCmd create the new "promote" subcommand
 func NewCmd() *cobra.Command {
 	promoteCmd := &cobra.Command{
-		Use:     "promote CLUSTER NODE",
-		Short:   "Promote the pod named CLUSTER-NODE to primary",
+		Use:     "promote CLUSTER INSTANCE",
+		Short:   "Promote the pod named CLUSTER-INSTANCE to primary",
 		GroupID: plugin.GroupIDCluster,
 		Args:    plugin.RequiresArguments(2),
 		RunE: func(_ *cobra.Command, args []string) error {

--- a/internal/cmd/plugin/promote/cmd.go
+++ b/internal/cmd/plugin/promote/cmd.go
@@ -29,8 +29,8 @@ import (
 // NewCmd create the new "promote" subcommand
 func NewCmd() *cobra.Command {
 	promoteCmd := &cobra.Command{
-		Use:     "promote [cluster] [node]",
-		Short:   "Promote the pod named [cluster]-[node] or [node] to primary",
+		Use:     "promote CLUSTER NODE",
+		Short:   "Promote the pod named CLUSTER-NODE to primary",
 		GroupID: plugin.GroupIDCluster,
 		Args:    plugin.RequiresArguments(2),
 		RunE: func(_ *cobra.Command, args []string) error {

--- a/internal/cmd/plugin/psql/cmd.go
+++ b/internal/cmd/plugin/psql/cmd.go
@@ -31,7 +31,7 @@ func NewCmd() *cobra.Command {
 	var passStdin bool
 
 	cmd := &cobra.Command{
-		Use:   "psql [cluster] [-- psqlArgs...]",
+		Use:   "psql CLUSTER [-- psqlArgs...]",
 		Short: "Start a psql session targeting a CloudNativePG cluster",
 		Args:  validatePsqlArgs,
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/internal/cmd/plugin/psql/cmd.go
+++ b/internal/cmd/plugin/psql/cmd.go
@@ -31,7 +31,7 @@ func NewCmd() *cobra.Command {
 	var passStdin bool
 
 	cmd := &cobra.Command{
-		Use:   "psql CLUSTER [-- psqlArgs...]",
+		Use:   "psql CLUSTER [-- PSQL_ARGS...]",
 		Short: "Start a psql session targeting a CloudNativePG cluster",
 		Args:  validatePsqlArgs,
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/internal/cmd/plugin/reload/cmd.go
+++ b/internal/cmd/plugin/reload/cmd.go
@@ -27,7 +27,7 @@ import (
 // NewCmd creates the new "reset" command
 func NewCmd() *cobra.Command {
 	restartCmd := &cobra.Command{
-		Use:     "reload [clusterName]",
+		Use:     "reload CLUSTER",
 		Short:   `Reload a cluster`,
 		Long:    `Triggers a reconciliation loop for all the cluster's instances, rolling out new configurations if present.`,
 		GroupID: plugin.GroupIDCluster,

--- a/internal/cmd/plugin/report/cluster.go
+++ b/internal/cmd/plugin/report/cluster.go
@@ -32,7 +32,7 @@ func clusterCmd() *cobra.Command {
 
 	const filePlaceholder = "report_cluster_<name>_<timestamp>.zip"
 	cmd := &cobra.Command{
-		Use:   "cluster <clusterName>",
+		Use:   "cluster CLUSTER",
 		Short: "Report cluster resources, pods, events, logs (opt-in)",
 		Long:  "Collects combined information on the cluster in a Zip file",
 		Args:  plugin.RequiresArguments(1),

--- a/internal/cmd/plugin/restart/cmd.go
+++ b/internal/cmd/plugin/restart/cmd.go
@@ -28,7 +28,7 @@ import (
 // NewCmd creates the new "reset" command
 func NewCmd() *cobra.Command {
 	restartCmd := &cobra.Command{
-		Use:   "restart CLUSTER [NODE]",
+		Use:   "restart CLUSTER [INSTANCE]",
 		Short: `Restart a cluster or a single instance in a cluster`,
 		Long: `If only the cluster name is specified, the whole cluster will be restarted, 
 rolling out new configurations if present.

--- a/internal/cmd/plugin/restart/cmd.go
+++ b/internal/cmd/plugin/restart/cmd.go
@@ -28,7 +28,7 @@ import (
 // NewCmd creates the new "reset" command
 func NewCmd() *cobra.Command {
 	restartCmd := &cobra.Command{
-		Use:   "restart clusterName [instance]",
+		Use:   "restart CLUSTER [NODE]",
 		Short: `Restart a cluster or a single instance in a cluster`,
 		Long: `If only the cluster name is specified, the whole cluster will be restarted, 
 rolling out new configurations if present.

--- a/internal/cmd/plugin/snapshot/cmd.go
+++ b/internal/cmd/plugin/snapshot/cmd.go
@@ -28,7 +28,7 @@ import (
 // NewCmd implements the `snapshot` subcommand
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "snapshot <cluster-name>",
+		Use:     "snapshot CLUSTER",
 		Short:   "DEPRECATED (use `backup -m volumeSnapshot` instead)",
 		Long:    "Replaced by `kubectl cnpg backup <cluster-name> -m volumeSnapshot`",
 		GroupID: plugin.GroupIDDatabase,

--- a/internal/cmd/plugin/status/cmd.go
+++ b/internal/cmd/plugin/status/cmd.go
@@ -28,7 +28,7 @@ import (
 // NewCmd create the new "status" subcommand
 func NewCmd() *cobra.Command {
 	statusCmd := &cobra.Command{
-		Use:     "status [cluster]",
+		Use:     "status CLUSTER",
 		Short:   "Get the status of a PostgreSQL cluster",
 		Args:    plugin.RequiresArguments(1),
 		GroupID: plugin.GroupIDDatabase,


### PR DESCRIPTION
The cluster_name parameters in the plugin have been changed to clusterName.

Closes #5848