### PR TITLE
fix: prevent replicas from restoring old-timeline WAL segments

### DIFF
--- a/internal/cmd/manager/walrestore/cmd.go
+++ b/internal/cmd/manager/walrestore/cmd.go
@@ -128,6 +128,12 @@ func run(ctx context.Context, pgData string, podName string, args []string) erro
 		return err
 	}
 
+	// Validate WAL segment timeline to prevent replicas from downloading
+	// old-timeline WAL segments from the archive after switchover/failover
+	if err := validateWALSegmentTimeline(ctx, walName, cluster, podName); err != nil {
+		return err
+	}
+
 	walFound, err := restoreWALViaPlugins(ctx, cluster, walName, pgData, destinationPath)
 	if err != nil {
 		// With the current implementation, this happens when both of the following conditions are met:
@@ -479,6 +485,53 @@ func validateTimelineHistoryFile(ctx context.Context, walName string, cluster *a
 		"walName", walName,
 		"fileTimeline", fileTimeline,
 		"clusterTimeline", clusterTimeline)
+
+	return nil
+}
+
+// validateWALSegmentTimeline prevents replicas from downloading old-timeline
+// WAL segments from the archive after a switchover or failover.
+// Skipped during bootstrap/recovery (CurrentPrimary not yet set) to allow PITR.
+func validateWALSegmentTimeline(ctx context.Context, walName string, cluster *apiv1.Cluster, podName string) error {
+	contextLog := log.FromContext(ctx)
+
+	if !postgres.IsWALFile(walName) {
+		return nil
+	}
+
+	if cluster.Status.CurrentPrimary == "" {
+		return nil
+	}
+
+	if cluster.Status.CurrentPrimary == podName || cluster.Status.TargetPrimary == podName {
+		return nil
+	}
+
+	segment, err := postgres.SegmentFromName(walName)
+	if err != nil {
+		contextLog.Warning("Could not parse WAL segment name",
+			"walName", walName,
+			"error", err)
+		return nil
+	}
+
+	walTimeline := int(segment.Tli)
+	clusterTimeline := cluster.Status.TimelineID
+
+	if clusterTimeline == 0 {
+		return nil
+	}
+
+	if walTimeline < clusterTimeline {
+		contextLog.Warning("Refusing to restore old-timeline WAL segment for replica",
+			"walName", walName,
+			"walTimeline", walTimeline,
+			"clusterTimeline", clusterTimeline,
+			"podName", podName,
+			"currentPrimary", cluster.Status.CurrentPrimary)
+
+		return barmanRestorer.ErrWALNotFound
+	}
 
 	return nil
 }

--- a/internal/cmd/manager/walrestore/cmd.go
+++ b/internal/cmd/manager/walrestore/cmd.go
@@ -507,11 +507,20 @@ func validateWALSegmentTimeline(ctx context.Context, walName string, cluster *ap
 		return nil
 	}
 
+	// During an active failover TimelineID still reports the old timeline,
+	// so the comparison below is unsafe; refuse outright.
+	if cluster.Status.TargetPrimary == apiv1.PendingFailoverMarker {
+		contextLog.Info("Refusing to restore WAL segment during pending failover",
+			"walName", walName,
+			"podName", podName,
+			"currentPrimary", cluster.Status.CurrentPrimary)
+		return barmanRestorer.ErrWALNotFound
+	}
+
 	segment, err := postgres.SegmentFromName(walName)
 	if err != nil {
-		contextLog.Warning("Could not parse WAL segment name",
-			"walName", walName,
-			"error", err)
+		contextLog.Error(err, "Could not parse WAL segment name despite passing IsWALFile",
+			"walName", walName)
 		return nil
 	}
 

--- a/internal/cmd/manager/walrestore/cmd_test.go
+++ b/internal/cmd/manager/walrestore/cmd_test.go
@@ -225,3 +225,102 @@ var _ = Describe("validateTimelineHistoryFile", func() {
 		Expect(err).To(Equal(barmanRestorer.ErrWALNotFound))
 	})
 })
