### PR TITLE
fix(backup,status): add `majorVersion` to backups

### DIFF
--- a/api/v1/backup_types.go
+++ b/api/v1/backup_types.go
@@ -195,8 +195,8 @@ type BackupStatus struct {
 	// The potential credentials for each cloud provider
 	BarmanCredentials `json:",inline"`
 
-	// The major version of PostgreSQL of the cluster where the backup
-	// has been taken from.
+	// The PostgreSQL major version that was running when the
+	// backup was taken.
 	MajorVersion int `json:"majorVersion,omitempty"`
 
 	// EndpointCA store the CA bundle of the barman endpoint.

--- a/api/v1/backup_types.go
+++ b/api/v1/backup_types.go
@@ -195,6 +195,10 @@ type BackupStatus struct {
 	// The potential credentials for each cloud provider
 	BarmanCredentials `json:",inline"`
 
+	// The major version of PostgreSQL of the cluster where the backup
+	// has been taken from.
+	MajorVersion int `json:"majorVersion,omitempty"`
+
 	// EndpointCA store the CA bundle of the barman endpoint.
 	// Useful when using self-signed certificates to avoid
 	// errors with certificate issuer and barman-cloud-wal-archive.

--- a/config/crd/bases/postgresql.cnpg.io_backups.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_backups.yaml
@@ -314,8 +314,8 @@ spec:
                 type: object
               majorVersion:
                 description: |-
-                  The major version of PostgreSQL of the cluster where the backup
-                  has been taken from.
+                  The PostgreSQL major version that was running when the
+                  backup was taken.
                 type: integer
               method:
                 description: The backup method being used

--- a/config/crd/bases/postgresql.cnpg.io_backups.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_backups.yaml
@@ -312,6 +312,11 @@ spec:
                     description: The pod name
                     type: string
                 type: object
+              majorVersion:
+                description: |-
+                  The major version of PostgreSQL of the cluster where the backup
+                  has been taken from.
+                type: integer
               method:
                 description: The backup method being used
                 type: string

--- a/docs/src/cloudnative-pg.v1.md
+++ b/docs/src/cloudnative-pg.v1.md
@@ -796,8 +796,8 @@ Overrides the default settings specified in the cluster '.backup.volumeSnapshot.
 <i>int</i>
 </td>
 <td>
-   <p>The major version of PostgreSQL of the cluster where the backup
-has been taken from.</p>
+   <p>The PostgreSQL major version that was running when the
+backup was taken.</p>
 </td>
 </tr>
 <tr><td><code>endpointCA</code><br/>

--- a/docs/src/cloudnative-pg.v1.md
+++ b/docs/src/cloudnative-pg.v1.md
@@ -792,6 +792,14 @@ Overrides the default settings specified in the cluster '.backup.volumeSnapshot.
    <p>The potential credentials for each cloud provider</p>
 </td>
 </tr>
+<tr><td><code>majorVersion</code> <B>[Required]</B><br/>
+<i>int</i>
+</td>
+<td>
+   <p>The major version of PostgreSQL of the cluster where the backup
+has been taken from.</p>
+</td>
+</tr>
 <tr><td><code>endpointCA</code><br/>
 <a href="https://pkg.go.dev/github.com/cloudnative-pg/machinery/pkg/api/#SecretKeySelector"><i>github.com/cloudnative-pg/machinery/pkg/api.SecretKeySelector</i></a>
 </td>

--- a/docs/src/labels_annotations.md
+++ b/docs/src/labels_annotations.md
@@ -51,10 +51,6 @@ CloudNativePG manages the following predefined labels:
 : The year a backup was taken.
   This label is available only on `VolumeSnapshot` resources.
 
-`cnpg.io/majorVersion`
-: Integer PostgreSQL major version of the backup's data directory (for example, `16`).
-This label is available only on `VolumeSnapshot` resources.
-
 `cnpg.io/cluster`
 : Name of the cluster.
 
@@ -68,6 +64,10 @@ This label is available only on `VolumeSnapshot` resources.
 
 `cnpg.io/jobRole`
 : Role of the job (that is, `import`, `initdb`, `join`, ...)
+
+`cnpg.io/majorVersion`
+: Integer PostgreSQL major version of the backup's data directory (for example, `17`).
+This label is available only on `VolumeSnapshot` resources.
 
 `cnpg.io/onlineBackup`
 : Whether the backup is online (hot) or taken when Postgres is down (cold).

--- a/docs/src/labels_annotations.md
+++ b/docs/src/labels_annotations.md
@@ -51,6 +51,10 @@ CloudNativePG manages the following predefined labels:
 : The year a backup was taken.
   This label is available only on `VolumeSnapshot` resources.
 
+`cnpg.io/majorVersion`
+: Integer PostgreSQL major version of the backup's data directory (for example, `16`).
+This label is available only on `VolumeSnapshot` resources.
+
 `cnpg.io/cluster`
 : Name of the cluster.
 

--- a/internal/controller/backup_controller.go
+++ b/internal/controller/backup_controller.go
@@ -733,7 +733,7 @@ func (r *BackupReconciler) getBackupTargetPod(ctx context.Context,
 		Name:      cluster.Status.TargetPrimary,
 	}, &pod)
 
-	if podHasLatestMajorImage(&pod) {
+	if !podHasLatestMajorImage(&pod) {
 		return nil, fmt.Errorf("primary instance not having expected image, cannot run backup")
 	}
 

--- a/internal/controller/backup_controller.go
+++ b/internal/controller/backup_controller.go
@@ -667,13 +667,10 @@ func (r *BackupReconciler) getBackupTargetPod(ctx context.Context,
 	contextLogger := log.FromContext(ctx)
 
 	podHasLatestMajorImage := func(pod *corev1.Pod) bool {
-		if cluster.Status.PGDataImageInfo == nil {
-			return true
-		}
-
-		// we are not undergoing major upgrade
-		if cluster.Status.Image != cluster.Status.PGDataImageInfo.Image {
-			return true
+		// No backup should run during a major version upgrade
+		if cluster.Status.PGDataImageInfo != nil &&
+			cluster.Status.Image != cluster.Status.PGDataImageInfo.Image {
+			return false
 		}
 
 		if len(pod.Spec.Containers) == 0 {

--- a/internal/controller/backup_controller.go
+++ b/internal/controller/backup_controller.go
@@ -190,6 +190,8 @@ func (r *BackupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		return ctrl.Result{RequeueAfter: 10 * time.Minute}, nil
 	}
 
+	// The backup is ready to start, and before starting it we store
+	// the major version inside the Backup resource.
 	if err := r.reconcileMajorVersion(ctx, &backup, &cluster); err != nil {
 		return ctrl.Result{}, fmt.Errorf("error setting major version for backup: %w", err)
 	}

--- a/pkg/reconciler/backup/volumesnapshot/reconciler.go
+++ b/pkg/reconciler/backup/volumesnapshot/reconciler.go
@@ -85,6 +85,7 @@ func (se *Reconciler) enrichSnapshot(
 	snapshotConfig := backup.GetVolumeSnapshotConfiguration(*cluster.Spec.Backup.VolumeSnapshot)
 
 	vs.Labels[utils.BackupNameLabelName] = backup.Name
+	vs.Labels[utils.MajorVersionLabelName] = strconv.Itoa(backup.Status.MajorVersion)
 
 	switch snapshotConfig.SnapshotOwnerReference {
 	case apiv1.SnapshotOwnerReferenceCluster:

--- a/pkg/utils/labels_annotations.go
+++ b/pkg/utils/labels_annotations.go
@@ -62,6 +62,9 @@ const (
 	// BackupNameLabelName is the name of the label containing the backup id, available on backup resources
 	BackupNameLabelName = MetadataNamespace + "/backupName"
 
+	// MajorVersionLabelName is the Postgres major version contained in a snapshot backup
+	MajorVersionLabelName = MetadataNamespace + "/majorVersion"
+
 	// PgbouncerNameLabel is the name of the label of containing the pooler name
 	PgbouncerNameLabel = MetadataNamespace + "/poolerName"
 


### PR DESCRIPTION
Expose the PostgreSQL major version in the backup status and add a new label `cnpg.io/majorVersion` to volume snapshots.

This change also fixes a bug during major upgrades, preventing backups from being taken.

Partially closes #7705 