### PR TITLE
fix(report,cluster): ensure the process continues when previous logs are unavailable

### DIFF
--- a/pkg/podlogs/writer_test.go
+++ b/pkg/podlogs/writer_test.go
@@ -250,5 +250,87 @@ fake logs
 fake logs
 `))
 		})
+
+		It("ensures containerOpts with correct container name is passed to sendLogsToWriter", func(ctx context.Context) {
+			client := fake.NewClientset(&podWithSidecar)
+			streamPodLog := Writer{
+				Pod:    podWithSidecar,
+				Client: client,
+			}
+
+			namer := func(container string) string {
+				return fmt.Sprintf("%s-%s.log", streamPodLog.Pod.Name, container)
+			}
+			mw := newMultiWriter()
+
+			// This is a regression test for bug where opts was passed instead of containerOpts
+			// If container name isn't set correctly, the fake client might not behave as expected
+			// The test verifies that each container gets its own log file
+			err := streamPodLog.Multiple(ctx, &corev1.PodLogOptions{}, mw, namer)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(mw.writers).To(HaveLen(2))
+			Expect(mw.writers).To(HaveKey("pod-name-test-postgres.log"))
+			Expect(mw.writers).To(HaveKey("pod-name-test-sidecar.log"))
+		})
+	})
+
+	When("handling Previous logs edge cases", func() {
+		It("should fetch current logs even when Previous is true (regression test for #8985)", func(ctx context.Context) {
+			// This test verifies that when Previous: true is set, the function attempts
+			// to fetch both previous and current logs, not previous logs twice
+			client := fake.NewClientset(&pod)
+			streamPodLog := Writer{
+				Pod:    pod,
+				Client: client,
+			}
+
+			var logBuffer bytes.Buffer
+			err := streamPodLog.Single(ctx, &logBuffer, &corev1.PodLogOptions{
+				Previous: true,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			// The output should contain the previous log markers and both log entries
+			output := logBuffer.String()
+			Expect(output).To(ContainSubstring("====== Beginning of Previous Log ====="))
+			Expect(output).To(ContainSubstring("====== End of Previous Log ====="))
+			// Should have logs from both previous and current (fake client returns "fake logs" for both)
+			Expect(output).To(ContainSubstring("fake logs"))
+		})
+
+		It("should handle Previous logs in Multiple with correct container options", func(ctx context.Context) {
+			// Regression test to ensure containerOpts is passed (not opts) in Multiple
+			// when Previous is enabled
+			client := fake.NewClientset(&podWithSidecar)
+			streamPodLog := Writer{
+				Pod:    podWithSidecar,
+				Client: client,
+			}
+
+			namer := func(container string) string {
+				return fmt.Sprintf("%s-%s.log", streamPodLog.Pod.Name, container)
+			}
+			mw := newMultiWriter()
+
+			err := streamPodLog.Multiple(ctx, &corev1.PodLogOptions{
+				Previous:   true,
+				Timestamps: true,
+			}, mw, namer)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Both containers should have their logs collected
+			Expect(mw.writers).To(HaveLen(2))
+
+			// Each should contain the previous log markers and actual logs
+			for containerName, writer := range mw.writers {
+				output := writer.String()
+				Expect(output).To(ContainSubstring("====== Beginning of Previous Log ====="),
+					"Container %s should have previous log marker", containerName)
+				Expect(output).To(ContainSubstring("====== End of Previous Log ====="),
+					"Container %s should have end marker", containerName)
+				Expect(output).To(ContainSubstring("fake logs"),
+					"Container %s should have actual logs", containerName)
+			}
+		})
 	})
 })


### PR DESCRIPTION
Fixed two bugs in the pod logs writer that caused log collection to fail:

1. When Previous option is enabled, sendLogsToWriter was attempting to fetch logs with Previous=true twice - once for previous logs and again for current logs. This caused failures when containers had never been restarted (no previous terminated container exists). Now it correctly fetches previous logs first (with error handling), then fetches current logs with Previous=false.

2. The Multiple method was incorrectly passing opts instead of containerOpts to sendLogsToWriter, causing the container name to not be set properly.

These fixes ensure that:
- Missing previous logs are handled gracefully without stopping execution
- Current logs are always collected even if previous logs are unavailable
- Each container's logs are fetched with the correct container name

Fixes #8985 
