### PR TITLE
test(e2e): strenghten readiness checks

### DIFF
--- a/tests/e2e/asserts_test.go
+++ b/tests/e2e/asserts_test.go
@@ -20,7 +20,6 @@ SPDX-License-Identifier: Apache-2.0
 package e2e
 
 import (
-	"context"
 	"database/sql"
 	"errors"
 	"fmt"
@@ -38,7 +37,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/utils/strings/slices"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -450,23 +448,6 @@ func AssertConnection(
 			g.Expect(strings.TrimSpace(rawValue)).To(BeEquivalentTo("1"))
 		}, RetryTimeout).Should(Succeed())
 	})
-}
-
-// AssertOperatorIsReady verifies that the operator is ready
-func AssertOperatorIsReady(
-	ctx context.Context,
-	crudClient ctrlclient.Client,
-	kubeInterface kubernetes.Interface,
-) {
-	Eventually(func() (bool, error) {
-		ready, err := operator.IsReady(ctx, crudClient, kubeInterface)
-		if ready && err == nil {
-			return true, nil
-		}
-		// Waiting a bit to avoid overloading the API server
-		time.Sleep(1 * time.Second)
-		return ready, err
-	}, testTimeouts[timeouts.OperatorIsReady]).Should(BeTrue(), "Operator pod is not ready")
 }
 
 type TableLocator struct {

--- a/tests/e2e/config_support_test.go
+++ b/tests/e2e/config_support_test.go
@@ -122,7 +122,7 @@ var _ = Describe("Config support", Serial, Ordered, Label(tests.LabelDisruptive,
 			Expect(err).ToNot(HaveOccurred())
 		}
 
-		err = operator.ReloadDeployment(env.Ctx, env.Client, env.Interface, 120)
+		err = operator.ReloadDeployment(env.Ctx, env.Client, 120)
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -156,7 +156,7 @@ var _ = Describe("Config support", Serial, Ordered, Label(tests.LabelDisruptive,
 		}, 10).Should(HaveLen(1))
 
 		// Reload the operator with the new config
-		err = operator.ReloadDeployment(env.Ctx, env.Client, env.Interface, 120)
+		err = operator.ReloadDeployment(env.Ctx, env.Client, 120)
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/tests/e2e/openshift_upgrade_test.go
+++ b/tests/e2e/openshift_upgrade_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/openshift"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/operator"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/run"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/timeouts"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -123,7 +124,8 @@ var _ = Describe("Upgrade Paths on OpenShift", Label(tests.LabelUpgrade), Ordere
 		By("Applying the initial subscription", func() {
 			err := openshift.CreateSubscription(env.Ctx, env.Client, initialSubscription)
 			Expect(err).ToNot(HaveOccurred())
-			AssertOperatorIsReady(env.Ctx, env.Client, env.Interface)
+			Expect(operator.WaitForReady(env.Ctx, env.Client, uint(testTimeouts[timeouts.OperatorIsReady]),
+				true)).Should(Succeed())
 		})
 
 		// Gather the version and semantic Versions of the operator
@@ -155,7 +157,8 @@ var _ = Describe("Upgrade Paths on OpenShift", Label(tests.LabelUpgrade), Ordere
 				return openshift.GetSubscriptionVersion(env.Ctx, env.Client)
 			}, 300).
 				ShouldNot(BeEquivalentTo(currentVersion))
-			AssertOperatorIsReady(env.Ctx, env.Client, env.Interface)
+			Expect(operator.WaitForReady(env.Ctx, env.Client, uint(testTimeouts[timeouts.OperatorIsReady]),
+				true)).Should(Succeed())
 		})
 
 		// Check if the upgrade was successful by making sure all the pods

