### PR TITLE
chore(controller_backup): add VolumeSnapshotReconciler to the struct

### DIFF
--- a/internal/controller/backup_controller.go
+++ b/internal/controller/backup_controller.go
@@ -86,6 +86,8 @@ type BackupReconciler struct {
 	Plugins  repository.Interface
 
 	instanceStatusClient remote.InstanceClient
+
+	vsr *volumesnapshot.Reconciler
 }
 
 // NewBackupReconciler properly initializes the BackupReconciler
@@ -94,13 +96,16 @@ func NewBackupReconciler(
 	discoveryClient *discovery.DiscoveryClient,
 	plugins repository.Interface,
 ) *BackupReconciler {
+	cli := mgr.GetClient()
+	recorder := mgr.GetEventRecorderFor("cloudnative-pg-backup")
 	return &BackupReconciler{
-		Client:               mgr.GetClient(),
+		Client:               cli,
 		DiscoveryClient:      discoveryClient,
 		Scheme:               mgr.GetScheme(),
-		Recorder:             mgr.GetEventRecorderFor("cloudnative-pg-backup"),
+		Recorder:             recorder,
 		instanceStatusClient: remote.NewClient().Instance(),
 		Plugins:              plugins,
+		vsr:                  volumesnapshot.NewReconcilerBuilder(cli, recorder).Build(),
 	}
 }
 
@@ -490,11 +495,7 @@ func (r *BackupReconciler) reconcileSnapshotBackup(
 		return nil, fmt.Errorf("cannot get PVCs: %w", err)
 	}
 
-	reconciler := volumesnapshot.
-		NewReconcilerBuilder(r.Client, r.Recorder).
-		Build()
-
-	res, err := reconciler.Reconcile(ctx, cluster, backup, targetPod, pvcs)
+	res, err := r.vsr.Reconcile(ctx, cluster, backup, targetPod, pvcs)
 	if err != nil {
 		// Volume Snapshot errors are not retryable, we need to set this backup as failed
 		// and un-fence the Pod

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -44,6 +44,7 @@ import (
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	schemeBuilder "github.com/cloudnative-pg/cloudnative-pg/internal/scheme"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/certs"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/reconciler/backup/volumesnapshot"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/reconciler/persistentvolumeclaim"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/specs"
 
@@ -117,6 +118,7 @@ func buildTestEnvironment() *testingEnvironment {
 		Client:   k8sClient,
 		Scheme:   scheme,
 		Recorder: record.NewFakeRecorder(120),
+		vsr:      volumesnapshot.NewReconcilerBuilder(k8sClient, record.NewFakeRecorder(120)).Build(),
 	}
 
 	return &testingEnvironment{


### PR DESCRIPTION
The volumesnapshot.Reconciler was previously created on-the-fly inside the reconcileSnapshotBackup method, worsening the overall performance and making the BackupReconciler harder to test in isolation.


Low priority chore