### PR TITLE
feat(plugin): add `--ttl` option to `pgbench` command

### DIFF
--- a/internal/cmd/plugin/pgbench/cmd.go
+++ b/internal/cmd/plugin/pgbench/cmd.go
@@ -67,8 +67,8 @@ func NewCmd() *cobra.Command {
 	pgBenchCmd.Flags().Int32Var(
 		&run.ttlSecondsAfterFinished,
 		"ttl",
-		86400,
-		"Time to live of the pgbench job. Defaults to: one day",
+		0,
+		"Time to live of the pgbench job. Defaults to no TTL.",
 	)
 
 	pgBenchCmd.Flags().BoolVar(

--- a/internal/cmd/plugin/pgbench/cmd.go
+++ b/internal/cmd/plugin/pgbench/cmd.go
@@ -64,6 +64,13 @@ func NewCmd() *cobra.Command {
 		"The name of the database that will be used by pgbench. Defaults to: app",
 	)
 
+	pgBenchCmd.Flags().Int32Var(
+		&run.ttlSecondsAfterFinished,
+		"ttl",
+		86400,
+		"Time to live of the pgbench job. Defaults to: one day",
+	)
+
 	pgBenchCmd.Flags().BoolVar(
 		&run.dryRun,
 		"dry-run",

--- a/internal/cmd/plugin/pgbench/cmd_test.go
+++ b/internal/cmd/plugin/pgbench/cmd_test.go
@@ -48,6 +48,10 @@ var _ = Describe("NewCmd", func() {
 		nodeSelectorFlag := cmd.Flag("node-selector")
 		Expect(nodeSelectorFlag).ToNot(BeNil())
 		Expect(nodeSelectorFlag.DefValue).To(Equal("[]"))
+
+		ttlFlag := cmd.Flag("ttl")
+		Expect(ttlFlag).ToNot(BeNil())
+		Expect(ttlFlag.DefValue).To(Equal("86400"))
 	})
 
 	It("should correctly parse flags and arguments", func() {
@@ -62,7 +66,7 @@ var _ = Describe("NewCmd", func() {
 			testRun.dbName, _ = cmd.Flags().GetString("db-name")
 			testRun.dryRun, _ = cmd.Flags().GetBool("dry-run")
 			testRun.nodeSelector, _ = cmd.Flags().GetStringSlice("node-selector")
-
+			testRun.ttlSecondsAfterFinished, _ = cmd.Flags().GetInt32("ttl")
 			testRun.clusterName = args[0]
 			testRun.pgBenchCommandArgs = args[1:]
 			return nil
@@ -75,6 +79,7 @@ var _ = Describe("NewCmd", func() {
 			"--db-name=mydb",
 			"--dry-run=true",
 			"--node-selector=label=value",
+			"--ttl=86400",
 			"arg1",
 			"arg2",
 		}
@@ -91,6 +96,7 @@ var _ = Describe("NewCmd", func() {
 		Expect(testRun.dbName).To(Equal("mydb"))
 		Expect(testRun.dryRun).To(BeTrue())
 		Expect(testRun.nodeSelector).To(Equal([]string{"label=value"}))
+		Expect(testRun.ttlSecondsAfterFinished).To(Equal(int32(86400)))
 		Expect(testRun.pgBenchCommandArgs).To(Equal([]string{"arg1", "arg2"}))
 	})
 })

--- a/internal/cmd/plugin/pgbench/cmd_test.go
+++ b/internal/cmd/plugin/pgbench/cmd_test.go
@@ -48,10 +48,6 @@ var _ = Describe("NewCmd", func() {
 		nodeSelectorFlag := cmd.Flag("node-selector")
 		Expect(nodeSelectorFlag).ToNot(BeNil())
 		Expect(nodeSelectorFlag.DefValue).To(Equal("[]"))
-
-		ttlFlag := cmd.Flag("ttl")
-		Expect(ttlFlag).ToNot(BeNil())
-		Expect(ttlFlag.DefValue).To(Equal("86400"))
 	})
 
 	It("should correctly parse flags and arguments", func() {

--- a/internal/cmd/plugin/pgbench/pgbench.go
+++ b/internal/cmd/plugin/pgbench/pgbench.go
@@ -129,8 +129,9 @@ func (cmd *pgBenchRun) buildJob(cluster *apiv1.Cluster) *batchv1.Job {
 	labels := map[string]string{
 		"pgBenchJob": cluster.Name,
 	}
-	return &batchv1.Job{
-		// To ensure we have manifest with Kind and APi in --dry-run
+
+	result := &batchv1.Job{
+		// To ensure we have manifest with Kind and API in --dry-run
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "batch/v1",
 			Kind:       "Job",
@@ -141,7 +142,6 @@ func (cmd *pgBenchRun) buildJob(cluster *apiv1.Cluster) *batchv1.Job {
 			Labels:    labels,
 		},
 		Spec: batchv1.JobSpec{
-			TTLSecondsAfterFinished: &cmd.ttlSecondsAfterFinished,
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: labels,
@@ -164,6 +164,12 @@ func (cmd *pgBenchRun) buildJob(cluster *apiv1.Cluster) *batchv1.Job {
 			},
 		},
 	}
+
+	if cmd.ttlSecondsAfterFinished != 0 {
+		result.Spec.TTLSecondsAfterFinished = &cmd.ttlSecondsAfterFinished
+	}
+
+	return result
 }
 
 func (cmd *pgBenchRun) buildEnvVariables() []corev1.EnvVar {


### PR DESCRIPTION
This patch introduces the `--ttl` option to the `pgbench` plugin command,
allowing users to configure automatic cleanup of completed jobs after a
specified duration. By default, jobs do not expire, preserving existing
behavior.

Closes #4374

## Release notes

```
Add an optional `--ttl` flag to the `pgbench` plugin command, enabling
automatic deletion of completed jobs after a user-specified duration. By
default, jobs do not expire.
```