### PR TITLE
feat(plugin): add Kubernetes events for improved observability

### DIFF
--- a/internal/controller/plugin_controller.go
+++ b/internal/controller/plugin_controller.go
@@ -34,6 +34,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -50,8 +51,9 @@ import (
 type PluginReconciler struct {
 	client.Client
 
-	Scheme  *runtime.Scheme
-	Plugins repository.Interface
+	Scheme   *runtime.Scheme
+	Recorder record.EventRecorder
+	Plugins  repository.Interface
 
 	OperatorNamespace string
 }
@@ -65,6 +67,7 @@ func NewPluginReconciler(
 	return &PluginReconciler{
 		Client:            mgr.GetClient(),
 		Scheme:            mgr.GetScheme(),
+		Recorder:          mgr.GetEventRecorderFor("cloudnative-pg-plugin"),
 		Plugins:           plugins,
 		OperatorNamespace: operatorNamespace,
 	}
@@ -115,6 +118,8 @@ func (r *PluginReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 			contextLogger.Error(err, "Error while adding finalizer to plugin service")
 			return ctrl.Result{}, err
 		}
+		r.Recorder.Eventf(&service, "Normal", "FinalizerAdded",
+			"Added finalizer to manage plugin %s lifecycle", pluginName)
 		return ctrl.Result{RequeueAfter: time.Second}, nil
 	}
 
@@ -152,6 +157,8 @@ func (r *PluginReconciler) reconcile(
 	if err != nil {
 		contextLogger.Error(err, "Error while getting server secret for plugin",
 			"secretName", pluginServerSecret)
+		r.Recorder.Eventf(service, "Warning", "ServerSecretNotFound",
+			"Failed to get server secret %s: %v", pluginServerSecret, err)
 		return ctrl.Result{}, err
 	}
 
@@ -167,6 +174,8 @@ func (r *PluginReconciler) reconcile(
 	if err != nil {
 		contextLogger.Error(err, "Error while getting client secret for plugin",
 			"secretName", pluginClientSecret)
+		r.Recorder.Eventf(service, "Warning", "ClientSecretNotFound",
+			"Failed to get client secret %s: %v", pluginClientSecret, err)
 		return ctrl.Result{}, err
 	}
 
@@ -183,6 +192,8 @@ func (r *PluginReconciler) reconcile(
 			"Detected service whose plugin port annotation content is not correct, retrying",
 			"pluginPortString", pluginPortString,
 		)
+		r.Recorder.Eventf(service, "Warning", "InvalidPortAnnotation",
+			"Invalid port annotation %q: %v", pluginPortString, err)
 		return ctrl.Result{}, err
 	}
 
@@ -194,6 +205,8 @@ func (r *PluginReconciler) reconcile(
 	if err != nil {
 		contextLogger.Error(err, "Error while parsing client key and certificate for mTLS authentication",
 			"secretName", clientSecret.Name)
+		r.Recorder.Eventf(service, "Warning", "InvalidClientCertificate",
+			"Failed to parse client certificate from secret %s: %v", clientSecret.Name, err)
 		return ctrl.Result{}, err
 	}
 
@@ -210,6 +223,8 @@ func (r *PluginReconciler) reconcile(
 		if block == nil {
 			err := fmt.Errorf("no valid PEM block found in server certificate from secret %q", serverSecret.Name)
 			secretLogger.Error(err, "Error while parsing server certificate for mTLS authentication")
+			r.Recorder.Eventf(service, "Warning", "InvalidServerCertificate",
+				"No valid PEM block found in server certificate from secret %s", serverSecret.Name)
 			return ctrl.Result{}, err
 		}
 
@@ -224,6 +239,8 @@ func (r *PluginReconciler) reconcile(
 		}
 
 		secretLogger.Error(err, "Error while parsing server certificate for mTLS authentication")
+		r.Recorder.Eventf(service, "Warning", "InvalidServerCertificate",
+			"Failed to parse server certificate from secret %s: %v", serverSecret.Name, err)
 		return ctrl.Result{}, err
 	}
 
@@ -255,10 +272,14 @@ func (r *PluginReconciler) reconcile(
 			return ctrl.Result{}, nil
 		}
 		contextLogger.Error(err, "Error while registering plugin")
+		r.Recorder.Eventf(service, "Warning", "PluginRegistrationFailed",
+			"Failed to register plugin %s at %s: %v", pluginName, pluginAddress, err)
 		return ctrl.Result{}, err
 	}
 
 	contextLogger.Info("Registered plugin")
+	r.Recorder.Eventf(service, "Normal", "PluginRegistered",
+		"Successfully registered plugin %s at %s", pluginName, pluginAddress)
 
 	return ctrl.Result{}, nil
 }
@@ -272,12 +293,16 @@ func (r *PluginReconciler) handleDeletion(
 
 	if controllerutil.ContainsFinalizer(service, utils.PluginFinalizerName) {
 		contextLogger.Info("Removing plugin from pool due to service deletion")
+		r.Recorder.Eventf(service, "Normal", "PluginCleanup",
+			"Removing plugin %s from pool due to service deletion", pluginName)
 		r.Plugins.ForgetPlugin(pluginName)
 
 		contextLogger.Debug("Removing finalizer from plugin service")
 		controllerutil.RemoveFinalizer(service, utils.PluginFinalizerName)
 		if err := r.Update(ctx, service); err != nil {
 			contextLogger.Error(err, "Error while removing finalizer from plugin service")
+			r.Recorder.Eventf(service, "Warning", "FinalizerRemovalFailed",
+				"Failed to remove finalizer: %v. Check RBAC permissions or API server connectivity", err)
 			return err
 		}
 	}
@@ -333,6 +358,10 @@ func (r *PluginReconciler) mapSecretToPlugin(ctx context.Context, obj client.Obj
 
 	return result
 }
+
+// +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;update
+// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 
 // SetupWithManager adds this PluginReconciler to the passed controller manager
 func (r *PluginReconciler) SetupWithManager(

--- a/internal/controller/plugin_controller_test.go
+++ b/internal/controller/plugin_controller_test.go
@@ -32,6 +32,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -151,6 +152,7 @@ var _ = Describe("PluginReconciler", func() {
 		reconciler = &PluginReconciler{
 			Client:            fakeClient,
 			Scheme:            scheme.BuildWithAllKnownScheme(),
+			Recorder:          record.NewFakeRecorder(120),
 			Plugins:           pluginRepository,
 			OperatorNamespace: testNamespace,
 		}


### PR DESCRIPTION
Emit events at key points in the plugin lifecycle to improve user experience. Users can now see plugin registration status, configuration errors, and cleanup progress directly on the service resource using kubectl describe, rather than having to check operator logs.

Events are emitted for successful operations (finalizer added, plugin registered, cleanup started) and failures (missing secrets, invalid certificates, registration errors). Error events include actionable details to help troubleshooting.

Closes #10041 