### PR TITLE
feat(replica): clean up Pending PVCs with deleted VolumeSnapshot dataSource

### DIFF
--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -763,6 +763,15 @@ func (r *ClusterReconciler) reconcileResources(
 		return *result, err
 	}
 
+	// Clean up Pending PVCs whose VolumeSnapshot dataSource has been deleted.
+	// This must run before the running jobs check, because a stuck restore Job
+	// referencing such a PVC would block reconciliation indefinitely.
+	if res, err := persistentvolumeclaim.DeletePVCsWithMissingVolumeSnapshots(
+		ctx, r.Client, resources.pvcs.Items, resources.jobs.Items,
+	); err != nil || !res.IsZero() {
+		return res, err
+	}
+
 	runningJobs := resources.runningJobNames()
 
 	// Act on Pods and PVCs only if there is nothing that is currently being created or deleted

--- a/internal/controller/cluster_create.go
+++ b/internal/controller/cluster_create.go
@@ -1253,7 +1253,7 @@ func (r *ClusterReconciler) joinReplicaInstance(
 	job := specs.JoinReplicaInstance(*cluster, nodeSerial)
 
 	// If we can bootstrap this replica from a pre-existing source, we do it
-	storageSource := persistentvolumeclaim.GetCandidateStorageSourceForReplica(ctx, cluster, backupList)
+	storageSource := persistentvolumeclaim.GetCandidateStorageSourceForReplica(ctx, r.Client, cluster, backupList)
 	if storageSource != nil {
 		job = specs.RestoreReplicaInstance(*cluster, nodeSerial)
 	}

--- a/pkg/reconciler/persistentvolumeclaim/cleanup.go
+++ b/pkg/reconciler/persistentvolumeclaim/cleanup.go
@@ -1,0 +1,140 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package persistentvolumeclaim
+
+import (
+	"context"
+	"time"
+
+	"github.com/cloudnative-pg/machinery/pkg/log"
+	volumesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// DeletePVCsWithMissingVolumeSnapshots detects Pending PVCs whose VolumeSnapshot
+// dataSource no longer exists and deletes them (along with any associated Job)
+// so the next reconciliation can fall back to pg_basebackup.
+func DeletePVCsWithMissingVolumeSnapshots(
+	ctx context.Context,
+	c client.Client,
+	pvcs []corev1.PersistentVolumeClaim,
+	jobs []batchv1.Job,
+) (ctrl.Result, error) {
+	contextLogger := log.FromContext(ctx)
+
+	var deletionExecuted bool
+	for i := range pvcs {
+		deleted, err := deletePVCWithMissingSnapshot(ctx, c, &pvcs[i], jobs)
+		if err != nil {
+			contextLogger.Error(err, "Error while cleaning up PVC with missing VolumeSnapshot",
+				"pvc", pvcs[i].Name)
+			continue
+		}
+		deletionExecuted = deletionExecuted || deleted
+	}
+
+	var res ctrl.Result
+	if deletionExecuted {
+		res = ctrl.Result{RequeueAfter: time.Second}
+	}
+
+	return res, nil
+}
+
+// deletePVCWithMissingSnapshot checks whether a Pending PVC references a
+// VolumeSnapshot that no longer exists. If so, it deletes the PVC and any
+// associated Job so the operator can retry replica creation via pg_basebackup.
+func deletePVCWithMissingSnapshot(
+	ctx context.Context,
+	c client.Client,
+	pvc *corev1.PersistentVolumeClaim,
+	jobs []batchv1.Job,
+) (bool, error) {
+	if pvc.Status.Phase != corev1.ClaimPending {
+		return false, nil
+	}
+
+	snapshotName := getSnapshotDataSourceName(pvc)
+	if snapshotName == "" {
+		return false, nil
+	}
+
+	contextLogger := log.FromContext(ctx)
+
+	var vs volumesnapshotv1.VolumeSnapshot
+	err := c.Get(ctx, client.ObjectKey{Namespace: pvc.Namespace, Name: snapshotName}, &vs)
+	if err == nil {
+		return false, nil
+	}
+	if !apierrs.IsNotFound(err) {
+		contextLogger.Error(err, "Error checking VolumeSnapshot existence, skipping PVC",
+			"pvc", pvc.Name, "snapshot", snapshotName)
+		return false, nil
+	}
+
+	contextLogger.Info(
+		"Deleting Pending PVC whose VolumeSnapshot dataSource no longer exists",
+		"pvc", pvc.Name,
+		"missingSnapshot", snapshotName,
+	)
+
+	if job := findJobUsingPVC(jobs, pvc.Name); job != nil {
+		contextLogger.Info("Deleting Job associated with stuck PVC",
+			"job", job.Name, "pvc", pvc.Name)
+		if err := c.Delete(ctx, job); err != nil && !apierrs.IsNotFound(err) {
+			return false, err
+		}
+	}
+
+	if err := c.Delete(ctx, pvc); err != nil && !apierrs.IsNotFound(err) {
+		return false, err
+	}
+
+	return true, nil
+}
+
+// getSnapshotDataSourceName returns the VolumeSnapshot name referenced in the
+// PVC's DataSource, or empty string if the DataSource is not a VolumeSnapshot.
+func getSnapshotDataSourceName(pvc *corev1.PersistentVolumeClaim) string {
+	ds := pvc.Spec.DataSource
+	if ds == nil {
+		return ""
+	}
+	if ds.APIGroup == nil || *ds.APIGroup != volumesnapshotv1.GroupName {
+		return ""
+	}
+	return ds.Name
+}
+
+// findJobUsingPVC returns the first Job from the list that references the given PVC name.
+func findJobUsingPVC(jobs []batchv1.Job, pvcName string) *batchv1.Job {
+	for i := range jobs {
+		for _, vol := range jobs[i].Spec.Template.Spec.Volumes {
+			if vol.PersistentVolumeClaim != nil && vol.PersistentVolumeClaim.ClaimName == pvcName {
+				return &jobs[i]
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/reconciler/persistentvolumeclaim/cleanup_test.go
+++ b/pkg/reconciler/persistentvolumeclaim/cleanup_test.go
@@ -1,0 +1,234 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package persistentvolumeclaim
+
+import (
+	"context"
+
+	volumesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/cloudnative-pg/cloudnative-pg/internal/scheme"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func fakeClientWithObjects(objs ...client.Object) client.Client {
+	return fake.NewClientBuilder().
+		WithScheme(scheme.BuildWithAllKnownScheme()).
+		WithObjects(objs...).
+		Build()
+}
+
+func makePendingPVCWithSnapshotDataSource(name, snapshotName string) corev1.PersistentVolumeClaim {
+	return corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: storageSourceTestNamespace,
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			DataSource: &corev1.TypedLocalObjectReference{
+				APIGroup: ptr.To(volumesnapshotv1.GroupName),
+				Kind:     "VolumeSnapshot",
+				Name:     snapshotName,
+			},
+		},
+		Status: corev1.PersistentVolumeClaimStatus{
+			Phase: corev1.ClaimPending,
+		},
+	}
+}
+
+func makeBoundPVCWithSnapshotDataSource(name, snapshotName string) corev1.PersistentVolumeClaim {
+	return corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: storageSourceTestNamespace,
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			DataSource: &corev1.TypedLocalObjectReference{
+				APIGroup: ptr.To(volumesnapshotv1.GroupName),
+				Kind:     "VolumeSnapshot",
+				Name:     snapshotName,
+			},
+		},
+		Status: corev1.PersistentVolumeClaimStatus{
+			Phase: corev1.ClaimBound,
+		},
+	}
+}
+
+func makeJobUsingPVC(name, pvcName string) batchv1.Job {
+	return batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: storageSourceTestNamespace,
+		},
+		Spec: batchv1.JobSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Volumes: []corev1.Volume{
+						{
+							Name: "data",
+							VolumeSource: corev1.VolumeSource{
+								PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+									ClaimName: pvcName,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+var _ = Describe("DeletePVCsWithMissingVolumeSnapshots", func() {
+	When("a Pending PVC references a VolumeSnapshot that no longer exists", func() {
+		It("should delete the PVC", func(ctx context.Context) {
+			pvc := makePendingPVCWithSnapshotDataSource("test-pvc-1", "deleted-snapshot")
+			c := fakeClientWithObjects(&pvc)
+
+			result, err := DeletePVCsWithMissingVolumeSnapshots(
+				ctx, c, []corev1.PersistentVolumeClaim{pvc}, nil,
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.IsZero()).To(BeFalse())
+
+			var remaining corev1.PersistentVolumeClaimList
+			Expect(c.List(ctx, &remaining, client.InNamespace(storageSourceTestNamespace))).To(Succeed())
+			Expect(remaining.Items).To(BeEmpty())
+		})
+	})
+
+	When("a Pending PVC references a VolumeSnapshot that still exists", func() {
+		It("should not delete the PVC", func(ctx context.Context) {
+			pvc := makePendingPVCWithSnapshotDataSource("test-pvc-1", "existing-snapshot")
+			snapshot := &volumesnapshotv1.VolumeSnapshot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "existing-snapshot",
+					Namespace: storageSourceTestNamespace,
+				},
+			}
+			c := fakeClientWithObjects(&pvc, snapshot)
+
+			result, err := DeletePVCsWithMissingVolumeSnapshots(
+				ctx, c, []corev1.PersistentVolumeClaim{pvc}, nil,
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.IsZero()).To(BeTrue())
+
+			var remaining corev1.PersistentVolumeClaimList
+			Expect(c.List(ctx, &remaining, client.InNamespace(storageSourceTestNamespace))).To(Succeed())
+			Expect(remaining.Items).To(HaveLen(1))
+		})
+	})
+
+	When("a Bound PVC references a VolumeSnapshot that no longer exists", func() {
+		It("should not delete the PVC", func(ctx context.Context) {
+			pvc := makeBoundPVCWithSnapshotDataSource("test-pvc-1", "deleted-snapshot")
+			c := fakeClientWithObjects(&pvc)
+
+			result, err := DeletePVCsWithMissingVolumeSnapshots(
+				ctx, c, []corev1.PersistentVolumeClaim{pvc}, nil,
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.IsZero()).To(BeTrue())
+
+			var remaining corev1.PersistentVolumeClaimList
+			Expect(c.List(ctx, &remaining, client.InNamespace(storageSourceTestNamespace))).To(Succeed())
+			Expect(remaining.Items).To(HaveLen(1))
+		})
+	})
+
+	When("a Pending PVC has no DataSource", func() {
+		It("should not delete the PVC", func(ctx context.Context) {
+			pvc := corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pvc-1",
+					Namespace: storageSourceTestNamespace,
+				},
+				Status: corev1.PersistentVolumeClaimStatus{
+					Phase: corev1.ClaimPending,
+				},
+			}
+			c := fakeClientWithObjects(&pvc)
+
+			result, err := DeletePVCsWithMissingVolumeSnapshots(
+				ctx, c, []corev1.PersistentVolumeClaim{pvc}, nil,
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.IsZero()).To(BeTrue())
+		})
+	})
+
+	When("a Pending PVC references a deleted snapshot and has an associated Job", func() {
+		It("should delete both the PVC and the Job", func(ctx context.Context) {
+			pvc := makePendingPVCWithSnapshotDataSource("test-pvc-1", "deleted-snapshot")
+			job := makeJobUsingPVC("restore-job", "test-pvc-1")
+			c := fakeClientWithObjects(&pvc, &job)
+
+			result, err := DeletePVCsWithMissingVolumeSnapshots(
+				ctx, c, []corev1.PersistentVolumeClaim{pvc}, []batchv1.Job{job},
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.IsZero()).To(BeFalse())
+
+			var remainingPVCs corev1.PersistentVolumeClaimList
+			Expect(c.List(ctx, &remainingPVCs, client.InNamespace(storageSourceTestNamespace))).To(Succeed())
+			Expect(remainingPVCs.Items).To(BeEmpty())
+
+			var remainingJobs batchv1.JobList
+			Expect(c.List(ctx, &remainingJobs, client.InNamespace(storageSourceTestNamespace))).To(Succeed())
+			Expect(remainingJobs.Items).To(BeEmpty())
+		})
+	})
+
+	When("there are multiple PVCs and only one has a missing snapshot", func() {
+		It("should delete only the stuck PVC and requeue", func(ctx context.Context) {
+			snapshot := &volumesnapshotv1.VolumeSnapshot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "existing-snapshot",
+					Namespace: storageSourceTestNamespace,
+				},
+			}
+			stuckPVC := makePendingPVCWithSnapshotDataSource("stuck-pvc", "deleted-snapshot")
+			healthyPVC := makePendingPVCWithSnapshotDataSource("healthy-pvc", "existing-snapshot")
+			c := fakeClientWithObjects(&stuckPVC, &healthyPVC, snapshot)
+
+			result, err := DeletePVCsWithMissingVolumeSnapshots(
+				ctx, c, []corev1.PersistentVolumeClaim{stuckPVC, healthyPVC}, nil,
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.IsZero()).To(BeFalse())
+
+			var remaining corev1.PersistentVolumeClaimList
+			Expect(c.List(ctx, &remaining, client.InNamespace(storageSourceTestNamespace))).To(Succeed())
+			Expect(remaining.Items).To(HaveLen(1))
+			Expect(remaining.Items[0].Name).To(Equal("healthy-pvc"))
+		})
+	})
+})

