### PR TITLE
fix(backup): use instance session ID to detect instance manager restarts

### DIFF
--- a/api/v1/backup_funcs.go
+++ b/api/v1/backup_funcs.go
@@ -70,12 +70,12 @@ func (backupStatus *BackupStatus) SetAsCompleted() {
 }
 
 // SetAsStarted marks a certain backup as started
-func (backupStatus *BackupStatus) SetAsStarted(podName, containerID, executableHash string, method BackupMethod) {
+func (backupStatus *BackupStatus) SetAsStarted(podName, containerID, sessionID string, method BackupMethod) {
 	backupStatus.Phase = BackupPhaseStarted
 	backupStatus.InstanceID = &InstanceID{
-		PodName:        podName,
-		ContainerID:    containerID,
-		ExecutableHash: executableHash,
+		PodName:     podName,
+		ContainerID: containerID,
+		SessionID:   sessionID,
 	}
 	backupStatus.Method = method
 	backupStatus.ReconciliationStartedAt = ptr.To(metav1.Now())

--- a/api/v1/backup_funcs.go
+++ b/api/v1/backup_funcs.go
@@ -70,11 +70,12 @@ func (backupStatus *BackupStatus) SetAsCompleted() {
 }
 
 // SetAsStarted marks a certain backup as started
-func (backupStatus *BackupStatus) SetAsStarted(podName, containerID string, method BackupMethod) {
+func (backupStatus *BackupStatus) SetAsStarted(podName, containerID, executableHash string, method BackupMethod) {
 	backupStatus.Phase = BackupPhaseStarted
 	backupStatus.InstanceID = &InstanceID{
-		PodName:     podName,
-		ContainerID: containerID,
+		PodName:        podName,
+		ContainerID:    containerID,
+		ExecutableHash: executableHash,
 	}
 	backupStatus.Method = method
 	backupStatus.ReconciliationStartedAt = ptr.To(metav1.Now())

--- a/api/v1/backup_funcs_test.go
+++ b/api/v1/backup_funcs_test.go
@@ -58,11 +58,12 @@ var _ = Describe("BackupStatus structure", func() {
 			},
 		}
 
-		status.SetAsStarted(pod.Name, pod.Status.ContainerStatuses[0].ContainerID, BackupMethodBarmanObjectStore)
+		status.SetAsStarted(pod.Name, pod.Status.ContainerStatuses[0].ContainerID, "test-hash", BackupMethodBarmanObjectStore)
 		Expect(status.Phase).To(BeEquivalentTo(BackupPhaseStarted))
 		Expect(status.InstanceID).ToNot(BeNil())
 		Expect(status.InstanceID.PodName).To(Equal("cluster-example-1"))
 		Expect(status.InstanceID.ContainerID).To(Equal("container-id"))
+		Expect(status.InstanceID.ExecutableHash).To(Equal("test-hash"))
 		Expect(status.IsDone()).To(BeFalse())
 		Expect(status.ReconciliationStartedAt).ToNot(BeNil())
 	})

--- a/api/v1/backup_funcs_test.go
+++ b/api/v1/backup_funcs_test.go
@@ -58,12 +58,13 @@ var _ = Describe("BackupStatus structure", func() {
 			},
 		}
 
-		status.SetAsStarted(pod.Name, pod.Status.ContainerStatuses[0].ContainerID, "test-hash", BackupMethodBarmanObjectStore)
+		status.SetAsStarted(pod.Name, pod.Status.ContainerStatuses[0].ContainerID,
+			"test-session-id", BackupMethodBarmanObjectStore)
 		Expect(status.Phase).To(BeEquivalentTo(BackupPhaseStarted))
 		Expect(status.InstanceID).ToNot(BeNil())
 		Expect(status.InstanceID.PodName).To(Equal("cluster-example-1"))
 		Expect(status.InstanceID.ContainerID).To(Equal("container-id"))
-		Expect(status.InstanceID.ExecutableHash).To(Equal("test-hash"))
+		Expect(status.InstanceID.SessionID).To(Equal("test-session-id"))
 		Expect(status.IsDone()).To(BeFalse())
 		Expect(status.ReconciliationStartedAt).ToNot(BeNil())
 	})

--- a/api/v1/backup_types.go
+++ b/api/v1/backup_types.go
@@ -319,11 +319,12 @@ type InstanceID struct {
 	// The container ID
 	// +optional
 	ContainerID string `json:"ContainerID,omitempty"`
-	// The instance manager executable hash. This is used to detect if the instance
-	// manager binary was upgraded (e.g., during a release) which would terminate
-	// any running backup process.
+	// The instance manager session ID. This is a unique identifier generated at instance manager
+	// startup and changes on every restart (including container reboots). Used to detect if
+	// the instance manager was restarted during long-running operations like backups, which
+	// would terminate any running backup process.
 	// +optional
-	ExecutableHash string `json:"executableHash,omitempty"`
+	SessionID string `json:"sessionID,omitempty"`
 }
 
 // +genclient

