### PR TITLE
feat(plugin): remove 386 and arm architectures from the build

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -71,9 +71,7 @@ builds:
   - windows
   goarch:
   - amd64
-  - 386
   - arm64
-  - arm
   - ppc64le
   - s390x
   goarm:
@@ -81,8 +79,6 @@ builds:
   - 6
   - 7
   ignore:
-  - goos: darwin
-    goarch: 386
   - goos: windows
     goarch: ppc64le
   - goos: windows
@@ -93,7 +89,6 @@ archives:
     kubectl-cnpg_{{ .Version }}_
     {{- .Os }}_
     {{- if eq .Arch "amd64" }}x86_64
-    {{- else if eq .Arch "386" }}i386
     {{- else }}{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}{{ end }}
   ids:
   - kubectl-cnpg
@@ -104,7 +99,6 @@ nfpms:
       kubectl-cnpg_{{ .Version }}_
       {{- .Os }}_
       {{- if eq .Arch "amd64" }}x86_64
-      {{- else if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}{{ end }}
     homepage: https://github.com/cloudnative-pg/cloudnative-pg
     bindir: /usr/local/bin


### PR DESCRIPTION
The architectures 386 and arm5/6/7 aren't way too used, and just
removing these architectures we reduce to half the amount of os/arch
we build for the plugin.

Closes #7564 