### PR TITLE
docs: fix titles in nav menu

### DIFF
--- a/docs/markdown/pkg.tpl
+++ b/docs/markdown/pkg.tpl
@@ -1,7 +1,6 @@
 {{ define "packages" -}}
-<!-- SPDX-License-Identifier: CC-BY-4.0 -->
-
 # API Reference
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 
 {{ $grpname := "" -}}
 {{- range $idx, $val := .packages -}}

--- a/docs/src/appendixes/object_stores.md
+++ b/docs/src/appendixes/object_stores.md
@@ -1,5 +1,5 @@
-<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 # Appendix A - Common object stores for backups
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 
 You can store the [backup](../backup.md) files in any service that is supported
 by the Barman Cloud infrastructure. That is:

--- a/docs/src/applications.md
+++ b/docs/src/applications.md
@@ -1,5 +1,5 @@
-<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 # Connecting from an application
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 
 Applications are supposed to work with the services created by CloudNativePG
 in the same Kubernetes cluster.
@@ -82,4 +82,3 @@ and correspond to the `postgres` user.
 
 !!! Important
     Superuser access over the network is disabled by default.
-

--- a/docs/src/architecture.md
+++ b/docs/src/architecture.md
@@ -1,5 +1,5 @@
-<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 # Architecture
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 
 !!! Hint
     For a deeper understanding, we recommend reading our article on the CNCF

--- a/docs/src/backup.md
+++ b/docs/src/backup.md
@@ -1,5 +1,5 @@
-<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 # Backup
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 
 PostgreSQL natively provides first class backup and recovery capabilities based
 on file system level (physical) copy. These have been successfully used for
@@ -378,4 +378,3 @@ spec:
 
 In the previous example, CloudNativePG will invariably choose the primary
 instance even if the `Cluster` is set to prefer replicas.
-

--- a/docs/src/backup_barmanobjectstore.md
+++ b/docs/src/backup_barmanobjectstore.md
@@ -1,5 +1,5 @@
-<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 # Backup on object stores
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 
 CloudNativePG natively supports **online/hot backup** of PostgreSQL
 clusters through continuous physical backup and WAL archiving on an object

--- a/docs/src/backup_recovery.md
+++ b/docs/src/backup_recovery.md
@@ -1,4 +1,4 @@
-<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 # Backup and Recovery
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 
 [Backup](backup.md) and [recovery](recovery.md) are in two separate sections.

--- a/docs/src/backup_volumesnapshot.md
+++ b/docs/src/backup_volumesnapshot.md
@@ -1,5 +1,5 @@
-<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 # Backup on volume snapshots
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 
 !!! Warning
     As noted in the [backup document](backup.md), a cold snapshot explicitly

--- a/docs/src/before_you_start.md
+++ b/docs/src/before_you_start.md
@@ -1,5 +1,5 @@
-<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 # Before You Start
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 
 Before we get started, it is essential to go over some terminology that is
 specific to Kubernetes and PostgreSQL.

--- a/docs/src/benchmarking.md
+++ b/docs/src/benchmarking.md
@@ -1,5 +1,5 @@
-<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 # Benchmarking
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 
 The CNPG kubectl plugin provides an easy way for benchmarking a PostgreSQL deployment in Kubernetes using CloudNativePG.
 

--- a/docs/src/bootstrap.md
+++ b/docs/src/bootstrap.md
@@ -1,5 +1,5 @@
-<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 # Bootstrap
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 
 This section describes the options available to create a new
 PostgreSQL cluster and the design rationale behind them.

--- a/docs/src/certificates.md
+++ b/docs/src/certificates.md
@@ -1,5 +1,5 @@
-<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 # Certificates
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 
 CloudNativePG was designed to natively support TLS certificates.
 To set up a cluster, the operator requires:

--- a/docs/src/cloudnative-pg.v1.md
+++ b/docs/src/cloudnative-pg.v1.md
@@ -1,6 +1,5 @@
-<!-- SPDX-License-Identifier: CC-BY-4.0 -->
-
 # API Reference
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 
 <p>Package v1 contains API Schema definitions for the postgresql v1 API group</p>
 

--- a/docs/src/cluster_conf.md
+++ b/docs/src/cluster_conf.md
@@ -1,5 +1,5 @@
-<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 # Instance pod configuration
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 
 ## Projected volumes
 

