### PR TITLE
  chore(hack): add `-o` flag to deploy published operator versions and snapshots

### DIFF
--- a/contribute/development_environment/README.md
+++ b/contribute/development_environment/README.md
@@ -188,6 +188,17 @@ This will build the operator based on the `main` branch content, create a
 `kind` cluster in your workstation with a container registry that provides the
 operator image that you just built.
 
+Alternatively, you can deploy a published release instead of building from
+sources by using the `-o` flag:
+
+```shell
+# Deploy the latest published operator
+./hack/setup-cluster.sh -o main create deploy
+
+# Deploy a specific release
+./hack/setup-cluster.sh -o 1.28.1 create deploy
+```
+
 *Note:* For a list of options, run `./hack/setup-cluster.sh`.
 
 > **NOTE:** In case of errors, make sure that you have the latest versions of the Go

--- a/contribute/development_environment/README.md
+++ b/contribute/development_environment/README.md
@@ -219,7 +219,7 @@ kubectl get deploy -n cnpg-system cnpg-controller-manager
 Now that your system has been validated, you can tear down the local cluster with:
 
 ```shell
-./hack/setup-cluster.sh destroy
+./hack/setup-cluster.sh teardown
 ```
 
 Congratulations, you have a suitable development environment. You are now able

--- a/contribute/development_environment/README.md
+++ b/contribute/development_environment/README.md
@@ -196,7 +196,7 @@ sources by using the `-o` flag:
 ./hack/setup-cluster.sh -s source create deploy
 
 # Deploy a specific release
-./hack/setup-cluster.sh -o 1.28.1 create deploy
+./hack/setup-cluster.sh -s 1.28.1 create deploy
 ```
 
 *Note:* For a list of options, run `./hack/setup-cluster.sh`.

--- a/contribute/development_environment/README.md
+++ b/contribute/development_environment/README.md
@@ -188,15 +188,18 @@ This will build the operator based on the `main` branch content, create a
 `kind` cluster in your workstation with a container registry that provides the
 operator image that you just built.
 
-Alternatively, you can deploy a published release instead of building from
-sources by using the `-o` flag:
+Alternatively, you can deploy a published release or development snapshot
+instead of building from sources by using the `-o` flag:
 
 ```shell
-# Deploy the latest built operator from source
-./hack/setup-cluster.sh -s source create deploy
+# Deploy a specific published release
+./hack/setup-cluster.sh -o 1.28.1 create deploy
 
-# Deploy a specific release
-./hack/setup-cluster.sh -s 1.28.1 create deploy
+# Deploy the latest snapshot from the main branch
+./hack/setup-cluster.sh -o main create deploy
+
+# Deploy the latest snapshot for a release branch
+./hack/setup-cluster.sh -o release-1.28 create deploy
 ```
 
 *Note:* For a list of options, run `./hack/setup-cluster.sh`.

--- a/contribute/development_environment/README.md
+++ b/contribute/development_environment/README.md
@@ -206,7 +206,7 @@ Branch snapshots are pulled from the
 [`cloudnative-pg/artifacts`](https://github.com/cloudnative-pg/artifacts)
 repository.
 
-*Note:* For a list of options, run `./hack/setup-cluster.sh`.
+> **Note:** For a list of options, run `./hack/setup-cluster.sh`.
 
 > **NOTE:** In case of errors, make sure that you have the latest versions of the Go
 > binaries in your system. For this reason, from time to time, we recommend

--- a/contribute/development_environment/README.md
+++ b/contribute/development_environment/README.md
@@ -192,8 +192,8 @@ Alternatively, you can deploy a published release instead of building from
 sources by using the `-o` flag:
 
 ```shell
-# Deploy the latest published operator
-./hack/setup-cluster.sh -o main create deploy
+# Deploy the latest built operator from source
+./hack/setup-cluster.sh -s source create deploy
 
 # Deploy a specific release
 ./hack/setup-cluster.sh -o 1.28.1 create deploy

