### PR TITLE
fix(cluster,backup): set the appropriate statuses on `Backup` failure

### DIFF
--- a/internal/controller/backup_controller.go
+++ b/internal/controller/backup_controller.go
@@ -26,6 +26,7 @@ import (
 	"reflect"
 	"time"
 
+	"github.com/cloudnative-pg/machinery/pkg/log"
 	storagesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
@@ -54,7 +55,6 @@ import (
 	resourcestatus "github.com/cloudnative-pg/cloudnative-pg/pkg/resources/status"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/specs"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
-	"github.com/cloudnative-pg/machinery/pkg/log"
 )
 
 // backupPhase indicates the path inside the Backup kind

--- a/pkg/resources/status/backup.go
+++ b/pkg/resources/status/backup.go
@@ -116,7 +116,7 @@ func FlagBackupAsFailed(
 			cluster.Status.LastFailedBackup = pgTime.GetCurrentTimestampWithFormat(time.RFC3339)
 		},
 	); err != nil {
-		contextLogger.Error(err, "while patching cluster with failed backup condition")
+		contextLogger.Error(err, "while patching cluster status with last failed backup")
 		flagErr.clusterStatusErr = err
 	}
 
@@ -126,7 +126,7 @@ func FlagBackupAsFailed(
 		cluster,
 		apiv1.BuildClusterBackupFailedCondition(err),
 	); err != nil {
-		contextLogger.Error(err, "Error while updating backup condition (backup failed)")
+		contextLogger.Error(err, "while patching backup condition in the cluster status (backup failed)")
 		flagErr.clusterConditionErr = err
 	}
 

--- a/pkg/resources/status/backup.go
+++ b/pkg/resources/status/backup.go
@@ -64,6 +64,7 @@ func (f flagBackupErrors) toError() error {
 	return nil
 }
 
+// FlagBackupAsFailed updates the status of a Backup object to indicate that it has failed.
 func FlagBackupAsFailed(
 	ctx context.Context,
 	cli client.Client,

--- a/pkg/resources/status/backup.go
+++ b/pkg/resources/status/backup.go
@@ -1,0 +1,122 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package status
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	"github.com/cloudnative-pg/machinery/pkg/log"
+	pgTime "github.com/cloudnative-pg/machinery/pkg/postgres/time"
+)
+
+type BackupTransaction func(*apiv1.Backup)
+
+type flagBackupErrors struct {
+	clusterStatusErr    error
+	backupErr           error
+	clusterConditionErr error
+}
+
+func (f flagBackupErrors) Error() string {
+	var message string
+	if f.clusterStatusErr != nil {
+		message += fmt.Sprintf("error patching cluster status: %v; ", f.clusterStatusErr)
+	}
+	if f.backupErr != nil {
+		message += fmt.Sprintf("error patching backup status: %v; ", f.backupErr)
+	}
+	if f.clusterConditionErr != nil {
+		message += fmt.Sprintf("error patching cluster conditions: %v; ", f.clusterConditionErr)
+	}
+
+	return message
+}
+
+// toError returns the errors encountered or nil
+func (f flagBackupErrors) toError() error {
+	if f.clusterStatusErr != nil || f.backupErr != nil || f.clusterConditionErr != nil {
+		return f
+	}
+	return nil
+}
+
+func FlagBackupAsFailed(
+	ctx context.Context,
+	cli client.Client,
+	backup *apiv1.Backup,
+	cluster *apiv1.Cluster,
+	err error,
+	transactions ...BackupTransaction,
+) error {
+	contextLogger := log.FromContext(ctx)
+
+	var flagErr flagBackupErrors
+
+	if err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		var livingBackup *apiv1.Backup
+		if err := cli.Get(ctx, client.ObjectKeyFromObject(backup), livingBackup); err != nil {
+			return err
+		}
+		origBackup := livingBackup.DeepCopy()
+		backup.Status.SetAsFailed(err)
+		backup.Status.Method = backup.Spec.Method
+		for _, transaction := range transactions {
+			transaction(backup)
+		}
+		return cli.Status().Patch(ctx, backup, client.MergeFrom(origBackup))
+	}); err != nil {
+		contextLogger.Error(err, "while flagging backup as failed")
+		flagErr.backupErr = err
+	}
+
+	if cluster == nil {
+		return flagErr.toError()
+	}
+
+	if err := PatchWithOptimisticLock(
+		ctx,
+		cli,
+		cluster,
+		func(cluster *apiv1.Cluster) {
+			cluster.Status.LastFailedBackup = pgTime.GetCurrentTimestampWithFormat(time.RFC3339)
+		},
+	); err != nil {
+		contextLogger.Error(err, "while patching cluster with failed backup condition")
+		flagErr.clusterStatusErr = err
+	}
+
+	if err := PatchConditionsWithOptimisticLock(
+		ctx,
+		cli,
+		cluster,
+		apiv1.BuildClusterBackupFailedCondition(err),
+	); err != nil {
+		contextLogger.Error(err, "Error while updating backup condition (backup failed)")
+		flagErr.clusterConditionErr = err
+	}
+
+	return flagErr.toError()
+}

