### PR TITLE
test(e2e): retry failures on imperative backup

### DIFF
--- a/tests/e2e/tablespaces_test.go
+++ b/tests/e2e/tablespaces_test.go
@@ -460,14 +460,15 @@ var _ = Describe("Tablespaces tests", Label(tests.LabelTablespaces,
 
 			backupName = clusterName + pgTime.GetCurrentTimestampWithFormat("20060102150405")
 			By("creating a volumeSnapshot and waiting until it's completed", func() {
-				err := backups.CreateOnDemandBackupViaKubectlPlugin(
-					namespace,
-					clusterName,
-					backupName,
-					apiv1.BackupTargetStandby,
-					apiv1.BackupMethodVolumeSnapshot,
-				)
-				Expect(err).ToNot(HaveOccurred())
+				Eventually(func() error {
+					return backups.CreateOnDemandBackupViaKubectlPlugin(
+						namespace,
+						clusterName,
+						backupName,
+						apiv1.BackupTargetStandby,
+						apiv1.BackupMethodVolumeSnapshot,
+					)
+				}).WithTimeout(time.Minute).WithPolling(5 * time.Second).Should(Succeed())
 
 				// TODO: this is to force a CHECKPOINT when we run the backup on standby.
 				// This should probably be moved elsewhere

--- a/tests/e2e/volume_snapshot_test.go
+++ b/tests/e2e/volume_snapshot_test.go
@@ -110,14 +110,15 @@ var _ = Describe("Verify Volume Snapshot",
 			It("can create a Volume Snapshot", func() {
 				var backupObject apiv1.Backup
 				By("creating a volumeSnapshot and waiting until it's completed", func() {
-					err := backups.CreateOnDemandBackupViaKubectlPlugin(
-						namespace,
-						clusterName,
-						"",
-						apiv1.BackupTargetStandby,
-						apiv1.BackupMethodVolumeSnapshot,
-					)
-					Expect(err).ToNot(HaveOccurred())
+					Eventually(func() error {
+						return backups.CreateOnDemandBackupViaKubectlPlugin(
+							namespace,
+							clusterName,
+							"",
+							apiv1.BackupTargetStandby,
+							apiv1.BackupMethodVolumeSnapshot,
+						)
+					}).WithTimeout(time.Minute).WithPolling(5 * time.Second).Should(Succeed())
 
 					// trigger a checkpoint as the backup may run on standby
 					CheckPointAndSwitchWalOnPrimary(namespace, clusterName)


### PR DESCRIPTION
Retry backup execution through the plugin in case of a failure. Adding the retry works around short-lived network issues with the api-server.

Closes #6412 
