### PR TITLE
feat(report,operator): add support for least-privilege access

### DIFF
--- a/docs/src/kubectl-plugin.md
+++ b/docs/src/kubectl-plugin.md
@@ -504,8 +504,9 @@ regarding the operator deployment, configuration and events.
 !!! Important "Least-Privilege Support"
     The `report operator` command works with minimal permissions. Only the operator
     deployment is **required** - all other resources are optional and collected on a
-    best-effort basis. If you lack permissions for certain resources, warnings are
-    logged and report generation continues with available data.
+    best-effort basis. If you lack permissions for certain resources (e.g., webhooks,
+    OLM resources), warnings are logged and report generation continues with available
+    data.
 
 The report includes:
 
@@ -513,14 +514,27 @@ The report includes:
 * **operator pods** (optional): the operator Pod information
 * **configuration** (optional): Secrets and ConfigMaps in the operator namespace
 * **events** (optional): Events in the operator namespace
-* **webhook configuration** (optional): mutating and validating webhook configurations
+* **webhook configuration** (optional): mutating and validating webhook configurations (cluster-scoped)
 * **webhook service** (optional): the webhook service
+* **OLM resources** (optional): subscriptions, cluster service versions, install plans (if OLM is installed)
 * **logs** (optional): operator Pod logs in JSON-lines format (requires `--logs` flag)
 
-**Minimal permissions**: Read access (`get`) to the operator deployment.
+**Minimal permissions**: Read access (`get`) to the operator deployment in the operator
+namespace. This allows namespace-scoped users to generate basic troubleshooting reports.
 
-**Full report permissions**: Add `list` on pods, events; `get` on secrets, configmaps,
-services (namespace-scoped); and `list` on webhook configurations (cluster-scoped).
+**Recommended permissions for full report**: Add `list` on pods, events; `get` on secrets,
+configmaps, services (namespace-scoped); and `list` on webhook configurations (cluster-scoped).
+
+!!! Example "Namespace-Scoped User"
+    A user with only namespace-scoped permissions can still generate useful reports:
+
+    ```sh
+    # With only deployment read access
+    kubectl cnpg report operator -n cnpg-system -f report.zip
+    ```
+
+    The command will log warnings for inaccessible resources but successfully generate
+    a report with the deployment manifest, which is often sufficient for basic troubleshooting.
 
 The command will generate a ZIP file containing various manifest in YAML format
 (by default, but settable to JSON with the `-o` flag).

--- a/docs/src/kubectl-plugin.md
+++ b/docs/src/kubectl-plugin.md
@@ -501,12 +501,26 @@ regarding the operator deployment, configuration and events.
     By default, operator logs are not collected, but you can enable operator
     log collection with the `--logs` flag
 
-* **deployment information**: the operator Deployment and operator Pod
-* **configuration**: the Secrets and ConfigMaps in the operator namespace
-* **events**: the Events in the operator namespace
-* **webhook configuration**: the mutating and validating webhook configurations
-* **webhook service**: the webhook service
-* **logs**: logs for the operator Pod (optional, off by default) in JSON-lines format
+!!! Important "Least-Privilege Support"
+    The `report operator` command works with minimal permissions. Only the operator
+    deployment is **required** - all other resources are optional and collected on a
+    best-effort basis. If you lack permissions for certain resources, warnings are
+    logged and report generation continues with available data.
+
+The report includes:
+
+* **deployment information** (required): the operator Deployment
+* **operator pods** (optional): the operator Pod information
+* **configuration** (optional): Secrets and ConfigMaps in the operator namespace
+* **events** (optional): Events in the operator namespace
+* **webhook configuration** (optional): mutating and validating webhook configurations
+* **webhook service** (optional): the webhook service
+* **logs** (optional): operator Pod logs in JSON-lines format (requires `--logs` flag)
+
+**Minimal permissions**: Read access (`get`) to the operator deployment.
+
+**Full report permissions**: Add `list` on pods, events; `get` on secrets, configmaps,
+services (namespace-scoped); and `list` on webhook configurations (cluster-scoped).
 
 The command will generate a ZIP file containing various manifest in YAML format
 (by default, but settable to JSON with the `-o` flag).
@@ -1397,7 +1411,7 @@ table contains the full details:
 | publication     | clusters: get<br/>pods: get,list<br/>pods/exec: create                                                                                                                                                                                                                                                                                                |
 | reload          | clusters: get,patch                                                                                                                                                                                                                                                                                                                                   |
 | report cluster  | clusters: get<br/>pods: list<br/>pods/log: get<br/>jobs: list<br/>events: list<br/>PVCs: list                                                                                                                                                                                                                                                         |
