### PR TITLE
feat(instance): liveness probe isolation checker

### DIFF
--- a/docs/src/instance_manager.md
+++ b/docs/src/instance_manager.md
@@ -229,6 +229,7 @@ metadata:
   annotations:
     alpha.cnpg.io/livenessPinger: '{"enabled": true,"requestTimeout":1000,"connectionTimeout":1000}'
 ```
+
 ## Readiness Probe
 
 The readiness probe starts once the startup probe has successfully completed.

--- a/docs/src/instance_manager.md
+++ b/docs/src/instance_manager.md
@@ -210,7 +210,7 @@ metadata:
 
 !!! Warning
     This feature is experimental and will be introduced in a future CloudNativePG
-    release with a new API. If you decide to use it now, note that the API **might
+    release with a new API. If you decide to use it now, note that the API **will
     change**.
 
 !!! Important
@@ -219,11 +219,16 @@ metadata:
     be aggressive (30 seconds). As such, we recommend explicitly setting the
     liveness probe configuration to suit your environment.
 
-!!! Note
-    The annotation also accepts two optional network settings: `requestTimeout`
-    and `connectionTimeout`, both defaulting to `500` (in milliseconds).
-    In cloud environments, you may need to increase these values.
+The annotation also accepts two optional network settings: `requestTimeout`
+and `connectionTimeout`, both defaulting to `500` (in milliseconds).
+In cloud environments, you may need to increase these values.
+For example:
 
+```yaml
+metadata:
+  annotations:
+    alpha.cnpg.io/livenessPinger: '{"enabled": true,"requestTimeout":1000,"connectionTimeout":1000}'
+```
 ## Readiness Probe
 
 The readiness probe starts once the startup probe has successfully completed.

--- a/docs/src/instance_manager.md
+++ b/docs/src/instance_manager.md
@@ -188,6 +188,42 @@ spec:
       failureThreshold: 10
 ```
 
+### Primary Isolation (alpha)
+
+CloudNativePG 1.26 introduces an opt-in experimental behavior for the liveness
+probe of a PostgreSQL primary, which will report a failure if **both** of the
+following conditions are met:
+
+1. The instance manager cannot reach the Kubernetes API server
+2. The instance manager cannot reach **any** other instance via the instance manager’s REST API
+
+The effect of this behavior is to consider an isolated primary to be not alive and subsequently **shut it down** when the liveness probe fails.
+
+It is **disabled by default** and can be enabled by adding the following
+annotation to the `Cluster` resource:
+
+```yaml
+metadata:
+  annotations:
+    alpha.cnpg.io/livenessPinger: '{"enabled": true}'
+```
+
+!!! Warning
+    This feature is experimental and will be introduced in a future CloudNativePG
+    release with a new API. If you decide to use it now, note that the API **might
+    change**.
+
+!!! Important
+    If you plan to enable this experimental feature, be aware that the default
+    liveness probe settings—automatically derived from `livenessProbeTimeout`—might
+    be aggressive (30 seconds). As such, we recommend explicitly setting the
+    liveness probe configuration to suit your environment.
+
+!!! Note
+    The annotation also accepts two optional network settings: `requestTimeout`
+    and `connectionTimeout`, both defaulting to `500` (in milliseconds).
+    In cloud environments, you may need to increase these values.
+
 ## Readiness Probe
 
 The readiness probe starts once the startup probe has successfully completed.

--- a/internal/webhook/v1/cluster_webhook_test.go
+++ b/internal/webhook/v1/cluster_webhook_test.go
@@ -5089,3 +5089,43 @@ var _ = Describe("validatePluginConfiguration", func() {
 		Expect(v.validatePluginConfiguration(cluster)).To(BeNil())
 	})
 })
