### PR TITLE
fix(security): switch to pinDigest to follow OSSF recommendations

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -411,13 +411,13 @@
         'patch',
       ],
       groupName: 'all non-major github action',
-      pinDigests: false,
+      pinDigests: true,
     },
     {
       matchDepTypes: [
         'action',
       ],
-      pinDigests: false,
+      pinDigests: true,
     },
     {
       groupName: 'kubernetes CSI',


### PR DESCRIPTION
Following the OSSF recommendations we should pin all the dependencies in our workflows https://github.com/ossf/scorecard/blob/026dc41355a4e40c7b64e7413b726c0bce326356/docs/checks.md#pinned-dependencies

Closes #7257 