### PR TITLE
feat(barman-cloud): remove support for Barman <= 3.4

### DIFF
--- a/config/crd/bases/postgresql.cnpg.io_clusters.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_clusters.yaml
@@ -1152,14 +1152,11 @@ spec:
                             description: |-
                               Compress a backup file (a tar file per tablespace) while streaming it
                               to the object store. Available options are empty string (no
-                              compression, default), `gzip`, `bzip2`, `lz4`, `snappy`, `xz`, and `zstd`.
+                              compression, default), `gzip`, `bzip2`, and `snappy`.
                             enum:
                             - bzip2
                             - gzip
-                            - lz4
                             - snappy
-                            - xz
-                            - zstd
                             type: string
                           encryption:
                             description: |-
@@ -2661,14 +2658,11 @@ spec:
                               description: |-
                                 Compress a backup file (a tar file per tablespace) while streaming it
                                 to the object store. Available options are empty string (no
-                                compression, default), `gzip`, `bzip2`, `lz4`, `snappy`, `xz`, and `zstd`.
+                                compression, default), `gzip`, `bzip2`, and `snappy`.
                               enum:
                               - bzip2
                               - gzip
-                              - lz4
                               - snappy
-                              - xz
-                              - zstd
                               type: string
                             encryption:
                               description: |-

