### PR TITLE
feat: limit backup permissions to involved objects

### DIFF
--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -1307,14 +1307,6 @@ func (r *ClusterReconciler) createFieldIndexes(ctx context.Context, mgr ctrl.Man
 		return err
 	}
 
-	// Create a new indexed field on Jobs.
-	if err := mgr.GetFieldIndexer().IndexField(
-		ctx,
-		&batchv1.Job{},
-		jobOwnerKey, jobOwnerIndexFunc); err != nil {
-		return err
-	}
-
 	// Create a new indexed field on Backup.
 	if err := mgr.GetFieldIndexer().IndexField(
 		ctx,
@@ -1326,7 +1318,11 @@ func (r *ClusterReconciler) createFieldIndexes(ctx context.Context, mgr ctrl.Man
 		return err
 	}
 
-	return nil
+	// Create a new indexed field on Jobs.
+	return mgr.GetFieldIndexer().IndexField(
+		ctx,
+		&batchv1.Job{},
+		jobOwnerKey, jobOwnerIndexFunc)
 }
 
 // IsOwnedByCluster checks that an object is owned by a Cluster and returns


### PR DESCRIPTION
This patch modifies the operator to explicitly enumerate the backup objects that the instance manager needs to interact with, rather than granting it permission to access all backup objects within the containing namespace.

This change improves our stance on the principle of least privilege, limiting access to only the necessary resources.