### PR TITLE
feat: enhance log message for certificate parsing errors

### DIFF
--- a/internal/controller/plugin_controller.go
+++ b/internal/controller/plugin_controller.go
@@ -186,6 +186,12 @@ func (r *PluginReconciler) reconcile(
 		// To emit a better log message, we individually execute the parsing
 		// step and look at the real error.
 		block, _ := pem.Decode(serverSecret.Data[corev1.TLSCertKey])
+		if block == nil {
+			err := fmt.Errorf("no valid PEM block found in server certificate")
+			contextLogger.Error(err, "Error while parsing server certificate for mTLS authentication")
+			return ctrl.Result{}, err
+		}
+
 		_, err := x509.ParseCertificate(block.Bytes)
 
 		// If we don't manage to get the real error, we fall back to the


### PR DESCRIPTION
When the certificate parser failed, the log only contained a generic error message, making it difficult to diagnose the underlying problem.

This patch introduces a dedicated parsing step that captures and logs the specific parsing error, improving observability and troubleshooting.

This change is especially relevant after the fix for `CVE-2025-58187` included in Go 1.25.2 and 1.24.8, which increases the likelihood of parsing failures if a DNS Subject Alternative Name in the certificate is invalid.

Closes: #8800 
