### PR TITLE
fix: eliminate redundant Cluster status updates with image catalog

### DIFF
--- a/internal/controller/cluster_image.go
+++ b/internal/controller/cluster_image.go
@@ -113,7 +113,7 @@ func (r *ClusterReconciler) reconcileImage(ctx context.Context, cluster *apiv1.C
 	}
 
 	// If the image is different, we set it into the cluster status
-	if cluster.Spec.ImageName != catalogImage {
+	if cluster.Status.Image != catalogImage {
 		cluster.Status.Image = catalogImage
 		patch := client.MergeFrom(oldCluster)
 		if err := r.Status().Patch(ctx, cluster, patch); err != nil {


### PR DESCRIPTION
This patch resolves the issue of redundant Cluster status updates triggered when the image catalog is enabled.

Closes: #6276 

## Release Notes

* Resolved an issue causing redundant Cluster status updates when an image catalog is enabled