### PR TITLE
chore(lint): strict nil check in termination grace period comparison

### DIFF
--- a/pkg/specs/podspec_diff.go
+++ b/pkg/specs/podspec_diff.go
@@ -92,8 +92,9 @@ func ComparePodSpecs(
 			return currentPodSpec.Hostname == targetPodSpec.Hostname
 		},
 		"termination-grace-period": func() bool {
-			return currentPodSpec.TerminationGracePeriodSeconds == nil && targetPodSpec.TerminationGracePeriodSeconds == nil ||
-				*currentPodSpec.TerminationGracePeriodSeconds == *targetPodSpec.TerminationGracePeriodSeconds
+			return (currentPodSpec.TerminationGracePeriodSeconds == nil && targetPodSpec.TerminationGracePeriodSeconds == nil) ||
+				(currentPodSpec.TerminationGracePeriodSeconds != nil && targetPodSpec.TerminationGracePeriodSeconds != nil &&
+					*currentPodSpec.TerminationGracePeriodSeconds == *targetPodSpec.TerminationGracePeriodSeconds)
 		},
 	}
 


### PR DESCRIPTION
Add proper nil checks before dereferencing TerminationGracePeriodSeconds pointers to prevent panic when only one of the pointers is nil. 

In practice only the proposed pod could have the nil value, for this reason I'm tagging the PR as a strict nil check lint 

