### PR TITLE
test(e2e): optimize MinIO test resource usage

### DIFF
--- a/tests/e2e/backup_restore_minio_test.go
+++ b/tests/e2e/backup_restore_minio_test.go
@@ -112,6 +112,13 @@ var _ = Describe("MinIO - Backup and restore", Label(tests.LabelBackupRestore), 
 			})
 		})
 
+		AfterAll(func() {
+			// While namespace deletion would handle this implicitly, explicit deletion helps:
+			// - Identify any deletion issues early and in a more clear way rather than waiting for namespace cleanup
+			err := DeleteResourcesFromFile(namespace, clusterWithMinioSampleFile)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
 		// We back up and restore a cluster, and verify some expected data to
 		// be there
 		It("backs up and restores a cluster using minio", func() {

--- a/tests/e2e/backup_restore_minio_test.go
+++ b/tests/e2e/backup_restore_minio_test.go
@@ -322,6 +322,11 @@ var _ = Describe("MinIO - Backup and restore", Label(tests.LabelBackupRestore), 
 					return cluster.Status.FirstRecoverabilityPoint, err //nolint:staticcheck
 				}, 30).ShouldNot(BeEmpty())
 			})
+
+			By("deleting the standby cluster", func() {
+				err = DeleteResourcesFromFile(namespace, clusterWithMinioStandbySampleFile)
+				Expect(err).ToNot(HaveOccurred())
+			})
 		})
 
 		// We backup and restore a cluster from a standby, and verify some expected data to

--- a/tests/e2e/fixtures/backup/minio/cluster-with-backup-minio-custom-servername.yaml.template
+++ b/tests/e2e/fixtures/backup/minio/cluster-with-backup-minio-custom-servername.yaml.template
@@ -3,7 +3,7 @@ kind: Cluster
 metadata:
   name: pg-backup-minio-custom
 spec:
-  instances: 2
+  instances: 1
 
   postgresql:
     parameters:

--- a/tests/e2e/fixtures/backup/recovery_external_clusters/source-cluster-minio-01.yaml.template
+++ b/tests/e2e/fixtures/backup/recovery_external_clusters/source-cluster-minio-01.yaml.template
@@ -3,7 +3,7 @@ kind: Cluster
 metadata:
   name: source-cluster-minio
 spec:
-  instances: 2
+  instances: 1
 
   postgresql:
     parameters:


### PR DESCRIPTION
This PR reduces resource consumption during MinIO E2E tests through targeted optimizations to cluster configurations and test cleanup.

The changes reduce instance count from 2 to 1 for test clusters that don't require standbys: the custom serverName test cluster and the recovery test source cluster. Both clusters explicitly set backup.target to primary, so reducing to 1 instance doesn't change their backup behavior or test coverage.

Additionally, the standby backup test cluster is now explicitly deleted immediately after its test completes, freeing resources earlier instead of waiting for namespace cleanup.

The main cluster, standby test cluster, and primary test cluster remain at 2 instances since they require standby replicas for switchover testing, prefer-standby backup testing, and backup target override verification.

This reduces peak PostgreSQL instance count during MinIO E2E tests from 8+ to 7, with an estimated 12-25% reduction in CPU and memory consumption during test execution.