### PR TITLE
chore(golangci): migrate to golangci-lint v2

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -19,7 +19,7 @@ permissions: read-all
 # set up environment variables to be used across all the jobs
 env:
   GOLANG_VERSION: "1.24.x"
-  GOLANGCI_LINT_VERSION: "v1.64.8"
+  GOLANGCI_LINT_VERSION: "v2.1.6"
   KUBEBUILDER_VERSION: "2.3.1"
   KIND_VERSION: "v0.27.0"
   OPERATOR_IMAGE_NAME: "ghcr.io/${{ github.repository }}-testing"
@@ -162,7 +162,7 @@ jobs:
           check-latest: true
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6
+        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8
         with:
           version: ${{ env.GOLANGCI_LINT_VERSION }}
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,45 +1,25 @@
-linters-settings:
-  lll:
-    line-length: 120
-  gci:
-    sections:
-      - standard
-      - default
-      - prefix(github.com/cloudnative-pg/cloudnative-pg)
-      - blank
-      - dot
-  gosec:
-    excludes:
-      - G101 # remove this exclude when https://github.com/securego/gosec/issues/1001 is fixed
-
+version: "2"
 linters:
-  # please, do not use `enable-all`: it's deprecated and will be removed soon.
-  # inverted configuration with `enable-all` and `disable` is not scalable during updates of golangci-lint
-  disable-all: true
+  default: none
   enable:
     - asciicheck
     - bodyclose
+    - copyloopvar
     - dogsled
     - dupl
     - durationcheck
     - errcheck
-    - copyloopvar
-    - gci
+    - ginkgolinter
     - gocognit
     - goconst
     - gocritic
     - gocyclo
-    - gofmt
-    - gofumpt
     - goheader
-    - goimports
     - gomoddirectives
     - gomodguard
     - goprintffuncname
     - gosec
-    - gosimple
     - govet
-    - ginkgolinter
     - importas
     - ineffassign
     - lll
@@ -53,78 +33,64 @@ linters:
     - rowserrcheck
     - sqlclosecheck
     - staticcheck
-    - stylecheck
     - thelper
     - tparallel
-    - typecheck
     - unconvert
     - unparam
     - unused
     - wastedassign
     - whitespace
-
-  # to be checked:
-  # - errorlint
-  # - forbidigo
-  # - forcetypeassert
-  # - goerr113
-  # - ifshort
-  # - nilerr
-  # - nlreturn
-  # - noctx
-  # - nolintlint
-  # - paralleltest
-  # - promlinter
-  # - tagliatelle
-  # - wrapcheck
-
-  # don't enable:
-  # - cyclop
-  # - depguard
-  # - exhaustive
-  # - exhaustivestruct
-  # - funlen
-  # - gochecknoglobals
-  # - gochecknoinits
-  # - godot
-  # - godox
-  # - gomnd
-  # - testpackage
-  # - wsl
-
-  # deprecated:
-  # - deadcode
-  # - golint
-  # - interfacer
-  # - maligned
-  # - scopelint
-  # - structcheck
-  # - varcheck
-
-run:
-  timeout: 5m
-
-issues:
-  exclude-rules:
-    # Allow dot imports for ginkgo and gomega
-    - source: ginkgo|gomega
-      linters:
-      - revive
-      text: "should not use dot imports"
-    # Exclude some linters from running on tests files.
-    - path: _test\.go
-      linters:
-        - goconst
-    # Exclude lll issues for lines with long annotations
-    - linters:
-      - lll
-      source: "//\\s*\\+"
-    # We have no control of this in zz_generated files and it looks like that excluding those files is not enough
-    # so we disable "ST1016: methods on the same type should have the same receiver name" in api directory
-    - linters:
-      - stylecheck
-      text: "ST1016:"
-      path: api/
-  exclude-use-default: false
-  exclude-files:
-    - zz_generated.*
+  settings:
+    gosec:
+      excludes:
+        - G101
+    staticcheck:
+      checks:
+        - all
+        - '-QF1001'
+        - '-QF1007'
+    lll:
+      line-length: 120
+  exclusions:
+    generated: lax
+    rules:
+      - linters:
+          - revive
+        text: should not use dot imports
+        source: ginkgo|gomega
+      - linters:
+          - goconst
+        path: _test\.go
+      - linters:
+          - lll
+        source: //\s*\+
+      - linters:
+          - staticcheck
+        path: api/
+        text: 'ST1016:'
+    paths:
+      - zz_generated.*
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gci
+    - gofmt
+    - gofumpt
+    - goimports
+  settings:
+    gci:
+      sections:
+        - standard
+        - default
+        - prefix(github.com/cloudnative-pg/cloudnative-pg)
+        - blank
+        - dot
+  exclusions:
+    generated: lax
+    paths:
+      - zz_generated.*
+      - third_party$
+      - builtin$
+      - examples$

