### PR TITLE
chore: sanitize path for Stream() function

### DIFF
--- a/pkg/executablehash/executablehash.go
+++ b/pkg/executablehash/executablehash.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"sync"
 )
 
@@ -35,8 +36,8 @@ var (
 
 // Stream opens a stream reading from the executable of the current binary
 func Stream() (io.ReadCloser, error) {
-	processBinaryFileName := os.Args[0]
-	return os.Open(processBinaryFileName) // #nosec
+	processBinaryFileName := filepath.Clean(os.Args[0])
+	return os.Open(processBinaryFileName)
 }
 
 // StreamByName opens a stream reading from an executable given its name

--- a/pkg/executablehash/executablehash.go
+++ b/pkg/executablehash/executablehash.go
@@ -34,10 +34,9 @@ var (
 	mx                sync.Mutex
 )
 
-// Stream opens a stream reading from the executable of the current binary
+// Stream opens a stream reading from the executable of the current process binary (os.Args[0] after path cleaning).
 func Stream() (io.ReadCloser, error) {
-	processBinaryFileName := filepath.Clean(os.Args[0])
-	return os.Open(processBinaryFileName)
+	return os.Open(filepath.Clean(os.Args[0]))
 }
 
 // StreamByName opens a stream reading from an executable given its name


### PR DESCRIPTION
Add a sanitization to the path passed to the os.Open() function when
reading the operator binary

Closes #9062 