### PR TITLE
[draft] Automatically switch cluster to read-only on a high disk usage

### DIFF
--- a/api/v1/cluster_funcs.go
+++ b/api/v1/cluster_funcs.go
@@ -666,6 +666,20 @@ func (cluster *Cluster) GetMaxStopDelay() int32 {
 	return 1800
 }
 
+func (cluster *Cluster) GetReadOnlyDiskUsageThreshold() float64 {
+	if cluster.Spec.DiskWatcher != nil && cluster.Spec.DiskWatcher.ReadOnlyThreshold != nil {
+		return float64(*cluster.Spec.DiskWatcher.ReadOnlyThreshold)
+	}
+	return DefaultReadOnlyDiskUsageThreshold
+}
+
+func (cluster *Cluster) GetDiskWatcherCheckInterval() time.Duration {
+	if cluster.Spec.DiskWatcher != nil && cluster.Spec.DiskWatcher.DiskSpaceCheckInterval != nil {
+		return time.Duration(*cluster.Spec.DiskWatcher.DiskSpaceCheckInterval) * time.Second
+	}
+	return time.Duration(DefaultDiskWatcherCheckInterval) * time.Second
+}
+
 // GetSmartShutdownTimeout is used to ensure that smart shutdown timeout is a positive integer
 func (cluster *Cluster) GetSmartShutdownTimeout() int32 {
 	if cluster.Spec.SmartShutdownTimeout != nil {

--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -481,6 +481,10 @@ type ClusterSpec struct {
 	// in the PostgreSQL Pods.
 	// +optional
 	Probes *ProbesConfiguration `json:"probes,omitempty"`
+
+	// The configuration of the disk watcher
+	// +optional
+	DiskWatcher *DiskWatcherConfiguration `json:"diskWatcher,omitempty"`
 }
 
 // ProbesConfiguration represent the configuration for the probes
@@ -494,6 +498,20 @@ type ProbesConfiguration struct {
 
 	// The readiness probe configuration
 	Readiness *Probe `json:"readiness,omitempty"`
+}
+
+// DiskWatcherConfiguration defines parameters
+// for cluster free disk space checks. If the free disk space
+// falls below the specified threshold, the instance manager
+// will switch all databases in cluster to read-only mode.
+type DiskWatcherConfiguration struct {
+	// Disk usage threshold, in percents. After the disk usage exceeds this value,
+	// the instance manager will switch all databases in the cluster
+	// to read-only mode.
+	ReadOnlyThreshold *int32 `json:"readOnlyThreshold,omitempty"`
+
+	// Interval between free disk space checks, in seconds.
+	DiskSpaceCheckInterval *int32 `json:"diskSpaceCheckInterval,omitempty"`
 }
 
 // Probe describes a health check to be performed against a container to determine whether it is
@@ -1211,6 +1229,15 @@ const (
 	// FailureThreshold of startupProbe, the formula is `FailureThreshold = ceiling(startDelay / periodSeconds)`,
 	// the minimum value is 1
 	DefaultStartupDelay = 3600
+
+	// DefaultReadOnlyDiskUsageThreshold is the disk usage percentage threshold after which the instance will
+	// be put to ReadOnly mode. After the disk usage drops below the threshold, the instance will be put back to
+	// ReadWrite mode.
+	DefaultReadOnlyDiskUsageThreshold = 95
+
+	// DefaultDiskWatcherCheckInterval is the default interval in seconds
+	// for the disk watcher to check the disk usage
+	DefaultDiskWatcherCheckInterval = 30
 )
 
 // SynchronousReplicaConfigurationMethod configures whether to use

--- a/config/crd/bases/postgresql.cnpg.io_clusters.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_clusters.yaml
@@ -2100,6 +2100,21 @@ spec:
               description:
                 description: Description of this PostgreSQL cluster
                 type: string
+              diskWatcher:
+                description: The configuration of the disk watcher
+                properties:
+                  diskSpaceCheckInterval:
+                    description: Interval between free disk space checks, in seconds.
+                    format: int32
+                    type: integer
+                  readOnlyThreshold:
+                    description: |-
+                      Disk usage threshold, in percents. After the disk usage exceeds this value,
+                      the instance manager will switch all databases in the cluster
+                      to read-only mode.
+                    format: int32
+                    type: integer
+                type: object
               enablePDB:
                 default: true
                 description: |-

--- a/internal/cmd/manager/instance/run/cmd.go
+++ b/internal/cmd/manager/instance/run/cmd.go
@@ -330,6 +330,12 @@ func runSubCommand(ctx context.Context, instance *postgres.Instance) error {
 		return err
 	}
 
+	diskWatcher := controller.NewDiskWatcher(ctx, instance)
+	if err = mgr.Add(diskWatcher); err != nil {
+		contextLogger.Error(err, "unable to add disk watcher")
+		return err
+	}
+
 	contextLogger.Info("starting tablespace manager")
 	if err := tablespaces.NewTablespaceReconciler(instance, mgr.GetClient()).
 		SetupWithManager(mgr); err != nil {

--- a/internal/management/controller/disk_watcher.go
+++ b/internal/management/controller/disk_watcher.go
@@ -1,0 +1,148 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres"
+	"github.com/cloudnative-pg/machinery/pkg/log"
+	"time"
+)
+
+type DisKWatcher struct {
+	instance *postgres.Instance
+
+	globalCtx    context.Context
+	globalCancel context.CancelFunc
+}
+
+func NewDiskWatcher(ctx context.Context, instance *postgres.Instance) *DisKWatcher {
+	return &DisKWatcher{
+		instance:  instance,
+		globalCtx: ctx,
+	}
+}
+
+func (dw *DisKWatcher) Start(ctx context.Context) error {
+	contextLog := log.FromContext(ctx).WithName("DiskWatcher")
+	go func() {
+		updateInterval := 5 * time.Second
+		ticker := time.NewTicker(updateInterval)
+
+		defer func() {
+			ticker.Stop()
+			contextLog.Info("Terminated DiskWatcher loop")
+		}()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+			}
+
+			newInterval := dw.instance.DiskWatcherCheckInterval
+			if newInterval == 0 {
+				// If the interval is set to 0, it might mean the one of the following
+				// 1. The feature is disabled
+				// 2. The feature is enabled but the instance reconcilation is not done yet
+				// In any of these two cases, we will do nothing here and wait.
+				continue
+			}
+
+			if newInterval != updateInterval {
+				// If the interval has changed, update the ticker
+				ticker.Reset(newInterval)
+				updateInterval = newInterval
+			}
+
+			err := dw.reconcileDiskUsageWatcher(ctx, contextLog)
+			if err != nil {
+				contextLog.Warning("reconciling disk usage watcher", "err", err)
+				continue
+			}
+		}
+	}()
+	<-ctx.Done()
+	return nil
+}
+
+func (dw *DisKWatcher) reconcileDiskUsageWatcher(ctx context.Context, ctxLog log.Logger) error {
+	if !dw.instance.CanCheckReadiness() {
+		return fmt.Errorf("instance is not ready yet")
+	}
+
+	isPrimary, err := dw.instance.IsPrimary()
+	if err != nil {
+		return fmt.Errorf("check if the instance is primary: %w", err)
+	}
+
+	if !isPrimary {
+		// Instance is not primary, skip the reconcile
+		return nil
+	}
+
+	used, err := dw.instance.GetPgDataDiskUsage()
+	if err != nil {
+		return fmt.Errorf("calculate disk usage: %w", err)
+	}
+
+	conn, err := dw.instance.GetSuperUserDB()
+	if err != nil {
+		return fmt.Errorf("get connection to the postgres database: %w", err)
+	}
+
+	tx, err := conn.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		// This is a no-op when the transaction is committed
+		_ = tx.Rollback()
+	}()
+
+	// Get the list of databases and their default_transaction_read_only status
+	statusByDatabase, err := dw.instance.GetDBAndStatus(tx)
+	if err != nil {
+		return fmt.Errorf("get databases and their status: %w", err)
+	}
+
+	killExistingConnections := false
+	if used < dw.instance.ReadOnlyDiskUsageThreshold {
+		// Disk usage is below the threshold, set all databases to read-write
+		for dbName, isReadOnly := range statusByDatabase {
+			if isReadOnly {
+				err := dw.instance.OpenDatabase(tx, dbName)
+				if err != nil {
+					return fmt.Errorf("open database %s: %w", dbName, err)
+				}
+				killExistingConnections = true
+			}
+		}
+	} else {
+		// Disk usage is above the threshold, set all databases to read-only
+		for dbName, isReadOnly := range statusByDatabase {
+			if !isReadOnly {
+				err := dw.instance.CloseDatabase(tx, dbName)
+				if err != nil {
+					return fmt.Errorf("close database %s: %w", dbName, err)
+				}
+				killExistingConnections = true
+			}
+		}
+	}
+
+	if killExistingConnections {
+		ctxLog.Warning(
+			"default_transaction_readonly state changed, dropping existing user connections for changes to take effect",
+			"disk_usage", fmt.Sprintf("%.2f", used),
+			"threshold", fmt.Sprintf("%.2f", dw.instance.ReadOnlyDiskUsageThreshold))
+		// Drop existing connections for changes to take effect. This is necessary
+		// because the old connections will retain the old read-only session configuration.
+		err = dw.instance.DropUserConnections()
+		if err != nil {
+			return fmt.Errorf("drop existing connections: %w", err)
+		}
+	}
+
+	return tx.Commit()
+}

