### PR TITLE
chore: update k8s.io/utils and remove deprecated functions

### DIFF
--- a/internal/cmd/plugin/hibernate/off.go
+++ b/internal/cmd/plugin/hibernate/off.go
@@ -22,13 +22,13 @@ package hibernate
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	"github.com/cloudnative-pg/machinery/pkg/log"
 	corev1 "k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/strings/slices"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/plugin"


### PR DESCRIPTION
follow up #9575

The package k8s.io/utils depcrecated the functions from `slices` package in favor of the stdlib ones:

https://github.com/kubernetes/utils/commit/581440567a63482570db6b1b5e58aa628b1307d4