### PR TITLE
fix: avoid loading helper images when running test on kind

### DIFF
--- a/hack/e2e/run-e2e-kind.sh
+++ b/hack/e2e/run-e2e-kind.sh
@@ -84,7 +84,8 @@ main() {
     "${HACK_DIR}/setup-cluster.sh" load
   fi
 
-  "${HACK_DIR}/setup-cluster.sh" load-helper-images
+  # Comment out when the a new release of kindest/node is release newer than v1.32.1
+  # "${HACK_DIR}/setup-cluster.sh" load-helper-images
 
   RC=0
 


### PR DESCRIPTION
Avoid loading the images due to a known issue that makes kind 
v0.26.0 with kindest/node v1.32.1 fails when loading the images.

This issue was reported here https://github.com/kubernetes-sigs/kind/issues/3853