### PR TITLE
fix: register the cluster Healthy phase as the last reconciliation step

### DIFF
--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -599,20 +599,9 @@ func (r *ClusterReconciler) reconcile(ctx context.Context, cluster *apiv1.Cluste
 		return res, err
 	}
 
-	// Calls post-reconcile hooks
-	if hookResult := postReconcilePluginHooks(ctx, cluster, cluster); hookResult.Err != nil ||
-		!hookResult.Result.IsZero() {
-		contextLogger.Info("Post-reconcile hook stopped the reconciliation loop",
-			"hookResult", hookResult)
-		return hookResult.Result, hookResult.Err
-	}
-
-	res, err = setStatusPluginHook(ctx, r.Client, cnpgiClient.GetPluginClientFromContext(ctx), cluster)
-	if err != nil || !res.IsZero() {
-		return res, err
-	}
-
-	return ctrl.Result{}, r.RegisterPhase(ctx, cluster, apiv1.PhaseHealthy, "")
+	// Run plugin post-reconcile hooks, sync per-plugin statuses, and
+	// register PhaseHealthy as the LAST status mutation. See #8582.
+	return r.finalizeReconciliation(ctx, cnpgiClient.GetPluginClientFromContext(ctx), cluster)
 }
 
 // evaluatePodReadinessGuards short-circuits the reconciliation loop with a

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -607,7 +607,12 @@ func (r *ClusterReconciler) reconcile(ctx context.Context, cluster *apiv1.Cluste
 		return hookResult.Result, hookResult.Err
 	}
 
-	return setStatusPluginHook(ctx, r.Client, cnpgiClient.GetPluginClientFromContext(ctx), cluster)
+	res, err = setStatusPluginHook(ctx, r.Client, cnpgiClient.GetPluginClientFromContext(ctx), cluster)
+	if err != nil || !res.IsZero() {
+		return res, err
+	}
+
+	return ctrl.Result{}, r.RegisterPhase(ctx, cluster, apiv1.PhaseHealthy, "")
 }
 
 // evaluatePodReadinessGuards short-circuits the reconciliation loop with a
@@ -964,11 +969,6 @@ func (r *ClusterReconciler) reconcileResources(
 	// PhaseInplacePrimaryRestart will be patched to healthy in instance manager
 	if cluster.Status.Phase == apiv1.PhaseInplacePrimaryRestart {
 		return ctrl.Result{RequeueAfter: 1 * time.Second}, ErrNextLoop
-	}
-
-	// When everything is reconciled, update the status
-	if err := r.RegisterPhase(ctx, cluster, apiv1.PhaseHealthy, ""); err != nil {
-		return ctrl.Result{}, err
 	}
 
 	r.cleanupCompletedJobs(ctx, resources.jobs)

--- a/internal/controller/plugins.go
+++ b/internal/controller/plugins.go
@@ -88,3 +88,48 @@ func setStatusPluginHook(
 	}
 	return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 }
+
+// finalizeReconciliation runs the post-reconcile plugin hooks, syncs the
+// per-plugin statuses, and registers PhaseHealthy as the very last status
+// mutation of the reconciliation loop.
+//
+// PhaseHealthy MUST be the final status update of a successful loop. Any
+// later phase patch (e.g. an error path that registers PhaseFailurePlugin)
+// would race with the next reconciliation and oscillate Phase between
+// Healthy and the error phase. See #8582.
+//
+// The result is propagated from the underlying plugin operations so any
+// requeue they request (notably the 5s polling from setStatusPluginHook
+// after a successful status patch) is honored alongside the Healthy
+// registration.
+func (r *ClusterReconciler) finalizeReconciliation(
+	ctx context.Context,
+	pluginClient cnpgiClient.Client,
+	cluster *apiv1.Cluster,
+) (ctrl.Result, error) {
+	contextLogger := log.FromContext(ctx)
+
+	hookResult := pluginClient.PostReconcile(ctx, cluster, cluster)
+	if hookResult.Err != nil || !hookResult.Result.IsZero() {
+		contextLogger.Info("Post-reconcile hook stopped the reconciliation loop",
+			"hookResult", hookResult)
+		if hookResult.Err != nil {
+			return hookResult.Result, hookResult.Err
+		}
+	}
+
+	res := hookResult.Result
+	if res.IsZero() {
+		var err error
+		res, err = setStatusPluginHook(ctx, r.Client, pluginClient, cluster)
+		if err != nil {
+			return res, err
+		}
+	}
+
+	if err := r.RegisterPhase(ctx, cluster, apiv1.PhaseHealthy, ""); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	return res, nil
+}

