### PR TITLE
chore(ci): link velero plugin version to container images in Renovate

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -1326,7 +1326,7 @@ jobs:
         env:
           # renovate: datasource=github-releases depName=vmware-tanzu/velero
           VELERO_VERSION: "v1.16.1"
-          # renovate: datasource=github-releases depName=vmware-tanzu/velero
+          # renovate: datasource=docker depName=velero/velero-plugin-for-aws
           VELERO_AWS_PLUGIN_VERSION: "v1.16.1"
         with:
           timeout_minutes: 10


### PR DESCRIPTION
The velero plugin should be updated based on the availability of the images since those are the one required when deploying Velero. The Velero version should be always the GitHub release, since that's what we use to install Velero

Closes #7779 