### PR TITLE
fix(walrestore): prevent replicas from downloading future timeline history files

### DIFF
--- a/tests/e2e/backup_restore_minio_test.go
+++ b/tests/e2e/backup_restore_minio_test.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"k8s.io/client-go/util/retry"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
@@ -561,6 +562,64 @@ var _ = Describe("MinIO - Backup and restore", Label(tests.LabelBackupRestore), 
 			tags, err = minio.GetFileTags(minioEnv, minio.GetFilePath(clusterName, "*.history.gz"))
 			Expect(err).ToNot(HaveOccurred())
 			Expect(tags.Tags).ToNot(BeEmpty())
+		})
+
+		It("protects replicas from downloading future timeline history files", func() {
+			firstClusterName := "cluster-timeline-1"
+			secondClusterName := "cluster-timeline-2"
+
+			firstClusterFile := fixturesDir + "/backup/minio/cluster-timeline-divergence-1.yaml.template"
+			secondClusterFile := fixturesDir + "/backup/minio/cluster-timeline-divergence-2.yaml.template"
+			backupFile := fixturesDir + "/backup/minio/backup-timeline-test.yaml"
+
+			By("creating first cluster with 1 instance", func() {
+				AssertCreateCluster(namespace, firstClusterName, firstClusterFile, env)
+			})
+
+			By("creating backup", func() {
+				backups.Execute(env.Ctx, env.Client, env.Scheme, namespace, backupFile, false,
+					testTimeouts[timeouts.BackupIsReady])
+			})
+
+			By("creating second cluster from backup", func() {
+				AssertCreateCluster(namespace, secondClusterName, secondClusterFile, env)
+			})
+
+			By("verifying second cluster is on timeline 2", func() {
+				Eventually(func() (int, error) {
+					cluster, err := clusterutils.Get(env.Ctx, env.Client, namespace, secondClusterName)
+					return cluster.Status.TimelineID, err
+				}, 60).Should(BeEquivalentTo(2))
+			})
+
+			By("verifying timeline 2 history file is archived", func() {
+				AssertArchiveWalOnMinio(namespace, secondClusterName, "shared-timeline-test")
+				Eventually(func() (int, error) {
+					return minio.CountFiles(minioEnv, minio.GetFilePath("shared-timeline-test", "00000002.history*"))
+				}, 60).Should(BeNumerically(">", 0))
+			})
+
+			By("scaling first cluster to 2 instances", func() {
+				err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+					cluster, err := clusterutils.Get(env.Ctx, env.Client, namespace, firstClusterName)
+					if err != nil {
+						return err
+					}
+					cluster.Spec.Instances = 2
+					return env.Client.Update(env.Ctx, cluster)
+				})
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			By("verifying new replica is streaming", func() {
+				// Critical: This verifies the replica successfully joins despite timeline 2
+				// history file existing in the shared archive. If the replica were to download
+				// the incompatible timeline 2 history file, PostgreSQL would crash with
+				// "requested timeline 2 is not a child of this server's history" and enter
+				// a crash-loop, causing this assertion to timeout. The validation logic must
+				// reject the future timeline file to allow the replica to join successfully.
+				AssertClusterStandbysAreStreaming(namespace, firstClusterName, int32(testTimeouts[timeouts.ClusterIsReadyQuick]))
+			})
 		})
 	})
 })

--- a/tests/e2e/backup_restore_minio_test.go
+++ b/tests/e2e/backup_restore_minio_test.go
@@ -565,12 +565,14 @@ var _ = Describe("MinIO - Backup and restore", Label(tests.LabelBackupRestore), 
 		})
 
 		It("protects replicas from downloading future timeline history files", func() {
-			firstClusterName := "cluster-timeline-1"
-			secondClusterName := "cluster-timeline-2"
-
 			firstClusterFile := fixturesDir + "/backup/minio/cluster-timeline-divergence-1.yaml.template"
 			secondClusterFile := fixturesDir + "/backup/minio/cluster-timeline-divergence-2.yaml.template"
 			backupFile := fixturesDir + "/backup/minio/backup-timeline-test.yaml"
+
+			firstClusterName, err := yaml.GetResourceNameFromYAML(env.Scheme, firstClusterFile)
+			Expect(err).ToNot(HaveOccurred())
+			secondClusterName, err := yaml.GetResourceNameFromYAML(env.Scheme, secondClusterFile)
+			Expect(err).ToNot(HaveOccurred())
 
 			By("creating first cluster with 1 instance", func() {
 				AssertCreateCluster(namespace, firstClusterName, firstClusterFile, env)

--- a/tests/e2e/backup_restore_minio_test.go
+++ b/tests/e2e/backup_restore_minio_test.go
@@ -622,6 +622,16 @@ var _ = Describe("MinIO - Backup and restore", Label(tests.LabelBackupRestore), 
 				// reject the future timeline file to allow the replica to join successfully.
 				AssertClusterStandbysAreStreaming(namespace, firstClusterName, int32(testTimeouts[timeouts.ClusterIsReadyQuick]))
 			})
+
+			By("deleting the first cluster", func() {
+				err = DeleteResourcesFromFile(namespace, firstClusterFile)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			By("deleting the second cluster", func() {
+				err = DeleteResourcesFromFile(namespace, secondClusterFile)
+				Expect(err).ToNot(HaveOccurred())
+			})
 		})
 	})
 })

