### PR TITLE
test: cleanup leftover logs from db management E2Es

### DIFF
--- a/tests/e2e/declarative_database_management_test.go
+++ b/tests/e2e/declarative_database_management_test.go
@@ -226,6 +226,9 @@ var _ = Describe("Declarative database management", Label(tests.LabelSmoke, test
 			By("deleting the namespace and making sure it succeeds before timeout", func() {
 				err := namespaces.DeleteNamespaceAndWait(env.Ctx, env.Client, namespace, 120)
 				Expect(err).ToNot(HaveOccurred())
+				// we need to cleanup testing logs adhoc since we are not using a testingNamespace for this test
+				err = namespaces.CleanupClusterLogs(namespace, CurrentSpecReport().Failed())
+				Expect(err).ToNot(HaveOccurred())
 			})
 		})
 	})

--- a/tests/utils/namespaces/namespace.go
+++ b/tests/utils/namespaces/namespace.go
@@ -64,6 +64,18 @@ func getPreserveNamespaces() []string {
 	return preserveNamespacesList
 }
 
+// CleanupClusterLogs cleans up the cluster logs of a given namespace
+func CleanupClusterLogs(namespace string, testFailed bool) error {
+	exists, _ := fileutils.FileExists(path.Join(SternLogDirectory, namespace))
+	if exists && !testFailed {
+		if err := fileutils.RemoveDirectory(path.Join(SternLogDirectory, namespace)); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 // cleanupNamespace does cleanup duty related to the tear-down of a namespace,
 // and is intended to be called in a DeferCleanup clause
 func cleanupNamespace(
@@ -79,12 +91,9 @@ func cleanupNamespace(
 	if len(namespace) == 0 {
 		return fmt.Errorf("namespace is empty")
 	}
-	exists, _ := fileutils.FileExists(path.Join(SternLogDirectory, namespace))
-	if exists && !testFailed {
-		err := fileutils.RemoveDirectory(path.Join(SternLogDirectory, namespace))
-		if err != nil {
-			return err
-		}
+
+	if err := CleanupClusterLogs(namespace, testFailed); err != nil {
+		return err
 	}
 
 	return deleteNamespace(ctx, crudClient, namespace)


### PR DESCRIPTION
Closes #6411 

Usually, at the end of a green test, `cleanupNamespace()` will take care of deleting the testing logs captured and issuing an `objects.Delete` request (we do not actually wait for the namespace to be gone though).

This Database management E2E is an exception to the usual way we create/destroy testing namespaces.
Here we want to test that Database object finalizers do not prevent the deletion of a namespace, hence we need to ensure the namespace is properly gone before declaring that the test succeded. After doing that, we now cleanup the testing logs.