### PR TITLE
fix(cluster): strip stale primary label during failover

### DIFF
--- a/contribute/technical-architecture.md
+++ b/contribute/technical-architecture.md
@@ -214,9 +214,11 @@ Networking is purely label-driven. The Operator manages the
 
 2. **Replica:** Labeled as `replica`. The `-ro` Service selects these Pods.
 
-3. **Failover:** When a new primary is promoted via `pg_ctl promote`, the
-   Operator updates the labels. The Kubernetes API Server then automatically
-   updates the **Endpoints** for the respective Services.
+3. **Unhealthy:** Transient value applied to the old primary during a
+   failover or switchover, so that neither the `-rw` nor the `-ro`
+   Service selects it. Once the transition completes, the Operator
+   relabels the demoted instance as `replica` and the Kubernetes API
+   Server updates the Service **Endpoints** accordingly.
 
 ## Source Code Reference
 

--- a/docs/src/labels_annotations.md
+++ b/docs/src/labels_annotations.md
@@ -102,15 +102,21 @@ This label is available only on `VolumeSnapshot` resources.
   default users created by CloudNativePG (typically `postgres` and `app`).
 
 `role` - **deprecated**
-:  Whether the instance running in a pod is a `primary` or a `replica`.
-   This label is deprecated, you should use `cnpg.io/instanceRole` instead.
+:  Role of the instance running in a pod: `primary`, `replica`, or
+   `unhealthy`. The `unhealthy` value is transient: the operator sets
+   it on the old primary during a failover or switchover and clears it
+   automatically once the transition completes. This label is deprecated,
+   you should use `cnpg.io/instanceRole` instead.
 
 `cnpg.io/scheduled-backup`
 :  When available, name of the `ScheduledBackup` resource that created a given
    `Backup` object.
 
 `cnpg.io/instanceRole`
