### PR TITLE
chore(webserver,update): get instance architecture without using using a sql connection

### DIFF
--- a/pkg/management/postgres/instance.go
+++ b/pkg/management/postgres/instance.go
@@ -28,6 +28,7 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"time"
 
@@ -1149,6 +1150,11 @@ func (instance *Instance) GetPodName() string {
 // GetNamespaceName returns the name of the namespace where this instance is running
 func (instance *Instance) GetNamespaceName() string {
 	return instance.namespace
+}
+
+// GetArchitecture returns the runtime architecture
+func (instance *Instance) GetArchitecture() string {
+	return runtime.GOARCH
 }
 
 // RequestFastImmediateShutdown request the lifecycle manager to shut down

--- a/pkg/management/postgres/probes.go
+++ b/pkg/management/postgres/probes.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
-	"runtime"
 	"strings"
 
 	"github.com/cloudnative-pg/machinery/pkg/fileutils"
@@ -126,7 +125,7 @@ func (instance *Instance) GetStatus() (result *postgres.PostgresqlStatus, err er
 		return result, err
 	}
 
-	result.InstanceArch = runtime.GOARCH
+	result.InstanceArch = instance.GetArchitecture()
 
 	result.ExecutableHash, err = executablehash.Get()
 	if err != nil {

--- a/pkg/management/upgrade/upgrade.go
+++ b/pkg/management/upgrade/upgrade.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"runtime"
 	"syscall"
 
 	"github.com/cloudnative-pg/machinery/pkg/log"
@@ -80,7 +79,7 @@ func FromReader(
 	// Validate the hash of this instance manager
 	if err := validateInstanceManagerHash(typedClient,
 		instance.GetClusterName(), instance.GetNamespaceName(),
-		runtime.GOARCH, newHash); err != nil {
+		instance.GetArchitecture(), newHash); err != nil {
 		return fmt.Errorf("while validating instance manager binary: %w", err)
 	}
 

--- a/pkg/management/upgrade/upgrade.go
+++ b/pkg/management/upgrade/upgrade.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"runtime"
 	"syscall"
 
 	"github.com/cloudnative-pg/machinery/pkg/log"
@@ -69,11 +70,6 @@ func FromReader(
 				"name", updatedInstanceManager.Name(), "err", err)
 		}
 	}()
-	// Gather the status of the instance
-	instanceStatus, err := instance.GetStatus()
-	if err != nil {
-		return fmt.Errorf("while retrieving instance's status: %w", err)
-	}
 
 	// Read the new instance manager version
 	newHash, err := downloadAndCloseInstanceManagerBinary(updatedInstanceManager, r)
@@ -84,7 +80,7 @@ func FromReader(
 	// Validate the hash of this instance manager
 	if err := validateInstanceManagerHash(typedClient,
 		instance.GetClusterName(), instance.GetNamespaceName(),
-		instanceStatus.InstanceArch, newHash); err != nil {
+		runtime.GOARCH, newHash); err != nil {
 		return fmt.Errorf("while validating instance manager binary: %w", err)
 	}
 


### PR DESCRIPTION
# I cannot get GitHub to stop saying there's a merge commit on this branch?

This PR reduces the number of super user connections used by leveraging the Go runtime to determine the CPU architecture of the Postgres container.

**Why:**
- In the event a bug or edge case caused the super user connection pool to be exhausted, a bugfix/upgrade of the operator/instance manager would be blocked.
- This change makes it so that if the connection pool is somehow exhausted, the upgrade will not fail.
- **Running `curl -X PUT -T /controller/manager -k https://localhost:8000/update` from inside the container will cause an in-place restart (which remedies connection pool exhaustion) and other instances where the manager is in a bad state; but the Postgres instance itself is not.**
- Reducing the points of failure and connections used increases reliability.

**Helps to address/mitigate:** #6599  #6761 