-| report operator | configmaps: get<br/>deployments: get<br/>events: list<br/>pods: list<br/>pods/log: get<br/>secrets: get<br/>services: get<br/>mutatingwebhookconfigurations: list[^1]<br/> validatingwebhookconfigurations: list[^1]<br/> If OLM is present on the K8s cluster, also:<br/>clusterserviceversions: list<br/>installplans: list<br/>subscriptions: list |
+| report operator | **Required:**<br/>deployments: get<br/>**Optional (for full report):**<br/>configmaps: get<br/>events: list<br/>pods: list<br/>pods/log: get<br/>secrets: get<br/>services: get<br/>mutatingwebhookconfigurations: list[^1]<br/>validatingwebhookconfigurations: list[^1]<br/>**If OLM is present:**<br/>clusterserviceversions: list[^1]<br/>installplans: list[^1]<br/>subscriptions: list[^1] |
 | restart         | clusters: get,patch<br/>pods: get,delete                                                                                                                                                                                                                                                                                                              |
 | status          | clusters: get<br/>pods: list<br/>pods/exec: create<br/>pods/proxy: create<br/>PDBs: list<br/>objectstores.barmancloud.cnpg.io: get                                                                                                                                                                                                                    |
 | subscription    | clusters: get<br/>pods: get,list<br/>pods/exec: create                                                                                                                                                                                                                                                                                                |

--- a/docs/src/kubectl-plugin.md
+++ b/docs/src/kubectl-plugin.md
@@ -143,20 +143,20 @@ brew upgrade kubectl-cnpg
 CloudNativePG Plugin is currently built for the following
 operating system and architectures:
 
-* Linux
-    * amd64
-    * arm 5/6/7
-    * arm64
-    * s390x
-    * ppc64le
-* macOS
-    * amd64
-    * arm64
-* Windows
-    * 386
-    * amd64
-    * arm 5/6/7
-    * arm64
+- Linux
+  - amd64
+  - arm 5/6/7
+  - arm64
+  - s390x
+  - ppc64le
+- macOS
+  - amd64
+  - arm64
+- Windows
+  - 386
+  - amd64
+  - arm 5/6/7
+  - arm64
 
 ### Configuring auto-completion
 
@@ -245,14 +245,14 @@ The flags in the above command have the following meaning:
 The `status` command provides an overview of the current status of your
 cluster, including:
 
-* **general information**: name of the cluster, PostgreSQL's system ID, number of
+- **general information**: name of the cluster, PostgreSQL's system ID, number of
   instances, current timeline and position in the WAL
-* **backup**: point of recoverability, and WAL archiving status as returned by
+- **backup**: point of recoverability, and WAL archiving status as returned by
   the `pg_stat_archiver` view from the primary - or designated primary in the
   case of a replica cluster
-* **streaming replication**: information taken directly from the `pg_stat_replication`
+- **streaming replication**: information taken directly from the `pg_stat_replication`
   view on the primary instance
-* **instances**: information about each Postgres instance, taken directly by each
+- **instances**: information about each Postgres instance, taken directly by each
   instance manager; in the case of a standby, the `Current LSN` field corresponds
   to the latest write-ahead log location that has been replayed during recovery
   (replay LSN).
@@ -446,8 +446,8 @@ The `kubectl cnpg maintenance` command helps to modify one or more clusters
 across namespaces and set the maintenance window values, it will change
 the following fields:
 
-* .spec.nodeMaintenanceWindow.inProgress
-* .spec.nodeMaintenanceWindow.reusePVC
+- `.spec.nodeMaintenanceWindow.inProgress`
+- `.spec.nodeMaintenanceWindow.reusePVC`
 
 Accepts as argument `set` and `unset` using this to set the
 `inProgress` to `true` in case `set`and to `false` in case of `unset`.
@@ -510,42 +510,50 @@ regarding the operator deployment, configuration and events.
 
 The report includes:
 
