### PR TITLE
chore: deprecate `monitoring.enablePodMonitor` in Cluster and Pooler

### DIFF
--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -2197,8 +2197,8 @@ type MonitoringConfiguration struct {
 	// Enable or disable the `PodMonitor`
 	// +kubebuilder:default:=false
 	//
-	// Deprecated: Will be removed in future releases, create a PodMonitor manually instead,
-	// if needed.
+	// Deprecated: This feature will be removed in an upcoming release. If
+	// you need this functionality, you can create a PodMonitor manually.
 	// +optional
 	EnablePodMonitor bool `json:"enablePodMonitor,omitempty"`
 

--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -2211,6 +2211,7 @@ type MonitoringConfiguration struct {
 	//
 	// Deprecated: This feature will be removed in an upcoming release. If
 	// you need this functionality, you can create a PodMonitor manually.
+	// +optional
 	PodMonitorMetricRelabelConfigs []monitoringv1.RelabelConfig `json:"podMonitorMetricRelabelings,omitempty"`
 
 	// The list of relabelings for the `PodMonitor`. Applied to samples before scraping.

--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -2208,10 +2208,15 @@ type MonitoringConfiguration struct {
 	TLSConfig *ClusterMonitoringTLSConfiguration `json:"tls,omitempty"`
 
 	// The list of metric relabelings for the `PodMonitor`. Applied to samples before ingestion.
-	// +optional
+	//
+	// Deprecated: This feature will be removed in an upcoming release. If
+	// you need this functionality, you can create a PodMonitor manually.
 	PodMonitorMetricRelabelConfigs []monitoringv1.RelabelConfig `json:"podMonitorMetricRelabelings,omitempty"`
 
 	// The list of relabelings for the `PodMonitor`. Applied to samples before scraping.
+	//
+	// Deprecated: This feature will be removed in an upcoming release. If
+	// you need this functionality, you can create a PodMonitor manually.
 	// +optional
 	PodMonitorRelabelConfigs []monitoringv1.RelabelConfig `json:"podMonitorRelabelings,omitempty"`
 }

--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -2196,6 +2196,9 @@ type MonitoringConfiguration struct {
 
 	// Enable or disable the `PodMonitor`
 	// +kubebuilder:default:=false
+	//
+	// Deprecated: Will be removed in future releases, create a PodMonitor manually instead,
+	// if needed.
 	// +optional
 	EnablePodMonitor bool `json:"enablePodMonitor,omitempty"`
 

--- a/api/v1/pooler_types.go
+++ b/api/v1/pooler_types.go
@@ -104,6 +104,9 @@ type PoolerSpec struct {
 type PoolerMonitoringConfiguration struct {
 	// Enable or disable the `PodMonitor`
 	// +kubebuilder:default:=false
+	//
+	// Deprecated: Will be removed in future releases, create a PodMonitor manually instead,
+	// if needed.
 	// +optional
 	EnablePodMonitor bool `json:"enablePodMonitor,omitempty"`
 

--- a/api/v1/pooler_types.go
+++ b/api/v1/pooler_types.go
@@ -88,6 +88,9 @@ type PoolerSpec struct {
 	DeploymentStrategy *appsv1.DeploymentStrategy `json:"deploymentStrategy,omitempty"`
 
 	// The configuration of the monitoring infrastructure of this pooler.
+	//
+	// Deprecated: This feature will be removed in an upcoming release. If
+	// you need this functionality, you can create a PodMonitor manually.
 	// +optional
 	Monitoring *PoolerMonitoringConfiguration `json:"monitoring,omitempty"`
 
@@ -104,9 +107,6 @@ type PoolerSpec struct {
 type PoolerMonitoringConfiguration struct {
 	// Enable or disable the `PodMonitor`
 	// +kubebuilder:default:=false
-	//
-	// Deprecated: This feature will be removed in an upcoming release. If
-	// you need this functionality, you can create a PodMonitor manually.
 	// +optional
 	EnablePodMonitor bool `json:"enablePodMonitor,omitempty"`
 

--- a/api/v1/pooler_types.go
+++ b/api/v1/pooler_types.go
@@ -105,8 +105,8 @@ type PoolerMonitoringConfiguration struct {
 	// Enable or disable the `PodMonitor`
 	// +kubebuilder:default:=false
 	//
-	// Deprecated: Will be removed in future releases, create a PodMonitor manually instead,
-	// if needed.
+	// Deprecated: This feature will be removed in an upcoming release. If
+	// you need this functionality, you can create a PodMonitor manually.
 	// +optional
 	EnablePodMonitor bool `json:"enablePodMonitor,omitempty"`
 

--- a/config/crd/bases/postgresql.cnpg.io_clusters.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_clusters.yaml
@@ -3831,7 +3831,11 @@ spec:
                     type: boolean
                   enablePodMonitor:
                     default: false
-                    description: Enable or disable the `PodMonitor`
+                    description: |-
+                      Enable or disable the `PodMonitor`
+
+                      Deprecated: Will be removed in future releases, create a PodMonitor manually instead,
+                      if needed.
                     type: boolean
                   podMonitorMetricRelabelings:
                     description: The list of metric relabelings for the `PodMonitor`.

--- a/config/crd/bases/postgresql.cnpg.io_clusters.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_clusters.yaml
@@ -3838,8 +3838,11 @@ spec:
                       you need this functionality, you can create a PodMonitor manually.
                     type: boolean
                   podMonitorMetricRelabelings:
-                    description: The list of metric relabelings for the `PodMonitor`.
-                      Applied to samples before ingestion.
+                    description: |-
+                      The list of metric relabelings for the `PodMonitor`. Applied to samples before ingestion.
+
+                      Deprecated: This feature will be removed in an upcoming release. If
+                      you need this functionality, you can create a PodMonitor manually.
                     items:
                       description: |-
                         RelabelConfig allows dynamic rewriting of the label set for targets, alerts,
@@ -3926,8 +3929,11 @@ spec:
                       type: object
                     type: array
                   podMonitorRelabelings:
-                    description: The list of relabelings for the `PodMonitor`. Applied
-                      to samples before scraping.
+                    description: |-
+                      The list of relabelings for the `PodMonitor`. Applied to samples before scraping.
+
+                      Deprecated: This feature will be removed in an upcoming release. If
+                      you need this functionality, you can create a PodMonitor manually.
                     items:
                       description: |-
                         RelabelConfig allows dynamic rewriting of the label set for targets, alerts,

--- a/config/crd/bases/postgresql.cnpg.io_clusters.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_clusters.yaml
@@ -3834,8 +3834,8 @@ spec:
                     description: |-
                       Enable or disable the `PodMonitor`
 
-                      Deprecated: Will be removed in future releases, create a PodMonitor manually instead,
-                      if needed.
+                      Deprecated: This feature will be removed in an upcoming release. If
+                      you need this functionality, you can create a PodMonitor manually.
                     type: boolean
                   podMonitorMetricRelabelings:
                     description: The list of metric relabelings for the `PodMonitor`.

--- a/config/crd/bases/postgresql.cnpg.io_poolers.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_poolers.yaml
@@ -124,8 +124,8 @@ spec:
                     description: |-
                       Enable or disable the `PodMonitor`
 
-                      Deprecated: Will be removed in future releases, create a PodMonitor manually instead,
-                      if needed.
+                      Deprecated: This feature will be removed in an upcoming release. If
+                      you need this functionality, you can create a PodMonitor manually.
                     type: boolean
                   podMonitorMetricRelabelings:
                     description: The list of metric relabelings for the `PodMonitor`.

--- a/config/crd/bases/postgresql.cnpg.io_poolers.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_poolers.yaml
@@ -121,7 +121,11 @@ spec:
                 properties:
                   enablePodMonitor:
                     default: false
-                    description: Enable or disable the `PodMonitor`
+                    description: |-
+                      Enable or disable the `PodMonitor`
+
+                      Deprecated: Will be removed in future releases, create a PodMonitor manually instead,
+                      if needed.
                     type: boolean
                   podMonitorMetricRelabelings:
                     description: The list of metric relabelings for the `PodMonitor`.

--- a/config/crd/bases/postgresql.cnpg.io_poolers.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_poolers.yaml
@@ -116,16 +116,15 @@ spec:
                 format: int32
                 type: integer
               monitoring:
-                description: The configuration of the monitoring infrastructure of
-                  this pooler.
+                description: |-
+                  The configuration of the monitoring infrastructure of this pooler.
+
+                  Deprecated: This feature will be removed in an upcoming release. If
+                  you need this functionality, you can create a PodMonitor manually.
                 properties:
                   enablePodMonitor:
                     default: false
-                    description: |-
-                      Enable or disable the `PodMonitor`
-
-                      Deprecated: This feature will be removed in an upcoming release. If
-                      you need this functionality, you can create a PodMonitor manually.
+                    description: Enable or disable the `PodMonitor`
                     type: boolean
                   podMonitorMetricRelabelings:
                     description: The list of metric relabelings for the `PodMonitor`.

--- a/docs/src/cloudnative-pg.v1.md
+++ b/docs/src/cloudnative-pg.v1.md
@@ -3967,8 +3967,8 @@ Default: false.</p>
 </td>
 <td>
    <p>Enable or disable the <code>PodMonitor</code></p>
-<p>Deprecated: Will be removed in future releases, create a PodMonitor manually instead,
-if needed.</p>
+<p>Deprecated: This feature will be removed in an upcoming release. If
+you need this functionality, you can create a PodMonitor manually.</p>
 </td>
 </tr>
 <tr><td><code>tls</code><br/>
@@ -4512,8 +4512,8 @@ part for now.</p>
 </td>
 <td>
    <p>Enable or disable the <code>PodMonitor</code></p>
-<p>Deprecated: Will be removed in future releases, create a PodMonitor manually instead,
-if needed.</p>
+<p>Deprecated: This feature will be removed in an upcoming release. If
+you need this functionality, you can create a PodMonitor manually.</p>
 </td>
 </tr>
 <tr><td><code>podMonitorMetricRelabelings</code><br/>

--- a/docs/src/cloudnative-pg.v1.md
+++ b/docs/src/cloudnative-pg.v1.md
@@ -3967,6 +3967,8 @@ Default: false.</p>
 </td>
 <td>
    <p>Enable or disable the <code>PodMonitor</code></p>
+<p>Deprecated: Will be removed in future releases, create a PodMonitor manually instead,
+if needed.</p>
 </td>
 </tr>
 <tr><td><code>tls</code><br/>
@@ -4510,6 +4512,8 @@ part for now.</p>
 </td>
 <td>
    <p>Enable or disable the <code>PodMonitor</code></p>
+<p>Deprecated: Will be removed in future releases, create a PodMonitor manually instead,
+if needed.</p>
 </td>
 </tr>
 <tr><td><code>podMonitorMetricRelabelings</code><br/>

--- a/docs/src/cloudnative-pg.v1.md
+++ b/docs/src/cloudnative-pg.v1.md
@@ -3979,7 +3979,7 @@ you need this functionality, you can create a PodMonitor manually.</p>
 Changing tls.enabled option will force a rollout of all instances.</p>
 </td>
 </tr>
-<tr><td><code>podMonitorMetricRelabelings</code> <B>[Required]</B><br/>
+<tr><td><code>podMonitorMetricRelabelings</code><br/>
 <a href="https://pkg.go.dev/github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1#RelabelConfig"><i>[]github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1.RelabelConfig</i></a>
 </td>
 <td>

--- a/docs/src/cloudnative-pg.v1.md
+++ b/docs/src/cloudnative-pg.v1.md
@@ -3979,11 +3979,13 @@ you need this functionality, you can create a PodMonitor manually.</p>
 Changing tls.enabled option will force a rollout of all instances.</p>
 </td>
 </tr>
-<tr><td><code>podMonitorMetricRelabelings</code><br/>
+<tr><td><code>podMonitorMetricRelabelings</code> <B>[Required]</B><br/>
 <a href="https://pkg.go.dev/github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1#RelabelConfig"><i>[]github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1.RelabelConfig</i></a>
 </td>
 <td>
    <p>The list of metric relabelings for the <code>PodMonitor</code>. Applied to samples before ingestion.</p>
+<p>Deprecated: This feature will be removed in an upcoming release. If
+you need this functionality, you can create a PodMonitor manually.</p>
 </td>
 </tr>
 <tr><td><code>podMonitorRelabelings</code><br/>
@@ -3991,6 +3993,8 @@ Changing tls.enabled option will force a rollout of all instances.</p>
 </td>
 <td>
    <p>The list of relabelings for the <code>PodMonitor</code>. Applied to samples before scraping.</p>
+<p>Deprecated: This feature will be removed in an upcoming release. If
+you need this functionality, you can create a PodMonitor manually.</p>
 </td>
 </tr>
 </tbody>
@@ -4512,8 +4516,6 @@ part for now.</p>
 </td>
 <td>
    <p>Enable or disable the <code>PodMonitor</code></p>
-<p>Deprecated: This feature will be removed in an upcoming release. If
-you need this functionality, you can create a PodMonitor manually.</p>
 </td>
 </tr>
 <tr><td><code>podMonitorMetricRelabelings</code><br/>
@@ -4640,6 +4642,8 @@ Pooler name should never match with any cluster name within the same namespace.<
 </td>
 <td>
    <p>The configuration of the monitoring infrastructure of this pooler.</p>
+<p>Deprecated: This feature will be removed in an upcoming release. If
+you need this functionality, you can create a PodMonitor manually.</p>
 </td>
 </tr>
 <tr><td><code>serviceTemplate</code><br/>

--- a/docs/src/connection_pooling.md
+++ b/docs/src/connection_pooling.md
@@ -609,18 +609,10 @@ cnpg_pgbouncer_stats_total_xact_time{database="pgbouncer"} 0
     For a better understanding of the metrics please refer to the PgBouncer documentation.
 
 As for clusters, a specific pooler can be monitored using the
-[Prometheus operator's](https://github.com/prometheus-operator/prometheus-operator) resource
-[PodMonitor](https://github.com/prometheus-operator/prometheus-operator/blob/v0.47.1/Documentation/api.md#podmonitor).
-A `PodMonitor` correctly pointing to a pooler can be created by the operator by setting
-`.spec.monitoring.enablePodMonitor` to `true` in the `Pooler` resource. The default is `false`.
+[Prometheus operator's](https://github.com/prometheus-operator/prometheus-operator)
+[`PodMonitor` resource](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#monitoring.coreos.com/v1.PodMonitor).
 
-!!! Important
-    Any change to `PodMonitor` created automatically is overridden by the
-    operator at the next reconciliation cycle. If you need to customize it, you can
-    do so as shown in the following example.
-
-To deploy a `PodMonitor` for a specific pooler manually, you can define it as
-follows and change it as needed:
+You can deploy a `PodMonitor` for a specific pooler using the following basic example, and change it as needed:
 
 ```yaml
 apiVersion: monitoring.coreos.com/v1
@@ -634,6 +626,18 @@ spec:
   podMetricsEndpoints:
   - port: metrics
 ```
+
+### Deprecation of Automatic `PodMonitor` Creation
+
+!!!warning "Feature Deprecation Notice"
+    The `.spec.monitoring.enablePodMonitor` field in the `Pooler` resource is
+    now deprecated and will be removed in a future version of the operator.
+
+If you are currently using this feature, we strongly recommend you either
+remove or set `.spec.monitoring.enablePodMonitor` to `false` and manually
+create a `PodMonitor` resource for your pooler as described above.
+This change ensures that you have complete ownership of your monitoring
+configuration, preventing it from being managed or overwritten by the operator.
 
 ## Logging
 

--- a/docs/src/monitoring.md
+++ b/docs/src/monitoring.md
@@ -57,18 +57,19 @@ by specifying a list of one or more databases in the `target_databases` option.
 
 ### Monitoring with the Prometheus operator
 
-A specific PostgreSQL cluster can be monitored using the
-[Prometheus Operator's](https://github.com/prometheus-operator/prometheus-operator) resource
-[PodMonitor](https://github.com/prometheus-operator/prometheus-operator/blob/v0.75.1/Documentation/api.md#podmonitor).
+You can monitor a specific PostgreSQL cluster using the
+[Prometheus Operator's](https://github.com/prometheus-operator/prometheus-operator)
+[`PodMonitor` resource](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#monitoring.coreos.com/v1.PodMonitor).
 
-A `PodMonitor` that correctly points to the Cluster can be automatically created by the operator by setting
-`.spec.monitoring.enablePodMonitor` to `true` in the Cluster resource itself (default: `false`).
+The recommended approach is to manually create and manage a `PodMonitor` for
+each CloudNativePG cluster. This method provides you with full control over the
+monitoring configuration and lifecycle.
 
-!!! Important
-    Any change to the `PodMonitor` created automatically will be overridden by the Operator at the next reconciliation
-    cycle, in case you need to customize it, you can do so as described below.
+#### Creating a `PodMonitor`
 
-To deploy a `PodMonitor` for a specific Cluster manually, define it as follows and adjust as needed:
+To monitor your cluster, define a `PodMonitor` resource as follows. Be sure to
+deploy it in the same namespace where your Prometheus Operator is configured to
+find `PodMonitor` resources.
 
 ```yaml
 apiVersion: monitoring.coreos.com/v1
@@ -78,19 +79,29 @@ metadata:
 spec:
   selector:
     matchLabels:
-      "cnpg.io/cluster": cluster-example
+      cnpg.io/cluster: cluster-example
   podMetricsEndpoints:
   - port: metrics
 ```
 
-!!! Important
-    Ensure you modify the example above with a unique name, as well as the
-    correct cluster's namespace and labels (e.g., `cluster-example`).
+!!! important "Important Configuration Details"
+    - `metadata.name`: Give your `PodMonitor` a unique name.
+    - `spec.namespaceSelector`: Use this to specify the namespace where
+      your PostgreSQL cluster is running.
+    - `spec.selector.matchLabels`: You must use the `cnpg.io/cluster: <cluster-name>`
+      label to correctly target the PostgreSQL instances.
 
-!!! Important
-    The `postgresql` label, used in previous versions of this document, is deprecated
-    and will be removed in the future. Please use the `cnpg.io/cluster` label
-    instead to select the instances.
+#### Deprecation of Automatic `PodMonitor` Creation
+
+!!!warning "Feature Deprecation Notice"
+    The `.spec.monitoring.enablePodMonitor` field in the `Cluster` resource is
+    now deprecated and will be removed in a future version of the operator.
+
+If you are currently using this feature, we strongly recommend you either
+remove or set `.spec.monitoring.enablePodMonitor` to `false` and manually
+create a `PodMonitor` resource for your cluster as described above.
+This change ensures that you have complete ownership of your monitoring
+configuration, preventing it from being managed or overwritten by the operator.
 
 ### Enabling TLS on the Metrics Port
 
@@ -799,7 +810,7 @@ metadata:
 spec:
   containers:
   - name: curl
-    image: curlimages/curl:8.2.1
+    image: curlimages/curl:8.16.0
     command: ['sleep', '3600']
 EOF
 ```

--- a/docs/src/quickstart.md
+++ b/docs/src/quickstart.md
@@ -255,9 +255,17 @@ spec:
 
   storage:
     size: 1Gi
-
-  monitoring:
-    enablePodMonitor: true
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: cluster-with-metrics
+spec:
+  selector:
+    matchLabels:
+      cnpg.io/cluster: cluster-with-metrics
+  podMetricsEndpoints:
+  - port: metrics
 EOF
 ```
 

--- a/docs/src/samples/cluster-example-monitoring.yaml
+++ b/docs/src/samples/cluster-example-monitoring.yaml
@@ -9,13 +9,23 @@ spec:
     size: 1Gi
 
   monitoring:
-    enablePodMonitor: true
     customQueriesConfigMap:
       - name: example-monitoring
         key: custom-queries
     customQueriesSecret:
       - name: example-monitoring-secret
         key: pg-database
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: cluster-example
+spec:
+  selector:
+    matchLabels:
+      cnpg.io/cluster: cluster-example
+  podMetricsEndpoints:
+  - port: metrics
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/internal/webhook/v1/cluster_webhook.go
+++ b/internal/webhook/v1/cluster_webhook.go
@@ -2640,19 +2640,20 @@ func getDeprecatedMonitoringFieldsWarnings(r *apiv1.Cluster) admission.Warnings 
 		if r.Spec.Monitoring.EnablePodMonitor {
 			result = append(result,
 				"spec.monitoring.enablePodMonitor is deprecated and will be removed in a future release. "+
-					"Create a PodMonitor manually instead, if needed.")
+					"Please migrate to manually managing your PodMonitor resources. "+
+					"Set this field to false and create a PodMonitor resource for your cluster as described in the documentation.")
 		}
 		//nolint:staticcheck // Checking deprecated fields to warn users
 		if len(r.Spec.Monitoring.PodMonitorMetricRelabelConfigs) > 0 {
 			result = append(result,
 				"spec.monitoring.podMonitorMetricRelabelings is deprecated and will be removed in a future release. "+
-					"Create a PodMonitor manually instead, if needed.")
+					"Please migrate to manually managing your PodMonitor resources with custom relabeling configurations.")
 		}
 		//nolint:staticcheck // Checking deprecated fields to warn users
 		if len(r.Spec.Monitoring.PodMonitorRelabelConfigs) > 0 {
 			result = append(result,
 				"spec.monitoring.podMonitorRelabelings is deprecated and will be removed in a future release. "+
-					"Create a PodMonitor manually instead, if needed.")
+					"Please migrate to manually managing your PodMonitor resources with custom relabeling configurations.")
 		}
 	}
 

--- a/internal/webhook/v1/cluster_webhook.go
+++ b/internal/webhook/v1/cluster_webhook.go
@@ -2518,7 +2518,8 @@ func (v *ClusterCustomValidator) getAdmissionWarnings(r *apiv1.Cluster) admissio
 	list = append(list, getInTreeBarmanWarnings(r)...)
 	list = append(list, getRetentionPolicyWarnings(r)...)
 	list = append(list, getStorageWarnings(r)...)
-	return append(list, getSharedBuffersWarnings(r)...)
+	list = append(list, getSharedBuffersWarnings(r)...)
+	return append(list, getDeprecatedMonitoringFieldsWarnings(r)...)
 }
 
 func getStorageWarnings(r *apiv1.Cluster) admission.Warnings {
@@ -2628,6 +2629,33 @@ func getSharedBuffersWarnings(r *apiv1.Cluster) admission.Warnings {
 			)
 		}
 	}
+	return result
+}
+
+func getDeprecatedMonitoringFieldsWarnings(r *apiv1.Cluster) admission.Warnings {
+	var result admission.Warnings
+
+	if r.Spec.Monitoring != nil {
+		//nolint:staticcheck // Checking deprecated fields to warn users
+		if r.Spec.Monitoring.EnablePodMonitor {
+			result = append(result,
+				"spec.monitoring.enablePodMonitor is deprecated and will be removed in a future release. "+
+					"Create a PodMonitor manually instead, if needed.")
+		}
+		//nolint:staticcheck // Checking deprecated fields to warn users
+		if len(r.Spec.Monitoring.PodMonitorMetricRelabelConfigs) > 0 {
+			result = append(result,
+				"spec.monitoring.podMonitorMetricRelabelings is deprecated and will be removed in a future release. "+
+					"Create a PodMonitor manually instead, if needed.")
+		}
+		//nolint:staticcheck // Checking deprecated fields to warn users
+		if len(r.Spec.Monitoring.PodMonitorRelabelConfigs) > 0 {
+			result = append(result,
+				"spec.monitoring.podMonitorRelabelings is deprecated and will be removed in a future release. "+
+					"Create a PodMonitor manually instead, if needed.")
+		}
+	}
+
 	return result
 }
 

--- a/internal/webhook/v1/pooler_webhook.go
+++ b/internal/webhook/v1/pooler_webhook.go
@@ -267,8 +267,8 @@ func (v *PoolerCustomValidator) validatePgbouncerGenericParameters(r *apiv1.Pool
 func (v *PoolerCustomValidator) validateDeprecatedMonitoringFields(r *apiv1.Pooler) admission.Warnings {
 	var warns admission.Warnings
 
+	//nolint:staticcheck // Checking deprecated fields to warn users
 	if r.Spec.Monitoring != nil {
-		//nolint:staticcheck // Checking deprecated fields to warn users
 		if r.Spec.Monitoring.EnablePodMonitor ||
 			len(r.Spec.Monitoring.PodMonitorMetricRelabelConfigs) > 0 ||
 			len(r.Spec.Monitoring.PodMonitorRelabelConfigs) > 0 {

--- a/internal/webhook/v1/pooler_webhook.go
+++ b/internal/webhook/v1/pooler_webhook.go
@@ -273,7 +273,7 @@ func (v *PoolerCustomValidator) validateDeprecatedMonitoringFields(r *apiv1.Pool
 			len(r.Spec.Monitoring.PodMonitorMetricRelabelConfigs) > 0 ||
 			len(r.Spec.Monitoring.PodMonitorRelabelConfigs) > 0 {
 			warns = append(warns, "spec.monitoring is deprecated and will be removed in a future release. "+
-				"Create a PodMonitor manually instead, if needed.")
+				"Set this field to false and create a PodMonitor resource for your pooler as described in the documentation")
 		}
 	}
 

--- a/pkg/specs/pgbouncer/deployments_test.go
+++ b/pkg/specs/pgbouncer/deployments_test.go
@@ -62,6 +62,7 @@ var _ = Describe("Deployment", func() {
 				DeploymentStrategy: &appsv1.DeploymentStrategy{
 					Type: appsv1.RollingUpdateDeploymentStrategyType,
 				},
+				//nolint:staticcheck // Using deprecated type during deprecation period
 				Monitoring: &apiv1.PoolerMonitoringConfiguration{
 					EnablePodMonitor: true,
 				},

--- a/pkg/specs/pgbouncer/podmonitor.go
+++ b/pkg/specs/pgbouncer/podmonitor.go
@@ -39,6 +39,7 @@ func NewPoolerPodMonitorManager(pooler *apiv1.Pooler) *PoolerPodMonitorManager {
 
 // IsPodMonitorEnabled returns a boolean indicating if the PodMonitor should exists or not
 func (c PoolerPodMonitorManager) IsPodMonitorEnabled() bool {
+	//nolint:staticcheck
 	return c.pooler.Spec.Monitoring != nil && c.pooler.Spec.Monitoring.EnablePodMonitor
 }
 

--- a/pkg/specs/pgbouncer/podmonitor.go
+++ b/pkg/specs/pgbouncer/podmonitor.go
@@ -60,6 +60,7 @@ func (c PoolerPodMonitorManager) BuildPodMonitor() *monitoringv1.PodMonitor {
 		Port: &metricsPort,
 	}
 
+	//nolint:staticcheck // Using deprecated fields during deprecation period
 	if c.pooler.Spec.Monitoring != nil {
 		endpoint.MetricRelabelConfigs = c.pooler.Spec.Monitoring.PodMonitorMetricRelabelConfigs
 		endpoint.RelabelConfigs = c.pooler.Spec.Monitoring.PodMonitorRelabelConfigs

--- a/pkg/specs/pgbouncer/podmonitor_test.go
+++ b/pkg/specs/pgbouncer/podmonitor_test.go
@@ -56,6 +56,7 @@ var _ = Describe("PoolerPodMonitorManager", func() {
 
 			Expect(manager.IsPodMonitorEnabled()).To(BeFalse())
 
+			//nolint:staticcheck
 			pooler.Spec.Monitoring.EnablePodMonitor = true
 			Expect(manager.IsPodMonitorEnabled()).To(BeTrue())
 		})
@@ -63,6 +64,7 @@ var _ = Describe("PoolerPodMonitorManager", func() {
 
 	Context("when calling BuildPodMonitor", func() {
 		BeforeEach(func() {
+			//nolint:staticcheck
 			pooler.Spec.Monitoring.EnablePodMonitor = true
 		})
 

--- a/pkg/specs/pgbouncer/podmonitor_test.go
+++ b/pkg/specs/pgbouncer/podmonitor_test.go
@@ -43,6 +43,7 @@ var _ = Describe("PoolerPodMonitorManager", func() {
 				Namespace: "test-namespace",
 			},
 			Spec: apiv1.PoolerSpec{
+				//nolint:staticcheck // Using deprecated type during deprecation period
 				Monitoring: &apiv1.PoolerMonitoringConfiguration{
 					EnablePodMonitor: false,
 				},

--- a/pkg/specs/podmonitor.go
+++ b/pkg/specs/podmonitor.go
@@ -72,7 +72,9 @@ func (c ClusterPodMonitorManager) BuildPodMonitor() *monitoringv1.PodMonitor {
 	}
 
 	if c.cluster.Spec.Monitoring != nil {
+		//nolint:staticcheck // Using deprecated fields during deprecation period
 		endpoint.MetricRelabelConfigs = c.cluster.Spec.Monitoring.PodMonitorMetricRelabelConfigs
+		//nolint:staticcheck // Using deprecated fields during deprecation period
 		endpoint.RelabelConfigs = c.cluster.Spec.Monitoring.PodMonitorRelabelConfigs
 	}
 

--- a/pkg/specs/podmonitor_test.go
+++ b/pkg/specs/podmonitor_test.go
@@ -78,6 +78,7 @@ var _ = Describe("PodMonitor test", func() {
 
 		It("should create a monitoringv1.PodMonitor object with MetricRelabelConfigs rules", func() {
 			relabeledCluster := cluster.DeepCopy()
+			//nolint:staticcheck // Using deprecated fields during deprecation period
 			relabeledCluster.Spec.Monitoring.PodMonitorMetricRelabelConfigs = getMetricRelabelings()
 			mgr := NewClusterPodMonitorManager(relabeledCluster)
 			monitor := mgr.BuildPodMonitor()
@@ -89,6 +90,7 @@ var _ = Describe("PodMonitor test", func() {
 
 		It("should create a monitoringv1.PodMonitor object with RelabelConfigs rules", func() {
 			relabeledCluster := cluster.DeepCopy()
+			//nolint:staticcheck // Using deprecated fields during deprecation period
 			relabeledCluster.Spec.Monitoring.PodMonitorRelabelConfigs = getRelabelings()
 			mgr := NewClusterPodMonitorManager(relabeledCluster)
 			monitor := mgr.BuildPodMonitor()
@@ -100,7 +102,9 @@ var _ = Describe("PodMonitor test", func() {
 
 		It("should create a monitoringv1.PodMonitor object with MetricRelabelConfigs and RelabelConfigs rules", func() {
 			relabeledCluster := cluster.DeepCopy()
+			//nolint:staticcheck // Using deprecated fields during deprecation period
 			relabeledCluster.Spec.Monitoring.PodMonitorMetricRelabelConfigs = getMetricRelabelings()
+			//nolint:staticcheck // Using deprecated fields during deprecation period
 			relabeledCluster.Spec.Monitoring.PodMonitorRelabelConfigs = getRelabelings()
 			mgr := NewClusterPodMonitorManager(relabeledCluster)
 			monitor := mgr.BuildPodMonitor()


### PR DESCRIPTION
Mark the `enablePodMonitor` field as deprecated in both `Cluster` and `Pooler` monitoring configuration. This field will be removed in future releases, and users should create `PodMonitor` resources manually if needed.

The deprecation notice has been added to:

- API type definitions (`cluster_types.go` and `pooler_types.go`)
- Generated CRD manifests for both Clusters and Poolers

Documentation has been updated accordingly.

Closes #8075 