### PR TITLE
fix(recovery): fix external cluster validation

### DIFF
--- a/internal/webhook/v1/cluster_webhook.go
+++ b/internal/webhook/v1/cluster_webhook.go
@@ -682,14 +682,16 @@ func (v *ClusterCustomValidator) validateBootstrapRecoverySource(r *apiv1.Cluste
 
 	// Ensure the external cluster definition has enough information
 	// to be used to recover a data directory
-	if externalCluster.BarmanObjectStore == nil && externalCluster.PluginConfiguration == nil {
+	if externalCluster.ConnectionParameters == nil &&
+		externalCluster.BarmanObjectStore == nil &&
+		externalCluster.PluginConfiguration == nil {
 		result = append(
 			result,
 			field.Invalid(
 				field.NewPath("spec", "bootstrap", "recovery", "source"),
 				r.Spec.Bootstrap.Recovery.Source,
 				fmt.Sprintf("External cluster %v cannot be used for recovery: "+
-					"both Barman and CNPG-i plugin configurations are missing", r.Spec.Bootstrap.Recovery.Source)))
+					"missing connection parameters, Barman, or CNPG-i configuration", r.Spec.Bootstrap.Recovery.Source)))
 	}
 
 	return result

--- a/pkg/management/postgres/restore.go
+++ b/pkg/management/postgres/restore.go
@@ -234,6 +234,9 @@ func (info InitInfo) createEnvAndConfigForSnapshotRestore(
 	}
 	serverName := server.GetServerName()
 
+	if server.BarmanObjectStore == nil {
+		return nil, "", nil
+	}
 	env, err := barmanCredentials.EnvSetRestoreCloudCredentials(
 		ctx,
 		typedClient,

--- a/pkg/management/postgres/restore.go
+++ b/pkg/management/postgres/restore.go
@@ -154,9 +154,12 @@ func (info InitInfo) RestoreSnapshot(ctx context.Context, cli client.Client, imm
 		restoreCmd)
 
 	if pluginConfiguration := cluster.GetRecoverySourcePlugin(); pluginConfiguration == nil {
-		envs, config, err = info.createEnvAndConfigForSnapshotRestore(ctx, cli, cluster)
-		if err != nil {
-			return err
+		server, found := cluster.ExternalCluster(cluster.Spec.Bootstrap.Recovery.Source)
+		if found && server.BarmanObjectStore != nil {
+			envs, config, err = info.createEnvAndConfigForSnapshotRestore(ctx, cli, cluster, &server)
+			if err != nil {
+				return err
+			}
 		}
 	}
 
@@ -218,25 +221,14 @@ func (info InitInfo) createEnvAndConfigForSnapshotRestore(
 	ctx context.Context,
 	typedClient client.Client,
 	cluster *apiv1.Cluster,
+	server *apiv1.ExternalCluster,
 ) ([]string, string, error) {
 	contextLogger := log.FromContext(ctx)
-	sourceName := cluster.Spec.Bootstrap.Recovery.Source
 
-	if sourceName == "" {
-		return nil, "", fmt.Errorf("recovery source not specified")
-	}
+	contextLogger.Info("Recovering from external cluster", "sourceName", server.Name)
 
-	contextLogger.Info("Recovering from external cluster", "sourceName", sourceName)
-
-	server, found := cluster.ExternalCluster(sourceName)
-	if !found {
-		return nil, "", fmt.Errorf("missing external cluster: %v", sourceName)
-	}
 	serverName := server.GetServerName()
 
-	if server.BarmanObjectStore == nil {
-		return nil, "", nil
-	}
 	env, err := barmanCredentials.EnvSetRestoreCloudCredentials(
 		ctx,
 		typedClient,


### PR DESCRIPTION
Add missing check for `ConnectionParameters` in `validateBootstrapRecoverySource` and update the error message to include all valid configuration types.

Closes #10260 