### PR TITLE
fix: deadlock when a plugin is used multiple times

### DIFF
--- a/internal/cnpi/plugin/repository/connection.go
+++ b/internal/cnpi/plugin/repository/connection.go
@@ -26,6 +26,10 @@ import (
 	"github.com/cloudnative-pg/cloudnative-pg/internal/cnpi/plugin/connection"
 )
 
+// maxConnectionAttempts is the maximum number of connections attempts to a
+// plugin. maxConnectionAttempts should be higher or equal to maxPoolSize
+const maxConnectionAttempts = 5
+
 type releasingConnection struct {
 	connection.Interface
 	closer func() error
@@ -51,7 +55,7 @@ func (r *data) GetConnection(ctx context.Context, name string) (connection.Inter
 	var resource *puddle.Resource[connection.Interface]
 	var err error
 
-	for i := 0; i < maxPoolSize; i++ {
+	for i := 0; i < maxConnectionAttempts; i++ {
 		contextLogger.Trace("try getting connection")
 		resource, err = pool.Acquire(ctx)
 		if err != nil {

--- a/internal/cnpi/plugin/repository/setup.go
+++ b/internal/cnpi/plugin/repository/setup.go
@@ -60,6 +60,8 @@ type data struct {
 	pluginConnectionPool map[string]*puddle.Pool[connection.Interface]
 }
 
+// maxPoolSize is the maximum number of connections in a plugin's connection
+// pool
 const maxPoolSize = 5
 
 func (r *data) setPluginProtocol(name string, protocol connection.Protocol) error {

--- a/internal/cnpi/plugin/repository/setup.go
+++ b/internal/cnpi/plugin/repository/setup.go
@@ -92,6 +92,8 @@ func (r *data) setPluginProtocol(name string, protocol connection.Protocol) erro
 			WithValues("pluginName", name)
 		ctx = log.IntoContext(ctx, constructorLogger)
 
+		constructorLogger.Trace("Acquired physical plugin connection")
+
 		if handler, err = protocol.Dial(ctx); err != nil {
 			constructorLogger.Error(err, "Got error while connecting to plugin")
 			return nil, err
@@ -101,6 +103,12 @@ func (r *data) setPluginProtocol(name string, protocol connection.Protocol) erro
 	}
 
 	destructor := func(res connection.Interface) {
+		constructorLogger := log.
+			FromContext(context.Background()).
+			WithName("setPluginProtocol").
+			WithValues("pluginName", name)
+		constructorLogger.Trace("Released physical plugin connection")
+
 		err := res.Close()
 		if err != nil {
 			destructorLogger := log.FromContext(context.Background()).

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -177,7 +177,11 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	// Load the plugins required to bootstrap and reconcile this cluster
 	enabledPluginNames := cluster.Spec.Plugins.GetEnabledPluginNames()
 	enabledPluginNames = append(enabledPluginNames, cluster.Spec.ExternalClusters.GetEnabledPluginNames()...)
-	pluginClient, err := cnpgiClient.WithPlugins(ctx, r.Plugins, enabledPluginNames...)
+
+	pluginLoadingContext, cancelPluginLoading := context.WithTimeout(ctx, 5*time.Second)
+	defer cancelPluginLoading()
+
+	pluginClient, err := cnpgiClient.WithPlugins(pluginLoadingContext, r.Plugins, enabledPluginNames...)
 	if err != nil {
 		var errUnknownPlugin *repository.ErrUnknownPlugin
 		if errors.As(err, &errUnknownPlugin) {


### PR DESCRIPTION
Now the operator requests one connection per used plugin, even if the same plugin has been requested
multiple times.

Fixes a deadlock arising when the same plugin is used multiple times. The operator was acquiring
multiple connections to the plugin, and could get stuck without releasing the ones it had already taken
in case of high concurrency.

Closes: #6310 