### PR TITLE
docs: add guide on using Cilium to secure CloudNativePG traffic

### DIFF
--- a/.wordlist-en-custom.txt
+++ b/.wordlist-en-custom.txt
@@ -141,7 +141,6 @@ DisabledDefaultServices
 DoD
 DockerHub
 Dockle
-eBPF
 EBS
 EDB
 EKS
@@ -787,6 +786,7 @@ downtimes
 dvcmQ
 dwm
 dx
+eBPF
 ecdsa
 edb
 eks

--- a/.wordlist-en-custom.txt
+++ b/.wordlist-en-custom.txt
@@ -75,6 +75,7 @@ Ceph
 CertificatesConfiguration
 CertificatesStatus
 Certmanager
+CiliumNetworkPolicy
 ClassName
 ClientCASecret
 ClientCertsCASecret
@@ -140,6 +141,7 @@ DisabledDefaultServices
 DoD
 DockerHub
 Dockle
+eBPF
 EBS
 EDB
 EKS
@@ -209,6 +211,7 @@ Innocenti
 InstanceID
 InstanceReportedState
 IsolationCheckConfiguration
+Isovalent
 Istio
 Istio's
 JSON
@@ -268,6 +271,7 @@ NOCREATEROLE
 NOSUPERUSER
 Namespaces
 Nenciarini
+NetworkPolicy
 Niccolò
 NodeAffinity
 NodeMaintenanceWindow

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -75,6 +75,7 @@ nav:
   - release_notes.md
   - CNCF Projects Integrations:
     - cncf-projects/external-secrets.md
+    - cncf-projects/cilium.md
   - Appendixes:
     - appendixes/backup_volumesnapshot.md
     - appendixes/backup_barmanobjectstore.md

--- a/docs/src/cncf-projects/cilium.md
+++ b/docs/src/cncf-projects/cilium.md
@@ -1,10 +1,12 @@
 # Cilium
 
