### PR TITLE
ci: improve EKS version check regexp

### DIFF
--- a/.github/workflows/k8s-versions-check.yml
+++ b/.github/workflows/k8s-versions-check.yml
@@ -40,7 +40,7 @@ jobs:
         name: Get updated EKS versions
         run: |
           DOC_URL="https://raw.githubusercontent.com/awsdocs/amazon-eks-user-guide/mainline/latest/ug/versioning/kubernetes-versions-standard.adoc"
-          curl --silent "${DOC_URL}" | sed -e 's/.*Kubernetes \([0-9].[0-9][0-9]\).*/\1/;/^[0-9]\./!d' | uniq | \
+          curl --silent "${DOC_URL}" | sed -e 's/^== Kubernetes \([0-9].[0-9][0-9]\).*/\1/;/^[0-9]\./!d' | uniq | sort -rV | \
             awk -vv=$MINIMAL_K8S '$0>=v {print $0}' | \
             jq -Rn '[inputs]' | tee .github/eks_versions.json
         if: github.event.inputs.limit == null || github.event.inputs.limit == 'eks'


### PR DESCRIPTION
The `k8s-version-check` was wrongly detecting a new EKS 1.36 version while it's not out yet, because the regexp was matching any line mentioning a Kubernetes version (e.g. deprecation notices).

Anchor the regexp to only match AsciiDoc section headings (`== Kubernetes X.XX`) and add explicit version sorting to make the output deterministic regardless of document order.