### PR TITLE
chore(ci): use independent names for recovery backups

### DIFF
--- a/tests/e2e/fixtures/backup/recovery_external_clusters/backup-azure-blob-02.yaml
+++ b/tests/e2e/fixtures/backup/recovery_external_clusters/backup-azure-blob-02.yaml
@@ -1,7 +1,7 @@
 apiVersion: postgresql.cnpg.io/v1
 kind: Backup
 metadata:
-  name: cluster-backup
+  name: cluster-backup-02
 spec:
   cluster:
     name: source-cluster-azure

--- a/tests/e2e/fixtures/backup/recovery_external_clusters/backup-azure-blob-pitr-sas.yaml
+++ b/tests/e2e/fixtures/backup/recovery_external_clusters/backup-azure-blob-pitr-sas.yaml
@@ -1,7 +1,7 @@
 apiVersion: postgresql.cnpg.io/v1
 kind: Backup
 metadata:
-  name: cluster-backup
+  name: cluster-backup-pitr-sas
 spec:
   cluster:
     name: pg-backup-azure-blob-sas

--- a/tests/e2e/fixtures/backup/recovery_external_clusters/backup-azure-blob-pitr.yaml
+++ b/tests/e2e/fixtures/backup/recovery_external_clusters/backup-azure-blob-pitr.yaml
@@ -1,7 +1,7 @@
 apiVersion: postgresql.cnpg.io/v1
 kind: Backup
 metadata:
-  name: cluster-backup
+  name: cluster-backup-pitr
 spec:
   cluster:
     name: external-cluster-azure

--- a/tests/e2e/fixtures/backup/recovery_external_clusters/backup-azure-blob-sas.yaml
+++ b/tests/e2e/fixtures/backup/recovery_external_clusters/backup-azure-blob-sas.yaml
@@ -1,7 +1,7 @@
 apiVersion: postgresql.cnpg.io/v1
 kind: Backup
 metadata:
-  name: cluster-backup
+  name: cluster-backup-sas
 spec:
   cluster:
     name: pg-backup-azure-blob-sas

--- a/tests/e2e/fixtures/backup/recovery_external_clusters/backup-azurite-02.yaml
+++ b/tests/e2e/fixtures/backup/recovery_external_clusters/backup-azurite-02.yaml
@@ -1,7 +1,7 @@
 apiVersion: postgresql.cnpg.io/v1
 kind: Backup
 metadata:
-  name: cluster-backup
+  name: cluster-backup-azurite-02
 spec:
   cluster:
     name: pg-backup-azurite

--- a/tests/e2e/fixtures/backup/recovery_external_clusters/backup-minio-02.yaml
+++ b/tests/e2e/fixtures/backup/recovery_external_clusters/backup-minio-02.yaml
@@ -1,7 +1,7 @@
 apiVersion: postgresql.cnpg.io/v1
 kind: Backup
 metadata:
-  name: cluster-backup
+  name: cluster-backup-02
 spec:
   cluster:
     name: source-cluster-minio


### PR DESCRIPTION
In Azure tests, we were using the name `cluster-backup` multiple times, which caused issues with the tests since we can no longer modify the backup objects.

Closes #8120 