### PR TITLE
fix(rollout): prevent supervised primary strategy from starving rollout slots

### DIFF
--- a/internal/controller/cluster_upgrade_test.go
+++ b/internal/controller/cluster_upgrade_test.go
@@ -989,8 +989,8 @@ var _ = Describe("Supervised primary update strategy and rollout slots", func() 
 	buildPodListWithPrimaryNeedingRollout := func(cluster *apiv1.Cluster) *postgres.PostgresqlStatusList {
 		pod := &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-cluster-1",
-				Namespace: namespace,
+				Name:      cluster.Status.CurrentPrimary,
+				Namespace: cluster.Namespace,
 				Annotations: map[string]string{
 					utils.ClusterSerialAnnotationName: "1",
 				},

--- a/internal/controller/cluster_upgrade_test.go
+++ b/internal/controller/cluster_upgrade_test.go
@@ -22,16 +22,21 @@ package controller
 import (
 	"context"
 	"encoding/json"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
 	k8client "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/internal/cnpi/plugin"
 	pluginClient "github.com/cloudnative-pg/cloudnative-pg/internal/cnpi/plugin/client"
 	"github.com/cloudnative-pg/cloudnative-pg/internal/configuration"
+	rolloutManager "github.com/cloudnative-pg/cloudnative-pg/internal/controller/rollout"
+	schemeBuilder "github.com/cloudnative-pg/cloudnative-pg/internal/scheme"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/postgres"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/specs"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
@@ -917,5 +922,146 @@ var _ = Describe("checkPodSpec with plugins", Ordered, func() {
 		Expect(rollout.required).To(BeTrue())
 		Expect(rollout.reason).To(Equal(
 			"original and target PodSpec differ in containers: container postgres differs in environment"))
+	})
+})
+
+var _ = Describe("Supervised primary update strategy and rollout slots", func() {
+	const namespace = "supervised-test"
+
+	var (
+		reconciler *ClusterReconciler
+		rm         *rolloutManager.Manager
+		k8sClient  k8client.Client
+	)
+
+	BeforeEach(func() {
+		scheme := schemeBuilder.BuildWithAllKnownScheme()
+		k8sClient = fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithStatusSubresource(&apiv1.Cluster{}).
+			Build()
+
+		// Create namespace
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: namespace},
+		}
+		Expect(k8sClient.Create(context.Background(), ns)).To(Succeed())
+
+		// Rollout manager with a large cluster delay so we can detect slot consumption
+		rm = rolloutManager.New(time.Hour, 0)
+
+		reconciler = &ClusterReconciler{
+			Client:         k8sClient,
+			Scheme:         scheme,
+			Recorder:       record.NewFakeRecorder(120),
+			rolloutManager: rm,
+		}
+
+		configuration.Current = configuration.NewConfiguration()
+	})
+
+	// Helper to create a cluster in the fake client with the given primary update strategy
+	createCluster := func(strategy apiv1.PrimaryUpdateStrategy) *apiv1.Cluster {
+		cluster := &apiv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-cluster",
+				Namespace: namespace,
+			},
+			Spec: apiv1.ClusterSpec{
+				Instances:             1,
+				ImageName:             "postgres:16.0",
+				PrimaryUpdateStrategy: strategy,
+				PrimaryUpdateMethod:   apiv1.PrimaryUpdateMethodRestart,
+				StorageConfiguration:  apiv1.StorageConfiguration{Size: "1Gi"},
+			},
+		}
+		cluster.SetDefaults()
+		// Set status fields after SetDefaults() since it may clear them
+		cluster.Status.CurrentPrimary = "test-cluster-1"
+		cluster.Status.Image = "postgres:16.1"
+		cluster.Status.Instances = 1
+		Expect(k8sClient.Create(context.Background(), cluster)).To(Succeed())
+		Expect(k8sClient.Status().Update(context.Background(), cluster)).To(Succeed())
+		return cluster
+	}
+
+	// Helper to build a pod status list where the primary needs rollout (image mismatch)
+	buildPodListWithPrimaryNeedingRollout := func(cluster *apiv1.Cluster) *postgres.PostgresqlStatusList {
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-cluster-1",
+				Namespace: namespace,
+				Annotations: map[string]string{
+					utils.ClusterSerialAnnotationName: "1",
+				},
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:  "postgres",
+						Image: "postgres:16.0", // Different from cluster.Status.Image (16.1) -> triggers rollout
+					},
+				},
+			},
+		}
+		return &postgres.PostgresqlStatusList{
+			Items: []postgres.PostgresqlStatus{
+				{
+					Pod:            pod,
+					IsPodReady:     true,
+					ExecutableHash: "test_hash",
+				},
+			},
+		}
+	}
+
+	It("supervised cluster does NOT consume a rollout slot", func(ctx SpecContext) {
+		cluster := createCluster(apiv1.PrimaryUpdateStrategySupervised)
+		podList := buildPodListWithPrimaryNeedingRollout(cluster)
+
+		restarted, err := reconciler.rolloutRequiredInstances(ctx, cluster, podList)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(restarted).To(BeTrue())
+
+		// Verify the rollout slot was NOT consumed: a second cluster should still be allowed
+		secondCluster := k8client.ObjectKey{Namespace: namespace, Name: "other-cluster"}
+		result := rm.CoordinateRollout(secondCluster, "other-pod")
+		Expect(result.RolloutAllowed).To(BeTrue(),
+			"supervised strategy should not consume the rollout slot")
+	})
+
+	It("supervised cluster returns true and sets PhaseWaitingForUser", func(ctx SpecContext) {
+		cluster := createCluster(apiv1.PrimaryUpdateStrategySupervised)
+		podList := buildPodListWithPrimaryNeedingRollout(cluster)
+
+		restarted, err := reconciler.rolloutRequiredInstances(ctx, cluster, podList)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(restarted).To(BeTrue())
+
+		// Re-fetch the cluster to see the updated status
+		var updatedCluster apiv1.Cluster
+		Expect(k8sClient.Get(ctx,
+			k8client.ObjectKeyFromObject(cluster),
+			&updatedCluster)).To(Succeed())
+		Expect(updatedCluster.Status.Phase).To(Equal(apiv1.PhaseWaitingForUser))
+	})
+
+	It("unsupervised cluster DOES consume a rollout slot", func(ctx SpecContext) {
+		cluster := createCluster(apiv1.PrimaryUpdateStrategyUnsupervised)
+		podList := buildPodListWithPrimaryNeedingRollout(cluster)
+
+		// Create the pod in the fake client so upgradePod (Delete) can find it
+		pod := podList.Items[0].Pod.DeepCopy()
+		Expect(k8sClient.Create(ctx, pod)).To(Succeed())
+
+		restarted, err := reconciler.rolloutRequiredInstances(ctx, cluster, podList)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(restarted).To(BeTrue())
+
+		// Verify the rollout slot WAS consumed: a second cluster should be blocked
+		secondCluster := k8client.ObjectKey{Namespace: namespace, Name: "other-cluster"}
+		result := rm.CoordinateRollout(secondCluster, "other-pod")
+		Expect(result.RolloutAllowed).To(BeFalse(),
+			"unsupervised strategy should consume the rollout slot")
 	})
 })

