### PR TITLE
fix(managed-services): preserve user specified port settings

### DIFF
--- a/pkg/specs/services.go
+++ b/pkg/specs/services.go
@@ -155,7 +155,8 @@ func BuildManagedServices(cluster apiv1.Cluster) ([]corev1.Service, error) {
 			SetSelectors(defaultService.Spec.Selector)
 
 		for idx := range defaultService.Spec.Ports {
-			builder = builder.WithServicePort(&defaultService.Spec.Ports[idx])
+			// we preserve the user settings over the default configuration, issue: #6389
+			builder = builder.WithServicePortNoOverwrite(&defaultService.Spec.Ports[idx])
 		}
 
 		for key, value := range defaultService.Labels {

--- a/pkg/specs/services_test.go
+++ b/pkg/specs/services_test.go
@@ -108,6 +108,15 @@ var _ = Describe("BuildManagedServices", func() {
 										Selector: map[string]string{
 											"additional": "true",
 										},
+										Ports: []corev1.ServicePort{
+											{
+												Name:       PostgresContainerName,
+												Protocol:   corev1.ProtocolTCP,
+												TargetPort: intstr.FromInt32(postgres.ServerPort),
+												Port:       postgres.ServerPort,
+												NodePort:   5533,
+											},
+										},
 									},
 								},
 							},
@@ -152,6 +161,14 @@ var _ = Describe("BuildManagedServices", func() {
 			Expect(services[0].ObjectMeta.Labels).To(HaveKeyWithValue(utils.IsManagedLabelName, "true"))
 			Expect(services[0].ObjectMeta.Labels).To(HaveKeyWithValue("test-label", "test-value"))
 			Expect(services[0].ObjectMeta.Annotations).To(HaveKeyWithValue("test-annotation", "test-value"))
+		})
+
+		It("should not overwrite the user specified service port with the default one", func() {
+			services, err := BuildManagedServices(cluster)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(services).NotTo(BeNil())
+			Expect(services).To(HaveLen(1))
+			Expect(services[0].Spec.Ports[0].NodePort).To(Equal(int32(5533)))
 		})
 	})
 })

--- a/pkg/specs/services_test.go
+++ b/pkg/specs/services_test.go
@@ -108,15 +108,6 @@ var _ = Describe("BuildManagedServices", func() {
 										Selector: map[string]string{
 											"additional": "true",
 										},
-										Ports: []corev1.ServicePort{
-											{
-												Name:       PostgresContainerName,
-												Protocol:   corev1.ProtocolTCP,
-												TargetPort: intstr.FromInt32(postgres.ServerPort),
-												Port:       postgres.ServerPort,
-												NodePort:   5533,
-											},
-										},
 									},
 								},
 							},
@@ -161,9 +152,25 @@ var _ = Describe("BuildManagedServices", func() {
 			Expect(services[0].ObjectMeta.Labels).To(HaveKeyWithValue(utils.IsManagedLabelName, "true"))
 			Expect(services[0].ObjectMeta.Labels).To(HaveKeyWithValue("test-label", "test-value"))
 			Expect(services[0].ObjectMeta.Annotations).To(HaveKeyWithValue("test-annotation", "test-value"))
+			Expect(services[0].Spec.Ports).To(ContainElement(corev1.ServicePort{
+				Name:       PostgresContainerName,
+				Protocol:   corev1.ProtocolTCP,
+				TargetPort: intstr.FromInt32(postgres.ServerPort),
+				Port:       postgres.ServerPort,
+				NodePort:   0,
+			}))
 		})
 
 		It("should not overwrite the user specified service port with the default one", func() {
+			cluster.Spec.Managed.Services.Additional[0].ServiceTemplate.Spec.Ports = []corev1.ServicePort{
+				{
+					Name:       PostgresContainerName,
+					Protocol:   corev1.ProtocolTCP,
+					TargetPort: intstr.FromInt32(postgres.ServerPort),
+					Port:       postgres.ServerPort,
+					NodePort:   5533,
+				},
+			}
 			services, err := BuildManagedServices(cluster)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(services).NotTo(BeNil())


### PR DESCRIPTION
Closes #6389 

## Release Notes

```
The ports specified in the managed services will now take precedence over the defaults defined by the operator.
```


