### PR TITLE
fix(lifecycle): return correct error on system initialization failure

### DIFF
--- a/internal/cmd/manager/instance/run/lifecycle/run.go
+++ b/internal/cmd/manager/instance/run/lifecycle/run.go
@@ -80,7 +80,7 @@ func (i *PostgresLifecycle) runPostgresAndWait(ctx context.Context) <-chan error
 		// If the system initialization failed, we return an error and let
 		// the instance manager quit.
 		if i.systemInitialization.Err() != nil {
-			return err
+			return i.systemInitialization.Err()
 		}
 
 		// The lifecycle loop will call us even when PostgreSQL is fenced.


### PR DESCRIPTION
The `systemInitialization.Err()` check in the lifecycle loop was returning the `err` variable from the previously succeeded `VerifyPgDataCoherence` call, which is always `nil` at that point, silently swallowing initialization failures.

Closes #10300 