--- a/pkg/resources/status/backup_test.go
+++ b/pkg/resources/status/backup_test.go
@@ -1,0 +1,82 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package status
+
+import (
+	"errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	schemeBuilder "github.com/cloudnative-pg/cloudnative-pg/internal/scheme"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("FlagBackupAsFailed", func() {
+	scheme := schemeBuilder.BuildWithAllKnownScheme()
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).
+		WithStatusSubresource(&apiv1.Cluster{}, &apiv1.Backup{}).
+		Build()
+
+	It("selects the new target primary right away", func(ctx SpecContext) {
+		cluster := &apiv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "cluster-example",
+				Namespace: "default",
+			},
+		}
+
+		backup := &apiv1.Backup{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      cluster.Name,
+				Namespace: cluster.Namespace,
+			},
+			Spec: apiv1.BackupSpec{
+				Cluster: apiv1.LocalObjectReference{
+					Name: cluster.Name,
+				},
+			},
+			Status: apiv1.BackupStatus{
+				Phase: apiv1.BackupPhaseRunning,
+			},
+		}
+		Expect(k8sClient.Create(ctx, cluster)).To(Succeed())
+		Expect(k8sClient.Create(ctx, backup)).To(Succeed())
+
+		err := FlagBackupAsFailed(ctx, k8sClient, backup, cluster, errors.New("my dummy error"))
+		Expect(err).NotTo(HaveOccurred())
+
+		// Backup status assertions
+		Expect(backup.Status.Phase).To(BeEquivalentTo(apiv1.BackupPhaseFailed))
+		Expect(backup.Status.Error).To(BeEquivalentTo("my dummy error"))
+
+		// Cluster status assertions
+		Expect(cluster.Status.LastFailedBackup).ToNot(BeEmpty())
+		for _, condition := range cluster.Status.Conditions {
+			if condition.Type == string(apiv1.ConditionBackup) {
+				Expect(condition.Status).To(BeEquivalentTo(metav1.ConditionFalse))
+				Expect(condition.Reason).To(BeEquivalentTo(string(apiv1.ConditionReasonLastBackupFailed)))
+				Expect(condition.Message).To(BeEquivalentTo("my dummy error"))
+			}
+		}
+	})
+})

--- a/pkg/resources/status/backup_test.go
+++ b/pkg/resources/status/backup_test.go
@@ -21,6 +21,7 @@ package status
 
 import (
 	"errors"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -62,12 +63,12 @@ var _ = Describe("FlagBackupAsFailed", func() {
 		Expect(k8sClient.Create(ctx, cluster)).To(Succeed())
 		Expect(k8sClient.Create(ctx, backup)).To(Succeed())
 
-		err := FlagBackupAsFailed(ctx, k8sClient, backup, cluster, errors.New("my dummy error"))
+		err := FlagBackupAsFailed(ctx, k8sClient, backup, cluster, errors.New("my sample error"))
 		Expect(err).NotTo(HaveOccurred())
 
 		// Backup status assertions
 		Expect(backup.Status.Phase).To(BeEquivalentTo(apiv1.BackupPhaseFailed))
-		Expect(backup.Status.Error).To(BeEquivalentTo("my dummy error"))
+		Expect(backup.Status.Error).To(BeEquivalentTo("my sample error"))
 
 		// Cluster status assertions
 		Expect(cluster.Status.LastFailedBackup).ToNot(BeEmpty())
@@ -75,7 +76,7 @@ var _ = Describe("FlagBackupAsFailed", func() {
 			if condition.Type == string(apiv1.ConditionBackup) {
 				Expect(condition.Status).To(BeEquivalentTo(metav1.ConditionFalse))
 				Expect(condition.Reason).To(BeEquivalentTo(string(apiv1.ConditionReasonLastBackupFailed)))
-				Expect(condition.Message).To(BeEquivalentTo("my dummy error"))
+				Expect(condition.Message).To(BeEquivalentTo("my sample error"))
 			}
 		}
 	})

--- a/pkg/resources/status/suite_test.go
+++ b/pkg/resources/status/suite_test.go
@@ -1,0 +1,32 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package status
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestConfiguration(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Internal Configuration Test Suite")
+}


### PR DESCRIPTION
This patch ensures that:

- The backup has the correct status.method when failing
- The cluster has the relevant fail backup condition
- The cluster has the lastFailedBackup field properly set

Closes #7892 
