### PR TITLE
fix(backup): add reconciliation timestamps to backup status

### DIFF
--- a/.wordlist-en-custom.txt
+++ b/.wordlist-en-custom.txt
@@ -1057,13 +1057,13 @@ malcolm
 mallocs
 managedRoleSecretVersion
 managedRolesStatus
-matchExpressions
-matchLabels
-mateusoliveira
 managedconfiguration
 managedroles
 managedservice
 managedservices
+matchExpressions
+matchLabels
+mateusoliveira
 maxClientConnections
 maxParallel
 maxStandbyNamesFromCluster

--- a/.wordlist-en-custom.txt
+++ b/.wordlist-en-custom.txt
@@ -1057,13 +1057,14 @@ malcolm
 mallocs
 managedRoleSecretVersion
 managedRolesStatus
+matchExpressions
+matchLabels
+mateusoliveira
 managedconfiguration
 managedroles
 managedservice
 managedservices
-matchExpressions
-matchLabels
-mateusoliveira
+maxClientConnections
 maxParallel
 maxStandbyNamesFromCluster
 maxSyncReplicas
@@ -1287,6 +1288,8 @@ readthedocs
 readyInstances
 reconciler
 reconciliationLoop
+reconciliationStartedAt
+reconciliationTerminatedAt
 reconnection
 recoverability
 recoveredCluster

--- a/api/v1/backup_funcs.go
+++ b/api/v1/backup_funcs.go
@@ -52,6 +52,8 @@ func (backupStatus *BackupStatus) SetAsFailed(
 	} else {
 		backupStatus.Error = ""
 	}
+
+	backupStatus.ReconciliationTerminatedAt = ptr.To(metav1.Now())
 }
 
 // SetAsFinalizing marks a certain backup as finalizing
@@ -64,7 +66,7 @@ func (backupStatus *BackupStatus) SetAsFinalizing() {
 func (backupStatus *BackupStatus) SetAsCompleted() {
 	backupStatus.Phase = BackupPhaseCompleted
 	backupStatus.Error = ""
-	backupStatus.StoppedAt = ptr.To(metav1.Now())
+	backupStatus.ReconciliationTerminatedAt = ptr.To(metav1.Now())
 }
 
 // SetAsStarted marks a certain backup as started
@@ -75,6 +77,7 @@ func (backupStatus *BackupStatus) SetAsStarted(podName, containerID string, meth
 		ContainerID: containerID,
 	}
 	backupStatus.Method = method
+	backupStatus.ReconciliationStartedAt = ptr.To(metav1.Now())
 }
 
 // SetSnapshotElements sets the Snapshots field from a list of VolumeSnapshot

