### PR TITLE
feat(database): allow `template1` as a database name

### DIFF
--- a/api/v1/database_types.go
+++ b/api/v1/database_types.go
@@ -55,7 +55,6 @@ type DatabaseSpec struct {
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="name is immutable"
 	// +kubebuilder:validation:XValidation:rule="self != 'postgres'",message="the name postgres is reserved"
 	// +kubebuilder:validation:XValidation:rule="self != 'template0'",message="the name template0 is reserved"
-	// +kubebuilder:validation:XValidation:rule="self != 'template1'",message="the name template1 is reserved"
 	Name string `json:"name"`
 
 	// Maps to the `OWNER` parameter of `CREATE DATABASE`.

--- a/config/crd/bases/postgresql.cnpg.io_databases.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_databases.yaml
@@ -232,8 +232,6 @@ spec:
                   rule: self != 'postgres'
                 - message: the name template0 is reserved
                   rule: self != 'template0'
-                - message: the name template1 is reserved
-                  rule: self != 'template1'
               owner:
                 description: |-
                   Maps to the `OWNER` parameter of `CREATE DATABASE`.


### PR DESCRIPTION
With the recent support for extensions in database management, users should be able to enable extensions in the `template1` database.

**Note:** Since the `app` user is created by default, we cannot guarantee that extensions will be added to `template1` beforehand. Therefore, if you use the `template1` approach via the `Database` resource, you should also apply the same configuration to the `app` database.

Closes #7145 