### PR TITLE
fix(replica_cluster): check condition for designated primary transition completion

### DIFF
--- a/internal/management/controller/instance_controller.go
+++ b/internal/management/controller/instance_controller.go
@@ -1212,8 +1212,10 @@ func (r *InstanceReconciler) reconcileDesignatedPrimary(
 	ctx context.Context,
 	cluster *apiv1.Cluster,
 ) (changed bool, err error) {
-	// If I'm already the current designated primary everything is ok.
-	if cluster.Status.CurrentPrimary == r.instance.GetPodName() && !r.instance.RequiresDesignatedPrimaryTransition {
+	// Return early if this pod is already the designated primary and
+	// the transition condition is not requested.
+	if cluster.Status.CurrentPrimary == r.instance.GetPodName() &&
+		!externalcluster.IsDesignatedPrimaryTransitionRequested(cluster) {
 		return false, nil
 	}
 


### PR DESCRIPTION
When a replica cluster switch is initiated, a race condition occurs where the operator and instance manager concurrently modify the cluster object, resulting in an optimistic lock conflict that prevents the designated primary transition condition from being set.

The root cause was in the early return check of reconcileDesignatedPrimary, which used transient instance state (RequiresDesignatedPrimaryTransition) instead of checking the actual cluster condition status. This caused the function to return early on subsequent reconciliation loops, never retrying the failed status update.

This fix makes the early return check more robust by verifying the actual condition status using IsDesignatedPrimaryTransitionRequested. If the condition is still requested (not yet completed), the function will retry setting it, even if CurrentPrimary already matches this pod.

Closes #9591 