### PR TITLE
chore: update postgres versions using trixie distribution

### DIFF
--- a/.github/postgres-versions-update.py
+++ b/.github/postgres-versions-update.py
@@ -34,13 +34,16 @@ pg_versions_file = ".github/pg_versions.json"
 
 
 def get_json(repo_name):
-    data = check_output([
-        "docker",
-        "run",
-        "--rm",
-        "quay.io/skopeo/stable",
-        "list-tags",
-        "docker://ghcr.io/{}".format(repo_name)])
+    data = check_output(
+        [
+            "docker",
+            "run",
+            "--rm",
+            "quay.io/skopeo/stable",
+            "list-tags",
+            "docker://ghcr.io/{}".format(repo_name),
+        ]
+    )
     repo_json = json.loads(data.decode("utf-8"))
     return repo_json
 

--- a/.github/postgres-versions-update.py
+++ b/.github/postgres-versions-update.py
@@ -93,7 +93,7 @@ def write_json(repo_url, version_re, output_file):
             if major not in extra_results:
                 extra_results[major] = item
 
-    # If there are not enough version without the timestamp inside, we add the one we kept
+    # If there are not enough versions without the timestamp inside, we add the one we kept
     for major in results:
         if len(results[major]) < 2:
             results[major].append(extra_results[major])

--- a/.github/postgres-versions-update.py
+++ b/.github/postgres-versions-update.py
@@ -25,8 +25,11 @@ from packaging import version
 from subprocess import check_output
 
 min_supported_major = 13
+os_name = "trixie"
+image_type = "system"
+
 pg_repo_name = "cloudnative-pg/postgresql"
-pg_version_re = re.compile(r"^(\d+)(?:\.\d+|beta\d+|rc\d+|alpha\d+)(-\d+)?-bookworm$")
+pg_version_re = r"(\d+)(?:\.\d+|beta\d+|rc\d+|alpha\d+)(-\d{12})?"
 pg_versions_file = ".github/pg_versions.json"
 
 
@@ -41,15 +44,20 @@ def get_json(repo_name):
     repo_json = json.loads(data.decode("utf-8"))
     return repo_json
 
+
 def parse_version(v):
-    return version.Version(v.removesuffix("-bookworm"))
+    return version.Version(v.removesuffix(f"-{image_type}-{os_name}"))
+
 
 def is_pre_release(v):
     return parse_version(v).is_prerelease
 
+
 def write_json(repo_url, version_re, output_file):
     repo_json = get_json(repo_url)
     tags = repo_json["Tags"]
+
+    version_re = re.compile(rf"^{version_re}-{image_type}-{os_name}$")
 
     # Filter out all the tags which do not match the version regexp
     tags = [item for item in tags if version_re.search(item)]
@@ -70,19 +78,19 @@ def write_json(repo_url, version_re, output_file):
         if int(major) < min_supported_major:
             continue
 
-        # We normally want to handle only versions without the '-' inside
+        # We normally want to handle only versions without the timestamp inside
         extra = match.group(2)
         if not extra:
             if major not in results:
                 results[major] = [item]
             elif len(results[major]) < 2:
                 results[major].append(item)
-        # But we keep the highest version with the '-' in case we have not enough other versions
+        # But we keep the highest version with the timestamp in case we have not enough other versions
         else:
             if major not in extra_results:
                 extra_results[major] = item
 
-    # If there are not enough version without '-` inside we add the one we kept
+    # If there are not enough version without the timestamp inside, we add the one we kept
     for major in results:
         if len(results[major]) < 2:
             results[major].append(extra_results[major])

--- a/.github/workflows/latest-postgres-version-check.yml
+++ b/.github/workflows/latest-postgres-version-check.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
 
-      - name: Set up Python 3.9
+      - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: 3.13
@@ -67,8 +67,15 @@ jobs:
           # Update docs directory (only .md and .yaml filename extensions)
           find docs -type f \( -name '*.md' -o -name '*.yaml' \) \! -path '*release_notes*' -exec sed -i "/[ :]${CURRENT_POSTGRES_VERSION//./\\.}/s/${CURRENT_POSTGRES_VERSION//./\\.}/${LATEST_POSTGRES_VERSION}/g" {} +
 
+      - name: Diff
+        run: |
+          git status
+          git diff
+
       - name: Create PR to update PostgreSQL version
-        if: env.LATEST_POSTGRES_VERSION_IMAGE != env.CURRENT_POSTGRES_VERSION_IMAGE
+        if: |
+          env.LATEST_POSTGRES_VERSION_IMAGE != env.CURRENT_POSTGRES_VERSION_IMAGE &&
+          github.ref == 'refs/heads/main'
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7
         with:
           token: ${{ secrets.REPO_GHA_PAT }}
@@ -80,7 +87,9 @@ jobs:
           signoff: true
 
       - name: Create Pull Request if postgresql versions have been updated
-        if: env.LATEST_POSTGRES_VERSION_IMAGE == env.CURRENT_POSTGRES_VERSION_IMAGE
+        if: |
+          env.LATEST_POSTGRES_VERSION_IMAGE == env.CURRENT_POSTGRES_VERSION_IMAGE &&
+          github.ref == 'refs/heads/main'
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7
         with:
           token: ${{ secrets.REPO_GHA_PAT }}

--- a/.github/workflows/latest-postgres-version-check.yml
+++ b/.github/workflows/latest-postgres-version-check.yml
@@ -65,7 +65,9 @@ jobs:
           sed -i '/DefaultImageName *=/s@".*"@"'"${LATEST_POSTGRES_VERSION_IMAGE}"'"@' pkg/versions/versions.go
 
           # Update docs directory (only .md and .yaml filename extensions)
