### PR TITLE
fix(targetTime): clarify timestamp formats and UTC interpretation

### DIFF
--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -2021,7 +2021,8 @@ type RecoveryTarget struct {
 	// +optional
 	TargetLSN string `json:"targetLSN,omitempty"`
 
-	// The target time as a timestamp in the RFC3339 standard
+	// The target time as a timestamp in RFC3339 format or PostgreSQL timestamp format.
+	// Timestamps without an explicit timezone are interpreted as UTC.
 	// +optional
 	TargetTime string `json:"targetTime,omitempty"`
 

--- a/config/crd/bases/postgresql.cnpg.io_clusters.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_clusters.yaml
@@ -1978,8 +1978,9 @@ spec:
                               integer)
                             type: string
                           targetTime:
-                            description: The target time as a timestamp in the RFC3339
-                              standard
+                            description: |-
+                              The target time as a timestamp in RFC3339 format or PostgreSQL timestamp format.
+                              Timestamps without an explicit timezone are interpreted as UTC.
                             type: string
                           targetXID:
                             description: The target transaction ID

--- a/docs/src/cloudnative-pg.v1.md
+++ b/docs/src/cloudnative-pg.v1.md
@@ -2232,7 +2232,7 @@ _Appears in:_
 | `targetXID` _string_ | The target transaction ID |  |  |  |
 | `targetName` _string_ | The target name (to be previously created<br />with `pg_create_restore_point`) |  |  |  |
 | `targetLSN` _string_ | The target LSN (Log Sequence Number) |  |  |  |
-| `targetTime` _string_ | The target time as a timestamp in the RFC3339 standard |  |  |  |
+| `targetTime` _string_ | The target time as a timestamp in RFC3339 format or PostgreSQL timestamp format.<br />Timestamps without an explicit timezone are interpreted as UTC. |  |  |  |
 | `targetImmediate` _boolean_ | End recovery as soon as a consistent state is reached |  |  |  |
 | `exclusive` _boolean_ | Set the target to be exclusive. If omitted, defaults to false, so that<br />in Postgres, `recovery_target_inclusive` will be true |  |  |  |
 

--- a/docs/src/recovery.md
+++ b/docs/src/recovery.md
@@ -405,12 +405,19 @@ Here are the recovery target criteria you can use:
 
 targetTime
 :  Time stamp up to which recovery proceeds, expressed in
