### PR TITLE
chore: improve renovate configuration

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -36,9 +36,11 @@
       customType: 'regex',
       managerFilePatterns: [
         '/^Makefile$/',
+        '/^hack/setup-cluster.sh$/',
+        '/^hack/e2e/run-e2e-kind.sh$/',
       ],
       matchStrings: [
-        '# renovate: datasource=(?<datasource>[a-z-.]+?) depName=(?<depName>[^\\s]+?)(?: (?:lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?\\s+[A-Za-z0-9_]+?_VERSION\\s*\\?=\\s*["\']?(?<currentValue>.+?)["\']?\\s',
+        '# renovate: datasource=(?<datasource>[a-z-.]+?) depName=(?<depName>[^\\s]+?)(?: (?:lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?\\s+[A-Za-z0-9_]+?_VERSION\\s*\\??=\\s*["\']?(?<currentValue>.+?)["\']?\\s',
       ],
     },
     {
@@ -58,86 +60,6 @@
       matchStrings: [
         '# renovate: datasource=(?<datasource>[a-z-.]+?)(?: (?:lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?\\s+[A-Za-z0-9_]+?\\s*=\\s*["\']?(?<depName>[^:@]+):(?<currentValue>[a-z0-9.-]+)(?:@(?<currentDigest>sha256:[a-f0-9]+))?["\']?,?\\s',
       ],
-    },
-    {
-      customType: 'regex',
-      managerFilePatterns: [
-        '/^.github/workflows/continuous-delivery.yml/',
-        '/^hack/setup-cluster.sh$/',
-      ],
-      matchStrings: [
-        'EXTERNAL_SNAPSHOTTER_VERSION: "(?<currentValue>.*?)"',
-        'EXTERNAL_SNAPSHOTTER_VERSION=(?<currentValue>.*?)\\n',
-      ],
-      datasourceTemplate: 'github-releases',
-      versioningTemplate: 'loose',
-      depNameTemplate: 'kubernetes-csi/external-snapshotter',
-      extractVersionTemplate: '^(?<version>v\\d+\\.\\d+\\.\\d+)',
-    },
-    {
-      customType: 'regex',
-      managerFilePatterns: [
-        '/^hack/setup-cluster.sh$/',
-      ],
-      matchStrings: [
-        'EXTERNAL_PROVISIONER_VERSION=(?<currentValue>.*?)\\n',
-      ],
-      datasourceTemplate: 'github-releases',
-      versioningTemplate: 'loose',
-      depNameTemplate: 'kubernetes-csi/external-provisioner',
-      extractVersionTemplate: '^(?<version>v\\d+\\.\\d+\\.\\d+)',
-    },
-    {
-      customType: 'regex',
-      managerFilePatterns: [
-        '/^hack/setup-cluster.sh$/',
-      ],
-      matchStrings: [
-        'EXTERNAL_RESIZER_VERSION=(?<currentValue>.*?)\\n',
-      ],
-      datasourceTemplate: 'github-releases',
-      versioningTemplate: 'loose',
-      depNameTemplate: 'kubernetes-csi/external-resizer',
-      extractVersionTemplate: '^(?<version>v\\d+\\.\\d+\\.\\d+)',
-    },
-    {
-      customType: 'regex',
-      managerFilePatterns: [
-        '/^hack/setup-cluster.sh$/',
-      ],
-      matchStrings: [
-        'EXTERNAL_ATTACHER_VERSION=(?<currentValue>.*?)\\n',
-      ],
-      datasourceTemplate: 'github-releases',
-      versioningTemplate: 'loose',
-      depNameTemplate: 'kubernetes-csi/external-attacher',
-      extractVersionTemplate: '^(?<version>v\\d+\\.\\d+\\.\\d+)',
-    },
-    {
-      customType: 'regex',
-      managerFilePatterns: [
-        '/^hack/setup-cluster.sh$/',
-      ],
-      matchStrings: [
-        'CSI_DRIVER_HOST_PATH_DEFAULT_VERSION=(?<currentValue>.*?)\\n',
-      ],
-      datasourceTemplate: 'github-releases',
-      versioningTemplate: 'loose',
-      depNameTemplate: 'kubernetes-csi/csi-driver-host-path',
-      extractVersionTemplate: '^(?<version>v\\d+\\.\\d+\\.\\d+)',
-    },
-    {
-      customType: 'regex',
-      managerFilePatterns: [
-        '/^hack/setup-cluster.sh$/',
-        '/^hack/e2e/run-e2e-kind.sh$/',
-      ],
-      matchStrings: [
-        'KIND_NODE_DEFAULT_VERSION=(?<currentValue>.*?)\\n',
-      ],
-      datasourceTemplate: 'docker',
-      versioningTemplate: 'loose',
-      depNameTemplate: 'kindest/node',
     },
     {
       customType: 'regex',
@@ -317,5 +239,15 @@
       pinDigests: true,
       separateMajorMinor: false,
     },
