### PR TITLE
test(e2e): fix configuration update test flakiness

### DIFF
--- a/tests/e2e/configuration_update_test.go
+++ b/tests/e2e/configuration_update_test.go
@@ -465,6 +465,9 @@ var _ = Describe("Configuration update", Label(tests.LabelClusterMetadata), func
 		})
 
 		It("2. restarting (in place) the primary after increasing max_connection", func() {
+			// Ensure cluster is fully ready after previous test configuration change
+			AssertClusterIsReady(namespace, clusterName, testTimeouts[timeouts.ClusterIsReadyQuick], env)
+
 			var oldPrimaryPodName string
 			var newMaxConnectionsValue int
 			var primaryStartTime time.Time


### PR DESCRIPTION
Fix E2E configuration update test flakiness where the test occasionally fails with "connection refused" errors when querying PostgreSQL immediately after establishing a port-forward connection.

The first test in the Ordered context modifies work_mem, triggering a PostgreSQL reload/restart, but doesn't wait for the cluster to be fully ready. The second test then starts immediately and fails when trying to connect to PostgreSQL that is still starting up.

This adds AssertClusterIsReady at the beginning of the second test to ensure PostgreSQL is accepting connections before proceeding.

Closes #9378 