### PR TITLE
chore(snapshots): clone maps during creation to avoid side effects

### DIFF
--- a/pkg/reconciler/backup/volumesnapshot/reconciler.go
+++ b/pkg/reconciler/backup/volumesnapshot/reconciler.go
@@ -459,9 +459,9 @@ func (se *Reconciler) createSnapshot(
 		pvc.Labels = map[string]string{}
 	}
 
-	labels := pvc.Labels
+	labels := maps.Clone(pvc.Labels)
 	maps.Copy(labels, snapshotConfig.Labels)
-	annotations := pvc.Annotations
+	annotations := maps.Clone(pvc.Annotations)
 	maps.Copy(annotations, snapshotConfig.Annotations)
 	transferLabelsToAnnotations(labels, annotations)
 


### PR DESCRIPTION
This avoids that we mutate the underlying maps objects.

Low priority, code cleanup.