### PR TITLE
docs: clarify image structure for PostgreSQL extensions

### DIFF
--- a/docs/src/imagevolume_extensions.md
+++ b/docs/src/imagevolume_extensions.md
@@ -312,8 +312,8 @@ system libraries at runtime.
 A standard extension container image for CloudNativePG includes two
 required directories at its root:
 
-- `/share/`: contains an `extension` subdirectory which includes the extension control file (e.g., `<EXTENSION>.control`)
-  and any SQL files.
+- `/share/`: contains an `extension` subdirectory with the extension control
+  file (e.g. `<EXTENSION>.control`) and the corresponding SQL files.
 - `/lib/`: contains the extension's shared library (e.g., `<EXTENSION>.so`) and
   any additional required libraries.
 

--- a/docs/src/imagevolume_extensions.md
+++ b/docs/src/imagevolume_extensions.md
@@ -310,11 +310,9 @@ system libraries at runtime.
 ## Image Specifications
 
 A standard extension container image for CloudNativePG includes two
-required directories at its root. As mentioned in the 
-[PostgreSQL documentation](https://www.postgresql.org/docs/18/runtime-config-client.html#GUC-EXTENSION-CONTROL-PATH),
-a subdirectory `extension` must exist in `share` folder in order to have :
+required directories at its root:
 
-- `/share/extension`: contains the extension control file (e.g., `<EXTENSION>.control`)
+- `/share/`: contains an `extension` subdirectory which includes the extension control file (e.g., `<EXTENSION>.control`)
   and any SQL files.
 - `/lib/`: contains the extension's shared library (e.g., `<EXTENSION>.so`) and
   any additional required libraries.

--- a/docs/src/imagevolume_extensions.md
+++ b/docs/src/imagevolume_extensions.md
@@ -314,8 +314,8 @@ required directories at its root:
 
 - `/share/`: contains an `extension` subdirectory with the extension control
   file (e.g. `<EXTENSION>.control`) and the corresponding SQL files.
-- `/lib/`: contains the extension's shared library (e.g., `<EXTENSION>.so`) and
-  any additional required libraries.
+- `/lib/`: contains the extension’s shared library (e.g. `<EXTENSION>.so`) as
+  well as any other required libraries.
 
 Following this structure ensures that the extension will be automatically
 discoverable and usable by PostgreSQL within CloudNativePG without requiring

--- a/docs/src/imagevolume_extensions.md
+++ b/docs/src/imagevolume_extensions.md
@@ -312,11 +312,11 @@ system libraries at runtime.
 A standard extension container image for CloudNativePG includes two
 required directories at its root. As mentioned in the 
 [PostgreSQL documentation](https://www.postgresql.org/docs/18/runtime-config-client.html#GUC-EXTENSION-CONTROL-PATH),
-a subdirectory `extension` must exist in the two folders in order to have :
+a subdirectory `extension` must exist in `share` folder in order to have :
 
 - `/share/extension`: contains the extension control file (e.g., `<EXTENSION>.control`)
   and any SQL files.
-- `/lib/extension`: contains the extension's shared library (e.g., `<EXTENSION>.so`) and
+- `/lib/`: contains the extension's shared library (e.g., `<EXTENSION>.so`) and
   any additional required libraries.
 
 Following this structure ensures that the extension will be automatically

--- a/docs/src/imagevolume_extensions.md
+++ b/docs/src/imagevolume_extensions.md
@@ -310,11 +310,13 @@ system libraries at runtime.
 ## Image Specifications
 
 A standard extension container image for CloudNativePG includes two
-required directories at its root:
+required directories at its root. As mentioned in the 
+[PostgreSQL documentation](https://www.postgresql.org/docs/18/runtime-config-client.html#GUC-EXTENSION-CONTROL-PATH),
+a subdirectory `extension` must exist in the two folders in order to have :
 
-- `share`: contains the extension control file (e.g., `<EXTENSION>.control`)
+- `/share/extension`: contains the extension control file (e.g., `<EXTENSION>.control`)
   and any SQL files.
-- `lib`: contains the extension's shared library (e.g., `<EXTENSION>.so`) and
+- `/lib/extension`: contains the extension's shared library (e.g., `<EXTENSION>.so`) and
   any additional required libraries.
 
 Following this structure ensures that the extension will be automatically


### PR DESCRIPTION
Clarify that a valid extension container image for CloudNativePG must include an `extension` subdirectory inside `/share`, containing the control file and SQL files. This explicitly defines the required layout for PostgreSQL to discover and use the extension automatically.
