### PR TITLE
test(e2e): centralize the Postgres ImageName in the E2E environment

### DIFF
--- a/tests/e2e/cluster_major_upgrade_test.go
+++ b/tests/e2e/cluster_major_upgrade_test.go
@@ -113,7 +113,7 @@ var _ = Describe("Postgres Major Upgrade", Label(tests.LabelPostgresMajorUpgrade
 
 	generatePostgreSQLCluster := func(namespace string, storageClass string, tagVersion string) *apiv1.Cluster {
 		cluster := generateBaseCluster(namespace, storageClass)
-		cluster.Spec.ImageName = env.StandardImageName(tagVersion)
+		cluster.Spec.ImageName = env.OfficialStandardImageName(tagVersion)
 		cluster.Spec.Bootstrap.InitDB.PostInitSQL = []string{
 			"CREATE EXTENSION IF NOT EXISTS pg_stat_statements;",
 			"CREATE EXTENSION IF NOT EXISTS pg_trgm;",
@@ -124,13 +124,13 @@ var _ = Describe("Postgres Major Upgrade", Label(tests.LabelPostgresMajorUpgrade
 
 	generatePostgreSQLMinimalCluster := func(namespace string, storageClass string, tagVersion string) *apiv1.Cluster {
 		cluster := generatePostgreSQLCluster(namespace, storageClass, tagVersion)
-		cluster.Spec.ImageName = env.MinimalImageName(tagVersion)
+		cluster.Spec.ImageName = env.OfficialMinimalImageName(tagVersion)
 		return cluster
 	}
 
 	generatePostGISCluster := func(namespace string, storageClass string, tagVersion string) *apiv1.Cluster {
 		cluster := generateBaseCluster(namespace, storageClass)
-		cluster.Spec.ImageName = env.PostGISImageName(tagVersion)
+		cluster.Spec.ImageName = env.OfficialPostGISImageName(tagVersion)
 		cluster.Spec.Bootstrap.InitDB.PostInitApplicationSQL = []string{
 			"CREATE EXTENSION postgis",
 			"CREATE EXTENSION postgis_raster",
@@ -159,10 +159,7 @@ var _ = Describe("Postgres Major Upgrade", Label(tests.LabelPostgresMajorUpgrade
 	}
 
 	determineVersionsForTesting := func() versionInfo {
-		currentImage := os.Getenv("POSTGRES_IMG")
-		Expect(currentImage).ToNot(BeEmpty())
-
-		currentVersion, err := version.FromTag(reference.New(currentImage).Tag)
+		currentVersion, err := version.FromTag(env.PostgresImageTag)
 		Expect(err).NotTo(HaveOccurred())
 		currentMajor := currentVersion.Major()
 		currentTag := strconv.FormatUint(currentMajor, 10)
@@ -185,7 +182,7 @@ var _ = Describe("Postgres Major Upgrade", Label(tests.LabelPostgresMajorUpgrade
 			// Beta images don't have a major version only tag yet, and
 			// are most likely in the following format: "18beta1", "18rc2"
 			// So, we split at the first `-` and use that prefix to build the target image.
-			targetTag = strings.Split(reference.New(currentImage).Tag, "-")[0]
+			targetTag = strings.Split(env.PostgresImageTag, "-")[0]
 			GinkgoWriter.Printf("Using %v as the current major and upgrading to %v.\n", currentMajor, targetMajor)
 		}
 

--- a/tests/e2e/cluster_major_upgrade_test.go
+++ b/tests/e2e/cluster_major_upgrade_test.go
@@ -60,13 +60,12 @@ var _ = Describe("Postgres Major Upgrade", Label(tests.LabelPostgresMajorUpgrade
 		postgisEntry           = "postgis"
 		postgresqlEntry        = "postgresql"
 		postgresqlMinimalEntry = "postgresql-minimal"
+
 		// custom registry envs
 		customPostgresImageRegistryEnvVar = "POSTGRES_MAJOR_UPGRADE_IMAGE_REGISTRY"
 		customPostgisImageRegistryEnvVar  = "POSTGIS_MAJOR_UPGRADE_IMAGE_REGISTRY"
-	)
 
-	// PostgisImageRepository is the default repository for Postgis container images
-	var (
+		// PostgisImageRepository is the default repository for Postgis container images
 		PostgisImageRepository = "ghcr.io/cloudnative-pg/postgis"
 	)
 

--- a/tests/e2e/configuration_update_test.go
+++ b/tests/e2e/configuration_update_test.go
@@ -210,7 +210,7 @@ var _ = Describe("Configuration update", Label(tests.LabelClusterMetadata), func
 			var err error
 			cluster, err = clusterutils.Get(env.Ctx, env.Client, namespace, clusterName)
 			Expect(err).NotTo(HaveOccurred())
-			cluster.Spec.ImageName = fmt.Sprintf("%s:%s-standard-trixie", env.PostgresImageName, targetTag)
+			cluster.Spec.ImageName = env.StandardImageName(targetTag)
 			cluster.Spec.PostgresConfiguration.Parameters["pgaudit.log"] = "all, -misc"
 			cluster.Spec.PostgresConfiguration.Parameters["pgaudit.log_catalog"] = "off"
 			cluster.Spec.PostgresConfiguration.Parameters["pgaudit.log_parameter"] = "on"
@@ -261,7 +261,7 @@ var _ = Describe("Configuration update", Label(tests.LabelClusterMetadata), func
 			Expect(err).ToNot(HaveOccurred())
 
 			cluster := generateBaseCluster(namespace)
-			cluster.Spec.ImageName = fmt.Sprintf("%s:%s-minimal-trixie", env.PostgresImageName, targetTag)
+			cluster.Spec.ImageName = env.MinimalImageName(targetTag)
 			cluster.Spec.PrimaryUpdateMethod = apiv1.PrimaryUpdateMethodSwitchover
 			err = env.Client.Create(env.Ctx, cluster)
 			Expect(err).NotTo(HaveOccurred())
@@ -456,7 +456,7 @@ var _ = Describe("Configuration update", Label(tests.LabelClusterMetadata), func
 			Expect(err).ToNot(HaveOccurred())
 
 			cluster := generateBaseCluster(namespace)
-			cluster.Spec.ImageName = fmt.Sprintf("%s:%s-minimal-trixie", env.PostgresImageName, targetTag)
+			cluster.Spec.ImageName = env.MinimalImageName(targetTag)
 			cluster.Spec.PrimaryUpdateMethod = apiv1.PrimaryUpdateMethodRestart
 			err = env.Client.Create(env.Ctx, cluster)
 			Expect(err).NotTo(HaveOccurred())

--- a/tests/e2e/configuration_update_test.go
+++ b/tests/e2e/configuration_update_test.go
@@ -26,7 +26,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cloudnative-pg/machinery/pkg/image/reference"
 	cnpgTypes "github.com/cloudnative-pg/machinery/pkg/types"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -248,9 +247,7 @@ var _ = Describe("Configuration update", Label(tests.LabelClusterMetadata), func
 
 		// TODO: remove this once all E2Es run on minimal images
 		// https://github.com/cloudnative-pg/cloudnative-pg/issues/8123
-		currentImage := os.Getenv("POSTGRES_IMG")
-		Expect(currentImage).ToNot(BeEmpty())
-		targetTag = strings.Split(reference.New(currentImage).Tag, "-")[0]
+		targetTag = strings.Split(env.PostgresImageTag, "-")[0]
 	})
 
 	Context("PrimaryUpdateMethod: switchover", Ordered, func() {

--- a/tests/e2e/configuration_update_test.go
+++ b/tests/e2e/configuration_update_test.go
@@ -210,7 +210,7 @@ var _ = Describe("Configuration update", Label(tests.LabelClusterMetadata), func
 			var err error
 			cluster, err = clusterutils.Get(env.Ctx, env.Client, namespace, clusterName)
 			Expect(err).NotTo(HaveOccurred())
-			cluster.Spec.ImageName = fmt.Sprintf("ghcr.io/cloudnative-pg/postgresql:%s-standard-trixie", targetTag)
+			cluster.Spec.ImageName = fmt.Sprintf("%s:%s-standard-trixie", env.PostgresImageName, targetTag)
 			cluster.Spec.PostgresConfiguration.Parameters["pgaudit.log"] = "all, -misc"
 			cluster.Spec.PostgresConfiguration.Parameters["pgaudit.log_catalog"] = "off"
 			cluster.Spec.PostgresConfiguration.Parameters["pgaudit.log_parameter"] = "on"
@@ -261,7 +261,7 @@ var _ = Describe("Configuration update", Label(tests.LabelClusterMetadata), func
 			Expect(err).ToNot(HaveOccurred())
 
 			cluster := generateBaseCluster(namespace)
-			cluster.Spec.ImageName = fmt.Sprintf("ghcr.io/cloudnative-pg/postgresql:%s-minimal-trixie", targetTag)
+			cluster.Spec.ImageName = fmt.Sprintf("%s:%s-minimal-trixie", env.PostgresImageName, targetTag)
 			cluster.Spec.PrimaryUpdateMethod = apiv1.PrimaryUpdateMethodSwitchover
 			err = env.Client.Create(env.Ctx, cluster)
 			Expect(err).NotTo(HaveOccurred())
@@ -456,7 +456,7 @@ var _ = Describe("Configuration update", Label(tests.LabelClusterMetadata), func
 			Expect(err).ToNot(HaveOccurred())
 
 			cluster := generateBaseCluster(namespace)
-			cluster.Spec.ImageName = fmt.Sprintf("ghcr.io/cloudnative-pg/postgresql:%s-minimal-trixie", targetTag)
+			cluster.Spec.ImageName = fmt.Sprintf("%s:%s-minimal-trixie", env.PostgresImageName, targetTag)
 			cluster.Spec.PrimaryUpdateMethod = apiv1.PrimaryUpdateMethodRestart
 			err = env.Client.Create(env.Ctx, cluster)
 			Expect(err).NotTo(HaveOccurred())

--- a/tests/utils/environment/environment.go
+++ b/tests/utils/environment/environment.go
@@ -66,25 +66,26 @@ const (
 	MinimalTrixieSuffix = "minimal-trixie"
 
 	// Official CloudNativePG image repositories
-	officialPostgresImageRepository = "ghcr.io/cloudnative-pg/postgresql"
-	defaultPostGISImageRepository   = "ghcr.io/cloudnative-pg/postgis"
-	defaultPostGISVersion           = "3"
+	defaultPostgresImageRepository = "ghcr.io/cloudnative-pg/postgresql"
+	defaultPostGISImageRepository  = "ghcr.io/cloudnative-pg/postgis"
+	defaultPostGISVersion          = "3"
 )
 
 // TestingEnvironment struct for operator testing
 type TestingEnvironment struct {
-	RestClientConfig       *rest.Config
-	Client                 client.Client
-	Interface              kubernetes.Interface
-	APIExtensionClient     apiextensionsclientset.Interface
-	Ctx                    context.Context
-	Scheme                 *runtime.Scheme
-	Log                    logr.Logger
-	PostgresImageName      string
-	PostgresImageTag       string
-	PostgresVersion        uint64
-	PostGISImageRepository string
-	createdNamespaces      *uniqueStringSlice
+	RestClientConfig        *rest.Config
+	Client                  client.Client
+	Interface               kubernetes.Interface
+	APIExtensionClient      apiextensionsclientset.Interface
+	Ctx                     context.Context
+	Scheme                  *runtime.Scheme
+	Log                     logr.Logger
+	PostgresImageName       string
+	PostgresImageTag        string
+	PostgresVersion         uint64
+	PostgresImageRepository string
+	PostGISImageRepository  string
+	createdNamespaces       *uniqueStringSlice
 }
 
 type uniqueStringSlice struct {
@@ -143,6 +144,12 @@ func NewTestingEnvironment() (*TestingEnvironment, error) {
 	imageReference := reference.New(postgresImage)
 	env.PostgresImageName = imageReference.Name
 	env.PostgresImageTag = imageReference.Tag
+
+	// Set PostgreSQL image repository (can be overridden via env variable)
+	env.PostgresImageRepository = defaultPostgresImageRepository
+	if postgresRepoFromUser, exist := os.LookupEnv("POSTGRES_IMG_REPOSITORY"); exist {
+		env.PostgresImageRepository = postgresRepoFromUser
+	}
 
 	// Set PostGIS image repository (can be overridden via env variable)
 	env.PostGISImageRepository = defaultPostGISImageRepository
@@ -237,21 +244,21 @@ func (env *TestingEnvironment) PostGISImageName(tag string) string {
 // OfficialPostgresImageName returns the full image name for the official CloudNativePG Postgres image.
 // Example: ghcr.io/cloudnative-pg/postgresql:17
 func (env *TestingEnvironment) OfficialPostgresImageName(tag string) string {
-	return fmt.Sprintf("%s:%s", officialPostgresImageRepository, tag)
+	return fmt.Sprintf("%s:%s", defaultPostgresImageRepository, tag)
 }
 
 // OfficialStandardImageName returns the full image name for the official standard Postgres image.
 // This is used for major upgrade tests where source images must come from the official registry.
 // Example: ghcr.io/cloudnative-pg/postgresql:16-standard-trixie
 func (env *TestingEnvironment) OfficialStandardImageName(tag string) string {
-	return fmt.Sprintf("%s:%s-%s", officialPostgresImageRepository, tag, StandardTrixieSuffix)
+	return fmt.Sprintf("%s:%s-%s", defaultPostgresImageRepository, tag, StandardTrixieSuffix)
 }
 
 // OfficialMinimalImageName returns the full image name for the official minimal Postgres image.
 // This is used for major upgrade tests where source images must come from the official registry.
 // Example: ghcr.io/cloudnative-pg/postgresql:16-minimal-trixie
 func (env *TestingEnvironment) OfficialMinimalImageName(tag string) string {
-	return fmt.Sprintf("%s:%s-%s", officialPostgresImageRepository, tag, MinimalTrixieSuffix)
+	return fmt.Sprintf("%s:%s-%s", defaultPostgresImageRepository, tag, MinimalTrixieSuffix)
 }
 
 // OfficialPostGISImageName returns the full image name for the official CloudNativePG PostGIS image.

--- a/tests/utils/environment/environment.go
+++ b/tests/utils/environment/environment.go
@@ -69,6 +69,8 @@ type TestingEnvironment struct {
 	Ctx                context.Context
 	Scheme             *runtime.Scheme
 	Log                logr.Logger
+	PostgresImageName  string
+	PostgresImageTag   string
 	PostgresVersion    uint64
 	createdNamespaces  *uniqueStringSlice
 }
@@ -122,11 +124,14 @@ func NewTestingEnvironment() (*TestingEnvironment, error) {
 
 	postgresImage := versions.DefaultImageName
 
-	// Fetching postgres image version.
+	// Fetching postgres image.
 	if postgresImageFromUser, exist := os.LookupEnv("POSTGRES_IMG"); exist {
 		postgresImage = postgresImageFromUser
 	}
 	imageReference := reference.New(postgresImage)
+	env.PostgresImageName = imageReference.Name
+	env.PostgresImageTag = imageReference.Tag
+
 	postgresImageVersion, err := version.FromTag(imageReference.Tag)
 	if err != nil {
 		return nil, err

--- a/tests/utils/environment/environment.go
+++ b/tests/utils/environment/environment.go
@@ -65,8 +65,10 @@ const (
 	// MinimalTrixieSuffix is the suffix for minimal Trixie images
 	MinimalTrixieSuffix = "minimal-trixie"
 
-	defaultPostGISImageRepository = "ghcr.io/cloudnative-pg/postgis"
-	defaultPostGISVersion         = "3"
+	// Official CloudNativePG image repositories
+	officialPostgresImageRepository = "ghcr.io/cloudnative-pg/postgresql"
+	defaultPostGISImageRepository   = "ghcr.io/cloudnative-pg/postgis"
+	defaultPostGISVersion           = "3"
 )
 
 // TestingEnvironment struct for operator testing
@@ -230,4 +232,31 @@ func (env *TestingEnvironment) MinimalImageName(tag string) string {
 // Example: ghcr.io/cloudnative-pg/postgis:17-3-standard-trixie
 func (env *TestingEnvironment) PostGISImageName(tag string) string {
 	return fmt.Sprintf("%s:%s-%s-%s", env.PostGISImageRepository, tag, defaultPostGISVersion, StandardTrixieSuffix)
+}
+
+// OfficialPostgresImageName returns the full image name for the official CloudNativePG Postgres image.
+// Example: ghcr.io/cloudnative-pg/postgresql:17
+func (env *TestingEnvironment) OfficialPostgresImageName(tag string) string {
+	return fmt.Sprintf("%s:%s", officialPostgresImageRepository, tag)
+}
+
+// OfficialStandardImageName returns the full image name for the official standard Postgres image.
+// This is used for major upgrade tests where source images must come from the official registry.
+// Example: ghcr.io/cloudnative-pg/postgresql:16-standard-trixie
+func (env *TestingEnvironment) OfficialStandardImageName(tag string) string {
+	return fmt.Sprintf("%s:%s-%s", officialPostgresImageRepository, tag, StandardTrixieSuffix)
+}
+
+// OfficialMinimalImageName returns the full image name for the official minimal Postgres image.
+// This is used for major upgrade tests where source images must come from the official registry.
+// Example: ghcr.io/cloudnative-pg/postgresql:16-minimal-trixie
+func (env *TestingEnvironment) OfficialMinimalImageName(tag string) string {
+	return fmt.Sprintf("%s:%s-%s", officialPostgresImageRepository, tag, MinimalTrixieSuffix)
+}
+
+// OfficialPostGISImageName returns the full image name for the official CloudNativePG PostGIS image.
+// This is used for major upgrade tests where source images must come from the official registry.
+// Example: ghcr.io/cloudnative-pg/postgis:16-3-standard-trixie
+func (env *TestingEnvironment) OfficialPostGISImageName(tag string) string {
+	return fmt.Sprintf("%s:%s-%s-%s", defaultPostGISImageRepository, tag, defaultPostGISVersion, StandardTrixieSuffix)
 }

--- a/tests/utils/environment/environment.go
+++ b/tests/utils/environment/environment.go
@@ -59,29 +59,30 @@ const (
 	// RetryTimeout retry timeout (in seconds) when a client api call or kubectl cli request get failed
 	RetryTimeout = 60
 
-	// Image suffix constants
+	// StandardTrixieSuffix is the suffix for standard Trixie images
 	StandardTrixieSuffix = "standard-trixie"
-	MinimalTrixieSuffix  = "minimal-trixie"
 
-	// PostGIS configuration
-	DefaultPostGISImageRepository = "ghcr.io/cloudnative-pg/postgis"
-	DefaultPostGISVersion         = "3"
+	// MinimalTrixieSuffix is the suffix for minimal Trixie images
+	MinimalTrixieSuffix = "minimal-trixie"
+
+	defaultPostGISImageRepository = "ghcr.io/cloudnative-pg/postgis"
+	defaultPostGISVersion         = "3"
 )
 
 // TestingEnvironment struct for operator testing
 type TestingEnvironment struct {
-	RestClientConfig   *rest.Config
-	Client             client.Client
-	Interface          kubernetes.Interface
-	APIExtensionClient apiextensionsclientset.Interface
-	Ctx                context.Context
-	Scheme             *runtime.Scheme
-	Log                logr.Logger
-	PostgresImageName  string
-	PostgresImageTag   string
-	PostgresVersion    uint64
+	RestClientConfig       *rest.Config
+	Client                 client.Client
+	Interface              kubernetes.Interface
+	APIExtensionClient     apiextensionsclientset.Interface
+	Ctx                    context.Context
+	Scheme                 *runtime.Scheme
+	Log                    logr.Logger
+	PostgresImageName      string
+	PostgresImageTag       string
+	PostgresVersion        uint64
 	PostGISImageRepository string
-	createdNamespaces  *uniqueStringSlice
+	createdNamespaces      *uniqueStringSlice
 }
 
 type uniqueStringSlice struct {
@@ -142,7 +143,7 @@ func NewTestingEnvironment() (*TestingEnvironment, error) {
 	env.PostgresImageTag = imageReference.Tag
 
 	// Set PostGIS image repository (can be overridden via env variable)
-	env.PostGISImageRepository = DefaultPostGISImageRepository
+	env.PostGISImageRepository = defaultPostGISImageRepository
 	if postgisRepoFromUser, exist := os.LookupEnv("POSTGIS_IMG_REPOSITORY"); exist {
 		env.PostGISImageRepository = postgisRepoFromUser
 	}
@@ -228,5 +229,5 @@ func (env *TestingEnvironment) MinimalImageName(tag string) string {
 // PostGISImageName returns the full image name for a PostGIS image.
 // Example: ghcr.io/cloudnative-pg/postgis:17-3-standard-trixie
 func (env *TestingEnvironment) PostGISImageName(tag string) string {
-	return fmt.Sprintf("%s:%s-%s-%s", env.PostGISImageRepository, tag, DefaultPostGISVersion, StandardTrixieSuffix)
+	return fmt.Sprintf("%s:%s-%s-%s", env.PostGISImageRepository, tag, defaultPostGISVersion, StandardTrixieSuffix)
 }


### PR DESCRIPTION
* Centralize the `PostgresImageName` and `PostgresImageTag` in the suite environment, alongside the existing `PostgresVersion` (the current major version being tested)
* Updated the major upgrade tests to use the new PostGIS tags (e.g `18-3-standard-trixie`)
* Unlocked a few PostGIS upgrade scenarios that were being skipped for issues that have been solved
* Added an extra ENV variable to also allow customizing the PostGIS registry for the upgrade "target" images. 
  This is useful for projects such as [cloudnative-pg/postgres-trunk-containers](https://github.com/cloudnative-pg/postgres-trunk-containers) where we want to customize the target images (and in that case point to the trunk images) . 
Envs:
  *  `POSTGRES_MAJOR_UPGRADE_IMAGE_REGISTRY` for PG images
  * `POSTGIS_MAJOR_UPGRADE_IMAGE_REGISTRY` for PostGIS images

Closes #8893 