### PR TITLE
fix: don't fail on missing wal in plugin wal restore

### DIFF
--- a/internal/cmd/manager/walrestore/cmd.go
+++ b/internal/cmd/manager/walrestore/cmd.go
@@ -107,6 +107,7 @@ func NewCmd() *cobra.Command {
 }
 
 func run(ctx context.Context, pgData string, podName string, args []string) error {
+	// FIXME: logs here are not shown to the user
 	contextLog := log.FromContext(ctx)
 	startTime := time.Now()
 	walName := args[0]
@@ -123,7 +124,7 @@ func run(ctx context.Context, pgData string, podName string, args []string) erro
 
 	walFound, err := restoreWALViaPlugins(ctx, cluster, walName, path.Join(pgData, destinationPath))
 	if err != nil {
-		return err
+		contextLog.Trace("could not restore WAL via plugins", "wal", walName, "error", err)
 	}
 	if walFound {
 		return nil

--- a/internal/cmd/manager/walrestore/cmd.go
+++ b/internal/cmd/manager/walrestore/cmd.go
@@ -72,6 +72,8 @@ func NewCmd() *cobra.Command {
 		SilenceErrors: true,
 		Args:          cobra.ExactArgs(2),
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
+			// TODO: The command is triggered by PG, resulting in the loss of stdout logs.
+			// TODO: We need to implement a logpipe to prevent this.
 			contextLog := log.WithName("wal-restore")
 			ctx := log.IntoContext(cobraCmd.Context(), contextLog)
 			err := run(ctx, pgData, podName, args)
@@ -107,7 +109,6 @@ func NewCmd() *cobra.Command {
 }
 
 func run(ctx context.Context, pgData string, podName string, args []string) error {
-	// FIXME: logs here are not shown to the user
 	contextLog := log.FromContext(ctx)
 	startTime := time.Now()
 	walName := args[0]
@@ -124,16 +125,14 @@ func run(ctx context.Context, pgData string, podName string, args []string) erro
 
 	walFound, err := restoreWALViaPlugins(ctx, cluster, walName, path.Join(pgData, destinationPath))
 	if err != nil {
-		// With the current implementation, this happens when both the
-		// following conditions are met:
+		// With the current implementation, this happens when both of the following conditions are met:
 		//
-		// 1. at least one CNPG-i plugin implementing the WAL service exists
-		// 2. no plugin was able to restore the WAL file because:
-		//   - the requested WAL was not found or
-		//   - the plugin failed restoring it
+		// 1. At least one CNPG-i plugin that implements the WAL service is present.
+		// 2. No plugin can restore the WAL file because:
+		//   a) The requested WAL could not be found
+		//   b) The plugin failed in the restoration process.
 		//
-		// When this happens, walFound is false and we fall back
-		// to the in-tree barman-cloud support.
+		// When this happens, `walFound` is false, prompting us to revert to the in-tree barman-cloud support.
 		contextLog.Trace("could not restore WAL via plugins", "wal", walName, "error", err)
 	}
 	if walFound {


### PR DESCRIPTION
Fix a problem where, if the plugins could not find a wal using the plugins defined in the cluster, the restore command would exit with an error, without trying to use the in-tree barmanObjectStore.

Closes #7499 