### PR TITLE
Feature/optional webhooks

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -50,6 +50,8 @@ spec:
             name: metrics
             protocol: TCP
         env:
+        - name: ENABLE_WEBHOOKS
+          value: "false"
         - name: OPERATOR_IMAGE_NAME
           value: $(OPERATOR_IMAGE_NAME)
         - name: OPERATOR_NAMESPACE
@@ -67,20 +69,20 @@ spec:
             memory: 100Mi
         livenessProbe:
           httpGet:
-            port: 9443
-            scheme: HTTPS
+            port: 8081
+            scheme: HTTP
             path: /readyz
         startupProbe:
           failureThreshold: 6
           periodSeconds: 5
           httpGet:
-            port: 9443
-            scheme: HTTPS
+            port: 8081
+            scheme: HTTP
             path: /readyz
         readinessProbe:
           httpGet:
-            port: 9443
-            scheme: HTTPS
+            port: 8081
+            scheme: HTTP
             path: /readyz
         volumeMounts:
           - mountPath: /controller

--- a/internal/cmd/manager/controller/cmd.go
+++ b/internal/cmd/manager/controller/cmd.go
@@ -38,6 +38,7 @@ func NewCmd() *cobra.Command {
 	var leaderLeaseDuration int
 	var leaderRenewDeadline int
 	var maxConcurrentReconciles int
+	var healthProbeAddr string
 
 	cmd := cobra.Command{
 		Use:           "controller [flags]",
@@ -55,12 +56,14 @@ func NewCmd() *cobra.Command {
 				pprofHTTPServer,
 				port,
 				maxConcurrentReconciles,
+				healthProbeAddr,
 				configuration.Current,
 			)
 		},
 	}
 
 	cmd.Flags().StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
+	cmd.Flags().StringVar(&healthProbeAddr, "health-probe-bind-address", ":8081", "The address the health probe endpoint binds to.")
 
 	cmd.Flags().BoolVar(&leaderElectionEnable, "leader-elect", false,
 		"Enable leader election for controller manager. "+

--- a/internal/configuration/configuration.go
+++ b/internal/configuration/configuration.go
@@ -76,6 +76,10 @@ const DefaultPluginSocketDir = "/plugins"
 // Data is the struct containing the configuration of the operator.
 // Usually the operator code will use the "Current" configuration.
 type Data struct {
+	// EnableWebhooks checks if webhooks should be enabled.
+	// Webhooks are enabled by default unless explicitly set to "false".
+	EnableWebhooks bool `json:"enableWebhooks" env:"ENABLE_WEBHOOKS"`
+
 	// WebhookCertDir is the directory where the certificates for the webhooks
 	// need to written. This is different between plain Kubernetes and OpenShift
 	WebhookCertDir string `json:"webhookCertDir" env:"WEBHOOK_CERT_DIR"`
@@ -183,6 +187,7 @@ var Current = NewConfiguration()
 // newDefaultConfig creates a configuration holding the defaults
 func newDefaultConfig() *Data {
 	return &Data{
+		EnableWebhooks:          true,
 		OperatorPullSecretName:  DefaultOperatorPullSecretName,
 		OperatorImageName:       versions.DefaultOperatorImageName,
 		PostgresImageName:       versions.DefaultImageName,


### PR DESCRIPTION
What is your opinion on moving the readiness probe out of the webhook server to its own dedicated one?

Right now it is not ready as testing and validation in the controller is missing.
Any other comment is welcome here or on slack.