### PR TITLE
feat: allow bypassing the validation webhook

### DIFF
--- a/docs/src/labels_annotations.md
+++ b/docs/src/labels_annotations.md
@@ -228,6 +228,13 @@ CloudNativePG manages the following predefined annotations:
 `cnpg.io/snapshotEndTime`
 :   The time a snapshot was marked as ready to use.
 
+`cnpg.io/validation`
+:   When set to `disabled` on a CloudNativePG-managed custom resource, the
+    validation webhook allows all changes without restriction.
+
+    **⚠️ WARNING:** Disabling validation may permit unsafe or destructive
+    operations. Use this setting with caution and at your own risk.
+
 `cnpg.io/volumeSnapshotDeadline`
 :   Applied to `Backup` and `ScheduledBackup` resources, allows you to control
     how long the operator should retry recoverable errors before considering the
@@ -235,13 +242,6 @@ CloudNativePG manages the following predefined annotations:
 
 `kubectl.kubernetes.io/restartedAt`
 :   When available, the time of last requested restart of a Postgres cluster.
-
-`cnpg.io/validation`
-:   When set to `disabled` on a CNPG-managed custom resource,
-    the validation webhook will permit all changes without restriction.
-
-    **⚠️ WARNING:** Disabling validation can allow potentially unsafe or destructive operations.
-    Use this setting with caution and at your own risk.
 
 ## Prerequisites
 

--- a/docs/src/labels_annotations.md
+++ b/docs/src/labels_annotations.md
@@ -236,6 +236,11 @@ CloudNativePG manages the following predefined annotations:
 `kubectl.kubernetes.io/restartedAt`
 :   When available, the time of last requested restart of a Postgres cluster.
 
+`cnpg.io/validation`
+:   When set to `disabled` on a CNPG-managed custom object, the validation webhook
+    will allow every change. Important: this allows potentially dangerous activities,
+    please use it with care and at your own risk.
+
 ## Prerequisites
 
 By default, no label or annotation defined in the cluster's metadata is

--- a/docs/src/labels_annotations.md
+++ b/docs/src/labels_annotations.md
@@ -237,9 +237,11 @@ CloudNativePG manages the following predefined annotations:
 :   When available, the time of last requested restart of a Postgres cluster.
 
 `cnpg.io/validation`
-:   When set to `disabled` on a CNPG-managed custom object, the validation webhook
-    will allow every change. Important: this allows potentially dangerous activities,
-    please use it with care and at your own risk.
+:   When set to `disabled` on a CNPG-managed custom resource,
+    the validation webhook will permit all changes without restriction.
+
+    **⚠️ WARNING:** Disabling validation can allow potentially unsafe or destructive operations.
+    Use this setting with caution and at your own risk.
 
 ## Prerequisites
 

--- a/docs/src/release_notes/v1.26.md
+++ b/docs/src/release_notes/v1.26.md
@@ -36,6 +36,10 @@ on the release branch in GitHub.
 
 ### Enhancements:
 
+- Implemented the `cnpg.io/validation` annotation, allowing users to disable
+  the validation webhook on CloudNativePG-managed resources. Use with caution,
+  as this can permit unrestricted changes. (#7196)
+
 - Introduced the `STANDBY_TCP_USER_TIMEOUT` operator configuration setting,
   which, if specified, sets the `tcp_user_timeout` parameter on all standby
   instances managed by the operator.

--- a/internal/webhook/v1/backup_webhook.go
+++ b/internal/webhook/v1/backup_webhook.go
@@ -43,7 +43,7 @@ var backupLog = log.WithName("backup-resource").WithValues("version", "v1")
 // SetupBackupWebhookWithManager registers the webhook for Backup in the manager.
 func SetupBackupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).For(&apiv1.Backup{}).
-		WithValidator(&BackupCustomValidator{}).
+		WithValidator(newBypassableValidator(&BackupCustomValidator{})).
 		WithDefaulter(&BackupCustomDefaulter{}).
 		Complete()
 }

--- a/internal/webhook/v1/cluster_webhook.go
+++ b/internal/webhook/v1/cluster_webhook.go
@@ -62,7 +62,7 @@ var clusterLog = log.WithName("cluster-resource").WithValues("version", "v1")
 // SetupClusterWebhookWithManager registers the webhook for Cluster in the manager.
 func SetupClusterWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).For(&apiv1.Cluster{}).
