### PR TITLE
test(e2e): avoid requiring pg_stat_archiver metric on non-archiving standbys

### DIFF
--- a/tests/e2e/asserts_test.go
+++ b/tests/e2e/asserts_test.go
@@ -2503,7 +2503,6 @@ func collectAndAssertDefaultMetricsPresentOnEachPod(
 			"cnpg_backends_waiting_total",
 			"cnpg_pg_postmaster_start_time",
 			"cnpg_pg_replication",
-			"cnpg_pg_stat_archiver",
 			"cnpg_pg_stat_bgwriter",
 			"cnpg_pg_stat_database",
 		}


### PR DESCRIPTION
Closes #9477 