### PR TITLE
feat(metrics): check if extensions have updates

### DIFF
--- a/config/manager/default-monitoring.yaml
+++ b/config/manager/default-monitoring.yaml
@@ -454,3 +454,35 @@ data:
         - setting:
             usage: "GAUGE"
             description: "Setting value"
+
+    pg_extensions:
+      query: |
+        SELECT
+         current_database() as datname,
+         name as extname,
+         default_version,
+         installed_version,
+         CASE
+           WHEN default_version = installed_version THEN 0
+           ELSE 1
+        END AS update_available
+        FROM pg_catalog.pg_available_extensions
+        WHERE installed_version IS NOT NULL
+      metrics:
+        - datname:
+            usage: "LABEL"
+            description: "Name of the database"
+        - extname:
+            usage: "LABEL"
+            description: "Extension name"
+        - default_version:
+            usage: "LABEL"
+            description: "Default version"
+        - installed_version:
+            usage: "LABEL"
+            description: "Installed version"
+        - update_available:
+            usage: "GAUGE"
+            description: "An update is available"
+      target_databases:
+        - '*'


### PR DESCRIPTION
Updating the image can update the extensions available, but doesn't change the version installed in the database. We want to expose the info about an available update to the users.

Closes #7194

# Release notes

The pg_extensions matric has been added, exposing information about the installed extensions and their latest available version.