-* **deployment information** (required): the operator Deployment
-* **operator pods** (optional): the operator Pod information
-* **configuration** (optional): Secrets and ConfigMaps in the operator namespace
-* **events** (optional): Events in the operator namespace
-* **webhook configuration** (optional): mutating and validating webhook configurations (cluster-scoped)
-* **webhook service** (optional): the webhook service
-* **OLM resources** (optional): subscriptions, cluster service versions, install plans (if OLM is installed)
-* **logs** (optional): operator Pod logs in JSON-lines format (requires `--logs` flag)
+- **deployment information** (required): the operator `Deployment`
+- **operator pods** (optional): the operator `Pod` information
+- **configuration** (optional): `Secrets` and `ConfigMaps` in the operator
+  namespace
+- **events** (optional): `Events` in the operator namespace
+- **webhook configuration** (optional): mutating and validating webhook
+  configurations (cluster-scoped)
+- **webhook service** (optional): the webhook service
+- **OLM resources** (optional): subscriptions, cluster service versions,
+  install plans (if OLM is installed)
+- **logs** (optional): operator `Pod` logs in JSON-lines format (requires
+  `--logs` flag)
 
-**Minimal permissions**: Read access (`get`) to the operator deployment in the operator
-namespace. This allows namespace-scoped users to generate basic troubleshooting reports.
+!!! Warning "Minimal permissions"
+    Read access (`get`) to the operator deployment in the operator namespace.
+    This allows namespace-scoped users to generate basic troubleshooting reports.
 
-**Recommended permissions for full report**: Add `list` on pods, events; `get` on secrets,
-configmaps, services (namespace-scoped); and `list` on webhook configurations (cluster-scoped).
+!!! Important "Recommended permissions for full report"
+    Add `list` on pods, events; `get` on secrets, configmaps, services
+    (namespace-scoped); and `list` on webhook configurations (cluster-scoped).
 
-!!! Example "Namespace-Scoped User"
-    A user with only namespace-scoped permissions can still generate useful reports:
+A user with only namespace-scoped permissions can still generate useful
+reports:
 
-    ```sh
-    # With only deployment read access
-    kubectl cnpg report operator -n cnpg-system -f report.zip
-    ```
+```sh
+# With only deployment read access
+kubectl cnpg report operator -n cnpg-system -f report.zip
+```
 
-    The command will log warnings for inaccessible resources but successfully generate
-    a report with the deployment manifest, which is often sufficient for basic troubleshooting.
+!!! Info
+    The command will log warnings for inaccessible resources but successfully
+    generate a report with the deployment manifest, which is often sufficient for
+    basic troubleshooting.
 
 The command will generate a ZIP file containing various manifest in YAML format
-(by default, but settable to JSON with the `-o` flag).
-Use the `-f` flag to name a result file explicitly. If the `-f` flag is not used, a
-default time-stamped filename is created for the zip file.
+(by default, but settable to JSON with the `-o` flag). Use the `-f` flag to
+name a result file explicitly. If the `-f` flag is not used, a default
+time-stamped filename is created for the zip file.
 
 !!! Note
