### PR TITLE
api: fix DisabledDefaultServices enum validation

### DIFF
--- a/api/v1/cluster_funcs.go
+++ b/api/v1/cluster_funcs.go
@@ -1410,16 +1410,13 @@ func (cluster *Cluster) IsReadServiceEnabled() bool {
 		return true
 	}
 
-	return !slices.Contains(cluster.Spec.Managed.Services.DisabledDefaultServices, ServiceSelectorTypeR)
+	return !slices.Contains(cluster.Spec.Managed.Services.DisabledDefaultServices, DisabledDefaultServiceSelectorTypeR)
 }
 
 // IsReadWriteServiceEnabled checks if the read-write service is enabled for the cluster.
-// It returns false if the read-write service is listed in the DisabledDefaultServices slice.
+// The read-write service cannot be disabled, so this always returns true.
 func (cluster *Cluster) IsReadWriteServiceEnabled() bool {
-	if cluster.Spec.Managed == nil || cluster.Spec.Managed.Services == nil {
-		return true
-	}
-	return !slices.Contains(cluster.Spec.Managed.Services.DisabledDefaultServices, ServiceSelectorTypeRW)
+	return true
 }
 
 // IsReadOnlyServiceEnabled checks if the read-only service is enabled for the cluster.
@@ -1429,7 +1426,7 @@ func (cluster *Cluster) IsReadOnlyServiceEnabled() bool {
 		return true
 	}
 
-	return !slices.Contains(cluster.Spec.Managed.Services.DisabledDefaultServices, ServiceSelectorTypeRO)
+	return !slices.Contains(cluster.Spec.Managed.Services.DisabledDefaultServices, DisabledDefaultServiceSelectorTypeRO)
 }
 
 // GetRecoverySourcePlugin returns the configuration of the plugin being

