### PR TITLE
feat(cnpgi): add `Postgres` interface support to the operator

### DIFF
--- a/api/v1/cluster_funcs.go
+++ b/api/v1/cluster_funcs.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cloudnative-pg/cnpg-i/pkg/identity"
 	"github.com/cloudnative-pg/machinery/pkg/image/reference"
 	"github.com/cloudnative-pg/machinery/pkg/log"
 	pgTime "github.com/cloudnative-pg/machinery/pkg/postgres/time"
@@ -83,6 +84,50 @@ func GetPluginConfigurationEnabledPluginNames(pluginList []PluginConfiguration) 
 		}
 	}
 	return pluginNames
+}
+
+// GetInstanceEnabledPluginNames gets the name of the plugins that are available to the instance container
+func (cluster *Cluster) GetInstanceEnabledPluginNames() (result []string) {
+	var instance []string
+	for _, pluginStatus := range cluster.Status.PluginStatus {
+		if slices.Contains(pluginStatus.Capabilities,
+			identity.PluginCapability_Service_TYPE_INSTANCE_SIDECAR_INJECTION.String()) {
+			instance = append(instance, pluginStatus.Name)
+		}
+	}
+
+	enabled := GetPluginConfigurationEnabledPluginNames(cluster.Spec.Plugins)
+
+	var instanceEnabled []string
+	for _, pluginName := range instance {
+		if slices.Contains(enabled, pluginName) {
+			instanceEnabled = append(instanceEnabled, pluginName)
+		}
+	}
+
+	return instanceEnabled
+}
+
+// GetJobEnabledPluginNames gets the name of the plugins that are available to the job container
+func (cluster *Cluster) GetJobEnabledPluginNames() (result []string) {
+	var instance []string
+	for _, pluginStatus := range cluster.Status.PluginStatus {
+		if slices.Contains(pluginStatus.Capabilities,
+			identity.PluginCapability_Service_TYPE_INSTANCE_JOB_SIDECAR_INJECTION.String()) {
+			instance = append(instance, pluginStatus.Name)
+		}
+	}
+
+	enabled := GetPluginConfigurationEnabledPluginNames(cluster.Spec.Plugins)
+
+	var instanceEnabled []string
+	for _, pluginName := range instance {
+		if slices.Contains(enabled, pluginName) {
+			instanceEnabled = append(instanceEnabled, pluginName)
+		}
+	}
+
+	return instanceEnabled
 }
 
 // GetExternalClustersEnabledPluginNames gets the name of the plugins that are

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/cheynewallace/tabby v1.1.1
 	github.com/cloudnative-pg/barman-cloud v0.3.1
-	github.com/cloudnative-pg/cnpg-i v0.2.1
+	github.com/cloudnative-pg/cnpg-i v0.2.2-0.20250604112552-98f6620152b1
 	github.com/cloudnative-pg/machinery v0.2.0
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/evanphx/json-patch/v5 v5.9.11

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/cheynewallace/tabby v1.1.1
 	github.com/cloudnative-pg/barman-cloud v0.3.1
-	github.com/cloudnative-pg/cnpg-i v0.2.2-0.20250604112552-98f6620152b1
+	github.com/cloudnative-pg/cnpg-i v0.2.2-0.20250609075931-7cb57628933b
 	github.com/cloudnative-pg/machinery v0.2.0
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/evanphx/json-patch/v5 v5.9.11

--- a/go.sum
+++ b/go.sum
@@ -20,8 +20,8 @@ github.com/cheynewallace/tabby v1.1.1 h1:JvUR8waht4Y0S3JF17G6Vhyt+FRhnqVCkk8l4Yr
 github.com/cheynewallace/tabby v1.1.1/go.mod h1:Pba/6cUL8uYqvOc9RkyvFbHGrQ9wShyrn6/S/1OYVys=
 github.com/cloudnative-pg/barman-cloud v0.3.1 h1:kzkY77k2lN/caoyh7ibXDSZjJeSJTNvnVt6Gfa8Iq5M=
 github.com/cloudnative-pg/barman-cloud v0.3.1/go.mod h1:4HL3AjY9oEl2Ed0HSkyvTZEQPhwyFOaAnuCz9lfVeYQ=
-github.com/cloudnative-pg/cnpg-i v0.2.1 h1:g96BE1ojdiFtDwtb7tg5wUF9a2kAh0eVg4SkjsO8jnk=
-github.com/cloudnative-pg/cnpg-i v0.2.1/go.mod h1:kPfJpPGAKN1/2xvwBcC3WzMP46pj3sKLHLNB8NHr77U=
+github.com/cloudnative-pg/cnpg-i v0.2.2-0.20250604112552-98f6620152b1 h1:vwGIWt6yU2UV8aCv139iZZlZKT4r9SYbtTTSboBrtQY=
+github.com/cloudnative-pg/cnpg-i v0.2.2-0.20250604112552-98f6620152b1/go.mod h1:9oJ+qmY4tqhGTXnGur+LBMYDB4Yu5ZkkOX0XmQpAnCU=
 github.com/cloudnative-pg/machinery v0.2.0 h1:x8OAwxdeL/6wkbxqorz+nX6UovTyx7/TBeCfiRebR2o=
 github.com/cloudnative-pg/machinery v0.2.0/go.mod h1:Kg8W8Tb/1UFGGtw3hR8S5SytSWddlHaCnJSgBo4x/nc=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=

--- a/go.sum
+++ b/go.sum
@@ -20,8 +20,8 @@ github.com/cheynewallace/tabby v1.1.1 h1:JvUR8waht4Y0S3JF17G6Vhyt+FRhnqVCkk8l4Yr
 github.com/cheynewallace/tabby v1.1.1/go.mod h1:Pba/6cUL8uYqvOc9RkyvFbHGrQ9wShyrn6/S/1OYVys=
 github.com/cloudnative-pg/barman-cloud v0.3.1 h1:kzkY77k2lN/caoyh7ibXDSZjJeSJTNvnVt6Gfa8Iq5M=
 github.com/cloudnative-pg/barman-cloud v0.3.1/go.mod h1:4HL3AjY9oEl2Ed0HSkyvTZEQPhwyFOaAnuCz9lfVeYQ=
