### PR TITLE
ci: disable provenance in metadata to avoid size limits

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -381,6 +381,7 @@ jobs:
         uses: docker/bake-action@5be5f02ff8819ecd3092ea6b2e6261c31774f2b4 # v6
         id: bake-push
         env:
+          BUILDX_METADATA_PROVENANCE: disabled
           environment: "testing"
           buildVersion: ${{ env.VERSION }}
           tag: ${{ env.IMAGE_TAG }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -562,6 +562,7 @@ jobs:
         uses: docker/bake-action@5be5f02ff8819ecd3092ea6b2e6261c31774f2b4 # v6
         id: bake-push
         env:
+          BUILDX_METADATA_PROVENANCE: disabled
           environment: "testing"
           buildVersion: ${{ env.VERSION }}
           tag: ${{ env.IMAGE_TAG }}

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -208,6 +208,7 @@ jobs:
         uses: docker/bake-action@5be5f02ff8819ecd3092ea6b2e6261c31774f2b4 # v6
         id: bake-push
         env:
+          BUILDX_METADATA_PROVENANCE: disabled
           environment: "production"
           buildVersion: ${{ env.VERSION }}
           tag: ${{ env.IMAGE_TAG }}


### PR DESCRIPTION
Docker Buildx 0.31.0 includes full provenance attestations in the metadata output for multi-platform builds, resulting in 444KB+ JSON that exceeds bash argument list limits.

Setting BUILDX_METADATA_PROVENANCE=disabled excludes provenance from the metadata file while keeping attestations attached to images in the registry.