### PR TITLE
chore: improve OLM interface by adding fields

### DIFF
--- a/config/olm-manifests/bases/cloudnative-pg.clusterserviceversion.yaml
+++ b/config/olm-manifests/bases/cloudnative-pg.clusterserviceversion.yaml
@@ -472,21 +472,6 @@ spec:
         description: Configuration of the probes to be injected in the PostgreSQL instances
         x-descriptors:
           - 'urn:alm:descriptor:com.tectonic.ui:advanced'
-      - path: probes.liveness
-        displayName: Liveness Probe configuration
-        description: Configuration of the liveness probe
-        x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:advanced'
-      - path: probes.startup
-        displayName: Startup Probe configuration
-        description: Configuration of the startup probe
-        x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:advanced'
-      - path: probes.readiness
-        displayName: Readiness Probe configuration
-        description: Configuration of the readiness probe
-        x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:advanced'
       # Affinity section
       - path: affinity
         displayName: Pod Affinity

--- a/config/olm-manifests/bases/cloudnative-pg.clusterserviceversion.yaml
+++ b/config/olm-manifests/bases/cloudnative-pg.clusterserviceversion.yaml
@@ -139,6 +139,7 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
+    # Backup Section
     - kind: Backup
       name: backups.postgresql.cnpg.io
       displayName: Backups
@@ -163,6 +164,7 @@ spec:
         path: phase
         x-descriptors:
         - 'urn:alm:descriptor:io.kubernetes.phase'
+    # Cluster Section
     - kind: Cluster
       name: clusters.postgresql.cnpg.io
       version: v1
@@ -319,6 +321,18 @@ spec:
         description: Boolean to enable TLS
         x-descriptors:
           - 'urn:alm:descriptor:com.tectonic.ui:booleanSwitch'
+      - path: postgresql.synchronous
+        displayName: Synchronous Replication Configuration
+        description: Configuration of the synchronous replication feature
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+      - path: postgresql.synchronous.method
+        displayName: Synchronous Replication Configuration Method
+        description: The method to use for synchronous replication feature
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:select:any'
+          - 'urn:alm:descriptor:com.tectonic.ui:select:first'
+          - 'urn:alm:descriptor:com.tectonic.ui:advanced'
       - path: tablespaces
         displayName: Tablespaces
         description: Configuration of the tablespaces
@@ -451,6 +465,27 @@ spec:
           complete
         x-descriptors:
           - 'urn:alm:descriptor:com.tectonic.ui:number'
+          - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+      # Probes configuration section
+      - path: probes
+        display: Probes Configuration
+        description: Configuration of the probes to be injected in the PostgreSQL instances
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+      - path: probes.liveness
+        displayName: Liveness Probe configuration
+        description: Configuration of the liveness probe
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+      - path: probes.startup
+        displayName: Startup Probe configuration
+        description: Configuration of the startup probe
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+      - path: probes.readiness
+        displayName: Readiness Probe configuration
+        description: Configuration of the readiness probe
+        x-descriptors:
           - 'urn:alm:descriptor:com.tectonic.ui:advanced'
       # Affinity section
       - path: affinity


### PR DESCRIPTION
Added some missing fields in the section `spec.postgresql.synchronous` and
`spec.probes` for the OLM UI have a better looking

Partially-closes: #7616 