### PR TITLE
docs:  add OpenBao as OSS alternative to Vault

### DIFF
--- a/.wordlist-en-custom.txt
+++ b/.wordlist-en-custom.txt
@@ -25,6 +25,7 @@ AzureCredentials
 AzurePVCUpdateEnabled
 Azurite
 BDR
+BUSL
 BackupCapabilities
 BackupConfiguration
 BackupFrom
@@ -285,6 +286,7 @@ OngoingSnapshotBackups
 OnlineConfiguration
 OnlineUpdateEnabled
 OnlineUpgrading
+OpenBao
 OpenID
 OpenSSL
 OpenShift

--- a/docs/src/cncf-projects/external-secrets.md
+++ b/docs/src/cncf-projects/external-secrets.md
@@ -149,11 +149,12 @@ password.
 
 ## Example: Integration with an External KMS
 
-A widely used Key Management Service (KMS) provider in the CNCF ecosystem is
-[HashiCorp Vault](https://www.vaultproject.io/). While Hashicorp Vault itself is
-under a BUSL license, there is an actively maintained, fully compatible open source
-project called [Open Bao](https://openbao.org/). All the interfaces supported by
-Hashicorp Vault are also supported by Open Bao, so this is a drop in replacement.
+One of the most widely used Key Management Service (KMS) providers in the CNCF
+ecosystem is [HashiCorp Vault](https://www.vaultproject.io/). Although Vault is
+licensed under the Business Source License (BUSL), a fully compatible and
+actively maintained open source alternative is available: [OpenBao](https://openbao.org/).
+OpenBao supports all the same interfaces as HashiCorp Vault, making it a true
+drop-in replacement.
 
 In this example, we'll demonstrate how to integrate CloudNativePG,
 External Secrets Operator, and HashiCorp Vault to automatically rotate

--- a/docs/src/cncf-projects/external-secrets.md
+++ b/docs/src/cncf-projects/external-secrets.md
@@ -150,7 +150,10 @@ password.
 ## Example: Integration with an External KMS
 
 A widely used Key Management Service (KMS) provider in the CNCF ecosystem is
-[HashiCorp Vault](https://www.vaultproject.io/).
+[HashiCorp Vault](https://www.vaultproject.io/). While Hashicorp Vault itself is
+under a BUSL license, there is an actively maintained, fully compatible open source
+project called [Open Bao](https://openbao.org/). All the interfaces supported by
+Hashicorp Vault are also supported by Open Bao, so this is a drop in replacement.
 
 In this example, we'll demonstrate how to integrate CloudNativePG,
 External Secrets Operator, and HashiCorp Vault to automatically rotate


### PR DESCRIPTION
Hashicorp Vault, though commonly used, does have a restrictive, BUSL license that most organizations cannot use.

Adding mention to https://openbao.org , which is MPL, thus really open source for users :smile: 