### PR TITLE
fix: add missing pinDigest into renovate for spellcheck group

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -449,7 +449,7 @@
     {
       groupName: 'spellcheck',
       separateMajorMinor: false,
-      pinDigests: false,
+      pinDigests: true,
       matchPackageNames: [
         'jonasbn/github-action-spellcheck{/,}**',
         'rojopolis/spellcheck-github-actions{/,}**',


### PR DESCRIPTION
Closes #7257 