### PR TITLE
test(e2e): optimize Azure and Azurite test resource usage

### DIFF
--- a/tests/e2e/fixtures/backup/azure_blob/cluster-with-backup-azure-blob.yaml.template
+++ b/tests/e2e/fixtures/backup/azure_blob/cluster-with-backup-azure-blob.yaml.template
@@ -3,7 +3,7 @@ kind: Cluster
 metadata:
   name: pg-backup-azure-blob
 spec:
-  instances: 2
+  instances: 1
 
   postgresql:
     parameters:

--- a/tests/e2e/fixtures/backup/azurite/cluster-backup.yaml.template
+++ b/tests/e2e/fixtures/backup/azurite/cluster-backup.yaml.template
@@ -3,7 +3,7 @@ kind: Cluster
 metadata:
   name: pg-backup-azurite
 spec:
-  instances: 2
+  instances: 1
 
   # Persistent storage configuration
   storage:

--- a/tests/e2e/fixtures/backup/recovery_external_clusters/cluster-with-backup-azure-blob-sas.yaml.template
+++ b/tests/e2e/fixtures/backup/recovery_external_clusters/cluster-with-backup-azure-blob-sas.yaml.template
@@ -3,7 +3,7 @@ kind: Cluster
 metadata:
   name: pg-backup-azure-blob-sas
 spec:
-  instances: 2
+  instances: 1
 
   postgresql:
     parameters:

--- a/tests/e2e/fixtures/backup/recovery_external_clusters/source-cluster-azure-blob-01.yaml.template
+++ b/tests/e2e/fixtures/backup/recovery_external_clusters/source-cluster-azure-blob-01.yaml.template
@@ -3,7 +3,7 @@ kind: Cluster
 metadata:
   name: source-cluster-azure
 spec:
-  instances: 2
+  instances: 1
 
   postgresql:
     parameters:


### PR DESCRIPTION
Reduce instance count from 2 to 1 for backup source clusters in Azure Blob and Azurite E2E tests. Source clusters explicitly configure backup.target as primary, meaning they don't require standby replicas for backup operations.

Restore clusters remain at 2 instances because tests verify that replication works correctly after restore operations by checking that restored standbys are streaming from the primary.

This optimization applies to 4 source cluster templates used for creating backups, while keeping 5 restore cluster templates at 2 instances for proper replication test coverage. The changes reduce peak concurrent PostgreSQL instances during backup creation from 2 to 1 per source cluster, achieving resource savings while maintaining full test coverage of restore and replication scenarios.