### PR TITLE
fix: prevent reconciler hook from skipping later plugins when an earlier one returns a continue result

### DIFF
--- a/internal/cnpi/plugin/client/reconciler.go
+++ b/internal/cnpi/plugin/client/reconciler.go
@@ -174,7 +174,7 @@ func reconcilerHook(
 			return newReconcilerRequeueResult(plugin.Name(), result.GetRequeueAfter())
 
 		case reconciler.ReconcilerHooksResult_BEHAVIOR_CONTINUE:
-			return newContinueResult(plugin.Name())
+			// Continue to next plugin
 		}
 	}
 

--- a/internal/cnpi/plugin/client/reconciler_test.go
+++ b/internal/cnpi/plugin/client/reconciler_test.go
@@ -111,9 +111,9 @@ func (f *fakeReconcilerHooksClient) set(d *fakeConnection) {
 
 var _ = Describe("reconcilerHook", func() {
 	var (
-		ctx           context.Context
-		plugins       []connection.Interface
-		cluster       k8client.Object
+		ctx            context.Context
+		plugins        []connection.Interface
+		cluster        k8client.Object
 		executePreHook = func(
 			ctx context.Context,
 			plugin reconciler.ReconcilerHooksClient,

--- a/internal/cnpi/plugin/client/reconciler_test.go
+++ b/internal/cnpi/plugin/client/reconciler_test.go
@@ -1,0 +1,364 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package client
+
+import (
+	"context"
+	"errors"
+
+	"github.com/cloudnative-pg/cnpg-i/pkg/reconciler"
+	"google.golang.org/grpc"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8client "sigs.k8s.io/controller-runtime/pkg/client"
+
+	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	"github.com/cloudnative-pg/cloudnative-pg/internal/cnpi/plugin/connection"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+type fakeReconcilerHooksClient struct {
+	behavior     reconciler.ReconcilerHooksResult_Behavior
+	requeueAfter int64
+	err          error
+	capabilities []reconciler.ReconcilerHooksCapability_Kind
+	callCount    int
+}
+
+func newFakeReconcilerHooksClient(
+	capabilities []reconciler.ReconcilerHooksCapability_Kind,
+	behavior reconciler.ReconcilerHooksResult_Behavior,
+	requeueAfter int64,
+	err error,
+) *fakeReconcilerHooksClient {
+	return &fakeReconcilerHooksClient{
+		capabilities: capabilities,
+		behavior:     behavior,
+		requeueAfter: requeueAfter,
+		err:          err,
+	}
+}
+
+func (f *fakeReconcilerHooksClient) GetCapabilities(
+	_ context.Context,
+	_ *reconciler.ReconcilerHooksCapabilitiesRequest,
+	_ ...grpc.CallOption,
+) (*reconciler.ReconcilerHooksCapabilitiesResult, error) {
+	return &reconciler.ReconcilerHooksCapabilitiesResult{}, nil
+}
+
+func (f *fakeReconcilerHooksClient) Pre(
+	_ context.Context,
+	_ *reconciler.ReconcilerHooksRequest,
+	_ ...grpc.CallOption,
+) (*reconciler.ReconcilerHooksResult, error) {
+	f.callCount++
+	if f.err != nil {
+		return nil, f.err
+	}
+	return &reconciler.ReconcilerHooksResult{
+		Behavior:     f.behavior,
+		RequeueAfter: f.requeueAfter,
+	}, nil
+}
+
+func (f *fakeReconcilerHooksClient) Post(
+	_ context.Context,
+	_ *reconciler.ReconcilerHooksRequest,
+	_ ...grpc.CallOption,
+) (*reconciler.ReconcilerHooksResult, error) {
+	f.callCount++
+	if f.err != nil {
+		return nil, f.err
+	}
+	return &reconciler.ReconcilerHooksResult{
+		Behavior:     f.behavior,
+		RequeueAfter: f.requeueAfter,
+	}, nil
+}
+
+func (f *fakeReconcilerHooksClient) getCallCount() int {
+	return f.callCount
+}
+
+func (f *fakeReconcilerHooksClient) set(d *fakeConnection) {
+	if d == nil {
+		return
+	}
+
+	d.reconcilerHooksClient = f
+	d.reconcilerCapabilities = f.capabilities
+}
+
+var _ = Describe("reconcilerHook", func() {
+	var (
+		ctx     context.Context
+		d       *data
+		cluster k8client.Object
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		d = &data{
+			plugins: []connection.Interface{
+				&fakeConnection{
+					name: "test",
+				},
+			},
+		}
+
+		cluster = &apiv1.Cluster{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "postgresql.cnpg.io/v1",
+				Kind:       "Cluster",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-cluster",
+				Namespace: "default",
+			},
+		}
+	})
+
+	It("should continue when a plugin returns CONTINUE behavior", func() {
+		f := newFakeReconcilerHooksClient(
+			[]reconciler.ReconcilerHooksCapability_Kind{reconciler.ReconcilerHooksCapability_KIND_CLUSTER},
+			reconciler.ReconcilerHooksResult_BEHAVIOR_CONTINUE,
+			0,
+			nil,
+		)
+		f.set(d.plugins[0].(*fakeConnection))
+
+		result := d.PreReconcile(ctx, cluster, cluster)
+		Expect(result.StopReconciliation).To(BeFalse())
+		Expect(result.Err).ToNot(HaveOccurred())
+		Expect(result.Identifier).To(Equal(cnpgOperatorKey))
+	})
+
+	It("should stop when a plugin returns TERMINATE behavior", func() {
+		f := newFakeReconcilerHooksClient(
+			[]reconciler.ReconcilerHooksCapability_Kind{reconciler.ReconcilerHooksCapability_KIND_CLUSTER},
+			reconciler.ReconcilerHooksResult_BEHAVIOR_TERMINATE,
+			0,
+			nil,
+		)
+		f.set(d.plugins[0].(*fakeConnection))
+
+		result := d.PreReconcile(ctx, cluster, cluster)
+		Expect(result.StopReconciliation).To(BeTrue())
+		Expect(result.Err).ToNot(HaveOccurred())
+		Expect(result.Identifier).To(Equal("test"))
+	})
+
+	It("should requeue when a plugin returns REQUEUE behavior", func() {
+		f := newFakeReconcilerHooksClient(
+			[]reconciler.ReconcilerHooksCapability_Kind{reconciler.ReconcilerHooksCapability_KIND_CLUSTER},
+			reconciler.ReconcilerHooksResult_BEHAVIOR_REQUEUE,
+			10,
+			nil,
+		)
+		f.set(d.plugins[0].(*fakeConnection))
+
+		result := d.PreReconcile(ctx, cluster, cluster)
+		Expect(result.StopReconciliation).To(BeTrue())	
+		Expect(result.Result.RequeueAfter.Seconds()).To(BeEquivalentTo(10))
+		Expect(result.Err).ToNot(HaveOccurred())
+		Expect(result.Identifier).To(Equal("test"))
+	})
+
+	It("should return error when plugin execution fails", func() {
+		expectedErr := errors.New("plugin execution failed")
+		f := newFakeReconcilerHooksClient(
+			[]reconciler.ReconcilerHooksCapability_Kind{reconciler.ReconcilerHooksCapability_KIND_CLUSTER},
+			reconciler.ReconcilerHooksResult_BEHAVIOR_CONTINUE,
+			0,
+			expectedErr,
+		)
+		f.set(d.plugins[0].(*fakeConnection))
+
+		result := d.PreReconcile(ctx, cluster, cluster)
+		Expect(result.StopReconciliation).To(BeTrue())
+		Expect(result.Err).To(HaveOccurred())
+		Expect(result.Identifier).To(Equal("test"))
+	})
+
+	It("should process multiple plugins when all return CONTINUE", func() {
+		d.plugins = []connection.Interface{
+			&fakeConnection{name: "plugin-1"},
+			&fakeConnection{name: "plugin-2"},
+			&fakeConnection{name: "plugin-3"},
+		}
+
+		f1 := newFakeReconcilerHooksClient(
+			[]reconciler.ReconcilerHooksCapability_Kind{reconciler.ReconcilerHooksCapability_KIND_CLUSTER},
+			reconciler.ReconcilerHooksResult_BEHAVIOR_CONTINUE,
+			0,
+			nil,
+		)
+		f1.set(d.plugins[0].(*fakeConnection))
+
+		f2 := newFakeReconcilerHooksClient(
+			[]reconciler.ReconcilerHooksCapability_Kind{reconciler.ReconcilerHooksCapability_KIND_CLUSTER},
+			reconciler.ReconcilerHooksResult_BEHAVIOR_CONTINUE,
+			0,
+			nil,
+		)
+		f2.set(d.plugins[1].(*fakeConnection))
+
+		f3 := newFakeReconcilerHooksClient(
+			[]reconciler.ReconcilerHooksCapability_Kind{reconciler.ReconcilerHooksCapability_KIND_CLUSTER},
+			reconciler.ReconcilerHooksResult_BEHAVIOR_CONTINUE,
+			0,
+			nil,
+		)
+		f3.set(d.plugins[2].(*fakeConnection))
+
+		result := d.PreReconcile(ctx, cluster, cluster)
+		Expect(result.StopReconciliation).To(BeFalse())
+		Expect(result.Err).ToNot(HaveOccurred())
+		Expect(result.Identifier).To(Equal(cnpgOperatorKey))
+		Expect(f1.getCallCount()).To(Equal(1), "plugin-1 should be called once")
+		Expect(f2.getCallCount()).To(Equal(1), "plugin-2 should be called once")
+		Expect(f3.getCallCount()).To(Equal(1), "plugin-3 should be called once")
+	})
+
+	It("should stop at second plugin when it returns TERMINATE after first returns CONTINUE", func() {
+		d.plugins = []connection.Interface{
+			&fakeConnection{name: "plugin-1"},
+			&fakeConnection{name: "plugin-2"},
+			&fakeConnection{name: "plugin-3"},
+		}
+
+		f1 := newFakeReconcilerHooksClient(
+			[]reconciler.ReconcilerHooksCapability_Kind{reconciler.ReconcilerHooksCapability_KIND_CLUSTER},
+			reconciler.ReconcilerHooksResult_BEHAVIOR_CONTINUE,
+			0,
+			nil,
+		)
+		f1.set(d.plugins[0].(*fakeConnection))
+
+		f2 := newFakeReconcilerHooksClient(
+			[]reconciler.ReconcilerHooksCapability_Kind{reconciler.ReconcilerHooksCapability_KIND_CLUSTER},
+			reconciler.ReconcilerHooksResult_BEHAVIOR_TERMINATE,
+			0,
+			nil,
+		)
+		f2.set(d.plugins[1].(*fakeConnection))
+
+		f3 := newFakeReconcilerHooksClient(
+			[]reconciler.ReconcilerHooksCapability_Kind{reconciler.ReconcilerHooksCapability_KIND_CLUSTER},
+			reconciler.ReconcilerHooksResult_BEHAVIOR_CONTINUE,
+			0,
+			nil,
+		)
+		f3.set(d.plugins[2].(*fakeConnection))
+
+		result := d.PreReconcile(ctx, cluster, cluster)
+		Expect(result.StopReconciliation).To(BeTrue())
+		Expect(result.Err).ToNot(HaveOccurred())
+		Expect(result.Identifier).To(Equal("plugin-2"))
+		Expect(f1.getCallCount()).To(Equal(1), "plugin-1 should be called once")
+		Expect(f2.getCallCount()).To(Equal(1), "plugin-2 should be called once")
+		Expect(f3.getCallCount()).To(Equal(0), "plugin-3 should not be called")
+	})
+
+	It("should skip plugins without the required capability", func() {
+		d.plugins = []connection.Interface{
+			&fakeConnection{name: "plugin-without-capability"},
+			&fakeConnection{name: "plugin-with-capability"},
+		}
+
+		f1 := newFakeReconcilerHooksClient(
+			[]reconciler.ReconcilerHooksCapability_Kind{reconciler.ReconcilerHooksCapability_KIND_BACKUP},
+			reconciler.ReconcilerHooksResult_BEHAVIOR_TERMINATE,
+			0,
+			nil,
+		)
+		f1.set(d.plugins[0].(*fakeConnection))
+
+		f2 := newFakeReconcilerHooksClient(
+			[]reconciler.ReconcilerHooksCapability_Kind{reconciler.ReconcilerHooksCapability_KIND_CLUSTER},
+			reconciler.ReconcilerHooksResult_BEHAVIOR_CONTINUE,
+			0,
+			nil,
+		)
+		f2.set(d.plugins[1].(*fakeConnection))
+
+		result := d.PreReconcile(ctx, cluster, cluster)
+		Expect(result.StopReconciliation).To(BeFalse())
+		Expect(result.Err).ToNot(HaveOccurred())
+		Expect(result.Identifier).To(Equal(cnpgOperatorKey))
+		Expect(f1.getCallCount()).To(Equal(0), "plugin without capability should not be called")
+		Expect(f2.getCallCount()).To(Equal(1), "plugin with capability should be called once")
+	})
+
+	It("should handle Backup objects", func() {
+		backup := &apiv1.Backup{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "postgresql.cnpg.io/v1",
+				Kind:       "Backup",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-backup",
+				Namespace: "default",
+			},
+		}
+
+		f := newFakeReconcilerHooksClient(
+			[]reconciler.ReconcilerHooksCapability_Kind{reconciler.ReconcilerHooksCapability_KIND_BACKUP},
+			reconciler.ReconcilerHooksResult_BEHAVIOR_CONTINUE,
+			0,
+			nil,
+		)
+		f.set(d.plugins[0].(*fakeConnection))
+
+		result := d.PreReconcile(ctx, cluster, backup)
+		Expect(result.StopReconciliation).To(BeFalse())
+		Expect(result.Err).ToNot(HaveOccurred())
+		Expect(result.Identifier).To(Equal(cnpgOperatorKey))
+	})
+
+	It("should skip unknown object kinds", func() {
+		pod := &corev1.Pod{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "v1",
+				Kind:       "Pod",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-pod",
+				Namespace: "default",
+			},
+		}
+
+		f := newFakeReconcilerHooksClient(
+			[]reconciler.ReconcilerHooksCapability_Kind{reconciler.ReconcilerHooksCapability_KIND_CLUSTER},
+			reconciler.ReconcilerHooksResult_BEHAVIOR_TERMINATE,
+			0,
+			nil,
+		)
+		f.set(d.plugins[0].(*fakeConnection))
+
+		result := d.PreReconcile(ctx, cluster, pod)
+		Expect(result.StopReconciliation).To(BeFalse())
+		Expect(result.Err).ToNot(HaveOccurred())
+		Expect(result.Identifier).To(Equal(cnpgOperatorKey))
+	})
+})

--- a/internal/cnpi/plugin/client/suite_test.go
+++ b/internal/cnpi/plugin/client/suite_test.go
@@ -104,10 +104,12 @@ func (f *fakeOperatorClient) Deregister(
 }
 
 type fakeConnection struct {
-	lifecycleClient       lifecycle.OperatorLifecycleClient
-	lifecycleCapabilities []*lifecycle.OperatorLifecycleCapabilities
-	name                  string
-	operatorClient        *fakeOperatorClient
+	lifecycleClient        lifecycle.OperatorLifecycleClient
+	lifecycleCapabilities  []*lifecycle.OperatorLifecycleCapabilities
+	name                   string
+	operatorClient         *fakeOperatorClient
+	reconcilerHooksClient  reconciler.ReconcilerHooksClient
+	reconcilerCapabilities []reconciler.ReconcilerHooksCapability_Kind
 }
 
 func (f *fakeConnection) MetricsClient() metrics.MetricsClient {
@@ -173,7 +175,7 @@ func (f *fakeConnection) BackupClient() backup.BackupClient {
 }
 
 func (f *fakeConnection) ReconcilerHooksClient() reconciler.ReconcilerHooksClient {
-	panic("not implemented") // TODO: Implement
+	return f.reconcilerHooksClient
 }
 
 func (f *fakeConnection) PluginCapabilities() []identity.PluginCapability_Service_Type {
@@ -205,7 +207,7 @@ func (f *fakeConnection) BackupCapabilities() []backup.BackupCapability_RPC_Type
 }
 
 func (f *fakeConnection) ReconcilerCapabilities() []reconciler.ReconcilerHooksCapability_Kind {
-	panic("not implemented")
+	return f.reconcilerCapabilities
 }
 
 func (f *fakeConnection) Ping(_ context.Context) error {


### PR DESCRIPTION
## Description                                                                                                                                                           
                                                                                                                                                                           
  Fixes a bug where only the first plugin with `ReconcilerHooks` capability is executed during cluster/backup reconciliation. When a plugin returns `BEHAVIOR_CONTINUE`,   
  the reconciler loop returns immediately instead of continuing to process remaining plugins.

It is not clear that there is another type of `reconciler.ReconcilerHooksResult` that should be returned to allow processing of subsequent plugins, unless plugins are expected to use `ReconcilerHooksResult_BEHAVIOR_UNSPECIFIED`, but this seems inconsistent with the documentation.                                                                                                                                                                                                                                 

  ### Root Cause

  In `internal/cnpi/plugin/client/reconciler.go`, the `reconcilerHook` function's switch statement for `BEHAVIOR_CONTINUE` returns immediately:

  ```go
  case reconciler.ReconcilerHooksResult_BEHAVIOR_CONTINUE:
      return newContinueResult(plugin.Name()) 
```
  This breaks what I suspect is the intended behavior based on this definition
```
	// BEHAVIOR_CONTINUE indicates that this reconciliation loop will
	// proceed running.
	// BEHAVIOR_CONTINUE is useful when the plugin executes changes on internal status or resources not directly managed
	// by the main reconciliation loop
```

where I would imagine BEHAVIOR_CONTINUE should allow the loop to proceed to the next plugin before continuing with the operator's core reconciliation.

### Solution

  Changed the BEHAVIOR_CONTINUE case to continue the loop instead of returning:
```go
  case reconciler.ReconcilerHooksResult_BEHAVIOR_CONTINUE:
      // Continue to next plugin
```
  Now all plugins that return the BEHAVIOR_CONTINUE cause the reconciler hook to iterate to the next plugin.

### Testing

  Deployed a cluster with two plugins:
  1. barman-cloud.cloudnative-pg.io (index 0)
  2. modified local version of https://github.com/cloudnative-pg/cnpg-i-hello-world that implemented the reconciler interface (index 1)

**Before Fix**

The reconciler Pre hook on the second plugin (index 1) never executed

**After Fix**

The reconciler Pre hook for both plugins executed

**Impact**

I tested this with the latest version of the operator as of the time of the creation of this ticket at https://github.com/cloudnative-pg/cloudnative-pg/commit/1bf4584b84a5bfa38f37b9da1403509ee2bd1706. The logic skipping plugins seems to present ever since `internal/cnpi/plugin/client/reconciler.go` was introduced a couple years ago and looks to be in v1.28x and v1.27.x.

Assisted-by: Claude Opus 4.6