### PR TITLE
fix(webhook): prevent cluster failures from PostgreSQL parameter name typos

### DIFF
--- a/internal/webhook/v1/cluster_webhook.go
+++ b/internal/webhook/v1/cluster_webhook.go
@@ -26,6 +26,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"unicode"
 
 	barmanWebhooks "github.com/cloudnative-pg/barman-cloud/pkg/api/webhooks"
 	"github.com/cloudnative-pg/machinery/pkg/image/reference"
@@ -976,6 +977,16 @@ func (v *ClusterCustomValidator) validateConfiguration(r *apiv1.Cluster) field.E
 	sanitizedParameters := postgres.CreatePostgresqlConfiguration(info).GetConfigurationParameters()
 
 	for key, value := range r.Spec.PostgresConfiguration.Parameters {
+		// Validate parameter name syntax to prevent configuration parsing errors
+		if err := validateParameterName(key); err != nil {
+			result = append(
+				result,
+				field.Invalid(
+					field.NewPath("spec", "postgresql", "parameters", key),
+					key,
+					err.Error()))
+		}
+
 		_, isFixed := postgres.FixedConfigurationParameters[key]
 		sanitizedValue, presentInSanitizedConfiguration := sanitizedParameters[key]
 		if isFixed && (!presentInSanitizedConfiguration || value != sanitizedValue) {
@@ -2571,6 +2582,68 @@ func (v *ClusterCustomValidator) validateLivenessPingerProbe(r *apiv1.Cluster) f
 				value,
 				fmt.Sprintf("error decoding liveness pinger config: %s", err.Error()),
 			),
+		}
+	}
+
+	return nil
+}
+
+// validateParameterName validates PostgreSQL parameter name syntax
+// to prevent configuration parsing errors that can kill cluster startup
+func validateParameterName(name string) error {
+	if name == "" {
+		return fmt.Errorf("parameter name cannot be empty")
+	}
+
+	// Check for syntax errors that break PostgreSQL configuration parsing
+	// Check for double equals first since it's more specific than single equals
+	if strings.Contains(name, "==") {
+		return fmt.Errorf("parameter name cannot contain '=='")
+	}
+	if strings.HasSuffix(name, "=") {
+		return fmt.Errorf("parameter name cannot end with '='")
+	}
+	if strings.TrimSpace(name) != name {
+		return fmt.Errorf("parameter name cannot have leading/trailing whitespace")
+	}
+
+	// Validate character set following PostgreSQL identifier rules
+	// as referenced in https://github.com/postgres/postgres/blob/master/src/backend/utils/misc/guc.c#L1076
+	return validatePostgreSQLIdentifier(name)
+}
+
+// validatePostgreSQLIdentifier validates parameter name follows PostgreSQL identifier rules
+func validatePostgreSQLIdentifier(name string) error {
+	// Extension parameters (with dots) require each part to be a valid identifier
+	if strings.Contains(name, ".") {
+		parts := strings.Split(name, ".")
+		for _, part := range parts {
+			if err := validateIdentifierPart(part); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	// Regular parameters must be valid identifiers
+	return validateIdentifierPart(name)
+}
+
+// validateIdentifierPart validates a single identifier part according to PostgreSQL rules
+func validateIdentifierPart(part string) error {
+	if part == "" {
+		return fmt.Errorf("parameter name part cannot be empty")
+	}
+
+	// First character must be letter or underscore
+	if !unicode.IsLetter(rune(part[0])) && part[0] != '_' {
+		return fmt.Errorf("parameter name must start with letter or underscore")
+	}
+
+	// Subsequent characters: letters, digits, underscores, dollar signs
+	for _, char := range part[1:] {
+		if !unicode.IsLetter(char) && !unicode.IsDigit(char) && char != '_' && char != '$' {
+			return fmt.Errorf("parameter name contains invalid character: %c", char)
 		}
 	}
 


### PR DESCRIPTION
### Problem

PostgreSQL parameter names with syntax errors, such as trailing `=`, invalid characters, or leading/trailing whitespace, can cause cluster startup failures, even when the parameter values are valid. These issues are hard to trace because they only surface after deployment. (See #7045)

### Solution

This PR introduces early validation for PostgreSQL **parameter names** to catch names with typos during admission, following PostgreSQL's identifier rules defined in [`guc.c`](https://github.com/postgres/postgres/blob/master/src/backend/utils/misc/guc.c#L1076). This prevents invalid cluster configurations from being accepted.

### Limitations

This is not a complete validation engine for PostgreSQL identifiers, but it covers a broad set of commonly misused patterns, such as:
- Trailing equals (`=`)
- Double equals (`==`)
- Whitespace around names
- Invalid characters (e.g. dashes)
- Names starting with numbers

Parameter values are not validated here.

### Manual Testing

Reproducing the bug in #7045:
```bash
$ kubectl apply --dry-run=server -f - <<EOF
  apiVersion: postgresql.cnpg.io/v1
  kind: Cluster
  metadata:
    name: cluster-example
  spec:
    instances: 3
    storage:
      size: 1Gi
    postgresql:
      parameters:
        log_diconnections=: "off"  # Typo from issue #7045
EOF
```
Now results in:
```bash
The Cluster "cluster-example" is invalid: spec.postgresql.parameters.log_diconnections=: Invalid value: "log_diconnections=": parameter name cannot end with '='
```
Testing multiple syntax errors (should be rejected):
```bash
$ kubectl apply --dry-run=server -f - <<EOF
  apiVersion: postgresql.cnpg.io/v1
  kind: Cluster
  metadata:
    name: test-validation
  spec:
    instances: 1
    storage:
      size: 1Gi
    postgresql:
      parameters:
        shared_buffers==: "128MB"      # Double equals
        " log_statement": "all"        # Leading space
        "log_connections ": "on"       # Trailing space
        log-connections: "on"          # Invalid character (dash)
        123invalid: "value"            # Starts with number
EOF
```
Now results in:
```bash
The Cluster "test-validation" is invalid:
* spec.postgresql.parameters.shared_buffers==: Invalid value: "shared_buffers==": parameter name cannot contain '=='
* spec.postgresql.parameters.123invalid: Invalid value: "123invalid": parameter name must start with letter or underscore
* spec.postgresql.parameters.log_connections : Invalid value: "log_connections ": parameter name cannot have leading/trailing whitespace
* spec.postgresql.parameters. log_statement: Invalid value: " log_statement": parameter name cannot have leading/trailing whitespace
* spec.postgresql.parameters.log-connections: Invalid value: "log-connections": parameter name contains invalid character: -
```
Valid configuration (that should pass):

Testing valid parameters including extensions (should be accepted):
```bash
$ kubectl apply --dry-run=server -f - <<EOF
  apiVersion: postgresql.cnpg.io/v1
  kind: Cluster
  metadata:
    name: test-valid
  spec:
    instances: 1
    storage:
      size: 1Gi
    postgresql:
      parameters:
        log_connections: "on"          # Valid built-in parameter
        shared_buffers: "128MB"        # Valid built-in parameter
        my_extension.param: "value"    # Valid extension parameter
        _underscore_start: "test"      # Valid (starts with underscore)
        param_with_$dollar: "value"    # Valid (contains dollar)
EOF
```
Will result in:
```bash
cluster.postgresql.cnpg.io/test-valid created (server dry run)
```
### Fixes

Fixes #7045