### PR TITLE
Fix WAL data loss on instance hibernation/shutdown (#10341)

### DIFF
--- a/internal/cmd/manager/instance/run/lifecycle/lifecycle.go
+++ b/internal/cmd/manager/instance/run/lifecycle/lifecycle.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/concurrency"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres/archiver"
 )
 
 // PostgresLifecycle implements the manager.Runnable interface for a postgres.Instance
@@ -132,6 +133,9 @@ func (i *PostgresLifecycle) Start(ctx context.Context) error {
 				if err := i.instance.TryShuttingDownSmartFast(ctx); err != nil {
 					contextLogger.Error(err, "error shutting down instance, proceeding")
 				}
+				if err := archiver.ArchiveAllReadyWALs(ctx, i.instance.GetClusterOrDefault(), i.instance.PgData); err != nil {
+					contextLogger.Error(err, "error archiving WALs before exiting, proceeding")
+				}
 				return nil
 
 			case sig := <-signals:
@@ -145,6 +149,9 @@ func (i *PostgresLifecycle) Start(ctx context.Context) error {
 				)
 				if err := i.instance.TryShuttingDownSmartFast(ctx); err != nil {
 					contextLogger.Error(err, "error while shutting down instance, proceeding")
+				}
+				if err := archiver.ArchiveAllReadyWALs(ctx, i.instance.GetClusterOrDefault(), i.instance.PgData); err != nil {
+					contextLogger.Error(err, "error archiving WALs before exiting, proceeding")
 				}
 				return nil
 


### PR DESCRIPTION
While looking at the WAL archiving logic, I noticed that when a CNPG instance shuts down normally, any final WAL segments sitting in .ready state never get pushed to S3. The archiver only runs during switchover/demotion, not during regular shutdown. This is a problem especially during cluster hibernation — you lose the last batch of transactions.

The fix is straightforward: call ArchiveAllReadyWALs() after the PostgreSQL shutdown completes, same way we do for switchover. Ensures those final segments don't sit orphaned on local storage.

Fixes #10341