### PR TITLE
fix(instance-manager): use pgdata content to discover PostgreSQL version

### DIFF
--- a/internal/cmd/manager/instance/run/lifecycle/run.go
+++ b/internal/cmd/manager/instance/run/lifecycle/run.go
@@ -150,7 +150,7 @@ func configureInstancePermissions(ctx context.Context, instance *postgres.Instan
 		return nil
 	}
 
-	majorVersion, err := postgresutils.GetPgdataVersion(instance.PgData)
+	pgVersion, err := postgresutils.GetPgdataVersion(instance.PgData)
 	if err != nil {
 		return fmt.Errorf("while getting major version: %w", err)
 	}
@@ -180,7 +180,7 @@ func configureInstancePermissions(ctx context.Context, instance *postgres.Instan
 		return err
 	}
 
-	err = configurePgRewindPrivileges(majorVersion, hasSuperuser, tx)
+	err = configurePgRewindPrivileges(pgVersion, hasSuperuser, tx)
 	if err != nil {
 		_ = tx.Rollback()
 		return err

--- a/internal/cmd/manager/instance/run/lifecycle/run.go
+++ b/internal/cmd/manager/instance/run/lifecycle/run.go
@@ -228,10 +228,10 @@ func configureStreamingReplicaUser(tx *sql.Tx) (bool, error) {
 }
 
 // configurePgRewindPrivileges ensures that the StreamingReplicationUser has enough rights to execute pg_rewind
-func configurePgRewindPrivileges(majorVersion semver.Version, hasSuperuser bool, tx *sql.Tx) error {
+func configurePgRewindPrivileges(pgVersion semver.Version, hasSuperuser bool, tx *sql.Tx) error {
 	// We need the superuser bit for the streaming-replication user since pg_rewind in PostgreSQL <= 10
 	// will require it.
-	if majorVersion.Major <= 10 {
+	if pgVersion.Major <= 10 {
 		if !hasSuperuser {
 			_, err := tx.Exec(fmt.Sprintf(
 				"ALTER USER %v SUPERUSER",

--- a/internal/cmd/manager/instance/run/lifecycle/run.go
+++ b/internal/cmd/manager/instance/run/lifecycle/run.go
@@ -228,10 +228,10 @@ func configureStreamingReplicaUser(tx *sql.Tx) (bool, error) {
 }
 
 // configurePgRewindPrivileges ensures that the StreamingReplicationUser has enough rights to execute pg_rewind
-func configurePgRewindPrivileges(majorVersion *semver.Version, hasSuperuser bool, tx *sql.Tx) error {
+func configurePgRewindPrivileges(majorVersion semver.Version, hasSuperuser bool, tx *sql.Tx) error {
 	// We need the superuser bit for the streaming-replication user since pg_rewind in PostgreSQL <= 10
 	// will require it.
-	if majorVersion != nil && majorVersion.Major <= 10 {
+	if majorVersion.Major <= 10 {
 		if !hasSuperuser {
 			_, err := tx.Exec(fmt.Sprintf(
 				"ALTER USER %v SUPERUSER",

--- a/pkg/management/postgres/configuration.go
+++ b/pkg/management/postgres/configuration.go
@@ -67,12 +67,12 @@ func (instance *Instance) RefreshConfigurationFilesFromCluster(
 	cluster *apiv1.Cluster,
 	preserveUserSettings bool,
 ) (bool, error) {
-	majorVersion, err := postgresutils.GetPgdataVersion(instance.PgData)
+	pgVersion, err := postgresutils.GetPgdataVersion(instance.PgData)
 	if err != nil {
 		return false, err
 	}
 
-	postgresConfiguration, sha256 := createPostgresqlConfiguration(cluster, preserveUserSettings, majorVersion.Major)
+	postgresConfiguration, sha256 := createPostgresqlConfiguration(cluster, preserveUserSettings, pgVersion.Major)
 	postgresConfigurationChanged, err := InstallPgDataFileContent(
 		ctx,
 		instance.PgData,

--- a/pkg/management/postgres/configuration.go
+++ b/pkg/management/postgres/configuration.go
@@ -27,10 +27,12 @@ import (
 
 	"github.com/cloudnative-pg/machinery/pkg/fileutils"
 	"github.com/cloudnative-pg/machinery/pkg/log"
+	"github.com/cloudnative-pg/machinery/pkg/postgres/version"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/configfile"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres/constants"
+	postgresutils "github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres/utils"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/postgres"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/postgres/replication"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
@@ -65,11 +67,12 @@ func (instance *Instance) RefreshConfigurationFilesFromCluster(
 	cluster *apiv1.Cluster,
 	preserveUserSettings bool,
 ) (bool, error) {
-	postgresConfiguration, sha256, err := createPostgresqlConfiguration(cluster, preserveUserSettings)
+	majorVersion, err := postgresutils.GetPgdataVersion(instance.PgData)
 	if err != nil {
 		return false, err
 	}
 
+	postgresConfiguration, sha256 := createPostgresqlConfiguration(cluster, preserveUserSettings, majorVersion.Major)
 	postgresConfigurationChanged, err := InstallPgDataFileContent(
 		ctx,
 		instance.PgData,
@@ -376,16 +379,14 @@ func (instance *Instance) migratePostgresAutoConfFile(ctx context.Context) (bool
 
 // createPostgresqlConfiguration creates the PostgreSQL configuration to be
 // used for this cluster and return it and its sha256 checksum
-func createPostgresqlConfiguration(cluster *apiv1.Cluster, preserveUserSettings bool) (string, string, error) {
-	// Extract the PostgreSQL major version
-	fromVersion, err := cluster.GetPostgresqlVersion()
-	if err != nil {
-		return "", "", err
-	}
-
+func createPostgresqlConfiguration(
+	cluster *apiv1.Cluster,
+	preserveUserSettings bool,
+	majorVersion uint64,
+) (string, string) {
 	info := postgres.ConfigurationInfo{
 		Settings:                         postgres.CnpgConfigurationSettings,
-		Version:                          fromVersion,
+		Version:                          version.New(majorVersion, 0),
 		UserSettings:                     cluster.Spec.PostgresConfiguration.Parameters,
 		IncludingSharedPreloadLibraries:  true,
 		AdditionalSharedPreloadLibraries: cluster.Spec.PostgresConfiguration.AdditionalLibraries,
@@ -417,8 +418,7 @@ func createPostgresqlConfiguration(cluster *apiv1.Cluster, preserveUserSettings 
 		info.RecoveryMinApplyDelay = cluster.Spec.ReplicaCluster.MinApplyDelay.Duration
 	}
 
-	conf, sha256 := postgres.CreatePostgresqlConfFile(postgres.CreatePostgresqlConfiguration(info))
-	return conf, sha256, nil
+	return postgres.CreatePostgresqlConfFile(postgres.CreatePostgresqlConfiguration(info))
 }
 
 // configurePostgresForImport configures Postgres to be optimized for the firt import

--- a/pkg/management/postgres/configuration_test.go
+++ b/pkg/management/postgres/configuration_test.go
@@ -21,11 +21,14 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cloudnative-pg/machinery/pkg/image/reference"
+	"github.com/cloudnative-pg/machinery/pkg/postgres/version"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/versions"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -116,6 +119,9 @@ var _ = Describe("testing the building of the ldap config string", func() {
 })
 
 var _ = Describe("Test building of the list of temporary tablespaces", func() {
+	defaultVersion, err := version.FromTag(reference.New(versions.DefaultImageName).Tag)
+	Expect(err).ToNot(HaveOccurred())
+
 	clusterWithoutTablespaces := apiv1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "configurationTest",
@@ -166,25 +172,25 @@ var _ = Describe("Test building of the list of temporary tablespaces", func() {
 	}
 
 	It("doesn't set temp_tablespaces if there are no declared tablespaces", func() {
-		config, _, err := createPostgresqlConfiguration(&clusterWithoutTablespaces, true)
-		Expect(err).ShouldNot(HaveOccurred())
+		config, _ := createPostgresqlConfiguration(&clusterWithoutTablespaces, true, defaultVersion.Major())
 		Expect(config).ToNot(ContainSubstring("temp_tablespaces"))
 	})
 
 	It("doesn't set temp_tablespaces if there are no temporary tablespaces", func() {
-		config, _, err := createPostgresqlConfiguration(&clusterWithoutTemporaryTablespaces, true)
-		Expect(err).ShouldNot(HaveOccurred())
+		config, _ := createPostgresqlConfiguration(&clusterWithoutTemporaryTablespaces, true, defaultVersion.Major())
 		Expect(config).ToNot(ContainSubstring("temp_tablespaces"))
 	})
 
 	It("sets temp_tablespaces when there are temporary tablespaces", func() {
-		config, _, err := createPostgresqlConfiguration(&clusterWithTemporaryTablespaces, true)
-		Expect(err).ShouldNot(HaveOccurred())
+		config, _ := createPostgresqlConfiguration(&clusterWithTemporaryTablespaces, true, defaultVersion.Major())
 		Expect(config).To(ContainSubstring("temp_tablespaces = 'other_temporary_tablespace,temporary_tablespace'"))
 	})
 })
 
 var _ = Describe("recovery_min_apply_delay", func() {
+	defaultVersion, err := version.FromTag(reference.New(versions.DefaultImageName).Tag)
+	Expect(err).ToNot(HaveOccurred())
+
 	primaryCluster := apiv1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "configurationTest",
@@ -233,24 +239,21 @@ var _ = Describe("recovery_min_apply_delay", func() {
 	It("do not set recovery_min_apply_delay in primary clusters", func() {
 		Expect(primaryCluster.IsReplica()).To(BeFalse())
 
-		config, _, err := createPostgresqlConfiguration(&primaryCluster, true)
-		Expect(err).ShouldNot(HaveOccurred())
+		config, _ := createPostgresqlConfiguration(&primaryCluster, true, defaultVersion.Major())
 		Expect(config).ToNot(ContainSubstring("recovery_min_apply_delay"))
 	})
 
 	It("set recovery_min_apply_delay in replica clusters when set", func() {
 		Expect(replicaCluster.IsReplica()).To(BeTrue())
 
-		config, _, err := createPostgresqlConfiguration(&replicaCluster, true)
-		Expect(err).ShouldNot(HaveOccurred())
+		config, _ := createPostgresqlConfiguration(&replicaCluster, true, defaultVersion.Major())
 		Expect(config).To(ContainSubstring("recovery_min_apply_delay = '3600s'"))
 	})
 
 	It("do not set recovery_min_apply_delay in replica clusters when not set", func() {
 		Expect(replicaClusterWithNoDelay.IsReplica()).To(BeTrue())
 
-		config, _, err := createPostgresqlConfiguration(&replicaClusterWithNoDelay, true)
-		Expect(err).ShouldNot(HaveOccurred())
+		config, _ := createPostgresqlConfiguration(&replicaClusterWithNoDelay, true, defaultVersion.Major())
 		Expect(config).ToNot(ContainSubstring("recovery_min_apply_delay"))
 	})
 })

--- a/pkg/management/postgres/utils/version.go
+++ b/pkg/management/postgres/utils/version.go
@@ -52,18 +52,16 @@ func parseVersionNum(versionNum string) (*semver.Version, error) {
 
 // GetPgdataVersion read the PG_VERSION file in the data directory
 // returning the major version of the database
-func GetPgdataVersion(pgData string) (*semver.Version, error) {
+func GetPgdataVersion(pgData string) (semver.Version, error) {
 	content, err := os.ReadFile(path.Join(pgData, "PG_VERSION")) // #nosec
 	if err != nil {
-		return nil, err
+		return semver.Version{}, err
 	}
 
 	major, err := strconv.ParseUint(strings.TrimSpace(string(content)), 10, 64)
 	if err != nil {
-		return nil, err
+		return semver.Version{}, err
 	}
 
-	return &semver.Version{
-		Major: major,
-	}, nil
+	return semver.Version{Major: major}, nil
 }

--- a/pkg/management/postgres/utils/version.go
+++ b/pkg/management/postgres/utils/version.go
@@ -38,25 +38,32 @@ func GetPgVersion(db *sql.DB) (*semver.Version, error) {
 }
 
 func parseVersionNum(versionNum string) (*semver.Version, error) {
-	versionInt, err := strconv.Atoi(versionNum)
+	versionInt, err := strconv.ParseUint(versionNum, 10, 64)
 	if err != nil {
 		return nil, err
 	}
 
 	return &semver.Version{
-		Major: uint64(versionInt / 10000),       //nolint:gosec
-		Minor: uint64((versionInt / 100) % 100), //nolint:gosec
-		Patch: uint64(versionInt % 100),         //nolint:gosec
+		Major: versionInt / 10000,
+		Minor: (versionInt / 100) % 100,
+		Patch: versionInt % 100,
 	}, nil
 }
 
-// GetMajorVersion read the PG_VERSION file in the data directory
+// GetPgdataVersion read the PG_VERSION file in the data directory
 // returning the major version of the database
-func GetMajorVersion(pgData string) (int, error) {
+func GetPgdataVersion(pgData string) (*semver.Version, error) {
 	content, err := os.ReadFile(path.Join(pgData, "PG_VERSION")) // #nosec
 	if err != nil {
-		return 0, err
+		return nil, err
 	}
 
-	return strconv.Atoi(strings.TrimSpace(string(content)))
+	major, err := strconv.ParseUint(strings.TrimSpace(string(content)), 10, 64)
+	if err != nil {
+		return nil, err
+	}
+
+	return &semver.Version{
+		Major: major,
+	}, nil
 }


### PR DESCRIPTION
Use a precise check of the data directory to determine the PostgreSQL major version during PostgreSQL configuration generation.

Closes #6658 