### PR TITLE
chore(podspec): remove reintroduced isLegacyVolumeToIgnore code

### DIFF
--- a/pkg/specs/podspec_diff.go
+++ b/pkg/specs/podspec_diff.go
@@ -136,14 +136,6 @@ func compareMaps[V comparable](current, target map[string]V) (bool, string) {
 	return true, ""
 }
 
-// isLegacyVolumeToIgnore returns true for volumes that were removed in 1.24
-// but may still exist on running pods.
-//
-// TODO: delete this function after minor version 1.24 is discontinued
-func isLegacyVolumeToIgnore(name string) bool {
-	return name == "superuser-secret" || name == "app-secret"
-}
-
 // normalizeVolumeName maps old unprefixed volume names to the new prefixed
 // scheme (ext- for extensions, tbs- for tablespaces) to avoid spurious
 // pod restarts on upgrade. Names already starting with the correct prefix
@@ -190,9 +182,6 @@ func compareVolumes(currentVolumes, targetVolumes []corev1.Volume) (bool, string
 	current := make(map[string]corev1.Volume)
 	target := make(map[string]corev1.Volume)
 	for _, vol := range currentVolumes {
-		if isLegacyVolumeToIgnore(vol.Name) {
-			continue
-		}
 		normalized := normalizeVolumeName(vol)
 		vol.Name = normalized
 		current[normalized] = vol
@@ -208,9 +197,6 @@ func compareVolumeMounts(currentMounts, targetMounts []corev1.VolumeMount) (bool
 	current := make(map[string]corev1.VolumeMount)
 	target := make(map[string]corev1.VolumeMount)
 	for _, mount := range currentMounts {
-		if isLegacyVolumeToIgnore(mount.Name) {
-			continue
-		}
 		normalized := normalizeVolumeMountName(mount)
 		mount.Name = normalized
 		current[normalized] = mount


### PR DESCRIPTION
Commit 8d3af4d24 ("fix: prefix extension and tablespace volume names to avoid collisions") reintroduced the superuser-secret/app-secret volume ignore logic that was removed by cd15e5c0d ("chore: remove stale shouldIgnoreCurrentVolume compatibility code for v1.24"). The function was renamed from shouldIgnoreCurrentVolume to isLegacyVolumeToIgnore but is otherwise identical, including the stale v1.24 TODO comment.

Remove isLegacyVolumeToIgnore and its call sites in compareVolumes and compareVolumeMounts, restoring the cleanup from #9964.