### PR TITLE
chore: improve detection of released OpenShift versions

### DIFF
--- a/.github/workflows/k8s-versions-check.yml
+++ b/.github/workflows/k8s-versions-check.yml
@@ -109,13 +109,11 @@ jobs:
           # We limit the range starting on 4 to 9 to skip the 13 version
           # this needs to be updated when the 15 version is also EOL
           curl -s https://mirror.openshift.com/pub/openshift-v4/clients/ocp/ | \
-          grep -Eo 'href.*"4\.(1[46-9]|20)\.[0-9].*"' | \
-          sed -E 's/href="//;s/\/"//;s/(4\.1[46-9]|2[0-9])(\..*$)/\1/' | \
+          grep -Eo 'href.*"4\.(1[46-9]|[2-9][0-9])\.[0-9].*"' | \
+          sed -E 's/href="//;s/\/"//;s/(4\.(1[46-9]|[2-9][0-9]))(\..*$)/\1/' | \
           sort -Vru | \
           awk -vv="$MINIMAL_OCP" '$0>=v {print $0}' | \
           jq -Rn '[inputs]' | tee .github/openshift_versions.json
-
-
         if: github.event.inputs.limit == null || github.event.inputs.limit == 'ocp'
       -
         name: Create Pull Request if versions have been updated

--- a/.github/workflows/k8s-versions-check.yml
+++ b/.github/workflows/k8s-versions-check.yml
@@ -109,14 +109,13 @@ jobs:
           # We limit the range starting on 4 to 9 to skip the 13 version
           # this needs to be updated when the 15 version is also EOL
           curl -s https://mirror.openshift.com/pub/openshift-v4/clients/ocp/ | \
-          grep -e 'href.*"4\.1[24-9]\.[0-9].*"' | \
-          sed -e 's/\(.*\)href="\(4\.1[2-9]\)\(.*\)/\2/' | \
+          grep -Eo 'href.*"4\.(1[46-9]|20)\.[0-9].*"' | \
+          sed -E 's/href="//;s/\/"//;s/(4\.1[46-9]|2[0-9])(\..*$)/\1/' | \
           sort -Vru | \
           awk -vv="$MINIMAL_OCP" '$0>=v {print $0}' | \
           jq -Rn '[inputs]' | tee .github/openshift_versions.json
 
-          OCP_VERSIONS=`cat .github/openshift_versions.json | jq -r '"v"+.[-1]+"-v"+.[0]'`
-          sed -i -e 's/\(OPENSHIFT_VERSIONS ?= \)\(.*\)/\1'${OCP_VERSIONS}'/g' Makefile
+
         if: github.event.inputs.limit == null || github.event.inputs.limit == 'ocp'
       -
         name: Create Pull Request if versions have been updated

--- a/.github/workflows/k8s-versions-check.yml
+++ b/.github/workflows/k8s-versions-check.yml
@@ -25,7 +25,7 @@ defaults:
 env:
   # The minimal k8s version supported, k8s version smaller than this one will be removed from vendor
   MINIMAL_K8S: "1.27"
-  MINIMAL_OCP: "4.12"
+  MINIMAL_OCP: "4.14"
 
 jobs:
 

--- a/.github/workflows/k8s-versions-check.yml
+++ b/.github/workflows/k8s-versions-check.yml
@@ -110,6 +110,7 @@ jobs:
           # Version 4.15 is excluded as it is EOL
           curl -s https://mirror.openshift.com/pub/openshift-v4/clients/ocp/ | \
           grep -Eo 'href.*"4\.(1[46-9]|[2-9][0-9])\.[0-9].*"' | \
+          grep -v rc | \
           sed -E 's/href="//;s/\/"//;s/(4\.(1[46-9]|[2-9][0-9]))(\..*$)/\1/' | \
           sort -Vru | \
           awk -vv="$MINIMAL_OCP" '$0>=v {print $0}' | \

--- a/.github/workflows/k8s-versions-check.yml
+++ b/.github/workflows/k8s-versions-check.yml
@@ -106,8 +106,8 @@ jobs:
       -
         name: Get updated OpenShift versions
         run: |
-          # We limit the range starting on 4 to 9 to skip the 13 version
-          # this needs to be updated when the 15 version is also EOL
+          # Match OpenShift 4.14, 4.16-4.19, and 4.20+
+          # Version 4.15 is excluded as it is EOL
           curl -s https://mirror.openshift.com/pub/openshift-v4/clients/ocp/ | \
           grep -Eo 'href.*"4\.(1[46-9]|[2-9][0-9])\.[0-9].*"' | \
           sed -E 's/href="//;s/\/"//;s/(4\.(1[46-9]|[2-9][0-9]))(\..*$)/\1/' | \


### PR DESCRIPTION
The old regexp wasn't accepting versions over 4.19,
now we add support to detect 4.20 and above.

Other versions like 4.15 and 4.12 were excluded since
those are not supported anymore or will not be
supported in near future.

Closes #8963 