--- a/internal/controller/plugins.go
+++ b/internal/controller/plugins.go
@@ -95,8 +95,8 @@ func setStatusPluginHook(
 //
 // PhaseHealthy MUST be the final status update of a successful loop. Any
 // later phase patch (e.g. an error path that registers PhaseFailurePlugin)
-// would race with the next reconciliation and oscillate Phase between
-// Healthy and the error phase. See #8582.
+// would be overwritten by the error path on the next reconciliation,
+// oscillating Phase between Healthy and the error phase. See #8582.
 //
 // The result is propagated from the underlying plugin operations so any
 // requeue they request (notably the 5s polling from setStatusPluginHook

--- a/internal/controller/plugins.go
+++ b/internal/controller/plugins.go
@@ -110,12 +110,14 @@ func (r *ClusterReconciler) finalizeReconciliation(
 	contextLogger := log.FromContext(ctx)
 
 	hookResult := pluginClient.PostReconcile(ctx, cluster, cluster)
-	if hookResult.Err != nil || !hookResult.Result.IsZero() {
-		contextLogger.Info("Post-reconcile hook stopped the reconciliation loop",
+	if hookResult.Err != nil {
+		contextLogger.Info("Post-reconcile hook returned an error",
 			"hookResult", hookResult)
-		if hookResult.Err != nil {
-			return hookResult.Result, hookResult.Err
-		}
+		return hookResult.Result, hookResult.Err
+	}
+	if !hookResult.Result.IsZero() {
+		contextLogger.Info("Post-reconcile hook requested a requeue",
+			"hookResult", hookResult)
 	}
 
 	res := hookResult.Result

--- a/internal/controller/plugins_test.go
+++ b/internal/controller/plugins_test.go
@@ -22,8 +22,11 @@ package controller
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
 	k8client "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -37,14 +40,24 @@ import (
 
 type fakePluginClient struct {
 	pluginClient.Client
-	setClusterStatus map[string]string
+	setClusterStatus    map[string]string
+	setClusterStatusErr error
+	postReconcileResult pluginClient.ReconcilerHookResult
 }
 
 func (f *fakePluginClient) SetStatusInCluster(
 	_ context.Context,
 	_ k8client.Object,
 ) (map[string]string, error) {
-	return f.setClusterStatus, nil
+	return f.setClusterStatus, f.setClusterStatusErr
+}
+
+func (f *fakePluginClient) PostReconcile(
+	_ context.Context,
+	_ k8client.Object,
+	_ k8client.Object,
+) pluginClient.ReconcilerHookResult {
+	return f.postReconcileResult
 }
 
 var _ = Describe("setStatusPluginHook", func() {
@@ -86,5 +99,135 @@ var _ = Describe("setStatusPluginHook", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(res).ToNot(BeNil())
 		Expect(cluster.Status.PluginStatus[0].Status).To(BeEquivalentTo(string(content)))
+	})
+})
+
+var _ = Describe("finalizeReconciliation", func() {
+	const pluginName = "test1_plugin"
+	const initialPhase = "InitialPhase"
+
+	var (
+		cluster    *apiv1.Cluster
+		cli        k8client.Client
+		pluginCli  *fakePluginClient
+		reconciler *ClusterReconciler
+	)
+
+	BeforeEach(func() {
+		cluster = &apiv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: "test-suite",
+			},
+			Status: apiv1.ClusterStatus{
+				Phase: initialPhase,
+				PluginStatus: []apiv1.PluginStatus{
+					{Name: pluginName},
+				},
+			},
+		}
+		cli = fake.NewClientBuilder().
+			WithObjects(cluster).
+			WithScheme(scheme.BuildWithAllKnownScheme()).
+			WithStatusSubresource(&apiv1.Cluster{}).
+			Build()
+
+		pluginCli = &fakePluginClient{}
+		reconciler = &ClusterReconciler{
+			Client: cli,
+		}
+	})
+
+	It("registers PhaseHealthy when no plugin sets a status", func(ctx SpecContext) {
+		res, err := reconciler.finalizeReconciliation(ctx, pluginCli, cluster)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(res.IsZero()).To(BeTrue())
+
+		var fresh apiv1.Cluster
+		Expect(cli.Get(ctx, k8client.ObjectKeyFromObject(cluster), &fresh)).To(Succeed())
+		Expect(fresh.Status.Phase).To(Equal(apiv1.PhaseHealthy))
+	})
+
+	It("registers PhaseHealthy and propagates the requeue when plugins patch their statuses", func(ctx SpecContext) {
+		// Regression test for the original PR's `!res.IsZero()` short-circuit:
+		// setStatusPluginHook returns RequeueAfter=5s on every successful
+		// status patch, but that requeue must NOT skip the PhaseHealthy
+		// registration. Otherwise clusters with status-reporting plugins
+		// (e.g. barman-cloud) would never reach Healthy.
+		content, err := json.Marshal(map[string]string{"key": "value"})
+		Expect(err).ToNot(HaveOccurred())
+		pluginCli.setClusterStatus = map[string]string{pluginName: string(content)}
+
+		res, err := reconciler.finalizeReconciliation(ctx, pluginCli, cluster)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(res.RequeueAfter).To(Equal(5 * time.Second))
+
+		var fresh apiv1.Cluster
+		Expect(cli.Get(ctx, k8client.ObjectKeyFromObject(cluster), &fresh)).To(Succeed())
+		Expect(fresh.Status.Phase).To(Equal(apiv1.PhaseHealthy))
+		Expect(fresh.Status.PluginStatus[0].Status).To(BeEquivalentTo(string(content)))
+	})
+
+	It("does not register PhaseHealthy when post-reconcile returns an error", func(ctx SpecContext) {
+		// Regression test for #8582: when a post-reconcile plugin hook
+		// returns an error, the loop must not also mark the cluster
+		// Healthy. Otherwise the next reconciliation overwrites the
+		// PhaseFailurePlugin set by Reconcile()'s error path and the
+		// cluster oscillates between Healthy and FailurePlugin.
+		expectedErr := errors.New("plugin post-reconcile failure")
+		pluginCli.postReconcileResult = pluginClient.ReconcilerHookResult{Err: expectedErr}
+		// Wired up to verify setStatusPluginHook is NOT reached when
+		// post-reconcile errored.
+		pluginCli.setClusterStatus = map[string]string{pluginName: `"unused"`}
+
+		_, err := reconciler.finalizeReconciliation(ctx, pluginCli, cluster)
+
+		Expect(err).To(MatchError(expectedErr))
+
+		var fresh apiv1.Cluster
+		Expect(cli.Get(ctx, k8client.ObjectKeyFromObject(cluster), &fresh)).To(Succeed())
+		Expect(fresh.Status.Phase).To(Equal(initialPhase))
+		Expect(fresh.Status.PluginStatus[0].Status).To(BeEmpty())
+	})
+
+	It("registers PhaseHealthy when post-reconcile requests a requeue without error", func(ctx SpecContext) {
+		// Behavior consistency vs pre-#10421 OLD code, which had set
+		// PhaseHealthy in reconcileResources before the post-reconcile
+		// hook ran. A plugin requesting a requeue (no error) from
+		// PostReconcile must still see the cluster transition to Healthy.
+		pluginCli.postReconcileResult = pluginClient.ReconcilerHookResult{
+			Result: ctrl.Result{RequeueAfter: 30 * time.Second},
+		}
+		// Wired up to verify setStatusPluginHook is NOT called when
+		// post-reconcile already requested a requeue.
+		pluginCli.setClusterStatus = map[string]string{pluginName: `"unused"`}
+
+		res, err := reconciler.finalizeReconciliation(ctx, pluginCli, cluster)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(res.RequeueAfter).To(Equal(30 * time.Second))
+
+		var fresh apiv1.Cluster
+		Expect(cli.Get(ctx, k8client.ObjectKeyFromObject(cluster), &fresh)).To(Succeed())
+		Expect(fresh.Status.Phase).To(Equal(apiv1.PhaseHealthy))
+		Expect(fresh.Status.PluginStatus[0].Status).To(BeEmpty())
+	})
+
+	It("does not register PhaseHealthy when SetStatusInCluster returns an error", func(ctx SpecContext) {
+		expectedErr := errors.New("set status failure")
+		pluginCli.setClusterStatusErr = expectedErr
+
+		_, err := reconciler.finalizeReconciliation(ctx, pluginCli, cluster)
+
+		// errors.Is to ensure the wrap chain is preserved (% w, not % v):
+		// downstream callers depend on Unwrap to classify plugin errors via
+		// cnpgiClient.ContainsPluginError.
+		Expect(errors.Is(err, expectedErr)).To(BeTrue())
+
+		var fresh apiv1.Cluster
+		Expect(cli.Get(ctx, k8client.ObjectKeyFromObject(cluster), &fresh)).To(Succeed())
+		Expect(fresh.Status.Phase).To(Equal(initialPhase))
 	})
 })

--- a/internal/controller/plugins_test.go
+++ b/internal/controller/plugins_test.go
@@ -40,15 +40,17 @@ import (
 
 type fakePluginClient struct {
 	pluginClient.Client
-	setClusterStatus    map[string]string
-	setClusterStatusErr error
-	postReconcileResult pluginClient.ReconcilerHookResult
+	setClusterStatus         map[string]string
+	setClusterStatusErr      error
+	setStatusInClusterCalled bool
+	postReconcileResult      pluginClient.ReconcilerHookResult
 }
 
 func (f *fakePluginClient) SetStatusInCluster(
 	_ context.Context,
 	_ k8client.Object,
 ) (map[string]string, error) {
+	f.setStatusInClusterCalled = true
 	return f.setClusterStatus, f.setClusterStatusErr
 }
 
@@ -150,11 +152,11 @@ var _ = Describe("finalizeReconciliation", func() {
 	})
 
 	It("registers PhaseHealthy and propagates the requeue when plugins patch their statuses", func(ctx SpecContext) {
-		// Regression test for the original PR's `!res.IsZero()` short-circuit:
 		// setStatusPluginHook returns RequeueAfter=5s on every successful
-		// status patch, but that requeue must NOT skip the PhaseHealthy
-		// registration. Otherwise clusters with status-reporting plugins
-		// (e.g. barman-cloud) would never reach Healthy.
+		// status patch. That requeue must NOT short-circuit the PhaseHealthy
+		// registration: clusters with status-reporting plugins (e.g.
+		// barman-cloud) requeue every 5s in steady state and would otherwise
+		// never reach Healthy.
 		content, err := json.Marshal(map[string]string{"key": "value"})
 		Expect(err).ToNot(HaveOccurred())
 		pluginCli.setClusterStatus = map[string]string{pluginName: string(content)}
@@ -178,41 +180,35 @@ var _ = Describe("finalizeReconciliation", func() {
 		// cluster oscillates between Healthy and FailurePlugin.
 		expectedErr := errors.New("plugin post-reconcile failure")
 		pluginCli.postReconcileResult = pluginClient.ReconcilerHookResult{Err: expectedErr}
-		// Wired up to verify setStatusPluginHook is NOT reached when
-		// post-reconcile errored.
-		pluginCli.setClusterStatus = map[string]string{pluginName: `"unused"`}
 
 		_, err := reconciler.finalizeReconciliation(ctx, pluginCli, cluster)
 
 		Expect(err).To(MatchError(expectedErr))
+		// A post-reconcile error must short-circuit before the status sync.
+		Expect(pluginCli.setStatusInClusterCalled).To(BeFalse())
 
 		var fresh apiv1.Cluster
 		Expect(cli.Get(ctx, k8client.ObjectKeyFromObject(cluster), &fresh)).To(Succeed())
 		Expect(fresh.Status.Phase).To(Equal(initialPhase))
-		Expect(fresh.Status.PluginStatus[0].Status).To(BeEmpty())
 	})
 
 	It("registers PhaseHealthy when post-reconcile requests a requeue without error", func(ctx SpecContext) {
-		// Behavior consistency vs pre-#10421 OLD code, which had set
-		// PhaseHealthy in reconcileResources before the post-reconcile
-		// hook ran. A plugin requesting a requeue (no error) from
-		// PostReconcile must still see the cluster transition to Healthy.
+		// A plugin requesting a requeue (no error) from PostReconcile must
+		// still transition the cluster to Healthy, and the status sync is
+		// skipped because the requeue already short-circuits the loop.
 		pluginCli.postReconcileResult = pluginClient.ReconcilerHookResult{
 			Result: ctrl.Result{RequeueAfter: 30 * time.Second},
 		}
-		// Wired up to verify setStatusPluginHook is NOT called when
-		// post-reconcile already requested a requeue.
-		pluginCli.setClusterStatus = map[string]string{pluginName: `"unused"`}
 
 		res, err := reconciler.finalizeReconciliation(ctx, pluginCli, cluster)
 
 		Expect(err).ToNot(HaveOccurred())
 		Expect(res.RequeueAfter).To(Equal(30 * time.Second))
+		Expect(pluginCli.setStatusInClusterCalled).To(BeFalse())
 
 		var fresh apiv1.Cluster
 		Expect(cli.Get(ctx, k8client.ObjectKeyFromObject(cluster), &fresh)).To(Succeed())
 		Expect(fresh.Status.Phase).To(Equal(apiv1.PhaseHealthy))
-		Expect(fresh.Status.PluginStatus[0].Status).To(BeEmpty())
 	})
 
 	It("does not register PhaseHealthy when SetStatusInCluster returns an error", func(ctx SpecContext) {

--- a/internal/controller/plugins_test.go
+++ b/internal/controller/plugins_test.go
@@ -217,7 +217,7 @@ var _ = Describe("finalizeReconciliation", func() {
 
 		_, err := reconciler.finalizeReconciliation(ctx, pluginCli, cluster)
 
-		// errors.Is to ensure the wrap chain is preserved (% w, not % v):
+		// errors.Is to ensure the wrap chain is preserved (%w, not %v):
 		// downstream callers depend on Unwrap to classify plugin errors via
 		// cnpgiClient.ContainsPluginError.
 		Expect(errors.Is(err, expectedErr)).To(BeTrue())


### PR DESCRIPTION
Register the Cluster phase as Healthy as the last status mutation of a successful reconciliation loop.

Previously the phase was set to Healthy mid-loop, before the post-reconcile plugin hooks ran. When a hook then returned an error, the error path set PhaseFailurePlugin, so the phase flipped between Healthy and FailurePlugin and the cluster never settled on a stable phase. Registering Healthy at the end means a loop that ends in a plugin error never reports Healthy.

Healthy is still registered when a plugin only requests a requeue (for example the periodic status sync that requeues every 5s), so clusters with status-reporting plugins still reach Healthy. It is suppressed only when a plugin operation returns an error.

Closes #8582