### PR TITLE
fix(docs): use the correct `warning` syntax

### DIFF
--- a/docs/src/connection_pooling.md
+++ b/docs/src/connection_pooling.md
@@ -666,9 +666,10 @@ spec:
 
 ### Deprecation of Automatic `PodMonitor` Creation
 
-!!!warning "Feature Deprecation Notice"
+:::warning[Feature Deprecation Notice]
     The `.spec.monitoring.enablePodMonitor` field in the `Pooler` resource is
     now deprecated and will be removed in a future version of the operator.
+:::
 
 If you are currently using this feature, we strongly recommend you either
 remove or set `.spec.monitoring.enablePodMonitor` to `false` and manually

--- a/docs/src/monitoring.md
+++ b/docs/src/monitoring.md
@@ -118,9 +118,10 @@ spec:
 
 #### Deprecation of Automatic `PodMonitor` Creation
 
-!!!warning "Feature Deprecation Notice"
+:::warning[Feature Deprecation Notice]
     The `.spec.monitoring.enablePodMonitor` field in the `Cluster` resource is
     now deprecated and will be removed in a future version of the operator.
+:::
 
 If you are currently using this feature, we strongly recommend you either
 remove or set `.spec.monitoring.enablePodMonitor` to `false` and manually


### PR DESCRIPTION
The current warning does not use the correct syntax for warnings, so the warning is mangled and displayed as normal text:

<img width="1466" height="232" alt="Screenshot 2025-12-24 at 2 07 59 PM" src="https://github.com/user-attachments/assets/0181e0fa-fb43-41d2-b623-049ab5ba955a" />

This PR simply fixes the warning syntax according to the [Docusaurus documentation](https://docusaurus.io/docs/markdown-features/admonitions):

```
:::warning

Some **content** with _Markdown_ `syntax`. Check [this `api`](#).

:::
```

Note: Untested and unchecked.