### PR TITLE
fix(probes): avoid liveness probe to timeout when not needed

### DIFF
--- a/pkg/management/postgres/webserver/probes/liveness.go
+++ b/pkg/management/postgres/webserver/probes/liveness.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/cloudnative-pg/machinery/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -52,9 +53,12 @@ func NewLivenessChecker(
 // tryRefreshLatestCluster refreshes the latest cluster definition, returns a bool indicating if the operation was
 // successful
 func (e *livenessExecutor) tryRefreshLatestCluster(ctx context.Context) bool {
+	timeoutContext, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
+	defer cancel()
+
 	var cluster apiv1.Cluster
 	err := e.cli.Get(
-		ctx,
+		timeoutContext,
 		client.ObjectKey{Namespace: e.instance.GetNamespaceName(), Name: e.instance.GetClusterName()},
 		&cluster,
 	)

--- a/pkg/management/postgres/webserver/probes/liveness.go
+++ b/pkg/management/postgres/webserver/probes/liveness.go
@@ -91,6 +91,9 @@ func (e *livenessExecutor) IsHealthy(
 		return
 	}
 
+	// We set a safe context timeout of 500ms to avoid a failed request from taking
+	// more time than the minimum configurable timeout (1s) of the container's livenessProbe,
+	// which otherwise could have triggered a restart of the instance.
 	if clusterRefreshed := e.tryRefreshLatestClusterWithTimeout(ctx, 500*time.Millisecond); clusterRefreshed {
 		// We correctly reached the API server but, as a failsafe measure, we
 		// exercise the reachability checker and leave a log message if something

--- a/pkg/management/postgres/webserver/probes/liveness.go
+++ b/pkg/management/postgres/webserver/probes/liveness.go
@@ -50,10 +50,10 @@ func NewLivenessChecker(
 	}
 }
 
-// tryRefreshLatestCluster refreshes the latest cluster definition, returns a bool indicating if the operation was
-// successful
-func (e *livenessExecutor) tryRefreshLatestCluster(ctx context.Context) bool {
-	timeoutContext, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
+// tryRefreshLatestClusterWithTimeout refreshes the latest cluster definition, returns a bool indicating if the
+// operation was successful
+func (e *livenessExecutor) tryRefreshLatestClusterWithTimeout(ctx context.Context, timeout time.Duration) bool {
+	timeoutContext, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
 	var cluster apiv1.Cluster
@@ -91,7 +91,7 @@ func (e *livenessExecutor) IsHealthy(
 		return
 	}
 
-	if clusterRefreshed := e.tryRefreshLatestCluster(ctx); clusterRefreshed {
+	if clusterRefreshed := e.tryRefreshLatestClusterWithTimeout(ctx, 500*time.Millisecond); clusterRefreshed {
 		// We correctly reached the API server but, as a failsafe measure, we
 		// exercise the reachability checker and leave a log message if something
 		// is not right.

--- a/tests/e2e/fixtures/self-fencing/cluster-liveness-pinger-disabled.yaml.template
+++ b/tests/e2e/fixtures/self-fencing/cluster-liveness-pinger-disabled.yaml.template
@@ -1,0 +1,27 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: postgresql-liveness-pinger-disabled
+  annotations:
+    alpha.cnpg.io/livenessPinger: '{"enabled": false}'
+spec:
+  instances: 3
+
+  postgresql:
+    parameters:
+      max_connections: "110"
+      log_checkpoints: "on"
+      log_lock_waits: "on"
+      log_min_duration_statement: '1000'
+      log_statement: 'ddl'
+      log_temp_files: '1024'
+      log_autovacuum_min_duration: '1s'
+      log_replication_commands: 'on'
+
+  # Persistent storage configuration
+  storage:
+    storageClass: ${E2E_DEFAULT_STORAGE_CLASS}
+    size: 1Gi
+  walStorage:
+    storageClass: ${E2E_DEFAULT_STORAGE_CLASS}
+    size: 1Gi

--- a/tests/e2e/fixtures/self-fencing/cluster-liveness-pinger-enabled.yaml.template
+++ b/tests/e2e/fixtures/self-fencing/cluster-liveness-pinger-enabled.yaml.template
@@ -1,7 +1,7 @@
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
-  name: postgresql-self-fencing
+  name: postgresql-liveness-pinger-enabled
   annotations:
     alpha.cnpg.io/livenessPinger: '{"enabled": true}'
 spec:


### PR DESCRIPTION
When the API server is not reachable, the default liveness probe configuration may trigger an automatic shutdown of the PG instance, even when the isolation checker is not active.

This happens bacause a call to the API server may time out after the time out of the Kubelet.

This fix includes a safe limit, choosen after the default timeout of Pods' probes and is safe to use with the default CNPG configuration.

Closes: #7901 