--- a/api/v1/cluster_funcs_test.go
+++ b/api/v1/cluster_funcs_test.go
@@ -530,9 +530,9 @@ var _ = Describe("look up for secrets", Ordered, func() {
 		})
 
 		It("should not generate the default service names if disabled", func() {
-			cluster.Spec.Managed.Services.DisabledDefaultServices = []ServiceSelectorType{
-				ServiceSelectorTypeRO,
-				ServiceSelectorTypeR,
+			cluster.Spec.Managed.Services.DisabledDefaultServices = []DisabledDefaultServiceSelectorType{
+				DisabledDefaultServiceSelectorTypeRO,
+				DisabledDefaultServiceSelectorTypeR,
 			}
 			namesSet := stringset.From(cluster.GetClusterAltDNSNames())
 			Expect(namesSet.Len()).To(Equal(12))
@@ -1504,7 +1504,7 @@ var _ = Describe("Cluster Managed Service Enablement", func() {
 		It("should return true if read service is not in DisabledDefaultServices", func() {
 			cluster.Spec.Managed = &ManagedConfiguration{
 				Services: &ManagedServices{
-					DisabledDefaultServices: []ServiceSelectorType{},
+					DisabledDefaultServices: []DisabledDefaultServiceSelectorType{},
 				},
 			}
 			Expect(cluster.IsReadServiceEnabled()).To(BeTrue())
@@ -1513,7 +1513,7 @@ var _ = Describe("Cluster Managed Service Enablement", func() {
 		It("should return false if read service is in DisabledDefaultServices", func() {
 			cluster.Spec.Managed = &ManagedConfiguration{
 				Services: &ManagedServices{
-					DisabledDefaultServices: []ServiceSelectorType{ServiceSelectorTypeR},
+					DisabledDefaultServices: []DisabledDefaultServiceSelectorType{DisabledDefaultServiceSelectorTypeR},
 				},
 			}
 			Expect(cluster.IsReadServiceEnabled()).To(BeFalse())
@@ -1521,29 +1521,21 @@ var _ = Describe("Cluster Managed Service Enablement", func() {
 	})
 
 	Describe("IsReadWriteServiceEnabled", func() {
-		It("should return true if Managed or Services is nil", func() {
+		It("should always return true because the read-write service cannot be disabled", func() {
 			Expect(cluster.IsReadWriteServiceEnabled()).To(BeTrue())
 
 			cluster.Spec.Managed = &ManagedConfiguration{}
 			Expect(cluster.IsReadWriteServiceEnabled()).To(BeTrue())
-		})
 
-		It("should return true if read-write service is not in DisabledDefaultServices", func() {
 			cluster.Spec.Managed = &ManagedConfiguration{
 				Services: &ManagedServices{
-					DisabledDefaultServices: []ServiceSelectorType{},
+					DisabledDefaultServices: []DisabledDefaultServiceSelectorType{
+						DisabledDefaultServiceSelectorTypeR,
+						DisabledDefaultServiceSelectorTypeRO,
+					},
 				},
 			}
 			Expect(cluster.IsReadWriteServiceEnabled()).To(BeTrue())
-		})
-
-		It("should return false if read-write service is in DisabledDefaultServices", func() {
-			cluster.Spec.Managed = &ManagedConfiguration{
-				Services: &ManagedServices{
-					DisabledDefaultServices: []ServiceSelectorType{ServiceSelectorTypeRW},
-				},
-			}
-			Expect(cluster.IsReadWriteServiceEnabled()).To(BeFalse())
 		})
 	})
 
@@ -1558,7 +1550,7 @@ var _ = Describe("Cluster Managed Service Enablement", func() {
 		It("should return true if read-only service is not in DisabledDefaultServices", func() {
 			cluster.Spec.Managed = &ManagedConfiguration{
 				Services: &ManagedServices{
-					DisabledDefaultServices: []ServiceSelectorType{},
+					DisabledDefaultServices: []DisabledDefaultServiceSelectorType{},
 				},
 			}
 			Expect(cluster.IsReadOnlyServiceEnabled()).To(BeTrue())
@@ -1567,7 +1559,7 @@ var _ = Describe("Cluster Managed Service Enablement", func() {
 		It("should return false if read-only service is in DisabledDefaultServices", func() {
 			cluster.Spec.Managed = &ManagedConfiguration{
 				Services: &ManagedServices{
-					DisabledDefaultServices: []ServiceSelectorType{ServiceSelectorTypeRO},
+					DisabledDefaultServices: []DisabledDefaultServiceSelectorType{DisabledDefaultServiceSelectorTypeRO},
 				},
 			}
 			Expect(cluster.IsReadOnlyServiceEnabled()).To(BeFalse())

--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -2333,6 +2333,20 @@ const (
 	ServiceSelectorTypeRO ServiceSelectorType = "ro"
 )
 
+// DisabledDefaultServiceSelectorType is the type for DisabledDefaultServices.
+// Only "r" and "ro" are valid because the read-write service cannot be disabled.
+//
+// +kubebuilder:validation:Enum=r;ro
+type DisabledDefaultServiceSelectorType string
+
+// Constants representing the valid values for DisabledDefaultServiceSelectorType.
+const (
+	// DisabledDefaultServiceSelectorTypeR selects the read service.
+	DisabledDefaultServiceSelectorTypeR DisabledDefaultServiceSelectorType = "r"
+	// DisabledDefaultServiceSelectorTypeRO selects the read-only service.
+	DisabledDefaultServiceSelectorTypeRO DisabledDefaultServiceSelectorType = "ro"
+)
+
 // ServiceUpdateStrategy describes how the changes to the managed service should be handled
 // +kubebuilder:validation:Enum=patch;replace
 type ServiceUpdateStrategy string
@@ -2349,7 +2363,7 @@ type ManagedServices struct {
 	// DisabledDefaultServices is a list of service types that are disabled by default.
 	// Valid values are "r", and "ro", representing read, and read-only services.
 	// +optional
-	DisabledDefaultServices []ServiceSelectorType `json:"disabledDefaultServices,omitempty"`
+	DisabledDefaultServices []DisabledDefaultServiceSelectorType `json:"disabledDefaultServices,omitempty"`
 	// Additional is a list of additional managed services specified by the user.
 	// +optional
 	Additional []ManagedService `json:"additional,omitempty"`

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -1920,7 +1920,7 @@ func (in *ManagedServices) DeepCopyInto(out *ManagedServices) {
 	*out = *in
 	if in.DisabledDefaultServices != nil {
 		in, out := &in.DisabledDefaultServices, &out.DisabledDefaultServices
-		*out = make([]ServiceSelectorType, len(*in))
+		*out = make([]DisabledDefaultServiceSelectorType, len(*in))
 		copy(*out, *in)
 	}
 	if in.Additional != nil {

--- a/docs/src/cloudnative-pg.v1.md
+++ b/docs/src/cloudnative-pg.v1.md
@@ -906,6 +906,27 @@ _Appears in:_
 | `servers` _[DatabaseObjectStatus](#databaseobjectstatus) array_ | Servers is the status of the managed servers |  |  |  |
 
 
+#### DisabledDefaultServiceSelectorType
+
+_Underlying type:_ _string_
+
+DisabledDefaultServiceSelectorType is the type for DisabledDefaultServices.
+Only "r" and "ro" are valid because the read-write service cannot be disabled.
+
+_Validation:_
+
+- Enum: [r ro]
+
+_Appears in:_
+
+- [ManagedServices](#managedservices)
+
+| Field | Description |
+| --- | --- |
+| `r` | DisabledDefaultServiceSelectorTypeR selects the read service.<br /> |
+| `ro` | DisabledDefaultServiceSelectorTypeRO selects the read-only service.<br /> |
+
+
 #### EmbeddedObjectMetadata
 
 
@@ -1460,7 +1481,7 @@ _Appears in:_
 
 | Field | Description | Required | Default | Validation |
 | --- | --- | --- | --- | --- |
-| `disabledDefaultServices` _[ServiceSelectorType](#serviceselectortype) array_ | DisabledDefaultServices is a list of service types that are disabled by default.<br />Valid values are "r", and "ro", representing read, and read-only services. |  |  | Enum: [rw r ro] <br /> |
+| `disabledDefaultServices` _[DisabledDefaultServiceSelectorType](#disableddefaultserviceselectortype) array_ | DisabledDefaultServices is a list of service types that are disabled by default.<br />Valid values are "r", and "ro", representing read, and read-only services. |  |  | Enum: [r ro] <br /> |
 | `additional` _[ManagedService](#managedservice) array_ | Additional is a list of additional managed services specified by the user. |  |  |  |
 
 
@@ -2570,7 +2591,6 @@ _Validation:_
 _Appears in:_
 
 - [ManagedService](#managedservice)
-- [ManagedServices](#managedservices)
 
 | Field | Description |
 | --- | --- |

--- a/internal/webhook/v1/cluster_webhook.go
+++ b/internal/webhook/v1/cluster_webhook.go
@@ -2369,14 +2369,6 @@ func (v *ClusterCustomValidator) validateManagedServices(r *apiv1.Cluster) field
 	basePath := field.NewPath("spec", "managed", "services")
 	var errs field.ErrorList
 
-	if slices.Contains(managedServices.DisabledDefaultServices, apiv1.ServiceSelectorTypeRW) {
-		errs = append(errs, field.Invalid(
-			basePath.Child("disabledDefaultServices"),
-			apiv1.ServiceSelectorTypeRW,
-			"service of type RW cannot be disabled.",
-		))
-	}
-
 	names := make([]string, len(managedServices.Additional))
 	for idx := range managedServices.Additional {
 		additionalService := &managedServices.Additional[idx]

--- a/internal/webhook/v1/cluster_webhook_test.go
+++ b/internal/webhook/v1/cluster_webhook_test.go
@@ -5146,22 +5146,12 @@ var _ = Describe("validateManagedServices", func() {
 
 	Context("disabledDefault service validation", func() {
 		It("should allow the disablement of ro and r service", func() {
-			cluster.Spec.Managed.Services.DisabledDefaultServices = []apiv1.ServiceSelectorType{
-				apiv1.ServiceSelectorTypeR,
-				apiv1.ServiceSelectorTypeRO,
+			cluster.Spec.Managed.Services.DisabledDefaultServices = []apiv1.DisabledDefaultServiceSelectorType{
+				apiv1.DisabledDefaultServiceSelectorTypeR,
+				apiv1.DisabledDefaultServiceSelectorTypeRO,
 			}
 			errs := v.validateManagedServices(cluster)
 			Expect(errs).To(BeEmpty())
-		})
-
-		It("should not allow the disablement of rw service", func() {
-			cluster.Spec.Managed.Services.DisabledDefaultServices = []apiv1.ServiceSelectorType{
-				apiv1.ServiceSelectorTypeRW,
-			}
-			errs := v.validateManagedServices(cluster)
-			Expect(errs).To(HaveLen(1))
-			Expect(errs[0].Type).To(Equal(field.ErrorTypeInvalid))
-			Expect(errs[0].Field).To(Equal("spec.managed.services.disabledDefaultServices"))
 		})
 	})
 })

--- a/tests/e2e/managed_services_test.go
+++ b/tests/e2e/managed_services_test.go
@@ -131,7 +131,7 @@ var _ = Describe("Managed services tests", Label(tests.LabelSmoke, tests.LabelBa
 			Eventually(func(g Gomega) error {
 				cluster, err := clusterutils.Get(env.Ctx, env.Client, namespace, clusterName)
 				g.Expect(err).ToNot(HaveOccurred())
-				cluster.Spec.Managed.Services.DisabledDefaultServices = []apiv1.ServiceSelectorType{}
+				cluster.Spec.Managed.Services.DisabledDefaultServices = []apiv1.DisabledDefaultServiceSelectorType{}
 				return env.Client.Update(ctx, cluster)
 			}, RetryTimeout, PollingTime).Should(Succeed())
 


### PR DESCRIPTION
Fixes a mismatch between validation and documentation for
ManagedServices.disabledDefaultServices.

The RW service cannot be disabled at runtime but was still included
in the enum. This change introduces a dedicated enum restricted to
r and ro, updates validation, regenerates CRDs, and refreshes
generated API documentation.

Fixes #9782
@gbartolini  @mnencia 