--- a/api/v1/backup_funcs.go
+++ b/api/v1/backup_funcs.go
@@ -194,7 +194,7 @@ func (list *BackupList) SortByName() {
 func (list *BackupList) SortByReverseCreationTime() {
 	// Sort the list of backups in reverse creation time
 	sort.Slice(list.Items, func(i, j int) bool {
-		return list.Items[i].CreationTimestamp.Time.Compare(list.Items[j].CreationTimestamp.Time) > 0
+		return list.Items[i].CreationTimestamp.Compare(list.Items[j].CreationTimestamp.Time) > 0
 	})
 }
 

--- a/api/v1/base_funcs.go
+++ b/api/v1/base_funcs.go
@@ -34,7 +34,7 @@ func SecretKeySelectorToCore(selector *SecretKeySelector) *corev1.SecretKeySelec
 
 	return &corev1.SecretKeySelector{
 		LocalObjectReference: corev1.LocalObjectReference{
-			Name: selector.LocalObjectReference.Name,
+			Name: selector.Name,
 		},
 		Key: selector.Key,
 	}

--- a/api/v1/cluster_funcs.go
+++ b/api/v1/cluster_funcs.go
@@ -1261,7 +1261,7 @@ func (cluster *Cluster) GetServerCASecretObjectKey() types.NamespacedName {
 // is configured, false otherwise
 func (backupConfiguration *BackupConfiguration) IsBarmanBackupConfigured() bool {
 	return backupConfiguration != nil && backupConfiguration.BarmanObjectStore != nil &&
-		backupConfiguration.BarmanObjectStore.BarmanCredentials.ArePopulated()
+		backupConfiguration.BarmanObjectStore.ArePopulated()
 }
 
 // IsBarmanEndpointCASet returns true if we have a CA bundle for the endpoint

--- a/internal/cmd/manager/walrestore/cmd.go
+++ b/internal/cmd/manager/walrestore/cmd.go
@@ -353,9 +353,9 @@ func GetRecoverConfiguration(
 			return "", nil, nil, ErrNoBackupConfigured
 		}
 		configuration := externalCluster.BarmanObjectStore
-		if configuration.EndpointCA != nil && configuration.BarmanCredentials.AWS != nil {
+		if configuration.EndpointCA != nil && configuration.AWS != nil {
 			env = append(env, fmt.Sprintf("AWS_CA_BUNDLE=%s", postgres.BarmanRestoreEndpointCACertificateLocation))
-		} else if configuration.EndpointCA != nil && configuration.BarmanCredentials.Azure != nil {
+		} else if configuration.EndpointCA != nil && configuration.Azure != nil {
 			env = append(env, fmt.Sprintf("REQUESTS_CA_BUNDLE=%s", postgres.BarmanRestoreEndpointCACertificateLocation))
 		}
 		return externalCluster.Name, env, externalCluster.BarmanObjectStore, nil
@@ -365,9 +365,9 @@ func GetRecoverConfiguration(
 	// back up this cluster
 	if cluster.Spec.Backup != nil && cluster.Spec.Backup.BarmanObjectStore != nil {
 		configuration := cluster.Spec.Backup.BarmanObjectStore
-		if configuration.EndpointCA != nil && configuration.BarmanCredentials.AWS != nil {
+		if configuration.EndpointCA != nil && configuration.AWS != nil {
 			env = append(env, fmt.Sprintf("AWS_CA_BUNDLE=%s", postgres.BarmanBackupEndpointCACertificateLocation))
-		} else if configuration.EndpointCA != nil && configuration.BarmanCredentials.Azure != nil {
+		} else if configuration.EndpointCA != nil && configuration.Azure != nil {
 			env = append(env, fmt.Sprintf("REQUESTS_CA_BUNDLE=%s", postgres.BarmanBackupEndpointCACertificateLocation))
 		}
 		return cluster.Name, env, cluster.Spec.Backup.BarmanObjectStore, nil

--- a/internal/cmd/plugin/status/status.go
+++ b/internal/cmd/plugin/status/status.go
@@ -358,7 +358,7 @@ func (fullStatus *PostgresqlStatus) printHibernationInfo() {
 		hibernationStatus.AddLine("Status", "Active")
 	}
 	hibernationStatus.AddLine("Message", hibernationCondition.Message)
-	hibernationStatus.AddLine("Time", hibernationCondition.LastTransitionTime.Time.UTC())
+	hibernationStatus.AddLine("Time", hibernationCondition.LastTransitionTime.UTC())
 
 	fmt.Println(aurora.Green("Hibernation"))
 	hibernationStatus.Print()

--- a/internal/cnpi/plugin/mapping.go
+++ b/internal/cnpi/plugin/mapping.go
@@ -38,7 +38,7 @@ const (
 )
 
 // ToOperationType_Type converts an OperationVerb into a lifecycle.OperationType_Type
-// nolint: revive,stylecheck
+// nolint: revive,staticcheck
 func (o OperationVerb) ToOperationType_Type() (lifecycle.OperatorOperationType_Type, error) {
 	switch o {
 	case OperationVerbPatch:

--- a/internal/controller/backup_predicates.go
+++ b/internal/controller/backup_predicates.go
@@ -73,7 +73,7 @@ func (r *BackupReconciler) mapClustersToBackup() handler.MapFunc {
 			return nil
 		}
 		var backups apiv1.BackupList
-		err := r.Client.List(ctx, &backups,
+		err := r.List(ctx, &backups,
 			client.MatchingFields{
 				backupPhase: apiv1.BackupPhaseRunning,
 			},

--- a/internal/controller/cluster_controller_test.go
+++ b/internal/controller/cluster_controller_test.go
@@ -266,7 +266,7 @@ var _ = Describe("Updating target primary", func() {
 		By("checking that the third instance exists even if the cluster has two instances", func() {
 			var expectedPod corev1.Pod
 			instanceName := specs.GetInstanceName(cluster.Name, 3)
-			err := env.clusterReconciler.Client.Get(ctx, types.NamespacedName{
+			err := env.clusterReconciler.Get(ctx, types.NamespacedName{
 				Name:      instanceName,
 				Namespace: cluster.Namespace,
 			}, &expectedPod)

--- a/internal/controller/cluster_create_test.go
+++ b/internal/controller/cluster_create_test.go
@@ -185,13 +185,13 @@ var _ = Describe("cluster_create unit tests", func() {
 				svc.Spec.Selector = map[string]string{
 					"outdated": "selector",
 				}
-				err := env.clusterReconciler.Client.Create(ctx, svc)
+				err := env.clusterReconciler.Create(ctx, svc)
 				Expect(err).ToNot(HaveOccurred())
 			}
 
 			checkService := func(before *corev1.Service, expectedLabels map[string]string) {
 				var afterChangesService corev1.Service
-				err := env.clusterReconciler.Client.Get(ctx, types.NamespacedName{
+				err := env.clusterReconciler.Get(ctx, types.NamespacedName{
 					Name:      before.Name,
 					Namespace: before.Namespace,
 				}, &afterChangesService)
@@ -309,7 +309,7 @@ var _ = Describe("cluster_create unit tests", func() {
 
 		By("executing createOrPatchServiceAccount (patch)", func() {
 			By("setting owner reference to nil", func() {
-				sa.ObjectMeta.OwnerReferences = nil
+				sa.OwnerReferences = nil
 				err := env.client.Update(context.Background(), sa)
 				Expect(err).ToNot(HaveOccurred())
 			})
@@ -899,9 +899,9 @@ var _ = Describe("createOrPatchClusterCredentialSecret", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Assuming secretName is the name of the existing secret
-			proposed.ObjectMeta.Name = secretName
-			proposed.ObjectMeta.Labels = map[string]string{"old": "label"}
-			proposed.ObjectMeta.Annotations = map[string]string{"old": "annotation"}
+			proposed.Name = secretName
+			proposed.Labels = map[string]string{"old": "label"}
+			proposed.Annotations = map[string]string{"old": "annotation"}
 
 			err = createOrPatchClusterCredentialSecret(ctx, cli, proposed)
 			Expect(err).NotTo(HaveOccurred())
@@ -1007,7 +1007,7 @@ var _ = Describe("createOrPatchOwnedPodDisruptionBudget", func() {
 		})
 
 		It("should update the existing PodDisruptionBudget if the metadata is different", func() {
-			pdb.ObjectMeta.Labels["newlabel"] = "newvalue"
+			pdb.Labels["newlabel"] = "newvalue"
 			err = reconciler.createOrPatchOwnedPodDisruptionBudget(ctx, cluster, pdb)
 			Expect(err).ShouldNot(HaveOccurred())
 
@@ -1295,19 +1295,19 @@ var _ = Describe("Service Reconciling", func() {
 		It("should create the default services", func() {
 			err := reconciler.reconcilePostgresServices(ctx, &cluster)
 			Expect(err).NotTo(HaveOccurred())
-			err = reconciler.Client.Get(
+			err = reconciler.Get(
 				ctx,
 				types.NamespacedName{Name: cluster.GetServiceReadWriteName(), Namespace: cluster.Namespace},
 				&corev1.Service{},
 			)
 			Expect(err).ToNot(HaveOccurred())
-			err = reconciler.Client.Get(
+			err = reconciler.Get(
 				ctx,
 				types.NamespacedName{Name: cluster.GetServiceReadName(), Namespace: cluster.Namespace},
 				&corev1.Service{},
 			)
 			Expect(err).ToNot(HaveOccurred())
-			err = reconciler.Client.Get(
+			err = reconciler.Get(
 				ctx,
 				types.NamespacedName{Name: cluster.GetServiceReadOnlyName(), Namespace: cluster.Namespace},
 				&corev1.Service{},
@@ -1323,19 +1323,19 @@ var _ = Describe("Service Reconciling", func() {
 			}
 			err := reconciler.reconcilePostgresServices(ctx, &cluster)
 			Expect(err).NotTo(HaveOccurred())
-			err = reconciler.Client.Get(
+			err = reconciler.Get(
 				ctx,
 				types.NamespacedName{Name: cluster.GetServiceReadWriteName(), Namespace: cluster.Namespace},
 				&corev1.Service{},
 			)
 			Expect(apierrs.IsNotFound(err)).To(BeTrue())
-			err = reconciler.Client.Get(
+			err = reconciler.Get(
 				ctx,
 				types.NamespacedName{Name: cluster.GetServiceReadName(), Namespace: cluster.Namespace},
 				&corev1.Service{},
 			)
 			Expect(apierrs.IsNotFound(err)).To(BeTrue())
-			err = reconciler.Client.Get(
+			err = reconciler.Get(
 				ctx,
 				types.NamespacedName{Name: cluster.GetServiceReadOnlyName(), Namespace: cluster.Namespace},
 				&corev1.Service{},

--- a/internal/controller/cluster_delete_test.go
+++ b/internal/controller/cluster_delete_test.go
@@ -116,7 +116,7 @@ var _ = Describe("ensures that deleteDanglingMonitoringQueries works correctly",
 			cluster.Spec.Monitoring = &apiv1.MonitoringConfiguration{
 				DisableDefaultQueries: ptr.To(false),
 			}
-			err := crReconciler.Client.Update(context.Background(), cluster)
+			err := crReconciler.Update(context.Background(), cluster)
 			Expect(err).ToNot(HaveOccurred())
 		})
 

--- a/internal/controller/cluster_image.go
+++ b/internal/controller/cluster_image.go
@@ -154,7 +154,7 @@ func (r *ClusterReconciler) getRequestedImageInfo(
 
 	// Get the referenced catalog
 	catalogName := cluster.Spec.ImageCatalogRef.Name
-	err := r.Client.Get(ctx, types.NamespacedName{Namespace: cluster.Namespace, Name: catalogName}, catalog)
+	err := r.Get(ctx, types.NamespacedName{Namespace: cluster.Namespace, Name: catalogName}, catalog)
 	if err != nil {
 		if apierrs.IsNotFound(err) {
 			r.Recorder.Eventf(cluster, "Warning", "DiscoverImage", "Cannot get %v/%v",

--- a/internal/controller/cluster_restore.go
+++ b/internal/controller/cluster_restore.go
@@ -311,7 +311,7 @@ func getNodeSerialsFromPVCs(
 			highestSerial = serial
 		}
 
-		instanceRole, _ := utils.GetInstanceRole(pvc.ObjectMeta.Labels)
+		instanceRole, _ := utils.GetInstanceRole(pvc.Labels)
 		if instanceRole == specs.ClusterRoleLabelPrimary {
 			primarySerial = serial
 		}

--- a/internal/controller/cluster_upgrade.go
+++ b/internal/controller/cluster_upgrade.go
@@ -258,7 +258,7 @@ func (r *ClusterReconciler) updateRestartAnnotation(
 			primaryPod.Annotations = make(map[string]string)
 		}
 		primaryPod.Annotations[utils.ClusterRestartAnnotationName] = clusterRestart
-		if err := r.Client.Patch(ctx, &primaryPod, client.MergeFrom(original)); err != nil {
+		if err := r.Patch(ctx, &primaryPod, client.MergeFrom(original)); err != nil {
 			return err
 		}
 	}
@@ -398,7 +398,7 @@ func isPodNeedingRollout(
 
 // check if the pod has a valid podSpec
 func hasValidPodSpec(pod *corev1.Pod) bool {
-	podSpecAnnotation, hasStoredPodSpec := pod.ObjectMeta.Annotations[utils.PodSpecAnnotationName]
+	podSpecAnnotation, hasStoredPodSpec := pod.Annotations[utils.PodSpecAnnotationName]
 	if !hasStoredPodSpec {
 		return false
 	}
@@ -604,7 +604,7 @@ func checkPodSpecIsOutdated(
 	pod *corev1.Pod,
 	cluster *apiv1.Cluster,
 ) (rollout, error) {
-	podSpecAnnotation, ok := pod.ObjectMeta.Annotations[utils.PodSpecAnnotationName]
+	podSpecAnnotation, ok := pod.Annotations[utils.PodSpecAnnotationName]
 	if !ok {
 		return rollout{}, nil
 	}

--- a/internal/controller/cluster_upgrade_test.go
+++ b/internal/controller/cluster_upgrade_test.go
@@ -762,14 +762,14 @@ var _ = Describe("hasValidPodSpec", func() {
 			It("should return true", func() {
 				podSpec := &corev1.PodSpec{}
 				podSpecBytes, _ := json.Marshal(podSpec)
-				pod.ObjectMeta.Annotations[utils.PodSpecAnnotationName] = string(podSpecBytes)
+				pod.Annotations[utils.PodSpecAnnotationName] = string(podSpecBytes)
 				Expect(hasValidPodSpec(pod)).To(BeTrue())
 			})
 		})
 
 		Context("and the PodSpecAnnotation is invalid", func() {
 			It("should return false", func() {
-				pod.ObjectMeta.Annotations[utils.PodSpecAnnotationName] = "invalid JSON"
+				pod.Annotations[utils.PodSpecAnnotationName] = "invalid JSON"
 				Expect(hasValidPodSpec(pod)).To(BeFalse())
 			})
 		})
@@ -794,7 +794,7 @@ var _ = Describe("Cluster upgrade with podSpec reconciliation disabled", func() 
 	})
 
 	It("skips the rollout if the annotation that disables PodSpec reconciliation is set", func(ctx SpecContext) {
-		cluster.ObjectMeta.Annotations[utils.ReconcilePodSpecAnnotationName] = "disabled"
+		cluster.Annotations[utils.ReconcilePodSpecAnnotationName] = "disabled"
 
 		pod, err := specs.NewInstance(ctx, cluster, 1, true)
 		Expect(err).ToNot(HaveOccurred())

--- a/internal/controller/plugin_controller.go
+++ b/internal/controller/plugin_controller.go
@@ -233,7 +233,7 @@ func (r *PluginReconciler) mapSecretToPlugin(ctx context.Context, obj client.Obj
 	logger := log.FromContext(ctx)
 
 	var services corev1.ServiceList
-	if err := r.Client.List(
+	if err := r.List(
 		ctx,
 		&services,
 		client.HasLabels{utils.PluginNameLabelName},

--- a/internal/controller/pooler_update_test.go
+++ b/internal/controller/pooler_update_test.go
@@ -300,7 +300,7 @@ var _ = Describe("unit test of pooler_update reconciliation logic", func() {
 		pooler := newFakePooler(env.client, cluster)
 		res := &poolerManagedResources{Deployment: nil, Cluster: cluster}
 		By("setting the reconcilePodSpec annotation to disabled on the pooler ", func() {
-			pooler.ObjectMeta.Annotations[utils.ReconcilePodSpecAnnotationName] = "disabled"
+			pooler.Annotations[utils.ReconcilePodSpecAnnotationName] = "disabled"
 			pooler.Spec.Template = &apiv1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
 					TerminationGracePeriodSeconds: ptr.To(int64(100)),
@@ -347,7 +347,7 @@ var _ = Describe("unit test of pooler_update reconciliation logic", func() {
 		})
 
 		By("enable again, making sure pooler change updates the deployment", func() {
-			delete(pooler.ObjectMeta.Annotations, utils.ReconcilePodSpecAnnotationName)
+			delete(pooler.Annotations, utils.ReconcilePodSpecAnnotationName)
 			beforeDep := getPoolerDeployment(ctx, env.client, pooler)
 			pooler.Spec.Template.Spec.TerminationGracePeriodSeconds = ptr.To(int64(300))
 			err := env.poolerReconciler.updateDeployment(ctx, pooler, res)

--- a/internal/management/controller/database_controller.go
+++ b/internal/management/controller/database_controller.go
@@ -82,7 +82,7 @@ func (r *DatabaseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 
 	// Get the database object
 	var database apiv1.Database
-	if err := r.Client.Get(ctx, client.ObjectKey{
+	if err := r.Get(ctx, client.ObjectKey{
 		Namespace: req.Namespace,
 		Name:      req.Name,
 	}, &database); err != nil {

--- a/internal/management/controller/publication_controller.go
+++ b/internal/management/controller/publication_controller.go
@@ -69,7 +69,7 @@ func (r *PublicationReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 	// Get the publication object
 	var publication apiv1.Publication
-	if err := r.Client.Get(ctx, client.ObjectKey{
+	if err := r.Get(ctx, client.ObjectKey{
 		Namespace: req.Namespace,
 		Name:      req.Name,
 	}, &publication); err != nil {

--- a/internal/management/controller/roles/postgres.go
+++ b/internal/management/controller/roles/postgres.go
@@ -310,7 +310,7 @@ func appendInRoleOptions(role DatabaseRole, query *strings.Builder) {
 			quotedInRoles[i] = pgx.Identifier{inRole}.Sanitize()
 		}
 
-		query.WriteString(fmt.Sprintf(" IN ROLE %s ", strings.Join(quotedInRoles, ",")))
+		fmt.Fprintf(query, " IN ROLE %s ", strings.Join(quotedInRoles, ","))
 	}
 }
 
@@ -357,7 +357,7 @@ func appendRoleOptions(role DatabaseRole, query *strings.Builder) {
 		query.WriteString(" NOSUPERUSER")
 	}
 
-	query.WriteString(fmt.Sprintf(" CONNECTION LIMIT %d", role.ConnectionLimit))
+	fmt.Fprintf(query, " CONNECTION LIMIT %d", role.ConnectionLimit)
 }
 
 func appendPasswordOption(role DatabaseRole, query *strings.Builder) {
@@ -369,7 +369,7 @@ func appendPasswordOption(role DatabaseRole, query *strings.Builder) {
 	case !role.password.Valid:
 		query.WriteString(" PASSWORD NULL")
 	default:
-		query.WriteString(fmt.Sprintf(" PASSWORD %s", pq.QuoteLiteral(role.password.String)))
+		fmt.Fprintf(query, " PASSWORD %s", pq.QuoteLiteral(role.password.String))
 	}
 
 	if role.ValidUntil.Valid {
@@ -379,6 +379,6 @@ func appendPasswordOption(role DatabaseRole, query *strings.Builder) {
 		} else {
 			value = role.ValidUntil.InfinityModifier.String()
 		}
-		query.WriteString(fmt.Sprintf(" VALID UNTIL %s", pq.QuoteLiteral(value)))
+		fmt.Fprintf(query, " VALID UNTIL %s", pq.QuoteLiteral(value))
 	}
 }

--- a/internal/management/controller/subscription_controller.go
+++ b/internal/management/controller/subscription_controller.go
@@ -62,7 +62,7 @@ func (r *SubscriptionReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 	// Get the subscription object
 	var subscription apiv1.Subscription
-	if err := r.Client.Get(ctx, client.ObjectKey{
+	if err := r.Get(ctx, client.ObjectKey{
 		Namespace: req.Namespace,
 		Name:      req.Name,
 	}, &subscription); err != nil {

--- a/internal/plugin/resources/instance.go
+++ b/internal/plugin/resources/instance.go
@@ -62,7 +62,7 @@ func GetInstancePods(ctx context.Context, clusterName string) ([]corev1.Pod, cor
 	var managedPods []corev1.Pod
 	var primaryPod corev1.Pod
 	for idx := range pods.Items {
-		for _, owner := range pods.Items[idx].ObjectMeta.OwnerReferences {
+		for _, owner := range pods.Items[idx].OwnerReferences {
 			if owner.Kind == apiv1.ClusterKind && owner.Name == clusterName {
 				managedPods = append(managedPods, pods.Items[idx])
 				if specs.IsPodPrimary(pods.Items[idx]) {

--- a/internal/webhook/v1/cluster_webhook.go
+++ b/internal/webhook/v1/cluster_webhook.go
@@ -1858,7 +1858,7 @@ func (v *ClusterCustomValidator) validateReplicaMode(r *apiv1.Cluster) field.Err
 		} else if r.Spec.Bootstrap.PgBaseBackup == nil && r.Spec.Bootstrap.Recovery == nil &&
 			// this is needed because we only want to validate this during cluster creation, currently if we would have
 			// to enable this logic only during creation and not cluster changes it would require a meaningful refactor
-			len(r.ObjectMeta.ResourceVersion) == 0 {
+			len(r.ResourceVersion) == 0 {
 			result = append(result, field.Invalid(
 				field.NewPath("spec", "replicaCluster"),
 				replicaClusterConf,

--- a/pkg/certs/certs.go
+++ b/pkg/certs/certs.go
@@ -194,11 +194,11 @@ func (pair KeyPair) createAndSignPairWithValidity(
 	}
 
 	leafTemplate.KeyUsage = x509.KeyUsageDigitalSignature | x509.KeyUsageKeyAgreement
-	switch {
-	case usage == CertTypeClient:
+	switch usage {
+	case CertTypeClient:
 		leafTemplate.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}
 
-	case usage == CertTypeServer:
+	case CertTypeServer:
 		leafTemplate.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}
 		leafTemplate.KeyUsage |= x509.KeyUsageKeyEncipherment
 

--- a/pkg/configfile/configfile_test.go
+++ b/pkg/configfile/configfile_test.go
@@ -23,10 +23,10 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/cloudnative-pg/machinery/pkg/fileutils"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
-	"github.com/cloudnative-pg/machinery/pkg/fileutils"
 )
 
 var _ = Describe("update Postgres configuration files", func() {

--- a/pkg/management/postgres/logpipe/CSVReadWriter.go
+++ b/pkg/management/postgres/logpipe/CSVReadWriter.go
@@ -58,7 +58,7 @@ func (r *CSVRecordReadWriter) Read() ([]string, error) {
 
 	for _, allowedFields := range r.allowedFieldsPerRecord {
 		if len(record) == allowedFields {
-			r.Reader.FieldsPerRecord = allowedFields
+			r.FieldsPerRecord = allowedFields
 			return record, nil
 		}
 	}

--- a/pkg/management/postgres/logpipe/pgaudit.go
+++ b/pkg/management/postgres/logpipe/pgaudit.go
@@ -67,7 +67,7 @@ func (r *PgAuditLoggingDecorator) FromCSV(content []string) NamedRecord {
 		return r.LoggingRecord
 	}
 
-	_, err := r.CSVReadWriter.Write([]byte(record))
+	_, err := r.Write([]byte(record))
 	if err != nil {
 		return r.LoggingRecord
 	}
@@ -76,7 +76,7 @@ func (r *PgAuditLoggingDecorator) FromCSV(content []string) NamedRecord {
 		return r.LoggingRecord
 	}
 
-	r.LoggingRecord.Message = ""
+	r.Message = ""
 	r.Audit.fromCSV(auditContent)
 	return r
 }

--- a/pkg/management/postgres/webserver/client/remote/instance.go
+++ b/pkg/management/postgres/webserver/client/remote/instance.go
@@ -190,8 +190,8 @@ func (r *instanceClientImpl) GetPgControlDataFromInstance(
 	if err != nil {
 		return "", err
 	}
-	r.Client.Timeout = defaultRequestTimeout
-	resp, err := r.Client.Do(req)
+	r.Timeout = defaultRequestTimeout
+	resp, err := r.Do(req)
 	if err != nil {
 		return "", err
 	}
@@ -250,8 +250,8 @@ func (r *instanceClientImpl) UpgradeInstanceManager(
 	}
 	req.Body = binaryFileStream
 
-	r.Client.Timeout = noRequestTimeout
-	resp, err := r.Client.Do(req)
+	r.Timeout = noRequestTimeout
+	resp, err := r.Do(req)
 	// This is the desired response. The instance manager will
 	// synchronously update and this call won't return.
 	if isEOF(err) {
@@ -299,8 +299,8 @@ func (r *instanceClientImpl) rawInstanceStatusRequest(
 		return result
 	}
 
-	r.Client.Timeout = defaultRequestTimeout
-	resp, err := r.Client.Do(req)
+	r.Timeout = defaultRequestTimeout
+	resp, err := r.Do(req)
 	if err != nil {
 		result.Error = err
 		return result
@@ -379,7 +379,7 @@ func (r *instanceClientImpl) ArchivePartialWAL(ctx context.Context, pod *corev1.
 	if err != nil {
 		return "", err
 	}
-	resp, err := r.Client.Do(req)
+	resp, err := r.Do(req)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/reconciler/hibernation/status_test.go
+++ b/pkg/reconciler/hibernation/status_test.go
@@ -47,7 +47,7 @@ var _ = Describe("Hibernation annotation management", func() {
 		}
 		Expect(isHibernationEnabled(&cluster)).To(BeTrue())
 
-		cluster.ObjectMeta.Annotations[utils.HibernationAnnotationName] = HibernationOff
+		cluster.Annotations[utils.HibernationAnnotationName] = HibernationOff
 		Expect(isHibernationEnabled(&cluster)).To(BeFalse())
 	})
 })

--- a/pkg/reconciler/instance/metadata.go
+++ b/pkg/reconciler/instance/metadata.go
@@ -187,11 +187,11 @@ func updateRoleLabels(
 
 	// it is important to note that even if utils.ClusterRoleLabelName is deprecated,
 	// we still ensure that the values are aligned between the two fields
-	podRole, hasRole := instance.ObjectMeta.Labels[utils.ClusterRoleLabelName]
-	newPodRole, newHasRole := instance.ObjectMeta.Labels[utils.ClusterInstanceRoleLabelName]
+	podRole, hasRole := instance.Labels[utils.ClusterRoleLabelName]
+	newPodRole, newHasRole := instance.Labels[utils.ClusterInstanceRoleLabelName]
 
-	switch {
-	case instance.Name == cluster.Status.CurrentPrimary:
+	switch instance.Name {
+	case cluster.Status.CurrentPrimary:
 		if !hasRole || podRole != specs.ClusterRoleLabelPrimary || !newHasRole ||
 			newPodRole != specs.ClusterRoleLabelPrimary {
 			contextLogger.Info("Setting primary label", "pod", instance.Name)

--- a/pkg/reconciler/majorupgrade/reconciler.go
+++ b/pkg/reconciler/majorupgrade/reconciler.go
@@ -282,7 +282,7 @@ func getPrimarySerial(
 	pvcs []corev1.PersistentVolumeClaim,
 ) (int, error) {
 	for _, pvc := range pvcs {
-		instanceRole, _ := utils.GetInstanceRole(pvc.ObjectMeta.Labels)
+		instanceRole, _ := utils.GetInstanceRole(pvc.Labels)
 		if instanceRole != specs.ClusterRoleLabelPrimary {
 			continue
 		}

--- a/pkg/reconciler/persistentvolumeclaim/metadata.go
+++ b/pkg/reconciler/persistentvolumeclaim/metadata.go
@@ -90,10 +90,10 @@ func reconcileInstanceRoleLabel(
 		instanceReconciler := metadataReconciler{
 			name: "instance-role",
 			isUpToDate: func(pvc *corev1.PersistentVolumeClaim) bool {
-				if pvc.ObjectMeta.Labels[utils.ClusterRoleLabelName] != instanceRole {
+				if pvc.Labels[utils.ClusterRoleLabelName] != instanceRole {
 					return false
 				}
-				if pvc.ObjectMeta.Labels[utils.ClusterInstanceRoleLabelName] != instanceRole {
+				if pvc.Labels[utils.ClusterInstanceRoleLabelName] != instanceRole {
 					return false
 				}
 

--- a/pkg/reconciler/persistentvolumeclaim/status.go
+++ b/pkg/reconciler/persistentvolumeclaim/status.go
@@ -110,7 +110,7 @@ func EnrichStatus(
 		}
 
 		// There's no point in reattaching ignored PVCs
-		if pvc.ObjectMeta.DeletionTimestamp != nil {
+		if pvc.DeletionTimestamp != nil {
 			continue
 		}
 
@@ -162,7 +162,7 @@ func classifyPVC(
 	instanceName string,
 ) status {
 	// PVC to ignore
-	if pvc.ObjectMeta.DeletionTimestamp != nil || hasUnknownStatus(ctx, pvc) {
+	if pvc.DeletionTimestamp != nil || hasUnknownStatus(ctx, pvc) {
 		return ignored
 	}
 

--- a/pkg/reconciler/persistentvolumeclaim/storagesource.go
+++ b/pkg/reconciler/persistentvolumeclaim/storagesource.go
@@ -92,7 +92,7 @@ func GetCandidateStorageSourceForReplica(
 
 	if result := getCandidateSourceFromBackupList(
 		ctx,
-		cluster.ObjectMeta.CreationTimestamp,
+		cluster.CreationTimestamp,
 		backupList,
 	); result != nil {
 		return result
@@ -129,7 +129,7 @@ func getCandidateSourceFromBackupList(
 			continue
 		}
 
-		if backup.ObjectMeta.CreationTimestamp.Before(&clusterCreationTime) {
+		if backup.CreationTimestamp.Before(&clusterCreationTime) {
 			contextLogger.Info(
 				"skipping backup as a potential recovery storage source candidate " +
 					"because if was created before the Cluster object")

--- a/pkg/specs/pods.go
+++ b/pkg/specs/pods.go
@@ -280,9 +280,9 @@ func createPostgresContainers(cluster apiv1.Cluster, envConfig EnvConfig, enable
 	}
 
 	if enableHTTPS {
-		containers[0].StartupProbe.ProbeHandler.HTTPGet.Scheme = corev1.URISchemeHTTPS
-		containers[0].LivenessProbe.ProbeHandler.HTTPGet.Scheme = corev1.URISchemeHTTPS
-		containers[0].ReadinessProbe.ProbeHandler.HTTPGet.Scheme = corev1.URISchemeHTTPS
+		containers[0].StartupProbe.HTTPGet.Scheme = corev1.URISchemeHTTPS
+		containers[0].LivenessProbe.HTTPGet.Scheme = corev1.URISchemeHTTPS
+		containers[0].ReadinessProbe.HTTPGet.Scheme = corev1.URISchemeHTTPS
 		containers[0].Command = append(containers[0].Command, "--status-port-tls")
 	}
 

--- a/pkg/specs/podspec_diff.go
+++ b/pkg/specs/podspec_diff.go
@@ -199,7 +199,7 @@ func doContainersMatch(currentContainer, targetContainer corev1.Container) (bool
 		},
 		"resources": func() bool {
 			// semantic equality will compare the two objects semantically, not only numbers
-			return equality.Semantic.Equalities.DeepEqual(
+			return equality.Semantic.DeepEqual(
 				currentContainer.Resources,
 				targetContainer.Resources,
 			)

--- a/pkg/specs/roles.go
+++ b/pkg/specs/roles.go
@@ -296,13 +296,13 @@ func externalClusterSecrets(cluster apiv1.Cluster) []string {
 		if barmanObjStore := server.BarmanObjectStore; barmanObjStore != nil {
 			result = append(
 				result,
-				s3CredentialsSecrets(barmanObjStore.BarmanCredentials.AWS)...)
+				s3CredentialsSecrets(barmanObjStore.AWS)...)
 			result = append(
 				result,
-				azureCredentialsSecrets(barmanObjStore.BarmanCredentials.Azure)...)
+				azureCredentialsSecrets(barmanObjStore.Azure)...)
 			result = append(
 				result,
-				googleCredentialsSecrets(barmanObjStore.BarmanCredentials.Google)...)
+				googleCredentialsSecrets(barmanObjStore.Google)...)
 			if barmanObjStore.EndpointCA != nil {
 				result = append(result, barmanObjStore.EndpointCA.Name)
 			}
@@ -319,13 +319,13 @@ func backupSecrets(cluster apiv1.Cluster, backupOrigin *apiv1.Backup) []string {
 	if cluster.Spec.Backup != nil && cluster.Spec.Backup.BarmanObjectStore != nil {
 		result = append(
 			result,
-			s3CredentialsSecrets(cluster.Spec.Backup.BarmanObjectStore.BarmanCredentials.AWS)...)
+			s3CredentialsSecrets(cluster.Spec.Backup.BarmanObjectStore.AWS)...)
 		result = append(
 			result,
-			azureCredentialsSecrets(cluster.Spec.Backup.BarmanObjectStore.BarmanCredentials.Azure)...)
+			azureCredentialsSecrets(cluster.Spec.Backup.BarmanObjectStore.Azure)...)
 		result = append(
 			result,
-			googleCredentialsSecrets(cluster.Spec.Backup.BarmanObjectStore.BarmanCredentials.Google)...)
+			googleCredentialsSecrets(cluster.Spec.Backup.BarmanObjectStore.Google)...)
 	}
 
 	// Secrets needed by Barman, if set
@@ -338,13 +338,13 @@ func backupSecrets(cluster apiv1.Cluster, backupOrigin *apiv1.Backup) []string {
 	if backupOrigin != nil {
 		result = append(
 			result,
-			s3CredentialsSecrets(backupOrigin.Status.BarmanCredentials.AWS)...)
+			s3CredentialsSecrets(backupOrigin.Status.AWS)...)
 		result = append(
 			result,
-			azureCredentialsSecrets(backupOrigin.Status.BarmanCredentials.Azure)...)
+			azureCredentialsSecrets(backupOrigin.Status.Azure)...)
 		result = append(
 			result,
-			googleCredentialsSecrets(backupOrigin.Status.BarmanCredentials.Google)...)
+			googleCredentialsSecrets(backupOrigin.Status.Google)...)
 	}
 
 	return result

--- a/pkg/utils/labels_annotations_test.go
+++ b/pkg/utils/labels_annotations_test.go
@@ -155,7 +155,7 @@ var _ = Describe("Annotate pods management", func() {
 		}
 
 		AnnotateAppArmor(&pod.ObjectMeta, &pod.Spec, annotations)
-		_, isPresent := pod.ObjectMeta.Annotations[appArmorPostgres]
+		_, isPresent := pod.Annotations[appArmorPostgres]
 		Expect(isPresent).To(BeFalse())
 	})
 })

--- a/tests/e2e/apparmor_test.go
+++ b/tests/e2e/apparmor_test.go
@@ -61,7 +61,7 @@ var _ = Describe("AppArmor support", Serial, Label(tests.LabelNoOpenshift, tests
 			// Gathers the pod list using annotations
 			podList, _ := clusterutils.ListPods(env.Ctx, env.Client, namespace, clusterName)
 			for _, pod := range podList.Items {
-				annotation := pod.ObjectMeta.Annotations[pkgutils.AppArmorAnnotationPrefix+"/"+specs.PostgresContainerName]
+				annotation := pod.Annotations[pkgutils.AppArmorAnnotationPrefix+"/"+specs.PostgresContainerName]
 				Expect(annotation).ShouldNot(BeEmpty(),
 					fmt.Sprintf("annotation for apparmor is not on pod %v", specs.PostgresContainerName))
 				Expect(annotation).Should(BeEquivalentTo("runtime/default"),

--- a/tests/e2e/asserts_test.go
+++ b/tests/e2e/asserts_test.go
@@ -2160,7 +2160,7 @@ func assertPodIsRecreated(namespace, poolerSampleFile string) {
 			}
 			if len(podList.Items) == 1 {
 				if utils.IsPodActive(podList.Items[0]) && utils.IsPodReady(podList.Items[0]) {
-					if !(podNameBeforeDelete == podList.Items[0].GetName()) {
+					if podNameBeforeDelete != podList.Items[0].GetName() {
 						return true, err
 					}
 				}

--- a/tests/e2e/nodeselector_test.go
+++ b/tests/e2e/nodeselector_test.go
@@ -126,7 +126,7 @@ var _ = Describe("nodeSelector", Label(tests.LabelPodScheduling), func() {
 				for _, nodeDetails := range nodeList.Items {
 					if (nodeDetails.Spec.Unschedulable != true) &&
 						(len(nodeDetails.Spec.Taints) == 0) {
-						nodeName = nodeDetails.ObjectMeta.Name
+						nodeName = nodeDetails.Name
 						break
 					}
 				}

--- a/tests/e2e/operator_unavailable_test.go
+++ b/tests/e2e/operator_unavailable_test.go
@@ -169,7 +169,7 @@ var _ = Describe("Operator unavailable", Serial, Label(tests.LabelDisruptive, te
 				podList := &corev1.PodList{}
 				err := env.Client.List(env.Ctx, podList, ctrlclient.InNamespace(operatorNamespace))
 				Expect(err).ToNot(HaveOccurred())
-				operatorPodName = podList.Items[0].ObjectMeta.Name
+				operatorPodName = podList.Items[0].Name
 
 				// Force-delete the operator and the primary
 				quickDelete := &ctrlclient.DeleteOptions{

--- a/tests/e2e/tablespaces_test.go
+++ b/tests/e2e/tablespaces_test.go
@@ -94,8 +94,8 @@ var _ = Describe("Tablespaces tests", Label(tests.LabelTablespaces,
 
 	// Verify that the tablespace exists on the primary pod of a cluster
 	hasTablespaceAndOwner := func(cluster *apiv1.Cluster, tablespace, owner string) (bool, error) {
-		namespace := cluster.ObjectMeta.Namespace
-		clusterName := cluster.ObjectMeta.Name
+		namespace := cluster.Namespace
+		clusterName := cluster.Name
 		primaryPod, err := clusterutils.GetPrimary(env.Ctx, env.Client, namespace, clusterName)
 		if err != nil {
 			return false, err
@@ -915,8 +915,8 @@ func AssertClusterHasMountPointsAndVolumesForTablespaces(
 	numTablespaces int,
 	timeout int,
 ) {
-	namespace := cluster.ObjectMeta.Namespace
-	clusterName := cluster.ObjectMeta.Name
+	namespace := cluster.Namespace
+	clusterName := cluster.Name
 	podMountPaths := func(pod corev1.Pod) (bool, []string) {
 		var hasPostgresContainer bool
 		var mountPaths []string
@@ -987,8 +987,8 @@ func getDatabasUserUID(cluster *apiv1.Cluster, dbContainer *corev1.Container) in
 }
 
 func AssertClusterHasPvcsAndDataDirsForTablespaces(cluster *apiv1.Cluster, timeout int) {
-	namespace := cluster.ObjectMeta.Namespace
-	clusterName := cluster.ObjectMeta.Name
+	namespace := cluster.Namespace
+	clusterName := cluster.Name
 	By("checking all the required PVCs were created", func() {
 		Eventually(func(g Gomega) {
 			pvcList, err := storage.GetPVCList(env.Ctx, env.Client, namespace)
@@ -1051,8 +1051,8 @@ func AssertClusterHasPvcsAndDataDirsForTablespaces(cluster *apiv1.Cluster, timeo
 }
 
 func AssertDatabaseContainsTablespaces(cluster *apiv1.Cluster, timeout int) {
-	namespace := cluster.ObjectMeta.Namespace
-	clusterName := cluster.ObjectMeta.Name
+	namespace := cluster.Namespace
+	clusterName := cluster.Name
 	By("checking the expected tablespaces are in the database", func() {
 		Eventually(func(g Gomega) {
 			instances, err := clusterutils.ListPods(env.Ctx, env.Client, namespace, clusterName)
@@ -1081,8 +1081,8 @@ func AssertDatabaseContainsTablespaces(cluster *apiv1.Cluster, timeout int) {
 }
 
 func AssertTempTablespaceContent(cluster *apiv1.Cluster, timeout int, content string) {
-	namespace := cluster.ObjectMeta.Namespace
-	clusterName := cluster.ObjectMeta.Name
+	namespace := cluster.Namespace
+	clusterName := cluster.Name
 	By("checking the expected setting in a new PG session", func() {
 		Eventually(func(g Gomega) {
 			primary, err := clusterutils.GetPrimary(env.Ctx, env.Client, namespace, clusterName)
@@ -1107,8 +1107,8 @@ func AssertTempTablespaceContent(cluster *apiv1.Cluster, timeout int, content st
 }
 
 func AssertTempTablespaceBehavior(cluster *apiv1.Cluster, expectedTempTablespaceName string) {
-	namespace := cluster.ObjectMeta.Namespace
-	clusterName := cluster.ObjectMeta.Name
+	namespace := cluster.Namespace
+	clusterName := cluster.Name
 
 	primary, err := clusterutils.GetPrimary(env.Ctx, env.Client, namespace, clusterName)
 	if err != nil {

--- a/tests/utils/sternmultitailer/multitailer.go
+++ b/tests/utils/sternmultitailer/multitailer.go
@@ -162,7 +162,7 @@ func outputWriter(baseDir string, logReader io.Reader) {
 			continue
 		}
 
-		_, err = file.WriteString(fmt.Sprintf("%v\n", logLine.Message))
+		_, err = fmt.Fprintf(file, "%v\n", logLine.Message)
 		if err != nil {
 			fmt.Printf("could not write message to file %v: %v\n", file.Name(), err)
 			continue


### PR DESCRIPTION
The new version of golangci-lint v2 found some issues that need to 
be migrated before we can even try to update to the latest version

Disabled checks:
* The Morgan's Law was disable in the staticcheck (QF1001)
* The Merge conditional assignment into variable declarion (QF1007)