### PR TITLE
chore: delete the registry when cleaning up the test cluster

### DIFF
--- a/hack/setup-cluster.sh
+++ b/hack/setup-cluster.sh
@@ -213,6 +213,8 @@ destroy_kind() {
   docker network disconnect "kind" "${registry_name}" &>/dev/null || true
   kind delete cluster --name "${cluster_name}" || true
   docker network rm "kind" &>/dev/null || true
+  docker container stop "${registry_name}" &>/dev/null || true
+  docker rm "${registry_name}" &>/dev/null || true
 }
 
 ##


### PR DESCRIPTION
When applying `hack/setup-cluster.sh destroy`, the registry is disconnected
and the Kind cluster destroyed, but the registry container remains, sometimes
leading to incompatibility when re-creating the dev cluster.