### PR TITLE
test(pidfile): use impossible PID in unit test to prevent flakiness

### DIFF
--- a/pkg/management/postgres/pidfile_test.go
+++ b/pkg/management/postgres/pidfile_test.go
@@ -62,12 +62,16 @@ var _ = Describe("the detection of a postmaster process using the pid file", fun
 		instance.PgData = pgdata
 		instance.SocketDirectory = socketDir
 
+		// Use a PID that is guaranteed not to exist on any system.
+		// The Linux kernel pid_max is at most 4194304 (2^22),
+		// so 5000000 is safely above any possible real PID and
+		// well within the range of a 32-bit int.
 		pidFile := filepath.Join(pgdata, PostgresqlPidFile)
-		err := os.WriteFile(pidFile, []byte("1234"), 0o400)
+		err := os.WriteFile(pidFile, []byte("5000000"), 0o400)
 		Expect(err).ShouldNot(HaveOccurred())
 
 		lockFile := filepath.Join(socketDir, PostgresqlPidFile)
-		err = os.WriteFile(filepath.Join(socketDir, ".s.PGSQL.5432.lock"), []byte("1234"), 0o400)
+		err = os.WriteFile(filepath.Join(socketDir, ".s.PGSQL.5432.lock"), []byte("5000000"), 0o400)
 		Expect(err).ShouldNot(HaveOccurred())
 
 		process, err := instance.CheckForExistingPostmaster(GetPostgresExecutableName())


### PR DESCRIPTION
The pidfile unit test was using PID 1234, which could match an actual process on CI runners. When that happened, the go-ps library would attempt to parse `/proc/1234/stat` and fail with "expected space in input to match format" if the process name contained special characters (e.g., parentheses or spaces).

Use PID 5000000 instead, which is above the Linux kernel's maximum `pid_max` (4194304), guaranteeing it will never correspond to a real process.

Flaky test trace: https://github.com/cloudnative-pg/cloudnative-pg/actions/runs/22711464590/job/65850424794?pr=10136