### PR TITLE
Docs: Add default keys for cluster bootstrap values

### DIFF
--- a/docs/src/database_import.md
+++ b/docs/src/database_import.md
@@ -113,6 +113,8 @@ spec:
   instances: 3
 
   bootstrap:
+    database: angus
+    # owner: angus
     initdb:
       import:
         type: microservice

--- a/docs/src/samples/cluster-example-logical-destination.yaml
+++ b/docs/src/samples/cluster-example-logical-destination.yaml
@@ -9,6 +9,8 @@ spec:
     size: 1Gi
 
   bootstrap:
+    # database: app
+    # owner: app
     initdb:
       import:
         type: microservice


### PR DESCRIPTION
Update docs to be a bit more clear about the default values for the replication cases when using `microservice`-based bootstrap.

Hopefully this makes logical replication-based upgrades more clear - #9771 