### PR TITLE
test(e2e): fix AfterAll cleanup failure when minio test is skipped

### DIFF
--- a/tests/e2e/backup_restore_minio_test.go
+++ b/tests/e2e/backup_restore_minio_test.go
@@ -114,6 +114,9 @@ var _ = Describe("MinIO - Backup and restore", Label(tests.LabelBackupRestore), 
 		})
 
 		AfterAll(func() {
+			if namespace == "" {
+				return
+			}
 			// While namespace deletion would handle this implicitly, explicit deletion helps:
 			// - Identify any deletion issues early and in a more clear way rather than waiting for namespace cleanup
 			err := DeleteResourcesFromFile(namespace, clusterWithMinioSampleFile)

--- a/tests/e2e/backup_restore_minio_test.go
+++ b/tests/e2e/backup_restore_minio_test.go
@@ -114,7 +114,7 @@ var _ = Describe("MinIO - Backup and restore", Label(tests.LabelBackupRestore), 
 		})
 
 		AfterAll(func() {
-			if namespace == "" {
+			if CurrentSpecReport().State.Is(types.SpecStateSkipped) {
 				return
 			}
 			// While namespace deletion would handle this implicitly, explicit deletion helps:

--- a/tests/e2e/backup_restore_minio_test.go
+++ b/tests/e2e/backup_restore_minio_test.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/onsi/ginkgo/v2/types"
 	"k8s.io/client-go/util/retry"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 


### PR DESCRIPTION
The backup_restore_minio AfterAll handler attempts to delete cluster resources even when BeforeAll was skipped on non-kind/k3d clusters, causing a spurious failure because the namespace was never created.

Skip the cleanup when namespace is empty.