### PR TITLE
fix(backup): use correct pod name in event when pod is not found

### DIFF
--- a/internal/controller/backup_controller.go
+++ b/internal/controller/backup_controller.go
@@ -451,7 +451,7 @@ func (r *BackupReconciler) isValidBackupRunning(
 			"ReStarting",
 			"Could not find the elected backup pod. Restarting backup for cluster %v on instance %v",
 			cluster.Name,
-			pod.Name,
+			backup.Status.InstanceID.PodName,
 		)
 		return false, nil
 	}


### PR DESCRIPTION
In isValidBackupRunning, when the elected backup pod is not found, the event message was incorrectly referencing pod.Name which is empty since the Get() call returned NotFound. Changed to use the actual pod name from backup.Status.InstanceID.PodName which contains the name of the pod that couldn't be found. 
