### PR TITLE
Fixes Issue #8215 [Bug]: The annotation skipEmptyWalArchiveCheck is not working when recovering a Cluster via Barman Cloud Plugin 

### DIFF
--- a/pkg/management/postgres/restore.go
+++ b/pkg/management/postgres/restore.go
@@ -290,6 +290,12 @@ func (info InitInfo) Restore(ctx context.Context, cli client.Client) error {
 	// nolint:nestif
 	if pluginConfiguration := cluster.GetRecoverySourcePlugin(); pluginConfiguration != nil {
 		contextLogger.Info("Restore through plugin detected, proceeding...")
+
+		err = info.checkBackupDestination(ctx, cli, cluster)
+		if err != nil {
+			return err
+		}
+
 		res, err := restoreViaPlugin(ctx, cluster, pluginConfiguration)
 		if err != nil {
 			return err

--- a/pkg/utils/labels_annotations_test.go
+++ b/pkg/utils/labels_annotations_test.go
@@ -180,3 +180,32 @@ var _ = Describe("Pod spec reconciliation", func() {
 		Expect(IsPodSpecReconciliationDisabled(objectMeta)).To(BeTrue())
 	})
 })
+
+var _ = Describe("Empty WAL archive check annotation management", func() {
+	var objectMeta metav1.ObjectMeta
+
+	BeforeEach(func() {
+		objectMeta = metav1.ObjectMeta{
+			Annotations: make(map[string]string),
+		}
+	})
+
+	It("is enabled by default when annotation doesn't exist", func() {
+		Expect(IsEmptyWalArchiveCheckEnabled(&objectMeta)).To(BeTrue())
+	})
+
+	It("is enabled when annotation exists but value is not 'enabled'", func() {
+		objectMeta.Annotations["cnpg.io/skipEmptyWalArchiveCheck"] = "disabled"
+		Expect(IsEmptyWalArchiveCheckEnabled(&objectMeta)).To(BeTrue())
+	})
+
+	It("is enabled when annotation exists but value is random string", func() {
+		objectMeta.Annotations["cnpg.io/skipEmptyWalArchiveCheck"] = "random"
+		Expect(IsEmptyWalArchiveCheckEnabled(&objectMeta)).To(BeTrue())
+	})
+
+	It("is disabled (skipped) when annotation is set to 'enabled'", func() {
+		objectMeta.Annotations["cnpg.io/skipEmptyWalArchiveCheck"] = "enabled"
+		Expect(IsEmptyWalArchiveCheckEnabled(&objectMeta)).To(BeFalse())
+	})
+})


### PR DESCRIPTION
@gabriele-wolfox @gbartolini @sxd the following changes resolves the issue #8215 
please review the PR and request if any further changes required 