### PR TITLE
fix: make sure certificate private key has 0o600 permission

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/cheynewallace/tabby v1.1.1
 	github.com/cloudnative-pg/barman-cloud v0.3.3
 	github.com/cloudnative-pg/cnpg-i v0.3.0
-	github.com/cloudnative-pg/machinery v0.3.1
+	github.com/cloudnative-pg/machinery v0.3.2-0.20251014152802-0da5936168b6
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/evanphx/json-patch/v5 v5.9.11
 	github.com/go-logr/logr v1.4.3

--- a/go.sum
+++ b/go.sum
@@ -24,8 +24,8 @@ github.com/cloudnative-pg/barman-cloud v0.3.3 h1:EEcjeV+IUivDpmyF/H/XGY1pGaKJ5LS
 github.com/cloudnative-pg/barman-cloud v0.3.3/go.mod h1:5CM4MncAxAjnqxjDt0I5E/oVd7gsMLL0/o/wQ+vUSgs=
 github.com/cloudnative-pg/cnpg-i v0.3.0 h1:5ayNOG5x68lU70IVbHDZQrv5p+bErCJ0mqRmOpW2jjE=
 github.com/cloudnative-pg/cnpg-i v0.3.0/go.mod h1:VOIWWXcJ1RyioK+elR2DGOa4cBA6K+6UQgx05aZmH+g=
-github.com/cloudnative-pg/machinery v0.3.1 h1:KtPA6EwELTUNisCMLiFYkK83GU9606rkGQhDJGPB8Yw=
-github.com/cloudnative-pg/machinery v0.3.1/go.mod h1:jebuqKxZAbrRKDEEpVCIDMKW+FbWtB9Kf/hb2kMUu9o=
+github.com/cloudnative-pg/machinery v0.3.2-0.20251014152802-0da5936168b6 h1:Z6TTLc19G18Afh/5BRcp/3UviOHkkUaKW+hoHjkAIXM=
+github.com/cloudnative-pg/machinery v0.3.2-0.20251014152802-0da5936168b6/go.mod h1:tYlu9IaseHka6Evqz+F1vEB0CS6YtDp4eMICT2ZXQ6A=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
 github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=

--- a/pkg/reconciler/instance/certificate/reconciler.go
+++ b/pkg/reconciler/instance/certificate/reconciler.go
@@ -346,6 +346,11 @@ func (r *Reconciler) refreshCertificateFilesFromSecret(
 			"secret", secret.Name)
 	}
 
+	// ensure the permission of the private key is correct
+	if err := fileutils.EnsureFileMode(privateKeyLocation, 0o600); err != nil {
+		return false, fmt.Errorf("while fixing permissions of server private key: %w", err)
+	}
+
 	return certificateIsChanged || privateKeyIsChanged, nil
 }
 


### PR DESCRIPTION
At every certificate reconciliation, this patch makes sure the private keys
has permission 0o600, in case something external has changed it.

Closes #8838 