--- a/tests/e2e/fixtures/backup/minio/backup-timeline-test.yaml
+++ b/tests/e2e/fixtures/backup/minio/backup-timeline-test.yaml
@@ -1,0 +1,7 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Backup
+metadata:
+  name: backup-timeline-test
+spec:
+  cluster:
+    name: cluster-timeline-1

--- a/tests/e2e/fixtures/backup/minio/cluster-timeline-divergence-1.yaml.template
+++ b/tests/e2e/fixtures/backup/minio/cluster-timeline-divergence-1.yaml.template
@@ -1,0 +1,42 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: cluster-timeline-1
+spec:
+  instances: 1
+
+  postgresql:
+    parameters:
+      log_checkpoints: "on"
+      log_lock_waits: "on"
+      log_min_duration_statement: '1000'
+      log_statement: 'ddl'
+      log_temp_files: '1024'
+      log_autovacuum_min_duration: '1s'
+      log_replication_commands: 'on'
+
+  storage:
+    storageClass: ${E2E_DEFAULT_STORAGE_CLASS}
+    size: 1Gi
+
+  backup:
+    target: primary
+    barmanObjectStore:
+        destinationPath: s3://cluster-timeline-shared/
+        serverName: shared-timeline-test
+        endpointURL: https://minio-service.minio:9000
+        endpointCA:
+          key: ca.crt
+          name: minio-server-ca-secret
+        s3Credentials:
+          accessKeyId:
+            name: backup-storage-creds
+            key: ID
+          secretAccessKey:
+            name: backup-storage-creds
+            key: KEY
+        wal:
+          compression: gzip
+        data:
+          immediateCheckpoint: true
+    retentionPolicy: "30d"

--- a/tests/e2e/fixtures/backup/minio/cluster-timeline-divergence-2.yaml.template
+++ b/tests/e2e/fixtures/backup/minio/cluster-timeline-divergence-2.yaml.template
@@ -1,0 +1,52 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: cluster-timeline-2
+  annotations:
+    cnpg.io/skipEmptyWalArchiveCheck: enabled
+spec:
+  instances: 1
+
+  postgresql:
+    parameters:
+      log_checkpoints: "on"
+      log_lock_waits: "on"
+      log_min_duration_statement: '1000'
+      log_statement: 'ddl'
+      log_temp_files: '1024'
+      log_autovacuum_min_duration: '1s'
+      log_replication_commands: 'on'
+
+  storage:
+    storageClass: ${E2E_DEFAULT_STORAGE_CLASS}
+    size: 1Gi
+
+  bootstrap:
+    recovery:
+      backup:
+        name: backup-timeline-test
+        endpointCA:
+          key: ca.crt
+          name: minio-server-ca-secret
+
+  backup:
+    target: primary
+    barmanObjectStore:
+        destinationPath: s3://cluster-timeline-shared/
+        serverName: shared-timeline-test
+        endpointURL: https://minio-service.minio:9000
+        endpointCA:
+          key: ca.crt
+          name: minio-server-ca-secret
+        s3Credentials:
+          accessKeyId:
+            name: backup-storage-creds
+            key: ID
+          secretAccessKey:
+            name: backup-storage-creds
+            key: KEY
+        wal:
+          compression: gzip
+        data:
+          immediateCheckpoint: true
+    retentionPolicy: "30d"


### PR DESCRIPTION
Replicas can crash-loop when orphaned "future timeline" .history files
exist in the WAL archive. This can occur during split-brain scenarios
or other conditions where timeline history files are created for timelines
that the cluster never officially adopts.

This fix adds validation during WAL restore to prevent replicas from
downloading timeline history files with timeline IDs greater than the
cluster's current timeline. Primary instances retain full access.

The validation works by:
- Parsing timeline ID from .history filenames (e.g., 00000022.history)
- Checking if the instance is a primary or replica
- For replicas, rejecting files where fileTimeline > clusterTimeline
- Returning "file not found" to PostgreSQL for rejected files

This prevents PostgreSQL from ever seeing the problematic history file,
allowing normal recovery to proceed. Combined with PR #9637 (auto-recovery
via re-cloning), this provides complete coverage of timeline divergence
scenarios.

Closes #4188