### PR TITLE
chore: add missing labels with arm64 arch for CSV

### DIFF
--- a/config/olm-manifests/bases/cloudnative-pg.clusterserviceversion.yaml
+++ b/config/olm-manifests/bases/cloudnative-pg.clusterserviceversion.yaml
@@ -21,6 +21,7 @@ metadata:
     features.operators.openshift.io/token-auth-gcp: "false"
   labels:
     operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.arm64: supported
   name: cloudnative-pg.v0.0.0
   namespace: placeholder
 spec:


### PR DESCRIPTION
The ClusterServiceVersion was missing the label with the arm64 architecture
avoiding users to install the operator on OLM environments running on arm64

Closes #9437 