### PR TITLE
fix(pvc): support `VolumeAttributesClass` reconciliation

### DIFF
--- a/docs/src/storage.md
+++ b/docs/src/storage.md
@@ -144,8 +144,8 @@ spec:
 
 ## Configuration via a PVC template
 
-To further customize the generated PVCs, you can provide a PVC template inside
-the custom resource, as shown below:
+To further customize the generated PVCs, you can provide a PVC template inside the custom resource,
+like in the following example:
 
 ```yaml
 apiVersion: postgresql.cnpg.io/v1
@@ -165,14 +165,6 @@ spec:
       storageClassName: standard
       volumeMode: Filesystem
 ```
-
-!!! Info
-    Depending on your Kubernetes cluster configuration, you can also specify a
-    `VolumeAttributesClass` in the `pvcTemplate`.
-    [Volume Attributes Classes](https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/),
-    promoted to beta in Kubernetes 1.31 (disabled by default), allow administrators
-    (typically cloud providers) to define mutable "classes" of storage that map to
-    different quality-of-service levels.
 
 ## Volume for WAL
 

--- a/docs/src/storage.md
+++ b/docs/src/storage.md
@@ -144,8 +144,8 @@ spec:
 
 ## Configuration via a PVC template
 
-To further customize the generated PVCs, you can provide a PVC template inside the custom resource,
-like in the following example:
+To further customize the generated PVCs, you can provide a PVC template inside
+the custom resource, as shown below:
 
 ```yaml
 apiVersion: postgresql.cnpg.io/v1
@@ -165,6 +165,14 @@ spec:
       storageClassName: standard
       volumeMode: Filesystem
 ```
+
+!!! Info
+    Depending on your Kubernetes cluster configuration, you can also specify a
+    `VolumeAttributesClass` in the `pvcTemplate`.
+    [Volume Attributes Classes](https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/),
+    promoted to beta in Kubernetes 1.31 (disabled by default), allow administrators
+    (typically cloud providers) to define mutable "classes" of storage that map to
+    different quality-of-service levels.
 
 ## Volume for WAL
 

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -735,7 +735,7 @@ func (r *ClusterReconciler) reconcileResources(
 		cluster,
 		resources.instances.Items,
 		resources.pvcs.Items,
-	); !res.IsZero() || err != nil {
+	); err != nil || !res.IsZero() {
 		return res, err
 	}
 

--- a/pkg/reconciler/persistentvolumeclaim/existing.go
+++ b/pkg/reconciler/persistentvolumeclaim/existing.go
@@ -39,7 +39,7 @@ type reconciliationUnit func(
 	pvc *corev1.PersistentVolumeClaim,
 ) error
 
