### PR TITLE
fix(major-upgrade): reset TimelineID to 1 after upgrade

### DIFF
--- a/docs/src/postgres_upgrades.md
+++ b/docs/src/postgres_upgrades.md
@@ -160,7 +160,7 @@ automatically decide the rollback.
 ### Backup and WAL Archive Considerations
 
 When performing a major upgrade, `pg_upgrade` creates a new database system
-with a new System ID and resets the PostgreSQL timeline to 1. This has
+with a new *System ID* and resets the PostgreSQL timeline to 1. This has
 implications for backup and WAL archiving:
 
 - **Timeline file conflicts**: New timeline 1 files may overwrite timeline 1
@@ -181,11 +181,11 @@ others require manual configuration to use different archive paths for each
 major version. Consult your backup plugin documentation for its specific
 behavior during major upgrades.
 
-**Example: Manual archive path separation with plugin-barman-cloud**
+#### Example: Manual archive path separation with the Barman Cloud plugin
 
-The `plugin-barman-cloud` backup plugin does not automatically separate
-archives during major upgrades. To preserve pre-upgrade backups and keep
-archives clean, change the `serverName` parameter when you trigger the upgrade.
+The Barman Cloud plugin does not automatically separate archives during major
+upgrades. To preserve pre-upgrade backups and keep archives clean, change the
+`serverName` parameter when you trigger the upgrade.
 
 Before upgrade (PostgreSQL 16):
 
@@ -219,8 +219,7 @@ intact for pre-upgrade recovery, while the upgraded cluster writes to
 
 :::info
 The deprecated in-tree `barmanObjectStore` implementation also requires manual
-`serverName` changes to separate archives during major upgrades. Consider
-migrating to backup plugins for better flexibility and ongoing support.
+`serverName` changes to separate archives during major upgrades.
 :::
 
 ### Example: Performing a Major Upgrade

--- a/pkg/reconciler/majorupgrade/reconciler.go
+++ b/pkg/reconciler/majorupgrade/reconciler.go
@@ -237,6 +237,9 @@ func majorVersionUpgradeHandleCompletion(
 		return nil, err
 	}
 
+	// Reset timeline ID to 1 after major upgrade to match pg_upgrade behavior.
+	// This prevents replicas from restoring incompatible timeline history files
+	// from the pre-upgrade cluster in object storage.
 	if err := status.PatchWithOptimisticLock(
 		ctx,
 		c,
@@ -245,6 +248,7 @@ func majorVersionUpgradeHandleCompletion(
 			Image:        jobImage,
 			MajorVersion: requestedMajor,
 		}),
