### PR TITLE
chore: remove stale shouldIgnoreCurrentVolume compatibility code for v1.24

### DIFF
--- a/pkg/specs/podspec_diff.go
+++ b/pkg/specs/podspec_diff.go
@@ -132,22 +132,10 @@ func compareMaps[V comparable](current, target map[string]V) (bool, string) {
 	return true, ""
 }
 
-// shouldIgnoreCurrentVolume checks if a volume or mount is the superuser or app
-// mount, which had been added, superflously, in previous versions. If so, ignores
-// it for the PodSpec drift detector, to avoid unnecessary restarts
-//
-// TODO: delete this function after minor version 1.24 is discontinued
-func shouldIgnoreCurrentVolume(name string) bool {
-	return name == "superuser-secret" || name == "app-secret"
-}
-
 func compareVolumes(currentVolumes, targetVolumes []corev1.Volume) (bool, string) {
 	current := make(map[string]corev1.Volume)
 	target := make(map[string]corev1.Volume)
 	for _, vol := range currentVolumes {
-		if shouldIgnoreCurrentVolume(vol.Name) {
-			continue
-		}
 		current[vol.Name] = vol
 	}
 	for _, vol := range targetVolumes {
@@ -161,9 +149,6 @@ func compareVolumeMounts(currentMounts, targetMounts []corev1.VolumeMount) (bool
 	current := make(map[string]corev1.VolumeMount)
 	target := make(map[string]corev1.VolumeMount)
 	for _, mount := range currentMounts {
-		if shouldIgnoreCurrentVolume(mount.Name) {
-			continue
-		}
 		current[mount.Name] = mount
 	}
 	for _, mount := range targetMounts {

--- a/pkg/specs/podspec_diff_test.go
+++ b/pkg/specs/podspec_diff_test.go
@@ -27,22 +27,6 @@ import (
 )
 
 var _ = Describe("PodSpecDiff", func() {
-	It("returns true for superuser-secret volume", func() {
-		Expect(shouldIgnoreCurrentVolume("superuser-secret")).To(BeTrue())
-	})
-
-	It("returns true for app-secret volume", func() {
-		Expect(shouldIgnoreCurrentVolume("app-secret")).To(BeTrue())
-	})
-
-	It("returns false for other volumes", func() {
-		Expect(shouldIgnoreCurrentVolume("other-volume")).To(BeFalse())
-	})
-
-	It("returns false for empty volume name", func() {
-		Expect(shouldIgnoreCurrentVolume("")).To(BeFalse())
-	})
-
 	It("return false when the startup probe do not match and true otherwise", func() {
 		containerPre := corev1.Container{
 			StartupProbe: &corev1.Probe{


### PR DESCRIPTION
Remove the shouldIgnoreCurrentVolume function and its usages in compareVolumes and compareVolumeMounts. This compatibility code for superuser-secret and app-secret volumes was marked for removal after v1.24 EOL, which has long passed (Feb 2026).
