### PR TITLE
fix: reload plugin certificates when secret changes

### DIFF
--- a/internal/cmd/manager/controller/controller.go
+++ b/internal/cmd/manager/controller/controller.go
@@ -236,7 +236,7 @@ func RunController(
 		return err
 	}
 
-	if err = controller.NewPluginReconciler(mgr, configuration.Current.OperatorNamespace, pluginRepository).
+	if err = controller.NewPluginReconciler(mgr, conf.OperatorNamespace, pluginRepository).
 		SetupWithManager(mgr, maxConcurrentReconciles); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Plugin")
 		return err

--- a/internal/cmd/manager/controller/controller.go
+++ b/internal/cmd/manager/controller/controller.go
@@ -236,8 +236,8 @@ func RunController(
 		return err
 	}
 
-	if err = controller.NewPluginReconciler(mgr, pluginRepository).
-		SetupWithManager(mgr, configuration.Current.OperatorNamespace, maxConcurrentReconciles); err != nil {
+	if err = controller.NewPluginReconciler(mgr, configuration.Current.OperatorNamespace, pluginRepository).
+		SetupWithManager(mgr, maxConcurrentReconciles); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Plugin")
 		return err
 	}

--- a/internal/cnpi/plugin/repository/setup.go
+++ b/internal/cnpi/plugin/repository/setup.go
@@ -103,7 +103,7 @@ func pluginConnectionConstructor(name string, protocol connection.Protocol) pudd
 
 func pluginConnectionDestructor(res connection.Interface) {
 	logger := log.FromContext(context.Background()).
-		WithName("setPluginProtocol").
+		WithName("pluginConnectionDestructor").
 		WithValues("pluginName", res.Name())
 
 	logger.Trace("Released physical plugin connection")

--- a/internal/cnpi/plugin/repository/setup.go
+++ b/internal/cnpi/plugin/repository/setup.go
@@ -34,11 +34,12 @@ import (
 type Interface interface {
 	// ForgetPlugin closes every connection to the plugin with the passed name
 	// and forgets its discovery info.
-	// If the plug in was not available in the repository, this is a no-op
+	// This operation is synchronous and blocks until every connection is closed.
+	// If the plug in was not available in the repository, this is a no-op.
 	ForgetPlugin(name string)
 
 	// RegisterRemotePlugin registers a plugin available on a remote
-	// TCP entrypoint
+	// TCP entrypoint.
 	RegisterRemotePlugin(name string, address string, tlsConfig *tls.Config) error
 
 	// RegisterUnixSocketPluginsInPath scans the passed directory
@@ -60,11 +61,60 @@ type data struct {
 	pluginConnectionPool map[string]*puddle.Pool[connection.Interface]
 }
 
+// pluginSetupOptions are the options to be used when setting up
+// a plugin connection
+type pluginSetupOptions struct {
+	force bool
+}
+
 // maxPoolSize is the maximum number of connections in a plugin's connection
 // pool
 const maxPoolSize = 5
 
-func (r *data) setPluginProtocol(name string, protocol connection.Protocol) error {
+func pluginConnectionConstructor(name string, protocol connection.Protocol) puddle.Constructor[connection.Interface] {
+	return func(ctx context.Context) (connection.Interface, error) {
+		logger := log.
+			FromContext(ctx).
+			WithName("setPluginProtocol").
+			WithValues("pluginName", name)
+		ctx = log.IntoContext(ctx, logger)
+
+		logger.Trace("Connecting to plugin")
+		var (
+			result  connection.Interface
+			handler connection.Handler
+			err     error
+		)
+
+		if handler, err = protocol.Dial(ctx); err != nil {
+			logger.Error(err, "Error while connecting to plugin (physical)")
+			return nil, err
+		}
+
+		if result, err = connection.LoadPlugin(ctx, handler); err != nil {
+			logger.Error(err, "Error while connecting to plugin (logical)")
+			_ = handler.Close()
+			return nil, err
+		}
+
+		return result, err
+	}
+}
+
+func pluginConnectionDestructor(res connection.Interface) {
+	logger := log.FromContext(context.Background()).
+		WithName("setPluginProtocol").
+		WithValues("pluginName", res.Name())
+
+	logger.Trace("Released physical plugin connection")
+
+	err := res.Close()
+	if err != nil {
+		logger.Warning("Error while closing plugin connection", "err", err)
+	}
+}
+
+func (r *data) setPluginProtocol(name string, protocol connection.Protocol, opts pluginSetupOptions) error {
 	r.mux.Lock()
 	defer r.mux.Unlock()
 
@@ -72,59 +122,21 @@ func (r *data) setPluginProtocol(name string, protocol connection.Protocol) erro
 		r.pluginConnectionPool = make(map[string]*puddle.Pool[connection.Interface])
 	}
 
-	_, ok := r.pluginConnectionPool[name]
-	if ok {
-		return &ErrPluginAlreadyRegistered{
-			Name: name,
-		}
-	}
-
-	constructor := func(ctx context.Context) (res connection.Interface, err error) {
-		var handler connection.Handler
-
-		defer func() {
-			if err != nil && handler != nil {
-				_ = handler.Close()
+	if oldPool, alreadyRegistered := r.pluginConnectionPool[name]; alreadyRegistered {
+		if opts.force {
+			oldPool.Close()
+		} else {
+			return &ErrPluginAlreadyRegistered{
+				Name: name,
 			}
-		}()
-
-		constructorLogger := log.
-			FromContext(ctx).
-			WithName("setPluginProtocol").
-			WithValues("pluginName", name)
-		ctx = log.IntoContext(ctx, constructorLogger)
-
-		constructorLogger.Trace("Acquired physical plugin connection")
-
-		if handler, err = protocol.Dial(ctx); err != nil {
-			constructorLogger.Error(err, "Got error while connecting to plugin")
-			return nil, err
-		}
-
-		return connection.LoadPlugin(ctx, handler)
-	}
-
-	destructor := func(res connection.Interface) {
-		constructorLogger := log.
-			FromContext(context.Background()).
-			WithName("setPluginProtocol").
-			WithValues("pluginName", name)
-		constructorLogger.Trace("Released physical plugin connection")
-
-		err := res.Close()
-		if err != nil {
-			destructorLogger := log.FromContext(context.Background()).
-				WithName("setPluginProtocol").
-				WithValues("pluginName", res.Name())
-			destructorLogger.Warning("Error while closing plugin connection", "err", err)
 		}
 	}
 
 	var err error
 	r.pluginConnectionPool[name], err = puddle.NewPool(
 		&puddle.Config[connection.Interface]{
-			Constructor: constructor,
-			Destructor:  destructor,
+			Constructor: pluginConnectionConstructor(name, protocol),
+			Destructor:  pluginConnectionDestructor,
 			MaxSize:     maxPoolSize,
 		},
 	)
@@ -143,22 +155,34 @@ func (r *data) ForgetPlugin(name string) {
 		return
 	}
 
-	// TODO(leonardoce): should we really wait for all the plugin connections
-	// to be closed?
 	pool.Close()
+	delete(r.pluginConnectionPool, name)
 }
 
 // registerUnixSocketPlugin registers a plugin available at the passed
 // unix socket path
 func (r *data) registerUnixSocketPlugin(name, path string) error {
-	return r.setPluginProtocol(name, connection.ProtocolUnix(path))
+	return r.setPluginProtocol(name, connection.ProtocolUnix(path), pluginSetupOptions{
+		// forcing the registration of a Unix socket plugin has no meaning
+		// because they can be installed and started only when the Pod is created
+		force: false,
+	})
 }
 
 func (r *data) RegisterRemotePlugin(name string, address string, tlsConfig *tls.Config) error {
-	return r.setPluginProtocol(name, &connection.ProtocolTCP{
+	protocol := &connection.ProtocolTCP{
 		TLSConfig: tlsConfig,
 		Address:   address,
-	})
+	}
+
+	// The RegisterRemotePlugin function is called when the plugin is registered for
+	// the first time and when the certificates of an existing plugin get refreshed.
+	// In the second case, the plugin loading will be forced and all existing
+	// connections will be dropped and recreated.
+	opts := pluginSetupOptions{
+		force: true,
+	}
+	return r.setPluginProtocol(name, protocol, opts)
 }
 
 func (r *data) RegisterUnixSocketPluginsInPath(pluginsPath string) ([]string, error) {

--- a/internal/cnpi/plugin/repository/setup_test.go
+++ b/internal/cnpi/plugin/repository/setup_test.go
@@ -1,0 +1,62 @@
+package repository
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Set Plugin Protocol", func() {
+	var repository *data
+
+	BeforeEach(func() {
+		repository = &data{}
+	})
+
+	It("creates connection pool for new plugin", func() {
+		err := repository.setPluginProtocol("plugin1", newUnitTestProtocol("test"), pluginSetupOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(repository.pluginConnectionPool).To(HaveKey("plugin1"))
+	})
+
+	It("fails when adding same plugin name without force", func() {
+		err := repository.setPluginProtocol("plugin1", newUnitTestProtocol("/tmp/socket"), pluginSetupOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		err = repository.setPluginProtocol("plugin1", newUnitTestProtocol("/tmp/socket2"), pluginSetupOptions{})
+		Expect(err).To(BeEquivalentTo(&ErrPluginAlreadyRegistered{Name: "plugin1"}))
+	})
+
+	It("overwrites existing plugin when force is true", func() {
+		first := newUnitTestProtocol("/tmp/socket")
+		err := repository.setPluginProtocol("plugin1", first, pluginSetupOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		pool1 := repository.pluginConnectionPool["plugin1"]
+
+		ctx1, cancel := context.WithCancel(context.Background())
+		conn1, err := pool1.Acquire(ctx1)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(conn1).NotTo(BeNil())
+		cancel()
+		conn1.Release()
+
+		second := newUnitTestProtocol("/tmp/socket2")
+		err = repository.setPluginProtocol("plugin1", second, pluginSetupOptions{force: true})
+		Expect(err).NotTo(HaveOccurred())
+		pool2 := repository.pluginConnectionPool["plugin1"]
+
+		ctx2, cancel := context.WithCancel(context.Background())
+		conn2, err := pool2.Acquire(ctx2)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(conn2).NotTo(BeNil())
+		cancel()
+		conn2.Release()
+
+		Expect(pool1).NotTo(Equal(pool2))
+		Expect(first.mockHandlers).To(HaveLen(1))
+		Expect(first.mockHandlers[0].closed).To(BeTrue())
+		Expect(second.mockHandlers).To(HaveLen(1))
+		Expect(second.mockHandlers[0].closed).To(BeFalse())
+	})
+})

--- a/internal/cnpi/plugin/repository/setup_test.go
+++ b/internal/cnpi/plugin/repository/setup_test.go
@@ -20,7 +20,7 @@ var _ = Describe("Set Plugin Protocol", func() {
 		Expect(repository.pluginConnectionPool).To(HaveKey("plugin1"))
 	})
 
-	It("fails when adding same plugin name without force", func() {
+	It("fails when adding same plugin name without forceRegistration", func() {
 		err := repository.setPluginProtocol("plugin1", newUnitTestProtocol("/tmp/socket"), pluginSetupOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
@@ -28,7 +28,7 @@ var _ = Describe("Set Plugin Protocol", func() {
 		Expect(err).To(BeEquivalentTo(&ErrPluginAlreadyRegistered{Name: "plugin1"}))
 	})
 
-	It("overwrites existing plugin when force is true", func() {
+	It("overwrites existing plugin when forceRegistration is true", func() {
 		first := newUnitTestProtocol("/tmp/socket")
 		err := repository.setPluginProtocol("plugin1", first, pluginSetupOptions{})
 		Expect(err).NotTo(HaveOccurred())
@@ -42,7 +42,7 @@ var _ = Describe("Set Plugin Protocol", func() {
 		conn1.Release()
 
 		second := newUnitTestProtocol("/tmp/socket2")
-		err = repository.setPluginProtocol("plugin1", second, pluginSetupOptions{force: true})
+		err = repository.setPluginProtocol("plugin1", second, pluginSetupOptions{forceRegistration: true})
 		Expect(err).NotTo(HaveOccurred())
 		pool2 := repository.pluginConnectionPool["plugin1"]
 

--- a/internal/cnpi/plugin/repository/suite_test.go
+++ b/internal/cnpi/plugin/repository/suite_test.go
@@ -1,0 +1,119 @@
+package repository
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/cloudnative-pg/cnpg-i/pkg/identity"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/test/bufconn"
+
+	"github.com/cloudnative-pg/cloudnative-pg/internal/cnpi/plugin/connection"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestRepository(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Repository Suite")
+}
+
+type identityImplementation struct {
+	identity.UnimplementedIdentityServer
+}
+
+// GetPluginMetadata implements Identity
+func (i identityImplementation) GetPluginMetadata(
+	_ context.Context,
+	_ *identity.GetPluginMetadataRequest,
+) (*identity.GetPluginMetadataResponse, error) {
+	return &identity.GetPluginMetadataResponse{
+		Name:          "testing-service",
+		Version:       "0.0.1",
+		DisplayName:   "testing-service",
+		ProjectUrl:    "https://github.com/cloudnative-pg/cloudnative-pg",
+		RepositoryUrl: "https://github.com/cloudnative-pg/cloudnative-pg",
+		License:       "APACHE 2.0",
+		Maturity:      "alpha",
+	}, nil
+}
+
+// GetPluginCapabilities implements identity
+func (i identityImplementation) GetPluginCapabilities(
+	_ context.Context,
+	_ *identity.GetPluginCapabilitiesRequest,
+) (*identity.GetPluginCapabilitiesResponse, error) {
+	return &identity.GetPluginCapabilitiesResponse{
+		Capabilities: []*identity.PluginCapability{},
+	}, nil
+}
+
+// Probe implements Identity
+func (i identityImplementation) Probe(
+	_ context.Context,
+	_ *identity.ProbeRequest,
+) (*identity.ProbeResponse, error) {
+	return &identity.ProbeResponse{
+		Ready: true,
+	}, nil
+}
+
+type unitTestProtocol struct {
+	name         string
+	mockHandlers []*mockHandler
+	server       *grpc.Server
+}
+
+type mockHandler struct {
+	*grpc.ClientConn
+	closed bool
+}
+
+func newUnitTestProtocol(name string) *unitTestProtocol {
+	return &unitTestProtocol{name: name}
+}
+
+func (h *mockHandler) Close() error {
+	_ = h.ClientConn.Close()
+	h.closed = true
+	return nil
+}
+
+func (p *unitTestProtocol) Dial(ctx context.Context) (connection.Handler, error) {
+	listener := bufconn.Listen(1024 * 1024)
+
+	if len(p.mockHandlers) == 0 {
+		p.server = grpc.NewServer()
+
+		identity.RegisterIdentityServer(p.server, &identityImplementation{})
+
+		go func() {
+			<-ctx.Done()
+			p.server.Stop()
+		}()
+
+		go func() {
+			_ = p.server.Serve(listener)
+		}()
+	}
+
+	dialer := func(_ context.Context, _ string) (net.Conn, error) {
+		return listener.Dial()
+	}
+
+	conn, err := grpc.NewClient("passthrough://bufnet",
+		grpc.WithContextDialer(dialer),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		return nil, err
+	}
+	mh := &mockHandler{
+		ClientConn: conn,
+	}
+	p.mockHandlers = append(p.mockHandlers, mh)
+	return mh, nil
+}

--- a/internal/controller/plugin_controller.go
+++ b/internal/controller/plugin_controller.go
@@ -88,7 +88,7 @@ func (r *PluginReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	}
 
 	if !isPluginService(&service, r.OperatorNamespace) {
-		contextLogger.Trace("Skipping reconciliation for a non-cnpgi service")
+		contextLogger.Trace("Skipping reconciliation for a non-cnpg-i service")
 		return ctrl.Result{}, nil
 	}
 
@@ -238,7 +238,7 @@ func (r *PluginReconciler) mapSecretToPlugin(ctx context.Context, obj client.Obj
 	); err != nil {
 		logger.Error(
 			err,
-			"Error while listing CNPG-i services in the operator namespace",
+			"Error while listing CNPG-I services in the operator namespace",
 		)
 		return nil
 	}

--- a/internal/controller/plugin_predicates.go
+++ b/internal/controller/plugin_predicates.go
@@ -22,7 +22,7 @@ import (
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 )
 
-var isPluginService = func(object client.Object, operatorNamespace string) bool {
+func isPluginService(object client.Object, operatorNamespace string) bool {
 	if object.GetNamespace() != operatorNamespace {
 		// Only consider the services that are in the same
 		// namespace where the operator is installed
@@ -49,4 +49,15 @@ var isPluginService = func(object client.Object, operatorNamespace string) bool 
 	}
 
 	return true
+}
+
+// isSecretUsedByPluginService returns true when the secret with the passed name
+// is used by the passed service
+func isSecretUsedByPluginService(service client.Object, secretName string) bool {
+	annotations := service.GetAnnotations()
+
+	clientSecretName := annotations[utils.PluginClientSecretAnnotationName]
+	serverSecretName := annotations[utils.PluginServerSecretAnnotationName]
+
+	return clientSecretName == secretName || serverSecretName == secretName
 }

--- a/internal/controller/plugin_predicates.go
+++ b/internal/controller/plugin_predicates.go
@@ -51,8 +51,8 @@ func isPluginService(object client.Object, operatorNamespace string) bool {
 	return true
 }
 
-// isSecretUsedByPluginService returns true when the secret with the passed name
-// is used by the passed service
+// isSecretUsedByPluginService returns true when the passed service
+// uses the secret with the passed name
 func isSecretUsedByPluginService(service client.Object, secretName string) bool {
 	annotations := service.GetAnnotations()
 


### PR DESCRIPTION
This patch uses the existing operator watch infrastructure to reload the plugin TLS secrets when they change.

Fixes: #7024 

# Release notes

```
Automatic reload the TLS certificates of the CNPG-i plugins when they change.
```