### PR TITLE
ci(release): build race only when RACE env is set

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -534,6 +534,7 @@ jobs:
           DATE: ${{ env.DATE }}
           COMMIT: ${{ env.COMMIT }}
           VERSION: ${{ env.VERSION }}
+          RACE: "true"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -153,7 +153,7 @@ jobs:
         with:
           distribution: goreleaser
           version: v2
-          args: release --clean --timeout 60m --id manager --id kubectl-cnpg
+          args: release --clean --timeout 60m
         env:
           DATE: ${{ env.DATE }}
           COMMIT: ${{ env.COMMIT }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -37,6 +37,8 @@ builds:
   binary: manager/manager_{{ .Arch }}
   main: cmd/manager/main.go
   no_unique_dist_dir: true
+  skip: >-
+    {{ if and (isEnvSet "RACE") (eq .Env.RACE "true") }}false{{ else }}true{{ end }}
   gcflags:
     - all=-trimpath={{.Env.GOPATH}};{{.Env.PWD}}
   ldflags:


### PR DESCRIPTION
We build the manager-race id with GoReleaser when the RACE env variable is set