### PR TITLE
chore(security-insights): OSPS baseline action and asset verification

### DIFF
--- a/.github/security-self-assessment.md
+++ b/.github/security-self-assessment.md
@@ -1,0 +1,23 @@
+# CloudNativePG Security Self-Assessment
+
+This document is the entry point for the CloudNativePG security
+self-assessment. It is referenced from
+[`SECURITY-INSIGHTS.yml`](../SECURITY-INSIGHTS.yml) as the project's
+self-assessment evidence.
+
+The assessment follows the [Gemara](https://github.com/ossf/gemara) model
+(version 1.2.0) and maps capabilities and threats to the FINOS
+[Common Cloud Controls (CCC) Core](https://github.com/finos/common-cloud-controls)
+v2025.10. It is split across two machine-readable catalogs:
+
+- [Threat Catalog](threat-catalog.yaml) (`CNPG.THREATS`): threats specific
+  to operating PostgreSQL clusters on Kubernetes with the CloudNativePG
+  operator, each mapped to the capabilities it affects and to CCC Core.
+- [Capability Catalog](capability-catalog.yaml) (`CNPG.CAPABILITIES`):
+  capabilities the operator provides for managing PostgreSQL clusters,
+  grouped by availability, security, and data management.
+
+Both catalogs are versioned together and are the authoritative source of
+the assessment. This page exists because the Security Insights schema
+records a single self-assessment evidence URL, while the assessment itself
+is maintained as the two catalogs above.

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -113,6 +113,7 @@ jobs:
       shell-script-changed: ${{ steps.filter.outputs.shell-script-changed }}
       go-code-changed: ${{ steps.filter.outputs.go-code-changed }}
       renovate-changed: ${{ steps.filter.outputs.renovate-changed }}
+      security-insights-changed: ${{ steps.filter.outputs.security-insights-changed }}
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
@@ -155,6 +156,9 @@ jobs:
               - '.golangci.yml'
             renovate-changed:
               - '.github/renovate.json5'
+            security-insights-changed:
+              - 'SECURITY-INSIGHTS.yml'
+              - '.github/workflows/continuous-integration.yml'
 
   go-linters:
     name: Run linters
@@ -206,6 +210,30 @@ jobs:
 
       - name: Validate Renovate JSON
         run: npx --yes --package renovate@latest -- renovate-config-validator
+
+  security-insights-linter:
+    name: Security Insights Linter
+    needs:
+      - duplicate_runs
+      - change-triage
+    if: |
+      needs.duplicate_runs.outputs.should_skip != 'true' &&
+      needs.change-triage.outputs.security-insights-changed == 'true'
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Install CUE
+        uses: cue-lang/setup-cue@a93fa358375740cd8b0078f76355512b9208acb1 # v1.0.1
+
+      - name: Validate SECURITY-INSIGHTS.yml against its schema
+        run: |
+          version=$(yq '.header.schema-version' SECURITY-INSIGHTS.yml)
+          curl -sSfL \
+            "https://raw.githubusercontent.com/ossf/security-insights/v${version}/spec/schema.cue" \
+            -o /tmp/si-schema.cue
+          cue vet SECURITY-INSIGHTS.yml /tmp/si-schema.cue -d '#SecurityInsights'
 
   go-vulncheck:
     name: Run govulncheck

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -158,7 +158,6 @@ jobs:
               - '.github/renovate.json5'
             security-insights-changed:
               - 'SECURITY-INSIGHTS.yml'
-              - '.github/workflows/continuous-integration.yml'
 
   go-linters:
     name: Run linters
@@ -224,16 +223,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - name: Install CUE
-        uses: cue-lang/setup-cue@a93fa358375740cd8b0078f76355512b9208acb1 # v1.0.1
-
       - name: Validate SECURITY-INSIGHTS.yml against its schema
-        run: |
-          version=$(yq '.header.schema-version' SECURITY-INSIGHTS.yml)
-          curl -sSfL \
-            "https://raw.githubusercontent.com/ossf/security-insights/v${version}/spec/schema.cue" \
-            -o /tmp/si-schema.cue
-          cue vet SECURITY-INSIGHTS.yml /tmp/si-schema.cue -d '#SecurityInsights'
+        run: make validate-security-insights
 
   go-vulncheck:
     name: Run govulncheck

--- a/Makefile
+++ b/Makefile
@@ -312,6 +312,16 @@ validate-threat-model: ## Validate Gemara threat-model artifacts against the sch
 		vet -c -d '#CapabilityCatalog' \
 		github.com/gemaraproj/gemara@$(GEMARA_VERSION) .github/capability-catalog.yaml
 
+validate-security-insights: ## Validate SECURITY-INSIGHTS.yml against the OSSF Security Insights schema.
+	@version=$$(sed -n 's/^[[:space:]]*schema-version:[[:space:]]*//p' SECURITY-INSIGHTS.yml | head -1); \
+	tmp=$$(mktemp -d); \
+	curl -sSfL \
+		"https://raw.githubusercontent.com/ossf/security-insights/v$${version}/spec/schema.cue" \
+		-o "$$tmp/schema.cue"; \
+	docker run --rm -v $(PWD):/src:Z -v "$$tmp":/schema:Z -w /src cuelang/cue:$(CUE_VERSION) \
+		vet SECURITY-INSIGHTS.yml /schema/schema.cue -d '#SecurityInsights'; \
+	rm -rf "$$tmp"
+
 wordlist-ordered: ## Order the wordlist using sort
 	LANG=C LC_ALL=C sort .wordlist-en-custom.txt > .wordlist-en-custom.txt.new && \
 	mv -f .wordlist-en-custom.txt.new .wordlist-en-custom.txt
@@ -325,7 +335,7 @@ run-govulncheck: govulncheck ## Check if there's any known vulnerabilities with 
 	$(GOVULNCHECK) ./...
 	cd tests && $(GOVULNCHECK) ./...
 
-checks: go-mod-check generate manifests apidoc fmt spellcheck wordlist-ordered woke vet lint run-govulncheck validate-threat-model ## Runs all the checks on the project.
+checks: go-mod-check generate manifests apidoc fmt spellcheck wordlist-ordered woke vet lint run-govulncheck validate-threat-model validate-security-insights ## Runs all the checks on the project.
 
 ##@ Documentation
 

--- a/SECURITY-INSIGHTS.yml
+++ b/SECURITY-INSIGHTS.yml
@@ -219,9 +219,7 @@ repository:
 
     assessments:
       self:
-        evidence:
-          - https://github.com/cloudnative-pg/cloudnative-pg/blob/main/.github/threat-catalog.yaml
-          - https://github.com/cloudnative-pg/cloudnative-pg/blob/main/.github/capability-catalog.yaml
+        evidence: https://github.com/cloudnative-pg/cloudnative-pg/blob/main/.github/security-self-assessment.md
         comment: >-
           Gemara-compatible threat self-assessment covering capabilities
           and threats mapped to FINOS Common Cloud Controls (CCC) Core

--- a/SECURITY-INSIGHTS.yml
+++ b/SECURITY-INSIGHTS.yml
@@ -207,7 +207,7 @@ repository:
           ci: true
           release: true
       - name: OSPS Baseline Scanner
-        type: Policy-as-Code
+        type: other
         rulesets:
           - Maturity Level 2
         results:

--- a/SECURITY-INSIGHTS.yml
+++ b/SECURITY-INSIGHTS.yml
@@ -223,7 +223,7 @@ repository:
 
     assessments:
       self:
-        evidence-url:
+        evidence:
           - https://github.com/cloudnative-pg/cloudnative-pg/blob/main/.github/threat-catalog.yaml
           - https://github.com/cloudnative-pg/cloudnative-pg/blob/main/.github/capability-catalog.yaml
         comment: >-

--- a/SECURITY-INSIGHTS.yml
+++ b/SECURITY-INSIGHTS.yml
@@ -79,7 +79,7 @@ project:
     quickstart-guide: https://cloudnative-pg.io/docs/current/quickstart
     release-process: https://github.com/cloudnative-pg/cloudnative-pg/blob/main/contribute/release_procedure.md
     # OSPS-DO-03.01
-    signature-verification: https://github.com/cloudnative-pg/postgres-containers?tab=readme-ov-file#security
+    signature-verification: https://cloudnative-pg.io/docs/devel/installation_upgrade/#verifying-release-assets
     # OSPS-DO-04.01, OSPS-DO-05.01
     support-policy: https://cloudnative-pg.io/docs/current/supported_releases
 
@@ -206,6 +206,20 @@ repository:
           adhoc: false
           ci: true
           release: true
+      - name: OSPS Baseline Scanner
+        type: Policy-as-Code
+        rulesets:
+          - Maturity Level 1
+        results:
+          adhoc:
+            name: OSPS Baseline Assessment
+            location: https://github.com/cloudnative-pg/cloudnative-pg/actions/workflows/osps_security_assessment.yml
+            comment: |
+              Evaluates the repository against the Open Source Project Security Baseline
+        integration:
+          adhoc: true
+          ci: true
+          release: false
 
     assessments:
       self:

--- a/SECURITY-INSIGHTS.yml
+++ b/SECURITY-INSIGHTS.yml
@@ -210,12 +210,8 @@ repository:
         type: other
         rulesets:
           - Maturity Level 2
-        results:
-          adhoc:
-            name: OSPS Baseline Assessment
-            location: https://github.com/cloudnative-pg/cloudnative-pg/actions/workflows/osps_security_assessment.yml
-            comment: |
-              Evaluates the repository against the Open Source Project Security Baseline
+        comment: Evaluates the repository against the Open Source Project Security Baseline
+        results: {}
         integration:
           adhoc: true
           ci: false

--- a/SECURITY-INSIGHTS.yml
+++ b/SECURITY-INSIGHTS.yml
@@ -79,7 +79,7 @@ project:
     quickstart-guide: https://cloudnative-pg.io/docs/current/quickstart
     release-process: https://github.com/cloudnative-pg/cloudnative-pg/blob/main/contribute/release_procedure.md
     # OSPS-DO-03.01
-    signature-verification: https://cloudnative-pg.io/docs/devel/installation_upgrade/#verifying-release-assets
+    signature-verification: https://cloudnative-pg.io/docs/current/installation_upgrade/#verifying-release-assets
     # OSPS-DO-04.01, OSPS-DO-05.01
     support-policy: https://cloudnative-pg.io/docs/current/supported_releases
 
@@ -201,7 +201,7 @@ repository:
           release assets. This ensures that the binary artifacts and images are traced
           back to the specific source commit and build environment without manual
           intervention.
-
+        results: {}
         integration:
           adhoc: false
           ci: true

--- a/SECURITY-INSIGHTS.yml
+++ b/SECURITY-INSIGHTS.yml
@@ -194,7 +194,7 @@ repository:
           ci: true
           release: true
       - name: SLSA GitHub Generator Action
-        type: automated-tooling
+        type: other
         rulesets: ["default"]
         comment: >-
           Generates non-falsifiable SLSA Level 3 provenance attestations for

--- a/SECURITY-INSIGHTS.yml
+++ b/SECURITY-INSIGHTS.yml
@@ -218,7 +218,7 @@ repository:
               Evaluates the repository against the Open Source Project Security Baseline
         integration:
           adhoc: true
-          ci: true
+          ci: false
           release: false
 
     assessments:

--- a/SECURITY-INSIGHTS.yml
+++ b/SECURITY-INSIGHTS.yml
@@ -209,7 +209,7 @@ repository:
       - name: OSPS Baseline Scanner
         type: Policy-as-Code
         rulesets:
-          - Maturity Level 1
+          - Maturity Level 2
         results:
           adhoc:
             name: OSPS Baseline Assessment


### PR DESCRIPTION
Relates #10058

Brings `SECURITY-INSIGHTS.yml` in line with the OSSF Security Insights v2.2.0 schema and adds CI to keep it that way.

It adds the OSPS Baseline Scanner tooling entry and repoints `signature-verification` to the documented release-asset verification procedure. The self-assessment evidence, which the schema models as a single URL, now points to a new `.github/security-self-assessment.md` that links both the threat and capability catalogs rather than listing the two files directly. It also corrects the SLSA tool entry, which declared a `type` (`automated-tooling`) that is not part of the schema enum, to `other`.

A new `Security Insights Linter` job validates the file with `cue vet` against the schema version declared in its header, so future drift is caught in CI.
