### PR TITLE
chore: fix ReplicaFailingReplication alert expr

### DIFF
--- a/docs/src/samples/monitoring/prometheusrule.yaml
+++ b/docs/src/samples/monitoring/prometheusrule.yaml
@@ -65,7 +65,7 @@ spec:
         description: Replica {{ $labels.pod }} is failing to replicate
         summary: Checks if the replica is failing to replicate
       expr: |-
-        cnpg_pg_replication_in_recovery > cnpg_pg_replication_is_wal_receiver_up
+        cnpg_pg_replication_in_recovery == 1 and cnpg_pg_replication_is_wal_receiver_up == 0
       for: 1m
       labels:
         severity: warning


### PR DESCRIPTION
**Problem**:
The current alert expression uses a arithmetic comparison operator (>) on two boolean-style metrics. This is semantically incorrect.

**Analysis**:
Both metrics are gauges representing boolean states (0 = false, 1 = true):

```text
# HELP cnpg_pg_replication_in_recovery Whether the instance is in recovery
# TYPE cnpg_pg_replication_in_recovery gauge
cnpg_pg_replication_in_recovery 0
# HELP cnpg_pg_replication_is_wal_receiver_up Whether the instance wal_receiver is up
# TYPE cnpg_pg_replication_is_wal_receiver_up gauge
cnpg_pg_replication_is_wal_receiver_up 0
```

**Solution**:
Replace the arithmetic comparison with an explicit logical `and` condition:

```yaml
expr: |
  cnpg_pg_replication_in_recovery == 1 and cnpg_pg_replication_is_wal_receiver_up == 0
```
