### PR TITLE
fix(cnpg-plugin): Primary start time

### DIFF
--- a/internal/cmd/plugin/status/status.go
+++ b/internal/cmd/plugin/status/status.go
@@ -280,7 +280,7 @@ func (fullStatus *PostgresqlStatus) printBasicInfo(ctx context.Context, k8sClien
 		// Avoid printing the start time when hibernated or fenced
 		primaryStartTime := getPrimaryStartTime(cluster)
 		if len(primaryStartTime) > 0 {
-			summary.AddLine("Primary start time:", primaryStartTime)
+			summary.AddLine("Primary promotion time:", primaryStartTime)
 		}
 		summary.AddLine("Status:", fullStatus.getStatus(cluster))
 	}


### PR DESCRIPTION
fixes #7428

Change the status output from "Primary start time" to "Primary promotion time"

Signed-off-by: Daniel Chambre <smiyc@pm.me>