### PR TITLE
fix: add ownership check before deleting PodMonitor

### DIFF
--- a/internal/controller/cluster_create.go
+++ b/internal/controller/cluster_create.go
@@ -986,10 +986,12 @@ func createOrPatchPodMonitor(
 		return nil
 	// Pod monitor disabled and pod monitor present - delete it
 	case !manager.IsPodMonitorEnabled() && podMonitor != nil:
-		contextLogger.Info("Deleting PodMonitor")
-		if err := cli.Delete(ctx, podMonitor); err != nil {
-			if !apierrs.IsNotFound(err) {
-				return err
+		if _, owned := IsOwnedByCluster(podMonitor); owned {
+			contextLogger.Info("Deleting PodMonitor")
+			if err := cli.Delete(ctx, podMonitor); err != nil {
+				if !apierrs.IsNotFound(err) {
+					return err
+				}
 			}
 		}
 		return nil

--- a/internal/controller/cluster_create_test.go
+++ b/internal/controller/cluster_create_test.go
@@ -762,8 +762,7 @@ var _ = Describe("CreateOrPatchPodMonitor", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	It("should remove the PodMonitor if it is disabled when the PodMonitor exists", func() {
-		// Create a cluster and set owner reference on the PodMonitor
+	It("should remove the PodMonitor if it is disabled and is owned by a cluster", func() {
 		cluster := apiv1.Cluster{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       apiv1.ClusterKind,
@@ -798,8 +797,7 @@ var _ = Describe("CreateOrPatchPodMonitor", func() {
 		Expect(apierrs.IsNotFound(err)).To(BeTrue())
 	})
 
-	It("should NOT remove the PodMonitor if it is not owned by the cluster", func() {
-		// Create a PodMonitor without owner reference (manually created)
+	It("should NOT remove the PodMonitor if it is not owned by a cluster", func() {
 		unownedPodMonitor := &monitoringv1.PodMonitor{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test",
@@ -813,7 +811,6 @@ var _ = Describe("CreateOrPatchPodMonitor", func() {
 		err = createOrPatchPodMonitor(ctx, fakeCli, fakeDiscoveryClient, manager)
 		Expect(err).ToNot(HaveOccurred())
 
-		// Verify the PodMonitor still exists (was not deleted)
 		podMonitor := &monitoringv1.PodMonitor{}
 		err = fakeCli.Get(
 			ctx,


### PR DESCRIPTION
The operator was incorrectly deleting manually-created PodMonitors that shared the same name and namespace as the cluster, even when they were not owned by the cluster.

This fix adds an ownership check before deleting PodMonitors when monitoring is disabled, ensuring only operator-managed PodMonitors are deleted.

Closes #6109 