### PR TITLE
Fixes Issue #8337 [Feature]: service definitions use port names rather than numbers

### DIFF
--- a/pkg/specs/pods.go
+++ b/pkg/specs/pods.go
@@ -73,6 +73,9 @@ const (
 	// inside one Pod
 	PostgresContainerName = "postgres"
 
+	// PostgresPortName is the name of the PostgreSQL port inside the container
+	PostgresPortName = "postgresql"
+
 	// BootstrapControllerContainerName is the name of the container copying the bootstrap
 	// controller inside the Pod file system
 	BootstrapControllerContainerName = "bootstrap-controller"
@@ -260,7 +263,7 @@ func createPostgresContainers(cluster apiv1.Cluster, envConfig EnvConfig, enable
 			Resources: cluster.Spec.Resources,
 			Ports: []corev1.ContainerPort{
 				{
-					Name:          "postgresql",
+					Name:          PostgresPortName,
 					ContainerPort: postgres.ServerPort,
 					Protocol:      "TCP",
 				},

--- a/pkg/specs/services.go
+++ b/pkg/specs/services.go
@@ -37,7 +37,7 @@ func buildInstanceServicePorts() []corev1.ServicePort {
 		{
 			Name:       PostgresContainerName,
 			Protocol:   corev1.ProtocolTCP,
-			TargetPort: intstr.FromInt32(postgres.ServerPort),
+			TargetPort: intstr.FromString(PostgresPortName),
 			Port:       postgres.ServerPort,
 		},
 	}

--- a/pkg/specs/services_test.go
+++ b/pkg/specs/services_test.go
@@ -41,7 +41,7 @@ var _ = Describe("Services specification", func() {
 	expectedPort := corev1.ServicePort{
 		Name:       PostgresContainerName,
 		Protocol:   corev1.ProtocolTCP,
-		TargetPort: intstr.FromInt32(postgres.ServerPort),
+		TargetPort: intstr.FromString(PostgresPortName),
 		Port:       postgres.ServerPort,
 	}
 
@@ -158,7 +158,7 @@ var _ = Describe("BuildManagedServices", func() {
 			Expect(services[0].Spec.Ports).To(ContainElement(corev1.ServicePort{
 				Name:       PostgresContainerName,
 				Protocol:   corev1.ProtocolTCP,
-				TargetPort: intstr.FromInt32(postgres.ServerPort),
+				TargetPort: intstr.FromString(PostgresPortName),
 				Port:       postgres.ServerPort,
 				NodePort:   0,
 			}))
@@ -169,7 +169,7 @@ var _ = Describe("BuildManagedServices", func() {
 				{
 					Name:       PostgresContainerName,
 					Protocol:   corev1.ProtocolTCP,
-					TargetPort: intstr.FromInt32(postgres.ServerPort),
+					TargetPort: intstr.FromString(PostgresPortName),
 					Port:       postgres.ServerPort,
 					NodePort:   5533,
 				},


### PR DESCRIPTION
fixes #8337 by changing service definitions to use port names instead of port numbers in the targetport field the services now reference the container port by name postgresql rather than by number 5432 which resolves linter warnings from tool popeyecli.io
@sxd @gbartolini review please !! 
