### PR TITLE
test(e2e): reduce cluster instances in tolerations test

### DIFF
--- a/tests/e2e/fixtures/tolerations/cluster-tolerations.yaml.template
+++ b/tests/e2e/fixtures/tolerations/cluster-tolerations.yaml.template
@@ -3,7 +3,7 @@ kind: Cluster
 metadata:
   name: cluster-tolerations
 spec:
-  instances: 3
+  instances: 1
 
   affinity:
       tolerations:

--- a/tests/e2e/tolerations_test.go
+++ b/tests/e2e/tolerations_test.go
@@ -30,8 +30,8 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-// Set of tests in which we check that the operator is able to failover primary and brings back
-// replicas when we drain node
+// Set of tests in which we verify that Cluster's pods can be scheduled on tainted nodes
+// when proper tolerations are configured
 var _ = Describe("E2E Tolerations Node", Serial, Label(tests.LabelDisruptive, tests.LabelPodScheduling), func() {
 	var taintedNodes []string
 	var namespace string


### PR DESCRIPTION
The tolerations e2e test only verifies that PostgreSQL pods can be scheduled on tainted nodes when proper tolerations are configured. It does not test failover, switchover, or any replica-specific behavior.

Reduced cluster instances from 3 to 1 in cluster-tolerations.yaml.template.

This optimization reduces resource consumption and test execution time without sacrificing test coverage.