### PR TITLE
fix: Preserve LoadBalancerClass if unset in the servicespec

### DIFF
--- a/pkg/servicespec/defaults.go
+++ b/pkg/servicespec/defaults.go
@@ -59,6 +59,9 @@ func PreserveKubernetesDefaults(proposed, living *corev1.ServiceSpec) {
 	if proposed.AllocateLoadBalancerNodePorts == nil {
 		proposed.AllocateLoadBalancerNodePorts = living.AllocateLoadBalancerNodePorts
 	}
+	if proposed.LoadBalancerClass == nil {
+		proposed.LoadBalancerClass = living.LoadBalancerClass
+	}
 	if proposed.TrafficDistribution == nil {
 		proposed.TrafficDistribution = living.TrafficDistribution
 	}

--- a/pkg/servicespec/defaults_test.go
+++ b/pkg/servicespec/defaults_test.go
@@ -239,6 +239,38 @@ var _ = Describe("PreserveKubernetesDefaults", func() {
 		Expect(proposed.AllocateLoadBalancerNodePorts).To(Equal(&allocFalse))
 	})
 
+	It("should preserve LoadbalancerClass when not set", func() {
+		lbClass := "load-balancer-class"
+		proposed := corev1.ServiceSpec{
+			Type:  corev1.ServiceTypeLoadBalancer,
+			Ports: []corev1.ServicePort{{Port: 5432, Name: "postgres"}},
+		}
+		living := corev1.ServiceSpec{
+			Type:               corev1.ServiceTypeLoadBalancer,
+			Ports:             []corev1.ServicePort{{Port: 5432, Name: "postgres"}},
+			LoadBalancerClass: &lbClass,
+		}
+		PreserveKubernetesDefaults(&proposed, &living)
+		Expect(proposed.LoadBalancerClass).To(Equal(&lbClass))
+	})
+
+	It("should not override explicitly set LoadBalancerClass", func() {
+		proposedLBClass := "proposed-load-balancer-class"
+		livingLBClass := "living-load-balancer-class"
+		proposed := corev1.ServiceSpec{
+			Type:              corev1.ServiceTypeLoadBalancer,
+			Ports:             []corev1.ServicePort{{Port: 5432, Name: "postgres"}},
+			LoadBalancerClass: &proposedLBClass,
+		}
+		living := corev1.ServiceSpec{
+			Type:              corev1.ServiceTypeLoadBalancer,
+			Ports:             []corev1.ServicePort{{Port: 5432, Name: "postgres"}},
+			LoadBalancerClass: &livingLBClass,
+		}
+		PreserveKubernetesDefaults(&proposed, &living)
+		Expect(proposed.LoadBalancerClass).To(Equal(&proposedLBClass))
+	})
+
 	It("should preserve TrafficDistribution when not set", func() {
 		dist := "PreferClose"
 		proposed := corev1.ServiceSpec{


### PR DESCRIPTION
When a LoadBalancerClass is not defined in a proposed service template spec it causes an error with the Cluster's Service reconciliation. 
```
phase: Unable to create required cluster objects
phaseReason: 'Service "test-rw-external" is invalid: spec.loadBalancerClass:
      Invalid value: null: may not change once set'
```
I believe this is due to the recent enhancement https://github.com/cloudnative-pg/cloudnative-pg/commit/c16f7483. The proposed change simply ensures that LoadBalancerClass is also configured with the `living` Service spec value if it is not set on the `proposed` service. This means that we will get the same error phase if a LB class is explicitly changed in the template spec, but we will avoid the error if the proposed template does not explicitly set a class.