### PR TITLE
test(e2e): skip operator unavailable test when leader election is disabled

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -1743,8 +1743,6 @@ jobs:
           cat config/manager/env_override.yaml
       -
         name: Run E2E tests
-        env:
-          LEADER_ELECTION: "false"
         run: hack/e2e/run-e2e.sh
       -
         name: Report failed E2E tests

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -1743,6 +1743,8 @@ jobs:
           cat config/manager/env_override.yaml
       -
         name: Run E2E tests
+        env:
+          LEADER_ELECTION: "false"
         run: hack/e2e/run-e2e.sh
       -
         name: Report failed E2E tests

--- a/tests/e2e/operator_unavailable_test.go
+++ b/tests/e2e/operator_unavailable_test.go
@@ -20,7 +20,6 @@ SPDX-License-Identifier: Apache-2.0
 package e2e
 
 import (
-	"os"
 	"sync"
 	"time"
 
@@ -57,8 +56,7 @@ var _ = Describe("Operator unavailable", Serial, Label(tests.LabelDisruptive, te
 		if testLevelEnv.Depth < int(level) {
 			Skip("Test depth is lower than the amount requested for this test")
 		}
-
-		if os.Getenv("LEADER_ELECTION") == "false" {
+		if !MustGetEnvProfile().IsLeaderElectionEnabled() {
 			Skip("Leader election is disabled")
 		}
 	})

--- a/tests/e2e/operator_unavailable_test.go
+++ b/tests/e2e/operator_unavailable_test.go
@@ -20,6 +20,7 @@ SPDX-License-Identifier: Apache-2.0
 package e2e
 
 import (
+	"os"
 	"sync"
 	"time"
 
@@ -55,6 +56,10 @@ var _ = Describe("Operator unavailable", Serial, Label(tests.LabelDisruptive, te
 	BeforeEach(func() {
 		if testLevelEnv.Depth < int(level) {
 			Skip("Test depth is lower than the amount requested for this test")
+		}
+
+		if os.Getenv("LEADER_ELECTION") == "false" {
+			Skip("Leader election is disabled")
 		}
 	})
 

--- a/tests/utils/operator/operator.go
+++ b/tests/utils/operator/operator.go
@@ -153,7 +153,7 @@ func GetPod(ctx context.Context, crudClient client.Client) (corev1.Pod, error) {
 		return corev1.Pod{}, err
 	}
 
-	return podList.Items[0], nil
+	return activePods[0], nil
 }
 
 // NamespaceName returns the namespace the operator Deployment is running in


### PR DESCRIPTION
The "Operator unavailable" E2E test relies on scaling the operator deployment, which behaves differently when leader election is disabled (e.g. in GKE environments). This commit adds a check for the LEADER_ELECTION environment variable to skip this test when leader election is explicitly disabled. It also updates the GKE E2E workflow to pass this environment variable to the test runner. 

Closes #7229 

