### PR TITLE
feat(instance-manager): warn on deprecated or unsupported OS versions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ toolchain go1.25.1
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/Masterminds/semver/v3 v3.4.0
+	github.com/acobaugh/osrelease v0.1.0
 	github.com/avast/retry-go/v4 v4.6.1
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/cheynewallace/tabby v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7Oputl
 github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
 github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
+github.com/acobaugh/osrelease v0.1.0 h1:Yb59HQDGGNhCj4suHaFQQfBps5wyoKLSSX/J/+UifRE=
+github.com/acobaugh/osrelease v0.1.0/go.mod h1:4bFEs0MtgHNHBrmHCt67gNisnabCRAlzdVasCEGHTWY=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/avast/retry-go/v4 v4.6.1 h1:VkOLRubHdisGrHnTu89g08aQEWEgRU7LVEop3GbIcMk=

--- a/internal/cmd/manager/instance/run/cmd.go
+++ b/internal/cmd/manager/instance/run/cmd.go
@@ -17,7 +17,6 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 */
 
-// Package run implements the "instance run" subcommand of the operator
 package run
 
 import (
@@ -104,6 +103,9 @@ func NewCmd() *cobra.Command {
 				cmd.Context(),
 				log.GetLogger().WithValues("logger", "instance-manager"),
 			)
+
+			checkCurrentOSRelease(ctx)
+
 			instance := postgres.NewInstance().
 				WithPodName(podName).
 				WithClusterName(clusterName).

--- a/internal/cmd/manager/instance/run/doc.go
+++ b/internal/cmd/manager/instance/run/doc.go
@@ -1,0 +1,21 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+// Package run implements the "instance run" subcommand of the operator
+package run

--- a/internal/cmd/manager/instance/run/osdb.go
+++ b/internal/cmd/manager/instance/run/osdb.go
@@ -78,23 +78,23 @@ func (db *OSDB) Get(version string) (OSEntry, bool) {
 func init() {
 	// Known Debian releases
 	defaultOSDB.Register(OSEntry{
-		Version:         "10 (buster)",
-		DeprecatedFrom:  time.Date(2022, time.September, 10, 0, 0, 0, 0, time.UTC),
+		Version:        "10 (buster)",
+		DeprecatedFrom: time.Date(2022, time.September, 10, 0, 0, 0, 0, time.UTC),
 		SupportedUntil: time.Date(2024, time.June, 30, 0, 0, 0, 0, time.UTC),
 	})
 	defaultOSDB.Register(OSEntry{
-		Version:         "11 (bullseye)",
-		DeprecatedFrom:  time.Date(2024, time.August, 14, 0, 0, 0, 0, time.UTC),
+		Version:        "11 (bullseye)",
+		DeprecatedFrom: time.Date(2024, time.August, 14, 0, 0, 0, 0, time.UTC),
 		SupportedUntil: time.Date(2026, time.August, 31, 0, 0, 0, 0, time.UTC),
 	})
 	defaultOSDB.Register(OSEntry{
-		Version:         "12 (bookworm)",
-		DeprecatedFrom:  time.Date(2026, time.June, 10, 0, 0, 0, 0, time.UTC),
+		Version:        "12 (bookworm)",
+		DeprecatedFrom: time.Date(2026, time.June, 10, 0, 0, 0, 0, time.UTC),
 		SupportedUntil: time.Date(2028, time.June, 30, 0, 0, 0, 0, time.UTC),
 	})
 	defaultOSDB.Register(OSEntry{
-		Version:         "13 (trixie)",
-		DeprecatedFrom:  time.Date(2028, time.August, 9, 0, 0, 0, 0, time.UTC),
+		Version:        "13 (trixie)",
+		DeprecatedFrom: time.Date(2028, time.August, 9, 0, 0, 0, 0, time.UTC),
 		SupportedUntil: time.Date(2030, time.June, 30, 0, 0, 0, 0, time.UTC),
 	})
 }

--- a/internal/cmd/manager/instance/run/osdb.go
+++ b/internal/cmd/manager/instance/run/osdb.go
@@ -1,0 +1,100 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package run
+
+import "time"
+
+// OSEntry represents an OS version.
+//
+// Between the release date and SupportedUntil, the OS Version
+// is **supported** and **not deprecated**.
+//
+// Between SupportedUntil and DeprectatedFrom, the OS Version
+// is **supported** and **deprecated**.
+//
+// After DeprectatedFrom, the OS Version
+// is **not supported** and **deprecated**.
+type OSEntry struct {
+	// Version identifies the operating system version. This is the same
+	// as the "VERSION" field in the "/etc/osrelease" file.
+	Version string `json:"version"`
+
+	// SupportedUntil is the end-of-life date of this OS version
+	SupportedUntil time.Time `json:"supportedUntil"`
+
+	// DeprectatedFrom is the end of the OS version long-term-support period,
+	// as defined.
+	DeprectatedFrom time.Time `json:"deprecatedFrom"`
+}
+
+// IsSupported checks if the release is supported.
+func (e *OSEntry) IsSupported(now time.Time) bool {
+	return now.Before(e.DeprectatedFrom)
+}
+
+// IsDeprecated checks if the release is deprecated.
+func (e *OSEntry) IsDeprecated(now time.Time) bool {
+	return now.After(e.SupportedUntil)
+}
+
+// OSDB is a set of known OS releases
+type OSDB struct {
+	data map[string]OSEntry
+}
+
+var defaultOSDB OSDB
+
+// Register adds a new know OS entry
+func (db *OSDB) Register(entry OSEntry) {
+	if db.data == nil {
+		db.data = make(map[string]OSEntry)
+	}
+	db.data[entry.Version] = entry
+}
+
+// Get gets the OS entry for a known version
+func (db *OSDB) Get(version string) (OSEntry, bool) {
+	entry, ok := db.data[version]
+	return entry, ok
+}
+
+func init() {
+	// Known Debian releases
+	defaultOSDB.Register(OSEntry{
+		Version:         "10 (buster)",
+		SupportedUntil:  time.Date(2022, time.September, 10, 0, 0, 0, 0, time.UTC),
+		DeprectatedFrom: time.Date(2024, time.June, 30, 0, 0, 0, 0, time.UTC),
+	})
+	defaultOSDB.Register(OSEntry{
+		Version:         "11 (bullseye)",
+		SupportedUntil:  time.Date(2024, time.August, 14, 0, 0, 0, 0, time.UTC),
+		DeprectatedFrom: time.Date(2026, time.August, 31, 0, 0, 0, 0, time.UTC),
+	})
+	defaultOSDB.Register(OSEntry{
+		Version:         "12 (bookworm)",
+		SupportedUntil:  time.Date(2026, time.June, 10, 0, 0, 0, 0, time.UTC),
+		DeprectatedFrom: time.Date(2028, time.June, 30, 0, 0, 0, 0, time.UTC),
+	})
+	defaultOSDB.Register(OSEntry{
+		Version:         "13 (trixie)",
+		SupportedUntil:  time.Date(2028, time.August, 9, 0, 0, 0, 0, time.UTC),
+		DeprectatedFrom: time.Date(2030, time.June, 30, 0, 0, 0, 0, time.UTC),
+	})
+}

--- a/internal/cmd/manager/instance/run/osdb.go
+++ b/internal/cmd/manager/instance/run/osdb.go
@@ -37,11 +37,11 @@ type OSEntry struct {
 	Version string `json:"version"`
 
 	// DeprecatedFrom is the end-of-life date of this OS version
-	DeprecatedFrom time.Time `json:"supportedUntil"`
+	DeprecatedFrom time.Time `json:"deprecatedFrom"`
 
 	// SupportedUntil is the end of the OS version long-term-support period,
 	// as defined.
-	SupportedUntil time.Time `json:"deprecatedFrom"`
+	SupportedUntil time.Time `json:"supportedUntil"`
 }
 
 // IsSupported checks if the release is supported.

--- a/internal/cmd/manager/instance/run/osdb.go
+++ b/internal/cmd/manager/instance/run/osdb.go
@@ -23,35 +23,35 @@ import "time"
 
 // OSEntry represents an OS version.
 //
-// Between the release date and SupportedUntil, the OS Version
+// Between the release date and DeprecatedFrom, the OS Version
 // is **supported** and **not deprecated**.
 //
-// Between SupportedUntil and DeprectatedFrom, the OS Version
+// Between DeprecatedFrom and SupportedUntil, the OS Version
 // is **supported** and **deprecated**.
 //
-// After DeprectatedFrom, the OS Version
+// After SupportedUntil, the OS Version
 // is **not supported** and **deprecated**.
 type OSEntry struct {
 	// Version identifies the operating system version. This is the same
 	// as the "VERSION" field in the "/etc/osrelease" file.
 	Version string `json:"version"`
 
-	// SupportedUntil is the end-of-life date of this OS version
-	SupportedUntil time.Time `json:"supportedUntil"`
+	// DeprecatedFrom is the end-of-life date of this OS version
+	DeprecatedFrom time.Time `json:"supportedUntil"`
 
-	// DeprectatedFrom is the end of the OS version long-term-support period,
+	// SupportedUntil is the end of the OS version long-term-support period,
 	// as defined.
-	DeprectatedFrom time.Time `json:"deprecatedFrom"`
+	SupportedUntil time.Time `json:"deprecatedFrom"`
 }
 
 // IsSupported checks if the release is supported.
 func (e *OSEntry) IsSupported(now time.Time) bool {
-	return now.Before(e.DeprectatedFrom)
+	return now.Before(e.SupportedUntil)
 }
 
 // IsDeprecated checks if the release is deprecated.
 func (e *OSEntry) IsDeprecated(now time.Time) bool {
-	return now.After(e.SupportedUntil)
+	return now.After(e.DeprecatedFrom)
 }
 
 // OSDB is a set of known OS releases
@@ -79,22 +79,22 @@ func init() {
 	// Known Debian releases
 	defaultOSDB.Register(OSEntry{
 		Version:         "10 (buster)",
-		SupportedUntil:  time.Date(2022, time.September, 10, 0, 0, 0, 0, time.UTC),
-		DeprectatedFrom: time.Date(2024, time.June, 30, 0, 0, 0, 0, time.UTC),
+		DeprecatedFrom:  time.Date(2022, time.September, 10, 0, 0, 0, 0, time.UTC),
+		SupportedUntil: time.Date(2024, time.June, 30, 0, 0, 0, 0, time.UTC),
 	})
 	defaultOSDB.Register(OSEntry{
 		Version:         "11 (bullseye)",
-		SupportedUntil:  time.Date(2024, time.August, 14, 0, 0, 0, 0, time.UTC),
-		DeprectatedFrom: time.Date(2026, time.August, 31, 0, 0, 0, 0, time.UTC),
+		DeprecatedFrom:  time.Date(2024, time.August, 14, 0, 0, 0, 0, time.UTC),
+		SupportedUntil: time.Date(2026, time.August, 31, 0, 0, 0, 0, time.UTC),
 	})
 	defaultOSDB.Register(OSEntry{
 		Version:         "12 (bookworm)",
-		SupportedUntil:  time.Date(2026, time.June, 10, 0, 0, 0, 0, time.UTC),
-		DeprectatedFrom: time.Date(2028, time.June, 30, 0, 0, 0, 0, time.UTC),
+		DeprecatedFrom:  time.Date(2026, time.June, 10, 0, 0, 0, 0, time.UTC),
+		SupportedUntil: time.Date(2028, time.June, 30, 0, 0, 0, 0, time.UTC),
 	})
 	defaultOSDB.Register(OSEntry{
 		Version:         "13 (trixie)",
-		SupportedUntil:  time.Date(2028, time.August, 9, 0, 0, 0, 0, time.UTC),
-		DeprectatedFrom: time.Date(2030, time.June, 30, 0, 0, 0, 0, time.UTC),
+		DeprecatedFrom:  time.Date(2028, time.August, 9, 0, 0, 0, 0, time.UTC),
+		SupportedUntil: time.Date(2030, time.June, 30, 0, 0, 0, 0, time.UTC),
 	})
 }

--- a/internal/cmd/manager/instance/run/osdb_test.go
+++ b/internal/cmd/manager/instance/run/osdb_test.go
@@ -42,13 +42,13 @@ var _ = Describe("OS database", func() {
 			actualDeprecated := entry.IsDeprecated(today)
 			Expect(actualDeprecated).To(
 				Equal(deprecated),
-				"expected %s depracation status to be %t instead of %t", distro, deprecated, actualDeprecated)
+				"expected %s deprecation status to be %t instead of %t", distro, deprecated, actualDeprecated)
 			Expect(actualSupported).To(
 				Equal(supported),
 				"expected %s support status to be %t instead of %t", distro, supported, actualSupported)
 		},
 		Entry("trixie", "13 (trixie)", false, true),
 		Entry("bullseye", "11 (bullseye)", true, true),
-		Entry("bullseye", "10 (buster)", true, false),
+		Entry("buster", "10 (buster)", true, false),
 	)
 })

