### PR TITLE
fix: add support for PgBouncer 1.24

### DIFF
--- a/docs/src/connection_pooling.md
+++ b/docs/src/connection_pooling.md
@@ -577,6 +577,9 @@ cnpg_pgbouncer_stats_total_xact_count{database="pgbouncer"} 15
 cnpg_pgbouncer_stats_total_xact_time{database="pgbouncer"} 0
 ```
 
+!!! Info
+    For a better understanding of the metrics please refer to the PgBouncer documentation.
+
 As for clusters, a specific pooler can be monitored using the
 [Prometheus operator's](https://github.com/prometheus-operator/prometheus-operator) resource
 [PodMonitor](https://github.com/prometheus-operator/prometheus-operator/blob/v0.47.1/Documentation/api.md#podmonitor).

--- a/docs/src/connection_pooling.md
+++ b/docs/src/connection_pooling.md
@@ -421,160 +421,157 @@ This example shows the output for `cnpg_pgbouncer` metrics:
 ```text
 # HELP cnpg_pgbouncer_collection_duration_seconds Collection time duration in seconds
 # TYPE cnpg_pgbouncer_collection_duration_seconds gauge
-cnpg_pgbouncer_collection_duration_seconds{collector="Collect.up"} 0.002443168
-
+cnpg_pgbouncer_collection_duration_seconds{collector="Collect.up"} 0.002338805
+# HELP cnpg_pgbouncer_collection_errors_total Total errors occurred accessing PostgreSQL for metrics.
+# TYPE cnpg_pgbouncer_collection_errors_total counter
+cnpg_pgbouncer_collection_errors_total{collector="sql: Scan error on column index 16, name \"load_balance_hosts\": converting NULL to int is unsupported"} 5
 # HELP cnpg_pgbouncer_collections_total Total number of times PostgreSQL was accessed for metrics.
 # TYPE cnpg_pgbouncer_collections_total counter
-cnpg_pgbouncer_collections_total 1
-
+cnpg_pgbouncer_collections_total 5
 # HELP cnpg_pgbouncer_last_collection_error 1 if the last collection ended with error, 0 otherwise.
 # TYPE cnpg_pgbouncer_last_collection_error gauge
 cnpg_pgbouncer_last_collection_error 0
-
 # HELP cnpg_pgbouncer_lists_databases Count of databases.
 # TYPE cnpg_pgbouncer_lists_databases gauge
 cnpg_pgbouncer_lists_databases 1
-
 # HELP cnpg_pgbouncer_lists_dns_names Count of DNS names in the cache.
 # TYPE cnpg_pgbouncer_lists_dns_names gauge
 cnpg_pgbouncer_lists_dns_names 0
-
 # HELP cnpg_pgbouncer_lists_dns_pending Not used.
 # TYPE cnpg_pgbouncer_lists_dns_pending gauge
 cnpg_pgbouncer_lists_dns_pending 0
-
 # HELP cnpg_pgbouncer_lists_dns_queries Count of in-flight DNS queries.
 # TYPE cnpg_pgbouncer_lists_dns_queries gauge
 cnpg_pgbouncer_lists_dns_queries 0
-
 # HELP cnpg_pgbouncer_lists_dns_zones Count of DNS zones in the cache.
 # TYPE cnpg_pgbouncer_lists_dns_zones gauge
 cnpg_pgbouncer_lists_dns_zones 0
-
 # HELP cnpg_pgbouncer_lists_free_clients Count of free clients.
 # TYPE cnpg_pgbouncer_lists_free_clients gauge
 cnpg_pgbouncer_lists_free_clients 49
-
 # HELP cnpg_pgbouncer_lists_free_servers Count of free servers.
 # TYPE cnpg_pgbouncer_lists_free_servers gauge
 cnpg_pgbouncer_lists_free_servers 0
-
 # HELP cnpg_pgbouncer_lists_login_clients Count of clients in login state.
 # TYPE cnpg_pgbouncer_lists_login_clients gauge
 cnpg_pgbouncer_lists_login_clients 0
-
 # HELP cnpg_pgbouncer_lists_pools Count of pools.
 # TYPE cnpg_pgbouncer_lists_pools gauge
 cnpg_pgbouncer_lists_pools 1
-
 # HELP cnpg_pgbouncer_lists_used_clients Count of used clients.
 # TYPE cnpg_pgbouncer_lists_used_clients gauge
 cnpg_pgbouncer_lists_used_clients 1
