### PR TITLE
Execute db init in parallel

### DIFF
--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -739,7 +739,7 @@ func (r *ClusterReconciler) reconcileResources(
 
 	if len(runningJobs) > 0 {
 		contextLogger.Debug("A job is currently running. Waiting", "runningJobs", runningJobs)
-		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+		return ctrl.Result{RequeueAfter: 2 * time.Second}, nil
 	}
 
 	if result, err := r.deleteTerminatedPods(ctx, cluster, resources); err != nil {


### PR DESCRIPTION
This change executes `postgres` & `template` DB bootstraps in parallel, helping to reduce overall cluster provision times.