### PR TITLE
fix: cosmetic error in cnpg status output

### DIFF
--- a/internal/cmd/plugin/status/status.go
+++ b/internal/cmd/plugin/status/status.go
@@ -759,7 +759,6 @@ func (fullStatus *PostgresqlStatus) printInstancesStatus() {
 				instance.Pod.Name,
 				"-",
 				"-",
-				"-",
 				apierrs.ReasonForError(instance.Error),
 				instance.Pod.Status.QOSClass,
 				"-",


### PR DESCRIPTION
The table columns don't line up in the "cnpg status" output when a pod status lookup failed.

Fixes: #8145 