### PR TITLE
fix(plugin): recognize barman-plugin in `status` command

### DIFF
--- a/internal/cmd/plugin/status/status.go
+++ b/internal/cmd/plugin/status/status.go
@@ -516,7 +516,7 @@ func (fullStatus *PostgresqlStatus) printBackupStatus() {
 
 	fmt.Println(aurora.Green("Continuous Backup status"))
 
-	// Check if barman-cloud plugin is configured
+	// Check if Barman Cloud plugin is configured
 	isBarmanPluginEnabled, barmanObjectName := isBarmanCloudPluginEnabled(cluster)
 
 	if cluster.Spec.Backup == nil && !isBarmanPluginEnabled {
@@ -525,20 +525,20 @@ func (fullStatus *PostgresqlStatus) printBackupStatus() {
 		return
 	}
 
-	// If backup is managed by barman-cloud plugin, inform the user. We assume that the WALArchiving is also managed
-	// by the barman-cloud plugin
+	// If backup is managed by Barman Cloud plugin, inform the user. We assume that the WALArchiving is also managed
+	// by the Barman Cloud plugin
 	// Note: The webhook ensures barmanObjectStore and plugin WAL archiver are mutually exclusive,
 	// so we don't need to check both conditions
 	if isBarmanPluginEnabled {
 		if barmanObjectName == "" {
-			fmt.Println(aurora.Red("Backup is managed by the barman-cloud plugin, " +
+			fmt.Println(aurora.Red("Backup is managed by the Barman Cloud plugin, " +
 				"but 'barmanObjectName' parameter is not configured."))
 			fmt.Println(aurora.Red("Please configure the 'barmanObjectName' parameter in the plugin configuration."))
 			fmt.Println()
 			return
 		}
-		fmt.Println(aurora.Cyan("Backup is managed by the barman-cloud plugin."))
-		arg := fmt.Sprintf("Please check the Barman plugin CRD: '%s' for detailed backup status.", barmanObjectName)
+		fmt.Println(aurora.Cyan("Backup is managed by the Barman Cloud plugin."))
+		arg := fmt.Sprintf("Please check the Barman Cloud plugin CRD: '%s' for detailed backup status.", barmanObjectName)
 		fmt.Println(aurora.Cyan(arg))
 		fmt.Println()
 		return

--- a/internal/cmd/plugin/status/status.go
+++ b/internal/cmd/plugin/status/status.go
@@ -515,17 +515,22 @@ func (fullStatus *PostgresqlStatus) printBackupStatus() {
 	cluster := fullStatus.Cluster
 
 	fmt.Println(aurora.Green("Continuous Backup status"))
-	if cluster.Spec.Backup == nil {
+	if cluster.Spec.Backup == nil && len(cluster.Status.PluginStatus) == 0 {
 		fmt.Println(aurora.Yellow("Not configured"))
 		fmt.Println()
 		return
 	}
 	status := tabby.New()
-	FPoR := cluster.Status.FirstRecoverabilityPoint //nolint:staticcheck
-	if FPoR == "" {
-		FPoR = "Not Available"
+	// FirstRecoverabilityPoint is deprecated and will be removed together
+	// with native Barman Cloud support. It is only shown when the backup
+	// section is not empty.
+	if cluster.Spec.Backup != nil {
+		FPoR := cluster.Status.FirstRecoverabilityPoint //nolint:staticcheck
+		if FPoR == "" {
+			FPoR = "Not Available"
+		}
+		status.AddLine("First Point of Recoverability:", FPoR)
 	}
-	status.AddLine("First Point of Recoverability:", FPoR)
 
 	primaryInstanceStatus := fullStatus.tryGetPrimaryInstance()
 	if primaryInstanceStatus == nil {


### PR DESCRIPTION
The `status` command previously interrupted the display of continuous backup information when `.spec.backup` was empty. It now also checks that the plugin list is empty before doing so.

The first recoverability point is shown only if `.spec.backup` is present.

Closes #8276
See [plugin-barman-cloud #541](https://github.com/cloudnative-pg/plugin-barman-cloud/issues/541)