### PR TITLE
fix(backup,VolumeSnapshots): treat timeout errors as retryable

### DIFF
--- a/api/v1/backup_funcs.go
+++ b/api/v1/backup_funcs.go
@@ -19,6 +19,7 @@ package v1
 import (
 	"context"
 	"sort"
+	"strconv"
 	"strings"
 
 	volumesnapshot "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
@@ -93,6 +94,23 @@ func (backupStatus *BackupStatus) GetOnline() bool {
 	}
 
 	return *backupStatus.Online
+}
+
+// GetVolumeSnapshotDeadline returns the volume snapshot deadline in minutes.
+func (backup *Backup) GetVolumeSnapshotDeadline() int {
+	const defaultValue = 10
+
+	value := backup.Annotations[utils.BackupVolumeSnapshotDeadlineAnnotationName]
+	if value == "" {
+		return defaultValue
+	}
+
+	minutes, err := strconv.Atoi(value)
+	if err != nil {
+		return defaultValue
+	}
+
+	return minutes
 }
 
 // IsCompletedVolumeSnapshot checks if a backup is completed using the volume snapshot method.

--- a/api/v1/backup_funcs.go
+++ b/api/v1/backup_funcs.go
@@ -21,6 +21,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	volumesnapshot "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -97,20 +98,20 @@ func (backupStatus *BackupStatus) GetOnline() bool {
 }
 
 // GetVolumeSnapshotDeadline returns the volume snapshot deadline in minutes.
-func (backup *Backup) GetVolumeSnapshotDeadline() int {
+func (backup *Backup) GetVolumeSnapshotDeadline() time.Duration {
 	const defaultValue = 10
 
 	value := backup.Annotations[utils.BackupVolumeSnapshotDeadlineAnnotationName]
 	if value == "" {
-		return defaultValue
+		return defaultValue * time.Minute
 	}
 
 	minutes, err := strconv.Atoi(value)
 	if err != nil {
-		return defaultValue
+		return defaultValue * time.Minute
 	}
 
-	return minutes
+	return time.Duration(minutes) * time.Minute
 }
 
 // IsCompletedVolumeSnapshot checks if a backup is completed using the volume snapshot method.

--- a/api/v1/scheduledbackup_funcs.go
+++ b/api/v1/scheduledbackup_funcs.go
@@ -78,5 +78,14 @@ func (scheduledBackup *ScheduledBackup) CreateBackup(name string) *Backup {
 		},
 	}
 	utils.InheritAnnotations(&backup.ObjectMeta, scheduledBackup.Annotations, nil, configuration.Current)
+
+	if backup.Annotations == nil {
+		backup.Annotations = make(map[string]string)
+	}
+
+	if v := scheduledBackup.Annotations[utils.BackupVolumeSnapshotDeadlineAnnotationName]; v != "" {
+		backup.Annotations[utils.BackupVolumeSnapshotDeadlineAnnotationName] = v
+	}
+
 	return &backup
 }

--- a/docs/src/labels_annotations.md
+++ b/docs/src/labels_annotations.md
@@ -227,13 +227,13 @@ CloudNativePG manages the following predefined annotations:
 `cnpg.io/snapshotEndTime`
 :   The time a snapshot was marked as ready to use.
 
+`cnpg.io/volumeSnapshotDeadline`
+:   Applied to `Backup` and `ScheduledBackup` resources, allows you to control
+    how long the operator should retry recoverable errors before considering the
+    volume snapshot backup failed. In minutes, defaulting to 10.
+
 `kubectl.kubernetes.io/restartedAt`
 :   When available, the time of last requested restart of a Postgres cluster.
-
-`cnpg.io/volumeSnapshotDeadline`
-:   Allows the user to control how long the operator should retry
-    recoverable errors before considering the volume snapshot backup
-    failed. In minutes, defaulting to 10.
 
 ## Prerequisites
 

--- a/docs/src/labels_annotations.md
+++ b/docs/src/labels_annotations.md
@@ -230,6 +230,11 @@ CloudNativePG manages the following predefined annotations:
 `kubectl.kubernetes.io/restartedAt`
 :   When available, the time of last requested restart of a Postgres cluster.
 
+`cnpg.io/volumeSnapshotDeadline`
+:   Allows the user to control how long the operator should retry
+    recoverable errors before considering the volume snapshot backup
+    failed. In minutes, defaulting to 10.
+
 ## Prerequisites
 
 By default, no label or annotation defined in the cluster's metadata is

