### PR TITLE
fix(podlogs): Follow mode exit bug and test improvements

### DIFF
--- a/pkg/podlogs/cluster_writer.go
+++ b/pkg/podlogs/cluster_writer.go
@@ -220,7 +220,7 @@ func (csr *ClusterWriter) SingleStream(ctx context.Context, writer io.Writer) er
 				}
 			}
 		}
-		if streamSet.isZero() {
+		if !csr.Options.Follow && streamSet.isZero() {
 			return nil
 		}
 


### PR DESCRIPTION
The test "should catch extra logs if given the follow option" was flaky in CI because it tested implementation details (counting loop iterations with tight timing) rather than actual behavior.

Redesigned the test to verify what Follow=true actually does: it keeps streaming until the context is cancelled. The test now uses Eventually/Consistently patterns that handle timing variations gracefully, making it robust across different environments.

The improved test exposed a bug in the production code: the streaming function would exit when all current log streams completed, even when Follow=true was set. This caused premature exit instead of continuing to poll for new or restarted pods. Fixed by changing the exit condition to only apply when Follow=false.