### PR TITLE
feat(webhook): add warnings for storage configuration

### DIFF
--- a/internal/webhook/v1/cluster_webhook.go
+++ b/internal/webhook/v1/cluster_webhook.go
@@ -2421,7 +2421,58 @@ func (v *ClusterCustomValidator) getAdmissionWarnings(r *apiv1.Cluster) admissio
 	list := getMaintenanceWindowsAdmissionWarnings(r)
 	list = append(list, getInTreeBarmanWarnings(r)...)
 	list = append(list, getRetentionPolicyWarnings(r)...)
+	list = append(list, getStorageWarnings(r)...)
 	return append(list, getSharedBuffersWarnings(r)...)
+}
+
+func getStorageWarnings(r *apiv1.Cluster) admission.Warnings {
+	generateWarningsFunc := func(path field.Path, configuration *apiv1.StorageConfiguration) admission.Warnings {
+		if configuration == nil {
+			return nil
+		}
+
+		if configuration.PersistentVolumeClaimTemplate == nil {
+			return nil
+		}
+
+		pvcTemplatePath := path.Child("pvcTemplate")
+
+		var result admission.Warnings
+		if configuration.StorageClass != nil && configuration.PersistentVolumeClaimTemplate.StorageClassName != nil {
+			storageClass := path.Child("storageClass").String()
+			result = append(
+				result,
+				fmt.Sprintf("%s and %s are both specified, %s value will be used.",
+					storageClass,
+					pvcTemplatePath.Child("storageClassName"),
+					storageClass,
+				),
+			)
+		}
+		requestsSpecified := !configuration.PersistentVolumeClaimTemplate.Resources.Requests.Storage().IsZero()
+		if configuration.Size != "" && requestsSpecified {
+			size := path.Child("size").String()
+			result = append(
+				result,
+				fmt.Sprintf(
+					"%s and %s  are both specified, %s value will be used.",
+					size,
+					pvcTemplatePath.Child("resources", "requests", "storage").String(),
+					size,
+				),
+			)
+		}
+
+		return result
+	}
+
+	var result admission.Warnings
+
+	storagePath := *field.NewPath("spec", "storage")
+	result = append(result, generateWarningsFunc(storagePath, &r.Spec.StorageConfiguration)...)
+
+	walStoragePath := *field.NewPath("spec", "walStorage")
+	return append(result, generateWarningsFunc(walStoragePath, r.Spec.WalStorage)...)
 }
 
 func getInTreeBarmanWarnings(r *apiv1.Cluster) admission.Warnings {

--- a/internal/webhook/v1/cluster_webhook.go
+++ b/internal/webhook/v1/cluster_webhook.go
@@ -2455,7 +2455,7 @@ func getStorageWarnings(r *apiv1.Cluster) admission.Warnings {
 			result = append(
 				result,
 				fmt.Sprintf(
-					"%s and %s  are both specified, %s value will be used.",
+					"%s and %s are both specified, %s value will be used.",
 					size,
 					pvcTemplatePath.Child("resources", "requests", "storage").String(),
 					size,

--- a/internal/webhook/v1/cluster_webhook_test.go
+++ b/internal/webhook/v1/cluster_webhook_test.go
@@ -5559,3 +5559,191 @@ var _ = Describe("getRetentionPolicyWarnings", func() {
 		Expect(warnings).To(HaveLen(1))
 	})
 })
+
+var _ = Describe("getStorageWarnings", func() {
+	It("returns no warnings when storage is properly configured", func() {
+		cluster := &apiv1.Cluster{
+			Spec: apiv1.ClusterSpec{
+				StorageConfiguration: apiv1.StorageConfiguration{
+					Size: "1Gi",
+				},
+			},
+		}
+		Expect(getStorageWarnings(cluster)).To(BeEmpty())
+	})
+
+	It("returns no warnings when PVC template has storage configured", func() {
+		cluster := &apiv1.Cluster{
+			Spec: apiv1.ClusterSpec{
+				StorageConfiguration: apiv1.StorageConfiguration{
+					PersistentVolumeClaimTemplate: &corev1.PersistentVolumeClaimSpec{
+						Resources: corev1.VolumeResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceStorage: resource.MustParse("1Gi"),
+							},
+						},
+					},
+				},
+			},
+		}
+		Expect(getStorageWarnings(cluster)).To(BeEmpty())
+	})
+
+	It("returns a warning when both storageClass and storageClassName are specified", func() {
+		storageClass := "fast-ssd"
+		cluster := &apiv1.Cluster{
+			Spec: apiv1.ClusterSpec{
+				StorageConfiguration: apiv1.StorageConfiguration{
+					StorageClass: &storageClass,
+					PersistentVolumeClaimTemplate: &corev1.PersistentVolumeClaimSpec{
+						StorageClassName: &storageClass,
+					},
+				},
+			},
+		}
+		warnings := getStorageWarnings(cluster)
+		Expect(warnings).To(HaveLen(1))
+		Expect(warnings[0]).To(ContainSubstring("spec.storage.storageClass"))
+		Expect(warnings[0]).To(ContainSubstring("spec.storage.pvcTemplate.storageClassName"))
+		Expect(warnings[0]).To(ContainSubstring("spec.storage.storageClass value will be used"))
+	})
+
+	It("returns a warning when both size and storage requests are specified", func() {
+		cluster := &apiv1.Cluster{
+			Spec: apiv1.ClusterSpec{
+				StorageConfiguration: apiv1.StorageConfiguration{
+					Size: "1Gi",
+					PersistentVolumeClaimTemplate: &corev1.PersistentVolumeClaimSpec{
+						Resources: corev1.VolumeResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceStorage: resource.MustParse("2Gi"),
+							},
+						},
+					},
+				},
+			},
+		}
+		warnings := getStorageWarnings(cluster)
+		Expect(warnings).To(HaveLen(1))
+		Expect(warnings[0]).To(ContainSubstring("spec.storage.size"))
+		Expect(warnings[0]).To(ContainSubstring("spec.storage.pvcTemplate.resources.requests.storage"))
+		Expect(warnings[0]).To(ContainSubstring("spec.storage.size value will be used"))
+	})
+
+	It("returns multiple warnings when both storage conflicts exist", func() {
+		storageClass := "fast-ssd"
+		cluster := &apiv1.Cluster{
+			Spec: apiv1.ClusterSpec{
+				StorageConfiguration: apiv1.StorageConfiguration{
+					Size:         "1Gi",
+					StorageClass: &storageClass,
+					PersistentVolumeClaimTemplate: &corev1.PersistentVolumeClaimSpec{
+						StorageClassName: &storageClass,
+						Resources: corev1.VolumeResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceStorage: resource.MustParse("2Gi"),
+							},
+						},
+					},
+				},
+			},
+		}
+		warnings := getStorageWarnings(cluster)
+		Expect(warnings).To(HaveLen(2))
+		Expect(warnings[0]).To(ContainSubstring("storageClass"))
+		Expect(warnings[1]).To(ContainSubstring("size"))
+	})
+
+	It("returns warnings for WAL storage configuration conflicts", func() {
+		storageClass := "fast-ssd"
+		cluster := &apiv1.Cluster{
+			Spec: apiv1.ClusterSpec{
+				WalStorage: &apiv1.StorageConfiguration{
+					Size:         "500Mi",
+					StorageClass: &storageClass,
+					PersistentVolumeClaimTemplate: &corev1.PersistentVolumeClaimSpec{
+						StorageClassName: &storageClass,
+						Resources: corev1.VolumeResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceStorage: resource.MustParse("1Gi"),
+							},
+						},
+					},
+				},
+			},
+		}
+		warnings := getStorageWarnings(cluster)
+		Expect(warnings).To(HaveLen(2))
+		Expect(warnings[0]).To(ContainSubstring("spec.walStorage.storageClass"))
+		Expect(warnings[1]).To(ContainSubstring("spec.walStorage.size"))
+	})
+
+	It("returns warnings for both storage and WAL storage conflicts", func() {
+		storageClass := "fast-ssd"
+		cluster := &apiv1.Cluster{
+			Spec: apiv1.ClusterSpec{
+				StorageConfiguration: apiv1.StorageConfiguration{
+					Size:         "1Gi",
+					StorageClass: &storageClass,
+					PersistentVolumeClaimTemplate: &corev1.PersistentVolumeClaimSpec{
+						StorageClassName: &storageClass,
+					},
+				},
+				WalStorage: &apiv1.StorageConfiguration{
+					Size: "500Mi",
+					PersistentVolumeClaimTemplate: &corev1.PersistentVolumeClaimSpec{
+						Resources: corev1.VolumeResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceStorage: resource.MustParse("1Gi"),
+							},
+						},
+					},
+				},
+			},
+		}
+		warnings := getStorageWarnings(cluster)
+		Expect(warnings).To(HaveLen(2))
+		Expect(warnings[0]).To(ContainSubstring("spec.storage"))
+		Expect(warnings[1]).To(ContainSubstring("spec.walStorage"))
+	})
+
+	It("returns no warnings when WAL storage is nil", func() {
+		cluster := &apiv1.Cluster{
+			Spec: apiv1.ClusterSpec{
+				StorageConfiguration: apiv1.StorageConfiguration{
+					Size: "1Gi",
+				},
+				WalStorage: nil,
+			},
+		}
+		Expect(getStorageWarnings(cluster)).To(BeEmpty())
+	})
+
+	It("returns no warnings when PVC template is nil", func() {
+		cluster := &apiv1.Cluster{
+			Spec: apiv1.ClusterSpec{
+				StorageConfiguration: apiv1.StorageConfiguration{
+					Size:                          "1Gi",
+					PersistentVolumeClaimTemplate: nil,
+				},
+			},
+		}
+		Expect(getStorageWarnings(cluster)).To(BeEmpty())
+	})
+
+	It("returns no warnings when storage requests are zero", func() {
+		cluster := &apiv1.Cluster{
+			Spec: apiv1.ClusterSpec{
+				StorageConfiguration: apiv1.StorageConfiguration{
+					Size: "1Gi",
+					PersistentVolumeClaimTemplate: &corev1.PersistentVolumeClaimSpec{
+						Resources: corev1.VolumeResourceRequirements{
+							Requests: corev1.ResourceList{},
+						},
+					},
+				},
+			},
+		}
+		Expect(getStorageWarnings(cluster)).To(BeEmpty())
+	})
+})


### PR DESCRIPTION
This commit introduces new admission warnings for the Cluster resource to inform users about potentially confusing storage configurations.

A warning is now issued when:
- Both `spec.storage.size` and `spec.storage.pvcTemplate.resources.requests.storage` are set, clarifying that `size` will be used.
- Both `spec.storage.storageClass` and  `spec.storage.pvcTemplate.storageClassName` are set, clarifying that`storageClass` will be used.

These checks are applied to both `spec.storage` and `spec.walStorage`. 
