### PR TITLE
chore: enable unit tests on Kubernetes 1.32

### DIFF
--- a/.github/k8s_versions_scope.json
+++ b/.github/k8s_versions_scope.json
@@ -1,10 +1,10 @@
 {
   "e2e_test": {
     "KIND": {"min": "1.27", "max": ""},
-    "AKS": {"min": "1.27", "max": ""},
-    "EKS": {"min": "1.27", "max": ""},
-    "GKE": {"min": "1.27", "max": ""},
+    "AKS": {"min": "1.28", "max": ""},
+    "EKS": {"min": "1.29", "max": ""},
+    "GKE": {"min": "1.29", "max": ""},
     "OPENSHIFT": {"min":  "4.12", "max": ""}
   },
-  "unit_test": {"min":  "1.27", "max":  "1.31"}
+  "unit_test": {"min":  "1.27", "max":  "1.32"}
 }


### PR DESCRIPTION
Also, update the min versions for GKE, AKS and EKS