### PR TITLE
docs: update PostGIS page for Image Volume Extensions

### DIFF
--- a/docs/src/imagevolume_extensions.md
+++ b/docs/src/imagevolume_extensions.md
@@ -47,7 +47,7 @@ Extension images must be built according to the
 To use image volume extensions with CloudNativePG, you need:
 
 - **PostgreSQL 18 or later**, with support for `extension_control_path`.
-- **Kubernetes 1.33**, with the `ImageVolume` feature gate enabled.
+- **Kubernetes 1.35** or later (1.33 and 1.34 with the `ImageVolume` feature gate enabled).
 - **Container runtime with `ImageVolume` support**:
     - `containerd` v2.1.0 or later, or
     - `CRI-O` v1.31 or later.

--- a/docs/src/postgis.md
+++ b/docs/src/postgis.md
@@ -115,17 +115,12 @@ spec:
   imageName: ghcr.io/cloudnative-pg/postgis:18.1-3.6.1-system-trixie
   storage:
     size: 1Gi
-  postgresql:
-    parameters:
-      log_statement: ddl
 ```
-
----
 
 ## Enabling the Extension
 
-Once the binaries are provisioned (via an image volume extension or directly in
-the `Cluster` resource), you must enable the extension in the database.
+Once the binaries are provisioned (via either method above), you must enable
+the extension in the database.
 
 Using the `Database` resource allows for declarative management of the
 extension's lifecycle, including version upgrades.
@@ -204,17 +199,14 @@ kubectl cnpg psql cluster-postgis -- app -c '\dx'
 The command returns something like this:
 
 ```console
-                                                                                List of installed extensions
-             Name             | Version | Default version |   Schema   |                                                     Description
-
-------------------------------+---------+-----------------+------------+---------------------------------------------------------------------------------
-------------------------------------
- address_standardizer         | 3.6.1   | 3.6.1           | public     | Used to parse an address into constituent elements. Generally used to support ge
-ocoding address normalization step.
+                                        List of installed extensions
+             Name             | Version | Default version |   Schema   |                  Description
+------------------------------+---------+-----------------+------------+------------------------------------------------
+ address_standardizer         | 3.6.1   | 3.6.1           | public     | Used to parse an address into constituent ...
  address_standardizer_data_us | 3.6.1   | 3.6.1           | public     | Address Standardizer US dataset example
- fuzzystrmatch                | 1.2     | 1.2             | public     | determine similarities and distance between strings
+ fuzzystrmatch                | 1.2     | 1.2             | public     | determine similarities and distance between...
  plpgsql                      | 1.0     | 1.0             | pg_catalog | PL/pgSQL procedural language
- postgis                      | 3.6.1   | 3.6.1           | public     | PostGIS geometry and geography spatial types and functions
+ postgis                      | 3.6.1   | 3.6.1           | public     | PostGIS geometry and geography spatial type...
  postgis_raster               | 3.6.1   | 3.6.1           | public     | PostGIS raster types and functions
  postgis_sfcgal               | 3.6.1   | 3.6.1           | public     | PostGIS SFCGAL functions
  postgis_tiger_geocoder       | 3.6.1   | 3.6.1           | tiger      | PostGIS tiger geocoder and reverse geocoder
