### PR TITLE
feat: fallback to pg_basebackup on snapshot recovery failure (#7793)

### DIFF
--- a/api/v1/cluster_funcs.go
+++ b/api/v1/cluster_funcs.go
@@ -1310,6 +1310,12 @@ func (cluster *Cluster) IsInplaceRestartPhase() bool {
 		cluster.Status.Phase == PhaseInplaceDeletePrimaryRestart
 }
 
+// IsScalingPhase returns true if the cluster is in a phase related to instance creation
+func (cluster *Cluster) IsScalingPhase() bool {
+	return cluster.Status.Phase == PhaseFirstPrimary ||
+		cluster.Status.Phase == PhaseCreatingReplica
+}
+
 // GetTablespaceConfiguration returns the tablespaceConfiguration for the given name
 // otherwise return nil
 func (cluster *Cluster) GetTablespaceConfiguration(name string) *TablespaceConfiguration {

--- a/api/v1/cluster_funcs_test.go
+++ b/api/v1/cluster_funcs_test.go
@@ -1788,3 +1788,23 @@ var _ = Describe("Failover quorum", func() {
 		Entry("with failover quorum disabled", clusterWithFailoverQuorumDisabled, false),
 	)
 })
+
+var _ = Describe("Scaling phase detection", func() {
+	DescribeTable(
+		"IsScalingPhase",
+		func(phase string, expected bool) {
+			cluster := &Cluster{
+				Status: ClusterStatus{
+					Phase: phase,
+				},
+			}
+			Expect(cluster.IsScalingPhase()).To(Equal(expected))
+		},
+		Entry("returns true for PhaseFirstPrimary", PhaseFirstPrimary, true),
+		Entry("returns true for PhaseCreatingReplica", PhaseCreatingReplica, true),
+		Entry("returns false for PhaseHealthy", PhaseHealthy, false),
+		Entry("returns false for PhaseSwitchover", PhaseSwitchover, false),
+		Entry("returns false for PhaseUpgrade", PhaseUpgrade, false),
+		Entry("returns false for PhaseInplacePrimaryRestart", PhaseInplacePrimaryRestart, false),
+	)
+})

--- a/internal/controller/cluster_cleanup.go
+++ b/internal/controller/cluster_cleanup.go
@@ -30,7 +30,9 @@ import (
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 )
 
-// cleanupCompletedJobs remove all the Jobs which are completed
+// cleanupCompletedJobs removes all Jobs which are completed.
+// Note: Failed jobs are intentionally left intact for troubleshooting
+// and to serve as markers for fallback logic (e.g., snapshot recovery fallback).
 func (r *ClusterReconciler) cleanupCompletedJobs(
 	ctx context.Context,
 	jobs batchv1.JobList,

--- a/internal/controller/cluster_cleanup_test.go
+++ b/internal/controller/cluster_cleanup_test.go
@@ -78,4 +78,44 @@ var _ = Describe("cluster_cleanup", func() {
 		err = cli.Get(ctx, client.ObjectKeyFromObject(&jobList.Items[1]), &batchv1.Job{})
 		Expect(err).ToNot(HaveOccurred())
 	})
+
+	It("should NOT delete failed jobs (left for troubleshooting)", func(ctx SpecContext) {
+		jobList := &batchv1.JobList{Items: []batchv1.Job{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "failed-job", Namespace: "test"},
+				Spec: batchv1.JobSpec{
+					Completions: ptr.To(int32(1)),
+				},
+				Status: batchv1.JobStatus{
+					Succeeded: 0,
+					Conditions: []batchv1.JobCondition{
+						{
+							Type:   batchv1.JobFailed,
+							Status: "True",
+						},
+					},
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "running-job", Namespace: "test"},
+				Spec: batchv1.JobSpec{
+					Completions: ptr.To(int32(1)),
+				},
+				Status: batchv1.JobStatus{
+					Succeeded: 0,
+				},
+			},
+		}}
+		cli := fake.NewClientBuilder().WithScheme(scheme).WithLists(jobList).Build()
+		r.Client = cli
+		r.cleanupCompletedJobs(ctx, *jobList)
+
+		By("verifying failed job is NOT deleted (kept for troubleshooting)")
+		err := cli.Get(ctx, client.ObjectKeyFromObject(&jobList.Items[0]), &batchv1.Job{})
+		Expect(err).ToNot(HaveOccurred())
+
+		By("verifying running job is not deleted")
+		err = cli.Get(ctx, client.ObjectKeyFromObject(&jobList.Items[1]), &batchv1.Job{})
+		Expect(err).ToNot(HaveOccurred())
+	})
 })