--- a/api/v1/backup_types.go
+++ b/api/v1/backup_types.go
@@ -319,6 +319,11 @@ type InstanceID struct {
 	// The container ID
 	// +optional
 	ContainerID string `json:"ContainerID,omitempty"`
+	// The instance manager executable hash. This is used to detect if the instance
+	// manager binary was upgraded (e.g., during a release) which would terminate
+	// any running backup process.
+	// +optional
+	ExecutableHash string `json:"executableHash,omitempty"`
 }
 
 // +genclient

--- a/config/crd/bases/postgresql.cnpg.io_backups.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_backups.yaml
@@ -313,14 +313,15 @@ spec:
                   ContainerID:
                     description: The container ID
                     type: string
-                  executableHash:
-                    description: |-
-                      The instance manager executable hash. This is used to detect if the instance
-                      manager binary was upgraded (e.g., during a release) which would terminate
-                      any running backup process.
-                    type: string
                   podName:
                     description: The pod name
+                    type: string
+                  sessionID:
+                    description: |-
+                      The instance manager session ID. This is a unique identifier generated at instance manager
+                      startup and changes on every restart (including container reboots). Used to detect if
+                      the instance manager was restarted during long-running operations like backups, which
+                      would terminate any running backup process.
                     type: string
                 type: object
               majorVersion:

--- a/config/crd/bases/postgresql.cnpg.io_backups.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_backups.yaml
@@ -313,6 +313,12 @@ spec:
                   ContainerID:
                     description: The container ID
                     type: string
+                  executableHash:
+                    description: |-
+                      The instance manager executable hash. This is used to detect if the instance
+                      manager binary was upgraded (e.g., during a release) which would terminate
+                      any running backup process.
+                    type: string
                   podName:
                     description: The pod name
                     type: string

--- a/docs/src/cloudnative-pg.v1.md
+++ b/docs/src/cloudnative-pg.v1.md
@@ -1239,6 +1239,7 @@ _Appears in:_
 | --- | --- | --- | --- | --- |
 | `podName` _string_ | The pod name |  |  |  |
 | `ContainerID` _string_ | The container ID |  |  |  |
+| `sessionID` _string_ | The instance manager session ID. This is a unique identifier generated at instance manager<br />startup and changes on every restart (including container reboots). Used to detect if<br />the instance manager was restarted during long-running operations like backups, which<br />would terminate any running backup process. |  |  |  |
 
 
 #### InstanceReportedState

