### PR TITLE
fix(plugin): fix duplicating pgData on walrestore

### DIFF
--- a/internal/cmd/manager/walrestore/cmd.go
+++ b/internal/cmd/manager/walrestore/cmd.go
@@ -25,7 +25,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -267,10 +266,6 @@ func restoreWALViaPlugins(
 ) (bool, error) {
 	contextLogger := log.FromContext(ctx)
 
-	// check if the `destinationPathName` is an absolute path or just the filename
-	if !filepath.IsAbs(destinationPathName) {
-		destinationPathName = filepath.Join(pgData, destinationPathName)
-	}
 	plugins := repository.New()
 	defer plugins.Close()
 
@@ -287,7 +282,7 @@ func restoreWALViaPlugins(
 	}
 	defer client.Close(ctx)
 
-	return client.RestoreWAL(ctx, cluster, walName, destinationPathName)
+	return client.RestoreWAL(ctx, cluster, walName, postgres.BuildWALPath(pgData, destinationPathName))
 }
 
 // checkEndOfWALStreamFlag returns ErrEndOfWALStreamReached if the flag is set in the restorer

--- a/pkg/management/postgres/archiver/archiver.go
+++ b/pkg/management/postgres/archiver/archiver.go
@@ -282,11 +282,6 @@ func archiveWALViaPlugins(
 ) error {
 	contextLogger := log.FromContext(ctx)
 
-	// check if the `walName` is an absolute path or just the filename
-	if !filepath.IsAbs(walName) {
-		walName = filepath.Join(pgData, walName)
-	}
-
 	plugins := repository.New()
 	defer plugins.Close()
 
@@ -306,7 +301,7 @@ func archiveWALViaPlugins(
 		}
 	}
 
-	return client.ArchiveWAL(ctx, cluster, walName)
+	return client.ArchiveWAL(ctx, cluster, postgres.BuildWALPath(pgData, walName))
 }
 
 // isCheckWalArchiveFlagFilePresent returns true if the file CheckEmptyWalArchiveFile is present in the PGDATA directory

--- a/pkg/postgres/wal.go
+++ b/pkg/postgres/wal.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"path"
+	"path/filepath"
 	"regexp"
 	"strconv"
 )
@@ -192,4 +193,15 @@ func (segment Segment) NextSegments(size int, postgresVersion *int, segmentSize 
 	}
 
 	return result
+}
+
+// BuildWALPath constructs the full destination path for WAL operations.
+// If walPath is already absolute, it returns it as-is.
+// If walPath is relative, it joins it with pgData.
+// This prevents path duplication when PostgreSQL or pg_rewind passes absolute paths.
+func BuildWALPath(pgData, walPath string) string {
+	if !filepath.IsAbs(walPath) {
+		return filepath.Join(pgData, walPath)
+	}
+	return walPath
 }


### PR DESCRIPTION
This commit fixes incorrect walrestore path passed to plugins if destination path is already absolute.

Similar to https://github.com/cloudnative-pg/cloudnative-pg/pull/6964, but refers `walrestore` part.

Closes #9067
