### PR TITLE
test: give more disk space to syncreplicas E2Es

### DIFF
--- a/docs/src/failover.md
+++ b/docs/src/failover.md
@@ -151,7 +151,7 @@ spec:
       failoverQuorum: true
 
   storage:
-    size: 1G
+    size: 1Gi
 ```
 
 For backward compatibility, the legacy annotation

--- a/docs/src/replication.md
+++ b/docs/src/replication.md
@@ -187,7 +187,7 @@ spec:
   maxSyncReplicas: 1
 
   storage:
-    size: 1G
+    size: 1Gi
 ```
 
 You can update it to the new format as follows:
@@ -201,7 +201,7 @@ spec:
   instances: 3
 
   storage:
-    size: 1G
+    size: 1Gi
 
   postgresql:
     synchronous:

--- a/docs/src/samples/cluster-example-syncreplicas-explicit.yaml
+++ b/docs/src/samples/cluster-example-syncreplicas-explicit.yaml
@@ -11,4 +11,4 @@ spec:
       number: 2
 
   storage:
-    size: 1G
+    size: 1Gi

--- a/docs/src/samples/cluster-example-syncreplicas-legacy.yaml
+++ b/docs/src/samples/cluster-example-syncreplicas-legacy.yaml
@@ -9,4 +9,4 @@ spec:
   maxSyncReplicas: 3
 
   storage:
-    size: 1G
+    size: 1Gi

--- a/docs/src/samples/cluster-example-syncreplicas-quorum.yaml
+++ b/docs/src/samples/cluster-example-syncreplicas-quorum.yaml
@@ -12,4 +12,4 @@ spec:
       failoverQuorum: true
 
   storage:
-    size: 1G
+    size: 1Gi

--- a/tests/e2e/fixtures/sync_replicas/cluster-pgstatstatements.yaml.template
+++ b/tests/e2e/fixtures/sync_replicas/cluster-pgstatstatements.yaml.template
@@ -25,4 +25,4 @@ spec:
 
   storage:
     storageClass: ${E2E_DEFAULT_STORAGE_CLASS}
-    size: 1G
+    size: 1Gi

--- a/tests/e2e/fixtures/sync_replicas/cluster-sync-replica-legacy.yaml.template
+++ b/tests/e2e/fixtures/sync_replicas/cluster-sync-replica-legacy.yaml.template
@@ -24,4 +24,4 @@ spec:
 
   storage:
     storageClass: ${E2E_DEFAULT_STORAGE_CLASS}
-    size: 1G
+    size: 1Gi

--- a/tests/e2e/fixtures/sync_replicas/cluster-sync-replica.yaml.template
+++ b/tests/e2e/fixtures/sync_replicas/cluster-sync-replica.yaml.template
@@ -24,4 +24,4 @@ spec:
 
   storage:
     storageClass: ${E2E_DEFAULT_STORAGE_CLASS}
-    size: 1G
+    size: 1Gi

--- a/tests/e2e/fixtures/sync_replicas/preferred.yaml.template
+++ b/tests/e2e/fixtures/sync_replicas/preferred.yaml.template
@@ -25,4 +25,4 @@ spec:
 
   storage:
     storageClass: ${E2E_DEFAULT_STORAGE_CLASS}
-    size: 1G
+    size: 1Gi

--- a/tests/e2e/fixtures/sync_replicas/readiness-probe-lag-control.yaml.template
+++ b/tests/e2e/fixtures/sync_replicas/readiness-probe-lag-control.yaml.template
@@ -28,4 +28,4 @@ spec:
 
   storage:
     storageClass: ${E2E_DEFAULT_STORAGE_CLASS}
-    size: 2Gi
+    size: 3Gi

--- a/tests/e2e/fixtures/sync_replicas/readiness-probe-lag-control.yaml.template
+++ b/tests/e2e/fixtures/sync_replicas/readiness-probe-lag-control.yaml.template
@@ -28,4 +28,4 @@ spec:
 
   storage:
     storageClass: ${E2E_DEFAULT_STORAGE_CLASS}
-    size: 1G
+    size: 2Gi

--- a/tests/e2e/fixtures/sync_replicas/startup-probe-lag-control.yaml.template
+++ b/tests/e2e/fixtures/sync_replicas/startup-probe-lag-control.yaml.template
@@ -31,4 +31,4 @@ spec:
 
   storage:
     storageClass: ${E2E_DEFAULT_STORAGE_CLASS}
-    size: 1G
+    size: 2Gi

--- a/tests/e2e/fixtures/sync_replicas/startup-probe-lag-control.yaml.template
+++ b/tests/e2e/fixtures/sync_replicas/startup-probe-lag-control.yaml.template
@@ -31,4 +31,4 @@ spec:
 
   storage:
     storageClass: ${E2E_DEFAULT_STORAGE_CLASS}
-    size: 2Gi
+    size: 3Gi

--- a/tests/e2e/pg_wal_volume_test.go
+++ b/tests/e2e/pg_wal_volume_test.go
@@ -103,7 +103,7 @@ var _ = Describe("Separate pg_wal volume", Label(tests.LabelStorage), func() {
 			Expect(err).NotTo(HaveOccurred())
 			WalStorageClass := os.Getenv("E2E_DEFAULT_STORAGE_CLASS")
 			cluster.Spec.WalStorage = &apiv1.StorageConfiguration{
-				Size:         "1G",
+				Size:         "1Gi",
 				StorageClass: &WalStorageClass,
 			}
 			return env.Client.Update(env.Ctx, cluster)

--- a/tests/e2e/syncreplicas_test.go
+++ b/tests/e2e/syncreplicas_test.go
@@ -139,8 +139,12 @@ var _ = Describe("Synchronous Replicas", Label(tests.LabelReplication), func() {
 			primary, err := clusterutils.GetPrimary(env.Ctx, env.Client, namespace, clusterName)
 			Expect(err).ToNot(HaveOccurred())
 
-			// This will generate 1Gi of data in the primary node and, since the replica we fenced
+			// This will generate ~1GB of data in the primary node and, since the replica we fenced
 			// is not aligned, will generate lag.
+			// The test creates 1M rows, then doubles 3 times (2M, 4M, 8M rows = ~400-500MB data).
+			// However, PostgreSQL generates significant WAL overhead, temporary files, and index data
+			// during these operations. The fixtures using this function should have at least 3Gi
+			// of storage to ensure sufficient space for data, WAL files, and temporary operations.
 			_, _, err = exec.Command(
 				env.Ctx, env.Interface, env.RestClientConfig,
 				*primary, specs.PostgresContainerName, &commandTimeout,


### PR DESCRIPTION
* Increased syncreplicas storage.size to 2Gi
* Aligned all storage units in the E2Es to use the 1024-based notation

Closes #8969 