### PR TITLE
fix(slots): cleanup orphaned failover logical slots after switchover

### DIFF
--- a/api/v1/cluster_funcs.go
+++ b/api/v1/cluster_funcs.go
@@ -327,6 +327,17 @@ func (r *ReplicationSlotsHAConfiguration) GetEnabled() bool {
 	return true
 }
 
+// GetSynchronizeLogicalDecoding returns true if logical slot synchronization is configured.
+// This requires both HighAvailability slots to be enabled and SynchronizeLogicalDecoding
+// to be set to true. When true on PostgreSQL 17+, the cluster is configured for native
+// slot synchronization from primary to standbys.
+func (r *ReplicationSlotsHAConfiguration) GetSynchronizeLogicalDecoding() bool {
+	if r == nil {
+		return false
+	}
+	return r.GetEnabled() && r.SynchronizeLogicalDecoding
+}
+
 // ToPostgreSQLConfigurationKeyword returns the contained value as a valid PostgreSQL parameter to be injected
 // in the 'synchronous_standby_names' field
 func (s SynchronousReplicaConfigurationMethod) ToPostgreSQLConfigurationKeyword() string {

--- a/api/v1/cluster_funcs_test.go
+++ b/api/v1/cluster_funcs_test.go
@@ -1014,6 +1014,45 @@ var _ = Describe("Replication slots names for instances", func() {
 	})
 })
 
