### PR TITLE
docs(plugin): improve `psql` command instructions

### DIFF
--- a/docs/src/kubectl-plugin.md
+++ b/docs/src/kubectl-plugin.md
@@ -1104,8 +1104,12 @@ postgres=# select pg_is_in_recovery();
 postgres=# \q
 ```
 
-By default, the `postgres` database will be used. You can specify the database
-you want to connect to right after the `--` delimiter. For example:
+This command will start `kubectl exec`, and the `kubectl` executable must be
+reachable in your `PATH` variable to correctly work.
+
+By default, the `postgres` database will be used. You can pass additional
+arguments to `psql` after the `--` delimiter. For example, to connect to a
+specific database:
 
 ```console
 $ kubectl cnpg psql cluster-example -- app

--- a/docs/src/kubectl-plugin.md
+++ b/docs/src/kubectl-plugin.md
@@ -1107,8 +1107,8 @@ postgres=# \q
 This command will start `kubectl exec`, and the `kubectl` executable must be
 reachable in your `PATH` variable to correctly work.
 
-By default, the `postgres` database will be used. You can pass additional
-arguments to `psql` after the `--` delimiter. For example, to connect to a
+By default, the `postgres` database will be used. Any option supported by
+`psql` can be passed after the `--` delimiter. For example, to connect to a
 specific database:
 
 ```console

--- a/docs/src/kubectl-plugin.md
+++ b/docs/src/kubectl-plugin.md
@@ -1072,8 +1072,8 @@ it from the actual pod. This means that you will be using the `postgres` user an
 to the `postgres` database.
 
 :::info[Important]
-    As you will be connecting as `postgres` user, in production environments this
-    method should be used with extreme care, by authorized personnel only.
+As you will be connecting as `postgres` user, in production environments this
+method should be used with extreme care, by authorized personnel only.
 :::
 
 ```console
@@ -1108,19 +1108,19 @@ By default, the `postgres` database will be used. You can specify the database
 you want to connect right after the `--` delimiter. For example:
 
 ```console
-$ kubectl cnpg psql cluster-example -- app                               
+$ kubectl cnpg psql cluster-example -- app
 
 psql (18.3 (Debian 18.3-1.pgdg110+1))
 Type "help" for help.
 
-app=# 
+app=#
 ```
 
 Also, you can directly write the request you want to execute with the psql option `-c ̀.
 
 ```console
 $ kubectl cnpg psql cluster-example -- -c "SELECT pg_is_in_recovery();"
- pg_is_in_recovery 
+ pg_is_in_recovery
 -------------------
  f
 (1 row)

--- a/docs/src/kubectl-plugin.md
+++ b/docs/src/kubectl-plugin.md
@@ -1119,7 +1119,7 @@ app=#
 Also, you can directly write the request you want to execute with the psql option `-c ̀.
 
 ```console
-$ kubectl cnpg psql cluster-example -- -c "select pg_is_in_recovery();"
+$ kubectl cnpg psql cluster-example -- -c "SELECT pg_is_in_recovery();"
  pg_is_in_recovery 
 -------------------
  f

--- a/docs/src/kubectl-plugin.md
+++ b/docs/src/kubectl-plugin.md
@@ -1071,9 +1071,6 @@ process (psql) connected to an existing Postgres cluster, as if you were running
 it from the actual pod. This means that you will be using the `postgres` user and connect
 to the `postgres` database.
 
-This command will start `kubectl exec`, and the `kubectl` executable must be
-reachable in your `PATH` variable to correctly work.
-
 :::info[Important]
     As you will be connecting as `postgres` user, in production environments this
     method should be used with extreme care, by authorized personnel only.

--- a/docs/src/kubectl-plugin.md
+++ b/docs/src/kubectl-plugin.md
@@ -1068,7 +1068,7 @@ the configuration settings.
 
 The `kubectl cnpg psql CLUSTER` command starts a new PostgreSQL interactive front-end
 process (psql) connected to an existing Postgres cluster, as if you were running
-it from the actual pod. This means that you will be using the `postgres` user and connect
+it from the actual pod. This means that you will be using the `postgres` user and connecting
 to the `postgres` database.
 
 :::info[Important]
@@ -1105,7 +1105,7 @@ postgres=# \q
 ```
 
 By default, the `postgres` database will be used. You can specify the database
-you want to connect right after the `--` delimiter. For example:
+you want to connect to right after the `--` delimiter. For example:
 
 ```console
 $ kubectl cnpg psql cluster-example -- app

--- a/docs/src/kubectl-plugin.md
+++ b/docs/src/kubectl-plugin.md
@@ -1068,7 +1068,11 @@ the configuration settings.
 
 The `kubectl cnpg psql CLUSTER` command starts a new PostgreSQL interactive front-end
 process (psql) connected to an existing Postgres cluster, as if you were running
-it from the actual pod. This means that you will be using the `postgres` user.
+it from the actual pod. This means that you will be using the `postgres` user and connect
+to the `postgres` database.
+
+This command will start `kubectl exec`, and the `kubectl` executable must be
+reachable in your `PATH` variable to correctly work.
 
 :::info[Important]
     As you will be connecting as `postgres` user, in production environments this
@@ -1103,8 +1107,27 @@ postgres=# select pg_is_in_recovery();
 postgres=# \q
 ```
 
-This command will start `kubectl exec`, and the `kubectl` executable must be
-reachable in your `PATH` variable to correctly work.
+By default, the `postgres` database will be used. You can specify the database
+you want to connect right after the `--` delimiter. For example:
+
+```console
+$ kubectl cnpg psql cluster-example -- app                               
+
+psql (18.3 (Debian 18.3-1.pgdg110+1))
+Type "help" for help.
+
+app=# 
+```
+
+Also, you can directly write the request you want to execute with the psql option `-c ̀.
+
+```console
+$ kubectl cnpg psql cluster-example -- -c "select pg_is_in_recovery();"
+ pg_is_in_recovery 
+-------------------
+ f
+(1 row)
+```
 
 ### Snapshotting a Postgres cluster
 

--- a/docs/src/kubectl-plugin.md
+++ b/docs/src/kubectl-plugin.md
@@ -1116,7 +1116,7 @@ Type "help" for help.
 app=#
 ```
 
-Also, you can directly write the request you want to execute with the psql option `-c ̀.
+Also, you can directly execute a query with the psql option `-c`.
 
 ```console
 $ kubectl cnpg psql cluster-example -- -c "SELECT pg_is_in_recovery();"


### PR DESCRIPTION
Integrate the `psql` command documentation of the `cnpg` plugin with a few examples.

Closes #10363 