### PR TITLE
feat(operator,metrics): add TLS support for metrics server

### DIFF
--- a/docs/src/monitoring.md
+++ b/docs/src/monitoring.md
@@ -749,6 +749,30 @@ Currently, the operator exposes default `kubebuilder` metrics. See
 [kubebuilder documentation](https://book.kubebuilder.io/reference/metrics.html)
 for more details.
 
+### Monitoring the operator with Prometheus
+
+The operator can be monitored using the
+[Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator) by defining a
+[PodMonitor](https://github.com/prometheus-operator/prometheus-operator/blob/v0.47.1/Documentation/api.md#podmonitor)
+pointing to the operator pod(s), as follows (note it's applied in the same
+namespace as the operator):
+
+```yaml
+kubectl -n cnpg-system apply -f - <<EOF
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: cnpg-controller-manager
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: cloudnative-pg
+  podMetricsEndpoints:
+    - port: metrics
+EOF
+```
+
 ### Enabling TLS for operator metrics
 
 By default, the operator exposes metrics via HTTP on port 8080. To enable TLS
@@ -816,30 +840,6 @@ spec:
       scheme: https
       tlsConfig:
         insecureSkipVerify: true  # or configure proper CA validation
-```
-
-### Monitoring the operator with Prometheus
-
-The operator can be monitored using the
-[Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator) by defining a
-[PodMonitor](https://github.com/prometheus-operator/prometheus-operator/blob/v0.47.1/Documentation/api.md#podmonitor)
-pointing to the operator pod(s), as follows (note it's applied in the same
-namespace as the operator):
-
-```yaml
-kubectl -n cnpg-system apply -f - <<EOF
----
-apiVersion: monitoring.coreos.com/v1
-kind: PodMonitor
-metadata:
-  name: cnpg-controller-manager
-spec:
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: cloudnative-pg
-  podMetricsEndpoints:
-    - port: metrics
-EOF
 ```
 
 ## How to inspect the exported metrics

--- a/docs/src/monitoring.md
+++ b/docs/src/monitoring.md
@@ -764,7 +764,7 @@ Example configuration:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: cnpg-metrics-certs
+  name: cnpg-metrics-cert
   namespace: cnpg-system
 type: kubernetes.io/tls
 data:
@@ -790,7 +790,7 @@ spec:
       volumes:
       - name: metrics-certificates
         secret:
-          secretName: cnpg-metrics-certs
+          secretName: cnpg-metrics-cert
           defaultMode: 420
 ```
 

--- a/docs/src/monitoring.md
+++ b/docs/src/monitoring.md
@@ -775,14 +775,16 @@ EOF
 
 ### Enabling TLS for operator metrics
 
-By default, the operator exposes metrics via HTTP on port 8080. To enable TLS
-for the metrics endpoint, you need to:
+By default, the operator exposes its metrics over HTTP on port `8080`.
+To secure this endpoint with TLS, follow these steps:
 
-1. Create a Kubernetes secret containing TLS certificates (`tls.crt` and `tls.key`)
-2. Mount the secret to the operator pod
-3. Set the `METRICS_CERT_DIR` environment variable to point to the certificate directory
+1. Create a Kubernetes Secret containing the TLS certificate (`tls.crt`) and
+   private key (`tls.key`).
+2. Mount the Secret into the operator Pod.
+3. Set the `METRICS_CERT_DIR` environment variable to point to the directory
+   where the certificates are mounted.
 
-Example configuration:
+Example `Secret` definition:
 
 ```yaml
 apiVersion: v1
@@ -796,7 +798,8 @@ data:
   tls.key: <base64-encoded-key>
 ```
 
-Then, update the operator deployment to mount the secret and set the environment variable:
+Next, update the operator deployment to mount the secret and configure the
+environment variable:
 
 ```yaml
 spec:
@@ -819,11 +822,11 @@ spec:
 ```
 
 !!! Note
-    When `METRICS_CERT_DIR` is set, the operator will automatically enable
-    TLS for the metrics server. The PodMonitor configuration must be updated
-    to use HTTPS scheme.
+    When `METRICS_CERT_DIR` is set, the operator automatically enables TLS for
+    the metrics server. You must also update your PodMonitor configuration to
+    use the `https` scheme.
 
-With TLS enabled, update the PodMonitor to use HTTPS:
+Example `PodMonitor` configuration with TLS enabled:
 
 ```yaml
 apiVersion: monitoring.coreos.com/v1

--- a/docs/src/operator_conf.md
+++ b/docs/src/operator_conf.md
@@ -46,6 +46,7 @@ Name | Description
 `INHERITED_LABELS` | List of label names that, when defined in a `Cluster` metadata, will be inherited by all the generated resources, including pods
 `INSTANCES_ROLLOUT_DELAY` | The duration (in seconds) to wait between roll-outs of individual PostgreSQL instances within the same cluster during an operator upgrade. The default value is `0`, meaning no delay between upgrades of instances in the same PostgreSQL cluster.
 `KUBERNETES_CLUSTER_DOMAIN` | Defines the domain suffix for service FQDNs within the Kubernetes cluster. If left unset, it defaults to "cluster.local".
+`METRICS_CERT_DIR` | The directory where TLS certificates for the operator metrics server are stored. When set, enables TLS for the metrics endpoint on port 8080. The directory must contain `tls.crt` and `tls.key` files following standard Kubernetes TLS secret conventions. If not set, the metrics server operates without TLS (default behavior).
 `MONITORING_QUERIES_CONFIGMAP` | The name of a ConfigMap in the operator's namespace with a set of default queries (to be specified under the key `queries`) to be applied to all created Clusters
 `MONITORING_QUERIES_SECRET` | The name of a Secret in the operator's namespace with a set of default queries (to be specified under the key `queries`) to be applied to all created Clusters
 `OPERATOR_IMAGE_NAME` | The name of the operator image used to bootstrap Pods. Defaults to the image specified during installation.

--- a/internal/cmd/manager/controller/controller.go
+++ b/internal/cmd/manager/controller/controller.go
@@ -66,7 +66,7 @@ const (
 	// ValidatingWebhookConfigurationName is the name of the validating webhook configuration
 	ValidatingWebhookConfigurationName = "cnpg-validating-webhook-configuration"
 
-	// The name of the directory containing the TLS certificates
+	// The name of the directory containing the TLS certificates for webhooks
 	defaultWebhookCertDir = "/run/secrets/cnpg.io/webhook"
 
 	// LeaderElectionID The operator Leader Election ID
@@ -91,7 +91,7 @@ type leaderElectionConfiguration struct {
 // This code really belongs to app/controller_manager.go but we can't put
 // it here to respect the project layout created by kubebuilder.
 func RunController(
-	metricsAddr,
+	metricsAddr string,
 	configMapName,
 	secretName string,
 	leaderConfig leaderElectionConfiguration,
@@ -106,10 +106,8 @@ func RunController(
 		"build", versions.Info)
 
 	managerOptions := ctrl.Options{
-		Scheme: scheme,
-		Metrics: server.Options{
-			BindAddress: metricsAddr,
-		},
+		Scheme:           scheme,
+		Metrics:          buildMetricsOpts(metricsAddr, conf),
 		LeaderElection:   leaderConfig.enable,
 		LeaseDuration:    &leaderConfig.leaseDuration,
 		RenewDeadline:    &leaderConfig.renewDeadline,
@@ -313,6 +311,25 @@ func RunController(
 	}
 
 	return nil
+}
+
+func buildMetricsOpts(metricsAddr string, conf *configuration.Data) server.Options {
+	metricsOptions := server.Options{
+		BindAddress: metricsAddr,
+	}
+
+	if conf.MetricsCertDir == "" {
+		setupLog.Info("Metrics server enabled without TLS")
+		return metricsOptions
+	}
+
+	metricsOptions.CertName = "tls.crt"
+	metricsOptions.KeyName = "tls.key"
+	metricsOptions.SecureServing = true
+	metricsOptions.CertDir = conf.MetricsCertDir
+	setupLog.Info("Metrics server enabled with TLS", "certDir", conf.MetricsCertDir)
+
+	return metricsOptions
 }
 
 // loadConfiguration reads the configuration from the provided configmap and secret

--- a/internal/cmd/manager/controller/controller.go
+++ b/internal/cmd/manager/controller/controller.go
@@ -92,7 +92,7 @@ type leaderElectionConfiguration struct {
 // it here to respect the project layout created by kubebuilder.
 func RunController(
 	metricsAddr string,
-	configMapName,
+	configMapName string,
 	secretName string,
 	leaderConfig leaderElectionConfiguration,
 	pprofDebug bool,

--- a/internal/configuration/configuration.go
+++ b/internal/configuration/configuration.go
@@ -80,6 +80,10 @@ type Data struct {
 	// need to written. This is different between plain Kubernetes and OpenShift
 	WebhookCertDir string `json:"webhookCertDir" env:"WEBHOOK_CERT_DIR"`
 
+	// MetricsCertDir is the directory where the certificates for the metrics
+	// server are stored. If set, the metrics server will use TLS.
+	MetricsCertDir string `json:"metricsCertDir" env:"METRICS_CERT_DIR"`
+
 	// PluginSocketDir is the directory where the plugins sockets are to be
 	// found
 	PluginSocketDir string `json:"pluginSocketDir" env:"PLUGIN_SOCKET_DIR"`


### PR DESCRIPTION
Add optional TLS support for the operator metrics server (port 8080) to enhance security when exposing Prometheus metrics.

The feature is opt-in and controlled entirely by the `METRICS_CERT_DIR` environment variable. When set, the operator will:
- Enable TLS (SecureServing) for the metrics server
- Look for certificates at the specified path
- Use standard Kubernetes TLS secret naming (tls.crt/tls.key)

When `METRICS_CERT_DIR` is not set (default), the metrics server continues to operate without TLS, ensuring no breaking changes to existing deployments.

Usage:
1. Create a Kubernetes secret with TLS certificates (tls.crt and tls.key)
2. Mount the secret into the operator pod (e.g., /run/secrets/cnpg.io/metrics)
3. Set `METRICS_CERT_DIR` environment variable to the mount path
4. Update monitoring configuration (e.g., PodMonitor) to use HTTPS

Closes #5070 
