### PR TITLE
fix(roles): prevent password deletion if password secret is not found

### DIFF
--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -2571,8 +2571,10 @@ type RoleConfiguration struct {
 	// +optional
 	Ensure EnsureOption `json:"ensure,omitempty"`
 
-	// Secret containing the password of the role (if present)
-	// If null, the password will be ignored unless DisablePassword is set
+	// Secret containing the password of the role (if present).
+	// If null, the password will be ignored unless DisablePassword is set.
+	// When set, the secret must follow the `kubernetes.io/basic-auth` format
+	// and contain both a `username` and a `password` field.
 	// +optional
 	PasswordSecret *LocalObjectReference `json:"passwordSecret,omitempty"`
 

--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -795,8 +795,10 @@ type ManagedRoles struct {
 	// +optional
 	ByStatus map[RoleStatus][]string `json:"byStatus,omitempty"`
 
-	// CannotReconcile lists roles that cannot be reconciled in PostgreSQL,
-	// with an explanation of the cause
+	// CannotReconcile lists roles that cannot be reconciled, with an
+	// explanation of the cause. Failures may originate in PostgreSQL
+	// (e.g. dropping a role that owns objects) or in Kubernetes (e.g.
+	// the referenced password Secret cannot be fetched).
 	// +optional
 	CannotReconcile map[string][]string `json:"cannotReconcile,omitempty"`
 

--- a/config/crd/bases/postgresql.cnpg.io_clusters.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_clusters.yaml
@@ -3321,8 +3321,10 @@ spec:
                           type: string
                         passwordSecret:
                           description: |-
-                            Secret containing the password of the role (if present)
-                            If null, the password will be ignored unless DisablePassword is set
+                            Secret containing the password of the role (if present).
+                            If null, the password will be ignored unless DisablePassword is set.
+                            When set, the secret must follow the `kubernetes.io/basic-auth` format
+                            and contain both a `username` and a `password` field.
                           properties:
                             name:
                               description: Name of the referent.

--- a/config/crd/bases/postgresql.cnpg.io_clusters.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_clusters.yaml
@@ -7093,8 +7093,10 @@ spec:
                         type: string
                       type: array
                     description: |-
-                      CannotReconcile lists roles that cannot be reconciled in PostgreSQL,
-                      with an explanation of the cause
+                      CannotReconcile lists roles that cannot be reconciled, with an
+                      explanation of the cause. Failures may originate in PostgreSQL
+                      (e.g. dropping a role that owns objects) or in Kubernetes (e.g.
+                      the referenced password Secret cannot be fetched).
                     type: object
                   passwordStatus:
                     additionalProperties:

--- a/docs/src/cloudnative-pg.v1.md
+++ b/docs/src/cloudnative-pg.v1.md
@@ -1491,7 +1491,7 @@ _Appears in:_
 | Field | Description | Required | Default | Validation |
 | --- | --- | --- | --- | --- |
 | `byStatus` _object (keys:[RoleStatus](#rolestatus), values:string array)_ | ByStatus gives the list of roles in each state |  |  |  |
-| `cannotReconcile` _object (keys:string, values:string array)_ | CannotReconcile lists roles that cannot be reconciled in PostgreSQL,<br />with an explanation of the cause |  |  |  |
+| `cannotReconcile` _object (keys:string, values:string array)_ | CannotReconcile lists roles that cannot be reconciled, with an<br />explanation of the cause. Failures may originate in PostgreSQL<br />(e.g. dropping a role that owns objects) or in Kubernetes (e.g.<br />the referenced password Secret cannot be fetched). |  |  |  |
 | `passwordStatus` _object (keys:string, values:[PasswordState](#passwordstate))_ | PasswordStatus gives the last transaction id and password secret version for each managed role |  |  |  |
 
 

--- a/docs/src/cloudnative-pg.v1.md
+++ b/docs/src/cloudnative-pg.v1.md
@@ -2484,7 +2484,7 @@ _Appears in:_
 | `name` _string_ | Name of the role | True |  |  |
 | `comment` _string_ | Description of the role |  |  |  |
 | `ensure` _[EnsureOption](#ensureoption)_ | Ensure the role is `present` or `absent` - defaults to "present" |  | present | Enum: [present absent] <br /> |
-| `passwordSecret` _[LocalObjectReference](https://pkg.go.dev/github.com/cloudnative-pg/machinery/pkg/api#LocalObjectReference)_ | Secret containing the password of the role (if present)<br />If null, the password will be ignored unless DisablePassword is set |  |  |  |
+| `passwordSecret` _[LocalObjectReference](https://pkg.go.dev/github.com/cloudnative-pg/machinery/pkg/api#LocalObjectReference)_ | Secret containing the password of the role (if present).<br />If null, the password will be ignored unless DisablePassword is set.<br />When set, the secret must follow the `kubernetes.io/basic-auth` format<br />and contain both a `username` and a `password` field. |  |  |  |
 | `connectionLimit` _integer_ | If the role can log in, this specifies how many concurrent<br />connections the role can make. `-1` (the default) means no limit. |  | -1 |  |
 | `validUntil` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#time-v1-meta)_ | Date and time after which the role's password is no longer valid.<br />When omitted, the password will never expire (default). |  |  |  |
 | `inRoles` _string array_ | List of one or more existing roles to which this role will be<br />immediately added as a new member. Default empty. |  |  |  |

--- a/internal/management/controller/roles/reconciler.go
+++ b/internal/management/controller/roles/reconciler.go
@@ -76,7 +76,8 @@ func Reconcile(
 
 	if len(rolesByStatus[apiv1.RoleStatusPendingReconciliation]) != 0 {
 		instance.TriggerRoleSynchronizer(cluster.Spec.Managed)
-		contextLogger.Info("Triggered a managed role reconciliation")
+		contextLogger.Info("Triggered a managed role reconciliation",
+			"pending-roles", roleNamesByStatus[apiv1.RoleStatusPendingReconciliation])
 	}
 
 	updatedCluster := cluster.DeepCopy()

--- a/internal/management/controller/roles/reconciler.go
+++ b/internal/management/controller/roles/reconciler.go
@@ -52,11 +52,8 @@ func Reconcile(
 	}
 
 	// get current passwords from spec/secrets
-	latestPasswordResourceVersion, err := getPasswordSecretResourceVersion(
+	latestPasswordResourceVersion := getPasswordSecretResourceVersion(
 		ctx, c, cluster.Spec.Managed.Roles, cluster.Namespace)
-	if err != nil {
-		return reconcile.Result{}, err
-	}
 
 	contextLogger.Debug("getting the managed roles status")
 	rolesInDB, err := List(ctx, db)

--- a/internal/management/controller/roles/roles.go
+++ b/internal/management/controller/roles/roles.go
@@ -114,6 +114,22 @@ func (r rolesByAction) convertToRolesByStatus() rolesByStatus {
 	return rolesByStatus
 }
 
+// passwordSecretIsRequiredButMissing reports whether the spec asks for a
+// password secret that getPasswordSecretResourceVersion was unable to fetch.
+// Such roles must be routed through the update path so the synchronizer can
+// surface the failure in CannotReconcile rather than silently classifying
+// them as reconciled.
+func passwordSecretIsRequiredButMissing(
+	inSpec apiv1.RoleConfiguration,
+	latestSecretResourceVersion map[string]string,
+) bool {
+	if inSpec.PasswordSecret == nil || inSpec.DisablePassword {
+		return false
+	}
+	_, ok := latestSecretResourceVersion[inSpec.Name]
+	return !ok
+}
+
 // evaluateNextRoleActions evaluates the action needed for each role in the DB and/or the Spec.
 // It has no side effects
 func evaluateNextRoleActions(
@@ -148,7 +164,8 @@ func evaluateNextRoleActions(
 				roleAdapterFromName(role.Name))
 		case isInSpec &&
 			(!role.isEquivalentTo(inSpec) ||
-				role.passwordNeedsUpdating(lastPasswordState, latestSecretResourceVersion)):
+				role.passwordNeedsUpdating(lastPasswordState, latestSecretResourceVersion) ||
+				passwordSecretIsRequiredButMissing(inSpec, latestSecretResourceVersion)):
 			internalRole := roleConfigurationAdapter{
 				RoleConfiguration:        inSpec,
 				validUntilNullIsInfinity: role.ValidUntil.Valid,

--- a/internal/management/controller/roles/runnable.go
+++ b/internal/management/controller/roles/runnable.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/cloudnative-pg/machinery/pkg/log"
 	corev1 "k8s.io/api/core/v1"
-	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -132,13 +131,6 @@ func (sr *RoleSynchronizer) Start(ctx context.Context) error {
 // with the spec. It also updates the cluster Status with the latest applied changes
 func (sr *RoleSynchronizer) reconcile(ctx context.Context, config *apiv1.ManagedConfiguration) error {
 	var err error
-
-	defer func() {
-		if r := recover(); r != nil {
-			err = fmt.Errorf("recovered from a panic: %s", r)
-		}
-	}()
-
 	contextLog := log.FromContext(ctx).WithName("roles_reconciler")
 	contextLog.Debug("reconciling managed roles")
 
@@ -163,7 +155,7 @@ func (sr *RoleSynchronizer) reconcile(ctx context.Context, config *apiv1.Managed
 	if err != nil {
 		return fmt.Errorf("while getting superuser connection: %w", err)
 	}
-	appliedState, irreconcilableRoles, err := sr.synchronizeRoles(ctx, superUserDB, config, rolePasswords)
+	appliedState, unreconciledRoles, err := sr.synchronizeRoles(ctx, superUserDB, config, rolePasswords)
 	if err != nil {
 		return fmt.Errorf("while syncrhonizing managed roles: %w", err)
 	}
@@ -176,7 +168,7 @@ func (sr *RoleSynchronizer) reconcile(ctx context.Context, config *apiv1.Managed
 	}
 	updatedCluster := remoteCluster.DeepCopy()
 	updatedCluster.Status.ManagedRolesStatus.PasswordStatus = appliedState
-	updatedCluster.Status.ManagedRolesStatus.CannotReconcile = irreconcilableRoles
+	updatedCluster.Status.ManagedRolesStatus.CannotReconcile = unreconciledRoles
 	return sr.client.Status().Patch(ctx, updatedCluster, client.MergeFrom(&remoteCluster))
 }
 
@@ -208,17 +200,14 @@ func (sr *RoleSynchronizer) synchronizeRoles(
 	rolesByAction := evaluateNextRoleActions(
 		ctx, config, rolesInDB, storedPasswordState, latestSecretResourceVersion)
 
-	passwordStates, irreconcilableRoles, err := sr.applyRoleActions(ctx, db, rolesByAction)
-	if err != nil {
-		return nil, nil, err
-	}
+	passwordStates, unreconciledRoles := sr.applyRoleActions(ctx, db, rolesByAction)
 
 	// Merge the status from database into spec. We should keep all the status
 	// otherwise in the next loop the user without status will be marked as need update
 	for role, stateInDatabase := range passwordStates {
 		storedPasswordState[role] = stateInDatabase
 	}
-	return storedPasswordState, irreconcilableRoles, nil
+	return storedPasswordState, unreconciledRoles, nil
 }
 
 // applyRoleActions applies the actions to reconcile roles in the DB with the Spec
@@ -233,25 +222,22 @@ func (sr *RoleSynchronizer) applyRoleActions(
 	ctx context.Context,
 	db *sql.DB,
 	rolesByAction rolesByAction,
-) (map[string]apiv1.PasswordState, map[string][]string, error) {
+) (map[string]apiv1.PasswordState, map[string][]string) {
 	contextLog := log.FromContext(ctx).WithName("roles_reconciler")
 	contextLog.Debug("applying role actions")
 
-	irreconcilableRoles := make(map[string][]string)
+	unreconciledRoles := make(map[string][]string)
 	appliedChanges := make(map[string]apiv1.PasswordState)
-	handleRoleError := func(errToEvaluate error, roleName string, action roleAction) error {
-		// log unexpected errors, collect expectable PostgreSQL errors
+	handleRoleError := func(errToEvaluate error, roleName string, action roleAction) {
 		if errToEvaluate == nil {
-			return nil
+			return
 		}
 		roleError, err := parseRoleError(errToEvaluate, roleName, action)
-		if err != nil {
-			contextLog.Error(err, "while performing "+string(action), "role", roleName)
-			return err
+		if err == nil {
+			unreconciledRoles[roleName] = append(unreconciledRoles[roleName], roleError.Error())
+		} else {
+			unreconciledRoles[roleName] = append(unreconciledRoles[roleName], errToEvaluate.Error())
 		}
-
-		irreconcilableRoles[roleName] = append(irreconcilableRoles[roleName], roleError.Error())
-		return nil
 	}
 
 	actionsCreateUpdate := []roleAction{roleCreate, roleUpdate}
@@ -261,42 +247,32 @@ func (sr *RoleSynchronizer) applyRoleActions(
 			if err == nil {
 				appliedChanges[role.Name] = appliedState
 			}
-			if unhandledErr := handleRoleError(err, role.Name, action); unhandledErr != nil {
-				return nil, nil, unhandledErr
-			}
+			handleRoleError(err, role.Name, action)
 		}
 	}
 
 	for _, role := range rolesByAction[roleSetComment] {
 		// NOTE: adding/updating a comment on a role does not alter its TransactionID
 		err := UpdateComment(ctx, db, role.toDatabaseRole())
-		if unhandledErr := handleRoleError(err, role.Name, roleSetComment); unhandledErr != nil {
-			return nil, nil, unhandledErr
-		}
+		handleRoleError(err, role.Name, roleSetComment)
 	}
 
 	for _, role := range rolesByAction[roleUpdateMemberships] {
 		// NOTE: revoking / granting to a role does not alter its TransactionID
 		dbRole := role.toDatabaseRole()
 		grants, revokes, err := getRoleMembershipDiff(ctx, db, role, dbRole)
-		if unhandledErr := handleRoleError(err, role.Name, roleUpdateMemberships); unhandledErr != nil {
-			return nil, nil, unhandledErr
-		}
+		handleRoleError(err, role.Name, roleUpdateMemberships)
 
 		err = UpdateMembership(ctx, db, dbRole, grants, revokes)
-		if unhandledErr := handleRoleError(err, role.Name, roleUpdateMemberships); unhandledErr != nil {
-			return nil, nil, unhandledErr
-		}
+		handleRoleError(err, role.Name, roleUpdateMemberships)
 	}
 
 	for _, role := range rolesByAction[roleDelete] {
 		err := Delete(ctx, db, role.toDatabaseRole())
-		if unhandledErr := handleRoleError(err, role.Name, roleDelete); unhandledErr != nil {
-			return nil, nil, unhandledErr
-		}
+		handleRoleError(err, role.Name, roleDelete)
 	}
 
-	return appliedChanges, irreconcilableRoles, nil
+	return appliedChanges, unreconciledRoles
 }
 
 func getRoleMembershipDiff(
@@ -390,18 +366,12 @@ func getPassword(
 	}
 
 	var secret corev1.Secret
-	wrapSecretErr := func(secretName string, err error) error {
-		return fmt.Errorf("failed to get password secret %s: %w",
-			secretName, err)
-	}
 	err := cl.Get(ctx,
 		client.ObjectKey{Namespace: namespace, Name: secretName},
 		&secret)
 	if err != nil {
-		if apierrs.IsNotFound(err) {
-			return passwordSecret{}, wrapSecretErr(secretName, err)
-		}
-		return passwordSecret{}, wrapSecretErr(secretName, err)
+		return passwordSecret{},
+			fmt.Errorf("failed to get password secret %s: %w", secretName, err)
 	}
 	usernameFromSecret, passwordFromSecret, err := utils.GetUserPasswordFromSecret(&secret)
 	if err != nil {
@@ -428,14 +398,12 @@ func getPasswordSecretResourceVersion(
 	namespace string,
 ) map[string]string {
 	re := make(map[string]string)
-	logger := log.FromContext(ctx)
 	for _, role := range rolesInSpec {
 		if role.PasswordSecret == nil || role.DisablePassword {
 			continue
 		}
 		passwordSecret, err := getPassword(ctx, client, roleConfigurationAdapter{RoleConfiguration: role}, namespace)
 		if err != nil {
-			logger.Error(err, "while getting password secret resource versions", "namespace", namespace)
 			continue
 		}
 		re[role.Name] = passwordSecret.version

--- a/internal/management/controller/roles/runnable.go
+++ b/internal/management/controller/roles/runnable.go
@@ -199,11 +199,8 @@ func (sr *RoleSynchronizer) synchronizeRoles(
 	config *apiv1.ManagedConfiguration,
 	storedPasswordState map[string]apiv1.PasswordState,
 ) (map[string]apiv1.PasswordState, map[string][]string, error) {
-	latestSecretResourceVersion, err := getPasswordSecretResourceVersion(
+	latestSecretResourceVersion := getPasswordSecretResourceVersion(
 		ctx, sr.client, config.Roles, sr.instance.GetNamespaceName())
-	if err != nil {
-		return nil, nil, err
-	}
 	rolesInDB, err := List(ctx, db)
 	if err != nil {
 		return nil, nil, err
@@ -393,14 +390,18 @@ func getPassword(
 	}
 
 	var secret corev1.Secret
+	wrapSecretErr := func(secretName string, err error) error {
+		return fmt.Errorf("failed to get password secret %s: %w",
+			secretName, err)
+	}
 	err := cl.Get(ctx,
 		client.ObjectKey{Namespace: namespace, Name: secretName},
 		&secret)
 	if err != nil {
 		if apierrs.IsNotFound(err) {
-			return passwordSecret{}, nil
+			return passwordSecret{}, wrapSecretErr(secretName, err)
 		}
-		return passwordSecret{}, err
+		return passwordSecret{}, wrapSecretErr(secretName, err)
 	}
 	usernameFromSecret, passwordFromSecret, err := utils.GetUserPasswordFromSecret(&secret)
 	if err != nil {
@@ -418,26 +419,28 @@ func getPassword(
 		nil
 }
 
-// getPasswordSecretResourceVersion returns a list of resource version of the passwords secrets for managed roles
+// getPasswordSecretResourceVersion returns a list of resource version of the password secrets for managed roles
 // stored as Kubernetes secrets
 func getPasswordSecretResourceVersion(
 	ctx context.Context,
 	client client.Client,
 	rolesInSpec []apiv1.RoleConfiguration,
 	namespace string,
-) (map[string]string, error) {
+) map[string]string {
 	re := make(map[string]string)
+	logger := log.FromContext(ctx)
 	for _, role := range rolesInSpec {
 		if role.PasswordSecret == nil || role.DisablePassword {
 			continue
 		}
 		passwordSecret, err := getPassword(ctx, client, roleConfigurationAdapter{RoleConfiguration: role}, namespace)
 		if err != nil {
-			return nil, err
+			logger.Error(err, "while getting password secret resource versions", "namespace", namespace)
+			continue
 		}
 		re[role.Name] = passwordSecret.version
 	}
-	return re, nil
+	return re
 }
 
 func getRolesToGrant(inRoleInDB, inRoleInSpec []string) []string {

--- a/internal/management/controller/roles/runnable.go
+++ b/internal/management/controller/roles/runnable.go
@@ -390,20 +390,25 @@ func getPassword(
 }
 
 // getPasswordSecretResourceVersion returns a list of resource version of the password secrets for managed roles
-// stored as Kubernetes secrets
+// stored as Kubernetes secrets. Roles whose secret cannot be fetched are
+// omitted from the result; the action evaluator will route them through the
+// update path so the failure surfaces in CannotReconcile.
 func getPasswordSecretResourceVersion(
 	ctx context.Context,
-	client client.Client,
+	cl client.Client,
 	rolesInSpec []apiv1.RoleConfiguration,
 	namespace string,
 ) map[string]string {
+	contextLog := log.FromContext(ctx).WithName("roles_reconciler")
 	re := make(map[string]string)
 	for _, role := range rolesInSpec {
 		if role.PasswordSecret == nil || role.DisablePassword {
 			continue
 		}
-		passwordSecret, err := getPassword(ctx, client, roleConfigurationAdapter{RoleConfiguration: role}, namespace)
+		passwordSecret, err := getPassword(ctx, cl, roleConfigurationAdapter{RoleConfiguration: role}, namespace)
 		if err != nil {
+			contextLog.Debug("could not fetch password secret for role; will be flagged for reconciliation",
+				"role", role.Name, "secret", role.PasswordSecret.Name, "err", err.Error())
 			continue
 		}
 		re[role.Name] = passwordSecret.version

--- a/internal/management/controller/roles/runnable.go
+++ b/internal/management/controller/roles/runnable.go
@@ -183,8 +183,10 @@ func getRoleNames(roles []roleConfigurationAdapter) []string {
 // synchronizeRoles aligns roles in the database to the spec
 // It returns
 //   - the PasswordState for any updated roles
-//   - any roles that had expectable postgres errors
-//   - any unexpected error
+//   - the per-role errors encountered while applying role actions (e.g.
+//     unrealizable postgres operations, missing password secret)
+//   - any error that prevents the whole synchronization from running
+//     (e.g. listing the roles in the database failed)
 func (sr *RoleSynchronizer) synchronizeRoles(
 	ctx context.Context,
 	db *sql.DB,
@@ -210,14 +212,12 @@ func (sr *RoleSynchronizer) synchronizeRoles(
 	return storedPasswordState, unreconciledRoles, nil
 }
 
-// applyRoleActions applies the actions to reconcile roles in the DB with the Spec
-// It returns the apiv1.PasswordState for each role, as well as a map of roles that
-// cannot be reconciled for expectable errors, e.g. dropping a role owning content
-//
-// NOTE: applyRoleActions will carry on after an expectable error, i.e. an error
-// due to an invalid request for postgres. This is so that other actions will not
-// be blocked by a user error.
-// It will, however, error out on unexpected errors.
+// applyRoleActions applies the actions to reconcile roles in the DB with the Spec.
+// It returns the apiv1.PasswordState for each successfully applied role, and a
+// map collecting the errors encountered per role. Both expectable errors
+// (e.g. dropping a role that owns content) and unexpected errors are recorded
+// in the map, so that an error on one role does not block the reconciliation
+// of the others.
 func (sr *RoleSynchronizer) applyRoleActions(
 	ctx context.Context,
 	db *sql.DB,

--- a/internal/management/controller/roles/runnable_test.go
+++ b/internal/management/controller/roles/runnable_test.go
@@ -423,13 +423,14 @@ var _ = Describe("Role synchronizer tests", func() {
 			Expect(roleSynchronizer.client.Get(ctx,
 				client.ObjectKey{Namespace: namespace, Name: secretInDBName},
 				&secret)).To(Succeed())
-			_, _, err := roleSynchronizer.synchronizeRoles(ctx, db, &managedConf, map[string]apiv1.PasswordState{
+			_, unreconciled, err := roleSynchronizer.synchronizeRoles(ctx, db, &managedConf, map[string]apiv1.PasswordState{
 				"role_with_pass": {
 					TransactionID:         11,
 					SecretResourceVersion: secret.ResourceVersion,
 				},
 			})
 			Expect(err).ShouldNot(HaveOccurred())
+			Expect(unreconciled).To(BeEmpty())
 		})
 
 		It("it will not update a role password if the secret cannot be retrieved", func(ctx context.Context) {
@@ -447,14 +448,16 @@ var _ = Describe("Role synchronizer tests", func() {
 					},
 				},
 			}
-			_, _, err := roleSynchronizer.synchronizeRoles(ctx, db, &managedConf, map[string]apiv1.PasswordState{
+			_, unreconciled, err := roleSynchronizer.synchronizeRoles(ctx, db, &managedConf, map[string]apiv1.PasswordState{
 				"role_to_test1": {
 					TransactionID:         11, // defined in the mock query to the DB above
 					SecretResourceVersion: "11",
 				},
 			})
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("failed to get password secret"))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(unreconciled).To(HaveLen(1))
+			Expect(unreconciled["role_to_test1"]).To(HaveLen(1))
+			Expect(unreconciled["role_to_test1"][0]).To(ContainSubstring("failed to get password secret"))
 		})
 
 		It("it will ignore ensure:absent roles in spec missing from DB", func(ctx context.Context) {

--- a/internal/management/controller/roles/runnable_test.go
+++ b/internal/management/controller/roles/runnable_test.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/cloudnative-pg/machinery/pkg/api"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/lib/pq"
@@ -34,6 +35,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
@@ -202,15 +204,20 @@ var _ = Describe("Role synchronizer tests", func() {
 		err              error
 		roleSynchronizer RoleSynchronizer
 	)
-
+	const (
+		secretName                        = "vinci-secret-name"
+		secretNameWithUpdates             = "vinci-secret-with-updates-name"
+		secretInDBName                    = "vinci-secret-in-db-name"
+		wantedLogStatementSuppressionStmt = "SET LOCAL log_statement = 'none'"
+		wantedLogPreventionStmt           = "SET LOCAL log_min_error_statement = 'PANIC'"
+	)
+	testDate := time.Date(2023, 4, 4, 0, 0, 0, 0, time.UTC)
 	BeforeEach(func() {
 		db, mock, err = sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 		Expect(err).ToNot(HaveOccurred())
 		DeferCleanup(func() {
 			Expect(mock.ExpectationsWereMet()).To(Succeed())
 		})
-
-		testDate := time.Date(2023, 4, 4, 0, 0, 0, 0, time.UTC)
 
 		rowsInMockDatabase := sqlmock.NewRows([]string{
 			"rolname", "rolsuper", "rolinherit", "rolcreaterole", "rolcreatedb",
@@ -230,14 +237,56 @@ var _ = Describe("Role synchronizer tests", func() {
 			AddRow("role_to_test1", true, true, false, false, false, false, -1, []byte("12345"),
 				nil, false, []byte("This is a role to test with"), 11, []byte("{}")).
 			AddRow("role_to_test2", true, true, false, false, false, false, -1, []byte("12345"),
-				nil, false, []byte("This is a role to test with"), 11, []byte("{inrole}"))
+				nil, false, []byte("This is a role to test with"), 11, []byte("{inrole}")).
+			AddRow("role_with_pass", false, true, false, false, false, false, -1, []byte(password),
+				pgtype.Timestamp{
+					Valid:            true,
+					Time:             testDate,
+					InfinityModifier: pgtype.Finite,
+				}, false, []byte(""), 11, []byte("{}"))
 		mock.ExpectQuery(expectedSelStmt).WillReturnRows(rowsInMockDatabase)
+
+		// define various secrets as test cases to show failure modes
+		secret := corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secretName,
+				Namespace: namespace,
+			},
+			Data: map[string][]byte{
+				corev1.BasicAuthUsernameKey: []byte("foo_bar"),
+				corev1.BasicAuthPasswordKey: []byte(password),
+			},
+		}
+		secretInDB := corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secretInDBName,
+				Namespace: namespace,
+			},
+			Data: map[string][]byte{
+				corev1.BasicAuthUsernameKey: []byte("role_with_pass"),
+				corev1.BasicAuthPasswordKey: []byte(password),
+			},
+		}
+		secretWithUpdates := corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secretNameWithUpdates,
+				Namespace: namespace,
+			},
+			Data: map[string][]byte{
+				corev1.BasicAuthUsernameKey: []byte("role_to_test1"),
+				corev1.BasicAuthPasswordKey: []byte(password),
+			},
+		}
+		cl := fake.NewClientBuilder().WithScheme(scheme.BuildWithAllKnownScheme()).
+			WithObjects(&secret, &secretWithUpdates, &secretInDB).
+			Build()
 
 		roleSynchronizer = RoleSynchronizer{
 			instance: &fakeInstanceData{
-				Instance: postgres.NewInstance().WithNamespace("default"),
+				Instance: postgres.NewInstance().WithNamespace("vinci-namespace"),
 				db:       db,
 			},
+			client: cl,
 		}
 	})
 
@@ -267,6 +316,145 @@ var _ = Describe("Role synchronizer tests", func() {
 					SecretResourceVersion: "",
 				},
 			}))
+		})
+
+		It("it will update a role password if the password secret resourceVersion changed", func(ctx context.Context) {
+			managedConf := apiv1.ManagedConfiguration{
+				Roles: []apiv1.RoleConfiguration{
+					{
+						Name:            "role_to_test1",
+						Superuser:       true,
+						Inherit:         ptr.To(true),
+						Comment:         "This is a role to test with",
+						ConnectionLimit: -1,
+						PasswordSecret: &api.LocalObjectReference{
+							Name: secretNameWithUpdates,
+						},
+					},
+				},
+			}
+			var secret corev1.Secret
+			Expect(roleSynchronizer.client.Get(ctx,
+				client.ObjectKey{Namespace: namespace, Name: secretName},
+				&secret)).To(Succeed())
+			mock.ExpectBegin()
+			mock.ExpectExec(wantedLogStatementSuppressionStmt).
+				WillReturnResult(sqlmock.NewResult(0, 1))
+			mock.ExpectExec(wantedLogPreventionStmt).
+				WillReturnResult(sqlmock.NewResult(0, 1))
+			alterStmt := fmt.Sprintf(
+				"ALTER ROLE \"%s\"  NOBYPASSRLS NOCREATEDB NOCREATEROLE INHERIT NOLOGIN NOREPLICATION SUPERUSER "+
+					"CONNECTION LIMIT -1 PASSWORD '%s'",
+				"role_to_test1", password)
+			mock.ExpectExec(alterStmt).WillReturnResult(sqlmock.NewResult(2, 3))
+			rows := mock.NewRows([]string{"xmin"}).AddRow("11")
+			mock.ExpectCommit()
+			lastTransactionQuery := "SELECT xmin FROM pg_catalog.pg_authid WHERE rolname = $1"
+			mock.ExpectQuery(lastTransactionQuery).WithArgs("role_to_test1").WillReturnRows(rows)
+			_, _, err := roleSynchronizer.synchronizeRoles(ctx, db, &managedConf, map[string]apiv1.PasswordState{
+				"role_to_test1": {
+					TransactionID:         11, // defined in the mock query to the DB above
+					SecretResourceVersion: "1" + secret.ResourceVersion,
+				},
+			})
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+
+		It("it will update a role password if the password was changed in the DB", func(ctx context.Context) {
+			managedConf := apiv1.ManagedConfiguration{
+				Roles: []apiv1.RoleConfiguration{
+					{
+						Name:            "role_to_test1",
+						Superuser:       true,
+						Inherit:         ptr.To(true),
+						Comment:         "This is a role to test with",
+						ConnectionLimit: -1,
+						PasswordSecret: &api.LocalObjectReference{
+							Name: secretNameWithUpdates,
+						},
+					},
+				},
+			}
+			var secret corev1.Secret
+			Expect(roleSynchronizer.client.Get(ctx,
+				client.ObjectKey{Namespace: namespace, Name: secretName},
+				&secret)).To(Succeed())
+			mock.ExpectBegin()
+			mock.ExpectExec(wantedLogStatementSuppressionStmt).
+				WillReturnResult(sqlmock.NewResult(0, 1))
+			mock.ExpectExec(wantedLogPreventionStmt).
+				WillReturnResult(sqlmock.NewResult(0, 1))
+			alterStmt := fmt.Sprintf(
+				"ALTER ROLE \"%s\"  NOBYPASSRLS NOCREATEDB NOCREATEROLE INHERIT NOLOGIN NOREPLICATION SUPERUSER "+
+					"CONNECTION LIMIT -1 PASSWORD '%s'",
+				"role_to_test1", password)
+			mock.ExpectExec(alterStmt).WillReturnResult(sqlmock.NewResult(2, 3))
+			mock.ExpectCommit()
+			// xmin set to 12 where the old value was 11
+			rows := mock.NewRows([]string{"xmin"}).AddRow("13")
+			lastTransactionQuery := "SELECT xmin FROM pg_catalog.pg_authid WHERE rolname = $1"
+			mock.ExpectQuery(lastTransactionQuery).WithArgs("role_to_test1").WillReturnRows(rows)
+			_, _, err := roleSynchronizer.synchronizeRoles(ctx, db, &managedConf, map[string]apiv1.PasswordState{
+				"role_to_test1": {
+					TransactionID:         12, // defined in the mock query to the DB above
+					SecretResourceVersion: secret.ResourceVersion,
+				},
+			})
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+
+		It("it will not update a role password if role is in sync with the DB", func(ctx context.Context) {
+			validUntil := metav1.NewTime(testDate)
+			managedConf := apiv1.ManagedConfiguration{
+				Roles: []apiv1.RoleConfiguration{
+					{
+						Name:    "role_with_pass",
+						Ensure:  apiv1.EnsurePresent,
+						Inherit: ptr.To(true),
+						PasswordSecret: &api.LocalObjectReference{
+							Name: secretInDBName,
+						},
+						ValidUntil:      &validUntil,
+						ConnectionLimit: -1,
+					},
+				},
+			}
+			var secret corev1.Secret
+			Expect(roleSynchronizer.client.Get(ctx,
+				client.ObjectKey{Namespace: namespace, Name: secretInDBName},
+				&secret)).To(Succeed())
+			_, _, err := roleSynchronizer.synchronizeRoles(ctx, db, &managedConf, map[string]apiv1.PasswordState{
+				"role_with_pass": {
+					TransactionID:         11,
+					SecretResourceVersion: secret.ResourceVersion,
+				},
+			})
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+
+		It("it will not update a role password if the secret cannot be retrieved", func(ctx context.Context) {
+			managedConf := apiv1.ManagedConfiguration{
+				Roles: []apiv1.RoleConfiguration{
+					{
+						Name:            "role_to_test1",
+						Superuser:       true,
+						Inherit:         ptr.To(true),
+						Comment:         "This is a role to test with",
+						ConnectionLimit: -1,
+						PasswordSecret: &api.LocalObjectReference{
+							Name: "not-findable",
+						},
+					},
+				},
+			}
+			_, _, err := roleSynchronizer.synchronizeRoles(ctx, db, &managedConf, map[string]apiv1.PasswordState{
+				"role_to_test1": {
+					TransactionID:         11, // defined in the mock query to the DB above
+					SecretResourceVersion: "11",
+				},
+			})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to get password secret"))
 		})
 
 		It("it will ignore ensure:absent roles in spec missing from DB", func(ctx context.Context) {
@@ -727,7 +915,7 @@ var (
 	password = rand.String(12)
 )
 
-var _ = DescribeTable("role secrets test",
+var _ = DescribeTable("getPassword test",
 	func(
 		roleConfig *apiv1.RoleConfiguration,
 		expectedResult passwordSecret,
@@ -799,7 +987,7 @@ var _ = DescribeTable("role secrets test",
 		passwordSecret{},
 		false,
 	),
-	Entry("Cannot extract credentials if role's secretName does not match a secret",
+	Entry("Throws error if role's secretName does not match a secret",
 		&apiv1.RoleConfiguration{
 			Name: userName,
 			PasswordSecret: &apiv1.LocalObjectReference{
@@ -807,7 +995,7 @@ var _ = DescribeTable("role secrets test",
 			},
 		},
 		passwordSecret{},
-		false,
+		true,
 	),
 	Entry("Throws error if secret username does not match role name",
 		&apiv1.RoleConfiguration{

--- a/internal/management/controller/roles/runnable_test.go
+++ b/internal/management/controller/roles/runnable_test.go
@@ -460,6 +460,38 @@ var _ = Describe("Role synchronizer tests", func() {
 			Expect(unreconciled["role_to_test1"][0]).To(ContainSubstring("failed to get password secret"))
 		})
 
+		It("it will surface a missing-secret error even when the role would otherwise be in sync",
+			func(ctx context.Context) {
+				managedConf := apiv1.ManagedConfiguration{
+					Roles: []apiv1.RoleConfiguration{
+						{
+							Name:            "role_to_test1",
+							Superuser:       true,
+							Inherit:         ptr.To(true),
+							Comment:         "This is a role to test with",
+							ConnectionLimit: -1,
+							PasswordSecret: &api.LocalObjectReference{
+								Name: "not-findable",
+							},
+						},
+					},
+				}
+				// The role has the same TransactionID as the DB and no
+				// previously-stored SecretResourceVersion, so the password-diff
+				// heuristic alone would classify it as Reconciled. We still
+				// expect the missing secret to surface in the unreconciled map
+				// because the spec references a secret that does not exist.
+				_, unreconciled, err := roleSynchronizer.synchronizeRoles(ctx, db, &managedConf, map[string]apiv1.PasswordState{
+					"role_to_test1": {
+						TransactionID: 11, // matches the mock DB row's xmin
+					},
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(unreconciled).To(HaveLen(1))
+				Expect(unreconciled["role_to_test1"]).To(HaveLen(1))
+				Expect(unreconciled["role_to_test1"][0]).To(ContainSubstring("failed to get password secret"))
+			})
+
 		It("it will ignore ensure:absent roles in spec missing from DB", func(ctx context.Context) {
 			managedConf := apiv1.ManagedConfiguration{
 				Roles: []apiv1.RoleConfiguration{

--- a/internal/management/utils/secrets.go
+++ b/internal/management/utils/secrets.go
@@ -30,13 +30,15 @@ import (
 // GetUserPasswordFromSecret gets the username and the password from
 // a secret of type basic-auth
 func GetUserPasswordFromSecret(secret *corev1.Secret) (string, string, error) {
-	if _, ok := secret.Data["username"]; !ok {
+	if _, ok := secret.Data[corev1.BasicAuthUsernameKey]; !ok {
 		return "", "", fmt.Errorf("username key doesn't exist inside the secret")
 	}
 
-	if _, ok := secret.Data["password"]; !ok {
+	if _, ok := secret.Data[corev1.BasicAuthPasswordKey]; !ok {
 		return "", "", fmt.Errorf("password key doesn't exist inside the secret")
 	}
 
-	return string(secret.Data["username"]), string(secret.Data["password"]), nil
+	return string(secret.Data[corev1.BasicAuthUsernameKey]),
+		string(secret.Data[corev1.BasicAuthPasswordKey]),
+		nil
 }


### PR DESCRIPTION
Closes #9677 

- Prevents deleting a role's password when the passwordSecret is not found.
  The affected role is not updated (or created)
- Applies all role actions and collects errors, rather than cancel out of reconciliation
  on the first error

Overrides a previous incomplete fix which is inactive #9785