### PR TITLE
test: adjust E2E tests to run with minimal images

### DIFF
--- a/tests/e2e/fixtures/declarative_databases/database.yaml.template
+++ b/tests/e2e/fixtures/declarative_databases/database.yaml.template
@@ -5,7 +5,7 @@ metadata:
 spec:
   name: declarative
   owner: app
-  localeCType: "C.utf8"
+  localeCType: C
   localeCollate: C
   encoding: SQL_ASCII
   template: template0

--- a/tests/e2e/fixtures/declarative_databases/database.yaml.template
+++ b/tests/e2e/fixtures/declarative_databases/database.yaml.template
@@ -5,7 +5,7 @@ metadata:
 spec:
   name: declarative
   owner: app
-  localeCType: "en_US.utf8"
+  localeCType: "C.utf8"
   localeCollate: C
   encoding: SQL_ASCII
   template: template0

--- a/tests/e2e/fixtures/initdb/cluster-custom-locale.yaml.template
+++ b/tests/e2e/fixtures/initdb/cluster-custom-locale.yaml.template
@@ -25,7 +25,7 @@ spec:
       owner: app
       options:
       - "--locale"
-      - "en_US.utf8"
+      - "C.utf8"
 
   # Persistent storage configuration
   storage:

--- a/tests/e2e/fixtures/initdb/cluster-custom-locale.yaml.template
+++ b/tests/e2e/fixtures/initdb/cluster-custom-locale.yaml.template
@@ -25,7 +25,7 @@ spec:
       owner: app
       options:
       - "--locale"
-      - "C.utf8"
+      - "C"
 
   # Persistent storage configuration
   storage:

--- a/tests/e2e/initdb_test.go
+++ b/tests/e2e/initdb_test.go
@@ -176,7 +176,7 @@ var _ = Describe("InitDB settings", Label(tests.LabelSmoke, tests.LabelBasic), f
 					}, "postgres",
 					"select datcollate from pg_catalog.pg_database where datname='template0'")
 				Expect(err).ToNot(HaveOccurred())
-				Expect(strings.TrimSpace(stdout), err).To(Equal("C.utf8"))
+				Expect(strings.TrimSpace(stdout), err).To(Equal("C"))
 			})
 		})
 	})

--- a/tests/e2e/initdb_test.go
+++ b/tests/e2e/initdb_test.go
@@ -176,7 +176,7 @@ var _ = Describe("InitDB settings", Label(tests.LabelSmoke, tests.LabelBasic), f
 					}, "postgres",
 					"select datcollate from pg_catalog.pg_database where datname='template0'")
 				Expect(err).ToNot(HaveOccurred())
-				Expect(stdout, err).To(Equal("en_US.utf8\n"))
+				Expect(strings.TrimSpace(stdout), err).To(Equal("C.utf8"))
 			})
 		})
 	})

--- a/tests/e2e/replica_mode_cluster_test.go
+++ b/tests/e2e/replica_mode_cluster_test.go
@@ -340,7 +340,7 @@ var _ = Describe("Replica Mode", Label(tests.LabelReplication), func() {
 		})
 	})
 
-	Context("can bootstrap a replica cluster from a backup", Ordered, Label(tests.LabelBackupRestore), func() {
+	Context("can bootstrap a replica cluster from a backup", Label(tests.LabelBackupRestore), Ordered, func() {
 		const (
 			clusterSample   = fixturesDir + replicaModeClusterDir + "cluster-replica-src-with-backup.yaml.template"
 			namespacePrefix = "replica-cluster-from-backup"

--- a/tests/e2e/replica_mode_cluster_test.go
+++ b/tests/e2e/replica_mode_cluster_test.go
@@ -269,7 +269,7 @@ var _ = Describe("Replica Mode", Label(tests.LabelReplication), func() {
 		})
 	})
 
-	Context("archive mode set to 'always' on designated primary", func() {
+	Context("archive mode set to 'always' on designated primary", Label(tests.LabelBackupRestore), func() {
 		It("verifies replica cluster can archive WALs from the designated primary", func() {
 			const (
 				replicaClusterSample   = fixturesDir + replicaModeClusterDir + "cluster-replica-archive-mode-always.yaml.template"
@@ -340,7 +340,7 @@ var _ = Describe("Replica Mode", Label(tests.LabelReplication), func() {
 		})
 	})
 
-	Context("can bootstrap a replica cluster from a backup", Ordered, func() {
+	Context("can bootstrap a replica cluster from a backup", Ordered, Label(tests.LabelBackupRestore), func() {
 		const (
 			clusterSample   = fixturesDir + replicaModeClusterDir + "cluster-replica-src-with-backup.yaml.template"
 			namespacePrefix = "replica-cluster-from-backup"
@@ -492,7 +492,7 @@ var _ = Describe("Replica Mode", Label(tests.LabelReplication), func() {
 
 // In this test we create a replica cluster from a backup and then promote it to a primary.
 // We expect the original primary to be demoted to a replica and be able to follow the new primary.
-var _ = Describe("Replica switchover", Label(tests.LabelReplication), Ordered, func() {
+var _ = Describe("Replica switchover", Label(tests.LabelReplication, tests.LabelBackupRestore), Ordered, func() {
 	const (
 		replicaSwitchoverClusterDir = "/replica_mode_cluster/"
 		namespacePrefix             = "replica-switchover"


### PR DESCRIPTION
Minor adjustments to a few E2E tests to be able to run the testing suite using a -minimal image, specifically:

- Avoid referencing locales that are not available in minimal images
- Label Replica Cluster E2Es which require bootstrapping from a backup with LabelBackupRestore. This is useful because it allows running E2Es excluding all the tests that require backup/recovery capabilities, given that -minimal images do not contain Barman cloud.
They can be skipped by setting FEATURE_TYPE=!backup-restore

Closes #7654 