### PR TITLE
chore: improve renovate configuration

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -20,382 +20,215 @@
     'contribute/**',
     'licenses/**',
     'pkg/versions/**',
-    'pkg/specs/pgbouncer/',
+    'pkg/specs/pgbouncer/'
   ],
   postUpdateOptions: [
-    'gomodTidy',
+    'gomodTidy'
   ],
   semanticCommits: 'enabled',
   labels: [
     'automated',
     'do not backport',
-    'no-issue',
+    'no-issue'
   ],
   customManagers: [
     {
-      customType: 'regex',
+      customType: "regex",
       fileMatch: [
-        '^Makefile$',
+        "^Makefile$"
       ],
       matchStrings: [
-        'KUSTOMIZE_VERSION \\?= (?<currentValue>.*?)\\n',
-      ],
-      datasourceTemplate: 'go',
-      depNameTemplate: 'sigs.k8s.io/kustomize/kustomize/v5',
+        "# renovate: datasource=(?<datasource>[a-z-.]+?) depName=(?<depName>[^\\s]+?)(?: (?:lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?\\s+[A-Za-z0-9_]+?_VERSION\\s*\\?=\\s*[\"']?(?<currentValue>.+?)[\"']?\\s"
+      ]
     },
     {
-      customType: 'regex',
+      customType: "regex",
       fileMatch: [
-        '^Makefile$',
+        '^\\.github\\/workflows\\/[^/]+\\.ya?ml$'
       ],
       matchStrings: [
-        'CONTROLLER_TOOLS_VERSION \\?= (?<currentValue>.*?)\\n',
-      ],
-      datasourceTemplate: 'go',
-      depNameTemplate: 'sigs.k8s.io/controller-tools',
-    },
-{
-      customType: 'regex',
-      fileMatch: [
-        '^Makefile$',
-      ],
-      matchStrings: [
-        'GENREF_VERSION \\?= (?<currentValue>.*?)\\n',
-      ],
-      datasourceTemplate: 'go',
-      depNameTemplate: 'github.com/kubernetes-sigs/reference-docs/genref',
-    },
-    {
-      customType: 'regex',
-      fileMatch: [
-        '^Makefile$',
-      ],
-      matchStrings: [
-        'GORELEASER_VERSION \\?= (?<currentValue>.*?)\\n',
-      ],
-      datasourceTemplate: 'go',
-      versioningTemplate: 'loose',
-      depNameTemplate: 'github.com/goreleaser/goreleaser',
+        "# renovate: datasource=(?<datasource>[a-z-.]+?) depName=(?<depName>[^\\s]+?)(?: (?:lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?\\s+[A-Za-z0-9_]+?_VERSION\\s*\: \\s*[\"']?(?<currentValue>.+?)[\"']?\\s"
+      ]
     },
     {
       customType: 'regex',
       fileMatch: [
         '^.github/workflows/continuous-delivery.yml',
-        '^hack/setup-cluster.sh$',
+        '^hack/setup-cluster.sh$'
       ],
       matchStrings: [
         'EXTERNAL_SNAPSHOTTER_VERSION: "(?<currentValue>.*?)"',
-        'EXTERNAL_SNAPSHOTTER_VERSION=(?<currentValue>.*?)\\n',
+        'EXTERNAL_SNAPSHOTTER_VERSION=(?<currentValue>.*?)\\n'
       ],
       datasourceTemplate: 'github-releases',
       versioningTemplate: 'loose',
       depNameTemplate: 'kubernetes-csi/external-snapshotter',
-      extractVersionTemplate: '^(?<version>v\\d+\\.\\d+\\.\\d+)',
+      extractVersionTemplate: '^(?<version>v\\d+\\.\\d+\\.\\d+)'
     },
     {
       customType: 'regex',
       fileMatch: [
-        '^hack/setup-cluster.sh$',
+        '^hack/setup-cluster.sh$'
       ],
       matchStrings: [
-        'EXTERNAL_PROVISIONER_VERSION=(?<currentValue>.*?)\\n',
+        'EXTERNAL_PROVISIONER_VERSION=(?<currentValue>.*?)\\n'
       ],
       datasourceTemplate: 'github-releases',
       versioningTemplate: 'loose',
       depNameTemplate: 'kubernetes-csi/external-provisioner',
-      extractVersionTemplate: '^(?<version>v\\d+\\.\\d+\\.\\d+)',
+      extractVersionTemplate: '^(?<version>v\\d+\\.\\d+\\.\\d+)'
     },
     {
       customType: 'regex',
       fileMatch: [
-        '^hack/setup-cluster.sh$',
+        '^hack/setup-cluster.sh$'
       ],
       matchStrings: [
-        'EXTERNAL_RESIZER_VERSION=(?<currentValue>.*?)\\n',
+        'EXTERNAL_RESIZER_VERSION=(?<currentValue>.*?)\\n'
       ],
       datasourceTemplate: 'github-releases',
       versioningTemplate: 'loose',
       depNameTemplate: 'kubernetes-csi/external-resizer',
-      extractVersionTemplate: '^(?<version>v\\d+\\.\\d+\\.\\d+)',
+      extractVersionTemplate: '^(?<version>v\\d+\\.\\d+\\.\\d+)'
     },
     {
       customType: 'regex',
       fileMatch: [
-        '^hack/setup-cluster.sh$',
+        '^hack/setup-cluster.sh$'
       ],
       matchStrings: [
-        'EXTERNAL_ATTACHER_VERSION=(?<currentValue>.*?)\\n',
+        'EXTERNAL_ATTACHER_VERSION=(?<currentValue>.*?)\\n'
       ],
       datasourceTemplate: 'github-releases',
       versioningTemplate: 'loose',
       depNameTemplate: 'kubernetes-csi/external-attacher',
-      extractVersionTemplate: '^(?<version>v\\d+\\.\\d+\\.\\d+)',
+      extractVersionTemplate: '^(?<version>v\\d+\\.\\d+\\.\\d+)'
     },
     {
       customType: 'regex',
       fileMatch: [
-        '^hack/setup-cluster.sh$',
+        '^hack/setup-cluster.sh$'
       ],
       matchStrings: [
-        'CSI_DRIVER_HOST_PATH_DEFAULT_VERSION=(?<currentValue>.*?)\\n',
+        'CSI_DRIVER_HOST_PATH_DEFAULT_VERSION=(?<currentValue>.*?)\\n'
       ],
       datasourceTemplate: 'github-releases',
       versioningTemplate: 'loose',
       depNameTemplate: 'kubernetes-csi/csi-driver-host-path',
-      extractVersionTemplate: '^(?<version>v\\d+\\.\\d+\\.\\d+)',
-    },
-    {
-      customType: 'regex',
-      fileMatch: [
-        '^.github/workflows/continuous-delivery.yml',
-      ],
-      matchStrings: [
-        'ROOK_VERSION: "(?<currentValue>.*?)"',
-      ],
-      datasourceTemplate: 'github-releases',
-      versioningTemplate: 'loose',
-      depNameTemplate: 'rook/rook',
-      extractVersionTemplate: '^(?<version>v\\d+\\.\\d+\\.\\d+)',
-    },
-    {
-      customType: 'regex',
-      fileMatch: [
-        '^.github/workflows/continuous-delivery.yml',
-        '^.github/workflows/continuous-integration.yml',
-      ],
-      matchStrings: [
-        'KIND_VERSION: "(?<currentValue>.*?)"',
-      ],
-      datasourceTemplate: 'github-tags',
-      depNameTemplate: 'kubernetes-sigs/kind',
+      extractVersionTemplate: '^(?<version>v\\d+\\.\\d+\\.\\d+)'
     },
     {
       customType: 'regex',
       fileMatch: [
         '^hack/setup-cluster.sh$',
-        '^hack/e2e/run-e2e-kind.sh$',
+        '^hack/e2e/run-e2e-kind.sh$'
       ],
       matchStrings: [
-        'KIND_NODE_DEFAULT_VERSION=(?<currentValue>.*?)\\n',
+        'KIND_NODE_DEFAULT_VERSION=(?<currentValue>.*?)\\n'
       ],
       datasourceTemplate: 'docker',
       versioningTemplate: 'loose',
-      depNameTemplate: 'kindest/node',
-    },
-    {
-      customType: 'regex',
-      fileMatch: [
-        '^Makefile$',
-      ],
-      matchStrings: [
-        'SPELLCHECK_VERSION \\?= (?<currentValue>.*?)\\n',
-      ],
-      datasourceTemplate: 'docker',
-      versioningTemplate: 'loose',
-      depNameTemplate: 'jonasbn/github-action-spellcheck',
-    },
-    {
-      customType: 'regex',
-      fileMatch: [
-        '^Makefile$',
-      ],
-      matchStrings: [
-        'WOKE_VERSION \\?= (?<currentValue>.*?)\\n',
-      ],
-      datasourceTemplate: 'docker',
-      versioningTemplate: 'loose',
-      depNameTemplate: 'getwoke/woke',
-    },
-    {
-      customType: 'regex',
-      fileMatch: [
-        '^Makefile$',
-      ],
-      matchStrings: [
-        'OPERATOR_SDK_VERSION \\?= (?<currentValue>.*?)\\n',
-      ],
-      datasourceTemplate: 'github-releases',
-      depNameTemplate: 'operator-framework/operator-sdk',
-      versioningTemplate: 'loose',
-      extractVersionTemplate: '^(?<version>v\\d+\\.\\d+\\.\\d+)',
-    },
-    {
-      customType: 'regex',
-      fileMatch: [
-        '^Makefile$',
-      ],
-      matchStrings: [
-        'OPM_VERSION \\?= (?<currentValue>.*?)\\n',
-      ],
-      datasourceTemplate: 'github-releases',
-      depNameTemplate: 'operator-framework/operator-registry',
-      versioningTemplate: 'loose',
-      extractVersionTemplate: '^(?<version>v\\d+\\.\\d+\\.\\d+)',
-    },
-    {
-      customType: 'regex',
-      fileMatch: [
-        '^Makefile$',
-      ],
-      matchStrings: [
-        'PREFLIGHT_VERSION \\?= (?<currentValue>.*?)\\n',
-      ],
-      datasourceTemplate: 'github-releases',
-      depNameTemplate: 'redhat-openshift-ecosystem/openshift-preflight',
-      versioningTemplate: 'loose',
-      extractVersionTemplate: '^(?<version>\\d+\\.\\d+\\.\\d+)',
+      depNameTemplate: 'kindest/node'
     },
     {
       customType: 'regex',
       fileMatch: [
         '^config\\/olm-scorecard\\/patches\\/basic\\.config\\.yaml$',
-        '^config\\/olm-scorecard\\/patches\\/olm\\.config\\.yaml$',
+        '^config\\/olm-scorecard\\/patches\\/olm\\.config\\.yaml$'
       ],
       matchStrings: [
-        'image: quay.io/operator-framework/scorecard-test:(?<currentValue>.*?)\\n',
+        'image: quay.io/operator-framework/scorecard-test:(?<currentValue>.*?)\\n'
       ],
       datasourceTemplate: 'docker',
       versioningTemplate: 'loose',
       depNameTemplate: 'quay.io/operator-framework/scorecard-test',
-      extractVersionTemplate: '^(?<version>v\\d+\\.\\d+\\.\\d+)',
+      extractVersionTemplate: '^(?<version>v\\d+\\.\\d+\\.\\d+)'
     },
     {
       customType: 'regex',
       fileMatch: [
         '^pkg\\/versions\\/versions\\.go$',
-        '^pkg\\/specs\\/pgbouncer\\/deployments\\.go$',
+        '^pkg\\/specs\\/pgbouncer\\/deployments\\.go$'
       ],
       matchStrings: [
         'DefaultImageName = "(?<depName>.+?):(?<currentValue>.*?)"\\n',
-        'DefaultPgbouncerImage = "(?<depName>.+?):(?<currentValue>.*?)"\\n',
+        'DefaultPgbouncerImage = "(?<depName>.+?):(?<currentValue>.*?)"\\n'
       ],
       datasourceTemplate: 'docker',
-      versioningTemplate: 'loose',
-    },
-    {
-      customType: 'regex',
-      fileMatch: [
-        '^\\.github\\/workflows\\/[^/]+\\.ya?ml$',
-      ],
-      matchStrings: [
-        'GOLANG_VERSION: "(?<currentValue>.*?)\\.x"',
-      ],
-      datasourceTemplate: 'golang-version',
-      depNameTemplate: 'golang',
-      versioningTemplate: 'loose',
-      extractVersionTemplate: '^(?<version>\\d+\\.\\d+)',
-    },
-    {
-      customType: 'regex',
-      fileMatch: [
-        '^\\.github\\/workflows\\/[^/]+\\.ya?ml$',
-      ],
-      matchStrings: [
-        'GOLANGCI_LINT_VERSION: "v(?<currentValue>.*?)"',
-      ],
-      datasourceTemplate: 'github-releases',
-      depNameTemplate: 'golangci/golangci-lint',
-      versioningTemplate: 'loose',
-      extractVersionTemplate: '^v(?<version>\\d+\\.\\d+\\.\\d+)',
-    },
-    {
-      customType: 'regex',
-      fileMatch: [
-        '^.github/workflows/continuous-delivery.yml',
-      ],
-      matchStrings: [
-        'VELERO_VERSION: "v(?<currentValue>.*?)"',
-      ],
-      datasourceTemplate: 'github-releases',
-      depNameTemplate: 'vmware-tanzu/velero',
-      versioningTemplate: 'loose',
-      extractVersionTemplate: '^(?<version>v\\d+\\.\\d+\\.\\d+)',
-    },
-    {
-      customType: 'regex',
-      fileMatch: [
-        '^.github/workflows/continuous-delivery.yml',
-      ],
-      matchStrings: [
-        'VELERO_AWS_PLUGIN_VERSION: "v(?<currentValue>.*?)"',
-      ],
-      datasourceTemplate: 'github-releases',
-      depNameTemplate: 'vmware-tanzu/velero-plugin-for-aws',
-      versioningTemplate: 'loose',
-      extractVersionTemplate: '^(?<version>v\\d+\\.\\d+\\.\\d+)',
+      versioningTemplate: 'loose'
     },
   ],
   packageRules: [
     {
       matchDatasources: [
-        'docker',
+        'docker'
       ],
-      allowedVersions: '!/alpha/',
+      allowedVersions: '!/alpha/'
     },
     {
       matchDatasources: [
-        'go',
+        'go'
       ],
       matchDepNames: [
-        'k8s.io/client-go',
+        'k8s.io/client-go'
       ],
-      allowedVersions: '<1.0',
+      allowedVersions: '<1.0'
     },
     {
       matchDatasources: [
-        'go',
+        'go'
       ],
       groupName: 'kubernetes patches',
       matchUpdateTypes: [
         'patch',
-        'digest',
+        'digest'
       ],
       matchPackageNames: [
         'k8s.io{/,}**',
         'sigs.k8s.io{/,}**',
-        'github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring{/,}**',
+        'github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring{/,}**'
       ],
       matchDepNames: [
         '!sigs.k8s.io/kustomize/kustomize/v5',
-        '!sigs.k8s.io/controller-tools',
-      ],
+        '!sigs.k8s.io/controller-tools'
+      ]
     },
     {
       matchDatasources: [
-        'go',
+        'go'
       ],
       matchUpdateTypes: [
         'major',
-        'minor',
+        'minor'
       ],
       matchPackageNames: [
         'k8s.io{/,}**',
         'sigs.k8s.io{/,}**',
-        'github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring{/,}**',
-      ],
+        'github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring{/,}**'
+      ]
     },
     {
       matchDatasources: [
-        'go',
+        'go'
       ],
       matchUpdateTypes: [
-        'major',
+        'major'
       ],
       matchPackageNames: [
         '*',
         '!k8s.io{/,}**',
         '!sigs.k8s.io{/,}**',
-        '!github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring{/,}**',
-      ],
+        '!github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring{/,}**'
+      ]
     },
     {
       matchDatasources: [
-        'go',
+        'go'
       ],
       matchUpdateTypes: [
         'minor',
         'patch',
-        'digest',
+        'digest'
       ],
       groupName: 'all non-major go dependencies',
       matchPackageNames: [
@@ -403,8 +236,8 @@
         '!k8s.io{/,}**',
         '!sigs.k8s.io{/,}**',
         '!github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring{/,}**',
-        '!github.com/cloudnative-pg/{/,}**',
-      ],
+        '!github.com/cloudnative-pg/{/,}**'
+      ]
     },
     {
       matchDatasources: [
@@ -425,16 +258,16 @@
       pinDigests: false,
       matchPackageNames: [
         'kubernetes-csi{/,}**',
-        'rook{/,}**',
-      ],
+        'rook{/,}**'
+      ]
     },
     {
       groupName: 'backup test tools',
       separateMajorMinor: false,
       pinDigests: false,
       matchPackageNames: [
-        'vmware-tanzu{/,}**',
-      ],
+        'vmware-tanzu{/,}**'
+      ]
     },
     {
       groupName: 'operator framework',
@@ -443,16 +276,16 @@
       matchPackageNames: [
         'operator-framework{/,}**',
         'redhat-openshift-ecosystem{/,}**',
-        'quay.io/operator-framework{/,}**',
-      ],
+        'quay.io/operator-framework{/,}**'
+      ]
     },
     {
       groupName: 'cnpg',
       matchPackageNames: [
-        'github.com/cloudnative-pg/',
+        'github.com/cloudnative-pg/'
       ],
       separateMajorMinor: false,
-      pinDigests: false,
-    },
-  ],
+      pinDigests: false
+    }
+  ]
 }

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -11,6 +11,7 @@ on:
 permissions: read-all
 
 env:
