### PR TITLE
chore(lint): lint import aliases

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -52,6 +52,40 @@ linters:
         - '-QF1007'
     lll:
       line-length: 120
+    importas:
+      alias:
+        - pkg: github.com/cloudnative-pg/cloudnative-pg/api/v1
+          alias: apiv1
+        - pkg: github.com/cloudnative-pg/cloudnative-pg/internal/webhook/v1
+          alias: webhookv1
+        - pkg: github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1
+          alias: volumesnapshotv1
+        - pkg: github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1
+          alias: monitoringv1
+        - pkg: k8s.io/api/admissionregistration/v1
+          alias: admissionregistrationv1
+        - pkg: k8s.io/api/apps/v1
+          alias: appsv1
+        - pkg: k8s.io/api/batch/v1
+          alias: batchv1
+        - pkg: k8s.io/api/core/v1
+          alias: corev1
+        - pkg: k8s.io/api/discovery/v1
+          alias: discoveryv1
+        - pkg: k8s.io/api/events/v1
+          alias: eventsv1
+        - pkg: k8s.io/api/policy/v1
+          alias: policyv1
+        - pkg: k8s.io/api/rbac/v1
+          alias: rbacv1
+        - pkg: k8s.io/api/storage/v1
+          alias: storagev1
+        - pkg: k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1
+          alias: apiextensionsv1
+        - pkg: k8s.io/apimachinery/pkg/apis/meta/v1
+          alias: metav1
+        - pkg: k8s.io/client-go/kubernetes/typed/core/v1
+          alias: corev1client
   exclusions:
     generated: lax
     rules:

