### PR TITLE
feat: replica method preference option

### DIFF
--- a/api/v1/backup_types.go
+++ b/api/v1/backup_types.go
@@ -118,6 +118,22 @@ const (
 	BackupMethodPlugin BackupMethod = "plugin"
 )
 
+// ReplicaBackupMethodPreference defines the preferred backup method for
+// creating replicas
+type ReplicaBackupMethodPreference string
+
+const (
+	// ReplicaBackupMethodPreferenceVolumeSnapshot prefers volume snapshots for
+	// replica creation, falling back to barman if no volume snapshots are
+	// available
+	ReplicaBackupMethodPreferenceVolumeSnapshot ReplicaBackupMethodPreference = "volumeSnapshot"
+
+	// ReplicaBackupMethodPreferenceBarmanObjectStore prefers barman object
+	// store for replica creation, falling back to volume snapshots if no barman
+	// backups are available
+	ReplicaBackupMethodPreferenceBarmanObjectStore ReplicaBackupMethodPreference = "barmanObjectStore"
+)
+
 // BackupSpec defines the desired state of Backup
 // +kubebuilder:validation:XValidation:rule="oldSelf == self",message="BackupSpec is immutable once set"
 type BackupSpec struct {

--- a/api/v1/cluster_defaults.go
+++ b/api/v1/cluster_defaults.go
@@ -84,8 +84,13 @@ func (r *Cluster) setDefaults(preserveUserSettings bool) {
 		r.Spec.Affinity.PodAntiAffinityType = PodAntiAffinityTypePreferred
 	}
 
-	if r.Spec.Backup != nil && r.Spec.Backup.Target == "" {
-		r.Spec.Backup.Target = DefaultBackupTarget
+	if r.Spec.Backup != nil {
+		if r.Spec.Backup.Target == "" {
+			r.Spec.Backup.Target = DefaultBackupTarget
+		}
+		if r.Spec.Backup.ReplicaMethodPreference == "" {
+			r.Spec.Backup.ReplicaMethodPreference = ReplicaBackupMethodPreferenceVolumeSnapshot
+		}
 	}
 
 	psqlVersion, err := r.GetPostgresqlMajorVersion()

--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -2129,6 +2129,16 @@ type BackupConfiguration struct {
 	// +kubebuilder:default:=prefer-standby
 	// +optional
 	Target BackupTarget `json:"target,omitempty"`
+
+	// The preferred backup method to use when creating replicas:
+	// `volumeSnapshot` or `barmanObjectStore`. This setting only affects
+	// replica creation and does not influence the backup method used for
+	// regular backups. If the preferred method is unavailable, it will fall
+	// back to the other available option.
+	// +kubebuilder:validation:Enum=volumeSnapshot;barmanObjectStore
+	// +kubebuilder:default:=volumeSnapshot
+	// +optional
+	ReplicaMethodPreference ReplicaBackupMethodPreference `json:"replicaMethodPreference,omitempty"`
 }
 
 // MonitoringConfiguration is the type containing all the monitoring

--- a/config/crd/bases/postgresql.cnpg.io_clusters.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_clusters.yaml
@@ -1387,6 +1387,18 @@ spec:
                     required:
                     - destinationPath
                     type: object
+                  replicaMethodPreference:
+                    default: volumeSnapshot
+                    description: |-
+                      The preferred backup method to use when creating replicas:
+                      `volumeSnapshot` or `barmanObjectStore`. This setting only affects
+                      replica creation and does not influence the backup method used for
+                      regular backups. If the preferred method is unavailable, it will fall
+                      back to the other available option.
+                    enum:
+                    - volumeSnapshot
+                    - barmanObjectStore
+                    type: string
                   retentionPolicy:
                     description: |-
                       RetentionPolicy is the retention policy to be used for backups


### PR DESCRIPTION
Add `replicaMethodPreference` to the  backup config in the cluster spec 
which allows users to control which backup method is preferred when 
creating new replicas. Useful if you are moving clusters between storage
backends where snapshots wont work. Like before, the default prefers 
VolumeSnapshot.

Signed-off-by: Martin Hansen <dontbeevilpls@gmail.com>