### PR TITLE
feat(plugin): add sysbench benchmarking support

### DIFF
--- a/cmd/kubectl-cnpg/main.go
+++ b/cmd/kubectl-cnpg/main.go
@@ -50,6 +50,7 @@ import (
 	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/plugin/restart"
 	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/plugin/snapshot"
 	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/plugin/status"
+	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/plugin/sysbench"
 	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/versions"
 
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
@@ -133,6 +134,7 @@ func main() {
 		snapshot.NewCmd(),
 		status.NewCmd(),
 		subscription.NewCmd(),
+		sysbench.NewCmd(),
 		versions.NewCmd(),
 	}
 

--- a/docs/src/benchmarking.md
+++ b/docs/src/benchmarking.md
@@ -9,13 +9,14 @@ title: Benchmarking
 
 The CNPG kubectl plugin provides an easy way for benchmarking a PostgreSQL deployment in Kubernetes using CloudNativePG.
 
-Benchmarking is focused on two aspects:
+Benchmarking is focused on three aspects:
 
 - the **database**, by relying on [pgbench](https://www.postgresql.org/docs/current/pgbench.html)
+- the **database (OLTP)**, by relying on [sysbench](https://github.com/akopytov/sysbench)
 - the **storage**, by relying on [fio](https://fio.readthedocs.io/en/latest/fio_doc.html)
 
 :::info[IMPORTANT]
-    `pgbench` and `fio` must be run in a staging or pre-production environment.
+    `pgbench`, `sysbench`, and `fio` must be run in a staging or pre-production environment.
     Do not use these plugins in a production environment, as it might have
     catastrophic consequences on your databases and the other
     workloads/applications that run in the same shared environment.
@@ -123,6 +124,93 @@ job-name   1/1           15s        41s
 Once the job is completed the results can be gathered by executing:
 ```
 kubectl logs job/pgbench-job -n <namespace>
+```
+
+### sysbench
+
+The `kubectl` CNPG plugin command `sysbench` executes a user-defined
+[sysbench](https://github.com/akopytov/sysbench) job against an existing
+Postgres Cluster.
+
+Through the `--dry-run` flag you can generate the manifest of the job for later
+modification/execution.
+
+A common command structure with `sysbench` is the following:
+
+```shell
+kubectl cnpg sysbench \
+  -n <namespace> <cluster-name> \
+  --job-name <sysbench-job> \
+  --db-name <db-name> \
+  -- <sysbench options>
+```
+
+:::info[IMPORTANT]
+    Please refer to the [`sysbench` documentation](https://github.com/akopytov/sysbench)
+    for information about the specific options to be used in your jobs.
+:::
+
+This example creates a job that initializes the sysbench OLTP tables in the
+`app` database of a `Cluster` named `cluster-example`, with 4 tables of
+10000 rows each:
+
+```shell
+kubectl cnpg sysbench \
+  cluster-example \
+  -- oltp_read_write --tables=4 --table-size=10000 prepare
+```
+
+You can see the progress of the job with:
+
+```shell
+kubectl logs jobs/<job-name>
+```
+
+The following example runs a sysbench OLTP read/write benchmark for 30 seconds
+with 4 threads:
+
+```shell
+kubectl cnpg sysbench \
+  cluster-example \
+  -- oltp_read_write --tables=4 --table-size=10000 --time=30 --threads=4 --report-interval=1 run
+```
+
+After benchmarking, clean up the sysbench tables:
+
+```shell
+kubectl cnpg sysbench \
+  cluster-example \
+  -- oltp_read_write --tables=4 --table-size=10000 cleanup
+```
+
+By default, the plugin uses the `perconalab/sysbench:1.1` container image.
+You can override this with the `--sysbench-image` flag:
+
+```shell
+kubectl cnpg sysbench \
+  --sysbench-image my-registry/sysbench:custom \
+  cluster-example \
+  -- oltp_read_write --tables=4 --table-size=10000 run
+```
+
+By default, jobs do not expire. You can enable automatic deletion with the
+`--ttl` flag. The job will be deleted after the specified duration (in seconds).
+
+```shell
+kubectl cnpg sysbench \
+  --ttl 600 \
+  cluster-example \
+  -- oltp_read_write --tables=4 --table-size=10000 --time=30 run
+```
+
+If you want to run a `sysbench` job on a specific worker node, you can use
+the `--node-selector` option:
+
+```shell
+kubectl cnpg sysbench \
+  --node-selector workload=benchmark \
+  cluster-example \
+  -- oltp_read_write --tables=4 --table-size=10000 run
 ```
 
 ### fio

--- a/internal/cmd/plugin/sysbench/cmd.go
+++ b/internal/cmd/plugin/sysbench/cmd.go
@@ -6,7 +6,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -29,6 +29,7 @@ import (
 
 const defaultSysbenchImage = "perconalab/sysbench:1.1"
 
+// NewCmd initializes the sysbench command
 func NewCmd() *cobra.Command {
 	run := &sysbenchRun{}
 

--- a/internal/cmd/plugin/sysbench/cmd.go
+++ b/internal/cmd/plugin/sysbench/cmd.go
@@ -1,0 +1,106 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package sysbench
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/plugin"
+)
+
+const defaultSysbenchImage = "perconalab/sysbench:1.1"
+
+func NewCmd() *cobra.Command {
+	run := &sysbenchRun{}
+
+	sysBenchCmd := &cobra.Command{
+		Use:     "sysbench CLUSTER [-- SYSBENCH_COMMAND_ARGS...]",
+		Short:   "Creates a sysbench job",
+		Args:    validateCommandArgs,
+		Long:    "Creates a sysbench job to run against the specified Postgres Cluster.",
+		GroupID: plugin.GroupIDMiscellaneous,
+		Example: jobExample,
+
+		// RunE - returns an error, Cobra will print the error message and the usage message from the original command
+		RunE: func(cmd *cobra.Command, args []string) error {
+			run.clusterName = args[0]
+			run.sysbenchCommandArgs = args[1:]
+
+			return run.execute(cmd.Context())
+		},
+	}
+
+	sysBenchCmd.Flags().StringVar(
+		&run.jobName,
+		"job-name",
+		"",
+		"Name of the job, defaulting to: CLUSTER-sysbench-xxxx",
+	)
+
+	sysBenchCmd.Flags().StringVar(
+		&run.dbName,
+		"db-name",
+		"app",
+		"The name of the database that will be used by sysbench. Defaults to: app",
+	)
+	sysBenchCmd.Flags().StringVar(
+		&run.sysbenchImage,
+		"sysbench-image",
+		defaultSysbenchImage,
+		"The sysbench image to use for the job.",
+	)
+
+	sysBenchCmd.Flags().BoolVar(
+		&run.dryRun,
+		"dry-run",
+		false,
+		"Whether to print the job manifest without creating the job. Defaults to false.",
+	)
+
+	sysBenchCmd.Flags().StringSliceVar(
+		&run.nodeSelector,
+		"node-selector",
+		[]string{},
+		"Node label selector, in the format: key=value,key2=value",
+	)
+
+	sysBenchCmd.Flags().Int32Var(
+		&run.ttlSecondsAfterFinished,
+		"ttl",
+		0,
+		"TTL seconds to clean up the job after it finishes. Defaults to no TTL.",
+	)
+
+	return sysBenchCmd
+}
+
+func validateCommandArgs(cmd *cobra.Command, args []string) error {
+	if err := cobra.MinimumNArgs(1)(cmd, args); err != nil {
+		return err
+	}
+
+	if cmd.ArgsLenAtDash() > 1 {
+		return fmt.Errorf("SYSBENCH_COMMAND_ARGS should be passed after the -- delimiter")
+	}
+
+	return nil
+}

--- a/internal/cmd/plugin/sysbench/cmd.go
+++ b/internal/cmd/plugin/sysbench/cmd.go
@@ -33,15 +33,21 @@ func NewCmd() *cobra.Command {
 	run := &sysbenchRun{}
 
 	sysBenchCmd := &cobra.Command{
-		Use:     "sysbench CLUSTER [-- SYSBENCH_COMMAND_ARGS...]",
+		Use:     "sysbench <cluster-name> [-- sysbench_command_args...]",
 		Short:   "Creates a sysbench job",
-		Args:    validateCommandArgs,
+		Args:    plugin.RequiresArguments(1),
 		Long:    "Creates a sysbench job to run against the specified Postgres Cluster.",
 		GroupID: plugin.GroupIDMiscellaneous,
 		Example: jobExample,
 
-		// RunE - returns an error, Cobra will print the error message and the usage message from the original command
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return plugin.CompleteClusters(cmd.Context(), args, toComplete), cobra.ShellCompDirectiveNoFileComp
+		},
+
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if cmd.ArgsLenAtDash() > 1 {
+				return fmt.Errorf("sysbench_command_args should be passed after the -- delimiter")
+			}
 			run.clusterName = args[0]
 			run.sysbenchCommandArgs = args[1:]
 
@@ -53,7 +59,7 @@ func NewCmd() *cobra.Command {
 		&run.jobName,
 		"job-name",
 		"",
-		"Name of the job, defaulting to: CLUSTER-sysbench-xxxx",
+		"Name of the job, defaulting to: cluster-name-sysbench-xxxx",
 	)
 
 	sysBenchCmd.Flags().StringVar(
@@ -91,16 +97,4 @@ func NewCmd() *cobra.Command {
 	)
 
 	return sysBenchCmd
-}
-
-func validateCommandArgs(cmd *cobra.Command, args []string) error {
-	if err := cobra.MinimumNArgs(1)(cmd, args); err != nil {
-		return err
-	}
-
-	if cmd.ArgsLenAtDash() > 1 {
-		return fmt.Errorf("SYSBENCH_COMMAND_ARGS should be passed after the -- delimiter")
-	}
-
-	return nil
 }

--- a/internal/cmd/plugin/sysbench/cmd_test.go
+++ b/internal/cmd/plugin/sysbench/cmd_test.go
@@ -33,7 +33,7 @@ var _ = Describe("NewCmd", func() {
 	It("should create a cobra.Command with correct defaults", func() {
 		cmd := NewCmd()
 
-		Expect(cmd.Use).To(Equal("sysbench CLUSTER [-- SYSBENCH_COMMAND_ARGS...]"))
+		Expect(cmd.Use).To(Equal("sysbench <cluster-name> [-- sysbench_command_args...]"))
 		Expect(cmd.Short).To(Equal("Creates a sysbench job"))
 		Expect(cmd.Example).To(Equal(jobExample))
 

--- a/internal/cmd/plugin/sysbench/cmd_test.go
+++ b/internal/cmd/plugin/sysbench/cmd_test.go
@@ -140,3 +140,33 @@ var _ = Describe("getJobName", func() {
 		Expect(cmd.getJobName()).To(HavePrefix("my-cluster-sysbench-"))
 	})
 })
+
+var _ = Describe("validateSysbenchArgs", func() {
+	It("valid args should pass validation", func() {
+		args := []string{
+			"--threads=4",
+			"--tables=10",
+			"--table-size=1000",
+		}
+		Expect(validateSysbenchArgs(args)).To(Succeed())
+	})
+	It("single blocked arg should fail validation", func() {
+		args := []string{
+			"--threads=4",
+			"--pgsql-host=localhost", // This should be blocked
+			"--table-size=1000",
+		}
+		Expect(validateSysbenchArgs(args)).To(MatchError(
+			"the following flags are managed automatically and cannot be overridden: --pgsql-host=localhost"))
+	})
+	It("multiple blocked args should fail validation", func() {
+		args := []string{
+			"--threads=4",
+			"--pgsql-host=localhost",  // This should be blocked
+			"--pgsql-password=secret", // This should also be blocked
+			"--table-size=1000",
+		}
+		Expect(validateSysbenchArgs(args)).To(MatchError(
+			"the following flags are managed automatically and cannot be overridden: --pgsql-host=localhost, --pgsql-password=secret"))
+	})
+})

--- a/internal/cmd/plugin/sysbench/cmd_test.go
+++ b/internal/cmd/plugin/sysbench/cmd_test.go
@@ -1,0 +1,142 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package sysbench
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("NewCmd", func() {
+	It("should create a cobra.Command with correct defaults", func() {
+		cmd := NewCmd()
+
+		Expect(cmd.Use).To(Equal("sysbench CLUSTER [-- SYSBENCH_COMMAND_ARGS...]"))
+		Expect(cmd.Short).To(Equal("Creates a sysbench job"))
+		Expect(cmd.Example).To(Equal(jobExample))
+
+		// Check each flag exists and has the right default
+		jobNameFlag := cmd.Flag("job-name")
+		Expect(jobNameFlag).ToNot(BeNil())
+		Expect(jobNameFlag.DefValue).To(Equal(""))
+
+		dbNameFlag := cmd.Flag("db-name")
+		Expect(dbNameFlag).ToNot(BeNil())
+		Expect(dbNameFlag.DefValue).To(Equal("app"))
+
+		imageFlag := cmd.Flag("sysbench-image")
+		Expect(imageFlag).ToNot(BeNil())
+		Expect(imageFlag.DefValue).To(Equal(defaultSysbenchImage))
+
+		dryRunFlag := cmd.Flag("dry-run")
+		Expect(dryRunFlag).ToNot(BeNil())
+		Expect(dryRunFlag.DefValue).To(Equal("false"))
+
+		nodeSelectorFlag := cmd.Flag("node-selector")
+		Expect(nodeSelectorFlag).ToNot(BeNil())
+		Expect(nodeSelectorFlag.DefValue).To(Equal("[]"))
+	})
+})
+
+var _ = Describe("buildJob", func() {
+	It("should use the sysbench image, not the cluster image", func() {
+		cluster := &apiv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-cluster",
+				Namespace: "default",
+			},
+		}
+
+		cmd := &sysbenchRun{
+			clusterName:   "test-cluster",
+			dbName:        "app",
+			sysbenchImage: "perconalab/sysbench:1.1",
+		}
+
+		job := cmd.buildJob(cluster)
+
+		Expect(job.Spec.Template.Spec.Containers[0].Image).To(Equal("perconalab/sysbench:1.1"))
+	})
+
+	It("should propagate ImagePullSecrets from the Cluster", func() {
+		cluster := &apiv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-cluster",
+				Namespace: "default",
+			},
+			Spec: apiv1.ClusterSpec{
+				ImagePullSecrets: []apiv1.LocalObjectReference{
+					{Name: "my-secret"},
+				},
+			},
+		}
+
+		cmd := &sysbenchRun{
+			clusterName:   "test-cluster",
+			dbName:        "app",
+			sysbenchImage: "perconalab/sysbench:1.1",
+		}
+
+		job := cmd.buildJob(cluster)
+
+		Expect(job.Spec.Template.Spec.ImagePullSecrets).To(ConsistOf(
+			corev1.LocalObjectReference{Name: "my-secret"},
+		))
+	})
+})
+
+var _ = Describe("buildArgs", func() {
+	It("should prepend connection args before user args", func() {
+		cmd := &sysbenchRun{
+			clusterName:         "my-cluster",
+			dbName:              "testdb",
+			sysbenchCommandArgs: []string{"oltp_read_write", "run"},
+		}
+
+		args := cmd.buildArgs()
+
+		Expect(args[0]).To(Equal("--db-driver=pgsql"))
+		Expect(args).To(ContainElement("--pgsql-db=testdb"))
+		Expect(args).To(ContainElement("oltp_read_write"))
+		Expect(args).To(ContainElement("run"))
+	})
+})
+
+var _ = Describe("getJobName", func() {
+	It("should return custom name when set", func() {
+		cmd := &sysbenchRun{
+			clusterName: "my-cluster",
+			jobName:     "my-custom-job",
+		}
+		Expect(cmd.getJobName()).To(Equal("my-custom-job"))
+	})
+
+	It("should generate a name when not set", func() {
+		cmd := &sysbenchRun{
+			clusterName: "my-cluster",
+		}
+		Expect(cmd.getJobName()).To(HavePrefix("my-cluster-sysbench-"))
+	})
+})

--- a/internal/cmd/plugin/sysbench/cmd_test.go
+++ b/internal/cmd/plugin/sysbench/cmd_test.go
@@ -6,7 +6,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -166,7 +166,8 @@ var _ = Describe("validateSysbenchArgs", func() {
 			"--pgsql-password=secret", // This should also be blocked
 			"--table-size=1000",
 		}
-		Expect(validateSysbenchArgs(args)).To(MatchError(
-			"the following flags are managed automatically and cannot be overridden: --pgsql-host=localhost, --pgsql-password=secret"))
+		expectedErr := "the following flags are managed automatically and cannot be overridden: " +
+			"--pgsql-host=localhost, --pgsql-password=secret"
+		Expect(validateSysbenchArgs(args)).To(MatchError(expectedErr))
 	})
 })

--- a/internal/cmd/plugin/sysbench/doc.go
+++ b/internal/cmd/plugin/sysbench/doc.go
@@ -6,7 +6,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,5 +18,4 @@ SPDX-License-Identifier: Apache-2.0
 */
 
 // Package sysbench implements the kubectl-cnpg sysbench sub-command
-
 package sysbench

--- a/internal/cmd/plugin/sysbench/doc.go
+++ b/internal/cmd/plugin/sysbench/doc.go
@@ -1,0 +1,22 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+// Package sysbench implements the kubectl-cnpg sysbench sub-command
+
+package sysbench

--- a/internal/cmd/plugin/sysbench/suite_test.go
+++ b/internal/cmd/plugin/sysbench/suite_test.go
@@ -1,0 +1,32 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package sysbench
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestSysbench(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Sysbench Suite")
+}

--- a/internal/cmd/plugin/sysbench/sysbench.go
+++ b/internal/cmd/plugin/sysbench/sysbench.go
@@ -17,8 +17,6 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 */
 
-// Package sysbench implements the kubectl-cnpg sysbench sub-command
-
 package sysbench
 
 import (
@@ -60,7 +58,7 @@ var jobExample = `
   kubectl-cnpg sysbench cluster-example -- oltp_read_write --tables=4 --table-size=10000 prepare
 
   # Run the benchmark with 4 threads for 30 seconds
-  kubectl-cnpg sysbench cluster-example -- oltp_read_write --tables=4 --table-size=10000 --time=30 --threads=4 --report-interval=1 run
+  kubectl-cnpg sysbench cluster-example -- oltp_read_write --tables=4 --table-size=10000 --time=30 --threads=4 run
 
   # Cleanup the sysbench tables after benchmarking
   kubectl-cnpg sysbench cluster-example -- oltp_read_write --tables=4 --table-size=10000 cleanup
@@ -134,14 +132,15 @@ func (cmd *sysbenchRun) getCluster(ctx context.Context) (*apiv1.Cluster, error) 
 }
 
 func (cmd *sysbenchRun) buildArgs() []string {
-	connArgs := []string{
+	connArgs := make([]string, 0, 6+len(cmd.sysbenchCommandArgs))
+	connArgs = append(connArgs,
 		"--db-driver=pgsql",
 		fmt.Sprintf("--pgsql-host=%s%s", cmd.clusterName, apiv1.ServiceReadWriteSuffix),
 		"--pgsql-port=5432",
 		fmt.Sprintf("--pgsql-db=%s", cmd.dbName),
 		"--pgsql-user=$(PGUSER)",         // resolved from env var
 		"--pgsql-password=$(PGPASSWORD)", // resolved from env var
-	}
+	)
 	return append(connArgs, cmd.sysbenchCommandArgs...)
 }
 

--- a/internal/cmd/plugin/sysbench/sysbench.go
+++ b/internal/cmd/plugin/sysbench/sysbench.go
@@ -66,8 +66,41 @@ var jobExample = `
   kubectl-cnpg sysbench cluster-example -- oltp_read_write --tables=4 --table-size=10000 cleanup
 `
 
+var blockedSysbenchArgs = []string{
+	"--db-driver",
+	"--pgsql-host",
+	"--pgsql-port",
+	"--pgsql-db",
+	"--pgsql-user",
+	"--pgsql-password",
+}
+
+func validateSysbenchArgs(args []string) error {
+	var blockedFound []string
+
+	for _, arg := range args {
+		for _, blocked := range blockedSysbenchArgs {
+			if strings.HasPrefix(arg, blocked) {
+				blockedFound = append(blockedFound, arg)
+				break // Don't check other blocked flags for this arg
+			}
+		}
+	}
+
+	if len(blockedFound) > 0 {
+		return fmt.Errorf("the following flags are managed automatically and cannot be overridden: %s",
+			strings.Join(blockedFound, ", "))
+	}
+
+	return nil
+}
+
 // Method executes the sysbench command, creating a job with the specified parameters and printing the result.
 func (cmd *sysbenchRun) execute(ctx context.Context) error {
+	if err := validateSysbenchArgs(cmd.sysbenchCommandArgs); err != nil {
+		return err
+	}
+
 	cluster, err := cmd.getCluster(ctx)
 	if err != nil {
 		return err

--- a/internal/cmd/plugin/sysbench/sysbench.go
+++ b/internal/cmd/plugin/sysbench/sysbench.go
@@ -1,0 +1,229 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+// Package sysbench implements the kubectl-cnpg sysbench sub-command
+
+package sysbench
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/rand"
+	client "sigs.k8s.io/controller-runtime/pkg/client"
+
+	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/plugin"
+)
+
+type sysbenchRun struct {
+	clusterName             string
+	jobName                 string
+	dbName                  string
+	sysbenchImage           string
+	sysbenchCommandArgs     []string
+	nodeSelector            []string
+	dryRun                  bool
+	ttlSecondsAfterFinished int32
+}
+
+const (
+	sysBenchKeyword = "sysbench"
+)
+
+var jobExample = `
+  # Dry-run with default values
+  kubectl-cnpg sysbench cluster-example --dry-run
+
+  # Initialize the database with oltp_read_write workload with 4 tables and 10000 rows per table
+  kubectl-cnpg sysbench cluster-example -- oltp_read_write --tables=4 --table-size=10000 prepare
+
+  # Run the benchmark with 4 threads for 30 seconds
+  kubectl-cnpg sysbench cluster-example -- oltp_read_write --tables=4 --table-size=10000 --time=30 --threads=4 --report-interval=1 run
+
+  # Cleanup the sysbench tables after benchmarking
+  kubectl-cnpg sysbench cluster-example -- oltp_read_write --tables=4 --table-size=10000 cleanup
+`
+
+// Method executes the sysbench command, creating a job with the specified parameters and printing the result.
+func (cmd *sysbenchRun) execute(ctx context.Context) error {
+	cluster, err := cmd.getCluster(ctx)
+	if err != nil {
+		return err
+	}
+
+	job := cmd.buildJob(cluster)
+
+	if cmd.dryRun {
+		return plugin.Print(job, plugin.OutputFormatYAML, os.Stdout)
+	}
+
+	if err := plugin.Client.Create(ctx, job); err != nil {
+		return err
+	}
+
+	fmt.Printf("job/%v created\n", job.Name)
+	return nil
+}
+
+func (cmd *sysbenchRun) getCluster(ctx context.Context) (*apiv1.Cluster, error) {
+	var cluster apiv1.Cluster
+	err := plugin.Client.Get(
+		ctx,
+		client.ObjectKey{Namespace: plugin.Namespace, Name: cmd.clusterName},
+		&cluster,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &cluster, nil
+}
+
+func (cmd *sysbenchRun) buildArgs() []string {
+	connArgs := []string{
+		"--db-driver=pgsql",
+		fmt.Sprintf("--pgsql-host=%s%s", cmd.clusterName, apiv1.ServiceReadWriteSuffix),
+		"--pgsql-port=5432",
+		fmt.Sprintf("--pgsql-db=%s", cmd.dbName),
+		"--pgsql-user=$(PGUSER)",         // resolved from env var
+		"--pgsql-password=$(PGPASSWORD)", // resolved from env var
+	}
+	return append(connArgs, cmd.sysbenchCommandArgs...)
+}
+
+func (cmd *sysbenchRun) buildJob(cluster *apiv1.Cluster) *batchv1.Job {
+	labels := map[string]string{
+		"sysbench": cluster.Name,
+	}
+
+	result := &batchv1.Job{
+		// To ensure we have manifest with Kind and API in --dry-run
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "batch/v1",
+			Kind:       "Job",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cmd.getJobName(),
+			Namespace: cluster.Namespace,
+			Labels:    labels,
+		},
+		Spec: batchv1.JobSpec{
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: labels,
+				},
+				Spec: corev1.PodSpec{
+					RestartPolicy: corev1.RestartPolicyNever,
+					SchedulerName: cluster.Spec.SchedulerName,
+					Containers: []corev1.Container{
+						{
+							Name:            "sysbench",
+							Image:           cmd.sysbenchImage,
+							ImagePullPolicy: corev1.PullAlways,
+							Env:             cmd.buildEnvVariables(),
+							Command:         []string{sysBenchKeyword},
+							Args:            cmd.buildArgs(),
+						},
+					},
+					NodeSelector:     cmd.buildNodeSelector(),
+					ImagePullSecrets: buildImagePullSecrets(cluster),
+				},
+			},
+		},
+	}
+
+	if cmd.ttlSecondsAfterFinished != 0 {
+		result.Spec.TTLSecondsAfterFinished = &cmd.ttlSecondsAfterFinished
+	}
+
+	return result
+}
+
+func (cmd *sysbenchRun) getJobName() string {
+	if cmd.jobName != "" {
+		return cmd.jobName
+	}
+
+	return fmt.Sprintf("%v-sysbench-%v", cmd.clusterName, rand.Intn(100000))
+}
+
+func (cmd *sysbenchRun) buildNodeSelector() map[string]string {
+	selectorLength := len(cmd.nodeSelector)
+	if selectorLength < 1 {
+		return nil
+	}
+
+	mappedSelectors := make(map[string]string, selectorLength)
+	for _, v := range cmd.nodeSelector {
+		selector := strings.Split(v, "=")
+		if len(selector) <= 1 {
+			continue
+		}
+		mappedSelectors[selector[0]] = selector[1]
+	}
+	return mappedSelectors
+}
+
+func buildImagePullSecrets(cluster *apiv1.Cluster) []corev1.LocalObjectReference {
+	if len(cluster.Spec.ImagePullSecrets) == 0 {
+		return nil
+	}
+
+	secrets := make([]corev1.LocalObjectReference, len(cluster.Spec.ImagePullSecrets))
+	for i, s := range cluster.Spec.ImagePullSecrets {
+		secrets[i] = corev1.LocalObjectReference{Name: s.Name}
+	}
+	return secrets
+}
+
+func (cmd *sysbenchRun) buildEnvVariables() []corev1.EnvVar {
+	appSecretName := fmt.Sprintf("%v-%v", cmd.clusterName, "app")
+
+	envVar := []corev1.EnvVar{
+		{
+			Name: "PGUSER",
+			ValueFrom: &corev1.EnvVarSource{
+				SecretKeyRef: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: appSecretName,
+					},
+					Key: "username",
+				},
+			},
+		},
+		{
+			Name: "PGPASSWORD",
+			ValueFrom: &corev1.EnvVarSource{
+				SecretKeyRef: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: appSecretName,
+					},
+					Key: "password",
+				},
+			},
+		},
+	}
+
+	return envVar
+}


### PR DESCRIPTION
 ## Summary
- Add `kubectl cnpg sysbench` plugin command for running sysbench OLTP benchmarks against CNPG clusters
- Follow the same pattern as the existing pgbench plugin, creating a Kubernetes Job with connection details
  automatically injected from cluster Secrets
- Support `--dry-run`, `--job-name`, `--db-name`, `--sysbench-image`, `--ttl`, `--node-selector` flags
- Default image: `perconalab/sysbench:1.1`, overridable by the user
- Add documentation in benchmarking.md

Closes: #10350


 ## Notes

  
 - The default image (`perconalab/sysbench:1.1`) is amd64 only; a follow-up task will create a multi-arch image under the CNPG org