### PR TITLE
ci(release): build OLM bundle for release candidate versions

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -248,8 +248,7 @@ jobs:
     if: |
       (always() && !cancelled()) &&
       needs.release-binaries.result == 'success' &&
-      needs.check-version.outputs.is_latest == 'true' &&
-      needs.check-version.outputs.is_stable == 'true'
+      needs.check-version.outputs.is_latest == 'true'
     steps:
       - name: Checkout code
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -20,8 +20,8 @@ jobs:
     name: Evaluate release tag
     runs-on: ubuntu-24.04
     outputs:
-      is_latest: ${{ env.IS_LATEST }}
-      is_stable: ${{ env.IS_STABLE }}
+      is_latest: ${{ steps.check-release.outputs.is_latest }}
+      is_stable: ${{ steps.check-release.outputs.is_stable }}
       is_rc: ${{ steps.check-release.outputs.is_rc }}
     steps:
       -
@@ -49,8 +49,8 @@ jobs:
           if [[ "$tag" =~ ^.*-rc[0-9]+$ ]]; then
             is_rc="true"
           fi
-          echo "IS_LATEST=${is_latest}" >> $GITHUB_ENV
-          echo "IS_STABLE=${is_stable}" >> $GITHUB_ENV
+          echo "is_latest=${is_latest}" >> $GITHUB_OUTPUT
+          echo "is_stable=${is_stable}" >> $GITHUB_OUTPUT
           echo "is_rc=${is_rc}" >> $GITHUB_OUTPUT
 
   release:
@@ -89,7 +89,7 @@ jobs:
           name: v${{ env.TAG }}
           files: releases/cnpg-${{ env.VERSION }}.yaml
           make_latest: ${{ needs.check-version.outputs.is_latest == 'true' && needs.check-version.outputs.is_stable == 'true' }}
-          prerelease: ${{ needs.check-version.outputs.is_stable == 'false' }}
+          prerelease: ${{ needs.check-version.outputs.is_stable == 'false' || needs.check-version.outputs.is_rc == 'true' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -22,7 +22,7 @@ jobs:
     outputs:
       is_latest: ${{ env.IS_LATEST }}
       is_stable: ${{ env.IS_STABLE }}
-      is_rc : ${{ steps.check-release.outputs.is_rc }}
+      is_rc: ${{ steps.check-release.outputs.is_rc }}
     steps:
       -
         name: Checkout
@@ -46,7 +46,7 @@ jobs:
             is_stable="true"
           fi
           is_rc="false"
-          if [[ "$tag" =~ ^.*-rc[0-9]$ ]]; then
+          if [[ "$tag" =~ ^.*-rc[0-9]+$ ]]; then
             is_rc="true"
           fi
           echo "IS_LATEST=${is_latest}" >> $GITHUB_ENV

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -46,7 +46,7 @@ jobs:
             is_stable="true"
           fi
           is_rc="false"
-          if [[ "$tag" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          if [[ "$tag" =~ ^.*-rc[0-9]$ ]]; then
             is_rc="true"
           fi
           echo "IS_LATEST=${is_latest}" >> $GITHUB_ENV

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -22,6 +22,7 @@ jobs:
     outputs:
       is_latest: ${{ env.IS_LATEST }}
       is_stable: ${{ env.IS_STABLE }}
+      is_rc : ${{ steps.check-release.outputs.is_rc }}
     steps:
       -
         name: Checkout
@@ -31,6 +32,7 @@ jobs:
           fetch-depth: 0
       -
         name: Check release version
+        id: check-release
         run: |
           tag="${GITHUB_REF#refs/tags/v}"
           latest_release_branch=$(git branch -rl 'origin/release-*' | sort -r | head -n1 | sed -e 's/^.*\(release-.*\)/\1/')
@@ -43,8 +45,13 @@ jobs:
           if [[ "$tag" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             is_stable="true"
           fi
+          is_rc="false"
+          if [[ "$tag" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            is_rc="true"
+          fi
           echo "IS_LATEST=${is_latest}" >> $GITHUB_ENV
           echo "IS_STABLE=${is_stable}" >> $GITHUB_ENV
+          echo "is_rc=${is_rc}" >> $GITHUB_OUTPUT
 
   release:
     name: Create Github release
@@ -248,7 +255,10 @@ jobs:
     if: |
       (always() && !cancelled()) &&
       needs.release-binaries.result == 'success' &&
-      needs.check-version.outputs.is_latest == 'true'
+      (
+        needs.check-version.outputs.is_latest == 'true' ||
+        needs.check-version.outputs.is_rc == 'true'
+      )
     steps:
       - name: Checkout code
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6


### PR DESCRIPTION
Enable OLM bundle and catalog creation for RC releases by removing the is_stable condition from the olm-bundle job.

Closes #7569 