### PR TITLE
test(e2e): fix race condition in replica mode test

### DIFF
--- a/tests/e2e/replica_mode_cluster_test.go
+++ b/tests/e2e/replica_mode_cluster_test.go
@@ -226,6 +226,17 @@ var _ = Describe("Replica Mode", Label(tests.LabelReplication), func() {
 					DatabaseName: sourceDBName,
 					TableName:    "new_test_table",
 				}
+				Eventually(func() error {
+					_, err := postgres.RunExecOverForward(ctx,
+						env.Client,
+						env.Interface,
+						env.RestClientConfig,
+						namespace, clusterTwoName, sourceDBName,
+						apiv1.ApplicationUserSecretSuffix,
+						"SELECT 1;",
+					)
+					return err
+				}, testTimeouts[timeouts.Short]).Should(Succeed())
 				AssertCreateTestData(env, tableLocator)
 			})
 


### PR DESCRIPTION
Fix an issue where we could fail to connect to a newly promoted cluster if our connection happens before the password is update. This could randomly cause suite failures.

Fixes #6893 

# Release notes

```
NONE
```
