### PR TITLE
feat(rollout): support changing image and PostgreSQL settings simultaneously

### DIFF
--- a/api/v1/cluster_funcs.go
+++ b/api/v1/cluster_funcs.go
@@ -1465,16 +1465,6 @@ func (cluster *Cluster) EnsureGVKIsPresent() {
 	})
 }
 
-// GetExtensionImages returns the list of images that are used by the extensions
-func (p PostgresConfiguration) GetExtensionImages() []string {
-	var images []string
-	for _, extension := range p.Extensions {
-		images = append(images, extension.ImageVolumeSource.Reference)
-	}
-
-	return images
-}
-
 // BuildPostgresOptions create the list of options that
 // should be added to the PostgreSQL configuration to
 // recover given a certain target

--- a/api/v1/cluster_funcs.go
+++ b/api/v1/cluster_funcs.go
@@ -1465,6 +1465,16 @@ func (cluster *Cluster) EnsureGVKIsPresent() {
 	})
 }
 
+// GetExtensionImages returns the list of images that are used by the extensions
+func (p PostgresConfiguration) GetExtensionImages() []string {
+	var images []string
+	for _, extension := range p.Extensions {
+		images = append(images, extension.ImageVolumeSource.Reference)
+	}
+
+	return images
+}
+
 // BuildPostgresOptions create the list of options that
 // should be added to the PostgreSQL configuration to
 // recover given a certain target

--- a/docs/src/rolling_update.md
+++ b/docs/src/rolling_update.md
@@ -1,32 +1,38 @@
 # Rolling Updates
 <!-- SPDX-License-Identifier: CC-BY-4.0 -->
 
-The operator allows changing the PostgreSQL version used in a cluster while
-applications are running against it.
+The operator allows you to change the PostgreSQL version used in a cluster
+while applications continue running against it.
 
-!!! Important
-    Only upgrades for PostgreSQL minor releases are supported.
+Rolling upgrades are triggered when:
 
-Rolling upgrades are started when:
+- you change the `imageName` attribute in the cluster specification;
 
-- the user changes the `imageName` attribute of the cluster specification;
+- you change the list of extension images in the `.spec.postgresql.extensions`
+  stanza of the cluster specification;
 
-- the [image catalog](image_catalog.md) is updated with a new image for the major used by the cluster;
+- the [image catalog](image_catalog.md) is updated with a new image for the
+  major version used by the cluster;
 
-- a change in the PostgreSQL configuration requires a restart to be
-  applied;
+- a change in the PostgreSQL configuration requires a restart to apply;
 
-- a change on the `Cluster` `.spec.resources` values
+- you change the `Cluster` `.spec.resources` values;
 
-- a change in size of the persistent volume claim on AKS
+- you resize the persistent volume claim on AKS;
 
