### PR TITLE
chore: enable SBOMs within GoReleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -125,7 +125,9 @@ changelog:
   disable: true
 
 sboms:
-  - disable: false
+  - artifacts: archive
+  - id: packages
+    artifacts: package
 
 signs:
   - artifacts: all

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -124,6 +124,9 @@ snapshot:
 changelog:
   disable: true
 
+sboms:
+  - disable: false
+
 signs:
   - artifacts: all
     args: ["--batch", "-u", "{{ .Env.GPG_FINGERPRINT }}", "--output", "${signature}", "--detach-sign", "${artifact}"]


### PR DESCRIPTION
Enable GoReleaser SBOM generation for archives and packages (RPM/DEB), producing SPDX JSON SBOMs via syft. The existing `signs` configuration (`artifacts: all`) will automatically sign the generated SBOMs.

Closes #10073 