--- a/api/v1/backup_funcs_test.go
+++ b/api/v1/backup_funcs_test.go
@@ -20,6 +20,7 @@ SPDX-License-Identifier: Apache-2.0
 package v1
 
 import (
+	"errors"
 	"time"
 
 	volumesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
@@ -63,6 +64,35 @@ var _ = Describe("BackupStatus structure", func() {
 		Expect(status.InstanceID.PodName).To(Equal("cluster-example-1"))
 		Expect(status.InstanceID.ContainerID).To(Equal("container-id"))
 		Expect(status.IsDone()).To(BeFalse())
+		Expect(status.ReconciliationStartedAt).ToNot(BeNil())
+	})
+
+	It("can be set as completed", func() {
+		status := BackupStatus{}
+		status.SetAsCompleted()
+		Expect(status.Phase).To(BeEquivalentTo(BackupPhaseCompleted))
+		Expect(status.Error).To(BeEmpty())
+		Expect(status.ReconciliationTerminatedAt).ToNot(BeNil())
+		Expect(status.IsDone()).To(BeTrue())
+	})
+
+	It("can be set as failed with error", func() {
+		status := BackupStatus{}
+		testErr := errors.New("test error")
+		status.SetAsFailed(testErr)
+		Expect(status.Phase).To(BeEquivalentTo(BackupPhaseFailed))
+		Expect(status.Error).To(Equal("test error"))
+		Expect(status.ReconciliationTerminatedAt).ToNot(BeNil())
+		Expect(status.IsDone()).To(BeTrue())
+	})
+
+	It("can be set as failed without error", func() {
+		status := BackupStatus{}
+		status.SetAsFailed(nil)
+		Expect(status.Phase).To(BeEquivalentTo(BackupPhaseFailed))
+		Expect(status.Error).To(BeEmpty())
+		Expect(status.ReconciliationTerminatedAt).ToNot(BeNil())
+		Expect(status.IsDone()).To(BeTrue())
 	})
 
 	It("can be set to contain a snapshot list", func() {

--- a/api/v1/backup_types.go
+++ b/api/v1/backup_types.go
@@ -237,13 +237,21 @@ type BackupStatus struct {
 	// +optional
 	Phase BackupPhase `json:"phase,omitempty"`
 
-	// When the backup was started
+	// When the backup execution was started by the backup tool
 	// +optional
 	StartedAt *metav1.Time `json:"startedAt,omitempty"`
 
-	// When the backup was terminated
+	// When the backup execution was terminated by the backup tool
 	// +optional
 	StoppedAt *metav1.Time `json:"stoppedAt,omitempty"`
+
+	// When the backup process was started by the operator
+	// +optional
+	ReconciliationStartedAt *metav1.Time `json:"reconciliationStartedAt,omitempty"`
+
+	// When the reconciliation was terminated by the operator (either successfully or not)
+	// +optional
+	ReconciliationTerminatedAt *metav1.Time `json:"reconciliationTerminatedAt,omitempty"`
 
 	// The starting WAL
 	// +optional

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -305,6 +305,14 @@ func (in *BackupStatus) DeepCopyInto(out *BackupStatus) {
 		in, out := &in.StoppedAt, &out.StoppedAt
 		*out = (*in).DeepCopy()
 	}
+	if in.ReconciliationStartedAt != nil {
+		in, out := &in.ReconciliationStartedAt, &out.ReconciliationStartedAt
+		*out = (*in).DeepCopy()
+	}
+	if in.ReconciliationTerminatedAt != nil {
+		in, out := &in.ReconciliationTerminatedAt, &out.ReconciliationTerminatedAt
+		*out = (*in).DeepCopy()
+	}
 	if in.BackupLabelFile != nil {
 		in, out := &in.BackupLabelFile, &out.BackupLabelFile
 		*out = make([]byte, len(*in))

--- a/config/crd/bases/postgresql.cnpg.io_backups.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_backups.yaml
@@ -332,6 +332,15 @@ spec:
                   type: string
                 description: A map containing the plugin metadata
                 type: object
+              reconciliationStartedAt:
+                description: When the backup process was started by the operator
+                format: date-time
+                type: string
+              reconciliationTerminatedAt:
+                description: When the reconciliation was terminated by the operator
+                  (either successfully or not)
+                format: date-time
+                type: string
               s3Credentials:
                 description: The credentials to use to upload data to S3
                 properties:
@@ -427,11 +436,12 @@ spec:
                     type: array
                 type: object
               startedAt:
-                description: When the backup was started
+                description: When the backup execution was started by the backup tool
                 format: date-time
                 type: string
               stoppedAt:
-                description: When the backup was terminated
+                description: When the backup execution was terminated by the backup
+                  tool
                 format: date-time
                 type: string
               tablespaceMapFile:

--- a/docs/src/cloudnative-pg.v1.md
+++ b/docs/src/cloudnative-pg.v1.md
@@ -275,8 +275,10 @@ _Appears in:_
 | `backupId` _string_ | The ID of the Barman backup |  |  |  |
 | `backupName` _string_ | The Name of the Barman backup |  |  |  |
 | `phase` _[BackupPhase](#backupphase)_ | The last backup status |  |  |  |
-| `startedAt` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#time-v1-meta)_ | When the backup was started |  |  |  |
-| `stoppedAt` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#time-v1-meta)_ | When the backup was terminated |  |  |  |
+| `startedAt` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#time-v1-meta)_ | When the backup execution was started by the backup tool |  |  |  |
+| `stoppedAt` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#time-v1-meta)_ | When the backup execution was terminated by the backup tool |  |  |  |
+| `reconciliationStartedAt` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#time-v1-meta)_ | When the backup process was started by the operator |  |  |  |
+| `reconciliationTerminatedAt` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#time-v1-meta)_ | When the reconciliation was terminated by the operator (either successfully or not) |  |  |  |
 | `beginWal` _string_ | The starting WAL |  |  |  |
 | `endWal` _string_ | The ending WAL |  |  |  |
 | `beginLSN` _string_ | The starting xlog |  |  |  |

--- a/internal/controller/backup_controller.go
+++ b/internal/controller/backup_controller.go
@@ -31,13 +31,11 @@ import (
 	volumesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/retry"
-	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -567,7 +565,7 @@ func (r *BackupReconciler) reconcileSnapshotBackup(
 		// given that we use only kubernetes resources we can use the backup name as ID
 		backup.Status.BackupID = backup.Name
 		backup.Status.BackupName = backup.Name
-		backup.Status.StartedAt = ptr.To(metav1.Now())
+		backup.Status.StartedAt = backup.Status.ReconciliationStartedAt.DeepCopy()
 		if err := postgres.PatchBackupStatusAndRetry(ctx, r.Client, backup); err != nil {
 			return nil, err
 		}

--- a/pkg/reconciler/backup/volumesnapshot/reconciler.go
+++ b/pkg/reconciler/backup/volumesnapshot/reconciler.go
@@ -294,6 +294,8 @@ func (se *Reconciler) completeSnapshotBackupStep(
 ) (*ctrl.Result, error) {
 	contextLogger := log.FromContext(ctx)
 	backup.Status.SetAsCompleted()
+	backup.Status.StoppedAt = backup.Status.ReconciliationTerminatedAt.DeepCopy()
+
 	snapshots, err := getBackupVolumeSnapshots(ctx, se.cli, backup.Namespace, backup.Name)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Add `reconciliationStartedAt` and `reconciliationTerminatedAt` fields to the BackupStatus to track when the operator started and terminated the backup reconciliation process.

This separates the operator's reconciliation timing from the backup tool's execution timing (`startedAt`/`stoppedAt`), which allows for better monitoring of long-running backups.

Previously, `startedAt` was not set until the backup completed, making it difficult to monitor backup progress. Now:

- `reconciliationStartedAt`: Set when the operator begins processing the backup (in `SetAsStarted`)
- `reconciliationTerminatedAt`: Set when the operator finishes processing (in `SetAsCompleted` or `SetAsFailed`)
- `startedAt`/`stoppedAt`: Reserved for the backup tool's actual execution times

For volume snapshot backups, `startedAt` and `stoppedAt` are now aligned with the reconciliation timestamps since the backup execution is managed by the operator.

Fixes monitoring of long-running backups by providing accurate timing information throughout the backup lifecycle. 


Closes #9352 


