### PR TITLE
chore(plugin): clarify primary promotion time in status command

### DIFF
--- a/internal/cmd/plugin/status/status.go
+++ b/internal/cmd/plugin/status/status.go
@@ -281,10 +281,10 @@ func (fullStatus *PostgresqlStatus) printBasicInfo(ctx context.Context, k8sClien
 	case isPrimaryFenced:
 		summary.AddLine("Status:", aurora.Red("Primary instance is fenced"))
 	default:
-		// Avoid printing the start time when hibernated or fenced
-		primaryStartTime := getPrimaryStartTime(cluster)
-		if len(primaryStartTime) > 0 {
-			summary.AddLine("Primary since:", primaryStartTime)
+		// Avoid printing the promotion time when hibernated or fenced
+		primaryPromotionTime := getPrimaryPromotionTime(cluster)
+		if len(primaryPromotionTime) > 0 {
+			summary.AddLine("Primary promotion time:", primaryPromotionTime)
 		}
 		summary.AddLine("Status:", fullStatus.getStatus(cluster))
 	}
@@ -1331,11 +1331,11 @@ func (fullStatus *PostgresqlStatus) printPluginStatus(verbosity int) {
 	fmt.Println()
 }
 
-func getPrimaryStartTime(cluster *apiv1.Cluster) string {
-	return getPrimaryStartTimeIdempotent(cluster, time.Now())
+func getPrimaryPromotionTime(cluster *apiv1.Cluster) string {
+	return getPrimaryPromotionTimeIdempotent(cluster, time.Now())
 }
 
-func getPrimaryStartTimeIdempotent(cluster *apiv1.Cluster, currentTime time.Time) string {
+func getPrimaryPromotionTimeIdempotent(cluster *apiv1.Cluster, currentTime time.Time) string {
 	if len(cluster.Status.CurrentPrimaryTimestamp) == 0 {
 		return ""
 	}
@@ -1348,11 +1348,11 @@ func getPrimaryStartTimeIdempotent(cluster *apiv1.Cluster, currentTime time.Time
 		return aurora.Red("error: " + err.Error()).String()
 	}
 
-	uptime := currentTime.Sub(primaryInstanceTimestamp)
+	duration := currentTime.Sub(primaryInstanceTimestamp)
 	return fmt.Sprintf(
 		"%s (%s)",
 		primaryInstanceTimestamp.Round(time.Second),
-		uptime.Round(time.Second),
+		duration.Round(time.Second),
 	)
 }
 

--- a/internal/cmd/plugin/status/status.go
+++ b/internal/cmd/plugin/status/status.go
@@ -284,7 +284,7 @@ func (fullStatus *PostgresqlStatus) printBasicInfo(ctx context.Context, k8sClien
 		// Avoid printing the start time when hibernated or fenced
 		primaryStartTime := getPrimaryStartTime(cluster)
 		if len(primaryStartTime) > 0 {
-			summary.AddLine("Primary start time:", primaryStartTime)
+			summary.AddLine("Primary since:", primaryStartTime)
 		}
 		summary.AddLine("Status:", fullStatus.getStatus(cluster))
 	}

--- a/internal/cmd/plugin/status/status.go
+++ b/internal/cmd/plugin/status/status.go
@@ -1350,7 +1350,7 @@ func getPrimaryStartTimeIdempotent(cluster *apiv1.Cluster, currentTime time.Time
 
 	uptime := currentTime.Sub(primaryInstanceTimestamp)
 	return fmt.Sprintf(
-		"%s (uptime %s)",
+		"%s (%s)",
 		primaryInstanceTimestamp.Round(time.Second),
 		uptime.Round(time.Second),
 	)

--- a/internal/cmd/plugin/status/status_test.go
+++ b/internal/cmd/plugin/status/status_test.go
@@ -31,7 +31,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("getPrimaryStartTime", func() {
+var _ = Describe("getPrimaryPromotionTime", func() {
 	var cluster *apiv1.Cluster
 
 	Context("when CurrentPrimaryTimestamp is empty", func() {
@@ -44,7 +44,7 @@ var _ = Describe("getPrimaryStartTime", func() {
 		})
 
 		It("should return an empty string", func() {
-			Expect(getPrimaryStartTime(cluster)).To(Equal(""))
+			Expect(getPrimaryPromotionTime(cluster)).To(Equal(""))
 		})
 	})
 
@@ -61,7 +61,7 @@ var _ = Describe("getPrimaryStartTime", func() {
 			}
 
 			expected := fmt.Sprintf("%s (uptime %s)", currentPrimaryTimestamp.Round(time.Second), uptime)
-			Expect(getPrimaryStartTimeIdempotent(cluster, now)).To(Equal(expected))
+			Expect(getPrimaryPromotionTimeIdempotent(cluster, now)).To(Equal(expected))
 		})
 	})
 
@@ -75,7 +75,7 @@ var _ = Describe("getPrimaryStartTime", func() {
 		})
 
 		It("should return the error message", func() {
-			Expect(getPrimaryStartTime(cluster)).To(ContainSubstring("error"))
+			Expect(getPrimaryPromotionTime(cluster)).To(ContainSubstring("error"))
 		})
 	})
 })

--- a/internal/cmd/plugin/status/status_test.go
+++ b/internal/cmd/plugin/status/status_test.go
@@ -60,7 +60,7 @@ var _ = Describe("getPrimaryPromotionTime", func() {
 				},
 			}
 
-			expected := fmt.Sprintf("%s (uptime %s)", currentPrimaryTimestamp.Round(time.Second), uptime)
+			expected := fmt.Sprintf("%s (%s)", currentPrimaryTimestamp.Round(time.Second), uptime)
 			Expect(getPrimaryPromotionTimeIdempotent(cluster, now)).To(Equal(expected))
 		})
 	})


### PR DESCRIPTION
In the plugin status output, there is a line called "Primary start time". I found it quite confusing because it doesn't represent what it pretend to be. It's actually the time when the current primary instance became primary but when it's restart time.

Example : 
```
Primary instance:    postgresql-enabled-2
Primary start time:  2025-08-29 09:02:43 +0000 UTC (uptime 4m50s)
```

I understand that my instance postgresql-enabled-2 is primary and (re)started almost 5m ago.

But the actual restart time of the PostgreSQL instance/postmaster is not that at all (and can be days, weeks ago or even more) :
```
kubectl exec -it postgresql-enabled-2 -- psql -c "select pg_postmaster_start_time()"
Defaulted container "postgres" out of: postgres, bootstrap-controller (init)
   pg_postmaster_start_time    
-------------------------------
 2025-08-29 08:49:26.845241+00
(1 row)
```

So I suggest to change the word used in the output.