### PR TITLE
docs: streamline documentation on failure modes

### DIFF
--- a/.wordlist-en-custom.txt
+++ b/.wordlist-en-custom.txt
@@ -1,4 +1,3 @@
-tolerationSeconds
 AES
 API's
 APIs
@@ -1329,6 +1328,7 @@ timeoutSeconds
 tls
 tmp
 tmpfs
+tolerationSeconds
 tolerations
 topologies
 topologyKey

--- a/.wordlist-en-custom.txt
+++ b/.wordlist-en-custom.txt
@@ -1,3 +1,4 @@
+tolerationSeconds
 AES
 API's
 APIs

--- a/.wordlist-en-custom.txt
+++ b/.wordlist-en-custom.txt
@@ -1328,7 +1328,6 @@ timeoutSeconds
 tls
 tmp
 tmpfs
-tolerationSeconds
 tolerations
 topologies
 topologyKey

--- a/docs/src/failure_modes.md
+++ b/docs/src/failure_modes.md
@@ -12,40 +12,27 @@ PostgreSQL can face on a Kubernetes cluster during its lifetime.
     for more information the liveness and readiness probes implemented by
     CloudNativePG.
 
-## Storage space usage
+## Storage Space Usage
 
-The operator will instantiate one PVC for every PostgreSQL instance to store the `PGDATA` content.
-A second PVC dedicated to the WAL storage will be provisioned in case `.spec.walStorage` is
-specified during cluster initialization.
+The operator provisions a Persistent Volume Claim (PVC) for each PostgreSQL
+instance to store `PGDATA`. If `.spec.walStorage` is defined during cluster
+initialization, an additional PVC is created for WAL storage. Likewise, extra
+PVCs are provisioned for any tablespaces specified in `.spec.tablespaces`.
 
-Such storage space is set for reuse in two cases:
+Storage reuse occurs in two scenarios:
 
-- when the corresponding Pod is deleted by the user (and a new Pod will be recreated)
-- when the corresponding Pod is evicted and scheduled on another node
+- When a Pod is deleted by the user, triggering its automatic recreation.
+- When a Pod is evicted.
 
-If you want to prevent the operator from reusing a certain PVC you need to
-remove the PVC before deleting the Pod. For this purpose, you can use the
-following command:
-
-```sh
-kubectl delete -n [namespace] pvc/[cluster-name]-[serial] pod/[cluster-name]-[serial]
-```
-
-!!! Note
-    If you specified a dedicated WAL volume, it will also have to be deleted during this process.
+To prevent the operator from reusing a specific PVC group, delete it before
+removing the associated Pod. Use the following command:
 
 ```sh
-kubectl delete -n [namespace] pvc/[cluster-name]-[serial] pvc/[cluster-name]-[serial]-wal pod/[cluster-name]-[serial]
+kubectl cnpg destroy -n [namespace] [cluster-name] [serial]
 ```
 
