### PR TITLE
fix: ensure operator version is reconciled

### DIFF
--- a/api/v1/cluster_funcs.go
+++ b/api/v1/cluster_funcs.go
@@ -601,12 +601,18 @@ func (cluster *Cluster) GetClientCASecretName() string {
 }
 
 // GetFixedInheritedAnnotations gets the annotations that should be
-// inherited by all resources according the cluster spec
+// inherited by all resources according to the cluster spec and the operator version
 func (cluster *Cluster) GetFixedInheritedAnnotations() map[string]string {
+	var meta metav1.ObjectMeta
+	utils.SetOperatorVersion(&meta, versions.Version)
+
 	if cluster.Spec.InheritedMetadata == nil || cluster.Spec.InheritedMetadata.Annotations == nil {
-		return nil
+		return meta.Annotations
 	}
-	return cluster.Spec.InheritedMetadata.Annotations
+
+	utils.MergeMap(meta.Annotations, cluster.Spec.InheritedMetadata.Annotations)
+
+	return meta.Annotations
 }
 
 // GetFixedInheritedLabels gets the labels that should be
@@ -1210,7 +1216,6 @@ func (cluster *Cluster) SetInheritedData(obj *metav1.ObjectMeta) {
 	utils.InheritAnnotations(obj, cluster.Annotations, cluster.GetFixedInheritedAnnotations(), configuration.Current)
 	utils.InheritLabels(obj, cluster.Labels, cluster.GetFixedInheritedLabels(), configuration.Current)
 	utils.LabelClusterName(obj, cluster.GetName())
-	utils.SetOperatorVersion(obj, versions.Version)
 }
 
 // ShouldForceLegacyBackup if present takes a backup without passing the name argument even on barman version 3.3.0+.

--- a/internal/controller/cluster_create.go
+++ b/internal/controller/cluster_create.go
@@ -1169,7 +1169,6 @@ func (r *ClusterReconciler) createPrimaryInstance(
 		"jobName", job.Name,
 		"primary", true)
 
-	utils.SetOperatorVersion(&job.ObjectMeta, versions.Version)
 	utils.InheritAnnotations(&job.ObjectMeta, cluster.Annotations,
 		cluster.GetFixedInheritedAnnotations(), configuration.Current)
 	utils.InheritAnnotations(&job.Spec.Template.ObjectMeta, cluster.Annotations,
@@ -1266,7 +1265,6 @@ func (r *ClusterReconciler) joinReplicaInstance(
 		return ctrl.Result{}, err
 	}
 
-	utils.SetOperatorVersion(&job.ObjectMeta, versions.Version)
 	utils.InheritAnnotations(&job.ObjectMeta, cluster.Annotations,
 		cluster.GetFixedInheritedAnnotations(), configuration.Current)
 	utils.InheritAnnotations(&job.Spec.Template.ObjectMeta, cluster.Annotations,
@@ -1375,7 +1373,6 @@ func (r *ClusterReconciler) ensureInstancesAreCreated(
 		return ctrl.Result{}, fmt.Errorf("unable to set the owner reference for the Pod: %w", err)
 	}
 
-	utils.SetOperatorVersion(&instanceToCreate.ObjectMeta, versions.Version)
 	utils.InheritAnnotations(&instanceToCreate.ObjectMeta, cluster.Annotations,
 		cluster.GetFixedInheritedAnnotations(), configuration.Current)
 	utils.InheritLabels(&instanceToCreate.ObjectMeta, cluster.Labels,

--- a/pkg/reconciler/persistentvolumeclaim/reconciler_test.go
+++ b/pkg/reconciler/persistentvolumeclaim/reconciler_test.go
@@ -402,8 +402,9 @@ var _ = Describe("PVC reconciliation", Ordered, func() {
 			utils.ClusterInstanceRoleLabelName: "replica",
 		}))
 		Expect(patchedPvc2.Annotations).To(Equal(map[string]string{
-			utils.ClusterSerialAnnotationName: "2",
-			utils.PVCStatusAnnotationName:     "ready",
+			utils.OperatorVersionAnnotationName: versions.Version,
+			utils.ClusterSerialAnnotationName:   "2",
+			utils.PVCStatusAnnotationName:       "ready",
 		}))
 
 		patchedPvc3Wal := fetchPVC(cl, pvc3Wal)
@@ -414,8 +415,9 @@ var _ = Describe("PVC reconciliation", Ordered, func() {
 			utils.ClusterInstanceRoleLabelName: "replica",
 		}))
 		Expect(patchedPvc3Wal.Annotations).To(Equal(map[string]string{
-			utils.ClusterSerialAnnotationName: "3",
-			utils.PVCStatusAnnotationName:     "ready",
+			utils.OperatorVersionAnnotationName: versions.Version,
+			utils.ClusterSerialAnnotationName:   "3",
+			utils.PVCStatusAnnotationName:       "ready",
 		}))
 
 		patchedPvc3Data := fetchPVC(cl, pvc3Data)
@@ -426,8 +428,9 @@ var _ = Describe("PVC reconciliation", Ordered, func() {
 			utils.ClusterInstanceRoleLabelName: "replica",
 		}))
 		Expect(patchedPvc3Data.Annotations).To(Equal(map[string]string{
-			utils.ClusterSerialAnnotationName: "3",
-			utils.PVCStatusAnnotationName:     "ready",
+			utils.OperatorVersionAnnotationName: versions.Version,
+			utils.ClusterSerialAnnotationName:   "3",
+			utils.PVCStatusAnnotationName:       "ready",
 		}))
 	})
 })

--- a/pkg/reconciler/persistentvolumeclaim/reconciler_test.go
+++ b/pkg/reconciler/persistentvolumeclaim/reconciler_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cloudnative-pg/cloudnative-pg/internal/scheme"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/specs"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/versions"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -255,10 +256,11 @@ var _ = Describe("PVC reconciliation", Ordered, func() {
 		)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(pvcs.Items[2].Annotations).To(BeEquivalentTo(map[string]string{
-			utils.PVCStatusAnnotationName:     "ready",
-			utils.ClusterSerialAnnotationName: "3",
-			"annotation1":                     "value",
-			"annotation2":                     "value",
+			utils.PVCStatusAnnotationName:       "ready",
+			utils.ClusterSerialAnnotationName:   "3",
+			"annotation1":                       "value",
+			"annotation2":                       "value",
+			utils.OperatorVersionAnnotationName: versions.Version,
 		}))
 	})
 
@@ -387,8 +389,9 @@ var _ = Describe("PVC reconciliation", Ordered, func() {
 			utils.ClusterInstanceRoleLabelName: "primary",
 		}))
 		Expect(patchedPvc.Annotations).To(Equal(map[string]string{
-			utils.ClusterSerialAnnotationName: "1",
-			utils.PVCStatusAnnotationName:     "ready",
+			utils.ClusterSerialAnnotationName:   "1",
+			utils.PVCStatusAnnotationName:       "ready",
+			utils.OperatorVersionAnnotationName: versions.Version,
 		}))
 
 		patchedPvc2 := fetchPVC(cl, pvc2)


### PR DESCRIPTION
In the current code, the `operatorVersion` annotation is set manually when creating resources. This has led to several consistency issues, as it is not always invoked.

This patch proposes a new approach that integrates the `operatorVersion` reconciliation within the `GetFixedInheritedAnnotations` function. This method offers several advantages:

- The function is already called throughout the code, making it easy to implement the change consistently.
- It simplifies code maintenance since the `operatorVersion` no longer requires a separate handling approach from the developer's perspective.

Closes #6457 


## Note for reviewers

We can consider to drop the operatorVersion on resources
