### PR TITLE
fix(plugin): validate TLS secret keys and plugin port before use

### DIFF
--- a/internal/controller/plugin_controller.go
+++ b/internal/controller/plugin_controller.go
@@ -191,6 +191,13 @@ func (r *PluginReconciler) reconcile(
 		return ctrl.Result{}, err
 	}
 
+	// Validate port range
+	if pluginPort < 1 || pluginPort > 65535 {
+		err := fmt.Errorf("plugin port %d is outside valid range (1-65535)", pluginPort)
+		contextLogger.Error(err, "Invalid plugin port annotation")
+		return ctrl.Result{}, err
+	}
+
 	// Create the plugin TLS configuration
 	clientKeyPair, err := tls.X509KeyPair(
 		clientSecret.Data[corev1.TLSCertKey],

--- a/internal/controller/plugin_controller.go
+++ b/internal/controller/plugin_controller.go
@@ -141,6 +141,13 @@ func (r *PluginReconciler) reconcile(
 		return ctrl.Result{}, err
 	}
 
+	// Validate that server secret contains required certificate key
+	if _, hasCert := serverSecret.Data[corev1.TLSCertKey]; !hasCert {
+		err := fmt.Errorf("server secret %q is missing required key %q", serverSecret.Name, corev1.TLSCertKey)
+		contextLogger.Error(err, "Invalid server secret for plugin")
+		return ctrl.Result{}, err
+	}
+
 	pluginClientSecret := service.Annotations[utils.PluginClientSecretAnnotationName]
 	if len(pluginClientSecret) == 0 {
 		contextLogger.Info("Detected service whose client secret annotation is empty, skipping")
@@ -153,6 +160,18 @@ func (r *PluginReconciler) reconcile(
 	if err != nil {
 		contextLogger.Error(err, "Error while getting client secret for plugin",
 			"secretName", pluginClientSecret)
+		return ctrl.Result{}, err
+	}
+
+	// Validate that client secret contains required keys
+	if _, hasCert := clientSecret.Data[corev1.TLSCertKey]; !hasCert {
+		err := fmt.Errorf("client secret %q is missing required key %q", clientSecret.Name, corev1.TLSCertKey)
+		contextLogger.Error(err, "Invalid client secret for plugin")
+		return ctrl.Result{}, err
+	}
+	if _, hasKey := clientSecret.Data[corev1.TLSPrivateKeyKey]; !hasKey {
+		err := fmt.Errorf("client secret %q is missing required key %q", clientSecret.Name, corev1.TLSPrivateKeyKey)
+		contextLogger.Error(err, "Invalid client secret for plugin")
 		return ctrl.Result{}, err
 	}
 


### PR DESCRIPTION
Add validation to ensure that client and server secrets contain the required TLS keys (tls.crt and tls.key) before attempting to use them. This prevents potential panics when secrets are missing the expected data. 