-
 # HELP cnpg_pgbouncer_lists_used_servers Count of used servers.
 # TYPE cnpg_pgbouncer_lists_used_servers gauge
 cnpg_pgbouncer_lists_used_servers 0
-
 # HELP cnpg_pgbouncer_lists_users Count of users.
 # TYPE cnpg_pgbouncer_lists_users gauge
 cnpg_pgbouncer_lists_users 2
-
 # HELP cnpg_pgbouncer_pools_cl_active Client connections that are linked to server connection and can process queries.
 # TYPE cnpg_pgbouncer_pools_cl_active gauge
 cnpg_pgbouncer_pools_cl_active{database="pgbouncer",user="pgbouncer"} 1
-
+# HELP cnpg_pgbouncer_pools_cl_active_cancel_req Client connections that have forwarded query cancellations to the server and are waiting for the server response.
+# TYPE cnpg_pgbouncer_pools_cl_active_cancel_req gauge
+cnpg_pgbouncer_pools_cl_active_cancel_req{database="pgbouncer",user="pgbouncer"} 0
 # HELP cnpg_pgbouncer_pools_cl_cancel_req Client connections that have not forwarded query cancellations to the server yet.
 # TYPE cnpg_pgbouncer_pools_cl_cancel_req gauge
 cnpg_pgbouncer_pools_cl_cancel_req{database="pgbouncer",user="pgbouncer"} 0
-
 # HELP cnpg_pgbouncer_pools_cl_waiting Client connections that have sent queries but have not yet got a server connection.
 # TYPE cnpg_pgbouncer_pools_cl_waiting gauge
 cnpg_pgbouncer_pools_cl_waiting{database="pgbouncer",user="pgbouncer"} 0
-
+# HELP cnpg_pgbouncer_pools_cl_waiting_cancel_req Client connections that have not forwarded query cancellations to the server yet.
+# TYPE cnpg_pgbouncer_pools_cl_waiting_cancel_req gauge
+cnpg_pgbouncer_pools_cl_waiting_cancel_req{database="pgbouncer",user="pgbouncer"} 0
+# HELP cnpg_pgbouncer_pools_load_balance_hosts Number of hosts not load balancing between hosts
+# TYPE cnpg_pgbouncer_pools_load_balance_hosts gauge
+cnpg_pgbouncer_pools_load_balance_hosts{database="pgbouncer",user="pgbouncer"} 0
 # HELP cnpg_pgbouncer_pools_maxwait How long the first (oldest) client in the queue has waited, in seconds. If this starts increasing, then the current pool of servers does not handle requests quickly enough. The reason may be either an overloaded server or just too small of a pool_size setting.
 # TYPE cnpg_pgbouncer_pools_maxwait gauge
 cnpg_pgbouncer_pools_maxwait{database="pgbouncer",user="pgbouncer"} 0
-
 # HELP cnpg_pgbouncer_pools_maxwait_us Microsecond part of the maximum waiting time.
 # TYPE cnpg_pgbouncer_pools_maxwait_us gauge
 cnpg_pgbouncer_pools_maxwait_us{database="pgbouncer",user="pgbouncer"} 0
-
 # HELP cnpg_pgbouncer_pools_pool_mode The pooling mode in use. 1 for session, 2 for transaction, 3 for statement, -1 if unknown
 # TYPE cnpg_pgbouncer_pools_pool_mode gauge
 cnpg_pgbouncer_pools_pool_mode{database="pgbouncer",user="pgbouncer"} 3
-
 # HELP cnpg_pgbouncer_pools_sv_active Server connections that are linked to a client.
 # TYPE cnpg_pgbouncer_pools_sv_active gauge
 cnpg_pgbouncer_pools_sv_active{database="pgbouncer",user="pgbouncer"} 0
-
+# HELP cnpg_pgbouncer_pools_sv_active_cancel Server connections that are currently forwarding a cancel request
+# TYPE cnpg_pgbouncer_pools_sv_active_cancel gauge
+cnpg_pgbouncer_pools_sv_active_cancel{database="pgbouncer",user="pgbouncer"} 0
 # HELP cnpg_pgbouncer_pools_sv_idle Server connections that are unused and immediately usable for client queries.
 # TYPE cnpg_pgbouncer_pools_sv_idle gauge
 cnpg_pgbouncer_pools_sv_idle{database="pgbouncer",user="pgbouncer"} 0
