### PR TITLE
feat(cluster): add `spec.postgresql.synchronous.failoverQuorum` field

### DIFF
--- a/.wordlist-en-custom.txt
+++ b/.wordlist-en-custom.txt
@@ -844,6 +844,7 @@ externalclusters
 facto
 failover
 failoverDelay
+failoverQuorum
 failoverquorums
 failovers
 failureThreshold

--- a/api/v1/cluster_defaults.go
+++ b/api/v1/cluster_defaults.go
@@ -347,12 +347,7 @@ func (r *Cluster) tryConvertAlphaFailoverQuorum() {
 		return
 	}
 
-	// There's nothing to do if failover quorum is disabled
-	if !v {
-		return
-	}
-
-	// Again, the webhook prevents the user from enabling
+	// The webhook prevents the user from enabling
 	// failover quorum without synchronous replication.
 	if r.Spec.PostgresConfiguration.Synchronous == nil {
 		return

--- a/api/v1/cluster_defaults.go
+++ b/api/v1/cluster_defaults.go
@@ -22,6 +22,7 @@ package v1
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
 
 	"github.com/cloudnative-pg/machinery/pkg/log"
 	"github.com/cloudnative-pg/machinery/pkg/stringset"
@@ -142,6 +143,7 @@ func (r *Cluster) setDefaults(preserveUserSettings bool) {
 
 	r.setDefaultPlugins(configuration.Current)
 	r.setProbes()
+	r.tryConvertAlphaFailoverQuorum()
 }
 
 func (r *Cluster) setDefaultPlugins(config *configuration.Data) {
@@ -330,6 +332,33 @@ func (r *Cluster) tryConvertAlphaLivenessPinger() {
 		RequestTimeout:    v.RequestTimeout,
 		ConnectionTimeout: v.ConnectionTimeout,
 	}
+}
+
+func (r *Cluster) tryConvertAlphaFailoverQuorum() {
+	annotationValue, ok := r.Annotations[utils.FailoverQuorumAnnotationName]
+	if !ok {
+		return
+	}
+
+	v, err := strconv.ParseBool(annotationValue)
+	if err != nil {
+		// The validation webhook will catch this
+		// error and notify the user.
+		return
+	}
+
+	// There's nothing to do if failover quorum is disabled
+	if !v {
+		return
+	}
+
+	// Again, the webhook prevents the user from enabling
+	// failover quorum without synchronous replication.
+	if r.Spec.PostgresConfiguration.Synchronous == nil {
+		return
+	}
+
+	r.Spec.PostgresConfiguration.Synchronous.FailoverQuorum = v
 }
 
 // NewLivenessPingerConfigFromAnnotations creates a new pinger configuration from the annotations

--- a/api/v1/cluster_defaults_test.go
+++ b/api/v1/cluster_defaults_test.go
@@ -538,6 +538,13 @@ var _ = Describe("failover quorum defaults", func() {
 		Expect(cluster.Spec.PostgresConfiguration.Synchronous.FailoverQuorum).To(BeTrue())
 	})
 
+	It("should convert the annotation if present and set to false", func() {
+		cluster := clusterWithFailoverQuorumAnnotation("f")
+		cluster.Spec.PostgresConfiguration.Synchronous.FailoverQuorum = true
+		cluster.Default()
+		Expect(cluster.Spec.PostgresConfiguration.Synchronous.FailoverQuorum).To(BeFalse())
+	})
+
 	It("should not convert the annotation if the value is wrong", func() {
 		cluster := clusterWithFailoverQuorumAnnotation("toast")
 		cluster.Spec.PostgresConfiguration.Synchronous.FailoverQuorum = true

--- a/api/v1/cluster_funcs.go
+++ b/api/v1/cluster_funcs.go
@@ -25,7 +25,6 @@ import (
 	"maps"
 	"regexp"
 	"slices"
-	"strconv"
 	"strings"
 	"time"
 
@@ -1565,16 +1564,10 @@ func (cluster *Cluster) GetEnabledWALArchivePluginName() string {
 
 // IsFailoverQuorumActive check if we should enable the
 // quorum failover protection alpha-feature.
-func (cluster *Cluster) IsFailoverQuorumActive() (bool, error) {
-	failoverQuorumAnnotation, ok := cluster.GetAnnotations()[utils.FailoverQuorumAnnotationName]
-	if !ok || failoverQuorumAnnotation == "" {
-		return false, nil
+func (cluster *Cluster) IsFailoverQuorumActive() bool {
+	if cluster.Spec.PostgresConfiguration.Synchronous == nil {
+		return false
 	}
 
-	v, err := strconv.ParseBool(failoverQuorumAnnotation)
-	if err != nil {
-		return false, fmt.Errorf("failed to parse failover quorum annotation '%v': %v", failoverQuorumAnnotation, err)
-	}
-
-	return v, nil
+	return cluster.Spec.PostgresConfiguration.Synchronous.FailoverQuorum
 }

--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -1388,8 +1388,8 @@ type SynchronousReplicaConfiguration struct {
 	// +optional
 	DataDurability DataDurabilityLevel `json:"dataDurability,omitempty"`
 
-	// FailoverQuorum enables quorum-based check before failover, enhances data
-	// durability and safety during failover events in CloudNativePG-managed
+	// FailoverQuorum enables a quorum-based check before failover, improving
+	// data durability and safety during failover events in CloudNativePG-managed
 	// PostgreSQL clusters.
 	// +optional
 	FailoverQuorum bool `json:"failoverQuorum"`

--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -1387,6 +1387,12 @@ type SynchronousReplicaConfiguration struct {
 	// +kubebuilder:validation:Enum=required;preferred
 	// +optional
 	DataDurability DataDurabilityLevel `json:"dataDurability,omitempty"`
+
+	// FailoverQuorum enables quorum-based check before failover, enhances data
+	// durability and safety during failover events in CloudNativePG-managed
+	// PostgreSQL clusters.
+	// +optional
+	FailoverQuorum bool `json:"failoverQuorum"`
 }
 
 // PostgresConfiguration defines the PostgreSQL configuration

--- a/config/crd/bases/postgresql.cnpg.io_clusters.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_clusters.yaml
@@ -4292,8 +4292,8 @@ spec:
                         type: string
                       failoverQuorum:
                         description: |-
-                          FailoverQuorum enables quorum-based check before failover, enhances data
-                          durability and safety during failover events in CloudNativePG-managed
+                          FailoverQuorum enables a quorum-based check before failover, improving
+                          data durability and safety during failover events in CloudNativePG-managed
                           PostgreSQL clusters.
                         type: boolean
                       maxStandbyNamesFromCluster:

--- a/config/crd/bases/postgresql.cnpg.io_clusters.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_clusters.yaml
@@ -4290,6 +4290,12 @@ spec:
                         - required
                         - preferred
                         type: string
+                      failoverQuorum:
+                        description: |-
+                          FailoverQuorum enables quorum-based check before failover, enhances data
+                          durability and safety during failover events in CloudNativePG-managed
+                          PostgreSQL clusters.
+                        type: boolean
                       maxStandbyNamesFromCluster:
                         description: |-
                           Specifies the maximum number of local cluster pods that can be

--- a/docs/src/cloudnative-pg.v1.md
+++ b/docs/src/cloudnative-pg.v1.md
@@ -6466,6 +6466,15 @@ to allow for operational continuity. This setting is only applicable if both
 <code>standbyNamesPre</code> and <code>standbyNamesPost</code> are unset (empty).</p>
 </td>
 </tr>
+<tr><td><code>failoverQuorum</code><br/>
+<i>bool</i>
+</td>
+<td>
+   <p>FailoverQuorum enables quorum-based check before failover, enhances data
+durability and safety during failover events in CloudNativePG-managed
+PostgreSQL clusters.</p>
+</td>
+</tr>
 </tbody>
 </table>
 

--- a/docs/src/cloudnative-pg.v1.md
+++ b/docs/src/cloudnative-pg.v1.md
@@ -6470,8 +6470,8 @@ to allow for operational continuity. This setting is only applicable if both
 <i>bool</i>
 </td>
 <td>
-   <p>FailoverQuorum enables quorum-based check before failover, enhances data
-durability and safety during failover events in CloudNativePG-managed
+   <p>FailoverQuorum enables a quorum-based check before failover, improving
+data durability and safety during failover events in CloudNativePG-managed
 PostgreSQL clusters.</p>
 </td>
 </tr>

--- a/docs/src/failover.md
+++ b/docs/src/failover.md
@@ -155,6 +155,13 @@ spec:
     size: 1G
 ```
 
+!!! Note
+    For backward compatibility, the legacy annotation `alpha.cnpg.io/failoverQuorum` is still
+    accepted by the admission webhook. When the annotation evaluates to "true"
+    and a synchronous replication stanza is present, the webhook will set the
+    `.spec.postgresql.synchronous.failoverQuorum` to true.
+    When the annotation evaluates to "false", it is ignored.
+
 ### How it works
 
 Before promoting a replica to primary, the operator performs a quorum check,

--- a/docs/src/failover.md
+++ b/docs/src/failover.md
@@ -133,13 +133,27 @@ the instance to promote, and it does not occur otherwise.
 This feature allows users to choose their preferred trade-off between data
 durability and data availability.
 
-Failover quorum can be enabled by setting the annotation
-`alpha.cnpg.io/failoverQuorum="true"` in the `Cluster` resource.
+Failover quorum can be enabled by setting the
+`.spec.postgresql.synchronous.failoverQuorum` field to `true`, like in the
+following example:
 
-!!! info
-    When this feature is out of the experimental phase, the annotation
-    `alpha.cnpg.io/failoverQuorum` will be replaced by a configuration option in
-    the `Cluster` resource.
+```yaml
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: cluster-example
+spec:
+  instances: 3
+
+  postgresql:
+    synchronous:
+      method: any
+      number: 1
+      failoverQuorum: true
+
+  storage:
+    size: 1G
+```
 
 ### How it works
 

--- a/docs/src/failover.md
+++ b/docs/src/failover.md
@@ -161,7 +161,7 @@ takes precedence over the `Cluster` spec option:
 - If the annotation evaluates to `"true"` and a synchronous replication stanza
   is present, the webhook automatically sets
   `.spec.postgresql.synchronous.failoverQuorum` to `true`.
-- If the annotation evaluates to `"false"`, the annotation is ignored.
+- If the annotation evaluates to `"false"`, the feature is always disabled
 
 !!! Important
     Because the annotation overrides the spec, we recommend that users of this

--- a/docs/src/failover.md
+++ b/docs/src/failover.md
@@ -134,8 +134,7 @@ This feature allows users to choose their preferred trade-off between data
 durability and data availability.
 
 Failover quorum can be enabled by setting the
-`.spec.postgresql.synchronous.failoverQuorum` field to `true`, like in the
-following example:
+`.spec.postgresql.synchronous.failoverQuorum` field to `true`:
 
 ```yaml
 apiVersion: postgresql.cnpg.io/v1
@@ -155,12 +154,21 @@ spec:
     size: 1G
 ```
 
-!!! Note
-    For backward compatibility, the legacy annotation `alpha.cnpg.io/failoverQuorum` is still
-    accepted by the admission webhook. When the annotation evaluates to "true"
-    and a synchronous replication stanza is present, the webhook will set the
-    `.spec.postgresql.synchronous.failoverQuorum` to true.
-    When the annotation evaluates to "false", it is ignored.
+For backward compatibility, the legacy annotation
+`alpha.cnpg.io/failoverQuorum` is still supported by the admission webhook and
+takes precedence over the `Cluster` spec option:
+
+- If the annotation evaluates to `"true"` and a synchronous replication stanza
+  is present, the webhook automatically sets
+  `.spec.postgresql.synchronous.failoverQuorum` to `true`.
+- If the annotation evaluates to `"false"`, the feature is always disabled.
+
+!!! Important
+    Because the annotation overrides the spec, we recommend that users of this
+    experimental feature migrate to the native
+    `.spec.postgresql.synchronous.failoverQuorum` option and remove the annotation
+    from their manifests. The annotation is **deprecated** and will be removed in a
+    future release.
 
 ### How it works
 

--- a/docs/src/failover.md
+++ b/docs/src/failover.md
@@ -161,7 +161,7 @@ takes precedence over the `Cluster` spec option:
 - If the annotation evaluates to `"true"` and a synchronous replication stanza
   is present, the webhook automatically sets
   `.spec.postgresql.synchronous.failoverQuorum` to `true`.
-- If the annotation evaluates to `"false"`, the feature is always disabled.
+- If the annotation evaluates to `"false"`, the annotation is ignored.
 
 !!! Important
     Because the annotation overrides the spec, we recommend that users of this

--- a/docs/src/samples/cluster-example-syncreplicas-quorum.yaml
+++ b/docs/src/samples/cluster-example-syncreplicas-quorum.yaml
@@ -2,8 +2,6 @@ apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
   name: cluster-example
-  annotations:
-    alpha.cnpg.io/failoverQuorum: "true"
 spec:
   instances: 3
 
@@ -11,6 +9,7 @@ spec:
     synchronous:
       method: any
       number: 1
+      failoverQuorum: true
 
   storage:
     size: 1G

--- a/internal/controller/replicas.go
+++ b/internal/controller/replicas.go
@@ -111,15 +111,9 @@ func (r *ClusterReconciler) reconcileTargetPrimaryForNonReplicaCluster(
 	}
 
 	// If quorum check is active, ensure we don't failover in unsafe scenarios.
-	isFailoverQuorumActive, err := cluster.IsFailoverQuorumActive()
-	if err != nil {
-		contextLogger.Error(err, "Failed to determine if failover quorum is active")
-		isFailoverQuorumActive = false
-	}
-
 	if cluster.Status.TargetPrimary == cluster.Status.CurrentPrimary &&
 		cluster.Spec.PostgresConfiguration.Synchronous != nil &&
-		isFailoverQuorumActive {
+		cluster.IsFailoverQuorumActive() {
 		if status, err := r.evaluateQuorumCheck(ctx, cluster, status); err != nil {
 			return "", err
 		} else if !status {

--- a/internal/controller/replicas.go
+++ b/internal/controller/replicas.go
@@ -112,7 +112,6 @@ func (r *ClusterReconciler) reconcileTargetPrimaryForNonReplicaCluster(
 
 	// If quorum check is active, ensure we don't failover in unsafe scenarios.
 	if cluster.Status.TargetPrimary == cluster.Status.CurrentPrimary &&
-		cluster.Spec.PostgresConfiguration.Synchronous != nil &&
 		cluster.IsFailoverQuorumActive() {
 		if status, err := r.evaluateQuorumCheck(ctx, cluster, status); err != nil {
 			return "", err

--- a/internal/controller/replicas_quorum.go
+++ b/internal/controller/replicas_quorum.go
@@ -134,14 +134,7 @@ func (r *ClusterReconciler) evaluateQuorumCheckWithStatus(
 }
 
 func (r *ClusterReconciler) reconcileFailoverQuorumObject(ctx context.Context, cluster *apiv1.Cluster) error {
-	contextLogger := log.FromContext(ctx).WithValues("tag", "quorumCheck")
-
-	syncConfig := cluster.Spec.PostgresConfiguration.Synchronous
-	failoverQuorumActive, err := cluster.IsFailoverQuorumActive()
-	if err != nil {
-		contextLogger.Error(err, "Failed to determine if failover quorum is active")
-	}
-	if syncConfig != nil && failoverQuorumActive {
+	if cluster.IsFailoverQuorumActive() {
 		return r.ensureFailoverQuorumObjectExists(ctx, cluster)
 	}
 

--- a/internal/webhook/v1/cluster_webhook.go
+++ b/internal/webhook/v1/cluster_webhook.go
@@ -1050,7 +1050,7 @@ func (v *ClusterCustomValidator) validateFailoverQuorum(r *apiv1.Cluster) field.
 		err := field.Invalid(
 			field.NewPath("spec", "postgresql", "synchronous"),
 			cfg,
-			"Invalid failoverQuorum configuration: spec.postgresql.synchronous.number must the greater than "+
+			"Invalid failoverQuorum configuration: spec.postgresql.synchronous.number must be greater than "+
 				"the total number of instances in spec.postgresql.synchronous.standbyNamesPre and "+
 				"spec.postgresql.synchronous.standbyNamesPost to allow automatic failover.",
 		)


### PR DESCRIPTION
Introduce a native configuration field, `spec.postgresql.synchronous.failoverQuorum`, allowing users to enable or disable the failover quorum feature directly in the `Cluster` spec.

Existing clusters using the `alpha.cnpg.io/failoverQuorum` annotation are unaffected: the mutating webhook automatically sets the new field to honour the annotation.

The annotation takes precedence if both the annotation and the field are set.

Deprecation notice: the `alpha.cnpg.io/failoverQuorum` annotation is deprecated. Users are encouraged to migrate to the native `.spec.postgresql.synchronous.failoverQuorum` option and remove the annotation from their manifests. The annotation will be removed in a future release.

Closes #8170 
