### PR TITLE
fix(publication): ensure PostgreSQL 13+ compatibility for multi-table publications

### DIFF
--- a/docs/src/logical_replication.md
+++ b/docs/src/logical_replication.md
@@ -84,12 +84,46 @@ In the above example:
 - It includes all tables (`spec.target.allTables: true`) from the `app`
   database (`spec.dbname`).
 
+### Fine-grained control over publication tables
+
+While the `allTables` option provides a convenient way to replicate all tables
+in a database, PostgreSQL version 15 and later introduce enhanced flexibility
+through the [`CREATE PUBLICATION`](https://www.postgresql.org/docs/current/sql-createpublication.html)
+command. This allows you to precisely define which tables, or even which types
+of data changes, should be included in a publication.
+
 !!! Important
-    While `allTables` simplifies configuration, PostgreSQL offers fine-grained
-    control for replicating specific tables or targeted data changes. For advanced
-    configurations, consult the [PostgreSQL documentation](https://www.postgresql.org/docs/current/logical-replication.html).
-    Additionally, refer to the [CloudNativePG API reference](cloudnative-pg.v1.md#postgresql-cnpg-io-v1-PublicationTarget)
-    for details on declaratively customizing replication targets.
+    If you are using PostgreSQL versions earlier than 15, review the syntax and
+    options available for `CREATE PUBLICATION` in your specific release. Some
+    parameters and features may not be supported.
+
+For complex or tailored replication setups, refer to the
+[PostgreSQL logical replication documentation](https://www.postgresql.org/docs/current/logical-replication.html).
+
+Additionally, refer to the [CloudNativePG API reference](cloudnative-pg.v1.md#postgresql-cnpg-io-v1-PublicationTarget)
+for details on declaratively customizing replication targets.
+
+The following example defines a publication that replicates all tables in the
+`portal` schema of the `app` database, along with the `users` table from the
+`access` schema:
+
+```yaml
+apiVersion: postgresql.cnpg.io/v1
+kind: Publication
+metadata:
+  name: publisher
+spec:
+  cluster:
+    name: freddie
+  dbname: app
+  name: publisher
+  target:
+    objects:
+      - tablesInSchema: portal
+      - table:
+          name: users
+          schema: access
+```
 
 ### Required Fields in the `Publication` Manifest
 

--- a/docs/src/logical_replication.md
+++ b/docs/src/logical_replication.md
@@ -381,7 +381,7 @@ metadata:
 spec:
   instances: 1
 
-  imageName: ghcr.io/cloudnative-pg/postgresql:16
+  imageName: ghcr.io/cloudnative-pg/postgresql:16-standard-trixie
 
   storage:
     size: 1Gi
@@ -429,6 +429,8 @@ metadata:
   name: king
 spec:
   instances: 1
+
+  imageName: ghcr.io/cloudnative-pg/postgresql:18-standard-trixie
 
   storage:
     size: 1Gi

--- a/internal/management/controller/publication_controller_sql.go
+++ b/internal/management/controller/publication_controller_sql.go
@@ -151,38 +151,52 @@ func toPublicationTargetSQL(obj *apiv1.PublicationTarget) string {
 }
 
 func toPublicationTargetObjectsSQL(obj *apiv1.PublicationTarget) string {
-	result := ""
-	for _, object := range obj.Objects {
-		if len(result) > 0 {
-			result += ", "
+	var parts []string
+	var currentTables []string
+
+	flushTables := func() {
+		if len(currentTables) > 0 {
+			parts = append(parts, fmt.Sprintf("TABLE %s", strings.Join(currentTables, ", ")))
+			currentTables = nil
 		}
-		result += toPublicationObjectSQL(&object)
 	}
 
-	return result
+	for _, object := range obj.Objects {
+		if len(object.TablesInSchema) > 0 {
+			// Flush any accumulated tables before adding schema
+			flushTables()
+			parts = append(parts, fmt.Sprintf("TABLES IN SCHEMA %s", pgx.Identifier{object.TablesInSchema}.Sanitize()))
+		} else if object.Table != nil {
+			// Accumulate table definitions
+			// Note: Grouping consecutive tables under a single TABLE keyword ensures
+			// compatibility with PostgreSQL 13/14. Mixed TABLE and TABLES IN SCHEMA
+			// in the same publication requires PostgreSQL 15+.
+			currentTables = append(currentTables, toTableDefinitionSQL(object.Table))
+		}
+	}
+
+	// Flush any remaining tables
+	flushTables()
+
+	return strings.Join(parts, ", ")
 }
 
-func toPublicationObjectSQL(obj *apiv1.PublicationTargetObject) string {
-	if len(obj.TablesInSchema) > 0 {
-		return fmt.Sprintf("TABLES IN SCHEMA %s", pgx.Identifier{obj.TablesInSchema}.Sanitize())
-	}
-
+func toTableDefinitionSQL(table *apiv1.PublicationTargetTable) string {
 	result := strings.Builder{}
-	result.WriteString("TABLE ")
 
-	if obj.Table.Only {
+	if table.Only {
 		result.WriteString("ONLY ")
 	}
 
-	if len(obj.Table.Schema) > 0 {
-		result.WriteString(fmt.Sprintf("%s.", pgx.Identifier{obj.Table.Schema}.Sanitize()))
+	if len(table.Schema) > 0 {
+		result.WriteString(fmt.Sprintf("%s.", pgx.Identifier{table.Schema}.Sanitize()))
 	}
 
-	result.WriteString(pgx.Identifier{obj.Table.Name}.Sanitize())
+	result.WriteString(pgx.Identifier{table.Name}.Sanitize())
 
-	if len(obj.Table.Columns) > 0 {
-		sanitizedColumns := make([]string, 0, len(obj.Table.Columns))
-		for _, column := range obj.Table.Columns {
+	if len(table.Columns) > 0 {
+		sanitizedColumns := make([]string, 0, len(table.Columns))
+		for _, column := range table.Columns {
 			sanitizedColumns = append(sanitizedColumns, pgx.Identifier{column}.Sanitize())
 		}
 		result.WriteString(fmt.Sprintf(" (%s)", strings.Join(sanitizedColumns, ", ")))


### PR DESCRIPTION
The previous implementation generated SQL that only worked on PostgreSQL 15+:
  CREATE PUBLICATION "pub" FOR TABLE "t1", TABLE "t2"

While this syntax is valid in PostgreSQL 15+, it fails in PostgreSQL 13+ with a syntax error. The fix now generates backward-compatible SQL:
  CREATE PUBLICATION "pub" FOR TABLE "t1", "t2"

The implementation groups consecutive tables under a single TABLE keyword and properly handles mixed scenarios with TABLES IN SCHEMA, ensuring full compatibility across all supported PostgreSQL versions (13+).

Fixes #8588 


# Note for reviewers

- this still doesn't solve the issue of mixed tables and schemas on pg13-14 and aims only to fix the issue reported
- minimal implementation, we could have refactored the cnpg publication cmd to reuse the same logic but the diff would have gone way bigger