### PR TITLE
feat: drop support for pg12

### DIFF
--- a/docs/src/database_import.md
+++ b/docs/src/database_import.md
@@ -18,8 +18,8 @@ As a result, the instructions in this section are suitable for both:
 - importing one or more databases from an existing PostgreSQL instance, even
   outside Kubernetes
 - importing the database from any PostgreSQL version to one that is either the
-  same or newer, enabling *major upgrades* of PostgreSQL (e.g. from version 11.x
-  to version 15.x)
+  same or newer, enabling *major upgrades* of PostgreSQL (e.g. from version 13.x
+  to version 17.x)
 
 !!! Warning
     When performing major upgrades of PostgreSQL you are responsible for making
@@ -316,4 +316,3 @@ upgrades.
 
 For more details, including limitations and best practices, refer to the
 [Logical Replication](logical_replication.md) section in the documentation.
-

--- a/docs/src/postgresql_conf.md
+++ b/docs/src/postgresql_conf.md
@@ -65,7 +65,7 @@ operator by applying the following sections in this order:
 The **global default parameters** are:
 
 ```text
-archive_mode = 'on'
+archive_timeout = '5min'
 dynamic_shared_memory_type = 'posix'
 full_page_writes = 'on'
 logging_collector = 'on'
@@ -78,9 +78,11 @@ log_truncate_on_rotation = 'false'
 max_parallel_workers = '32'
 max_replication_slots = '32'
 max_worker_processes = '32'
-shared_memory_type = 'mmap' # for PostgreSQL >= 12 only
-wal_keep_size = '512MB' # for PostgreSQL >= 13 only
-wal_keep_segments = '32' # for PostgreSQL <= 12 only
+shared_memory_type = 'mmap'
+shared_preload_libraries = ''
+ssl_max_protocol_version = 'TLSv1.3'
+ssl_min_protocol_version = 'TLSv1.3'
+wal_keep_size = '512MB'
 wal_level = 'logical'
 wal_log_hints = 'on'
 wal_sender_timeout = '5s'

--- a/internal/cmd/manager/instance/pgbasebackup/cmd.go
+++ b/internal/cmd/manager/instance/pgbasebackup/cmd.go
@@ -105,8 +105,6 @@ func NewCmd() *cobra.Command {
 
 // bootstrapUsingPgbasebackup creates a new data dir from the configuration
 func (env *CloneInfo) bootstrapUsingPgbasebackup(ctx context.Context) error {
-	contextLogger := log.FromContext(ctx)
-
 	var cluster apiv1.Cluster
 	err := env.client.Get(ctx, ctrl.ObjectKey{Namespace: env.info.Namespace, Name: env.info.ClusterName}, &cluster)
 	if err != nil {
@@ -134,22 +132,13 @@ func (env *CloneInfo) bootstrapUsingPgbasebackup(ctx context.Context) error {
 		return err
 	}
 
-	pgVersion, err := cluster.GetPostgresqlVersion()
-	if err != nil {
-		contextLogger.Warning(
-			"Error while parsing PostgreSQL server version to define connection options, defaulting to PostgreSQL 11",
-			"imageName", cluster.Status.Image,
-			"err", err)
-	} else if pgVersion.Major() >= 12 {
-		// We explicitly disable wal_sender_timeout for join-related pg_basebackup executions.
-		// A short timeout could not be enough in case the instance is slow to send data,
-		// like when the I/O is overloaded.
-		connectionString += " options='-c wal_sender_timeout=0s'"
-	}
+	// We explicitly disable wal_sender_timeout for join-related pg_basebackup executions.
+	// A short timeout could not be enough in case the instance is slow to send data,
+	// like when the I/O is overloaded.
+	connectionString += " options='-c wal_sender_timeout=0s'"
 
-	err = postgres.ClonePgData(ctx, connectionString, env.info.PgData, env.info.PgWal)
-	if err != nil {
-		return err
+	if err := postgres.ClonePgData(ctx, connectionString, env.info.PgData, env.info.PgWal); err != nil {
+		return fmt.Errorf("while cloning pgdata: %w", err)
 	}
 
 	if cluster.IsReplica() {

--- a/internal/controller/cluster_image_test.go
+++ b/internal/controller/cluster_image_test.go
@@ -150,8 +150,8 @@ var _ = Describe("Cluster image detection", func() {
 			Spec: apiv1.ImageCatalogSpec{
 				Images: []apiv1.CatalogImage{
 					{
-						Image: "postgres:11.2",
-						Major: 11,
+						Image: "postgres:17.4",
+						Major: 17,
 					},
 				},
 			},

--- a/internal/webhook/v1/cluster_webhook.go
+++ b/internal/webhook/v1/cluster_webhook.go
@@ -107,7 +107,8 @@ func (v *ClusterCustomValidator) ValidateCreate(_ context.Context, obj runtime.O
 	if !ok {
 		return nil, fmt.Errorf("expected a Cluster object but got %T", obj)
 	}
-	clusterLog.Info("Validation for Cluster upon creation", "name", cluster.GetName(), "namespace", cluster.GetNamespace())
+	clusterLog.Info("Validation for Cluster upon creation", "name", cluster.GetName(), "namespace",
+		cluster.GetNamespace())
 
 	allErrs := v.validate(cluster)
 	allWarnings := v.getAdmissionWarnings(cluster)
@@ -136,7 +137,8 @@ func (v *ClusterCustomValidator) ValidateUpdate(
 		return nil, fmt.Errorf("expected a Cluster object for the oldObj but got %T", oldObj)
 	}
 
-	clusterLog.Info("Validation for Cluster upon update", "name", cluster.GetName(), "namespace", cluster.GetNamespace())
+	clusterLog.Info("Validation for Cluster upon update", "name", cluster.GetName(), "namespace",
+		cluster.GetNamespace())
 
 	// applying defaults before validating updates to set any new default
 	oldCluster.SetDefaults()
@@ -162,7 +164,8 @@ func (v *ClusterCustomValidator) ValidateDelete(_ context.Context, obj runtime.O
 	if !ok {
 		return nil, fmt.Errorf("expected a Cluster object but got %T", obj)
 	}
-	clusterLog.Info("Validation for Cluster upon deletion", "name", cluster.GetName(), "namespace", cluster.GetNamespace())
+	clusterLog.Info("Validation for Cluster upon deletion", "name", cluster.GetName(), "namespace",
+		cluster.GetNamespace())
 
 	// TODO(user): fill in your validation logic upon object deletion.
 
@@ -954,12 +957,12 @@ func (v *ClusterCustomValidator) validateConfiguration(r *apiv1.Cluster) field.E
 		// validateImageName function
 		return result
 	}
-	if pgVersion.Major() < 12 {
+	if pgVersion.Major() < 13 {
 		result = append(result,
 			field.Invalid(
 				field.NewPath("spec", "imageName"),
 				r.Spec.ImageName,
-				"Unsupported PostgreSQL version. Versions 12 or newer are supported"))
+				"Unsupported PostgreSQL version. Versions 13 or newer are supported"))
 	}
 	info := postgres.ConfigurationInfo{
 		Settings:               postgres.CnpgConfigurationSettings,

--- a/internal/webhook/v1/cluster_webhook_test.go
+++ b/internal/webhook/v1/cluster_webhook_test.go
@@ -1030,6 +1030,23 @@ var _ = Describe("configuration change validation", func() {
 		Expect(v.validateConfiguration(cluster)).To(HaveLen(1))
 	})
 
+	It("rejects PostgreSQL version lower than 13", func() {
+		v := &ClusterCustomValidator{}
+
+		cluster := &apiv1.Cluster{
+			Spec: apiv1.ClusterSpec{
+				ImageName: "postgres:12",
+			},
+		}
+
+		result := v.validateConfiguration(cluster)
+
+		Expect(result).To(HaveLen(1))
+		Expect(result[0].Field).To(Equal("spec.imageName"))
+		Expect(result[0].Detail).To(ContainSubstring("Unsupported PostgreSQL version"))
+		Expect(result[0].Detail).To(ContainSubstring("Versions 13 or newer are supported"))
+	})
+
 	It("should disallow changing wal_level to minimal for existing clusters", func() {
 		oldCluster := &apiv1.Cluster{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/management/postgres/logpipe/logpipe_test.go
+++ b/pkg/management/postgres/logpipe/logpipe_test.go
@@ -57,22 +57,6 @@ var _ = Describe("CSV file reader", func() {
 			Expect(spy.records).To(HaveLen(2))
 		})
 
-		It("can read multiple CSV lines on PostgreSQL version <= 12", func(ctx SpecContext) {
-			f, err := os.Open("testdata/two_lines_12.csv")
-			defer func() {
-				_ = f.Close()
-			}()
-			Expect(err).ToNot(HaveOccurred())
-
-			spy := SpyRecordWriter{}
-			p := LogPipe{
-				record:          &LoggingRecord{},
-				fieldsValidator: LogFieldValidator,
-			}
-			Expect(p.streamLogFromCSVFile(ctx, f, &spy)).To(Succeed())
-			Expect(spy.records).To(HaveLen(2))
-		})
-
 		It("can read multiple CSV lines on PostgreSQL version == 14", func(ctx SpecContext) {
 			f, err := os.Open("testdata/two_lines_14.csv")
 			defer func() {

--- a/pkg/management/postgres/logpipe/testdata/two_lines_12.csv
+++ b/pkg/management/postgres/logpipe/testdata/two_lines_12.csv
@@ -1,2 +1,0 @@
-2021-05-10 06:25:24.239 UTC,,,9298,,601c20b5.2452,61853,,2021-02-04 16:28:37 UTC,,0,LOG,00000,"checkpoint starting: time",,,,,,,,,""
-2021-05-10 06:25:30.200 UTC,,,9298,,601c20b5.2452,61854,,2021-02-04 16:28:37 UTC,,0,LOG,00000,"checkpoint complete: wrote 59 buffers (0.0%); 0 WAL file(s) added, 0 removed, 1 recycled; write=5.937 s, sync=0.004 s, total=5.961 s; sync files=7, longest=0.002 s, average=0.000 s; distance=16415 kB, estimate=16910 kB",,,,,,,,,""

--- a/pkg/management/postgres/probes_test.go
+++ b/pkg/management/postgres/probes_test.go
@@ -93,13 +93,6 @@ var _ = Describe("probes", func() {
 	})
 
 	Context("Fill basebackup stats", func() {
-		It("does nothing in case of that major version is less than 13 ", func() {
-			instance := &Instance{
-				pgVersion: &semver.Version{Major: 12},
-			}
-			Expect(instance.fillBasebackupStats(nil, nil)).To(Succeed())
-		})
-
 		It("set the information", func() {
 			instance := (&Instance{
 				pgVersion: &semver.Version{Major: 13},

--- a/pkg/postgres/configuration.go
+++ b/pkg/postgres/configuration.go
@@ -475,64 +475,52 @@ var (
 	CnpgConfigurationSettings = ConfigurationSettings{
 		GlobalDefaultSettings: SettingsCollection{
 			"archive_timeout":            "5min",
+			"dynamic_shared_memory_type": "posix",
 			"full_page_writes":           "on",
-			"max_parallel_workers":       "32",
-			"max_worker_processes":       "32",
-			"max_replication_slots":      "32",
 			"logging_collector":          "on",
 			"log_destination":            "csvlog",
+			"log_directory":              LogPath,
+			"log_filename":               LogFileName,
 			"log_rotation_age":           "0",
 			"log_rotation_size":          "0",
 			"log_truncate_on_rotation":   "false",
-			"log_directory":              LogPath,
-			"log_filename":               LogFileName,
-			"dynamic_shared_memory_type": "posix",
-			"wal_sender_timeout":         "5s",
-			"wal_receiver_timeout":       "5s",
+			"max_parallel_workers":       "32",
+			"max_worker_processes":       "32",
+			"max_replication_slots":      "32",
+			"shared_memory_type":         "mmap",
+			"ssl_max_protocol_version":   "TLSv1.3",
+			"ssl_min_protocol_version":   "TLSv1.3",
+			"wal_keep_size":              "512MB",
 			"wal_level":                  "logical",
 			ParameterWalLogHints:         "on",
+			"wal_sender_timeout":         "5s",
+			"wal_receiver_timeout":       "5s",
 			// Workaround for PostgreSQL not behaving correctly when
 			// a default value is not explicit in the postgresql.conf and
 			// the parameter cannot be changed without a restart.
 			SharedPreloadLibraries: "",
 		},
-		DefaultSettings: map[VersionRange]SettingsCollection{
-			{MajorVersionRangeUnlimited, version.New(12, 0)}: {
-				"wal_keep_segments": "32",
-			},
-			{version.New(12, 0), version.New(13, 0)}: {
-				"wal_keep_segments":  "32",
-				"shared_memory_type": "mmap",
-			},
-			{version.New(13, 0), MajorVersionRangeUnlimited}: {
-				"wal_keep_size":      "512MB",
-				"shared_memory_type": "mmap",
-			},
-			{version.New(12, 0), MajorVersionRangeUnlimited}: {
-				"ssl_max_protocol_version": "TLSv1.3",
-				"ssl_min_protocol_version": "TLSv1.3",
-			},
-		},
 		MandatorySettings: SettingsCollection{
-			"listen_addresses":        "*",
-			"unix_socket_directories": SocketDirectory,
-			"hot_standby":             "true",
 			"archive_command": fmt.Sprintf(
 				"/controller/manager wal-archive --log-destination %s/%s.json %%p",
 				LogPath, LogFileName),
-			"port":                fmt.Sprint(ServerPort),
-			"ssl":                 "on",
-			"ssl_cert_file":       ServerCertificateLocation,
-			"ssl_key_file":        ServerKeyLocation,
-			"ssl_ca_file":         ClientCACertificateLocation,
-			"restart_after_crash": "false",
+			"hot_standby":             "true",
+			"listen_addresses":        "*",
+			"port":                    fmt.Sprint(ServerPort),
+			"restart_after_crash":     "false",
+			"ssl":                     "on",
+			"ssl_cert_file":           ServerCertificateLocation,
+			"ssl_key_file":            ServerKeyLocation,
+			"ssl_ca_file":             ClientCACertificateLocation,
+			"unix_socket_directories": SocketDirectory,
 		},
 	}
 )
 
 // CreateHBARules will create the content of pg_hba.conf file given
 // the rules set by the cluster spec
-func CreateHBARules(hba []string,
+func CreateHBARules(
+	hba []string,
 	defaultAuthenticationMethod, ldapConfigString string,
 ) (string, error) {
 	var hbaContent bytes.Buffer

--- a/pkg/postgres/configuration_test.go
+++ b/pkg/postgres/configuration_test.go
@@ -83,19 +83,6 @@ var _ = Describe("PostgreSQL configuration creation", func() {
 		Expect(confFile).To(ContainSubstring("log_destination = 'stderr'\nshared_buffers = '128KB'\n"))
 	})
 
-	When("version is 10", func() {
-		It("will use appropriate settings", func() {
-			info := ConfigurationInfo{
-				Settings:           CnpgConfigurationSettings,
-				Version:            version.New(10, 0),
-				UserSettings:       settings,
-				IncludingMandatory: true,
-			}
-			config := CreatePostgresqlConfiguration(info)
-			Expect(config.GetConfig("wal_keep_segments")).To(Equal("32"))
-		})
-	})
-
 	When("version is 13", func() {
 		It("will use appropriate settings", func() {
 			info := ConfigurationInfo{

--- a/tests/e2e/replication_slot_test.go
+++ b/tests/e2e/replication_slot_test.go
@@ -73,13 +73,6 @@ var _ = Describe("Replication Slot", Label(tests.LabelReplication), func() {
 			}, 10, 2).Should(BeTrue())
 		})
 
-		if env.PostgresVersion == 11 {
-			// We need to take into account the fact that on PostgreSQL 11
-			// it is required to rolling restart the cluster to
-			// enable or disable the feature once the cluster is created.
-			AssertClusterRollingRestart(namespace, clusterName)
-		}
-
 		By("checking Primary HA slots exist and are active", func() {
 			primaryPod, err := clusterutils.GetPrimary(env.Ctx, env.Client, namespace, clusterName)
 			Expect(err).ToNot(HaveOccurred())
@@ -166,13 +159,6 @@ var _ = Describe("Replication Slot", Label(tests.LabelReplication), func() {
 				return cluster.Spec.ReplicationSlots.GetEnabled(), nil
 			}, 10, 2).Should(BeFalse())
 		})
-
-		if env.PostgresVersion == 11 {
-			// We need to take into account the fact that on PostgreSQL 11
-			// it is required to rolling restart the cluster to
-			// enable or disable the feature once the cluster is created.
-			AssertClusterRollingRestart(namespace, clusterName)
-		}
 
 		By("verifying slots have been removed from the cluster's pods", func() {
 			pods, err := clusterutils.ListPods(env.Ctx, env.Client, namespace, clusterName)


### PR DESCRIPTION
Drop conditional logic specific to PostgreSQL 12 and previous versions which have reached end-of-life and are already out of support.

Closes #7395
