### PR TITLE
chore: pin `packaging` version in workflow

### DIFF
--- a/.github/workflows/latest-postgres-version-check.yml
+++ b/.github/workflows/latest-postgres-version-check.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Install Python dependencies
         run: |
-          pip install packaging
+          pip install packaging==25.0
 
       - name: Generate PostgreSQL JSON files
         run: |


### PR DESCRIPTION
The package `packaging` must use a pinned version when it's installed

Closes #8322 