### PR TITLE
fix(major-upgrade): wait for pods to fully terminate before starting upgrade job

### DIFF
--- a/pkg/reconciler/majorupgrade/reconciler.go
+++ b/pkg/reconciler/majorupgrade/reconciler.go
@@ -145,7 +145,9 @@ func deleteAllPodsInMajorUpgradePreparation(
 
 		foundSomethingToDelete = true
 		if err := c.Delete(ctx, &pod); err != nil {
-			return nil, err
+			if !apierrs.IsNotFound(err) {
+				return nil, err
+			}
 		}
 	}
 
@@ -159,7 +161,9 @@ func deleteAllPodsInMajorUpgradePreparation(
 		if err := c.Delete(ctx, &job, &client.DeleteOptions{
 			PropagationPolicy: ptr.To(metav1.DeletePropagationForeground),
 		}); err != nil {
-			return nil, err
+			if !apierrs.IsNotFound(err) {
+				return nil, err
+			}
 		}
 	}
 

--- a/pkg/reconciler/majorupgrade/reconciler.go
+++ b/pkg/reconciler/majorupgrade/reconciler.go
@@ -135,9 +135,11 @@ func deleteAllPodsInMajorUpgradePreparation(
 	jobs []batchv1.Job,
 ) (*ctrl.Result, error) {
 	foundSomethingToDelete := false
+	waitingForDeletion := false
 
 	for _, pod := range instances {
 		if pod.GetDeletionTimestamp() != nil {
+			waitingForDeletion = true
 			continue
 		}
 
@@ -149,6 +151,7 @@ func deleteAllPodsInMajorUpgradePreparation(
 
 	for _, job := range jobs {
 		if job.GetDeletionTimestamp() != nil {
+			waitingForDeletion = true
 			continue
 		}
 
@@ -160,8 +163,8 @@ func deleteAllPodsInMajorUpgradePreparation(
 		}
 	}
 
-	if foundSomethingToDelete {
-		return &ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+	if foundSomethingToDelete || waitingForDeletion {
+		return &ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 	}
 
 	return nil, nil

--- a/pkg/reconciler/majorupgrade/reconciler_test.go
+++ b/pkg/reconciler/majorupgrade/reconciler_test.go
@@ -189,6 +189,58 @@ var _ = Describe("Major upgrade rollback handling", func() {
 	})
 })
 
+var _ = Describe("deleteAllPodsInMajorUpgradePreparation", func() {
+	It("deletes pods and requeues when pods have no deletion timestamp", func(ctx SpecContext) {
+		pod := corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "cluster-example-1",
+				Namespace: "default",
+			},
+		}
+
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(schemeBuilder.BuildWithAllKnownScheme()).
+			WithRuntimeObjects(&pod).
+			Build()
+
+		result, err := deleteAllPodsInMajorUpgradePreparation(ctx, fakeClient, []corev1.Pod{pod}, nil)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result).ToNot(BeNil())
+		Expect(*result).To(Equal(ctrl.Result{RequeueAfter: 10 * time.Second}))
+	})
+
+	It("requeues when pods are still terminating", func(ctx SpecContext) {
+		now := metav1.Now()
+		terminatingPod := corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "cluster-example-1",
+				Namespace:         "default",
+				DeletionTimestamp: &now,
+				Finalizers:        []string{"test-finalizer"},
+			},
+		}
+
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(schemeBuilder.BuildWithAllKnownScheme()).
+			Build()
+
+		result, err := deleteAllPodsInMajorUpgradePreparation(ctx, fakeClient, []corev1.Pod{terminatingPod}, nil)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result).ToNot(BeNil())
+		Expect(*result).To(Equal(ctrl.Result{RequeueAfter: 10 * time.Second}))
+	})
+
+	It("returns nil when no pods or jobs exist", func(ctx SpecContext) {
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(schemeBuilder.BuildWithAllKnownScheme()).
+			Build()
+
+		result, err := deleteAllPodsInMajorUpgradePreparation(ctx, fakeClient, nil, nil)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result).To(BeNil())
+	})
+})
+
 var _ = Describe("Major upgrade job definition", func() {
 	It("sets BackoffLimit to 0", func() {
 		cluster := &apiv1.Cluster{


### PR DESCRIPTION
During a major version upgrade, the upgrade job could be created while old instance pods were still gracefully terminating. This happened because `deleteAllPodsInMajorUpgradePreparation` treated pods with a `deletionTimestamp` as already gone, returning "all clear" to proceed with job creation.

Track terminating pods/jobs separately and only signal readiness to proceed when all pods and jobs have been completely removed from the API server. Reduce the requeue interval from 30s to 10s since we are actively waiting for termination to complete.

Closes #10297 