### PR TITLE
feat: run `CHECKPOINT` before `smart` and `fast` shutdowns

### DIFF
--- a/docs/src/instance_manager.md
+++ b/docs/src/instance_manager.md
@@ -334,9 +334,9 @@ to 180 and 1800 seconds, respectively.
 
 The shutdown procedure is composed of two steps:
 
-1. The instance manager requests a **smart** shut down, disallowing any
-new connection to PostgreSQL. This step will last for up to
-`.spec.smartShutdownTimeout` seconds.
+1. The instance manager first issues a `CHECKPOINT`, then initiates a **smart**
+shut down, disallowing any new connection to PostgreSQL. This step will last
+for up to `.spec.smartShutdownTimeout` seconds.
 
 2. If PostgreSQL is still up, the instance manager requests a **fast**
 shut down, terminating any existing connection and exiting promptly.
@@ -353,10 +353,11 @@ seconds.
 
 ### Shutdown of the primary during a switchover
 
-During a switchover, the shutdown procedure is slightly different from the
-general case. Indeed, the operator requires the former primary to issue a
-**fast** shut down before the selected new primary can be promoted,
-in order to ensure that all the data are available on the new primary.
+During a switchover, the shutdown procedure slightly differs from the general
+case. The instance manager of the former primary first issues a `CHECKPOINT`,
+then initiates a **fast** shutdown of PostgreSQL before the designated new
+primary is promoted, ensuring that all data are safely available on the new
+primary.
 
 For this reason, the `.spec.switchoverDelay`, expressed in seconds, controls
 the  time given to the former primary to shut down gracefully and archive all

--- a/internal/management/controller/instance_controller.go
+++ b/internal/management/controller/instance_controller.go
@@ -594,7 +594,7 @@ func (r *InstanceReconciler) reconcileOldPrimary(
 		return false, err
 	}
 
-	contextLogger.Info("This is an old primary node. Shutting it down to get it demoted to a replica")
+	contextLogger.Info("This is the former primary instance. Shutting it down to allow it to be demoted to a replica.")
 
 	// Perform a fast shutdown on the instance and wait for the instance manager to stop.
 	// The fast shutdown process will be preceded by a CHECKPOINT.

--- a/internal/management/controller/instance_controller.go
+++ b/internal/management/controller/instance_controller.go
@@ -594,23 +594,11 @@ func (r *InstanceReconciler) reconcileOldPrimary(
 		return false, err
 	}
 
-	contextLogger.Info("This is an old primary node. Requesting a checkpoint before demotion")
-
-	db, err := r.instance.GetSuperUserDB()
-	if err != nil {
-		contextLogger.Error(err, "Cannot connect to primary server")
-	} else {
-		_, err = db.Exec("CHECKPOINT")
-		if err != nil {
-			contextLogger.Error(err, "Error while requesting a checkpoint")
-		}
-	}
-
 	contextLogger.Info("This is an old primary node. Shutting it down to get it demoted to a replica")
 
-	// Here we need to invoke a fast shutdown on the instance, and wait the instance
-	// manager to be stopped.
-	// When the Pod will restart, we will demote as a replica of the new primary
+	// Perform a fast shutdown on the instance and wait for the instance manager to stop.
+	// The fast shutdown process will be preceded by a CHECKPOINT.
+	// When the Pod restarts, it will be demoted to act as a replica of the new primary.
 	r.Instance().RequestFastImmediateShutdown()
 
 	// We wait for the lifecycle manager to have received the immediate shutdown request

--- a/pkg/management/postgres/instance.go
+++ b/pkg/management/postgres/instance.go
@@ -511,10 +511,9 @@ func (instance *Instance) ShutdownConnections() {
 	}
 }
 
-// Shutdown shuts down a PostgreSQL instance which was previously started
-// with Startup.
-// This function will return an error whether PostgreSQL is still up
-// after the shutdown request.
+// Shutdown stops a PostgreSQL instance that was previously started with Startup.
+// Before shutting down, it attempts to execute a CHECKPOINT.
+// The function returns an error if PostgreSQL remains running after the shutdown request.
 func (instance *Instance) Shutdown(ctx context.Context, options shutdownOptions) error {
 	contextLogger := log.FromContext(ctx)
 
@@ -560,9 +559,9 @@ func (instance *Instance) Shutdown(ctx context.Context, options shutdownOptions)
 	return nil
 }
 
