### PR TITLE
chore: move dataDurability defaulting logic to webhook to avoid OLM issues

### DIFF
--- a/api/v1/cluster_defaults.go
+++ b/api/v1/cluster_defaults.go
@@ -132,8 +132,8 @@ func (r *Cluster) setDefaults(preserveUserSettings bool) {
 		r.defaultTablespaces()
 	}
 
-	// If Synchronous is not nil we set the default values
-	if r.Spec.PostgresConfiguration.Synchronous != nil {
+	if r.Spec.PostgresConfiguration.Synchronous != nil &&
+		r.Spec.PostgresConfiguration.Synchronous.DataDurability == "" {
 		r.Spec.PostgresConfiguration.Synchronous.DataDurability = DataDurabilityLevelRequired
 	}
 

--- a/api/v1/cluster_defaults.go
+++ b/api/v1/cluster_defaults.go
@@ -132,6 +132,11 @@ func (r *Cluster) setDefaults(preserveUserSettings bool) {
 		r.defaultTablespaces()
 	}
 
+	// If Synchronous is not nil we set the default values
+	if r.Spec.PostgresConfiguration.Synchronous != nil {
+		r.Spec.PostgresConfiguration.Synchronous.DataDurability = DataDurabilityLevelRequired
+	}
+
 	r.setDefaultPlugins(configuration.Current)
 }
 

--- a/api/v1/cluster_defaults_test.go
+++ b/api/v1/cluster_defaults_test.go
@@ -317,3 +317,45 @@ var _ = Describe("setDefaultPlugins", func() {
 			ContainElement(PluginConfiguration{Name: "predefined-plugin1", Enabled: ptr.To(true)}))
 	})
 })
+
+var _ = Describe("default dataDurability", func() {
+	It("should default dataDurability to 'required' when synchronous is present", func() {
+		cluster := &Cluster{
+			Spec: ClusterSpec{
+				PostgresConfiguration: PostgresConfiguration{
+					Synchronous: &SynchronousReplicaConfiguration{},
+				},
+			},
+		}
+		cluster.SetDefaults()
+		Expect(cluster.Spec.PostgresConfiguration.Synchronous).ToNot(BeNil())
+		Expect(cluster.Spec.PostgresConfiguration.Synchronous.DataDurability).To(Equal(DataDurabilityLevelRequired))
+	})
+
+	It("should not touch synchronous if nil", func() {
+		cluster := &Cluster{
+			Spec: ClusterSpec{
+				PostgresConfiguration: PostgresConfiguration{
+					Synchronous: nil,
+				},
+			},
+		}
+		cluster.SetDefaults()
+		Expect(cluster.Spec.PostgresConfiguration.Synchronous).To(BeNil())
+	})
+
+	It("should not change the dataDurability when set", func() {
+		cluster := &Cluster{
+			Spec: ClusterSpec{
+				PostgresConfiguration: PostgresConfiguration{
+					Synchronous: &SynchronousReplicaConfiguration{
+						DataDurability: DataDurabilityLevelPreferred,
+					},
+				},
+			},
+		}
+		cluster.SetDefaults()
+		Expect(cluster.Spec.PostgresConfiguration.Synchronous).ToNot(BeNil())
+		Expect(cluster.Spec.PostgresConfiguration.Synchronous.DataDurability).To(Equal(DataDurabilityLevelPreferred))
+	})
+})

--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -1317,7 +1317,6 @@ type SynchronousReplicaConfiguration struct {
 	// to allow for operational continuity. This setting is only applicable if both
 	// `standbyNamesPre` and `standbyNamesPost` are unset (empty).
 	// +kubebuilder:validation:Enum=required;preferred
-	// +kubebuilder:default:=required
 	// +optional
 	DataDurability DataDurabilityLevel `json:"dataDurability,omitempty"`
 }

--- a/config/crd/bases/postgresql.cnpg.io_clusters.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_clusters.yaml
@@ -4146,7 +4146,6 @@ spec:
                       feature
                     properties:
                       dataDurability:
-                        default: required
                         description: |-
                           If set to "required", data durability is strictly enforced. Write operations
                           with synchronous commit settings (`on`, `remote_write`, or `remote_apply`) will

--- a/config/olm-manifests/bases/cloudnative-pg.clusterserviceversion.yaml
+++ b/config/olm-manifests/bases/cloudnative-pg.clusterserviceversion.yaml
@@ -139,7 +139,6 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
-    # Backup Section
     - kind: Backup
       name: backups.postgresql.cnpg.io
       displayName: Backups
