### PR TITLE
chore(Makefile): remove targets for `kind` clusters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -228,10 +228,6 @@ manifests: controller-gen ## Generate manifests e.g. CRD, RBAC etc.
 generate: controller-gen ## Generate code.
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
 
-deploy-locally: kind-cluster ## Build and deploy operator in local cluster
-	set -e ;\
-	hack/setup-cluster.sh -n1 load deploy
-
 olm-scorecard: operator-sdk ## Run the Scorecard test from operator-sdk
 	$(OPERATOR_SDK) scorecard ${BUNDLE_IMG} --wait-time 60s --verbose
 
@@ -349,14 +345,6 @@ echo "Downloading $(2)" ;\
 GOBIN=$(PROJECT_DIR)/bin go install $(2) ;\
 }
 endef
-
-kind-cluster: ## Create KinD cluster to run operator locally
-	set -e ;\
-	hack/setup-cluster.sh -n1 create
-
-kind-cluster-destroy: ## Destroy KinD cluster created using kind-cluster command
-	set -e ;\
-	hack/setup-cluster.sh -n1 destroy
 
 .PHONY: operator-sdk
 OPERATOR_SDK = $(LOCALBIN)/operator-sdk

--- a/contribute/development_environment/README.md
+++ b/contribute/development_environment/README.md
@@ -187,7 +187,7 @@ This will build the operator based on the `main` branch content, create a
 `kind` cluster in your workstation with a container registry that provides the
 operator image that you just built.
 
-*Note:* For a list of option, run `./hack/setup-cluster.sh`.
+*Note:* For a list of options, run `./hack/setup-cluster.sh`.
 
 > **NOTE:** In case of errors, make sure that you have the latest versions of the Go
 > binaries in your system. For this reason, from time to time, we recommend

--- a/contribute/development_environment/README.md
+++ b/contribute/development_environment/README.md
@@ -180,12 +180,14 @@ build and deploy:
 ```shell
 cd cloudnative-pg
 git checkout main
-make deploy-locally
+./hack/setup.sh create load deploy
 ```
 
 This will build the operator based on the `main` branch content, create a
 `kind` cluster in your workstation with a container registry that provides the
 operator image that you just built.
+
+*Note:* For a list of option, run `./hack/setup-cluster.sh`.
 
 > **NOTE:** In case of errors, make sure that you have the latest versions of the Go
 > binaries in your system. For this reason, from time to time, we recommend
@@ -202,7 +204,7 @@ kubectl get deploy -n cnpg-system cnpg-controller-manager
 Now that your system has been validated, you can tear down the local cluster with:
 
 ```shell
-make kind-cluster-destroy
+./hack/setup.sh destroy
 ```
 
 Congratulations, you have a suitable development environment. You are now able


### PR DESCRIPTION
Now everything can be done directly through the `hack/setup.sh` script.

Closes #7185