### PR TITLE
test: run EKS e2e on x86_64 instead of arm64

### DIFF
--- a/hack/e2e/eks-cluster.yaml.template
+++ b/hack/e2e/eks-cluster.yaml.template
@@ -11,7 +11,7 @@ iam:
 
 managedNodeGroups:
   - name: default
-    instanceType: c6g.xlarge
+    instanceType: c6a.xlarge
     desiredCapacity: 3
 
 addons:


### PR DESCRIPTION
In #7053 we switched to a machine with 4 cpus instead of 2, but the architecture was changed as well. To keep the tests aligned, we change to a 4 cpus x86_64 machine.