-
 # HELP cnpg_pgbouncer_pools_sv_login Server connections currently in the process of logging in.
 # TYPE cnpg_pgbouncer_pools_sv_login gauge
 cnpg_pgbouncer_pools_sv_login{database="pgbouncer",user="pgbouncer"} 0
-
 # HELP cnpg_pgbouncer_pools_sv_tested Server connections that are currently running either server_reset_query or server_check_query.
 # TYPE cnpg_pgbouncer_pools_sv_tested gauge
 cnpg_pgbouncer_pools_sv_tested{database="pgbouncer",user="pgbouncer"} 0
-
 # HELP cnpg_pgbouncer_pools_sv_used Server connections that have been idle for more than server_check_delay, so they need server_check_query to run on them before they can be used again.
 # TYPE cnpg_pgbouncer_pools_sv_used gauge
 cnpg_pgbouncer_pools_sv_used{database="pgbouncer",user="pgbouncer"} 0
-
+# HELP cnpg_pgbouncer_pools_sv_wait_cancels Servers that normally could become idle, but are waiting to do so until all in-flight cancel requests have completed that were sent to cancel a query on this server.
+# TYPE cnpg_pgbouncer_pools_sv_wait_cancels gauge
+cnpg_pgbouncer_pools_sv_wait_cancels{database="pgbouncer",user="pgbouncer"} 0
+# HELP cnpg_pgbouncer_stats_avg_bind_count Average number of prepared statements readied for execution by clients and forwarded to PostgreSQL by pgbouncer.
+# TYPE cnpg_pgbouncer_stats_avg_bind_count gauge
+cnpg_pgbouncer_stats_avg_bind_count{database="pgbouncer"} 0
+# HELP cnpg_pgbouncer_stats_avg_client_parse_count Average number of prepared statements created by clients.
+# TYPE cnpg_pgbouncer_stats_avg_client_parse_count gauge
+cnpg_pgbouncer_stats_avg_client_parse_count{database="pgbouncer"} 0
 # HELP cnpg_pgbouncer_stats_avg_query_count Average queries per second in last stat period.
 # TYPE cnpg_pgbouncer_stats_avg_query_count gauge
-cnpg_pgbouncer_stats_avg_query_count{database="pgbouncer"} 1
-
+cnpg_pgbouncer_stats_avg_query_count{database="pgbouncer"} 0
 # HELP cnpg_pgbouncer_stats_avg_query_time Average query duration, in microseconds.
 # TYPE cnpg_pgbouncer_stats_avg_query_time gauge
 cnpg_pgbouncer_stats_avg_query_time{database="pgbouncer"} 0
-
 # HELP cnpg_pgbouncer_stats_avg_recv Average received (from clients) bytes per second.
 # TYPE cnpg_pgbouncer_stats_avg_recv gauge
 cnpg_pgbouncer_stats_avg_recv{database="pgbouncer"} 0
-
 # HELP cnpg_pgbouncer_stats_avg_sent Average sent (to clients) bytes per second.
 # TYPE cnpg_pgbouncer_stats_avg_sent gauge
 cnpg_pgbouncer_stats_avg_sent{database="pgbouncer"} 0
-
+# HELP cnpg_pgbouncer_stats_avg_server_parse_count Average number of prepared statements created by pgbouncer on a server.
+# TYPE cnpg_pgbouncer_stats_avg_server_parse_count gauge
+cnpg_pgbouncer_stats_avg_server_parse_count{database="pgbouncer"} 0
 # HELP cnpg_pgbouncer_stats_avg_wait_time Time spent by clients waiting for a server, in microseconds (average per second).
 # TYPE cnpg_pgbouncer_stats_avg_wait_time gauge
 cnpg_pgbouncer_stats_avg_wait_time{database="pgbouncer"} 0
-
 # HELP cnpg_pgbouncer_stats_avg_xact_count Average transactions per second in last stat period.
 # TYPE cnpg_pgbouncer_stats_avg_xact_count gauge
-cnpg_pgbouncer_stats_avg_xact_count{database="pgbouncer"} 1
-
+cnpg_pgbouncer_stats_avg_xact_count{database="pgbouncer"} 0
 # HELP cnpg_pgbouncer_stats_avg_xact_time Average transaction duration, in microseconds.
 # TYPE cnpg_pgbouncer_stats_avg_xact_time gauge
 cnpg_pgbouncer_stats_avg_xact_time{database="pgbouncer"} 0
