### PR TITLE
ci: fix regexp to retrieve EKS versions

### DIFF
--- a/.github/workflows/k8s-versions-check.yml
+++ b/.github/workflows/k8s-versions-check.yml
@@ -43,7 +43,7 @@ jobs:
         name: Get updated EKS versions
         run: |
           DOC_URL="https://raw.githubusercontent.com/awsdocs/amazon-eks-user-guide/mainline/latest/ug/clusters/kubernetes-versions-standard.adoc"
-          curl --silent "${DOC_URL}" | sed -e 's/.*`Kubernetes` \([0-9].[0-9][0-9]\).*/\1/;/^[0-9]\./!d' | uniq | \
+          curl --silent "${DOC_URL}" | sed -e 's/.*Kubernetes \([0-9].[0-9][0-9]\).*/\1/;/^[0-9]\./!d' | uniq | \
             awk -vv=$MINIMAL_K8S '$0>=v {print $0}' | \
             jq -Rn '[inputs]' | tee .github/eks_versions.json
         if: github.event.inputs.limit == null || github.event.inputs.limit == 'eks'


### PR DESCRIPTION
The EKS documentation page changed the formatting of the version list,
this patch changes our detection code to work with the new format.