### PR TITLE
test: wait for tablespace owner change

### DIFF
--- a/tests/e2e/tablespaces_test.go
+++ b/tests/e2e/tablespaces_test.go
@@ -89,6 +89,34 @@ var _ = Describe("Tablespaces tests", Label(tests.LabelTablespaces,
 		Expect(err).ToNot(HaveOccurred())
 	}
 
+	// Verify that the tablespace exists on the primary pod of a cluster
+	hasTablespaceAndOwner := func(cluster *apiv1.Cluster, tablespace, owner string) (bool, error) {
+		namespace := cluster.ObjectMeta.Namespace
+		clusterName := cluster.ObjectMeta.Name
+		primaryPod, err := clusterutils.GetPrimary(env.Ctx, env.Client, namespace, clusterName)
+		if err != nil {
+			return false, err
+		}
+		result, stdErr, err := exec.QueryInInstancePod(
+			env.Ctx, env.Client, env.Interface, env.RestClientConfig,
+			exec.PodLocator{
+				Namespace: namespace,
+				PodName:   primaryPod.Name,
+			}, postgres.AppDBName,
+			fmt.Sprintf("SELECT 1 FROM pg_catalog.pg_tablespace WHERE spcname = '%s' "+
+				"AND pg_catalog.pg_get_userbyid(spcowner) = '%s'",
+				tablespace,
+				owner),
+		)
+		if err != nil {
+			return false, err
+		}
+		if stdErr != "" {
+			return false, fmt.Errorf("error while checking tablespaces: %s", stdErr)
+		}
+		return result == "1\n", nil
+	}
+
 	Context("on a new cluster with tablespaces", Ordered, func() {
 		var namespace, backupName string
 		var err error
@@ -131,19 +159,20 @@ var _ = Describe("Tablespaces tests", Label(tests.LabelTablespaces,
 			AssertDatabaseContainsTablespaces(cluster, testTimeouts[timeouts.Short])
 			AssertRoleReconciled(namespace, clusterName, "dante", testTimeouts[timeouts.Short])
 			AssertRoleReconciled(namespace, clusterName, "alpha", testTimeouts[timeouts.Short])
-			AssertTablespaceAndOwnerExist(cluster, "atablespace", "app")
-			AssertTablespaceAndOwnerExist(cluster, "anothertablespace", "dante")
+			Expect(hasTablespaceAndOwner(cluster, "atablespace", "app")).To(BeTrue())
+			Expect(hasTablespaceAndOwner(cluster, "anothertablespace", "dante")).To(BeTrue())
 		})
 
-		It("can update the cluster by change the owner of tablesapce", func() {
+		It("can update the cluster by change the owner of tablespace", func() {
 			cluster, err := clusterutils.Get(env.Ctx, env.Client, namespace, clusterName)
 			Expect(err).ToNot(HaveOccurred())
 			updateTablespaceOwner(cluster, "anothertablespace", "alpha")
 
 			cluster, err = clusterutils.Get(env.Ctx, env.Client, namespace, clusterName)
 			Expect(err).ToNot(HaveOccurred())
-			AssertTablespaceReconciled(namespace, clusterName, "anothertablespace", testTimeouts[timeouts.Short])
-			AssertTablespaceAndOwnerExist(cluster, "anothertablespace", "alpha")
+			Eventually(func() (bool, error) {
+				return hasTablespaceAndOwner(cluster, "anothertablespace", "alpha")
+			}).WithTimeout(30 * time.Second).Should(BeTrue())
 		})
 
 		It("can update the cluster to set a tablespace as temporary", func() {
@@ -228,9 +257,9 @@ var _ = Describe("Tablespaces tests", Label(tests.LabelTablespaces,
 				AssertClusterHasMountPointsAndVolumesForTablespaces(cluster, 3, testTimeouts[timeouts.PodRollout])
 				AssertClusterHasPvcsAndDataDirsForTablespaces(cluster, testTimeouts[timeouts.PodRollout])
 				AssertDatabaseContainsTablespaces(cluster, testTimeouts[timeouts.PodRollout])
-				AssertTablespaceAndOwnerExist(cluster, "atablespace", "app")
-				AssertTablespaceAndOwnerExist(cluster, "anothertablespace", "alpha")
-				AssertTablespaceAndOwnerExist(cluster, "thirdtablespace", "dante")
+				Expect(hasTablespaceAndOwner(cluster, "atablespace", "app")).To(BeTrue())
+				Expect(hasTablespaceAndOwner(cluster, "anothertablespace", "alpha")).To(BeTrue())
+				Expect(hasTablespaceAndOwner(cluster, "thirdtablespace", "dante")).To(BeTrue())
 			})
 
 			By("waiting for the cluster to be ready", func() {
@@ -328,9 +357,9 @@ var _ = Describe("Tablespaces tests", Label(tests.LabelTablespaces,
 					testTimeouts[timeouts.Short])
 				AssertClusterHasPvcsAndDataDirsForTablespaces(restoredCluster, testTimeouts[timeouts.Short])
 				AssertDatabaseContainsTablespaces(restoredCluster, testTimeouts[timeouts.Short])
-				AssertTablespaceAndOwnerExist(cluster, "atablespace", "app")
-				AssertTablespaceAndOwnerExist(cluster, "anothertablespace", "alpha")
-				AssertTablespaceAndOwnerExist(cluster, "thirdtablespace", "dante")
+				Expect(hasTablespaceAndOwner(cluster, "atablespace", "app")).To(BeTrue())
+				Expect(hasTablespaceAndOwner(cluster, "anothertablespace", "alpha")).To(BeTrue())
+				Expect(hasTablespaceAndOwner(cluster, "thirdtablespace", "dante")).To(BeTrue())
 			})
 		})
 	})
@@ -859,25 +888,6 @@ func updateTablespaceOwner(cluster *apiv1.Cluster, tablespaceName, newOwner stri
 	Expect(err).ToNot(HaveOccurred())
 }
 
-func AssertTablespaceReconciled(
-	namespace, clusterName,
-	tablespaceName string,
-	timeout int,
-) {
-	By(fmt.Sprintf("checking if tablespace %v is in reconciled status", tablespaceName), func() {
-		Eventually(func(g Gomega) bool {
-			cluster, err := clusterutils.Get(env.Ctx, env.Client, namespace, clusterName)
-			g.Expect(err).ToNot(HaveOccurred())
-			for _, state := range cluster.Status.TablespacesStatus {
-				if state.State == apiv1.TablespaceStatusReconciled && state.Name == tablespaceName {
-					return true
-				}
-			}
-			return false
-		}, timeout).Should(BeTrue())
-	})
-}
-
 func AssertRoleReconciled(
 	namespace, clusterName,
 	roleName string,
@@ -1119,28 +1129,6 @@ func AssertTempTablespaceBehavior(cluster *apiv1.Cluster, expectedTempTablespace
 		Expect(commandOutputLines[len(commandOutputLines)-1]).To(Equal(expectedTempTablespaceName))
 		GinkgoWriter.Printf("CREATE TEMPORARY ... command output was:\n%s\n", commandOutput)
 	})
-}
-
-func AssertTablespaceAndOwnerExist(cluster *apiv1.Cluster, tablespace, owner string) {
-	namespace := cluster.ObjectMeta.Namespace
-	clusterName := cluster.ObjectMeta.Name
-	primaryPod, err := clusterutils.GetPrimary(env.Ctx, env.Client, namespace, clusterName)
-	Expect(err).ShouldNot(HaveOccurred())
-	result, stdErr, err := exec.QueryInInstancePod(
-		env.Ctx, env.Client, env.Interface, env.RestClientConfig,
-		exec.PodLocator{
-			Namespace: namespace,
-			PodName:   primaryPod.Name,
-		}, postgres.AppDBName,
-		fmt.Sprintf("SELECT 1 FROM pg_catalog.pg_tablespace WHERE spcname = '%s' "+
-			"AND pg_catalog.pg_get_userbyid(spcowner) = '%s'",
-			tablespace,
-			owner),
-	)
-	Expect(stdErr).To(BeEmpty())
-	Expect(err).ShouldNot(HaveOccurred())
-	Expect(result).To(Equal("1\n"))
-	GinkgoWriter.Printf("Found Tablespaces %s with owner %s", tablespace, owner)
 }
 
 func assertCanHibernateClusterWithTablespaces(


### PR DESCRIPTION
Fix a failure in the e2e tests when the check for the tablespace being reconciled was done on a cluster that had not updated its status.

Closes #7125
