### PR TITLE
fix(workaround): handle Azure CSI driver resizing condition conflict

### DIFF
--- a/pkg/reconciler/persistentvolumeclaim/resources.go
+++ b/pkg/reconciler/persistentvolumeclaim/resources.go
@@ -66,14 +66,21 @@ external:
 }
 
 // isResizing returns true if PersistentVolumeClaimResizing condition is present
+// and not PersistentVolumeClaimFileSystemResizePending
 func isResizing(pvc corev1.PersistentVolumeClaim) bool {
+	isResizing := false
+	isFileSystemResizePending := false
+
 	for _, condition := range pvc.Status.Conditions {
 		if condition.Type == corev1.PersistentVolumeClaimResizing {
-			return true
+			isResizing = true
+		}
+		if condition.Type == corev1.PersistentVolumeClaimFileSystemResizePending {
+			isFileSystemResizePending = true
 		}
 	}
 
-	return false
+	return isResizing && !isFileSystemResizePending
 }
 
 // BelongToInstance returns a boolean indicating if that given PVC belongs to an instance

--- a/pkg/reconciler/persistentvolumeclaim/resources_test.go
+++ b/pkg/reconciler/persistentvolumeclaim/resources_test.go
@@ -151,3 +151,35 @@ var _ = Describe("instance with tablespace test", func() {
 		}
 	})
 })
+
+var _ = Describe("PVC resize detection", func() {
+	pvc := corev1.PersistentVolumeClaim{
+		Status: corev1.PersistentVolumeClaimStatus{},
+	}
+	It("no resizing", func() {
+		pvc.Status.Conditions = nil
+		Expect(isResizing(pvc)).To(BeFalse())
+	})
+
+	It("with one resizing condition", func() {
+		pvc.Status.Conditions = []corev1.PersistentVolumeClaimCondition{
+			{
+				Type: corev1.PersistentVolumeClaimResizing,
+			},
+		}
+		Expect(isResizing(pvc)).To(BeTrue())
+	})
+
+	It("with one resizing condition", func() {
+		pvc := makePVC("test", "1", "1", NewPgDataCalculator(), false)
+		pvc.Status.Conditions = []corev1.PersistentVolumeClaimCondition{
+			{
+				Type: corev1.PersistentVolumeClaimResizing,
+			},
+			{
+				Type: corev1.PersistentVolumeClaimFileSystemResizePending,
+			},
+		}
+		Expect(isResizing(pvc)).To(BeFalse())
+	})
+})


### PR DESCRIPTION
Implement a workaround to address cases where both `PersistentVolumeClaimResizing` and `PersistentVolumeClaimFileSystemResizePending` conditions are true, which is an unexpected behavior specific to the Azure CSI driver. Update the `isResizing` function to correctly return `false` in such cases and add unit tests to validate the behavior.

Fixes #7324 