--- a/internal/management/controller/instance_controller.go
+++ b/internal/management/controller/instance_controller.go
@@ -977,6 +977,8 @@ func (r *InstanceReconciler) reconcileInstance(cluster *apiv1.Cluster) {
 	r.instance.MaxStopDelay = cluster.GetMaxStopDelay()
 	r.instance.SmartStopDelay = cluster.GetSmartShutdownTimeout()
 	r.instance.RequiresDesignatedPrimaryTransition = detectRequiresDesignatedPrimaryTransition()
+	r.instance.ReadOnlyDiskUsageThreshold = cluster.GetReadOnlyDiskUsageThreshold()
+	r.instance.DiskWatcherCheckInterval = cluster.GetDiskWatcherCheckInterval()
 }
 
 // PostgreSQLAutoConfWritable reconciles the permissions bit of `postgresql.auto.conf`

--- a/pkg/management/postgres/instance.go
+++ b/pkg/management/postgres/instance.go
@@ -22,6 +22,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"golang.org/x/sys/unix"
 	"io/fs"
 	"math"
 	"os"
@@ -211,6 +212,13 @@ type Instance struct {
 
 	// ServerCertificate is the certificate we use to serve https connections
 	ServerCertificate *tls.Certificate
+
+	// ReadOnlyDiskUsageThreshold is the minimal amount of disk space usage in percentage
+	// after which the instance should be put in Read-Only mode.
+	ReadOnlyDiskUsageThreshold float64
+
+	// DiskWatcherCheckInterval is the interval at which the disk watcher should check the disk usage
+	DiskWatcherCheckInterval time.Duration
 }
 
 // SetPostgreSQLAutoConfWritable allows or deny writes to the
