### PR TITLE
fix(lint): work around nolintlint false positives from cache bug

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -87,6 +87,11 @@ linters:
           alias: metav1
         - pkg: k8s.io/client-go/kubernetes/typed/core/v1
           alias: corev1client
+    nolintlint:
+      # We are temporarily allowing unused nolints due to apparently
+      # false failures in CI. See
+      # https://github.com/golangci/golangci-lint/issues/3228
+      allow-unused: true
   exclusions:
     generated: lax
     rules:


### PR DESCRIPTION
Set allow-unused: true for nolintlint to prevent flaky CI failures caused by a known golangci-lint bug (https://github.com/golangci/golangci-lint/issues/3228) where the internal cache loses staticcheck SA1019 deprecation facts across runs, causing nolintlint to falsely report `//nolint:staticcheck` directives as unused.