### PR TITLE
chore: suppress revive warnings for package naming conflicts

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -107,6 +107,11 @@ linters:
           - revive
         path: /(utils|common)/[^/]+.go
         text: avoid meaningless package names
+      # TODO: fix by renaming or removing pkg/utils/context and pkg/utils/hash packages
+      - linters:
+          - revive
+        path: pkg/utils/(context|hash)/
+        text: avoid package names that conflict with Go standard library package names
     paths:
       - zz_generated.*
       - third_party$

--- a/pkg/utils/context/doc.go
+++ b/pkg/utils/context/doc.go
@@ -18,6 +18,4 @@ SPDX-License-Identifier: Apache-2.0
 */
 
 // Package context contains utility functions to work with context.Context
-//
-//nolint:revive
 package context

--- a/pkg/utils/hash/suite_test.go
+++ b/pkg/utils/hash/suite_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 */
 
-//nolint:revive
 package hash
 
 import (


### PR DESCRIPTION
Follow up of issue #9371 and PR #9372.

The nolint comment approach proved unstable because CI and local systems disagree about which files need the comments. This commit uses golangci-lint configuration to exclude revive warnings for package names that conflict with Go standard library (context and hash packages).

Added a TODO comment to track the need to fix the root cause by renaming or removing these packages.

Closes #9371 