### PR TITLE
test(e2e): fix lag control probe threshold

### DIFF
--- a/tests/e2e/fixtures/sync_replicas/startup-probe-lag-control.yaml.template
+++ b/tests/e2e/fixtures/sync_replicas/startup-probe-lag-control.yaml.template
@@ -25,6 +25,9 @@ spec:
       maximumLag: 16Mi
       failureThreshold: 60
       periodSeconds: 1
+    readiness:
+      failureThreshold: 10
+      periodSeconds: 1
 
   storage:
     storageClass: ${E2E_DEFAULT_STORAGE_CLASS}


### PR DESCRIPTION
The test timeout and the total readiness time coincide. This means that the test can pass or fail for fractions of a second. Define a quicker readiness probe so we should be ready before we fail the test.

Closes #7198
