### PR TITLE
chore: update bug issue template versions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -51,6 +51,7 @@ body:
         - "1.28 (latest patch)"
         - "1.27 (latest patch)"
         - "trunk (main)"
+        - "older in 1.28.x"
         - "older in 1.27.x"
         - "older minor (unsupported)"
     validations:
@@ -60,6 +61,7 @@ body:
     attributes:
       label: What version of Kubernetes are you using?
       options:
+        - "1.35"
         - "1.34"
         - "1.33"
         - "1.32"


### PR DESCRIPTION
Add Kubernetes 1.35 and "older in 1.28.x" option to align with the currently supported releases.