### PR TITLE
ci(release): build specific ids during release process

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -153,7 +153,7 @@ jobs:
         with:
           distribution: goreleaser
           version: v2
-          args: release --clean --timeout 60m
+          args: release --clean --timeout 60m --id manager --id kubectl-cnpg
         env:
           DATE: ${{ env.DATE }}
           COMMIT: ${{ env.COMMIT }}


### PR DESCRIPTION
Goreleaser by default builds all the ids inside the goreleaser file, after we included the `-race` build detection this was being build inside the release process and is not desired, now we build the specific ids we want for the release