### PR TITLE
feat: allow targetImmediate without backupID

### DIFF
--- a/internal/webhook/v1/cluster_webhook.go
+++ b/internal/webhook/v1/cluster_webhook.go
@@ -1432,15 +1432,17 @@ func (v *ClusterCustomValidator) validateRecoveryTarget(r *apiv1.Cluster) field.
 	}
 
 	// When using a backup catalog, we can identify the backup to be restored
-	// only if the PITR is time-based. If the PITR is not time-based, the user
-	// need to specify a backup ID.
+	// only if the PITR is time-based or targetImmediate is set (which uses
+	// the latest available backup). If the PITR is label-based (targetName
+	// or targetXID), the user must specify a backup ID.
 	// If we use a dataSource, the operator will directly access the backup
 	// and a backupID is not needed.
 
-	// validate BackupID is defined when TargetName or TargetXID or TargetImmediate are set
+	// validate BackupID is defined when TargetName or TargetXID are set
+	// (targetImmediate is excluded: when no backupID is given, the operator
+	// automatically selects the latest available backup from the catalog)
 	labelBasedPITR := recoveryTarget.TargetName != "" ||
-		recoveryTarget.TargetXID != "" ||
-		recoveryTarget.TargetImmediate != nil
+		recoveryTarget.TargetXID != ""
 	recoveryFromSnapshot := r.Spec.Bootstrap.Recovery.VolumeSnapshots != nil
 	if labelBasedPITR && !recoveryFromSnapshot && recoveryTarget.BackupID == "" {
 		result = append(result, field.Required(

--- a/internal/webhook/v1/cluster_webhook_test.go
+++ b/internal/webhook/v1/cluster_webhook_test.go
@@ -1703,6 +1703,39 @@ var _ = Describe("recovery target", func() {
 		Expect(v.validateRecoveryTarget(cluster)).To(BeEmpty())
 	})
 
+	It("allows TargetImmediate without BackupID (auto-selects latest backup)", func() {
+		cluster := &apiv1.Cluster{
+			Spec: apiv1.ClusterSpec{
+				Bootstrap: &apiv1.BootstrapConfiguration{
+					Recovery: &apiv1.BootstrapRecovery{
+						RecoveryTarget: &apiv1.RecoveryTarget{
+							TargetImmediate: ptr.To(true),
+						},
+					},
+				},
+			},
+		}
+
+		Expect(v.validateRecoveryTarget(cluster)).To(BeEmpty())
+	})
+
+	It("allows TargetImmediate with explicit BackupID", func() {
+		cluster := &apiv1.Cluster{
+			Spec: apiv1.ClusterSpec{
+				Bootstrap: &apiv1.BootstrapConfiguration{
+					Recovery: &apiv1.BootstrapRecovery{
+						RecoveryTarget: &apiv1.RecoveryTarget{
+							TargetImmediate: ptr.To(true),
+							BackupID:        "20220616T031500",
+						},
+					},
+				},
+			},
+		}
+
+		Expect(v.validateRecoveryTarget(cluster)).To(BeEmpty())
+	})
+
 	When("recoveryTLI is specified", func() {
 		It("allows 'latest'", func() {
 			cluster := &apiv1.Cluster{


### PR DESCRIPTION
## Summary

When `targetImmediate` is set in `bootstrap.recovery.recoveryTarget`, allow omitting `backupID` — the operator automatically selects the latest available backup from the catalog.

**Problem:** Currently, `backupID` is required for all non-time-based recovery targets (`targetImmediate`, `targetName`, `targetXID`). While this requirement makes sense for `targetName` and `targetXID` (where the operator cannot determine which base backup is appropriate), `targetImmediate` has no such ambiguity — it simply means "stop at the first consistent state after restoring the base backup."

This forces users who want a simple "restore latest backup without WAL replay" to first look up the backup ID externally (via kubectl or scripts), making what should be a declarative operation into a two-step imperative process.

**Solution:** Remove `targetImmediate` from the webhook validation that requires `backupID`. The barman-cloud catalog's `FindBackupInfo()` already handles this case correctly — when `backupID` is empty and no time/LSN target is set, it falls through to selecting the latest available backup via `findLatestBackupFromTimeline()`.

## Changes

- `internal/webhook/v1/cluster_webhook.go`: Exclude `TargetImmediate` from the `labelBasedPITR` check that requires `backupID`
- `internal/webhook/v1/cluster_webhook_test.go`: Add test cases for `targetImmediate` without and with `backupID`

## Use case

```yaml
spec:
  bootstrap:
    recovery:
      source: prod
      recoveryTarget:
        targetImmediate: true
        # No backupID needed — operator picks latest automatically
```

This enables fully declarative "clone from latest backup" workflows (e.g., staging refresh from production) without requiring external scripts to look up backup IDs.

## Test plan

- [x] Existing webhook validation tests pass (397/397)
- [x] New test: `targetImmediate: true` without `backupID` is accepted
- [x] New test: `targetImmediate: true` with explicit `backupID` still works
- [x] `targetName` and `targetXID` still require `backupID` (unchanged behavior)

Closes #8031