-          find docs -type f \( -name '*.md' -o -name '*.yaml' \) \! -path '*release_notes*' -exec sed -i "/[ :]${CURRENT_POSTGRES_VERSION//./\\.}/s/${CURRENT_POSTGRES_VERSION//./\\.}/${LATEST_POSTGRES_VERSION}/g" {} +
+          CURRENT_POSTGRES_VERSION_MM=${CURRENT_POSTGRES_VERSION%%-*}
+          LATEST_POSTGRES_VERSION_MM=${LATEST_POSTGRES_VERSION%%-*}
+          find docs -type f \( -name '*.md' -o -name '*.yaml' \) \! -path '*release_notes*' -exec sed -i "/[ :]${CURRENT_POSTGRES_VERSION_MM//./\\.}/s/${CURRENT_POSTGRES_VERSION_MM//./\\.}/${LATEST_POSTGRES_VERSION_MM}/g" {} +
 
       - name: Diff
         run: |

--- a/docs/src/bootstrap.md
+++ b/docs/src/bootstrap.md
@@ -603,7 +603,7 @@ metadata:
   name: target-db
 spec:
   instances: 3
-  imageName: ghcr.io/cloudnative-pg/postgresql:17.5
+  imageName: ghcr.io/cloudnative-pg/postgresql:17.5-system-trixie
 
   bootstrap:
     pg_basebackup:
@@ -653,7 +653,7 @@ metadata:
   name: cluster-clone-tls
 spec:
   instances: 3
-  imageName: ghcr.io/cloudnative-pg/postgresql:17.5
+  imageName: ghcr.io/cloudnative-pg/postgresql:17.5-system-trixie
 
   bootstrap:
     pg_basebackup:

--- a/docs/src/declarative_hibernation.md
+++ b/docs/src/declarative_hibernation.md
@@ -51,7 +51,7 @@ $ kubectl cnpg status <cluster-name>
 Cluster Summary
 Name:              cluster-example
 Namespace:         default
-PostgreSQL Image:  ghcr.io/cloudnative-pg/postgresql:17.5
+PostgreSQL Image:  ghcr.io/cloudnative-pg/postgresql:17.5-system-trixie
 Primary instance:  cluster-example-2
 Status:            Cluster in healthy state 
 Instances:         3

--- a/docs/src/image_catalog.md
+++ b/docs/src/image_catalog.md
@@ -31,11 +31,11 @@ metadata:
 spec:
   images:
     - major: 15
-      image: ghcr.io/cloudnative-pg/postgresql:15.6
+      image: ghcr.io/cloudnative-pg/postgresql:15.14-system-trixie
     - major: 16
-      image: ghcr.io/cloudnative-pg/postgresql:16.8
+      image: ghcr.io/cloudnative-pg/postgresql:16.10-system-trixie
     - major: 17
-      image: ghcr.io/cloudnative-pg/postgresql:17.5
+      image: ghcr.io/cloudnative-pg/postgresql:17.5-system-trixie
 ```
 
 **Example of a Cluster-Wide Catalog using `ClusterImageCatalog` Resource:**
@@ -48,11 +48,11 @@ metadata:
 spec:
   images:
     - major: 15
-      image: ghcr.io/cloudnative-pg/postgresql:15.6
+      image: ghcr.io/cloudnative-pg/postgresql:15.14-system-trixie
     - major: 16
-      image: ghcr.io/cloudnative-pg/postgresql:16.8
+      image: ghcr.io/cloudnative-pg/postgresql:16.10-system-trixie
     - major: 17
-      image: ghcr.io/cloudnative-pg/postgresql:17.5
+      image: ghcr.io/cloudnative-pg/postgresql:17.5-system-trixie
 ```
 
 A `Cluster` resource has the flexibility to reference either an `ImageCatalog`

--- a/docs/src/samples/cluster-example-full.yaml
+++ b/docs/src/samples/cluster-example-full.yaml
@@ -35,7 +35,7 @@ metadata:
   name: cluster-example-full
 spec:
   description: "Example of cluster"
-  imageName: ghcr.io/cloudnative-pg/postgresql:17.5
+  imageName: ghcr.io/cloudnative-pg/postgresql:17.5-system-trixie
   # imagePullSecret is only required if the images are located in a private registry
   # imagePullSecrets:
   #   - name: private_registry_access

--- a/docs/src/scheduling.md
+++ b/docs/src/scheduling.md
@@ -41,7 +41,7 @@ metadata:
   name: cluster-example
 spec:
   instances: 3
-  imageName: ghcr.io/cloudnative-pg/postgresql:17.5
+  imageName: ghcr.io/cloudnative-pg/postgresql:17.5-system-trixie
 
   affinity:
     enablePodAntiAffinity: true # Default value

--- a/docs/src/troubleshooting.md
+++ b/docs/src/troubleshooting.md
@@ -210,7 +210,7 @@ Cluster in healthy state
 Name:               cluster-example
 Namespace:          default
 System ID:          7044925089871458324
-PostgreSQL Image:   ghcr.io/cloudnative-pg/postgresql:17.5-3
+PostgreSQL Image:   ghcr.io/cloudnative-pg/postgresql:17.5-system-trixie
 Primary instance:   cluster-example-1
 Instances:          3
 Ready instances:    3
@@ -278,7 +278,7 @@ kubectl describe cluster <CLUSTER_NAME> -n <NAMESPACE> | grep "Image Name"
 Output:
 
 ```shell
-  Image Name:    ghcr.io/cloudnative-pg/postgresql:17.5-3
+  Image Name:    ghcr.io/cloudnative-pg/postgresql:17.5-system-trixie
 ```
 
 !!! Note


### PR DESCRIPTION
Since bullseye images aren't maintained anymore we need to start using the bookworm images which have the suffix after the version for all the E2E tests.

Closes #8435 