--- a/internal/controller/backup_controller.go
+++ b/internal/controller/backup_controller.go
@@ -241,7 +241,9 @@ func (r *BackupReconciler) startBackupManagedByInstance(
 
 	// If no good running backups are found we elect a pod for the backup
 	podStatus, err := r.getBackupTargetPod(ctx, &cluster, &backup)
-	if apierrs.IsNotFound(err) || errors.Is(err, ErrPrimaryImageNeedsUpdate) || errors.Is(err, ErrInstanceStatusUnavailable) {
+	if apierrs.IsNotFound(err) ||
+		errors.Is(err, ErrPrimaryImageNeedsUpdate) ||
+		errors.Is(err, ErrInstanceStatusUnavailable) {
 		r.Recorder.Eventf(&backup, "Warning", "FindingPod",
 			"Couldn't find target pod %s, will retry in 30 seconds", cluster.Status.TargetPrimary)
 		contextLogger.Info("Couldn't find target pod, will retry in 30 seconds", "target",
@@ -517,6 +519,8 @@ func (r *BackupReconciler) isValidBackupRunning(
 			"cluster", cluster.Name,
 			"pod", pod.Name,
 			"storedSessionID", backup.Status.InstanceID.SessionID)
+		r.Recorder.Eventf(backup, "Warning", "InstanceManagerRestarted",
+			"Backup failed: instance manager was restarted on pod %s", pod.Name)
 		if err := resourcestatus.FlagBackupAsFailed(ctx, r.Client, backup, cluster, failureReason); err != nil {
 			return false, fmt.Errorf("while marking backup as failed: %w", err)
 		}

--- a/internal/controller/backup_controller.go
+++ b/internal/controller/backup_controller.go
@@ -496,7 +496,7 @@ func (r *BackupReconciler) isValidBackupRunning(
 	// If the session ID changed, the instance manager was restarted (e.g., during an operator
 	// upgrade or container reboot), which means any running backup goroutine was killed.
 	instanceManagerRestarted := false
-	if backup.Spec.Method.IsManagedByInstance() && backup.Status.InstanceID.SessionID != "" {
+	if backup.Spec.Method.IsManagedByInstance() {
 		instanceManagerRestarted = r.isInstanceManagerRestarted(ctx, &pod, backup.Status.InstanceID.SessionID)
 	}
 

--- a/internal/controller/backup_controller_test.go
+++ b/internal/controller/backup_controller_test.go
@@ -68,6 +68,8 @@ var _ = Describe("backup_controller barmanObjectStore unit tests", func() {
 					TargetPrimary: clusterPrimary,
 				},
 			}
+			err := env.backupReconciler.Create(ctx, cluster)
+			Expect(err).ToNot(HaveOccurred())
 
 			backup = &apiv1.Backup{
 				ObjectMeta: metav1.ObjectMeta{
@@ -87,6 +89,8 @@ var _ = Describe("backup_controller barmanObjectStore unit tests", func() {
 					},
 				},
 			}
+			err = env.backupReconciler.Create(ctx, backup)
+			Expect(err).ToNot(HaveOccurred())
 
 			pod = &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
@@ -102,7 +106,7 @@ var _ = Describe("backup_controller barmanObjectStore unit tests", func() {
 					},
 				},
 			}
-			err := env.backupReconciler.Create(ctx, pod)
+			err = env.backupReconciler.Create(ctx, pod)
 			Expect(err).ToNot(HaveOccurred())
 
 			pod.Status = corev1.PodStatus{

--- a/pkg/management/postgres/instance.go
+++ b/pkg/management/postgres/instance.go
@@ -45,6 +45,7 @@ import (
 	"github.com/cloudnative-pg/machinery/pkg/fileutils/compatibility"
 	"github.com/cloudnative-pg/machinery/pkg/log"
 	"go.uber.org/atomic"
+	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
 
@@ -180,6 +181,12 @@ type Instance struct {
 
 	// instanceCommandChan is a channel for requesting actions on the instance
 	instanceCommandChan chan InstanceCommand
+
+	// SessionID is a unique identifier generated at instance manager startup.
+	// This ID changes on every instance manager restart, including reboots that don't
+	// change the container ID. Used to detect if the instance manager was restarted
+	// during long-running operations like backups.
+	SessionID string
 
 	// InstanceManagerIsUpgrading tells if there is an instance manager upgrade in process
 	InstanceManagerIsUpgrading atomic.Bool
@@ -402,6 +409,7 @@ func NewInstance() *Instance {
 		slotsReplicatorChan:        make(chan *apiv1.ReplicationSlotsConfiguration),
 		roleSynchronizerChan:       make(chan *apiv1.ManagedConfiguration),
 		tablespaceSynchronizerChan: make(chan map[string]apiv1.TablespaceConfiguration),
+		SessionID:                  string(uuid.NewUUID()),
 	}
 }
 

--- a/pkg/management/postgres/probes.go
+++ b/pkg/management/postgres/probes.go
@@ -122,6 +122,7 @@ func (instance *Instance) GetStatus() (result *postgres.PostgresqlStatus, err er
 	}
 
 	result.IsInstanceManagerUpgrading = instance.InstanceManagerIsUpgrading.Load()
+	result.SessionID = instance.SessionID
 
 	return result, nil
 }

--- a/pkg/postgres/status.go
+++ b/pkg/postgres/status.go
@@ -87,6 +87,10 @@ type PostgresqlStatus struct {
 	InstanceManagerVersion     string `json:"instanceManagerVersion"`
 	InstanceArch               string `json:"instanceArch"`
 	IsInstanceManagerUpgrading bool   `json:"isInstanceManagerUpgrading"`
+	// SessionID is a unique identifier generated at instance manager startup.
+	// This ID changes on every instance manager restart (including container reboots),
+	// allowing detection of restarts that don't change the container ID or executable hash.
+	SessionID string `json:"sessionID"`
 
 	// This field represents the Kubelet point-of-view of the readiness
 	// status of this instance and may be slightly stale when the Kubelet has


### PR DESCRIPTION
This fix addresses an issue where backups would hang indefinitely during operator releases. When the operator and barman plugin were updated simultaneously, the backup goroutine running in the instance manager would be killed (due to the instance manager binary being replaced via exec()), but the operator would still think the backup was running because the container ID hadn't changed.

The fix introduces a deterministic mechanism to detect instance manager restarts by tracking the SessionID

