### PR TITLE
fix(backup): set pending phase when backup is waiting to be processed

### DIFF
--- a/api/v1/backup_funcs.go
+++ b/api/v1/backup_funcs.go
@@ -36,6 +36,11 @@ import (
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 )
 
+// SetAsPending marks a certain backup as pending
+func (backupStatus *BackupStatus) SetAsPending() {
+	backupStatus.Phase = BackupPhasePending
+}
+
 // SetAsFailed marks a certain backup as invalid
 func (backupStatus *BackupStatus) SetAsFailed(
 	err error,

--- a/api/v1/backup_funcs_test.go
+++ b/api/v1/backup_funcs_test.go
@@ -34,6 +34,14 @@ import (
 )
 
 var _ = Describe("BackupStatus structure", func() {
+	It("can be set as pending", func() {
+		status := BackupStatus{}
+		status.SetAsPending()
+		Expect(status.Phase).To(BeEquivalentTo(BackupPhasePending))
+		Expect(status.IsInProgress()).To(BeTrue())
+		Expect(status.IsDone()).To(BeFalse())
+	})
+
 	It("can be set as started", func() {
 		status := BackupStatus{}
 		pod := corev1.Pod{

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -78,6 +78,9 @@ func buildTestEnvironment() *testingEnvironment {
 		WithStatusSubresource(&apiv1.Cluster{}, &apiv1.Backup{}, &apiv1.Pooler{}, &corev1.Service{},
 			&corev1.ConfigMap{}, &corev1.Secret{}).
 		WithIndex(&batchv1.Job{}, jobOwnerKey, jobOwnerIndexFunc).
+		WithIndex(&apiv1.Backup{}, ".spec.cluster.name", func(rawObj client.Object) []string {
+			return []string{rawObj.(*apiv1.Backup).Spec.Cluster.Name}
+		}).
 		Build()
 	Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
When a backup is created but cannot be immediately processed (e.g., cluster not found, another backup is running, or target pod is not ready), the backup's phase should be set to "pending" to indicate its state to users.

Previously, the backup phase could remain empty in these scenarios, which was misleading as users couldn't distinguish between a backup that hadn't started processing and one that was actively waiting.

This change:
- Adds a SetAsPending() method to BackupStatus for consistency with other SetAs* methods (SetAsStarted, SetAsCompleted, SetAsFailed)
- Updates getCluster() to set pending when the target cluster is not found
- Updates waitIfOtherBackupsRunning() to set pending when another backup for the same cluster is already running or waiting
- Ensures startBackupManagedByInstance() and reconcileSnapshotBackup() use the new SetAsPending() method instead of direct phase assignment 

