### PR TITLE
ci(e2e): use containerd v2 hosts-based registry config

### DIFF
--- a/hack/setup-cluster.sh
+++ b/hack/setup-cluster.sh
@@ -189,30 +189,41 @@ featureGates:
 EOF
   fi
 
-  # Add containerdConfigPatches section
+  # Add containerdConfigPatches section to enable hosts-based registry configuration
   cat >>"${config_file}" <<-EOF
 
 containerdConfigPatches:
-EOF
-
-  if [ -n "${DOCKER_REGISTRY_MIRROR:-}" ]; then
-    cat >>"${config_file}" <<-EOF
 - |-
-  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
-    endpoint = ["${DOCKER_REGISTRY_MIRROR}"]
-EOF
-  fi
-
-  cat >>"${config_file}" <<-EOF
-- |-
-  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."${registry_name}:5000"]
-    endpoint = ["http://${registry_name}:5000"]
+  [plugins."io.containerd.cri.v1.images".registry]
+    config_path = "/etc/containerd/certs.d"
 EOF
 
   # Create the cluster
   kind create cluster --name "${cluster_name}" --image "kindest/node:${k8s_version}" --config "${config_file}"
 
   docker network connect "kind" "${registry_name}" &>/dev/null || true
+
+  # Configure registry mirrors using hosts.toml files
+  REGISTRY_DIR="/etc/containerd/certs.d/${registry_name}:5000"
+  for node in $(kind get nodes --name "${cluster_name}"); do
+    docker exec "$node" mkdir -p "${REGISTRY_DIR}"
+    docker exec "$node" bash -c "cat > ${REGISTRY_DIR}/hosts.toml <<EOF
+[host.\"http://${registry_name}:5000\"]
+EOF
+"
+  done
+
+  # Configure docker.io mirror if specified
+  if [ -n "${DOCKER_REGISTRY_MIRROR:-}" ]; then
+    DOCKER_IO_DIR="/etc/containerd/certs.d/docker.io"
+    for node in $(kind get nodes --name "${cluster_name}"); do
+      docker exec "$node" mkdir -p "${DOCKER_IO_DIR}"
+      docker exec "$node" bash -c "cat > ${DOCKER_IO_DIR}/hosts.toml <<EOF
+[host.\"${DOCKER_REGISTRY_MIRROR}\"]
+EOF
+"
+    done
+  fi
 
   # Workaround for https://kind.sigs.k8s.io/docs/user/known-issues/#pod-errors-due-to-too-many-open-files
   for node in $(kind get nodes --name "${cluster_name}"); do


### PR DESCRIPTION
Updates `hack/setup-cluster.sh` to use the hosts-based registry configuration method for containerd v2, which is required by kind images for Kubernetes 1.35.0 and 1.34.2+.

The previous inline registry configuration format using `io.containerd.grpc.v1.cri.registry.mirrors` is deprecated. The new approach uses `io.containerd.cri.v1.images.registry` with config_path pointing to `/etc/containerd/certs.d`, where individual `hosts.toml` files configure each registry's endpoint and TLS settings.

Closes #9546 