### PR TITLE
feat: clean up logging of database, publication, subscriptio controllers

### DIFF
--- a/internal/management/controller/database_controller.go
+++ b/internal/management/controller/database_controller.go
@@ -66,7 +66,9 @@ const databaseReconciliationInterval = 30 * time.Second
 
 // Reconcile is the database reconciliation loop
 func (r *DatabaseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	contextLogger := log.FromContext(ctx)
+	contextLogger := log.FromContext(ctx).
+		WithName("database_reconciler").
+		WithValues("databaseName", req.Name)
 
 	// Get the database object
 	var database apiv1.Database
@@ -110,9 +112,9 @@ func (r *DatabaseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		return ctrl.Result{RequeueAfter: databaseReconciliationInterval}, nil
 	}
 
-	contextLogger.Info("Reconciling database", "databaseName", req.Name)
+	contextLogger.Info("Reconciling database")
 	defer func() {
-		contextLogger.Info("Reconciliation loop of database exited", "databaseName", req.Name)
+		contextLogger.Info("Reconciliation loop of database exited")
 	}()
 
 	// Still not for me, we're waiting for a switchover
@@ -165,7 +167,7 @@ func (r *DatabaseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		ctx,
 		&database,
 	); err != nil {
-		contextLogger.Error(err, "while reconciling database", "databaseName", req.Name)
+		contextLogger.Error(err, "while reconciling database")
 		return r.failedReconciliation(
 			ctx,
 			&database,
@@ -173,7 +175,7 @@ func (r *DatabaseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		)
 	}
 
-	contextLogger.Info("Reconciliation of database completed", "databaseName", req.Name)
+	contextLogger.Info("Reconciliation of database completed")
 	return r.succeededReconciliation(
 		ctx,
 		&database,

--- a/internal/management/controller/database_controller.go
+++ b/internal/management/controller/database_controller.go
@@ -68,11 +68,6 @@ const databaseReconciliationInterval = 30 * time.Second
 func (r *DatabaseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	contextLogger := log.FromContext(ctx)
 
-	contextLogger.Debug("Reconciliation loop start")
-	defer func() {
-		contextLogger.Debug("Reconciliation loop end")
-	}()
-
 	// Get the database object
 	var database apiv1.Database
 	if err := r.Client.Get(ctx, client.ObjectKey{
@@ -114,6 +109,11 @@ func (r *DatabaseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	if cluster.Status.CurrentPrimary != r.instance.GetPodName() {
 		return ctrl.Result{RequeueAfter: databaseReconciliationInterval}, nil
 	}
+
+	contextLogger.Info("Reconciling database", "databaseName", req.Name)
+	defer func() {
+		contextLogger.Info("Reconciliation loop of database exited", "databaseName", req.Name)
+	}()
 
 	// Still not for me, we're waiting for a switchover
 	if cluster.Status.CurrentPrimary != cluster.Status.TargetPrimary {
@@ -165,6 +165,7 @@ func (r *DatabaseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		ctx,
 		&database,
 	); err != nil {
+		contextLogger.Error(err, "while reconciling database", "databaseName", req.Name)
 		return r.failedReconciliation(
 			ctx,
 			&database,
@@ -172,6 +173,7 @@ func (r *DatabaseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		)
 	}
 
+	contextLogger.Info("Reconciliation of database completed", "databaseName", req.Name)
 	return r.succeededReconciliation(
 		ctx,
 		&database,

--- a/internal/management/controller/publication_controller.go
+++ b/internal/management/controller/publication_controller.go
@@ -128,7 +128,7 @@ func (r *PublicationReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		return ctrl.Result{RequeueAfter: publicationReconciliationInterval}, nil
 	}
 
-	contextLogger.Info("Reconciliation loop of publication completed", "publicationName", req.Name)
+	contextLogger.Info("Reconciliation of publication completed", "publicationName", req.Name)
 	if err := markAsReady(ctx, r.Client, &publication); err != nil {
 		return ctrl.Result{}, err
 	}

--- a/internal/management/controller/subscription_controller.go
+++ b/internal/management/controller/subscription_controller.go
@@ -51,7 +51,9 @@ const subscriptionReconciliationInterval = 30 * time.Second
 
 // Reconcile is the subscription reconciliation loop
 func (r *SubscriptionReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	contextLogger := log.FromContext(ctx)
+	contextLogger := log.FromContext(ctx).
+		WithName("subscription_reconciler").
+		WithValues("subscriptionName", req.Name)
 
 	// Get the subscription object
 	var subscription apiv1.Subscription
@@ -93,9 +95,9 @@ func (r *SubscriptionReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{RequeueAfter: subscriptionReconciliationInterval}, nil
 	}
 
-	contextLogger.Info("Reconciling subscription", "subscriptionName", req.Name)
+	contextLogger.Info("Reconciling subscription")
 	defer func() {
-		contextLogger.Info("Reconciliation loop of subscription exited", "subscriptionName", req.Name)
+		contextLogger.Info("Reconciliation loop of subscription exited")
 	}()
 
 	// Cannot do anything on a replica cluster
@@ -127,14 +129,14 @@ func (r *SubscriptionReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	}
 
 	if err := r.alignSubscription(ctx, &subscription, connString); err != nil {
-		contextLogger.Error(err, "while reconciling subscription", "subscriptionName", req.Name)
+		contextLogger.Error(err, "while reconciling subscription")
 		if err := markAsFailed(ctx, r.Client, &subscription, err); err != nil {
 			return ctrl.Result{}, err
 		}
 		return ctrl.Result{RequeueAfter: subscriptionReconciliationInterval}, nil
 	}
 
-	contextLogger.Info("Reconciliation of subscription completed", "subscriptionName", req.Name)
+	contextLogger.Info("Reconciliation of subscription completed")
 	if err := markAsReady(ctx, r.Client, &subscription); err != nil {
 		return ctrl.Result{}, err
 	}


### PR DESCRIPTION
Ensures that the primary pod has a clear indication of when a
database/publication/subscription is being reconciled, whether it succeeds,
or there is any error.
Puts those logs at the Info level so they're there by default.
Neither replica instances nor the controller will get any logs.

Closes #5524 