### PR TITLE
test(e2e): serialize major upgrade test variants

### DIFF
--- a/tests/e2e/cluster_major_upgrade_test.go
+++ b/tests/e2e/cluster_major_upgrade_test.go
@@ -55,7 +55,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Postgres Major Upgrade", Label(tests.LabelPostgresMajorUpgrade), func() {
+var _ = Describe("Postgres Major Upgrade", Ordered, ContinueOnFailure, Label(tests.LabelPostgresMajorUpgrade), func() {
 	const (
 		level                  = tests.Medium
 		namespacePrefix        = "cluster-major-upgrade"


### PR DESCRIPTION
The 4 DescribeTable entries (PostGIS, PostgreSQL, PostgreSQL minimal, PostgreSQL system) run concurrently across Ginkgo processes, creating 12 concurrent PostgreSQL pods plus 4 upgrade/join Jobs. This can overwhelm test infrastructure causing timeout failures on resource-constrained environments.

Add `Ordered` and `ContinueOnFailure` decorators so entries run sequentially on a single Ginkgo process while others continue running other specs. `Ordered` makes entries run one at a time on a single process while the other 3 processes continue running other E2E specs. `ContinueOnFailure` ensures that if one variant fails, subsequent variants still run instead of being skipped.