### PR TITLE
fix(initdb): restore initialization order in initdb job

### DIFF
--- a/pkg/management/postgres/initdb.go
+++ b/pkg/management/postgres/initdb.go
@@ -53,6 +53,15 @@ import (
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/system"
 )
 
+type connectionProvider interface {
+	// GetSuperUserDB returns the superuser database connection
+	GetSuperUserDB() (*sql.DB, error)
+	// GetTemplateDB returns the template database connection
+	GetTemplateDB() (*sql.DB, error)
+	// ConnectionPool returns the connection pool for this instance
+	ConnectionPool() pool.Pooler
+}
+
 // InitInfo contains all the info needed to bootstrap a new PostgreSQL instance
 type InitInfo struct {
 	// The data directory where to generate the new cluster
@@ -295,7 +304,7 @@ func (info InitInfo) GetInstance() *Instance {
 
 // ConfigureNewInstance creates the expected users and databases in a new
 // PostgreSQL instance. If any error occurs, we return it
-func (info InitInfo) ConfigureNewInstance(instance *Instance) error {
+func (info InitInfo) ConfigureNewInstance(instance connectionProvider) error {
 	log.Info("Configuring new PostgreSQL instance")
 
 	dbSuperUser, err := instance.GetSuperUserDB()

--- a/pkg/management/postgres/instance.go
+++ b/pkg/management/postgres/instance.go
@@ -786,7 +786,7 @@ func (instance *Instance) GetPgVersion() (semver.Version, error) {
 }
 
 // ConnectionPool gets or initializes the connection pool for this instance
-func (instance *Instance) ConnectionPool() *pool.ConnectionPool {
+func (instance *Instance) ConnectionPool() pool.Pooler {
 	const applicationName = "cnpg-instance-manager"
 	if instance.pool == nil {
 		socketDir := GetSocketDir()

--- a/pkg/management/postgres/suite_test.go
+++ b/pkg/management/postgres/suite_test.go
@@ -20,7 +20,10 @@ SPDX-License-Identifier: Apache-2.0
 package postgres
 
 import (
+	"database/sql"
 	"testing"
+
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres/pool"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -29,4 +32,38 @@ import (
 func TestPostgres(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "PostgreSQL instance manager test suite")
+}
+
+// mockInstance implements the minimum required functionality to test ConfigureNewInstance
+type mockInstance struct {
+	superUserDB *sql.DB
+	templateDB  *sql.DB
+	appDB       *sql.DB
+}
+
+type fakePooler struct {
+	db *sql.DB
+}
+
+func (f fakePooler) Connection(_ string) (*sql.DB, error) {
+	return f.db, nil
+}
+
+func (f fakePooler) GetDsn(dbName string) string {
+	return dbName
+}
+
+func (f fakePooler) ShutdownConnections() {
+}
+
+func (m *mockInstance) GetSuperUserDB() (*sql.DB, error) {
+	return m.superUserDB, nil
+}
+
+func (m *mockInstance) GetTemplateDB() (*sql.DB, error) {
+	return m.templateDB, nil
+}
+
+func (m *mockInstance) ConnectionPool() pool.Pooler {
+	return &fakePooler{db: m.appDB}
 }


### PR DESCRIPTION
Restore the initialization order as it was before merging #7811

Closes #7870 