### PR TITLE
[DOCS] Clarification: Placement of method Property in ScheduledBackup Spec

### DIFF
--- a/docs/src/backup.md
+++ b/docs/src/backup.md
@@ -221,9 +221,9 @@ metadata:
 spec:
   schedule: "0 0 0 * * *"  # At midnight every day
   backupOwnerReference: self
+  # method: plugin, volumeSnapshot, or barmanObjectStore (default)
   cluster:
     name: pg-backup
-  # method: plugin, volumeSnapshot, or barmanObjectStore (default)
 ```
 
 The schedule `"0 0 0 * * *"` triggers a backup every day at midnight


### PR DESCRIPTION
This pull request makes a small adjustment in the documentation regarding the placement of the method property within the ScheduledBackup resource specification to improve clarity.

Previous usage (potentially confusing):

```yaml
spec:
  schedule: "0 0 0 * * *"
  backupOwnerReference: self
  cluster:
    name: pg-backup
    method: barmanObjectStore
```

Updated usage (clearer and aligned with documentation):

```yaml
spec:
  schedule: "0 0 0 * * *"
  backupOwnerReference: self
  method: barmanObjectStore
  cluster:
    name: pg-backup
```
