### PR TITLE
docs: enhance 'Preview Versions' to emphasize Release Candidate testing

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -29,7 +29,7 @@ docker run --rm -ti -p 3000:3000 \
 ```
 
 Once the server is running, open your browser and navigate to the local
-documentation preview at: `http://127.0.0.1:3000/docs/`.
+documentation preview at: `http://127.0.0.1:3000/docs/next/`.
 
 Thoroughly check your changes—put yourself in the end user's shoes to verify
 clarity and accuracy. Complete a final spell check, and then proceed with

--- a/docs/src/preview_version.md
+++ b/docs/src/preview_version.md
@@ -12,10 +12,9 @@ testing before the community issues a new generally available (GA) release.
 These versions are feature-frozen, meaning no new features are added, and are
 intended for public testing prior to the final release.
 
-:::info[Important]
-    CloudNativePG release candidates are **not intended for use in production**
-    systems. They should only be deployed in staging or dedicated testing
-    environments.
+:::warning[Important]
+    CloudNativePG release candidates are **not intended for use in production** systems.
+    They should only be deployed in staging or dedicated testing environments.
 :::
 
 ## Purpose of Release Candidates

--- a/docs/src/preview_version.md
+++ b/docs/src/preview_version.md
@@ -13,8 +13,9 @@ These versions are feature-frozen, meaning no new features are added, and are
 intended for public testing prior to the final release.
 
 :::info[Important]
-    CloudNativePG release candidates are not intended for use in production
-    systems.
+    CloudNativePG release candidates are **not intended for use in production**
+    systems. They should only be deployed in staging or dedicated testing
+    environments.
 :::
 
 ## Purpose of Release Candidates
@@ -24,12 +25,46 @@ the official release. While a release candidate aims to be identical to the
 initial release of a new minor version of CloudNativePG, additional changes may
 be implemented before the GA release.
 
-## Community Involvement
+### Mitigating Critical Issues
+
+The primary purpose of an RC is to catch serious defects and regressions that our
+automated testing and internal manual checks might miss. **Specifically, community testing
+is invaluable for validating real-world scenarios, such as:**
+
+- **Upgrade Paths:** Testing the process of upgrading an existing CloudNativePG
+  cluster from the previous stable minor version to the RC version. This often
+  uncovers critical compatibility or migration issues, like those that affect PVC
+  ownership, which can only be reliably tested with diverse existing user setups.
+- **Unique Configurations:** Validating compatibility with specific Kubernetes
+  versions, storage providers, networking setups, or custom PostgreSQL
+  extensions not covered by our standard test matrix.
+- **Real-world Workloads:** Running the RC with your actual application
+  workload and traffic patterns to expose performance regressions or race
+  conditions.
+
+## Community Involvement: How to Help
 
 The stability of each CloudNativePG minor release significantly depends on the
 community's efforts to test the upcoming version with their workloads and
 tools. Identifying bugs and regressions through user testing is crucial in
 determining when we can finalize the release.
+
+### Your Call to Action
+
+If a Release Candidate is available, we encourage you to perform the following tests in a
+non-production environment:
+
+- **New Deployment Test:** Deploy a new CloudNativePG cluster using the RC version.
+- **Upgrade Test (Crucial):** **Upgrade an existing cluster** (from the
+  preceding stable minor version) to the RC version, and verify all key
+  operational aspects (scaling, failover, backup/restore) function correctly.
+- **Basic Operations:** Verify key features like rolling update,
+  backup/restore, instance failover, and connection pooling function as
+  expected.
+- **Report Issues:** **Immediately report any issues or unexpected behavior**
+  by opening a GitHub issue and clearly marking it with a **`Release
+  Candidate`** tag or label, along with the RC version number
+  (e.g., `1.28.0-rc1`).
 
 ## Usage Advisory
 
@@ -38,6 +73,9 @@ CloudNativePG in production environments or active development projects. Althoug
 CloudNativePG undergoes extensive automated and manual testing, beta releases
 may contain serious bugs. Features in preview versions may change in ways that
 are not backwards compatible and could be removed entirely.
+
+**By testing the Release Candidate, you are helping to prevent a potentially
+critical bug from affecting the entire community upon the GA release.**
 
 ## Current Preview Version
 


### PR DESCRIPTION
Improve documentation for Release Candidates to strongly encourage and guide community testing, particularly focusing on crucial real-world scenarios like cluster upgrade paths. This update highlights the necessity of testing to catch critical regressions before GA.

Relates #9392 