### PR TITLE
test: simplify test depth code

### DIFF
--- a/tests/e2e/affinity_test.go
+++ b/tests/e2e/affinity_test.go
@@ -38,7 +38,7 @@ var _ = Describe("E2E Affinity", Serial, Label(tests.LabelPodScheduling), func()
 	var err error
 
 	BeforeEach(func() {
-		if testLevelEnv.Depth < int(level) {
+		if testLevel < int(level) {
 			Skip("Test depth is lower than the amount requested for this test")
 		}
 	})

--- a/tests/e2e/apparmor_test.go
+++ b/tests/e2e/apparmor_test.go
@@ -40,7 +40,7 @@ var _ = Describe("AppArmor support", Serial, Label(tests.LabelNoOpenshift, tests
 	var namespace string
 
 	BeforeEach(func() {
-		if testLevelEnv.Depth < int(level) {
+		if testLevel < int(level) {
 			Skip("Test depth is lower than the amount requested for this test")
 		}
 		if !MustGetEnvProfile().CanRunAppArmor() {

--- a/tests/e2e/architecture_test.go
+++ b/tests/e2e/architecture_test.go
@@ -35,7 +35,7 @@ var _ = Describe("Available Architectures", Label(tests.LabelBasic), func() {
 	)
 
 	BeforeEach(func() {
-		if testLevelEnv.Depth < int(level) {
+		if testLevel < int(level) {
 			Skip("Test depth is lower than the amount requested for this test")
 		}
 	})

--- a/tests/e2e/backup_restore_azure_test.go
+++ b/tests/e2e/backup_restore_azure_test.go
@@ -40,7 +40,7 @@ var _ = Describe("Azure - Backup and restore", Label(tests.LabelBackupRestore), 
 	AzureConfiguration := backups.NewAzureConfigurationFromEnv()
 
 	BeforeEach(func() {
-		if testLevelEnv.Depth < int(tests.High) {
+		if testLevel < int(tests.High) {
 			Skip("Test depth is lower than the amount requested for this test")
 		}
 		if !IsAKS() {
@@ -220,7 +220,7 @@ var _ = Describe("Azure - Clusters Recovery From Barman Object Store", Label(tes
 	AzureConfiguration := backups.NewAzureConfigurationFromEnv()
 
 	BeforeEach(func() {
-		if testLevelEnv.Depth < int(level) {
+		if testLevel < int(level) {
 			Skip("Test depth is lower than the amount requested for this test")
 		}
 		if !IsAKS() {

--- a/tests/e2e/backup_restore_azurite_test.go
+++ b/tests/e2e/backup_restore_azurite_test.go
@@ -38,7 +38,7 @@ var _ = Describe("Azurite - Backup and restore", Label(tests.LabelBackupRestore)
 		azuriteBlobSampleFile = fixturesDir + "/backup/azurite/cluster-backup.yaml.template"
 	)
 	BeforeEach(func() {
-		if testLevelEnv.Depth < int(tests.High) {
+		if testLevel < int(tests.High) {
 			Skip("Test depth is lower than the amount requested for this test")
 		}
 

--- a/tests/e2e/backup_restore_minio_test.go
+++ b/tests/e2e/backup_restore_minio_test.go
@@ -45,7 +45,7 @@ var _ = Describe("MinIO - Backup and restore", Label(tests.LabelBackupRestore), 
 		barmanCloudBackupLogEntry = "Starting barman-cloud-backup"
 	)
 	BeforeEach(func() {
-		if testLevelEnv.Depth < int(tests.High) {
+		if testLevel < int(tests.High) {
 			Skip("Test depth is lower than the amount requested for this test")
 		}
 	})
@@ -564,7 +564,7 @@ var _ = Describe("MinIO - Clusters Recovery from Barman Object Store", Label(tes
 		tableName                       = "to_restore"
 	)
 	BeforeEach(func() {
-		if testLevelEnv.Depth < int(tests.High) {
+		if testLevel < int(tests.High) {
 			Skip("Test depth is lower than the amount requested for this test")
 		}
 	})

--- a/tests/e2e/certificates_test.go
+++ b/tests/e2e/certificates_test.go
@@ -151,7 +151,7 @@ var _ = Describe("Certificates", func() {
 		level                           = tests.Low
 	)
 	BeforeEach(func() {
-		if testLevelEnv.Depth < int(level) {
+		if testLevel < int(level) {
 			Skip("Test depth is lower than the amount requested for this test")
 		}
 	})

--- a/tests/e2e/cluster_microservice_test.go
+++ b/tests/e2e/cluster_microservice_test.go
@@ -57,7 +57,7 @@ var _ = Describe("Imports with Microservice Approach", Label(tests.LabelImportin
 	var namespace, sourceClusterName, importedClusterName string
 
 	BeforeEach(func() {
-		if testLevelEnv.Depth < int(level) {
+		if testLevel < int(level) {
 			Skip("Test depth is lower than the amount requested for this test")
 		}
 	})

--- a/tests/e2e/cluster_monolithic_test.go
+++ b/tests/e2e/cluster_monolithic_test.go
@@ -59,7 +59,7 @@ var _ = Describe("Imports with Monolithic Approach", Label(tests.LabelImportingD
 	var connTarget *sql.DB
 
 	BeforeEach(func() {
-		if testLevelEnv.Depth < int(level) {
+		if testLevel < int(level) {
 			Skip("Test depth is lower than the amount requested for this test")
 		}
 	})

--- a/tests/e2e/cluster_setup_test.go
+++ b/tests/e2e/cluster_setup_test.go
@@ -45,7 +45,7 @@ var _ = Describe("Cluster setup", Label(tests.LabelSmoke, tests.LabelBasic), fun
 	var namespace string
 
 	BeforeEach(func() {
-		if testLevelEnv.Depth < int(level) {
+		if testLevel < int(level) {
 			Skip("Test depth is lower than the amount requested for this test")
 		}
 	})

--- a/tests/e2e/config_support_test.go
+++ b/tests/e2e/config_support_test.go
@@ -47,7 +47,7 @@ var _ = Describe("Config support", Serial, Ordered, Label(tests.LabelDisruptive,
 	var operatorNamespace, namespace string
 
 	BeforeEach(func() {
-		if testLevelEnv.Depth < int(level) {
+		if testLevel < int(level) {
 			Skip("Test depth is lower than the amount requested for this test")
 		}
 

--- a/tests/e2e/configuration_update_test.go
+++ b/tests/e2e/configuration_update_test.go
@@ -138,7 +138,7 @@ var _ = Describe("Configuration update", Ordered, Label(tests.LabelClusterMetada
 	}
 
 	BeforeAll(func() {
-		if testLevelEnv.Depth < int(level) {
+		if testLevel < int(level) {
 			Skip("Test depth is lower than the amount requested for this test")
 		}
 
@@ -470,7 +470,7 @@ var _ = Describe("Configuration update with primaryUpdateMethod", Label(tests.La
 	const level = tests.High
 
 	BeforeEach(func() {
-		if testLevelEnv.Depth < int(level) {
+		if testLevel < int(level) {
 			Skip("Test depth is lower than the amount requested for this test")
 		}
 	})

--- a/tests/e2e/connection_test.go
+++ b/tests/e2e/connection_test.go
@@ -41,7 +41,7 @@ var _ = Describe("Connection via services", Label(tests.LabelServiceConnectivity
 	)
 
 	BeforeEach(func() {
-		if testLevelEnv.Depth < int(level) {
+		if testLevel < int(level) {
 			Skip("Test depth is lower than the amount requested for this test")
 		}
 	})

--- a/tests/e2e/declarative_database_management_test.go
+++ b/tests/e2e/declarative_database_management_test.go
@@ -46,7 +46,7 @@ var _ = Describe("Declarative database management", Label(tests.LabelSmoke, test
 	)
 
 	BeforeEach(func() {
-		if testLevelEnv.Depth < int(level) {
+		if testLevel < int(level) {
 			Skip("Test depth is lower than the amount requested for this test")
 		}
 	})

--- a/tests/e2e/declarative_hibernation_test.go
+++ b/tests/e2e/declarative_hibernation_test.go
@@ -41,7 +41,7 @@ var _ = Describe("Cluster declarative hibernation", func() {
 
 	var namespace string
 	BeforeEach(func() {
-		if testLevelEnv.Depth < int(level) {
+		if testLevel < int(level) {
 			Skip("Test depth is lower than the amount requested for this test")
 		}
 	})

--- a/tests/e2e/disk_space_test.go
+++ b/tests/e2e/disk_space_test.go
@@ -186,7 +186,7 @@ var _ = Describe("Volume space unavailable", Label(tests.LabelStorage), func() {
 	}
 
 	BeforeEach(func() {
-		if testLevelEnv.Depth < int(level) {
+		if testLevel < int(level) {
 			Skip("Test depth is lower than the amount requested for this test")
 		}
 		if MustGetEnvProfile().UsesNodeDiskSpace() {

--- a/tests/e2e/drain_node_test.go
+++ b/tests/e2e/drain_node_test.go
@@ -44,7 +44,7 @@ var _ = Describe("E2E Drain Node", Serial, Label(tests.LabelDisruptive, tests.La
 	const level = tests.Lowest
 
 	BeforeEach(func() {
-		if testLevelEnv.Depth < int(level) {
+		if testLevel < int(level) {
 			Skip("Test depth is lower than the amount requested for this test")
 		}
 		nodes, _ := nodes.List(env.Ctx, env.Client)

--- a/tests/e2e/eviction_test.go
+++ b/tests/e2e/eviction_test.go
@@ -110,7 +110,7 @@ var _ = Describe("Pod eviction", Serial, Label(tests.LabelDisruptive), func() {
 		var namespace string
 
 		BeforeEach(func() {
-			if testLevelEnv.Depth < int(level) {
+			if testLevel < int(level) {
 				Skip("Test depth is lower than the amount requested for this test")
 			}
 		})
@@ -169,7 +169,7 @@ var _ = Describe("Pod eviction", Serial, Label(tests.LabelDisruptive), func() {
 		)
 
 		BeforeEach(func() {
-			if testLevelEnv.Depth < int(level) {
+			if testLevel < int(level) {
 				Skip("Test depth is lower than the amount requested for this test")
 			}
 			if !IsLocal() {

--- a/tests/e2e/failover_test.go
+++ b/tests/e2e/failover_test.go
@@ -44,7 +44,7 @@ var _ = Describe("Failover", Label(tests.LabelSelfHealing), func() {
 		level = tests.Medium
 	)
 	BeforeEach(func() {
-		if testLevelEnv.Depth < int(level) {
+		if testLevel < int(level) {
 			Skip("Test depth is lower than the amount requested for this test")
 		}
 	})

--- a/tests/e2e/fastfailover_test.go
+++ b/tests/e2e/fastfailover_test.go
@@ -41,7 +41,7 @@ var _ = Describe("Fast failover", Serial, Label(tests.LabelPerformance, tests.La
 	)
 
 	BeforeEach(func() {
-		if testLevelEnv.Depth < int(level) {
+		if testLevel < int(level) {
 			Skip("Test depth is lower than the amount requested for this test")
 		}
 

--- a/tests/e2e/fastswitchover_test.go
+++ b/tests/e2e/fastswitchover_test.go
@@ -49,7 +49,7 @@ var _ = Describe("Fast switchover", Serial, Label(tests.LabelPerformance, tests.
 	)
 	var namespace string
 	BeforeEach(func() {
-		if testLevelEnv.Depth < int(level) {
+		if testLevel < int(level) {
 			Skip("Test depth is lower than the amount requested for this test")
 		}
 	})

--- a/tests/e2e/fencing_test.go
+++ b/tests/e2e/fencing_test.go
@@ -50,7 +50,7 @@ var _ = Describe("Fencing", Label(tests.LabelPlugin), func() {
 	var pod corev1.Pod
 
 	BeforeEach(func() {
-		if testLevelEnv.Depth < int(level) {
+		if testLevel < int(level) {
 			Skip("Test depth is lower than the amount requested for this test")
 		}
 	})

--- a/tests/e2e/hibernation_test.go
+++ b/tests/e2e/hibernation_test.go
@@ -60,7 +60,7 @@ var _ = Describe("Cluster Hibernation with plugin", Label(tests.LabelPlugin), fu
 		tableName                                     = "test"
 	)
 	BeforeEach(func() {
-		if testLevelEnv.Depth < int(level) {
+		if testLevel < int(level) {
 			Skip("Test depth is lower than the amount requested for this test")
 		}
 	})

--- a/tests/e2e/initdb_test.go
+++ b/tests/e2e/initdb_test.go
@@ -39,7 +39,7 @@ var _ = Describe("InitDB settings", Label(tests.LabelSmoke, tests.LabelBasic), f
 	)
 
 	BeforeEach(func() {
-		if testLevelEnv.Depth < int(level) {
+		if testLevel < int(level) {
 			Skip("Test depth is lower than the amount requested for this test")
 		}
 	})

--- a/tests/e2e/logs_test.go
+++ b/tests/e2e/logs_test.go
@@ -41,7 +41,7 @@ var _ = Describe("JSON log output", Label(tests.LabelObservability), func() {
 	const level = tests.Low
 
 	BeforeEach(func() {
-		if testLevelEnv.Depth < int(level) {
+		if testLevel < int(level) {
 			Skip("Test depth is lower than the amount requested for this test")
 		}
 	})

--- a/tests/e2e/managed_roles_test.go
+++ b/tests/e2e/managed_roles_test.go
@@ -52,7 +52,7 @@ var _ = Describe("Managed roles tests", Label(tests.LabelSmoke, tests.LabelBasic
 	)
 
 	BeforeEach(func() {
-		if testLevelEnv.Depth < int(level) {
+		if testLevel < int(level) {
 			Skip("Test depth is lower than the amount requested for this test")
 		}
 	})

--- a/tests/e2e/managed_services_test.go
+++ b/tests/e2e/managed_services_test.go
@@ -47,7 +47,7 @@ var _ = Describe("Managed services tests", Label(tests.LabelSmoke, tests.LabelBa
 	var err error
 
 	BeforeEach(func() {
-		if testLevelEnv.Depth < int(level) {
+		if testLevel < int(level) {
 			Skip("Test depth is lower than the amount requested for this test")
 		}
 	})

--- a/tests/e2e/metrics_test.go
+++ b/tests/e2e/metrics_test.go
@@ -88,7 +88,7 @@ var _ = Describe("Metrics", Label(tests.LabelObservability), func() {
 	}
 
 	BeforeEach(func() {
-		if testLevelEnv.Depth < int(level) {
+		if testLevel < int(level) {
 			Skip("Test depth is lower than the amount requested for this test")
 		}
 	})

--- a/tests/e2e/monitoring_test.go
+++ b/tests/e2e/monitoring_test.go
@@ -61,7 +61,7 @@ var _ = Describe("PodMonitor support", Serial, Label(tests.LabelObservability), 
 	var namespace string
 
 	BeforeEach(func() {
-		if testLevelEnv.Depth < int(level) {
+		if testLevel < int(level) {
 			Skip("Test depth is lower than the amount requested for this test")
 		}
 

--- a/tests/e2e/nodeselector_test.go
+++ b/tests/e2e/nodeselector_test.go
@@ -36,7 +36,7 @@ var _ = Describe("nodeSelector", Label(tests.LabelPodScheduling), func() {
 	const level = tests.Low
 
 	BeforeEach(func() {
-		if testLevelEnv.Depth < int(level) {
+		if testLevel < int(level) {
 			Skip("Test depth is lower than the amount requested for this test")
 		}
 	})

--- a/tests/e2e/openshift_upgrade_test.go
+++ b/tests/e2e/openshift_upgrade_test.go
@@ -50,7 +50,7 @@ var _ = Describe("Upgrade Paths on OpenShift", Label(tests.LabelUpgrade), Ordere
 	})
 
 	BeforeEach(func() {
-		if testLevelEnv.Depth < int(level) {
+		if testLevel < int(level) {
 			Skip("Test depth is lower than the amount requested for this test")
 		}
 		if !IsOpenshift() {

--- a/tests/e2e/operator_deployment_test.go
+++ b/tests/e2e/operator_deployment_test.go
@@ -28,7 +28,7 @@ var _ = Describe("PostgreSQL operator deployment", Label(tests.LabelBasic, tests
 	const level = tests.Highest
 
 	BeforeEach(func() {
-		if testLevelEnv.Depth < int(level) {
+		if testLevel < int(level) {
 			Skip("Test depth is lower than the amount requested for this test")
 		}
 	})

--- a/tests/e2e/operator_ha_test.go
+++ b/tests/e2e/operator_ha_test.go
@@ -41,7 +41,7 @@ var _ = Describe("Operator High Availability", Serial,
 		var oldLeaderPodName, namespace string
 
 		BeforeEach(func() {
-			if testLevelEnv.Depth < int(level) {
+			if testLevel < int(level) {
 				Skip("Test depth is lower than the amount requested for this test")
 			}
 			if !MustGetEnvProfile().IsLeaderElectionEnabled() {

--- a/tests/e2e/operator_unavailable_test.go
+++ b/tests/e2e/operator_unavailable_test.go
@@ -46,7 +46,7 @@ var _ = Describe("Operator unavailable", Serial, Label(tests.LabelDisruptive, te
 	var namespace string
 
 	BeforeEach(func() {
-		if testLevelEnv.Depth < int(level) {
+		if testLevel < int(level) {
 			Skip("Test depth is lower than the amount requested for this test")
 		}
 	})

--- a/tests/e2e/pg_basebackup_test.go
+++ b/tests/e2e/pg_basebackup_test.go
@@ -40,7 +40,7 @@ var _ = Describe("Bootstrap with pg_basebackup", Label(tests.LabelRecovery), fun
 	var namespace, srcClusterName string
 	var err error
 	BeforeEach(func() {
-		if testLevelEnv.Depth < int(level) {
+		if testLevel < int(level) {
 			Skip("Test depth is lower than the amount requested for this test")
 		}
 	})

--- a/tests/e2e/pg_data_corruption_test.go
+++ b/tests/e2e/pg_data_corruption_test.go
@@ -46,7 +46,7 @@ var _ = Describe("PGDATA Corruption", Label(tests.LabelRecovery), Ordered, func(
 	)
 	var namespace string
 	BeforeAll(func() {
-		if testLevelEnv.Depth < int(level) {
+		if testLevel < int(level) {
 			Skip("Test depth is lower than the amount requested for this test")
 		}
 		var err error

--- a/tests/e2e/pg_wal_volume_test.go
+++ b/tests/e2e/pg_wal_volume_test.go
@@ -109,7 +109,7 @@ var _ = Describe("Separate pg_wal volume", Label(tests.LabelStorage), func() {
 	}
 
 	BeforeEach(func() {
-		if testLevelEnv.Depth < int(level) {
+		if testLevel < int(level) {
 			Skip("Test depth is lower than the amount requested for this test")
 		}
 	})

--- a/tests/e2e/pgbouncer_metrics_test.go
+++ b/tests/e2e/pgbouncer_metrics_test.go
@@ -42,7 +42,7 @@ var _ = Describe("PGBouncer Metrics", Label(tests.LabelObservability), func() {
 	)
 	var namespace, clusterName string
 	BeforeEach(func() {
-		if testLevelEnv.Depth < int(level) {
+		if testLevel < int(level) {
 			Skip("Test depth is lower than the amount requested for this test")
 		}
 	})

--- a/tests/e2e/pgbouncer_test.go
+++ b/tests/e2e/pgbouncer_test.go
@@ -42,7 +42,7 @@ var _ = Describe("PGBouncer Connections", Label(tests.LabelServiceConnectivity),
 	var err error
 	var namespace, clusterName string
 	BeforeEach(func() {
-		if testLevelEnv.Depth < int(level) {
+		if testLevel < int(level) {
 			Skip("Test depth is lower than the amount requested for this test")
 		}
 	})

--- a/tests/e2e/pgbouncer_types_test.go
+++ b/tests/e2e/pgbouncer_types_test.go
@@ -46,7 +46,7 @@ var _ = Describe("PGBouncer Types", Ordered, Label(tests.LabelServiceConnectivit
 	var namespace, clusterName string
 
 	BeforeEach(func() {
-		if testLevelEnv.Depth < int(level) {
+		if testLevel < int(level) {
 			Skip("Test depth is lower than the amount requested for this test")
 		}
 	})

--- a/tests/e2e/pod_patch_test.go
+++ b/tests/e2e/pod_patch_test.go
@@ -37,7 +37,7 @@ var _ = Describe("Pod patch", Label(tests.LabelSmoke, tests.LabelBasic), func() 
 	var namespace string
 
 	BeforeEach(func() {
-		if testLevelEnv.Depth < int(level) {
+		if testLevel < int(level) {
 			Skip("Test depth is lower than the amount requested for this test")
 		}
 	})

--- a/tests/e2e/probes_test.go
+++ b/tests/e2e/probes_test.go
@@ -37,7 +37,7 @@ var _ = Describe("Probes configuration tests", Label(tests.LabelBasic), func() {
 	)
 
 	BeforeEach(func() {
-		if testLevelEnv.Depth < int(level) {
+		if testLevel < int(level) {
 			Skip("Test depth is lower than the amount requested for this test")
 		}
 	})

--- a/tests/e2e/publication_subscription_test.go
+++ b/tests/e2e/publication_subscription_test.go
@@ -49,7 +49,7 @@ var _ = Describe("Publication and Subscription", Label(tests.LabelPublicationSub
 	)
 
 	BeforeEach(func() {
-		if testLevelEnv.Depth < int(level) {
+		if testLevel < int(level) {
 			Skip("Test depth is lower than the amount requested for this test")
 		}
 	})

--- a/tests/e2e/pvc_deletion_test.go
+++ b/tests/e2e/pvc_deletion_test.go
@@ -41,7 +41,7 @@ var _ = Describe("PVC Deletion", Label(tests.LabelSelfHealing), func() {
 	)
 	var namespace string
 	BeforeEach(func() {
-		if testLevelEnv.Depth < int(level) {
+		if testLevel < int(level) {
 			Skip("Test depth is lower than the amount requested for this test")
 		}
 	})

--- a/tests/e2e/replica_mode_cluster_test.go
+++ b/tests/e2e/replica_mode_cluster_test.go
@@ -69,7 +69,7 @@ var _ = Describe("Replica Mode", Label(tests.LabelReplication), func() {
 
 	var err error
 	BeforeEach(func() {
-		if testLevelEnv.Depth < int(level) {
+		if testLevel < int(level) {
 			Skip("Test depth is lower than the amount requested for this test")
 		}
 	})
@@ -507,7 +507,7 @@ var _ = Describe("Replica switchover", Label(tests.LabelReplication), Ordered, f
 	var namespace, clusterAName, clusterBName string
 
 	BeforeAll(func() {
-		if testLevelEnv.Depth < int(level) {
+		if testLevel < int(level) {
 			Skip("Test depth is lower than the amount requested for this test")
 		}
 	})

--- a/tests/e2e/replication_slot_test.go
+++ b/tests/e2e/replication_slot_test.go
@@ -43,7 +43,7 @@ var _ = Describe("Replication Slot", Label(tests.LabelReplication), func() {
 	)
 	var namespace string
 	BeforeEach(func() {
-		if testLevelEnv.Depth < int(level) {
+		if testLevel < int(level) {
 			Skip("Test depth is lower than the amount requested for this test")
 		}
 	})

--- a/tests/e2e/rolling_update_test.go
+++ b/tests/e2e/rolling_update_test.go
@@ -45,7 +45,7 @@ import (
 var _ = Describe("Rolling updates", Label(tests.LabelPostgresConfiguration), func() {
 	const level = tests.Medium
 	BeforeEach(func() {
-		if testLevelEnv.Depth < int(level) {
+		if testLevel < int(level) {
 			Skip("Test depth is lower than the amount requested for this test")
 		}
 	})

--- a/tests/e2e/scaling_test.go
+++ b/tests/e2e/scaling_test.go
@@ -37,7 +37,7 @@ var _ = Describe("Cluster scale up and down", Serial, Label(tests.LabelReplicati
 
 	var namespace string
 	BeforeEach(func() {
-		if testLevelEnv.Depth < int(level) {
+		if testLevel < int(level) {
 			Skip("Test depth is lower than the amount requested for this test")
 		}
 	})

--- a/tests/e2e/storage_expansion_test.go
+++ b/tests/e2e/storage_expansion_test.go
@@ -40,7 +40,7 @@ var _ = Describe("Verify storage", Label(tests.LabelStorage), func() {
 	var namespace, namespacePrefix string
 
 	BeforeEach(func() {
-		if testLevelEnv.Depth < int(level) {
+		if testLevel < int(level) {
 			Skip("Test depth is lower than the amount requested for this test")
 		}
 	})

--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -56,7 +56,7 @@ const (
 
 var (
 	env                     *environment.TestingEnvironment
-	testLevelEnv            *tests.TestEnvLevel
+	testLevel               int
 	testCloudVendorEnv      *cloudvendors.TestEnvVendor
 	expectedOperatorPodName string
 	operatorPodWasRenamed   bool
@@ -130,7 +130,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	_ = k8sscheme.AddToScheme(env.Scheme)
 	_ = apiv1.AddToScheme(env.Scheme)
 
-	if testLevelEnv, err = tests.TestLevel(); err != nil {
+	if testLevel, err = tests.TestLevel(); err != nil {
 		panic(err)
 	}
 

--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -121,8 +121,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	return jsonObjs
 }, func(jsonObjs []byte) {
 	var err error
-	// We are creating new testing env object again because above testing env can not serialize and
-	// accessible to all nodes (specs)
+	// Create a testing env object for each parallel process
 	if env, err = environment.NewTestingEnvironment(); err != nil {
 		panic(err)
 	}

--- a/tests/e2e/switchover_test.go
+++ b/tests/e2e/switchover_test.go
@@ -32,7 +32,7 @@ var _ = Describe("Switchover", Serial, Label(tests.LabelSelfHealing), func() {
 	)
 	var namespace string
 	BeforeEach(func() {
-		if testLevelEnv.Depth < int(level) {
+		if testLevel < int(level) {
 			Skip("Test depth is lower than the amount requested for this test")
 		}
 	})

--- a/tests/e2e/syncreplicas_test.go
+++ b/tests/e2e/syncreplicas_test.go
@@ -40,7 +40,7 @@ import (
 var _ = Describe("Synchronous Replicas", Label(tests.LabelReplication), func() {
 	const level = tests.Medium
 	BeforeEach(func() {
-		if testLevelEnv.Depth < int(level) {
+		if testLevel < int(level) {
 			Skip("Test depth is lower than the amount requested for this test")
 		}
 	})

--- a/tests/e2e/tablespaces_test.go
+++ b/tests/e2e/tablespaces_test.go
@@ -71,7 +71,7 @@ var _ = Describe("Tablespaces tests", Label(tests.LabelTablespaces,
 	storageClassName := os.Getenv("E2E_DEFAULT_STORAGE_CLASS")
 
 	BeforeEach(func() {
-		if testLevelEnv.Depth < int(level) {
+		if testLevel < int(level) {
 			Skip("Test depth is lower than the amount requested for this test")
 		}
 	})

--- a/tests/e2e/tolerations_test.go
+++ b/tests/e2e/tolerations_test.go
@@ -41,7 +41,7 @@ var _ = Describe("E2E Tolerations Node", Serial, Label(tests.LabelDisruptive, te
 	)
 
 	BeforeEach(func() {
-		if testLevelEnv.Depth < int(level) {
+		if testLevel < int(level) {
 			Skip("Test depth is lower than the amount requested for this test")
 		}
 	})

--- a/tests/e2e/update_user_test.go
+++ b/tests/e2e/update_user_test.go
@@ -47,7 +47,7 @@ var _ = Describe("Update user and superuser password", Label(tests.LabelServiceC
 	var namespace string
 
 	BeforeEach(func() {
-		if testLevelEnv.Depth < int(level) {
+		if testLevel < int(level) {
 			Skip("Test depth is lower than the amount requested for this test")
 		}
 	})
@@ -131,7 +131,7 @@ var _ = Describe("Enable superuser password", Label(tests.LabelServiceConnectivi
 	var namespace string
 
 	BeforeEach(func() {
-		if testLevelEnv.Depth < int(level) {
+		if testLevel < int(level) {
 			Skip("Test depth is lower than the amount requested for this test")
 		}
 	})

--- a/tests/e2e/upgrade_test.go
+++ b/tests/e2e/upgrade_test.go
@@ -121,7 +121,7 @@ var _ = Describe("Upgrade", Label(tests.LabelUpgrade, tests.LabelNoOpenshift), O
 	})
 
 	BeforeEach(func() {
-		if testLevelEnv.Depth < int(level) {
+		if testLevel < int(level) {
 			Skip("Test depth is lower than the amount requested for this test")
 		}
 

--- a/tests/e2e/volume_snapshot_test.go
+++ b/tests/e2e/volume_snapshot_test.go
@@ -92,7 +92,7 @@ var _ = Describe("Verify Volume Snapshot",
 
 			var clusterName string
 			BeforeAll(func() {
-				if testLevelEnv.Depth < int(level) {
+				if testLevel < int(level) {
 					Skip("Test depth is lower than the amount requested for this test")
 				}
 				var err error
@@ -174,7 +174,7 @@ var _ = Describe("Verify Volume Snapshot",
 
 			var clusterToSnapshotName string
 			BeforeAll(func() {
-				if testLevelEnv.Depth < int(level) {
+				if testLevel < int(level) {
 					Skip("Test depth is lower than the amount requested for this test")
 				}
 
@@ -399,7 +399,7 @@ var _ = Describe("Verify Volume Snapshot",
 			}
 
 			BeforeAll(func() {
-				if testLevelEnv.Depth < int(level) {
+				if testLevel < int(level) {
 					Skip("Test depth is lower than the amount requested for this test")
 				}
 
@@ -635,7 +635,7 @@ var _ = Describe("Verify Volume Snapshot",
 			var clusterToSnapshotName string
 			var backupTaken *apiv1.Backup
 			BeforeAll(func() {
-				if testLevelEnv.Depth < int(level) {
+				if testLevel < int(level) {
 					Skip("Test depth is lower than the amount requested for this test")
 				}
 

--- a/tests/e2e/wal_restore_parallel_test.go
+++ b/tests/e2e/wal_restore_parallel_test.go
@@ -48,7 +48,7 @@ var _ = Describe("Wal-restore in parallel", Label(tests.LabelBackupRestore), fun
 	var primary, standby, latestWAL, walFile1, walFile2, walFile3, walFile4, walFile5, walFile6 string
 
 	BeforeEach(func() {
-		if testLevelEnv.Depth < int(level) {
+		if testLevel < int(level) {
 			Skip("Test depth is lower than the amount requested for this test")
 		}
 		if !IsLocal() {

--- a/tests/e2e/webhook_test.go
+++ b/tests/e2e/webhook_test.go
@@ -51,7 +51,7 @@ var _ = Describe("webhook", Serial, Label(tests.LabelDisruptive, tests.LabelOper
 	var err error
 
 	BeforeEach(func() {
-		if testLevelEnv.Depth < int(level) {
+		if testLevel < int(level) {
 			Skip("Test depth is lower than the amount requested for this test")
 		}
 	})

--- a/tests/levels.go
+++ b/tests/levels.go
@@ -42,11 +42,6 @@ const testDepthEnvVarName = "TEST_DEPTH"
 // By default, we run tests with at least a medium level of importance
 const defaultTestDepth = int(Medium)
 
-// TestEnvLevel struct for operator testing
-type TestEnvLevel struct {
-	Depth int
-}
-
 // TestLevel gets the level for testing from the environment TEST_DEPTH,
 // or sets the default value
 func TestLevel() (int, error) {

--- a/tests/levels.go
+++ b/tests/levels.go
@@ -19,8 +19,6 @@ package tests
 import (
 	"os"
 	"strconv"
-
-	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/environment"
 )
 
 // Level - Define test importance. Each test should define its own importance
@@ -46,20 +44,15 @@ const defaultTestDepth = int(Medium)
 
 // TestEnvLevel struct for operator testing
 type TestEnvLevel struct {
-	*environment.TestingEnvironment
 	Depth int
 }
 
 // TestLevel creates the environment for testing
 func TestLevel() (*TestEnvLevel, error) {
-	env, err := environment.NewTestingEnvironment()
-	if err != nil {
-		return nil, err
-	}
 	if depthEnv, exists := os.LookupEnv(testDepthEnvVarName); exists {
 		depth, err := strconv.Atoi(depthEnv)
-		return &TestEnvLevel{env, depth}, err
+		return &TestEnvLevel{depth}, err
 	}
 
-	return &TestEnvLevel{env, defaultTestDepth}, err
+	return &TestEnvLevel{defaultTestDepth}, nil
 }

--- a/tests/levels.go
+++ b/tests/levels.go
@@ -47,12 +47,13 @@ type TestEnvLevel struct {
 	Depth int
 }
 
-// TestLevel creates the environment for testing
-func TestLevel() (*TestEnvLevel, error) {
+// TestLevel gets the level for testing from the environment TEST_DEPTH,
+// or sets the default value
+func TestLevel() (int, error) {
 	if depthEnv, exists := os.LookupEnv(testDepthEnvVarName); exists {
 		depth, err := strconv.Atoi(depthEnv)
-		return &TestEnvLevel{depth}, err
+		return depth, err
 	}
 
-	return &TestEnvLevel{defaultTestDepth}, nil
+	return defaultTestDepth, nil
 }


### PR DESCRIPTION
The struct that was used to hold the depth number initialized a
test environment structure unnecessarily