### PR TITLE
docs(cnpg-i): deprecate backup metrics and fields in `Cluster` status

### DIFF
--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -907,32 +907,32 @@ type ClusterStatus struct {
 	// The first recoverability point, stored as a date in RFC3339 format.
 	// This field is calculated from the content of FirstRecoverabilityPointByMethod.
 	//
-	// Deprecated: the field is not set for backup plugins. In-tree backup will be removed in 1.28.
+	// Deprecated: the field is not set for backup plugins.
 	// +optional
 	FirstRecoverabilityPoint string `json:"firstRecoverabilityPoint,omitempty"`
 
 	// The first recoverability point, stored as a date in RFC3339 format, per backup method type.
 	//
-	// Deprecated: the field is not set for backup plugins. In-tree backup will be removed in 1.28.
+	// Deprecated: the field is not set for backup plugins.
 	// +optional
 	FirstRecoverabilityPointByMethod map[BackupMethod]metav1.Time `json:"firstRecoverabilityPointByMethod,omitempty"`
 
 	// Last successful backup, stored as a date in RFC3339 format.
 	// This field is calculated from the content of LastSuccessfulBackupByMethod.
 	//
-	// Deprecated: the field is not set for backup plugins. In-tree backup will be removed in 1.28.
+	// Deprecated: the field is not set for backup plugins.
 	// +optional
 	LastSuccessfulBackup string `json:"lastSuccessfulBackup,omitempty"`
 
 	// Last successful backup, stored as a date in RFC3339 format, per backup method type.
 	//
-	// Deprecated: the field is not set for backup plugins. In-tree backup will be removed in 1.28.
+	// Deprecated: the field is not set for backup plugins.
 	// +optional
 	LastSuccessfulBackupByMethod map[BackupMethod]metav1.Time `json:"lastSuccessfulBackupByMethod,omitempty"`
 
 	// Last failed backup, stored as a date in RFC3339 format.
 	//
-	// Deprecated: the field is not set for backup plugins. In-tree backup will be removed in 1.28.
+	// Deprecated: the field is not set for backup plugins.
 	// +optional
 	LastFailedBackup string `json:"lastFailedBackup,omitempty"`
 

--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -905,24 +905,24 @@ type ClusterStatus struct {
 	Certificates CertificatesStatus `json:"certificates,omitempty"`
 
 	// The first recoverability point, stored as a date in RFC3339 format.
-	// This field is calculated from the content of FirstRecoverabilityPointByMethod
+	// This field is calculated from the content of FirstRecoverabilityPointByMethod (DEPRECATED).
 	// +optional
 	FirstRecoverabilityPoint string `json:"firstRecoverabilityPoint,omitempty"`
 
-	// The first recoverability point, stored as a date in RFC3339 format, per backup method type
+	// The first recoverability point, stored as a date in RFC3339 format, per backup method type (DEPRECATED).
 	// +optional
 	FirstRecoverabilityPointByMethod map[BackupMethod]metav1.Time `json:"firstRecoverabilityPointByMethod,omitempty"`
 
-	// Last successful backup, stored as a date in RFC3339 format
-	// This field is calculated from the content of LastSuccessfulBackupByMethod
+	// Last successful backup, stored as a date in RFC3339 format.
+	// This field is calculated from the content of LastSuccessfulBackupByMethod (DEPRECATED).
 	// +optional
 	LastSuccessfulBackup string `json:"lastSuccessfulBackup,omitempty"`
 
-	// Last successful backup, stored as a date in RFC3339 format, per backup method type
+	// Last successful backup, stored as a date in RFC3339 format, per backup method type (DEPRECATED).
 	// +optional
 	LastSuccessfulBackupByMethod map[BackupMethod]metav1.Time `json:"lastSuccessfulBackupByMethod,omitempty"`
 
-	// Stored as a date in RFC3339 format
+	// Last failed backup, stored as a date in RFC3339 format (DEPRECATED).
 	// +optional
 	LastFailedBackup string `json:"lastFailedBackup,omitempty"`
 

--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -905,24 +905,34 @@ type ClusterStatus struct {
 	Certificates CertificatesStatus `json:"certificates,omitempty"`
 
 	// The first recoverability point, stored as a date in RFC3339 format.
-	// This field is calculated from the content of FirstRecoverabilityPointByMethod (DEPRECATED).
+	// This field is calculated from the content of FirstRecoverabilityPointByMethod.
+	//
+	// Deprecated: the field is not set for backup plugins. In-tree backup will be removed in 1.28.
 	// +optional
 	FirstRecoverabilityPoint string `json:"firstRecoverabilityPoint,omitempty"`
 
-	// The first recoverability point, stored as a date in RFC3339 format, per backup method type (DEPRECATED).
+	// The first recoverability point, stored as a date in RFC3339 format, per backup method type.
+	//
+	// Deprecated: the field is not set for backup plugins. In-tree backup will be removed in 1.28.
 	// +optional
 	FirstRecoverabilityPointByMethod map[BackupMethod]metav1.Time `json:"firstRecoverabilityPointByMethod,omitempty"`
 
 	// Last successful backup, stored as a date in RFC3339 format.
-	// This field is calculated from the content of LastSuccessfulBackupByMethod (DEPRECATED).
+	// This field is calculated from the content of LastSuccessfulBackupByMethod.
+	//
+	// Deprecated: the field is not set for backup plugins. In-tree backup will be removed in 1.28.
 	// +optional
 	LastSuccessfulBackup string `json:"lastSuccessfulBackup,omitempty"`
 
-	// Last successful backup, stored as a date in RFC3339 format, per backup method type (DEPRECATED).
+	// Last successful backup, stored as a date in RFC3339 format, per backup method type.
+	//
+	// Deprecated: the field is not set for backup plugins. In-tree backup will be removed in 1.28.
 	// +optional
 	LastSuccessfulBackupByMethod map[BackupMethod]metav1.Time `json:"lastSuccessfulBackupByMethod,omitempty"`
 
-	// Last failed backup, stored as a date in RFC3339 format (DEPRECATED).
+	// Last failed backup, stored as a date in RFC3339 format.
+	//
+	// Deprecated: the field is not set for backup plugins. In-tree backup will be removed in 1.28.
 	// +optional
 	LastFailedBackup string `json:"lastFailedBackup,omitempty"`
 

--- a/config/crd/bases/postgresql.cnpg.io_clusters.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_clusters.yaml
@@ -6110,14 +6110,18 @@ spec:
               firstRecoverabilityPoint:
                 description: |-
                   The first recoverability point, stored as a date in RFC3339 format.
-                  This field is calculated from the content of FirstRecoverabilityPointByMethod (DEPRECATED).
+                  This field is calculated from the content of FirstRecoverabilityPointByMethod.
+
+                  Deprecated: the field is not set for backup plugins. In-tree backup will be removed in 1.28.
                 type: string
               firstRecoverabilityPointByMethod:
                 additionalProperties:
                   format: date-time
                   type: string
-                description: The first recoverability point, stored as a date in RFC3339
-                  format, per backup method type (DEPRECATED).
+                description: |-
+                  The first recoverability point, stored as a date in RFC3339 format, per backup method type.
+
+                  Deprecated: the field is not set for backup plugins. In-tree backup will be removed in 1.28.
                 type: object
               healthyPVC:
                 description: List of all the PVCs not dangling nor initializing
@@ -6175,8 +6179,10 @@ spec:
                 format: int32
                 type: integer
               lastFailedBackup:
-                description: Last failed backup, stored as a date in RFC3339 format
-                  (DEPRECATED).
+                description: |-
+                  Last failed backup, stored as a date in RFC3339 format.
+
+                  Deprecated: the field is not set for backup plugins. In-tree backup will be removed in 1.28.
                 type: string
               lastPromotionToken:
                 description: |-
@@ -6186,14 +6192,18 @@ spec:
               lastSuccessfulBackup:
                 description: |-
                   Last successful backup, stored as a date in RFC3339 format.
-                  This field is calculated from the content of LastSuccessfulBackupByMethod (DEPRECATED).
+                  This field is calculated from the content of LastSuccessfulBackupByMethod.
+
+                  Deprecated: the field is not set for backup plugins. In-tree backup will be removed in 1.28.
                 type: string
               lastSuccessfulBackupByMethod:
                 additionalProperties:
                   format: date-time
                   type: string
-                description: Last successful backup, stored as a date in RFC3339 format,
-                  per backup method type (DEPRECATED).
+                description: |-
+                  Last successful backup, stored as a date in RFC3339 format, per backup method type.
+
+                  Deprecated: the field is not set for backup plugins. In-tree backup will be removed in 1.28.
                 type: object
               latestGeneratedNode:
                 description: ID of the latest generated node (used to avoid node name

--- a/config/crd/bases/postgresql.cnpg.io_clusters.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_clusters.yaml
@@ -6112,7 +6112,7 @@ spec:
                   The first recoverability point, stored as a date in RFC3339 format.
                   This field is calculated from the content of FirstRecoverabilityPointByMethod.
 
-                  Deprecated: the field is not set for backup plugins. In-tree backup will be removed in 1.28.
+                  Deprecated: the field is not set for backup plugins.
                 type: string
               firstRecoverabilityPointByMethod:
                 additionalProperties:
@@ -6121,7 +6121,7 @@ spec:
                 description: |-
                   The first recoverability point, stored as a date in RFC3339 format, per backup method type.
 
-                  Deprecated: the field is not set for backup plugins. In-tree backup will be removed in 1.28.
+                  Deprecated: the field is not set for backup plugins.
                 type: object
               healthyPVC:
                 description: List of all the PVCs not dangling nor initializing
@@ -6182,7 +6182,7 @@ spec:
                 description: |-
                   Last failed backup, stored as a date in RFC3339 format.
 
-                  Deprecated: the field is not set for backup plugins. In-tree backup will be removed in 1.28.
+                  Deprecated: the field is not set for backup plugins.
                 type: string
               lastPromotionToken:
                 description: |-
@@ -6194,7 +6194,7 @@ spec:
                   Last successful backup, stored as a date in RFC3339 format.
                   This field is calculated from the content of LastSuccessfulBackupByMethod.
 
-                  Deprecated: the field is not set for backup plugins. In-tree backup will be removed in 1.28.
+                  Deprecated: the field is not set for backup plugins.
                 type: string
               lastSuccessfulBackupByMethod:
                 additionalProperties:
@@ -6203,7 +6203,7 @@ spec:
                 description: |-
                   Last successful backup, stored as a date in RFC3339 format, per backup method type.
 
-                  Deprecated: the field is not set for backup plugins. In-tree backup will be removed in 1.28.
+                  Deprecated: the field is not set for backup plugins.
                 type: object
               latestGeneratedNode:
                 description: ID of the latest generated node (used to avoid node name

--- a/config/crd/bases/postgresql.cnpg.io_clusters.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_clusters.yaml
@@ -6110,14 +6110,14 @@ spec:
               firstRecoverabilityPoint:
                 description: |-
                   The first recoverability point, stored as a date in RFC3339 format.
-                  This field is calculated from the content of FirstRecoverabilityPointByMethod
+                  This field is calculated from the content of FirstRecoverabilityPointByMethod (DEPRECATED).
                 type: string
               firstRecoverabilityPointByMethod:
                 additionalProperties:
                   format: date-time
                   type: string
                 description: The first recoverability point, stored as a date in RFC3339
-                  format, per backup method type
+                  format, per backup method type (DEPRECATED).
                 type: object
               healthyPVC:
                 description: List of all the PVCs not dangling nor initializing
@@ -6175,7 +6175,8 @@ spec:
                 format: int32
                 type: integer
               lastFailedBackup:
-                description: Stored as a date in RFC3339 format
+                description: Last failed backup, stored as a date in RFC3339 format
+                  (DEPRECATED).
                 type: string
               lastPromotionToken:
                 description: |-
@@ -6184,15 +6185,15 @@ spec:
                 type: string
               lastSuccessfulBackup:
                 description: |-
-                  Last successful backup, stored as a date in RFC3339 format
-                  This field is calculated from the content of LastSuccessfulBackupByMethod
+                  Last successful backup, stored as a date in RFC3339 format.
+                  This field is calculated from the content of LastSuccessfulBackupByMethod (DEPRECATED).
                 type: string
               lastSuccessfulBackupByMethod:
                 additionalProperties:
                   format: date-time
                   type: string
                 description: Last successful backup, stored as a date in RFC3339 format,
-                  per backup method type
+                  per backup method type (DEPRECATED).
                 type: object
               latestGeneratedNode:
                 description: ID of the latest generated node (used to avoid node name

--- a/docs/src/cloudnative-pg.v1.md
+++ b/docs/src/cloudnative-pg.v1.md
@@ -2148,14 +2148,16 @@ configmap data</p>
 </td>
 <td>
    <p>The first recoverability point, stored as a date in RFC3339 format.
-This field is calculated from the content of FirstRecoverabilityPointByMethod (DEPRECATED).</p>
+This field is calculated from the content of FirstRecoverabilityPointByMethod.</p>
+<p>Deprecated: the field is not set for backup plugins. In-tree backup will be removed in 1.28.</p>
 </td>
 </tr>
 <tr><td><code>firstRecoverabilityPointByMethod</code><br/>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta"><i>map[BackupMethod]meta/v1.Time</i></a>
 </td>
 <td>
-   <p>The first recoverability point, stored as a date in RFC3339 format, per backup method type (DEPRECATED).</p>
+   <p>The first recoverability point, stored as a date in RFC3339 format, per backup method type.</p>
+<p>Deprecated: the field is not set for backup plugins. In-tree backup will be removed in 1.28.</p>
 </td>
 </tr>
 <tr><td><code>lastSuccessfulBackup</code><br/>
@@ -2163,21 +2165,24 @@ This field is calculated from the content of FirstRecoverabilityPointByMethod (D
 </td>
 <td>
    <p>Last successful backup, stored as a date in RFC3339 format.
-This field is calculated from the content of LastSuccessfulBackupByMethod (DEPRECATED).</p>
+This field is calculated from the content of LastSuccessfulBackupByMethod.</p>
+<p>Deprecated: the field is not set for backup plugins. In-tree backup will be removed in 1.28.</p>
 </td>
 </tr>
 <tr><td><code>lastSuccessfulBackupByMethod</code><br/>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta"><i>map[BackupMethod]meta/v1.Time</i></a>
 </td>
 <td>
-   <p>Last successful backup, stored as a date in RFC3339 format, per backup method type (DEPRECATED).</p>
+   <p>Last successful backup, stored as a date in RFC3339 format, per backup method type.</p>
+<p>Deprecated: the field is not set for backup plugins. In-tree backup will be removed in 1.28.</p>
 </td>
 </tr>
 <tr><td><code>lastFailedBackup</code><br/>
 <i>string</i>
 </td>
 <td>
-   <p>Last failed backup, stored as a date in RFC3339 format (DEPRECATED).</p>
+   <p>Last failed backup, stored as a date in RFC3339 format.</p>
+<p>Deprecated: the field is not set for backup plugins. In-tree backup will be removed in 1.28.</p>
 </td>
 </tr>
 <tr><td><code>cloudNativePGCommitHash</code><br/>

--- a/docs/src/cloudnative-pg.v1.md
+++ b/docs/src/cloudnative-pg.v1.md
@@ -2148,36 +2148,36 @@ configmap data</p>
 </td>
 <td>
    <p>The first recoverability point, stored as a date in RFC3339 format.
-This field is calculated from the content of FirstRecoverabilityPointByMethod</p>
+This field is calculated from the content of FirstRecoverabilityPointByMethod (DEPRECATED).</p>
 </td>
 </tr>
 <tr><td><code>firstRecoverabilityPointByMethod</code><br/>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta"><i>map[BackupMethod]meta/v1.Time</i></a>
 </td>
 <td>
-   <p>The first recoverability point, stored as a date in RFC3339 format, per backup method type</p>
+   <p>The first recoverability point, stored as a date in RFC3339 format, per backup method type (DEPRECATED).</p>
 </td>
 </tr>
 <tr><td><code>lastSuccessfulBackup</code><br/>
 <i>string</i>
 </td>
 <td>
-   <p>Last successful backup, stored as a date in RFC3339 format
-This field is calculated from the content of LastSuccessfulBackupByMethod</p>
+   <p>Last successful backup, stored as a date in RFC3339 format.
+This field is calculated from the content of LastSuccessfulBackupByMethod (DEPRECATED).</p>
 </td>
 </tr>
 <tr><td><code>lastSuccessfulBackupByMethod</code><br/>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta"><i>map[BackupMethod]meta/v1.Time</i></a>
 </td>
 <td>
-   <p>Last successful backup, stored as a date in RFC3339 format, per backup method type</p>
+   <p>Last successful backup, stored as a date in RFC3339 format, per backup method type (DEPRECATED).</p>
 </td>
 </tr>
 <tr><td><code>lastFailedBackup</code><br/>
 <i>string</i>
 </td>
 <td>
-   <p>Stored as a date in RFC3339 format</p>
+   <p>Last failed backup, stored as a date in RFC3339 format (DEPRECATED).</p>
 </td>
 </tr>
 <tr><td><code>cloudNativePGCommitHash</code><br/>

--- a/docs/src/cloudnative-pg.v1.md
+++ b/docs/src/cloudnative-pg.v1.md
@@ -2149,7 +2149,7 @@ configmap data</p>
 <td>
    <p>The first recoverability point, stored as a date in RFC3339 format.
 This field is calculated from the content of FirstRecoverabilityPointByMethod.</p>
-<p>Deprecated: the field is not set for backup plugins. In-tree backup will be removed in 1.28.</p>
+<p>Deprecated: the field is not set for backup plugins.</p>
 </td>
 </tr>
 <tr><td><code>firstRecoverabilityPointByMethod</code><br/>
@@ -2157,7 +2157,7 @@ This field is calculated from the content of FirstRecoverabilityPointByMethod.</
 </td>
 <td>
    <p>The first recoverability point, stored as a date in RFC3339 format, per backup method type.</p>
-<p>Deprecated: the field is not set for backup plugins. In-tree backup will be removed in 1.28.</p>
+<p>Deprecated: the field is not set for backup plugins.</p>
 </td>
 </tr>
 <tr><td><code>lastSuccessfulBackup</code><br/>
@@ -2166,7 +2166,7 @@ This field is calculated from the content of FirstRecoverabilityPointByMethod.</
 <td>
    <p>Last successful backup, stored as a date in RFC3339 format.
 This field is calculated from the content of LastSuccessfulBackupByMethod.</p>
-<p>Deprecated: the field is not set for backup plugins. In-tree backup will be removed in 1.28.</p>
+<p>Deprecated: the field is not set for backup plugins.</p>
 </td>
 </tr>
 <tr><td><code>lastSuccessfulBackupByMethod</code><br/>
@@ -2174,7 +2174,7 @@ This field is calculated from the content of LastSuccessfulBackupByMethod.</p>
 </td>
 <td>
    <p>Last successful backup, stored as a date in RFC3339 format, per backup method type.</p>
-<p>Deprecated: the field is not set for backup plugins. In-tree backup will be removed in 1.28.</p>
+<p>Deprecated: the field is not set for backup plugins.</p>
 </td>
 </tr>
 <tr><td><code>lastFailedBackup</code><br/>
@@ -2182,7 +2182,7 @@ This field is calculated from the content of LastSuccessfulBackupByMethod.</p>
 </td>
 <td>
    <p>Last failed backup, stored as a date in RFC3339 format.</p>
-<p>Deprecated: the field is not set for backup plugins. In-tree backup will be removed in 1.28.</p>
+<p>Deprecated: the field is not set for backup plugins.</p>
 </td>
 </tr>
 <tr><td><code>cloudNativePGCommitHash</code><br/>

--- a/docs/src/installation_upgrade.md
+++ b/docs/src/installation_upgrade.md
@@ -293,6 +293,41 @@ spec:
     even if in-place updates are enabled (`ENABLE_INSTANCE_MANAGER_INPLACE_UPDATES=true`).
     Your applications will need to reconnect to PostgreSQL after the upgrade.
 
+#### Deprecation of backup fields in the `Cluster` `.status`
+
+With the transition to a backup and recovery agnostic approach based on CNPG-I
+plugins in CloudNativePG, which began with version 1.26.0 for Barman Cloud, we
+are starting the deprecation period for the following fields in the `.status`
+section of the `Cluster` resource:
+
+- `firstRecoverabilityPoint`
+- `firstRecoverabilityPointByMethod`
+- `lastSuccessfulBackup`
+- `lastSuccessfulBackupByMethod`
+- `lastFailedBackup`
+
+!!! Warning
+    If you have migrated to a plugin-based backup and recovery solution such as
+    Barman Cloud, these fields are no longer synchronized and will not be updated.
+    Users still relying on the in-core support for Barman Cloud and volume
+    snapshots can continue to use these fields for the time being.
+
+Under the new plugin-based approach, multiple backup methods can operate
+simultaneously, each with its own timeline for backup and recovery. For
+example, some plugins may provide snapshots without WAL archiving, while others
+support continuous archiving.
+
+Because of this flexibility, maintaining centralized status fields in the
+`Cluster` resource could be misleading or confusing, as they would not
+accurately represent the state across all configured backup methods.
+For this reason, these fields are being deprecated.
+
+Instead, each plugin is responsible for exposing its own backup status
+information and providing metrics back to the instance manager for monitoring
+and operational awareness.
+
+#### Declarative Hibernation in the `cnpg` plugin
+
 In this release, the `cnpg` plugin for `kubectl` transitions from an imperative
 to a [declarative approach for cluster hibernation](declarative_hibernation.md).
 The `hibernate on` and `hibernate off` commands are now convenient shortcuts

--- a/docs/src/installation_upgrade.md
+++ b/docs/src/installation_upgrade.md
@@ -293,7 +293,7 @@ spec:
     even if in-place updates are enabled (`ENABLE_INSTANCE_MANAGER_INPLACE_UPDATES=true`).
     Your applications will need to reconnect to PostgreSQL after the upgrade.
 
-#### Deprecation of backup fields in the `Cluster` `.status`
+#### Deprecation of backup metrics and fields in the `Cluster` `.status`
 
 With the transition to a backup and recovery agnostic approach based on CNPG-I
 plugins in CloudNativePG, which began with version 1.26.0 for Barman Cloud, we
@@ -306,11 +306,17 @@ section of the `Cluster` resource:
 - `lastSuccessfulBackupByMethod`
 - `lastFailedBackup`
 
+The following Prometheus metrics are also deprecated:
+
+- `cnpg_collector_first_recoverability_point`
+- `cnpg_collector_last_failed_backup_timestamp`
+- `cnpg_collector_last_available_backup_timestamp`
+
 !!! Warning
     If you have migrated to a plugin-based backup and recovery solution such as
-    Barman Cloud, these fields are no longer synchronized and will not be updated.
-    Users still relying on the in-core support for Barman Cloud and volume
-    snapshots can continue to use these fields for the time being.
+    Barman Cloud, these fields and metrics are no longer synchronized and will
+    not be updated. Users still relying on the in-core support for Barman Cloud
+    and volume snapshots can continue to use these fields for the time being.
 
 Under the new plugin-based approach, multiple backup methods can operate
 simultaneously, each with its own timeline for backup and recovery. For

--- a/docs/src/monitoring.md
+++ b/docs/src/monitoring.md
@@ -220,15 +220,15 @@ cnpg_collector_up{cluster="cluster-example"} 1
 # TYPE cnpg_collector_postgres_version gauge
 cnpg_collector_postgres_version{cluster="cluster-example",full="17.5"} 17.5
 
-# HELP cnpg_collector_last_failed_backup_timestamp The last failed backup as a unix timestamp
+# HELP cnpg_collector_last_failed_backup_timestamp The last failed backup as a unix timestamp (Deprecated)
 # TYPE cnpg_collector_last_failed_backup_timestamp gauge
 cnpg_collector_last_failed_backup_timestamp 0
 
-# HELP cnpg_collector_last_available_backup_timestamp The last available backup as a unix timestamp
+# HELP cnpg_collector_last_available_backup_timestamp The last available backup as a unix timestamp (Deprecated)
 # TYPE cnpg_collector_last_available_backup_timestamp gauge
 cnpg_collector_last_available_backup_timestamp 1.63238406e+09
 
-# HELP cnpg_collector_first_recoverability_point The first point of recoverability for the cluster as a unix timestamp
+# HELP cnpg_collector_first_recoverability_point The first point of recoverability for the cluster as a unix timestamp (Deprecated)
 # TYPE cnpg_collector_first_recoverability_point gauge
 cnpg_collector_first_recoverability_point 1.63238406e+09
 
@@ -398,9 +398,16 @@ go_threads 18
     `Major.Minor.Patch` can be found inside one of its label field
     named `full`.
 
-!!! Note
-    `cnpg_collector_first_recoverability_point` and `cnpg_collector_last_available_backup_timestamp`
-    will be zero until your first backup to the object store. This is separate from the WAL archival.
+!!! Warning
+    The metrics `cnpg_collector_last_failed_backup_timestamp`,
+    `cnpg_collector_last_available_backup_timestamp`, and
+    `cnpg_collector_first_recoverability_point` have been deprecated starting
+    from version 1.26. These metrics will continue to function with native backup
+    solutions such as in-core Barman Cloud (deprecated) and volume snapshots. Note
+    that for these cases, `cnpg_collector_first_recoverability_point` and
+    `cnpg_collector_last_available_backup_timestamp` will remain zero until the
+    first backup is completed to the object store. This is separate from WAL
+    archiving.
 
 ### User defined metrics
 

--- a/docs/src/troubleshooting.md
+++ b/docs/src/troubleshooting.md
@@ -60,17 +60,6 @@ Please refer to the [plugin document](kubectl-plugin.md) for complete instructio
 After getting the cluster manifest with the plugin, you should verify if backups
 are set up and working.
 
-In a cluster with backups set up, you will find, in the cluster Status, the fields
-`lastSuccessfulBackup` and `firstRecoverabilityPoint`. You should make sure
-there is a recent `lastSuccessfulBackup`.
-
-A cluster lacking the `.spec.backup` stanza won't have backups. 
-An insistent message will appear in the PostgreSQL logs:
-
-```
-Backup not configured, skip WAL archiving.
-```
-
 Before proceeding with troubleshooting operations, it may be advisable
 to perform an emergency backup depending on your findings regarding backups.
 Refer to the following section for instructions.

--- a/internal/cmd/plugin/status/status.go
+++ b/internal/cmd/plugin/status/status.go
@@ -520,7 +520,7 @@ func (fullStatus *PostgresqlStatus) printBackupStatus() {
 		return
 	}
 	status := tabby.New()
-	FPoR := cluster.Status.FirstRecoverabilityPoint
+	FPoR := cluster.Status.FirstRecoverabilityPoint //nolint:staticcheck
 	if FPoR == "" {
 		FPoR = "Not Available"
 	}

--- a/internal/controller/backup_controller_test.go
+++ b/internal/controller/backup_controller_test.go
@@ -336,9 +336,13 @@ var _ = Describe("update snapshot backup metadata", func() {
 	})
 
 	It("should update cluster with no metadata", func(ctx context.Context) {
+		//nolint:staticcheck
 		Expect(cluster.Status.FirstRecoverabilityPoint).To(BeEmpty())
+		//nolint:staticcheck
 		Expect(cluster.Status.FirstRecoverabilityPointByMethod).To(BeEmpty())
+		//nolint:staticcheck
 		Expect(cluster.Status.LastSuccessfulBackup).To(BeEmpty())
+		//nolint:staticcheck
 		Expect(cluster.Status.LastSuccessfulBackupByMethod).To(BeEmpty())
 		fakeClient := fake.NewClientBuilder().WithScheme(schemeBuilder.BuildWithAllKnownScheme()).
 			WithObjects(cluster).
@@ -354,24 +358,34 @@ var _ = Describe("update snapshot backup metadata", func() {
 			Name:      cluster.Name,
 		}, &updatedCluster)
 		Expect(err).ToNot(HaveOccurred())
+		//nolint:staticcheck
 		Expect(updatedCluster.Status.FirstRecoverabilityPoint).To(Equal(twoHoursAgo.Format(time.RFC3339)))
+		//nolint:staticcheck
 		Expect(updatedCluster.Status.FirstRecoverabilityPointByMethod).
 			ToNot(HaveKey(apiv1.BackupMethodBarmanObjectStore))
+		//nolint:staticcheck
 		Expect(updatedCluster.Status.FirstRecoverabilityPointByMethod[apiv1.BackupMethodVolumeSnapshot]).
 			To(Equal(twoHoursAgo))
+		//nolint:staticcheck
 		Expect(updatedCluster.Status.LastSuccessfulBackup).To(Equal(oneHourAgo.Format(time.RFC3339)))
+		//nolint:staticcheck
 		Expect(updatedCluster.Status.LastSuccessfulBackupByMethod).
 			ToNot(HaveKey(apiv1.BackupMethodBarmanObjectStore))
+		//nolint:staticcheck
 		Expect(updatedCluster.Status.LastSuccessfulBackupByMethod[apiv1.BackupMethodVolumeSnapshot]).
 			To(Equal(oneHourAgo))
 	})
 
 	It("should consider other methods when update the metadata", func(ctx context.Context) {
+		//nolint:staticcheck
 		cluster.Status.FirstRecoverabilityPoint = threeHoursAgo.Format(time.RFC3339)
+		//nolint:staticcheck
 		cluster.Status.FirstRecoverabilityPointByMethod = map[apiv1.BackupMethod]metav1.Time{
 			apiv1.BackupMethodBarmanObjectStore: threeHoursAgo,
 		}
+		//nolint:staticcheck
 		cluster.Status.LastSuccessfulBackup = now.Format(time.RFC3339)
+		//nolint:staticcheck
 		cluster.Status.LastSuccessfulBackupByMethod = map[apiv1.BackupMethod]metav1.Time{
 			apiv1.BackupMethodBarmanObjectStore: now,
 		}
@@ -389,25 +403,35 @@ var _ = Describe("update snapshot backup metadata", func() {
 			Name:      cluster.Name,
 		}, &updatedCluster)
 		Expect(err).ToNot(HaveOccurred())
+		//nolint:staticcheck
 		Expect(updatedCluster.Status.FirstRecoverabilityPoint).To(Equal(threeHoursAgo.Format(time.RFC3339)))
+		//nolint:staticcheck
 		Expect(updatedCluster.Status.FirstRecoverabilityPointByMethod[apiv1.BackupMethodBarmanObjectStore]).
 			To(Equal(threeHoursAgo))
+		//nolint:staticcheck
 		Expect(updatedCluster.Status.FirstRecoverabilityPointByMethod[apiv1.BackupMethodVolumeSnapshot]).
 			To(Equal(twoHoursAgo))
+		//nolint:staticcheck
 		Expect(updatedCluster.Status.LastSuccessfulBackup).To(Equal(now.Format(time.RFC3339)))
+		//nolint:staticcheck
 		Expect(updatedCluster.Status.LastSuccessfulBackupByMethod[apiv1.BackupMethodBarmanObjectStore]).
 			To(Equal(now))
+		//nolint:staticcheck
 		Expect(updatedCluster.Status.LastSuccessfulBackupByMethod[apiv1.BackupMethodVolumeSnapshot]).
 			To(Equal(oneHourAgo))
 	})
 
 	It("should override other method metadata when appropriate", func(ctx context.Context) {
+		//nolint:staticcheck
 		cluster.Status.FirstRecoverabilityPoint = oneHourAgo.Format(time.RFC3339)
+		//nolint:staticcheck
 		cluster.Status.FirstRecoverabilityPointByMethod = map[apiv1.BackupMethod]metav1.Time{
 			apiv1.BackupMethodBarmanObjectStore: oneHourAgo,
 			apiv1.BackupMethodVolumeSnapshot:    now,
 		}
+		//nolint:staticcheck
 		cluster.Status.LastSuccessfulBackup = oneHourAgo.Format(time.RFC3339)
+		//nolint:staticcheck
 		cluster.Status.LastSuccessfulBackupByMethod = map[apiv1.BackupMethod]metav1.Time{
 			apiv1.BackupMethodBarmanObjectStore: twoHoursAgo,
 			apiv1.BackupMethodVolumeSnapshot:    threeHoursAgo,
@@ -426,14 +450,20 @@ var _ = Describe("update snapshot backup metadata", func() {
 			Name:      cluster.Name,
 		}, &updatedCluster)
 		Expect(err).ToNot(HaveOccurred())
+		//nolint:staticcheck
 		Expect(updatedCluster.Status.FirstRecoverabilityPoint).To(Equal(twoHoursAgo.Format(time.RFC3339)))
+		//nolint:staticcheck
 		Expect(updatedCluster.Status.FirstRecoverabilityPointByMethod[apiv1.BackupMethodBarmanObjectStore]).
 			To(Equal(oneHourAgo))
+		//nolint:staticcheck
 		Expect(updatedCluster.Status.FirstRecoverabilityPointByMethod[apiv1.BackupMethodVolumeSnapshot]).
 			To(Equal(twoHoursAgo))
+		//nolint:staticcheck
 		Expect(updatedCluster.Status.LastSuccessfulBackup).To(Equal(oneHourAgo.Format(time.RFC3339)))
+		//nolint:staticcheck
 		Expect(updatedCluster.Status.LastSuccessfulBackupByMethod[apiv1.BackupMethodBarmanObjectStore]).
 			To(Equal(twoHoursAgo))
+		//nolint:staticcheck
 		Expect(updatedCluster.Status.LastSuccessfulBackupByMethod[apiv1.BackupMethodVolumeSnapshot]).
 			To(Equal(oneHourAgo))
 	})

--- a/pkg/management/postgres/backup_test.go
+++ b/pkg/management/postgres/backup_test.go
@@ -136,7 +136,7 @@ var _ = Describe("testing backup command", func() {
 
 	It("should fail and update cluster and backup resource", func() {
 		backupCommand.run(context.Background())
-		Expect(cluster.Status.LastFailedBackup).ToNot(BeEmpty())
+		Expect(cluster.Status.LastFailedBackup).ToNot(BeEmpty()) //nolint:staticcheck
 
 		clusterCond := meta.FindStatusCondition(cluster.Status.Conditions, string(apiv1.ConditionBackup))
 		Expect(clusterCond.Status).To(Equal(metav1.ConditionFalse))

--- a/pkg/management/postgres/webserver/metricserver/pg_collector.go
+++ b/pkg/management/postgres/webserver/metricserver/pg_collector.go
@@ -176,19 +176,20 @@ func newMetrics() *metrics {
 			Namespace: PrometheusNamespace,
 			Subsystem: subsystem,
 			Name:      "first_recoverability_point",
-			Help:      "The first point of recoverability for the cluster as a unix timestamp",
+			Help:      "The first point of recoverability for the cluster as a unix timestamp"+
+				" (Deprecated)",
 		}),
 		LastAvailableBackupTimestamp: prometheus.NewGauge(prometheus.GaugeOpts{
 			Namespace: PrometheusNamespace,
 			Subsystem: subsystem,
 			Name:      "last_available_backup_timestamp",
-			Help:      "The last available backup as a unix timestamp",
+			Help:      "The last available backup as a unix timestamp (Deprecated)",
 		}),
 		LastFailedBackupTimestamp: prometheus.NewGauge(prometheus.GaugeOpts{
 			Namespace: PrometheusNamespace,
 			Subsystem: subsystem,
 			Name:      "last_failed_backup_timestamp",
-			Help:      "The last failed backup as a unix timestamp",
+			Help:      "The last failed backup as a unix timestamp (Deprecated)",
 		}),
 		FencingOn: prometheus.NewGauge(prometheus.GaugeOpts{
 			Namespace: PrometheusNamespace,

--- a/pkg/management/postgres/webserver/metricserver/pg_collector.go
+++ b/pkg/management/postgres/webserver/metricserver/pg_collector.go
@@ -176,7 +176,7 @@ func newMetrics() *metrics {
 			Namespace: PrometheusNamespace,
 			Subsystem: subsystem,
 			Name:      "first_recoverability_point",
-			Help:      "The first point of recoverability for the cluster as a unix timestamp"+
+			Help: "The first point of recoverability for the cluster as a unix timestamp" +
 				" (Deprecated)",
 		}),
 		LastAvailableBackupTimestamp: prometheus.NewGauge(prometheus.GaugeOpts{
@@ -507,21 +507,21 @@ func (e *Exporter) collectNodesUsed() {
 func (e *Exporter) collectFromPrimaryLastFailedBackupTimestamp() {
 	const errorLabel = "Collect.LastFailedBackupTimestamp"
 	e.setTimestampMetric(e.Metrics.LastFailedBackupTimestamp, errorLabel, func(cluster *apiv1.Cluster) string {
-		return cluster.Status.LastFailedBackup
+		return cluster.Status.LastFailedBackup //nolint:staticcheck
 	})
 }
 
 func (e *Exporter) collectFromPrimaryLastAvailableBackupTimestamp() {
 	const errorLabel = "Collect.LastAvailableBackupTimestamp"
 	e.setTimestampMetric(e.Metrics.LastAvailableBackupTimestamp, errorLabel, func(cluster *apiv1.Cluster) string {
-		return cluster.Status.LastSuccessfulBackup
+		return cluster.Status.LastSuccessfulBackup //nolint:staticcheck
 	})
 }
 
 func (e *Exporter) collectFromPrimaryFirstPointOnTimeRecovery() {
 	const errorLabel = "Collect.FirstRecoverabilityPoint"
 	e.setTimestampMetric(e.Metrics.FirstRecoverabilityPoint, errorLabel, func(cluster *apiv1.Cluster) string {
-		return cluster.Status.FirstRecoverabilityPoint
+		return cluster.Status.FirstRecoverabilityPoint //nolint:staticcheck
 	})
 }
 

--- a/pkg/resources/status/backup.go
+++ b/pkg/resources/status/backup.go
@@ -113,7 +113,7 @@ func FlagBackupAsFailed(
 		cli,
 		cluster,
 		func(cluster *apiv1.Cluster) {
-			cluster.Status.LastFailedBackup = pgTime.GetCurrentTimestampWithFormat(time.RFC3339)
+			cluster.Status.LastFailedBackup = pgTime.GetCurrentTimestampWithFormat(time.RFC3339) //nolint:staticcheck
 		},
 	); err != nil {
 		contextLogger.Error(err, "while patching cluster status with last failed backup")

--- a/pkg/resources/status/backup_test.go
+++ b/pkg/resources/status/backup_test.go
@@ -71,7 +71,7 @@ var _ = Describe("FlagBackupAsFailed", func() {
 		Expect(backup.Status.Error).To(BeEquivalentTo("my sample error"))
 
 		// Cluster status assertions
-		Expect(cluster.Status.LastFailedBackup).ToNot(BeEmpty())
+		Expect(cluster.Status.LastFailedBackup).ToNot(BeEmpty()) //nolint:staticcheck
 		for _, condition := range cluster.Status.Conditions {
 			if condition.Type == string(apiv1.ConditionBackup) {
 				Expect(condition.Status).To(BeEquivalentTo(metav1.ConditionFalse))

--- a/tests/e2e/backup_restore_azure_test.go
+++ b/tests/e2e/backup_restore_azure_test.go
@@ -118,7 +118,7 @@ var _ = Describe("Azure - Backup and restore", Label(tests.LabelBackupRestore), 
 				}, 30).Should(BeNumerically(">=", 1))
 				Eventually(func() (string, error) {
 					cluster, err := clusterutils.Get(env.Ctx, env.Client, namespace, clusterName)
-					return cluster.Status.FirstRecoverabilityPoint, err
+					return cluster.Status.FirstRecoverabilityPoint, err //nolint:staticcheck
 				}, 30).ShouldNot(BeEmpty())
 			})
 
@@ -485,7 +485,7 @@ func prepareClusterForPITROnAzureBlob(
 		Eventually(func(g Gomega) {
 			cluster, err := clusterutils.Get(env.Ctx, env.Client, namespace, clusterName)
 			g.Expect(err).ToNot(HaveOccurred())
-			g.Expect(cluster.Status.FirstRecoverabilityPoint).ToNot(BeEmpty())
+			g.Expect(cluster.Status.FirstRecoverabilityPoint).ToNot(BeEmpty()) //nolint:staticcheck
 		}, 30).Should(Succeed())
 	})
 

--- a/tests/e2e/backup_restore_azurite_test.go
+++ b/tests/e2e/backup_restore_azurite_test.go
@@ -298,7 +298,7 @@ func prepareClusterBackupOnAzurite(
 		Eventually(func(g Gomega) {
 			cluster, err := clusterutils.Get(env.Ctx, env.Client, namespace, clusterName)
 			g.Expect(err).ToNot(HaveOccurred())
-			g.Expect(cluster.Status.FirstRecoverabilityPoint).ToNot(BeEmpty())
+			g.Expect(cluster.Status.FirstRecoverabilityPoint).ToNot(BeEmpty()) //nolint:staticcheck
 		}, 30).Should(Succeed())
 	})
 	backups.AssertBackupConditionInClusterStatus(env.Ctx, env.Client, namespace, clusterName)
@@ -324,7 +324,7 @@ func prepareClusterForPITROnAzurite(
 		Eventually(func(g Gomega) {
 			cluster, err := clusterutils.Get(env.Ctx, env.Client, namespace, clusterName)
 			g.Expect(err).ToNot(HaveOccurred())
-			g.Expect(cluster.Status.FirstRecoverabilityPoint).ToNot(BeEmpty())
+			g.Expect(cluster.Status.FirstRecoverabilityPoint).ToNot(BeEmpty()) //nolint:staticcheck
 		}, 30).Should(Succeed())
 	})
 

--- a/tests/e2e/backup_restore_minio_test.go
+++ b/tests/e2e/backup_restore_minio_test.go
@@ -160,21 +160,21 @@ var _ = Describe("MinIO - Backup and restore", Label(tests.LabelBackupRestore), 
 						if err != nil {
 							return "", err
 						}
-						return cluster.Status.FirstRecoverabilityPoint, err
+						return cluster.Status.FirstRecoverabilityPoint, err //nolint:staticcheck
 					}, 30).ShouldNot(BeEmpty())
 					Eventually(func() (string, error) {
 						cluster, err := clusterutils.Get(env.Ctx, env.Client, namespace, clusterName)
 						if err != nil {
 							return "", err
 						}
-						return cluster.Status.LastSuccessfulBackup, err
+						return cluster.Status.LastSuccessfulBackup, err //nolint:staticcheck
 					}, 30).ShouldNot(BeEmpty())
 					Eventually(func() (string, error) {
 						cluster, err := clusterutils.Get(env.Ctx, env.Client, namespace, clusterName)
 						if err != nil {
 							return "", err
 						}
-						return cluster.Status.LastFailedBackup, err
+						return cluster.Status.LastFailedBackup, err //nolint:staticcheck
 					}, 30).Should(BeEmpty())
 				})
 
@@ -321,7 +321,7 @@ var _ = Describe("MinIO - Backup and restore", Label(tests.LabelBackupRestore), 
 				}, 60).Should(BeEquivalentTo(1))
 				Eventually(func() (string, error) {
 					cluster, err := clusterutils.Get(env.Ctx, env.Client, namespace, targetClusterName)
-					return cluster.Status.FirstRecoverabilityPoint, err
+					return cluster.Status.FirstRecoverabilityPoint, err //nolint:staticcheck
 				}, 30).ShouldNot(BeEmpty())
 			})
 		})
@@ -375,7 +375,7 @@ var _ = Describe("MinIO - Backup and restore", Label(tests.LabelBackupRestore), 
 				}, 60).Should(BeEquivalentTo(1))
 				Eventually(func() (string, error) {
 					cluster, err := clusterutils.Get(env.Ctx, env.Client, namespace, targetClusterName)
-					return cluster.Status.FirstRecoverabilityPoint, err
+					return cluster.Status.FirstRecoverabilityPoint, err //nolint:staticcheck
 				}, 30).ShouldNot(BeEmpty())
 			})
 
@@ -439,7 +439,7 @@ var _ = Describe("MinIO - Backup and restore", Label(tests.LabelBackupRestore), 
 				// this is the second backup we take on the bucket
 				Eventually(func() (string, error) {
 					cluster, err := clusterutils.Get(env.Ctx, env.Client, namespace, customClusterName)
-					return cluster.Status.FirstRecoverabilityPoint, err
+					return cluster.Status.FirstRecoverabilityPoint, err //nolint:staticcheck
 				}, 30).ShouldNot(BeEmpty())
 			})
 
@@ -660,7 +660,7 @@ var _ = Describe("MinIO - Clusters Recovery from Barman Object Store", Label(tes
 						if err != nil {
 							return "", err
 						}
-						return cluster.Status.FirstRecoverabilityPoint, err
+						return cluster.Status.FirstRecoverabilityPoint, err //nolint:staticcheck
 					}, 30).ShouldNot(BeEmpty())
 				})
 
