### PR TITLE
fix(plugin,backup): close plugin connection

### DIFF
--- a/pkg/management/postgres/webserver/plugin_backup.go
+++ b/pkg/management/postgres/webserver/plugin_backup.go
@@ -116,6 +116,7 @@ func (b *PluginBackupCommand) invokeStart(ctx context.Context) {
 		b.markBackupAsFailed(ctx, err)
 		return
 	}
+	defer cli.Close(ctx)
 
 	// record the backup beginning
 	contextLogger.Info("Plugin backup started")


### PR DESCRIPTION
## Release Notes

The operator now properly closes the plugin connection when initiating a backup using the plugin.