### PR TITLE
feat(majorupgrade): auto-cleanup failed upgrade job on image rollback

### DIFF
--- a/docs/src/operator_capability_levels.md
+++ b/docs/src/operator_capability_levels.md
@@ -366,7 +366,7 @@ consistency and initiates a job to validate upgrade conditions and execute
 `pg_upgrade`. This job creates the necessary new directories for `PGDATA`, WAL
 files, and tablespaces before re-creating the replicas. This structured
 workflow provides a reliable path for major version transitions and supports
-rollbacks in the event of a failure.
+automatic rollback cleanup when the user reverts the image after a failure.
 
 ### Display cluster availability status during upgrade
 

--- a/docs/src/postgres_upgrades.md
+++ b/docs/src/postgres_upgrades.md
@@ -146,9 +146,10 @@ If the upgrade is successful, CloudNativePG:
     may want to run `ANALYZE` on your databases to update them.
 :::
 
-If the upgrade fails, you must manually revert the major version change in the
-cluster's configuration and delete the upgrade job, as CloudNativePG cannot
-automatically decide the rollback.
+If the upgrade fails, revert the image in the cluster's configuration to the
+previous major version. The operator detects the rollback and automatically
+deletes the failed upgrade job, allowing the cluster to restart on the original
+version.
 
 :::info[Important]
     This process **protects your existing database from data loss**, as no data

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -752,6 +752,7 @@ func (r *ClusterReconciler) reconcileResources(
 	if result, err := majorupgrade.Reconcile(
 		ctx,
 		r.Client,
+		r.Recorder,
 		cluster,
 		resources.instances.Items,
 		resources.pvcs.Items,

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -745,6 +745,23 @@ func (r *ClusterReconciler) reconcileResources(
 	resources *managedResources, instancesStatus postgres.PostgresqlStatusList,
 ) (ctrl.Result, error) {
 	contextLogger := log.FromContext(ctx)
+
+	// Major upgrade reconciliation runs before the running-jobs guard
+	// because it owns the upgrade job lifecycle. A failed upgrade job
+	// (BackoffLimit=0) would otherwise block rollback detection.
+	if result, err := majorupgrade.Reconcile(
+		ctx,
+		r.Client,
+		cluster,
+		resources.instances.Items,
+		resources.pvcs.Items,
+		resources.jobs.Items,
+	); err != nil {
+		return ctrl.Result{}, fmt.Errorf("cannot reconcile in-place major version upgrades: %w", err)
+	} else if result != nil {
+		return *result, err
+	}
+
 	runningJobs := resources.runningJobNames()
 
 	// Act on Pods and PVCs only if there is nothing that is currently being created or deleted
@@ -808,20 +825,6 @@ func (r *ClusterReconciler) reconcileResources(
 		resources.pvcs.Items,
 	); err != nil || !res.IsZero() {
 		return res, err
-	}
-
-	// In-place Postgres major version upgrades
-	if result, err := majorupgrade.Reconcile(
-		ctx,
-		r.Client,
-		cluster,
-		resources.instances.Items,
-		resources.pvcs.Items,
-		resources.jobs.Items,
-	); err != nil {
-		return ctrl.Result{}, fmt.Errorf("cannot reconcile in-place major version upgrades: %w", err)
-	} else if result != nil {
-		return *result, err
 	}
 
 	// Reconcile Pods

--- a/pkg/reconciler/majorupgrade/doc.go
+++ b/pkg/reconciler/majorupgrade/doc.go
@@ -23,8 +23,9 @@ SPDX-License-Identifier: Apache-2.0
 // The upgrade process consists of the following steps:
 //
 //  1. Delete all Pods in the cluster.
-//  2. Create and initiate the major upgrade job.
+//  2. Create and initiate the major upgrade job (BackoffLimit=0, no retries).
 //  3. Wait for the job to complete.
 //  4. If the upgrade job completes successfully, start new Pods for the upgraded version.
-//     Otherwise, stop and wait for input by the user.
+//     If the user reverts the image to the previous major version, the operator
+//     automatically deletes the failed upgrade job and lets the cluster restart.
 package majorupgrade

--- a/pkg/reconciler/majorupgrade/job.go
+++ b/pkg/reconciler/majorupgrade/job.go
@@ -22,6 +22,7 @@ package majorupgrade
 import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/specs"
@@ -92,6 +93,8 @@ func createMajorUpgradeJobDefinition(
 	}
 	job := specs.CreatePrimaryJob(*cluster, nodeSerial, jobMajorUpgrade, majorUpgradeCommand, extensions)
 	job.Spec.Template.Spec.InitContainers = append(job.Spec.Template.Spec.InitContainers, oldVersionInitContainer)
+	// A failed pg_upgrade will not succeed on retry.
+	job.Spec.BackoffLimit = ptr.To(int32(0))
 
 	return job
 }

--- a/pkg/reconciler/majorupgrade/reconciler.go
+++ b/pkg/reconciler/majorupgrade/reconciler.go
@@ -63,7 +63,16 @@ func Reconcile(
 	contextLogger := log.FromContext(ctx)
 
 	if majorUpgradeJob := getMajorUpdateJob(jobs); majorUpgradeJob != nil {
-		return majorVersionUpgradeHandleCompletion(ctx, c, cluster, majorUpgradeJob, pvcs)
+		if utils.JobHasOneCompletion(*majorUpgradeJob) {
+			return majorVersionUpgradeHandleCompletion(ctx, c, cluster, majorUpgradeJob, pvcs)
+		}
+
+		if result, err := handleRollbackIfNeeded(ctx, c, cluster, majorUpgradeJob); result != nil || err != nil {
+			return result, err
+		}
+
+		contextLogger.Info("Major upgrade job not completed.")
+		return &ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 	}
 
 	requestedMajor, err := cluster.GetPostgresqlMajorVersion()
@@ -231,11 +240,6 @@ func majorVersionUpgradeHandleCompletion(
 ) (*ctrl.Result, error) {
 	contextLogger := log.FromContext(ctx)
 
-	if !utils.JobHasOneCompletion(*job) {
-		contextLogger.Info("Major upgrade job not completed.")
-		return &ctrl.Result{RequeueAfter: 30 * time.Second}, nil
-	}
-
 	for _, pvc := range pvcs {
 		if pvc.GetDeletionTimestamp() != nil {
 			continue
@@ -314,6 +318,61 @@ func majorVersionUpgradeHandleCompletion(
 	}
 
 	return &ctrl.Result{Requeue: true}, nil
+}
+
+// handleRollbackIfNeeded checks whether the user rolled back the image
+// while the upgrade job is still running (or has failed). If the requested
+// major version is no longer higher than PGDataImageInfo.MajorVersion,
+// the job is deleted so the cluster can restart on the old version.
+func handleRollbackIfNeeded(
+	ctx context.Context,
+	c client.Client,
+	cluster *apiv1.Cluster,
+	job *batchv1.Job,
+) (*ctrl.Result, error) {
+	contextLogger := log.FromContext(ctx)
+
+	requestedMajor, err := cluster.GetPostgresqlMajorVersion()
+	if err != nil {
+		contextLogger.Error(err, "Unable to retrieve the requested PostgreSQL version")
+		return nil, err
+	}
+
+	// Equal major version is also treated as a rollback: the user changed
+	// to a same-major image, so the in-progress upgrade is no longer wanted.
+	if cluster.Status.PGDataImageInfo == nil || requestedMajor > cluster.Status.PGDataImageInfo.MajorVersion {
+		return nil, nil
+	}
+
+	contextLogger.Info("Image rolled back during major upgrade, cleaning up the upgrade job",
+		"requestedMajor", requestedMajor,
+		"pgDataMajor", cluster.Status.PGDataImageInfo.MajorVersion)
+
+	if job.GetDeletionTimestamp() != nil {
+		return &ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+	}
+
+	if err := c.Delete(ctx, job, &client.DeleteOptions{
+		PropagationPolicy: ptr.To(metav1.DeletePropagationForeground),
+	}); err != nil {
+		if !apierrs.IsNotFound(err) {
+			return nil, err
+		}
+	}
+
+	// reconcileImage set Status.Image to the upgrade target but left
+	// PGDataImageInfo unchanged. Reset it so pods use the correct image.
+	if err := status.PatchWithOptimisticLock(
+		ctx,
+		c,
+		cluster,
+		status.SetImage(cluster.Status.PGDataImageInfo.Image),
+	); err != nil {
+		contextLogger.Error(err, "Unable to reset status image after rollback")
+		return nil, err
+	}
+
+	return &ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 }
 
 // registerPhase sets a phase into the cluster

--- a/pkg/reconciler/majorupgrade/reconciler.go
+++ b/pkg/reconciler/majorupgrade/reconciler.go
@@ -29,6 +29,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -55,6 +56,7 @@ var ErrNoPrimaryPVCFound = fmt.Errorf("no primary PVC found")
 func Reconcile(
 	ctx context.Context,
 	c client.Client,
+	recorder record.EventRecorder,
 	cluster *apiv1.Cluster,
 	instances []corev1.Pod,
 	pvcs []corev1.PersistentVolumeClaim,
@@ -67,7 +69,7 @@ func Reconcile(
 			return majorVersionUpgradeHandleCompletion(ctx, c, cluster, majorUpgradeJob, pvcs)
 		}
 
-		if result, err := handleRollbackIfNeeded(ctx, c, cluster, majorUpgradeJob); result != nil || err != nil {
+		if result, err := handleRollbackIfNeeded(ctx, c, recorder, cluster, majorUpgradeJob); result != nil || err != nil {
 			return result, err
 		}
 
@@ -324,9 +326,14 @@ func majorVersionUpgradeHandleCompletion(
 // while the upgrade job is still running (or has failed). If the requested
 // major version is no longer higher than PGDataImageInfo.MajorVersion,
 // the job is deleted so the cluster can restart on the old version.
+//
+// NOTE: this function runs regardless of job status, including while the
+// job is still actively executing. If the user reverts the image mid-upgrade,
+// the running job will be terminated.
 func handleRollbackIfNeeded(
 	ctx context.Context,
 	c client.Client,
+	recorder record.EventRecorder,
 	cluster *apiv1.Cluster,
 	job *batchv1.Job,
 ) (*ctrl.Result, error) {
@@ -371,6 +378,9 @@ func handleRollbackIfNeeded(
 		contextLogger.Error(err, "Unable to reset status image after rollback")
 		return nil, err
 	}
+
+	recorder.Eventf(cluster, "Normal", "MajorUpgradeRollback",
+		"Cleaned up failed upgrade job, rolling back to major version %d", requestedMajor)
 
 	return &ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 }

--- a/pkg/reconciler/majorupgrade/reconciler_test.go
+++ b/pkg/reconciler/majorupgrade/reconciler_test.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -105,46 +106,54 @@ var _ = Describe("Major upgrade job status reconciliation", func() {
 })
 
 var _ = Describe("Major upgrade rollback handling", func() {
-	It("deletes the job and requeues when the image is rolled back", func(ctx SpecContext) {
-		job := buildFailedUpgradeJob()
-		cluster := &apiv1.Cluster{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "cluster-example",
-			},
-			Spec: apiv1.ClusterSpec{
-				ImageName: "postgres:15",
-			},
-			Status: apiv1.ClusterStatus{
-				Image: "postgres:16",
-				PGDataImageInfo: &apiv1.ImageInfo{
-					Image:        "postgres:15",
-					MajorVersion: 15,
+	DescribeTable("deletes the job and resets the image when the user rolls back",
+		func(
+			ctx SpecContext, specImage, statusImage, pgDataImage string, pgDataMajor int, expectedImage string,
+		) {
+			job := buildFailedUpgradeJob()
+			cluster := &apiv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cluster-example",
 				},
-			},
-		}
+				Spec: apiv1.ClusterSpec{
+					ImageName: specImage,
+				},
+				Status: apiv1.ClusterStatus{
+					Image: statusImage,
+					PGDataImageInfo: &apiv1.ImageInfo{
+						Image:        pgDataImage,
+						MajorVersion: pgDataMajor,
+					},
+				},
+			}
 
-		fakeClient := fake.NewClientBuilder().
-			WithScheme(schemeBuilder.BuildWithAllKnownScheme()).
-			WithRuntimeObjects(job, cluster).
-			WithStatusSubresource(cluster).
-			Build()
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(schemeBuilder.BuildWithAllKnownScheme()).
+				WithRuntimeObjects(job, cluster).
+				WithStatusSubresource(cluster).
+				Build()
 
-		result, err := handleRollbackIfNeeded(ctx, fakeClient, cluster, job)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(result).ToNot(BeNil())
-		Expect(*result).To(Equal(ctrl.Result{RequeueAfter: 10 * time.Second}))
+			result, err := handleRollbackIfNeeded(ctx, fakeClient, record.NewFakeRecorder(10), cluster, job)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).ToNot(BeNil())
+			Expect(*result).To(Equal(ctrl.Result{RequeueAfter: 10 * time.Second}))
 
-		// the job has been deleted
-		var tempJob batchv1.Job
-		err = fakeClient.Get(ctx, client.ObjectKeyFromObject(job), &tempJob)
-		Expect(err).To(MatchError(errors.IsNotFound, "is not found"))
+			// the job has been deleted
+			var tempJob batchv1.Job
+			err = fakeClient.Get(ctx, client.ObjectKeyFromObject(job), &tempJob)
+			Expect(err).To(MatchError(errors.IsNotFound, "is not found"))
 
-		// Status.Image has been reset to the pre-upgrade image
-		var updatedCluster apiv1.Cluster
-		err = fakeClient.Get(ctx, client.ObjectKeyFromObject(cluster), &updatedCluster)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(updatedCluster.Status.Image).To(Equal("postgres:15"))
-	})
+			// Status.Image has been reset to the pre-upgrade image
+			var updatedCluster apiv1.Cluster
+			err = fakeClient.Get(ctx, client.ObjectKeyFromObject(cluster), &updatedCluster)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(updatedCluster.Status.Image).To(Equal(expectedImage))
+		},
+		Entry("reverted to previous major version",
+			"postgres:15", "postgres:16", "postgres:15", 15, "postgres:15"),
+		Entry("changed to same-major image during upgrade",
+			"postgres:16.1", "postgres:17", "postgres:16.0", 16, "postgres:16.0"),
+	)
 
 	It("does nothing when the requested version is still higher", func(ctx SpecContext) {
 		job := buildFailedUpgradeJob()
@@ -169,7 +178,7 @@ var _ = Describe("Major upgrade rollback handling", func() {
 			WithStatusSubresource(cluster).
 			Build()
 
-		result, err := handleRollbackIfNeeded(ctx, fakeClient, cluster, job)
+		result, err := handleRollbackIfNeeded(ctx, fakeClient, record.NewFakeRecorder(10), cluster, job)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(result).To(BeNil())
 

--- a/pkg/reconciler/majorupgrade/reconciler_test.go
+++ b/pkg/reconciler/majorupgrade/reconciler_test.go
@@ -21,6 +21,7 @@ package majorupgrade
 
 import (
 	"fmt"
+	"time"
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -42,23 +43,6 @@ import (
 )
 
 var _ = Describe("Major upgrade job status reconciliation", func() {
-	It("waits until the job completed", func(ctx SpecContext) {
-		job := buildRunningUpgradeJob()
-		cluster := &apiv1.Cluster{}
-		fakeClient := fake.NewClientBuilder().
-			WithScheme(schemeBuilder.BuildWithAllKnownScheme()).
-			WithRuntimeObjects(job, cluster).
-			WithStatusSubresource(cluster).
-			Build()
-
-		result, err := majorVersionUpgradeHandleCompletion(ctx, fakeClient, cluster, job, nil)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(result).ToNot(BeNil())
-
-		// the job has not been deleted
-		Expect(job.ObjectMeta.DeletionTimestamp).To(BeNil())
-	})
-
 	It("deletes the replica PVCs when and makes the cluster use the new image", func(ctx SpecContext) {
 		job := buildCompletedUpgradeJob()
 		cluster := &apiv1.Cluster{
@@ -117,6 +101,105 @@ var _ = Describe("Major upgrade job status reconciliation", func() {
 		var tempJob batchv1.Job
 		err = fakeClient.Get(ctx, client.ObjectKeyFromObject(job), &tempJob)
 		Expect(err).To(MatchError(errors.IsNotFound, "is not found"))
+	})
+})
+
+var _ = Describe("Major upgrade rollback handling", func() {
+	It("deletes the job and requeues when the image is rolled back", func(ctx SpecContext) {
+		job := buildFailedUpgradeJob()
+		cluster := &apiv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "cluster-example",
+			},
+			Spec: apiv1.ClusterSpec{
+				ImageName: "postgres:15",
+			},
+			Status: apiv1.ClusterStatus{
+				Image: "postgres:16",
+				PGDataImageInfo: &apiv1.ImageInfo{
+					Image:        "postgres:15",
+					MajorVersion: 15,
+				},
+			},
+		}
+
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(schemeBuilder.BuildWithAllKnownScheme()).
+			WithRuntimeObjects(job, cluster).
+			WithStatusSubresource(cluster).
+			Build()
+
+		result, err := handleRollbackIfNeeded(ctx, fakeClient, cluster, job)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result).ToNot(BeNil())
+		Expect(*result).To(Equal(ctrl.Result{RequeueAfter: 10 * time.Second}))
+
+		// the job has been deleted
+		var tempJob batchv1.Job
+		err = fakeClient.Get(ctx, client.ObjectKeyFromObject(job), &tempJob)
+		Expect(err).To(MatchError(errors.IsNotFound, "is not found"))
+
+		// Status.Image has been reset to the pre-upgrade image
+		var updatedCluster apiv1.Cluster
+		err = fakeClient.Get(ctx, client.ObjectKeyFromObject(cluster), &updatedCluster)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(updatedCluster.Status.Image).To(Equal("postgres:15"))
+	})
+
+	It("does nothing when the requested version is still higher", func(ctx SpecContext) {
+		job := buildFailedUpgradeJob()
+		cluster := &apiv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "cluster-example",
+			},
+			Spec: apiv1.ClusterSpec{
+				ImageName: "postgres:16",
+			},
+			Status: apiv1.ClusterStatus{
+				PGDataImageInfo: &apiv1.ImageInfo{
+					Image:        "postgres:15",
+					MajorVersion: 15,
+				},
+			},
+		}
+
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(schemeBuilder.BuildWithAllKnownScheme()).
+			WithRuntimeObjects(job, cluster).
+			WithStatusSubresource(cluster).
+			Build()
+
+		result, err := handleRollbackIfNeeded(ctx, fakeClient, cluster, job)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result).To(BeNil())
+
+		// the job is still there
+		var tempJob batchv1.Job
+		err = fakeClient.Get(ctx, client.ObjectKeyFromObject(job), &tempJob)
+		Expect(err).ToNot(HaveOccurred())
+	})
+})
+
+var _ = Describe("Major upgrade job definition", func() {
+	It("sets BackoffLimit to 0", func() {
+		cluster := &apiv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "cluster-example",
+				Namespace: "default",
+			},
+			Spec: apiv1.ClusterSpec{
+				ImageName: "postgres:16",
+			},
+			Status: apiv1.ClusterStatus{
+				PGDataImageInfo: &apiv1.ImageInfo{
+					Image:        "postgres:15",
+					MajorVersion: 15,
+				},
+			},
+		}
+		job := createMajorUpgradeJobDefinition(cluster, 1, nil)
+		Expect(job.Spec.BackoffLimit).ToNot(BeNil())
+		Expect(*job.Spec.BackoffLimit).To(Equal(int32(0)))
 	})
 })
 
@@ -227,13 +310,21 @@ func buildCompletedUpgradeJob() *batchv1.Job {
 	}
 }
 
-func buildRunningUpgradeJob() *batchv1.Job {
+func buildFailedUpgradeJob() *batchv1.Job {
 	return &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cluster-example-major-upgrade",
+			Labels: map[string]string{
+				utils.JobRoleLabelName: jobMajorUpgrade,
+			},
+		},
 		Spec: batchv1.JobSpec{
-			Completions: ptr.To[int32](1),
+			Completions:  ptr.To[int32](1),
+			BackoffLimit: ptr.To[int32](0),
 		},
 		Status: batchv1.JobStatus{
 			Succeeded: 0,
+			Failed:    1,
 		},
 	}
 }

--- a/tests/e2e/cluster_major_upgrade_test.go
+++ b/tests/e2e/cluster_major_upgrade_test.go
@@ -29,7 +29,9 @@ import (
 
 	"github.com/cloudnative-pg/machinery/pkg/image/reference"
 	"github.com/cloudnative-pg/machinery/pkg/postgres/version"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
@@ -63,6 +65,7 @@ var _ = Describe("Postgres Major Upgrade", Ordered, ContinueOnFailure, Label(tes
 		postgresqlEntry        = "postgresql"
 		postgresqlMinimalEntry = "postgresql-minimal"
 		postgresqlSystemEntry  = "postgresql-system"
+		rollbackEntry          = "rollback"
 
 		// custom registry envs
 		customPostgresImageRegistryEnvVar       = "POSTGRES_MAJOR_UPGRADE_IMAGE_REGISTRY"
@@ -217,6 +220,18 @@ var _ = Describe("Postgres Major Upgrade", Ordered, ContinueOnFailure, Label(tes
 		return cluster
 	}
 
+	generateRollbackCluster := func(
+		namespace string, storageClass string, tagVersion string, enableBackup bool,
+	) *apiv1.Cluster {
+		cluster := generatePostgreSQLCluster(namespace, storageClass, tagVersion, enableBackup)
+		cluster.Spec.Bootstrap.InitDB.PostInitApplicationSQL = []string{
+			"CREATE EXTENSION vector;",
+			"CREATE TABLE items (id serial PRIMARY KEY,embedding vector(3));",
+			"INSERT INTO items (embedding) VALUES ('[1,2,3]');",
+		}
+		return cluster
+	}
+
 	type versionInfo struct {
 		currentMajor uint64
 		currentTag   string
@@ -332,6 +347,15 @@ var _ = Describe("Postgres Major Upgrade", Ordered, ContinueOnFailure, Label(tes
 				targetImage:   targetImages[postgresqlSystemEntry],
 				targetMajor:   int(info.targetMajor),
 			},
+			// Upgrades to a minimal image lacking pgvector, causing the
+			// upgrade job to fail, then reverts to the original image.
+			rollbackEntry: {
+				startingCluster: generateRollbackCluster(namespace, storageClass,
+					strconv.FormatUint(info.currentMajor, 10), false),
+				startingMajor: int(info.currentMajor),
+				targetImage:   targetImages[postgresqlMinimalEntry],
+				targetMajor:   int(info.targetMajor),
+			},
 		}
 	}
 
@@ -366,7 +390,11 @@ var _ = Describe("Postgres Major Upgrade", Ordered, ContinueOnFailure, Label(tes
 	}
 
 	verifyPostgresVersion := func(
-		env *environment.TestingEnvironment, primary *corev1.Pod, oldStdOut string, targetMajor int,
+		env *environment.TestingEnvironment,
+		primary *corev1.Pod,
+		oldStdOut string,
+		targetMajor int,
+		expectVersionChanged bool,
 	) {
 		Eventually(func(g Gomega) {
 			stdOut, stdErr, err := exec.EventuallyExecQueryInInstancePod(env.Ctx, env.Client, env.Interface,
@@ -375,9 +403,14 @@ var _ = Describe("Postgres Major Upgrade", Ordered, ContinueOnFailure, Label(tes
 				"SELECT version();", 60, objects.PollingTime)
 			g.Expect(err).ToNot(HaveOccurred(), "failed to execute version query")
 			g.Expect(stdErr).To(BeEmpty(), "unexpected stderr output when checking version")
-			g.Expect(stdOut).ToNot(Equal(oldStdOut), "postgres version did not change")
-			g.Expect(stdOut).To(ContainSubstring(strconv.Itoa(targetMajor)),
-				fmt.Sprintf("version string doesn't contain expected major version %d: %s", targetMajor, stdOut))
+
+			if expectVersionChanged {
+				g.Expect(stdOut).ToNot(Equal(oldStdOut), "postgres version did not change")
+				g.Expect(stdOut).To(ContainSubstring(strconv.Itoa(targetMajor)),
+					fmt.Sprintf("version string doesn't contain expected major version %d: %s", targetMajor, stdOut))
+			} else {
+				g.Expect(stdOut).To(Equal(oldStdOut), "postgres version should not have changed")
+			}
 		}).WithTimeout(5 * time.Minute).WithPolling(10 * time.Second).Should(Succeed())
 	}
 
@@ -401,6 +434,46 @@ var _ = Describe("Postgres Major Upgrade", Ordered, ContinueOnFailure, Label(tes
 		currentCluster, err := clusterutils.Get(ctx, client, cluster.Namespace, cluster.Name)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(currentCluster.Status.TimelineID).To(Equal(1))
+	}
+
+	applyRollback := func(ctx context.Context, client client.Client, cluster *apiv1.Cluster, startingImage string) {
+		By("Waiting for the upgrade job to fail")
+		currentCluster, err := clusterutils.Get(ctx, client, cluster.Namespace, cluster.Name)
+		Expect(err).ToNot(HaveOccurred())
+		upgradeJobName := fmt.Sprintf("%s-major-upgrade", currentCluster.Status.CurrentPrimary)
+		jobKey := types.NamespacedName{
+			Namespace: currentCluster.Namespace,
+			Name:      upgradeJobName,
+		}
+
+		Eventually(func(g Gomega) {
+			var job batchv1.Job
+			g.Expect(client.Get(ctx, jobKey, &job)).To(Succeed())
+			g.Expect(job.Status.Failed).To(BeNumerically(">", 0))
+		}).WithTimeout(3 * time.Minute).WithPolling(10 * time.Second).Should(Succeed())
+
+		By("Reverting the cluster to the previous major version")
+		Eventually(func() error {
+			cluster, err := clusterutils.Get(ctx, client, cluster.Namespace, cluster.Name)
+			if err != nil {
+				return err
+			}
+			cluster.Spec.ImageName = startingImage
+			return client.Update(ctx, cluster)
+		}).WithTimeout(1*time.Minute).WithPolling(10*time.Second).Should(
+			Succeed(),
+			"Failed to update cluster image from %s to %s",
+			cluster.Spec.ImageName,
+			startingImage,
+		)
+
+		By("Waiting for the operator to clean up the failed upgrade job")
+		Eventually(func(g Gomega) {
+			var job batchv1.Job
+			err := client.Get(ctx, jobKey, &job)
+			g.Expect(err).To(HaveOccurred())
+			g.Expect(errors.IsNotFound(err)).To(BeTrue())
+		}).WithTimeout(3 * time.Minute).WithPolling(10 * time.Second).Should(Succeed())
 	}
 
 	BeforeEach(func() {
@@ -441,6 +514,7 @@ var _ = Describe("Postgres Major Upgrade", Ordered, ContinueOnFailure, Label(tes
 	DescribeTable("can upgrade a Cluster to a newer major version", func(scenarioName string) {
 		By("Creating the starting cluster")
 		scenario := scenarios[scenarioName]
+		startingImage := scenario.startingCluster.Spec.ImageName
 
 		// If the skipArchiveScenarioEnvVar is present, skip the archiving scenario.
 		skipArchiveScenario := false
@@ -481,6 +555,7 @@ var _ = Describe("Postgres Major Upgrade", Ordered, ContinueOnFailure, Label(tes
 			g.Expect(currentCluster.Status.TimelineID).To(Equal(2))
 		}).WithTimeout(time.Duration(testTimeouts[timeouts.NewPrimaryAfterSwitchover]) * time.Second).
 			WithPolling(5 * time.Second).Should(Succeed())
+		initialTimelineID := 2
 
 		By("Collecting the pods UUIDs")
 		podList, err := clusterutils.ListPods(env.Ctx, env.Client, cluster.Name, cluster.Namespace)
@@ -532,6 +607,23 @@ var _ = Describe("Postgres Major Upgrade", Ordered, ContinueOnFailure, Label(tes
 			g.Expect(cluster.Status.Phase).To(Equal(apiv1.PhaseMajorUpgrade))
 		}).WithTimeout(1 * time.Minute).WithPolling(10 * time.Second).Should(Succeed())
 
+		if scenarioName == rollbackEntry {
+			By("Rolling back the cluster to the initial major version")
+			applyRollback(env.Ctx, env.Client, cluster, startingImage)
+
+			AssertClusterIsReady(cluster.Namespace, cluster.Name, testTimeouts[timeouts.ClusterIsReady], env)
+
+			By("Verifying the cluster was rolled back to the starting version")
+			verifyPostgresVersion(env, primary, oldStdOut, scenario.startingMajor, false)
+
+			By("Verifying the cluster timeline didn't change")
+			cluster, err = clusterutils.Get(env.Ctx, env.Client, cluster.Namespace, cluster.Name)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(cluster.Status.TimelineID).To(Equal(initialTimelineID))
+
+			return
+		}
+
 		AssertClusterIsReady(cluster.Namespace, cluster.Name, testTimeouts[timeouts.ClusterIsReady], env)
 
 		// The upgrade destroys all the original pods and creates new ones. We want to make sure that we have
@@ -547,7 +639,7 @@ var _ = Describe("Postgres Major Upgrade", Ordered, ContinueOnFailure, Label(tes
 
 		// Check that the version has been updated
 		By("Verifying the cluster is running the target version")
-		verifyPostgresVersion(env, primary, oldStdOut, scenario.targetMajor)
+		verifyPostgresVersion(env, primary, oldStdOut, scenario.targetMajor, true)
 
 		By("Verifying timeline ID is reset to 1 after major upgrade")
 		verifyTimelineResetAfterUpgrade(env.Ctx, env.Client, cluster)
@@ -566,5 +658,6 @@ var _ = Describe("Postgres Major Upgrade", Ordered, ContinueOnFailure, Label(tes
 		Entry("PostgreSQL", postgresqlEntry),
 		Entry("PostgreSQL minimal", postgresqlMinimalEntry),
 		Entry("PostgreSQL system", postgresqlSystemEntry),
+		Entry("Rollback", rollbackEntry),
 	)
 })


### PR DESCRIPTION
Set BackoffLimit=0 on the major upgrade job so Kubernetes does not retry a failed pg_upgrade. When the user reverts the image after a failed upgrade, the operator automatically deletes the failed job and lets the cluster restart on the original version.

Inspired by Maxim Ivanov's initial rollback approach in #9344.

Closes #9128 