-    The report plugin obeys `kubectl` conventions, and will look for objects constrained
-    by namespace. The CNPG Operator will generally not be installed in the same
-    namespace as the clusters.
-    E.g. the default installation namespace is cnpg-system
+    The report plugin obeys `kubectl` conventions, and will look for objects
+    constrained by namespace. The CNPG Operator will generally not be installed in
+    the same namespace as the clusters. E.g. the default installation namespace is
+    cnpg-system.
 
 ```sh
 kubectl cnpg report operator -n cnpg-system
@@ -667,12 +675,12 @@ metadata:
 
 The `cluster` sub-command gathers the following:
 
-* **cluster resources**: the cluster information, same as `kubectl get cluster -o yaml`
-* **cluster pods**: pods in the cluster namespace matching the cluster name
-* **cluster jobs**: jobs, if any, in the cluster namespace matching the cluster name
-* **events**: events in the cluster namespace
-* **pod logs**: logs for the cluster Pods (optional, off by default) in JSON-lines format
-* **job logs**: logs for the Pods created by jobs (optional, off by default) in JSON-lines format
+- **cluster resources**: the cluster information, same as `kubectl get cluster -o yaml`
+- **cluster pods**: pods in the cluster namespace matching the cluster name
+- **cluster jobs**: jobs, if any, in the cluster namespace matching the cluster name
+- **events**: events in the cluster namespace
+- **pod logs**: logs for the cluster Pods (optional, off by default) in JSON-lines format
+- **job logs**: logs for the Pods created by jobs (optional, off by default) in JSON-lines format
 
 The `cluster` sub-command accepts the `-f` and `-o` flags, as the `operator` does.
 If the `-f` flag is not used, a default timestamped report name will be used.

--- a/internal/cmd/plugin/report/operator_report.go
+++ b/internal/cmd/plugin/report/operator_report.go
@@ -98,66 +98,35 @@ func (or operatorReport) writeToZip(zipper *zip.Writer, format plugin.OutputForm
 func operator(ctx context.Context, format plugin.OutputFormat,
 	file string, stopRedaction, includeLogs, logTimeStamp bool, now time.Time,
 ) error {
-	secretRedactor := redactSecret
-	configMapRedactor := redactConfigMap
-	if stopRedaction {
-		secretRedactor = passSecret
-		configMapRedactor = passConfigMap
-		fmt.Println("WARNING: secret Redaction is OFF. Use it with caution")
-	}
+	// Configure redactors
+	secretRedactor, configMapRedactor := configureRedactors(stopRedaction)
 
-	operatorDeployment, err := getOperatorDeployment(ctx)
-	if errors.Is(err, errNoOperatorDeployment) {
-		// Try to be helpful to the user
-		return fmt.Errorf("%w\n"+
-			"HINT: Operator might be installed in another namespace."+
-			"Specify a namespace using the '-n' option", err)
-	} else if err != nil {
-		return fmt.Errorf("could not get operator deployment: %w", err)
-	}
-
-	operatorPods, err := getOperatorPods(ctx)
+	// Collect required namespace-scoped resources (these must succeed)
+	deployment, pods, err := collectRequiredResources(ctx)
 	if err != nil {
-		return fmt.Errorf("could not get operator pod: %w", err)
+		return err
 	}
 
-	operatorSecrets, err := getOperatorSecrets(ctx, operatorDeployment)
+	// Collect configurations with redaction
+	secrets, configs, err := collectConfigurations(ctx, deployment, secretRedactor, configMapRedactor)
 	if err != nil {
-		return fmt.Errorf("could not get operator secrets: %w", err)
-	}
-	secrets := make([]namedObject, 0, len(operatorSecrets))
-	for _, ss := range operatorSecrets {
-		secrets = append(secrets, namedObject{Name: ss.Name + "(secret)", Object: secretRedactor(ss)})
+		return err
 	}
 
-	operatorConfigMaps, err := getOperatorConfigMaps(ctx, operatorDeployment)
+	// Collect events
+	events, err := collectEvents(ctx, pods[0].Namespace)
 	if err != nil {
-		return fmt.Errorf("could not get operator configmap: %w", err)
-	}
-	configs := make([]namedObject, 0, len(operatorConfigMaps))
-	for _, cm := range operatorConfigMaps {
-		configs = append(configs, namedObject{Name: cm.Name, Object: configMapRedactor(cm)})
+		return err
 	}
 
-	var events corev1.EventList
-	err = plugin.Client.List(ctx, &events, client.InNamespace(operatorPods[0].Namespace))
-	if err != nil {
-		return fmt.Errorf("could not get events: %w", err)
-	}
+	// Collect optional cluster-scoped resources (these can fail gracefully)
+	mutatingWebhook, validatingWebhook := tryCollectWebhooks(ctx, stopRedaction)
+	webhookService := tryCollectWebhookService(ctx, mutatingWebhook)
 
-	mutatingWebhook, validatingWebhook, err := getWebhooks(ctx, stopRedaction)
-	if err != nil {
-		return fmt.Errorf("could not get webhooks: %w", err)
-	}
-
-	webhookService, err := getWebhookService(ctx, mutatingWebhook)
-	if err != nil {
-		return fmt.Errorf("could not get webhook service: %w", err)
-	}
-
+	// Build the report structure
 	rep := operatorReport{
-		deployment:              operatorDeployment,
-		operatorPods:            operatorPods,
+		deployment:              deployment,
+		operatorPods:            pods,
 		secrets:                 secrets,
 		configs:                 configs,
 		events:                  events,
@@ -166,46 +135,187 @@ func operator(ctx context.Context, format plugin.OutputFormat,
 		webhookService:          webhookService,
 	}
 
-	reportZipper := func(zipper *zip.Writer, dirname string) error {
-		return rep.writeToZip(zipper, format, dirname)
-	}
+	// Assemble all sections for the ZIP file
+	sections := assembleSections(ctx, rep, pods, format, includeLogs, logTimeStamp)
 
-	sections := []zipFileWriter{reportZipper}
-
-	if includeLogs {
-		logZipper := func(zipper *zip.Writer, dirname string) error {
-			return streamOperatorLogsToZip(ctx, operatorPods, dirname, "operator-logs", logTimeStamp, zipper)
-		}
-		sections = append(sections, logZipper)
-	}
-
-	// Detect if we are running in an OLM cluster
-	discoveryClient, err := utils.GetDiscoveryClient()
-	if err != nil {
-		return err
-	}
-
-	if err = utils.DetectOLM(discoveryClient); err != nil {
-		return fmt.Errorf("unable too look for OLM resources: %w", err)
-	}
-
-	if utils.RunningOnOLM() {
-		olmReport, err := getOlmReport(ctx, plugin.Namespace)
-		if err != nil {
-			return fmt.Errorf("could not get openshift operator report: %w", err)
-		}
-		olmZipper := func(zipper *zip.Writer, dirname string) error {
-			return olmReport.writeToZip(zipper, format, dirname)
-		}
-		sections = append(sections, olmZipper)
-	}
-
-	err = writeZippedReport(sections, file, reportName("operator", now))
-	if err != nil {
+	// Write the final report
+	if err := writeZippedReport(sections, file, reportName("operator", now)); err != nil {
 		return fmt.Errorf("could not write report: %w", err)
 	}
 
 	fmt.Printf("Successfully written report to \"%s\" (format: \"%s\")\n", file, format)
-
 	return nil
+}
+
+// configureRedactors sets up the appropriate redaction functions based on user preference
+func configureRedactors(stopRedaction bool) (
+	func(corev1.Secret) corev1.Secret, func(corev1.ConfigMap) corev1.ConfigMap,
+) {
+	if stopRedaction {
+		fmt.Println("WARNING: secret Redaction is OFF. Use it with caution")
+		return passSecret, passConfigMap
+	}
+	return redactSecret, redactConfigMap
+}
+
+// collectRequiredResources gathers deployment and pods which are required for the report
+func collectRequiredResources(ctx context.Context) (appsv1.Deployment, []corev1.Pod, error) {
+	deployment, err := getOperatorDeployment(ctx)
+	if errors.Is(err, errNoOperatorDeployment) {
+		return appsv1.Deployment{}, nil, fmt.Errorf("%w\n"+
+			"HINT: Operator might be installed in another namespace."+
+			"Specify a namespace using the '-n' option", err)
+	}
+	if err != nil {
+		return appsv1.Deployment{}, nil, fmt.Errorf("could not get operator deployment: %w", err)
+	}
+
+	pods, err := getOperatorPods(ctx)
+	if err != nil {
+		return appsv1.Deployment{}, nil, fmt.Errorf("could not get operator pod: %w", err)
+	}
+
+	return deployment, pods, nil
+}
+
+// collectConfigurations gathers secrets and configmaps with appropriate redaction
+func collectConfigurations(
+	ctx context.Context,
+	deployment appsv1.Deployment,
+	secretRedactor func(corev1.Secret) corev1.Secret,
+	configMapRedactor func(corev1.ConfigMap) corev1.ConfigMap,
+) ([]namedObject, []namedObject, error) {
+	operatorSecrets, err := getOperatorSecrets(ctx, deployment)
+	if err != nil {
+		return nil, nil, fmt.Errorf("could not get operator secrets: %w", err)
+	}
+
+	secrets := make([]namedObject, 0, len(operatorSecrets))
+	for _, ss := range operatorSecrets {
+		secrets = append(secrets, namedObject{
+			Name:   ss.Name + "(secret)",
+			Object: secretRedactor(ss),
+		})
+	}
+
+	operatorConfigMaps, err := getOperatorConfigMaps(ctx, deployment)
+	if err != nil {
+		return nil, nil, fmt.Errorf("could not get operator configmap: %w", err)
+	}
+
+	configs := make([]namedObject, 0, len(operatorConfigMaps))
+	for _, cm := range operatorConfigMaps {
+		configs = append(configs, namedObject{
+			Name:   cm.Name,
+			Object: configMapRedactor(cm),
+		})
+	}
+
+	return secrets, configs, nil
+}
+
+// collectEvents gathers events from the specified namespace
+func collectEvents(ctx context.Context, namespace string) (corev1.EventList, error) {
+	var events corev1.EventList
+	err := plugin.Client.List(ctx, &events, client.InNamespace(namespace))
+	if err != nil {
+		return corev1.EventList{}, fmt.Errorf("could not get events: %w", err)
+	}
+	return events, nil
+}
+
+// tryCollectWebhooks attempts to collect webhook configurations, logging warnings on failure
+func tryCollectWebhooks(
+	ctx context.Context,
+	stopRedaction bool,
+) (*admissionregistrationv1.MutatingWebhookConfigurationList,
+	*admissionregistrationv1.ValidatingWebhookConfigurationList,
+) {
+	mutatingWebhook, validatingWebhook, err := getWebhooks(ctx, stopRedaction)
+	if err != nil {
+		logWarning("could not get webhooks", err,
+			"Continuing without webhook information. This is expected if you don't have cluster-level permissions.")
+	}
+	return mutatingWebhook, validatingWebhook
+}
+
+// tryCollectWebhookService attempts to collect the webhook service, logging warnings on failure
+func tryCollectWebhookService(
+	ctx context.Context,
+	mutatingWebhook *admissionregistrationv1.MutatingWebhookConfigurationList,
+) corev1.Service {
+	webhookService, err := getWebhookService(ctx, mutatingWebhook)
+	if err != nil {
+		logWarning("could not get webhook service", err,
+			"Continuing without webhook service information.")
+	}
+	return webhookService
+}
+
+// assembleSections creates all ZIP file sections including manifests, logs, and OLM data
+func assembleSections(
+	ctx context.Context,
+	rep operatorReport,
+	pods []corev1.Pod,
+	format plugin.OutputFormat,
+	includeLogs bool,
+	logTimeStamp bool,
+) []zipFileWriter {
+	// Main report section
+	sections := []zipFileWriter{
+		func(zipper *zip.Writer, dirname string) error {
+			return rep.writeToZip(zipper, format, dirname)
+		},
+	}
+
+	// Optional logs section
+	if includeLogs {
+		sections = append(sections, func(zipper *zip.Writer, dirname string) error {
+			return streamOperatorLogsToZip(ctx, pods, dirname, "operator-logs", logTimeStamp, zipper)
+		})
+	}
+
+	// Optional OLM section
+	if olmZipper := tryGetOLMReport(ctx, format); olmZipper != nil {
+		sections = append(sections, olmZipper)
+	}
+
+	return sections
+}
+
+// logWarning prints a formatted warning message with additional context
+func logWarning(message string, err error, additionalInfo string) {
+	fmt.Printf("WARNING: %s: %v\n", message, err)
+	fmt.Printf("         %s\n", additionalInfo)
+}
+
+// tryGetOLMReport attempts to detect and collect OLM information,
+// returning a zipper function if successful, or nil if OLM is not available or permissions are insufficient
+func tryGetOLMReport(ctx context.Context, format plugin.OutputFormat) zipFileWriter {
+	discoveryClient, err := utils.GetDiscoveryClient()
+	if err != nil {
+		logWarning("could not get discovery client", err, "Continuing without OLM detection.")
+		return nil
+	}
+
+	if err = utils.DetectOLM(discoveryClient); err != nil {
+		logWarning("unable to look for OLM resources", err,
+			"Continuing without OLM information. This is expected if you don't have cluster-level permissions.")
+		return nil
+	}
+
+	if !utils.RunningOnOLM() {
+		return nil
+	}
+
+	olmReport, err := getOlmReport(ctx, plugin.Namespace)
+	if err != nil {
+		logWarning("could not get openshift operator report", err,
+			"Continuing without OLM report. This is expected if you don't have cluster-level permissions.")
+		return nil
+	}
+
+	return func(zipper *zip.Writer, dirname string) error {
+		return olmReport.writeToZip(zipper, format, dirname)
+	}
 }

--- a/internal/cmd/plugin/report/operator_report_test.go
+++ b/internal/cmd/plugin/report/operator_report_test.go
@@ -20,9 +20,7 @@ SPDX-License-Identifier: Apache-2.0
 package report
 
 import (
-	"bytes"
 	"context"
-	"fmt"
 	"io"
 	"os"
 
@@ -68,54 +66,6 @@ var _ = Describe("configureRedactors", func() {
 		configMap := corev1.ConfigMap{Data: map[string]string{"key": "value"}}
 		passedCM := configMapRedactor(configMap)
 		Expect(passedCM.Data["key"]).To(Equal("value"))
-	})
-})
-
-var _ = Describe("logWarning", func() {
-	It("should format warning message correctly", func() {
-		// Capture stdout
-		oldStdout := os.Stdout
-		r, w, _ := os.Pipe()
-		os.Stdout = w
-
-		testErr := fmt.Errorf("test error")
-		logWarning("test operation", testErr, "Additional context here")
-
-		// Restore stdout and read output
-		_ = w.Close()
-		os.Stdout = oldStdout
-
-		var buf bytes.Buffer
-		_, err := io.Copy(&buf, r)
-		Expect(err).ToNot(HaveOccurred())
-
-		output := buf.String()
-		Expect(output).To(ContainSubstring("WARNING: test operation: test error"))
-		Expect(output).To(ContainSubstring("         Additional context here"))
-	})
-
-	It("should handle permission error messages", func() {
-		// Capture stdout
-		oldStdout := os.Stdout
-		r, w, _ := os.Pipe()
-		os.Stdout = w
-
-		testErr := fmt.Errorf("permission denied")
-		logWarning("could not get webhooks", testErr,
-			"Continuing without webhook information. This is expected if you don't have cluster-level permissions.")
-
-		// Restore stdout and read output
-		_ = w.Close()
-		os.Stdout = oldStdout
-
-		var buf bytes.Buffer
-		_, err := io.Copy(&buf, r)
-		Expect(err).ToNot(HaveOccurred())
-
-		output := buf.String()
-		Expect(output).To(ContainSubstring("WARNING: could not get webhooks: permission denied"))
-		Expect(output).To(ContainSubstring("         Continuing without webhook information"))
-		Expect(output).To(ContainSubstring("cluster-level permissions"))
 	})
 })
 

--- a/internal/cmd/plugin/report/operator_report_test.go
+++ b/internal/cmd/plugin/report/operator_report_test.go
@@ -1,0 +1,118 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package report
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+
+	corev1 "k8s.io/api/core/v1"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("configureRedactors", func() {
+	It("should return redact functions when stopRedaction is false", func() {
+		secretRedactor, configMapRedactor := configureRedactors(false)
+
+		// Verify they are actual redactors by testing behavior
+		secret := corev1.Secret{Data: map[string][]byte{"key": []byte("value")}}
+		redacted := secretRedactor(secret)
+		Expect(redacted.Data["key"]).To(Equal([]byte("")))
+
+		configMap := corev1.ConfigMap{Data: map[string]string{"key": "value"}}
+		redactedCM := configMapRedactor(configMap)
+		Expect(redactedCM.Data["key"]).To(Equal(""))
+	})
+
+	It("should return pass-through functions when stopRedaction is true", func() {
+		// Capture stdout to avoid polluting test output
+		oldStdout := os.Stdout
+		r, w, _ := os.Pipe()
+		os.Stdout = w
+
+		secretRedactor, configMapRedactor := configureRedactors(true)
+
+		// Restore stdout
+		_ = w.Close()
+		os.Stdout = oldStdout
+		_, _ = io.Copy(io.Discard, r)
+
+		// Verify they are pass-through functions
+		secret := corev1.Secret{Data: map[string][]byte{"key": []byte("value")}}
+		passed := secretRedactor(secret)
+		Expect(passed.Data["key"]).To(Equal([]byte("value")))
+
+		configMap := corev1.ConfigMap{Data: map[string]string{"key": "value"}}
+		passedCM := configMapRedactor(configMap)
+		Expect(passedCM.Data["key"]).To(Equal("value"))
+	})
+})
+
+var _ = Describe("logWarning", func() {
+	It("should format warning message correctly", func() {
+		// Capture stdout
+		oldStdout := os.Stdout
+		r, w, _ := os.Pipe()
+		os.Stdout = w
+
+		testErr := fmt.Errorf("test error")
+		logWarning("test operation", testErr, "Additional context here")
+
+		// Restore stdout and read output
+		_ = w.Close()
+		os.Stdout = oldStdout
+
+		var buf bytes.Buffer
+		_, err := io.Copy(&buf, r)
+		Expect(err).ToNot(HaveOccurred())
+
+		output := buf.String()
+		Expect(output).To(ContainSubstring("WARNING: test operation: test error"))
+		Expect(output).To(ContainSubstring("         Additional context here"))
+	})
+
+	It("should handle permission error messages", func() {
+		// Capture stdout
+		oldStdout := os.Stdout
+		r, w, _ := os.Pipe()
+		os.Stdout = w
+
+		testErr := fmt.Errorf("permission denied")
+		logWarning("could not get webhooks", testErr,
+			"Continuing without webhook information. This is expected if you don't have cluster-level permissions.")
+
+		// Restore stdout and read output
+		_ = w.Close()
+		os.Stdout = oldStdout
+
+		var buf bytes.Buffer
+		_, err := io.Copy(&buf, r)
+		Expect(err).ToNot(HaveOccurred())
+
+		output := buf.String()
+		Expect(output).To(ContainSubstring("WARNING: could not get webhooks: permission denied"))
+		Expect(output).To(ContainSubstring("         Continuing without webhook information"))
+		Expect(output).To(ContainSubstring("cluster-level permissions"))
+	})
+})

--- a/internal/cmd/plugin/report/operator_utils.go
+++ b/internal/cmd/plugin/report/operator_utils.go
@@ -47,7 +47,8 @@ func getWebhooks(
 	)
 
 	if err := plugin.Client.List(ctx, &mutatingWebhookConfigList); err != nil {
-		return nil, nil, err
+		// Return empty lists instead of error to handle permission issues gracefully
+		return &mWebhookConfig, &vWebhookConfig, fmt.Errorf("insufficient permissions to list mutating webhooks: %w", err)
 	}
 
 	for _, item := range mutatingWebhookConfigList.Items {
@@ -66,7 +67,8 @@ func getWebhooks(
 	}
 
 	if err := plugin.Client.List(ctx, &validatingWebhookConfigList); err != nil {
-		return nil, nil, err
+		// Return empty lists instead of error to handle permission issues gracefully
+		return &mWebhookConfig, &vWebhookConfig, fmt.Errorf("insufficient permissions to list validating webhooks: %w", err)
 	}
 
 	for _, item := range validatingWebhookConfigList.Items {
@@ -84,8 +86,8 @@ func getWebhooks(
 		}
 	}
 
-	if len(mWebhookConfig.Items) == 0 || len(vWebhookConfig.Items) == 0 {
-		return nil, nil, fmt.Errorf(
+	if len(mWebhookConfig.Items) == 0 && len(vWebhookConfig.Items) == 0 {
+		return &mWebhookConfig, &vWebhookConfig, fmt.Errorf(
 			"can't find the webhooks that targeting resources within the group %s",
 			apiv1.SchemeGroupVersion.Group,
 		)

--- a/internal/cmd/plugin/report/operator_utils.go
+++ b/internal/cmd/plugin/report/operator_utils.go
@@ -98,7 +98,8 @@ func getWebhookService(
 	ctx context.Context,
 	mutatingWebhookList *admissionregistrationv1.MutatingWebhookConfigurationList,
 ) (corev1.Service, error) {
-	if len(mutatingWebhookList.Items) == 0 ||
+	if mutatingWebhookList == nil ||
+		len(mutatingWebhookList.Items) == 0 ||
 		len(mutatingWebhookList.Items[0].Webhooks) == 0 {
 		return corev1.Service{}, nil
 	}

--- a/internal/cmd/plugin/report/operator_utils.go
+++ b/internal/cmd/plugin/report/operator_utils.go
@@ -47,8 +47,7 @@ func getWebhooks(
 	)
 
 	if err := plugin.Client.List(ctx, &mutatingWebhookConfigList); err != nil {
-		// Return empty lists instead of error to handle permission issues gracefully
-		return &mWebhookConfig, &vWebhookConfig, fmt.Errorf("insufficient permissions to list mutating webhooks: %w", err)
+		return nil, nil, fmt.Errorf("insufficient permissions to list mutating webhooks: %w", err)
 	}
 
 	for _, item := range mutatingWebhookConfigList.Items {
@@ -67,8 +66,7 @@ func getWebhooks(
 	}
 
 	if err := plugin.Client.List(ctx, &validatingWebhookConfigList); err != nil {
-		// Return empty lists instead of error to handle permission issues gracefully
-		return &mWebhookConfig, &vWebhookConfig, fmt.Errorf("insufficient permissions to list validating webhooks: %w", err)
+		return nil, nil, fmt.Errorf("insufficient permissions to list validating webhooks: %w", err)
 	}
 
 	for _, item := range validatingWebhookConfigList.Items {
@@ -87,7 +85,7 @@ func getWebhooks(
 	}
 
 	if len(mWebhookConfig.Items) == 0 && len(vWebhookConfig.Items) == 0 {
-		return &mWebhookConfig, &vWebhookConfig, fmt.Errorf(
+		return nil, nil, fmt.Errorf(
 			"can't find the webhooks that targeting resources within the group %s",
 			apiv1.SchemeGroupVersion.Group,
 		)


### PR DESCRIPTION
Enable `cnpg report operator` to work with minimal permissions by making only the operator deployment required. All other resources (pods, secrets, config maps, events, webhooks, and OLM data) are now optional and collected on a best-efforts basis.

The command gracefully handles permission errors for those resources by logging clear warnings and continuing report generation with available data, rather than failing completely. This enables least-privileged access, where users may have limited, namespace-scoped permissions. 