+    {
+      groupName: 'Containers no-digests',
+      matchPackageNames: [
+        'kindest{/,}**',
+        'getwoke{/,}**',
+        'jonasbn/github-action-spellcheck'
+      ],
+      pinDigests: false,
+      separateMajorMinor: false,
+    }
   ],
 }

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -43,6 +43,7 @@ env:
   KIND_VERSION: "v0.30.0"
   # renovate: datasource=github-releases depName=rook/rook versioning=loose
   ROOK_VERSION: "v1.18.5"
+  # renovate: datasource=github-releases depName=kubernetes-csi/external-snapshotter
   EXTERNAL_SNAPSHOTTER_VERSION: "v8.4.0"
   OPERATOR_IMAGE_NAME: "ghcr.io/${{ github.repository }}-testing"
   BUILD_PUSH_PROVENANCE: ""
@@ -1327,7 +1328,7 @@ jobs:
         env:
           # renovate: datasource=github-releases depName=vmware-tanzu/velero
           VELERO_VERSION: "v1.17.0"
-          # renovate: datasource=docker depName=velero/velero-plugin-for-aws
+          # renovate: datasource=github-releases depName=vmware-tanzu/velero-plugin-for-aws
           VELERO_AWS_PLUGIN_VERSION: "v1.13.0"
         with:
           timeout_minutes: 10

--- a/hack/e2e/run-e2e-kind.sh
+++ b/hack/e2e/run-e2e-kind.sh
@@ -33,6 +33,7 @@ E2E_DIR="${HACK_DIR}/e2e"
 
 export PRESERVE_CLUSTER=${PRESERVE_CLUSTER:-false}
 export BUILD_IMAGE=${BUILD_IMAGE:-false}
+# renovate: datasource=docker depName=kindest/node
 KIND_NODE_DEFAULT_VERSION=v1.34.0
 export K8S_VERSION=${K8S_VERSION:-$KIND_NODE_DEFAULT_VERSION}
 export CLUSTER_ENGINE=kind

--- a/hack/setup-cluster.sh
+++ b/hack/setup-cluster.sh
@@ -27,11 +27,17 @@ if [ "${DEBUG-}" = true ]; then
 fi
 
 # Defaults
+# renovate: datasource=docker depName=kindest/node
 KIND_NODE_DEFAULT_VERSION=v1.34.0
+# renovate: datasource=github-releases depName=kubernetes-csi/csi-driver-host-path
 CSI_DRIVER_HOST_PATH_DEFAULT_VERSION=v1.17.0
+# renovate: datasource=github-releases depName=kubernetes-csi/external-snapshotter
 EXTERNAL_SNAPSHOTTER_VERSION=v8.4.0
+# renovate: datasource=github-releases depName=kubernetes-csi/external-provisioner
 EXTERNAL_PROVISIONER_VERSION=v6.0.0
+# renovate: datasource=github-releases depName=kubernetes-csi/external-resizer
 EXTERNAL_RESIZER_VERSION=v2.0.0
+# renovate: datasource=github-releases depName=kubernetes-csi/external-attacher
 EXTERNAL_ATTACHER_VERSION=v4.10.0
 K8S_VERSION=${K8S_VERSION-}
 KUBECTL_VERSION=${KUBECTL_VERSION-}


### PR DESCRIPTION
Renovate wasn't properly handling some versions inside hack/setup-cluster.sh now we manage those version plus a couple of other more.

Added a group for containers that, for now, should not have the digest.

Closes #7722 