-
+# HELP cnpg_pgbouncer_stats_total_bind_count Total number of prepared statements readied for execution by clients and forwarded to PostgreSQL by pgbouncer
+# TYPE cnpg_pgbouncer_stats_total_bind_count gauge
+cnpg_pgbouncer_stats_total_bind_count{database="pgbouncer"} 0
+# HELP cnpg_pgbouncer_stats_total_client_parse_count Total number of prepared statements created by clients.
+# TYPE cnpg_pgbouncer_stats_total_client_parse_count gauge
+cnpg_pgbouncer_stats_total_client_parse_count{database="pgbouncer"} 0
 # HELP cnpg_pgbouncer_stats_total_query_count Total number of SQL queries pooled by pgbouncer.
 # TYPE cnpg_pgbouncer_stats_total_query_count gauge
-cnpg_pgbouncer_stats_total_query_count{database="pgbouncer"} 3
-
+cnpg_pgbouncer_stats_total_query_count{database="pgbouncer"} 15
 # HELP cnpg_pgbouncer_stats_total_query_time Total number of microseconds spent by pgbouncer when actively connected to PostgreSQL, executing queries.
 # TYPE cnpg_pgbouncer_stats_total_query_time gauge
 cnpg_pgbouncer_stats_total_query_time{database="pgbouncer"} 0
-
 # HELP cnpg_pgbouncer_stats_total_received Total volume in bytes of network traffic received by pgbouncer.
 # TYPE cnpg_pgbouncer_stats_total_received gauge
 cnpg_pgbouncer_stats_total_received{database="pgbouncer"} 0
-
 # HELP cnpg_pgbouncer_stats_total_sent Total volume in bytes of network traffic sent by pgbouncer.
 # TYPE cnpg_pgbouncer_stats_total_sent gauge
 cnpg_pgbouncer_stats_total_sent{database="pgbouncer"} 0
-
+# HELP cnpg_pgbouncer_stats_total_server_parse_count Total number of prepared statements created by pgbouncer on a server.
+# TYPE cnpg_pgbouncer_stats_total_server_parse_count gauge
+cnpg_pgbouncer_stats_total_server_parse_count{database="pgbouncer"} 0
 # HELP cnpg_pgbouncer_stats_total_wait_time Time spent by clients waiting for a server, in microseconds.
 # TYPE cnpg_pgbouncer_stats_total_wait_time gauge
 cnpg_pgbouncer_stats_total_wait_time{database="pgbouncer"} 0
-
 # HELP cnpg_pgbouncer_stats_total_xact_count Total number of SQL transactions pooled by pgbouncer.
 # TYPE cnpg_pgbouncer_stats_total_xact_count gauge
-cnpg_pgbouncer_stats_total_xact_count{database="pgbouncer"} 3
-
+cnpg_pgbouncer_stats_total_xact_count{database="pgbouncer"} 15
 # HELP cnpg_pgbouncer_stats_total_xact_time Total number of microseconds spent by pgbouncer when connected to PostgreSQL in a transaction, either idle in transaction or executing queries.
 # TYPE cnpg_pgbouncer_stats_total_xact_time gauge
 cnpg_pgbouncer_stats_total_xact_time{database="pgbouncer"} 0

--- a/pkg/management/pgbouncer/metricsserver/pools.go
+++ b/pkg/management/pgbouncer/metricsserver/pools.go
@@ -253,8 +253,11 @@ func (e *Exporter) collectShowPools(ch chan<- prometheus.Metric, db *sql.DB) {
 		return
 	}
 	for rows.Next() {
-		const poolsColumnsPgBouncer1180 = 16
-		const poolsColumnsPgBouncer1240 = 17
+		const (
+			poolsColumnsPgBouncer1180 = 16
+			poolsColumnsPgBouncer1240 = 17
+		)
+
 		switch len(cols) {
 		case poolsColumnsPgBouncer1180:
 			if err = rows.Scan(&database, &user,

--- a/pkg/management/pgbouncer/metricsserver/pools.go
+++ b/pkg/management/pgbouncer/metricsserver/pools.go
@@ -39,7 +39,8 @@ type ShowPoolsMetrics struct {
 	SvLogin,
 	MaxWait,
 	MaxWaitUs,
-	PoolMode *prometheus.GaugeVec
+	PoolMode,
+	LoadBalanceHosts *prometheus.GaugeVec
 }
 
 // Describe produces the description for all the contained Metrics
@@ -180,6 +181,12 @@ func NewShowPoolsMetrics(subsystem string) *ShowPoolsMetrics {
 			Name:      "pool_mode",
 			Help:      "The pooling mode in use. 1 for session, 2 for transaction, 3 for statement, -1 if unknown",
 		}, []string{"database", "user"}),
+		LoadBalanceHosts: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: PrometheusNamespace,
+			Subsystem: subsystem,
+			Name:      "load_balance_hosts",
+			Help:      "Number of hosts not load balancing between hosts",
+		}, []string{"database", "user"}),
 	}
 }
 
