### PR TITLE
fix(replica clusters): apply hot-standby parameter changes

### DIFF
--- a/pkg/management/postgres/probes.go
+++ b/pkg/management/postgres/probes.go
@@ -149,8 +149,19 @@ func updateResultForDecrease(
 	// mark the pending restart as due to a decrease
 	result.PendingRestartForDecrease = true
 	if !result.IsPrimary {
-		// in case of hot standby parameters being decreased,
-		// followers need to wait for the new value to be present in the PGDATA before being restarted.
+		// In a replica cluster, pg_controldata values are received from the external
+		// source primary through the WAL stream, not from this cluster's designated
+		// primary. Comparing decreased parameter values against pg_controldata is
+		// incorrect for replica clusters because those values reflect the source
+		// primary's configuration, not the local cluster's. We skip this check and
+		// keep PendingRestart as-is, allowing the restart to proceed.
+		cluster := instance.GetClusterOrDefault()
+		if cluster.IsReplica() {
+			return nil
+		}
+
+		// In non-replica clusters, followers need to wait for the new value to be
+		// present in the PGDATA before being restarted.
 		pgControldataParams, err := LoadEnforcedParametersFromPgControldata(instance.PgData)
 		if err != nil {
 			return err

--- a/pkg/management/postgres/probes_test.go
+++ b/pkg/management/postgres/probes_test.go
@@ -25,12 +25,135 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/blang/semver"
+	"k8s.io/utils/ptr"
 
+	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/postgres"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
+
+var _ = Describe("areAllParamsUpdated", func() {
+	It("should return true when all params match", func() {
+		decreased := map[string]int{"max_connections": 90, "max_worker_processes": 4}
+		controldata := map[string]int{"max_connections": 90, "max_worker_processes": 4}
+		Expect(areAllParamsUpdated(decreased, controldata)).To(BeTrue())
+	})
+
+	It("should return false when a param doesn't match", func() {
+		decreased := map[string]int{"max_connections": 90}
+		controldata := map[string]int{"max_connections": 100}
+		Expect(areAllParamsUpdated(decreased, controldata)).To(BeFalse())
+	})
+
+	It("should return false when a param is missing from controldata", func() {
+		decreased := map[string]int{"max_connections": 90}
+		controldata := map[string]int{}
+		Expect(areAllParamsUpdated(decreased, controldata)).To(BeFalse())
+	})
+
+	It("should return true for empty decreased values", func() {
+		decreased := map[string]int{}
+		controldata := map[string]int{"max_connections": 100}
+		Expect(areAllParamsUpdated(decreased, controldata)).To(BeTrue())
+	})
+})
+
+var _ = Describe("updateResultForDecrease", func() {
+	// decreasedSettingsQuery matches the SQL used by GetDecreasedSensibleSettings
+	decreasedSettingsQuery := regexp.QuoteMeta(
+		`SELECT pending_settings.name, CAST(coalesce(new_setting,default_setting) AS INTEGER) as new_setting`)
+
+	Context("when there are no decreased sensible settings", func() {
+		It("should not modify the result", func() {
+			db, mock, err := sqlmock.New()
+			Expect(err).ToNot(HaveOccurred())
+
+			mock.ExpectQuery(decreasedSettingsQuery).
+				WillReturnRows(sqlmock.NewRows([]string{"name", "new_setting"}))
+
+			instance := &Instance{}
+			result := &postgres.PostgresqlStatus{
+				IsPrimary:      false,
+				PendingRestart: true,
+			}
+
+			err = updateResultForDecrease(instance, db, result)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.PendingRestart).To(BeTrue())
+			Expect(result.PendingRestartForDecrease).To(BeFalse())
+			Expect(mock.ExpectationsWereMet()).To(Succeed())
+		})
+	})
+
+	Context("when this is a primary instance", func() {
+		It("should keep PendingRestart true and set PendingRestartForDecrease", func() {
+			db, mock, err := sqlmock.New()
+			Expect(err).ToNot(HaveOccurred())
+
+			mock.ExpectQuery(decreasedSettingsQuery).
+				WillReturnRows(sqlmock.NewRows([]string{"name", "new_setting"}).
+					AddRow("max_connections", 90))
+
+			instance := &Instance{}
+			result := &postgres.PostgresqlStatus{
+				IsPrimary:      true,
+				PendingRestart: true,
+			}
+
+			err = updateResultForDecrease(instance, db, result)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.PendingRestart).To(BeTrue())
+			Expect(result.PendingRestartForDecrease).To(BeTrue())
+			Expect(mock.ExpectationsWereMet()).To(Succeed())
+		})
+	})
+
+	Context("when this is a replica cluster instance", func() {
+		DescribeTable("should keep PendingRestart true regardless of pod role",
+			func(podName string, currentPrimary string) {
+				db, mock, err := sqlmock.New()
+				Expect(err).ToNot(HaveOccurred())
+
+				mock.ExpectQuery(decreasedSettingsQuery).
+					WillReturnRows(sqlmock.NewRows([]string{"name", "new_setting"}).
+						AddRow("max_connections", 95))
+
+				instance := (&Instance{}).WithPodName(podName)
+				instance.SetCluster(&apiv1.Cluster{
+					Spec: apiv1.ClusterSpec{
+						ReplicaCluster: &apiv1.ReplicaClusterConfiguration{
+							Enabled: ptr.To(true),
+							Source:  "cluster-example",
+						},
+					},
+					Status: apiv1.ClusterStatus{
+						CurrentPrimary: currentPrimary,
+					},
+				})
+
+				result := &postgres.PostgresqlStatus{
+					IsPrimary:      false,
+					PendingRestart: true,
+				}
+
+				err = updateResultForDecrease(instance, db, result)
+				Expect(err).ToNot(HaveOccurred())
+				// In a replica cluster, PendingRestart should remain true
+				// because pg_controldata values come from the external source
+				// primary, not from this cluster
+				Expect(result.PendingRestart).To(BeTrue())
+				Expect(result.PendingRestartForDecrease).To(BeTrue())
+				Expect(mock.ExpectationsWereMet()).To(Succeed())
+			},
+			Entry("designated primary",
+				"cluster-replica-tls-1", "cluster-replica-tls-1"),
+			Entry("non-designated-primary standby",
+				"cluster-replica-tls-2", "cluster-replica-tls-1"),
+		)
+	})
+})
 
 var _ = Describe("probes", func() {
 	It("fillWalStatus should properly handle errors", func() {

--- a/pkg/management/postgres/probes_test.go
+++ b/pkg/management/postgres/probes_test.go
@@ -65,7 +65,7 @@ var _ = Describe("updateResultForDecrease", func() {
 	decreasedSettingsQuery := regexp.QuoteMeta(
 		`SELECT pending_settings.name, CAST(coalesce(new_setting,default_setting) AS INTEGER) as new_setting`)
 
-	Context("when there are no decreased sensible settings", func() {
+	Context("when there are no decreased standby-sensitive settings", func() {
 		It("should not modify the result", func() {
 			db, mock, err := sqlmock.New()
 			Expect(err).ToNot(HaveOccurred())

--- a/tests/e2e/replica_mode_cluster_test.go
+++ b/tests/e2e/replica_mode_cluster_test.go
@@ -31,6 +31,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/utils/ptr"
 	k8client "sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -105,6 +106,75 @@ var _ = Describe("Replica Mode", Label(tests.LabelReplication), func() {
 			AssertSwitchoverOnReplica(replicaNamespace, replicaName, env)
 
 			assertReplicaClusterTopology(replicaNamespace, replicaName)
+
+			By("increasing max_connections to 120 on the replica cluster", func() {
+				err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+					cluster, err := clusterutils.Get(env.Ctx, env.Client, replicaNamespace, replicaName)
+					if err != nil {
+						return err
+					}
+					if cluster.Spec.PostgresConfiguration.Parameters == nil {
+						cluster.Spec.PostgresConfiguration.Parameters = map[string]string{}
+					}
+					cluster.Spec.PostgresConfiguration.Parameters["max_connections"] = "120"
+					return env.Client.Update(env.Ctx, cluster)
+				})
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			By("waiting for the replica cluster to apply the increased max_connections", func() {
+				AssertClusterEventuallyReachesPhase(replicaNamespace, replicaName,
+					[]string{
+						apiv1.PhaseApplyingConfiguration, apiv1.PhaseUpgrade,
+						apiv1.PhaseWaitingForInstancesToBeActive,
+					}, 30)
+				AssertClusterIsReady(replicaNamespace, replicaName,
+					testTimeouts[timeouts.ClusterIsReadyQuick], env)
+			})
+
+			By("verifying max_connections is 120 on all pods", func() {
+				podList, err := clusterutils.ListPods(env.Ctx, env.Client, replicaNamespace, replicaName)
+				Expect(err).ToNot(HaveOccurred())
+				for idx := range podList.Items {
+					pod := &podList.Items[idx]
+					Eventually(QueryMatchExpectationPredicate(
+						pod, postgres.PostgresDBName, "SHOW max_connections", "120"),
+						30).Should(Succeed())
+				}
+			})
+
+			By("decreasing max_connections to 110 on the replica cluster", func() {
+				err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+					cluster, err := clusterutils.Get(env.Ctx, env.Client, replicaNamespace, replicaName)
+					if err != nil {
+						return err
+					}
+					cluster.Spec.PostgresConfiguration.Parameters["max_connections"] = "110"
+					return env.Client.Update(env.Ctx, cluster)
+				})
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			By("waiting for the replica cluster to apply the decreased max_connections", func() {
+				AssertClusterEventuallyReachesPhase(replicaNamespace, replicaName,
+					[]string{
+						apiv1.PhaseApplyingConfiguration, apiv1.PhaseUpgrade,
+						apiv1.PhaseWaitingForInstancesToBeActive,
+					}, 30)
+				AssertClusterIsReady(replicaNamespace, replicaName,
+					testTimeouts[timeouts.ClusterIsReadyQuick], env)
+			})
+
+			By("verifying max_connections is 110 on all pods", func() {
+				podList, err := clusterutils.ListPods(env.Ctx, env.Client, replicaNamespace, replicaName)
+				Expect(err).ToNot(HaveOccurred())
+				for idx := range podList.Items {
+					pod := &podList.Items[idx]
+					Eventually(QueryMatchExpectationPredicate(
+						pod, postgres.PostgresDBName, "SHOW max_connections", "110"),
+						30).Should(Succeed())
+				}
+			})
 		})
 	})
 


### PR DESCRIPTION
In replica clusters, decreasing hot-standby sensitive parameters (e.g., max_connections) never triggered a restart because:

1. pg_controldata values come from the external source primary via WAL, not from the local cluster's designated primary, making the pg_controldata comparison permanently unsatisfiable for replicas.

2. The designated primary was not recognized as "primary-like" for restart purposes since IsPrimary is always false in replica clusters.

Skip the pg_controldata check for replica clusters and treat the designated primary as primary-like for in-place restart triggering.

Closes #9855 
