### PR TITLE
ci(workflows): add release-1.29 branch support, remove EOL 1.27

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -11,8 +11,8 @@
   baseBranchPatterns: [
     'main',
     'release-1.25',
-    'release-1.27',
     'release-1.28',
+    'release-1.29',
   ],
   ignorePaths: [
     'docs/**',

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -33,8 +33,8 @@ jobs:
           labels: |
             backport-requested :arrow_backward:
             release-1.25
-            release-1.27
             release-1.28
+            release-1.29
       -
         name: Create comment
         uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5
@@ -57,8 +57,8 @@ jobs:
           labels: |
             backport-requested :arrow_backward:
             release-1.25
-            release-1.27
             release-1.28
+            release-1.29
 
   ## backport pull request in condition when pr contains 'backport-requested' label and contains target branches labels
   back-porting-pr:
@@ -74,7 +74,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: [release-1.25, release-1.27, release-1.28]
+        branch: [release-1.25, release-1.28, release-1.29]
     env:
       PR: ${{ github.event.pull_request.number }}
       BRANCH: ${{ matrix.branch }}

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -79,7 +79,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: [release-1.25, release-1.27, release-1.28]
+        branch: [release-1.25, release-1.28, release-1.29]
     env:
       BRANCH: ${{ matrix.branch }}
     steps:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -59,7 +59,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: [release-1.25, release-1.27, release-1.28]
+        branch: [release-1.25, release-1.28, release-1.29]
     env:
       BRANCH: ${{ matrix.branch }}
     steps:


### PR DESCRIPTION
Update backport, CI, CD workflows and Renovate config to support the new release-1.29 branch and drop end-of-life release-1.27.