### PR TITLE
test(e2e): install CRDs required by rook v1.18

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -983,6 +983,7 @@ jobs:
             kubectl apply -f ${ROOK_BASE_URL}/crds.yaml
             kubectl apply -f ${ROOK_BASE_URL}/common.yaml
             kubectl apply -f ${ROOK_BASE_URL}/operator.yaml
+            kubectl apply -f ${ROOK_BASE_URL}/csi-operator.yaml
             curl ${ROOK_BASE_URL}/cluster-on-pvc.yaml | \
               sed '/^ *#/d;/^ *$/d' | \
               yq e ".spec.storage.storageClassDeviceSets[].volumeClaimTemplates[].spec.resources.requests.storage = \"50Gi\" |


### PR DESCRIPTION
On v1.18, our CephCluster would fail with:
no matches for kind "CephConnection" in version "csi.ceph.io/v1". 
Installing the "csi-operator.yaml" which contains the missing CRDs.

Closes #8715 