### PR TITLE
feat(pooler): enable `stats_users` to be configured

### DIFF
--- a/docs/src/connection_pooling.md
+++ b/docs/src/connection_pooling.md
@@ -374,6 +374,7 @@ are the ones directly set by PgBouncer.
 - [`server_tls_ciphers`](https://www.pgbouncer.org/config.html#server_tls_ciphers)
 - [`server_tls_protocols`](https://www.pgbouncer.org/config.html#server_tls_protocols)
 - [`stats_period`](https://www.pgbouncer.org/config.html#stats_period)
+- [`stats_users`](https://www.pgbouncer.org/config.html#stats_users)
 - [`suspend_timeout`](https://www.pgbouncer.org/config.html#suspend_timeout)
 - [`tcp_defer_accept`](https://www.pgbouncer.org/config.html#tcp_defer_accept)
 - [`tcp_keepalive`](https://www.pgbouncer.org/config.html#tcp_keepalive)

--- a/internal/webhook/v1/pooler_webhook.go
+++ b/internal/webhook/v1/pooler_webhook.go
@@ -79,6 +79,7 @@ var AllowedPgbouncerGenericConfigurationParameters = stringset.From([]string{
 	"server_tls_ciphers",
 	"server_tls_protocols",
 	"stats_period",
+	"stats_users",
 	"suspend_timeout",
 	"tcp_defer_accept",
 	"tcp_socket_buffer",


### PR DESCRIPTION
Enable PgBouncer's `stats_users` parameter in the webhook.

Closes #7973