### PR TITLE
fix(upgrade): stop testing `max_slot_wal_keep_size`

### DIFF
--- a/docs/src/postgres_upgrades.md
+++ b/docs/src/postgres_upgrades.md
@@ -63,7 +63,7 @@ requested for a cluster.
     There is a bug in PostgreSQL 17.0 through 17.5 that prevents successful upgrades
     if the `max_slot_wal_keep_size` parameter is set to any value other than `-1`.
     The upgrade process will fail with an error related to replication slot configuration.
-    This issue has been fixed in PostgreSQL 17.6 and 18beta2 or later versions.
+    This issue has been [fixed in PostgreSQL 17.6 and 18beta2 or later versions](https://github.com/postgres/postgres/commit/f36e5774).
     If you are using PostgreSQL 17.0 through 17.5, ensure that you upgrade to at least
     PostgreSQL 17.6 before attempting a major upgrade, or make sure to temporarily set
     the `max_slot_wal_keep_size` parameter to `-1` in your cluster configuration.

--- a/docs/src/postgres_upgrades.md
+++ b/docs/src/postgres_upgrades.md
@@ -59,6 +59,15 @@ requested for a cluster.
     operating system distribution. For example, if your previous version uses a
     `bullseye` image, you cannot upgrade to a `bookworm` image.
 
+!!! Warning
+    There is a bug in PostgreSQL 17.0 through 17.5 that prevents successful upgrades
+    if the `max_slot_wal_keep_size` parameter is set to any value other than `-1`.
+    The upgrade process will fail with an error related to replication slot configuration.
+    This issue has been fixed in PostgreSQL 17.6 and 18beta2 or later versions.
+    If you are using PostgreSQL 17.0 through 17.5, ensure that you upgrade to at least
+    PostgreSQL 17.6 before attempting a major upgrade, or make sure to temporarily set
+    the `max_slot_wal_keep_size` parameter to `-1` in your cluster configuration.
+
 You can trigger the upgrade in one of two ways:
 
 - By updating the major version in the image tag via the `.spec.imageName`

--- a/internal/cmd/manager/instance/upgrade/execute/cmd.go
+++ b/internal/cmd/manager/instance/upgrade/execute/cmd.go
@@ -393,7 +393,9 @@ func prepareConfigurationFiles(ctx context.Context, cluster apiv1.Cluster, destD
 		return fmt.Errorf("appending inclusion directives to postgresql.conf file resulted in an error: %w", err)
 	}
 
-	// Set `max_slot_wal_keep_size` to the default value because any other value it is not supported in pg_upgrade
+	// Set `max_slot_wal_keep_size` to the default value because any other value causes an error
+	// during pg_upgrade in PostgreSQL 17 before 17.6. The bug has been fixed with the commit
+	// https://github.com/postgres/postgres/commit/f36e5774
 	tmpCluster := cluster.DeepCopy()
 	tmpCluster.Spec.PostgresConfiguration.Parameters["max_slot_wal_keep_size"] = "-1"
 

--- a/tests/e2e/cluster_major_upgrade_test.go
+++ b/tests/e2e/cluster_major_upgrade_test.go
@@ -103,7 +103,6 @@ var _ = Describe("Postgres Major Upgrade", Label(tests.LabelPostgresMajorUpgrade
 						"log_temp_files":              "1024",
 						"log_autovacuum_min_duration": "1000",
 						"log_replication_commands":    "on",
-						"max_slot_wal_keep_size":      "1GB",
 					},
 				},
 			},


### PR DESCRIPTION
The behavior is due to a PostgreSQL bug solved in https://github.com/postgres/postgres/commit/f36e5774.
We kept the workaround for PostgreSQL 17 as upgrade target, and documented what versions contain the bug.

Closes #7283 
