### PR TITLE
feat: allow the customization of webhook related resource names

### DIFF
--- a/internal/cmd/manager/controller/controller.go
+++ b/internal/cmd/manager/controller/controller.go
@@ -56,16 +56,6 @@ const (
 	// for the webhook server are stored
 	WebhookSecretName = "cnpg-webhook-cert" // #nosec
 
-	// WebhookServiceName is the name of the service where the webhook server
-	// is reachable
-	WebhookServiceName = "cnpg-webhook-service" // #nosec
-
-	// MutatingWebhookConfigurationName is the name of the mutating webhook configuration
-	MutatingWebhookConfigurationName = "cnpg-mutating-webhook-configuration"
-
-	// ValidatingWebhookConfigurationName is the name of the validating webhook configuration
-	ValidatingWebhookConfigurationName = "cnpg-validating-webhook-configuration"
-
 	// The name of the directory containing the TLS certificates
 	defaultWebhookCertDir = "/run/secrets/cnpg.io/webhook"
 
@@ -385,10 +375,10 @@ func ensurePKI(
 		CaSecretName:                       CaSecretName,
 		CertDir:                            mgrCertDir,
 		SecretName:                         WebhookSecretName,
-		ServiceName:                        WebhookServiceName,
+		ServiceName:                        conf.WebhookServiceName,
 		OperatorNamespace:                  conf.OperatorNamespace,
-		MutatingWebhookConfigurationName:   MutatingWebhookConfigurationName,
-		ValidatingWebhookConfigurationName: ValidatingWebhookConfigurationName,
+		MutatingWebhookConfigurationName:   conf.MutatingWebhookConfigurationName,
+		ValidatingWebhookConfigurationName: conf.ValidatingWebhookConfigurationName,
 		OperatorDeploymentLabelSelector:    "app.kubernetes.io/name=cloudnative-pg",
 	}
 	err := pkiConfig.Setup(ctx, kubeClient)

--- a/internal/configuration/configuration.go
+++ b/internal/configuration/configuration.go
@@ -47,6 +47,16 @@ const (
 	// DefaultKubernetesClusterDomain is the default value used as
 	// Kubernetes cluster domain.
 	DefaultKubernetesClusterDomain = "cluster.local"
+
+	// DefaultwebhookServiceName is the default name of the service where the webhook server
+	// is reachable
+	DefaultWebhookServiceName = "cnpg-webhook-service" // #nosec
+
+	// DefaultMutatingWebhookConfigurationName is the default name of the mutating webhook configuration
+	DefaultMutatingWebhookConfigurationName = "cnpg-mutating-webhook-configuration"
+
+	// DefaultValidatingWebhookConfigurationName is the default name of the validating webhook configuration
+	DefaultValidatingWebhookConfigurationName = "cnpg-validating-webhook-configuration"
 )
 
 // DefaultDrainTaints is the default list of taints the operator will watch and treat
@@ -165,6 +175,16 @@ type Data struct {
 
 	// DrainTaints is a list of taints the operator will watch and treat as Unschedule
 	DrainTaints []string `json:"drainTaints" env:"DRAIN_TAINTS"`
+
+	// WebhookServiceName is the name of the service where the webhook server
+	// is reachable
+	WebhookServiceName string `json:"webhookServiceName" env:"WEBHOOK_SERVICE_NAME"`
+
+	// MutatingWebhookConfigurationName is the name of the mutating webhook configuration
+	MutatingWebhookConfigurationName string `json:"mutatingWebhookConfigurationName" env:"MUTATING_WEBHOOK_CONFIGURATION_NAME"`
+
+	// ValidatingWebhookConfigurationName is the name of the validating webhook configuration
+	ValidatingWebhookConfigurationName string `json:"validatingWebhookConfigurationName" env:"VALIDATING_WEBHOOK_CONFIGURATION_NAME"`
 }
 
 // Current is the configuration used by the operator
@@ -173,16 +193,19 @@ var Current = NewConfiguration()
 // newDefaultConfig creates a configuration holding the defaults
 func newDefaultConfig() *Data {
 	return &Data{
-		OperatorPullSecretName:  DefaultOperatorPullSecretName,
-		OperatorImageName:       versions.DefaultOperatorImageName,
-		PostgresImageName:       versions.DefaultImageName,
-		PluginSocketDir:         DefaultPluginSocketDir,
-		CreateAnyService:        false,
-		CertificateDuration:     CertificateDuration,
-		ExpiringCheckThreshold:  ExpiringCheckThreshold,
-		StandbyTCPUserTimeout:   0,
-		KubernetesClusterDomain: DefaultKubernetesClusterDomain,
-		DrainTaints:             DefaultDrainTaints,
+		OperatorPullSecretName:             DefaultOperatorPullSecretName,
+		OperatorImageName:                  versions.DefaultOperatorImageName,
+		PostgresImageName:                  versions.DefaultImageName,
+		PluginSocketDir:                    DefaultPluginSocketDir,
+		CreateAnyService:                   false,
+		CertificateDuration:                CertificateDuration,
+		ExpiringCheckThreshold:             ExpiringCheckThreshold,
+		StandbyTCPUserTimeout:              0,
+		KubernetesClusterDomain:            DefaultKubernetesClusterDomain,
+		DrainTaints:                        DefaultDrainTaints,
+		WebhookServiceName:                 DefaultWebhookServiceName,
+		MutatingWebhookConfigurationName:   DefaultMutatingWebhookConfigurationName,
+		ValidatingWebhookConfigurationName: DefaultValidatingWebhookConfigurationName,
 	}
 }
 

--- a/tests/utils/operator/webhooks.go
+++ b/tests/utils/operator/webhooks.go
@@ -34,6 +34,7 @@ import (
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/manager/controller"
+	"github.com/cloudnative-pg/cloudnative-pg/internal/configuration"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/objects"
 )
 
@@ -84,7 +85,7 @@ func getCNPGsValidatingWebhookConf(
 	*admissionregistrationv1.ValidatingWebhookConfiguration, error,
 ) {
 	validatingWebhookConf := &admissionregistrationv1.ValidatingWebhookConfiguration{}
-	err := crudClient.Get(ctx, types.NamespacedName{Name: controller.ValidatingWebhookConfigurationName},
+	err := crudClient.Get(ctx, types.NamespacedName{Name: configuration.DefaultValidatingWebhookConfigurationName},
 		validatingWebhookConf)
 	return validatingWebhookConf, err
 }
@@ -155,7 +156,7 @@ func checkWebhookSetup(
 	for _, webhook := range mutatingWebhookConfig.Webhooks {
 		if !bytes.Equal(webhook.ClientConfig.CABundle, ca) {
 			return fmt.Errorf("secret %+v not match with ca bundle in %v: %v is not equal to %v",
-				controller.MutatingWebhookConfigurationName, secret, string(ca), string(webhook.ClientConfig.CABundle))
+				configuration.DefaultMutatingWebhookConfigurationName, secret, string(ca), string(webhook.ClientConfig.CABundle))
 		}
 	}
 
@@ -167,7 +168,7 @@ func checkWebhookSetup(
 	for _, webhook := range validatingWebhookConfig.Webhooks {
 		if !bytes.Equal(webhook.ClientConfig.CABundle, ca) {
 			return fmt.Errorf("secret not match with ca bundle in %v",
-				controller.ValidatingWebhookConfigurationName)
+				configuration.DefaultValidatingWebhookConfigurationName)
 		}
 	}
 
@@ -182,7 +183,7 @@ func getCNPGsMutatingWebhookConf(
 	*admissionregistrationv1.MutatingWebhookConfiguration, error,
 ) {
 	mutatingWebhookConfiguration := &admissionregistrationv1.MutatingWebhookConfiguration{}
-	err := crudClient.Get(ctx, types.NamespacedName{Name: controller.MutatingWebhookConfigurationName},
+	err := crudClient.Get(ctx, types.NamespacedName{Name: configuration.DefaultMutatingWebhookConfigurationName},
 		mutatingWebhookConfiguration)
 	return mutatingWebhookConfiguration, err
 }


### PR DESCRIPTION
Introduce the `WEBHOOK_SERVICE_NAME` configuration option, allowing users to specify the webhook service name, which will also be used in the generated certificate.

Introduce the `MUTATING_WEBHOOK_CONFIGURATION_NAME` configuration option, allowing users to specify a different name for the MutatingWebhookConfiguration resource.

Introduce the `VALIDATING_WEBHOOK_CONFIGURATION_NAME` configuration option, allowing users to specify a different name for the ValidatingWebhookConfiguration resource.

Signed-off-by: Hsn723 <me@atelierhsn.com>