### PR TITLE
fix(slots): handle context cancellation in `Replicator` `Start`

### DIFF
--- a/internal/management/controller/slots/runner/runner.go
+++ b/internal/management/controller/slots/runner/runner.go
@@ -49,7 +49,13 @@ func NewReplicator(instance *postgres.Instance) *Replicator {
 func (sr *Replicator) Start(ctx context.Context) error {
 	contextLog := log.FromContext(ctx).WithName("Replicator")
 	go func() {
-		config := <-sr.instance.SlotReplicatorChan()
+		var config *apiv1.ReplicationSlotsConfiguration
+		select {
+		case config = <-sr.instance.SlotReplicatorChan():
+		case <-ctx.Done():
+			return
+		}
+
 		updateInterval := config.GetUpdateInterval()
 		ticker := time.NewTicker(updateInterval)
 


### PR DESCRIPTION
Wrap the initial config channel read in a select statement to properly handle context cancellation. This prevents the goroutine from blocking indefinitely when the context is cancelled before the config is available.

## Note for reviewers

- This is coherent with how we act inside roles Start().
- Given that is an edge case this PR could be also be marked as chore