### PR TITLE
chore: add MinIO to Renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -157,6 +157,18 @@
       datasourceTemplate: 'docker',
       versioningTemplate: 'loose',
     },
+    {
+      customType: 'regex',
+      fileMatch: [
+        '^tests\\/utils\\/minio\\/minio\\.go$',
+      ],
+      matchStrings: [
+        'minioImage = "(?<depName>.+?):(?<currentValue>.*?)"',
+        'minioClientImage = "(?<depName>.+?):(?<currentValue>.*?)"',
+      ],
+      datasourceTemplate: 'docker',
+      versioningTemplate: "regex:^RELEASE\\.(?<major>\\d{4})-(?<minor>\\d{2})-(?<patch>\\d{2})T\\d{2}-\\d{2}-\\d{2}Z$"
+    },
   ],
   packageRules: [
     {
@@ -267,6 +279,7 @@
       pinDigests: false,
       matchPackageNames: [
         'vmware-tanzu{/,}**',
+        'minio{/,}**'
       ],
     },
     {

--- a/tests/utils/minio/minio.go
+++ b/tests/utils/minio/minio.go
@@ -49,7 +49,9 @@ import (
 )
 
 const (
-	minioImage       = "minio/minio:RELEASE.2025-05-24T17-08-30Z"
+	// minioImage is the image used to run a MinIO server
+	minioImage = "minio/minio:RELEASE.2025-05-24T17-08-30Z"
+	// minioClientImage is the image used to run a MinIO client
 	minioClientImage = "minio/mc:RELEASE.2025-05-21T01-59-54Z"
 )
 


### PR DESCRIPTION
Add MinIO images being used by the testing suite to Renovate.

Closes #7748 