### PR TITLE
docs: clarify container runtime requirements for `ImageVolume`

### DIFF
--- a/docs/src/imagevolume_extensions.md
+++ b/docs/src/imagevolume_extensions.md
@@ -48,6 +48,9 @@ To use image volume extensions with CloudNativePG, you need:
 
 - **PostgreSQL 18 or later**, with support for `extension_control_path`.
 - **Kubernetes 1.33**, with the `ImageVolume` feature gate enabled.
+- **Container runtime with ImageVolume support**:
+    - `containerd` v2.1.0 or later, or
+    - `CRI-O` v1.31 or later.
 - **CloudNativePG-compatible extension container images**, ensuring:
     - Matching PostgreSQL major version of the `Cluster` resource.
     - Compatible operating system distribution of the `Cluster` resource.

--- a/docs/src/imagevolume_extensions.md
+++ b/docs/src/imagevolume_extensions.md
@@ -48,7 +48,7 @@ To use image volume extensions with CloudNativePG, you need:
 
 - **PostgreSQL 18 or later**, with support for `extension_control_path`.
 - **Kubernetes 1.33**, with the `ImageVolume` feature gate enabled.
-- **Container runtime with ImageVolume support**:
+- **Container runtime with `ImageVolume` support**:
     - `containerd` v2.1.0 or later, or
     - `CRI-O` v1.31 or later.
 - **CloudNativePG-compatible extension container images**, ensuring:


### PR DESCRIPTION
Add explicit container runtime version requirements to the ImageVolume documentation. While the `ImageVolume` feature gate must be enabled in Kubernetes 1.33, users also need a compatible container runtime version:

- containerd v2.1.0 or later
- CRI-O v1.31 or later

This addresses issues where users enable the feature gate but encounter errors due to older container runtime versions that don't support ImageVolume (e.g., containerd 1.7.27 in default minikube images).

Closes #9354 