### PR TITLE
feat: in-tree barman-cloud support deprecation notice

### DIFF
--- a/internal/webhook/v1/cluster_webhook.go
+++ b/internal/webhook/v1/cluster_webhook.go
@@ -2335,9 +2335,9 @@ func (v *ClusterCustomValidator) validatePgFailoverSlots(r *apiv1.Cluster) field
 
 func (v *ClusterCustomValidator) getAdmissionWarnings(r *apiv1.Cluster) admission.Warnings {
 	list := getMaintenanceWindowsAdmissionWarnings(r)
-	list = append(list, getSharedBuffersWarnings(r)...)
 	list = append(list, getInTreeBarmanWarnings(r)...)
-	return append(list, getRetentionPolicyWarnings(r)...)
+	list = append(list, getRetentionPolicyWarnings(r)...)
+	return append(list, getSharedBuffersWarnings(r)...)
 }
 
 func getInTreeBarmanWarnings(r *apiv1.Cluster) admission.Warnings {

--- a/internal/webhook/v1/cluster_webhook_test.go
+++ b/internal/webhook/v1/cluster_webhook_test.go
@@ -5130,7 +5130,7 @@ var _ = Describe("", func() {
 	})
 })
 
-var _ = Describe("getBarmanWarnings", func() {
+var _ = Describe("getInTreeBarmanWarnings", func() {
 	It("returns no warnings when BarmanObjectStore is not configured", func() {
 		cluster := &apiv1.Cluster{
 			Spec: apiv1.ClusterSpec{
@@ -5138,7 +5138,7 @@ var _ = Describe("getBarmanWarnings", func() {
 				ExternalClusters: nil,
 			},
 		}
-		Expect(getBarmanWarnings(cluster)).To(BeEmpty())
+		Expect(getInTreeBarmanWarnings(cluster)).To(BeEmpty())
 	})
 
 	It("returns a warning when BarmanObjectStore is configured in backup", func() {
@@ -5149,7 +5149,7 @@ var _ = Describe("getBarmanWarnings", func() {
 				},
 			},
 		}
-		warnings := getBarmanWarnings(cluster)
+		warnings := getInTreeBarmanWarnings(cluster)
 		Expect(warnings).To(HaveLen(1))
 		Expect(warnings[0]).To(ContainSubstring("spec.backup.barmanObjectStore"))
 	})
@@ -5163,7 +5163,7 @@ var _ = Describe("getBarmanWarnings", func() {
 				},
 			},
 		}
-		warnings := getBarmanWarnings(cluster)
+		warnings := getInTreeBarmanWarnings(cluster)
 		Expect(warnings).To(HaveLen(1))
 		Expect(warnings[0]).To(ContainSubstring("spec.externalClusters.0.barmanObjectStore"))
 		Expect(warnings[0]).To(ContainSubstring("spec.externalClusters.1.barmanObjectStore"))
@@ -5180,9 +5180,38 @@ var _ = Describe("getBarmanWarnings", func() {
 				},
 			},
 		}
-		warnings := getBarmanWarnings(cluster)
+		warnings := getInTreeBarmanWarnings(cluster)
 		Expect(warnings).To(HaveLen(1))
 		Expect(warnings[0]).To(ContainSubstring("spec.backup.barmanObjectStore"))
 		Expect(warnings[0]).To(ContainSubstring("spec.externalClusters.0.barmanObjectStore"))
+	})
+})
+
+var _ = Describe("getRetentionPolicyWarnings", func() {
+	It("returns no warnings if the retention policy is used with the in-tree backup support", func() {
+		cluster := &apiv1.Cluster{
+			Spec: apiv1.ClusterSpec{
+				Backup: &apiv1.BackupConfiguration{
+					RetentionPolicy:   "this retention policy",
+					BarmanObjectStore: &apiv1.BarmanObjectStoreConfiguration{},
+				},
+			},
+		}
+
+		warnings := getRetentionPolicyWarnings(cluster)
+		Expect(warnings).To(BeEmpty())
+	})
+
+	It("return a warning when retention policies are declared and not used", func() {
+		cluster := &apiv1.Cluster{
+			Spec: apiv1.ClusterSpec{
+				Backup: &apiv1.BackupConfiguration{
+					RetentionPolicy: "this retention policy",
+				},
+			},
+		}
+
+		warnings := getRetentionPolicyWarnings(cluster)
+		Expect(warnings).To(HaveLen(1))
 	})
 })


### PR DESCRIPTION
The admission webhook warns when the in-tree Barman Cloud support is used in a cluster definition, advising the user to try the plugin.

Additionally, the admission webhook now emits a warning when the retentionPolicy field is specified without an associated in-tree Barman Cloud configuration.

Closes #7065 