### PR TITLE
fix: handle OCI CSI 409 Conflict error

### DIFF
--- a/pkg/reconciler/backup/volumesnapshot/errors.go
+++ b/pkg/reconciler/backup/volumesnapshot/errors.go
@@ -79,6 +79,7 @@ func isCSIErrorMessageRetriable(msg string) bool {
 		isRetryableHTTPError,
 		isConflictError,
 		isContextDeadlineExceededError,
+		isOCIConflictError,
 	}
 
 	for _, isRetryableFunc := range isRetryableFuncs {
@@ -135,4 +136,12 @@ func isRetryableHTTPError(msg string) bool {
 	}
 
 	return false
+}
+
+// isOCIConflictError detects the 409 Conflict returned by the OCI Blockstorage
+// Service while a snapshot is still being created.
+func isOCIConflictError(msg string) bool {
+	return strings.Contains(msg, "Error returned by Blockstorage Service") &&
+		strings.Contains(msg, "Http Status Code: 409") &&
+		strings.Contains(msg, "Error Code: Conflict")
 }

--- a/pkg/reconciler/backup/volumesnapshot/errors_test.go
+++ b/pkg/reconciler/backup/volumesnapshot/errors_test.go
@@ -50,6 +50,7 @@ var _ = Describe("Retriable error messages", func() {
 		Entry("context deadline exceeded - retriable", "context deadline exceeded waiting for snapshot creation", true),
 		Entry("deadline exceeded - retriable", "deadline exceeded during Azure snapshot creation", true),
 		Entry("timed out - retriable", "operation timed out for csi-disk-handler", true),
+		Entry("OCI 409", "Error returned by Blockstorage Service. Http Status Code: 409. Error Code: Conflict.", true),
 	)
 
 	Describe("isContextDeadlineExceededError", func() {

--- a/pkg/reconciler/backup/volumesnapshot/reconciler_test.go
+++ b/pkg/reconciler/backup/volumesnapshot/reconciler_test.go
@@ -716,3 +716,94 @@ var _ = Describe("unmarshalMetadata", func() {
 		Expect(data).To(BeNil())
 	})
 })
+
+var _ = Describe("createSnapshot AlreadyExists handling", func() {
+	var (
+		ctx       context.Context
+		backup    *apiv1.Backup
+		cluster   *apiv1.Cluster
+		targetPod *corev1.Pod
+		pvc       *corev1.PersistentVolumeClaim
+	)
+
+	BeforeEach(func() {
+		ctx = context.TODO()
+		backup = &apiv1.Backup{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "test-namespace",
+				Name:      "test-backup",
+			},
+			Status: apiv1.BackupStatus{
+				StartedAt: ptr.To(metav1.Now()),
+			},
+		}
+		cluster = &apiv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "test-namespace",
+				Name:      "test-cluster",
+			},
+			Spec: apiv1.ClusterSpec{
+				Backup: &apiv1.BackupConfiguration{
+					VolumeSnapshot: &apiv1.VolumeSnapshotConfiguration{
+						ClassName: "csi-hostpath-snapclass",
+					},
+				},
+			},
+		}
+		targetPod = &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "test-namespace",
+				Name:      "test-pod",
+			},
+		}
+		pvc = &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "test-namespace",
+				Name:      "test-pvc",
+				Labels: map[string]string{
+					utils.PvcRoleLabelName: string(utils.PVCRolePgData),
+				},
+			},
+		}
+	})
+
+	buildClient := func(createErr error) k8client.Client {
+		return fake.NewClientBuilder().
+			WithScheme(scheme.BuildWithAllKnownScheme()).
+			WithInterceptorFuncs(interceptor.Funcs{
+				Create: func(
+					ctx context.Context,
+					c k8client.WithWatch,
+					obj k8client.Object,
+					opts ...k8client.CreateOption,
+				) error {
+					if _, ok := obj.(*volumesnapshotv1.VolumeSnapshot); ok && createErr != nil {
+						return createErr
+					}
+					return c.Create(ctx, obj, opts...)
+				},
+			}).
+			Build()
+	}
+
+	It("should succeed when Create returns AlreadyExists", func() {
+		gr := schema.GroupResource{Group: volumesnapshotv1.GroupName, Resource: "volumesnapshots"}
+		snapName := persistentvolumeclaim.NewPgDataCalculator().GetSnapshotName(backup.Name)
+		alreadyExistsErr := apierrs.NewAlreadyExists(gr, snapName)
+
+		cli := buildClient(alreadyExistsErr)
+		reconciler := NewReconcilerBuilder(cli, record.NewFakeRecorder(3)).Build()
+
+		err := reconciler.createSnapshot(ctx, cluster, backup, targetPod, pvc)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("should fail when Create returns a non-AlreadyExists error", func() {
+		cli := buildClient(fmt.Errorf("simulated transient error"))
+		reconciler := NewReconcilerBuilder(cli, record.NewFakeRecorder(3)).Build()
+
+		err := reconciler.createSnapshot(ctx, cluster, backup, targetPod, pvc)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("simulated transient error"))
+	})
+})


### PR DESCRIPTION
## Description

This PR addresses a race condition encountered with the OCI (Oracle Cloud Infrastructure) CSI driver during VolumeSnapshot backups.

The OCI CSI driver may return a `409 Conflict` error when a backup operation is requested while another implementation-level backup is already in progress (e.g. due to internal retries). The error message typically contains:
`Error returned by Blockstorage Service. Http Status Code: 409. Error Code: Conflict.`

Previously, this error was treated as fatal, causing the backup to fail immediately (and preventing the `VolumeSnapshot` mechanism from succeeding). This change identifies this specific error signature and classifies it as **retryable**, allowing the operator to wait and retry the operation instead of failing.

## Checklist

- [x] Code compiles correctly
- [x] Unit tests added and passed (`errors_test.go`)
- [x] Verified manually on OCI environment

Fixes #8608
