### PR TITLE
fix: consistent threshold calculation for probes

### DIFF
--- a/api/v1/cluster_funcs.go
+++ b/api/v1/cluster_funcs.go
@@ -1457,10 +1457,22 @@ func (p *Probe) ApplyInto(k8sProbe *corev1.Probe) {
 		return
 	}
 
-	k8sProbe.InitialDelaySeconds = p.InitialDelaySeconds
-	k8sProbe.TimeoutSeconds = p.TimeoutSeconds
-	k8sProbe.PeriodSeconds = p.PeriodSeconds
-	k8sProbe.SuccessThreshold = p.SuccessThreshold
-	k8sProbe.FailureThreshold = p.FailureThreshold
-	k8sProbe.TerminationGracePeriodSeconds = p.TerminationGracePeriodSeconds
+	if p.InitialDelaySeconds != 0 {
+		k8sProbe.InitialDelaySeconds = p.InitialDelaySeconds
+	}
+	if p.TimeoutSeconds != 0 {
+		k8sProbe.TimeoutSeconds = p.TimeoutSeconds
+	}
+	if p.PeriodSeconds != 0 {
+		k8sProbe.PeriodSeconds = p.PeriodSeconds
+	}
+	if p.SuccessThreshold != 0 {
+		k8sProbe.SuccessThreshold = p.SuccessThreshold
+	}
+	if p.FailureThreshold != 0 {
+		k8sProbe.FailureThreshold = p.FailureThreshold
+	}
+	if p.TerminationGracePeriodSeconds != nil {
+		k8sProbe.TerminationGracePeriodSeconds = p.TerminationGracePeriodSeconds
+	}
 }

--- a/api/v1/cluster_funcs_test.go
+++ b/api/v1/cluster_funcs_test.go
@@ -1723,6 +1723,6 @@ var _ = Describe("Probes configuration", func() {
 		Expect(configuredProbe.PeriodSeconds).To(Equal(config.PeriodSeconds))
 		Expect(configuredProbe.SuccessThreshold).To(Equal(config.SuccessThreshold))
 		Expect(configuredProbe.FailureThreshold).To(Equal(config.FailureThreshold))
-		Expect(configuredProbe.TerminationGracePeriodSeconds).To(BeNil())
+		Expect(*configuredProbe.TerminationGracePeriodSeconds).To(BeEquivalentTo(23))
 	})
 })

--- a/api/v1/cluster_funcs_test.go
+++ b/api/v1/cluster_funcs_test.go
@@ -1725,4 +1725,12 @@ var _ = Describe("Probes configuration", func() {
 		Expect(configuredProbe.FailureThreshold).To(Equal(config.FailureThreshold))
 		Expect(*configuredProbe.TerminationGracePeriodSeconds).To(BeEquivalentTo(23))
 	})
+
+	It("should not overwrite any field", func() {
+		config := &Probe{}
+		configuredProbe := originalProbe.DeepCopy()
+		config.ApplyInto(configuredProbe)
+		Expect(originalProbe).To(BeEquivalentTo(*configuredProbe),
+			"configured probe should not be modified with zero values")
+	})
 })

--- a/docs/src/instance_manager.md
+++ b/docs/src/instance_manager.md
@@ -51,23 +51,25 @@ successThreshold: 1
 timeoutSeconds: 5
 ```
 
-Here, `FAILURE_THRESHOLD` is calculated as `startDelay` divided by
-`periodSeconds`.
+The `failureThreshold` value is automatically calculated by dividing
+`startDelay` by `periodSeconds`.
 
-If the default behavior based on `startDelay` is not suitable for your use
-case, you can take full control of the startup probe by specifying custom
-parameters in the `.spec.probes.startup` stanza. Note that defining this stanza
-will override the default behavior, including the use of `startDelay`.
+You can customize any of the probe settings in the `.spec.probes.startup`
+section of your configuration.
 
 !!! Warning
-    Ensure that any custom probe settings are aligned with your cluster’s
-    operational requirements to prevent unintended disruptions.
+    Be sure that any custom probe settings are tailored to your cluster's
+    operational requirements to avoid unintended disruptions.
 
 !!! Info
-    For detailed information about probe configuration, refer to the
-    [probe API](cloudnative-pg.v1.md#postgresql-cnpg-io-v1-Probe).
+    For more details on probe configuration, refer to the
+    [probe API documentation](cloudnative-pg.v1.md#postgresql-cnpg-io-v1-Probe).
 
-For example, the following configuration bypasses `startDelay` entirely:
+If you manually specify `.spec.probes.startup.failureThreshold`, it will
+override the default behavior and disable the automatic use of `startDelay`.
+
+For example, the following configuration explicitly sets custom probe
+parameters, bypassing `startDelay`:
 
 ```yaml
 # ... snip
