### PR TITLE
fix(cnpgi-plugins): add archive and backup capabilities fields to configuration

### DIFF
--- a/.wordlist-en-custom.txt
+++ b/.wordlist-en-custom.txt
@@ -27,6 +27,7 @@ Azurite
 BDR
 BackupCapabilities
 BackupConfiguration
+BackupExecutor
 BackupFrom
 BackupLabelFile
 BackupList
@@ -492,6 +493,7 @@ VolumeSnapshotConfiguration
 VolumeSnapshots
 WAL
 WAL's
+WALArchiver
 WALBackupConfiguration
 WALCapabilities
 WALs
@@ -875,8 +877,10 @@ io
 ip
 ipcs
 ips
+isBackupExecutor
 isPrimary
 isTemplate
+isWALArchiver
 issuecomment
 italy
 jdbc

--- a/.wordlist-en-custom.txt
+++ b/.wordlist-en-custom.txt
@@ -27,7 +27,6 @@ Azurite
 BDR
 BackupCapabilities
 BackupConfiguration
-BackupExecutor
 BackupFrom
 BackupLabelFile
 BackupList
@@ -877,7 +876,6 @@ io
 ip
 ipcs
 ips
-isBackupExecutor
 isPrimary
 isTemplate
 isWALArchiver

--- a/api/v1/cluster_funcs.go
+++ b/api/v1/cluster_funcs.go
@@ -1493,14 +1493,3 @@ func (cluster *Cluster) GetEnabledWALArchivePluginName() string {
 
 	return ""
 }
-
-// GetEnabledBackupExecutorPluginName returns the name of the enabled backup executor plugin or an empty string
-func (cluster *Cluster) GetEnabledBackupExecutorPluginName() string {
-	for _, plugin := range cluster.Spec.Plugins {
-		if plugin.IsEnabled() && plugin.IsBackupExecutor != nil && *plugin.IsBackupExecutor {
-			return plugin.Name
-		}
-	}
-
-	return ""
-}

--- a/api/v1/cluster_funcs.go
+++ b/api/v1/cluster_funcs.go
@@ -1493,3 +1493,14 @@ func (cluster *Cluster) GetEnabledWALArchivePluginName() string {
 
 	return ""
 }
+
+// GetEnabledBackupExecutorPluginName returns the name of the enabled backup executor plugin or an empty string
+func (cluster *Cluster) GetEnabledBackupExecutorPluginName() string {
+	for _, plugin := range cluster.Spec.Plugins {
+		if plugin.IsEnabled() && plugin.IsBackupExecutor != nil && *plugin.IsBackupExecutor {
+			return plugin.Name
+		}
+	}
+
+	return ""
+}

--- a/api/v1/cluster_funcs.go
+++ b/api/v1/cluster_funcs.go
@@ -1481,3 +1481,15 @@ func (p *Probe) ApplyInto(k8sProbe *corev1.Probe) {
 		k8sProbe.TerminationGracePeriodSeconds = p.TerminationGracePeriodSeconds
 	}
 }
+
+// GetEnabledWALArchivePluginName returns the name of the enabled backup plugin or an empty string
+// if no backup plugin is enabled
+func (cluster *Cluster) GetEnabledWALArchivePluginName() string {
+	for _, plugin := range cluster.Spec.Plugins {
+		if plugin.IsEnabled() && plugin.IsWALArchiver != nil && *plugin.IsWALArchiver {
+			return plugin.Name
+		}
+	}
+
+	return ""
+}

