### PR TITLE
feat: conditionally watch node resources

### DIFF
--- a/contribute/e2e_testing_environment/README.md
+++ b/contribute/e2e_testing_environment/README.md
@@ -228,6 +228,7 @@ type provided.
 | `backup-restore`                  |
 | `snapshot`                        |
 | `operator`                        |
+| `reduced-rbac-operator`           |
 | `observability`                   |
 | `replication`                     |
 | `plugin`                          |

--- a/docs/src/e2e.md
+++ b/docs/src/e2e.md
@@ -58,6 +58,10 @@ and the following suite of E2E tests are performed on that cluster:
      * Operator upgrade
      * Operator High Availability
 
+* **Reduced RBAC deployment:**
+  * Operator configured with reduced RBAC
+  * Node drain while operator is configured without node RBAC
+
 * **Observability:**
      * Metrics collection
      * PgBouncer Metrics

--- a/docs/src/e2e.md
+++ b/docs/src/e2e.md
@@ -59,8 +59,8 @@ and the following suite of E2E tests are performed on that cluster:
      * Operator High Availability
 
 * **Reduced RBAC deployment:**
-  * Operator configured with reduced RBAC
-  * Node drain while operator is configured without node RBAC
+  * Operator Deployment
+  * Node drain
 
 * **Observability:**
      * Metrics collection

--- a/docs/src/operator_conf.md
+++ b/docs/src/operator_conf.md
@@ -61,6 +61,7 @@ Name | Description
 `METRICS_CERT_DIR` | The directory where TLS certificates for the operator metrics server are stored. When set, enables TLS for the metrics endpoint on port 8080. The directory must contain `tls.crt` and `tls.key` files following standard Kubernetes TLS secret conventions. If not set, the metrics server operates without TLS (default behavior).
 `MONITORING_QUERIES_CONFIGMAP` | The name of a ConfigMap in the operator's namespace with a set of default queries (to be specified under the key `queries`) to be applied to all created Clusters
 `MONITORING_QUERIES_SECRET` | The name of a Secret in the operator's namespace with a set of default queries (to be specified under the key `queries`) to be applied to all created Clusters
+`WATCH_NODES` | When set to `true`, the operator will watch Kubernetes nodes and use node information for scheduling and failover decisions. When set to `false`, the operator will not require `nodes` RBAC permissions. Default is `true`.
 `OPERATOR_IMAGE_NAME` | The name of the operator image used to bootstrap Pods. Defaults to the image specified during installation.
 `PGBOUNCER_IMAGE_NAME` | The name of the PgBouncer image used by default for new poolers. Defaults to the version specified in the operator.
 `POSTGRES_IMAGE_NAME` | The name of the PostgreSQL image used by default for new clusters. Defaults to the version specified in the operator.

--- a/docs/src/security.md
+++ b/docs/src/security.md
@@ -429,6 +429,44 @@ to viewing resources. However, if an unauthorized user gains access to the
 Therefore, it's crucial to prevent users from accessing the operator's
 `ServiceAccount` and any other `ServiceAccount` with elevated permissions.
 
+### Restricted RBAC Mode
+
+You can restrict the operator's RBAC permissions by configuring `WATCH_NAMESPACES`
+to the same namespace as the operator deployment. This way all namespaced resource
+policies can be created in a `Role`, and the `ClusterRole` only needs to contain
+`admissionregistration.k8s.io`, `clusterImageCatalogs` and `Nodes` resources.
+
+#### Disable Node Watching
+
+Set `WATCH_NODES` to `false` to disable node access:
+
+When `WATCH_NODES` is set to `false`:
+- The operator will not require `nodes` RBAC permissions
+
+### Known Limitations with Restricted Nodes RBAC
+
+#### SyncReplicaElectionConstraint
+
+`cluster.Spec.PostgresConfiguration.SyncReplicaElectionConstraint` is used to enforce deployment constraints for synchronous replicas during election. This feature will not work with restricted RBAC due to lack of node access.
+
+#### PodDisruptionBudget
+
+:::warning
+    When running with restricted RBAC and PodDisruptionBudget (PDB) enabled, node drain operations may fail.
+:::
+
+CloudNativePG creates PodDisruptionBudgets to protect PostgreSQL instances during voluntary disruptions. However, with restricted RBAC, a critical limitation exists:
+
+- The Kubernetes node drain process requires cluster-level permissions to evict pods protected by PDBs
+- With restricted RBAC, the operator lacks the necessary cluster-wide permissions to properly coordinate with the node drain controller
+- This can result in node drain operations timing out or failing when attempting to evict PostgreSQL pods
+
+**Workarounds:**
+
+1. **Disable PDB**: Set `spec.enablePDB: false` in your `Cluster` specification when using restricted RBAC
+2. **Manual intervention**: Manually delete or scale down PostgreSQL pods before draining nodes
+3. **Use full RBAC**: If node drain automation is critical, consider using the default cluster-wide RBAC configuration
+
 ### Calls to the API server made by the instance manager
 
 The instance manager, which is the entry point of the operand container, needs

--- a/docs/src/security.md
+++ b/docs/src/security.md
@@ -431,13 +431,13 @@ Therefore, it's crucial to prevent users from accessing the operator's
 
 ### Restricted RBAC Mode
 
-You can restrict the operator's RBAC permissions by configuring `WATCH_NAMESPACES`
+You can restrict the operator's RBAC permissions by configuring `WATCH_NAMESPACE`
 to the same namespace as the operator deployment. This way all namespaced resource
 policies can be created in a `Role`, and the `ClusterRole` only needs to contain
 - admissionregistration.k8s.io resources (mutatingwebhookconfigurations,
 validatingwebhookconfigurations) with get, patch verbs
 - postgresql.cnpg.io/clusterimagecatalogs with get, list, watch verbs
