### PR TITLE
ci: fix buildx bake output type

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -91,7 +91,7 @@ target "default" {
   }
 
   output = [
-    "type=registry,registry.insecure=${insecure}",
+    "type=image,registry.insecure=${insecure}",
   ]
 
   attest = [


### PR DESCRIPTION
output `type=registry` always tries to push images. Switch to `type=image`.

Closes #7016
