### PR TITLE
chore(github): mark files in `config/crd/bases` as generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+config/crd/bases/** linguist-generated=true


### PR DESCRIPTION
This lets GitHub know it should hide the diff of these files by default like it does for `api/v1/zz_generated.deepcopy.go`.

More info: https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github