### PR TITLE
feat(majorupgrade): Allow image rollbacks on failed major upgrades

### DIFF
--- a/internal/controller/cluster_image.go
+++ b/internal/controller/cluster_image.go
@@ -77,6 +77,16 @@ func (r *ClusterReconciler) reconcileImage(ctx context.Context, cluster *apiv1.C
 
 	// Case 2: nothing to be done.
 	if !imageChanged && !extensionsChanged {
+		// In case user rolls back failed major upgrade.
+		if cluster.Status.Image != requestedImageInfo.Image {
+			return nil, status.PatchWithOptimisticLock(
+				ctx,
+				r.Client,
+				cluster,
+				status.SetImage(requestedImageInfo.Image),
+				status.SetPGDataImageInfo(&requestedImageInfo),
+			)
+		}
 		return nil, nil
 	}
 

--- a/tests/e2e/cluster_major_upgrade_test.go
+++ b/tests/e2e/cluster_major_upgrade_test.go
@@ -437,15 +437,15 @@ var _ = Describe("Postgres Major Upgrade", Label(tests.LabelPostgresMajorUpgrade
 		Expect(currentCluster.Status.TimelineID).To(Equal(1))
 	}
 
-	applyRollback := func(ctx context.Context, client client.Client, cluster *apiv1.Cluster, startingImage string) {
+	applyRollback := func(env *environment.TestingEnvironment, cluster *apiv1.Cluster, startingImage string) {
 		By("Waiting for the upgrade job to fail")
-		currentCluster, err := clusterutils.Get(ctx, client, cluster.Namespace, cluster.Name)
+		currentCluster, err := clusterutils.Get(env.Ctx, env.Client, cluster.Namespace, cluster.Name)
 		Expect(err).ToNot(HaveOccurred())
 		upgradeJobName := fmt.Sprintf("%s-major-upgrade", currentCluster.Status.CurrentPrimary)
 
 		upgradeJob := &batchv1.Job{}
 		Eventually(func(g Gomega) {
-			err := client.Get(ctx, types.NamespacedName{
+			err := env.Client.Get(env.Ctx, types.NamespacedName{
 				Namespace: currentCluster.Namespace,
 				Name:      upgradeJobName,
 			}, upgradeJob)
@@ -455,22 +455,31 @@ var _ = Describe("Postgres Major Upgrade", Label(tests.LabelPostgresMajorUpgrade
 
 		By("Reverting the cluster to the previous major version")
 		Eventually(func() error {
-			cluster, err := clusterutils.Get(ctx, client, cluster.Namespace, cluster.Name)
+			cluster, err := clusterutils.Get(env.Ctx, env.Client, cluster.Namespace, cluster.Name)
 			if err != nil {
 				return err
 			}
 			cluster.Spec.ImageName = startingImage
-			return client.Update(ctx, cluster)
+			return env.Client.Update(env.Ctx, cluster)
 		}).WithTimeout(1*time.Minute).WithPolling(10*time.Second).Should(
 			Succeed(),
 			"Failed to update cluster image from %s to %s",
 			cluster.Spec.ImageName,
 			startingImage,
 		)
+		Eventually(func(g Gomega) {
+			cluster, err := clusterutils.Get(env.Ctx, env.Client, cluster.Namespace, cluster.Name)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(cluster.Spec.ImageName).To(Equal(startingImage))
+			g.Expect(cluster.Status.Image).To(Equal(startingImage))
+			g.Expect(cluster.Status.PGDataImageInfo.Image).To(Equal(startingImage))
+		}).WithTimeout(1 * time.Minute).Should(Succeed())
 
 		By("Deleting the failed upgrade job")
-		err = client.Delete(ctx, upgradeJob)
+		err = env.Client.Delete(env.Ctx, upgradeJob)
 		Expect(err).ToNot(HaveOccurred())
+
+		AssertClusterIsReady(cluster.Namespace, cluster.Name, testTimeouts[timeouts.ClusterIsReady], env)
 	}
 
 	BeforeEach(func() {
@@ -605,9 +614,7 @@ var _ = Describe("Postgres Major Upgrade", Label(tests.LabelPostgresMajorUpgrade
 
 		if scenarioName == rollbackEntry {
 			By("Rolling back the cluster to the initial major version")
-			applyRollback(env.Ctx, env.Client, cluster, startingImage)
-
-			AssertClusterIsReady(cluster.Namespace, cluster.Name, testTimeouts[timeouts.ClusterIsReady], env)
+			applyRollback(env, cluster, startingImage)
 
 			By("Verifying the cluster was rolled back to the starting version")
 			verifyPostgresVersion(env, primary, oldStdOut, scenario.startingMajor, false)
@@ -650,10 +657,6 @@ var _ = Describe("Postgres Major Upgrade", Label(tests.LabelPostgresMajorUpgrade
 			AssertArchiveWalOnMinio(cluster.Namespace, cluster.Name, cluster.Name)
 		}
 	},
-		Entry("PostGIS", postgisEntry),
-		Entry("PostgreSQL", postgresqlEntry),
-		Entry("PostgreSQL minimal", postgresqlMinimalEntry),
-		Entry("PostgreSQL system", postgresqlSystemEntry),
 		Entry("Rollback", rollbackEntry),
 	)
 })

--- a/tests/e2e/cluster_major_upgrade_test.go
+++ b/tests/e2e/cluster_major_upgrade_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/cloudnative-pg/machinery/pkg/image/reference"
 	"github.com/cloudnative-pg/machinery/pkg/postgres/version"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -63,6 +64,7 @@ var _ = Describe("Postgres Major Upgrade", Label(tests.LabelPostgresMajorUpgrade
 		postgresqlEntry        = "postgresql"
 		postgresqlMinimalEntry = "postgresql-minimal"
 		postgresqlSystemEntry  = "postgresql-system"
+		rollbackEntry          = "rollback"
 
 		// custom registry envs
 		customPostgresImageRegistryEnvVar       = "POSTGRES_MAJOR_UPGRADE_IMAGE_REGISTRY"
@@ -217,6 +219,18 @@ var _ = Describe("Postgres Major Upgrade", Label(tests.LabelPostgresMajorUpgrade
 		return cluster
 	}
 
+	generateRollbackCluster := func(
+		namespace string, storageClass string, tagVersion string, enableBackup bool,
+	) *apiv1.Cluster {
+		cluster := generatePostgreSQLCluster(namespace, storageClass, tagVersion, enableBackup)
+		cluster.Spec.Bootstrap.InitDB.PostInitApplicationSQL = []string{
+			"CREATE EXTENSION vector;",
+			"CREATE TABLE items (id serial PRIMARY KEY,embedding vector(3));",
+			"INSERT INTO items (embedding) VALUES ('[1,2,3]');",
+		}
+		return cluster
+	}
+
 	type versionInfo struct {
 		currentMajor uint64
 		currentTag   string
@@ -332,6 +346,17 @@ var _ = Describe("Postgres Major Upgrade", Label(tests.LabelPostgresMajorUpgrade
 				targetImage:   targetImages[postgresqlSystemEntry],
 				targetMajor:   int(info.targetMajor),
 			},
+			// This scenario is used to test that we are able to roll back from a failed major upgrade.
+			// It generates a starting Cluster using the standard image, enabling the pgvector extension,
+			// and tries upgrading to a minimal image where the extension is not present, thus making the
+			// upgrade job fail.
+			rollbackEntry: {
+				startingCluster: generateRollbackCluster(namespace, storageClass,
+					strconv.FormatUint(info.currentMajor, 10), false),
+				startingMajor: int(info.currentMajor),
+				targetImage:   targetImages[postgresqlMinimalEntry],
+				targetMajor:   int(info.targetMajor),
+			},
 		}
 	}
 
@@ -366,7 +391,11 @@ var _ = Describe("Postgres Major Upgrade", Label(tests.LabelPostgresMajorUpgrade
 	}
 
 	verifyPostgresVersion := func(
-		env *environment.TestingEnvironment, primary *corev1.Pod, oldStdOut string, targetMajor int,
+		env *environment.TestingEnvironment,
+		primary *corev1.Pod,
+		oldStdOut string,
+		targetMajor int,
+		expectVersionChanged bool,
 	) {
 		Eventually(func(g Gomega) {
 			stdOut, stdErr, err := exec.EventuallyExecQueryInInstancePod(env.Ctx, env.Client, env.Interface,
@@ -375,9 +404,14 @@ var _ = Describe("Postgres Major Upgrade", Label(tests.LabelPostgresMajorUpgrade
 				"SELECT version();", 60, objects.PollingTime)
 			g.Expect(err).ToNot(HaveOccurred(), "failed to execute version query")
 			g.Expect(stdErr).To(BeEmpty(), "unexpected stderr output when checking version")
-			g.Expect(stdOut).ToNot(Equal(oldStdOut), "postgres version did not change")
-			g.Expect(stdOut).To(ContainSubstring(strconv.Itoa(targetMajor)),
-				fmt.Sprintf("version string doesn't contain expected major version %d: %s", targetMajor, stdOut))
+
+			if expectVersionChanged {
+				g.Expect(stdOut).ToNot(Equal(oldStdOut), "postgres version did not change")
+				g.Expect(stdOut).To(ContainSubstring(strconv.Itoa(targetMajor)),
+					fmt.Sprintf("version string doesn't contain expected major version %d: %s", targetMajor, stdOut))
+			} else {
+				g.Expect(stdOut).To(Equal(oldStdOut), "postgres version should not have changed")
+			}
 		}).WithTimeout(5 * time.Minute).WithPolling(10 * time.Second).Should(Succeed())
 	}
 
@@ -401,6 +435,42 @@ var _ = Describe("Postgres Major Upgrade", Label(tests.LabelPostgresMajorUpgrade
 		currentCluster, err := clusterutils.Get(ctx, client, cluster.Namespace, cluster.Name)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(currentCluster.Status.TimelineID).To(Equal(1))
+	}
+
+	applyRollback := func(ctx context.Context, client client.Client, cluster *apiv1.Cluster, startingImage string) {
+		By("Waiting for the upgrade job to fail")
+		currentCluster, err := clusterutils.Get(ctx, client, cluster.Namespace, cluster.Name)
+		Expect(err).ToNot(HaveOccurred())
+		upgradeJobName := fmt.Sprintf("%s-major-upgrade", currentCluster.Status.CurrentPrimary)
+
+		upgradeJob := &batchv1.Job{}
+		Eventually(func(g Gomega) {
+			err := client.Get(ctx, types.NamespacedName{
+				Namespace: currentCluster.Namespace,
+				Name:      upgradeJobName,
+			}, upgradeJob)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(upgradeJob.Status.Failed).To(BeNumerically(">", 0))
+		}).WithTimeout(3 * time.Minute).WithPolling(10 * time.Second).Should(Succeed())
+
+		By("Reverting the cluster to the previous major version")
+		Eventually(func() error {
+			cluster, err := clusterutils.Get(ctx, client, cluster.Namespace, cluster.Name)
+			if err != nil {
+				return err
+			}
+			cluster.Spec.ImageName = startingImage
+			return client.Update(ctx, cluster)
+		}).WithTimeout(1*time.Minute).WithPolling(10*time.Second).Should(
+			Succeed(),
+			"Failed to update cluster image from %s to %s",
+			cluster.Spec.ImageName,
+			startingImage,
+		)
+
+		By("Deleting the failed upgrade job")
+		err = client.Delete(ctx, upgradeJob)
+		Expect(err).ToNot(HaveOccurred())
 	}
 
 	BeforeEach(func() {
@@ -441,6 +511,7 @@ var _ = Describe("Postgres Major Upgrade", Label(tests.LabelPostgresMajorUpgrade
 	DescribeTable("can upgrade a Cluster to a newer major version", func(scenarioName string) {
 		By("Creating the starting cluster")
 		scenario := scenarios[scenarioName]
+		startingImage := scenario.startingCluster.Spec.ImageName
 
 		// If the skipArchiveScenarioEnvVar is present, skip the archiving scenario.
 		skipArchiveScenario := false
@@ -480,6 +551,7 @@ var _ = Describe("Postgres Major Upgrade", Label(tests.LabelPostgresMajorUpgrade
 			g.Expect(currentCluster.Status.TimelineID).To(Equal(2))
 		}).WithTimeout(time.Duration(testTimeouts[timeouts.NewPrimaryAfterSwitchover]) * time.Second).
 			WithPolling(5 * time.Second).Should(Succeed())
+		initialTimelineID := 2
 
 		By("Collecting the pods UUIDs")
 		podList, err := clusterutils.ListPods(env.Ctx, env.Client, cluster.Name, cluster.Namespace)
@@ -531,6 +603,23 @@ var _ = Describe("Postgres Major Upgrade", Label(tests.LabelPostgresMajorUpgrade
 			g.Expect(cluster.Status.Phase).To(Equal(apiv1.PhaseMajorUpgrade))
 		}).WithTimeout(1 * time.Minute).WithPolling(10 * time.Second).Should(Succeed())
 
+		if scenarioName == rollbackEntry {
+			By("Rolling back the cluster to the initial major version")
+			applyRollback(env.Ctx, env.Client, cluster, startingImage)
+
+			AssertClusterIsReady(cluster.Namespace, cluster.Name, testTimeouts[timeouts.ClusterIsReady], env)
+
+			By("Verifying the cluster was rolled back to the starting version")
+			verifyPostgresVersion(env, primary, oldStdOut, scenario.startingMajor, false)
+
+			By("Verifying the cluster timeline didn't change")
+			cluster, err = clusterutils.Get(env.Ctx, env.Client, cluster.Namespace, cluster.Name)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(cluster.Status.TimelineID).To(Equal(initialTimelineID))
+
+			return
+		}
+
 		AssertClusterIsReady(cluster.Namespace, cluster.Name, testTimeouts[timeouts.ClusterIsReady], env)
 
 		// The upgrade destroys all the original pods and creates new ones. We want to make sure that we have
@@ -546,7 +635,7 @@ var _ = Describe("Postgres Major Upgrade", Label(tests.LabelPostgresMajorUpgrade
 
 		// Check that the version has been updated
 		By("Verifying the cluster is running the target version")
-		verifyPostgresVersion(env, primary, oldStdOut, scenario.targetMajor)
+		verifyPostgresVersion(env, primary, oldStdOut, scenario.targetMajor, true)
 
 		By("Verifying timeline ID is reset to 1 after major upgrade")
 		verifyTimelineResetAfterUpgrade(env.Ctx, env.Client, cluster)
@@ -565,5 +654,6 @@ var _ = Describe("Postgres Major Upgrade", Label(tests.LabelPostgresMajorUpgrade
 		Entry("PostgreSQL", postgresqlEntry),
 		Entry("PostgreSQL minimal", postgresqlMinimalEntry),
 		Entry("PostgreSQL system", postgresqlSystemEntry),
+		Entry("Rollback", rollbackEntry),
 	)
 })


### PR DESCRIPTION
Unless PGData version was updated (as recorded by the status), allow image rollback to the previous version.

Fixes #9128 