### PR TITLE
fix(bootstrap): clean up the WAL volume before initializing a cluster

### DIFF
--- a/internal/cmd/manager/instance/initdb/cmd.go
+++ b/internal/cmd/manager/instance/initdb/cmd.go
@@ -150,7 +150,7 @@ func NewCmd() *cobra.Command {
 
 func initSubCommand(ctx context.Context, info postgres.InitInfo) error {
 	contextLogger := log.FromContext(ctx)
-	err := info.CheckTargetDataDirectories(ctx)
+	err := info.EnsureTargetDirectoriesDoNotExist(ctx)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/manager/instance/initdb/cmd.go
+++ b/internal/cmd/manager/instance/initdb/cmd.go
@@ -150,7 +150,7 @@ func NewCmd() *cobra.Command {
 
 func initSubCommand(ctx context.Context, info postgres.InitInfo) error {
 	contextLogger := log.FromContext(ctx)
-	err := info.CheckTargetDataDirectory(ctx)
+	err := info.CheckTargetDataDirectories(ctx)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/manager/instance/join/cmd.go
+++ b/internal/cmd/manager/instance/join/cmd.go
@@ -95,7 +95,7 @@ func NewCmd() *cobra.Command {
 func joinSubCommand(ctx context.Context, instance *postgres.Instance, info postgres.InitInfo) error {
 	contextLogger := log.FromContext(ctx)
 
-	if err := info.CheckTargetDataDirectory(ctx); err != nil {
+	if err := info.CheckTargetDataDirectories(ctx); err != nil {
 		return err
 	}
 

--- a/internal/cmd/manager/instance/join/cmd.go
+++ b/internal/cmd/manager/instance/join/cmd.go
@@ -95,7 +95,7 @@ func NewCmd() *cobra.Command {
 func joinSubCommand(ctx context.Context, instance *postgres.Instance, info postgres.InitInfo) error {
 	contextLogger := log.FromContext(ctx)
 
-	if err := info.CheckTargetDataDirectories(ctx); err != nil {
+	if err := info.EnsureTargetDirectoriesDoNotExist(ctx); err != nil {
 		return err
 	}
 

--- a/internal/cmd/manager/instance/restore/restore.go
+++ b/internal/cmd/manager/instance/restore/restore.go
@@ -68,7 +68,7 @@ func (r *restoreRunnable) Start(ctx context.Context) error {
 
 func restoreSubCommand(ctx context.Context, info postgres.InitInfo, cli client.Client) error {
 	contextLogger := log.FromContext(ctx)
-	if err := info.CheckTargetDataDirectories(ctx); err != nil {
+	if err := info.EnsureTargetDirectoriesDoNotExist(ctx); err != nil {
 		return err
 	}
 

--- a/internal/cmd/manager/instance/restore/restore.go
+++ b/internal/cmd/manager/instance/restore/restore.go
@@ -68,7 +68,7 @@ func (r *restoreRunnable) Start(ctx context.Context) error {
 
 func restoreSubCommand(ctx context.Context, info postgres.InitInfo, cli client.Client) error {
 	contextLogger := log.FromContext(ctx)
-	if err := info.CheckTargetDataDirectory(ctx); err != nil {
+	if err := info.CheckTargetDataDirectories(ctx); err != nil {
 		return err
 	}
 

--- a/pkg/management/postgres/initdb.go
+++ b/pkg/management/postgres/initdb.go
@@ -164,7 +164,7 @@ func (info InitInfo) CheckTargetDataDirectories(ctx context.Context) error {
 			}
 		} else {
 			contextLogger.Info("pg_controldata check on existing directory succeeded, renaming the folders")
-			return info.renameEsistingTargetDataDirectories(ctx)
+			return info.renameExistingTargetDataDirectories(ctx)
 		}
 	}
 
@@ -179,7 +179,7 @@ func (info InitInfo) CheckTargetDataDirectories(ctx context.Context) error {
 	return nil
 }
 
-func (info InitInfo) renameEsistingTargetDataDirectories(ctx context.Context) error {
+func (info InitInfo) renameExistingTargetDataDirectories(ctx context.Context) error {
 	contextLogger := log.FromContext(ctx).WithValues("pgdata", info.PgData, "pgwal", info.PgWal)
 
 	suffixTimestamp := fileutils.FormatFriendlyTimestamp(time.Now())

--- a/pkg/management/postgres/initdb.go
+++ b/pkg/management/postgres/initdb.go
@@ -112,7 +112,7 @@ type InitInfo struct {
 	TablespaceMapFile []byte
 }
 
-// CheckTargetDataDirectories ensures that the target data and WAL directories do not exist.
+// EnsureTargetDirectoriesDoNotExist ensures that the target data and WAL directories do not exist.
 // This is a safety check we do before initializing a new instance.
 //
 // If the PGDATA directory already exists and contains a valid PostgreSQL control file,
@@ -132,7 +132,7 @@ type InitInfo struct {
 //     important user data. This is particularly relevant when using static provisioning
 //     of PersistentVolumeClaims (PVCs), as it prevents accidental overwriting of a valid
 //     data directory that may exist in the PersistentVolumes (PVs).
-func (info InitInfo) CheckTargetDataDirectories(ctx context.Context) error {
+func (info InitInfo) EnsureTargetDirectoriesDoNotExist(ctx context.Context) error {
 	contextLogger := log.FromContext(ctx).WithValues("pgdata", info.PgData)
 
 	pgDataExists, err := fileutils.FileExists(info.PgData)

--- a/pkg/management/postgres/initdb.go
+++ b/pkg/management/postgres/initdb.go
@@ -138,14 +138,14 @@ func (info InitInfo) EnsureTargetDirectoriesDoNotExist(ctx context.Context) erro
 	pgDataExists, err := fileutils.FileExists(info.PgData)
 	if err != nil {
 		contextLogger.Error(err, "Error while checking for an existing data directory")
-		return fmt.Errorf("while verifying if data directory exists: %w", err)
+		return fmt.Errorf("while verifying if the data directory exists: %w", err)
 	}
 
 	pgWalExists := false
 	if info.PgWal != "" {
 		if pgWalExists, err = fileutils.FileExists(info.PgWal); err != nil {
 			contextLogger.Error(err, "Error while checking for an existing WAL directory")
-			return fmt.Errorf("while verifying if WAL directory exists: %w", err)
+			return fmt.Errorf("while verifying if the WAL directory exists: %w", err)
 		}
 	}
 

--- a/pkg/management/postgres/initdb.go
+++ b/pkg/management/postgres/initdb.go
@@ -204,7 +204,7 @@ func (info InitInfo) renameExistingTargetDataDirectories(ctx context.Context, pg
 		pgwalNewName := fmt.Sprintf("%s_%s", info.PgWal, suffixTimestamp)
 
 		contextLogger.Info("renaming the WAL directory", "pgwalNewName", pgwalNewName)
-		if err := os.Rename(info.PgData, pgwalNewName); err != nil {
+		if err := os.Rename(info.PgWal, pgwalNewName); err != nil {
 			contextLogger.Error(err, "error while renaming existing WAL directory")
 			return fmt.Errorf("while renaming existing WAL directory: %w", err)
 		}

--- a/pkg/management/postgres/initdb.go
+++ b/pkg/management/postgres/initdb.go
@@ -144,8 +144,8 @@ func (info InitInfo) CheckTargetDataDirectories(ctx context.Context) error {
 	pgWalExists := false
 	if info.PgWal != "" {
 		if pgWalExists, err = fileutils.FileExists(info.PgWal); err != nil {
-			contextLogger.Error(err, "Error while checking for an existing PGData")
-			return fmt.Errorf("while verifying is PGWAL exists: %w", err)
+			contextLogger.Error(err, "Error while checking for an existing PGWAL")
+			return fmt.Errorf("while verifying if PGWAL exists: %w", err)
 		}
 	}
 

--- a/pkg/management/postgres/initdb_test.go
+++ b/pkg/management/postgres/initdb_test.go
@@ -33,7 +33,7 @@ var _ = Describe("EnsureTargetDirectoriesDoNotExist", func() {
 			PgWal:  GinkgoT().TempDir(),
 		}
 		Expect(os.Create(filepath.Join(initInfo.PgData, "PG_VERSION"))).Error().To(Succeed())
-		Expect(os.Mkdir(filepath.Join(initInfo.PgWal, "archive_status"), 0o777)).To(Succeed())
+		Expect(os.Mkdir(filepath.Join(initInfo.PgWal, "archive_status"), 0o700)).To(Succeed())
 	})
 
 	It("should do nothing if both data and WAL directories do not exist", func(ctx SpecContext) {
@@ -85,7 +85,7 @@ var _ = Describe("renameExistingTargetDataDirectories", func() {
 			PgWal:  GinkgoT().TempDir(),
 		}
 		Expect(os.Create(filepath.Join(initInfo.PgData, "PG_VERSION"))).Error().To(Succeed())
-		Expect(os.Mkdir(filepath.Join(initInfo.PgWal, "archive_status"), 0o777)).To(Succeed())
+		Expect(os.Mkdir(filepath.Join(initInfo.PgWal, "archive_status"), 0o700)).To(Succeed())
 	})
 
 	It("should rename existing data and WAL directories", func(ctx SpecContext) {

--- a/pkg/management/postgres/initdb_test.go
+++ b/pkg/management/postgres/initdb_test.go
@@ -1,0 +1,124 @@
+/*
+Copyright The CloudNativePG Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package postgres
+
+import (
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("EnsureTargetDirectoriesDoNotExist", func() {
+	var initInfo InitInfo
+
+	BeforeEach(func() {
+		initInfo = InitInfo{
+			PgData: GinkgoT().TempDir(),
+			PgWal:  GinkgoT().TempDir(),
+		}
+		Expect(os.Create(filepath.Join(initInfo.PgData, "PG_VERSION"))).Error().To(Succeed())
+		Expect(os.Mkdir(filepath.Join(initInfo.PgWal, "archive_status"), 0o777)).To(Succeed())
+	})
+
+	It("should do nothing if both data and WAL directories do not exist", func(ctx SpecContext) {
+		Expect(os.RemoveAll(initInfo.PgData)).Should(Succeed())
+		Expect(os.RemoveAll(initInfo.PgWal)).Should(Succeed())
+
+		err := initInfo.EnsureTargetDirectoriesDoNotExist(ctx)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(os.Stat(initInfo.PgData)).Error().To(MatchError(os.ErrNotExist))
+		Expect(os.Stat(initInfo.PgWal)).Error().To(MatchError(os.ErrNotExist))
+	})
+
+	It("should remove existing directories if pg_controldata check fails", func(ctx SpecContext) {
+		err := initInfo.EnsureTargetDirectoriesDoNotExist(ctx)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(os.Stat(initInfo.PgData)).Error().To(MatchError(os.ErrNotExist))
+		Expect(os.Stat(initInfo.PgWal)).Error().To(MatchError(os.ErrNotExist))
+	})
+
+	It("should remove data directory even if WAL directory is not present", func(ctx SpecContext) {
+		Expect(os.RemoveAll(initInfo.PgWal)).Should(Succeed())
+
+		err := initInfo.EnsureTargetDirectoriesDoNotExist(ctx)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(os.Stat(initInfo.PgData)).Error().To(MatchError(os.ErrNotExist))
+		Expect(os.Stat(initInfo.PgWal)).Error().To(MatchError(os.ErrNotExist))
+	})
+
+	It("should remove WAL directory even if data directory is not present", func(ctx SpecContext) {
+		Expect(os.RemoveAll(initInfo.PgData)).Should(Succeed())
+
+		err := initInfo.EnsureTargetDirectoriesDoNotExist(ctx)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(os.Stat(initInfo.PgData)).Error().To(MatchError(os.ErrNotExist))
+		Expect(os.Stat(initInfo.PgWal)).Error().To(MatchError(os.ErrNotExist))
+	})
+})
+
+var _ = Describe("renameExistingTargetDataDirectories", func() {
+	var initInfo InitInfo
+
+	BeforeEach(func() {
+		initInfo = InitInfo{
+			PgData: GinkgoT().TempDir(),
+			PgWal:  GinkgoT().TempDir(),
+		}
+		Expect(os.Create(filepath.Join(initInfo.PgData, "PG_VERSION"))).Error().To(Succeed())
+		Expect(os.Mkdir(filepath.Join(initInfo.PgWal, "archive_status"), 0o777)).To(Succeed())
+	})
+
+	It("should rename existing data and WAL directories", func(ctx SpecContext) {
+		err := initInfo.renameExistingTargetDataDirectories(ctx, true)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(os.Stat(initInfo.PgData)).Error().To(MatchError(os.ErrNotExist))
+		Expect(os.Stat(initInfo.PgWal)).Error().To(MatchError(os.ErrNotExist))
+
+		filelist, err := filepath.Glob(initInfo.PgData + "_*")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(filelist).To(HaveLen(1))
+
+		filelist, err = filepath.Glob(initInfo.PgWal + "_*")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(filelist).To(HaveLen(1))
+	})
+
+	It("should rename existing data without WAL directories", func(ctx SpecContext) {
+		Expect(os.RemoveAll(initInfo.PgWal)).Should(Succeed())
+
+		err := initInfo.renameExistingTargetDataDirectories(ctx, false)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(os.Stat(initInfo.PgData)).Error().To(MatchError(os.ErrNotExist))
+		Expect(os.Stat(initInfo.PgWal)).Error().To(MatchError(os.ErrNotExist))
+
+		filelist, err := filepath.Glob(initInfo.PgData + "_*")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(filelist).To(HaveLen(1))
+
+		filelist, err = filepath.Glob(initInfo.PgWal + "_*")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(filelist).To(BeEmpty())
+	})
+})


### PR DESCRIPTION
This patch ensures that the WAL volume is cleaned during the bootstrap as we clean the data directory volume.

Closes #6264 

## Release notes

Fix:
* Include the WAL volume in the clean-up performed during the bootstrap of a cluster.