### PR TITLE
ci(openshift): add timeouts to E2E job to prevent orphaned clusters

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -1992,6 +1992,7 @@ jobs:
           oc: ${{ matrix.k8s_version }}
       -
         name: Install OpenShift Cluster ${{ matrix.k8s_version }}
+        timeout-minutes: 60
         run: |
           envsubst < hack/install-config.yaml.template > hack/install-config.yaml
           openshift-install create cluster --dir hack/ --log-level debug
@@ -2012,6 +2013,7 @@ jobs:
             --docker-server="$REGISTRY" --docker-username="$REGISTRY_USER" --docker-password="$REGISTRY_PASSWORD"
       -
         name: Run preflight operator test
+        timeout-minutes: 30
         env:
           BUNDLE_IMG: ${{ needs.buildx.outputs.bundle_img }}
           PFLT_INDEXIMAGE: ${{ needs.buildx.outputs.index_img }}
@@ -2034,6 +2036,7 @@ jobs:
           fi
       -
         name: Run E2E tests
+        timeout-minutes: 180
         if: (always() && !cancelled())
         run: |
           # Before running on OpenShift we make sure that the catalog is created


### PR DESCRIPTION
Add step-level timeouts to ensure long-running steps fail fast and the cluster cleanup step always has time to run. Previously, jobs hitting the 6-hour GitHub Actions limit were killed before cleanup, leaving orphaned OpenShift clusters in AWS.

Step timeouts:
- Install OpenShift Cluster: 60 minutes
- Run preflight operator test: 30 minutes
- Run E2E tests: 180 minutes