### PR TITLE
fix(probe,readiness): improve resilience to transient API server connectivity issues

### DIFF
--- a/pkg/management/postgres/webserver/probes/cache.go
+++ b/pkg/management/postgres/webserver/probes/cache.go
@@ -30,10 +30,10 @@ import (
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 )
 
-// clusterCache provides a resilient way to fetch cluster definitions with caching
+// ClusterCache provides a resilient way to fetch cluster definitions with caching
 // to handle transient API server connectivity issues.
-// This cache is thread-safe and can be shared across concurrent probe requests.
-type clusterCache struct {
+// This cache is thread-safe and can be shared across multiple probe types.
+type ClusterCache struct {
 	cli     client.Client
 	key     client.ObjectKey
 	timeout time.Duration
@@ -42,9 +42,9 @@ type clusterCache struct {
 	latestKnownCluster *apiv1.Cluster
 }
 
-// newClusterCache creates a new cluster cache instance
-func newClusterCache(cli client.Client, key client.ObjectKey) *clusterCache {
-	return &clusterCache{
+// NewClusterCache creates a new cluster cache instance that can be shared across multiple probes
+func NewClusterCache(cli client.Client, key client.ObjectKey) *ClusterCache {
+	return &ClusterCache{
 		cli: cli,
 		key: key,
 		// We set a safe context timeout of 500ms to avoid a failed request from taking
@@ -56,7 +56,7 @@ func newClusterCache(cli client.Client, key client.ObjectKey) *clusterCache {
 
 // tryGetLatestClusterWithTimeout attempts to fetch a fresh cluster definition with a timeout.
 // Returns the refreshed cluster and true if successful, or the cached cluster (may be nil) and false on failure.
-func (c *clusterCache) tryGetLatestClusterWithTimeout(ctx context.Context) (*apiv1.Cluster, bool) {
+func (c *ClusterCache) tryGetLatestClusterWithTimeout(ctx context.Context) (*apiv1.Cluster, bool) {
 	timeoutContext, cancel := context.WithTimeout(ctx, c.timeout)
 	defer cancel()
 

--- a/pkg/management/postgres/webserver/probes/cache.go
+++ b/pkg/management/postgres/webserver/probes/cache.go
@@ -1,0 +1,72 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package probes
+
+import (
+	"context"
+	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+)
+
+// clusterCache provides a resilient way to fetch cluster definitions with caching
+// to handle transient API server connectivity issues
+type clusterCache struct {
+	cli     client.Client
+	key     client.ObjectKey
+	timeout time.Duration
+
+	latestKnownCluster *apiv1.Cluster
+}
+
+// newClusterCache creates a new cluster cache instance
+func newClusterCache(cli client.Client, key client.ObjectKey) *clusterCache {
+	return &clusterCache{
+		cli: cli,
+		key: key,
+		// We set a safe context timeout of 500ms to avoid a failed request from taking
+		// more time than the minimum configurable timeout (1s) of the container's probe,
+		// which otherwise could have triggered a restart of the instance.
+		timeout: 500 * time.Millisecond,
+	}
+}
+
+// tryRefreshLatestClusterWithTimeout refreshes the latest cluster definition with a timeout,
+// returns a bool indicating if the operation was successful
+func (c *clusterCache) tryRefreshLatestClusterWithTimeout(ctx context.Context) bool {
+	timeoutContext, cancel := context.WithTimeout(ctx, c.timeout)
+	defer cancel()
+
+	var cluster apiv1.Cluster
+	err := c.cli.Get(timeoutContext, c.key, &cluster)
+	if err != nil {
+		return false
+	}
+
+	c.latestKnownCluster = cluster.DeepCopy()
+	return true
+}
+
+// getLatestKnownCluster returns the latest known cluster definition, or nil if none is available
+func (c *clusterCache) getLatestKnownCluster() *apiv1.Cluster {
+	return c.latestKnownCluster
+}

--- a/pkg/management/postgres/webserver/probes/cache.go
+++ b/pkg/management/postgres/webserver/probes/cache.go
@@ -30,6 +30,7 @@ import (
 
 // clusterCache provides a resilient way to fetch cluster definitions with caching
 // to handle transient API server connectivity issues
+// Note: This cache is not thread-safe and should be used by a single probe executor.
 type clusterCache struct {
 	cli     client.Client
 	key     client.ObjectKey

--- a/pkg/management/postgres/webserver/probes/cache.go
+++ b/pkg/management/postgres/webserver/probes/cache.go
@@ -24,6 +24,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cloudnative-pg/machinery/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
@@ -62,6 +63,13 @@ func (c *clusterCache) tryGetLatestClusterWithTimeout(ctx context.Context) (*api
 	var cluster apiv1.Cluster
 	err := c.cli.Get(timeoutContext, c.key, &cluster)
 	if err != nil {
+		log.FromContext(ctx).Debug(
+			"Failed to refresh cluster definition, using cached value",
+			"cluster", c.key.Name,
+			"namespace", c.key.Namespace,
+			"err", err.Error(),
+		)
+
 		// Return the current cached value on failure
 		c.mu.RLock()
 		cached := c.latestKnownCluster

--- a/pkg/management/postgres/webserver/probes/cache.go
+++ b/pkg/management/postgres/webserver/probes/cache.go
@@ -70,7 +70,7 @@ func (c *clusterCache) tryGetLatestClusterWithTimeout(ctx context.Context) (*api
 	}
 
 	c.mu.Lock()
-	c.latestKnownCluster = cluster.DeepCopy()
+	c.latestKnownCluster = &cluster
 	result := c.latestKnownCluster
 	c.mu.Unlock()
 	return result, true

--- a/pkg/management/postgres/webserver/probes/cache_test.go
+++ b/pkg/management/postgres/webserver/probes/cache_test.go
@@ -1,0 +1,163 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package probes
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	"github.com/cloudnative-pg/cloudnative-pg/internal/scheme"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("clusterCache", func() {
+	var (
+		ctx      context.Context
+		cli      client.Client
+		instance *postgres.Instance
+		cache    *clusterCache
+		cluster  *apiv1.Cluster
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+
+		cluster = &apiv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-cluster",
+				Namespace: "test-namespace",
+			},
+			Spec: apiv1.ClusterSpec{
+				Instances: 3,
+			},
+		}
+
+		cli = fake.NewClientBuilder().
+			WithScheme(scheme.BuildWithAllKnownScheme()).
+			WithObjects(cluster).
+			Build()
+
+		instance = postgres.NewInstance().
+			WithNamespace("test-namespace").
+			WithClusterName("test-cluster")
+
+		cache = newClusterCache(cli, client.ObjectKey{
+			Namespace: instance.GetNamespaceName(),
+			Name:      instance.GetClusterName(),
+		})
+	})
+
+	Context("tryRefreshLatestClusterWithTimeout", func() {
+		It("should successfully refresh the cluster definition", func() {
+			success := cache.tryRefreshLatestClusterWithTimeout(ctx)
+			Expect(success).To(BeTrue())
+			Expect(cache.getLatestKnownCluster()).ToNot(BeNil())
+			Expect(cache.getLatestKnownCluster().Name).To(Equal("test-cluster"))
+			Expect(cache.getLatestKnownCluster().Spec.Instances).To(Equal(3))
+		})
+
+		It("should return false when the cluster is not found", func() {
+			cache = newClusterCache(cli, client.ObjectKey{
+				Namespace: "test-namespace",
+				Name:      "non-existent-cluster",
+			})
+
+			success := cache.tryRefreshLatestClusterWithTimeout(ctx)
+			Expect(success).To(BeFalse())
+			Expect(cache.getLatestKnownCluster()).To(BeNil())
+		})
+
+		It("should handle context cancellation", func() {
+			// Create a context that is already cancelled
+			cancelledCtx, cancel := context.WithCancel(ctx)
+			cancel()
+
+			// With a cancelled context, the operation should fail
+			// Note: With fake client, this might still succeed if it's fast enough,
+			// but in real scenarios with actual API server delays, this would fail
+			success := cache.tryRefreshLatestClusterWithTimeout(cancelledCtx)
+			// We don't assert the result here because the fake client is too fast
+			// This test mainly verifies the code doesn't panic with a cancelled context
+			_ = success
+		})
+
+		It("should cache the cluster definition across multiple calls", func() {
+			// First refresh
+			success := cache.tryRefreshLatestClusterWithTimeout(ctx)
+			Expect(success).To(BeTrue())
+			firstCluster := cache.getLatestKnownCluster()
+
+			// Update the cluster
+			cluster.Spec.Instances = 5
+			err := cli.Update(ctx, cluster)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Second refresh should get the updated cluster
+			success = cache.tryRefreshLatestClusterWithTimeout(ctx)
+			Expect(success).To(BeTrue())
+			secondCluster := cache.getLatestKnownCluster()
+
+			Expect(firstCluster.Spec.Instances).To(Equal(3))
+			Expect(secondCluster.Spec.Instances).To(Equal(5))
+		})
+
+		It("should maintain the cached cluster when refresh fails", func() {
+			// First successful refresh
+			success := cache.tryRefreshLatestClusterWithTimeout(ctx)
+			Expect(success).To(BeTrue())
+			cachedCluster := cache.getLatestKnownCluster()
+			Expect(cachedCluster).ToNot(BeNil())
+
+			// Change cache to point to non-existent cluster
+			cache.key = client.ObjectKey{
+				Namespace: "test-namespace",
+				Name:      "non-existent-cluster",
+			}
+
+			// Second refresh should fail but cache should remain
+			success = cache.tryRefreshLatestClusterWithTimeout(ctx)
+			Expect(success).To(BeFalse())
+			// Cache should still have the old cluster
+			Expect(cache.getLatestKnownCluster()).To(Equal(cachedCluster))
+		})
+	})
+
+	Context("getLatestKnownCluster", func() {
+		It("should return nil when no cluster has been cached", func() {
+			Expect(cache.getLatestKnownCluster()).To(BeNil())
+		})
+
+		It("should return the cached cluster after a successful refresh", func() {
+			success := cache.tryRefreshLatestClusterWithTimeout(ctx)
+			Expect(success).To(BeTrue())
+
+			cachedCluster := cache.getLatestKnownCluster()
+			Expect(cachedCluster).ToNot(BeNil())
+			Expect(cachedCluster.Name).To(Equal("test-cluster"))
+		})
+	})
+})

--- a/pkg/management/postgres/webserver/probes/cache_test.go
+++ b/pkg/management/postgres/webserver/probes/cache_test.go
@@ -34,12 +34,12 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("clusterCache", func() {
+var _ = Describe("ClusterCache", func() {
 	var (
 		ctx      context.Context
 		cli      client.Client
 		instance *postgres.Instance
-		cache    *clusterCache
+		cache    *ClusterCache
 		cluster  *apiv1.Cluster
 	)
 
@@ -65,7 +65,7 @@ var _ = Describe("clusterCache", func() {
 			WithNamespace("test-namespace").
 			WithClusterName("test-cluster")
 
-		cache = newClusterCache(cli, client.ObjectKey{
+		cache = NewClusterCache(cli, client.ObjectKey{
 			Namespace: instance.GetNamespaceName(),
 			Name:      instance.GetClusterName(),
 		})
@@ -81,7 +81,7 @@ var _ = Describe("clusterCache", func() {
 		})
 
 		It("should return false when the cluster is not found", func() {
-			cache = newClusterCache(cli, client.ObjectKey{
+			cache = NewClusterCache(cli, client.ObjectKey{
 				Namespace: "test-namespace",
 				Name:      "non-existent-cluster",
 			})

--- a/pkg/management/postgres/webserver/probes/cache_test.go
+++ b/pkg/management/postgres/webserver/probes/cache_test.go
@@ -99,10 +99,10 @@ var _ = Describe("clusterCache", func() {
 			// With a cancelled context, the operation should fail
 			// Note: With fake client, this might still succeed if it's fast enough,
 			// but in real scenarios with actual API server delays, this would fail
-			success := cache.tryRefreshLatestClusterWithTimeout(cancelledCtx)
+			_ = cache.tryRefreshLatestClusterWithTimeout(cancelledCtx)
+
 			// We don't assert the result here because the fake client is too fast
 			// This test mainly verifies the code doesn't panic with a cancelled context
-			_ = success
 		})
 
 		It("should cache the cluster definition across multiple calls", func() {

--- a/pkg/management/postgres/webserver/probes/checker.go
+++ b/pkg/management/postgres/webserver/probes/checker.go
@@ -116,18 +116,15 @@ func (e *executor) IsHealthy(
 
 	contextLogger = contextLogger.WithValues("apiServerReachable", false)
 
-	// Use the cached cluster definition as a fallback, or create a default if none exists
 	cluster := e.cache.getLatestKnownCluster()
 	if cluster == nil {
-		// We were never able to download a cluster definition. This should not
-		// happen because we check the API server connectivity as soon as the
-		// instance manager starts, before starting the probe web server.
-		//
-		// To be safe, we use an empty cluster with default probe settings.
-		contextLogger.Warning(fmt.Sprintf("no cluster definition has been received for %s probe, using default probe settings", e.probeType))
+		contextLogger.Warning(
+			fmt.Sprintf("no cluster definition has been received for %s probe, using default probe settings", e.probeType),
+		)
 		cluster = &apiv1.Cluster{}
 	} else {
-		contextLogger.Warning(fmt.Sprintf("%s probe using cached cluster definition due to API server connectivity issue", e.probeType))
+		contextLogger.Warning(
+			fmt.Sprintf("%s probe using cached cluster definition due to API server connectivity issue", e.probeType))
 	}
 
 	probeRunner := getProbeRunnerFromCluster(e.probeType, *cluster)

--- a/pkg/management/postgres/webserver/probes/checker.go
+++ b/pkg/management/postgres/webserver/probes/checker.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/cloudnative-pg/machinery/pkg/log"
 	"k8s.io/utils/ptr"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres"
@@ -56,20 +55,17 @@ type Checker interface {
 
 type executor struct {
 	probeType probeType
-	cache     *clusterCache
+	cache     *ClusterCache
 	instance  *postgres.Instance
 }
 
 // NewReadinessChecker creates a new instance of the readiness probe checker
 func NewReadinessChecker(
-	cli client.Client,
 	instance *postgres.Instance,
+	cache *ClusterCache,
 ) Checker {
 	return &executor{
-		cache: newClusterCache(
-			cli,
-			client.ObjectKey{Namespace: instance.GetNamespaceName(), Name: instance.GetClusterName()},
-		),
+		cache:     cache,
 		instance:  instance,
 		probeType: probeTypeReadiness,
 	}
@@ -77,14 +73,11 @@ func NewReadinessChecker(
 
 // NewStartupChecker creates a new instance of the startup probe checker
 func NewStartupChecker(
-	cli client.Client,
 	instance *postgres.Instance,
+	cache *ClusterCache,
 ) Checker {
 	return &executor{
-		cache: newClusterCache(
-			cli,
-			client.ObjectKey{Namespace: instance.GetNamespaceName(), Name: instance.GetClusterName()},
-		),
+		cache:     cache,
 		instance:  instance,
 		probeType: probeTypeStartup,
 	}

--- a/pkg/management/postgres/webserver/probes/checker.go
+++ b/pkg/management/postgres/webserver/probes/checker.go
@@ -138,7 +138,7 @@ func (e *executor) IsHealthy(
 		return
 	}
 
-	contextLogger.Debug(fmt.Sprintf("%s probe succeeding with cached cluster definition", e.probeType))
+	contextLogger.Trace(fmt.Sprintf("%s probe succeeding with cached cluster definition", e.probeType))
 	_, _ = fmt.Fprint(w, "OK")
 }
 

--- a/pkg/management/postgres/webserver/probes/liveness.go
+++ b/pkg/management/postgres/webserver/probes/liveness.go
@@ -79,7 +79,7 @@ func (e *livenessExecutor) IsHealthy(
 		// is not right.
 		// In this way, a network configuration problem can be discovered as
 		// quickly as possible.
-		if err := evaluateLivenessPinger(ctx, cluster.DeepCopy()); err != nil {
+		if err := evaluateLivenessPinger(ctx, *cluster); err != nil {
 			contextLogger.Warning(
 				"Instance connectivity error - liveness probe succeeding because "+
 					"the API server is reachable",
@@ -107,7 +107,7 @@ func (e *livenessExecutor) IsHealthy(
 		return
 	}
 
-	err := evaluateLivenessPinger(ctx, cluster.DeepCopy())
+	err := evaluateLivenessPinger(ctx, *cluster)
 	if err != nil {
 		contextLogger.Error(err, "Instance connectivity error - liveness probe failing")
 		http.Error(
@@ -127,7 +127,7 @@ func (e *livenessExecutor) IsHealthy(
 
 func evaluateLivenessPinger(
 	ctx context.Context,
-	cluster *apiv1.Cluster,
+	cluster apiv1.Cluster,
 ) error {
 	contextLogger := log.FromContext(ctx)
 
@@ -159,7 +159,7 @@ func evaluateLivenessPinger(
 		return fmt.Errorf("failed to build instance reachability checker: %w", err)
 	}
 
-	if err := checker.ensureInstancesAreReachable(cluster); err != nil {
+	if err := checker.ensureInstancesAreReachable(&cluster); err != nil {
 		return fmt.Errorf("liveness check failed: %w", err)
 	}
 

--- a/pkg/management/postgres/webserver/probes/liveness.go
+++ b/pkg/management/postgres/webserver/probes/liveness.go
@@ -118,7 +118,7 @@ func (e *livenessExecutor) IsHealthy(
 		return
 	}
 
-	contextLogger.Debug(
+	contextLogger.Trace(
 		"Instance connectivity test succeeded - liveness probe succeeding",
 		"latestKnownInstancesReportedState", cluster.Status.InstancesReportedState,
 	)

--- a/pkg/management/postgres/webserver/probes/liveness.go
+++ b/pkg/management/postgres/webserver/probes/liveness.go
@@ -26,27 +26,23 @@ import (
 	"net/http"
 
 	"github.com/cloudnative-pg/machinery/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres"
 )
 
 type livenessExecutor struct {
-	cache    *clusterCache
+	cache    *ClusterCache
 	instance *postgres.Instance
 }
 
 // NewLivenessChecker creates a new instance of the liveness probe checker
 func NewLivenessChecker(
-	cli client.Client,
 	instance *postgres.Instance,
+	cache *ClusterCache,
 ) Checker {
 	return &livenessExecutor{
-		cache: newClusterCache(
-			cli,
-			client.ObjectKey{Namespace: instance.GetNamespaceName(), Name: instance.GetClusterName()},
-		),
+		cache:    cache,
 		instance: instance,
 	}
 }

--- a/pkg/management/postgres/webserver/probes/liveness.go
+++ b/pkg/management/postgres/webserver/probes/liveness.go
@@ -69,55 +69,56 @@ func (e *livenessExecutor) IsHealthy(
 	}
 
 	var cluster apiv1.Cluster
-	if err := e.cache.tryGetLatestClusterWithTimeout(ctx, &cluster); err != nil {
-		contextLogger = contextLogger.WithValues("apiServerReachable", false,
-			"apiServerErr", err.Error())
-
-		if cluster.Name == "" {
-			// We were never able to download a cluster definition. This should not
-			// happen because we check the API server connectivity as soon as the
-			// instance manager starts, before starting the probe web server.
-			//
-			// To be safe, we classify this instance manager to be not isolated and
-			// postpone any decision to a later liveness probe call.
+	err := e.cache.tryGetLatestClusterWithTimeout(ctx, &cluster)
+	if err == nil {
+		// We correctly reached the API server but, as a failsafe measure, we
+		// exercise the reachability checker and leave a log message if something
+		// is not right.
+		// In this way, a network configuration problem can be discovered as
+		// quickly as possible.
+		if err := evaluateLivenessPinger(ctx, cluster); err != nil {
 			contextLogger.Warning(
-				"No cluster definition has been received, skipping automatic shutdown.")
-
-			_, _ = fmt.Fprint(w, "OK")
-			return
-		}
-
-		if err = evaluateLivenessPinger(ctx, cluster); err != nil {
-			contextLogger.Error(err, "Instance connectivity error - liveness probe failing")
-			http.Error(
-				w,
-				fmt.Sprintf("liveness check failed: %s", err.Error()),
-				http.StatusInternalServerError,
+				"Instance connectivity error - liveness probe succeeding because "+
+					"the API server is reachable",
+				"err",
+				err.Error(),
 			)
-			return
 		}
-
-		contextLogger.Trace(
-			"Instance connectivity test succeeded - liveness probe succeeding",
-			"latestKnownInstancesReportedState", cluster.Status.InstancesReportedState,
-		)
 		_, _ = fmt.Fprint(w, "OK")
 		return
 	}
 
-	// We correctly reached the API server but, as a failsafe measure, we
-	// exercise the reachability checker and leave a log message if something
-	// is not right.
-	// In this way, a network configuration problem can be discovered as
-	// quickly as possible.
-	if err := evaluateLivenessPinger(ctx, cluster); err != nil {
+	contextLogger = contextLogger.WithValues("apiServerReachable", false,
+		"apiServerErr", err.Error())
+
+	if cluster.Name == "" {
+		// We were never able to download a cluster definition. This should not
+		// happen because we check the API server connectivity as soon as the
+		// instance manager starts, before starting the probe web server.
+		//
+		// To be safe, we classify this instance manager to be not isolated and
+		// postpone any decision to a later liveness probe call.
 		contextLogger.Warning(
-			"Instance connectivity error - liveness probe succeeding because "+
-				"the API server is reachable",
-			"err",
-			err.Error(),
-		)
+			"No cluster definition has been received, skipping automatic shutdown.")
+
+		_, _ = fmt.Fprint(w, "OK")
+		return
 	}
+
+	if err = evaluateLivenessPinger(ctx, cluster); err != nil {
+		contextLogger.Error(err, "Instance connectivity error - liveness probe failing")
+		http.Error(
+			w,
+			fmt.Sprintf("liveness check failed: %s", err.Error()),
+			http.StatusInternalServerError,
+		)
+		return
+	}
+
+	contextLogger.Trace(
+		"Instance connectivity test succeeded - liveness probe succeeding",
+		"latestKnownInstancesReportedState", cluster.Status.InstancesReportedState,
+	)
 	_, _ = fmt.Fprint(w, "OK")
 }
 

--- a/pkg/management/postgres/webserver/probes/liveness.go
+++ b/pkg/management/postgres/webserver/probes/liveness.go
@@ -68,56 +68,56 @@ func (e *livenessExecutor) IsHealthy(
 		return
 	}
 
-	cluster, clusterRefreshed := e.cache.tryGetLatestClusterWithTimeout(ctx)
-	if clusterRefreshed {
-		// We correctly reached the API server but, as a failsafe measure, we
-		// exercise the reachability checker and leave a log message if something
-		// is not right.
-		// In this way, a network configuration problem can be discovered as
-		// quickly as possible.
-		if err := evaluateLivenessPinger(ctx, *cluster); err != nil {
+	var cluster apiv1.Cluster
+	if err := e.cache.tryGetLatestClusterWithTimeout(ctx, &cluster); err != nil {
+		contextLogger = contextLogger.WithValues("apiServerReachable", false,
+			"apiServerErr", err.Error())
+
+		if cluster.Name == "" {
+			// We were never able to download a cluster definition. This should not
+			// happen because we check the API server connectivity as soon as the
+			// instance manager starts, before starting the probe web server.
+			//
+			// To be safe, we classify this instance manager to be not isolated and
+			// postpone any decision to a later liveness probe call.
 			contextLogger.Warning(
-				"Instance connectivity error - liveness probe succeeding because "+
-					"the API server is reachable",
-				"err",
-				err.Error(),
-			)
+				"No cluster definition has been received, skipping automatic shutdown.")
+
+			_, _ = fmt.Fprint(w, "OK")
+			return
 		}
-		_, _ = fmt.Fprint(w, "OK")
-		return
-	}
 
-	contextLogger = contextLogger.WithValues("apiServerReachable", false)
+		if err = evaluateLivenessPinger(ctx, cluster); err != nil {
+			contextLogger.Error(err, "Instance connectivity error - liveness probe failing")
+			http.Error(
+				w,
+				fmt.Sprintf("liveness check failed: %s", err.Error()),
+				http.StatusInternalServerError,
+			)
+			return
+		}
 
-	if cluster == nil {
-		// We were never able to download a cluster definition. This should not
-		// happen because we check the API server connectivity as soon as the
-		// instance manager starts, before starting the probe web server.
-		//
-		// To be safe, we classify this instance manager to be not isolated and
-		// postpone any decision to a later liveness probe call.
-		contextLogger.Warning(
-			"No cluster definition has been received, skipping automatic shutdown.")
-
-		_, _ = fmt.Fprint(w, "OK")
-		return
-	}
-
-	err := evaluateLivenessPinger(ctx, *cluster)
-	if err != nil {
-		contextLogger.Error(err, "Instance connectivity error - liveness probe failing")
-		http.Error(
-			w,
-			fmt.Sprintf("liveness check failed: %s", err.Error()),
-			http.StatusInternalServerError,
+		contextLogger.Trace(
+			"Instance connectivity test succeeded - liveness probe succeeding",
+			"latestKnownInstancesReportedState", cluster.Status.InstancesReportedState,
 		)
+		_, _ = fmt.Fprint(w, "OK")
 		return
 	}
 
-	contextLogger.Trace(
-		"Instance connectivity test succeeded - liveness probe succeeding",
-		"latestKnownInstancesReportedState", cluster.Status.InstancesReportedState,
-	)
+	// We correctly reached the API server but, as a failsafe measure, we
+	// exercise the reachability checker and leave a log message if something
+	// is not right.
+	// In this way, a network configuration problem can be discovered as
+	// quickly as possible.
+	if err := evaluateLivenessPinger(ctx, cluster); err != nil {
+		contextLogger.Warning(
+			"Instance connectivity error - liveness probe succeeding because "+
+				"the API server is reachable",
+			"err",
+			err.Error(),
+		)
+	}
 	_, _ = fmt.Fprint(w, "OK")
 }
 

--- a/pkg/management/postgres/webserver/probes/suite_test.go
+++ b/pkg/management/postgres/webserver/probes/suite_test.go
@@ -1,0 +1,32 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package probes
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestProbes(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Probes Suite")
+}


### PR DESCRIPTION
This change enhances the resilience of all probe types (liveness, readiness, and startup) when facing transient Kubernetes API server connectivity issues. Previously, readiness and startup probes would fail immediately if unable to reach the API server, potentially causing unnecessary pod restarts or preventing pods from becoming ready.

The improvement introduces a unified cluster caching mechanism that:
- Creates a **single shared cache** instance used across all three probe types (liveness, readiness, startup) to reduce memory usage and ensure consistency
- Implements **thread-safe** cache operations with proper mutex locking to support concurrent probe execution
- Attempts to fetch the cluster definition with a **500ms timeout** to avoid blocking the probe for too long
- **Falls back to a cached cluster definition** if the API server is temporarily unreachable
- **Falls back to default probe configuration** if no cached cluster is found
- Maintains probe functionality during brief network interruptions or API server unavailability
- Uses optimized memory allocation patterns to avoid unnecessary `DeepCopy` operations

This ensures consistent behavior across all probe types and reduces false positives during transient network issues, while also improving performance through shared resources and optimized memory usage.