### PR TITLE
refactor(instance): eliminate cached cluster configuration fields

### DIFF
--- a/internal/cmd/manager/instance/join/cmd.go
+++ b/internal/cmd/manager/instance/join/cmd.go
@@ -116,7 +116,7 @@ func joinSubCommand(ctx context.Context, instance *postgres.Instance, info postg
 		contextLogger.Error(err, "Error while getting cluster")
 		return err
 	}
-	instance.Cluster = &cluster
+	instance.SetCluster(&cluster)
 
 	if _, err := instancecertificate.NewReconciler(client, instance).RefreshSecrets(ctx, &cluster); err != nil {
 		contextLogger.Error(err, "Error while refreshing secrets")

--- a/internal/cmd/manager/instance/run/cmd.go
+++ b/internal/cmd/manager/instance/run/cmd.go
@@ -420,7 +420,7 @@ func runSubCommand( //nolint:gocognit,gocyclo
 		return makeUnretryableError(errNoFreeWALSpace)
 	}
 
-	enabledArchiverPluginName := instance.Cluster.GetEnabledWALArchivePluginName()
+	enabledArchiverPluginName := instance.GetClusterOrDefault().GetEnabledWALArchivePluginName()
 	if enabledArchiverPluginName != "" && !slices.Contains(loadedPluginNames, enabledArchiverPluginName) {
 		contextLogger.Info(
 			"Detected missing WAL archiver plugin, waiting for the operator to rollout a new instance Pod",

--- a/internal/cmd/manager/instance/run/cmd.go
+++ b/internal/cmd/manager/instance/run/cmd.go
@@ -420,15 +420,13 @@ func runSubCommand( //nolint:gocognit,gocyclo
 		return makeUnretryableError(errNoFreeWALSpace)
 	}
 
-	if instance.Cluster != nil {
-		enabledArchiverPluginName := instance.Cluster.GetEnabledWALArchivePluginName()
-		if enabledArchiverPluginName != "" && !slices.Contains(loadedPluginNames, enabledArchiverPluginName) {
-			contextLogger.Info(
-				"Detected missing WAL archiver plugin, waiting for the operator to rollout a new instance Pod",
-				"enabledArchiverPluginName", enabledArchiverPluginName,
-				"loadedPluginNames", loadedPluginNames)
-			return makeUnretryableError(errWALArchivePluginNotAvailable)
-		}
+	enabledArchiverPluginName := instance.Cluster.GetEnabledWALArchivePluginName()
+	if enabledArchiverPluginName != "" && !slices.Contains(loadedPluginNames, enabledArchiverPluginName) {
+		contextLogger.Info(
+			"Detected missing WAL archiver plugin, waiting for the operator to rollout a new instance Pod",
+			"enabledArchiverPluginName", enabledArchiverPluginName,
+			"loadedPluginNames", loadedPluginNames)
+		return makeUnretryableError(errWALArchivePluginNotAvailable)
 	}
 
 	return nil

--- a/internal/cmd/manager/instance/run/lifecycle/lifecycle.go
+++ b/internal/cmd/manager/instance/run/lifecycle/lifecycle.go
@@ -140,7 +140,7 @@ func (i *PostgresLifecycle) Start(ctx context.Context) error {
 				// resulting in a data corruption.
 				contextLogger.Info("Received termination signal",
 					"signal", sig,
-					"smartShutdownTimeout", i.instance.SmartStopDelay,
+					"smartShutdownTimeout", i.instance.Cluster.GetSmartShutdownTimeout(),
 				)
 				if err := i.instance.TryShuttingDownSmartFast(ctx); err != nil {
 					contextLogger.Error(err, "error while shutting down instance, proceeding")

--- a/internal/cmd/manager/instance/run/lifecycle/lifecycle.go
+++ b/internal/cmd/manager/instance/run/lifecycle/lifecycle.go
@@ -140,7 +140,7 @@ func (i *PostgresLifecycle) Start(ctx context.Context) error {
 				// resulting in a data corruption.
 				contextLogger.Info("Received termination signal",
 					"signal", sig,
-					"smartShutdownTimeout", i.instance.Cluster.GetSmartShutdownTimeout(),
+					"smartShutdownTimeout", i.instance.GetClusterOrDefault().GetSmartShutdownTimeout(),
 				)
 				if err := i.instance.TryShuttingDownSmartFast(ctx); err != nil {
 					contextLogger.Error(err, "error while shutting down instance, proceeding")

--- a/internal/cmd/manager/instance/upgrade/execute/cmd.go
+++ b/internal/cmd/manager/instance/upgrade/execute/cmd.go
@@ -160,7 +160,7 @@ func (ui upgradeInfo) upgradeSubCommand(ctx context.Context, instance *postgres.
 		contextLogger.Error(err, "Error while getting cluster")
 		return err
 	}
-	instance.Cluster = &cluster
+	instance.SetCluster(&cluster)
 
 	if _, err := instancecertificate.NewReconciler(client, instance).RefreshSecrets(ctx, &cluster); err != nil {
 		return fmt.Errorf("error while downloading secrets: %w", err)

--- a/internal/management/controller/instance_controller.go
+++ b/internal/management/controller/instance_controller.go
@@ -1209,12 +1209,7 @@ func (r *InstanceReconciler) reconcileDesignatedPrimary(
 	if r.instance.RequiresDesignatedPrimaryTransition() {
 		conditions.SetDesignatedPrimaryTransitionCompleted(cluster)
 	}
-
-	if err := r.client.Status().Update(ctx, cluster); err != nil {
-		return changed, err
-	}
-
-	return changed, nil
+	return changed, r.client.Status().Update(ctx, cluster)
 }
 
 // waitForWalReceiverDown wait until the wal receiver is down, and it's used

--- a/internal/management/controller/instance_controller.go
+++ b/internal/management/controller/instance_controller.go
@@ -139,8 +139,7 @@ func (r *InstanceReconciler) Reconcile(
 	ctx = cnpgiclient.SetPluginClientInContext(ctx, pluginClient)
 	ctx = cluster.SetInContext(ctx)
 
-	// Update the cached cluster for use outside the reconciliation cycle
-	r.updateClusterCache(cluster)
+	r.instance.SetCluster(cluster)
 
 	// Takes care of the `.check-empty-wal-archive` file
 	if err := r.reconcileCheckWalArchiveFile(cluster); err != nil {
@@ -977,12 +976,6 @@ func (r *InstanceReconciler) reconcileMonitoringQueries(
 	}
 
 	r.metricsServerExporter.SetCustomQueries(queriesCollector)
-}
-
-// updateClusterCache updates the cached cluster in the instance for use
-// outside the reconciliation cycle when the API client is not available
-func (r *InstanceReconciler) updateClusterCache(cluster *apiv1.Cluster) {
-	r.instance.Cluster = cluster
 }
 
 // PostgreSQLAutoConfWritable reconciles the permissions bit of `postgresql.auto.conf`

--- a/internal/management/controller/instance_controller.go
+++ b/internal/management/controller/instance_controller.go
@@ -59,7 +59,7 @@ import (
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/postgres"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/postgres/replication"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/promotiontoken"
-	externalcluster "github.com/cloudnative-pg/cloudnative-pg/pkg/reconciler/replicaclusterswitch"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/reconciler/replicaclusterswitch/conditions"
 	clusterstatus "github.com/cloudnative-pg/cloudnative-pg/pkg/resources/status"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/system"
 )
@@ -979,35 +979,8 @@ func (r *InstanceReconciler) reconcileMonitoringQueries(
 	r.metricsServerExporter.SetCustomQueries(queriesCollector)
 }
 
-// reconcileInstance sets PostgreSQL instance parameters to current values
+// reconcileInstance sets the cluster reference in the instance
 func (r *InstanceReconciler) reconcileInstance(cluster *apiv1.Cluster) {
-	detectRequiresDesignatedPrimaryTransition := func() bool {
-		if !cluster.IsReplica() {
-			return false
-		}
-
-		if !externalcluster.IsDesignatedPrimaryTransitionRequested(cluster) {
-			return false
-		}
-
-		if !r.instance.IsFenced() && !r.instance.MightBeUnavailable() {
-			return false
-		}
-
-		// Check if this pod was the primary before the transition started.
-		// We use CurrentPrimary instead of IsPrimary() because IsPrimary()
-		// checks for the absence of standby.signal, which gets created during
-		// the transition by RefreshReplicaConfiguration(). Using CurrentPrimary
-		// keeps the sentinel true throughout the transition, allowing retries
-		// if the status update fails due to optimistic locking conflicts.
-		return cluster.Status.CurrentPrimary == r.instance.GetPodName()
-	}
-
-	r.instance.PgCtlTimeoutForPromotion = cluster.GetPgCtlTimeoutForPromotion()
-	r.instance.MaxSwitchoverDelay = cluster.GetMaxSwitchoverDelay()
-	r.instance.MaxStopDelay = cluster.GetMaxStopDelay()
-	r.instance.SmartStopDelay = cluster.GetSmartShutdownTimeout()
-	r.instance.RequiresDesignatedPrimaryTransition = detectRequiresDesignatedPrimaryTransition()
 	r.instance.Cluster = cluster
 }
 
@@ -1218,7 +1191,7 @@ func (r *InstanceReconciler) reconcileDesignatedPrimary(
 ) (changed bool, err error) {
 	// If I'm already the current designated primary everything is ok.
 	if cluster.Status.CurrentPrimary == r.instance.GetPodName() &&
-		!r.instance.RequiresDesignatedPrimaryTransition {
+		!r.instance.RequiresDesignatedPrimaryTransition() {
 		return false, nil
 	}
 
@@ -1233,8 +1206,8 @@ func (r *InstanceReconciler) reconcileDesignatedPrimary(
 
 	cluster.Status.CurrentPrimary = r.instance.GetPodName()
 	cluster.Status.CurrentPrimaryTimestamp = pgTime.GetCurrentTimestamp()
-	if r.instance.RequiresDesignatedPrimaryTransition {
-		externalcluster.SetDesignatedPrimaryTransitionCompleted(cluster)
+	if r.instance.RequiresDesignatedPrimaryTransition() {
+		conditions.SetDesignatedPrimaryTransitionCompleted(cluster)
 	}
 
 	if err := r.client.Status().Update(ctx, cluster); err != nil {

--- a/internal/management/controller/instance_controller.go
+++ b/internal/management/controller/instance_controller.go
@@ -139,8 +139,8 @@ func (r *InstanceReconciler) Reconcile(
 	ctx = cnpgiclient.SetPluginClientInContext(ctx, pluginClient)
 	ctx = cluster.SetInContext(ctx)
 
-	// Reconcile PostgreSQL instance parameters
-	r.reconcileInstance(cluster)
+	// Update the cached cluster for use outside the reconciliation cycle
+	r.updateClusterCache(cluster)
 
 	// Takes care of the `.check-empty-wal-archive` file
 	if err := r.reconcileCheckWalArchiveFile(cluster); err != nil {
@@ -979,8 +979,9 @@ func (r *InstanceReconciler) reconcileMonitoringQueries(
 	r.metricsServerExporter.SetCustomQueries(queriesCollector)
 }
 
-// reconcileInstance sets the cluster reference in the instance
-func (r *InstanceReconciler) reconcileInstance(cluster *apiv1.Cluster) {
+// updateClusterCache updates the cached cluster in the instance for use
+// outside the reconciliation cycle when the API client is not available
+func (r *InstanceReconciler) updateClusterCache(cluster *apiv1.Cluster) {
 	r.instance.Cluster = cluster
 }
 

--- a/pkg/management/postgres/initdb.go
+++ b/pkg/management/postgres/initdb.go
@@ -299,7 +299,7 @@ func (info InitInfo) GetInstance(cluster *apiv1.Cluster) *Instance {
 	postgresInstance := NewInstance()
 	postgresInstance.PgData = info.PgData
 	postgresInstance.StartupOptions = []string{"listen_addresses='127.0.0.1'"}
-	postgresInstance.Cluster = cluster
+	postgresInstance.SetCluster(cluster)
 	return postgresInstance
 }
 

--- a/pkg/management/postgres/instance.go
+++ b/pkg/management/postgres/instance.go
@@ -423,6 +423,9 @@ func NewInstance() *Instance {
 		roleSynchronizerChan:       make(chan *apiv1.ManagedConfiguration),
 		tablespaceSynchronizerChan: make(chan map[string]apiv1.TablespaceConfiguration),
 		SessionID:                  string(uuid.NewUUID()),
+		// Initialize with an empty cluster to provide safe defaults for
+		// timeout/delay getters before the reconciler sets the real cluster
+		Cluster: &apiv1.Cluster{},
 	}
 }
 

--- a/pkg/management/postgres/instance.go
+++ b/pkg/management/postgres/instance.go
@@ -218,7 +218,9 @@ type Instance struct {
 
 	serverCertificateHandler serverCertificateHandler
 
-	// Cluster is the cluster this instance belongs to
+	// Cluster is the cluster this instance belongs to.
+	// Guaranteed non-nil: initialized as empty in NewInstance(),
+	// then set to the actual cluster by the reconciler.
 	Cluster *apiv1.Cluster
 }
 
@@ -293,10 +295,6 @@ func (instance *Instance) SetCanCheckReadiness(enabled bool) {
 // RequiresDesignatedPrimaryTransition checks if this instance is a primary
 // that needs to become a designated primary in a replica cluster
 func (instance *Instance) RequiresDesignatedPrimaryTransition() bool {
-	if instance.Cluster == nil {
-		return false
-	}
-
 	if !instance.Cluster.IsReplica() {
 		return false
 	}
@@ -766,10 +764,6 @@ func (instance *Instance) buildPostgresEnv() []string {
 	envMap, _ := envmap.Parse(env)
 	envMap["PG_OOM_ADJUST_FILE"] = "/proc/self/oom_score_adj"
 	envMap["PG_OOM_ADJUST_VALUE"] = "0"
-
-	if instance.Cluster == nil {
-		return envMap.StringSlice()
-	}
 
 	// If there are no additional library paths, we use the environment variables
 	// of the current process

--- a/pkg/management/postgres/instance_replica.go
+++ b/pkg/management/postgres/instance_replica.go
@@ -50,7 +50,7 @@ func (instance *Instance) RefreshReplicaConfiguration(
 		return changed, err
 	}
 
-	if primary && !instance.RequiresDesignatedPrimaryTransition {
+	if primary && !instance.RequiresDesignatedPrimaryTransition() {
 		return changed, nil
 	}
 

--- a/pkg/management/postgres/instance_test.go
+++ b/pkg/management/postgres/instance_test.go
@@ -424,6 +424,11 @@ var _ = Describe("NewInstance", func() {
 		instance := NewInstance()
 		Expect(instance.Cluster).ToNot(BeNil())
 	})
+
+	It("should generate a non-empty SessionID", func() {
+		instance := NewInstance()
+		Expect(instance.SessionID).ToNot(BeEmpty())
+	})
 })
 
 var _ = Describe("RequiresDesignatedPrimaryTransition", func() {

--- a/pkg/management/postgres/instance_test.go
+++ b/pkg/management/postgres/instance_test.go
@@ -451,12 +451,6 @@ var _ = Describe("RequiresDesignatedPrimaryTransition", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	It("should return false when Cluster is nil", func() {
-		instance.Cluster = nil
-		result := instance.RequiresDesignatedPrimaryTransition()
-		Expect(result).To(BeFalse())
-	})
-
 	It("should return false when cluster is not a replica", func() {
 		cluster.Spec.ReplicaCluster = nil
 		instance.Cluster = cluster

--- a/pkg/management/postgres/instance_test.go
+++ b/pkg/management/postgres/instance_test.go
@@ -419,6 +419,13 @@ var _ = Describe("GetPrimaryConnInfo", func() {
 	})
 })
 
+var _ = Describe("NewInstance", func() {
+	It("should initialize Cluster as non-nil", func() {
+		instance := NewInstance()
+		Expect(instance.Cluster).ToNot(BeNil())
+	})
+})
+
 var _ = Describe("RequiresDesignatedPrimaryTransition", func() {
 	var instance *Instance
 	var cluster *apiv1.Cluster
@@ -429,9 +436,8 @@ var _ = Describe("RequiresDesignatedPrimaryTransition", func() {
 		tempDir, err = os.MkdirTemp("", "test-primary")
 		Expect(err).ToNot(HaveOccurred())
 
-		instance = &Instance{
-			PgData: tempDir,
-		}
+		instance = NewInstance()
+		instance.PgData = tempDir
 
 		cluster = &apiv1.Cluster{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/management/postgres/promote.go
+++ b/pkg/management/postgres/promote.go
@@ -44,7 +44,7 @@ func (instance *Instance) PromoteAndWait(ctx context.Context) error {
 		instance.PgData,
 		"-w",
 		"promote",
-		"-t " + strconv.Itoa(int(instance.Cluster.GetPgCtlTimeoutForPromotion())),
+		"-t " + strconv.Itoa(int(instance.GetClusterOrDefault().GetPgCtlTimeoutForPromotion())),
 	}
 
 	contextLogger.Info("Promoting instance", "pgctl_options", options)

--- a/pkg/management/postgres/promote.go
+++ b/pkg/management/postgres/promote.go
@@ -44,7 +44,7 @@ func (instance *Instance) PromoteAndWait(ctx context.Context) error {
 		instance.PgData,
 		"-w",
 		"promote",
-		"-t " + strconv.Itoa(int(instance.PgCtlTimeoutForPromotion)),
+		"-t " + strconv.Itoa(int(instance.Cluster.GetPgCtlTimeoutForPromotion())),
 	}
 
 	contextLogger.Info("Promoting instance", "pgctl_options", options)

--- a/pkg/reconciler/replicaclusterswitch/conditions/conditions.go
+++ b/pkg/reconciler/replicaclusterswitch/conditions/conditions.go
@@ -17,7 +17,8 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 */
 
-package replicaclusterswitch
+// Package conditions contains utilities for working with replica cluster switch conditions
+package conditions
 
 import (
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -27,28 +28,32 @@ import (
 )
 
 const (
-	conditionDesignatedPrimaryTransition = "ReplicaClusterDesignatedPrimaryTransition"
-	conditionFence                       = "ReplicaClusterFencing"
-	// ConditionReplicaClusterSwitch is a consumer facing condition and should not be used to decide actions
+	// DesignatedPrimaryTransition is the condition type for designated primary transitions
+	DesignatedPrimaryTransition = "ReplicaClusterDesignatedPrimaryTransition"
+
+	// Fence is the condition type for replica cluster fencing
+	Fence = "ReplicaClusterFencing"
+
+	// ReplicaClusterSwitch is a consumer facing condition and should not be used to decide actions
 	// inside the code
-	ConditionReplicaClusterSwitch = "ReplicaClusterSwitch"
+	ReplicaClusterSwitch = "ReplicaClusterSwitch"
 )
 
 // IsDesignatedPrimaryTransitionRequested returns a boolean indicating if the instance primary should transition to
 // designated primary
 func IsDesignatedPrimaryTransitionRequested(cluster *apiv1.Cluster) bool {
-	return meta.IsStatusConditionFalse(cluster.Status.Conditions, conditionDesignatedPrimaryTransition)
+	return meta.IsStatusConditionFalse(cluster.Status.Conditions, DesignatedPrimaryTransition)
 }
 
-// isDesignatedPrimaryTransitionCompleted returns a boolean indicating if the transition is complete
-func isDesignatedPrimaryTransitionCompleted(cluster *apiv1.Cluster) bool {
-	return meta.IsStatusConditionTrue(cluster.Status.Conditions, conditionDesignatedPrimaryTransition)
+// IsDesignatedPrimaryTransitionCompleted returns a boolean indicating if the transition is complete
+func IsDesignatedPrimaryTransitionCompleted(cluster *apiv1.Cluster) bool {
+	return meta.IsStatusConditionTrue(cluster.Status.Conditions, DesignatedPrimaryTransition)
 }
 
 // SetDesignatedPrimaryTransitionCompleted creates the condition
 func SetDesignatedPrimaryTransitionCompleted(cluster *apiv1.Cluster) {
 	meta.SetStatusCondition(&cluster.Status.Conditions, metav1.Condition{
-		Type:    conditionDesignatedPrimaryTransition,
+		Type:    DesignatedPrimaryTransition,
 		Status:  metav1.ConditionTrue,
 		Reason:  "TransitionCompleted",
 		Message: "Instance Manager has completed the DesignatedPrimary transition",

--- a/tests/e2e/replica_mode_cluster_test.go
+++ b/tests/e2e/replica_mode_cluster_test.go
@@ -35,7 +35,7 @@ import (
 	k8client "sigs.k8s.io/controller-runtime/pkg/client"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
-	"github.com/cloudnative-pg/cloudnative-pg/pkg/reconciler/replicaclusterswitch"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/reconciler/replicaclusterswitch/conditions"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 	"github.com/cloudnative-pg/cloudnative-pg/tests"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/backups"
@@ -154,9 +154,9 @@ var _ = Describe("Replica Mode", Label(tests.LabelReplication), func() {
 			)
 			var clusterOnePrimary, clusterTwoPrimary *corev1.Pod
 
-			getReplicaClusterSwitchCondition := func(conditions []metav1.Condition) *metav1.Condition {
-				for _, condition := range conditions {
-					if condition.Type == replicaclusterswitch.ConditionReplicaClusterSwitch {
+			getReplicaClusterSwitchCondition := func(conds []metav1.Condition) *metav1.Condition {
+				for _, condition := range conds {
+					if condition.Type == conditions.ReplicaClusterSwitch {
 						return &condition
 					}
 				}


### PR DESCRIPTION
The Instance struct was caching cluster configuration values in separate fields, hiding their original source and making the code harder to understand. This refactoring improves clarity by accessing cluster configuration directly through the cluster object.

The Cluster field is now private with GetClusterOrDefault() and SetCluster() methods providing encapsulation and lazy initialization. The getter returns an empty cluster when nil, providing safe defaults without explicit initialization. This eliminates the need for cached timeout fields (PgCtlTimeoutForPromotion, MaxSwitchoverDelay, MaxStopDelay, SmartStopDelay) while making it obvious where configuration values originate.

RequiresDesignatedPrimaryTransition has been converted from a cached field to a method on Instance, keeping the logic close to where it's used. The conditions package has been moved to replicaclusterswitch/conditions for better import organization.