### PR TITLE
test(e2e): reduce cluster instances in initdb tests

### DIFF
--- a/tests/e2e/fixtures/initdb/cluster-custom-locale.yaml.template
+++ b/tests/e2e/fixtures/initdb/cluster-custom-locale.yaml.template
@@ -4,7 +4,7 @@ kind: Cluster
 metadata:
   name: p-locale
 spec:
-  instances: 3
+  instances: 1
 
   postgresql:
     parameters:

--- a/tests/e2e/fixtures/initdb/cluster-postinit-sql.yaml.template
+++ b/tests/e2e/fixtures/initdb/cluster-postinit-sql.yaml.template
@@ -4,7 +4,7 @@ kind: Cluster
 metadata:
   name: p-postinit-sql
 spec:
-  instances: 3
+  instances: 1
 
   postgresql:
     parameters:


### PR DESCRIPTION
The initdb e2e tests (postinit-sql and custom-locale) only query the primary pod to verify SQL execution and locale settings. They do not test standby streaming, replication, or any replica-specific behavior.

Reduced cluster instances from 3 to 1 in:
- cluster-postinit-sql.yaml.template
- cluster-custom-locale.yaml.template

This optimization reduces resource consumption and test execution time without sacrificing test coverage. 
