### PR TITLE
chore: add `pg_catalog` schema where needed

### DIFF
--- a/internal/cmd/manager/instance/run/lifecycle/run.go
+++ b/internal/cmd/manager/instance/run/lifecycle/run.go
@@ -193,7 +193,7 @@ func configureInstancePermissions(ctx context.Context, instance *postgres.Instan
 // and has the required rights
 func configureStreamingReplicaUser(tx *sql.Tx) (bool, error) {
 	var hasLoginRight, hasReplicationRight, hasSuperuser bool
-	row := tx.QueryRow("SELECT rolcanlogin, rolreplication, rolsuper FROM pg_roles WHERE rolname = $1",
+	row := tx.QueryRow("SELECT rolcanlogin, rolreplication, rolsuper FROM pg_catalog.pg_roles WHERE rolname = $1",
 		apiv1.StreamingReplicationUser)
 	err := row.Scan(&hasLoginRight, &hasReplicationRight, &hasSuperuser)
 	if err != nil {
@@ -247,10 +247,14 @@ func configurePgRewindPrivileges(pgVersion semver.Version, hasSuperuser bool, tx
 	var hasPgRewindPrivileges bool
 	row := tx.QueryRow(
 		`
-			SELECT has_function_privilege($1, 'pg_ls_dir(text, boolean, boolean)', 'execute') AND
-			       has_function_privilege($2, 'pg_stat_file(text, boolean)', 'execute') AND
-			       has_function_privilege($3, 'pg_read_binary_file(text)', 'execute') AND
-			       has_function_privilege($4, 'pg_read_binary_file(text, bigint, bigint, boolean)', 'execute')`,
+		SELECT pg_catalog.has_function_privilege($1,
+				'pg_catalog.pg_ls_dir(text, boolean, boolean)', 'execute') AND
+			pg_catalog.has_function_privilege($2,
+				'pg_catalog.pg_stat_file(text, boolean)', 'execute') AND
+			pg_catalog.has_function_privilege($3,
+				'pg_catalog.pg_read_binary_file(text)', 'execute') AND
+			pg_catalog.has_function_privilege($4,
+				'pg_catalog.pg_read_binary_file(text, bigint, bigint, boolean)', 'execute')`,
 		apiv1.StreamingReplicationUser,
 		apiv1.StreamingReplicationUser,
 		apiv1.StreamingReplicationUser,

--- a/internal/cmd/plugin/logical/subscription/syncsequences/update.go
+++ b/internal/cmd/plugin/logical/subscription/syncsequences/update.go
@@ -44,7 +44,7 @@ func CreateSyncScript(source, destination SequenceMap, offset int) string {
 		}
 
 		script += fmt.Sprintf(
-			"SELECT setval(%s, %v);\n",
+			"SELECT pg_catalog.setval(%s, %v);\n",
 			pq.QuoteLiteral(name),
 			sqlTargetValue)
 	}

--- a/internal/management/controller/database_controller_sql.go
+++ b/internal/management/controller/database_controller_sql.go
@@ -37,7 +37,7 @@ func detectDatabase(
 		ctx,
 		`
 		SELECT count(*)
-		FROM pg_database
+		FROM pg_catalog.pg_database
 	        WHERE datname = $1
 		`,
 		obj.Spec.Name)

--- a/internal/management/controller/database_controller_sql_test.go
+++ b/internal/management/controller/database_controller_sql_test.go
@@ -66,7 +66,7 @@ var _ = Describe("Managed Database SQL", func() {
 		It("returns true when it detects an existing Database", func(ctx SpecContext) {
 			expectedValue := sqlmock.NewRows([]string{""}).AddRow("1")
 			dbMock.ExpectQuery(`SELECT count(*)
-		FROM pg_database
+		FROM pg_catalog.pg_database
 		WHERE datname = $1`).WithArgs(database.Spec.Name).WillReturnRows(expectedValue)
 
 			dbExists, err := detectDatabase(ctx, db, database)
@@ -77,7 +77,7 @@ var _ = Describe("Managed Database SQL", func() {
 		It("returns false when a Database is missing", func(ctx SpecContext) {
 			expectedValue := sqlmock.NewRows([]string{""}).AddRow("0")
 			dbMock.ExpectQuery(`SELECT count(*)
-		FROM pg_database
+		FROM pg_catalog.pg_database
 		WHERE datname = $1`).WithArgs(database.Spec.Name).WillReturnRows(expectedValue)
 
 			dbExists, err := detectDatabase(ctx, db, database)

--- a/internal/management/controller/database_controller_test.go
+++ b/internal/management/controller/database_controller_test.go
@@ -42,7 +42,7 @@ import (
 )
 
 const databaseDetectionQuery = `SELECT count(*)
-			FROM pg_database
+			FROM pg_catalog.pg_database
 			WHERE datname = $1`
 
 var _ = Describe("Managed Database status", func() {

--- a/internal/management/controller/instance_controller.go
+++ b/internal/management/controller/instance_controller.go
@@ -642,7 +642,7 @@ func (r *InstanceReconciler) reconcileExtensions(
 	for _, extension := range postgres.ManagedExtensions {
 		extensionIsUsed := extension.IsUsed(userSettings)
 
-		row := tx.QueryRow("SELECT COUNT(*) > 0 FROM pg_extension WHERE extname = $1", extension.Name)
+		row := tx.QueryRow("SELECT COUNT(*) > 0 FROM pg_catalog.pg_extension WHERE extname = $1", extension.Name)
 		err = row.Err()
 		if err != nil {
 			break
@@ -710,7 +710,7 @@ func (r *InstanceReconciler) reconcilePoolers(
 	}
 
 	var existsFunction bool
-	row = tx.QueryRow(fmt.Sprintf("SELECT COUNT(*) > 0 FROM pg_proc WHERE proname='%s' and prosrc='%s'",
+	row = tx.QueryRow(fmt.Sprintf("SELECT COUNT(*) > 0 FROM pg_catalog.pg_proc WHERE proname='%s' and prosrc='%s'",
 		userSearchFunctionName,
 		userSearchFunction))
 	err = row.Scan(&existsFunction)
@@ -1507,8 +1507,8 @@ func (r *InstanceReconciler) dropStaleReplicationConnections(
 
 	result, err := conn.ExecContext(
 		ctx,
-		`SELECT pg_terminate_backend(pid)
-		FROM pg_stat_replication
+		`SELECT pg_catalog.pg_terminate_backend(pid)
+		FROM pg_catalog.pg_stat_replication
 		WHERE application_name LIKE $1`,
 		fmt.Sprintf("%v-%%", cluster.Name),
 	)

--- a/internal/management/controller/publication_controller_sql.go
+++ b/internal/management/controller/publication_controller_sql.go
@@ -37,7 +37,7 @@ func (r *PublicationReconciler) alignPublication(ctx context.Context, obj *apiv1
 		ctx,
 		`
 		SELECT count(*)
-		FROM pg_publication
+		FROM pg_catalog.pg_publication
 	        WHERE pubname = $1
 		`,
 		obj.Spec.Name)

--- a/internal/management/controller/publication_controller_test.go
+++ b/internal/management/controller/publication_controller_test.go
@@ -42,7 +42,7 @@ import (
 )
 
 const publicationDetectionQuery = `SELECT count(*)
-		FROM pg_publication
+		FROM pg_catalog.pg_publication
 		WHERE pubname = $1`
 
 var _ = Describe("Managed publication controller tests", func() {

--- a/internal/management/controller/roles/postgres.go
+++ b/internal/management/controller/roles/postgres.go
@@ -44,8 +44,8 @@ func List(ctx context.Context, db *sql.DB) ([]DatabaseRole, error) {
 				mem.inroles
 		FROM pg_catalog.pg_authid as auth
 		LEFT JOIN (
-			SELECT array_agg(pg_get_userbyid(roleid)) as inroles, member
-			FROM pg_auth_members GROUP BY member
+			SELECT pg_catalog.array_agg(pg_catalog.pg_get_userbyid(roleid)) as inroles, member
+			FROM pg_catalog.pg_auth_members GROUP BY member
 		) mem ON member = oid
 		WHERE rolname not like 'pg\_%'`)
 	if err != nil {
@@ -282,8 +282,8 @@ func GetParentRoles(ctx context.Context, db *sql.DB, role DatabaseRole) ([]strin
 	query := `SELECT mem.inroles 
 		FROM pg_catalog.pg_authid as auth
 		LEFT JOIN (
-			SELECT array_agg(pg_get_userbyid(roleid)) as inroles, member
-			FROM pg_auth_members GROUP BY member
+			SELECT pg_catalog.array_agg(pg_catalog.pg_get_userbyid(roleid)) as inroles, member
+			FROM pg_catalog.pg_auth_members GROUP BY member
 		) mem ON member = oid
 		WHERE rolname = $1`
 	contextLog.Debug("get parent role", "query", query)

--- a/internal/management/controller/roles/suite_test.go
+++ b/internal/management/controller/roles/suite_test.go
@@ -30,16 +30,16 @@ const (
 		mem.inroles
 	FROM pg_catalog.pg_authid as auth
 	LEFT JOIN (
-		SELECT array_agg(pg_get_userbyid(roleid)) as inroles, member
-		FROM pg_auth_members GROUP BY member
+		SELECT pg_catalog.array_agg(pg_catalog.pg_get_userbyid(roleid)) as inroles, member
+		FROM pg_catalog.pg_auth_members GROUP BY member
 	) mem ON member = oid
 	WHERE rolname not like 'pg\_%'`
 
 	expectedMembershipStmt = `SELECT mem.inroles 
 	FROM pg_catalog.pg_authid as auth
 	LEFT JOIN (
-		SELECT array_agg(pg_get_userbyid(roleid)) as inroles, member
-		FROM pg_auth_members GROUP BY member
+		SELECT pg_catalog.array_agg(pg_catalog.pg_get_userbyid(roleid)) as inroles, member
+		FROM pg_catalog.pg_auth_members GROUP BY member
 	) mem ON member = oid
 	WHERE rolname = $1`
 

--- a/internal/management/controller/slots/infrastructure/postgresmanager.go
+++ b/internal/management/controller/slots/infrastructure/postgresmanager.go
@@ -32,7 +32,7 @@ func List(ctx context.Context, db *sql.DB, config *v1.ReplicationSlotsConfigurat
 		ctx,
 		`SELECT slot_name, slot_type, active, coalesce(restart_lsn::TEXT, '') AS restart_lsn,
             xmin IS NOT NULL OR catalog_xmin IS NOT NULL AS holds_xmin
-            FROM pg_replication_slots
+            FROM pg_catalog.pg_replication_slots
             WHERE NOT temporary AND slot_type = 'physical'`,
 	)
 	if err != nil {
@@ -83,7 +83,7 @@ func Update(ctx context.Context, db *sql.DB, slot ReplicationSlot) error {
 		return nil
 	}
 
-	_, err := db.ExecContext(ctx, "SELECT pg_replication_slot_advance($1, $2)", slot.SlotName, slot.RestartLSN)
+	_, err := db.ExecContext(ctx, "SELECT pg_catalog.pg_replication_slot_advance($1, $2)", slot.SlotName, slot.RestartLSN)
 	return err
 }
 
@@ -92,7 +92,7 @@ func Create(ctx context.Context, db *sql.DB, slot ReplicationSlot) error {
 	contextLog := log.FromContext(ctx).WithName("createSlot")
 	contextLog.Trace("Invoked", "slot", slot)
 
-	_, err := db.ExecContext(ctx, "SELECT pg_create_physical_replication_slot($1, $2)",
+	_, err := db.ExecContext(ctx, "SELECT pg_catalog.pg_create_physical_replication_slot($1, $2)",
 		slot.SlotName, slot.RestartLSN != "")
 	return err
 }
@@ -105,6 +105,6 @@ func Delete(ctx context.Context, db *sql.DB, slot ReplicationSlot) error {
 		return nil
 	}
 
-	_, err := db.ExecContext(ctx, "SELECT pg_drop_replication_slot($1)", slot.SlotName)
+	_, err := db.ExecContext(ctx, "SELECT pg_catalog.pg_drop_replication_slot($1)", slot.SlotName)
 	return err
 }

--- a/internal/management/controller/slots/infrastructure/postgresmanager_test.go
+++ b/internal/management/controller/slots/infrastructure/postgresmanager_test.go
@@ -52,7 +52,7 @@ var _ = Describe("PostgresManager", func() {
 	})
 
 	Context("Create", func() {
-		const expectedSQL = "SELECT pg_create_physical_replication_slot"
+		const expectedSQL = "SELECT pg_catalog.pg_create_physical_replication_slot"
 		It("should successfully create a replication slot", func(ctx SpecContext) {
 			mock.ExpectExec(expectedSQL).
 				WithArgs(slot.SlotName, slot.RestartLSN != "").
@@ -73,7 +73,7 @@ var _ = Describe("PostgresManager", func() {
 	})
 
 	Context("List", func() {
-		const expectedSQL = "^SELECT (.+) FROM pg_replication_slots"
+		const expectedSQL = "^SELECT (.+) FROM pg_catalog.pg_replication_slots"
 
 		var config *v1.ReplicationSlotsConfiguration
 		BeforeEach(func() {
@@ -123,7 +123,7 @@ var _ = Describe("PostgresManager", func() {
 	})
 
 	Context("Update", func() {
-		const expectedSQL = "SELECT pg_replication_slot_advance"
+		const expectedSQL = "SELECT pg_catalog.pg_replication_slot_advance"
 
 		It("should successfully update a replication slot", func(ctx SpecContext) {
 			mock.ExpectExec(expectedSQL).
@@ -151,7 +151,7 @@ var _ = Describe("PostgresManager", func() {
 	})
 
 	Context("Delete", func() {
-		const expectedSQL = "SELECT pg_drop_replication_slot"
+		const expectedSQL = "SELECT pg_catalog.pg_drop_replication_slot"
 
 		It("should successfully delete a replication slot", func(ctx SpecContext) {
 			slot.Active = false

--- a/internal/management/controller/slots/reconciler/replicationslot_test.go
+++ b/internal/management/controller/slots/reconciler/replicationslot_test.go
@@ -78,10 +78,10 @@ var _ = Describe("HA Replication Slots reconciliation in Primary", func() {
 			AddRow(newRepSlot("instance1", true, "lsn1")...).
 			AddRow(newRepSlot("instance2", true, "lsn2")...)
 
-		mock.ExpectQuery("^SELECT (.+) FROM pg_replication_slots").
+		mock.ExpectQuery("^SELECT (.+) FROM pg_catalog.pg_replication_slots").
 			WillReturnRows(rows)
 
-		mock.ExpectExec("SELECT pg_create_physical_replication_slot").
+		mock.ExpectExec("SELECT pg_catalog.pg_create_physical_replication_slot").
 			WithArgs(slotPrefix+"instance3", false).
 			WillReturnResult(sqlmock.NewResult(1, 1))
 
@@ -97,10 +97,10 @@ var _ = Describe("HA Replication Slots reconciliation in Primary", func() {
 			AddRow(newRepSlot("instance2", true, "lsn2")...).
 			AddRow(newRepSlot("instance3", false, "lsn2")...)
 
-		mock.ExpectQuery("^SELECT (.+) FROM pg_replication_slots").
+		mock.ExpectQuery("^SELECT (.+) FROM pg_catalog.pg_replication_slots").
 			WillReturnRows(rows)
 
-		mock.ExpectExec("SELECT pg_drop_replication_slot").WithArgs(slotPrefix + "instance3").
+		mock.ExpectExec("SELECT pg_catalog.pg_drop_replication_slot").WithArgs(slotPrefix + "instance3").
 			WillReturnResult(sqlmock.NewResult(1, 1))
 
 		cluster := makeClusterWithInstanceNames([]string{"instance1", "instance2"}, "instance1")
@@ -115,7 +115,7 @@ var _ = Describe("HA Replication Slots reconciliation in Primary", func() {
 			AddRow(newRepSlot("instance2", true, "lsn2")...).
 			AddRow(newRepSlot("instance3", true, "lsn2")...)
 
-		mock.ExpectQuery("^SELECT (.+) FROM pg_replication_slots").
+		mock.ExpectQuery("^SELECT (.+) FROM pg_catalog.pg_replication_slots").
 			WillReturnRows(rows)
 
 		cluster := makeClusterWithInstanceNames([]string{"instance1", "instance2"}, "instance1")
@@ -126,7 +126,7 @@ var _ = Describe("HA Replication Slots reconciliation in Primary", func() {
 })
 
 var _ = Describe("dropReplicationSlots", func() {
-	const selectPgRepSlot = "^SELECT (.+) FROM pg_replication_slots"
+	const selectPgRepSlot = "^SELECT (.+) FROM pg_catalog.pg_replication_slots"
 
 	var (
 		db   *sql.DB
@@ -166,7 +166,7 @@ var _ = Describe("dropReplicationSlots", func() {
 	It("skips the deletion of user defined replication slots on the primary", func(ctx SpecContext) {
 		rows := sqlmock.NewRows(repSlotColumns).
 			AddRow("custom-slot", string(infrastructure.SlotTypePhysical), true, "lsn1", false)
-		mock.ExpectQuery("^SELECT (.+) FROM pg_replication_slots").
+		mock.ExpectQuery("^SELECT (.+) FROM pg_catalog.pg_replication_slots").
 			WillReturnRows(rows)
 
 		cluster := makeClusterWithInstanceNames([]string{}, "")
@@ -182,7 +182,7 @@ var _ = Describe("dropReplicationSlots", func() {
 			AddRow(newRepSlot("instance1", false, "lsn1")...)
 		mock.ExpectQuery(selectPgRepSlot).WillReturnRows(rows)
 
-		mock.ExpectExec("SELECT pg_drop_replication_slot").WithArgs(slotPrefix + "instance1").
+		mock.ExpectExec("SELECT pg_catalog.pg_drop_replication_slot").WithArgs(slotPrefix + "instance1").
 			WillReturnError(errors.New("delete error"))
 
 		cluster := makeClusterWithInstanceNames([]string{}, "")
@@ -197,7 +197,7 @@ var _ = Describe("dropReplicationSlots", func() {
 			AddRow(newRepSlot("instance1", false, "lsn1")...)
 		mock.ExpectQuery(selectPgRepSlot).WillReturnRows(rows)
 
-		mock.ExpectExec("SELECT pg_drop_replication_slot").WithArgs(slotPrefix + "instance1").
+		mock.ExpectExec("SELECT pg_catalog.pg_drop_replication_slot").WithArgs(slotPrefix + "instance1").
 			WillReturnResult(sqlmock.NewResult(1, 1))
 
 		cluster := makeClusterWithInstanceNames([]string{}, "")

--- a/internal/management/controller/slots/runner/runner_test.go
+++ b/internal/management/controller/slots/runner/runner_test.go
@@ -31,8 +31,8 @@ import (
 
 var _ = Describe("Slot synchronization", Ordered, func() {
 	const (
-		selectPgReplicationSlots = "^SELECT (.+) FROM pg_replication_slots"
-		selectPgSlotAdvance      = "SELECT pg_replication_slot_advance"
+		selectPgReplicationSlots = "^SELECT (.+) FROM pg_catalog.pg_replication_slots"
+		selectPgSlotAdvance      = "SELECT pg_catalog.pg_replication_slot_advance"
 
 		localPodName  = "cluster-2"
 		localSlotName = "_cnpg_cluster_2"
@@ -81,7 +81,7 @@ var _ = Describe("Slot synchronization", Ordered, func() {
 		mockLocal.ExpectQuery(selectPgReplicationSlots).
 			WillReturnRows(sqlmock.NewRows(columns))
 
-		mockLocal.ExpectExec("SELECT pg_create_physical_replication_slot").
+		mockLocal.ExpectExec("SELECT pg_catalog.pg_create_physical_replication_slot").
 			WithArgs(slot3, true).
 			WillReturnResult(sqlmock.NewResult(1, 1))
 
@@ -89,7 +89,7 @@ var _ = Describe("Slot synchronization", Ordered, func() {
 			WithArgs(slot3, lsnSlot3).
 			WillReturnResult(sqlmock.NewResult(1, 1))
 
-		mockLocal.ExpectExec("SELECT pg_create_physical_replication_slot").
+		mockLocal.ExpectExec("SELECT pg_catalog.pg_create_physical_replication_slot").
 			WithArgs(slot4, true).
 			WillReturnResult(sqlmock.NewResult(1, 1))
 
@@ -137,7 +137,7 @@ var _ = Describe("Slot synchronization", Ordered, func() {
 			WillReturnRows(sqlmock.NewRows(columns).
 				AddRow(slot4, string(infrastructure.SlotTypePhysical), false, lsnSlot4, false))
 
-		mockLocal.ExpectExec("SELECT pg_drop_replication_slot").WithArgs(slot4).
+		mockLocal.ExpectExec("SELECT pg_catalog.pg_drop_replication_slot").WithArgs(slot4).
 			WillReturnResult(sqlmock.NewResult(1, 1))
 
 		err := synchronizeReplicationSlots(ctx, dbPrimary, dbLocal, localPodName, &config)
@@ -157,7 +157,7 @@ var _ = Describe("Slot synchronization", Ordered, func() {
 
 		mockLocal.ExpectExec(selectPgSlotAdvance).WithArgs(slotWithXmin, "0/301C4D8").
 			WillReturnResult(sqlmock.NewResult(1, 1))
-		mockLocal.ExpectExec("SELECT pg_drop_replication_slot").WithArgs(slotWithXmin).
+		mockLocal.ExpectExec("SELECT pg_catalog.pg_drop_replication_slot").WithArgs(slotWithXmin).
 			WillReturnResult(sqlmock.NewResult(1, 1))
 
 		err := synchronizeReplicationSlots(ctx, dbPrimary, dbLocal, localPodName, &config)

--- a/internal/management/controller/subscription_controller_sql.go
+++ b/internal/management/controller/subscription_controller_sql.go
@@ -41,7 +41,7 @@ func (r *SubscriptionReconciler) alignSubscription(
 		ctx,
 		`
 		SELECT count(*)
-		FROM pg_subscription
+		FROM pg_catalog.pg_subscription
 	    WHERE subname = $1
 		`,
 		obj.Spec.Name)

--- a/internal/management/controller/subscription_controller_test.go
+++ b/internal/management/controller/subscription_controller_test.go
@@ -43,7 +43,7 @@ import (
 )
 
 const subscriptionDetectionQuery = `SELECT count(*)
-		FROM pg_subscription
+		FROM pg_catalog.pg_subscription
 		WHERE subname = $1`
 
 var _ = Describe("Managed subscription controller tests", func() {

--- a/internal/management/controller/tablespaces/controller_test.go
+++ b/internal/management/controller/tablespaces/controller_test.go
@@ -77,7 +77,7 @@ const (
 		pg_tablespace.spcname spcname,
 		COALESCE(pg_roles.rolname, '') rolname
 	FROM pg_catalog.pg_tablespace
-	LEFT JOIN pg_roles ON pg_tablespace.spcowner = pg_roles.oid
+	LEFT JOIN pg_catalog.pg_roles ON pg_tablespace.spcowner = pg_roles.oid
 	WHERE spcname NOT LIKE $1
 	`
 	expectedCreateStmt = "CREATE TABLESPACE \"%s\" OWNER \"%s\" " +

--- a/internal/management/controller/tablespaces/controller_test.go
+++ b/internal/management/controller/tablespaces/controller_test.go
@@ -76,7 +76,7 @@ const (
 	SELECT
 		pg_tablespace.spcname spcname,
 		COALESCE(pg_roles.rolname, '') rolname
-	FROM pg_tablespace
+	FROM pg_catalog.pg_tablespace
 	LEFT JOIN pg_roles ON pg_tablespace.spcowner = pg_roles.oid
 	WHERE spcname NOT LIKE $1
 	`
@@ -87,9 +87,9 @@ const (
 
 	expectedReadinessCheck = `
 		SELECT
-			NOT pg_is_in_recovery()
-			OR (SELECT coalesce(setting, '') = '' FROM pg_settings WHERE name = 'primary_conninfo')
-			OR pg_last_wal_replay_lsn() IS NOT NULL
+			NOT pg_catalog.pg_is_in_recovery()
+			OR (SELECT coalesce(setting, '') = '' FROM pg_catalog.pg_settings WHERE name = 'primary_conninfo')
+			OR pg_catalog.pg_last_wal_replay_lsn() IS NOT NULL
 		`
 )
 

--- a/internal/management/controller/tablespaces/infrastructure/postgres.go
+++ b/internal/management/controller/tablespaces/infrastructure/postgres.go
@@ -42,7 +42,7 @@ func List(ctx context.Context, db *sql.DB) ([]Tablespace, error) {
 			pg_tablespace.spcname spcname,
 			COALESCE(pg_roles.rolname, '') rolname
 		FROM pg_catalog.pg_tablespace
-		LEFT JOIN pg_roles ON pg_tablespace.spcowner = pg_roles.oid
+		LEFT JOIN pg_catalog.pg_roles ON pg_tablespace.spcowner = pg_roles.oid
 		WHERE spcname NOT LIKE $1
 		`,
 		postgres.SystemTablespacesPrefix,

--- a/internal/management/controller/tablespaces/infrastructure/postgres.go
+++ b/internal/management/controller/tablespaces/infrastructure/postgres.go
@@ -41,7 +41,7 @@ func List(ctx context.Context, db *sql.DB) ([]Tablespace, error) {
 		SELECT
 			pg_tablespace.spcname spcname,
 			COALESCE(pg_roles.rolname, '') rolname
-		FROM pg_tablespace
+		FROM pg_catalog.pg_tablespace
 		LEFT JOIN pg_roles ON pg_tablespace.spcowner = pg_roles.oid
 		WHERE spcname NOT LIKE $1
 		`,

--- a/internal/management/controller/tablespaces/infrastructure/postgres_test.go
+++ b/internal/management/controller/tablespaces/infrastructure/postgres_test.go
@@ -31,7 +31,7 @@ var _ = Describe("Postgres tablespaces functions test", func() {
 		pg_tablespace.spcname spcname,
 		COALESCE(pg_roles.rolname, '') rolname
 	FROM pg_catalog.pg_tablespace
-	LEFT JOIN pg_roles ON pg_tablespace.spcowner = pg_roles.oid
+	LEFT JOIN pg_catalog.pg_roles ON pg_tablespace.spcowner = pg_roles.oid
 	WHERE spcname NOT LIKE $1
 	`
 	expectedCreateStmt := "CREATE TABLESPACE \"%s\" OWNER \"%s\" " +

--- a/internal/management/controller/tablespaces/infrastructure/postgres_test.go
+++ b/internal/management/controller/tablespaces/infrastructure/postgres_test.go
@@ -30,7 +30,7 @@ var _ = Describe("Postgres tablespaces functions test", func() {
 	SELECT
 		pg_tablespace.spcname spcname,
 		COALESCE(pg_roles.rolname, '') rolname
-	FROM pg_tablespace
+	FROM pg_catalog.pg_tablespace
 	LEFT JOIN pg_roles ON pg_tablespace.spcowner = pg_roles.oid
 	WHERE spcname NOT LIKE $1
 	`

--- a/pkg/management/postgres/initdb.go
+++ b/pkg/management/postgres/initdb.go
@@ -340,7 +340,9 @@ func (info InitInfo) ConfigureNewInstance(instance *Instance) error {
 	}
 
 	var existsDB bool
-	dbRow := dbSuperUser.QueryRow("SELECT COUNT(*) > 0 FROM pg_database WHERE datname = $1", info.ApplicationDatabase)
+	dbRow := dbSuperUser.QueryRow(
+		"SELECT COUNT(*) > 0 FROM pg_catalog.pg_database WHERE datname = $1",
+		info.ApplicationDatabase)
 	err = dbRow.Scan(&existsDB)
 	if err != nil {
 		return err

--- a/pkg/management/postgres/instance.go
+++ b/pkg/management/postgres/instance.go
@@ -1237,7 +1237,7 @@ func (instance *Instance) waitForInstanceRestarted(ctx context.Context, after ti
 			return err
 		}
 		var startTime time.Time
-		row := db.QueryRowContext(ctx, "SELECT pg_postmaster_start_time()")
+		row := db.QueryRowContext(ctx, "SELECT pg_catalog.pg_postmaster_start_time()")
 		err = row.Scan(&startTime)
 		if err != nil {
 			return err
@@ -1257,8 +1257,8 @@ func (instance *Instance) DropConnections() error {
 	}
 
 	if _, err := conn.Exec(
-		`SELECT pg_terminate_backend(pid)
-			   FROM pg_stat_activity
+		`SELECT pg_catalog.pg_terminate_backend(pid)
+			   FROM pg_catalog.pg_stat_activity
 			   WHERE pid <> pg_backend_pid()
 			     AND backend_type = 'client backend';`,
 	); err != nil {

--- a/pkg/management/postgres/logicalimport/database.go
+++ b/pkg/management/postgres/logicalimport/database.go
@@ -51,7 +51,7 @@ func (ds *databaseSnapshotter) getDatabaseList(ctx context.Context, target pool.
 	if err != nil {
 		return nil, err
 	}
-	query := `SELECT datname FROM pg_database d WHERE datallowconn
+	query := `SELECT datname FROM pg_catalog.pg_database d WHERE datallowconn
               AND NOT datistemplate
               AND datallowconn
               AND datname != 'postgres'
@@ -331,7 +331,7 @@ func (ds *databaseSnapshotter) dropExtensionsFromDatabase(
 
 	// In Postgres, OID 16384 is the first non system ID that can be used in the database
 	// catalog, as defined in the `FirstNormalObjectId` constant (src/include/access/transam.h)
-	rows, err := db.QueryContext(ctx, "SELECT extname FROM pg_extension WHERE oid >= 16384")
+	rows, err := db.QueryContext(ctx, "SELECT extname FROM pg_catalog.pg_extension WHERE oid >= 16384")
 	if err != nil {
 		return err
 	}

--- a/pkg/management/postgres/logicalimport/database_test.go
+++ b/pkg/management/postgres/logicalimport/database_test.go
@@ -130,7 +130,7 @@ var _ = Describe("databaseSnapshotter methods test", func() {
 		var expectedQuery *sqlmock.ExpectedQuery
 
 		BeforeEach(func() {
-			expectedQuery = mock.ExpectQuery("SELECT extname FROM pg_extension WHERE oid >= 16384")
+			expectedQuery = mock.ExpectQuery("SELECT extname FROM pg_catalog.pg_extension WHERE oid >= 16384")
 		})
 
 		It("should drop the user-defined extensions successfully", func(ctx SpecContext) {
@@ -169,7 +169,7 @@ var _ = Describe("databaseSnapshotter methods test", func() {
 	})
 
 	Context("getDatabaseList testing", func() {
-		const query = "SELECT datname FROM pg_database d " +
+		const query = "SELECT datname FROM pg_catalog.pg_database d " +
 			"WHERE datallowconn AND NOT datistemplate AND datallowconn AND datname != 'postgres' " +
 			"ORDER BY datname"
 

--- a/pkg/management/postgres/logicalimport/role.go
+++ b/pkg/management/postgres/logicalimport/role.go
@@ -155,8 +155,8 @@ func (rs *roleManager) getRoles(ctx context.Context) ([]Role, error) {
 			"rolcanlogin, rolconnlimit, rolpassword, " +
 			"rolvaliduntil, rolreplication, rolbypassrls, " +
 			"pg_catalog.shobj_description(oid, 'pg_authid') as rolcomment, " +
-			"rolname = current_user AS is_current_user " +
-			"FROM pg_authid " +
+			"rolname = CURRENT_USER AS is_current_user " +
+			"FROM pg_catalog.pg_authid " +
 			"WHERE oid >= 16384 " +
 			"ORDER BY 2"
 	} else {
@@ -166,8 +166,8 @@ func (rs *roleManager) getRoles(ctx context.Context) ([]Role, error) {
 			"rolvaliduntil, rolreplication, " +
 			"false as rolbypassrls, " +
 			"pg_catalog.shobj_description(oid, 'pg_authid') as rolcomment, " +
-			"rolname = current_user AS is_current_user " +
-			"FROM pg_authid " +
+			"rolname = CURRENT_USER AS is_current_user " +
+			"FROM pg_catalog.pg_authid " +
 			"WHERE oid >= 16384 " +
 			"ORDER BY 2"
 	}

--- a/pkg/management/postgres/logicalimport/role_test.go
+++ b/pkg/management/postgres/logicalimport/role_test.go
@@ -29,7 +29,7 @@ import (
 var _ = Describe("", func() {
 	const inhQuery = "SELECT ur.rolname AS roleid, um.rolname AS member, a.admin_option, ug.rolname AS grantor " +
 		"FROM pg_catalog.pg_auth_members a LEFT JOIN pg_authid ur on ur.oid = a.roleid " +
-		"LEFT JOIN pg_authid um on um.oid = a.member " +
+		"LEFT JOIN pg_catalog.pg_authid um on um.oid = a.member " +
 		"LEFT JOIN pg_catalog.pg_authid ug on ug.oid = a.grantor " +
 		"WHERE ur.oid >= 16384 AND um.oid >= 16384"
 

--- a/pkg/management/postgres/logicalimport/role_test.go
+++ b/pkg/management/postgres/logicalimport/role_test.go
@@ -28,7 +28,7 @@ import (
 
 var _ = Describe("", func() {
 	const inhQuery = "SELECT ur.rolname AS roleid, um.rolname AS member, a.admin_option, ug.rolname AS grantor " +
-		"FROM pg_catalog.pg_auth_members a LEFT JOIN pg_authid ur on ur.oid = a.roleid " +
+		"FROM pg_catalog.pg_auth_members a LEFT JOIN pg_catalog.pg_authid ur on ur.oid = a.roleid " +
 		"LEFT JOIN pg_catalog.pg_authid um on um.oid = a.member " +
 		"LEFT JOIN pg_catalog.pg_authid ug on ug.oid = a.grantor " +
 		"WHERE ur.oid >= 16384 AND um.oid >= 16384"

--- a/pkg/management/postgres/logicalimport/role_test.go
+++ b/pkg/management/postgres/logicalimport/role_test.go
@@ -30,7 +30,7 @@ var _ = Describe("", func() {
 	const inhQuery = "SELECT ur.rolname AS roleid, um.rolname AS member, a.admin_option, ug.rolname AS grantor " +
 		"FROM pg_catalog.pg_auth_members a LEFT JOIN pg_authid ur on ur.oid = a.roleid " +
 		"LEFT JOIN pg_authid um on um.oid = a.member " +
-		"LEFT JOIN pg_authid ug on ug.oid = a.grantor " +
+		"LEFT JOIN pg_catalog.pg_authid ug on ug.oid = a.grantor " +
 		"WHERE ur.oid >= 16384 AND um.oid >= 16384"
 
 	var (

--- a/pkg/management/postgres/logicalimport/role_test.go
+++ b/pkg/management/postgres/logicalimport/role_test.go
@@ -28,7 +28,7 @@ import (
 
 var _ = Describe("", func() {
 	const inhQuery = "SELECT ur.rolname AS roleid, um.rolname AS member, a.admin_option, ug.rolname AS grantor " +
-		"FROM pg_auth_members a LEFT JOIN pg_authid ur on ur.oid = a.roleid " +
+		"FROM pg_catalog.pg_auth_members a LEFT JOIN pg_authid ur on ur.oid = a.roleid " +
 		"LEFT JOIN pg_authid um on um.oid = a.member " +
 		"LEFT JOIN pg_authid ug on ug.oid = a.grantor " +
 		"WHERE ur.oid >= 16384 AND um.oid >= 16384"

--- a/pkg/management/postgres/logicalimport/roleinheritance.go
+++ b/pkg/management/postgres/logicalimport/roleinheritance.go
@@ -98,7 +98,7 @@ func (rs *roleInheritanceManager) getRoleInheritance(ctx context.Context) ([]Rol
 		"um.rolname AS member, " +
 		"a.admin_option, " +
 		"ug.rolname AS grantor " +
-		"FROM pg_auth_members a " +
+		"FROM pg_catalog.pg_auth_members a " +
 		"LEFT JOIN pg_authid ur on ur.oid = a.roleid " +
 		"LEFT JOIN pg_authid um on um.oid = a.member " +
 		"LEFT JOIN pg_authid ug on ug.oid = a.grantor " +

--- a/pkg/management/postgres/logicalimport/roleinheritance.go
+++ b/pkg/management/postgres/logicalimport/roleinheritance.go
@@ -99,9 +99,9 @@ func (rs *roleInheritanceManager) getRoleInheritance(ctx context.Context) ([]Rol
 		"a.admin_option, " +
 		"ug.rolname AS grantor " +
 		"FROM pg_catalog.pg_auth_members a " +
-		"LEFT JOIN pg_authid ur on ur.oid = a.roleid " +
-		"LEFT JOIN pg_authid um on um.oid = a.member " +
-		"LEFT JOIN pg_authid ug on ug.oid = a.grantor " +
+		"LEFT JOIN pg_catalog.pg_authid ur on ur.oid = a.roleid " +
+		"LEFT JOIN pg_catalog.pg_authid um on um.oid = a.member " +
+		"LEFT JOIN pg_catalog.pg_authid ug on ug.oid = a.grantor " +
 		"WHERE ur.oid >= 16384 AND um.oid >= 16384"
 
 	rows, err := originDB.Query(query)

--- a/pkg/management/postgres/logicalimport/roleinheritance_test.go
+++ b/pkg/management/postgres/logicalimport/roleinheritance_test.go
@@ -66,7 +66,7 @@ var _ = Describe("RoleInheritanceManager", func() {
 				AddRow("role2", "member2", false, nil)
 
 			query := "SELECT ur\\.rolname AS roleid, um\\.rolname AS member, a\\.admin_option, ug\\.rolname AS grantor " +
-				"FROM pg_auth_members a LEFT JOIN pg_authid ur on ur\\.oid = a\\.roleid " +
+				"FROM pg_catalog.pg_auth_members a LEFT JOIN pg_authid ur on ur\\.oid = a\\.roleid " +
 				"LEFT JOIN pg_authid um on um\\.oid = a\\.member " +
 				"LEFT JOIN pg_authid ug on ug\\.oid = a\\.grantor " +
 				"WHERE ur\\.oid >= 16384 AND um\\.oid >= 16384"

--- a/pkg/management/postgres/logicalimport/roleinheritance_test.go
+++ b/pkg/management/postgres/logicalimport/roleinheritance_test.go
@@ -66,9 +66,9 @@ var _ = Describe("RoleInheritanceManager", func() {
 				AddRow("role2", "member2", false, nil)
 
 			query := "SELECT ur\\.rolname AS roleid, um\\.rolname AS member, a\\.admin_option, ug\\.rolname AS grantor " +
-				"FROM pg_catalog.pg_auth_members a LEFT JOIN pg_authid ur on ur\\.oid = a\\.roleid " +
-				"LEFT JOIN pg_authid um on um\\.oid = a\\.member " +
-				"LEFT JOIN pg_authid ug on ug\\.oid = a\\.grantor " +
+				"FROM pg_catalog.pg_auth_members a LEFT JOIN pg_catalog.pg_authid ur on ur\\.oid = a\\.roleid " +
+				"LEFT JOIN pg_catalog.pg_authid um on um\\.oid = a\\.member " +
+				"LEFT JOIN pg_catalog.pg_authid ug on ug\\.oid = a\\.grantor " +
 				"WHERE ur\\.oid >= 16384 AND um\\.oid >= 16384"
 
 			mock.ExpectQuery(query).WillReturnRows(rows)

--- a/pkg/management/postgres/readiness/readiness.go
+++ b/pkg/management/postgres/readiness/readiness.go
@@ -78,9 +78,9 @@ func (data *Data) IsServerReady(ctx context.Context) error {
 		ctx,
 		`
 		SELECT
-			NOT pg_is_in_recovery()
-			OR (SELECT coalesce(setting, '') = '' FROM pg_settings WHERE name = 'primary_conninfo')
-			OR pg_last_wal_replay_lsn() IS NOT NULL
+			NOT pg_catalog.pg_is_in_recovery()
+			OR (SELECT coalesce(setting, '') = '' FROM pg_catalog.pg_settings WHERE name = 'primary_conninfo')
+			OR pg_catalog.pg_last_wal_replay_lsn() IS NOT NULL
 		`,
 	)
 	if err := row.Err(); err != nil {

--- a/pkg/management/postgres/restore.go
+++ b/pkg/management/postgres/restore.go
@@ -1035,7 +1035,7 @@ func waitUntilRecoveryFinishes(db *sql.DB) error {
 	}
 
 	return retry.OnError(RetryUntilRecoveryDone, errorIsRetriable, func() error {
-		row := db.QueryRow("SELECT pg_is_in_recovery()")
+		row := db.QueryRow("SELECT pg_catalog.pg_is_in_recovery()")
 
 		var status bool
 		if err := row.Scan(&status); err != nil {

--- a/pkg/management/postgres/utils/utils.go
+++ b/pkg/management/postgres/utils/utils.go
@@ -132,7 +132,7 @@ func DBToString(t interface{}) (string, bool) {
 // GetAllAccessibleDatabases returns the list of all the accessible databases using the superuser
 func GetAllAccessibleDatabases(tx *sql.Tx, whereClause string) (databases []string, errors []error) {
 	rows, err := tx.Query(strings.Join(
-		[]string{"SELECT datname FROM pg_database", whereClause},
+		[]string{"SELECT datname FROM pg_catalog.pg_database", whereClause},
 		" WHERE "),
 	)
 	if err != nil {

--- a/pkg/management/postgres/wal.go
+++ b/pkg/management/postgres/wal.go
@@ -91,7 +91,7 @@ func (w *walArchiveAnalyzer) mustHaveFirstWalArchivedWithBackoff(backoff wait.Ba
 func (w *walArchiveAnalyzer) mustHaveFirstWalArchived(db *sql.DB) error {
 	row := db.QueryRow("SELECT COALESCE(last_archived_time,'-infinity') > " +
 		"COALESCE(last_failed_time, '-infinity') AS is_archiving, last_failed_time IS NOT NULL " +
-		"FROM pg_stat_archiver")
+		"FROM pg_catalog.pg_stat_archiver")
 
 	var walArchivingWorking, lastFailedTimePresent bool
 
@@ -183,7 +183,7 @@ func (w *walArchiveBootstrapper) shipWalFile(db *sql.DB) error {
 		return fmt.Errorf("error while requiring a checkpoint: %w", err)
 	}
 
-	if _, err := db.Exec("SELECT pg_switch_wal()"); err != nil {
+	if _, err := db.Exec("SELECT pg_catalog.pg_switch_wal()"); err != nil {
 		return fmt.Errorf("error while switching to a new WAL: %w", err)
 	}
 

--- a/pkg/management/postgres/wal_test.go
+++ b/pkg/management/postgres/wal_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 var _ = Describe("ensure isWalArchiveWorking works correctly", func() {
-	const flexibleCoalescenceQuery = "SELECT COALESCE.*FROM pg_stat_archiver"
+	const flexibleCoalescenceQuery = "SELECT COALESCE.*FROM pg_catalog.pg_stat_archiver"
 	var (
 		db           *sql.DB
 		mock         sqlmock.Sqlmock
@@ -75,7 +75,7 @@ var _ = Describe("ensure isWalArchiveWorking works correctly", func() {
 		rows := sqlmock.NewRows([]string{"is_archiving", "last_failed_time_present"}).AddRow(false, false)
 		mock.ExpectQuery(flexibleCoalescenceQuery).WillReturnRows(rows)
 		mock.ExpectExec("CHECKPOINT").WillReturnResult(fakeResult)
-		mock.ExpectExec("SELECT pg_switch_wal()").WillReturnResult(fakeResult)
+		mock.ExpectExec("SELECT pg_catalog.pg_switch_wal()").WillReturnResult(fakeResult)
 
 		// Call the function
 		err := bootstrapper.mustHaveFirstWalArchived(db)

--- a/pkg/management/postgres/webserver/backup_connection.go
+++ b/pkg/management/postgres/webserver/backup_connection.go
@@ -156,7 +156,8 @@ func (bc *backupConnection) startBackup(ctx context.Context, backupName string) 
 	slotName := replicationSlotInvalidCharacters.ReplaceAllString(bc.data.BackupName, "_")
 	if _, err := bc.conn.ExecContext(
 		ctx,
-		"SELECT pg_create_physical_replication_slot(slot_name => $1, immediately_reserve => true, temporary => true)",
+		"SELECT pg_catalog.pg_create_physical_replication_slot("+
+			"slot_name => $1, immediately_reserve => true, temporary => true)",
 		slotName,
 	); err != nil {
 		bc.err = fmt.Errorf("while creating the replication slot: %w", bc.err)
@@ -165,10 +166,10 @@ func (bc *backupConnection) startBackup(ctx context.Context, backupName string) 
 
 	var row *sql.Row
 	if bc.postgresMajorVersion < 15 {
-		row = bc.conn.QueryRowContext(ctx, "SELECT pg_start_backup($1, $2, false);", bc.data.BackupName,
+		row = bc.conn.QueryRowContext(ctx, "SELECT pg_catalog.pg_start_backup($1, $2, false);", bc.data.BackupName,
 			bc.immediateCheckpoint)
 	} else {
-		row = bc.conn.QueryRowContext(ctx, "SELECT pg_backup_start(label => $1, fast => $2);", bc.data.BackupName,
+		row = bc.conn.QueryRowContext(ctx, "SELECT pg_catalog.pg_backup_start(label => $1, fast => $2);", bc.data.BackupName,
 			bc.immediateCheckpoint)
 	}
 
@@ -204,10 +205,10 @@ func (bc *backupConnection) stopBackup(ctx context.Context, backupName string) {
 	var row *sql.Row
 	if bc.postgresMajorVersion < 15 {
 		row = bc.conn.QueryRowContext(ctx,
-			"SELECT lsn, labelfile, spcmapfile FROM pg_stop_backup(false, $1);", bc.waitForArchive)
+			"SELECT lsn, labelfile, spcmapfile FROM pg_catalog.pg_stop_backup(false, $1);", bc.waitForArchive)
 	} else {
 		row = bc.conn.QueryRowContext(ctx,
-			"SELECT lsn, labelfile, spcmapfile FROM pg_backup_stop(wait_for_archive => $1);", bc.waitForArchive)
+			"SELECT lsn, labelfile, spcmapfile FROM pg_catalog.pg_backup_stop(wait_for_archive => $1);", bc.waitForArchive)
 	}
 
 	bc.executeWithLock(backupName, func() error {

--- a/pkg/management/postgres/webserver/metricserver/pg_collector.go
+++ b/pkg/management/postgres/webserver/metricserver/pg_collector.go
@@ -583,8 +583,8 @@ func (e *Exporter) SetCustomQueries(queries *m.QueriesCollector) {
 // DefaultQueries is the set of default queries for postgresql
 var DefaultQueries = m.UserQueries{
 	"collector": m.UserQuery{
-		Query: "SELECT current_database() as datname, relpages as lo_pages " +
-			"FROM pg_class c JOIN pg_namespace n ON (n.oid = c.relnamespace) " +
+		Query: "SELECT pg_catalog.current_database() as datname, relpages as lo_pages " +
+			"FROM pg_catalog.pg_class c JOIN pg_catalog.pg_namespace n ON (n.oid = c.relnamespace) " +
 			"WHERE n.nspname = 'pg_catalog' AND c.relname = 'pg_largeobject';",
 		TargetDatabases: []string{"*"},
 		Metrics: []m.Mapping{

--- a/pkg/management/postgres/webserver/metricserver/wal.go
+++ b/pkg/management/postgres/webserver/metricserver/wal.go
@@ -78,7 +78,7 @@ func (s *walSettings) synchronize(db *sql.DB, configSha256 string) error {
 	}
 
 	rows, err := db.Query(`
-SELECT name, setting FROM pg_settings 
+SELECT name, setting FROM pg_catalog.pg_settings
 WHERE pg_settings.name
 IN ('wal_segment_size', 'min_wal_size', 'max_wal_size', 'wal_keep_size', 'wal_keep_segments', 'max_slot_wal_keep_size')`) // nolint: lll
 	if err != nil {

--- a/pkg/management/postgres/webserver/metricserver/wal_test.go
+++ b/pkg/management/postgres/webserver/metricserver/wal_test.go
@@ -38,7 +38,7 @@ var _ = Describe("ensures walSettings works correctly", func() {
 		maxSlotWalKeepSize float64 = -1
 		walKeepSegments    float64 = 25
 		query                      = `
-SELECT name, setting FROM pg_settings 
+SELECT name, setting FROM pg_catalog.pg_settings
 WHERE pg_settings.name
 IN ('wal_segment_size', 'min_wal_size', 'max_wal_size', 'wal_keep_size', 'wal_keep_segments', 'max_slot_wal_keep_size')`
 	)

--- a/tests/e2e/asserts_test.go
+++ b/tests/e2e/asserts_test.go
@@ -307,7 +307,7 @@ func AssertClusterIsReady(namespace string, clusterName string, timeout int, env
 						PodName:   primaryPod.Name,
 					},
 					"postgres",
-					fmt.Sprintf("SELECT COUNT(*) FROM pg_stat_replication WHERE application_name IN (%s)",
+					fmt.Sprintf("SELECT COUNT(*) FROM pg_catalog.pg_stat_replication WHERE application_name IN (%s)",
 						replicaNamesString),
 				)
 				g.Expect(err).ToNot(HaveOccurred(), "cannot extract the list of streaming replicas")
@@ -554,11 +554,11 @@ func QueryMatchExpectationPredicate(
 }
 
 func roleExistsQuery(roleName string) string {
-	return fmt.Sprintf("SELECT EXISTS(SELECT 1 FROM pg_roles WHERE rolname='%v')", roleName)
+	return fmt.Sprintf("SELECT EXISTS(SELECT 1 FROM pg_catalog.pg_roles WHERE rolname='%v')", roleName)
 }
 
 func databaseExistsQuery(dbName string) string {
-	return fmt.Sprintf("SELECT EXISTS(SELECT 1 FROM pg_database WHERE datname='%v')", dbName)
+	return fmt.Sprintf("SELECT EXISTS(SELECT 1 FROM pg_catalog.pg_database WHERE datname='%v')", dbName)
 }
 
 // AssertDataExpectedCount verifies that an expected amount of rows exists on the table
@@ -617,7 +617,7 @@ func AssertLargeObjectValue(namespace, clusterName string, oid int, data string)
 
 // AssertClusterStandbysAreStreaming verifies that all the standbys of a cluster have a wal-receiver running.
 func AssertClusterStandbysAreStreaming(namespace string, clusterName string, timeout int32) {
-	query := "SELECT count(*) FROM pg_stat_wal_receiver"
+	query := "SELECT count(*) FROM pg_catalog.pg_stat_wal_receiver"
 	Eventually(func() error {
 		standbyPods, err := clusterutils.GetReplicas(env.Ctx, env.Client, namespace, clusterName)
 		if err != nil {
@@ -914,7 +914,7 @@ func AssertPgRecoveryMode(pod *corev1.Pod, expectedValue bool) {
 					PodName:   pod.Name,
 				},
 				postgres.PostgresDBName,
-				"select pg_is_in_recovery();")
+				"select pg_catalog.pg_is_in_recovery()")
 			if err != nil {
 				GinkgoWriter.Printf("stdout: %v\nstderr: %v\n", stdOut, stdErr)
 			}
@@ -1157,7 +1157,7 @@ func AssertWritesToReplicaFails(
 
 			var rawValue string
 			// Expect to be connected to a replica
-			row := conn.QueryRow("SELECT pg_is_in_recovery()")
+			row := conn.QueryRow("SELECT pg_catalog.pg_is_in_recovery()")
 			err = row.Scan(&rawValue)
 			g.Expect(err).ToNot(HaveOccurred())
 			isReplica := strings.TrimSpace(rawValue)
@@ -1186,7 +1186,7 @@ func AssertWritesToPrimarySucceeds(namespace, service, appDBName, appDBUser, app
 
 			var rawValue string
 			// Expect to be connected to a primary
-			row := conn.QueryRow("SELECT pg_is_in_recovery()")
+			row := conn.QueryRow("SELECT pg_catalog.pg_is_in_recovery()")
 			err = row.Scan(&rawValue)
 			g.Expect(err).ToNot(HaveOccurred())
 			isReplica := strings.TrimSpace(rawValue)
@@ -2021,7 +2021,7 @@ func switchWalAndGetLatestArchive(namespace, podName string) string {
 			PodName:   podName,
 		},
 		postgres.PostgresDBName,
-		"SELECT pg_walfile_name(pg_switch_wal());",
+		"SELECT pg_catalog.pg_walfile_name(pg_switch_wal())",
 	)
 	Expect(err).ToNot(
 		HaveOccurred(),
@@ -2795,12 +2795,12 @@ func AssertReplicationSlotsOnPod(
 
 	for _, slot := range expectedSlots {
 		query := fmt.Sprintf(
-			"SELECT EXISTS (SELECT 1 FROM pg_replication_slots "+
+			"SELECT EXISTS (SELECT 1 FROM pg_catalog.pg_replication_slots "+
 				"WHERE slot_name = '%v' AND active = '%t' "+
 				"AND temporary = 'f' AND slot_type = 'physical')", slot, isActiveOnReplica)
 		if specs.IsPodPrimary(pod) {
 			query = fmt.Sprintf(
-				"SELECT EXISTS (SELECT 1 FROM pg_replication_slots "+
+				"SELECT EXISTS (SELECT 1 FROM pg_catalog.pg_replication_slots "+
 					"WHERE slot_name = '%v' AND active = '%t' "+
 					"AND temporary = 'f' AND slot_type = 'physical')", slot, isActiveOnPrimary)
 		}

--- a/tests/e2e/cluster_microservice_test.go
+++ b/tests/e2e/cluster_microservice_test.go
@@ -251,7 +251,7 @@ func assertTableAndDataOnImportedCluster(
 
 		By("Verifying imported table has owner app user", func() {
 			queryImported := fmt.Sprintf(
-				"select * from pg_tables where tablename = '%v' and tableowner = '%v'",
+				"select * from pg_catalog.pg_tables where tablename = '%v' and tableowner = '%v'",
 				tableName,
 				postgres.AppUser,
 			)

--- a/tests/e2e/cluster_monolithic_test.go
+++ b/tests/e2e/cluster_monolithic_test.go
@@ -170,7 +170,7 @@ var _ = Describe("Imports with Monolithic Approach", Label(tests.LabelImportingD
 		})
 
 		By("verifying that the specified source databases were imported", func() {
-			stmt, err := connTarget.Prepare("SELECT datname FROM pg_database WHERE datname IN ($1)")
+			stmt, err := connTarget.Prepare("SELECT datname FROM pg_catalog.pg_database WHERE datname IN ($1)")
 			Expect(err).ToNot(HaveOccurred())
 			rows, err := stmt.QueryContext(env.Ctx, pq.Array(sourceDatabases))
 			Expect(err).ToNot(HaveOccurred())
@@ -184,7 +184,9 @@ var _ = Describe("Imports with Monolithic Approach", Label(tests.LabelImportingD
 
 		By(fmt.Sprintf("verifying that the source superuser '%s' became a normal user in target",
 			databaseSuperUser), func() {
-			row := connTarget.QueryRow(fmt.Sprintf("SELECT usesuper FROM pg_user WHERE usename='%s'", databaseSuperUser))
+			row := connTarget.QueryRow(fmt.Sprintf(
+				"SELECT usesuper FROM pg_catalog.pg_user WHERE usename='%s'",
+				databaseSuperUser))
 			var superUser bool
 			err := row.Scan(&superUser)
 			Expect(err).ToNot(HaveOccurred())

--- a/tests/e2e/configuration_update_test.go
+++ b/tests/e2e/configuration_update_test.go
@@ -199,7 +199,7 @@ var _ = Describe("Configuration update", Ordered, Label(tests.LabelClusterMetada
 
 		By("verify that connections succeed after pg_hba_reload", func() {
 			// The new pg_hba rule should be present in every pod
-			query := "select count(*) from pg_hba_file_rules where type = 'host' and auth_method = 'trust'"
+			query := "select count(*) from pg_catalog.pg_hba_file_rules where type = 'host' and auth_method = 'trust'"
 			for _, pod := range podList.Items {
 				Eventually(func() (string, error) {
 					stdout, _, err := exec.QueryInInstancePod(
@@ -429,7 +429,7 @@ var _ = Describe("Configuration update", Ordered, Label(tests.LabelClusterMetada
 		if env.PostgresVersion > 14 {
 			primaryPod, err := clusterutils.GetPrimary(env.Ctx, env.Client, namespace, clusterName)
 			Expect(err).ToNot(HaveOccurred())
-			query := "select count(1) from pg_ident_file_mappings;"
+			query := "select count(1) from pg_catalog.pg_ident_file_mappings;"
 
 			By("check that there is only one entry in pg_ident_file_mappings", func() {
 				Eventually(func() (string, error) {

--- a/tests/e2e/declarative_database_management_test.go
+++ b/tests/e2e/declarative_database_management_test.go
@@ -75,7 +75,7 @@ var _ = Describe("Declarative database management", Label(tests.LabelSmoke, test
 		})
 
 		assertDatabaseHasExpectedFields := func(namespace, primaryPod string, db apiv1.Database) {
-			query := fmt.Sprintf("select count(*) from pg_database where datname = '%s' "+
+			query := fmt.Sprintf("select count(*) from pg_catalog.pg_database where datname = '%s' "+
 				"and encoding = pg_char_to_encoding('%s') and datctype = '%s' and datcollate = '%s'",
 				db.Spec.Name, db.Spec.Encoding, db.Spec.LcCtype, db.Spec.LcCollate)
 			Eventually(func(g Gomega) {

--- a/tests/e2e/disk_space_test.go
+++ b/tests/e2e/disk_space_test.go
@@ -88,7 +88,7 @@ var _ = Describe("Volume space unavailable", Label(tests.LabelStorage), func() {
 				query)
 			Expect(err).To(HaveOccurred())
 
-			query = "CHECKPOINT; SELECT pg_switch_wal(); CHECKPOINT"
+			query = "CHECKPOINT; SELECT pg_catalog.pg_switch_wal(); CHECKPOINT"
 			_, _, err = exec.QueryInInstancePod(
 				env.Ctx, env.Client, env.Interface, env.RestClientConfig,
 				exec.PodLocator{
@@ -172,7 +172,7 @@ var _ = Describe("Volume space unavailable", Label(tests.LabelStorage), func() {
 			}).WithTimeout(10 * time.Minute).Should(BeTrue())
 		})
 		By("writing some WAL", func() {
-			query := "CHECKPOINT; SELECT pg_switch_wal(); CHECKPOINT"
+			query := "CHECKPOINT; SELECT pg_catalog.pg_switch_wal(); CHECKPOINT"
 			_, _, err := exec.QueryInInstancePod(
 				env.Ctx, env.Client, env.Interface, env.RestClientConfig,
 				exec.PodLocator{

--- a/tests/e2e/failover_test.go
+++ b/tests/e2e/failover_test.go
@@ -84,7 +84,7 @@ var _ = Describe("Failover", Label(tests.LabelSelfHealing), func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// Get the walreceiver pid
-			query := "SELECT pid FROM pg_stat_activity WHERE backend_type = 'walreceiver'"
+			query := "SELECT pid FROM pg_catalog.pg_stat_activity WHERE backend_type = 'walreceiver'"
 			out, _, err := exec.EventuallyExecQueryInInstancePod(
 				env.Ctx, env.Client, env.Interface, env.RestClientConfig,
 				exec.PodLocator{
@@ -105,7 +105,7 @@ var _ = Describe("Failover", Label(tests.LabelSelfHealing), func() {
 
 			// Terminate the pausedReplica walsender on the primary.
 			// We don't want to wait for the replication timeout.
-			query = fmt.Sprintf("SELECT pg_terminate_backend(pid) FROM pg_stat_replication "+
+			query = fmt.Sprintf("SELECT pg_catalog.pg_terminate_backend(pid) FROM pg_catalog.pg_stat_replication "+
 				"WHERE application_name = '%v'", pausedReplica)
 			_, _, err = exec.EventuallyExecQueryInInstancePod(
 				env.Ctx, env.Client, env.Interface, env.RestClientConfig,
@@ -142,7 +142,7 @@ var _ = Describe("Failover", Label(tests.LabelSelfHealing), func() {
 					Namespace: primaryPod.Namespace,
 					PodName:   primaryPod.Name,
 				}, postgres.PostgresDBName,
-				"SELECT pg_current_wal_lsn()",
+				"SELECT pg_catalog.pg_current_wal_lsn()",
 				RetryTimeout,
 				PollingTime,
 			)
@@ -161,7 +161,7 @@ var _ = Describe("Failover", Label(tests.LabelSelfHealing), func() {
 			)
 			Expect(err).ToNot(HaveOccurred())
 
-			query := fmt.Sprintf("SELECT true FROM pg_stat_replication "+
+			query := fmt.Sprintf("SELECT true FROM pg_catalog.pg_stat_replication "+
 				"WHERE application_name = '%v' AND replay_lsn > '%v'",
 				targetPrimary, strings.Trim(initialLSN, "\n"))
 			// The replay_lsn of the targetPrimary should be ahead

--- a/tests/e2e/fencing_test.go
+++ b/tests/e2e/fencing_test.go
@@ -76,7 +76,7 @@ var _ = Describe("Fencing", Label(tests.LabelPlugin), func() {
 	}
 
 	checkInstanceIsStreaming := func(instanceName, namespace string) {
-		query := "SELECT count(*) FROM pg_stat_wal_receiver"
+		query := "SELECT count(*) FROM pg_catalog.pg_stat_wal_receiver"
 		Eventually(func() (int, error) {
 			err := env.Client.Get(env.Ctx,
 				ctrlclient.ObjectKey{Namespace: namespace, Name: instanceName},

--- a/tests/e2e/initdb_test.go
+++ b/tests/e2e/initdb_test.go
@@ -138,7 +138,7 @@ var _ = Describe("InitDB settings", Label(tests.LabelSmoke, tests.LabelBasic), f
 						Namespace: namespace,
 						PodName:   primary.Name,
 					}, "postgres",
-					"select datcollate from pg_database where datname='template0'")
+					"select datcollate from pg_catalog.pg_database where datname='template0'")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(stdout, err).To(Equal("C\n"))
 			})
@@ -171,7 +171,7 @@ var _ = Describe("InitDB settings", Label(tests.LabelSmoke, tests.LabelBasic), f
 						Namespace: namespace,
 						PodName:   primary.Name,
 					}, "postgres",
-					"select datcollate from pg_database where datname='template0'")
+					"select datcollate from pg_catalog.pg_database where datname='template0'")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(stdout, err).To(Equal("en_US.utf8\n"))
 			})

--- a/tests/e2e/managed_roles_test.go
+++ b/tests/e2e/managed_roles_test.go
@@ -92,8 +92,8 @@ var _ = Describe("Managed roles tests", Label(tests.LabelSmoke, tests.LabelBasic
 				query := `SELECT mem.inroles 
 					FROM pg_catalog.pg_authid as auth
 					LEFT JOIN (
-						SELECT string_agg(pg_get_userbyid(roleid), ',') as inroles, member
-						FROM pg_auth_members GROUP BY member
+						SELECT string_agg(pg_catalog.pg_get_userbyid(roleid), ',') as inroles, member
+						FROM pg_catalog.pg_auth_members GROUP BY member
 					) mem ON member = oid
 					WHERE rolname =` + pq.QuoteLiteral(roleName)
 				stdout, _, err := exec.QueryInInstancePod(
@@ -155,12 +155,12 @@ var _ = Describe("Managed roles tests", Label(tests.LabelSmoke, tests.LabelBasic
 				Eventually(QueryMatchExpectationPredicate(primaryPod, postgres.PostgresDBName,
 					roleExistsQuery(unrealizableUser), "f"), 30).Should(Succeed())
 
-				query := fmt.Sprintf("SELECT true FROM pg_roles WHERE rolname='%s' and rolcanlogin=%v and rolsuper=%v "+
+				query := fmt.Sprintf("SELECT true FROM pg_catalog.pg_roles WHERE rolname='%s' and rolcanlogin=%v and rolsuper=%v "+
 					"and rolcreatedb=%v and rolcreaterole=%v and rolinherit=%v and rolreplication=%v "+
 					"and rolbypassrls=%v and rolconnlimit=%v", username, rolCanLoginInSpec, rolSuperInSpec,
 					rolCreateDBInSpec,
 					rolCreateRoleInSpec, rolInheritInSpec, rolReplicationInSpec, rolByPassRLSInSpec, rolConnLimitInSpec)
-				query2 := fmt.Sprintf("SELECT rolvaliduntil is NULL FROM pg_roles WHERE rolname='%s'",
+				query2 := fmt.Sprintf("SELECT rolvaliduntil is NULL FROM pg_catalog.pg_roles WHERE rolname='%s'",
 					userWithPerpetualPass)
 
 				for _, q := range []string{query, query2} {
@@ -191,7 +191,7 @@ var _ = Describe("Managed roles tests", Label(tests.LabelSmoke, tests.LabelBasic
 					roleExistsQuery(appUsername), "t"), 30).Should(Succeed())
 
 				query := fmt.Sprintf("SELECT rolcreatedb and rolvaliduntil='infinity' "+
-					"FROM pg_roles WHERE rolname='%s'", appUsername)
+					"FROM pg_catalog.pg_roles WHERE rolname='%s'", appUsername)
 				assertRoleStatus(namespace, clusterName, query, "t")
 			})
 
@@ -250,7 +250,7 @@ var _ = Describe("Managed roles tests", Label(tests.LabelSmoke, tests.LabelBasic
 			})
 
 			By("Verify the role has been updated in the database", func() {
-				query := fmt.Sprintf("SELECT 1 FROM pg_roles WHERE rolname='%s' and rolcanlogin=%v "+
+				query := fmt.Sprintf("SELECT 1 FROM pg_catalog.pg_roles WHERE rolname='%s' and rolcanlogin=%v "+
 					"and rolcreatedb=%v and rolcreaterole=%v and rolconnlimit=%v",
 					username, expectedLogin, expectedCreateDB, expectedCreateRole, expectedConnLmt)
 				assertRoleStatus(namespace, clusterName, query, "1")
@@ -283,7 +283,7 @@ var _ = Describe("Managed roles tests", Label(tests.LabelSmoke, tests.LabelBasic
 
 			By("verifying Login is now enabled", func() {
 				expectedLogin = true
-				query := fmt.Sprintf("SELECT 1 FROM pg_roles WHERE rolname='%s' and rolcanlogin=%v "+
+				query := fmt.Sprintf("SELECT 1 FROM pg_catalog.pg_roles WHERE rolname='%s' and rolcanlogin=%v "+
 					"and rolcreatedb=%v and rolcreaterole=%v and rolconnlimit=%v",
 					username, expectedLogin, expectedCreateDB, expectedCreateRole, expectedConnLmt)
 				assertRoleStatus(namespace, clusterName, query, "1")
@@ -321,7 +321,7 @@ var _ = Describe("Managed roles tests", Label(tests.LabelSmoke, tests.LabelBasic
 			})
 
 			By("Verify new_role exists with all attribute default", func() {
-				query := fmt.Sprintf("SELECT 1 FROM pg_roles WHERE rolname='%s' and rolcanlogin=%v and rolsuper=%v "+
+				query := fmt.Sprintf("SELECT 1 FROM pg_catalog.pg_roles WHERE rolname='%s' and rolcanlogin=%v and rolsuper=%v "+
 					"and rolcreatedb=%v and rolcreaterole=%v and rolinherit=%v and rolreplication=%v "+
 					"and rolbypassrls=%v and rolconnlimit=%v", newUserName, defaultRolCanLogin,
 					defaultRolSuper, defaultRolCreateDB,

--- a/tests/e2e/publication_subscription_test.go
+++ b/tests/e2e/publication_subscription_test.go
@@ -350,9 +350,9 @@ var _ = Describe("Publication and Subscription", Label(tests.LabelPublicationSub
 })
 
 func publicationExistsQuery(pubName string) string {
-	return fmt.Sprintf("SELECT EXISTS(SELECT 1 FROM pg_publication WHERE pubname='%s')", pubName)
+	return fmt.Sprintf("SELECT EXISTS(SELECT 1 FROM pg_catalog.pg_publication WHERE pubname='%s')", pubName)
 }
 
 func subscriptionExistsQuery(subName string) string {
-	return fmt.Sprintf("SELECT EXISTS(SELECT 1 FROM pg_subscription WHERE subname='%s')", subName)
+	return fmt.Sprintf("SELECT EXISTS(SELECT 1 FROM pg_catalog.pg_subscription WHERE subname='%s')", subName)
 }

--- a/tests/e2e/replica_mode_cluster_test.go
+++ b/tests/e2e/replica_mode_cluster_test.go
@@ -550,7 +550,7 @@ var _ = Describe("Replica switchover", Label(tests.LabelReplication), Ordered, f
 				env.Ctx, env.Client, env.Interface, env.RestClientConfig,
 				exec.PodLocator{Namespace: namespace, PodName: primary.Name},
 				"postgres",
-				"SELECT timeline_id FROM pg_control_checkpoint();",
+				"SELECT timeline_id FROM pg_catalog.pg_control_checkpoint()",
 			)
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(strings.TrimSpace(stdout)).To(Equal(fmt.Sprintf("%d", expectedTimeline)))
@@ -725,7 +725,7 @@ var _ = Describe("Replica switchover", Label(tests.LabelReplication), Ordered, f
 							PodName:   pod.Name,
 						},
 						postgres.PostgresDBName,
-						"select pg_is_in_recovery();")
+						"select pg_catalog.pg_is_in_recovery()")
 					g.Expect(err).ToNot(HaveOccurred())
 					g.Expect(strings.Trim(stdOut, "\n")).To(Equal("t"))
 				}, 60, 10).Should(Succeed())
@@ -799,7 +799,7 @@ func assertReplicaClusterTopology(namespace, clusterName string) {
 			},
 			&commandTimeout,
 			"psql", "-U", "postgres", "-tAc",
-			"select string_agg(application_name, ',') from pg_stat_replication;",
+			"select string_agg(application_name, ',') from pg_catalog.pg_stat_replication;",
 		)
 		if err != nil {
 			return nil, err
@@ -844,7 +844,7 @@ func assertReplicaClusterTopology(namespace, clusterName string) {
 				},
 				&commandTimeout,
 				"psql", "-U", "postgres", "-tAc",
-				"select sender_host from pg_stat_wal_receiver limit 1;",
+				"select sender_host from pg_catalog.pg_stat_wal_receiver limit 1",
 			)
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(strings.TrimSpace(stdout)).To(BeEquivalentTo(sourceHost))

--- a/tests/e2e/replication_slot_test.go
+++ b/tests/e2e/replication_slot_test.go
@@ -117,7 +117,7 @@ var _ = Describe("Replication Slot", Label(tests.LabelReplication), func() {
 			primaryPod, err := clusterutils.GetPrimary(env.Ctx, env.Client, namespace, clusterName)
 			Expect(err).ToNot(HaveOccurred())
 
-			query := fmt.Sprintf("SELECT pg_create_physical_replication_slot('%s');", userPhysicalSlot)
+			query := fmt.Sprintf("SELECT pg_catalog.pg_create_physical_replication_slot('%s')", userPhysicalSlot)
 			_, _, err = exec.QueryInInstancePod(
 				env.Ctx, env.Client, env.Interface, env.RestClientConfig,
 				exec.PodLocator{

--- a/tests/e2e/syncreplicas_test.go
+++ b/tests/e2e/syncreplicas_test.go
@@ -57,7 +57,7 @@ var _ = Describe("Synchronous Replicas", Label(tests.LabelReplication), func() {
 					PodName:   primaryPod.GetName(),
 				},
 				"postgres",
-				fmt.Sprintf("SELECT count(*) from pg_stat_replication WHERE sync_state = '%s'", syncState))
+				fmt.Sprintf("SELECT count(*) from pg_catalog.pg_stat_replication WHERE sync_state = '%s'", syncState))
 			Expect(stdErr).To(BeEmpty())
 			Expect(err).ShouldNot(HaveOccurred())
 
@@ -78,7 +78,7 @@ var _ = Describe("Synchronous Replicas", Label(tests.LabelReplication), func() {
 					PodName:   primaryPod.GetName(),
 				},
 				"postgres",
-				"select setting from pg_settings where name = 'synchronous_standby_names'")
+				"select setting from pg_catalog.pg_settings where name = 'synchronous_standby_names'")
 			Expect(stdErr).To(BeEmpty())
 			Expect(err).ShouldNot(HaveOccurred())
 

--- a/tests/e2e/tablespaces_test.go
+++ b/tests/e2e/tablespaces_test.go
@@ -1057,7 +1057,7 @@ func AssertDatabaseContainsTablespaces(cluster *apiv1.Cluster, timeout int) {
 						Namespace: namespace,
 						PodName:   instance.Name,
 					}, postgres.AppDBName,
-					"SELECT oid, spcname, pg_get_userbyid(spcowner) FROM pg_tablespace;",
+					"SELECT oid, spcname, pg_catalog.pg_get_userbyid(spcowner) FROM pg_catalog.pg_tablespace",
 				)
 				g.Expect(stdErr).To(BeEmpty())
 				g.Expect(err).ShouldNot(HaveOccurred())
@@ -1113,8 +1113,8 @@ func AssertTempTablespaceBehavior(cluster *apiv1.Cluster, expectedTempTablespace
 				PodName:   primary.Name,
 			}, postgres.AppDBName,
 			"CREATE TEMPORARY TABLE cnp_e2e_test_table (i INTEGER); "+
-				"SELECT spcname FROM pg_tablespace WHERE OID="+
-				"(SELECT reltablespace FROM pg_class WHERE oid = 'cnp_e2e_test_table'::regclass)",
+				"SELECT spcname FROM pg_catalog.pg_tablespace WHERE OID="+
+				"(SELECT reltablespace FROM pg_catalog.pg_class WHERE oid = 'cnp_e2e_test_table'::regclass)",
 		)
 		Expect(stdErr).To(BeEmpty())
 		Expect(err).ShouldNot(HaveOccurred())
@@ -1135,7 +1135,8 @@ func AssertTablespaceAndOwnerExist(cluster *apiv1.Cluster, tablespace, owner str
 			Namespace: namespace,
 			PodName:   primaryPod.Name,
 		}, postgres.AppDBName,
-		fmt.Sprintf("SELECT 1 FROM pg_tablespace WHERE spcname = '%s' AND pg_get_userbyid(spcowner) = '%s';",
+		fmt.Sprintf("SELECT 1 FROM pg_catalog.pg_tablespace WHERE spcname = '%s' "+
+			"AND pg_catalog.pg_get_userbyid(spcowner) = '%s'",
 			tablespace,
 			owner),
 	)

--- a/tests/e2e/update_user_test.go
+++ b/tests/e2e/update_user_test.go
@@ -164,7 +164,7 @@ var _ = Describe("Enable superuser password", Label(tests.LabelServiceConnectivi
 				g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
 			}, 200).Should(Succeed())
 
-			query := "SELECT rolpassword IS NULL FROM pg_authid WHERE rolname='postgres'"
+			query := "SELECT rolpassword IS NULL FROM pg_catalog.pg_authid WHERE rolname='postgres'"
 			// We should have the `postgres` user with a null password
 			Eventually(func() string {
 				stdout, _, err := exec.QueryInInstancePod(

--- a/tests/e2e/upgrade_test.go
+++ b/tests/e2e/upgrade_test.go
@@ -726,7 +726,7 @@ var _ = Describe("Upgrade", Label(tests.LabelUpgrade, tests.LabelNoOpenshift), O
 						PodName:   primary,
 					},
 					exec.DatabaseName(databaseName),
-					"SELECT count(*) FROM pg_stat_replication")
+					"SELECT count(*) FROM pg_catalog.pg_stat_replication")
 				return strings.Trim(out, "\n"), err
 			}, 180).Should(BeEquivalentTo("2"))
 		})

--- a/tests/utils/postgres/postgres.go
+++ b/tests/utils/postgres/postgres.go
@@ -59,7 +59,7 @@ func CountReplicas(
 	pod *corev1.Pod,
 	retryTimeout int,
 ) (int, error) {
-	query := "SELECT count(*) FROM pg_stat_replication"
+	query := "SELECT count(*) FROM pg_catalog.pg_stat_replication"
 	stdOut, _, err := exec.EventuallyExecQueryInInstancePod(
 		ctx, crudClient, kubeInterface, restConfig,
 		exec.PodLocator{

--- a/tests/utils/replicationslot/replication_slots.go
+++ b/tests/utils/replicationslot/replication_slots.go
@@ -66,7 +66,7 @@ func PrintReplicationSlots(
 		}
 		m := make(map[string]string)
 		for _, slot := range slots {
-			query := fmt.Sprintf("SELECT restart_lsn FROM pg_catalog.qpg_replication_slots WHERE slot_name = '%v'", slot)
+			query := fmt.Sprintf("SELECT restart_lsn FROM pg_catalog.pg_replication_slots WHERE slot_name = '%v'", slot)
 			restartLsn, _, err := exec.QueryInInstancePod(
 				ctx, crudClient, kubeInterface, restConfig,
 				exec.PodLocator{

--- a/tests/utils/replicationslot/replication_slots.go
+++ b/tests/utils/replicationslot/replication_slots.go
@@ -66,7 +66,7 @@ func PrintReplicationSlots(
 		}
 		m := make(map[string]string)
 		for _, slot := range slots {
-			query := fmt.Sprintf("SELECT restart_lsn FROM pg_replication_slots WHERE slot_name = '%v'", slot)
+			query := fmt.Sprintf("SELECT restart_lsn FROM pg_catalog.qpg_replication_slots WHERE slot_name = '%v'", slot)
 			restartLsn, _, err := exec.QueryInInstancePod(
 				ctx, crudClient, kubeInterface, restConfig,
 				exec.PodLocator{
@@ -146,7 +146,7 @@ func GetReplicationSlotsOnPod(
 		return nil, err
 	}
 
-	query := "SELECT slot_name FROM pg_replication_slots WHERE temporary = 'f' AND slot_type = 'physical'"
+	query := "SELECT slot_name FROM pg_catalog.pg_replication_slots WHERE temporary = 'f' AND slot_type = 'physical'"
 	stdout, _, err := exec.QueryInInstancePod(
 		ctx, crudClient, kubeInterface, restConfig,
 		exec.PodLocator{
@@ -185,7 +185,7 @@ func GetReplicationSlotLsnsOnPod(
 
 	lsnList := make([]string, 0, len(slots))
 	for _, slot := range slots {
-		query := fmt.Sprintf("SELECT restart_lsn FROM pg_replication_slots WHERE slot_name = '%v'",
+		query := fmt.Sprintf("SELECT restart_lsn FROM pg_catalog.pg_replication_slots WHERE slot_name = '%v'",
 			slot)
 		restartLsn, _, err := exec.QueryInInstancePod(
 			ctx, crudClient, kubeInterface, restConfig,


### PR DESCRIPTION
Add the `pg_catalog` schema to fully qualify the usage of system functions and views provided by PostgreSQL.