### PR TITLE
Resets superuser secret when access is disabled

### DIFF
--- a/internal/controller/cluster_status.go
+++ b/internal/controller/cluster_status.go
@@ -566,6 +566,9 @@ func (r *ClusterReconciler) refreshSecretResourceVersions(ctx context.Context, c
 			return err
 		}
 		versions.SuperuserSecretVersion = version
+	} else {
+		// Resets the version when superuser access is disabled
+		versions.SuperuserSecretVersion = ""
 	}
 
 	version, err = r.getSecretResourceVersion(ctx, cluster, cluster.GetApplicationSecretName())


### PR DESCRIPTION
Fixes #9721 

Added a else clause in `internal/controller/cluster_status.go` which clears `SuperuserSecretVersion` when superuser access is disabled, so credentials can be reapplied when access is enabled again