### PR TITLE
feat(cnpgi,snapshot): support WAL recovery via plugins during snapshot restore

### DIFF
--- a/internal/cmd/manager/instance/pgbasebackup/cmd.go
+++ b/internal/cmd/manager/instance/pgbasebackup/cmd.go
@@ -180,5 +180,5 @@ func (env *CloneInfo) configureInstanceAsNewPrimary(ctx context.Context, cluster
 	// In the future, when we will support recovering WALs in the
 	// designated primary from an object store, we'll need to use
 	// the environment variables of the recovery object store.
-	return env.info.ConfigureInstanceAfterRestore(ctx, cluster)
+	return env.info.ConfigureInstanceAfterRestore(ctx, cluster, nil)
 }

--- a/internal/cmd/manager/instance/pgbasebackup/cmd.go
+++ b/internal/cmd/manager/instance/pgbasebackup/cmd.go
@@ -180,5 +180,5 @@ func (env *CloneInfo) configureInstanceAsNewPrimary(ctx context.Context, cluster
 	// In the future, when we will support recovering WALs in the
 	// designated primary from an object store, we'll need to use
 	// the environment variables of the recovery object store.
-	return env.info.ConfigureInstanceAfterRestore(ctx, cluster, nil)
+	return env.info.ConfigureInstanceAfterRestore(ctx, cluster)
 }