+
+var _ = Describe("validateWALSegmentTimeline", func() {
+	It("should allow non-WAL files to pass through", func(ctx SpecContext) {
+		cluster := &apiv1.Cluster{
+			Status: apiv1.ClusterStatus{
+				CurrentPrimary: "primary-pod",
+				TimelineID:     3,
+			},
+		}
+
+		err := validateWALSegmentTimeline(ctx, "00000001.history", cluster, "replica-pod")
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("should allow any WAL during bootstrap when CurrentPrimary is empty", func(ctx SpecContext) {
+		cluster := &apiv1.Cluster{
+			Status: apiv1.ClusterStatus{
+				CurrentPrimary: "",
+				TimelineID:     0,
+			},
+		}
+
+		err := validateWALSegmentTimeline(ctx, "000000010000000000000048", cluster, "replica-pod")
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("should allow primary to download any timeline WAL", func(ctx SpecContext) {
+		cluster := &apiv1.Cluster{
+			Status: apiv1.ClusterStatus{
+				CurrentPrimary: "primary-pod",
+				TimelineID:     3,
+			},
+		}
+
+		err := validateWALSegmentTimeline(ctx, "000000010000000000000048", cluster, "primary-pod")
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("should allow target primary to download any timeline WAL", func(ctx SpecContext) {
+		cluster := &apiv1.Cluster{
+			Status: apiv1.ClusterStatus{
+				CurrentPrimary: "old-primary",
+				TargetPrimary:  "new-primary",
+				TimelineID:     3,
+			},
+		}
+
+		err := validateWALSegmentTimeline(ctx, "000000010000000000000048", cluster, "new-primary")
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("should allow replica to download current timeline WAL", func(ctx SpecContext) {
+		cluster := &apiv1.Cluster{
+			Status: apiv1.ClusterStatus{
+				CurrentPrimary: "primary-pod",
+				TimelineID:     3,
+			},
+		}
+
+		err := validateWALSegmentTimeline(ctx, "000000030000000000000048", cluster, "replica-pod")
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("should reject old-timeline WAL for replica", func(ctx SpecContext) {
+		cluster := &apiv1.Cluster{
+			Status: apiv1.ClusterStatus{
+				CurrentPrimary: "primary-pod",
+				TimelineID:     3,
+			},
+		}
+
+		err := validateWALSegmentTimeline(ctx, "000000010000000000000048", cluster, "replica-pod")
+		Expect(err).To(Equal(barmanRestorer.ErrWALNotFound))
+	})
+
+	It("should reject old-timeline WAL with timeline 2 when cluster is on timeline 3", func(ctx SpecContext) {
+		cluster := &apiv1.Cluster{
+			Status: apiv1.ClusterStatus{
+				CurrentPrimary: "primary-pod",
+				TimelineID:     3,
+			},
+		}
+
+		err := validateWALSegmentTimeline(ctx, "000000020000000000000010", cluster, "replica-pod")
+		Expect(err).To(Equal(barmanRestorer.ErrWALNotFound))
+	})
+
+	It("should allow any WAL when cluster timeline is not yet known", func(ctx SpecContext) {
+		cluster := &apiv1.Cluster{
+			Status: apiv1.ClusterStatus{
+				CurrentPrimary: "primary-pod",
+				TimelineID:     0,
+			},
+		}
+
+		err := validateWALSegmentTimeline(ctx, "000000010000000000000048", cluster, "replica-pod")
+		Expect(err).ToNot(HaveOccurred())
+	})
+})

--- a/internal/cmd/manager/walrestore/cmd_test.go
+++ b/internal/cmd/manager/walrestore/cmd_test.go
@@ -323,4 +323,17 @@ var _ = Describe("validateWALSegmentTimeline", func() {
 		err := validateWALSegmentTimeline(ctx, "000000010000000000000048", cluster, "replica-pod")
 		Expect(err).ToNot(HaveOccurred())
 	})
+
+	It("should reject WAL when failover is pending (TargetPrimary is the marker)", func(ctx SpecContext) {
+		cluster := &apiv1.Cluster{
+			Status: apiv1.ClusterStatus{
+				CurrentPrimary: "old-primary",
+				TargetPrimary:  apiv1.PendingFailoverMarker,
+				TimelineID:     3,
+			},
+		}
+
+		err := validateWALSegmentTimeline(ctx, "000000030000000000000048", cluster, "replica-pod")
+		Expect(err).To(Equal(barmanRestorer.ErrWALNotFound))
+	})
 })


### PR DESCRIPTION
After a switchover or failover, the WAL archive (S3/object storage) still contains segments from previous timelines. When a replica restarts with existing PVC data (e.g. after a rolling restart triggered by parameter change), its `restore_command` can fetch old-timeline WAL segments from the archive before streaming replication reconnects to the new primary.

This causes the replica's timeline history to diverge from the current primary, resulting in either:

**CrashLoopBackOff:**
```
LOG: restored log file "00000002.history" from archive
LOG: restored log file "00000003.history" from archive
LOG: restored log file "00000001000000000000004B" from archive   ← timeline 1!
LOG: restored log file "000000010000000000000048" from archive   ← timeline 1!
LOG: entering standby mode
FATAL: requested timeline 3 is not a child of this server's history
LOG: startup process (PID 34) exited with exit code 1
LOG: database system is shut down
```

**Stuck in "Standby (file based)" mode:**
```
LOG: restored log file "0000000100000032000000E8" from archive   ← timeline 1!
LOG: invalid record length at 32/E80000A0: expected at least 24, got 0
LOG: fetching timeline history file for timeline 2 from primary server
FATAL: could not receive timeline history file from the primary server: ERROR:
  could not open file "pg_wal/00000002.history": No such file or directory
LOG: waiting for WAL to become available at 32/E80000B8
```

### Root cause

`validateTimelineHistoryFile()` in `walrestore/cmd.go` validates `.history` files but does not check regular WAL segments. A replica can successfully download `000000010000000000000048` (timeline 1) from the archive when the primary is already on timeline 3.

### Fix

Added `validateWALSegmentTimeline()` which rejects WAL segments whose timeline is older than the cluster's current timeline, for replica instances in established clusters. This forces PostgreSQL to fall back to streaming replication from the current primary instead of consuming stale WAL from the archive.

The check is skipped when `CurrentPrimary` is not set (during bootstrap or PITR recovery) to allow fetching WAL from any timeline.

### Reproduction

Minimal reproducer using kind + MinIO: [reproduce.sh](https://gist.github.com/IgorOhrimenko/c61fdd5d7de8df38a451d3b17585ab30)

1. Create a 3-instance cluster with synchronous replication and WAL archiving to MinIO
2. Write data, take backup, write more data
3. Change `shared_buffers` to trigger a rolling restart with switchover
4. Replica restarts with existing PVC, `restore_command` fetches old-timeline WAL from MinIO
5. Replica crashes or gets stuck in file-based mode

In the provided test environment (kind, single-node, local MinIO, synchronous replication), the bug reproduces consistently. In multi-node production clusters the issue is intermittent, depending on the timing between switchover completion and replica reconnection.

**Without the fix:** replica enters CrashLoopBackOff or Standby (file based).
**With the fix:** old WAL is rejected with warning log, replica uses streaming replication:
```
WARNING: Refusing to restore old-timeline WAL segment for replica
  walName=000000010000000000000048 walTimeline=1 clusterTimeline=3
```

### Testing

- Unit tests added for `validateWALSegmentTimeline` covering all branches
- Verified recovery from S3 backup works correctly (PITR not broken)
- Verified rolling restarts with switchover work without file-based or CrashLoop

Closes #4990
Related: #4188, #3344