### PR TITLE
feat(backup): make `Backup.Spec` immutable after creation

### DIFF
--- a/api/v1/backup_types.go
+++ b/api/v1/backup_types.go
@@ -138,6 +138,7 @@ type BackupSpec struct {
 	// +optional
 	// +kubebuilder:validation:Enum=barmanObjectStore;volumeSnapshot;plugin
 	// +kubebuilder:default:=barmanObjectStore
+	// +kubebuilder:validation:XValidation:rule="oldSelf == '' || self == oldSelf",message="method is immutable once set"
 	Method BackupMethod `json:"method,omitempty"`
 
 	// Configuration parameters passed to the plugin managing this backup

--- a/api/v1/backup_types.go
+++ b/api/v1/backup_types.go
@@ -119,6 +119,7 @@ const (
 )
 
 // BackupSpec defines the desired state of Backup
+// +kubebuilder:validation:XValidation:rule="oldSelf == self",message="BackupSpec is immutable once set"
 type BackupSpec struct {
 	// The cluster to backup
 	Cluster LocalObjectReference `json:"cluster"`
@@ -138,7 +139,6 @@ type BackupSpec struct {
 	// +optional
 	// +kubebuilder:validation:Enum=barmanObjectStore;volumeSnapshot;plugin
 	// +kubebuilder:default:=barmanObjectStore
-	// +kubebuilder:validation:XValidation:rule="oldSelf == '' || self == oldSelf",message="method is immutable once set"
 	Method BackupMethod `json:"method,omitempty"`
 
 	// Configuration parameters passed to the plugin managing this backup

--- a/config/crd/bases/postgresql.cnpg.io_backups.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_backups.yaml
@@ -77,9 +77,6 @@ spec:
                 - volumeSnapshot
                 - plugin
                 type: string
-                x-kubernetes-validations:
-                - message: method is immutable once set
-                  rule: oldSelf == '' || self == oldSelf
               online:
                 description: |-
                   Whether the default type of backup with volume snapshots is
@@ -145,6 +142,9 @@ spec:
             required:
             - cluster
             type: object
+            x-kubernetes-validations:
+            - message: BackupSpec is immutable once set
+              rule: oldSelf == self
           status:
             description: |-
               Most recently observed status of the backup. This data may not be up to

--- a/config/crd/bases/postgresql.cnpg.io_backups.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_backups.yaml
@@ -77,6 +77,9 @@ spec:
                 - volumeSnapshot
                 - plugin
                 type: string
+                x-kubernetes-validations:
+                - message: method is immutable once set
+                  rule: oldSelf == '' || self == oldSelf
               online:
                 description: |-
                   Whether the default type of backup with volume snapshots is


### PR DESCRIPTION
Add XValidation rule to prevent modification of Backup.Spec fields
after initial creation, ensuring the backup spec remains
consistent throughout the lifecycle.

# Release Notes
`Backup.Spec` fields can no longer be modified after backup creation.