### PR TITLE
feat(backup): support reconciliation-disabled annotation

### DIFF
--- a/docs/src/failure_modes.md
+++ b/docs/src/failure_modes.md
@@ -60,17 +60,10 @@ may be required.
 
 ### Disabling Reconciliation
 
-To temporarily disable the reconciliation loop for a PostgreSQL cluster, use
-the `cnpg.io/reconciliationLoop` annotation:
-
-```yaml
-metadata:
-  name: cluster-example-no-reconcile
-  annotations:
-    cnpg.io/reconciliationLoop: "disabled"
-spec:
-  # ...
-```
+The `cnpg.io/reconciliationLoop` annotation allows you to temporarily disable
+the reconciliation loop for CloudNativePG resources. When set to `"disabled"`,
+the operator will stop processing updates for the annotated resource, preventing
+any automated changes or self-healing actions.
 
 Use this annotation **with extreme caution** and only during emergency
 operations.
@@ -80,3 +73,19 @@ operations.
     it in place prevents the operator from executing self-healing actions,
     including failover.
 :::
+
+The following resources support this annotation:
+
+- **Cluster**: Disables reconciliation of the PostgreSQL cluster
+- **Backup**: Disables reconciliation of backup operations
+
+Example usage:
+
+```yaml
+metadata:
+  name: cluster-example-no-reconcile
+  annotations:
+    cnpg.io/reconciliationLoop: "disabled"
+spec:
+  # ...
+```

--- a/docs/src/failure_modes.md
+++ b/docs/src/failure_modes.md
@@ -70,8 +70,8 @@ operations.
 
 :::warning
     This annotation should be removed as soon as the issue is resolved. Leaving
-    it in place prevents the operator from executing self-healing actions,
-    including failover.
+    it in place prevents the operator from managing the annotated resource. On a
+    Cluster, this includes self-healing actions and failover.
 :::
 
 The following resources support this annotation:

--- a/internal/controller/backup_controller.go
+++ b/internal/controller/backup_controller.go
@@ -125,6 +125,11 @@ func (r *BackupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		return ctrl.Result{}, err
 	}
 
+	if utils.IsReconciliationDisabled(backup.GetMetadata()) {
+		contextLogger.Warning("Disable reconciliation loop annotation set, skipping the reconciliation.")
+		return ctrl.Result{}, nil
+	}
+
 	switch backup.Status.Phase {
 	case apiv1.BackupPhaseFailed, apiv1.BackupPhaseCompleted:
 		return ctrl.Result{}, nil

--- a/internal/controller/backup_controller.go
+++ b/internal/controller/backup_controller.go
@@ -113,7 +113,7 @@ func NewBackupReconciler(
 // +kubebuilder:rbac:groups="",resources=pods,verbs=get
 
 // Reconcile is the main reconciliation loop
-func (r *BackupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) { // nolint: gocognit
+func (r *BackupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) { //nolint:gocognit
 	contextLogger, ctx := log.SetupLogger(ctx)
 	contextLogger.Debug(fmt.Sprintf("reconciling object %#q", req.NamespacedName))
 

--- a/internal/controller/backup_controller.go
+++ b/internal/controller/backup_controller.go
@@ -113,7 +113,7 @@ func NewBackupReconciler(
 // +kubebuilder:rbac:groups="",resources=pods,verbs=get
 
 // Reconcile is the main reconciliation loop
-func (r *BackupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+func (r *BackupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) { // nolint: gocognit
 	contextLogger, ctx := log.SetupLogger(ctx)
 	contextLogger.Debug(fmt.Sprintf("reconciling object %#q", req.NamespacedName))
 


### PR DESCRIPTION
Add support for the `cnpg.io/reconciliationLoop=disabled` annotation on Backup resources, matching the existing Cluster behavior.

Closes #10019 