### PR TITLE
refactor(instance,storage): extract sub-reconciler for instance storage

### DIFF
--- a/internal/cmd/manager/instance/run/cmd.go
+++ b/internal/cmd/manager/instance/run/cmd.go
@@ -56,6 +56,7 @@ import (
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres/webserver"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres/webserver/metricserver"
 	pg "github.com/cloudnative-pg/cloudnative-pg/pkg/postgres"
+	instancestorage "github.com/cloudnative-pg/cloudnative-pg/pkg/reconciler/instance/storage"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/versions"
 )
 
@@ -267,7 +268,7 @@ func runSubCommand(ctx context.Context, instance *postgres.Instance) error {
 	postgresStartConditions = append(postgresStartConditions, jsonPipe.GetExecutedCondition())
 	exitedConditions = append(exitedConditions, jsonPipe.GetExitedCondition())
 
-	if err := reconciler.ReconcileWalStorage(ctx); err != nil {
+	if err := instancestorage.ReconcileWalStorage(ctx); err != nil {
 		return err
 	}
 

--- a/internal/cmd/manager/instance/run/cmd.go
+++ b/internal/cmd/manager/instance/run/cmd.go
@@ -268,7 +268,7 @@ func runSubCommand(ctx context.Context, instance *postgres.Instance) error {
 	postgresStartConditions = append(postgresStartConditions, jsonPipe.GetExecutedCondition())
 	exitedConditions = append(exitedConditions, jsonPipe.GetExitedCondition())
 
-	if err := instancestorage.ReconcileWalStorage(ctx); err != nil {
+	if err := instancestorage.ReconcileWalDirectory(ctx); err != nil {
 		return err
 	}
 

--- a/internal/cmd/manager/instance/upgrade/execute/cmd.go
+++ b/internal/cmd/manager/instance/upgrade/execute/cmd.go
@@ -142,7 +142,7 @@ func upgradeSubCommand(
 		return fmt.Errorf("error while downloading secrets: %w", err)
 	}
 
-	if err := instancestorage.ReconcileWalStorage(ctx); err != nil {
+	if err := instancestorage.ReconcileWalDirectory(ctx); err != nil {
 		return fmt.Errorf("error while reconciling the WAL storage: %w", err)
 	}
 

--- a/internal/cmd/manager/instance/upgrade/execute/cmd.go
+++ b/internal/cmd/manager/instance/upgrade/execute/cmd.go
@@ -43,7 +43,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
-	"github.com/cloudnative-pg/cloudnative-pg/internal/management/controller"
 	"github.com/cloudnative-pg/cloudnative-pg/internal/management/istio"
 	"github.com/cloudnative-pg/cloudnative-pg/internal/management/linkerd"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/configfile"
@@ -51,8 +50,8 @@ import (
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres/constants"
 	postgresutils "github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres/utils"
-	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres/webserver/metricserver"
 	instancecertificate "github.com/cloudnative-pg/cloudnative-pg/pkg/reconciler/instance/certificate"
+	instancestorage "github.com/cloudnative-pg/cloudnative-pg/pkg/reconciler/instance/storage"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/specs"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 )
@@ -143,12 +142,7 @@ func upgradeSubCommand(
 		return fmt.Errorf("error while downloading secrets: %w", err)
 	}
 
-	// Create a fake reconciler just to download the secrets and
-	// the cluster definition
-	metricExporter := metricserver.NewExporter(instance)
-	reconciler := controller.NewInstanceReconciler(instance, client, metricExporter)
-
-	if err := reconciler.ReconcileWalStorage(ctx); err != nil {
+	if err := instancestorage.ReconcileWalStorage(ctx); err != nil {
 		return fmt.Errorf("error while reconciling the WAL storage: %w", err)
 	}
 

--- a/internal/management/controller/instance_startup.go
+++ b/internal/management/controller/instance_startup.go
@@ -22,7 +22,6 @@ package controller
 import (
 	"context"
 	"fmt"
-	"io/fs"
 	"os"
 	"path/filepath"
 
@@ -145,47 +144,6 @@ func (r *InstanceReconciler) verifyPgDataCoherenceForPrimary(ctx context.Context
 		// Now I can demote myself
 		return r.instance.Demote(ctx, cluster)
 	}
-}
-
-// ReconcileWalStorage moves the files from PGDATA/pg_wal to the volume attached, if exists, and
-// creates a symlink for it
-func (r *InstanceReconciler) ReconcileWalStorage(ctx context.Context) error {
-	contextLogger := log.FromContext(ctx)
-
-	if pgWalExists, err := fileutils.FileExists(specs.PgWalVolumePath); err != nil {
-		return err
-	} else if !pgWalExists {
-		return nil
-	}
-
-	pgWalDirInfo, err := os.Lstat(specs.PgWalPath)
-	if err != nil {
-		return err
-	}
-	// The pgWalDir it's already a symlink meaning that there's nothing to do
-	mode := pgWalDirInfo.Mode() & fs.ModeSymlink
-	if !pgWalDirInfo.IsDir() && mode != 0 {
-		return nil
-	}
-
-	// We discarded every possibility that this has been done, let's move the current file to their
-	// new location
-	contextLogger.Info("Moving data", "from", specs.PgWalPath, "to", specs.PgWalVolumePgWalPath)
-	if err := fileutils.MoveDirectoryContent(specs.PgWalPath, specs.PgWalVolumePgWalPath); err != nil {
-		contextLogger.Error(err, "Moving data", "from", specs.PgWalPath, "to",
-			specs.PgWalVolumePgWalPath)
-		return err
-	}
-
-	contextLogger.Debug("Deleting old path", "path", specs.PgWalPath)
-	if err := fileutils.RemoveFile(specs.PgWalPath); err != nil {
-		contextLogger.Error(err, "Deleting old path", "path", specs.PgWalPath)
-		return err
-	}
-
-	// We moved all the files now we should create the proper symlink
-	contextLogger.Debug("Creating symlink", "from", specs.PgWalPath, "to", specs.PgWalVolumePgWalPath)
-	return os.Symlink(specs.PgWalVolumePgWalPath, specs.PgWalPath)
 }
 
 // ReconcileTablespaces ensures the mount points created for the tablespaces

--- a/internal/webhook/v1/cluster_webhook.go
+++ b/internal/webhook/v1/cluster_webhook.go
@@ -1544,7 +1544,7 @@ func (v *ClusterCustomValidator) validateWalStorageChange(r, old *apiv1.Cluster)
 			field.Invalid(
 				field.NewPath("spec", "walStorage"),
 				r.Spec.WalStorage,
-				"walStorage cannot be disabled once the cluster is created"),
+				"walStorage cannot be disabled once configured"),
 		}
 	}
 

--- a/pkg/reconciler/instance/storage/doc.go
+++ b/pkg/reconciler/instance/storage/doc.go
@@ -1,0 +1,2 @@
+// Package storage contains the Instance storage reconcilers
+package storage

--- a/pkg/reconciler/instance/storage/doc.go
+++ b/pkg/reconciler/instance/storage/doc.go
@@ -1,2 +1,21 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
 // Package storage contains the Instance storage reconcilers
 package storage

--- a/pkg/reconciler/instance/storage/reconciler.go
+++ b/pkg/reconciler/instance/storage/reconciler.go
@@ -1,0 +1,53 @@
+package storage
+
+import (
+	"context"
+	"io/fs"
+	"os"
+
+	"github.com/cloudnative-pg/machinery/pkg/fileutils"
+	"github.com/cloudnative-pg/machinery/pkg/log"
+
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/specs"
+)
+
+// ReconcileWalStorage moves the files from PGDATA/pg_wal to the volume attached, if exists, and
+// creates a symlink for it
+func ReconcileWalStorage(ctx context.Context) error {
+	contextLogger := log.FromContext(ctx)
+
+	if pgWalExists, err := fileutils.FileExists(specs.PgWalVolumePath); err != nil {
+		return err
+	} else if !pgWalExists {
+		return nil
+	}
+
+	pgWalDirInfo, err := os.Lstat(specs.PgWalPath)
+	if err != nil {
+		return err
+	}
+	// The pgWalDir it's already a symlink meaning that there's nothing to do
+	mode := pgWalDirInfo.Mode() & fs.ModeSymlink
+	if !pgWalDirInfo.IsDir() && mode != 0 {
+		return nil
+	}
+
+	// We discarded every possibility that this has been done, let's move the current file to their
+	// new location
+	contextLogger.Info("Moving data", "from", specs.PgWalPath, "to", specs.PgWalVolumePgWalPath)
+	if err := fileutils.MoveDirectoryContent(specs.PgWalPath, specs.PgWalVolumePgWalPath); err != nil {
+		contextLogger.Error(err, "Moving data", "from", specs.PgWalPath, "to",
+			specs.PgWalVolumePgWalPath)
+		return err
+	}
+
+	contextLogger.Debug("Deleting old path", "path", specs.PgWalPath)
+	if err := fileutils.RemoveFile(specs.PgWalPath); err != nil {
+		contextLogger.Error(err, "Deleting old path", "path", specs.PgWalPath)
+		return err
+	}
+
+	// We moved all the files now we should create the proper symlink
+	contextLogger.Debug("Creating symlink", "from", specs.PgWalPath, "to", specs.PgWalVolumePgWalPath)
+	return os.Symlink(specs.PgWalVolumePgWalPath, specs.PgWalPath)
+}

--- a/pkg/reconciler/instance/storage/reconciler_test.go
+++ b/pkg/reconciler/instance/storage/reconciler_test.go
@@ -1,0 +1,112 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package storage
+
+import (
+	"io/fs"
+	"os"
+	"path"
+
+	"github.com/cloudnative-pg/machinery/pkg/fileutils"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("WAL Storage reconciler", func() {
+	var pgDataDir string
+	var separateWALVolumeDir string
+	var separateWALVolumeWALDir string
+	var opts walDirectoryReconcilerOptions
+
+	BeforeEach(func() {
+		tempDir := GinkgoT().TempDir()
+		pgDataDir = path.Join(tempDir, "pg_data")
+		separateWALVolumeDir = path.Join(tempDir, "separate_wal")
+		separateWALVolumeWALDir = path.Join(tempDir, "separate_wal", "pg_wal")
+
+		opts = walDirectoryReconcilerOptions{
+			pgWalDirectory:        path.Join(pgDataDir, "pg_wal"),
+			walVolumeDirectory:    separateWALVolumeDir,
+			walVolumeWalDirectory: separateWALVolumeWALDir,
+		}
+	})
+
+	It("will not error out if a separate WAL storage doesn't exist", func(ctx SpecContext) {
+		err := internalReconcileWalDirectory(ctx, opts)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("won't change anything if pg_wal is already a symlink", func(ctx SpecContext) {
+		err := fileutils.EnsureDirectoryExists(pgDataDir)
+		Expect(err).ToNot(HaveOccurred())
+
+		err = fileutils.EnsureDirectoryExists(separateWALVolumeDir)
+		Expect(err).ToNot(HaveOccurred())
+
+		err = os.Symlink(separateWALVolumeDir, opts.pgWalDirectory)
+		Expect(err).ToNot(HaveOccurred())
+
+		err = internalReconcileWalDirectory(ctx, opts)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("moves the existing WALs to the target volume", func(ctx SpecContext) {
+		wal1 := path.Join(opts.pgWalDirectory, "000000010000000100000001")
+		wal2 := path.Join(opts.pgWalDirectory, "000000010000000100000002")
+		wal3 := path.Join(opts.pgWalDirectory, "000000010000000100000003")
+
+		By("creating a pg_wal directory and a separate WAL volume directory", func() {
+			err := fileutils.EnsureDirectoryExists(opts.pgWalDirectory)
+			Expect(err).ToNot(HaveOccurred())
+
+			err = fileutils.EnsureDirectoryExists(separateWALVolumeDir)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		By("creating a few WALs file in pg_wal", func() {
+			_, err := fileutils.WriteStringToFile(wal1, "wal content")
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = fileutils.WriteStringToFile(wal2, "wal content")
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = fileutils.WriteStringToFile(wal3, "wal content")
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		By("reconciling the WALs to the target volume", func() {
+			err := internalReconcileWalDirectory(ctx, opts)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		By("checking if pg_wal is a symlink", func() {
+			pgWalDirInfo, err := os.Lstat(opts.pgWalDirectory)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(pgWalDirInfo.Mode().Type()).To(Equal(fs.ModeSymlink))
+		})
+
+		By("checking the WAL files are in the target volume", func() {
+			Expect(fileutils.FileExists(wal1)).To(BeTrue())
+			Expect(fileutils.FileExists(wal2)).To(BeTrue())
+			Expect(fileutils.FileExists(wal3)).To(BeTrue())
+		})
+	})
+})

--- a/pkg/reconciler/instance/storage/suite_test.go
+++ b/pkg/reconciler/instance/storage/suite_test.go
@@ -1,0 +1,32 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package storage
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestStorage(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Storage Reconciler")
+}


### PR DESCRIPTION
This patch introduces a dedicated subreconciler to manage PostgreSQL separate WAL storage.
The refactored logic is now reused across multiple components:

* the PostgreSQL startup process
* the PostgreSQL major upgrade process

## Note for reviewers
- decide if we should backport
- depends on #7265