### PR TITLE
ci(build): skip prime build when main build fails

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -472,9 +472,7 @@ jobs:
       # upgrade test
         name: Build binary for upgrade test
         uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7
-        if: |
-          always() && !cancelled() &&
-          needs.evaluate_options.outputs.test_level == '4'
+        if: needs.evaluate_options.outputs.test_level == '4'
         with:
           distribution: goreleaser
           version: v2
@@ -495,9 +493,7 @@ jobs:
         name: Build and push image for upgrade test
         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
         id: build-prime
-        if: |
-          always() && !cancelled() &&
-          needs.evaluate_options.outputs.test_level == '4'
+        if: needs.evaluate_options.outputs.test_level == '4'
         with:
           platforms: ${{ env.PLATFORMS }}
           context: .


### PR DESCRIPTION
Remove `always() && !cancelled()` from the prime build steps so they only run when prior steps, including the main build, succeed.

The prime image build steps used `always() && !cancelled()` in their conditions, causing them to run even when the main container build failed. This resulted in an invalid docker tag (`-prime`) because the `CONTROLLER_IMG` env var was never set by the skipped main build.