### PR TITLE
chore: specify the toolchain in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/cloudnative-pg/cloudnative-pg
 
 go 1.24.1
 
+toolchain go1.25.1
+
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/Masterminds/semver/v3 v3.4.0


### PR DESCRIPTION
This modification clarifies the Go version used for builds and helps Renovate prevent version mismatches.