### PR TITLE
refactor: detect storage classes in Go instead of bash

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -113,7 +113,7 @@
       customType: 'regex',
       managerFilePatterns:  [
         '/^\\.github\\/workflows\\/[^/]+\\.ya?ml$/',
-        '/^hack/e2e/run-e2e-existing-cluster.sh$/',
+        '/^hack/e2e/run-e2e-suite.sh$/',
         '/^hack/e2e/run-e2e\\.sh$/',
       ],
       matchStrings: [

--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,7 @@ e2e-test-k3d: ## Run e2e tests locally using k3d.
 	CLUSTER_ENGINE=k3d hack/e2e/run-e2e-local.sh
 
 e2e-test-existing-cluster: ## Run e2e tests using the default kubernetes context.
-	hack/e2e/run-e2e-existing-cluster.sh
+	hack/e2e/run-e2e-suite.sh
 
 ##@ Build
 build: generate fmt vet build-manager build-plugin ## Build binaries.

--- a/contribute/e2e_testing_environment/README.md
+++ b/contribute/e2e_testing_environment/README.md
@@ -226,11 +226,14 @@ tests for `kind` and `k3d`. It embeds `hack/setup-cluster.sh` and
 `hack/e2e/run-e2e.sh` to create a local Kubernetes cluster and then
 run E2E tests on it.
 
-Both `run-e2e-local.sh` and `run-e2e-existing-cluster.sh` detect the
-appropriate defaults for storage class, CSI storage class, and volume
-snapshot class environment variables from the live cluster by looking
-at the `storageclass.kubernetes.io/is-default-class` and
-`storage.kubernetes.io/default-snapshot-class` annotations.
+The Go test framework automatically detects the appropriate defaults for
+storage class, CSI storage class, and volume snapshot class from the
+live cluster during `BeforeSuite` by looking at the
+`storageclass.kubernetes.io/is-default-class` and
+`storage.kubernetes.io/default-snapshot-class` annotations on
+StorageClass objects. You can override detection by setting the
+`E2E_DEFAULT_STORAGE_CLASS`, `E2E_CSI_STORAGE_CLASS`, and
+`E2E_DEFAULT_VOLUMESNAPSHOT_CLASS` environment variables explicitly.
 
 #### On kind
 
@@ -269,20 +272,10 @@ make e2e-test-k3d
 You can test the operator on an existing Kubernetes cluster with:
 
 ``` bash
-run-e2e-existing-cluster.sh
+run-e2e-suite.sh
 ```
 
-The script detects the storage classes and volume snapshot class to use
-from the live cluster using the following annotations:
-
-* `storageclass.kubernetes.io/is-default-class: "true"` to find the default storage class (`E2E_DEFAULT_STORAGE_CLASS`)
-* `storage.kubernetes.io/default-snapshot-class: "$SNAPSHOT_CLASS_NAME"` to find the CSI storage class
-  that supports snapshots (`E2E_CSI_STORAGE_CLASS`) and the associated volume snapshot class
-  (`E2E_DEFAULT_VOLUMESNAPSHOT_CLASS`)
-
-All three variables can be overridden by setting them explicitly in the environment.
-
-The script will then run the tests on the existing cluster.
+The Go test framework auto-detects storage class configuration from the live cluster (see above). You can override any value by setting `E2E_DEFAULT_STORAGE_CLASS`, `E2E_CSI_STORAGE_CLASS`, or `E2E_DEFAULT_VOLUMESNAPSHOT_CLASS` in the environment before running the script.
 
 We have also provided a shortcut to this script in the main `Makefile`:
 
@@ -385,6 +378,6 @@ Example:
 
 The `setup-cluster.sh` script installs a CSI storage class with snapshot
 support (e.g. `csi-hostpath-sc`) and an associated volume snapshot class
-(e.g. `csi-hostpath-snapclass`) on local clusters. The e2e wrapper scripts
-detect these automatically via the `storage.kubernetes.io/default-snapshot-class`
+(e.g. `csi-hostpath-snapclass`) on local clusters. The Go test framework
+detects these automatically via the `storage.kubernetes.io/default-snapshot-class`
 annotation on the storage class.

--- a/hack/e2e/run-e2e-local.sh
+++ b/hack/e2e/run-e2e-local.sh
@@ -61,69 +61,9 @@ cleanup() {
   fi
 }
 
-# Detect the default storage class from the live cluster
-detect_default_storage_class() {
-  local sc_names sc_count
-  sc_names=$(kubectl get storageclass -o json | \
-    jq -r '[.items[] | select(.metadata.annotations["storageclass.kubernetes.io/is-default-class"] == "true") | .metadata.name]')
-  sc_count=$(echo "$sc_names" | jq 'length')
-  if [[ "$sc_count" -eq 0 ]]; then
-    echo "ERROR: no default storage class found in the cluster" >&2
-    return 1
-  elif [[ "$sc_count" -gt 1 ]]; then
-    echo "ERROR: multiple default storage classes found: $(echo "$sc_names" | jq -r 'join(", ")')" >&2
-    return 1
-  fi
-  echo "$sc_names" | jq -r '.[0]'
-}
-
-# Detect the CSI storage class that supports snapshots (has the default-snapshot-class annotation)
-detect_csi_storage_class() {
-  local sc_names sc_count
-  sc_names=$(kubectl get storageclass -o json | \
-    jq -r '[.items[] | select(.metadata.annotations["storage.kubernetes.io/default-snapshot-class"] != null) | .metadata.name]')
-  sc_count=$(echo "$sc_names" | jq 'length')
-  if [[ "$sc_count" -eq 0 ]]; then
-    echo "ERROR: no storage class with default-snapshot-class annotation found in the cluster" >&2
-    return 1
-  elif [[ "$sc_count" -gt 1 ]]; then
-    echo "ERROR: multiple storage classes with default-snapshot-class annotation found: $(echo "$sc_names" | jq -r 'join(", ")')" >&2
-    return 1
-  fi
-  echo "$sc_names" | jq -r '.[0]'
-}
-
-# Detect the default volume snapshot class from the CSI storage class annotation
-detect_default_volumesnapshot_class() {
-  local storage_class=$1 snap_class
-  snap_class=$(kubectl get storageclass "$storage_class" -o json | \
-    jq -r '.metadata.annotations["storage.kubernetes.io/default-snapshot-class"] // empty')
-  if [[ -z "$snap_class" ]]; then
-    echo "ERROR: no default-snapshot-class annotation found on storage class ${storage_class}" >&2
-    return 1
-  fi
-  echo "$snap_class"
-}
-
 main() {
   # Call to setup-cluster.sh script
   "${HACK_DIR}/setup-cluster.sh" -e "${CLUSTER_ENGINE}" create
-
-  # Detect storage class defaults from the live cluster
-  if [[ -z "${E2E_DEFAULT_STORAGE_CLASS:-}" ]]; then
-    E2E_DEFAULT_STORAGE_CLASS=$(detect_default_storage_class)
-  fi
-  export E2E_DEFAULT_STORAGE_CLASS
-
-  if [[ -z "${E2E_CSI_STORAGE_CLASS:-}" ]]; then
-    E2E_CSI_STORAGE_CLASS=$(detect_csi_storage_class)
-  fi
-  export E2E_CSI_STORAGE_CLASS
-
-  if [[ -z "${E2E_DEFAULT_VOLUMESNAPSHOT_CLASS:-}" ]]; then
-    E2E_DEFAULT_VOLUMESNAPSHOT_CLASS=$(detect_default_volumesnapshot_class "$E2E_CSI_STORAGE_CLASS")
-  fi
-  export E2E_DEFAULT_VOLUMESNAPSHOT_CLASS
 
   trap cleanup EXIT
 

--- a/hack/e2e/run-e2e-suite.sh
+++ b/hack/e2e/run-e2e-suite.sh
@@ -54,13 +54,8 @@ fi
 # renovate: datasource=github-releases depName=onsi/ginkgo
 go install github.com/onsi/ginkgo/v2/ginkgo@v2.28.1
 
-
 # Unset DEBUG to prevent k8s from spamming messages
 unset DEBUG
-
-# Build kubectl-cnpg and export its path
-make build-plugin
-export PATH=${ROOT_DIR}/bin/:${PATH}
 
 LABEL_FILTERS="${FEATURE_TYPE//,/ || }"
 readonly LABEL_FILTERS

--- a/hack/e2e/run-e2e.sh
+++ b/hack/e2e/run-e2e.sh
@@ -81,6 +81,9 @@ fi
 # renovate: datasource=github-releases depName=onsi/ginkgo
 go install github.com/onsi/ginkgo/v2/ginkgo@v2.28.1
 
+# Build kubectl-cnpg and export its path
+make build-plugin
+export PATH=${ROOT_DIR}/bin/:${PATH}
 
 LABEL_FILTERS=""
 if [ "${FEATURE_TYPE-}" ]; then
@@ -147,7 +150,7 @@ if [[ "${TEST_CLOUD_VENDOR}" != "ocp" ]]; then
 fi
 
 # Run the main (non-upgrade) test suite via run-e2e-suite.sh,
-# which handles ginkgo install, plugin build, and test execution.
+# which handles ginkgo install and test execution.
 RC_MAIN=0
 "${ROOT_DIR}/hack/e2e/run-e2e-suite.sh" || RC_MAIN=$?
 

--- a/hack/e2e/run-e2e.sh
+++ b/hack/e2e/run-e2e.sh
@@ -87,7 +87,6 @@ if [ "${FEATURE_TYPE-}" ]; then
   LABEL_FILTERS="${FEATURE_TYPE//,/ || }"
 fi
 echo "E2E tests are running with the following filters: ${LABEL_FILTERS}"
-# The RC return code will be non-zero iff either the two `jq` calls has a non-zero exit
 RC=0
 RC_GINKGO1=0
 if [[ "${TEST_UPGRADE_TO_V1}" != "false" ]] && [[ "${TEST_CLOUD_VENDOR}" != "ocp" ]]; then
@@ -147,34 +146,20 @@ if [[ "${TEST_CLOUD_VENDOR}" != "ocp" ]]; then
     cnpg-controller-manager
 fi
 
-# Unset DEBUG to prevent k8s from spamming messages
-unset DEBUG
-
-# Build kubectl-cnpg and export its path
-make build-plugin
-export PATH=${ROOT_DIR}/bin/:${PATH}
-
-mkdir -p "${ROOT_DIR}/tests/e2e/out"
-
-# Create at most 4 testing nodes. Using -p instead of --nodes
-# would create CPUs-1 nodes and saturate the testing server
-RC_GINKGO2=0
-export TEST_SKIP_UPGRADE=true
-ginkgo --nodes=4 --timeout 3h --poll-progress-after=1200s --poll-progress-interval=150s \
-       ${LABEL_FILTERS:+--label-filter "${LABEL_FILTERS}"} \
-       --github-output --force-newlines \
-       --output-dir "${ROOT_DIR}/tests/e2e/out/" \
-       --json-report  "report.json" -v "${ROOT_DIR}/tests/e2e/..." || RC_GINKGO2=$?
-
-# Report if there are any tests that failed
-jq -e -c -f "${ROOT_DIR}/hack/e2e/test-report.jq" "${ROOT_DIR}/tests/e2e/out/report.json" || RC=$?
+# Run the main (non-upgrade) test suite via run-e2e-suite.sh,
+# which handles ginkgo install, plugin build, and test execution.
+RC_MAIN=0
+"${ROOT_DIR}/hack/e2e/run-e2e-suite.sh" || RC_MAIN=$?
 
 set +x
-if [[ $RC == 0 ]]; then
-  if [[ $RC_GINKGO1 != 0 || $RC_GINKGO2 != 0 ]]; then
+if [[ $RC == 0 && $RC_MAIN == 0 ]]; then
+  if [[ $RC_GINKGO1 != 0 ]]; then
     printf "\033[0;32m%s\n" "SUCCESS."
     echo
   fi
 fi
 
-exit $RC
+if [[ $RC -ne 0 ]]; then
+  exit $RC
+fi
+exit $RC_MAIN


### PR DESCRIPTION
Move storage class detection from shell scripts into Go code, simplifying the run-e2e scripts and making the test environment configuration more robust. The e2e suite now queries the live cluster for available storage classes at runtime rather than relying on shell-level detection and environment variable passing.