-// reconcileExistingPVCs align the resource requests
+// reconcileExistingPVCs align the existing pvcs to the desired state
 func reconcileExistingPVCs(
 	ctx context.Context,
 	c client.Client,

--- a/pkg/reconciler/persistentvolumeclaim/existing.go
+++ b/pkg/reconciler/persistentvolumeclaim/existing.go
@@ -21,6 +21,7 @@ package persistentvolumeclaim
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cloudnative-pg/machinery/pkg/log"
 	corev1 "k8s.io/api/core/v1"
@@ -31,21 +32,90 @@ import (
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 )
 
-// reconcileResourceRequests align the resource requests
-func reconcileResourceRequests(
+type reconciliationUnit func(
+	ctx context.Context,
+	c client.Client,
+	storageConfiguration *apiv1.StorageConfiguration,
+	pvc *corev1.PersistentVolumeClaim,
+) error
+
+// reconcileExistingPVCs align the resource requests
+func reconcileExistingPVCs(
 	ctx context.Context,
 	c client.Client,
 	cluster *apiv1.Cluster,
 	pvcs []corev1.PersistentVolumeClaim,
 ) error {
-	if !cluster.ShouldResizeInUseVolumes() {
+	if len(pvcs) == 0 {
+		return nil
+	}
+
+	contextLogger := log.FromContext(ctx)
+
+	var reconciliationUnits []reconciliationUnit
+
+	if cluster.ShouldResizeInUseVolumes() {
+		reconciliationUnits = append(reconciliationUnits, reconcilePVCQuantity)
+	}
+	if cluster.Spec.StorageConfiguration.PersistentVolumeClaimTemplate != nil {
+		reconciliationUnits = append(reconciliationUnits, reconcileVolumeAttributeClass)
+	}
+
+	if len(reconciliationUnits) == 0 {
 		return nil
 	}
 
 	for idx := range pvcs {
-		if err := reconcilePVCQuantity(ctx, c, cluster, &pvcs[idx]); err != nil {
+		pvc := &pvcs[idx]
+
+		pvcRole, err := GetExpectedObjectCalculator(pvc.GetLabels())
+		if err != nil {
+			contextLogger.Error(err,
+				"encountered an error while trying to get pvc role from label",
+				"role", pvc.Labels[utils.PvcRoleLabelName],
+			)
 			return err
 		}
+
+		storageConfiguration, err := pvcRole.GetStorageConfiguration(cluster)
+		if err != nil {
+			contextLogger.Error(err,
+				"encountered an error while trying to obtain the storage configuration",
+				"role", pvc.Labels[utils.PvcRoleLabelName],
+				"pvcName", pvc.Name,
+			)
+			return err
+		}
+
+		for _, reconciler := range reconciliationUnits {
+			if err := reconciler(ctx, c, &storageConfiguration, pvc); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func reconcileVolumeAttributeClass(
+	ctx context.Context,
+	c client.Client,
+	storageConfiguration *apiv1.StorageConfiguration,
+	pvc *corev1.PersistentVolumeClaim,
+) error {
+	if storageConfiguration.PersistentVolumeClaimTemplate == nil {
+		return nil
+	}
+
+	expectedVolumeAttributesClassName := storageConfiguration.PersistentVolumeClaimTemplate.VolumeAttributesClassName
+	if expectedVolumeAttributesClassName == pvc.Spec.VolumeAttributesClassName {
+		return nil
+	}
+
+	oldPVC := pvc.DeepCopy()
+	pvc.Spec.VolumeAttributesClassName = expectedVolumeAttributesClassName
+	if err := c.Patch(ctx, pvc, client.MergeFrom(oldPVC)); err != nil {
+		return fmt.Errorf("error while changing PVC volume attributes class name: %w", err)
 	}
 
 	return nil
@@ -54,28 +124,10 @@ func reconcileResourceRequests(
 func reconcilePVCQuantity(
 	ctx context.Context,
 	c client.Client,
-	cluster *apiv1.Cluster,
+	storageConfiguration *apiv1.StorageConfiguration,
 	pvc *corev1.PersistentVolumeClaim,
 ) error {
 	contextLogger := log.FromContext(ctx)
-	pvcRole, err := GetExpectedObjectCalculator(pvc.GetLabels())
-	if err != nil {
-		contextLogger.Error(err,
-			"encountered an error while trying to get pvc role from label",
-			"role", pvc.Labels[utils.PvcRoleLabelName],
-		)
-		return err
-	}
-
-	storageConfiguration, err := pvcRole.GetStorageConfiguration(cluster)
-	if err != nil {
-		contextLogger.Error(err,
-			"encountered an error while trying to obtain the storage configuration",
-			"role", pvc.Labels[utils.PvcRoleLabelName],
-			"pvcName", pvc.Name,
-		)
-		return err
-	}
 
 	parsedSize := storageConfiguration.GetSizeOrNil()
 	if parsedSize == nil {
@@ -105,7 +157,7 @@ func reconcilePVCQuantity(
 			"pvc", pvc,
 			"requests", pvc.Spec.Resources.Requests,
 			"oldRequests", oldPVC.Spec.Resources.Requests)
-		return err
+		return fmt.Errorf("error while changing PVC storage requirement: %w", err)
 	}
 
 	return nil

--- a/pkg/reconciler/persistentvolumeclaim/reconciler.go
+++ b/pkg/reconciler/persistentvolumeclaim/reconciler.go
@@ -45,7 +45,7 @@ func Reconcile(
 		return res, err
 	}
 
-	if err := reconcileResourceRequests(ctx, c, cluster, pvcs); err != nil {
+	if err := reconcileExistingPVCs(ctx, c, cluster, pvcs); err != nil {
 		if apierrs.IsConflict(err) {
 			contextLogger.Debug("Conflict error while reconciling PVCs", "error", err)
 			return ctrl.Result{Requeue: true}, nil


### PR DESCRIPTION
Add missing support for reconciling `VolumeAttributesClass` in `pvcTemplate`, leveraging the feature promoted to beta in Kubernetes 1.31 (disabled by default).

A `VolumeAttributesClass` allows administrators (typically cloud providers) to define mutable "classes" of storage, mapping to different quality-of-service levels, while Kubernetes remains unopinionated about their semantics.
See: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/

This patch also refactors the PVC reconciliation logic to simplify handling additional parameters.

Closes #7800 

## Release notes

The operator now ensures that the `VolumeAttributesClassName` in PVCs matches the configuration defined in the `pvcTemplate`.
