### PR TITLE
chore: add trivy scanner for CI and code

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -618,6 +618,7 @@ jobs:
 
       - name: Run Trivy to check Docker image for vulnerabilities
         uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # 0.33.1
+        if: env.PUSH == 'true'
         id: trivy
         continue-on-error: true
         with:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -623,8 +623,7 @@ jobs:
         with:
           version: 'latest'
           image-ref: ${{ env.CONTROLLER_IMG }}
-          format: 'sarif'
-          output: 'trivy-results.sarif'
+          format: 'table'
 
       - name: Install cosign
         if: |

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -617,7 +617,7 @@ jobs:
           args: --severity-threshold=high --file=Dockerfile --username=${{ env.REGISTRY_USER }} --password=${{ env.REGISTRY_PASSWORD }}
 
       - name: Run Trivy to check Docker image for vulnerabilities
-        uses: aquasecurity/trivy-action@0.33.1
+        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # 0.33.1
         id: trivy
         continue-on-error: true
         with:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -616,6 +616,16 @@ jobs:
           image: ${{ env.CONTROLLER_IMG }}
           args: --severity-threshold=high --file=Dockerfile --username=${{ env.REGISTRY_USER }} --password=${{ env.REGISTRY_PASSWORD }}
 
+      - name: Run Trivy to check Docker image for vulnerabilities
+        uses: aquasecurity/trivy-action@0.33.1
+        id: trivy
+        continue-on-error: true
+        with:
+          version: 'latest'
+          image-ref: ${{ env.CONTROLLER_IMG }}
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+
       - name: Install cosign
         if: |
           env.SIGN_IMAGES == 'true' &&

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run Trivy vulnerability scanner in fs mode
         uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # 0.33.1
@@ -26,6 +26,6 @@ jobs:
           severity: 'CRITICAL'
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v1
+        uses: github/codeql-action/upload-sarif@89a39a4e59826350b863aa6b6252a07ad50cf83e # v4
         with:
           sarif_file: 'trivy-results-fs.sarif'

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -17,16 +17,13 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Run Trivy vulnerability scanner in fs mode
-        uses: anandg112/trivy-action@feat/add-skip-dirs-option
+        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # 0.33.1
         with:
           scan-type: 'fs'
-#          scan-ref: '.'
           ignore-unfixed: true
-          format: 'template'
-          template: '@/contrib/sarif.tpl'
+          format: 'sarif'
           output: 'trivy-results-fs.sarif'
           severity: 'CRITICAL'
-          skip-dirs: "ignored-dir"
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v1

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,0 +1,34 @@
+name: Trivy Scanning
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  Trivy-Scan:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Run Trivy vulnerability scanner in fs mode
+        uses: anandg112/trivy-action@feat/add-skip-dirs-option
+        with:
+          scan-type: 'fs'
+#          scan-ref: '.'
+          ignore-unfixed: true
+          format: 'template'
+          template: '@/contrib/sarif.tpl'
+          output: 'trivy-results-fs.sarif'
+          severity: 'CRITICAL'
+          skip-dirs: "ignored-dir"
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v1
+        with:
+          sarif_file: 'trivy-results-fs.sarif'

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -11,6 +11,8 @@ permissions: read-all
 jobs:
   Trivy-Scan:
     runs-on: ubuntu-24.04
+    permissions:
+      security-events: write
 
     steps:
       - name: Checkout code

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -9,7 +9,7 @@ on:
 permissions: read-all
 
 jobs:
-  Trivy-Scan:
+  trivy-scan:
     runs-on: ubuntu-24.04
     permissions:
       security-events: write


### PR DESCRIPTION
Add Trivy vulnerability scanner as a standalone workflow for filesystem
scanning with SARIF upload to the GitHub Security tab, and as an image
scanner in the CI pipeline with table output in build logs.

Closes #10075 