### PR TITLE
docs: inheritFromAzureAD for managed identities (review #9468)

### DIFF
--- a/api/v1/backup_types.go
+++ b/api/v1/backup_types.go
@@ -66,7 +66,7 @@ type BarmanCredentials = barmanApi.BarmanCredentials
 //
 // - storageKey
 // - storageSasToken
-// - inheritFromAzureAD: inheriting the credentials from the pod environment
+// - inheritFromAzureAD: enables the usage of Managed Identity authentication mechanism
 // - useDefaultAzureCredentials: using the default Azure authentication flow, which includes DefaultAzureCredential
 //
 // +kubebuilder:object:generate:=false

--- a/docs/src/appendixes/object_stores.md
+++ b/docs/src/appendixes/object_stores.md
@@ -202,12 +202,12 @@ combinations of credentials:
 - [Connection String](https://docs.microsoft.com/en-us/azure/storage/common/storage-configure-connection-string#configure-a-connection-string-for-an-azure-storage-account)
 - Storage account name and [Storage account access key](https://docs.microsoft.com/en-us/azure/storage/common/storage-account-keys-manage)
 - Storage account name and [Storage account SAS Token](https://docs.microsoft.com/en-us/azure/storage/blobs/sas-service-create)
-- Storage account name and [Azure AD Workload Identity](https://azure.github.io/azure-workload-identity/docs/introduction.html)
+- Storage account name and [Azure AD Managed Identity](https://learn.microsoft.com/en-us/entra/identity/managed-identities-azure-resources/overview)
 properly configured
 - [DefaultAzureCredential](https://learn.microsoft.com/en-us/python/api/azure-identity/azure.identity.defaultazurecredential?view=azure-python)
 authentication mechanism (which supports environment variables, managed identities, and other Azure authentication methods)
 
-Using **Azure AD Workload Identity**, you can avoid saving the credentials into a Kubernetes Secret,
+Using **Azure AD Managed Identity**, you can avoid saving the credentials into a Kubernetes Secret,
 and have a Cluster configuration adding the `inheritFromAzureAD` as follows:
 
 ```yaml


### PR DESCRIPTION
Make explicit in docs that the inheritFromAzureAD option enables the usage of Azure Managed Identity
authentication mechanism.