### PR TITLE
fix(subscriptions): restrict subscription parameter updates to valid PostgreSQL options

### DIFF
--- a/api/v1/subscription_types.go
+++ b/api/v1/subscription_types.go
@@ -53,7 +53,9 @@ type SubscriptionSpec struct {
 	DBName string `json:"dbname"`
 
 	// Subscription parameters part of the `WITH` clause as expected by
-	// PostgreSQL `CREATE SUBSCRIPTION` command
+	// PostgreSQL `CREATE SUBSCRIPTION` command.
+	// Altering these parameters after the subscription creation will be ignored exept from a limited number of them
+	// documented at https://www.postgresql.org/docs/current/sql-altersubscription.html#SQL-ALTERSUBSCRIPTION-PARAMS-SET
 	// +optional
 	Parameters map[string]string `json:"parameters,omitempty"`
 

--- a/api/v1/subscription_types.go
+++ b/api/v1/subscription_types.go
@@ -53,7 +53,7 @@ type SubscriptionSpec struct {
 	DBName string `json:"dbname"`
 
 	// Subscription parameters included in the `WITH` clause of the PostgreSQL
-	// `CREATE SUBSCRIPTION` command.Most parameters cannot be changed
+	// `CREATE SUBSCRIPTION` command. Most parameters cannot be changed
 	// after the subscription is created and will be ignored if modified
 	// later, except for a limited set documented at:
 	// https://www.postgresql.org/docs/current/sql-altersubscription.html#SQL-ALTERSUBSCRIPTION-PARAMS-SET

--- a/api/v1/subscription_types.go
+++ b/api/v1/subscription_types.go
@@ -52,10 +52,11 @@ type SubscriptionSpec struct {
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="dbname is immutable"
 	DBName string `json:"dbname"`
 
-	// Subscription parameters part of the `WITH` clause as expected by
-	// PostgreSQL `CREATE SUBSCRIPTION` command.
-	// Altering these parameters after the subscription creation will be ignored except from a limited number of them
-	// documented at https://www.postgresql.org/docs/current/sql-altersubscription.html#SQL-ALTERSUBSCRIPTION-PARAMS-SET
+	// Subscription parameters included in the `WITH` clause of the PostgreSQL
+	// `CREATE SUBSCRIPTION` command.Most parameters cannot be changed
+	// after the subscription is created and will be ignored if modified
+	// later, except for a limited set documented at:
+	// https://www.postgresql.org/docs/current/sql-altersubscription.html#SQL-ALTERSUBSCRIPTION-PARAMS-SET
 	// +optional
 	Parameters map[string]string `json:"parameters,omitempty"`
 

--- a/api/v1/subscription_types.go
+++ b/api/v1/subscription_types.go
@@ -54,7 +54,7 @@ type SubscriptionSpec struct {
 
 	// Subscription parameters part of the `WITH` clause as expected by
 	// PostgreSQL `CREATE SUBSCRIPTION` command.
-	// Altering these parameters after the subscription creation will be ignored exept from a limited number of them
+	// Altering these parameters after the subscription creation will be ignored except from a limited number of them
 	// documented at https://www.postgresql.org/docs/current/sql-altersubscription.html#SQL-ALTERSUBSCRIPTION-PARAMS-SET
 	// +optional
 	Parameters map[string]string `json:"parameters,omitempty"`

--- a/config/crd/bases/postgresql.cnpg.io_subscriptions.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_subscriptions.yaml
@@ -95,7 +95,7 @@ spec:
                 description: |-
                   Subscription parameters part of the `WITH` clause as expected by
                   PostgreSQL `CREATE SUBSCRIPTION` command.
-                  Altering these parameters after the subscription creation will be ignored exept from a limited number of them
+                  Altering these parameters after the subscription creation will be ignored except from a limited number of them
                   documented at https://www.postgresql.org/docs/current/sql-altersubscription.html#SQL-ALTERSUBSCRIPTION-PARAMS-SET
                 type: object
               publicationDBName:

--- a/config/crd/bases/postgresql.cnpg.io_subscriptions.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_subscriptions.yaml
@@ -93,10 +93,11 @@ spec:
                 additionalProperties:
                   type: string
                 description: |-
-                  Subscription parameters part of the `WITH` clause as expected by
-                  PostgreSQL `CREATE SUBSCRIPTION` command.
-                  Altering these parameters after the subscription creation will be ignored except from a limited number of them
-                  documented at https://www.postgresql.org/docs/current/sql-altersubscription.html#SQL-ALTERSUBSCRIPTION-PARAMS-SET
+                  Subscription parameters included in the `WITH` clause of the PostgreSQL
+                  `CREATE SUBSCRIPTION` command.Most parameters cannot be changed
+                  after the subscription is created and will be ignored if modified
+                  later, except for a limited set documented at:
+                  https://www.postgresql.org/docs/current/sql-altersubscription.html#SQL-ALTERSUBSCRIPTION-PARAMS-SET
                 type: object
               publicationDBName:
                 description: |-

--- a/config/crd/bases/postgresql.cnpg.io_subscriptions.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_subscriptions.yaml
@@ -94,7 +94,7 @@ spec:
                   type: string
                 description: |-
                   Subscription parameters included in the `WITH` clause of the PostgreSQL
-                  `CREATE SUBSCRIPTION` command.Most parameters cannot be changed
+                  `CREATE SUBSCRIPTION` command. Most parameters cannot be changed
                   after the subscription is created and will be ignored if modified
                   later, except for a limited set documented at:
                   https://www.postgresql.org/docs/current/sql-altersubscription.html#SQL-ALTERSUBSCRIPTION-PARAMS-SET

--- a/config/crd/bases/postgresql.cnpg.io_subscriptions.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_subscriptions.yaml
@@ -94,7 +94,9 @@ spec:
                   type: string
                 description: |-
                   Subscription parameters part of the `WITH` clause as expected by
-                  PostgreSQL `CREATE SUBSCRIPTION` command
+                  PostgreSQL `CREATE SUBSCRIPTION` command.
+                  Altering these parameters after the subscription creation will be ignored exept from a limited number of them
+                  documented at https://www.postgresql.org/docs/current/sql-altersubscription.html#SQL-ALTERSUBSCRIPTION-PARAMS-SET
                 type: object
               publicationDBName:
                 description: |-

--- a/docs/src/cloudnative-pg.v1.md
+++ b/docs/src/cloudnative-pg.v1.md
@@ -5839,7 +5839,9 @@ the &quot;subscriber&quot; cluster</p>
 </td>
 <td>
    <p>Subscription parameters part of the <code>WITH</code> clause as expected by
-PostgreSQL <code>CREATE SUBSCRIPTION</code> command</p>
+PostgreSQL <code>CREATE SUBSCRIPTION</code> command.
+Altering these parameters after the subscription creation will be ignored except from a limited number of them
+documented at https://www.postgresql.org/docs/current/sql-altersubscription.html#SQL-ALTERSUBSCRIPTION-PARAMS-SET</p>
 </td>
 </tr>
 <tr><td><code>publicationName</code> <B>[Required]</B><br/>

--- a/docs/src/cloudnative-pg.v1.md
+++ b/docs/src/cloudnative-pg.v1.md
@@ -5838,10 +5838,11 @@ the &quot;subscriber&quot; cluster</p>
 <i>map[string]string</i>
 </td>
 <td>
-   <p>Subscription parameters part of the <code>WITH</code> clause as expected by
-PostgreSQL <code>CREATE SUBSCRIPTION</code> command.
-Altering these parameters after the subscription creation will be ignored except from a limited number of them
-documented at https://www.postgresql.org/docs/current/sql-altersubscription.html#SQL-ALTERSUBSCRIPTION-PARAMS-SET</p>
+   <p>Subscription parameters included in the <code>WITH</code> clause of the PostgreSQL
+<code>CREATE SUBSCRIPTION</code> command. Most parameters cannot be changed
+after the subscription is created and will be ignored if modified
+later, except for a limited set documented at:
+https://www.postgresql.org/docs/current/sql-altersubscription.html#SQL-ALTERSUBSCRIPTION-PARAMS-SET</p>
 </td>
 </tr>
 <tr><td><code>publicationName</code> <B>[Required]</B><br/>

--- a/internal/management/controller/subscription_controller.go
+++ b/internal/management/controller/subscription_controller.go
@@ -42,9 +42,10 @@ type SubscriptionReconciler struct {
 	client.Client
 	Scheme *runtime.Scheme
 
-	instance            *postgres.Instance
-	finalizerReconciler *finalizerReconciler[*apiv1.Subscription]
-	getDB               func(name string) (*sql.DB, error)
+	instance                *postgres.Instance
+	finalizerReconciler     *finalizerReconciler[*apiv1.Subscription]
+	getDB                   func(name string) (*sql.DB, error)
+	getPostgresMajorVersion func() (int, error)
 }
 
 // subscriptionReconciliationInterval is the time between the
@@ -189,6 +190,10 @@ func NewSubscriptionReconciler(
 		instance: instance,
 		getDB: func(name string) (*sql.DB, error) {
 			return instance.ConnectionPool().Connection(name)
+		},
+		getPostgresMajorVersion: func() (int, error) {
+			version, err := instance.GetPgVersion()
+			return int(version.Major), err //nolint:gosec
 		},
 	}
 	sr.finalizerReconciler = newFinalizerReconciler(

--- a/internal/management/controller/subscription_controller_sql_test.go
+++ b/internal/management/controller/subscription_controller_sql_test.go
@@ -143,8 +143,9 @@ var _ = Describe("subscription sql", func() {
 				Name:            "test_sub",
 				PublicationName: "test_pub",
 				Parameters: map[string]string{
-					"param1": "value1",
-					"param2": "value2",
+					"copy_data": "true",
+					"origin":    "none",
+					"failover":  "true",
 				},
 			},
 		}
@@ -153,7 +154,7 @@ var _ = Describe("subscription sql", func() {
 		sqls := toSubscriptionAlterSQL(obj, connString)
 		Expect(sqls).To(ContainElement(`ALTER SUBSCRIPTION "test_sub" SET PUBLICATION "test_pub"`))
 		Expect(sqls).To(ContainElement(`ALTER SUBSCRIPTION "test_sub" CONNECTION 'host=localhost user=test dbname=test'`))
-		Expect(sqls).To(ContainElement(`ALTER SUBSCRIPTION "test_sub" SET ("param1" = 'value1', "param2" = 'value2')`))
+		Expect(sqls).To(ContainElement(`ALTER SUBSCRIPTION "test_sub" SET ("failover" = 'true', "origin" = 'none')`))
 	})
 
 	It("returns correct SQL for altering subscription with no owner or parameters", func() {

--- a/internal/management/controller/subscription_controller_test.go
+++ b/internal/management/controller/subscription_controller_test.go
@@ -50,6 +50,8 @@ const subscriptionDetectionQuery = `SELECT count(*)
 		WHERE subname = $1`
 
 var _ = Describe("Managed subscription controller tests", func() {
+	const defaultPostgresMajorVersion = 17
+
 	var (
 		dbMock       sqlmock.Sqlmock
 		db           *sql.DB
@@ -122,6 +124,9 @@ var _ = Describe("Managed subscription controller tests", func() {
 			instance: pgInstance,
 			getDB: func(_ string) (*sql.DB, error) {
 				return db, nil
+			},
+			getPostgresMajorVersion: func() (int, error) {
+				return defaultPostgresMajorVersion, nil
 			},
 		}
 		r.finalizerReconciler = newFinalizerReconciler(


### PR DESCRIPTION
This pull request fixes a bug related to updating PostgreSQL subscription parameters in CloudNativePG. Previously, the operator attempted to update parameters such as `copy_data` via `ALTER SUBSCRIPTION`, which is not permitted by PostgreSQL and led to reconciliation failures. With this patch, the operator restricts updates to only those subscription parameters allowed by PostgreSQL, preventing invalid SQL statements.

Closes #7585 

### Release notes

```
Limits subscription parameter updates to those supported by PostgreSQL,
fixing reconciliation failures from invalid `ALTER SUBSCRIPTION` statements. (#7585)
```