--- a/internal/cmd/manager/instance/restore/cmd.go
+++ b/internal/cmd/manager/instance/restore/cmd.go
@@ -44,10 +44,12 @@ import (
 
 // NewCmd creates the "restore" subcommand
 func NewCmd() *cobra.Command {
-	var clusterName string
-	var namespace string
-	var pgData string
-	var pgWal string
+	var (
+		clusterName string
+		namespace   string
+		pgData      string
+		pgWal       string
+	)
 
 	cmd := &cobra.Command{
 		Use:           "restore [flags]",

--- a/internal/cmd/manager/instance/restoresnapshot/cmd.go
+++ b/internal/cmd/manager/instance/restoresnapshot/cmd.go
@@ -17,22 +17,30 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 */
 
-// Package restoresnapshot implements the "instance restoresnapshot" subcommand of the operator
 package restoresnapshot
 
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	"os"
 
 	"github.com/cloudnative-pg/machinery/pkg/log"
 	"github.com/spf13/cobra"
-	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	controllerruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
+	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/internal/management/istio"
 	"github.com/cloudnative-pg/cloudnative-pg/internal/management/linkerd"
-	"github.com/cloudnative-pg/cloudnative-pg/pkg/management"
+	"github.com/cloudnative-pg/cloudnative-pg/internal/scheme"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres/webserver"
 )
 
 // NewCmd creates the "restoresnapshot" subcommand
@@ -50,21 +58,47 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:           "restoresnapshot [flags]",
 		SilenceErrors: true,
-		PreRunE: func(cmd *cobra.Command, _ []string) error {
-			return management.WaitForGetCluster(cmd.Context(), ctrl.ObjectKey{
-				Name:      clusterName,
-				Namespace: namespace,
-			})
-		},
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			ctx := cmd.Context()
-			contextLogger := log.FromContext(ctx)
+			contextLogger := log.FromContext(cmd.Context())
 
-			info := postgres.InitInfo{
-				ClusterName: clusterName,
-				Namespace:   namespace,
-				PgData:      pgData,
-				PgWal:       pgWal,
+			// Canceling this context
+			ctx, cancel := context.WithCancel(cmd.Context())
+			defer cancel()
+
+			// Step 1: build the manager
+			mgr, err := buildManager(clusterName, namespace)
+			if err != nil {
+				contextLogger.Error(err, "while building the manager")
+				return err
+			}
+
+			// Step 1.1: add the local webserver to the manager
+			localSrv, err := webserver.NewLocalWebServer(
+				postgres.NewInstance().WithClusterName(clusterName).WithNamespace(namespace),
+				mgr.GetClient(),
+				mgr.GetEventRecorderFor("local-webserver"),
+			)
+			if err != nil {
+				return err
+			}
+			if err = mgr.Add(localSrv); err != nil {
+				contextLogger.Error(err, "unable to add local webserver runnable")
+				return err
+			}
+
+			// Step 2: add the restore process to the manager
+			restoreProcess := restoreRunnable{
+				cli:         mgr.GetClient(),
+				clusterName: clusterName,
+				namespace:   namespace,
+				pgData:      pgData,
+				pgWal:       pgWal,
+				immediate:   immediate,
+				cancel:      cancel,
+			}
+			if mgr.Add(&restoreProcess) != nil {
+				contextLogger.Error(err, "while building the restore process")
+				return err
 			}
 
 			if backupLabel != "" {
@@ -72,7 +106,7 @@ func NewCmd() *cobra.Command {
 				if err != nil {
 					return err
 				}
-				info.BackupLabelFile = res
+				restoreProcess.backupLabelFile = res
 			}
 
 			if tablespaceMap != "" {
@@ -80,15 +114,23 @@ func NewCmd() *cobra.Command {
 				if err != nil {
 					return err
 				}
-				info.TablespaceMapFile = res
+				restoreProcess.tablespaceMapFile = res
 			}
 
-			err := execute(ctx, info, immediate)
-			if err != nil {
-				contextLogger.Error(err, "Error while recovering Volume Snapshot backup")
+			// Step 3: start everything
+			if err := mgr.Start(ctx); err != nil {
+				contextLogger.Error(err, "restore error")
+				return err
 			}
-			return err
+
+			if !errors.Is(ctx.Err(), context.Canceled) {
+				contextLogger.Error(err, "error while recovering backup")
+				return err
+			}
+
+			return nil
 		},
+
 		PostRunE: func(cmd *cobra.Command, _ []string) error {
 			if err := istio.TryInvokeQuitEndpoint(cmd.Context()); err != nil {
 				return err
@@ -111,11 +153,32 @@ func NewCmd() *cobra.Command {
 	return cmd
 }
 
-func execute(ctx context.Context, info postgres.InitInfo, immediate bool) error {
-	typedClient, err := management.NewControllerRuntimeClient()
-	if err != nil {
-		return err
-	}
-
-	return info.RestoreSnapshot(ctx, typedClient, immediate)
+func buildManager(clusterName string, namespace string) (manager.Manager, error) {
+	return controllerruntime.NewManager(controllerruntime.GetConfigOrDie(), controllerruntime.Options{
+		Scheme: scheme.BuildWithAllKnownScheme(),
+		Cache: cache.Options{
+			ByObject: map[client.Object]cache.ByObject{
+				&apiv1.Cluster{}: {
+					Field: fields.OneTermEqualSelector("metadata.name", clusterName),
+					Namespaces: map[string]cache.Config{
+						namespace: {},
+					},
+				},
+			},
+		},
+		Client: client.Options{
+			Cache: &client.CacheOptions{
+				DisableFor: []client.Object{
+					&corev1.Secret{},
+					&corev1.ConfigMap{},
+					// todo(armru): we should remove the backup endpoints from the local webserver
+					&apiv1.Backup{},
+				},
+			},
+		},
+		LeaderElection: false,
+		Metrics: metricsserver.Options{
+			BindAddress: "0",
+		},
+	})
 }

--- a/internal/cmd/manager/instance/restoresnapshot/restore.go
+++ b/internal/cmd/manager/instance/restoresnapshot/restore.go
@@ -1,0 +1,113 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package restoresnapshot
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+
+	barmanCommand "github.com/cloudnative-pg/barman-cloud/pkg/command"
+	"github.com/cloudnative-pg/machinery/pkg/fileutils"
+	"github.com/cloudnative-pg/machinery/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/management"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres"
+)
+
+type restoreRunnable struct {
+	cli               client.Client
+	clusterName       string
+	namespace         string
+	pgData            string
+	pgWal             string
+	backupLabelFile   []byte
+	tablespaceMapFile []byte
+	immediate         bool
+	cancel            context.CancelFunc
+}
+
+func (r *restoreRunnable) Start(ctx context.Context) error {
+	// we will wait this way for the mgr and informers to be online
+	if err := management.WaitForGetClusterWithClient(ctx, r.cli, client.ObjectKey{
+		Name:      r.clusterName,
+		Namespace: r.namespace,
+	}); err != nil {
+		return fmt.Errorf("while waiting for API server connectivity: %w", err)
+	}
+
+	info := postgres.InitInfo{
+		ClusterName:       r.clusterName,
+		Namespace:         r.namespace,
+		PgData:            r.pgData,
+		PgWal:             r.pgWal,
+		BackupLabelFile:   r.backupLabelFile,
+		TablespaceMapFile: r.tablespaceMapFile,
+	}
+
+	if err := restoreSubCommand(ctx, info, r.cli, r.immediate); err != nil {
+		return fmt.Errorf("while restoring cluster: %s", err)
+	}
+
+	// the backup was restored correctly and we now ask
+	// the manager to quit
+	r.cancel()
+	return nil
+}
+
+func restoreSubCommand(ctx context.Context, info postgres.InitInfo, cli client.Client, immediate bool) error {
+	contextLogger := log.FromContext(ctx)
+	if err := info.EnsureTargetDirectoriesDoNotExist(ctx); err != nil {
+		return err
+	}
+
+	if err := info.RestoreSnapshot(ctx, cli, immediate); err != nil {
+		contextLogger.Error(err, "Error while restoring a backup")
+		cleanupDataDirectoryIfNeeded(ctx, err, info.PgData)
+		return err
+	}
+
+	contextLogger.Info("restoresnapshot command execution completed without errors")
+
+	return nil
+}
+
+func cleanupDataDirectoryIfNeeded(ctx context.Context, restoreError error, dataDirectory string) {
+	contextLogger := log.FromContext(ctx)
+
+	var barmanError *barmanCommand.CloudRestoreError
+	if !errors.As(restoreError, &barmanError) {
+		return
+	}
+
+	if !barmanError.IsRetriable() {
+		return
+	}
+
+	contextLogger.Info("Cleaning up data directory", "directory", dataDirectory)
+	if err := fileutils.RemoveDirectory(dataDirectory); err != nil && !os.IsNotExist(err) {
+		contextLogger.Error(
+			err,
+			"error occurred cleaning up data directory",
+			"directory", dataDirectory)
+	}
+}

--- a/pkg/management/postgres/restore.go
+++ b/pkg/management/postgres/restore.go
@@ -205,6 +205,11 @@ func (info InitInfo) createBackupObjectForSnapshotRestore(
 	if !found {
 		return nil, nil, fmt.Errorf("missing external cluster: %v", sourceName)
 	}
+
+	if server.BarmanObjectStore == nil {
+		return nil, nil, fmt.Errorf("missing barman object store configuration for source: %v", sourceName)
+	}
+
 	serverName := server.GetServerName()
 
 	env, err := barmanCredentials.EnvSetRestoreCloudCredentials(

--- a/pkg/management/postgres/restore.go
+++ b/pkg/management/postgres/restore.go
@@ -41,7 +41,6 @@ import (
 	barmanRestorer "github.com/cloudnative-pg/barman-cloud/pkg/restorer"
 	barmanUtils "github.com/cloudnative-pg/barman-cloud/pkg/utils"
 	restore "github.com/cloudnative-pg/cnpg-i/pkg/restore/job"
-	"github.com/cloudnative-pg/machinery/pkg/envmap"
 	"github.com/cloudnative-pg/machinery/pkg/execlog"
 	"github.com/cloudnative-pg/machinery/pkg/fileutils"
 	"github.com/cloudnative-pg/machinery/pkg/log"
@@ -146,32 +145,16 @@ func (info InitInfo) RestoreSnapshot(ctx context.Context, cli client.Client, imm
 	}
 
 	var envs []string
-	var config string
+	restoreCmd := fmt.Sprintf(
+		"/controller/manager wal-restore --log-destination %s/%s.json %%f %%p",
+		postgresSpec.LogPath, postgresSpec.LogFileName)
+	config := fmt.Sprintf(
+		"recovery_target_action = promote\n"+
+			"restore_command = '%s'\n",
+		restoreCmd)
 
 	// nolint:nestif
-	if pluginConfiguration := cluster.GetRecoverySourcePlugin(); pluginConfiguration != nil {
-		contextLogger.Info("Restore through plugin detected, proceeding...")
-		res, err := restoreViaPlugin(ctx, cluster, pluginConfiguration)
-		if err != nil {
-			return err
-		}
-		if res == nil {
-			return errors.New("empty response from restoreViaPlugin, programmatic error")
-		}
-
-		processEnvironment, err := envmap.ParseEnviron()
-		if err != nil {
-			return fmt.Errorf("error while parsing the process environment: %w", err)
-		}
-
-		pluginEnvironment, err := envmap.Parse(res.Envs)
-		if err != nil {
-			return fmt.Errorf("error while parsing the plugin environment: %w", err)
-		}
-
-		envs = envmap.Merge(processEnvironment, pluginEnvironment).StringSlice()
-		config = res.RestoreConfig
-	} else {
+	if pluginConfiguration := cluster.GetRecoverySourcePlugin(); pluginConfiguration == nil {
 		envs, config, err = info.createEnvAndConfigForSnapshotRestore(ctx, cli, cluster)
 		if err != nil {
 			return err
@@ -291,31 +274,21 @@ func (info InitInfo) Restore(ctx context.Context, cli client.Client) error {
 	}
 
 	var envs []string
-	var config string
+	restoreCmd := fmt.Sprintf(
+		"/controller/manager wal-restore --log-destination %s/%s.json %%f %%p",
+		postgresSpec.LogPath, postgresSpec.LogFileName)
+	config := fmt.Sprintf(
+		"recovery_target_action = promote\n"+
+			"restore_command = '%s'\n",
+		restoreCmd)
 
 	// nolint:nestif
 	if pluginConfiguration := cluster.GetRecoverySourcePlugin(); pluginConfiguration != nil {
 		contextLogger.Info("Restore through plugin detected, proceeding...")
-		res, err := restoreViaPlugin(ctx, cluster, pluginConfiguration)
+		_, err := restoreViaPlugin(ctx, cluster, pluginConfiguration)
 		if err != nil {
 			return err
 		}
-		if res == nil {
-			return errors.New("empty response from restoreViaPlugin, programmatic error")
-		}
-
-		processEnvironment, err := envmap.ParseEnviron()
-		if err != nil {
-			return fmt.Errorf("error while parsing the process environment: %w", err)
-		}
-
-		pluginEnvironment, err := envmap.Parse(res.Envs)
-		if err != nil {
-			return fmt.Errorf("error while parsing the plugin environment: %w", err)
-		}
-
-		envs = envmap.Merge(processEnvironment, pluginEnvironment).StringSlice()
-		config = res.RestoreConfig
 	} else {
 		// Before starting the restore we check if the archive destination is safe to use
 		// otherwise, we stop creating the cluster


### PR DESCRIPTION
This patch enables CNPG-i plugins to serve as a source of WALs during recovery from volume snapshots.

Previously, plugins were required to provide both WALs and PGDATA, which prevented their use in snapshot-based recovery scenarios. With this change, plugins can now be used solely for WAL retrieval during recovery.

Closes #7275 
