### PR TITLE
fix: prevent potential nil pointer dereference

### DIFF
--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -512,13 +512,17 @@ func (r *ClusterReconciler) reconcile(ctx context.Context, cluster *apiv1.Cluste
 	// ensuring the primary to be healthy. The hibernation starts from the
 	// primary Pod to ensure the replicas are in sync and doing it here avoids
 	// any unwanted switchover.
-	if result, err := hibernation.Reconcile(
+	hibernationResult, err := hibernation.Reconcile(
 		ctx,
 		r.Client,
 		cluster,
 		resources.instances.Items,
-	); result != nil || err != nil {
-		return *result, err
+	)
+	if hibernationResult != nil {
+		return *hibernationResult, err
+	}
+	if err != nil {
+		return ctrl.Result{}, err
 	}
 
 	// We have already updated the status in updateResourceStatus call,

--- a/tests/utils/storage/storage.go
+++ b/tests/utils/storage/storage.go
@@ -54,7 +54,7 @@ func IsWalStorageEnabled(
 	namespace, clusterName string,
 ) (bool, error) {
 	cluster, err := clusterutils.Get(ctx, crudClient, namespace, clusterName)
-	if cluster.Spec.WalStorage == nil {
+	if cluster == nil || cluster.Spec.WalStorage == nil {
 		return false, err
 	}
 	return true, err


### PR DESCRIPTION
Prevent possible nil pointer dereference when an error occurs inside the hibernation reconciler.