### PR TITLE
chore: update object status to failed when referred cluster is deleted

### DIFF
--- a/api/v1/database_funcs.go
+++ b/api/v1/database_funcs.go
@@ -40,6 +40,11 @@ func (db *Database) SetAsReady() {
 	db.Status.ObservedGeneration = db.Generation
 }
 
+// GetStatusMessage returns the applied status of the database
+func (db *Database) GetStatusMessage() string {
+	return db.Status.Message
+}
+
 // GetClusterRef returns the cluster reference of the database
 func (db *Database) GetClusterRef() corev1.LocalObjectReference {
 	return db.Spec.ClusterRef

--- a/api/v1/database_funcs.go
+++ b/api/v1/database_funcs.go
@@ -40,7 +40,7 @@ func (db *Database) SetAsReady() {
 	db.Status.ObservedGeneration = db.Generation
 }
 
-// GetStatusMessage returns the applied status of the database
+// GetStatusMessage returns the status message of the database
 func (db *Database) GetStatusMessage() string {
 	return db.Status.Message
 }

--- a/api/v1/publication_funcs.go
+++ b/api/v1/publication_funcs.go
@@ -40,6 +40,11 @@ func (pub *Publication) SetAsReady() {
 	pub.Status.ObservedGeneration = pub.Generation
 }
 
+// GetStatusMessage returns the applied status of the publication
+func (pub *Publication) GetStatusMessage() string {
+	return pub.Status.Message
+}
+
 // GetClusterRef returns the cluster reference of the publication
 func (pub *Publication) GetClusterRef() corev1.LocalObjectReference {
 	return pub.Spec.ClusterRef

--- a/api/v1/publication_funcs.go
+++ b/api/v1/publication_funcs.go
@@ -40,7 +40,7 @@ func (pub *Publication) SetAsReady() {
 	pub.Status.ObservedGeneration = pub.Generation
 }
 
-// GetStatusMessage returns the applied status of the publication
+// GetStatusMessage returns the status message of the publication
 func (pub *Publication) GetStatusMessage() string {
 	return pub.Status.Message
 }

--- a/api/v1/subscription_funcs.go
+++ b/api/v1/subscription_funcs.go
@@ -40,6 +40,11 @@ func (sub *Subscription) SetAsReady() {
 	sub.Status.ObservedGeneration = sub.Generation
 }
 
+// GetStatusMessage returns the applied status of the subscription
+func (sub *Subscription) GetStatusMessage() string {
+	return sub.Status.Message
+}
+
 // GetClusterRef returns the cluster reference of the subscription
 func (sub *Subscription) GetClusterRef() corev1.LocalObjectReference {
 	return sub.Spec.ClusterRef

--- a/api/v1/subscription_funcs.go
+++ b/api/v1/subscription_funcs.go
@@ -40,7 +40,7 @@ func (sub *Subscription) SetAsReady() {
 	sub.Status.ObservedGeneration = sub.Generation
 }
 
-// GetStatusMessage returns the applied status of the subscription
+// GetStatusMessage returns the status message of the subscription
 func (sub *Subscription) GetStatusMessage() string {
 	return sub.Status.Message
 }

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -160,7 +160,7 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 				"namespace", req.Namespace,
 			)
 		}
-		if err := r.deleteFinalizers(ctx, req.NamespacedName); err != nil {
+		if err := r.notifyDeletionToOwnedResources(ctx, req.NamespacedName); err != nil {
 			contextLogger.Error(
 				err,
 				"error while deleting finalizers of objects on the cluster",

--- a/internal/controller/finalizers_delete_test.go
+++ b/internal/controller/finalizers_delete_test.go
@@ -90,7 +90,7 @@ var _ = Describe("CRD finalizers", func() {
 		cli := fake.NewClientBuilder().WithScheme(scheme).WithLists(databaseList).
 			WithStatusSubresource(&databaseList.Items[0], &databaseList.Items[1]).Build()
 		r.Client = cli
-		err := r.deleteFinalizers(ctx, namespacedName)
+		err := r.notifyDeletionToOwnedResources(ctx, namespacedName)
 		Expect(err).ToNot(HaveOccurred())
 
 		for _, db := range databaseList.Items {
@@ -127,7 +127,7 @@ var _ = Describe("CRD finalizers", func() {
 
 			cli := fake.NewClientBuilder().WithScheme(scheme).WithLists(databaseList).Build()
 			r.Client = cli
-			err := r.deleteFinalizers(ctx, namespacedName)
+			err := r.notifyDeletionToOwnedResources(ctx, namespacedName)
 			Expect(err).ToNot(HaveOccurred())
 
 			database := &apiv1.Database{}
@@ -177,7 +177,7 @@ var _ = Describe("CRD finalizers", func() {
 		cli := fake.NewClientBuilder().WithScheme(scheme).WithLists(publicationList).
 			WithStatusSubresource(&publicationList.Items[0], &publicationList.Items[1]).Build()
 		r.Client = cli
-		err := r.deleteFinalizers(ctx, namespacedName)
+		err := r.notifyDeletionToOwnedResources(ctx, namespacedName)
 		Expect(err).ToNot(HaveOccurred())
 
 		for _, pub := range publicationList.Items {
@@ -213,7 +213,7 @@ var _ = Describe("CRD finalizers", func() {
 
 		cli := fake.NewClientBuilder().WithScheme(scheme).WithLists(publicationList).Build()
 		r.Client = cli
-		err := r.deleteFinalizers(ctx, namespacedName)
+		err := r.notifyDeletionToOwnedResources(ctx, namespacedName)
 		Expect(err).ToNot(HaveOccurred())
 
 		publication := &apiv1.Publication{}
@@ -263,7 +263,7 @@ var _ = Describe("CRD finalizers", func() {
 		cli := fake.NewClientBuilder().WithScheme(scheme).WithLists(subscriptionList).
 			WithStatusSubresource(&subscriptionList.Items[0], &subscriptionList.Items[1]).Build()
 		r.Client = cli
-		err := r.deleteFinalizers(ctx, namespacedName)
+		err := r.notifyDeletionToOwnedResources(ctx, namespacedName)
 		Expect(err).ToNot(HaveOccurred())
 
 		for _, sub := range subscriptionList.Items {
@@ -299,7 +299,7 @@ var _ = Describe("CRD finalizers", func() {
 
 		cli := fake.NewClientBuilder().WithScheme(scheme).WithLists(subscriptionList).Build()
 		r.Client = cli
-		err := r.deleteFinalizers(ctx, namespacedName)
+		err := r.notifyDeletionToOwnedResources(ctx, namespacedName)
 		Expect(err).ToNot(HaveOccurred())
 
 		subscription := &apiv1.Subscription{}

--- a/internal/controller/finalizers_delete_test.go
+++ b/internal/controller/finalizers_delete_test.go
@@ -87,7 +87,8 @@ var _ = Describe("CRD finalizers", func() {
 			},
 		}
 
-		cli := fake.NewClientBuilder().WithScheme(scheme).WithLists(databaseList).Build()
+		cli := fake.NewClientBuilder().WithScheme(scheme).WithLists(databaseList).
+			WithStatusSubresource(&databaseList.Items[0], &databaseList.Items[1]).Build()
 		r.Client = cli
 		err := r.deleteFinalizers(ctx, namespacedName)
 		Expect(err).ToNot(HaveOccurred())
@@ -97,6 +98,8 @@ var _ = Describe("CRD finalizers", func() {
 			err = cli.Get(ctx, client.ObjectKeyFromObject(&db), database)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(database.Finalizers).To(BeZero())
+			Expect(*database.Status.Applied).To(BeFalse())
+			Expect(database.Status.Message).To(ContainSubstring("not reconciled"))
 		}
 	})
 
@@ -131,6 +134,8 @@ var _ = Describe("CRD finalizers", func() {
 			err = cli.Get(ctx, client.ObjectKeyFromObject(&databaseList.Items[0]), database)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(database.Finalizers).To(BeEquivalentTo([]string{utils.DatabaseFinalizerName}))
+			Expect(database.Status.Applied).To(BeNil())
+			Expect(database.Status.Message).ToNot(ContainSubstring("not reconciled"))
 		})
 
 	It("should delete publication finalizers for publications on the cluster", func(ctx SpecContext) {
@@ -169,7 +174,8 @@ var _ = Describe("CRD finalizers", func() {
 			},
 		}
 
-		cli := fake.NewClientBuilder().WithScheme(scheme).WithLists(publicationList).Build()
+		cli := fake.NewClientBuilder().WithScheme(scheme).WithLists(publicationList).
+			WithStatusSubresource(&publicationList.Items[0], &publicationList.Items[1]).Build()
 		r.Client = cli
 		err := r.deleteFinalizers(ctx, namespacedName)
 		Expect(err).ToNot(HaveOccurred())
@@ -179,6 +185,8 @@ var _ = Describe("CRD finalizers", func() {
 			err = cli.Get(ctx, client.ObjectKeyFromObject(&pub), publication)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(publication.Finalizers).To(BeZero())
+			Expect(*publication.Status.Applied).To(BeFalse())
+			Expect(publication.Status.Message).To(ContainSubstring("not reconciled"))
 		}
 	})
 
@@ -212,6 +220,8 @@ var _ = Describe("CRD finalizers", func() {
 		err = cli.Get(ctx, client.ObjectKeyFromObject(&publicationList.Items[0]), publication)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(publication.Finalizers).To(BeEquivalentTo([]string{utils.PublicationFinalizerName}))
+		Expect(publication.Status.Applied).To(BeNil())
+		Expect(publication.Status.Message).ToNot(ContainSubstring("not reconciled"))
 	})
 
 	It("should delete subscription finalizers for subscriptions on the cluster", func(ctx SpecContext) {
@@ -250,7 +260,8 @@ var _ = Describe("CRD finalizers", func() {
 			},
 		}
 
-		cli := fake.NewClientBuilder().WithScheme(scheme).WithLists(subscriptionList).Build()
+		cli := fake.NewClientBuilder().WithScheme(scheme).WithLists(subscriptionList).
+			WithStatusSubresource(&subscriptionList.Items[0], &subscriptionList.Items[1]).Build()
 		r.Client = cli
 		err := r.deleteFinalizers(ctx, namespacedName)
 		Expect(err).ToNot(HaveOccurred())
@@ -260,6 +271,8 @@ var _ = Describe("CRD finalizers", func() {
 			err = cli.Get(ctx, client.ObjectKeyFromObject(&sub), subscription)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(subscription.Finalizers).To(BeZero())
+			Expect(*subscription.Status.Applied).To(BeFalse())
+			Expect(subscription.Status.Message).To(ContainSubstring("not reconciled"))
 		}
 	})
 
@@ -293,5 +306,7 @@ var _ = Describe("CRD finalizers", func() {
 		err = cli.Get(ctx, client.ObjectKeyFromObject(&subscriptionList.Items[0]), subscription)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(subscription.Finalizers).To(BeEquivalentTo([]string{utils.SubscriptionFinalizerName}))
+		Expect(subscription.Status.Applied).To(BeNil())
+		Expect(subscription.Status.Message).ToNot(ContainSubstring("not reconciled"))
 	})
 })

--- a/internal/controller/finalizers_delete_test.go
+++ b/internal/controller/finalizers_delete_test.go
@@ -21,6 +21,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -33,7 +34,7 @@ import (
 )
 
 // nolint: dupl
-var _ = Describe("CRD finalizers", func() {
+var _ = Describe("Test cleanup of owned objects on cluster deletion", func() {
 	var (
 		r              ClusterReconciler
 		scheme         *runtime.Scheme
@@ -51,7 +52,7 @@ var _ = Describe("CRD finalizers", func() {
 		}
 	})
 
-	It("should delete database finalizers for databases on the cluster", func(ctx SpecContext) {
+	It("should set databases on the cluster as failed and delete their finalizers", func(ctx SpecContext) {
 		databaseList := &apiv1.DatabaseList{
 			Items: []apiv1.Database{
 				{
@@ -67,6 +68,10 @@ var _ = Describe("CRD finalizers", func() {
 						ClusterRef: corev1.LocalObjectReference{
 							Name: "cluster",
 						},
+					},
+					Status: apiv1.DatabaseStatus{
+						Applied: ptr.To(true),
+						Message: "",
 					},
 				},
 				{
@@ -98,8 +103,8 @@ var _ = Describe("CRD finalizers", func() {
 			err = cli.Get(ctx, client.ObjectKeyFromObject(&db), database)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(database.Finalizers).To(BeZero())
-			Expect(*database.Status.Applied).To(BeFalse())
-			Expect(database.Status.Message).To(ContainSubstring("not reconciled"))
+			Expect(database.Status.Applied).To(HaveValue(BeFalse()))
+			Expect(database.Status.Message).To(ContainSubstring("cluster resource has been deleted"))
 		}
 	})
 
@@ -138,7 +143,7 @@ var _ = Describe("CRD finalizers", func() {
 			Expect(database.Status.Message).ToNot(ContainSubstring("not reconciled"))
 		})
 
-	It("should delete publication finalizers for publications on the cluster", func(ctx SpecContext) {
+	It("should set publications on the cluster as failed and delete their finalizers", func(ctx SpecContext) {
 		publicationList := &apiv1.PublicationList{
 			Items: []apiv1.Publication{
 				{
@@ -154,6 +159,10 @@ var _ = Describe("CRD finalizers", func() {
 						ClusterRef: corev1.LocalObjectReference{
 							Name: "cluster",
 						},
+					},
+					Status: apiv1.PublicationStatus{
+						Applied: ptr.To(true),
+						Message: "",
 					},
 				},
 				{
@@ -185,8 +194,8 @@ var _ = Describe("CRD finalizers", func() {
 			err = cli.Get(ctx, client.ObjectKeyFromObject(&pub), publication)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(publication.Finalizers).To(BeZero())
-			Expect(*publication.Status.Applied).To(BeFalse())
-			Expect(publication.Status.Message).To(ContainSubstring("not reconciled"))
+			Expect(publication.Status.Applied).To(HaveValue(BeFalse()))
+			Expect(publication.Status.Message).To(ContainSubstring("cluster resource has been deleted"))
 		}
 	})
 
@@ -224,7 +233,7 @@ var _ = Describe("CRD finalizers", func() {
 		Expect(publication.Status.Message).ToNot(ContainSubstring("not reconciled"))
 	})
 
-	It("should delete subscription finalizers for subscriptions on the cluster", func(ctx SpecContext) {
+	It("should set subscriptions on the cluster as failed and delete their finalizers ", func(ctx SpecContext) {
 		subscriptionList := &apiv1.SubscriptionList{
 			Items: []apiv1.Subscription{
 				{
@@ -240,6 +249,10 @@ var _ = Describe("CRD finalizers", func() {
 						ClusterRef: corev1.LocalObjectReference{
 							Name: "cluster",
 						},
+					},
+					Status: apiv1.SubscriptionStatus{
+						Applied: ptr.To(true),
+						Message: "",
 					},
 				},
 				{
@@ -271,8 +284,8 @@ var _ = Describe("CRD finalizers", func() {
 			err = cli.Get(ctx, client.ObjectKeyFromObject(&sub), subscription)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(subscription.Finalizers).To(BeZero())
-			Expect(*subscription.Status.Applied).To(BeFalse())
-			Expect(subscription.Status.Message).To(ContainSubstring("not reconciled"))
+			Expect(subscription.Status.Applied).To(HaveValue(BeFalse()))
+			Expect(subscription.Status.Message).To(ContainSubstring("cluster resource has been deleted"))
 		}
 	})
 


### PR DESCRIPTION
When a cluster referred to by an object is deleted, the object status was previously left unchanged, which could lead to confusion. This patch sets the status to `failed`, and the message to `cluster resource has been deleted, skipping reconciliation`.

Closes #6211
Closes #6172 