### PR TITLE
chore: fix BackendsWaiting alert

### DIFF
--- a/docs/src/samples/monitoring/alerts.yaml
+++ b/docs/src/samples/monitoring/alerts.yaml
@@ -12,8 +12,8 @@ groups:
       severity: warning
   - alert: BackendsWaiting
     annotations:
-      description: Pod {{ $labels.pod  }} has been waiting for longer than 5 minutes
-      summary: If a backend is waiting for longer than 5 minutes
+      description: Pod {{ $labels.pod  }} has more than 300 backends in waiting state
+      summary: High waiting backends count
     expr: |-
       cnpg_backends_waiting_total > 300
     for: 1m

--- a/docs/src/samples/monitoring/prometheusrule.yaml
+++ b/docs/src/samples/monitoring/prometheusrule.yaml
@@ -17,8 +17,8 @@ spec:
         severity: warning
     - alert: BackendsWaiting
       annotations:
-        description: Pod {{ $labels.pod  }} has been waiting for longer than 5 minutes
-        summary: If a backend is waiting for longer than 5 minutes
+        description: Pod {{ $labels.pod  }} has more than 300 backends in waiting state
+        summary: High waiting backends count
       expr: |-
         cnpg_backends_waiting_total > 300
       for: 1m


### PR DESCRIPTION
It seems like `cnpg_backends_waiting_total` shows a count of waiting backends but not seconds. Also metric description says the same:
```text
# HELP cnpg_backends_waiting_total Total number of backends that are currently waiting on other queries
# TYPE cnpg_backends_waiting_total gauge
```
Thus we should fix alert summary and description