### PR TITLE
chore: set to none the top level permissions for OSPS workflow

### DIFF
--- a/.github/workflows/osps_security_assessment.yml
+++ b/.github/workflows/osps_security_assessment.yml
@@ -5,6 +5,8 @@ on:
     - cron: "0 9 * * 1"  # Weekly on Mondays at 9 AM UTC
   workflow_dispatch:  # Allow manual triggering
 
+permissions: {}
+
 jobs:
   osps-assessment:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
The top level permission was left by default, we set it to none to avoid the
warning left by the OpenSSF scorecard

Closes #10274 