@@ -231,13 +223,14 @@ kubectl cnpg psql cluster-postgis -- app -c 'SELECT postgis_full_version()'
 Returning:
 
 ```console
-                             postgis_full_version
-
----------------------------------------------------------------------------------------------------------------------------------------------------------
----------------------------------------------------------------------------------------------------------------------------------------------------------
-------------------------------------------------------------------------------
- POSTGIS="3.6.1 f533623" [EXTENSION] PGSQL="180" GEOS="3.13.1-CAPI-1.19.2" SFCGAL="SFCGAL 2.0.0, CGAL 6.0, BOOST 1.83.0" PROJ="9.6.0 NETWORK_ENABLED=OFF
-URL_ENDPOINT= USER_WRITABLE_DIRECTORY=/tmp/proj" (compiled against PROJ 9.6.0) GDAL="GDAL 3.10.3, released 2025/04/01 GDAL_DATA not found" LIBXML="2.9.14
-" LIBJSON="0.18" LIBPROTOBUF="1.5.1" WAGYU="0.5.0 (Internal)" TOPOLOGY RASTER
+                                                    postgis_full_version
+------------------------------------------------------------------------------------------------------------------------
+ POSTGIS="3.6.1 f533623" [EXTENSION] PGSQL="180" GEOS="3.13.1-CAPI-1.19.2"
+ SFCGAL="SFCGAL 2.0.0, CGAL 6.0, BOOST 1.83.0"
+ PROJ="9.6.0 NETWORK_ENABLED=OFF URL_ENDPOINT= USER_WRITABLE_DIRECTORY=/tmp/proj"
+ (compiled against PROJ 9.6.0)
+ GDAL="GDAL 3.10.3, released 2025/04/01 GDAL_DATA not found"
+ LIBXML="2.9.14" LIBJSON="0.18" LIBPROTOBUF="1.5.1" WAGYU="0.5.0 (Internal)"
+ TOPOLOGY RASTER
 (1 row)
 ```

--- a/docs/src/postgis.md
+++ b/docs/src/postgis.md
@@ -112,7 +112,7 @@ metadata:
   name: cluster-postgis
 spec:
   instances: 1
-  imageName: ghcr.io/cloudnative-pg/postgis:18-3.6.1-system-trixie
+  imageName: ghcr.io/cloudnative-pg/postgis:18.1-3.6.1-system-trixie
   storage:
     size: 1Gi
   postgresql:

