### PR TITLE
feat(backup,cnpgi): add lifecycle support to the backup controller

### DIFF
--- a/internal/controller/backup_controller.go
+++ b/internal/controller/backup_controller.go
@@ -181,6 +181,7 @@ func (r *BackupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	}()
 
 	ctx = cnpgiClient.SetPluginClientInContext(ctx, pluginClient)
+	ctx = cluster.SetInContext(ctx)
 
 	// Plugin pre-hooks
 	if hookResult := preReconcilePluginHooks(ctx, &cluster, &backup); hookResult.StopReconciliation {


### PR DESCRIPTION
This patch makes sure that the cluster is present in the context, otherwise many cnpgi calls would be silently skipped

