### PR TITLE
refactor(instance,secrets): extract sub-reconciler for instance secrets management

### DIFF
--- a/internal/management/controller/manager.go
+++ b/internal/management/controller/manager.go
@@ -34,6 +34,7 @@ import (
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/concurrency"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres/webserver/metricserver"
+	instancecertificate "github.com/cloudnative-pg/cloudnative-pg/pkg/reconciler/instance/certificate"
 )
 
 // InstanceReconciler reconciles the status of the Cluster resource with
@@ -49,6 +50,8 @@ type InstanceReconciler struct {
 	systemInitialization  *concurrency.Executed
 	firstReconcileDone    atomic.Bool
 	metricsServerExporter *metricserver.Exporter
+
+	certificateReconciler *instancecertificate.Reconciler
 }
 
 // NewInstanceReconciler creates a new instance reconciler
@@ -64,6 +67,7 @@ func NewInstanceReconciler(
 		extensionStatus:       make(map[string]bool),
 		systemInitialization:  concurrency.NewExecuted(),
 		metricsServerExporter: metricsExporter,
+		certificateReconciler: instancecertificate.NewReconciler(client, instance),
 	}
 }
 

--- a/pkg/management/postgres/instance.go
+++ b/pkg/management/postgres/instance.go
@@ -34,6 +34,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/blang/semver"
@@ -213,8 +214,30 @@ type Instance struct {
 	// MetricsPortTLS enables TLS on the port used to publish metrics over HTTP/HTTPS
 	MetricsPortTLS bool
 
+	serverCertificateHandler serverCertificateHandler
+}
+
+type serverCertificateHandler struct {
+	operationInProgress sync.Mutex
+
 	// ServerCertificate is the certificate we use to serve https connections
 	ServerCertificate *tls.Certificate
+}
+
+// GetServerCertificate returns the server certificate for the instance
+func (instance *Instance) GetServerCertificate() *tls.Certificate {
+	instance.serverCertificateHandler.operationInProgress.Lock()
+	defer instance.serverCertificateHandler.operationInProgress.Unlock()
+
+	return instance.serverCertificateHandler.ServerCertificate
+}
+
+// SetServerCertificate sets the server certificate for the instance
+func (instance *Instance) SetServerCertificate(cert *tls.Certificate) {
+	instance.serverCertificateHandler.operationInProgress.Lock()
+	defer instance.serverCertificateHandler.operationInProgress.Unlock()
+
+	instance.serverCertificateHandler.ServerCertificate = cert
 }
 
 // SetPostgreSQLAutoConfWritable allows or deny writes to the

--- a/pkg/management/postgres/webserver/metricserver/metrics.go
+++ b/pkg/management/postgres/webserver/metricserver/metrics.go
@@ -66,7 +66,7 @@ func New(serverInstance *postgres.Instance, exporter *Exporter) (*MetricsServer,
 		server.TLSConfig = &tls.Config{
 			MinVersion: tls.VersionTLS13,
 			GetCertificate: func(_ *tls.ClientHelloInfo) (*tls.Certificate, error) {
-				return serverInstance.ServerCertificate, nil
+				return serverInstance.GetServerCertificate(), nil
 			},
 		}
 	}

--- a/pkg/management/postgres/webserver/remote.go
+++ b/pkg/management/postgres/webserver/remote.go
@@ -122,7 +122,7 @@ func NewRemoteWebServer(
 		server.TLSConfig = &tls.Config{
 			MinVersion: tls.VersionTLS13,
 			GetCertificate: func(_ *tls.ClientHelloInfo) (*tls.Certificate, error) {
-				return instance.ServerCertificate, nil
+				return instance.GetServerCertificate(), nil
 			},
 		}
 	}

--- a/pkg/reconciler/instance/certificate/doc.go
+++ b/pkg/reconciler/instance/certificate/doc.go
@@ -1,2 +1,21 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
 // Package certificate contains the reconciler for the PostgreSQL instance manager secrets
 package certificate

--- a/pkg/reconciler/instance/certificate/doc.go
+++ b/pkg/reconciler/instance/certificate/doc.go
@@ -1,0 +1,2 @@
+// Package certificate contains the reconciler for the PostgreSQL instance manager secrets
+package certificate

