### PR TITLE
chore: stop testing Kubernetes versions older than 1.29

### DIFF
--- a/.github/k8s_versions_scope.json
+++ b/.github/k8s_versions_scope.json
@@ -1,10 +1,10 @@
 {
   "e2e_test": {
-    "KIND": {"min": "1.27", "max": ""},
-    "AKS": {"min": "1.28", "max": ""},
+    "KIND": {"min": "1.29", "max": ""},
+    "AKS": {"min": "1.29", "max": ""},
     "EKS": {"min": "1.29", "max": ""},
     "GKE": {"min": "1.29", "max": ""},
-    "OPENSHIFT": {"min":  "4.12", "max": ""}
+    "OPENSHIFT": {"min":  "4.16", "max": ""}
   },
-  "unit_test": {"min":  "1.27", "max":  "1.33"}
+  "unit_test": {"min":  "1.29", "max":  "1.33"}
 }


### PR DESCRIPTION
Removed support for Kubernetes (and OpenShift) versions older than 1.29.

Closes #7607 