-For example:
-
-```sh
-$ kubectl delete -n default pvc/cluster-example-1 pvc/cluster-example-1-wal pod/cluster-example-1
-persistentvolumeclaim "cluster-example-1" deleted
-persistentvolumeclaim "cluster-example-1-wal" deleted
-pod "cluster-example-1" deleted
-```
+For more information, please refer to the
+[`destroy` command of the `cnpg` plugin for `kubectl`](kubectl-plugin.md#destroy).
 
 ## Failure modes
 

--- a/docs/src/failure_modes.md
+++ b/docs/src/failure_modes.md
@@ -88,22 +88,21 @@ kubectl delete pod [primary pod] --grace-period=1
 
 ### Liveness Probe Failure
 
-By default, after three consecutive liveness probe failures, the `postgres`
-container will be considered failed. The Pod will remain part of the `Cluster`,
-but the *kubelet* will attempt to restart the failed container. If the issue
-causing the failure persists and cannot be resolved, you can manually delete
-the Pod.
-
-In both cases, self-healing occurs automatically once the underlying issues are
-resolved.
+If the [liveness probe](instance_manager.md#liveness-probe) fails, the
+`postgres` container is marked as failed. The Pod remains part of the
+`Cluster`, but the *kubelet* will attempt to restart the container.
+If the failure persists and cannot be resolved, you may manually delete the
+Pod.
+In both cases, the system will automatically recover once the underlying issue
+is fixed.
 
 ### Readiness Probe Failure
 
-By default, after three consecutive readiness probe failures, the Pod will be
-marked as *not ready*. It will remain part of the `Cluster`, and no new Pod
-will be created. If the issue causing the failure cannot be resolved, you can
-manually delete the Pod. Once the failure is addressed, the Pod will
-automatically regain its previous role.
+If the [readiness probe](instance_manager.md#readiness-probe) fails, the Pod is
+marked as *not ready* but remains part of the `Cluster`. No new Pod will be
+created.
+If the issue persists, you may manually delete the Pod. Once resolved, the Pod
+will automatically resume its previous role.
 
 ### Worker node drained
 

--- a/docs/src/failure_modes.md
+++ b/docs/src/failure_modes.md
@@ -186,7 +186,7 @@ This command ensures that all necessary resources associated with the
 instance are properly removed before the operator provisions a new
 instance on a healthy node.
 
-After destroying the instance, verify that the CloudNativePG operator
+After destroying the instance, verify that the operator
 properly registers the instance removal and provisions a new
 replacement instance on a healthy node. Use the following command to
 monitor the instance creation process:
@@ -205,7 +205,7 @@ Volume Claims (PVCs) and the Pod associated with the instance using
 kubectl delete pvc,pod -n <namespace> -l cnpg.io/instanceName=<instance-name> --force --grace-period=0
 ```
 
-After destroying the instance, verify that the CloudNativePG operator
+After destroying the instance, verify that the operator
 properly registers the instance removal and provisions a new
 replacement instance on a healthy node. Use the following command to
 monitor the instance creation process:

--- a/docs/src/failure_modes.md
+++ b/docs/src/failure_modes.md
@@ -139,8 +139,7 @@ Self-healing will happen as soon as the *apiserver* is notified.
 When a worker node fails, the *kubelet* stops executing the liveness
 and readiness probes. The affected pod will be marked for deletion
 after the *tolerationSeconds* period configured by the Kubernetes
-cluster administrator for that specific failure cause. Depending on
-the cluster configuration, the pod might be removed earlier.
+cluster administrator for that specific failure cause.
 
 When a worker node fails unexpectedly, the priority should be
 to assess whether recovery is feasible, or if the node should be
@@ -173,7 +172,7 @@ operator can properly initialize a new instance on another available
 node. Alternatively, the [kubectl plugin's destroy](kubectl-plugin.md#destroy)
 command can simplify this process.
 
-### Using the Plugin to Destroy an Instance
+#### Using the Plugin to Destroy an Instance
 
 The [`kubectl-cnpg`](kubectl-plugin.md) plugin provides a convenient way to
 safely destroy an instance. Run the following command:
@@ -195,7 +194,7 @@ monitor the instance creation process:
 kubectl cnpg status -n <namespace> <cluster-name>
 ```
 
-### Manually Destroying an Instance
+#### Manually Destroying an Instance
 
 If the plugin is not available, you can manually remove the Persistent
 Volume Claims (PVCs) and the Pod associated with the instance using

--- a/docs/src/failure_modes.md
+++ b/docs/src/failure_modes.md
@@ -140,11 +140,10 @@ When a worker node fails, the *kubelet* stops executing the liveness
 and readiness probes. The affected pod will be marked for deletion
 after the *tolerationSeconds* period configured by the Kubernetes
 cluster administrator for that specific failure cause. Depending on
-the cluster configuration, the pod might be removed from the service
-earlier.
+the cluster configuration, the pod might be removed earlier.
 
-When an unplanned worker node failure occurs, the priority should be
-to assess whether recovery is feasible or if the node should be
+When a worker node fails unexpectedly, the priority should be
+to assess whether recovery is feasible, or if the node should be
 replaced. In most cases, especially if the data volumes are not
 located on the node, replacing the node is the preferred
 approach. Before proceeding with any action, ensure that the
@@ -158,7 +157,7 @@ delete the node from the cluster and provision a new one.
 
     `kubectl delete pod <pod-name> --force --grace-period=0 -n <namespace>`
 
-    However, this simply makes Kubernetes forget about the pod, so you
+    Note that this simply makes Kubernetes stop tracking the pod, so you
     must be certain that the underlying container is not running anymore.
 
 If the storage class used by the instance volumes is not node-bound,
@@ -167,17 +166,17 @@ storage is node-bound (e.g., using local persistent volumes),
 additional steps are required to allow the operator to create a new
 instance on the newly provisioned hardware.
 
-For example, if a PostgreSQL instance was running on a failed node
-using a local persistent volume, administrators must remove all
-associated Persistent Volume Claims (PVCs) and the Pod to ensure the
+For example, if a PostgreSQL instance using a local persistent volume
+was running on a failed node, administrators must remove the Pod
+and all associated Persistent Volume Claims (PVCs), to ensure the
 operator can properly initialize a new instance on another available
-node. Alternatively, the plugin's `destroy` command can simplify this
-process.
+node. Alternatively, the [kubectl plugin's destroy](kubectl-plugin.md#destroy)
+command can simplify this process.
 
 ### Using the Plugin to Destroy an Instance
 
-The `kubectl-cnpg` plugin provides a convenient way to safely destroy
-an instance. Run the following command:
+The [`kubectl-cnpg`](kubectl-plugin.md) plugin provides a convenient way to
+safely destroy an instance. Run the following command:
 
 ```sh
 kubectl cnpg destroy -n <namespace> <cluster-name> <instance-name>
@@ -187,7 +186,7 @@ This command ensures that all necessary resources associated with the
 instance are properly removed before the operator provisions a new
 instance on a healthy node.
 
-After destroying the instance, verify that the PostgreSQL operator
+After destroying the instance, verify that the CloudNativePG operator
 properly registers the instance removal and provisions a new
 replacement instance on a healthy node. Use the following command to
 monitor the instance creation process:
@@ -206,7 +205,7 @@ Volume Claims (PVCs) and the Pod associated with the instance using
 kubectl delete pvc,pod -n <namespace> -l cnpg.io/instanceName=<instance-name> --force --grace-period=0
 ```
 
-After destroying the instance, verify that the PostgreSQL operator
+After destroying the instance, verify that the CloudNativePG operator
 properly registers the instance removal and provisions a new
 replacement instance on a healthy node. Use the following command to
 monitor the instance creation process:

--- a/docs/src/failure_modes.md
+++ b/docs/src/failure_modes.md
@@ -39,8 +39,6 @@ For more information, please refer to the
 A pod belonging to a `Cluster` can fail in the following ways:
 
 * the pod is explicitly deleted by the user;
-* the readiness probe on its `postgres` container fails;
-* the liveness probe on its `postgres` container fails;
 * the Kubernetes worker node is drained;
 * the Kubernetes worker node where the pod is scheduled fails.
 
@@ -86,39 +84,15 @@ kubectl delete pod [primary pod] --grace-period=1
     triggers a failover promoting the most aligned standby, without
     the guarantee that the primary had been shut down.
 
-### Liveness Probe Failure
+### Worker Node Drained
 
-If the [liveness probe](instance_manager.md#liveness-probe) fails, the
-`postgres` container is marked as failed. The Pod remains part of the
-`Cluster`, but the *kubelet* will attempt to restart the container.
-If the failure persists and cannot be resolved, you may manually delete the
-Pod.
-In both cases, the system will automatically recover once the underlying issue
-is fixed.
-
-### Readiness Probe Failure
-
-If the [readiness probe](instance_manager.md#readiness-probe) fails, the Pod is
-marked as *not ready* but remains part of the `Cluster`. No new Pod will be
-created.
-If the issue persists, you may manually delete the Pod. Once resolved, the Pod
-will automatically resume its previous role.
-
-### Worker node drained
-
-The pod will be evicted from the worker node and removed from the service. A
-new pod will be created on a different worker node from a physical backup of the
-*primary* if the `reusePVC` option of the `nodeMaintenanceWindow` parameter
-is set to `off` (default: `on` during maintenance windows, `off` otherwise).
-
-The `PodDisruptionBudget` may prevent the pod from being evicted if there
-is at least another pod that is not ready.
+If a worker node is drained, the Pod will be evicted and removed from the
+service, provided the `PodDisruptionBudget` allows it.
 
 !!! Note
-    Single instance clusters prevent node drain when `reusePVC` is
-    set to `false`. Refer to the [Kubernetes Upgrade section](kubernetes_upgrade.md).
-
-Self-healing will happen as soon as the *apiserver* is notified.
+    Single-instance clusters prevent node draining by default. See the
+    ["Kubernetes Upgrade" section](kubernetes_upgrade.md#postgresql-clusters-used-for-development-or-testing)
+    for details.
 
 ### Worker Node Failure
 


### PR DESCRIPTION
This page included specific failure scenarios. Since these largely follow standard Kubernetes behavior, we have streamlined the content to avoid duplication of information that belongs to the underlying Kubernetes stack and is not specific to CloudNativePG.