### PR TITLE
fix(ci): add repository condition to Snyk and sync API workflows

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -12,6 +12,7 @@ permissions: read-all
 
 jobs:
   security:
+    if: github.repository == 'cloudnative-pg/cloudnative-pg'
     name: Security scan
     runs-on: ubuntu-24.04
     permissions:

--- a/.github/workflows/sync-api.yml
+++ b/.github/workflows/sync-api.yml
@@ -9,6 +9,7 @@ permissions: read-all
 
 jobs:
   trigger-sync:
+    if: github.repository == 'cloudnative-pg/cloudnative-pg'
     runs-on: ubuntu-latest
     steps:
       - name: Invoke repository dispatch


### PR DESCRIPTION
Fix #9619 Added a job-level condition so the workflow runs only in the upstream repository.