### PR TITLE
test(e2e,snapshot): disable wait for archive for primary

### DIFF
--- a/tests/e2e/fixtures/volume_snapshot/declarative-backup-on-primary.yaml.template
+++ b/tests/e2e/fixtures/volume_snapshot/declarative-backup-on-primary.yaml.template
@@ -7,3 +7,4 @@ spec:
   target: primary
   cluster:
     name: cluster-declarative-backup
+  waitForArchive: false


### PR DESCRIPTION
Disables the waitForArchive flag in the E2e tests of Volume Snapshot backups, where the
primary is explicitely chosen.

Since the target cluster have no workload, no WAL segment will be generated and this makes
the E2e fail after 5 minutes of timeout. Note: archive_timeout is set to 5 minutes too.

Fix: #6917 

# Release notes

```
NONE
```