### PR TITLE
fix(security): add imagePullPolicy to operator deployment

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -43,6 +43,7 @@ spec:
         - --secret-name=$(OPERATOR_DEPLOYMENT_NAME)-config
         - --webhook-port=9443
         image: controller:latest
+        imagePullPolicy: Always
         name: manager
         ports:
           - containerPort: 8080


### PR DESCRIPTION
We should always have an imagePullPolicy to make sure the operator
images is always pulled avoiding using possible local and dangerous images.