### PR TITLE
fix: prevent leaking connection when snapshot backup fail

### DIFF
--- a/pkg/management/postgres/webserver/backup_connection.go
+++ b/pkg/management/postgres/webserver/backup_connection.go
@@ -85,6 +85,13 @@ func (bc *backupConnection) closeConnection(backupName string) error {
 	return bc.conn.Close()
 }
 
+func (bc *backupConnection) forceCloseConnection() error {
+	bc.sync.Lock()
+	defer bc.sync.Unlock()
+
+	return bc.conn.Close()
+}
+
 func (bc *backupConnection) executeWithLock(backupName string, cb func() error) {
 	bc.sync.Lock()
 	defer bc.sync.Unlock()

--- a/pkg/management/postgres/webserver/remote.go
+++ b/pkg/management/postgres/webserver/remote.go
@@ -277,7 +277,7 @@ func (ws *remoteWebserverEndpoints) backup(w http.ResponseWriter, req *http.Requ
 				sendUnprocessableEntityJSONResponse(w, "PROCESS_ALREADY_RUNNING", "")
 				return
 			}
-			if err := ws.currentBackup.closeConnection(p.BackupName); err != nil {
+			if err := ws.currentBackup.forceCloseConnection(); err != nil {
 				if !errors.Is(err, sql.ErrConnDone) {
 					log.Error(err, "Error while closing backup connection (start)")
 				}

--- a/pkg/management/postgres/webserver/remote.go
+++ b/pkg/management/postgres/webserver/remote.go
@@ -277,6 +277,9 @@ func (ws *remoteWebserverEndpoints) backup(w http.ResponseWriter, req *http.Requ
 				sendUnprocessableEntityJSONResponse(w, "PROCESS_ALREADY_RUNNING", "")
 				return
 			}
+			log.Info("trying to close the current backup connection",
+				"backupName", ws.currentBackup.data.BackupName,
+			)
 			if err := ws.currentBackup.forceCloseConnection(); err != nil {
 				if !errors.Is(err, sql.ErrConnDone) {
 					log.Error(err, "Error while closing backup connection (start)")


### PR DESCRIPTION
The instance manager allocates a PostgreSQL connection every time a
volume snapshot backup need to be taken and then runs
`pg_backup_start` on it.  That connection will stay up until the backup
is done.

If the snapshotting process fails, the backup will be marked as failed
but the connection won't be closed.

This patch ensures that a successive backup is able to proceed correctly
by closing the previous connection.

A successive commit will allow the operator to close that stale commit
even when there's no successive backup.

Fix: #6761 

# Release notes

```
Allow the instance manager to close a stale PostgreSQL connection left by a previous
failed volume snapshot backup.
``` 