### PR TITLE
chore(podlogs): add context.Done logic to `SingleStream`

### DIFF
--- a/pkg/podlogs/cluster_writer.go
+++ b/pkg/podlogs/cluster_writer.go
@@ -223,8 +223,12 @@ func (csr *ClusterWriter) SingleStream(ctx context.Context, writer io.Writer) er
 		if streamSet.isZero() {
 			return nil
 		}
-		// wait before looking for new pods to log
-		time.Sleep(csr.getFollowWaitingTime())
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(csr.getFollowWaitingTime()):
+		}
 	}
 }
 


### PR DESCRIPTION
This patch makes the function more robust and better handles the flaky test failing on the main branch.

# Release notes

```
NONE
```
