### PR TITLE
docs: Remove deprecated Pod Security Policies from docs

### DIFF
--- a/docs/src/operator_capability_levels.md
+++ b/docs/src/operator_capability_levels.md
@@ -159,7 +159,7 @@ CloudNativePG supports
 [management of PostgreSQL roles, users, and groups through declarative configuration](declarative_role_management.md)
 using the `.spec.managed.roles` stanza.
 
-### Pod security policies
+### Pod security standards
 
 For InfoSec requirements, the operator doesn't require privileged mode for
 any container. It enforces a read-only root filesystem to guarantee containers

--- a/docs/src/security.md
+++ b/docs/src/security.md
@@ -293,7 +293,7 @@ CloudNativePG.
 : The instance manager requires to `update` and `patch` the status of any
   `Backup` resource in the namespace
 
-### Security Contexts
+### Pod and Container Security Contexts
 
 A [Security Context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)
 defines privilege and access control settings for a pod or container.
@@ -325,11 +325,10 @@ securityContext:
     type: RuntimeDefault
 ```
 
-#### RedHat OpenShift SCC
+#### Security Context Constraints
 
-When running in a RedHat OpenShift environment the operator does not explicitly set the security context of the
-PostgreSQL cluster pods, but rather allows the pods to inherit the restricted [Security Context Constraints (SCC)](https://docs.openshift.com/container-platform/4.17/authentication/managing-security-context-constraints.html) 
-that are defined within OpenShift.
+When running in an environment that is utilizing [Security Context Constraints (SCC)](https://docs.openshift.com/container-platform/4.17/authentication/managing-security-context-constraints.html)
+the operator does not explicitly set the security context of the PostgreSQL cluster pods, but rather allows the pods to inherit the restricted Security Context Constraints that are already defined.
 
 ### Restricting Pod access using AppArmor
 

--- a/docs/src/security.md
+++ b/docs/src/security.md
@@ -299,19 +299,23 @@ A [Security Context](https://kubernetes.io/docs/tasks/configure-pod-container/se
 defines privilege and access control settings for a pod or container.
 
 CloudNativePG does not require *privileged* mode for container execution.
-The PostgreSQL containers run as the `postgres` system user. No component whatsoever requires running as `root`.
+The PostgreSQL containers run as the `postgres` system user. No component
+whatsoever requires running as `root`.
 
-Likewise, Volume access does not require *privileged* mode nor `root` privileges.
-Proper permissions must be assigned by the Kubernetes platform and/or administrators.
-The PostgreSQL containers run with a read-only root filesystem (i.e. no writable layer).
+Likewise, Volume access does not require *privileged* mode nor `root`
+privileges. Proper permissions must be assigned by the Kubernetes platform
+and/or administrators. The PostgreSQL containers run with a read-only root
+filesystem (i.e. no writable layer).
 
-The operator manages the setting of security contexts for all pods and containers of a PostgreSQL cluster.
-The [Seccomp Profile](https://kubernetes.io/docs/tutorials/security/seccomp/) to be used for the PostgreSQL
-containers can be configured with the `spec.seccompProfile` section of the `Cluster` resource. If this 
-section is left blank, the containers will use a seccompProfile `Type` of `RuntimeDefault`, that is, the
-container runtime default.
+The operator manages the setting of security contexts for all pods and 
+containers of a PostgreSQL cluster. The [Seccomp Profile](https://kubernetes.io/docs/tutorials/security/seccomp/) 
+to be used for the PostgreSQL containers can be configured with the 
+`spec.seccompProfile` section of the `Cluster` resource. If this section is left
+blank, the containers will use a seccompProfile `Type` of `RuntimeDefault`, that
+is, the container runtime default.
 
-The security context of PostgreSQL containers using the default `seccompProfile` will look like this:
+The security context of PostgreSQL containers using the default `seccompProfile`
+will look like this:
 ```
 securityContext:
   allowPrivilegeEscalation: false
@@ -327,8 +331,11 @@ securityContext:
 
 #### Security Context Constraints
 
-When running in an environment that is utilizing [Security Context Constraints (SCC)](https://docs.openshift.com/container-platform/4.17/authentication/managing-security-context-constraints.html)
-the operator does not explicitly set the security context of the PostgreSQL cluster pods, but rather allows the pods to inherit the restricted Security Context Constraints that are already defined.
+When running in an environment that is utilizing
+[Security Context Constraints (SCC)](https://docs.openshift.com/container-platform/4.17/authentication/managing-security-context-constraints.html)
+the operator does not explicitly set the security context of the PostgreSQL
+cluster pods, but rather allows the pods to inherit the restricted Security
+Context Constraints that are already defined.
 
 ### Restricting Pod access using AppArmor
 

--- a/docs/src/security.md
+++ b/docs/src/security.md
@@ -293,28 +293,43 @@ CloudNativePG.
 : The instance manager requires to `update` and `patch` the status of any
   `Backup` resource in the namespace
 
-### Pod Security Policies
+### Security Contexts
 
-!!! Important
-    Starting from Kubernetes v1.21, the use of `PodSecurityPolicy` has been
-    deprecated, and as of Kubernetes v1.25, it has been completely removed. Despite
-    this deprecation, we acknowledge that the operator is currently undergoing
-    testing in older and unsupported versions of Kubernetes. Therefore, this
-    section is retained for those specific scenarios.
+A [Security Context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)
+defines privilege and access control settings for a pod or container.
 
-A [Pod Security Policy](https://kubernetes.io/docs/concepts/policy/pod-security-policy/)
-is the Kubernetes way to define security rules and specifications that a pod needs to meet
-to run in a cluster.
-For InfoSec reasons, every Kubernetes platform should implement them.
+CloudNativePG does not require *privileged* mode for container execution.
+The PostgreSQL containers run as the `postgres` system user. No component whatsoever requires running as `root`.
 
-CloudNativePG does not require *privileged* mode for containers execution.
-The PostgreSQL containers run as `postgres` system user. No component whatsoever requires running as `root`.
-
-Likewise, Volumes access does not require *privileges* mode or `root` privileges either.
-Proper permissions must be properly assigned by the Kubernetes platform and/or administrators.
+Likewise, Volume access does not require *privileged* mode nor `root` privileges.
+Proper permissions must be assigned by the Kubernetes platform and/or administrators.
 The PostgreSQL containers run with a read-only root filesystem (i.e. no writable layer).
 
-The operator explicitly sets the required security contexts.
+The operator manages the setting of security contexts for all pods and containers of a PostgreSQL cluster.
+The [Seccomp Profile](https://kubernetes.io/docs/tutorials/security/seccomp/) to be used for the PostgreSQL
+containers can be configured with the `spec.seccompProfile` section of the `Cluster` resource. If this 
+section is left blank, the containers will use a seccompProfile `Type` of `RuntimeDefault`, that is, the
+container runtime default.
+
+The security context of PostgreSQL containers using the default `seccompProfile` will look like this:
+```
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+    - ALL
+  privileged: false
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
+```
+
+#### RedHat OpenShift SCC
+
+When running in a RedHat OpenShift environment the operator does not explicitly set the security context of the
+PostgreSQL cluster pods, but rather allows the pods to inherit the restricted [Security Context Constraints (SCC)](https://docs.openshift.com/container-platform/4.17/authentication/managing-security-context-constraints.html) 
+that are defined within OpenShift.
 
 ### Restricting Pod access using AppArmor
 


### PR DESCRIPTION
Removing deprecated Pod Security Policies information from security docs. 

Closes #5996
