### PR TITLE
chore(renovate): create a group for distroless digests images

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -300,5 +300,13 @@
       separateMajorMinor: false,
       pinDigests: false,
     },
+    {
+      groupName: 'container distroless digests',
+      matchPackageNames: [
+        'gcr.io/distroless{/,}**',
+      ],
+      pinDigests: true,
+      separateMajorMinor: false,
+    },
   ],
 }


### PR DESCRIPTION
Create a group for the distroless digest in Renovate