### PR TITLE
fix(.devcontainer): disable moby feature for trixie

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,9 @@
 {
   "image": "mcr.microsoft.com/devcontainers/go:2-1.25-trixie",
   "features": {
-    "ghcr.io/devcontainers/features/docker-in-docker:2": {},
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {
+      "moby": false
+    },
     "ghcr.io/mpriscella/features/kind:1": {},
     "ghcr.io/rjfmachado/devcontainer-features/cloud-native:1": {
       "kubectl": "latest",


### PR DESCRIPTION
Set moby to false given that it's no longer available in trixie distribution.

Without this patch the .devcontainer will fail to start due to the following error:

```
0.270 (!) The 'moby' option is not supported on Debian 'trixie' because 'moby-cli' and related system packages have been removed from that distribution.
0.270 (!) To continue, either set the feature option '"moby": false' or use a different base image (for example: 'debian:bookworm' or 'ubuntu-24.04').
0.270 ERROR: Feature "Docker (Docker-in-Docker)" (ghcr.io/devcontainers/features/docker-in-docker) failed to install! Look at the documentation at https://github.com/devcontainers/features/tree/main/src/docker-in-docker for help troubleshooting this error.
```

# Notes

- not sure if it should be backported