### PR TITLE
ci(e2e): run probe lag tests serially to avoid I/O saturation

### DIFF
--- a/tests/e2e/syncreplicas_test.go
+++ b/tests/e2e/syncreplicas_test.go
@@ -366,7 +366,7 @@ var _ = Describe("Synchronous Replicas", Label(tests.LabelReplication), func() {
 			})
 		})
 
-		Context("Lag-control in startup & readiness probes", func() {
+		Context("Lag-control in startup & readiness probes", Serial, func() {
 			var (
 				namespace         string
 				namespacePrefix   string


### PR DESCRIPTION
The lag-control readiness/startup probe tests generate ~1GB of data each, causing severe I/O pressure when running concurrently with other tests. This was observed causing 63.68% iowait on AKS nodes, leading to unrelated test timeouts (e.g. PostGIS major upgrade).

Mark the "Lag-control in startup & readiness probes" context as `Serial` so these I/O-heavy tests run in isolation.

Closes #10071 