### PR TITLE
fix: panic when recovering from an external server with no barman configuration

### DIFF
--- a/api/v1/cluster_webhook.go
+++ b/api/v1/cluster_webhook.go
@@ -878,7 +878,7 @@ func (r *Cluster) validateBootstrapRecoverySource() field.ErrorList {
 				fmt.Sprintf("External cluster %v not found", r.Spec.Bootstrap.Recovery.Source)))
 	}
 
-	// Ensure the external cluster definition have enough information
+	// Ensure the external cluster definition has enough information
 	// to be used to recover a data directory
 	if externalCluster.BarmanObjectStore == nil && externalCluster.PluginConfiguration == nil {
 		result = append(
@@ -886,9 +886,8 @@ func (r *Cluster) validateBootstrapRecoverySource() field.ErrorList {
 			field.Invalid(
 				field.NewPath("spec", "bootstrap", "recovery", "source"),
 				r.Spec.Bootstrap.Recovery.Source,
-				fmt.Sprintf("External cluster %v cannot be used to recover "+
-					"a cluster because both the barman and the CNPG-i plugin "+
-					"configuration are not present", r.Spec.Bootstrap.Recovery.Source)))
+				fmt.Sprintf("External cluster %v cannot be used for recovery: "+
+					"both Barman and CNPG-i plugin configurations are missing", r.Spec.Bootstrap.Recovery.Source)))
 	}
 
 	return result

--- a/api/v1/cluster_webhook.go
+++ b/api/v1/cluster_webhook.go
@@ -866,7 +866,9 @@ func (r *Cluster) validateBootstrapRecoverySource() field.ErrorList {
 		return result
 	}
 
-	_, found := r.ExternalCluster(r.Spec.Bootstrap.Recovery.Source)
+	externalCluster, found := r.ExternalCluster(r.Spec.Bootstrap.Recovery.Source)
+
+	// Ensure the existence of the external cluster
 	if !found {
 		result = append(
 			result,
@@ -874,6 +876,19 @@ func (r *Cluster) validateBootstrapRecoverySource() field.ErrorList {
 				field.NewPath("spec", "bootstrap", "recovery", "source"),
 				r.Spec.Bootstrap.Recovery.Source,
 				fmt.Sprintf("External cluster %v not found", r.Spec.Bootstrap.Recovery.Source)))
+	}
+
+	// Ensure the external cluster definition have enough information
+	// to be used to recover a data directory
+	if externalCluster.BarmanObjectStore == nil && externalCluster.PluginConfiguration == nil {
+		result = append(
+			result,
+			field.Invalid(
+				field.NewPath("spec", "bootstrap", "recovery", "source"),
+				r.Spec.Bootstrap.Recovery.Source,
+				fmt.Sprintf("External cluster %v cannot be used to recover "+
+					"a cluster because both the barman and the CNPG-i plugin "+
+					"configuration are not present", r.Spec.Bootstrap.Recovery.Source)))
 	}
 
 	return result

--- a/api/v1/cluster_webhook_test.go
+++ b/api/v1/cluster_webhook_test.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cloudnative-pg/barman-cloud/pkg/api"
 	"github.com/cloudnative-pg/machinery/pkg/image/reference"
 	pgversion "github.com/cloudnative-pg/machinery/pkg/postgres/version"
 	storagesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
@@ -2328,23 +2329,46 @@ var _ = Describe("bootstrap recovery validation", func() {
 		Expect(result).To(BeEmpty())
 	})
 
-	It("does not complain when bootstrap recovery source matches one of the names of external clusters", func() {
-		recoveryCluster := &Cluster{
-			Spec: ClusterSpec{
-				Bootstrap: &BootstrapConfiguration{
-					Recovery: &BootstrapRecovery{
-						Source: "test",
+	Context("does not complain when bootstrap recovery source matches one of the names of external clusters", func() {
+		When("using a barman object store configuration", func() {
+			recoveryCluster := &Cluster{
+				Spec: ClusterSpec{
+					Bootstrap: &BootstrapConfiguration{
+						Recovery: &BootstrapRecovery{
+							Source: "test",
+						},
+					},
+					ExternalClusters: []ExternalCluster{
+						{
+							Name:              "test",
+							BarmanObjectStore: &api.BarmanObjectStoreConfiguration{},
+						},
 					},
 				},
-				ExternalClusters: []ExternalCluster{
-					{
-						Name: "test",
+			}
+			errorsList := recoveryCluster.validateBootstrapRecoverySource()
+			Expect(errorsList).To(BeEmpty())
+		})
+
+		When("using a plugin configuration", func() {
+			recoveryCluster := &Cluster{
+				Spec: ClusterSpec{
+					Bootstrap: &BootstrapConfiguration{
+						Recovery: &BootstrapRecovery{
+							Source: "test",
+						},
+					},
+					ExternalClusters: []ExternalCluster{
+						{
+							Name:                "test",
+							PluginConfiguration: &PluginConfiguration{},
+						},
 					},
 				},
-			},
-		}
-		errorsList := recoveryCluster.validateBootstrapRecoverySource()
-		Expect(errorsList).To(BeEmpty())
+			}
+			errorsList := recoveryCluster.validateBootstrapRecoverySource()
+			Expect(errorsList).To(BeEmpty())
+		})
 	})
 
 	It("complains when bootstrap recovery source does not match one of the names of external clusters", func() {
@@ -2364,6 +2388,25 @@ var _ = Describe("bootstrap recovery validation", func() {
 		}
 		errorsList := recoveryCluster.validateBootstrapRecoverySource()
 		Expect(errorsList).ToNot(BeEmpty())
+	})
+
+	It("complains when bootstrap recovery source have no BarmanObjectStore nor plugin configuration", func() {
+		recoveryCluster := &Cluster{
+			Spec: ClusterSpec{
+				Bootstrap: &BootstrapConfiguration{
+					Recovery: &BootstrapRecovery{
+						Source: "test",
+					},
+				},
+				ExternalClusters: []ExternalCluster{
+					{
+						Name: "test",
+					},
+				},
+			},
+		}
+		errorsList := recoveryCluster.validateBootstrapRecoverySource()
+		Expect(errorsList).To(HaveLen(1))
 	})
 })
 

--- a/pkg/management/postgres/restore.go
+++ b/pkg/management/postgres/restore.go
@@ -511,6 +511,11 @@ func (info InitInfo) loadBackupObjectFromExternalCluster(
 	if !found {
 		return nil, nil, fmt.Errorf("missing external cluster: %v", sourceName)
 	}
+
+	if server.BarmanObjectStore == nil {
+		return nil, nil, fmt.Errorf("missing barman object store configuration for source: %v", sourceName)
+	}
+
 	serverName := server.GetServerName()
 
 	env, err := barmanCredentials.EnvSetRestoreCloudCredentials(


### PR DESCRIPTION
The instance manager panicked when recovering from an external server with no Barman object store configuration and no plugin configuration.

This patch fixes that and prevents such a configuration from being applied using the validation webhook.

Closes: #6295 