### PR TITLE
test(e2e): spread pods across nodes with topology spread constraint

### DIFF
--- a/tests/e2e/asserts_test.go
+++ b/tests/e2e/asserts_test.go
@@ -2685,6 +2685,9 @@ func CreateResourcesFromFileWithError(namespace, sampleFilePath string) error {
 		return wrapErr(err)
 	}
 	for _, obj := range objects {
+		if cluster, ok := obj.(*apiv1.Cluster); ok {
+			clusterutils.AddTopologySpreadConstraint(cluster)
+		}
 		_, err := objectsutils.Create(env.Ctx, env.Client, obj)
 		if err != nil {
 			return wrapErr(err)

--- a/tests/e2e/cluster_major_upgrade_test.go
+++ b/tests/e2e/cluster_major_upgrade_test.go
@@ -452,6 +452,7 @@ var _ = Describe("Postgres Major Upgrade", Label(tests.LabelPostgresMajorUpgrade
 		}
 
 		cluster := scenario.startingCluster
+		clusterutils.AddTopologySpreadConstraint(cluster)
 		err := env.Client.Create(env.Ctx, cluster)
 		Expect(err).NotTo(HaveOccurred())
 		AssertClusterIsReady(cluster.Namespace, cluster.Name, testTimeouts[timeouts.ClusterIsReady],

--- a/tests/e2e/configuration_update_test.go
+++ b/tests/e2e/configuration_update_test.go
@@ -273,6 +273,7 @@ var _ = Describe("Configuration update", Label(tests.LabelClusterMetadata), func
 			cluster := generateBaseCluster(namespace)
 			cluster.Spec.ImageName = env.MinimalImageName(targetTag)
 			cluster.Spec.PrimaryUpdateMethod = apiv1.PrimaryUpdateMethodSwitchover
+			clusterutils.AddTopologySpreadConstraint(cluster)
 			err = env.Client.Create(env.Ctx, cluster)
 			Expect(err).NotTo(HaveOccurred())
 			AssertClusterIsReady(cluster.Namespace, cluster.Name, testTimeouts[timeouts.ClusterIsReady], env)
@@ -468,6 +469,7 @@ var _ = Describe("Configuration update", Label(tests.LabelClusterMetadata), func
 			cluster := generateBaseCluster(namespace)
 			cluster.Spec.ImageName = env.MinimalImageName(targetTag)
 			cluster.Spec.PrimaryUpdateMethod = apiv1.PrimaryUpdateMethodRestart
+			clusterutils.AddTopologySpreadConstraint(cluster)
 			err = env.Client.Create(env.Ctx, cluster)
 			Expect(err).NotTo(HaveOccurred())
 			AssertClusterIsReady(cluster.Namespace, cluster.Name, testTimeouts[timeouts.ClusterIsReady], env)

--- a/tests/e2e/imagevolume_extensions_test.go
+++ b/tests/e2e/imagevolume_extensions_test.go
@@ -347,6 +347,7 @@ var _ = Describe("ImageVolume Extensions", Label(tests.LabelImageVolumeExtension
 			}
 			err := env.Client.Create(env.Ctx, catalog)
 			Expect(err).ToNot(HaveOccurred())
+			clusterutils.AddTopologySpreadConstraint(cluster)
 			err = env.Client.Create(env.Ctx, cluster)
 			Expect(err).ToNot(HaveOccurred())
 			AssertClusterIsReady(namespace, clusterName, testTimeouts[timeouts.ClusterIsReady], env)

--- a/tests/e2e/rolling_update_test.go
+++ b/tests/e2e/rolling_update_test.go
@@ -379,6 +379,7 @@ var _ = Describe("Rolling updates", Label(tests.LabelPostgresConfiguration), fun
 		clusterName := cluster.Name
 		err := env.Client.Create(env.Ctx, catalog)
 		Expect(err).ToNot(HaveOccurred())
+		clusterutils.AddTopologySpreadConstraint(cluster)
 		err = env.Client.Create(env.Ctx, cluster)
 		Expect(err).ToNot(HaveOccurred())
 		AssertClusterIsReady(namespace, clusterName, testTimeouts[timeouts.ClusterIsReady], env)

--- a/tests/utils/clusterutils/cluster.go
+++ b/tests/utils/clusterutils/cluster.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -223,6 +224,26 @@ func GetFirstReplica(
 		return nil, fmt.Errorf("no replicas found")
 	}
 	return &podList.Items[0], nil
+}
+
+// AddTopologySpreadConstraint appends a soft topology spread constraint
+// that distributes all CNPG-managed pods (instances and jobs) across
+// nodes. Call this on E2E clusters to prevent co-location of concurrent
+// test workloads.
+func AddTopologySpreadConstraint(cluster *apiv1.Cluster) {
+	cluster.Spec.TopologySpreadConstraints = append(
+		cluster.Spec.TopologySpreadConstraints,
+		corev1.TopologySpreadConstraint{
+			MaxSkew:           1,
+			TopologyKey:       "kubernetes.io/hostname",
+			WhenUnsatisfiable: corev1.ScheduleAnyway,
+			LabelSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					utils.KubernetesAppManagedByLabelName: utils.ManagerName,
+				},
+			},
+		},
+	)
 }
 
 // ScaleSize scales a cluster to the requested size


### PR DESCRIPTION
Add a TopologySpreadConstraint to all E2E test clusters so that CNPG-managed pods (including initdb/join jobs) are spread across available nodes. Without this, concurrent test clusters' job pods can co-locate on a single node, causing I/O contention and timeouts. Since PVCs with WaitForFirstConsumer bind to the job's node, this co-location also locks subsequent instance pods there, defeating instance-level anti-affinity.

The constraint uses ScheduleAnyway with maxSkew=1, matching all pods with the app.kubernetes.io/managed-by=cloudnative-pg label, which covers both instance pods and job pods across all clusters.

Closes #10068 