### PR TITLE
fix(pooler): clear stale TLS status fields when configuration is removed

### DIFF
--- a/internal/controller/pooler_status.go
+++ b/internal/controller/pooler_status.go
@@ -54,6 +54,8 @@ func (r *PoolerReconciler) updatePoolerStatus(
 			Name:    resources.ServerCASecret.Name,
 			Version: resources.ServerCASecret.ResourceVersion,
 		}
+	} else {
+		updatedStatus.Secrets.ServerCA = apiv1.SecretVersion{}
 	}
 
 	if resources.ClientCASecret != nil {
@@ -61,6 +63,8 @@ func (r *PoolerReconciler) updatePoolerStatus(
 			Name:    resources.ClientCASecret.Name,
 			Version: resources.ClientCASecret.ResourceVersion,
 		}
+	} else {
+		updatedStatus.Secrets.ClientCA = apiv1.SecretVersion{}
 	}
 
 	if resources.ClientTLSSecret != nil {
@@ -68,6 +72,8 @@ func (r *PoolerReconciler) updatePoolerStatus(
 			Name:    resources.ClientTLSSecret.Name,
 			Version: resources.ClientTLSSecret.ResourceVersion,
 		}
+	} else {
+		updatedStatus.Secrets.ClientTLS = apiv1.SecretVersion{}
 	}
 
 	if resources.ServerTLSSecret != nil {
@@ -76,7 +82,9 @@ func (r *PoolerReconciler) updatePoolerStatus(
 			Version: resources.ServerTLSSecret.ResourceVersion,
 		}
 	} else {
-		// Clear ServerTLS for migration from v1.27
+		// Clear ServerTLS when not using manual TLS authentication.
+		// This is particularly important for migration from v1.27, where
+		// ServerTLS was always set to the cluster's server certificate.
 		updatedStatus.Secrets.ServerTLS = apiv1.SecretVersion{}
 	}
 

--- a/internal/controller/pooler_status.go
+++ b/internal/controller/pooler_status.go
@@ -75,6 +75,9 @@ func (r *PoolerReconciler) updatePoolerStatus(
 			Name:    resources.ServerTLSSecret.Name,
 			Version: resources.ServerTLSSecret.ResourceVersion,
 		}
+	} else {
+		// Clear ServerTLS for migration from v1.27
+		updatedStatus.Secrets.ServerTLS = apiv1.SecretVersion{}
 	}
 
 	if resources.Deployment != nil {

--- a/tests/e2e/upgrade_test.go
+++ b/tests/e2e/upgrade_test.go
@@ -674,6 +674,10 @@ var _ = Describe("Upgrade", Label(tests.LabelUpgrade, tests.LabelNoOpenshift), O
 
 		AssertConfUpgrade(clusterName1, upgradeNamespace)
 
+		By("verifying connection through pooler after upgrade", func() {
+			assertReadWriteConnectionUsingPgBouncerService(upgradeNamespace, clusterName1, pgBouncerSampleFile, true)
+		})
+
 		By("installing a second Cluster on the upgraded operator", func() {
 			// set the serverName to a random name
 			err := os.Setenv("SERVER_NAME", serverName2)


### PR DESCRIPTION
fix(pooler): clear stale TLS status fields when configuration is removed

The pooler status update logic only set status fields when resources were
present, but never cleared them when absent. This caused stale TLS
configuration (ServerCA, ClientCA, ClientTLS, ServerTLS) to persist in
status even after being removed from the spec, breaking pooler connectivity.

This particularly impacts users upgrading to v1.28 from any prior version.
Before v1.28, the ServerTLS status field was always set to the cluster's
server certificate. In v1.28, this field was repurposed for optional manual
TLS authentication to PostgreSQL. On upgrade, the stale pre-v1.28 value
persists, causing pgbouncer to use the wrong certificate and fail with
"ssl/tls alert unsupported certificate" errors. This breaks all application
connectivity through the pooler.

The same issue affects any user who configures custom TLS settings and later
removes them - pgbouncer continues using the stale certificates until manually
intervened.

This fix adds explicit clearing of optional TLS status fields when the
corresponding resources are not configured, ensuring status accurately reflects
the current specification.

Closes #9392 