--- a/internal/controller/backup_controller.go
+++ b/internal/controller/backup_controller.go
@@ -571,7 +571,8 @@ func updateClusterWithSnapshotsBackupTimes(
 
 // isErrorRetryable detects is an error is retryable or not
 func isErrorRetryable(err error) bool {
-	return apierrs.IsServerTimeout(err) || apierrs.IsConflict(err) || apierrs.IsInternalError(err)
+	return apierrs.IsServerTimeout(err) || apierrs.IsConflict(err) || apierrs.IsInternalError(err) ||
+		errors.Is(err, context.DeadlineExceeded)
 }
 
 // getBackupTargetPod returns the pod that should run the backup according to the current

--- a/internal/controller/backup_controller.go
+++ b/internal/controller/backup_controller.go
@@ -456,10 +456,6 @@ func (r *BackupReconciler) reconcileSnapshotBackup(
 		Build()
 
 	res, err := reconciler.Reconcile(ctx, cluster, backup, targetPod, pvcs)
-	if isErrorRetryable(err) {
-		contextLogger.Error(err, "detected retryable error while executing snapshot backup, retrying...")
-		return &ctrl.Result{RequeueAfter: 5 * time.Second}, nil
-	}
 	if err != nil {
 		// Volume Snapshot errors are not retryable, we need to set this backup as failed
 		// and un-fence the Pod
@@ -567,12 +563,6 @@ func updateClusterWithSnapshotsBackupTimes(
 		}
 	}
 	return nil
-}
-
-// isErrorRetryable detects is an error is retryable or not
-func isErrorRetryable(err error) bool {
-	return apierrs.IsServerTimeout(err) || apierrs.IsConflict(err) || apierrs.IsInternalError(err) ||
-		errors.Is(err, context.DeadlineExceeded)
 }
 
 // getBackupTargetPod returns the pod that should run the backup according to the current

--- a/internal/controller/backup_controller_test.go
+++ b/internal/controller/backup_controller_test.go
@@ -18,15 +18,11 @@ package controller
 
 import (
 	"context"
-	"errors"
-	"fmt"
 	"time"
 
 	volumesnapshot "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
 	corev1 "k8s.io/api/core/v1"
-	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -164,38 +160,6 @@ var _ = Describe("backup_controller barmanObjectStore unit tests", func() {
 })
 
 var _ = Describe("backup_controller volumeSnapshot unit tests", func() {
-	Context("isErrorRetryable", func() {
-		It("recognizes server timeout errors", func() {
-			err := apierrs.NewServerTimeout(schema.GroupResource{}, "test", 1)
-			Expect(isErrorRetryable(err)).To(BeTrue())
-		})
-
-		It("recognizes conflict errors", func() {
-			err := apierrs.NewConflict(schema.GroupResource{}, "test", nil)
-			Expect(isErrorRetryable(err)).To(BeTrue())
-		})
-
-		It("recognizes internal errors", func() {
-			err := apierrs.NewInternalError(fmt.Errorf("test error"))
-			Expect(isErrorRetryable(err)).To(BeTrue())
-		})
-
-		It("recognizes context deadline exceeded errors", func() {
-			err := context.DeadlineExceeded
-			Expect(isErrorRetryable(err)).To(BeTrue())
-		})
-
-		It("does not retry on not found errors", func() {
-			err := apierrs.NewNotFound(schema.GroupResource{}, "test")
-			Expect(isErrorRetryable(err)).To(BeFalse())
-		})
-
-		It("does not retry on random errors", func() {
-			err := errors.New("random error")
-			Expect(isErrorRetryable(err)).To(BeFalse())
-		})
-	})
-
 	When("there's a running backup", func() {
 		It("prevents concurrent backups", func() {
 			backupList := apiv1.BackupList{

--- a/internal/webhook/v1/backup_webhook.go
+++ b/internal/webhook/v1/backup_webhook.go
@@ -19,6 +19,7 @@ package v1
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	"github.com/cloudnative-pg/machinery/pkg/log"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -166,6 +167,17 @@ func (v *BackupCustomValidator) validate(r *apiv1.Backup) field.ErrorList {
 			r.Spec.OnlineConfiguration,
 			"cannot be empty when the backup method is plugin",
 		))
+	}
+
+	if value := r.Annotations[utils.BackupVolumeSnapshotDeadlineAnnotationName]; value != "" {
+		_, err := strconv.Atoi(value)
+		if err != nil {
+			result = append(result, field.Invalid(
+				field.NewPath("metadata", "annotations", utils.BackupVolumeSnapshotDeadlineAnnotationName),
+				value,
+				"must be an integer",
+			))
+		}
 	}
 
 	return result

--- a/pkg/reconciler/backup/volumesnapshot/errors.go
+++ b/pkg/reconciler/backup/volumesnapshot/errors.go
@@ -36,6 +36,7 @@ func isRetriableErrorMessage(msg string) bool {
 		isExplicitlyRetriableError,
 		isRetryableHTTPError,
 		isConflictError,
+		isContextDeadlineExceededError,
 	}
 
 	for _, isRetryableFunc := range isRetryableFuncs {
@@ -45,6 +46,12 @@ func isRetriableErrorMessage(msg string) bool {
 	}
 
 	return false
+}
+
+// isContextDeadlineExceededError detects context deadline exceeded errors
+// These are timeouts that may be retried by the Kubernetes CSI controller
+func isContextDeadlineExceededError(msg string) bool {
+	return strings.Contains(msg, "deadline exceeded") || strings.Contains(msg, "timed out")
 }
 
 // isConflictError detects optimistic locking errors

--- a/pkg/reconciler/backup/volumesnapshot/errors.go
+++ b/pkg/reconciler/backup/volumesnapshot/errors.go
@@ -17,15 +17,25 @@ limitations under the License.
 package volumesnapshot
 
 import (
+	"context"
+	"errors"
 	"regexp"
 	"strconv"
 	"strings"
+
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
 )
 
 var (
 	retryableStatusCodes = []int{408, 429, 500, 502, 503, 504}
 	httpStatusCodeRegex  = regexp.MustCompile(`HTTPStatusCode:\s(\d{3})`)
 )
+
+// isErrorRetryable detects is an error is retryable or not
+func isErrorRetryable(err error) bool {
+	return apierrs.IsServerTimeout(err) || apierrs.IsConflict(err) || apierrs.IsInternalError(err) ||
+		errors.Is(err, context.DeadlineExceeded)
+}
 
 // isRetriableErrorMessage detects if a certain error message belongs
 // to a retriable error or not. This is obviously an heuristic but

--- a/pkg/reconciler/backup/volumesnapshot/errors.go
+++ b/pkg/reconciler/backup/volumesnapshot/errors.go
@@ -37,7 +37,7 @@ var (
 // occur during communication between the operator and the Kubernetes
 // API server, as well as between the operator and the instance
 // manager.
-// It is not designed to  check errors raised  by the CSI  driver and
+// It is not designed to check errors raised by the CSI driver and
 // exposed by the CSI snapshotter sidecar.
 func isNetworkErrorRetryable(err error) bool {
 	return apierrs.IsServerTimeout(err) || apierrs.IsConflict(err) || apierrs.IsInternalError(err) ||

--- a/pkg/reconciler/backup/volumesnapshot/errors_test.go
+++ b/pkg/reconciler/backup/volumesnapshot/errors_test.go
@@ -33,5 +33,28 @@ var _ = Describe("Retriable error messages", func() {
 		Entry("explicitly non-retriable error", "Retriable: false because my pod is working", false),
 		Entry("error code 502 - retriable", "RetryAfter: 0s, HTTPStatusCode: 502, RawError: Internal Server Error", true),
 		Entry("error code 404 - non retriable", "RetryAfter: 0s, HTTPStatusCode: 404, RawError: Not found", false),
+		Entry("context deadline exceeded - retriable", "context deadline exceeded waiting for snapshot creation", true),
+		Entry("deadline exceeded - retriable", "deadline exceeded during Azure snapshot creation", true),
+		Entry("timed out - retriable", "operation timed out for csi-disk-handler", true),
 	)
+
+	Describe("isContextDeadlineExceededError", func() {
+		It("detects 'context deadline exceeded' error messages", func() {
+			Expect(isContextDeadlineExceededError("context deadline exceeded")).To(BeTrue())
+		})
+
+		It("detects 'deadline exceeded' error messages", func() {
+			Expect(isContextDeadlineExceededError("deadline exceeded")).To(BeTrue())
+		})
+
+		It("detects 'timed out' error messages", func() {
+			Expect(isContextDeadlineExceededError("operation timed out")).To(BeTrue())
+		})
+
+		It("rejects non-timeout error messages", func() {
+			Expect(isContextDeadlineExceededError("not found")).To(BeFalse())
+			Expect(isContextDeadlineExceededError("permission denied")).To(BeFalse())
+			Expect(isContextDeadlineExceededError("invalid input")).To(BeFalse())
+		})
+	})
 })

--- a/pkg/reconciler/backup/volumesnapshot/errors_test.go
+++ b/pkg/reconciler/backup/volumesnapshot/errors_test.go
@@ -32,7 +32,7 @@ var _ = Describe("Retriable error messages", func() {
 	DescribeTable(
 		"Retriable error messages",
 		func(msg string, isRetriable bool) {
-			Expect(isRetriableErrorMessage(msg)).To(Equal(isRetriable))
+			Expect(isCSIErrorMessageRetriable(msg)).To(Equal(isRetriable))
 		},
 		Entry("conflict", "Hey, the object has been modified!", true),
 		Entry("non-retriable error", "VolumeSnapshotClass not found", false),
@@ -66,34 +66,34 @@ var _ = Describe("Retriable error messages", func() {
 	})
 })
 
-var _ = Describe("isErrorRetryable", func() {
+var _ = Describe("isNetworkErrorRetryable", func() {
 	It("recognizes server timeout errors", func() {
 		err := apierrs.NewServerTimeout(schema.GroupResource{}, "test", 1)
-		Expect(isErrorRetryable(err)).To(BeTrue())
+		Expect(isNetworkErrorRetryable(err)).To(BeTrue())
 	})
 
 	It("recognizes conflict errors", func() {
 		err := apierrs.NewConflict(schema.GroupResource{}, "test", nil)
-		Expect(isErrorRetryable(err)).To(BeTrue())
+		Expect(isNetworkErrorRetryable(err)).To(BeTrue())
 	})
 
 	It("recognizes internal errors", func() {
 		err := apierrs.NewInternalError(fmt.Errorf("test error"))
-		Expect(isErrorRetryable(err)).To(BeTrue())
+		Expect(isNetworkErrorRetryable(err)).To(BeTrue())
 	})
 
 	It("recognizes context deadline exceeded errors", func() {
 		err := context.DeadlineExceeded
-		Expect(isErrorRetryable(err)).To(BeTrue())
+		Expect(isNetworkErrorRetryable(err)).To(BeTrue())
 	})
 
 	It("does not retry on not found errors", func() {
 		err := apierrs.NewNotFound(schema.GroupResource{}, "test")
-		Expect(isErrorRetryable(err)).To(BeFalse())
+		Expect(isNetworkErrorRetryable(err)).To(BeFalse())
 	})
 
 	It("does not retry on random errors", func() {
 		err := errors.New("random error")
-		Expect(isErrorRetryable(err)).To(BeFalse())
+		Expect(isNetworkErrorRetryable(err)).To(BeFalse())
 	})
 })

--- a/pkg/reconciler/backup/volumesnapshot/reconciler.go
+++ b/pkg/reconciler/backup/volumesnapshot/reconciler.go
@@ -619,10 +619,9 @@ func isDeadlineExceeded(backup *apiv1.Backup) (bool, error) {
 		return false, fmt.Errorf("while unmarshalling plugin metadata: %w", err)
 	}
 
-	deadlineMinutes := backup.GetVolumeSnapshotDeadline()
-
-	// if deadlineMinutes have passed since firstFailureTime we need to consider the deadline exceeded
-	return time.Now().Unix()-data.VolumeSnapshotFirstDetectedFailure > int64(deadlineMinutes*60), nil
+	// if the deadline have passed since firstFailureTime we need to consider the deadline exceeded
+	deadline := int64(backup.GetVolumeSnapshotDeadline().Seconds())
+	return time.Now().Unix()-data.VolumeSnapshotFirstDetectedFailure > deadline, nil
 }
 
 type metadata struct {

--- a/pkg/reconciler/backup/volumesnapshot/reconciler.go
+++ b/pkg/reconciler/backup/volumesnapshot/reconciler.go
@@ -159,7 +159,7 @@ func (se *Reconciler) Reconcile(
 	contextLogger := log.FromContext(ctx).WithName("volumesnapshot_reconciler")
 
 	res, err := se.internalReconcile(ctx, cluster, backup, targetPod, pvcs)
-	if isErrorRetryable(err) {
+	if isNetworkErrorRetryable(err) {
 		contextLogger.Error(err, "detected retryable error while executing snapshot backup, retrying...")
 		return &ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 	}

--- a/pkg/reconciler/backup/volumesnapshot/resources.go
+++ b/pkg/reconciler/backup/volumesnapshot/resources.go
@@ -68,10 +68,13 @@ func (err volumeSnapshotError) Error() string {
 // IsRetryable returns true if the external snapshotter controller
 // will retry taking the snapshot
 func (err volumeSnapshotError) isRetryable() bool {
-	// TODO: instead of blindingly retry on matching errors, we
-	// should enhance our CRD with a configurable deadline. After
-	// the deadline have been met on err.InternalError.CreatedAt
-	// the backup can be marked as failed
+	// The Kubernetes CSI driver/controller will automatically retry snapshot creation
+	// for certain errors, including timeouts. We use pattern matching to identify
+	// these retryable errors and handle them appropriately.
+	//
+	// TODO: Enhance our CRD with a configurable deadline/max retry time.
+	// After the deadline has been met based on err.InternalError.CreatedAt,
+	// the backup should be marked as failed instead of continuing to retry.
 
 	if err.InternalError.Message == nil {
 		return false

--- a/pkg/reconciler/backup/volumesnapshot/resources.go
+++ b/pkg/reconciler/backup/volumesnapshot/resources.go
@@ -78,7 +78,7 @@ func (err volumeSnapshotError) isRetryable() bool {
 		return false
 	}
 
-	return isRetriableErrorMessage(*err.InternalError.Message)
+	return isCSIErrorMessageRetriable(*err.InternalError.Message)
 }
 
 // slice represents a slice of []storagesnapshotv1.VolumeSnapshot

--- a/pkg/reconciler/backup/volumesnapshot/resources.go
+++ b/pkg/reconciler/backup/volumesnapshot/resources.go
@@ -26,6 +26,8 @@ import (
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 )
 
+const pluginName = "cnpg_volumesnapshot"
+
 // volumeSnapshotInfo host information about a volume snapshot
 type volumeSnapshotInfo struct {
 	// error contains the raised error when the volume snapshot terminated
@@ -71,10 +73,6 @@ func (err volumeSnapshotError) isRetryable() bool {
 	// The Kubernetes CSI driver/controller will automatically retry snapshot creation
 	// for certain errors, including timeouts. We use pattern matching to identify
 	// these retryable errors and handle them appropriately.
-	//
-	// TODO: Enhance our CRD with a configurable deadline/max retry time.
-	// After the deadline has been met based on err.InternalError.CreatedAt,
-	// the backup should be marked as failed instead of continuing to retry.
 
 	if err.InternalError.Message == nil {
 		return false

--- a/pkg/utils/labels_annotations.go
+++ b/pkg/utils/labels_annotations.go
@@ -209,6 +209,10 @@ const (
 	// BackupTablespaceMapFileAnnotationName is the name of the annotation where the `tablespace_map` file is kept
 	BackupTablespaceMapFileAnnotationName = MetadataNamespace + "/backupTablespaceMapFile"
 
+	// BackupVolumeSnapshotDeadlineAnnotationName the numbers of minutes that a retryable error will be retried before
+	// it's considered a failure
+	BackupVolumeSnapshotDeadlineAnnotationName = MetadataNamespace + "/volumeSnapshotDeadline"
+
 	// SnapshotStartTimeAnnotationName is the name of the annotation where a snapshot's start time is kept
 	SnapshotStartTimeAnnotationName = MetadataNamespace + "/snapshotStartTime"
 

--- a/pkg/utils/labels_annotations.go
+++ b/pkg/utils/labels_annotations.go
@@ -209,8 +209,8 @@ const (
 	// BackupTablespaceMapFileAnnotationName is the name of the annotation where the `tablespace_map` file is kept
 	BackupTablespaceMapFileAnnotationName = MetadataNamespace + "/backupTablespaceMapFile"
 
-	// BackupVolumeSnapshotDeadlineAnnotationName the numbers of minutes that a retryable error will be retried before
-	// it's considered a failure
+	// BackupVolumeSnapshotDeadlineAnnotationName is the annotation for the snapshot backup failure deadline in minutes.
+	// It is only applied to snapshot retryable errors
 	BackupVolumeSnapshotDeadlineAnnotationName = MetadataNamespace + "/volumeSnapshotDeadline"
 
 	// SnapshotStartTimeAnnotationName is the name of the annotation where a snapshot's start time is kept


### PR DESCRIPTION
When creating volume snapshots, the CSI controller will automatically retry snapshot creation for certain errors (including timeouts). However, CNPG was marking backups as `failed` immediately when encountering timeouts.

**This change:**
1. Added detection for `context.DeadlineExceeded` errors in `isErrorRetryable` function
2. Added new pattern matching for deadline/timeout errors in error messages
3. Improved test coverage for these scenarios
4. Added clarification in comments about future enhancements for configurable deadlines (see #7012)

Fixes #7000