### PR TITLE
fix(backup): clean unused backup connections

### DIFF
--- a/pkg/management/postgres/webserver/remote.go
+++ b/pkg/management/postgres/webserver/remote.go
@@ -137,6 +137,12 @@ func (ws *remoteWebserverEndpoints) connectionsGarbageCollector(ctx context.Cont
 		bc.sync.Lock()
 		defer bc.sync.Unlock()
 
+		if bc.err != nil {
+			_ = bc.conn.Close()
+			bc.data.Phase = Completed
+			return
+		}
+
 		if err := bc.conn.PingContext(ctx); errors.Is(err, sql.ErrConnDone) {
 			bc.data.Phase = Completed
 			return

--- a/pkg/management/postgres/webserver/remote.go
+++ b/pkg/management/postgres/webserver/remote.go
@@ -146,6 +146,7 @@ func (ws *remoteWebserverEndpoints) connectionsGarbageCollector(ctx context.Cont
 		if err := bc.conn.PingContext(ctx); err != nil {
 			_ = bc.conn.Close()
 			bc.data.Phase = Completed
+			bc.err = fmt.Errorf("error while pinging: %w", err)
 			return
 		}
 
@@ -158,6 +159,7 @@ func (ws *remoteWebserverEndpoints) connectionsGarbageCollector(ctx context.Cont
 		if apierrs.IsNotFound(err) {
 			_ = bc.conn.Close()
 			bc.data.Phase = Completed
+			bc.err = fmt.Errorf("backup %s not found", bc.data.BackupName)
 			return
 		}
 		if err != nil {
@@ -167,6 +169,7 @@ func (ws *remoteWebserverEndpoints) connectionsGarbageCollector(ctx context.Cont
 		if backup.Status.IsDone() {
 			_ = bc.conn.Close()
 			bc.data.Phase = Completed
+			bc.err = fmt.Errorf("backup %s is done", bc.data.BackupName)
 			return
 		}
 	}

--- a/pkg/management/postgres/webserver/remote.go
+++ b/pkg/management/postgres/webserver/remote.go
@@ -143,7 +143,8 @@ func (ws *remoteWebserverEndpoints) connectionsGarbageCollector(ctx context.Cont
 			return
 		}
 
-		if err := bc.conn.PingContext(ctx); errors.Is(err, sql.ErrConnDone) {
+		if err := bc.conn.PingContext(ctx); err != nil {
+			_ = bc.conn.Close()
 			bc.data.Phase = Completed
 			return
 		}

--- a/pkg/management/postgres/webserver/webserver.go
+++ b/pkg/management/postgres/webserver/webserver.go
@@ -67,7 +67,8 @@ func (body Response[T]) EnsureDataIsPresent() error {
 
 // Webserver wraps a webserver to make it a kubernetes Runnable
 type Webserver struct {
-	server *http.Server
+	server   *http.Server
+	routines []func(ctx context.Context)
 }
 
 // NewWebServer creates a Webserver as a Kubernetes Runnable, given a http.Server
@@ -95,6 +96,13 @@ func (ws *Webserver) Start(ctx context.Context) error {
 			errChan <- err
 		}
 	}()
+
+	subCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	for _, routine := range ws.routines {
+		routine(subCtx)
+	}
 
 	select {
 	// we exit with error code, potentially we could do a retry logic, but rarely a webserver that doesn't start will run


### PR DESCRIPTION
An error while taking a snapshot backup could leave an unused connection open until the next backup. This patch ensures that backup connections are explicitly closed when no longer needed, preventing potential connection leaks.

Partially closes #6761 