### PR TITLE
fix: auto-recover replicas with diverged timelines by re-cloning

### DIFF
--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -118,6 +118,11 @@ const (
 	// to indicate that it started successfully, but the configured WAL
 	// archiving plugin is not available.
 	MissingWALArchivePlugin = 5
+
+	// TimelineDivergenceExitCode is the exit code used by the instance manager
+	// to indicate that a replica's timeline has diverged from the primary's
+	// timeline after a failover, requiring PGDATA deletion and re-cloning.
+	TimelineDivergenceExitCode = 6
 )
 
 // SnapshotOwnerReference defines the reference type for the owner of the snapshot.

--- a/internal/cmd/manager/instance/run/cmd.go
+++ b/internal/cmd/manager/instance/run/cmd.go
@@ -133,6 +133,10 @@ func NewCmd() *cobra.Command {
 			if errors.Is(err, errWALArchivePluginNotAvailable) {
 				os.Exit(apiv1.MissingWALArchivePlugin)
 			}
+			var timelineDivergenceErr controller.ErrTimelineDivergence
+			if errors.As(err, &timelineDivergenceErr) {
+				os.Exit(apiv1.TimelineDivergenceExitCode)
+			}
 
 			return err
 		},

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -479,7 +479,11 @@ func (r *ClusterReconciler) reconcile(ctx context.Context, cluster *apiv1.Cluste
 	}
 
 	// Handle replicas that terminated due to timeline divergence after failover