-[Cilium](https://cilium.io/) is a CNCF Graduated project that was accepted as an Incubating project in 2021 and graduated in 2023 under the sponsorship of Isovalent. It is an
-advanced networking, security, and observability solution for cloud-native environments, built on
-top of eBPF (Extended Berkeley Packet Filter) technology. Cilium manages network traffic in
-Kubernetes clusters by dynamically injecting eBPF programs into the Linux Kernel, enabling
-low-latency, high-performance communication and enforcing fine-grained security policies.
+## About
+
+[Cilium](https://cilium.io/) is a CNCF Graduated project that was accepted as an Incubating project in 2021 and graduated in 2023 under
+the sponsorship of Isovalent. It is an advanced networking, security, and observability solution for cloud-native
+environments, built on top of eBPF (Extended Berkeley Packet Filter) technology. Cilium manages network traffic in
+Kubernetes clusters by dynamically injecting eBPF programs into the Linux Kernel, enabling low-latency,
+high-performance communication and enforcing fine-grained security policies.
 
 Key features of Cilium:
 
@@ -17,12 +19,13 @@ Key features of Cilium:
 ## Pod-to-Pod Network Security with CloudNativePG and Cilium
 
 Kubernetes’ default behavior is to allow traffic between any two pods in the cluster network.
-Cilium provides advanced L3/L4 network security using the CiliumNetworkPolicy resource. This
+Cilium provides advanced L3/L4 network security using the `CiliumNetworkPolicy` resource. This
 enables fine-grained control over network traffic between Pods within a Kubernetes cluster. It is
 especially useful for securing communication between application workloads and backend
 services.
 
-In the following examples, we demonstrate how Cilium can be used to secure a CloudNativePG PostgreSQL instance by restricting ingress traffic to only authorized Pods.
+In the following examples, we demonstrate how Cilium can be used to secure a CloudNativePG PostgreSQL instance by
+restricting ingress traffic to only authorized Pods.
 
 !!! Important
     Before proceeding, ensure that the `cluster-example` Postgres cluster is up and running in your environment.
@@ -34,7 +37,7 @@ in the target namespace. This is important because the operator needs to be able
 and one of those actions requires to access the port `8000` on the pods to get the current status of the PostgreSQL
 instance running inside.
 
-The following CiliumNetworkPolicy allows the operator to access the pods in the target `default` namespace
+The following `CiliumNetworkPolicy` allows the operator to access the pods in the target `default` namespace
 
 ```yaml
 apiVersion: cilium.io/v2
@@ -56,7 +59,7 @@ spec:
 ```
 !!! Important
     The `cnpg-system` namespace is the default namespace for the operator when using the YAML manifests, if the operator
-    was installed using a different process(Helm,OLM, etc.), the namespace may be different. Make sure to adjust the
+    was installed using a different process(Helm, OLM, etc.), the namespace may be different. Make sure to adjust the
     namespace properly.
 
 ## Allowing access between cluster pods
@@ -88,10 +91,10 @@ spec:
               protocol: TCP
 ```
 
-## Example: Restricting Access to PostgreSQL with Cilium
+## Restricting Access to PostgreSQL with Cilium
 
-In this example, we define a CiliumNetworkPolicy that allows only Pods labeled `role=backend` in the default namespace
-to connect to a PostgreSQL cluster named cluster-example. All other ingress traffic is blocked by default.
+In this example, we define a `CiliumNetworkPolicy` that allows only Pods labeled `role=backend` in the default namespace
+to connect to a PostgreSQL cluster named `cluster-example`. All other ingress traffic is blocked by default.
 
 ```yaml
 apiVersion: cilium.io/v2
@@ -114,11 +117,11 @@ spec:
             protocol: TCP
 ```
 
-This CiliumNetworkPolicy ensures that only Pods labeled with `role=backend` can access the
+This `CiliumNetworkPolicy` ensures that only Pods labeled with `role=backend` can access the
 PostgreSQL instance managed by CloudNativePG via port 5432 in the default namespace.
 
-In the following example, we demonstrate how to allow ingress traffic to port 5432 of a CloudNativePG cluster named
-cluster-example, only from Pods with the label `role=backend` in any namespace.
+In the following policy, we demonstrate how to allow ingress traffic to port 5432 of a PostgreSQL cluster named
+`cluster-example`, only from Pods with the label `role=backend` in any namespace.
 
 ```yaml
 apiVersion: cilium.io/v2
@@ -144,7 +147,7 @@ spec:
             protocol: TCP
 ```
 
-The following example allows ingress traffic to port 5432 of the cluster-example CloudNativePG cluster (located in the
+The following example allows ingress traffic to port 5432 of the `cluster-example` cluster (located in the
 default namespace) from any Pods in the backend namespace.
 
 ```yaml
@@ -168,11 +171,11 @@ spec:
               protocol: TCP
 ```
 
-Using Cilium’s L3/L4 policy model, we define a CiliumNetworkPolicy that explicitly allows ingress
-traffic to CloudNativePG pods only from application pods in the backend namespace. All other
+Using Cilium’s L3/L4 policy model, we define a `CiliumNetworkPolicy` that explicitly allows ingress
+traffic to cluster pods only from application pods in the `backend` namespace. All other
 traffic is implicitly denied unless explicitly permitted by additional policies.
 
-The following example allows ingress traffic to port 5432 of the cluster-example CloudNativePG cluster (located in the
+The following example allows ingress traffic to port 5432 of the `cluster-example` cluster (located in the
 default namespace) from any source within the Kubernetes cluster.
 
 ```yaml

--- a/docs/src/cncf-projects/cilium.md
+++ b/docs/src/cncf-projects/cilium.md
@@ -91,6 +91,8 @@ spec:
               protocol: TCP
 ```
 
+The policy allows access from `cnpg-system` pods and from default namespace pods that also belong to `cluster-example`. The matchLabels selector requires pods to have the complete set of listed labels. Missing even one label means the pod will not match.
+
 ## Restricting Access to PostgreSQL with Cilium
 
 In this example, we define a `CiliumNetworkPolicy` that allows only Pods labeled `role=backend` in the default namespace

--- a/docs/src/cncf-projects/cilium.md
+++ b/docs/src/cncf-projects/cilium.md
@@ -1,10 +1,10 @@
-# Securing CloudNativePG Network with Cilium
+# Cilium
 
 [Cilium](https://cilium.io/) is a CNCF Graduated project that was accepted as an Incubating project in 2021 and graduated in 2023 under the sponsorship of Isovalent. It is an
 advanced networking, security, and observability solution for cloud-native environments, built on
 top of eBPF (Extended Berkeley Packet Filter) technology. Cilium manages network traffic in
 Kubernetes clusters by dynamically injecting eBPF programs into the Linux Kernel, enabling
-low-latency, high-performant communication and enforcing fine-grained security policies.
+low-latency, high-performance communication and enforcing fine-grained security policies.
 
 Key features of Cilium:
 
@@ -24,11 +24,74 @@ services.
 
 In the following examples, we demonstrate how Cilium can be used to secure a CloudNativePG PostgreSQL instance by restricting ingress traffic to only authorized Pods.
 
-!!! Important Before proceeding, ensure that the `cluster-example` Postgres cluster is up and running in your environment.
+!!! Important
+    Before proceeding, ensure that the `cluster-example` Postgres cluster is up and running in your environment.
+
+## Making Cilium Network Policies work with CloudNativePG Operator
+
+When working with a network policy, Cilium or not, the first step is to make sure that the operator can reach the pods
+in the target namespace. This is important because the operator needs to be able to perform checks and actions on the pods,
+and one of those actions requires to access the port `8000` on the pods to get the current status of the PostgreSQL
+instance running inside.
+
+The following CiliumNetworkPolicy allows the operator to access the pods in the target `default` namespace
+
+```yaml
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: cnpg-operator-policy
+  namespace: default
+spec:
+  description: "Allow CloudNativePG operator access to any pod in the target namespace"
+  endpointSelector: {}
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: cnpg-system
+      toPorts:
+        - ports:
+            - port: "8000"
+              protocol: TCP
+```
+!!! Important
+    The `cnpg-system` namespace is the default namespace for the operator when using the YAML manifests, if the operator
+    was installed using a different process(Helm,OLM, etc.), the namespace may be different. Make sure to adjust the
+    namespace properly.
+
+## Allowing access between cluster pods
+
+Since the default policy is deny all, we need to explicitly allow access between the cluster pods in the same namespace.
+We will improve our previous policy by adding the required ingress rule
+
+```yaml
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: cnpg-policy
+  namespace: default
+spec:
+  description: "Allow CloudNativePG operator access and connection between pods in the same namespace"
+  endpointSelector: {}
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: cnpg-system
+        - matchLabels:
+            io.kubernetes.pod.namespace: default
+            cnpg.io/cluster: cluster-example
+      toPorts:
+        - ports:
+            - port: "8000"
+              protocol: TCP
+            - port: "5432"
+              protocol: TCP
+```
 
 ## Example: Restricting Access to PostgreSQL with Cilium
 
-In this example, we define a CiliumNetworkPolicy that allows only Pods labeled role=backend in the default namespace to connect to a CloudNativePG-managed PostgreSQL cluster named cluster-example. All other ingress traffic is blocked by default.
+In this example, we define a CiliumNetworkPolicy that allows only Pods labeled `role=backend` in the default namespace
+to connect to a PostgreSQL cluster named cluster-example. All other ingress traffic is blocked by default.
 
 ```yaml
 apiVersion: cilium.io/v2
@@ -51,10 +114,11 @@ spec:
             protocol: TCP
 ```
 
-This CiliumNetworkPolicy ensures that only Pods labeled with role=backend can access the
-PostgreSQL instance managed by CloudNativePG via port 5432  in the default namespace.
+This CiliumNetworkPolicy ensures that only Pods labeled with `role=backend` can access the
+PostgreSQL instance managed by CloudNativePG via port 5432 in the default namespace.
 
-In the following example, we demonstrate how to allow ingress traffic to port 5432 of a CloudNativePG cluster named cluster-example, only from Pods with the label role=backend in any namespace.
+In the following example, we demonstrate how to allow ingress traffic to port 5432 of a CloudNativePG cluster named
+cluster-example, only from Pods with the label `role=backend` in any namespace.
 
 ```yaml
 apiVersion: cilium.io/v2
@@ -80,7 +144,8 @@ spec:
             protocol: TCP
 ```
 
-The following example allows ingress traffic to port 5432 of the cluster-example CloudNativePG cluster (located in the default namespace) from any Pods in the backend namespace.
+The following example allows ingress traffic to port 5432 of the cluster-example CloudNativePG cluster (located in the
+default namespace) from any Pods in the backend namespace.
 
 ```yaml
 apiVersion: cilium.io/v2
@@ -107,7 +172,8 @@ Using Cilium’s L3/L4 policy model, we define a CiliumNetworkPolicy that explic
 traffic to CloudNativePG pods only from application pods in the backend namespace. All other
 traffic is implicitly denied unless explicitly permitted by additional policies.
 
-The following example allows ingress traffic to port 5432 of the cluster-example CloudNativePG cluster (located in the default namespace) from any source within the Kubernetes cluster.
+The following example allows ingress traffic to port 5432 of the cluster-example CloudNativePG cluster (located in the
+default namespace) from any source within the Kubernetes cluster.
 
 ```yaml
 apiVersion: cilium.io/v2
@@ -129,5 +195,6 @@ spec:
               protocol: TCP
 ```
 
-You may consider using [editor.networkpolicy.io](https://editor.networkpolicy.io/), a visual and interactive tool that simplifies the creation and validation of Cilium Network Policies. It’s especially helpful for avoiding misconfigurations and understanding traffic rules more clearly by presenting in a visual way.
-
+You may consider using [editor.networkpolicy.io](https://editor.networkpolicy.io/), a visual and interactive tool that simplifies the creation and
+validation of Cilium Network Policies. It’s especially helpful for avoiding misconfigurations and understanding traffic
+rules more clearly by presenting in a visual way.

--- a/docs/src/cncf-projects/cilium.md
+++ b/docs/src/cncf-projects/cilium.md
@@ -17,7 +17,7 @@ Key features of Cilium:
 - Built-in observability and monitoring with Hubble
 
 To install Cilium in your environment, follow the instructions in the documentation:
-https://docs.cilium.io/en/stable/gettingstarted/k8s-install-default/
+[https://docs.cilium.io/en/stable/gettingstarted/k8s-install-default/](https://docs.cilium.io/en/stable/gettingstarted/k8s-install-default/)
 
 ## Pod-to-Pod Network Security with CloudNativePG and Cilium
 

--- a/docs/src/cncf-projects/cilium.md
+++ b/docs/src/cncf-projects/cilium.md
@@ -16,9 +16,12 @@ Key features of Cilium:
 - Support for both NetworkPolicy and CiliumNetworkPolicy
 - Built-in observability and monitoring with Hubble
 
+To install Cilium in your environment, follow the instructions in the documentation:
+https://docs.cilium.io/en/stable/gettingstarted/k8s-install-default/
+
 ## Pod-to-Pod Network Security with CloudNativePG and Cilium
 
-Kubernetes’ default behavior is to allow traffic between any two pods in the cluster network.
+Kubernetes’ default behavior is to allow traffic between any two Pods in the cluster network.
 Cilium provides advanced L3/L4 network security using the `CiliumNetworkPolicy` resource. This
 enables fine-grained control over network traffic between Pods within a Kubernetes cluster. It is
 especially useful for securing communication between application workloads and backend
@@ -32,12 +35,12 @@ restricting ingress traffic to only authorized Pods.
 
 ## Making Cilium Network Policies work with CloudNativePG Operator
 
-When working with a network policy, Cilium or not, the first step is to make sure that the operator can reach the pods
-in the target namespace. This is important because the operator needs to be able to perform checks and actions on the pods,
-and one of those actions requires to access the port `8000` on the pods to get the current status of the PostgreSQL
+When working with a network policy, Cilium or not, the first step is to make sure that the operator can reach the Pods
+in the target namespace. This is important because the operator needs to be able to perform checks and actions on the
+Pods, and one of those actions requires to access the port `8000` on the Pods to get the current status of the PostgreSQL
 instance running inside.
 
-The following `CiliumNetworkPolicy` allows the operator to access the pods in the target `default` namespace
+The following `CiliumNetworkPolicy` allows the operator to access the Pods in the target `default` namespace
 
 ```yaml
 apiVersion: cilium.io/v2
@@ -62,10 +65,10 @@ spec:
     was installed using a different process(Helm, OLM, etc.), the namespace may be different. Make sure to adjust the
     namespace properly.
 
-## Allowing access between cluster pods
+## Allowing access between cluster Pods
 
-Since the default policy is deny all, we need to explicitly allow access between the cluster pods in the same namespace.
-We will improve our previous policy by adding the required ingress rule
+Since the default policy is "deny all", we need to explicitly allow access between the cluster Pods in the same namespace.
+We will improve our previous policy by adding the required ingress rule:
 
 ```yaml
 apiVersion: cilium.io/v2
@@ -91,11 +94,13 @@ spec:
               protocol: TCP
 ```
 
-The policy allows access from `cnpg-system` pods and from default namespace pods that also belong to `cluster-example`. The matchLabels selector requires pods to have the complete set of listed labels. Missing even one label means the pod will not match.
+The policy allows access from `cnpg-system` Pods and from `default` namespace Pods that also belong to `cluster-example`.
+The `matchLabels` selector requires Pods to have the complete set of listed labels. Missing even one label means the Pod
+will not match.
 
 ## Restricting Access to PostgreSQL with Cilium
 
-In this example, we define a `CiliumNetworkPolicy` that allows only Pods labeled `role=backend` in the default namespace
+In this example, we define a `CiliumNetworkPolicy` that allows only Pods labeled `role=backend` in the `default` namespace
 to connect to a PostgreSQL cluster named `cluster-example`. All other ingress traffic is blocked by default.
 
 ```yaml
@@ -120,7 +125,7 @@ spec:
 ```
 
 This `CiliumNetworkPolicy` ensures that only Pods labeled with `role=backend` can access the
-PostgreSQL instance managed by CloudNativePG via port 5432 in the default namespace.
+PostgreSQL instance managed by CloudNativePG via port 5432 in the `default` namespace.
 
 In the following policy, we demonstrate how to allow ingress traffic to port 5432 of a PostgreSQL cluster named
 `cluster-example`, only from Pods with the label `role=backend` in any namespace.
@@ -150,7 +155,7 @@ spec:
 ```
 
 The following example allows ingress traffic to port 5432 of the `cluster-example` cluster (located in the
-default namespace) from any Pods in the backend namespace.
+`default` namespace) from any Pods in the `backend` namespace.
 
 ```yaml
 apiVersion: cilium.io/v2
@@ -174,11 +179,11 @@ spec:
 ```
 
 Using Cilium’s L3/L4 policy model, we define a `CiliumNetworkPolicy` that explicitly allows ingress
-traffic to cluster pods only from application pods in the `backend` namespace. All other
+traffic to cluster Pods only from application Pods in the `backend` namespace. All other
 traffic is implicitly denied unless explicitly permitted by additional policies.
 
 The following example allows ingress traffic to port 5432 of the `cluster-example` cluster (located in the
-default namespace) from any source within the Kubernetes cluster.
+`default` namespace) from any source within the Kubernetes cluster.
 
 ```yaml
 apiVersion: cilium.io/v2

--- a/docs/src/cncf-projects/securing_cloudnative-pg_network.md
+++ b/docs/src/cncf-projects/securing_cloudnative-pg_network.md
@@ -1,6 +1,6 @@
-# Securing CloudNativePG Network with CiliumAdd commentMore actions
+# Securing CloudNativePG Network with Cilium
 
-Cilium is a CNCF Sandbox project, accepted in 2021 under the sponsorship of Isovalent. It is an
+[Cilium](https://cilium.io/) is a CNCF Graduated project, accepted in 2021 under the sponsorship of Isovalent. It is an
 advanced networking, security, and observability solution for cloud-native environments, built on
 top of eBPF (Extended Berkeley Packet Filter) technology. Cilium manages network traffic in
 Kubernetes clusters by dynamically injecting eBPF programs into the Linux kernel, enabling
@@ -8,11 +8,11 @@ low-latency, high-performance communication and enforcing fine-grained security 
 
 Key features of Cilium:
 
-● Advanced L3-L7 security policies for fine-grained network traffic control
-● Efficient, kernel-level traffic management via eBPF
-● Service Mesh integration (Cilium Service Mesh)
-● Support for both NetworkPolicy and CiliumNetworkPolicy
-● Built-in observability and monitoring with Hubble
+- Advanced L3-L7 security policies for fine-grained network traffic control
+- Efficient, kernel-level traffic management via eBPF
+- Service Mesh integration (Cilium Service Mesh)
+- Support for both NetworkPolicy and CiliumNetworkPolicy
+- Built-in observability and monitoring with Hubble
 
 ## Pod-to-Pod Network Security with CloudNativePG and Cilium
 

--- a/docs/src/cncf-projects/securing_cloudnative-pg_network.md
+++ b/docs/src/cncf-projects/securing_cloudnative-pg_network.md
@@ -1,6 +1,6 @@
 # Securing CloudNativePG Network with Cilium
 
-[Cilium](https://cilium.io/) is a CNCF Graduated project, accepted in 2021 under the sponsorship of Isovalent. It is an
+[Cilium](https://cilium.io/) is a CNCF Graduated project that was accepted as an Incubating project in 2021 and graduated in 2023 under the sponsorship of Isovalent. It is an
 advanced networking, security, and observability solution for cloud-native environments, built on
 top of eBPF (Extended Berkeley Packet Filter) technology. Cilium manages network traffic in
 Kubernetes clusters by dynamically injecting eBPF programs into the Linux kernel, enabling

--- a/docs/src/cncf-projects/securing_cloudnative-pg_network.md
+++ b/docs/src/cncf-projects/securing_cloudnative-pg_network.md
@@ -3,8 +3,8 @@
 [Cilium](https://cilium.io/) is a CNCF Graduated project that was accepted as an Incubating project in 2021 and graduated in 2023 under the sponsorship of Isovalent. It is an
 advanced networking, security, and observability solution for cloud-native environments, built on
 top of eBPF (Extended Berkeley Packet Filter) technology. Cilium manages network traffic in
-Kubernetes clusters by dynamically injecting eBPF programs into the Linux kernel, enabling
-low-latency, high-performance communication and enforcing fine-grained security policies.
+Kubernetes clusters by dynamically injecting eBPF programs into the Linux Kernel, enabling
+low-latency, high-performant communication and enforcing fine-grained security policies.
 
 Key features of Cilium:
 
@@ -22,17 +22,13 @@ enables fine-grained control over network traffic between Pods within a Kubernet
 especially useful for securing communication between application workloads and backend
 services.
 
-In the following example, we define a CiliumNetworkPolicy that allows only Pods labeled
-role=backend in the backend namespace to connect to a CloudNativePG-managed PostgreSQL
-cluster named my-postgres. All other ingress traffic is blocked by default.
+In the following examples, we demonstrate how Cilium can be used to secure a CloudNativePG PostgreSQL instance by restricting ingress traffic to only authorized Pods.
+
+!!! Important Before proceeding, ensure that the `cluster-example` Postgres cluster is up and running in your environment.
 
 ## Example: Restricting Access to PostgreSQL with Cilium
 
-In this example, we demonstrate how Cilium can be used to secure a CloudNativePG
-PostgreSQL instance by restricting ingress traffic to only authorized Pods.
-
-In the following example, we demonstrate how to restrict access to a CloudNativePG cluster
-named cluster-example so that only Pods in the backend namespace are allowed to connect.
+In this example, we define a CiliumNetworkPolicy that allows only Pods labeled role=backend in the default namespace to connect to a CloudNativePG-managed PostgreSQL cluster named cluster-example. All other ingress traffic is blocked by default.
 
 ```yaml
 apiVersion: cilium.io/v2
@@ -55,9 +51,83 @@ spec:
             protocol: TCP
 ```
 
-This CiliumNetworkPolicy ensures that only Pods labeled with role: backend can access the
-PostgreSQL instance managed by CloudNativePG via port 5432.
+This CiliumNetworkPolicy ensures that only Pods labeled with role=backend can access the
+PostgreSQL instance managed by CloudNativePG via port 5432  in the default namespace.
+
+In the following example, we demonstrate how to allow ingress traffic to port 5432 of a CloudNativePG cluster named cluster-example, only from Pods with the label role=backend in any namespace.
+
+```yaml
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: postgres-policy
+  namespace: default
+spec:
+  description: "Allow PostgreSQL access on port 5432 from Pods with role=backend in any namespace"
+  endpointSelector:
+    matchLabels:
+      cnpg.io/cluster: cluster-example
+  ingress:
+    - fromEndpoints:
+       - matchLabels:
+            role: backend
+         matchExpressions:
+          - key: io.kubernetes.pod.namespace
+            operator: Exists
+      toPorts:
+        - ports:
+          - port: "5432"
+            protocol: TCP
+```
+
+The following example allows ingress traffic to port 5432 of the cluster-example CloudNativePG cluster (located in the default namespace) from any Pods in the backend namespace.
+
+```yaml
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: postgres-policy
+  namespace: default
+spec:
+  description: "Allow PostgreSQL access on port 5432 from any Pods in the backend namespace"
+  endpointSelector:
+    matchLabels:
+      cnpg.io/cluster: cluster-example
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: backend
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP
+```
 
 Using Cilium’s L3/L4 policy model, we define a CiliumNetworkPolicy that explicitly allows ingress
 traffic to CloudNativePG pods only from application pods in the backend namespace. All other
 traffic is implicitly denied unless explicitly permitted by additional policies.
+
+The following example allows ingress traffic to port 5432 of the cluster-example CloudNativePG cluster (located in the default namespace) from any source within the Kubernetes cluster.
+
+```yaml
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: postgres-policy
+  namespace: default
+spec:
+  description: "Allow ingress traffic to port 5432 of the cluster-example from any pods within the Kubernetes cluster"
+  endpointSelector:
+    matchLabels:
+      cnpg.io/cluster: cluster-example
+  ingress:
+    - fromEntities:
+        - cluster
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP
+```
+
+You may consider using [editor.networkpolicy.io](https://editor.networkpolicy.io/), a visual and interactive tool that simplifies the creation and validation of Cilium Network Policies. It’s especially helpful for avoiding misconfigurations and understanding traffic rules more clearly by presenting in a visual way.
+

--- a/docs/src/cncf-projects/securing_cloudnative-pg_network.md
+++ b/docs/src/cncf-projects/securing_cloudnative-pg_network.md
@@ -1,0 +1,63 @@
+# Securing CloudNativePG Network with CiliumAdd commentMore actions
+
+Cilium is a CNCF Sandbox project, accepted in 2021 under the sponsorship of Isovalent. It is an
+advanced networking, security, and observability solution for cloud-native environments, built on
+top of eBPF (Extended Berkeley Packet Filter) technology. Cilium manages network traffic in
+Kubernetes clusters by dynamically injecting eBPF programs into the Linux kernel, enabling
+low-latency, high-performance communication and enforcing fine-grained security policies.
+
+Key features of Cilium:
+
+● Advanced L3-L7 security policies for fine-grained network traffic control
+● Efficient, kernel-level traffic management via eBPF
+● Service Mesh integration (Cilium Service Mesh)
+● Support for both NetworkPolicy and CiliumNetworkPolicy
+● Built-in observability and monitoring with Hubble
+
+## Pod-to-Pod Network Security with CloudNativePG and Cilium
+
+Kubernetes’ default behavior is to allow traffic between any two pods in the cluster network.
+Cilium provides advanced L3/L4 network security using the CiliumNetworkPolicy resource. This
+enables fine-grained control over network traffic between Pods within a Kubernetes cluster. It is
+especially useful for securing communication between application workloads and backend
+services.
+
+In the following example, we define a CiliumNetworkPolicy that allows only Pods labeled
+role=backend in the backend namespace to connect to a CloudNativePG-managed PostgreSQL
+cluster named my-postgres. All other ingress traffic is blocked by default.
+
+## Example: Restricting Access to PostgreSQL with Cilium
+
+In this example, we demonstrate how Cilium can be used to secure a CloudNativePG
+PostgreSQL instance by restricting ingress traffic to only authorized Pods.
+
+In the following example, we demonstrate how to restrict access to a CloudNativePG cluster
+named cluster-example so that only Pods in the backend namespace are allowed to connect.
+
+```yaml
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: postgres-policy
+  namespace: default
+spec:
+  description: "Allow PostgreSQL access on port 5432 from Pods with role=backend"
+  endpointSelector:
+    matchLabels:
+      cnpg.io/cluster: cluster-example
+  ingress:
+    - fromEndpoints:
+       - matchLabels:
+            role: backend
+      toPorts:
+        - ports:
+          - port: "5432"
+            protocol: TCP
+```
+
+This CiliumNetworkPolicy ensures that only Pods labeled with role: backend can access the
+PostgreSQL instance managed by CloudNativePG via port 5432.
+
+Using Cilium’s L3/L4 policy model, we define a CiliumNetworkPolicy that explicitly allows ingress
+traffic to CloudNativePG pods only from application pods in the backend namespace. All other
+traffic is implicitly denied unless explicitly permitted by additional policies.


### PR DESCRIPTION
This contribution adds a new documentation section on securing CloudNativePG-managed PostgreSQL clusters using Cilium, a CNCF Sandbox project that provides eBPF-powered networking and security. It includes an introduction to Cilium, an example CiliumNetworkPolicy manifest to restrict access to PostgreSQL. 

Closes #7691 