### PR TITLE
fix(roles): prevent postgres from leaking role passwords in logs

### DIFF
--- a/.wordlist-en-custom.txt
+++ b/.wordlist-en-custom.txt
@@ -696,6 +696,7 @@ cisecurity
 claimRef
 className
 classid
+cleartext
 cli
 clientCA
 clientCASecret

--- a/docs/src/declarative_role_management.md
+++ b/docs/src/declarative_role_management.md
@@ -179,7 +179,7 @@ stringData:
   password: SCRAM-SHA-256$<iteration count>:<salt>$<StoredKey>:<ServerKey>
 ```
 
-### Safety when using non-encrypted passwords
+### Safety when transmitting cleartext passwords
 
 While role passwords are safely managed in Kubernetes using Secrets,
 there is still a risk on the PostgreSQL side. If creating/altering a role with

--- a/docs/src/declarative_role_management.md
+++ b/docs/src/declarative_role_management.md
@@ -189,10 +189,11 @@ in some `postgres` logs, as mentioned in the [PostgreSQL documentation](https://
 > The password will be transmitted to the server in cleartext, and it might
 > also be logged in the client's command history or the server log
 
-CloudNativePG adds a safety layer by ensuring that `postgres` logging does not
-include the query statement for any CREATE or ALTER operation on a role with
-password, thus preventing leakage.
-The  Status section of the cluster does not print the query statement for any
+CloudNativePG adds a safety layer by temporarily suppressing both statement
+logging (`log_statement`) and error statement logging
+(`log_min_error_statement`) for any CREATE or ALTER operation on a role with
+password, thus preventing leakage in both success and failure scenarios.
+The Status section of the cluster does not print the query statement for any
 managed role operation.
 
 ## Unrealizable role configurations

--- a/docs/src/declarative_role_management.md
+++ b/docs/src/declarative_role_management.md
@@ -179,6 +179,19 @@ stringData:
   password: SCRAM-SHA-256$<iteration count>:<salt>$<StoredKey>:<ServerKey>
 ```
 
