### PR TITLE
docs(k9s): do not use bashisms in k9s integration sample

### DIFF
--- a/docs/src/samples/k9s/plugins.yml
+++ b/docs/src/samples/k9s/plugins.yml
@@ -26,7 +26,7 @@ plugins:
     background: false
     args:
       - -c
-      - "kubectl cnpg backup $NAME -n $NAMESPACE --context \"$CONTEXT\" |& less -R"
+      - "kubectl cnpg backup $NAME -n $NAMESPACE --context \"$CONTEXT\" 2>&1 | less -R"
   cnpg-hibernate-status:
     shortCut: h
     description: Hibernate status
@@ -36,7 +36,7 @@ plugins:
     background: false
     args:
       - -c
-      - "kubectl cnpg hibernate status $NAME -n $NAMESPACE --context \"$CONTEXT\" |& less -R"
+      - "kubectl cnpg hibernate status $NAME -n $NAMESPACE --context \"$CONTEXT\" 2>&1 | less -R"
   cnpg-hibernate:
     shortCut: Shift-H
     description: Hibernate
@@ -47,7 +47,7 @@ plugins:
     background: false
     args:
       - -c
-      - "kubectl cnpg hibernate on $NAME -n $NAMESPACE --context \"$CONTEXT\" |& less -R"
+      - "kubectl cnpg hibernate on $NAME -n $NAMESPACE --context \"$CONTEXT\" 2>&1 | less -R"
   cnpg-hibernate-off:
     shortCut: Shift-H
     description: Wake up hibernated cluster in this namespace
@@ -58,7 +58,7 @@ plugins:
     background: false
     args:
       - -c
-      - "kubectl cnpg hibernate off $NAME -n $NAME --context \"$CONTEXT\" |& less -R"
+      - "kubectl cnpg hibernate off $NAME -n $NAME --context \"$CONTEXT\" 2>&1 | less -R"
   cnpg-logs:
     shortCut: l
     description: Logs
@@ -89,7 +89,7 @@ plugins:
     background: false
     args:
       - -c
-      - "kubectl cnpg reload $NAME -n $NAMESPACE --context \"$CONTEXT\" |& less -R"
+      - "kubectl cnpg reload $NAME -n $NAMESPACE --context \"$CONTEXT\" 2>&1 | less -R"
   cnpg-restart:
     shortCut: Shift-R
     description: Restart
@@ -100,7 +100,7 @@ plugins:
     background: false
     args:
       - -c
-      - "kubectl cnpg restart $NAME -n $NAMESPACE --context \"$CONTEXT\" |& less -R"
+      - "kubectl cnpg restart $NAME -n $NAMESPACE --context \"$CONTEXT\" 2>&1 | less -R"
   cnpg-status:
     shortCut: s
     description: Status
@@ -110,7 +110,7 @@ plugins:
     background: false
     args:
       - -c
-      - "kubectl cnpg status $NAME -n $NAMESPACE --context \"$CONTEXT\" |& less -R"
+      - "kubectl cnpg status $NAME -n $NAMESPACE --context \"$CONTEXT\" 2>&1 | less -R"
   cnpg-status-verbose:
     shortCut: Shift-S
     description: Status (verbose)
@@ -120,4 +120,4 @@ plugins:
     background: false
     args:
       - -c
-      - "kubectl cnpg status $NAME -n $NAMESPACE --context \"$CONTEXT\" --verbose |& less -R"
+      - "kubectl cnpg status $NAME -n $NAMESPACE --context \"$CONTEXT\" --verbose 2>&1 | less -R"


### PR DESCRIPTION
Replace bash-specific syntax with POSIX-compatible commands in the k9s integration sample,
improving portability across different shell environments.

Fixes #6958 