### PR TITLE
feat: use P384 instead of P256 elliptic algorithm

### DIFF
--- a/pkg/certs/certs.go
+++ b/pkg/certs/certs.go
@@ -166,7 +166,7 @@ func (pair KeyPair) createAndSignPairWithValidity(
 	}
 
 	// Generate a new private key
-	leafKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	leafKey, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
 	if err != nil {
 		return nil, err
 	}
@@ -434,7 +434,7 @@ func createCAWithValidity(
 	if err != nil {
 		return nil, err
 	}
-	rootKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	rootKey, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Even if the P256 elliptic algorithm is approved, using a P384 makes it
more secure and increase the security during the creation of root CA 
and certificates for the internal authentication.

Closes #6597 