### PR TITLE
chore: suppress revive warnings for package naming conflicts

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -107,6 +107,10 @@ linters:
           - revive
         path: /(utils|common)/[^/]+.go
         text: avoid meaningless package names
+      - linters:
+          - revive
+        path: pkg/utils/(context|hash)/
+        text: avoid package names that conflict with Go standard library package names
     paths:
       - zz_generated.*
       - third_party$

--- a/pkg/utils/context/doc.go
+++ b/pkg/utils/context/doc.go
@@ -18,6 +18,4 @@ SPDX-License-Identifier: Apache-2.0
 */
 
 // Package context contains utility functions to work with context.Context
-//
-//nolint:revive
 package context

--- a/pkg/utils/hash/doc.go
+++ b/pkg/utils/hash/doc.go
@@ -25,4 +25,6 @@ SPDX-License-Identifier: Apache-2.0
 //
 // https://github.com/kubernetes/kubernetes/blob/master/pkg/util/hash/hash.go   // wokeignore:rule=master
 // https://github.com/kubernetes/kubernetes/blob/ea07644/pkg/controller/controller_utils.go#L1189
+//
+//nolint:revive
 package hash

--- a/pkg/utils/hash/doc.go
+++ b/pkg/utils/hash/doc.go
@@ -25,6 +25,4 @@ SPDX-License-Identifier: Apache-2.0
 //
 // https://github.com/kubernetes/kubernetes/blob/master/pkg/util/hash/hash.go   // wokeignore:rule=master
 // https://github.com/kubernetes/kubernetes/blob/ea07644/pkg/controller/controller_utils.go#L1189
-//
-//nolint:revive
 package hash

--- a/pkg/utils/hash/suite_test.go
+++ b/pkg/utils/hash/suite_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 */
 
-//nolint:revive
 package hash
 
 import (


### PR DESCRIPTION
Follow up of issue #9371 and pr #9372 , there was a missing file to exclude from
the revive check.