+  # renovate: datasource=golang-version depName=golang versioning=loose
   GOLANG_VERSION: "1.24.x"
 
 jobs:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -34,6 +34,7 @@ permissions: read-all
 
 # set up environment variables to be used across all the jobs
 env:
+  # renovate: datasource=golang-version depName=golang versioning=loose
   GOLANG_VERSION: "1.24.x"
 
 jobs:

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -36,9 +36,12 @@ permissions: read-all
 
 # set up environment variables to be used across all the jobs
 env:
+  # renovate: datasource=golang-version depName=golang versioning=loose
   GOLANG_VERSION: "1.24.x"
   KUBEBUILDER_VERSION: "2.3.1"
+  # renovate: datasource=github-tags depName=kubernetes-sigs/kind versioning=semver
   KIND_VERSION: "v0.29.0"
+  # renovate: datasource=github-releases depName=rook/rook versioning=loose
   ROOK_VERSION: "v1.17.2"
   EXTERNAL_SNAPSHOTTER_VERSION: "v8.2.1"
   OPERATOR_IMAGE_NAME: "ghcr.io/${{ github.repository }}-testing"
@@ -1321,7 +1324,9 @@ jobs:
         name: Setup Velero
         uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
         env:
+          # renovate: datasource=github-releases depName=vmware-tanzu/velero
           VELERO_VERSION: "v1.16.1"