--- a/docs/src/postgis.md
+++ b/docs/src/postgis.md
@@ -153,7 +153,7 @@ spec:
 ```
 
 :::tip
-Specifying the `version` in the extensions stanza is highly recommended.
+Specifying the `version` in the `extensions` stanza is highly recommended.
 CloudNativePG will compare this version with the one currently installed in the
 database; if they differ, it will automatically execute the necessary
 `ALTER EXTENSION ... UPDATE TO ...` command.

--- a/docs/src/postgis.md
+++ b/docs/src/postgis.md
@@ -17,147 +17,227 @@ Systems) objects in the database and be queried via SQL.
     in Kubernetes via CloudNativePG.
 :::
 
-The CloudNativePG Community maintains container images that are built on top
-of the maintained [PostgreSQL Container images](https://github.com/cloudnative-pg/postgres-containers).
-For more information, please visit:
+## Supported Installation Methods
 
-- The [`postgis-containers` project in GitHub](https://github.com/cloudnative-pg/postgis-containers)
-- The [`postgis-containers` Container Registry in GitHub](https://github.com/cloudnative-pg/postgis-containers/pkgs/container/postgis)
+Depending on your environment (PostgreSQL version, Kubernetes version, and
+CloudNativePG version), you have two primary ways to provision PostGIS:
 
-## Basic concepts about a PostGIS cluster
+1. [**Image Volume Extensions**](#method-1-image-volume-extensions): Mounts
+   extension binaries directly from OCI images as read-only volumes (recommended
+   for PG 18+ and Kubernetes 1.35+).
 
-Conceptually, a PostGIS-based PostgreSQL cluster (or simply a PostGIS cluster)
-is like any other PostgreSQL cluster. The only differences are:
+2. [**PostGIS Operand Images**](#method-2-postgis-operand-images): Uses a
+   pre-built PostgreSQL image that already contains PostGIS libraries.
 
-- the presence in the system of PostGIS and related libraries
-- the presence in the database(s) of the PostGIS extension
+Once PostGIS is provisioned on the system using one of the methods below, you
+must still enable and manage it inside the database (see the
+["Enabling the Extension"](#enabling-the-extension) section below).
 
-Since CloudNativePG is based on Immutable Application Containers, the only way
-to provision PostGIS is to add it to the container image that you use for the
-operand. The ["Container Image Requirements" section](container_images.md) provides
-detailed instructions on how this is achieved. More simply, you can just use
-the PostGIS container images from the Community, as in the examples below.
+## Method 1: Image Volume Extensions
 
-The second step is to install the extension in the PostgreSQL database. You can
-do this in two ways:
+Starting with **PostgreSQL 18** and **Kubernetes 1.35** (1.33 and 1.34 with the
+`ImageVolume` feature gate enabled), you can leverage
+[image volume extensions](imagevolume_extensions.md).
 
-- install it in the application database, which is the main and supposedly only
-  database you host in the cluster according to the microservice architecture, or
-- install it in the `template1` database to make it available for all the
-  databases you end up creating in the cluster, in case you adopt the monolith
-  architecture where the instance is shared by multiple databases
+This is the modern way to manage extensions, as it allows you to use an
+official minimal PostgreSQL image and "plug in" PostGIS at runtime, by mounting
+the content of the extension's OCI image directly into the Postgres container
+as a read-only volume. This decouples the extension lifecycle from the base
+PostgreSQL image, keeping your operand images slim and secure.
 
-:::info
-    For more information on the microservice vs monolith architecture in the database,
-    please refer to the ["How many databases should be hosted in a single PostgreSQL instance?" FAQ](faq.md)
-    or the ["Database import" section](database_import.md).
-:::
+The CloudNativePG Community distributes standalone extension container images
+for PostGIS via the
+[`postgres-extensions-containers`](https://github.com/cloudnative-pg/postgres-extensions-containers/tree/main/postgis)
+repository.
 
-## Create a new PostgreSQL cluster with PostGIS
+<!--
+### For CloudNativePG 1.29+
 
-Let's suppose you want to create a new PostgreSQL 18 cluster with PostGIS 3.6.
+Starting from CloudNativePG 1.29 you can take advantage of
+[image catalogs with image volume extensions](image_catalog.md)
+to automate the management of these versions.
 
-The first step is to ensure you use the right PostGIS container image for the
-operand, and properly set the `.spec.imageName` option in the `Cluster`
-resource.
+### For other supported CNPG versions
+-->
 
-The [`postgis-example.yaml` manifest](samples/postgis-example.yaml) below
-provides some guidance on how the creation of a PostGIS cluster can be done.
-
-:::warning
-    Please consider that, although convention over configuration applies in
-    CloudNativePG, you should spend time configuring and tuning your system for
-    production. Also, the `imageName` in the example below deliberately points
-    to the latest available image for PostgreSQL 18 - you should use a specific
-    image name or, preferably, the SHA256 digest for true immutability.
-    Alternatively, use the provided [image catalogs](https://github.com/cloudnative-pg/postgis-containers?tab=readme-ov-file#image-catalogs).
-:::
+The following illustrative example shows how to add PostGIS 3.6.1 to a
+PostgreSQL 18 cluster, by loading the extension directly in the `Cluster`
+resource:
 
 ```yaml
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
-  name: postgis-example
+  name: cluster-postgis
+spec:
+  imageName: ghcr.io/cloudnative-pg/postgresql:18-minimal-trixie
+  instances: 1
+
+  storage:
+    size: 1Gi
+
+  postgresql:
+    extensions:
+    - name: postgis
+      image:
+        reference: ghcr.io/cloudnative-pg/postgis-extension:3.6.1-18-trixie
+      ld_library_path:
+      - system
+```
+
+:::note
+Refer to the [`postgres-extensions-containers`](https://github.com/cloudnative-pg/postgres-extensions-containers/tree/main/postgis)
+project for the latest versions and instructions for this extension.
+:::
+
+## Method 2: PostGIS Operand Images
+
+For users who prefer to keep using the dedicated `postgis-containers` registry,
+or for those on older versions of PostgreSQL or Kubernetes that do not support
+image volume extensions, the community continues to maintain images with
+PostGIS pre-installed (built on top of the [PostgreSQL Container images](https://github.com/cloudnative-pg/postgres-containers)).
+
+For more information, please visit:
+
+- The [`postgis-containers` project in GitHub](https://github.com/cloudnative-pg/postgis-containers)
+- The [`postgis-containers` Container Registry in GitHub](https://github.com/cloudnative-pg/postgis-containers/pkgs/container/postgis)
+
+To use this method, point the `.spec.imageName` to the desired PostGIS-enabled
+image:
+
+```yaml
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: cluster-postgis
 spec:
   instances: 1
