### PR TITLE
chore: add SLSA provenance to release binaries and container images

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -647,18 +647,27 @@ jobs:
           cosign sign --yes ${images}
 
       - name: Prepare images matrix
+        if: env.PUSH == 'true'
         id: images_matrix
+        env:
+          BAKE_METADATA: ${{ steps.bake-push.outputs.metadata }}
         shell: bash
         run: |
-          images_matrix=$(echo '${{ steps.bake-push.outputs.metadata }}' |
-            jq -r -c '. | del(.[].["containerimage.descriptor", "buildx.build.ref"]) | to_entries | map({variant: .key} + .value)'
+          images_matrix=$(echo "$BAKE_METADATA" |
+            jq -r -c '
+              del(.[].["containerimage.descriptor", "buildx.build.ref"])
+              | to_entries
+              | map({variant: .key} + .value + {"image.name": (.value["image.name"] | split(",")[0] | sub(":[^/]+$"; ""))})
+            '
           )
-          echo "images_matrix="$images_matrix >> $GITHUB_OUTPUT
+          echo "images_matrix=${images_matrix}" >> "$GITHUB_OUTPUT"
 
   provenance:
     name: Provenance for images
     if: |
-      always() && !cancelled()
+      (always() && !cancelled()) &&
+      needs.buildx.result == 'success' &&
+      needs.buildx.outputs.push == 'true'
     needs:
       - buildx
     permissions:
@@ -668,7 +677,7 @@ jobs:
     strategy:
       matrix:
         include: ${{ fromJson(needs.buildx.outputs.images_matrix) }}
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.1.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a # v2.1.0
     with:
       image: ${{ matrix['image.name'] }}
       digest: ${{ matrix['containerimage.digest'] }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -677,7 +677,10 @@ jobs:
     strategy:
       matrix:
         include: ${{ fromJson(needs.buildx.outputs.images_matrix) }}
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a # v2.1.0
+    # NOTE: pinned by tag, not SHA — the SLSA generator's builder-fetch.sh
+    # resolves the binary download URL from the git ref and breaks with SHA pins.
+    # See: https://github.com/slsa-framework/slsa-github-generator/issues/4216
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.1.0
     with:
       image: ${{ matrix['image.name'] }}
       digest: ${{ matrix['containerimage.digest'] }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -424,6 +424,7 @@ jobs:
       bundle_img: ${{ env.BUNDLE_IMG }}
       catalog_img: ${{ env.CATALOG_IMG }}
       push: ${{ env.PUSH }}
+      images_matrix: ${{ steps.images_matrix.outputs.images_matrix }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -645,6 +646,35 @@ jobs:
           )
           cosign sign --yes ${images}
 
+      - name: Prepare images matrix
+        id: images_matrix
+        shell: bash
+        run: |
+          images_matrix=$(echo '${{ steps.bake-push.outputs.metadata }}' |
+            jq -r -c '. | del(.[].["containerimage.descriptor", "buildx.build.ref"]) | to_entries | map({variant: .key} + .value)'
+          )
+          echo "images_matrix="$images_matrix >> $GITHUB_OUTPUT
+
+  provenance:
+    name: Provenance for images
+    if: |
+      always() && !cancelled()
+    needs:
+      - buildx
+    permissions:
+      actions: read
+      id-token: write
+      packages: write
+    strategy:
+      matrix:
+        include: ${{ fromJson(needs.buildx.outputs.images_matrix) }}
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.1.0
+    with:
+      image: ${{ matrix['image.name'] }}
+      digest: ${{ matrix['containerimage.digest'] }}
+      registry-username: ${{ github.actor }}
+    secrets:
+      registry-password: ${{ secrets.GITHUB_TOKEN }}
 
   olm-bundle:
     name: Create OLM bundle and catalog

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -294,7 +294,10 @@ jobs:
       actions: read
       id-token: write
       contents: write
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a # v2.1.0
+    # NOTE: pinned by tag, not SHA — the SLSA generator's builder-fetch.sh
+    # resolves the binary download URL from the git ref and breaks with SHA pins.
+    # See: https://github.com/slsa-framework/slsa-github-generator/issues/4216
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
     with:
       base64-subjects: "${{ needs.release-binaries.outputs.hashes }}"
       upload-assets: true
@@ -310,7 +313,8 @@ jobs:
     strategy:
       matrix:
         include: ${{ fromJson(needs.release-binaries.outputs.images_matrix) }}
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a # v2.1.0
+    # NOTE: pinned by tag, not SHA — see comment on provenance-binaries above.
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.1.0
     with:
       image: ${{ matrix['image.name'] }}
       digest: ${{ matrix['containerimage.digest'] }}

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -122,8 +122,8 @@ jobs:
       author_email: ${{ steps.build-meta.outputs.author_email }}
       platforms: ${{ env.PLATFORMS }}
       olm_img: ${{ steps.olm-image.outputs.olm_image }}
-      hashes: ${{ steps.goreleaser.outputs.hashes }}
-      images_matrix: ${{ steps.images_matrix.outputs.hashes }}
+      hashes: ${{ steps.hashes.outputs.hashes }}
+      images_matrix: ${{ steps.images_matrix.outputs.images_matrix }}
     steps:
       -
         name: Checkout
@@ -273,12 +273,18 @@ jobs:
       -
         name: Prepare images matrix
         id: images_matrix
+        env:
+          BAKE_METADATA: ${{ steps.bake-push.outputs.metadata }}
         shell: bash
         run: |
-          images_matrix=$(echo '${{ steps.bake-push.outputs.metadata }}' |
-            jq -r -c '. | del(.[].["containerimage.descriptor", "buildx.build.ref"]) | to_entries | map({variant: .key} + .value)'
+          images_matrix=$(echo "$BAKE_METADATA" |
+            jq -r -c '
+              del(.[].["containerimage.descriptor", "buildx.build.ref"])
+              | to_entries
+              | map({variant: .key} + .value + {"image.name": (.value["image.name"] | split(",")[0] | sub(":[^/]+$"; ""))})
+            '
           )
-          echo "images_matrix="$images_matrix >> $GITHUB_OUTPUT
+          echo "images_matrix=${images_matrix}" >> "$GITHUB_OUTPUT"
 
   provenance-binaries:
     name: Add provenance to binaries
@@ -288,10 +294,10 @@ jobs:
       actions: read
       id-token: write
       contents: write
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a # v2.1.0
     with:
       base64-subjects: "${{ needs.release-binaries.outputs.hashes }}"
-      upload-assets: tue
+      upload-assets: true
 
   provenance-images:
     name: Provenance for images
@@ -304,7 +310,7 @@ jobs:
     strategy:
       matrix:
         include: ${{ fromJson(needs.release-binaries.outputs.images_matrix) }}
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.1.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a # v2.1.0
     with:
       image: ${{ matrix['image.name'] }}
       digest: ${{ matrix['containerimage.digest'] }}

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -122,6 +122,8 @@ jobs:
       author_email: ${{ steps.build-meta.outputs.author_email }}
       platforms: ${{ env.PLATFORMS }}
       olm_img: ${{ steps.olm-image.outputs.olm_image }}
+      hashes: ${{ steps.goreleaser.outputs.hashes }}
+      images_matrix: ${{ steps.images_matrix.outputs.hashes }}
     steps:
       -
         name: Checkout
@@ -175,6 +177,7 @@ jobs:
           echo "$GPG_PRIVATE_KEY" > gpg_signing_key.asc
       -
         name: Run GoReleaser
+        id: goreleaser
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6
         with:
           distribution: goreleaser
@@ -187,6 +190,16 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
           NFPM_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+
+      - name: Build checksum file
+        id: hashes
+        env:
+          ARTIFACTS: "${{ steps.goreleaser.outputs.artifacts }}"
+        shell: bash
+        run: |
+          checksum_file=$(echo "$ARTIFACTS" | jq -r '.[] | select (.type=="Checksum") | .path')
+          echo "hashes=$(cat $checksum_file | base64 -w0)" >> "$GITHUB_OUTPUT"
+
       -
         name: Publish Krew
         if: |
@@ -257,6 +270,48 @@ jobs:
           ubi_tags: ${{ fromJSON(steps.bake-push.outputs.metadata)['ubi']['image.name'] }}
         run: |
           echo "olm_image=$(echo "$ubi_tags" | tr ',' '\n' | grep -v 'latest' | sed 's/^ *//g' | head -n 1)" >> $GITHUB_OUTPUT
+      -
+        name: Prepare images matrix
+        id: images_matrix
+        shell: bash
+        run: |
+          images_matrix=$(echo '${{ steps.bake-push.outputs.metadata }}' |
+            jq -r -c '. | del(.[].["containerimage.descriptor", "buildx.build.ref"]) | to_entries | map({variant: .key} + .value)'
+          )
+          echo "images_matrix="$images_matrix >> $GITHUB_OUTPUT
+
+  provenance-binaries:
+    name: Add provenance to binaries
+    needs:
+      - release-binaries
+    permissions:
+      actions: read
+      id-token: write
+      contents: write
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
+    with:
+      base64-subjects: "${{ needs.release-binaries.outputs.hashes }}"
+      upload-assets: tue
+
+  provenance-images:
+    name: Provenance for images
+    needs:
+      - release-binaries
+    permissions:
+      actions: read
+      id-token: write
+      packages: write
+    strategy:
+      matrix:
+        include: ${{ fromJson(needs.release-binaries.outputs.images_matrix) }}
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.1.0
+    with:
+      image: ${{ matrix['image.name'] }}
+      digest: ${{ matrix['containerimage.digest'] }}
+      registry-username: ${{ github.actor }}
+    secrets:
+      registry-password: ${{ secrets.GITHUB_TOKEN }}
+
 
   olm-bundle:
     name: Create OLM bundle and catalog

--- a/.wordlist-en-custom.txt
+++ b/.wordlist-en-custom.txt
@@ -1405,6 +1405,7 @@ sigs
 sigstore
 singlenamespace
 slotPrefix
+slsa
 smartShutdownTimeout
 snapshotBackupStatus
 snapshotOwnerReference

--- a/SECURITY-INSIGHTS.yml
+++ b/SECURITY-INSIGHTS.yml
@@ -203,6 +203,19 @@ repository:
           adhoc: true
           ci: true
           release: true
+      - name: SLSA GitHub Generator Action
+        type: automated-tooling
+        rulesets: ["default"]
+        comment: >-
+          Generates non-falsifiable SLSA Level 3 provenance attestations for
+          release assets. This ensures that the binary artifacts and images are traced
+          back to the specific source commit and build environment without manual
+          intervention.
+
+        integration:
+          adhoc: false
+          ci: true
+          release: true
 
     assessments:
       self:

--- a/docs/src/installation_upgrade.md
+++ b/docs/src/installation_upgrade.md
@@ -391,6 +391,19 @@ cosign verify-blob \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
 ```
 
+#### Verifying SLSA provenance
+
+To verify a release binary, download both the artifact and the provenance file
+(`multiple.intoto.jsonl`) from the
+[GitHub release](https://github.com/cloudnative-pg/cloudnative-pg/releases),
+then run:
+
+```shell
+slsa-verifier verify-artifact <ARTIFACT> \
+  --provenance-path multiple.intoto.jsonl \
+  --source-uri github.com/cloudnative-pg/cloudnative-pg
+```
+
 ### Verifying the operator container images
 
 Run the following command to verify the signature of the CloudNativePG operator
@@ -419,6 +432,11 @@ To inspect the SLSA Provenance (build details):
 docker buildx imagetools inspect ghcr.io/cloudnative-pg/cloudnative-pg:{tag} \
   --format '{{ json (index .Provenance "linux/amd64").SLSA }}'
 ```
+
+:::info
+Refer to ["Verifying SLSA provenance"](security.md#verifying-slsa-provenance)
+for SLSA Build Level 3 compliance verification.
+:::
 
 ### Verifying PostgreSQL operand images
 

--- a/docs/src/security.md
+++ b/docs/src/security.md
@@ -186,17 +186,6 @@ slsa-verifier verify-image \
   --source-uri github.com/cloudnative-pg/cloudnative-pg
 ```
 
-To verify a release binary, download both the artifact and the provenance file
-(`multiple.intoto.jsonl`) from the
-[GitHub release](https://github.com/cloudnative-pg/cloudnative-pg/releases),
-then run:
-
-```shell
-slsa-verifier verify-artifact <ARTIFACT> \
-  --provenance-path multiple.intoto.jsonl \
-  --source-uri github.com/cloudnative-pg/cloudnative-pg
-```
-
 ### Guidelines and Frameworks for Container Security
 
 The following guidelines and frameworks have been considered for ensuring

--- a/docs/src/security.md
+++ b/docs/src/security.md
@@ -149,9 +149,11 @@ traceability:
   comprehensive list of software artifacts included in the image or used during
   its build process, formatted using the
   [in-toto SPDX predicate standard](https://github.com/in-toto/attestation/blob/main/spec/predicates/spdx.md).
-- **[Provenance](https://docs.docker.com/build/metadata/attestations/slsa-provenance/):**
-  Metadata detailing how the image was built, following the [SLSA Provenance](https://slsa.dev)
-  framework.
+- **Provenance:** Metadata detailing the build process, generated via the
+  [SLSA GitHub Generator Github action](https://github.com/slsa-framework/slsa-github-generator).
+  This provides [SLSA Level 3 assurance](https://slsa.dev/spec/v1.0/levels)
+  that the artifact was built on a trusted, isolated GitHub Actions runner
+  directly from the project's source.
 
 You can retrieve the SBOM for a specific image and platform using the following
 command:

--- a/docs/src/security.md
+++ b/docs/src/security.md
@@ -166,11 +166,35 @@ docker buildx imagetools inspect <IMAGE> \
 This command outputs the SBOM in JSON format, providing a detailed view of the
 software components and build dependencies.
 
-For the provenance, use:
+For the build-level provenance, use:
 
 ```shell
 docker buildx imagetools inspect <IMAGE> \
   --format '{{ json (index .Provenance "<PLATFORM>").SLSA }}'
+```
+
+#### Verifying SLSA provenance
+
+You can verify SLSA Level 3 provenance using
+[`slsa-verifier`](https://github.com/slsa-framework/slsa-verifier).
+
+To verify a container image, pass its digest reference:
+
+```shell
+slsa-verifier verify-image \
+  ghcr.io/cloudnative-pg/cloudnative-pg@sha256:<DIGEST> \
+  --source-uri github.com/cloudnative-pg/cloudnative-pg
+```
+
+To verify a release binary, download both the artifact and the provenance file
+(`multiple.intoto.jsonl`) from the
+[GitHub release](https://github.com/cloudnative-pg/cloudnative-pg/releases),
+then run:
+
+```shell
+slsa-verifier verify-artifact <ARTIFACT> \
+  --provenance-path multiple.intoto.jsonl \
+  --source-uri github.com/cloudnative-pg/cloudnative-pg
 ```
 
 ### Guidelines and Frameworks for Container Security


### PR DESCRIPTION
Add SLSA3 provenance attestation for release binaries (via
slsa-framework generator_generic_slsa3) and container images (via
generator_container_slsa3) in both the release and CI workflows,
satisfying the OpenSSF Scorecard signed-releases check.

Closes #9440 