### PR TITLE
fix: unblock rollout of former primary Pod when WAL archiving plugin is missing (#8236)

### DIFF
--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -112,6 +112,11 @@ const (
 	// MissingWALDiskSpaceExitCode is the exit code the instance manager
 	// will use to signal that there's no more WAL disk space
 	MissingWALDiskSpaceExitCode = 4
+
+	// MissingWALArchivePlugin is the exit code used by the instance manager
+	// to indicate that it started successfully, but the configured WAL
+	// archiving plugin is not available.
+	MissingWALArchivePlugin = 5
 )
 
 // SnapshotOwnerReference defines the reference type for the owner of the snapshot.

--- a/internal/cmd/manager/instance/join/cmd.go
+++ b/internal/cmd/manager/instance/join/cmd.go
@@ -116,6 +116,7 @@ func joinSubCommand(ctx context.Context, instance *postgres.Instance, info postg
 		contextLogger.Error(err, "Error while getting cluster")
 		return err
 	}
+	instance.Cluster = &cluster
 
 	if _, err := instancecertificate.NewReconciler(client, instance).RefreshSecrets(ctx, &cluster); err != nil {
 		contextLogger.Error(err, "Error while refreshing secrets")

--- a/internal/cmd/manager/instance/run/cmd.go
+++ b/internal/cmd/manager/instance/run/cmd.go
@@ -26,6 +26,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 
 	"github.com/cloudnative-pg/machinery/pkg/log"
 	"github.com/spf13/cobra"
@@ -42,6 +43,8 @@ import (
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/manager/instance/run/lifecycle"
+	"github.com/cloudnative-pg/cloudnative-pg/internal/cnpi/plugin/repository"
+	"github.com/cloudnative-pg/cloudnative-pg/internal/configuration"
 	"github.com/cloudnative-pg/cloudnative-pg/internal/management/controller"
 	"github.com/cloudnative-pg/cloudnative-pg/internal/management/controller/externalservers"
 	"github.com/cloudnative-pg/cloudnative-pg/internal/management/controller/roles"
@@ -63,9 +66,13 @@ import (
 var (
 	scheme = runtime.NewScheme()
 
-	// errNoFreeWALSpace is raised when there's not enough disk space
-	// to store two WAL files
+	// errNoFreeWALSpace is returned when there isn't enough disk space
+	// available to store at least two WAL files.
 	errNoFreeWALSpace = fmt.Errorf("no free disk space for WALs")
+
+	// errWALArchivePluginNotAvailable is returned when the configured
+	// WAL archiving plugin is not available or cannot be found.
+	errWALArchivePluginNotAvailable = fmt.Errorf("WAL archive plugin not available")
 )
 
 func init() {
@@ -111,6 +118,9 @@ func NewCmd() *cobra.Command {
 			if errors.Is(err, errNoFreeWALSpace) {
 				os.Exit(apiv1.MissingWALDiskSpaceExitCode)
 			}
+			if errors.Is(err, errWALArchivePluginNotAvailable) {
+				os.Exit(apiv1.MissingWALArchivePlugin)
+			}
 
 			return err
 		},
@@ -137,7 +147,7 @@ func NewCmd() *cobra.Command {
 	return cmd
 }
 
-func runSubCommand(ctx context.Context, instance *postgres.Instance) error {
+func runSubCommand(ctx context.Context, instance *postgres.Instance) error { //nolint:gocognit,gocyclo
 	var err error
 
 	contextLogger := log.FromContext(ctx)
@@ -210,8 +220,18 @@ func runSubCommand(ctx context.Context, instance *postgres.Instance) error {
 	postgresStartConditions := concurrency.MultipleExecuted{}
 	exitedConditions := concurrency.MultipleExecuted{}
 
+	var loadedPluginNames []string
+	pluginRepository := repository.New()
+	if loadedPluginNames, err = pluginRepository.RegisterUnixSocketPluginsInPath(
+		configuration.Current.PluginSocketDir,
+	); err != nil {
+		contextLogger.Error(err, "Unable to load sidecar CNPG-i plugins, skipping")
+	}
+	defer pluginRepository.Close()
+
 	metricsExporter := metricserver.NewExporter(instance)
 	reconciler := controller.NewInstanceReconciler(instance, mgr.GetClient(), metricsExporter)
+
 	err = ctrl.NewControllerManagedBy(mgr).
 		For(&apiv1.Cluster{}).
 		Named("instance-cluster").
@@ -360,7 +380,18 @@ func runSubCommand(ctx context.Context, instance *postgres.Instance) error {
 		contextLogger.Error(err, "Error while checking if there is enough disk space for WALs, skipping")
 	} else if !hasDiskSpaceForWals {
 		contextLogger.Info("Detected low-disk space condition")
-		return errNoFreeWALSpace
+		return makeUnretryableError(errNoFreeWALSpace)
+	}
+
+	if instance.Cluster != nil {
+		enabledArchiverPluginName := instance.Cluster.GetEnabledWALArchivePluginName()
+		if enabledArchiverPluginName != "" && !slices.Contains(loadedPluginNames, enabledArchiverPluginName) {
+			contextLogger.Info(
+				"Detected missing WAL archiver plugin, waiting for the operator to rollout a new instance Pod",
+				"enabledArchiverPluginName", enabledArchiverPluginName,
+				"loadedPluginNames", loadedPluginNames)
+			return makeUnretryableError(errWALArchivePluginNotAvailable)
+		}
 	}
 
 	return nil

--- a/internal/cmd/manager/instance/run/lifecycle/run.go
+++ b/internal/cmd/manager/instance/run/lifecycle/run.go
@@ -77,6 +77,12 @@ func (i *PostgresLifecycle) runPostgresAndWait(ctx context.Context) <-chan error
 		// following will be a no-op.
 		i.systemInitialization.Wait()
 
+		// If the system initialization failed, we return an error and let
+		// the instance manager quit.
+		if i.systemInitialization.Err() != nil {
+			return err
+		}
+
 		// The lifecycle loop will call us even when PostgreSQL is fenced.
 		// In that case there's no need to proceed.
 		if i.instance.IsFenced() {

--- a/internal/cmd/manager/instance/upgrade/execute/cmd.go
+++ b/internal/cmd/manager/instance/upgrade/execute/cmd.go
@@ -157,6 +157,7 @@ func (ui upgradeInfo) upgradeSubCommand(ctx context.Context, instance *postgres.
 		contextLogger.Error(err, "Error while getting cluster")
 		return err
 	}
+	instance.Cluster = &cluster
 
 	if _, err := instancecertificate.NewReconciler(client, instance).RefreshSecrets(ctx, &cluster); err != nil {
 		return fmt.Errorf("error while downloading secrets: %w", err)

--- a/internal/management/controller/instance_controller.go
+++ b/internal/management/controller/instance_controller.go
@@ -917,6 +917,7 @@ func (r *InstanceReconciler) reconcileInstance(cluster *apiv1.Cluster) {
 	r.instance.MaxStopDelay = cluster.GetMaxStopDelay()
 	r.instance.SmartStopDelay = cluster.GetSmartShutdownTimeout()
 	r.instance.RequiresDesignatedPrimaryTransition = detectRequiresDesignatedPrimaryTransition()
+	r.instance.Cluster = cluster
 }
 
 // PostgreSQLAutoConfWritable reconciles the permissions bit of `postgresql.auto.conf`

--- a/pkg/management/postgres/initdb.go
+++ b/pkg/management/postgres/initdb.go
@@ -165,7 +165,7 @@ func (info InitInfo) EnsureTargetDirectoriesDoNotExist(ctx context.Context) erro
 		return nil
 	}
 
-	out, err := info.GetInstance().GetPgControldata()
+	out, err := info.GetInstance(nil).GetPgControldata()
 	if err == nil {
 		contextLogger.Info("pg_controldata check on existing directory succeeded, renaming the folders", "out", out)
 		return info.renameExistingTargetDataDirectories(ctx, pgWalExists)
@@ -292,10 +292,11 @@ func (info InitInfo) CreateDataDirectory() error {
 }
 
 // GetInstance gets the PostgreSQL instance which correspond to these init information
-func (info InitInfo) GetInstance() *Instance {
+func (info InitInfo) GetInstance(cluster *apiv1.Cluster) *Instance {
 	postgresInstance := NewInstance()
 	postgresInstance.PgData = info.PgData
 	postgresInstance.StartupOptions = []string{"listen_addresses='127.0.0.1'"}
+	postgresInstance.Cluster = cluster
 	return postgresInstance
 }
 
@@ -465,7 +466,7 @@ func (info InitInfo) Bootstrap(ctx context.Context) error {
 		return err
 	}
 
-	instance := info.GetInstance()
+	instance := info.GetInstance(cluster)
 
 	// Detect an initdb bootstrap with import
 	isImportBootstrap := cluster.Spec.Bootstrap != nil &&

--- a/pkg/management/postgres/instance.go
+++ b/pkg/management/postgres/instance.go
@@ -215,6 +215,9 @@ type Instance struct {
 	MetricsPortTLS bool
 
 	serverCertificateHandler serverCertificateHandler
+
+	// Cluster is the cluster this instance belongs to
+	Cluster *apiv1.Cluster
 }
 
 type serverCertificateHandler struct {

--- a/pkg/management/postgres/restore.go
+++ b/pkg/management/postgres/restore.go
@@ -110,7 +110,7 @@ func (info InitInfo) RestoreSnapshot(ctx context.Context, cli client.Client, imm
 		// If the instance will start as a primary, we will enter in the
 		// same logic attaching an old primary back after a failover.
 		// We don't need that as this instance has never diverged.
-		if err := info.GetInstance().Demote(ctx, cluster); err != nil {
+		if err := info.GetInstance(nil).Demote(ctx, cluster); err != nil {
 			return fmt.Errorf("error while demoting the instance: %w", err)
 		}
 		return nil
@@ -182,7 +182,7 @@ func (info InitInfo) concludeRestore(
 	// we recover from a base which has postgresql.auto.conf
 	// the override.conf and include statement is present, what we need to do is to
 	// migrate the content
-	if _, err := info.GetInstance().migratePostgresAutoConfFile(ctx); err != nil {
+	if _, err := info.GetInstance(cluster).migratePostgresAutoConfFile(ctx); err != nil {
 		return err
 	}
 	if cluster.IsReplica() {
@@ -826,7 +826,7 @@ func (info InitInfo) WriteInitialPostgresqlConf(ctx context.Context, cluster *ap
 		return fmt.Errorf("while creating a temporary data directory: %w", err)
 	}
 
-	temporaryInstance := temporaryInitInfo.GetInstance().
+	temporaryInstance := temporaryInitInfo.GetInstance(cluster).
 		WithNamespace(info.Namespace).
 		WithClusterName(info.ClusterName)
 
@@ -888,7 +888,7 @@ func (info InitInfo) WriteRestoreHbaConf(ctx context.Context) error {
 	}
 
 	// Create only the local map referred in the HBA configuration
-	_, err = info.GetInstance().RefreshPGIdent(ctx, nil)
+	_, err = info.GetInstance(nil).RefreshPGIdent(ctx, nil)
 	return err
 }
 
@@ -899,7 +899,7 @@ func (info InitInfo) WriteRestoreHbaConf(ctx context.Context) error {
 func (info InitInfo) ConfigureInstanceAfterRestore(ctx context.Context, cluster *apiv1.Cluster, env []string) error {
 	contextLogger := log.FromContext(ctx)
 
-	instance := info.GetInstance()
+	instance := info.GetInstance(cluster)
 	instance.Env = env
 
 	if err := instance.VerifyPgDataCoherence(ctx); err != nil {


### PR DESCRIPTION
This patch addresses a rollout issue when migrating from the in-tree Barman Cloud support to the `barman-cloud` plugin, particularly when using the `switchover` primary update strategy.

During such a migration, a switchover is triggered to roll out the former primary instance. After the switchover, the former primary Pod restarts and attempts to archive any remaining WAL files in the queue before starting PostgreSQL. These files may still be present due to archiving or misconfiguration delays.

However, the previous version of the Pod does not include support for the plugin-based archiving system, causing all archiving attempts to fail during this pre-start phase. As a result, the Pod stalls indefinitely, blocking the rollout.

This fix introduces a mechanism to detect this specific failure scenario. If WAL archiving cannot proceed due to a missing plugin, the Pod exits with a distinct exit code. The operator recognises this exit code and replaces the Pod with one based on the updated container image, ensuring the plugin is available and WAL archiving can continue as expected.

Fixes: #8189

(cherry picked from commit 99550adf171efb72d806cea2210fee5698ef5386)