### PR TITLE
Fixes #6761 & #6599: Use dedicated connection pool for backups

### DIFF
--- a/pkg/management/postgres/instance.go
+++ b/pkg/management/postgres/instance.go
@@ -723,6 +723,12 @@ func (instance *Instance) GetSuperUserDB() (*sql.DB, error) {
 	return instance.ConnectionPool().Connection("postgres")
 }
 
+// GetBackgroundDB returns a connection to the instance that should be used for long running
+// background processes such as creating backups.
+func (instance *Instance) GetBackgroundDB() (*sql.DB, error) {
+	return instance.ConnectionPool().BackgroundConnection("postgres")
+}
+
 // GetTemplateDB gets a connection to the "template1" database on this instance
 func (instance *Instance) GetTemplateDB() (*sql.DB, error) {
 	return instance.ConnectionPool().Connection("template1")
@@ -902,7 +908,7 @@ func (instance *Instance) WaitForConfigReload(ctx context.Context) (*postgres.Po
 		return nil, fmt.Errorf("while waiting for new configuration to be reloaded: %w", err)
 	}
 
-	status, err := instance.GetStatus()
+	status, err := instance.GetStatus(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("while applying new configuration: %w", err)
 	}

--- a/pkg/management/postgres/instance.go
+++ b/pkg/management/postgres/instance.go
@@ -908,7 +908,7 @@ func (instance *Instance) WaitForConfigReload(ctx context.Context) (*postgres.Po
 		return nil, fmt.Errorf("while waiting for new configuration to be reloaded: %w", err)
 	}
 
-	status, err := instance.GetStatus(ctx)
+	status, err := instance.GetStatus()
 	if err != nil {
 		return nil, fmt.Errorf("while applying new configuration: %w", err)
 	}

--- a/pkg/management/postgres/probes.go
+++ b/pkg/management/postgres/probes.go
@@ -17,7 +17,6 @@ limitations under the License.
 package postgres
 
 import (
-	"context"
 	"database/sql"
 	"errors"
 	"fmt"
@@ -52,7 +51,7 @@ func (instance *Instance) IsServerHealthy() error {
 }
 
 // GetStatus Extract the status of this PostgreSQL database
-func (instance *Instance) GetStatus(ctx context.Context) (result *postgres.PostgresqlStatus, err error) {
+func (instance *Instance) GetStatus() (result *postgres.PostgresqlStatus, err error) {
 	result = &postgres.PostgresqlStatus{
 		Pod:                    &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: instance.GetPodName()}},
 		InstanceManagerVersion: versions.Version,
@@ -87,7 +86,7 @@ func (instance *Instance) GetStatus(ctx context.Context) (result *postgres.Postg
 		return result, err
 	}
 
-	row := superUserDB.QueryRowContext(ctx,
+	row := superUserDB.QueryRow(
 		`SELECT
 			(pg_control_system()).system_identifier,
 			-- True if this is a primary instance

--- a/pkg/management/postgres/probes.go
+++ b/pkg/management/postgres/probes.go
@@ -17,6 +17,7 @@ limitations under the License.
 package postgres
 
 import (
+	"context"
 	"database/sql"
 	"errors"
 	"fmt"
@@ -51,7 +52,7 @@ func (instance *Instance) IsServerHealthy() error {
 }
 
 // GetStatus Extract the status of this PostgreSQL database
-func (instance *Instance) GetStatus() (result *postgres.PostgresqlStatus, err error) {
+func (instance *Instance) GetStatus(ctx context.Context) (result *postgres.PostgresqlStatus, err error) {
 	result = &postgres.PostgresqlStatus{
 		Pod:                    &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: instance.GetPodName()}},
 		InstanceManagerVersion: versions.Version,
@@ -86,7 +87,7 @@ func (instance *Instance) GetStatus() (result *postgres.PostgresqlStatus, err er
 		return result, err
 	}
 
-	row := superUserDB.QueryRow(
+	row := superUserDB.QueryRowContext(ctx,
 		`SELECT
 			(pg_control_system()).system_identifier,
 			-- True if this is a primary instance

--- a/pkg/management/postgres/webserver/backup_connection.go
+++ b/pkg/management/postgres/webserver/backup_connection.go
@@ -104,18 +104,18 @@ func newBackupConnection(
 	immediateCheckpoint bool,
 	waitForArchive bool,
 ) (*backupConnection, error) {
-	superUserDB, err := instance.GetSuperUserDB()
+	db, err := instance.GetBackgroundDB()
 	if err != nil {
 		return nil, err
 	}
 
-	vers, err := utils.GetPgVersion(superUserDB)
+	vers, err := utils.GetPgVersion(db)
 	if err != nil {
 		return nil, err
 	}
 
 	// the context is used only while obtaining the connection
-	conn, err := superUserDB.Conn(ctx)
+	conn, err := db.Conn(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/management/postgres/webserver/remote.go
+++ b/pkg/management/postgres/webserver/remote.go
@@ -27,12 +27,10 @@ import (
 	"os"
 	"os/exec"
 	"path"
-	"time"
 
 	"github.com/cloudnative-pg/machinery/pkg/execlog"
 	"github.com/cloudnative-pg/machinery/pkg/fileutils"
 	"github.com/cloudnative-pg/machinery/pkg/log"
-	"golang.org/x/sync/singleflight"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
@@ -51,8 +49,6 @@ type remoteWebserverEndpoints struct {
 	instance         *postgres.Instance
 	currentBackup    *backupConnection
 	readinessChecker *readiness.Data
-
-	sg singleflight.Group
 }
 
 // StartBackupRequest the required data to execute the pg_start_backup
@@ -153,34 +149,13 @@ func (ws *remoteWebserverEndpoints) isServerReady(w http.ResponseWriter, r *http
 
 // This probe is for the instance status, including replication
 func (ws *remoteWebserverEndpoints) pgStatus(w http.ResponseWriter, _ *http.Request) {
-	// Extract the status of the current instance. Dedupe concurrent calls to make this cheap to
-	// call concurrently.
-	res, err, _ := ws.sg.Do("pgStatus", func() (any, error) {
-		// Use a single context here that's shared among the goroutines calling this to decouple
-		// the lifetimes.
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer cancel()
-
-		// Extract the status of the current instance
-		status, err := ws.instance.GetStatus(ctx)
-		if err != nil {
-			return nil, err
-		}
-
-		return status, nil
-	})
+	// Extract the status of the current instance
+	status, err := ws.instance.GetStatus()
 	if err != nil {
 		log.Debug(
 			"Instance status probe failing",
 			"err", err.Error())
 		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-
-	status, ok := res.(*pg.PostgresqlStatus)
-	if !ok {
-		log.Debug("got something that's not a postgres status", "got", fmt.Sprintf("%T", res))
-		http.Error(w, "unexpected status type", http.StatusInternalServerError)
 		return
 	}
 

--- a/pkg/management/postgres/webserver/remote.go
+++ b/pkg/management/postgres/webserver/remote.go
@@ -27,10 +27,12 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"time"
 
 	"github.com/cloudnative-pg/machinery/pkg/execlog"
 	"github.com/cloudnative-pg/machinery/pkg/fileutils"
 	"github.com/cloudnative-pg/machinery/pkg/log"
+	"golang.org/x/sync/singleflight"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
@@ -49,6 +51,8 @@ type remoteWebserverEndpoints struct {
 	instance         *postgres.Instance
 	currentBackup    *backupConnection
 	readinessChecker *readiness.Data
+
+	sg singleflight.Group
 }
 
 // StartBackupRequest the required data to execute the pg_start_backup
@@ -149,13 +153,34 @@ func (ws *remoteWebserverEndpoints) isServerReady(w http.ResponseWriter, r *http
 
 // This probe is for the instance status, including replication
 func (ws *remoteWebserverEndpoints) pgStatus(w http.ResponseWriter, _ *http.Request) {
-	// Extract the status of the current instance
-	status, err := ws.instance.GetStatus()
+	// Extract the status of the current instance. Dedupe concurrent calls to make this cheap to
+	// call concurrently.
+	res, err, _ := ws.sg.Do("pgStatus", func() (any, error) {
+		// Use a single context here that's shared among the goroutines calling this to decouple
+		// the lifetimes.
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		// Extract the status of the current instance
+		status, err := ws.instance.GetStatus(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		return status, nil
+	})
 	if err != nil {
 		log.Debug(
 			"Instance status probe failing",
 			"err", err.Error())
 		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	status, ok := res.(*pg.PostgresqlStatus)
+	if !ok {
+		log.Debug("got something that's not a postgres status", "got", fmt.Sprintf("%T", res))
+		http.Error(w, "unexpected status type", http.StatusInternalServerError)
 		return
 	}
 
@@ -272,6 +297,10 @@ func (ws *remoteWebserverEndpoints) backup(w http.ResponseWriter, req *http.Requ
 				log.Error(err, "while closing the body")
 			}
 		}()
+
+		// TODO: There is a race condition here: ws.currentBackup is both being read and written to in this handler, without
+		// any locking. That ain't good.
+
 		if ws.currentBackup != nil {
 			if !p.Force {
 				sendUnprocessableEntityJSONResponse(w, "PROCESS_ALREADY_RUNNING", "")

--- a/pkg/management/upgrade/upgrade.go
+++ b/pkg/management/upgrade/upgrade.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"runtime"
 	"syscall"
 
 	"github.com/cloudnative-pg/machinery/pkg/log"
@@ -69,11 +70,6 @@ func FromReader(
 				"name", updatedInstanceManager.Name(), "err", err)
 		}
 	}()
-	// Gather the status of the instance
-	instanceStatus, err := instance.GetStatus()
-	if err != nil {
-		return fmt.Errorf("while retrieving instance's status: %w", err)
-	}
 
 	// Read the new instance manager version
 	newHash, err := downloadAndCloseInstanceManagerBinary(updatedInstanceManager, r)
@@ -84,7 +80,7 @@ func FromReader(
 	// Validate the hash of this instance manager
 	if err := validateInstanceManagerHash(typedClient,
 		instance.GetClusterName(), instance.GetNamespaceName(),
-		instanceStatus.InstanceArch, newHash); err != nil {
+		runtime.GOARCH, newHash); err != nil {
 		return fmt.Errorf("while validating instance manager binary: %w", err)
 	}
 


### PR DESCRIPTION
### 🙇 Acknowledgments
Special thanks to @farhaven and nbraun from the Go Slack channel for their invaluable help.

### 🎯 Key Changes
1. Added dedicated connection pool for backups
2. Removed instance status check from upgrade endpoint
3. Improved handling of in-place upgrades

### 🔍 Problem Context
Previously, long-running backups would consume connections from the super user pool (max 3 connections) for their entire duration. This could lead to:
- Connection pool exhaustion
- Deadlocked processes requiring super user access
- Failed status probes

### ✨ Solutions
1. **Dedicated Backup Connections**
   - Separate connection pool for backups
   - Prevents backup operations from blocking critical system functions

2. **Improved Upgrade Process**
   - Removed instance status check from upgrade endpoint
   - Enables successful in-place upgrades even during connection pool exhaustion
   - Enables support for triggering in-place restart via `curl PUT` with current instance manager binary even when the super user pool is exhausted

### 🔗 Related Issues
Fixes #6599
Fixes #6761