### PR TITLE
feat!: change default `STANDBY_TCP_USER_TIMEOUT` to 10s

### DIFF
--- a/docs/src/operator_conf.md
+++ b/docs/src/operator_conf.md
@@ -53,7 +53,7 @@ Name | Description
 `PGBOUNCER_IMAGE_NAME` | The name of the PgBouncer image used by default for new poolers. Defaults to the version specified in the operator.
 `POSTGRES_IMAGE_NAME` | The name of the PostgreSQL image used by default for new clusters. Defaults to the version specified in the operator.
 `PULL_SECRET_NAME` | Name of an additional pull secret to be defined in the operator's namespace and to be used to download images
-`STANDBY_TCP_USER_TIMEOUT` | Defines the [`TCP_USER_TIMEOUT` socket option](https://www.postgresql.org/docs/current/runtime-config-connection.html#GUC-TCP-USER-TIMEOUT) for replication connections from standby instances to the primary. Default is 0 (system's default).
+`STANDBY_TCP_USER_TIMEOUT` | Defines the [`TCP_USER_TIMEOUT` socket option](https://www.postgresql.org/docs/current/runtime-config-connection.html#GUC-TCP-USER-TIMEOUT) for replication connections from standby instances to the primary. Default is 10000 (10 seconds).
 `DRAIN_TAINTS` | Specifies the taint keys that should be interpreted as indicators of node drain. By default, it includes the taints commonly applied by [kubectl](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/), [Cluster Autoscaler](https://github.com/kubernetes/autoscaler), and [Karpenter](https://github.com/aws/karpenter-provider-aws): `node.kubernetes.io/unschedulable`, `ToBeDeletedByClusterAutoscaler`, `karpenter.sh/disrupted`, `karpenter.sh/disruption`.
 
 Values in `INHERITED_ANNOTATIONS` and `INHERITED_LABELS` support path-like wildcards. For example, the value `example.com/*` will match

--- a/docs/src/postgresql_conf.md
+++ b/docs/src/postgresql_conf.md
@@ -162,19 +162,20 @@ role within the cluster. These parameters are effectively applied only when the
 instance is operating as a replica.
 
 ```text
-primary_conninfo = 'host=<PRIMARY> user=postgres dbname=postgres'
+primary_conninfo = 'host=<PRIMARY> user=postgres dbname=postgres tcp_user_timeout=10000'
 recovery_target_timeline = 'latest'
 ```
 
-The [`STANDBY_TCP_USER_TIMEOUT` operator configuration setting](operator_conf.md#available-options),
-if specified, sets the `tcp_user_timeout` parameter on all standby instances
-managed by the operator. The default value is 10000 (10 seconds).
-
-The `tcp_user_timeout` parameter determines how long transmitted data can
-remain unacknowledged before the TCP connection is forcibly closed. Adjusting
-this value allows you to fine-tune the responsiveness of standby instances to
-network disruptions. For more details, refer to the
-[PostgreSQL documentation](https://www.postgresql.org/docs/current/runtime-config-connection.html#GUC-TCP-USER-TIMEOUT).
+!!! Important
+    By default, every standby sets `tcp_user_timeout` to **10 seconds**, as shown
+    above. This parameter defines how long transmitted data may remain
+    unacknowledged before the TCP connection is forcibly closed. Adjusting it lets
+    you control how quickly a standby reacts to network issues.
+    If the default value does not meet your requirements, you can override it
+    for all standbys managed by the operator using the
+    [`STANDBY_TCP_USER_TIMEOUT` operator configuration option](operator_conf.md#available-options).
+    For additional details on `tcp_user_timeout`, refer to the
+    [PostgreSQL documentation](https://www.postgresql.org/docs/current/runtime-config-connection.html#GUC-TCP-USER-TIMEOUT).
 
 ### Log control settings
 

--- a/docs/src/postgresql_conf.md
+++ b/docs/src/postgresql_conf.md
@@ -168,7 +168,7 @@ recovery_target_timeline = 'latest'
 
 The [`STANDBY_TCP_USER_TIMEOUT` operator configuration setting](operator_conf.md#available-options),
 if specified, sets the `tcp_user_timeout` parameter on all standby instances
-managed by the operator.
+managed by the operator. The default value is 10000 (10 seconds).
 
 The `tcp_user_timeout` parameter determines how long transmitted data can
 remain unacknowledged before the TCP connection is forcibly closed. Adjusting

--- a/internal/configuration/configuration.go
+++ b/internal/configuration/configuration.go
@@ -165,6 +165,7 @@ type Data struct {
 	// added as a tcp_user_timeout option to the primary_conninfo
 	// string, which is used by the standby server to connect to the
 	// primary server in CloudNativePG.
+	// The value is in milliseconds.
 	StandbyTCPUserTimeout int `json:"standbyTcpUserTimeout" env:"STANDBY_TCP_USER_TIMEOUT"`
 
 	// KubernetesClusterDomain defines the domain suffix for service FQDNs
@@ -189,7 +190,7 @@ func newDefaultConfig() *Data {
 		CreateAnyService:        false,
 		CertificateDuration:     CertificateDuration,
 		ExpiringCheckThreshold:  ExpiringCheckThreshold,
-		StandbyTCPUserTimeout:   0,
+		StandbyTCPUserTimeout:   10000,
 		KubernetesClusterDomain: DefaultKubernetesClusterDomain,
 		DrainTaints:             DefaultDrainTaints,
 	}

--- a/internal/configuration/configuration_test.go
+++ b/internal/configuration/configuration_test.go
@@ -20,6 +20,7 @@ SPDX-License-Identifier: Apache-2.0
 package configuration
 
 import (
+	"os"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -169,5 +170,26 @@ var _ = Describe("Annotation and label inheritance", func() {
 	It("returns zero as default delay for instances rollout when not set", func() {
 		config := Data{}
 		Expect(config.GetInstancesRolloutDelay()).To(BeZero())
+	})
+})
+
+var _ = Describe("Configuration Defaults", func() {
+	AfterEach(func() {
+		err := os.Unsetenv("STANDBY_TCP_USER_TIMEOUT")
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("should have StandbyTCPUserTimeout default to 10000", func() {
+		config := newDefaultConfig()
+		Expect(config.StandbyTCPUserTimeout).To(Equal(10000))
+	})
+
+	It("should correctly parse ConfigMap with STANDBY_TCP_USER_TIMEOUT set to 0", func() {
+		config := newDefaultConfig()
+		Expect(config.StandbyTCPUserTimeout).To(Equal(10000))
+		err := os.Setenv("STANDBY_TCP_USER_TIMEOUT", "0")
+		Expect(err).NotTo(HaveOccurred())
+		config.ReadConfigMap(nil)
+		Expect(config.StandbyTCPUserTimeout).To(Equal(0))
 	})
 })


### PR DESCRIPTION
BREAKING CHANGE:
The default value of `STANDBY_TCP_USER_TIMEOUT` has changed from `0` (system default) to `10000` milliseconds (10 seconds).
This new default improves the out-of-the-box experience for replica connections by providing a more responsive TCP timeout.

Guidance for existing installations:
If your CloudNativePG installation relies on the previous default (`0`), and you want to preserve that behaviour during an upgrade, you must now explicitly set `STANDBY_TCP_USER_TIMEOUT` to `0` in the `cnpg-controller-manager-config` ConfigMap or Secret.

Example with ConfigMap:

```
  apiVersion: v1
  kind: ConfigMap
  metadata:
    name: cnpg-controller-manager-config
    namespace: cnpg-system
  data:
    STANDBY_TCP_USER_TIMEOUT: "0"
```

Closes #9229  

