### PR TITLE
fix(controller,backup): select Postgres container by name instead of assuming index

### DIFF
--- a/internal/controller/backup_controller.go
+++ b/internal/controller/backup_controller.go
@@ -688,7 +688,9 @@ func (r *BackupReconciler) getBackupTargetPod(ctx context.Context,
 			return false
 		}
 
-		if pod.Spec.Containers[0].Image != cluster.Status.Image {
+		idx := slices.IndexFunc(pod.Spec.Containers, func(container Container) bool { return container.name == "postgres" })
+
+		if pod.Spec.Containers[idx].Image != cluster.Status.Image {
 			contextLogger.Debug("Instance not having expected image, discarded as target for backup")
 			return false
 		}

--- a/internal/controller/backup_controller_test.go
+++ b/internal/controller/backup_controller_test.go
@@ -107,6 +107,7 @@ var _ = Describe("backup_controller barmanObjectStore unit tests", func() {
 				Phase: corev1.PodRunning,
 				ContainerStatuses: []corev1.ContainerStatus{
 					{
+						Name:        "postgres",
 						ContainerID: containerID,
 					},
 				},


### PR DESCRIPTION
Ensure backups identify the Postgres container by its name rather than assuming the Postgres container is the first container in the Pod spec/status. Pods may include sidecars or other containers which can shift ordering; relying on index 0 is brittle and caused incorrect containerID/image checks.

Closes #8966 

