### PR TITLE
fix(cnpg-plugin): Primary start time

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -48,6 +48,7 @@ body:
       label: Version
       description: What is the version of CloudNativePG you are running?
       options:
+        - "1.26.0-rc2"            
         - "1.26.0-rc1"      
         - "1.25 (latest patch)"
         - "1.24 (latest patch)"

--- a/internal/cmd/plugin/status/status.go
+++ b/internal/cmd/plugin/status/status.go
@@ -280,7 +280,7 @@ func (fullStatus *PostgresqlStatus) printBasicInfo(ctx context.Context, k8sClien
 		// Avoid printing the start time when hibernated or fenced
 		primaryStartTime := getPrimaryStartTime(cluster)
 		if len(primaryStartTime) > 0 {
-			summary.AddLine("Primary start time:", primaryStartTime)
+			summary.AddLine("Primary promotion time:", primaryStartTime)
 		}
 		summary.AddLine("Status:", fullStatus.getStatus(cluster))
 	}


### PR DESCRIPTION
fixes #7428

Change the status output from "Primary start time" to "Primary promotion time"

Signed-off-by: Daniel Chambre <smiyc@pm.me>