### PR TITLE
fix(replica_cluster): resolve race condition in designated primary transition

### DIFF
--- a/internal/management/controller/instance_controller.go
+++ b/internal/management/controller/instance_controller.go
@@ -40,7 +40,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -995,8 +994,13 @@ func (r *InstanceReconciler) reconcileInstance(cluster *apiv1.Cluster) {
 			return false
 		}
 
-		isPrimary, _ := r.instance.IsPrimary()
-		return isPrimary
+		// Check if this pod was the primary before the transition started.
+		// We use CurrentPrimary instead of IsPrimary() because IsPrimary()
+		// checks for the absence of standby.signal, which gets created during
+		// the transition by RefreshReplicaConfiguration(). Using CurrentPrimary
+		// keeps the sentinel true throughout the transition, allowing retries
+		// if the status update fails due to optimistic locking conflicts.
+		return cluster.Status.CurrentPrimary == r.instance.GetPodName()
 	}
 
 	r.instance.PgCtlTimeoutForPromotion = cluster.GetPgCtlTimeoutForPromotion()
@@ -1213,7 +1217,8 @@ func (r *InstanceReconciler) reconcileDesignatedPrimary(
 	cluster *apiv1.Cluster,
 ) (changed bool, err error) {
 	// If I'm already the current designated primary everything is ok.
-	if cluster.Status.CurrentPrimary == r.instance.GetPodName() && !r.instance.RequiresDesignatedPrimaryTransition {
+	if cluster.Status.CurrentPrimary == r.instance.GetPodName() &&
+		!r.instance.RequiresDesignatedPrimaryTransition {
 		return false, nil
 	}
 
@@ -1226,25 +1231,17 @@ func (r *InstanceReconciler) reconcileDesignatedPrimary(
 	// I'm the primary, need to inform the operator
 	log.FromContext(ctx).Info("Setting myself as the current designated primary")
 
-	return changed, retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-		var livingCluster apiv1.Cluster
+	cluster.Status.CurrentPrimary = r.instance.GetPodName()
+	cluster.Status.CurrentPrimaryTimestamp = pgTime.GetCurrentTimestamp()
+	if r.instance.RequiresDesignatedPrimaryTransition {
+		externalcluster.SetDesignatedPrimaryTransitionCompleted(cluster)
+	}
 
-		err := r.client.Get(ctx, client.ObjectKeyFromObject(cluster), &livingCluster)
-		if err != nil {
-			return err
-		}
+	if err := r.client.Status().Update(ctx, cluster); err != nil {
+		return changed, err
+	}
 
-		updatedCluster := livingCluster.DeepCopy()
-		updatedCluster.Status.CurrentPrimary = r.instance.GetPodName()
-		updatedCluster.Status.CurrentPrimaryTimestamp = pgTime.GetCurrentTimestamp()
-		if r.instance.RequiresDesignatedPrimaryTransition {
-			externalcluster.SetDesignatedPrimaryTransitionCompleted(updatedCluster)
-		}
-
-		cluster.Status = updatedCluster.Status
-
-		return r.client.Status().Update(ctx, updatedCluster)
-	})
+	return changed, nil
 }
 
 // waitForWalReceiverDown wait until the wal receiver is down, and it's used


### PR DESCRIPTION
When a replica cluster switch is initiated, a race condition could occur where the instance manager fails to set the designated primary transition completion condition after an optimistic lock conflict, causing the operator to wait indefinitely.

The root cause was in the RequiresDesignatedPrimaryTransition sentinel calculation, which used IsPrimary() to check for the absence of standby.signal. After RefreshReplicaConfiguration() creates standby.signal during the first reconciliation loop, IsPrimary() returns false, making the sentinel false and causing subsequent loops to return early without retrying the status update.

This fix changes the sentinel to use CurrentPrimary status instead of IsPrimary(), keeping it true throughout the transition and allowing retries when status updates fail. Additionally, the RetryOnConflict wrapper is removed since the reconciliation loop itself provides the retry mechanism, simplifying the code and making all conflicts follow the same clear path.

Closes #9591 