### PR TITLE
feat(api): add initContainerResources field to configure init contain…

### DIFF
--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -387,6 +387,12 @@ type ClusterSpec struct {
 	// +optional
 	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
 
+	// InitContainerResources defines the resource requirements for init containers.
+	// If not specified, init containers will use the same resources as the main
+	// PostgreSQL container (Resources field).
+	// +optional
+	InitContainerResources *corev1.ResourceRequirements `json:"initContainerResources,omitempty"`
+
 	// EphemeralVolumesSizeLimit allows the user to set the limits for the ephemeral
 	// volumes
 	// +optional

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -777,6 +777,11 @@ func (in *ClusterSpec) DeepCopyInto(out *ClusterSpec) {
 		}
 	}
 	in.Resources.DeepCopyInto(&out.Resources)
+	if in.InitContainerResources != nil {
+		in, out := &in.InitContainerResources, &out.InitContainerResources
+		*out = new(corev1.ResourceRequirements)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.EphemeralVolumesSizeLimit != nil {
 		in, out := &in.EphemeralVolumesSizeLimit, &out.EphemeralVolumesSizeLimit
 		*out = new(EphemeralVolumesSizeLimitConfiguration)

--- a/config/crd/bases/postgresql.cnpg.io_clusters.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_clusters.yaml
@@ -3216,6 +3216,68 @@ spec:
                       type: string
                     type: object
                 type: object
+              initContainerResources:
+                description: |-
+                  InitContainerResources defines the resource requirements for init containers.
+                  If not specified, init containers will use the same resources as the main
+                  PostgreSQL container (Resources field).
+                properties:
+                  claims:
+                    description: |-
+                      Claims lists the names of resources, defined in spec.resourceClaims,
+                      that are used by this container.
+
+                      This field depends on the
+                      DynamicResourceAllocation feature gate.
+
+                      This field is immutable. It can only be set for containers.
+                    items:
+                      description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                      properties:
+                        name:
+                          description: |-
+                            Name must match the name of one entry in pod.spec.resourceClaims of
+                            the Pod where this field is used. It makes that resource available
+                            inside a container.
+                          type: string
+                        request:
+                          description: |-
+                            Request is the name chosen for a request in the referenced claim.
+                            If empty, everything from the claim is made available, otherwise
+                            only the result of this request.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                  limits:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: |-
+                      Limits describes the maximum amount of compute resources allowed.
+                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    type: object
+                  requests:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: |-
+                      Requests describes the minimum amount of compute resources required.
+                      If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                      otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    type: object
+                type: object
               instances:
                 default: 1
                 description: Number of instances required in the cluster

--- a/pkg/specs/containers.go
+++ b/pkg/specs/containers.go
@@ -32,6 +32,12 @@ import (
 // createBootstrapContainer creates the init container bootstrapping the operator
 // executable inside the generated Pods
 func createBootstrapContainer(cluster apiv1.Cluster) corev1.Container {
+	// Use InitContainerResources if specified, otherwise fall back to main container Resources
+	resources := cluster.Spec.Resources
+	if cluster.Spec.InitContainerResources != nil {
+		resources = *cluster.Spec.InitContainerResources
+	}
+
 	container := corev1.Container{
 		Name:            BootstrapControllerContainerName,
 		Image:           configuration.Current.OperatorImageName,
@@ -42,7 +48,7 @@ func createBootstrapContainer(cluster apiv1.Cluster) corev1.Container {
 			"/controller/manager",
 		},
 		VolumeMounts:    CreatePostgresVolumeMounts(cluster),
-		Resources:       cluster.Spec.Resources,
+		Resources:       resources,
 		SecurityContext: GetSecurityContext(&cluster),
 	}
 


### PR DESCRIPTION
…er resources

This change allows users to specify separate resource requirements (CPU/memory requests and limits) for init containers, independently from the main PostgreSQL container resources.

If initContainerResources is not specified, init containers will use the same resources as the main container (existing behavior).

- Add InitContainerResources field to ClusterSpec
- Update createBootstrapContainer to use the new field
- Add webhook validation for initContainerResources
- Add unit tests for the new validation