-- nodes with get, list, watch verbs"
+- nodes with get, list, watch verbs
 
 #### Disable Node Watching
 

--- a/docs/src/security.md
+++ b/docs/src/security.md
@@ -434,38 +434,55 @@ Therefore, it's crucial to prevent users from accessing the operator's
 You can restrict the operator's RBAC permissions by configuring `WATCH_NAMESPACES`
 to the same namespace as the operator deployment. This way all namespaced resource
 policies can be created in a `Role`, and the `ClusterRole` only needs to contain
-`admissionregistration.k8s.io`, `clusterImageCatalogs` and `Nodes` resources.
+- admissionregistration.k8s.io resources (mutatingwebhookconfigurations,
+validatingwebhookconfigurations) with get, patch verbs
+- postgresql.cnpg.io/clusterimagecatalogs with get, list, watch verbs
+- nodes with get, list, watch verbs"
 
 #### Disable Node Watching
 
 Set `WATCH_NODES` to `false` to disable node access:
 
 When `WATCH_NODES` is set to `false`:
-- The operator will not require `nodes` RBAC permissions
+- The operator will not require nodes resource permissions with get, list, watch verbs
 
 ### Known Limitations with Restricted Nodes RBAC
 
 #### SyncReplicaElectionConstraint
 
-`cluster.Spec.PostgresConfiguration.SyncReplicaElectionConstraint` is used to enforce deployment constraints for synchronous replicas during election. This feature will not work with restricted RBAC due to lack of node access.
+`cluster.Spec.PostgresConfiguration.SyncReplicaElectionConstraint` is used to
+enforce deployment constraints for synchronous replicas during election.
+This feature will not work with restricted RBAC because the operator needs to
+read node labels (specified in nodeLabelsAntiAffinity) to determine pod topology.
+Without get, list, and watch permissions on the nodes resource, the operator
+cannot extract label values from nodes where pods are scheduled, making it
+impossible to enforce topology-based synchronous replica election constraints.
 
 #### PodDisruptionBudget
 
 :::warning
-    When running with restricted RBAC and PodDisruptionBudget (PDB) enabled, node drain operations may fail.
+    When running with restricted RBAC and PodDisruptionBudget (PDB) enabled,
+    node drain operations may fail.
 :::
 
-CloudNativePG creates PodDisruptionBudgets to protect PostgreSQL instances during voluntary disruptions. However, with restricted RBAC, a critical limitation exists:
+CloudNativePG creates `PodDisruptionBudget` to protect PostgreSQL instances
+during voluntary disruptions. However, with restricted RBAC, a critical limitation exists:
 
-- The Kubernetes node drain process requires cluster-level permissions to evict pods protected by PDBs
-- With restricted RBAC, the operator lacks the necessary cluster-wide permissions to properly coordinate with the node drain controller
-- This can result in node drain operations timing out or failing when attempting to evict PostgreSQL pods
+- The Kubernetes node drain process requires cluster-level permissions to evict
+ pods protected by PDBs
+- With restricted RBAC, the operator lacks the necessary cluster-wide
+permissions to properly coordinate with the node drain controller
+- This can result in node drain operations timing out or failing when
+attempting to evict PostgreSQL pods
 
 **Workarounds:**
 
-1. **Disable PDB**: Set `spec.enablePDB: false` in your `Cluster` specification when using restricted RBAC
-2. **Manual intervention**: Manually delete or scale down PostgreSQL pods before draining nodes
-3. **Use full RBAC**: If node drain automation is critical, consider using the default cluster-wide RBAC configuration
+1. **Disable PDB**: Set `spec.enablePDB: false` in your `Cluster` specification
+when using restricted RBAC
+2. **Manual intervention**: Manually delete or scale down PostgreSQL pods before
+draining nodes
+3. **Use full RBAC**: If node drain automation is critical, consider using the
+default cluster-wide RBAC configuration
 
 ### Calls to the API server made by the instance manager
 

--- a/internal/configuration/configuration.go
+++ b/internal/configuration/configuration.go
@@ -102,6 +102,10 @@ type Data struct {
 	// OperatorNamespace is the namespace where the operator is installed
 	OperatorNamespace string `json:"operatorNamespace" env:"OPERATOR_NAMESPACE"`
 
+	// WatchNodes defines if the operator should watch and manage node resources.
+	// When false, the operator will not monitor node events or handle node-related operations.
+	WatchNodes bool `json:"watchNodes" env:"WATCH_NODES"`
+
 	// OperatorPullSecretName is the pull secret used to download the
 	// pull secret name
 	OperatorPullSecretName string `json:"operatorPullSecretName" env:"PULL_SECRET_NAME"`
@@ -212,6 +216,7 @@ func newDefaultConfig() *Data {
 		KubernetesClusterDomain:     DefaultKubernetesClusterDomain,
 		DrainTaints:                 DefaultDrainTaints,
 		ManageWebhookConfigurations: true,
+		WatchNodes:                  true,
 	}
 }
 

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -1317,11 +1317,6 @@ func (r *ClusterReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manag
 			&apiv1.Pooler{},
 			handler.EnqueueRequestsFromMapFunc(r.mapPoolersToClusters()),
 		).
