### PR TITLE
fix: linter errors for golangci-lint 1.63.1

### DIFF
--- a/internal/cmd/plugin/psql/psql_test.go
+++ b/internal/cmd/plugin/psql/psql_test.go
@@ -69,8 +69,9 @@ var _ = Describe("psql launcher", func() {
 		}
 
 		_, err := cmd.getPodName()
-		Expect(err).To(HaveOccurred())
-		Expect(err.(*ErrMissingPod)).To(HaveOccurred())
+		Expect(err).To(MatchError((&ErrMissingPod{
+			role: "primary",
+		}).Error()))
 	})
 
 	It("correctly composes a kubectl exec command line", func() {

--- a/internal/cmd/plugin/psql/psql_test.go
+++ b/internal/cmd/plugin/psql/psql_test.go
@@ -70,7 +70,7 @@ var _ = Describe("psql launcher", func() {
 
 		_, err := cmd.getPodName()
 		Expect(err).To(HaveOccurred())
-		Expect(err.(*ErrMissingPod)).ToNot(BeNil())
+		Expect(err.(*ErrMissingPod)).To(HaveOccurred())
 	})
 
 	It("correctly composes a kubectl exec command line", func() {


### PR DESCRIPTION
The new version of golangci-lint 1.63.1 detected a new issue that we should fix.

Closes #6488 