### PR TITLE
fix: improve efficiency of replication-sensitive parameter updates

### DIFF
--- a/api/v1/cluster_funcs.go
+++ b/api/v1/cluster_funcs.go
@@ -682,8 +682,8 @@ func (cluster *Cluster) GetSmartShutdownTimeout() int32 {
 
 // GetRestartTimeout is used to have a timeout for operations that involve
 // a restart of a PostgreSQL instance
-func (cluster *Cluster) GetRestartTimeout() int32 {
-	return cluster.GetMaxStopDelay() + cluster.GetMaxStartDelay()
+func (cluster *Cluster) GetRestartTimeout() time.Duration {
+	return time.Duration(cluster.GetMaxStopDelay()+cluster.GetMaxStartDelay()) * time.Second
 }
 
 // GetMaxSwitchoverDelay get the amount of time PostgreSQL has to stop before switchover

--- a/internal/management/controller/instance_controller.go
+++ b/internal/management/controller/instance_controller.go
@@ -1091,6 +1091,7 @@ func (r *InstanceReconciler) triggerRestartForDecrease(ctx context.Context, clus
 		r.client,
 		cluster,
 		clusterstatus.SetPhaseTX(phase, phaseReason),
+		clusterstatus.SetClusterReadyConditionTX,
 	)
 }
 

--- a/internal/management/controller/instance_controller.go
+++ b/internal/management/controller/instance_controller.go
@@ -1086,7 +1086,12 @@ func (r *InstanceReconciler) triggerRestartForDecrease(ctx context.Context, clus
 	phase := apiv1.PhaseApplyingConfiguration
 	phaseReason := "Decrease of hot standby sensitive parameters"
 
-	return clusterstatus.RegisterPhase(ctx, r.client, cluster, phase, phaseReason)
+	return clusterstatus.PatchWithOptimisticLock(
+		ctx,
+		r.client,
+		cluster,
+		clusterstatus.SetPhaseTX(phase, phaseReason),
+	)
 }
 
 // refreshCertificateFilesFromSecret receive a secret and rewrite the file

--- a/internal/management/controller/instance_controller.go
+++ b/internal/management/controller/instance_controller.go
@@ -318,11 +318,10 @@ func (r *InstanceReconciler) restartPrimaryInplaceIfRequested(
 		if cluster.Status.CurrentPrimary != cluster.Status.TargetPrimary {
 			return false, fmt.Errorf("cannot restart the primary in-place when a switchover is in progress")
 		}
-		restartTimeout := cluster.GetRestartTimeout()
 
 		if err := r.instance.RequestAndWaitRestartSmartFast(
 			ctx,
-			time.Duration(restartTimeout)*time.Second,
+			cluster.GetRestartTimeout(),
 		); err != nil {
 			return true, err
 		}
@@ -1080,8 +1079,7 @@ func (r *InstanceReconciler) triggerRestartForDecrease(ctx context.Context, clus
 	contextLogger := log.FromContext(ctx)
 
 	contextLogger.Info("Restarting primary in-place due to hot standby sensible parameters decrease")
-	restartTimeout := time.Duration(cluster.GetRestartTimeout()) * time.Second
-	if err := r.Instance().RequestAndWaitRestartSmartFast(ctx, restartTimeout); err != nil {
+	if err := r.Instance().RequestAndWaitRestartSmartFast(ctx, cluster.GetRestartTimeout()); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
When decreasing values of replication-sensitive parameters, such as  
`max_connections`, the reconciliation process could experience delays due to  
inefficient update propagation. In cases where these parameters are reduced  
using an unsupervised method, the instance manager does not trigger a  
reconciliation loop after the primary server restarts, leading to potential  
delays in applying the new configuration.  

This patch resolves the issue by ensuring that the status is updated with a  
known phase and reason, allowing the operator to promptly detect and  
synchronize the changes.  

Closes #6409  

## Release notes  

Improve the handling of replication-sensitive parameter reductions by ensuring  
timely reconciliation after primary server restarts.  