### PR TITLE
chore(lint): fix warnings from golangci-lint v2.10.1

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -21,7 +21,7 @@ env:
   # renovate: datasource=golang-version depName=golang versioning=loose
   GOLANG_VERSION: "1.25.7"
   # renovate: datasource=github-releases depName=golangci/golangci-lint versioning=loose
-  GOLANGCI_LINT_VERSION: "v2.8.0"
+  GOLANGCI_LINT_VERSION: "v2.10.1"
   KUBEBUILDER_VERSION: "2.3.1"
   # renovate: datasource=github-tags depName=kubernetes-sigs/kind versioning=semver
   KIND_VERSION: "v0.31.0"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -107,10 +107,30 @@ linters:
           - revive
         path: /(utils|common)/[^/]+.go
         text: avoid meaningless package names
-      # TODO: fix by renaming or removing pkg/utils/context and pkg/utils/hash packages
+      # TODO: fix by renaming packages that conflict with Go standard library names
       - linters:
           - revive
         path: pkg/utils/(context|hash)/
+        text: avoid package names that conflict with Go standard library package names
+      - linters:
+          - revive
+        path: internal/(cmd|cnpi)/plugin/
+        text: avoid package names that conflict with Go standard library package names
+      - linters:
+          - revive
+        path: internal/cmd/manager/debug/
+        text: avoid package names that conflict with Go standard library package names
+      - linters:
+          - revive
+        path: tests/utils/exec/
+        text: avoid package names that conflict with Go standard library package names
+      - linters:
+          - revive
+        path: pkg/management/(postgres/metrics|url)/
+        text: avoid package names that conflict with Go standard library package names
+      - linters:
+          - revive
+        path: pkg/postgres/plugin/
         text: avoid package names that conflict with Go standard library package names
     paths:
       - zz_generated.*

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -27,6 +27,7 @@ linters:
     - misspell
     - nakedret
     - nestif
+    - nolintlint
     - prealloc
     - predeclared
     - revive

--- a/internal/cmd/manager/controller/controller.go
+++ b/internal/cmd/manager/controller/controller.go
@@ -248,7 +248,7 @@ func RunController(
 	if err = (&controller.ScheduledBackupReconciler{
 		Client:   mgr.GetClient(),
 		Scheme:   mgr.GetScheme(),
-		Recorder: mgr.GetEventRecorderFor("cloudnative-pg-scheduledbackup"),
+		Recorder: mgr.GetEventRecorderFor("cloudnative-pg-scheduledbackup"), //nolint:staticcheck
 	}).SetupWithManager(ctx, mgr, maxConcurrentReconciles); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ScheduledBackup")
 		return err
@@ -258,7 +258,7 @@ func RunController(
 		Client:          mgr.GetClient(),
 		DiscoveryClient: discoveryClient,
 		Scheme:          mgr.GetScheme(),
-		Recorder:        mgr.GetEventRecorderFor("cloudnative-pg-pooler"),
+		Recorder:        mgr.GetEventRecorderFor("cloudnative-pg-pooler"), //nolint:staticcheck
 	}).SetupWithManager(mgr, maxConcurrentReconciles); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Pooler")
 		return err

--- a/internal/cmd/manager/controller/controller.go
+++ b/internal/cmd/manager/controller/controller.go
@@ -248,7 +248,7 @@ func RunController(
 	if err = (&controller.ScheduledBackupReconciler{
 		Client:   mgr.GetClient(),
 		Scheme:   mgr.GetScheme(),
-		Recorder: mgr.GetEventRecorderFor("cloudnative-pg-scheduledbackup"), //nolint:staticcheck
+		Recorder: mgr.GetEventRecorderFor("cloudnative-pg-scheduledbackup"),
 	}).SetupWithManager(ctx, mgr, maxConcurrentReconciles); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ScheduledBackup")
 		return err
@@ -258,7 +258,7 @@ func RunController(
 		Client:          mgr.GetClient(),
 		DiscoveryClient: discoveryClient,
 		Scheme:          mgr.GetScheme(),
-		Recorder:        mgr.GetEventRecorderFor("cloudnative-pg-pooler"), //nolint:staticcheck
+		Recorder:        mgr.GetEventRecorderFor("cloudnative-pg-pooler"),
 	}).SetupWithManager(mgr, maxConcurrentReconciles); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Pooler")
 		return err

