### PR TITLE
fix(volumesnapshots,cnpg-i): ensure `CheckEmptyWalArchive` runs during WAL restore

### DIFF
--- a/internal/cmd/manager/instance/pgbasebackup/cmd.go
+++ b/internal/cmd/manager/instance/pgbasebackup/cmd.go
@@ -146,7 +146,7 @@ func (env *CloneInfo) bootstrapUsingPgbasebackup(ctx context.Context) error {
 
 	filePath := filepath.Join(env.info.PgData, constants.CheckEmptyWalArchiveFile)
 	// We create the check empty wal archive file to tell that we should check if the
-	// destination path it is empty
+	// destination path is empty
 	if err := fileutils.CreateEmptyFile(filePath); err != nil {
 		return fmt.Errorf("could not create %v file: %w", filePath, err)
 	}

--- a/pkg/management/postgres/initdb.go
+++ b/pkg/management/postgres/initdb.go
@@ -354,8 +354,8 @@ func (info InitInfo) ConfigureNewInstance(instance connectionProvider) error {
 
 	filePath := filepath.Join(info.PgData, constants.CheckEmptyWalArchiveFile)
 	// We create the check empty wal archive file to tell that we should check if the
-	// destination path it is empty
-	if err := fileutils.CreateEmptyFile(filepath.Clean(filePath)); err != nil {
+	// destination path is empty
+	if err := fileutils.CreateEmptyFile(filePath); err != nil {
 		return fmt.Errorf("could not create %v file: %w", filePath, err)
 	}
 

--- a/pkg/management/postgres/restore.go
+++ b/pkg/management/postgres/restore.go
@@ -186,6 +186,14 @@ func (info InitInfo) concludeRestore(
 	if _, err := info.GetInstance(cluster).migratePostgresAutoConfFile(ctx); err != nil {
 		return err
 	}
+
+	filePath := filepath.Join(info.PgData, constants.CheckEmptyWalArchiveFile)
+	// We create the check empty wal archive file to tell that we should check if the
+	// destination path is empty
+	if err := fileutils.CreateEmptyFile(filePath); err != nil {
+		return fmt.Errorf("could not create %v file: %w", filePath, err)
+	}
+
 	if cluster.IsReplica() {
 		server, ok := cluster.ExternalCluster(cluster.Spec.ReplicaCluster.Source)
 		if !ok {


### PR DESCRIPTION
The `CheckEmptyWalArchive` safeguard was not executed when restoring from a volume snapshot using a CNPG-I backup/WAL plugin (e.g. `plugin-barman-cloud`).
This was due to the operator skipping creation of the `CheckEmptyWalArchiveFile` marker and relying instead on an early direct call to the in-tree `barman-cloud-check-wal-archive` command—an approach incompatible with external plugins.

This patch ensures that the `CheckEmptyWalArchive` mechanism is triggered reliably for both in-tree and plugin-based WAL archive implementations during snapshot restore.

Closes #9305 