### PR TITLE
docs: add category metadata for autogenerated sidebar

### DIFF
--- a/docs/src/appendixes/_category_.json
+++ b/docs/src/appendixes/_category_.json
@@ -1,0 +1,7 @@
+{
+  "label": "Appendixes",
+  "position": 600,
+  "link": {
+    "type": "generated-index"
+  }
+}

--- a/docs/src/cncf-projects/_category_.json
+++ b/docs/src/cncf-projects/_category_.json
@@ -1,0 +1,7 @@
+{
+  "label": "CNCF Projects Integrations",
+  "position": 590,
+  "link": {
+    "type": "generated-index"
+  }
+}


### PR DESCRIPTION
Add \_category_.json files to define category metadata for CNCF Projects Integrations and Appendixes sections, enabling autogenerated sidebar in Docusaurus documentation.

This simplifies sidebar maintenance by using document metadata and category files instead of manual configuration.

Related to cloudnative-pg/docs#20 