@@ -103,28 +105,30 @@ successThreshold: 1
 timeoutSeconds: 5
 ```
 
-Here, `FAILURE_THRESHOLD` is calculated as `livenessProbeTimeout` divided by
-`periodSeconds`.
+The `failureThreshold` value is automatically calculated by dividing
+`livenessProbeTimeout` by `periodSeconds`.
 
 By default, `.spec.livenessProbeTimeout` is set to `30` seconds. This means the
 liveness probe will report a failure if it detects three consecutive probe
 failures, with a 10-second interval between each check.
 
-If the default behavior using `livenessProbeTimeout` does not meet your needs,
-you can fully customize the liveness probe by defining parameters in the
-`.spec.probes.liveness` stanza. Keep in mind that specifying this stanza will
-override the default behavior, including the use of `livenessProbeTimeout`.
+You can customize any of the probe settings in the `.spec.probes.liveness`
+section of your configuration.
 
 !!! Warning
-    Ensure that any custom probe settings are aligned with your cluster’s
-    operational requirements to prevent unintended disruptions.
+    Be sure that any custom probe settings are tailored to your cluster's
+    operational requirements to avoid unintended disruptions.
 
 !!! Info
     For more details on probe configuration, refer to the
-    [probe API](cloudnative-pg.v1.md#postgresql-cnpg-io-v1-Probe).
+    [probe API documentation](cloudnative-pg.v1.md#postgresql-cnpg-io-v1-Probe).
 
-For example, the following configuration overrides the default behavior and
-bypasses `livenessProbeTimeout`:
+If you manually specify `.spec.probes.liveness.failureThreshold`, it will
+override the default behavior and disable the automatic use of
+`livenessProbeTimeout`.
+
+For example, the following configuration explicitly sets custom probe
+parameters, bypassing `livenessProbeTimeout`:
 
 ```yaml
 # ... snip

--- a/pkg/specs/pods_test.go
+++ b/pkg/specs/pods_test.go
@@ -917,20 +917,12 @@ var _ = Describe("PodSpec drift detection", func() {
 
 var _ = Describe("Compute startup probe failure threshold", func() {
 	It("should take the minimum value 1", func() {
-		Expect(getStartupProbeFailureThreshold(5)).To(BeNumerically("==", 1))
+		Expect(getFailureThreshold(5, StartupProbePeriod)).To(BeNumerically("==", 1))
+		Expect(getFailureThreshold(5, LivenessProbePeriod)).To(BeNumerically("==", 1))
 	})
 
 	It("should take the value from 'startDelay / periodSeconds'", func() {
-		Expect(getStartupProbeFailureThreshold(109)).To(BeNumerically("==", 11))
-	})
-})
-
-var _ = Describe("Compute liveness probe failure threshold", func() {
-	It("should take the minimum value 1", func() {
-		Expect(getLivenessProbeFailureThreshold(5)).To(BeNumerically("==", 1))
-	})
-
-	It("should take the value from 'startDelay / periodSeconds'", func() {
-		Expect(getLivenessProbeFailureThreshold(31)).To(BeNumerically("==", 4))
+		Expect(getFailureThreshold(109, StartupProbePeriod)).To(BeNumerically("==", 11))
+		Expect(getFailureThreshold(31, LivenessProbePeriod)).To(BeNumerically("==", 4))
 	})
 })


### PR DESCRIPTION
In version 1.25.0, we introduced an inconsistent behavior in determining the default value of the standard probe knobs when a stanza under `.spec.probes` is defined.

This patch rectifies that behavior by allowing users to override any of the settings, including `failureThreshold`. When `failureThreshold` is not specified in the startup probe, its value is calculated by dividing `.spec.startupDelay` by `periodSeconds` (which defaults to 10 and is now overridable). The same principle applies to the liveness probe with the `.spec.livenessProbeTimeout` option.

Closes: #6655