### PR TITLE
feat: make webhooks optional

### DIFF
--- a/internal/configuration/configuration.go
+++ b/internal/configuration/configuration.go
@@ -76,6 +76,10 @@ const DefaultPluginSocketDir = "/plugins"
 // Data is the struct containing the configuration of the operator.
 // Usually the operator code will use the "Current" configuration.
 type Data struct {
+	// EnableWebhooks checks if webhooks should be enabled.
+	// Webhooks are enabled by default unless explicitly set to "false".
+	EnableWebhooks bool `json:"enableWebhooks" env:"ENABLE_WEBHOOKS"`
+
 	// WebhookCertDir is the directory where the certificates for the webhooks
 	// need to written. This is different between plain Kubernetes and OpenShift
 	WebhookCertDir string `json:"webhookCertDir" env:"WEBHOOK_CERT_DIR"`
@@ -183,6 +187,7 @@ var Current = NewConfiguration()
 // newDefaultConfig creates a configuration holding the defaults
 func newDefaultConfig() *Data {
 	return &Data{
+		EnableWebhooks:          true,
 		OperatorPullSecretName:  DefaultOperatorPullSecretName,
 		OperatorImageName:       versions.DefaultOperatorImageName,
 		PostgresImageName:       versions.DefaultImageName,


### PR DESCRIPTION
With the webhooks made optional, CNPG can be deployed into an environment where cluster wide resources cannot be installed.

The commit makes admission webhooks optional. Webhook server is disabled when the webhooks are not deployed, this requires the Kubernetes probes to be disabled.

If this approach is approved, a documentation PR will be updated to document this deployment option

Feature request: https://github.com/cloudnative-pg/cloudnative-pg/issues/9278
### Changes

Webhook server: When Webhook server is disabled when the webhooks are not deployed, this requires the Kubernetes probes to be disabled.

Tests: Need to be discussed in the community meeting, but the plan is to add e2e tests to namespaced only deployment introduced in https://github.com/cloudnative-pg/cloudnative-pg/pull/9350