+### Safety when using non-encrypted passwords
+
+While role passwords are safely managed in Kubernetes using Secrets,
+there is still a risk on the PostgreSQL side. If creating/altering a role with
+password, postgres may print the password in some logging statements,
+as mentioned in the [PostgreSQL documentation](https://www.postgresql.org/docs/current/sql-createrole.html):
+
+> The password will be transmitted to the server in cleartext, and it might
+> also be logged in the client's command history or the server log
+
+CloudNativePG adds a safety layer by ensuring that postgres logging is disabled during a CREATE or ALTER of a role that includes a non-null password.
+The  Status section of the cluster will still report any pending roles.
+
 ## Unrealizable role configurations
 
 In PostgreSQL, in some cases, commands cannot be honored by the database and

--- a/docs/src/declarative_role_management.md
+++ b/docs/src/declarative_role_management.md
@@ -189,7 +189,8 @@ as mentioned in the [PostgreSQL documentation](https://www.postgresql.org/docs/c
 > The password will be transmitted to the server in cleartext, and it might
 > also be logged in the client's command history or the server log
 
-CloudNativePG adds a safety layer by ensuring that postgres logging is disabled for any CREATE or ALTER operation on a role that includes a non-null password.
+CloudNativePG adds a safety layer by ensuring that postgres logging is disabled
+for any CREATE or ALTER operation on a role that includes a non-null password.
 The  Status section of the cluster will still report any pending roles.
 
 ## Unrealizable role configurations

--- a/docs/src/declarative_role_management.md
+++ b/docs/src/declarative_role_management.md
@@ -189,7 +189,7 @@ as mentioned in the [PostgreSQL documentation](https://www.postgresql.org/docs/c
 > The password will be transmitted to the server in cleartext, and it might
 > also be logged in the client's command history or the server log
 
-CloudNativePG adds a safety layer by ensuring that postgres logging is disabled during a CREATE or ALTER of a role that includes a non-null password.
+CloudNativePG adds a safety layer by ensuring that postgres logging is disabled for any CREATE or ALTER operation on a role that includes a non-null password.
 The  Status section of the cluster will still report any pending roles.
 
 ## Unrealizable role configurations

--- a/docs/src/declarative_role_management.md
+++ b/docs/src/declarative_role_management.md
@@ -183,15 +183,17 @@ stringData:
 
 While role passwords are safely managed in Kubernetes using Secrets,
 there is still a risk on the PostgreSQL side. If creating/altering a role with
-password, postgres may print the password in some logging statements,
-as mentioned in the [PostgreSQL documentation](https://www.postgresql.org/docs/current/sql-createrole.html):
+password, PostgreSQL may print the password as part of the query statement
+in some `postgres` logs, as mentioned in the [PostgreSQL documentation](https://www.postgresql.org/docs/current/sql-createrole.html):
 
 > The password will be transmitted to the server in cleartext, and it might
 > also be logged in the client's command history or the server log
 
-CloudNativePG adds a safety layer by ensuring that postgres logging is disabled
-for any CREATE or ALTER operation on a role that includes a non-null password.
-The  Status section of the cluster will still report any pending roles.
+CloudNativePG adds a safety layer by ensuring that `postgres` logging does not
+include the query statement for any CREATE or ALTER operation on a role with
+password, thus preventing leakage.
+The  Status section of the cluster does not print the query statement for any
+managed role operation.
 
 ## Unrealizable role configurations
 

--- a/docs/src/security.md
+++ b/docs/src/security.md
@@ -592,6 +592,13 @@ versions it is set to `md5`.
     `postgres` user to `NULL` (de facto disabling remote access through password authentication).
 :::
 
+:::info[Important]
+    Postgres may include cleartext password in its logs in some cases, as
+    mentioned in the [PostgreSQL documentation](https://www.postgresql.org/docs/current/sql-createrole.html). \
+    CloudNativePG disables postgres logs produced by CREATE/ALTER operations on
+    roles that include a password string.
+:::
+
 See the ["Secrets" section in the "Connecting from an application" page](applications.md#secrets) for more information.
 
 You can use those files to configure application access to the database.

--- a/docs/src/security.md
+++ b/docs/src/security.md
@@ -594,10 +594,10 @@ versions it is set to `md5`.
 
 :::info[Important]
     PostgreSQL may include cleartext role passwords in its logs for some role
-     operations, as mentioned in the [PostgreSQL documentation](https://www.postgresql.org/docs/current/sql-createrole.html). \
-    CloudNativePG ensures that `postgres` logs produced by CREATE/ALTER ROLE
-    operations don't include the query statement, thus preventing any password
-    leakage.
+    operations, as mentioned in the [PostgreSQL documentation](https://www.postgresql.org/docs/current/sql-createrole.html). \
+    CloudNativePG ensures that `postgres` logging (both statement logging and
+    error statement logging) is temporarily suppressed for CREATE/ALTER ROLE
+    operations with passwords, thus preventing any password leakage.
 :::
 
 See the ["Secrets" section in the "Connecting from an application" page](applications.md#secrets) for more information.

--- a/docs/src/security.md
+++ b/docs/src/security.md
@@ -594,7 +594,7 @@ versions it is set to `md5`.
 
 :::info[Important]
     PostgreSQL may include cleartext role passwords in its logs for some role
-    operations, as mentioned in the [PostgreSQL documentation](https://www.postgresql.org/docs/current/sql-createrole.html). \
+    operations, as mentioned in the [PostgreSQL documentation](https://www.postgresql.org/docs/current/sql-createrole.html).
     CloudNativePG ensures that `postgres` logging (both statement logging and
     error statement logging) is temporarily suppressed for CREATE/ALTER ROLE
     operations with passwords, thus preventing any password leakage.

--- a/docs/src/security.md
+++ b/docs/src/security.md
@@ -593,10 +593,11 @@ versions it is set to `md5`.
 :::
 
 :::info[Important]
-    Postgres may include cleartext password in its logs in some cases, as
-    mentioned in the [PostgreSQL documentation](https://www.postgresql.org/docs/current/sql-createrole.html). \
-    CloudNativePG disables postgres logs produced by CREATE/ALTER operations on
-    roles that include a password string.
+    PostgreSQL may include cleartext role passwords in its logs for some role
+     operations, as mentioned in the [PostgreSQL documentation](https://www.postgresql.org/docs/current/sql-createrole.html). \
+    CloudNativePG ensures that `postgres` logs produced by CREATE/ALTER ROLE
+    operations don't include the query statement, thus preventing any password
+    leakage.
 :::
 
 See the ["Secrets" section in the "Connecting from an application" page](applications.md#secrets) for more information.

--- a/internal/management/controller/instance_controller.go
+++ b/internal/management/controller/instance_controller.go
@@ -1307,7 +1307,7 @@ func (r *InstanceReconciler) reconcileUser(ctx context.Context, username string,
 		return fmt.Errorf("wrong username '%v' in secret, expected '%v'", usernameFromSecret, username)
 	}
 
-	err = postgresutils.SetUserPassword(username, password, db)
+	err = postgresutils.SetUserPassword(ctx, username, password, db)
 	if err != nil {
 		return err
 	}

--- a/internal/management/controller/roles/postgres.go
+++ b/internal/management/controller/roles/postgres.go
@@ -119,7 +119,7 @@ func Update(ctx context.Context, db *sql.DB, role DatabaseRole) error {
 	}
 	var query strings.Builder
 
-	query.WriteString(fmt.Sprintf("ALTER ROLE %s ", pgx.Identifier{role.Name}.Sanitize()))
+	query.WriteString(fmt.Sprintf("ALTER ROLE %s", pgx.Identifier{role.Name}.Sanitize()))
 	appendRoleOptions(role, &query)
 	// Log before appending password to prevent password leakage in operator logs
 	contextLog.Debug("Updating role", "role", role.Name, "query", query.String())
@@ -143,7 +143,7 @@ func Create(ctx context.Context, db *sql.DB, role DatabaseRole) error {
 	}
 
 	var query strings.Builder
-	query.WriteString(fmt.Sprintf("CREATE ROLE %s ", pgx.Identifier{role.Name}.Sanitize()))
+	query.WriteString(fmt.Sprintf("CREATE ROLE %s", pgx.Identifier{role.Name}.Sanitize()))
 	appendRoleOptions(role, &query)
 	appendInRoleOptions(role, &query)
 	// Log before appending password to prevent password leakage in operator logs
@@ -321,7 +321,7 @@ func appendInRoleOptions(role DatabaseRole, query *strings.Builder) {
 			quotedInRoles[i] = pgx.Identifier{inRole}.Sanitize()
 		}
 
-		fmt.Fprintf(query, " IN ROLE %s ", strings.Join(quotedInRoles, ","))
+		fmt.Fprintf(query, " IN ROLE %s", strings.Join(quotedInRoles, ","))
 	}
 }
 

--- a/internal/management/controller/roles/postgres.go
+++ b/internal/management/controller/roles/postgres.go
@@ -100,8 +100,8 @@ func List(ctx context.Context, db *sql.DB) ([]DatabaseRole, error) {
 	return roles, nil
 }
 
-func executeRoleStatement(ctx context.Context, db *sql.DB, statement string, silcenceErrLog bool) error {
-	if !silcenceErrLog {
+func executeRoleStatement(ctx context.Context, db *sql.DB, statement string, silenceErrLog bool) error {
+	if !silenceErrLog {
 		_, err := db.ExecContext(ctx, statement)
 		return err
 	}

--- a/internal/management/controller/roles/postgres.go
+++ b/internal/management/controller/roles/postgres.go
@@ -110,12 +110,9 @@ func executeRoleStatement(ctx context.Context, db *sql.DB, statement string, sil
 		return err
 	}
 	defer func() {
-		if err != nil {
-			errRollback := tx.Rollback()
-			if errRollback != nil {
-				err = errors.Join(err, errRollback)
-			}
-		}
+		// This has no effect if the transaction
+		// is committed
+		_ = tx.Rollback()
 	}()
 	_, err = tx.ExecContext(ctx, "SET LOCAL log_min_error_statement = 'PANIC'")
 	if err != nil {

--- a/internal/management/controller/roles/postgres.go
+++ b/internal/management/controller/roles/postgres.go
@@ -121,6 +121,7 @@ func Update(ctx context.Context, db *sql.DB, role DatabaseRole) error {
 
 	query.WriteString(fmt.Sprintf("ALTER ROLE %s ", pgx.Identifier{role.Name}.Sanitize()))
 	appendRoleOptions(role, &query)
+	// Log before appending password to prevent password leakage in operator logs
 	contextLog.Debug("Updating role", "role", role.Name, "query", query.String())
 	// NOTE: always apply the password update. Since the transaction ID of the role
 	// will change no matter what, the next reconciliation cycle we would update the password
@@ -145,6 +146,7 @@ func Create(ctx context.Context, db *sql.DB, role DatabaseRole) error {
 	query.WriteString(fmt.Sprintf("CREATE ROLE %s ", pgx.Identifier{role.Name}.Sanitize()))
 	appendRoleOptions(role, &query)
 	appendInRoleOptions(role, &query)
+	// Log before appending password to prevent password leakage in operator logs
 	contextLog.Debug("Creating", "query", query.String())
 	appendPasswordOption(role, &query)
 

--- a/internal/management/controller/roles/postgres.go
+++ b/internal/management/controller/roles/postgres.go
@@ -114,6 +114,10 @@ func executeRoleStatement(ctx context.Context, db *sql.DB, statement string, sil
 		// is committed
 		_ = tx.Rollback()
 	}()
+	_, err = tx.ExecContext(ctx, "SET LOCAL log_statement = 'none'")
+	if err != nil {
+		return err
+	}
 	_, err = tx.ExecContext(ctx, "SET LOCAL log_min_error_statement = 'PANIC'")
 	if err != nil {
 		return err
@@ -160,8 +164,8 @@ func Create(ctx context.Context, db *sql.DB, role DatabaseRole) error {
 	query.WriteString(fmt.Sprintf("CREATE ROLE %s ", pgx.Identifier{role.Name}.Sanitize()))
 	appendRoleOptions(role, &query)
 	appendInRoleOptions(role, &query)
-	containsPassword := appendPasswordOption(role, &query)
 	contextLog.Debug("Creating", "query", query.String())
+	containsPassword := appendPasswordOption(role, &query)
 
 	// NOTE: defensively we might think of doing CREATE ... IF EXISTS
 	// but at least during development, we want to catch the error

--- a/internal/management/controller/roles/postgres_test.go
+++ b/internal/management/controller/roles/postgres_test.go
@@ -322,7 +322,7 @@ var _ = Describe("Postgres RoleManager implementation test", func() {
 		dbRole.password = sql.NullString{Valid: true, String: "myPassword"}
 		err = Create(ctx, db, dbRole)
 		Expect(err).To(HaveOccurred())
-		Expect(errors.Is(err, dbError)).To(BeTrue())
+		Expect(err).To(MatchError(dbError))
 	})
 
 	It("Create will send a correct CREATE with password deletion to the DB", func(ctx context.Context) {
@@ -338,7 +338,7 @@ var _ = Describe("Postgres RoleManager implementation test", func() {
 			roleConfigurationAdapter{RoleConfiguration: wantedRoleWithPassDeletion}.toDatabaseRole())
 		Expect(err).ShouldNot(HaveOccurred())
 	})
-	It("Create will send a correct CREATE with password deletion to the DB", func(ctx context.Context) {
+	It("Create will send a correct CREATE with default connection limit to the DB", func(ctx context.Context) {
 		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 		Expect(err).ToNot(HaveOccurred())
 
@@ -419,7 +419,7 @@ var _ = Describe("Postgres RoleManager implementation test", func() {
 		dbRole.password = sql.NullString{Valid: true, String: "myPassword"}
 		err = Update(ctx, db, dbRole)
 		Expect(err).To(HaveOccurred())
-		Expect(errors.Is(err, dbError)).To(BeTrue())
+		Expect(err).To(MatchError(dbError))
 	})
 	It("Update will return error if there is a problem updating the role in the DB", func(ctx context.Context) {
 		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
@@ -431,7 +431,7 @@ var _ = Describe("Postgres RoleManager implementation test", func() {
 
 		err = Update(ctx, db, roleConfigurationAdapter{RoleConfiguration: wantedRole}.toDatabaseRole())
 		Expect(err).To(HaveOccurred())
-		Expect(errors.Is(err, dbError)).To(BeTrue())
+		Expect(err).To(MatchError(dbError))
 	})
 
 	// Testing COMMENT
@@ -455,7 +455,7 @@ var _ = Describe("Postgres RoleManager implementation test", func() {
 
 		err = UpdateComment(ctx, db, roleConfigurationAdapter{RoleConfiguration: wantedRole}.toDatabaseRole())
 		Expect(err).To(HaveOccurred())
-		Expect(errors.Is(err, dbError)).To(BeTrue())
+		Expect(err).To(MatchError(dbError))
 	})
 
 	It("GetParentRoles will return the roles a given role belongs to", func(ctx context.Context) {

--- a/internal/management/controller/roles/postgres_test.go
+++ b/internal/management/controller/roles/postgres_test.go
@@ -255,7 +255,7 @@ var _ = Describe("Postgres RoleManager implementation test", func() {
 		Expect(err).To(HaveOccurred())
 		Expect(errors.Unwrap(err)).To(BeEquivalentTo(dbError))
 	})
-	It("Create will send a correct CREATE with password and prevent Postgres logging", func(ctx context.Context) {
+	It("Create with password will send CREATE and prevent Postgres from logging the query", func(ctx context.Context) {
 		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 		Expect(err).ToNot(HaveOccurred())
 
@@ -297,7 +297,7 @@ var _ = Describe("Postgres RoleManager implementation test", func() {
 		err = Create(ctx, db, dbRole)
 		Expect(err).ShouldNot(HaveOccurred())
 	})
-	It("Create will rollback CREATE with password to the DB if there is an error", func(ctx context.Context) {
+	It("Create with password will rollback CREATE if there is an error", func(ctx context.Context) {
 		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 		Expect(err).ToNot(HaveOccurred())
 
@@ -376,7 +376,7 @@ var _ = Describe("Postgres RoleManager implementation test", func() {
 		err = Update(ctx, db, roleConfigurationAdapter{RoleConfiguration: wantedRole}.toDatabaseRole())
 		Expect(err).ShouldNot(HaveOccurred())
 	})
-	It("Update with PASS will ALTER the DB and prevent Postgres logging", func(ctx context.Context) {
+	It("Update with password will ALTER the DB and prevent Postgres from logging the query", func(ctx context.Context) {
 		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 		Expect(err).ToNot(HaveOccurred())
 
@@ -392,7 +392,7 @@ var _ = Describe("Postgres RoleManager implementation test", func() {
 		err = Update(ctx, db, dbRole)
 		Expect(err).ShouldNot(HaveOccurred())
 	})
-	It("Update with PASS will rollback ALTER if there is an error", func(ctx context.Context) {
+	It("Update with password will rollback ALTER if there is an error", func(ctx context.Context) {
 		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 		Expect(err).ToNot(HaveOccurred())
 

--- a/internal/management/controller/roles/postgres_test.go
+++ b/internal/management/controller/roles/postgres_test.go
@@ -115,6 +115,8 @@ var _ = Describe("Postgres RoleManager implementation test", func() {
 			"NOSUPERUSER CONNECTION LIMIT 2 IN ROLE \"pg_monitoring\" PASSWORD 'myPassword' VALID UNTIL '2100-01-01 00:00:00Z'",
 		wantedRole.Name)
 
+	wantedLogPreventionStmt := "SET LOCAL log_min_error_statement = 'PANIC'"
+
 	wantedRoleWithoutValidUntilExpectedCrtStmt := fmt.Sprintf(
 		"CREATE ROLE \"%s\" BYPASSRLS NOCREATEDB CREATEROLE NOINHERIT LOGIN NOREPLICATION "+
 			"NOSUPERUSER CONNECTION LIMIT 2 IN ROLE \"pg_monitoring\" PASSWORD 'myPassword'",
@@ -134,7 +136,12 @@ var _ = Describe("Postgres RoleManager implementation test", func() {
 		wantedRole.Name, pq.QuoteLiteral(wantedRole.Comment))
 
 	wantedRoleExpectedAltStmt := fmt.Sprintf(
-		"ALTER ROLE \"%s\" BYPASSRLS NOCREATEDB CREATEROLE NOINHERIT LOGIN NOREPLICATION NOSUPERUSER CONNECTION LIMIT 2 ",
+		"ALTER ROLE \"%s\" BYPASSRLS NOCREATEDB CREATEROLE NOINHERIT LOGIN NOREPLICATION NOSUPERUSER CONNECTION LIMIT 2 "+
+			"VALID UNTIL '2100-01-01 00:00:00Z'",
+		wantedRole.Name)
+	wantedRoleExpectedAltWithPasswordStmt := fmt.Sprintf(
+		"ALTER ROLE \"%s\"  BYPASSRLS NOCREATEDB CREATEROLE NOINHERIT LOGIN NOREPLICATION NOSUPERUSER CONNECTION LIMIT 2 "+
+			"PASSWORD 'myPassword' VALID UNTIL '2100-01-01 00:00:00Z'",
 		wantedRole.Name)
 	unWantedRoleExpectedDelStmt := fmt.Sprintf("DROP ROLE \"%s\"", unWantedRole.Name)
 
@@ -248,12 +255,16 @@ var _ = Describe("Postgres RoleManager implementation test", func() {
 		Expect(err).To(HaveOccurred())
 		Expect(errors.Unwrap(err)).To(BeEquivalentTo(dbError))
 	})
-	It("Create will send a correct CREATE with password to the DB", func(ctx context.Context) {
+	It("Create will send a correct CREATE with password and prevent Postgres logging", func(ctx context.Context) {
 		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 		Expect(err).ToNot(HaveOccurred())
 
+		mock.ExpectBegin()
+		mock.ExpectExec(wantedLogPreventionStmt).
+			WillReturnResult(sqlmock.NewResult(0, 1))
 		mock.ExpectExec(wantedRoleWithPassExpectedCrtStmt).
 			WillReturnResult(sqlmock.NewResult(2, 3))
+		mock.ExpectCommit()
 
 		mock.ExpectExec(wantedRoleCommentStmt).
 			WillReturnResult(sqlmock.NewResult(2, 3))
@@ -268,8 +279,12 @@ var _ = Describe("Postgres RoleManager implementation test", func() {
 		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 		Expect(err).ToNot(HaveOccurred())
 
+		mock.ExpectBegin()
+		mock.ExpectExec(wantedLogPreventionStmt).
+			WillReturnResult(sqlmock.NewResult(0, 1))
 		mock.ExpectExec(wantedRoleWithoutValidUntilExpectedCrtStmt).
 			WillReturnResult(sqlmock.NewResult(2, 3))
+		mock.ExpectCommit()
 
 		mock.ExpectExec(wantedRoleCommentStmt).
 			WillReturnResult(sqlmock.NewResult(2, 3))
@@ -282,6 +297,27 @@ var _ = Describe("Postgres RoleManager implementation test", func() {
 		err = Create(ctx, db, dbRole)
 		Expect(err).ShouldNot(HaveOccurred())
 	})
+	It("Create will rollback CREATE with password to the DB if there is an error", func(ctx context.Context) {
+		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+		Expect(err).ToNot(HaveOccurred())
+
+		mock.ExpectBegin()
+		mock.ExpectExec(wantedLogPreventionStmt).
+			WillReturnResult(sqlmock.NewResult(0, 1))
+		dbError := errors.New("kaboom")
+		mock.ExpectExec(wantedRoleWithPassExpectedCrtStmt).
+			WillReturnError(dbError)
+		mock.ExpectRollback()
+
+		dbRole := roleConfigurationAdapter{RoleConfiguration: wantedRoleWithPass}.toDatabaseRole()
+		// In this unit test we are not testing the retrieval of secrets, so let's
+		// fetch the password content by hand
+		dbRole.password = sql.NullString{Valid: true, String: "myPassword"}
+		err = Create(ctx, db, dbRole)
+		Expect(err).To(HaveOccurred())
+		Expect(errors.Is(err, dbError)).To(BeTrue())
+	})
+
 	It("Create will send a correct CREATE with password deletion to the DB", func(ctx context.Context) {
 		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 		Expect(err).ToNot(HaveOccurred())
@@ -332,7 +368,7 @@ var _ = Describe("Postgres RoleManager implementation test", func() {
 	})
 	// Testing Alter
 	It("Update will send a correct ALTER to the DB", func(ctx context.Context) {
-		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherRegexp))
+		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 		Expect(err).ToNot(HaveOccurred())
 
 		mock.ExpectExec(wantedRoleExpectedAltStmt).
@@ -340,8 +376,42 @@ var _ = Describe("Postgres RoleManager implementation test", func() {
 		err = Update(ctx, db, roleConfigurationAdapter{RoleConfiguration: wantedRole}.toDatabaseRole())
 		Expect(err).ShouldNot(HaveOccurred())
 	})
+	It("Update with PASS will ALTER the DB and prevent Postgres logging", func(ctx context.Context) {
+		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+		Expect(err).ToNot(HaveOccurred())
+
+		mock.ExpectBegin()
+		mock.ExpectExec(wantedLogPreventionStmt).
+			WillReturnResult(sqlmock.NewResult(0, 1))
+		mock.ExpectExec(wantedRoleExpectedAltWithPasswordStmt).
+			WillReturnResult(sqlmock.NewResult(2, 3))
+		mock.ExpectCommit()
+
+		dbRole := roleConfigurationAdapter{RoleConfiguration: wantedRoleWithPass}.toDatabaseRole()
+		dbRole.password = sql.NullString{Valid: true, String: "myPassword"}
+		err = Update(ctx, db, dbRole)
+		Expect(err).ShouldNot(HaveOccurred())
+	})
+	It("Update with PASS will rollback ALTER if there is an error", func(ctx context.Context) {
+		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+		Expect(err).ToNot(HaveOccurred())
+
+		mock.ExpectBegin()
+		mock.ExpectExec(wantedLogPreventionStmt).
+			WillReturnResult(sqlmock.NewResult(0, 1))
+		dbError := errors.New("kaboom")
+		mock.ExpectExec(wantedRoleExpectedAltWithPasswordStmt).
+			WillReturnError(dbError)
+		mock.ExpectRollback()
+
+		dbRole := roleConfigurationAdapter{RoleConfiguration: wantedRoleWithPass}.toDatabaseRole()
+		dbRole.password = sql.NullString{Valid: true, String: "myPassword"}
+		err = Update(ctx, db, dbRole)
+		Expect(err).To(HaveOccurred())
+		Expect(errors.Is(err, dbError)).To(BeTrue())
+	})
 	It("Update will return error if there is a problem updating the role in the DB", func(ctx context.Context) {
-		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherRegexp))
+		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 		Expect(err).ToNot(HaveOccurred())
 
 		dbError := errors.New("Kaboom")
@@ -355,7 +425,7 @@ var _ = Describe("Postgres RoleManager implementation test", func() {
 
 	// Testing COMMENT
 	It("UpdateComment will send a correct COMMENT to the DB", func(ctx context.Context) {
-		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherRegexp))
+		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 		Expect(err).ToNot(HaveOccurred())
 
 		mock.ExpectExec(wantedRoleCommentStmt).
@@ -365,7 +435,7 @@ var _ = Describe("Postgres RoleManager implementation test", func() {
 	})
 
 	It("UpdateComment will return error if there is a problem updating the role in the DB", func(ctx context.Context) {
-		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherRegexp))
+		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 		Expect(err).ToNot(HaveOccurred())
 
 		dbError := errors.New("Kaboom")

--- a/internal/management/controller/roles/postgres_test.go
+++ b/internal/management/controller/roles/postgres_test.go
@@ -141,7 +141,7 @@ var _ = Describe("Postgres RoleManager implementation test", func() {
 			"VALID UNTIL '2100-01-01 00:00:00Z'",
 		wantedRole.Name)
 	wantedRoleExpectedAltWithPasswordStmt := fmt.Sprintf(
-		"ALTER ROLE \"%s\"  BYPASSRLS NOCREATEDB CREATEROLE NOINHERIT LOGIN NOREPLICATION NOSUPERUSER CONNECTION LIMIT 2 "+
+		"ALTER ROLE \"%s\" BYPASSRLS NOCREATEDB CREATEROLE NOINHERIT LOGIN NOREPLICATION NOSUPERUSER CONNECTION LIMIT 2 "+
 			"PASSWORD 'myPassword' VALID UNTIL '2100-01-01 00:00:00Z'",
 		wantedRole.Name)
 	unWantedRoleExpectedDelStmt := fmt.Sprintf("DROP ROLE \"%s\"", unWantedRole.Name)

--- a/internal/management/controller/roles/postgres_test.go
+++ b/internal/management/controller/roles/postgres_test.go
@@ -115,6 +115,7 @@ var _ = Describe("Postgres RoleManager implementation test", func() {
 			"NOSUPERUSER CONNECTION LIMIT 2 IN ROLE \"pg_monitoring\" PASSWORD 'myPassword' VALID UNTIL '2100-01-01 00:00:00Z'",
 		wantedRole.Name)
 
+	wantedLogStatementSuppressionStmt := "SET LOCAL log_statement = 'none'"
 	wantedLogPreventionStmt := "SET LOCAL log_min_error_statement = 'PANIC'"
 
 	wantedRoleWithoutValidUntilExpectedCrtStmt := fmt.Sprintf(
@@ -260,6 +261,8 @@ var _ = Describe("Postgres RoleManager implementation test", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		mock.ExpectBegin()
+		mock.ExpectExec(wantedLogStatementSuppressionStmt).
+			WillReturnResult(sqlmock.NewResult(0, 1))
 		mock.ExpectExec(wantedLogPreventionStmt).
 			WillReturnResult(sqlmock.NewResult(0, 1))
 		mock.ExpectExec(wantedRoleWithPassExpectedCrtStmt).
@@ -280,6 +283,8 @@ var _ = Describe("Postgres RoleManager implementation test", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		mock.ExpectBegin()
+		mock.ExpectExec(wantedLogStatementSuppressionStmt).
+			WillReturnResult(sqlmock.NewResult(0, 1))
 		mock.ExpectExec(wantedLogPreventionStmt).
 			WillReturnResult(sqlmock.NewResult(0, 1))
 		mock.ExpectExec(wantedRoleWithoutValidUntilExpectedCrtStmt).
@@ -302,6 +307,8 @@ var _ = Describe("Postgres RoleManager implementation test", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		mock.ExpectBegin()
+		mock.ExpectExec(wantedLogStatementSuppressionStmt).
+			WillReturnResult(sqlmock.NewResult(0, 1))
 		mock.ExpectExec(wantedLogPreventionStmt).
 			WillReturnResult(sqlmock.NewResult(0, 1))
 		dbError := errors.New("kaboom")
@@ -381,6 +388,8 @@ var _ = Describe("Postgres RoleManager implementation test", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		mock.ExpectBegin()
+		mock.ExpectExec(wantedLogStatementSuppressionStmt).
+			WillReturnResult(sqlmock.NewResult(0, 1))
 		mock.ExpectExec(wantedLogPreventionStmt).
 			WillReturnResult(sqlmock.NewResult(0, 1))
 		mock.ExpectExec(wantedRoleExpectedAltWithPasswordStmt).
@@ -397,6 +406,8 @@ var _ = Describe("Postgres RoleManager implementation test", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		mock.ExpectBegin()
+		mock.ExpectExec(wantedLogStatementSuppressionStmt).
+			WillReturnResult(sqlmock.NewResult(0, 1))
 		mock.ExpectExec(wantedLogPreventionStmt).
 			WillReturnResult(sqlmock.NewResult(0, 1))
 		dbError := errors.New("kaboom")

--- a/pkg/management/postgres/utils/roles.go
+++ b/pkg/management/postgres/utils/roles.go
@@ -74,11 +74,14 @@ func SetUserPassword(username string, password string, db *sql.DB) error {
 		_ = tx.Rollback()
 	}()
 
+	if _, err = tx.Exec("SET LOCAL log_statement = 'none'"); err != nil {
+		return err
+	}
 	if _, err = tx.Exec("SET LOCAL log_min_error_statement = 'PANIC'"); err != nil {
 		return err
 	}
 
-	_, err = db.Exec(fmt.Sprintf("ALTER ROLE %v WITH PASSWORD %v",
+	_, err = tx.Exec(fmt.Sprintf("ALTER ROLE %v WITH PASSWORD %v",
 		pgx.Identifier{username}.Sanitize(),
 		pq.QuoteLiteral(password)))
 	if err != nil {

--- a/pkg/management/postgres/utils/roles.go
+++ b/pkg/management/postgres/utils/roles.go
@@ -69,11 +69,9 @@ func SetUserPassword(username string, password string, db *sql.DB) error {
 		return err
 	}
 	defer func() {
-		if err != nil {
-			if errRollback := tx.Rollback(); errRollback != nil {
-				err = errors.Join(err, errRollback)
-			}
-		}
+		// This has no effect if the transaction
+		// is committed
+		_ = tx.Rollback()
 	}()
 
 	if _, err = tx.Exec("SET LOCAL log_min_error_statement = 'PANIC'"); err != nil {

--- a/pkg/management/postgres/utils/roles.go
+++ b/pkg/management/postgres/utils/roles.go
@@ -20,6 +20,7 @@ SPDX-License-Identifier: Apache-2.0
 package utils
 
 import (
+	"context"
 	"database/sql"
 	"errors"
 	"fmt"
@@ -46,11 +47,7 @@ func DisableSuperuserPassword(db *sql.DB) error {
 	if err != nil {
 		return err
 	}
-	defer func() {
-		// This has no effect if the transaction
-		// is committed
-		_ = tx.Rollback()
-	}()
+	defer func() { _ = tx.Rollback() }()
 
 	// we don't want to be stuck here if synchronous replicas are still not alive
 	// and kicking
@@ -62,30 +59,31 @@ func DisableSuperuserPassword(db *sql.DB) error {
 	return tx.Commit()
 }
 
-// SetUserPassword change the password of a user in the PostgreSQL database
-func SetUserPassword(username string, password string, db *sql.DB) error {
-	tx, err := db.Begin()
+// ExecWithSuppressedLogging executes a SQL statement within a transaction that
+// suppresses PostgreSQL statement logging, preventing passwords from appearing
+// in server logs.
+func ExecWithSuppressedLogging(ctx context.Context, db *sql.DB, statement string) error {
+	tx, err := db.BeginTx(ctx, nil)
 	if err != nil {
 		return err
 	}
-	defer func() {
-		// This has no effect if the transaction
-		// is committed
-		_ = tx.Rollback()
-	}()
+	defer func() { _ = tx.Rollback() }()
 
-	if _, err = tx.Exec("SET LOCAL log_statement = 'none'"); err != nil {
+	if _, err = tx.ExecContext(ctx, "SET LOCAL log_statement = 'none'"); err != nil {
 		return err
 	}
-	if _, err = tx.Exec("SET LOCAL log_min_error_statement = 'PANIC'"); err != nil {
+	if _, err = tx.ExecContext(ctx, "SET LOCAL log_min_error_statement = 'PANIC'"); err != nil {
 		return err
 	}
-
-	_, err = tx.Exec(fmt.Sprintf("ALTER ROLE %v WITH PASSWORD %v",
-		pgx.Identifier{username}.Sanitize(),
-		pq.QuoteLiteral(password)))
-	if err != nil {
+	if _, err = tx.ExecContext(ctx, statement); err != nil {
 		return err
 	}
 	return tx.Commit()
+}
+
+// SetUserPassword changes the password of a user in the PostgreSQL database
+func SetUserPassword(ctx context.Context, username string, password string, db *sql.DB) error {
+	return ExecWithSuppressedLogging(ctx, db, fmt.Sprintf("ALTER ROLE %v WITH PASSWORD %v",
+		pgx.Identifier{username}.Sanitize(),
+		pq.QuoteLiteral(password)))
 }

--- a/pkg/management/postgres/utils/roles_test.go
+++ b/pkg/management/postgres/utils/roles_test.go
@@ -80,6 +80,8 @@ var _ = Describe("Credentials management functions", func() {
 
 	It("can set the password for a PostgreSQL role", func() {
 		mock.ExpectBegin()
+		mock.ExpectExec("SET LOCAL log_statement = 'none'").
+			WillReturnResult(sqlmock.NewResult(0, 0))
 		mock.ExpectExec("SET LOCAL log_min_error_statement = 'PANIC'").
 			WillReturnResult(sqlmock.NewResult(0, 0))
 		mock.ExpectExec("ALTER ROLE \"testuser\" WITH PASSWORD 'testpassword'").
@@ -90,6 +92,8 @@ var _ = Describe("Credentials management functions", func() {
 
 	It("will correctly escape the password if needed", func() {
 		mock.ExpectBegin()
+		mock.ExpectExec("SET LOCAL log_statement = 'none'").
+			WillReturnResult(sqlmock.NewResult(0, 0))
 		mock.ExpectExec("SET LOCAL log_min_error_statement = 'PANIC'").
 			WillReturnResult(sqlmock.NewResult(0, 0))
 		mock.ExpectExec("ALTER ROLE \"testuser\" WITH PASSWORD 'this \"is\" weird but ''possible'''").
@@ -100,6 +104,8 @@ var _ = Describe("Credentials management functions", func() {
 
 	It("will rollback setting of the password if there is an error", func() {
 		mock.ExpectBegin()
+		mock.ExpectExec("SET LOCAL log_statement = 'none'").
+			WillReturnResult(sqlmock.NewResult(0, 0))
 		mock.ExpectExec("SET LOCAL log_min_error_statement = 'PANIC'").
 			WillReturnResult(sqlmock.NewResult(0, 0))
 		dbError := errors.New("kaboom")

--- a/pkg/management/postgres/utils/roles_test.go
+++ b/pkg/management/postgres/utils/roles_test.go
@@ -80,7 +80,8 @@ var _ = Describe("Credentials management functions", func() {
 
 	It("can set the password for a PostgreSQL role", func() {
 		mock.ExpectBegin()
-		mock.ExpectExec("SET LOCAL log_min_error_statement = 'PANIC'")
+		mock.ExpectExec("SET LOCAL log_min_error_statement = 'PANIC'").
+			WillReturnResult(sqlmock.NewResult(0, 0))
 		mock.ExpectExec("ALTER ROLE \"testuser\" WITH PASSWORD 'testpassword'").
 			WillReturnResult(sqlmock.NewResult(0, 0))
 		mock.ExpectCommit()
@@ -89,7 +90,8 @@ var _ = Describe("Credentials management functions", func() {
 
 	It("will correctly escape the password if needed", func() {
 		mock.ExpectBegin()
-		mock.ExpectExec("SET LOCAL log_min_error_statement = 'PANIC'")
+		mock.ExpectExec("SET LOCAL log_min_error_statement = 'PANIC'").
+			WillReturnResult(sqlmock.NewResult(0, 0))
 		mock.ExpectExec("ALTER ROLE \"testuser\" WITH PASSWORD 'this \"is\" weird but ''possible'''").
 			WillReturnResult(sqlmock.NewResult(0, 0))
 		mock.ExpectCommit()
@@ -98,13 +100,14 @@ var _ = Describe("Credentials management functions", func() {
 
 	It("will rollback setting of the password if there is an error", func() {
 		mock.ExpectBegin()
-		mock.ExpectExec("SET LOCAL log_min_error_statement = 'PANIC'")
+		mock.ExpectExec("SET LOCAL log_min_error_statement = 'PANIC'").
+			WillReturnResult(sqlmock.NewResult(0, 0))
 		dbError := errors.New("kaboom")
 		mock.ExpectExec("ALTER ROLE \"testuser\" WITH PASSWORD 'this \"is\" weird but ''possible'''").
 			WillReturnError(dbError)
 		mock.ExpectRollback()
 		err := SetUserPassword("testuser", "this \"is\" weird but 'possible'", db)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).To(HaveOccurred())
 		Expect(errors.Is(err, dbError)).To(BeTrue())
 	})
 })


### PR DESCRIPTION
When PostgreSQL executes CREATE/ALTER ROLE with a cleartext password, it
can log the password via log_statement and log_min_error_statement. Wrap
password-carrying role statements in a transaction that suppresses
logging with SET LOCAL, preventing leakage in both success and failure
scenarios.

Closes #9799 