### PR TITLE
docs: tcp_syn_retries behaviour

### DIFF
--- a/.wordlist-en-custom.txt
+++ b/.wordlist-en-custom.txt
@@ -1131,6 +1131,7 @@ readthedocs
 readyInstances
 reconciler
 reconciliationLoop
+reconnection
 recoverability
 recoveredCluster
 recoveryTarget

--- a/docs/src/troubleshooting.md
+++ b/docs/src/troubleshooting.md
@@ -800,13 +800,14 @@ you have sidecar injection enabled, retry with injection disabled.
 When the primary instance fails, the operator promotes the most advanced
 standby to the primary role. Other standby instances then attempt to reconnect
 to the `-rw` service for replication. However, during this reconnection
-process, the `kube-proxy` may not have updated its routing information yet.
-As a result, the initial `SYN` packet from the standby might fail to reach its
-destination.
+process, the `kube-proxy` may not yet have updated its routing information.
+As a result, the initial `SYN` packet sent by the standby instances can fail
+to reach the intended destination.
 
-On Linux systems, the default value of the `tcp_syn_retries` kernel parameter
-is 6. This configuration causes the system to retry a stuck connection after
-approximately 127 seconds. For more details, refer to the
+On Linux systems, the default value for the `tcp_syn_retries` kernel parameter
+is set to 6. This configuration means the system will retry a failed connection
+for approximately 127 seconds before giving up. This extended retry period can
+significantly delay the reconnection process. For more details, consult the
 [tcp_syn_retries documentation](https://www.kernel.org/doc/Documentation/networking/ip-sysctl.txt).
 
 Altering this behaviour will require changing the `tcp_syn_retries`

--- a/docs/src/troubleshooting.md
+++ b/docs/src/troubleshooting.md
@@ -794,3 +794,20 @@ API. Please check your networking.
 Another possible cause is when you have sidecar injection configured. Sidecars
 such as Istio may make the network temporarily unavailable during startup. If
 you have sidecar injection enabled, retry with injection disabled.
+
+### Standbys take over two minutes to reconnect after a failover
+
+When the primary instance fails, the operator promotes the most advanced
+standby to the primary role. Other standby instances then attempt to reconnect
+to the `-rw` service for replication. However, during this reconnection
+process, the `kube-proxy` may not have updated its routing information yet.
+As a result, the initial `SYN` packet from the standby might fail to reach its
+destination.
+
+On Linux systems, the default value of the `tcp_syn_retries` kernel parameter
+is 6. This configuration causes the system to retry a stuck connection after
+approximately 127 seconds. For more details, refer to the
+[tcp_syn_retries documentation](https://www.kernel.org/doc/Documentation/networking/ip-sysctl.txt).
+
+Altering this behaviour will require changing the `tcp_syn_retries`
+parameter on the host node.

--- a/docs/src/troubleshooting.md
+++ b/docs/src/troubleshooting.md
@@ -795,7 +795,7 @@ Another possible cause is when you have sidecar injection configured. Sidecars
 such as Istio may make the network temporarily unavailable during startup. If
 you have sidecar injection enabled, retry with injection disabled.
 
-### Standbys take over two minutes to reconnect after a failover
+### Replicas take over two minutes to reconnect after a failover
 
 When the primary instance fails, the operator promotes the most advanced
 standby to the primary role. Other standby instances then attempt to reconnect

--- a/docs/src/troubleshooting.md
+++ b/docs/src/troubleshooting.md
@@ -800,7 +800,7 @@ you have sidecar injection enabled, retry with injection disabled.
 When the primary instance fails, the operator promotes the most advanced
 standby to the primary role. Other standby instances then attempt to reconnect
 to the `-rw` service for replication. However, during this reconnection
-process, the `kube-proxy` may not yet have updated its routing information.
+process, `kube-proxy` may not yet have updated its routing information.
 As a result, the initial `SYN` packet sent by the standby instances can fail
 to reach the intended destination.
 

--- a/docs/src/troubleshooting.md
+++ b/docs/src/troubleshooting.md
@@ -810,5 +810,5 @@ for approximately 127 seconds before giving up. This extended retry period can
 significantly delay the reconnection process. For more details, consult the
 [tcp_syn_retries documentation](https://www.kernel.org/doc/Documentation/networking/ip-sysctl.txt).
 
-Altering this behaviour will require changing the `tcp_syn_retries`
+Altering this behavior will require changing the `tcp_syn_retries`
 parameter on the host node.


### PR DESCRIPTION
Add documentation for the replication connection behaviour in relation to the `tcp_syn_retries` setting.