-// TryShuttingDownSmartFast first tries to shut down the instance with mode smart,
-// then in case of failure or the given timeout expiration,
-// it will issue a fast shutdown request and wait for it to complete.
+// TryShuttingDownSmartFast first attempts to shut down the instance using the "smart" mode,
+// which is preceded by a CHECKPOINT. If this fails or the specified timeout expires,
+// it issues an "fast" shutdown request and waits for completion.
 func (instance *Instance) TryShuttingDownSmartFast(ctx context.Context) error {
 	contextLogger := log.FromContext(ctx)
 
@@ -610,10 +609,10 @@ func (instance *Instance) TryShuttingDownSmartFast(ctx context.Context) error {
 	return nil
 }
 
-// TryShuttingDownFastImmediate first tries to shut down the instance with mode fast,
-// then in case of failure or the given timeout expiration,
-// it will issue an immediate shutdown request and wait for it to complete.
-// N.B. immediate shutdown can cause data loss.
+// TryShuttingDownFastImmediate first attempts to shut down the instance using the "fast" mode,
+// which is preceded by a CHECKPOINT. If this fails or the specified timeout expires,
+// it issues an "immediate" shutdown request and waits for completion.
+// Note: an immediate shutdown may lead to data loss.
 func (instance *Instance) TryShuttingDownFastImmediate(ctx context.Context) error {
 	contextLogger := log.FromContext(ctx)
 

--- a/pkg/management/postgres/instance.go
+++ b/pkg/management/postgres/instance.go
@@ -1448,38 +1448,40 @@ func (instance *Instance) HandleInstanceCommandRequests(
 	}
 }
 
-// tryCheckpointBeforeShutdown attempts to issue a checkpoint before shutdown if the instance is a primary.
+// tryCheckpointBeforeShutdown attempts to issue a checkpoint before shutdown.
+// This is skipped if the instance is not a primary or if an immediate shutdown is requested.
 // This reduces shutdown time and subsequent promotion time for replicas, especially for systems with high
 // checkpoint_timeout.
 // All outcomes (success, failure, or skipped) are logged appropriately.
 func (instance *Instance) tryCheckpointBeforeShutdown(ctx context.Context, mode shutdownMode) {
 	contextLogger := log.FromContext(ctx).WithName("checkpoint_before_shutdown")
-	contextLogger.Info("Trying to issue a checkpoint")
+	contextLogger.Info("Attempting checkpoint before shutdown")
 
 	if mode == shutdownModeImmediate {
-		contextLogger.Info("Checkpoint skipped, immediate shutdown requested")
+		contextLogger.Info("Skipping checkpoint: immediate shutdown requested")
 		return
 	}
 
 	isPrimary, err := instance.IsPrimary()
 	if err != nil {
-		contextLogger.Error(err, "while determining instance role")
+		contextLogger.Error(err, "Failed to determine instance role, skipping checkpoint")
 		return
 	}
 
 	if !isPrimary {
-		contextLogger.Info("Checkpoint skipped, instance is not primary")
+		contextLogger.Info("Skipping checkpoint: instance is not primary")
 		return
 	}
 
 	db, err := instance.GetSuperUserDB()
 	if err != nil {
-		contextLogger.Error(err, "Checkpoint failed while fetching super user db")
+		contextLogger.Error(err, "Failed to get superuser DB connection, skipping checkpoint")
 		return
 	}
 
+	contextLogger.Info("Executing CHECKPOINT command before shutdown")
 	if _, err = db.ExecContext(ctx, "CHECKPOINT"); err != nil {
-		contextLogger.Error(err, "Checkpoint execution failed")
+		contextLogger.Error(err, "Failed to execute CHECKPOINT command")
 		return
 	}
 


### PR DESCRIPTION
Run a `CHECKPOINT` before every PostgreSQL `smart` and `fast` shutdown request to reduce both shutdown duration and replica promotion time, especially in systems with a high `checkpoint_timeout`.

This follows the best-effort approach used in `instance_controller.go`: errors during the checkpoint are logged, but the shutdown proceeds regardless. The checkpoint step is skipped for `immediate` shutdown mode.

Closes #8865 
