### PR TITLE
fix(slots): cleanup replication slots on replicas when features disabled

### DIFF
--- a/internal/management/controller/slots/runner/runner.go
+++ b/internal/management/controller/slots/runner/runner.go
@@ -72,16 +72,16 @@ func (sr *Replicator) Start(ctx context.Context) error {
 			case <-ticker.C:
 			}
 
-			// If replication is disabled stop the timer and perform cleanup
+			// If replication is disabled, stop the timer and perform cleanup
 			if config == nil || !config.GetEnabled() {
 				ticker.Stop()
-				// we set updateInterval to 0 to make sure the Ticker will be reset
+				// We set updateInterval to 0 to make sure the Ticker will be reset
 				// if the feature is enabled again
 				updateInterval = 0
 				// Perform cleanup before continuing
 				if config != nil {
 					if err := sr.reconcile(ctx, config); err != nil {
-						contextLog.Warning("cleanup during reconcile when features disabled", "err", err)
+						contextLog.Warning("cleanup during reconcile when features are disabled", "err", err)
 					}
 				}
 				continue

--- a/internal/management/controller/slots/runner/runner.go
+++ b/internal/management/controller/slots/runner/runner.go
@@ -72,13 +72,18 @@ func (sr *Replicator) Start(ctx context.Context) error {
 			case <-ticker.C:
 			}
 
-			// If replication is disabled stop the timer,
-			// the process will resume through the wakeUp channel if necessary
+			// If replication is disabled stop the timer and perform cleanup
 			if config == nil || !config.GetEnabled() {
 				ticker.Stop()
 				// we set updateInterval to 0 to make sure the Ticker will be reset
 				// if the feature is enabled again
 				updateInterval = 0
+				// Perform cleanup before continuing
+				if config != nil {
+					if err := sr.reconcile(ctx, config); err != nil {
+						contextLog.Warning("cleanup during reconcile when features disabled", "err", err)
+					}
+				}
 				continue
 			}
 

--- a/internal/webhook/v1/cluster_webhook.go
+++ b/internal/webhook/v1/cluster_webhook.go
@@ -2281,8 +2281,8 @@ func (v *ClusterCustomValidator) validateReplicationSlotsChange(r, old *apiv1.Cl
 
 	// Validate HighAvailability changes
 	if oldReplicationSlots.HighAvailability.GetEnabled() {
-		// when disabling we should check that the prefix it's not removed, and it doesn't change to
-		// properly execute the cleanup logic
+		// When disabling, we should check that the prefix is not removed and doesn't change
+		// to properly execute the cleanup logic
 		if newReplicationSlots == nil || newReplicationSlots.HighAvailability == nil {
 			path := field.NewPath("spec", "replicationSlots")
 			if newReplicationSlots != nil {

--- a/internal/webhook/v1/cluster_webhook.go
+++ b/internal/webhook/v1/cluster_webhook.go
@@ -2273,33 +2273,54 @@ func (v *ClusterCustomValidator) validateReplicationSlotsChange(r, old *apiv1.Cl
 	newReplicationSlots := r.Spec.ReplicationSlots
 	oldReplicationSlots := old.Spec.ReplicationSlots
 
-	if oldReplicationSlots == nil || oldReplicationSlots.HighAvailability == nil ||
-		!oldReplicationSlots.HighAvailability.GetEnabled() {
+	var errs field.ErrorList
+
+	if oldReplicationSlots == nil {
 		return nil
 	}
 
-	var errs field.ErrorList
-
-	// when disabling we should check that the prefix it's not removed, and it doesn't change to
-	// properly execute the cleanup logic
-	if newReplicationSlots == nil || newReplicationSlots.HighAvailability == nil {
-		path := field.NewPath("spec", "replicationSlots")
-		if newReplicationSlots != nil {
-			path = path.Child("highAvailability")
+	// Validate HighAvailability changes
+	if oldReplicationSlots.HighAvailability.GetEnabled() {
+		// when disabling we should check that the prefix it's not removed, and it doesn't change to
+		// properly execute the cleanup logic
+		if newReplicationSlots == nil || newReplicationSlots.HighAvailability == nil {
+			path := field.NewPath("spec", "replicationSlots")
+			if newReplicationSlots != nil {
+				path = path.Child("highAvailability")
+			}
+			errs = append(errs,
+				field.Invalid(
+					path,
+					nil,
+					fmt.Sprintf("Cannot remove %v section while highAvailability is enabled", path)),
+			)
+		} else if oldReplicationSlots.HighAvailability.SlotPrefix != newReplicationSlots.HighAvailability.SlotPrefix {
+			errs = append(errs,
+				field.Invalid(
+					field.NewPath("spec", "replicationSlots", "highAvailability", "slotPrefix"),
+					newReplicationSlots.HighAvailability.SlotPrefix,
+					"Cannot change replication slot prefix while highAvailability is enabled"),
+			)
 		}
-		errs = append(errs,
-			field.Invalid(
-				path,
-				nil,
-				fmt.Sprintf("Cannot remove %v section while highAvailability is enabled", path)),
-		)
-	} else if oldReplicationSlots.HighAvailability.SlotPrefix != newReplicationSlots.HighAvailability.SlotPrefix {
-		errs = append(errs,
-			field.Invalid(
-				field.NewPath("spec", "replicationSlots", "highAvailability", "slotPrefix"),
-				newReplicationSlots.HighAvailability.SlotPrefix,
-				"Cannot change replication slot prefix while highAvailability is enabled"),
-		)
+	}
+
+	// Validate SynchronizeReplicas changes
+	// When synchronizeReplicas is enabled, we need to ensure users disable it before removing the configuration
+	// to allow the cleanup logic to properly remove user-defined replication slots from replicas
+	if oldReplicationSlots.SynchronizeReplicas.GetEnabled() {
+		if newReplicationSlots == nil || newReplicationSlots.SynchronizeReplicas == nil {
+			path := field.NewPath("spec", "replicationSlots")
+			if newReplicationSlots != nil {
+				path = path.Child("synchronizeReplicas")
+			}
+			errs = append(errs,
+				field.Invalid(
+					path,
+					nil,
+					fmt.Sprintf("Cannot remove %v section while synchronizeReplicas is enabled. "+
+						"Disable synchronizeReplicas first to allow cleanup of user-defined replication slots on replicas", path)),
+			)
+		}
 	}
 
 	return errs


### PR DESCRIPTION
When both replicationSlots.highAvailability.enabled and replicationSlots.synchronizeReplicas.enabled are disabled, the Replicator now performs cleanup by calling reconcile() before continuing the loop, ensuring user-defined replication slots are properly removed from replica pods.

This change also adds webhook validation to prevent users from removing
the synchronizeReplicas configuration section while it is still enabled.
This ensures that cleanup logic can properly execute before the
configuration is removed, preventing orphaned replication slots on
replicas.


Closes #9380

# TODO

- document the known limitations: when excludedPatterns is modified the operator isn't able to compare the difference with the previous this my cause some lingering rep slots