### PR TITLE
test(targetTime): add E2E for PITR with targetTime specified in RFC3339 format

### DIFF
--- a/api/v1/cluster_funcs.go
+++ b/api/v1/cluster_funcs.go
@@ -1500,9 +1500,7 @@ func (target *RecoveryTarget) BuildPostgresOptions() string {
 	}
 	if target.TargetTime != "" {
 		tt := pgTime.ConvertToPostgresFormat(target.TargetTime)
-		if strings.HasSuffix(tt, "Z") {
-			tt += "ulu"
-		}
+		tt = strings.ReplaceAll(tt, "Z", "+00")
 		result += fmt.Sprintf(
 			"recovery_target_time = '%v'\n",
 			tt)

--- a/api/v1/cluster_funcs.go
+++ b/api/v1/cluster_funcs.go
@@ -1501,6 +1501,7 @@ func (target *RecoveryTarget) BuildPostgresOptions() string {
 	if target.TargetTime != "" {
 		tt := pgTime.ConvertToPostgresFormat(target.TargetTime)
 		tt = strings.ReplaceAll(tt, "Z", "+00")
+		tt = strings.ReplaceAll(tt, " ", "T")
 		result += fmt.Sprintf(
 			"recovery_target_time = '%v'\n",
 			tt)

--- a/api/v1/cluster_funcs.go
+++ b/api/v1/cluster_funcs.go
@@ -1499,9 +1499,13 @@ func (target *RecoveryTarget) BuildPostgresOptions() string {
 			target.TargetLSN)
 	}
 	if target.TargetTime != "" {
+		tt := pgTime.ConvertToPostgresFormat(target.TargetTime)
+		if strings.HasSuffix(tt, "Z") {
+			tt += "ulu"
+		}
 		result += fmt.Sprintf(
 			"recovery_target_time = '%v'\n",
-			pgTime.ConvertToPostgresFormat(target.TargetTime))
+			tt)
 	}
 	if target.TargetImmediate != nil && *target.TargetImmediate {
 		result += "recovery_target = immediate\n"

--- a/api/v1/cluster_funcs.go
+++ b/api/v1/cluster_funcs.go
@@ -1499,12 +1499,9 @@ func (target *RecoveryTarget) BuildPostgresOptions() string {
 			target.TargetLSN)
 	}
 	if target.TargetTime != "" {
-		tt := pgTime.ConvertToPostgresFormat(target.TargetTime)
-		tt = strings.ReplaceAll(tt, "Z", "")
-		tt = strings.ReplaceAll(tt, " ", "T")
 		result += fmt.Sprintf(
 			"recovery_target_time = '%v'\n",
-			tt)
+			pgTime.ConvertToPostgresFormat(target.TargetTime))
 	}
 	if target.TargetImmediate != nil && *target.TargetImmediate {
 		result += "recovery_target = immediate\n"

--- a/api/v1/cluster_funcs.go
+++ b/api/v1/cluster_funcs.go
@@ -1500,7 +1500,7 @@ func (target *RecoveryTarget) BuildPostgresOptions() string {
 	}
 	if target.TargetTime != "" {
 		tt := pgTime.ConvertToPostgresFormat(target.TargetTime)
-		tt = strings.ReplaceAll(tt, "Z", "+00")
+		tt = strings.ReplaceAll(tt, "Z", "")
 		tt = strings.ReplaceAll(tt, " ", "T")
 		result += fmt.Sprintf(
 			"recovery_target_time = '%v'\n",

--- a/tests/e2e/fixtures/volume_snapshot/cluster-pvc-snapshot-restore-rfc3339-pitr.yaml.template
+++ b/tests/e2e/fixtures/volume_snapshot/cluster-pvc-snapshot-restore-rfc3339-pitr.yaml.template
@@ -1,0 +1,46 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: cluster-pvc-snapshot-recovery-rfc3339
+spec:
+  instances: 2
+  primaryUpdateStrategy: unsupervised
+
+  # Persistent storage configuration
+  storage:
+    storageClass: ${E2E_CSI_STORAGE_CLASS}
+    size: 1Gi
+  walStorage:
+    storageClass: ${E2E_CSI_STORAGE_CLASS}
+    size: 1Gi
+
+  bootstrap:
+    recovery:
+      source: cluster-pvc-snapshot
+      volumeSnapshots:
+        storage:
+          name: ${SNAPSHOT_PITR_PGDATA}
+          kind: VolumeSnapshot
+          apiGroup: snapshot.storage.k8s.io
+        walStorage:
+          name: ${SNAPSHOT_PITR_PGWAL}
+          kind: VolumeSnapshot
+          apiGroup: snapshot.storage.k8s.io
+      recoveryTarget:
+        targetTime:  ${SNAPSHOT_PITR_RFC3339}
+
+  externalClusters:
+    - name: cluster-pvc-snapshot
+      barmanObjectStore:
+        destinationPath: s3://cluster-pvc-snapshot/
+        endpointURL: https://minio-service.minio:9000
+        endpointCA:
+          key: ca.crt
+          name: minio-server-ca-secret
+        s3Credentials:
+          accessKeyId:
+            name: backup-storage-creds
+            key: ID
+          secretAccessKey:
+            name: backup-storage-creds
+            key: KEY

--- a/tests/e2e/volume_snapshot_test.go
+++ b/tests/e2e/volume_snapshot_test.go
@@ -210,14 +210,17 @@ var _ = Describe("Verify Volume Snapshot",
 
 			It("correctly executes PITR with a cold snapshot", func() {
 				DeferCleanup(func() error {
-					if err := os.Unsetenv(snapshotDataEnv); err != nil {
-						return err
+					for _, envvar := range []string{
+						snapshotDataEnv,
+						snapshotWalEnv,
+						recoveryTargetTimeEnv,
+						recoveryTargetTimeRFC3339Env,
+					} {
+						if err := os.Unsetenv(envvar); err != nil {
+							return err
+						}
 					}
-					if err := os.Unsetenv(snapshotWalEnv); err != nil {
-						return err
-					}
-					err := os.Unsetenv(recoveryTargetTimeEnv)
-					return err
+					return nil
 				})
 
 				By("creating the cluster to snapshot", func() {

--- a/tests/e2e/volume_snapshot_test.go
+++ b/tests/e2e/volume_snapshot_test.go
@@ -355,13 +355,11 @@ var _ = Describe("Verify Volume Snapshot",
 					})
 				}
 
-				Context("with recovery time as Postgres timestamp", func() {
-					assertRecoveryIsAtExpectedPointInTime(clusterSnapshotRestoreFile)
-				})
+				By("with recovery time as Postgres timestamp")
+				assertRecoveryIsAtExpectedPointInTime(clusterSnapshotRestoreFile)
 
-				Context("with recovery time in RFC3339 format", func() {
-					assertRecoveryIsAtExpectedPointInTime(clusterSnapshotRestoreRFC3339File)
-				})
+				By("with recovery time in RFC3339 format")
+				assertRecoveryIsAtExpectedPointInTime(clusterSnapshotRestoreRFC3339File)
 			})
 		})
 

--- a/tests/e2e/volume_snapshot_test.go
+++ b/tests/e2e/volume_snapshot_test.go
@@ -160,17 +160,19 @@ var _ = Describe("Verify Volume Snapshot",
 		Context("Can restore from a Volume Snapshot", Ordered, func() {
 			// test env constants
 			const (
-				namespacePrefix       = "volume-snapshot-recovery"
-				level                 = tests.High
-				filesDir              = fixturesDir + "/volume_snapshot"
-				snapshotDataEnv       = "SNAPSHOT_PITR_PGDATA"
-				snapshotWalEnv        = "SNAPSHOT_PITR_PGWAL"
-				recoveryTargetTimeEnv = "SNAPSHOT_PITR"
+				namespacePrefix              = "volume-snapshot-recovery"
+				level                        = tests.High
+				filesDir                     = fixturesDir + "/volume_snapshot"
+				snapshotDataEnv              = "SNAPSHOT_PITR_PGDATA"
+				snapshotWalEnv               = "SNAPSHOT_PITR_PGWAL"
+				recoveryTargetTimeEnv        = "SNAPSHOT_PITR"
+				recoveryTargetTimeRFC3339Env = "SNAPSHOT_PITR_RFC3339"
 			)
 			// file constants
 			const (
-				clusterToSnapshot          = filesDir + "/cluster-pvc-snapshot.yaml.template"
-				clusterSnapshotRestoreFile = filesDir + "/cluster-pvc-snapshot-restore.yaml.template"
+				clusterToSnapshot                 = filesDir + "/cluster-pvc-snapshot.yaml.template"
+				clusterSnapshotRestoreFile        = filesDir + "/cluster-pvc-snapshot-restore.yaml.template"
+				clusterSnapshotRestoreRFC3339File = filesDir + "/cluster-pvc-snapshot-restore-rfc3339-pitr.yaml.template"
 			)
 			// database constants
 			const (
@@ -305,6 +307,10 @@ var _ = Describe("Verify Volume Snapshot",
 					err = os.Setenv(recoveryTargetTimeEnv, recoveryTargetTime)
 					Expect(err).ToNot(HaveOccurred())
 
+					recoveryTargetTimeRFC3339 := time.Now().Format(time.RFC3339)
+					Expect(os.Setenv(recoveryTargetTimeRFC3339Env, recoveryTargetTimeRFC3339)).
+						To(Succeed())
+
 					forward, conn, err := postgres.ForwardPSQLConnection(
 						env.Ctx,
 						env.Client,
@@ -328,23 +334,33 @@ var _ = Describe("Verify Volume Snapshot",
 					AssertArchiveWalOnMinio(namespace, clusterToSnapshotName, clusterToSnapshotName)
 				})
 
-				clusterToRestoreName, err := yaml.GetResourceNameFromYAML(env.Scheme, clusterSnapshotRestoreFile)
-				Expect(err).ToNot(HaveOccurred())
+				assertRecoveryIsAtExpectedPointInTime := func(restoreFile string) {
+					clusterToRestoreName, err := yaml.GetResourceNameFromYAML(env.Scheme, restoreFile)
+					Expect(err).ToNot(HaveOccurred())
 
-				By("creating the cluster to be restored through snapshot and PITR", func() {
-					AssertCreateCluster(namespace, clusterToRestoreName, clusterSnapshotRestoreFile, env)
-					AssertClusterIsReady(namespace, clusterToRestoreName, testTimeouts[timeouts.ClusterIsReadySlow],
-						env)
+					By("creating the cluster to be restored through snapshot and PITR", func() {
+						AssertCreateCluster(namespace, clusterToRestoreName, restoreFile, env)
+						AssertClusterIsReady(namespace, clusterToRestoreName, testTimeouts[timeouts.ClusterIsReadySlow],
+							env)
+					})
+
+					By("verifying the correct data exists in the restored cluster", func() {
+						tableLocator := TableLocator{
+							Namespace:    namespace,
+							ClusterName:  clusterToRestoreName,
+							DatabaseName: postgres.AppDBName,
+							TableName:    tableName,
+						}
+						AssertDataExpectedCount(env, tableLocator, 2)
+					})
+				}
+
+				Context("with recovery time as Postgres timestamp", func() {
+					assertRecoveryIsAtExpectedPointInTime(clusterSnapshotRestoreFile)
 				})
 
-				By("verifying the correct data exists in the restored cluster", func() {
-					tableLocator := TableLocator{
-						Namespace:    namespace,
-						ClusterName:  clusterToRestoreName,
-						DatabaseName: postgres.AppDBName,
-						TableName:    tableName,
-					}
-					AssertDataExpectedCount(env, tableLocator, 2)
+				Context("with recovery time in RFC3339 format", func() {
+					assertRecoveryIsAtExpectedPointInTime(clusterSnapshotRestoreRFC3339File)
 				})
 			})
 		})

--- a/tests/e2e/volume_snapshot_test.go
+++ b/tests/e2e/volume_snapshot_test.go
@@ -206,7 +206,7 @@ var _ = Describe("Verify Volume Snapshot",
 				Expect(err).ToNot(HaveOccurred())
 			})
 
-			assertExecutesPITRwithColdSnapshot := func(recoveryTargetTime string) {
+			It("correctly executes PITR with a cold snapshot", func() {
 				DeferCleanup(func() error {
 					if err := os.Unsetenv(snapshotDataEnv); err != nil {
 						return err
@@ -296,7 +296,11 @@ var _ = Describe("Verify Volume Snapshot",
 					// right after the creation of the test data, we wait for 1s to avoid not
 					// including the newly created data within the recovery_target_time
 					time.Sleep(1 * time.Second)
-					Expect(os.Setenv(recoveryTargetTimeEnv, recoveryTargetTime)).To(Succeed())
+					// Get the recovery_target_time and pass it to the template engine
+					recoveryTargetTime := time.Now().Format(time.RFC3339)
+					GinkgoWriter.Println("XXX RECOVERY TARGET", recoveryTargetTime)
+					err := os.Setenv(recoveryTargetTimeEnv, recoveryTargetTime)
+					Expect(err).ToNot(HaveOccurred())
 
 					forward, conn, err := postgres.ForwardPSQLConnection(
 						env.Ctx,
@@ -338,25 +342,6 @@ var _ = Describe("Verify Volume Snapshot",
 						TableName:    tableName,
 					}
 					AssertDataExpectedCount(env, tableLocator, 2)
-				})
-			}
-
-			When("targetTime is specified in Postgres timestamp format", func() {
-				It("correctly executes PITR with a cold snapshot", func() {
-					// Get the recovery_target_time and pass it to the template engine
-					recoveryTargetTime, err := postgres.GetCurrentTimestamp(
-						env.Ctx, env.Client, env.Interface, env.RestClientConfig,
-						namespace, clusterToSnapshotName,
-					)
-					Expect(err).ShouldNot(HaveOccurred())
-					assertExecutesPITRwithColdSnapshot(recoveryTargetTime)
-				})
-			})
-
-			When("targetTime is specified in RFC3339 format", func() {
-				It("correctly executes PITR with a cold snapshot", func() {
-					recoveryTargetTime := time.Now().Format(time.RFC3339)
-					assertExecutesPITRwithColdSnapshot(recoveryTargetTime)
 				})
 			})
 		})

--- a/tests/e2e/volume_snapshot_test.go
+++ b/tests/e2e/volume_snapshot_test.go
@@ -297,9 +297,12 @@ var _ = Describe("Verify Volume Snapshot",
 					// including the newly created data within the recovery_target_time
 					time.Sleep(1 * time.Second)
 					// Get the recovery_target_time and pass it to the template engine
-					recoveryTargetTime := time.Now().Format(time.RFC3339)
-					GinkgoWriter.Println("XXX RECOVERY TARGET", recoveryTargetTime)
-					err := os.Setenv(recoveryTargetTimeEnv, recoveryTargetTime)
+					recoveryTargetTime, err := postgres.GetCurrentTimestamp(
+						env.Ctx, env.Client, env.Interface, env.RestClientConfig,
+						namespace, clusterToSnapshotName,
+					)
+					Expect(err).ToNot(HaveOccurred())
+					err = os.Setenv(recoveryTargetTimeEnv, recoveryTargetTime)
 					Expect(err).ToNot(HaveOccurred())
 
 					forward, conn, err := postgres.ForwardPSQLConnection(

--- a/tests/e2e/volume_snapshot_test.go
+++ b/tests/e2e/volume_snapshot_test.go
@@ -297,12 +297,9 @@ var _ = Describe("Verify Volume Snapshot",
 					// including the newly created data within the recovery_target_time
 					time.Sleep(1 * time.Second)
 					// Get the recovery_target_time and pass it to the template engine
-					recoveryTargetTime, err := postgres.GetCurrentTimestamp(
-						env.Ctx, env.Client, env.Interface, env.RestClientConfig,
-						namespace, clusterToSnapshotName,
-					)
-					Expect(err).ToNot(HaveOccurred())
-					err = os.Setenv(recoveryTargetTimeEnv, recoveryTargetTime)
+					recoveryTargetTime := time.Now().Format(time.RFC3339)
+					GinkgoWriter.Println("XXX RECOVERY TARGET", recoveryTargetTime)
+					err := os.Setenv(recoveryTargetTimeEnv, recoveryTargetTime)
 					Expect(err).ToNot(HaveOccurred())
 
 					forward, conn, err := postgres.ForwardPSQLConnection(


### PR DESCRIPTION
Exercises the machinery fix (cloudnative-pg/machinery#168) that allows RFC3339 timestamps in recovery_target_time. The existing PITR snapshot test is extended to also restore with an RFC3339-formatted targetTime, ensuring both formats work end-to-end.

Ref: https://github.com/cloudnative-pg/cloudnative-pg/pull/8937, https://github.com/cloudnative-pg/machinery/issues/167