### PR TITLE
fix: remove `Backup` owner field indexer from `ScheduledBackup` controller

### DIFF
--- a/internal/cmd/manager/controller/controller.go
+++ b/internal/cmd/manager/controller/controller.go
@@ -249,7 +249,7 @@ func RunController(
 		Client:   mgr.GetClient(),
 		Scheme:   mgr.GetScheme(),
 		Recorder: mgr.GetEventRecorderFor("cloudnative-pg-scheduledbackup"),
-	}).SetupWithManager(ctx, mgr, maxConcurrentReconciles); err != nil {
+	}).SetupWithManager(mgr, maxConcurrentReconciles); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ScheduledBackup")
 		return err
 	}


### PR DESCRIPTION
Remove the indexer on `Backup` resources that allowed finding all `Backups` owned by a `ScheduledBackup`.

The indexer never worked because it was checking `Backups` for owner references of kind `Backup` instead of `ScheduledBackup`:

https://github.com/cloudnative-pg/cloudnative-pg/blob/e2d6bd090cc17c123299ec109056fa510c72ddf6/internal/controller/scheduledbackup_controller.go?plain=1#L350-L352

This check meant that the indexer never returned any results and so the `GetChildBackups` method always returned an empty slice.

Even if it had correctly looked for owners of kind `ScheduledBackup`, it would only have worked for the cases where the `ScheduledBackup` was configured with:

```yaml
backupOwnerReference: self
```

When `backupOwnerReference` was set to `none` (the default) or `cluster` this indexer would also not have returned anything.

The intended purpose of the `GetChildBackups` method that used the indexer was to prevent concurrent `Backups` for a `ScheduledBackup`.  The check never worked and the `Backup` controller handles concurrency itself by checking for running `Backups` before starting a new one. So rather than fixing this indexer it is better to simply remove it.