### PR TITLE
fix: cluster name length not validated

### DIFF
--- a/internal/webhook/v1/cluster_webhook.go
+++ b/internal/webhook/v1/cluster_webhook.go
@@ -1615,11 +1615,11 @@ func (v *ClusterCustomValidator) validateName(r *apiv1.Cluster) field.ErrorList 
 			"cluster name must be a valid DNS label"))
 	}
 
-	if len(r.Name) > 50 {
+	if len(r.Name) > 40 {
 		result = append(result, field.Invalid(
 			field.NewPath("metadata", "name"),
 			r.Name,
-			"the maximum length of a cluster name is 50 characters"))
+			"the maximum length of a cluster name is 40 characters"))
 	}
 
 	return result

--- a/internal/webhook/v1/cluster_webhook_test.go
+++ b/internal/webhook/v1/cluster_webhook_test.go
@@ -2029,10 +2029,10 @@ var _ = Describe("Cluster name validation", func() {
 		Expect(v.validateName(cluster)).NotTo(BeEmpty())
 	})
 
-	It("should return errors when the name length is greater than 50", func() {
+	It("should return errors when the name length is greater than 40", func() {
 		cluster := &apiv1.Cluster{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: strings.Repeat("toomuchlong", 4) + "-" + "after4times",
+				Name: strings.Repeat("toomuchlong", 3) + "-" + "after4times",
 			},
 		}
 		Expect(v.validateName(cluster)).NotTo(BeEmpty())


### PR DESCRIPTION
Fixes #6753 

Here is a simple fix for the issue #6753.

I lowered the limit to 40 characters. So we have now : 
`<cluster name>-<instance number>-snapshot-recovery`
which is in numbers : 
<40>-<4>-<17> = 40 + 1 + 4 +1 + 17 = 63

So the instance number will be on 4 digits (from 1 to 9999).

I do not know (yet :) ) if there will be some consequences to limit it to 9999.

Furthermore, it might be a good idea to have a doc page saying that cluster name length must be <= 40.