### PR TITLE
feat(bootstrap): stop defaulting database field

### DIFF
--- a/api/v1/cluster_defaults.go
+++ b/api/v1/cluster_defaults.go
@@ -42,10 +42,6 @@ const (
 	// DefaultMonitoringSecretName is the name of the target secret with the default monitoring queries,
 	// if configured
 	DefaultMonitoringSecretName = DefaultMonitoringConfigMapName
-	// DefaultApplicationDatabaseName is the name of application database if not specified
-	DefaultApplicationDatabaseName = "app"
-	// DefaultApplicationUserName is the name of application database owner if not specified
-	DefaultApplicationUserName = DefaultApplicationDatabaseName
 )
 
 // Default apply the defaults to undefined values in a Cluster preserving the user settings
@@ -233,18 +229,7 @@ func (r *Cluster) defaultMonitoringQueries(config *configuration.Data) {
 // defaultInitDB enriches the initDB with defaults if not all the required arguments were passed
 func (r *Cluster) defaultInitDB() {
 	if r.Spec.Bootstrap.InitDB == nil {
-		r.Spec.Bootstrap.InitDB = &BootstrapInitDB{
-			Database: DefaultApplicationDatabaseName,
-			Owner:    DefaultApplicationUserName,
-		}
-	}
-
-	if r.Spec.Bootstrap.InitDB.Database == "" {
-		// Set the default only if not executing a monolithic import
-		if r.Spec.Bootstrap.InitDB.Import == nil ||
-			r.Spec.Bootstrap.InitDB.Import.Type != MonolithSnapshotType {
-			r.Spec.Bootstrap.InitDB.Database = DefaultApplicationDatabaseName
-		}
+		r.Spec.Bootstrap.InitDB = &BootstrapInitDB{}
 	}
 	if r.Spec.Bootstrap.InitDB.Owner == "" {
 		r.Spec.Bootstrap.InitDB.Owner = r.Spec.Bootstrap.InitDB.Database
@@ -262,9 +247,6 @@ func (r *Cluster) defaultInitDB() {
 
 // defaultRecovery enriches the recovery with defaults if not all the required arguments were passed
 func (r *Cluster) defaultRecovery() {
-	if r.Spec.Bootstrap.Recovery.Database == "" {
-		r.Spec.Bootstrap.Recovery.Database = DefaultApplicationDatabaseName
-	}
 	if r.Spec.Bootstrap.Recovery.Owner == "" {
 		r.Spec.Bootstrap.Recovery.Owner = r.Spec.Bootstrap.Recovery.Database
 	}
@@ -272,9 +254,6 @@ func (r *Cluster) defaultRecovery() {
 
 // defaultPgBaseBackup enriches the pg_basebackup with defaults if not all the required arguments were passed
 func (r *Cluster) defaultPgBaseBackup() {
-	if r.Spec.Bootstrap.PgBaseBackup.Database == "" {
-		r.Spec.Bootstrap.PgBaseBackup.Database = DefaultApplicationDatabaseName
-	}
 	if r.Spec.Bootstrap.PgBaseBackup.Owner == "" {
 		r.Spec.Bootstrap.PgBaseBackup.Owner = r.Spec.Bootstrap.PgBaseBackup.Database
 	}

--- a/api/v1/cluster_defaults_test.go
+++ b/api/v1/cluster_defaults_test.go
@@ -31,11 +31,12 @@ import (
 )
 
 var _ = Describe("cluster default configuration", func() {
-	It("defaults to creating an application database", func() {
+	It("defaults to initdb", func() {
 		cluster := Cluster{}
 		cluster.Default()
-		Expect(cluster.Spec.Bootstrap.InitDB.Database).To(Equal("app"))
-		Expect(cluster.Spec.Bootstrap.InitDB.Owner).To(Equal("app"))
+		Expect(cluster.Spec.Bootstrap.InitDB).ToNot(BeNil())
+		Expect(cluster.Spec.Bootstrap.InitDB.Database).To(BeEmpty())
+		Expect(cluster.Spec.Bootstrap.InitDB.Owner).To(BeEmpty())
 	})
 
 	It("defaults the owner user with the database name", func() {
@@ -53,7 +54,7 @@ var _ = Describe("cluster default configuration", func() {
 		Expect(cluster.Spec.Bootstrap.InitDB.Owner).To(Equal("appdb"))
 	})
 
-	It("defaults to create an application database if recovery is used", func() {
+	It("defaults to not create an application database if recovery is used", func() {
 		cluster := Cluster{
 			Spec: ClusterSpec{
 				Bootstrap: &BootstrapConfiguration{
@@ -62,9 +63,9 @@ var _ = Describe("cluster default configuration", func() {
 			},
 		}
 		cluster.Default()
-		Expect(cluster.ShouldRecoveryCreateApplicationDatabase()).Should(BeTrue())
-		Expect(cluster.Spec.Bootstrap.Recovery.Database).ShouldNot(BeEmpty())
-		Expect(cluster.Spec.Bootstrap.Recovery.Owner).ShouldNot(BeEmpty())
+		Expect(cluster.ShouldRecoveryCreateApplicationDatabase()).Should(BeFalse())
+		Expect(cluster.Spec.Bootstrap.Recovery.Database).Should(BeEmpty())
+		Expect(cluster.Spec.Bootstrap.Recovery.Owner).Should(BeEmpty())
 		Expect(cluster.Spec.Bootstrap.Recovery.Secret).Should(BeNil())
 	})
 
@@ -83,7 +84,7 @@ var _ = Describe("cluster default configuration", func() {
 		Expect(cluster.Spec.Bootstrap.Recovery.Owner).To(Equal("appdb"))
 	})
 
-	It("defaults to create an application database if pg_basebackup is used", func() {
+	It("defaults to not create an application database if pg_basebackup is used", func() {
 		cluster := Cluster{
 			Spec: ClusterSpec{
 				Bootstrap: &BootstrapConfiguration{
@@ -92,9 +93,9 @@ var _ = Describe("cluster default configuration", func() {
 			},
 		}
 		cluster.Default()
-		Expect(cluster.ShouldPgBaseBackupCreateApplicationDatabase()).Should(BeTrue())
-		Expect(cluster.Spec.Bootstrap.PgBaseBackup.Database).ShouldNot(BeEmpty())
-		Expect(cluster.Spec.Bootstrap.PgBaseBackup.Owner).ShouldNot(BeEmpty())
+		Expect(cluster.ShouldPgBaseBackupCreateApplicationDatabase()).Should(BeFalse())
+		Expect(cluster.Spec.Bootstrap.PgBaseBackup.Database).Should(BeEmpty())
+		Expect(cluster.Spec.Bootstrap.PgBaseBackup.Owner).Should(BeEmpty())
 		Expect(cluster.Spec.Bootstrap.PgBaseBackup.Secret).Should(BeNil())
 	})
 
@@ -144,13 +145,6 @@ var _ = Describe("cluster default configuration", func() {
 		}
 		cluster.Default()
 		Expect(cluster.Spec.ImageName).To(Equal("test:13"))
-	})
-
-	It("should setup the application database name", func() {
-		cluster := Cluster{}
-		cluster.Default()
-		Expect(cluster.Spec.Bootstrap.InitDB.Database).To(Equal("app"))
-		Expect(cluster.Spec.Bootstrap.InitDB.Owner).To(Equal("app"))
 	})
 
 	It("should set the owner name as the database name", func() {

--- a/api/v1/cluster_funcs_test.go
+++ b/api/v1/cluster_funcs_test.go
@@ -265,8 +265,9 @@ var _ = Describe("Bootstrap via initdb", func() {
 		// InitDB is the default bootstrap method, and is triggered by
 		// the defaulting webhook if nothing else is specified by the user
 		cluster.Default()
-		Expect(cluster.ShouldCreateApplicationDatabase()).To(BeTrue())
-		Expect(cluster.ShouldCreateApplicationSecret()).To(BeTrue())
+		Expect(cluster.Spec.Bootstrap.InitDB).ToNot(BeNil())
+		Expect(cluster.ShouldCreateApplicationDatabase()).To(BeFalse())
+		Expect(cluster.ShouldCreateApplicationSecret()).To(BeFalse())
 	})
 })
 

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -192,6 +192,11 @@ func newFakeCNPGCluster(
 			Labels:      map[string]string{},
 		},
 		Spec: apiv1.ClusterSpec{
+			Bootstrap: &apiv1.BootstrapConfiguration{
+				InitDB: &apiv1.BootstrapInitDB{
+					Database: "app",
+				},
+			},
 			Instances: instances,
 			Certificates: &apiv1.CertificatesConfiguration{
 				ServerCASecret: caServer,

--- a/tests/internal/asserts/pgbouncer/pgbouncer.go
+++ b/tests/internal/asserts/pgbouncer/pgbouncer.go
@@ -151,9 +151,6 @@ func AssertReadWriteConnectionUsingPgBouncerService(
 	Expect(err).ToNot(HaveOccurred())
 
 	dbName := cluster.GetApplicationDatabaseName()
-	if dbName == "" {
-		dbName = apiv1.DefaultApplicationDatabaseName
-	}
 
 	if isPoolerRW {
 		replication.AssertWritesToPrimarySucceeds(env, namespace, poolerService, dbName, appUser,


### PR DESCRIPTION
This pull request changes the default behavior of the `database` fields in all bootstrap methods (initdb, pg_basebackup, and recovery). If neither the `database` nor the `owner` fields are explicitly set, no application-specific database or role will be created during the bootstrap process. However, if only the `database` value is provided, the existing behavior will remain unchanged.

Partially implements #3242 