--- a/internal/controller/cluster_status.go
+++ b/internal/controller/cluster_status.go
@@ -62,7 +62,7 @@ type managedResources struct {
 func (resources *managedResources) runningJobNames() []string {
 	result := make([]string, 0, len(resources.jobs.Items))
 	for _, job := range resources.jobs.Items {
-		if !utils.JobHasOneCompletion(job) {
+		if !utils.JobHasOneCompletion(job) && !utils.IsJobFailed(job) {
 			result = append(result, job.Name)
 		}
 	}

--- a/internal/controller/cluster_status_test.go
+++ b/internal/controller/cluster_status_test.go
@@ -585,3 +585,95 @@ var _ = Describe("updateClusterStatusThatRequiresInstancesState tests", func() {
 		})
 	})
 })
+
+var _ = Describe("managedResources", func() {
+	Context("runningJobNames", func() {
+		It("should exclude completed jobs", func() {
+			resources := &managedResources{
+				jobs: batchv1.JobList{
+					Items: []batchv1.Job{
+						{
+							ObjectMeta: metav1.ObjectMeta{Name: "completed-job"},
+							Status: batchv1.JobStatus{
+								Succeeded: 1,
+							},
+						},
+						{
+							ObjectMeta: metav1.ObjectMeta{Name: "running-job"},
+							Status: batchv1.JobStatus{
+								Succeeded: 0,
+							},
+						},
+					},
+				},
+			}
+
+			names := resources.runningJobNames()
+			Expect(names).To(HaveLen(1))
+			Expect(names).To(ContainElement("running-job"))
+			Expect(names).NotTo(ContainElement("completed-job"))
+		})
+
+		It("should exclude failed jobs", func() {
+			resources := &managedResources{
+				jobs: batchv1.JobList{
+					Items: []batchv1.Job{
+						{
+							ObjectMeta: metav1.ObjectMeta{Name: "failed-job"},
+							Status: batchv1.JobStatus{
+								Succeeded: 0,
+								Conditions: []batchv1.JobCondition{
+									{
+										Type:   batchv1.JobFailed,
+										Status: "True",
+									},
+								},
+							},
+						},
+						{
+							ObjectMeta: metav1.ObjectMeta{Name: "running-job"},
+							Status: batchv1.JobStatus{
+								Succeeded: 0,
+							},
+						},
+					},
+				},
+			}
+
+			names := resources.runningJobNames()
+			Expect(names).To(HaveLen(1))
+			Expect(names).To(ContainElement("running-job"))
+			Expect(names).NotTo(ContainElement("failed-job"))
+		})
+
+		It("should return empty when all jobs are completed or failed", func() {
+			resources := &managedResources{
+				jobs: batchv1.JobList{
+					Items: []batchv1.Job{
+						{
+							ObjectMeta: metav1.ObjectMeta{Name: "completed-job"},
+							Status: batchv1.JobStatus{
+								Succeeded: 1,
+							},
+						},
+						{
+							ObjectMeta: metav1.ObjectMeta{Name: "failed-job"},
+							Status: batchv1.JobStatus{
+								Succeeded: 0,
+								Conditions: []batchv1.JobCondition{
+									{
+										Type:   batchv1.JobFailed,
+										Status: "True",
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			names := resources.runningJobNames()
+			Expect(names).To(BeEmpty())
+		})
+	})
+})

--- a/pkg/reconciler/persistentvolumeclaim/instance.go
+++ b/pkg/reconciler/persistentvolumeclaim/instance.go
@@ -39,9 +39,8 @@ func CreateInstancePVCs(
 	cluster *apiv1.Cluster,
 	source *StorageSource,
 	serial int,
-) error {
-	_, err := reconcileSingleInstanceMissingPVCs(ctx, c, cluster, serial, nil, source)
-	return err
+) (ctrl.Result, error) {
+	return reconcileSingleInstanceMissingPVCs(ctx, c, cluster, serial, nil, source)
 }
 
 // reconcileMultipleInstancesMissingPVCs evaluate multiple instances that may miss some PVCs.

--- a/pkg/utils/job_conditions.go
+++ b/pkg/utils/job_conditions.go
@@ -32,6 +32,16 @@ func JobHasOneCompletion(job batchv1.Job) bool {
 	return job.Status.Succeeded == requestedCompletions
 }
 
+// IsJobFailed checks if a job has failed
+func IsJobFailed(job batchv1.Job) bool {
+	for _, condition := range job.Status.Conditions {
+		if condition.Type == batchv1.JobFailed && condition.Status == "True" {
+			return true
+		}
+	}
+	return false
+}
+
 // FilterJobsWithOneCompletion returns jobs that have one completion
 func FilterJobsWithOneCompletion(jobList []batchv1.Job) []batchv1.Job {
 	var result []batchv1.Job

--- a/pkg/utils/job_conditions.go
+++ b/pkg/utils/job_conditions.go
@@ -21,6 +21,7 @@ package utils
 
 import (
 	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
 )
 
 // JobHasOneCompletion Completion check if a certain job is complete
@@ -35,7 +36,7 @@ func JobHasOneCompletion(job batchv1.Job) bool {
 // IsJobFailed checks if a job has failed
 func IsJobFailed(job batchv1.Job) bool {
 	for _, condition := range job.Status.Conditions {
-		if condition.Type == batchv1.JobFailed && condition.Status == "True" {
+		if condition.Type == batchv1.JobFailed && condition.Status == corev1.ConditionTrue {
 			return true
 		}
 	}

--- a/pkg/utils/job_conditions_test.go
+++ b/pkg/utils/job_conditions_test.go
@@ -54,7 +54,7 @@ var _ = Describe("Job conditions", func() {
 
 	runningJob := batchv1.Job{
 		Status: batchv1.JobStatus{
-			Succeeded: 0,
+			Succeeded:  0,
 			Conditions: []batchv1.JobCondition{},
 		},
 	}

--- a/pkg/utils/job_conditions_test.go
+++ b/pkg/utils/job_conditions_test.go
@@ -21,6 +21,7 @@ package utils
 
 import (
 	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -45,7 +46,7 @@ var _ = Describe("Job conditions", func() {
 			Conditions: []batchv1.JobCondition{
 				{
 					Type:   batchv1.JobFailed,
-					Status: "True",
+					Status: corev1.ConditionTrue,
 				},
 			},
 		},

--- a/pkg/utils/job_conditions_test.go
+++ b/pkg/utils/job_conditions_test.go
@@ -39,8 +39,34 @@ var _ = Describe("Job conditions", func() {
 		},
 	}
 
+	failedJob := batchv1.Job{
+		Status: batchv1.JobStatus{
+			Succeeded: 0,
+			Conditions: []batchv1.JobCondition{
+				{
+					Type:   batchv1.JobFailed,
+					Status: "True",
+				},
+			},
+		},
+	}
+
+	runningJob := batchv1.Job{
+		Status: batchv1.JobStatus{
+			Succeeded: 0,
+			Conditions: []batchv1.JobCondition{},
+		},
+	}
+
 	It("detects if a certain job is completed", func() {
 		Expect(JobHasOneCompletion(nonCompleteJob)).To(BeFalse())
 		Expect(JobHasOneCompletion(completeJob)).To(BeTrue())
+	})
+
+	It("detects if a certain job has failed", func() {
+		Expect(IsJobFailed(failedJob)).To(BeTrue())
+		Expect(IsJobFailed(runningJob)).To(BeFalse())
+		Expect(IsJobFailed(completeJob)).To(BeFalse())
+		Expect(IsJobFailed(nonCompleteJob)).To(BeFalse())
 	})
 })

--- a/pkg/utils/labels_annotations.go
+++ b/pkg/utils/labels_annotations.go
@@ -247,6 +247,10 @@ const (
 	// BackupEndWALAnnotationName is the name of the annotation where a backup's end WAL is kept
 	BackupEndWALAnnotationName = MetadataNamespace + "/backupEndWAL"
 
+	// SnapshotDataSourceAnnotationName is the name of the annotation containing the name of the
+	// VolumeSnapshot used as the data source for a snapshot-recovery job
+	SnapshotDataSourceAnnotationName = MetadataNamespace + "/snapshotDataSource"
+
 	// BackupStartTimeAnnotationName is the name of the annotation where a backup's start time is kept
 	BackupStartTimeAnnotationName = MetadataNamespace + "/backupStartTime"
 

--- a/tests/e2e/failed_job_handling_test.go
+++ b/tests/e2e/failed_job_handling_test.go
@@ -1,0 +1,173 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package e2e
+
+import (
+	"fmt"
+	"time"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	k8client "sigs.k8s.io/controller-runtime/pkg/client"
+
+	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
+	"github.com/cloudnative-pg/cloudnative-pg/tests"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/clusterutils"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/run"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Failed job handling", Serial, Label(tests.LabelReplication), func() {
+	const (
+		sampleFile  = fixturesDir + "/base/cluster-storage-class.yaml.template"
+		clusterName = "postgresql-storage-class"
+		level       = tests.High
+	)
+
+	var namespace string
+
+	BeforeEach(func() {
+		if testLevelEnv.Depth < int(level) {
+			Skip("Test depth is lower than the amount requested for this test")
+		}
+	})
+
+	// This test verifies that a failed join job does not block the reconciliation loop.
+	// When a join job fails, the operator should:
+	// 1. Exclude the failed job from runningJobNames() count
+	// 2. Continue processing other scaling operations
+	// 3. Eventually reach the desired cluster state
+	It("continues scaling after a join job fails", func() {
+		const namespacePrefix = "failed-job-handling"
+		var err error
+
+		namespace, err = env.CreateUniqueTestNamespace(env.Ctx, env.Client, namespacePrefix)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("creating a cluster with 3 instances", func() {
+			AssertCreateCluster(namespace, clusterName, sampleFile, env)
+		})
+
+		By("scaling to 4 instances", func() {
+			_, _, err := run.Run(fmt.Sprintf("kubectl scale --replicas=4 -n %v cluster/%v", namespace, clusterName))
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		var joinJob *batchv1.Job
+		By("waiting for a join job to be created", func() {
+			Eventually(func(g Gomega) {
+				var jobs batchv1.JobList
+				err := env.Client.List(env.Ctx, &jobs,
+					k8client.InNamespace(namespace),
+					k8client.MatchingLabels{
+						utils.ClusterLabelName: clusterName,
+						utils.JobRoleLabelName: "join",
+					},
+				)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(jobs.Items).ToNot(BeEmpty())
+				joinJob = &jobs.Items[0]
+			}, 60, 2).Should(Succeed())
+		})
+
+		By("attempting to disrupt the join job by deleting its pods", func() {
+			// Try to cause job disruption by deleting pods
+			// Note: The job might succeed anyway if Azure disk attach is fast enough
+			for i := 0; i < 3; i++ {
+				var pods corev1.PodList
+				err := env.Client.List(env.Ctx, &pods,
+					k8client.InNamespace(namespace),
+					k8client.MatchingLabels{
+						"job-name": joinJob.Name,
+					},
+				)
+				if err != nil || len(pods.Items) == 0 {
+					time.Sleep(3 * time.Second)
+					continue
+				}
+
+				for _, pod := range pods.Items {
+					_ = env.Client.Delete(env.Ctx, &pod,
+						k8client.GracePeriodSeconds(0),
+					)
+				}
+				time.Sleep(3 * time.Second)
+			}
+		})
+
+		// The key test: whether the job fails or succeeds, the cluster should
+		// eventually reach a stable state and not get stuck in "Creating replica"
+		By("verifying the cluster eventually reaches healthy state", func() {
+			// The reconciler should handle both success and failure scenarios:
+			// - If job succeeded: cluster becomes healthy
+			// - If job failed: reconciler continues (doesn't get stuck)
+			// Either way, scaling down to 3 should result in a healthy cluster
+			AssertClusterIsReady(namespace, clusterName, 600, env)
+		})
+
+		By("verifying we can scale back to 3 instances", func() {
+			_, _, err := run.Run(fmt.Sprintf("kubectl scale --replicas=3 -n %v cluster/%v", namespace, clusterName))
+			Expect(err).ToNot(HaveOccurred())
+			AssertClusterIsReady(namespace, clusterName, 300, env)
+		})
+	})
+
+	// This test verifies that the safety net clears stuck scaling phases
+	// when the number of running instances matches the desired count
+	It("clears stuck phase when instances match desired count", func() {
+		const namespacePrefix = "stuck-phase-recovery"
+		var err error
+
+		namespace, err = env.CreateUniqueTestNamespace(env.Ctx, env.Client, namespacePrefix)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("creating a cluster with 3 instances", func() {
+			AssertCreateCluster(namespace, clusterName, sampleFile, env)
+		})
+
+		By("verifying cluster is healthy", func() {
+			AssertClusterIsReady(namespace, clusterName, 300, env)
+		})
+
+		By("manually setting phase to 'Creating replica' to simulate stuck state", func() {
+			cluster, err := clusterutils.Get(env.Ctx, env.Client, namespace, clusterName)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Patch the status to simulate a stuck phase
+			cluster.Status.Phase = apiv1.PhaseCreatingReplica
+			cluster.Status.PhaseReason = "Simulated stuck phase for testing"
+			err = env.Client.Status().Update(env.Ctx, cluster)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		By("verifying the safety net clears the stuck phase", func() {
+			// The reconciler should detect that instances == desired and clear the phase
+			Eventually(func(g Gomega) {
+				cluster, err := clusterutils.Get(env.Ctx, env.Client, namespace, clusterName)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(cluster.Status.Phase).To(Equal(apiv1.PhaseHealthy),
+					"safety net should clear stuck phase when instances match desired")
+			}, 120, 5).Should(Succeed())
+		})
+	})
+})

--- a/tests/e2e/failed_job_handling_test.go
+++ b/tests/e2e/failed_job_handling_test.go
@@ -25,13 +25,18 @@ import (
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	k8client "sigs.k8s.io/controller-runtime/pkg/client"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 	"github.com/cloudnative-pg/cloudnative-pg/tests"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/clusterutils"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/minio"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/run"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/secrets"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/yaml"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -168,6 +173,163 @@ var _ = Describe("Failed job handling", Serial, Label(tests.LabelReplication), f
 				g.Expect(cluster.Status.Phase).To(Equal(apiv1.PhaseHealthy),
 					"safety net should clear stuck phase when instances match desired")
 			}, 120, 5).Should(Succeed())
+		})
+	})
+})
+
+var _ = Describe("Snapshot recovery fallback", Serial, Label(tests.LabelBackupRestore, tests.LabelSnapshot), func() {
+	const (
+		clusterWithSnapshotFile = fixturesDir + "/volume_snapshot/cluster-pvc-snapshot.yaml.template"
+		level                   = tests.High
+	)
+
+	var namespace string
+	var clusterName string
+
+	BeforeEach(func() {
+		if testLevelEnv.Depth < int(level) {
+			Skip("Test depth is lower than the amount requested for this test")
+		}
+	})
+
+	// This test verifies that when a snapshot-recovery job fails,
+	// the operator falls back to pg_basebackup for that specific snapshot
+	It("falls back to pg_basebackup when snapshot recovery fails", func() {
+		const namespacePrefix = "snapshot-fallback"
+		var err error
+
+		namespace, err = env.CreateUniqueTestNamespace(env.Ctx, env.Client, namespacePrefix)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("creating the minio certificates", func() {
+			err := minioEnv.CreateCaSecret(env, namespace)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		By("creating the backup storage credentials", func() {
+			_, err = secrets.CreateObjectStorageSecret(
+				env.Ctx,
+				env.Client,
+				namespace,
+				"backup-storage-creds",
+				"minio",
+				"minio123",
+			)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		By("creating a cluster with snapshot backup capability", func() {
+			clusterName, err = yaml.GetResourceNameFromYAML(env.Scheme, clusterWithSnapshotFile)
+			Expect(err).ToNot(HaveOccurred())
+			AssertCreateCluster(namespace, clusterName, clusterWithSnapshotFile, env)
+		})
+
+		By("verifying barman connectivity to minio", func() {
+			primaryPod, err := clusterutils.GetPrimary(env.Ctx, env.Client, namespace, clusterName)
+			Expect(err).ToNot(HaveOccurred())
+			Eventually(func() (bool, error) {
+				return minio.TestBarmanConnectivity(
+					namespace, clusterName, primaryPod.Name,
+					"minio", "minio123", minioEnv.ServiceName)
+			}, 60).Should(BeTrue())
+		})
+
+		var backup *apiv1.Backup
+		By("taking a volume snapshot backup", func() {
+			backupName := fmt.Sprintf("%s-snapshot", clusterName)
+			backup = &apiv1.Backup{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      backupName,
+				},
+				Spec: apiv1.BackupSpec{
+					Target:  apiv1.BackupTargetStandby,
+					Method:  apiv1.BackupMethodVolumeSnapshot,
+					Cluster: apiv1.LocalObjectReference{Name: clusterName},
+				},
+			}
+			err := env.Client.Create(env.Ctx, backup)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Trigger a checkpoint to ensure backup completes
+			CheckPointAndSwitchWalOnPrimary(namespace, clusterName)
+
+			// Wait for backup to complete
+			Eventually(func(g Gomega) {
+				err := env.Client.Get(env.Ctx, types.NamespacedName{
+					Namespace: namespace,
+					Name:      backupName,
+				}, backup)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(backup.Status.Phase).To(BeEquivalentTo(apiv1.BackupPhaseCompleted),
+					"Backup should be completed, error: %s", backup.Status.Error)
+				g.Expect(backup.Status.BackupSnapshotStatus.Elements).To(HaveLen(2),
+					"Backup should have 2 snapshot elements (pgdata and pgwal)")
+			}, 300, 5).Should(Succeed())
+		})
+
+		By("scaling up to trigger snapshot recovery", func() {
+			_, _, err := run.Run(fmt.Sprintf("kubectl scale --replicas=3 -n %v cluster/%v", namespace, clusterName))
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		var snapshotRecoveryJob *batchv1.Job
+		By("waiting for a snapshot-recovery job to be created", func() {
+			Eventually(func(g Gomega) {
+				var jobs batchv1.JobList
+				err := env.Client.List(env.Ctx, &jobs,
+					k8client.InNamespace(namespace),
+					k8client.MatchingLabels{
+						utils.ClusterLabelName: clusterName,
+						utils.JobRoleLabelName: "snapshot-recovery",
+					},
+				)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(jobs.Items).ToNot(BeEmpty(),
+					"snapshot-recovery job should be created when scaling up with available snapshot")
+				snapshotRecoveryJob = &jobs.Items[0]
+
+				// Verify the job has the snapshot data source annotation
+				g.Expect(snapshotRecoveryJob.Annotations).To(HaveKey(utils.SnapshotDataSourceAnnotationName),
+					"snapshot-recovery job should have snapshot data source annotation")
+			}, 120, 5).Should(Succeed())
+		})
+
+		By("attempting to disrupt the snapshot-recovery job by deleting its pods", func() {
+			// Try to cause job disruption by deleting pods
+			for i := 0; i < 3; i++ {
+				var pods corev1.PodList
+				err := env.Client.List(env.Ctx, &pods,
+					k8client.InNamespace(namespace),
+					k8client.MatchingLabels{
+						"job-name": snapshotRecoveryJob.Name,
+					},
+				)
+				if err != nil || len(pods.Items) == 0 {
+					time.Sleep(3 * time.Second)
+					continue
+				}
+
+				for _, pod := range pods.Items {
+					_ = env.Client.Delete(env.Ctx, &pod,
+						k8client.GracePeriodSeconds(0),
+					)
+				}
+				time.Sleep(3 * time.Second)
+			}
+		})
+
+		// The key test: whether snapshot recovery fails or succeeds, the cluster should
+		// eventually reach a healthy state (either via snapshot or pg_basebackup fallback)
+		By("verifying the cluster eventually reaches healthy state", func() {
+			AssertClusterIsReady(namespace, clusterName, 900, env)
+		})
+
+		By("verifying all replicas are connected", func() {
+			cluster, err := clusterutils.Get(env.Ctx, env.Client, namespace, clusterName)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(cluster.Status.ReadyInstances).To(Equal(int32(3)),
+				"all 3 instances should be ready")
 		})
 	})
 })


### PR DESCRIPTION
## Summary

When a snapshot recovery job fails during replica creation, the operator now automatically falls back to using `pg_basebackup` instead of remaining stuck or repeatedly retrying broken snapshot recovery.

This provides self-healing behavior: instead of just unblocking (#10004), the cluster recovers by trying an alternative join method.

## Changes

| File | Change |
|------|--------|
| `internal/controller/cluster_create.go` | Add `getFailedSnapshotDataSources()`, integrate fallback logic in `joinReplicaInstance`, and annotate snapshot-recovery jobs with their data source |
| `internal/controller/cluster_create_test.go` | Unit tests for `getFailedSnapshotDataSources()` and fallback behavior |
| `pkg/utils/labels_annotations.go` | Add `SnapshotDataSourceAnnotationName` constant |
| `tests/e2e/failed_job_handling_test.go` | E2E test: snapshot-based replica creation and graceful fallback |

## How It Works

1. When `joinReplicaInstance` is called and a snapshot source is available:
2. Check if the specific snapshot's recovery job has previously failed
3. If that snapshot failed:
   - Emit a warning event
   - Fall back to pg_basebackup instead of attempting snapshot recovery
4. If the snapshot hasn't failed, annotate the job with the snapshot name for tracking

This design means:
- Only the specific failed snapshot is skipped; new snapshots are still attempted
- The failed job is preserved as both troubleshooting evidence and a marker to prevent retrying that snapshot
- To re-enable snapshot recovery for a specific snapshot, a user can manually delete the failed job (`kubectl delete job <job-name>`)

## Why Create PVCs Before Job

The order of operations was changed from "create job, then PVCs" to "create PVCs, then job" because:
- If the job is created first and PVC creation fails, we have an orphaned job
- Creating PVCs first is safer: if it fails, no job is created
- This matches the pattern in `createPrimaryInstance`

Note: The `ctrl.Result` from `CreateInstancePVCs` is intentionally ignored in both `createPrimaryInstance` and `joinReplicaInstance`. PVC creation returns a requeue request, but the init/join job must be created in the same reconciliation loop. Returning early would leave dangling PVCs without pods, causing the operator to get stuck.

## Test Plan

- [x] Unit tests for `getFailedSnapshotDataSources()`
- [x] Unit tests for snapshot fallback logic
- [x] All existing tests pass
- [x] E2E (AKS): Snapshot-based replica creation succeeds
- [x] E2E (AKS): Phase 1 tests still pass on Phase 2 branch (backward compatible)

## Related

- Builds on #10004
- Fixes #7793