### PR TITLE
chore: set `STANDBY_TCP_USER_TIMEOUT` from e2e manifests

### DIFF
--- a/hack/e2e/env_override_customized.yaml.template
+++ b/hack/e2e/env_override_customized.yaml.template
@@ -12,6 +12,9 @@ spec:
         envFrom:
         - configMapRef:
             name: controller-manager-env
+        env:
+        - name: STANDBY_TCP_USER_TIMEOUT
+          value: "5000"
         args:
         - controller
         - --leader-elect=${LEADER_ELECTION}


### PR DESCRIPTION
Closes #8327 