### PR TITLE
docs: add "CNCF Project Integration" section for External Secrets

### DIFF
--- a/.wordlist-en-custom.txt
+++ b/.wordlist-en-custom.txt
@@ -366,6 +366,7 @@ PublicationTargetAllTables
 PublicationTargetObject
 PublicationTargetTable
 PullPolicy
+PushSecret
 QoS
 Quaresima
 QuickStart
@@ -430,6 +431,7 @@ Seccomp
 SeccompProfile
 SecretKeySelector
 SecretRefs
+SecretStore
 SecretVersion
 SecretsResourceVersion
 SecurityProfiles

--- a/.wordlist-en-custom.txt
+++ b/.wordlist-en-custom.txt
@@ -211,6 +211,7 @@ Istio's
 JSON
 Jihyuk
 Jitendra
+KV
 Karpenter
 KinD
 Krew

--- a/.wordlist-en-custom.txt
+++ b/.wordlist-en-custom.txt
@@ -144,6 +144,7 @@ EDB
 EKS
 EOF
 EOL
+ESO
 EmbeddedObjectMetadata
 EnablePDB
 EncryptionType

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -74,5 +74,7 @@ nav:
   - supported_releases.md
   - preview_version.md
   - release_notes.md
+  - CNCF Projects Integrations:
+    - cncf-projects/external-secrets.md
   - Appendixes:
     - appendixes/object_stores.md

