### PR TITLE
fix: enforce min_wal_size >= 2 * wal_segment_size for custom WAL segment sizes

### DIFF
--- a/docs/src/postgresql_conf.md
+++ b/docs/src/postgresql_conf.md
@@ -686,3 +686,6 @@ Users are not allowed to set the following configuration parameters in the
 - `unix_socket_directories`
 - `unix_socket_group`
 - `unix_socket_permissions`
+
+!!! Note
+    When using a custom `walSegmentSize`, CloudNativePG ensures that `min_wal_size` is always at least twice the `walSegmentSize`, as required by PostgreSQL. The operator will automatically enforce this during restore and validate it on cluster creation and update.

--- a/docs/src/release_notes/v1.26.md
+++ b/docs/src/release_notes/v1.26.md
@@ -95,7 +95,7 @@ on the release branch in GitHub.
 
 - Added support for patching PostgreSQL instance pods using the
   `cnpg.io/podPatch` annotation with a JSON Patch. This may introduce
-  discrepancies between the operator’s expectations and Kubernetes behavior, so
+  discrepancies between the operator's expectations and Kubernetes behavior, so
   it should be used with caution. (#6323) <!-- no 1.25 1.24 1.22 -->
 
 - Added support for collecting `pg_stat_wal` metrics in PostgreSQL 18. (#7005)
@@ -203,3 +203,7 @@ on the release branch in GitHub.
 - PostgreSQL 17, 16, 15, 14, and 13
     - PostgreSQL 17.5 is the default image
     - PostgreSQL 13 support ends on November 12, 2025
+
+## Bug Fixes
+
+- Fixed an issue where restoring a cluster from a volume snapshot with a non-default `walSegmentSize` (e.g., 64MB) could result in a failed restore due to an invalid default `min_wal_size`. The operator now ensures that `min_wal_size` is always at least twice the `walSegmentSize`, as required by PostgreSQL. The webhook also validates this relationship on cluster creation and update. (#7967)

--- a/internal/webhook/v1/cluster_webhook.go
+++ b/internal/webhook/v1/cluster_webhook.go
@@ -1060,8 +1060,20 @@ func (v *ClusterCustomValidator) validateConfiguration(r *apiv1.Cluster) field.E
 	}
 
 	// verify the postgres setting min_wal_size < max_wal_size < volume size
+	// and validate WAL segment size relationship
+	walSegmentSize := (*int32)(nil)
+	if param, ok := r.Spec.PostgresConfiguration.Parameters["wal_segment_size"]; ok && param != "" {
+		if v, err := strconv.Atoi(param); err == nil {
+			v32 := int32(v)
+			walSegmentSize = &v32
+		}
+	}
+	if walSegmentSize == nil && r.Spec.Bootstrap != nil && r.Spec.Bootstrap.InitDB != nil && r.Spec.Bootstrap.InitDB.WalSegmentSize != 0 {
+		v := int32(r.Spec.Bootstrap.InitDB.WalSegmentSize)
+		walSegmentSize = &v
+	}
 	result = append(result, validateWalSizeConfiguration(
-		r.Spec.PostgresConfiguration, r.Spec.WalStorage.GetSizeOrNil())...)
+		r.Spec.PostgresConfiguration, r.Spec.WalStorage.GetSizeOrNil(), walSegmentSize)...)
 
 	if err := validateSyncReplicaElectionConstraint(
 		r.Spec.PostgresConfiguration.SyncReplicaElectionConstraint,
@@ -1073,8 +1085,10 @@ func (v *ClusterCustomValidator) validateConfiguration(r *apiv1.Cluster) field.E
 }
 
 // validateWalSizeConfiguration verifies that min_wal_size < max_wal_size < wal volume size
