### PR TITLE
feat(user,secret): add `fqdn-uri` and `fqdn-jdbc-uri` fields

### DIFF
--- a/.wordlist-en-custom.txt
+++ b/.wordlist-en-custom.txt
@@ -831,6 +831,7 @@ fio
 fips
 firstRecoverabilityPoint
 firstRecoverabilityPointByMethod
+fqdn
 freddie
 fuzzystrmatch
 gapped

--- a/docs/src/applications.md
+++ b/docs/src/applications.md
@@ -72,6 +72,13 @@ Each secret contain the following:
 * a working [`.pgpass file`](https://www.postgresql.org/docs/current/libpq-pgpass.html)
 * [uri](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING)
 * [jdbc-uri](https://jdbc.postgresql.org/documentation/use/#connecting-to-the-database)
+* [fqdn-uri](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING)
+* [fqdn-jdbc-uri](https://jdbc.postgresql.org/documentation/use/#connecting-to-the-database)
+
+The FQDN to be used in the URIs is calculated using the Kubernetes cluster
+domain specified in the `KUBERNETES_CLUSTER_DOMAIN` configuration parameter.
+See [the operator configuration documentation](operator_conf.md) for more information
+about that.
 
 The `-app` credentials are the ones that should be used by applications
 connecting to the PostgreSQL cluster, and correspond to the user *owning* the

--- a/pkg/specs/secrets.go
+++ b/pkg/specs/secrets.go
@@ -41,21 +41,24 @@ func CreateSecret(
 	password string,
 	usertype utils.UserType,
 ) *corev1.Secret {
+	hostWithNamespace := fmt.Sprintf("%s.%s:%d", hostname, namespace, postgres.ServerPort)
+	hostWithFQDN := fmt.Sprintf(
+		"%s.%s.svc.%s:%d",
+		hostname,
+		namespace,
+		configuration.Current.KubernetesClusterDomain,
+		postgres.ServerPort,
+	)
+
 	namespacedBuilder := &connectionStringBuilder{
-		host:     fmt.Sprintf("%s.%s:%d", hostname, namespace, postgres.ServerPort),
+		host:     hostWithNamespace,
 		dbname:   dbname,
 		username: username,
 		password: password,
 	}
 
 	fqdnBuilder := &connectionStringBuilder{
-		host: fmt.Sprintf(
-			"%s.%s.svc.%s:%d",
-			hostname,
-			namespace,
-			configuration.Current.KubernetesClusterDomain,
-			postgres.ServerPort,
-		),
+		host:     hostWithFQDN,
 		dbname:   dbname,
 		username: username,
 		password: password,

--- a/pkg/specs/secrets.go
+++ b/pkg/specs/secrets.go
@@ -26,6 +26,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/cloudnative-pg/cloudnative-pg/internal/configuration"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/postgres"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 )
@@ -40,7 +41,25 @@ func CreateSecret(
 	password string,
 	usertype utils.UserType,
 ) *corev1.Secret {
-	uriBuilder := newConnectionStringBuilder(hostname, dbname, username, password, namespace)
+	namespacedBuilder := &connectionStringBuilder{
+		host:     fmt.Sprintf("%s.%s:%d", hostname, namespace, postgres.ServerPort),
+		dbname:   dbname,
+		username: username,
+		password: password,
+	}
+
+	fqdnBuilder := &connectionStringBuilder{
+		host: fmt.Sprintf(
+			"%s.%s.svc.%s:%d",
+			hostname,
+			namespace,
+			configuration.Current.KubernetesClusterDomain,
+			postgres.ServerPort,
+		),
+		dbname:   dbname,
+		username: username,
+		password: password,
+	}
 
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -66,28 +85,19 @@ func CreateSecret(
 				dbname,
 				username,
 				password),
-			"uri":      uriBuilder.buildPostgres(),
-			"jdbc-uri": uriBuilder.buildJdbc(),
+			"uri":           namespacedBuilder.buildPostgres(),
+			"jdbc-uri":      namespacedBuilder.buildJdbc(),
+			"fqdn-uri":      fqdnBuilder.buildPostgres(),
+			"fqdn-jdbc-uri": fqdnBuilder.buildJdbc(),
 		},
 	}
 }
 
 type connectionStringBuilder struct {
-	host      string
-	dbname    string
-	username  string
-	password  string
-	namespace string
-}
-
-func newConnectionStringBuilder(hostname, dbname, username, password, namespace string) *connectionStringBuilder {
-	return &connectionStringBuilder{
-		host:      fmt.Sprintf("%s.%s:%d", hostname, namespace, postgres.ServerPort),
-		dbname:    dbname,
-		username:  username,
-		password:  password,
-		namespace: namespace,
-	}
+	host     string
+	dbname   string
+	username string
+	password string
 }
 
 func (c connectionStringBuilder) buildPostgres() string {

--- a/pkg/specs/secrets_test.go
+++ b/pkg/specs/secrets_test.go
@@ -44,6 +44,14 @@ var _ = Describe("Secret creation", func() {
 		Expect(secret.StringData["jdbc-uri"]).To(
 			Equal("jdbc:postgresql://thishost.namespace:5432/thisdb?password=thispassword&user=thisuser"),
 		)
+
+		Expect(secret.StringData["fqdn-uri"]).To(
+			Equal("postgresql://thisuser:thispassword@thishost.namespace.svc.cluster.local:5432/thisdb"),
+		)
+		Expect(secret.StringData["fqdn-jdbc-uri"]).To(
+			Equal("jdbc:postgresql://thishost.namespace.svc.cluster.local:5432/thisdb?password=thispassword&user=thisuser"),
+		)
+
 		Expect(secret.Labels).To(
 			HaveKeyWithValue(utils.UserTypeLabelName, string(utils.UserTypeApp)))
 	})


### PR DESCRIPTION
## Release Notes

The generated user secrets now contain two additional fields `fqdn-uri` and `fqdn-jdbc-uri`. These fields use fully qualified domain names following the Kubernetes standard format: <hostname>.<namespace>.svc.<cluster-domain>.

Closes #7807 
