### PR TITLE
fix(release): preserve RPM release number in kubectl-plugin.md

### DIFF
--- a/docs/src/kubectl-plugin.md
+++ b/docs/src/kubectl-plugin.md
@@ -77,7 +77,7 @@ Dependencies resolved.
  Package            Architecture         Version                   Repository                  Size
 ====================================================================================================
 Installing:
- cnpg               x86_64               1.28.1                  @commandline                20 M
+ cnpg               x86_64               1.28.1-1                  @commandline                20 M
 
 Transaction Summary
 ====================================================================================================

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -112,7 +112,7 @@ sed -i -e "s@\(release-[0-9.]\+\|main\)/releases/cnpg-[0-9.]\+\(-rc.*\)\?.yaml@$
     -e "s@artifacts/release-[0-9.]*/@artifacts/${release_branch}/@g" \
     docs/src/installation_upgrade.md
 
-sed -i -e "s@1\.[0-9]\+\.[0-9]\+\(-[a-z0-9]\+\)\?@${release_version}@g" docs/src/kubectl-plugin.md
+sed -i -e "s@1\.[0-9]\+\.[0-9]\+\(-[a-z][a-z0-9]*\)\?@${release_version}@g" docs/src/kubectl-plugin.md
 
 CONFIG_TMP_DIR=$(mktemp -d)
 cp -r config/* "${CONFIG_TMP_DIR}"


### PR DESCRIPTION
The version regex `\(-[a-z0-9]\+\)\?` in `hack/release.sh` also matches the RPM release number `-1` in the yum output example, which is eaten during stable-to-stable bumps. Change to `\(-[a-z][a-z0-9]*\)\?` so the suffix must start with a letter, and restore the lost `-1`.