### PR TITLE
fix(docs): replace mkdocs site links with local paths

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -22,7 +22,7 @@ body:
     id: troubleshooting
     attributes:
       label: I have read the troubleshooting guide
-      description: Before you submit a bug, make sure you have read the ["Common issues" section in the Troubleshooting guide](https://cloudnative-pg.io/documentation/current/troubleshooting/#some-common-issues).
+      description: Before you submit a bug, make sure you have read the ["Common issues" section in the Troubleshooting guide](https://github.com/cloudnative-pg/cloudnative-pg/blob/main/docs/src/supported_releases.md).
       options:
         - label: I have read the troubleshooting guide and I think this is a new bug.
           required: true

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -22,7 +22,7 @@ body:
     id: troubleshooting
     attributes:
       label: I have read the troubleshooting guide
-      description: Before you submit a bug, make sure you have read the ["Common issues" section in the Troubleshooting guide](https://cloudnative-pg.io/documentation/current/troubleshooting/#some-common-issues).
+      description: Before you submit a bug, make sure you have read the ["Common issues" section in the Troubleshooting guide](docs/src/troubleshooting.md).
       options:
         - label: I have read the troubleshooting guide and I think this is a new bug.
           required: true
@@ -30,7 +30,7 @@ body:
     id: supported
     attributes:
       label: I am running a supported version of CloudNativePG
-      description: Before you submit a bug, make sure you have read ["Supported releases"](https://cloudnative-pg.io/documentation/current/supported_releases/) and that you are running a supported version of CloudNativePG with the latest patch/security fixes, or you are working on the current trunk (`main` branch)
+      description: Before you submit a bug, make sure you have read ["Supported releases"](docs/src/supported_releases.md) and that you are running a supported version of CloudNativePG with the latest patch/security fixes, or you are working on the current trunk (`main` branch)
       options:
         - label: I have read the troubleshooting guide and I think this is a new bug.
           required: true

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -22,7 +22,7 @@ body:
     id: troubleshooting
     attributes:
       label: I have read the troubleshooting guide
-      description: Before you submit a bug, make sure you have read the ["Common issues" section in the Troubleshooting guide](docs/src/troubleshooting.md).
+      description: Before you submit a bug, make sure you have read the ["Common issues" section in the Troubleshooting guide](https://cloudnative-pg.io/documentation/current/troubleshooting/#some-common-issues).
       options:
         - label: I have read the troubleshooting guide and I think this is a new bug.
           required: true
@@ -30,7 +30,7 @@ body:
     id: supported
     attributes:
       label: I am running a supported version of CloudNativePG
-      description: Before you submit a bug, make sure you have read ["Supported releases"](docs/src/supported_releases.md) and that you are running a supported version of CloudNativePG with the latest patch/security fixes, or you are working on the current trunk (`main` branch)
+      description: Before you submit a bug, make sure you have read ["Supported releases"](https://cloudnative-pg.io/documentation/current/supported_releases/) and that you are running a supported version of CloudNativePG with the latest patch/security fixes, or you are working on the current trunk (`main` branch)
       options:
         - label: I have read the troubleshooting guide and I think this is a new bug.
           required: true

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ ongoing maintenance—through its core component, the CloudNativePG operator.
 
 ## Getting Started
 
-The best way to get started is the [Quickstart Guide](https://cloudnative-pg.io/documentation/current/quickstart/).
+The best way to get started is the [Quickstart Guide](docs/src/quickstart.md).
 
 ## Scope
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ ongoing maintenance—through its core component, the CloudNativePG operator.
 
 ## Getting Started
 
-The best way to get started is the [Quickstart Guide](https://cloudnative-pg.io/documentation/current/quickstart/).
+The best way to get started is the [Quickstart Guide](/docs/src/quickstart.md).
 
 ## Scope
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ ongoing maintenance—through its core component, the CloudNativePG operator.
 
 ## Getting Started
 
-The best way to get started is the [Quickstart Guide](docs/src/quickstart.md).
+The best way to get started is the [Quickstart Guide](https://cloudnative-pg.io/documentation/current/quickstart/).
 
 ## Scope
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,7 +3,7 @@
 ## Supported Versions
 
 For details on all Community supported versions of CloudNativePG, please refer to the
-["Supported releases" section in the official documentation](https://cloudnative-pg.io/documentation/current/supported_releases/).
+["Supported releases" section in the official documentation](/docs/src/supported_releases.md).
 
 ## Reporting a Vulnerability
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,7 +3,7 @@
 ## Supported Versions
 
 For details on all Community supported versions of CloudNativePG, please refer to the
-["Supported releases" section in the official documentation](docs/src/supported_releases.md).
+["Supported releases" section in the official documentation](https://cloudnative-pg.io/documentation/current/supported_releases/).
 
 ## Reporting a Vulnerability
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,7 +3,7 @@
 ## Supported Versions
 
 For details on all Community supported versions of CloudNativePG, please refer to the
-["Supported releases" section in the official documentation](https://cloudnative-pg.io/documentation/current/supported_releases/).
+["Supported releases" section in the official documentation](docs/src/supported_releases.md).
 
 ## Reporting a Vulnerability
 

--- a/docs/src/cnpg_i.md
+++ b/docs/src/cnpg_i.md
@@ -166,7 +166,7 @@ spec:
 
 To enable a plugin, configure the `.spec.plugins` section in your `Cluster`
 resource. Refer to the CloudNativePG API Reference for the full
-[PluginConfiguration](https://cloudnative-pg.io/documentation/current/cloudnative-pg.v1/#postgresql-cnpg-io-v1-PluginConfiguration)
+[PluginConfiguration](https://github.com/cloudnative-pg/cloudnative-pg/blob/main/docs/src/cloudnative-pg.v1.md#pluginconfiguration-----postgresql-cnpg-io-v1-pluginconfiguration)
 specification.
 
 Example:

--- a/docs/src/cnpg_i.md
+++ b/docs/src/cnpg_i.md
@@ -166,7 +166,7 @@ spec:
 
 To enable a plugin, configure the `.spec.plugins` section in your `Cluster`
 resource. Refer to the CloudNativePG API Reference for the full
-[PluginConfiguration](https://github.com/cloudnative-pg/cloudnative-pg/blob/main/docs/src/cloudnative-pg.v1.md#pluginconfiguration-----postgresql-cnpg-io-v1-pluginconfiguration)
+[PluginConfiguration](https://cloudnative-pg.io/documentation/current/cloudnative-pg.v1/#postgresql-cnpg-io-v1-PluginConfiguration)
 specification.
 
 Example:

--- a/docs/src/release_notes/old/v1.19.md
+++ b/docs/src/release_notes/old/v1.19.md
@@ -285,7 +285,7 @@ Important announcements:
 - PostgreSQL version 10 is no longer supported as it has reached its EOL.
   Versions 11 and newer are supported. Please plan your migration to
   PostgreSQL 15 as soon as possible. Refer to
-  ["Importing Postgres databases"](/docs/src/database_import.md)
+  ["Importing Postgres databases"](https://cloudnative-pg.io/documentation/current/database_import/)
   for more information on PostgreSQL major offline upgrades.
 
 Features:

--- a/docs/src/release_notes/old/v1.19.md
+++ b/docs/src/release_notes/old/v1.19.md
@@ -285,7 +285,7 @@ Important announcements:
 - PostgreSQL version 10 is no longer supported as it has reached its EOL.
   Versions 11 and newer are supported. Please plan your migration to
   PostgreSQL 15 as soon as possible. Refer to
-  ["Importing Postgres databases"](https://cloudnative-pg.io/documentation/current/database_import/)
+  ["Importing Postgres databases"](/docs/src/database_import.md)
   for more information on PostgreSQL major offline upgrades.
 
 Features:

--- a/docs/src/samples/k9s/plugins.yml
+++ b/docs/src/samples/k9s/plugins.yml
@@ -1,5 +1,5 @@
 # Move/add to $XDG_CONFIG_HOME/k9s/plugins.yaml
-# Requires the cnpg kubectl plugin. See https://cloudnative-pg.io/documentation/current/kubectl-plugin/
+# Requires the cnpg kubectl plugin. See https://github.com/cloudnative-pg/cloudnative-pg/blob/main/docs/src/kubectl-plugin.md
 #
 # Cluster actions:
 #   b         Request a new physical backup

--- a/docs/src/samples/k9s/plugins.yml
+++ b/docs/src/samples/k9s/plugins.yml
@@ -1,5 +1,5 @@
 # Move/add to $XDG_CONFIG_HOME/k9s/plugins.yaml
-# Requires the cnpg kubectl plugin. See https://github.com/cloudnative-pg/cloudnative-pg/blob/main/docs/src/kubectl-plugin.md
+# Requires the cnpg kubectl plugin. See https://cloudnative-pg.io/documentation/current/kubectl-plugin/
 #
 # Cluster actions:
 #   b         Request a new physical backup


### PR DESCRIPTION
### Summary
Replaced links pointing to the MkDocs site (https://cloudnative-pg.io/documentation/...) with relative links to local files in the repo.

### Changes
Updated internal documentation links in README and related markdown files.
Verified that all internal links render correctly.

### Why
Once the MkDocs site is deprecated, these external links would break. This PR ensures all documentation links are self-contained and future-proof within the repository files.