### PR TITLE
ci(release): sign operator YAML manifest during release

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -81,13 +81,26 @@ jobs:
             --out-file /src/release_notes.md \
             /src/docs/src/${{ env.FILE }}
       -
+        name: Install cosign
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3
+        # See https://github.blog/security/supply-chain-security/safeguard-container-signing-capability-actions/
+        # and https://github.com/actions/starter-workflows/blob/main/ci/docker-publish.yml for more details on
+        # how to use cosign.
+      -
+        name: Sign yaml files
+        run: |
+          cosign sign-blob releases/cnpg-${{ env.VERSION }}.yaml \
+          --bundle releases/cnpg-${{ env.VERSION }}.sigstore.json --yes
+      -
         name: Release
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2
         with:
           body_path: release_notes.md
           draft: false
           name: v${{ env.TAG }}
-          files: releases/cnpg-${{ env.VERSION }}.yaml
+          files: |
+            releases/cnpg-${{ env.VERSION }}.yaml
+            releases/cnpg-${{ env.VERSION }}.sigstore.json
           make_latest: ${{ needs.check-version.outputs.is_latest == 'true' && needs.check-version.outputs.is_stable == 'true' }}
           prerelease: ${{ needs.check-version.outputs.is_stable == 'false' || needs.check-version.outputs.is_rc == 'true' }}
         env:

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -58,6 +58,7 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: write
+      id-token: write
     needs:
       - check-version
     steps:

--- a/.wordlist-en-custom.txt
+++ b/.wordlist-en-custom.txt
@@ -50,6 +50,7 @@ BootstrapConfiguration
 BootstrapInitDB
 BootstrapPgBaseBackup
 BootstrapRecovery
+Buildx
 Burstable
 ByStatus
 CAs
@@ -294,6 +295,7 @@ OCI
 OLAP
 OLTP
 OOM
+OSPS
 OU
 ObjectMeta
 OnlineConfiguration
@@ -301,6 +303,7 @@ OnlineUpdateEnabled
 OnlineUpgrading
 OpenBao
 OpenID
+OpenSSF
 OpenSSL
 OpenShift
 Openshift

--- a/README.md
+++ b/README.md
@@ -77,6 +77,34 @@ CloudNativePG manages additional Kubernetes resources to enhance PostgreSQL
 management, including: `Backup`, `ClusterImageCatalog`, `Database`,
 `ImageCatalog`, `Pooler`, `Publication`, `ScheduledBackup`, and `Subscription`.
 
