### PR TITLE
Modify the DatabaseDeadlockConflicts PrometheusRule

### DIFF
--- a/docs/src/samples/monitoring/alerts.yaml
+++ b/docs/src/samples/monitoring/alerts.yaml
@@ -46,13 +46,13 @@ groups:
     for: 1m
     labels:
       severity: warning
-  - alert: DatabaseDeadlockConflicts 
+  - alert: DatabaseDeadlockConflicts
     annotations:
-      description: There are over 10 deadlock conflicts in {{ $labels.pod }}
+      description: Over 5 deadlock conflicts on pod {{ $labels.pod }} in the last 60 seconds (1 minute)
       summary: Checks the number of database conflicts
     expr: |-
-      cnpg_pg_stat_database_deadlocks > 10
-    for: 1m
+      increase(cnpg_pg_stat_database_deadlocks{datname!~"template[0-9]+|postgres"}[1m]) > 5
+    for: 0m
     labels:
       severity: warning
   - alert: ReplicaFailingReplication

--- a/docs/src/samples/monitoring/prometheusrule.yaml
+++ b/docs/src/samples/monitoring/prometheusrule.yaml
@@ -53,10 +53,10 @@ spec:
         severity: warning
     - alert: DatabaseDeadlockConflicts
       annotations:
-        description: There are over 10 deadlock conflicts in {{ $labels.pod }}
-        summary: Checks the number of database conflicts
+      description: Over 5 deadlock conflicts on pod {{ $labels.pod }} in the last 60 seconds (1 minute)
+      summary: Checks the number of database conflicts
       expr: |-
-        cnpg_pg_stat_database_deadlocks > 10
+        increase(cnpg_pg_stat_database_deadlocks{datname!~"template[0-9]+|postgres"}[1m]) > 5
       for: 1m
       labels:
         severity: warning


### PR DESCRIPTION
`cnpg_pg_stat_database_deadlocks` is a counter, so once the conflicts reached 10, the alert would fire continuously until PostgreSQL was restarted.

Resolves #7149