-		WithValidator(&ClusterCustomValidator{}).
+		WithValidator(newBypassableValidator(&ClusterCustomValidator{})).
 		WithDefaulter(&ClusterCustomDefaulter{}).
 		Complete()
 }

--- a/internal/webhook/v1/common.go
+++ b/internal/webhook/v1/common.go
@@ -1,5 +1,6 @@
 /*
-Copyright The CloudNativePG Contributors
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -12,6 +13,8 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
 */
 
 package v1

--- a/internal/webhook/v1/common.go
+++ b/internal/webhook/v1/common.go
@@ -109,6 +109,9 @@ func (b bypassableValidator) ValidateDelete(
 	})
 }
 
+const validationDisabledWarning = "validation webhook is disabled — all changes are accepted without validation. " +
+	"This may lead to unsafe or destructive operations. Proceed with extreme caution."
+
 func validate(obj runtime.Object, validator func() (admission.Warnings, error)) (admission.Warnings, error) {
 	var warnings admission.Warnings
 
@@ -120,7 +123,7 @@ func validate(obj runtime.Object, validator func() (admission.Warnings, error)) 
 	}
 
 	if !validationEnabled {
-		warnings = append(warnings, "validation webhook disabled")
+		warnings = append(warnings, validationDisabledWarning)
 		return warnings, nil
 	}
 

--- a/internal/webhook/v1/common_test.go
+++ b/internal/webhook/v1/common_test.go
@@ -1,5 +1,6 @@
 /*
-Copyright The CloudNativePG Contributors
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -12,6 +13,8 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
 */
 
 package v1

