### PR TITLE
test(e2e): retry port-forward connection on failure

### DIFF
--- a/tests/utils/forwardconnection/forwardconnection.go
+++ b/tests/utils/forwardconnection/forwardconnection.go
@@ -120,7 +120,7 @@ func NewDialer(
 }
 
 // StartAndWait begins the port-forwarding and waits until it's ready
-func (fc *ForwardConnection) StartAndWait() error {
+func (fc *ForwardConnection) StartAndWait(ctx context.Context) error {
 	var err error
 	go func() {
 		ginkgo.GinkgoWriter.Println("Starting port-forward")
@@ -140,6 +140,9 @@ func (fc *ForwardConnection) StartAndWait() error {
 	case <-fc.stopChannel:
 		ginkgo.GinkgoWriter.Println("port-forward closed")
 		return err
+	case <-ctx.Done():
+		close(fc.stopChannel)
+		return ctx.Err()
 	}
 }
 


### PR DESCRIPTION
The E2E tests were failing because the port-forward connection was getting stuck. This commit introduces a retry mechanism with a timeout for the port-forward connection establishment. It modifies `StartAndWait` to accept a context and `startForwardConnection` to retry the connection attempt with a shorter timeout (60s) using `k8s.io/client-go/util/retry`.

