### PR TITLE
chore: remove misused %w format verb from structured logger calls

### DIFF
--- a/pkg/management/postgres/logicalimport/database.go
+++ b/pkg/management/postgres/logicalimport/database.go
@@ -67,7 +67,7 @@ func (ds *databaseSnapshotter) getDatabaseList(ctx context.Context, target pool.
 	defer func() {
 		closeErr := rows.Close()
 		if closeErr != nil {
-			contextLogger.Error(closeErr, "while closing rows: %w")
+			contextLogger.Error(closeErr, "while closing rows")
 		}
 	}()
 

--- a/pkg/management/postgres/logicalimport/role.go
+++ b/pkg/management/postgres/logicalimport/role.go
@@ -183,7 +183,7 @@ func (rs *roleManager) getRoles(ctx context.Context) ([]Role, error) {
 	defer func() {
 		closeErr := rows.Close()
 		if closeErr != nil {
-			contextLogger.Error(closeErr, "while closing rows: %w")
+			contextLogger.Error(closeErr, "while closing rows")
 		}
 	}()
 

--- a/pkg/management/postgres/logicalimport/roleinheritance.go
+++ b/pkg/management/postgres/logicalimport/roleinheritance.go
@@ -114,7 +114,7 @@ func (rs *roleInheritanceManager) getRoleInheritance(ctx context.Context) ([]Rol
 	defer func() {
 		closeErr := rows.Close()
 		if closeErr != nil {
-			contextLogger.Error(closeErr, "while closing rows: %w")
+			contextLogger.Error(closeErr, "while closing rows")
 		}
 	}()
 

--- a/pkg/management/postgres/restore.go
+++ b/pkg/management/postgres/restore.go
@@ -367,7 +367,7 @@ func (info InitInfo) ensureArchiveContainsLastCheckpointRedoWAL(
 
 	defer func() {
 		if err := fileutils.RemoveFile(testWALPath); err != nil {
-			contextLogger.Error(err, "while deleting the temporary wal file: %w")
+			contextLogger.Error(err, "while deleting the temporary wal file")
 		}
 	}()
 

--- a/pkg/management/postgres/utils/utils.go
+++ b/pkg/management/postgres/utils/utils.go
@@ -144,7 +144,7 @@ func GetAllAccessibleDatabases(tx *sql.Tx, whereClause string) (databases []stri
 	defer func() {
 		err = rows.Close()
 		if err != nil {
-			log.Error(err, "while closing rows: %w")
+			log.Error(err, "while closing rows")
 		}
 	}()
 	for rows.Next() {


### PR DESCRIPTION
The %w verb is only valid in fmt.Errorf for error wrapping. In structured logger calls (log.Error), it is printed as a literal string. Remove it from 5 affected log messages. 
