### PR TITLE
feat(replication): add `synchronizeLogicalDecoding` for HA logical slots

### DIFF
--- a/.wordlist-en-custom.txt
+++ b/.wordlist-en-custom.txt
@@ -1332,6 +1332,7 @@ switchReplicaClusterStatus
 switchoverDelay
 switchovers
 syncReplicaElectionConstraint
+synchronizeLogicalDecoding
 synchronizeReplicas
 synchronizeReplicasCache
 sys

--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -1212,14 +1212,12 @@ type ReplicationSlotsHAConfiguration struct {
 	SlotPrefix string `json:"slotPrefix,omitempty"`
 
 	// When enabled, the operator automatically manages synchronization of logical
-	// decoding (replication) slots across high-availability clusters. This
-	// feature primarily uses the sync_replication_slots server parameter
-	// (introduced in PostgreSQL 17) for native and robust slot synchronization.
-	// For clusters running older PostgreSQL versions, the pg_failover_slots
-	// extension is used as a fallback mechanism. This ensures that changes are
-	// not consumed from logical replication failover slots until they are received
-	// and flushed to all physical standby nodes, providing reliable logical
-	// replication continuity during failover events.
+	// decoding (replication) slots across high-availability clusters.
+	//
+	// Requires one of the following conditions:
+	// - PostgreSQL version 17 or later
+	// - PostgreSQL version < 17 with pg_failover_slots extension enabled
+	//
 	// +optional
 	SynchronizeLogicalDecoding bool `json:"synchronizeLogicalDecoding,omitempty"`
 }

--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -1210,6 +1210,18 @@ type ReplicationSlotsHAConfiguration struct {
 	// +kubebuilder:validation:Pattern=^[0-9a-z_]*$
 	// +optional
 	SlotPrefix string `json:"slotPrefix,omitempty"`
+
+	// When enabled, the operator automatically manages synchronization of logical
+	// decoding (replication) slots across high-availability clusters. This
+	// feature primarily uses the sync_replication_slots server parameter
+	// (introduced in PostgreSQL 17) for native and robust slot synchronization.
+	// For clusters running older PostgreSQL versions, the pg_failover_slots
+	// extension is used as a fallback mechanism. This ensures that changes are
+	// not consumed from logical replication failover slots until they are received
+	// and flushed to all physical standby nodes, providing reliable logical
+	// replication continuity during failover events.
+	// +optional
+	SynchronizeLogicalDecoding bool `json:"synchronizeLogicalDecoding,omitempty"`
 }
 
 // KubernetesUpgradeStrategy tells the operator if the user want to

--- a/config/crd/bases/postgresql.cnpg.io_clusters.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_clusters.yaml
@@ -4847,14 +4847,11 @@ spec:
                       synchronizeLogicalDecoding:
                         description: |-
                           When enabled, the operator automatically manages synchronization of logical
-                          decoding (replication) slots across high-availability clusters. This
-                          feature primarily uses the sync_replication_slots server parameter
-                          (introduced in PostgreSQL 17) for native and robust slot synchronization.
-                          For clusters running older PostgreSQL versions, the pg_failover_slots
-                          extension is used as a fallback mechanism. This ensures that changes are
-                          not consumed from logical replication failover slots until they are received
-                          and flushed to all physical standby nodes, providing reliable logical
-                          replication continuity during failover events.
+                          decoding (replication) slots across high-availability clusters.
+
+                          Requires one of the following conditions:
+                          - PostgreSQL version 17 or later
+                          - PostgreSQL version < 17 with pg_failover_slots extension enabled
                         type: boolean
                     type: object
                   synchronizeReplicas:

--- a/config/crd/bases/postgresql.cnpg.io_clusters.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_clusters.yaml
@@ -4844,6 +4844,18 @@ spec:
                           This can only be set at creation time. By default set to `_cnpg_`.
                         pattern: ^[0-9a-z_]*$
                         type: string
