### PR TITLE
chore: add missing community meetings links

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,10 +100,7 @@ CloudNativePG can be extended via the [CNPG-I plugin interface](https://github.c
 - [Twitter](https://twitter.com/CloudNativePg)
 - [Mastodon](https://mastodon.social/@CloudNativePG)
 - [Bluesky](https://bsky.app/profile/cloudnativepg.bsky.social)
-
-## Community Meetings
-
-Everyone is welcome! No invitation is needed. More information on the [main GitHub project page](https://github.com/cloudnative-pg/#cloudnativepg-community-meetings)
+- [Community Meetings](https://github.com/cloudnative-pg/#cloudnativepg-community-meetings) — everyone is welcome, no invitation needed.
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,10 @@ CloudNativePG can be extended via the [CNPG-I plugin interface](https://github.c
 - [Mastodon](https://mastodon.social/@CloudNativePG)
 - [Bluesky](https://bsky.app/profile/cloudnativepg.bsky.social)
 
+## Community Meetings
+
+Everyone is welcome! No invitation is needed. More information on the [main GitHub project page](https://github.com/cloudnative-pg/#cloudnativepg-community-meetings)
+
 ## Resources
 
 - [Roadmap](ROADMAP.md)

--- a/README.md
+++ b/README.md
@@ -94,13 +94,14 @@ CloudNativePG can be extended via the [CNPG-I plugin interface](https://github.c
 
 ## Communications
 
-- [Github Discussions](https://github.com/cloudnative-pg/cloudnative-pg/discussions)
-- [Slack](https://cloud-native.slack.com/archives/C08MAUJ7NPM)
-  (join the [CNCF Slack Workspace](https://communityinviter.com/apps/cloud-native/cncf)).
-- [Twitter](https://twitter.com/CloudNativePg)
-- [Mastodon](https://mastodon.social/@CloudNativePG)
-- [Bluesky](https://bsky.app/profile/cloudnativepg.bsky.social)
-- [Community Meetings](https://github.com/cloudnative-pg/#cloudnativepg-community-meetings) — everyone is welcome, no invitation needed.
+Please refer to the [Getting in touch](https://github.com/cloudnative-pg#getting-in-touch)
+section on the GitHub organization page.
+
+## Community Meetings
+
+Everyone is welcome, no invitation needed. For details, see the
+[Community Meetings](https://github.com/cloudnative-pg#cloudnativepg-community-meetings)
+section on the GitHub organization page.
 
 ## Resources
 


### PR DESCRIPTION
This will help to clean up the CLOMonitor alert about community meetings