### PR TITLE
docs(development_environment): add helm requirement

### DIFF
--- a/contribute/development_environment/README.md
+++ b/contribute/development_environment/README.md
@@ -47,6 +47,7 @@ environment variable:
 - [golangci-lint](https://github.com/golangci/golangci-lint)
 - [goreleaser](https://goreleaser.com/)
 - [Operator SDK CLI](https://sdk.operatorframework.io/)
+- [Helm](https://helm.sh/)
 
 In addition, check that the following packages are installed in your system:
 
@@ -83,7 +84,8 @@ components in your Mac OS X system:
 brew install go \
   kind \
   golangci/tap/golangci-lint \
-  goreleaser
+  goreleaser \
+  helm
 ```
 
 Please note that bash v5.0+ is required, this can be installed with:


### PR DESCRIPTION
This is needed otherwise we encounter in the following error:

```
volumesnapshotclass.snapshot.storage.k8s.io/csi-hostpath-snapclass created
volumesnapshotclass.snapshot.storage.k8s.io/csi-hostpath-snapclass patched
storageclass.storage.k8s.io/csi-hostpath-sc created
storageclass.storage.k8s.io/csi-hostpath-sc annotated
 CSI driver plugin deployment has started. Waiting for the CSI plugin to be ready...
Success: The CSI plugin is deployed and ready.
Starting deployment of Prometheus CRDs...
./hack/setup-cluster.sh: line 400: helm: command not found
```