### PR TITLE
fix(cnpgi,connection): improve retry algorithm

### DIFF
--- a/internal/controller/plugin_controller.go
+++ b/internal/controller/plugin_controller.go
@@ -117,7 +117,13 @@ func (r *PluginReconciler) reconcile(
 	service *corev1.Service,
 	pluginName string,
 ) (ctrl.Result, error) {
-	contextLogger := log.FromContext(ctx).WithValues("pluginName", pluginName)
+	contextLogger := log.FromContext(ctx).WithValues(
+		"pluginName", pluginName,
+		"service", client.ObjectKeyFromObject(service))
+	contextLogger.Debug("Plugin reconciliation loop start")
+	defer func() {
+		contextLogger.Debug("Plugin reconciliation loop end")
+	}()
 
 	pluginServerSecret := service.Annotations[utils.PluginServerSecretAnnotationName]
 	if len(pluginServerSecret) == 0 {


### PR DESCRIPTION
On each execution of the plugin reconciliation loop, the plugin’s connection pool is closed and recreated with the newly detected settings.

If a connection request occurs while the pool is being recreated, the request may fail with a "closed pool" error.

This patch improves the reconciliation logic to properly detect pool changes and enhances the retry mechanism by introducing an exponential backoff strategy.

Fixes: #8553 
