### PR TITLE
chore(ci): adding missing permissions to action

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -93,6 +93,7 @@ jobs:
     permissions:
       pull-requests: write
       contents: read
+      issues: read
     runs-on: ubuntu-24.04
     outputs:
       github_ref: ${{ steps.refs.outputs.head_sha }}


### PR DESCRIPTION
The action xt0rted/pull-request-comment-branch requires the permission
`issues: read` to do the work properly, this was missing. Per documentation
here: https://github.com/xt0rted/pull-request-comment-branch?tab=readme-ov-file#token-permissions