### PR TITLE
[chore]: update avast/retry-go to v5 #9544

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/acobaugh/osrelease v0.1.0
-	github.com/avast/retry-go/v4 v4.7.0
+	github.com/avast/retry-go/v5 v5.0.0
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/cheynewallace/tabby v1.1.1
 	github.com/cloudnative-pg/barman-cloud v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/acobaugh/osrelease v0.1.0 h1:Yb59HQDGGNhCj4suHaFQQfBps5wyoKLSSX/J/+Ui
 github.com/acobaugh/osrelease v0.1.0/go.mod h1:4bFEs0MtgHNHBrmHCt67gNisnabCRAlzdVasCEGHTWY=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/avast/retry-go/v4 v4.7.0 h1:yjDs35SlGvKwRNSykujfjdMxMhMQQM0TnIjJaHB+Zio=
-github.com/avast/retry-go/v4 v4.7.0/go.mod h1:ZMPDa3sY2bKgpLtap9JRUgk2yTAba7cgiFhqxY2Sg6Q=
+github.com/avast/retry-go/v5 v5.0.0 h1:kf1Qc2UsTZ4qq8elDymqfbISvkyMuhgRxuJqX2NHP7k=
+github.com/avast/retry-go/v5 v5.0.0/go.mod h1://d+usmKWio1agtZfS1H/ltTqwtIfBnRq9zEwjc3eH8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=

--- a/tests/utils/operator/operator.go
+++ b/tests/utils/operator/operator.go
@@ -30,7 +30,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/avast/retry-go/v4"
+	"github.com/avast/retry-go/v5"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -213,7 +213,8 @@ func WaitForReady(
 	timeoutSeconds uint,
 	checkWebhook bool,
 ) error {
-	return retry.Do(
+	return retry.New(retry.Delay(time.Second),
+		retry.Attempts(timeoutSeconds)).Do(
 		func() error {
 			ready, err := IsReady(ctx, crudClient, checkWebhook)
 			if err != nil || !ready {
@@ -221,8 +222,6 @@ func WaitForReady(
 			}
 			return nil
 		},
-		retry.Delay(time.Second),
-		retry.Attempts(timeoutSeconds),
 	)
 }
 

--- a/tests/utils/operator/operator.go
+++ b/tests/utils/operator/operator.go
@@ -214,15 +214,16 @@ func WaitForReady(
 	checkWebhook bool,
 ) error {
 	return retry.New(retry.Delay(time.Second),
-		retry.Attempts(timeoutSeconds)).Do(
-		func() error {
-			ready, err := IsReady(ctx, crudClient, checkWebhook)
-			if err != nil || !ready {
-				return fmt.Errorf("operator deployment is not ready")
-			}
-			return nil
-		},
-	)
+		retry.Attempts(timeoutSeconds)).
+		Do(
+			func() error {
+				ready, err := IsReady(ctx, crudClient, checkWebhook)
+				if err != nil || !ready {
+					return fmt.Errorf("operator deployment is not ready")
+				}
+				return nil
+			},
+		)
 }
 
 // isDeploymentReady returns true if the operator deployment has the expected number


### PR DESCRIPTION
FIX #9544 This PR updates the avast/retry-go library from v4 to v5 and migrates all test utility code to use the new API pattern. The migration changes from retry.Do() with inline options to retry.New().Do() pattern, which fixes go vet failures in the test helpers.

Key changes:

- Updated dependency from github.com/avast/retry-go/v4 to github.com/avast/retry-go/v5 in go.mod and go.sum
- Migrated retry API usage across 7 files from retry.Do(func, options...) to retry.New(options...).Do(func)
- Preserved all retry configuration options (Delay, Attempts, DelayType, RetryIf) in the migration