### PR TITLE
feat: add kubernetes `client-gen` tool support

### DIFF
--- a/api/v1/backup_funcs.go
+++ b/api/v1/backup_funcs.go
@@ -236,8 +236,8 @@ func (backup *Backup) GetVolumeSnapshotConfiguration(
 // By setting the GVK, we ensure that components such as the plugins have enough metadata to typecheck the object.
 func (backup *Backup) EnsureGVKIsPresent() {
 	backup.SetGroupVersionKind(schema.GroupVersionKind{
-		Group:   GroupVersion.Group,
-		Version: GroupVersion.Version,
+		Group:   SchemeGroupVersion.Group,
+		Version: SchemeGroupVersion.Version,
 		Kind:    BackupKind,
 	})
 }

--- a/api/v1/cluster_funcs.go
+++ b/api/v1/cluster_funcs.go
@@ -1397,8 +1397,8 @@ func (cluster *Cluster) GetRecoverySourcePlugin() *PluginConfiguration {
 // By setting the GVK, we ensure that components such as the plugins have enough metadata to typecheck the object.
 func (cluster *Cluster) EnsureGVKIsPresent() {
 	cluster.SetGroupVersionKind(schema.GroupVersionKind{
-		Group:   GroupVersion.Group,
-		Version: GroupVersion.Version,
+		Group:   SchemeGroupVersion.Group,
+		Version: SchemeGroupVersion.Version,
 		Kind:    ClusterKind,
 	})
 }

--- a/api/v1/clusterimagecatalog_types.go
+++ b/api/v1/clusterimagecatalog_types.go
@@ -19,6 +19,7 @@ package v1
 import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 // +genclient
+// +genclient:nonNamespaced
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:scope=Cluster
 // +kubebuilder:storageversion

--- a/api/v1/groupversion_info.go
+++ b/api/v1/groupversion_info.go
@@ -14,9 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package v1 contains API Schema definitions for the postgresql v1 API group
-// +kubebuilder:object:generate=true
-// +groupName=postgresql.cnpg.io
 package v1
 
 import (
@@ -51,14 +48,11 @@ const (
 )
 
 var (
-	// GroupVersion is group version used to register these objects
-	GroupVersion = schema.GroupVersion{Group: "postgresql.cnpg.io", Version: "v1"}
-
-	// SchemeGroupVersion is the group version used to register these objects.
-	SchemeGroupVersion = GroupVersion
+	// SchemeGroupVersion is group version used to register these objects
+	SchemeGroupVersion = schema.GroupVersion{Group: "postgresql.cnpg.io", Version: "v1"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
-	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
+	SchemeBuilder = &scheme.Builder{GroupVersion: SchemeGroupVersion}
 
 	// AddToScheme adds the types in this group-version to the given scheme.
 	AddToScheme = SchemeBuilder.AddToScheme

--- a/api/v1/groupversion_info.go
+++ b/api/v1/groupversion_info.go
@@ -54,6 +54,9 @@ var (
 	// GroupVersion is group version used to register these objects
 	GroupVersion = schema.GroupVersion{Group: "postgresql.cnpg.io", Version: "v1"}
 
+	// SchemeGroupVersion is the group version used to register these objects.
+	SchemeGroupVersion = GroupVersion
+
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
 

--- a/internal/cmd/plugin/report/operator_utils.go
+++ b/internal/cmd/plugin/report/operator_utils.go
@@ -44,7 +44,7 @@ func getWebhooks(ctx context.Context, stopRedact bool) (
 
 	for _, item := range mutatingWebhookConfigList.Items {
 		for _, webhook := range item.Webhooks {
-			if len(webhook.Rules) > 0 && webhook.Rules[0].APIGroups[0] == apiv1.GroupVersion.Group {
+			if len(webhook.Rules) > 0 && webhook.Rules[0].APIGroups[0] == apiv1.SchemeGroupVersion.Group {
 				mWebhookConfig.Items = append(mWebhookConfig.Items, item)
 			}
 		}
@@ -63,7 +63,7 @@ func getWebhooks(ctx context.Context, stopRedact bool) (
 
 	for _, item := range validatingWebhookConfigList.Items {
 		for _, webhook := range item.Webhooks {
-			if len(webhook.Rules) > 0 && webhook.Rules[0].APIGroups[0] == apiv1.GroupVersion.Group {
+			if len(webhook.Rules) > 0 && webhook.Rules[0].APIGroups[0] == apiv1.SchemeGroupVersion.Group {
 				vWebhookConfig.Items = append(vWebhookConfig.Items, item)
 			}
 		}
@@ -79,7 +79,7 @@ func getWebhooks(ctx context.Context, stopRedact bool) (
 	if len(mWebhookConfig.Items) == 0 || len(vWebhookConfig.Items) == 0 {
 		return nil, nil, fmt.Errorf(
 			"can't find the webhooks that targeting resources within the group %s",
-			apiv1.GroupVersion.Group,
+			apiv1.SchemeGroupVersion.Group,
 		)
 	}
 

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -69,7 +69,7 @@ const (
 	imageCatalogKey               = ".spec.imageCatalog.name"
 )
 
-var apiGVString = apiv1.GroupVersion.String()
+var apiGVString = apiv1.SchemeGroupVersion.String()
 
 // errOldPrimaryDetected occurs when a primary Pod loses connectivity with the
 // API server and, upon reconnection, attempts to retain its previous primary

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -69,7 +69,7 @@ const (
 	imageCatalogKey               = ".spec.imageCatalog.name"
 )
 
-var apiGVString = apiv1.SchemeGroupVersion.String()
+var apiSGVString = apiv1.SchemeGroupVersion.String()
 
 // errOldPrimaryDetected occurs when a primary Pod loses connectivity with the
 // API server and, upon reconnection, attempts to retain its previous primary
@@ -1205,7 +1205,7 @@ func IsOwnedByCluster(obj client.Object) (string, bool) {
 		return "", false
 	}
 
-	if owner.APIVersion != apiGVString {
+	if owner.APIVersion != apiSGVString {
 		return "", false
 	}
 

--- a/internal/controller/cluster_create_test.go
+++ b/internal/controller/cluster_create_test.go
@@ -868,7 +868,7 @@ var _ = Describe("createOrPatchClusterCredentialSecret", func() {
 			cluster := apiv1.Cluster{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       apiv1.ClusterKind,
-					APIVersion: apiGVString,
+					APIVersion: apiSGVString,
 				},
 				ObjectMeta: metav1.ObjectMeta{Name: "test-cluster", Namespace: namespace},
 			}

--- a/internal/controller/cluster_create_test.go
+++ b/internal/controller/cluster_create_test.go
@@ -1159,7 +1159,7 @@ var _ = Describe("Service Reconciling", func() {
 		cluster = apiv1.Cluster{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       apiv1.ClusterKind,
-				APIVersion: apiv1.GroupVersion.String(),
+				APIVersion: apiv1.SchemeGroupVersion.String(),
 			},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-cluster",

--- a/internal/controller/cluster_image.go
+++ b/internal/controller/cluster_image.go
@@ -76,7 +76,7 @@ func (r *ClusterReconciler) reconcileImage(ctx context.Context, cluster *apiv1.C
 	}
 
 	apiGroup := cluster.Spec.ImageCatalogRef.APIGroup
-	if apiGroup == nil || *apiGroup != apiv1.GroupVersion.Group {
+	if apiGroup == nil || *apiGroup != apiv1.SchemeGroupVersion.Group {
 		contextLogger.Info("Unknown catalog group")
 		return &ctrl.Result{}, r.RegisterPhase(ctx, cluster, apiv1.PhaseImageCatalogError,
 			"Invalid image catalog group")

--- a/internal/controller/cluster_restore_test.go
+++ b/internal/controller/cluster_restore_test.go
@@ -483,7 +483,7 @@ var _ = Describe("ensureOrphanServicesAreNotPresent", func() {
 					Namespace: cluster.Namespace,
 				},
 			}
-			cluster.TypeMeta = metav1.TypeMeta{Kind: apiv1.ClusterKind, APIVersion: apiv1.GroupVersion.String()}
+			cluster.TypeMeta = metav1.TypeMeta{Kind: apiv1.ClusterKind, APIVersion: apiv1.SchemeGroupVersion.String()}
 			cluster.SetInheritedDataAndOwnership(&svc.ObjectMeta)
 			mockCli = fake.NewClientBuilder().
 				WithScheme(k8scheme.BuildWithAllKnownScheme()).

--- a/internal/controller/pooler_controller.go
+++ b/internal/controller/pooler_controller.go
@@ -157,7 +157,7 @@ func isOwnedByPoolerKind(obj client.Object) (string, bool) {
 		return "", false
 	}
 
-	if owner.APIVersion != apiGVString {
+	if owner.APIVersion != apiSGVString {
 		return "", false
 	}
 

--- a/internal/controller/scheduledbackup_controller.go
+++ b/internal/controller/scheduledbackup_controller.go
@@ -348,7 +348,7 @@ func (r *ScheduledBackupReconciler) SetupWithManager(
 				return nil
 			}
 
-			if owner.APIVersion != apiGVString {
+			if owner.APIVersion != apiSGVString {
 				return nil
 			}
 

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -151,7 +151,7 @@ func newFakePooler(k8sClient client.Client, cluster *apiv1.Cluster) *apiv1.Poole
 	// upstream issue, go client cleans typemeta: https://github.com/kubernetes/client-go/issues/308
 	pooler.TypeMeta = metav1.TypeMeta{
 		Kind:       apiv1.PoolerKind,
-		APIVersion: apiv1.GroupVersion.String(),
+		APIVersion: apiv1.SchemeGroupVersion.String(),
 	}
 
 	return pooler
@@ -219,7 +219,7 @@ func newFakeCNPGCluster(
 	// upstream issue, go client cleans typemeta: https://github.com/kubernetes/client-go/issues/308
 	cluster.TypeMeta = metav1.TypeMeta{
 		Kind:       apiv1.ClusterKind,
-		APIVersion: apiv1.GroupVersion.String(),
+		APIVersion: apiv1.SchemeGroupVersion.String(),
 	}
 
 	return cluster
@@ -270,7 +270,7 @@ func newFakeCNPGClusterWithPGWal(k8sClient client.Client, namespace string) *api
 	// upstream issue, go client cleans typemeta: https://github.com/kubernetes/client-go/issues/308
 	cluster.TypeMeta = metav1.TypeMeta{
 		Kind:       apiv1.ClusterKind,
-		APIVersion: apiv1.GroupVersion.String(),
+		APIVersion: apiv1.SchemeGroupVersion.String(),
 	}
 
 	return cluster

--- a/pkg/management/client.go
+++ b/pkg/management/client.go
@@ -73,7 +73,7 @@ func NewControllerRuntimeClient() (client.WithWatch, error) {
 		return nil, err
 	}
 
-	mapper := meta.NewDefaultRESTMapper([]schema.GroupVersion{apiv1.GroupVersion})
+	mapper := meta.NewDefaultRESTMapper([]schema.GroupVersion{apiv1.SchemeGroupVersion})
 	// add here any resource that need to be registered.
 	objectsToRegister := []runtime.Object{
 		// custom resources

--- a/tests/e2e/rolling_update_test.go
+++ b/tests/e2e/rolling_update_test.go
@@ -352,7 +352,7 @@ var _ = Describe("Rolling updates", Label(tests.LabelPostgresConfiguration), fun
 				Instances: instances,
 				ImageCatalogRef: &apiv1.ImageCatalogRef{
 					TypedLocalObjectReference: corev1.TypedLocalObjectReference{
-						APIGroup: &apiv1.GroupVersion.Group,
+						APIGroup: &apiv1.SchemeGroupVersion.Group,
 						Name:     name,
 						Kind:     "ImageCatalog",
 					},

--- a/tests/utils/operator/upgrade.go
+++ b/tests/utils/operator/upgrade.go
@@ -104,8 +104,8 @@ func InstallLatest(
 
 	Eventually(func() error {
 		mapping, err := crudClient.RESTMapper().RESTMapping(
-			schema.GroupKind{Group: apiv1.GroupVersion.Group, Kind: apiv1.ClusterKind},
-			apiv1.GroupVersion.Version)
+			schema.GroupKind{Group: apiv1.SchemeGroupVersion.Group, Kind: apiv1.ClusterKind},
+			apiv1.SchemeGroupVersion.Version)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This patch introduces support for the Kubernetes `client-gen` tool, enabling the automated generation of Go clients for all custom resources defined by cloudnative-pg CRDs.

Closes #6585 

## Release notes

Added support for Kubernetes `client-gen`, allowing the automated generation of Go clients for all custom resources defined by cloudnative-pg CRDs.