+                      synchronizeLogicalDecoding:
+                        description: |-
+                          When enabled, the operator automatically manages synchronization of logical
+                          decoding (replication) slots across high-availability clusters. This
+                          feature primarily uses the sync_replication_slots server parameter
+                          (introduced in PostgreSQL 17) for native and robust slot synchronization.
+                          For clusters running older PostgreSQL versions, the pg_failover_slots
+                          extension is used as a fallback mechanism. This ensures that changes are
+                          not consumed from logical replication failover slots until they are received
+                          and flushed to all physical standby nodes, providing reliable logical
+                          replication continuity during failover events.
+                        type: boolean
                     type: object
                   synchronizeReplicas:
                     description: Configures the synchronization of the user defined

--- a/docs/src/cloudnative-pg.v1.md
+++ b/docs/src/cloudnative-pg.v1.md
@@ -5108,6 +5108,21 @@ It may only contain lower case letters, numbers, and the underscore character.
 This can only be set at creation time. By default set to <code>_cnpg_</code>.</p>
 </td>
 </tr>
+<tr><td><code>synchronizeLogicalDecoding</code><br/>
+<i>bool</i>
+</td>
+<td>
+   <p>When enabled, the operator automatically manages synchronization of logical
+decoding (replication) slots across high-availability clusters. This
+feature primarily uses the sync_replication_slots server parameter
+(introduced in PostgreSQL 17) for native and robust slot synchronization.
+For clusters running older PostgreSQL versions, the pg_failover_slots
+extension is used as a fallback mechanism. This ensures that changes are
+not consumed from logical replication failover slots until they are received
+and flushed to all physical standby nodes, providing reliable logical
+replication continuity during failover events.</p>
+</td>
+</tr>
 </tbody>
 </table>
 

--- a/docs/src/cloudnative-pg.v1.md
+++ b/docs/src/cloudnative-pg.v1.md
@@ -5113,14 +5113,12 @@ This can only be set at creation time. By default set to <code>_cnpg_</code>.</p
 </td>
 <td>
    <p>When enabled, the operator automatically manages synchronization of logical
