### PR TITLE
chore: `startedAt` vs `started at` in log messages key

### DIFF
--- a/internal/controller/backup_controller.go
+++ b/internal/controller/backup_controller.go
@@ -381,7 +381,7 @@ func (r *BackupReconciler) isValidBackupRunning(
 		contextLogger.Info("Backup is already running on",
 			"cluster", cluster.Name,
 			"pod", pod.Name,
-			"started at", backup.Status.StartedAt)
+			"startedAt", backup.Status.StartedAt)
 
 		// Nothing to do here
 		return true, nil


### PR DESCRIPTION
#8205 
used camelcase for log field names to improve log parsing 
changed ```started at``` to ```startedAt```

@gbartolini @sxd please review this 