### PR TITLE
fix(instance_replica): include dbname in primary_conninfo for replication configuration

### DIFF
--- a/pkg/management/postgres/instance.go
+++ b/pkg/management/postgres/instance.go
@@ -841,7 +841,7 @@ func (instance *Instance) Demote(ctx context.Context, cluster *apiv1.Cluster) er
 
 // WaitForPrimaryAvailable waits until we can connect to the primary
 func (instance *Instance) WaitForPrimaryAvailable(ctx context.Context) error {
-	primaryConnInfo := instance.GetPrimaryConnInfo() + " dbname=postgres connect_timeout=5"
+	primaryConnInfo := instance.GetPrimaryConnInfo() + " connect_timeout=5"
 
 	log.Info("Waiting for the new primary to be available",
 		"primaryConnInfo", primaryConnInfo)
@@ -1041,7 +1041,7 @@ func (instance *Instance) Rewind(ctx context.Context) error {
 	primaryConnInfo := instance.GetPrimaryConnInfo()
 	options := []string{
 		"-P",
-		"--source-server", primaryConnInfo + " dbname=postgres",
+		"--source-server", primaryConnInfo,
 		"--target-pgdata", instance.PgData,
 	}
 
@@ -1300,7 +1300,7 @@ func (instance *Instance) DropConnections() error {
 
 // GetPrimaryConnInfo returns the DSN to reach the primary
 func (instance *Instance) GetPrimaryConnInfo() string {
-	result := buildPrimaryConnInfo(instance.GetClusterName()+"-rw", instance.GetPodName())
+	result := buildPrimaryConnInfo(instance.GetClusterName()+"-rw", instance.GetPodName()) + " dbname=postgres"
 
 	standbyTCPUserTimeout := os.Getenv("CNPG_STANDBY_TCP_USER_TIMEOUT")
 	if len(standbyTCPUserTimeout) > 0 {

--- a/pkg/management/postgres/instance_replica.go
+++ b/pkg/management/postgres/instance_replica.go
@@ -64,7 +64,7 @@ func (instance *Instance) RefreshReplicaConfiguration(
 
 func (instance *Instance) writeReplicaConfigurationForReplica(cluster *apiv1.Cluster) (changed bool, err error) {
 	slotName := cluster.GetSlotNameFromInstanceName(instance.GetPodName())
-	primaryConnInfo := instance.GetPrimaryConnInfo() + fmt.Sprintf(" dbname=%v", cluster.GetApplicationDatabaseName())
+	primaryConnInfo := instance.GetPrimaryConnInfo() + " dbname=postgres"
 	return UpdateReplicaConfiguration(instance.PgData, primaryConnInfo, slotName)
 }
 

--- a/pkg/management/postgres/instance_replica.go
+++ b/pkg/management/postgres/instance_replica.go
@@ -64,10 +64,7 @@ func (instance *Instance) RefreshReplicaConfiguration(
 
 func (instance *Instance) writeReplicaConfigurationForReplica(cluster *apiv1.Cluster) (changed bool, err error) {
 	slotName := cluster.GetSlotNameFromInstanceName(instance.GetPodName())
-	primaryConnInfo := instance.GetPrimaryConnInfo()
-	if applicationDB := cluster.GetApplicationDatabaseName(); applicationDB != "" {
-		primaryConnInfo += fmt.Sprintf("dbname=%v", applicationDB)
-	}
+	primaryConnInfo := instance.GetPrimaryConnInfo() + fmt.Sprintf(" dbname=%v", cluster.GetApplicationDatabaseName())
 	return UpdateReplicaConfiguration(instance.PgData, primaryConnInfo, slotName)
 }
 

--- a/pkg/management/postgres/instance_replica.go
+++ b/pkg/management/postgres/instance_replica.go
@@ -64,7 +64,11 @@ func (instance *Instance) RefreshReplicaConfiguration(
 
 func (instance *Instance) writeReplicaConfigurationForReplica(cluster *apiv1.Cluster) (changed bool, err error) {
 	slotName := cluster.GetSlotNameFromInstanceName(instance.GetPodName())
-	return UpdateReplicaConfiguration(instance.PgData, instance.GetPrimaryConnInfo(), slotName)
+	primaryConnInfo := instance.GetPrimaryConnInfo()
+	if applicationDB := cluster.GetApplicationDatabaseName(); applicationDB != "" {
+		primaryConnInfo += fmt.Sprintf("dbname=%v", applicationDB)
+	}
+	return UpdateReplicaConfiguration(instance.PgData, primaryConnInfo, slotName)
 }
 
 func (instance *Instance) writeReplicaConfigurationForDesignatedPrimary(

--- a/pkg/management/postgres/instance_replica.go
+++ b/pkg/management/postgres/instance_replica.go
@@ -64,7 +64,7 @@ func (instance *Instance) RefreshReplicaConfiguration(
 
 func (instance *Instance) writeReplicaConfigurationForReplica(cluster *apiv1.Cluster) (changed bool, err error) {
 	slotName := cluster.GetSlotNameFromInstanceName(instance.GetPodName())
-	primaryConnInfo := instance.GetPrimaryConnInfo() + " dbname=postgres"
+	primaryConnInfo := instance.GetPrimaryConnInfo()
 	return UpdateReplicaConfiguration(instance.PgData, primaryConnInfo, slotName)
 }
 

--- a/pkg/management/postgres/wal.go
+++ b/pkg/management/postgres/wal.go
@@ -65,7 +65,7 @@ func newWalArchiveAnalyzerForReplicaInstance(primaryConnInfo string) *walArchive
 		dbFactory: func() (*sql.DB, error) {
 			db, openErr := sql.Open(
 				"pgx",
-				fmt.Sprintf("%s dbname=%s", primaryConnInfo, "postgres"),
+				primaryConnInfo,
 			)
 			if openErr != nil {
 				log.Error(openErr, "can not open postgres database")


### PR DESCRIPTION
closes #5917 include dbname within primary_conninfo for replica configuration to support replication slot synchronization and enable logical replication failover

> replication slot synchronization requires "dbname" to be specified in "primary_conninfo"