-- after the operator is updated, to ensure the Pods run the latest instance
-  manager (unless [in-place updates are enabled](installation_upgrade.md#in-place-updates-of-the-instance-manager)).
+- the operator is updated, ensuring Pods run the latest instance manager
+  (unless [in-place updates are enabled](installation_upgrade.md#in-place-updates-of-the-instance-manager)).
 
-The operator starts upgrading all the replicas, one Pod at a time, and begins
-from the one with the highest serial.
+!!! Warning
+    Any change of container images (including extensions) takes precedence over any
+    other change, potentially triggering multiple restarts. For example, if you
+    change the PostgreSQL configuration and the PostgreSQL version simultaneously,
+    the container image change will take precedence.
 
-The primary is the last node to be upgraded.
+During a rolling upgrade, the operator upgrades all replicas one Pod at a time,
+starting from the one with the highest serial.
+
+The primary is always the last node to be upgraded.
 
 Rolling updates are configurable and can be either entirely automated
 (`unsupervised`) or requiring human intervention (`supervised`).

--- a/docs/src/rolling_update.md
+++ b/docs/src/rolling_update.md
@@ -24,10 +24,11 @@ Rolling upgrades are triggered when:
   (unless [in-place updates are enabled](installation_upgrade.md#in-place-updates-of-the-instance-manager)).
 
 !!! Warning
-    Any change of container images (including extensions) takes precedence over any
-    other change, potentially triggering multiple restarts. For example, if you
-    change the PostgreSQL configuration and the PostgreSQL version simultaneously,
-    the container image change will take precedence.
+    Any change to container images (including extensions) takes precedence over
+    all other changes and will trigger a rollout first. For example, if you update
+    both the PostgreSQL configuration and the PostgreSQL version at the same time,
+    the container image change will take priority, and the configuration change
+    will be applied in a subsequent rollout.
 
 During a rolling upgrade, the operator upgrades all replicas one Pod at a time,
 starting from the one with the highest serial.

--- a/internal/management/controller/instance_controller.go
+++ b/internal/management/controller/instance_controller.go
@@ -419,12 +419,15 @@ func (r *InstanceReconciler) requiresImagesRollout(ctx context.Context, cluster 
 
 	if r.runningImages == nil {
 		r.runningImages = latestImages
-		contextLogger.Info("Detected runningImages images", "runningImages", r.runningImages.ToSortedList())
+		contextLogger.Info("Detected running images", "runningImages", r.runningImages.ToSortedList())
 
 		return false
 	}
 
-	contextLogger.Trace("Calculated image requirements", "latestImages", latestImages.ToSortedList(), "runningImages", r.runningImages.ToSortedList())
+	contextLogger.Trace(
+	        "Calculated image requirements", 
+	        "latestImages", latestImages.ToSortedList(), 
+	        "runningImages", r.runningImages.ToSortedList())
 
 	if latestImages.Eq(r.runningImages) {
 		return false

--- a/internal/management/controller/instance_controller.go
+++ b/internal/management/controller/instance_controller.go
@@ -425,9 +425,9 @@ func (r *InstanceReconciler) requiresImagesRollout(ctx context.Context, cluster 
 	}
 
 	contextLogger.Trace(
-	        "Calculated image requirements", 
-	        "latestImages", latestImages.ToSortedList(), 
-	        "runningImages", r.runningImages.ToSortedList())
+		"Calculated image requirements",
+		"latestImages", latestImages.ToSortedList(),
+		"runningImages", r.runningImages.ToSortedList())
 
 	if latestImages.Eq(r.runningImages) {
 		return false

--- a/internal/management/controller/manager.go
+++ b/internal/management/controller/manager.go
@@ -43,9 +43,9 @@ import (
 // the one of this PostgreSQL instance. Also, the configuration in the
 // ConfigMap is applied when needed
 type InstanceReconciler struct {
-	client          ctrl.Client
-	instance        *postgres.Instance
-	bootstrapImages *stringset.Data
+	client        ctrl.Client
+	instance      *postgres.Instance
+	runningImages *stringset.Data
 
 	secretVersions  map[string]string
 	extensionStatus map[string]bool

--- a/internal/management/controller/manager.go
+++ b/internal/management/controller/manager.go
@@ -25,6 +25,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/cloudnative-pg/machinery/pkg/stringset"
 	"go.uber.org/atomic"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -42,8 +43,9 @@ import (
 // the one of this PostgreSQL instance. Also, the configuration in the
 // ConfigMap is applied when needed
 type InstanceReconciler struct {
-	client   ctrl.Client
-	instance *postgres.Instance
+	client          ctrl.Client
+	instance        *postgres.Instance
+	bootstrapImages *stringset.Data
 
 	secretVersions  map[string]string
 	extensionStatus map[string]bool

--- a/internal/webhook/v1/cluster_webhook.go
+++ b/internal/webhook/v1/cluster_webhook.go
@@ -21,7 +21,6 @@ package v1
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"slices"
 	"strconv"
@@ -241,7 +240,6 @@ func (v *ClusterCustomValidator) validateClusterChanges(r, old *apiv1.Cluster) (
 	type validationFunc func(*apiv1.Cluster, *apiv1.Cluster) field.ErrorList
 	validations := []validationFunc{
 		v.validateImageChange,
-		v.validateConfigurationChange,
 		v.validateStorageChange,
 		v.validateWalStorageChange,
 		v.validateTablespacesChange,
@@ -1259,30 +1257,6 @@ func parsePostgresQuantityValue(value string) (resource.Quantity, error) {
 	}
 
 	return resource.ParseQuantity(value)
-}
-
-// validateConfigurationChange determines whether a PostgreSQL configuration
-// change can be applied
-func (v *ClusterCustomValidator) validateConfigurationChange(r, old *apiv1.Cluster) field.ErrorList {
-	var result field.ErrorList
-
-	if old.Spec.ImageName != r.Spec.ImageName {
-		diff := utils.CollectDifferencesFromMaps(old.Spec.PostgresConfiguration.Parameters,
-			r.Spec.PostgresConfiguration.Parameters)
-		if len(diff) > 0 {
-			jsonDiff, _ := json.Marshal(diff)
-			result = append(
-				result,
-				field.Invalid(
-					field.NewPath("spec", "imageName"),
-					r.Spec.ImageName,
-					fmt.Sprintf("Can't change image name and configuration at the same time. "+
-						"There are differences in PostgreSQL configuration parameters: %s", jsonDiff)))
-			return result
-		}
-	}
-
-	return result
 }
 
 func validateSyncReplicaElectionConstraint(constraints apiv1.SyncReplicaElectionConstraints) *field.Error {

--- a/internal/webhook/v1/cluster_webhook_test.go
+++ b/internal/webhook/v1/cluster_webhook_test.go
@@ -514,54 +514,6 @@ var _ = Describe("configuration change validation", func() {
 		v = &ClusterCustomValidator{}
 	})
 
-	It("doesn't complain when the configuration is exactly the same", func() {
-		clusterOld := &apiv1.Cluster{
-			Spec: apiv1.ClusterSpec{
-				ImageName: "postgres:10.4",
-			},
-		}
-		clusterNew := clusterOld.DeepCopy()
-		Expect(v.validateConfigurationChange(clusterNew, clusterOld)).To(BeEmpty())
-	})
-
-	It("doesn't complain when we change a setting which is not fixed", func() {
-		clusterOld := &apiv1.Cluster{
-			Spec: apiv1.ClusterSpec{
-				ImageName: "postgres:10.4",
-			},
-		}
-		clusterNew := &apiv1.Cluster{
-			Spec: apiv1.ClusterSpec{
-				ImageName: "postgres:10.4",
-				PostgresConfiguration: apiv1.PostgresConfiguration{
-					Parameters: map[string]string{
-						"shared_buffers": "4G",
-					},
-				},
-			},
-		}
-		Expect(v.validateConfigurationChange(clusterNew, clusterOld)).To(BeEmpty())
-	})
-
-	It("complains when changing postgres major version and settings", func() {
-		clusterOld := &apiv1.Cluster{
-			Spec: apiv1.ClusterSpec{
-				ImageName: "postgres:10.4",
-			},
-		}
-		clusterNew := &apiv1.Cluster{
-			Spec: apiv1.ClusterSpec{
-				ImageName: "postgres:10.5",
-				PostgresConfiguration: apiv1.PostgresConfiguration{
-					Parameters: map[string]string{
-						"shared_buffers": "4G",
-					},
-				},
-			},
-		}
-		Expect(v.validateConfigurationChange(clusterNew, clusterOld)).To(HaveLen(1))
-	})
-
 	It("produces no error when WAL size settings are correct", func() {
 		clusterNew := &apiv1.Cluster{
 			Spec: apiv1.ClusterSpec{


### PR DESCRIPTION
Allow updating the container image (including PostgreSQL version or extensions) and PostgreSQL configuration settings in a single operation. The image change will trigger the first rollout, followed by the configuration changes in a subsequent rollout.

Closes: #2530 