--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -2174,6 +2174,16 @@ type PluginConfiguration struct {
 	// +optional
 	Enabled *bool `json:"enabled,omitempty"`
 
+	// Only one plugin can be declared as WALArchiver . Cannot be active at the same time with the "backup" field
+	// +kubebuilder:default:=false
+	// +optional
+	IsWALArchiver *bool `json:"isWALArchiver,omitempty"`
+
+	// Only one plugin can be declared as BackupExecutor. Cannot be active at the same time with the "backup" field
+	// +kubebuilder:default:=false
+	// +optional
+	IsBackupExecutor *bool `json:"isBackupExecutor,omitempty"`
+
 	// Parameters is the configuration of the plugin
 	// +optional
 	Parameters map[string]string `json:"parameters,omitempty"`

--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -2174,15 +2174,11 @@ type PluginConfiguration struct {
 	// +optional
 	Enabled *bool `json:"enabled,omitempty"`
 
-	// Only one plugin can be declared as WALArchiver. Cannot be active at the same time with the "backup" field
+	// Only one plugin can be declared as WALArchiver.
+	// Cannot be active if ".spec.backup.barmanObjectStore" configuration is present.
 	// +kubebuilder:default:=false
 	// +optional
 	IsWALArchiver *bool `json:"isWALArchiver,omitempty"`
-
-	// Only one plugin can be declared as BackupExecutor. Cannot be active at the same time with the "backup" field
-	// +kubebuilder:default:=false
-	// +optional
-	IsBackupExecutor *bool `json:"isBackupExecutor,omitempty"`
 
 	// Parameters is the configuration of the plugin
 	// +optional

--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -2174,7 +2174,7 @@ type PluginConfiguration struct {
 	// +optional
 	Enabled *bool `json:"enabled,omitempty"`
 
-	// Only one plugin can be declared as WALArchiver . Cannot be active at the same time with the "backup" field
+	// Only one plugin can be declared as WALArchiver. Cannot be active at the same time with the "backup" field
 	// +kubebuilder:default:=false
 	// +optional
 	IsWALArchiver *bool `json:"isWALArchiver,omitempty"`

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -1839,6 +1839,16 @@ func (in *PluginConfiguration) DeepCopyInto(out *PluginConfiguration) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.IsWALArchiver != nil {
+		in, out := &in.IsWALArchiver, &out.IsWALArchiver
+		*out = new(bool)
+		**out = **in
+	}
+	if in.IsBackupExecutor != nil {
+		in, out := &in.IsBackupExecutor, &out.IsBackupExecutor
+		*out = new(bool)
+		**out = **in
+	}
 	if in.Parameters != nil {
 		in, out := &in.Parameters, &out.Parameters
 		*out = make(map[string]string, len(*in))

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -1844,11 +1844,6 @@ func (in *PluginConfiguration) DeepCopyInto(out *PluginConfiguration) {
 		*out = new(bool)
 		**out = **in
 	}
-	if in.IsBackupExecutor != nil {
-		in, out := &in.IsBackupExecutor, &out.IsBackupExecutor
-		*out = new(bool)
-		**out = **in
-	}
 	if in.Parameters != nil {
 		in, out := &in.Parameters, &out.Parameters
 		*out = make(map[string]string, len(*in))

--- a/config/crd/bases/postgresql.cnpg.io_clusters.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_clusters.yaml
@@ -2949,9 +2949,8 @@ spec:
                           type: boolean
                         isWALArchiver:
                           default: false
-                          description: Only one plugin can be declared as WALArchiver
-                            . Cannot be active at the same time with the "backup"
-                            field
+                          description: Only one plugin can be declared as WALArchiver.
+                            Cannot be active at the same time with the "backup" field
                           type: boolean
                         name:
                           description: Name is the plugin name
@@ -3986,8 +3985,8 @@ spec:
                       type: boolean
                     isWALArchiver:
                       default: false
-                      description: Only one plugin can be declared as WALArchiver
-                        . Cannot be active at the same time with the "backup" field
+                      description: Only one plugin can be declared as WALArchiver.
+                        Cannot be active at the same time with the "backup" field
                       type: boolean
                     name:
                       description: Name is the plugin name

--- a/config/crd/bases/postgresql.cnpg.io_clusters.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_clusters.yaml
@@ -2942,15 +2942,11 @@ spec:
                           default: true
                           description: Enabled is true if this plugin will be used
                           type: boolean
-                        isBackupExecutor:
-                          default: false
-                          description: Only one plugin can be declared as BackupExecutor.
-                            Cannot be active at the same time with the "backup" field
-                          type: boolean
                         isWALArchiver:
                           default: false
-                          description: Only one plugin can be declared as WALArchiver.
-                            Cannot be active at the same time with the "backup" field
+                          description: |-
+                            Only one plugin can be declared as WALArchiver.
+                            Cannot be active if ".spec.backup.barmanObjectStore" configuration is present.
                           type: boolean
                         name:
                           description: Name is the plugin name
@@ -3978,15 +3974,11 @@ spec:
                       default: true
                       description: Enabled is true if this plugin will be used
                       type: boolean
-                    isBackupExecutor:
-                      default: false
-                      description: Only one plugin can be declared as BackupExecutor.
-                        Cannot be active at the same time with the "backup" field
-                      type: boolean
                     isWALArchiver:
                       default: false
-                      description: Only one plugin can be declared as WALArchiver.
-                        Cannot be active at the same time with the "backup" field
+                      description: |-
+                        Only one plugin can be declared as WALArchiver.
+                        Cannot be active if ".spec.backup.barmanObjectStore" configuration is present.
                       type: boolean
                     name:
                       description: Name is the plugin name

--- a/config/crd/bases/postgresql.cnpg.io_clusters.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_clusters.yaml
@@ -2942,6 +2942,17 @@ spec:
                           default: true
                           description: Enabled is true if this plugin will be used
                           type: boolean
+                        isBackupExecutor:
+                          default: false
+                          description: Only one plugin can be declared as BackupExecutor.
+                            Cannot be active at the same time with the "backup" field
+                          type: boolean
+                        isWALArchiver:
+                          default: false
+                          description: Only one plugin can be declared as WALArchiver
+                            . Cannot be active at the same time with the "backup"
+                            field
+                          type: boolean
                         name:
                           description: Name is the plugin name
                           type: string
@@ -3967,6 +3978,16 @@ spec:
                     enabled:
                       default: true
                       description: Enabled is true if this plugin will be used
+                      type: boolean
+                    isBackupExecutor:
+                      default: false
+                      description: Only one plugin can be declared as BackupExecutor.
+                        Cannot be active at the same time with the "backup" field
+                      type: boolean
+                    isWALArchiver:
+                      default: false
+                      description: Only one plugin can be declared as WALArchiver
+                        . Cannot be active at the same time with the "backup" field
                       type: boolean
                     name:
                       description: Name is the plugin name

--- a/docs/src/cloudnative-pg.v1.md
+++ b/docs/src/cloudnative-pg.v1.md
@@ -3712,6 +3712,20 @@ cluster to be reconciled</p>
    <p>Enabled is true if this plugin will be used</p>
 </td>
 </tr>
+<tr><td><code>isWALArchiver</code><br/>
+<i>bool</i>
+</td>
+<td>
+   <p>Only one plugin can be declared as WALArchiver . Cannot be active at the same time with the &quot;backup&quot; field</p>
+</td>
+</tr>
+<tr><td><code>isBackupExecutor</code><br/>
+<i>bool</i>
+</td>
+<td>
+   <p>Only one plugin can be declared as BackupExecutor. Cannot be active at the same time with the &quot;backup&quot; field</p>
+</td>
+</tr>
 <tr><td><code>parameters</code><br/>
 <i>map[string]string</i>
 </td>

--- a/docs/src/cloudnative-pg.v1.md
+++ b/docs/src/cloudnative-pg.v1.md
@@ -3716,14 +3716,8 @@ cluster to be reconciled</p>
 <i>bool</i>
 </td>
 <td>
-   <p>Only one plugin can be declared as WALArchiver. Cannot be active at the same time with the &quot;backup&quot; field</p>
-</td>
-</tr>
-<tr><td><code>isBackupExecutor</code><br/>
-<i>bool</i>
-</td>
-<td>
-   <p>Only one plugin can be declared as BackupExecutor. Cannot be active at the same time with the &quot;backup&quot; field</p>
+   <p>Only one plugin can be declared as WALArchiver.
+Cannot be active if &quot;.spec.backup.barmanObjectStore&quot; configuration is present.</p>
 </td>
 </tr>
 <tr><td><code>parameters</code><br/>

--- a/docs/src/cloudnative-pg.v1.md
+++ b/docs/src/cloudnative-pg.v1.md
@@ -3716,7 +3716,7 @@ cluster to be reconciled</p>
 <i>bool</i>
 </td>
 <td>
-   <p>Only one plugin can be declared as WALArchiver . Cannot be active at the same time with the &quot;backup&quot; field</p>
+   <p>Only one plugin can be declared as WALArchiver. Cannot be active at the same time with the &quot;backup&quot; field</p>
 </td>
 </tr>
 <tr><td><code>isBackupExecutor</code><br/>

--- a/internal/controller/backup_controller.go
+++ b/internal/controller/backup_controller.go
@@ -135,8 +135,8 @@ func (r *BackupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		return ctrl.Result{}, nil
 	}
 
-	if backup.Spec.Method == apiv1.BackupMethodPlugin && cluster.GetEnabledBackupExecutorPluginName() == "" {
-		message := "cannot proceed with the backup as the cluster has no backup executor plugin enabled"
+	if backup.Spec.Method == apiv1.BackupMethodPlugin && len(cluster.Spec.Plugins) == 0 {
+		message := "cannot proceed with the backup as the cluster has no plugin configured"
 		contextLogger.Warning(message)
 		r.Recorder.Event(&backup, "Warning", "ClusterHasNoBackupExecutorPlugin", message)
 		tryFlagBackupAsFailed(ctx, r.Client, &backup, errors.New(message))

--- a/internal/controller/backup_controller.go
+++ b/internal/controller/backup_controller.go
@@ -99,7 +99,7 @@ func NewBackupReconciler(
 // +kubebuilder:rbac:groups="",resources=pods,verbs=get
 
 // Reconcile is the main reconciliation loop
-// nolint: gocognit
+// nolint: gocognit,gocyclo
 func (r *BackupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	contextLogger, ctx := log.SetupLogger(ctx)
 	contextLogger.Debug(fmt.Sprintf("reconciling object %#q", req.NamespacedName))

--- a/internal/webhook/v1/cluster_webhook_test.go
+++ b/internal/webhook/v1/cluster_webhook_test.go
@@ -4937,3 +4937,91 @@ var _ = Describe("validatePodPatchAnnotation", func() {
 		Expect(v.validatePodPatchAnnotation(cluster)).To(BeNil())
 	})
 })
+
+var _ = Describe("validatePluginConfiguration", func() {
+	var v *ClusterCustomValidator
+	var cluster *apiv1.Cluster
+	walPlugin1 := apiv1.PluginConfiguration{
+		Name:          "walArchiverPlugin1",
+		Enabled:       ptr.To(true),
+		IsWALArchiver: ptr.To(true),
+	}
+	walPlugin2 := apiv1.PluginConfiguration{
+		Name:          "walArchiverPlugin2",
+		Enabled:       ptr.To(true),
+		IsWALArchiver: ptr.To(true),
+	}
+	executorPlugin1 := apiv1.PluginConfiguration{
+		Name:             "backupExecutorPlugin1",
+		Enabled:          ptr.To(true),
+		IsBackupExecutor: ptr.To(true),
+	}
+	executorPlugin2 := apiv1.PluginConfiguration{
+		Name:    "backupExecutorPlugin2",
+		Enabled: ptr.To(true),
+
+		IsBackupExecutor: ptr.To(true),
+	}
+
+	BeforeEach(func() {
+		v = &ClusterCustomValidator{}
+		cluster = &apiv1.Cluster{
+			Spec: apiv1.ClusterSpec{
+				Plugins: []apiv1.PluginConfiguration{},
+			},
+		}
+	})
+
+	It("returns no errors if no plugins are enabled", func() {
+		Expect(v.validatePluginConfiguration(cluster)).To(BeNil())
+	})
+
+	It("returns an error if a WAL archiver plugin is enabled when backup is enabled", func() {
+		cluster.Spec.Backup = &apiv1.BackupConfiguration{}
+		cluster.Spec.Plugins = append(cluster.Spec.Plugins, walPlugin1)
+		errs := v.validatePluginConfiguration(cluster)
+		Expect(errs).To(HaveLen(2))
+		Expect(errs[0].Error()).To(ContainSubstring("Cannot enable a WAL archiver plugin when backup is enabled"))
+	})
+
+	It("returns an error if a backup executor plugin is enabled when backup is enabled", func() {
+		cluster.Spec.Backup = &apiv1.BackupConfiguration{}
+		cluster.Spec.Plugins = append(cluster.Spec.Plugins, executorPlugin1)
+		errs := v.validatePluginConfiguration(cluster)
+		Expect(errs).To(HaveLen(2))
+		Expect(errs[0].Error()).To(ContainSubstring("Cannot enable a backup executor plugin when backup is enabled"))
+	})
+
+	It("returns an error if more than one WAL archiver plugin is enabled", func() {
+		cluster.Spec.Plugins = append(cluster.Spec.Plugins, walPlugin1, walPlugin2, executorPlugin1)
+		errs := v.validatePluginConfiguration(cluster)
+		Expect(errs).To(HaveLen(1))
+		Expect(errs[0].Error()).To(ContainSubstring("Cannot enable more than one WAL archiver plugin"))
+	})
+
+	It("returns an error if more than one backup executor plugin is enabled", func() {
+		cluster.Spec.Plugins = append(cluster.Spec.Plugins, walPlugin1, executorPlugin1, executorPlugin2)
+		errs := v.validatePluginConfiguration(cluster)
+		Expect(errs).To(HaveLen(1))
+		Expect(errs[0].Error()).To(ContainSubstring("Cannot enable more than one backup executor plugin"))
+	})
+
+	It("returns an error if a WAL archiver plugin is enabled without a backup executor plugin", func() {
+		cluster.Spec.Plugins = append(cluster.Spec.Plugins, walPlugin1)
+		errs := v.validatePluginConfiguration(cluster)
+		Expect(errs).To(HaveLen(1))
+		Expect(errs[0].Error()).To(ContainSubstring("Cannot enable a WAL archiver plugin without a backup executor plugin"))
+	})
+
+	It("returns an error if a backup executor plugin is enabled without a WAL archiver plugin", func() {
+		cluster.Spec.Plugins = append(cluster.Spec.Plugins, executorPlugin1)
+		errs := v.validatePluginConfiguration(cluster)
+		Expect(errs).To(HaveLen(1))
+		Expect(errs[0].Error()).To(ContainSubstring("Cannot enable a backup executor plugin without a WAL archiver plugin"))
+	})
+
+	It("returns no errors when WAL archiver and backup executor plugins are enabled", func() {
+		cluster.Spec.Plugins = append(cluster.Spec.Plugins, walPlugin1, executorPlugin1)
+		Expect(v.validatePluginConfiguration(cluster)).To(BeNil())
+	})
+})

--- a/pkg/management/postgres/archiver/archiver.go
+++ b/pkg/management/postgres/archiver/archiver.go
@@ -268,7 +268,7 @@ func archiveWALViaPlugins(
 	availableAndEnabled := stringset.From(availablePluginNamesSet.Intersect(enabledPluginNamesSet).ToList())
 
 	if !availableAndEnabled.Has(cluster.GetEnabledWALArchivePluginName()) {
-		return fmt.Errorf("wal archive plugin is enabled but not available: %s", cluster.GetEnabledWALArchivePluginName())
+		return fmt.Errorf("wal archive plugin is not available: %s", cluster.GetEnabledWALArchivePluginName())
 	}
 
 	client, err := pluginClient.WithPlugins(

--- a/pkg/management/postgres/webserver/plugin_backup.go
+++ b/pkg/management/postgres/webserver/plugin_backup.go
@@ -18,6 +18,7 @@ package webserver
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -85,6 +86,13 @@ func (b *PluginBackupCommand) invokeStart(ctx context.Context) {
 		"pluginConfiguration", b.Backup.Spec.PluginConfiguration,
 		"backupName", b.Backup.Name,
 		"backupNamespace", b.Backup.Name)
+
+	if b.Cluster.GetEnabledBackupExecutorPluginName() == "" {
+		err := errors.New("plugin backup was invoked but no backupExecutor plugin is configured")
+		contextLogger.Error(err, "Error while starting plugin backup")
+		b.markBackupAsFailed(ctx, err)
+		return
+	}
 
 	plugins := repository.New()
 	availablePlugins, err := plugins.RegisterUnixSocketPluginsInPath(configuration.Current.PluginSocketDir)


### PR DESCRIPTION
This patch provides the configuration of plugin capabilities for
archive and backup. Ensure that one and only one plugin can be used for archive
and backup separately if backup section in-tree is not used. 

# Release notes

```
Introduce a new flag called `isWALArchiver` in the plugin configuration, allowing the
user to indicate that the plugin will be used as a WAL archiver. This allows migrating 
between the in-tree barman-cloud support to the plugin without losing the
consistency of the WAL archiving.
```