### PR TITLE
chore: fix cloudnative-pg grouping test dependencies

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -295,7 +295,7 @@
     {
       groupName: 'cnpg',
       matchPackageNames: [
-        'github.com/cloudnative-pg/',
+        'github.com/cloudnative-pg{/,}**',
       ],
       separateMajorMinor: false,
       pinDigests: false,


### PR DESCRIPTION
The groiup created for Renovate on the cloudnative-pg dependencies repo
was missing the `{/,}**` to cover all the sub-repos.