+// and that min_wal_size >= 2 * wal_segment_size when walSegmentSize is specified
 func validateWalSizeConfiguration(
 	postgresConfig apiv1.PostgresConfiguration, walVolumeSize *resource.Quantity,
+	walSegmentSize *int32,
 ) field.ErrorList {
 	const (
 		minWalSizeKey     = "min_wal_size"
@@ -1124,6 +1138,22 @@ func validateWalSizeConfiguration(
 				minWalSize,
 				fmt.Sprintf("Invalid vale. Parameter %s (default %s) should be smaller than parameter %s (default %s)",
 					minWalSizeKey, minWalSizeDefault, maxWalSizeKey, maxWalSizeDefault)))
+	}
+
+	// Validate that min_wal_size >= 2 * wal_segment_size when walSegmentSize is specified
+	if walSegmentSize != nil && *walSegmentSize > 0 {
+		requiredMinWalSizeMB := int64(*walSegmentSize) * 2
+		requiredMinWalSize := resource.NewQuantity(requiredMinWalSizeMB*1024*1024, resource.BinarySI)
+
+		if minWalSizeValue.Cmp(*requiredMinWalSize) < 0 {
+			result = append(
+				result,
+				field.Invalid(
+					field.NewPath("spec", "postgresql", "parameters", minWalSizeKey),
+					minWalSize,
+					fmt.Sprintf("Parameter %s must be at least %dMB when walSegmentSize is %dMB (PostgreSQL requirement: min_wal_size >= 2 * wal_segment_size)",
+						minWalSizeKey, requiredMinWalSizeMB, *walSegmentSize)))
+		}
 	}
 
 	if walVolumeSize == nil {

--- a/internal/webhook/v1/cluster_webhook_test.go
+++ b/internal/webhook/v1/cluster_webhook_test.go
@@ -1214,6 +1214,100 @@ var _ = Describe("configuration change validation", func() {
 			Expect(v.validateConfiguration(cluster)).To(BeEmpty())
 		})
 	})
