### PR TITLE
feat: add support for CNPG-I `ValidateClusterCreate` capability

### DIFF
--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -691,6 +691,9 @@ const (
 
 	// PhaseCannotCreateClusterObjects is set by the operator when is unable to create cluster resources
 	PhaseCannotCreateClusterObjects = "Unable to create required cluster objects"
+
+	// PhasePluginValidationFailed is set when cluster validation by a plugin fails
+	PhasePluginValidationFailed = "Cluster validation failed due to validation in plugin"
 )
 
 // EphemeralVolumesSizeLimitConfiguration contains the configuration of the ephemeral

--- a/internal/cnpi/plugin/client/suite_test.go
+++ b/internal/cnpi/plugin/client/suite_test.go
@@ -65,7 +65,7 @@ func (f *fakeOperatorClient) ValidateClusterCreate(
 	_ *operator.OperatorValidateClusterCreateRequest,
 	_ ...grpc.CallOption,
 ) (*operator.OperatorValidateClusterCreateResult, error) {
-	panic("implement me")
+	return &operator.OperatorValidateClusterCreateResult{}, nil
 }
 
 func (f *fakeOperatorClient) ValidateClusterChange(

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -239,6 +239,14 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 	ctx = cnpgiClient.SetPluginClientInContext(ctx, pluginClient)
 
+	// Validate cluster creation
+	// At the first reconciliation the number of instances will be 0
+	if cluster.Status.Instances == 0 {
+		if err := validateClusterCreate(ctx, r.Client, pluginClient, cluster); err != nil {
+			return ctrl.Result{RequeueAfter: 60 * time.Second}, nil
+		}
+	}
+
 	// Run the inner reconcile loop. Translate any ErrNextLoop to an errorless return
 	result, err := r.reconcile(ctx, cluster)
 	if errors.Is(err, ErrNextLoop) {


### PR DESCRIPTION
This PR adds ValidateClusterCreate callback for CNPG-I. This callback already exist in the gRPC spec but is not fully implemented. This will allow plugins to validate the cluster spec before reconciliation. For example to validate plugin configurations, or individual restrictions that one might want to impose on the cluster spec.

* Added source code changes needed to call ValidateClusterCreate before reconciliation. 
* Added unit tests to verify expected plugin behavior. 

This implementation will block reconciliation if the validation fails, or if the plugin fails to respond successfully.
The corresponding feature request: #9149. 
