### PR TITLE
chore(linter): fix new reports from golangci-lint 2.6.0

### DIFF
--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -1641,6 +1641,7 @@ type BootstrapInitDB struct {
 	Secret *LocalObjectReference `json:"secret,omitempty"`
 
 	// The list of options that must be passed to initdb when creating the cluster.
+	//
 	// Deprecated: This could lead to inconsistent configurations,
 	// please use the explicit provided parameters instead.
 	// If defined, explicit values will be ignored.

--- a/config/crd/bases/postgresql.cnpg.io_clusters.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_clusters.yaml
@@ -1652,6 +1652,7 @@ spec:
                       options:
                         description: |-
                           The list of options that must be passed to initdb when creating the cluster.
+
                           Deprecated: This could lead to inconsistent configurations,
                           please use the explicit provided parameters instead.
                           If defined, explicit values will be ignored.

--- a/docs/src/cloudnative-pg.v1.md
+++ b/docs/src/cloudnative-pg.v1.md
@@ -1083,8 +1083,8 @@ created from scratch</p>
 <i>[]string</i>
 </td>
 <td>
-   <p>The list of options that must be passed to initdb when creating the cluster.
-Deprecated: This could lead to inconsistent configurations,
+   <p>The list of options that must be passed to initdb when creating the cluster.</p>
+<p>Deprecated: This could lead to inconsistent configurations,
 please use the explicit provided parameters instead.
 If defined, explicit values will be ignored.</p>
 </td>

--- a/internal/controller/cluster_upgrade.go
+++ b/internal/controller/cluster_upgrade.go
@@ -553,6 +553,7 @@ func checkClusterHasDifferentRestartAnnotation(
 }
 
 // checkPodEnvironmentIsOutdated checks if the environment variables in the pod have changed.
+//
 // Deprecated: this function doesn't take into account plugin changes, use PodSpec annotation.
 func checkPodEnvironmentIsOutdated(_ context.Context, pod *corev1.Pod, cluster *apiv1.Cluster) (rollout, error) {
 	// Check if there is a change in the environment section

--- a/pkg/reconciler/backup/volumesnapshot/reconciler.go
+++ b/pkg/reconciler/backup/volumesnapshot/reconciler.go
@@ -509,6 +509,7 @@ func transferLabelsToAnnotations(labels map[string]string, annotations map[strin
 	labelsToBeTransferred := []string{
 		utils.InstanceNameLabelName,
 		utils.ClusterInstanceRoleLabelName,
+		//nolint:staticcheck // still in use for backward compatibility
 		utils.ClusterRoleLabelName,
 		utils.PvcRoleLabelName,
 	}

--- a/pkg/reconciler/backup/volumesnapshot/reconciler_test.go
+++ b/pkg/reconciler/backup/volumesnapshot/reconciler_test.go
@@ -380,6 +380,7 @@ var _ = Describe("transferLabelsToAnnotations", func() {
 	It("should transfer specified labels to annotations", func() {
 		labels[utils.ClusterInstanceRoleLabelName] = exampleValueOne
 		labels[utils.InstanceNameLabelName] = exampleValueTwo
+		//nolint:staticcheck
 		labels[utils.ClusterRoleLabelName] = "value3"
 		labels["extraLabel"] = "value4" // This should not be transferred
 
@@ -387,6 +388,7 @@ var _ = Describe("transferLabelsToAnnotations", func() {
 
 		Expect(annotations[utils.ClusterInstanceRoleLabelName]).To(Equal(exampleValueOne))
 		Expect(annotations[utils.InstanceNameLabelName]).To(Equal(exampleValueTwo))
+		//nolint:staticcheck
 		Expect(annotations[utils.ClusterRoleLabelName]).To(Equal("value3"))
 		Expect(annotations).ToNot(HaveKey("extraLabel"))
 
@@ -398,12 +400,14 @@ var _ = Describe("transferLabelsToAnnotations", func() {
 
 	It("should not modify annotations if label is not present", func() {
 		labels[utils.ClusterInstanceRoleLabelName] = exampleValueOne
+		//nolint:staticcheck
 		labels[utils.ClusterRoleLabelName] = "value3"
 
 		transferLabelsToAnnotations(labels, annotations)
 
 		Expect(annotations[utils.ClusterInstanceRoleLabelName]).To(Equal(exampleValueOne))
 		Expect(annotations).ToNot(HaveKey(utils.InstanceNameLabelName))
+		//nolint:staticcheck
 		Expect(annotations[utils.ClusterRoleLabelName]).To(Equal("value3"))
 	})
 

--- a/pkg/reconciler/instance/metadata.go
+++ b/pkg/reconciler/instance/metadata.go
@@ -187,6 +187,7 @@ func updateRoleLabels(
 
 	// it is important to note that even if utils.ClusterRoleLabelName is deprecated,
 	// we still ensure that the values are aligned between the two fields
+	//nolint:staticcheck
 	podRole, hasRole := instance.Labels[utils.ClusterRoleLabelName]
 	newPodRole, newHasRole := instance.Labels[utils.ClusterInstanceRoleLabelName]
 

--- a/pkg/reconciler/instance/metadata_test.go
+++ b/pkg/reconciler/instance/metadata_test.go
@@ -62,11 +62,13 @@ var _ = Describe("object metadata test", func() {
 			updated := updateRoleLabels(context.Background(), cluster, primaryPod)
 			Expect(updated).To(BeTrue())
 
+			//nolint:staticcheck
 			Expect(primaryPod.Labels[utils.ClusterRoleLabelName]).To(Equal(specs.ClusterRoleLabelPrimary))
 			Expect(primaryPod.Labels[utils.ClusterInstanceRoleLabelName]).To(Equal(specs.ClusterRoleLabelPrimary))
 
 			updated = updateRoleLabels(context.Background(), cluster, replicaPod)
 			Expect(updated).To(BeTrue())
+			//nolint:staticcheck
 			Expect(replicaPod.Labels[utils.ClusterRoleLabelName]).To(Equal(specs.ClusterRoleLabelReplica))
 			Expect(replicaPod.Labels[utils.ClusterInstanceRoleLabelName]).To(Equal(specs.ClusterRoleLabelReplica))
 		})
@@ -83,6 +85,7 @@ var _ = Describe("object metadata test", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "newPrimaryPod",
 					Labels: map[string]string{
+						//nolint:staticcheck
 						utils.ClusterRoleLabelName:         specs.ClusterRoleLabelReplica,
 						utils.ClusterInstanceRoleLabelName: specs.ClusterRoleLabelReplica,
 					},
@@ -93,6 +96,7 @@ var _ = Describe("object metadata test", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "newReplicaPod",
 					Labels: map[string]string{
+						//nolint:staticcheck
 						utils.ClusterRoleLabelName:         specs.ClusterRoleLabelPrimary,
 						utils.ClusterInstanceRoleLabelName: specs.ClusterRoleLabelPrimary,
 					},
@@ -101,11 +105,13 @@ var _ = Describe("object metadata test", func() {
 
 			updated := updateRoleLabels(context.Background(), cluster, newPrimaryPod)
 			Expect(updated).To(BeTrue())
+			//nolint:staticcheck
 			Expect(newPrimaryPod.Labels[utils.ClusterRoleLabelName]).To(Equal(specs.ClusterRoleLabelPrimary))
 			Expect(newPrimaryPod.Labels[utils.ClusterInstanceRoleLabelName]).To(Equal(specs.ClusterRoleLabelPrimary))
 
 			updated = updateRoleLabels(context.Background(), cluster, newReplicaPod)
 			Expect(updated).To(BeTrue())
+			//nolint:staticcheck
 			Expect(newReplicaPod.Labels[utils.ClusterRoleLabelName]).To(Equal(specs.ClusterRoleLabelReplica))
 			Expect(newReplicaPod.Labels[utils.ClusterInstanceRoleLabelName]).To(Equal(specs.ClusterRoleLabelReplica))
 		})
@@ -133,11 +139,13 @@ var _ = Describe("object metadata test", func() {
 
 			updated := updateRoleLabels(context.Background(), cluster, oldPrimaryPod)
 			Expect(updated).To(BeFalse())
+			//nolint:staticcheck
 			Expect(oldPrimaryPod.Labels).ToNot(ContainElement(utils.ClusterRoleLabelName))
 			Expect(oldPrimaryPod.Labels[utils.ClusterInstanceRoleLabelName]).To(Equal(specs.ClusterRoleLabelPrimary))
 
 			updated = updateRoleLabels(context.Background(), cluster, oldReplicaPod)
 			Expect(updated).To(BeFalse())
+			//nolint:staticcheck
 			Expect(oldReplicaPod.Labels).ToNot(ContainElement(utils.ClusterRoleLabelName))
 			Expect(oldReplicaPod.Labels[utils.ClusterInstanceRoleLabelName]).To(Equal(specs.ClusterRoleLabelReplica))
 		})
@@ -154,6 +162,7 @@ var _ = Describe("object metadata test", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "primaryPod",
 					Labels: map[string]string{
+						//nolint:staticcheck
 						utils.ClusterRoleLabelName:         specs.ClusterRoleLabelPrimary,
 						utils.ClusterInstanceRoleLabelName: specs.ClusterRoleLabelPrimary,
 					},
@@ -164,6 +173,7 @@ var _ = Describe("object metadata test", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "replicaPod",
 					Labels: map[string]string{
+						//nolint:staticcheck
 						utils.ClusterRoleLabelName:         specs.ClusterRoleLabelReplica,
 						utils.ClusterInstanceRoleLabelName: specs.ClusterRoleLabelReplica,
 					},
@@ -172,11 +182,13 @@ var _ = Describe("object metadata test", func() {
 
 			updated := updateRoleLabels(context.Background(), cluster, primaryPod)
 			Expect(updated).To(BeFalse())
+			//nolint:staticcheck
 			Expect(primaryPod.Labels[utils.ClusterRoleLabelName]).To(Equal(specs.ClusterRoleLabelPrimary))
 			Expect(primaryPod.Labels[utils.ClusterInstanceRoleLabelName]).To(Equal(specs.ClusterRoleLabelPrimary))
 
 			updated = updateRoleLabels(context.Background(), cluster, replicaPod)
 			Expect(updated).To(BeFalse())
+			//nolint:staticcheck
 			Expect(replicaPod.Labels[utils.ClusterRoleLabelName]).To(Equal(specs.ClusterRoleLabelReplica))
 			Expect(replicaPod.Labels[utils.ClusterInstanceRoleLabelName]).To(Equal(specs.ClusterRoleLabelReplica))
 		})
@@ -193,6 +205,7 @@ var _ = Describe("object metadata test", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "primaryPod",
 					Labels: map[string]string{
+						//nolint:staticcheck
 						utils.ClusterRoleLabelName: specs.ClusterRoleLabelPrimary,
 					},
 				},
@@ -202,6 +215,7 @@ var _ = Describe("object metadata test", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "replicaPod",
 					Labels: map[string]string{
+						//nolint:staticcheck
 						utils.ClusterRoleLabelName: specs.ClusterRoleLabelReplica,
 					},
 				},
@@ -209,11 +223,13 @@ var _ = Describe("object metadata test", func() {
 
 			updated := updateRoleLabels(context.Background(), cluster, primaryPod)
 			Expect(updated).To(BeTrue())
+			//nolint:staticcheck
 			Expect(primaryPod.Labels[utils.ClusterRoleLabelName]).To(Equal(specs.ClusterRoleLabelPrimary))
 			Expect(primaryPod.Labels[utils.ClusterInstanceRoleLabelName]).To(Equal(specs.ClusterRoleLabelPrimary))
 
 			updated = updateRoleLabels(context.Background(), cluster, replicaPod)
 			Expect(updated).To(BeTrue())
+			//nolint:staticcheck
 			Expect(replicaPod.Labels[utils.ClusterRoleLabelName]).To(Equal(specs.ClusterRoleLabelReplica))
 			Expect(replicaPod.Labels[utils.ClusterInstanceRoleLabelName]).To(Equal(specs.ClusterRoleLabelReplica))
 		})
@@ -507,6 +523,7 @@ var _ = Describe("metadata reconciliation test", func() {
 			for _, pod := range updatedInstanceList.Items {
 				Expect(pod.Labels[utils.PodRoleLabelName]).To(Equal(string(utils.PodRoleInstance)))
 				Expect(pod.Labels[utils.InstanceNameLabelName]).To(Equal(pod.Name))
+				//nolint:staticcheck
 				Expect(pod.Labels[utils.ClusterRoleLabelName]).To(Or(Equal(specs.ClusterRoleLabelPrimary),
 					Equal(specs.ClusterRoleLabelReplica)))
 				Expect(pod.Labels[utils.ClusterInstanceRoleLabelName]).To(Or(Equal(specs.ClusterRoleLabelPrimary),
@@ -556,6 +573,7 @@ var _ = Describe("metadata update functions", func() {
 		It("Should updateRoleLabels correctly", func() {
 			modified := updateRoleLabels(ctx, cluster, instance)
 			Expect(modified).To(BeTrue())
+			//nolint:staticcheck
 			Expect(instance.Labels[utils.ClusterRoleLabelName]).To(Equal(specs.ClusterRoleLabelPrimary))
 			Expect(instance.Labels[utils.ClusterInstanceRoleLabelName]).To(Equal(specs.ClusterRoleLabelPrimary))
 		})

--- a/pkg/reconciler/majorupgrade/reconciler_test.go
+++ b/pkg/reconciler/majorupgrade/reconciler_test.go
@@ -156,7 +156,7 @@ func buildPrimaryPVC(serial int) corev1.PersistentVolumeClaim {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: fmt.Sprintf("cluster-example-%d", serial),
 			Labels: map[string]string{
-				utils.ClusterRoleLabelName: specs.ClusterRoleLabelPrimary,
+				utils.ClusterInstanceRoleLabelName: specs.ClusterRoleLabelPrimary,
 			},
 			Annotations: map[string]string{
 				utils.ClusterSerialAnnotationName: fmt.Sprintf("%v", serial),
@@ -170,7 +170,7 @@ func buildInvalidPrimaryPVC(serial int) corev1.PersistentVolumeClaim {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: fmt.Sprintf("cluster-example-%d", serial),
 			Labels: map[string]string{
-				utils.ClusterRoleLabelName: specs.ClusterRoleLabelPrimary,
+				utils.ClusterInstanceRoleLabelName: specs.ClusterRoleLabelPrimary,
 			},
 			Annotations: map[string]string{
 				utils.ClusterSerialAnnotationName: fmt.Sprintf("%v - this is a test", serial),
@@ -184,7 +184,7 @@ func buildReplicaPVC(serial int) corev1.PersistentVolumeClaim {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: fmt.Sprintf("cluster-example-%d", serial),
 			Labels: map[string]string{
-				utils.ClusterRoleLabelName: specs.ClusterRoleLabelReplica,
+				utils.ClusterInstanceRoleLabelName: specs.ClusterRoleLabelReplica,
 			},
 			Annotations: map[string]string{
 				utils.ClusterSerialAnnotationName: fmt.Sprintf("%v", serial),

--- a/pkg/reconciler/persistentvolumeclaim/metadata.go
+++ b/pkg/reconciler/persistentvolumeclaim/metadata.go
@@ -90,6 +90,7 @@ func reconcileInstanceRoleLabel(
 		instanceReconciler := metadataReconciler{
 			name: "instance-role",
 			isUpToDate: func(pvc *corev1.PersistentVolumeClaim) bool {
+				//nolint:staticcheck // still in use for backward compatibility
 				if pvc.Labels[utils.ClusterRoleLabelName] != instanceRole {
 					return false
 				}

--- a/pkg/reconciler/persistentvolumeclaim/reconciler_test.go
+++ b/pkg/reconciler/persistentvolumeclaim/reconciler_test.go
@@ -84,6 +84,7 @@ var _ = Describe("Reconcile Metadata", func() {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: clusterName + "-3",
 						Labels: map[string]string{
+							//nolint:staticcheck
 							utils.ClusterRoleLabelName: specs.ClusterRoleLabelPrimary,
 						},
 						Annotations: map[string]string{
@@ -107,6 +108,7 @@ var _ = Describe("Reconcile Metadata", func() {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: clusterName + "-2",
 						Labels: map[string]string{
+							//nolint:staticcheck
 							utils.ClusterRoleLabelName: specs.ClusterRoleLabelReplica,
 						},
 						Annotations: map[string]string{
@@ -118,6 +120,7 @@ var _ = Describe("Reconcile Metadata", func() {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: clusterName + "-1",
 						Labels: map[string]string{
+							//nolint:staticcheck
 							utils.ClusterRoleLabelName: specs.ClusterRoleLabelReplica,
 						},
 						Annotations: map[string]string{
@@ -388,7 +391,7 @@ var _ = Describe("PVC reconciliation", Ordered, func() {
 		Expect(patchedPvc.Labels).To(Equal(map[string]string{
 			utils.InstanceNameLabelName:        clusterName + "-1",
 			utils.PvcRoleLabelName:             "PG_DATA",
-			utils.ClusterRoleLabelName:         "primary",
+			utils.ClusterRoleLabelName:         "primary", //nolint:staticcheck
 			utils.ClusterInstanceRoleLabelName: "primary",
 		}))
 		Expect(patchedPvc.Annotations).To(Equal(map[string]string{
@@ -401,7 +404,7 @@ var _ = Describe("PVC reconciliation", Ordered, func() {
 		Expect(patchedPvc2.Labels).To(Equal(map[string]string{
 			utils.InstanceNameLabelName:        clusterName + "-2",
 			utils.PvcRoleLabelName:             "PG_DATA",
-			utils.ClusterRoleLabelName:         "replica",
+			utils.ClusterRoleLabelName:         "replica", //nolint:staticcheck
 			utils.ClusterInstanceRoleLabelName: "replica",
 		}))
 		Expect(patchedPvc2.Annotations).To(Equal(map[string]string{
@@ -414,7 +417,7 @@ var _ = Describe("PVC reconciliation", Ordered, func() {
 		Expect(patchedPvc3Wal.Labels).To(Equal(map[string]string{
 			utils.InstanceNameLabelName:        clusterName + "-3",
 			utils.PvcRoleLabelName:             "PG_WAL",
-			utils.ClusterRoleLabelName:         "replica",
+			utils.ClusterRoleLabelName:         "replica", //nolint:staticcheck
 			utils.ClusterInstanceRoleLabelName: "replica",
 		}))
 		Expect(patchedPvc3Wal.Annotations).To(Equal(map[string]string{
@@ -427,7 +430,7 @@ var _ = Describe("PVC reconciliation", Ordered, func() {
 		Expect(patchedPvc3Data.Labels).To(Equal(map[string]string{
 			utils.InstanceNameLabelName:        clusterName + "-3",
 			utils.PvcRoleLabelName:             "PG_DATA",
-			utils.ClusterRoleLabelName:         "replica",
+			utils.ClusterRoleLabelName:         "replica", //nolint:staticcheck
 			utils.ClusterInstanceRoleLabelName: "replica",
 		}))
 		Expect(patchedPvc3Data.Annotations).To(Equal(map[string]string{

--- a/pkg/specs/jobs.go
+++ b/pkg/specs/jobs.go
@@ -122,6 +122,7 @@ func buildInitDBFlags(cluster apiv1.Cluster) (initCommand []string) {
 			"cluster", cluster.Name,
 			"namespace", cluster.Namespace)
 
+		//nolint:staticcheck // still in use for backward compatibility
 		options = append(options, config.Options...)
 		initCommand = append(
 			initCommand,

--- a/pkg/specs/pods.go
+++ b/pkg/specs/pods.go
@@ -527,7 +527,8 @@ func buildInstance(
 			},
 			Annotations: map[string]string{
 				utils.ClusterSerialAnnotationName: strconv.Itoa(nodeSerial),
-				utils.PodEnvHashAnnotationName:    envConfig.Hash,
+				//nolint:staticcheck // still in use for backward compatibility
+				utils.PodEnvHashAnnotationName: envConfig.Hash,
 			},
 			Name:      podName,
 			Namespace: cluster.Namespace,

--- a/pkg/system/compatibility/darwin.go
+++ b/pkg/system/compatibility/darwin.go
@@ -1,5 +1,4 @@
 //go:build darwin
-// +build darwin
 
 /*
 Copyright © contributors to CloudNativePG, established as

--- a/pkg/system/compatibility/unix.go
+++ b/pkg/system/compatibility/unix.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 /*
 Copyright © contributors to CloudNativePG, established as

--- a/pkg/system/compatibility/windows.go
+++ b/pkg/system/compatibility/windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 /*
 Copyright © contributors to CloudNativePG, established as

--- a/pkg/utils/labels_annotations.go
+++ b/pkg/utils/labels_annotations.go
@@ -70,6 +70,7 @@ const (
 	PgbouncerNameLabel = MetadataNamespace + "/poolerName"
 
 	// ClusterRoleLabelName is the name of label applied to instances to mark primary/replica
+	//
 	// Deprecated: Use ClusterInstanceRoleLabelName.
 	ClusterRoleLabelName = "role"
 
@@ -145,6 +146,7 @@ const (
 	HibernatePgControlDataAnnotationName = MetadataNamespace + "/hibernatePgControlData"
 
 	// PodEnvHashAnnotationName is the name of the annotation containing the podEnvHash value
+	//
 	// Deprecated: the PodSpec annotation covers the environment drift. This annotation is
 	// kept for backward compatibility
 	PodEnvHashAnnotationName = MetadataNamespace + "/podEnvHash"


### PR DESCRIPTION
Update linter fixes for golangci-lint 2.6.0

This PR updates code to address new checks from golangci-lint 2.6.0:

- Ensure a blank line before deprecation comments so the deprecation notice is recognized.
- Remove obsolete old-style conditional build directives where the new form is sufficient.

Small, non-functional formatting and build-directive cleanups only.