### PR TITLE
fix(security): ignore pgbouncer path for the digest updater

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -20,6 +20,7 @@
     'contribute/**',
     'licenses/**',
     'pkg/versions/**',
+    'pkg/specs/pgbouncer/',
   ],
   postUpdateOptions: [
     'gomodTidy',


### PR DESCRIPTION
Renovate fails when looking into the container images inside a Go file.
In this case failed looking for pkg/specs/pgbouncer/deployments.go 

Closes #7257 