### PR TITLE
docs: improve tcp_syn_retry troubleshooting section

### DIFF
--- a/.wordlist-en-custom.txt
+++ b/.wordlist-en-custom.txt
@@ -563,6 +563,7 @@ azurite
 ba
 backend
 backends
+backoff
 backport
 backported
 backporting

--- a/docs/src/troubleshooting.md
+++ b/docs/src/troubleshooting.md
@@ -797,18 +797,18 @@ you have sidecar injection enabled, retry with injection disabled.
 
 ### Replicas take over two minutes to reconnect after a failover
 
-When the primary instance fails, the operator promotes the most advanced
-standby to the primary role. Other standby instances then attempt to reconnect
-to the `-rw` service for replication. However, during this reconnection
-process, `kube-proxy` may not yet have updated its routing information.
-As a result, the initial `SYN` packet sent by the standby instances can fail
-to reach the intended destination.
+When the primary instance fails, the operator promotes the most advanced standby
+to the primary role. Other standby instances then attempt to reconnect to the
+`-rw` service for replication. However, during this reconnection process,
+`kube-proxy` may not have updated its routing information yet. As a result, the
+initial `SYN` packet sent by the standby instances might fail to reach its
+intended destination.
 
-On Linux systems, the default value for the `tcp_syn_retries` kernel parameter
-is set to 6. This configuration means the system will retry a failed connection
-for approximately 127 seconds before giving up. This extended retry period can
-significantly delay the reconnection process. For more details, consult the
+If the network is configured to silently drop packets instead of rejecting them,
+standby instances will not receive a response and will retry the connection
+after an exponential backoff period. On Linux systems, the default value for the
+`tcp_syn_retries` kernel parameter is 6, meaning the system will attempt to
+establish the connection for approximately 127 seconds before giving up. This
+prolonged retry period can significantly delay the reconnection process.
+For more details, consult the
 [tcp_syn_retries documentation](https://www.kernel.org/doc/Documentation/networking/ip-sysctl.txt).
-
-Altering this behavior will require changing the `tcp_syn_retries`
-parameter on the host node.


### PR DESCRIPTION
Removed the part about setting values on the host. The sysctl is namespaced so altering the host configuration has no effect.

Closes #7017
