### PR TITLE
fix(cnpgi,instance,backup): do not assume that the cluster plugins are available to the instance

### DIFF
--- a/pkg/management/postgres/webserver/plugin_backup.go
+++ b/pkg/management/postgres/webserver/plugin_backup.go
@@ -89,7 +89,7 @@ func (b *PluginBackupCommand) invokeStart(ctx context.Context) {
 	availablePluginNamesSet := stringset.From(availablePlugins)
 
 	enabledPluginNamesSet := stringset.From([]string{b.Backup.Spec.PluginConfiguration.Name})
-	availableAndEnabled := stringset.From(availablePluginNamesSet.Intersect(enabledPluginNamesSet).ToList())
+	availableAndEnabled := availablePluginNamesSet.Intersect(enabledPluginNamesSet)
 
 	if !availableAndEnabled.Has(b.Backup.Spec.PluginConfiguration.Name) {
 		b.markBackupAsFailed(

--- a/pkg/management/postgres/webserver/plugin_backup.go
+++ b/pkg/management/postgres/webserver/plugin_backup.go
@@ -88,8 +88,7 @@ func (b *PluginBackupCommand) invokeStart(ctx context.Context) {
 
 	availablePluginNamesSet := stringset.From(availablePlugins)
 
-	enabledPluginNamesSet := stringset.From(
-		apiv1.GetPluginConfigurationEnabledPluginNames(b.Cluster.Spec.Plugins))
+	enabledPluginNamesSet := stringset.From([]string{b.Backup.Spec.PluginConfiguration.Name})
 	availableAndEnabled := stringset.From(availablePluginNamesSet.Intersect(enabledPluginNamesSet).ToList())
 
 	if !availableAndEnabled.Has(b.Backup.Spec.PluginConfiguration.Name) {


### PR DESCRIPTION
The main branch code incorrectly assumes that all reported plugins in the cluster are available to the instance. 

The patch aims to correctly load only the expected backup plugin.