### PR TITLE
feat: allow postgres executable name customization

### DIFF
--- a/internal/cmd/manager/instance/run/lifecycle/reaper.go
+++ b/internal/cmd/manager/instance/run/lifecycle/reaper.go
@@ -102,7 +102,7 @@ func (z *PostgresOrphansReaper) handleSignal(contextLogger log.Logger) error {
 	pidFile := path.Join(z.instance.PgData, postgres.PostgresqlPidFile)
 	_, postMasterPid, _ := z.instance.GetPostmasterPidFromFile(pidFile)
 	for _, p := range processes {
-		if p.PPid() == 1 && p.Executable() == "postgres" {
+		if p.PPid() == 1 && p.Executable() == postgres.GetPostgresExecutableName() {
 			pid := p.Pid()
 			if pid == postMasterPid {
 				continue

--- a/pkg/management/postgres/instance.go
+++ b/pkg/management/postgres/instance.go
@@ -59,7 +59,6 @@ import (
 )
 
 const (
-	postgresName      = "postgres"
 	pgCtlName         = "pg_ctl"
 	pgRewindName      = "pg_rewind"
 	pgBaseBackupName  = "pg_basebackup"
@@ -72,6 +71,15 @@ const (
 	pqPingNoResponse = 2 // could not establish connection
 	pgPingNoAttempt  = 3 // connection not attempted (bad params)
 )
+
+// GetPostgresExecutableName returns the name of the PostgreSQL executable
+func GetPostgresExecutableName() string {
+	if name := os.Getenv("POSTGRES_NAME"); name != "" {
+		return name
+	}
+
+	return "postgres"
+}
 
 // shutdownMode represent a way to request the postmaster shutdown
 type shutdownMode string
@@ -670,7 +678,7 @@ func (instance *Instance) Reload(ctx context.Context) error {
 // Run this instance returning an OS process needed
 // to control the instance execution
 func (instance *Instance) Run() (*execlog.StreamingCmd, error) {
-	process, err := instance.CheckForExistingPostmaster(postgresName)
+	process, err := instance.CheckForExistingPostmaster(GetPostgresExecutableName())
 	if err != nil {
 		return nil, err
 	}
@@ -703,11 +711,11 @@ func (instance *Instance) Run() (*execlog.StreamingCmd, error) {
 		return nil, err
 	}
 
-	postgresCmd := exec.Command(postgresName, options...) // #nosec
+	postgresCmd := exec.Command(GetPostgresExecutableName(), options...) // #nosec
 	postgresCmd.Env = instance.Env
 	compatibility.AddInstanceRunCommands(postgresCmd)
 
-	streamingCmd, err := execlog.RunStreamingNoWait(postgresCmd, postgresName)
+	streamingCmd, err := execlog.RunStreamingNoWait(postgresCmd, GetPostgresExecutableName())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/management/postgres/pidfile_test.go
+++ b/pkg/management/postgres/pidfile_test.go
@@ -52,7 +52,7 @@ var _ = Describe("the detection of a postmaster process using the pid file", fun
 		instance := NewInstance()
 		instance.PgData = pgdata
 		instance.SocketDirectory = socketDir
-		process, err := instance.CheckForExistingPostmaster(postgresName)
+		process, err := instance.CheckForExistingPostmaster(GetPostgresExecutableName())
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(process).To(BeNil())
 	})
@@ -70,7 +70,7 @@ var _ = Describe("the detection of a postmaster process using the pid file", fun
 		err = os.WriteFile(filepath.Join(socketDir, ".s.PGSQL.5432.lock"), []byte("1234"), 0o400)
 		Expect(err).ShouldNot(HaveOccurred())
 
-		process, err := instance.CheckForExistingPostmaster(postgresName)
+		process, err := instance.CheckForExistingPostmaster(GetPostgresExecutableName())
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(process).To(BeNil())
 


### PR DESCRIPTION
## Release Notes

The default PostgreSQL executable name can be changed by adding the `POSTGRES_NAME` environment variable to the instance container.


Closes #7625 
