### PR TITLE
chore: introduce the `no-stale` label to issues

### DIFF
--- a/.github/workflows/close-inactive-issues.yml
+++ b/.github/workflows/close-inactive-issues.yml
@@ -21,3 +21,4 @@ jobs:
           days-before-pr-stale: -1
           days-before-pr-close: -1
           ascending: true
+          exempt-issue-labels: "no-stale"


### PR DESCRIPTION
Use the `no-stale` action to control which issues should be exempted from being considered inactive.