### PR TITLE
test(configuration-e2e): skip simultaneous update when running on a development version of Postgres

### DIFF
--- a/tests/e2e/configuration_update_test.go
+++ b/tests/e2e/configuration_update_test.go
@@ -210,7 +210,10 @@ var _ = Describe("Configuration update", Label(tests.LabelClusterMetadata), func
 		currentVersion, err := version.FromTag(env.PostgresImageTag)
 		Expect(err).NotTo(HaveOccurred())
 		defaultVersion, err := version.FromTag(reference.New(versions.DefaultImageName).Tag)
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred())
+		// Skip this test for development PostgreSQL versions (newer than default)
+		// because they may not have compatible extensions like pgaudit available.
+		// See https://github.com/cloudnative-pg/cloudnative-pg/issues/9331
 		if currentVersion.Major() > defaultVersion.Major() {
 			Skip("Running on a version newer than the default image, skipping this test")
 		}

--- a/tests/e2e/configuration_update_test.go
+++ b/tests/e2e/configuration_update_test.go
@@ -26,6 +26,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cloudnative-pg/machinery/pkg/image/reference"
+	"github.com/cloudnative-pg/machinery/pkg/postgres/version"
 	cnpgTypes "github.com/cloudnative-pg/machinery/pkg/types"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -36,6 +38,7 @@ import (
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/specs"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/versions"
 	"github.com/cloudnative-pg/cloudnative-pg/tests"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/clusterutils"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/exec"
@@ -204,9 +207,16 @@ var _ = Describe("Configuration update", Label(tests.LabelClusterMetadata), func
 	}
 
 	assertChangeImageAndGucs := func(namespace string, primaryUpdateMethod apiv1.PrimaryUpdateMethod) {
+		currentVersion, err := version.FromTag(env.PostgresImageTag)
+		Expect(err).NotTo(HaveOccurred())
+		defaultVersion, err := version.FromTag(reference.New(versions.DefaultImageName).Tag)
+		Expect(err).ToNot(HaveOccurred())
+		if currentVersion.Major() > defaultVersion.Major() {
+			Skip("Running on a version newer than the default image, skipping this test")
+		}
+
 		cluster := &apiv1.Cluster{}
-		err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-			var err error
+		err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 			cluster, err = clusterutils.Get(env.Ctx, env.Client, namespace, clusterName)
 			Expect(err).NotTo(HaveOccurred())
 			cluster.Spec.ImageName = env.StandardImageName(targetTag)


### PR DESCRIPTION
Avoid running the simultaneous update test when we are testing a 
Pg major that's greater then the `DefaultImageName` specified by the operator.
The `DefaultImageName` always points to the latest stable major version, thus if
the image we are testing is a newer Pg Major, that most likely means we are running
on a development version of PG (like the ones being built in [postgres-trunk-containers](https://github.com/cloudnative-pg/postgres-trunk-containers/)).

The simultaneous update test requires applying an extension, which for development versions of PG
should be built from source and we have no guarantee that the extension is compatible yet. 

Closes #9331 