### PR TITLE
ci(release): use correct secret name in release-pr workflow

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -33,7 +33,7 @@ jobs:
         uses: repo-sync/pull-request@572331753c3787dee4a6c0b6719c889af9646b81 # v2.12
         with:
           destination_branch: ${{ env.DEST }}
-          github_token: ${{ secrets.GHA_PAT }}
+          github_token: ${{ secrets.REPO_GHA_PAT }}
           pr_body: "Automated PR. Will trigger the ${{ env.TAG }} release when approved."
           pr_label: release
           pr_title: "Version tag to ${{ env.TAG }}"


### PR DESCRIPTION
The workflow was using `secrets.GHA_PAT` but the actual secret configured in the repository is `REPO_GHA_PAT`, causing the workflow to fail.

Closes #10308 