### PR TITLE
fix(pooler): apply `resources` to the `bootstrap-controller`

### DIFF
--- a/api/v1/pooler_funcs.go
+++ b/api/v1/pooler_funcs.go
@@ -19,6 +19,8 @@ SPDX-License-Identifier: Apache-2.0
 
 package v1
 
+import corev1 "k8s.io/api/core/v1"
+
 // IsPaused returns whether all database should be paused or not.
 func (in PgBouncerSpec) IsPaused() bool {
 	return in.Paused != nil && *in.Paused
@@ -57,4 +59,17 @@ func (in *Pooler) IsAutomatedIntegration() bool {
 		return false
 	}
 	return true
+}
+
+// GetResourcesRequirements returns the resource requirements for the Pooler
+func (in *Pooler) GetResourcesRequirements() corev1.ResourceRequirements {
+	if in.Spec.Template == nil {
+		return corev1.ResourceRequirements{}
+	}
+
+	if in.Spec.Template.Spec.Resources == nil {
+		return corev1.ResourceRequirements{}
+	}
+
+	return *in.Spec.Template.Spec.Resources
 }

--- a/pkg/podspec/builder.go
+++ b/pkg/podspec/builder.go
@@ -386,6 +386,28 @@ func (builder *Builder) WithInitContainerSecurityContext(
 	return builder
 }
 
+// WithInitContainerResources ensures that, if in the current status there is
+// an init container with the passed name and the resources are empty, the resources will be
+// set to the ones passed.
+// If `overwrite` is true the resources are overwritten even when they're not empty
+func (builder *Builder) WithInitContainerResources(
+	name string,
+	resources corev1.ResourceRequirements,
+	overwrite bool,
+) *Builder {
+	builder.WithInitContainer(name)
+
+	for idx, value := range builder.status.Spec.InitContainers {
+		if value.Name == name {
+			if overwrite || value.Resources.Limits == nil && value.Resources.Requests == nil {
+				builder.status.Spec.InitContainers[idx].Resources = resources
+			}
+		}
+	}
+
+	return builder
+}
+
 // Build gets the final Pod template
 func (builder *Builder) Build() *apiv1.PodTemplateSpec {
 	return &builder.status

--- a/pkg/specs/pgbouncer/deployments.go
+++ b/pkg/specs/pgbouncer/deployments.go
@@ -94,6 +94,7 @@ func Deployment(pooler *apiv1.Pooler, cluster *apiv1.Cluster) (*appsv1.Deploymen
 		WithInitContainerCommand(specs.BootstrapControllerContainerName,
 			[]string{"/manager", "bootstrap", "/controller/manager"},
 			true).
+		WithInitContainerResources(specs.BootstrapControllerContainerName, pooler.GetResourcesRequirements(), true).
 		WithInitContainerSecurityContext(specs.BootstrapControllerContainerName,
 			specs.CreateContainerSecurityContext(cluster.GetSeccompProfile()),
 			true).


### PR DESCRIPTION
The resources specified in the `Pooler` template now correctly apply to the init `bootstrap-controller` container.

Closes #7822 
