### PR TITLE
feat(secret): secret to expose fully qualified `host`

### DIFF
--- a/docs/src/applications.md
+++ b/docs/src/applications.md
@@ -64,18 +64,19 @@ every PostgreSQL cluster it deploys:
 
 Each secret contain the following:
 
-* username
-* password
-* hostname to the RW service
-* port number
-* database name
-* a working [`.pgpass file`](https://www.postgresql.org/docs/current/libpq-pgpass.html)
-* [uri](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING)
-* [jdbc-uri](https://jdbc.postgresql.org/documentation/use/#connecting-to-the-database)
-* [fqdn-uri](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING)
-* [fqdn-jdbc-uri](https://jdbc.postgresql.org/documentation/use/#connecting-to-the-database)
+* `user` and its alias `username`
+* `password`
+* `hostname` to the RW service
+* `host`, a FQDN to the RW service
+* `port` number
+* `dbname` database name
+* `pgpass`, a working [`.pgpass file`](https://www.postgresql.org/docs/current/libpq-pgpass.html)
+* [`uri`](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING)
+* [`jdbc-uri`](https://jdbc.postgresql.org/documentation/use/#connecting-to-the-database)
+* [`fqdn-uri`](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING)
+* [`fqdn-jdbc-uri`](https://jdbc.postgresql.org/documentation/use/#connecting-to-the-database)
 
-The FQDN to be used in the URIs is calculated using the Kubernetes cluster
+The FQDN to be used in the URIs and `host` is calculated using the Kubernetes cluster
 domain specified in the `KUBERNETES_CLUSTER_DOMAIN` configuration parameter.
 See [the operator configuration documentation](operator_conf.md) for more information
 about that.

--- a/pkg/specs/secrets.go
+++ b/pkg/specs/secrets.go
@@ -41,24 +41,25 @@ func CreateSecret(
 	password string,
 	usertype utils.UserType,
 ) *corev1.Secret {
-	hostWithNamespace := fmt.Sprintf("%s.%s:%d", hostname, namespace, postgres.ServerPort)
-	hostWithFQDN := fmt.Sprintf(
-		"%s.%s.svc.%s:%d",
+	hostnameWithNamespace := fmt.Sprintf("%s.%s:%d", hostname, namespace, postgres.ServerPort)
+
+	host := fmt.Sprintf(
+		"%s.%s.svc.%s",
 		hostname,
 		namespace,
 		configuration.Current.KubernetesClusterDomain,
-		postgres.ServerPort,
 	)
+	hostWithPort := fmt.Sprintf("%s:%d", host, postgres.ServerPort)
 
 	namespacedBuilder := &connectionStringBuilder{
-		host:     hostWithNamespace,
+		host:     hostnameWithNamespace,
 		dbname:   dbname,
 		username: username,
 		password: password,
 	}
 
 	fqdnBuilder := &connectionStringBuilder{
-		host:     hostWithFQDN,
+		host:     hostWithPort,
 		dbname:   dbname,
 		username: username,
 		password: password,
@@ -79,7 +80,8 @@ func CreateSecret(
 			"user":     username,
 			"password": password,
 			"dbname":   dbname,
-			"host":     hostname,
+			"host":     host,
+			"hostname": hostname,
 			"port":     fmt.Sprintf("%d", postgres.ServerPort),
 			"pgpass": fmt.Sprintf(
 				"%v:%v:%v:%v:%v\n",

--- a/pkg/specs/secrets_test.go
+++ b/pkg/specs/secrets_test.go
@@ -36,7 +36,8 @@ var _ = Describe("Secret creation", func() {
 		Expect(secret.StringData["user"]).To(Equal("thisuser"))
 		Expect(secret.StringData["password"]).To(Equal("thispassword"))
 		Expect(secret.StringData["dbname"]).To(Equal("thisdb"))
-		Expect(secret.StringData["host"]).To(Equal("thishost"))
+		Expect(secret.StringData["host"]).To(Equal("thishost.namespace.svc.cluster.local"))
+		Expect(secret.StringData["hostname"]).To(Equal("thishost"))
 		Expect(secret.StringData["port"]).To(Equal("5432"))
 		Expect(secret.StringData["uri"]).To(
 			Equal("postgresql://thisuser:thispassword@thishost.namespace:5432/thisdb"),


### PR DESCRIPTION
https://github.com/cloudnative-pg/cloudnative-pg/issues/7807 brought a issue that I faced with my deployment: accessing the instance across namespaces. However, I find the resolution #7852 lacking as it does not directly address the main issue.

Use case:
* `Cluster` deployed in a namespace `A`.
* A resource `R` that needs to access it is in a namespace `B`.
* `R` uses `Cluster`'s secret to get connection details (via [`NamespacedName`](https://pkg.go.dev/k8s.io/apimachinery/pkg/types)).
* `R` reads `host`, `port`, `user`, and `password` to connect to the instance.

This doesn't work because `Secret#host` is not fully qualified and the connection doesn't get through. One might say to combine data from the secret myself but it becomes cumbersome with 7645988 enabled, it is no longer `${host}.svc.cluster.local` and there is no more transparent way to get the host (except parsing `fqdn-uri` or `fqdn-jdbc-uri` which I'd call transparent).

This change makes `Secret#host` to contain fully qualified host and keeps local hostname in `Secret#hostname`. 

The change should not have any effect on users that use this field directly, but might break some brittle code that have worked around the issue by adding `.svc.cluster.local` suffix.

Relates to 7645988
Relates to #7807