### PR TITLE
feat: 5299 check for nodes drain tainted by well known autoscalers

### DIFF
--- a/internal/controller/cluster_predicates.go
+++ b/internal/controller/cluster_predicates.go
@@ -74,7 +74,7 @@ var (
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			oldNode, oldOk := e.ObjectOld.(*corev1.Node)
 			newNode, newOk := e.ObjectNew.(*corev1.Node)
-			return oldOk && newOk && oldNode.Spec.Unschedulable != newNode.Spec.Unschedulable
+			return oldOk && newOk && hasDrainTaints(oldNode) != hasDrainTaints(newNode)
 		},
 		CreateFunc: func(_ event.CreateEvent) bool {
 			return false
@@ -99,4 +99,13 @@ func isOwnedByClusterOrSatisfiesPredicate(
 func hasReloadLabelSet(obj client.Object) bool {
 	_, hasLabel := obj.GetLabels()[utils.WatchedLabelName]
 	return hasLabel
+}
+
+func hasDrainTaints(node *corev1.Node) bool {
+	for _, taint := range node.Spec.Taints {
+		if _, ok := drainTaints[taint.Key]; ok {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/controller/replicas.go
+++ b/internal/controller/replicas.go
@@ -173,7 +173,7 @@ func (r *ClusterReconciler) isNodeUnschedulable(ctx context.Context, nodeName st
 	if err != nil {
 		return false, err
 	}
-	return node.Spec.Unschedulable, nil
+	return hasDrainTaints(&node), nil
 }
 
 // Pick the next primary on a schedulable node, if the current is running on an unschedulable one,

--- a/tests/e2e/fixtures/drain-node/cluster-drain-node-autoscaler.yaml.template
+++ b/tests/e2e/fixtures/drain-node/cluster-drain-node-autoscaler.yaml.template
@@ -1,0 +1,33 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: cluster-drain-node-autoscaler
+spec:
+  instances: 3
+
+  affinity:
+      nodeSelector:
+        drain: 'drain'
+
+  postgresql:
+    parameters:
+      log_checkpoints: "on"
+      log_lock_waits: "on"
+      log_min_duration_statement: '1000'
+      log_statement: 'ddl'
+      log_temp_files: '1024'
+      log_autovacuum_min_duration: '1s'
+      log_replication_commands: 'on'
+      wal_receiver_timeout: '2s'
+
+  bootstrap:
+    initdb:
+      database: app
+      owner: appuser
+
+  storage:
+    size: 1Gi
+    storageClass: ${E2E_DEFAULT_STORAGE_CLASS}
+  walStorage:
+    storageClass: ${E2E_DEFAULT_STORAGE_CLASS}
+    size: 1Gi

--- a/tests/e2e/fixtures/drain-node/cluster-drain-node-karpenter.yaml.template
+++ b/tests/e2e/fixtures/drain-node/cluster-drain-node-karpenter.yaml.template
@@ -1,0 +1,33 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: cluster-drain-node-karpenter
+spec:
+  instances: 3
+
+  affinity:
+      nodeSelector:
+        drain: 'drain'
+
+  postgresql:
+    parameters:
+      log_checkpoints: "on"
+      log_lock_waits: "on"
+      log_min_duration_statement: '1000'
+      log_statement: 'ddl'
+      log_temp_files: '1024'
+      log_autovacuum_min_duration: '1s'
+      log_replication_commands: 'on'
+      wal_receiver_timeout: '2s'
+
+  bootstrap:
+    initdb:
+      database: app
+      owner: appuser
+
+  storage:
+    size: 1Gi
+    storageClass: ${E2E_DEFAULT_STORAGE_CLASS}
+  walStorage:
+    storageClass: ${E2E_DEFAULT_STORAGE_CLASS}
+    size: 1Gi


### PR DESCRIPTION
Allows the controller to detect all well-known k8 autoscaler taints instead of only relying on `node.Spec.Unschedulable`

Fixes #5299 
Supercedes #6794