### PR TITLE
chore: clarify semantics of hasPostgresContainerTerminationReason

### DIFF
--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -621,7 +621,7 @@ func (r *ClusterReconciler) requireWALArchivingPluginOrDelete(
 	contextLogger := log.FromContext(ctx).WithName("require_wal_archiving_plugin_delete")
 
 	for _, state := range instances.Items {
-		if !isTerminatedBecauseOfMissingWALArchivePlugin(state.Pod) {
+		if isTerminatedBecauseOfMissingWALArchivePlugin(state.Pod) {
 			contextLogger.Warning(
 				"Detected instance manager initialization procedure that failed "+
 					"because the required WAL archive plugin is missing. Deleting it to trigger rollout",

--- a/internal/controller/cluster_status.go
+++ b/internal/controller/cluster_status.go
@@ -861,9 +861,8 @@ func hasPostgresContainerTerminationReason(pod *corev1.Pod, reason func(state *c
 		return true
 	}
 
-	// The Pod is now running but not still ready, and last time it
-	// was terminated with the specified reason. Return true
-	// to indicate the termination reason was found
+	// The container is not ready and was last terminated with the specified reason.
+	// Return true to indicate the termination reason was found
 	if !pgContainerStatus.Ready && reason(&pgContainerStatus.LastTerminationState) {
 		return true
 	}

--- a/internal/controller/cluster_status.go
+++ b/internal/controller/cluster_status.go
@@ -825,16 +825,18 @@ func isWALSpaceAvailableOnPod(pod *corev1.Pod) bool {
 	isTerminatedForMissingWALDiskSpace := func(state *corev1.ContainerState) bool {
 		return state.Terminated != nil && state.Terminated.ExitCode == apiv1.MissingWALDiskSpaceExitCode
 	}
-	return hasPostgresContainerTerminationReason(pod, isTerminatedForMissingWALDiskSpace)
+	// Return true if WAL space IS available (i.e., NOT terminated for missing disk space)
+	return !hasPostgresContainerTerminationReason(pod, isTerminatedForMissingWALDiskSpace)
 }
 
 // isTerminatedBecauseOfMissingWALArchivePlugin check if a Pod terminated because the
 // WAL archiving plugin was missing when the Pod started
 func isTerminatedBecauseOfMissingWALArchivePlugin(pod *corev1.Pod) bool {
-	isTerminatedForMissingWALDiskSpace := func(state *corev1.ContainerState) bool {
+	isTerminatedForMissingWALArchivePlugin := func(state *corev1.ContainerState) bool {
 		return state.Terminated != nil && state.Terminated.ExitCode == apiv1.MissingWALArchivePlugin
 	}
-	return hasPostgresContainerTerminationReason(pod, isTerminatedForMissingWALDiskSpace)
+	// Return true if the pod IS terminated because of missing WAL archive plugin
+	return hasPostgresContainerTerminationReason(pod, isTerminatedForMissingWALArchivePlugin)
 }
 
 func hasPostgresContainerTerminationReason(pod *corev1.Pod, reason func(state *corev1.ContainerState) bool) bool {
@@ -850,21 +852,21 @@ func hasPostgresContainerTerminationReason(pod *corev1.Pod, reason func(state *c
 	// This is not an instance Pod as there's no PostgreSQL
 	// container
 	if pgContainerStatus == nil {
+		return false
+	}
+
+	// If the Pod was terminated with the specified reason,
+	// then return true
+	if reason(&pgContainerStatus.State) {
 		return true
 	}
 
-	// If the Pod was terminated because it didn't have enough disk
-	// space, then we have no disk space
-	if reason(&pgContainerStatus.State) {
-		return false
-	}
-
 	// The Pod is now running but not still ready, and last time it
-	// was terminated for missing disk space. Let's wait for it
-	// to be ready before classifying it as having enough disk space
+	// was terminated with the specified reason. Return true
+	// to indicate the termination reason was found
 	if !pgContainerStatus.Ready && reason(&pgContainerStatus.LastTerminationState) {
-		return false
+		return true
 	}
 
-	return true
+	return false
 }

--- a/internal/controller/cluster_status_test.go
+++ b/internal/controller/cluster_status_test.go
@@ -387,4 +387,201 @@ var _ = Describe("updateClusterStatusThatRequiresInstancesState tests", func() {
 		Expect(state2.TimeLineID).To(Equal(123))
 		Expect(state2.IP).To(Equal("192.168.1.2"))
 	})
+
+	Context("Pod termination reason detection", func() {
+		It("should detect when a pod has no PostgreSQL container", func() {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-pod"},
+				Status: corev1.PodStatus{
+					ContainerStatuses: []corev1.ContainerStatus{
+						{Name: "other-container"},
+					},
+				},
+			}
+
+			// When no postgres container exists, hasPostgresContainerTerminationReason returns false
+			result := hasPostgresContainerTerminationReason(pod, func(state *corev1.ContainerState) bool {
+				return state.Terminated != nil
+			})
+			Expect(result).To(BeFalse())
+		})
+
+		It("should detect termination with specific exit code in current state", func() {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-pod"},
+				Status: corev1.PodStatus{
+					ContainerStatuses: []corev1.ContainerStatus{
+						{
+							Name: "postgres",
+							State: corev1.ContainerState{
+								Terminated: &corev1.ContainerStateTerminated{
+									ExitCode: apiv1.MissingWALDiskSpaceExitCode,
+								},
+							},
+						},
+					},
+				},
+			}
+
+			result := hasPostgresContainerTerminationReason(pod, func(state *corev1.ContainerState) bool {
+				return state.Terminated != nil && state.Terminated.ExitCode == apiv1.MissingWALDiskSpaceExitCode
+			})
+			Expect(result).To(BeTrue())
+		})
+
+		It("should detect termination with specific exit code in last termination state", func() {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-pod"},
+				Status: corev1.PodStatus{
+					ContainerStatuses: []corev1.ContainerStatus{
+						{
+							Name: "postgres",
+							State: corev1.ContainerState{
+								Running: &corev1.ContainerStateRunning{},
+							},
+							Ready: false,
+							LastTerminationState: corev1.ContainerState{
+								Terminated: &corev1.ContainerStateTerminated{
+									ExitCode: apiv1.MissingWALArchivePlugin,
+								},
+							},
+						},
+					},
+				},
+			}
+
+			result := hasPostgresContainerTerminationReason(pod, func(state *corev1.ContainerState) bool {
+				return state.Terminated != nil && state.Terminated.ExitCode == apiv1.MissingWALArchivePlugin
+			})
+			Expect(result).To(BeTrue())
+		})
+
+		It("should return false when termination reason does not match", func() {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-pod"},
+				Status: corev1.PodStatus{
+					ContainerStatuses: []corev1.ContainerStatus{
+						{
+							Name: "postgres",
+							State: corev1.ContainerState{
+								Terminated: &corev1.ContainerStateTerminated{
+									ExitCode: 1, // Different exit code
+								},
+							},
+						},
+					},
+				},
+			}
+
+			result := hasPostgresContainerTerminationReason(pod, func(state *corev1.ContainerState) bool {
+				return state.Terminated != nil && state.Terminated.ExitCode == apiv1.MissingWALDiskSpaceExitCode
+			})
+			Expect(result).To(BeFalse())
+		})
+
+		It("should return false when container is ready despite last termination", func() {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-pod"},
+				Status: corev1.PodStatus{
+					ContainerStatuses: []corev1.ContainerStatus{
+						{
+							Name: "postgres",
+							State: corev1.ContainerState{
+								Running: &corev1.ContainerStateRunning{},
+							},
+							Ready: true,
+							LastTerminationState: corev1.ContainerState{
+								Terminated: &corev1.ContainerStateTerminated{
+									ExitCode: apiv1.MissingWALDiskSpaceExitCode,
+								},
+							},
+						},
+					},
+				},
+			}
+
+			result := hasPostgresContainerTerminationReason(pod, func(state *corev1.ContainerState) bool {
+				return state.Terminated != nil && state.Terminated.ExitCode == apiv1.MissingWALDiskSpaceExitCode
+			})
+			Expect(result).To(BeFalse())
+		})
+
+		It("isWALSpaceAvailableOnPod should return true when space is available", func() {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-pod"},
+				Status: corev1.PodStatus{
+					ContainerStatuses: []corev1.ContainerStatus{
+						{
+							Name: "postgres",
+							State: corev1.ContainerState{
+								Running: &corev1.ContainerStateRunning{},
+							},
+							Ready: true,
+						},
+					},
+				},
+			}
+
+			Expect(isWALSpaceAvailableOnPod(pod)).To(BeTrue())
+		})
+
+		It("isWALSpaceAvailableOnPod should return false when terminated due to missing disk space", func() {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-pod"},
+				Status: corev1.PodStatus{
+					ContainerStatuses: []corev1.ContainerStatus{
+						{
+							Name: "postgres",
+							State: corev1.ContainerState{
+								Terminated: &corev1.ContainerStateTerminated{
+									ExitCode: apiv1.MissingWALDiskSpaceExitCode,
+								},
+							},
+						},
+					},
+				},
+			}
+
+			Expect(isWALSpaceAvailableOnPod(pod)).To(BeFalse())
+		})
+
+		It("isTerminatedBecauseOfMissingWALArchivePlugin should return true when terminated due to missing plugin", func() {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-pod"},
+				Status: corev1.PodStatus{
+					ContainerStatuses: []corev1.ContainerStatus{
+						{
+							Name: "postgres",
+							State: corev1.ContainerState{
+								Terminated: &corev1.ContainerStateTerminated{
+									ExitCode: apiv1.MissingWALArchivePlugin,
+								},
+							},
+						},
+					},
+				},
+			}
+
+			Expect(isTerminatedBecauseOfMissingWALArchivePlugin(pod)).To(BeTrue())
+		})
+
+		It("isTerminatedBecauseOfMissingWALArchivePlugin should return false when not terminated", func() {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-pod"},
+				Status: corev1.PodStatus{
+					ContainerStatuses: []corev1.ContainerStatus{
+						{
+							Name: "postgres",
+							State: corev1.ContainerState{
+								Running: &corev1.ContainerStateRunning{},
+							},
+							Ready: true,
+						},
+					},
+				},
+			}
+
+			Expect(isTerminatedBecauseOfMissingWALArchivePlugin(pod)).To(BeFalse())
+		})
+	})
 })


### PR DESCRIPTION
The function hasPostgresContainerTerminationReason had confusing inverted semantics, returning false when a termination reason was found and true when it wasn't.

This refactoring corrects the function's return values to be intuitive while updating all callers to maintain identical behavior. All existing compensating negations have been adjusted accordingly, resulting in no functional changes to the codebase.