### PR TITLE
Fixes Issue #8119 [Bug]: Pooler reconciliation loop when service is type LoadBalancer

### DIFF
--- a/internal/controller/pooler_update.go
+++ b/internal/controller/pooler_update.go
@@ -150,12 +150,12 @@ func (r *PoolerReconciler) reconcileService(
 	}
 
 	patchedService := resources.Service.DeepCopy()
-	
+
 	// only update specific fields in the spec to avoid overwriting
 	// fields that might be automatically managed by the cloud environment
 	// e.g., externalIPs for LoadBalancer services
 	var shouldUpdate bool
-	
+
 	// update the selector if it is different
 	if !reflect.DeepEqual(expectedService.Spec.Selector, patchedService.Spec.Selector) {
 		patchedService.Spec.Selector = expectedService.Spec.Selector
@@ -185,7 +185,7 @@ func (r *PoolerReconciler) reconcileService(
 		patchedService.Spec.SessionAffinityConfig = expectedService.Spec.SessionAffinityConfig
 		shouldUpdate = true
 	}
-	
+
 	// merge metadata
 	originalLabels := make(map[string]string)
 	for k, v := range patchedService.GetLabels() {
@@ -195,9 +195,9 @@ func (r *PoolerReconciler) reconcileService(
 	for k, v := range patchedService.GetAnnotations() {
 		originalAnnotations[k] = v
 	}
-	
+
 	utils.MergeObjectsMetadata(patchedService, expectedService)
-	
+
 	// check if metadata actually changed
 	if !reflect.DeepEqual(originalLabels, patchedService.GetLabels()) ||
 		!reflect.DeepEqual(originalAnnotations, patchedService.GetAnnotations()) {

--- a/internal/controller/pooler_update.go
+++ b/internal/controller/pooler_update.go
@@ -150,11 +150,61 @@ func (r *PoolerReconciler) reconcileService(
 	}
 
 	patchedService := resources.Service.DeepCopy()
-	patchedService.Spec = expectedService.Spec
-	utils.MergeObjectsMetadata(patchedService, expectedService)
+	
+	// only update specific fields in the spec to avoid overwriting
+	// fields that might be automatically managed by the cloud environment
+	// e.g., externalIPs for LoadBalancer services
+	var shouldUpdate bool
+	
+	// update the selector if it is different
+	if !reflect.DeepEqual(expectedService.Spec.Selector, patchedService.Spec.Selector) {
+		patchedService.Spec.Selector = expectedService.Spec.Selector
+		shouldUpdate = true
+	}
 
-	if reflect.DeepEqual(patchedService.ObjectMeta, resources.Service.ObjectMeta) &&
-		reflect.DeepEqual(patchedService.Spec, resources.Service.Spec) {
+	// update ports if they are different
+	if !reflect.DeepEqual(expectedService.Spec.Ports, patchedService.Spec.Ports) {
+		patchedService.Spec.Ports = expectedService.Spec.Ports
+		shouldUpdate = true
+	}
+
+	// update service type if it is different
+	if expectedService.Spec.Type != patchedService.Spec.Type {
+		patchedService.Spec.Type = expectedService.Spec.Type
+		shouldUpdate = true
+	}
+
+	// update session affinity if it is different
+	if expectedService.Spec.SessionAffinity != patchedService.Spec.SessionAffinity {
+		patchedService.Spec.SessionAffinity = expectedService.Spec.SessionAffinity
+		shouldUpdate = true
+	}
+
+	// update session affinity config if it is different
+	if !reflect.DeepEqual(expectedService.Spec.SessionAffinityConfig, patchedService.Spec.SessionAffinityConfig) {
+		patchedService.Spec.SessionAffinityConfig = expectedService.Spec.SessionAffinityConfig
+		shouldUpdate = true
+	}
+	
+	// merge metadata
+	originalLabels := make(map[string]string)
+	for k, v := range patchedService.GetLabels() {
+		originalLabels[k] = v
+	}
+	originalAnnotations := make(map[string]string)
+	for k, v := range patchedService.GetAnnotations() {
+		originalAnnotations[k] = v
+	}
+	
+	utils.MergeObjectsMetadata(patchedService, expectedService)
+	
+	// check if metadata actually changed
+	if !reflect.DeepEqual(originalLabels, patchedService.GetLabels()) ||
+		!reflect.DeepEqual(originalAnnotations, patchedService.GetAnnotations()) {
+		shouldUpdate = true
+	}
+
+	if !shouldUpdate {
 		return nil
 	}
 


### PR DESCRIPTION
Fixes Issue #8119 

the problem was in the reconcileService function where we were doing a wholesale replacement of the entire service spec (patchedService.Spec = expectedService.Spec), which was inadvertently removing cloud-managed fields like externalIPs that are automatically populated by load balancers this created a cycle where the cloud provider would re-add these fields  triggering another reconciliation that would remove them again
this is resolved by refactoring the reconciliation logic to be selective rather than destructive now we only update the specific fields that CloudNativePG actually manages (Selector, Ports, Type, SessionAffinity, and SessionAffinityConfig) while preserving any cloud-managed fields. This approach eliminates the reconciliation loops while maintaining full compatibility with all existing functionality.

@sxd @gbartolini please review this PR and request if any further changes required !!