@@ -806,7 +806,7 @@ func prepareClusterForPITROnMinio(
 		Eventually(func(g Gomega) {
 			cluster, err := clusterutils.Get(env.Ctx, env.Client, namespace, clusterName)
 			g.Expect(err).ToNot(HaveOccurred())
-			g.Expect(cluster.Status.FirstRecoverabilityPoint).ToNot(BeEmpty())
+			g.Expect(cluster.Status.FirstRecoverabilityPoint).ToNot(BeEmpty()) //nolint:staticcheck
 		}, 30).Should(Succeed())
 	})
 

--- a/tests/e2e/tablespaces_test.go
+++ b/tests/e2e/tablespaces_test.go
@@ -224,7 +224,7 @@ var _ = Describe("Tablespaces tests", Label(tests.LabelTablespaces,
 					if err != nil {
 						return "", err
 					}
-					return cluster.Status.FirstRecoverabilityPoint, err
+					return cluster.Status.FirstRecoverabilityPoint, err //nolint:staticcheck
 				}, 30).ShouldNot(BeEmpty())
 			})
 		})
@@ -316,21 +316,21 @@ var _ = Describe("Tablespaces tests", Label(tests.LabelTablespaces,
 					if err != nil {
 						return "", err
 					}
-					return cluster.Status.FirstRecoverabilityPoint, err
+					return cluster.Status.FirstRecoverabilityPoint, err //nolint:staticcheck
 				}, 30).ShouldNot(BeEmpty())
 				Eventually(func() (string, error) {
 					cluster, err := clusterutils.Get(env.Ctx, env.Client, namespace, clusterName)
 					if err != nil {
 						return "", err
 					}
-					return cluster.Status.LastSuccessfulBackup, err
+					return cluster.Status.LastSuccessfulBackup, err //nolint:staticcheck
 				}, 30).ShouldNot(BeEmpty())
 				Eventually(func() (string, error) {
 					cluster, err := clusterutils.Get(env.Ctx, env.Client, namespace, clusterName)
 					if err != nil {
 						return "", err
 					}
-					return cluster.Status.LastFailedBackup, err
+					return cluster.Status.LastFailedBackup, err //nolint:staticcheck
 				}, 30).Should(BeEmpty())
 			})
 		})


### PR DESCRIPTION
Due to the transition to a plugin-based, backup-agnostic architecture in CloudNativePG, we are deprecating:

- `firstRecoverabilityPoint`, `firstRecoverabilityPointByMethod`, `lastSuccessfulBackup`, `lastSuccessfulBackupByMethod`, and `lastFailedBackup` in `Cluster.status`
- `cnpg_collector_first_recoverability_point`, `cnpg_collector_last_failed_backup_timestamp`, `cnpg_collector_last_available_backup_timestamp` metrics

If you have migrated to a plugin-based backup and recovery solution such as Barman Cloud, these fields/metrics are no longer synchronized and will not be updated. Users still relying on the in-core support for Barman Cloud and volume snapshots can continue to use these fields for the time being.

Closes #8051 