### PR TITLE
fix: allow unrecoverable annotation to work on non-ready pods

### DIFF
--- a/internal/controller/cluster_unrecoverable_test.go
+++ b/internal/controller/cluster_unrecoverable_test.go
@@ -113,7 +113,7 @@ var _ = Describe("Unrecoverable replicas", func() {
 		Expect(result).To(ConsistOf("cluster-example-3", "cluster-example-4"))
 	})
 
-	It("Detects unrecoverable instances even when pods are not ready", func(ctx SpecContext) {
+	It("Collects unrecoverable instances regardless of pod readiness status", func(ctx SpecContext) {
 		makeNonReadyPod := func(name string, unrecoverable string) corev1.Pod {
 			pod := corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Pods annotated with alpha.cnpg.io/unrecoverable=true were not being deleted when the postgres process was not running, because the reconciliation loop returned early waiting for pods to report their status before reaching the unrecoverable instance check.

Move the reconcileUnrecoverableInstances call before the early return so that unrecoverable pods are handled regardless of their readiness state.

Closes #9947 