### PR TITLE
fix: ensure cluster dependant resources reconcile after cluster rehydratation

### DIFF
--- a/api/v1/database_funcs.go
+++ b/api/v1/database_funcs.go
@@ -65,6 +65,11 @@ func (db *Database) HasReconciliations() bool {
 	return db.Status.ObservedGeneration > 0
 }
 
+// SetStatusObservedGeneration sets the observed generation of the database
+func (db *Database) SetStatusObservedGeneration(obsGeneration int64) {
+	db.Status.ObservedGeneration = obsGeneration
+}
+
 // MustHaveManagedResourceExclusivity detects conflicting databases
 func (dbList *DatabaseList) MustHaveManagedResourceExclusivity(reference *Database) error {
 	pointers := toSliceWithPointers(dbList.Items)

--- a/api/v1/publication_funcs.go
+++ b/api/v1/publication_funcs.go
@@ -65,6 +65,11 @@ func (pub *Publication) GetName() string {
 	return pub.Name
 }
 
+// SetStatusObservedGeneration sets the observed generation of the publication
+func (pub *Publication) SetStatusObservedGeneration(obsGeneration int64) {
+	pub.Status.ObservedGeneration = obsGeneration
+}
+
 // MustHaveManagedResourceExclusivity detects conflicting publications
 func (pub *PublicationList) MustHaveManagedResourceExclusivity(reference *Publication) error {
 	pointers := toSliceWithPointers(pub.Items)

--- a/api/v1/subscription_funcs.go
+++ b/api/v1/subscription_funcs.go
@@ -65,6 +65,11 @@ func (sub *Subscription) HasReconciliations() bool {
 	return sub.Status.ObservedGeneration > 0
 }
 
+// SetStatusObservedGeneration sets the observed generation of the subscription
+func (sub *Subscription) SetStatusObservedGeneration(obsGeneration int64) {
+	sub.Status.ObservedGeneration = obsGeneration
+}
+
 // MustHaveManagedResourceExclusivity detects conflicting subscriptions
 func (pub *SubscriptionList) MustHaveManagedResourceExclusivity(reference *Subscription) error {
 	pointers := toSliceWithPointers(pub.Items)

--- a/internal/controller/finalizers_delete.go
+++ b/internal/controller/finalizers_delete.go
@@ -123,6 +123,8 @@ func notifyOwnedResourceDeletion[T clusterOwnedResourceWithStatus](
 		if obj.GetStatusMessage() != statusMessage {
 			obj.SetAsFailed(errors.New(statusMessage))
 			obj.SetStatusObservedGeneration(0)
+			// We need to use an update here because of the observed generation set to 0
+			// that would be ignored with the patch method.
 			if err := cli.Status().Update(ctx, obj); err != nil {
 				itemLogger.Error(err, "error while updating failed status for cluster deletion")
 				return err


### PR DESCRIPTION
Closes #6550 


# Release notes

```
After the cluster rehydration, the `Database`, `Publication`, and `Subscription` CRDs now properly reconcile instead of being stuck at `cluster resource has been deleted, skipping reconciliation. This is done by forcing `status.observedGeneration` to zero.
```