### PR TITLE
fix(repository,plugin): ensure that `repository` is closed

### DIFF
--- a/internal/cmd/manager/controller/controller.go
+++ b/internal/cmd/manager/controller/controller.go
@@ -217,6 +217,7 @@ func RunController(
 	); err != nil {
 		setupLog.Error(err, "Unable to load sidecar CNPG-i plugins, skipping")
 	}
+	defer pluginRepository.Close()
 
 	if err = controller.NewClusterReconciler(
 		mgr,

--- a/pkg/management/postgres/webserver/plugin_backup.go
+++ b/pkg/management/postgres/webserver/plugin_backup.go
@@ -57,16 +57,6 @@ func NewPluginBackupCommand(
 ) *PluginBackupCommand {
 	backup.EnsureGVKIsPresent()
 
-	logger := log.WithValues(
-		"pluginConfiguration", backup.Spec.PluginConfiguration,
-		"backupName", backup.Name,
-		"backupNamespace", backup.Name)
-
-	plugins := repository.New()
-	if _, err := plugins.RegisterUnixSocketPluginsInPath(configuration.Current.PluginSocketDir); err != nil {
-		logger.Error(err, "Error while discovering plugins")
-	}
-
 	return &PluginBackupCommand{
 		Cluster:  cluster,
 		Backup:   backup,


### PR DESCRIPTION
No Release notes

This patch ensures that we only open the plugin repository when necessary, and that we close it when done.