### PR TITLE
chore: add OpenSSF baseline scanner GitHub action 

### DIFF
--- a/.github/workflows/osps_security_assessment.yml
+++ b/.github/workflows/osps_security_assessment.yml
@@ -15,20 +15,20 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       
       - name: Open Source Project Security Baseline Scanner
-        uses: revanite-io/osps-baseline-action@v1.0.0
+        uses: revanite-io/osps-baseline-action@ffcef1f33b6ee5b916c7e357e4ae1481b99b46b6 # v1.0.0
         with:
-            owner: ${{ github.repository_owner }}
-            repo: ${{ github.event.repository.name }}
-            token: ${{ secrets.GITHUB_TOKEN }}
-            catalog: "osps-baseline"
-            upload-sarif: "true"
+          owner: ${{ github.repository_owner }}
+          repo: ${{ github.event.repository.name }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          catalog: "osps-baseline"
+          upload-sarif: "true"
       
       - name: Upload Assessment Results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: osps-assessment-results-${{ github.run_number }}
           path: evaluation_results/

--- a/.github/workflows/osps_security_assessment.yml
+++ b/.github/workflows/osps_security_assessment.yml
@@ -1,0 +1,35 @@
+name: OSPS Security Assessment
+
+on:
+  schedule:
+    - cron: "0 9 * * 1"  # Weekly on Mondays at 9 AM UTC
+  workflow_dispatch:  # Allow manual triggering
+
+jobs:
+  osps-assessment:
+    runs-on: ubuntu-24.04
+    
+    permissions:
+      contents: read
+      security-events: write  # Required for SARIF upload
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      
+      - name: Open Source Project Security Baseline Scanner
+        uses: revanite-io/osps-baseline-action@v1.0.0
+        with:
+            owner: ${{ github.repository_owner }}
+            repo: ${{ github.event.repository.name }}
+            token: ${{ secrets.GITHUB_TOKEN }}
+            catalog: "osps-baseline"
+            upload-sarif: "true"
+      
+      - name: Upload Assessment Results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: osps-assessment-results-${{ github.run_number }}
+          path: evaluation_results/
+          retention-days: 30


### PR DESCRIPTION
Integrate the OpenSSF Baseline Scanner GitHub Action into our pipeline to ensure the workflow returns zero failures.

Closes #10060 