### PR TITLE
feat: add label selector to the Cluster scale subresource

### DIFF
--- a/.wordlist-en-custom.txt
+++ b/.wordlist-en-custom.txt
@@ -638,6 +638,7 @@ authn
 authz
 autocompletion
 autoscaler
+autoscalers
 autovacuum
 availableArchitectures
 availablearchitecture

--- a/.wordlist-en-custom.txt
+++ b/.wordlist-en-custom.txt
@@ -203,6 +203,7 @@ GoogleCredentials
 Grafana
 GrantUsageSpecType
 HH
+HPA
 HashiCorp
 HistoryTags
 Homebrew
@@ -564,6 +565,7 @@ VLDBs
 VM
 VMs
 VOLNAME
+VPA
 ValidationError
 VirtualBox
 VolumeSnapshot

--- a/.wordlist-en-custom.txt
+++ b/.wordlist-en-custom.txt
@@ -959,6 +959,7 @@ historyTags
 hostPort
 hostname
 hostssl
+hpa
 href
 html
 http
@@ -1616,6 +1617,7 @@ volumeSnapshot
 volumeSnapshots
 volumesnapshot
 volumesnapshotconfiguration
+vpa
 waitForArchive
 wal
 walCapabilities

--- a/api/v1/cluster_funcs.go
+++ b/api/v1/cluster_funcs.go
@@ -37,6 +37,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -713,6 +714,17 @@ func (cluster *Cluster) GetServiceReadOnlyName() string {
 // read-write transactions
 func (cluster *Cluster) GetServiceReadWriteName() string {
 	return fmt.Sprintf("%v%v", cluster.Name, ServiceReadWriteSuffix)
+}
+
+// GetInstancesSelector returns the serialized label selector that matches all
+// the instance pods managed by this cluster. It is published in the status and
+// exposed through the scale sub-resource so that autoscalers (such as HPA or
+// VPA) can discover the managed pods.
+func (cluster *Cluster) GetInstancesSelector() string {
+	return labels.SelectorFromSet(labels.Set{
+		utils.ClusterLabelName: cluster.Name,
+		utils.PodRoleLabelName: string(utils.PodRoleInstance),
+	}).String()
 }
 
 // GetMaxStartDelay get the amount of time of startDelay config option

--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -855,6 +855,12 @@ type ClusterStatus struct {
 	// +optional
 	ReadyInstances int `json:"readyInstances,omitempty"`
 
+	// SelectorLabels is the label query used to select pods managed by this cluster.
+	// This field is populated by the operator and used by the scale sub-resource
+	// to enable VPA (Vertical Pod Autoscaler) support.
+	// +optional
+	SelectorLabels string `json:"selectorLabels,omitempty"`
+
 	// InstancesStatus indicates in which status the instances are
 	// +optional
 	InstancesStatus map[PodStatus][]string `json:"instancesStatus,omitempty"`
@@ -2650,7 +2656,7 @@ type RoleConfiguration struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
-// +kubebuilder:subresource:scale:specpath=.spec.instances,statuspath=.status.instances
+// +kubebuilder:subresource:scale:specpath=.spec.instances,statuspath=.status.instances,selectorpath=.status.selectorLabels
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:printcolumn:name="Instances",type="integer",JSONPath=".status.instances",description="Number of instances"
 // +kubebuilder:printcolumn:name="Ready",type="integer",JSONPath=".status.readyInstances",description="Number of ready instances"

--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -855,11 +855,12 @@ type ClusterStatus struct {
 	// +optional
 	ReadyInstances int `json:"readyInstances,omitempty"`
 
-	// SelectorLabels is the label query used to select pods managed by this cluster.
-	// This field is populated by the operator and used by the scale sub-resource
-	// to enable VPA (Vertical Pod Autoscaler) support.
+	// Selector is the serialized form of the label selector that identifies
+	// the pods managed by this cluster. Populated by the operator and exposed
+	// through the scale sub-resource so an autoscaler (such as HPA or VPA)
+	// can discover the managed instance pods.
 	// +optional
-	SelectorLabels string `json:"selectorLabels,omitempty"`
+	Selector string `json:"selector,omitempty"`
 
 	// InstancesStatus indicates in which status the instances are
 	// +optional
@@ -2656,7 +2657,7 @@ type RoleConfiguration struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
-// +kubebuilder:subresource:scale:specpath=.spec.instances,statuspath=.status.instances,selectorpath=.status.selectorLabels
+// +kubebuilder:subresource:scale:specpath=.spec.instances,statuspath=.status.instances,selectorpath=.status.selector
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:printcolumn:name="Instances",type="integer",JSONPath=".status.instances",description="Number of instances"
 // +kubebuilder:printcolumn:name="Ready",type="integer",JSONPath=".status.readyInstances",description="Number of ready instances"

--- a/config/crd/bases/postgresql.cnpg.io_clusters.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_clusters.yaml
@@ -7411,11 +7411,12 @@ spec:
                     description: The resource version of the "postgres" user secret
                     type: string
                 type: object
-              selectorLabels:
+              selector:
                 description: |-
-                  SelectorLabels is the label query used to select pods managed by this cluster.
-                  This field is populated by the operator and used by the scale sub-resource
-                  to enable VPA (Vertical Pod Autoscaler) support.
+                  Selector is the serialized form of the label selector that identifies
+                  the pods managed by this cluster. Populated by the operator and exposed
+                  through the scale sub-resource so an autoscaler (such as HPA or VPA)
+                  can discover the managed instance pods.
                 type: string
               switchReplicaClusterStatus:
                 description: SwitchReplicaClusterStatus is the status of the switch
@@ -7510,7 +7511,7 @@ spec:
     storage: true
     subresources:
       scale:
-        labelSelectorPath: .status.selectorLabels
+        labelSelectorPath: .status.selector
         specReplicasPath: .spec.instances
         statusReplicasPath: .status.instances
       status: {}

--- a/config/crd/bases/postgresql.cnpg.io_clusters.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_clusters.yaml
@@ -7411,6 +7411,12 @@ spec:
                     description: The resource version of the "postgres" user secret
                     type: string
                 type: object
+              selectorLabels:
+                description: |-
+                  SelectorLabels is the label query used to select pods managed by this cluster.
+                  This field is populated by the operator and used by the scale sub-resource
+                  to enable VPA (Vertical Pod Autoscaler) support.
+                type: string
               switchReplicaClusterStatus:
                 description: SwitchReplicaClusterStatus is the status of the switch
                   to replica cluster
@@ -7504,6 +7510,7 @@ spec:
     storage: true
     subresources:
       scale:
+        labelSelectorPath: .status.selectorLabels
         specReplicasPath: .spec.instances
         statusReplicasPath: .status.instances
       status: {}

--- a/docs/src/cloudnative-pg.v1.md
+++ b/docs/src/cloudnative-pg.v1.md
@@ -656,6 +656,7 @@ _Appears in:_
 | --- | --- | --- | --- | --- |
 | `instances` _integer_ | The total number of PVC Groups detected in the cluster. It may differ from the number of existing instance pods. |  |  |  |
 | `readyInstances` _integer_ | The total number of ready instances in the cluster. It is equal to the number of ready instance pods. |  |  |  |
+| `selector` _string_ | Selector is the serialized form of the label selector that identifies<br />the pods managed by this cluster. Populated by the operator and exposed<br />through the scale sub-resource so an autoscaler (such as HPA or VPA)<br />can discover the managed instance pods. |  |  |  |
 | `instancesStatus` _object (keys:[PodStatus](#podstatus), values:string array)_ | InstancesStatus indicates in which status the instances are |  |  |  |
 | `instancesReportedState` _object (keys:[PodName](#podname), values:[InstanceReportedState](#instancereportedstate))_ | The reported state of the instances during the last reconciliation loop |  |  |  |
 | `managedRolesStatus` _[ManagedRoles](#managedroles)_ | ManagedRolesStatus reports the state of the managed roles in the cluster |  |  |  |

--- a/docs/src/operator_capability_levels.md
+++ b/docs/src/operator_capability_levels.md
@@ -589,7 +589,9 @@ The operator allows you to scale up and down the number of instances in a
 PostgreSQL cluster. New replicas are started up from the
 primary server and participate in the cluster's HA infrastructure.
 The CRD declares a "scale" subresource that allows you to use the
-`kubectl scale` command.
+`kubectl scale` command. The scale subresource also publishes the label
+selector of the managed instance pods, so the `Cluster` can be targeted by a
+[Horizontal Pod Autoscaler](resource_management.md#integration-with-the-horizontal-pod-autoscaler-hpa).
 
 ### Maintenance window and PodDisruptionBudget for Kubernetes nodes
 
@@ -638,6 +640,10 @@ to clone the data from the primary again.
 The operator allows administrators to control and manage resource usage by
 the cluster's pods in the `resources` section of the manifest. In
 particular, you can set `requests` and `limits` values for both CPU and RAM.
+Because the `Cluster` exposes a label selector through its scale subresource,
+it can also be used as a target for the
+[Vertical Pod Autoscaler](resource_management.md#integration-with-the-vertical-pod-autoscaler-vpa)
+in recommendation-only mode, to obtain sizing suggestions for these values.
 
 ### Connection pooling with PgBouncer
 

--- a/docs/src/operator_capability_levels.md
+++ b/docs/src/operator_capability_levels.md
@@ -590,8 +590,11 @@ PostgreSQL cluster. New replicas are started up from the
 primary server and participate in the cluster's HA infrastructure.
 The CRD declares a "scale" subresource that allows you to use the
 `kubectl scale` command. The scale subresource also publishes the label
-selector of the managed instance pods, so the `Cluster` can be targeted by a
-[Horizontal Pod Autoscaler](resource_management.md#integration-with-the-horizontal-pod-autoscaler-hpa).
+selector of the managed instance pods, which lets autoscalers discover them.
+See the [Vertical Pod Autoscaler integration](resource_management.md#integration-with-the-vertical-pod-autoscaler-vpa)
+for the recommended use, and the
+[Horizontal Pod Autoscaler integration](resource_management.md#integration-with-the-horizontal-pod-autoscaler-hpa)
+for the caveats that apply to HPA.
 
 ### Maintenance window and PodDisruptionBudget for Kubernetes nodes
 

--- a/docs/src/resource_management.md
+++ b/docs/src/resource_management.md
@@ -138,12 +138,12 @@ Example targeting a `Cluster`:
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
-  name: my-cluster-vpa
+  name: cluster-example-vpa
 spec:
   targetRef:
     apiVersion: postgresql.cnpg.io/v1
     kind: Cluster
-    name: my-cluster
+    name: cluster-example
   updatePolicy:
     updateMode: "Off"
 ```

--- a/docs/src/resource_management.md
+++ b/docs/src/resource_management.md
@@ -121,7 +121,7 @@ section in the PostgreSQL documentation.
 
 The `Cluster` CRD exposes the `scale` subresource together with the label
 selector for its instance pods. This makes a `Cluster` a valid `targetRef` for the
-[Vertical Pod Autoscaler](https://kubernetes.io/docs/concepts/workloads/autoscaling/vertical-pod-autoscale/)
+[Vertical Pod Autoscaler](https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler)
 (VPA), so VPA can observe the instance pods and emit CPU and memory
 recommendations for them.
 
@@ -129,7 +129,9 @@ We recommend running VPA in **recommendation-only** mode
 (`updatePolicy.updateMode: Off`). In this mode VPA only reports its
 recommendations, which an operator can then apply to `spec.resources` of the
 `Cluster` through a normal manifest update; CloudNativePG performs the rolling
-update of the instances using its usual switchover-aware procedure.
+update of the instances using its usual switchover-aware procedure. VPA
+produces a recommendation per container: use the one for the `postgres`
+container, since that is what `spec.resources` configures.
 
 Example targeting a `Cluster`:
 
@@ -150,21 +152,39 @@ spec:
 :::warning
 Do not use `updateMode: Auto`, `Recreate`, or `Initial` against a
 CloudNativePG-managed `Cluster`. The operator owns the pod specification and
-will roll any instance whose `resources` drift from `spec.resources` of the
-`Cluster`. Combined with a VPA mode that actively mutates pods this can lead
-to ping-pong restarts, where VPA changes a pod's resources, CloudNativePG
-detects the drift and re-creates the pod with the declared values, and VPA
-changes them again. Apply the VPA recommendations to the `Cluster` manifest
+treats `spec.resources` of the `Cluster` as the source of truth: it does not
+adopt the resources VPA writes onto a running pod, so the live pod and the
+declared `spec.resources` silently diverge. Any tuning you sized against the
+declared resources (for example a `shared_buffers` value the operator
+validated against the memory request) no longer matches the pod's actual
+limits. VPA also evicts pods through the Kubernetes eviction API, bypassing
+the operator's switchover-aware sequencing; the default primary
+`PodDisruptionBudget` then blocks eviction of the primary, so VPA stalls
+instead of completing. Apply the VPA recommendations to the `Cluster` manifest
 manually instead.
 :::
 
 ## Integration with the Horizontal Pod Autoscaler (HPA)
 
-The `scale` subresource also exposes `spec.instances`, so the
+The `scale` subresource also exposes `spec.instances`, so a
 [Horizontal Pod Autoscaler](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/)
-(HPA) can change the number of instances in a `Cluster`.
-For PostgreSQL this only adds or removes standby replicas — it does not
-relieve write load on the primary — and the chosen metrics need to make sense
-for a stateful database (CPU/memory typically do not). Review the impact on
-replication and quorum carefully before enabling HPA against a database
-cluster.
+(HPA) can technically change the number of instances in a `Cluster`.
+In practice this is **not recommended** for a PostgreSQL cluster, for several
+reasons.
+
+Scaling a `Cluster` only adds or removes standby replicas; it never relieves
+write load on the primary. The selector exposed through the scale subresource
+matches the primary and all replicas, which have opposite workload profiles
+(write-heavy primary, read-only replicas), so the per-pod average that HPA
+computes from a CPU or memory metric is not a meaningful signal for any of
+them. Adding a replica only dilutes that average further without addressing a
+hot primary.
+
+HPA is also unaware of CloudNativePG's own constraints on `spec.instances`. If
+you configure synchronous replicas, a scale-down below `maxSyncReplicas + 1`
+instances is rejected by the validating webhook, and HPA keeps retrying a
+value it cannot satisfy.
+If you nonetheless drive `spec.instances` from an HPA, base it on a custom
+metric that actually reflects read replica load, and set `minReplicas` above
+the synchronous-replica floor. Review the impact on replication and quorum
+carefully first.

--- a/docs/src/resource_management.md
+++ b/docs/src/resource_management.md
@@ -121,7 +121,7 @@ section in the PostgreSQL documentation.
 
 The `Cluster` CRD exposes the `scale` subresource together with the label
 selector for its instance pods. This makes a `Cluster` a valid `targetRef` for the
-[Vertical Pod Autoscaler](https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler)
+[Vertical Pod Autoscaler](https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler) <!-- wokeignore:rule=master -->
 (VPA), so VPA can observe the instance pods and emit CPU and memory
 recommendations for them.
 

--- a/docs/src/resource_management.md
+++ b/docs/src/resource_management.md
@@ -117,12 +117,11 @@ section in the PostgreSQL documentation.
     page from the Kubernetes documentation.
 :::
 
-## Sizing recommendations with the Vertical Pod Autoscaler
+## Integration with the Vertical Pod Autoscaler (VPA)
 
 The `Cluster` CRD exposes the `scale` subresource together with the label
-selector for its instance pods. This makes a `Cluster` a valid `targetRef` for
-the
-[Vertical Pod Autoscaler](https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler) <!-- wokeignore:rule=master -->
+selector for its instance pods. This makes a `Cluster` a valid `targetRef` for the
+[Vertical Pod Autoscaler](https://kubernetes.io/docs/concepts/workloads/autoscaling/vertical-pod-autoscale/)
 (VPA), so VPA can observe the instance pods and emit CPU and memory
 recommendations for them.
 
@@ -159,10 +158,11 @@ changes them again. Apply the VPA recommendations to the `Cluster` manifest
 manually instead.
 :::
 
-## Horizontal scaling
+## Integration with the Horizontal Pod Autoscaler (HPA)
 
-The `scale` subresource also exposes `spec.instances`, so a
-`HorizontalPodAutoscaler` can change the number of instances in a `Cluster`.
+The `scale` subresource also exposes `spec.instances`, so the
+[Horizontal Pod Autoscaler](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/)
+(HPA) can change the number of instances in a `Cluster`.
 For PostgreSQL this only adds or removes standby replicas — it does not
 relieve write load on the primary — and the chosen metrics need to make sense
 for a stateful database (CPU/memory typically do not). Review the impact on

--- a/docs/src/resource_management.md
+++ b/docs/src/resource_management.md
@@ -116,3 +116,55 @@ section in the PostgreSQL documentation.
     ["Managing Compute Resources for Containers"](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/)
     page from the Kubernetes documentation.
 :::
+
+## Sizing recommendations with the Vertical Pod Autoscaler
+
+The `Cluster` CRD exposes the `scale` subresource together with the label
+selector for its instance pods. This makes a `Cluster` a valid `targetRef` for
+the
+[Vertical Pod Autoscaler](https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler) <!-- wokeignore:rule=master -->
+(VPA), so VPA can observe the instance pods and emit CPU and memory
+recommendations for them.
+
+We recommend running VPA in **recommendation-only** mode
+(`updatePolicy.updateMode: Off`). In this mode VPA only reports its
+recommendations, which an operator can then apply to `spec.resources` of the
+`Cluster` through a normal manifest update; CloudNativePG performs the rolling
+update of the instances using its usual switchover-aware procedure.
+
+Example targeting a `Cluster`:
+
+```yaml
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: my-cluster-vpa
+spec:
+  targetRef:
+    apiVersion: postgresql.cnpg.io/v1
+    kind: Cluster
+    name: my-cluster
+  updatePolicy:
+    updateMode: "Off"
+```
+
+:::warning
+Do not use `updateMode: Auto`, `Recreate`, or `Initial` against a
+CloudNativePG-managed `Cluster`. The operator owns the pod specification and
+will roll any instance whose `resources` drift from `spec.resources` of the
+`Cluster`. Combined with a VPA mode that actively mutates pods this can lead
+to ping-pong restarts, where VPA changes a pod's resources, CloudNativePG
+detects the drift and re-creates the pod with the declared values, and VPA
+changes them again. Apply the VPA recommendations to the `Cluster` manifest
+manually instead.
+:::
+
+## Horizontal scaling
+
+The `scale` subresource also exposes `spec.instances`, so a
+`HorizontalPodAutoscaler` can change the number of instances in a `Cluster`.
+For PostgreSQL this only adds or removes standby replicas — it does not
+relieve write load on the primary — and the chosen metrics need to make sense
+for a stateful database (CPU/memory typically do not). Review the impact on
+replication and quorum carefully before enabling HPA against a database
+cluster.

--- a/internal/controller/cluster_status.go
+++ b/internal/controller/cluster_status.go
@@ -247,6 +247,12 @@ func (r *ClusterReconciler) updateResourceStatus(
 	cluster.Status.WriteService = cluster.GetServiceReadWriteName()
 	cluster.Status.ReadService = cluster.GetServiceReadName()
 
+	// Set the label selector for VPA support
+	// This allows VPA to discover pods managed by this cluster through the scale sub-resource
+	cluster.Status.SelectorLabels = fmt.Sprintf("%s=%s,%s=%s",
+		utils.ClusterLabelName, cluster.Name,
+		utils.PodRoleLabelName, string(utils.PodRoleInstance))
+
 	// If we are switching, check if the target primary is still active
 	// Ignore this check if current primary is empty (it happens during the bootstrap)
 	if cluster.Status.TargetPrimary != cluster.Status.CurrentPrimary &&

--- a/internal/controller/cluster_status.go
+++ b/internal/controller/cluster_status.go
@@ -35,7 +35,6 @@ import (
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
@@ -250,10 +249,7 @@ func (r *ClusterReconciler) updateResourceStatus(
 
 	// Expose the label selector for the scale sub-resource so autoscalers
 	// (HPA, VPA) can discover the instance pods managed by this cluster.
-	cluster.Status.Selector = labels.SelectorFromSet(labels.Set{
-		utils.ClusterLabelName: cluster.Name,
-		utils.PodRoleLabelName: string(utils.PodRoleInstance),
-	}).String()
+	cluster.Status.Selector = cluster.GetInstancesSelector()
 
 	// If we are switching, check if the target primary is still active
 	// Ignore this check if current primary is empty (it happens during the bootstrap)

--- a/internal/controller/cluster_status.go
+++ b/internal/controller/cluster_status.go
@@ -35,6 +35,7 @@ import (
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
@@ -247,11 +248,12 @@ func (r *ClusterReconciler) updateResourceStatus(
 	cluster.Status.WriteService = cluster.GetServiceReadWriteName()
 	cluster.Status.ReadService = cluster.GetServiceReadName()
 
-	// Set the label selector for VPA support
-	// This allows VPA to discover pods managed by this cluster through the scale sub-resource
-	cluster.Status.SelectorLabels = fmt.Sprintf("%s=%s,%s=%s",
-		utils.ClusterLabelName, cluster.Name,
-		utils.PodRoleLabelName, string(utils.PodRoleInstance))
+	// Expose the label selector for the scale sub-resource so autoscalers
+	// (HPA, VPA) can discover the instance pods managed by this cluster.
+	cluster.Status.Selector = labels.SelectorFromSet(labels.Set{
+		utils.ClusterLabelName: cluster.Name,
+		utils.PodRoleLabelName: string(utils.PodRoleInstance),
+	}).String()
 
 	// If we are switching, check if the target primary is still active
 	// Ignore this check if current primary is empty (it happens during the bootstrap)

--- a/internal/controller/cluster_status_test.go
+++ b/internal/controller/cluster_status_test.go
@@ -193,6 +193,9 @@ var _ = Describe("cluster_status unit tests", func() {
 
 		selectorString := cluster.GetInstancesSelector()
 
+		// GetInstancesSelector serializes through labels.SelectorFromSet, which
+		// sorts requirements by key. The cluster label key sorts before the pod
+		// role label key, so the expected string lists them in that order.
 		expected := fmt.Sprintf("%s=%s,%s=%s",
 			utils.ClusterLabelName, cluster.Name,
 			utils.PodRoleLabelName, string(utils.PodRoleInstance))

--- a/internal/controller/cluster_status_test.go
+++ b/internal/controller/cluster_status_test.go
@@ -181,24 +181,29 @@ var _ = Describe("cluster_status unit tests", func() {
 	})
 
 	It("produces a scale-subresource selector matching managed instance pods", func() {
-		// The scale subresource uses .status.selector (set in updateResourceStatus)
-		// so VPA/HPA can discover instance pods. The format must remain a valid serialized
-		// label selector and must match the labels actually applied to instance pods.
+		// updateResourceStatus publishes cluster.GetInstancesSelector() into
+		// .status.selector so VPA/HPA can discover instance pods through the scale
+		// subresource. We exercise the production code (GetInstancesSelector) and
+		// verify both that it has the expected format and that it actually matches
+		// the labels the operator applies to every instance pod.
 		namespace := newFakeNamespace(env.client)
 		cluster := newFakeCNPGCluster(env.client, namespace)
 		pods := generateFakeClusterPods(env.client, cluster, true)
 		Expect(pods).ToNot(BeEmpty())
 
+		selectorString := cluster.GetInstancesSelector()
+
 		expected := fmt.Sprintf("%s=%s,%s=%s",
 			utils.ClusterLabelName, cluster.Name,
 			utils.PodRoleLabelName, string(utils.PodRoleInstance))
+		Expect(selectorString).To(Equal(expected))
 
-		selector, err := labels.Parse(expected)
+		selector, err := labels.Parse(selectorString)
 		Expect(err).ToNot(HaveOccurred())
 
 		for i := range pods {
 			Expect(selector.Matches(labels.Set(pods[i].Labels))).To(BeTrue(),
-				"selector %q must match pod %s labels %v", expected, pods[i].Name, pods[i].Labels)
+				"selector %q must match pod %s labels %v", selectorString, pods[i].Name, pods[i].Labels)
 		}
 	})
 })

--- a/internal/controller/cluster_status_test.go
+++ b/internal/controller/cluster_status_test.go
@@ -21,11 +21,13 @@ package controller
 
 import (
 	"context"
+	"fmt"
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
 
@@ -33,6 +35,7 @@ import (
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/certs"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/postgres"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/reconciler/persistentvolumeclaim"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -175,6 +178,28 @@ var _ = Describe("cluster_status unit tests", func() {
 					len(mr.pvcs.Items) == len(pvcs)
 			}))
 		})
+	})
+
+	It("produces a scale-subresource selector matching managed instance pods", func() {
+		// The scale subresource uses .status.selectorLabels (set in updateResourceStatus)
+		// so VPA/HPA can discover instance pods. The format must remain a valid serialized
+		// label selector and must match the labels actually applied to instance pods.
+		namespace := newFakeNamespace(env.client)
+		cluster := newFakeCNPGCluster(env.client, namespace)
+		pods := generateFakeClusterPods(env.client, cluster, true)
+		Expect(pods).ToNot(BeEmpty())
+
+		expected := fmt.Sprintf("%s=%s,%s=%s",
+			utils.ClusterLabelName, cluster.Name,
+			utils.PodRoleLabelName, string(utils.PodRoleInstance))
+
+		selector, err := labels.Parse(expected)
+		Expect(err).ToNot(HaveOccurred())
+
+		for i := range pods {
+			Expect(selector.Matches(labels.Set(pods[i].Labels))).To(BeTrue(),
+				"selector %q must match pod %s labels %v", expected, pods[i].Name, pods[i].Labels)
+		}
 	})
 })
 

--- a/internal/controller/cluster_status_test.go
+++ b/internal/controller/cluster_status_test.go
@@ -181,7 +181,7 @@ var _ = Describe("cluster_status unit tests", func() {
 	})
 
 	It("produces a scale-subresource selector matching managed instance pods", func() {
-		// The scale subresource uses .status.selectorLabels (set in updateResourceStatus)
+		// The scale subresource uses .status.selector (set in updateResourceStatus)
 		// so VPA/HPA can discover instance pods. The format must remain a valid serialized
 		// label selector and must match the labels actually applied to instance pods.
 		namespace := newFakeNamespace(env.client)


### PR DESCRIPTION
# Add VPA Support for CloudNativePG Clusters

## Summary

This PR enables Vertical Pod Autoscaler (VPA) to discover and monitor CloudNativePG database pods by exposing the pod label selector through the Cluster CRD's scale subresource.

## Problem Statement

Currently, VPA cannot provide resource recommendations for CNPG Cluster resources. When attempting to create a VPA targeting a CNPG Cluster, the VPA fails with the following errors:

```yaml
status:
  conditions:
  - type: ConfigUnsupported
    status: "True"
    message: "Cannot read targetRef. Reason: Unhandled targetRef postgresql.cnpg.io/v1 / Cluster / <name>, 
              last error Resource has an empty selector for scale sub-resource"
  - type: NoPodsMatched
    status: "True"
  - type: RecommendationProvided
    status: "False"
```

The root cause is that the Cluster CRD's scale subresource does not expose a pod selector, which VPA requires to discover which pods are managed by the resource.

## Solution

This PR implements VPA support by:

1. **Adding `SelectorLabels` field** to `ClusterStatus` to store the pod label selector
2. **Populating the selector** in the cluster controller with the labels that CNPG already applies to pods:
   ```
   cnpg.io/cluster=<cluster-name>,cnpg.io/podRole=instance
   ```
3. **Exposing the selector** through the scale subresource by adding `labelSelectorPath: .status.selectorLabels`

### Changes Made

#### 1. API Changes (`api/v1/cluster_types.go`)
- Added `SelectorLabels string` field to `ClusterStatus` struct
- Updated kubebuilder marker to include `selectorpath=.status.selectorLabels` in the scale subresource configuration

#### 2. Controller Changes (`internal/controller/cluster_status.go`)
- Modified `updateResourceStatus()` to populate `cluster.Status.SelectorLabels` during reconciliation
- Selector format: `"cnpg.io/cluster=<name>,cnpg.io/podRole=instance"`

#### 3. CRD Changes (`config/crd/bases/postgresql.cnpg.io_clusters.yaml`)
- Added `labelSelectorPath: .status.selectorLabels` to the scale subresource
- Added `selectorLabels` field definition to the status schema

## Testing

Comprehensive testing was performed in a KIND cluster with VPA installed:

### Before Fix (Unpatched CNPG 1.27.1)

Scale subresource response:
```json
{
  "status": {
    "replicas": 1
    // No "selector" field
  }
}
```

VPA Status:
- ❌ `ConfigUnsupported: True`
- ❌ `NoPodsMatched: True`
- ❌ `RecommendationProvided: False`
- ❌ No recommendations

### After Fix (Patched CNPG)

Scale subresource response:
```json
{
  "status": {
    "replicas": 1,
    "selector": "cnpg.io/cluster=test-database,cnpg.io/podRole=instance"
  }
}
```

VPA Status:
- ✅ `RecommendationProvided: True`
- ✅ No errors
- ✅ Actual CPU and memory recommendations provided

VPA Recommender logs confirm successful pod discovery:
```
I1029 14:49:55.115536 cluster_feeder.go:432] "Using selector" 
  selector="cnpg.io/cluster=test-database,cnpg.io/podRole=instance" 
  vpa="test-db/test-database-vpa"
I1029 14:49:55.124309 checkpoint_writer.go:114] "Saved checkpoint for VPA" 
  vpa="test-db/test-database-vpa" container="postgres"
```

## Backward Compatibility

This change is fully backward compatible:
- Only adds new fields, does not modify existing behavior
- The selector labels match the existing labels CNPG already applies to database pods
- Clusters created before this change will have their `selectorLabels` populated on next reconciliation
- No migration or manual intervention required

## Use Case

Users can now create VPAs for CNPG database clusters to get automatic resource recommendations:

```yaml
apiVersion: autoscaling.k8s.io/v1
kind: VerticalPodAutoscaler
metadata:
  name: my-database-vpa
  namespace: default
spec:
  targetRef:
    apiVersion: postgresql.cnpg.io/v1
    kind: Cluster
    name: my-database
  updatePolicy:
    updateMode: "Off"
```

VPA will now successfully discover the database pods and provide recommendations for CPU and memory sizing.

## Benefits

1. **Automatic Resource Optimization**: Users can leverage VPA to right-size their database resources
2. **Cost Efficiency**: Better resource allocation based on actual usage patterns
3. **Operational Excellence**: Reduces manual effort in capacity planning
4. **Standard Kubernetes Integration**: Works with existing VPA deployments

## Related Issues

This addresses the long-standing limitation where VPA could not be used with CNPG Cluster resources, requiring users to either:
- Manually monitor and adjust resources
- Create workarounds with custom label selectors
- Use VPA with StatefulSets directly (bypassing the Cluster abstraction)

## Checklist

- [x] Changes are backward compatible
- [x] API changes include proper documentation comments
- [x] CRD manifests regenerated with `make manifests`
- [x] Deepcopy code regenerated with `make generate`
- [x] Tested in a real Kubernetes cluster with VPA
- [x] No changes to existing functionality
- [x] Labels used match existing CNPG pod labels

## Additional Notes

The implementation uses the existing labels that CNPG applies to all database pods:
- `cnpg.io/cluster`: identifies which cluster the pod belongs to
- `cnpg.io/podRole`: set to "instance" for database pods

This ensures consistency with CNPG's existing labelling scheme and makes the selector reliable for pod discovery.

# Commit message

The `Cluster` scale subresource exposed `spec.instances` and `status.instances` but no selector. Standard Kubernetes tooling expects the scale subresource to publish a label selector identifying the pods it counts; without one, autoscalers cannot map a `Cluster` to its instance pods.

Populate a `status.selector` field and wire it into the scale subresource:

- Add the `status.selector` field, set it from `updateResourceStatus` via the new `Cluster.GetInstancesSelector()`, which returns the canonical serialised selector (`cluster=<name>,role=instance`) built with `labels.SelectorFromSet`.
- Add `selectorpath=.status.selector` to the `+kubebuilder:subresource:scale` marker and regenerate the CRD and API docs.

This makes a `Cluster` a valid `targetRef` for the Vertical Pod Autoscaler (`VPA`), which can now observe the instance pods and emit CPU/memory recommendations, and lets a `HorizontalPodAutoscaler` (`HPA`) scale `spec.instances`.

Document recommended `VPA` usage (recommendation-only `updateMode: Off`, with a warning against `Auto`/`Recreate`/`Initial` to avoid ping-pong restarts against the operator's drift reconciliation) and `HPA` caveats for a stateful database. Add a unit test that verifies the selector format and that it matches the labels applied to every instance pod.

Closes #2574  