+
+var _ = Describe("", func() {
+	var v *ClusterCustomValidator
+	BeforeEach(func() {
+		v = &ClusterCustomValidator{}
+	})
+
+	It("returns no errors if the liveness pinger annotation is not present", func() {
+		cluster := &apiv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{},
+			},
+		}
+		Expect(v.validateLivenessPingerProbe(cluster)).To(BeNil())
+	})
+
+	It("returns no errors if the liveness pinger annotation is valid", func() {
+		cluster := &apiv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					utils.LivenessPingerAnnotationName: `{"connectionTimeout": 1000, "requestTimeout": 5000, "enabled": true}`,
+				},
+			},
+		}
+		Expect(v.validateLivenessPingerProbe(cluster)).To(BeNil())
+	})
+
+	It("returns an error if the liveness pinger annotation is invalid", func() {
+		cluster := &apiv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					utils.LivenessPingerAnnotationName: `{"requestTimeout": 5000}`,
+				},
+			},
+		}
+		errs := v.validateLivenessPingerProbe(cluster)
+		Expect(errs).To(HaveLen(1))
+		Expect(errs[0].Error()).To(ContainSubstring("error decoding liveness pinger config"))
+	})
+})

--- a/pkg/certs/tls.go
+++ b/pkg/certs/tls.go
@@ -57,9 +57,18 @@ func newTLSConfigFromSecret(
 	// for the <cluster>-rw service, which would cause a name verification error.
 	caCertPool := x509.NewCertPool()
 	caCertPool.AppendCertsFromPEM(caCertificate)
+
+	return NewTLSConfigFromCertPool(caCertPool), nil
+}
+
+// NewTLSConfigFromCertPool creates a tls.Config object from X509 cert pool
+// containing the expected server CA
+func NewTLSConfigFromCertPool(
+	certPool *x509.CertPool,
+) *tls.Config {
 	tlsConfig := tls.Config{
 		MinVersion:         tls.VersionTLS13,
-		RootCAs:            caCertPool,
+		RootCAs:            certPool,
 		InsecureSkipVerify: true, //#nosec G402 -- we are verifying the certificate ourselves
 		VerifyPeerCertificate: func(rawCerts [][]byte, _ [][]*x509.Certificate) error {
 			// Code adapted from https://go.dev/src/crypto/tls/handshake_client.go#L986
@@ -77,7 +86,7 @@ func newTLSConfigFromSecret(
 			}
 
 			opts := x509.VerifyOptions{
-				Roots:         caCertPool,
+				Roots:         certPool,
 				Intermediates: x509.NewCertPool(),
 			}
 
@@ -93,7 +102,7 @@ func newTLSConfigFromSecret(
 		},
 	}
 
-	return &tlsConfig, nil
+	return &tlsConfig
 }
 
 // NewTLSConfigForContext creates a tls.config with the provided data and returns an expanded context that contains

--- a/pkg/management/postgres/webserver/probes/liveness.go
+++ b/pkg/management/postgres/webserver/probes/liveness.go
@@ -143,12 +143,12 @@ func evaluateLivenessPinger(
 ) error {
 	contextLogger := log.FromContext(ctx)
 
-	cfg, err := newLivenessPingerConfigFromCluster(ctx, cluster)
+	cfg, err := NewLivenessPingerConfigFromAnnotations(ctx, cluster.Annotations)
 	if err != nil {
 		return err
 	}
-	if cfg == nil || !cfg.Enabled {
-		contextLogger.Debug("pinger config not found in the cluster annotations, skipping")
+	if !cfg.isEnabled() {
+		contextLogger.Debug("pinger config not enabled, skipping")
 		return nil
 	}
 

--- a/pkg/management/postgres/webserver/probes/liveness.go
+++ b/pkg/management/postgres/webserver/probes/liveness.go
@@ -104,6 +104,8 @@ func (e *livenessExecutor) IsHealthy(
 		return
 	}
 
+	contextLogger = contextLogger.WithValues("apiServerReachable", false)
+
 	if e.lastestKnownCluster == nil {
 		// We were never able to download a cluster definition. This should not
 		// happen because we check the API server connectivity as soon as the
@@ -112,8 +114,7 @@ func (e *livenessExecutor) IsHealthy(
 		// To be safe, we classify this instance manager to be not isolated and
 		// postpone any decision to a later liveness probe call.
 		contextLogger.Warning(
-			"The API server is not reachable and no cluster definition has been received, " +
-				"skipping automatic shutdown.")
+			"No cluster definition has been received, skipping automatic shutdown.")
 
 		_, _ = fmt.Fprint(w, "OK")
 		return

--- a/pkg/management/postgres/webserver/probes/liveness.go
+++ b/pkg/management/postgres/webserver/probes/liveness.go
@@ -1,0 +1,180 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package probes
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/cloudnative-pg/machinery/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres"
+)
+
+type livenessExecutor struct {
+	cli      client.Client
+	instance *postgres.Instance
+
+	lastestKnownCluster *apiv1.Cluster
+}
+
+// NewLivenessChecker creates a new instance of the liveness probe checker
+func NewLivenessChecker(
+	cli client.Client,
+	instance *postgres.Instance,
+) Checker {
+	return &livenessExecutor{
+		cli:      cli,
+		instance: instance,
+	}
+}
+
+func (e *livenessExecutor) IsHealthy(
+	ctx context.Context,
+	w http.ResponseWriter,
+) {
+	contextLogger := log.FromContext(ctx)
+
+	isPrimary, err := e.instance.IsPrimary()
+	if err != nil {
+		contextLogger.Error(
+			err,
+			"Error while checking the instance role, skipping automatic shutdown.")
+		_, _ = fmt.Fprint(w, "OK")
+		return
+	}
+
+	if !isPrimary {
+		// There's no need to restart a replica if isolated
+		_, _ = fmt.Fprint(w, "OK")
+		return
+	}
+
+	var cluster apiv1.Cluster
+	err = e.cli.Get(
+		ctx,
+		client.ObjectKey{Namespace: e.instance.GetNamespaceName(), Name: e.instance.GetClusterName()},
+		&cluster,
+	)
+	if err == nil {
+		// We were able to reach the API server. Everything is right.
+		_, _ = fmt.Fprint(w, "OK")
+
+		// Even if we reach this point concurrently, assignment is an atomic
+		// operation and it would not represent a problem.
+		e.lastestKnownCluster = &cluster
+
+		// We correctly reached the API server but, as a failsafe measure, we
+		// exercise the rechability checker and leave a log message if something
+		// is not right.
+		// In this way a network configuration problem can be discovered as
+		// quickly as possible.
+		e.reachabilityCheckerExercise(ctx, &cluster)
+
+		return
+	}
+
+	e.isHealthyWithCluster(ctx, w, e.lastestKnownCluster)
+}
+
+func (e *livenessExecutor) isHealthyWithCluster(
+	ctx context.Context,
+	w http.ResponseWriter,
+	cluster *apiv1.Cluster,
+) {
+	contextLogger := log.FromContext(ctx)
+
+	if cluster == nil {
+		// We were never able to download a cluster definition. This should not
+		// happen because we check the API server connectivity as soon as the
+		// instance manager starts, before starting the probe web server.
+		//
+		// To be safe, we classify this instance manager to be not isolated and
+		// postpone any decision to a later liveness probe call.
+		contextLogger.Warning(
+			"The API server is not reachable and no cluster definition has been received, " +
+				"skipping automatic shutdown.")
+
+		_, _ = fmt.Fprint(w, "OK")
+		return
+	}
+
+	if cluster.Spec.Instances == 1 {
+		// There will be just one instance, and it will be not possible to have
+		// two primaries at the same time.
+		contextLogger.Warning(
+			"The API server is not reachable in a single-instance cluster, " +
+				"skipping automatic shutdown.")
+
+		_, _ = fmt.Fprint(w, "OK")
+		return
+	}
+
+	// We are isolated from the API server. We use the failsafe entrypoint to
+	// check if we're isolated from the other PG instances too.
+	contextLogger.Warning(
+		"The API server is not reachable, triggering instance connectivity check")
+	if err := e.ensureInstancesAreReachable(ctx, cluster); err != nil {
+		contextLogger.Error(err, "Instance connectivity error - liveness probe failing")
+		http.Error(
+			w,
+			fmt.Sprintf("liveness check failed: %s", err.Error()),
+			http.StatusInternalServerError,
+		)
+		return
+	}
+
+	contextLogger.Info(
+		"Instance connectivity test succeeded - liveness probe succeeding",
+		"latestKnownInstancesReportedState", e.lastestKnownCluster.Status.InstancesReportedState,
+	)
+
+	_, _ = fmt.Fprint(w, "OK")
+}
+
+func (e *livenessExecutor) reachabilityCheckerExercise(ctx context.Context, cluster *apiv1.Cluster) {
+	contextLogger := log.FromContext(ctx)
+
+	if err := e.ensureInstancesAreReachable(ctx, cluster); err != nil {
+		contextLogger.Warning("Instances connectivity test failed, skipping", "err", err)
+		return
+	}
+}
+
+func (e *livenessExecutor) ensureInstancesAreReachable(ctx context.Context, cluster *apiv1.Cluster) error {
+	pingerCfg := pingerConfigFromCluster(ctx, cluster)
+	checker, err := newInstanceReachabilityChecker(pingerCfg)
+	if err != nil {
+		return err
+	}
+
+	for name, state := range cluster.Status.InstancesReportedState {
+		host := string(name)
+		ip := state.IP
+		if err := checker.ping(host, ip); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/management/postgres/webserver/probes/pinger.go
+++ b/pkg/management/postgres/webserver/probes/pinger.go
@@ -75,11 +75,8 @@ func NewLivenessPingerConfigFromAnnotations(
 	v, ok := annotations[utils.LivenessPingerAnnotationName]
 	if !ok {
 		contextLogger.Debug("pinger config not found in the cluster annotations")
-		// TODO: remove, needed to run all E2E
 		return &LivenessPingerCfg{
-			Enabled:           ptr.To(true),
-			RequestTimeout:    defaultRequestTimeout,
-			ConnectionTimeout: defaultConnectionTimeout,
+			Enabled: ptr.To(false),
 		}, nil
 	}
 

--- a/pkg/management/postgres/webserver/probes/pinger.go
+++ b/pkg/management/postgres/webserver/probes/pinger.go
@@ -57,7 +57,7 @@ func (probe *LivenessPingerCfg) isEnabled() bool {
 }
 
 // NewLivenessPingerConfigFromAnnotations creates a new pinger configuration from the annotations
-// in the passed cluster definition
+// in the cluster definition
 func NewLivenessPingerConfigFromAnnotations(
 	ctx context.Context,
 	annotations map[string]string,
@@ -93,9 +93,11 @@ func NewLivenessPingerConfigFromAnnotations(
 		return nil, fmt.Errorf("pinger config is missing the enabled field")
 	}
 
+	cfg.RequestTimeout = cfg.RequestTimeout * time.Millisecond
 	if cfg.RequestTimeout == 0 {
 		cfg.RequestTimeout = defaultRequestTimeout
 	}
+	cfg.ConnectionTimeout = cfg.ConnectionTimeout * time.Millisecond
 	if cfg.ConnectionTimeout == 0 {
 		cfg.ConnectionTimeout = defaultConnectionTimeout
 	}

--- a/pkg/management/postgres/webserver/probes/pinger.go
+++ b/pkg/management/postgres/webserver/probes/pinger.go
@@ -1,0 +1,178 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package probes
+
+import (
+	"context"
+	"crypto/x509"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/certs"
+	cnpgUrl "github.com/cloudnative-pg/cloudnative-pg/pkg/management/url"
+	postgresSpec "github.com/cloudnative-pg/cloudnative-pg/pkg/postgres"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
+)
+
+const (
+	// defaultRequestTimeout is the default value of the request timeout
+	defaultRequestTimeout = 500 * time.Millisecond
+
+	// defaultConnectionTimeout is the default value of the connection timeout
+	defaultConnectionTimeout = 1000 * time.Millisecond
+)
+
+// pingerCfg if the configuration of the instance
+// reachability checker
+type pingerCfg struct {
+	requestTimeout    time.Duration
+	connectionTimeout time.Duration
+}
+
+// pingerConfigFromCluster creates a new pinger configuration from the annotations
+// in the passed cluster definition
+func pingerConfigFromCluster(ctx context.Context, cluster *apiv1.Cluster) pingerCfg {
+	contextLogger := log.FromContext(ctx)
+
+	timeoutFromAnnotation := func(name string, defaultValue time.Duration) time.Duration {
+		if value, ok := cluster.Annotations[name]; ok {
+			parsedValue, parserErr := strconv.ParseInt(value, 10, 64)
+			if parserErr != nil {
+				contextLogger.Info(
+					"Wrong annotation value, using defaut value",
+					"parserErr", parserErr,
+					"name", name,
+					"value", value,
+					"default", defaultValue)
+				return defaultValue
+			}
+
+			return time.Duration(parsedValue) * time.Millisecond
+		}
+
+		return defaultValue
+	}
+
+	return pingerCfg{
+		requestTimeout:    timeoutFromAnnotation(utils.PingerRequestTimeoutAnnotationName, defaultRequestTimeout),
+		connectionTimeout: timeoutFromAnnotation(utils.PingerConnectionTimeoutAnnotationName, defaultConnectionTimeout),
+	}
+}
+
+// pinger can check if a certain instance is reachable by using
+// the failsafe REST endpoint
+type pinger struct {
+	dialer *net.Dialer
+	client *http.Client
+
+	config pingerCfg
+}
+
+// newInstanceReachabilityChecker creates a new instance reachability checker by loading
+// the server CA certificate from the same location that will be used by PostgreSQL.
+// In this case, we avoid using the API Server as it may be unreliable.
+func newInstanceReachabilityChecker(
+	cfg pingerCfg,
+) (*pinger, error) {
+	certificateLocation := postgresSpec.ServerCACertificateLocation
+	caCertificate, err := os.ReadFile(certificateLocation) //nolint:gosec
+	if err != nil {
+		return nil, fmt.Errorf("while reading server CA certificate [%s]: %w", certificateLocation, err)
+	}
+
+	caCertPool := x509.NewCertPool()
+	caCertPool.AppendCertsFromPEM(caCertificate)
+
+	tlsConfig := certs.NewTLSConfigFromCertPool(caCertPool)
+
+	dialer := &net.Dialer{Timeout: cfg.connectionTimeout}
+
+	client := http.Client{
+		Transport: &http.Transport{
+			DialContext:     dialer.DialContext,
+			TLSClientConfig: tlsConfig,
+		},
+		Timeout: cfg.requestTimeout,
+	}
+
+	return &pinger{
+		dialer: dialer,
+		client: &client,
+		config: cfg,
+	}, nil
+}
+
+// ping checks if the instance with the passed coordinates is reachable
+// by calling the failsafe endpoint.
+func (e *pinger) ping(host, ip string) error {
+	failsafeURL := url.URL{
+		Scheme: "https",
+		Host:   fmt.Sprintf("%s:%d", ip, cnpgUrl.StatusPort),
+		Path:   cnpgUrl.PathFailSafe,
+	}
+
+	var res *http.Response
+	var err error
+	if res, err = e.client.Get(failsafeURL.String()); err != nil {
+		return &pingError{
+			host:   host,
+			err:    err,
+			config: e.config,
+		}
+	}
+
+	_ = res.Body.Close()
+
+	return nil
+}
+
+// pingError is raised when the instance connectivity test failed.
+type pingError struct {
+	host string
+	ip   string
+
+	config pingerCfg
+
+	err error
+}
+
+// Error implements the error interface
+func (e *pingError) Error() string {
+	return fmt.Sprintf(
+		"instance connectivity error for instance [%s] with ip [%s] (requestTimeout:%v connectionTimeout:%v): %s",
+		e.host,
+		e.ip,
+		e.config.requestTimeout,
+		e.config.connectionTimeout,
+		e.err.Error())
+}
+
+// Unwrap implements the error interface
+func (e *pingError) Unwrap() error {
+	return e.err
+}

--- a/pkg/management/postgres/webserver/remote.go
+++ b/pkg/management/postgres/webserver/remote.go
@@ -66,7 +66,7 @@ type remoteWebserverEndpoints struct {
 	instance             *postgres.Instance
 	currentBackup        *backupConnection
 	ongoingBackupRequest sync.Mutex
-
+	// livenessChecker is a  stateful probe
 	livenessChecker probes.Checker
 }
 

--- a/pkg/management/postgres/webserver/remote.go
+++ b/pkg/management/postgres/webserver/remote.go
@@ -66,6 +66,8 @@ type remoteWebserverEndpoints struct {
 	instance             *postgres.Instance
 	currentBackup        *backupConnection
 	ongoingBackupRequest sync.Mutex
+
+	livenessChecker probes.Checker
 }
 
 // StartBackupRequest the required data to execute the pg_start_backup
@@ -97,11 +99,13 @@ func NewRemoteWebServer(
 	}
 
 	endpoints := remoteWebserverEndpoints{
-		typedClient: typedClient,
-		instance:    instance,
+		typedClient:     typedClient,
+		instance:        instance,
+		livenessChecker: probes.NewLivenessChecker(typedClient, instance),
 	}
 
 	serveMux := http.NewServeMux()
+	serveMux.HandleFunc(url.PathFailSafe, endpoints.failSafe)
 	serveMux.HandleFunc(url.PathPgModeBackup, endpoints.backup)
 	serveMux.HandleFunc(url.PathHealth, endpoints.isServerHealthy)
 	serveMux.HandleFunc(url.PathReady, endpoints.isServerReady)
@@ -222,8 +226,14 @@ func (ws *remoteWebserverEndpoints) isServerStartedUp(w http.ResponseWriter, req
 	checker.IsHealthy(req.Context(), w)
 }
 
-func (ws *remoteWebserverEndpoints) isServerHealthy(w http.ResponseWriter, _ *http.Request) {
+// This is the failsafe entrypoint
+func (ws *remoteWebserverEndpoints) failSafe(w http.ResponseWriter, _ *http.Request) {
 	_, _ = fmt.Fprint(w, "OK")
+}
+
+// This is the failsafe probe
+func (ws *remoteWebserverEndpoints) isServerHealthy(w http.ResponseWriter, req *http.Request) {
+	ws.livenessChecker.IsHealthy(req.Context(), w)
 }
 
 // This is the readiness probe

--- a/pkg/management/url/url.go
+++ b/pkg/management/url/url.go
@@ -34,6 +34,9 @@ const (
 	// PgBouncerMetricsPort is the port for the exporter of PgBouncer related metrics (HTTP)
 	PgBouncerMetricsPort int32 = 9127
 
+	// PathFailSafe is the path for the failsafe entrypoint
+	PathFailSafe string = "/failsafe"
+
 	// PathHealth is the URL path for Health State
 	PathHealth string = "/healthz"
 

--- a/pkg/utils/labels_annotations.go
+++ b/pkg/utils/labels_annotations.go
@@ -110,13 +110,8 @@ const (
 	// to have them detected as CNPG-i plugins
 	PluginNameLabelName = MetadataNamespace + "/pluginName"
 
-	// PingerRequestTimeoutAnnotationName is the name of the annotation containing
-	// the request timeout in milliseconds for the isolation tester. Defaults to 500.
-	PingerRequestTimeoutAnnotationName = AlphaMetadataNamespace + "/pingerRequestTimeout"
-
-	// PingerConnectionTimeoutAnnotationName is the name of the annotation containing
-	// the connection timeout in milliseconds for the isolation tester. Defaults to 1000.
-	PingerConnectionTimeoutAnnotationName = AlphaMetadataNamespace + "/pingerConnectionTimeout"
+	// LivenessPingerAnnotationName is the name of the pinger configuration
+	LivenessPingerAnnotationName = AlphaMetadataNamespace + "/livenessPinger"
 )
 
 const (

--- a/pkg/utils/labels_annotations.go
+++ b/pkg/utils/labels_annotations.go
@@ -116,7 +116,7 @@ const (
 
 	// PingerConnectionTimeoutAnnotationName is the name of the annotation containing
 	// the connection timeout in milliseconds for the isolation tester. Defaults to 1000.
-	PingerConnectionTimeoutAnnotationName = AlphaMetadataNamespace + "/pingerRequestTimeout"
+	PingerConnectionTimeoutAnnotationName = AlphaMetadataNamespace + "/pingerConnectionTimeout"
 )
 
 const (

--- a/pkg/utils/labels_annotations.go
+++ b/pkg/utils/labels_annotations.go
@@ -30,6 +30,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+// AlphaMetadataNamespace is the annotation and label namespace used by the alpha features of
+// the operator
+const AlphaMetadataNamespace = "alpha.cnpg.io"
+
 // MetadataNamespace is the annotation and label namespace used by the operator
 const MetadataNamespace = "cnpg.io"
 
@@ -105,6 +109,14 @@ const (
 	// PluginNameLabelName is the name of the label to be applied to services
 	// to have them detected as CNPG-i plugins
 	PluginNameLabelName = MetadataNamespace + "/pluginName"
+
+	// PingerRequestTimeoutAnnotationName is the name of the annotation containing
+	// the request timeout in milliseconds for the isolation tester. Defaults to 500.
+	PingerRequestTimeoutAnnotationName = AlphaMetadataNamespace + "/pingerRequestTimeout"
+
+	// PingerConnectionTimeoutAnnotationName is the name of the annotation containing
+	// the connection timeout in milliseconds for the isolation tester. Defaults to 1000.
+	PingerConnectionTimeoutAnnotationName = AlphaMetadataNamespace + "/pingerRequestTimeout"
 )
 
 const (

--- a/tests/e2e/fixtures/self-fencing/cluster-self-fencing.yaml.template
+++ b/tests/e2e/fixtures/self-fencing/cluster-self-fencing.yaml.template
@@ -1,0 +1,27 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: postgresql-self-fencing
+  annotations:
+    alpha.cnpg.io/livenessPinger: '{"enabled": true}'
+spec:
+  instances: 3
+
+  postgresql:
+    parameters:
+      max_connections: "110"
+      log_checkpoints: "on"
+      log_lock_waits: "on"
+      log_min_duration_statement: '1000'
+      log_statement: 'ddl'
+      log_temp_files: '1024'
+      log_autovacuum_min_duration: '1s'
+      log_replication_commands: 'on'
+
+  # Persistent storage configuration
+  storage:
+    storageClass: ${E2E_DEFAULT_STORAGE_CLASS}
+    size: 1Gi
+  walStorage:
+    storageClass: ${E2E_DEFAULT_STORAGE_CLASS}
+    size: 1Gi

--- a/tests/e2e/self_fencing_test.go
+++ b/tests/e2e/self_fencing_test.go
@@ -1,0 +1,140 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package e2e
+
+import (
+	"fmt"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/specs"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
+	"github.com/cloudnative-pg/cloudnative-pg/tests"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/clusterutils"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/operator"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/run"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/timeouts"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/yaml"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Self-fencing with liveness probe", Serial, Label(tests.LabelDisruptive), func() {
+	const (
+		level           = tests.Lowest
+		sampleFile      = fixturesDir + "/self-fencing/cluster-self-fencing.yaml.template"
+		namespacePrefix = "self-fencing"
+	)
+
+	BeforeEach(func() {
+		if testLevelEnv.Depth < int(level) {
+			Skip("Test depth is lower than the amount requested for this test")
+		}
+		if !IsLocal() {
+			Skip("This test is only run on local cluster")
+		}
+	})
+
+	It("will terminate an isolated primary", func() {
+		var namespace, clusterName, isolatedNode string
+		var err error
+		var oldPrimaryPod *corev1.Pod
+
+		DeferCleanup(func() {
+			// Ensure the isolatedNode networking is re-established
+			if CurrentSpecReport().Failed() {
+				_, _, _ = run.Unchecked(fmt.Sprintf("docker network connect kind %v", isolatedNode))
+			}
+		})
+
+		By("creating a Cluster", func() {
+			clusterName, err = yaml.GetResourceNameFromYAML(env.Scheme, sampleFile)
+			Expect(err).ToNot(HaveOccurred())
+			namespace, err = env.CreateUniqueTestNamespace(env.Ctx, env.Client, namespacePrefix)
+			Expect(err).ToNot(HaveOccurred())
+			AssertCreateCluster(namespace, clusterName, sampleFile, env)
+		})
+
+		By("setting up the environment", func() {
+			// Ensure the operator is not running on the same node as the primary.
+			// If it is, we switch to a new primary
+			primaryPod, err := clusterutils.GetPrimary(env.Ctx, env.Client, namespace, clusterName)
+			Expect(err).ToNot(HaveOccurred())
+			operatorPod, err := operator.GetPod(env.Ctx, env.Client)
+			Expect(err).NotTo(HaveOccurred())
+			if primaryPod.Spec.NodeName == operatorPod.Spec.NodeName {
+				AssertSwitchover(namespace, clusterName, env)
+			}
+		})
+
+		By("disconnecting the node containing the primary", func() {
+			oldPrimaryPod, err = clusterutils.GetPrimary(env.Ctx, env.Client, namespace, clusterName)
+			Expect(err).ToNot(HaveOccurred())
+			isolatedNode = oldPrimaryPod.Spec.NodeName
+			_, _, err = run.Unchecked(fmt.Sprintf("docker network disconnect kind %v", isolatedNode))
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		By("verifying that a new primary has been promoted", func() {
+			AssertClusterEventuallyReachesPhase(namespace, clusterName,
+				[]string{apiv1.PhaseFailOver}, 120)
+			Eventually(func(g Gomega) {
+				cluster, err := clusterutils.Get(env.Ctx, env.Client, namespace, clusterName)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(cluster.Status.CurrentPrimary).ToNot(BeEquivalentTo(oldPrimaryPod.Name))
+			}, testTimeouts[timeouts.NewPrimaryAfterFailover]).Should(Succeed())
+		})
+
+		By("verifying that oldPrimary will self isolate", func() {
+			// Assert that the oldPrimary is eventually terminated
+			Eventually(func(g Gomega) {
+				out, _, err := run.Unchecked(fmt.Sprintf(
+					"docker exec %v crictl ps -a --namespace %v --name postgres -s Exited -q",
+					isolatedNode, namespace))
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(out).ToNot(BeEmpty())
+				if out != "" {
+					GinkgoWriter.Printf("Container %s has been terminated\n", strings.TrimSpace(out))
+				}
+			}, 120).Should(Succeed())
+		})
+
+		By("reconnecting the isolated Node", func() {
+			_, _, err = run.Unchecked(fmt.Sprintf("docker network connect kind %v", isolatedNode))
+			Expect(err).ToNot(HaveOccurred())
+
+			// Assert that the oldPrimary comes back as a replica
+			namespacedName := types.NamespacedName{
+				Namespace: oldPrimaryPod.Namespace,
+				Name:      oldPrimaryPod.Name,
+			}
+			timeout := 180
+			Eventually(func() (bool, error) {
+				pod := corev1.Pod{}
+				err := env.Client.Get(env.Ctx, namespacedName, &pod)
+				return utils.IsPodActive(pod) && utils.IsPodReady(pod) && specs.IsPodStandby(pod), err
+			}, timeout).Should(BeTrue())
+		})
+	})
+})

--- a/tests/e2e/self_fencing_test.go
+++ b/tests/e2e/self_fencing_test.go
@@ -110,12 +110,14 @@ var _ = Describe("Self-fencing with liveness probe", Serial, Label(tests.LabelDi
 			// Assert that the oldPrimary is eventually terminated
 			Eventually(func(g Gomega) {
 				out, _, err := run.Unchecked(fmt.Sprintf(
-					"docker exec %v crictl ps -a --namespace %v --name postgres -s Exited -q",
-					isolatedNode, namespace))
+					"docker exec %v crictl ps -a "+
+						"--label io.kubernetes.pod.namespace=%s,io.kubernetes.pod.name=%s "+
+						"--name postgres -s Exited -q", isolatedNode, namespace, oldPrimaryPod.Name))
 				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(out).ToNot(BeEmpty())
 				if out != "" {
-					GinkgoWriter.Printf("Container %s has been terminated\n", strings.TrimSpace(out))
+					GinkgoWriter.Printf("Container %s (%s) has been terminated\n",
+						oldPrimaryPod.Name, strings.TrimSpace(out))
 				}
 			}, 120).Should(Succeed())
 		})


### PR DESCRIPTION
Enhances the liveness probe logic for primary instances in HA clusters to detect network isolation scenarios.

The probe first checks if the Pod can reach the API server. If the API server is unreachable, it then attempts to contact peer PostgreSQL instances in the same cluster via a REST entrypoint.

If neither the API server nor any replicas are reachable, the liveness probe fails, prompting Kubernetes to restart the Pod.

Upon restart, the instance manager will refuse to start PostgreSQL, as it cannot download the Cluster definition—preventing unsafe behavior in isolated environments.

This behavior applies only to primary instances in clusters with HA replicas.

Closes: #7465 