### PR TITLE
chore: instruct controller-gen to skip objectstore type

### DIFF
--- a/internal/cmd/plugin/status/doc.go
+++ b/internal/cmd/plugin/status/doc.go
@@ -18,4 +18,5 @@ SPDX-License-Identifier: Apache-2.0
 */
 
 // Package status implements the kubectl-cnpg status command
+// +kubebuilder:skip
 package status


### PR DESCRIPTION
Without this directive controller-gen generates an unwanted `config/crd/bases/_objectstores.yaml` file.