--- a/docs/src/connection_pooling.md
+++ b/docs/src/connection_pooling.md
@@ -1,5 +1,5 @@
-<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 # Connection pooling
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 
 CloudNativePG provides native support for connection pooling with
 [PgBouncer](https://www.pgbouncer.org/), one of the most popular open source

--- a/docs/src/container_images.md
+++ b/docs/src/container_images.md
@@ -1,5 +1,5 @@
-<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 # Container Image Requirements
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 
 The CloudNativePG operator for Kubernetes is designed to
 work with any compatible container image of PostgreSQL that complies

--- a/docs/src/controller.md
+++ b/docs/src/controller.md
@@ -1,5 +1,5 @@
-<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 # Custom Pod Controller
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 
 Kubernetes uses the
 [Controller pattern](https://kubernetes.io/docs/concepts/architecture/controller/)

--- a/docs/src/database_import.md
+++ b/docs/src/database_import.md
@@ -1,5 +1,5 @@
-<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 # Importing Postgres databases
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 
 This section describes how to import one or more existing PostgreSQL
 databases inside a brand new CloudNativePG cluster.

--- a/docs/src/declarative_database_management.md
+++ b/docs/src/declarative_database_management.md
@@ -1,5 +1,5 @@
-<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 # PostgreSQL Database Management
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 
 CloudNativePG simplifies PostgreSQL database provisioning by automatically
 creating an application database named `app` by default. This default behavior

--- a/docs/src/declarative_hibernation.md
+++ b/docs/src/declarative_hibernation.md
@@ -1,5 +1,5 @@
-<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 # Declarative hibernation
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 
 CloudNativePG is designed to keep PostgreSQL clusters up, running and available
 anytime.

--- a/docs/src/declarative_role_management.md
+++ b/docs/src/declarative_role_management.md
@@ -1,5 +1,5 @@
-<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 # PostgreSQL Role Management
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 
 From its inception, CloudNativePG has managed the creation of specific roles
 required in PostgreSQL instances:

--- a/docs/src/e2e.md
+++ b/docs/src/e2e.md
@@ -1,5 +1,5 @@
-<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 # End-to-End Tests
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 
 CloudNativePG is automatically tested after each
 commit via a suite of **End-to-end (E2E) tests** (or integration tests)

--- a/docs/src/failover.md
+++ b/docs/src/failover.md
@@ -1,5 +1,5 @@
-<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 # Automated failover
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 
 In the case of unexpected errors on the primary for longer than the
 `.spec.failoverDelay` (by default `0` seconds), the cluster will go into

--- a/docs/src/failure_modes.md
+++ b/docs/src/failure_modes.md
@@ -1,5 +1,5 @@
-<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 # Failure Modes
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 
 !!! Note
     In previous versions of CloudNativePG, this page included specific failure

--- a/docs/src/faq.md
+++ b/docs/src/faq.md
@@ -1,5 +1,5 @@
-<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 # Frequently Asked Questions (FAQ)
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 
 ## Running PostgreSQL in Kubernetes
 

--- a/docs/src/fencing.md
+++ b/docs/src/fencing.md
@@ -1,5 +1,5 @@
-<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 # Fencing
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 
 Fencing in CloudNativePG is the ultimate process of protecting the
 data in one, more, or even all instances of a PostgreSQL cluster when they

--- a/docs/src/image_catalog.md
+++ b/docs/src/image_catalog.md
@@ -1,5 +1,5 @@
-<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 # Image Catalog
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 
 `ImageCatalog` and `ClusterImageCatalog` are essential resources that empower
 you to define images for creating a `Cluster`.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,5 +1,5 @@
-<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 # CloudNativePG
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 
 **CloudNativePG** is an open-source
 [operator](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/)

--- a/docs/src/installation_upgrade.md
+++ b/docs/src/installation_upgrade.md
@@ -1,5 +1,5 @@
-<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 # Installation and upgrades
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 
 ## Installation on Kubernetes
 

--- a/docs/src/instance_manager.md
+++ b/docs/src/instance_manager.md
@@ -1,5 +1,5 @@
-<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 # Postgres instance manager
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 
 CloudNativePG does not rely on an external tool for failover management.
 It simply relies on the Kubernetes API server and a native key component called:

--- a/docs/src/kubectl-plugin.md
+++ b/docs/src/kubectl-plugin.md
@@ -1,5 +1,5 @@
-<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 # Kubectl Plugin
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 
 CloudNativePG provides a plugin for `kubectl` to manage a cluster in Kubernetes.
 

--- a/docs/src/kubernetes_upgrade.md
+++ b/docs/src/kubernetes_upgrade.md
@@ -1,5 +1,5 @@
-<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 # Kubernetes Upgrade and Maintenance
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 
 Maintaining an up-to-date Kubernetes cluster is crucial for ensuring optimal
 performance and security, particularly for self-managed clusters, especially

--- a/docs/src/labels_annotations.md
+++ b/docs/src/labels_annotations.md
@@ -1,5 +1,5 @@
-<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 # Labels and annotations
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 
 Resources in Kubernetes are organized in a flat structure, with no hierarchical
 information or relationship between them. However, such resources and objects

--- a/docs/src/logging.md
+++ b/docs/src/logging.md
@@ -1,5 +1,5 @@
-<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 # Logging
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 
 CloudNativePG outputs logs in JSON format directly to standard output, including
 PostgreSQL logs, without persisting them to storage for security reasons. This

--- a/docs/src/logical_replication.md
+++ b/docs/src/logical_replication.md
@@ -1,5 +1,5 @@
-<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 # Logical Replication
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 
 PostgreSQL extends its replication capabilities beyond physical replication,
 which operates at the level of exact block addresses and byte-by-byte copying,

--- a/docs/src/monitoring.md
+++ b/docs/src/monitoring.md
@@ -1,5 +1,5 @@
-<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 # Monitoring
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 
 !!! Important
     Installing Prometheus and Grafana is beyond the scope of this project.

--- a/docs/src/networking.md
+++ b/docs/src/networking.md
@@ -1,5 +1,5 @@
-<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 # Networking
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 
 CloudNativePG assumes the underlying Kubernetes cluster has the required
 connectivity already set up.

--- a/docs/src/operator_capability_levels.md
+++ b/docs/src/operator_capability_levels.md
@@ -1,5 +1,5 @@
-<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 # Operator capability levels
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 
 These capabilities were implemented by CloudNativePG,
 classified using the

--- a/docs/src/operator_conf.md
+++ b/docs/src/operator_conf.md
@@ -1,5 +1,5 @@
-<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 # Operator configuration
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 
 The operator for CloudNativePG is installed from a standard
 deployment manifest and follows the convention over configuration paradigm.

--- a/docs/src/postgis.md
+++ b/docs/src/postgis.md
@@ -1,5 +1,5 @@
-<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 # PostGIS
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 
 [PostGIS](https://postgis.net/) is a very popular open source extension
 for PostgreSQL that introduces support for storing GIS (Geographic Information

--- a/docs/src/postgresql_conf.md
+++ b/docs/src/postgresql_conf.md
@@ -1,5 +1,5 @@
-<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 # PostgreSQL Configuration
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 
 Users that are familiar with PostgreSQL are aware of the existence of the
 following three files to configure an instance:

--- a/docs/src/preview_version.md
+++ b/docs/src/preview_version.md
@@ -1,5 +1,5 @@
-<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 # Preview Versions
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 
 CloudNativePG candidate releases are pre-release versions made available for
 testing before the community issues a new generally available (GA) release.

--- a/docs/src/quickstart.md
+++ b/docs/src/quickstart.md
@@ -1,5 +1,5 @@
-<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 # Quickstart
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 
 This section guides you through testing a PostgreSQL cluster on your local machine by
 deploying CloudNativePG on a local Kubernetes cluster

--- a/docs/src/recovery.md
+++ b/docs/src/recovery.md
@@ -1,5 +1,5 @@
-<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 # Recovery
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 
 In PostgreSQL terminology, recovery is the process of starting a PostgreSQL
 instance using an existing backup. The PostgreSQL recovery mechanism

--- a/docs/src/release_notes.md
+++ b/docs/src/release_notes.md
@@ -1,5 +1,5 @@
-<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 # Release notes
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 
 History of user-visible changes for CloudNativePG, classified for each minor release.
 

--- a/docs/src/release_notes/edb-cloud-native-postgresql.md
+++ b/docs/src/release_notes/edb-cloud-native-postgresql.md
@@ -1,5 +1,5 @@
-<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 # Release notes for 1.14.0 and earlier
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 
 The first public release of CloudNativePG is version 1.15.0. Before that,
 the product was entirely owned by EDB and distributed under the name of

--- a/docs/src/release_notes/v1.24.md
+++ b/docs/src/release_notes/v1.24.md
@@ -1,5 +1,5 @@
-<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 # Release notes for CloudNativePG 1.24
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 
 History of user-visible changes in the 1.24 minor release of CloudNativePG.
 

--- a/docs/src/release_notes/v1.25.md
+++ b/docs/src/release_notes/v1.25.md
@@ -1,5 +1,5 @@
-<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 # Release notes for CloudNativePG 1.25
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 
 History of user-visible changes in the 1.25 minor release of CloudNativePG.
 

--- a/docs/src/release_notes/v1.26.md
+++ b/docs/src/release_notes/v1.26.md
@@ -1,5 +1,5 @@
-<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 # Release notes for CloudNativePG 1.26
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 
 History of user-visible changes in the 1.26 minor release of CloudNativePG.
 

--- a/docs/src/replica_cluster.md
+++ b/docs/src/replica_cluster.md
@@ -1,5 +1,5 @@
-<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 # Replica clusters
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 
 A replica cluster is a CloudNativePG `Cluster` resource designed to
 replicate data from another PostgreSQL instance, ideally also managed by

--- a/docs/src/replication.md
+++ b/docs/src/replication.md
@@ -1,5 +1,5 @@
-<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 # Replication
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 
 Physical replication is one of the strengths of PostgreSQL and one of the
 reasons why some of the largest organizations in the world have chosen it for

--- a/docs/src/resource_management.md
+++ b/docs/src/resource_management.md
@@ -1,5 +1,5 @@
-<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 # Resource management
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 
 In a typical Kubernetes cluster, pods run with unlimited resources. By default,
 they might be allowed to use as much CPU and RAM as needed.

--- a/docs/src/rolling_update.md
+++ b/docs/src/rolling_update.md
@@ -1,5 +1,5 @@
-<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 # Rolling Updates
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 
 The operator allows changing the PostgreSQL version used in a cluster while
 applications are running against it.

--- a/docs/src/samples.md
+++ b/docs/src/samples.md
@@ -1,5 +1,5 @@
-<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 # Examples
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 
 The examples show configuration files for setting up
 your PostgreSQL cluster.

--- a/docs/src/scheduling.md
+++ b/docs/src/scheduling.md
@@ -1,5 +1,5 @@
-<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 # Scheduling
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 
 Scheduling, in Kubernetes, is the process responsible for placing a new pod on
 the best node possible, based on several criteria.

--- a/docs/src/security.md
+++ b/docs/src/security.md
@@ -1,5 +1,5 @@
-<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 # Security
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 
 This section contains information about security for CloudNativePG,
 that are analyzed at 3 different layers: Code, Container and Cluster.

--- a/docs/src/service_management.md
+++ b/docs/src/service_management.md
@@ -1,5 +1,5 @@
-<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 # Service Management
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 
 A PostgreSQL cluster should only be accessed via standard Kubernetes network
 services directly managed by CloudNativePG. For more details, refer to the

--- a/docs/src/ssl_connections.md
+++ b/docs/src/ssl_connections.md
@@ -1,5 +1,5 @@
-<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 # Client TLS/SSL connections
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 
 !!! Seealso "Certificates"
     See [Certificates](certificates.md)

--- a/docs/src/storage.md
+++ b/docs/src/storage.md
@@ -1,5 +1,5 @@
-<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 # Storage
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 
 Storage is the most critical component in a database workload.
 Storage must always be available, scale, perform well,

--- a/docs/src/supported_releases.md
+++ b/docs/src/supported_releases.md
@@ -1,5 +1,5 @@
-<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 # Supported releases
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 
 <!-- Inspired by https://github.com/istio/istio.io/blob/933b896c/content/en/docs/releases/supported-releases/index.md -->
 <!-- Inspired by https://github.com/cert-manager/website/blob/009c5e41/content/docs/installation/supported-releases.md -->

--- a/docs/src/tablespaces.md
+++ b/docs/src/tablespaces.md
@@ -1,5 +1,5 @@
-<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 # Tablespaces
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 
 A tablespace is a robust and widely embraced feature in database
 management systems. It offers a powerful means to enhance the vertical

--- a/docs/src/troubleshooting.md
+++ b/docs/src/troubleshooting.md
@@ -1,5 +1,5 @@
-<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 # Troubleshooting
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 
 In this page, you can find some basic information on how to troubleshoot
 CloudNativePG in your Kubernetes cluster deployment.

--- a/docs/src/use_cases.md
+++ b/docs/src/use_cases.md
@@ -1,5 +1,5 @@
-<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 # Use cases
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 
 CloudNativePG has been designed to work with applications
 that reside in the same Kubernetes cluster, for a full cloud native

--- a/docs/src/wal_archiving.md
+++ b/docs/src/wal_archiving.md
@@ -1,5 +1,5 @@
-<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 # WAL archiving
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 
 WAL archiving is the process that feeds a [WAL archive](backup.md#wal-archive)
 in CloudNativePG.


### PR DESCRIPTION
Move the license comment in the documentation markdown files to the second line, as it was messing with the title detection.

Closes #7231
