### PR TITLE
fix(webhook): use correct API group in webhook errors

### DIFF
--- a/internal/webhook/v1/backup_webhook.go
+++ b/internal/webhook/v1/backup_webhook.go
@@ -117,7 +117,7 @@ func (v *BackupCustomValidator) ValidateUpdate(
 	}
 
 	return nil, apierrors.NewInvalid(
-		schema.GroupKind{Group: "backup.cnpg.io", Kind: "Backup"},
+		schema.GroupKind{Group: "postgresql.cnpg.io", Kind: "Backup"},
 		backup.Name, allErrs)
 }
 

--- a/internal/webhook/v1/pooler_webhook.go
+++ b/internal/webhook/v1/pooler_webhook.go
@@ -170,7 +170,7 @@ func (v *PoolerCustomValidator) ValidateUpdate(
 	}
 
 	return warns, apierrors.NewInvalid(
-		schema.GroupKind{Group: "pooler.cnpg.io", Kind: "Pooler"},
+		schema.GroupKind{Group: "postgresql.cnpg.io", Kind: "Pooler"},
 		pooler.Name, allErrs)
 }
 


### PR DESCRIPTION
Replace incorrect GroupKind group with "postgresql.cnpg.io" in Pooler ValidateUpdate admission error to align with the CRD group and ensure consistent API error reporting.

Also fixed  inside backup webhook.

