### PR TITLE
feat(pgbouncer): make more auth-related parameters configurable

### DIFF
--- a/docs/src/connection_pooling.md
+++ b/docs/src/connection_pooling.md
@@ -354,11 +354,13 @@ These are the PgBouncer options you can customize, with links to the PgBouncer
 documentation for each parameter. Unless stated otherwise, the default values
 are the ones directly set by PgBouncer.
 
+- [`auth_type`](https://www.pgbouncer.org/config.html#auth_type)
 - [`application_name_add_host`](https://www.pgbouncer.org/config.html#application_name_add_host)
 - [`autodb_idle_timeout`](https://www.pgbouncer.org/config.html#autodb_idle_timeout)
 - [`cancel_wait_timeout`](https://www.pgbouncer.org/config.html#cancel_wait_timeout)
 - [`client_idle_timeout`](https://www.pgbouncer.org/config.html#client_idle_timeout)
 - [`client_login_timeout`](https://www.pgbouncer.org/config.html#client_login_timeout)
+- [`client_tls_sslmode`](https://www.pgbouncer.org/config.html#client_tls_sslmode)
 - [`default_pool_size`](https://www.pgbouncer.org/config.html#default_pool_size)
 - [`disable_pqexec`](https://www.pgbouncer.org/config.html#disable_pqexec)
 - [`dns_max_ttl`](https://www.pgbouncer.org/config.html#dns_max_ttl)
@@ -397,6 +399,7 @@ are the ones directly set by PgBouncer.
 - [`server_round_robin`](https://www.pgbouncer.org/config.html#server_round_robin)
 - [`server_tls_ciphers`](https://www.pgbouncer.org/config.html#server_tls_ciphers)
 - [`server_tls_protocols`](https://www.pgbouncer.org/config.html#server_tls_protocols)
+- [`server_tls_sslmode`](https://www.pgbouncer.org/config.html#server_tls_sslmode)
 - [`stats_period`](https://www.pgbouncer.org/config.html#stats_period)
 - [`suspend_timeout`](https://www.pgbouncer.org/config.html#suspend_timeout)
 - [`tcp_defer_accept`](https://www.pgbouncer.org/config.html#tcp_defer_accept)

--- a/internal/webhook/v1/pooler_webhook.go
+++ b/internal/webhook/v1/pooler_webhook.go
@@ -39,10 +39,12 @@ import (
 // AllowedPgbouncerGenericConfigurationParameters is the list of allowed parameters for PgBouncer
 var AllowedPgbouncerGenericConfigurationParameters = stringset.From([]string{
 	"application_name_add_host",
+	"auth_type",
 	"autodb_idle_timeout",
 	"cancel_wait_timeout",
 	"client_idle_timeout",
 	"client_login_timeout",
+	"client_tls_sslmode",
 	"default_pool_size",
 	"disable_pqexec",
 	"dns_max_ttl",
@@ -78,6 +80,7 @@ var AllowedPgbouncerGenericConfigurationParameters = stringset.From([]string{
 	"server_round_robin",
 	"server_tls_ciphers",
 	"server_tls_protocols",
+	"server_tls_sslmode",
 	"stats_period",
 	"suspend_timeout",
 	"tcp_defer_accept",

--- a/pkg/management/pgbouncer/config/config.go
+++ b/pkg/management/pgbouncer/config/config.go
@@ -110,7 +110,10 @@ var (
 
 	// the PgBouncer parameters we want to have a default different from the default one
 	defaultPgBouncerParameters = map[string]string{
-		"log_stats": "0",
+		"log_stats":          "0",
+		"auth_type":          "hba",
+		"client_tls_sslmode": "prefer",
+		"server_tls_sslmode": "verify-ca",
 		// We are going to append these ignore_startup_parameters to the ones provided by the user,
 		// as we need them to be able to connect using libpq.
 		// See: https://github.com/lib/pq/issues/475
@@ -123,11 +126,8 @@ var (
 		"listen_port":          "5432",
 		"listen_addr":          "*",
 		"admin_users":          PgBouncerAdminUser,
-		"auth_type":            "hba",
 		"auth_hba_file":        ConfigsDir + "/pg_hba.conf",
-		"server_tls_sslmode":   "verify-ca",
 		"server_tls_ca_file":   serverTLSCAPath,
-		"client_tls_sslmode":   "prefer",
 		"client_tls_cert_file": clientTLSCertPath,
 		"client_tls_key_file":  clientTLSKeyPath,
 		"client_tls_ca_file":   clientTLSCAPath,


### PR DESCRIPTION
The operator now allows overriding `auth_type`, `server_tls_sslmode`, and `client_tls_sslmode`, which were previously hardcoded.

Default values remain aligned with the former hardcoded settings, but can be customised when needed.

Closes: #8673
