### PR TITLE
ci(backport): skip Go installation when backport is excluded

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -91,6 +91,7 @@ jobs:
           token: ${{ secrets.REPO_GHA_PAT }}
       -
         name: Install Go
+        if: contains( github.event.pull_request.labels.*.name, env.BRANCH )
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           go-version-file: go.mod


### PR DESCRIPTION
The Install Go step in the backport workflow was missing the branch label condition, causing it to run even when the checkout step was skipped. This resulted in a failure because `go.mod` didn't exist.

Example failure: https://github.com/cloudnative-pg/cloudnative-pg/actions/runs/22844350392/job/66257070697#step:3:11