### PR TITLE
feat(auth): support user maps for predefined users to enable self-managed certificates

### DIFF
--- a/docs/src/certificates.md
+++ b/docs/src/certificates.md
@@ -265,18 +265,18 @@ the following parameters:
 
 #### Customizing the `streaming_replica` client certificate
 
-In some environments it might not be possible to generate a certificate with the common
-name set to `streaming_replica`  due to a company policy or other security concerns,
-like CA shared across multiple clusters. In such cases the user mapping feature can be
-used to allow authentication as the `streaming_replica` user with certificates
-containing different common names.
+In some environments, it may not be possible to generate a certificate with the
+common name `streaming_replica` due to company policies or other security
+concerns, such as a CA shared across multiple clusters. In such cases, the user
+mapping feature can be used to allow authentication as the `streaming_replica`
+user with certificates containing different common names.
 
-The only thing necessary to configure such setup is to add a `pg_ident.conf` entry
-for a predefined map named `cnpg_streaming_replica`.
+To configure this setup, add a `pg_ident.conf` entry for the predefined map
+named `cnpg_streaming_replica`.
 
-For example, to enable `streaming_replica` authentication using a certificate with
-a common name `streaming-replica.cnpg.svc.cluster.local` this should be added to the
-cluster definition:
+For example, to enable `streaming_replica` authentication using a certificate
+with the common name `streaming-replica.cnpg.svc.cluster.local`, add the
+following to your cluster definition:
 
 ```yaml
 apiVersion: postgresql.cnpg.io/v1
@@ -289,8 +289,9 @@ spec:
     - cnpg_streaming_replica streaming-replica.cnpg.svc.cluster.local streaming_replica
 ```
 
-For further detail on how `pg_ident.conf` is managed by the operator, see the
-["PostgreSQL Configuration" page](postgresql_conf.md#the-pg_ident-section) of the documentation.
+For further details on how `pg_ident.conf` is managed by the operator, see the
+["PostgreSQL Configuration" page](postgresql_conf.md#the-pg_ident-section) in
+the documentation.
 
 #### Cert-manager example
 

--- a/docs/src/certificates.md
+++ b/docs/src/certificates.md
@@ -284,6 +284,7 @@ kind: Cluster
 metadata:
   name: cluster-example
 spec:
+  postgresql:
     pg_ident:
     - cnpg_streaming_replica streaming-replica.cnpg.svc.cluster.local streaming_replica
 ```

--- a/docs/src/certificates.md
+++ b/docs/src/certificates.md
@@ -263,6 +263,34 @@ the following parameters:
     instances, you can add a label with the key `cnpg.io/reload` to it. Otherwise,
     you must reload the instances using the `kubectl cnpg reload` subcommand.
 
+#### Customizing the `streaming_replica` client certificate
+
+In some environments it might not be possible to generate a certificate with the common
+name set to `streaming_replica`  due to a company policy or other security concerns,
+like CA shared across multiple clusters. In such cases the user mapping feature can be
+used to allow authentication as the `streaming_replica` user with certificates
+containing different common names.
+
+The only thing necessary to configure such setup is to add a `pg_ident.conf` entry
+for a predefined map named `cnpg_streaming_replica`.
+
+For example, to enable `streaming_replica` authentication using a certificate with
+a common name `streaming-replica.cnpg.svc.cluster.local` this should be added to the
+cluster definition:
+
+```yaml
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: cluster-example
+spec:
+    pg_ident:
+    - cnpg_streaming_replica streaming-replica.cnpg.svc.cluster.local streaming_replica
+```
+
+For further detail on how `pg_ident.conf` is managed by the operator, see the
+["PostgreSQL Configuration" page](postgresql_conf.md#the-pg_ident-section) of the documentation.
+
 #### Cert-manager example
 
 This simple example shows how to use [cert-manager](https://cert-manager.io/)

--- a/docs/src/postgresql_conf.md
+++ b/docs/src/postgresql_conf.md
@@ -373,9 +373,9 @@ Fixed rules:
 ```text
 local all all peer
 
-hostssl postgres streaming_replica all cert
-hostssl replication streaming_replica all cert
-hostssl all cnpg_pooler_pgbouncer all cert
+hostssl postgres streaming_replica all cert map=cnpg_streaming_replica
+hostssl replication streaming_replica all cert map=cnpg_streaming_replica
+hostssl all cnpg_pooler_pgbouncer all cert map=cnpg_pooler_pgbouncer
 ```
 
 Default rules:
@@ -397,8 +397,9 @@ The resulting `pg_hba.conf` will look like this:
 ```text
 local all all peer
 
-hostssl postgres streaming_replica all cert
-hostssl replication streaming_replica all cert
+hostssl postgres streaming_replica all cert map=cnpg_streaming_replica
+hostssl replication streaming_replica all cert map=cnpg_streaming_replica
+hostssl all cnpg_pooler_pgbouncer all cert map=cnpg_pooler_pgbouncer
 
 <user defined rules>
 <user defined LDAP>

--- a/docs/src/replication.md
+++ b/docs/src/replication.md
@@ -81,8 +81,8 @@ following excerpt taken from `pg_hba.conf`:
 
 ```
 # Require client certificate authentication for the streaming_replica user
-hostssl postgres streaming_replica all cert
-hostssl replication streaming_replica all cert
+hostssl postgres streaming_replica all cert map=cnpg_streaming_replica
+hostssl replication streaming_replica all cert map=cnpg_streaming_replica
 ```
 
 !!! Seealso "Certificates"

--- a/pkg/postgres/configuration.go
+++ b/pkg/postgres/configuration.go
@@ -99,9 +99,9 @@ const (
 local all all peer map=local
 
 # Require client certificate authentication for the streaming_replica user
-hostssl postgres streaming_replica all cert
-hostssl replication streaming_replica all cert
-hostssl all cnpg_pooler_pgbouncer all cert
+hostssl postgres streaming_replica all cert map=cnpg_streaming_replica
+hostssl replication streaming_replica all cert map=cnpg_streaming_replica
+hostssl all cnpg_pooler_pgbouncer all cert map=cnpg_pooler_pgbouncer
 
 #
 # USER-DEFINED RULES
@@ -133,6 +133,12 @@ host all all all {{.DefaultAuthenticationMethod}}
 
 # Grant local access ('local' user map)
 local {{.Username}} postgres
+
+# Grant streaming_replica access ('cnpg_streaming_replica' user map)
+cnpg_streaming_replica streaming_replica streaming_replica
+
+# Grant cnpg_pooler_pgbouncer access ('cnpg_pooler_pgbouncer' user map)
+cnpg_pooler_pgbouncer cnpg_pooler_pgbouncer cnpg_pooler_pgbouncer
 
 #
 # USER-DEFINED RULES


### PR DESCRIPTION
Add support for default user maps for predefined users, allowing administrators to remap certificate identities and enable the `streaming_replica` user to authenticate with certificates using different Common Names.

This improves compatibility and flexibility when using self-managed PKI infrastructures.

Closes #7697 