### PR TITLE
chore: azurite test failing due to API versions mismatch

### DIFF
--- a/tests/utils/backups/azurite.go
+++ b/tests/utils/backups/azurite.go
@@ -290,6 +290,7 @@ func getAzuriteDeployment(namespace string) apiv1.Deployment {
 							Name:    "azurite",
 							Command: []string{"azurite"},
 							Args: []string{
+								"--skipApiVersionCheck",
 								"-l", "/data", "--cert", "/etc/ssl/certs/azurite.pem",
 								"--key", "/etc/ssl/certs/azurite-key.pem",
 								"--oauth", "basic", "--blobHost", "0.0.0.0",


### PR DESCRIPTION
The azurite tests were failing with the following error:
ERROR: Can't connect to cloud provider: The API version 2025-07-05 is not supported by Azurite. Please upgrade Azurite to latest version and retry. If you are using Azurite in Visual Studio, please check you have installed latest Visual Studio patch. Azurite command line parameter \"--skipApiVersionCheck\" or Visual Studio Code configuration \"Skip Api Version Check\" can skip this error.

Added the `--skipApiVersionCheck` to the azurite server we run and that avoid having this issue.

This was already reported in the azurite community here: https://github.com/azure/azurite/issues/2564

Closes #8059 