-decoding (replication) slots across high-availability clusters. This
-feature primarily uses the sync_replication_slots server parameter
-(introduced in PostgreSQL 17) for native and robust slot synchronization.
-For clusters running older PostgreSQL versions, the pg_failover_slots
-extension is used as a fallback mechanism. This ensures that changes are
-not consumed from logical replication failover slots until they are received
-and flushed to all physical standby nodes, providing reliable logical
-replication continuity during failover events.</p>
+decoding (replication) slots across high-availability clusters.</p>
+<p>Requires one of the following conditions:</p>
+<ul>
+<li>PostgreSQL version 17 or later</li>
+<li>PostgreSQL version &lt; 17 with pg_failover_slots extension enabled</li>
+</ul>
 </td>
 </tr>
 </tbody>

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -131,7 +131,7 @@ Additionally, the community provides images for the [PostGIS extension](postgis.
     - *Offline Import*: Direct restore from existing databases.
     - *Online Import*: PostgreSQL native logical replication via the `Subscription` resource.
 - High Availability physical replication slots, including synchronization of
-  user-defined replication slots.
+  user-defined replication slots and logical decoding failover.
 - Parallel WAL archiving and restore, ensuring high-performance data
   synchronization in high-write environments.
 - TLS support, including:

--- a/docs/src/logical_replication.md
+++ b/docs/src/logical_replication.md
@@ -12,6 +12,14 @@ connect to publications on a publisher node. Subscribers pull data changes from
 these publications and can re-publish them, enabling cascading replication and
 complex topologies.
 
+!!! Important
+    To protect your logical replication subscribers after a failover of the
+    publisher cluster in CloudNativePG, ensure that replication slot
+    synchronization for logical decoding is enabled. Without this, your logical
+    replication clients may lose data and fail to continue seamlessly after a
+    failover. For configuration details, see
+    ["Replication: Logical Decoding Slot Synchronization"](replication.md#logical-decoding-slot-synchronization).
+
 This flexible model is particularly useful for:
 
 - Online data migrations

--- a/docs/src/logical_replication.md
+++ b/docs/src/logical_replication.md
@@ -253,7 +253,7 @@ the `Subscription` status will reflect the following:
 If an error occurs during reconciliation, `status.applied` will be `false`, and
 an error message will be included in the `status.message` field.
 
-### Removing a subscription
+### Removing a Subscription
 
 The `subscriptionReclaimPolicy` field controls the behavior when deleting a
 `Subscription` object:
@@ -281,6 +281,13 @@ spec:
 
 In this case, deleting the `Subscription` object also removes the `subscriber`
 subscription from the `app` database of the `king` cluster.
+
+### Resilience to Failovers
+
+To ensure that your logical replication subscriptions remain operational after
+a failover of the publisher, configure CloudNativePG to synchronize logical
+decoding slots across the cluster. For detailed instructions, see
+[Logical Decoding Slot Synchronization](replication.md#logical-decoding-slot-synchronization).
 
 ## Limitations
 

--- a/docs/src/operator_capability_levels.md
+++ b/docs/src/operator_capability_levels.md
@@ -115,11 +115,11 @@ than `1`, the operator manages `instances -1` replicas, including high
 availability (HA) through automated failover and rolling updates through
 switchover operations.
 
-CloudNativePG manages replication slots for all the replicas
-in the HA cluster. The implementation is inspired by the previously
-proposed patch for PostgreSQL, called
-[failover slots](https://wiki.postgresql.org/wiki/Failover_slots), and
-also supports user defined physical replication slots on the primary.
+CloudNativePG manages replication slots for all replicas in the
+high-availability cluster. It also supports user-defined physical replication
+slots on the primary and enables logical decoding failover—natively for
+PostgreSQL 17 and later using `sync_replication_slots`, and through the
+`pg_failover_slots` extension for earlier versions.
 
 ### Service Configuration
 

--- a/docs/src/replication.md
+++ b/docs/src/replication.md
@@ -734,6 +734,24 @@ spec:
     size: 1Gi
 ```
 
+### Logical Decoding Slot Synchronization
+
+CloudNativePG can now synchronize logical decoding (replication) slots across all nodes in a high-availability cluster.
+To enable this, set:
+
+```yaml
+replicationSlots:
+  highAvailability:
+    synchronizeLogicalDecoding: true
+```
+
+When enabled, the operator manages logical decoding slot state across failover and switchover events.
+For PostgreSQL 17 and later, this uses the built-in `sync_replication_slots` parameter.
+For older versions, `pg_failover_slots` is used as a fallback.
+
+This ensures logical replication clients can continue from the correct position after failover,
+preventing data loss or slot invalidation.
+
 ### Capping the WAL size retained for replication slots
 
 When replication slots is enabled, you might end up running out of disk space

--- a/docs/src/replication.md
+++ b/docs/src/replication.md
@@ -738,41 +738,55 @@ spec:
 
 CloudNativePG can synchronize logical decoding (replication) slots across all
 nodes in a high-availability cluster, ensuring seamless continuation of logical
-replication after a failover or switchover. This feature is disabled by default
-and can be enabled with:
+replication after a failover or switchover. This feature is disabled by
+default, and enabling it requires two steps.
+
+The first step is to enable logical decoding slot synchronization:
 
 ```yaml
-replicationSlots:
-  highAvailability:
-    synchronizeLogicalDecoding: true
+  # ...
+  replicationSlots:
+    highAvailability:
+      synchronizeLogicalDecoding: true
 ```
 
-When enabled, the operator automatically manages the state of logical decoding
-slots during failover and switchover events, avoiding slot invalidation or data
+The second step involves configuring PostgreSQL parameters: the required
+configuration depends on your PostgreSQL version, as explained below.
+
+When enabled, the operator automatically manages logical decoding slot states
+during failover and switchover, preventing slot invalidation and avoiding data
 loss for logical replication clients.
 
 #### Behavior on PostgreSQL 17 and later
 
 For PostgreSQL 17 and newer, CloudNativePG transparently manages the
 [`sync_replication_slots` parameter](https://www.postgresql.org/docs/current/runtime-config-replication.html#GUC-SYNCHRONIZED-STANDBY-SLOTS).
-Logical WAL sender processes will send decoded changes to plugins only after
-the specified replication slots confirm receiving and flushing the relevant
-WAL, ensuring that:
+You must enable both `sync_replication_slots` and `hot_standby_feedback` in
+your PostgreSQL configuration:
+
+```yaml
+  # ...
+  postgresql:
+    parameters:
+      # ...
+      hot_standby_feedback: 'on'
+      sync_replication_slots: 'on'
+```
+
+When configured, logical WAL sender processes send decoded changes to plugins
+only after the specified replication slots confirm receiving and flushing the
+relevant WAL, ensuring that:
 
 - logical replication slots do not consume changes until they are safely
-  received by the replicas, and
-- logical replication connections can safely switch to a promoted standby
-  without missing data.
-
-If your logical replication client is designed to reconnect to a promoted
-standby after failover, ensure the relevant physical replication slot for that
-standby is included in your configuration.
+  received by replicas, and
+- logical replication clients can safely reconnect to a promoted standby
+  without missing data after failover.
 
 #### Behavior on PostgreSQL 16 and earlier
 
 For PostgreSQL 16 and older versions, CloudNativePG uses the
-`pg_failover_slots` extension to maintain synchronization of logical
-replication slots across failovers.
+[`pg_failover_slots` extension](https://github.com/EnterpriseDB/pg_failover_slots)
+to maintain synchronization of logical replication slots across failovers.
 
 ### Capping the WAL size retained for replication slots
 

--- a/internal/webhook/v1/cluster_webhook.go
+++ b/internal/webhook/v1/cluster_webhook.go
@@ -209,6 +209,7 @@ func (v *ClusterCustomValidator) validate(r *apiv1.Cluster) (allErrs field.Error
 		v.validateSynchronousReplicaConfiguration,
 		v.validateLDAP,
 		v.validateReplicationSlots,
+		v.validateSynchronizeLogicalDecoding,
 		v.validateEnv,
 		v.validateManagedServices,
 		v.validateManagedRoles,
@@ -1038,25 +1039,27 @@ func (v *ClusterCustomValidator) validateConfiguration(r *apiv1.Cluster) field.E
 		}
 	}
 
-	walLogHintsValue, walLogHintsSet := r.Spec.PostgresConfiguration.Parameters[postgres.ParameterWalLogHints]
-	if walLogHintsSet {
-		walLogHintsActivated, err := postgres.ParsePostgresConfigBoolean(walLogHintsValue)
-		if err != nil {
-			result = append(
-				result,
-				field.Invalid(
-					field.NewPath("spec", "postgresql", "parameters", postgres.ParameterWalLogHints),
-					walLogHintsValue,
-					"invalid `wal_log_hints`. Must be a postgres boolean"))
-		}
-		if r.Spec.Instances > 1 && !walLogHintsActivated {
-			result = append(
-				result,
-				field.Invalid(
-					field.NewPath("spec", "postgresql", "parameters", postgres.ParameterWalLogHints),
-					r.Spec.PostgresConfiguration.Parameters[postgres.ParameterWalLogHints],
-					"`wal_log_hints` must be set to `on` when `instances` > 1"))
-		}
+	if _, fieldError := validateBooleanPostgresParameter(r,
+		postgres.ParameterHotStandbyFeedback, false); fieldError != nil {
+		result = append(result, fieldError)
+	}
+
+	if _, fieldError := validateBooleanPostgresParameter(r,
+		postgres.ParameterSyncReplicationSlots, false); fieldError != nil {
+		result = append(result, fieldError)
+	}
+
+	walLogHintsActivated, fieldError := validateBooleanPostgresParameter(r, postgres.ParameterWalLogHints, true)
+	if fieldError != nil {
+		result = append(result, fieldError)
+	}
+	if !walLogHintsActivated && r.Spec.Instances > 1 {
+		result = append(
+			result,
+			field.Invalid(
+				field.NewPath("spec", "postgresql", "parameters", postgres.ParameterWalLogHints),
+				r.Spec.PostgresConfiguration.Parameters[postgres.ParameterWalLogHints],
+				"`wal_log_hints` must be set to `on` when `instances` > 1"))
 	}
 
 	// verify the postgres setting min_wal_size < max_wal_size < volume size
@@ -1070,6 +1073,21 @@ func (v *ClusterCustomValidator) validateConfiguration(r *apiv1.Cluster) field.E
 	}
 
 	return result
+}
+
+func validateBooleanPostgresParameter(r *apiv1.Cluster, parameterName string, defaultValue bool) (bool, *field.Error) {
+	stringValue, hasParameter := r.Spec.PostgresConfiguration.Parameters[parameterName]
+	if hasParameter {
+		value, err := postgres.ParsePostgresConfigBoolean(stringValue)
+		if err != nil {
+			return defaultValue, field.Invalid(
+				field.NewPath("spec", "postgresql", "parameters", parameterName),
+				stringValue,
+				fmt.Sprintf("invalid `%s` value. Must be a postgres boolean", parameterName))
+		}
+		return value, nil
+	}
+	return defaultValue, nil
 }
 
 // validateWalSizeConfiguration verifies that min_wal_size < max_wal_size < wal volume size
@@ -2070,6 +2088,62 @@ func (v *ClusterCustomValidator) validateReplicationSlots(r *apiv1.Cluster) fiel
 	return nil
 }
 
+func (v *ClusterCustomValidator) validateSynchronizeLogicalDecoding(r *apiv1.Cluster) field.ErrorList {
+	replicationSlots := r.Spec.ReplicationSlots
+	if replicationSlots.HighAvailability == nil || !replicationSlots.HighAvailability.SynchronizeLogicalDecoding {
+		return nil
+	}
+
+	if postgres.IsManagedExtensionUsed("pg_failover_slots", r.Spec.PostgresConfiguration.Parameters) {
+		return nil
+	}
+
+	pgMajor, err := r.GetPostgresqlMajorVersion()
+	if err != nil {
+		return nil
+	}
+
+	if pgMajor < 17 {
+		return field.ErrorList{
+			field.Invalid(
+				field.NewPath("spec", "replicationSlots", "highAvailability", "synchronizeLogicalDecoding"),
+				replicationSlots.HighAvailability.SynchronizeLogicalDecoding,
+				"pg_failover_slots extension must be enabled to use synchronizeLogicalDecoding with Postgres versions < 17",
+			),
+		}
+	}
+
+	result := field.ErrorList{}
+
+	hotStandbyFeedback, _ := postgres.ParsePostgresConfigBoolean(
+		r.Spec.PostgresConfiguration.Parameters[postgres.ParameterHotStandbyFeedback])
+	if !hotStandbyFeedback {
+		result = append(
+			result,
+			field.Invalid(
+				field.NewPath("spec", "postgresql", "parameters", postgres.ParameterHotStandbyFeedback),
+				hotStandbyFeedback,
+				fmt.Sprintf("`%s` must be enabled to enable "+
+					"`spec.replicationSlots.highAvailability.synchronizeLogicalDecoding`",
+					postgres.ParameterHotStandbyFeedback)))
+	}
+
+	const syncReplicationSlotsKey = "sync_replication_slots"
+	syncReplicationSlots, _ := postgres.ParsePostgresConfigBoolean(
+		r.Spec.PostgresConfiguration.Parameters[syncReplicationSlotsKey])
+	if !syncReplicationSlots {
+		result = append(
+			result,
+			field.Invalid(
+				field.NewPath("spec", "postgresql", "parameters", syncReplicationSlotsKey),
+				syncReplicationSlots,
+				fmt.Sprintf("either `%s` setting or pg_failover_slots extension must be enabled to enable "+
+					"`spec.replicationSlots.highAvailability.synchronizeLogicalDecoding`", syncReplicationSlotsKey)))
+	}
+
+	return result
+}
+
 func (v *ClusterCustomValidator) validateReplicationSlotsChange(r, old *apiv1.Cluster) field.ErrorList {
 	newReplicationSlots := r.Spec.ReplicationSlots
 	oldReplicationSlots := old.Spec.ReplicationSlots
@@ -2276,38 +2350,20 @@ func (v *ClusterCustomValidator) validatePgFailoverSlots(r *apiv1.Cluster) field
 	var result field.ErrorList
 	var pgFailoverSlots postgres.ManagedExtension
 
-	for i, ext := range postgres.ManagedExtensions {
-		if ext.Name == "pg_failover_slots" {
-			pgFailoverSlots = postgres.ManagedExtensions[i]
-		}
-	}
-	if !pgFailoverSlots.IsUsed(r.Spec.PostgresConfiguration.Parameters) {
+	if !postgres.IsManagedExtensionUsed("pg_failover_slots", r.Spec.PostgresConfiguration.Parameters) {
 		return nil
 	}
 
-	const hotStandbyFeedbackKey = "hot_standby_feedback"
-	hotStandbyFeedbackActivated := false
-	hotStandbyFeedback, hasHotStandbyFeedback := r.Spec.PostgresConfiguration.Parameters[hotStandbyFeedbackKey]
-	if hasHotStandbyFeedback {
-		var err error
-		hotStandbyFeedbackActivated, err = postgres.ParsePostgresConfigBoolean(hotStandbyFeedback)
-		if err != nil {
-			result = append(
-				result,
-				field.Invalid(
-					field.NewPath("spec", "postgresql", "parameters", hotStandbyFeedbackKey),
-					hotStandbyFeedback,
-					fmt.Sprintf("invalid `%s` value. Must be a postgres boolean", hotStandbyFeedbackKey)))
-		}
-	}
-
-	if !hotStandbyFeedbackActivated {
+	hotStandbyFeedback, _ := postgres.ParsePostgresConfigBoolean(
+		r.Spec.PostgresConfiguration.Parameters[postgres.ParameterHotStandbyFeedback])
+	if !hotStandbyFeedback {
 		result = append(
 			result,
 			field.Invalid(
-				field.NewPath("spec", "postgresql", "parameters", hotStandbyFeedbackKey),
+				field.NewPath("spec", "postgresql", "parameters", postgres.ParameterHotStandbyFeedback),
 				hotStandbyFeedback,
-				fmt.Sprintf("`%s` must be enabled to use %s extension", hotStandbyFeedbackKey, pgFailoverSlots.Name)))
+				fmt.Sprintf("`%s` must be enabled to use %s extension",
+					postgres.ParameterHotStandbyFeedback, pgFailoverSlots.Name)))
 	}
 
 	if r.Spec.ReplicationSlots == nil {


### PR DESCRIPTION
Add the `synchronizeLogicalDecoding` field under `spec.replicationSlots.highAvailability` to enable automatic synchronization of logical decoding slots across high-availability clusters.

This feature primarily leverages the `sync_replication_slots` server parameter, introduced in PostgreSQL 17, to provide native and future-proof slot synchronization.

For clusters running older PostgreSQL versions, the `pg_failover_slots` extension is used as a fallback.

A validating admission webhook is included to enforce prerequisites and prevent misconfiguration.

Closes #7454

### Release notes

```
Logical decoding slot synchronization in HA clusters: Add the `synchronizeLogicalDecoding` field under `spec.replicationSlots.highAvailability` to enable automatic synchronization of logical decoding slots across high-availability clusters, ensuring logical replication subscribers continue seamlessly after a publisher failover.
```
