### PR TITLE
fix: concurrent-write to map in connection pool

### DIFF
--- a/pkg/management/postgres/pool/pool.go
+++ b/pkg/management/postgres/pool/pool.go
@@ -24,6 +24,7 @@ package pool
 import (
 	"database/sql"
 	"fmt"
+	"sync"
 
 	// this is needed to correctly open the sql connection with the pgx driver
 	_ "github.com/jackc/pgx/v5/stdlib"
@@ -51,7 +52,8 @@ type ConnectionPool struct {
 	connectionProfile ConnectionProfile
 
 	// A map of connection for every used database
-	connectionMap map[string]*sql.DB
+	connectionMap      map[string]*sql.DB
+	connectionMapMutex sync.Mutex
 }
 
 // NewPostgresqlConnectionPool creates a new connectionMap of connections given
@@ -78,6 +80,8 @@ func newConnectionPool(baseConnectionString string, connectionProfile Connection
 
 // Connection gets the connection for the given database
 func (pool *ConnectionPool) Connection(dbname string) (*sql.DB, error) {
+	pool.connectionMapMutex.Lock()
+	defer pool.connectionMapMutex.Unlock()
 	if result, ok := pool.connectionMap[dbname]; ok {
 		return result, nil
 	}

--- a/pkg/management/postgres/pool/pool.go
+++ b/pkg/management/postgres/pool/pool.go
@@ -97,6 +97,9 @@ func (pool *ConnectionPool) Connection(dbname string) (*sql.DB, error) {
 
 // ShutdownConnections closes every database connection
 func (pool *ConnectionPool) ShutdownConnections() {
+	pool.connectionMapMutex.Lock()
+	defer pool.connectionMapMutex.Unlock()
+
 	for _, db := range pool.connectionMap {
 		_ = db.Close()
 	}

--- a/pkg/management/postgres/pool/pool.go
+++ b/pkg/management/postgres/pool/pool.go
@@ -107,7 +107,7 @@ func (pool *ConnectionPool) ShutdownConnections() {
 	pool.connectionMap = make(map[string]*sql.DB)
 }
 
-// newConnection creates a database connection connectionMap, connecting via
+// newConnection creates a database connection, connecting via
 // Unix domain socket to a database with a certain name
 func (pool *ConnectionPool) newConnection(dbname string) (*sql.DB, error) {
 	dsn := pool.GetDsn(dbname)


### PR DESCRIPTION
We've run into a concurrent-write fatal error for one of our production
databases (see attached stacktrace). We also have the suspicion of this
causing a split brain / two master instances running since we had a new
timeline ID on the WAL after the process has restarted.
During the restart, the operator promoted a replica as new primary since the endpoint has not
been reachable.
We cannot fully correlate the issue to the process crashing, but this is
Nevertheless a bug worth fixing ;-)

```
{"level":"info","ts":"2025-06-08T03:47:08.178508404Z","logger":"postgres","msg":"record","logging_pod":"<redacted>","record":{"log_time":"2025-06-08 03:47:08.178 UTC","user_name":"postgres","database_name":"postgres","process_id":"432693","connection_from":"[local]","session_id":"684507b7.69a35","session_line_num":"2","command_tag":"idle","session_start_time":"2025-06-08 03:47:03 UTC","virtual_transaction_id":"31/0","transaction_id":"0","error_severity":"FATAL","sql_state_code":"08006","message":"connection to client lost","application_name":"pg_isready","backend_type":"client backend","query_id":"0"}}

fatal error: concurrent map writes
-
-
goroutine 707347 [running]:
internal/runtime/maps.fatal({0x25e819d?, 0x1da94f2?})
	/opt/hostedtoolcache/go/1.24.0/x64/src/runtime/panic.go:1053 +0x18
github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres/pool.(*ConnectionPool).Connection(0xc0003240f0, {0xc000a8e65c, 0x3})
	pkg/management/postgres/pool/pool.go:87 +0x7b
github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres/metrics.QueriesCollector.getAllAccessibleDatabases({0xc0004bb200, {0xc000a8e65c, 0x3}, {0x25c9cf9, 0x4}, 0xc0014c9590, 0xc0014c9530, 0xc0014c9560, 0xc0005aaf58, {0x298b3a8, ...}})
	pkg/management/postgres/metrics/collector.go:210 +0x5a
github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres/metrics.(*QueriesCollector).collectUserQueries(0xc000fa3ca0, 0xc00025f5e0)
	pkg/management/postgres/metrics/collector.go:110 +0x538
github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres/metrics.QueriesCollector.Collect({0xc0004bb200, {0xc000a8e65c, 0x3}, {0x25c9cf9, 0x4}, 0xc0014c9590, 0xc0014c9530, 0xc0014c9560, 0xc0005aaf58, {0x298b3a8, ...}}, ...)
	pkg/management/postgres/metrics/collector.go:64 +0x34
github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres/webserver/metricserver.(*Exporter).collectPgMetrics(0xc000282580, 0xc00025f5e0)
	pkg/management/postgres/webserver/metricserver/pg_collector.go:375 +0x525
github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres/webserver/metricserver.(*Exporter).Collect(0xc000282580, 0xc00025f5e0)
	pkg/management/postgres/webserver/metricserver/pg_collector.go:304 +0x2f
github.com/prometheus/client_golang/prometheus.(*Registry).Gather.func1()
	pkg/mod/github.com/prometheus/client_golang@v1.21.0/prometheus/registry.go:456 +0x105
created by github.com/prometheus/client_golang/prometheus.(*Registry).Gather in goroutine 707199
	pkg/mod/github.com/prometheus/client_golang@v1.21.0/prometheus/registry.go:548 +0xbf1
-
goroutine 1 [select, 1517 minutes]:
sigs.k8s.io/controller-runtime/pkg/manager.(*controllerManager).Start(0xc000594e00, {0x297a730, 0xc000345950})
	pkg/mod/sigs.k8s.io/controller-runtime@v0.20.2/pkg/manager/internal.go:466 +0xabc
github.com/cloudnative-pg/cloudnative-pg/internal/cmd/manager/instance/run.runSubCommand({0x297a6f8, 0xc00054e8d0}, 0xc0004bb200)
	internal/cmd/manager/instance/run/cmd.go:348 +0x1c42
github.com/cloudnative-pg/cloudnative-pg/internal/cmd/manager/instance/run.NewCmd.func2.1()
	internal/cmd/manager/instance/run/cmd.go:104 +0x1f
k8s.io/client-go/util/retry.OnError.func1()
	pkg/mod/k8s.io/client-go@v0.32.2/util/retry/util.go:51 +0x30
k8s.io/apimachinery/pkg/util/wait.runConditionWithCrashProtection(0x1300000000000070?)
	pkg/mod/k8s.io/apimachinery@v0.32.2/pkg/util/wait/wait.go:145 +0x3e
k8s.io/apimachinery/pkg/util/wait.ExponentialBackoff({0x989680, 0x3ff0000000000000, 0x3fb999999999999a, 0x5, 0x0}, 0xc001187b78)
	pkg/mod/k8s.io/apimachinery@v0.32.2/pkg/util/wait/backoff.go:461 +0x5a
k8s.io/client-go/util/retry.OnError({0x989680, 0x3ff0000000000000, 0x3fb999999999999a, 0x5, 0x0}, 0x0?, 0x0?)
	pkg/mod/k8s.io/client-go@v0.32.2/util/retry/util.go:50 +0x96
github.com/cloudnative-pg/cloudnative-pg/internal/cmd/manager/instance/run.NewCmd.func2(0xc00070b930?, {0x25c9931?, 0x4?, 0x25c9935?})
	internal/cmd/manager/instance/run/cmd.go:103 +0x305
github.com/spf13/cobra.(*Command).execute(0xc0002f4608, {0xc000527380, 0x2, 0x2})
	pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:1015 +0xa94
github.com/spf13/cobra.(*Command).ExecuteC(0xc000326908)
	pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:1148 +0x40c
github.com/spf13/cobra.(*Command).Execute(...)
	pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:1071
main.main()
	cmd/manager/main.go:68 +0x3d1
-
goroutine 116 [IO wait]:
internal/poll.runtime_pollWait(0x7d31517d6018, 0x72)
	/opt/hostedtoolcache/go/1.24.0/x64/src/runtime/netpoll.go:351 +0x85
crypto/tls.(*Conn).readFromUntil(0xc00033e388, {0x294f8a0, 0xc0005aa040}, 0x4403b4?)
	/opt/hostedtoolcache/go/1.24.0/x64/src/crypto/tls/conn.go:831 +0xde
crypto/tls.(*Conn).readRecordOrCCS(0xc00033e388, 0x0)
	/opt/hostedtoolcache/go/1.24.0/x64/src/crypto/tls/conn.go:629 +0x3cf
crypto/tls.(*Conn).readRecord(...)
	/opt/hostedtoolcache/go/1.24.0/x64/src/crypto/tls/conn.go:591
crypto/tls.(*Conn).Read(0xc00033e388, {0xc000675000, 0x1000, 0xc000c13d38?})
	/opt/hostedtoolcache/go/1.24.0/x64/src/crypto/tls/conn.go:1385 +0x145
bufio.(*Reader).Read(0xc000626d80, {0xc000654200, 0x9, 0xc0000f72f0?})
	/opt/hostedtoolcache/go/1.24.0/x64/src/bufio/bufio.go:245 +0x197
io.ReadAtLeast({0x294e380, 0xc000626d80}, {0xc000654200, 0x9, 0x9}, 0x9)
	/opt/hostedtoolcache/go/1.24.0/x64/src/io/io.go:335 +0x91
io.ReadFull(...)
	/opt/hostedtoolcache/go/1.24.0/x64/src/io/io.go:354
golang.org/x/net/http2.readFrameHeader({0xc000654200, 0x9, 0x47deb1?}, {0x294e380?, 0xc000626d80?})
	pkg/mod/golang.org/x/net@v0.35.0/http2/frame.go:237 +0x65
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start(0x29a09e0, {0x297a730, 0xc000345680})
	pkg/mod/sigs.k8s.io/controller-runtime@v0.20.2/pkg/internal/controller/controller.go:261 +0x1a9
sigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).reconcile.func1(0xc000282c40)
	pkg/mod/sigs.k8s.io/controller-runtime@v0.20.2/pkg/manager/runnable_group.go:226 +0xbf
created by sigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).reconcile in goroutine 163
	pkg/mod/sigs.k8s.io/controller-runtime@v0.20.2/pkg/manager/runnable_group.go:210 +0x191
-
-
goroutine 149 [chan receive, 1517 minutes]:
sigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).reconcile(0xc000914bd0)
	pkg/mod/sigs.k8s.io/controller-runtime@v0.20.2/pkg/manager/runnable_group.go:186 +0x45
created by sigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).Start.func1 in goroutine 1
	pkg/mod/sigs.k8s.io/controller-runtime@v0.20.2/pkg/manager/runnable_group.go:139 +0xbf
goroutine 161 [chan receive, 1517 minutes]:
-
goroutine 153 [select, 1517 minutes]:
sigs.k8s.io/controller-runtime/pkg/cache.(*multiNamespaceCache).Start(0xc0006643f0, {0x297a730, 0xc000345630})
	pkg/mod/sigs.k8s.io/controller-runtime@v0.20.2/pkg/cache/multi_namespace_cache.go:185 +0x2b5
sigs.k8s.io/controller-runtime/pkg/cache.(*delegatingByGVKCache).Start.func1()
	pkg/mod/sigs.k8s.io/controller-runtime@v0.20.2/pkg/cache/delegating_by_gvk_cache.go:87 +0x62
created by sigs.k8s.io/controller-runtime/pkg/cache.(*delegatingByGVKCache).Start in goroutine 150
	pkg/mod/sigs.k8s.io/controller-runtime@v0.20.2/pkg/cache/delegating_by_gvk_cache.go:85 +0x21c
internal/poll.(*pollDesc).wait(0xc000199980?, 0xc000772000?, 0x0)
	/opt/hostedtoolcache/go/1.24.0/x64/src/internal/poll/fd_poll_runtime.go:84 +0x27
internal/poll.(*pollDesc).waitRead(...)
	/opt/hostedtoolcache/go/1.24.0/x64/src/internal/poll/fd_poll_runtime.go:89
internal/poll.(*FD).Read(0xc000199980, {0xc000772000, 0xa000, 0xa000})
	/opt/hostedtoolcache/go/1.24.0/x64/src/internal/poll/fd_unix.go:165 +0x27a
net.(*netFD).Read(0xc000199980, {0xc000772000?, 0xc000784420?, 0xc000ca6c00?})
	/opt/hostedtoolcache/go/1.24.0/x64/src/net/fd_posix.go:55 +0x25
net.(*conn).Read(0xc0005aa040, {0xc000772000?, 0x7d31514ae2c8?, 0x7d31983ff3e8?})
	/opt/hostedtoolcache/go/1.24.0/x64/src/net/net.go:194 +0x45
crypto/tls.(*atLeastReader).Read(0xc000782b88, {0xc000772000?, 0xc000c13928?, 0xc000c13988?})
	/opt/hostedtoolcache/go/1.24.0/x64/src/crypto/tls/conn.go:809 +0x3b
bytes.(*Buffer).ReadFrom(0xc00033e638, {0x2950a00, 0xc000782b88})
	/opt/hostedtoolcache/go/1.24.0/x64/src/bytes/buffer.go:211 +0x98
golang.org/x/net/http2.(*Framer).ReadFrame(0xc0006541c0)
	pkg/mod/golang.org/x/net@v0.35.0/http2/frame.go:501 +0x7d
golang.org/x/net/http2.(*clientConnReadLoop).run(0xc000c13fa8)
	pkg/mod/golang.org/x/net@v0.35.0/http2/transport.go:2227 +0xda
golang.org/x/net/http2.(*ClientConn).readLoop(0xc0000f7180)
	pkg/mod/golang.org/x/net@v0.35.0/http2/transport.go:2103 +0x79
created by golang.org/x/net/http2.(*Transport).newClientConn in goroutine 115
	pkg/mod/golang.org/x/net@v0.35.0/http2/transport.go:912 +0xde5
-
...
```

Signed-off-by: Matthias Riegler <me@xvzf.tech>
