### PR TITLE
docs(apidoc): transform Go map syntax to JSON-like format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -305,6 +305,8 @@ apidoc: crd-ref-docs ## Update the API Reference section of the documentation.
 		--max-depth 15 \
 		--templates-dir docs/crd-gen-refs/markdown \
 		--output-path docs/src/cloudnative-pg.v1.md
+	@echo "Escaping Markdown directives in generated API documentation..."
+	sed -i 's/:map\[\([^]]*\)\]/\\: \\{ \1 \\}/g' docs/src/cloudnative-pg.v1.md
 
 ##@ Cleanup
 

--- a/docs/src/cloudnative-pg.v1.md
+++ b/docs/src/cloudnative-pg.v1.md
@@ -576,7 +576,7 @@ _Appears in:_
 | `minSyncReplicas` _integer_ | Minimum number of instances required in synchronous replication with the<br />primary. Undefined or 0 allow writes to complete when no standby is<br />available. |  | 0 | Minimum: 0 <br /> |
 | `maxSyncReplicas` _integer_ | The target value for the synchronous replication quorum, that can be<br />decreased if the number of ready standbys is lower than this.<br />Undefined or 0 disable synchronous replication. |  | 0 | Minimum: 0 <br /> |
 | `postgresql` _[PostgresConfiguration](#postgresconfiguration)_ | Configuration of the PostgreSQL server |  |  |  |
-| `replicationSlots` _[ReplicationSlotsConfiguration](#replicationslotsconfiguration)_ | Replication slots management configuration |  | \{ highAvailability:map[enabled:true] \} |  |
+| `replicationSlots` _[ReplicationSlotsConfiguration](#replicationslotsconfiguration)_ | Replication slots management configuration |  | \{ highAvailability\: \{ enabled:true \} \} |  |
 | `bootstrap` _[BootstrapConfiguration](#bootstrapconfiguration)_ | Instructions to bootstrap this cluster |  |  |  |
 | `replica` _[ReplicaClusterConfiguration](#replicaclusterconfiguration)_ | Replica cluster configuration |  |  |  |
 | `superuserSecret` _[LocalObjectReference](https://pkg.go.dev/github.com/cloudnative-pg/machinery/pkg/api#LocalObjectReference)_ | The secret containing the superuser password. If not defined a new<br />secret will be created with a randomly generated password |  |  |  |


### PR DESCRIPTION
Transform Go map representation (map[key:value]) to JSON-like syntax ({ key:value }) in generated API documentation, making default values more intuitive for users unfamiliar with Go.

Closes #9776 