### PR TITLE
feat(plugin): use `wallnerryan/fiotools-aio:v2` for FIO

### DIFF
--- a/internal/cmd/plugin/fio/fio.go
+++ b/internal/cmd/plugin/fio/fio.go
@@ -45,7 +45,7 @@ type fioCommand struct {
 
 const (
 	fioKeyWord = "fio"
-	fioImage   = "wallnerryan/fiotools-aio:latest"
+	fioImage   = "wallnerryan/fiotools-aio:v2"
 )
 
 var jobExample = `


### PR DESCRIPTION
Update the Flexible I/O Tester image to version 2 as provided by Ryan Wallner.

Closes #8181 