### PR TITLE
fix: fail fast during WAL archiving on primary demotion

### DIFF
--- a/pkg/management/postgres/wal.go
+++ b/pkg/management/postgres/wal.go
@@ -37,7 +37,7 @@ var errNoWalArchivePresent = errors.New("no wal-archive present")
 // On primary, it could run even before the first WAL has completed. For this reason it
 // could require a WAL switch, to quicken the check.
 // On standby, the mere existence of the standby guarantees that a WAL file has already been generated
-// by the pg_basebakup used to prime the standby data directory, so we check only if the WAL
+// by the pg_basebackup used to prime the standby data directory, so we check only if the WAL
 // archive process is not failing.
 func ensureWalArchiveIsWorking(instance *Instance) error {
 	isPrimary, err := instance.IsPrimary()
@@ -46,7 +46,7 @@ func ensureWalArchiveIsWorking(instance *Instance) error {
 	}
 
 	if isPrimary {
-		return newWalArchiveBootstrapperForPrimary().ensureFirstWalArchived(retryUntilWalArchiveWorking)
+		return newWalArchiveBootstrapperForPrimary().ensureFirstWalArchived(instance, retryUntilWalArchiveWorking)
 	}
 
 	return newWalArchiveAnalyzerForReplicaInstance(instance.GetPrimaryConnInfo()).
@@ -146,8 +146,18 @@ func newWalArchiveBootstrapperForPrimary() *walArchiveBootstrapper {
 	}
 }
 
-func (w *walArchiveBootstrapper) ensureFirstWalArchived(backoff wait.Backoff) error {
-	return retry.OnError(backoff, resources.RetryAlways, func() error {
+var errPrimaryDemoted = errors.New("primary was demoted while waiting for the first wal-archive")
+
+func (w *walArchiveBootstrapper) ensureFirstWalArchived(instance *Instance, backoff wait.Backoff) error {
+	return retry.OnError(backoff, func(err error) bool { return !errors.Is(err, errPrimaryDemoted) }, func() error {
+		isPrimary, err := instance.IsPrimary()
+		if err != nil {
+			return fmt.Errorf("error checking primary: %w", err)
+		}
+		if !isPrimary {
+			return errPrimaryDemoted
+		}
+
 		db, err := w.dbFactory()
 		if err != nil {
 			return err


### PR DESCRIPTION
This patch addresses an issue where the primary server, when unexpectedly demoted during an initial WAL archiving check, would attempt an impossible WAL switch for up to 10 minutes. The updated logic in the ensureFirstWalArchived function now gracefully detects demotion and terminates the operation early, improving reliability and backup efficiency.

Closes #7482

# Release notes

```
If the primary server is unexpectedly demoted, fail fast during WAL archiving checks, avoiding unnecessary retries and improving backup efficiency.
```