### PR TITLE
fix(upgrade): break config uniformity deadlock during operator upgrades

### DIFF
--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -1088,12 +1088,20 @@ func (r *ClusterReconciler) reconcilePods(
 	// proceed with a rolling update to upgrade the instance manager
 	// to a version that reports the configuration status.
 	// If all pods report their configuration, wait until all instances
-	// report the same configuration.
+	// report the same configuration — unless the non-uniformity is caused
+	// by an operator upgrade that changed the hash algorithm. In that case
+	// configs will never converge on their own; proceeding to the rolling
+	// update (or in-place upgrade) is the only way to break the deadlock.
 	if uniform := report.IsUniform(); uniform != nil && !*uniform {
-		contextLogger.Debug(
-			"Waiting for all Pods to have the same PostgreSQL configuration",
+		if !isConfigNonUniformityFromUpgrade(instancesStatus) {
+			contextLogger.Debug(
+				"Waiting for all Pods to have the same PostgreSQL configuration",
+				"configurationReport", report)
+			return ctrl.Result{RequeueAfter: 1 * time.Second}, ErrNextLoop
+		}
+		contextLogger.Info(
+			"Configuration non-uniformity caused by operator upgrade, proceeding with rolling update",
 			"configurationReport", report)
-		return ctrl.Result{RequeueAfter: 1 * time.Second}, ErrNextLoop
 	}
 
 	return r.handleRollingUpdate(ctx, cluster, instancesStatus)

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -1088,10 +1088,10 @@ func (r *ClusterReconciler) reconcilePods(
 	// proceed with a rolling update to upgrade the instance manager
 	// to a version that reports the configuration status.
 	// If all pods report their configuration, wait until all instances
-	// report the same configuration — unless the non-uniformity is caused
+	// report the same configuration, unless the non-uniformity is caused
 	// by an operator upgrade that changed the hash algorithm. In that case
-	// configs will never converge on their own; proceeding to the rolling
-	// update (or in-place upgrade) is the only way to break the deadlock.
+	// configuration hashes will never converge on their own; proceeding
+	// to the rolling update (or in-place upgrade) is the only way forward.
 	if uniform := report.IsUniform(); uniform != nil && !*uniform {
 		if !isConfigNonUniformityFromUpgrade(instancesStatus) {
 			contextLogger.Debug(
@@ -1100,7 +1100,7 @@ func (r *ClusterReconciler) reconcilePods(
 			return ctrl.Result{RequeueAfter: 1 * time.Second}, ErrNextLoop
 		}
 		contextLogger.Info(
-			"Configuration non-uniformity caused by operator upgrade, proceeding with rolling update",
+			"Configuration non-uniformity caused by operator upgrade, proceeding with upgrade",
 			"configurationReport", report)
 	}
 

--- a/internal/controller/cluster_upgrade.go
+++ b/internal/controller/cluster_upgrade.go
@@ -336,6 +336,50 @@ func isInstanceNeedingRollout(
 	return rollout{}
 }
 
+// isConfigNonUniformityFromUpgrade checks whether the configuration hash
+// non-uniformity across pods is caused by an operator upgrade that changed
+// the hash algorithm. It returns true only when multiple operator versions
+// are present and each version group is internally uniform — meaning the
+// non-uniformity is structural (different algorithms) and will never
+// self-resolve without restarting or upgrading the remaining pods.
+func isConfigNonUniformityFromUpgrade(instancesStatus postgres.PostgresqlStatusList) bool {
+	// Map each operator bootstrap image to the config hash observed for
+	// that version. If pods running the same operator version report
+	// different hashes, the non-uniformity is from config propagation
+	// and will resolve on its own.
+	hashByImage := make(map[string]string, len(instancesStatus.Items))
+	for i := range instancesStatus.Items {
+		pod := instancesStatus.Items[i].Pod
+		if pod == nil {
+			continue
+		}
+		opImage, err := specs.GetBootstrapControllerImageName(*pod)
+		if err != nil {
+			continue
+		}
+		configHash := instancesStatus.Items[i].LoadedConfigurationHash
+		if configHash == "" {
+			continue
+		}
+		if existing, ok := hashByImage[opImage]; ok {
+			if existing != configHash {
+				// Same operator version, different configs: still propagating
+				return false
+			}
+		} else {
+			hashByImage[opImage] = configHash
+		}
+	}
+
+	// Deadlock only when multiple operator versions are present,
+	// each with internally uniform but mutually different hashes.
+	// Note: this function is only called when IsUniform() returned false,
+	// which guarantees that different hashes exist globally. If each
+	// operator-image group is internally uniform and there are 2+ groups,
+	// the hash difference must come from between groups.
+	return len(hashByImage) > 1
+}
+
 // isPodNeedingRollout checks if a given cluster instance needs a rollout by comparing its current state
 // with its expected state defined inside the cluster struct.
 //

--- a/internal/controller/cluster_upgrade.go
+++ b/internal/controller/cluster_upgrade.go
@@ -336,18 +336,17 @@ func isInstanceNeedingRollout(
 	return rollout{}
 }
 
-// isConfigNonUniformityFromUpgrade checks whether the configuration hash
-// non-uniformity across pods is caused by an operator upgrade that changed
-// the hash algorithm. It returns true only when multiple operator versions
-// are present and each version group is internally uniform — meaning the
-// non-uniformity is structural (different algorithms) and will never
-// self-resolve without restarting or upgrading the remaining pods.
+// isConfigNonUniformityFromUpgrade returns true when config hash differences
+// across pods are caused by an operator upgrade (different hash algorithms)
+// rather than config propagation. It groups pods by operator version (using
+// both bootstrap image and executable hash) and checks whether each group
+// is internally uniform.
 func isConfigNonUniformityFromUpgrade(instancesStatus postgres.PostgresqlStatusList) bool {
-	// Map each operator bootstrap image to the config hash observed for
-	// that version. If pods running the same operator version report
-	// different hashes, the non-uniformity is from config propagation
-	// and will resolve on its own.
-	hashByImage := make(map[string]string, len(instancesStatus.Items))
+	type versionKey struct {
+		image          string
+		executableHash string
+	}
+	hashByVersion := make(map[versionKey]string, len(instancesStatus.Items))
 	for i := range instancesStatus.Items {
 		pod := instancesStatus.Items[i].Pod
 		if pod == nil {
@@ -361,23 +360,21 @@ func isConfigNonUniformityFromUpgrade(instancesStatus postgres.PostgresqlStatusL
 		if configHash == "" {
 			continue
 		}
-		if existing, ok := hashByImage[opImage]; ok {
+		key := versionKey{
+			image:          opImage,
+			executableHash: instancesStatus.Items[i].ExecutableHash,
+		}
+		if existing, ok := hashByVersion[key]; ok {
 			if existing != configHash {
-				// Same operator version, different configs: still propagating
+				// Same version, different hashes: config still propagating
 				return false
 			}
 		} else {
-			hashByImage[opImage] = configHash
+			hashByVersion[key] = configHash
 		}
 	}
 
-	// Deadlock only when multiple operator versions are present,
-	// each with internally uniform but mutually different hashes.
-	// Note: this function is only called when IsUniform() returned false,
-	// which guarantees that different hashes exist globally. If each
-	// operator-image group is internally uniform and there are 2+ groups,
-	// the hash difference must come from between groups.
-	return len(hashByImage) > 1
+	return len(hashByVersion) > 1
 }
 
 // isPodNeedingRollout checks if a given cluster instance needs a rollout by comparing its current state

--- a/internal/controller/cluster_upgrade_test.go
+++ b/internal/controller/cluster_upgrade_test.go
@@ -820,6 +820,105 @@ var _ = Describe("Cluster upgrade with podSpec reconciliation disabled", func() 
 	})
 })
 
+var _ = Describe("isConfigNonUniformityFromUpgrade", func() {
+	const (
+		oldOperatorImage = "ghcr.io/cloudnative-pg/cloudnative-pg:1.27.0"
+		newOperatorImage = "ghcr.io/cloudnative-pg/cloudnative-pg:1.27.1"
+	)
+
+	makePodWithBootstrapImage := func(name, image string) *corev1.Pod {
+		return &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Spec: corev1.PodSpec{
+				InitContainers: []corev1.Container{
+					{Name: specs.BootstrapControllerContainerName, Image: image},
+				},
+			},
+		}
+	}
+
+	It("returns false when all pods have the same operator image and same hash", func() {
+		statusList := postgres.PostgresqlStatusList{
+			Items: []postgres.PostgresqlStatus{
+				{Pod: makePodWithBootstrapImage("pod-1", oldOperatorImage), LoadedConfigurationHash: "hash-a"},
+				{Pod: makePodWithBootstrapImage("pod-2", oldOperatorImage), LoadedConfigurationHash: "hash-a"},
+			},
+		}
+		Expect(isConfigNonUniformityFromUpgrade(statusList)).To(BeFalse())
+	})
+
+	It("returns false when all pods have the same operator image but different hashes", func() {
+		statusList := postgres.PostgresqlStatusList{
+			Items: []postgres.PostgresqlStatus{
+				{Pod: makePodWithBootstrapImage("pod-1", oldOperatorImage), LoadedConfigurationHash: "hash-a"},
+				{Pod: makePodWithBootstrapImage("pod-2", oldOperatorImage), LoadedConfigurationHash: "hash-b"},
+				{Pod: makePodWithBootstrapImage("pod-3", oldOperatorImage), LoadedConfigurationHash: "hash-a"},
+			},
+		}
+		Expect(isConfigNonUniformityFromUpgrade(statusList)).To(BeFalse())
+	})
+
+	It("returns true when operator versions differ and each group has uniform hashes", func() {
+		statusList := postgres.PostgresqlStatusList{
+			Items: []postgres.PostgresqlStatus{
+				{Pod: makePodWithBootstrapImage("pod-1", newOperatorImage), LoadedConfigurationHash: "hash-new"},
+				{Pod: makePodWithBootstrapImage("pod-2", oldOperatorImage), LoadedConfigurationHash: "hash-old"},
+				{Pod: makePodWithBootstrapImage("pod-3", oldOperatorImage), LoadedConfigurationHash: "hash-old"},
+			},
+		}
+		Expect(isConfigNonUniformityFromUpgrade(statusList)).To(BeTrue())
+	})
+
+	It("returns false when same operator version has different hashes (config propagation)", func() {
+		statusList := postgres.PostgresqlStatusList{
+			Items: []postgres.PostgresqlStatus{
+				{Pod: makePodWithBootstrapImage("pod-1", newOperatorImage), LoadedConfigurationHash: "hash-new"},
+				{Pod: makePodWithBootstrapImage("pod-2", oldOperatorImage), LoadedConfigurationHash: "hash-old-a"},
+				{Pod: makePodWithBootstrapImage("pod-3", oldOperatorImage), LoadedConfigurationHash: "hash-old-b"},
+			},
+		}
+		Expect(isConfigNonUniformityFromUpgrade(statusList)).To(BeFalse())
+	})
+
+	It("returns false with an empty status list", func() {
+		statusList := postgres.PostgresqlStatusList{}
+		Expect(isConfigNonUniformityFromUpgrade(statusList)).To(BeFalse())
+	})
+
+	It("skips pods with nil Pod or empty config hash", func() {
+		statusList := postgres.PostgresqlStatusList{
+			Items: []postgres.PostgresqlStatus{
+				{Pod: nil, LoadedConfigurationHash: "hash-a"},
+				{Pod: makePodWithBootstrapImage("pod-2", oldOperatorImage), LoadedConfigurationHash: ""},
+				{Pod: makePodWithBootstrapImage("pod-3", oldOperatorImage), LoadedConfigurationHash: "hash-a"},
+			},
+		}
+		Expect(isConfigNonUniformityFromUpgrade(statusList)).To(BeFalse())
+	})
+
+	It("returns false when config propagation is in progress during an operator upgrade", func() {
+		// New-image pods have different hashes (config still propagating),
+		// so the non-uniformity is not purely from the algorithm change
+		statusList := postgres.PostgresqlStatusList{
+			Items: []postgres.PostgresqlStatus{
+				{Pod: makePodWithBootstrapImage("pod-1", newOperatorImage), LoadedConfigurationHash: "hash-new-stale"},
+				{Pod: makePodWithBootstrapImage("pod-2", newOperatorImage), LoadedConfigurationHash: "hash-new-current"},
+				{Pod: makePodWithBootstrapImage("pod-3", oldOperatorImage), LoadedConfigurationHash: "hash-old"},
+			},
+		}
+		Expect(isConfigNonUniformityFromUpgrade(statusList)).To(BeFalse())
+	})
+
+	It("returns false with a single pod", func() {
+		statusList := postgres.PostgresqlStatusList{
+			Items: []postgres.PostgresqlStatus{
+				{Pod: makePodWithBootstrapImage("pod-1", oldOperatorImage), LoadedConfigurationHash: "hash-a"},
+			},
+		}
+		Expect(isConfigNonUniformityFromUpgrade(statusList)).To(BeFalse())
+	})
+})
+
 type fakePluginClientRollout struct {
 	pluginClient.Client
 	returnedPod   *corev1.Pod

--- a/internal/controller/cluster_upgrade_test.go
+++ b/internal/controller/cluster_upgrade_test.go
@@ -824,95 +824,112 @@ var _ = Describe("isConfigNonUniformityFromUpgrade", func() {
 	const (
 		oldOperatorImage = "ghcr.io/cloudnative-pg/cloudnative-pg:1.27.0"
 		newOperatorImage = "ghcr.io/cloudnative-pg/cloudnative-pg:1.27.1"
+		oldExecHash      = "exec-old"
+		newExecHash      = "exec-new"
 	)
 
-	makePodWithBootstrapImage := func(name, image string) *corev1.Pod {
-		return &corev1.Pod{
-			ObjectMeta: metav1.ObjectMeta{Name: name},
-			Spec: corev1.PodSpec{
-				InitContainers: []corev1.Container{
-					{Name: specs.BootstrapControllerContainerName, Image: image},
+	makeStatus := func(
+		name, image, execHash, configHash string,
+	) postgres.PostgresqlStatus {
+		return postgres.PostgresqlStatus{
+			Pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: name},
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{
+						{
+							Name:  specs.BootstrapControllerContainerName,
+							Image: image,
+						},
+					},
 				},
 			},
+			ExecutableHash:          execHash,
+			LoadedConfigurationHash: configHash,
 		}
 	}
 
-	It("returns false when all pods have the same operator image and same hash", func() {
-		statusList := postgres.PostgresqlStatusList{
-			Items: []postgres.PostgresqlStatus{
-				{Pod: makePodWithBootstrapImage("pod-1", oldOperatorImage), LoadedConfigurationHash: "hash-a"},
-				{Pod: makePodWithBootstrapImage("pod-2", oldOperatorImage), LoadedConfigurationHash: "hash-a"},
-			},
-		}
-		Expect(isConfigNonUniformityFromUpgrade(statusList)).To(BeFalse())
-	})
+	// Positive cases: deadlock detected, bypass should trigger
 
-	It("returns false when all pods have the same operator image but different hashes", func() {
+	It("rolling update with uniform groups", func() {
 		statusList := postgres.PostgresqlStatusList{
 			Items: []postgres.PostgresqlStatus{
-				{Pod: makePodWithBootstrapImage("pod-1", oldOperatorImage), LoadedConfigurationHash: "hash-a"},
-				{Pod: makePodWithBootstrapImage("pod-2", oldOperatorImage), LoadedConfigurationHash: "hash-b"},
-				{Pod: makePodWithBootstrapImage("pod-3", oldOperatorImage), LoadedConfigurationHash: "hash-a"},
-			},
-		}
-		Expect(isConfigNonUniformityFromUpgrade(statusList)).To(BeFalse())
-	})
-
-	It("returns true when operator versions differ and each group has uniform hashes", func() {
-		statusList := postgres.PostgresqlStatusList{
-			Items: []postgres.PostgresqlStatus{
-				{Pod: makePodWithBootstrapImage("pod-1", newOperatorImage), LoadedConfigurationHash: "hash-new"},
-				{Pod: makePodWithBootstrapImage("pod-2", oldOperatorImage), LoadedConfigurationHash: "hash-old"},
-				{Pod: makePodWithBootstrapImage("pod-3", oldOperatorImage), LoadedConfigurationHash: "hash-old"},
+				makeStatus("pod-1", newOperatorImage, newExecHash, "hash-new"),
+				makeStatus("pod-2", oldOperatorImage, oldExecHash, "hash-old"),
+				makeStatus("pod-3", oldOperatorImage, oldExecHash, "hash-old"),
 			},
 		}
 		Expect(isConfigNonUniformityFromUpgrade(statusList)).To(BeTrue())
 	})
 
-	It("returns false when same operator version has different hashes (config propagation)", func() {
+	It("in-place upgrade with uniform groups", func() {
+		// Same bootstrap image but different executable hashes from binary replacement
 		statusList := postgres.PostgresqlStatusList{
 			Items: []postgres.PostgresqlStatus{
-				{Pod: makePodWithBootstrapImage("pod-1", newOperatorImage), LoadedConfigurationHash: "hash-new"},
-				{Pod: makePodWithBootstrapImage("pod-2", oldOperatorImage), LoadedConfigurationHash: "hash-old-a"},
-				{Pod: makePodWithBootstrapImage("pod-3", oldOperatorImage), LoadedConfigurationHash: "hash-old-b"},
+				makeStatus("pod-1", oldOperatorImage, newExecHash, "hash-new"),
+				makeStatus("pod-2", oldOperatorImage, oldExecHash, "hash-old"),
+				makeStatus("pod-3", oldOperatorImage, oldExecHash, "hash-old"),
+			},
+		}
+		Expect(isConfigNonUniformityFromUpgrade(statusList)).To(BeTrue())
+	})
+
+	// Negative cases: not a deadlock, should keep waiting
+
+	It("same version, config still propagating", func() {
+		statusList := postgres.PostgresqlStatusList{
+			Items: []postgres.PostgresqlStatus{
+				makeStatus("pod-1", oldOperatorImage, oldExecHash, "hash-a"),
+				makeStatus("pod-2", oldOperatorImage, oldExecHash, "hash-b"),
+				makeStatus("pod-3", oldOperatorImage, oldExecHash, "hash-a"),
 			},
 		}
 		Expect(isConfigNonUniformityFromUpgrade(statusList)).To(BeFalse())
 	})
 
-	It("returns false with an empty status list", func() {
+	It("config propagation within old-version group during upgrade", func() {
+		statusList := postgres.PostgresqlStatusList{
+			Items: []postgres.PostgresqlStatus{
+				makeStatus("pod-1", newOperatorImage, newExecHash, "hash-new"),
+				makeStatus("pod-2", oldOperatorImage, oldExecHash, "hash-old-a"),
+				makeStatus("pod-3", oldOperatorImage, oldExecHash, "hash-old-b"),
+			},
+		}
+		Expect(isConfigNonUniformityFromUpgrade(statusList)).To(BeFalse())
+	})
+
+	It("config propagation within new-version group during upgrade", func() {
+		statusList := postgres.PostgresqlStatusList{
+			Items: []postgres.PostgresqlStatus{
+				makeStatus("pod-1", newOperatorImage, newExecHash, "hash-new-stale"),
+				makeStatus("pod-2", newOperatorImage, newExecHash, "hash-new-current"),
+				makeStatus("pod-3", oldOperatorImage, oldExecHash, "hash-old"),
+			},
+		}
+		Expect(isConfigNonUniformityFromUpgrade(statusList)).To(BeFalse())
+	})
+
+	// Edge cases
+
+	It("empty status list", func() {
 		statusList := postgres.PostgresqlStatusList{}
 		Expect(isConfigNonUniformityFromUpgrade(statusList)).To(BeFalse())
 	})
 
-	It("skips pods with nil Pod or empty config hash", func() {
+	It("single pod", func() {
+		statusList := postgres.PostgresqlStatusList{
+			Items: []postgres.PostgresqlStatus{
+				makeStatus("pod-1", oldOperatorImage, oldExecHash, "hash-a"),
+			},
+		}
+		Expect(isConfigNonUniformityFromUpgrade(statusList)).To(BeFalse())
+	})
+
+	It("nil Pod and empty config hash are skipped", func() {
 		statusList := postgres.PostgresqlStatusList{
 			Items: []postgres.PostgresqlStatus{
 				{Pod: nil, LoadedConfigurationHash: "hash-a"},
-				{Pod: makePodWithBootstrapImage("pod-2", oldOperatorImage), LoadedConfigurationHash: ""},
-				{Pod: makePodWithBootstrapImage("pod-3", oldOperatorImage), LoadedConfigurationHash: "hash-a"},
-			},
-		}
-		Expect(isConfigNonUniformityFromUpgrade(statusList)).To(BeFalse())
-	})
-
-	It("returns false when config propagation is in progress during an operator upgrade", func() {
-		// New-image pods have different hashes (config still propagating),
-		// so the non-uniformity is not purely from the algorithm change
-		statusList := postgres.PostgresqlStatusList{
-			Items: []postgres.PostgresqlStatus{
-				{Pod: makePodWithBootstrapImage("pod-1", newOperatorImage), LoadedConfigurationHash: "hash-new-stale"},
-				{Pod: makePodWithBootstrapImage("pod-2", newOperatorImage), LoadedConfigurationHash: "hash-new-current"},
-				{Pod: makePodWithBootstrapImage("pod-3", oldOperatorImage), LoadedConfigurationHash: "hash-old"},
-			},
-		}
-		Expect(isConfigNonUniformityFromUpgrade(statusList)).To(BeFalse())
-	})
-
-	It("returns false with a single pod", func() {
-		statusList := postgres.PostgresqlStatusList{
-			Items: []postgres.PostgresqlStatus{
-				{Pod: makePodWithBootstrapImage("pod-1", oldOperatorImage), LoadedConfigurationHash: "hash-a"},
+				{LoadedConfigurationHash: ""},
+				makeStatus("pod-3", oldOperatorImage, oldExecHash, "hash-a"),
 			},
 		}
 		Expect(isConfigNonUniformityFromUpgrade(statusList)).To(BeFalse())


### PR DESCRIPTION
When upgrading from an operator version that includes cnpg.* parameters in the PostgreSQL configuration hash to one that excludes them (change introduced in #8868), pods running the old and new operator end up computing different hashes for the same effective configuration. The uniformity check in reconcilePods then blocks indefinitely, waiting for all pods to report the same hash, but that can never happen because the remaining pods still use the old algorithm. Neither the rolling update nor the in-place instance manager upgrade can run, since both live behind the blocked check.

The fix introduces `isConfigNonUniformityFromUpgrade()`, which groups pods by their operator version and checks whether the hash split aligns exactly with the version split. If every pod running the same operator version agrees on its hash, but different versions disagree, the non-uniformity is structural and will never self-resolve. In that case we skip the wait and let `handleRollingUpdate` proceed.

The operator version key combines both the bootstrap controller image (changes on rolling updates) and the executable hash (changes on in-place upgrades), so the deadlock is detected regardless of the upgrade strategy.

When the non-uniformity is from normal config propagation (pods on the same operator version reporting different hashes), the function returns false and the existing wait-for-uniformity behavior is preserved. This keeps the fix scoped strictly to the operator upgrade deadlock scenario, with no change in behavior during normal operations.

Closes: #10348

Assisted-by: Claude