--- a/tests/e2e/operator_deployment_test.go
+++ b/tests/e2e/operator_deployment_test.go
@@ -22,6 +22,7 @@ package e2e
 import (
 	"github.com/cloudnative-pg/cloudnative-pg/tests"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/operator"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/timeouts"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -38,10 +39,11 @@ var _ = Describe("PostgreSQL operator deployment", Label(tests.LabelBasic, tests
 
 	It("sets up the operator", func() {
 		By("having a pod for the operator in state ready", func() {
-			AssertOperatorIsReady(env.Ctx, env.Client, env.Interface)
+			Expect(operator.WaitForReady(env.Ctx, env.Client, uint(testTimeouts[timeouts.OperatorIsReady]),
+				true)).Should(Succeed())
 		})
 		By("having a deployment for the operator in state ready", func() {
-			ready, err := operator.IsDeploymentReady(env.Ctx, env.Client)
+			ready, err := operator.IsReady(env.Ctx, env.Client, true)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(ready).To(BeTrue())
 		})

--- a/tests/e2e/operator_unavailable_test.go
+++ b/tests/e2e/operator_unavailable_test.go
@@ -211,7 +211,7 @@ var _ = Describe("Operator unavailable", Serial, Label(tests.LabelDisruptive, te
 					g.Expect(podList.Items[0].Name).NotTo(BeEquivalentTo(operatorPodName))
 				}, timeout).Should(Succeed())
 				Eventually(func() (bool, error) {
-					return operator.IsDeploymentReady(env.Ctx, env.Client)
+					return operator.IsReady(env.Ctx, env.Client, true)
 				}, timeout).Should(BeTrue())
 			})
 

--- a/tests/e2e/self_fencing_test.go
+++ b/tests/e2e/self_fencing_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 	"github.com/cloudnative-pg/cloudnative-pg/tests"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/clusterutils"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/nodes"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/operator"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/run"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/timeouts"
@@ -132,11 +133,15 @@ var _ = Describe("Self-fencing with liveness probe", Serial, Label(tests.LabelDi
 				Name:      oldPrimaryPod.Name,
 			}
 			timeout := 180
-			Eventually(func() (bool, error) {
+			Eventually(func(g Gomega) {
 				pod := corev1.Pod{}
 				err := env.Client.Get(env.Ctx, namespacedName, &pod)
-				return utils.IsPodActive(pod) && utils.IsPodReady(pod) && specs.IsPodStandby(pod), err
-			}, timeout).Should(BeTrue())
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(utils.IsPodActive(pod)).To(BeTrue())
+				g.Expect(utils.IsPodReady(pod)).To(BeTrue())
+				g.Expect(specs.IsPodStandby(pod)).To(BeTrue())
+				g.Expect(nodes.IsNodeReachable(env.Ctx, env.Client, isolatedNode)).To(BeTrue())
+			}, timeout).Should(Succeed())
 		})
 	})
 })

--- a/tests/e2e/webhook_test.go
+++ b/tests/e2e/webhook_test.go
@@ -71,7 +71,7 @@ var _ = Describe("webhook", Serial, Label(tests.LabelDisruptive, tests.LabelOper
 			err := operator.ScaleOperatorDeployment(env.Ctx, env.Client, 1)
 			Expect(err).ToNot(HaveOccurred())
 
-			ready, err := operator.IsDeploymentReady(env.Ctx, env.Client)
+			ready, err := operator.IsReady(env.Ctx, env.Client, true)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(ready).To(BeTrue())
 		})