-  imageName: ghcr.io/cloudnative-pg/postgis:18-3.6-system-trixie
+  imageName: ghcr.io/cloudnative-pg/postgis:18-3.6.1-system-trixie
   storage:
     size: 1Gi
   postgresql:
     parameters:
       log_statement: ddl
+```
+
 ---
+
+## Enabling the Extension
+
+Once the binaries are provisioned (via an image volume extension or directly in
+the `Cluster` resource), you must enable the extension in the database.
+
+Using the `Database` resource allows for declarative management of the
+extension's lifecycle, including version upgrades.
+
+:::info
+For more details, see the
+["Managing Extensions in a Database" section](declarative_database_management.md#managing-extensions-in-a-database).
+:::
+
+```yaml
 apiVersion: postgresql.cnpg.io/v1
 kind: Database
 metadata:
-  name: postgis-example-app
+  name: cluster-postgis-app
 spec:
   name: app
   owner: app
   cluster:
-    name: postgis-example
+    name: cluster-postgis
   extensions:
   - name: postgis
-  - name: postgis_topology
+    version: '3.6.1'
+  - name: postgis_raster
+  - name: postgis_sfcgal
   - name: fuzzystrmatch
+  - name: address_standardizer
+  - name: address_standardizer_data_us
   - name: postgis_tiger_geocoder
+  - name: postgis_topology
 ```
 
-The example leverages the `Database` resource's declarative extension
-management to add the specified extensions to the `app` database.
-
-:::info
-    For more details, see the
-    ["Managing Extensions in a Database" section](declarative_database_management.md#managing-extensions-in-a-database).
+:::tip
+Specifying the `version` in the extensions stanza is highly recommended.
+CloudNativePG will compare this version with the one currently installed in the
+database; if they differ, it will automatically execute the necessary
+`ALTER EXTENSION ... UPDATE TO ...` command.
 :::
 
+## Verification
+
 You can easily verify the available version of PostGIS that is in the
-container, by connecting to the `app` database (you might obtain different
-values from the ones in this document):
+container, by connecting to the `app` database and querying the PostgreSQL
+catalog. For example:
+
+```bash
+kubectl cnpg psql cluster-postgis -- app -c \
+  "SELECT * FROM pg_available_extensions WHERE name ~ '^postgis' ORDER BY 1"
+```
+
+Returning something similar to this (you might obtain different values from the
+ones in this document):
 
 ```console
-$ kubectl cnpg psql postgis-example -- app
-psql (18.1 (Debian 18.1-1.pgdg13+3))
-Type "help" for help.
-
-app=# SELECT * FROM pg_available_extensions WHERE name ~ '^postgis' ORDER BY 1;
            name           | default_version | installed_version |                          comment
 --------------------------+-----------------+-------------------+------------------------------------------------------------
