### PR TITLE
docs: fix files names in report archive

### DIFF
--- a/docs/src/kubectl-plugin.md
+++ b/docs/src/kubectl-plugin.md
@@ -553,8 +553,8 @@ Archive:  reportRedacted.zip
   inflating: report_operator_<TIMESTAMP>/manifests/validating-webhook-configuration.yaml
   inflating: report_operator_<TIMESTAMP>/manifests/mutating-webhook-configuration.yaml
   inflating: report_operator_<TIMESTAMP>/manifests/webhook-service.yaml
-  inflating: report_operator_<TIMESTAMP>/manifests/cnpg-ca-secret.yaml
-  inflating: report_operator_<TIMESTAMP>/manifests/cnpg-webhook-cert.yaml
+  inflating: report_operator_<TIMESTAMP>/manifests/cnpg-ca-secret(secret).yaml
+  inflating: report_operator_<TIMESTAMP>/manifests/cnpg-webhook-cert(secret).yaml
 ```
 
 If you activated the `--logs` option, you'd see an extra subdirectory:
@@ -590,7 +590,7 @@ You can verify that the confidential information is REDACTED by default:
 
 ```sh
 cd report_operator_<TIMESTAMP>/manifests/
-head cnpg-ca-secret.yaml
+head cnpg-ca-secret\(secret\).yaml
 ```
 
 ```yaml
@@ -620,7 +620,7 @@ Successfully written report to "reportNonRedacted.zip" (format: "yaml")
 
 ```sh
 unzip reportNonRedacted.zip
-head cnpg-ca-secret.yaml
+head cnpg-ca-secret\(secret\).yaml
 ```
 
 ```yaml


### PR DESCRIPTION
Simple doc fix as `(secret)` is now added in two files names :

- in example's output
- in `head` commands