@@ -749,6 +757,58 @@ func (instance *Instance) GetPgVersion() (semver.Version, error) {
 	return *parsedVersion, nil
 }
 
+// GetDBAndStatus retrieves all non-system databases and their default_transaction_read_only status.
+func (instance *Instance) GetDBAndStatus(conn *sql.Tx) (map[string]bool, error) {
+	query := `
+        SELECT datname,
+        COALESCE(setconfig @> '{default_transaction_read_only=true}'::text[], false) AS read_only
+        FROM pg_database
+        LEFT JOIN pg_db_role_setting
+        ON (setdatabase=oid)
+        WHERE datname != 'postgres' AND NOT datistemplate`
+
+	rows, err := conn.Query(query)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	databases := make(map[string]bool)
+
+	for rows.Next() {
+		var dbName string
+		var readOnly bool
+
+		if err := rows.Scan(&dbName, &readOnly); err != nil {
+			return nil, err
+		}
+
+		// Escape the database name
+		escapedDBName := fmt.Sprintf(`"%s"`, dbName)
+		databases[escapedDBName] = readOnly
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return databases, nil
+}
+
+// CloseDatabase sets default_transaction_read_only to true for the specified database.
+func (instance *Instance) CloseDatabase(conn *sql.Tx, dbName string) error {
+	query := fmt.Sprintf(`ALTER DATABASE %s SET default_transaction_read_only TO true`, dbName)
+	_, err := conn.Exec(query)
+	return err
+}
+
+// OpenDatabase resets default_transaction_read_only for the specified database.
+func (instance *Instance) OpenDatabase(conn *sql.Tx, dbName string) error {
+	query := fmt.Sprintf(`ALTER DATABASE %s RESET default_transaction_read_only`, dbName)
+	_, err := conn.Exec(query)
+	return err
+}
+
 // ConnectionPool gets or initializes the connection pool for this instance
 func (instance *Instance) ConnectionPool() *pool.ConnectionPool {
 	const applicationName = "cnpg-instance-manager"
@@ -1264,6 +1324,25 @@ func (instance *Instance) DropConnections() error {
 	return nil
 }
 
+// DropUserConnections drops all the connections that hold user sessions
+func (instance *Instance) DropUserConnections() error {
+	conn, err := instance.GetSuperUserDB()
+	if err != nil {
+		return err
+	}
+
+	if _, err := conn.Exec(
+		`SELECT pg_terminate_backend(pid)
+			   FROM pg_stat_activity
+			   WHERE pid <> pg_backend_pid()
+			     AND usename NOT IN ('postgres') AND backend_type != 'walsender';`,
+	); err != nil {
+		return fmt.Errorf("while dropping user connections: %w", err)
+	}
+
+	return nil
+}
+
 // GetPrimaryConnInfo returns the DSN to reach the primary
 func (instance *Instance) GetPrimaryConnInfo() string {
 	return buildPrimaryConnInfo(instance.GetClusterName()+"-rw", instance.GetPodName())
@@ -1306,4 +1385,26 @@ func (instance *Instance) HandleInstanceCommandRequests(
 	default:
 		return false, fmt.Errorf("unrecognized request: %s", req)
 	}
+}
+
+func (instance *Instance) GetPgDataDiskUsage() (float64, error) {
+	var stat unix.Statfs_t
+	err := unix.Statfs(instance.PgData, &stat)
+	if err != nil {
+		return 0, fmt.Errorf("while getting disk space information: %w", err)
+	}
+
+	// Total space = block size * total blocks
+	total := stat.Blocks * uint64(stat.Bsize)
+	// Free space = block size * free blocks
+	free := stat.Bfree * uint64(stat.Bsize)
+	// Used space = total space - free space
+	used := total - free
+
+	// Calculate percentage of used space
+	if total > 0 {
+		return (float64(used) / float64(total)) * 100, nil
+	}
+
+	return 0, nil
 }

--- a/pkg/management/postgres/pool/pool.go
+++ b/pkg/management/postgres/pool/pool.go
@@ -112,12 +112,13 @@ func (pool *ConnectionPool) newConnection(dbname string) (*sql.DB, error) {
 	// * Declarative Role Management
 	// * Probes
 	// * Replication slots reconciler
+	// * Disk usage watcher (Read-Only switch manager)
 	// * Online VolumeSnapshot backup connection
 	//
 	// The latter will use an exclusive connection, that is required
 	// for the PostgreSQL Physical backup APIs
 
-	db.SetMaxOpenConns(3)
+	db.SetMaxOpenConns(4)
 	db.SetMaxIdleConns(0)
 
 	return db, nil


### PR DESCRIPTION
Hello, folks!

I propose to implement the periodic free disk space checks on behalf of cloudnative-pg instance manager. These checks will occur every `DiskSpaceCheckInterval` seconds.

If disk usage exceeds the `ReadOnlyThreshold`, instance will be automatically switched to read-only mode, i.e. all databases except `postgres` and template ones will be altered with `default_transaction_read_only` set to true.

If disk usage drops below the `ReadOnlyThreshold`, instance will be automatically switched back to read-write mode.

To ensure the propagation of the instance changes, all client connections will be dropped after the RW / RO mode switch.


Example:

```
postgres@postgresql-cluster-3:/$ fallocate -l9.4G /var/lib/postgresql/data/test

...

logs:

│ postgres {"level":"info","ts":"2025-03-03T15:23:32.381741445Z","logger":"DiskWatcher","msg":"default_transaction_readonly state changed, dropping existing user connections for changes to take effect","l │
│ ogger":"instance-manager","logging_pod":"postgresql-cluster-3","disk_usage":"99.23","threshold":"95.00"} 

...

postgres=# SELECT datname,
        COALESCE(setconfig @> '{default_transaction_read_only=true}'::text[], false) AS read_only
        FROM pg_database
        LEFT JOIN pg_db_role_setting
        ON (setdatabase=oid)
        WHERE datname != 'postgres' AND NOT datistemplate;
  datname   | read_only
------------+-----------
 usernamedt | t
(1 row)

postgres@postgresql-cluster-3:/$ rm /var/lib/postgresql/data/test

│ postgres {"level":"info","ts":"2025-03-03T15:29:32.381334211Z","logger":"DiskWatcher","msg":"default_transaction_readonly state changed, dropping existing user connections for changes to take effect","l │
│ ogger":"instance-manager","logging_pod":"postgresql-cluster-3","disk_usage":"1.91","threshold":"95.00"}                                                                                                    │

postgres=# SELECT datname,
        COALESCE(setconfig @> '{default_transaction_read_only=true}'::text[], false) AS read_only
        FROM pg_database
        LEFT JOIN pg_db_role_setting
        ON (setdatabase=oid)
        WHERE datname != 'postgres' AND NOT datistemplate;
  datname   | read_only
------------+-----------
 usernamedt | f
(1 row)


```

Existing connections are dropped during the RW / RO mode changes:
```
➜  ~ /opt/homebrew/Cellar/postgresql@16/16.4_1/bin/pgbench -i -s 100 "host=HOST\
   port=5432 \
   dbname=usernamedt \
   user=usernamedt"
Password:
dropping old tables...
NOTICE:  table "pgbench_accounts" does not exist, skipping
NOTICE:  table "pgbench_branches" does not exist, skipping
NOTICE:  table "pgbench_history" does not exist, skipping
NOTICE:  table "pgbench_tellers" does not exist, skipping
creating tables...
generating data (client-side)...
pgbench: error: query failed: FATAL:  terminating connection due to administrator command
FATAL:  server conn crashed?
server closed the connection unexpectedly
	This probably means the server terminated abnormally
	before or while processing the request.
pgbench: detail: Query was: insert into pgbench_tellers(tid,bid,tbalance) values (728,73,0)
```

if we try to write now there will be an expected error:

```
➜  ~ /opt/homebrew/Cellar/postgresql@16/16.4_1/bin/pgbench -i -s 100 "host=HOST\
   port=5432 \
   dbname=usernamedt \
   user=usernamedt"
Password:
dropping old tables...
pgbench: error: query failed: ERROR:  cannot execute DROP TABLE in a read-only transaction
pgbench: detail: Query was: drop table if exists pgbench_accounts, pgbench_branches, pgbench_history, pgbench_tellers
```

if default_transaction_read_only is altered manually, user can create / drop the tables, etc.

```
➜  ~ /opt/homebrew/Cellar/postgresql@16/16.4_1/bin/psql "host=HOST\
   port=5432 \
   dbname=usernamedt \
   user=usernamedt"
Password for user usernamedt:
psql (16.4 (Homebrew), server 16.6 (...))
Type "help" for help.

usernamedt=> set default_transaction_read_only = false;
SET

usernamedt=> drop table public.pgbench_accounts ;
DROP TABLE
```