### PR TITLE
chore(ci): remove release-1.24 branch and added release-1.26

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -11,8 +11,8 @@
   baseBranches: [
     'main',
     'release-1.22',
-    'release-1.24',
-    'release-1.25'
+    'release-1.25',
+    'release-1.26',
   ],
   ignorePaths: [
     'docs/**',

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -36,8 +36,8 @@ jobs:
           labels: |
             backport-requested :arrow_backward:
             release-1.22
-            release-1.24
             release-1.25
+            release-1.26
       -
         name: Create comment
         uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4
@@ -60,8 +60,8 @@ jobs:
           labels: |
             backport-requested :arrow_backward:
             release-1.22
-            release-1.24
             release-1.25
+            release-1.26
 
   ## backport pull request in condition when pr contains 'backport-requested' label and contains target branches labels
   back-porting-pr:
@@ -77,7 +77,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: [release-1.22, release-1.24, release-1.25]
+        branch: [release-1.22, release-1.25, release-1.26]
     env:
       PR: ${{ github.event.pull_request.number }}
     outputs:

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -74,7 +74,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: [release-1.22, release-1.24, release-1.25]
+        branch: [release-1.22, release-1.25, release-1.26]
     steps:
       - name: Invoke workflow with inputs
         uses: benc-uk/workflow-dispatch@e2e5e9a103e331dad343f381a29e654aea3cf8fc # v1

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -57,7 +57,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: [release-1.22, release-1.24, release-1.25]
+        branch: [release-1.22, release-1.25, release-1.26]
     steps:
       - name: Invoke workflow with inputs
         uses: benc-uk/workflow-dispatch@e2e5e9a103e331dad343f381a29e654aea3cf8fc # v1


### PR DESCRIPTION
The branch release-1.24 is now locked, and no changes should be made to it.
The new branch added to the list is release-1.26.

Closes #7649 