### PR TITLE
feat(backup): prevent backups on hibernated clusters

### DIFF
--- a/internal/controller/backup_controller.go
+++ b/internal/controller/backup_controller.go
@@ -339,6 +339,13 @@ func (r *BackupReconciler) checkPrerequisites(
 		err := resourcestatus.FlagBackupAsFailed(ctx, r.Client, &backup, &cluster, errors.New(message))
 		return &ctrl.Result{}, err
 	}
+
+	if hibernation := cluster.Annotations[utils.HibernationAnnotationName]; hibernation ==
+		string(utils.HibernationAnnotationValueOn) {
+		const message = "cannot proceed with the backup as the cluster has hibernation enabled"
+		return flagMissingPrerequisite(message, "ClusterIsHibernated")
+	}
+
 	if backup.Spec.Method == apiv1.BackupMethodPlugin {
 		if len(cluster.Spec.Plugins) == 0 {
 			const message = "cannot proceed with the backup as the cluster has no plugin configured"

--- a/internal/controller/backup_controller.go
+++ b/internal/controller/backup_controller.go
@@ -342,7 +342,7 @@ func (r *BackupReconciler) checkPrerequisites(
 
 	if hibernation := cluster.Annotations[utils.HibernationAnnotationName]; hibernation ==
 		string(utils.HibernationAnnotationValueOn) {
-		const message = "cannot proceed with the backup as the cluster has hibernation enabled"
+		const message = "cannot backup a hibernated cluster"
 		return flagMissingPrerequisite(message, "ClusterIsHibernated")
 	}
 


### PR DESCRIPTION
Add hibernation validation in BackupReconciler.checkPrerequisites to fail backups when the target cluster has hibernation enabled.

The validation follows the existing pattern where prerequisite checks are performed in the backup controller after the Backup resource is created. When hibernation is detected, the backup is marked as failed with reason "ClusterIsHibernated" and a warning event is recorded on the Backup resource itself.

This approach is consistent with how other prerequisite failures are handled (e.g., missing backup configuration, missing plugins, no VolumeSnapshot support), allowing the error to be visible directly on the Backup object regardless of how it was created (manually, via ScheduledBackup, or other means).

Related #8508 
