### PR TITLE
chore: limit the tag length to 50 characters

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -464,7 +464,7 @@ jobs:
           fi
 
           # extract tag from branch name
-          tag_name=$(echo "$branch_name" | tr / -)
+          tag_name=$(echo "$branch_name" | tr / - | head -c 50)
 
           echo "DATE=${commit_date}" >> $GITHUB_ENV
           echo "VERSION=${commit_version}" >> $GITHUB_ENV


### PR DESCRIPTION
Long tag names may cause errors in components that require parsing, such as operator-sdk. This limit is given by the spec https://github.com/opencontainers/distribution-spec/blob/main/spec.md#pulling-manifests that requires having 128 characters to pull images, that's the tag plus the digest sha256, limiting to 50 it's a close number to leave the 72 characters for the digest plus some extra.

Closes #10175 