### PR TITLE
fix(cache): return value copy when loading env

### DIFF
--- a/internal/management/cache/cache.go
+++ b/internal/management/cache/cache.go
@@ -20,6 +20,7 @@ SPDX-License-Identifier: Apache-2.0
 package cache
 
 import (
+	"slices"
 	"sync"
 )
 
@@ -43,8 +44,7 @@ func LoadEnv(c string) ([]string, error) {
 	}
 
 	if v, ok := value.([]string); ok {
-		clone := append([]string(nil), v...)
-		return clone, nil
+		return slices.Clone(v), nil
 	}
 
 	return nil, ErrUnsupportedObject

--- a/internal/management/cache/cache_test.go
+++ b/internal/management/cache/cache_test.go
@@ -1,0 +1,52 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package cache
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("LoadEnv", func() {
+	const key = "test-env"
+
+	AfterEach(func() {
+		Delete(key)
+	})
+
+	It("returns a copy of the cached slice", func() {
+		original := []string{"first", "second"}
+		Store(key, append([]string(nil), original...))
+
+		loaded, err := LoadEnv(key)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(loaded).To(HaveLen(len(original)))
+		Expect(loaded).To(Equal(original))
+		Expect(loaded).NotTo(BeIdenticalTo(original))
+
+		loaded[0] = "mutated"
+
+		reloaded, err := LoadEnv(key)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(reloaded[0]).To(Equal(original[0]))
+		Expect(reloaded).To(Equal(original))
+		Expect(loaded[0]).NotTo(Equal(reloaded[0]))
+	})
+})

--- a/internal/management/cache/suite_test.go
+++ b/internal/management/cache/suite_test.go
@@ -20,32 +20,14 @@ SPDX-License-Identifier: Apache-2.0
 package cache
 
 import (
-	"sync"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
-var cache sync.Map
+func TestCache(t *testing.T) {
+	RegisterFailHandler(Fail)
 
-// Store write an object into the local cache
-func Store(c string, v interface{}) {
-	cache.Store(c, v)
-}
-
-// Delete an object from the local cache
-func Delete(c string) {
-	cache.Delete(c)
-}
-
-// LoadEnv loads a key from the local cache
-func LoadEnv(c string) ([]string, error) {
-	value, ok := cache.Load(c)
-	if !ok {
-		return nil, ErrCacheMiss
-	}
-
-	if v, ok := value.([]string); ok {
-		clone := append([]string(nil), v...)
-		return clone, nil
-	}
-
-	return nil, ErrUnsupportedObject
+	RunSpecs(t, "Internal Management Cache Test Suite")
 }


### PR DESCRIPTION
Make `LoadEnv` copy cached environment slices before returning so callers can't mutate the shared backing array. Add a regression test to ensure mutations to the returned slice don't leak back into the cache.
