### PR TITLE
chore(plugin-backup): use exit code `2` when encountering kube-api server errors

### DIFF
--- a/cmd/kubectl-cnpg/main.go
+++ b/cmd/kubectl-cnpg/main.go
@@ -20,6 +20,7 @@ kubectl-cnp is a plugin to manage your CloudNativePG clusters
 package main
 
 import (
+	"errors"
 	"os"
 
 	"github.com/cloudnative-pg/machinery/pkg/log"
@@ -30,6 +31,7 @@ import (
 	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/plugin/backup"
 	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/plugin/certificate"
 	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/plugin/destroy"
+	pluginErrors "github.com/cloudnative-pg/cloudnative-pg/internal/cmd/plugin/errors"
 	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/plugin/fence"
 	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/plugin/fio"
 	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/plugin/hibernate"
@@ -139,6 +141,10 @@ func main() {
 	}
 
 	if err := rootCmd.Execute(); err != nil {
+		var pluginErr *pluginErrors.PluginError
+		if errors.As(err, &pluginErr) {
+			os.Exit(pluginErr.Code)
+		}
 		os.Exit(1)
 	}
 }

--- a/internal/cmd/plugin/errors/custom.go
+++ b/internal/cmd/plugin/errors/custom.go
@@ -1,0 +1,21 @@
+package errors
+
+import "fmt"
+
+// PluginError is a type that allows us to define a custom exit code for the error
+type PluginError struct {
+	Code  int
+	error error
+}
+
+func (e *PluginError) Error() string {
+	return e.error.Error()
+}
+
+// NewKubeAPIServerError returns a new PluginError with an exit code of 2
+func NewKubeAPIServerError(err error) *PluginError {
+	return &PluginError{
+		Code:  2,
+		error: fmt.Errorf("while interacting with the kube-api server: %w", err),
+	}
+}

--- a/internal/cmd/plugin/errors/doc.go
+++ b/internal/cmd/plugin/errors/doc.go
@@ -1,0 +1,2 @@
+// Package errors provides a way to create and handle errors in a consistent way.
+package errors

--- a/tests/utils/backups/backup.go
+++ b/tests/utils/backups/backup.go
@@ -23,10 +23,10 @@ import (
 	"os"
 	"os/exec"
 
-	v1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
+	storagesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
-	v2 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
@@ -74,12 +74,12 @@ func GetVolumeSnapshot(
 	ctx context.Context,
 	crudClient client.Client,
 	namespace, name string,
-) (*v1.VolumeSnapshot, error) {
+) (*storagesnapshotv1.VolumeSnapshot, error) {
 	namespacedName := types.NamespacedName{
 		Namespace: namespace,
 		Name:      name,
 	}
-	volumeSnapshot := &v1.VolumeSnapshot{}
+	volumeSnapshot := &storagesnapshotv1.VolumeSnapshot{}
 	err := objects.Get(ctx, crudClient, namespacedName, volumeSnapshot)
 	if err != nil {
 		return nil, err
@@ -151,7 +151,7 @@ func GetConditionsInClusterStatus(
 	namespace,
 	clusterName string,
 	conditionType apiv1.ClusterConditionType,
-) (*v2.Condition, error) {
+) (*metav1.Condition, error) {
 	var cluster *apiv1.Cluster
 	var err error
 
@@ -253,7 +253,7 @@ func CreateClusterFromBackupUsingPITR(
 	}
 	storageClassName := os.Getenv("E2E_DEFAULT_STORAGE_CLASS")
 	restoreCluster := &apiv1.Cluster{
-		ObjectMeta: v2.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      clusterName,
 			Namespace: namespace,
 		},
@@ -315,7 +315,7 @@ func CreateClusterFromExternalClusterBackupWithPITROnMinio(
 	storageClassName := os.Getenv("E2E_DEFAULT_STORAGE_CLASS")
 
 	restoreCluster := &apiv1.Cluster{
-		ObjectMeta: v2.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      externalClusterName,
 			Namespace: namespace,
 		},
@@ -405,7 +405,7 @@ func CreateOnDemand(
 	method apiv1.BackupMethod,
 ) (*apiv1.Backup, error) {
 	targetBackup := &apiv1.Backup{
-		ObjectMeta: v2.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      backupName,
 			Namespace: namespace,
 		},


### PR DESCRIPTION
Closes #6412 