@@ -164,7 +163,6 @@ spec:
         path: phase
         x-descriptors:
         - 'urn:alm:descriptor:io.kubernetes.phase'
-    # Cluster Section
     - kind: Cluster
       name: clusters.postgresql.cnpg.io
       version: v1
@@ -321,18 +319,6 @@ spec:
         description: Boolean to enable TLS
         x-descriptors:
           - 'urn:alm:descriptor:com.tectonic.ui:booleanSwitch'
-      - path: postgresql.synchronous
-        displayName: Synchronous Replication Configuration
-        description: Configuration of the synchronous replication feature
-        x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:advanced'
-      - path: postgresql.synchronous.method
-        displayName: Synchronous Replication Configuration Method
-        description: The method to use for synchronous replication feature
-        x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:select:any'
-          - 'urn:alm:descriptor:com.tectonic.ui:select:first'
-          - 'urn:alm:descriptor:com.tectonic.ui:advanced'
       - path: tablespaces
         displayName: Tablespaces
         description: Configuration of the tablespaces
@@ -465,27 +451,6 @@ spec:
           complete
         x-descriptors:
           - 'urn:alm:descriptor:com.tectonic.ui:number'
-          - 'urn:alm:descriptor:com.tectonic.ui:advanced'
-      # Probes configuration section
-      - path: probes
-        display: Probes Configuration
-        description: Configuration of the probes to be injected in the PostgreSQL instances
-        x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:advanced'
-      - path: probes.liveness
-        displayName: Liveness Probe configuration
-        description: Configuration of the liveness probe
-        x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:advanced'
-      - path: probes.startup
-        displayName: Startup Probe configuration
-        description: Configuration of the startup probe
-        x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:advanced'
-      - path: probes.readiness
-        displayName: Readiness Probe configuration
-        description: Configuration of the readiness probe
-        x-descriptors:
           - 'urn:alm:descriptor:com.tectonic.ui:advanced'
       # Affinity section
       - path: affinity

--- a/config/olm-manifests/bases/cloudnative-pg.clusterserviceversion.yaml
+++ b/config/olm-manifests/bases/cloudnative-pg.clusterserviceversion.yaml
@@ -139,6 +139,7 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
+    # Backup Section
     - kind: Backup
       name: backups.postgresql.cnpg.io
       displayName: Backups
@@ -163,6 +164,7 @@ spec:
         path: phase
         x-descriptors:
         - 'urn:alm:descriptor:io.kubernetes.phase'
+    # Cluster Section
     - kind: Cluster
       name: clusters.postgresql.cnpg.io
       version: v1
@@ -319,6 +321,18 @@ spec:
         description: Boolean to enable TLS
         x-descriptors:
           - 'urn:alm:descriptor:com.tectonic.ui:booleanSwitch'
+      - path: postgresql.synchronous
+        displayName: Synchronous Replication Configuration
+        description: Configuration of the synchronous replication feature
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+      - path: postgresql.synchronous.method
+        displayName: Synchronous Replication Configuration Method
+        description: The method to use for synchronous replication feature
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:select:any'
+          - 'urn:alm:descriptor:com.tectonic.ui:select:first'
+          - 'urn:alm:descriptor:com.tectonic.ui:advanced'
       - path: tablespaces
         displayName: Tablespaces
         description: Configuration of the tablespaces
@@ -451,6 +465,27 @@ spec:
           complete
         x-descriptors:
           - 'urn:alm:descriptor:com.tectonic.ui:number'
+          - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+      # Probes configuration section
+      - path: probes
+        display: Probes Configuration
+        description: Configuration of the probes to be injected in the PostgreSQL instances
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+      - path: probes.liveness
+        displayName: Liveness Probe configuration
+        description: Configuration of the liveness probe
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+      - path: probes.startup
+        displayName: Startup Probe configuration
+        description: Configuration of the startup probe
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+      - path: probes.readiness
+        displayName: Readiness Probe configuration
+        description: Configuration of the readiness probe
+        x-descriptors:
           - 'urn:alm:descriptor:com.tectonic.ui:advanced'
       # Affinity section
       - path: affinity


### PR DESCRIPTION
Defining an OpenAPI default for a field within an optional section (such as `spec.postgresql.synchronous`) causes OLM to treat the entire section as required. This leads to validation errors when other mandatory fields in that section are not set.

To resolve this, the defaulting logic for `spec.postgresql.synchronous.dataDurability` has been moved from the CRD schema to the defaulting webhook.

Closes #7599 