- postgis                  | 3.6.0           | 3.6.0             | PostGIS geometry and geography spatial types and functions
- postgis-3                | 3.6.0           |                   | PostGIS geometry and geography spatial types and functions
- postgis_raster           | 3.6.0           |                   | PostGIS raster types and functions
- postgis_raster-3         | 3.6.0           |                   | PostGIS raster types and functions
- postgis_sfcgal           | 3.6.0           |                   | PostGIS SFCGAL functions
- postgis_sfcgal-3         | 3.6.0           |                   | PostGIS SFCGAL functions
- postgis_tiger_geocoder   | 3.6.0           | 3.6.0             | PostGIS tiger geocoder and reverse geocoder
- postgis_tiger_geocoder-3 | 3.6.0           |                   | PostGIS tiger geocoder and reverse geocoder
- postgis_topology         | 3.6.0           | 3.6.0             | PostGIS topology spatial types and functions
- postgis_topology-3       | 3.6.0           |                   | PostGIS topology spatial types and functions
+ postgis                  | 3.6.1           | 3.6.1             | PostGIS geometry and geography spatial types and functions
+ postgis-3                | 3.6.1           |                   | PostGIS geometry and geography spatial types and functions
+ postgis_raster           | 3.6.1           | 3.6.1             | PostGIS raster types and functions
+ postgis_raster-3         | 3.6.1           |                   | PostGIS raster types and functions
+ postgis_sfcgal           | 3.6.1           | 3.6.1             | PostGIS SFCGAL functions
+ postgis_sfcgal-3         | 3.6.1           |                   | PostGIS SFCGAL functions
+ postgis_tiger_geocoder   | 3.6.1           | 3.6.1             | PostGIS tiger geocoder and reverse geocoder
+ postgis_tiger_geocoder-3 | 3.6.1           |                   | PostGIS tiger geocoder and reverse geocoder
+ postgis_topology         | 3.6.1           | 3.6.1             | PostGIS topology spatial types and functions
+ postgis_topology-3       | 3.6.1           |                   | PostGIS topology spatial types and functions
 (10 rows)
 ```
 
 The next step is to verify that the extensions listed in the `Database`
-resource have been correctly installed in the `app` database.
+resource have been correctly installed in the `app` database:
+
+```bash
+kubectl cnpg psql cluster-postgis -- app -c '\dx'
+```
+
+The command returns something like this:
 
 ```console
-app=# \dx
-                                                 List of installed extensions
-          Name          | Version | Default version |   Schema   |                        Description
-------------------------+---------+-----------------+------------+------------------------------------------------------------
- fuzzystrmatch          | 1.2     | 1.2             | public     | determine similarities and distance between strings
- plpgsql                | 1.0     | 1.0             | pg_catalog | PL/pgSQL procedural language
- postgis                | 3.6.0   | 3.6.0           | public     | PostGIS geometry and geography spatial types and functions
- postgis_tiger_geocoder | 3.6.0   | 3.6.0           | tiger      | PostGIS tiger geocoder and reverse geocoder
- postgis_topology       | 3.6.0   | 3.6.0           | topology   | PostGIS topology spatial types and functions
+                                                                                List of installed extensions
+             Name             | Version | Default version |   Schema   |                                                     Description
+
+------------------------------+---------+-----------------+------------+---------------------------------------------------------------------------------
+------------------------------------
+ address_standardizer         | 3.6.1   | 3.6.1           | public     | Used to parse an address into constituent elements. Generally used to support ge
+ocoding address normalization step.
+ address_standardizer_data_us | 3.6.1   | 3.6.1           | public     | Address Standardizer US dataset example
+ fuzzystrmatch                | 1.2     | 1.2             | public     | determine similarities and distance between strings
+ plpgsql                      | 1.0     | 1.0             | pg_catalog | PL/pgSQL procedural language
+ postgis                      | 3.6.1   | 3.6.1           | public     | PostGIS geometry and geography spatial types and functions
+ postgis_raster               | 3.6.1   | 3.6.1           | public     | PostGIS raster types and functions
+ postgis_sfcgal               | 3.6.1   | 3.6.1           | public     | PostGIS SFCGAL functions
+ postgis_tiger_geocoder       | 3.6.1   | 3.6.1           | tiger      | PostGIS tiger geocoder and reverse geocoder
+ postgis_topology             | 3.6.1   | 3.6.1           | topology   | PostGIS topology spatial types and functions
+(9 rows)
 ```
 
 Finally:
 
+```bash
+kubectl cnpg psql cluster-postgis -- app -c 'SELECT postgis_full_version()'
+```
+
+Returning:
+
 ```console
