### PR TITLE
docs: add doc on pgbench ttl option

### DIFF
--- a/docs/src/benchmarking.md
+++ b/docs/src/benchmarking.md
@@ -80,6 +80,7 @@ kubectl cnpg pgbench \
 
 By default, jobs do not expire. You can enable automatic deletion with the
 `--ttl` flag. The job will be deleted after the specified duration (in seconds).
+
 ```shell
 kubectl cnpg pgbench \
   --job-name pgbench-run \

--- a/docs/src/benchmarking.md
+++ b/docs/src/benchmarking.md
@@ -78,6 +78,16 @@ kubectl cnpg pgbench \
   -- --time 30 --client 1 --jobs 1
 ```
 
+By default, jobs do not expire. You can enable automatic deletion with the
+`--ttl` flag. The job will be deleted after the specified duration (in seconds).
+```shell
+kubectl cnpg pgbench \
+  --job-name pgbench-run \
+  --ttl 600 \
+  cluster-example \
+  -- --time 30 --client 1 --jobs 1
+```
+
 If you want to run a `pgbench` job on a specific worker node, you can use
 the `--node-selector` option. Suppose you want to run the previous
 initialization job on a node having the `workload=pgbench` label, you can run:

--- a/internal/cmd/plugin/pgbench/pgbench.go
+++ b/internal/cmd/plugin/pgbench/pgbench.go
@@ -62,7 +62,7 @@ var jobExample = `
   kubectl-cnpg pgbench cluster-example --db-name pgbenchDBName --job-name job-name -- \
     --time 30 --client 1 --jobs 1
 
-  # Create a job with given values on[cluster] "cluster-example". The job will be cleaned after 10 minutes.
+  # Create a job with given values on [cluster] "cluster-example". The job will be cleaned after 10 minutes.
   kubectl-cnpg pgbench cluster-example --db-name pgbenchDBName --job-name job-name --ttl 600 -- \
     --time 30 --client 1 --jobs 1`
 


### PR DESCRIPTION
This PR :

- Adds an example with --ttl option in the documentation ;
- Fixes a space typo in `pgbench.go`.

Following: #6701 