### PR TITLE
docs: Update PodMonitor examples to use distinct names from clusters

### DIFF
--- a/docs/src/monitoring.md
+++ b/docs/src/monitoring.md
@@ -99,7 +99,7 @@ find `PodMonitor` resources.
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
-  name: cluster-example
+  name: cluster-example-podmonitor
 spec:
   selector:
     matchLabels:
@@ -109,7 +109,9 @@ spec:
 ```
 
 :::info[Important Configuration Details]
-    - `metadata.name`: Give your `PodMonitor` a unique name.
+    - `metadata.name`: Give your `PodMonitor` a unique name that differs from your
+      cluster name to avoid conflicts with the operator. For example, if your cluster
+      is named `cluster-example`, you might name the PodMonitor `cluster-example-podmonitor`.
     - `spec.namespaceSelector`: Use this to specify the namespace where
       your PostgreSQL cluster is running.
     - `spec.selector.matchLabels`: You must use the `cnpg.io/cluster: <cluster-name>`
@@ -121,6 +123,8 @@ spec:
 :::warning[Feature Deprecation Notice]
     The `.spec.monitoring.enablePodMonitor` field in the `Cluster` resource is
     now deprecated and will be removed in a future version of the operator.
+    See [issue #8075](https://github.com/cloudnative-pg/cloudnative-pg/issues/8075)
+    for more details.
 :::
 
 If you are currently using this feature, we strongly recommend you either
@@ -128,6 +132,15 @@ remove or set `.spec.monitoring.enablePodMonitor` to `false` and manually
 create a `PodMonitor` resource for your cluster as described above.
 This change ensures that you have complete ownership of your monitoring
 configuration, preventing it from being managed or overwritten by the operator.
+
+:::warning[Naming Conflict]
+    When manually creating a `PodMonitor`, ensure its `metadata.name` differs from
+    your cluster's name. If you disable `.spec.monitoring.enablePodMonitor` and create
+    a manual `PodMonitor` with the same name as your cluster, the operator will delete it
+    during reconciliation. See [issue #6109](https://github.com/cloudnative-pg/cloudnative-pg/issues/6109)
+    for details. For example, a suffix like `-podmonitor` (e.g., `cluster-example-podmonitor`)
+    can avoid this conflict.
+:::
 
 ### Enabling TLS on the Metrics Port
 
@@ -149,7 +162,7 @@ adjust as needed:
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
-  name: cluster-example
+  name: cluster-example-podmonitor
 spec:
   selector:
     matchLabels:
@@ -166,8 +179,8 @@ spec:
 ```
 
 :::info[Important]
-    Ensure you modify the example above with a unique name, as well as the
-    correct Cluster's namespace and labels (e.g., `cluster-example`).
+    Ensure you modify the example above with a unique name that differs from your
+    cluster name, as well as the correct Cluster's namespace and labels (e.g., `cluster-example`).
 :::
 
 :::info[Important]

--- a/docs/src/quickstart.md
+++ b/docs/src/quickstart.md
@@ -273,7 +273,7 @@ spec:
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
-  name: cluster-with-metrics
+  name: cluster-with-metrics-podmonitor
 spec:
   selector:
     matchLabels:

--- a/docs/src/samples/cluster-example-monitoring.yaml
+++ b/docs/src/samples/cluster-example-monitoring.yaml
@@ -19,7 +19,7 @@ spec:
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
-  name: cluster-example
+  name: cluster-example-podmonitor
 spec:
   selector:
     matchLabels:


### PR DESCRIPTION
For documentation of current CNPG versions, update all manual PodMonitor
examples in the documentation to use names that differ from the cluster
name (e.g., 'cluster-example-podmonitor' instead of 'cluster-example').

This change addresses a known issue where manually created PodMonitors
with the same name as the cluster are deleted by the operator during
reconciliation when .spec.monitoring.enablePodMonitor is disabled.

The pattern of using a suffix like '-podmonitor' ensures clear
separation between operator-managed and user-managed resources, and
prevents unintended deletion during operator reconciliation.

In future versions of CNPG once the deletion behavior is removed, we can
update the language here to indicate it applies only to older versions,
or we can remove this text.

Related to: #8075 (deprecation of enablePodMonitor)
Fixes naming conflict described in: #6109

Signed-off-by: Jeremy Schneider <schneider@ardentperf.com>