--- a/pkg/reconciler/persistentvolumeclaim/storagesource.go
+++ b/pkg/reconciler/persistentvolumeclaim/storagesource.go
@@ -25,7 +25,9 @@ import (
 	"github.com/cloudnative-pg/machinery/pkg/log"
 	volumesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
@@ -60,6 +62,7 @@ func GetCandidateStorageSourceForPrimary(
 // to be used to create a replica PVC
 func GetCandidateStorageSourceForReplica(
 	ctx context.Context,
+	c client.Client,
 	cluster *apiv1.Cluster,
 	backupList apiv1.BackupList,
 ) *StorageSource {
@@ -94,6 +97,7 @@ func GetCandidateStorageSourceForReplica(
 
 	if result := getCandidateSourceFromBackupList(
 		ctx,
+		c,
 		cluster,
 		backupList,
 	); result != nil {
@@ -109,13 +113,32 @@ func GetCandidateStorageSourceForReplica(
 	}
 
 	// Try using the backup the Cluster has been bootstrapped from
-	return getCandidateSourceFromClusterDefinition(cluster)
+	result := getCandidateSourceFromClusterDefinition(cluster)
+	if result == nil {
+		return nil
+	}
+
+	contextLogger := log.FromContext(ctx)
+	exists, err := storageSourceExistsInNamespace(ctx, c, cluster.Namespace, result)
+	if err != nil {
+		contextLogger.Error(err, "Error while checking if storage source exists, falling back to pg_basebackup")
+		return nil
+	}
+	if !exists {
+		contextLogger.Info(
+			"Bootstrap VolumeSnapshot no longer exists, falling back to pg_basebackup for replica creation",
+		)
+		return nil
+	}
+
+	return result
 }
 
 // getCandidateSourceFromBackupList gets a candidate storage source
 // given a backup list
 func getCandidateSourceFromBackupList(
 	ctx context.Context,
+	c client.Client,
 	cluster *apiv1.Cluster,
 	backupList apiv1.BackupList,
 ) *StorageSource {
@@ -170,9 +193,21 @@ func getCandidateSourceFromBackupList(
 			continue
 		}
 
-		contextLogger.Debug("found a backup that is a valid storage source candidate")
+		candidate := getCandidateSourceFromBackup(backup)
+		exists, err := storageSourceExistsInNamespace(ctx, c, cluster.Namespace, candidate)
+		if err != nil {
+			contextLogger.Error(err, "Error while checking if backup snapshot exists, skipping backup",
+				"backup", backup.Name)
+			continue
+		}
+		if !exists {
+			contextLogger.Info("Backup VolumeSnapshot no longer exists, skipping backup",
+				"backup", backup.Name)
+			continue
+		}
 
-		return getCandidateSourceFromBackup(backup)
+		contextLogger.Debug("found a backup that is a valid storage source candidate")
+		return candidate
 	}
 
 	return nil
@@ -200,6 +235,53 @@ func getCandidateSourceFromBackup(backup *apiv1.Backup) *StorageSource {
 	}
 
 	return &result
+}
+
+// snapshotReferences returns all VolumeSnapshot references contained in this
+// StorageSource, filtering out entries with empty names or non-snapshot API groups.
+func (s *StorageSource) snapshotReferences() []corev1.TypedLocalObjectReference {
+	isSnapshot := func(ref corev1.TypedLocalObjectReference) bool {
+		return ref.Name != "" && ref.APIGroup != nil && *ref.APIGroup == volumesnapshotv1.GroupName
+	}
+
+	var refs []corev1.TypedLocalObjectReference
+	if isSnapshot(s.DataSource) {
+		refs = append(refs, s.DataSource)
+	}
+	if s.WALSource != nil && isSnapshot(*s.WALSource) {
+		refs = append(refs, *s.WALSource)
+	}
+	for _, ref := range s.TablespaceSource {
+		if isSnapshot(ref) {
+			refs = append(refs, ref)
+		}
+	}
+
+	return refs
+}
+
+// storageSourceExistsInNamespace checks whether the VolumeSnapshots referenced
+// in the given StorageSource still exist in the specified namespace.
+// This function is called during each reconciliation loop; since the client
+// reads from the informer cache, these lookups are local and do not generate
+// additional requests to the API server.
+func storageSourceExistsInNamespace(
+	ctx context.Context,
+	c client.Client,
+	namespace string,
+	source *StorageSource,
+) (bool, error) {
+	for _, ref := range source.snapshotReferences() {
+		var vs volumesnapshotv1.VolumeSnapshot
+		if err := c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: ref.Name}, &vs); err != nil {
+			if apierrs.IsNotFound(err) {
+				return false, nil
+			}
+			return false, err
+		}
+	}
+
+	return true, nil
 }
 
 // getCandidateSourceFromClusterDefinition gets a candidate storage source

--- a/pkg/reconciler/persistentvolumeclaim/storagesource_test.go
+++ b/pkg/reconciler/persistentvolumeclaim/storagesource_test.go
@@ -23,16 +23,38 @@ import (
 	"context"
 	"time"
 
+	volumesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	"github.com/cloudnative-pg/cloudnative-pg/internal/scheme"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
+
+const storageSourceTestNamespace = "default"
+
+func fakeClientWithSnapshots(names ...string) client.Client {
+	objs := make([]client.Object, len(names))
+	for i, name := range names {
+		objs[i] = &volumesnapshotv1.VolumeSnapshot{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: storageSourceTestNamespace,
+			},
+		}
+	}
+	return fake.NewClientBuilder().
+		WithScheme(scheme.BuildWithAllKnownScheme()).
+		WithObjects(objs...).
+		Build()
+}
 
 var _ = Describe("Storage configuration", func() {
 	cluster := &apiv1.Cluster{
@@ -56,7 +78,11 @@ var _ = Describe("Storage configuration", func() {
 var _ = Describe("Storage source", func() {
 	pgDataSnapshotVolumeName := "pgdata-snapshot"
 	pgWalSnapshotVolumeName := "pgwal-snapshot"
+
 	clusterWithBootstrapSnapshot := &apiv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: storageSourceTestNamespace,
+		},
 		Spec: apiv1.ClusterSpec{
 			StorageConfiguration: apiv1.StorageConfiguration{},
 			WalStorage:           &apiv1.StorageConfiguration{},
@@ -85,6 +111,9 @@ var _ = Describe("Storage source", func() {
 	}
 
 	clusterWithBackupSection := &apiv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: storageSourceTestNamespace,
+		},
 		Spec: apiv1.ClusterSpec{
 			StorageConfiguration: apiv1.StorageConfiguration{},
 			WalStorage:           &apiv1.StorageConfiguration{},
@@ -97,6 +126,9 @@ var _ = Describe("Storage source", func() {
 	}
 
 	clusterWithPluginOnly := &apiv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: storageSourceTestNamespace,
+		},
 		Spec: apiv1.ClusterSpec{
 			StorageConfiguration: apiv1.StorageConfiguration{},
 			WalStorage:           &apiv1.StorageConfiguration{},
@@ -139,16 +171,18 @@ var _ = Describe("Storage source", func() {
 		When("we don't have backups", func() {
 			When("there's no source WAL archive", func() {
 				It("should return the correct source when choosing pgdata", func(ctx context.Context) {
+					c := fakeClientWithSnapshots(pgDataSnapshotVolumeName, pgWalSnapshotVolumeName)
 					source, err := NewPgDataCalculator().GetSource(GetCandidateStorageSourceForReplica(
-						ctx, clusterWithBootstrapSnapshot, apiv1.BackupList{}))
+						ctx, c, clusterWithBootstrapSnapshot, apiv1.BackupList{}))
 					Expect(err).ToNot(HaveOccurred())
 					Expect(source).ToNot(BeNil())
 					Expect(source.Name).To(Equal(pgDataSnapshotVolumeName))
 				})
 
 				It("should return the correct source when choosing pgwal", func(ctx context.Context) {
+					c := fakeClientWithSnapshots(pgDataSnapshotVolumeName, pgWalSnapshotVolumeName)
 					source, err := NewPgWalCalculator().GetSource(GetCandidateStorageSourceForReplica(
-						ctx, clusterWithBootstrapSnapshot, apiv1.BackupList{}))
+						ctx, c, clusterWithBootstrapSnapshot, apiv1.BackupList{}))
 					Expect(err).ToNot(HaveOccurred())
 					Expect(source).ToNot(BeNil())
 					Expect(source.Name).To(Equal(pgWalSnapshotVolumeName))
@@ -157,13 +191,25 @@ var _ = Describe("Storage source", func() {
 
 			When("there's a source WAL archive", func() {
 				It("should return an empty storage source", func(ctx context.Context) {
+					c := fakeClientWithSnapshots(pgDataSnapshotVolumeName, pgWalSnapshotVolumeName)
 					clusterSourceWALArchive := clusterWithBootstrapSnapshot.DeepCopy()
 					clusterSourceWALArchive.Spec.Bootstrap.Recovery.Source = "test"
 					source, err := NewPgDataCalculator().GetSource(GetCandidateStorageSourceForReplica(
 						ctx,
+						c,
 						clusterSourceWALArchive,
 						apiv1.BackupList{},
 					))
+					Expect(err).ToNot(HaveOccurred())
+					Expect(source).To(BeNil())
+				})
+			})
+
+			When("the bootstrap VolumeSnapshot has been deleted", func() {
+				It("should fall back to nil when the snapshot no longer exists", func(ctx context.Context) {
+					c := fakeClientWithSnapshots() // no snapshots exist
+					source, err := NewPgDataCalculator().GetSource(GetCandidateStorageSourceForReplica(
+						ctx, c, clusterWithBootstrapSnapshot, apiv1.BackupList{}))
 					Expect(err).ToNot(HaveOccurred())
 					Expect(source).To(BeNil())
 				})
@@ -172,8 +218,10 @@ var _ = Describe("Storage source", func() {
 
 		When("we have backups", func() {
 			It("should return the correct backup", func(ctx context.Context) {
+				c := fakeClientWithSnapshots("completed-backup")
 				source, err := NewPgDataCalculator().GetSource(GetCandidateStorageSourceForReplica(
 					ctx,
+					c,
 					clusterWithBootstrapSnapshot,
 					backupList,
 				))
@@ -181,13 +229,29 @@ var _ = Describe("Storage source", func() {
 				Expect(source).ToNot(BeNil())
 				Expect(source.Name).To(Equal("completed-backup"))
 			})
+
+			It("should skip backup when its snapshot has been deleted", func(ctx context.Context) {
+				// No snapshots exist - should fall back to bootstrap snapshot check,
+				// which also won't find snapshots, so returns nil
+				c := fakeClientWithSnapshots()
+				source, err := NewPgDataCalculator().GetSource(GetCandidateStorageSourceForReplica(
+					ctx,
+					c,
+					clusterWithBootstrapSnapshot,
+					backupList,
+				))
+				Expect(err).ToNot(HaveOccurred())
+				Expect(source).To(BeNil())
+			})
 		})
 	})
 
 	When("not bootstrapping from a VolumeSnapshot with no backups", func() {
 		It("should return an empty storage source", func(ctx context.Context) {
+			c := fakeClientWithSnapshots()
 			source, err := NewPgDataCalculator().GetSource(GetCandidateStorageSourceForReplica(
 				ctx,
+				c,
 				clusterWithBackupSection,
 				apiv1.BackupList{},
 			))
@@ -198,8 +262,10 @@ var _ = Describe("Storage source", func() {
 
 	When("not bootstrapping from a VolumeSnapshot with backups", func() {
 		It("should return the backup as storage source", func(ctx context.Context) {
+			c := fakeClientWithSnapshots("completed-backup")
 			source, err := NewPgDataCalculator().GetSource(GetCandidateStorageSourceForReplica(
 				ctx,
+				c,
 				clusterWithBackupSection,
 				backupList,
 			))
@@ -209,8 +275,10 @@ var _ = Describe("Storage source", func() {
 		})
 
 		It("should return the backup as storage source when WAL archiving is via plugin only", func(ctx context.Context) {
+			c := fakeClientWithSnapshots("completed-backup")
 			source, err := NewPgDataCalculator().GetSource(GetCandidateStorageSourceForReplica(
 				ctx,
+				c,
 				clusterWithPluginOnly,
 				backupList,
 			))
@@ -222,11 +290,13 @@ var _ = Describe("Storage source", func() {
 
 	When("there's no WAL archiving", func() {
 		It("should return an empty storage source", func(ctx context.Context) {
+			c := fakeClientWithSnapshots()
 			clusterNoWalArchiving := clusterWithBackupSection.DeepCopy()
 			clusterNoWalArchiving.Spec.Backup = nil
 
 			source, err := NewPgDataCalculator().GetSource(GetCandidateStorageSourceForReplica(
 				ctx,
+				c,
 				clusterNoWalArchiving,
 				backupList,
 			))
@@ -305,6 +375,7 @@ var _ = Describe("candidate backups", func() {
 	}
 
 	It("takes the most recent candidate backup as source", func(ctx context.Context) {
+		c := fakeClientWithSnapshots("completed-backup", "bad-name")
 		backupList := apiv1.BackupList{
 			Items: []apiv1.Backup{
 				objectStoreBackup,
@@ -317,15 +388,17 @@ var _ = Describe("candidate backups", func() {
 
 		cluster := &apiv1.Cluster{
 			ObjectMeta: metav1.ObjectMeta{
+				Namespace:         storageSourceTestNamespace,
 				CreationTimestamp: metav1.NewTime(time.Now().Add(-1 * time.Hour)),
 			},
 		}
-		source := getCandidateSourceFromBackupList(ctx, cluster, backupList)
+		source := getCandidateSourceFromBackupList(ctx, c, cluster, backupList)
 		Expect(source).ToNot(BeNil())
 		Expect(source.DataSource.Name).To(Equal("completed-backup"))
 	})
 
 	It("will refuse to use automatically use snapshots if they are older than the Cluster", func(ctx context.Context) {
+		c := fakeClientWithSnapshots("completed-backup", "bad-name")
 		backupList := apiv1.BackupList{
 			Items: []apiv1.Backup{
 				objectStoreBackup,
@@ -338,11 +411,36 @@ var _ = Describe("candidate backups", func() {
 
 		cluster := &apiv1.Cluster{
 			ObjectMeta: metav1.ObjectMeta{
+				Namespace:         storageSourceTestNamespace,
 				CreationTimestamp: metav1.NewTime(time.Now().Add(1 * time.Hour)),
 			},
 		}
-		source := getCandidateSourceFromBackupList(ctx, cluster, backupList)
+		source := getCandidateSourceFromBackupList(ctx, c, cluster, backupList)
 		Expect(source).To(BeNil())
+	})
+
+	It("falls back to older backup when most recent snapshot is deleted", func(ctx context.Context) {
+		// Only "bad-name" snapshot exists (from oldCompletedBackup), "completed-backup" is deleted
+		c := fakeClientWithSnapshots("bad-name")
+		backupList := apiv1.BackupList{
+			Items: []apiv1.Backup{
+				objectStoreBackup,
+				nonCompletedBackup,
+				oldCompletedBackup,
+				completedBackup,
+			},
+		}
+		backupList.SortByReverseCreationTime()
+
+		cluster := &apiv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:         storageSourceTestNamespace,
+				CreationTimestamp: metav1.NewTime(time.Now().Add(-6 * time.Hour)),
+			},
+		}
+		source := getCandidateSourceFromBackupList(ctx, c, cluster, backupList)
+		Expect(source).ToNot(BeNil())
+		Expect(source.DataSource.Name).To(Equal("bad-name"))
 	})
 })
 
@@ -371,12 +469,14 @@ var _ = Describe("major version filtering in candidate backup selection", func()
 	}
 
 	It("does not filter by major version when PGDataImageInfo is nil", func(ctx context.Context) {
+		c := fakeClientWithSnapshots("completed-backup")
 		backup := makeCompletedSnapshotBackup("no-major-version")
 		// Explicitly leave MajorVersion=0 and no annotation to simulate missing version
 		backupList := apiv1.BackupList{Items: []apiv1.Backup{backup}}
 
 		cluster := &apiv1.Cluster{
 			ObjectMeta: metav1.ObjectMeta{
+				Namespace:         storageSourceTestNamespace,
 				CreationTimestamp: metav1.NewTime(time.Now().Add(-1 * time.Hour)),
 			},
 			Spec: apiv1.ClusterSpec{
@@ -389,18 +489,20 @@ var _ = Describe("major version filtering in candidate backup selection", func()
 			// Status.PGDataImageInfo is nil here on purpose
 		}
 
-		source := getCandidateSourceFromBackupList(ctx, cluster, backupList)
+		source := getCandidateSourceFromBackupList(ctx, c, cluster, backupList)
 		Expect(source).ToNot(BeNil())
 		Expect(source.DataSource.Name).To(Equal("completed-backup"))
 	})
 
 	It("skips backup when PGDataImageInfo is set and backup major version is missing", func(ctx context.Context) {
+		c := fakeClientWithSnapshots("completed-backup")
 		backup := makeCompletedSnapshotBackup("missing-major-version")
 		// MajorVersion=0 and no annotation, will be rejected when PGDataImageInfo != nil
 		backupList := apiv1.BackupList{Items: []apiv1.Backup{backup}}
 
 		cluster := &apiv1.Cluster{
 			ObjectMeta: metav1.ObjectMeta{
+				Namespace:         storageSourceTestNamespace,
 				CreationTimestamp: metav1.NewTime(time.Now().Add(-1 * time.Hour)),
 			},
 			Spec: apiv1.ClusterSpec{
@@ -415,17 +517,19 @@ var _ = Describe("major version filtering in candidate backup selection", func()
 			},
 		}
 
-		source := getCandidateSourceFromBackupList(ctx, cluster, backupList)
+		source := getCandidateSourceFromBackupList(ctx, c, cluster, backupList)
 		Expect(source).To(BeNil())
 	})
 
 	It("skips backup when PGDataImageInfo is set and major version mismatches", func(ctx context.Context) {
+		c := fakeClientWithSnapshots("completed-backup")
 		backup := makeCompletedSnapshotBackup("mismatching-major-version")
 		backup.Status.MajorVersion = 99 // intentionally mismatching
 		backupList := apiv1.BackupList{Items: []apiv1.Backup{backup}}
 
 		cluster := &apiv1.Cluster{
 			ObjectMeta: metav1.ObjectMeta{
+				Namespace:         storageSourceTestNamespace,
 				CreationTimestamp: metav1.NewTime(time.Now().Add(-1 * time.Hour)),
 			},
 			Spec: apiv1.ClusterSpec{
@@ -440,7 +544,7 @@ var _ = Describe("major version filtering in candidate backup selection", func()
 			},
 		}
 
-		source := getCandidateSourceFromBackupList(ctx, cluster, backupList)
+		source := getCandidateSourceFromBackupList(ctx, c, cluster, backupList)
 		Expect(source).To(BeNil())
 	})
 })


### PR DESCRIPTION
When a VolumeSnapshot is deleted after a PVC has already been created with it as dataSource, the PVC stays in Pending state indefinitely and the associated restore Job blocks the reconciliation loop.

Add DeletePVCsWithMissingVolumeSnapshots to detect Pending PVCs whose VolumeSnapshot dataSource no longer exists and delete them along with any associated Job, allowing the operator to retry replica creation via pg_basebackup on the next reconciliation.