### PR TITLE
test(e2e): enable race detector in the E2e tests

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -30,7 +30,7 @@ env:
   BUILD_PUSH_CACHE_FROM: ""
   BUILD_PUSH_CACHE_TO: ""
   BUILD_PLUGIN_RELEASE_ARGS: "build --skip=validate --clean --id kubectl-cnpg --timeout 60m"
-  BUILD_MANAGER_RELEASE_ARGS: "build --skip=validate --clean --id manager"
+  BUILD_MANAGER_RELEASE_ARGS: "build --skip=validate --clean --id manager-race"
   REPOSITORY_OWNER: "cloudnative-pg"
   REGISTRY: "ghcr.io"
   REGISTRY_USER: ${{ github.actor }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -33,6 +33,25 @@ builds:
     - amd64
     - arm64
 
+- id: manager-race
+  binary: manager/manager_{{ .Arch }}
+  main: cmd/manager/main.go
+  no_unique_dist_dir: true
+  gcflags:
+    - all=-trimpath={{.Env.GOPATH}};{{.Env.PWD}}
+  ldflags:
+    - -race
+    - -s
+    - -w
+    - -X github.com/cloudnative-pg/cloudnative-pg/pkg/versions.buildVersion={{.Env.VERSION}}
+    - -X github.com/cloudnative-pg/cloudnative-pg/pkg/versions.buildCommit={{.Env.COMMIT}}
+    - -X github.com/cloudnative-pg/cloudnative-pg/pkg/versions.buildDate={{.Env.DATE}}
+  goos:
+    - linux
+  goarch:
+    - amd64
+    - arm64
+
 - id: kubectl-cnpg
   binary: kubectl-cnpg
   main: cmd/kubectl-cnpg/main.go

--- a/Makefile
+++ b/Makefile
@@ -128,6 +128,15 @@ build-manager: generate fmt vet ## Build manager binary.
 build-plugin: generate fmt vet ## Build plugin binary.
 	go build -o bin/kubectl-cnpg -ldflags ${LDFLAGS} ./cmd/kubectl-cnpg
 
+build-race: generate fmt vet build-manager-race build-plugin-race ## Build the binaries adding the -race option.
+
+build-manager-race: generate fmt vet ## Build manager binary with -race option.
+	go build -race -o bin/manager -ldflags ${LDFLAGS} ./cmd/manager
+
+build-plugin-race: generate fmt vet ## Build plugin binary.
+	go build -race -o bin/kubectl-cnpg -ldflags ${LDFLAGS} ./cmd/kubectl-cnpg
+
+
 run: generate fmt vet manifests ## Run against the configured Kubernetes cluster in ~/.kube/config.
 	go run ./cmd/manager
 


### PR DESCRIPTION
This patch enables the Go built-in race condition detector when running the
E2e tests.

Closes #6633 