### PR TITLE
Use targetPod.Name in WithValues() instead of targetPod

### DIFF
--- a/internal/controller/backup_controller.go
+++ b/internal/controller/backup_controller.go
@@ -381,7 +381,7 @@ func (r *BackupReconciler) reconcileSnapshotBackup(
 		return &ctrl.Result{}, nil
 	}
 
-	ctx = log.IntoContext(ctx, contextLogger.WithValues("targetPod", targetPod))
+	ctx = log.IntoContext(ctx, contextLogger.WithValues("targetPodName", targetPod.Name))
 
 	// Validate we don't have other running backups
 	var clusterBackups apiv1.BackupList


### PR DESCRIPTION
Fix #6400 

I also changed the name of the parameter from `targetPod` to `targetPodName` to be more consistent with other log lines.

Result : 

``` json
{  
  "level": "info",
  "ts": "2025-01-09T14:25:24.394293941Z",
  "msg": "Waiting for VolumeSnapshot to be provisioned",
  "controller": "backup",
  "controllerGroup": "postgresql.cnpg.io",
  "controllerKind": "Backup",
  "Backup": {
    "name": "snapshot-volume-3",
    "namespace": "default"
  },
  "namespace": "default",
  "name": "snapshot-volume-3",
  "reconcileID": "b524b993-b153-4344-9a6e-6bcbe08a20e9",
  "targetPodName": "cluster2-1",
  "volumeSnapshotName": "snapshot-volume-3"
}
```