### PR TITLE
fix(metrics): adapt pg_stat_wal metrics collection for PostgreSQL 18 compatibility

### DIFF
--- a/pkg/management/postgres/probes.go
+++ b/pkg/management/postgres/probes.go
@@ -596,7 +596,7 @@ type PgStatWal struct {
 	StatsReset     string
 }
 
-// TryGetPgStatWAL retrieves pg_wal_stat on pg version 14 and further
+// TryGetPgStatWAL retrieves pg_stat_wal on pg version 14 and further
 func (instance *Instance) TryGetPgStatWAL() (*PgStatWal, error) {
 	version, err := instance.GetPgVersion()
 	if err != nil || version.Major < 14 {
@@ -609,30 +609,52 @@ func (instance *Instance) TryGetPgStatWAL() (*PgStatWal, error) {
 	}
 
 	var pgWalStat PgStatWal
-	row := superUserDB.QueryRow(
-		`SELECT
+	if version.Major < 18 {
+		row := superUserDB.QueryRow(
+			`SELECT
+			wal_records,
+			wal_fpi,
+			wal_bytes,
+			wal_buffers_full,
+			wal_write,
+			wal_sync,
+			wal_write_time,
+			wal_sync_time,
+			stats_reset
+			FROM pg_catalog.pg_stat_wal`)
+		if err := row.Scan(
+			&pgWalStat.WalRecords,
+			&pgWalStat.WalFpi,
+			&pgWalStat.WalBytes,
+			&pgWalStat.WALBuffersFull,
+			&pgWalStat.WalWrite,
+			&pgWalStat.WalSync,
+			&pgWalStat.WalWriteTime,
+			&pgWalStat.WalSyncTime,
+			&pgWalStat.StatsReset,
+		); err != nil {
+			return nil, err
+		}
+	}
+
+	if version.Major >= 18 {
+		row := superUserDB.QueryRow(
+			`SELECT
         	wal_records,
 		wal_fpi,
 		wal_bytes,
 		wal_buffers_full,
-		wal_write,
-		wal_sync,
-		wal_write_time,
-		wal_sync_time,
 		stats_reset
 	    FROM pg_catalog.pg_stat_wal`)
-	if err := row.Scan(
-		&pgWalStat.WalRecords,
-		&pgWalStat.WalFpi,
-		&pgWalStat.WalBytes,
-		&pgWalStat.WALBuffersFull,
-		&pgWalStat.WalWrite,
-		&pgWalStat.WalSync,
-		&pgWalStat.WalWriteTime,
-		&pgWalStat.WalSyncTime,
-		&pgWalStat.StatsReset,
-	); err != nil {
-		return nil, err
+		if err := row.Scan(
+			&pgWalStat.WalRecords,
+			&pgWalStat.WalFpi,
+			&pgWalStat.WalBytes,
+			&pgWalStat.WALBuffersFull,
+			&pgWalStat.StatsReset,
+		); err != nil {
+			return nil, err
+		}
 	}
 
 	return &pgWalStat, nil

--- a/pkg/management/postgres/probes.go
+++ b/pkg/management/postgres/probes.go
@@ -583,7 +583,7 @@ func (instance *Instance) IsWALReceiverActive() (bool, error) {
 	return result, nil
 }
 
-// PgStatWal is a representation of the pg_stat_wal table
+// PgStatWal is a representation of the pg_stat_wal table, introduced in PostgreSQL 14.
 type PgStatWal struct {
 	WalRecords     int64
 	WalFpi         int64
@@ -608,6 +608,9 @@ func (instance *Instance) TryGetPgStatWAL() (*PgStatWal, error) {
 		return nil, err
 	}
 
+	// Since PostgreSQL 18, `wal_write`, `wal_sync`, `wal_write_time` and
+	// `wal_sync_time` have been removed.
+	// See https://github.com/postgres/postgres/commit/2421e9a51d20bb83154e54a16ce628f9249fa907
 	var pgWalStat PgStatWal
 	if version.Major < 18 {
 		row := superUserDB.QueryRow(

--- a/pkg/management/postgres/webserver/metricserver/pg_collector.go
+++ b/pkg/management/postgres/webserver/metricserver/pg_collector.go
@@ -232,7 +232,8 @@ func newMetrics() *metrics {
 				Namespace: PrometheusNamespace,
 				Subsystem: subsystem,
 				Name:      "wal_write",
-				Help:      "Number of times WAL buffers were written out to disk via XLogWrite request. Only available on PG 14+",
+				Help: "Number of times WAL buffers were written out to disk via XLogWrite request." +
+					" Only available on PG 14+. Moved to pg_stat_io from PG 18.",
 			}, []string{"stats_reset"}),
 			WalSync: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 				Namespace: PrometheusNamespace,
@@ -240,7 +241,7 @@ func newMetrics() *metrics {
 				Name:      "wal_sync",
 				Help: "Number of times WAL files were synced to disk via issue_xlog_fsync request " +
 					"(if fsync is on and wal_sync_method is either fdatasync, fsync or fsync_writethrough, otherwise zero)." +
-					" Only available on PG 14+",
+					" Only available on PG 14+. Moved to pg_stat_io from PG 18.",
 			}, []string{"stats_reset"}),
 			WalWriteTime: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 				Namespace: PrometheusNamespace,
@@ -249,7 +250,7 @@ func newMetrics() *metrics {
 				Help: "Total amount of time spent writing WAL buffers to disk via XLogWrite request, in milliseconds " +
 					"(if track_wal_io_timing is enabled, otherwise zero). This includes the sync time when wal_sync_method " +
 					"is either open_datasync or open_sync." +
-					" Only available on PG 14+",
+					" Only available on PG 14+. Moved to pg_stat_io from PG 18.",
 			}, []string{"stats_reset"}),
 			WalSyncTime: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 				Namespace: PrometheusNamespace,
@@ -257,7 +258,7 @@ func newMetrics() *metrics {
 				Name:      "wal_sync_time",
 				Help: "Total amount of time spent syncing WAL files to disk via issue_xlog_fsync request, in milliseconds " +
 					"(if track_wal_io_timing is enabled, fsync is on, and wal_sync_method is either fdatasync, fsync or " +
-					"fsync_writethrough, otherwise zero). Only available on PG 14+",
+					"fsync_writethrough, otherwise zero). Only available on PG 14+. Moved to pg_stat_io from PG 18.",
 			}, []string{"stats_reset"}),
 		},
 	}
@@ -287,14 +288,16 @@ func (e *Exporter) Describe(ch chan<- *prometheus.Desc) {
 	}
 
 	if version, _ := e.instance.GetPgVersion(); version.Major >= 14 {
-		e.Metrics.PgStatWalMetrics.WalSync.Describe(ch)
-		e.Metrics.PgStatWalMetrics.WalWriteTime.Describe(ch)
-		e.Metrics.PgStatWalMetrics.WalFpi.Describe(ch)
-		e.Metrics.PgStatWalMetrics.WalWrite.Describe(ch)
-		e.Metrics.PgStatWalMetrics.WalSyncTime.Describe(ch)
 		e.Metrics.PgStatWalMetrics.WalRecords.Describe(ch)
-		e.Metrics.PgStatWalMetrics.WALBuffersFull.Describe(ch)
+		e.Metrics.PgStatWalMetrics.WalFpi.Describe(ch)
 		e.Metrics.PgStatWalMetrics.WalBytes.Describe(ch)
+		e.Metrics.PgStatWalMetrics.WALBuffersFull.Describe(ch)
+		if version.Major < 18 {
+			e.Metrics.PgStatWalMetrics.WalWrite.Describe(ch)
+			e.Metrics.PgStatWalMetrics.WalSync.Describe(ch)
+			e.Metrics.PgStatWalMetrics.WalWriteTime.Describe(ch)
+			e.Metrics.PgStatWalMetrics.WalSyncTime.Describe(ch)
+		}
 	}
 }
 
@@ -321,14 +324,16 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 	e.Metrics.NodesUsed.Collect(ch)
 
 	if version, _ := e.instance.GetPgVersion(); version.Major >= 14 {
-		e.Metrics.PgStatWalMetrics.WalSync.Collect(ch)
-		e.Metrics.PgStatWalMetrics.WalWriteTime.Collect(ch)
-		e.Metrics.PgStatWalMetrics.WalFpi.Collect(ch)
-		e.Metrics.PgStatWalMetrics.WalWrite.Collect(ch)
-		e.Metrics.PgStatWalMetrics.WalSyncTime.Collect(ch)
 		e.Metrics.PgStatWalMetrics.WalRecords.Collect(ch)
-		e.Metrics.PgStatWalMetrics.WALBuffersFull.Collect(ch)
+		e.Metrics.PgStatWalMetrics.WalFpi.Collect(ch)
 		e.Metrics.PgStatWalMetrics.WalBytes.Collect(ch)
+		e.Metrics.PgStatWalMetrics.WALBuffersFull.Collect(ch)
+		if version.Major < 18 {
+			e.Metrics.PgStatWalMetrics.WalWrite.Collect(ch)
+			e.Metrics.PgStatWalMetrics.WalSync.Collect(ch)
+			e.Metrics.PgStatWalMetrics.WalWriteTime.Collect(ch)
+			e.Metrics.PgStatWalMetrics.WalSyncTime.Collect(ch)
+		}
 	}
 }
 
@@ -424,7 +429,7 @@ func (e *Exporter) collectPgMetrics(ch chan<- prometheus.Metric) {
 
 	if version, _ := e.instance.GetPgVersion(); version.Major >= 14 {
 		if err := collectPGWALStat(e); err != nil {
-			log.Error(err, "while collecting pg_wal_stat")
+			log.Error(err, "while collecting pg_stat_wal")
 			e.Metrics.Error.Set(1)
 			e.Metrics.PgCollectionErrors.WithLabelValues("Collect.PGWALStat").Inc()
 		}

--- a/pkg/management/postgres/webserver/metricserver/pg_collector.go
+++ b/pkg/management/postgres/webserver/metricserver/pg_collector.go
@@ -233,7 +233,7 @@ func newMetrics() *metrics {
 				Subsystem: subsystem,
 				Name:      "wal_write",
 				Help: "Number of times WAL buffers were written out to disk via XLogWrite request." +
-					" Only available on PG 14+. Moved to pg_stat_io from PG 18.",
+					" Only available on PG 14 to 17.",
 			}, []string{"stats_reset"}),
 			WalSync: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 				Namespace: PrometheusNamespace,
@@ -241,7 +241,7 @@ func newMetrics() *metrics {
 				Name:      "wal_sync",
 				Help: "Number of times WAL files were synced to disk via issue_xlog_fsync request " +
 					"(if fsync is on and wal_sync_method is either fdatasync, fsync or fsync_writethrough, otherwise zero)." +
-					" Only available on PG 14+. Moved to pg_stat_io from PG 18.",
+					" Only available on PG 14 to 17.",
 			}, []string{"stats_reset"}),
 			WalWriteTime: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 				Namespace: PrometheusNamespace,
@@ -250,7 +250,7 @@ func newMetrics() *metrics {
 				Help: "Total amount of time spent writing WAL buffers to disk via XLogWrite request, in milliseconds " +
 					"(if track_wal_io_timing is enabled, otherwise zero). This includes the sync time when wal_sync_method " +
 					"is either open_datasync or open_sync." +
-					" Only available on PG 14+. Moved to pg_stat_io from PG 18.",
+					" Only available on PG 14 to 17.",
 			}, []string{"stats_reset"}),
 			WalSyncTime: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 				Namespace: PrometheusNamespace,
@@ -258,7 +258,7 @@ func newMetrics() *metrics {
 				Name:      "wal_sync_time",
 				Help: "Total amount of time spent syncing WAL files to disk via issue_xlog_fsync request, in milliseconds " +
 					"(if track_wal_io_timing is enabled, fsync is on, and wal_sync_method is either fdatasync, fsync or " +
-					"fsync_writethrough, otherwise zero). Only available on PG 14+. Moved to pg_stat_io from PG 18.",
+					"fsync_writethrough, otherwise zero). Only available on PG 14 to 17.",
 			}, []string{"stats_reset"}),
 		},
 	}
@@ -428,7 +428,7 @@ func (e *Exporter) collectPgMetrics(ch chan<- prometheus.Metric) {
 	}
 
 	if version, _ := e.instance.GetPgVersion(); version.Major >= 14 {
-		if err := collectPGWALStat(e); err != nil {
+		if err := collectPGStatWAL(e); err != nil {
 			log.Error(err, "while collecting pg_stat_wal")
 			e.Metrics.Error.Set(1)
 			e.Metrics.PgCollectionErrors.WithLabelValues("Collect.PGWALStat").Inc()

--- a/pkg/management/postgres/webserver/metricserver/wal.go
+++ b/pkg/management/postgres/webserver/metricserver/wal.go
@@ -47,14 +47,16 @@ func collectPGWALStat(e *Exporter) error {
 		return err
 	}
 	walMetrics := e.Metrics.PgStatWalMetrics
-	walMetrics.WalSync.WithLabelValues(walStat.StatsReset).Set(float64(walStat.WalSync))
-	walMetrics.WalSyncTime.WithLabelValues(walStat.StatsReset).Set(walStat.WalSyncTime)
-	walMetrics.WALBuffersFull.WithLabelValues(walStat.StatsReset).Set(float64(walStat.WALBuffersFull))
-	walMetrics.WalFpi.WithLabelValues(walStat.StatsReset).Set(float64(walStat.WalFpi))
-	walMetrics.WalWrite.WithLabelValues(walStat.StatsReset).Set(float64(walStat.WalWrite))
-	walMetrics.WalBytes.WithLabelValues(walStat.StatsReset).Set(float64(walStat.WalBytes))
-	walMetrics.WalWriteTime.WithLabelValues(walStat.StatsReset).Set(walStat.WalWriteTime)
 	walMetrics.WalRecords.WithLabelValues(walStat.StatsReset).Set(float64(walStat.WalRecords))
+	walMetrics.WalFpi.WithLabelValues(walStat.StatsReset).Set(float64(walStat.WalFpi))
+	walMetrics.WalBytes.WithLabelValues(walStat.StatsReset).Set(float64(walStat.WalBytes))
+	walMetrics.WALBuffersFull.WithLabelValues(walStat.StatsReset).Set(float64(walStat.WALBuffersFull))
+	if version, _ := e.instance.GetPgVersion(); version.Major < 18 {
+		walMetrics.WalWrite.WithLabelValues(walStat.StatsReset).Set(float64(walStat.WalWrite))
+		walMetrics.WalSync.WithLabelValues(walStat.StatsReset).Set(float64(walStat.WalSync))
+		walMetrics.WalWriteTime.WithLabelValues(walStat.StatsReset).Set(walStat.WalWriteTime)
+		walMetrics.WalSyncTime.WithLabelValues(walStat.StatsReset).Set(walStat.WalSyncTime)
+	}
 
 	return nil
 }

--- a/pkg/management/postgres/webserver/metricserver/wal.go
+++ b/pkg/management/postgres/webserver/metricserver/wal.go
@@ -41,7 +41,7 @@ func collectPGWalArchiveMetric(exporter *Exporter) error {
 	return nil
 }
 
-func collectPGWALStat(e *Exporter) error {
+func collectPGStatWAL(e *Exporter) error {
 	walStat, err := e.instance.TryGetPgStatWAL()
 	if walStat == nil || err != nil {
 		return err

--- a/tests/e2e/asserts_test.go
+++ b/tests/e2e/asserts_test.go
@@ -2542,17 +2542,21 @@ func collectAndAssertCollectorMetricsPresentOnEachPod(cluster *apiv1.Cluster) {
 		"cnpg_collector_replica_mode",
 	}
 
-	if env.PostgresVersion > 14 {
+	if env.PostgresVersion >= 14 {
 		cnpgCollectorMetrics = append(cnpgCollectorMetrics,
 			"cnpg_collector_wal_records",
 			"cnpg_collector_wal_fpi",
 			"cnpg_collector_wal_bytes",
 			"cnpg_collector_wal_buffers_full",
-			"cnpg_collector_wal_write",
-			"cnpg_collector_wal_sync",
-			"cnpg_collector_wal_write_time",
-			"cnpg_collector_wal_sync_time",
 		)
+		if env.PostgresVersion < 18 {
+			cnpgCollectorMetrics = append(cnpgCollectorMetrics,
+				"cnpg_collector_wal_write",
+				"cnpg_collector_wal_sync",
+				"cnpg_collector_wal_write_time",
+				"cnpg_collector_wal_sync_time",
+			)
+		}
 	}
 	By("collecting and verify set of collector metrics on each pod", func() {
 		podList, err := clusterutils.ListPods(env.Ctx, env.Client, cluster.Namespace, cluster.Name)


### PR DESCRIPTION
Adjust the metrics collected from the `pg_stat_wal` system view to align with the changes introduced in PostgreSQL 18.

Closes #7004

# Release Notes

```
Fix collection of `pg_stat_wal` metrics for PostgreSQL 18.
```