--- a/internal/cmd/manager/instance/run/osdb_test.go
+++ b/internal/cmd/manager/instance/run/osdb_test.go
@@ -48,6 +48,7 @@ var _ = Describe("OS database", func() {
 				"expected %s support status to be %t instead of %t", distro, supported, actualSupported)
 		},
 		Entry("trixie", "13 (trixie)", false, true),
+		Entry("bookworm", "12 (bookworm)", false, true),
 		Entry("bullseye", "11 (bullseye)", true, true),
 		Entry("buster", "10 (buster)", true, false),
 	)

--- a/internal/cmd/manager/instance/run/osdb_test.go
+++ b/internal/cmd/manager/instance/run/osdb_test.go
@@ -1,0 +1,54 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package run
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("OS database", func() {
+	today := time.Date(2025, time.September, 18, 0, 0, 0, 0, time.UTC)
+
+	DescribeTable(
+		"OS checks",
+		func(distro string, deprecated, supported bool) {
+			entry, ok := defaultOSDB.Get(distro)
+			Expect(ok).To(
+				BeTrue(),
+				"entry for distro %q not found",
+				distro)
+
+			actualSupported := entry.IsSupported(today)
+			actualDeprecated := entry.IsDeprecated(today)
+			Expect(actualDeprecated).To(
+				Equal(deprecated),
+				"expected %s depracation status to be %t instead of %t", distro, deprecated, actualDeprecated)
+			Expect(actualSupported).To(
+				Equal(supported),
+				"expected %s support status to be %t instead of %t", distro, supported, actualSupported)
+		},
+		Entry("trixie", "13 (trixie)", false, true),
+		Entry("bullseye", "11 (bullseye)", true, true),
+		Entry("bullseye", "10 (buster)", true, false),
+	)
+})

