### PR TITLE
fix: update phase when rollout blocked by WAL receiver

### DIFF
--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -679,6 +679,9 @@ const (
 	// PhaseWaitingForInstancesToBeActive is a waiting phase that is triggered when an instance pod is not active
 	PhaseWaitingForInstancesToBeActive = "Waiting for the instances to become active"
 
+	// PhaseWaitingForWalReceiver is set when a rollout is blocked waiting for WAL receiver on switchover target
+	PhaseWaitingForWalReceiver = "Waiting for WAL receiver on switchover target"
+
 	// PhaseOnlineUpgrading for when the instance manager is being upgraded in place
 	PhaseOnlineUpgrading = "Online upgrade in progress"
 


### PR DESCRIPTION
## Summary

When a cluster with `primaryUpdateMethod: switchover` needs a rollout, the operator may block waiting for the WAL receiver to be active on the switchover target. This left a stale phase message ("Waiting for instances to become active") that was confusing since all pods were actually running.

This follows the existing pattern for `errRolloutDelayed` by updating the cluster phase to reflect the actual blocking condition.

## Changes

- Add `PhaseWaitingForWalReceiver` constant
- Update phase when `errLogShippingReplicaElected` is returned (same pattern as `errRolloutDelayed` at lines 1117-1131)

## Test plan

- [x] All existing controller tests pass (252 specs)
- [ ] E2E test with replica cluster + switchover (manual verification done)

Fixes: #9919