### PR TITLE
refactor(backup-client): move the backup client to the remote client

### DIFF
--- a/pkg/management/postgres/webserver/client/local/local.go
+++ b/pkg/management/postgres/webserver/client/local/local.go
@@ -24,13 +24,11 @@ import (
 
 // Client is an entity capable of interacting with the local webserver endpoints
 type Client interface {
-	Backup() BackupClient
 	Cache() CacheClient
 	Cluster() ClusterClient
 }
 
 type localClient struct {
-	backup  BackupClient
 	cache   CacheClient
 	cluster ClusterClient
 }
@@ -43,14 +41,9 @@ func NewClient() Client {
 	standardClient := common.NewHTTPClient(connectionTimeout, requestTimeout)
 
 	return &localClient{
-		backup:  &backupClientImpl{cli: standardClient},
 		cache:   &cacheClientImpl{cli: standardClient},
 		cluster: &clusterClientImpl{cli: standardClient},
 	}
-}
-
-func (c *localClient) Backup() BackupClient {
-	return c.backup
 }
 
 func (c *localClient) Cache() CacheClient {

--- a/pkg/management/postgres/webserver/client/remote/backup.go
+++ b/pkg/management/postgres/webserver/client/remote/backup.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package local
+package remote
 
 import (
 	"bytes"
@@ -26,7 +26,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres/webserver"
-	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres/webserver/client/remote"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/url"
 )
 
@@ -56,7 +55,7 @@ func (c *backupClientImpl) StatusWithErrors(
 	ctx context.Context,
 	pod *corev1.Pod,
 ) (*webserver.Response[webserver.BackupResultData], error) {
-	scheme := remote.GetStatusSchemeFromPod(pod)
+	scheme := GetStatusSchemeFromPod(pod)
 	httpURL := url.Build(scheme.ToString(), pod.Status.PodIP, url.PathPgModeBackup, url.StatusPort)
 	req, err := http.NewRequestWithContext(ctx, "GET", httpURL, nil)
 	if err != nil {
@@ -72,7 +71,7 @@ func (c *backupClientImpl) Start(
 	pod *corev1.Pod,
 	sbq webserver.StartBackupRequest,
 ) (*webserver.Response[webserver.BackupResultData], error) {
-	scheme := remote.GetStatusSchemeFromPod(pod)
+	scheme := GetStatusSchemeFromPod(pod)
 	httpURL := url.Build(scheme.ToString(), pod.Status.PodIP, url.PathPgModeBackup, url.StatusPort)
 
 	// Marshalling the payload to JSON
@@ -96,7 +95,7 @@ func (c *backupClientImpl) Stop(
 	pod *corev1.Pod,
 	sbq webserver.StopBackupRequest,
 ) (*webserver.Response[webserver.BackupResultData], error) {
-	scheme := remote.GetStatusSchemeFromPod(pod)
+	scheme := GetStatusSchemeFromPod(pod)
 	httpURL := url.Build(scheme.ToString(), pod.Status.PodIP, url.PathPgModeBackup, url.StatusPort)
 	// Marshalling the payload to JSON
 	jsonBody, err := json.Marshal(sbq)

--- a/pkg/management/postgres/webserver/client/remote/instance.go
+++ b/pkg/management/postgres/webserver/client/remote/instance.go
@@ -34,7 +34,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
 
-	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres/webserver/client/common"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/url"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/postgres"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/specs"
@@ -95,14 +94,6 @@ type StatusError struct {
 
 func (i StatusError) Error() string {
 	return fmt.Sprintf("error status code: %v, body: %v", i.StatusCode, i.Body)
-}
-
-// newInstanceClient returns a client capable of querying the instance HTTP endpoints
-func newInstanceClient() InstanceClient {
-	const connectionTimeout = 2 * time.Second
-	const requestTimeout = 10 * time.Second
-
-	return &instanceClientImpl{Client: common.NewHTTPClient(connectionTimeout, requestTimeout)}
 }
 
 // extractInstancesStatus extracts the status of the underlying PostgreSQL instance from

--- a/pkg/management/postgres/webserver/client/remote/request.go
+++ b/pkg/management/postgres/webserver/client/remote/request.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package local
+package remote
 
 import (
 	"context"
@@ -28,6 +28,7 @@ import (
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres/webserver"
 )
 
+// executeRequestWithError executes an http request and returns a webserver.response and any error encountered
 func executeRequestWithError[T any](
 	ctx context.Context,
 	cli *http.Client,

--- a/pkg/reconciler/backup/volumesnapshot/online.go
+++ b/pkg/reconciler/backup/volumesnapshot/online.go
@@ -26,15 +26,15 @@ import (
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres/webserver"
-	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres/webserver/client/local"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres/webserver/client/remote"
 )
 
 type onlineExecutor struct {
-	backupClient local.BackupClient
+	backupClient remote.BackupClient
 }
 
 func newOnlineExecutor() *onlineExecutor {
-	return &onlineExecutor{backupClient: local.NewClient().Backup()}
+	return &onlineExecutor{backupClient: remote.NewClient().Backup()}
 }
 
 func (o *onlineExecutor) finalize(


### PR DESCRIPTION
Previously, the backup client was incorrectly included in the local client, as the backup endpoints are exposed on the remote web server.