--- a/api/v1/backup_funcs.go
+++ b/api/v1/backup_funcs.go
@@ -26,7 +26,7 @@ import (
 	"strings"
 	"time"
 
-	volumesnapshot "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
+	volumesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -73,7 +73,7 @@ func (backupStatus *BackupStatus) SetAsStarted(podName, containerID string, meth
 }
 
 // SetSnapshotElements sets the Snapshots field from a list of VolumeSnapshot
-func (snapshotStatus *BackupSnapshotStatus) SetSnapshotElements(snapshots []volumesnapshot.VolumeSnapshot) {
+func (snapshotStatus *BackupSnapshotStatus) SetSnapshotElements(snapshots []volumesnapshotv1.VolumeSnapshot) {
 	snapshotNames := make([]BackupSnapshotElementStatus, len(snapshots))
 	for idx, volumeSnapshot := range snapshots {
 		snapshotNames[idx] = BackupSnapshotElementStatus{

--- a/api/v1/backup_funcs_test.go
+++ b/api/v1/backup_funcs_test.go
@@ -22,7 +22,7 @@ package v1
 import (
 	"time"
 
-	volumesnapshot "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
+	volumesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
@@ -59,7 +59,7 @@ var _ = Describe("BackupStatus structure", func() {
 
 	It("can be set to contain a snapshot list", func() {
 		status := BackupStatus{}
-		status.BackupSnapshotStatus.SetSnapshotElements([]volumesnapshot.VolumeSnapshot{
+		status.BackupSnapshotStatus.SetSnapshotElements([]volumesnapshotv1.VolumeSnapshot{
 			{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-example-snapshot-1",

--- a/internal/cmd/plugin/logs/cluster_logs.go
+++ b/internal/cmd/plugin/logs/cluster_logs.go
@@ -32,7 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 
-	cnpgv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/plugin"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/podlogs"
 )
@@ -49,8 +49,8 @@ type clusterLogs struct {
 	client      kubernetes.Interface
 }
 
-func getCluster(cl clusterLogs) (*cnpgv1.Cluster, error) {
-	var cluster cnpgv1.Cluster
+func getCluster(cl clusterLogs) (*apiv1.Cluster, error) {
+	var cluster apiv1.Cluster
 	err := plugin.Client.Get(cl.ctx,
 		types.NamespacedName{Namespace: cl.namespace, Name: cl.clusterName},
 		&cluster)
@@ -58,7 +58,7 @@ func getCluster(cl clusterLogs) (*cnpgv1.Cluster, error) {
 	return &cluster, err
 }
 
-func getStreamClusterLogs(cluster *cnpgv1.Cluster, cl clusterLogs) podlogs.ClusterWriter {
+func getStreamClusterLogs(cluster *apiv1.Cluster, cl clusterLogs) podlogs.ClusterWriter {
 	var sinceTime *metav1.Time
 	var tail *int64
 	if cl.timestamp {

--- a/internal/cmd/plugin/maintenance/maintenance.go
+++ b/internal/cmd/plugin/maintenance/maintenance.go
@@ -30,7 +30,7 @@ import (
 	"github.com/cheynewallace/tabby"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	v1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/plugin"
 )
 
@@ -48,7 +48,7 @@ func Maintenance(ctx context.Context,
 		"Maintenance",
 		"reusePVC")
 
-	var clusterList v1.ClusterList
+	var clusterList apiv1.ClusterList
 	var err error
 	if allNamespaces || clusterName == "" {
 		clusterList, err = getClusters(ctx, allNamespaces)
@@ -107,8 +107,8 @@ func askToProceed() bool {
 	return false
 }
 
-func getClusters(ctx context.Context, allNamespaces bool) (v1.ClusterList, error) {
-	var clusterList v1.ClusterList
+func getClusters(ctx context.Context, allNamespaces bool) (apiv1.ClusterList, error) {
+	var clusterList apiv1.ClusterList
 	var opts []client.ListOption
 	if !allNamespaces {
 		opts = append(opts, client.InNamespace(plugin.Namespace))
@@ -117,9 +117,9 @@ func getClusters(ctx context.Context, allNamespaces bool) (v1.ClusterList, error
 	return clusterList, err
 }
 
-func getCluster(ctx context.Context, clusterName string) (v1.ClusterList, error) {
-	var clusterList v1.ClusterList
-	var cluster v1.Cluster
+func getCluster(ctx context.Context, clusterName string) (apiv1.ClusterList, error) {
+	var clusterList apiv1.ClusterList
+	var cluster apiv1.Cluster
 	err := plugin.Client.Get(ctx, client.ObjectKey{Namespace: plugin.Namespace, Name: clusterName}, &cluster)
 	if err == nil {
 		clusterList.Items = append(clusterList.Items, cluster)
@@ -129,13 +129,13 @@ func getCluster(ctx context.Context, clusterName string) (v1.ClusterList, error)
 
 func patchNodeMaintenanceWindow(
 	ctx context.Context,
-	cluster v1.Cluster,
+	cluster apiv1.Cluster,
 	inProgress, reusePVC bool,
 ) error {
 	maintenanceCluster := cluster.DeepCopy()
 
 	if maintenanceCluster.Spec.NodeMaintenanceWindow == nil {
-		maintenanceCluster.Spec.NodeMaintenanceWindow = &v1.NodeMaintenanceWindow{}
+		maintenanceCluster.Spec.NodeMaintenanceWindow = &apiv1.NodeMaintenanceWindow{}
 	}
 	maintenanceCluster.Spec.NodeMaintenanceWindow.InProgress = inProgress
 	maintenanceCluster.Spec.NodeMaintenanceWindow.ReusePVC = &reusePVC

--- a/internal/cmd/plugin/plugin.go
+++ b/internal/cmd/plugin/plugin.go
@@ -27,7 +27,7 @@ import (
 	"strings"
 	"time"
 
-	storagesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
+	volumesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -116,7 +116,7 @@ func createClient(cfg *rest.Config) error {
 	scheme := runtime.NewScheme()
 	_ = clientgoscheme.AddToScheme(scheme)
 	_ = apiv1.AddToScheme(scheme)
-	_ = storagesnapshotv1.AddToScheme(scheme)
+	_ = volumesnapshotv1.AddToScheme(scheme)
 
 	cfg.UserAgent = fmt.Sprintf("kubectl-cnpg/v%s (%s)", versions.Version, versions.Info.Commit)
 

--- a/internal/cmd/plugin/promote/promote.go
+++ b/internal/cmd/plugin/promote/promote.go
@@ -25,7 +25,7 @@ import (
 	"fmt"
 
 	pgTime "github.com/cloudnative-pg/machinery/pkg/postgres/time"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
@@ -52,7 +52,7 @@ func Promote(ctx context.Context, cli client.Client,
 	}
 
 	// Check if the Pod exist
-	var pod v1.Pod
+	var pod corev1.Pod
 	err = cli.Get(ctx, client.ObjectKey{Namespace: namespace, Name: serverName}, &pod)
 	if err != nil {
 		return fmt.Errorf("new primary node %s not found in namespace %s: %w", serverName, namespace, err)

--- a/internal/cmd/plugin/report/cluster_report.go
+++ b/internal/cmd/plugin/report/cluster_report.go
@@ -31,14 +31,14 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	cnpgv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/plugin"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 )
 
 // clusterReport contains the data to be printed by the `report cluster` plugin
 type clusterReport struct {
-	cluster     cnpgv1.Cluster
+	cluster     apiv1.Cluster
 	clusterPods corev1.PodList
 	clusterJobs batchv1.JobList
 	clusterPVCs corev1.PersistentVolumeClaimList
@@ -91,7 +91,7 @@ func cluster(ctx context.Context, clusterName, namespace string, format plugin.O
 		return fmt.Errorf("could not get events: %w", err)
 	}
 
-	var cluster cnpgv1.Cluster
+	var cluster apiv1.Cluster
 	err = plugin.Client.Get(ctx,
 		types.NamespacedName{Namespace: namespace, Name: clusterName},
 		&cluster)

--- a/internal/cmd/plugin/report/operator_report.go
+++ b/internal/cmd/plugin/report/operator_report.go
@@ -28,7 +28,7 @@ import (
 	"path/filepath"
 	"time"
 
-	v12 "k8s.io/api/admissionregistration/v1"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -45,8 +45,8 @@ type operatorReport struct {
 	configs                 []namedObject
 	events                  corev1.EventList
 	webhookService          corev1.Service
-	mutatingWebhookConfig   *v12.MutatingWebhookConfigurationList
-	validatingWebhookConfig *v12.ValidatingWebhookConfigurationList
+	mutatingWebhookConfig   *admissionregistrationv1.MutatingWebhookConfigurationList
+	validatingWebhookConfig *admissionregistrationv1.ValidatingWebhookConfigurationList
 }
 
 // writeToZip makes a new section in the ZIP file, and adds in it various

--- a/internal/cmd/plugin/report/operator_utils.go
+++ b/internal/cmd/plugin/report/operator_utils.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"fmt"
 
-	v1 "k8s.io/api/admissionregistration/v1"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -31,14 +31,19 @@ import (
 	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/plugin"
 )
 
-func getWebhooks(ctx context.Context, stopRedact bool) (
-	*v1.MutatingWebhookConfigurationList, *v1.ValidatingWebhookConfigurationList, error,
+func getWebhooks(
+	ctx context.Context,
+	stopRedact bool,
+) (
+	*admissionregistrationv1.MutatingWebhookConfigurationList,
+	*admissionregistrationv1.ValidatingWebhookConfigurationList,
+	error,
 ) {
 	var (
-		mutatingWebhookConfigList   v1.MutatingWebhookConfigurationList
-		validatingWebhookConfigList v1.ValidatingWebhookConfigurationList
-		mWebhookConfig              v1.MutatingWebhookConfigurationList
-		vWebhookConfig              v1.ValidatingWebhookConfigurationList
+		mutatingWebhookConfigList   admissionregistrationv1.MutatingWebhookConfigurationList
+		validatingWebhookConfigList admissionregistrationv1.ValidatingWebhookConfigurationList
+		mWebhookConfig              admissionregistrationv1.MutatingWebhookConfigurationList
+		vWebhookConfig              admissionregistrationv1.ValidatingWebhookConfigurationList
 	)
 
 	if err := plugin.Client.List(ctx, &mutatingWebhookConfigList); err != nil {
@@ -91,7 +96,7 @@ func getWebhooks(ctx context.Context, stopRedact bool) (
 
 func getWebhookService(
 	ctx context.Context,
-	mutatingWebhookList *v1.MutatingWebhookConfigurationList,
+	mutatingWebhookList *admissionregistrationv1.MutatingWebhookConfigurationList,
 ) (corev1.Service, error) {
 	if len(mutatingWebhookList.Items) == 0 ||
 		len(mutatingWebhookList.Items[0].Webhooks) == 0 {

--- a/internal/cmd/plugin/report/redactors.go
+++ b/internal/cmd/plugin/report/redactors.go
@@ -20,7 +20,7 @@ SPDX-License-Identifier: Apache-2.0
 package report
 
 import (
-	admissionv1 "k8s.io/api/admissionregistration/v1"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -63,7 +63,9 @@ func passConfigMap(configMap corev1.ConfigMap) corev1.ConfigMap {
 // may change the behavior. See https://pkg.go.dev/k8s.io/api@v0.23.5/admissionregistration/v1#WebhookClientConfig
 // If the CABundle is present, override with a small string. The one chosen is "-"
 // which will print in Base64 as "LQ=="
-func redactWebhookClientConfig(config admissionv1.WebhookClientConfig) admissionv1.WebhookClientConfig {
+func redactWebhookClientConfig(
+	config admissionregistrationv1.WebhookClientConfig,
+) admissionregistrationv1.WebhookClientConfig {
 	if len(config.CABundle) != 0 {
 		config.CABundle = []byte("-") // will print in Base64 as "LQ=="
 	}

--- a/internal/cmd/plugin/report/redactors_test.go
+++ b/internal/cmd/plugin/report/redactors_test.go
@@ -20,7 +20,7 @@ SPDX-License-Identifier: Apache-2.0
 package report
 
 import (
-	admissionv1 "k8s.io/api/admissionregistration/v1"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -53,14 +53,14 @@ var _ = Describe("Redact ConfigMap", func() {
 
 var _ = Describe("Redact WebhookClientConfig", func() {
 	It("should override CABundle if present", func() {
-		webhookClientConfig := admissionv1.WebhookClientConfig{CABundle: []byte("test")}
+		webhookClientConfig := admissionregistrationv1.WebhookClientConfig{CABundle: []byte("test")}
 		redactedWebhookClientConfig := redactWebhookClientConfig(webhookClientConfig)
 		Expect(redactedWebhookClientConfig).ToNot(BeEquivalentTo(webhookClientConfig))
 		Expect(redactedWebhookClientConfig.CABundle).Should(BeEquivalentTo([]byte("-")))
 	})
 
 	It("should not create CABundle if missing", func() {
-		webhookClientConfig := admissionv1.WebhookClientConfig{}
+		webhookClientConfig := admissionregistrationv1.WebhookClientConfig{}
 		redactedWebhookClientConfig := redactWebhookClientConfig(webhookClientConfig)
 		Expect(redactedWebhookClientConfig).To(BeEquivalentTo(webhookClientConfig))
 		Expect(redactedWebhookClientConfig.CABundle).Should(BeEmpty())

--- a/internal/controller/backup_controller.go
+++ b/internal/controller/backup_controller.go
@@ -28,7 +28,7 @@ import (
 	"time"
 
 	"github.com/cloudnative-pg/machinery/pkg/log"
-	storagesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
+	volumesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -820,7 +820,7 @@ func (r *BackupReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manage
 		)
 	if utils.HaveVolumeSnapshot() {
 		controllerBuilder = controllerBuilder.Watches(
-			&storagesnapshotv1.VolumeSnapshot{},
+			&volumesnapshotv1.VolumeSnapshot{},
 			handler.EnqueueRequestsFromMapFunc(r.mapVolumeSnapshotsToBackups()),
 			builder.WithPredicates(volumeSnapshotsPredicate),
 		)

--- a/internal/controller/backup_controller_test.go
+++ b/internal/controller/backup_controller_test.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"time"
 
-	volumesnapshot "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
+	volumesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
@@ -266,7 +266,7 @@ var _ = Describe("backup_controller volumeSnapshot unit tests", func() {
 var _ = Describe("update snapshot backup metadata", func() {
 	var (
 		env           *testingEnvironment
-		snapshots     volumesnapshot.VolumeSnapshotList
+		snapshots     volumesnapshotv1.VolumeSnapshotList
 		cluster       *apiv1.Cluster
 		now           = metav1.NewTime(time.Now().Local().Truncate(time.Second))
 		oneHourAgo    = metav1.NewTime(now.Add(-1 * time.Hour))
@@ -286,8 +286,8 @@ var _ = Describe("update snapshot backup metadata", func() {
 				TargetPrimary: "cluster-example-2",
 			},
 		}
-		snapshots = volumesnapshot.VolumeSnapshotList{
-			Items: []volumesnapshot.VolumeSnapshot{
+		snapshots = volumesnapshotv1.VolumeSnapshotList{
+			Items: []volumesnapshotv1.VolumeSnapshot{
 				{ObjectMeta: metav1.ObjectMeta{
 					Name:      "snapshot-0",
 					Namespace: namespace,

--- a/internal/controller/backup_predicates.go
+++ b/internal/controller/backup_predicates.go
@@ -23,7 +23,7 @@ import (
 	"context"
 
 	"github.com/cloudnative-pg/machinery/pkg/log"
-	storagesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
+	volumesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -101,7 +101,7 @@ func (r *BackupReconciler) mapClustersToBackup() handler.MapFunc {
 
 var volumeSnapshotsPredicate = predicate.Funcs{
 	CreateFunc: func(e event.CreateEvent) bool {
-		volumeSnapshot, ok := e.Object.(*storagesnapshotv1.VolumeSnapshot)
+		volumeSnapshot, ok := e.Object.(*volumesnapshotv1.VolumeSnapshot)
 		if !ok {
 			return false
 		}
@@ -109,21 +109,21 @@ var volumeSnapshotsPredicate = predicate.Funcs{
 		return volumeSnapshotHasBackuplabel(volumeSnapshot)
 	},
 	DeleteFunc: func(e event.DeleteEvent) bool {
-		volumeSnapshot, ok := e.Object.(*storagesnapshotv1.VolumeSnapshot)
+		volumeSnapshot, ok := e.Object.(*volumesnapshotv1.VolumeSnapshot)
 		if !ok {
 			return false
 		}
 		return volumeSnapshotHasBackuplabel(volumeSnapshot)
 	},
 	GenericFunc: func(e event.GenericEvent) bool {
-		volumeSnapshot, ok := e.Object.(*storagesnapshotv1.VolumeSnapshot)
+		volumeSnapshot, ok := e.Object.(*volumesnapshotv1.VolumeSnapshot)
 		if !ok {
 			return false
 		}
 		return volumeSnapshotHasBackuplabel(volumeSnapshot)
 	},
 	UpdateFunc: func(e event.UpdateEvent) bool {
-		volumeSnapshot, ok := e.ObjectNew.(*storagesnapshotv1.VolumeSnapshot)
+		volumeSnapshot, ok := e.ObjectNew.(*volumesnapshotv1.VolumeSnapshot)
 		if !ok {
 			return false
 		}
@@ -133,7 +133,7 @@ var volumeSnapshotsPredicate = predicate.Funcs{
 
 func (r *BackupReconciler) mapVolumeSnapshotsToBackups() handler.MapFunc {
 	return func(_ context.Context, obj client.Object) []reconcile.Request {
-		volumeSnapshot, ok := obj.(*storagesnapshotv1.VolumeSnapshot)
+		volumeSnapshot, ok := obj.(*volumesnapshotv1.VolumeSnapshot)
 		if !ok {
 			return nil
 		}
@@ -153,7 +153,7 @@ func (r *BackupReconciler) mapVolumeSnapshotsToBackups() handler.MapFunc {
 	}
 }
 
-func volumeSnapshotHasBackuplabel(volumeSnapshot *storagesnapshotv1.VolumeSnapshot) bool {
+func volumeSnapshotHasBackuplabel(volumeSnapshot *volumesnapshotv1.VolumeSnapshot) bool {
 	_, ok := volumeSnapshot.Labels[utils.BackupNameLabelName]
 	return ok
 }

--- a/internal/controller/backup_predicates_test.go
+++ b/internal/controller/backup_predicates_test.go
@@ -20,7 +20,7 @@ SPDX-License-Identifier: Apache-2.0
 package controller
 
 import (
-	storagesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
+	volumesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 
@@ -33,7 +33,7 @@ import (
 var _ = Describe("backup_controller volumeSnapshots predicates", func() {
 	Context("volumeSnapshotHasBackuplabel and relative predicate", func() {
 		It("returns false for a volumesnapshot without the backup label", func() {
-			snapshot := storagesnapshotv1.VolumeSnapshot{
+			snapshot := volumesnapshotv1.VolumeSnapshot{
 				ObjectMeta: metav1.ObjectMeta{},
 			}
 
@@ -53,7 +53,7 @@ var _ = Describe("backup_controller volumeSnapshots predicates", func() {
 		})
 
 		It("returns true for a volumesnapshot with the backup label", func() {
-			snapshot := storagesnapshotv1.VolumeSnapshot{
+			snapshot := volumesnapshotv1.VolumeSnapshot{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
 						utils.BackupNameLabelName: "test",
@@ -79,7 +79,7 @@ var _ = Describe("backup_controller volumeSnapshots predicates", func() {
 
 	Context("volumeSnapshotHasBackuplabel and relative mappers", func() {
 		It("correctly maps volume snapshots to backups", func(ctx SpecContext) {
-			snapshot := storagesnapshotv1.VolumeSnapshot{
+			snapshot := volumesnapshotv1.VolumeSnapshot{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "snapshot-1",
 					Namespace: "default",

--- a/internal/controller/cluster_create_test.go
+++ b/internal/controller/cluster_create_test.go
@@ -22,8 +22,8 @@ package controller
 import (
 	"context"
 
-	volumesnapshot "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
-	v1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	volumesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
@@ -528,7 +528,7 @@ var _ = Describe("check if bootstrap recovery can proceed from volume snapshot",
 					Recovery: &apiv1.BootstrapRecovery{
 						VolumeSnapshots: &apiv1.DataSource{
 							Storage: corev1.TypedLocalObjectReference{
-								APIGroup: ptr.To(volumesnapshot.GroupName),
+								APIGroup: ptr.To(volumesnapshotv1.GroupName),
 								Kind:     apiv1.VolumeSnapshotKind,
 								Name:     "pgdata",
 							},
@@ -540,8 +540,8 @@ var _ = Describe("check if bootstrap recovery can proceed from volume snapshot",
 	})
 
 	It("should not requeue if bootstrapping from a valid volume snapshot", func(ctx SpecContext) {
-		snapshots := volumesnapshot.VolumeSnapshotList{
-			Items: []volumesnapshot.VolumeSnapshot{
+		snapshots := volumesnapshotv1.VolumeSnapshotList{
+			Items: []volumesnapshotv1.VolumeSnapshot{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "pgdata",
@@ -576,8 +576,8 @@ var _ = Describe("check if bootstrap recovery can proceed from volume snapshot",
 
 	// nolint: dupl
 	It("should requeue if bootstrapping from an invalid volume snapshot", func(ctx SpecContext) {
-		snapshots := volumesnapshot.VolumeSnapshotList{
-			Items: []volumesnapshot.VolumeSnapshot{
+		snapshots := volumesnapshotv1.VolumeSnapshotList{
+			Items: []volumesnapshotv1.VolumeSnapshot{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "pgdata",
@@ -613,8 +613,8 @@ var _ = Describe("check if bootstrap recovery can proceed from volume snapshot",
 
 	// nolint: dupl
 	It("should requeue if bootstrapping from a snapshot that isn't there", func(ctx SpecContext) {
-		snapshots := volumesnapshot.VolumeSnapshotList{
-			Items: []volumesnapshot.VolumeSnapshot{
+		snapshots := volumesnapshotv1.VolumeSnapshotList{
+			Items: []volumesnapshotv1.VolumeSnapshot{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "foobar",
@@ -688,14 +688,14 @@ var _ = Describe("Set cluster metadata of service account", func() {
 
 type mockPodMonitorManager struct {
 	isEnabled  bool
-	podMonitor *v1.PodMonitor
+	podMonitor *monitoringv1.PodMonitor
 }
 
 func (m *mockPodMonitorManager) IsPodMonitorEnabled() bool {
 	return m.isEnabled
 }
 
-func (m *mockPodMonitorManager) BuildPodMonitor() *v1.PodMonitor {
+func (m *mockPodMonitorManager) BuildPodMonitor() *monitoringv1.PodMonitor {
 	return m.podMonitor
 }
 
@@ -711,7 +711,7 @@ var _ = Describe("CreateOrPatchPodMonitor", func() {
 		ctx = context.Background()
 		manager = &mockPodMonitorManager{}
 		manager.isEnabled = true
-		manager.podMonitor = &v1.PodMonitor{
+		manager.podMonitor = &monitoringv1.PodMonitor{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test",
 				Namespace: "default",
@@ -742,7 +742,7 @@ var _ = Describe("CreateOrPatchPodMonitor", func() {
 		err := createOrPatchPodMonitor(ctx, fakeCli, fakeDiscoveryClient, manager)
 		Expect(err).ToNot(HaveOccurred())
 
-		podMonitor := &v1.PodMonitor{}
+		podMonitor := &monitoringv1.PodMonitor{}
 		err = fakeCli.Get(
 			ctx,
 			types.NamespacedName{
@@ -772,7 +772,7 @@ var _ = Describe("CreateOrPatchPodMonitor", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		// Ensure the PodMonitor doesn't exist anymore
-		podMonitor := &v1.PodMonitor{}
+		podMonitor := &monitoringv1.PodMonitor{}
 		err = fakeCli.Get(
 			ctx,
 			types.NamespacedName{
@@ -803,7 +803,7 @@ var _ = Describe("CreateOrPatchPodMonitor", func() {
 		err = createOrPatchPodMonitor(ctx, fakeCli, fakeDiscoveryClient, manager)
 		Expect(err).ToNot(HaveOccurred())
 
-		podMonitor := &v1.PodMonitor{}
+		podMonitor := &monitoringv1.PodMonitor{}
 		err = fakeCli.Get(
 			ctx,
 			types.NamespacedName{

--- a/internal/controller/cluster_status_test.go
+++ b/internal/controller/cluster_status_test.go
@@ -29,7 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
 
-	v1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/certs"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/postgres"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/reconciler/persistentvolumeclaim"
@@ -75,7 +75,7 @@ var _ = Describe("cluster_status unit tests", func() {
 		pooler1 := *newFakePooler(env.client, cluster)
 		pooler2 := *newFakePooler(env.client, cluster)
 		Expect(pooler1.Name).ToNot(Equal(pooler2.Name))
-		poolerList := v1.PoolerList{Items: []v1.Pooler{pooler1, pooler2}}
+		poolerList := apiv1.PoolerList{Items: []apiv1.Pooler{pooler1, pooler2}}
 
 		intStatus, err := env.clusterReconciler.getPgbouncerIntegrationStatus(ctx, cluster, poolerList)
 		Expect(err).ToNot(HaveOccurred())
@@ -88,7 +88,7 @@ var _ = Describe("cluster_status unit tests", func() {
 		cluster := newFakeCNPGCluster(env.client, namespace)
 		pooler := newFakePooler(env.client, cluster)
 
-		version, err := env.clusterReconciler.getObjectResourceVersion(ctx, cluster, pooler.Name, &v1.Pooler{})
+		version, err := env.clusterReconciler.getObjectResourceVersion(ctx, cluster, pooler.Name, &apiv1.Pooler{})
 		Expect(err).ToNot(HaveOccurred())
 		Expect(version).To(Equal(pooler.ResourceVersion))
 	})
@@ -108,7 +108,7 @@ var _ = Describe("cluster_status unit tests", func() {
 		})
 
 		By("making sure the remote resource is updated", func() {
-			remoteCluster := &v1.Cluster{}
+			remoteCluster := &apiv1.Cluster{}
 
 			err := env.client.Get(ctx, types.NamespacedName{Name: cluster.Name, Namespace: cluster.Namespace}, remoteCluster)
 			Expect(err).ToNot(HaveOccurred())
@@ -124,17 +124,17 @@ var _ = Describe("cluster_status unit tests", func() {
 		cluster := newFakeCNPGCluster(env.client, namespace)
 
 		By("registering the phase and making sure the passed object is updated", func() {
-			err := env.clusterReconciler.RegisterPhase(ctx, cluster, v1.PhaseSwitchover, phaseReason)
+			err := env.clusterReconciler.RegisterPhase(ctx, cluster, apiv1.PhaseSwitchover, phaseReason)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(cluster.Status.Phase).To(Equal(v1.PhaseSwitchover))
+			Expect(cluster.Status.Phase).To(Equal(apiv1.PhaseSwitchover))
 			Expect(cluster.Status.PhaseReason).To(Equal(phaseReason))
 		})
 
 		By("making sure the remote resource is updated", func() {
-			remoteCluster := &v1.Cluster{}
+			remoteCluster := &apiv1.Cluster{}
 			err := env.client.Get(ctx, types.NamespacedName{Name: cluster.Name, Namespace: cluster.Namespace}, remoteCluster)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(remoteCluster.Status.Phase).To(Equal(v1.PhaseSwitchover))
+			Expect(remoteCluster.Status.Phase).To(Equal(apiv1.PhaseSwitchover))
 			Expect(remoteCluster.Status.PhaseReason).To(Equal(phaseReason))
 		})
 	})
@@ -181,7 +181,7 @@ var _ = Describe("cluster_status unit tests", func() {
 var _ = Describe("updateClusterStatusThatRequiresInstancesState tests", func() {
 	var (
 		env     *testingEnvironment
-		cluster *v1.Cluster
+		cluster *apiv1.Cluster
 	)
 
 	BeforeEach(func() {
@@ -198,7 +198,7 @@ var _ = Describe("updateClusterStatusThatRequiresInstancesState tests", func() {
 		Expect(cluster.Status.InstancesReportedState).To(BeEmpty())
 		Expect(cluster.Status.SystemID).To(BeEmpty())
 
-		condition := meta.FindStatusCondition(cluster.Status.Conditions, string(v1.ConditionConsistentSystemID))
+		condition := meta.FindStatusCondition(cluster.Status.Conditions, string(apiv1.ConditionConsistentSystemID))
 		Expect(condition).ToNot(BeNil())
 		Expect(condition.Status).To(Equal(metav1.ConditionFalse))
 		Expect(condition.Reason).To(Equal("NotFound"))
@@ -235,7 +235,7 @@ var _ = Describe("updateClusterStatusThatRequiresInstancesState tests", func() {
 		Expect(cluster.Status.TimelineID).To(Equal(123))
 		Expect(cluster.Status.SystemID).To(BeEmpty())
 
-		condition := meta.FindStatusCondition(cluster.Status.Conditions, string(v1.ConditionConsistentSystemID))
+		condition := meta.FindStatusCondition(cluster.Status.Conditions, string(apiv1.ConditionConsistentSystemID))
 		Expect(condition).ToNot(BeNil())
 		Expect(condition.Status).To(Equal(metav1.ConditionFalse))
 		Expect(condition.Reason).To(Equal("NotFound"))
@@ -273,7 +273,7 @@ var _ = Describe("updateClusterStatusThatRequiresInstancesState tests", func() {
 		Expect(cluster.Status.TimelineID).To(Equal(123))
 		Expect(cluster.Status.SystemID).To(Equal(systemID))
 
-		condition := meta.FindStatusCondition(cluster.Status.Conditions, string(v1.ConditionConsistentSystemID))
+		condition := meta.FindStatusCondition(cluster.Status.Conditions, string(apiv1.ConditionConsistentSystemID))
 		Expect(condition).ToNot(BeNil())
 		Expect(condition.Status).To(Equal(metav1.ConditionTrue))
 		Expect(condition.Reason).To(Equal("Unique"))
@@ -310,7 +310,7 @@ var _ = Describe("updateClusterStatusThatRequiresInstancesState tests", func() {
 		Expect(cluster.Status.TimelineID).To(Equal(123))
 		Expect(cluster.Status.SystemID).To(BeEmpty())
 
-		condition := meta.FindStatusCondition(cluster.Status.Conditions, string(v1.ConditionConsistentSystemID))
+		condition := meta.FindStatusCondition(cluster.Status.Conditions, string(apiv1.ConditionConsistentSystemID))
 		Expect(condition).ToNot(BeNil())
 		Expect(condition.Status).To(Equal(metav1.ConditionFalse))
 		Expect(condition.Reason).To(Equal("Mismatch"))

--- a/internal/controller/pooler_controller.go
+++ b/internal/controller/pooler_controller.go
@@ -26,7 +26,7 @@ import (
 	"time"
 
 	"github.com/cloudnative-pg/machinery/pkg/log"
-	v1 "k8s.io/api/apps/v1"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
@@ -135,7 +135,7 @@ func (r *PoolerReconciler) SetupWithManager(mgr ctrl.Manager, maxConcurrentRecon
 		WithOptions(controller.Options{MaxConcurrentReconciles: maxConcurrentReconciles}).
 		For(&apiv1.Pooler{}).
 		Named("pooler").
-		Owns(&v1.Deployment{}).
+		Owns(&appsv1.Deployment{}).
 		Owns(&corev1.Service{}).
 		Owns(&corev1.ServiceAccount{}).
 		Owns(&rbacv1.Role{}).

--- a/internal/controller/pooler_controller_test.go
+++ b/internal/controller/pooler_controller_test.go
@@ -28,7 +28,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	v1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	schemeBuilder "github.com/cloudnative-pg/cloudnative-pg/internal/scheme"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 
@@ -43,7 +43,7 @@ var _ = Describe("pooler_controller unit tests", func() {
 	})
 
 	It("should make sure that getPoolersUsingSecret works correctly", func() {
-		var poolers []v1.Pooler
+		var poolers []apiv1.Pooler
 		var expectedContent []types.NamespacedName
 		var nonExpectedContent []types.NamespacedName
 		var expectedAuthSecretName string
@@ -57,7 +57,7 @@ var _ = Describe("pooler_controller unit tests", func() {
 
 			pooler2 := *newFakePooler(env.client, cluster)
 			pooler3 := *newFakePooler(env.client, cluster)
-			for _, expectedPooler := range []v1.Pooler{pooler1, pooler2, pooler3} {
+			for _, expectedPooler := range []apiv1.Pooler{pooler1, pooler2, pooler3} {
 				poolers = append(poolers, expectedPooler)
 				expectedContent = append(
 					expectedContent,
@@ -75,7 +75,7 @@ var _ = Describe("pooler_controller unit tests", func() {
 		})
 
 		By("making sure only expected poolers are fetched", func() {
-			poolerList := v1.PoolerList{Items: poolers}
+			poolerList := apiv1.PoolerList{Items: poolers}
 			secret := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      expectedAuthSecretName,
@@ -95,7 +95,7 @@ var _ = Describe("pooler_controller unit tests", func() {
 
 		pooler1 := *newFakePooler(env.client, cluster)
 		pooler2 := *newFakePooler(env.client, cluster)
-		poolerList := v1.PoolerList{Items: []v1.Pooler{pooler1, pooler2}}
+		poolerList := apiv1.PoolerList{Items: []apiv1.Pooler{pooler1, pooler2}}
 
 		secret := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
@@ -129,7 +129,7 @@ var _ = Describe("pooler_controller unit tests", func() {
 			pooler2 := *newFakePooler(env.client, cluster)
 			expectedAuthSecretName = pooler1.GetAuthQuerySecretName()
 
-			for _, expectedPooler := range []v1.Pooler{pooler1, pooler2} {
+			for _, expectedPooler := range []apiv1.Pooler{pooler1, pooler2} {
 				request := reconcile.Request{
 					NamespacedName: types.NamespacedName{
 						Name:      expectedPooler.Name,
@@ -142,7 +142,7 @@ var _ = Describe("pooler_controller unit tests", func() {
 
 		By("creating pooler with a different secret that should be skipped", func() {
 			pooler3 := *newFakePooler(env.client, cluster)
-			pooler3.Spec.PgBouncer.AuthQuerySecret = &v1.LocalObjectReference{
+			pooler3.Spec.PgBouncer.AuthQuerySecret = &apiv1.LocalObjectReference{
 				Name: "test-one",
 			}
 			pooler3.Spec.PgBouncer.AuthQuery = "SELECT usename, passwd FROM pg_catalog.pg_shadow WHERE usename=$1"

--- a/internal/controller/pooler_resources.go
+++ b/internal/controller/pooler_resources.go
@@ -24,7 +24,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/rbac/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -50,8 +50,8 @@ type poolerManagedResources struct {
 	// The RBAC resources needed for the pooler instance manager
 	// to watch over the relative Pooler resource
 	ServiceAccount *corev1.ServiceAccount
-	RoleBinding    *v1.RoleBinding
-	Role           *v1.Role
+	RoleBinding    *rbacv1.RoleBinding
+	Role           *rbacv1.Role
 }
 
 // getManagedResources detects the list of the resources created and manager
@@ -162,8 +162,8 @@ func getServiceAccountOrNil(
 }
 
 // getRoleOrNil gets a role with a certain name, returning nil when it doesn't exist
-func getRoleOrNil(ctx context.Context, r client.Client, objectKey client.ObjectKey) (*v1.Role, error) {
-	var role v1.Role
+func getRoleOrNil(ctx context.Context, r client.Client, objectKey client.ObjectKey) (*rbacv1.Role, error) {
+	var role rbacv1.Role
 	err := r.Get(ctx, objectKey, &role)
 	if err != nil {
 		if apierrs.IsNotFound(err) {
@@ -177,8 +177,12 @@ func getRoleOrNil(ctx context.Context, r client.Client, objectKey client.ObjectK
 }
 
 // getRoleBindingOrNil gets a rolebinding with a certain name, returning nil when it doesn't exist
-func getRoleBindingOrNil(ctx context.Context, r client.Client, objectKey client.ObjectKey) (*v1.RoleBinding, error) {
-	var rb v1.RoleBinding
+func getRoleBindingOrNil(
+	ctx context.Context,
+	r client.Client,
+	objectKey client.ObjectKey,
+) (*rbacv1.RoleBinding, error) {
+	var rb rbacv1.RoleBinding
 	err := r.Get(ctx, objectKey, &rb)
 	if err != nil {
 		if apierrs.IsNotFound(err) {

--- a/internal/management/controller/roles/reconciler_test.go
+++ b/internal/management/controller/roles/reconciler_test.go
@@ -23,7 +23,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	v1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -32,7 +32,7 @@ import (
 
 var _ = Describe("Role reconciler test", func() {
 	It("reconcile an empty cluster", func(ctx SpecContext) {
-		cluster := &v1.Cluster{}
+		cluster := &apiv1.Cluster{}
 		instance := &postgres.Instance{}
 		mockClient := fake.NewClientBuilder().Build()
 
@@ -44,10 +44,10 @@ var _ = Describe("Role reconciler test", func() {
 	It("reconcile fails with no database connection", func(ctx SpecContext) {
 		instance := &postgres.Instance{}
 		mockClient := fake.NewClientBuilder().Build()
-		cluster := &v1.Cluster{
-			Spec: v1.ClusterSpec{
-				Managed: &v1.ManagedConfiguration{
-					Roles: []v1.RoleConfiguration{
+		cluster := &apiv1.Cluster{
+			Spec: apiv1.ClusterSpec{
+				Managed: &apiv1.ManagedConfiguration{
+					Roles: []apiv1.RoleConfiguration{
 						{
 							Name:    "dante",
 							Comment: "divine comedy",

--- a/internal/management/controller/roles/runnable_test.go
+++ b/internal/management/controller/roles/runnable_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/lib/pq"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -588,7 +588,7 @@ var _ = DescribeTable("role secrets test",
 	) {
 		// define various secrets as test cases to show failure modes
 		secret := corev1.Secret{
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      secretName,
 				Namespace: namespace,
 			},
@@ -598,7 +598,7 @@ var _ = DescribeTable("role secrets test",
 			},
 		}
 		secretNoUser := corev1.Secret{
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      secretNameNoUser,
 				Namespace: namespace,
 			},
@@ -607,7 +607,7 @@ var _ = DescribeTable("role secrets test",
 			},
 		}
 		secretNoPass := corev1.Secret{
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      secretNameNoPass,
 				Namespace: namespace,
 			},

--- a/internal/management/controller/slots/infrastructure/postgresmanager.go
+++ b/internal/management/controller/slots/infrastructure/postgresmanager.go
@@ -26,11 +26,11 @@ import (
 
 	"github.com/cloudnative-pg/machinery/pkg/log"
 
-	v1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 )
 
 // List the available replication slots
-func List(ctx context.Context, db *sql.DB, config *v1.ReplicationSlotsConfiguration) (ReplicationSlotList, error) {
+func List(ctx context.Context, db *sql.DB, config *apiv1.ReplicationSlotsConfiguration) (ReplicationSlotList, error) {
 	rows, err := db.QueryContext(
 		ctx,
 		`SELECT slot_name, slot_type, active, coalesce(restart_lsn::TEXT, '') AS restart_lsn,

--- a/internal/management/controller/slots/infrastructure/postgresmanager_test.go
+++ b/internal/management/controller/slots/infrastructure/postgresmanager_test.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 
-	v1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -78,10 +78,10 @@ var _ = Describe("PostgresManager", func() {
 	Context("List", func() {
 		const expectedSQL = "^SELECT (.+) FROM pg_catalog.pg_replication_slots"
 
-		var config *v1.ReplicationSlotsConfiguration
+		var config *apiv1.ReplicationSlotsConfiguration
 		BeforeEach(func() {
-			config = &v1.ReplicationSlotsConfiguration{
-				HighAvailability: &v1.ReplicationSlotsHAConfiguration{
+			config = &apiv1.ReplicationSlotsConfiguration{
+				HighAvailability: &apiv1.ReplicationSlotsHAConfiguration{
 					Enabled:    new(bool),
 					SlotPrefix: "_cnpg_",
 				},

--- a/internal/scheme/scheme.go
+++ b/internal/scheme/scheme.go
@@ -20,7 +20,7 @@ SPDX-License-Identifier: Apache-2.0
 package scheme
 
 import (
-	storagesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
+	volumesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -67,9 +67,9 @@ func (b *Builder) WithAPIExtensionV1() *Builder {
 	return b
 }
 
-// WithStorageSnapshotV1 adds storagesnapshotv1
-func (b *Builder) WithStorageSnapshotV1() *Builder {
-	_ = storagesnapshotv1.AddToScheme(b.scheme)
+// WithVolumeSnapshotV1 adds volumesnapshotv1
+func (b *Builder) WithVolumeSnapshotV1() *Builder {
+	_ = volumesnapshotv1.AddToScheme(b.scheme)
 
 	return b
 }
@@ -86,7 +86,7 @@ func BuildWithAllKnownScheme() *runtime.Scheme {
 		WithClientGoScheme().
 		WithMonitoringV1().
 		WithAPIExtensionV1().
-		WithStorageSnapshotV1().
+		WithVolumeSnapshotV1().
 		Build()
 
 	// +kubebuilder:scaffold:scheme

--- a/internal/webhook/v1/cluster_webhook.go
+++ b/internal/webhook/v1/cluster_webhook.go
@@ -34,7 +34,7 @@ import (
 	"github.com/cloudnative-pg/machinery/pkg/stringset"
 	"github.com/cloudnative-pg/machinery/pkg/types"
 	jsonpatch "github.com/evanphx/json-patch/v5"
-	storagesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
+	volumesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -787,7 +787,7 @@ func validateVolumeSnapshotSource(
 	}
 
 	switch {
-	case apiGroup == storagesnapshotv1.GroupName && value.Kind == "VolumeSnapshot":
+	case apiGroup == volumesnapshotv1.GroupName && value.Kind == "VolumeSnapshot":
 	case apiGroup == corev1.GroupName && value.Kind == "PersistentVolumeClaim":
 	default:
 		return field.ErrorList{

--- a/internal/webhook/v1/cluster_webhook_test.go
+++ b/internal/webhook/v1/cluster_webhook_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/cloudnative-pg/barman-cloud/pkg/api"
 	"github.com/cloudnative-pg/machinery/pkg/image/reference"
 	pgversion "github.com/cloudnative-pg/machinery/pkg/postgres/version"
-	storagesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
+	volumesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -4243,12 +4243,12 @@ var _ = Describe("Recovery from volume snapshot validation", func() {
 					Recovery: &apiv1.BootstrapRecovery{
 						VolumeSnapshots: &apiv1.DataSource{
 							Storage: corev1.TypedLocalObjectReference{
-								APIGroup: ptr.To(storagesnapshotv1.GroupName),
+								APIGroup: ptr.To(volumesnapshotv1.GroupName),
 								Kind:     "VolumeSnapshot",
 								Name:     "pgdata",
 							},
 							WalStorage: &corev1.TypedLocalObjectReference{
-								APIGroup: ptr.To(storagesnapshotv1.GroupName),
+								APIGroup: ptr.To(volumesnapshotv1.GroupName),
 								Kind:     "VolumeSnapshot",
 								Name:     "pgwal",
 							},
@@ -4267,12 +4267,12 @@ var _ = Describe("Recovery from volume snapshot validation", func() {
 					Recovery: &apiv1.BootstrapRecovery{
 						VolumeSnapshots: &apiv1.DataSource{
 							Storage: corev1.TypedLocalObjectReference{
-								APIGroup: ptr.To(storagesnapshotv1.GroupName),
+								APIGroup: ptr.To(volumesnapshotv1.GroupName),
 								Kind:     "VolumeSnapshot",
 								Name:     "pgdata",
 							},
 							WalStorage: &corev1.TypedLocalObjectReference{
-								APIGroup: ptr.To(storagesnapshotv1.GroupName),
+								APIGroup: ptr.To(volumesnapshotv1.GroupName),
 								Kind:     "VolumeSnapshot",
 								Name:     "pgwal",
 							},
@@ -4289,12 +4289,12 @@ var _ = Describe("Recovery from volume snapshot validation", func() {
 		cluster := clusterFromRecovery(&apiv1.BootstrapRecovery{
 			VolumeSnapshots: &apiv1.DataSource{
 				Storage: corev1.TypedLocalObjectReference{
-					APIGroup: ptr.To(storagesnapshotv1.GroupName),
+					APIGroup: ptr.To(volumesnapshotv1.GroupName),
 					Kind:     apiv1.VolumeSnapshotKind,
 					Name:     "pgdata",
 				},
 				WalStorage: &corev1.TypedLocalObjectReference{
-					APIGroup: ptr.To(storagesnapshotv1.GroupName),
+					APIGroup: ptr.To(volumesnapshotv1.GroupName),
 					Kind:     apiv1.VolumeSnapshotKind,
 					Name:     "pgwal",
 				},
@@ -4307,7 +4307,7 @@ var _ = Describe("Recovery from volume snapshot validation", func() {
 		cluster := clusterFromRecovery(&apiv1.BootstrapRecovery{
 			VolumeSnapshots: &apiv1.DataSource{
 				Storage: corev1.TypedLocalObjectReference{
-					APIGroup: ptr.To(storagesnapshotv1.GroupName),
+					APIGroup: ptr.To(volumesnapshotv1.GroupName),
 					Kind:     apiv1.VolumeSnapshotKind,
 					Name:     "pgdata",
 				},
@@ -4323,12 +4323,12 @@ var _ = Describe("Recovery from volume snapshot validation", func() {
 			cluster := clusterFromRecovery(&apiv1.BootstrapRecovery{
 				VolumeSnapshots: &apiv1.DataSource{
 					Storage: corev1.TypedLocalObjectReference{
-						APIGroup: ptr.To(storagesnapshotv1.GroupName),
+						APIGroup: ptr.To(volumesnapshotv1.GroupName),
 						Kind:     "VolumeSnapshot",
 						Name:     "pgdata",
 					},
 					WalStorage: &corev1.TypedLocalObjectReference{
-						APIGroup: ptr.To(storagesnapshotv1.GroupName),
+						APIGroup: ptr.To(volumesnapshotv1.GroupName),
 						Kind:     "VolumeSnapshot",
 						Name:     "pgwal",
 					},
@@ -4343,12 +4343,12 @@ var _ = Describe("Recovery from volume snapshot validation", func() {
 			cluster := clusterFromRecovery(&apiv1.BootstrapRecovery{
 				VolumeSnapshots: &apiv1.DataSource{
 					Storage: corev1.TypedLocalObjectReference{
-						APIGroup: ptr.To(storagesnapshotv1.GroupName),
+						APIGroup: ptr.To(volumesnapshotv1.GroupName),
 						Kind:     "VolumeSnapshot",
 						Name:     "pgdata",
 					},
 					WalStorage: &corev1.TypedLocalObjectReference{
-						APIGroup: ptr.To(storagesnapshotv1.GroupName),
+						APIGroup: ptr.To(volumesnapshotv1.GroupName),
 						Kind:     "VolumeSnapshot",
 						Name:     "pgwal",
 					},

--- a/pkg/certs/certs.go
+++ b/pkg/certs/certs.go
@@ -36,7 +36,7 @@ import (
 	"strings"
 	"time"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/cloudnative-pg/cloudnative-pg/internal/configuration"
@@ -232,8 +232,8 @@ func (pair KeyPair) createAndSignPairWithValidity(
 }
 
 // GenerateCASecret create a k8s CA secret from a key pair
-func (pair KeyPair) GenerateCASecret(namespace, name string) *v1.Secret {
-	return &v1.Secret{
+func (pair KeyPair) GenerateCASecret(namespace, name string) *corev1.Secret {
+	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
@@ -242,13 +242,13 @@ func (pair KeyPair) GenerateCASecret(namespace, name string) *v1.Secret {
 			CAPrivateKeyKey: pair.Private,
 			CACertKey:       pair.Certificate,
 		},
-		Type: v1.SecretTypeOpaque,
+		Type: corev1.SecretTypeOpaque,
 	}
 }
 
 // GenerateCertificateSecret creates a k8s server secret from a key pair
-func (pair KeyPair) GenerateCertificateSecret(namespace, name string) *v1.Secret {
-	return &v1.Secret{
+func (pair KeyPair) GenerateCertificateSecret(namespace, name string) *corev1.Secret {
+	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
@@ -257,7 +257,7 @@ func (pair KeyPair) GenerateCertificateSecret(namespace, name string) *v1.Secret
 			TLSPrivateKeyKey: pair.Private,
 			TLSCertKey:       pair.Certificate,
 		},
-		Type: v1.SecretTypeTLS,
+		Type: corev1.SecretTypeTLS,
 	}
 }
 
@@ -375,7 +375,7 @@ func CreateRootCA(commonName string, organizationalUnit string) (*KeyPair, error
 }
 
 // ParseCASecret parse a CA secret to a key pair
-func ParseCASecret(secret *v1.Secret) (*KeyPair, error) {
+func ParseCASecret(secret *corev1.Secret) (*KeyPair, error) {
 	privateKey, ok := secret.Data[CAPrivateKeyKey]
 	if !ok {
 		return nil, fmt.Errorf("missing %s secret data", CAPrivateKeyKey)
@@ -399,7 +399,7 @@ func ParseCASecret(secret *v1.Secret) (*KeyPair, error) {
 }
 
 // ParseServerSecret parse a secret for a server to a key pair
-func ParseServerSecret(secret *v1.Secret) (*KeyPair, error) {
+func ParseServerSecret(secret *corev1.Secret) (*KeyPair, error) {
 	privateKey, ok := secret.Data[TLSPrivateKeyKey]
 	if !ok {
 		return nil, fmt.Errorf("missing %v secret data", TLSPrivateKeyKey)

--- a/pkg/certs/operator_deployment.go
+++ b/pkg/certs/operator_deployment.go
@@ -24,7 +24,7 @@ import (
 	"fmt"
 
 	"github.com/cloudnative-pg/machinery/pkg/log"
-	v1 "k8s.io/api/apps/v1"
+	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -63,7 +63,7 @@ func GetOperatorDeployment(
 	ctx context.Context,
 	kubeClient client.Client,
 	namespace, operatorLabelSelector string,
-) (*v1.Deployment, error) {
+) (*appsv1.Deployment, error) {
 	labelMap, err := labels.ConvertSelectorToLabelsMap(operatorLabelSelector)
 	if err != nil {
 		return nil, err
@@ -99,10 +99,10 @@ func findOperatorDeploymentByFilter(ctx context.Context,
 	kubeClient client.Client,
 	namespace string,
 	filter client.ListOption,
-) (*v1.Deployment, error) {
+) (*appsv1.Deployment, error) {
 	logger := log.FromContext(ctx)
 
-	deploymentList := &v1.DeploymentList{}
+	deploymentList := &appsv1.DeploymentList{}
 	err := kubeClient.List(
 		ctx,
 		deploymentList,

--- a/pkg/certs/tls.go
+++ b/pkg/certs/tls.go
@@ -25,7 +25,7 @@ import (
 	"crypto/x509"
 	"fmt"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -41,7 +41,7 @@ func newTLSConfigFromSecret(
 	cli client.Client,
 	caSecret types.NamespacedName,
 ) (*tls.Config, error) {
-	secret := &v1.Secret{}
+	secret := &corev1.Secret{}
 	err := cli.Get(ctx, caSecret, secret)
 	if err != nil {
 		return nil, fmt.Errorf("while getting caSecret %s: %w", caSecret.Name, err)

--- a/pkg/certs/tls_test.go
+++ b/pkg/certs/tls_test.go
@@ -26,7 +26,7 @@ import (
 	"errors"
 	"fmt"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -102,7 +102,7 @@ IRh7fVEH8WBfMA8GA1UdEwEB/wQFMAMBAf8wCgYIKoZIzj0EAwIDaAAwZQIwBdrw
 -----END CERTIFICATE-----
 `),
 			}
-			ca := &v1.Secret{
+			ca := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      caSecret.Name,
 					Namespace: caSecret.Namespace,
@@ -287,7 +287,7 @@ MQCKGqId+Xj6O6gnoi9xhu0rbzSnMjrURoa1v2d5+O5XssE7LGtJdIKrd2p7EuwE
 
 	Context("when the ca.crt entry is missing in the secret", func() {
 		BeforeEach(func() {
-			secret := &v1.Secret{
+			secret := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      caSecret.Name,
 					Namespace: caSecret.Namespace,

--- a/pkg/management/client.go
+++ b/pkg/management/client.go
@@ -27,14 +27,14 @@ import (
 	"time"
 
 	"github.com/cloudnative-pg/machinery/pkg/log"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
-	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/retry"
@@ -82,7 +82,7 @@ func NewControllerRuntimeClient() (client.WithWatch, error) {
 		// custom resources
 		&apiv1.Cluster{}, &apiv1.Backup{}, &apiv1.Pooler{}, &apiv1.ImageCatalog{}, &apiv1.ClusterImageCatalog{},
 		// k8s resources needed for the typedClient to work properly
-		&v1.ConfigMap{}, &v1.Secret{},
+		&corev1.ConfigMap{}, &corev1.Secret{},
 	}
 
 	// we register the resources
@@ -121,12 +121,12 @@ func NewEventRecorder() (record.EventRecorder, error) {
 
 	eventBroadcaster := record.NewBroadcaster()
 	eventBroadcaster.StartRecordingToSink(
-		&typedcorev1.EventSinkImpl{
+		&corev1client.EventSinkImpl{
 			Interface: kubeClient.CoreV1().Events(""),
 		})
 	recorder := eventBroadcaster.NewRecorder(
 		Scheme,
-		v1.EventSource{Component: "instance-manager"},
+		corev1.EventSource{Component: "instance-manager"},
 	)
 
 	return recorder, nil

--- a/pkg/management/postgres/probes.go
+++ b/pkg/management/postgres/probes.go
@@ -31,7 +31,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	v1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/executablehash"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/postgres"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/specs"
@@ -473,7 +473,7 @@ func (instance *Instance) fillWalStatusFromConnection(result *postgres.Postgresq
 		FROM pg_catalog.pg_stat_replication
 		WHERE application_name ~ $1 AND usename = $2`,
 		fmt.Sprintf("%s-[0-9]+$", instance.GetClusterName()),
-		v1.StreamingReplicationUser,
+		apiv1.StreamingReplicationUser,
 	)
 	if err != nil {
 		return err

--- a/pkg/reconciler/backup/volumesnapshot/catalog.go
+++ b/pkg/reconciler/backup/volumesnapshot/catalog.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"time"
 
-	storagesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
+	volumesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
@@ -36,7 +36,7 @@ func GetSnapshotsBackupTimes(
 	namespace string,
 	clusterName string,
 ) (*time.Time, *time.Time, error) {
-	var list storagesnapshotv1.VolumeSnapshotList
+	var list volumesnapshotv1.VolumeSnapshotList
 	if err := cli.List(
 		ctx,
 		&list,
@@ -48,7 +48,7 @@ func GetSnapshotsBackupTimes(
 		return nil, nil, err
 	}
 
-	dataVolSnapshots := make([]storagesnapshotv1.VolumeSnapshot, 0, len(list.Items))
+	dataVolSnapshots := make([]volumesnapshotv1.VolumeSnapshot, 0, len(list.Items))
 	for _, snapshot := range list.Items {
 		if snapshot.Annotations[utils.PvcRoleLabelName] == string(utils.PVCRolePgData) {
 			dataVolSnapshots = append(dataVolSnapshots, snapshot)

--- a/pkg/reconciler/backup/volumesnapshot/reconciler.go
+++ b/pkg/reconciler/backup/volumesnapshot/reconciler.go
@@ -29,7 +29,7 @@ import (
 	"time"
 
 	"github.com/cloudnative-pg/machinery/pkg/log"
-	storagesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
+	volumesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
@@ -77,7 +77,7 @@ func (e *ExecutorBuilder) Build() *Reconciler {
 
 func (se *Reconciler) enrichSnapshot(
 	ctx context.Context,
-	vs *storagesnapshotv1.VolumeSnapshot,
+	vs *volumesnapshotv1.VolumeSnapshot,
 	backup *apiv1.Backup,
 	cluster *apiv1.Cluster,
 	targetPod *corev1.Pod,
@@ -409,7 +409,7 @@ func (se *Reconciler) createSnapshotPVCGroupStep(
 func (se *Reconciler) waitSnapshotToBeProvisionedStep(
 	ctx context.Context,
 	backup *apiv1.Backup,
-	snapshots []storagesnapshotv1.VolumeSnapshot,
+	snapshots []volumesnapshotv1.VolumeSnapshot,
 ) (*ctrl.Result, error) {
 	for i := range snapshots {
 		if res, err := se.waitSnapshotToBeProvisionedAndAnnotate(ctx, backup, &snapshots[i]); res != nil || err != nil {
@@ -424,7 +424,7 @@ func (se *Reconciler) waitSnapshotToBeProvisionedStep(
 func (se *Reconciler) waitSnapshotToBeReadyStep(
 	ctx context.Context,
 	backup *apiv1.Backup,
-	snapshots []storagesnapshotv1.VolumeSnapshot,
+	snapshots []volumesnapshotv1.VolumeSnapshot,
 ) (*ctrl.Result, error) {
 	for i := range snapshots {
 		if res, err := se.waitSnapshotToBeReady(ctx, backup, &snapshots[i]); res != nil || err != nil {
@@ -465,15 +465,15 @@ func (se *Reconciler) createSnapshot(
 	maps.Copy(annotations, snapshotConfig.Annotations)
 	transferLabelsToAnnotations(labels, annotations)
 
-	snapshot := storagesnapshotv1.VolumeSnapshot{
+	snapshot := volumesnapshotv1.VolumeSnapshot{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        pvcCalculator.GetSnapshotName(backup.Name),
 			Namespace:   pvc.Namespace,
 			Labels:      labels,
 			Annotations: annotations,
 		},
-		Spec: storagesnapshotv1.VolumeSnapshotSpec{
-			Source: storagesnapshotv1.VolumeSnapshotSource{
+		Spec: volumesnapshotv1.VolumeSnapshotSpec{
+			Source: volumesnapshotv1.VolumeSnapshotSource{
 				PersistentVolumeClaimName: &pvc.Name,
 			},
 			VolumeSnapshotClassName: snapshotClassName,
@@ -527,7 +527,7 @@ func transferLabelsToAnnotations(labels map[string]string, annotations map[strin
 func (se *Reconciler) waitSnapshotToBeProvisionedAndAnnotate(
 	ctx context.Context,
 	backup *apiv1.Backup,
-	snapshot *storagesnapshotv1.VolumeSnapshot,
+	snapshot *volumesnapshotv1.VolumeSnapshot,
 ) (*ctrl.Result, error) {
 	contextLogger := log.FromContext(ctx)
 
@@ -564,7 +564,7 @@ func (se *Reconciler) waitSnapshotToBeProvisionedAndAnnotate(
 func (se *Reconciler) waitSnapshotToBeReady(
 	ctx context.Context,
 	backup *apiv1.Backup,
-	snapshot *storagesnapshotv1.VolumeSnapshot,
+	snapshot *volumesnapshotv1.VolumeSnapshot,
 ) (*ctrl.Result, error) {
 	contextLogger := log.FromContext(ctx)
 

--- a/pkg/reconciler/backup/volumesnapshot/resources.go
+++ b/pkg/reconciler/backup/volumesnapshot/resources.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"fmt"
 
-	storagesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
+	volumesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
@@ -53,7 +53,7 @@ type volumeSnapshotInfo struct {
 type volumeSnapshotError struct {
 	// InternalError is a representation of the error given
 	// by the CSI driver
-	InternalError storagesnapshotv1.VolumeSnapshotError
+	InternalError volumesnapshotv1.VolumeSnapshotError
 
 	// Name is the name of the VolumeSnapshot object
 	Name string
@@ -84,8 +84,8 @@ func (err volumeSnapshotError) isRetryable() bool {
 	return isCSIErrorMessageRetriable(*err.InternalError.Message)
 }
 
-// slice represents a slice of []storagesnapshotv1.VolumeSnapshot
-type slice []storagesnapshotv1.VolumeSnapshot
+// slice represents a slice of []volumesnapshotv1.VolumeSnapshot
+type slice []volumesnapshotv1.VolumeSnapshot
 
 // getControldata retrieves the pg_controldata stored as an annotation in VolumeSnapshots
 func (s slice) getControldata() (string, error) {
@@ -107,7 +107,7 @@ func getBackupVolumeSnapshots(
 	namespace string,
 	backupName string,
 ) (slice, error) {
-	var list storagesnapshotv1.VolumeSnapshotList
+	var list volumesnapshotv1.VolumeSnapshotList
 
 	if err := cli.List(
 		ctx,
@@ -122,7 +122,7 @@ func getBackupVolumeSnapshots(
 }
 
 // parseVolumeSnapshotInfo extracts information from a volume snapshot resource
-func parseVolumeSnapshotInfo(snapshot *storagesnapshotv1.VolumeSnapshot) volumeSnapshotInfo {
+func parseVolumeSnapshotInfo(snapshot *volumesnapshotv1.VolumeSnapshot) volumeSnapshotInfo {
 	if snapshot.Status == nil {
 		return volumeSnapshotInfo{
 			error:       nil,

--- a/pkg/reconciler/backup/volumesnapshot/resources_test.go
+++ b/pkg/reconciler/backup/volumesnapshot/resources_test.go
@@ -22,7 +22,7 @@ package volumesnapshot
 import (
 	"errors"
 
-	storagesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
+	volumesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
@@ -32,7 +32,7 @@ import (
 
 var _ = Describe("parseVolumeSnapshotInfo", func() {
 	It("should not fail when the VolumeSnapshot CR have not been handled by the External Snapshotter operator", func() {
-		info := parseVolumeSnapshotInfo(&storagesnapshotv1.VolumeSnapshot{})
+		info := parseVolumeSnapshotInfo(&volumesnapshotv1.VolumeSnapshot{})
 		Expect(info).To(BeEquivalentTo(volumeSnapshotInfo{
 			error:       nil,
 			provisioned: false,
@@ -41,13 +41,13 @@ var _ = Describe("parseVolumeSnapshotInfo", func() {
 	})
 
 	It("should gracefully handle snapshot errors", func() {
-		volumeSnapshot := &storagesnapshotv1.VolumeSnapshot{
+		volumeSnapshot := &volumesnapshotv1.VolumeSnapshot{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "snapshot",
 				Namespace: "default",
 			},
-			Status: &storagesnapshotv1.VolumeSnapshotStatus{
-				Error: &storagesnapshotv1.VolumeSnapshotError{
+			Status: &volumesnapshotv1.VolumeSnapshotStatus{
+				Error: &volumesnapshotv1.VolumeSnapshotError{
 					Time:    ptr.To(metav1.Now()),
 					Message: nil,
 				},
@@ -68,13 +68,13 @@ var _ = Describe("parseVolumeSnapshotInfo", func() {
 	})
 
 	It("should detect retryable errors", func() {
-		volumeSnapshot := &storagesnapshotv1.VolumeSnapshot{
+		volumeSnapshot := &volumesnapshotv1.VolumeSnapshot{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "snapshot",
 				Namespace: "default",
 			},
-			Status: &storagesnapshotv1.VolumeSnapshotStatus{
-				Error: &storagesnapshotv1.VolumeSnapshotError{
+			Status: &volumesnapshotv1.VolumeSnapshotStatus{
+				Error: &volumesnapshotv1.VolumeSnapshotError{
 					Time: ptr.To(metav1.Now()),
 					Message: ptr.To(
 						"the object has been modified; please apply your changes to the latest version and try again"),
@@ -97,8 +97,8 @@ var _ = Describe("parseVolumeSnapshotInfo", func() {
 
 	When("BoundVolumeSnapshotContentName is nil", func() {
 		It("should detect that a VolumeSnapshot is not provisioned", func() {
-			volumeSnapshot := &storagesnapshotv1.VolumeSnapshot{
-				Status: &storagesnapshotv1.VolumeSnapshotStatus{
+			volumeSnapshot := &volumesnapshotv1.VolumeSnapshot{
+				Status: &volumesnapshotv1.VolumeSnapshotStatus{
 					Error:                          nil,
 					BoundVolumeSnapshotContentName: nil,
 				},
@@ -110,8 +110,8 @@ var _ = Describe("parseVolumeSnapshotInfo", func() {
 
 	When("BoundVolumeSnapshotContentName is not nil", func() {
 		It("should detect that a VolumeSnapshot is not provisioned", func() {
-			volumeSnapshot := &storagesnapshotv1.VolumeSnapshot{
-				Status: &storagesnapshotv1.VolumeSnapshotStatus{
+			volumeSnapshot := &volumesnapshotv1.VolumeSnapshot{
+				Status: &volumesnapshotv1.VolumeSnapshotStatus{
 					ReadyToUse:                     ptr.To(false),
 					Error:                          nil,
 					BoundVolumeSnapshotContentName: ptr.To(""),
@@ -123,8 +123,8 @@ var _ = Describe("parseVolumeSnapshotInfo", func() {
 		})
 
 		It("should detect that a VolumeSnapshot is not provisioned", func() {
-			volumeSnapshot := &storagesnapshotv1.VolumeSnapshot{
-				Status: &storagesnapshotv1.VolumeSnapshotStatus{
+			volumeSnapshot := &volumesnapshotv1.VolumeSnapshot{
+				Status: &volumesnapshotv1.VolumeSnapshotStatus{
 					ReadyToUse:                     ptr.To(false),
 					Error:                          nil,
 					BoundVolumeSnapshotContentName: ptr.To("content-name"),
@@ -136,8 +136,8 @@ var _ = Describe("parseVolumeSnapshotInfo", func() {
 		})
 
 		It("should detect that a VolumeSnapshot is provisioned", func() {
-			volumeSnapshot := &storagesnapshotv1.VolumeSnapshot{
-				Status: &storagesnapshotv1.VolumeSnapshotStatus{
+			volumeSnapshot := &volumesnapshotv1.VolumeSnapshot{
+				Status: &volumesnapshotv1.VolumeSnapshotStatus{
 					ReadyToUse:                     ptr.To(false),
 					Error:                          nil,
 					BoundVolumeSnapshotContentName: ptr.To("content-name"),
@@ -152,8 +152,8 @@ var _ = Describe("parseVolumeSnapshotInfo", func() {
 
 	When("ReadyToUse is nil", func() {
 		It("should detect that a VolumeSnapshot is not ready to use", func() {
-			volumeSnapshot := &storagesnapshotv1.VolumeSnapshot{
-				Status: &storagesnapshotv1.VolumeSnapshotStatus{
+			volumeSnapshot := &volumesnapshotv1.VolumeSnapshot{
+				Status: &volumesnapshotv1.VolumeSnapshotStatus{
 					ReadyToUse:                     nil,
 					Error:                          nil,
 					BoundVolumeSnapshotContentName: ptr.To("content-name"),
@@ -168,8 +168,8 @@ var _ = Describe("parseVolumeSnapshotInfo", func() {
 
 	When("ReadyToUse is not nil", func() {
 		It("should detect that a VolumeSnapshot is not ready to use", func() {
-			volumeSnapshot := &storagesnapshotv1.VolumeSnapshot{
-				Status: &storagesnapshotv1.VolumeSnapshotStatus{
+			volumeSnapshot := &volumesnapshotv1.VolumeSnapshot{
+				Status: &volumesnapshotv1.VolumeSnapshotStatus{
 					ReadyToUse:                     ptr.To(false),
 					Error:                          nil,
 					BoundVolumeSnapshotContentName: ptr.To("content-name"),
@@ -182,8 +182,8 @@ var _ = Describe("parseVolumeSnapshotInfo", func() {
 		})
 
 		It("should detect that a VolumeSnapshot is ready to use", func() {
-			volumeSnapshot := &storagesnapshotv1.VolumeSnapshot{
-				Status: &storagesnapshotv1.VolumeSnapshotStatus{
+			volumeSnapshot := &volumesnapshotv1.VolumeSnapshot{
+				Status: &volumesnapshotv1.VolumeSnapshotStatus{
 					ReadyToUse:                     ptr.To(true),
 					Error:                          nil,
 					BoundVolumeSnapshotContentName: ptr.To("content-name"),

--- a/pkg/reconciler/persistentvolumeclaim/calculator.go
+++ b/pkg/reconciler/persistentvolumeclaim/calculator.go
@@ -22,7 +22,7 @@ package persistentvolumeclaim
 import (
 	"fmt"
 
-	volumesnapshot "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
+	volumesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/ptr"
 
@@ -176,7 +176,7 @@ func (r pgDataCalculator) GetSourceFromBackup(backup *apiv1.Backup) *corev1.Type
 	for _, element := range backup.Status.BackupSnapshotStatus.Elements {
 		if element.Type == string(utils.PVCRolePgData) {
 			return &corev1.TypedLocalObjectReference{
-				APIGroup: ptr.To(volumesnapshot.GroupName),
+				APIGroup: ptr.To(volumesnapshotv1.GroupName),
 				Kind:     apiv1.VolumeSnapshotKind,
 				Name:     element.Name,
 			}

--- a/pkg/reconciler/persistentvolumeclaim/storagesource.go
+++ b/pkg/reconciler/persistentvolumeclaim/storagesource.go
@@ -23,7 +23,7 @@ import (
 	"context"
 
 	"github.com/cloudnative-pg/machinery/pkg/log"
-	volumesnapshot "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
+	volumesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/ptr"
 
@@ -182,7 +182,7 @@ func getCandidateSourceFromBackup(backup *apiv1.Backup) *StorageSource {
 	var result StorageSource
 	for _, element := range backup.Status.BackupSnapshotStatus.Elements {
 		reference := corev1.TypedLocalObjectReference{
-			APIGroup: ptr.To(volumesnapshot.GroupName),
+			APIGroup: ptr.To(volumesnapshotv1.GroupName),
 			Kind:     apiv1.VolumeSnapshotKind,
 			Name:     element.Name,
 		}

--- a/pkg/reconciler/persistentvolumeclaim/validation.go
+++ b/pkg/reconciler/persistentvolumeclaim/validation.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"fmt"
 
-	storagesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
+	volumesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -177,7 +177,7 @@ func VerifyDataSourceCoherence(
 }
 
 type metadataSource struct {
-	snapshot *storagesnapshotv1.VolumeSnapshot
+	snapshot *volumesnapshotv1.VolumeSnapshot
 	pvc      *corev1.PersistentVolumeClaim
 }
 
@@ -187,8 +187,8 @@ func newMetadataSource(source corev1.TypedLocalObjectReference) (*metadataSource
 	if source.APIGroup != nil {
 		apiGroup = *source.APIGroup
 	}
-	if apiGroup == storagesnapshotv1.GroupName && source.Kind == "VolumeSnapshot" {
-		objRef.snapshot = &storagesnapshotv1.VolumeSnapshot{}
+	if apiGroup == volumesnapshotv1.GroupName && source.Kind == "VolumeSnapshot" {
+		objRef.snapshot = &volumesnapshotv1.VolumeSnapshot{}
 		return objRef, nil
 	}
 	if apiGroup == corev1.GroupName && source.Kind == "PersistentVolumeClaim" {

--- a/pkg/reconciler/persistentvolumeclaim/validation_test.go
+++ b/pkg/reconciler/persistentvolumeclaim/validation_test.go
@@ -20,7 +20,7 @@ SPDX-License-Identifier: Apache-2.0
 package persistentvolumeclaim
 
 import (
-	volumesnapshot "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
+	volumesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
@@ -36,7 +36,7 @@ import (
 
 var _ = Describe("Volume Snapshot validation", func() {
 	It("Complains with warnings when the labels are missing", func() {
-		snapshot := volumesnapshot.VolumeSnapshot{
+		snapshot := volumesnapshotv1.VolumeSnapshot{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{},
 			},
@@ -75,7 +75,7 @@ var _ = Describe("Volume Snapshot validation", func() {
 	})
 
 	It("Fails when the snapshot have the pvcRole annotation, but the value is not correct", func() {
-		snapshot := volumesnapshot.VolumeSnapshot{
+		snapshot := volumesnapshotv1.VolumeSnapshot{
 			ObjectMeta: metav1.ObjectMeta{
 				Annotations: map[string]string{
 					utils.PvcRoleLabelName: "test",
@@ -103,8 +103,8 @@ var _ = Describe("Volume Snapshot validation", func() {
 	})
 
 	It("Verifies the coherence of multiple volumeSnapshot backups", func(ctx SpecContext) {
-		snapshots := volumesnapshot.VolumeSnapshotList{
-			Items: []volumesnapshot.VolumeSnapshot{
+		snapshots := volumesnapshotv1.VolumeSnapshotList{
+			Items: []volumesnapshotv1.VolumeSnapshot{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "pgdata",
@@ -133,12 +133,12 @@ var _ = Describe("Volume Snapshot validation", func() {
 		}
 		dataSource := apiv1.DataSource{
 			Storage: corev1.TypedLocalObjectReference{
-				APIGroup: ptr.To(volumesnapshot.GroupName),
+				APIGroup: ptr.To(volumesnapshotv1.GroupName),
 				Kind:     "VolumeSnapshot",
 				Name:     "pgdata",
 			},
 			WalStorage: &corev1.TypedLocalObjectReference{
-				APIGroup: ptr.To(volumesnapshot.GroupName),
+				APIGroup: ptr.To(volumesnapshotv1.GroupName),
 				Kind:     "VolumeSnapshot",
 				Name:     "pgwal",
 			},
@@ -161,8 +161,8 @@ var _ = Describe("Volume Snapshot validation", func() {
 	})
 
 	It("doesn't complain if the snapshots are correct", func(ctx SpecContext) {
-		snapshots := volumesnapshot.VolumeSnapshotList{
-			Items: []volumesnapshot.VolumeSnapshot{
+		snapshots := volumesnapshotv1.VolumeSnapshotList{
+			Items: []volumesnapshotv1.VolumeSnapshot{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "pgdata",
@@ -191,12 +191,12 @@ var _ = Describe("Volume Snapshot validation", func() {
 		}
 		dataSource := apiv1.DataSource{
 			Storage: corev1.TypedLocalObjectReference{
-				APIGroup: ptr.To(volumesnapshot.GroupName),
+				APIGroup: ptr.To(volumesnapshotv1.GroupName),
 				Kind:     "VolumeSnapshot",
 				Name:     "pgdata",
 			},
 			WalStorage: &corev1.TypedLocalObjectReference{
-				APIGroup: ptr.To(volumesnapshot.GroupName),
+				APIGroup: ptr.To(volumesnapshotv1.GroupName),
 				Kind:     "VolumeSnapshot",
 				Name:     "pgwal",
 			},
@@ -212,8 +212,8 @@ var _ = Describe("Volume Snapshot validation", func() {
 	})
 
 	It("doesn't complain if we only have the pgdata snapshot", func(ctx SpecContext) {
-		snapshots := volumesnapshot.VolumeSnapshotList{
-			Items: []volumesnapshot.VolumeSnapshot{
+		snapshots := volumesnapshotv1.VolumeSnapshotList{
+			Items: []volumesnapshotv1.VolumeSnapshot{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "pgdata",
@@ -230,7 +230,7 @@ var _ = Describe("Volume Snapshot validation", func() {
 		}
 		dataSource := apiv1.DataSource{
 			Storage: corev1.TypedLocalObjectReference{
-				APIGroup: ptr.To(volumesnapshot.GroupName),
+				APIGroup: ptr.To(volumesnapshotv1.GroupName),
 				Kind:     "VolumeSnapshot",
 				Name:     "pgdata",
 			},
@@ -246,8 +246,8 @@ var _ = Describe("Volume Snapshot validation", func() {
 	})
 
 	It("complains if we referenced a snapshot which we don't have", func(ctx SpecContext) {
-		snapshots := volumesnapshot.VolumeSnapshotList{
-			Items: []volumesnapshot.VolumeSnapshot{
+		snapshots := volumesnapshotv1.VolumeSnapshotList{
+			Items: []volumesnapshotv1.VolumeSnapshot{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "pgdata",
@@ -264,12 +264,12 @@ var _ = Describe("Volume Snapshot validation", func() {
 		}
 		dataSource := apiv1.DataSource{
 			Storage: corev1.TypedLocalObjectReference{
-				APIGroup: ptr.To(volumesnapshot.GroupName),
+				APIGroup: ptr.To(volumesnapshotv1.GroupName),
 				Kind:     "VolumeSnapshot",
 				Name:     "pgdata",
 			},
 			WalStorage: &corev1.TypedLocalObjectReference{
-				APIGroup: ptr.To(volumesnapshot.GroupName),
+				APIGroup: ptr.To(volumesnapshotv1.GroupName),
 				Kind:     "VolumeSnapshot",
 				Name:     "pgwal",
 			},

--- a/pkg/specs/pgbouncer/rbac.go
+++ b/pkg/specs/pgbouncer/rbac.go
@@ -21,7 +21,7 @@ package pgbouncer
 
 import (
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/rbac/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
@@ -36,7 +36,7 @@ func ServiceAccount(pooler *apiv1.Pooler) *corev1.ServiceAccount {
 }
 
 // Role creates a role for a given pooler
-func Role(pooler *apiv1.Pooler) *v1.Role {
+func Role(pooler *apiv1.Pooler) *rbacv1.Role {
 	secretNames := []string{pooler.GetAuthQuerySecretName()}
 	if pooler.Status.Secrets != nil {
 		if pooler.Status.Secrets.ServerCA.Name != "" {
@@ -52,9 +52,9 @@ func Role(pooler *apiv1.Pooler) *v1.Role {
 		}
 	}
 
-	return &v1.Role{ObjectMeta: metav1.ObjectMeta{
+	return &rbacv1.Role{ObjectMeta: metav1.ObjectMeta{
 		Name: pooler.Name, Namespace: pooler.Namespace,
-	}, Rules: []v1.PolicyRule{
+	}, Rules: []rbacv1.PolicyRule{
 		{
 			APIGroups: []string{
 				"postgresql.cnpg.io",
@@ -104,6 +104,6 @@ func Role(pooler *apiv1.Pooler) *v1.Role {
 }
 
 // RoleBinding creates a role binding for a given pooler
-func RoleBinding(pooler *apiv1.Pooler) v1.RoleBinding {
+func RoleBinding(pooler *apiv1.Pooler) rbacv1.RoleBinding {
 	return specs.CreateRoleBinding(pooler.ObjectMeta)
 }

--- a/pkg/specs/pods_test.go
+++ b/pkg/specs/pods_test.go
@@ -27,7 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	v1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/postgres"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 
@@ -66,7 +66,7 @@ var (
 
 var _ = Describe("The PostgreSQL security context with", func() {
 	It("default RuntimeDefault profile", func() {
-		cluster := v1.Cluster{}
+		cluster := apiv1.Cluster{}
 		securityContext := CreatePodSecurityContext(cluster.GetSeccompProfile(), 26, 26)
 
 		Expect(securityContext.SeccompProfile).ToNot(BeNil())
@@ -79,7 +79,7 @@ var _ = Describe("The PostgreSQL security context with", func() {
 			Type:             corev1.SeccompProfileTypeLocalhost,
 			LocalhostProfile: &profilePath,
 		}
-		cluster := v1.Cluster{Spec: v1.ClusterSpec{SeccompProfile: localhostProfile}}
+		cluster := apiv1.Cluster{Spec: apiv1.ClusterSpec{SeccompProfile: localhostProfile}}
 		securityContext := CreatePodSecurityContext(cluster.GetSeccompProfile(), 26, 26)
 
 		Expect(securityContext.SeccompProfile).ToNot(BeNil())
@@ -92,7 +92,7 @@ var _ = Describe("Create affinity section", func() {
 	clusterName := "cluster-test"
 
 	It("enable preferred pod affinity everything default", func() {
-		config := v1.AffinityConfiguration{
+		config := apiv1.AffinityConfiguration{
 			PodAntiAffinityType: "preferred",
 		}
 		affinity := CreateAffinitySection(clusterName, config)
@@ -101,7 +101,7 @@ var _ = Describe("Create affinity section", func() {
 	})
 
 	It("can not set pod affinity if pod anti-affinity is disabled", func() {
-		config := v1.AffinityConfiguration{
+		config := apiv1.AffinityConfiguration{
 			EnablePodAntiAffinity: pointerToBool(false),
 		}
 		affinity := CreateAffinitySection(clusterName, config)
@@ -109,7 +109,7 @@ var _ = Describe("Create affinity section", func() {
 	})
 
 	It("can set pod anti affinity with 'preferred' pod anti-affinity type", func() {
-		config := v1.AffinityConfiguration{
+		config := apiv1.AffinityConfiguration{
 			EnablePodAntiAffinity: pointerToBool(true),
 			PodAntiAffinityType:   "preferred",
 		}
@@ -119,7 +119,7 @@ var _ = Describe("Create affinity section", func() {
 	})
 
 	It("can set pod anti-affinity with 'required' pod anti-affinity type", func() {
-		config := v1.AffinityConfiguration{
+		config := apiv1.AffinityConfiguration{
 			EnablePodAntiAffinity: pointerToBool(true),
 			PodAntiAffinityType:   "required",
 		}
@@ -129,7 +129,7 @@ var _ = Describe("Create affinity section", func() {
 		Expect(affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution).To(BeNil())
 	})
 	It("does not set pod anti-affinity if provided an invalid type", func() {
-		config := v1.AffinityConfiguration{
+		config := apiv1.AffinityConfiguration{
 			EnablePodAntiAffinity: pointerToBool(true),
 			PodAntiAffinityType:   "not-a-type",
 		}
@@ -143,7 +143,7 @@ var _ = Describe("Create affinity section", func() {
 	When("given additional affinity terms", func() {
 		When("generated pod anti-affinity is enabled", func() {
 			It("sets both pod affinity and anti-affinity correctly if passed and set to required", func() {
-				config := v1.AffinityConfiguration{
+				config := apiv1.AffinityConfiguration{
 					EnablePodAntiAffinity: pointerToBool(true),
 					PodAntiAffinityType:   "required",
 					AdditionalPodAffinity: &corev1.PodAffinity{
@@ -169,7 +169,7 @@ var _ = Describe("Create affinity section", func() {
 					To(BeEquivalentTo([]corev1.WeightedPodAffinityTerm{testWeightedAffinityTerm}))
 			})
 			It("sets pod both affinity and anti-affinity correctly if passed and set to preferred", func() {
-				config := v1.AffinityConfiguration{
+				config := apiv1.AffinityConfiguration{
 					EnablePodAntiAffinity: pointerToBool(true),
 					PodAntiAffinityType:   "preferred",
 					AdditionalPodAffinity: &corev1.PodAffinity{
@@ -197,7 +197,7 @@ var _ = Describe("Create affinity section", func() {
 		})
 		When("generated pod anti-affinity is disabled", func() {
 			It("sets pod required anti-affinity correctly if passed", func() {
-				config := v1.AffinityConfiguration{
+				config := apiv1.AffinityConfiguration{
 					EnablePodAntiAffinity: pointerToBool(false),
 					AdditionalPodAntiAffinity: &corev1.PodAntiAffinity{
 						RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{testAffinityTerm},
@@ -211,7 +211,7 @@ var _ = Describe("Create affinity section", func() {
 				Expect(affinity.PodAffinity).To(BeNil())
 			})
 			It("sets pod preferred anti-affinity correctly if passed", func() {
-				config := v1.AffinityConfiguration{
+				config := apiv1.AffinityConfiguration{
 					EnablePodAntiAffinity: pointerToBool(false),
 					AdditionalPodAntiAffinity: &corev1.PodAntiAffinity{
 						PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{testWeightedAffinityTerm},
@@ -225,7 +225,7 @@ var _ = Describe("Create affinity section", func() {
 				Expect(affinity.PodAffinity).To(BeNil())
 			})
 			It("sets pod preferred affinity correctly if passed", func() {
-				config := v1.AffinityConfiguration{
+				config := apiv1.AffinityConfiguration{
 					EnablePodAntiAffinity: pointerToBool(false),
 					AdditionalPodAffinity: &corev1.PodAffinity{
 						PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{testWeightedAffinityTerm},
@@ -239,7 +239,7 @@ var _ = Describe("Create affinity section", func() {
 				Expect(affinity.PodAntiAffinity).To(BeNil())
 			})
 			It("sets pod required affinity correctly if passed", func() {
-				config := v1.AffinityConfiguration{
+				config := apiv1.AffinityConfiguration{
 					EnablePodAntiAffinity: pointerToBool(false),
 					AdditionalPodAffinity: &corev1.PodAffinity{
 						RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{testAffinityTerm},
@@ -253,7 +253,7 @@ var _ = Describe("Create affinity section", func() {
 				Expect(affinity.PodAntiAffinity).To(BeNil())
 			})
 			It("sets pod both affinity and anti-affinity correctly if passed", func() {
-				config := v1.AffinityConfiguration{
+				config := apiv1.AffinityConfiguration{
 					EnablePodAntiAffinity: pointerToBool(false),
 					AdditionalPodAffinity: &corev1.PodAffinity{
 						PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{testWeightedAffinityTerm},
@@ -282,7 +282,7 @@ var _ = Describe("Create affinity section", func() {
 
 	When("given node affinity config", func() {
 		It("sets node affinity", func() {
-			config := v1.AffinityConfiguration{
+			config := apiv1.AffinityConfiguration{
 				NodeAffinity: &corev1.NodeAffinity{
 					RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
 						NodeSelectorTerms: []corev1.NodeSelectorTerm{testNodeSelectorTerm},
@@ -302,12 +302,12 @@ var _ = Describe("Create affinity section", func() {
 var _ = Describe("EnvConfig", func() {
 	Context("IsEnvEqual function", func() {
 		It("returns true if the Env are equal", func() {
-			cluster := v1.Cluster{
+			cluster := apiv1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test",
 					Namespace: "test-ns",
 				},
-				Spec: v1.ClusterSpec{
+				Spec: apiv1.ClusterSpec{
 					Env: []corev1.EnvVar{
 						{
 							Name:  "TEST_ENV",
@@ -363,7 +363,7 @@ var _ = Describe("EnvConfig", func() {
 		})
 
 		It("returns false if the Env are different", func() {
-			cluster := v1.Cluster{
+			cluster := apiv1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test",
 					Namespace: "test-ns",
@@ -412,12 +412,12 @@ var _ = Describe("EnvConfig", func() {
 		})
 
 		It("returns true if the EnvFrom are equal", func() {
-			cluster := v1.Cluster{
+			cluster := apiv1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test",
 					Namespace: "test-ns",
 				},
-				Spec: v1.ClusterSpec{
+				Spec: apiv1.ClusterSpec{
 					EnvFrom: []corev1.EnvFromSource{
 						{
 							ConfigMapRef: &corev1.ConfigMapEnvSource{
@@ -448,12 +448,12 @@ var _ = Describe("EnvConfig", func() {
 		})
 
 		It("returns false if the EnvFrom are different", func() {
-			cluster := v1.Cluster{
+			cluster := apiv1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test",
 					Namespace: "test-ns",
 				},
-				Spec: v1.ClusterSpec{
+				Spec: apiv1.ClusterSpec{
 					EnvFrom: []corev1.EnvFromSource{
 						{
 							SecretRef: &corev1.SecretEnvSource{
@@ -933,7 +933,7 @@ var _ = Describe("Compute startup probe failure threshold", func() {
 
 var _ = Describe("NewInstance", func() {
 	It("applies JSON patch from annotation", func(ctx SpecContext) {
-		cluster := v1.Cluster{
+		cluster := apiv1.Cluster{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-cluster",
 				Namespace: "default",
@@ -941,7 +941,7 @@ var _ = Describe("NewInstance", func() {
 					utils.PodPatchAnnotationName: `[{"op": "replace", "path": "/spec/containers/0/image", "value": "new-image:latest"}]`, // nolint: lll
 				},
 			},
-			Status: v1.ClusterStatus{
+			Status: apiv1.ClusterStatus{
 				Image: "test",
 			},
 		}
@@ -953,7 +953,7 @@ var _ = Describe("NewInstance", func() {
 	})
 
 	It("returns error if JSON patch is invalid", func(ctx SpecContext) {
-		cluster := v1.Cluster{
+		cluster := apiv1.Cluster{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-cluster",
 				Namespace: "default",

--- a/pkg/specs/roles_test.go
+++ b/pkg/specs/roles_test.go
@@ -21,7 +21,7 @@ package specs
 
 import (
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/rbac/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
@@ -349,7 +349,7 @@ var _ = Describe("Managed Roles", func() {
 		serviceAccount := CreateRole(cluster, nil)
 		Expect(serviceAccount.Name).To(Equal(cluster.Name))
 		Expect(serviceAccount.Namespace).To(Equal(cluster.Namespace))
-		var secretsPolicy v1.PolicyRule
+		var secretsPolicy rbacv1.PolicyRule
 		for _, policy := range serviceAccount.Rules {
 			if len(policy.Resources) > 0 && policy.Resources[0] == "secrets" {
 				secretsPolicy = policy

--- a/pkg/specs/serviceaccount_test.go
+++ b/pkg/specs/serviceaccount_test.go
@@ -20,7 +20,7 @@ SPDX-License-Identifier: Apache-2.0
 package specs
 
 import (
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
@@ -33,14 +33,14 @@ var _ = Describe("Service accounts", func() {
 	emptyMeta := metav1.ObjectMeta{}
 
 	It("create a service account with the cluster name", func() {
-		sa := &v1.ServiceAccount{}
+		sa := &corev1.ServiceAccount{}
 		err := UpdateServiceAccount(nil, sa)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(sa.Annotations[utils.OperatorManagedSecretsAnnotationName]).To(Equal("null"))
 	})
 
 	It("correctly create the annotation storing the secret names", func() {
-		sa := &v1.ServiceAccount{}
+		sa := &corev1.ServiceAccount{}
 		err := UpdateServiceAccount([]string{"one", "two"}, sa)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(sa.Annotations[utils.OperatorManagedSecretsAnnotationName]).To(Equal(`["one","two"]`))
@@ -48,7 +48,7 @@ var _ = Describe("Service accounts", func() {
 
 	When("the pull secrets are changed", func() {
 		It("can detect that the ServiceAccount is needing a refresh", func(ctx SpecContext) {
-			sa := &v1.ServiceAccount{}
+			sa := &corev1.ServiceAccount{}
 			err := UpdateServiceAccount([]string{"one", "two"}, sa)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(IsServiceAccountAligned(ctx, sa, []string{"one", "two"}, emptyMeta)).To(BeTrue())
@@ -58,12 +58,12 @@ var _ = Describe("Service accounts", func() {
 
 	When("there are secrets not directly managed by the operator", func() {
 		It("can detect that the ServiceAccount is needing a refresh", func(ctx SpecContext) {
-			sa := &v1.ServiceAccount{}
+			sa := &corev1.ServiceAccount{}
 			err := UpdateServiceAccount([]string{"one", "two"}, sa)
 
 			// This image pull secret is not managed by the operator since its name
 			// has not been stored inside the annotation inside the ServiceAccount
-			sa.ImagePullSecrets = append(sa.ImagePullSecrets, v1.LocalObjectReference{
+			sa.ImagePullSecrets = append(sa.ImagePullSecrets, corev1.LocalObjectReference{
 				Name: "token",
 			})
 			Expect(err).ToNot(HaveOccurred())
@@ -86,7 +86,7 @@ var _ = Describe("Service accounts", func() {
 				},
 			}
 
-			sa := &v1.ServiceAccount{
+			sa := &corev1.ServiceAccount{
 				ObjectMeta: meta,
 			}
 			err := UpdateServiceAccount([]string{}, sa)
@@ -110,7 +110,7 @@ var _ = Describe("Service accounts", func() {
 				},
 			}
 
-			sa := &v1.ServiceAccount{
+			sa := &corev1.ServiceAccount{
 				ObjectMeta: meta,
 			}
 			err := UpdateServiceAccount([]string{}, sa)

--- a/pkg/utils/ownership.go
+++ b/pkg/utils/ownership.go
@@ -19,14 +19,14 @@ SPDX-License-Identifier: Apache-2.0
 
 package utils
 
-import v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 // SetAsOwnedBy sets the controlled object as owned by a certain other
 // controller object with his type information
-func SetAsOwnedBy(controlled *v1.ObjectMeta, controller v1.ObjectMeta, typeMeta v1.TypeMeta) {
+func SetAsOwnedBy(controlled *metav1.ObjectMeta, controller metav1.ObjectMeta, typeMeta metav1.TypeMeta) {
 	isController := true
 
-	controlled.SetOwnerReferences([]v1.OwnerReference{
+	controlled.SetOwnerReferences([]metav1.OwnerReference{
 		{
 			APIVersion: typeMeta.APIVersion,
 			Kind:       typeMeta.Kind,

--- a/tests/e2e/replica_mode_cluster_test.go
+++ b/tests/e2e/replica_mode_cluster_test.go
@@ -26,7 +26,7 @@ import (
 	"strings"
 	"time"
 
-	volumesnapshot "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
+	volumesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
 	"github.com/thoas/go-funk"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -462,7 +462,7 @@ var _ = Describe("Replica Mode", Label(tests.LabelReplication), func() {
 			})
 
 			By("fetching the volume snapshots", func() {
-				snapshotList := volumesnapshot.VolumeSnapshotList{}
+				snapshotList := volumesnapshotv1.VolumeSnapshotList{}
 				err := env.Client.List(env.Ctx, &snapshotList, k8client.MatchingLabels{
 					utils.ClusterLabelName: clusterName,
 				})

--- a/tests/e2e/tablespaces_test.go
+++ b/tests/e2e/tablespaces_test.go
@@ -31,7 +31,7 @@ import (
 	"time"
 
 	pgTime "github.com/cloudnative-pg/machinery/pkg/postgres/time"
-	volumesnapshot "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
+	volumesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -1247,8 +1247,8 @@ func getSnapshots(
 	backupName string,
 	clusterName string,
 	namespace string,
-) (volumesnapshot.VolumeSnapshotList, error) {
-	var snapshotList volumesnapshot.VolumeSnapshotList
+) (volumesnapshotv1.VolumeSnapshotList, error) {
+	var snapshotList volumesnapshotv1.VolumeSnapshotList
 	err := env.Client.List(env.Ctx, &snapshotList, client.InNamespace(namespace),
 		client.MatchingLabels{
 			utils.ClusterLabelName:    clusterName,

--- a/tests/e2e/volume_snapshot_test.go
+++ b/tests/e2e/volume_snapshot_test.go
@@ -27,7 +27,7 @@ import (
 	"strings"
 	"time"
 
-	volumesnapshot "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
+	volumesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
@@ -59,8 +59,8 @@ var _ = Describe("Verify Volume Snapshot",
 			backupName string,
 			clusterName string,
 			namespace string,
-		) (volumesnapshot.VolumeSnapshotList, error) {
-			var snapshotList volumesnapshot.VolumeSnapshotList
+		) (volumesnapshotv1.VolumeSnapshotList, error) {
+			var snapshotList volumesnapshotv1.VolumeSnapshotList
 			err := env.Client.List(env.Ctx, &snapshotList, k8client.InNamespace(namespace),
 				k8client.MatchingLabels{
 					utils.ClusterLabelName:    clusterName,
@@ -374,8 +374,8 @@ var _ = Describe("Verify Volume Snapshot",
 			getAndVerifySnapshots := func(
 				clusterToBackup *apiv1.Cluster,
 				backup apiv1.Backup,
-			) volumesnapshot.VolumeSnapshotList {
-				snapshotList := volumesnapshot.VolumeSnapshotList{}
+			) volumesnapshotv1.VolumeSnapshotList {
+				snapshotList := volumesnapshotv1.VolumeSnapshotList{}
 				By("fetching the volume snapshots", func() {
 					var err error
 					snapshotList, err = getSnapshots(backup.Name, clusterToBackup.Name, backup.Namespace)

--- a/tests/utils/backups/azurite.go
+++ b/tests/utils/backups/azurite.go
@@ -27,7 +27,7 @@ import (
 	"strings"
 	"time"
 
-	apiv1 "k8s.io/api/apps/v1"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -35,7 +35,7 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	v1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/certs"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/deployments"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/objects"
@@ -124,7 +124,7 @@ func InstallAzurite(
 		Namespace: namespace,
 		Name:      "azurite",
 	}
-	deployment := &apiv1.Deployment{}
+	deployment := &appsv1.Deployment{}
 	err = crudClient.Get(ctx, deploymentNamespacedName, deployment)
 	if err != nil {
 		return err
@@ -262,19 +262,19 @@ func getAzuriteService(namespace string) corev1.Service {
 }
 
 // getAzuriteDeployment get the deployment for Azurite
-func getAzuriteDeployment(namespace string) apiv1.Deployment {
+func getAzuriteDeployment(namespace string) appsv1.Deployment {
 	replicas := int32(1)
 	seccompProfile := &corev1.SeccompProfile{
 		Type: corev1.SeccompProfileTypeRuntimeDefault,
 	}
 
-	azuriteDeployment := apiv1.Deployment{
+	azuriteDeployment := appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "azurite",
 			Namespace: namespace,
 			Labels:    map[string]string{"app": "azurite"},
 		},
-		Spec: apiv1.DeploymentSpec{
+		Spec: appsv1.DeploymentSpec{
 			Replicas: &replicas,
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{"app": "azurite"},
@@ -393,25 +393,25 @@ func CreateClusterFromExternalClusterBackupWithPITROnAzure(
 	storageCredentialsSecretName,
 	azStorageAccount,
 	azBlobContainer string,
-) (*v1.Cluster, error) {
+) (*apiv1.Cluster, error) {
 	storageClassName := os.Getenv("E2E_DEFAULT_STORAGE_CLASS")
 	destinationPath := fmt.Sprintf("https://%v.blob.core.windows.net/%v/",
 		azStorageAccount, azBlobContainer)
 
-	restoreCluster := &v1.Cluster{
+	restoreCluster := &apiv1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      externalClusterName,
 			Namespace: namespace,
 		},
-		Spec: v1.ClusterSpec{
+		Spec: apiv1.ClusterSpec{
 			Instances: 3,
 
-			StorageConfiguration: v1.StorageConfiguration{
+			StorageConfiguration: apiv1.StorageConfiguration{
 				Size:         "1Gi",
 				StorageClass: &storageClassName,
 			},
 
-			PostgresConfiguration: v1.PostgresConfiguration{
+			PostgresConfiguration: apiv1.PostgresConfiguration{
 				Parameters: map[string]string{
 					"log_checkpoints":             "on",
 					"log_lock_waits":              "on",
@@ -423,30 +423,30 @@ func CreateClusterFromExternalClusterBackupWithPITROnAzure(
 				},
 			},
 
-			Bootstrap: &v1.BootstrapConfiguration{
-				Recovery: &v1.BootstrapRecovery{
+			Bootstrap: &apiv1.BootstrapConfiguration{
+				Recovery: &apiv1.BootstrapRecovery{
 					Source: sourceClusterName,
-					RecoveryTarget: &v1.RecoveryTarget{
+					RecoveryTarget: &apiv1.RecoveryTarget{
 						TargetTime: targetTime,
 					},
 				},
 			},
 
-			ExternalClusters: []v1.ExternalCluster{
+			ExternalClusters: []apiv1.ExternalCluster{
 				{
 					Name: sourceClusterName,
-					BarmanObjectStore: &v1.BarmanObjectStoreConfiguration{
+					BarmanObjectStore: &apiv1.BarmanObjectStoreConfiguration{
 						DestinationPath: destinationPath,
-						BarmanCredentials: v1.BarmanCredentials{
-							Azure: &v1.AzureCredentials{
-								StorageAccount: &v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+						BarmanCredentials: apiv1.BarmanCredentials{
+							Azure: &apiv1.AzureCredentials{
+								StorageAccount: &apiv1.SecretKeySelector{
+									LocalObjectReference: apiv1.LocalObjectReference{
 										Name: storageCredentialsSecretName,
 									},
 									Key: "ID",
 								},
-								StorageKey: &v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								StorageKey: &apiv1.SecretKeySelector{
+									LocalObjectReference: apiv1.LocalObjectReference{
 										Name: storageCredentialsSecretName,
 									},
 									Key: "KEY",
@@ -462,7 +462,7 @@ func CreateClusterFromExternalClusterBackupWithPITROnAzure(
 	if err != nil {
 		return nil, err
 	}
-	cluster, ok := obj.(*v1.Cluster)
+	cluster, ok := obj.(*apiv1.Cluster)
 	if !ok {
 		return nil, fmt.Errorf("created object is not of type cluster: %T, %v", obj, obj)
 	}
@@ -478,24 +478,24 @@ func CreateClusterFromExternalClusterBackupWithPITROnAzurite(
 	externalClusterName,
 	sourceClusterName,
 	targetTime string,
-) (*v1.Cluster, error) {
+) (*apiv1.Cluster, error) {
 	storageClassName := os.Getenv("E2E_DEFAULT_STORAGE_CLASS")
 	DestinationPath := fmt.Sprintf("https://azurite:10000/storageaccountname/%v", sourceClusterName)
 
-	restoreCluster := &v1.Cluster{
+	restoreCluster := &apiv1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      externalClusterName,
 			Namespace: namespace,
 		},
-		Spec: v1.ClusterSpec{
+		Spec: apiv1.ClusterSpec{
 			Instances: 3,
 
-			StorageConfiguration: v1.StorageConfiguration{
+			StorageConfiguration: apiv1.StorageConfiguration{
 				Size:         "1Gi",
 				StorageClass: &storageClassName,
 			},
 
-			PostgresConfiguration: v1.PostgresConfiguration{
+			PostgresConfiguration: apiv1.PostgresConfiguration{
 				Parameters: map[string]string{
 					"log_checkpoints":             "on",
 					"log_lock_waits":              "on",
@@ -507,30 +507,30 @@ func CreateClusterFromExternalClusterBackupWithPITROnAzurite(
 				},
 			},
 
-			Bootstrap: &v1.BootstrapConfiguration{
-				Recovery: &v1.BootstrapRecovery{
+			Bootstrap: &apiv1.BootstrapConfiguration{
+				Recovery: &apiv1.BootstrapRecovery{
 					Source: sourceClusterName,
-					RecoveryTarget: &v1.RecoveryTarget{
+					RecoveryTarget: &apiv1.RecoveryTarget{
 						TargetTime: targetTime,
 					},
 				},
 			},
 
-			ExternalClusters: []v1.ExternalCluster{
+			ExternalClusters: []apiv1.ExternalCluster{
 				{
 					Name: sourceClusterName,
-					BarmanObjectStore: &v1.BarmanObjectStoreConfiguration{
+					BarmanObjectStore: &apiv1.BarmanObjectStoreConfiguration{
 						DestinationPath: DestinationPath,
-						EndpointCA: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						EndpointCA: &apiv1.SecretKeySelector{
+							LocalObjectReference: apiv1.LocalObjectReference{
 								Name: "azurite-ca-secret",
 							},
 							Key: "ca.crt",
 						},
-						BarmanCredentials: v1.BarmanCredentials{
-							Azure: &v1.AzureCredentials{
-								ConnectionString: &v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+						BarmanCredentials: apiv1.BarmanCredentials{
+							Azure: &apiv1.AzureCredentials{
+								ConnectionString: &apiv1.SecretKeySelector{
+									LocalObjectReference: apiv1.LocalObjectReference{
 										Name: "azurite",
 									},
 									Key: "AZURE_CONNECTION_STRING",
@@ -546,7 +546,7 @@ func CreateClusterFromExternalClusterBackupWithPITROnAzurite(
 	if err != nil {
 		return nil, err
 	}
-	cluster, ok := obj.(*v1.Cluster)
+	cluster, ok := obj.(*apiv1.Cluster)
 	if !ok {
 		return nil, fmt.Errorf("created object is not of type cluster: %T, %v", obj, obj)
 	}

--- a/tests/utils/backups/backup.go
+++ b/tests/utils/backups/backup.go
@@ -24,10 +24,10 @@ import (
 	"fmt"
 	"os"
 
-	v1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
+	volumesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
-	v2 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -74,12 +74,12 @@ func GetVolumeSnapshot(
 	ctx context.Context,
 	crudClient client.Client,
 	namespace, name string,
-) (*v1.VolumeSnapshot, error) {
+) (*volumesnapshotv1.VolumeSnapshot, error) {
 	namespacedName := types.NamespacedName{
 		Namespace: namespace,
 		Name:      name,
 	}
-	volumeSnapshot := &v1.VolumeSnapshot{}
+	volumeSnapshot := &volumesnapshotv1.VolumeSnapshot{}
 	err := objects.Get(ctx, crudClient, namespacedName, volumeSnapshot)
 	if err != nil {
 		return nil, err
@@ -140,7 +140,7 @@ func GetConditionsInClusterStatus(
 	namespace,
 	clusterName string,
 	conditionType apiv1.ClusterConditionType,
-) (*v2.Condition, error) {
+) (*metav1.Condition, error) {
 	var cluster *apiv1.Cluster
 	var err error
 
@@ -242,7 +242,7 @@ func CreateClusterFromBackupUsingPITR(
 	}
 	storageClassName := os.Getenv("E2E_DEFAULT_STORAGE_CLASS")
 	restoreCluster := &apiv1.Cluster{
-		ObjectMeta: v2.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      clusterName,
 			Namespace: namespace,
 		},
@@ -304,7 +304,7 @@ func CreateClusterFromExternalClusterBackupWithPITROnMinio(
 	storageClassName := os.Getenv("E2E_DEFAULT_STORAGE_CLASS")
 
 	restoreCluster := &apiv1.Cluster{
-		ObjectMeta: v2.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      externalClusterName,
 			Namespace: namespace,
 		},
@@ -394,7 +394,7 @@ func CreateOnDemand(
 	method apiv1.BackupMethod,
 ) (*apiv1.Backup, error) {
 	targetBackup := &apiv1.Backup{
-		ObjectMeta: v2.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      backupName,
 			Namespace: namespace,
 		},

--- a/tests/utils/environment/environment.go
+++ b/tests/utils/environment/environment.go
@@ -30,7 +30,7 @@ import (
 	"github.com/cloudnative-pg/machinery/pkg/log"
 	"github.com/cloudnative-pg/machinery/pkg/postgres/version"
 	"github.com/go-logr/logr"
-	storagesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
+	volumesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/thoas/go-funk"
 	corev1 "k8s.io/api/core/v1"
@@ -102,7 +102,7 @@ func NewTestingEnvironment() (*TestingEnvironment, error) {
 	env.Ctx = context.Background()
 	env.Scheme = runtime.NewScheme()
 
-	if err := storagesnapshotv1.AddToScheme(env.Scheme); err != nil {
+	if err := volumesnapshotv1.AddToScheme(env.Scheme); err != nil {
 		return nil, err
 	}
 

--- a/tests/utils/exec/exec.go
+++ b/tests/utils/exec/exec.go
@@ -25,7 +25,7 @@ import (
 	"fmt"
 	"time"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -164,7 +164,7 @@ func Command(
 	ctx context.Context,
 	kubeInterface kubernetes.Interface,
 	restConfig *rest.Config,
-	pod v1.Pod,
+	pod corev1.Pod,
 	containerName string,
 	timeout *time.Duration,
 	command ...string,

--- a/tests/utils/importdb/import_db.go
+++ b/tests/utils/importdb/import_db.go
@@ -26,7 +26,7 @@ import (
 	"os"
 
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -59,7 +59,7 @@ func ImportDatabaseMicroservice(
 	}
 	appUserSecretName := sourceClusterName + apiv1.ApplicationUserSecretSuffix
 	restoreCluster := &apiv1.Cluster{
-		ObjectMeta: v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      importedClusterName,
 			Namespace: namespace,
 		},
@@ -141,7 +141,7 @@ func ImportDatabasesMonolith(
 	}
 	superUserSecretName := sourceClusterName + apiv1.SuperUserSecretSuffix
 	targetCluster := &apiv1.Cluster{
-		ObjectMeta: v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      importedClusterName,
 			Namespace: namespace,
 		},

--- a/tests/utils/namespaces/namespace.go
+++ b/tests/utils/namespaces/namespace.go
@@ -37,7 +37,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
-	v1 "k8s.io/api/events/v1"
+	eventsv1 "k8s.io/api/events/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -376,8 +376,8 @@ func GetEventList(
 	ctx context.Context,
 	crudClient client.Client,
 	namespace string,
-) (*v1.EventList, error) {
-	eventList := &v1.EventList{}
+) (*eventsv1.EventList, error) {
+	eventList := &eventsv1.EventList{}
 	err := crudClient.List(
 		ctx, eventList, client.InNamespace(namespace),
 	)

--- a/tests/utils/nodes/nodes.go
+++ b/tests/utils/nodes/nodes.go
@@ -25,7 +25,7 @@ import (
 	"fmt"
 	"strings"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/clusterutils"
@@ -106,8 +106,8 @@ func UncordonAll(
 func List(
 	ctx context.Context,
 	crudClient client.Client,
-) (*v1.NodeList, error) {
-	nodeList := &v1.NodeList{}
+) (*corev1.NodeList, error) {
+	nodeList := &corev1.NodeList{}
 	err := crudClient.List(ctx, nodeList, client.InNamespace(""))
 	return nodeList, err
 }
@@ -141,20 +141,20 @@ func IsNodeReachable(
 	crudClient client.Client,
 	nodeName string,
 ) (bool, error) {
-	node := &v1.Node{}
+	node := &corev1.Node{}
 	err := crudClient.Get(ctx, client.ObjectKey{Name: nodeName}, node)
 	if err != nil {
 		return false, err
 	}
 	for _, condition := range node.Status.Conditions {
-		if condition.Type == v1.NodeReady && condition.Status == v1.ConditionFalse {
+		if condition.Type == corev1.NodeReady && condition.Status == corev1.ConditionFalse {
 			return false, nil
 		}
 	}
 
 	// check that the node does not have the unreachable taint
 	for _, taint := range node.Spec.Taints {
-		if taint.Key == v1.TaintNodeUnreachable {
+		if taint.Key == corev1.TaintNodeUnreachable {
 			return false, nil
 		}
 	}

--- a/tests/utils/openshift/openshift.go
+++ b/tests/utils/openshift/openshift.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/blang/semver"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -112,7 +112,7 @@ func GetOpenshiftVersion(ctx context.Context, restConfig *rest.Config) (semver.V
 		Group:    "operator.openshift.io",
 		Version:  "v1",
 		Resource: "openshiftcontrollermanagers",
-	}).Get(ctx, "cluster", v1.GetOptions{})
+	}).Get(ctx, "cluster", metav1.GetOptions{})
 	if err != nil {
 		return semver.Version{}, err
 	}

--- a/tests/utils/pods/pod.go
+++ b/tests/utils/pods/pod.go
@@ -29,7 +29,7 @@ import (
 	"time"
 
 	"github.com/avast/retry-go/v4"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes"
@@ -44,8 +44,8 @@ func List(
 	ctx context.Context,
 	crudClient client.Client,
 	namespace string,
-) (*v1.PodList, error) {
-	podList := &v1.PodList{}
+) (*corev1.PodList, error) {
+	podList := &corev1.PodList{}
 	err := objects.List(
 		ctx, crudClient, podList, client.InNamespace(namespace),
 	)
@@ -75,7 +75,7 @@ func Delete(
 func CreateAndWaitForReady(
 	ctx context.Context,
 	crudClient client.Client,
-	pod *v1.Pod,
+	pod *corev1.Pod,
 	timeoutSeconds uint,
 ) error {
 	_, err := objects.Create(ctx, crudClient, pod)
@@ -89,7 +89,7 @@ func CreateAndWaitForReady(
 func waitForReady(
 	ctx context.Context,
 	crudClient client.Client,
-	pod *v1.Pod,
+	pod *corev1.Pod,
 	timeoutSeconds uint,
 ) error {
 	err := retry.Do(
@@ -118,7 +118,7 @@ func Logs(
 	kubeInterface kubernetes.Interface,
 	namespace, podName string,
 ) (string, error) {
-	req := kubeInterface.CoreV1().Pods(namespace).GetLogs(podName, &v1.PodLogOptions{})
+	req := kubeInterface.CoreV1().Pods(namespace).GetLogs(podName, &corev1.PodLogOptions{})
 	podLogs, err := req.Stream(ctx)
 	if err != nil {
 		return "", err
@@ -144,7 +144,7 @@ func Get(
 	ctx context.Context,
 	crudClient client.Client,
 	namespace, podName string,
-) (*v1.Pod, error) {
+) (*corev1.Pod, error) {
 	wrapErr := func(err error) error {
 		return fmt.Errorf("while getting pod '%s/%s': %w", namespace, podName, err)
 	}
@@ -162,7 +162,7 @@ func Get(
 
 // HasLabels verifies that the labels of a pod contain a specified
 // labels map
-func HasLabels(pod v1.Pod, labels map[string]string) bool {
+func HasLabels(pod corev1.Pod, labels map[string]string) bool {
 	podLabels := pod.Labels
 	for k, v := range labels {
 		val, ok := podLabels[k]
@@ -175,7 +175,7 @@ func HasLabels(pod v1.Pod, labels map[string]string) bool {
 
 // HasAnnotations verifies that the annotations of a pod contain a specified
 // annotations map
-func HasAnnotations(pod v1.Pod, annotations map[string]string) bool {
+func HasAnnotations(pod corev1.Pod, annotations map[string]string) bool {
 	podAnnotations := pod.Annotations
 	for k, v := range annotations {
 		val, ok := podAnnotations[k]
@@ -187,7 +187,7 @@ func HasAnnotations(pod v1.Pod, annotations map[string]string) bool {
 }
 
 // HasCondition verifies that a pod has a specified condition
-func HasCondition(pod *v1.Pod, conditionType v1.PodConditionType, status v1.ConditionStatus) bool {
+func HasCondition(pod *corev1.Pod, conditionType corev1.PodConditionType, status corev1.ConditionStatus) bool {
 	for _, cond := range pod.Status.Conditions {
 		if cond.Type == conditionType && cond.Status == status {
 			return true

--- a/tests/utils/postgres/postgres.go
+++ b/tests/utils/postgres/postgres.go
@@ -32,7 +32,7 @@ import (
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	v1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/versions"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/exec"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/objects"
@@ -95,7 +95,7 @@ func GetCurrentTimestamp(
 		namespace,
 		clusterName,
 		AppDBName,
-		v1.ApplicationUserSecretSuffix,
+		apiv1.ApplicationUserSecretSuffix,
 		"select TO_CHAR(CURRENT_TIMESTAMP,'YYYY-MM-DD HH24:MI:SS.US');",
 	)
 	if err != nil {

--- a/tests/utils/storage/storage.go
+++ b/tests/utils/storage/storage.go
@@ -25,7 +25,7 @@ import (
 	"fmt"
 	"os"
 
-	volumesnapshot "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
+	volumesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -116,7 +116,7 @@ type EnvVarsForSnapshots struct {
 // SetSnapshotNameAsEnv sets the names of a PG_DATA, a PG_WAL and a list of PG_TABLESPACE snapshots from a
 // given snapshotList as env variables
 func SetSnapshotNameAsEnv(
-	snapshotList *volumesnapshot.VolumeSnapshotList,
+	snapshotList *volumesnapshotv1.VolumeSnapshotList,
 	backup *apiv1.Backup,
 	envVars EnvVarsForSnapshots,
 ) error {
@@ -170,8 +170,8 @@ func GetSnapshotList(
 	ctx context.Context,
 	crudClient client.Client,
 	namespace string,
-) (*volumesnapshot.VolumeSnapshotList, error) {
-	list := &volumesnapshot.VolumeSnapshotList{}
+) (*volumesnapshotv1.VolumeSnapshotList, error) {
+	list := &volumesnapshotv1.VolumeSnapshotList{}
 	err := crudClient.List(ctx, list, client.InNamespace(namespace))
 
 	return list, err

--- a/tests/utils/utils.go
+++ b/tests/utils/utils.go
@@ -29,7 +29,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	v1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	utils2 "github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/clusterutils"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/run"
@@ -72,7 +72,7 @@ func PrintClusterResources(ctx context.Context, crudClient client.Client, namesp
 		clusterInfo.AddLine("Pod name", pod.Name)
 		clusterInfo.AddLine("Pod phase", pod.Status.Phase)
 		if cluster.Status.InstancesReportedState != nil {
-			if instanceReportState, ok := cluster.Status.InstancesReportedState[v1.PodName(pod.Name)]; ok {
+			if instanceReportState, ok := cluster.Status.InstancesReportedState[apiv1.PodName(pod.Name)]; ok {
 				clusterInfo.AddLine("Is Primary", instanceReportState.IsPrimary)
 				clusterInfo.AddLine("TimeLineID", instanceReportState.TimeLineID)
 				clusterInfo.AddLine("---", "---")


### PR DESCRIPTION
The main goal of this patch is to eliminate all unqualified `v1` aliases.

In multiple places within the code, we import API packages that end with `v1`, all of which are aliased as `v1`. When reading the code, encountering `v1.XxxYyyZzz(...)` makes it unclear which package's functions are being invoked.

In contrast, we have a more consistent naming model in other places, where we use more descriptive names such as `appsv1`, `metav1`, or `corev1`.

This patch implements a linter for the imports of these packages, ensuring that they are consistently imported using the longer, more explanatory names.

A comment in the patch highlights the relevant section.