### PR TITLE
feat(docs): add automated documentation sync trigger on release

### DIFF
--- a/.github/workflows/trigger-docs-sync.yml
+++ b/.github/workflows/trigger-docs-sync.yml
@@ -20,12 +20,9 @@ jobs:
         run: echo "CLEAN_VERSION=$(echo ${{ github.event.inputs.version }} | sed 's/^v//')" >> $GITHUB_OUTPUT
 
       - name: Dispatch Docs Repository Workflow
-        uses: peter-evans/repository-dispatch@v4
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4
         with:
           repository: cloudnative-pg/docs
-          
-          token: ${{ secrets.DOCS_SYNC_PAT }} # PAT with repo permissions for docs repo
-          
+          token: ${{ secrets.REPO_GHA_PAT }}
           event-type: cnpg-docs-release
-          
           client-payload: '{"tag": "${{ steps.version.outputs.CLEAN_VERSION }}"}'

--- a/.github/workflows/trigger-docs-sync.yml
+++ b/.github/workflows/trigger-docs-sync.yml
@@ -1,0 +1,31 @@
+name: Manual Trigger for Docs Sync
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Simulated Release Tag (e.g., 1.30.0)'
+        required: true
+        default: '1.28.0'
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    
+    permissions: {}
+
+    steps:
+      - name: Extract Clean Version
+        id: version
+        run: echo "CLEAN_VERSION=$(echo ${{ github.event.inputs.version }} | sed 's/^v//')" >> $GITHUB_OUTPUT
+
+      - name: Dispatch Docs Repository Workflow
+        uses: peter-evans/repository-dispatch@v4
+        with:
+          repository: cloudnative-pg/docs
+          
+          token: ${{ secrets.DOCS_SYNC_PAT }} # PAT with repo permissions for docs repo
+          
+          event-type: cnpg-docs-release
+          
+          client-payload: '{"tag": "${{ steps.version.outputs.CLEAN_VERSION }}"}'

--- a/.github/workflows/trigger-docs-sync.yml
+++ b/.github/workflows/trigger-docs-sync.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Simulated Release Tag (e.g., 1.30.0)'
+        description: 'Release Tag (e.g., 1.28.0)'
         required: true
         default: '1.28.0'
 
@@ -15,14 +15,10 @@ jobs:
     permissions: {}
 
     steps:
-      - name: Extract Clean Version
-        id: version
-        run: echo "CLEAN_VERSION=$(echo ${{ github.event.inputs.version }} | sed 's/^v//')" >> $GITHUB_OUTPUT
-
       - name: Dispatch Docs Repository Workflow
         uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4
         with:
           repository: cloudnative-pg/docs
           token: ${{ secrets.REPO_GHA_PAT }}
           event-type: cnpg-docs-release
-          client-payload: '{"tag": "${{ steps.version.outputs.CLEAN_VERSION }}"}'
+          client-payload: '{"tag": "${{ github.event.inputs.version }}"}'


### PR DESCRIPTION
## Description

This PR introduces the required workflow to migrate the CloudNativePG documentation source to the Docusaurus build environment in the `cloudnative-pg/docs` repository.

### Changes in this PR

The new workflow, `.github/workflows/docs-sync-on-release.yml`, runs on the creation of a new release/tag (e.g., `v1.28.0`). It performs the following action:

1.  **Dispatches an event** to the `cloudnative-pg/docs` repository, passing the new version number in the payload.
2.  The `docs` repository then receives this event, pulls the source files, versions the content, and builds the site.
3. The workflow currently shows using `DOCS_SYNC_PAT` for auth token that was used in my local setup for testing purposes which will be replaced by the secrets we'll use for cross-repository auth.

Once the `docs` repository is ready, we can mark this PR as "Ready for Review."

## Related issue(s)
#8122 , #9315 
