### PR TITLE
fix(services): reconcile managed service spec changes with patch strategy

### DIFF
--- a/internal/controller/cluster_create.go
+++ b/internal/controller/cluster_create.go
@@ -47,6 +47,7 @@ import (
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/certs"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/postgres"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/reconciler/persistentvolumeclaim"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/servicespec"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/specs"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/versions"
@@ -421,12 +422,6 @@ func (r *ClusterReconciler) serviceReconciler(
 	}
 	var shouldUpdate bool
 
-	// we ensure that the selector perfectly match
-	if !reflect.DeepEqual(proposed.Spec.Selector, livingService.Spec.Selector) {
-		livingService.Spec.Selector = proposed.Spec.Selector
-		shouldUpdate = true
-	}
-
 	// we ensure we've some space to store the labels and the annotations
 	if livingService.Labels == nil {
 		livingService.Labels = make(map[string]string)
@@ -446,13 +441,20 @@ func (r *ClusterReconciler) serviceReconciler(
 		shouldUpdate = true
 	}
 
+	// we check if the service spec has changed, preserving Kubernetes-managed fields
+	patchedSpec := proposed.Spec.DeepCopy()
+	servicespec.PreserveKubernetesDefaults(patchedSpec, &livingService.Spec)
+	if !reflect.DeepEqual(*patchedSpec, livingService.Spec) {
+		livingService.Spec = *patchedSpec
+		shouldUpdate = true
+	}
+
 	if !shouldUpdate {
 		return nil
 	}
 
 	if strategy == apiv1.ServiceUpdateStrategyPatch {
 		contextLogger.Info("reconciling service")
-		// we update to ensure that we substitute the selectors
 		return r.Update(ctx, &livingService)
 	}
 

--- a/internal/controller/cluster_create_test.go
+++ b/internal/controller/cluster_create_test.go
@@ -1306,6 +1306,78 @@ var _ = Describe("Service Reconciling", func() {
 				Expect(updatedService.Spec.Selector).To(Equal(proposedService.Spec.Selector))
 			})
 
+			It("should update the service spec when using patch strategy and spec fields change", func() {
+				existingService := proposedService.DeepCopy()
+				existingService.Annotations = map[string]string{
+					utils.UpdateStrategyAnnotation: string(apiv1.ServiceUpdateStrategyPatch),
+				}
+				existingService.Spec.Type = corev1.ServiceTypeLoadBalancer
+				existingService.Spec.LoadBalancerSourceRanges = []string{"10.0.0.0/8"}
+				err := serviceClient.Update(ctx, existingService)
+				Expect(err).NotTo(HaveOccurred())
+
+				proposedService.Annotations = map[string]string{
+					utils.UpdateStrategyAnnotation: string(apiv1.ServiceUpdateStrategyPatch),
+				}
+				proposedService.Spec.Type = corev1.ServiceTypeLoadBalancer
+				proposedService.Spec.LoadBalancerSourceRanges = []string{"10.0.0.0/8", "172.16.0.0/12"}
+
+				err = reconciler.serviceReconciler(ctx, &cluster, proposedService, true)
+				Expect(err).NotTo(HaveOccurred())
+
+				var updatedService corev1.Service
+				err = serviceClient.Get(ctx, types.NamespacedName{
+					Name:      proposedService.Name,
+					Namespace: proposedService.Namespace,
+				}, &updatedService)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(updatedService.Spec.LoadBalancerSourceRanges).To(Equal([]string{"10.0.0.0/8", "172.16.0.0/12"}))
+			})
+
+			It("should not trigger unnecessary updates when only Kubernetes-managed fields differ", func() {
+				singleStack := corev1.IPFamilyPolicySingleStack
+				clusterPolicy := corev1.ServiceInternalTrafficPolicyCluster
+				existingService := proposedService.DeepCopy()
+				existingService.Spec.Type = corev1.ServiceTypeLoadBalancer
+				existingService.Spec.ClusterIP = "10.96.0.1"
+				existingService.Spec.ClusterIPs = []string{"10.96.0.1"}
+				existingService.Spec.IPFamilies = []corev1.IPFamily{corev1.IPv4Protocol}
+				existingService.Spec.IPFamilyPolicy = &singleStack
+				existingService.Spec.InternalTrafficPolicy = &clusterPolicy
+				existingService.Spec.SessionAffinity = corev1.ServiceAffinityNone
+				existingService.Spec.ExternalTrafficPolicy = corev1.ServiceExternalTrafficPolicyLocal
+				existingService.Spec.Ports = []corev1.ServicePort{
+					{Port: 80, Protocol: corev1.ProtocolTCP,
+						TargetPort: intstr.FromInt32(80), NodePort: 31234},
+				}
+				existingService.Spec.HealthCheckNodePort = 30000
+				err := serviceClient.Update(ctx, existingService)
+				Expect(err).NotTo(HaveOccurred())
+
+				proposedService.Spec.Type = corev1.ServiceTypeLoadBalancer
+				proposedService.Spec.Ports = []corev1.ServicePort{{Port: 80}}
+				proposedService.Spec.ExternalTrafficPolicy = corev1.ServiceExternalTrafficPolicyLocal
+
+				err = reconciler.serviceReconciler(ctx, &cluster, proposedService, true)
+				Expect(err).NotTo(HaveOccurred())
+
+				var updatedService corev1.Service
+				err = serviceClient.Get(ctx, types.NamespacedName{
+					Name:      proposedService.Name,
+					Namespace: proposedService.Namespace,
+				}, &updatedService)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(updatedService.Spec.ClusterIP).To(Equal("10.96.0.1"))
+				Expect(updatedService.Spec.Ports[0].NodePort).To(Equal(int32(31234)))
+				Expect(updatedService.Spec.Ports[0].Protocol).To(Equal(corev1.ProtocolTCP))
+				Expect(updatedService.Spec.Ports[0].TargetPort).To(Equal(intstr.FromInt32(80)))
+				Expect(updatedService.Spec.HealthCheckNodePort).To(Equal(int32(30000)))
+				Expect(updatedService.Spec.IPFamilies).To(Equal([]corev1.IPFamily{corev1.IPv4Protocol}))
+				Expect(updatedService.Spec.IPFamilyPolicy).To(Equal(&singleStack))
+				Expect(updatedService.Spec.InternalTrafficPolicy).To(Equal(&clusterPolicy))
+				Expect(updatedService.Spec.SessionAffinity).To(Equal(corev1.ServiceAffinityNone))
+			})
+
 			It("should preserve existing labels and annotations added by third parties", func() {
 				existingService := proposedService.DeepCopy()
 				existingService.Labels = map[string]string{"custom-label": "value"}

--- a/internal/controller/cluster_create_test.go
+++ b/internal/controller/cluster_create_test.go
@@ -1347,8 +1347,10 @@ var _ = Describe("Service Reconciling", func() {
 				existingService.Spec.SessionAffinity = corev1.ServiceAffinityNone
 				existingService.Spec.ExternalTrafficPolicy = corev1.ServiceExternalTrafficPolicyLocal
 				existingService.Spec.Ports = []corev1.ServicePort{
-					{Port: 80, Protocol: corev1.ProtocolTCP,
-						TargetPort: intstr.FromInt32(80), NodePort: 31234},
+					{
+						Port: 80, Protocol: corev1.ProtocolTCP,
+						TargetPort: intstr.FromInt32(80), NodePort: 31234,
+					},
 				}
 				existingService.Spec.HealthCheckNodePort = 30000
 				err := serviceClient.Update(ctx, existingService)

--- a/internal/controller/pooler_update.go
+++ b/internal/controller/pooler_update.go
@@ -33,6 +33,7 @@ import (
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/internal/configuration"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/servicespec"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/specs/pgbouncer"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 )
@@ -149,6 +150,7 @@ func (r *PoolerReconciler) reconcileService(
 
 	patchedService := resources.Service.DeepCopy()
 	patchedService.Spec = expectedService.Spec
+	servicespec.PreserveKubernetesDefaults(&patchedService.Spec, &resources.Service.Spec)
 	utils.MergeObjectsMetadata(patchedService, expectedService)
 
 	if reflect.DeepEqual(patchedService.ObjectMeta, resources.Service.ObjectMeta) &&

--- a/pkg/servicespec/defaults.go
+++ b/pkg/servicespec/defaults.go
@@ -48,6 +48,9 @@ func PreserveKubernetesDefaults(proposed, living *corev1.ServiceSpec) {
 	if proposed.HealthCheckNodePort == 0 {
 		proposed.HealthCheckNodePort = living.HealthCheckNodePort
 	}
+	if proposed.AllocateLoadBalancerNodePorts == nil {
+		proposed.AllocateLoadBalancerNodePorts = living.AllocateLoadBalancerNodePorts
+	}
 
 	preservePortDefaults(proposed.Ports, living.Ports)
 }

--- a/pkg/servicespec/defaults.go
+++ b/pkg/servicespec/defaults.go
@@ -19,7 +19,12 @@ SPDX-License-Identifier: Apache-2.0
 
 package servicespec
 
-import corev1 "k8s.io/api/core/v1"
+import (
+	"slices"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
 
 // PreserveKubernetesDefaults copies Kubernetes-managed fields from the living
 // service spec into the proposed one, so that a DeepEqual comparison only
@@ -27,11 +32,11 @@ import corev1 "k8s.io/api/core/v1"
 func PreserveKubernetesDefaults(proposed, living *corev1.ServiceSpec) {
 	// Always assigned by Kubernetes
 	proposed.ClusterIP = living.ClusterIP
-	proposed.ClusterIPs = living.ClusterIPs
+	proposed.ClusterIPs = slices.Clone(living.ClusterIPs)
 
 	// Defaulted at creation time
 	if len(proposed.IPFamilies) == 0 {
-		proposed.IPFamilies = living.IPFamilies
+		proposed.IPFamilies = slices.Clone(living.IPFamilies)
 	}
 	if proposed.IPFamilyPolicy == nil {
 		proposed.IPFamilyPolicy = living.IPFamilyPolicy
@@ -42,6 +47,9 @@ func PreserveKubernetesDefaults(proposed, living *corev1.ServiceSpec) {
 	if proposed.SessionAffinity == "" {
 		proposed.SessionAffinity = living.SessionAffinity
 	}
+	if proposed.SessionAffinityConfig == nil {
+		proposed.SessionAffinityConfig = living.SessionAffinityConfig
+	}
 	if proposed.ExternalTrafficPolicy == "" {
 		proposed.ExternalTrafficPolicy = living.ExternalTrafficPolicy
 	}
@@ -50,6 +58,9 @@ func PreserveKubernetesDefaults(proposed, living *corev1.ServiceSpec) {
 	}
 	if proposed.AllocateLoadBalancerNodePorts == nil {
 		proposed.AllocateLoadBalancerNodePorts = living.AllocateLoadBalancerNodePorts
+	}
+	if proposed.TrafficDistribution == nil {
+		proposed.TrafficDistribution = living.TrafficDistribution
 	}
 
 	preservePortDefaults(proposed.Ports, living.Ports)
@@ -83,7 +94,7 @@ func preservePortDefaults(proposed, living []corev1.ServicePort) {
 		if proposed[i].Protocol == "" {
 			proposed[i].Protocol = lp.Protocol
 		}
-		if proposed[i].TargetPort.IntValue() == 0 && proposed[i].TargetPort.StrVal == "" {
+		if proposed[i].TargetPort == (intstr.IntOrString{}) {
 			proposed[i].TargetPort = lp.TargetPort
 		}
 		if proposed[i].NodePort == 0 {

--- a/pkg/servicespec/defaults.go
+++ b/pkg/servicespec/defaults.go
@@ -1,0 +1,90 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package servicespec
+
+import corev1 "k8s.io/api/core/v1"
+
+// PreserveKubernetesDefaults copies Kubernetes-managed fields from the living
+// service spec into the proposed one, so that a DeepEqual comparison only
+// detects changes the operator actually controls.
+func PreserveKubernetesDefaults(proposed, living *corev1.ServiceSpec) {
+	// Always assigned by Kubernetes
+	proposed.ClusterIP = living.ClusterIP
+	proposed.ClusterIPs = living.ClusterIPs
+
+	// Defaulted at creation time
+	if len(proposed.IPFamilies) == 0 {
+		proposed.IPFamilies = living.IPFamilies
+	}
+	if proposed.IPFamilyPolicy == nil {
+		proposed.IPFamilyPolicy = living.IPFamilyPolicy
+	}
+	if proposed.InternalTrafficPolicy == nil {
+		proposed.InternalTrafficPolicy = living.InternalTrafficPolicy
+	}
+	if proposed.SessionAffinity == "" {
+		proposed.SessionAffinity = living.SessionAffinity
+	}
+	if proposed.ExternalTrafficPolicy == "" {
+		proposed.ExternalTrafficPolicy = living.ExternalTrafficPolicy
+	}
+	if proposed.HealthCheckNodePort == 0 {
+		proposed.HealthCheckNodePort = living.HealthCheckNodePort
+	}
+
+	preservePortDefaults(proposed.Ports, living.Ports)
+}
+
+// preservePortDefaults preserves Kubernetes-defaulted and Kubernetes-assigned
+// fields in service ports, matching by the strategic merge key (Port, Protocol).
+func preservePortDefaults(proposed, living []corev1.ServicePort) {
+	type portKey struct {
+		port     int32
+		protocol corev1.Protocol
+	}
+	key := func(p corev1.ServicePort) portKey {
+		protocol := p.Protocol
+		if protocol == "" {
+			protocol = corev1.ProtocolTCP
+		}
+		return portKey{port: p.Port, protocol: protocol}
+	}
+
+	livingPorts := make(map[portKey]*corev1.ServicePort, len(living))
+	for i := range living {
+		livingPorts[key(living[i])] = &living[i]
+	}
+
+	for i := range proposed {
+		lp, ok := livingPorts[key(proposed[i])]
+		if !ok {
+			continue
+		}
+		if proposed[i].Protocol == "" {
+			proposed[i].Protocol = lp.Protocol
+		}
+		if proposed[i].TargetPort.IntValue() == 0 && proposed[i].TargetPort.StrVal == "" {
+			proposed[i].TargetPort = lp.TargetPort
+		}
+		if proposed[i].NodePort == 0 {
+			proposed[i].NodePort = lp.NodePort
+		}
+	}
+}

--- a/pkg/servicespec/defaults_test.go
+++ b/pkg/servicespec/defaults_test.go
@@ -226,8 +226,10 @@ var _ = Describe("PreserveKubernetesDefaults", func() {
 		}
 		living := corev1.ServiceSpec{
 			Ports: []corev1.ServicePort{
-				{Name: "custom", Port: 8080, Protocol: corev1.ProtocolTCP,
-					TargetPort: intstr.FromInt32(8080), NodePort: 30001},
+				{
+					Name: "custom", Port: 8080, Protocol: corev1.ProtocolTCP,
+					TargetPort: intstr.FromInt32(8080), NodePort: 30001,
+				},
 			},
 		}
 		PreserveKubernetesDefaults(&proposed, &living)
@@ -239,14 +241,18 @@ var _ = Describe("PreserveKubernetesDefaults", func() {
 	It("should not override explicitly set Protocol and TargetPort", func() {
 		proposed := corev1.ServiceSpec{
 			Ports: []corev1.ServicePort{
-				{Name: "custom", Port: 8080, Protocol: corev1.ProtocolUDP,
-					TargetPort: intstr.FromInt32(9090)},
+				{
+					Name: "custom", Port: 8080, Protocol: corev1.ProtocolUDP,
+					TargetPort: intstr.FromInt32(9090),
+				},
 			},
 		}
 		living := corev1.ServiceSpec{
 			Ports: []corev1.ServicePort{
-				{Name: "custom", Port: 8080, Protocol: corev1.ProtocolUDP,
-					TargetPort: intstr.FromInt32(8080), NodePort: 30001},
+				{
+					Name: "custom", Port: 8080, Protocol: corev1.ProtocolUDP,
+					TargetPort: intstr.FromInt32(8080), NodePort: 30001,
+				},
 			},
 		}
 		PreserveKubernetesDefaults(&proposed, &living)

--- a/pkg/servicespec/defaults_test.go
+++ b/pkg/servicespec/defaults_test.go
@@ -1,0 +1,272 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package servicespec
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("PreserveKubernetesDefaults", func() {
+	It("should preserve ClusterIP and ClusterIPs", func() {
+		proposed := corev1.ServiceSpec{
+			Type:  corev1.ServiceTypeClusterIP,
+			Ports: []corev1.ServicePort{{Port: 5432, Name: "postgres"}},
+		}
+		living := corev1.ServiceSpec{
+			Type:       corev1.ServiceTypeClusterIP,
+			Ports:      []corev1.ServicePort{{Port: 5432, Name: "postgres"}},
+			ClusterIP:  "10.96.0.1",
+			ClusterIPs: []string{"10.96.0.1"},
+		}
+		PreserveKubernetesDefaults(&proposed, &living)
+		Expect(proposed.ClusterIP).To(Equal("10.96.0.1"))
+		Expect(proposed.ClusterIPs).To(Equal([]string{"10.96.0.1"}))
+	})
+
+	It("should preserve IPFamilies and IPFamilyPolicy when not set", func() {
+		proposed := corev1.ServiceSpec{
+			Type:  corev1.ServiceTypeClusterIP,
+			Ports: []corev1.ServicePort{{Port: 5432, Name: "postgres"}},
+		}
+		singleStack := corev1.IPFamilyPolicySingleStack
+		living := corev1.ServiceSpec{
+			Type:           corev1.ServiceTypeClusterIP,
+			Ports:          []corev1.ServicePort{{Port: 5432, Name: "postgres"}},
+			IPFamilies:     []corev1.IPFamily{corev1.IPv4Protocol},
+			IPFamilyPolicy: &singleStack,
+		}
+		PreserveKubernetesDefaults(&proposed, &living)
+		Expect(proposed.IPFamilies).To(Equal([]corev1.IPFamily{corev1.IPv4Protocol}))
+		Expect(proposed.IPFamilyPolicy).To(Equal(&singleStack))
+	})
+
+	It("should not override explicitly set IPFamilies", func() {
+		dualStack := corev1.IPFamilyPolicyPreferDualStack
+		proposed := corev1.ServiceSpec{
+			Type:           corev1.ServiceTypeClusterIP,
+			Ports:          []corev1.ServicePort{{Port: 5432, Name: "postgres"}},
+			IPFamilies:     []corev1.IPFamily{corev1.IPv4Protocol, corev1.IPv6Protocol},
+			IPFamilyPolicy: &dualStack,
+		}
+		singleStack := corev1.IPFamilyPolicySingleStack
+		living := corev1.ServiceSpec{
+			Type:           corev1.ServiceTypeClusterIP,
+			Ports:          []corev1.ServicePort{{Port: 5432, Name: "postgres"}},
+			IPFamilies:     []corev1.IPFamily{corev1.IPv4Protocol},
+			IPFamilyPolicy: &singleStack,
+		}
+		PreserveKubernetesDefaults(&proposed, &living)
+		Expect(proposed.IPFamilies).To(Equal([]corev1.IPFamily{corev1.IPv4Protocol, corev1.IPv6Protocol}))
+		Expect(proposed.IPFamilyPolicy).To(Equal(&dualStack))
+	})
+
+	It("should preserve InternalTrafficPolicy when not set", func() {
+		proposed := corev1.ServiceSpec{
+			Type:  corev1.ServiceTypeClusterIP,
+			Ports: []corev1.ServicePort{{Port: 5432, Name: "postgres"}},
+		}
+		clusterPolicy := corev1.ServiceInternalTrafficPolicyCluster
+		living := corev1.ServiceSpec{
+			Type:                  corev1.ServiceTypeClusterIP,
+			Ports:                 []corev1.ServicePort{{Port: 5432, Name: "postgres"}},
+			InternalTrafficPolicy: &clusterPolicy,
+		}
+		PreserveKubernetesDefaults(&proposed, &living)
+		Expect(proposed.InternalTrafficPolicy).To(Equal(&clusterPolicy))
+	})
+
+	It("should preserve SessionAffinity when not set", func() {
+		proposed := corev1.ServiceSpec{
+			Type:  corev1.ServiceTypeClusterIP,
+			Ports: []corev1.ServicePort{{Port: 5432, Name: "postgres"}},
+		}
+		living := corev1.ServiceSpec{
+			Type:            corev1.ServiceTypeClusterIP,
+			Ports:           []corev1.ServicePort{{Port: 5432, Name: "postgres"}},
+			SessionAffinity: corev1.ServiceAffinityNone,
+		}
+		PreserveKubernetesDefaults(&proposed, &living)
+		Expect(proposed.SessionAffinity).To(Equal(corev1.ServiceAffinityNone))
+	})
+
+	It("should not override explicitly set SessionAffinity", func() {
+		proposed := corev1.ServiceSpec{
+			Type:            corev1.ServiceTypeClusterIP,
+			Ports:           []corev1.ServicePort{{Port: 5432, Name: "postgres"}},
+			SessionAffinity: corev1.ServiceAffinityClientIP,
+		}
+		living := corev1.ServiceSpec{
+			Type:            corev1.ServiceTypeClusterIP,
+			Ports:           []corev1.ServicePort{{Port: 5432, Name: "postgres"}},
+			SessionAffinity: corev1.ServiceAffinityNone,
+		}
+		PreserveKubernetesDefaults(&proposed, &living)
+		Expect(proposed.SessionAffinity).To(Equal(corev1.ServiceAffinityClientIP))
+	})
+
+	It("should preserve ExternalTrafficPolicy when not set", func() {
+		proposed := corev1.ServiceSpec{
+			Type:  corev1.ServiceTypeLoadBalancer,
+			Ports: []corev1.ServicePort{{Port: 5432, Name: "postgres"}},
+		}
+		living := corev1.ServiceSpec{
+			Type:                  corev1.ServiceTypeLoadBalancer,
+			Ports:                 []corev1.ServicePort{{Port: 5432, Name: "postgres"}},
+			ExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyCluster,
+		}
+		PreserveKubernetesDefaults(&proposed, &living)
+		Expect(proposed.ExternalTrafficPolicy).To(Equal(corev1.ServiceExternalTrafficPolicyCluster))
+	})
+
+	It("should preserve HealthCheckNodePort when not set", func() {
+		proposed := corev1.ServiceSpec{
+			Type:  corev1.ServiceTypeLoadBalancer,
+			Ports: []corev1.ServicePort{{Port: 5432, Name: "postgres"}},
+		}
+		living := corev1.ServiceSpec{
+			Type:                corev1.ServiceTypeLoadBalancer,
+			Ports:               []corev1.ServicePort{{Port: 5432, Name: "postgres"}},
+			HealthCheckNodePort: 31000,
+		}
+		PreserveKubernetesDefaults(&proposed, &living)
+		Expect(proposed.HealthCheckNodePort).To(Equal(int32(31000)))
+	})
+
+	It("should not override explicitly set HealthCheckNodePort", func() {
+		proposed := corev1.ServiceSpec{
+			Type:                corev1.ServiceTypeLoadBalancer,
+			Ports:               []corev1.ServicePort{{Port: 5432, Name: "postgres"}},
+			HealthCheckNodePort: 32000,
+		}
+		living := corev1.ServiceSpec{
+			Type:                corev1.ServiceTypeLoadBalancer,
+			Ports:               []corev1.ServicePort{{Port: 5432, Name: "postgres"}},
+			HealthCheckNodePort: 31000,
+		}
+		PreserveKubernetesDefaults(&proposed, &living)
+		Expect(proposed.HealthCheckNodePort).To(Equal(int32(32000)))
+	})
+
+	It("should match NodePorts by port and protocol, not by index", func() {
+		proposed := corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{Name: "metrics", Port: 9187, Protocol: corev1.ProtocolTCP},
+				{Name: "postgres", Port: 5432, Protocol: corev1.ProtocolTCP},
+			},
+		}
+		living := corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{Name: "postgres", Port: 5432, Protocol: corev1.ProtocolTCP, NodePort: 30001},
+				{Name: "metrics", Port: 9187, Protocol: corev1.ProtocolTCP, NodePort: 30002},
+			},
+		}
+		PreserveKubernetesDefaults(&proposed, &living)
+		Expect(proposed.Ports[0].NodePort).To(Equal(int32(30002)), "metrics should get NodePort 30002")
+		Expect(proposed.Ports[1].NodePort).To(Equal(int32(30001)), "postgres should get NodePort 30001")
+	})
+
+	It("should not override explicitly set NodePorts", func() {
+		proposed := corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{Name: "postgres", Port: 5432, Protocol: corev1.ProtocolTCP, NodePort: 32000},
+			},
+		}
+		living := corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{Name: "postgres", Port: 5432, Protocol: corev1.ProtocolTCP, NodePort: 30001},
+			},
+		}
+		PreserveKubernetesDefaults(&proposed, &living)
+		Expect(proposed.Ports[0].NodePort).To(Equal(int32(32000)))
+	})
+
+	It("should handle new ports not present in living service", func() {
+		proposed := corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{Name: "postgres", Port: 5432, Protocol: corev1.ProtocolTCP},
+				{Name: "metrics", Port: 9187, Protocol: corev1.ProtocolTCP},
+			},
+		}
+		living := corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{Name: "postgres", Port: 5432, Protocol: corev1.ProtocolTCP, NodePort: 30001},
+			},
+		}
+		PreserveKubernetesDefaults(&proposed, &living)
+		Expect(proposed.Ports[0].NodePort).To(Equal(int32(30001)))
+		Expect(proposed.Ports[1].NodePort).To(Equal(int32(0)), "new port should have no NodePort")
+	})
+
+	It("should preserve Kubernetes-defaulted Protocol and TargetPort", func() {
+		proposed := corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{Name: "custom", Port: 8080},
+			},
+		}
+		living := corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{Name: "custom", Port: 8080, Protocol: corev1.ProtocolTCP,
+					TargetPort: intstr.FromInt32(8080), NodePort: 30001},
+			},
+		}
+		PreserveKubernetesDefaults(&proposed, &living)
+		Expect(proposed.Ports[0].Protocol).To(Equal(corev1.ProtocolTCP))
+		Expect(proposed.Ports[0].TargetPort).To(Equal(intstr.FromInt32(8080)))
+		Expect(proposed.Ports[0].NodePort).To(Equal(int32(30001)))
+	})
+
+	It("should not override explicitly set Protocol and TargetPort", func() {
+		proposed := corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{Name: "custom", Port: 8080, Protocol: corev1.ProtocolUDP,
+					TargetPort: intstr.FromInt32(9090)},
+			},
+		}
+		living := corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{Name: "custom", Port: 8080, Protocol: corev1.ProtocolUDP,
+					TargetPort: intstr.FromInt32(8080), NodePort: 30001},
+			},
+		}
+		PreserveKubernetesDefaults(&proposed, &living)
+		Expect(proposed.Ports[0].Protocol).To(Equal(corev1.ProtocolUDP))
+		Expect(proposed.Ports[0].TargetPort).To(Equal(intstr.FromInt32(9090)))
+	})
+
+	It("should match ports with empty protocol against TCP living ports", func() {
+		proposed := corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{Name: "postgres", Port: 5432},
+			},
+		}
+		living := corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{Name: "postgres", Port: 5432, Protocol: corev1.ProtocolTCP, NodePort: 30001},
+			},
+		}
+		PreserveKubernetesDefaults(&proposed, &living)
+		Expect(proposed.Ports[0].NodePort).To(Equal(int32(30001)))
+		Expect(proposed.Ports[0].Protocol).To(Equal(corev1.ProtocolTCP))
+	})
+})

