### PR TITLE
fix: emit event and log when ImageCatalog retrieval fails

### DIFF
--- a/internal/controller/cluster_image.go
+++ b/internal/controller/cluster_image.go
@@ -162,6 +162,10 @@ func (r *ClusterReconciler) getRequestedImageInfo(
 			return apiv1.ImageInfo{}, fmt.Errorf("catalog %s/%s not found", catalogKind, catalogName)
 		}
 
+		r.Recorder.Eventf(cluster, "Warning", "DiscoverImage", "Error getting %v/%v: %v",
+			catalogKind, catalogName, err)
+		contextLogger.Error(err, "while getting imageCatalog",
+			"catalogKind", catalogKind, "catalogName", catalogName, "error", err)
 		return apiv1.ImageInfo{}, err
 	}
 

--- a/internal/controller/cluster_image.go
+++ b/internal/controller/cluster_image.go
@@ -165,7 +165,7 @@ func (r *ClusterReconciler) getRequestedImageInfo(
 		r.Recorder.Eventf(cluster, "Warning", "DiscoverImage", "Error getting %v/%v: %v",
 			catalogKind, catalogName, err)
 		contextLogger.Error(err, "while getting imageCatalog",
-			"catalogKind", catalogKind, "catalogName", catalogName, "error", err)
+			"catalogKind", catalogKind, "catalogName", catalogName)
 		return apiv1.ImageInfo{}, err
 	}
 


### PR DESCRIPTION
Previously we emitted error and logs only for the errors of NotFound category, for the other types the the controller would fail silently without emitting a Kubernetes event. This made troubleshooting difficult, especially when using tools like ArgoCD.

This commit ensures that a Warning event and a log is emitted when the ImageCatalog cannot be retrieved for any reason, providing better visibility into configuration errors. 

Closes #9016 
