### PR TITLE
Fix(status): add skipWalArchiving annotation check and update status logic

### DIFF
--- a/internal/cmd/plugin/status/status.go
+++ b/internal/cmd/plugin/status/status.go
@@ -630,9 +630,11 @@ func (fullStatus *PostgresqlStatus) printWALArchivingStatus(status *tabby.Tabby)
 		status.AddLine("No Primary instance found")
 		return
 	}
-	isConfigured := fullStatus.Cluster.Spec.Backup != nil &&
-		fullStatus.Cluster.Spec.Backup.BarmanObjectStore != nil &&
-		utils.IsWalArchivingDisabled(&fullStatus.Cluster.ObjectMeta) == false
+	pluginEnabled, _ := isBarmanCloudPluginEnabled(fullStatus.Cluster)
+	isConfigured := !utils.IsWalArchivingDisabled(&fullStatus.Cluster.ObjectMeta) &&
+		((fullStatus.Cluster.Spec.Backup != nil &&
+			fullStatus.Cluster.Spec.Backup.BarmanObjectStore != nil) ||
+			pluginEnabled)
 	status.AddLine("Working WAL archiving:",
 		getWalArchivingStatus(primaryInstanceStatus.IsArchivingWAL, primaryInstanceStatus.LastFailedWAL, isConfigured))
 	status.AddLine("WALs waiting to be archived:", primaryInstanceStatus.ReadyWALFiles)

--- a/internal/cmd/plugin/status/status.go
+++ b/internal/cmd/plugin/status/status.go
@@ -623,16 +623,6 @@ func isBarmanCloudPluginEnabled(cluster *apiv1.Cluster) (bool, map[string]string
 	return false, nil
 }
 
-// isSkipWalArchivingEnabled checks if the skipWalArchiving annotation is set to "enabled"
-func isSkipWalArchivingEnabled(cluster *apiv1.Cluster) bool {
-	if cluster == nil {
-		return false
-	}
-
-	value, ok := cluster.Annotations[utils.SkipWalArchiving]
-	return ok && value == "enabled"
-}
-
 // printWALArchivingStatus prints the WAL archiving status to the provided tabby table
 func (fullStatus *PostgresqlStatus) printWALArchivingStatus(status *tabby.Tabby) {
 	primaryInstanceStatus := fullStatus.tryGetPrimaryInstance()
@@ -642,7 +632,7 @@ func (fullStatus *PostgresqlStatus) printWALArchivingStatus(status *tabby.Tabby)
 	}
 	isConfigured := fullStatus.Cluster.Spec.Backup != nil &&
 		fullStatus.Cluster.Spec.Backup.BarmanObjectStore != nil &&
-		!isSkipWalArchivingEnabled(fullStatus.Cluster)
+		utils.IsWalArchivingDisabled(&fullStatus.Cluster.ObjectMeta) == false
 	status.AddLine("Working WAL archiving:",
 		getWalArchivingStatus(primaryInstanceStatus.IsArchivingWAL, primaryInstanceStatus.LastFailedWAL, isConfigured))
 	status.AddLine("WALs waiting to be archived:", primaryInstanceStatus.ReadyWALFiles)

--- a/internal/cmd/plugin/status/status.go
+++ b/internal/cmd/plugin/status/status.go
@@ -629,7 +629,7 @@ func isSkipWalArchivingEnabled(cluster *apiv1.Cluster) bool {
 		return false
 	}
 
-	value, ok := cluster.Annotations["cnpg.io/skipWalArchiving"]
+	value, ok := cluster.Annotations[utils.SkipWalArchiving]
 	return ok && value == "enabled"
 }
 

--- a/internal/cmd/plugin/status/status_test.go
+++ b/internal/cmd/plugin/status/status_test.go
@@ -79,3 +79,54 @@ var _ = Describe("getPrimaryPromotionTime", func() {
 		})
 	})
 })
+
+var _ = Describe("getWalArchivingStatus", func() {
+
+	Context("when WAL archiving is not configured", func() {
+		It("should return Disabled", func() {
+			result := getWalArchivingStatus(
+				false,
+				"",
+				false,
+			)
+
+			Expect(result).To(ContainSubstring("Disabled"))
+		})
+	})
+
+	Context("when WAL archiving is working", func() {
+		It("should return OK", func() {
+			result := getWalArchivingStatus(
+				true,
+				"",
+				true,
+			)
+
+			Expect(result).To(ContainSubstring("OK"))
+		})
+	})
+
+	Context("when WAL archiving is failing", func() {
+		It("should return Failing", func() {
+			result := getWalArchivingStatus(
+				false,
+				"0000000101",
+				true,
+			)
+
+			Expect(result).To(ContainSubstring("Failing"))
+		})
+	})
+
+	Context("when WAL archiving is configured but not yet started", func() {
+		It("should return Starting Up", func() {
+			result := getWalArchivingStatus(
+				false,
+				"",
+				true,
+			)
+
+			Expect(result).To(ContainSubstring("Starting Up"))
+		})
+	})
+})

--- a/internal/cmd/plugin/status/status_test.go
+++ b/internal/cmd/plugin/status/status_test.go
@@ -81,7 +81,6 @@ var _ = Describe("getPrimaryPromotionTime", func() {
 })
 
 var _ = Describe("getWalArchivingStatus", func() {
-
 	Context("when WAL archiving is not configured", func() {
 		It("should return Disabled", func() {
 			result := getWalArchivingStatus(


### PR DESCRIPTION
Fix #9692 

The WAL archiving status logic has been updated to explicitly check whether WAL archiving is configured and enabled, taking into account:

the presence of continuous backup configuration, and

the cnpg.io/skipWalArchiving annotation.

Based on this, the CLI now correctly reports:

Disabled when WAL archiving is intentionally skipped

Starting Up only when archiving is configured but not yet active

OK when WAL archiving is running

Failing when failures are detected

### Result

For clusters with cnpg.io/skipWalArchiving: enabled, kubectl cnpg status now correctly shows:
```yaml
Working WAL archiving: Disabled
```

- CLI-only change
- No behavioral changes to the controller or WAL archiving logic
- Improves correctness and clarity of status reporting