### PR TITLE
fix(PodMonitor): add proper `matchLabels` constraints

### DIFF
--- a/pkg/specs/pgbouncer/podmonitor.go
+++ b/pkg/specs/pgbouncer/podmonitor.go
@@ -63,7 +63,10 @@ func (c PoolerPodMonitorManager) BuildPodMonitor() *monitoringv1.PodMonitor {
 
 	spec := monitoringv1.PodMonitorSpec{
 		Selector: metav1.LabelSelector{
-			MatchLabels: meta.Labels,
+			MatchLabels: map[string]string{
+				utils.PgbouncerNameLabel: c.pooler.Name,
+				utils.PodRoleLabelName:   string(utils.PodRolePooler),
+			},
 		},
 		PodMetricsEndpoints: []monitoringv1.PodMetricsEndpoint{endpoint},
 	}

--- a/pkg/specs/pgbouncer/podmonitor_test.go
+++ b/pkg/specs/pgbouncer/podmonitor_test.go
@@ -76,6 +76,7 @@ var _ = Describe("PoolerPodMonitorManager", func() {
 
 			Expect(podMonitor.Spec.Selector.MatchLabels).To(Equal(map[string]string{
 				utils.PgbouncerNameLabel: pooler.Name,
+				utils.PodRoleLabelName:   string(utils.PodRolePooler),
 			}))
 
 			Expect(podMonitor.Spec.PodMetricsEndpoints).To(HaveLen(1))

--- a/pkg/specs/podmonitor.go
+++ b/pkg/specs/podmonitor.go
@@ -24,6 +24,7 @@ import (
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/certs"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 )
 
 // ClusterPodMonitorManager builds the PodMonitor for the cluster resource
@@ -74,7 +75,10 @@ func (c ClusterPodMonitorManager) BuildPodMonitor() *monitoringv1.PodMonitor {
 
 	spec := monitoringv1.PodMonitorSpec{
 		Selector: metav1.LabelSelector{
-			MatchLabels: meta.Labels,
+			MatchLabels: map[string]string{
+				utils.ClusterLabelName: c.cluster.Name,
+				utils.PodRoleLabelName: string(utils.PodRoleInstance),
+			},
 		},
 		PodMetricsEndpoints: []monitoringv1.PodMetricsEndpoint{endpoint},
 	}

--- a/pkg/specs/podmonitor_test.go
+++ b/pkg/specs/podmonitor_test.go
@@ -62,8 +62,14 @@ var _ = Describe("PodMonitor test", func() {
 		It("should create a valid monitoringv1.PodMonitor object", func() {
 			mgr := NewClusterPodMonitorManager(cluster.DeepCopy())
 			monitor := mgr.BuildPodMonitor()
-			Expect(monitor.Labels[utils.ClusterLabelName]).To(Equal(cluster.Name))
-			Expect(monitor.Spec.Selector.MatchLabels[utils.ClusterLabelName]).To(Equal(cluster.Name))
+			Expect(monitor.Labels).To(BeEquivalentTo(map[string]string{
+				utils.ClusterLabelName: cluster.Name,
+			}))
+			Expect(monitor.Spec.Selector.MatchLabels).To(BeEquivalentTo(map[string]string{
+				utils.ClusterLabelName: cluster.Name,
+				utils.PodRoleLabelName: string(utils.PodRoleInstance),
+			}))
+
 			Expect(monitor.Spec.PodMetricsEndpoints).To(ContainElement(expectedEndpoint))
 		})
 


### PR DESCRIPTION
## Release Notes

The generated `PodMonitors` now have an appropriate `matchLabels` scope for the targeted pooler and cluster pods. Previously, the `matchLabels` were too broad and wrongly inherited labels from the cluster, leading to data collection from unwanted targets.

The following `matchLabels` will be generated:

For PodMonitors targeting cluster instance pods
```
"cnpg.io/cluster": <cluster_name>,
"cnpg.io/podRole": "instance"
```

For PodMonitors targeting pooler pods
```
"cnpg.io/poolerName": <pooler_name>
"cnpg.io/podRole": "pooler"
```

Closes #7006 
