### PR TITLE
docs: fix broken liveness-probe link in v1.27 release notes

### DIFF
--- a/docs/src/release_notes/v1.27.md
+++ b/docs/src/release_notes/v1.27.md
@@ -12,7 +12,7 @@ on the release branch in GitHub.
 
 ### Important changes:
 
-- A change in the default behavior of the [liveness probe](instance_manager.md#liveness-probe),
+- A change in the default behavior of the [liveness probe](../instance_manager.md#liveness-probe),
   now enforcing the [shutdown of an isolated primary](instance_manager.md#primary-isolation)
   within the `livenessProbeTimeout` (30 seconds), will require a restart of your pods.
 


### PR DESCRIPTION
markdown Fixes an MkDocs warning: WARNING - Doc file 'release_notes/v1.27.md' contains a link 'instance_manager.md#liveness-probe', but the target 'release_notes/instance_manager.md' is not found. Changed the path to `../instance_manager.md#liveness-probe`, which renders correctly. Built locally with `mkdocs serve`; warning is gone.