### PR TITLE
fix: add missing labels in container images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,14 +12,16 @@ ARG VERSION="dev"
 ARG TARGETARCH
 
 ENV SUMMARY="CloudNativePG Operator Container Image." \
-    DESCRIPTION="This Docker image contains CloudNativePG Operator."
+    DESCRIPTION="This Docker image contains CloudNativePG Operator." \
+    MAINTAINER="CloudNativePG Contributors."
 
 LABEL summary="$SUMMARY" \
       description="$DESCRIPTION" \
       io.k8s.display-name="$SUMMARY" \
       io.k8s.description="$DESCRIPTION" \
       name="CloudNativePG Operator" \
-      vendor="CloudNativePG Contributors" \
+      vendor="$MAINTAINER" \
+      maintainer="$MAINTAINER" \
       url="https://cloudnative-pg.io/" \
       version="$VERSION" \
       release="1"

--- a/Dockerfile-ubi8
+++ b/Dockerfile-ubi8
@@ -3,14 +3,16 @@ ARG VERSION="dev"
 ARG TARGETARCH
 
 ENV SUMMARY="CloudNativePG Operator Container Image." \
-    DESCRIPTION="This Docker image contains CloudNativePG Operator."
+    DESCRIPTION="This Docker image contains CloudNativePG Operator." \
+    MAINTAINER="CloudNativePG Contributors."
 
 LABEL summary="$SUMMARY" \
       description="$DESCRIPTION" \
       io.k8s.display-name="$SUMMARY" \
       io.k8s.description="$DESCRIPTION" \
       name="CloudNativePG Operator" \
-      vendor="CloudNativePG Contributors" \
+      vendor="$MAINTAINER" \
+      maintainer="$MAINTAINER" \
       url="https://cloudnative-pg.io/" \
       version="$VERSION" \
       release="1"

--- a/Dockerfile-ubi9
+++ b/Dockerfile-ubi9
@@ -3,14 +3,16 @@ ARG VERSION="dev"
 ARG TARGETARCH
 
 ENV SUMMARY="CloudNativePG Operator Container Image." \
-    DESCRIPTION="This Docker image contains CloudNativePG Operator."
+    DESCRIPTION="This Docker image contains CloudNativePG Operator." \
+    MAINTAINER="CloudNativePG Contributors."
 
 LABEL summary="$SUMMARY" \
       description="$DESCRIPTION" \
       io.k8s.display-name="$SUMMARY" \
       io.k8s.description="$DESCRIPTION" \
       name="CloudNativePG Operator" \
-      vendor="CloudNativePG Contributors" \
+      vendor="$MAINTAINER" \
+      maintainer="$MAINTAINER" \
       url="https://cloudnative-pg.io/" \
       version="$VERSION" \
       release="1"


### PR DESCRIPTION
The operator was missing a label "maintainer" for certifications
and also for standards, it was relying on having the label from
the parent image.