-github.com/cloudnative-pg/cnpg-i v0.2.2-0.20250604112552-98f6620152b1 h1:vwGIWt6yU2UV8aCv139iZZlZKT4r9SYbtTTSboBrtQY=
-github.com/cloudnative-pg/cnpg-i v0.2.2-0.20250604112552-98f6620152b1/go.mod h1:9oJ+qmY4tqhGTXnGur+LBMYDB4Yu5ZkkOX0XmQpAnCU=
+github.com/cloudnative-pg/cnpg-i v0.2.2-0.20250609075931-7cb57628933b h1:B7Ugp5epMIDNPe0bIOcqpErKkiQfuCM3nXoGh4GiPHM=
+github.com/cloudnative-pg/cnpg-i v0.2.2-0.20250609075931-7cb57628933b/go.mod h1:FUA8ELMnqHpA2MIOeG425sX7D+u3m8SD/oFd1CnXSEw=
 github.com/cloudnative-pg/machinery v0.2.0 h1:x8OAwxdeL/6wkbxqorz+nX6UovTyx7/TBeCfiRebR2o=
 github.com/cloudnative-pg/machinery v0.2.0/go.mod h1:Kg8W8Tb/1UFGGtw3hR8S5SytSWddlHaCnJSgBo4x/nc=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=

