### PR TITLE
Pin GitHub Action & OCI dependencies

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -633,7 +633,7 @@ jobs:
     steps:
       -
         name: Cleanup Disk
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
         with:
           android: true
           dotnet: true

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -605,9 +605,9 @@ jobs:
           accept-keywords: key
 
       - name: Run Snyk to check Docker image for vulnerabilities
-        uses: snyk/actions/docker@master
+        uses: snyk/actions/docker@28606799782bc8e809f4076e9f8293bc4212d05e # master
         if: |
-          !github.event.repository.fork && 
+          !github.event.repository.fork &&
           !github.event.pull_request.head.repo.fork
         continue-on-error: true
         env:
@@ -619,7 +619,7 @@ jobs:
       - name: Upload result to GitHub Code Scanning
         uses: github/codeql-action/upload-sarif@51f77329afa6477de8c49fc9c7046c15b9a4e79d # v3
         if: |
-          !github.event.repository.fork && 
+          !github.event.repository.fork &&
           !github.event.pull_request.head.repo.fork
         continue-on-error: true
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-ARG BASE=gcr.io/distroless/static-debian12:nonroot
+ARG BASE=gcr.io/distroless/static-debian12:nonroot@sha256:627d6c5a23ad24e6bdff827f16c7b60e0289029b0c79e9f7ccd54ae3279fb45f
 
 # This builder stage it's only because we need a command
 # to create a symlink and we do not have it in a distroless image
-FROM gcr.io/distroless/static-debian12:debug-nonroot AS builder
+FROM gcr.io/distroless/static-debian12:debug-nonroot@sha256:edbeb7a4e79938116dc9cb672b231792e0b5ac86c56fb49781a79e54f3842c67 AS builder
 ARG TARGETARCH
 SHELL ["/busybox/sh", "-c"]
 RUN ln -sf operator/manager_${TARGETARCH} manager


### PR DESCRIPTION
#7632 highlights that some GitHub Actions and OCI image references are missing the hash to properly pin the version

I have pinned the `free-disk-space` action to the latest commit on main, and moved the reference from `main` to `v1.3.1` as they reference the same commit.

The synk action repository is a collection of actions, and there are no releases for each action (or any recent releases for that matter). Therefore I pinned to the latest commit and left the reference as `master`. Renovate will still track and recommend updates when there are new commits on `master` branch.

The third reference in #7632 to be pinned (`.github/workflows/require-labels.yml:21`) was already fixed by https://github.com/cloudnative-pg/cloudnative-pg/commit/61a0537c45a394c94fa3d9e31312f95ab90afe2a

For the two OCI image references I pulled the latest version of the tag and added the SHA accordingly.