### PR TITLE
test(e2e): replace `corev1.Endpoints` with `discoveryv1.EndpointSlice`

### DIFF
--- a/tests/e2e/asserts_test.go
+++ b/tests/e2e/asserts_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/thoas/go-funk"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
@@ -1229,23 +1230,18 @@ func AssertFastFailOver(
 	// Node 1 should be the primary, so the -rw service should
 	// point there. We verify this.
 	By("having the current primary on node1", func() {
-		endpointName := clusterName + "-rw"
-		endpoint := &corev1.Endpoints{}
-		endpointNamespacedName := types.NamespacedName{
-			Namespace: namespace,
-			Name:      endpointName,
-		}
+		rwServiceName := clusterName + "-rw"
+
 		podName := clusterName + "-1"
 		pod := &corev1.Pod{}
 		podNamespacedName := types.NamespacedName{
 			Namespace: namespace,
 			Name:      podName,
 		}
-		err = env.Client.Get(env.Ctx, endpointNamespacedName,
-			endpoint)
+		endpointSlice, err := testsUtils.GetEndpointSliceByServiceName(env.Ctx, env.Client, namespace, rwServiceName)
 		Expect(err).ToNot(HaveOccurred())
 		err = env.Client.Get(env.Ctx, podNamespacedName, pod)
-		Expect(testsUtils.FirstEndpointIP(endpoint), err).To(
+		Expect(testsUtils.FirstEndpointIP(endpointSlice), err).To(
 			BeEquivalentTo(pod.Status.PodIP))
 	})
 
@@ -2221,12 +2217,13 @@ func assertPGBouncerEndpointsContainsPodsIP(
 	expectedPodCount int,
 ) {
 	var pgBouncerPods []*corev1.Pod
-	endpoint := &corev1.Endpoints{}
-	endpointName, err := yaml.GetResourceNameFromYAML(env.Scheme, poolerYamlFilePath)
+	endpointSlice := &discoveryv1.EndpointSlice{}
+	poolerServiceName, err := yaml.GetResourceNameFromYAML(env.Scheme, poolerYamlFilePath)
 	Expect(err).ToNot(HaveOccurred())
 
 	Eventually(func(g Gomega) {
-		err := env.Client.Get(env.Ctx, types.NamespacedName{Namespace: namespace, Name: endpointName}, endpoint)
+		var err error
+		endpointSlice, err = testsUtils.GetEndpointSliceByServiceName(env.Ctx, env.Client, namespace, poolerServiceName)
 		g.Expect(err).ToNot(HaveOccurred())
 	}).Should(Succeed())
 
@@ -2236,18 +2233,19 @@ func assertPGBouncerEndpointsContainsPodsIP(
 	err = env.Client.List(env.Ctx, podList, ctrlclient.InNamespace(namespace),
 		ctrlclient.MatchingLabels{utils.PgbouncerNameLabel: poolerName})
 	Expect(err).ToNot(HaveOccurred())
-	Expect(endpoint.Subsets).ToNot(BeEmpty())
+	Expect(endpointSlice.Endpoints).ToNot(BeEmpty())
 
-	for _, ip := range endpoint.Subsets[0].Addresses {
+	for _, endpoint := range endpointSlice.Endpoints {
+		ip := endpoint.Addresses[0]
 		for podIndex, pod := range podList.Items {
-			if pod.Status.PodIP == ip.IP {
+			if pod.Status.PodIP == ip {
 				pgBouncerPods = append(pgBouncerPods, &podList.Items[podIndex])
 				continue
 			}
 		}
 	}
 
-	Expect(pgBouncerPods).Should(HaveLen(expectedPodCount), "Pod length or IP mismatch in ep")
+	Expect(pgBouncerPods).Should(HaveLen(expectedPodCount), "Pod length or IP mismatch in endpoint")
 }
 
 // assertPGBouncerHasServiceNameInsideHostParameter makes sure that the service name is contained inside the host file

--- a/tests/e2e/fastswitchover_test.go
+++ b/tests/e2e/fastswitchover_test.go
@@ -115,23 +115,19 @@ func assertFastSwitchover(namespace, sampleFile, clusterName, webTestFile, webTe
 	// Node 1 should be the primary, so the -rw service should
 	// point there. We verify this.
 	By("having the current primary on node1", func() {
-		endpointName := clusterName + "-rw"
-		endpoint := &corev1.Endpoints{}
-		endpointNamespacedName := types.NamespacedName{
-			Namespace: namespace,
-			Name:      endpointName,
-		}
+		rwServiceName := clusterName + "-rw"
 		oldPrimary = clusterName + "-1"
 		pod := &corev1.Pod{}
 		podNamespacedName := types.NamespacedName{
 			Namespace: namespace,
 			Name:      oldPrimary,
 		}
-		err := env.Client.Get(env.Ctx, endpointNamespacedName,
-			endpoint)
+
+		endpointSlice, err := utils.GetEndpointSliceByServiceName(env.Ctx, env.Client, namespace, rwServiceName)
 		Expect(err).ToNot(HaveOccurred())
 		err = env.Client.Get(env.Ctx, podNamespacedName, pod)
-		Expect(utils.FirstEndpointIP(endpoint), err).To(
+		Expect(err).ToNot(HaveOccurred())
+		Expect(utils.FirstEndpointIP(endpointSlice), err).To(
 			BeEquivalentTo(pod.Status.PodIP))
 	})
 	By("preparing the db for the test scenario", func() {

--- a/tests/e2e/fastswitchover_test.go
+++ b/tests/e2e/fastswitchover_test.go
@@ -116,19 +116,14 @@ func assertFastSwitchover(namespace, sampleFile, clusterName, webTestFile, webTe
 	// point there. We verify this.
 	By("having the current primary on node1", func() {
 		rwServiceName := clusterName + "-rw"
-		oldPrimary = clusterName + "-1"
-		pod := &corev1.Pod{}
-		podNamespacedName := types.NamespacedName{
-			Namespace: namespace,
-			Name:      oldPrimary,
-		}
-
 		endpointSlice, err := utils.GetEndpointSliceByServiceName(env.Ctx, env.Client, namespace, rwServiceName)
 		Expect(err).ToNot(HaveOccurred())
-		err = env.Client.Get(env.Ctx, podNamespacedName, pod)
+
+		oldPrimary = clusterName + "-1"
+		pod := &corev1.Pod{}
+		err = env.Client.Get(env.Ctx, types.NamespacedName{Namespace: namespace, Name: oldPrimary}, pod)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(utils.FirstEndpointIP(endpointSlice), err).To(
-			BeEquivalentTo(pod.Status.PodIP))
+		Expect(utils.FirstEndpointSliceIP(endpointSlice)).To(BeEquivalentTo(pod.Status.PodIP))
 	})
 	By("preparing the db for the test scenario", func() {
 		// Create the table used by the scenario

--- a/tests/e2e/rolling_update_test.go
+++ b/tests/e2e/rolling_update_test.go
@@ -227,38 +227,27 @@ var _ = Describe("Rolling updates", Label(tests.LabelPostgresConfiguration), fun
 		Expect(err).ToNot(HaveOccurred())
 
 		endpointName := clusterName + "-rw"
-		endpointNamespacedName := types.NamespacedName{
-			Namespace: namespace,
-			Name:      endpointName,
-		}
 		// we give 10 seconds to the apiserver to update the endpoint
 		timeout := 10
 		Eventually(func() (string, error) {
-			endpoint := &corev1.Endpoints{}
-			err := env.Client.Get(env.Ctx, endpointNamespacedName, endpoint)
-			return testsUtils.FirstEndpointIP(endpoint), err
+			endpointSlice, err := testsUtils.GetEndpointSliceByServiceName(env.Ctx, env.Client, namespace, endpointName)
+			return testsUtils.FirstEndpointIP(endpointSlice), err
 		}, timeout).Should(BeEquivalentTo(currentPrimaryPod.Status.PodIP))
 	}
 
 	// Verify that the IPs of the podutils match the ones in the -r endpoint and
 	// that the amount of podutils is the expected one
 	AssertReadyEndpoint := func(namespace string, clusterName string, expectedEndpoints int) {
-		endpointName := clusterName + "-r"
-		endpoint := &corev1.Endpoints{}
-		endpointNamespacedName := types.NamespacedName{
-			Namespace: namespace,
-			Name:      endpointName,
-		}
-		err := env.Client.Get(env.Ctx, endpointNamespacedName,
-			endpoint)
+		readServiceName := clusterName + "-r"
+		endpointSlice, err := testsUtils.GetEndpointSliceByServiceName(env.Ctx, env.Client, namespace, readServiceName)
 		Expect(err).ToNot(HaveOccurred())
 		podList, err := clusterutils.ListPods(env.Ctx, env.Client, namespace, clusterName)
 		Expect(expectedEndpoints, err).To(BeEquivalentTo(len(podList.Items)))
 		matchingIP := 0
 		for _, pod := range podList.Items {
 			ip := pod.Status.PodIP
-			for _, addr := range endpoint.Subsets[0].Addresses {
-				if ip == addr.IP {
+			for _, endpoint := range endpointSlice.Endpoints {
+				if ip == endpoint.Addresses[0] {
 					matchingIP++
 				}
 			}

--- a/tests/e2e/rolling_update_test.go
+++ b/tests/e2e/rolling_update_test.go
@@ -231,7 +231,7 @@ var _ = Describe("Rolling updates", Label(tests.LabelPostgresConfiguration), fun
 		timeout := 10
 		Eventually(func() (string, error) {
 			endpointSlice, err := testsUtils.GetEndpointSliceByServiceName(env.Ctx, env.Client, namespace, endpointName)
-			return testsUtils.FirstEndpointIP(endpointSlice), err
+			return testsUtils.FirstEndpointSliceIP(endpointSlice), err
 		}, timeout).Should(BeEquivalentTo(currentPrimaryPod.Status.PodIP))
 	}
 

--- a/tests/utils/endpoints.go
+++ b/tests/utils/endpoints.go
@@ -27,8 +27,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// FirstEndpointIP returns the IP of first Address in the Endpoint
-func FirstEndpointIP(endpoint *discoveryv1.EndpointSlice) string {
+// FirstEndpointSliceIP returns the IP of the first Address in the EndpointSlice
+func FirstEndpointSliceIP(endpoint *discoveryv1.EndpointSlice) string {
 	if endpoint == nil {
 		return ""
 	}

--- a/tests/utils/namespaces/namespace.go
+++ b/tests/utils/namespaces/namespace.go
@@ -319,10 +319,10 @@ func DumpNamespaceObjects(
 				Namespace: namespace,
 				Name:      cluster.Name + suffix,
 			}
-			endpoint := &discoveryv1.EndpointSlice{}
-			_ = crudClient.Get(ctx, namespacedName, endpoint)
-			out, _ := json.MarshalIndent(endpoint, "", "    ")
-			_, _ = fmt.Fprintf(w, "Dumping %v/%v endpoint\n", namespace, endpoint.Name)
+			endpointSlice := &discoveryv1.EndpointSlice{}
+			_ = crudClient.Get(ctx, namespacedName, endpointSlice)
+			out, _ := json.MarshalIndent(endpointSlice, "", "    ")
+			_, _ = fmt.Fprintf(w, "Dumping %v/%v endpointSlice\n", namespace, endpointSlice.Name)
 			_, _ = fmt.Fprintln(w, string(out))
 		}
 	}

--- a/tests/utils/namespaces/namespace.go
+++ b/tests/utils/namespaces/namespace.go
@@ -36,6 +36,7 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	v1 "k8s.io/api/events/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -318,7 +319,7 @@ func DumpNamespaceObjects(
 				Namespace: namespace,
 				Name:      cluster.Name + suffix,
 			}
-			endpoint := &corev1.Endpoints{}
+			endpoint := &discoveryv1.EndpointSlice{}
 			_ = crudClient.Get(ctx, namespacedName, endpoint)
 			out, _ := json.MarshalIndent(endpoint, "", "    ")
 			_, _ = fmt.Fprintf(w, "Dumping %v/%v endpoint\n", namespace, endpoint.Name)


### PR DESCRIPTION
The corev1.Endpoints() has been deprecated on Kubernetes API 1.33
and replaced by discoveryv1.EndpointSlice().

Closes #7543 