### PR TITLE
refactor: renamed failoverQuorum annotation

### DIFF
--- a/docs/src/failover.md
+++ b/docs/src/failover.md
@@ -134,12 +134,12 @@ This feature allows users to choose their preferred trade-off between data
 durability and data availability.
 
 Failover quorum can be enabled by setting the annotation
-`cnpg.io/failoverQuorum="true"` in the `Cluster` resource.
+`alpha.cnpg.io/failoverQuorum="true"` in the `Cluster` resource.
 
 !!! info
     When this feature is out of the experimental phase, the annotation
-    `cnpg.io/failoverQuorum` will be replaced by a configuration option in the
-    `Cluster` resource.
+    `alpha.cnpg.io/failoverQuorum` will be replaced by a configuration option in
+    the `Cluster` resource.
 
 ### How it works
 

--- a/docs/src/samples/cluster-example-syncreplicas-quorum.yaml
+++ b/docs/src/samples/cluster-example-syncreplicas-quorum.yaml
@@ -3,7 +3,7 @@ kind: Cluster
 metadata:
   name: cluster-example
   annotations:
-    cnpg.io/failoverQuorum: "t"
+    alpha.cnpg.io/failoverQuorum: "true"
 spec:
   instances: 3
 
@@ -14,4 +14,3 @@ spec:
 
   storage:
     size: 1G
-

--- a/pkg/utils/labels_annotations.go
+++ b/pkg/utils/labels_annotations.go
@@ -263,7 +263,7 @@ const (
 	//
 	// This feature enables quorum-based check before failover, ensuring
 	// no data loss at the expense of availability.
-	FailoverQuorumAnnotationName = MetadataNamespace + "/failoverQuorum"
+	FailoverQuorumAnnotationName = AlphaMetadataNamespace + "/failoverQuorum"
 )
 
 type annotationStatus string


### PR DESCRIPTION
Use alpha.cnpg.io/failoverQuorum instead of cnpg.io/failoverQuorum.

Closes #8168