+          # renovate: datasource=github-releases depName=vmware-tanzu/velero
           VELERO_AWS_PLUGIN_VERSION: "v1.12.1"
         with:
           timeout_minutes: 10

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -18,10 +18,12 @@ permissions: read-all
 
 # set up environment variables to be used across all the jobs
 env:
+  # renovate: datasource=golang-version depName=golang versioning=loose
   GOLANG_VERSION: "1.24.x"
   # renovate: datasource=github-releases depName=golangci/golangci-lint versioning=loose
   GOLANGCI_LINT_VERSION: "v2.1.6"
   KUBEBUILDER_VERSION: "2.3.1"
+  # renovate: datasource=github-tags depName=kubernetes-sigs/kind versioning=semver
   KIND_VERSION: "v0.29.0"
   OPERATOR_IMAGE_NAME: "ghcr.io/${{ github.repository }}-testing"
   API_DOC_NAME: "cloudnative-pg.v1.md"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -19,6 +19,7 @@ permissions: read-all
 # set up environment variables to be used across all the jobs
 env:
   GOLANG_VERSION: "1.24.x"
+  # renovate: datasource=github-releases depName=golangci/golangci-lint versioning=loose
   GOLANGCI_LINT_VERSION: "v2.1.6"
   KUBEBUILDER_VERSION: "2.3.1"
   KIND_VERSION: "v0.29.0"

