### PR TITLE
fix(ci): make sure to run only on created comments

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -81,6 +81,7 @@ jobs:
   check_commenter:
     if: |
       github.event_name == 'issue_comment' &&
+      github.event.action == 'created' &&
       github.event.issue.pull_request &&
       startsWith(github.event.comment.body, '/test')
     name: Retrieve command


### PR DESCRIPTION
The action we use doesn't trigger and error when users delete a comment,
now we make sure that the event comes with the action created until 
the github action fix the issue.