### PR TITLE
docs(security): mention new CRDs

### DIFF
--- a/docs/src/security.md
+++ b/docs/src/security.md
@@ -113,8 +113,8 @@ more about these roles, you can use the `kubectl describe clusterrole` or
     The above permissions are exclusively reserved for the operator's service
     account to interact with the Kubernetes API server.  They are not directly
     accessible by the users of the operator that interact only with `Cluster`,
-    `Pooler`, `Backup`, `ScheduledBackup`, `ImageCatalog` and
-    `ClusterImageCatalog` resources.
+    `Pooler`, `Backup`, `ScheduledBackup`, `Database`, `Publication`,
+    `Subscription`, `ImageCatalog` and `ClusterImageCatalog` resources.
 
 Below we provide some examples and, most importantly, the reasons why
 CloudNativePG requires full or partial management of standard Kubernetes


### PR DESCRIPTION
Mention `Database`, `Publication`, and `Subscription` CRDs in the security page.

Closes #6241 