### PR TITLE
Fixes Issue #8123 [Chore]: Use minimal images for E2E tests

### DIFF
--- a/tests/e2e/asserts_test.go
+++ b/tests/e2e/asserts_test.go
@@ -2599,7 +2599,7 @@ func GetYAMLContent(sampleFilePath string) ([]byte, error) {
 	if filepath.Ext(cleanPath) == ".template" {
 		preRollingUpdateImg := os.Getenv("E2E_PRE_ROLLING_UPDATE_IMG")
 		if preRollingUpdateImg == "" {
-			preRollingUpdateImg = os.Getenv("POSTGRES_IMG")
+			preRollingUpdateImg = testsUtils.GetPostgresImageForTest()
 		}
 		csiStorageClass := os.Getenv("E2E_CSI_STORAGE_CLASS")
 		if csiStorageClass == "" {

--- a/tests/e2e/backup_restore_azure_test.go
+++ b/tests/e2e/backup_restore_azure_test.go
@@ -36,7 +36,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Azure - Backup and restore", Label(tests.LabelBackupRestore), func() {
+var _ = Describe("Azure - Backup and restore", Label(tests.LabelBackupRestore, tests.LabelBarmanCloud), func() {
 	const (
 		tableName = "to_restore"
 	)
@@ -204,7 +204,7 @@ var _ = Describe("Azure - Backup and restore", Label(tests.LabelBackupRestore), 
 	})
 })
 
-var _ = Describe("Azure - Clusters Recovery From Barman Object Store", Label(tests.LabelBackupRestore), func() {
+var _ = Describe("Azure - Clusters Recovery From Barman Object Store", Label(tests.LabelBackupRestore, tests.LabelBarmanCloud), func() {
 	const (
 		fixturesBackupDir            = fixturesDir + "/backup/recovery_external_clusters/"
 		sourceBackupFileAzure        = fixturesBackupDir + "backup-azure-blob-02.yaml"

--- a/tests/e2e/backup_restore_azurite_test.go
+++ b/tests/e2e/backup_restore_azurite_test.go
@@ -35,7 +35,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Azurite - Backup and restore", Label(tests.LabelBackupRestore), func() {
+var _ = Describe("Azurite - Backup and restore", Label(tests.LabelBackupRestore, tests.LabelBarmanCloud), func() {
 	const (
 		tableName             = "to_restore"
 		azuriteBlobSampleFile = fixturesDir + "/backup/azurite/cluster-backup.yaml.template"
@@ -158,7 +158,7 @@ var _ = Describe("Azurite - Backup and restore", Label(tests.LabelBackupRestore)
 	})
 })
 
-var _ = Describe("Clusters Recovery From Barman Object Store", Label(tests.LabelBackupRestore), func() {
+var _ = Describe("Clusters Recovery From Barman Object Store", Label(tests.LabelBackupRestore, tests.LabelBarmanCloud), func() {
 	const (
 		fixturesBackupDir          = fixturesDir + "/backup/recovery_external_clusters/"
 		azuriteBlobSampleFile      = fixturesDir + "/backup/azurite/cluster-backup.yaml.template"

--- a/tests/e2e/backup_restore_minio_test.go
+++ b/tests/e2e/backup_restore_minio_test.go
@@ -42,7 +42,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("MinIO - Backup and restore", Label(tests.LabelBackupRestore), func() {
+var _ = Describe("MinIO - Backup and restore", Label(tests.LabelBackupRestore, tests.LabelBarmanCloud), func() {
 	const (
 		tableName                 = "to_restore"
 		barmanCloudBackupLogEntry = "Starting barman-cloud-backup"
@@ -555,7 +555,7 @@ var _ = Describe("MinIO - Backup and restore", Label(tests.LabelBackupRestore), 
 	})
 })
 
-var _ = Describe("MinIO - Clusters Recovery from Barman Object Store", Label(tests.LabelBackupRestore), func() {
+var _ = Describe("MinIO - Clusters Recovery from Barman Object Store", Label(tests.LabelBackupRestore, tests.LabelBarmanCloud), func() {
 	const (
 		fixturesBackupDir               = fixturesDir + "/backup/recovery_external_clusters/"
 		externalClusterFileMinioReplica = fixturesBackupDir + "external-clusters-minio-replica-04.yaml.template"

--- a/tests/e2e/cluster_major_upgrade_test.go
+++ b/tests/e2e/cluster_major_upgrade_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/versions"
 	"github.com/cloudnative-pg/cloudnative-pg/tests"
+	testsUtils "github.com/cloudnative-pg/cloudnative-pg/tests/utils"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/clusterutils"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/environment"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/exec"
@@ -157,7 +158,7 @@ var _ = Describe("Postgres Major Upgrade", Label(tests.LabelPostgresMajorUpgrade
 	}
 
 	determineVersionsForTesting := func() versionInfo {
-		currentImage := os.Getenv("POSTGRES_IMG")
+		currentImage := testsUtils.GetPostgresImageForTest()
 		Expect(currentImage).ToNot(BeEmpty())
 
 		currentVersion, err := version.FromTag(reference.New(currentImage).Tag)

--- a/tests/e2e/cluster_microservice_test.go
+++ b/tests/e2e/cluster_microservice_test.go
@@ -21,7 +21,6 @@ package e2e
 
 import (
 	"fmt"
-	"os"
 	"strings"
 
 	batchv1 "k8s.io/api/batch/v1"
@@ -29,6 +28,7 @@ import (
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/tests"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/clusterutils"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/exec"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/importdb"
@@ -167,8 +167,8 @@ var _ = Describe("Imports with Microservice Approach", Label(tests.LabelImportin
 		importedClusterName = "cluster-pgdump-different-db-version"
 
 		// Gather the current image
-		postgresImage := os.Getenv("POSTGRES_IMG")
-		Expect(postgresImage).ShouldNot(BeEmpty(), "POSTGRES_IMG env should not be empty")
+		postgresImage := utils.GetPostgresImageForTest()
+		Expect(postgresImage).ShouldNot(BeEmpty(), "postgresImage could not be empty")
 
 		// this test case is only applicable if we are not already on the latest major
 		if postgres.IsLatestMajor(postgresImage) {

--- a/tests/e2e/cluster_monolithic_test.go
+++ b/tests/e2e/cluster_monolithic_test.go
@@ -22,12 +22,12 @@ package e2e
 import (
 	"database/sql"
 	"fmt"
-	"os"
 
 	"github.com/lib/pq"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/tests"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/importdb"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/postgres"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/timeouts"
@@ -138,8 +138,8 @@ var _ = Describe("Imports with Monolithic Approach", Label(tests.LabelImportingD
 		})
 
 		By("creating target cluster", func() {
-			postgresImage := os.Getenv("POSTGRES_IMG")
-			Expect(postgresImage).ShouldNot(BeEmpty(), "POSTGRES_IMG env should not be empty")
+			postgresImage := utils.GetPostgresImageForTest()
+			Expect(postgresImage).ShouldNot(BeEmpty(), "postgresImage could not be empty")
 			expectedImageName, err := postgres.BumpPostgresImageMajorVersion(postgresImage)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(expectedImageName).ShouldNot(BeEmpty(), "imageName could not be empty")

--- a/tests/e2e/replica_mode_cluster_test.go
+++ b/tests/e2e/replica_mode_cluster_test.go
@@ -269,7 +269,7 @@ var _ = Describe("Replica Mode", Label(tests.LabelReplication), func() {
 		})
 	})
 
-	Context("archive mode set to 'always' on designated primary", Label(tests.LabelBackupRestore), func() {
+	Context("archive mode set to 'always' on designated primary", Label(tests.LabelBackupRestore, tests.LabelBarmanCloud), func() {
 		It("verifies replica cluster can archive WALs from the designated primary", func() {
 			const (
 				replicaClusterSample   = fixturesDir + replicaModeClusterDir + "cluster-replica-archive-mode-always.yaml.template"
@@ -340,7 +340,7 @@ var _ = Describe("Replica Mode", Label(tests.LabelReplication), func() {
 		})
 	})
 
-	Context("can bootstrap a replica cluster from a backup", Label(tests.LabelBackupRestore), Ordered, func() {
+	Context("can bootstrap a replica cluster from a backup", Label(tests.LabelBackupRestore, tests.LabelBarmanCloud), Ordered, func() {
 		const (
 			clusterSample   = fixturesDir + replicaModeClusterDir + "cluster-replica-src-with-backup.yaml.template"
 			namespacePrefix = "replica-cluster-from-backup"
@@ -492,7 +492,7 @@ var _ = Describe("Replica Mode", Label(tests.LabelReplication), func() {
 
 // In this test we create a replica cluster from a backup and then promote it to a primary.
 // We expect the original primary to be demoted to a replica and be able to follow the new primary.
-var _ = Describe("Replica switchover", Label(tests.LabelReplication, tests.LabelBackupRestore), Ordered, func() {
+var _ = Describe("Replica switchover", Label(tests.LabelReplication, tests.LabelBackupRestore, tests.LabelBarmanCloud), Ordered, func() {
 	const (
 		replicaSwitchoverClusterDir = "/replica_mode_cluster/"
 		namespacePrefix             = "replica-switchover"

--- a/tests/e2e/rolling_update_test.go
+++ b/tests/e2e/rolling_update_test.go
@@ -113,7 +113,7 @@ var _ = Describe("Rolling updates", Label(tests.LabelPostgresConfiguration), fun
 		timeout := 900
 
 		// Update to the latest minor
-		updatedImageName := os.Getenv("POSTGRES_IMG")
+		updatedImageName := testsUtils.GetPostgresImageForTest()
 		if updatedImageName == "" {
 			updatedImageName = configuration.Current.PostgresImageName
 		}
@@ -531,7 +531,7 @@ var _ = Describe("Rolling updates", Label(tests.LabelPostgresConfiguration), fun
 		BeforeEach(func() {
 			storageClass = os.Getenv("E2E_DEFAULT_STORAGE_CLASS")
 			preRollingImg = os.Getenv("E2E_PRE_ROLLING_UPDATE_IMG")
-			updatedImageName = os.Getenv("POSTGRES_IMG")
+			updatedImageName = testsUtils.GetPostgresImageForTest()
 			if updatedImageName == "" {
 				updatedImageName = configuration.Current.PostgresImageName
 			}

--- a/tests/e2e/wal_restore_parallel_test.go
+++ b/tests/e2e/wal_restore_parallel_test.go
@@ -40,7 +40,7 @@ import (
 // wal section under backup for wal archive storing/recovering. To facilitate controlling the testing, we directly forge
 // wals on the object storage ("minio" in this testing) by copying and renaming an existing wal file.
 
-var _ = Describe("Wal-restore in parallel", Label(tests.LabelBackupRestore), func() {
+var _ = Describe("Wal-restore in parallel", Label(tests.LabelBackupRestore, tests.LabelBarmanCloud), func() {
 	const (
 		level          = tests.High
 		PgWalPath      = specs.PgWalPath

--- a/tests/labels.go
+++ b/tests/labels.go
@@ -25,6 +25,9 @@ package tests
 const (
 	// LabelBackupRestore is a label for only selecting backup and restore tests
 	LabelBackupRestore = "backup-restore"
+	
+	// LabelBarmanCloud is a label for tests that require Barman Cloud tools (deprecated)
+	LabelBarmanCloud = "barman-cloud"
 
 	// LabelBasic is a label for selecting basic tests
 	LabelBasic = "basic"


### PR DESCRIPTION
## Fixes #8123 : Add support for minimal images in E2E tests, isolate Barman Cloud tests

### What Changed

* **Labeled Barman Cloud tests** (`LabelBarmanCloud = "barman-cloud"`) to run them separately.
* **Tagged relevant tests** like `backup_restore_minio_test.go`, etc., with the new label.
* **Added minimal image support** in `utils.go`:

  * `ShouldUseMinimalImages()` to check env
  * `GetPostgresImageForTest()` to pick the right image
  * `transformToMinimalImage()` to switch to `-minimal-bookworm` variants
* **Updated E2E tests** to use `GetPostgresImageForTest()` instead of reading `POSTGRES_IMG` directly.

### Usage

Run core tests with minimal images:

```
export USE_MINIMAL_IMAGES=true
make e2e-test-kind
```

Run Barman Cloud tests with full images:

```
unset USE_MINIMAL_IMAGES
export LABEL_FILTERS="barman-cloud"
make e2e-test-kind
```

Run everything with full images (default):

```
unset USE_MINIMAL_IMAGES
make e2e-test-kind
```
 
* Faster test runs 
* Clean separation between core PG tests and Barman Cloud
* Aligns with the move to plugin-based Barman Cloud support

@gbartolini please review the changes and request if further refinements are required !!