--- a/internal/controller/rollout/doc.go
+++ b/internal/controller/rollout/doc.go
@@ -18,6 +18,27 @@ SPDX-License-Identifier: Apache-2.0
 */
 
 // Package rollout contains the rollout manager, allowing
-// CloudNative-PG to spread Pod rollouts depending on
-// the passed configuration
+// CloudNativePG to spread Pod rollouts depending on
+// the passed configuration.
+//
+// The manager uses a single global slot to enforce that only one Pod
+// rollout proceeds at a time across all clusters managed by the
+// operator. When [Manager.CoordinateRollout] is called and the rollout
+// is allowed, the manager records the cluster, instance, and current
+// timestamp. Subsequent calls are denied until the configured delay
+// has elapsed: [Manager.clusterRolloutDelay] when the caller is a
+// different cluster, or [Manager.instanceRolloutDelay] when it is the
+// same cluster.
+//
+// Because the slot is global, callers that will not actually perform a
+// rollout must avoid calling [Manager.CoordinateRollout]. For example,
+// a cluster whose primary update strategy is "supervised" waits
+// indefinitely for a user-initiated switchover; if it claimed the slot,
+// it would block every other cluster from rolling out until the delay
+// expires, and would re-claim it on every reconciliation loop,
+// effectively starving other clusters.
+//
+// The delays are configured via the CLUSTERS_ROLLOUT_DELAY and
+// INSTANCES_ROLLOUT_DELAY operator environment variables (both
+// default to 0, meaning no delay).
 package rollout


### PR DESCRIPTION
## Summary

When a cluster with `primaryUpdateStrategy: supervised` has its primary pod
pending rollout, it calls `CoordinateRollout()` which resets the global rollout
delay timer — but then does nothing (just logs "Waiting for the user to request
a switchover"). This blocks all other clusters from getting rollout slots
indefinitely, causing complete rollout starvation.

## Changes

Move the supervised strategy check in `rolloutRequiredInstances()` to execute
**before** `CoordinateRollout()`, so supervised clusters set
`PhaseWaitingForUser` and return early without consuming the global rollout
slot. The now-unreachable duplicate check in `updatePrimaryPod()` is removed.

Unit tests added to verify supervised clusters don't consume rollout slots
and unsupervised clusters still work as before.