### PR TITLE
feat(cluster,status): track latest `Instance` IP

### DIFF
--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -982,7 +982,7 @@ type InstanceReportedState struct {
 	// indicates on which TimelineId the instance is
 	// +optional
 	TimeLineID int `json:"timeLineID,omitempty"`
-	// IP is the IP address of the instance
+	// IP address of the instance
 	IP string `json:"ip,omitempty"`
 }
 

--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -982,6 +982,8 @@ type InstanceReportedState struct {
 	// indicates on which TimelineId the instance is
 	// +optional
 	TimeLineID int `json:"timeLineID,omitempty"`
+	// IP is the IP address of the instance
+	IP string `json:"ip,omitempty"`
 }
 
 // ClusterConditionType defines types of cluster conditions

--- a/config/crd/bases/postgresql.cnpg.io_clusters.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_clusters.yaml
@@ -6125,6 +6125,9 @@ spec:
                   description: InstanceReportedState describes the last reported state
                     of an instance during a reconciliation loop
                   properties:
+                    ip:
+                      description: IP is the IP address of the instance
+                      type: string
                     isPrimary:
                       description: indicates if an instance is the primary one
                       type: boolean

--- a/config/crd/bases/postgresql.cnpg.io_clusters.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_clusters.yaml
@@ -6126,7 +6126,7 @@ spec:
                     of an instance during a reconciliation loop
                   properties:
                     ip:
-                      description: IP is the IP address of the instance
+                      description: IP address of the instance
                       type: string
                     isPrimary:
                       description: indicates if an instance is the primary one

--- a/docs/src/cloudnative-pg.v1.md
+++ b/docs/src/cloudnative-pg.v1.md
@@ -3193,6 +3193,13 @@ conflict with the operator's intended functionality or design.</p>
    <p>indicates on which TimelineId the instance is</p>
 </td>
 </tr>
+<tr><td><code>ip</code> <B>[Required]</B><br/>
+<i>string</i>
+</td>
+<td>
+   <p>IP is the IP address of the instance</p>
+</td>
+</tr>
 </tbody>
 </table>
 

--- a/docs/src/cloudnative-pg.v1.md
+++ b/docs/src/cloudnative-pg.v1.md
@@ -3197,7 +3197,7 @@ conflict with the operator's intended functionality or design.</p>
 <i>string</i>
 </td>
 <td>
-   <p>IP is the IP address of the instance</p>
+   <p>IP address of the instance</p>
 </td>
 </tr>
 </tbody>

--- a/internal/controller/cluster_status.go
+++ b/internal/controller/cluster_status.go
@@ -758,6 +758,7 @@ func (r *ClusterReconciler) updateClusterStatusThatRequiresInstancesState(
 		cluster.Status.InstancesReportedState[apiv1.PodName(item.Pod.Name)] = apiv1.InstanceReportedState{
 			IsPrimary:  item.IsPrimary,
 			TimeLineID: item.TimeLineID,
+			IP:         item.Pod.Status.PodIP,
 		}
 	}
 


### PR DESCRIPTION
This patch makes the operator track the latest known Pod IP in the Cluster status.

The newly introduced field could be used by the instance manager to test the connectivity with the other PostgreSQL Instances.

Related to #7465