### PR TITLE
fix: handle `load_balance_hosts` null value

### DIFF
--- a/pkg/management/pgbouncer/metricsserver/pools.go
+++ b/pkg/management/pgbouncer/metricsserver/pools.go
@@ -242,7 +242,7 @@ func (e *Exporter) collectShowPools(ch chan<- prometheus.Metric, db *sql.DB) {
 	)
 	// PGBouncer 1.24.0 or above
 	var (
-		loadBalanceHosts int
+		loadBalanceHosts sql.NullInt32
 	)
 
 	cols, err := rows.Columns()
@@ -336,7 +336,7 @@ func (e *Exporter) collectShowPools(ch chan<- prometheus.Metric, db *sql.DB) {
 		e.Metrics.ShowPools.MaxWait.WithLabelValues(database, user).Set(float64(maxWait))
 		e.Metrics.ShowPools.MaxWaitUs.WithLabelValues(database, user).Set(float64(maxWaitUs))
 		e.Metrics.ShowPools.PoolMode.WithLabelValues(database, user).Set(float64(poolModeToInt(poolMode)))
-		e.Metrics.ShowPools.LoadBalanceHosts.WithLabelValues(database, user).Set(float64(loadBalanceHosts))
+		e.Metrics.ShowPools.LoadBalanceHosts.WithLabelValues(database, user).Set(float64(loadBalanceHosts.Int32))
 	}
 
 	e.Metrics.ShowPools.ClActive.Collect(ch)


### PR DESCRIPTION
Hi, everyone! After testing the PgBouncer 1.24 and CNPG 1.25 with [this fix](https://github.com/cloudnative-pg/cloudnative-pg/pull/6630) applied I see the following errors in the pooler logs:
```
{
  "level": "error",
  "ts": "2025-02-10T13:01:21.430417823Z",
  "msg": "Error while executing SHOW POOLS",
  "logger": "pgbouncer-manager",
  "error": "sql: Scan error on column index 16, name \"load_balance_hosts\": converting NULL to int is unsupported",
  "stacktrace": "github.com/cloudnative-pg/machinery/pkg/log.(*logger).Error\n\t/root/go/pkg/mod/github.com/cloudnative-pg/machinery@v0.0.0-20241219102532-2807bc88310d/pkg/log/log.go:125\ngithub.com/cloudnative-pg/cloudnative-pg/pkg/management/pgbouncer/metricsserver.(*Exporter).collectShowPools\n\tpkg/management/pgbouncer/metricsserver/pools.go:301\ngithub.com/cloudnative-pg/cloudnative-pg/pkg/management/pgbouncer/metricsserver.(*Exporter).collectPgBouncerMetrics\n\tpkg/management/pgbouncer/metricsserver/pgbouncer_collector.go:143\ngithub.com/cloudnative-pg/cloudnative-pg/pkg/management/pgbouncer/metricsserver.(*Exporter).Collect\n\tpkg/management/pgbouncer/metricsserver/pgbouncer_collector.go:119\ngithub.com/prometheus/client_golang/prometheus.(*Registry).Gather.func1\n\t/root/go/pkg/mod/github.com/prometheus/client_golang@v1.20.5/prometheus/registry.go:456"
}
```

```
pgbouncer=# show pools;
    database     |         user          | cl_active | cl_waiting | cl_active_cancel_req | cl_waiting_cancel_req | sv_active | sv_active_cancel | sv_being_canceled | sv_idle | sv_used | sv_tested | sv_login | maxwait | maxwait_us |  pool_mode  | load_balance_hosts
-----------------+-----------------------+-----------+------------+----------------------+-----------------------+-----------+------------------+-------------------+---------+---------+-----------+----------+---------+------------+-------------+--------------------
 test_cluster    | test_user             |        19 |          0 |                    0 |                     0 |         0 |                0 |                 0 |       3 |       5 |         0 |        0 |       0 |          0 | transaction |
 pgbouncer       | pgbouncer             |         1 |          0 |                    0 |                     0 |         0 |                0 |                 0 |       0 |       0 |         0 |        0 |       0 |          0 | statement   |
 postgres        | cnpg_pooler_pgbouncer |         0 |          0 |                    0 |                     0 |         0 |                0 |                 0 |       2 |       2 |         0 |        0 |       0 |          0 | transaction |
(3 rows)
```

Given the fact that I am using more or less standard setup, I propose to ignore the null values here instead of error.