### PR TITLE
ci(e2e): add explicit docker.io registry prefix

### DIFF
--- a/internal/cmd/plugin/fio/fio.go
+++ b/internal/cmd/plugin/fio/fio.go
@@ -45,7 +45,7 @@ type fioCommand struct {
 
 const (
 	fioKeyWord = "fio"
-	fioImage   = "wallnerryan/fiotools-aio:v2"
+	fioImage   = "docker.io/wallnerryan/fiotools-aio:v2"
 )
 
 var jobExample = `

--- a/tests/e2e/fixtures/fastfailover/apache-benchmark-webtest.yaml
+++ b/tests/e2e/fixtures/fastfailover/apache-benchmark-webtest.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       containers:
       - name: apache-benchmark
-        image: httpd
+        image: docker.io/httpd:latest
         command:
          - "/usr/local/apache2/bin/ab"
          - "-t"

--- a/tests/e2e/fixtures/fastswitchover/apache-benchmark-webtest.yaml
+++ b/tests/e2e/fixtures/fastswitchover/apache-benchmark-webtest.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       containers:
       - name: apache-benchmark
-        image: httpd
+        image: docker.io/httpd:latest
         command:
           - "/usr/local/apache2/bin/ab"
           - "-t"

--- a/tests/utils/minio/minio.go
+++ b/tests/utils/minio/minio.go
@@ -50,9 +50,9 @@ import (
 
 const (
 	// minioImage is the image used to run a MinIO server
-	minioImage = "minio/minio:RELEASE.2025-09-07T16-13-09Z"
+	minioImage = "docker.io/minio/minio:RELEASE.2025-09-07T16-13-09Z"
 	// minioClientImage is the image used to run a MinIO client
-	minioClientImage = "minio/mc:RELEASE.2025-08-13T08-35-41Z"
+	minioClientImage = "docker.io/minio/mc:RELEASE.2025-08-13T08-35-41Z"
 )
 
 // Env contains all the information related or required by MinIO deployment and


### PR DESCRIPTION
Latest cri-o versions in OpenShift 4.21 require explicit registry prefixes for all container images. Updated minio/minio, minio/mc, wallnerryan/fiotools-aio, and httpd images to include the docker.io prefix.