-	if res, err := r.markTimelineDivergenceInstancesAsUnrecoverable(ctx, cluster, instancesStatus); err != nil || !res.IsZero() {
+	if res, err := r.markTimelineDivergenceInstancesAsUnrecoverable(
+		ctx,
+		cluster,
+		instancesStatus,
+	); err != nil || !res.IsZero() {
 		return res, err
 	}
 

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -478,6 +478,11 @@ func (r *ClusterReconciler) reconcile(ctx context.Context, cluster *apiv1.Cluste
 		return res, err
 	}
 
+	// Handle replicas that terminated due to timeline divergence after failover
+	if res, err := r.markTimelineDivergenceInstancesAsUnrecoverable(ctx, cluster, instancesStatus); err != nil || !res.IsZero() {
+		return res, err
+	}
+
 	if res, err := replicaclusterswitch.Reconcile(
 		ctx, r.Client, cluster, r.InstanceClient, instancesStatus); res != nil || err != nil {
 		if res != nil {
@@ -633,6 +638,66 @@ func (r *ClusterReconciler) requireWALArchivingPluginOrDelete(
 
 			return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 		}
+	}
+
+	return ctrl.Result{}, nil
+}
+
+// markTimelineDivergenceInstancesAsUnrecoverable detects instances that terminated
+// due to timeline divergence and marks them as unrecoverable. The existing
+// reconcileUnrecoverableInstances flow will then delete the PVCs and Pod,
+// triggering a re-clone via pg_basebackup.
+func (r *ClusterReconciler) markTimelineDivergenceInstancesAsUnrecoverable(
+	ctx context.Context,
+	cluster *apiv1.Cluster,
+	instances postgres.PostgresqlStatusList,
+) (ctrl.Result, error) {
+	contextLogger := log.FromContext(ctx).WithName("timeline_divergence_handler")
+
+	for _, state := range instances.Items {
+		if !isTerminatedBecauseOfTimelineDivergence(state.Pod) {
+			continue
+		}
+
+		// Skip if already marked as unrecoverable
+		if state.Pod.Annotations != nil {
+			if _, ok := state.Pod.Annotations[utils.UnrecoverableInstanceAnnotationName]; ok {
+				continue
+			}
+		}
+
+		// Protect the primary from being marked as unrecoverable
+		if state.Pod.Name == cluster.Status.CurrentPrimary ||
+			state.Pod.Name == cluster.Status.TargetPrimary {
+			contextLogger.Warning(
+				"Refusing to mark primary instance as unrecoverable due to timeline divergence",
+				"podName", state.Pod.Name,
+				"currentPrimary", cluster.Status.CurrentPrimary,
+				"targetPrimary", cluster.Status.TargetPrimary)
+			continue
+		}
+
+		contextLogger.Warning(
+			"Detected instance terminated due to timeline divergence, marking as unrecoverable for re-clone",
+			"podName", state.Pod.Name)
+
+		// Set the unrecoverable annotation on the pod
+		oldPod := state.Pod.DeepCopy()
+		if state.Pod.Annotations == nil {
+			state.Pod.Annotations = make(map[string]string)
+		}
+		state.Pod.Annotations[utils.UnrecoverableInstanceAnnotationName] = "true"
+
+		if err := r.Patch(ctx, state.Pod, client.MergeFrom(oldPod)); err != nil {
+			contextLogger.Error(err, "Cannot patch pod with unrecoverable annotation", "pod", state.Pod.Name)
+			return ctrl.Result{}, err
+		}
+
+		contextLogger.Info(
+			"Marked instance as unrecoverable due to timeline divergence, will be re-cloned",
+			"podName", state.Pod.Name)
+
+		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 	}
 
 	return ctrl.Result{}, nil

--- a/internal/controller/cluster_status.go
+++ b/internal/controller/cluster_status.go
@@ -837,6 +837,16 @@ func isTerminatedBecauseOfMissingWALArchivePlugin(pod *corev1.Pod) bool {
 	return hasPostgresContainerTerminationReason(pod, isTerminatedForMissingWALDiskSpace)
 }
 
+// isTerminatedBecauseOfTimelineDivergence checks if a Pod terminated because
+// the replica's timeline diverged from the primary's timeline after a failover.
+// This condition requires the instance to be re-cloned.
+func isTerminatedBecauseOfTimelineDivergence(pod *corev1.Pod) bool {
+	isTerminatedForTimelineDivergence := func(state *corev1.ContainerState) bool {
+		return state.Terminated != nil && state.Terminated.ExitCode == apiv1.TimelineDivergenceExitCode
+	}
+	return hasPostgresContainerTerminationReason(pod, isTerminatedForTimelineDivergence)
+}
+
 func hasPostgresContainerTerminationReason(pod *corev1.Pod, reason func(state *corev1.ContainerState) bool) bool {
 	var pgContainerStatus *corev1.ContainerStatus
 	for i := range pod.Status.ContainerStatuses {

--- a/internal/management/controller/instance_controller.go
+++ b/internal/management/controller/instance_controller.go
@@ -500,6 +500,11 @@ func (r *InstanceReconciler) initialize(ctx context.Context, cluster *apiv1.Clus
 		return err
 	}
 
+	// Check if this replica has diverged from the cluster's timeline and needs re-cloning
+	if err := r.verifyPgDataCoherenceForReplica(ctx, cluster); err != nil {
+		return err
+	}
+
 	if err := system.SetCoredumpFilter(cluster.GetCoredumpFilter()); err != nil {
 		return err
 	}

--- a/internal/management/controller/instance_startup_test.go
+++ b/internal/management/controller/instance_startup_test.go
@@ -1,0 +1,35 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package controller
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("ErrTimelineDivergence", func() {
+	It("formats error message correctly", func() {
+		err := ErrTimelineDivergence{
+			LocalTimeline:   20,
+			PrimaryTimeline: 21,
+		}
+		Expect(err.Error()).To(Equal("timeline divergence detected: local timeline 20 is behind primary timeline 21"))
+	})
+})

--- a/pkg/utils/parser.go
+++ b/pkg/utils/parser.go
@@ -51,6 +51,10 @@ const (
 	// checkpoint's REDO location pg_controldata entry
 	pgControlDataKeyLatestCheckpointREDOLocation pgControlDataKey = "Latest checkpoint's REDO location"
 
+	// pgControlDataKeyLatestCheckpointLocation is the latest
+	// checkpoint location pg_controldata entry
+	pgControlDataKeyLatestCheckpointLocation pgControlDataKey = "Latest checkpoint location"
+
 	// pgControlDataKeyTimeOfLatestCheckpoint is the time
 	// of latest checkpoint pg_controldata entry
 	pgControlDataKeyTimeOfLatestCheckpoint pgControlDataKey = "Time of latest checkpoint"
@@ -99,6 +103,11 @@ func (p PgControlData) GetDatabaseSystemIdentifier() string {
 // GetLatestCheckpointREDOLocation returns the latest checkpoint's REDO location
 func (p PgControlData) GetLatestCheckpointREDOLocation() string {
 	return p[pgControlDataKeyLatestCheckpointREDOLocation]
+}
+
+// GetLatestCheckpointLocation returns the latest checkpoint location (the LSN of the checkpoint record)
+func (p PgControlData) GetLatestCheckpointLocation() string {
+	return p[pgControlDataKeyLatestCheckpointLocation]
 }
 
 // GetTimeOfLatestCheckpoint returns the time of latest checkpoint


### PR DESCRIPTION
fix: auto-recover replicas with diverged timelines by re-cloning

When a replica's timeline diverges from the primary after a failover
(e.g., due to network issues or WAL archiving lag), PostgreSQL fails
to start with "requested timeline X is not a child of this server's
history". This left replicas in a crash-loop requiring manual PVC
deletion to recover.

This fix adds automatic recovery by:
- Detecting timeline mismatch between replica and primary during
      instance startup by checking cluster status
- Exiting with a specific exit code (6) when divergence is detected
- Operator detects this exit code and marks the instance as
  unrecoverable, triggering automatic PVC deletion and re-cloning
  via pg_basebackup

Closes #4990

