### PR TITLE
chore: add release-1.28 branch to templates and workflows

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -11,8 +11,8 @@
   baseBranchPatterns: [
     'main',
     'release-1.25',
-    'release-1.26',
     'release-1.27',
+    'release-1.28',
   ],
   ignorePaths: [
     'docs/**',

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -37,8 +37,8 @@ jobs:
           labels: |
             backport-requested :arrow_backward:
             release-1.25
-            release-1.26
             release-1.27
+            release-1.28
       -
         name: Create comment
         uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5
@@ -61,8 +61,8 @@ jobs:
           labels: |
             backport-requested :arrow_backward:
             release-1.25
-            release-1.26
             release-1.27
+            release-1.28
 
   ## backport pull request in condition when pr contains 'backport-requested' label and contains target branches labels
   back-porting-pr:
@@ -78,7 +78,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: [release-1.25, release-1.26, release-1.27]
+        branch: [release-1.25, release-1.27, release-1.28]
     env:
       PR: ${{ github.event.pull_request.number }}
     outputs:

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -79,7 +79,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: [release-1.25, release-1.26, release-1.27]
+        branch: [release-1.25, release-1.27, release-1.28]
     steps:
       - name: Invoke workflow with inputs
         uses: benc-uk/workflow-dispatch@e2e5e9a103e331dad343f381a29e654aea3cf8fc # v1

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -60,7 +60,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: [release-1.25, release-1.26, release-1.27]
+        branch: [release-1.25, release-1.27, release-1.28]
     steps:
       - name: Invoke workflow with inputs
         uses: benc-uk/workflow-dispatch@e2e5e9a103e331dad343f381a29e654aea3cf8fc # v1


### PR DESCRIPTION
Remove release-1.26 and add release-1.28 to bug issue template, Renovate config, backport workflow, and CI/CD smoke test matrices.