--- a/pkg/reconciler/instance/certificate/reconciler.go
+++ b/pkg/reconciler/instance/certificate/reconciler.go
@@ -1,0 +1,341 @@
+package certificate
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+
+	"github.com/cloudnative-pg/machinery/pkg/fileutils"
+	"github.com/cloudnative-pg/machinery/pkg/log"
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/certs"
+	postgresSpec "github.com/cloudnative-pg/cloudnative-pg/pkg/postgres"
+)
+
+// Reconciler returns a certificate reconciler
+type Reconciler struct {
+	cli                      client.Client
+	serverCertificateHandler serverCertificateHandler
+}
+
+// NewReconciler creates a new certificate reconciler
+func NewReconciler(cli client.Client, serverHandler serverCertificateHandler) *Reconciler {
+	return &Reconciler{
+		cli:                      cli,
+		serverCertificateHandler: serverHandler,
+	}
+}
+
+type serverCertificateHandler interface {
+	SetServerCertificate(certificate *tls.Certificate)
+	GetServerCertificate() *tls.Certificate
+}
+
+// RefreshSecrets is called when the PostgreSQL secrets are changed
+// and will refresh the contents of the file inside the Pod, without
+// reloading the actual PostgreSQL instance.
+//
+// It returns a boolean flag telling if something changed. Usually
+// the invoker will check that flag and reload the PostgreSQL
+// instance it is up.
+func (r *Reconciler) RefreshSecrets(
+	ctx context.Context,
+	cluster *apiv1.Cluster,
+) (bool, error) {
+	type executor func(context.Context, *apiv1.Cluster) (bool, error)
+
+	contextLogger := log.FromContext(ctx)
+
+	var changed bool
+
+	secretRefresher := func(cb executor) error {
+		localChanged, err := cb(ctx, cluster)
+		if err == nil {
+			changed = changed || localChanged
+			return nil
+		}
+
+		if !apierrors.IsNotFound(err) {
+			return err
+		}
+
+		return nil
+	}
+
+	if err := secretRefresher(r.refreshServerCertificateFiles); err != nil {
+		contextLogger.Error(err, "Error while getting server secret")
+		return changed, err
+	}
+
+	if err := secretRefresher(r.refreshReplicationUserCertificate); err != nil {
+		contextLogger.Error(err, "Error while getting streaming replication secret")
+		return changed, err
+	}
+	if err := secretRefresher(r.refreshClientCA); err != nil {
+		contextLogger.Error(err, "Error while getting cluster CA Client secret")
+		return changed, err
+	}
+	if err := secretRefresher(r.refreshServerCA); err != nil {
+		contextLogger.Error(err, "Error while getting cluster CA Server secret")
+		return changed, err
+	}
+	if err := secretRefresher(r.refreshBarmanEndpointCA); err != nil {
+		contextLogger.Error(err, "Error while getting barman endpoint CA secret")
+		return changed, err
+	}
+
+	return changed, nil
+}
+
+// refreshServerCertificateFiles gets the latest server certificates files from the
+// secrets, and may set the instance certificate if it was missing our outdated.
+// Returns true if configuration has been changed or the instance has been updated
+func (r *Reconciler) refreshServerCertificateFiles(ctx context.Context, cluster *apiv1.Cluster) (bool, error) {
+	contextLogger := log.FromContext(ctx)
+
+	var secret v1.Secret
+
+	err := retry.OnError(retry.DefaultBackoff, func(error) bool { return true },
+		func() error {
+			err := r.cli.Get(
+				ctx,
+				client.ObjectKey{Namespace: cluster.Namespace, Name: cluster.Status.Certificates.ServerTLSSecret},
+				&secret)
+			if err != nil {
+				contextLogger.Info("Error accessing server TLS Certificate. Retrying with exponential backoff.",
+					"secret", cluster.Status.Certificates.ServerTLSSecret)
+				return err
+			}
+			return nil
+		})
+	if err != nil {
+		return false, err
+	}
+
+	changed, err := r.refreshCertificateFilesFromSecret(
+		ctx,
+		&secret,
+		postgresSpec.ServerCertificateLocation,
+		postgresSpec.ServerKeyLocation)
+	if err != nil {
+		return changed, err
+	}
+
+	if r.serverCertificateHandler.GetServerCertificate() == nil || changed {
+		return changed, r.refreshInstanceCertificateFromSecret(&secret)
+	}
+
+	return changed, nil
+}
+
+// refreshReplicationUserCertificate gets the latest replication certificates from the
+// secrets. Returns true if configuration has been changed
+func (r *Reconciler) refreshReplicationUserCertificate(
+	ctx context.Context,
+	cluster *apiv1.Cluster,
+) (bool, error) {
+	var secret v1.Secret
+	err := r.cli.Get(
+		ctx,
+		client.ObjectKey{Namespace: cluster.Namespace, Name: cluster.Status.Certificates.ReplicationTLSSecret},
+		&secret)
+	if err != nil {
+		return false, err
+	}
+
+	return r.refreshCertificateFilesFromSecret(
+		ctx,
+		&secret,
+		postgresSpec.StreamingReplicaCertificateLocation,
+		postgresSpec.StreamingReplicaKeyLocation)
+}
+
+// refreshClientCA gets the latest client CA certificates from the secrets.
+// It returns true if configuration has been changed
+func (r *Reconciler) refreshClientCA(ctx context.Context, cluster *apiv1.Cluster) (bool, error) {
+	var secret v1.Secret
+	err := r.cli.Get(
+		ctx,
+		client.ObjectKey{Namespace: cluster.Namespace, Name: cluster.Status.Certificates.ClientCASecret},
+		&secret)
+	if err != nil {
+		return false, err
+	}
+
+	return r.refreshCAFromSecret(ctx, &secret, postgresSpec.ClientCACertificateLocation)
+}
+
+// refreshServerCA gets the latest server CA certificates from the secrets.
+// It returns true if configuration has been changed
+func (r *Reconciler) refreshServerCA(ctx context.Context, cluster *apiv1.Cluster) (bool, error) {
+	var secret v1.Secret
+	err := r.cli.Get(
+		ctx,
+		client.ObjectKey{Namespace: cluster.Namespace, Name: cluster.Status.Certificates.ServerCASecret},
+		&secret)
+	if err != nil {
+		return false, err
+	}
+
+	return r.refreshCAFromSecret(ctx, &secret, postgresSpec.ServerCACertificateLocation)
+}
+
+// refreshBarmanEndpointCA gets the latest barman endpoint CA certificates from the secrets.
+// It returns true if configuration has been changed
+func (r *Reconciler) refreshBarmanEndpointCA(ctx context.Context, cluster *apiv1.Cluster) (bool, error) {
+	endpointCAs := map[string]*apiv1.SecretKeySelector{}
+	if cluster.Spec.Backup.IsBarmanEndpointCASet() {
+		endpointCAs[postgresSpec.BarmanBackupEndpointCACertificateLocation] = cluster.Spec.Backup.BarmanObjectStore.EndpointCA
+	}
+	if replicaBarmanCA := cluster.GetBarmanEndpointCAForReplicaCluster(); replicaBarmanCA != nil {
+		endpointCAs[postgresSpec.BarmanRestoreEndpointCACertificateLocation] = replicaBarmanCA
+	}
+	if len(endpointCAs) == 0 {
+		return false, nil
+	}
+
+	var changed bool
+	for target, secretKeySelector := range endpointCAs {
+		var secret v1.Secret
+		err := r.cli.Get(
+			ctx,
+			client.ObjectKey{Namespace: cluster.Namespace, Name: secretKeySelector.Name},
+			&secret)
+		if err != nil {
+			return false, err
+		}
+		c, err := r.refreshFileFromSecret(ctx, &secret, secretKeySelector.Key, target)
+		changed = changed || c
+		if err != nil {
+			return changed, err
+		}
+	}
+	return changed, nil
+}
+
+// refreshCertificateFilesFromSecret receive a secret and rewrite the file
+// corresponding to the server certificate
+func (r *Reconciler) refreshInstanceCertificateFromSecret(
+	secret *v1.Secret,
+) error {
+	certData, ok := secret.Data[v1.TLSCertKey]
+	if !ok {
+		return fmt.Errorf("missing %s field in Secret", v1.TLSCertKey)
+	}
+
+	keyData, ok := secret.Data[v1.TLSPrivateKeyKey]
+	if !ok {
+		return fmt.Errorf("missing %s field in Secret", v1.TLSPrivateKeyKey)
+	}
+
+	certificate, err := tls.X509KeyPair(certData, keyData)
+	if err != nil {
+		return fmt.Errorf("failed decoding Secret: %w", err)
+	}
+
+	r.serverCertificateHandler.SetServerCertificate(&certificate)
+
+	return err
+}
+
+// refreshCertificateFilesFromSecret receive a secret and rewrite the file
+// corresponding to the server certificate
+func (r *Reconciler) refreshCertificateFilesFromSecret(
+	ctx context.Context,
+	secret *v1.Secret,
+	certificateLocation string,
+	privateKeyLocation string,
+) (bool, error) {
+	contextLogger := log.FromContext(ctx)
+
+	certificate, ok := secret.Data[v1.TLSCertKey]
+	if !ok {
+		return false, fmt.Errorf("missing %s field in Secret", v1.TLSCertKey)
+	}
+
+	privateKey, ok := secret.Data[v1.TLSPrivateKeyKey]
+	if !ok {
+		return false, fmt.Errorf("missing %s field in Secret", v1.TLSPrivateKeyKey)
+	}
+
+	certificateIsChanged, err := fileutils.WriteFileAtomic(certificateLocation, certificate, 0o600)
+	if err != nil {
+		return false, fmt.Errorf("while writing server certificate: %w", err)
+	}
+
+	if certificateIsChanged {
+		contextLogger.Info("Refreshed configuration file",
+			"filename", certificateLocation,
+			"secret", secret.Name)
+	}
+
+	privateKeyIsChanged, err := fileutils.WriteFileAtomic(privateKeyLocation, privateKey, 0o600)
+	if err != nil {
+		return false, fmt.Errorf("while writing server private key: %w", err)
+	}
+
+	if privateKeyIsChanged {
+		contextLogger.Info("Refreshed configuration file",
+			"filename", privateKeyLocation,
+			"secret", secret.Name)
+	}
+
+	return certificateIsChanged || privateKeyIsChanged, nil
+}
+
+// refreshCAFromSecret receive a secret and rewrite the ca.crt file to the provided location
+func (r *Reconciler) refreshCAFromSecret(
+	ctx context.Context,
+	secret *v1.Secret,
+	destLocation string,
+) (bool, error) {
+	caCertificate, ok := secret.Data[certs.CACertKey]
+	if !ok {
+		return false, fmt.Errorf("missing %s entry in Secret", certs.CACertKey)
+	}
+
+	changed, err := fileutils.WriteFileAtomic(destLocation, caCertificate, 0o600)
+	if err != nil {
+		return false, fmt.Errorf("while writing server certificate: %w", err)
+	}
+
+	if changed {
+		log.FromContext(ctx).Info("Refreshed configuration file",
+			"filename", destLocation,
+			"secret", secret.Name)
+	}
+
+	return changed, nil
+}
+
+// refreshFileFromSecret receive a secret and rewrite the file corresponding to the key to the provided location
+func (r *Reconciler) refreshFileFromSecret(
+	ctx context.Context,
+	secret *v1.Secret,
+	key, destLocation string,
+) (bool, error) {
+	contextLogger := log.FromContext(ctx)
+	data, ok := secret.Data[key]
+	if !ok {
+		return false, fmt.Errorf("missing %s entry in Secret", key)
+	}
+
+	changed, err := fileutils.WriteFileAtomic(destLocation, data, 0o600)
+	if err != nil {
+		return false, fmt.Errorf("while writing file: %w", err)
+	}
+
+	if changed {
+		contextLogger.Info("Refreshed configuration file",
+			"filename", destLocation,
+			"secret", secret.Name,
+			"key", key)
+	}
+
+	return changed, nil
+}

