### PR TITLE
test: larger eks image

### DIFF
--- a/hack/e2e/eks-cluster.yaml.template
+++ b/hack/e2e/eks-cluster.yaml.template
@@ -11,7 +11,7 @@ iam:
 
 managedNodeGroups:
   - name: default
-    instanceType: m5.large
+    instanceType: c6g.xlarge
     desiredCapacity: 3
 
 addons:


### PR DESCRIPTION
Drain E2E on EKS can fail because the operator can become unschedulable during a drain due to cpu requirements not available. Use a larger machine.

Closes #7052