--- a/internal/cmd/manager/instance/restore/cmd.go
+++ b/internal/cmd/manager/instance/restore/cmd.go
@@ -72,7 +72,7 @@ func NewCmd() *cobra.Command {
 			localSrv, err := webserver.NewLocalWebServer(
 				postgres.NewInstance().WithClusterName(clusterName).WithNamespace(namespace),
 				mgr.GetClient(),
-				mgr.GetEventRecorderFor("local-webserver"),
+				mgr.GetEventRecorderFor("local-webserver"), //nolint:staticcheck
 			)
 			if err != nil {
 				return err

--- a/internal/cmd/manager/instance/restore/cmd.go
+++ b/internal/cmd/manager/instance/restore/cmd.go
@@ -72,7 +72,7 @@ func NewCmd() *cobra.Command {
 			localSrv, err := webserver.NewLocalWebServer(
 				postgres.NewInstance().WithClusterName(clusterName).WithNamespace(namespace),
 				mgr.GetClient(),
-				mgr.GetEventRecorderFor("local-webserver"), //nolint:staticcheck
+				mgr.GetEventRecorderFor("local-webserver"),
 			)
 			if err != nil {
 				return err

--- a/internal/cmd/manager/instance/restoresnapshot/cmd.go
+++ b/internal/cmd/manager/instance/restoresnapshot/cmd.go
@@ -76,7 +76,7 @@ func NewCmd() *cobra.Command {
 			localSrv, err := webserver.NewLocalWebServer(
 				postgres.NewInstance().WithClusterName(clusterName).WithNamespace(namespace),
 				mgr.GetClient(),
-				mgr.GetEventRecorderFor("local-webserver"),
+				mgr.GetEventRecorderFor("local-webserver"), //nolint:staticcheck
 			)
 			if err != nil {
 				return err

--- a/internal/cmd/manager/instance/restoresnapshot/cmd.go
+++ b/internal/cmd/manager/instance/restoresnapshot/cmd.go
@@ -76,7 +76,7 @@ func NewCmd() *cobra.Command {
 			localSrv, err := webserver.NewLocalWebServer(
 				postgres.NewInstance().WithClusterName(clusterName).WithNamespace(namespace),
 				mgr.GetClient(),
-				mgr.GetEventRecorderFor("local-webserver"), //nolint:staticcheck
+				mgr.GetEventRecorderFor("local-webserver"),
 			)
 			if err != nil {
 				return err

--- a/internal/cmd/manager/instance/run/cmd.go
+++ b/internal/cmd/manager/instance/run/cmd.go
@@ -165,7 +165,7 @@ func NewCmd() *cobra.Command {
 	return cmd
 }
 
-func runSubCommand( //nolint:gocognit,gocyclo
+func runSubCommand(
 	ctx context.Context,
 	instance *postgres.Instance,
 	pprofServer bool,

--- a/internal/cmd/manager/instance/run/cmd.go
+++ b/internal/cmd/manager/instance/run/cmd.go
@@ -370,7 +370,7 @@ func runSubCommand(
 	localSrv, err := webserver.NewLocalWebServer(
 		instance,
 		mgr.GetClient(),
-		mgr.GetEventRecorderFor("local-webserver"), //nolint:staticcheck
+		mgr.GetEventRecorderFor("local-webserver"),
 	)
 	if err != nil {
 		contextLogger.Error(err, "unable to create local webserver runnable")

--- a/internal/cmd/manager/instance/run/cmd.go
+++ b/internal/cmd/manager/instance/run/cmd.go
@@ -370,7 +370,7 @@ func runSubCommand(
 	localSrv, err := webserver.NewLocalWebServer(
 		instance,
 		mgr.GetClient(),
-		mgr.GetEventRecorderFor("local-webserver"),
+		mgr.GetEventRecorderFor("local-webserver"), //nolint:staticcheck
 	)
 	if err != nil {
 		contextLogger.Error(err, "unable to create local webserver runnable")

--- a/internal/cmd/manager/instance/run/lifecycle/lifecycle.go
+++ b/internal/cmd/manager/instance/run/lifecycle/lifecycle.go
@@ -63,7 +63,8 @@ func (i *PostgresLifecycle) GetGlobalContext() context.Context {
 }
 
 // Start starts running the PostgresLifecycle
-// nolint:gocognit
+//
+//nolint:gocognit
 func (i *PostgresLifecycle) Start(ctx context.Context) error {
 	contextLogger := log.FromContext(ctx)
 	signals := make(chan os.Signal, 1)

--- a/internal/cmd/manager/instance/status/cmd.go
+++ b/internal/cmd/manager/instance/status/cmd.go
@@ -135,5 +135,5 @@ func executeRequest(ctx context.Context, scheme string) (*http.Response, error) 
 		return nil, err
 	}
 	httpClient := common.NewHTTPClient(connectionTimeout, requestTimeout)
-	return httpClient.Do(req) // nolint:gosec
+	return httpClient.Do(req) //nolint:gosec
 }

--- a/internal/cmd/manager/instance/upgrade/execute/cmd.go
+++ b/internal/cmd/manager/instance/upgrade/execute/cmd.go
@@ -139,7 +139,7 @@ type upgradeInfo struct {
 	initdbArgs    []string
 }
 
-// nolint:gocognit
+//nolint:gocognit
 func (ui upgradeInfo) upgradeSubCommand(ctx context.Context, instance *postgres.Instance) error {
 	contextLogger := log.FromContext(ctx)
 

--- a/internal/cmd/plugin/color.go
+++ b/internal/cmd/plugin/color.go
@@ -65,7 +65,7 @@ func (e *colorConfiguration) Type() string {
 
 // ConfigureColor renews aurora.DefaultColorizer based on flags and TTY
 func ConfigureColor(cmd *cobra.Command) {
-	configureColor(cmd, term.IsTerminal(int(os.Stdout.Fd())))
+	configureColor(cmd, term.IsTerminal(int(os.Stdout.Fd()))) //nolint:gosec // file descriptors always fit in int
 }
 
 func configureColor(cmd *cobra.Command, isTTY bool) {

--- a/internal/cmd/plugin/logs/pretty/pretty.go
+++ b/internal/cmd/plugin/logs/pretty/pretty.go
@@ -121,7 +121,7 @@ func (bf *prettyCmd) decode(ctx context.Context, reader io.Reader, recordChannel
 
 		record, err := newLogRecordFromBytes(scanner.Bytes())
 		if err != nil {
-			_, _ = fmt.Fprintln(
+			_, _ = fmt.Fprintln( //nolint:gosec // output to local stderr
 				os.Stderr,
 				aurora.Red(fmt.Sprintf("JSON syntax error (%s)", err.Error())),
 				scanner.Text())

--- a/internal/cmd/plugin/psql/psql.go
+++ b/internal/cmd/plugin/psql/psql.go
@@ -183,7 +183,7 @@ func (psql *Command) Run() error {
 		return err
 	}
 
-	cmd := exec.Command(psql.kubectlPath, kubectlExec[1:]...) // nolint:gosec
+	cmd := exec.Command(psql.kubectlPath, kubectlExec[1:]...) //nolint:gosec
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	return cmd.Run()
@@ -197,7 +197,7 @@ func (psql *Command) Output() ([]byte, error) {
 		return nil, err
 	}
 
-	cmd := exec.Command(psql.kubectlPath, kubectlExec[1:]...) // nolint:gosec
+	cmd := exec.Command(psql.kubectlPath, kubectlExec[1:]...) //nolint:gosec
 	cmd.Stderr = os.Stderr
 	return cmd.Output()
 }

--- a/internal/cnpi/plugin/mapping.go
+++ b/internal/cnpi/plugin/mapping.go
@@ -38,7 +38,8 @@ const (
 )
 
 // ToOperationType_Type converts an OperationVerb into a lifecycle.OperationType_Type
-// nolint: revive,staticcheck
+//
+//nolint:revive,staticcheck
 func (o OperationVerb) ToOperationType_Type() (lifecycle.OperatorOperationType_Type, error) {
 	switch o {
 	case OperationVerbPatch:

--- a/internal/configuration/configuration.go
+++ b/internal/configuration/configuration.go
@@ -57,7 +57,7 @@ var DefaultDrainTaints = []string{
 	"node.kubernetes.io/unschedulable",
 
 	// Used by the Kubernetes Cluster Autoscaler
-	// nolint: lll
+	//nolint: lll
 	// See: https://github.com/kubernetes/autoscaler/blob/aa1d413ea3bf319b56c7b2e65ade1a028e149439/cluster-autoscaler/cloudprovider/oci/nodepools/consts/annotations.go#L27
 	"ToBeDeletedByClusterAutoscaler",
 

--- a/internal/controller/backup_controller.go
+++ b/internal/controller/backup_controller.go
@@ -92,7 +92,7 @@ func NewBackupReconciler(
 	plugins repository.Interface,
 ) *BackupReconciler {
 	cli := mgr.GetClient()
-	recorder := mgr.GetEventRecorderFor("cloudnative-pg-backup")
+	recorder := mgr.GetEventRecorderFor("cloudnative-pg-backup") //nolint:staticcheck
 	return &BackupReconciler{
 		Client:               cli,
 		DiscoveryClient:      discoveryClient,

--- a/internal/controller/backup_controller.go
+++ b/internal/controller/backup_controller.go
@@ -92,7 +92,7 @@ func NewBackupReconciler(
 	plugins repository.Interface,
 ) *BackupReconciler {
 	cli := mgr.GetClient()
-	recorder := mgr.GetEventRecorderFor("cloudnative-pg-backup") //nolint:staticcheck
+	recorder := mgr.GetEventRecorderFor("cloudnative-pg-backup")
 	return &BackupReconciler{
 		Client:               cli,
 		DiscoveryClient:      discoveryClient,

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -107,7 +107,7 @@ func NewClusterReconciler(
 		DiscoveryClient: discoveryClient,
 		Client:          operatorclient.NewExtendedClient(mgr.GetClient()),
 		Scheme:          mgr.GetScheme(),
-		Recorder:        mgr.GetEventRecorderFor("cloudnative-pg"),
+		Recorder:        mgr.GetEventRecorderFor("cloudnative-pg"), //nolint:staticcheck
 		Plugins:         plugins,
 		rolloutManager: rolloutManager.New(
 			configuration.Current.GetClustersRolloutDelay(),

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -107,7 +107,7 @@ func NewClusterReconciler(
 		DiscoveryClient: discoveryClient,
 		Client:          operatorclient.NewExtendedClient(mgr.GetClient()),
 		Scheme:          mgr.GetScheme(),
-		Recorder:        mgr.GetEventRecorderFor("cloudnative-pg"), //nolint:staticcheck
+		Recorder:        mgr.GetEventRecorderFor("cloudnative-pg"),
 		Plugins:         plugins,
 		rolloutManager: rolloutManager.New(
 			configuration.Current.GetClustersRolloutDelay(),

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -269,7 +269,8 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 }
 
 // Inner reconcile loop. Anything inside can require the reconciliation loop to stop by returning ErrNextLoop
-// nolint:gocognit,gocyclo
+//
+//nolint:gocognit,gocyclo
 func (r *ClusterReconciler) reconcile(ctx context.Context, cluster *apiv1.Cluster) (ctrl.Result, error) {
 	contextLogger := log.FromContext(ctx)
 

--- a/internal/controller/cluster_create.go
+++ b/internal/controller/cluster_create.go
@@ -1055,7 +1055,6 @@ func (r *ClusterReconciler) generateNodeSerial(ctx context.Context, cluster *api
 	return cluster.Status.LatestGeneratedNode, nil
 }
 
-// nolint: gocognit
 func (r *ClusterReconciler) createPrimaryInstance(
 	ctx context.Context,
 	cluster *apiv1.Cluster,

--- a/internal/controller/cluster_create_test.go
+++ b/internal/controller/cluster_create_test.go
@@ -574,7 +574,7 @@ var _ = Describe("check if bootstrap recovery can proceed from volume snapshot",
 		Expect(res).To(Or(BeNil(), Equal(reconcile.Result{})))
 	})
 
-	// nolint: dupl
+	//nolint: dupl
 	It("should requeue if bootstrapping from an invalid volume snapshot", func(ctx SpecContext) {
 		snapshots := volumesnapshotv1.VolumeSnapshotList{
 			Items: []volumesnapshotv1.VolumeSnapshot{
@@ -611,7 +611,7 @@ var _ = Describe("check if bootstrap recovery can proceed from volume snapshot",
 		Expect(res).ToNot(Equal(reconcile.Result{}))
 	})
 
-	// nolint: dupl
+	//nolint: dupl
 	It("should requeue if bootstrapping from a snapshot that isn't there", func(ctx SpecContext) {
 		snapshots := volumesnapshotv1.VolumeSnapshotList{
 			Items: []volumesnapshotv1.VolumeSnapshot{

--- a/internal/controller/cluster_restore.go
+++ b/internal/controller/cluster_restore.go
@@ -184,7 +184,6 @@ func ensureOrphanServiceIsNotPresent(
 
 // ensureClusterRestoreCanStart is a function where the plugins can inject their custom logic to tell the
 // restore process to wait before starting the process
-// nolint: revive
 func ensureClusterRestoreCanStart(
 	ctx context.Context,
 	c client.Client,

--- a/internal/controller/finalizers_delete_test.go
+++ b/internal/controller/finalizers_delete_test.go
@@ -36,7 +36,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-// nolint: dupl
+//nolint:dupl
 var _ = Describe("Test cleanup of owned objects on cluster deletion", func() {
 	var (
 		r              ClusterReconciler

--- a/internal/controller/plugin_controller.go
+++ b/internal/controller/plugin_controller.go
@@ -112,7 +112,6 @@ func (r *PluginReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	return res, nil
 }
 
-// nolint:unparam
 func (r *PluginReconciler) reconcile(
 	ctx context.Context,
 	service *corev1.Service,

--- a/internal/controller/pooler_resources_test.go
+++ b/internal/controller/pooler_resources_test.go
@@ -153,7 +153,7 @@ var _ = Describe("pooler_resources unit tests", func() {
 		})
 	})
 
-	// nolint: dupl
+	//nolint: dupl
 	It("should correctly fetch the role when it exists", func() {
 		ctx := context.Background()
 		namespace := newFakeNamespace(env.client)
@@ -206,7 +206,7 @@ var _ = Describe("pooler_resources unit tests", func() {
 		})
 	})
 
-	// nolint: dupl
+	//nolint: dupl
 	It("should correctly fetch the SA when it exists", func() {
 		ctx := context.Background()
 		namespace := newFakeNamespace(env.client)

--- a/internal/controller/pooler_update.go
+++ b/internal/controller/pooler_update.go
@@ -63,8 +63,6 @@ func (r *PoolerReconciler) updateOwnedObjects(
 }
 
 // updateDeployment update the deployment or create it when needed
-//
-//nolint:dupl
 func (r *PoolerReconciler) updateDeployment(
 	ctx context.Context,
 	pooler *apiv1.Pooler,

--- a/internal/controller/replicas.go
+++ b/internal/controller/replicas.go
@@ -181,8 +181,9 @@ func (r *ClusterReconciler) reconcileTargetPrimaryForNonReplicaCluster(
 }
 
 // isNodeUnschedulableOrBeingDrained checks if a node is currently being drained.
-// nolint: lll
 // Copied from https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/7bacf2d36f397bd098b3388403e8759c480be7e5/cmd/hooks/prestop.go#L91
+//
+//nolint:lll
 func isNodeUnschedulableOrBeingDrained(node *corev1.Node, drainTaints []string) bool {
 	for _, taint := range node.Spec.Taints {
 		if slices.Contains(drainTaints, taint.Key) {

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -213,7 +213,7 @@ func newFakeCNPGCluster(
 			},
 		},
 	}
-	// nolint: lll
+	//nolint: lll
 	// https://github.com/kubernetes-sigs/controller-runtime/blob/c3c1f058a9a080581e8fe99c004fcc792b2aff07/pkg/client/fake/doc.go#L30
 	for _, mutator := range mutators {
 		mutator(cluster)
@@ -374,7 +374,7 @@ func generateFakeInitDBJobsWithDefaultClient(k8sClient client.Client, cluster *a
 func generateClusterPVC(
 	c client.Client,
 	cluster *apiv1.Cluster,
-	status persistentvolumeclaim.PVCStatus, // nolint:unparam
+	status persistentvolumeclaim.PVCStatus, //nolint:unparam
 ) []corev1.PersistentVolumeClaim {
 	var idx int
 	var pvcs []corev1.PersistentVolumeClaim
@@ -478,7 +478,7 @@ type (
 func (f fakeClientWithIndexAdapter) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
 	var optsWithoutMatchingFields []client.ListOption
 	// matchingFields rely on indexes that we don't have on the default kube client
-	var matchingFields []client.ListOption // nolint:prealloc
+	var matchingFields []client.ListOption
 	for _, opt := range opts {
 		_, ok := opt.(client.MatchingFields)
 		if !ok {

--- a/internal/management/controller/database_controller_sql.go
+++ b/internal/management/controller/database_controller_sql.go
@@ -87,54 +87,54 @@ func createDatabase(
 	contextLogger := log.FromContext(ctx)
 
 	var sqlCreateDatabase strings.Builder
-	sqlCreateDatabase.WriteString(fmt.Sprintf("CREATE DATABASE %s ", pgx.Identifier{obj.Spec.Name}.Sanitize()))
+	fmt.Fprintf(&sqlCreateDatabase, "CREATE DATABASE %s ", pgx.Identifier{obj.Spec.Name}.Sanitize())
 	if len(obj.Spec.Owner) > 0 {
-		sqlCreateDatabase.WriteString(fmt.Sprintf(" OWNER %s", pgx.Identifier{obj.Spec.Owner}.Sanitize()))
+		fmt.Fprintf(&sqlCreateDatabase, " OWNER %s", pgx.Identifier{obj.Spec.Owner}.Sanitize())
 	}
 	if len(obj.Spec.Template) > 0 {
-		sqlCreateDatabase.WriteString(fmt.Sprintf(" TEMPLATE %s", pgx.Identifier{obj.Spec.Template}.Sanitize()))
+		fmt.Fprintf(&sqlCreateDatabase, " TEMPLATE %s", pgx.Identifier{obj.Spec.Template}.Sanitize())
 	}
 	if len(obj.Spec.Tablespace) > 0 {
-		sqlCreateDatabase.WriteString(fmt.Sprintf(" TABLESPACE %s", pgx.Identifier{obj.Spec.Tablespace}.Sanitize()))
+		fmt.Fprintf(&sqlCreateDatabase, " TABLESPACE %s", pgx.Identifier{obj.Spec.Tablespace}.Sanitize())
 	}
 	if obj.Spec.AllowConnections != nil {
-		sqlCreateDatabase.WriteString(fmt.Sprintf(" ALLOW_CONNECTIONS %v", *obj.Spec.AllowConnections))
+		fmt.Fprintf(&sqlCreateDatabase, " ALLOW_CONNECTIONS %v", *obj.Spec.AllowConnections)
 	}
 	if obj.Spec.ConnectionLimit != nil {
-		sqlCreateDatabase.WriteString(fmt.Sprintf(" CONNECTION LIMIT %v", *obj.Spec.ConnectionLimit))
+		fmt.Fprintf(&sqlCreateDatabase, " CONNECTION LIMIT %v", *obj.Spec.ConnectionLimit)
 	}
 	if obj.Spec.IsTemplate != nil {
-		sqlCreateDatabase.WriteString(fmt.Sprintf(" IS_TEMPLATE %v", *obj.Spec.IsTemplate))
+		fmt.Fprintf(&sqlCreateDatabase, " IS_TEMPLATE %v", *obj.Spec.IsTemplate)
 	}
 	if obj.Spec.Encoding != "" {
-		sqlCreateDatabase.WriteString(fmt.Sprintf(" ENCODING %s", pgx.Identifier{obj.Spec.Encoding}.Sanitize()))
+		fmt.Fprintf(&sqlCreateDatabase, " ENCODING %s", pgx.Identifier{obj.Spec.Encoding}.Sanitize())
 	}
 	if obj.Spec.Locale != "" {
-		sqlCreateDatabase.WriteString(fmt.Sprintf(" LOCALE %s", pgx.Identifier{obj.Spec.Locale}.Sanitize()))
+		fmt.Fprintf(&sqlCreateDatabase, " LOCALE %s", pgx.Identifier{obj.Spec.Locale}.Sanitize())
 	}
 	if obj.Spec.LocaleProvider != "" {
-		sqlCreateDatabase.WriteString(fmt.Sprintf(" LOCALE_PROVIDER %s",
-			pgx.Identifier{obj.Spec.LocaleProvider}.Sanitize()))
+		fmt.Fprintf(&sqlCreateDatabase, " LOCALE_PROVIDER %s",
+			pgx.Identifier{obj.Spec.LocaleProvider}.Sanitize())
 	}
 	if obj.Spec.LcCollate != "" {
-		sqlCreateDatabase.WriteString(fmt.Sprintf(" LC_COLLATE %s", pgx.Identifier{obj.Spec.LcCollate}.Sanitize()))
+		fmt.Fprintf(&sqlCreateDatabase, " LC_COLLATE %s", pgx.Identifier{obj.Spec.LcCollate}.Sanitize())
 	}
 	if obj.Spec.LcCtype != "" {
-		sqlCreateDatabase.WriteString(fmt.Sprintf(" LC_CTYPE %s", pgx.Identifier{obj.Spec.LcCtype}.Sanitize()))
+		fmt.Fprintf(&sqlCreateDatabase, " LC_CTYPE %s", pgx.Identifier{obj.Spec.LcCtype}.Sanitize())
 	}
 	if obj.Spec.IcuLocale != "" {
-		sqlCreateDatabase.WriteString(fmt.Sprintf(" ICU_LOCALE %s", pgx.Identifier{obj.Spec.IcuLocale}.Sanitize()))
+		fmt.Fprintf(&sqlCreateDatabase, " ICU_LOCALE %s", pgx.Identifier{obj.Spec.IcuLocale}.Sanitize())
 	}
 	if obj.Spec.IcuRules != "" {
-		sqlCreateDatabase.WriteString(fmt.Sprintf(" ICU_RULES %s", pgx.Identifier{obj.Spec.IcuRules}.Sanitize()))
+		fmt.Fprintf(&sqlCreateDatabase, " ICU_RULES %s", pgx.Identifier{obj.Spec.IcuRules}.Sanitize())
 	}
 	if obj.Spec.BuiltinLocale != "" {
-		sqlCreateDatabase.WriteString(fmt.Sprintf(" BUILTIN_LOCALE %s",
-			pgx.Identifier{obj.Spec.BuiltinLocale}.Sanitize()))
+		fmt.Fprintf(&sqlCreateDatabase, " BUILTIN_LOCALE %s",
+			pgx.Identifier{obj.Spec.BuiltinLocale}.Sanitize())
 	}
 	if obj.Spec.CollationVersion != "" {
-		sqlCreateDatabase.WriteString(fmt.Sprintf(" COLLATION_VERSION %s",
-			pgx.Identifier{obj.Spec.CollationVersion}.Sanitize()))
+		fmt.Fprintf(&sqlCreateDatabase, " COLLATION_VERSION %s",
+			pgx.Identifier{obj.Spec.CollationVersion}.Sanitize())
 	}
 
 	_, err := db.ExecContext(ctx, sqlCreateDatabase.String())
@@ -268,12 +268,12 @@ func createDatabaseExtension(ctx context.Context, db *sql.DB, ext apiv1.Extensio
 	contextLogger := log.FromContext(ctx)
 
 	var sqlCreateExtension strings.Builder
-	sqlCreateExtension.WriteString(fmt.Sprintf("CREATE EXTENSION %s ", pgx.Identifier{ext.Name}.Sanitize()))
+	fmt.Fprintf(&sqlCreateExtension, "CREATE EXTENSION %s ", pgx.Identifier{ext.Name}.Sanitize())
 	if len(ext.Version) > 0 {
-		sqlCreateExtension.WriteString(fmt.Sprintf(" VERSION %s", pgx.Identifier{ext.Version}.Sanitize()))
+		fmt.Fprintf(&sqlCreateExtension, " VERSION %s", pgx.Identifier{ext.Version}.Sanitize())
 	}
 	if len(ext.Schema) > 0 {
-		sqlCreateExtension.WriteString(fmt.Sprintf(" SCHEMA %s", pgx.Identifier{ext.Schema}.Sanitize()))
+		fmt.Fprintf(&sqlCreateExtension, " SCHEMA %s", pgx.Identifier{ext.Schema}.Sanitize())
 	}
 
 	_, err := db.ExecContext(ctx, sqlCreateExtension.String())
@@ -360,9 +360,9 @@ func createDatabaseSchema(ctx context.Context, db *sql.DB, schema apiv1.SchemaSp
 	contextLogger := log.FromContext(ctx)
 
 	var sqlCreateExtension strings.Builder
-	sqlCreateExtension.WriteString(fmt.Sprintf("CREATE SCHEMA %s ", pgx.Identifier{schema.Name}.Sanitize()))
+	fmt.Fprintf(&sqlCreateExtension, "CREATE SCHEMA %s ", pgx.Identifier{schema.Name}.Sanitize())
 	if len(schema.Owner) > 0 {
-		sqlCreateExtension.WriteString(fmt.Sprintf(" AUTHORIZATION %s", pgx.Identifier{schema.Owner}.Sanitize()))
+		fmt.Fprintf(&sqlCreateExtension, " AUTHORIZATION %s", pgx.Identifier{schema.Owner}.Sanitize())
 	}
 
 	_, err := db.ExecContext(ctx, sqlCreateExtension.String())
@@ -548,7 +548,7 @@ func createDatabaseFDW(ctx context.Context, db *sql.DB, fdw apiv1.FDWSpec) error
 	contextLogger := log.FromContext(ctx)
 
 	var sqlCreateFDW strings.Builder
-	sqlCreateFDW.WriteString(fmt.Sprintf("CREATE FOREIGN DATA WRAPPER %s ", pgx.Identifier{fdw.Name}.Sanitize()))
+	fmt.Fprintf(&sqlCreateFDW, "CREATE FOREIGN DATA WRAPPER %s ", pgx.Identifier{fdw.Name}.Sanitize())
 
 	// Create Handler
 	if len(fdw.Handler) > 0 {
@@ -556,7 +556,7 @@ func createDatabaseFDW(ctx context.Context, db *sql.DB, fdw apiv1.FDWSpec) error
 		case "-":
 			sqlCreateFDW.WriteString("NO HANDLER ")
 		default:
-			sqlCreateFDW.WriteString(fmt.Sprintf("HANDLER %s ", pgx.Identifier{fdw.Handler}.Sanitize()))
+			fmt.Fprintf(&sqlCreateFDW, "HANDLER %s ", pgx.Identifier{fdw.Handler}.Sanitize())
 		}
 	}
 
@@ -566,7 +566,7 @@ func createDatabaseFDW(ctx context.Context, db *sql.DB, fdw apiv1.FDWSpec) error
 		case "-":
 			sqlCreateFDW.WriteString("NO VALIDATOR ")
 		default:
-			sqlCreateFDW.WriteString(fmt.Sprintf("VALIDATOR %s ", pgx.Identifier{fdw.Validator}.Sanitize()))
+			fmt.Fprintf(&sqlCreateFDW, "VALIDATOR %s ", pgx.Identifier{fdw.Validator}.Sanitize())
 		}
 	}
 
@@ -737,9 +737,9 @@ func createDatabaseForeignServer(ctx context.Context, db *sql.DB, server apiv1.S
 	contextLogger := log.FromContext(ctx)
 
 	var sqlCreateServer strings.Builder
-	sqlCreateServer.WriteString(fmt.Sprintf("CREATE SERVER %s FOREIGN DATA WRAPPER %s ",
+	fmt.Fprintf(&sqlCreateServer, "CREATE SERVER %s FOREIGN DATA WRAPPER %s ",
 		pgx.Identifier{server.Name}.Sanitize(),
-		pgx.Identifier{server.FdwName}.Sanitize()))
+		pgx.Identifier{server.FdwName}.Sanitize())
 
 	if opts := extractOptionsClauses(server.Options); len(opts) > 0 {
 		sqlCreateServer.WriteString("OPTIONS (" + strings.Join(opts, ", ") + ")")

--- a/internal/management/controller/database_controller_sql.go
+++ b/internal/management/controller/database_controller_sql.go
@@ -529,7 +529,7 @@ func applyUsagePermissions(
 			contextLogger.Info("granted usage", "type", objectType, "name", objectName, "user", usageSpec.Name)
 
 		case apiv1.RevokeUsageSpecType:
-			mutation := fmt.Sprintf("REVOKE USAGE ON %s %s FROM %s", objectType, sanitizedObject, sanitizedUser) // nolint:gosec
+			mutation := fmt.Sprintf("REVOKE USAGE ON %s %s FROM %s", objectType, sanitizedObject, sanitizedUser) //nolint:gosec
 			if _, err := db.ExecContext(ctx, mutation); err != nil {
 				return fmt.Errorf("revoking usage of %s: %w", objectType, err)
 			}

--- a/internal/management/controller/publication_controller_sql.go
+++ b/internal/management/controller/publication_controller_sql.go
@@ -189,7 +189,7 @@ func toTableDefinitionSQL(table *apiv1.PublicationTargetTable) string {
 	}
 
 	if len(table.Schema) > 0 {
-		result.WriteString(fmt.Sprintf("%s.", pgx.Identifier{table.Schema}.Sanitize()))
+		fmt.Fprintf(&result, "%s.", pgx.Identifier{table.Schema}.Sanitize())
 	}
 
 	result.WriteString(pgx.Identifier{table.Name}.Sanitize())
@@ -199,7 +199,7 @@ func toTableDefinitionSQL(table *apiv1.PublicationTargetTable) string {
 		for _, column := range table.Columns {
 			sanitizedColumns = append(sanitizedColumns, pgx.Identifier{column}.Sanitize())
 		}
-		result.WriteString(fmt.Sprintf(" (%s)", strings.Join(sanitizedColumns, ", ")))
+		fmt.Fprintf(&result, " (%s)", strings.Join(sanitizedColumns, ", "))
 	}
 
 	return result.String()

--- a/internal/management/controller/publication_controller_sql_test.go
+++ b/internal/management/controller/publication_controller_sql_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 */
 
-// nolint: dupl
 package controller
 
 import (

--- a/internal/management/controller/roles/postgres.go
+++ b/internal/management/controller/roles/postgres.go
@@ -119,7 +119,7 @@ func Update(ctx context.Context, db *sql.DB, role DatabaseRole) error {
 	}
 	var query strings.Builder
 
-	query.WriteString(fmt.Sprintf("ALTER ROLE %s", pgx.Identifier{role.Name}.Sanitize()))
+	fmt.Fprintf(&query, "ALTER ROLE %s", pgx.Identifier{role.Name}.Sanitize())
 	appendRoleOptions(role, &query)
 	// Log before appending password to prevent password leakage in operator logs
 	contextLog.Debug("Updating role", "role", role.Name, "query", query.String())
@@ -143,7 +143,7 @@ func Create(ctx context.Context, db *sql.DB, role DatabaseRole) error {
 	}
 
 	var query strings.Builder
-	query.WriteString(fmt.Sprintf("CREATE ROLE %s", pgx.Identifier{role.Name}.Sanitize()))
+	fmt.Fprintf(&query, "CREATE ROLE %s", pgx.Identifier{role.Name}.Sanitize())
 	appendRoleOptions(role, &query)
 	appendInRoleOptions(role, &query)
 	// Log before appending password to prevent password leakage in operator logs
@@ -159,8 +159,8 @@ func Create(ctx context.Context, db *sql.DB, role DatabaseRole) error {
 
 	if len(role.Comment) > 0 {
 		query.Reset()
-		query.WriteString(fmt.Sprintf("COMMENT ON ROLE %s IS %s",
-			pgx.Identifier{role.Name}.Sanitize(), pq.QuoteLiteral(role.Comment)))
+		fmt.Fprintf(&query, "COMMENT ON ROLE %s IS %s",
+			pgx.Identifier{role.Name}.Sanitize(), pq.QuoteLiteral(role.Comment))
 
 		if _, err := db.ExecContext(ctx, query.String()); err != nil {
 			return wrapErr(err)

--- a/internal/management/controller/roles/postgres_test.go
+++ b/internal/management/controller/roles/postgres_test.go
@@ -538,7 +538,7 @@ var _ = Describe("Postgres RoleManager implementation test", func() {
 			ConnectionLimit: 0,
 		}
 		var query strings.Builder
-		query.WriteString(fmt.Sprintf("ALTER ROLE %s", pgx.Identifier{"alighieri"}.Sanitize()))
+		fmt.Fprintf(&query, "ALTER ROLE %s", pgx.Identifier{"alighieri"}.Sanitize())
 		appendRoleOptions(roleWithNo, &query)
 
 		expectedQuery := "ALTER ROLE \"alighieri\" NOBYPASSRLS NOCREATEDB NOCREATEROLE NOINHERIT NOLOGIN " +
@@ -561,7 +561,7 @@ var _ = Describe("Postgres RoleManager implementation test", func() {
 		expectedQuery := "ALTER ROLE \"alighieri\" BYPASSRLS CREATEDB CREATEROLE INHERIT LOGIN " +
 			"REPLICATION SUPERUSER CONNECTION LIMIT 10"
 
-		query.WriteString(fmt.Sprintf("ALTER ROLE %s", pgx.Identifier{"alighieri"}.Sanitize()))
+		fmt.Fprintf(&query, "ALTER ROLE %s", pgx.Identifier{"alighieri"}.Sanitize())
 		appendRoleOptions(roles, &query)
 		Expect(query.String()).To(BeEquivalentTo(expectedQuery))
 	})
@@ -576,7 +576,7 @@ var _ = Describe("Postgres RoleManager implementation test", func() {
 		var query strings.Builder
 		expectedQuery := "ALTER ROLE \"alighieri\" PASSWORD 'divine comedy'"
 
-		query.WriteString(fmt.Sprintf("ALTER ROLE %s", pgx.Identifier{"alighieri"}.Sanitize()))
+		fmt.Fprintf(&query, "ALTER ROLE %s", pgx.Identifier{"alighieri"}.Sanitize())
 		appendPasswordOption(dbRole, &query)
 		Expect(query.String()).To(BeEquivalentTo(expectedQuery))
 	})
@@ -584,7 +584,7 @@ var _ = Describe("Postgres RoleManager implementation test", func() {
 	It("password with valid until", func() {
 		role := apiv1.RoleConfiguration{}
 		var queryValidUntil strings.Builder
-		queryValidUntil.WriteString(fmt.Sprintf("ALTER ROLE %s", pgx.Identifier{"alighieri"}.Sanitize()))
+		fmt.Fprintf(&queryValidUntil, "ALTER ROLE %s", pgx.Identifier{"alighieri"}.Sanitize())
 		expectedQueryValidUntil := "ALTER ROLE \"alighieri\" PASSWORD 'divine comedy' VALID UNTIL '2100-01-01 01:01:00Z'"
 		validUntil := metav1.Date(2100, 0o1, 0o1, 0o1, 0o1, 0o0, 0o0, time.UTC)
 		role.ValidUntil = &validUntil

--- a/internal/management/controller/slots/runner/runner.go
+++ b/internal/management/controller/slots/runner/runner.go
@@ -147,7 +147,8 @@ func (sr *Replicator) reconcile(ctx context.Context, config *apiv1.ReplicationSl
 }
 
 // synchronizeReplicationSlots aligns the slots in the local instance with those in the primary
-// nolint: gocognit
+//
+//nolint:gocognit
 func synchronizeReplicationSlots(
 	ctx context.Context,
 	primaryDB *sql.DB,

--- a/internal/management/controller/subscription_controller_sql_test.go
+++ b/internal/management/controller/subscription_controller_sql_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 */
 
-// nolint: dupl
 package controller
 
 import (
@@ -33,7 +32,6 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-// nolint: dupl
 var _ = Describe("subscription sql", func() {
 	const defaultPostgresMajorVersion = 17
 

--- a/internal/pgbouncer/management/controller/refresh_test.go
+++ b/internal/pgbouncer/management/controller/refresh_test.go
@@ -67,7 +67,7 @@ var _ = Describe("RefreshConfigurationFiles", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			for filename, content := range files {
-				fileContent, err := os.ReadFile(filename) // nolint: gosec
+				fileContent, err := os.ReadFile(filename) //nolint: gosec
 				Expect(err).NotTo(HaveOccurred())
 				Expect(fileContent).To(Equal(content))
 			}

--- a/internal/webhook/v1/pooler_webhook.go
+++ b/internal/webhook/v1/pooler_webhook.go
@@ -141,7 +141,7 @@ func (v *PoolerCustomValidator) getAdmissionWarnings(r *apiv1.Pooler) admission.
 	}
 
 	if r.Spec.PgBouncer != nil &&
-		r.Spec.PgBouncer.AuthQuerySecret != nil && r.Spec.PgBouncer.AuthQuerySecret.Name != "" { //nolint:staticcheck
+		r.Spec.PgBouncer.AuthQuerySecret != nil && r.Spec.PgBouncer.AuthQuerySecret.Name != "" {
 		warns = append(
 			warns,
 			"The .spec.pgbouncer.authQuerySecret field has been deprecated")

--- a/pkg/executablehash/executablehash.go
+++ b/pkg/executablehash/executablehash.go
@@ -36,7 +36,7 @@ var (
 
 // Stream opens a stream reading from the executable of the current process binary (os.Args[0] after path cleaning).
 func Stream() (io.ReadCloser, error) {
-	return os.Open(filepath.Clean(os.Args[0]))
+	return os.Open(filepath.Clean(os.Args[0])) //nolint:gosec // reading our own binary
 }
 
 // StreamByName opens a stream reading from an executable given its name

--- a/pkg/executablehash/executablehash.go
+++ b/pkg/executablehash/executablehash.go
@@ -41,7 +41,7 @@ func Stream() (io.ReadCloser, error) {
 
 // StreamByName opens a stream reading from an executable given its name
 func StreamByName(name string) (io.ReadCloser, error) {
-	return os.Open(name) //nolint:gosec // reading executable by trusted internal name
+	return os.Open(filepath.Clean(name))
 }
 
 // Get gets the hashcode of the executable of this binary

--- a/pkg/executablehash/executablehash.go
+++ b/pkg/executablehash/executablehash.go
@@ -41,7 +41,7 @@ func Stream() (io.ReadCloser, error) {
 
 // StreamByName opens a stream reading from an executable given its name
 func StreamByName(name string) (io.ReadCloser, error) {
-	return os.Open(name) // #nosec
+	return os.Open(name) //nolint:gosec // reading executable by trusted internal name
 }
 
 // Get gets the hashcode of the executable of this binary

--- a/pkg/management/external/utils.go
+++ b/pkg/management/external/utils.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 
 	corev1 "k8s.io/api/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
@@ -77,8 +77,8 @@ func getSecretKeyRefFileName(
 	serverName string,
 	selector *corev1.SecretKeySelector,
 ) string {
-	directory := path.Join(getExternalSecretsPath(), serverName)
-	filePath := path.Join(directory, fmt.Sprintf("%v_%v", selector.Name, selector.Key))
+	directory := filepath.Join(getExternalSecretsPath(), serverName)
+	filePath := filepath.Join(directory, fmt.Sprintf("%v_%v", selector.Name, selector.Key))
 	return filePath
 }
 
@@ -104,13 +104,13 @@ func dumpSecretKeyRefToFile(
 		return "", fmt.Errorf("missing key %v in secret %v", selector.Key, selector.Name)
 	}
 
-	directory := path.Join(getExternalSecretsPath(), serverName)
+	directory := filepath.Join(getExternalSecretsPath(), serverName)
 	if err := os.MkdirAll(directory, 0o700); err != nil {
 		return "", err
 	}
 
-	filePath := path.Join(directory, fmt.Sprintf("%v_%v", selector.Name, selector.Key))
-	f, err := os.OpenFile(filePath, os.O_WRONLY|os.O_CREATE, 0o600) // #nosec
+	filePath := filepath.Join(directory, fmt.Sprintf("%v_%v", selector.Name, selector.Key))
+	f, err := os.OpenFile(filepath.Clean(filePath), os.O_WRONLY|os.O_CREATE, 0o600)
 	if err != nil {
 		return "", err
 	}
@@ -128,8 +128,8 @@ func dumpSecretKeyRefToFile(
 
 // getPgPassFilePath gets the path where the pgpass file will be stored
 func getPgPassFilePath(serverName string) string {
-	directory := path.Join(getExternalSecretsPath(), serverName)
-	filePath := path.Join(directory, "pgpass")
+	directory := filepath.Join(getExternalSecretsPath(), serverName)
+	filePath := filepath.Join(directory, "pgpass")
 	return filePath
 }
 
@@ -141,11 +141,11 @@ func createPgPassFile(
 ) (string, error) {
 	pgpassLine := pgpass.NewConnectionInfo(connectionParameters, password)
 
-	directory := path.Join(getExternalSecretsPath(), serverName)
+	directory := filepath.Join(getExternalSecretsPath(), serverName)
 	if err := os.MkdirAll(directory, 0o700); err != nil {
 		return "", err
 	}
-	filePath := path.Join(directory, "pgpass")
+	filePath := filepath.Join(directory, "pgpass")
 
 	return filePath, pgpass.From(pgpassLine).Write(filePath)
 }

--- a/pkg/management/postgres/instance_test.go
+++ b/pkg/management/postgres/instance_test.go
@@ -244,7 +244,7 @@ var _ = Describe("ALTER SYSTEM enable and disable in PostgreSQL <17", func() {
 		instance.PgData = tmpDir
 
 		autoConfFile = filepath.Join(tmpDir, "postgresql.auto.conf")
-		f, err := os.Create(autoConfFile) // nolint: gosec
+		f, err := os.Create(autoConfFile) //nolint: gosec
 		Expect(err).ToNot(HaveOccurred())
 
 		err = f.Close()

--- a/pkg/management/postgres/logpipe/pgaudit_test.go
+++ b/pkg/management/postgres/logpipe/pgaudit_test.go
@@ -55,7 +55,7 @@ var _ = Describe("pgAudit CSV log record", func() {
 
 var _ = Describe("PgAudit CVS logging decorator", func() {
 	Context("Given a CSV record embedding pgAudit without rows", func() {
-		It("fills the fields for PostgreSQL 13", func() { // nolint:dupl
+		It("fills the fields for PostgreSQL 13", func() { //nolint:dupl
 			values := make([]string, FieldsPerRecord12)
 			for i := range values {
 				values[i] = fmt.Sprintf("%d", i)
@@ -108,7 +108,7 @@ var _ = Describe("PgAudit CVS logging decorator", func() {
 			}))
 		})
 
-		It("fills the fields for PostgreSQL 13", func() { // nolint:dupl
+		It("fills the fields for PostgreSQL 13", func() { //nolint:dupl
 			values := make([]string, FieldsPerRecord13)
 			for i := range values {
 				values[i] = fmt.Sprintf("%d", i)
@@ -163,7 +163,7 @@ var _ = Describe("PgAudit CVS logging decorator", func() {
 	})
 
 	Context("Given a CSV record embedding pgAudit with rows", func() {
-		It("fills the fields for PostgreSQL 13", func() { // nolint:dupl
+		It("fills the fields for PostgreSQL 13", func() { //nolint:dupl
 			values := make([]string, FieldsPerRecord12)
 			for i := range values {
 				values[i] = fmt.Sprintf("%d", i)
@@ -217,7 +217,7 @@ var _ = Describe("PgAudit CVS logging decorator", func() {
 			}))
 		})
 
-		It("fills the fields for PostgreSQL 13", func() { // nolint:dupl
+		It("fills the fields for PostgreSQL 13", func() { //nolint:dupl
 			values := make([]string, FieldsPerRecord13)
 			for i := range values {
 				values[i] = fmt.Sprintf("%d", i)

--- a/pkg/management/postgres/metrics/histogram/histogram.go
+++ b/pkg/management/postgres/metrics/histogram/histogram.go
@@ -94,7 +94,7 @@ func NewFromRawData(values []interface{}, columns []string, name string) (*Value
 		if i >= len(histogramValue.Values) {
 			break
 		}
-		histogramValue.Buckets[key] = uint64(histogramValue.Values[i]) //nolint:gosec
+		histogramValue.Buckets[key] = uint64(histogramValue.Values[i])
 	}
 
 	return histogramValue, nil

--- a/pkg/management/postgres/metrics/mappings.go
+++ b/pkg/management/postgres/metrics/mappings.go
@@ -102,7 +102,6 @@ func (columnMapping ColumnMapping) ToMetricMap(
 		columnFQName = fmt.Sprintf("%s_%s", namespace, columnMapping.Name)
 	}
 	// Determine how to convert the column based on its usage.
-	// nolint: dupl
 	switch columnMapping.Usage {
 	case DISCARD:
 		result[columnName] = MetricMap{

--- a/pkg/management/postgres/restore.go
+++ b/pkg/management/postgres/restore.go
@@ -86,7 +86,6 @@ var (
 )
 
 // RestoreSnapshot restores a PostgreSQL cluster from a volumeSnapshot
-// nolint:gocognit,gocyclo
 func (info InitInfo) RestoreSnapshot(ctx context.Context, cli client.Client, immediate bool) error {
 	contextLogger := log.FromContext(ctx)
 
@@ -154,7 +153,6 @@ func (info InitInfo) RestoreSnapshot(ctx context.Context, cli client.Client, imm
 			"restore_command = '%s'\n",
 		restoreCmd)
 
-	// nolint:nestif
 	if pluginConfiguration := cluster.GetRecoverySourcePlugin(); pluginConfiguration == nil {
 		envs, config, err = info.createEnvAndConfigForSnapshotRestore(ctx, cli, cluster)
 		if err != nil {
@@ -288,7 +286,7 @@ func (info InitInfo) Restore(ctx context.Context, cli client.Client) error {
 	var envs []string
 	var config string
 
-	// nolint:nestif
+	//nolint:nestif
 	if pluginConfiguration := cluster.GetRecoverySourcePlugin(); pluginConfiguration != nil {
 		contextLogger.Info("Restore through plugin detected, proceeding...")
 		res, err := restoreViaPlugin(ctx, cluster, pluginConfiguration)

--- a/pkg/management/postgres/utils/version.go
+++ b/pkg/management/postgres/utils/version.go
@@ -22,7 +22,7 @@ package utils
 import (
 	"database/sql"
 	"os"
-	"path"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -56,7 +56,7 @@ func parseVersionNum(versionNum string) (*semver.Version, error) {
 // GetMajorVersionFromPgData read the PG_VERSION file in the data directory
 // returning the major version of the database
 func GetMajorVersionFromPgData(pgData string) (int, error) {
-	content, err := os.ReadFile(path.Join(pgData, "PG_VERSION")) // #nosec
+	content, err := os.ReadFile(filepath.Clean(filepath.Join(pgData, "PG_VERSION")))
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/management/postgres/webserver/client/remote/instance.go
+++ b/pkg/management/postgres/webserver/client/remote/instance.go
@@ -199,7 +199,7 @@ func (r *instanceClientImpl) GetPgControlDataFromInstance(
 		return "", err
 	}
 	r.Timeout = defaultRequestTimeout
-	resp, err := r.Do(req)
+	resp, err := r.Do(req) //nolint:gosec // URL built from internal pod IP
 	if err != nil {
 		return "", err
 	}
@@ -259,7 +259,7 @@ func (r *instanceClientImpl) UpgradeInstanceManager(
 	req.Body = binaryFileStream
 
 	r.Timeout = noRequestTimeout
-	resp, err := r.Do(req)
+	resp, err := r.Do(req) //nolint:gosec // URL built from internal pod IP
 	// This is the desired response. The instance manager will
 	// synchronously update and this call won't return.
 	if isEOF(err) {
@@ -308,7 +308,7 @@ func (r *instanceClientImpl) rawInstanceStatusRequest(
 	}
 
 	r.Timeout = defaultRequestTimeout
-	resp, err := r.Do(req)
+	resp, err := r.Do(req) //nolint:gosec // URL built from internal pod IP
 	if err != nil {
 		result.Error = err
 		return result
@@ -387,7 +387,7 @@ func (r *instanceClientImpl) ArchivePartialWAL(ctx context.Context, pod *corev1.
 	if err != nil {
 		return "", err
 	}
-	resp, err := r.Do(req)
+	resp, err := r.Do(req) //nolint:gosec // URL built from internal pod IP
 	if err != nil {
 		return "", err
 	}

--- a/pkg/management/postgres/webserver/client/remote/request.go
+++ b/pkg/management/postgres/webserver/client/remote/request.go
@@ -40,7 +40,7 @@ func executeRequestWithError[T any](
 ) (*webserver.Response[T], error) {
 	contextLogger := log.FromContext(ctx)
 
-	resp, err := cli.Do(req)
+	resp, err := cli.Do(req) //nolint:gosec // URL built from internal pod IP
 	if err != nil {
 		return nil, fmt.Errorf("while executing http request: %w", err)
 	}

--- a/pkg/management/postgres/webserver/local.go
+++ b/pkg/management/postgres/webserver/local.go
@@ -124,7 +124,7 @@ func (ws *localWebserverEndpoints) serveCache(w http.ResponseWriter, r *http.Req
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	_, _ = w.Write(js)
+	_, _ = w.Write(js) //nolint:gosec // serving JSON from internal cache
 }
 
 // This function schedule a backup

--- a/pkg/management/postgres/webserver/metricserver/wal.go
+++ b/pkg/management/postgres/webserver/metricserver/wal.go
@@ -85,7 +85,7 @@ func (s *walSettings) synchronize(db *sql.DB, configSha256 string) error {
 	rows, err := db.Query(`
 SELECT name, setting FROM pg_catalog.pg_settings
 WHERE pg_settings.name
-IN ('wal_segment_size', 'min_wal_size', 'max_wal_size', 'wal_keep_size', 'wal_keep_segments', 'max_slot_wal_keep_size')`) // nolint: lll
+IN ('wal_segment_size', 'min_wal_size', 'max_wal_size', 'wal_keep_size', 'wal_keep_segments', 'max_slot_wal_keep_size')`) //nolint: lll
 	if err != nil {
 		log.Error(err, "while fetching rows")
 		return err

--- a/pkg/management/postgres/webserver/probes/pinger.go
+++ b/pkg/management/postgres/webserver/probes/pinger.go
@@ -27,6 +27,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path/filepath"
 	"time"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
@@ -53,7 +54,7 @@ func buildInstanceReachabilityChecker(cfg *apiv1.IsolationCheckConfiguration) (*
 	}
 
 	certificateLocation := postgresSpec.ServerCACertificateLocation
-	caCertificate, err := os.ReadFile(certificateLocation) //nolint:gosec
+	caCertificate, err := os.ReadFile(filepath.Clean(certificateLocation))
 	if err != nil {
 		return nil, fmt.Errorf("while reading server CA certificate [%s]: %w", certificateLocation, err)
 	}

--- a/pkg/management/postgres/webserver/remote.go
+++ b/pkg/management/postgres/webserver/remote.go
@@ -344,7 +344,7 @@ func (ws *remoteWebserverEndpoints) updateInstanceManager(
 	}
 }
 
-// nolint: gocognit
+//nolint:gocognit
 func (ws *remoteWebserverEndpoints) backup(w http.ResponseWriter, req *http.Request) {
 	log.Trace("request method", "method", req.Method)
 	if !ws.ongoingBackupRequest.TryLock() {
@@ -527,7 +527,7 @@ func (ws *remoteWebserverEndpoints) pgArchivePartial(w http.ResponseWriter, req 
 	}()
 
 	options := []string{constants.WalArchiveCommand, partialWalFileRelativePath}
-	walArchiveCmd := exec.Command("/controller/manager", options...) // nolint: gosec
+	walArchiveCmd := exec.Command("/controller/manager", options...) //nolint: gosec
 	walArchiveCmd.Dir = pgData
 	if err := execlog.RunBuffering(walArchiveCmd, "wal-archive-partial"); err != nil {
 		sendBadRequestJSONResponse(w, "ERROR_WHILE_EXECUTING_WAL_ARCHIVE", err.Error())

--- a/pkg/management/upgrade/upgrade.go
+++ b/pkg/management/upgrade/upgrade.go
@@ -66,7 +66,7 @@ func FromReader(
 	defer func() {
 		// This code is executed only if the instance manager has not been updated, and
 		// this is the only condition we have a temporary file to remove
-		removeError := os.Remove(updatedInstanceManager.Name())
+		removeError := os.Remove(updatedInstanceManager.Name()) //nolint:gosec // path from our own temp file
 		if removeError != nil {
 			log.Warning("Error while removing temporary instance manager upload file",
 				"name", updatedInstanceManager.Name(), "err", err)
@@ -97,6 +97,7 @@ func FromReader(
 	}
 
 	// Replace the new instance manager with the new one
+	//nolint:gosec // path from our own temp file
 	if err := os.Rename(updatedInstanceManager.Name(), InstanceManagerPath); err != nil {
 		return fmt.Errorf("while replacing instance manager binary: %w", err)
 	}
@@ -184,7 +185,7 @@ func validateInstanceManagerHash(
 // This function never returns in case of success.
 func reloadInstanceManager() error {
 	log.Info("Replacing current instance")
-	err := syscall.Exec(InstanceManagerPath, os.Args, os.Environ()) // #nosec G204
+	err := syscall.Exec(InstanceManagerPath, os.Args, os.Environ()) //nolint:gosec // execing our own binary with os.Args
 	if err != nil {
 		return err
 	}

--- a/pkg/management/upgrade/upgrade.go
+++ b/pkg/management/upgrade/upgrade.go
@@ -91,7 +91,7 @@ func FromReader(
 		"temporaryName", updatedInstanceManager.Name())
 
 	// Grant the executable bit to the new file
-	err = os.Chmod(updatedInstanceManager.Name(), 0o755) // #nosec
+	err = os.Chmod(updatedInstanceManager.Name(), 0o755) //nolint:gosec // path from our own temp file
 	if err != nil {
 		return fmt.Errorf("while granting the executable bit to the instance manager binary: %w", err)
 	}

--- a/pkg/postgres/configuration.go
+++ b/pkg/postgres/configuration.go
@@ -876,8 +876,8 @@ func CreatePostgresqlConfFile(configuration *PgConfiguration) (string, string) {
 
 	sha256sum := fmt.Sprintf("%x", sha256.Sum256([]byte(postgresConf.String())))
 	postgresConf.WriteString(cnpgConf.String())
-	postgresConf.WriteString(fmt.Sprintf("%v = %v\n", CNPGConfigSha256,
-		escapePostgresConfValue(sha256sum)))
+	fmt.Fprintf(&postgresConf, "%v = %v\n", CNPGConfigSha256,
+		escapePostgresConfValue(sha256sum))
 
 	return postgresConf.String(), sha256sum
 }

--- a/pkg/reconciler/instance/metadata_test.go
+++ b/pkg/reconciler/instance/metadata_test.go
@@ -73,7 +73,7 @@ var _ = Describe("object metadata test", func() {
 			Expect(replicaPod.Labels[utils.ClusterInstanceRoleLabelName]).To(Equal(specs.ClusterRoleLabelReplica))
 		})
 
-		// nolint: dupl
+		//nolint: dupl
 		It("Should update the role labels when the primary and the replica switch roles", func() {
 			cluster := &apiv1.Cluster{
 				Status: apiv1.ClusterStatus{
@@ -150,7 +150,7 @@ var _ = Describe("object metadata test", func() {
 			Expect(oldReplicaPod.Labels[utils.ClusterInstanceRoleLabelName]).To(Equal(specs.ClusterRoleLabelReplica))
 		})
 
-		// nolint: dupl
+		//nolint: dupl
 		It("should not perform any changes if everything is ok", func() {
 			cluster := &apiv1.Cluster{
 				Status: apiv1.ClusterStatus{
@@ -193,7 +193,6 @@ var _ = Describe("object metadata test", func() {
 			Expect(replicaPod.Labels[utils.ClusterInstanceRoleLabelName]).To(Equal(specs.ClusterRoleLabelReplica))
 		})
 
-		//nolint: dupl
 		It("should update existing instances with the old role label", func() {
 			cluster := &apiv1.Cluster{
 				Status: apiv1.ClusterStatus{

--- a/pkg/specs/pgbouncer/deployments_test.go
+++ b/pkg/specs/pgbouncer/deployments_test.go
@@ -62,7 +62,6 @@ var _ = Describe("Deployment", func() {
 				DeploymentStrategy: &appsv1.DeploymentStrategy{
 					Type: appsv1.RollingUpdateDeploymentStrategyType,
 				},
-				//nolint:staticcheck // Using deprecated type during deprecation period
 				Monitoring: &apiv1.PoolerMonitoringConfiguration{
 					EnablePodMonitor: true,
 				},

--- a/pkg/specs/pgbouncer/podmonitor_test.go
+++ b/pkg/specs/pgbouncer/podmonitor_test.go
@@ -43,7 +43,6 @@ var _ = Describe("PoolerPodMonitorManager", func() {
 				Namespace: "test-namespace",
 			},
 			Spec: apiv1.PoolerSpec{
-				//nolint:staticcheck // Using deprecated type during deprecation period
 				Monitoring: &apiv1.PoolerMonitoringConfiguration{
 					EnablePodMonitor: false,
 				},

--- a/pkg/specs/pods_test.go
+++ b/pkg/specs/pods_test.go
@@ -1035,7 +1035,7 @@ var _ = Describe("NewInstance", func() {
 				Name:      "test-cluster",
 				Namespace: "default",
 				Annotations: map[string]string{
-					utils.PodPatchAnnotationName: `[{"op": "replace", "path": "/spec/containers/0/image", "value": "new-image:latest"}]`, // nolint: lll
+					utils.PodPatchAnnotationName: `[{"op": "replace", "path": "/spec/containers/0/image", "value": "new-image:latest"}]`, //nolint: lll
 				},
 			},
 			Status: apiv1.ClusterStatus{

--- a/pkg/utils/labels_annotations_test.go
+++ b/pkg/utils/labels_annotations_test.go
@@ -64,7 +64,6 @@ var _ = Describe("Operator version annotation management", func() {
 	})
 })
 
-// nolint:dupl
 var _ = Describe("Annotation management", func() {
 	config := &fakeInhericanceController{
 		annotations: []string{
@@ -89,7 +88,6 @@ var _ = Describe("Annotation management", func() {
 	})
 })
 
-// nolint:dupl
 var _ = Describe("Label management", func() {
 	config := &fakeInhericanceController{
 		labels: []string{

--- a/tests/e2e/asserts_test.go
+++ b/tests/e2e/asserts_test.go
@@ -1780,7 +1780,7 @@ func AssertClusterRestoreWithApplicationDB(namespace, restoreClusterFile, tableN
 	})
 
 	By("update user application password for restored cluster and verify connectivity", func() {
-		const newPassword = "eeh2Zahohx" //nolint:gosec
+		const newPassword = "eeh2Zahohx"
 		AssertUpdateSecret("password", newPassword, secretName, namespace, restoredClusterName, 30, env)
 
 		AssertApplicationDatabaseConnection(
@@ -2025,7 +2025,7 @@ func AssertClusterWasRestoredWithPITRAndApplicationDB(namespace, clusterName, ta
 	})
 
 	By("update user application password for restored cluster and verify connectivity", func() {
-		const newPassword = "eeh2Zahohx" //nolint:gosec
+		const newPassword = "eeh2Zahohx"
 		AssertUpdateSecret("password", newPassword, secretName, namespace, clusterName, 30, env)
 		AssertApplicationDatabaseConnection(
 			namespace,

--- a/tests/e2e/pg_basebackup_test.go
+++ b/tests/e2e/pg_basebackup_test.go
@@ -82,7 +82,7 @@ var _ = Describe("Bootstrap with pg_basebackup", Label(tests.LabelRecovery), fun
 			})
 
 			By("update user application password for dst cluster and verify connectivity", func() {
-				const newPassword = "eeh2Zahohx" //nolint:gosec
+				const newPassword = "eeh2Zahohx"
 				AssertUpdateSecret("password", newPassword, secretName, namespace, dstClusterName, 30, env)
 				AssertApplicationDatabaseConnection(
 					namespace,

--- a/tests/e2e/publication_subscription_test.go
+++ b/tests/e2e/publication_subscription_test.go
@@ -171,7 +171,7 @@ var _ = Describe("Publication and Subscription", Label(tests.LabelPublicationSub
 			})
 		}
 
-		// nolint:dupl
+		//nolint:dupl
 		assertCreatePublication := func(namespace, clusterName, publicationManifest string) {
 			pubObjectName, err := yaml.GetResourceNameFromYAML(env.Scheme, publicationManifest)
 			Expect(err).NotTo(HaveOccurred())
@@ -204,7 +204,7 @@ var _ = Describe("Publication and Subscription", Label(tests.LabelPublicationSub
 			})
 		}
 
-		// nolint:dupl
+		//nolint:dupl
 		assertCreateSubscription := func(namespace, clusterName, subscriptionManifest string) {
 			subObjectName, err := yaml.GetResourceNameFromYAML(env.Scheme, subscriptionManifest)
 			Expect(err).NotTo(HaveOccurred())

--- a/tests/e2e/update_user_test.go
+++ b/tests/e2e/update_user_test.go
@@ -73,7 +73,7 @@ var _ = Describe("Update user and superuser password", Label(tests.LabelServiceC
 		Expect(err).ToNot(HaveOccurred())
 
 		By("update user application password", func() {
-			const newPassword = "eeh2Zahohx" //nolint:gosec
+			const newPassword = "eeh2Zahohx"
 
 			AssertUpdateSecret("password", newPassword, appSecretName, namespace, clusterName, 30, env)
 			AssertConnection(namespace, rwService, postgres.AppDBName, postgres.AppUser, newPassword, env)
@@ -118,7 +118,7 @@ var _ = Describe("Update user and superuser password", Label(tests.LabelServiceC
 				g.Expect(err).ToNot(HaveOccurred())
 			}, 60).Should(Succeed())
 
-			const newPassword = "fi6uCae7" //nolint:gosec
+			const newPassword = "fi6uCae7"
 			AssertUpdateSecret("password", newPassword, superUserSecretName, namespace, clusterName, 30, env)
 			AssertConnection(namespace, rwService, postgres.PostgresDBName, postgres.PostgresUser, newPassword, env)
 		})

--- a/tests/e2e/upgrade_test.go
+++ b/tests/e2e/upgrade_test.go
@@ -92,7 +92,7 @@ var _ = Describe("Upgrade", Label(tests.LabelUpgrade, tests.LabelNoOpenshift), O
 		rollingUpgradeNamespace = "rolling-upgrade"
 		onlineUpgradeNamespace  = "online-upgrade"
 
-		pgSecrets = fixturesDir + "/upgrade/pgsecrets.yaml" //nolint:gosec
+		pgSecrets = fixturesDir + "/upgrade/pgsecrets.yaml"
 
 		// This is a cluster of the previous version, created before the operator upgrade
 		clusterName1 = "cluster1"

--- a/tests/utils/environment/environment.go
+++ b/tests/utils/environment/environment.go
@@ -52,8 +52,8 @@ import (
 	// Import the client auth plugin package to allow use gke or ake to run tests
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
-	. "github.com/onsi/ginkgo/v2" // nolint
-	. "github.com/onsi/gomega"    // nolint
+	. "github.com/onsi/ginkgo/v2" //nolint
+	. "github.com/onsi/gomega"    //nolint
 )
 
 const (

--- a/tests/utils/exec/exec.go
+++ b/tests/utils/exec/exec.go
@@ -34,7 +34,7 @@ import (
 	pkgutils "github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/pods"
 
-	. "github.com/onsi/gomega" // nolint
+	. "github.com/onsi/gomega" //nolint
 )
 
 // ContainerLocator contains the necessary data to find a container on a pod

--- a/tests/utils/logs/logs_test.go
+++ b/tests/utils/logs/logs_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 var _ = Describe("testing CheckOptionForBarmanCommand", func() {
-	// nolint: lll
+	//nolint: lll
 	const podLogs = `{"level":"info","ts":"2024-03-04T06:07:29Z","msg":"Starting barman-cloud-backup","backupName":"pg-with-backup-20240304135929","backupNamespace":"pg-with-backup-20240304135929","logging_pod":"pg-with-backup-1","options":["--user","postgres","--name","backup-20240304055929","--immediate-checkpoint","--min-chunk-size=5MB","--read-timeout=60","--endpoint-url","http://minio-service:9000","--cloud-provider","aws-s3","s3://cluster-backups/","pg-with-backup"]}`
 
 	It("should return true if all expected options are found", func() {

--- a/tests/utils/operator/upgrade.go
+++ b/tests/utils/operator/upgrade.go
@@ -36,8 +36,8 @@ import (
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/objects"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/run"
 
-	. "github.com/onsi/ginkgo/v2" // nolint
-	. "github.com/onsi/gomega"    // nolint
+	. "github.com/onsi/ginkgo/v2" //nolint
+	. "github.com/onsi/gomega"    //nolint
 )
 
 // CreateConfigMap creates the operator namespace and enables/disable the online upgrade for

--- a/tests/utils/replicationslot/replication_slots.go
+++ b/tests/utils/replicationslot/replication_slots.go
@@ -79,12 +79,12 @@ func PrintReplicationSlots(
 				exec.DatabaseName(dbName),
 				query)
 			if err != nil {
-				output.WriteString(fmt.Sprintf("Couldn't retrieve restart_lsn for slot %v: %v\n", slot, err))
+				fmt.Fprintf(&output, "Couldn't retrieve restart_lsn for slot %v: %v\n", slot, err)
 			}
 			m[slot] = strings.TrimSpace(restartLsn)
 		}
-		output.WriteString(fmt.Sprintf("Replication slots on %v pod %v: %v\n",
-			pod.Labels[utils.ClusterInstanceRoleLabelName], pod.GetName(), m))
+		fmt.Fprintf(&output, "Replication slots on %v pod %v: %v\n",
+			pod.Labels[utils.ClusterInstanceRoleLabelName], pod.GetName(), m)
 	}
 	return output.String()
 }

--- a/tests/utils/sternmultitailer/multitailer.go
+++ b/tests/utils/sternmultitailer/multitailer.go
@@ -187,7 +187,7 @@ func getLogFile(baseDir string, log stern.Log, openFilesMap map[string]*os.File)
 	if err != nil {
 		return nil, fmt.Errorf("cannot ensure directory existence (%v): %w", dirFile, err)
 	}
-	file, err = os.OpenFile(filePath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o600) // nolint:gosec
+	file, err = os.OpenFile(filePath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o600) //nolint:gosec
 	if err != nil {
 		return nil, fmt.Errorf("cannot open file %v: %w", filePath, err)
 	}


### PR DESCRIPTION
Bump golangci-lint to v2.10.1 and address the new warnings it introduced. Gosec taint analysis (G703) and integer overflow (G115) false positives are suppressed with targeted nolint comments, and G304 path traversal warnings are resolved with filepath.Clean rather than suppression. Replace WriteString(fmt.Sprintf(...)) with fmt.Fprintf, and fix path.Join to filepath.Join for OS file paths. Enable nolintlint to enforce well-formed directives and clean up stale suppressions. Add revive exclusion rules for packages that conflict with Go standard library names.