+		status.SetTimelineID(1),
 	); err != nil {
 		contextLogger.Error(err, "Unable to update cluster status after major upgrade completed.")
 		return nil, err

--- a/pkg/reconciler/majorupgrade/reconciler_test.go
+++ b/pkg/reconciler/majorupgrade/reconciler_test.go
@@ -68,6 +68,9 @@ var _ = Describe("Major upgrade job status reconciliation", func() {
 			Spec: apiv1.ClusterSpec{
 				ImageName: "postgres:16",
 			},
+			Status: apiv1.ClusterStatus{
+				TimelineID: 5, // Simulating pre-upgrade timeline
+			},
 		}
 		pvcs := []corev1.PersistentVolumeClaim{
 			buildPrimaryPVC(1),
@@ -106,6 +109,9 @@ var _ = Describe("Major upgrade job status reconciliation", func() {
 		// the upgrade has been marked as done
 		Expect(cluster.Status.PGDataImageInfo.Image).To(Equal("postgres:16"))
 		Expect(cluster.Status.PGDataImageInfo.MajorVersion).To(Equal(16))
+
+		// the timeline ID has been reset to 1 to match pg_upgrade behavior
+		Expect(cluster.Status.TimelineID).To(Equal(1))
 
 		// the job has been deleted
 		var tempJob batchv1.Job

--- a/pkg/resources/status/transactions.go
+++ b/pkg/resources/status/transactions.go
@@ -76,3 +76,10 @@ func SetPGDataImageInfo(imageInfo *apiv1.ImageInfo) Transaction {
 		cluster.Status.PGDataImageInfo = imageInfo
 	}
 }
+
+// SetTimelineID is a transaction that sets the cluster timeline ID
+func SetTimelineID(timelineID int) Transaction {
+	return func(cluster *apiv1.Cluster) {
+		cluster.Status.TimelineID = timelineID
+	}
+}

--- a/pkg/resources/status/transactions_test.go
+++ b/pkg/resources/status/transactions_test.go
@@ -1,0 +1,188 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package status
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Status transactions", func() {
+	Describe("SetClusterReadyCondition", func() {
+		It("sets ready condition to true when phase is healthy", func() {
+			cluster := &apiv1.Cluster{
+				Status: apiv1.ClusterStatus{
+					Phase: apiv1.PhaseHealthy,
+				},
+			}
+
+			SetClusterReadyCondition(cluster)
+
+			Expect(cluster.Status.Conditions).To(HaveLen(1))
+			condition := cluster.Status.Conditions[0]
+			Expect(condition.Type).To(Equal(string(apiv1.ConditionClusterReady)))
+			Expect(condition.Status).To(Equal(metav1.ConditionTrue))
+			Expect(condition.Reason).To(Equal(string(apiv1.ClusterReady)))
+			Expect(condition.Message).To(Equal("Cluster is Ready"))
+		})
+
+		It("sets ready condition to false when phase is not healthy", func() {
+			cluster := &apiv1.Cluster{
+				Status: apiv1.ClusterStatus{
+					Phase: apiv1.PhaseMajorUpgrade,
+				},
+			}
+
+			SetClusterReadyCondition(cluster)
+
+			Expect(cluster.Status.Conditions).To(HaveLen(1))
+			condition := cluster.Status.Conditions[0]
+			Expect(condition.Type).To(Equal(string(apiv1.ConditionClusterReady)))
+			Expect(condition.Status).To(Equal(metav1.ConditionFalse))
+			Expect(condition.Reason).To(Equal(string(apiv1.ClusterIsNotReady)))
+			Expect(condition.Message).To(Equal("Cluster Is Not Ready"))
+		})
+
+		It("initializes conditions slice if nil", func() {
+			cluster := &apiv1.Cluster{
+				Status: apiv1.ClusterStatus{
+					Phase:      apiv1.PhaseHealthy,
+					Conditions: nil,
+				},
+			}
+
+			SetClusterReadyCondition(cluster)
+
+			Expect(cluster.Status.Conditions).ToNot(BeNil())
+			Expect(cluster.Status.Conditions).To(HaveLen(1))
+		})
+	})
+
+	Describe("SetPhase", func() {
+		It("sets the cluster phase and reason", func() {
+			cluster := &apiv1.Cluster{}
+
+			SetPhase(apiv1.PhaseMajorUpgrade, "Upgrading to version 17")(cluster)
+
+			Expect(cluster.Status.Phase).To(Equal(apiv1.PhaseMajorUpgrade))
+			Expect(cluster.Status.PhaseReason).To(Equal("Upgrading to version 17"))
+		})
+
+		It("overwrites existing phase and reason", func() {
+			cluster := &apiv1.Cluster{
+				Status: apiv1.ClusterStatus{
+					Phase:       apiv1.PhaseHealthy,
+					PhaseReason: "All good",
+				},
+			}
+
+			SetPhase(apiv1.PhaseUpgrade, "Rolling update")(cluster)
+
+			Expect(cluster.Status.Phase).To(Equal(apiv1.PhaseUpgrade))
+			Expect(cluster.Status.PhaseReason).To(Equal("Rolling update"))
+		})
+	})
+
+	Describe("SetImage", func() {
+		It("sets the cluster image", func() {
+			cluster := &apiv1.Cluster{}
+
+			SetImage("ghcr.io/cloudnative-pg/postgresql:17.2")(cluster)
+
+			Expect(cluster.Status.Image).To(Equal("ghcr.io/cloudnative-pg/postgresql:17.2"))
+		})
+
+		It("overwrites existing image", func() {
+			cluster := &apiv1.Cluster{
+				Status: apiv1.ClusterStatus{
+					Image: "ghcr.io/cloudnative-pg/postgresql:16.5",
+				},
+			}
+
+			SetImage("ghcr.io/cloudnative-pg/postgresql:17.2")(cluster)
+
+			Expect(cluster.Status.Image).To(Equal("ghcr.io/cloudnative-pg/postgresql:17.2"))
+		})
+	})
+
+	Describe("SetPGDataImageInfo", func() {
+		It("sets the PGData image info", func() {
+			cluster := &apiv1.Cluster{}
+			imageInfo := &apiv1.ImageInfo{
+				Image:        "ghcr.io/cloudnative-pg/postgresql:17.2",
+				MajorVersion: 17,
+			}
+
+			SetPGDataImageInfo(imageInfo)(cluster)
+
+			Expect(cluster.Status.PGDataImageInfo).ToNot(BeNil())
+			Expect(cluster.Status.PGDataImageInfo.Image).To(Equal("ghcr.io/cloudnative-pg/postgresql:17.2"))
+			Expect(cluster.Status.PGDataImageInfo.MajorVersion).To(Equal(17))
+		})
+
+		It("overwrites existing PGData image info", func() {
+			cluster := &apiv1.Cluster{
+				Status: apiv1.ClusterStatus{
+					PGDataImageInfo: &apiv1.ImageInfo{
+						Image:        "ghcr.io/cloudnative-pg/postgresql:16.5",
+						MajorVersion: 16,
+					},
+				},
+			}
+			newImageInfo := &apiv1.ImageInfo{
+				Image:        "ghcr.io/cloudnative-pg/postgresql:17.2",
+				MajorVersion: 17,
+			}
+
+			SetPGDataImageInfo(newImageInfo)(cluster)
+
+			Expect(cluster.Status.PGDataImageInfo.Image).To(Equal("ghcr.io/cloudnative-pg/postgresql:17.2"))
+			Expect(cluster.Status.PGDataImageInfo.MajorVersion).To(Equal(17))
+		})
+	})
+
+	Describe("SetTimelineID", func() {
+		It("sets the cluster timeline ID", func() {
+			cluster := &apiv1.Cluster{
+				Status: apiv1.ClusterStatus{
+					TimelineID: 5,
+				},
+			}
+
+			SetTimelineID(10)(cluster)
+			Expect(cluster.Status.TimelineID).To(Equal(10))
+		})
+
+		It("resets timeline ID to 1 after major upgrade", func() {
+			cluster := &apiv1.Cluster{
+				Status: apiv1.ClusterStatus{
+					TimelineID: 2,
+				},
+			}
+
+			SetTimelineID(1)(cluster)
+			Expect(cluster.Status.TimelineID).To(Equal(1))
+		})
+	})
+})


### PR DESCRIPTION
After a major version upgrade, pg_upgrade creates a new database system with a new System ID and resets the timeline to 1. However, cluster.Status.TimelineID retained its old value (e.g., timeline 2), causing replicas to restore incompatible timeline history files from object storage.

This resulted in PostgreSQL fatal errors:

    "requested timeline 2 is not a child of this server's history"
    "Latest checkpoint in file backup_label is at 0/13000080 on timeline 1, but in the history of the requested timeline, the server forked off from that timeline at 0/70226C8."

The fix sets cluster.Status.TimelineID to 1 after major upgrade completion, ensuring validateTimelineHistoryFile() blocks incompatible timeline history files (e.g., 00000002.history).

E2E tests verify this by performing a switchover to timeline 2 before the major upgrade, then confirming TimelineID is reset to 1 after upgrade completion.

Closes #9764 