+## Verifying releases
+
+During the release process CloudNativePG uses [cosign](https://www.sigstore.dev/)
+to sign some of the assest's like the YAML and container images, these can be verified
+with the following commands:
+
+### Container images
+
+The following command requires only the image to be verified
+```shell
+cosign verify OPERATOR_IMAGE \
+  --certificate-identity-regexp="^https://github.com/cloudnative-pg/cloudnative-pg/" \
+  --certificate-oidc-issuer="https://token.actions.githubusercontent.com"
+```
+
+### Operator YAML deployment
+
+This step requires to have the `.yaml` file and the `sigstore.json` file from the
+release page:
+
+```shell
+cosign verify-blob cnpg-{version}.yaml \
+--bundle cnpg-{version}.sigstore.json \
+--certificate-identity "https://github.com/cloudnative-pg/cloudnative-pg/.github/workflows/release-publish.yml@refs/heads/main" \
+--certificate-oidc-issuer "https://token.actions.githubusercontent.com"
+```
+
+
 ## Out of Scope
 
 - **Kubernetes only:** CloudNativePG is dedicated to vanilla Kubernetes

--- a/README.md
+++ b/README.md
@@ -77,34 +77,6 @@ CloudNativePG manages additional Kubernetes resources to enhance PostgreSQL
 management, including: `Backup`, `ClusterImageCatalog`, `Database`,
 `ImageCatalog`, `Pooler`, `Publication`, `ScheduledBackup`, and `Subscription`.
 
-## Verifying releases
-
-During the release process CloudNativePG uses [cosign](https://www.sigstore.dev/)
-to sign some of the assest's like the YAML and container images, these can be verified
-with the following commands:
-
-### Container images
-
-The following command requires only the image to be verified
-```shell
-cosign verify OPERATOR_IMAGE \
-  --certificate-identity-regexp="^https://github.com/cloudnative-pg/cloudnative-pg/" \
-  --certificate-oidc-issuer="https://token.actions.githubusercontent.com"
-```
-
-### Operator YAML deployment
-
-This step requires to have the `.yaml` file and the `sigstore.json` file from the
-release page:
-
-```shell
-cosign verify-blob cnpg-{version}.yaml \
---bundle cnpg-{version}.sigstore.json \
---certificate-identity "https://github.com/cloudnative-pg/cloudnative-pg/.github/workflows/release-publish.yml@refs/heads/main" \
---certificate-oidc-issuer "https://token.actions.githubusercontent.com"
-```
-
-
 ## Out of Scope
 
 - **Kubernetes only:** CloudNativePG is dedicated to vanilla Kubernetes

--- a/docs/src/installation_upgrade.md
+++ b/docs/src/installation_upgrade.md
@@ -387,7 +387,7 @@ Run the following command:
 cosign verify-blob \
   cnpg-{version}.yaml \
   --bundle cnpg-{version}.sigstore.json \
-  --certificate-identity "https://github.com/cloudnative-pg/cloudnative-pg/.github/workflows/release-publish.yml@refs/heads/main" \
+  --certificate-identity-regexp "^https://github.com/cloudnative-pg/cloudnative-pg/.github/workflows/release-publish.yml@refs/tags/v" \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
 ```
 

--- a/docs/src/installation_upgrade.md
+++ b/docs/src/installation_upgrade.md
@@ -32,7 +32,7 @@ kubectl rollout status deployment \
 ### Using the `cnpg` plugin for `kubectl`
 
 You can use the `cnpg` plugin to override the default configuration options
-that are in the static manifests. 
+that are in the static manifests.
 
 For example, to generate the default latest manifest but change the watch
 namespaces to only be a specific namespace, you could run:
@@ -44,7 +44,7 @@ kubectl cnpg install generate \
 ```
 
 Please refer to ["`cnpg` plugin"](./kubectl-plugin.md#generation-of-installation-manifests) documentation
-for a more comprehensive example. 
+for a more comprehensive example.
 
 :::warning
     If you are deploying CloudNativePG on GKE and get an error (`... failed to
@@ -358,3 +358,92 @@ that apply declarative changes to enable or disable hibernation.
 The `hibernate status` command has been removed, as its purpose is now
 fulfilled by the standard `status` command.
 
+## Verifying release assets
+
+CloudNativePG cryptographically signs all official release assets. Verifying these
+assets ensures the software has not been tampered with and was produced by our
+official, automated build pipeline.
+
+:::info
+Refer to the ["Release integrity and supply chain" section](security.md#release-integrity-and-supply-chain)
+for more information.
+:::
+
+### Prerequisites
+
+- **Signature verification:** [cosign](https://github.com/sigstore/cosign) CLI
+- **SBOM and Provenance:** [Docker Buildx](https://docs.docker.com/build/install-buildx/)
+  (included in Docker Desktop and modern Docker versions)
+
+### Verifying the Operator YAML Deployment
+
+When installing via a direct YAML manifest, you should verify the manifest file
+using the corresponding bundle (the `.sigstore.json` file) provided on the
+[GitHub Release page](https://github.com/cloudnative-pg/cloudnative-pg/releases).
+
+Run the following command:
+
+```bash
+cosign verify-blob \
+  cnpg-{version}.yaml \
+  --bundle cnpg-{version}.sigstore.json \
+  --certificate-identity "https://github.com/cloudnative-pg/cloudnative-pg/.github/workflows/release-publish.yml@refs/heads/main" \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
+```
+
+### Verifying the operator container images
+
+Run the following command to verify the signature of the CloudNativePG operator
+images:
+
+```bash
+cosign verify ghcr.io/cloudnative-pg/cloudnative-pg:{tag} \
+  --certificate-identity-regexp="^https://github.com/cloudnative-pg/cloudnative-pg/" \
+  --certificate-oidc-issuer="https://token.actions.githubusercontent.com"
+```
+
+We provide OCI attestations for full transparency. To inspect the Software Bill
+of Materials (SBOM) or build provenance, use the `docker buildx imagetools`
+command:
+
+To view the Software Bill of Materials (SBOM) in SPDX format:
+
+```bash
+docker buildx imagetools inspect ghcr.io/cloudnative-pg/cloudnative-pg:{tag} \
+  --format '{{ json (index .SBOM "linux/amd64").SPDX }}'
+```
+
+To inspect the SLSA Provenance (build details):
+
+```bash
+docker buildx imagetools inspect ghcr.io/cloudnative-pg/cloudnative-pg:{tag} \
+  --format '{{ json (index .Provenance "linux/amd64").SLSA }}'
+```
+
+### Verifying PostgreSQL operand images
+
+CloudNativePG maintains container images for all supported PostgreSQL versions
+as part of the [`postgres-containers` project](https://github.com/cloudnative-pg/postgres-containers)
+(also called operand images).
+
+To verify the signature of a specific operand image:
+
+```bash
+cosign verify ghcr.io/cloudnative-pg/postgresql:{tag} \
+  --certificate-identity-regexp="^https://github.com/cloudnative-pg/postgres-containers/" \
+  --certificate-oidc-issuer="https://token.actions.githubusercontent.com"
+```
+
+To view the Software Bill of Materials (SBOM) in SPDX format:
+
+```bash
+docker buildx imagetools inspect ghcr.io/cloudnative-pg/postgresql:{tag} \
+  --format '{{ json (index .SBOM "linux/amd64").SPDX }}'
+```
+
+To inspect the SLSA Provenance (Build details):
+
+```bash
+docker buildx imagetools inspect ghcr.io/cloudnative-pg/postgresql:{tag} \
+  --format '{{ json (index .Provenance "linux/amd64").SLSA }}'
+```

--- a/docs/src/installation_upgrade.md
+++ b/docs/src/installation_upgrade.md
@@ -398,7 +398,7 @@ images:
 
 ```bash
 cosign verify ghcr.io/cloudnative-pg/cloudnative-pg:{tag} \
-  --certificate-identity-regexp="^https://github.com/cloudnative-pg/cloudnative-pg/" \
+  --certificate-identity-regexp="^https://github.com/cloudnative-pg/cloudnative-pg/.github/workflows/release-publish.yml@refs/tags/v" \
   --certificate-oidc-issuer="https://token.actions.githubusercontent.com"
 ```
 

--- a/docs/src/installation_upgrade.md
+++ b/docs/src/installation_upgrade.md
@@ -361,8 +361,8 @@ fulfilled by the standard `status` command.
 ## Verifying release assets
 
 CloudNativePG cryptographically signs all official release assets. Verifying these
-assets ensures the software has not been tampered with and was produced by our
-official, automated build pipeline.
+signatures ensures the assets originate from the official repository and were
+published through our automated release workflow.
 
 :::info
 Refer to the ["Release integrity and supply chain" section](security.md#release-integrity-and-supply-chain)

--- a/docs/src/security.md
+++ b/docs/src/security.md
@@ -135,7 +135,7 @@ command with the image digest:
 
 ```shell
 cosign verify ghcr.io/cloudnative-pg/cloudnative-pg@sha256:<DIGEST> \
-  --certificate-identity-regexp="^https://github.com/cloudnative-pg/cloudnative-pg/" \
+  --certificate-identity-regexp="^https://github.com/cloudnative-pg/cloudnative-pg/.github/workflows/release-publish.yml@refs/tags/v" \
   --certificate-oidc-issuer="https://token.actions.githubusercontent.com"
 ```
 

--- a/docs/src/security.md
+++ b/docs/src/security.md
@@ -7,8 +7,10 @@ title: Security
 # Security
 <!-- SPDX-License-Identifier: CC-BY-4.0 -->
 
-This section contains information about security for CloudNativePG,
-that are analyzed at 3 different layers: Code, Container and Cluster.
+CloudNativePG is designed to be secure by default, following the "Least Privilege"
+principle across all layers of the stack. This document outlines our security
+governance, supply chain integrity, and the technical controls analyzed at three
+distinct layers: Code, Container, and Cluster.
 
 :::warning
     The information contained in this page must not exonerate you from
@@ -22,6 +24,33 @@ that are analyzed at 3 different layers: Code, Container and Cluster.
     blog article to get a better understanding and context of the approach EDB
     has taken with security in CloudNativePG.
 :::
+
+---
+
+## Governance and Trust
+
+### Vulnerability Reporting
+
+:::important
+Please do not report security vulnerabilities through public GitHub issues.
+:::
+
+CloudNativePG follows a coordinated disclosure model. For instructions on how to
+report a vulnerability privately, please refer to our
+[Security Policy on GitHub](https://github.com/cloudnative-pg/cloudnative-pg/blob/main/SECURITY.md).
+
+### Release Integrity and Supply Chain
+
+CloudNativePG follows the [OpenSSF Software Producer Security (OSPS) Baseline](https://baseline.openssf.org/).
+All official release assets, including Kubernetes manifests and container
+images, are cryptographically signed and verifiable.
+
+For quick-start instructions on verifying these assets during installation,
+see the [Installation Guide](installation_upgrade.md#verifying-release-assets).
+Detailed information on our [Signatures](#image-signatures) and [Attestations](#attestations)
+can be found below.
+
+---
 
 ## Code
 
@@ -381,9 +410,9 @@ privileges. Proper permissions must be assigned by the Kubernetes platform
 and/or administrators. The PostgreSQL containers run with a read-only root
 filesystem (i.e. no writable layer).
 
-The operator manages the setting of security contexts for all pods and 
-containers of a PostgreSQL cluster. The [Seccomp Profile](https://kubernetes.io/docs/tutorials/security/seccomp/) 
-to be used for the PostgreSQL containers can be configured with the 
+The operator manages the setting of security contexts for all pods and
+containers of a PostgreSQL cluster. The [Seccomp Profile](https://kubernetes.io/docs/tutorials/security/seccomp/)
+to be used for the PostgreSQL containers can be configured with the
 `spec.seccompProfile` section of the `Cluster` resource. If this section is left
 blank, the containers will use a seccompProfile `Type` of `RuntimeDefault`, that
 is, the container runtime default.


### PR DESCRIPTION
The release workflow was not signing the cnpg-{version}.yaml manifest
with cosign. Added blob signing with Sigstore bundle upload and
documented verification steps for all release assets (YAML, operator
images, operand images).

Closes #10065 