### PR TITLE
fix: unblock rollout of former primary Pod when WAL archiving plugin is missing

### DIFF
--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -113,9 +113,9 @@ const (
 	// will use to signal that there's no more WAL disk space
 	MissingWALDiskSpaceExitCode = 4
 
-	// MissingWALArchivePlugin is the exit code the instance manager
-	// will use to signal it started but the selected WAL archiving
-	// plugin is not available
+	// MissingWALArchivePlugin is the exit code used by the instance manager
+	// to indicate that it started successfully, but the configured WAL
+	// archiving plugin is not available.
 	MissingWALArchivePlugin = 5
 )
 

--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -112,6 +112,11 @@ const (
 	// MissingWALDiskSpaceExitCode is the exit code the instance manager
 	// will use to signal that there's no more WAL disk space
 	MissingWALDiskSpaceExitCode = 4
+
+	// MissingWALArchivePlugin is the exit code the instance manager
+	// will use to signal it started but the selected WAL archiving
+	// plugin is not available
+	MissingWALArchivePlugin = 5
 )
 
 // SnapshotOwnerReference defines the reference type for the owner of the snapshot.

--- a/internal/cmd/manager/instance/run/cmd.go
+++ b/internal/cmd/manager/instance/run/cmd.go
@@ -67,12 +67,12 @@ import (
 var (
 	scheme = runtime.NewScheme()
 
-	// errNoFreeWALSpace is raised when there's not enough disk space
-	// to store two WAL files
+	// errNoFreeWALSpace is returned when there isn't enough disk space
+	// available to store at least two WAL files.
 	errNoFreeWALSpace = fmt.Errorf("no free disk space for WALs")
 
-	// errWALArchivePluginNotAvailable is raised when there's not enough disk space
-	// to store two WAL files
+	// errWALArchivePluginNotAvailable is returned when the configured
+	// WAL archiving plugin is not available or cannot be found.
 	errWALArchivePluginNotAvailable = fmt.Errorf("WAL archive plugin not available")
 )
 

--- a/internal/cmd/manager/instance/run/lifecycle/run.go
+++ b/internal/cmd/manager/instance/run/lifecycle/run.go
@@ -77,6 +77,12 @@ func (i *PostgresLifecycle) runPostgresAndWait(ctx context.Context) <-chan error
 		// following will be a no-op.
 		i.systemInitialization.Wait()
 
+		// If the system initialization failed, we return an error and let
+		// the instance manager quit.
+		if i.systemInitialization.Err() != nil {
+			return err
+		}
+
 		// The lifecycle loop will call us even when PostgreSQL is fenced.
 		// In that case there's no need to proceed.
 		if i.instance.IsFenced() {

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -463,6 +463,10 @@ func (r *ClusterReconciler) reconcile(ctx context.Context, cluster *apiv1.Cluste
 		return res, err
 	}
 
+	if res, err := r.requireWALArchivingPluginOrDelete(ctx, instancesStatus); err != nil || !res.IsZero() {
+		return res, err
+	}
+
 	if res, err := replicaclusterswitch.Reconcile(
 		ctx, r.Client, cluster, r.InstanceClient, instancesStatus); res != nil || err != nil {
 		if res != nil {
@@ -593,6 +597,30 @@ func (r *ClusterReconciler) ensureNoFailoverOnFullDisk(
 		return ctrl.Result{}, err
 	}
 	return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+}
+
+func (r *ClusterReconciler) requireWALArchivingPluginOrDelete(
+	ctx context.Context,
+	instances postgres.PostgresqlStatusList,
+) (ctrl.Result, error) {
+	contextLogger := log.FromContext(ctx).WithName("require_wal_archiving_plugin_delete")
+
+	for _, state := range instances.Items {
+		if !isTerminatedBecauseOfMissingWALArchivePlugin(state.Pod) {
+			contextLogger.Warning(
+				"Detected instance manager initialization procedure that failed "+
+					"because the required WAL archive plugin is missing. Deleting it to trigger rollout",
+				"targetPod", state.Pod.Name)
+			if err := r.Delete(ctx, state.Pod); err != nil {
+				contextLogger.Error(err, "Cannot delete the pod", "pod", state.Pod.Name)
+				return ctrl.Result{}, err
+			}
+
+			return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+		}
+	}
+
+	return ctrl.Result{}, nil
 }
 
 func (r *ClusterReconciler) handleSwitchover(


### PR DESCRIPTION
This patch addresses a rollout issue when migrating from the in-tree Barman Cloud support to the `barman-cloud` plugin, particularly when using the `switchover` primary update strategy.

During such a migration, a switchover is triggered to roll out the former primary instance. After the switchover, the former primary Pod restarts and attempts to archive any remaining WAL files in the queue before starting PostgreSQL. These files may still be present due to archiving or misconfiguration delays.

However, the previous version of the Pod does not include support for the plugin-based archiving system, causing all archiving attempts to fail during this pre-start phase. As a result, the Pod stalls indefinitely, blocking the rollout.

This fix introduces a mechanism to detect this specific failure scenario. If WAL archiving cannot proceed due to a missing plugin, the Pod exits with a distinct exit code. The operator recognises this exit code and replaces the Pod with one based on the updated container image, ensuring the plugin is available and WAL archiving can continue as expected.

Fixes: #8189