### PR TITLE
fix(hibernation): report WaitingForHealthy condition for non-healthy clusters 

### DIFF
--- a/pkg/reconciler/hibernation/reconciler.go
+++ b/pkg/reconciler/hibernation/reconciler.go
@@ -53,6 +53,11 @@ func Reconcile(
 	case HibernationConditionReasonWaitingPodsDeletion:
 		return &ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 
+	case HibernationConditionReasonWaitingForHealthy:
+		// The cluster is not healthy yet, let the reconciliation loop
+		// continue so the cluster can recover and eventually be hibernated
+		return nil, nil
+
 	default:
 		return &ctrl.Result{}, nil
 	}

--- a/pkg/reconciler/hibernation/reconciler.go
+++ b/pkg/reconciler/hibernation/reconciler.go
@@ -55,7 +55,7 @@ func Reconcile(
 
 	case HibernationConditionReasonWaitingForHealthy:
 		// The cluster is not healthy yet, let the reconciliation loop
-		// continue so the cluster can recover and eventually be hibernated
+		// continue; hibernation will proceed once the cluster becomes healthy
 		return nil, nil
 
 	default:

--- a/pkg/reconciler/hibernation/reconciler_test.go
+++ b/pkg/reconciler/hibernation/reconciler_test.go
@@ -133,6 +133,29 @@ var _ = Describe("Reconcile resources", func() {
 		Expect(mock.deletedPods).To(BeEmpty())
 	})
 
+	It("lets the reconciliation loop proceed when the cluster is waiting to be healthy", func(ctx SpecContext) {
+		mock := &clientMock{}
+		cluster := apiv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					utils.HibernationAnnotationName: HibernationOn,
+				},
+			},
+			Status: apiv1.ClusterStatus{
+				Conditions: []metav1.Condition{
+					{
+						Type:   HibernationConditionType,
+						Status: metav1.ConditionFalse,
+						Reason: HibernationConditionReasonWaitingForHealthy,
+					},
+				},
+			},
+		}
+		// A Reconcile with a nil return will allow cluster reconciliation to proceed
+		Expect(Reconcile(ctx, mock, &cluster, nil)).To(BeNil())
+		Expect(mock.deletedPods).To(BeEmpty())
+	})
+
 	It("deletes the primary pod if available", func(ctx SpecContext) {
 		mock := &clientMock{}
 		cluster := apiv1.Cluster{

--- a/pkg/reconciler/hibernation/status.go
+++ b/pkg/reconciler/hibernation/status.go
@@ -61,6 +61,11 @@ const (
 	// hibernation condition that is used when the operator is waiting for a Pod
 	// to be deleted
 	HibernationConditionReasonWaitingPodsDeletion = "WaitingPodsDeletion"
+
+	// HibernationConditionReasonWaitingForHealthy is the value of the
+	// hibernation condition that is used when the cluster is not healthy
+	// and hibernation cannot proceed yet
+	HibernationConditionReasonWaitingForHealthy = "WaitingForHealthy"
 )
 
 // ErrInvalidHibernationValue is raised when the hibernation annotation has
@@ -90,6 +95,12 @@ func EnrichStatus(
 	// won't be completely created.
 	// We should stop the enrich status only when the cluster is unhealthy and the process hasn't already started
 	if cluster.Status.Phase != apiv1.PhaseHealthy && !isHibernationOngoing(cluster) {
+		meta.SetStatusCondition(&cluster.Status.Conditions, metav1.Condition{
+			Type:    HibernationConditionType,
+			Status:  metav1.ConditionFalse,
+			Reason:  HibernationConditionReasonWaitingForHealthy,
+			Message: "Waiting for the cluster to be healthy before proceeding with hibernation",
+		})
 		return
 	}
 
@@ -127,7 +138,22 @@ func isHibernationEnabled(cluster *apiv1.Cluster) bool {
 	return cluster.Annotations[utils.HibernationAnnotationName] == HibernationOn
 }
 
-// isHibernationOngoing check if the cluster is doing the hibernation process
+// isHibernationOngoing checks if the cluster has already started the
+// hibernation process (i.e. pod deletion has begun or completed).
+// It excludes informational states like WaitingForHealthy that should
+// not bypass the healthy-phase safety guard.
 func isHibernationOngoing(cluster *apiv1.Cluster) bool {
-	return meta.FindStatusCondition(cluster.Status.Conditions, HibernationConditionType) != nil
+	condition := meta.FindStatusCondition(cluster.Status.Conditions, HibernationConditionType)
+	if condition == nil {
+		return false
+	}
+
+	switch condition.Reason {
+	case HibernationConditionReasonDeletingPods,
+		HibernationConditionReasonWaitingPodsDeletion,
+		HibernationConditionReasonHibernated:
+		return true
+	default:
+		return false
+	}
 }

--- a/pkg/reconciler/hibernation/status.go
+++ b/pkg/reconciler/hibernation/status.go
@@ -90,10 +90,9 @@ func EnrichStatus(
 		return
 	}
 
-	// We proceed to hibernate the cluster only when it is ready.
-	// Hibernating a non-ready cluster may be dangerous since the PVCs
-	// won't be completely created.
-	// We should stop the enrich status only when the cluster is unhealthy and the process hasn't already started
+	// We defer hibernation when the cluster is unhealthy and the process
+	// hasn't already started. Hibernating a non-ready cluster may be
+	// dangerous since the PVCs won't be completely created.
 	if cluster.Status.Phase != apiv1.PhaseHealthy && !isHibernationOngoing(cluster) {
 		meta.SetStatusCondition(&cluster.Status.Conditions, metav1.Condition{
 			Type:    HibernationConditionType,

--- a/pkg/reconciler/hibernation/status_test.go
+++ b/pkg/reconciler/hibernation/status_test.go
@@ -120,7 +120,7 @@ var _ = Describe("Status enrichment", func() {
 		Expect(hibernationCondition.Reason).To(Equal(HibernationConditionReasonDeletingPods))
 	})
 
-	It("doesn't enrich the status while the cluster is not ready", func(ctx SpecContext) {
+	It("sets a WaitingForHealthy condition when the cluster is not ready", func(ctx SpecContext) {
 		cluster := apiv1.Cluster{
 			ObjectMeta: metav1.ObjectMeta{
 				Annotations: map[string]string{
@@ -134,7 +134,35 @@ var _ = Describe("Status enrichment", func() {
 
 		EnrichStatus(ctx, &cluster, []corev1.Pod{{}})
 		hibernationCondition := meta.FindStatusCondition(cluster.Status.Conditions, HibernationConditionType)
-		Expect(hibernationCondition).To(BeNil())
+		Expect(hibernationCondition).ToNot(BeNil())
+		Expect(hibernationCondition.Status).To(Equal(metav1.ConditionFalse))
+		Expect(hibernationCondition.Reason).To(Equal(HibernationConditionReasonWaitingForHealthy))
+	})
+
+	It("transitions from WaitingForHealthy to DeletingPods when the cluster becomes healthy", func(ctx SpecContext) {
+		cluster := apiv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					utils.HibernationAnnotationName: HibernationOn,
+				},
+			},
+			Status: apiv1.ClusterStatus{
+				Phase: apiv1.PhaseCreatingReplica,
+			},
+		}
+
+		// First call: cluster not healthy
+		EnrichStatus(ctx, &cluster, []corev1.Pod{{}})
+		hibernationCondition := meta.FindStatusCondition(cluster.Status.Conditions, HibernationConditionType)
+		Expect(hibernationCondition).ToNot(BeNil())
+		Expect(hibernationCondition.Reason).To(Equal(HibernationConditionReasonWaitingForHealthy))
+
+		// Cluster becomes healthy
+		cluster.Status.Phase = apiv1.PhaseHealthy
+		EnrichStatus(ctx, &cluster, []corev1.Pod{{}})
+		hibernationCondition = meta.FindStatusCondition(cluster.Status.Conditions, HibernationConditionType)
+		Expect(hibernationCondition).ToNot(BeNil())
+		Expect(hibernationCondition.Reason).To(Equal(HibernationConditionReasonDeletingPods))
 	})
 
 	It("waits for each Pod to be deleted gracefully", func(ctx SpecContext) {


### PR DESCRIPTION
When the hibernation annotation is set on a non-healthy cluster (e.g. CrashLoopBackOff), the operator correctly defers hibernation until the cluster recovers. However, this decision was previously silent — no condition was set, leaving `cnpg status` unable to report why hibernation had not started.

This PR addresses the missing reporting aspect of the issue. Non-healthy clusters with the hibernation annotation now receive a `WaitingForHealthy` condition (`Status=False`), providing clear feedback through `cnpg status` where previously there was none. The underlying behavior — deferring hibernation until the cluster is healthy — remains unchanged.

No pre-existing behavior is altered:
- Healthy clusters requesting hibernation still proceed immediately
- Already-ongoing hibernation (DeletingPods, WaitingPodsDeletion, Hibernated) still bypasses the healthy-phase guard
- Clusters without the annotation remain unaffected

Note: this does not solve the broader problem of hibernating a cluster that will never become healthy on its own (e.g. persistent CrashLoopBackOff). That would require a separate discussion about allowing forced hibernation when PVCs are already fully provisioned.

Ref #10024 