### PR TITLE
test(e2e): handle non-sequential pod numbering in cloud tests

### DIFF
--- a/tests/e2e/pvc_deletion_test.go
+++ b/tests/e2e/pvc_deletion_test.go
@@ -60,11 +60,8 @@ var _ = Describe("PVC Deletion", Label(tests.LabelSelfHealing), func() {
 		// Reuse the same pvc after a deletion
 		By("recreating a pod with the same PVC after it's deleted", func() {
 			// Get a replica pod to delete (not the primary)
-			replicas, err := clusterutils.GetReplicas(env.Ctx, env.Client, namespace, clusterName)
+			pod, err := clusterutils.GetFirstReplica(env.Ctx, env.Client, namespace, clusterName)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(replicas.Items).ToNot(BeEmpty(), "cluster should have at least one replica")
-
-			pod := &replicas.Items[0]
 			podName := pod.Name
 			podNamespacedName := types.NamespacedName{
 				Namespace: namespace,
@@ -108,11 +105,8 @@ var _ = Describe("PVC Deletion", Label(tests.LabelSelfHealing), func() {
 
 		By("removing a PVC and delete the Pod", func() {
 			// Get a replica pod to delete (not the primary)
-			replicas, err := clusterutils.GetReplicas(env.Ctx, env.Client, namespace, clusterName)
+			pod, err := clusterutils.GetFirstReplica(env.Ctx, env.Client, namespace, clusterName)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(replicas.Items).ToNot(BeEmpty(), "cluster should have at least one replica")
-
-			pod := &replicas.Items[0]
 			podName := pod.Name
 
 			// Get the UID of the PVC
@@ -160,7 +154,7 @@ var _ = Describe("PVC Deletion", Label(tests.LabelSelfHealing), func() {
 			err = podutils.Delete(env.Ctx, env.Client, namespace, podName, quickDelete)
 			Expect(err).ToNot(HaveOccurred())
 
-			// A new pod should be created (find it by listing all pods and checking for one not in the original list)
+			// A new pod should be created
 			timeout := 300
 			var newPodName string
 			Eventually(func() (bool, error) {

--- a/tests/e2e/pvc_deletion_test.go
+++ b/tests/e2e/pvc_deletion_test.go
@@ -150,7 +150,6 @@ var _ = Describe("PVC Deletion", Label(tests.LabelSelfHealing), func() {
 				Expect(err).ToNot(HaveOccurred())
 			}
 
-			// Deleting primary pod
 			err = podutils.Delete(env.Ctx, env.Client, namespace, podName, quickDelete)
 			Expect(err).ToNot(HaveOccurred())
 

--- a/tests/e2e/pvc_deletion_test.go
+++ b/tests/e2e/pvc_deletion_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 	"github.com/cloudnative-pg/cloudnative-pg/tests"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/clusterutils"
 	podutils "github.com/cloudnative-pg/cloudnative-pg/tests/utils/pods"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/storage"
 
@@ -58,15 +59,17 @@ var _ = Describe("PVC Deletion", Label(tests.LabelSelfHealing), func() {
 
 		// Reuse the same pvc after a deletion
 		By("recreating a pod with the same PVC after it's deleted", func() {
-			// Get a pod we want to delete
-			podName := clusterName + "-3"
-			pod := &corev1.Pod{}
+			// Get a replica pod to delete (not the primary)
+			replicas, err := clusterutils.GetReplicas(env.Ctx, env.Client, namespace, clusterName)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(replicas.Items).ToNot(BeEmpty(), "cluster should have at least one replica")
+
+			pod := &replicas.Items[0]
+			podName := pod.Name
 			podNamespacedName := types.NamespacedName{
 				Namespace: namespace,
 				Name:      podName,
 			}
-			err := env.Client.Get(env.Ctx, podNamespacedName, pod)
-			Expect(err).ToNot(HaveOccurred())
 
 			// Get the UID of the pod
 			pvcName := pod.Spec.Volumes[0].PersistentVolumeClaim.ClaimName
@@ -104,15 +107,13 @@ var _ = Describe("PVC Deletion", Label(tests.LabelSelfHealing), func() {
 		})
 
 		By("removing a PVC and delete the Pod", func() {
-			// Get a pod we want to delete
-			podName := clusterName + "-3"
-			pod := &corev1.Pod{}
-			podNamespacedName := types.NamespacedName{
-				Namespace: namespace,
-				Name:      podName,
-			}
-			err := env.Client.Get(env.Ctx, podNamespacedName, pod)
+			// Get a replica pod to delete (not the primary)
+			replicas, err := clusterutils.GetReplicas(env.Ctx, env.Client, namespace, clusterName)
 			Expect(err).ToNot(HaveOccurred())
+			Expect(replicas.Items).ToNot(BeEmpty(), "cluster should have at least one replica")
+
+			pod := &replicas.Items[0]
+			podName := pod.Name
 
 			// Get the UID of the PVC
 			pvcName := pod.Spec.Volumes[0].PersistentVolumeClaim.ClaimName
@@ -159,21 +160,30 @@ var _ = Describe("PVC Deletion", Label(tests.LabelSelfHealing), func() {
 			err = podutils.Delete(env.Ctx, env.Client, namespace, podName, quickDelete)
 			Expect(err).ToNot(HaveOccurred())
 
-			// A new pod should be created
+			// A new pod should be created (find it by listing all pods and checking for one not in the original list)
 			timeout := 300
-			newPodName := clusterName + "-4"
-			newPodNamespacedName := types.NamespacedName{
-				Namespace: namespace,
-				Name:      newPodName,
-			}
+			var newPodName string
 			Eventually(func() (bool, error) {
-				newPod := &corev1.Pod{}
-				err := env.Client.Get(env.Ctx, newPodNamespacedName, newPod)
-				return utils.IsPodActive(*newPod) && utils.IsPodReady(*newPod), err
+				podList, err := clusterutils.ListPods(env.Ctx, env.Client, namespace, clusterName)
+				if err != nil {
+					return false, err
+				}
+				// Check if there's a new pod that wasn't the one we deleted
+				for _, newPod := range podList.Items {
+					if newPod.Name != podName && utils.IsPodActive(newPod) && utils.IsPodReady(newPod) {
+						newPodName = newPod.Name
+						return true, nil
+					}
+				}
+				return false, nil
 			}, timeout).Should(BeTrue())
 
 			// The pod should have a different PVC
 			newPod := &corev1.Pod{}
+			newPodNamespacedName := types.NamespacedName{
+				Namespace: namespace,
+				Name:      newPodName,
+			}
 			err = env.Client.Get(env.Ctx, newPodNamespacedName, newPod)
 			Expect(err).ToNot(HaveOccurred())
 			newPvcName := newPod.Spec.Volumes[0].PersistentVolumeClaim.ClaimName

--- a/tests/e2e/upgrade_test.go
+++ b/tests/e2e/upgrade_test.go
@@ -272,7 +272,7 @@ var _ = Describe("Upgrade", Label(tests.LabelUpgrade, tests.LabelNoOpenshift), O
 			)
 			Expect(err).ToNot(HaveOccurred())
 
-			// Get all pods in the cluster dynamically instead of assuming sequential numbering
+			// Get all pods in the cluster dynamically
 			podList, err := clusterutils.ListPods(env.Ctx, env.Client, upgradeNamespace, clusterName)
 			Expect(err).ToNot(HaveOccurred())
 

--- a/tests/utils/clusterutils/cluster.go
+++ b/tests/utils/clusterutils/cluster.go
@@ -209,6 +209,22 @@ func GetReplicas(
 	return podList, err
 }
 
+// GetFirstReplica gets the first replica pod from a cluster
+func GetFirstReplica(
+	ctx context.Context,
+	crudClient client.Client,
+	namespace, clusterName string,
+) (*corev1.Pod, error) {
+	podList, err := GetReplicas(ctx, crudClient, namespace, clusterName)
+	if err != nil {
+		return nil, err
+	}
+	if len(podList.Items) == 0 {
+		return nil, fmt.Errorf("no replicas found")
+	}
+	return &podList.Items[0], nil
+}
+
 // ScaleSize scales a cluster to the requested size
 func ScaleSize(
 	ctx context.Context,


### PR DESCRIPTION
E2E tests were failing in cloud environments because they assumed sequential pod numbering (1,2,3) but CNPG uses a monotonically increasing counter that never reuses numbers. This is correct operator behavior to avoid name collisions.

Made tests resilient by using dynamic pod discovery instead of hardcoded names. Added systematic validation in AssertCreateCluster to detect non-sequential numbering on fresh clusters, which indicates a real problem requiring investigation.

Closes #9791 