### PR TITLE
fix(backup): use Status().Patch for backup status updates in reconcileSnapshotBackup

### DIFF
--- a/internal/controller/backup_controller.go
+++ b/internal/controller/backup_controller.go
@@ -529,7 +529,7 @@ func (r *BackupReconciler) reconcileSnapshotBackup(
 		// TODO: shouldn't this be a failed backup?
 		origBackup := backup.DeepCopy()
 		backup.Status.SetAsPending()
-		if err := r.Patch(ctx, backup, client.MergeFrom(origBackup)); err != nil {
+		if err := r.Status().Patch(ctx, backup, client.MergeFrom(origBackup)); err != nil {
 			return nil, err
 		}
 


### PR DESCRIPTION
The reconcileSnapshotBackup function was incorrectly using r.Patch() instead of r.Status().Patch() when setting backup status to pending. This is inconsistent with all other status patch operations in the controller and could cause issues since .status is a subresource that requires the status client. 

