### PR TITLE
chore: suppress revive warnings for package naming conflicts

### DIFF
--- a/pkg/utils/context/doc.go
+++ b/pkg/utils/context/doc.go
@@ -18,4 +18,6 @@ SPDX-License-Identifier: Apache-2.0
 */
 
 // Package context contains utility functions to work with context.Context
+//
+//nolint:revive
 package context

--- a/pkg/utils/hash/suite_test.go
+++ b/pkg/utils/hash/suite_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 */
 
+//nolint:revive
 package hash
 
 import (


### PR DESCRIPTION
Add nolint:revive directives to packages that conflict with
Go standard library names (context and hash). These warnings
were introduced in golangci-lint v2.7.0.

Renaming these packages would be a breaking change.

Closes #9371 