### PR TITLE
chore: sign all release artifacts

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -125,7 +125,7 @@ changelog:
   disable: true
 
 signs:
-  - artifacts: checksum
+  - artifacts: all
     args: ["--batch", "-u", "{{ .Env.GPG_FINGERPRINT }}", "--output", "${signature}", "--detach-sign", "${artifact}"]
 
 krews:


### PR DESCRIPTION
We use GoReleaser to create our packages, but until now, we only signed a limited number of artifacts, specifically the checksums. This led to a lower score in the OpenSSF review. 

With this update, all artifacts will now be signed by default, ensuring complete coverage and preventing any missing signatures in future releases.

Closes #9163 