### PR TITLE
fix: correct Barman Cloud deprecation warning version

### DIFF
--- a/internal/webhook/v1/cluster_webhook.go
+++ b/internal/webhook/v1/cluster_webhook.go
@@ -2600,7 +2600,7 @@ func getInTreeBarmanWarnings(r *apiv1.Cluster) admission.Warnings {
 		result = append(
 			result,
 			fmt.Sprintf("Native support for Barman Cloud backups and recovery is deprecated and will be "+
-				"completely removed in CloudNativePG 1.28.0. Found usage in: %s. "+
+				"completely removed in CloudNativePG 1.29.0. Found usage in: %s. "+
 				"Please migrate existing clusters to the new Barman Cloud Plugin to ensure a smooth transition.",
 				pathsStr),
 		)


### PR DESCRIPTION
Update the warning about the removal of native Barman Cloud to state that it will be removed in version 1.29.0 (instead of 1.28.0).

Closes #8669 