### PR TITLE
fix: prefix extension and tablespace volume names to avoid collisions

### DIFF
--- a/internal/webhook/v1/cluster_webhook.go
+++ b/internal/webhook/v1/cluster_webhook.go
@@ -2839,7 +2839,7 @@ func (v *ClusterCustomValidator) validateExtensions(r *apiv1.Cluster) field.Erro
 		}
 		extensionNames.Put(v.Name)
 
-		sanitizedName := "ext-" + strings.ReplaceAll(v.Name, "_", "-")
+		sanitizedName := specs.SanitizeExtensionNameForVolume(v.Name)
 		if sanitizedVolumeNames.Has(sanitizedName) {
 			result = append(result, field.Invalid(
 				basePath.Child("name"),

--- a/internal/webhook/v1/cluster_webhook.go
+++ b/internal/webhook/v1/cluster_webhook.go
@@ -2826,7 +2826,7 @@ func (v *ClusterCustomValidator) validateExtensions(r *apiv1.Cluster) field.Erro
 		}
 		extensionNames.Put(v.Name)
 
-		sanitizedName := strings.ReplaceAll(v.Name, "_", "-")
+		sanitizedName := "ext-" + strings.ReplaceAll(v.Name, "_", "-")
 		if sanitizedVolumeNames.Has(sanitizedName) {
 			result = append(result, field.Invalid(
 				basePath.Child("name"),

--- a/internal/webhook/v1/cluster_webhook.go
+++ b/internal/webhook/v1/cluster_webhook.go
@@ -1760,14 +1760,16 @@ func (v *ClusterCustomValidator) validateTablespaceNames(r *apiv1.Cluster) field
 	}
 
 	hasTablespace := make(map[string]bool)
+	sanitizedVolumeNames := stringset.New()
 	for idx, tbsConfig := range r.Spec.Tablespaces {
 		name := tbsConfig.Name
+		basePath := field.NewPath("spec", "tablespaces").Index(idx)
 		// NOTE: postgres identifiers are case-insensitive, so we could have
 		// different map keys (names) which are identical for PG
 		_, found := hasTablespace[strings.ToLower(name)]
 		if found {
 			result = append(result, field.Invalid(
-				field.NewPath("spec", "tablespaces").Index(idx),
+				basePath,
 				name,
 				"duplicate tablespace name"))
 			continue
@@ -1776,10 +1778,21 @@ func (v *ClusterCustomValidator) validateTablespaceNames(r *apiv1.Cluster) field
 
 		if _, err := postgres.IsTablespaceNameValid(name); err != nil {
 			result = append(result, field.Invalid(
-				field.NewPath("spec", "tablespaces").Index(idx),
+				basePath,
 				name,
 				err.Error()))
 		}
+
+		sanitizedName := specs.VolumeMountNameForTablespace(name)
+		if sanitizedVolumeNames.Has(sanitizedName) {
+			result = append(result, field.Invalid(
+				basePath,
+				name,
+				fmt.Sprintf("tablespace name results in duplicate volume name %q after sanitization "+
+					"(special characters are converted to hyphens)", sanitizedName),
+			))
+		}
+		sanitizedVolumeNames.Put(sanitizedName)
 	}
 	return result
 }

--- a/internal/webhook/v1/cluster_webhook_test.go
+++ b/internal/webhook/v1/cluster_webhook_test.go
@@ -4789,6 +4789,47 @@ var _ = Describe("Tablespaces validation", func() {
 		Expect(v.validate(cluster)).To(HaveLen(1))
 	})
 
+	It("should produce an error when tablespace names collide after sanitization", func() {
+		cluster := &apiv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "cluster1",
+			},
+			Spec: apiv1.ClusterSpec{
+				Instances: 3,
+				StorageConfiguration: apiv1.StorageConfiguration{
+					Size: "10Gi",
+				},
+				Tablespaces: []apiv1.TablespaceConfiguration{
+					createFakeTemporaryTbsConf("foo_bar"),
+					createFakeTemporaryTbsConf("foo$bar"),
+				},
+			},
+		}
+		errors := v.validate(cluster)
+		Expect(errors).To(HaveLen(1))
+		Expect(errors[0].Type).To(Equal(field.ErrorTypeInvalid))
+		Expect(errors[0].Detail).To(ContainSubstring("duplicate volume name"))
+	})
+
+	It("should not produce an error when tablespace names are distinct after sanitization", func() {
+		cluster := &apiv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "cluster1",
+			},
+			Spec: apiv1.ClusterSpec{
+				Instances: 3,
+				StorageConfiguration: apiv1.StorageConfiguration{
+					Size: "10Gi",
+				},
+				Tablespaces: []apiv1.TablespaceConfiguration{
+					createFakeTemporaryTbsConf("foo_bar"),
+					createFakeTemporaryTbsConf("baz_qux"),
+				},
+			},
+		}
+		Expect(v.validate(cluster)).To(BeEmpty())
+	})
+
 	It("should produce an error if the storage configured for the tablespace is invalid", func() {
 		cluster := &apiv1.Cluster{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/specs/pods_test.go
+++ b/pkg/specs/pods_test.go
@@ -699,7 +699,7 @@ var _ = Describe("PodSpec drift detection", func() {
 							SubPathExpr:      "",
 						},
 						{
-							Name:             "bar",
+							Name:             "tbs-bar",
 							ReadOnly:         false,
 							MountPath:        "/var/lib/postgresql/tablespaces/bar",
 							SubPath:          "",
@@ -717,7 +717,7 @@ var _ = Describe("PodSpec drift detection", func() {
 					Image: "postgres:13.11",
 					VolumeMounts: []corev1.VolumeMount{
 						{
-							Name:             "bar",
+							Name:             "tbs-bar",
 							ReadOnly:         false,
 							MountPath:        "/var/lib/postgresql/tablespaces/bar",
 							SubPath:          "",
@@ -803,7 +803,7 @@ var _ = Describe("PodSpec drift detection", func() {
 							SubPathExpr:      "",
 						},
 						{
-							Name:             "bar",
+							Name:             "tbs-bar",
 							ReadOnly:         false,
 							MountPath:        "/var/lib/postgresql/tablespaces/bar",
 							SubPath:          "",
@@ -821,7 +821,7 @@ var _ = Describe("PodSpec drift detection", func() {
 					Image: "postgres:13.11",
 					VolumeMounts: []corev1.VolumeMount{
 						{
-							Name:             "bar",
+							Name:             "tbs-bar",
 							ReadOnly:         false,
 							MountPath:        "/var/lib/postgresql/tablespaces/bar",
 							SubPath:          "",

--- a/pkg/specs/podspec_diff.go
+++ b/pkg/specs/podspec_diff.go
@@ -22,9 +22,13 @@ package specs
 import (
 	"fmt"
 	"reflect"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
+
+	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/postgres"
 )
 
 // ComparePodSpecs compares two pod specs, returns true iff they are equivalent, and
@@ -132,11 +136,65 @@ func compareMaps[V comparable](current, target map[string]V) (bool, string) {
 	return true, ""
 }
 
+// shouldIgnoreCurrentVolume checks if a volume or mount is the superuser or app
+// mount, which had been added, superflously, in previous versions. If so, ignores
+// it for the PodSpec drift detector, to avoid unnecessary restarts
+//
+// TODO: delete this function after minor version 1.24 is discontinued
+func shouldIgnoreCurrentVolume(name string) bool {
+	return name == "superuser-secret" || name == "app-secret"
+}
+
+// normalizeVolumeName maps old unprefixed volume names to the new prefixed
+// scheme (ext- for extensions, tbs- for tablespaces) to avoid spurious
+// pod restarts on upgrade.
+//
+// TODO: delete this function after minor version 1.28 is discontinued
+func normalizeVolumeName(vol corev1.Volume) string {
+	name := vol.Name
+
+	if vol.Image != nil && !strings.HasPrefix(name, "ext-") {
+		return sanitizeExtensionNameForVolume(name)
+	}
+
+	if vol.PersistentVolumeClaim != nil &&
+		strings.Contains(vol.PersistentVolumeClaim.ClaimName, apiv1.TablespaceVolumeInfix) &&
+		!strings.HasPrefix(name, "tbs-") {
+		return "tbs-" + name
+	}
+
+	return name
+}
+
+// normalizeVolumeMountName maps old unprefixed volume mount names to the new
+// prefixed scheme based on mount path.
+//
+// TODO: delete this function after minor version 1.28 is discontinued
+func normalizeVolumeMountName(mount corev1.VolumeMount) string {
+	name := mount.Name
+
+	extensionPathPrefix := postgres.ExtensionsBaseDirectory + "/"
+	if strings.HasPrefix(mount.MountPath, extensionPathPrefix) && !strings.HasPrefix(name, "ext-") {
+		return sanitizeExtensionNameForVolume(name)
+	}
+
+	if strings.HasPrefix(mount.MountPath, PgTablespaceVolumePath+"/") && !strings.HasPrefix(name, "tbs-") {
+		return "tbs-" + name
+	}
+
+	return name
+}
+
 func compareVolumes(currentVolumes, targetVolumes []corev1.Volume) (bool, string) {
 	current := make(map[string]corev1.Volume)
 	target := make(map[string]corev1.Volume)
 	for _, vol := range currentVolumes {
-		current[vol.Name] = vol
+		if shouldIgnoreCurrentVolume(vol.Name) {
+			continue
+		}
+		normalized := normalizeVolumeName(vol)
+		vol.Name = normalized
+		current[normalized] = vol
 	}
 	for _, vol := range targetVolumes {
 		target[vol.Name] = vol
@@ -149,7 +207,12 @@ func compareVolumeMounts(currentMounts, targetMounts []corev1.VolumeMount) (bool
 	current := make(map[string]corev1.VolumeMount)
 	target := make(map[string]corev1.VolumeMount)
 	for _, mount := range currentMounts {
-		current[mount.Name] = mount
+		if shouldIgnoreCurrentVolume(mount.Name) {
+			continue
+		}
+		normalized := normalizeVolumeMountName(mount)
+		mount.Name = normalized
+		current[normalized] = mount
 	}
 	for _, mount := range targetMounts {
 		target[mount.Name] = mount

--- a/pkg/specs/podspec_diff.go
+++ b/pkg/specs/podspec_diff.go
@@ -149,6 +149,11 @@ func shouldIgnoreCurrentVolume(name string) bool {
 // scheme (ext- for extensions, tbs- for tablespaces) to avoid spurious
 // pod restarts on upgrade.
 //
+// NOTE: extensions named "ext_*" or tablespaces named "tbs_*" will have
+// old sanitized names that already start with "ext-" or "tbs-", causing
+// this function to skip normalization. This results in one spurious pod
+// restart for the affected cluster on the first reconciliation after upgrade.
+//
 // TODO: delete this function after minor version 1.28 is discontinued
 func normalizeVolumeName(vol corev1.Volume) string {
 	name := vol.Name
@@ -167,7 +172,8 @@ func normalizeVolumeName(vol corev1.Volume) string {
 }
 
 // normalizeVolumeMountName maps old unprefixed volume mount names to the new
-// prefixed scheme based on mount path.
+// prefixed scheme based on mount path. See normalizeVolumeName for known
+// limitations with "ext_*" and "tbs_*" naming patterns.
 //
 // TODO: delete this function after minor version 1.28 is discontinued
 func normalizeVolumeMountName(mount corev1.VolumeMount) string {

--- a/pkg/specs/podspec_diff.go
+++ b/pkg/specs/podspec_diff.go
@@ -154,7 +154,7 @@ func normalizeVolumeName(vol corev1.Volume) string {
 	name := vol.Name
 
 	if vol.Image != nil && !strings.HasPrefix(name, "ext-") {
-		return sanitizeExtensionNameForVolume(name)
+		return SanitizeExtensionNameForVolume(name)
 	}
 
 	if vol.PersistentVolumeClaim != nil &&
@@ -175,7 +175,7 @@ func normalizeVolumeMountName(mount corev1.VolumeMount) string {
 
 	extensionPathPrefix := postgres.ExtensionsBaseDirectory + "/"
 	if strings.HasPrefix(mount.MountPath, extensionPathPrefix) && !strings.HasPrefix(name, "ext-") {
-		return sanitizeExtensionNameForVolume(name)
+		return SanitizeExtensionNameForVolume(name)
 	}
 
 	if strings.HasPrefix(mount.MountPath, PgTablespaceVolumePath+"/") && !strings.HasPrefix(name, "tbs-") {

--- a/pkg/specs/podspec_diff_test.go
+++ b/pkg/specs/podspec_diff_test.go
@@ -246,3 +246,39 @@ var _ = Describe("compareVolumes migration", func() {
 		Expect(match).To(BeTrue())
 	})
 })
+
+var _ = Describe("compareVolumeMounts migration", func() {
+	It("matches old unprefixed extension mount with new prefixed one", func() {
+		current := []corev1.VolumeMount{
+			{
+				Name:      "postgis",
+				MountPath: postgres.ExtensionsBaseDirectory + "/postgis",
+			},
+		}
+		target := []corev1.VolumeMount{
+			{
+				Name:      "ext-postgis",
+				MountPath: postgres.ExtensionsBaseDirectory + "/postgis",
+			},
+		}
+		match, _ := compareVolumeMounts(current, target)
+		Expect(match).To(BeTrue())
+	})
+
+	It("matches old unprefixed tablespace mount with new prefixed one", func() {
+		current := []corev1.VolumeMount{
+			{
+				Name:      "myts",
+				MountPath: PgTablespaceVolumePath + "/myts",
+			},
+		}
+		target := []corev1.VolumeMount{
+			{
+				Name:      "tbs-myts",
+				MountPath: PgTablespaceVolumePath + "/myts",
+			},
+		}
+		match, _ := compareVolumeMounts(current, target)
+		Expect(match).To(BeTrue())
+	})
+})

--- a/pkg/specs/volumes.go
+++ b/pkg/specs/volumes.go
@@ -75,7 +75,7 @@ func convertPostgresIDToK8s(tablespaceName string) string {
 	return name
 }
 
-// PvcNameForTablespace returns the normalized tablespace volume name for a given
+// PvcNameForTablespace returns the normalized tablespace PVC name for a given
 // tablespace, on a cluster pod
 func PvcNameForTablespace(podName, tablespaceName string) string {
 	return podName + apiv1.TablespaceVolumeInfix + convertPostgresIDToK8sName(tablespaceName)

--- a/pkg/specs/volumes.go
+++ b/pkg/specs/volumes.go
@@ -321,10 +321,13 @@ func createProjectedVolume(cluster *apiv1.Cluster) corev1.Volume {
 	}
 }
 
-// sanitizeExtensionNameForVolume replaces underscores with hyphens to comply with RFC 1123
-// DNS label requirements for Kubernetes volume names. The mount path preserves the original name.
+// sanitizeExtensionNameForVolume produces a Kubernetes-compliant volume name
+// for an extension. It adds an "ext-" prefix to avoid collisions with system
+// volume names (e.g. pgdata, shm, pg-wal) and replaces underscores with
+// hyphens to comply with RFC 1123 DNS label requirements.
+// The mount path preserves the original extension name.
 func sanitizeExtensionNameForVolume(extensionName string) string {
-	return strings.ReplaceAll(extensionName, "_", "-")
+	return "ext-" + strings.ReplaceAll(extensionName, "_", "-")
 }
 
 func createExtensionVolumes(cluster *apiv1.Cluster) []corev1.Volume {

--- a/pkg/specs/volumes.go
+++ b/pkg/specs/volumes.go
@@ -321,12 +321,9 @@ func createProjectedVolume(cluster *apiv1.Cluster) corev1.Volume {
 	}
 }
 
-// sanitizeExtensionNameForVolume produces a Kubernetes-compliant volume name
-// for an extension. It adds an "ext-" prefix to avoid collisions with system
-// volume names (e.g. pgdata, shm, pg-wal) and replaces underscores with
-// hyphens to comply with RFC 1123 DNS label requirements.
-// The mount path preserves the original extension name.
-func sanitizeExtensionNameForVolume(extensionName string) string {
+// SanitizeExtensionNameForVolume returns a prefixed, RFC 1123 compliant
+// volume name for an extension.
+func SanitizeExtensionNameForVolume(extensionName string) string {
 	return "ext-" + strings.ReplaceAll(extensionName, "_", "-")
 }
 
@@ -335,7 +332,7 @@ func createExtensionVolumes(cluster *apiv1.Cluster) []corev1.Volume {
 	for _, extension := range cluster.Spec.PostgresConfiguration.Extensions {
 		extensionVolumes = append(extensionVolumes,
 			corev1.Volume{
-				Name: sanitizeExtensionNameForVolume(extension.Name),
+				Name: SanitizeExtensionNameForVolume(extension.Name),
 				VolumeSource: corev1.VolumeSource{
 					Image: &extension.ImageVolumeSource,
 				},
@@ -351,7 +348,7 @@ func createExtensionVolumeMounts(cluster *apiv1.Cluster) []corev1.VolumeMount {
 	for _, extension := range cluster.Spec.PostgresConfiguration.Extensions {
 		extensionVolumeMounts = append(extensionVolumeMounts,
 			corev1.VolumeMount{
-				Name:      sanitizeExtensionNameForVolume(extension.Name),
+				Name:      SanitizeExtensionNameForVolume(extension.Name),
 				MountPath: filepath.Join(postgres.ExtensionsBaseDirectory, extension.Name),
 			},
 		)

--- a/pkg/specs/volumes.go
+++ b/pkg/specs/volumes.go
@@ -84,7 +84,7 @@ func PvcNameForTablespace(podName, tablespaceName string) string {
 // VolumeMountNameForTablespace returns the normalized tablespace volume name for a given
 // tablespace, on a cluster pod
 func VolumeMountNameForTablespace(tablespaceName string) string {
-	return convertPostgresIDToK8sName(tablespaceName)
+	return "tbs-" + convertPostgresIDToK8sName(tablespaceName)
 }
 
 // SnapshotBackupNameForTablespace returns the volume snapshot backup name for the tablespace

--- a/pkg/specs/volumes_test.go
+++ b/pkg/specs/volumes_test.go
@@ -566,9 +566,9 @@ var _ = Describe("ImageVolume Extensions", func() {
 			It("should create a Volume for each Extension", func() {
 				extensionVolumes := createExtensionVolumes(&cluster)
 				Expect(len(extensionVolumes)).To(BeEquivalentTo(2))
-				Expect(extensionVolumes[0].Name).To(Equal("foo"))
+				Expect(extensionVolumes[0].Name).To(Equal("ext-foo"))
 				Expect(extensionVolumes[0].VolumeSource.Image.Reference).To(Equal("foo:dev"))
-				Expect(extensionVolumes[1].Name).To(Equal("bar"))
+				Expect(extensionVolumes[1].Name).To(Equal("ext-bar"))
 				Expect(extensionVolumes[1].VolumeSource.Image.Reference).To(Equal("bar:dev"))
 			})
 			It("should sanitize extension names with underscores for volume names", func() {
@@ -582,7 +582,7 @@ var _ = Describe("ImageVolume Extensions", func() {
 				}
 				extensionVolumes := createExtensionVolumes(&cluster)
 				Expect(len(extensionVolumes)).To(BeEquivalentTo(1))
-				Expect(extensionVolumes[0].Name).To(Equal("pg-ivm"))
+				Expect(extensionVolumes[0].Name).To(Equal("ext-pg-ivm"))
 				Expect(extensionVolumes[0].VolumeSource.Image.Reference).To(Equal("pg_ivm:latest"))
 			})
 		})
@@ -604,9 +604,9 @@ var _ = Describe("ImageVolume Extensions", func() {
 				)
 				extensionVolumeMounts := createExtensionVolumeMounts(&cluster)
 				Expect(len(extensionVolumeMounts)).To(BeEquivalentTo(2))
-				Expect(extensionVolumeMounts[0].Name).To(Equal("foo"))
+				Expect(extensionVolumeMounts[0].Name).To(Equal("ext-foo"))
 				Expect(extensionVolumeMounts[0].MountPath).To(Equal(fooMountPath))
-				Expect(extensionVolumeMounts[1].Name).To(Equal("bar"))
+				Expect(extensionVolumeMounts[1].Name).To(Equal("ext-bar"))
 				Expect(extensionVolumeMounts[1].MountPath).To(Equal(barMountPath))
 			})
 			It("should sanitize extension names with underscores for volume mount names", func() {
@@ -620,32 +620,32 @@ var _ = Describe("ImageVolume Extensions", func() {
 				}
 				extensionVolumeMounts := createExtensionVolumeMounts(&cluster)
 				Expect(len(extensionVolumeMounts)).To(BeEquivalentTo(1))
-				Expect(extensionVolumeMounts[0].Name).To(Equal("pg-ivm"))
+				Expect(extensionVolumeMounts[0].Name).To(Equal("ext-pg-ivm"))
 				Expect(extensionVolumeMounts[0].MountPath).To(Equal(postgres.ExtensionsBaseDirectory + "/pg_ivm"))
 			})
 		})
 	})
 
 	Context("sanitizeExtensionNameForVolume", func() {
-		It("should replace underscores with hyphens", func() {
-			Expect(sanitizeExtensionNameForVolume("pg_ivm")).To(Equal("pg-ivm"))
+		It("should add ext- prefix and replace underscores with hyphens", func() {
+			Expect(sanitizeExtensionNameForVolume("pg_ivm")).To(Equal("ext-pg-ivm"))
 		})
 
 		It("should handle multiple underscores", func() {
-			Expect(sanitizeExtensionNameForVolume("my_custom_extension")).To(Equal("my-custom-extension"))
+			Expect(sanitizeExtensionNameForVolume("my_custom_extension")).To(Equal("ext-my-custom-extension"))
 		})
 
-		It("should not modify names without underscores", func() {
-			Expect(sanitizeExtensionNameForVolume("foo")).To(Equal("foo"))
-			Expect(sanitizeExtensionNameForVolume("foo-bar")).To(Equal("foo-bar"))
+		It("should add ext- prefix to names without underscores", func() {
+			Expect(sanitizeExtensionNameForVolume("foo")).To(Equal("ext-foo"))
+			Expect(sanitizeExtensionNameForVolume("foo-bar")).To(Equal("ext-foo-bar"))
 		})
 
 		It("should handle mixed underscores and hyphens", func() {
-			Expect(sanitizeExtensionNameForVolume("pg_foo-bar")).To(Equal("pg-foo-bar"))
+			Expect(sanitizeExtensionNameForVolume("pg_foo-bar")).To(Equal("ext-pg-foo-bar"))
 		})
 
 		It("should handle consecutive underscores", func() {
-			Expect(sanitizeExtensionNameForVolume("pg__stat")).To(Equal("pg--stat"))
+			Expect(sanitizeExtensionNameForVolume("pg__stat")).To(Equal("ext-pg--stat"))
 		})
 	})
 })

--- a/pkg/specs/volumes_test.go
+++ b/pkg/specs/volumes_test.go
@@ -626,7 +626,7 @@ var _ = Describe("ImageVolume Extensions", func() {
 		})
 	})
 
-	Context("sanitizeExtensionNameForVolume", func() {
+	Context("SanitizeExtensionNameForVolume", func() {
 		It("should add ext- prefix and replace underscores with hyphens", func() {
 			Expect(SanitizeExtensionNameForVolume("pg_ivm")).To(Equal("ext-pg-ivm"))
 		})

--- a/pkg/specs/volumes_test.go
+++ b/pkg/specs/volumes_test.go
@@ -628,24 +628,24 @@ var _ = Describe("ImageVolume Extensions", func() {
 
 	Context("sanitizeExtensionNameForVolume", func() {
 		It("should add ext- prefix and replace underscores with hyphens", func() {
-			Expect(sanitizeExtensionNameForVolume("pg_ivm")).To(Equal("ext-pg-ivm"))
+			Expect(SanitizeExtensionNameForVolume("pg_ivm")).To(Equal("ext-pg-ivm"))
 		})
 
 		It("should handle multiple underscores", func() {
-			Expect(sanitizeExtensionNameForVolume("my_custom_extension")).To(Equal("ext-my-custom-extension"))
+			Expect(SanitizeExtensionNameForVolume("my_custom_extension")).To(Equal("ext-my-custom-extension"))
 		})
 
 		It("should add ext- prefix to names without underscores", func() {
-			Expect(sanitizeExtensionNameForVolume("foo")).To(Equal("ext-foo"))
-			Expect(sanitizeExtensionNameForVolume("foo-bar")).To(Equal("ext-foo-bar"))
+			Expect(SanitizeExtensionNameForVolume("foo")).To(Equal("ext-foo"))
+			Expect(SanitizeExtensionNameForVolume("foo-bar")).To(Equal("ext-foo-bar"))
 		})
 
 		It("should handle mixed underscores and hyphens", func() {
-			Expect(sanitizeExtensionNameForVolume("pg_foo-bar")).To(Equal("ext-pg-foo-bar"))
+			Expect(SanitizeExtensionNameForVolume("pg_foo-bar")).To(Equal("ext-pg-foo-bar"))
 		})
 
 		It("should handle consecutive underscores", func() {
-			Expect(sanitizeExtensionNameForVolume("pg__stat")).To(Equal("ext-pg--stat"))
+			Expect(SanitizeExtensionNameForVolume("pg__stat")).To(Equal("ext-pg--stat"))
 		})
 	})
 })

--- a/pkg/specs/volumes_test.go
+++ b/pkg/specs/volumes_test.go
@@ -371,7 +371,7 @@ var _ = DescribeTable("test creation of volume mounts",
 		},
 		[]corev1.VolumeMount{
 			{
-				Name:             "fragglerock",
+				Name:             "tbs-fragglerock",
 				ReadOnly:         false,
 				MountPath:        "/var/lib/postgresql/tablespaces/fragglerock",
 				SubPath:          "",
@@ -379,7 +379,7 @@ var _ = DescribeTable("test creation of volume mounts",
 				SubPathExpr:      "",
 			},
 			{
-				Name:             "futurama",
+				Name:             "tbs-futurama",
 				ReadOnly:         false,
 				MountPath:        "/var/lib/postgresql/tablespaces/futurama",
 				SubPath:          "",
@@ -462,7 +462,7 @@ var _ = DescribeTable("test creation of volumes",
 		},
 		[]corev1.Volume{
 			{
-				Name: "fragglerock",
+				Name: "tbs-fragglerock",
 				VolumeSource: corev1.VolumeSource{
 					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
 						ClaimName: "pod-1-tbs-fragglerock",
@@ -470,7 +470,7 @@ var _ = DescribeTable("test creation of volumes",
 				},
 			},
 			{
-				Name: "futurama",
+				Name: "tbs-futurama",
 				VolumeSource: corev1.VolumeSource{
 					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
 						ClaimName: "pod-1-tbs-futurama",

--- a/tests/e2e/fixtures/upgrade/cluster-restore.yaml.template
+++ b/tests/e2e/fixtures/upgrade/cluster-restore.yaml.template
@@ -6,6 +6,12 @@ spec:
   instances: 3
   imageName: "${POSTGRES_IMG}"
 
+  tablespaces:
+    - name: atablespace
+      storage:
+        size: 1Gi
+        storageClass: ${E2E_DEFAULT_STORAGE_CLASS}
+
   storage:
     size: 1Gi
     storageClass: ${E2E_DEFAULT_STORAGE_CLASS}

--- a/tests/e2e/fixtures/upgrade/cluster1.yaml.template
+++ b/tests/e2e/fixtures/upgrade/cluster1.yaml.template
@@ -73,6 +73,12 @@ spec:
     inProgress: false
     reusePVC: false
 
+  tablespaces:
+    - name: atablespace
+      storage:
+        size: 1Gi
+        storageClass: ${E2E_DEFAULT_STORAGE_CLASS}
+
   storage:
     size: 1Gi
     storageClass: ${E2E_DEFAULT_STORAGE_CLASS}

--- a/tests/e2e/imagevolume_extensions_test.go
+++ b/tests/e2e/imagevolume_extensions_test.go
@@ -31,6 +31,7 @@ import (
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/postgres"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/specs"
 	"github.com/cloudnative-pg/cloudnative-pg/tests"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/clusterutils"
 	postgresutils "github.com/cloudnative-pg/cloudnative-pg/tests/utils/postgres"
@@ -75,7 +76,7 @@ var _ = Describe("ImageVolume Extensions", Label(tests.LabelImageVolumeExtension
 
 	assertVolumeMounts := func(podList *corev1.PodList, imageVolumeExtension string) {
 		found := false
-		volumeName := "ext-" + strings.ReplaceAll(imageVolumeExtension, "_", "-")
+		volumeName := specs.SanitizeExtensionNameForVolume(imageVolumeExtension)
 		mountPath := filepath.Join(postgres.ExtensionsBaseDirectory, imageVolumeExtension)
 		for _, pod := range podList.Items {
 			for _, volumeMount := range pod.Spec.Containers[0].VolumeMounts {
@@ -89,7 +90,7 @@ var _ = Describe("ImageVolume Extensions", Label(tests.LabelImageVolumeExtension
 
 	assertVolumes := func(podList *corev1.PodList, imageVolumeExtension string) {
 		found := false
-		volumeName := "ext-" + strings.ReplaceAll(imageVolumeExtension, "_", "-")
+		volumeName := specs.SanitizeExtensionNameForVolume(imageVolumeExtension)
 		for _, pod := range podList.Items {
 			for _, volume := range pod.Spec.Volumes {
 				if volume.Name == volumeName && volume.Image.Reference != "" {

--- a/tests/e2e/imagevolume_extensions_test.go
+++ b/tests/e2e/imagevolume_extensions_test.go
@@ -75,10 +75,11 @@ var _ = Describe("ImageVolume Extensions", Label(tests.LabelImageVolumeExtension
 
 	assertVolumeMounts := func(podList *corev1.PodList, imageVolumeExtension string) {
 		found := false
+		volumeName := "ext-" + strings.ReplaceAll(imageVolumeExtension, "_", "-")
 		mountPath := filepath.Join(postgres.ExtensionsBaseDirectory, imageVolumeExtension)
 		for _, pod := range podList.Items {
 			for _, volumeMount := range pod.Spec.Containers[0].VolumeMounts {
-				if volumeMount.Name == imageVolumeExtension && volumeMount.MountPath == mountPath {
+				if volumeMount.Name == volumeName && volumeMount.MountPath == mountPath {
 					found = true
 				}
 			}
@@ -88,9 +89,10 @@ var _ = Describe("ImageVolume Extensions", Label(tests.LabelImageVolumeExtension
 
 	assertVolumes := func(podList *corev1.PodList, imageVolumeExtension string) {
 		found := false
+		volumeName := "ext-" + strings.ReplaceAll(imageVolumeExtension, "_", "-")
 		for _, pod := range podList.Items {
 			for _, volume := range pod.Spec.Volumes {
-				if volume.Name == imageVolumeExtension && volume.Image.Reference != "" {
+				if volume.Name == volumeName && volume.Image.Reference != "" {
 					found = true
 				}
 			}

--- a/tests/e2e/tablespaces_test.go
+++ b/tests/e2e/tablespaces_test.go
@@ -977,7 +977,7 @@ func AssertClusterHasMountPointsAndVolumesForTablespaces(
 				}
 				for _, tbsConfig := range cluster.Spec.Tablespaces {
 					g.Expect(volumeNames).To(ContainElement(
-						tbsConfig.Name,
+						specs.VolumeMountNameForTablespace(tbsConfig.Name),
 					))
 					g.Expect(claimNames).To(ContainElement(
 						pod.Name + "-tbs-" + tbsConfig.Name,


### PR DESCRIPTION
Add namespace prefixes to extension and tablespace volume names so they cannot collide with system volumes (pgdata, shm, pg-wal, scratch-data, projected) or with each other. Extensions get an "ext-" prefix, tablespaces get a "tbs-" prefix.

Webhook validation rejects names that produce duplicate volume names after K8s name sanitization, for both extensions and tablespaces.

Migration logic normalizes old unprefixed volume names during pod spec comparison, preventing unnecessary pod restarts on upgrade. The operator upgrade E2E fixtures now include a tablespace to exercise this path.

Closes #9972 