### PR TITLE
chore: replace utils.MergeMap with maps.Copy

### DIFF
--- a/api/v1/cluster_funcs.go
+++ b/api/v1/cluster_funcs.go
@@ -22,6 +22,7 @@ package v1
 import (
 	"context"
 	"fmt"
+	"maps"
 	"regexp"
 	"slices"
 	"strconv"
@@ -175,8 +176,8 @@ func (st *ServiceAccountTemplate) MergeMetadata(sa *corev1.ServiceAccount) {
 		sa.Annotations = map[string]string{}
 	}
 
-	utils.MergeMap(sa.Labels, st.Metadata.Labels)
-	utils.MergeMap(sa.Annotations, st.Metadata.Annotations)
+	maps.Copy(sa.Labels, st.Metadata.Labels)
+	maps.Copy(sa.Annotations, st.Metadata.Annotations)
 }
 
 // MatchesTopology checks if the two topologies have
@@ -668,7 +669,7 @@ func (cluster *Cluster) GetFixedInheritedAnnotations() map[string]string {
 		return meta.Annotations
 	}
 
-	utils.MergeMap(meta.Annotations, cluster.Spec.InheritedMetadata.Annotations)
+	maps.Copy(meta.Annotations, cluster.Spec.InheritedMetadata.Annotations)
 
 	return meta.Annotations
 }

--- a/internal/controller/cluster_create.go
+++ b/internal/controller/cluster_create.go
@@ -22,6 +22,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"maps"
 	"reflect"
 	"slices"
 	"time"
@@ -437,12 +438,12 @@ func (r *ClusterReconciler) serviceReconciler(
 
 	// we preserve existing labels/annotation that could be added by third parties
 	if !utils.IsMapSubset(livingService.Labels, proposed.Labels) {
-		utils.MergeMap(livingService.Labels, proposed.Labels)
+		maps.Copy(livingService.Labels, proposed.Labels)
 		shouldUpdate = true
 	}
 
 	if !utils.IsMapSubset(livingService.Annotations, proposed.Annotations) {
-		utils.MergeMap(livingService.Annotations, proposed.Annotations)
+		maps.Copy(livingService.Annotations, proposed.Annotations)
 		shouldUpdate = true
 	}
 

--- a/pkg/reconciler/backup/volumesnapshot/reconciler.go
+++ b/pkg/reconciler/backup/volumesnapshot/reconciler.go
@@ -24,6 +24,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"strconv"
 	"time"
 
@@ -459,9 +460,9 @@ func (se *Reconciler) createSnapshot(
 	}
 
 	labels := pvc.Labels
-	utils.MergeMap(labels, snapshotConfig.Labels)
+	maps.Copy(labels, snapshotConfig.Labels)
 	annotations := pvc.Annotations
-	utils.MergeMap(annotations, snapshotConfig.Annotations)
+	maps.Copy(annotations, snapshotConfig.Annotations)
 	transferLabelsToAnnotations(labels, annotations)
 
 	snapshot := storagesnapshotv1.VolumeSnapshot{

--- a/pkg/utils/labels_annotations.go
+++ b/pkg/utils/labels_annotations.go
@@ -21,6 +21,7 @@ package utils
 
 import (
 	"fmt"
+	"maps"
 	"reflect"
 	"strconv"
 	"strings"
@@ -488,19 +489,6 @@ func IsWalArchivingDisabled(object *metav1.ObjectMeta) bool {
 	return object.Annotations[SkipWalArchiving] == string(annotationStatusEnabled)
 }
 
-func mergeMap(receiver, giver map[string]string) map[string]string {
-	for key, value := range giver {
-		receiver[key] = value
-	}
-	return receiver
-}
-
-// MergeMap transfers the content of a giver map to a receiver
-// ensure the receiver is not nil before call this method
-func MergeMap(receiver, giver map[string]string) {
-	_ = mergeMap(receiver, giver)
-}
-
 // GetInstanceRole tries to fetch the ClusterRoleLabelName andClusterInstanceRoleLabelName value from a given labels map
 func GetInstanceRole(labels map[string]string) (string, bool) {
 	if value := labels[ClusterRoleLabelName]; value != "" {
@@ -531,8 +519,8 @@ func MergeObjectsMetadata(receiver client.Object, giver client.Object) {
 		receiver.SetAnnotations(map[string]string{})
 	}
 
-	receiver.SetLabels(mergeMap(receiver.GetLabels(), giver.GetLabels()))
-	receiver.SetAnnotations(mergeMap(receiver.GetAnnotations(), giver.GetAnnotations()))
+	maps.Copy(receiver.GetLabels(), giver.GetLabels())
+	maps.Copy(receiver.GetAnnotations(), giver.GetAnnotations())
 }
 
 // GetClusterSerialValue returns the `nodeSerial` value from the given annotation map or return an error


### PR DESCRIPTION
Remove the implementation of `utils.MergeMap` in favor of `maps.Copy`, which is
now available in the Go standard library.