--- a/.github/workflows/refresh-licenses.yml
+++ b/.github/workflows/refresh-licenses.yml
@@ -9,6 +9,7 @@ on:
 permissions: read-all
 
 env:
+  # renovate: datasource=golang-version depName=golang versioning=loose
   GOLANG_VERSION: "1.24.x"
 
 jobs:

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -10,6 +10,7 @@ on:
 permissions: read-all
 
 env:
+  # renovate: datasource=golang-version depName=golang versioning=loose
   GOLANG_VERSION: "1.24.x"
   REGISTRY: "ghcr.io"
 

--- a/.github/workflows/require-labels.yml
+++ b/.github/workflows/require-labels.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Require labels
-        uses: docker://agilepathway/pull-request-label-checker:v1.6.65
+        uses: agilepathway/label-checker@v1.6.65
         with:
           any_of: "ok to merge :ok_hand:"
           none_of: "do not merge"

--- a/Makefile
+++ b/Makefile
@@ -51,14 +51,22 @@ LOCALBIN ?= $(shell pwd)/bin
 
 BUILD_IMAGE ?= true
 POSTGRES_IMAGE_NAME ?= $(shell grep 'DefaultImageName.*=' "pkg/versions/versions.go" | cut -f 2 -d \")
+# renovate: datasource=github-releases depName=kubernetes-sigs/kustomize versioning=loose
 KUSTOMIZE_VERSION ?= v5.6.0
+# renovate: datasource=go depName=sigs.k8s.io/controller-tools
 CONTROLLER_TOOLS_VERSION ?= v0.17.3
 GENREF_VERSION ?= 015aaac611407c4fe591bc8700d2c67b7521efca
+# renovate: datasource=go depName=github.com/goreleaser/goreleaser
 GORELEASER_VERSION ?= v2.9.0
+# renovate: datasource=docker depName=jonasbn/github-action-spellcheck versioning=docker
 SPELLCHECK_VERSION ?= 0.49.0
+# renovate: datasource=docker depName=getwoke/woke versioning=docker
 WOKE_VERSION ?= 0.19.0
+# renovate: datasource=github-releases depName=operator-framework/operator-sdk versioning=loose
 OPERATOR_SDK_VERSION ?= v1.40.0
+# renovate: datasource=github-tags depName=operator-framework/operator-registry
 OPM_VERSION ?= v1.55.0
+# renovate: datasource=github-tags depName=redhat-openshift-ecosystem/openshift-preflight
 PREFLIGHT_VERSION ?= 1.13.1
 OPENSHIFT_VERSIONS ?= v4.12-v4.19
 ARCH ?= amd64


### PR DESCRIPTION
As of now, the renovate configuration was about adding more and more 
`customManagers` to handle different versions, now, we adopt the concept 
of using a comment on top with the require fields to update the versions 
inside the specified files

Closes #7423 