### PR TITLE
Fix: Default synchronous_commit method to 'any'

### DIFF
--- a/api/v1/cluster_defaults.go
+++ b/api/v1/cluster_defaults.go
@@ -102,6 +102,13 @@ func (r *Cluster) setDefaults(preserveUserSettings bool) {
 		r.Spec.PostgresConfiguration.Parameters = sanitizedParameters
 	}
 
+	// Default synchronous_commit method if not specified.
+	// This is done after the general parameter sanitization to ensure
+	// that if Synchronous is defined, its Method subfield gets a default.
+	if r.Spec.PostgresConfiguration.Synchronous != nil && r.Spec.PostgresConfiguration.Synchronous.Method == "" {
+		r.Spec.PostgresConfiguration.Synchronous.Method = "any"
+	}
+
 	if r.Spec.LogLevel == "" {
 		r.Spec.LogLevel = log.InfoLevelString
 	}

--- a/api/v1/cluster_defaults_test.go
+++ b/api/v1/cluster_defaults_test.go
@@ -317,3 +317,45 @@ var _ = Describe("setDefaultPlugins", func() {
 			ContainElement(PluginConfiguration{Name: "predefined-plugin1", Enabled: ptr.To(true)}))
 	})
 })
+
+var _ = Describe("Cluster synchronous commit defaults", func() {
+	It("should default Synchronous.Method to 'any' when Synchronous is present and Method is empty", func() {
+		cluster := &Cluster{
+			Spec: ClusterSpec{
+				PostgresConfiguration: PostgresConfiguration{
+					Synchronous: &SynchronousReplicaConfiguration{},
+				},
+			},
+		}
+		cluster.SetDefaults() // Use SetDefaults to apply all defaults including the new one
+		Expect(cluster.Spec.PostgresConfiguration.Synchronous).ToNot(BeNil())
+		Expect(cluster.Spec.PostgresConfiguration.Synchronous.Method).To(Equal(SynchronousReplicaConfigurationMethodAny))
+	})
+
+	It("should not panic and leave Synchronous nil if it's not defined", func() {
+		cluster := &Cluster{
+			Spec: ClusterSpec{
+				PostgresConfiguration: PostgresConfiguration{
+					Synchronous: nil,
+				},
+			},
+		}
+		cluster.SetDefaults()
+		Expect(cluster.Spec.PostgresConfiguration.Synchronous).To(BeNil())
+	})
+
+	It("should not overwrite an existing Synchronous.Method", func() {
+		cluster := &Cluster{
+			Spec: ClusterSpec{
+				PostgresConfiguration: PostgresConfiguration{
+					Synchronous: &SynchronousReplicaConfiguration{
+						Method: SynchronousReplicaConfigurationMethodFirst,
+					},
+				},
+			},
+		}
+		cluster.SetDefaults()
+		Expect(cluster.Spec.PostgresConfiguration.Synchronous).ToNot(BeNil())
+		Expect(cluster.Spec.PostgresConfiguration.Synchronous.Method).To(Equal(SynchronousReplicaConfigurationMethodFirst))
+	})
+})


### PR DESCRIPTION
When creating a Cluster via OLM with only default settings, the `spec.postgresql.synchronous.method` field was being submitted as an empty string, leading to a validation error: "Unsupported value: "": supported values: "any", "first"".

This change modifies the defaulting logic in `api/v1/cluster_defaults.go` to set `spec.postgresql.synchronous.method` to "any" if the `synchronous` block is present but the `method` is not specified.

Unit tests have been added to `api/v1/cluster_defaults_test.go` to verify:
- The method defaults to "any" when the synchronous block is present and the method is empty.
- The synchronous block remains nil if not initially defined.
- An existing method value is not overwritten by the default.