### PR TITLE
docs: adopt new `postgres-containers` policies and artifacts

### DIFF
--- a/docs/src/image_catalog.md
+++ b/docs/src/image_catalog.md
@@ -80,33 +80,25 @@ Any alterations to the images within a catalog trigger automatic updates for
 
 ## CloudNativePG Catalogs
 
-The CloudNativePG project maintains `ClusterImageCatalogs` for the images it
-provides. These catalogs are regularly updated with the latest images for each
-major version. By applying the `ClusterImageCatalog.yaml` file from the
-CloudNativePG project's GitHub repositories, cluster administrators can ensure
-that their clusters are automatically updated to the latest version within the
-specified major release.
+The CloudNativePG project maintains `ClusterImageCatalog` manifests for all
+supported images.
 
-### PostgreSQL Container Images
+These catalogs are regularly updated and published in the
+[artifacts repository](https://github.com/cloudnative-pg/artifacts/tree/main/image-catalogs).
 
-You can install the
-[latest version of the cluster catalog for the PostgreSQL Container Images](https://raw.githubusercontent.com/cloudnative-pg/postgres-containers/main/Debian/ClusterImageCatalog-bookworm.yaml)
-([cloudnative-pg/postgres-containers](https://github.com/cloudnative-pg/postgres-containers) repository)
-with:
+Each catalog corresponds to a specific combination of image type (e.g.
+`minimal`) and Debian release (e.g. `trixie`). It lists the most up-to-date
+container images for every supported PostgreSQL major version.
 
-```shell
-kubectl apply \
-  -f https://raw.githubusercontent.com/cloudnative-pg/postgres-containers/main/Debian/ClusterImageCatalog-bookworm.yaml
-```
+By installing these catalogs, cluster administrators can ensure that their
+PostgreSQL clusters are automatically updated to the latest patch release
+within a given PostgreSQL major version, for the selected Debian distribution
+and image type.
 
-### PostGIS Container Images
-
-You can install the
-[latest version of the cluster catalog for the PostGIS Container Images](https://raw.githubusercontent.com/cloudnative-pg/postgis-containers/main/PostGIS/ClusterImageCatalog.yaml)
-([cloudnative-pg/postgis-containers](https://github.com/cloudnative-pg/postgis-containers) repository)
-with:
+For example, to install the latest catalog for the `minimal` PostgreSQL
+container images on Debian `trixie`, run:
 
 ```shell
-kubectl apply \
-  -f https://raw.githubusercontent.com/cloudnative-pg/postgis-containers/main/PostGIS/ClusterImageCatalog.yaml
+kubectl apply -f \
+  https://raw.githubusercontent.com/cloudnative-pg/artifacts/refs/heads/main/image-catalogs/catalog-minimal-trixie.yaml
 ```

--- a/docs/src/image_catalog.md
+++ b/docs/src/image_catalog.md
@@ -102,3 +102,10 @@ container images on Debian `trixie`, run:
 kubectl apply -f \
   https://raw.githubusercontent.com/cloudnative-pg/artifacts/refs/heads/main/image-catalogs/catalog-minimal-trixie.yaml
 ```
+
+You can install all the available catalogs by using the `kustomization` file
+present in the `image-catalogs` directory:
+
+```shell
+kubectl apply -k https://github.com/cloudnative-pg/artifacts//image-catalogs?ref=main
+```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -96,7 +96,7 @@ By default, this version of CloudNativePG deploys `ghcr.io/cloudnative-pg/postgr
 All images are signed and shipped with SBOM and provenance attestations.
 Weekly automated builds ensure that critical vulnerabilities (CVEs) are promptly fixed.
 
-For details and support, see the [`postgres-containers` project](https://github.com/cloudnative-pg/postgres-containers).
+For details and support, see the [`postgres-containers` project](https://github.com/cloudnative-pg/postgres-containers?tab=readme-ov-file#cnpg-postgresql-container-images).
 
 ## Main features
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -69,20 +69,34 @@ provided separately for each architecture.
 
 ### Operands
 
-The PostgreSQL operand container images are available for all
-[PGDG supported versions of PostgreSQL](https://www.postgresql.org/),
-across multiple architectures, directly from the
-[`postgres-containers` project's GitHub Container Registry](https://github.com/cloudnative-pg/postgres-containers/pkgs/container/postgresql).
+The CloudNativePG project provides and maintains PostgreSQL operand container
+images, built on top of the official [Debian `slim` base image](https://hub.docker.com/_/debian),
+for both `linux/amd64` and `linux/arm64` architectures.
 
-The [`minimal`](https://github.com/cloudnative-pg/postgres-containers#minimal-images)
-and [`standard`](https://github.com/cloudnative-pg/postgres-containers#standard-images)
-container images are signed and include SBOM and provenance attestations,
-provided separately for each architecture.
+Images are published for all [Debian supported releases](https://www.debian.org/releases/)
+([`stable`](https://www.debian.org/releases/stable/),
+[`oldstable`](https://www.debian.org/releases/oldstable/)) and for
+[PostgreSQL versions supported by PGDG](https://www.postgresql.org/).
+They are distributed via the [`postgres-containers` GitHub Container Registry](https://github.com/cloudnative-pg/postgres-containers/pkgs/container/postgresql).
 
-Weekly jobs ensure that critical vulnerabilities (CVEs) in the entire stack are
-promptly addressed.
+Three image flavours are available, each extending the previous one:
 
-Additionally, the community provides images for the [PostGIS extension](postgis.md).
+- [`minimal`](https://github.com/cloudnative-pg/postgres-containers#minimal-images)
+- [`standard`](https://github.com/cloudnative-pg/postgres-containers#standard-images)
+- [`system`](https://github.com/cloudnative-pg/postgres-containers#system-images) *(deprecated)*
+
+!!! Important
+    The `system` images are deprecated and will be removed once in-core
+    Barman Cloud support is phased out. They remain usable for now, but you may
+    want to plan a future migration to `minimal` or `standard` images with the
+    Barman Cloud plugin, or another supported backup solution.
+
+By default, this version of CloudNativePG deploys `ghcr.io/cloudnative-pg/postgresql:17.6-system-trixie`.
+
+All images are signed and shipped with SBOM and provenance attestations.
+Weekly automated builds ensure that critical vulnerabilities (CVEs) are promptly fixed.
+
+For details and support, see the [`postgres-containers` project](https://github.com/cloudnative-pg/postgres-containers).
 
 ## Main features
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -79,7 +79,7 @@ Images are published for all [Debian supported releases](https://www.debian.org/
 [PostgreSQL versions supported by PGDG](https://www.postgresql.org/).
 They are distributed via the [`postgres-containers` GitHub Container Registry](https://github.com/cloudnative-pg/postgres-containers/pkgs/container/postgresql).
 
-Three image flavours are available, each extending the previous one:
+Three image flavors are available, each extending the previous one:
 
 - [`minimal`](https://github.com/cloudnative-pg/postgres-containers#minimal-images)
 - [`standard`](https://github.com/cloudnative-pg/postgres-containers#standard-images)


### PR DESCRIPTION
The `postgres-containers` project now publishes `system` images, following the deprecation of the `bullseye` Debian version in the Docker PostgreSQL project.

The main CloudNativePG documentation page has been updated to:

- Refer to the `postgres-containers` project for details and supportability, instead of duplicating content.
- List the current default image (`17.6-system-trixie`).

The image catalog page has also been simplified to point directly to the new artifacts page.

Closes #8552 