### PR TITLE
fix(extensions): support underscores in extension names

### DIFF
--- a/.wordlist-en-custom.txt
+++ b/.wordlist-en-custom.txt
@@ -815,7 +815,6 @@ disablePassword
 disabledDefaultServices
 discoverable
 displayName
-displayName
 distro
 distroless
 distros
@@ -1341,6 +1340,7 @@ runtime
 rw
 sSfL
 sa
+sanitization
 sas
 scalability
 scalable

--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -1473,7 +1473,7 @@ type PostgresConfiguration struct {
 type ExtensionConfiguration struct {
 	// The name of the extension, required
 	// +kubebuilder:validation:MinLength=1
-	// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`
+	// +kubebuilder:validation:Pattern=`^[a-z0-9_]([-a-z0-9_]*[a-z0-9_])?$`
 	Name string `json:"name"`
 
 	// The image containing the extension, required

--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -1473,7 +1473,7 @@ type PostgresConfiguration struct {
 type ExtensionConfiguration struct {
 	// The name of the extension, required
 	// +kubebuilder:validation:MinLength=1
-	// +kubebuilder:validation:Pattern=`^[a-z0-9_]([-a-z0-9_]*[a-z0-9_])?$`
+	// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9_]*[a-z0-9])?$`
 	Name string `json:"name"`
 
 	// The image containing the extension, required

--- a/config/crd/bases/postgresql.cnpg.io_clusters.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_clusters.yaml
@@ -4414,7 +4414,7 @@ spec:
                         name:
                           description: The name of the extension, required
                           minLength: 1
-                          pattern: ^[a-z0-9_]([-a-z0-9_]*[a-z0-9_])?$
+                          pattern: ^[a-z0-9]([-a-z0-9_]*[a-z0-9])?$
                           type: string
                       required:
                       - image

--- a/config/crd/bases/postgresql.cnpg.io_clusters.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_clusters.yaml
@@ -4414,7 +4414,7 @@ spec:
                         name:
                           description: The name of the extension, required
                           minLength: 1
-                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          pattern: ^[a-z0-9_]([-a-z0-9_]*[a-z0-9_])?$
                           type: string
                       required:
                       - image

--- a/docs/src/cloudnative-pg.v1.md
+++ b/docs/src/cloudnative-pg.v1.md
@@ -984,7 +984,7 @@ _Appears in:_
 
 | Field | Description | Required | Default | Validation |
 | --- | --- | --- | --- | --- |
-| `name` _string_ | The name of the extension, required | True |  | MinLength: 1 <br />Pattern: `^[a-z0-9]([-a-z0-9]*[a-z0-9])?$` <br /> |
+| `name` _string_ | The name of the extension, required | True |  | MinLength: 1 <br />Pattern: `^[a-z0-9_]([-a-z0-9_]*[a-z0-9_])?$` <br /> |
 | `image` _[ImageVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#imagevolumesource-v1-core)_ | The image containing the extension, required | True |  |  |
 | `extension_control_path` _string array_ | The list of directories inside the image which should be added to extension_control_path.<br />If not defined, defaults to "/share". |  |  |  |
 | `dynamic_library_path` _string array_ | The list of directories inside the image which should be added to dynamic_library_path.<br />If not defined, defaults to "/lib". |  |  |  |

--- a/docs/src/cloudnative-pg.v1.md
+++ b/docs/src/cloudnative-pg.v1.md
@@ -984,7 +984,7 @@ _Appears in:_
 
 | Field | Description | Required | Default | Validation |
 | --- | --- | --- | --- | --- |
-| `name` _string_ | The name of the extension, required | True |  | MinLength: 1 <br />Pattern: `^[a-z0-9_]([-a-z0-9_]*[a-z0-9_])?$` <br /> |
+| `name` _string_ | The name of the extension, required | True |  | MinLength: 1 <br />Pattern: `^[a-z0-9]([-a-z0-9_]*[a-z0-9])?$` <br /> |
 | `image` _[ImageVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#imagevolumesource-v1-core)_ | The image containing the extension, required | True |  |  |
 | `extension_control_path` _string array_ | The list of directories inside the image which should be added to extension_control_path.<br />If not defined, defaults to "/share". |  |  |  |
 | `dynamic_library_path` _string array_ | The list of directories inside the image which should be added to dynamic_library_path.<br />If not defined, defaults to "/lib". |  |  |  |

--- a/docs/src/imagevolume_extensions.md
+++ b/docs/src/imagevolume_extensions.md
@@ -138,13 +138,14 @@ spec:
 The `name` field is **mandatory** and **must be unique within the cluster**, as
 it determines the mount path (`/extensions/foo` in this example). It must
 consist of *lowercase alphanumeric characters, underscores (`_`) or hyphens (`-`)* and must start
-and end with an alphanumeric character or underscore.
+and end with an alphanumeric character.
 
 :::note
 Extension names containing underscores (e.g., `pg_ivm`) are converted to use
 hyphens (e.g., `pg-ivm`) for Kubernetes volume names to comply with RFC 1123
-DNS label requirements. Ensure that extension names don't collide after this
-sanitization (e.g., `pg_ivm` and `pg-ivm` would conflict).
+DNS label requirements. Do not use extension names that become identical after
+sanitization (e.g., `pg_ivm` and `pg-ivm` both sanitize to `pg-ivm`). The
+webhook validation will prevent such conflicts.
 :::
 
 The `image` stanza follows the [Kubernetes `ImageVolume` API](https://kubernetes.io/docs/tasks/configure-pod-container/image-volumes/).

--- a/docs/src/imagevolume_extensions.md
+++ b/docs/src/imagevolume_extensions.md
@@ -137,7 +137,7 @@ spec:
 
 The `name` field is **mandatory** and **must be unique within the cluster**, as
 it determines the mount path (`/extensions/foo` in this example). It must
-consist of *lowercase alphanumeric characters or hyphens (`-`)* and must start
+consist of *lowercase alphanumeric characters, underscores (`_`) or hyphens (`-`)* and must start
 and end with an alphanumeric character.
 
 The `image` stanza follows the [Kubernetes `ImageVolume` API](https://kubernetes.io/docs/tasks/configure-pod-container/image-volumes/).

--- a/docs/src/imagevolume_extensions.md
+++ b/docs/src/imagevolume_extensions.md
@@ -138,7 +138,14 @@ spec:
 The `name` field is **mandatory** and **must be unique within the cluster**, as
 it determines the mount path (`/extensions/foo` in this example). It must
 consist of *lowercase alphanumeric characters, underscores (`_`) or hyphens (`-`)* and must start
-and end with an alphanumeric character.
+and end with an alphanumeric character or underscore.
+
+:::note
+Extension names containing underscores (e.g., `pg_ivm`) are converted to use
+hyphens (e.g., `pg-ivm`) for Kubernetes volume names to comply with RFC 1123
+DNS label requirements. Ensure that extension names don't collide after this
+sanitization (e.g., `pg_ivm` and `pg-ivm` would conflict).
+:::
 
 The `image` stanza follows the [Kubernetes `ImageVolume` API](https://kubernetes.io/docs/tasks/configure-pod-container/image-volumes/).
 The `reference` must point to a valid container registry path for the extension

--- a/pkg/specs/volumes.go
+++ b/pkg/specs/volumes.go
@@ -321,12 +321,18 @@ func createProjectedVolume(cluster *apiv1.Cluster) corev1.Volume {
 	}
 }
 
+// sanitizeExtensionNameForVolume converts an extension name to a valid Kubernetes volume name
+// by replacing underscores with hyphens to comply with RFC 1123 DNS label requirements
+func sanitizeExtensionNameForVolume(extensionName string) string {
+	return strings.ReplaceAll(extensionName, "_", "-")
+}
+
 func createExtensionVolumes(cluster *apiv1.Cluster) []corev1.Volume {
 	extensionVolumes := make([]corev1.Volume, 0, len(cluster.Spec.PostgresConfiguration.Extensions))
 	for _, extension := range cluster.Spec.PostgresConfiguration.Extensions {
 		extensionVolumes = append(extensionVolumes,
 			corev1.Volume{
-				Name: extension.Name,
+				Name: sanitizeExtensionNameForVolume(extension.Name),
 				VolumeSource: corev1.VolumeSource{
 					Image: &extension.ImageVolumeSource,
 				},
@@ -342,7 +348,7 @@ func createExtensionVolumeMounts(cluster *apiv1.Cluster) []corev1.VolumeMount {
 	for _, extension := range cluster.Spec.PostgresConfiguration.Extensions {
 		extensionVolumeMounts = append(extensionVolumeMounts,
 			corev1.VolumeMount{
-				Name:      extension.Name,
+				Name:      sanitizeExtensionNameForVolume(extension.Name),
 				MountPath: filepath.Join(postgres.ExtensionsBaseDirectory, extension.Name),
 			},
 		)

--- a/pkg/specs/volumes.go
+++ b/pkg/specs/volumes.go
@@ -321,8 +321,8 @@ func createProjectedVolume(cluster *apiv1.Cluster) corev1.Volume {
 	}
 }
 
-// sanitizeExtensionNameForVolume converts an extension name to a valid Kubernetes volume name
-// by replacing underscores with hyphens to comply with RFC 1123 DNS label requirements
+// sanitizeExtensionNameForVolume replaces underscores with hyphens to comply with RFC 1123
+// DNS label requirements for Kubernetes volume names. The mount path preserves the original name.
 func sanitizeExtensionNameForVolume(extensionName string) string {
 	return strings.ReplaceAll(extensionName, "_", "-")
 }

--- a/pkg/specs/volumes_test.go
+++ b/pkg/specs/volumes_test.go
@@ -625,4 +625,24 @@ var _ = Describe("ImageVolume Extensions", func() {
 			})
 		})
 	})
+
+	Context("sanitizeExtensionNameForVolume", func() {
+		It("should replace underscores with hyphens", func() {
+			Expect(sanitizeExtensionNameForVolume("pg_ivm")).To(Equal("pg-ivm"))
+		})
+
+		It("should handle multiple underscores", func() {
+			Expect(sanitizeExtensionNameForVolume("my_custom_extension")).To(Equal("my-custom-extension"))
+		})
+
+		It("should not modify names without underscores", func() {
+			Expect(sanitizeExtensionNameForVolume("foo")).To(Equal("foo"))
+			Expect(sanitizeExtensionNameForVolume("foo-bar")).To(Equal("foo-bar"))
+		})
+
+		It("should handle leading and trailing underscores", func() {
+			Expect(sanitizeExtensionNameForVolume("_pg_stat")).To(Equal("-pg-stat"))
+			Expect(sanitizeExtensionNameForVolume("pg_stat_")).To(Equal("pg-stat-"))
+		})
+	})
 })

--- a/pkg/specs/volumes_test.go
+++ b/pkg/specs/volumes_test.go
@@ -571,6 +571,20 @@ var _ = Describe("ImageVolume Extensions", func() {
 				Expect(extensionVolumes[1].Name).To(Equal("bar"))
 				Expect(extensionVolumes[1].VolumeSource.Image.Reference).To(Equal("bar:dev"))
 			})
+			It("should sanitize extension names with underscores for volume names", func() {
+				cluster.Spec.PostgresConfiguration.Extensions = []apiv1.ExtensionConfiguration{
+					{
+						Name: "pg_ivm",
+						ImageVolumeSource: corev1.ImageVolumeSource{
+							Reference: "pg_ivm:latest",
+						},
+					},
+				}
+				extensionVolumes := createExtensionVolumes(&cluster)
+				Expect(len(extensionVolumes)).To(BeEquivalentTo(1))
+				Expect(extensionVolumes[0].Name).To(Equal("pg-ivm"))
+				Expect(extensionVolumes[0].VolumeSource.Image.Reference).To(Equal("pg_ivm:latest"))
+			})
 		})
 	})
 
@@ -594,6 +608,20 @@ var _ = Describe("ImageVolume Extensions", func() {
 				Expect(extensionVolumeMounts[0].MountPath).To(Equal(fooMountPath))
 				Expect(extensionVolumeMounts[1].Name).To(Equal("bar"))
 				Expect(extensionVolumeMounts[1].MountPath).To(Equal(barMountPath))
+			})
+			It("should sanitize extension names with underscores for volume mount names", func() {
+				cluster.Spec.PostgresConfiguration.Extensions = []apiv1.ExtensionConfiguration{
+					{
+						Name: "pg_ivm",
+						ImageVolumeSource: corev1.ImageVolumeSource{
+							Reference: "pg_ivm:latest",
+						},
+					},
+				}
+				extensionVolumeMounts := createExtensionVolumeMounts(&cluster)
+				Expect(len(extensionVolumeMounts)).To(BeEquivalentTo(1))
+				Expect(extensionVolumeMounts[0].Name).To(Equal("pg-ivm"))
+				Expect(extensionVolumeMounts[0].MountPath).To(Equal(postgres.ExtensionsBaseDirectory + "/pg_ivm"))
 			})
 		})
 	})

