### PR TITLE
docs: escape podselector syntax in PodSelectorRef godoc

### DIFF
--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -1440,7 +1440,7 @@ type SynchronousReplicaConfiguration struct {
 // PodSelectorRef defines a named pod label selector for use in pg_hba rules.
 // Pods matching the selector in the Cluster's namespace will have their IPs
 // resolved and made available for pg_hba address expansion via the
-// ${podselector:NAME} syntax.
+// `${podselector:NAME}` syntax.
 type PodSelectorRef struct {
 	// Name is the identifier used to reference this selector in pg_hba rules
 	// via the ${podselector:NAME} syntax in the address field.

--- a/config/crd/bases/postgresql.cnpg.io_clusters.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_clusters.yaml
@@ -4349,7 +4349,7 @@ spec:
                     PodSelectorRef defines a named pod label selector for use in pg_hba rules.
                     Pods matching the selector in the Cluster's namespace will have their IPs
                     resolved and made available for pg_hba address expansion via the
-                    ${podselector:NAME} syntax.
+                    `${podselector:NAME}` syntax.
                   properties:
                     name:
                       description: |-

--- a/docs/src/cloudnative-pg.v1.md
+++ b/docs/src/cloudnative-pg.v1.md
@@ -1745,7 +1745,7 @@ _Appears in:_
 PodSelectorRef defines a named pod label selector for use in pg_hba rules.
 Pods matching the selector in the Cluster's namespace will have their IPs
 resolved and made available for pg_hba address expansion via the
-${podselector:NAME} syntax.
+`${podselector:NAME}` syntax.
 
 
 


### PR DESCRIPTION
Wrap `${podselector:NAME}` in backticks in the PodSelectorRef type comment so the MDX compiler doesn't interpret the curly braces as a JSX expression, which caused the docs build to fail with:

```
Error: MDX compilation failed for file "/website/docs/cloudnative-pg.v1.md"
Cause: Could not parse expression with acorn
```