### PR TITLE
docs: fix container image tag

### DIFF
--- a/docs/src/postgis.md
+++ b/docs/src/postgis.md
@@ -112,7 +112,7 @@ metadata:
   name: cluster-postgis
 spec:
   instances: 1
-  imageName: ghcr.io/cloudnative-pg/postgis:18-3.6.1-system-trixie
+  imageName: ghcr.io/cloudnative-pg/postgis:18.1-3.6.1-system-trixie
   storage:
     size: 1Gi
   postgresql:


### PR DESCRIPTION
Fixing wrong container image tag in the doc

```shell
crane ls ghcr.io/cloudnative-pg/postgis | grep "3.6.1-system-trixie"
18.1-3.6.1-system-trixie
15.15-3.6.1-system-trixie
16.11-3.6.1-system-trixie
14.20-3.6.1-system-trixie
17.7-3.6.1-system-trixie
```