### PR TITLE
chore: replace gopkg.in/yaml.v3 with go.yaml.in/yaml/v3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,9 +39,9 @@ require (
 	go.uber.org/atomic v1.11.0
 	go.uber.org/multierr v1.11.0
 	go.uber.org/zap v1.27.1
+	go.yaml.in/yaml/v3 v3.0.4
 	golang.org/x/term v0.37.0
 	google.golang.org/grpc v1.77.0
-	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.34.2
 	k8s.io/apiextensions-apiserver v0.34.2
 	k8s.io/apimachinery v0.34.2
@@ -111,7 +111,6 @@ require (
 	github.com/x448/float16 v0.8.4 // indirect
 	github.com/xlab/treeprint v1.2.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
-	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/crypto v0.45.0 // indirect
 	golang.org/x/mod v0.29.0 // indirect
 	golang.org/x/net v0.47.0 // indirect
@@ -126,6 +125,7 @@ require (
 	google.golang.org/protobuf v1.36.10 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20250905212525-66792eed8611 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect

--- a/pkg/management/postgres/metrics/parser.go
+++ b/pkg/management/postgres/metrics/parser.go
@@ -25,7 +25,7 @@ import (
 	"errors"
 	"fmt"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // UserQueries is a collection of custom queries


### PR DESCRIPTION
The package gopkg.in/yaml.v3 was declared unmaintained in April 2025,
and the YAML organization created go.yaml.in/yaml/v3 to officially maintain it.

Closes #9348 