### PR TITLE
ci(security): implement least privilege for GitHub Workflows

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -40,9 +40,6 @@ jobs:
   duplicate_runs:
     runs-on: ubuntu-24.04
     name: Skip duplicate runs
-    permissions:
-      actions: write
-      contents: read
     continue-on-error: true
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip == 'true' && github.ref != 'refs/heads/main' }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -58,7 +58,6 @@ jobs:
       fail-fast: false
       matrix:
         branch: [release-1.22, release-1.24, release-1.25]
-
     steps:
       - name: Invoke workflow with inputs
         uses: benc-uk/workflow-dispatch@e2e5e9a103e331dad343f381a29e654aea3cf8fc # v1
@@ -72,9 +71,6 @@ jobs:
   duplicate_runs:
     runs-on: ubuntu-24.04
     name: Skip duplicate runs
-    permissions:
-      actions: write
-      contents: read
     continue-on-error: true
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip == 'true' && github.ref != 'refs/heads/main' }}

--- a/.github/workflows/registry-clean.yml
+++ b/.github/workflows/registry-clean.yml
@@ -11,6 +11,8 @@ env:
   IMAGE_NAME: "cloudnative-pg-testing"
   CONTAINER_IMAGE_NAMES: "pgbouncer-testing, postgresql-testing, postgis-testing"
 
+permissions: read-all
+
 jobs:
   clean-ghcr:
     name: delete old testing container images

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -2,9 +2,7 @@
 
 name: release-pr
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: read-all
 
 on:
   push:
@@ -14,6 +12,9 @@ on:
 jobs:
   pull-request:
     runs-on: ubuntu-24.04
+    permissions:
+      pull-requests: write
+      contents: write
     steps:
       -
         name: Checkout

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -8,14 +8,14 @@ on:
       - main
   workflow_dispatch:
 
-permissions:
-  security-events: write
-  contents: read
+permissions: read-all
 
 jobs:
   security:
     name: Security scan
     runs-on: ubuntu-24.04
+    permissions:
+      security-events: write
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4


### PR DESCRIPTION
Add some missing permissions in the previous PR related. 
Default read permissions for registry-clean.yml
Default read permissions for release-pr.yml

Closes #7252 