### PR TITLE
chore(webhook): warn when `shared_buffers` lacks a unit qualifier

### DIFF
--- a/internal/webhook/v1/cluster_webhook.go
+++ b/internal/webhook/v1/cluster_webhook.go
@@ -2335,9 +2335,9 @@ func getSharedBuffersWarnings(r *apiv1.Cluster) admission.Warnings {
 		if _, err := strconv.Atoi(v); err == nil {
 			result = append(
 				result,
-				fmt.Sprintf("shared_buffers value '%s' is missing a unit qualifier (e.g., MB, GB). "+
-					"In future releases this will be an error. "+
-					"Please update your configuration to explicitly include units like '%sMB'.", v, v),
+				fmt.Sprintf("`shared_buffers` value '%s' is missing a unit (e.g., MB, GB). "+
+					"While this is currently allowed, future releases will require an explicit unit. "+
+					"Please update your configuration to specify a valid unit, such as '%sMB'.", v, v),
 			)
 		}
 	}


### PR DESCRIPTION
## Release Notes  

A webhook warning is now issued when applying a cluster with `shared_buffers` missing a unit (e.g., MB, GB). In future releases, this will become an error. Users should update their configurations to specify units explicitly (e.g., use `512MB` instead of `512`).

## Notes for Reviewers  

Consider backporting to provide users with more advance notice.  

Closes #6657  
