### PR TITLE
feat(plugin): add configurable timeout flag for status command

### DIFF
--- a/docs/src/kubectl-plugin.md
+++ b/docs/src/kubectl-plugin.md
@@ -360,6 +360,13 @@ also view PostgreSQL configuration, HBA settings, and certificates.
 
 The command also supports output in `yaml` and `json` format.
 
+!!! Note
+    The `status` command executes operations that access the pod filesystem,
+    such as `du` to calculate cluster size and `cat` to read configuration files.
+    For clusters with large data volumes (e.g., over 1TB), these operations may
+    take longer than the default timeout of 10 seconds. You can adjust the timeout
+    using the `--timeout` flag (e.g., `kubectl cnpg status sandbox --timeout 45s`).
+
 ### Promote
 
 The meaning of this command is to `promote` a pod in the cluster to primary, so you

--- a/internal/cmd/plugin/status/cmd.go
+++ b/internal/cmd/plugin/status/cmd.go
@@ -22,6 +22,7 @@ package status
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -47,8 +48,9 @@ func NewCmd() *cobra.Command {
 
 			verbose, _ := cmd.Flags().GetCount("verbose")
 			output, _ := cmd.Flags().GetString("output")
+			timeout, _ := cmd.Flags().GetDuration("timeout")
 
-			return Status(ctx, clusterName, verbose, plugin.OutputFormat(output))
+			return Status(ctx, clusterName, verbose, plugin.OutputFormat(output), timeout)
 		},
 	}
 
@@ -56,6 +58,8 @@ func NewCmd() *cobra.Command {
 		"verbose", "v", "Increase verbosity to display more information")
 	statusCmd.Flags().StringP(
 		"output", "o", "text", "Output format. One of text|json")
+	statusCmd.Flags().DurationP(
+		"timeout", "t", 10*time.Second, "Timeout for operations that access pod filesystems (e.g., du, cat)")
 
 	return statusCmd
 }

--- a/internal/cmd/plugin/status/status.go
+++ b/internal/cmd/plugin/status/status.go
@@ -111,6 +111,7 @@ func Status(
 	clusterName string,
 	verbosity int,
 	format plugin.OutputFormat,
+	timeout time.Duration,
 ) error {
 	var cluster apiv1.Cluster
 	var errs []error
@@ -134,12 +135,12 @@ func Status(
 	}
 	errs = append(errs, status.ErrorList...)
 
-	status.printBasicInfo(ctx, clientInterface)
+	status.printBasicInfo(ctx, clientInterface, timeout)
 	status.printHibernationInfo()
 	status.printDemotionTokenInfo()
 	status.printPromotionTokenInfo()
 	if verbosity > 1 {
-		errs = append(errs, status.printPostgresConfiguration(ctx, clientInterface)...)
+		errs = append(errs, status.printPostgresConfiguration(ctx, clientInterface, timeout)...)
 		status.printCertificatesStatus()
 	}
 	if !hibernated {
@@ -216,9 +217,11 @@ func listFencedInstances(fencedInstances *stringset.Data) string {
 	return strings.Join(fencedInstances.ToList(), ", ")
 }
 
-func (fullStatus *PostgresqlStatus) getClusterSize(ctx context.Context, client kubernetes.Interface) (string, error) {
-	timeout := time.Second * 10
-
+func (fullStatus *PostgresqlStatus) getClusterSize(
+	ctx context.Context,
+	client kubernetes.Interface,
+	timeout time.Duration,
+) (string, error) {
 	// Compute the disk space through `du`
 	output, _, err := utils.ExecCommand(
 		ctx,
@@ -238,10 +241,14 @@ func (fullStatus *PostgresqlStatus) getClusterSize(ctx context.Context, client k
 	return size, nil
 }
 
-func (fullStatus *PostgresqlStatus) printBasicInfo(ctx context.Context, k8sClient kubernetes.Interface) {
+func (fullStatus *PostgresqlStatus) printBasicInfo(
+	ctx context.Context,
+	k8sClient kubernetes.Interface,
+	timeout time.Duration,
+) {
 	summary := tabby.New()
 
-	clusterSize, clusterSizeErr := fullStatus.getClusterSize(ctx, k8sClient)
+	clusterSize, clusterSizeErr := fullStatus.getClusterSize(ctx, k8sClient, timeout)
 
 	cluster := fullStatus.Cluster
 
@@ -481,8 +488,8 @@ func (fullStatus *PostgresqlStatus) getStatus(cluster *apiv1.Cluster) string {
 func (fullStatus *PostgresqlStatus) printPostgresConfiguration(
 	ctx context.Context,
 	client kubernetes.Interface,
+	timeout time.Duration,
 ) []error {
-	timeout := time.Second * 10
 	var errs []error
 
 	// Read PostgreSQL configuration from custom.conf


### PR DESCRIPTION
Add a new --timeout flag to the `kubectl cnpg status` command to allow users to configure the timeout for operations that access the pod filesystem (e.g., `du` for calculating cluster size, `cat` for reading configuration files).

The timeout parameter:
- Defaults to 10 seconds to maintain backward compatibility
- Can be adjusted using --timeout/-t flag (e.g., --timeout 45s)
- Is applied to all timeout-based operations in the status command

This addresses issues with large clusters (e.g., >1TB) where filesystem operations may exceed the previous hardcoded 10-second timeout, causing "context deadline exceeded" errors.


Closes #9164 