--- a/pkg/specs/volumes_test.go
+++ b/pkg/specs/volumes_test.go
@@ -640,9 +640,12 @@ var _ = Describe("ImageVolume Extensions", func() {
 			Expect(sanitizeExtensionNameForVolume("foo-bar")).To(Equal("foo-bar"))
 		})
 
-		It("should handle leading and trailing underscores", func() {
-			Expect(sanitizeExtensionNameForVolume("_pg_stat")).To(Equal("-pg-stat"))
-			Expect(sanitizeExtensionNameForVolume("pg_stat_")).To(Equal("pg-stat-"))
+		It("should handle mixed underscores and hyphens", func() {
+			Expect(sanitizeExtensionNameForVolume("pg_foo-bar")).To(Equal("pg-foo-bar"))
+		})
+
+		It("should handle consecutive underscores", func() {
+			Expect(sanitizeExtensionNameForVolume("pg__stat")).To(Equal("pg--stat"))
 		})
 	})
 })


### PR DESCRIPTION
Allow PostgreSQL extension names to contain underscores (e.g., pg_ivm, pg_stat_statements) to support standard PostgreSQL extension naming conventions that were previously rejected by CRD validation.

Extension names with underscores are automatically sanitized to use hyphens for Kubernetes volume names (to comply with RFC 1123 DNS label requirements) while preserving the original name in mount paths. Webhook validation prevents naming conflicts after sanitization (e.g., pg_ivm and pg-ivm both become pg-ivm).

Closes #9383 