### PR TITLE
fix(persistentvolumeclaim): consider WAL-archiver plugins for replica recovery source

### DIFF
--- a/pkg/reconciler/persistentvolumeclaim/storagesource.go
+++ b/pkg/reconciler/persistentvolumeclaim/storagesource.go
@@ -85,8 +85,11 @@ func GetCandidateStorageSourceForReplica(
 	//    the cluster itself. Other backups are fine because the required
 	//    WALs have been archived in the cluster object store.
 
-	// Unless WAL archiving is active, we can't recover a replica from a backup
-	if cluster.Spec.Backup == nil || cluster.Spec.Backup.BarmanObjectStore == nil {
+	// Unless WAL archiving is active (via BarmanObjectStore or a WAL-archiver plugin),
+	// we can't recover a replica from a backup
+	walArchivingActive := (cluster.Spec.Backup != nil && cluster.Spec.Backup.BarmanObjectStore != nil) ||
+		cluster.GetEnabledWALArchivePluginName() != ""
+	if !walArchivingActive {
 		return nil
 	}
 

--- a/pkg/reconciler/persistentvolumeclaim/storagesource_test.go
+++ b/pkg/reconciler/persistentvolumeclaim/storagesource_test.go
@@ -193,6 +193,31 @@ var _ = Describe("Storage source", func() {
 			Expect(source).ToNot(BeNil())
 			Expect(source.Name).To(Equal("completed-backup"))
 		})
+
+		It("should return the backup as storage source when WAL archiving is via plugin only", func(ctx context.Context) {
+			clusterWithPluginOnly := &apiv1.Cluster{
+				Spec: apiv1.ClusterSpec{
+					StorageConfiguration: apiv1.StorageConfiguration{},
+					WalStorage:           &apiv1.StorageConfiguration{},
+					Backup:               nil,
+					Plugins: []apiv1.PluginConfiguration{
+						{
+							Name:          "test-wal-archiver",
+							IsWALArchiver: ptr.To(true),
+						},
+					},
+				},
+			}
+
+			source, err := NewPgDataCalculator().GetSource(GetCandidateStorageSourceForReplica(
+				ctx,
+				clusterWithPluginOnly,
+				backupList,
+			))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(source).ToNot(BeNil())
+			Expect(source.Name).To(Equal("completed-backup"))
+		})
 	})
 
 	When("there's no WAL archiving", func() {

--- a/pkg/reconciler/persistentvolumeclaim/storagesource_test.go
+++ b/pkg/reconciler/persistentvolumeclaim/storagesource_test.go
@@ -96,6 +96,20 @@ var _ = Describe("Storage source", func() {
 		},
 	}
 
+	clusterWithPluginOnly := &apiv1.Cluster{
+		Spec: apiv1.ClusterSpec{
+			StorageConfiguration: apiv1.StorageConfiguration{},
+			WalStorage:           &apiv1.StorageConfiguration{},
+			Backup:               nil,
+			Plugins: []apiv1.PluginConfiguration{
+				{
+					Name:          "test-wal-archiver",
+					IsWALArchiver: ptr.To(true),
+				},
+			},
+		},
+	}
+
 	backupList := apiv1.BackupList{
 		Items: []apiv1.Backup{
 			{
@@ -195,20 +209,6 @@ var _ = Describe("Storage source", func() {
 		})
 
 		It("should return the backup as storage source when WAL archiving is via plugin only", func(ctx context.Context) {
-			clusterWithPluginOnly := &apiv1.Cluster{
-				Spec: apiv1.ClusterSpec{
-					StorageConfiguration: apiv1.StorageConfiguration{},
-					WalStorage:           &apiv1.StorageConfiguration{},
-					Backup:               nil,
-					Plugins: []apiv1.PluginConfiguration{
-						{
-							Name:          "test-wal-archiver",
-							IsWALArchiver: ptr.To(true),
-						},
-					},
-				},
-			}
-
 			source, err := NewPgDataCalculator().GetSource(GetCandidateStorageSourceForReplica(
 				ctx,
 				clusterWithPluginOnly,


### PR DESCRIPTION
Treat WAL archiving as active if either Backup.BarmanObjectStore is set or a WAL-archiver plugin is enabled.

Closes #8507 

