### PR TITLE
fix(metrics): ensure WAL metrics load after instance restart

### DIFF
--- a/pkg/management/postgres/configuration.go
+++ b/pkg/management/postgres/configuration.go
@@ -83,10 +83,7 @@ func (instance *Instance) RefreshConfigurationFilesFromCluster(
 			"installing postgresql configuration: %w",
 			err)
 	}
-
-	if sha256 != "" {
-		instance.ConfigSha256 = sha256
-	}
+	instance.ConfigSha256 = sha256
 
 	return postgresConfigurationChanged, nil
 }

--- a/pkg/management/postgres/configuration.go
+++ b/pkg/management/postgres/configuration.go
@@ -84,7 +84,7 @@ func (instance *Instance) RefreshConfigurationFilesFromCluster(
 			err)
 	}
 
-	if sha256 != "" && postgresConfigurationChanged {
+	if sha256 != "" {
 		instance.ConfigSha256 = sha256
 	}
 

--- a/pkg/management/postgres/webserver/metricserver/wal.go
+++ b/pkg/management/postgres/webserver/metricserver/wal.go
@@ -73,7 +73,7 @@ type walSettings struct {
 }
 
 func (s *walSettings) synchronize(db *sql.DB, configSha256 string) error {
-	if s.configSha256 == configSha256 {
+	if s.configSha256 != "" && s.configSha256 == configSha256 {
 		return nil
 	}
 


### PR DESCRIPTION
This patch resolves an issue where WAL metrics were not available after a PostgreSQL instance restart until a configuration change occurred. The fix ensures that WAL metrics are correctly loaded upon startup.

Closes #6815

## Release notes

Fixed an issue where WAL metrics were not available after an instance restart until a configuration change was applied.