### PR TITLE
test: allow configuring a custom image repository in major upgrade E2Es

### DIFF
--- a/tests/e2e/cluster_major_upgrade_test.go
+++ b/tests/e2e/cluster_major_upgrade_test.go
@@ -173,11 +173,19 @@ var _ = Describe("Postgres Major Upgrade", Label(tests.LabelPostgresMajorUpgrade
 	// generateTargetImages, given a targetMajor, generates a target image for each buildScenario.
 	// MAJOR_UPGRADE_IMAGE_REPO env allows to customize the target image repository.
 	generateTargetImages := func(targetMajor uint64) map[string]string {
+		const (
+			// ImageRepository is the default repository for Postgres container images
+			ImageRepository = "ghcr.io/cloudnative-pg/postgresql"
+
+			// PostgisImageRepository is the default repository for Postgis container images
+			PostgisImageRepository = "ghcr.io/cloudnative-pg/postgis"
+		)
+
 		// Default target Images
 		targetImages := map[string]string{
-			postgisEntry:           fmt.Sprintf("%v:%v", postgres.PostgisImageRepository, targetMajor),
-			postgresqlEntry:        fmt.Sprintf("%v:%v-standard-bookworm", postgres.ImageRepository, targetMajor),
-			postgresqlMinimalEntry: fmt.Sprintf("%v:%v-minimal-bookworm", postgres.ImageRepository, targetMajor),
+			postgisEntry:           fmt.Sprintf("%v:%v", PostgisImageRepository, targetMajor),
+			postgresqlEntry:        fmt.Sprintf("%v:%v-standard-bookworm", ImageRepository, targetMajor),
+			postgresqlMinimalEntry: fmt.Sprintf("%v:%v-minimal-bookworm", ImageRepository, targetMajor),
 		}
 		// Set custom targets when detecting a given env variable
 		if envValue := os.Getenv(customImageRegistryEnvVar); envValue != "" {

--- a/tests/utils/postgres/postgres.go
+++ b/tests/utils/postgres/postgres.go
@@ -51,10 +51,6 @@ const (
 	PostgresDBName = "postgres"
 	// TablespaceDefaultName is the default tablespace location
 	TablespaceDefaultName = "pg_default"
-	// ImageRepository is the default repository for Postgres container images
-	ImageRepository = "ghcr.io/cloudnative-pg/postgresql"
-	// PostgisImageRepository is the default repository for Postgis container images
-	PostgisImageRepository = "ghcr.io/cloudnative-pg/postgis"
 )
 
 // CountReplicas counts the number of replicas attached to an instance

--- a/tests/utils/postgres/postgres.go
+++ b/tests/utils/postgres/postgres.go
@@ -51,6 +51,10 @@ const (
 	PostgresDBName = "postgres"
 	// TablespaceDefaultName is the default tablespace location
 	TablespaceDefaultName = "pg_default"
+	// ImageRepository is the default repository for Postgres container images
+	ImageRepository = "ghcr.io/cloudnative-pg/postgresql"
+	// PostgisImageRepository is the default repository for Postgis container images
+	PostgisImageRepository = "ghcr.io/cloudnative-pg/postgis"
 )
 
 // CountReplicas counts the number of replicas attached to an instance


### PR DESCRIPTION
This patch goes together with https://github.com/cloudnative-pg/postgres-trunk-containers/pull/80.
The goal is to allow configuring a custom repository (in this case the `postgresql-trunk`) instead of the default ones (via an env variable), which will be used to fetch the target images required to perform the major upgrade scenarios.
This will allow us to test major upgrades to development versions of PG18.

Closes #7302 