### PR TITLE
docs(contributing): clarify instructions for external contributors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,14 @@ We welcome many types of contributions including:
 For development contributions, please refer to the separate section called
 ["Contributing to the source code"](contribute/README.md).
 
+## External Contributors vs Maintainers
+
+**External Contributors:** If you're contributing from outside the core team, please note that some instructions in our detailed development docs apply only to maintainers. See the [development contribution guide](contribute/README.md) for complete details, but note:
+
+- **Issue Assignment**: Comment "I'd like to work on this" instead of self-assigning
+- **Testing**: Run local unit tests and basic e2e tests (see [testing guide](contribute/e2e_testing_environment/README.md)); maintainers will handle comprehensive cloud-based E2E testing
+- **Project Boards**: Maintainers will move tickets through project phases
+
 ## Ask for Help
 
 The best way to reach us with a question when contributing is to drop a line in

--- a/contribute/README.md
+++ b/contribute/README.md
@@ -94,15 +94,19 @@ If you have written code for an improvement to CloudNativePG or a bug fix,
 please follow this procedure to submit a pull request:
 
 1. [Create a fork](development_environment/README.md#forking-the-repository) of CloudNativePG
-2. Self-assign the ticket and begin working on it in the forked project. Move
-   the ticket to `Analysis` or `In Development` phase of
+2. **External contributors**: Comment on the issue with "I'd like to work on this" and wait for assignment. 
+   **Maintainers**: Self-assign the ticket and move it to `Analysis` or `In Development` phase of
    [CloudNativePG operator development](https://github.com/orgs/cloudnative-pg/projects/2)
-3. [Run the e2e tests in the forked repository](e2e_testing_environment/README.md#running-e2e-tests-on-a-fork-of-the-repository)
+3. **External contributors**: Run local unit tests and basic e2e tests using `FEATURE_TYPE=smoke,basic make e2e-test-kind` or `TEST_DEPTH=0 make e2e-test-kind` for critical tests only. 
+   **Maintainers**: [Run the comprehensive e2e tests in the forked repository](e2e_testing_environment/README.md#running-e2e-tests-on-a-fork-of-the-repository)
 4. Once development is finished, create a pull request from your forked project
-   to the CloudNativePG project and move the ticket to the `Waiting for First Review`
-   phase. Please make sure the pull request title and message follow
-   [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
-
+   to the CloudNativePG project. **Maintainers** will move the ticket to the `Waiting for First Review`
+   phase. 
+   
+   > Please make sure the pull request title and message follow
+   > [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
+   
+   > To facilitate collaboration, always [allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
 
 One of the maintainers will then proceed with the first review and approve the
 CI workflow to run in the CloudNativePG project.  The second reviewer will run

--- a/contribute/e2e_testing_environment/README.md
+++ b/contribute/e2e_testing_environment/README.md
@@ -273,10 +273,17 @@ the `kind` engine.
 
 ### Running E2E tests on a fork of the repository
 
-Additionally, if you fork the repository and want to run the tests on your fork, you can do so
+**For maintainers and organization members:** If you fork the repository and want to run the tests on your fork, you can do so
 by running the `/test` command in a Pull Request opened in your forked repository.
 `/test` is used to trigger a run of the end-to-end tests in the GitHub Actions.
 Only users who have `write` permission to the repository can use this command.
+
+**For external contributors:** You can run local e2e tests using:
+- `FEATURE_TYPE=smoke,basic make e2e-test-kind` for smoke and basic tests
+- `TEST_DEPTH=0 make e2e-test-kind` for critical tests only  
+- `TEST_DEPTH=1 make e2e-test-kind` for critical and high priority tests
+
+Maintainers will handle comprehensive cloud-based E2E testing during the pull request review process.
 
 Options supported are:
 


### PR DESCRIPTION
## Summary

This PR addresses the issues raised in #8017 by adding clear sections for "External Contributors" and "Maintainers" in the contributing instructions in the docs. It also adds guidance on how to express interest in issues and updates the necessary testing requirements for external contributors and maintainers.

## Problems it solves

**Problem 1**: Lack of Clear Distinction Between Contributor Types

Solved by:
- Added "External Contributors vs Maintainers" section in `CONTRIBUTING.md`
- Role-specific instructions in `contribute/README.md` (steps 2-4)
- Clear labeling in `e2e_testing_environment/README.md`

**Problem 2**: External contributors cannot self-assign issues or move tickets

Solved by:
- `contribute/README.md` step 2: "Comment on the issue with 'I'd like to work on this' and wait for assignment"
- `CONTRIBUTING.md:` "Comment 'I'd like to work on this' instead of self-assigning"
- `contribute/README.md` step 4: "Maintainers will move the ticket to the Waiting for First Review phase"

**Problem 3**: Excessive Testing Requirements - Full E2E testing is extremely burdensome

Solved by:
- `contribute/README.md` step 3: Specific lightweight commands for external contributors `(FEATURE_TYPE=smoke,basic` or `TEST_DEPTH=0`)
- `e2e_testing_environment/README.md:` Three practical local testing options
- Clear statement: "Maintainers will handle comprehensive cloud-based E2E testing"

**Problem 4**: Tests can take hours to complete, often fail due to environment-specific issues

Solved by:
- Smoke/basic tests are much faster than full E2E suite
- `TEST_DEPTH=0` runs only critical tests
- Removes cloud resource requirements for external contributors

## Note

This PR is intentionally narrow in scope and solve only the issues raised in #8017. As a follow-up, work could be done on the docs to improve the contributing guides by following **CNCF's guidelines** for [Contributor Growth](https://contribute.cncf.io/maintainers/community/contributor-growth-framework/) and making use of its [Templates](https://contribute.cncf.io/maintainers/templates/).

Fixes #8017