-app=# SELECT postgis_full_version();
-                                                                            postgis_full_version
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- POSTGIS="3.6.0 4c1967d" [EXTENSION] PGSQL="180" GEOS="3.13.1-CAPI-1.19.2" PROJ="9.6.0 NETWORK_ENABLED=OFF URL_ENDPOINT=https://cdn.proj.org USER_WRITABLE_DIRECTORY=/tmp/proj DATABASE_PATH=/usr/share/proj/proj.
-db" (compiled against PROJ 9.6.0) LIBXML="2.9.14" LIBJSON="0.18" LIBPROTOBUF="1.5.1" WAGYU="0.5.0 (Internal)" TOPOLOGY
+                             postgis_full_version
+
+---------------------------------------------------------------------------------------------------------------------------------------------------------
+---------------------------------------------------------------------------------------------------------------------------------------------------------
+------------------------------------------------------------------------------
+ POSTGIS="3.6.1 f533623" [EXTENSION] PGSQL="180" GEOS="3.13.1-CAPI-1.19.2" SFCGAL="SFCGAL 2.0.0, CGAL 6.0, BOOST 1.83.0" PROJ="9.6.0 NETWORK_ENABLED=OFF
+URL_ENDPOINT= USER_WRITABLE_DIRECTORY=/tmp/proj" (compiled against PROJ 9.6.0) GDAL="GDAL 3.10.3, released 2025/04/01 GDAL_DATA not found" LIBXML="2.9.14
+" LIBJSON="0.18" LIBPROTOBUF="1.5.1" WAGYU="0.5.0 (Internal)" TOPOLOGY RASTER
 (1 row)
 ```

--- a/docs/src/postgis.md
+++ b/docs/src/postgis.md
@@ -70,7 +70,7 @@ kind: Cluster
 metadata:
   name: cluster-postgis
 spec:
-  imageName: ghcr.io/cloudnative-pg/postgresql:18-minimal-trixie
+  imageName: ghcr.io/cloudnative-pg/postgresql:18.1-minimal-trixie
   instances: 1
 
   storage:

--- a/docs/src/samples.md
+++ b/docs/src/samples.md
@@ -118,9 +118,9 @@ your PostgreSQL cluster.
 
 ## PostGIS
 
-**PostGIS example**
+**PostGIS example with image volume extensions**
 : [`postgis-example.yaml`](samples/postgis-example.yaml):
-   An example of a PostGIS cluster. See [PostGIS](postgis.md) for details.
+   An example of a PostGIS cluster using image volume extensions. See [PostGIS](postgis.md) for details.
 
 ## Managed roles
 

--- a/docs/src/samples/postgis-example.yaml
+++ b/docs/src/samples/postgis-example.yaml
@@ -3,13 +3,19 @@ kind: Cluster
 metadata:
   name: postgis-example
 spec:
+  imageName: ghcr.io/cloudnative-pg/postgresql:18.1-minimal-trixie
   instances: 1
-  imageName: ghcr.io/cloudnative-pg/postgis:18-3.6-system-trixie
+
   storage:
     size: 1Gi
+
   postgresql:
-    parameters:
-      log_statement: ddl
+    extensions:
+    - name: postgis
+      image:
+        reference: ghcr.io/cloudnative-pg/postgis-extension:3.6.1-18-trixie
+      ld_library_path:
+      - system
 ---
 apiVersion: postgresql.cnpg.io/v1
 kind: Database
@@ -22,6 +28,11 @@ spec:
     name: postgis-example
   extensions:
   - name: postgis
-  - name: postgis_topology
+    version: '3.6.1'
+  - name: postgis_raster
+  - name: postgis_sfcgal
   - name: fuzzystrmatch
+  - name: address_standardizer
+  - name: address_standardizer_data_us
   - name: postgis_tiger_geocoder
+  - name: postgis_topology


### PR DESCRIPTION
Rework the PostGIS documentation to introduce Image Volume Extensions supported in PostgreSQL 18 and Kubernetes 1.35.

Changes include:

- Added Method 1: Provisioning via Image Volume Extensions using minimal PostgreSQL images.
- Refined Method 2: Legacy provisioning via PostGIS operand images.
- Updated examples to use the `extensions` stanza in the Cluster resource.
- Enhanced the Database resource section to emphasise declarative extension version management (`ALTER EXTENSION` updates).
- Clarified the distinction between system provisioning and database-level activation.

Assisted-by: Google Gemini

Closes #9938 