### PR TITLE
fix(backup,online): fail backup if targetPod becomes unhealthy

### DIFF
--- a/api/v1/backup_funcs.go
+++ b/api/v1/backup_funcs.go
@@ -238,6 +238,8 @@ func (backup *Backup) GetAssignedInstance(ctx context.Context, cli client.Client
 
 // GetOnlineOrDefault returns the online value for the backup.
 func (backup *Backup) GetOnlineOrDefault(cluster *Cluster) bool {
+	// Offline backups are supported only with the
+	// volume snapshot backup method,
 	if backup.Spec.Method != BackupMethodVolumeSnapshot {
 		return true
 	}
@@ -251,7 +253,6 @@ func (backup *Backup) GetOnlineOrDefault(cluster *Cluster) bool {
 	}
 
 	config := backup.GetVolumeSnapshotConfiguration(*cluster.Spec.Backup.VolumeSnapshot)
-
 	if config.Online != nil {
 		return *config.Online
 	}

--- a/api/v1/backup_funcs.go
+++ b/api/v1/backup_funcs.go
@@ -239,7 +239,7 @@ func (backup *Backup) GetAssignedInstance(ctx context.Context, cli client.Client
 // GetOnlineOrDefault returns the online value for the backup.
 func (backup *Backup) GetOnlineOrDefault(cluster *Cluster) bool {
 	// Offline backups are supported only with the
-	// volume snapshot backup method,
+	// volume snapshot backup method.
 	if backup.Spec.Method != BackupMethodVolumeSnapshot {
 		return true
 	}

--- a/api/v1/backup_funcs.go
+++ b/api/v1/backup_funcs.go
@@ -236,6 +236,29 @@ func (backup *Backup) GetAssignedInstance(ctx context.Context, cli client.Client
 	return &previouslyElectedPod, nil
 }
 
+// GetOnlineOrDefault returns the online value for the backup.
+func (backup *Backup) GetOnlineOrDefault(cluster *Cluster) bool {
+	if backup.Spec.Method != BackupMethodVolumeSnapshot {
+		return true
+	}
+
+	if backup.Spec.Online != nil {
+		return *backup.Spec.Online
+	}
+
+	if cluster.Spec.Backup == nil || cluster.Spec.Backup.VolumeSnapshot == nil {
+		return true
+	}
+
+	config := backup.GetVolumeSnapshotConfiguration(*cluster.Spec.Backup.VolumeSnapshot)
+
+	if config.Online != nil {
+		return *config.Online
+	}
+
+	return true
+}
+
 // GetVolumeSnapshotConfiguration overrides the  configuration value with the ones specified
 // in the backup, if present.
 func (backup *Backup) GetVolumeSnapshotConfiguration(

--- a/internal/controller/backup_controller.go
+++ b/internal/controller/backup_controller.go
@@ -66,10 +66,15 @@ const backupPhase = ".status.phase"
 // where the name of the cluster is written
 const clusterName = ".spec.cluster.name"
 
-// isRunningResult ensures that we periodically check running backups. It could happen that the targetPod is destroyed
+// getIsRunningResult gets the result that is returned to periodically
+// check for running backups.
+// This is particularly important when the target Pod is destroyed
 // or stops responding.
-// This should be used almost always when a backup is running
-var isRunningResult = ctrl.Result{RequeueAfter: 10 * time.Minute}
+//
+// This result should be used almost always when a backup is running
+func getIsRunningResult() ctrl.Result {
+	return ctrl.Result{RequeueAfter: 10 * time.Minute}
+}
 
 // BackupReconciler reconciles a Backup object
 type BackupReconciler struct {
@@ -230,7 +235,7 @@ func (r *BackupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		}
 
 		if isRunning {
-			return isRunningResult, nil
+			return getIsRunningResult(), nil
 		}
 
 		r.Recorder.Eventf(&backup, "Normal", "Starting",
@@ -239,7 +244,7 @@ func (r *BackupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 
 	if backup.Spec.Method == apiv1.BackupMethodPlugin {
 		if isRunning {
-			return isRunningResult, nil
+			return getIsRunningResult(), nil
 		}
 
 		r.Recorder.Eventf(&backup, "Normal", "Starting",


### PR DESCRIPTION
This patch ensures that the backup process is immediately aborted if the targetPod becomes unhealthy during an online backup operation. Previously, the backup would continue even if the target instance was no longer in a healthy state, potentially resulting in incomplete or inconsistent backups. By monitoring the pod's health status, the process now fails fast, providing early feedback and increasing the accuracy of the Backup object status.

Related #7503
Closes #7905

### Release notes

```
Online backup operation now fails immediately if the targetPod becomes
unhealthy, increasing the accuracy of the Backup object status.
```