+
+	It("complains when min_wal_size is less than twice walSegmentSize in validateConfiguration", func() {
+		walSeg := 64
+		clusterNew := &apiv1.Cluster{
+			Spec: apiv1.ClusterSpec{
+				Bootstrap: &apiv1.BootstrapConfiguration{
+					InitDB: &apiv1.BootstrapInitDB{
+						WalSegmentSize: walSeg,
+					},
+				},
+				PostgresConfiguration: apiv1.PostgresConfiguration{
+					Parameters: map[string]string{
+						"min_wal_size": "80MB",
+					},
+				},
+			},
+		}
+		// 2 * 64 = 128, so 80MB is invalid
+		validator := &ClusterCustomValidator{}
+		errs := validator.validateConfiguration(clusterNew)
+		Expect(errs).NotTo(BeEmpty())
+		found := false
+		for _, err := range errs {
+			if strings.Contains(err.Error(), "min_wal_size must be at least 128MB") {
+				found = true
+				break
+			}
+		}
+		Expect(found).To(BeTrue(), "Expected error message about min_wal_size being at least 128MB")
+	})
+
+	It("accepts when min_wal_size is at least twice walSegmentSize in validateConfiguration", func() {
+		walSeg := 64
+		clusterNew := &apiv1.Cluster{
+			Spec: apiv1.ClusterSpec{
+				Bootstrap: &apiv1.BootstrapConfiguration{
+					InitDB: &apiv1.BootstrapInitDB{
+						WalSegmentSize: walSeg,
+					},
+				},
+				PostgresConfiguration: apiv1.PostgresConfiguration{
+					Parameters: map[string]string{
+						"min_wal_size": "128MB",
+					},
+				},
+			},
+		}
+		// 2 * 64 = 128, so 128MB is valid
+		validator := &ClusterCustomValidator{}
+		errs := validator.validateConfiguration(clusterNew)
+		Expect(errs).To(BeEmpty())
+	})
+
+	It("accepts when wal_segment_size is specified in parameters and min_wal_size is sufficient", func() {
+		clusterNew := &apiv1.Cluster{
+			Spec: apiv1.ClusterSpec{
+				PostgresConfiguration: apiv1.PostgresConfiguration{
+					Parameters: map[string]string{
+						"wal_segment_size": "64",
+						"min_wal_size":     "128MB",
+					},
+				},
+			},
+		}
+		// 2 * 64 = 128, so 128MB is valid
+		validator := &ClusterCustomValidator{}
+		errs := validator.validateConfiguration(clusterNew)
+		Expect(errs).To(BeEmpty())
+	})
+
+	It("complains when wal_segment_size is specified in parameters but min_wal_size is insufficient", func() {
+		clusterNew := &apiv1.Cluster{
+			Spec: apiv1.ClusterSpec{
+				PostgresConfiguration: apiv1.PostgresConfiguration{
+					Parameters: map[string]string{
+						"wal_segment_size": "64",
+						"min_wal_size":     "80MB",
+					},
+				},
+			},
+		}
+		// 2 * 64 = 128, so 80MB is invalid
+		validator := &ClusterCustomValidator{}
+		errs := validator.validateConfiguration(clusterNew)
+		Expect(errs).NotTo(BeEmpty())
+		found := false
+		for _, err := range errs {
+			if strings.Contains(err.Error(), "min_wal_size must be at least 128MB") {
+				found = true
+				break
+			}
+		}
+		Expect(found).To(BeTrue(), "Expected error message about min_wal_size being at least 128MB")
+	})
 })
 
 var _ = Describe("validate image name change", func() {

--- a/pkg/management/postgres/restore.go
+++ b/pkg/management/postgres/restore.go
@@ -82,6 +82,7 @@ var (
 		"max_worker_processes setting": "max_worker_processes",
 		"max_prepared_xacts setting":   "max_prepared_transactions",
 		"max_locks_per_xact setting":   "max_locks_per_transaction",
+		"Bytes per WAL segment":        "wal_segment_size",
 	}
 )
 
@@ -653,6 +654,43 @@ func getRestoreWalConfig(ctx context.Context, backup *apiv1.Backup) (string, err
 	return recoveryFileContents, nil
 }
 
+// validateAndAdjustWalSizeParameters ensures that min_wal_size is at least twice the wal_segment_size
+// as required by PostgreSQL. This is particularly important when restoring from volume snapshots
+// where the original cluster had a non-default WAL segment size.
+func validateAndAdjustWalSizeParameters(
+	controldataParams map[string]int,
+	clusterParams map[string]int,
+	enforcedParams map[string]string,
+) {
+	// Get WAL segment size from pg_controldata (in bytes)
+	walSegmentSizeBytes, hasWalSegmentSize := controldataParams["wal_segment_size"]
+	if !hasWalSegmentSize {
+		// If we can't get WAL segment size from pg_controldata, use default (16MB)
+		walSegmentSizeBytes = 16 * 1024 * 1024
+	}
+
+	// Convert to MB for easier comparison
+	walSegmentSizeMB := walSegmentSizeBytes / (1024 * 1024)
+
+	// Check if min_wal_size is set and if it's sufficient
+	if minWalSizeStr, hasMinWalSize := clusterParams["min_wal_size"]; hasMinWalSize {
+		// Parse min_wal_size (it's stored as MB in clusterParams)
+		minWalSizeMB := minWalSizeStr
+
+		// PostgreSQL requires min_wal_size >= 2 * wal_segment_size
+		requiredMinWalSizeMB := walSegmentSizeMB * 2
+
+		if minWalSizeMB < requiredMinWalSizeMB {
+			// Update the enforced parameters to set the correct min_wal_size
+			enforcedParams["min_wal_size"] = fmt.Sprintf("%dMB", requiredMinWalSizeMB)
+		}
+	} else {
+		// If min_wal_size is not set, set it to the required value
+		requiredMinWalSizeMB := walSegmentSizeMB * 2
+		enforcedParams["min_wal_size"] = fmt.Sprintf("%dMB", requiredMinWalSizeMB)
+	}
+}
+
 func (info InitInfo) writeRecoveryConfiguration(cluster *apiv1.Cluster, recoveryFileContents string) error {
 	// Ensure restore_command is used to correctly recover WALs
 	// from the object storage
@@ -695,6 +733,7 @@ func (info InitInfo) writeRecoveryConfiguration(cluster *apiv1.Cluster, recovery
 		value := max(clusterParams[param], controldataParams[param])
 		enforcedParams[param] = strconv.Itoa(value)
 	}
+	validateAndAdjustWalSizeParameters(controldataParams, clusterParams, enforcedParams)
 	changed, err := configfile.UpdatePostgresConfigurationFile(
 		path.Join(info.PgData, constants.PostgresqlCustomConfigurationFile),
 		enforcedParams,


### PR DESCRIPTION
This PR fixes [#7967](https://github.com/cloudnative-pg/cloudnative-pg/issues/7967)
When restoring a cluster with a custom walSegmentSize, the default min_wal_size could be too low, causing PostgreSQL to fail to start.
This change ensures **min_wal_size** is always at least twice the **wal_segment_size**, as required by PostgreSQL, both during restore and via webhook validation.

- [x] Adds validation and enforcement for this relationship
- [x] Updates docs and release notes
- [x] Includes new tests