### PR TITLE
test(e2e): add operator pull secret to shared ServiceAccounts

### DIFF
--- a/tests/e2e/cluster_shared_service_account_test.go
+++ b/tests/e2e/cluster_shared_service_account_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/clusterutils"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/objects"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/operator"
-	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/pods"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/secrets"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -69,18 +68,10 @@ var _ = Describe("Shared ServiceAccount", Label(tests.LabelBasic), func() {
 		})
 
 		By("verifying cluster pods use the shared ServiceAccount", func() {
-			podList, err := pods.List(env.Ctx, env.Client, namespace)
+			podList, err := clusterutils.ListPods(env.Ctx, env.Client, namespace, cluster1Name)
 			Expect(err).ToNot(HaveOccurred())
 
-			cluster1Pods := []corev1.Pod{}
 			for _, pod := range podList.Items {
-				if pod.Labels["cnpg.io/cluster"] == cluster1Name {
-					cluster1Pods = append(cluster1Pods, pod)
-				}
-			}
-			Expect(cluster1Pods).ToNot(BeEmpty())
-
-			for _, pod := range cluster1Pods {
 				Expect(pod.Spec.ServiceAccountName).To(Equal(sharedSAName),
 					"Pod %s should use shared ServiceAccount %s", pod.Name, sharedSAName)
 			}

--- a/tests/e2e/cluster_shared_service_account_test.go
+++ b/tests/e2e/cluster_shared_service_account_test.go
@@ -70,6 +70,7 @@ var _ = Describe("Shared ServiceAccount", Label(tests.LabelBasic), func() {
 		By("verifying cluster pods use the shared ServiceAccount", func() {
 			podList, err := clusterutils.ListPods(env.Ctx, env.Client, namespace, cluster1Name)
 			Expect(err).ToNot(HaveOccurred())
+			Expect(podList.Items).ToNot(BeEmpty())
 
 			for _, pod := range podList.Items {
 				Expect(pod.Spec.ServiceAccountName).To(Equal(sharedSAName),

--- a/tests/e2e/cluster_shared_service_account_test.go
+++ b/tests/e2e/cluster_shared_service_account_test.go
@@ -27,7 +27,9 @@ import (
 	"github.com/cloudnative-pg/cloudnative-pg/tests"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/clusterutils"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/objects"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/operator"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/pods"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/secrets"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -53,8 +55,13 @@ var _ = Describe("Shared ServiceAccount", Label(tests.LabelBasic), func() {
 		namespace, err := env.CreateUniqueTestNamespace(env.Ctx, env.Client, namespacePrefix)
 		Expect(err).ToNot(HaveOccurred())
 
-		By("creating a shared ServiceAccount", func() {
+		By("creating a shared ServiceAccount with operator pull secrets", func() {
 			CreateResourceFromFile(namespace, sharedSAFile)
+			operatorDeployment, err := operator.GetDeployment(env.Ctx, env.Client)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(secrets.CopyOperatorPullSecretToServiceAccount(
+				env.Ctx, env.Client, operatorDeployment, namespace, sharedSAName,
+			)).To(Succeed())
 		})
 
 		By("creating cluster using shared ServiceAccount", func() {

--- a/tests/e2e/pooler_shared_service_account_test.go
+++ b/tests/e2e/pooler_shared_service_account_test.go
@@ -28,6 +28,8 @@ import (
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 	"github.com/cloudnative-pg/cloudnative-pg/tests"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/operator"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/secrets"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -59,8 +61,13 @@ var _ = Describe("Pooler Shared ServiceAccount", Label(tests.LabelBasic), func()
 			AssertCreateCluster(namespace, clusterName, clusterFile, env)
 		})
 
-		By("creating a shared ServiceAccount", func() {
+		By("creating a shared ServiceAccount with operator pull secrets", func() {
 			CreateResourceFromFile(namespace, sharedSAFile)
+			operatorDeployment, err := operator.GetDeployment(env.Ctx, env.Client)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(secrets.CopyOperatorPullSecretToServiceAccount(
+				env.Ctx, env.Client, operatorDeployment, namespace, sharedSAName,
+			)).To(Succeed())
 		})
 
 		By("creating pooler using shared ServiceAccount", func() {

--- a/tests/e2e/pooler_shared_service_account_test.go
+++ b/tests/e2e/pooler_shared_service_account_test.go
@@ -28,6 +28,7 @@ import (
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 	"github.com/cloudnative-pg/cloudnative-pg/tests"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/deployments"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/operator"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/secrets"
 
@@ -75,11 +76,13 @@ var _ = Describe("Pooler Shared ServiceAccount", Label(tests.LabelBasic), func()
 		})
 
 		By("waiting for pooler deployment to be ready", func() {
-			Eventually(func() error {
+			Eventually(func(g Gomega) {
 				var deployment appsv1.Deployment
-				return env.Client.Get(env.Ctx,
-					client.ObjectKey{Namespace: namespace, Name: pooler1Name},
-					&deployment)
+				err := env.Client.Get(env.Ctx, client.ObjectKey{Namespace: namespace, Name: pooler1Name}, &deployment)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(deployments.IsReady(deployment)).To(BeTrue(),
+					"Pooler deployment %s/%s is not ready", namespace, pooler1Name,
+				)
 			}, 300).Should(Succeed())
 		})
 

--- a/tests/utils/secrets/secrets.go
+++ b/tests/utils/secrets/secrets.go
@@ -24,6 +24,7 @@ import (
 	"context"
 	"fmt"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -31,6 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	"github.com/cloudnative-pg/cloudnative-pg/internal/configuration"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/certs"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/clusterutils"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/objects"
@@ -109,6 +111,87 @@ func GetCredentials(
 	username := string(secret.Data["username"])
 	password := string(secret.Data["password"])
 	return username, password, nil
+}
+
+// CopyOperatorPullSecretToServiceAccount copies the operator pull secret from
+// the operator namespace to the target namespace and adds it as an
+// imagePullSecret on the specified ServiceAccount. This is needed for shared
+// ServiceAccounts that are not managed by the operator, so they can pull the
+// operator image used by the bootstrap-controller init container.
+// If no operator pull secret exists, this is a no-op.
+func CopyOperatorPullSecretToServiceAccount(
+	ctx context.Context,
+	crudClient client.Client,
+	operatorDeployment appsv1.Deployment,
+	targetNamespace, serviceAccountName string,
+) error {
+	pullSecretName := getOperatorPullSecretName(operatorDeployment)
+	operatorNamespace := operatorDeployment.Namespace
+
+	// Get the operator pull secret
+	var operatorSecret corev1.Secret
+	err := crudClient.Get(ctx, client.ObjectKey{
+		Name:      pullSecretName,
+		Namespace: operatorNamespace,
+	}, &operatorSecret)
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("while getting operator pull secret: %w", err)
+	}
+
+	// Copy the secret to the target namespace
+	targetSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      pullSecretName,
+			Namespace: targetNamespace,
+		},
+		Data: operatorSecret.Data,
+		Type: operatorSecret.Type,
+	}
+	if err := crudClient.Create(ctx, targetSecret); err != nil && !apierrors.IsAlreadyExists(err) {
+		return fmt.Errorf("while creating pull secret in target namespace: %w", err)
+	}
+
+	// Add the pull secret to the ServiceAccount
+	var sa corev1.ServiceAccount
+	if err := crudClient.Get(ctx, client.ObjectKey{
+		Name:      serviceAccountName,
+		Namespace: targetNamespace,
+	}, &sa); err != nil {
+		return fmt.Errorf("while getting service account: %w", err)
+	}
+
+	for _, ref := range sa.ImagePullSecrets {
+		if ref.Name == pullSecretName {
+			return nil
+		}
+	}
+
+	original := sa.DeepCopy()
+	sa.ImagePullSecrets = append(sa.ImagePullSecrets, corev1.LocalObjectReference{
+		Name: pullSecretName,
+	})
+	if err := crudClient.Patch(ctx, &sa, client.MergeFrom(original)); err != nil {
+		return fmt.Errorf("while patching service account with pull secret: %w", err)
+	}
+
+	return nil
+}
+
+// getOperatorPullSecretName reads the PULL_SECRET_NAME env var from the
+// operator deployment, falling back to the default name.
+// NOTE: this only inspects literal env values, not valueFrom references.
+func getOperatorPullSecretName(deployment appsv1.Deployment) string {
+	for _, container := range deployment.Spec.Template.Spec.Containers {
+		for _, envVar := range container.Env {
+			if envVar.Name == "PULL_SECRET_NAME" && envVar.Value != "" {
+				return envVar.Value
+			}
+		}
+	}
+	return configuration.DefaultOperatorPullSecretName
 }
 
 // CreateObjectStorageSecret generates an Opaque Secret with a given ID and Key


### PR DESCRIPTION
The shared ServiceAccount E2E tests were failing in environments where the operator image requires authentication, because the shared SA had no imagePullSecrets for the bootstrap-controller init container.

Replicate what a real user would do by copying the operator pull secret to the test namespace and attaching it to the shared SA. The pull secret name is read from the operator deployment's PULL_SECRET_NAME env var to support non-default configurations.