### PR TITLE
chore: create renovate group for SLSA actions

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -268,6 +268,14 @@
       ],
       pinDigests: false,
       separateMajorMinor: false,
+    },
+    {
+      groupName: 'SLSA actions no-digest',
+      matchPackageNames: [
+        'slsa-framework{/,}**',
+      ],
+      pinDigests: false,
+      separateMajorMinor: false,
     }
   ],
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -271,6 +271,9 @@
     },
     {
       groupName: 'SLSA actions no-digest',
+      matchDatasources: [
+        'github-tags',
+      ],
       matchPackageNames: [
         'slsa-framework{/,}**',
       ],


### PR DESCRIPTION
The SLSA actions cannot be digest-pinned due to
https://github.com/slsa-framework/slsa-github-generator/issues/4216

Create a Renovate group that disables digest pinning for these actions.

Closes #10118 