### PR TITLE
fix: provide the operator extra time to start

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -69,6 +69,13 @@ spec:
             port: 9443
             scheme: HTTPS
             path: /readyz
+        startupProbe:
+          failureThreshold: 6
+          periodSeconds: 5
+          httpGet:
+            port: 9443
+            scheme: HTTPS
+            path: /readyz
         readinessProbe:
           httpGet:
             port: 9443


### PR DESCRIPTION
When the operator starts, it calculates the hash code of its binary for each architecture included in the image. This process occurs early in the initialization, before the web server that serves the probes is launched.

As a result, the liveness probe may fail. If the hash code calculation takes too long, the Kubelet will restart the operator.

This patch adds a startup probe to the operator deployment, allowing up to 30 seconds to start up.

Fixes: #7007 