### PR TITLE
fix(backup): do not check Cluster `spec.backup` if method is `plugin`

### DIFF
--- a/internal/controller/backup_controller.go
+++ b/internal/controller/backup_controller.go
@@ -329,17 +329,18 @@ func (r *BackupReconciler) checkPrerequisites(
 		err := resourcestatus.FlagBackupAsFailed(ctx, r.Client, &backup, &cluster, errors.New(message))
 		return &ctrl.Result{}, err
 	}
-
-	if cluster.Spec.Backup == nil {
-		const message = "cannot proceed with the backup as the cluster has no backup section"
-		return flagMissingPrerequisite(message, "ClusterHasBackupConfigured")
-	}
-
 	if backup.Spec.Method == apiv1.BackupMethodPlugin {
 		if len(cluster.Spec.Plugins) == 0 {
 			const message = "cannot proceed with the backup as the cluster has no plugin configured"
 			return flagMissingPrerequisite(message, "ClusterHasNoBackupExecutorPlugin")
 		}
+
+		return nil, nil
+	}
+
+	if cluster.Spec.Backup == nil {
+		const message = "cannot proceed with the backup as the cluster has no backup section"
+		return flagMissingPrerequisite(message, "ClusterHasBackupConfigured")
 	}
 
 	if backup.Spec.Method == apiv1.BackupMethodVolumeSnapshot {

--- a/internal/controller/backup_controller_test.go
+++ b/internal/controller/backup_controller_test.go
@@ -26,6 +26,7 @@ import (
 	volumesnapshot "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -466,5 +467,74 @@ var _ = Describe("update snapshot backup metadata", func() {
 		//nolint:staticcheck
 		Expect(updatedCluster.Status.LastSuccessfulBackupByMethod[apiv1.BackupMethodVolumeSnapshot]).
 			To(Equal(oneHourAgo))
+	})
+})
+
+var _ = Describe("checkPrerequisites for plugin backups", func() {
+	var env *testingEnvironment
+	BeforeEach(func() { env = buildTestEnvironment() })
+
+	It("allows plugin backups without cluster.spec.backup when a plugin is configured", func(ctx context.Context) {
+		ns := newFakeNamespace(env.client)
+
+		cluster := newFakeCNPGCluster(env.client, ns, func(c *apiv1.Cluster) {
+			c.Spec.Backup = nil
+			c.Spec.Plugins = []apiv1.PluginConfiguration{{
+				Name:       "test",
+				Enabled:    ptr.To(true),
+				Parameters: map[string]string{"key": "value"},
+			}}
+		})
+
+		backup := &apiv1.Backup{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-plugin-backup", Namespace: ns},
+			Spec: apiv1.BackupSpec{
+				Cluster: apiv1.LocalObjectReference{Name: cluster.Name},
+				Method:  apiv1.BackupMethodPlugin,
+			},
+		}
+		// Create the backup so that status updates in prerequisites can patch it if needed
+		expectErr := env.client.Create(ctx, backup)
+		Expect(expectErr).ToNot(HaveOccurred())
+
+		res, err := env.backupReconciler.checkPrerequisites(ctx, *backup, *cluster)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(res).To(BeNil())
+
+		// Ensure backup was not marked as failed
+		var stored apiv1.Backup
+		expectErr = env.client.Get(ctx, client.ObjectKeyFromObject(backup), &stored)
+		Expect(expectErr).ToNot(HaveOccurred())
+		Expect(stored.Status.Phase).To(BeEmpty())
+	})
+
+	It("fails plugin backups when no plugin is configured on the cluster", func(ctx context.Context) {
+		ns := newFakeNamespace(env.client)
+
+		cluster := newFakeCNPGCluster(env.client, ns, func(c *apiv1.Cluster) {
+			c.Spec.Backup = nil
+			c.Spec.Plugins = nil
+		})
+
+		backup := &apiv1.Backup{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-plugin-backup-missing", Namespace: ns},
+			Spec: apiv1.BackupSpec{
+				Cluster: apiv1.LocalObjectReference{Name: cluster.Name},
+				Method:  apiv1.BackupMethodPlugin,
+			},
+		}
+		expectErr := env.client.Create(ctx, backup)
+		Expect(expectErr).ToNot(HaveOccurred())
+
+		res, err := env.backupReconciler.checkPrerequisites(ctx, *backup, *cluster)
+		// We expect the reconciler to flag failure and return a non-nil result without bubbling an error
+		Expect(err).ToNot(HaveOccurred())
+		Expect(res).ToNot(BeNil())
+
+		var stored apiv1.Backup
+		expectErr = env.client.Get(ctx, client.ObjectKeyFromObject(backup), &stored)
+		Expect(expectErr).ToNot(HaveOccurred())
+		Expect(stored.Status.Phase).To(BeEquivalentTo(apiv1.BackupPhaseFailed))
+		Expect(stored.Status.Method).To(BeEquivalentTo(apiv1.BackupMethodPlugin))
 	})
 })


### PR DESCRIPTION
This patch addresses a regression introduced by #8320 that does not affect any released version.

The regression made it impossible to perform backups using a plugin, as the controller would incorrectly require and validate the `spec.backup` field even when the backup method was set to plugin. With this change, validating the `spec.backup` field is skipped when using plugin-based backups, restoring the expected behavior for plugin users.