### PR TITLE
fix(plugin,status): display "Disabled" for skipWalArchiving annotation

### DIFF
--- a/internal/cmd/plugin/status/status.go
+++ b/internal/cmd/plugin/status/status.go
@@ -630,7 +630,6 @@ func (fullStatus *PostgresqlStatus) printWALArchivingStatus(status *tabby.Tabby)
 		status.AddLine("No Primary instance found")
 		return
 	}
-	// Check if WAL archiving is disabled via annotation
 	isWalArchivingDisabled := fullStatus.Cluster != nil &&
 		utils.IsWalArchivingDisabled(&fullStatus.Cluster.ObjectMeta)
 

--- a/internal/cmd/plugin/status/status.go
+++ b/internal/cmd/plugin/status/status.go
@@ -630,8 +630,15 @@ func (fullStatus *PostgresqlStatus) printWALArchivingStatus(status *tabby.Tabby)
 		status.AddLine("No Primary instance found")
 		return
 	}
+	// Check if WAL archiving is disabled via annotation
+	isWalArchivingDisabled := fullStatus.Cluster != nil &&
+		utils.IsWalArchivingDisabled(&fullStatus.Cluster.ObjectMeta)
+
 	status.AddLine("Working WAL archiving:",
-		getWalArchivingStatus(primaryInstanceStatus.IsArchivingWAL, primaryInstanceStatus.LastFailedWAL))
+		getWalArchivingStatus(
+			primaryInstanceStatus.IsArchivingWAL,
+			primaryInstanceStatus.LastFailedWAL,
+			isWalArchivingDisabled))
 	status.AddLine("WALs waiting to be archived:", primaryInstanceStatus.ReadyWALFiles)
 
 	if primaryInstanceStatus.LastArchivedWAL == "" {
@@ -648,8 +655,10 @@ func (fullStatus *PostgresqlStatus) printWALArchivingStatus(status *tabby.Tabby)
 	}
 }
 
-func getWalArchivingStatus(isArchivingWAL bool, lastFailedWAL string) string {
+func getWalArchivingStatus(isArchivingWAL bool, lastFailedWAL string, isWalArchivingDisabled bool) string {
 	switch {
+	case isWalArchivingDisabled:
+		return aurora.Yellow("Disabled").String()
 	case isArchivingWAL:
 		return aurora.Green("OK").String()
 	case lastFailedWAL != "":

--- a/internal/cmd/plugin/status/status_test.go
+++ b/internal/cmd/plugin/status/status_test.go
@@ -96,6 +96,11 @@ var _ = Describe("getWalArchivingStatus", func() {
 		Expect(result).To(ContainSubstring("Failing"))
 	})
 
+	It("should return 'OK' even when there is a failed WAL if archiving is working", func() {
+		result := getWalArchivingStatus(true, "000000010000000000000001", false)
+		Expect(result).To(ContainSubstring("OK"))
+	})
+
 	It("should return 'Starting Up' when archiving hasn't started yet", func() {
 		result := getWalArchivingStatus(false, "", false)
 		Expect(result).To(ContainSubstring("Starting Up"))

--- a/internal/cmd/plugin/status/status_test.go
+++ b/internal/cmd/plugin/status/status_test.go
@@ -79,3 +79,31 @@ var _ = Describe("getPrimaryPromotionTime", func() {
 		})
 	})
 })
+
+var _ = Describe("getWalArchivingStatus", func() {
+	It("should return 'Disabled' when WAL archiving is disabled", func() {
+		result := getWalArchivingStatus(false, "", true)
+		Expect(result).To(ContainSubstring("Disabled"))
+	})
+
+	It("should return 'OK' when archiving is working", func() {
+		result := getWalArchivingStatus(true, "", false)
+		Expect(result).To(ContainSubstring("OK"))
+	})
+
+	It("should return 'Failing' when there is a failed WAL", func() {
+		result := getWalArchivingStatus(false, "000000010000000000000001", false)
+		Expect(result).To(ContainSubstring("Failing"))
+	})
+
+	It("should return 'Starting Up' when archiving hasn't started yet", func() {
+		result := getWalArchivingStatus(false, "", false)
+		Expect(result).To(ContainSubstring("Starting Up"))
+	})
+
+	It("should prioritize 'Disabled' over other statuses", func() {
+		// Even if archiving is working, disabled should take precedence
+		result := getWalArchivingStatus(true, "", true)
+		Expect(result).To(ContainSubstring("Disabled"))
+	})
+})


### PR DESCRIPTION
The status command now correctly shows "Disabled" instead of "Starting Up" when a cluster has the cnpg.io/skipWalArchiving annotation enabled.

Closes #9692 