--- a/docs/src/cncf-projects/external-secrets.md
+++ b/docs/src/cncf-projects/external-secrets.md
@@ -1,0 +1,148 @@
+# External Secrets
+
+[External Secrets](https://external-secrets.io/latest/) is a CNCF Sandbox
+project, accepted in 2022 under the sponsorship of TAG Security.
+
+## About
+
+The **External Secrets Operator (ESO)** is a Kubernetes operator that enhances
+secret management by decoupling the storage of secrets from Kubernetes itself.
+It enables seamless synchronization between external secret management systems
+and native Kubernetes `Secret` resources.
+
+ESO supports a wide range of backends, including:
+
+- [HashiCorp Vault](https://www.vaultproject.io/)
+- [AWS Secrets Manager](https://aws.amazon.com/secrets-manager/)
+- [Google Secret Manager](https://cloud.google.com/secret-manager)
+- [Azure Key Vault](https://azure.microsoft.com/en-us/services/key-vault/)
+- [IBM Cloud Secrets Manager](https://www.ibm.com/cloud/secrets-manager)
+
+…and many more. For a full and up-to-date list of supported providers, refer to
+the [official External Secrets documentation](https://external-secrets.io/latest/).
+
+## Integration with PostgreSQL and CloudNativePG
+
+When it comes to PostgreSQL databases, External Secrets integrates seamlessly
+with [CloudNativePG](https://cloudnative-pg.io/) in two major use cases:
+
+- **Automated password management:** ESO can handle the automatic generation
+  and rotation of database user passwords stored in Kubernetes `Secret`
+  resources, ensuring that applications running inside the cluster always have
+  access to up-to-date credentials.
+
+- **Cross-platform secret access:** It enables transparent synchronization of
+  those passwords with an external Key Management Service (KMS) via a
+  `SecretStore` resources. This allows applications and developers outside the
+  Kubernetes cluster—who may not have access to Kubernetes secrets—to retrieve
+  the database credentials directly from the external KMS.
+
+## Example: Automated Password Management with External Secrets
+
+Let’s walk through how to automatically rotate the password of the `app` user
+every 24 hours in the `cluster-example` Postgres cluster from the
+[quickstart guide](../quickstart.md#part-3-deploy-a-postgresql-cluster).
+
+By default, CloudNativePG generates and manages a Kubernetes `Secret` named
+`cluster-example-app`, which contains the credentials for the `app` user in the
+`cluster-example` cluster. You can read more about this in the
+[“Connecting from an application” section](../applications.md#secrets).
+
+With External Secrets, the goal is to:
+
+1. Define a `Password` generator that specifies how to generate the password.
+2. Create an `ExternalSecret` resource that keeps the `cluster-example-app`
+   secret in sync by updating only the `password` and `pgpass` fields.
+
+### Creating the Password Generator
+
+The following example creates a
+[`Password` generator](https://external-secrets.io/main/api/generator/password/)
+resource named `pg-password-generator` in the `default` namespace. You can
+customize the name and properties to suit your needs:
+
+```yaml
+apiVersion: generators.external-secrets.io/v1alpha1
+kind: Password
+metadata:
+  name: pg-password-generator
+spec:
+  length: 42
+  digits: 5
+  symbols: 5
+  symbolCharacters: "-_$@"
+  noUpper: false
+  allowRepeat: true
+```
+
+This specification defines the characteristics of the generated password,
+including its length and the inclusion of digits, symbols, and uppercase
+letters.
+
+### Creating the External Secret
+
+The example below creates an `ExternalSecret` resource named
+`cluster-example-app-secret`, which refreshes the password every 24 hours. It
+uses a `Merge` policy to update only the specified fields (`password` and
+`pgpass`) in the `cluster-example-app` secret.
+
+```yaml
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: cluster-example-app-secret
+spec:
+  refreshInterval: "24h"
+  target:
+    name: cluster-example-app
+    creationPolicy: Merge
+    template:
+      metadata:
+        labels:
+          cnpg.io/reload: "true"
+      data:
+        password: "{{ .password }}"
+        pgpass: "cluster-example-rw:5432:app:app:{{ .password }}"
+  dataFrom:
+    - sourceRef:
+        generatorRef:
+          apiVersion: generators.external-secrets.io/v1alpha1
+          kind: Password
+          name: pg-password-generator
+```
+
+The label `cnpg.io/reload: "true"` ensures that CloudNativePG triggers a reload
+of the user password in the database when the secret changes.
+
+### Verifying the Configuration
+
+To check that the `ExternalSecret` is correctly synchronizing:
+
+```sh
+kubectl get es cluster-example-app-secret
+```
+
+To observe the password being refreshed in real time, temporarily reduce the
+`refreshInterval` to `30s` and run the following command repeatedly:
+
+```sh
+kubectl get secret cluster-example-app \
+  -o jsonpath="{.data.password}" | base64 -d
+```
+
+You should see the password change every 30 seconds, confirming that the
+rotation is working correctly.
+
+### There's More
+
+While the example above focuses on the default `cluster-example-app` secret
+created by CloudNativePG, the same approach can be extended to manage any
+custom secrets or PostgreSQL users you create to regularly rotate their
+password.
+
+<!--
+## Example: Integration with an external KMS
+
+TODO
+
+-->

--- a/docs/src/cncf-projects/external-secrets.md
+++ b/docs/src/cncf-projects/external-secrets.md
@@ -43,6 +43,10 @@ Let’s walk through how to automatically rotate the password of the `app` user
 every 24 hours in the `cluster-example` Postgres cluster from the
 [quickstart guide](../quickstart.md#part-3-deploy-a-postgresql-cluster).
 
+!!! Important
+    Before proceeding, ensure that the `cluster-example` Postgres cluster is up
+    and running in your environment.
+
 By default, CloudNativePG generates and manages a Kubernetes `Secret` named
 `cluster-example-app`, which contains the credentials for the `app` user in the
 `cluster-example` cluster. You can read more about this in the

--- a/docs/src/cncf-projects/external-secrets.md
+++ b/docs/src/cncf-projects/external-secrets.md
@@ -87,8 +87,8 @@ letters.
 
 The example below creates an `ExternalSecret` resource named
 `cluster-example-app-secret`, which refreshes the password every 24 hours. It
-uses a `Merge` policy to update only the specified fields (`password` and
-`pgpass`) in the `cluster-example-app` secret.
+uses a `Merge` policy to update only the specified fields (`password`, `pgpass`,
+`jdbc-uri` and `uri`) in the `cluster-example-app` secret.
 
 ```yaml
 apiVersion: external-secrets.io/v1beta1
@@ -107,6 +107,8 @@ spec:
       data:
         password: "{{ .password }}"
         pgpass: "cluster-example-rw:5432:app:app:{{ .password }}"
+        jdbc-uri: "jdbc:postgresql://cluster-example-rw.default:5432/app?password={{ .password }}&user=app"
+        uri: "postgresql://app:{{ .password }}@cluster-example-rw.default:5432/app"
   dataFrom:
     - sourceRef:
         generatorRef:

--- a/docs/src/cncf-projects/external-secrets.md
+++ b/docs/src/cncf-projects/external-secrets.md
@@ -218,8 +218,8 @@ This configuration creates a `SecretStore` resource named `vault-backend`.
 
 ### Creating the `PushSecret`
 
-The `PushSecret` resource is used to push a Kubernetes secret to HashiCorp
-Vault. In this simplified example, we’ll push the credentials for the `app`
+The `PushSecret` resource is used to push a Kubernetes `Secret` to HashiCorp
+Vault. In this simplified example, we'll push the credentials for the `app`
 user of the sample cluster `cluster-example`.
 
 For more details on configuring `PushSecret`, refer to the

--- a/docs/src/cncf-projects/external-secrets.md
+++ b/docs/src/cncf-projects/external-secrets.md
@@ -200,10 +200,16 @@ kind: Secret
 metadata:
   name: vault-token
 data:
-  token: # TODO: Add the token here
+  token: aHZzLioqKioqKio= # hvs.*******
 ```
 
 This configuration creates a `SecretStore` resource named `vault-backend`.
+
+!!! Important
+    We use the basic token authentication method, which is suitable for API and CLI
+    usages, this is the default authentication method enabled but is not recommended
+    for production use. For production, consider using other authentication methods
+    that can be found [in the External Secrets Operator documentation](https://external-secrets.io/latest/provider/hashicorp-vault/).
 
 !!! Important
     HashiCorp Vault must have a KV secrets engine enabled at the `secrets` path

--- a/docs/src/cncf-projects/external-secrets.md
+++ b/docs/src/cncf-projects/external-secrets.md
@@ -206,14 +206,16 @@ data:
 This configuration creates a `SecretStore` resource named `vault-backend`.
 
 !!! Important
-    We use the basic token authentication method, which is suitable for API and CLI
-    usages, this is the default authentication method enabled but is not recommended
-    for production use. For production, consider using other authentication methods
-    that can be found [in the External Secrets Operator documentation](https://external-secrets.io/latest/provider/hashicorp-vault/).
+    This example uses basic token-based authentication, which is suitable for
+    testing API, and CLI use cases. While it is the default method enabled in
+    Vault, it is not recommended for production environments. For production,
+    consider using more secure authentication methods.
+    Refer to the [External Secrets Operator documentation](https://external-secrets.io/latest/provider/hashicorp-vault/)
+    for a full list of supported authentication mechanisms.
 
-!!! Important
+!!! Info
     HashiCorp Vault must have a KV secrets engine enabled at the `secrets` path
-    with version `v2`.  If your Vault instance uses a different path or
+    with version `v2`. If your Vault instance uses a different path or
     version, be sure to update the `path` and `version` fields accordingly.
 
 ### Creating the `PushSecret`


### PR DESCRIPTION
Introduce a new documentation section detailing the integration between CloudNativePG and the `external-secrets` project. This covers automated password rotation and secret management for PostgreSQL users using External Secrets and using Vault to store the secrets.

Closes #7286 