### PR TITLE
fix(roles): properly quote inRoles in SQL statements

### DIFF
--- a/internal/management/controller/roles/postgres.go
+++ b/internal/management/controller/roles/postgres.go
@@ -301,7 +301,13 @@ func GetParentRoles(ctx context.Context, db *sql.DB, role DatabaseRole) ([]strin
 
 func appendInRoleOptions(role DatabaseRole, query *strings.Builder) {
 	if len(role.InRoles) > 0 {
-		query.WriteString(fmt.Sprintf(" IN ROLE %s ", strings.Join(role.InRoles, ",")))
+		quotedInRoles := make([]string, len(role.InRoles))
+
+		for i, inRole := range role.InRoles {
+			quotedInRoles[i] = pq.QuoteIdentifier(inRole)
+		}
+
+		query.WriteString(fmt.Sprintf(" IN ROLE %s ", strings.Join(quotedInRoles, ",")))
 	}
 }
 

--- a/internal/management/controller/roles/postgres.go
+++ b/internal/management/controller/roles/postgres.go
@@ -304,7 +304,7 @@ func appendInRoleOptions(role DatabaseRole, query *strings.Builder) {
 		quotedInRoles := make([]string, len(role.InRoles))
 
 		for i, inRole := range role.InRoles {
-			quotedInRoles[i] = pq.QuoteIdentifier(inRole)
+			quotedInRoles[i] = pgx.Identifier{inRole}.Sanitize()
 		}
 
 		query.WriteString(fmt.Sprintf(" IN ROLE %s ", strings.Join(quotedInRoles, ",")))

--- a/internal/management/controller/roles/postgres_test.go
+++ b/internal/management/controller/roles/postgres_test.go
@@ -104,22 +104,22 @@ var _ = Describe("Postgres RoleManager implementation test", func() {
 	}
 	wantedRoleExpectedCrtStmt := fmt.Sprintf(
 		"CREATE ROLE \"%s\" BYPASSRLS NOCREATEDB CREATEROLE NOINHERIT LOGIN NOREPLICATION "+
-			"NOSUPERUSER CONNECTION LIMIT 2 IN ROLE pg_monitoring VALID UNTIL '2100-01-01 00:00:00Z'",
+			"NOSUPERUSER CONNECTION LIMIT 2 IN ROLE \"pg_monitoring\" VALID UNTIL '2100-01-01 00:00:00Z'",
 		wantedRole.Name)
 
 	wantedRoleWithPassExpectedCrtStmt := fmt.Sprintf(
 		"CREATE ROLE \"%s\" BYPASSRLS NOCREATEDB CREATEROLE NOINHERIT LOGIN NOREPLICATION "+
-			"NOSUPERUSER CONNECTION LIMIT 2 IN ROLE pg_monitoring PASSWORD 'myPassword' VALID UNTIL '2100-01-01 00:00:00Z'",
+			"NOSUPERUSER CONNECTION LIMIT 2 IN ROLE \"pg_monitoring\" PASSWORD 'myPassword' VALID UNTIL '2100-01-01 00:00:00Z'",
 		wantedRole.Name)
 
 	wantedRoleWithoutValidUntilExpectedCrtStmt := fmt.Sprintf(
 		"CREATE ROLE \"%s\" BYPASSRLS NOCREATEDB CREATEROLE NOINHERIT LOGIN NOREPLICATION "+
-			"NOSUPERUSER CONNECTION LIMIT 2 IN ROLE pg_monitoring PASSWORD 'myPassword'",
+			"NOSUPERUSER CONNECTION LIMIT 2 IN ROLE \"pg_monitoring\" PASSWORD 'myPassword'",
 		wantedRole.Name)
 
 	wantedRoleWithPassDeletionExpectedCrtStmt := fmt.Sprintf(
 		"CREATE ROLE \"%s\" BYPASSRLS NOCREATEDB CREATEROLE NOINHERIT LOGIN NOREPLICATION "+
-			"NOSUPERUSER CONNECTION LIMIT 2 IN ROLE pg_monitoring PASSWORD NULL VALID UNTIL '2100-01-01 00:00:00Z'",
+			"NOSUPERUSER CONNECTION LIMIT 2 IN ROLE \"pg_monitoring\" PASSWORD NULL VALID UNTIL '2100-01-01 00:00:00Z'",
 		wantedRole.Name)
 	wantedRoleWithDefaultConnectionLimitExpectedCrtStmt := fmt.Sprintf(
 		"CREATE ROLE \"%s\" NOBYPASSRLS NOCREATEDB NOCREATEROLE INHERIT NOLOGIN NOREPLICATION "+


### PR DESCRIPTION
This patch fixes an issue where the `inRoles` parameter was not properly quoted in SQL statements, which could cause syntax errors if the role name contains special characters.

Closes #6337 

## Release notes

Properly quote `inRoles` in SQL statements to prevent potential syntax errors in the generated SQL.
