### PR TITLE
 feat(plugin,status): enhance backup status when using `barman-cloud` plugin

### DIFF
--- a/.wordlist-en-custom.txt
+++ b/.wordlist-en-custom.txt
@@ -638,6 +638,7 @@ balancer
 balancers
 barmanEndpointCA
 barmanObjectStore
+barmancloud
 barmanobjectstore
 barmanobjectstoreconfiguration
 baseDN
@@ -1081,6 +1082,7 @@ num
 oauth
 objectmeta
 objectstore
+objectstores
 objid
 objref
 objsubid

--- a/docs/src/kubectl-plugin.md
+++ b/docs/src/kubectl-plugin.md
@@ -1399,7 +1399,7 @@ table contains the full details:
 | report cluster  | clusters: get<br/>pods: list<br/>pods/log: get<br/>jobs: list<br/>events: list<br/>PVCs: list                                                                                                                                                                                                                                                         |
 | report operator | configmaps: get<br/>deployments: get<br/>events: list<br/>pods: list<br/>pods/log: get<br/>secrets: get<br/>services: get<br/>mutatingwebhookconfigurations: list[^1]<br/> validatingwebhookconfigurations: list[^1]<br/> If OLM is present on the K8s cluster, also:<br/>clusterserviceversions: list<br/>installplans: list<br/>subscriptions: list |
 | restart         | clusters: get,patch<br/>pods: get,delete                                                                                                                                                                                                                                                                                                              |
-| status          | clusters: get<br/>pods: list<br/>pods/exec: create<br/>pods/proxy: create<br/>PDBs: list                                                                                                                                                                                                                                                              |
+| status          | clusters: get<br/>pods: list<br/>pods/exec: create<br/>pods/proxy: create<br/>PDBs: list<br/>objectstores.barmancloud.cnpg.io: get                                                                                                                                                                                                                    |
 | subscription    | clusters: get<br/>pods: get,list<br/>pods/exec: create                                                                                                                                                                                                                                                                                                |
 | version         | none                                                                                                                                                                                                                                                                                                                                                  |
 
@@ -1481,6 +1481,12 @@ rules:
       - policy
     resources:
       - poddisruptionbudgets
+  - verbs:
+      - get
+    apiGroups:
+      - barmancloud.cnpg.io
+    resources:
+      - objectstores
 ```
 
 !!! Important

--- a/internal/cmd/plugin/status/barman_types.go
+++ b/internal/cmd/plugin/status/barman_types.go
@@ -1,0 +1,56 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package status
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// ObjectStore represents the Barman ObjectStore CRD from the barman-cloud plugin.
+// This is a minimal representation containing only the fields we need for status display.
+type ObjectStore struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata"`
+
+	// Status contains the observed state of the ObjectStore
+	Status ObjectStoreStatus `json:"status,omitempty"`
+}
+
+// ObjectStoreStatus defines the observed state of ObjectStore.
+type ObjectStoreStatus struct {
+	// ServerRecoveryWindow maps each server to its recovery window
+	ServerRecoveryWindow map[string]RecoveryWindow `json:"serverRecoveryWindow,omitempty"`
+}
+
+// RecoveryWindow represents the time span between the first
+// recoverability point and the last successful backup of a PostgreSQL
+// server, defining the period during which data can be restored.
+type RecoveryWindow struct {
+	// The first recoverability point in a PostgreSQL server refers to
+	// the earliest point in time to which the database can be
+	// restored.
+	FirstRecoverabilityPoint *metav1.Time `json:"firstRecoverabilityPoint,omitempty"`
+
+	// The last successful backup time
+	LastSuccessfulBackupTime *metav1.Time `json:"lastSuccessfulBackupTime,omitempty"`
+
+	// The last failed backup time
+	LastFailedBackupTime *metav1.Time `json:"lastFailedBackupTime,omitempty"`
+}

--- a/internal/cmd/plugin/status/status.go
+++ b/internal/cmd/plugin/status/status.go
@@ -520,11 +520,12 @@ func (fullStatus *PostgresqlStatus) printBackupStatus() {
 	// Check if Barman Cloud plugin is configured
 	isBarmanPluginEnabled, pluginParams := isBarmanCloudPluginEnabled(cluster)
 
-	if isBarmanPluginEnabled {
+	switch {
+	case isBarmanPluginEnabled:
 		fmt.Println(aurora.Green("Continuous Backup status (Barman Cloud Plugin)"))
-	} else if cluster.Spec.Backup != nil {
+	case cluster.Spec.Backup != nil:
 		fmt.Println(aurora.Green("Continuous Backup status"))
-	} else {
+	default:
 		fmt.Println(aurora.Yellow("Continuous Backup not configured"))
 		fmt.Println()
 		return
@@ -1366,10 +1367,11 @@ func (fullStatus *PostgresqlStatus) printBarmanObjectStoreStatus(
 		serverName = fullStatus.Cluster.Name
 	}
 
-	// Print each server's recovery window information
+	// Retrieve server's recovery window information
 	recoveryWindow, ok := objectStore.Status.ServerRecoveryWindow[serverName]
 	if !ok {
-		fmt.Println(aurora.Red(fmt.Sprintf("No recovery window information found for server '%s'", serverName)))
+		fmt.Println(aurora.Red(fmt.Sprintf("No recovery window information found in ObjectStore '%s' for server '%s'",
+			objectStore.GetName(), serverName)))
 		return
 	}
 

--- a/internal/cmd/plugin/status/status.go
+++ b/internal/cmd/plugin/status/status.go
@@ -143,7 +143,7 @@ func Status(
 		status.printCertificatesStatus()
 	}
 	if !hibernated {
-		status.printBackupStatus(verbosity)
+		status.printBackupStatus()
 		status.printBasebackupStatus(verbosity)
 		status.printReplicaStatus(verbosity)
 		if verbosity > 0 {
@@ -514,7 +514,7 @@ func (fullStatus *PostgresqlStatus) printPostgresConfiguration(
 	return errs
 }
 
-func (fullStatus *PostgresqlStatus) printBackupStatus(verbosity int) {
+func (fullStatus *PostgresqlStatus) printBackupStatus() {
 	cluster := fullStatus.Cluster
 
 	// Check if Barman Cloud plugin is configured


### PR DESCRIPTION
This change improves the backup status reporting when using the `barman-cloud` plugin.

Example output with full information:
```
Continuous Backup status (Barman Cloud Plugin)
ObjectStore / Server name:      minio-store/cluster-example
First Point of Recoverability:  2025-10-13 14:07:43 CEST
Last Successful Backup:         2025-10-13 14:07:43 CEST
Last Failed Backup:             -
Working WAL archiving:          OK
WALs waiting to be archived:    0
Last Archived WAL:              000000010000000000000005.00000028.backup   @   2025-10-13T12:07:26.989682Z
Last Failed WAL:                -
```

Example output when recovery window information is missing:
```
Continuous Backup status (Barman Cloud Plugin)
No recovery window information found in ObjectStore 'minio-store' for server 'cluster-example'
Working WAL archiving:        OK
WALs waiting to be archived:  2
Last Archived WAL:            000000010000000000000002   @   2025-10-13T12:06:51.999857Z
Last Failed WAL:              -
```

Closes cloudnative-pg/plugin-barman-cloud#541