### PR TITLE
fix(plugin-install): anchor checksum grep to exact filename

### DIFF
--- a/hack/install-cnpg-plugin.sh
+++ b/hack/install-cnpg-plugin.sh
@@ -354,7 +354,7 @@ hash_sha256_verify() {
     return 1
   fi
   BASENAME=${TARGET##*/}
-  want=$(grep "${BASENAME}" "${checksums}" 2>/dev/null | tr '\t' ' ' | cut -d ' ' -f 1)
+  want=$(grep "  ${BASENAME}$" "${checksums}" 2>/dev/null | tr '\t' ' ' | cut -d ' ' -f 1)
   if [ -z "$want" ]; then
     log_err "hash_sha256_verify unable to find checksum for '${TARGET}' in '${checksums}'"
     return 1


### PR DESCRIPTION
The checksums file now includes `.sbom.json` entries for each artifact. The unanchored `grep` in `hash_sha256_verify` matched both the tarball and its `.sbom.json` entry, producing a multi-line "want" value that never matched the computed hash, causing the install script to fail with a checksum mismatch error.

Anchor the pattern to the exact filename (`"  ${BASENAME}$"`) to avoid false matches.