### PR TITLE
feat: check for empty wal archive on pg_basebackup bootstrap

### DIFF
--- a/internal/cmd/manager/instance/pgbasebackup/cmd.go
+++ b/internal/cmd/manager/instance/pgbasebackup/cmd.go
@@ -147,7 +147,7 @@ func (env *CloneInfo) bootstrapUsingPgbasebackup(ctx context.Context) error {
 	filePath := filepath.Join(env.info.PgData, constants.CheckEmptyWalArchiveFile)
 	// We create the check empty wal archive file to tell that we should check if the
 	// destination path it is empty
-	if err := fileutils.CreateEmptyFile(filepath.Clean(filePath)); err != nil {
+	if err := fileutils.CreateEmptyFile(filePath); err != nil {
 		return fmt.Errorf("could not create %v file: %w", filePath, err)
 	}
 


### PR DESCRIPTION
Enable the empty WAL archive check also when a Cluster is initialized using the pg_basebackup bootstrap method. 

Closes #8897 