### PR TITLE
docs(release): acknowledge community contributions in release notes

### DIFF
--- a/contribute/release-notes-template.md
+++ b/contribute/release-notes-template.md
@@ -25,6 +25,10 @@ on the release branch in GitHub.
 
 **Release date:** Mon DD, 20YY
 
+<!--
+If individual PRs are mentioned, make sure to include the contributor's GitHub handle alongside it.
+-->
+
 ### Important changes:
 
 - OPTIONAL
@@ -68,3 +72,7 @@ on the release branch in GitHub.
 - PostgreSQL 17, 16, 15, 14, and 13
     - PostgreSQL 17.X is the default image
     - PostgreSQL 13 support ends on November 12, 2025
+
+### New Contributors
+
+- @github-user-handle made their first contribution in #123

--- a/contribute/release_procedure.md
+++ b/contribute/release_procedure.md
@@ -72,7 +72,9 @@ activities:
   and [`.github/ISSUE_TEMPLATE/bug.yml`](../.github/ISSUE_TEMPLATE/bug.yml).
   These changes should go in a PR against `main`, and get maintainer approval.
   Look at the template file to get an idea of how to start a new minor release
-  version document.
+  version document. As a token of appreciation for the Community’s efforts, make sure to
+  include the contributor’s GitHub handle alongside their PRs, if mentioned.
+  First-time contributors should also be highlighted in the dedicated "New Contributors" section.
 
 - **Capabilities page:** in case of a new minor release, ensure that the
   operator capability levels page in


### PR DESCRIPTION

This pull request improves the contributor recognition process in release documentation by updating the release notes template and release procedure guidelines. The main changes ensure that contributors' GitHub handles are mentioned alongside their PRs and that first-time contributors are highlighted in a new section.

Enhancements to contributor recognition:

* Updated the `contribute/release-notes-template.md` file to instruct maintainers to add the contributor's GitHub handle alongside individual PRs mentioned in the release notes.
* Added a "New Contributors" section to the `contribute/release-notes-template.md` file to highlight first-time contributors and their PRs.
* Modified the `contribute/release_procedure.md` file to require release notes to include contributor handles and to highlight first-time contributors in a dedicated section.

Follow-up to #8338