### PR TITLE
fix(metrics): skip pg_stat_archiver metrics on non-archiving standbys

### DIFF
--- a/config/manager/default-monitoring.yaml
+++ b/config/manager/default-monitoring.yaml
@@ -173,6 +173,9 @@ data:
           , COALESCE(CAST(CAST('x'||pg_catalog.right(pg_catalog.split_part(last_failed_wal, '.', 1), 16) AS pg_catalog.bit(64)) AS pg_catalog.int8), -1) AS last_failed_wal_start_lsn
           , EXTRACT(EPOCH FROM stats_reset) AS stats_reset_time
         FROM pg_catalog.pg_stat_archiver
+      predicate_query: |
+        SELECT NOT pg_catalog.pg_is_in_recovery()
+          OR pg_catalog.current_setting('archive_mode') = 'always'
       metrics:
         - archived_count:
             usage: "COUNTER"


### PR DESCRIPTION
After a PostgreSQL instance is demoted from primary to standby, the pg_stat_archiver view retains stale data from when the instance was archiving WAL files. This causes misleading metrics and false alerts (e.g., "last archive age > 7 minutes") on standby nodes that do not actively archive WAL.

This fix adds a predicate_query to the pg_stat_archiver metrics collection that only runs the query on instances that actually perform WAL archiving:
- Primary instances (not in recovery)
- Designated primary replicas (archive_mode='always' in replica clusters)

Regular standby nodes will no longer export pg_stat_archiver metrics, preventing stale data from triggering false alerts.

Fixes #9101 