-		Watches(
-			&corev1.Node{},
-			handler.EnqueueRequestsFromMapFunc(r.mapNodeToClusters()),
-			builder.WithPredicates(r.nodesPredicate()),
-		).
 		// Watch external (non-owned) pods for podSelectorRefs IP resolution.
 		// Owned pods are already handled by Owns(&corev1.Pod{}) above.
 		Watches(
@@ -1346,6 +1341,15 @@ func (r *ClusterReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manag
 			// instance RBAC), so status-only changes are irrelevant here.
 			builder.WithPredicates(predicate.GenerationChangedPredicate{}),
 		)
+
+	// Conditionally watch node resource
+	if configuration.Current.WatchNodes {
+		ctrlBuilder = ctrlBuilder.Watches(
+			&corev1.Node{},
+			handler.EnqueueRequestsFromMapFunc(r.mapNodeToClusters()),
+			builder.WithPredicates(r.nodesPredicate()),
+		)
+	}
 
 	if configuration.Current.OperatorNamespace != "" {
 		ctrlBuilder = ctrlBuilder.Watches(
@@ -1428,6 +1432,7 @@ func (r *ClusterReconciler) createFieldIndexes(ctx context.Context, mgr ctrl.Man
 
 	// Create a new indexed field on Pods. This field will be used to easily
 	// find all the Pods created by node
+	// This is not used when WatchNodes is false
 	if err := mgr.GetFieldIndexer().IndexField(
 		ctx,
 		&corev1.Pod{},

--- a/internal/controller/cluster_status.go
+++ b/internal/controller/cluster_status.go
@@ -38,6 +38,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	"github.com/cloudnative-pg/cloudnative-pg/internal/configuration"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/certs"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/postgres"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/reconciler/hibernation"
@@ -116,9 +117,13 @@ func (r *ClusterReconciler) getManagedResources(
 		return nil, err
 	}
 
-	nodes, err := r.getNodes(ctx)
-	if err != nil {
-		return nil, err
+	// If operator is configured to not watch node resource, set empty list
+	var nodes map[string]corev1.Node
+	if configuration.Current.WatchNodes {
+		nodes, err = r.getNodes(ctx)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return &managedResources{
@@ -824,6 +829,7 @@ func getPodsTopology(
 		if !ok {
 			// node not found, it means that:
 			// - the node could have been drained
+			// - operator deployed without watching node resource
 			// - others
 			contextLogger.Debug("node not found, skipping pod topology matching")
 			return apiv1.Topology{}

--- a/internal/controller/replicas.go
+++ b/internal/controller/replicas.go
@@ -31,6 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	"github.com/cloudnative-pg/cloudnative-pg/internal/configuration"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/postgres"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/specs"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
@@ -64,17 +65,21 @@ func (r *ClusterReconciler) reconcileTargetPrimaryFromPods(
 
 	// First step: check if the current primary is running in an unschedulable node
 	// and issue a switchover if that's the case
-	if primary := status.Items[0]; (primary.IsPrimary || (cluster.IsReplica() && primary.IsPodReady)) &&
-		primary.Pod.Name == cluster.Status.CurrentPrimary &&
-		cluster.Status.TargetPrimary == cluster.Status.CurrentPrimary {
-		isPrimaryOnUnschedulableNode, err := r.isNodeUnschedulableOrBeingDrained(ctx, primary.Node)
-		if err != nil {
-			contextLogger.Error(err, "while checking if current primary is on an unschedulable node")
-			// in case of error it's better to proceed with the normal target primary reconciliation
-		} else if isPrimaryOnUnschedulableNode {
-			contextLogger.Info("Primary is running on an unschedulable node, will try switching over",
-				"node", primary.Node, "primary", primary.Pod.Name)
-			return r.setPrimaryOnSchedulableNode(ctx, cluster, status, &primary)
+	// Can not check node settings when operator service account does not have access
+	// to Nodes resource.
+	if configuration.Current.WatchNodes {
+		if primary := status.Items[0]; (primary.IsPrimary || (cluster.IsReplica() && primary.IsPodReady)) &&
+			primary.Pod.Name == cluster.Status.CurrentPrimary &&
+			cluster.Status.TargetPrimary == cluster.Status.CurrentPrimary {
+			isPrimaryOnUnschedulableNode, err := r.isNodeUnschedulableOrBeingDrained(ctx, primary.Node)
+			if err != nil {
+				contextLogger.Error(err, "while checking if current primary is on an unschedulable node")
+				// in case of error it's better to proceed with the normal target primary reconciliation
+			} else if isPrimaryOnUnschedulableNode {
+				contextLogger.Info("Primary is running on an unschedulable node, will try switching over",
+					"node", primary.Node, "primary", primary.Pod.Name)
+				return r.setPrimaryOnSchedulableNode(ctx, cluster, status, &primary)
+			}
 		}
 	}
 

--- a/tests/e2e/namespaced_deployment_test.go
+++ b/tests/e2e/namespaced_deployment_test.go
@@ -1,0 +1,275 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package e2e
+
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/utils/ptr"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/cloudnative-pg/cloudnative-pg/tests"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/clusterutils"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/exec"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/namespaced"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/namespaces"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/nodes"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/postgres"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/run"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/timeouts"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Namespaced Deployment", Label(tests.LabelNoOpenshift, tests.LabelDisruptive,
+	tests.LabelReducedRbacOperator), Ordered, Serial, func() {
+	const (
+		operatorNamespace          = "cnpg-system"
+		namespacedOperatorManifest = fixturesDir + "/namespaced/manifest.yaml"
+		clusterName                = "postgresql-storage-class"
+		sampleFile                 = fixturesDir + "/base/cluster-storage-class.yaml.template"
+		level                      = tests.Highest
+	)
+
+	BeforeAll(func() {
+		if testLevelEnv.Depth < int(level) {
+			Skip("Test depth is lower than the amount requested for this test")
+		}
+
+		if IsOpenshift() {
+			Skip("This test case is not applicable on OpenShift clusters")
+		}
+		namespaced.StoreDefaultRBACSpec(env)
+
+		namespaced.ConfigureOperatorWithoutNodeAccess(env, operatorNamespace, uint(testTimeouts[timeouts.OperatorIsReady]))
+	})
+
+	AfterAll(func() {
+		namespaced.RevertOperatorToClusterWideMode(env, operatorNamespace, uint(testTimeouts[timeouts.OperatorIsReady]))
+	})
+
+	AfterEach(func() {
+		if CurrentSpecReport().Failed() {
+			namespaces.DumpNamespaceObjects(
+				env.Ctx, env.Client,
+				operatorNamespace, "out/"+CurrentSpecReport().LeafNodeText+"operator.log")
+		}
+
+		By("deleting cluster", func() {
+			err := DeleteResourcesFromFile(operatorNamespace, sampleFile)
+			Expect(err).ToNot(HaveOccurred())
+			// Wait for the cluster to be deleted
+			Eventually(func() error {
+				_, err := clusterutils.Get(env.Ctx, env.Client, operatorNamespace, clusterName)
+				return err
+			}, testTimeouts[timeouts.ClusterIsReady]).Should(HaveOccurred())
+		})
+	})
+
+	It("can create and reconcile clusters in namespaced mode", func() {
+		By("creating a cluster in the operator namespace", func() {
+			CreateResourceFromFile(operatorNamespace, sampleFile)
+		})
+
+		By("verifying cluster becomes ready", func() {
+			AssertClusterIsReady(operatorNamespace, clusterName, testTimeouts[timeouts.ClusterIsReady], env)
+		})
+
+		By("verifying cluster can be reconciled", func() {
+			cluster, err := clusterutils.Get(env.Ctx, env.Client, operatorNamespace, clusterName)
+			Expect(err).ToNot(HaveOccurred())
+
+			oldCluster := cluster.DeepCopy()
+			cluster.Spec.PostgresConfiguration.Parameters["max_connections"] = "150"
+			err = env.Client.Patch(env.Ctx, cluster, ctrlclient.MergeFrom(oldCluster))
+			Expect(err).ToNot(HaveOccurred())
+
+			primary, err := clusterutils.GetPrimary(env.Ctx, env.Client, operatorNamespace, clusterName)
+			Expect(err).ToNot(HaveOccurred())
+
+			Eventually(func() (string, error) {
+				stdout, _, err := exec.QueryInInstancePod(
+					env.Ctx, env.Client, env.Interface, env.RestClientConfig,
+					exec.PodLocator{
+						Namespace: primary.Namespace,
+						PodName:   primary.Name,
+					},
+					postgres.PostgresDBName,
+					"show max_connections")
+				return strings.Trim(stdout, "\n"), err
+			}, 300).Should(BeEquivalentTo("150"))
+		})
+
+		By("verifying cluster can be scaled", func() {
+			cluster, err := clusterutils.Get(env.Ctx, env.Client, operatorNamespace, clusterName)
+			Expect(err).ToNot(HaveOccurred())
+
+			oldCluster := cluster.DeepCopy()
+			cluster.Spec.Instances = 2
+			err = env.Client.Patch(env.Ctx, cluster, ctrlclient.MergeFrom(oldCluster))
+			Expect(err).ToNot(HaveOccurred())
+
+			Eventually(func() (int, error) {
+				podList, err := clusterutils.ListPods(env.Ctx, env.Client, operatorNamespace, clusterName)
+				if err != nil {
+					return 0, err
+				}
+				return len(podList.Items), nil
+			}, 300).Should(BeEquivalentTo(2))
+
+			AssertClusterIsReady(operatorNamespace, clusterName, testTimeouts[timeouts.ClusterIsReady], env)
+		})
+	})
+})
+
+var _ = Describe("Namespaced Deployment - Node Drain", Label(tests.LabelNoOpenshift, tests.LabelDisruptive,
+	tests.LabelReducedRbacOperator), Ordered, Serial, func() {
+	const (
+		operatorNamespace = "cnpg-system"
+		clusterName       = "postgresql-storage-class"
+		sampleFile        = fixturesDir + "/base/cluster-storage-class.yaml.template"
+		level             = tests.Highest
+	)
+	var nodesWithLabels []string
+
+	BeforeAll(func() {
+		if testLevelEnv.Depth < int(level) {
+			Skip("Test depth is lower than the amount requested for this test")
+		}
+
+		if IsOpenshift() {
+			Skip("This test case is not applicable on OpenShift clusters")
+		}
+
+		namespaced.StoreDefaultRBACSpec(env)
+		namespaced.ConfigureOperatorWithoutNodeAccess(env, operatorNamespace, uint(testTimeouts[timeouts.OperatorIsReady]))
+	})
+
+	AfterAll(func() {
+		namespaced.RevertOperatorToClusterWideMode(env, operatorNamespace, uint(testTimeouts[timeouts.OperatorIsReady]))
+	})
+
+	AfterEach(func() {
+		if CurrentSpecReport().Failed() {
+			namespaces.DumpNamespaceObjects(
+				env.Ctx, env.Client,
+				operatorNamespace, "out/"+CurrentSpecReport().LeafNodeText+"operator.log")
+		}
+
+		By("deleting cluster", func() {
+			err := DeleteResourcesFromFile(operatorNamespace, sampleFile)
+			Expect(err).ToNot(HaveOccurred())
+			Eventually(func() error {
+				_, err := clusterutils.Get(env.Ctx, env.Client, operatorNamespace, clusterName)
+				return err
+			}, testTimeouts[timeouts.ClusterIsReady]).Should(HaveOccurred())
+		})
+	})
+
+	BeforeEach(func() {
+		nodeList, _ := nodes.List(env.Ctx, env.Client)
+		for _, node := range nodeList.Items {
+			if (node.Spec.Unschedulable != true) && (len(node.Spec.Taints) == 0) {
+				nodesWithLabels = append(nodesWithLabels, node.Name)
+				cmd := fmt.Sprintf("kubectl label node %v drain=drain --overwrite", node.Name)
+				_, stderr, err := run.Run(cmd)
+				Expect(stderr).To(BeEmpty())
+				Expect(err).ToNot(HaveOccurred())
+			}
+			if len(nodesWithLabels) == 3 {
+				break
+			}
+		}
+		Expect(len(nodesWithLabels)).Should(BeNumerically(">=", 2),
+			"Not enough nodes are available for this test")
+	})
+
+	AfterEach(func() {
+		err := nodes.UncordonAll(env.Ctx, env.Client)
+		Expect(err).ToNot(HaveOccurred())
+		for _, node := range nodesWithLabels {
+			cmd := fmt.Sprintf("kubectl label node %v drain-", node)
+			_, _, _ = run.Run(cmd)
+		}
+		nodesWithLabels = nil
+	})
+
+	It("can drain a node with cluster pods", func() {
+		By("creating a cluster in operator namespace", func() {
+			CreateResourceFromFile(operatorNamespace, sampleFile)
+			AssertClusterIsReady(operatorNamespace, clusterName, testTimeouts[timeouts.ClusterIsReady], env)
+		})
+
+		By("disabling PDB", func() {
+			cluster, err := clusterutils.Get(env.Ctx, env.Client, operatorNamespace, clusterName)
+			Expect(err).ToNot(HaveOccurred())
+
+			oldCluster := cluster.DeepCopy()
+			cluster.Spec.EnablePDB = ptr.To(false)
+			err = env.Client.Patch(env.Ctx, cluster, ctrlclient.MergeFrom(oldCluster))
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		tableLocator := TableLocator{
+			Namespace:    operatorNamespace,
+			ClusterName:  clusterName,
+			DatabaseName: postgres.AppDBName,
+			TableName:    "test",
+		}
+
+		By("loading test data", func() {
+			AssertCreateTestData(env, tableLocator)
+		})
+
+		oldPrimary, err := clusterutils.GetPrimary(env.Ctx, env.Client, operatorNamespace, clusterName)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("draining the primary node", func() {
+			_ = nodes.DrainPrimary(
+				env.Ctx, env.Client,
+				operatorNamespace, clusterName,
+				testTimeouts[timeouts.DrainNode],
+			)
+		})
+
+		By("verifying failover after drain", func() {
+			Eventually(func() (string, error) {
+				pod, err := clusterutils.GetPrimary(env.Ctx, env.Client, operatorNamespace, clusterName)
+				if err != nil {
+					return "", err
+				}
+				return pod.Name, err
+			}, 180).ShouldNot(BeEquivalentTo(oldPrimary.Name))
+		})
+
+		By("uncordoning all nodes", func() {
+			err := nodes.UncordonAll(env.Ctx, env.Client)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		By("verifying data and cluster health", func() {
+			AssertClusterIsReady(operatorNamespace, clusterName, testTimeouts[timeouts.ClusterIsReady], env)
+			AssertDataExpectedCount(env, tableLocator, 2)
+			AssertClusterStandbysAreStreaming(operatorNamespace, clusterName, 140)
+		})
+	})
+})

--- a/tests/e2e/namespaced_deployment_test.go
+++ b/tests/e2e/namespaced_deployment_test.go
@@ -27,6 +27,10 @@ import (
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/cloudnative-pg/cloudnative-pg/tests"
+	clusterasserts "github.com/cloudnative-pg/cloudnative-pg/tests/internal/asserts/cluster"
+	pgasserts "github.com/cloudnative-pg/cloudnative-pg/tests/internal/asserts/postgres"
+	replicationasserts "github.com/cloudnative-pg/cloudnative-pg/tests/internal/asserts/replication"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/internal/resources"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/clusterutils"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/exec"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/namespaced"
@@ -43,11 +47,10 @@ import (
 var _ = Describe("Namespaced Deployment", Label(tests.LabelNoOpenshift, tests.LabelDisruptive,
 	tests.LabelReducedRbacOperator), Ordered, Serial, func() {
 	const (
-		operatorNamespace          = "cnpg-system"
-		namespacedOperatorManifest = fixturesDir + "/namespaced/manifest.yaml"
-		clusterName                = "postgresql-storage-class"
-		sampleFile                 = fixturesDir + "/base/cluster-storage-class.yaml.template"
-		level                      = tests.Highest
+		operatorNamespace = "cnpg-system"
+		clusterName       = "postgresql-storage-class"
+		sampleFile        = fixturesDir + "/base/cluster-storage-class.yaml.template"
+		level             = tests.Highest
 	)
 
 	BeforeAll(func() {
@@ -75,7 +78,7 @@ var _ = Describe("Namespaced Deployment", Label(tests.LabelNoOpenshift, tests.La
 		}
 
 		By("deleting cluster", func() {
-			err := DeleteResourcesFromFile(operatorNamespace, sampleFile)
+			err := resources.DeleteResourcesFromFile(env, operatorNamespace, sampleFile)
 			Expect(err).ToNot(HaveOccurred())
 			// Wait for the cluster to be deleted
 			Eventually(func() error {
@@ -87,11 +90,11 @@ var _ = Describe("Namespaced Deployment", Label(tests.LabelNoOpenshift, tests.La
 
 	It("can create and reconcile clusters in namespaced mode", func() {
 		By("creating a cluster in the operator namespace", func() {
-			CreateResourceFromFile(operatorNamespace, sampleFile)
+			resources.CreateResourceFromFile(env, operatorNamespace, sampleFile)
 		})
 
 		By("verifying cluster becomes ready", func() {
-			AssertClusterIsReady(operatorNamespace, clusterName, testTimeouts[timeouts.ClusterIsReady], env)
+			clusterasserts.AssertClusterIsReady(env, operatorNamespace, clusterName, testTimeouts[timeouts.ClusterIsReady])
 		})
 
 		By("verifying cluster can be reconciled", func() {
@@ -136,7 +139,7 @@ var _ = Describe("Namespaced Deployment", Label(tests.LabelNoOpenshift, tests.La
 				return len(podList.Items), nil
 			}, 300).Should(BeEquivalentTo(2))
 
-			AssertClusterIsReady(operatorNamespace, clusterName, testTimeouts[timeouts.ClusterIsReady], env)
+			clusterasserts.AssertClusterIsReady(env, operatorNamespace, clusterName, testTimeouts[timeouts.ClusterIsReady])
 		})
 	})
 })
@@ -176,7 +179,7 @@ var _ = Describe("Namespaced Deployment - Node Drain", Label(tests.LabelNoOpensh
 		}
 
 		By("deleting cluster", func() {
-			err := DeleteResourcesFromFile(operatorNamespace, sampleFile)
+			err := resources.DeleteResourcesFromFile(env, operatorNamespace, sampleFile)
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(func() error {
 				_, err := clusterutils.Get(env.Ctx, env.Client, operatorNamespace, clusterName)
@@ -215,8 +218,8 @@ var _ = Describe("Namespaced Deployment - Node Drain", Label(tests.LabelNoOpensh
 
 	It("can drain a node with cluster pods", func() {
 		By("creating a cluster in operator namespace", func() {
-			CreateResourceFromFile(operatorNamespace, sampleFile)
-			AssertClusterIsReady(operatorNamespace, clusterName, testTimeouts[timeouts.ClusterIsReady], env)
+			resources.CreateResourceFromFile(env, operatorNamespace, sampleFile)
+			clusterasserts.AssertClusterIsReady(env, operatorNamespace, clusterName, testTimeouts[timeouts.ClusterIsReady])
 		})
 
 		By("disabling PDB", func() {
@@ -229,7 +232,7 @@ var _ = Describe("Namespaced Deployment - Node Drain", Label(tests.LabelNoOpensh
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		tableLocator := TableLocator{
+		tableLocator := pgasserts.TableLocator{
 			Namespace:    operatorNamespace,
 			ClusterName:  clusterName,
 			DatabaseName: postgres.AppDBName,
@@ -237,7 +240,7 @@ var _ = Describe("Namespaced Deployment - Node Drain", Label(tests.LabelNoOpensh
 		}
 
 		By("loading test data", func() {
-			AssertCreateTestData(env, tableLocator)
+			pgasserts.AssertCreateTestData(env, tableLocator)
 		})
 
 		oldPrimary, err := clusterutils.GetPrimary(env.Ctx, env.Client, operatorNamespace, clusterName)
@@ -267,9 +270,9 @@ var _ = Describe("Namespaced Deployment - Node Drain", Label(tests.LabelNoOpensh
 		})
 
 		By("verifying data and cluster health", func() {
-			AssertClusterIsReady(operatorNamespace, clusterName, testTimeouts[timeouts.ClusterIsReady], env)
-			AssertDataExpectedCount(env, tableLocator, 2)
-			AssertClusterStandbysAreStreaming(operatorNamespace, clusterName, 140)
+			clusterasserts.AssertClusterIsReady(env, operatorNamespace, clusterName, testTimeouts[timeouts.ClusterIsReady])
+			pgasserts.AssertDataExpectedCount(env, tableLocator, 2)
+			replicationasserts.AssertClusterStandbysAreStreaming(env, operatorNamespace, clusterName, 140)
 		})
 	})
 })

--- a/tests/labels.go
+++ b/tests/labels.go
@@ -106,4 +106,7 @@ const (
 
 	// LabelImageVolumeExtensions is a label for imageVolume extensions tests
 	LabelImageVolumeExtensions = "image-volume-extensions"
+
+	// LabelReducedRbacOperator is a label for namespaced deployment tests with restricted rbac
+	LabelReducedRbacOperator = "reduced-rbac-operator"
 )

--- a/tests/utils/namespaced/doc.go
+++ b/tests/utils/namespaced/doc.go
@@ -1,0 +1,21 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+// Package namespaced provides utilities for testing CloudNativePG operator with reduced RBAC permission.
+package namespaced

--- a/tests/utils/namespaced/namespaced.go
+++ b/tests/utils/namespaced/namespaced.go
@@ -1,0 +1,287 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package namespaced
+
+import (
+	"slices"
+	"strconv"
+	"strings"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/environment"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/operator"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// RBACRestrictionOptions defines which RBAC resources to restrict
+type RBACRestrictionOptions struct {
+	RemoveNodeAccess                bool
+	RemoveClusterImageCatalogAccess bool // TODO in separate commit
+}
+
+// defaultClusterRoleRules stores the original cluster role rules for restoration
+var defaultClusterRoleRules []rbacv1.PolicyRule
+
+// removeResourceFromRules removes a specific resource from all rules
+func removeResourceFromRules(rules []rbacv1.PolicyRule, resource string) []rbacv1.PolicyRule {
+	var filtered []rbacv1.PolicyRule
+	for _, rule := range rules {
+		var filteredResources []string
+		for _, r := range rule.Resources {
+			if r != resource {
+				filteredResources = append(filteredResources, r)
+			}
+		}
+		if len(filteredResources) > 0 {
+			rule.Resources = filteredResources
+			filtered = append(filtered, rule)
+		}
+	}
+	return filtered
+}
+
+// removeClusterImageCatalogsFromRules removes clusterimagecatalogs from all rules
+func removeClusterImageCatalogsFromRules(rules []rbacv1.PolicyRule) []rbacv1.PolicyRule {
+	return removeResourceFromRules(rules, "clusterimagecatalogs")
+}
+
+// removeNodesFromRules removes nodes from all rules
+func removeNodesFromRules(rules []rbacv1.PolicyRule) []rbacv1.PolicyRule {
+	return removeResourceFromRules(rules, "nodes")
+}
+
+// splitRBACRulesForNamespacedDeployment splits cluster role rules into cluster role and namespaced role rules
+func splitRBACRulesForNamespacedDeployment(clusterRole *rbacv1.ClusterRole) ([]rbacv1.PolicyRule, []rbacv1.PolicyRule) {
+	var roleRules, clusterRoleRules []rbacv1.PolicyRule
+
+	for _, rule := range clusterRole.Rules {
+		// Keep admission controller in cluster role
+		if slices.Contains(rule.APIGroups, "admissionregistration.k8s.io") {
+			clusterRoleRules = append(clusterRoleRules, *rule.DeepCopy())
+			continue
+		}
+
+		// Keep nodes in cluster role
+		if slices.Contains(rule.Resources, "nodes") {
+			clusterRoleRules = append(clusterRoleRules, *rule.DeepCopy())
+			continue
+		}
+
+		// Split imagecatalog and clusterimagecatalog into separate roles
+		if slices.Contains(rule.APIGroups, "postgresql.cnpg.io") &&
+			slices.Contains(rule.Resources, "imagecatalogs") && slices.Contains(rule.Resources, "clusterimagecatalogs") {
+			// clusterimagecatalog stays in cluster role
+			clusterRule := rule.DeepCopy()
+			clusterRule.Resources = []string{"clusterimagecatalogs"}
+			clusterRoleRules = append(clusterRoleRules, *clusterRule)
+
+			// imagecatalog goes to role
+			nsRule := rule.DeepCopy()
+			nsRule.Resources = []string{"imagecatalogs"}
+			roleRules = append(roleRules, *nsRule)
+			continue
+		}
+
+		// Add remaining resources to role
+		nsRule := rule.DeepCopy()
+		roleRules = append(roleRules, *nsRule)
+	}
+
+	return roleRules, clusterRoleRules
+}
+
+// StoreDefaultRBACSpec captures the default RBAC spec before modifications
+func StoreDefaultRBACSpec(env *environment.TestingEnvironment) {
+	var clusterRole rbacv1.ClusterRole
+	err := env.Client.Get(env.Ctx, types.NamespacedName{Name: "cnpg-manager"}, &clusterRole)
+	Expect(err).NotTo(HaveOccurred())
+	defaultClusterRoleRules = make([]rbacv1.PolicyRule, len(clusterRole.Rules))
+	for i, rule := range clusterRole.Rules {
+		defaultClusterRoleRules[i] = *rule.DeepCopy()
+	}
+}
+
+// ConfigureOperatorWithoutNodeAccess configures an existing operator deployment for namespaced mode
+func ConfigureOperatorWithoutNodeAccess(env *environment.TestingEnvironment, namespace string, timeout uint) {
+	ConfigureOperatorWithRBACRestrictions(env, namespace, RBACRestrictionOptions{
+		RemoveNodeAccess: true,
+	}, timeout)
+}
+
+// ConfigureOperatorWithRBACRestrictions configures RBAC restrictions based on provided options
+func ConfigureOperatorWithRBACRestrictions(
+	env *environment.TestingEnvironment,
+	namespace string,
+	opts RBACRestrictionOptions,
+	timeout uint,
+) {
+	By("patching deployment for namespaced mode", func() {
+		var deployment appsv1.Deployment
+		err := env.Client.Get(env.Ctx, types.NamespacedName{
+			Namespace: namespace,
+			Name:      "cnpg-controller-manager",
+		}, &deployment)
+		Expect(err).NotTo(HaveOccurred())
+
+		for i := range deployment.Spec.Template.Spec.Containers {
+			deployment.Spec.Template.Spec.Containers[i].Env = append(
+				deployment.Spec.Template.Spec.Containers[i].Env,
+				corev1.EnvVar{Name: "WATCH_NAMESPACE", Value: namespace},
+				corev1.EnvVar{Name: "WATCH_NODES", Value: strconv.FormatBool(!opts.RemoveNodeAccess)},
+			)
+		}
+		err = env.Client.Update(env.Ctx, &deployment)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	By("updating RBAC", func() {
+		var clusterRole rbacv1.ClusterRole
+		err := env.Client.Get(env.Ctx, types.NamespacedName{Name: "cnpg-manager"}, &clusterRole)
+		Expect(err).NotTo(HaveOccurred())
+
+		roleRules, clusterRoleRules := splitRBACRulesForNamespacedDeployment(&clusterRole)
+
+		if opts.RemoveClusterImageCatalogAccess {
+			clusterRoleRules = removeClusterImageCatalogsFromRules(clusterRoleRules)
+		}
+
+		if opts.RemoveNodeAccess {
+			clusterRoleRules = removeNodesFromRules(clusterRoleRules)
+		}
+
+		clusterRole.Rules = clusterRoleRules
+		err = env.Client.Update(env.Ctx, &clusterRole)
+		Expect(err).NotTo(HaveOccurred())
+
+		role := &rbacv1.Role{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "cnpg-manager",
+				Namespace: namespace,
+			},
+			Rules: roleRules,
+		}
+		err = env.Client.Create(env.Ctx, role)
+		if err != nil {
+			err = env.Client.Update(env.Ctx, role)
+			Expect(err).NotTo(HaveOccurred())
+		}
+
+		roleBinding := &rbacv1.RoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "cnpg-manager-rolebinding",
+				Namespace: namespace,
+			},
+			RoleRef: rbacv1.RoleRef{
+				APIGroup: "rbac.authorization.k8s.io",
+				Kind:     "Role",
+				Name:     "cnpg-manager",
+			},
+			Subjects: []rbacv1.Subject{
+				{
+					Kind:      "ServiceAccount",
+					Name:      "cnpg-manager",
+					Namespace: namespace,
+				},
+			},
+		}
+		err = env.Client.Create(env.Ctx, roleBinding)
+		if err != nil {
+			err = env.Client.Update(env.Ctx, roleBinding)
+			Expect(err).NotTo(HaveOccurred())
+		}
+	})
+
+	By("waiting for namespaced operator deployment to be ready", func() {
+		Expect(operator.WaitForReady(env.Ctx, env.Client, timeout, false)).Should(Succeed())
+	})
+}
+
+// RevertOperatorToClusterWideMode reverts the operator to cluster-wide mode with full permissions
+func RevertOperatorToClusterWideMode(env *environment.TestingEnvironment, namespace string, timeout uint) {
+	By("restoring cluster-wide RBAC", func() {
+		var clusterRole rbacv1.ClusterRole
+		err := env.Client.Get(env.Ctx, types.NamespacedName{Name: "cnpg-manager"}, &clusterRole)
+		Expect(err).NotTo(HaveOccurred())
+
+		clusterRole.Rules = make([]rbacv1.PolicyRule, len(defaultClusterRoleRules))
+		for i, rule := range defaultClusterRoleRules {
+			clusterRole.Rules[i] = *rule.DeepCopy()
+		}
+
+		err = env.Client.Update(env.Ctx, &clusterRole)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Verify the update
+		err = env.Client.Get(env.Ctx, types.NamespacedName{Name: "cnpg-manager"}, &clusterRole)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Delete existing role binding and role
+		err = env.Client.Delete(env.Ctx, &rbacv1.RoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "cnpg-manager-rolebinding",
+				Namespace: namespace,
+			},
+		})
+		if err != nil && !strings.Contains(err.Error(), "not found") {
+			Expect(err).NotTo(HaveOccurred())
+		}
+
+		err = env.Client.Delete(env.Ctx, &rbacv1.Role{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "cnpg-manager",
+				Namespace: namespace,
+			},
+		})
+		if err != nil && !strings.Contains(err.Error(), "not found") {
+			Expect(err).NotTo(HaveOccurred())
+		}
+	})
+	By("removing cluster-wide object access restrictions", func() {
+		var deployment appsv1.Deployment
+		err := env.Client.Get(env.Ctx, types.NamespacedName{
+			Namespace: namespace,
+			Name:      "cnpg-controller-manager",
+		}, &deployment)
+		Expect(err).NotTo(HaveOccurred())
+
+		for i := range deployment.Spec.Template.Spec.Containers {
+			var filteredEnv []corev1.EnvVar
+			for _, env := range deployment.Spec.Template.Spec.Containers[i].Env {
+				if env.Name != "WATCH_NAMESPACE" && env.Name != "WATCH_NODES" {
+					filteredEnv = append(filteredEnv, env)
+				}
+			}
+			deployment.Spec.Template.Spec.Containers[i].Env = filteredEnv
+		}
+		err = env.Client.Update(env.Ctx, &deployment)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	By("waiting for operator deployment to be ready", func() {
+		Expect(operator.WaitForReady(env.Ctx, env.Client, timeout, true)).Should(Succeed())
+	})
+}

--- a/tests/utils/namespaced/namespaced.go
+++ b/tests/utils/namespaced/namespaced.go
@@ -22,11 +22,11 @@ package namespaced
 import (
 	"slices"
 	"strconv"
-	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -185,10 +185,10 @@ func ConfigureOperatorWithRBACRestrictions(
 			Rules: roleRules,
 		}
 		err = env.Client.Create(env.Ctx, role)
-		if err != nil {
+		if apierrors.IsAlreadyExists(err) {
 			err = env.Client.Update(env.Ctx, role)
-			Expect(err).NotTo(HaveOccurred())
 		}
+		Expect(err).NotTo(HaveOccurred())
 
 		roleBinding := &rbacv1.RoleBinding{
 			ObjectMeta: metav1.ObjectMeta{
@@ -209,10 +209,10 @@ func ConfigureOperatorWithRBACRestrictions(
 			},
 		}
 		err = env.Client.Create(env.Ctx, roleBinding)
-		if err != nil {
+		if apierrors.IsAlreadyExists(err) {
 			err = env.Client.Update(env.Ctx, roleBinding)
-			Expect(err).NotTo(HaveOccurred())
 		}
+		Expect(err).NotTo(HaveOccurred())
 	})
 
 	By("waiting for namespaced operator deployment to be ready", func() {
@@ -246,7 +246,7 @@ func RevertOperatorToClusterWideMode(env *environment.TestingEnvironment, namesp
 				Namespace: namespace,
 			},
 		})
-		if err != nil && !strings.Contains(err.Error(), "not found") {
+		if err != nil && !apierrors.IsNotFound(err) {
 			Expect(err).NotTo(HaveOccurred())
 		}
 
@@ -256,7 +256,7 @@ func RevertOperatorToClusterWideMode(env *environment.TestingEnvironment, namesp
 				Namespace: namespace,
 			},
 		})
-		if err != nil && !strings.Contains(err.Error(), "not found") {
+		if err != nil && !apierrors.IsNotFound(err) {
 			Expect(err).NotTo(HaveOccurred())
 		}
 	})


### PR DESCRIPTION
CNPG currently relies on access to cluster nodes. This PR introduces the possibility to opt out of this dependency by not watching for node events or invoking the k8 api to request node info. 

This PR also introduces a new utils package for configuring the RBAC for the operator at runtime. This is used to split the default cluster role policies into role and cluster role. This intends to mimic a deployment of the operator where the operator and operand are deployed in the same namespace. This package also has the possibility to remove some resources from the rbac policies, such as nodes

**Note**
This is a modification & split out of #9350 

Fixes #9346

Signed-off-by: Max Lengdell max.a.lengdell@ericsson.com