### PR TITLE
test(e2e): prevent container restarts in startup probe lag control test

### DIFF
--- a/tests/e2e/fixtures/sync_replicas/startup-probe-lag-control.yaml.template
+++ b/tests/e2e/fixtures/sync_replicas/startup-probe-lag-control.yaml.template
@@ -23,7 +23,11 @@ spec:
     startup:
       type: streaming
       maximumLag: 16Mi
-      failureThreshold: 60
+      # High failureThreshold to prevent container restarts during WAL catch-up.
+      # On cloud environments with variable I/O, catching up ~400-500MB of WAL
+      # can take longer than 60 seconds. Container restarts would cause log loss,
+      # making it impossible to verify that the probe correctly detected lag.
+      failureThreshold: 600
       periodSeconds: 1
     readiness:
       failureThreshold: 10


### PR DESCRIPTION
The test was failing in cloud environments because the startup probe had failureThreshold=60, which caused Kubernetes to restart the container after 60 consecutive probe failures (60 seconds).

When WAL catch-up takes longer than 60 seconds (common on cloud environments with variable I/O performance when catching up ~400-500MB of WAL), the container is restarted and logs from the previous container are lost.

Since the test only fetches logs from the current container (pods.Logs() doesn't use Previous: true), the expected "startup probe failing" messages were never found, causing the test to timeout.

Increased failureThreshold from 60 to 600 (10 minutes) to prevent container restarts during catch-up, ensuring all probe failure logs are preserved and can be verified by the test.