### PR TITLE
test: fix tests remaining stuck waiting for portforward

### DIFF
--- a/tests/utils/forwardconnection/forwardconnection.go
+++ b/tests/utils/forwardconnection/forwardconnection.go
@@ -127,6 +127,9 @@ func (fc *ForwardConnection) StartAndWait() error {
 			return
 		}
 	}()
+	if err != nil {
+		return fmt.Errorf("error starting port-forward: %w", err)
+	}
 	select {
 	case <-fc.readyChannel:
 		ginkgo.GinkgoWriter.Println("port-forward ready")


### PR DESCRIPTION
Error out if ForwardPorts exists with error, instead of going into a blocking select.

Closes #6985