--- a/internal/cmd/manager/instance/upgrade/execute/cmd.go
+++ b/internal/cmd/manager/instance/upgrade/execute/cmd.go
@@ -31,6 +31,7 @@ import (
 	"strings"
 	"time"
 
+	cnpgiPostgres "github.com/cloudnative-pg/cnpg-i/pkg/postgres"
 	"github.com/cloudnative-pg/machinery/pkg/env"
 	"github.com/cloudnative-pg/machinery/pkg/execlog"
 	"github.com/cloudnative-pg/machinery/pkg/fileutils"
@@ -403,7 +404,12 @@ func prepareConfigurationFiles(ctx context.Context, cluster apiv1.Cluster, destD
 	}
 
 	newInstance := postgres.Instance{PgData: destDir}
-	if _, err := newInstance.RefreshConfigurationFilesFromCluster(ctx, tmpCluster, false); err != nil {
+	if _, err := newInstance.RefreshConfigurationFilesFromCluster(
+		ctx,
+		tmpCluster,
+		false,
+		cnpgiPostgres.OperationType_TYPE_UPGRADE,
+	); err != nil {
 		return fmt.Errorf("error while creating the configuration files for new datadir %q: %w", destDir, err)
 	}
 

--- a/internal/cmd/manager/instance/upgrade/execute/cmd.go
+++ b/internal/cmd/manager/instance/upgrade/execute/cmd.go
@@ -410,6 +410,8 @@ func prepareConfigurationFiles(ctx context.Context, cluster apiv1.Cluster, destD
 	if err != nil {
 		return fmt.Errorf("error while creating the plugin client: %w", err)
 	}
+	defer pluginCli.Close(ctx)
+
 	ctx = pluginClient.SetPluginClientInContext(ctx, pluginCli)
 	ctx = cluster.SetInContext(ctx)
 

--- a/internal/cmd/plugin/status/status.go
+++ b/internal/cmd/plugin/status/status.go
@@ -1206,6 +1206,8 @@ func (fullStatus *PostgresqlStatus) printPluginStatus(verbosity int) {
 				result[idx] = "Operator Service"
 			case identity.PluginCapability_Service_TYPE_LIFECYCLE_SERVICE.String():
 				result[idx] = "Lifecycle Service"
+			case identity.PluginCapability_Service_TYPE_POSTGRES.String():
+				result[idx] = "Postgres Service"
 			case identity.PluginCapability_Service_TYPE_UNSPECIFIED.String():
 				continue
 			default:

--- a/internal/cnpi/plugin/client/cluster_test.go
+++ b/internal/cnpi/plugin/client/cluster_test.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/cloudnative-pg/cnpg-i/pkg/operator"
 
-	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/internal/cnpi/plugin/connection"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -36,9 +35,9 @@ var _ = Describe("SetStatusInCluster", func() {
 	const pluginName = "fake-plugin"
 	const pluginName2 = "fake-plugin2"
 
-	var cluster *apiv1.Cluster
+	var cluster fakeCluster
 	BeforeEach(func() {
-		cluster = &apiv1.Cluster{}
+		cluster = fakeCluster{}
 	})
 
 	It("should correctly set the status of a single plugin", func(ctx SpecContext) {

--- a/internal/cnpi/plugin/client/contracts.go
+++ b/internal/cnpi/plugin/client/contracts.go
@@ -41,6 +41,7 @@ type Client interface {
 	WalCapabilities
 	BackupCapabilities
 	RestoreJobHooksCapabilities
+	PostgresConfigurationCapabilities
 }
 
 // SetPluginClientInContext records the plugin client in the given context

--- a/internal/cnpi/plugin/client/interfaces.go
+++ b/internal/cnpi/plugin/client/interfaces.go
@@ -17,17 +17,23 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 */
 
-package connection
+package client
 
-// Metadata expose the metadata as discovered
-// from a plugin
-type Metadata struct {
-	Name                       string
-	Version                    string
-	Capabilities               []string
-	OperatorCapabilities       []string
-	WALCapabilities            []string
-	BackupCapabilities         []string
-	RestoreJobHookCapabilities []string
-	PostgresCapabilities       []string
+import (
+	"context"
+
+	"github.com/cloudnative-pg/cnpg-i/pkg/postgres"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// PostgresConfigurationCapabilities is the interface that defines the
+// capabilities of interacting with PostgreSQL.
+type PostgresConfigurationCapabilities interface {
+	// EnrichConfiguration is the method that enriches the PostgreSQL configuration
+	EnrichConfiguration(
+		ctx context.Context,
+		cluster client.Object,
+		config map[string]string,
+		operationType postgres.OperationType_Type,
+	) (map[string]string, error)
 }

--- a/internal/cnpi/plugin/client/postgres.go
+++ b/internal/cnpi/plugin/client/postgres.go
@@ -1,0 +1,71 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"slices"
+
+	postgresClient "github.com/cloudnative-pg/cnpg-i/pkg/postgres"
+	"github.com/cloudnative-pg/machinery/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func (data *data) EnrichConfiguration(
+	ctx context.Context,
+	cluster client.Object,
+	config map[string]string,
+	operationType postgresClient.OperationType_Type,
+) (map[string]string, error) {
+	tempConfig := config
+
+	contextLogger := log.FromContext(ctx).WithName("enrichConfiguration")
+
+	clusterDefinition, marshalErr := json.Marshal(cluster)
+	if marshalErr != nil {
+		return nil, marshalErr
+	}
+
+	for idx := range data.plugins {
+		plugin := data.plugins[idx]
+
+		if !slices.Contains(plugin.PostgresCapabilities(), postgresClient.PostgresCapability_RPC_TYPE_ENRICH_CONFIGURATION) {
+			contextLogger.Debug("skipping plugin", "plugin", plugin.Name())
+			continue
+		}
+		req := &postgresClient.EnrichConfigurationRequest{
+			Configs:           config,
+			ClusterDefinition: clusterDefinition,
+			OperationType:     &postgresClient.OperationType{Type: operationType},
+		}
+		res, err := plugin.PostgresClient().EnrichConfiguration(ctx, req)
+		if err != nil {
+			return nil, err
+		}
+		contextLogger.Debug("received response", "resConfig", res.Configs)
+		if len(res.Configs) == 0 {
+			continue
+		}
+		tempConfig = res.Configs
+	}
+
+	return tempConfig, nil
+}

--- a/internal/cnpi/plugin/client/postgres_test.go
+++ b/internal/cnpi/plugin/client/postgres_test.go
@@ -1,0 +1,226 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package client
+
+import (
+	"context"
+	"errors"
+
+	"github.com/cloudnative-pg/cnpg-i/pkg/postgres"
+	"google.golang.org/grpc"
+
+	"github.com/cloudnative-pg/cloudnative-pg/internal/cnpi/plugin/connection"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+type fakePostgresClient struct {
+	enrichConfigResponse *postgres.EnrichConfigurationResult
+	enrichConfigError    error
+}
+
+type fakePostgresConnection struct {
+	name           string
+	capabilities   []postgres.PostgresCapability_RPC_Type
+	postgresClient *fakePostgresClient
+	connection.Interface
+}
+
+func (f *fakePostgresClient) GetCapabilities(
+	_ context.Context,
+	_ *postgres.PostgresCapabilitiesRequest,
+	_ ...grpc.CallOption,
+) (*postgres.PostgresCapabilitiesResult, error) {
+	return &postgres.PostgresCapabilitiesResult{
+		Capabilities: []*postgres.PostgresCapability{
+			{
+				Type: &postgres.PostgresCapability_Rpc{
+					Rpc: &postgres.PostgresCapability_RPC{
+						Type: postgres.PostgresCapability_RPC_TYPE_ENRICH_CONFIGURATION,
+					},
+				},
+			},
+		},
+	}, nil
+}
+
+func (f *fakePostgresClient) EnrichConfiguration(
+	_ context.Context,
+	_ *postgres.EnrichConfigurationRequest,
+	_ ...grpc.CallOption,
+) (*postgres.EnrichConfigurationResult, error) {
+	return f.enrichConfigResponse, f.enrichConfigError
+}
+
+func (f *fakePostgresConnection) Name() string {
+	return f.name
+}
+
+func (f *fakePostgresConnection) PostgresClient() postgres.PostgresClient {
+	return f.postgresClient
+}
+
+func (f *fakePostgresConnection) PostgresCapabilities() []postgres.PostgresCapability_RPC_Type {
+	return f.capabilities
+}
+
+var _ = Describe("EnrichConfiguration", func() {
+	var (
+		d       *data
+		cluster *fakeCluster
+		config  map[string]string
+	)
+
+	BeforeEach(func() {
+		config = map[string]string{"key1": "value1"}
+		d = &data{plugins: []connection.Interface{}}
+
+		cluster = &fakeCluster{}
+	})
+
+	It("should successfully enrich configuration", func(ctx SpecContext) {
+		postgresClient := &fakePostgresClient{
+			enrichConfigResponse: &postgres.EnrichConfigurationResult{
+				Configs: map[string]string{"key1": "value1", "key2": "value2"},
+			},
+		}
+
+		plugin := &fakePostgresConnection{
+			name:           "test-plugin",
+			capabilities:   []postgres.PostgresCapability_RPC_Type{postgres.PostgresCapability_RPC_TYPE_ENRICH_CONFIGURATION},
+			postgresClient: postgresClient,
+		}
+
+		d.plugins = append(d.plugins, plugin)
+
+		config, err := d.EnrichConfiguration(ctx, cluster, config, postgres.OperationType_TYPE_UNSPECIFIED)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(config).To(HaveKeyWithValue("key1", "value1"))
+		Expect(config).To(HaveKeyWithValue("key2", "value2"))
+	})
+
+	It("should return error when plugin returns error", func(ctx SpecContext) {
+		expectedErr := errors.New("plugin error")
+
+		postgresClient := &fakePostgresClient{
+			enrichConfigError: expectedErr,
+		}
+
+		plugin := &fakePostgresConnection{
+			name:           "test-plugin",
+			capabilities:   []postgres.PostgresCapability_RPC_Type{postgres.PostgresCapability_RPC_TYPE_ENRICH_CONFIGURATION},
+			postgresClient: postgresClient,
+		}
+
+		d.plugins = append(d.plugins, plugin)
+
+		_, err := d.EnrichConfiguration(ctx, cluster, config, postgres.OperationType_TYPE_UNSPECIFIED)
+
+		Expect(err).To(HaveOccurred())
+		Expect(err).To(Equal(expectedErr))
+	})
+
+	It("should skip plugins without required capability", func(ctx SpecContext) {
+		plugin := &fakePostgresConnection{
+			name:         "test-plugin",
+			capabilities: []postgres.PostgresCapability_RPC_Type{},
+		}
+
+		d.plugins = append(d.plugins, plugin)
+
+		origMap := cloneMap(config)
+
+		config, err := d.EnrichConfiguration(ctx, cluster, config, postgres.OperationType_TYPE_UNSPECIFIED)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(config).To(BeEquivalentTo(origMap))
+	})
+
+	It("should merge configurations from multiple plugins", func(ctx SpecContext) {
+		postgresClient1 := &fakePostgresClient{
+			enrichConfigResponse: &postgres.EnrichConfigurationResult{
+				Configs: map[string]string{"key2": "value2"},
+			},
+		}
+
+		plugin1 := &fakePostgresConnection{
+			name:           "plugin1",
+			capabilities:   []postgres.PostgresCapability_RPC_Type{postgres.PostgresCapability_RPC_TYPE_ENRICH_CONFIGURATION},
+			postgresClient: postgresClient1,
+		}
+
+		postgresClient2 := &fakePostgresClient{
+			enrichConfigResponse: &postgres.EnrichConfigurationResult{
+				Configs: map[string]string{
+					"key1": "value1",
+					"key2": "value2",
+					"key3": "value3",
+				},
+			},
+		}
+
+		plugin2 := &fakePostgresConnection{
+			name:           "plugin2",
+			capabilities:   []postgres.PostgresCapability_RPC_Type{postgres.PostgresCapability_RPC_TYPE_ENRICH_CONFIGURATION},
+			postgresClient: postgresClient2,
+		}
+
+		d.plugins = append(d.plugins, plugin1, plugin2)
+
+		config, err := d.EnrichConfiguration(ctx, cluster, config, postgres.OperationType_TYPE_UNSPECIFIED)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(config).To(HaveKeyWithValue("key1", "value1"))
+		Expect(config).To(HaveKeyWithValue("key2", "value2"))
+		Expect(config).To(HaveKeyWithValue("key3", "value3"))
+	})
+
+	It("should overwrite existing config key when plugin returns the same key", func(ctx SpecContext) {
+		postgresClient := &fakePostgresClient{
+			enrichConfigResponse: &postgres.EnrichConfigurationResult{
+				Configs: map[string]string{"key1": "overwritten-value"},
+			},
+		}
+
+		plugin := &fakePostgresConnection{
+			name:           "test-plugin",
+			capabilities:   []postgres.PostgresCapability_RPC_Type{postgres.PostgresCapability_RPC_TYPE_ENRICH_CONFIGURATION},
+			postgresClient: postgresClient,
+		}
+
+		d.plugins = append(d.plugins, plugin)
+
+		config, err := d.EnrichConfiguration(ctx, cluster, config, postgres.OperationType_TYPE_UNSPECIFIED)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(config).To(HaveKeyWithValue("key1", "overwritten-value"))
+		Expect(config).To(HaveLen(1))
+	})
+})
+
+func cloneMap(original map[string]string) map[string]string {
+	clone := make(map[string]string, len(original))
+	for k, v := range original {
+		clone[k] = v
+	}
+	return clone
+}

--- a/internal/cnpi/plugin/client/suite_test.go
+++ b/internal/cnpi/plugin/client/suite_test.go
@@ -27,10 +27,12 @@ import (
 	"github.com/cloudnative-pg/cnpg-i/pkg/identity"
 	"github.com/cloudnative-pg/cnpg-i/pkg/lifecycle"
 	"github.com/cloudnative-pg/cnpg-i/pkg/operator"
+	postgresClient "github.com/cloudnative-pg/cnpg-i/pkg/postgres"
 	"github.com/cloudnative-pg/cnpg-i/pkg/reconciler"
 	restore "github.com/cloudnative-pg/cnpg-i/pkg/restore/job"
 	"github.com/cloudnative-pg/cnpg-i/pkg/wal"
 	"google.golang.org/grpc"
+	k8client "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/cloudnative-pg/cloudnative-pg/internal/cnpi/plugin/connection"
 
@@ -105,6 +107,14 @@ type fakeConnection struct {
 	lifecycleCapabilities []*lifecycle.OperatorLifecycleCapabilities
 	name                  string
 	operatorClient        *fakeOperatorClient
+}
+
+func (f *fakeConnection) PostgresClient() postgresClient.PostgresClient {
+	panic("implement me")
+}
+
+func (f *fakeConnection) PostgresCapabilities() []postgresClient.PostgresCapability_RPC_Type {
+	panic("implement me")
 }
 
 func (f *fakeConnection) RestoreJobHooksClient() restore.RestoreJobHooksClient {
@@ -187,4 +197,8 @@ func (f *fakeConnection) Ping(_ context.Context) error {
 
 func (f *fakeConnection) Close() error {
 	panic("not implemented") // TODO: Implement
+}
+
+type fakeCluster struct {
+	k8client.Object
 }

--- a/internal/cnpi/plugin/connection/connection.go
+++ b/internal/cnpi/plugin/connection/connection.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cloudnative-pg/cnpg-i/pkg/identity"
 	"github.com/cloudnative-pg/cnpg-i/pkg/lifecycle"
 	"github.com/cloudnative-pg/cnpg-i/pkg/operator"
+	postgresClient "github.com/cloudnative-pg/cnpg-i/pkg/postgres"
 	"github.com/cloudnative-pg/cnpg-i/pkg/reconciler"
 	restore "github.com/cloudnative-pg/cnpg-i/pkg/restore/job"
 	"github.com/cloudnative-pg/cnpg-i/pkg/wal"
@@ -63,6 +64,7 @@ type Interface interface {
 	BackupClient() backup.BackupClient
 	ReconcilerHooksClient() reconciler.ReconcilerHooksClient
 	RestoreJobHooksClient() restore.RestoreJobHooksClient
+	PostgresClient() postgresClient.PostgresClient
 
 	PluginCapabilities() []identity.PluginCapability_Service_Type
 	OperatorCapabilities() []operator.OperatorCapability_RPC_Type
@@ -71,6 +73,7 @@ type Interface interface {
 	BackupCapabilities() []backup.BackupCapability_RPC_Type
 	ReconcilerCapabilities() []reconciler.ReconcilerHooksCapability_Kind
 	RestoreJobHooksCapabilities() []restore.RestoreJobHooksCapability_Kind
+	PostgresCapabilities() []postgresClient.PostgresCapability_RPC_Type
 
 	Ping(ctx context.Context) error
 	Close() error
@@ -85,6 +88,7 @@ type data struct {
 	backupClient          backup.BackupClient
 	reconcilerHooksClient reconciler.ReconcilerHooksClient
 	restoreJobHooksClient restore.RestoreJobHooksClient
+	postgresClient        postgresClient.PostgresClient
 
 	name                        string
 	version                     string
@@ -95,6 +99,7 @@ type data struct {
 	backupCapabilities          []backup.BackupCapability_RPC_Type
 	reconcilerCapabilities      []reconciler.ReconcilerHooksCapability_Kind
 	restoreJobHooksCapabilities []restore.RestoreJobHooksCapability_Kind
+	postgresCapabilities        []postgresClient.PostgresCapability_RPC_Type
 }
 
 func newPluginDataFromConnection(ctx context.Context, connection Handler) (data, error) {
@@ -122,6 +127,7 @@ func newPluginDataFromConnection(ctx context.Context, connection Handler) (data,
 		backupClient:          backup.NewBackupClient(connection),
 		reconcilerHooksClient: reconciler.NewReconcilerHooksClient(connection),
 		restoreJobHooksClient: restore.NewRestoreJobHooksClient(connection),
+		postgresClient:        postgresClient.NewPostgresClient(connection),
 	}
 
 	return result, err
@@ -264,6 +270,27 @@ func (pluginData *data) loadRestoreJobHooksCapabilities(ctx context.Context) err
 	return nil
 }
 
+func (pluginData *data) loadPostgresCapabilities(ctx context.Context) error {
+	var postgresCapabilitiesResponse *postgresClient.PostgresCapabilitiesResult
+	var err error
+
+	if postgresCapabilitiesResponse, err = pluginData.postgresClient.GetCapabilities(
+		ctx,
+		&postgresClient.PostgresCapabilitiesRequest{},
+	); err != nil {
+		return fmt.Errorf("while querying plugin operator capabilities: %w", err)
+	}
+
+	pluginData.postgresCapabilities = make(
+		[]postgresClient.PostgresCapability_RPC_Type,
+		len(postgresCapabilitiesResponse.Capabilities))
+	for i := range pluginData.postgresCapabilities {
+		pluginData.postgresCapabilities[i] = postgresCapabilitiesResponse.Capabilities[i].GetRpc().Type
+	}
+
+	return nil
+}
+
 // Metadata extracts the plugin metadata reading from
 // the internal metadata
 func (pluginData *data) Metadata() Metadata {
@@ -275,6 +302,7 @@ func (pluginData *data) Metadata() Metadata {
 		WALCapabilities:            make([]string, len(pluginData.walCapabilities)),
 		BackupCapabilities:         make([]string, len(pluginData.backupCapabilities)),
 		RestoreJobHookCapabilities: make([]string, len(pluginData.restoreJobHooksCapabilities)),
+		PostgresCapabilities:       make([]string, len(pluginData.postgresCapabilities)),
 	}
 
 	for i := range pluginData.capabilities {
@@ -333,6 +361,10 @@ func (pluginData *data) ReconcilerHooksClient() reconciler.ReconcilerHooksClient
 	return pluginData.reconcilerHooksClient
 }
 
+func (pluginData *data) PostgresClient() postgresClient.PostgresClient {
+	return pluginData.postgresClient
+}
+
 func (pluginData *data) PluginCapabilities() []identity.PluginCapability_Service_Type {
 	return pluginData.capabilities
 }
@@ -359,6 +391,10 @@ func (pluginData *data) ReconcilerCapabilities() []reconciler.ReconcilerHooksCap
 
 func (pluginData *data) RestoreJobHooksCapabilities() []restore.RestoreJobHooksCapability_Kind {
 	return pluginData.restoreJobHooksCapabilities
+}
+
+func (pluginData *data) PostgresCapabilities() []postgresClient.PostgresCapability_RPC_Type {
+	return pluginData.postgresCapabilities
 }
 
 func (pluginData *data) Ping(ctx context.Context) error {
@@ -423,6 +459,14 @@ func LoadPlugin(ctx context.Context, handler Handler) (Interface, error) {
 	// capabilities
 	if slices.Contains(result.capabilities, identity.PluginCapability_Service_TYPE_RESTORE_JOB) {
 		if err = result.loadRestoreJobHooksCapabilities(ctx); err != nil {
+			return nil, err
+		}
+	}
+
+	// If the plugin implements the postgres service, load its
+	// capabilities
+	if slices.Contains(result.capabilities, identity.PluginCapability_Service_TYPE_POSTGRES) {
+		if err = result.loadPostgresCapabilities(ctx); err != nil {
 			return nil, err
 		}
 	}

--- a/internal/controller/cluster_upgrade_test.go
+++ b/internal/controller/cluster_upgrade_test.go
@@ -860,6 +860,7 @@ var _ = Describe("checkPodSpec with plugins", Ordered, func() {
 		pluginCli := fakePluginClientRollout{
 			returnedPod: podModifiedByPlugins,
 		}
+
 		ctx := pluginClient.SetPluginClientInContext(context.TODO(), pluginCli)
 
 		rollout, err := checkPodSpecIsOutdated(ctx, pod, &cluster)

--- a/internal/management/controller/manager.go
+++ b/internal/management/controller/manager.go
@@ -31,6 +31,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	"github.com/cloudnative-pg/cloudnative-pg/internal/cnpi/plugin/repository"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/concurrency"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres/webserver/metricserver"
@@ -52,6 +53,7 @@ type InstanceReconciler struct {
 	metricsServerExporter *metricserver.Exporter
 
 	certificateReconciler *instancecertificate.Reconciler
+	pluginRepository      repository.Interface
 }
 
 // NewInstanceReconciler creates a new instance reconciler
@@ -59,6 +61,7 @@ func NewInstanceReconciler(
 	instance *postgres.Instance,
 	client ctrl.Client,
 	metricsExporter *metricserver.Exporter,
+	pluginRepository repository.Interface,
 ) *InstanceReconciler {
 	return &InstanceReconciler{
 		instance:              instance,
@@ -68,6 +71,7 @@ func NewInstanceReconciler(
 		systemInitialization:  concurrency.NewExecuted(),
 		metricsServerExporter: metricsExporter,
 		certificateReconciler: instancecertificate.NewReconciler(client, instance),
+		pluginRepository:      pluginRepository,
 	}
 }
 

--- a/pkg/management/postgres/configuration.go
+++ b/pkg/management/postgres/configuration.go
@@ -28,6 +28,7 @@ import (
 	"sort"
 	"strings"
 
+	postgresClient "github.com/cloudnative-pg/cnpg-i/pkg/postgres"
 	"github.com/cloudnative-pg/machinery/pkg/fileutils"
 	"github.com/cloudnative-pg/machinery/pkg/log"
 
@@ -36,6 +37,7 @@ import (
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres/constants"
 	postgresutils "github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres/utils"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/postgres"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/postgres/plugin"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/postgres/replication"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 )
@@ -68,13 +70,23 @@ func (instance *Instance) RefreshConfigurationFilesFromCluster(
 	ctx context.Context,
 	cluster *apiv1.Cluster,
 	preserveUserSettings bool,
+	operationType postgresClient.OperationType_Type,
 ) (bool, error) {
 	pgMajor, err := postgresutils.GetMajorVersionFromPgData(instance.PgData)
 	if err != nil {
 		return false, err
 	}
 
-	postgresConfiguration, sha256 := createPostgresqlConfiguration(cluster, preserveUserSettings, pgMajor)
+	postgresConfiguration, sha256, err := createPostgresqlConfiguration(
+		ctx,
+		cluster,
+		preserveUserSettings,
+		pgMajor,
+		operationType,
+	)
+	if err != nil {
+		return false, fmt.Errorf("creating postgresql configuration: %w", err)
+	}
 	postgresConfigurationChanged, err := InstallPgDataFileContent(
 		ctx,
 		instance.PgData,
@@ -379,10 +391,12 @@ func (instance *Instance) migratePostgresAutoConfFile(ctx context.Context) (chan
 // createPostgresqlConfiguration creates the PostgreSQL configuration to be
 // used for this cluster and return it and its sha256 checksum
 func createPostgresqlConfiguration(
+	ctx context.Context,
 	cluster *apiv1.Cluster,
 	preserveUserSettings bool,
 	majorVersion int,
-) (string, string) {
+	operationType postgresClient.OperationType_Type,
+) (string, string, error) {
 	info := postgres.ConfigurationInfo{
 		Settings:                         postgres.CnpgConfigurationSettings,
 		MajorVersion:                     majorVersion,
@@ -417,7 +431,13 @@ func createPostgresqlConfiguration(
 		info.RecoveryMinApplyDelay = cluster.Spec.ReplicaCluster.MinApplyDelay.Duration
 	}
 
-	return postgres.CreatePostgresqlConfFile(postgres.CreatePostgresqlConfiguration(info))
+	config, err := plugin.CreatePostgresqlConfigurationWithPlugins(ctx, info, operationType)
+	if err != nil {
+		return "", "", err
+	}
+
+	file, sha := postgres.CreatePostgresqlConfFile(config)
+	return file, sha, nil
 }
 
 // configurePostgresForImport configures Postgres to be optimized for the firt import

--- a/pkg/management/postgres/configuration_test.go
+++ b/pkg/management/postgres/configuration_test.go
@@ -181,7 +181,7 @@ var _ = Describe("Test building of the list of temporary tablespaces", func() {
 			ctx,
 			&clusterWithoutTablespaces,
 			true,
-			defaultVersion.Major(),
+			defaultMajor,
 			postgres.OperationType_TYPE_UNSPECIFIED,
 		)
 		Expect(err).ToNot(HaveOccurred())
@@ -193,7 +193,7 @@ var _ = Describe("Test building of the list of temporary tablespaces", func() {
 			ctx,
 			&clusterWithoutTemporaryTablespaces,
 			true,
-			defaultVersion.Major(),
+			defaultMajor,
 			postgres.OperationType_TYPE_UNSPECIFIED,
 		)
 		Expect(err).ToNot(HaveOccurred())
@@ -205,7 +205,7 @@ var _ = Describe("Test building of the list of temporary tablespaces", func() {
 			ctx,
 			&clusterWithTemporaryTablespaces,
 			true,
-			defaultVersion.Major(),
+			defaultMajor,
 			postgres.OperationType_TYPE_UNSPECIFIED,
 		)
 		Expect(err).ToNot(HaveOccurred())
@@ -270,7 +270,7 @@ var _ = Describe("recovery_min_apply_delay", func() {
 			ctx,
 			&primaryCluster,
 			true,
-			defaultVersion.Major(),
+			defaultMajor,
 			postgres.OperationType_TYPE_UNSPECIFIED,
 		)
 		Expect(err).ToNot(HaveOccurred())
@@ -284,7 +284,7 @@ var _ = Describe("recovery_min_apply_delay", func() {
 			ctx,
 			&replicaCluster,
 			true,
-			defaultVersion.Major(),
+			defaultMajor,
 			postgres.OperationType_TYPE_UNSPECIFIED,
 		)
 		Expect(err).ToNot(HaveOccurred())
@@ -298,7 +298,7 @@ var _ = Describe("recovery_min_apply_delay", func() {
 			ctx,
 			&replicaClusterWithNoDelay,
 			true,
-			defaultVersion.Major(),
+			defaultMajor,
 			postgres.OperationType_TYPE_UNSPECIFIED,
 		)
 		Expect(err).ToNot(HaveOccurred())

--- a/pkg/management/postgres/configuration_test.go
+++ b/pkg/management/postgres/configuration_test.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cloudnative-pg/cnpg-i/pkg/postgres"
 	"github.com/cloudnative-pg/machinery/pkg/image/reference"
 	"github.com/cloudnative-pg/machinery/pkg/postgres/version"
 	corev1 "k8s.io/api/core/v1"
@@ -122,8 +123,8 @@ var _ = Describe("testing the building of the ldap config string", func() {
 })
 
 var _ = Describe("Test building of the list of temporary tablespaces", func() {
-	defaultVersion, err := version.FromTag(reference.New(versions.DefaultImageName).Tag)
-	Expect(err).ToNot(HaveOccurred())
+	defaultVersion, defaultVersionErr := version.FromTag(reference.New(versions.DefaultImageName).Tag)
+	Expect(defaultVersionErr).ToNot(HaveOccurred())
 	defaultMajor := int(defaultVersion.Major())
 
 	clusterWithoutTablespaces := apiv1.Cluster{
@@ -175,18 +176,39 @@ var _ = Describe("Test building of the list of temporary tablespaces", func() {
 		},
 	}
 
-	It("doesn't set temp_tablespaces if there are no declared tablespaces", func() {
-		config, _ := createPostgresqlConfiguration(&clusterWithoutTablespaces, true, defaultMajor)
+	It("doesn't set temp_tablespaces if there are no declared tablespaces", func(ctx SpecContext) {
+		config, _, err := createPostgresqlConfiguration(
+			ctx,
+			&clusterWithoutTablespaces,
+			true,
+			defaultVersion.Major(),
+			postgres.OperationType_TYPE_UNSPECIFIED,
+		)
+		Expect(err).ToNot(HaveOccurred())
 		Expect(config).ToNot(ContainSubstring("temp_tablespaces"))
 	})
 
-	It("doesn't set temp_tablespaces if there are no temporary tablespaces", func() {
-		config, _ := createPostgresqlConfiguration(&clusterWithoutTemporaryTablespaces, true, defaultMajor)
+	It("doesn't set temp_tablespaces if there are no temporary tablespaces", func(ctx SpecContext) {
+		config, _, err := createPostgresqlConfiguration(
+			ctx,
+			&clusterWithoutTemporaryTablespaces,
+			true,
+			defaultVersion.Major(),
+			postgres.OperationType_TYPE_UNSPECIFIED,
+		)
+		Expect(err).ToNot(HaveOccurred())
 		Expect(config).ToNot(ContainSubstring("temp_tablespaces"))
 	})
 
-	It("sets temp_tablespaces when there are temporary tablespaces", func() {
-		config, _ := createPostgresqlConfiguration(&clusterWithTemporaryTablespaces, true, defaultMajor)
+	It("sets temp_tablespaces when there are temporary tablespaces", func(ctx SpecContext) {
+		config, _, err := createPostgresqlConfiguration(
+			ctx,
+			&clusterWithTemporaryTablespaces,
+			true,
+			defaultVersion.Major(),
+			postgres.OperationType_TYPE_UNSPECIFIED,
+		)
+		Expect(err).ToNot(HaveOccurred())
 		Expect(config).To(ContainSubstring("temp_tablespaces = 'other_temporary_tablespace,temporary_tablespace'"))
 	})
 })
@@ -241,24 +263,45 @@ var _ = Describe("recovery_min_apply_delay", func() {
 		},
 	}
 
-	It("do not set recovery_min_apply_delay in primary clusters", func() {
+	It("do not set recovery_min_apply_delay in primary clusters", func(ctx SpecContext) {
 		Expect(primaryCluster.IsReplica()).To(BeFalse())
 
-		config, _ := createPostgresqlConfiguration(&primaryCluster, true, defaultMajor)
+		config, _, err := createPostgresqlConfiguration(
+			ctx,
+			&primaryCluster,
+			true,
+			defaultVersion.Major(),
+			postgres.OperationType_TYPE_UNSPECIFIED,
+		)
+		Expect(err).ToNot(HaveOccurred())
 		Expect(config).ToNot(ContainSubstring("recovery_min_apply_delay"))
 	})
 
-	It("set recovery_min_apply_delay in replica clusters when set", func() {
+	It("set recovery_min_apply_delay in replica clusters when set", func(ctx SpecContext) {
 		Expect(replicaCluster.IsReplica()).To(BeTrue())
 
-		config, _ := createPostgresqlConfiguration(&replicaCluster, true, defaultMajor)
+		config, _, err := createPostgresqlConfiguration(
+			ctx,
+			&replicaCluster,
+			true,
+			defaultVersion.Major(),
+			postgres.OperationType_TYPE_UNSPECIFIED,
+		)
+		Expect(err).ToNot(HaveOccurred())
 		Expect(config).To(ContainSubstring("recovery_min_apply_delay = '3600s'"))
 	})
 
-	It("do not set recovery_min_apply_delay in replica clusters when not set", func() {
+	It("do not set recovery_min_apply_delay in replica clusters when not set", func(ctx SpecContext) {
 		Expect(replicaClusterWithNoDelay.IsReplica()).To(BeTrue())
 
-		config, _ := createPostgresqlConfiguration(&replicaClusterWithNoDelay, true, defaultMajor)
+		config, _, err := createPostgresqlConfiguration(
+			ctx,
+			&replicaClusterWithNoDelay,
+			true,
+			defaultVersion.Major(),
+			postgres.OperationType_TYPE_UNSPECIFIED,
+		)
+		Expect(err).ToNot(HaveOccurred())
 		Expect(config).ToNot(ContainSubstring("recovery_min_apply_delay"))
 	})
 })

--- a/pkg/management/postgres/initdb.go
+++ b/pkg/management/postgres/initdb.go
@@ -452,6 +452,9 @@ func (info InitInfo) Bootstrap(ctx context.Context) error {
 
 	enabledPluginNamesSet := stringset.From(cluster.GetJobEnabledPluginNames())
 	pluginCli, err := pluginClient.NewClient(ctx, enabledPluginNamesSet)
+	if err != nil {
+		return fmt.Errorf("error while creating the plugin client: %w", err)
+	}
 	ctx = pluginClient.SetPluginClientInContext(ctx, pluginCli)
 	ctx = cluster.SetInContext(ctx)
 

--- a/pkg/management/postgres/initdb.go
+++ b/pkg/management/postgres/initdb.go
@@ -455,6 +455,7 @@ func (info InitInfo) Bootstrap(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("error while creating the plugin client: %w", err)
 	}
+	defer pluginCli.Close(ctx)
 	ctx = pluginClient.SetPluginClientInContext(ctx, pluginCli)
 	ctx = cluster.SetInContext(ctx)
 

--- a/pkg/management/postgres/initdb.go
+++ b/pkg/management/postgres/initdb.go
@@ -33,14 +33,17 @@ import (
 	"sort"
 	"time"
 
+	"github.com/cloudnative-pg/cnpg-i/pkg/postgres"
 	"github.com/cloudnative-pg/machinery/pkg/execlog"
 	"github.com/cloudnative-pg/machinery/pkg/fileutils"
 	"github.com/cloudnative-pg/machinery/pkg/fileutils/compatibility"
 	"github.com/cloudnative-pg/machinery/pkg/log"
+	"github.com/cloudnative-pg/machinery/pkg/stringset"
 	"github.com/jackc/pgx/v5"
 	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	pluginClient "github.com/cloudnative-pg/cloudnative-pg/internal/cnpi/plugin/client"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/configfile"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/external"
@@ -447,6 +450,11 @@ func (info InitInfo) Bootstrap(ctx context.Context) error {
 		return err
 	}
 
+	enabledPluginNamesSet := stringset.From(cluster.GetJobEnabledPluginNames())
+	pluginCli, err := pluginClient.NewClient(ctx, enabledPluginNamesSet)
+	ctx = pluginClient.SetPluginClientInContext(ctx, pluginCli)
+	ctx = cluster.SetInContext(ctx)
+
 	coredumpFilter := cluster.GetCoredumpFilter()
 	if err := system.SetCoredumpFilter(coredumpFilter); err != nil {
 		return err
@@ -464,7 +472,12 @@ func (info InitInfo) Bootstrap(ctx context.Context) error {
 		cluster.Spec.Bootstrap.InitDB != nil &&
 		cluster.Spec.Bootstrap.InitDB.Import != nil
 
-	if applied, err := instance.RefreshConfigurationFilesFromCluster(ctx, cluster, true); err != nil {
+	if applied, err := instance.RefreshConfigurationFilesFromCluster(
+		ctx,
+		cluster,
+		true,
+		postgres.OperationType_TYPE_INIT,
+	); err != nil {
 		return fmt.Errorf("while writing the config: %w", err)
 	} else if !applied {
 		return fmt.Errorf("could not apply the config")

--- a/pkg/management/postgres/restore.go
+++ b/pkg/management/postgres/restore.go
@@ -823,6 +823,7 @@ func (info InitInfo) WriteInitialPostgresqlConf(ctx context.Context, cluster *ap
 	if err != nil {
 		return fmt.Errorf("error while creating the plugin client: %w", err)
 	}
+	defer pluginCli.Close(ctx)
 	ctx = pluginClient.SetPluginClientInContext(ctx, pluginCli)
 	ctx = cluster.SetInContext(ctx)
 

--- a/pkg/management/postgres/restore.go
+++ b/pkg/management/postgres/restore.go
@@ -820,6 +820,9 @@ func (info InitInfo) WriteInitialPostgresqlConf(ctx context.Context, cluster *ap
 
 	enabledPluginNamesSet := stringset.From(cluster.GetJobEnabledPluginNames())
 	pluginCli, err := pluginClient.NewClient(ctx, enabledPluginNamesSet)
+	if err != nil {
+		return fmt.Errorf("error while creating the plugin client: %w", err)
+	}
 	ctx = pluginClient.SetPluginClientInContext(ctx, pluginCli)
 	ctx = cluster.SetInContext(ctx)
 

--- a/pkg/management/postgres/restore.go
+++ b/pkg/management/postgres/restore.go
@@ -40,6 +40,7 @@ import (
 	barmanCredentials "github.com/cloudnative-pg/barman-cloud/pkg/credentials"
 	barmanRestorer "github.com/cloudnative-pg/barman-cloud/pkg/restorer"
 	barmanUtils "github.com/cloudnative-pg/barman-cloud/pkg/utils"
+	"github.com/cloudnative-pg/cnpg-i/pkg/postgres"
 	restore "github.com/cloudnative-pg/cnpg-i/pkg/restore/job"
 	"github.com/cloudnative-pg/machinery/pkg/envmap"
 	"github.com/cloudnative-pg/machinery/pkg/execlog"
@@ -817,6 +818,11 @@ func (info InitInfo) WriteInitialPostgresqlConf(ctx context.Context, cluster *ap
 		}
 	}()
 
+	enabledPluginNamesSet := stringset.From(cluster.GetJobEnabledPluginNames())
+	pluginCli, err := pluginClient.NewClient(ctx, enabledPluginNamesSet)
+	ctx = pluginClient.SetPluginClientInContext(ctx, pluginCli)
+	ctx = cluster.SetInContext(ctx)
+
 	temporaryInitInfo := InitInfo{
 		PgData:    tempDataDir,
 		Temporary: true,
@@ -838,7 +844,12 @@ func (info InitInfo) WriteInitialPostgresqlConf(ctx context.Context, cluster *ap
 	if err != nil {
 		return fmt.Errorf("while generating pg_ident.conf: %w", err)
 	}
-	_, err = temporaryInstance.RefreshConfigurationFilesFromCluster(ctx, cluster, false)
+	_, err = temporaryInstance.RefreshConfigurationFilesFromCluster(
+		ctx,
+		cluster,
+		false,
+		postgres.OperationType_TYPE_RESTORE,
+	)
 	if err != nil {
 		return fmt.Errorf("while generating Postgres configuration: %w", err)
 	}

--- a/pkg/postgres/configuration.go
+++ b/pkg/postgres/configuration.go
@@ -567,6 +567,11 @@ func (p *PgConfiguration) GetConfigurationParameters() map[string]string {
 	return p.configs
 }
 
+// SetConfigurationParameters sets the configuration parameters
+func (p *PgConfiguration) SetConfigurationParameters(configs map[string]string) {
+	p.configs = configs
+}
+
 // OverwriteConfig overwrites a configuration in the map, given the key/value pair.
 // If the map is nil, it is created and the pair is added
 func (p *PgConfiguration) OverwriteConfig(key, value string) {

--- a/pkg/postgres/plugin/config.go
+++ b/pkg/postgres/plugin/config.go
@@ -1,0 +1,72 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package plugin
+
+import (
+	"context"
+
+	postgresClient "github.com/cloudnative-pg/cnpg-i/pkg/postgres"
+	"github.com/cloudnative-pg/machinery/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	cnpgiClient "github.com/cloudnative-pg/cloudnative-pg/internal/cnpi/plugin/client"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/postgres"
+	contextutils "github.com/cloudnative-pg/cloudnative-pg/pkg/utils/context"
+)
+
+// CreatePostgresqlConfigurationWithPlugins creates a new PostgreSQL configuration and enriches it by invoking
+// the registered Plugins
+func CreatePostgresqlConfigurationWithPlugins(
+	ctx context.Context,
+	info postgres.ConfigurationInfo,
+	operationType postgresClient.OperationType_Type,
+) (*postgres.PgConfiguration, error) {
+	contextLogger := log.FromContext(ctx).WithName("enrichConfigurationWithPlugins")
+
+	pgConf := postgres.CreatePostgresqlConfiguration(info)
+
+	cluster, ok := ctx.Value(contextutils.ContextKeyCluster).(client.Object)
+	if !ok || cluster == nil {
+		contextLogger.Trace("skipping CreatePostgresqlConfigurationWithPlugins, cannot find the cluster inside the context")
+		return pgConf, nil
+	}
+
+	pluginClient := cnpgiClient.GetPluginClientFromContext(ctx)
+	if pluginClient == nil {
+		contextLogger.Trace(
+			"skipping CreatePostgresqlConfigurationWithPlugins, cannot find the plugin client inside the context")
+		return pgConf, nil
+	}
+
+	conf, err := pluginClient.EnrichConfiguration(
+		ctx,
+		cluster,
+		pgConf.GetConfigurationParameters(),
+		operationType,
+	)
+	if err != nil {
+		contextLogger.Error(err, "failed to enrich configuration with plugins")
+		return nil, err
+	}
+
+	pgConf.SetConfigurationParameters(conf)
+
+	return pgConf, nil
+}

--- a/pkg/postgres/plugin/doc.go
+++ b/pkg/postgres/plugin/doc.go
@@ -17,17 +17,5 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 */
 
-package connection
-
-// Metadata expose the metadata as discovered
-// from a plugin
-type Metadata struct {
-	Name                       string
-	Version                    string
-	Capabilities               []string
-	OperatorCapabilities       []string
-	WALCapabilities            []string
-	BackupCapabilities         []string
-	RestoreJobHookCapabilities []string
-	PostgresCapabilities       []string
-}
+// Package plugin contains the methods to interact with the plugins that have the Postgres capabilities
+package plugin


### PR DESCRIPTION
The `Postgres` interface allows the plugin developers to change the configuration
of the PostgreSQL instance after the manager has generated it.