### PR TITLE
test(e2e): add a higher timeout and better error descriptions to `switchWalAndGetLatestArchive`

### DIFF
--- a/tests/e2e/asserts_test.go
+++ b/tests/e2e/asserts_test.go
@@ -2007,17 +2007,21 @@ func switchWalAndGetLatestArchive(namespace, podName string) string {
 		},
 		postgres.PostgresDBName,
 		"CHECKPOINT;")
-	Expect(err).ToNot(HaveOccurred())
+	Expect(err).ToNot(HaveOccurred(),
+		"failed to trigger a new wal while executing 'switchWalAndGetLatestArchive'")
 
-	out, _, err := exec.QueryInInstancePod(
+	out, _, err := exec.QueryInInstancePodWithTimeout(
 		env.Ctx, env.Client, env.Interface, env.RestClientConfig,
 		exec.PodLocator{
 			Namespace: namespace,
 			PodName:   podName,
 		},
 		postgres.PostgresDBName,
-		"SELECT pg_walfile_name(pg_switch_wal());")
-	Expect(err).ToNot(HaveOccurred())
+		"SELECT pg_walfile_name(pg_switch_wal());",
+		20,
+	)
+	Expect(err).ToNot(HaveOccurred(), "failed to get latest wal file name while executing "+
+		"'switchWalAndGetLatestArchive")
 
 	return strings.TrimSpace(out)
 }

--- a/tests/utils/exec/exec.go
+++ b/tests/utils/exec/exec.go
@@ -107,6 +107,21 @@ func QueryInInstancePod(
 	query string,
 ) (string, string, error) {
 	timeout := time.Second * 10
+	return QueryInInstancePodWithTimeout(ctx, crudClient, kubeInterface, restConfig, podLocator, dbname, query, timeout)
+}
+
+// QueryInInstancePodWithTimeout executes a query in an instance pod, by connecting to the pod
+// and the postgres container, and using a local connection with the postgres user
+func QueryInInstancePodWithTimeout(
+	ctx context.Context,
+	crudClient client.Client,
+	kubeInterface kubernetes.Interface,
+	restConfig *rest.Config,
+	podLocator PodLocator,
+	dbname DatabaseName,
+	query string,
+	timeout time.Duration,
+) (string, string, error) {
 	return CommandInInstancePod(
 		ctx, crudClient, kubeInterface, restConfig,
 		PodLocator{


### PR DESCRIPTION
Closes #6413 
