### PR TITLE
chore: fix azure tests for backup and PITR

### DIFF
--- a/tests/e2e/backup_restore_azure_test.go
+++ b/tests/e2e/backup_restore_azure_test.go
@@ -306,7 +306,7 @@ var _ = Describe("Azure - Clusters Recovery From Barman Object Store", Label(tes
 					clusterName,
 					sourceBackupFileAzurePITR,
 					AzureConfiguration,
-					1,
+					2,
 					currentTimestamp,
 				)
 
@@ -413,7 +413,7 @@ var _ = Describe("Azure - Clusters Recovery From Barman Object Store", Label(tes
 					clusterName,
 					sourceBackupFileAzurePITRSAS,
 					AzureConfiguration,
-					1,
+					2,
 					currentTimestamp,
 				)
 

--- a/tests/e2e/fixtures/backup/recovery_external_clusters/backup-azure-blob-pitr.yaml
+++ b/tests/e2e/fixtures/backup/recovery_external_clusters/backup-azure-blob-pitr.yaml
@@ -4,4 +4,4 @@ metadata:
   name: cluster-backup-pitr
 spec:
   cluster:
-    name: external-cluster-azure
+    name: source-cluster-azure


### PR DESCRIPTION
The Azure tests was taking the backup from the wrong cluster when preparing to restore, causing a failure since our last patch to fix the backup names.

Close #8332 