### PR TITLE
feat: Switch Slack Channel links to the CNCF Slack

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,8 +10,8 @@ our project that we need help with, including:
 * Bugs in our Github actions
 * Promotion of PostgreSQL on Kubernetes with our operator
 
-First, though, it is important that you read the [code of
-conduct](CODE_OF_CONDUCT.md).
+First, though, it is important that you read the
+[code of conduct](CODE_OF_CONDUCT.md).
 
 The guidelines below are a starting point. We don't want to limit your
 creativity, passion, and initiative. If you think there's a better way, please
@@ -29,7 +29,7 @@ We welcome many types of contributions including:
 * [Documentation](docs/README.md)
 * Issue Triage
 * Answering questions on Slack or Github Discussions
-* Web design
+* [Website](https://github.com/cloudnative-pg/cloudnative-pg.github.io)
 * Communications / Social Media / Blog Posts
 * Events participation
 * Release management

--- a/README.md
+++ b/README.md
@@ -92,9 +92,8 @@ CloudNativePG can be extended via the [CNPG-I plugin interface](https://github.c
 ## Communications
 
 - [Github Discussions](https://github.com/cloudnative-pg/cloudnative-pg/discussions)
-- [#cloudnativepg-users on CNCF Slack Workspace](https://cloud-native.slack.com/archives/C08MAUJ7NPM)
-- [#cloudnativepg-dev on CNCF Slack Workspace](https://cloud-native.slack.com/archives/C08MW1HKF40)
-- [CNCF Slack Workspace Inviter](https://communityinviter.com/apps/cloud-native/cncf).
+- [Slack](https://cloud-native.slack.com/archives/C08MAUJ7NPM)
+  (on the [CNCF Slack Workspace](https://communityinviter.com/apps/cloud-native/cncf)).
 - [Twitter](https://twitter.com/CloudNativePg)
 - [Mastodon](https://mastodon.social/@CloudNativePG)
 - [Bluesky](https://bsky.app/profile/cloudnativepg.bsky.social)

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ CloudNativePG can be extended via the [CNPG-I plugin interface](https://github.c
 
 - [Github Discussions](https://github.com/cloudnative-pg/cloudnative-pg/discussions)
 - [Slack](https://cloud-native.slack.com/archives/C08MAUJ7NPM)
-  (on the [CNCF Slack Workspace](https://communityinviter.com/apps/cloud-native/cncf)).
+  (join the [CNCF Slack Workspace](https://communityinviter.com/apps/cloud-native/cncf)).
 - [Twitter](https://twitter.com/CloudNativePg)
 - [Mastodon](https://mastodon.social/@CloudNativePG)
 - [Bluesky](https://bsky.app/profile/cloudnativepg.bsky.social)

--- a/README.md
+++ b/README.md
@@ -92,8 +92,9 @@ CloudNativePG can be extended via the [CNPG-I plugin interface](https://github.c
 ## Communications
 
 - [Github Discussions](https://github.com/cloudnative-pg/cloudnative-pg/discussions)
-- [Slack Channel Users](https://cloud-native.slack.com/archives/C08MAUJ7NPM)
-- [Slack Channel Development](https://cloud-native.slack.com/archives/C08MW1HKF40)
+- [#cloudnativepg-users on CNCF Slack Workspace](https://cloud-native.slack.com/archives/C08MAUJ7NPM)
+- [#cloudnativepg-dev on CNCF Slack Workspace](https://cloud-native.slack.com/archives/C08MW1HKF40)
+- [CNCF Slack Workspace Inviter](https://communityinviter.com/apps/cloud-native/cncf).
 - [Twitter](https://twitter.com/CloudNativePg)
 - [Mastodon](https://mastodon.social/@CloudNativePG)
 - [Bluesky](https://bsky.app/profile/cloudnativepg.bsky.social)

--- a/README.md
+++ b/README.md
@@ -92,7 +92,8 @@ CloudNativePG can be extended via the [CNPG-I plugin interface](https://github.c
 ## Communications
 
 - [Github Discussions](https://github.com/cloudnative-pg/cloudnative-pg/discussions)
-- [Slack Channel](https://join.slack.com/t/cloudnativepg/shared_invite/zt-30a6l6bp3-u1lNAmh~N02Cfiv2utKTFg)
+- [Slack Channel Users](https://cloud-native.slack.com/archives/C08MAUJ7NPM)
+- [Slack Channel Development](https://cloud-native.slack.com/archives/C08MW1HKF40)
 - [Twitter](https://twitter.com/CloudNativePg)
 - [Mastodon](https://mastodon.social/@CloudNativePG)
 - [Bluesky](https://bsky.app/profile/cloudnativepg.bsky.social)

--- a/contribute/README.md
+++ b/contribute/README.md
@@ -9,7 +9,7 @@ a good set of docs that guide you through the development process. Having said t
 we know that everything can always be improved, so if you think our documentation
 is not enough, let us know or provide a pull request based on your experience.
 
-Feel free to ask in the ["dev" chat](https://cloudnativepg.slack.com/archives/C03D68KGG65)
+Feel free to ask in the ["dev" chat](https://cloud-native.slack.com/archives/C08MW1HKF40)
 if you have questions or are seeking guidance.
 
 ## About our development workflow

--- a/contribute/README.md
+++ b/contribute/README.md
@@ -9,8 +9,11 @@ a good set of docs that guide you through the development process. Having said t
 we know that everything can always be improved, so if you think our documentation
 is not enough, let us know or provide a pull request based on your experience.
 
-Feel free to ask in the ["dev" chat](https://cloud-native.slack.com/archives/C08MW1HKF40)
-if you have questions or are seeking guidance.
+If you have any questions or need guidance, feel free to reach out in the
+[#cloudnativepg-dev](https://cloud-native.slack.com/archives/C08MW1HKF40) channel
+on the CNCF Slack workspace.
+If you're not yet a member, you can join the Cloud Native Computing Foundation
+Slack via the [Community Inviter App](https://communityinviter.com/apps/cloud-native/cncf).
 
 ## About our development workflow
 

--- a/contribute/README.md
+++ b/contribute/README.md
@@ -11,9 +11,7 @@ is not enough, let us know or provide a pull request based on your experience.
 
 If you have any questions or need guidance, feel free to reach out in the
 [#cloudnativepg-dev](https://cloud-native.slack.com/archives/C08MW1HKF40) channel
-on the CNCF Slack workspace.
-If you're not yet a member, you can join the Cloud Native Computing Foundation
-Slack via the [Community Inviter App](https://communityinviter.com/apps/cloud-native/cncf).
+on the [CNCF Slack workspace](https://communityinviter.com/apps/cloud-native/cncf).
 
 ## About our development workflow
 

--- a/docs/src/supported_releases.md
+++ b/docs/src/supported_releases.md
@@ -183,13 +183,14 @@ Only the last patch release of each branch is supported.
 We offer two types of support:
 
 Technical support
-:   Technical assistance is provided on a best-effort basis and only for supported releases.
-    You can request help from the community through the
-    [#cloudnativepg-users](https://cloud-native.slack.com/archives/C08MAUJ7NPM) channel
-    on the CNCF Slack workspace (if you're not yet a member, you can join via the
-    [Community Inviter App](https://communityinviter.com/apps/cloud-native/cncf))
-    or through [GitHub Discussions](https://github.com/cloudnative-pg/cloudnative-pg/discussions)
-    in the CloudNativePG repository.
+:   Technical assistance is offered on a best-effort basis and is limited to
+    supported releases only.  For help, you can reach out to the community via the
+    [#cloudnativepg-users](https://cloud-native.slack.com/archives/C08MAUJ7NPM)
+    channel on the CNCF Slack workspace. If you're not yet a member, you can
+    [join the workspace](https://communityinviter.com/apps/cloud-native/cncf)
+    using the Community Inviter App. Alternatively, you can post your questions in
+    the [GitHub Discussions](https://github.com/cloudnative-pg/cloudnative-pg/discussions)
+    section of the CloudNativePG repository.
 
 Security and bug fixes
 :   We backport important bug fixes — including security fixes - to all
@@ -197,7 +198,7 @@ Security and bug fixes
     *"Does this backport improve `CloudNativePG`, bearing in mind that we really
     value stability for already-released versions?"*
 
-If you're looking for professional support, see the
-[Support page in the website](https://cloudnative-pg.io/support/).
-The vendors listed there might provide service level agreements that included
-extended support timeframes.
+If you’re looking for professional support, please refer to the
+[Support page on our website](https://cloudnative-pg.io/support/).
+The vendors listed there may offer service level agreements (SLAs), including
+extended support periods and additional services.

--- a/docs/src/supported_releases.md
+++ b/docs/src/supported_releases.md
@@ -186,9 +186,9 @@ Technical support
 :   Technical assistance is offered on a best-effort basis and is limited to
     supported releases only.  For help, you can reach out to the community via the
     [#cloudnativepg-users](https://cloud-native.slack.com/archives/C08MAUJ7NPM)
-    channel on the CNCF Slack workspace. If you're not yet a member, you can
-    [join the workspace](https://communityinviter.com/apps/cloud-native/cncf)
-    using the Community Inviter App. Alternatively, you can post your questions in
+    channel on the CNCF Slack workspace (if you're not yet a member, you can
+    [join the workspace](https://communityinviter.com/apps/cloud-native/cncf)).
+    Alternatively, you can post your questions in
     the [GitHub Discussions](https://github.com/cloudnative-pg/cloudnative-pg/discussions)
     section of the CloudNativePG repository.
 
@@ -200,5 +200,5 @@ Security and bug fixes
 
 If you’re looking for professional support, please refer to the
 [Support page on our website](https://cloudnative-pg.io/support/).
-The vendors listed there may offer service level agreements (SLAs), including
+The vendors listed there may offer service level agreements (SLA), including
 extended support periods and additional services.

--- a/docs/src/supported_releases.md
+++ b/docs/src/supported_releases.md
@@ -183,10 +183,13 @@ Only the last patch release of each branch is supported.
 We offer two types of support:
 
 Technical support
-:   Technical assistance is offered on a best-effort basis for supported
-    releases only. You can request support from the community on the
-    [CNCF Slack](https://cloud-native.slack.com/) (in the `#cloudnativepg-users` channel),
-    or using [GitHub Discussions](https://github.com/cloudnative-pg/cloudnative-pg/discussions).
+:   Technical assistance is provided on a best-effort basis and only for supported releases.
+    You can request help from the community through the
+    [#cloudnativepg-users](https://cloud-native.slack.com/archives/C08MAUJ7NPM) channel
+    on the CNCF Slack workspace (if you're not yet a member, you can join via the
+    [Community Inviter App](https://communityinviter.com/apps/cloud-native/cncf))
+    or through [GitHub Discussions](https://github.com/cloudnative-pg/cloudnative-pg/discussions)
+    in the CloudNativePG repository.
 
 Security and bug fixes
 :   We backport important bug fixes — including security fixes - to all

--- a/docs/src/supported_releases.md
+++ b/docs/src/supported_releases.md
@@ -185,7 +185,7 @@ We offer two types of support:
 Technical support
 :   Technical assistance is offered on a best-effort basis for supported
     releases only. You can request support from the community on the
-    [CloudNativePG Slack](https://cloudnativepg.slack.com/) (in the `#general` channel),
+    [CNCF Slack](https://cloud-native.slack.com/) (in the `#cloudnativepg-users` channel),
     or using [GitHub Discussions](https://github.com/cloudnative-pg/cloudnative-pg/discussions).
 
 Security and bug fixes


### PR DESCRIPTION
The links that were previously pointing to CloudNativePG Slack, now points to the CNCF Slack.