### PR TITLE
docs: fix two broken links in v1.27 release notes

### DIFF
--- a/docs/src/release_notes/v1.27.md
+++ b/docs/src/release_notes/v1.27.md
@@ -12,8 +12,8 @@ on the release branch in GitHub.
 
 ### Important changes:
 
-- A change in the default behavior of the [liveness probe](instance_manager.md#liveness-probe),
-  now enforcing the [shutdown of an isolated primary](instance_manager.md#primary-isolation)
+- A change in the default behavior of the [liveness probe](../instance_manager.md#liveness-probe),
+  now enforcing the [shutdown of an isolated primary](../instance_manager.md#primary-isolation)
   within the `livenessProbeTimeout` (30 seconds), will require a restart of your pods.
 
 ### Features:


### PR DESCRIPTION
Fixes two MkDocs warnings in v1.27 release notes by correcting relative paths:

- liveness probe → ../instance_manager.md#liveness-probe
- primary isolation → ../instance_manager.md#primary-isolation

Built locally with `mkdocs build`; warnings are gone.