@@ -124,7 +124,7 @@ var _ = Describe("webhook", Serial, Label(tests.LabelDisruptive, tests.LabelOper
 
 		// Make sure the operator is intact and not crashing
 		By("having a deployment for the operator in state ready", func() {
-			ready, err := operator.IsDeploymentReady(env.Ctx, env.Client)
+			ready, err := operator.IsReady(env.Ctx, env.Client, false)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(ready).To(BeTrue())
 		})

--- a/tests/utils/operator/operator.go
+++ b/tests/utils/operator/operator.go
@@ -205,7 +205,7 @@ func IsReady(
 	return isWebhookWorking(ctx, crudClient)
 }
 
-// WaitForReady waits for the operator deployment to be ready
+// WaitForReady waits for the operator deployment to be ready.
 // If checkWebhook is true, it will also check that the webhook is replying
 func WaitForReady(
 	ctx context.Context,

--- a/tests/utils/operator/operator.go
+++ b/tests/utils/operator/operator.go
@@ -34,14 +34,13 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/manager/controller"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/deployments"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/objects"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/pods"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/run"
@@ -52,35 +51,21 @@ import (
 func ReloadDeployment(
 	ctx context.Context,
 	crudClient client.Client,
-	kubeInterface kubernetes.Interface,
 	timeoutSeconds uint,
 ) error {
 	operatorPod, err := GetPod(ctx, crudClient)
 	if err != nil {
 		return err
 	}
-	zero := int64(0)
+
 	err = crudClient.Delete(ctx, &operatorPod,
-		&client.DeleteOptions{GracePeriodSeconds: &zero},
+		&client.DeleteOptions{GracePeriodSeconds: ptr.To(int64(1))},
 	)
 	if err != nil {
 		return err
 	}
-	err = retry.Do(
-		func() error {
-			ready, err := IsReady(ctx, crudClient, kubeInterface)
-			if err != nil {
-				return err
-			}
-			if !ready {
-				return fmt.Errorf("operator pod %v is not ready", operatorPod.Name)
-			}
-			return nil
-		},
-		retry.Delay(time.Second),
-		retry.Attempts(timeoutSeconds),
-	)
-	return err
+	// Wait for the operator pod to be ready
+	return WaitForReady(ctx, crudClient, timeoutSeconds, true)
 }
 
 // Dump logs the JSON for the deployment in an operator namespace, its pods and endpoints
@@ -155,7 +140,7 @@ func GetDeployment(ctx context.Context, crudClient client.Client) (appsv1.Deploy
 func GetPod(ctx context.Context, crudClient client.Client) (corev1.Pod, error) {
 	podList := &corev1.PodList{}
 
-	// This will work for newer version of the operator, which are using
+	// This will work for newer versions of the operator, which are using
 	// our custom label
 	if err := objects.List(
 		ctx, crudClient,
@@ -163,29 +148,6 @@ func GetPod(ctx context.Context, crudClient client.Client) (corev1.Pod, error) {
 		return corev1.Pod{}, err
 	}
 	activePods := utils.FilterActivePods(podList.Items)
-	switch {
-	case len(activePods) > 1:
-		err := fmt.Errorf("number of running operator pods greater than 1: %v pods running", len(activePods))
-		return corev1.Pod{}, err
-
-	case len(activePods) == 1:
-		return activePods[0], nil
-	}
-
-	operatorNamespace, err := NamespaceName(ctx, crudClient)
-	if err != nil {
-		return corev1.Pod{}, err
-	}
-
-	// This will work for older version of the operator, which are using
-	// the default label from kube-builder
-	if err := objects.List(
-		ctx, crudClient, podList,
-		client.MatchingLabels{"control-plane": "controller-manager"},
-		client.InNamespace(operatorNamespace)); err != nil {
-		return corev1.Pod{}, err
-	}
-	activePods = utils.FilterActivePods(podList.Items)
 	if len(activePods) != 1 {
 		err := fmt.Errorf("number of running operator different than 1: %v pods running", len(activePods))
 		return corev1.Pod{}, err
@@ -207,23 +169,26 @@ func NamespaceName(ctx context.Context, crudClient client.Client) (string, error
 func IsReady(
 	ctx context.Context,
 	crudClient client.Client,
-	kubeInterface kubernetes.Interface,
+	checkWebhook bool,
 ) (bool, error) {
-	pod, err := GetPod(ctx, crudClient)
+	if ready, err := isDeploymentReady(ctx, crudClient); err != nil || !ready {
+		return ready, err
+	}
+
+	// If the operator is not managing webhooks, we don't need to check. Exit early
+	if !checkWebhook {
+		return true, nil
+	}
+
+	deploy, err := GetDeployment(ctx, crudClient)
 	if err != nil {
 		return false, err
 	}
-
-	isPodReady := utils.IsPodReady(pod)
-	if !isPodReady {
-		return false, err
-	}
-
-	namespace := pod.Namespace
+	namespace := deploy.GetNamespace()
 
 	// Detect if we are running under OLM
 	var webhookManagedByOLM bool
-	for _, envVar := range pod.Spec.Containers[0].Env {
+	for _, envVar := range deploy.Spec.Template.Spec.Containers[0].Env {
 		if envVar.Name == "WEBHOOK_CERT_DIR" {
 			webhookManagedByOLM = true
 		}
@@ -231,58 +196,52 @@ func IsReady(
 
 	// If the operator is managing certificates for webhooks, check that the setup is completed
 	if !webhookManagedByOLM {
-		err = checkWebhookReady(ctx, crudClient, kubeInterface, namespace)
+		err = checkWebhookSetup(ctx, crudClient, namespace)
 		if err != nil {
 			return false, err
 		}
 	}
 
-	// Dry run object creation to check that webhook Service is correctly running
-	testCluster := &apiv1.Cluster{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "readiness-check-" + rand.String(5),
-			Namespace: "default",
-		},
-		Spec: apiv1.ClusterSpec{
-			Instances: 3,
-			StorageConfiguration: apiv1.StorageConfiguration{
-				Size: "1Gi",
-			},
-		},
-	}
-	_, err = objects.Create(
-		ctx,
-		crudClient,
-		testCluster,
-		&client.CreateOptions{DryRun: []string{metav1.DryRunAll}},
-	)
-	if err != nil {
-		return false, err
-	}
-
-	return true, err
+	return isWebhookWorking(ctx, crudClient)
 }
 
-// IsDeploymentReady returns true if the operator deployment has the expected number
+// WaitForReady waits for the operator deployment to be ready
+// If checkWebhook is true, it will also check that the webhook is replying
+func WaitForReady(
+	ctx context.Context,
+	crudClient client.Client,
+	timeoutSeconds uint,
+	checkWebhook bool,
+) error {
+	return retry.Do(
+		func() error {
+			ready, err := IsReady(ctx, crudClient, checkWebhook)
+			if err != nil || !ready {
+				return fmt.Errorf("operator deployment is not ready")
+			}
+			return nil
+		},
+		retry.Delay(time.Second),
+		retry.Attempts(timeoutSeconds),
+	)
+}
+
+// isDeploymentReady returns true if the operator deployment has the expected number
 // of ready pods.
 // It returns an error if there was a problem getting the operator deployment
-func IsDeploymentReady(ctx context.Context, crudClient client.Client) (bool, error) {
+func isDeploymentReady(ctx context.Context, crudClient client.Client) (bool, error) {
 	operatorDeployment, err := GetDeployment(ctx, crudClient)
 	if err != nil {
 		return false, err
 	}
 
-	if operatorDeployment.Spec.Replicas != nil &&
-		operatorDeployment.Status.ReadyReplicas != *operatorDeployment.Spec.Replicas {
-		return false, fmt.Errorf("deployment not ready %v of %v ready",
-			operatorDeployment.Status.ReadyReplicas, operatorDeployment.Status.ReadyReplicas)
-	}
-
-	return true, nil
+	return deployments.IsReady(operatorDeployment), nil
 }
 
-// ScaleOperatorDeployment will scale the operator to n replicas and return error in case of failure
-func ScaleOperatorDeployment(ctx context.Context, crudClient client.Client, replicas int32) error {
+// ScaleOperatorDeployment will scale the operator to n replicas and return an error in case of failure
+func ScaleOperatorDeployment(
+	ctx context.Context, crudClient client.Client, replicas int32,
+) error {
 	operatorDeployment, err := GetDeployment(ctx, crudClient)
 	if err != nil {
 		return err
@@ -291,20 +250,13 @@ func ScaleOperatorDeployment(ctx context.Context, crudClient client.Client, repl
 	updatedOperatorDeployment := *operatorDeployment.DeepCopy()
 	updatedOperatorDeployment.Spec.Replicas = ptr.To(replicas)
 
-	// Scale down operator deployment to zero replicas
 	err = crudClient.Patch(ctx, &updatedOperatorDeployment, client.MergeFrom(&operatorDeployment))
 	if err != nil {
 		return err
 	}
 
-	return retry.Do(
-		func() error {
-			_, err := IsDeploymentReady(ctx, crudClient)
-			return err
-		},
-		retry.Delay(time.Second),
-		retry.Attempts(120),
-	)
+	// Wait for the operator deployment to be ready
+	return WaitForReady(ctx, crudClient, 120, replicas > 0)
 }
 
 // PodRenamed checks if the operator pod was renamed

--- a/tests/utils/operator/webhooks.go
+++ b/tests/utils/operator/webhooks.go
@@ -187,7 +187,7 @@ func getCNPGsMutatingWebhookConf(
 	return mutatingWebhookConfiguration, err
 }
 
-// CheckWebhookSetup checks if the webhook denies a invalid request
+// CheckWebhookSetup checks if the webhook denies an invalid request
 func isWebhookWorking(
 	ctx context.Context,
 	crudClient client.Client,

--- a/tests/utils/operator/webhooks.go
+++ b/tests/utils/operator/webhooks.go
@@ -26,11 +26,13 @@ import (
 
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/manager/controller"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/objects"
 )
@@ -75,16 +77,16 @@ func UpdateMutatingWebhookConf(
 }
 
 // getCNPGsValidatingWebhookConf get the ValidatingWebhook linked to the operator
-func getCNPGsValidatingWebhookConf(kubeInterface kubernetes.Interface) (
+func getCNPGsValidatingWebhookConf(
+	ctx context.Context,
+	crudClient client.Client,
+) (
 	*admissionregistrationv1.ValidatingWebhookConfiguration, error,
 ) {
-	ctx := context.Background()
-	validatingWebhookConfig, err := kubeInterface.AdmissionregistrationV1().ValidatingWebhookConfigurations().Get(
-		ctx, controller.ValidatingWebhookConfigurationName, metav1.GetOptions{})
-	if err != nil {
-		return nil, err
-	}
-	return validatingWebhookConfig, nil
+	validatingWebhookConf := &admissionregistrationv1.ValidatingWebhookConfiguration{}
+	err := crudClient.Get(ctx, types.NamespacedName{Name: controller.ValidatingWebhookConfigurationName},
+		validatingWebhookConf)
+	return validatingWebhookConf, err
 }
 
 // GetValidatingWebhookByName get ValidatingWebhook by the name of one
@@ -126,11 +128,10 @@ func UpdateValidatingWebhookConf(
 	return nil
 }
 
-// checkWebhookReady ensures that the operator has finished the webhook setup.
-func checkWebhookReady(
+// checkWebhookSetup ensures that the operator has finished the webhook setup.
+func checkWebhookSetup(
 	ctx context.Context,
 	crudClient client.Client,
-	kubeInterface kubernetes.Interface,
 	namespace string,
 ) error {
 	// Check CA
@@ -146,7 +147,7 @@ func checkWebhookReady(
 
 	ca := secret.Data["tls.crt"]
 
-	mutatingWebhookConfig, err := getCNPGsMutatingWebhookConf(ctx, kubeInterface)
+	mutatingWebhookConfig, err := getCNPGsMutatingWebhookConf(ctx, crudClient)
 	if err != nil {
 		return err
 	}
@@ -158,7 +159,7 @@ func checkWebhookReady(
 		}
 	}
 
-	validatingWebhookConfig, err := getCNPGsValidatingWebhookConf(kubeInterface)
+	validatingWebhookConfig, err := getCNPGsValidatingWebhookConf(ctx, crudClient)
 	if err != nil {
 		return err
 	}
@@ -176,11 +177,38 @@ func checkWebhookReady(
 // getCNPGsMutatingWebhookConf get the MutatingWebhook linked to the operator
 func getCNPGsMutatingWebhookConf(
 	ctx context.Context,
-	kubeInterface kubernetes.Interface,
+	crudClient client.Client,
 ) (
 	*admissionregistrationv1.MutatingWebhookConfiguration, error,
 ) {
-	return kubeInterface.AdmissionregistrationV1().
-		MutatingWebhookConfigurations().
-		Get(ctx, controller.MutatingWebhookConfigurationName, metav1.GetOptions{})
+	mutatingWebhookConfiguration := &admissionregistrationv1.MutatingWebhookConfiguration{}
+	err := crudClient.Get(ctx, types.NamespacedName{Name: controller.MutatingWebhookConfigurationName},
+		mutatingWebhookConfiguration)
+	return mutatingWebhookConfiguration, err
+}
+
+// CheckWebhookSetup checks if the webhook denies a invalid request
+func isWebhookWorking(
+	ctx context.Context,
+	crudClient client.Client,
+) (bool, error) {
+	invalidCluster := &apiv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "invalid"},
+		Spec:       apiv1.ClusterSpec{Instances: 1},
+	}
+	_, err := objects.Create(
+		ctx,
+		crudClient,
+		invalidCluster,
+		&client.CreateOptions{DryRun: []string{metav1.DryRunAll}},
+	)
+	// If the error is not an invalid error, return false
+	if !errors.IsInvalid(err) {
+		return false, fmt.Errorf("expected invalid error, got: %v", err)
+	}
+	// If the error doesn't contain the expected message, return false
+	if !bytes.Contains([]byte(err.Error()), []byte("spec.storage.size")) {
+		return false, fmt.Errorf("expected error to contain 'spec.storage.size', got: %v", err)
+	}
+	return true, nil
 }


### PR DESCRIPTION
Fixes some cases in the e2e where the tests would race to the next test when
the operator is not ready yet, or when the nodes are not ready.

Refactor the code to improve reuse and simplify signatures.

Closes #7589 