### PR TITLE
fix: pointer slice loop

### DIFF
--- a/api/v1/generic_funcs.go
+++ b/api/v1/generic_funcs.go
@@ -59,9 +59,9 @@ func ensureManagedResourceExclusivity[T managedResourceComparer](t1 T, list []T)
 
 // toSliceWithPointers converts a slice of items to a slice of pointers to the items
 func toSliceWithPointers[T any](items []T) []*T {
-    result := make([]*T, len(items))
-    for i := range items {
-        result[i] = &items[i]
-    }
-    return result
+	result := make([]*T, len(items))
+	for i := range items {
+		result[i] = &items[i]
+	}
+	return result
 }

--- a/api/v1/generic_funcs.go
+++ b/api/v1/generic_funcs.go
@@ -59,9 +59,9 @@ func ensureManagedResourceExclusivity[T managedResourceComparer](t1 T, list []T)
 
 // toSliceWithPointers converts a slice of items to a slice of pointers to the items
 func toSliceWithPointers[T any](items []T) []*T {
-	result := make([]*T, len(items))
-	for i, item := range items {
-		result[i] = &item
-	}
-	return result
+    result := make([]*T, len(items))
+    for i := range items {
+        result[i] = &items[i]
+    }
+    return result
 }

--- a/api/v1/generic_funcs_test.go
+++ b/api/v1/generic_funcs_test.go
@@ -1,0 +1,38 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package v1
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+type testStruct struct{ Val int }
+
+var _ = Describe("toSliceWithPointers", func() {
+	It("should return pointers to the original slice elements", func() {
+		items := []testStruct{{1}, {2}, {3}}
+		pointers := toSliceWithPointers(items)
+		Expect(pointers).To(HaveLen(len(items)))
+		for i := range items {
+			Expect(pointers[i]).To(BeIdenticalTo(&items[i]))
+		}
+	})
+})

--- a/internal/controller/finalizers_delete.go
+++ b/internal/controller/finalizers_delete.go
@@ -93,11 +93,11 @@ type clusterOwnedResourceWithStatus interface {
 }
 
 func toSliceWithPointers[T any](items []T) []*T {
-	result := make([]*T, len(items))
-	for i, item := range items {
-		result[i] = &item
-	}
-	return result
+        result := make([]*T, len(items))
+        for i := range items {
+                result[i] = &items[i]
+        }
+        return result
 }
 
 // notifyOwnedResourceDeletion deletes finalizers for a given resource type

--- a/internal/controller/finalizers_delete.go
+++ b/internal/controller/finalizers_delete.go
@@ -93,11 +93,11 @@ type clusterOwnedResourceWithStatus interface {
 }
 
 func toSliceWithPointers[T any](items []T) []*T {
-        result := make([]*T, len(items))
-        for i := range items {
-                result[i] = &items[i]
-        }
-        return result
+	result := make([]*T, len(items))
+	for i := range items {
+		result[i] = &items[i]
+	}
+	return result
 }
 
 // notifyOwnedResourceDeletion deletes finalizers for a given resource type

--- a/internal/controller/finalizers_delete_test.go
+++ b/internal/controller/finalizers_delete_test.go
@@ -326,3 +326,16 @@ var _ = Describe("Test cleanup of owned objects on cluster deletion", func() {
 		Expect(subscription.Status.Message).ToNot(ContainSubstring("not reconciled"))
 	})
 })
+
+type testStruct struct{ Val int }
+
+var _ = Describe("toSliceWithPointers", func() {
+	It("should return pointers to the original slice elements", func() {
+		items := []testStruct{{1}, {2}, {3}}
+		pointers := toSliceWithPointers(items)
+		Expect(pointers).To(HaveLen(len(items)))
+		for i := range items {
+			Expect(pointers[i]).To(BeIdenticalTo(&items[i]))
+		}
+	})
+})


### PR DESCRIPTION
Fix the loop when converting item slices to pointer slices. The previous version unnecessarily allocates memory, and with an older compiler, it does not work as expected.