--- a/go.mod
+++ b/go.mod
@@ -8,9 +8,9 @@ require (
 	github.com/avast/retry-go/v4 v4.6.1
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/cheynewallace/tabby v1.1.1
-	github.com/cloudnative-pg/barman-cloud v0.3.1-0.20250327134509-02a82773123e
+	github.com/cloudnative-pg/barman-cloud v0.3.1
 	github.com/cloudnative-pg/cnpg-i v0.1.1-0.20250321093050-de4ab51537cb
-	github.com/cloudnative-pg/machinery v0.1.0
+	github.com/cloudnative-pg/machinery v0.2.0
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/evanphx/json-patch/v5 v5.9.11
 	github.com/go-logr/logr v1.4.2

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/avast/retry-go/v4 v4.6.1
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/cheynewallace/tabby v1.1.1
-	github.com/cloudnative-pg/barman-cloud v0.3.1-0.20250325174426-dbb1cf6d8fed
+	github.com/cloudnative-pg/barman-cloud v0.3.1-0.20250327134509-02a82773123e
 	github.com/cloudnative-pg/cnpg-i v0.1.1-0.20250321093050-de4ab51537cb
 	github.com/cloudnative-pg/machinery v0.1.0
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/avast/retry-go/v4 v4.6.1
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/cheynewallace/tabby v1.1.1
-	github.com/cloudnative-pg/barman-cloud v0.3.0
+	github.com/cloudnative-pg/barman-cloud v0.3.1-0.20250325174426-dbb1cf6d8fed
 	github.com/cloudnative-pg/cnpg-i v0.1.1-0.20250321093050-de4ab51537cb
 	github.com/cloudnative-pg/machinery v0.1.0
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cheynewallace/tabby v1.1.1 h1:JvUR8waht4Y0S3JF17G6Vhyt+FRhnqVCkk8l4YrOU54=
 github.com/cheynewallace/tabby v1.1.1/go.mod h1:Pba/6cUL8uYqvOc9RkyvFbHGrQ9wShyrn6/S/1OYVys=
-github.com/cloudnative-pg/barman-cloud v0.3.1-0.20250325174426-dbb1cf6d8fed h1:ZA8yS4ZAxG54S7gYsaJ1p6psMXv9r+5E0FJBr//bE5o=
-github.com/cloudnative-pg/barman-cloud v0.3.1-0.20250325174426-dbb1cf6d8fed/go.mod h1:kNBqYbcX1LmwkOWfCinNuAgz/ObT+AOWdptkLGEInek=
+github.com/cloudnative-pg/barman-cloud v0.3.1-0.20250327134509-02a82773123e h1:XMm8OvyhISeCcuIv1rkVK8pDZE/+j9wMAEfr/Y0Vw7Q=
+github.com/cloudnative-pg/barman-cloud v0.3.1-0.20250327134509-02a82773123e/go.mod h1:kNBqYbcX1LmwkOWfCinNuAgz/ObT+AOWdptkLGEInek=
 github.com/cloudnative-pg/cnpg-i v0.1.1-0.20250321093050-de4ab51537cb h1:FPORwCxjZwlnKnF7dOkuOAz0GBSQ3Hrn+8lm4uMiWeM=
 github.com/cloudnative-pg/cnpg-i v0.1.1-0.20250321093050-de4ab51537cb/go.mod h1:n+kbHm3rzRCY5IJKuE1tGMbG6JaeYz8yycYoLt7BeKo=
 github.com/cloudnative-pg/machinery v0.1.0 h1:tjRmsqQmsO/OlaT0uFmkEtVqgr+SGPM88cKZOHYKLBo=

--- a/go.sum
+++ b/go.sum
@@ -18,12 +18,12 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cheynewallace/tabby v1.1.1 h1:JvUR8waht4Y0S3JF17G6Vhyt+FRhnqVCkk8l4YrOU54=
 github.com/cheynewallace/tabby v1.1.1/go.mod h1:Pba/6cUL8uYqvOc9RkyvFbHGrQ9wShyrn6/S/1OYVys=
-github.com/cloudnative-pg/barman-cloud v0.3.1-0.20250327134509-02a82773123e h1:XMm8OvyhISeCcuIv1rkVK8pDZE/+j9wMAEfr/Y0Vw7Q=
-github.com/cloudnative-pg/barman-cloud v0.3.1-0.20250327134509-02a82773123e/go.mod h1:kNBqYbcX1LmwkOWfCinNuAgz/ObT+AOWdptkLGEInek=
+github.com/cloudnative-pg/barman-cloud v0.3.1 h1:kzkY77k2lN/caoyh7ibXDSZjJeSJTNvnVt6Gfa8Iq5M=
+github.com/cloudnative-pg/barman-cloud v0.3.1/go.mod h1:4HL3AjY9oEl2Ed0HSkyvTZEQPhwyFOaAnuCz9lfVeYQ=
 github.com/cloudnative-pg/cnpg-i v0.1.1-0.20250321093050-de4ab51537cb h1:FPORwCxjZwlnKnF7dOkuOAz0GBSQ3Hrn+8lm4uMiWeM=
 github.com/cloudnative-pg/cnpg-i v0.1.1-0.20250321093050-de4ab51537cb/go.mod h1:n+kbHm3rzRCY5IJKuE1tGMbG6JaeYz8yycYoLt7BeKo=
-github.com/cloudnative-pg/machinery v0.1.0 h1:tjRmsqQmsO/OlaT0uFmkEtVqgr+SGPM88cKZOHYKLBo=
-github.com/cloudnative-pg/machinery v0.1.0/go.mod h1:0V3vm44FaIsY+x4pm8ORry7xCC3AJiO+ebfPNxeP5Ck=
+github.com/cloudnative-pg/machinery v0.2.0 h1:x8OAwxdeL/6wkbxqorz+nX6UovTyx7/TBeCfiRebR2o=
+github.com/cloudnative-pg/machinery v0.2.0/go.mod h1:Kg8W8Tb/1UFGGtw3hR8S5SytSWddlHaCnJSgBo4x/nc=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
 github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cheynewallace/tabby v1.1.1 h1:JvUR8waht4Y0S3JF17G6Vhyt+FRhnqVCkk8l4YrOU54=
 github.com/cheynewallace/tabby v1.1.1/go.mod h1:Pba/6cUL8uYqvOc9RkyvFbHGrQ9wShyrn6/S/1OYVys=
-github.com/cloudnative-pg/barman-cloud v0.3.0 h1:tCtIF7nsHDH5X7nAXXd7VqNKKNGHrycXAyyKKKpdGS4=
-github.com/cloudnative-pg/barman-cloud v0.3.0/go.mod h1:8m6W117343zT28ctcskUYEu/dy+MX3hUUW4DynH8MLI=
+github.com/cloudnative-pg/barman-cloud v0.3.1-0.20250325174426-dbb1cf6d8fed h1:ZA8yS4ZAxG54S7gYsaJ1p6psMXv9r+5E0FJBr//bE5o=
+github.com/cloudnative-pg/barman-cloud v0.3.1-0.20250325174426-dbb1cf6d8fed/go.mod h1:kNBqYbcX1LmwkOWfCinNuAgz/ObT+AOWdptkLGEInek=
 github.com/cloudnative-pg/cnpg-i v0.1.1-0.20250321093050-de4ab51537cb h1:FPORwCxjZwlnKnF7dOkuOAz0GBSQ3Hrn+8lm4uMiWeM=
 github.com/cloudnative-pg/cnpg-i v0.1.1-0.20250321093050-de4ab51537cb/go.mod h1:n+kbHm3rzRCY5IJKuE1tGMbG6JaeYz8yycYoLt7BeKo=
 github.com/cloudnative-pg/machinery v0.1.0 h1:tjRmsqQmsO/OlaT0uFmkEtVqgr+SGPM88cKZOHYKLBo=

--- a/pkg/management/postgres/backup.go
+++ b/pkg/management/postgres/backup.go
@@ -28,7 +28,6 @@ import (
 	"time"
 
 	barmanBackup "github.com/cloudnative-pg/barman-cloud/pkg/backup"
-	barmanCapabilities "github.com/cloudnative-pg/barman-cloud/pkg/capabilities"
 	barmanCatalog "github.com/cloudnative-pg/barman-cloud/pkg/catalog"
 	barmanCommand "github.com/cloudnative-pg/barman-cloud/pkg/command"
 	barmanCredentials "github.com/cloudnative-pg/barman-cloud/pkg/credentials"
@@ -68,7 +67,6 @@ type BackupCommand struct {
 	Env          []string
 	Log          log.Logger
 	Instance     *Instance
-	Capabilities *barmanCapabilities.Capabilities
 	barmanBackup *barmanBackup.Command
 }
 
@@ -82,11 +80,6 @@ func NewBarmanBackupCommand(
 	instance *Instance,
 	log log.Logger,
 ) (*BackupCommand, error) {
-	capabilities, err := barmanCapabilities.CurrentCapabilities()
-	if err != nil {
-		return nil, err
-	}
-
 	return &BackupCommand{
 		Cluster:      cluster,
 		Backup:       backup,
@@ -95,8 +88,7 @@ func NewBarmanBackupCommand(
 		Env:          os.Environ(),
 		Instance:     instance,
 		Log:          log,
-		Capabilities: capabilities,
-		barmanBackup: barmanBackup.NewBackupCommand(cluster.Spec.Backup.BarmanObjectStore, capabilities),
+		barmanBackup: barmanBackup.NewBackupCommand(cluster.Spec.Backup.BarmanObjectStore),
 	}, nil
 }
 
@@ -104,9 +96,6 @@ func NewBarmanBackupCommand(
 // barman-cloud-backup
 func (b *BackupCommand) Start(ctx context.Context) error {
 	contextLogger := log.FromContext(ctx)
-	if err := b.ensureCompatibility(); err != nil {
-		return err
-	}
 
 	b.setupBackupStatus()
 
@@ -143,15 +132,6 @@ func (b *BackupCommand) Start(ctx context.Context) error {
 	go b.run(ctx)
 
 	return nil
-}
-
-func (b *BackupCommand) ensureCompatibility() error {
-	postgresVers, err := b.Instance.GetPgVersion()
-	if err != nil {
-		return err
-	}
-
-	return b.barmanBackup.IsCompatible(postgresVers)
 }
 
 func (b *BackupCommand) retryWithRefreshedCluster(
@@ -234,7 +214,6 @@ func (b *BackupCommand) takeBackup(ctx context.Context) error {
 		b.Backup.Status.BackupName,
 		backupStatus.ServerName,
 		b.Env,
-		b.Cluster,
 		postgres.BackupTemporaryDirectory,
 	)
 	if err != nil {
@@ -249,7 +228,7 @@ func (b *BackupCommand) takeBackup(ctx context.Context) error {
 	b.Backup.Status.SetAsCompleted()
 
 	barmanBackup, err := b.barmanBackup.GetExecutedBackupInfo(
-		ctx, b.Backup.Status.BackupName, backupStatus.ServerName, b.Cluster, b.Env)
+		ctx, b.Backup.Status.BackupName, backupStatus.ServerName, b.Env)
 	if err != nil {
 		return err
 	}
@@ -348,9 +327,7 @@ func (b *BackupCommand) setupBackupStatus() {
 	barmanConfiguration := b.Cluster.Spec.Backup.BarmanObjectStore
 	backupStatus := b.Backup.GetStatus()
 
-	if b.Capabilities.ShouldExecuteBackupWithName(b.Cluster) {
-		backupStatus.BackupName = fmt.Sprintf("backup-%v", pgTime.ToCompactISO8601(time.Now()))
-	}
+	backupStatus.BackupName = fmt.Sprintf("backup-%v", pgTime.ToCompactISO8601(time.Now()))
 	backupStatus.BarmanCredentials = barmanConfiguration.BarmanCredentials
 	backupStatus.EndpointCA = barmanConfiguration.EndpointCA
 	backupStatus.EndpointURL = barmanConfiguration.EndpointURL

--- a/pkg/management/postgres/restore.go
+++ b/pkg/management/postgres/restore.go
@@ -35,11 +35,11 @@ import (
 	"time"
 
 	barmanArchiver "github.com/cloudnative-pg/barman-cloud/pkg/archiver"
-	barmanCapabilities "github.com/cloudnative-pg/barman-cloud/pkg/capabilities"
 	barmanCatalog "github.com/cloudnative-pg/barman-cloud/pkg/catalog"
 	barmanCommand "github.com/cloudnative-pg/barman-cloud/pkg/command"
 	barmanCredentials "github.com/cloudnative-pg/barman-cloud/pkg/credentials"
 	barmanRestorer "github.com/cloudnative-pg/barman-cloud/pkg/restorer"
+	barmanUtils "github.com/cloudnative-pg/barman-cloud/pkg/utils"
 	restore "github.com/cloudnative-pg/cnpg-i/pkg/restore/job"
 	"github.com/cloudnative-pg/machinery/pkg/envmap"
 	"github.com/cloudnative-pg/machinery/pkg/execlog"
@@ -452,13 +452,13 @@ func (info InitInfo) restoreDataDir(ctx context.Context, backup *apiv1.Backup, e
 	contextLogger.Info("Starting barman-cloud-restore",
 		"options", options)
 
-	cmd := exec.Command(barmanCapabilities.BarmanCloudRestore, options...) // #nosec G204
+	cmd := exec.Command(barmanUtils.BarmanCloudRestore, options...) // #nosec G204
 	cmd.Env = env
-	err = execlog.RunStreaming(cmd, barmanCapabilities.BarmanCloudRestore)
+	err = execlog.RunStreaming(cmd, barmanUtils.BarmanCloudRestore)
 	if err != nil {
 		var exitError *exec.ExitError
 		if errors.As(err, &exitError) {
-			err = barmanCommand.UnmarshalBarmanCloudRestoreExitCode(ctx, exitError.ExitCode())
+			err = barmanCommand.UnmarshalBarmanCloudRestoreExitCode(exitError.ExitCode())
 		}
 
 		contextLogger.Error(err, "Can't restore backup")
@@ -655,7 +655,7 @@ func (info InitInfo) writeCustomRestoreWalConfig(cluster *apiv1.Cluster, conf st
 func getRestoreWalConfig(ctx context.Context, backup *apiv1.Backup) (string, error) {
 	var err error
 
-	cmd := []string{barmanCapabilities.BarmanCloudWalRestore}
+	cmd := []string{barmanUtils.BarmanCloudWalRestore}
 	if backup.Status.EndpointURL != "" {
 		cmd = append(cmd, "--endpoint-url", backup.Status.EndpointURL)
 	}


### PR DESCRIPTION
This patch removes compatibility with Barman versions 3.4 and earlier, which
have been deprecated. These versions, released before April 2023, are no
longer maintained and require specific workarounds that increase code
complexity. Removing support simplifies the backup integration logic and aligns
the operator with recent, supported versions of Barman (≥ 3.5).

We have simultaneously reduced technical debt by eliminating the capability
detection framework that required checking the version of Barman Cloud
before every execution of the program.

Users running an operand version released before January 2023 must upgrade
to a more recent version before updating the operator, as older operand images
may not be compatible with the updated backup mechanisms introduced in this
patch.

This commit represents progress in transitioning users to the recommended
Barman Cloud plugin.

Closes #3954 

# Release notes

```
Dropped support for Barman versions 3.4 and earlier, including capability
detection framework. Users running very old operand versions (from before
April 2023) must update the operand before upgrading the operator.
```
