### PR TITLE
docs(fix): use the correct dataDurability in the preferred section example

### DIFF
--- a/docs/src/replication.md
+++ b/docs/src/replication.md
@@ -422,7 +422,7 @@ spec:
     synchronous:
       method: any
       number: 2
-      dataDurability: required
+      dataDurability: preferred
 ```
 
 1. Initial state. The content of `synchronous_standby_names` is:


### PR DESCRIPTION
the section describes about preferred dataDurability, yet the example states required.

This does not seem correct to me, got me confused and I believe this is a mistake in the docs.