--- a/internal/webhook/v1/common_test.go
+++ b/internal/webhook/v1/common_test.go
@@ -1,0 +1,169 @@
+/*
+Copyright The CloudNativePG Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	"context"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func newClusterWithValidationAnnotation(value string) *apiv1.Cluster {
+	return &apiv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				utils.WebhookValidationAnnotationName: value,
+			},
+		},
+	}
+}
+
+var _ = Describe("Validation webhook validation parser", func() {
+	It("ensures that with no annotations the validation checking is enabled", func() {
+		cluster := &apiv1.Cluster{}
+		Expect(isValidationEnabled(cluster)).To(BeTrue())
+	})
+
+	It("ensures that with validation can be explicitly enabled", func() {
+		cluster := newClusterWithValidationAnnotation(validationEnabledAnnotationValue)
+		Expect(isValidationEnabled(cluster)).To(BeTrue())
+	})
+
+	It("ensures that with validation can be explicitly disabled", func() {
+		cluster := newClusterWithValidationAnnotation(validationDisabledAnnotationValue)
+		Expect(isValidationEnabled(cluster)).To(BeFalse())
+	})
+
+	It("ensures that with validation is enabled when the annotation value is unknown", func() {
+		cluster := newClusterWithValidationAnnotation("idontknow")
+		status, err := isValidationEnabled(cluster)
+		Expect(err).To(HaveOccurred())
+		Expect(status).To(BeTrue())
+	})
+})
+
+type fakeCustomValidator struct {
+	calls []string
+
+	createWarnings admission.Warnings
+	createError    error
+
+	updateWarnings admission.Warnings
+	updateError    error
+
+	deleteWarnings admission.Warnings
+	deleteError    error
+}
+
+func (f *fakeCustomValidator) ValidateCreate(
+	_ context.Context,
+	_ runtime.Object,
+) (admission.Warnings, error) {
+	f.calls = append(f.calls, "create")
+	return f.createWarnings, f.createError
+}
+
+func (f *fakeCustomValidator) ValidateUpdate(
+	_ context.Context,
+	_ runtime.Object,
+	_ runtime.Object,
+) (admission.Warnings, error) {
+	f.calls = append(f.calls, "update")
+	return f.updateWarnings, f.updateError
+}
+
+func (f *fakeCustomValidator) ValidateDelete(
+	_ context.Context,
+	_ runtime.Object,
+) (admission.Warnings, error) {
+	f.calls = append(f.calls, "delete")
+	return f.deleteWarnings, f.deleteError
+}
+
+var _ = Describe("Bypassable validator", func() {
+	fakeCreateError := fmt.Errorf("fake error")
+	fakeUpdateError := fmt.Errorf("fake error")
+	fakeDeleteError := fmt.Errorf("fake error")
+
+	disabledCluster := newClusterWithValidationAnnotation(validationDisabledAnnotationValue)
+	enabledCluster := newClusterWithValidationAnnotation(validationEnabledAnnotationValue)
+	wrongCluster := newClusterWithValidationAnnotation("dontknow")
+
+	fakeErrorValidator := &fakeCustomValidator{
+		createError: fakeCreateError,
+		deleteError: fakeDeleteError,
+		updateError: fakeUpdateError,
+	}
+
+	DescribeTable(
+		"validator callbacks",
+		func(ctx SpecContext, c *apiv1.Cluster, expectedError, withWarnings bool) {
+			b := newBypassableValidator(fakeErrorValidator)
+
+			By("creation entrypoint", func() {
+				result, err := b.ValidateCreate(ctx, c)
+				if expectedError {
+					Expect(err).To(Equal(fakeCreateError))
+				} else {
+					Expect(err).ToNot(HaveOccurred())
+				}
+
+				if withWarnings {
+					Expect(result).To(HaveLen(1))
+				}
+			})
+
+			By("update entrypoint", func() {
+				result, err := b.ValidateUpdate(ctx, enabledCluster, c)
+				if expectedError {
+					Expect(err).To(Equal(fakeUpdateError))
+				} else {
+					Expect(err).ToNot(HaveOccurred())
+				}
+
+				if withWarnings {
+					Expect(result).To(HaveLen(1))
+				}
+			})
+
+			By("delete entrypoint", func() {
+				result, err := b.ValidateDelete(ctx, c)
+				if expectedError {
+					Expect(err).To(Equal(fakeDeleteError))
+				} else {
+					Expect(err).ToNot(HaveOccurred())
+				}
+
+				if withWarnings {
+					Expect(result).To(HaveLen(1))
+				}
+			})
+		},
+		Entry("validation is disabled", disabledCluster, false, true),
+		Entry("validation is enabled", enabledCluster, true, false),
+		Entry("validation value is not expected", wrongCluster, true, true),
+	)
+})

--- a/internal/webhook/v1/database_webhook.go
+++ b/internal/webhook/v1/database_webhook.go
@@ -41,7 +41,7 @@ var databaseLog = log.WithName("database-resource").WithValues("version", "v1")
 // SetupDatabaseWebhookWithManager registers the webhook for Database in the manager.
 func SetupDatabaseWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).For(&apiv1.Database{}).
-		WithValidator(&DatabaseCustomValidator{}).
+		WithValidator(newBypassableValidator(&DatabaseCustomValidator{})).
 		WithDefaulter(&DatabaseCustomDefaulter{}).
 		Complete()
 }

--- a/internal/webhook/v1/pooler_webhook.go
+++ b/internal/webhook/v1/pooler_webhook.go
@@ -97,7 +97,7 @@ var poolerLog = log.WithName("pooler-resource").WithValues("version", "v1")
 // SetupPoolerWebhookWithManager registers the webhook for Pooler in the manager.
 func SetupPoolerWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).For(&apiv1.Pooler{}).
-		WithValidator(&PoolerCustomValidator{}).
+		WithValidator(newBypassableValidator(&PoolerCustomValidator{})).
 		Complete()
 }
 

--- a/pkg/utils/labels_annotations.go
+++ b/pkg/utils/labels_annotations.go
@@ -246,6 +246,10 @@ const (
 	// PodPatchAnnotationName is the name of the annotation containing the
 	// patch to apply to the pod
 	PodPatchAnnotationName = MetadataNamespace + "/podPatch"
+
+	// WebhookValidationAnnotationName is the name of the annotation describing if
+	// the validation webhook should be enabled or disabled
+	WebhookValidationAnnotationName = MetadataNamespace + "/validation"
 )
 
 type annotationStatus string


### PR DESCRIPTION
This patch introduces the `cnpg.io/validation` annotation, enabling users to disable the validation webhook on CloudNativePG-managed resources.  

This capability is essential for making unrestricted modifications to the cluster definition, allowing operations that the operator would typically prevent—such as reducing volume sizes and rebuilding them individually.  

However, this increased flexibility comes with the risk of executing potentially harmful operations, so it should be used with caution.  

Fixes: #7117  
