### PR TITLE
chore(olm-samples): update PostgreSQL images to current versions

### DIFF
--- a/config/olm-samples/postgresql_v1_clusterimagecatalog.yaml
+++ b/config/olm-samples/postgresql_v1_clusterimagecatalog.yaml
@@ -5,6 +5,6 @@ metadata:
 spec:
   images:
     - major: 15
-      image: ghcr.io/cloudnative-pg/postgresql:15.6
+      image: ghcr.io/cloudnative-pg/postgresql:15.15-system-trixie
     - major: 16
-      image: ghcr.io/cloudnative-pg/postgresql:16.2
+      image: ghcr.io/cloudnative-pg/postgresql:16.11-system-trixie

--- a/config/olm-samples/postgresql_v1_imagecatalog.yaml
+++ b/config/olm-samples/postgresql_v1_imagecatalog.yaml
@@ -6,6 +6,6 @@ metadata:
 spec:
   images:
     - major: 15
-      image: ghcr.io/cloudnative-pg/postgresql:15.6
+      image: ghcr.io/cloudnative-pg/postgresql:15.15-system-trixie
     - major: 16
-      image: ghcr.io/cloudnative-pg/postgresql:16.2
+      image: ghcr.io/cloudnative-pg/postgresql:16.11-system-trixie


### PR DESCRIPTION
Updated `ImageCatalog` and `ClusterImageCatalog` sample files to use current PostgreSQL image versions as defined in `pg_versions.json`.

Updated images:
- PostgreSQL 15: `15.6` -> `15.15-system-trixie`
- PostgreSQL 16: `16.2` -> `16.11-system-trixie`

Fixes: #9282