### PR TITLE
fix(roles): check primary status before each role reconciliation

### DIFF
--- a/internal/management/controller/instance_controller.go
+++ b/internal/management/controller/instance_controller.go
@@ -295,6 +295,7 @@ func (r *InstanceReconciler) Reconcile(
 	}
 
 	if r.instance.GetPodName() == cluster.Status.CurrentPrimary {
+		// run in primaries or designated primaries, updating the Status
 		result, err := roles.Reconcile(ctx, r.instance, cluster, r.client)
 		if err != nil || !result.IsZero() {
 			return result, err

--- a/internal/management/controller/instance_controller.go
+++ b/internal/management/controller/instance_controller.go
@@ -295,7 +295,6 @@ func (r *InstanceReconciler) Reconcile(
 	}
 
 	if r.instance.GetPodName() == cluster.Status.CurrentPrimary {
-		// run in primaries or designated primaries, updating the Status
 		result, err := roles.Reconcile(ctx, r.instance, cluster, r.client)
 		if err != nil || !result.IsZero() {
 			return result, err

--- a/internal/management/controller/roles/reconciler.go
+++ b/internal/management/controller/roles/reconciler.go
@@ -78,9 +78,15 @@ func Reconcile(
 	}
 
 	if len(rolesByStatus[apiv1.RoleStatusPendingReconciliation]) != 0 {
-		// forces runnable to run
-		instance.TriggerRoleSynchronizer(cluster.Spec.Managed)
-		contextLogger.Info("Triggered a managed role reconciliation")
+		// triggers reconciliation actions on DB, if this is a primary
+		isPrimary, err := instance.IsPrimary()
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+		if isPrimary {
+			instance.TriggerRoleSynchronizer(cluster.Spec.Managed)
+			contextLogger.Info("Triggered a managed role reconciliation")
+		}
 	}
 
 	updatedCluster := cluster.DeepCopy()

--- a/internal/management/controller/roles/reconciler.go
+++ b/internal/management/controller/roles/reconciler.go
@@ -78,15 +78,8 @@ func Reconcile(
 	}
 
 	if len(rolesByStatus[apiv1.RoleStatusPendingReconciliation]) != 0 {
-		// triggers reconciliation actions on DB, if this is a primary
-		isPrimary, err := instance.IsPrimary()
-		if err != nil {
-			return reconcile.Result{}, err
-		}
-		if isPrimary {
-			instance.TriggerRoleSynchronizer(cluster.Spec.Managed)
-			contextLogger.Info("Triggered a managed role reconciliation")
-		}
+		instance.TriggerRoleSynchronizer(cluster.Spec.Managed)
+		contextLogger.Info("Triggered a managed role reconciliation")
 	}
 
 	updatedCluster := cluster.DeepCopy()

--- a/internal/management/controller/roles/runnable.go
+++ b/internal/management/controller/roles/runnable.go
@@ -89,6 +89,7 @@ func (sr *RoleSynchronizer) Start(ctx context.Context) error {
 	}
 	if !isPrimary {
 		contextLog.Info("skipping the RoleSynchronizer in replicas")
+		<-ctx.Done()
 	}
 	go func() {
 		var config *apiv1.ManagedConfiguration

--- a/internal/management/controller/roles/runnable.go
+++ b/internal/management/controller/roles/runnable.go
@@ -106,10 +106,7 @@ func (sr *RoleSynchronizer) Start(ctx context.Context) error {
 				continue
 			}
 
-			// Only reconcile roles on primaries. Replicas and designated
-			// primaries must not write to the database. This check is
-			// evaluated on each trigger so that a promoted instance
-			// starts reconciling without requiring a pod restart.
+			// Skip replicas and designated primaries: only true primaries write roles.
 			isPrimary, err := sr.instance.IsPrimary()
 			if err != nil {
 				contextLog.Error(err, "checking primary status")


### PR DESCRIPTION
Move the IsPrimary() check from a one-time evaluation at startup into
the reconciliation loop so that replicas and designated primaries skip
role writes, and a promoted instance starts reconciling without
requiring a pod restart.

Closes #9800 