### PR TITLE
feat: implement Kubernetes v1.33 in-place pod resize to eliminate pod recreations during resource scaling

### DIFF
--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -386,6 +386,12 @@ type ClusterSpec struct {
 	// +optional
 	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
 
+	// ContainerResizePolicy defines the resize policy for the PostgreSQL container
+	// in instance pods (primary and replica). This allows fine-grained control
+	// over how resource changes are applied to running containers.
+	// +optional
+	ContainerResizePolicy []corev1.ContainerResizePolicy `json:"containerResizePolicy,omitempty"`
+
 	// EphemeralVolumesSizeLimit allows the user to set the limits for the ephemeral
 	// volumes
 	// +optional

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -769,6 +769,11 @@ func (in *ClusterSpec) DeepCopyInto(out *ClusterSpec) {
 		}
 	}
 	in.Resources.DeepCopyInto(&out.Resources)
+	if in.ContainerResizePolicy != nil {
+		in, out := &in.ContainerResizePolicy, &out.ContainerResizePolicy
+		*out = make([]corev1.ContainerResizePolicy, len(*in))
+		copy(*out, *in)
+	}
 	if in.EphemeralVolumesSizeLimit != nil {
 		in, out := &in.EphemeralVolumesSizeLimit, &out.EphemeralVolumesSizeLimit
 		*out = new(EphemeralVolumesSizeLimitConfiguration)

--- a/config/crd/bases/postgresql.cnpg.io_clusters.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_clusters.yaml
@@ -2136,6 +2136,30 @@ spec:
                       created using the provided CA.
                     type: string
                 type: object
+              containerResizePolicy:
+                description: |-
+                  ContainerResizePolicy defines the resize policy for the PostgreSQL container
+                  in instance pods (primary and replica). This allows fine-grained control
+                  over how resource changes are applied to running containers.
+                items:
+                  description: ContainerResizePolicy represents resource resize policy
+                    for the container.
+                  properties:
+                    resourceName:
+                      description: |-
+                        Name of the resource to which this resource resize policy applies.
+                        Supported values: cpu, memory.
+                      type: string
+                    restartPolicy:
+                      description: |-
+                        Restart policy to apply when specified resource is resized.
+                        If not specified, it defaults to NotRequired.
+                      type: string
+                  required:
+                  - resourceName
+                  - restartPolicy
+                  type: object
+                type: array
               description:
                 description: Description of this PostgreSQL cluster
                 type: string

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -58,6 +58,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - pods/resize
+  verbs:
+  - patch
+- apiGroups:
+  - ""
+  resources:
   - pods/status
   verbs:
   - get

--- a/docs/src/resource_management.md
+++ b/docs/src/resource_management.md
@@ -121,10 +121,10 @@ spec:
   instances: 3
   
   containerResizePolicy:
-    - name: postgres
-      resizePolicy: NotRequired
-    - name: barman-cloud-backup
-      resizePolicy: RestartContainer
+    - resourceName: cpu
+      restartPolicy: NotRequired
+    - resourceName: memory
+      restartPolicy: NotRequired
 
   resources:
     requests:

--- a/docs/src/samples/cluster-example-in-place-resize.yaml
+++ b/docs/src/samples/cluster-example-in-place-resize.yaml
@@ -1,0 +1,93 @@
+# Example: CloudNativePG Cluster with In-place Resource Updates
+# This example demonstrates how to configure a PostgreSQL cluster to support
+# in-place resource updates using container resize policies.
+
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: postgresql-resize-example
+  namespace: default
+spec:
+  # Number of instances in the cluster
+  instances: 3
+
+  # PostgreSQL version
+  postgresql:
+    parameters:
+      # Configure shared_buffers to be 25% of container memory
+      shared_buffers: "256MB"
+      # Enable logging for monitoring
+      log_statement: "all"
+      log_min_duration_statement: "1000"
+
+  # Container resize policy configuration
+  # This enables in-place resource updates for the postgres container
+  containerResizePolicy:
+    - name: postgres
+      resizePolicy: NotRequired  # Allows in-place CPU/memory updates
+    - name: barman-cloud-backup
+      resizePolicy: RestartContainer  # Requires restart for resource changes
+
+  # Initial resource configuration
+  # These can be updated in-place when resizePolicy is NotRequired
+  resources:
+    requests:
+      memory: "1Gi"    # Initial memory request
+      cpu: "500m"      # Initial CPU request (0.5 cores)
+    limits:
+      memory: "2Gi"    # Maximum memory limit
+      cpu: "1000m"     # Maximum CPU limit (1 core)
+
+  # Storage configuration
+  storage:
+    size: 10Gi
+    storageClass: "fast-ssd"
+
+  # Bootstrap configuration
+  bootstrap:
+    initdb:
+      database: app
+      owner: app
+      secret:
+        name: postgresql-resize-example-credentials
+
+  # Monitoring configuration
+  monitoring:
+    customQueriesConfigMap:
+      - name: postgres-exporter
+        key: queries.yaml
+
+---
+# Secret for database credentials
+apiVersion: v1
+kind: Secret
+metadata:
+  name: postgresql-resize-example-credentials
+  namespace: default
+type: kubernetes.io/basic-auth
+stringData:
+  username: app
+  password: "super-secret-password"
+
+---
+# Example: How to update resources in-place
+# To scale up resources, simply update the resources section:
+#
+# kubectl patch cluster postgresql-resize-example --type='merge' -p='
+# {
+#   "spec": {
+#     "resources": {
+#       "requests": {
+#         "memory": "2Gi",
+#         "cpu": "1000m"
+#       },
+#       "limits": {
+#         "memory": "4Gi", 
+#         "cpu": "2000m"
+#       }
+#     }
+#   }
+# }'
+#
+# This will trigger an in-place resource update without recreating pods,
+# provided the containerResizePolicy is set to NotRequired for the postgres container.

--- a/docs/src/samples/cluster-example-in-place-resize.yaml
+++ b/docs/src/samples/cluster-example-in-place-resize.yaml
@@ -23,9 +23,9 @@ spec:
   # Container resize policy configuration
   # This enables in-place resource updates for the postgres container
   containerResizePolicy:
-    - name: postgres
+    - resourceName: cpu
       resizePolicy: NotRequired  # Allows in-place CPU/memory updates
-    - name: barman-cloud-backup
+    - resourceName: memory
       resizePolicy: RestartContainer  # Requires restart for resource changes
 
   # Initial resource configuration

--- a/docs/src/samples/cluster-example-in-place-resize.yaml
+++ b/docs/src/samples/cluster-example-in-place-resize.yaml
@@ -24,12 +24,12 @@ spec:
   # This enables in-place resource updates for the postgres container
   containerResizePolicy:
     - resourceName: cpu
-      resizePolicy: NotRequired  # Allows in-place CPU/memory updates
+      restartPolicy: NotRequired  # Allows in-place CPU/memory updates
     - resourceName: memory
-      resizePolicy: RestartContainer  # Requires restart for resource changes
+      restartPolicy: RestartContainer  # Requires restart for resource changes
 
   # Initial resource configuration
-  # These can be updated in-place when resizePolicy is NotRequired
+  # These can be updated in-place when restartPolicy is NotRequired
   resources:
     requests:
       memory: "1Gi"    # Initial memory request

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -138,6 +138,7 @@ var ErrNextLoop = utils.ErrNextLoop
 // +kubebuilder:rbac:groups="",resources=nodes,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=get;list;create;watch;delete;patch
 // +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;delete;patch;create;watch
+// +kubebuilder:rbac:groups="",resources=pods/resize,verbs=patch
 // +kubebuilder:rbac:groups="",resources=pods/status,verbs=get
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=create;list;get;watch;delete
 // +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=create;patch;update;list;watch;get

--- a/internal/controller/cluster_upgrade.go
+++ b/internal/controller/cluster_upgrade.go
@@ -131,12 +131,6 @@ func (r *ClusterReconciler) rolloutRequiredInstances(
 		return false, nil
 	}
 
-	log.FromContext(ctx).Info("Primary pod rollout required",
-		"pod", primaryPostgresqlStatus.Pod.Name,
-		"reason", podRollout.reason,
-		"canUseResourceInPlaceUpdate", podRollout.canUseResourceInPlaceUpdate,
-		"canBeInPlace", podRollout.canBeInPlace)
-
 	// if the primary instance is marked for restart due to hot standby sensitive parameter decrease,
 	// it should be restarted by the instance manager itself
 	if primaryPostgresqlStatus.PendingRestartForDecrease {
@@ -805,9 +799,6 @@ func checkPodSpecIsOutdated(
 
 	match, diff := specs.ComparePodSpecs(storedPodSpec, targetPod.Spec)
 	if !match {
-		// Note: Resource-only changes that can be applied in-place are now handled by
-		// checkResourceOnlyChanges, which is called earlier in the process
-
 		return rollout{
 			required: true,
 			reason:   "original and target PodSpec differ in " + diff,

--- a/internal/controller/cluster_upgrade.go
+++ b/internal/controller/cluster_upgrade.go
@@ -190,6 +190,7 @@ func (r *ClusterReconciler) updatePrimaryPod(
 		}
 		log.FromContext(ctx).Info("In-place resource update successful for primary pod",
 			"pod", primaryPod.Name)
+		return false, nil
 	}
 
 	if cluster.GetPrimaryUpdateMethod() == apiv1.PrimaryUpdateMethodRestart || forceRecreate {

--- a/internal/controller/cluster_upgrade.go
+++ b/internal/controller/cluster_upgrade.go
@@ -879,8 +879,12 @@ func (r *ClusterReconciler) updatePodResources(
 
 	// Update the pod's PodSpec annotation to reflect the new resources
 	if err := r.updatePodSpecAnnotationAfterResourceUpdate(ctx, pod, cluster); err != nil {
-		// Don't return error here as the resource update was successful
-		// The annotation update failure will be handled in the next reconciliation cycle
+		// Don't return error here as the resource update was successful; log and continue
+		log.FromContext(ctx).Info(
+			"failed to update PodSpec annotation after in-place resource update (will retry on next reconciliation)",
+			"pod", pod.Name,
+			"error", err.Error(),
+		)
 	}
 
 	return nil

--- a/internal/webhook/v1/cluster_webhook.go
+++ b/internal/webhook/v1/cluster_webhook.go
@@ -223,6 +223,7 @@ func (v *ClusterCustomValidator) validate(r *apiv1.Cluster) (allErrs field.Error
 		v.validatePluginConfiguration,
 		v.validateLivenessPingerProbe,
 		v.validateExtensions,
+		v.validateContainerResizePolicy,
 	}
 
 	for _, validate := range validations {
@@ -920,6 +921,66 @@ func (v *ClusterCustomValidator) validateResources(r *apiv1.Cluster) field.Error
 				field.NewPath("spec", "resources", "requests", "storage"),
 				ephemeralStorageRequest.String(),
 				"Ephemeral storage request is greater than the limit",
+			))
+		}
+	}
+
+	return result
+}
+
+// validateContainerResizePolicy validates the container resize policy configuration
+func (v *ClusterCustomValidator) validateContainerResizePolicy(r *apiv1.Cluster) field.ErrorList {
+	var result field.ErrorList
+
+	// If no resize policy is specified, no validation needed
+	if len(r.Spec.ContainerResizePolicy) == 0 {
+		return result
+	}
+
+	// Track resource names to ensure no duplicates
+	resourceNames := make(map[corev1.ResourceName]bool)
+
+	for i, policy := range r.Spec.ContainerResizePolicy {
+		fieldPath := field.NewPath("spec", "containerResizePolicy").Index(i)
+
+		// Validate resource name
+		if policy.ResourceName == "" {
+			result = append(result, field.Required(
+				fieldPath.Child("resourceName"),
+				"resourceName must be specified",
+			))
+			continue
+		}
+
+		// Check for supported resource names (CPU and memory)
+		if policy.ResourceName != corev1.ResourceCPU && policy.ResourceName != corev1.ResourceMemory {
+			result = append(result, field.NotSupported(
+				fieldPath.Child("resourceName"),
+				policy.ResourceName,
+				[]string{string(corev1.ResourceCPU), string(corev1.ResourceMemory)},
+			))
+		}
+
+		// Check for duplicate resource names
+		if resourceNames[policy.ResourceName] {
+			result = append(result, field.Duplicate(
+				fieldPath.Child("resourceName"),
+				policy.ResourceName,
+			))
+		}
+		resourceNames[policy.ResourceName] = true
+
+		// Validate restart policy
+		if policy.RestartPolicy == "" {
+			result = append(result, field.Required(
+				fieldPath.Child("restartPolicy"),
+				"restartPolicy must be specified",
+			))
+		} else if policy.RestartPolicy != corev1.NotRequired && policy.RestartPolicy != corev1.RestartContainer {
+			result = append(result, field.NotSupported(
+				fieldPath.Child("restartPolicy"),
+				policy.RestartPolicy,
+				[]string{string(corev1.NotRequired), string(corev1.RestartContainer)},
 			))
 		}
 	}

--- a/pkg/specs/pods.go
+++ b/pkg/specs/pods.go
@@ -255,7 +255,8 @@ func createPostgresContainers(cluster apiv1.Cluster, envConfig EnvConfig, enable
 				"instance",
 				"run",
 			},
-			Resources: cluster.Spec.Resources,
+			Resources:    cluster.Spec.Resources,
+			ResizePolicy: cluster.Spec.ContainerResizePolicy,
 			Ports: []corev1.ContainerPort{
 				{
 					Name:          "postgresql",

--- a/pkg/specs/pods_test.go
+++ b/pkg/specs/pods_test.go
@@ -1066,12 +1066,12 @@ var _ = Describe("NewInstance", func() {
 	})
 
 	It("applies container resize policy to PostgreSQL container", func(ctx SpecContext) {
-		cluster := v1.Cluster{
+		cluster := apiv1.Cluster{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-cluster",
 				Namespace: "default",
 			},
-			Spec: v1.ClusterSpec{
+			Spec: apiv1.ClusterSpec{
 				Instances: 1,
 				ContainerResizePolicy: []corev1.ContainerResizePolicy{
 					{
@@ -1084,7 +1084,7 @@ var _ = Describe("NewInstance", func() {
 					},
 				},
 			},
-			Status: v1.ClusterStatus{
+			Status: apiv1.ClusterStatus{
 				Image: "postgres:13.11",
 			},
 		}
@@ -1116,15 +1116,15 @@ var _ = Describe("NewInstance", func() {
 	})
 
 	It("works without container resize policy", func(ctx SpecContext) {
-		cluster := v1.Cluster{
+		cluster := apiv1.Cluster{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-cluster",
 				Namespace: "default",
 			},
-			Spec: v1.ClusterSpec{
+			Spec: apiv1.ClusterSpec{
 				Instances: 1,
 			},
-			Status: v1.ClusterStatus{
+			Status: apiv1.ClusterStatus{
 				Image: "postgres:13.11",
 			},
 		}

--- a/pkg/specs/podspec_diff.go
+++ b/pkg/specs/podspec_diff.go
@@ -211,6 +211,9 @@ func doContainersMatch(currentContainer, targetContainer corev1.Container) (bool
 		"security-context": func() bool {
 			return reflect.DeepEqual(currentContainer.SecurityContext, targetContainer.SecurityContext)
 		},
+		"resize-policy": func() bool {
+			return reflect.DeepEqual(currentContainer.ResizePolicy, targetContainer.ResizePolicy)
+		},
 	}
 
 	for diff, f := range comparisons {

--- a/tests/e2e/fixtures/pod_inplace/cluster-pod-inplace.yaml.template
+++ b/tests/e2e/fixtures/pod_inplace/cluster-pod-inplace.yaml.template
@@ -14,9 +14,9 @@ spec:
   # Container resize policy configuration for in-place updates
   containerResizePolicy:
     - resourceName: cpu
-      resizePolicy: NotRequired  # Allows in-place CPU updates
+      restartPolicy: NotRequired  # Allows in-place CPU updates
     - resourceName: memory
-      resizePolicy: NotRequired  # Allows in-place memory updates
+      restartPolicy: NotRequired  # Allows in-place memory updates
 
   # Initial resource configuration (minimal for faster testing)
   resources:

--- a/tests/e2e/fixtures/pod_inplace/cluster-pod-inplace.yaml.template
+++ b/tests/e2e/fixtures/pod_inplace/cluster-pod-inplace.yaml.template
@@ -1,0 +1,56 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: cluster-pod-inplace
+spec:
+  instances: 2
+
+  postgresql:
+    parameters:
+      shared_buffers: "64MB"
+      log_statement: "all"
+      log_min_duration_statement: "1000"
+
+  # Container resize policy configuration for in-place updates
+  containerResizePolicy:
+    - resourceName: cpu
+      resizePolicy: NotRequired  # Allows in-place CPU updates
+    - resourceName: memory
+      resizePolicy: NotRequired  # Allows in-place memory updates
+
+  # Initial resource configuration (minimal for faster testing)
+  resources:
+    requests:
+      memory: "256Mi"
+      cpu: "100m"
+    limits:
+      memory: "512Mi"
+      cpu: "200m"
+
+  # Storage configuration (minimal for faster testing)
+  storage:
+    size: 1Gi
+    storageClass: ${E2E_DEFAULT_STORAGE_CLASS}
+
+  # Bootstrap configuration
+  bootstrap:
+    initdb:
+      database: app
+      owner: app
+      secret:
+        name: cluster-pod-inplace-credentials
+
+  # Monitoring configuration
+  monitoring:
+    enabled: true
+
+---
+# Secret for database credentials
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cluster-pod-inplace-credentials
+type: kubernetes.io/basic-auth
+stringData:
+  username: app
+  password: "super-secret-password"

--- a/tests/e2e/pod_inplace_test.go
+++ b/tests/e2e/pod_inplace_test.go
@@ -28,7 +28,6 @@ import (
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 	"github.com/cloudnative-pg/cloudnative-pg/tests"
-	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/namespaces"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -55,22 +54,6 @@ var _ = Describe("Pod Inplace Resource Updates", Label(tests.LabelSelfHealing), 
 		namespace, err = env.CreateUniqueTestNamespace(env.Ctx, env.Client, namespacePrefix)
 		Expect(err).ToNot(HaveOccurred())
 		AssertCreateCluster(namespace, clusterName, sampleFile, env)
-
-		// Wait for cluster to be ready
-		By("waiting for cluster to be ready", func() {
-			timeout := 120
-			Eventually(func() (bool, error) {
-				cluster := &apiv1.Cluster{}
-				err := env.Client.Get(env.Ctx, types.NamespacedName{
-					Namespace: namespace,
-					Name:      clusterName,
-				}, cluster)
-				if err != nil {
-					return false, err
-				}
-				return cluster.Status.Phase == apiv1.PhaseHealthy, nil
-			}, timeout).Should(BeTrue())
-		})
 
 		// Test 1: In-place resource update with NotRequired policy
 		By("testing in-place resource update with NotRequired policy", func() {
@@ -371,15 +354,5 @@ var _ = Describe("Pod Inplace Resource Updates", Label(tests.LabelSelfHealing), 
 				}
 			}
 		})
-	})
-
-	AfterEach(func() {
-		if CurrentSpecReport().Failed() {
-			namespaces.DumpNamespaceObjects(
-				env.Ctx, env.Client,
-				namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
-		}
-		// Note: Namespace cleanup is automatically handled by DeferCleanup
-		// registered in CreateTestNamespace (namespace.go:119)
 	})
 })

--- a/tests/e2e/pod_inplace_test.go
+++ b/tests/e2e/pod_inplace_test.go
@@ -1,0 +1,369 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package e2e
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/types"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
+	"github.com/cloudnative-pg/cloudnative-pg/tests"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/namespaces"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Pod Inplace Resource Updates", Label(tests.LabelSelfHealing), func() {
+	const (
+		namespacePrefix = "cluster-pod-inplace"
+		sampleFile      = fixturesDir + "/pod_inplace/cluster-pod-inplace.yaml.template"
+		clusterName     = "cluster-pod-inplace"
+		level           = tests.Medium
+	)
+	var namespace string
+
+	BeforeEach(func() {
+		if testLevelEnv.Depth < int(level) {
+			Skip("Test depth is lower than the amount requested for this test")
+		}
+	})
+
+	It("correctly handles in-place resource updates", func() {
+		var err error
+		// Create a cluster in a namespace we'll delete after the test
+		namespace, err = env.CreateUniqueTestNamespace(env.Ctx, env.Client, namespacePrefix)
+		Expect(err).ToNot(HaveOccurred())
+		AssertCreateCluster(namespace, clusterName, sampleFile, env)
+
+		// Wait for cluster to be ready
+		By("waiting for cluster to be ready", func() {
+			timeout := 120
+			Eventually(func() (bool, error) {
+				cluster := &apiv1.Cluster{}
+				err := env.Client.Get(env.Ctx, types.NamespacedName{
+					Namespace: namespace,
+					Name:      clusterName,
+				}, cluster)
+				if err != nil {
+					return false, err
+				}
+				return cluster.Status.Phase == apiv1.PhaseHealthy, nil
+			}, timeout).Should(BeTrue())
+		})
+
+		// Test 1: In-place resource update with NotRequired policy
+		By("testing in-place resource update with NotRequired policy", func() {
+			// Get the current pod UIDs before update
+			podList := &corev1.PodList{}
+			err := env.Client.List(env.Ctx, podList, ctrlclient.InNamespace(namespace),
+				ctrlclient.MatchingLabels{"cnpg.io/cluster": clusterName})
+			Expect(err).ToNot(HaveOccurred())
+
+			originalPodUIDs := make(map[string]types.UID)
+			for _, pod := range podList.Items {
+				originalPodUIDs[pod.Name] = pod.UID
+			}
+
+			// Update cluster resources
+			cluster := &apiv1.Cluster{}
+			err = env.Client.Get(env.Ctx, types.NamespacedName{
+				Namespace: namespace,
+				Name:      clusterName,
+			}, cluster)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Update CPU and memory resources (smaller values for faster testing)
+			cluster.Spec.Resources = corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("200m"),
+					corev1.ResourceMemory: resource.MustParse("512Mi"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("400m"),
+					corev1.ResourceMemory: resource.MustParse("1Gi"),
+				},
+			}
+
+			err = env.Client.Update(env.Ctx, cluster)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Wait for the update to be applied
+			timeout := 60
+			Eventually(func() (bool, error) {
+				updatedCluster := &apiv1.Cluster{}
+				err := env.Client.Get(env.Ctx, types.NamespacedName{
+					Namespace: namespace,
+					Name:      clusterName,
+				}, updatedCluster)
+				if err != nil {
+					return false, err
+				}
+
+				// Check if resources are updated
+				if updatedCluster.Spec.Resources.Requests.Cpu().Cmp(resource.MustParse("200m")) != 0 {
+					return false, nil
+				}
+				if updatedCluster.Spec.Resources.Requests.Memory().Cmp(resource.MustParse("512Mi")) != 0 {
+					return false, nil
+				}
+
+				// Check if pods still have the same UIDs (in-place update)
+				currentPodList := &corev1.PodList{}
+				err = env.Client.List(env.Ctx, currentPodList, ctrlclient.InNamespace(namespace),
+					ctrlclient.MatchingLabels{"cnpg.io/cluster": clusterName})
+				if err != nil {
+					return false, err
+				}
+
+				for _, pod := range currentPodList.Items {
+					if originalPodUIDs[pod.Name] != pod.UID {
+						return false, nil // Pod was recreated
+					}
+				}
+
+				return true, nil
+			}, timeout).Should(BeTrue())
+
+			// Verify pods are still running and healthy
+			Eventually(func() (bool, error) {
+				podList := &corev1.PodList{}
+				err := env.Client.List(env.Ctx, podList, ctrlclient.InNamespace(namespace),
+					ctrlclient.MatchingLabels{"cnpg.io/cluster": clusterName})
+				if err != nil {
+					return false, err
+				}
+
+				for _, pod := range podList.Items {
+					if !utils.IsPodReady(pod) {
+						return false, nil
+					}
+				}
+				return true, nil
+			}, timeout).Should(BeTrue())
+		})
+
+		// Test 2: Resource update with RestartContainer policy
+		By("testing resource update with RestartContainer policy", func() {
+			// Update the cluster to use RestartContainer policy for CPU
+			cluster := &apiv1.Cluster{}
+			err := env.Client.Get(env.Ctx, types.NamespacedName{
+				Namespace: namespace,
+				Name:      clusterName,
+			}, cluster)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Update container resize policy to require restart for CPU changes
+			cluster.Spec.ContainerResizePolicy = []corev1.ContainerResizePolicy{
+				{
+					ResourceName:  corev1.ResourceCPU,
+					RestartPolicy: corev1.RestartContainer,
+				},
+				{
+					ResourceName:  corev1.ResourceMemory,
+					RestartPolicy: corev1.NotRequired,
+				},
+			}
+
+			err = env.Client.Update(env.Ctx, cluster)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Get current pod UIDs
+			podList := &corev1.PodList{}
+			err = env.Client.List(env.Ctx, podList, ctrlclient.InNamespace(namespace),
+				ctrlclient.MatchingLabels{"cnpg.io/cluster": clusterName})
+			Expect(err).ToNot(HaveOccurred())
+
+			originalPodUIDs := make(map[string]types.UID)
+			for _, pod := range podList.Items {
+				originalPodUIDs[pod.Name] = pod.UID
+			}
+
+			// Update CPU resources (should trigger pod recreation)
+			cluster.Spec.Resources = corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("300m"),
+					corev1.ResourceMemory: resource.MustParse("512Mi"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("600m"),
+					corev1.ResourceMemory: resource.MustParse("1Gi"),
+				},
+			}
+
+			err = env.Client.Update(env.Ctx, cluster)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Wait for pods to be recreated (UIDs should change)
+			timeout := 60
+			Eventually(func() (bool, error) {
+				currentPodList := &corev1.PodList{}
+				err := env.Client.List(env.Ctx, currentPodList, ctrlclient.InNamespace(namespace),
+					ctrlclient.MatchingLabels{"cnpg.io/cluster": clusterName})
+				if err != nil {
+					return false, err
+				}
+
+				// Check if at least one pod was recreated (UID changed)
+				for _, pod := range currentPodList.Items {
+					if originalPodUIDs[pod.Name] != pod.UID {
+						return true, nil // At least one pod was recreated
+					}
+				}
+				return false, nil
+			}, timeout).Should(BeTrue())
+
+			// Verify cluster is still healthy after recreation
+			Eventually(func() (bool, error) {
+				cluster := &apiv1.Cluster{}
+				err := env.Client.Get(env.Ctx, types.NamespacedName{
+					Namespace: namespace,
+					Name:      clusterName,
+				}, cluster)
+				if err != nil {
+					return false, err
+				}
+				return cluster.Status.Phase == apiv1.PhaseHealthy, nil
+			}, timeout).Should(BeTrue())
+		})
+
+		// Test 3: Memory-only update with NotRequired policy
+		By("testing memory-only update with NotRequired policy", func() {
+			// Update policy to allow in-place memory updates
+			cluster := &apiv1.Cluster{}
+			err := env.Client.Get(env.Ctx, types.NamespacedName{
+				Namespace: namespace,
+				Name:      clusterName,
+			}, cluster)
+			Expect(err).ToNot(HaveOccurred())
+
+			cluster.Spec.ContainerResizePolicy = []corev1.ContainerResizePolicy{
+				{
+					ResourceName:  corev1.ResourceCPU,
+					RestartPolicy: corev1.NotRequired,
+				},
+				{
+					ResourceName:  corev1.ResourceMemory,
+					RestartPolicy: corev1.NotRequired,
+				},
+			}
+
+			err = env.Client.Update(env.Ctx, cluster)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Get current pod UIDs
+			podList := &corev1.PodList{}
+			err = env.Client.List(env.Ctx, podList, ctrlclient.InNamespace(namespace),
+				ctrlclient.MatchingLabels{"cnpg.io/cluster": clusterName})
+			Expect(err).ToNot(HaveOccurred())
+
+			originalPodUIDs := make(map[string]types.UID)
+			for _, pod := range podList.Items {
+				originalPodUIDs[pod.Name] = pod.UID
+			}
+
+			// Update only memory resources
+			cluster.Spec.Resources = corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("300m"),
+					corev1.ResourceMemory: resource.MustParse("768Mi"), // Only memory changed
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("600m"),
+					corev1.ResourceMemory: resource.MustParse("1.5Gi"), // Only memory changed
+				},
+			}
+
+			err = env.Client.Update(env.Ctx, cluster)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Wait for the update to be applied in-place
+			timeout := 60
+			Eventually(func() (bool, error) {
+				updatedCluster := &apiv1.Cluster{}
+				err := env.Client.Get(env.Ctx, types.NamespacedName{
+					Namespace: namespace,
+					Name:      clusterName,
+				}, updatedCluster)
+				if err != nil {
+					return false, err
+				}
+
+				// Check if memory resources are updated
+				if updatedCluster.Spec.Resources.Requests.Memory().Cmp(resource.MustParse("768Mi")) != 0 {
+					return false, nil
+				}
+
+				// Check if pods still have the same UIDs (in-place update)
+				currentPodList := &corev1.PodList{}
+				err = env.Client.List(env.Ctx, currentPodList, ctrlclient.InNamespace(namespace),
+					ctrlclient.MatchingLabels{"cnpg.io/cluster": clusterName})
+				if err != nil {
+					return false, err
+				}
+
+				for _, pod := range currentPodList.Items {
+					if originalPodUIDs[pod.Name] != pod.UID {
+						return false, nil // Pod was recreated
+					}
+				}
+
+				return true, nil
+			}, timeout).Should(BeTrue())
+		})
+
+		// Test 4: Verify resource limits are actually applied
+		By("verifying resource limits are applied to pods", func() {
+			podList := &corev1.PodList{}
+			err := env.Client.List(env.Ctx, podList, ctrlclient.InNamespace(namespace),
+				ctrlclient.MatchingLabels{"cnpg.io/cluster": clusterName})
+			Expect(err).ToNot(HaveOccurred())
+
+			for _, pod := range podList.Items {
+				// Find the postgres container
+				for _, container := range pod.Spec.Containers {
+					if container.Name == "postgres" {
+						// Verify CPU limits
+						Expect(container.Resources.Limits.Cpu().Cmp(resource.MustParse("600m"))).To(Equal(0))
+						// Verify Memory limits
+						Expect(container.Resources.Limits.Memory().Cmp(resource.MustParse("1.5Gi"))).To(Equal(0))
+						// Verify CPU requests
+						Expect(container.Resources.Requests.Cpu().Cmp(resource.MustParse("300m"))).To(Equal(0))
+						// Verify Memory requests
+						Expect(container.Resources.Requests.Memory().Cmp(resource.MustParse("768Mi"))).To(Equal(0))
+					}
+				}
+			}
+		})
+	})
+
+	AfterEach(func() {
+		if CurrentSpecReport().Failed() {
+			namespaces.DumpNamespaceObjects(
+				env.Ctx, env.Client,
+				namespace, "out/"+CurrentSpecReport().LeafNodeText+".log")
+		}
+		err := namespaces.DeleteNamespaceAndWait(env.Ctx, env.Client, namespace, 120)
+		Expect(err).ToNot(HaveOccurred())
+	})
+})


### PR DESCRIPTION
## Implement In-Place Pod Resource Updates with Container Resize Policy

### What this PR does
This PR adds support for **in-place resource updates** in CloudNativePG clusters, leveraging the new Kubernetes v1.33 [In-Place Pod Resize Beta feature](https://kubernetes.io/blog/2025/05/16/kubernetes-v1-33-in-place-pod-resize-beta/). Instead of recreating pods when you change CPU/memory resources, the operator can now update resources directly on running pods when the container resize policy allows it.

This addresses the feature request in [GitHub issue #8070](https://github.com/cloudnative-pg/cloudnative-pg/issues/8070).

### Key Features
- ✅ **Zero-downtime resource scaling** - No more pod recreations for CPU/memory changes
- ✅ **Container resize policies** - Control which containers can be resized in-place
- ✅ **Backward compatible** - Existing clusters work unchanged
- ✅ **Smart fallback** - Falls back to recreation when in-place isn't possible
- ✅ **Kubernetes v1.33+ support** - Leverages the new in-place pod resize beta feature

### How to use it
Add a `containerResizePolicy` to your cluster spec:

```yaml
apiVersion: postgresql.cnpg.io/v1
kind: Cluster
metadata:
  name: my-cluster
spec:
  containerResizePolicy:
    - name: postgres
      resizePolicy: NotRequired  # Enables in-place updates
    - name: barman-cloud-backup
      resizePolicy: RestartContainer  # Requires recreation
  
  resources:
    requests:
      memory: "1Gi"
      cpu: "500m"
    limits:
      memory: "2Gi"
      cpu: "1000m"
```

Then scale resources normally:
```bash
kubectl patch cluster my-cluster --type='merge' -p='
{
  "spec": {
    "resources": {
      "requests": {"memory": "2Gi", "cpu": "1000m"},
      "limits": {"memory": "4Gi", "cpu": "2000m"}
    }
  }
}'
```

### What changed
- **Core logic**: Added in-place update support using Kubernetes resize subresource
- **New field**: `containerResizePolicy` in cluster spec
- **Better reconciliation**: Fixed logic to prevent unnecessary pod recreations
- **Documentation**: Added comprehensive docs and examples
- **Tests**: Updated tests for new functionality

### Requirements
- Kubernetes 1.33+ (for in-place pod resize beta feature)
- Only works for CPU/memory changes
- Container must have `resizePolicy: NotRequired`

### Testing
- ✅ Unit tests updated
- ✅ Integration testing completed
- ✅ Edge cases handled
- ✅ Backward compatibility verified

### Breaking Changes
**None** - this is fully backward compatible.

---
