### PR TITLE
fix(status): show Disabled for WAL archiving when `skipWalArchiving` annotation is set

### DIFF
--- a/internal/cmd/plugin/status/status.go
+++ b/internal/cmd/plugin/status/status.go
@@ -630,8 +630,9 @@ func (fullStatus *PostgresqlStatus) printWALArchivingStatus(status *tabby.Tabby)
 		status.AddLine("No Primary instance found")
 		return
 	}
+	isWalArchivingDisabled := utils.IsWalArchivingDisabled(&fullStatus.Cluster.ObjectMeta)
 	status.AddLine("Working WAL archiving:",
-		getWalArchivingStatus(primaryInstanceStatus.IsArchivingWAL, primaryInstanceStatus.LastFailedWAL))
+		getWalArchivingStatus(primaryInstanceStatus.IsArchivingWAL, primaryInstanceStatus.LastFailedWAL, isWalArchivingDisabled))
 	status.AddLine("WALs waiting to be archived:", primaryInstanceStatus.ReadyWALFiles)
 
 	if primaryInstanceStatus.LastArchivedWAL == "" {
@@ -648,8 +649,10 @@ func (fullStatus *PostgresqlStatus) printWALArchivingStatus(status *tabby.Tabby)
 	}
 }
 
-func getWalArchivingStatus(isArchivingWAL bool, lastFailedWAL string) string {
+func getWalArchivingStatus(isArchivingWAL bool, lastFailedWAL string, isDisabled bool) string {
 	switch {
+	case isDisabled:
+		return aurora.Yellow("Disabled").String()
 	case isArchivingWAL:
 		return aurora.Green("OK").String()
 	case lastFailedWAL != "":


### PR DESCRIPTION
  ## Summary

  - Fix the `status` command showing "Starting Up" for WAL archiving when
  `cnpg.io/skipWalArchiving: 'enabled'` annotation is set
  - Now correctly displays "Disabled" when WAL archiving is intentionally turned off

  ## Test plan

  - [x] Added unit tests for `getWalArchivingStatus` covering all states (Disabled, OK,  Failing, Starting Up)
  - [x] Verified existing tests pass
  - [x] Manual test: 
     Create cluster with `cnpg.io/skipWalArchiving: 'enabled'`
  annotation and run `kubectl cnpg status <cluster>` to confirm "Disabled" is shown. 
  See the detailed verification steps below. 

Fix: #9692

## Verification steps

1. Build plugin `make build-plugin`
2. Check plugin version 
```
❯ ./bin/kubectl-cnpg version
Build: {Version: Commit:ede0a34e Date:2026-01-23}
```

3. Deploy a test CNPG cluster with the following manifest:

```yaml
apiVersion: postgresql.cnpg.io/v1
  kind: Cluster
  metadata:
    name: test1-dev
    annotations:
      cnpg.io/skipWalArchiving: "enabled"
  spec:
    instances: 1
    storage:
      size: 1Gi
    plugins:
      - isWALArchiver: true
        name: barman-cloud.cloudnative-pg.io
        parameters:
          barmanObjectName: s3-dev-test
    serviceAccountTemplate:
      metadata:
        annotations:
          eks.amazonaws.com/role-arn: arn:aws:iam::1234567:role/xx-eks-cnpg0-cloudnative-pg

```
4. Check the CNPG cluster status: 

```sh
./bin/kubectl-cnpg status test1-dev

Cluster Summary
Name                     default/test1-dev
System ID:               xxxx
PostgreSQL Image:        ghcr.io/cloudnative-pg/postgresql:18.1-system-trixie
Primary instance:        test1-dev-1
Primary promotion time:  2026-01-23 19:50:19 +0000 UTC (6m21s)
Status:                  Cluster in healthy state
Instances:               1
Ready instances:         1
Size:                    63M
Current Write LSN:       0/20000A0 (Timeline: 1 - WAL File: 000000010000000000000002)

Continuous Backup status (Barman Cloud Plugin)
ObjectStore / Server name:      s3-dev-test/test1-dev
First Point of Recoverability:  -
Last Successful Backup:         -
Last Failed Backup:             -
Working WAL archiving:          Disabled
WALs waiting to be archived:    0
Last Archived WAL:              000000010000000000000001   @   2026-01-23T19:56:31.717945Z
Last Failed WAL:                -

Streaming Replication status
Not configured

Instances status
Name             Current LSN  Replication role  Status  QoS         Manager Version  Node
----             -----------  ----------------  ------  ---         ---------------  ----
test1-dev-1  0/20000A0    Primary           OK      BestEffort  1.27.2           ip-10-11-223-112.us-west-2.compute.internal

Plugins status
Name                            Version  Status  Reported Operator Capabilities
----                            -------  ------  ------------------------------
barman-cloud.cloudnative-pg.io  0.6.0    N/A     Reconciler Hooks, Lifecycle Service