@@ -233,6 +240,10 @@ func (e *Exporter) collectShowPools(ch chan<- prometheus.Metric, db *sql.DB) {
 		svActiveCancel     int
 		svBeingCanceled    int
 	)
+	// PGBouncer 1.24.0 or above
+	var (
+		loadBalanceHosts int
+	)
 
 	cols, err := rows.Columns()
 	if err != nil {
@@ -243,6 +254,7 @@ func (e *Exporter) collectShowPools(ch chan<- prometheus.Metric, db *sql.DB) {
 	}
 	for rows.Next() {
 		const poolsColumnsPgBouncer1180 = 16
+		const poolsColumnsPgBouncer1240 = 17
 		switch len(cols) {
 		case poolsColumnsPgBouncer1180:
 			if err = rows.Scan(&database, &user,
@@ -260,6 +272,28 @@ func (e *Exporter) collectShowPools(ch chan<- prometheus.Metric, db *sql.DB) {
 				&maxWait,
 				&maxWaitUs,
 				&poolMode,
+			); err != nil {
+				contextLogger.Error(err, "Error while executing SHOW POOLS")
+				e.Metrics.Error.Set(1)
+				e.Metrics.PgCollectionErrors.WithLabelValues(err.Error()).Inc()
+			}
+		case poolsColumnsPgBouncer1240:
+			if err = rows.Scan(&database, &user,
+				&clActive,
+				&clWaiting,
+				&clActiveCancelReq,
+				&clWaitingCancelReq,
+				&svActive,
+				&svActiveCancel,
+				&svBeingCanceled,
+				&svIdle,
+				&svUsed,
+				&svTested,
+				&svLogin,
+				&maxWait,
+				&maxWaitUs,
+				&poolMode,
+				&loadBalanceHosts,
 			); err != nil {
 				contextLogger.Error(err, "Error while executing SHOW POOLS")
 				e.Metrics.Error.Set(1)
@@ -299,6 +333,7 @@ func (e *Exporter) collectShowPools(ch chan<- prometheus.Metric, db *sql.DB) {
 		e.Metrics.ShowPools.MaxWait.WithLabelValues(database, user).Set(float64(maxWait))
 		e.Metrics.ShowPools.MaxWaitUs.WithLabelValues(database, user).Set(float64(maxWaitUs))
 		e.Metrics.ShowPools.PoolMode.WithLabelValues(database, user).Set(float64(poolModeToInt(poolMode)))
+		e.Metrics.ShowPools.LoadBalanceHosts.WithLabelValues(database, user).Set(float64(loadBalanceHosts))
 	}
 
 	e.Metrics.ShowPools.ClActive.Collect(ch)
@@ -316,6 +351,7 @@ func (e *Exporter) collectShowPools(ch chan<- prometheus.Metric, db *sql.DB) {
 	e.Metrics.ShowPools.MaxWait.Collect(ch)
 	e.Metrics.ShowPools.MaxWaitUs.Collect(ch)
 	e.Metrics.ShowPools.PoolMode.Collect(ch)
+	e.Metrics.ShowPools.LoadBalanceHosts.Collect(ch)
 
 	if err = rows.Err(); err != nil {
 		e.Metrics.Error.Set(1)

--- a/pkg/management/pgbouncer/metricsserver/stats.go
+++ b/pkg/management/pgbouncer/metricsserver/stats.go
@@ -25,7 +25,10 @@ import (
 
 // ShowStatsMetrics contains all the SHOW STATS Metrics
 type ShowStatsMetrics struct {
-	TotalServerAssigCount,
+	TotalBindCount,
+	TotalClientParseCount,
+	TotalServerAssignCount,
+	TotalServerParseCount,
 	TotalXactCount,
 	TotalQueryCount,
 	TotalReceived,
@@ -33,7 +36,10 @@ type ShowStatsMetrics struct {
 	TotalXactTime,
 	TotalQueryTime,
 	TotalWaitTime,
-	AvgServerAssigCount,
+	AvgBindCount,
+	AvgClientParseCount,
+	AvgServerAssignCount,
+	AvgServerParseCount,
 	AvgXactCount,
 	AvgQueryCount,
 	AvgRecv,
@@ -45,7 +51,10 @@ type ShowStatsMetrics struct {
 
 // Describe produces the description for all the contained Metrics
 func (r *ShowStatsMetrics) Describe(ch chan<- *prometheus.Desc) {
-	r.TotalServerAssigCount.Describe(ch)
+	r.TotalBindCount.Describe(ch)
+	r.TotalClientParseCount.Describe(ch)
+	r.TotalServerAssignCount.Describe(ch)
+	r.TotalServerParseCount.Describe(ch)
 	r.TotalXactCount.Describe(ch)
 	r.TotalQueryCount.Describe(ch)
 	r.TotalReceived.Describe(ch)
@@ -53,7 +62,10 @@ func (r *ShowStatsMetrics) Describe(ch chan<- *prometheus.Desc) {
 	r.TotalXactTime.Describe(ch)
 	r.TotalQueryTime.Describe(ch)
 	r.TotalWaitTime.Describe(ch)
-	r.AvgServerAssigCount.Describe(ch)
+	r.AvgBindCount.Describe(ch)
+	r.AvgClientParseCount.Describe(ch)
+	r.AvgServerAssignCount.Describe(ch)
+	r.AvgServerParseCount.Describe(ch)
 	r.AvgXactCount.Describe(ch)
 	r.AvgQueryCount.Describe(ch)
 	r.AvgRecv.Describe(ch)
@@ -65,7 +77,10 @@ func (r *ShowStatsMetrics) Describe(ch chan<- *prometheus.Desc) {
 
 // Reset resets all the contained Metrics
 func (r *ShowStatsMetrics) Reset() {
-	r.AvgServerAssigCount.Reset()
+	r.TotalBindCount.Reset()
+	r.TotalClientParseCount.Reset()
+	r.TotalServerAssignCount.Reset()
+	r.TotalServerParseCount.Reset()
 	r.TotalXactCount.Reset()
 	r.TotalQueryCount.Reset()
 	r.TotalReceived.Reset()
@@ -73,7 +88,10 @@ func (r *ShowStatsMetrics) Reset() {
 	r.TotalXactTime.Reset()
 	r.TotalQueryTime.Reset()
 	r.TotalWaitTime.Reset()
-	r.AvgServerAssigCount.Reset()
+	r.AvgBindCount.Reset()
+	r.TotalClientParseCount.Reset()
+	r.AvgServerAssignCount.Reset()
+	r.TotalServerParseCount.Reset()
 	r.AvgXactCount.Reset()
 	r.AvgQueryCount.Reset()
 	r.AvgRecv.Reset()
@@ -87,11 +105,30 @@ func (r *ShowStatsMetrics) Reset() {
 func NewShowStatsMetrics(subsystem string) *ShowStatsMetrics {
 	subsystem += "_stats"
 	return &ShowStatsMetrics{
-		TotalServerAssigCount: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		TotalBindCount: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: PrometheusNamespace,
+			Subsystem: subsystem,
+			Name:      "total_bind_count",
+			Help: "Total number of prepared statements readied for execution by clients and forwarded to " +
+				"PostgreSQL by pgbouncer",
+		}, []string{"database"}),
+		TotalClientParseCount: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: PrometheusNamespace,
+			Subsystem: subsystem,
+			Name:      "total_client_parse_count",
+			Help:      "Total number of prepared statements created by clients.",
+		}, []string{"database"}),
+		TotalServerAssignCount: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: PrometheusNamespace,
 			Subsystem: subsystem,
 			Name:      "total_server_assignment_count",
 			Help:      "Total time a server was assigned to a client.",
+		}, []string{"database"}),
+		TotalServerParseCount: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: PrometheusNamespace,
+			Subsystem: subsystem,
+			Name:      "total_server_parse_count",
+			Help:      "Total number of prepared statements created by pgbouncer on a server.",
 		}, []string{"database"}),
 		TotalXactCount: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: PrometheusNamespace,
@@ -137,12 +174,31 @@ func NewShowStatsMetrics(subsystem string) *ShowStatsMetrics {
 			Name:      "total_wait_time",
 			Help:      "Time spent by clients waiting for a server, in microseconds.",
 		}, []string{"database"}),
-		AvgServerAssigCount: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		AvgBindCount: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: PrometheusNamespace,
+			Subsystem: subsystem,
+			Name:      "avg_bind_count",
+			Help: "Average number of prepared statements readied for execution by clients and forwarded to " +
+				"PostgreSQL by pgbouncer.",
+		}, []string{"database"}),
+		AvgClientParseCount: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: PrometheusNamespace,
+			Subsystem: subsystem,
+			Name:      "avg_client_parse_count",
+			Help:      "Average number of prepared statements created by clients.",
+		}, []string{"database"}),
+		AvgServerAssignCount: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: PrometheusNamespace,
 			Subsystem: subsystem,
 			Name:      "avg_server_assignment_count",
 			Help: "Average number of times a server was assigned to a client per second in " +
 				"the last stat period.",
+		}, []string{"database"}),
+		AvgServerParseCount: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: PrometheusNamespace,
+			Subsystem: subsystem,
+			Name:      "avg_server_parse_count",
+			Help:      "Average number of prepared statements created by pgbouncer on a server.",
 		}, []string{"database"}),
 		AvgXactCount: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: PrometheusNamespace,
@@ -230,10 +286,19 @@ func (e *Exporter) collectShowStats(ch chan<- prometheus.Metric, db *sql.DB) {
 
 	// PGBouncer >= 1.23.0
 	var (
-		totalServerAssigCount,
-		avgServerAssigCount int
+		totalServerAssignCount,
+		avgServerAssignCount int
 	)
 
+	// PGBouncer >= 1.24.0
+	var (
+		totalClientParseCount,
+		totalServerParseCount,
+		totalBindCount,
+		avgClientParseCount,
+		avgServerParseCount,
+		avgBindCount int
+	)
 	statCols, err := rows.Columns()
 	if err != nil {
 		contextLogger.Error(err, "Error while reading SHOW STATS")
@@ -244,7 +309,8 @@ func (e *Exporter) collectShowStats(ch chan<- prometheus.Metric, db *sql.DB) {
 
 	for rows.Next() {
 		var err error
-		if statColsCount < 16 {
+		switch {
+		case statColsCount < 16:
 			err = rows.Scan(&database,
 				&totalXactCount,
 				&totalQueryCount,
@@ -261,9 +327,9 @@ func (e *Exporter) collectShowStats(ch chan<- prometheus.Metric, db *sql.DB) {
 				&avgQueryTime,
 				&avgWaitTime,
 			)
-		} else {
+		case statColsCount == 17:
 			err = rows.Scan(&database,
-				&totalServerAssigCount,
+				&totalServerAssignCount,
 				&totalXactCount,
 				&totalQueryCount,
 				&totalReceived,
@@ -271,7 +337,7 @@ func (e *Exporter) collectShowStats(ch chan<- prometheus.Metric, db *sql.DB) {
 				&totalXactTime,
 				&totalQueryTime,
 				&totalWaitTime,
-				&avgServerAssigCount,
+				&avgServerAssignCount,
 				&avgXactCount,
 				&avgQueryCount,
 				&avgRecv,
@@ -279,6 +345,31 @@ func (e *Exporter) collectShowStats(ch chan<- prometheus.Metric, db *sql.DB) {
 				&avgXactTime,
 				&avgQueryTime,
 				&avgWaitTime,
+			)
+		default:
+			err = rows.Scan(&database,
+				&totalServerAssignCount,
+				&totalXactCount,
+				&totalQueryCount,
+				&totalReceived,
+				&totalSent,
+				&totalXactTime,
+				&totalQueryTime,
+				&totalWaitTime,
+				&totalClientParseCount,
+				&totalServerParseCount,
+				&totalBindCount,
+				&avgServerAssignCount,
+				&avgXactCount,
+				&avgQueryCount,
+				&avgRecv,
+				&avgSent,
+				&avgXactTime,
+				&avgQueryTime,
+				&avgWaitTime,
+				&avgClientParseCount,
+				&avgServerParseCount,
+				&avgBindCount,
 			)
 		}
 		if err != nil {
@@ -302,17 +393,25 @@ func (e *Exporter) collectShowStats(ch chan<- prometheus.Metric, db *sql.DB) {
 		e.Metrics.ShowStats.AvgQueryTime.WithLabelValues(database).Set(float64(avgQueryTime))
 		e.Metrics.ShowStats.AvgWaitTime.WithLabelValues(database).Set(float64(avgWaitTime))
 
-		if statColsCount >= 16 {
-			e.Metrics.ShowStats.TotalServerAssigCount.WithLabelValues(database).Set(
-				float64(totalServerAssigCount))
-			e.Metrics.ShowStats.AvgServerAssigCount.WithLabelValues(database).Set(
-				float64(avgServerAssigCount))
+		if statColsCount == 16 {
+			e.Metrics.ShowStats.TotalServerAssignCount.WithLabelValues(database).Set(
+				float64(totalServerAssignCount))
+			e.Metrics.ShowStats.AvgServerAssignCount.WithLabelValues(database).Set(
+				float64(avgServerAssignCount))
+		} else {
+			e.Metrics.ShowStats.TotalClientParseCount.WithLabelValues(database).Set(
+				float64(totalClientParseCount))
+			e.Metrics.ShowStats.TotalServerParseCount.WithLabelValues(database).Set(
+				float64(totalServerParseCount))
+			e.Metrics.ShowStats.TotalBindCount.WithLabelValues(database).Set(
+				float64(totalBindCount))
+			e.Metrics.ShowStats.AvgClientParseCount.WithLabelValues(database).Set(
+				float64(avgClientParseCount))
+			e.Metrics.ShowStats.AvgServerParseCount.WithLabelValues(database).Set(
+				float64(avgServerParseCount))
+			e.Metrics.ShowStats.AvgBindCount.WithLabelValues(database).Set(
+				float64(avgBindCount))
 		}
-	}
-
-	if statColsCount >= 16 {
-		e.Metrics.ShowStats.TotalServerAssigCount.Collect(ch)
-		e.Metrics.ShowStats.AvgServerAssigCount.Collect(ch)
 	}
 
 	e.Metrics.ShowStats.TotalXactCount.Collect(ch)
@@ -329,6 +428,18 @@ func (e *Exporter) collectShowStats(ch chan<- prometheus.Metric, db *sql.DB) {
 	e.Metrics.ShowStats.AvgXactTime.Collect(ch)
 	e.Metrics.ShowStats.AvgQueryTime.Collect(ch)
 	e.Metrics.ShowStats.AvgWaitTime.Collect(ch)
+
+	if statColsCount == 16 {
+		e.Metrics.ShowStats.TotalServerAssignCount.Collect(ch)
+		e.Metrics.ShowStats.AvgServerAssignCount.Collect(ch)
+	} else {
+		e.Metrics.ShowStats.TotalClientParseCount.Collect(ch)
+		e.Metrics.ShowStats.TotalServerParseCount.Collect(ch)
+		e.Metrics.ShowStats.TotalBindCount.Collect(ch)
+		e.Metrics.ShowStats.AvgClientParseCount.Collect(ch)
+		e.Metrics.ShowStats.AvgServerParseCount.Collect(ch)
+		e.Metrics.ShowStats.AvgBindCount.Collect(ch)
+	}
 
 	if err = rows.Err(); err != nil {
 		e.Metrics.Error.Set(1)

--- a/pkg/specs/pgbouncer/deployments.go
+++ b/pkg/specs/pgbouncer/deployments.go
@@ -39,7 +39,7 @@ import (
 
 const (
 	// DefaultPgbouncerImage is the name of the pgbouncer image used by default
-	DefaultPgbouncerImage = "ghcr.io/cloudnative-pg/pgbouncer:1.23.0"
+	DefaultPgbouncerImage = "ghcr.io/cloudnative-pg/pgbouncer:1.24.0"
 )
 
 // Deployment create the deployment of pgbouncer, given


### PR DESCRIPTION
The new vlersion of PgBouncer 1.24 add new metrics, following the release notes: https://github.com/pgbouncer/pgbouncer/releases/tag/pgbouncer_1_24_0 we add support for:
* total_bind_count
* total_client_parse_count
* total_server_parse_count
* avg_bind_ount
* avg_client_parse_count
* avg_server_parse_count

Closes #6566 