### PR TITLE
fix(import): do not create default user and database in monolith mode

### DIFF
--- a/api/v1/cluster_defaults.go
+++ b/api/v1/cluster_defaults.go
@@ -237,6 +237,11 @@ func (r *Cluster) defaultInitDB() {
 		}
 	}
 
+	if r.Spec.Bootstrap.InitDB.Import != nil &&
+		r.Spec.Bootstrap.InitDB.Import.Type == MonolithSnapshotType {
+		return
+	}
+
 	if r.Spec.Bootstrap.InitDB.Database == "" {
 		r.Spec.Bootstrap.InitDB.Database = DefaultApplicationDatabaseName
 	}

--- a/api/v1/cluster_defaults.go
+++ b/api/v1/cluster_defaults.go
@@ -237,13 +237,12 @@ func (r *Cluster) defaultInitDB() {
 		}
 	}
 
-	if r.Spec.Bootstrap.InitDB.Import != nil &&
-		r.Spec.Bootstrap.InitDB.Import.Type == MonolithSnapshotType {
-		return
-	}
-
 	if r.Spec.Bootstrap.InitDB.Database == "" {
-		r.Spec.Bootstrap.InitDB.Database = DefaultApplicationDatabaseName
+		// Set the default only if not executing a monolithic import
+		if r.Spec.Bootstrap.InitDB.Import == nil ||
+			r.Spec.Bootstrap.InitDB.Import.Type != MonolithSnapshotType {
+			r.Spec.Bootstrap.InitDB.Database = DefaultApplicationDatabaseName
+		}
 	}
 	if r.Spec.Bootstrap.InitDB.Owner == "" {
 		r.Spec.Bootstrap.InitDB.Owner = r.Spec.Bootstrap.InitDB.Database

--- a/docs/src/database_import.md
+++ b/docs/src/database_import.md
@@ -345,12 +345,15 @@ spec:
 
 In both cases, the database's contents will be imported, but:
 
-- In the microservice case, the database and owner both become `app`. You can
-  configure a different database and owner via the `bootstrap.initdb` stanza's
-  `database` and `owner` fields.
+- In the microservice case, the imported database's name and owner both become
+  `app`, or whichever configuration for the fields `database` and `owner` are
+  set in the `bootstrap.initdb` stanza.
 - In the monolith case, the database and owner are kept exactly as in the source
   cluster, i.e. `mydb` and `me` respectively. No `app` database nor user will be
-  created.
+  created. If there are custom settings for `database` and `owner` in the
+  `bootstrap.initdb` stanza that don't match the source databases/owners to
+  import, the instance manager will create a new empty application database and
+  owner role, but will leave the imported databases/owners intact.
 
 ## Import optimizations
 

--- a/docs/src/database_import.md
+++ b/docs/src/database_import.md
@@ -234,7 +234,8 @@ There are a few things you need to be aware of when using the `monolith` type:
   that needs to run `pg_dump` and retrieve roles information (*superuser* is
   OK)
 - Currently, the `pg_dump -Fd` result is stored temporarily inside the `dumps`
-  folder in the `PGDATA` volume, so there should be enough available space to
+  folder in the `PGDATA` volume of the destination cluster's instances, so
+  there should be enough available space to
   temporarily contain the dump result on the assigned node, as well as the
   restored data and indexes. Once the import operation is completed, this
   folder is automatically deleted by the operator.
@@ -250,7 +251,7 @@ There are a few things you need to be aware of when using the `monolith` type:
   and those databases not allowing connections
 - After the clone procedure is done, `ANALYZE VERBOSE` is executed for every
   database.
-- `postImportApplicationSQL` field is not supported
+- The `postImportApplicationSQL` field is not supported
 
 ## Comparing microservice vs monolith imports
 
@@ -345,10 +346,10 @@ spec:
 In both cases, the database's contents will be imported, but:
 
 - In the microservice case, the database and owner both become `app`. You can
-  configure the database and onwer via the `bootstrap.initdb` stanza's
-  `database` and `owner` fields, as always
-- In the monolith case, the database and owner as kept as in the source cluster,
-  i.e. `mydb` and `me` respectivelly. No `app` database nor user will be
+  configure a different database and owner via the `bootstrap.initdb` stanza's
+  `database` and `owner` fields.
+- In the monolith case, the database and owner are kept exactly as in the source
+  cluster, i.e. `mydb` and `me` respectively. No `app` database nor user will be
   created.
 
 ## Import optimizations

--- a/docs/src/database_import.md
+++ b/docs/src/database_import.md
@@ -253,7 +253,15 @@ There are a few things you need to be aware of when using the `monolith` type:
   database.
 - The `postImportApplicationSQL` field is not supported
 
-## Comparing microservice vs monolith imports
+!!! Hint
+    The databases and their owners are preserved exactly as they exist in the
+    source cluster—no `app` database or user will be created during import. If your
+    `bootstrap.initdb` stanza specifies custom `database` and `owner` values that
+    do not match any of the databases or users being imported, the instance
+    manager will create a new, empty application database and owner role with those
+    specified names, while leaving the imported databases and owners unchanged.
+
+## A practical example
 
 There is nothing to stop you from using the `monolith` approach to import a
 single database. It is interesting to see how the results of doing so would

--- a/tests/e2e/cluster_monolithic_test.go
+++ b/tests/e2e/cluster_monolithic_test.go
@@ -185,6 +185,20 @@ var _ = Describe("Imports with Monolithic Approach", Label(tests.LabelImportingD
 			}
 		})
 
+		By("verifying that no extra application database or owner were created", func() {
+			stmt, err := connTarget.Prepare("SELECT count(*) FROM pg_catalog.pg_database WHERE datname = $1")
+			Expect(err).ToNot(HaveOccurred())
+			var matchCount int
+			err = stmt.QueryRowContext(env.Ctx, "app").Scan(&matchCount)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(matchCount).To(BeZero(), "app database should not exist")
+			stmt, err = connTarget.Prepare("SELECT count(*) from pg_catalog.pg_user WHERE usename = $1")
+			Expect(err).ToNot(HaveOccurred())
+			err = stmt.QueryRowContext(env.Ctx, "app").Scan(&matchCount)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(matchCount).To(BeZero(), "app user should not exist")
+		})
+
 		By(fmt.Sprintf("verifying that the source superuser '%s' became a normal user in target",
 			databaseSuperUser), func() {
 			row := connTarget.QueryRow(fmt.Sprintf(


### PR DESCRIPTION
When importing in monolith mode, avoid automatically creating a default user and database. This approach ensures that the import process accurately mirrors the source environment, preventing the creation of unnecessary or unintended objects. Additionally, the documentation has been updated to clarify the import behavior and usage in monolith scenarios.

Closes #7731
Closes #7447
