### PR TITLE
docs: update Operands image signing context

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -74,7 +74,9 @@ The PostgreSQL operand container images are available for all
 across multiple architectures, directly from the
 [`postgres-containers` project's GitHub Container Registry](https://github.com/cloudnative-pg/postgres-containers/pkgs/container/postgresql).
 
-The [`minimal`](https://github.com/cloudnative-pg/postgres-containers#minimal-images) and [`standard`](https://github.com/cloudnative-pg/postgres-containers#standard-images) container images are signed and include SBOM and provenance attestations,
+The [`minimal`](https://github.com/cloudnative-pg/postgres-containers#minimal-images)
+and [`standard`](https://github.com/cloudnative-pg/postgres-containers#standard-images)
+container images are signed and include SBOM and provenance attestations,
 provided separately for each architecture.
 
 Weekly jobs ensure that critical vulnerabilities (CVEs) in the entire stack are

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -74,7 +74,7 @@ The PostgreSQL operand container images are available for all
 across multiple architectures, directly from the
 [`postgres-containers` project's GitHub Container Registry](https://github.com/cloudnative-pg/postgres-containers/pkgs/container/postgresql).
 
-All container images are signed and include SBOM and provenance attestations,
+The [`minimal`](https://github.com/cloudnative-pg/postgres-containers#minimal-images) and [`standard`](https://github.com/cloudnative-pg/postgres-containers#standard-images) container images are signed and include SBOM and provenance attestations,
 provided separately for each architecture.
 
 Weekly jobs ensure that critical vulnerabilities (CVEs) in the entire stack are


### PR DESCRIPTION
This change makes it clear in the documentation that _only_ `minimal` and `standard` Operand images are signed. `System` images built with the old process were never signed to begin with - this old process is being deprecated. 

For details, see https://github.com/cloudnative-pg/postgres-containers/issues/245