--- a/contribute/development_environment/README.md
+++ b/contribute/development_environment/README.md
@@ -202,6 +202,10 @@ instead of building from sources by using the `-o` flag:
 ./hack/setup-cluster.sh -o release-1.28 create deploy
 ```
 
+Branch snapshots are pulled from the
+[`cloudnative-pg/artifacts`](https://github.com/cloudnative-pg/artifacts)
+repository.
+
 *Note:* For a list of options, run `./hack/setup-cluster.sh`.
 
 > **NOTE:** In case of errors, make sure that you have the latest versions of the Go

--- a/contribute/e2e_testing_environment/README.md
+++ b/contribute/e2e_testing_environment/README.md
@@ -59,7 +59,7 @@ All flags have corresponding environment variables labeled `(Env:...` in the tab
 | -e    / --engine <CLUSTER_ENGINE>   | Use the specified Kubernetes engine (e.g., `-e k3d`). (Env: `CLUSTER_ENGINE`)                                   |
 | -k    / --k8s-version <K8S_VERSION> | Use the specified Kubernetes full version number (e.g., `-k v1.30.0`). (Env: `K8S_VERSION`)                                   |
 | -n    / --nodes \<NODES>            | Create a cluster with the required number of nodes. Used only during "create" command. Default: 3 (Env: `NODES`)              |
-| -o    / --operator \<OPERATOR> | Controls which version of the operator is deployed. Use `local` (default) to build from the local worktree, an exact version such as `1.28.1` to deploy that published release, or a branch name such as `main` or `release-1.28` to deploy the latest snapshot for that branch. (Env: `OPERATOR`) |
+| -o    / --operator \<OPERATOR> | Controls which version of the operator is deployed. Use `local` (default) to build from the local worktree, an exact version such as `1.28.1` to deploy that published release, or a branch name such as `main` or `release-1.28` to deploy the latest snapshot for that branch from the [`cloudnative-pg/artifacts`](https://github.com/cloudnative-pg/artifacts) repository. Only effective when using `make e2e-test-existing-cluster`; the `e2e-test-kind` and `e2e-test-k3d` targets are self-contained and always build the operator from the local worktree. (Env: `OPERATOR`) |
 
 > **NOTE:** on ARM64 architecture like Apple M1/M2/M3, `kind` provides different
 > images for AMD64 and ARM64 nodes. If the **x86/amd64 emulation** is not enabled,

--- a/contribute/e2e_testing_environment/README.md
+++ b/contribute/e2e_testing_environment/README.md
@@ -59,7 +59,7 @@ All flags have corresponding environment variables labeled `(Env:...` in the tab
 | -e    / --engine <CLUSTER_ENGINE>   | Use the specified Kubernetes engine (e.g., `-e k3d`). (Env: `CLUSTER_ENGINE`)                                   |
 | -k    / --k8s-version <K8S_VERSION> | Use the specified Kubernetes full version number (e.g., `-k v1.30.0`). (Env: `K8S_VERSION`)                                   |
 | -n    / --nodes \<NODES>            | Create a cluster with the required number of nodes. Used only during "create" command. Default: 3 (Env: `NODES`)              |
-| -o    / --operator-deploy-mode \<MODE> | Controls how the operator is deployed. Use `SOURCE` (default) to build from the local worktree, `main` to deploy the latest published manifest, or an exact version such as `1.28.1` to deploy that release. (Env: `OPERATOR_DEPLOY_MODE`) |
+| -s    / --source \<SOURCE> | Controls which release of the operator is deployed. Use `source` (default) to build from the local worktree or an exact version such as `1.28.1` to deploy that release. (Env: `SOURCE`) |
 
 > **NOTE:** on ARM64 architecture like Apple M1/M2/M3, `kind` provides different
 > images for AMD64 and ARM64 nodes. If the **x86/amd64 emulation** is not enabled,

--- a/contribute/e2e_testing_environment/README.md
+++ b/contribute/e2e_testing_environment/README.md
@@ -59,7 +59,7 @@ All flags have corresponding environment variables labeled `(Env:...` in the tab
 | -e    / --engine <CLUSTER_ENGINE>   | Use the specified Kubernetes engine (e.g., `-e k3d`). (Env: `CLUSTER_ENGINE`)                                   |
 | -k    / --k8s-version <K8S_VERSION> | Use the specified Kubernetes full version number (e.g., `-k v1.30.0`). (Env: `K8S_VERSION`)                                   |
 | -n    / --nodes \<NODES>            | Create a cluster with the required number of nodes. Used only during "create" command. Default: 3 (Env: `NODES`)              |
-| -s    / --source \<SOURCE> | Controls which release of the operator is deployed. Use `source` (default) to build from the local worktree or an exact version such as `1.28.1` to deploy that release. (Env: `SOURCE`) |
+| -o    / --operator \<OPERATOR> | Controls which version of the operator is deployed. Use `local` (default) to build from the local worktree, an exact version such as `1.28.1` to deploy that published release, or a branch name such as `main` or `release-1.28` to deploy the latest snapshot for that branch. (Env: `OPERATOR`) |
 
 > **NOTE:** on ARM64 architecture like Apple M1/M2/M3, `kind` provides different
 > images for AMD64 and ARM64 nodes. If the **x86/amd64 emulation** is not enabled,

--- a/contribute/e2e_testing_environment/README.md
+++ b/contribute/e2e_testing_environment/README.md
@@ -59,7 +59,16 @@ All flags have corresponding environment variables labeled `(Env:...` in the tab
 | -e    / --engine <CLUSTER_ENGINE>   | Use the specified Kubernetes engine (e.g., `-e k3d`). (Env: `CLUSTER_ENGINE`)                                   |
 | -k    / --k8s-version <K8S_VERSION> | Use the specified Kubernetes full version number (e.g., `-k v1.30.0`). (Env: `K8S_VERSION`)                                   |
 | -n    / --nodes \<NODES>            | Create a cluster with the required number of nodes. Used only during "create" command. Default: 3 (Env: `NODES`)              |
-| -o    / --operator \<OPERATOR> | Controls which version of the operator is deployed. Use `local` (default) to build from the local worktree, an exact version such as `1.28.1` to deploy that published release, or a branch name such as `main` or `release-1.28` to deploy the latest snapshot for that branch from the [`cloudnative-pg/artifacts`](https://github.com/cloudnative-pg/artifacts) repository. Only effective when using `make e2e-test-existing-cluster`; the `e2e-test-kind` and `e2e-test-k3d` targets are self-contained and always build the operator from the local worktree. (Env: `OPERATOR`) |
+| -o    / --operator \<OPERATOR> | Select the operator to deploy: `local` (default), a version, or a branch. See below. (Env: `OPERATOR`) |
+
+The `-o`/`--operator` flag accepts:
+
+- `local` (default): build and deploy from the local worktree.
+- A version such as `1.28.1`: deploy the matching published release.
+- A branch such as `main` or `release-1.28`: deploy the latest snapshot for
+  that branch from the
+  [`cloudnative-pg/artifacts`](https://github.com/cloudnative-pg/artifacts)
+  repository.
 
 > **NOTE:** on ARM64 architecture like Apple M1/M2/M3, `kind` provides different
 > images for AMD64 and ARM64 nodes. If the **x86/amd64 emulation** is not enabled,

--- a/contribute/e2e_testing_environment/README.md
+++ b/contribute/e2e_testing_environment/README.md
@@ -49,7 +49,7 @@ hack/setup-cluster.sh deploy
 To cleanup everything:
 
 ``` shell
-hack/setup-cluster.sh destroy
+hack/setup-cluster.sh teardown
 ```
 
 All flags have corresponding environment variables labeled `(Env:...` in the table below.

--- a/contribute/e2e_testing_environment/README.md
+++ b/contribute/e2e_testing_environment/README.md
@@ -59,6 +59,7 @@ All flags have corresponding environment variables labeled `(Env:...` in the tab
 | -e    / --engine <CLUSTER_ENGINE>   | Use the specified Kubernetes engine (e.g., `-e k3d`). (Env: `CLUSTER_ENGINE`)                                   |
 | -k    / --k8s-version <K8S_VERSION> | Use the specified Kubernetes full version number (e.g., `-k v1.30.0`). (Env: `K8S_VERSION`)                                   |
 | -n    / --nodes \<NODES>            | Create a cluster with the required number of nodes. Used only during "create" command. Default: 3 (Env: `NODES`)              |
+| -o    / --operator-deploy-mode \<MODE> | Controls how the operator is deployed. Use `SOURCE` (default) to build from the local worktree, `main` to deploy the latest published manifest, or an exact version such as `1.28.1` to deploy that release. (Env: `OPERATOR_DEPLOY_MODE`) |
 
 > **NOTE:** on ARM64 architecture like Apple M1/M2/M3, `kind` provides different
 > images for AMD64 and ARM64 nodes. If the **x86/amd64 emulation** is not enabled,

--- a/hack/e2e/run-e2e-local.sh
+++ b/hack/e2e/run-e2e-local.sh
@@ -52,12 +52,12 @@ export TEST_CLOUD_VENDOR="${CLUSTER_ENGINE}"
 # shellcheck disable=SC2329
 cleanup() {
   if [ "${PRESERVE_CLUSTER}" = false ]; then
-    "${HACK_DIR}/setup-cluster.sh" -e "${CLUSTER_ENGINE}" destroy || true
+    "${HACK_DIR}/setup-cluster.sh" -e "${CLUSTER_ENGINE}" teardown || true
   else
     set +x
     echo "You've chosen to preserve the Kubernetes cluster."
     echo "You can delete it manually later running:"
-    echo "'${HACK_DIR}/setup-cluster.sh' -e ${CLUSTER_ENGINE} destroy"
+    echo "'${HACK_DIR}/setup-cluster.sh' -e ${CLUSTER_ENGINE} teardown"
   fi
 }
 

--- a/hack/setup-cluster.sh
+++ b/hack/setup-cluster.sh
@@ -96,7 +96,7 @@ main() {
   # --- ARGUMENT PARSING ---
   # Parse command-line options (-k, -n, etc.) using getopt
   if ! getopt -T > /dev/null; then
-    parsed_opts=$(getopt -o e:k:n:o:r -l "engine:,k8s-version:,nodes:,operator-deploy-mode:,registry" -- "$@") || usage
+    parsed_opts=$(getopt -o e:k:n:s:r -l "engine:,k8s-version:,nodes:,source:,registry" -- "$@") || usage
   else
     parsed_opts=$(getopt e:k:n:o:r "$@") || usage
   fi

--- a/hack/setup-cluster.sh
+++ b/hack/setup-cluster.sh
@@ -98,7 +98,7 @@ main() {
   if ! getopt -T > /dev/null; then
     parsed_opts=$(getopt -o e:k:n:s:r -l "engine:,k8s-version:,nodes:,source:,registry" -- "$@") || usage
   else
-    parsed_opts=$(getopt e:k:n:o:r "$@") || usage
+    parsed_opts=$(getopt e:k:n:s:r "$@") || usage
   fi
   eval "set -- $parsed_opts"
 

--- a/hack/setup-cluster.sh
+++ b/hack/setup-cluster.sh
@@ -50,7 +50,7 @@ NODES=${NODES:-3}
 
 usage() {
   cat >&2 <<EOF
-Usage: $0 [-k <version>] [-n <nodes>] [-s <source>] <command>
+Usage: $0 [-k <version>] [-n <nodes>] [-o <operator>] <command>
 
 Commands:
     create                Create the test cluster and a local registry
@@ -78,12 +78,14 @@ Options:
                           Used only during "create" command. Default: 3
                           Env: NODES
 
-    -s|--source
-      <SOURCE>            Controls which version of  operator is deployed. 
-                          Use 'source (default) to build and deploy from the 
-                          local worktree or an exact version such as '1.28.1' to 
-                          deploy that release.
-                          Env: SOURCE
+    -o|--operator
+      <OPERATOR>          Controls which version of the operator is deployed.
+                          Use 'local' (default) to build and deploy from the
+                          local worktree, an exact version such as '1.28.1' to
+                          deploy that published release, or a branch name such
+                          as 'main' or 'release-1.28' to deploy the latest
+                          snapshot for that branch.
+                          Env: OPERATOR
 
 To use long options you need to have GNU enhanced getopt available, otherwise
 you can only use the short version of the options.
@@ -96,9 +98,9 @@ main() {
   # --- ARGUMENT PARSING ---
   # Parse command-line options (-k, -n, etc.) using getopt
   if ! getopt -T > /dev/null; then
-    parsed_opts=$(getopt -o e:k:n:s:r -l "engine:,k8s-version:,nodes:,source:,registry" -- "$@") || usage
+    parsed_opts=$(getopt -o e:k:n:o:r -l "engine:,k8s-version:,nodes:,operator:,registry" -- "$@") || usage
   else
-    parsed_opts=$(getopt e:k:n:s:r "$@") || usage
+    parsed_opts=$(getopt e:k:n:o:r "$@") || usage
   fi
   eval "set -- $parsed_opts"
 
@@ -131,9 +133,9 @@ main() {
           usage
         fi
         ;;
-      -s | --source)
+      -o | --operator)
         shift
-        export SOURCE="${1}"
+        export OPERATOR="${1}"
         shift
         ;;
       -r | --registry)

--- a/hack/setup-cluster.sh
+++ b/hack/setup-cluster.sh
@@ -50,7 +50,7 @@ NODES=${NODES:-3}
 
 usage() {
   cat >&2 <<EOF
-Usage: $0 [-k <version>] [-n <nodes>] [-o <operator>] <command>
+Usage: $0 [-e <engine>] [-k <version>] [-n <nodes>] [-o <operator>] <command>
 
 Commands:
     create                Create the test cluster and a local registry

--- a/hack/setup-cluster.sh
+++ b/hack/setup-cluster.sh
@@ -131,9 +131,9 @@ main() {
           usage
         fi
         ;;
-      -o | --operator-deploy-mode)
+      -s | --source)
         shift
-        export OPERATOR_DEPLOY_MODE="${1}"
+        export SOURCE="${1}"
         shift
         ;;
       -r | --registry)

--- a/hack/setup-cluster.sh
+++ b/hack/setup-cluster.sh
@@ -50,7 +50,7 @@ NODES=${NODES:-3}
 
 usage() {
   cat >&2 <<EOF
-Usage: $0 [-k <version>] [-n <nodes>] <command>
+Usage: $0 [-k <version>] [-n <nodes>] [-o <mode>] <command>
 
 Commands:
     create                Create the test cluster and a local registry
@@ -78,6 +78,13 @@ Options:
                           Used only during "create" command. Default: 3
                           Env: NODES
 
+    -o|--operator-deploy-mode
+        <MODE>            Controls how the operator is deployed. Use 'SOURCE'
+                          (default) to build and deploy from the local worktree,
+                          'main' to deploy the latest published manifest, or an
+                          exact version such as '1.28.1' to deploy that release.
+                          Env: OPERATOR_DEPLOY_MODE
+
 To use long options you need to have GNU enhanced getopt available, otherwise
 you can only use the short version of the options.
 EOF
@@ -89,9 +96,9 @@ main() {
   # --- ARGUMENT PARSING ---
   # Parse command-line options (-k, -n, etc.) using getopt
   if ! getopt -T > /dev/null; then
-    parsed_opts=$(getopt -o e:k:n:r -l "engine:,k8s-version:,nodes:,registry" -- "$@") || usage
+    parsed_opts=$(getopt -o e:k:n:o:r -l "engine:,k8s-version:,nodes:,operator-deploy-mode:,registry" -- "$@") || usage
   else
-    parsed_opts=$(getopt e:k:n:r "$@") || usage
+    parsed_opts=$(getopt e:k:n:o:r "$@") || usage
   fi
   eval "set -- $parsed_opts"
 
@@ -123,6 +130,11 @@ main() {
           echo >&2
           usage
         fi
+        ;;
+      -o | --operator-deploy-mode)
+        shift
+        export OPERATOR_DEPLOY_MODE="${1}"
+        shift
         ;;
       -r | --registry)
         shift

--- a/hack/setup-cluster.sh
+++ b/hack/setup-cluster.sh
@@ -50,7 +50,7 @@ NODES=${NODES:-3}
 
 usage() {
   cat >&2 <<EOF
-Usage: $0 [-k <version>] [-n <nodes>] [-o <mode>] <command>
+Usage: $0 [-k <version>] [-n <nodes>] [-s <source>] <command>
 
 Commands:
     create                Create the test cluster and a local registry
@@ -78,12 +78,12 @@ Options:
                           Used only during "create" command. Default: 3
                           Env: NODES
 
-    -o|--operator-deploy-mode
-        <MODE>            Controls how the operator is deployed. Use 'SOURCE'
-                          (default) to build and deploy from the local worktree,
-                          'main' to deploy the latest published manifest, or an
-                          exact version such as '1.28.1' to deploy that release.
-                          Env: OPERATOR_DEPLOY_MODE
+    -s|--source
+      <SOURCE>            Controls which version of  operator is deployed. 
+                          Use 'source (default) to build and deploy from the 
+                          local worktree or an exact version such as '1.28.1' to 
+                          deploy that release.
+                          Env: SOURCE
 
 To use long options you need to have GNU enhanced getopt available, otherwise
 you can only use the short version of the options.

--- a/hack/testing-tools/common/20-utils-k8s.sh
+++ b/hack/testing-tools/common/20-utils-k8s.sh
@@ -140,6 +140,68 @@ EOF
   echo -e "${bright}Pyroscope deployment successful and operator patched to expose profiling data.${reset}"
 }
 
+# print_operator_image: prints the operator image reference (as set on the
+# controller-manager Deployment's first container) when the deployment exists.
+function print_operator_image() {
+    local image
+    image=$(${K8S_CLI} get deployment cnpg-controller-manager -n cnpg-system \
+        --ignore-not-found \
+        -o jsonpath='{.spec.template.spec.containers[0].image}')
+    if [[ -n "${image}" ]]; then
+        printf '%bOperator image: %s%b\n' "${bright}" "${image}" "${reset}"
+    fi
+}
+
+# deploy_operator_from_manifest <operator>
+# Deploys the operator by applying its manifest. The <operator> argument is
+# interpreted either as a semver version (e.g. 1.28.1 or v1.28.1, with optional
+# prerelease suffix), in which case the published release manifest from the main
+# repository is used, or as a branch name (e.g. main, release-1.28), in which
+# case the snapshot manifest from the cloudnative-pg/artifacts repository is
+# used.
+function deploy_operator_from_manifest() {
+    local operator="${1:?operator is required}"
+    local mode
+    local manifest_url
+
+    if [[ "${operator}" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.-]+)?$ ]]; then
+        local version="${operator#v}"
+        mode="version"
+        manifest_url="https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg/v${version}/releases/cnpg-${version}.yaml"
+    elif [[ "${operator}" =~ ^v?[0-9] ]]; then
+        # Looks version-like but isn't valid semver -- refuse rather than silently
+        # fall through to branch mode and produce a misleading "not found" error.
+        printf '%bError: %s is not a valid operator version (expected e.g. 1.28.1 or v1.28.1)%b\n' \
+            "${bright}" "${operator}" "${reset}" >&2
+        exit 1
+    elif [[ "${operator}" =~ ^[A-Za-z0-9][A-Za-z0-9._/-]*$ ]] && [[ "${operator}" != *..* ]]; then
+        mode="branch"
+        manifest_url="https://raw.githubusercontent.com/cloudnative-pg/artifacts/${operator}/manifests/operator-manifest.yaml"
+    else
+        printf '%bError: %s is not a valid operator value%b\n' \
+            "${bright}" "${operator}" "${reset}" >&2
+        printf '%bExpected a semver (e.g. 1.28.1) or a branch name (e.g. main, release-1.28).%b\n' \
+            "${bright}" "${reset}" >&2
+        exit 1
+    fi
+
+    if ! curl --silent --fail -o /dev/null "${manifest_url}"; then
+        printf '%bError: Manifest not found at %s%b\n' "${bright}" "${manifest_url}" "${reset}" >&2
+        printf '%bInterpreted %s as a %s.%b\n' "${bright}" "${operator}" "${mode}" "${reset}" >&2
+        exit 1
+    fi
+
+    printf '%bDeploying operator from %s%b\n' "${bright}" "${operator}" "${reset}"
+    ${K8S_CLI} delete ns cnpg-system 2>/dev/null || true
+    # --server-side avoids the last-applied-configuration annotation exceeding
+    # the 262144 byte limit on large CRDs; --force-conflicts lets us adopt
+    # existing field ownership when re-deploying or switching operator version.
+    ${K8S_CLI} apply --server-side --force-conflicts -f "${manifest_url}"
+
+    printf '%bOperator deployment initiated.%b\n' "${bright}" "${reset}"
+    print_operator_image
+}
+
 # deploy_csi_host_path: Deploys the host path CSI driver and snapshotter components.
 function deploy_csi_host_path() {
   # shellcheck disable=SC2154

--- a/hack/testing-tools/common/20-utils-k8s.sh
+++ b/hack/testing-tools/common/20-utils-k8s.sh
@@ -152,6 +152,23 @@ function print_operator_image() {
     fi
 }
 
+# reset_operator_namespace: deletes the cnpg-system namespace if present and
+# waits for finalization, so the next apply doesn't race a terminating namespace.
+function reset_operator_namespace() {
+    if ${K8S_CLI} get ns cnpg-system >/dev/null 2>&1; then
+        ${K8S_CLI} delete ns cnpg-system --ignore-not-found --wait=false
+        ${K8S_CLI} wait --for=delete ns/cnpg-system --timeout=60s
+    fi
+}
+
+# wait_operator_ready: waits for the controller-manager rollout to finish and
+# prints a completion banner plus the deployed image reference.
+function wait_operator_ready() {
+    ${K8S_CLI} -n cnpg-system rollout status deploy/cnpg-controller-manager --timeout=5m
+    printf '%bOperator deployment complete.%b\n' "${bright}" "${reset}"
+    print_operator_image
+}
+
 # deploy_operator_from_manifest <operator>
 # Deploys the operator by applying its manifest. The <operator> argument is
 # interpreted either as a semver version (e.g. 1.28.1 or v1.28.1, with optional
@@ -193,18 +210,12 @@ function deploy_operator_from_manifest() {
     fi
 
     printf '%bDeploying operator from %s%b\n' "${bright}" "${operator}" "${reset}"
-    if ${K8S_CLI} get ns cnpg-system >/dev/null 2>&1; then
-        ${K8S_CLI} delete ns cnpg-system --ignore-not-found --wait=false
-        ${K8S_CLI} wait --for=delete ns/cnpg-system --timeout=60s
-    fi
+    reset_operator_namespace
     # --server-side avoids the last-applied-configuration annotation exceeding
     # the 262144 byte limit on large CRDs; --force-conflicts lets us adopt
     # existing field ownership when re-deploying or switching operator version.
     ${K8S_CLI} apply --server-side --force-conflicts -f "${manifest_file}"
-    ${K8S_CLI} -n cnpg-system rollout status deploy/cnpg-controller-manager --timeout=5m
-
-    printf '%bOperator deployment complete.%b\n' "${bright}" "${reset}"
-    print_operator_image
+    wait_operator_ready
 }
 
 # deploy_csi_host_path: Deploys the host path CSI driver and snapshotter components.

--- a/hack/testing-tools/common/20-utils-k8s.sh
+++ b/hack/testing-tools/common/20-utils-k8s.sh
@@ -167,7 +167,7 @@ function deploy_operator_from_manifest() {
     if [[ "${operator}" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.-]+)?$ ]]; then
         local version="${operator#v}"
         mode="version"
-        manifest_url="https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg/v${version}/releases/cnpg-${version}.yaml"
+        manifest_url="https://github.com/cloudnative-pg/cloudnative-pg/releases/download/v${version}/cnpg-${version}.yaml"
     elif [[ "${operator}" =~ ^v?[0-9] ]]; then
         # Looks version-like but isn't valid semver -- refuse rather than silently
         # fall through to branch mode and produce a misleading "not found" error.
@@ -185,7 +185,8 @@ function deploy_operator_from_manifest() {
         exit 1
     fi
 
-    if ! curl --silent --fail -o /dev/null "${manifest_url}"; then
+    local manifest_file="${TEMP_DIR}/cnpg-operator-manifest.yaml"
+    if ! curl -fsSL --retry 5 --retry-delay 2 -o "${manifest_file}" "${manifest_url}"; then
         printf '%bError: Manifest not found at %s%b\n' "${bright}" "${manifest_url}" "${reset}" >&2
         printf '%bInterpreted %s as a %s.%b\n' "${bright}" "${operator}" "${mode}" "${reset}" >&2
         exit 1
@@ -196,7 +197,7 @@ function deploy_operator_from_manifest() {
     # --server-side avoids the last-applied-configuration annotation exceeding
     # the 262144 byte limit on large CRDs; --force-conflicts lets us adopt
     # existing field ownership when re-deploying or switching operator version.
-    ${K8S_CLI} apply --server-side --force-conflicts -f "${manifest_url}"
+    ${K8S_CLI} apply --server-side --force-conflicts -f "${manifest_file}"
 
     printf '%bOperator deployment initiated.%b\n' "${bright}" "${reset}"
     print_operator_image

--- a/hack/testing-tools/common/20-utils-k8s.sh
+++ b/hack/testing-tools/common/20-utils-k8s.sh
@@ -193,13 +193,17 @@ function deploy_operator_from_manifest() {
     fi
 
     printf '%bDeploying operator from %s%b\n' "${bright}" "${operator}" "${reset}"
-    ${K8S_CLI} delete ns cnpg-system 2>/dev/null || true
+    if ${K8S_CLI} get ns cnpg-system >/dev/null 2>&1; then
+        ${K8S_CLI} delete ns cnpg-system --ignore-not-found --wait=false
+        ${K8S_CLI} wait --for=delete ns/cnpg-system --timeout=60s
+    fi
     # --server-side avoids the last-applied-configuration annotation exceeding
     # the 262144 byte limit on large CRDs; --force-conflicts lets us adopt
     # existing field ownership when re-deploying or switching operator version.
     ${K8S_CLI} apply --server-side --force-conflicts -f "${manifest_file}"
+    ${K8S_CLI} -n cnpg-system rollout status deploy/cnpg-controller-manager --timeout=5m
 
-    printf '%bOperator deployment initiated.%b\n' "${bright}" "${reset}"
+    printf '%bOperator deployment complete.%b\n' "${bright}" "${reset}"
     print_operator_image
 }
 

--- a/hack/testing-tools/common/50-utils-images-load.sh
+++ b/hack/testing-tools/common/50-utils-images-load.sh
@@ -90,15 +90,6 @@ function build_and_load_operator_image_from_sources() {
   docker buildx rm "${builder_name}"
 }
 
-function print_operator_image() {
-    local image
-    image=$(${K8S_CLI} get deployment cnpg-controller-manager -n cnpg-system \
-        -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null)
-    if [[ -n "${image}" ]]; then
-        echo -e "${bright}Operator image: ${image}${reset}"
-    fi
-}
-
 function deploy_operator_from_sources() {
     echo -e "${bright}Deploying operator manifests from current worktree...${reset}"
 
@@ -107,32 +98,6 @@ function deploy_operator_from_sources() {
 
     # Run the make target from the project root directory
     make -C "${ROOT_DIR}" deploy "CONTROLLER_IMG=${CONTROLLER_IMG}"
-
-    echo -e "${bright}Operator deployment initiated.${reset}"
-    print_operator_image
-}
-
-function deploy_operator_from_manifest() {
-    local operator="${1:?operator is required}"
-    local manifest_url
-
-    # Semver version (e.g. 1.28.1) -> published release manifest from the main repo
-    # Branch name (e.g. main, release-1.28) -> snapshot manifest from the artifacts repo
-    if [[ "${operator}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-        manifest_url="https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg/v${operator}/releases/cnpg-${operator}.yaml"
-    else
-        manifest_url="https://raw.githubusercontent.com/cloudnative-pg/artifacts/${operator}/manifests/operator-manifest.yaml"
-    fi
-
-    if ! curl --silent --head --fail "${manifest_url}" > /dev/null 2>&1; then
-        echo -e "${bright}Error: Manifest not found at ${manifest_url}${reset}" >&2
-        echo -e "${bright}Please verify the operator: ${operator}${reset}" >&2
-        exit 1
-    fi
-
-    echo -e "${bright}Deploying operator from '${operator}'${reset}"
-    ${K8S_CLI} delete ns cnpg-system 2>/dev/null || true
-    ${K8S_CLI} apply --server-side -f "${manifest_url}" # avoids last-applied-configuration annotation exceeding the 262144 byte limit on large CRDs
 
     echo -e "${bright}Operator deployment initiated.${reset}"
     print_operator_image

--- a/hack/testing-tools/common/50-utils-images-load.sh
+++ b/hack/testing-tools/common/50-utils-images-load.sh
@@ -107,10 +107,11 @@ function deploy_operator_from_version() {
     local base_url="https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg/${version}/releases"
     local manifest_url
 
-    if [[ "${version}" == "main" ]]; then
-        manifest_url="${base_url}/cnpg-latest.yaml"
-    else
-        manifest_url="${base_url}/cnpg-${version}.yaml"
+    manifest_url="${base_url}/cnpg-${version}.yaml"
+    if  ! curl --silent --head --fail "${manifest_url}" > /dev/null 2>&1; then
+        echo -e "${bright}Error: Manifest not found at ${manifest_url}${reset}" >&2
+        echo -e "${bright}Please verify the version: ${version}${reset}" >&2
+        exit 1
     fi
 
     echo -e "${bright}Deploying operator version '${version}'${reset}"

--- a/hack/testing-tools/common/50-utils-images-load.sh
+++ b/hack/testing-tools/common/50-utils-images-load.sh
@@ -104,7 +104,7 @@ function deploy_operator_from_sources() {
 
 function deploy_operator_from_version() {
     local version="${1:?version is required}"
-    local base_url="https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg/${version}/releases"
+    local base_url="https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg/v${version}/releases"
     local manifest_url
 
     manifest_url="${base_url}/cnpg-${version}.yaml"

--- a/hack/testing-tools/common/50-utils-images-load.sh
+++ b/hack/testing-tools/common/50-utils-images-load.sh
@@ -102,19 +102,25 @@ function deploy_operator_from_sources() {
     echo -e "${bright}Operator deployment initiated.${reset}"
 }
 
-function deploy_operator_from_version() {
-    local version="${1:?version is required}"
-    local base_url="https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg/v${version}/releases"
+function deploy_operator_from_manifest() {
+    local operator="${1:?operator is required}"
     local manifest_url
 
-    manifest_url="${base_url}/cnpg-${version}.yaml"
-    if  ! curl --silent --head --fail "${manifest_url}" > /dev/null 2>&1; then
+    # Semver version (e.g. 1.28.1) -> published release manifest from the main repo
+    # Branch name (e.g. main, release-1.28) -> snapshot manifest from the artifacts repo
+    if [[ "${operator}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+        manifest_url="https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg/v${operator}/releases/cnpg-${operator}.yaml"
+    else
+        manifest_url="https://raw.githubusercontent.com/cloudnative-pg/artifacts/${operator}/manifests/operator-manifest.yaml"
+    fi
+
+    if ! curl --silent --head --fail "${manifest_url}" > /dev/null 2>&1; then
         echo -e "${bright}Error: Manifest not found at ${manifest_url}${reset}" >&2
-        echo -e "${bright}Please verify the version: ${version}${reset}" >&2
+        echo -e "${bright}Please verify the operator: ${operator}${reset}" >&2
         exit 1
     fi
 
-    echo -e "${bright}Deploying operator version '${version}'${reset}"
+    echo -e "${bright}Deploying operator from '${operator}'${reset}"
     ${K8S_CLI} delete ns cnpg-system 2>/dev/null || true
     ${K8S_CLI} apply --server-side -f "${manifest_url}" # avoids last-applied-configuration annotation exceeding the 262144 byte limit on large CRDs
 

--- a/hack/testing-tools/common/50-utils-images-load.sh
+++ b/hack/testing-tools/common/50-utils-images-load.sh
@@ -90,6 +90,15 @@ function build_and_load_operator_image_from_sources() {
   docker buildx rm "${builder_name}"
 }
 
+function print_operator_image() {
+    local image
+    image=$(${K8S_CLI} get deployment cnpg-controller-manager -n cnpg-system \
+        -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null)
+    if [[ -n "${image}" ]]; then
+        echo -e "${bright}Operator image: ${image}${reset}"
+    fi
+}
+
 function deploy_operator_from_sources() {
     echo -e "${bright}Deploying operator manifests from current worktree...${reset}"
 
@@ -100,6 +109,7 @@ function deploy_operator_from_sources() {
     make -C "${ROOT_DIR}" deploy "CONTROLLER_IMG=${CONTROLLER_IMG}"
 
     echo -e "${bright}Operator deployment initiated.${reset}"
+    print_operator_image
 }
 
 function deploy_operator_from_manifest() {
@@ -125,4 +135,5 @@ function deploy_operator_from_manifest() {
     ${K8S_CLI} apply --server-side -f "${manifest_url}" # avoids last-applied-configuration annotation exceeding the 262144 byte limit on large CRDs
 
     echo -e "${bright}Operator deployment initiated.${reset}"
+    print_operator_image
 }

--- a/hack/testing-tools/common/50-utils-images-load.sh
+++ b/hack/testing-tools/common/50-utils-images-load.sh
@@ -104,7 +104,7 @@ function deploy_operator_from_sources() {
 
 function deploy_operator_from_version() {
     local version="${1:?version is required}"
-    local base_url="https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg/main/releases"
+    local base_url="https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg/${version}/releases"
     local manifest_url
 
     if [[ "${version}" == "main" ]]; then

--- a/hack/testing-tools/common/50-utils-images-load.sh
+++ b/hack/testing-tools/common/50-utils-images-load.sh
@@ -101,3 +101,21 @@ function deploy_operator_from_sources() {
 
     echo -e "${bright}Operator deployment initiated.${reset}"
 }
+
+function deploy_operator_from_version() {
+    local version="${1:?version is required}"
+    local base_url="https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg/main/releases"
+    local manifest_url
+
+    if [[ "${version}" == "main" ]]; then
+        manifest_url="${base_url}/cnpg-latest.yaml"
+    else
+        manifest_url="${base_url}/cnpg-${version}.yaml"
+    fi
+
+    echo -e "${bright}Deploying operator version '${version}'${reset}"
+    ${K8S_CLI} delete ns cnpg-system 2>/dev/null || true
+    ${K8S_CLI} apply --server-side -f "${manifest_url}" # avoids last-applied-configuration annotation exceeding the 262144 byte limit on large CRDs
+
+    echo -e "${bright}Operator deployment initiated.${reset}"
+}

--- a/hack/testing-tools/common/50-utils-images-load.sh
+++ b/hack/testing-tools/common/50-utils-images-load.sh
@@ -91,14 +91,12 @@ function build_and_load_operator_image_from_sources() {
 }
 
 function deploy_operator_from_sources() {
-    echo -e "${bright}Deploying operator manifests from current worktree...${reset}"
+    printf '%bDeploying operator manifests from current worktree...%b\n' "${bright}" "${reset}"
 
-    # Attempt to delete the namespace first (ignore errors if it doesn't exist)
-    ${K8S_CLI} delete ns cnpg-system 2> /dev/null || true
+    reset_operator_namespace
 
     # Run the make target from the project root directory
     make -C "${ROOT_DIR}" deploy "CONTROLLER_IMG=${CONTROLLER_IMG}"
 
-    echo -e "${bright}Operator deployment initiated.${reset}"
-    print_operator_image
+    wait_operator_ready
 }

--- a/hack/testing-tools/k8s-engines/manage.sh
+++ b/hack/testing-tools/k8s-engines/manage.sh
@@ -82,6 +82,8 @@ fi
 # --- Action Aliases for Backward Compatibility ---
 case "$ACTION" in
     load)
+        # Published releases and branch snapshots already ship images on
+        # ghcr.io; only the 'local' path needs a local build + registry push.
         if [[ "${OPERATOR:-local}" != "local" ]]; then
             echo "Skipping image build: OPERATOR=${OPERATOR}"
             exit 0

--- a/hack/testing-tools/k8s-engines/manage.sh
+++ b/hack/testing-tools/k8s-engines/manage.sh
@@ -118,7 +118,7 @@ case "$ACTION" in
         ;;
 
     load-from-sources)
-        if [[ "${OPERATOR_DEPLOY_MODE:-SOURCE}" != "SOURCE" ]]; then
+        if [[ "${SOURCE:-source}" != "source" ]]; then
             echo "Skipping image build: OPERATOR_DEPLOY_MODE=${OPERATOR_DEPLOY_MODE}"
         else
             LOAD_VENDOR_SCRIPT="${VENDOR_DIR}/load.sh"

--- a/hack/testing-tools/k8s-engines/manage.sh
+++ b/hack/testing-tools/k8s-engines/manage.sh
@@ -118,26 +118,33 @@ case "$ACTION" in
         ;;
 
     load-from-sources)
-        LOAD_VENDOR_SCRIPT="${VENDOR_DIR}/load.sh"
-
-        if [ -f "${LOAD_VENDOR_SCRIPT}" ]; then
-            source "${LOAD_VENDOR_SCRIPT}"
-            load_operator_image_vendor_specific
+        if [[ "${OPERATOR_DEPLOY_MODE:-SOURCE}" != "SOURCE" ]]; then
+            echo "Skipping image build: OPERATOR_DEPLOY_MODE=${OPERATOR_DEPLOY_MODE}"
         else
-            build_and_load_operator_image_from_sources
+            LOAD_VENDOR_SCRIPT="${VENDOR_DIR}/load.sh"
+
+            if [ -f "${LOAD_VENDOR_SCRIPT}" ]; then
+                source "${LOAD_VENDOR_SCRIPT}"
+                load_operator_image_vendor_specific
+            else
+                build_and_load_operator_image_from_sources
+            fi
         fi
         ;;
 
     deploy-from-sources)
-        # Ensure CONTROLLER_IMG is defined
-        CONTROLLER_IMG=${CONTROLLER_IMG:-$(print_image)}
-        if [ -z "$CONTROLLER_IMG" ]; then
-            echo "ERROR: Failed to determine CONTROLLER_IMG" >&2
-            exit 1
-        fi
-
         source "${COMMON_DIR}/20-utils-k8s.sh"
-        deploy_operator_from_sources
+
+        if [[ "${OPERATOR_DEPLOY_MODE:-SOURCE}" != "SOURCE" ]]; then
+            deploy_operator_from_version "${OPERATOR_DEPLOY_MODE}"
+        else
+            CONTROLLER_IMG=${CONTROLLER_IMG:-$(print_image)}
+            if [ -z "$CONTROLLER_IMG" ]; then
+                echo "ERROR: Failed to determine CONTROLLER_IMG" >&2
+                exit 1
+            fi
+            deploy_operator_from_sources
+        fi
         ;;
 
     load-helper-images)
@@ -195,6 +202,7 @@ case "$ACTION" in
         echo "NODES:                      ${NODES:-<not explicitly set>}"
         echo "ENABLE_APISERVER_AUDIT:     ${ENABLE_APISERVER_AUDIT:-false}"
         echo "ENABLE_FLUENTD:             ${ENABLE_FLUENTD:-false}"
+        echo "OPERATOR_DEPLOY_MODE:       ${OPERATOR_DEPLOY_MODE:-SOURCE}"
 
         # --- IMAGE & BUILD ARTIFACTS ---
         echo ""

--- a/hack/testing-tools/k8s-engines/manage.sh
+++ b/hack/testing-tools/k8s-engines/manage.sh
@@ -41,8 +41,8 @@
 #
 # Usage:
 #   manage.sh <action>
-#   where <action> can be: create, load-from-sources, deploy-from-sources,
-#   deploy-from-manifest, load-helper-images, print-image, export-logs, teardown, pyroscope, env
+#   where <action> can be: create, load, deploy, load-helper-images,
+#   print-image, export-logs, teardown, pyroscope, env
 #
 # Environment Variables:
 #   CLUSTER_ENGINE - Determines the target vendor (default: 'kind')
@@ -75,7 +75,7 @@ source "${COMMON_DIR}/50-utils-images-load.sh"
 ACTION="${1:-}"
 
 if [ -z "$ACTION" ]; then
-    echo "Usage: $0 <create|load-from-sources|deploy-from-sources|deploy-from-manifest|load-helper-images|print-image|export-logs|teardown|pyroscope|env>"
+    echo "Usage: $0 <create|load|deploy|load-helper-images|print-image|export-logs|teardown|pyroscope|env>"
     exit 1
 fi
 

--- a/hack/testing-tools/k8s-engines/manage.sh
+++ b/hack/testing-tools/k8s-engines/manage.sh
@@ -119,7 +119,7 @@ case "$ACTION" in
 
     load-from-sources)
         if [[ "${SOURCE:-source}" != "source" ]]; then
-            echo "Skipping image build: OPERATOR_DEPLOY_MODE=${OPERATOR_DEPLOY_MODE}"
+            echo "Skipping image build: SOURCE=${SOURCE}"
         else
             LOAD_VENDOR_SCRIPT="${VENDOR_DIR}/load.sh"
 

--- a/hack/testing-tools/k8s-engines/manage.sh
+++ b/hack/testing-tools/k8s-engines/manage.sh
@@ -42,7 +42,7 @@
 # Usage:
 #   manage.sh <action>
 #   where <action> can be: create, load-from-sources, deploy-from-sources,
-#   load-helper-images, print-image, export-logs, teardown, pyroscope, env
+#   deploy-from-manifest, load-helper-images, print-image, export-logs, teardown, pyroscope, env
 #
 # Environment Variables:
 #   CLUSTER_ENGINE - Determines the target vendor (default: 'kind')
@@ -75,14 +75,26 @@ source "${COMMON_DIR}/50-utils-images-load.sh"
 ACTION="${1:-}"
 
 if [ -z "$ACTION" ]; then
-    echo "Usage: $0 <create|load-from-sources|deploy-from-sources|load-helper-images|print-image|export-logs|teardown|pyroscope|env>"
+    echo "Usage: $0 <create|load-from-sources|deploy-from-sources|deploy-from-manifest|load-helper-images|print-image|export-logs|teardown|pyroscope|env>"
     exit 1
 fi
 
 # --- Action Aliases for Backward Compatibility ---
 case "$ACTION" in
-    load) ACTION="load-from-sources" ;;
-    deploy) ACTION="deploy-from-sources" ;;
+    load)
+        if [[ "${OPERATOR:-local}" != "local" ]]; then
+            echo "Skipping image build: OPERATOR=${OPERATOR}"
+            exit 0
+        fi
+        ACTION="load-from-sources"
+        ;;
+    deploy)
+        if [[ "${OPERATOR:-local}" != "local" ]]; then
+            ACTION="deploy-from-manifest"
+        else
+            ACTION="deploy-from-sources"
+        fi
+        ;;
 esac
 
 # Ensure registry exists for actions that need it
@@ -118,33 +130,29 @@ case "$ACTION" in
         ;;
 
     load-from-sources)
-        if [[ "${SOURCE:-source}" != "source" ]]; then
-            echo "Skipping image build: SOURCE=${SOURCE}"
-        else
-            LOAD_VENDOR_SCRIPT="${VENDOR_DIR}/load.sh"
+        LOAD_VENDOR_SCRIPT="${VENDOR_DIR}/load.sh"
 
-            if [ -f "${LOAD_VENDOR_SCRIPT}" ]; then
-                source "${LOAD_VENDOR_SCRIPT}"
-                load_operator_image_vendor_specific
-            else
-                build_and_load_operator_image_from_sources
-            fi
+        if [ -f "${LOAD_VENDOR_SCRIPT}" ]; then
+            source "${LOAD_VENDOR_SCRIPT}"
+            load_operator_image_vendor_specific
+        else
+            build_and_load_operator_image_from_sources
         fi
         ;;
 
     deploy-from-sources)
         source "${COMMON_DIR}/20-utils-k8s.sh"
-
-        if [[ "${SOURCE:-source}" != "source" ]]; then
-            deploy_operator_from_version "${SOURCE}"
-        else
-            CONTROLLER_IMG=${CONTROLLER_IMG:-$(print_image)}
-            if [ -z "$CONTROLLER_IMG" ]; then
-                echo "ERROR: Failed to determine CONTROLLER_IMG" >&2
-                exit 1
-            fi
-            deploy_operator_from_sources
+        CONTROLLER_IMG=${CONTROLLER_IMG:-$(print_image)}
+        if [ -z "$CONTROLLER_IMG" ]; then
+            echo "ERROR: Failed to determine CONTROLLER_IMG" >&2
+            exit 1
         fi
+        deploy_operator_from_sources
+        ;;
+
+    deploy-from-manifest)
+        source "${COMMON_DIR}/20-utils-k8s.sh"
+        deploy_operator_from_manifest "${OPERATOR}"
         ;;
 
     load-helper-images)
@@ -202,7 +210,7 @@ case "$ACTION" in
         echo "NODES:                      ${NODES:-<not explicitly set>}"
         echo "ENABLE_APISERVER_AUDIT:     ${ENABLE_APISERVER_AUDIT:-false}"
         echo "ENABLE_FLUENTD:             ${ENABLE_FLUENTD:-false}"
-        echo "SOURCE:       ${SOURCE:-source}"
+        echo "OPERATOR:                   ${OPERATOR:-local}"
 
         # --- IMAGE & BUILD ARTIFACTS ---
         echo ""

--- a/hack/testing-tools/k8s-engines/manage.sh
+++ b/hack/testing-tools/k8s-engines/manage.sh
@@ -135,8 +135,8 @@ case "$ACTION" in
     deploy-from-sources)
         source "${COMMON_DIR}/20-utils-k8s.sh"
 
-        if [[ "${OPERATOR_DEPLOY_MODE:-SOURCE}" != "SOURCE" ]]; then
-            deploy_operator_from_version "${OPERATOR_DEPLOY_MODE}"
+        if [[ "${SOURCE:-source}" != "source" ]]; then
+            deploy_operator_from_version "${SOURCE}"
         else
             CONTROLLER_IMG=${CONTROLLER_IMG:-$(print_image)}
             if [ -z "$CONTROLLER_IMG" ]; then
@@ -202,7 +202,7 @@ case "$ACTION" in
         echo "NODES:                      ${NODES:-<not explicitly set>}"
         echo "ENABLE_APISERVER_AUDIT:     ${ENABLE_APISERVER_AUDIT:-false}"
         echo "ENABLE_FLUENTD:             ${ENABLE_FLUENTD:-false}"
-        echo "OPERATOR_DEPLOY_MODE:       ${OPERATOR_DEPLOY_MODE:-SOURCE}"
+        echo "SOURCE:       ${SOURCE:-source}"
 
         # --- IMAGE & BUILD ARTIFACTS ---
         echo ""


### PR DESCRIPTION
Introduces the `OPERATOR` environment variable (and `-o`/`--operator` flag) to `setup-cluster.sh`. When set, the operator is deployed from a prebuilt manifest rather than built from the local worktree (`local`, the default).

Two deployment paths are supported:

- Semver version (e.g. `1.28.1`): applies the published release manifest from the `cloudnative-pg/cloudnative-pg` repository.

- Branch name (e.g. `main`, `release-1.28`): applies the latest snapshot manifest from the `cloudnative-pg/artifacts` repository (consistent with the documented snapshot installation procedure).

A dedicated `deploy-from-manifest` action is introduced in `manage.sh`, keeping `deploy-from-sources` focused solely on local worktree deployments.

The active operator image reference is printed after every deployment, so the exact version in use is always visible.

Closes #9822

Assisted-by: Claude Sonnet 4.6