### PR TITLE
fix(logpipe): add one second  before closing the file read

### DIFF
--- a/pkg/management/postgres/logpipe/logpipe.go
+++ b/pkg/management/postgres/logpipe/logpipe.go
@@ -156,7 +156,7 @@ func (p *LogPipe) collectLogsFromFile(ctx context.Context) error {
 	select {
 	case <-ctx.Done():
 		filenameLog.Info("Terminating log reading process")
-		err := f.SetDeadline(time.Now())
+		err := f.SetDeadline(time.Now().Add(1 * time.Second))
 		if err != nil {
 			filenameLog.Error(err,
 				"Error while setting the deadline for log reading. The instance manager may not refresh "+


### PR DESCRIPTION
This will fix the rare cases where the logs from PostgreSQL are incomplete.

This is a mitigation and does not entirely fix the issue. 