-: Whether the instance running in a pod is a `primary` or a `replica`.
+: Role of the instance running in a pod: `primary`, `replica`, or
+  `unhealthy`. The `unhealthy` value is transient: the operator sets
+  it on the old primary during a failover or switchover and clears it
+  automatically once the transition completes.
 
 `app.kubernetes.io/managed-by`
 : Name of the manager. It will always be `cloudnative-pg`.

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -367,6 +367,15 @@ func (r *ClusterReconciler) reconcile(ctx context.Context, cluster *apiv1.Cluste
 
 	if cluster.Status.CurrentPrimary != "" &&
 		cluster.Status.CurrentPrimary != cluster.Status.TargetPrimary {
+		// Strip the old primary's label on every pass while failover is
+		// in progress. This is retried each second until it succeeds,
+		// complementing the immediate best-effort attempt in replicas.go.
+		err := r.ensureOldPrimaryLabelIsDemoted(ctx, cluster.Status.CurrentPrimary, resources.instances.Items)
+		if err != nil {
+			contextLogger.Error(err, "Failed to strip primary label from old primary",
+				"oldPrimary", cluster.Status.CurrentPrimary)
+		}
+
 		contextLogger.Info("There is a switchover or a failover "+
 			"in progress, waiting for the operation to complete",
 			"currentPrimary", cluster.Status.CurrentPrimary,
@@ -423,26 +432,10 @@ func (r *ClusterReconciler) reconcile(ctx context.Context, cluster *apiv1.Cluste
 	if primaryNames := instancesStatus.PrimaryNames(); len(primaryNames) > 1 {
 		contextLogger.Error(
 			errOldPrimaryDetected,
-			"An old primary pod has been detected, reconciling metadata",
+			"An old primary pod has been detected. Awaiting its recognition of the new role",
 			"primaryNames", primaryNames,
 		)
 		instancesStatus.LogStatus(ctx)
-
-		// Reconcile pod labels even during dual-primary detection, so the -rw
-		// service stops routing to the old primary. At this point CurrentPrimary
-		// is already correct (the CurrentPrimary != TargetPrimary guard earlier
-		// in this function ensures they are equal before we reach here), so
-		// updateRoleLabels will set the new primary's label to "primary" and
-		// the old one to "replica".
-		if err := instanceReconciler.ReconcileMetadata(
-			ctx,
-			r.Client,
-			cluster,
-			resources.instances.Items,
-		); err != nil {
-			return ctrl.Result{}, err
-		}
-
 		return ctrl.Result{
 			RequeueAfter: 5 * time.Second,
 		}, nil

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -367,12 +367,14 @@ func (r *ClusterReconciler) reconcile(ctx context.Context, cluster *apiv1.Cluste
 
 	if cluster.Status.CurrentPrimary != "" &&
 		cluster.Status.CurrentPrimary != cluster.Status.TargetPrimary {
-		// Strip the old primary's label on every pass while failover is
-		// in progress. This is retried each second until it succeeds,
+		// Mark the old primary as unhealthy on every pass while failover is
+		// in progress. This retries each second until it succeeds,
 		// complementing the immediate best-effort attempt in replicas.go.
-		err := r.ensureOldPrimaryLabelIsDemoted(ctx, cluster.Status.CurrentPrimary, resources.instances.Items)
+		err := r.markOldPrimaryAsUnhealthy(ctx, cluster.Status.CurrentPrimary, resources.instances.Items)
 		if err != nil {
-			contextLogger.Error(err, "Failed to strip primary label from old primary",
+			contextLogger.Error(
+				err,
+				"Failed to strip primary label from old primary",
 				"oldPrimary", cluster.Status.CurrentPrimary)
 		}
 

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -370,12 +370,13 @@ func (r *ClusterReconciler) reconcile(ctx context.Context, cluster *apiv1.Cluste
 		// Mark the old primary as unhealthy on every pass while failover is
 		// in progress. This retries each second until it succeeds,
 		// complementing the immediate best-effort attempt in replicas.go.
-		err := r.markOldPrimaryAsUnhealthy(ctx, cluster.Status.CurrentPrimary, resources.instances.Items)
-		if err != nil {
-			contextLogger.Error(
-				err,
-				"Failed to strip primary label from old primary",
-				"oldPrimary", cluster.Status.CurrentPrimary)
+		if err := r.markOldPrimaryAsUnhealthy(
+			ctx, cluster.Status.CurrentPrimary, resources.instances.Items,
+		); err != nil {
+			contextLogger.Warning(
+				"Failed to strip primary label from old primary, will retry",
+				"oldPrimary", cluster.Status.CurrentPrimary,
+				"error", err)
 		}
 
 		contextLogger.Info("There is a switchover or a failover "+

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -423,10 +423,26 @@ func (r *ClusterReconciler) reconcile(ctx context.Context, cluster *apiv1.Cluste
 	if primaryNames := instancesStatus.PrimaryNames(); len(primaryNames) > 1 {
 		contextLogger.Error(
 			errOldPrimaryDetected,
-			"An old primary pod has been detected. Awaiting its recognition of the new role",
+			"An old primary pod has been detected, reconciling metadata",
 			"primaryNames", primaryNames,
 		)
 		instancesStatus.LogStatus(ctx)
+
+		// Reconcile pod labels even during dual-primary detection, so the -rw
+		// service stops routing to the old primary. At this point CurrentPrimary
+		// is already correct (the CurrentPrimary != TargetPrimary guard earlier
+		// in this function ensures they are equal before we reach here), so
+		// updateRoleLabels will set the new primary's label to "primary" and
+		// the old one to "replica".
+		if err := instanceReconciler.ReconcileMetadata(
+			ctx,
+			r.Client,
+			cluster,
+			resources.instances.Items,
+		); err != nil {
+			return ctrl.Result{}, err
+		}
+
 		return ctrl.Result{
 			RequeueAfter: 5 * time.Second,
 		}, nil

--- a/internal/controller/replicas.go
+++ b/internal/controller/replicas.go
@@ -140,6 +140,14 @@ func (r *ClusterReconciler) reconcileTargetPrimaryForNonReplicaCluster(
 		if err != nil {
 			return "", err
 		}
+
+		// Strip the primary label from the old primary pod immediately.
+		// This cuts it off from the -rw service, preventing replicas from
+		// reconnecting to it (primary_conninfo uses <cluster>-rw) and
+		// satisfying the synchronous replication quorum on a stale primary.
+		if err := r.demoteOldPrimaryLabel(ctx, cluster.Status.CurrentPrimary, resources); err != nil {
+			return "", err
+		}
 	}
 
 	// Wait until all the WAL receivers are down. This is needed to avoid losing the WAL
@@ -178,6 +186,32 @@ func (r *ClusterReconciler) reconcileTargetPrimaryForNonReplicaCluster(
 
 	// Set the first pod in the sorted list as the new targetPrimary
 	return mostAdvancedInstance.Pod.Name, r.setPrimaryInstance(ctx, cluster, mostAdvancedInstance.Pod.Name)
+}
+
+// demoteOldPrimaryLabel strips the primary label from the old primary pod,
+// cutting it off from the -rw service when failover starts.
+func (r *ClusterReconciler) demoteOldPrimaryLabel(
+	ctx context.Context,
+	oldPrimaryName string,
+	resources *managedResources,
+) error {
+	contextLogger := log.FromContext(ctx)
+	for i := range resources.instances.Items {
+		pod := &resources.instances.Items[i]
+		if pod.Name != oldPrimaryName {
+			continue
+		}
+
+		contextLogger.Info("Stripping primary label from old primary during failover",
+			"pod", pod.Name)
+		origPod := pod.DeepCopy()
+		utils.SetInstanceRole(pod.ObjectMeta, specs.ClusterRoleLabelReplica)
+		return r.Patch(ctx, pod, client.MergeFrom(origPod))
+	}
+
+	contextLogger.Warning("Old primary pod not found in managed instances, skipping label demotion",
+		"oldPrimary", oldPrimaryName)
+	return nil
 }
 
 // isNodeUnschedulableOrBeingDrained checks if a node is currently being drained.

--- a/internal/controller/replicas.go
+++ b/internal/controller/replicas.go
@@ -383,6 +383,11 @@ func (r *ClusterReconciler) reconcileTargetPrimaryForReplicaCluster(
 		return "", err
 	}
 
+	// Unlike the non-replica path, we do not strip the old primary label here:
+	// a designated primary does not accept application writes via the -rw
+	// service, so the split-brain window #10403 guards against does not
+	// apply. The retryable call in the reconcile loop's failover guard still
+	// relabels the pod on its next pass.
 	return status.Items[0].Pod.Name, r.setPrimaryInstance(ctx, cluster, status.Items[0].Pod.Name)
 }
 

--- a/internal/controller/replicas.go
+++ b/internal/controller/replicas.go
@@ -145,8 +145,16 @@ func (r *ClusterReconciler) reconcileTargetPrimaryForNonReplicaCluster(
 		// This cuts it off from the -rw service, preventing replicas from
 		// reconnecting to it (primary_conninfo uses <cluster>-rw) and
 		// satisfying the synchronous replication quorum on a stale primary.
-		if err := r.demoteOldPrimaryLabel(ctx, cluster.Status.CurrentPrimary, resources); err != nil {
-			return "", err
+		// Best-effort: the failover must proceed even if this fails. The
+		// retryable call in the reconcile loop's failover guard and the
+		// dual-primary detection path will correct labels on subsequent passes.
+		if err := r.ensureOldPrimaryLabelIsDemoted(
+			ctx,
+			cluster.Status.CurrentPrimary,
+			resources.instances.Items,
+		); err != nil {
+			contextLogger.Error(err, "Failed to strip primary label from old primary, continuing with failover",
+				"oldPrimary", cluster.Status.CurrentPrimary)
 		}
 	}
 
@@ -188,30 +196,34 @@ func (r *ClusterReconciler) reconcileTargetPrimaryForNonReplicaCluster(
 	return mostAdvancedInstance.Pod.Name, r.setPrimaryInstance(ctx, cluster, mostAdvancedInstance.Pod.Name)
 }
 
-// demoteOldPrimaryLabel strips the primary label from the old primary pod,
+// ensureOldPrimaryLabelIsDemoted strips the primary label from the old primary pod,
 // cutting it off from the -rw service when failover starts.
-func (r *ClusterReconciler) demoteOldPrimaryLabel(
+func (r *ClusterReconciler) ensureOldPrimaryLabelIsDemoted(
 	ctx context.Context,
 	oldPrimaryName string,
-	resources *managedResources,
+	instances []corev1.Pod,
 ) error {
 	contextLogger := log.FromContext(ctx)
-	for i := range resources.instances.Items {
-		pod := &resources.instances.Items[i]
-		if pod.Name != oldPrimaryName {
-			continue
-		}
 
-		contextLogger.Info("Stripping primary label from old primary during failover",
-			"pod", pod.Name)
-		origPod := pod.DeepCopy()
-		utils.SetInstanceRole(pod.ObjectMeta, specs.ClusterRoleLabelReplica)
-		return r.Patch(ctx, pod, client.MergeFrom(origPod))
+	idx := slices.IndexFunc(instances, func(pod corev1.Pod) bool {
+		return pod.Name == oldPrimaryName
+	})
+	if idx == -1 {
+		contextLogger.Warning("Old primary pod not found in managed instances, skipping label demotion",
+			"oldPrimary", oldPrimaryName)
+		return nil
 	}
 
-	contextLogger.Warning("Old primary pod not found in managed instances, skipping label demotion",
-		"oldPrimary", oldPrimaryName)
-	return nil
+	oldPrimary := &instances[idx]
+	if role, _ := utils.GetInstanceRole(oldPrimary.Labels); role == specs.ClusterRoleLabelReplica {
+		return nil
+	}
+
+	contextLogger.Info("Stripping primary label from old primary during failover",
+		"pod", oldPrimary.Name)
+	origPod := oldPrimary.DeepCopy()
+	utils.SetInstanceRole(oldPrimary.ObjectMeta, specs.ClusterRoleLabelReplica)
+	return r.Patch(ctx, oldPrimary, client.MergeFrom(origPod))
 }
 
 // isNodeUnschedulableOrBeingDrained checks if a node is currently being drained.

--- a/internal/controller/replicas.go
+++ b/internal/controller/replicas.go
@@ -141,14 +141,14 @@ func (r *ClusterReconciler) reconcileTargetPrimaryForNonReplicaCluster(
 			return "", err
 		}
 
-		// Strip the primary label from the old primary pod immediately.
-		// This cuts it off from the -rw service, preventing replicas from
-		// reconnecting to it (primary_conninfo uses <cluster>-rw) and
+		// Mark the old primary as unhealthy immediately when failover starts,
+		// removing it from both the -rw and -ro services. This prevents replicas
+		// from reconnecting to it (primary_conninfo uses <cluster>-rw) and
 		// satisfying the synchronous replication quorum on a stale primary.
 		// Best-effort: the failover must proceed even if this fails. The
-		// retryable call in the reconcile loop's failover guard and the
-		// dual-primary detection path will correct labels on subsequent passes.
-		if err := r.ensureOldPrimaryLabelIsDemoted(
+		// retryable call in the reconcile loop's failover guard will correct
+		// the label on subsequent passes.
+		if err := r.markOldPrimaryAsUnhealthy(
 			ctx,
 			cluster.Status.CurrentPrimary,
 			resources.instances.Items,
@@ -196,9 +196,10 @@ func (r *ClusterReconciler) reconcileTargetPrimaryForNonReplicaCluster(
 	return mostAdvancedInstance.Pod.Name, r.setPrimaryInstance(ctx, cluster, mostAdvancedInstance.Pod.Name)
 }
 
-// ensureOldPrimaryLabelIsDemoted strips the primary label from the old primary pod,
-// cutting it off from the -rw service when failover starts.
-func (r *ClusterReconciler) ensureOldPrimaryLabelIsDemoted(
+// markOldPrimaryAsUnhealthy labels the old primary pod as unhealthy when failover
+// starts, removing it from both the -rw and -ro service selectors until
+// ReconcileMetadata restores the correct label after promotion completes.
+func (r *ClusterReconciler) markOldPrimaryAsUnhealthy(
 	ctx context.Context,
 	oldPrimaryName string,
 	instances []corev1.Pod,
@@ -209,20 +210,22 @@ func (r *ClusterReconciler) ensureOldPrimaryLabelIsDemoted(
 		return pod.Name == oldPrimaryName
 	})
 	if idx == -1 {
-		contextLogger.Warning("Old primary pod not found in managed instances, skipping label demotion",
+		contextLogger.Warning(
+			"Old primary pod not found in managed instances, skipping label demotion",
 			"oldPrimary", oldPrimaryName)
 		return nil
 	}
 
 	oldPrimary := &instances[idx]
-	if role, _ := utils.GetInstanceRole(oldPrimary.Labels); role == specs.ClusterRoleLabelReplica {
+	if role, _ := utils.GetInstanceRole(oldPrimary.Labels); role == specs.ClusterRoleLabelUnhealthy {
 		return nil
 	}
 
-	contextLogger.Info("Stripping primary label from old primary during failover",
+	contextLogger.Info(
+		"Setting primary label to unhealthy in the old primary during failover",
 		"pod", oldPrimary.Name)
 	origPod := oldPrimary.DeepCopy()
-	utils.SetInstanceRole(oldPrimary.ObjectMeta, specs.ClusterRoleLabelReplica)
+	utils.SetInstanceRole(oldPrimary.ObjectMeta, specs.ClusterRoleLabelUnhealthy)
 	return r.Patch(ctx, oldPrimary, client.MergeFrom(origPod))
 }
 

--- a/internal/controller/replicas.go
+++ b/internal/controller/replicas.go
@@ -225,7 +225,7 @@ func (r *ClusterReconciler) markOldPrimaryAsUnhealthy(
 		"Setting primary label to unhealthy in the old primary during failover",
 		"pod", oldPrimary.Name)
 	origPod := oldPrimary.DeepCopy()
-	utils.SetInstanceRole(oldPrimary.ObjectMeta, specs.ClusterRoleLabelUnhealthy)
+	utils.SetInstanceRole(&oldPrimary.ObjectMeta, specs.ClusterRoleLabelUnhealthy)
 	return r.Patch(ctx, oldPrimary, client.MergeFrom(origPod))
 }
 

--- a/internal/controller/replicas_test.go
+++ b/internal/controller/replicas_test.go
@@ -133,7 +133,7 @@ var _ = Describe("Sacrificial Pod detection", func() {
 	})
 })
 
-var _ = Describe("demoteOldPrimaryLabel", func() {
+var _ = Describe("ensureOldPrimaryLabelIsDemoted", func() {
 	var env *testingEnvironment
 
 	BeforeEach(func() {
@@ -171,11 +171,9 @@ var _ = Describe("demoteOldPrimaryLabel", func() {
 			}
 		}
 
-		resources := &managedResources{
-			instances: corev1.PodList{Items: []corev1.Pod{primary, replica1, replica2}},
-		}
+		pods := []corev1.Pod{primary, replica1, replica2}
 
-		err := env.clusterReconciler.demoteOldPrimaryLabel(ctx, "cluster-1", resources)
+		err := env.clusterReconciler.ensureOldPrimaryLabelIsDemoted(ctx, "cluster-1", pods)
 		Expect(err).ToNot(HaveOccurred())
 
 		// Verify the old primary's label was changed to replica on the API server
@@ -198,11 +196,7 @@ var _ = Describe("demoteOldPrimaryLabel", func() {
 		replica := makePod("cluster-2", namespace, specs.ClusterRoleLabelReplica)
 		Expect(env.client.Create(ctx, &replica)).To(Succeed())
 
-		resources := &managedResources{
-			instances: corev1.PodList{Items: []corev1.Pod{replica}},
-		}
-
-		err := env.clusterReconciler.demoteOldPrimaryLabel(ctx, "cluster-1", resources)
+		err := env.clusterReconciler.ensureOldPrimaryLabelIsDemoted(ctx, "cluster-1", []corev1.Pod{replica})
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -213,11 +207,7 @@ var _ = Describe("demoteOldPrimaryLabel", func() {
 		pod := makePod("cluster-1", namespace, specs.ClusterRoleLabelReplica)
 		Expect(env.client.Create(ctx, &pod)).To(Succeed())
 
-		resources := &managedResources{
-			instances: corev1.PodList{Items: []corev1.Pod{pod}},
-		}
-
-		err := env.clusterReconciler.demoteOldPrimaryLabel(ctx, "cluster-1", resources)
+		err := env.clusterReconciler.ensureOldPrimaryLabelIsDemoted(ctx, "cluster-1", []corev1.Pod{pod})
 		Expect(err).ToNot(HaveOccurred())
 
 		var updated corev1.Pod

--- a/internal/controller/replicas_test.go
+++ b/internal/controller/replicas_test.go
@@ -133,7 +133,7 @@ var _ = Describe("Sacrificial Pod detection", func() {
 	})
 })
 
-var _ = Describe("ensureOldPrimaryLabelIsDemoted", func() {
+var _ = Describe("markOldPrimaryAsUnhealthy", func() {
 	var env *testingEnvironment
 
 	BeforeEach(func() {
@@ -154,7 +154,7 @@ var _ = Describe("ensureOldPrimaryLabelIsDemoted", func() {
 		return pod
 	}
 
-	It("strips the primary label from the old primary pod", func() {
+	It("changes the primary label from the old primary pod", func() {
 		ctx := context.Background()
 		namespace := newFakeNamespace(env.client)
 
@@ -173,15 +173,15 @@ var _ = Describe("ensureOldPrimaryLabelIsDemoted", func() {
 
 		pods := []corev1.Pod{primary, replica1, replica2}
 
-		err := env.clusterReconciler.ensureOldPrimaryLabelIsDemoted(ctx, "cluster-1", pods)
+		err := env.clusterReconciler.markOldPrimaryAsUnhealthy(ctx, "cluster-1", pods)
 		Expect(err).ToNot(HaveOccurred())
 
 		// Verify the old primary's label was changed to replica on the API server
 		var updated corev1.Pod
 		Expect(env.client.Get(ctx, client.ObjectKeyFromObject(&primary), &updated)).To(Succeed())
-		Expect(updated.Labels[utils.ClusterInstanceRoleLabelName]).To(Equal(specs.ClusterRoleLabelReplica))
+		Expect(updated.Labels[utils.ClusterInstanceRoleLabelName]).To(Equal(specs.ClusterRoleLabelUnhealthy))
 		//nolint:staticcheck
-		Expect(updated.Labels[utils.ClusterRoleLabelName]).To(Equal(specs.ClusterRoleLabelReplica))
+		Expect(updated.Labels[utils.ClusterRoleLabelName]).To(Equal(specs.ClusterRoleLabelUnhealthy))
 
 		// Verify replica pods are unchanged
 		var replica1Updated corev1.Pod
@@ -196,23 +196,23 @@ var _ = Describe("ensureOldPrimaryLabelIsDemoted", func() {
 		replica := makePod("cluster-2", namespace, specs.ClusterRoleLabelReplica)
 		Expect(env.client.Create(ctx, &replica)).To(Succeed())
 
-		err := env.clusterReconciler.ensureOldPrimaryLabelIsDemoted(ctx, "cluster-1", []corev1.Pod{replica})
+		err := env.clusterReconciler.markOldPrimaryAsUnhealthy(ctx, "cluster-1", []corev1.Pod{replica})
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	It("is a no-op when the old primary already has the replica label", func() {
+	It("is a no-op when the old primary already has the unhealthy label", func() {
 		ctx := context.Background()
 		namespace := newFakeNamespace(env.client)
 
-		pod := makePod("cluster-1", namespace, specs.ClusterRoleLabelReplica)
+		pod := makePod("cluster-1", namespace, specs.ClusterRoleLabelUnhealthy)
 		Expect(env.client.Create(ctx, &pod)).To(Succeed())
 
-		err := env.clusterReconciler.ensureOldPrimaryLabelIsDemoted(ctx, "cluster-1", []corev1.Pod{pod})
+		err := env.clusterReconciler.markOldPrimaryAsUnhealthy(ctx, "cluster-1", []corev1.Pod{pod})
 		Expect(err).ToNot(HaveOccurred())
 
 		var updated corev1.Pod
 		Expect(env.client.Get(ctx, client.ObjectKeyFromObject(&pod), &updated)).To(Succeed())
-		Expect(updated.Labels[utils.ClusterInstanceRoleLabelName]).To(Equal(specs.ClusterRoleLabelReplica))
+		Expect(updated.Labels[utils.ClusterInstanceRoleLabelName]).To(Equal(specs.ClusterRoleLabelUnhealthy))
 	})
 })
 

--- a/internal/controller/replicas_test.go
+++ b/internal/controller/replicas_test.go
@@ -20,11 +20,15 @@ SPDX-License-Identifier: Apache-2.0
 package controller
 
 import (
+	"context"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/postgres"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/specs"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -126,6 +130,99 @@ var _ = Describe("Sacrificial Pod detection", func() {
 		resultName := findDeletableInstance(&apiv1.Cluster{}, podList)
 		Expect(resultName).ToNot(BeEmpty())
 		Expect(resultName).To(Equal("car-2"))
+	})
+})
+
+var _ = Describe("demoteOldPrimaryLabel", func() {
+	var env *testingEnvironment
+
+	BeforeEach(func() {
+		env = buildTestEnvironment()
+	})
+
+	makePod := func(name, namespace, role string) corev1.Pod {
+		pod := corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+				Labels:    map[string]string{},
+			},
+		}
+		if role != "" {
+			utils.SetInstanceRole(pod.ObjectMeta, role)
+		}
+		return pod
+	}
+
+	It("strips the primary label from the old primary pod", func() {
+		ctx := context.Background()
+		namespace := newFakeNamespace(env.client)
+
+		primary := makePod("cluster-1", namespace, specs.ClusterRoleLabelPrimary)
+		replica1 := makePod("cluster-2", namespace, specs.ClusterRoleLabelReplica)
+		replica2 := makePod("cluster-3", namespace, specs.ClusterRoleLabelReplica)
+
+		for i, pod := range []corev1.Pod{primary, replica1, replica2} {
+			p := pod
+			Expect(env.client.Create(ctx, &p)).To(Succeed())
+			// refresh the local copy with server-assigned fields
+			if i == 0 {
+				primary = p
+			}
+		}
+
+		resources := &managedResources{
+			instances: corev1.PodList{Items: []corev1.Pod{primary, replica1, replica2}},
+		}
+
+		err := env.clusterReconciler.demoteOldPrimaryLabel(ctx, "cluster-1", resources)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Verify the old primary's label was changed to replica on the API server
+		var updated corev1.Pod
+		Expect(env.client.Get(ctx, client.ObjectKeyFromObject(&primary), &updated)).To(Succeed())
+		Expect(updated.Labels[utils.ClusterInstanceRoleLabelName]).To(Equal(specs.ClusterRoleLabelReplica))
+		//nolint:staticcheck
+		Expect(updated.Labels[utils.ClusterRoleLabelName]).To(Equal(specs.ClusterRoleLabelReplica))
+
+		// Verify replica pods are unchanged
+		var replica1Updated corev1.Pod
+		Expect(env.client.Get(ctx, client.ObjectKeyFromObject(&replica1), &replica1Updated)).To(Succeed())
+		Expect(replica1Updated.Labels[utils.ClusterInstanceRoleLabelName]).To(Equal(specs.ClusterRoleLabelReplica))
+	})
+
+	It("does not error when the old primary is not in the pod list", func() {
+		ctx := context.Background()
+		namespace := newFakeNamespace(env.client)
+
+		replica := makePod("cluster-2", namespace, specs.ClusterRoleLabelReplica)
+		Expect(env.client.Create(ctx, &replica)).To(Succeed())
+
+		resources := &managedResources{
+			instances: corev1.PodList{Items: []corev1.Pod{replica}},
+		}
+
+		err := env.clusterReconciler.demoteOldPrimaryLabel(ctx, "cluster-1", resources)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("is a no-op when the old primary already has the replica label", func() {
+		ctx := context.Background()
+		namespace := newFakeNamespace(env.client)
+
+		pod := makePod("cluster-1", namespace, specs.ClusterRoleLabelReplica)
+		Expect(env.client.Create(ctx, &pod)).To(Succeed())
+
+		resources := &managedResources{
+			instances: corev1.PodList{Items: []corev1.Pod{pod}},
+		}
+
+		err := env.clusterReconciler.demoteOldPrimaryLabel(ctx, "cluster-1", resources)
+		Expect(err).ToNot(HaveOccurred())
+
+		var updated corev1.Pod
+		Expect(env.client.Get(ctx, client.ObjectKeyFromObject(&pod), &updated)).To(Succeed())
+		Expect(updated.Labels[utils.ClusterInstanceRoleLabelName]).To(Equal(specs.ClusterRoleLabelReplica))
 	})
 })
 

--- a/internal/controller/replicas_test.go
+++ b/internal/controller/replicas_test.go
@@ -176,7 +176,7 @@ var _ = Describe("markOldPrimaryAsUnhealthy", func() {
 		err := env.clusterReconciler.markOldPrimaryAsUnhealthy(ctx, "cluster-1", pods)
 		Expect(err).ToNot(HaveOccurred())
 
-		// Verify the old primary's label was changed to replica on the API server
+		// Verify the old primary's label was changed to unhealthy on the API server
 		var updated corev1.Pod
 		Expect(env.client.Get(ctx, client.ObjectKeyFromObject(&primary), &updated)).To(Succeed())
 		Expect(updated.Labels[utils.ClusterInstanceRoleLabelName]).To(Equal(specs.ClusterRoleLabelUnhealthy))

--- a/internal/controller/replicas_test.go
+++ b/internal/controller/replicas_test.go
@@ -21,10 +21,13 @@ package controller
 
 import (
 	"context"
+	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/postgres"
@@ -213,6 +216,33 @@ var _ = Describe("markOldPrimaryAsUnhealthy", func() {
 		var updated corev1.Pod
 		Expect(env.client.Get(ctx, client.ObjectKeyFromObject(&pod), &updated)).To(Succeed())
 		Expect(updated.Labels[utils.ClusterInstanceRoleLabelName]).To(Equal(specs.ClusterRoleLabelUnhealthy))
+	})
+
+	It("surfaces the Patch error so callers can apply their best-effort or retry strategy", func() {
+		ctx := context.Background()
+		namespace := newFakeNamespace(env.client)
+
+		primary := makePod("cluster-1", namespace, specs.ClusterRoleLabelPrimary)
+
+		failingClient := fake.NewClientBuilder().
+			WithScheme(env.scheme).
+			WithObjects(&primary).
+			WithInterceptorFuncs(interceptor.Funcs{
+				Patch: func(_ context.Context, _ client.WithWatch, obj client.Object,
+					_ client.Patch, _ ...client.PatchOption,
+				) error {
+					Expect(obj).To(BeAssignableToTypeOf(&corev1.Pod{}))
+					Expect(obj.GetName()).To(Equal("cluster-1"))
+					Expect(obj.GetNamespace()).To(Equal(namespace))
+					return fmt.Errorf("simulated API server error")
+				},
+			}).
+			Build()
+
+		r := &ClusterReconciler{Client: failingClient, Scheme: env.scheme}
+
+		err := r.markOldPrimaryAsUnhealthy(ctx, "cluster-1", []corev1.Pod{primary})
+		Expect(err).To(MatchError(ContainSubstring("simulated API server error")))
 	})
 })
 

--- a/internal/controller/replicas_test.go
+++ b/internal/controller/replicas_test.go
@@ -152,7 +152,7 @@ var _ = Describe("markOldPrimaryAsUnhealthy", func() {
 			},
 		}
 		if role != "" {
-			utils.SetInstanceRole(pod.ObjectMeta, role)
+			utils.SetInstanceRole(&pod.ObjectMeta, role)
 		}
 		return pod
 	}

--- a/pkg/reconciler/instance/metadata.go
+++ b/pkg/reconciler/instance/metadata.go
@@ -201,6 +201,11 @@ func updateRoleLabels(
 		}
 
 	default:
+		// This intentionally overwrites the transient ClusterRoleLabelUnhealthy value
+		// that the failover path sets on the old primary. This function is only reached
+		// once CurrentPrimary == TargetPrimary (the failover guard in the reconcile loop
+		// returns early otherwise), so by the time we get here the old primary has been
+		// demoted and "replica" is the correct label.
 		if !hasRole || podRole != specs.ClusterRoleLabelReplica || !newHasRole ||
 			newPodRole != specs.ClusterRoleLabelReplica {
 			contextLogger.Info("Setting replica label", "pod", instance.Name)

--- a/pkg/reconciler/instance/metadata.go
+++ b/pkg/reconciler/instance/metadata.go
@@ -196,7 +196,7 @@ func updateRoleLabels(
 		if !hasRole || podRole != specs.ClusterRoleLabelPrimary || !newHasRole ||
 			newPodRole != specs.ClusterRoleLabelPrimary {
 			contextLogger.Info("Setting primary label", "pod", instance.Name)
-			utils.SetInstanceRole(instance.ObjectMeta, specs.ClusterRoleLabelPrimary)
+			utils.SetInstanceRole(&instance.ObjectMeta, specs.ClusterRoleLabelPrimary)
 			return true
 		}
 
@@ -209,7 +209,7 @@ func updateRoleLabels(
 		if !hasRole || podRole != specs.ClusterRoleLabelReplica || !newHasRole ||
 			newPodRole != specs.ClusterRoleLabelReplica {
 			contextLogger.Info("Setting replica label", "pod", instance.Name)
-			utils.SetInstanceRole(instance.ObjectMeta, specs.ClusterRoleLabelReplica)
+			utils.SetInstanceRole(&instance.ObjectMeta, specs.ClusterRoleLabelReplica)
 			return true
 		}
 	}

--- a/pkg/reconciler/majorupgrade/reconciler.go
+++ b/pkg/reconciler/majorupgrade/reconciler.go
@@ -223,7 +223,7 @@ func createMajorUpgradeJob(
 		cluster.GetFixedInheritedLabels(), configuration.Current)
 	utils.InheritLabels(&job.Spec.Template.ObjectMeta, cluster.Labels,
 		cluster.GetFixedInheritedLabels(), configuration.Current)
-	utils.SetInstanceRole(job.Spec.Template.ObjectMeta, specs.ClusterRoleLabelPrimary)
+	utils.SetInstanceRole(&job.Spec.Template.ObjectMeta, specs.ClusterRoleLabelPrimary)
 
 	contextLogger.Info("Creating new major upgrade Job",
 		"jobName", job.Name,

--- a/pkg/reconciler/persistentvolumeclaim/metadata.go
+++ b/pkg/reconciler/persistentvolumeclaim/metadata.go
@@ -82,6 +82,12 @@ func reconcileInstanceRoleLabel(
 		return nil
 	}
 	for _, instanceName := range cluster.Status.InstanceNames {
+		// Any instance that is not the current primary is classified as replica,
+		// including pods temporarily labeled ClusterRoleLabelUnhealthy during a
+		// failover. That label is transient and only exists while
+		// CurrentPrimary != TargetPrimary; the reconcile loop's failover guard
+		// prevents this code from running during that window, so by the time we
+		// get here the old primary has already been demoted and "replica" is correct.
 		instanceRole := specs.ClusterRoleLabelReplica
 		if instanceName == cluster.Status.CurrentPrimary {
 			instanceRole = specs.ClusterRoleLabelPrimary

--- a/pkg/reconciler/persistentvolumeclaim/metadata.go
+++ b/pkg/reconciler/persistentvolumeclaim/metadata.go
@@ -82,12 +82,11 @@ func reconcileInstanceRoleLabel(
 		return nil
 	}
 	for _, instanceName := range cluster.Status.InstanceNames {
-		// Any instance that is not the current primary is classified as replica,
-		// including pods temporarily labeled ClusterRoleLabelUnhealthy during a
-		// failover. That label is transient and only exists while
-		// CurrentPrimary != TargetPrimary; the reconcile loop's failover guard
-		// prevents this code from running during that window, so by the time we
-		// get here the old primary has already been demoted and "replica" is correct.
+		// PVCs inherit the role label from the instance name, independently of
+		// the pod's current label. The failover guard in the reconcile loop
+		// prevents this code from running while CurrentPrimary != TargetPrimary,
+		// so by the time we get here the old primary has already been demoted
+		// and "replica" is correct.
 		instanceRole := specs.ClusterRoleLabelReplica
 		if instanceName == cluster.Status.CurrentPrimary {
 			instanceRole = specs.ClusterRoleLabelPrimary

--- a/pkg/reconciler/persistentvolumeclaim/metadata.go
+++ b/pkg/reconciler/persistentvolumeclaim/metadata.go
@@ -106,7 +106,7 @@ func reconcileInstanceRoleLabel(
 				return true
 			},
 			update: func(pvc *corev1.PersistentVolumeClaim) {
-				utils.SetInstanceRole(pvc.ObjectMeta, instanceRole)
+				utils.SetInstanceRole(&pvc.ObjectMeta, instanceRole)
 			},
 		}
 

--- a/pkg/specs/pods.go
+++ b/pkg/specs/pods.go
@@ -70,6 +70,9 @@ const (
 	// ClusterRoleLabelReplica is written in labels to represent replica servers
 	ClusterRoleLabelReplica = "replica"
 
+	// ClusterRoleLabelUnhealthy is applied to the old primary when a failover starts.
+	ClusterRoleLabelUnhealthy = "unhealthy"
+
 	// PostgresContainerName is the name of the container executing PostgreSQL
 	// inside one Pod
 	PostgresContainerName = "postgres"

--- a/pkg/utils/labels_annotations.go
+++ b/pkg/utils/labels_annotations.go
@@ -553,7 +553,7 @@ func GetInstanceRole(labels map[string]string) (string, bool) {
 }
 
 // SetInstanceRole sets both ClusterRoleLabelName and ClusterInstanceRoleLabelName on the given ObjectMeta
-func SetInstanceRole(meta metav1.ObjectMeta, role string) {
+func SetInstanceRole(meta *metav1.ObjectMeta, role string) {
 	if meta.Labels == nil {
 		meta.Labels = map[string]string{}
 	}


### PR DESCRIPTION
When the operator initiates a failover, the old primary's pod keeps its `cnpg.io/instanceRole=primary` label until `ReconcileMetadata` runs. But `ReconcileMetadata` is skipped during the entire failover window (the `CurrentPrimary != TargetPrimary` guard returns early), so the `-rw` service keeps routing to the old primary. If the old primary comes back (e.g. after a temporary network partition), replicas reconnect through the `-rw` service, satisfy the sync quorum, and writes committed on the stale primary are lost to `pg_rewind`.

Introduce a third value for the instance role label, `unhealthy`, and apply it to the old primary as soon as failover starts. Since neither the `-rw` nor the `-ro` service selector matches `unhealthy`, the pod is immediately isolated from all service traffic for the duration of the failover window. `ReconcileMetadata` restores the `replica` label once `CurrentPrimary == TargetPrimary`.

The label is applied best-effort at the point where failover is initiated, and re-applied on every pass of the reconcile loop while the failover is in progress so transient API errors are retried automatically.

Note: stripping the label removes the pod from the service Endpoints, but does not drop TCP connections already established by a replica's walreceiver. This fix closes the reconnection window; established connections must still be terminated by the Postgres-level promotion on the new primary.

Closes #10403 