### PR TITLE
ci: allow configuring the output image name in bake

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -34,6 +34,10 @@ variable "latest" {
   default = "false"
 }
 
+variable "imageName" {
+  default = "cloudnative-pg"
+}
+
 variable "tag" {
   default = "dev"
 }
@@ -78,8 +82,8 @@ target "default" {
   name = "${distro}"
   platforms = ["linux/amd64", "linux/arm64"]
   tags = [
-    "${registry}/cloudnative-pg${suffix}:${tag}${distros[distro].tag}",
-    latest("${registry}/cloudnative-pg${suffix}", "${latest}"),
+    "${registry}/${imageName}${suffix}:${tag}${distros[distro].tag}",
+    latest("${registry}/${imageName}${suffix}", "${latest}"),
   ]
 
   dockerfile = "Dockerfile"


### PR DESCRIPTION
Right now the name of the output image is being hardcoded inside docker-bake.hcl.
We should make it configurable via an adhoc variable, defaulting to "cloudnative-pg".

Closes #7025 