+var _ = Describe("GetSynchronizeLogicalDecoding", func() {
+	It("returns false when configuration is nil", func() {
+		var config *ReplicationSlotsHAConfiguration
+		Expect(config.GetSynchronizeLogicalDecoding()).To(BeFalse())
+	})
+
+	It("returns false when HA slots are disabled", func() {
+		config := &ReplicationSlotsHAConfiguration{
+			Enabled:                    ptr.To(false),
+			SynchronizeLogicalDecoding: true,
+		}
+		Expect(config.GetSynchronizeLogicalDecoding()).To(BeFalse())
+	})
+
+	It("returns false when SynchronizeLogicalDecoding is false", func() {
+		config := &ReplicationSlotsHAConfiguration{
+			Enabled:                    ptr.To(true),
+			SynchronizeLogicalDecoding: false,
+		}
+		Expect(config.GetSynchronizeLogicalDecoding()).To(BeFalse())
+	})
+
+	It("returns true when HA enabled and SynchronizeLogicalDecoding is true", func() {
+		config := &ReplicationSlotsHAConfiguration{
+			Enabled:                    ptr.To(true),
+			SynchronizeLogicalDecoding: true,
+		}
+		Expect(config.GetSynchronizeLogicalDecoding()).To(BeTrue())
+	})
+
+	It("returns true when Enabled is nil (defaults to true) and SynchronizeLogicalDecoding is true", func() {
+		config := &ReplicationSlotsHAConfiguration{
+			Enabled:                    nil,
+			SynchronizeLogicalDecoding: true,
+		}
+		Expect(config.GetSynchronizeLogicalDecoding()).To(BeTrue())
+	})
+})
+
 var _ = Describe("Managed Roles", func() {
 	It("Verify default values", func() {
 		cluster := Cluster{

--- a/internal/management/controller/slots/infrastructure/postgresmanager.go
+++ b/internal/management/controller/slots/infrastructure/postgresmanager.go
@@ -159,6 +159,17 @@ func ListLogicalSlotsWithSyncStatus(ctx context.Context, db *sql.DB) ([]LogicalR
 	return slots, nil
 }
 
+// IsInRecovery reports whether PostgreSQL considers this instance to be in
+// recovery (i.e. running as a standby). pg_is_in_recovery() returns false on a
+// primary and true on a standby.
+func IsInRecovery(ctx context.Context, db *sql.DB) (bool, error) {
+	var inRecovery bool
+	if err := db.QueryRowContext(ctx, "SELECT pg_catalog.pg_is_in_recovery()").Scan(&inRecovery); err != nil {
+		return false, fmt.Errorf("querying pg_is_in_recovery: %w", err)
+	}
+	return inRecovery, nil
+}
+
 // DeleteLogicalSlot drops a logical replication slot by name.
 // Note: Active slots cannot be dropped - this will return an error from PostgreSQL.
 func DeleteLogicalSlot(ctx context.Context, db *sql.DB, slotName string) error {

--- a/internal/management/controller/slots/infrastructure/postgresmanager_test.go
+++ b/internal/management/controller/slots/infrastructure/postgresmanager_test.go
@@ -236,6 +236,35 @@ var _ = Describe("PostgresManager", func() {
 		})
 	})
 
+	Context("IsInRecovery", func() {
+		const expectedSQL = "SELECT pg_catalog.pg_is_in_recovery"
+
+		It("returns true when PostgreSQL is in recovery (standby)", func(ctx SpecContext) {
+			rows := sqlmock.NewRows([]string{"pg_is_in_recovery"}).AddRow(true)
+			mock.ExpectQuery(expectedSQL).WillReturnRows(rows)
+
+			inRecovery, err := IsInRecovery(ctx, db)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(inRecovery).To(BeTrue())
+		})
+
+		It("returns false when PostgreSQL is a primary", func(ctx SpecContext) {
+			rows := sqlmock.NewRows([]string{"pg_is_in_recovery"}).AddRow(false)
+			mock.ExpectQuery(expectedSQL).WillReturnRows(rows)
+
+			inRecovery, err := IsInRecovery(ctx, db)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(inRecovery).To(BeFalse())
+		})
+
+		It("returns error when the query fails", func(ctx SpecContext) {
+			mock.ExpectQuery(expectedSQL).WillReturnError(errors.New("mock error"))
+
+			_, err := IsInRecovery(ctx, db)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
 	Context("DeleteLogicalSlot", func() {
 		const expectedSQL = "SELECT pg_catalog.pg_drop_replication_slot"
 

--- a/internal/management/controller/slots/infrastructure/replicationslot.go
+++ b/internal/management/controller/slots/infrastructure/replicationslot.go
@@ -54,3 +54,15 @@ func (sl ReplicationSlotList) Get(name string) *ReplicationSlot {
 func (sl ReplicationSlotList) Has(name string) bool {
 	return sl.Get(name) != nil
 }
+
+// LogicalReplicationSlot represents a logical replication slot for logical decoding.
+// It parallels ReplicationSlot but captures logical-slot-specific fields
+// like Plugin and Synced (PG17+) instead of physical-slot fields like IsHA.
+type LogicalReplicationSlot struct {
+	SlotName   string `json:"slotName"`             // The slot's unique identifier
+	Plugin     string `json:"plugin,omitempty"`     // Output plugin (e.g., "pgoutput", "wal2json")
+	Active     bool   `json:"active"`               // True if a consumer is connected to the slot
+	RestartLSN string `json:"restartLSN,omitempty"` // WAL position from which the slot can start decoding
+	Synced     bool   `json:"synced"`               // PG17+: false if locally created, true if synced from primary
+	Failover   bool   `json:"failover"`             // PG17+: true if slot is configured for failover synchronization
+}

--- a/internal/management/controller/slots/reconciler/replicationslot.go
+++ b/internal/management/controller/slots/reconciler/replicationslot.go
@@ -73,8 +73,12 @@ func ReconcileReplicationSlots(
 				"imageName", cluster.Spec.ImageName,
 				"err", err)
 		} else if pgMajor >= 17 {
-			if err := cleanupOrphanedLogicalSlots(ctx, db); err != nil {
+			res, err := cleanupOrphanedLogicalSlots(ctx, db)
+			if err != nil {
 				return reconcile.Result{}, fmt.Errorf("cleaning up orphaned logical slots: %w", err)
+			}
+			if !res.IsZero() {
+				return res, nil
 			}
 		}
 	}
@@ -225,14 +229,30 @@ func dropReplicationSlots(
 // We specifically require failover=true to avoid dropping legitimate external
 // subscription slots (like those created by pg_createsubscription), which have
 // failover=false and should not be touched.
-func cleanupOrphanedLogicalSlots(ctx context.Context, db *sql.DB) error {
+func cleanupOrphanedLogicalSlots(ctx context.Context, db *sql.DB) (reconcile.Result, error) {
 	contextLog := log.FromContext(ctx).WithName("cleanupOrphanedLogicalSlots")
+
+	// Belt-and-suspenders: gate this destructive drop on PostgreSQL's own view of
+	// its role rather than relying solely on the caller's cluster-status check.
+	// During a demotion the cluster status can already name the new primary while
+	// this node's PostgreSQL has not yet been restarted into recovery; dropping a
+	// still-live failover slot in that window would lose a slot the sync worker
+	// (which only runs on standbys) will not recreate.
+	inRecovery, err := infrastructure.IsInRecovery(ctx, db)
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("checking recovery status before logical slot cleanup: %w", err)
+	}
+	if !inRecovery {
+		contextLog.Warning("Skipping orphaned logical slot cleanup: PostgreSQL reports this node is not in recovery")
+		return reconcile.Result{}, nil
+	}
 
 	slots, err := infrastructure.ListLogicalSlotsWithSyncStatus(ctx, db)
 	if err != nil {
-		return fmt.Errorf("listing logical slots: %w", err)
+		return reconcile.Result{}, fmt.Errorf("listing logical slots: %w", err)
 	}
 
+	needToReschedule := false
 	for _, slot := range slots {
 		// Skip synced slots - they are properly managed by the sync worker
 		if slot.Synced {
@@ -247,10 +267,11 @@ func cleanupOrphanedLogicalSlots(ctx context.Context, db *sql.DB) error {
 			continue
 		}
 
-		// Skip active slots - they cannot be dropped and we'll retry on next reconciliation
+		// Skip active slots - they cannot be dropped, so retry on a later reconciliation
 		if slot.Active {
 			contextLog.Trace("Skipping active orphaned logical slot (cannot be dropped)",
 				"slotName", slot.SlotName)
+			needToReschedule = true
 			continue
 		}
 
@@ -258,9 +279,19 @@ func cleanupOrphanedLogicalSlots(ctx context.Context, db *sql.DB) error {
 		contextLog.Info("Dropping orphaned logical slot", "slotName", slot.SlotName)
 
 		if err := infrastructure.DeleteLogicalSlot(ctx, db, slot.SlotName); err != nil {
-			return fmt.Errorf("deleting orphaned logical slot %q: %w", slot.SlotName, err)
+			// A slot can become active between listing and dropping. Mirror the
+			// physical-slot path: treat the failure as transient and retry on a
+			// later reconciliation rather than aborting the whole instance reconcile.
+			contextLog.Warning("Failed to drop orphaned logical slot, will retry",
+				"slotName", slot.SlotName, "err", err)
+			needToReschedule = true
+			continue
 		}
 	}
 
-	return nil
+	if needToReschedule {
+		return reconcile.Result{RequeueAfter: time.Second}, nil
+	}
+
+	return reconcile.Result{}, nil
 }

--- a/internal/management/controller/slots/reconciler/replicationslot_test.go
+++ b/internal/management/controller/slots/reconciler/replicationslot_test.go
@@ -261,6 +261,10 @@ var _ = Describe("ReconcileReplicationSlots logical slot cleanup integration", f
 				true,
 			)
 
+			// The cleanup first confirms the node is in recovery (a standby).
+			mock.ExpectQuery("SELECT pg_catalog.pg_is_in_recovery").
+				WillReturnRows(sqlmock.NewRows([]string{"pg_is_in_recovery"}).AddRow(true))
+
 			// Expect logical slot cleanup query
 			// Only the orphan_slot (synced=false, failover=true) should be dropped
 			// external_sub_slot (synced=false, failover=false) should NOT be dropped
@@ -346,8 +350,26 @@ var _ = Describe("cleanupOrphanedLogicalSlots", func() {
 		Expect(mock.ExpectationsWereMet()).To(Succeed())
 	})
 
+	expectInRecovery := func(inRecovery bool) {
+		mock.ExpectQuery("SELECT pg_catalog.pg_is_in_recovery").
+			WillReturnRows(sqlmock.NewRows([]string{"pg_is_in_recovery"}).AddRow(inRecovery))
+	}
+
+	It("does not drop any slot when PostgreSQL reports the node is not in recovery",
+		func(ctx SpecContext) {
+			// Belt-and-suspenders: even if the caller's cluster-status gate let us
+			// through, a node PostgreSQL still considers a primary must not have its
+			// slots dropped. No list or drop query should be issued.
+			expectInRecovery(false)
+
+			res, err := cleanupOrphanedLogicalSlots(ctx, db)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res.IsZero()).To(BeTrue())
+		})
+
 	It("should drop only orphaned failover slots (synced=false, failover=true, active=false)",
 		func(ctx SpecContext) {
+			expectInRecovery(true)
 			rows := sqlmock.NewRows([]string{"slot_name", "plugin", "active", "restart_lsn", "synced", "failover"}).
 				AddRow("synced_slot", "pgoutput", false, "0/1234", true, true).   // synced=true, skip
 				AddRow("orphan_slot", "pgoutput", false, "0/5678", false, true).  // orphaned failover slot, DROP
@@ -362,11 +384,12 @@ var _ = Describe("cleanupOrphanedLogicalSlots", func() {
 				WithArgs("orphan_slot").
 				WillReturnResult(sqlmock.NewResult(1, 1))
 
-			err := cleanupOrphanedLogicalSlots(ctx, db)
+			_, err := cleanupOrphanedLogicalSlots(ctx, db)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
 	It("should NOT drop external subscription slots (failover=false)", func(ctx SpecContext) {
+		expectInRecovery(true)
 		// This test ensures we don't accidentally break external logical replication
 		rows := sqlmock.NewRows([]string{"slot_name", "plugin", "active", "restart_lsn", "synced", "failover"}).
 			AddRow("test_sub", "pgoutput", false, "0/5678", false, false) // external subscription slot
@@ -375,42 +398,62 @@ var _ = Describe("cleanupOrphanedLogicalSlots", func() {
 			WillReturnRows(rows)
 
 		// No deletion should occur - test_sub has failover=false
-		err := cleanupOrphanedLogicalSlots(ctx, db)
+		_, err := cleanupOrphanedLogicalSlots(ctx, db)
 		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("should do nothing when no orphaned failover slots exist", func(ctx SpecContext) {
+		expectInRecovery(true)
 		rows := sqlmock.NewRows([]string{"slot_name", "plugin", "active", "restart_lsn", "synced", "failover"}).
 			AddRow("synced_slot", "pgoutput", false, "0/1234", true, true)
 
 		mock.ExpectQuery("SELECT .+ FROM pg_catalog.pg_replication_slots WHERE slot_type = 'logical'").
 			WillReturnRows(rows)
 
-		err := cleanupOrphanedLogicalSlots(ctx, db)
+		_, err := cleanupOrphanedLogicalSlots(ctx, db)
 		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("should return error when listing slots fails", func(ctx SpecContext) {
+		expectInRecovery(true)
 		mock.ExpectQuery("SELECT .+ FROM pg_catalog.pg_replication_slots WHERE slot_type = 'logical'").
 			WillReturnError(errors.New("mock error"))
 
-		err := cleanupOrphanedLogicalSlots(ctx, db)
+		_, err := cleanupOrphanedLogicalSlots(ctx, db)
 		Expect(err).To(HaveOccurred())
 	})
 
-	It("should return error when deleting a slot fails", func(ctx SpecContext) {
-		rows := sqlmock.NewRows([]string{"slot_name", "plugin", "active", "restart_lsn", "synced", "failover"}).
-			AddRow("orphan_slot", "pgoutput", false, "0/5678", false, true)
+	It("reschedules instead of failing when dropping a slot errors (e.g. it became active)",
+		func(ctx SpecContext) {
+			expectInRecovery(true)
+			rows := sqlmock.NewRows([]string{"slot_name", "plugin", "active", "restart_lsn", "synced", "failover"}).
+				AddRow("orphan_slot", "pgoutput", false, "0/5678", false, true)
 
-		mock.ExpectQuery("SELECT .+ FROM pg_catalog.pg_replication_slots WHERE slot_type = 'logical'").
-			WillReturnRows(rows)
+			mock.ExpectQuery("SELECT .+ FROM pg_catalog.pg_replication_slots WHERE slot_type = 'logical'").
+				WillReturnRows(rows)
 
-		mock.ExpectExec("SELECT pg_catalog.pg_drop_replication_slot").
-			WithArgs("orphan_slot").
-			WillReturnError(errors.New("delete error"))
+			// A consumer can connect between listing and dropping, making the drop fail.
+			// This must not abort the whole instance reconcile; it should requeue.
+			mock.ExpectExec("SELECT pg_catalog.pg_drop_replication_slot").
+				WithArgs("orphan_slot").
+				WillReturnError(errors.New("replication slot \"orphan_slot\" is active"))
 
-		err := cleanupOrphanedLogicalSlots(ctx, db)
-		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("delete error"))
-	})
+			res, err := cleanupOrphanedLogicalSlots(ctx, db)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res.RequeueAfter).To(Equal(time.Second))
+		})
+
+	It("reschedules when an orphaned failover slot is active and cannot be dropped",
+		func(ctx SpecContext) {
+			expectInRecovery(true)
+			rows := sqlmock.NewRows([]string{"slot_name", "plugin", "active", "restart_lsn", "synced", "failover"}).
+				AddRow("active_orphan", "pgoutput", true, "0/5678", false, true) // active, must be retried later
+
+			mock.ExpectQuery("SELECT .+ FROM pg_catalog.pg_replication_slots WHERE slot_type = 'logical'").
+				WillReturnRows(rows)
+
+			res, err := cleanupOrphanedLogicalSlots(ctx, db)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res.RequeueAfter).To(Equal(time.Second))
+		})
 })

--- a/pkg/management/postgres/configuration.go
+++ b/pkg/management/postgres/configuration.go
@@ -368,7 +368,8 @@ func createPostgresqlConfiguration(
 		info.RecoveryMinApplyDelay = cluster.Spec.ReplicaCluster.MinApplyDelay.Duration
 	}
 
-	if isSynchronizeLogicalDecodingEnabled(cluster) {
+	if cluster.Spec.ReplicationSlots != nil &&
+		cluster.Spec.ReplicationSlots.HighAvailability.GetSynchronizeLogicalDecoding() {
 		slots := make([]string, 0, len(cluster.Status.InstanceNames)-1)
 		for _, instanceName := range cluster.Status.InstanceNames {
 			if instanceName == cluster.Status.CurrentPrimary {
@@ -386,13 +387,6 @@ func createPostgresqlConfiguration(
 
 	file, sha := postgres.CreatePostgresqlConfFile(config)
 	return file, sha, nil
-}
-
-func isSynchronizeLogicalDecodingEnabled(cluster *apiv1.Cluster) bool {
-	return cluster.Spec.ReplicationSlots != nil &&
-		cluster.Spec.ReplicationSlots.HighAvailability != nil &&
-		cluster.Spec.ReplicationSlots.HighAvailability.GetEnabled() &&
-		cluster.Spec.ReplicationSlots.HighAvailability.SynchronizeLogicalDecoding
 }
 
 // selectAdditionalExtensions returns the extension list and mount base

--- a/tests/e2e/fixtures/logical_slot_switchover/source-cluster.yaml.template
+++ b/tests/e2e/fixtures/logical_slot_switchover/source-cluster.yaml.template
@@ -1,0 +1,51 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: logical-slot-source
+spec:
+  instances: 3
+
+  enableSuperuserAccess: true
+
+  replicationSlots:
+    highAvailability:
+      enabled: true
+      synchronizeLogicalDecoding: true
+
+  postgresql:
+    parameters:
+      max_connections: "110"
+      log_checkpoints: "on"
+      log_lock_waits: "on"
+      log_min_duration_statement: '1000'
+      log_statement: 'ddl'
+      log_temp_files: '1024'
+      log_autovacuum_min_duration: '1s'
+      log_replication_commands: 'on'
+      wal_level: logical
+      hot_standby_feedback: "on"
+      sync_replication_slots: "on"
+    pg_hba:
+      - hostssl replication app all scram-sha-256
+
+  managed:
+    roles:
+    - name: app
+      ensure: present
+      login: true
+      replication: true
+
+  primaryUpdateStrategy: unsupervised
+  primaryUpdateMethod: switchover
+
+  bootstrap:
+    initdb:
+      database: app
+      owner: app
+
+  storage:
+    storageClass: ${E2E_DEFAULT_STORAGE_CLASS}
+    size: 1Gi
+  walStorage:
+    storageClass: ${E2E_DEFAULT_STORAGE_CLASS}
+    size: 1Gi

--- a/tests/e2e/fixtures/logical_slot_switchover/source-database.yaml
+++ b/tests/e2e/fixtures/logical_slot_switchover/source-database.yaml
@@ -1,0 +1,10 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: source-db
+spec:
+  name: testdb
+  owner: app
+  databaseReclaimPolicy: delete
+  cluster:
+    name: logical-slot-source

--- a/tests/e2e/logical_slot_switchover_test.go
+++ b/tests/e2e/logical_slot_switchover_test.go
@@ -1,0 +1,212 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package e2e
+
+import (
+	"strings"
+	"time"
+
+	"github.com/cloudnative-pg/machinery/pkg/postgres/version"
+	"k8s.io/apimachinery/pkg/types"
+
+	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	"github.com/cloudnative-pg/cloudnative-pg/tests"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/clusterutils"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/exec"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/postgres"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/yaml"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// Tests for logical slot cleanup after switchover when synchronizeLogicalDecoding is enabled.
+// This tests the cleanup of orphaned failover-enabled logical slots that remain on a demoted
+// primary after switchover. PostgreSQL's sync_replication_slots syncs these slots to replicas
+// with synced=true, but when a primary is demoted, its locally-created slots remain with
+// synced=false and must be cleaned up for the sync worker to recreate them properly.
+var _ = Describe("Logical Slot Switchover", Label(tests.LabelPublicationSubscription, tests.LabelSelfHealing), func() {
+	const (
+		sourceClusterManifest  = fixturesDir + "/logical_slot_switchover/source-cluster.yaml.template"
+		sourceDatabaseManifest = fixturesDir + "/logical_slot_switchover/source-database.yaml"
+		level                  = tests.High
+	)
+
+	BeforeEach(func() {
+		if testLevelEnv.Depth < int(level) {
+			Skip("Test depth is lower than the amount requested for this test")
+		}
+	})
+
+	Context("with synchronizeLogicalDecoding enabled on PG17+", Ordered, func() {
+		const (
+			namespacePrefix = "logical-slot-switchover"
+			dbname          = "testdb"
+			slotName        = "test_failover_slot"
+		)
+		var (
+			sourceClusterName, namespace string
+			err                          error
+		)
+
+		BeforeAll(func() {
+			// This test requires PostgreSQL 17+ for sync_replication_slots and logical slot failover features
+			currentVersion, versionErr := version.FromTag(env.PostgresImageTag)
+			Expect(versionErr).ToNot(HaveOccurred())
+			if currentVersion.Major() < 17 {
+				Skip("This test requires PostgreSQL 17+ for sync_replication_slots and logical slot failover features")
+			}
+
+			namespace, err = env.CreateUniqueTestNamespace(env.Ctx, env.Client, namespacePrefix)
+			Expect(err).ToNot(HaveOccurred())
+
+			sourceClusterName, err = yaml.GetResourceNameFromYAML(env.Scheme, sourceClusterManifest)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("setting up source cluster with synchronizeLogicalDecoding", func() {
+				AssertCreateCluster(namespace, sourceClusterName, sourceClusterManifest, env)
+			})
+
+			By("creating database", func() {
+				CreateResourceFromFile(namespace, sourceDatabaseManifest)
+
+				// Wait for database to be ready
+				Eventually(func(g Gomega) {
+					db := &apiv1.Database{}
+					err := env.Client.Get(env.Ctx, types.NamespacedName{Namespace: namespace, Name: "source-db"}, db)
+					g.Expect(err).ToNot(HaveOccurred())
+					g.Expect(db.Status.Applied).Should(HaveValue(BeTrue()))
+				}, 300).WithPolling(10 * time.Second).Should(Succeed())
+			})
+
+			By("creating a failover-enabled logical replication slot on primary", func() {
+				// Create a logical slot with failover=true directly via SQL
+				// This simulates what happens when a subscription is created with failover=true
+				// or when using pg_failover_slots extension
+				query := "SELECT pg_create_logical_replication_slot('" + slotName + "', 'pgoutput', false, false, true)"
+				_, err = postgres.RunExecOverForward(
+					env.Ctx, env.Client, env.Interface, env.RestClientConfig,
+					namespace, sourceClusterName, dbname,
+					apiv1.SuperUserSecretSuffix, query,
+				)
+				Expect(err).ToNot(HaveOccurred())
+				GinkgoWriter.Printf("Created logical slot '%s' with failover=true\n", slotName)
+			})
+		})
+
+		// FlakeAttempts(1) because this test performs a switchover which changes cluster state
+		// and cannot be safely retried without recreating the cluster
+		It("cleans up orphaned failover logical slots after switchover", FlakeAttempts(1), func() {
+			var oldPrimary string
+
+			By("recording initial primary", func() {
+				cluster, err := clusterutils.Get(env.Ctx, env.Client, namespace, sourceClusterName)
+				Expect(err).ToNot(HaveOccurred())
+				oldPrimary = cluster.Status.CurrentPrimary
+				GinkgoWriter.Printf("Initial primary: %s\n", oldPrimary)
+			})
+
+			By("verifying failover slot exists on primary with correct flags", func() {
+				primaryPod, err := clusterutils.GetPrimary(env.Ctx, env.Client, namespace, sourceClusterName)
+				Expect(err).ToNot(HaveOccurred())
+
+				// Check that the slot has failover=true and synced=false (as expected on primary)
+				query := "SELECT slot_name, slot_type, synced, failover " +
+					"FROM pg_replication_slots WHERE slot_name = '" + slotName + "'"
+				Eventually(func(g Gomega) {
+					out, _, err := exec.QueryInInstancePod(
+						env.Ctx, env.Client, env.Interface, env.RestClientConfig,
+						exec.PodLocator{Namespace: primaryPod.Namespace, PodName: primaryPod.Name},
+						dbname, query,
+					)
+					g.Expect(err).ToNot(HaveOccurred())
+					GinkgoWriter.Printf("Slot on primary:\n%s\n", out)
+					// On primary: synced should be false (locally created), failover should be true
+					g.Expect(out).To(ContainSubstring(slotName))
+					g.Expect(out).To(ContainSubstring("f")) // synced=false
+					g.Expect(out).To(ContainSubstring("t")) // failover=true
+				}, 60).WithPolling(5 * time.Second).Should(Succeed())
+			})
+
+			By("waiting for slot to be synced to replicas", func() {
+				// PostgreSQL's sync_replication_slots should sync the failover slot to replicas
+				// On replicas, synced should be true
+				cluster, err := clusterutils.Get(env.Ctx, env.Client, namespace, sourceClusterName)
+				Expect(err).ToNot(HaveOccurred())
+
+				// Check one of the replicas
+				var replicaPod string
+				for _, instance := range cluster.Status.InstanceNames {
+					if instance != oldPrimary {
+						replicaPod = instance
+						break
+					}
+				}
+				Expect(replicaPod).ToNot(BeEmpty(), "Expected to find a replica pod")
+				GinkgoWriter.Printf("Checking replica pod: %s\n", replicaPod)
+
+				query := "SELECT slot_name, synced, failover FROM pg_replication_slots WHERE slot_name = '" + slotName + "'"
+				Eventually(func(g Gomega) {
+					out, _, err := exec.QueryInInstancePod(
+						env.Ctx, env.Client, env.Interface, env.RestClientConfig,
+						exec.PodLocator{Namespace: namespace, PodName: replicaPod},
+						postgres.PostgresDBName, query,
+					)
+					g.Expect(err).ToNot(HaveOccurred())
+					GinkgoWriter.Printf("Slot on replica %s:\n%s\n", replicaPod, out)
+					// On replica: slot should exist with synced=true (synced from primary)
+					g.Expect(out).To(ContainSubstring(slotName))
+				}, 120).WithPolling(10 * time.Second).Should(Succeed())
+			})
+
+			By("triggering switchover", func() {
+				GinkgoWriter.Printf("Triggering switchover from %s\n", oldPrimary)
+				AssertSwitchover(namespace, sourceClusterName, env)
+			})
+
+			By("verifying new primary", func() {
+				cluster, err := clusterutils.Get(env.Ctx, env.Client, namespace, sourceClusterName)
+				Expect(err).ToNot(HaveOccurred())
+				GinkgoWriter.Printf("New primary: %s (old was: %s)\n", cluster.Status.CurrentPrimary, oldPrimary)
+				Expect(cluster.Status.CurrentPrimary).ToNot(Equal(oldPrimary))
+			})
+
+			By("verifying orphaned failover slots are cleaned up on demoted primary", func() {
+				GinkgoWriter.Printf("Checking for orphaned slots on demoted primary: %s\n", oldPrimary)
+				// The old primary is now a replica
+				// After CNPG's cleanup runs, slots with synced=false AND failover=true should be removed
+				query := "SELECT slot_name, synced, failover FROM pg_replication_slots " +
+					"WHERE slot_name = '" + slotName + "' AND synced = false AND failover = true"
+
+				Eventually(func(g Gomega) {
+					out, _, err := exec.QueryInInstancePod(
+						env.Ctx, env.Client, env.Interface, env.RestClientConfig,
+						exec.PodLocator{Namespace: namespace, PodName: oldPrimary},
+						postgres.PostgresDBName, query,
+					)
+					g.Expect(err).ToNot(HaveOccurred())
+					GinkgoWriter.Printf("Orphaned failover slots on demoted primary:\n%s\n", out)
+					// Empty result means the orphaned slot was cleaned up
+					g.Expect(strings.TrimSpace(out)).To(BeEmpty(), "Expected orphaned failover slot to be cleaned up")
+				}, 180).WithPolling(10 * time.Second).Should(Succeed())
+			})
+		})
+	})
+})

--- a/tests/e2e/logical_slot_switchover_test.go
+++ b/tests/e2e/logical_slot_switchover_test.go
@@ -138,10 +138,13 @@ var _ = Describe("Logical Slot Switchover", Label(tests.LabelPublicationSubscrip
 					)
 					g.Expect(err).ToNot(HaveOccurred())
 					GinkgoWriter.Printf("Slot on primary:\n%s\n", out)
-					// On primary: synced should be false (locally created), failover should be true
-					g.Expect(out).To(ContainSubstring(slotName))
-					g.Expect(out).To(ContainSubstring("f")) // synced=false
-					g.Expect(out).To(ContainSubstring("t")) // failover=true
+					// psql -tA emits one pipe-separated row: slot_name|slot_type|synced|failover.
+					// On the primary the slot is locally created: synced=false (f), failover=true (t).
+					fields := strings.Split(strings.TrimSpace(out), "|")
+					g.Expect(fields).To(HaveLen(4))
+					g.Expect(fields[0]).To(Equal(slotName))
+					g.Expect(fields[2]).To(Equal("f"), "expected synced=false on primary")
+					g.Expect(fields[3]).To(Equal("t"), "expected failover=true on primary")
 				}, 60).WithPolling(5 * time.Second).Should(Succeed())
 			})
 
@@ -171,8 +174,12 @@ var _ = Describe("Logical Slot Switchover", Label(tests.LabelPublicationSubscrip
 					)
 					g.Expect(err).ToNot(HaveOccurred())
 					GinkgoWriter.Printf("Slot on replica %s:\n%s\n", replicaPod, out)
-					// On replica: slot should exist with synced=true (synced from primary)
-					g.Expect(out).To(ContainSubstring(slotName))
+					// Row layout: slot_name|synced|failover. On the replica the slot must be
+					// present and synced from the primary (synced=true), not just exist.
+					fields := strings.Split(strings.TrimSpace(out), "|")
+					g.Expect(fields).To(HaveLen(3))
+					g.Expect(fields[0]).To(Equal(slotName))
+					g.Expect(fields[1]).To(Equal("t"), "expected synced=true on replica")
 				}, 120).WithPolling(10 * time.Second).Should(Succeed())
 			})
 
@@ -205,6 +212,28 @@ var _ = Describe("Logical Slot Switchover", Label(tests.LabelPublicationSubscrip
 					GinkgoWriter.Printf("Orphaned failover slots on demoted primary:\n%s\n", out)
 					// Empty result means the orphaned slot was cleaned up
 					g.Expect(strings.TrimSpace(out)).To(BeEmpty(), "Expected orphaned failover slot to be cleaned up")
+				}, 180).WithPolling(10 * time.Second).Should(Succeed())
+			})
+
+			By("verifying the slot is re-synced from the new primary on the demoted primary", func() {
+				// Dropping the orphaned synced=false slot is only the means to an end:
+				// the slot-sync worker on the demoted primary (now a standby) must
+				// recreate it from the new primary with synced=true. Assert the recovery,
+				// not just the deletion.
+				query := "SELECT slot_name, synced FROM pg_replication_slots WHERE slot_name = '" + slotName + "'"
+				Eventually(func(g Gomega) {
+					out, _, err := exec.QueryInInstancePod(
+						env.Ctx, env.Client, env.Interface, env.RestClientConfig,
+						exec.PodLocator{Namespace: namespace, PodName: oldPrimary},
+						postgres.PostgresDBName, query,
+					)
+					g.Expect(err).ToNot(HaveOccurred())
+					GinkgoWriter.Printf("Re-synced slot on demoted primary:\n%s\n", out)
+					// Row layout: slot_name|synced. The slot must exist again with synced=true.
+					fields := strings.Split(strings.TrimSpace(out), "|")
+					g.Expect(fields).To(HaveLen(2))
+					g.Expect(fields[0]).To(Equal(slotName))
+					g.Expect(fields[1]).To(Equal("t"), "expected slot re-synced with synced=true")
 				}, 180).WithPolling(10 * time.Second).Should(Succeed())
 			})
 		})


### PR DESCRIPTION
## Summary

When using PostgreSQL 17's `sync_replication_slots` with CNPG's `synchronizeLogicalDecoding` feature, failover-enabled logical slots are synced from the primary to replicas with `synced=true`. However, after a switchover, the demoted primary retains its locally-created slots with `synced=false`, which prevents the sync worker from recreating them properly.

This PR adds automatic cleanup of orphaned failover slots on replicas when `synchronizeLogicalDecoding` is enabled:

- **Slots are dropped only when ALL criteria are met:**
  - `synced=false` (locally created, not from sync worker)
  - `failover=true` (meant to be managed by `sync_replication_slots`)
  - `active=false` (no consumer connected)

- **External subscription slots (`failover=false`) are explicitly preserved**

### Changes

1. **Infrastructure layer** (`internal/management/controller/slots/infrastructure/`):
   - Add `LogicalReplicationSlot` struct with `Synced` and `Failover` fields for PG17+
   - Add `ListLogicalSlotsWithSyncStatus()` to query logical slots with synced/failover columns
   - Add `DeleteLogicalSlot()` to drop logical slots by name

2. **Reconciler** (`internal/management/controller/slots/reconciler/`):
   - Add `cleanupOrphanedLogicalSlots()` to identify and remove orphaned failover slots
   - Integrate cleanup into the replication slot reconciliation loop (runs on PG17+ replicas only)

3. **API helpers** (`api/v1/`):
   - Add `GetSynchronizeLogicalDecoding()` helper function

4. **E2E test** (`tests/e2e/`):
   - Add comprehensive test that creates a failover slot, performs switchover, and verifies cleanup

## Test plan

- [x] Unit tests for `ListLogicalSlotsWithSyncStatus()`
- [x] Unit tests for `DeleteLogicalSlot()`
- [x] Unit tests for `cleanupOrphanedLogicalSlots()` covering:
  - Only drops orphan slots (synced=false AND failover=true AND active=false)
  - Does NOT drop external subscription slots (failover=false)
  - Does NOT drop synced slots (synced=true)
  - Does NOT run on primary
  - Does NOT run when synchronizeLogicalDecoding is disabled
  - Does NOT run on PG16 and earlier
- [x] E2E test validates slot cleanup after switchover
- [x] E2E test confirms failure without fix (main branch), success with fix (this branch)

Fixes: #9969

**Assisted by:** Claude Opus 4.5
