### PR TITLE
fix: ensure pull secret is added to pooler ServiceAccount

### DIFF
--- a/internal/controller/pooler_update.go
+++ b/internal/controller/pooler_update.go
@@ -235,7 +235,7 @@ func (r *PoolerReconciler) updateServiceAccount(
 
 	if resources.ServiceAccount == nil {
 		serviceAccount := pgbouncer.ServiceAccount(pooler)
-		ensureServiceAccountHaveImagePullSecret(resources.ServiceAccount, pullSecretName)
+		ensureServiceAccountHaveImagePullSecret(serviceAccount, pullSecretName)
 		contextLog.Info("Creating service account")
 		if err := ctrl.SetControllerReference(pooler, serviceAccount, r.Scheme); err != nil {
 			return err


### PR DESCRIPTION
When creating a new pooler ServiceAccount, the imagePullSecret was not being
added because the code incorrectly passed the nil resources.ServiceAccount
instead of the newly created serviceAccount variable to the
ensureServiceAccountHaveImagePullSecret function.

This caused pooler deployments to fail pulling images from private registries,
resulting in stuck rolling updates during operator upgrades.

Fixes #9426 