### PR TITLE
test(e2e): use Subscription config for OLM environment variables

### DIFF
--- a/hack/e2e/run-e2e-ocp.sh
+++ b/hack/e2e/run-e2e-ocp.sh
@@ -95,9 +95,6 @@ oc apply -f cloudnative-pg-catalog.yaml
 # create the secret for the index to be pulled in the marketplace
 oc create secret docker-registry -n openshift-marketplace --docker-server="${REGISTRY}" --docker-username="${REGISTRY_USER}" --docker-password="${REGISTRY_PASSWORD}" cnpg-pull-secret || true
 
-# Create the default configmap to set global keepalives on all the tests
-oc create configmap -n openshift-operators --from-literal=STANDBY_TCP_USER_TIMEOUT=5000 cnpg-controller-manager-config
-
 # Install the operator
 oc apply -f - <<EOF
 apiVersion: operators.coreos.com/v1alpha1
@@ -116,6 +113,8 @@ spec:
       value: ${POSTGRES_IMG}
     - name: PGBOUNCER_IMAGE_NAME
       value: ${PGBOUNCER_IMG}
+    - name: STANDBY_TCP_USER_TIMEOUT
+      value: "5000"
 EOF
 
 # The subscription will install the operator, but the service account used


### PR DESCRIPTION
Replace CSV patching with the proper OLM Subscription configuration mechanism for setting POSTGRES_IMAGE_NAME and PGBOUNCER_IMAGE_NAME environment variables.

The new approach uses spec.config.env in the Subscription resource, which OLM automatically applies to all containers in the operator pod.

Closes #9482 