### PR TITLE
feat: Adding status when Cluster resource is in namespace outside operator scope. 

### DIFF
--- a/api/v1/cluster_conditions.go
+++ b/api/v1/cluster_conditions.go
@@ -51,4 +51,12 @@ var (
 			Message: err.Error(),
 		}
 	}
+	// OutsideWatchScopeCondition is used to indicate that the Cluster resource is
+	// in a namespace not watched by the operator.
+	OutsideWatchScopeCondition = metav1.Condition{
+		Type:    string(ConditionReconciled),
+		Status:  metav1.ConditionFalse,
+		Reason:  string(ConditionReasonOutsideWatchScope),
+		Message: "This Cluster resource is in a namespace not watched by the operator",
+	}
 )

--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -1003,6 +1003,8 @@ const (
 	// ConditionConsistentSystemID is true when the all the instances of the
 	// cluster report the same System ID.
 	ConditionConsistentSystemID ClusterConditionType = "ConsistentSystemID"
+	// ConditionReconciled indicates whether the resource has been successfully reconciled.
+	ConditionReconciled ClusterConditionType = "Reconciled"
 )
 
 // ConditionStatus defines conditions of resources
@@ -1051,6 +1053,9 @@ const (
 
 	// DetachedVolume is the reason that is set when we do a rolling upgrade to add a PVC volume to a cluster
 	DetachedVolume ConditionReason = "DetachedVolume"
+
+	// ConditionReasonOutsideWatchScope is the reason when the resource is in a namespace not watched by the operator.
+	ConditionReasonOutsideWatchScope ConditionReason = "OutsideWatchScope"
 )
 
 // EmbeddedObjectMetadata contains metadata to be inherited by all resources related to a Cluster

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -32,6 +32,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -177,6 +178,9 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			)
 		}
 		return ctrl.Result{}, err
+	}
+	if configuration.Current.WatchNamespace == "cnpg-system" && cluster.Namespace != configuration.Current.OperatorNamespace {
+		return r.handleOutsideWatchScope(ctx, cluster)
 	}
 
 	ctx = cluster.SetInContext(ctx)
@@ -531,6 +535,20 @@ func (r *ClusterReconciler) reconcile(ctx context.Context, cluster *apiv1.Cluste
 	}
 
 	return setStatusPluginHook(ctx, r.Client, cnpgiClient.GetPluginClientFromContext(ctx), cluster)
+}
+
+func (r *ClusterReconciler) handleOutsideWatchScope(ctx context.Context, cluster *apiv1.Cluster) (ctrl.Result, error) {
+	log := log.FromContext(ctx)
+
+	meta.SetStatusCondition(&cluster.Status.Conditions, apiv1.OutsideWatchScopeCondition)
+
+	if err := r.Status().Update(ctx, cluster); err != nil {
+		log.Error(err, "unable to set OutsideWatchScope condition")
+		return ctrl.Result{}, err
+	}
+
+	log.Info("Cluster resource is in an unwatched namespace. Skipping reconciliation.")
+	return ctrl.Result{}, nil
 }
 
 func (r *ClusterReconciler) ensureNoFailoverOnFullDisk(


### PR DESCRIPTION
- Adding status when Cluster resource is in namespace outside operator scope (clusterWide=false) #7713