### PR TITLE
chore: ignore shellcheck warnings for SC2329

### DIFF
--- a/hack/e2e/run-e2e-kind.sh
+++ b/hack/e2e/run-e2e-kind.sh
@@ -51,6 +51,7 @@ export CONTROLLER_IMG_PRIME_DIGEST=${CONTROLLER_IMG_PRIME_DIGEST:-""}
 export DOCKER_REGISTRY_MIRROR=${DOCKER_REGISTRY_MIRROR:-}
 export TEST_CLOUD_VENDOR="local"
 
+# shellcheck disable=SC2329
 cleanup() {
   if [ "${PRESERVE_CLUSTER}" = false ]; then
     "${HACK_DIR}/setup-cluster.sh" destroy || true

--- a/hack/install-cnpg-plugin.sh
+++ b/hack/install-cnpg-plugin.sh
@@ -154,6 +154,7 @@ is_command() {
 echoerr() {
   echo "$@" 1>&2
 }
+# shellcheck disable=SC2329
 log_prefix() {
   echo "$0"
 }


### PR DESCRIPTION
With the latest version of shellcheck the test SC2329 was added looking
for unused functions, or explicitly ignore that test, in our case, the functions
are called indirectly and always used.

Closes #8455 