### PR TITLE
For k9s v0.50 - Update and rename plugins.yml to plugins.yaml, alter state command

### DIFF
--- a/docs/src/samples/k9s/plugins.yaml
+++ b/docs/src/samples/k9s/plugins.yaml
@@ -113,7 +113,7 @@ plugins:
       - -c
       - "kubectl cnpg restart $NAME -n $NAMESPACE --context \"$CONTEXT\" 2>&1 | less -R"
   cnpg-status:
-    shortCut: s
+    shortCut: Shift-S
     description: Status
     scopes:
       - cluster
@@ -123,7 +123,7 @@ plugins:
       - -c
       - "kubectl cnpg status $NAME -n $NAMESPACE --context \"$CONTEXT\" 2>&1 | less -R"
   cnpg-status-verbose:
-    shortCut: Shift-S
+    shortCut: Shift-V
     description: Status (verbose)
     scopes:
       - cluster


### PR DESCRIPTION
In k9s version 0.50, the command for checking the state of the current cluster object conflicts with the scale command, so it doesn’t run correctly.
Also, k9s only accepts files with the .yaml extension, which makes the community-provided plugins.yml file unusable.