### PR TITLE
fix: enter deletion path immediately when cluster is being deleted

### DIFF
--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -162,7 +162,7 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return ctrl.Result{}, err
 	}
 
-	if cluster == nil || cluster.DeletionTimestamp != nil {
+	if cluster == nil || cluster.GetDeletionTimestamp() != nil {
 		if err := r.deleteDanglingMonitoringQueries(ctx, req.Namespace); err != nil {
 			contextLogger.Error(
 				err,

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -180,7 +180,7 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 					"clusterName", req.Name,
 					"namespace", req.Namespace,
 				)
-				return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
+				return ctrl.Result{RequeueAfter: time.Second}, nil
 			}
 			contextLogger.Error(
 				err,

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -162,7 +162,7 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return ctrl.Result{}, err
 	}
 
-	if cluster == nil {
+	if cluster == nil || cluster.DeletionTimestamp != nil {
 		if err := r.deleteDanglingMonitoringQueries(ctx, req.Namespace); err != nil {
 			contextLogger.Error(
 				err,
@@ -173,6 +173,15 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			return ctrl.Result{}, err
 		}
 		if err := r.notifyDeletionToOwnedResources(ctx, req.NamespacedName); err != nil {
+			// Optimistic locking conflict is transient - requeue to retry
+			if apierrs.IsConflict(err) {
+				contextLogger.Info(
+					"Optimistic locking conflict while removing finalizers, requeueing",
+					"clusterName", req.Name,
+					"namespace", req.Namespace,
+				)
+				return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
+			}
 			contextLogger.Error(
 				err,
 				"error while deleting finalizers of objects on the cluster",


### PR DESCRIPTION
When a cluster has DeletionTimestamp set, skip normal reconciliation and enter the deletion path immediately. This prevents accumulating exponential backoff from failed attempts to create resources in a terminating namespace.

Additionally, handle optimistic locking conflicts during finalizer removal by requeueing after 1 second instead of returning an error, avoiding unnecessary backoff delays.

Closes #9554 