### PR TITLE
feat: allow to specify a scrapeClass on PodMonitors

### DIFF
--- a/.wordlist-en-custom.txt
+++ b/.wordlist-en-custom.txt
@@ -1099,6 +1099,7 @@ podCount
 podMetricsEndpoints
 podMonitorMetricRelabelings
 podMonitorRelabelings
+podMonitorScrapeClass
 podName
 podStatuses
 podmonitor

--- a/api/v1/cluster_funcs.go
+++ b/api/v1/cluster_funcs.go
@@ -328,6 +328,14 @@ func (m *MonitoringConfiguration) AreDefaultQueriesDisabled() bool {
 	return m != nil && m.DisableDefaultQueries != nil && *m.DisableDefaultQueries
 }
 
+// GetPodMonitorScrapeClass returns the PodMonitor scrape class
+func (m *MonitoringConfiguration) GetPodMonitorScrapeClass() *string {
+	if m == nil || m.PodMonitorScrapeClass == nil {
+		return nil
+	}
+	return m.PodMonitorScrapeClass
+}
+
 // GetServerName returns the server name, defaulting to the name of the external cluster or using the one specified
 // in the BarmanObjectStore
 func (in ExternalCluster) GetServerName() string {

--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -2070,6 +2070,11 @@ type MonitoringConfiguration struct {
 	// +optional
 	PodMonitorMetricRelabelConfigs []monitoringv1.RelabelConfig `json:"podMonitorMetricRelabelings,omitempty"`
 
+	// Specifies the `PodMonitor` scrape class.
+	// +optional.
+	// +kubebuilder:validation:MinLength=1
+	PodMonitorScrapeClass string `json:"podMonitorScrapeClass,omitempty"`
+
 	// The list of relabelings for the `PodMonitor`. Applied to samples before scraping.
 	// +optional
 	PodMonitorRelabelConfigs []monitoringv1.RelabelConfig `json:"podMonitorRelabelings,omitempty"`

--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -2072,8 +2072,7 @@ type MonitoringConfiguration struct {
 
 	// Specifies the `PodMonitor` scrape class.
 	// +optional.
-	// +kubebuilder:validation:MinLength=1
-	PodMonitorScrapeClass string `json:"podMonitorScrapeClass,omitempty"`
+	PodMonitorScrapeClass *string `json:"podMonitorScrapeClass,omitempty"`
 
 	// The list of relabelings for the `PodMonitor`. Applied to samples before scraping.
 	// +optional

--- a/api/v1/pooler_funcs.go
+++ b/api/v1/pooler_funcs.go
@@ -58,3 +58,11 @@ func (in *Pooler) IsAutomatedIntegration() bool {
 	}
 	return true
 }
+
+// GetPodMonitorScrapeClass returns the PodMonitor scrape class
+func (m *PoolerMonitoringConfiguration) GetPodMonitorScrapeClass() *string {
+	if m == nil || m.PodMonitorScrapeClass == nil {
+		return nil
+	}
+	return m.PodMonitorScrapeClass
+}

--- a/api/v1/pooler_types.go
+++ b/api/v1/pooler_types.go
@@ -108,6 +108,11 @@ type PoolerMonitoringConfiguration struct {
 	// +optional
 	PodMonitorMetricRelabelConfigs []monitoringv1.RelabelConfig `json:"podMonitorMetricRelabelings,omitempty"`
 
+	// Specifies the `PodMonitor` scrape class.
+	// +optional.
+	// +kubebuilder:validation:MinLength=1
+	PodMonitorScrapeClass string `json:"podMonitorScrapeClass,omitempty"`
+
 	// The list of relabelings for the `PodMonitor`. Applied to samples before scraping.
 	// +optional
 	PodMonitorRelabelConfigs []monitoringv1.RelabelConfig `json:"podMonitorRelabelings,omitempty"`

--- a/api/v1/pooler_types.go
+++ b/api/v1/pooler_types.go
@@ -110,8 +110,7 @@ type PoolerMonitoringConfiguration struct {
 
 	// Specifies the `PodMonitor` scrape class.
 	// +optional.
-	// +kubebuilder:validation:MinLength=1
-	PodMonitorScrapeClass string `json:"podMonitorScrapeClass,omitempty"`
+	PodMonitorScrapeClass *string `json:"podMonitorScrapeClass,omitempty"`
 
 	// The list of relabelings for the `PodMonitor`. Applied to samples before scraping.
 	// +optional

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -1753,6 +1753,11 @@ func (in *MonitoringConfiguration) DeepCopyInto(out *MonitoringConfiguration) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.PodMonitorScrapeClass != nil {
+		in, out := &in.PodMonitorScrapeClass, &out.PodMonitorScrapeClass
+		*out = new(string)
+		**out = **in
+	}
 	if in.PodMonitorRelabelConfigs != nil {
 		in, out := &in.PodMonitorRelabelConfigs, &out.PodMonitorRelabelConfigs
 		*out = make([]monitoringv1.RelabelConfig, len(*in))
@@ -2099,6 +2104,11 @@ func (in *PoolerMonitoringConfiguration) DeepCopyInto(out *PoolerMonitoringConfi
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
+	}
+	if in.PodMonitorScrapeClass != nil {
+		in, out := &in.PodMonitorScrapeClass, &out.PodMonitorScrapeClass
+		*out = new(string)
+		**out = **in
 	}
 	if in.PodMonitorRelabelConfigs != nil {
 		in, out := &in.PodMonitorRelabelConfigs, &out.PodMonitorRelabelConfigs

--- a/config/crd/bases/postgresql.cnpg.io_clusters.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_clusters.yaml
@@ -3941,7 +3941,6 @@ spec:
                     type: array
                   podMonitorScrapeClass:
                     description: Specifies the `PodMonitor` scrape class.
-                    minLength: 1
                     type: string
                   tls:
                     description: |-

--- a/config/crd/bases/postgresql.cnpg.io_clusters.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_clusters.yaml
@@ -3939,6 +3939,10 @@ spec:
                           type: string
                       type: object
                     type: array
+                  podMonitorScrapeClass:
+                    description: Specifies the `PodMonitor` scrape class.
+                    minLength: 1
+                    type: string
                   tls:
                     description: |-
                       Configure TLS communication for the metrics endpoint.

--- a/config/crd/bases/postgresql.cnpg.io_poolers.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_poolers.yaml
@@ -301,7 +301,6 @@ spec:
                     type: array
                   podMonitorScrapeClass:
                     description: Specifies the `PodMonitor` scrape class.
-                    minLength: 1
                     type: string
                 type: object
               pgbouncer:

--- a/config/crd/bases/postgresql.cnpg.io_poolers.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_poolers.yaml
@@ -299,6 +299,10 @@ spec:
                           type: string
                       type: object
                     type: array
+                  podMonitorScrapeClass:
+                    description: Specifies the `PodMonitor` scrape class.
+                    minLength: 1
+                    type: string
                 type: object
               pgbouncer:
                 description: The PgBouncer configuration

--- a/docs/src/cloudnative-pg.v1.md
+++ b/docs/src/cloudnative-pg.v1.md
@@ -3578,6 +3578,13 @@ Changing tls.enabled option will force a rollout of all instances.</p>
    <p>The list of metric relabelings for the <code>PodMonitor</code>. Applied to samples before ingestion.</p>
 </td>
 </tr>
+<tr><td><code>podMonitorScrapeClass</code> <B>[Required]</B><br/>
+<i>string</i>
+</td>
+<td>
+   <p>Specifies the <code>PodMonitor</code> scrape class.</p>
+</td>
+</tr>
 <tr><td><code>podMonitorRelabelings</code><br/>
 <a href="https://pkg.go.dev/github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1#RelabelConfig"><i>[]github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1.RelabelConfig</i></a>
 </td>
@@ -4068,6 +4075,13 @@ part for now.</p>
 </td>
 <td>
    <p>The list of metric relabelings for the <code>PodMonitor</code>. Applied to samples before ingestion.</p>
+</td>
+</tr>
+<tr><td><code>podMonitorScrapeClass</code> <B>[Required]</B><br/>
+<i>string</i>
+</td>
+<td>
+   <p>Specifies the <code>PodMonitor</code> scrape class.</p>
 </td>
 </tr>
 <tr><td><code>podMonitorRelabelings</code><br/>

--- a/pkg/specs/pgbouncer/podmonitor.go
+++ b/pkg/specs/pgbouncer/podmonitor.go
@@ -65,6 +65,7 @@ func (c PoolerPodMonitorManager) BuildPodMonitor() *monitoringv1.PodMonitor {
 	}
 
 	spec := monitoringv1.PodMonitorSpec{
+		ScrapeClassName: c.pooler.Spec.Monitoring.GetPodMonitorScrapeClass(),
 		Selector: metav1.LabelSelector{
 			MatchLabels: map[string]string{
 				utils.PgbouncerNameLabel: c.pooler.Name,
@@ -73,11 +74,6 @@ func (c PoolerPodMonitorManager) BuildPodMonitor() *monitoringv1.PodMonitor {
 		},
 		PodMetricsEndpoints: []monitoringv1.PodMetricsEndpoint{endpoint},
 	}
-
-	if monitoring := c.pooler.Spec.Monitoring; monitoring != nil && monitoring.PodMonitorScrapeClass != "" {
-		spec.ScrapeClassName = &monitoring.PodMonitorScrapeClass
-	}
-
 	return &monitoringv1.PodMonitor{
 		ObjectMeta: meta,
 		Spec:       spec,

--- a/pkg/specs/pgbouncer/podmonitor.go
+++ b/pkg/specs/pgbouncer/podmonitor.go
@@ -73,6 +73,11 @@ func (c PoolerPodMonitorManager) BuildPodMonitor() *monitoringv1.PodMonitor {
 		},
 		PodMetricsEndpoints: []monitoringv1.PodMetricsEndpoint{endpoint},
 	}
+
+	if monitoring := c.pooler.Spec.Monitoring; monitoring != nil && monitoring.PodMonitorScrapeClass != "" {
+		spec.ScrapeClassName = &monitoring.PodMonitorScrapeClass
+	}
+
 	return &monitoringv1.PodMonitor{
 		ObjectMeta: meta,
 		Spec:       spec,

--- a/pkg/specs/pgbouncer/podmonitor_test.go
+++ b/pkg/specs/pgbouncer/podmonitor_test.go
@@ -90,7 +90,7 @@ var _ = Describe("PoolerPodMonitorManager", func() {
 
 		It("returns the correct PodMonitor object with scrapeClass", func() {
 			scrapeClass := "custom-scrape-class"
-			pooler.Spec.Monitoring.PodMonitorScrapeClass = scrapeClass
+			pooler.Spec.Monitoring.PodMonitorScrapeClass = &scrapeClass
 			manager := NewPoolerPodMonitorManager(pooler)
 
 			podMonitor := manager.BuildPodMonitor()

--- a/pkg/specs/pgbouncer/podmonitor_test.go
+++ b/pkg/specs/pgbouncer/podmonitor_test.go
@@ -84,6 +84,19 @@ var _ = Describe("PoolerPodMonitorManager", func() {
 
 			Expect(podMonitor.Spec.PodMetricsEndpoints).To(HaveLen(1))
 			Expect(*podMonitor.Spec.PodMetricsEndpoints[0].Port).To(Equal("metrics"))
+
+			Expect(podMonitor.Spec.ScrapeClassName).To(BeNil())
+		})
+
+		It("returns the correct PodMonitor object with scrapeClass", func() {
+			scrapeClass := "custom-scrape-class"
+			pooler.Spec.Monitoring.PodMonitorScrapeClass = scrapeClass
+			manager := NewPoolerPodMonitorManager(pooler)
+
+			podMonitor := manager.BuildPodMonitor()
+
+			Expect(podMonitor).ToNot(BeNil())
+			Expect(podMonitor.Spec.ScrapeClassName).To(Equal(&scrapeClass))
 		})
 	})
 

--- a/pkg/specs/podmonitor.go
+++ b/pkg/specs/podmonitor.go
@@ -77,6 +77,7 @@ func (c ClusterPodMonitorManager) BuildPodMonitor() *monitoringv1.PodMonitor {
 	}
 
 	spec := monitoringv1.PodMonitorSpec{
+		ScrapeClassName: c.cluster.Spec.Monitoring.GetPodMonitorScrapeClass(),
 		Selector: metav1.LabelSelector{
 			MatchLabels: map[string]string{
 				utils.ClusterLabelName: c.cluster.Name,
@@ -84,10 +85,6 @@ func (c ClusterPodMonitorManager) BuildPodMonitor() *monitoringv1.PodMonitor {
 			},
 		},
 		PodMetricsEndpoints: []monitoringv1.PodMetricsEndpoint{endpoint},
-	}
-
-	if monitoring := c.cluster.Spec.Monitoring; monitoring != nil && monitoring.PodMonitorScrapeClass != "" {
-		spec.ScrapeClassName = &monitoring.PodMonitorScrapeClass
 	}
 
 	return &monitoringv1.PodMonitor{

--- a/pkg/specs/podmonitor.go
+++ b/pkg/specs/podmonitor.go
@@ -86,6 +86,10 @@ func (c ClusterPodMonitorManager) BuildPodMonitor() *monitoringv1.PodMonitor {
 		PodMetricsEndpoints: []monitoringv1.PodMetricsEndpoint{endpoint},
 	}
 
+	if monitoring := c.cluster.Spec.Monitoring; monitoring != nil && monitoring.PodMonitorScrapeClass != "" {
+		spec.ScrapeClassName = &monitoring.PodMonitorScrapeClass
+	}
+
 	return &monitoringv1.PodMonitor{
 		ObjectMeta: meta,
 		Spec:       spec,

--- a/pkg/specs/podmonitor_test.go
+++ b/pkg/specs/podmonitor_test.go
@@ -101,7 +101,7 @@ var _ = Describe("PodMonitor test", func() {
 		It("should create a monitoringv1.PodMonitor object with scrapeClass", func() {
 			scrapeClass := "custom-scrape-class"
 			cluster := cluster.DeepCopy()
-			cluster.Spec.Monitoring.PodMonitorScrapeClass = scrapeClass
+			cluster.Spec.Monitoring.PodMonitorScrapeClass = &scrapeClass
 			mgr := NewClusterPodMonitorManager(cluster)
 			monitor := mgr.BuildPodMonitor()
 
@@ -113,7 +113,7 @@ var _ = Describe("PodMonitor test", func() {
 			relabeledCluster := cluster.DeepCopy()
 			relabeledCluster.Spec.Monitoring.PodMonitorMetricRelabelConfigs = getMetricRelabelings()
 			relabeledCluster.Spec.Monitoring.PodMonitorRelabelConfigs = getRelabelings()
-			relabeledCluster.Spec.Monitoring.PodMonitorScrapeClass = scrapeClass
+			relabeledCluster.Spec.Monitoring.PodMonitorScrapeClass = &scrapeClass
 			mgr := NewClusterPodMonitorManager(relabeledCluster)
 			monitor := mgr.BuildPodMonitor()
 

--- a/pkg/specs/podmonitor_test.go
+++ b/pkg/specs/podmonitor_test.go
@@ -98,10 +98,22 @@ var _ = Describe("PodMonitor test", func() {
 			Expect(monitor.Spec.PodMetricsEndpoints).To(ContainElement(*expectedEndpoint))
 		})
 
-		It("should create a monitoringv1.PodMonitor object with MetricRelabelConfigs and RelabelConfigs rules", func() {
+		It("should create a monitoringv1.PodMonitor object with scrapeClass", func() {
+			scrapeClass := "custom-scrape-class"
+			cluster := cluster.DeepCopy()
+			cluster.Spec.Monitoring.PodMonitorScrapeClass = scrapeClass
+			mgr := NewClusterPodMonitorManager(cluster)
+			monitor := mgr.BuildPodMonitor()
+
+			Expect(monitor.Spec.ScrapeClassName).To(Equal(&scrapeClass))
+		})
+
+		It("should create a monitoringv1.PodMonitor object with all options", func() {
+			scrapeClass := "custom-scrape-class"
 			relabeledCluster := cluster.DeepCopy()
 			relabeledCluster.Spec.Monitoring.PodMonitorMetricRelabelConfigs = getMetricRelabelings()
 			relabeledCluster.Spec.Monitoring.PodMonitorRelabelConfigs = getRelabelings()
+			relabeledCluster.Spec.Monitoring.PodMonitorScrapeClass = scrapeClass
 			mgr := NewClusterPodMonitorManager(relabeledCluster)
 			monitor := mgr.BuildPodMonitor()
 
@@ -109,6 +121,7 @@ var _ = Describe("PodMonitor test", func() {
 			expectedEndpoint.MetricRelabelConfigs = getMetricRelabelings()
 			expectedEndpoint.RelabelConfigs = getRelabelings()
 			Expect(monitor.Spec.PodMetricsEndpoints).To(ContainElement(*expectedEndpoint))
+			Expect(monitor.Spec.ScrapeClassName).To(Equal(&scrapeClass))
 		})
 
 		It("does not panic if monitoring section is not present", func() {


### PR DESCRIPTION
This PR adds the option to configure a scrapeClass on the PodMonitors created by the operator.