### PR TITLE
ci: shorten the matrix.id of E2E jobs

### DIFF
--- a/.github/e2e-matrix-generator.py
+++ b/.github/e2e-matrix-generator.py
@@ -177,9 +177,10 @@ class E2EJob(dict):
     def __init__(self, k8s_version, postgres_version_list, flavor):
         postgres_version = postgres_version_list.latest
         postgres_version_pre = postgres_version_list.oldest
+        short_postgres_version = postgres_version.split('-')[0]
 
         if flavor == "pg":
-            name = f"{k8s_version}-PostgreSQL-{postgres_version}"
+            name = f"{k8s_version}-PostgreSQL-{short_postgres_version}"
             repo = POSTGRES_REPO
             kind = "PostgreSQL"
 

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -1656,7 +1656,7 @@ jobs:
           # and must be no longer than 40 characters
           # We need to shorten the name and lower the case
           SHORT_ID=$( echo ${{ matrix.id }} | tr -d '_.-' | tr '[:upper:]' '[:lower:]')
-          echo "CLUSTER_NAME=${{ env.E2E_SUFFIX }}-test-${{ github.run_number }}-${SHORT_ID}" >> $GITHUB_ENV
+          echo "CLUSTER_NAME=${{ env.E2E_SUFFIX }}-${{ github.run_number }}-${SHORT_ID}" >> $GITHUB_ENV
       -
         name: Authenticate to Google Cloud
         id: 'auth'


### PR DESCRIPTION
Recently we updated the E2E's PostgreSQL version to use tags that contain the imageType and os.
As a result, the ID of each job generated by `.github/e2e-matrix-generator.py` now is even longer,
and some Cloud Providers have a maximum length for Cluster names.  

Closes #8714 