--- a/internal/cmd/manager/instance/run/osrelease.go
+++ b/internal/cmd/manager/instance/run/osrelease.go
@@ -1,0 +1,82 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package run
+
+import (
+	"context"
+	"errors"
+	"io/fs"
+	"time"
+
+	"github.com/acobaugh/osrelease"
+	"github.com/cloudnative-pg/machinery/pkg/log"
+)
+
+func checkCurrentOSRelease(ctx context.Context) {
+	contextLogger := log.FromContext(ctx)
+
+	data, err := osrelease.Read()
+	if errors.Is(err, fs.ErrNotExist) {
+		// There is no need to complain if we don't
+		// find the os-release file. Some distributions
+		// don't have it.
+		return
+	}
+	if err != nil {
+		contextLogger.Warning(
+			"Can't parse the os-release file, distribution check skipped",
+			"err", err)
+		return
+	}
+
+	version := data["VERSION"]
+	if version == "" {
+		contextLogger.Warning(
+			"The os-release file doesn't contain the VERSION field, distribution check skipped",
+			"data", data)
+		return
+	}
+
+	entry, ok := defaultOSDB.Get(version)
+	if !ok {
+		contextLogger.Warning(
+			"Unknown distribution version, check skipped",
+			"version", version)
+		return
+	}
+
+	now := time.Now()
+	switch {
+	case !entry.IsSupported(now):
+		contextLogger.Warning(
+			"Base distribution is not supported",
+			"entry", entry)
+
+	case entry.IsDeprecated(now):
+		contextLogger.Warning(
+			"Base distribution is deprecated",
+			"entry", entry)
+
+	default:
+		contextLogger.Warning(
+			"Base distribution is supported",
+			"entry", entry)
+	}
+}


### PR DESCRIPTION
The instance manager now reads `/etc/os-release` and logs a warning if the detected OS version is deprecated or unsupported, according to the official CNPG `postgres-containers` project.

A table of known distributions is maintained internally. If the distribution is unknown, or if `/etc/os-release` is missing or unreadable, the check is skipped.

Closes: #8575 