### PR TITLE
fix(postgres,instance): set postgres workers `oom_score_adj`

### DIFF
--- a/docs/src/resource_management.md
+++ b/docs/src/resource_management.md
@@ -44,19 +44,21 @@ For a PostgreSQL workload it is recommended to set a "Guaranteed" QoS.
     When the quality of service is set to "Guaranteed", CloudNativePG sets the
     `PG_OOM_ADJUST_VALUE` for the `postmaster` process to `0`, in line with the
     [PostgreSQL documentation](https://www.postgresql.org/docs/current/kernel-resources.html#LINUX-MEMORY-OVERCOMMIT).
-    This allows the `postmaster` to retain its low OOM score (`-997`), while its
-    child processes run with an OOM score adjustment of `0`. As a result, if the
-    OOM killer is triggered, it will terminate the child processes before the
-    `postmaster`. This behaviour helps keep the PostgreSQL instance alive and
-    enables a clean shutdown procedure in the event of an eviction.
+    This allows the `postmaster` to retain its low Out-Of-Memory (OOM) score of
+    `-997`, while its child processes run with an OOM score adjustment of `0`. As a
+    result, if the OOM killer is triggered, it will terminate the child processes
+    before the `postmaster`. This behaviour helps keep the PostgreSQL instance
+    alive for as long as possible and enables a clean shutdown procedure in the
+    event of an eviction.
 
 To avoid resources related issues in Kubernetes, we can refer to the best practices for "out of resource" handling
 while creating a cluster:
 
 -  Specify your required values for memory and CPU in the resources section of the manifest file.
-   This way, you can avoid the `OOM Killed` (where "OOM" stands for Out Of Memory) and `CPU throttle` or any other
+   This way, you can avoid the `OOM Killed` and `CPU throttle` or any other
    resource-related issues on running instances.
--  For your cluster's pods to get assigned to the "Guaranteed" QoS class, you must set limits and requests
+-  For your cluster's pods to get assigned to the "Guaranteed" QoS class, you
+   must set limits and requests
    for both memory and CPU to the same value.
 -  Specify your required PostgreSQL memory parameters consistently with the pod resources (as you would do
    in a VM or physical machine scenario - see below).

--- a/docs/src/resource_management.md
+++ b/docs/src/resource_management.md
@@ -40,6 +40,16 @@ section in the Kubernetes documentation.
 
 For a PostgreSQL workload it is recommended to set a "Guaranteed" QoS.
 
+!!! Info
+    When the quality of service is set to "Guaranteed", CloudNativePG sets the
+    `PG_OOM_ADJUST_VALUE` for the `postmaster` process to `0`, in line with the
+    [PostgreSQL documentation](https://www.postgresql.org/docs/current/kernel-resources.html#LINUX-MEMORY-OVERCOMMIT).
+    This allows the `postmaster` to retain its low OOM score (`-997`), while its
+    child processes run with an OOM score adjustment of `0`. As a result, if the
+    OOM killer is triggered, it will terminate the child processes before the
+    `postmaster`. This behaviour helps keep the PostgreSQL instance alive and
+    enables a clean shutdown procedure in the event of an eviction.
+
 To avoid resources related issues in Kubernetes, we can refer to the best practices for "out of resource" handling
 while creating a cluster:
 

--- a/docs/src/resource_management.md
+++ b/docs/src/resource_management.md
@@ -47,7 +47,7 @@ For a PostgreSQL workload it is recommended to set a "Guaranteed" QoS.
     This allows the `postmaster` to retain its low Out-Of-Memory (OOM) score of
     `-997`, while its child processes run with an OOM score adjustment of `0`. As a
     result, if the OOM killer is triggered, it will terminate the child processes
-    before the `postmaster`. This behaviour helps keep the PostgreSQL instance
+    before the `postmaster`. This behavior helps keep the PostgreSQL instance
     alive for as long as possible and enables a clean shutdown procedure in the
     event of an eviction.
 

--- a/pkg/management/postgres/instance.go
+++ b/pkg/management/postgres/instance.go
@@ -487,7 +487,7 @@ func (instance *Instance) Startup() error {
 	}
 
 	pgCtlCmd := exec.Command(pgCtlName, options...) // #nosec
-	pgCtlCmd.Env = instance.Env
+	pgCtlCmd.Env = instance.buildPostgresEnv()
 	err := execlog.RunStreaming(pgCtlCmd, pgCtlName)
 	if err != nil {
 		return fmt.Errorf("error starting PostgreSQL instance: %w", err)
@@ -712,12 +712,7 @@ func (instance *Instance) Run() (*execlog.StreamingCmd, error) {
 	}
 
 	postgresCmd := exec.Command(GetPostgresExecutableName(), options...) // #nosec
-	postgresCmd.Env = os.Environ()
-	postgresCmd.Env = append(postgresCmd.Env,
-		"PG_OOM_ADJUST_FILE=/proc/self/oom_score_adj",
-		"PG_OOM_ADJUST_VALUE=0",
-	)
-	postgresCmd.Env = append(postgresCmd.Env, instance.Env...)
+	postgresCmd.Env = instance.buildPostgresEnv()
 	compatibility.AddInstanceRunCommands(postgresCmd)
 
 	streamingCmd, err := execlog.RunStreamingNoWait(postgresCmd, GetPostgresExecutableName())
@@ -726,6 +721,18 @@ func (instance *Instance) Run() (*execlog.StreamingCmd, error) {
 	}
 
 	return streamingCmd, nil
+}
+
+func (instance *Instance) buildPostgresEnv() []string {
+	env := instance.Env
+	if env == nil {
+		env = os.Environ()
+	}
+	env = append(env,
+		"PG_OOM_ADJUST_FILE=/proc/self/oom_score_adj",
+		"PG_OOM_ADJUST_VALUE=0",
+	)
+	return env
 }
 
 // WithActiveInstance execute the internal function while this
@@ -1076,7 +1083,7 @@ func (instance *Instance) Rewind(ctx context.Context) error {
 		"options", options)
 
 	pgRewindCmd := exec.Command(pgRewindName, options...) // #nosec
-	pgRewindCmd.Env = instance.Env
+	pgRewindCmd.Env = instance.buildPostgresEnv()
 	err = execlog.RunStreaming(pgRewindCmd, pgRewindName)
 	if err != nil {
 		contextLogger.Error(err, "Failed to execute pg_rewind", "options", options)

--- a/pkg/management/postgres/instance.go
+++ b/pkg/management/postgres/instance.go
@@ -712,7 +712,12 @@ func (instance *Instance) Run() (*execlog.StreamingCmd, error) {
 	}
 
 	postgresCmd := exec.Command(GetPostgresExecutableName(), options...) // #nosec
-	postgresCmd.Env = instance.Env
+	postgresCmd.Env = os.Environ()
+	postgresCmd.Env = append(postgresCmd.Env,
+		"PG_OOM_ADJUST_FILE=/proc/self/oom_score_adj",
+		"PG_OOM_ADJUST_VALUE=0",
+	)
+	postgresCmd.Env = append(postgresCmd.Env, instance.Env...)
 	compatibility.AddInstanceRunCommands(postgresCmd)
 
 	streamingCmd, err := execlog.RunStreamingNoWait(postgresCmd, GetPostgresExecutableName())


### PR DESCRIPTION
When the quality of service is set to "Guaranteed", CloudNativePG sets the `PG_OOM_ADJUST_VALUE` for the `postmaster` process to `0`.

This allows the `postmaster` to retain its low Out-Of-Memory (OOM) score of `-997`, while its child processes run with an OOM score adjustment of `0`. As a result, if the OOM killer is triggered, it will terminate the child processes before the `postmaster`.

This behaviour helps keep the PostgreSQL instance alive for as long as possible and enables a clean shutdown procedure in the event of an eviction.

Closes #7132 
