### PR TITLE
test(e2e): increase timeout for recovery CHECKPOINT in disk space test

### DIFF
--- a/tests/e2e/disk_space_test.go
+++ b/tests/e2e/disk_space_test.go
@@ -176,9 +176,8 @@ var _ = Describe("Volume space unavailable", Label(tests.LabelStorage), func() {
 			}).WithTimeout(10 * time.Minute).Should(BeTrue())
 		})
 		By("writing some WAL", func() {
-			// After crash recovery on network storage, PostgreSQL may need
-			// more time to complete CHECKPOINT operations.
 			query := "CHECKPOINT; SELECT pg_catalog.pg_switch_wal(); CHECKPOINT"
+			checkpointGracePeriod := time.Duration(testTimeouts[timeouts.ClusterIsReadyQuick]) * time.Second
 			_, _, err := exec.QueryInInstancePodWithTimeout(
 				env.Ctx, env.Client, env.Interface, env.RestClientConfig,
 				exec.PodLocator{
@@ -187,7 +186,7 @@ var _ = Describe("Volume space unavailable", Label(tests.LabelStorage), func() {
 				},
 				postgres.PostgresDBName,
 				query,
-				time.Duration(testTimeouts[timeouts.ClusterIsReadyQuick])*time.Second)
+				checkpointGracePeriod)
 			Expect(err).NotTo(HaveOccurred())
 		})
 	}


### PR DESCRIPTION
After crash recovery on network-attached storage, PostgreSQL may need more time to complete CHECKPOINT operations. The default 10-second timeout was insufficient on cloud environments like AKS with Rook-Ceph storage, causing the recovery phase of the disk space test to fail.

The test failure occurred in the recovery phase, not the detection phase. After resizing the PVC and waiting for the pod to become ready, the recovery CHECKPOINT command timed out after only 10 seconds. On network-attached storage with higher latency, PostgreSQL needs more time to complete CHECKPOINT operations after crash recovery.

This change uses the configurable ClusterIsReadyQuick timeout (300 seconds by default) to give PostgreSQL enough time to complete the recovery CHECKPOINT. The detection CHECKPOINT remains unchanged as it expects an error regardless of whether it fails immediately or times out.