### PR TITLE
ci(release): add missing permission to the release workflow

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -14,6 +14,7 @@ env:
 permissions:
   contents: write
   packages: write
+  id-token: write
 
 jobs:
 


### PR DESCRIPTION
The release-publish.yml was missing the id-token permission required by cosign to sign the container images