### PR TITLE
test(major-upgrade): enable archiving in upgrade tests

### DIFF
--- a/tests/e2e/cluster_major_upgrade_test.go
+++ b/tests/e2e/cluster_major_upgrade_test.go
@@ -541,6 +541,12 @@ var _ = Describe("Postgres Major Upgrade", Label(tests.LabelPostgresMajorUpgrade
 		// Expect temporary files to be deleted
 		By("Checking no leftovers exist from the upgrade")
 		verifyCleanupAfterUpgrade(env.Ctx, env.Client, primary)
+
+		// Verify WAL archiving continues to work after the major upgrade
+		if cluster.Spec.Backup != nil {
+			By("Verifying WAL archiving works after the major upgrade")
+			AssertArchiveWalOnMinio(cluster.Namespace, cluster.Name, cluster.Name)
+		}
 	},
 		Entry("PostGIS", postgisEntry),
 		Entry("PostgreSQL", postgresqlEntry),

--- a/tests/utils/environment/environment.go
+++ b/tests/utils/environment/environment.go
@@ -65,6 +65,9 @@ const (
 	// MinimalSuffix is the suffix for minimal images
 	MinimalSuffix = "minimal-trixie"
 
+	// SystemSuffix is the suffix for system images (includes barman-cloud tools)
+	SystemSuffix = "system-trixie"
+
 	// PostGISSuffix is the suffix for PostGIS images
 	PostGISSuffix = "3-standard-trixie"
 
@@ -249,4 +252,19 @@ func (env *TestingEnvironment) OfficialStandardImageName(tag string) string {
 // Example: ghcr.io/cloudnative-pg/postgresql:16-minimal-trixie
 func (env *TestingEnvironment) OfficialMinimalImageName(tag string) string {
 	return fmt.Sprintf("%s:%s-%s", env.PostgresImageRepository, tag, MinimalSuffix)
+}
+
+// SystemImageName returns the full image name for a system Postgres image.
+// System images include barman-cloud tools for backup and recovery.
+// Example: ghcr.io/cloudnative-pg/postgresql:17-system-trixie
+func (env *TestingEnvironment) SystemImageName(tag string) string {
+	return fmt.Sprintf("%s:%s-%s", env.PostgresImageName, tag, SystemSuffix)
+}
+
+// OfficialSystemImageName returns the full image name for the official CloudNativePG system Postgres image.
+// This is used for major upgrade tests where source images must come from the official registry.
+// System images include barman-cloud tools for backup and recovery.
+// Example: ghcr.io/cloudnative-pg/postgresql:16-system-trixie
+func (env *TestingEnvironment) OfficialSystemImageName(tag string) string {
+	return fmt.Sprintf("%s:%s-%s", env.PostgresImageRepository, tag, SystemSuffix)
 }


### PR DESCRIPTION
Enable MinIO backup configuration in major version upgrade tests to properly validate the barman object store reset logic during upgrades.

Add a fourth test scenario using PostgreSQL system images with backup enabled. System images include barman-cloud tools required for in-tree backup functionality. The PostgreSQL, PostGIS, and minimal image tests run without archiving as they lack barman support.

Without archiving enabled in at least one scenario, the tests cannot verify that WAL archiving continues working correctly after a major version transition.