### PR TITLE
fix: validate VolumeSnapshot existence before using as storage source

### DIFF
--- a/internal/controller/cluster_create.go
+++ b/internal/controller/cluster_create.go
@@ -1253,7 +1253,7 @@ func (r *ClusterReconciler) joinReplicaInstance(
 	job := specs.JoinReplicaInstance(*cluster, nodeSerial)
 
 	// If we can bootstrap this replica from a pre-existing source, we do it
-	storageSource := persistentvolumeclaim.GetCandidateStorageSourceForReplica(ctx, cluster, backupList)
+	storageSource := persistentvolumeclaim.GetCandidateStorageSourceForReplica(ctx, r.Client, cluster, backupList)
 	if storageSource != nil {
 		job = specs.RestoreReplicaInstance(*cluster, nodeSerial)
 	}

--- a/pkg/reconciler/persistentvolumeclaim/storagesource.go
+++ b/pkg/reconciler/persistentvolumeclaim/storagesource.go
@@ -25,7 +25,9 @@ import (
 	"github.com/cloudnative-pg/machinery/pkg/log"
 	volumesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
@@ -60,6 +62,7 @@ func GetCandidateStorageSourceForPrimary(
 // to be used to create a replica PVC
 func GetCandidateStorageSourceForReplica(
 	ctx context.Context,
+	c client.Client,
 	cluster *apiv1.Cluster,
 	backupList apiv1.BackupList,
 ) *StorageSource {
@@ -94,6 +97,7 @@ func GetCandidateStorageSourceForReplica(
 
 	if result := getCandidateSourceFromBackupList(
 		ctx,
+		c,
 		cluster,
 		backupList,
 	); result != nil {
@@ -109,13 +113,32 @@ func GetCandidateStorageSourceForReplica(
 	}
 
 	// Try using the backup the Cluster has been bootstrapped from
-	return getCandidateSourceFromClusterDefinition(cluster)
+	result := getCandidateSourceFromClusterDefinition(cluster)
+	if result == nil {
+		return nil
+	}
+
+	contextLogger := log.FromContext(ctx)
+	exists, err := storageSourceExistsInNamespace(ctx, c, cluster.Namespace, result)
+	if err != nil {
+		contextLogger.Error(err, "Error while checking if storage source exists, falling back to pg_basebackup")
+		return nil
+	}
+	if !exists {
+		contextLogger.Info(
+			"Bootstrap VolumeSnapshot no longer exists, falling back to pg_basebackup for replica creation",
+		)
+		return nil
+	}
+
+	return result
 }
 
 // getCandidateSourceFromBackupList gets a candidate storage source
 // given a backup list
 func getCandidateSourceFromBackupList(
 	ctx context.Context,
+	c client.Client,
 	cluster *apiv1.Cluster,
 	backupList apiv1.BackupList,
 ) *StorageSource {
@@ -170,9 +193,21 @@ func getCandidateSourceFromBackupList(
 			continue
 		}
 
-		contextLogger.Debug("found a backup that is a valid storage source candidate")
+		candidate := getCandidateSourceFromBackup(backup)
+		exists, err := storageSourceExistsInNamespace(ctx, c, cluster.Namespace, candidate)
+		if err != nil {
+			contextLogger.Error(err, "Error while checking if backup snapshot exists, skipping backup",
+				"backup", backup.Name)
+			continue
+		}
+		if !exists {
+			contextLogger.Info("Backup VolumeSnapshot no longer exists, skipping backup",
+				"backup", backup.Name)
+			continue
+		}
 
-		return getCandidateSourceFromBackup(backup)
+		contextLogger.Debug("found a backup that is a valid storage source candidate")
+		return candidate
 	}
 
 	return nil
@@ -200,6 +235,53 @@ func getCandidateSourceFromBackup(backup *apiv1.Backup) *StorageSource {
 	}
 
 	return &result
+}
+
+// snapshotReferences returns all VolumeSnapshot references contained in this
+// StorageSource, filtering out entries with empty names or non-snapshot API groups.
+func (s *StorageSource) snapshotReferences() []corev1.TypedLocalObjectReference {
+	isSnapshot := func(ref corev1.TypedLocalObjectReference) bool {
+		return ref.Name != "" && ref.APIGroup != nil && *ref.APIGroup == volumesnapshotv1.GroupName
+	}
+
+	var refs []corev1.TypedLocalObjectReference
+	if isSnapshot(s.DataSource) {
+		refs = append(refs, s.DataSource)
+	}
+	if s.WALSource != nil && isSnapshot(*s.WALSource) {
+		refs = append(refs, *s.WALSource)
+	}
+	for _, ref := range s.TablespaceSource {
+		if isSnapshot(ref) {
+			refs = append(refs, ref)
+		}
+	}
+
+	return refs
+}
+
+// storageSourceExistsInNamespace checks whether the VolumeSnapshots referenced
+// in the given StorageSource still exist in the specified namespace.
+// This function is called during each reconciliation loop; since the client
+// reads from the informer cache, these lookups are local and do not generate
+// additional requests to the API server.
+func storageSourceExistsInNamespace(
+	ctx context.Context,
+	c client.Client,
+	namespace string,
+	source *StorageSource,
+) (bool, error) {
+	for _, ref := range source.snapshotReferences() {
+		var vs volumesnapshotv1.VolumeSnapshot
+		if err := c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: ref.Name}, &vs); err != nil {
+			if apierrs.IsNotFound(err) {
+				return false, nil
+			}
+			return false, err
+		}
+	}
+
+	return true, nil
 }
 
 // getCandidateSourceFromClusterDefinition gets a candidate storage source

--- a/pkg/reconciler/persistentvolumeclaim/storagesource_test.go
+++ b/pkg/reconciler/persistentvolumeclaim/storagesource_test.go
@@ -23,16 +23,38 @@ import (
 	"context"
 	"time"
 
+	volumesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	"github.com/cloudnative-pg/cloudnative-pg/internal/scheme"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
+
+const storageSourceTestNamespace = "default"
+
+func fakeClientWithSnapshots(names ...string) client.Client {
+	objs := make([]client.Object, len(names))
+	for i, name := range names {
+		objs[i] = &volumesnapshotv1.VolumeSnapshot{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: storageSourceTestNamespace,
+			},
+		}
+	}
+	return fake.NewClientBuilder().
+		WithScheme(scheme.BuildWithAllKnownScheme()).
+		WithObjects(objs...).
+		Build()
+}
 
 var _ = Describe("Storage configuration", func() {
 	cluster := &apiv1.Cluster{
@@ -56,7 +78,11 @@ var _ = Describe("Storage configuration", func() {
 var _ = Describe("Storage source", func() {
 	pgDataSnapshotVolumeName := "pgdata-snapshot"
 	pgWalSnapshotVolumeName := "pgwal-snapshot"
+
 	clusterWithBootstrapSnapshot := &apiv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: storageSourceTestNamespace,
+		},
 		Spec: apiv1.ClusterSpec{
 			StorageConfiguration: apiv1.StorageConfiguration{},
 			WalStorage:           &apiv1.StorageConfiguration{},
@@ -85,6 +111,9 @@ var _ = Describe("Storage source", func() {
 	}
 
 	clusterWithBackupSection := &apiv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: storageSourceTestNamespace,
+		},
 		Spec: apiv1.ClusterSpec{
 			StorageConfiguration: apiv1.StorageConfiguration{},
 			WalStorage:           &apiv1.StorageConfiguration{},
@@ -97,6 +126,9 @@ var _ = Describe("Storage source", func() {
 	}
 
 	clusterWithPluginOnly := &apiv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: storageSourceTestNamespace,
+		},
 		Spec: apiv1.ClusterSpec{
 			StorageConfiguration: apiv1.StorageConfiguration{},
 			WalStorage:           &apiv1.StorageConfiguration{},
@@ -139,16 +171,18 @@ var _ = Describe("Storage source", func() {
 		When("we don't have backups", func() {
 			When("there's no source WAL archive", func() {
 				It("should return the correct source when choosing pgdata", func(ctx context.Context) {
+					c := fakeClientWithSnapshots(pgDataSnapshotVolumeName, pgWalSnapshotVolumeName)
 					source, err := NewPgDataCalculator().GetSource(GetCandidateStorageSourceForReplica(
-						ctx, clusterWithBootstrapSnapshot, apiv1.BackupList{}))
+						ctx, c, clusterWithBootstrapSnapshot, apiv1.BackupList{}))
 					Expect(err).ToNot(HaveOccurred())
 					Expect(source).ToNot(BeNil())
 					Expect(source.Name).To(Equal(pgDataSnapshotVolumeName))
 				})
 
 				It("should return the correct source when choosing pgwal", func(ctx context.Context) {
+					c := fakeClientWithSnapshots(pgDataSnapshotVolumeName, pgWalSnapshotVolumeName)
 					source, err := NewPgWalCalculator().GetSource(GetCandidateStorageSourceForReplica(
-						ctx, clusterWithBootstrapSnapshot, apiv1.BackupList{}))
+						ctx, c, clusterWithBootstrapSnapshot, apiv1.BackupList{}))
 					Expect(err).ToNot(HaveOccurred())
 					Expect(source).ToNot(BeNil())
 					Expect(source.Name).To(Equal(pgWalSnapshotVolumeName))
@@ -157,13 +191,25 @@ var _ = Describe("Storage source", func() {
 
 			When("there's a source WAL archive", func() {
 				It("should return an empty storage source", func(ctx context.Context) {
+					c := fakeClientWithSnapshots(pgDataSnapshotVolumeName, pgWalSnapshotVolumeName)
 					clusterSourceWALArchive := clusterWithBootstrapSnapshot.DeepCopy()
 					clusterSourceWALArchive.Spec.Bootstrap.Recovery.Source = "test"
 					source, err := NewPgDataCalculator().GetSource(GetCandidateStorageSourceForReplica(
 						ctx,
+						c,
 						clusterSourceWALArchive,
 						apiv1.BackupList{},
 					))
+					Expect(err).ToNot(HaveOccurred())
+					Expect(source).To(BeNil())
+				})
+			})
+
+			When("the bootstrap VolumeSnapshot has been deleted", func() {
+				It("should fall back to nil when the snapshot no longer exists", func(ctx context.Context) {
+					c := fakeClientWithSnapshots() // no snapshots exist
+					source, err := NewPgDataCalculator().GetSource(GetCandidateStorageSourceForReplica(
+						ctx, c, clusterWithBootstrapSnapshot, apiv1.BackupList{}))
 					Expect(err).ToNot(HaveOccurred())
 					Expect(source).To(BeNil())
 				})
@@ -172,8 +218,10 @@ var _ = Describe("Storage source", func() {
 
 		When("we have backups", func() {
 			It("should return the correct backup", func(ctx context.Context) {
+				c := fakeClientWithSnapshots("completed-backup")
 				source, err := NewPgDataCalculator().GetSource(GetCandidateStorageSourceForReplica(
 					ctx,
+					c,
 					clusterWithBootstrapSnapshot,
 					backupList,
 				))
@@ -181,13 +229,29 @@ var _ = Describe("Storage source", func() {
 				Expect(source).ToNot(BeNil())
 				Expect(source.Name).To(Equal("completed-backup"))
 			})
+
+			It("should skip backup when its snapshot has been deleted", func(ctx context.Context) {
+				// No snapshots exist - should fall back to bootstrap snapshot check,
+				// which also won't find snapshots, so returns nil
+				c := fakeClientWithSnapshots()
+				source, err := NewPgDataCalculator().GetSource(GetCandidateStorageSourceForReplica(
+					ctx,
+					c,
+					clusterWithBootstrapSnapshot,
+					backupList,
+				))
+				Expect(err).ToNot(HaveOccurred())
+				Expect(source).To(BeNil())
+			})
 		})
 	})
 
 	When("not bootstrapping from a VolumeSnapshot with no backups", func() {
 		It("should return an empty storage source", func(ctx context.Context) {
+			c := fakeClientWithSnapshots()
 			source, err := NewPgDataCalculator().GetSource(GetCandidateStorageSourceForReplica(
 				ctx,
+				c,
 				clusterWithBackupSection,
 				apiv1.BackupList{},
 			))
@@ -198,8 +262,10 @@ var _ = Describe("Storage source", func() {
 
 	When("not bootstrapping from a VolumeSnapshot with backups", func() {
 		It("should return the backup as storage source", func(ctx context.Context) {
+			c := fakeClientWithSnapshots("completed-backup")
 			source, err := NewPgDataCalculator().GetSource(GetCandidateStorageSourceForReplica(
 				ctx,
+				c,
 				clusterWithBackupSection,
 				backupList,
 			))
@@ -209,8 +275,10 @@ var _ = Describe("Storage source", func() {
 		})
 
 		It("should return the backup as storage source when WAL archiving is via plugin only", func(ctx context.Context) {
+			c := fakeClientWithSnapshots("completed-backup")
 			source, err := NewPgDataCalculator().GetSource(GetCandidateStorageSourceForReplica(
 				ctx,
+				c,
 				clusterWithPluginOnly,
 				backupList,
 			))
@@ -222,11 +290,13 @@ var _ = Describe("Storage source", func() {
 
 	When("there's no WAL archiving", func() {
 		It("should return an empty storage source", func(ctx context.Context) {
+			c := fakeClientWithSnapshots()
 			clusterNoWalArchiving := clusterWithBackupSection.DeepCopy()
 			clusterNoWalArchiving.Spec.Backup = nil
 
 			source, err := NewPgDataCalculator().GetSource(GetCandidateStorageSourceForReplica(
 				ctx,
+				c,
 				clusterNoWalArchiving,
 				backupList,
 			))
@@ -305,6 +375,7 @@ var _ = Describe("candidate backups", func() {
 	}
 
 	It("takes the most recent candidate backup as source", func(ctx context.Context) {
+		c := fakeClientWithSnapshots("completed-backup", "bad-name")
 		backupList := apiv1.BackupList{
 			Items: []apiv1.Backup{
 				objectStoreBackup,
@@ -317,15 +388,17 @@ var _ = Describe("candidate backups", func() {
 
 		cluster := &apiv1.Cluster{
 			ObjectMeta: metav1.ObjectMeta{
+				Namespace:         storageSourceTestNamespace,
 				CreationTimestamp: metav1.NewTime(time.Now().Add(-1 * time.Hour)),
 			},
 		}
-		source := getCandidateSourceFromBackupList(ctx, cluster, backupList)
+		source := getCandidateSourceFromBackupList(ctx, c, cluster, backupList)
 		Expect(source).ToNot(BeNil())
 		Expect(source.DataSource.Name).To(Equal("completed-backup"))
 	})
 
 	It("will refuse to use automatically use snapshots if they are older than the Cluster", func(ctx context.Context) {
+		c := fakeClientWithSnapshots("completed-backup", "bad-name")
 		backupList := apiv1.BackupList{
 			Items: []apiv1.Backup{
 				objectStoreBackup,
@@ -338,11 +411,36 @@ var _ = Describe("candidate backups", func() {
 
 		cluster := &apiv1.Cluster{
 			ObjectMeta: metav1.ObjectMeta{
+				Namespace:         storageSourceTestNamespace,
 				CreationTimestamp: metav1.NewTime(time.Now().Add(1 * time.Hour)),
 			},
 		}
-		source := getCandidateSourceFromBackupList(ctx, cluster, backupList)
+		source := getCandidateSourceFromBackupList(ctx, c, cluster, backupList)
 		Expect(source).To(BeNil())
+	})
+
+	It("falls back to older backup when most recent snapshot is deleted", func(ctx context.Context) {
+		// Only "bad-name" snapshot exists (from oldCompletedBackup), "completed-backup" is deleted
+		c := fakeClientWithSnapshots("bad-name")
+		backupList := apiv1.BackupList{
+			Items: []apiv1.Backup{
+				objectStoreBackup,
+				nonCompletedBackup,
+				oldCompletedBackup,
+				completedBackup,
+			},
+		}
+		backupList.SortByReverseCreationTime()
+
+		cluster := &apiv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:         storageSourceTestNamespace,
+				CreationTimestamp: metav1.NewTime(time.Now().Add(-6 * time.Hour)),
+			},
+		}
+		source := getCandidateSourceFromBackupList(ctx, c, cluster, backupList)
+		Expect(source).ToNot(BeNil())
+		Expect(source.DataSource.Name).To(Equal("bad-name"))
 	})
 })
 
@@ -371,12 +469,14 @@ var _ = Describe("major version filtering in candidate backup selection", func()
 	}
 
 	It("does not filter by major version when PGDataImageInfo is nil", func(ctx context.Context) {
+		c := fakeClientWithSnapshots("completed-backup")
 		backup := makeCompletedSnapshotBackup("no-major-version")
 		// Explicitly leave MajorVersion=0 and no annotation to simulate missing version
 		backupList := apiv1.BackupList{Items: []apiv1.Backup{backup}}
 
 		cluster := &apiv1.Cluster{
 			ObjectMeta: metav1.ObjectMeta{
+				Namespace:         storageSourceTestNamespace,
 				CreationTimestamp: metav1.NewTime(time.Now().Add(-1 * time.Hour)),
 			},
 			Spec: apiv1.ClusterSpec{
@@ -389,18 +489,20 @@ var _ = Describe("major version filtering in candidate backup selection", func()
 			// Status.PGDataImageInfo is nil here on purpose
 		}
 
-		source := getCandidateSourceFromBackupList(ctx, cluster, backupList)
+		source := getCandidateSourceFromBackupList(ctx, c, cluster, backupList)
 		Expect(source).ToNot(BeNil())
 		Expect(source.DataSource.Name).To(Equal("completed-backup"))
 	})
 
 	It("skips backup when PGDataImageInfo is set and backup major version is missing", func(ctx context.Context) {
+		c := fakeClientWithSnapshots("completed-backup")
 		backup := makeCompletedSnapshotBackup("missing-major-version")
 		// MajorVersion=0 and no annotation, will be rejected when PGDataImageInfo != nil
 		backupList := apiv1.BackupList{Items: []apiv1.Backup{backup}}
 
 		cluster := &apiv1.Cluster{
 			ObjectMeta: metav1.ObjectMeta{
+				Namespace:         storageSourceTestNamespace,
 				CreationTimestamp: metav1.NewTime(time.Now().Add(-1 * time.Hour)),
 			},
 			Spec: apiv1.ClusterSpec{
@@ -415,17 +517,19 @@ var _ = Describe("major version filtering in candidate backup selection", func()
 			},
 		}
 
-		source := getCandidateSourceFromBackupList(ctx, cluster, backupList)
+		source := getCandidateSourceFromBackupList(ctx, c, cluster, backupList)
 		Expect(source).To(BeNil())
 	})
 
 	It("skips backup when PGDataImageInfo is set and major version mismatches", func(ctx context.Context) {
+		c := fakeClientWithSnapshots("completed-backup")
 		backup := makeCompletedSnapshotBackup("mismatching-major-version")
 		backup.Status.MajorVersion = 99 // intentionally mismatching
 		backupList := apiv1.BackupList{Items: []apiv1.Backup{backup}}
 
 		cluster := &apiv1.Cluster{
 			ObjectMeta: metav1.ObjectMeta{
+				Namespace:         storageSourceTestNamespace,
 				CreationTimestamp: metav1.NewTime(time.Now().Add(-1 * time.Hour)),
 			},
 			Spec: apiv1.ClusterSpec{
@@ -440,7 +544,7 @@ var _ = Describe("major version filtering in candidate backup selection", func()
 			},
 		}
 
-		source := getCandidateSourceFromBackupList(ctx, cluster, backupList)
+		source := getCandidateSourceFromBackupList(ctx, c, cluster, backupList)
 		Expect(source).To(BeNil())
 	})
 })


### PR DESCRIPTION


When a cluster is bootstrapped from a VolumeSnapshot that is later deleted, adding replicas would fail because the operator referenced the deleted snapshot as data source for new PVCs, leaving them stuck in Pending state indefinitely.

Add VolumeSnapshot existence validation in GetCandidateStorageSourceForReplica and getCandidateSourceFromBackupList. When a referenced snapshot no longer exists, the operator now skips it and tries the next candidate or falls back to pg_basebackup for replica creation.

Closes #10029 