-   [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339) format, or as a timestamp.
+   [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339) format, or as a
+   [timestamp](https://www.postgresql.org/docs/current/runtime-config-wal.html#GUC-RECOVERY-TARGET-TIME).
    (The precise stopping point is also influenced by the `exclusive` option.)
 
 :::note
-    RFC 3339 timestamps without an explicit timezone suffix
-    (e.g., `2023-07-06T08:00:39`) are interpreted as UTC.
+    Timestamps without an explicit timezone suffix
+    (e.g., `2023-07-06 08:00:39`) are interpreted as UTC.
+:::
+
+:::warning
+    Always specify an explicit timezone in your timestamp to avoid ambiguity.
+    For example, use `2023-07-06T08:00:39Z` or `2023-07-06T08:00:39+02:00`
+    instead of `2023-07-06 08:00:39`.
 :::
 
 :::warning

--- a/docs/src/recovery.md
+++ b/docs/src/recovery.md
@@ -367,7 +367,7 @@ spec:
           kind: VolumeSnapshot
           apiGroup: snapshot.storage.k8s.io
       recoveryTarget:
-        targetTime: "2023-06-11 08:00:39.00000+02"
+        targetTime: "2023-07-06T08:00:39Z"
   externalClusters:
     - name: origin
       plugin:
@@ -404,7 +404,8 @@ recovery target.
 Here are the recovery target criteria you can use:
 
 targetTime
-:  Time stamp up to which recovery proceeds, expressed in the form of a timestamp.
+:  Time stamp up to which recovery proceeds, expressed in
+   [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339) format, or as a timestamp.
    (The precise stopping point is also influenced by the `exclusive` option.)
 
 :::warning

--- a/docs/src/recovery.md
+++ b/docs/src/recovery.md
@@ -367,7 +367,7 @@ spec:
           kind: VolumeSnapshot
           apiGroup: snapshot.storage.k8s.io
       recoveryTarget:
-        targetTime: "2023-07-06T08:00:39"
+        targetTime: "2023-06-11 08:00:39.00000+02"
   externalClusters:
     - name: origin
       plugin:
@@ -404,8 +404,7 @@ recovery target.
 Here are the recovery target criteria you can use:
 
 targetTime
-:  Time stamp up to which recovery proceeds, expressed in
-   [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339) format.
+:  Time stamp up to which recovery proceeds, expressed in the form of a timestamp.
    (The precise stopping point is also influenced by the `exclusive` option.)
 
 :::warning

--- a/docs/src/recovery.md
+++ b/docs/src/recovery.md
@@ -408,6 +408,11 @@ targetTime
    [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339) format, or as a timestamp.
    (The precise stopping point is also influenced by the `exclusive` option.)
 
+:::note
+    RFC 3339 timestamps without an explicit timezone suffix
+    (e.g., `2023-07-06T08:00:39`) are interpreted as UTC.
+:::
+
 :::warning
     PostgreSQL recovery will stop when it encounters the first transaction that
     occurs after the specified time. If no such transaction exists after the

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/cheynewallace/tabby v1.1.1
 	github.com/cloudnative-pg/barman-cloud v0.3.3
 	github.com/cloudnative-pg/cnpg-i v0.3.0
-	github.com/cloudnative-pg/machinery v0.3.1
+	github.com/cloudnative-pg/machinery v0.3.2-0.20251224124022-0a2c04fbd5fe
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/evanphx/json-patch/v5 v5.9.11
 	github.com/go-logr/logr v1.4.3

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/cheynewallace/tabby v1.1.1
 	github.com/cloudnative-pg/barman-cloud v0.3.3
 	github.com/cloudnative-pg/cnpg-i v0.3.0
-	github.com/cloudnative-pg/machinery v0.3.2-0.20251224124022-0a2c04fbd5fe
+	github.com/cloudnative-pg/machinery v0.3.3
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/evanphx/json-patch/v5 v5.9.11
 	github.com/go-logr/logr v1.4.3

--- a/go.sum
+++ b/go.sum
@@ -24,8 +24,8 @@ github.com/cloudnative-pg/barman-cloud v0.3.3 h1:EEcjeV+IUivDpmyF/H/XGY1pGaKJ5LS
 github.com/cloudnative-pg/barman-cloud v0.3.3/go.mod h1:5CM4MncAxAjnqxjDt0I5E/oVd7gsMLL0/o/wQ+vUSgs=
 github.com/cloudnative-pg/cnpg-i v0.3.0 h1:5ayNOG5x68lU70IVbHDZQrv5p+bErCJ0mqRmOpW2jjE=
 github.com/cloudnative-pg/cnpg-i v0.3.0/go.mod h1:VOIWWXcJ1RyioK+elR2DGOa4cBA6K+6UQgx05aZmH+g=
-github.com/cloudnative-pg/machinery v0.3.1 h1:KtPA6EwELTUNisCMLiFYkK83GU9606rkGQhDJGPB8Yw=
-github.com/cloudnative-pg/machinery v0.3.1/go.mod h1:jebuqKxZAbrRKDEEpVCIDMKW+FbWtB9Kf/hb2kMUu9o=
+github.com/cloudnative-pg/machinery v0.3.2-0.20251224124022-0a2c04fbd5fe h1:Tnh+eRQdcFquywy1Oit9vaMRw1YOfN14+PpMBDhexyk=
+github.com/cloudnative-pg/machinery v0.3.2-0.20251224124022-0a2c04fbd5fe/go.mod h1:RYAYlVKBF5pH4mg+Q8wHjNDyENV9ajbkG41zOEf8DEs=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
 github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=

--- a/go.sum
+++ b/go.sum
@@ -24,8 +24,8 @@ github.com/cloudnative-pg/barman-cloud v0.3.3 h1:EEcjeV+IUivDpmyF/H/XGY1pGaKJ5LS
 github.com/cloudnative-pg/barman-cloud v0.3.3/go.mod h1:5CM4MncAxAjnqxjDt0I5E/oVd7gsMLL0/o/wQ+vUSgs=
 github.com/cloudnative-pg/cnpg-i v0.3.0 h1:5ayNOG5x68lU70IVbHDZQrv5p+bErCJ0mqRmOpW2jjE=
 github.com/cloudnative-pg/cnpg-i v0.3.0/go.mod h1:VOIWWXcJ1RyioK+elR2DGOa4cBA6K+6UQgx05aZmH+g=
-github.com/cloudnative-pg/machinery v0.3.2-0.20251224124022-0a2c04fbd5fe h1:Tnh+eRQdcFquywy1Oit9vaMRw1YOfN14+PpMBDhexyk=
-github.com/cloudnative-pg/machinery v0.3.2-0.20251224124022-0a2c04fbd5fe/go.mod h1:RYAYlVKBF5pH4mg+Q8wHjNDyENV9ajbkG41zOEf8DEs=
+github.com/cloudnative-pg/machinery v0.3.3 h1:CaqXqLTJH9RrVv3R/YU0NmFaI/F18HLg2JfH3mQLcDk=
+github.com/cloudnative-pg/machinery v0.3.3/go.mod h1:RYAYlVKBF5pH4mg+Q8wHjNDyENV9ajbkG41zOEf8DEs=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
 github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=


### PR DESCRIPTION
Update the machinery dependency to v0.3.3 to ensure timestamps without timezone (both RFC3339 and PostgreSQL formats) are interpreted as UTC.

The documentation has been updated to clarify that targetTime accepts both RFC 3339 and PostgreSQL timestamp formats.

Closes #8928

Related: cloudnative-pg/machinery#167