--- a/pkg/servicespec/defaults_test.go
+++ b/pkg/servicespec/defaults_test.go
@@ -168,6 +168,38 @@ var _ = Describe("PreserveKubernetesDefaults", func() {
 		Expect(proposed.HealthCheckNodePort).To(Equal(int32(32000)))
 	})
 
+	It("should preserve AllocateLoadBalancerNodePorts when not set", func() {
+		alloc := true
+		proposed := corev1.ServiceSpec{
+			Type:  corev1.ServiceTypeLoadBalancer,
+			Ports: []corev1.ServicePort{{Port: 5432, Name: "postgres"}},
+		}
+		living := corev1.ServiceSpec{
+			Type:                          corev1.ServiceTypeLoadBalancer,
+			Ports:                         []corev1.ServicePort{{Port: 5432, Name: "postgres"}},
+			AllocateLoadBalancerNodePorts: &alloc,
+		}
+		PreserveKubernetesDefaults(&proposed, &living)
+		Expect(proposed.AllocateLoadBalancerNodePorts).To(Equal(&alloc))
+	})
+
+	It("should not override explicitly set AllocateLoadBalancerNodePorts", func() {
+		allocTrue := true
+		allocFalse := false
+		proposed := corev1.ServiceSpec{
+			Type:                          corev1.ServiceTypeLoadBalancer,
+			Ports:                         []corev1.ServicePort{{Port: 5432, Name: "postgres"}},
+			AllocateLoadBalancerNodePorts: &allocFalse,
+		}
+		living := corev1.ServiceSpec{
+			Type:                          corev1.ServiceTypeLoadBalancer,
+			Ports:                         []corev1.ServicePort{{Port: 5432, Name: "postgres"}},
+			AllocateLoadBalancerNodePorts: &allocTrue,
+		}
+		PreserveKubernetesDefaults(&proposed, &living)
+		Expect(proposed.AllocateLoadBalancerNodePorts).To(Equal(&allocFalse))
+	})
+
 	It("should match NodePorts by port and protocol, not by index", func() {
 		proposed := corev1.ServiceSpec{
 			Ports: []corev1.ServicePort{

--- a/pkg/servicespec/defaults_test.go
+++ b/pkg/servicespec/defaults_test.go
@@ -125,6 +125,45 @@ var _ = Describe("PreserveKubernetesDefaults", func() {
 		Expect(proposed.SessionAffinity).To(Equal(corev1.ServiceAffinityClientIP))
 	})
 
+	It("should preserve SessionAffinityConfig when not set", func() {
+		timeoutSeconds := int32(3600)
+		proposed := corev1.ServiceSpec{
+			Type:  corev1.ServiceTypeClusterIP,
+			Ports: []corev1.ServicePort{{Port: 5432, Name: "postgres"}},
+		}
+		living := corev1.ServiceSpec{
+			Type:            corev1.ServiceTypeClusterIP,
+			Ports:           []corev1.ServicePort{{Port: 5432, Name: "postgres"}},
+			SessionAffinity: corev1.ServiceAffinityClientIP,
+			SessionAffinityConfig: &corev1.SessionAffinityConfig{
+				ClientIP: &corev1.ClientIPConfig{TimeoutSeconds: &timeoutSeconds},
+			},
+		}
+		PreserveKubernetesDefaults(&proposed, &living)
+		Expect(proposed.SessionAffinityConfig).To(Equal(living.SessionAffinityConfig))
+	})
+
+	It("should not override explicitly set SessionAffinityConfig", func() {
+		timeout1 := int32(1800)
+		timeout2 := int32(3600)
+		proposed := corev1.ServiceSpec{
+			Type:  corev1.ServiceTypeClusterIP,
+			Ports: []corev1.ServicePort{{Port: 5432, Name: "postgres"}},
+			SessionAffinityConfig: &corev1.SessionAffinityConfig{
+				ClientIP: &corev1.ClientIPConfig{TimeoutSeconds: &timeout1},
+			},
+		}
+		living := corev1.ServiceSpec{
+			Type:  corev1.ServiceTypeClusterIP,
+			Ports: []corev1.ServicePort{{Port: 5432, Name: "postgres"}},
+			SessionAffinityConfig: &corev1.SessionAffinityConfig{
+				ClientIP: &corev1.ClientIPConfig{TimeoutSeconds: &timeout2},
+			},
+		}
+		PreserveKubernetesDefaults(&proposed, &living)
+		Expect(proposed.SessionAffinityConfig.ClientIP.TimeoutSeconds).To(Equal(&timeout1))
+	})
+
 	It("should preserve ExternalTrafficPolicy when not set", func() {
 		proposed := corev1.ServiceSpec{
 			Type:  corev1.ServiceTypeLoadBalancer,
@@ -198,6 +237,38 @@ var _ = Describe("PreserveKubernetesDefaults", func() {
 		}
 		PreserveKubernetesDefaults(&proposed, &living)
 		Expect(proposed.AllocateLoadBalancerNodePorts).To(Equal(&allocFalse))
+	})
+
+	It("should preserve TrafficDistribution when not set", func() {
+		dist := "PreferClose"
+		proposed := corev1.ServiceSpec{
+			Type:  corev1.ServiceTypeClusterIP,
+			Ports: []corev1.ServicePort{{Port: 5432, Name: "postgres"}},
+		}
+		living := corev1.ServiceSpec{
+			Type:                corev1.ServiceTypeClusterIP,
+			Ports:               []corev1.ServicePort{{Port: 5432, Name: "postgres"}},
+			TrafficDistribution: &dist,
+		}
+		PreserveKubernetesDefaults(&proposed, &living)
+		Expect(proposed.TrafficDistribution).To(Equal(&dist))
+	})
+
+	It("should not override explicitly set TrafficDistribution", func() {
+		proposedDist := "PreferClose"
+		livingDist := "other"
+		proposed := corev1.ServiceSpec{
+			Type:                corev1.ServiceTypeClusterIP,
+			Ports:               []corev1.ServicePort{{Port: 5432, Name: "postgres"}},
+			TrafficDistribution: &proposedDist,
+		}
+		living := corev1.ServiceSpec{
+			Type:                corev1.ServiceTypeClusterIP,
+			Ports:               []corev1.ServicePort{{Port: 5432, Name: "postgres"}},
+			TrafficDistribution: &livingDist,
+		}
+		PreserveKubernetesDefaults(&proposed, &living)
+		Expect(proposed.TrafficDistribution).To(Equal(&proposedDist))
 	})
 
 	It("should match NodePorts by port and protocol, not by index", func() {
@@ -290,6 +361,24 @@ var _ = Describe("PreserveKubernetesDefaults", func() {
 		PreserveKubernetesDefaults(&proposed, &living)
 		Expect(proposed.Ports[0].Protocol).To(Equal(corev1.ProtocolUDP))
 		Expect(proposed.Ports[0].TargetPort).To(Equal(intstr.FromInt32(9090)))
+	})
+
+	It("should not override explicitly set named string TargetPort", func() {
+		proposed := corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{Name: "custom", Port: 8080, TargetPort: intstr.FromString("http")},
+			},
+		}
+		living := corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{
+					Name: "custom", Port: 8080, Protocol: corev1.ProtocolTCP,
+					TargetPort: intstr.FromInt32(8080), NodePort: 30001,
+				},
+			},
+		}
+		PreserveKubernetesDefaults(&proposed, &living)
+		Expect(proposed.Ports[0].TargetPort).To(Equal(intstr.FromString("http")))
 	})
 
 	It("should match ports with empty protocol against TCP living ports", func() {


### PR DESCRIPTION
Previously, the cluster and pooler service reconcilers only detected changes in selectors, labels, and annotations. Changes to other spec fields like loadBalancerSourceRanges were silently ignored when using the patch update strategy, requiring users to switch to the replace strategy (which causes downtime) to apply spec changes.

Now the reconcilers compare the full service spec while preserving Kubernetes-managed and defaulted fields like ClusterIP, NodePort, and traffic policies.

Closes #10132 
