### PR TITLE
fix: ensure postgresql.auto.conf is writable during restore

### DIFF
--- a/pkg/management/postgres/restore.go
+++ b/pkg/management/postgres/restore.go
@@ -166,14 +166,6 @@ func (info InitInfo) RestoreSnapshot(ctx context.Context, cli client.Client, imm
 		return err
 	}
 
-	// Volume snapshots may contain postgresql.auto.conf with read-only (0400)
-	autoConfPath := filepath.Join(info.PgData, "postgresql.auto.conf")
-	if err := os.Chmod(autoConfPath, 0o600); err != nil && !os.IsNotExist(err) {
-		contextLogger.Error(
-			err,"Error while changing mode of postgresql.auto.conf after snapshot restore, skipped",
-		)
-	}
-
 	return info.concludeRestore(ctx, cli, cluster, config, envs)
 }
 
@@ -477,15 +469,6 @@ func (info InitInfo) restoreDataDir(ctx context.Context, backup *apiv1.Backup, e
 		return err
 	}
 	contextLogger.Info("Restore completed")
-
-	// Make sures postgresql.auto.conf is writable during restore for PostgreSQL <=16
-	// The reconciler will later re-enforce the intended permissions.
-	autoConfPath := filepath.Join(info.PgData, "postgresql.auto.conf")
-	if err := os.Chmod(autoConfPath, 0o600); err != nil && !os.IsNotExist(err) {
-		contextLogger.Error(
-			err,"Error while changing mode of postgresql.auto.conf after restore, skipped",
-		)
-	}
 	return nil
 }
 


### PR DESCRIPTION
PostgreSQL 16 and earlier restores fail when migratePostgresAutoConfFile()
tries to write to postgresql.auto.conf because the file is read-only (0400).
The operator sets these restrictive permissions to prevent ALTER SYSTEM usage.

This fix makes the migration function ensure the file is writable before
attempting to write to it. This approach catches all restore paths (barman-cloud,
volume snapshots, and plugins) automatically without needing separate fixes in
each path.

The reconciler will reset permissions after migration based on the cluster's
enableAlterSystem configuration.

Closes #9569 