--- a/pkg/reconciler/instance/certificate/reconciler_test.go
+++ b/pkg/reconciler/instance/certificate/reconciler_test.go
@@ -1,0 +1,178 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package certificate
+
+import (
+	"crypto/tls"
+	"path"
+
+	"github.com/cloudnative-pg/machinery/pkg/fileutils"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/certs"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+type fakeServerCertificateHandler struct {
+	certificate *tls.Certificate
+}
+
+func (f *fakeServerCertificateHandler) SetServerCertificate(certificate *tls.Certificate) {
+	f.certificate = certificate
+}
+
+func (f *fakeServerCertificateHandler) GetServerCertificate() *tls.Certificate {
+	return f.certificate
+}
+
+var _ = Describe("refresh certificate files from a secret", func() {
+	publicKeyContent := []byte("public_key")
+	privateKeyContent := []byte("private_key")
+	fakeReconciler := Reconciler{}
+	fakeSecret := corev1.Secret{
+		Data: map[string][]byte{
+			corev1.TLSCertKey:       publicKeyContent,
+			corev1.TLSPrivateKeyKey: privateKeyContent,
+		},
+	}
+
+	It("writing the required files into a directory", func(ctx SpecContext) {
+		tempDir := GinkgoT().TempDir()
+		certificateLocation := path.Join(tempDir, "tls.crt")
+		privateKeyLocation := path.Join(tempDir, "tls.key")
+
+		By("having code create new files", func() {
+			status, err := fakeReconciler.refreshCertificateFilesFromSecret(
+				ctx, &fakeSecret, certificateLocation, privateKeyLocation)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(status).To(BeTrue())
+
+			writtenPublicKey, err := fileutils.ReadFile(certificateLocation)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(writtenPublicKey).To(Equal(publicKeyContent))
+
+			writtenPrivateKey, err := fileutils.ReadFile(privateKeyLocation)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(writtenPrivateKey).To(Equal(privateKeyContent))
+		})
+
+		By("writing again the same data, and verifying that the certificate refresh is not triggered", func() {
+			status, err := fakeReconciler.refreshCertificateFilesFromSecret(
+				ctx, &fakeSecret, certificateLocation, privateKeyLocation)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(status).To(BeFalse())
+		})
+
+		By("changing the file contents, and verifying that the certificate refresh is triggered", func() {
+			newPublicKeyContent := []byte("changed public key")
+			newPrivateKeyContent := []byte("changed private key")
+
+			changedSecret := fakeSecret.DeepCopy()
+			changedSecret.Data[corev1.TLSCertKey] = newPublicKeyContent
+			changedSecret.Data[corev1.TLSPrivateKeyKey] = newPrivateKeyContent
+
+			status, err := fakeReconciler.refreshCertificateFilesFromSecret(
+				ctx, changedSecret, certificateLocation, privateKeyLocation)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(status).To(BeTrue())
+		})
+	})
+})
+
+var _ = Describe("refresh CA from a secret", func() {
+	publicKeyContent := []byte("public_key")
+	fakeReconciler := Reconciler{}
+	fakeSecret := corev1.Secret{
+		Data: map[string][]byte{
+			certs.CACertKey: publicKeyContent,
+		},
+	}
+
+	It("writing the required files into a directory", func(ctx SpecContext) {
+		tempDir := GinkgoT().TempDir()
+		certificateLocation := path.Join(tempDir, "ca.crt")
+
+		By("having code create new files", func() {
+			status, err := fakeReconciler.refreshCAFromSecret(
+				ctx, &fakeSecret, certificateLocation)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(status).To(BeTrue())
+
+			writtenPublicKey, err := fileutils.ReadFile(certificateLocation)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(writtenPublicKey).To(Equal(publicKeyContent))
+		})
+
+		By("writing again the same data, and verifying that the certificate refresh is not triggered", func() {
+			status, err := fakeReconciler.refreshCAFromSecret(
+				ctx, &fakeSecret, certificateLocation)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(status).To(BeFalse())
+		})
+
+		By("changing the file contents, and verifying that the certificate refresh is triggered", func() {
+			newPublicKeyContent := []byte("changed public key")
+
+			changedSecret := fakeSecret.DeepCopy()
+			changedSecret.Data[certs.CACertKey] = newPublicKeyContent
+
+			status, err := fakeReconciler.refreshCAFromSecret(
+				ctx, changedSecret, certificateLocation)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(status).To(BeTrue())
+		})
+	})
+})
+
+var _ = Describe("server certificate refresh handler", func() {
+	It("refresh the server certificate", func() {
+		var secret *corev1.Secret
+
+		By("creating a new root CA", func() {
+			root, err := certs.CreateRootCA("common-name", "organization-unit")
+			Expect(err).ToNot(HaveOccurred())
+
+			pair, err := root.CreateAndSignPair("host", certs.CertTypeServer, nil)
+			Expect(err).ToNot(HaveOccurred())
+
+			secret = pair.GenerateCertificateSecret("default", "pair")
+		})
+
+		By("triggering the certificate refresh when no handler is set", func() {
+			fakeReconciler := Reconciler{}
+			err := fakeReconciler.refreshInstanceCertificateFromSecret(secret)
+			Expect(err).Error().Should(Equal(ErrNoServerCertificateHandler))
+		})
+
+		By("triggering the certificate refresh when a handler is set", func() {
+			fakeReconciler := Reconciler{
+				serverCertificateHandler: &fakeServerCertificateHandler{},
+			}
+
+			err := fakeReconciler.refreshInstanceCertificateFromSecret(secret)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			cert := fakeReconciler.serverCertificateHandler.GetServerCertificate()
+			Expect(cert).ToNot(BeNil())
+		})
+	})
+})

--- a/pkg/reconciler/instance/certificate/suite_test.go
+++ b/pkg/reconciler/instance/certificate/suite_test.go
@@ -1,0 +1,32 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package certificate
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestCertificate(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Certificate Reconciler")
+}


### PR DESCRIPTION
This patch introduces a dedicated subreconciler to manage PostgreSQL cryptographic material.
The refactored logic is now reused across multiple components:

* the instance manager reconciliation loop
* the "join" bootstrap job
* the PostgreSQL major upgrade process

## Note for reviewers

- decide if we should backport
- depends on #7260