### PR TITLE
fix(pvc-resize): avoid deadlock on simultaneous storage and resource change

### DIFF
--- a/internal/controller/cluster_controller_test.go
+++ b/internal/controller/cluster_controller_test.go
@@ -273,6 +273,59 @@ var _ = Describe("Updating target primary", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 	})
+
+	It("Issue #9786: findInstancePodToCreate selects podless resizing PVC classified as dangling by EnrichStatus",
+		func(ctx SpecContext) {
+			namespace := newFakeNamespace(env.client)
+			cluster := newFakeCNPGCluster(env.client, namespace, func(cluster *apiv1.Cluster) {
+				cluster.Spec.Instances = 2
+				cluster.Status.LatestGeneratedNode = 2
+				cluster.Status.ReadyInstances = 1
+			})
+
+			By("creating cluster PVCs and marking them as resizing")
+			pvcs := generateClusterPVC(env.client, cluster, persistentvolumeclaim.StatusReady)
+			for i := range pvcs {
+				pvcs[i].Status.Phase = corev1.ClaimBound
+				pvcs[i].Status.Conditions = append(pvcs[i].Status.Conditions, corev1.PersistentVolumeClaimCondition{
+					Type:   corev1.PersistentVolumeClaimResizing,
+					Status: corev1.ConditionTrue,
+				})
+			}
+
+			By("creating a pod for instance 1 only (instance 2's pod was deleted during rolling update)")
+			pod1, err := specs.NewInstance(ctx, *cluster, 1, true)
+			Expect(err).ToNot(HaveOccurred())
+			cluster.SetInheritedDataAndOwnership(&pod1.ObjectMeta)
+			Expect(env.client.Create(ctx, pod1)).To(Succeed())
+			pod1.Status = corev1.PodStatus{
+				Phase: corev1.PodRunning,
+				Conditions: []corev1.PodCondition{
+					{Type: corev1.ContainersReady, Status: corev1.ConditionTrue},
+				},
+			}
+
+			By("running EnrichStatus to classify PVCs")
+			persistentvolumeclaim.EnrichStatus(ctx, cluster, []corev1.Pod{*pod1}, []batchv1.Job{}, pvcs)
+			instance2Name := specs.GetInstanceName(cluster.Name, 2)
+			Expect(cluster.Status.ResizingPVC).Should(HaveLen(1))
+			Expect(cluster.Status.DanglingPVC).Should(Equal([]string{instance2Name}))
+
+			By("verifying findInstancePodToCreate selects the dangling instance for pod creation")
+			statusList := postgres.PostgresqlStatusList{
+				Items: []postgres.PostgresqlStatus{
+					{
+						IsPodReady: true,
+						IsPrimary:  true,
+						Pod:        pod1,
+					},
+				},
+			}
+			instanceToCreate, err := findInstancePodToCreate(ctx, cluster, statusList, pvcs)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(instanceToCreate).ToNot(BeNil())
+			Expect(instanceToCreate.Name).To(Equal(instance2Name))
+		})
 })
 
 var _ = Describe("isNodeUnschedulableOrBeingDrained", func() {

--- a/pkg/reconciler/persistentvolumeclaim/resources.go
+++ b/pkg/reconciler/persistentvolumeclaim/resources.go
@@ -79,10 +79,6 @@ func isResizing(pvc corev1.PersistentVolumeClaim) bool {
 	return hasPVCCondition(pvc, corev1.PersistentVolumeClaimResizing)
 }
 
-func isFileSystemResizePending(pvc corev1.PersistentVolumeClaim) bool {
-	return hasPVCCondition(pvc, corev1.PersistentVolumeClaimFileSystemResizePending)
-}
-
 // BelongToInstance returns a boolean indicating if that given PVC belongs to an instance
 func BelongToInstance(cluster *apiv1.Cluster, instanceName, pvcName string) bool {
 	expectedPVCs := getExpectedInstancePVCNamesFromCluster(cluster, instanceName)

--- a/pkg/reconciler/persistentvolumeclaim/resources_test.go
+++ b/pkg/reconciler/persistentvolumeclaim/resources_test.go
@@ -109,43 +109,7 @@ var _ = Describe("PVCs used by instance", func() {
 	})
 })
 
-var _ = Describe("isFileSystemResizePending", func() {
-	pvcWith := func(conditions ...corev1.PersistentVolumeClaimCondition) corev1.PersistentVolumeClaim {
-		return corev1.PersistentVolumeClaim{
-			Status: corev1.PersistentVolumeClaimStatus{Conditions: conditions},
-		}
-	}
-
-	It("returns false when no conditions are present", func() {
-		Expect(isFileSystemResizePending(pvcWith())).To(BeFalse())
-	})
-
-	It("returns false when only Resizing condition is present", func() {
-		Expect(isFileSystemResizePending(pvcWith(
-			corev1.PersistentVolumeClaimCondition{
-				Type: corev1.PersistentVolumeClaimResizing, Status: corev1.ConditionTrue,
-			},
-		))).To(BeFalse())
-	})
-
-	It("returns true when FileSystemResizePending condition is true", func() {
-		Expect(isFileSystemResizePending(pvcWith(
-			corev1.PersistentVolumeClaimCondition{
-				Type: corev1.PersistentVolumeClaimFileSystemResizePending, Status: corev1.ConditionTrue,
-			},
-		))).To(BeTrue())
-	})
-
-	It("returns false when FileSystemResizePending condition is false", func() {
-		Expect(isFileSystemResizePending(pvcWith(
-			corev1.PersistentVolumeClaimCondition{
-				Type: corev1.PersistentVolumeClaimFileSystemResizePending, Status: corev1.ConditionFalse,
-			},
-		))).To(BeFalse())
-	})
-})
-
-var _ = Describe("PVC classification with FileSystemResizePending", func() {
+var _ = Describe("PVC classification with resizing PVCs", func() {
 	clusterName := "myCluster"
 	makeCluster := func() *apiv1.Cluster {
 		return &apiv1.Cluster{
@@ -164,12 +128,31 @@ var _ = Describe("PVC classification with FileSystemResizePending", func() {
 		Expect(cluster.Status.ResizingPVC).Should(BeEmpty())
 	})
 
-	It("classifies resizing PVC without pod and without FileSystemResizePending as resizing", func(ctx SpecContext) {
+	It("classifies resizing PVC without pod and without FileSystemResizePending as dangling", func(ctx SpecContext) {
 		pvc := makePVC(clusterName, "1", "1", NewPgDataCalculator(), true)
 		cluster := makeCluster()
 		EnrichStatus(ctx, cluster, []corev1.Pod{}, []batchv1.Job{}, []corev1.PersistentVolumeClaim{pvc})
+		Expect(cluster.Status.DanglingPVC).Should(Equal([]string{clusterName + "-1"}))
+		Expect(cluster.Status.ResizingPVC).Should(BeEmpty())
+	})
+
+	It("classifies resizing PVC as dangling when its pod was deleted during rolling update (#9786)", func(ctx SpecContext) {
+		// Simulate simultaneous storage + resource change:
+		// instance-1 has a running pod (primary), instance-2's pod was deleted
+		// for a rolling update while both PVCs are resizing.
+		pvc1 := makePVC(clusterName, "1", "1", NewPgDataCalculator(), true) // resizing, has pod
+		pvc2 := makePVC(clusterName, "2", "2", NewPgDataCalculator(), true) // resizing, pod deleted
+		cluster := makeCluster()
+		EnrichStatus(
+			ctx,
+			cluster,
+			[]corev1.Pod{makePod(clusterName, "1", specs.ClusterRoleLabelPrimary)},
+			[]batchv1.Job{},
+			[]corev1.PersistentVolumeClaim{pvc1, pvc2},
+		)
 		Expect(cluster.Status.ResizingPVC).Should(Equal([]string{clusterName + "-1"}))
-		Expect(cluster.Status.DanglingPVC).Should(BeEmpty())
+		Expect(cluster.Status.DanglingPVC).Should(Equal([]string{clusterName + "-2"}))
+		Expect(cluster.Status.Instances).Should(BeEquivalentTo(2))
 	})
 })
 

--- a/pkg/reconciler/persistentvolumeclaim/resources_test.go
+++ b/pkg/reconciler/persistentvolumeclaim/resources_test.go
@@ -20,67 +20,13 @@ SPDX-License-Identifier: Apache-2.0
 package persistentvolumeclaim
 
 import (
-	batchv1 "k8s.io/api/batch/v1"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
-	"github.com/cloudnative-pg/cloudnative-pg/pkg/specs"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
-
-var _ = Describe("PVC detection", func() {
-	It("will list PVCs with Jobs or Pods or which are Ready", func(ctx SpecContext) {
-		clusterName := "myCluster"
-		makeClusterPVC := func(serial string, isResizing bool) corev1.PersistentVolumeClaim {
-			return makePVC(clusterName, serial, serial, NewPgDataCalculator(), isResizing)
-		}
-		pvcs := []corev1.PersistentVolumeClaim{
-			makeClusterPVC("1", false), // has a Pod
-			makeClusterPVC("2", false), // has a Job
-			makeClusterPVC("3", true),  // resizing
-			makeClusterPVC("4", false), // dangling
-		}
-		cluster := &apiv1.Cluster{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: clusterName,
-			},
-		}
-		EnrichStatus(
-			ctx,
-			cluster,
-			[]corev1.Pod{
-				makePod(clusterName, "1", specs.ClusterRoleLabelPrimary),
-				makePod(clusterName, "3", specs.ClusterRoleLabelReplica),
-			},
-			[]batchv1.Job{makeJob(clusterName, "2")},
-			pvcs,
-		)
-
-		Expect(cluster.Status.PVCCount).Should(BeEquivalentTo(4))
-		Expect(cluster.Status.InstanceNames).Should(Equal([]string{
-			clusterName + "-1",
-			clusterName + "-2",
-			clusterName + "-3",
-			clusterName + "-4",
-		}))
-		Expect(cluster.Status.InitializingPVC).Should(Equal([]string{
-			clusterName + "-2",
-		}))
-		Expect(cluster.Status.ResizingPVC).Should(Equal([]string{
-			clusterName + "-3",
-		}))
-		Expect(cluster.Status.DanglingPVC).Should(Equal([]string{
-			clusterName + "-4",
-		}))
-		Expect(cluster.Status.HealthyPVC).Should(Equal([]string{
-			clusterName + "-1",
-		}))
-		Expect(cluster.Status.UnusablePVC).Should(BeEmpty())
-	})
-})
 
 var _ = Describe("PVCs used by instance", func() {
 	clusterName := "cluster-pvc-instance"
@@ -106,53 +52,6 @@ var _ = Describe("PVCs used by instance", func() {
 	It("fails when trying to get a pvc that doesn't belong to the instance", func() {
 		res := BelongToInstance(cluster, instanceName, instanceName+"-nil")
 		Expect(res).To(BeFalse())
-	})
-})
-
-var _ = Describe("PVC classification with resizing PVCs", func() {
-	clusterName := "myCluster"
-	makeCluster := func() *apiv1.Cluster {
-		return &apiv1.Cluster{
-			ObjectMeta: metav1.ObjectMeta{Name: clusterName},
-		}
-	}
-
-	It("classifies resizing PVC without pod and with FileSystemResizePending as dangling", func(ctx SpecContext) {
-		pvc := makePVC(clusterName, "1", "1", NewPgDataCalculator(), true)
-		pvc.Status.Conditions = append(pvc.Status.Conditions, corev1.PersistentVolumeClaimCondition{
-			Type: corev1.PersistentVolumeClaimFileSystemResizePending, Status: corev1.ConditionTrue,
-		})
-		cluster := makeCluster()
-		EnrichStatus(ctx, cluster, []corev1.Pod{}, []batchv1.Job{}, []corev1.PersistentVolumeClaim{pvc})
-		Expect(cluster.Status.DanglingPVC).Should(Equal([]string{clusterName + "-1"}))
-		Expect(cluster.Status.ResizingPVC).Should(BeEmpty())
-	})
-
-	It("classifies resizing PVC without pod and without FileSystemResizePending as dangling", func(ctx SpecContext) {
-		pvc := makePVC(clusterName, "1", "1", NewPgDataCalculator(), true)
-		cluster := makeCluster()
-		EnrichStatus(ctx, cluster, []corev1.Pod{}, []batchv1.Job{}, []corev1.PersistentVolumeClaim{pvc})
-		Expect(cluster.Status.DanglingPVC).Should(Equal([]string{clusterName + "-1"}))
-		Expect(cluster.Status.ResizingPVC).Should(BeEmpty())
-	})
-
-	It("classifies resizing PVC as dangling when its pod was deleted during rolling update (#9786)", func(ctx SpecContext) {
-		// Simulate simultaneous storage + resource change:
-		// instance-1 has a running pod (primary), instance-2's pod was deleted
-		// for a rolling update while both PVCs are resizing.
-		pvc1 := makePVC(clusterName, "1", "1", NewPgDataCalculator(), true) // resizing, has pod
-		pvc2 := makePVC(clusterName, "2", "2", NewPgDataCalculator(), true) // resizing, pod deleted
-		cluster := makeCluster()
-		EnrichStatus(
-			ctx,
-			cluster,
-			[]corev1.Pod{makePod(clusterName, "1", specs.ClusterRoleLabelPrimary)},
-			[]batchv1.Job{},
-			[]corev1.PersistentVolumeClaim{pvc1, pvc2},
-		)
-		Expect(cluster.Status.ResizingPVC).Should(Equal([]string{clusterName + "-1"}))
-		Expect(cluster.Status.DanglingPVC).Should(Equal([]string{clusterName + "-2"}))
-		Expect(cluster.Status.Instances).Should(BeEquivalentTo(2))
 	})
 })
 

--- a/pkg/reconciler/persistentvolumeclaim/status.go
+++ b/pkg/reconciler/persistentvolumeclaim/status.go
@@ -62,7 +62,8 @@ const (
 	// List of PVCs that are being initialized (they have a corresponding Job but not a corresponding Pod)
 	initializing status = "initializing"
 
-	// List of PVCs with resizing condition. Requires a pod restart.
+	// List of PVCs with resizing condition that have a running pod.
+	// Podless resizing PVCs are classified as dangling instead (see #9786).
 	//
 	// INFO: https://kubernetes.io/blog/2018/07/12/resizing-persistent-volumes-using-kubernetes/
 	resizing status = "resizing"
@@ -269,16 +270,16 @@ func classifyPVC(
 		return healthy
 	}
 
-	// PVC is resizing without a pod
+	// PVC is resizing without a pod — classify as dangling so a pod is
+	// created.  This is safe because volumes remain usable during
+	// expansion, and filesystem resize actually requires a mounted pod
+	// (kubelet performs it).  Without this, a simultaneous storage +
+	// resource change can leave the PVC orphaned as "resizing" while the
+	// rolling-update-deleted pod is never recreated (see #9786).
 	if isResizing(pvc) {
-		// Filesystem resize requires a pod mount to complete; classify as
-		// dangling so the reconciler creates one.
-		if isFileSystemResizePending(pvc) {
-			log.FromContext(ctx).Info("PVC filesystem resize pending without a pod, classifying as dangling",
-				"pvc", pvc.Name)
-			return dangling
-		}
-		return resizing
+		log.FromContext(ctx).Info("PVC resizing without a pod, classifying as dangling",
+			"pvc", pvc.Name)
+		return dangling
 	}
 
 	// PVC has a corresponding Job but not a corresponding Pod

--- a/pkg/reconciler/persistentvolumeclaim/status.go
+++ b/pkg/reconciler/persistentvolumeclaim/status.go
@@ -270,12 +270,17 @@ func classifyPVC(
 		return healthy
 	}
 
-	// PVC is resizing without a pod, classify as dangling so a pod is
-	// created.  This is safe because volumes remain usable during
-	// expansion, and filesystem resize actually requires a mounted pod
-	// (kubelet performs it).  Without this, a simultaneous storage +
-	// resource change can leave the PVC orphaned as "resizing" while the
-	// rolling-update-deleted pod is never recreated (see #9786).
+	// A resizing PVC without a pod must be classified as dangling so the
+	// reconciler recreates the pod. Two reasons:
+	//
+	//   1. Filesystem resize requires a mounted pod — kubelet performs it on mount.
+	//
+	//   2. Without a pod, the "resizing" classification is a dead end: a
+	//      simultaneous storage + resource change would leave the PVC orphaned
+	//      because the rolling-update-deleted pod is never recreated (see #9786).
+	//
+	// For online-expandable volumes reason 1 does not apply, but reason 2 still
+	// does; classifying as dangling is always safe here.
 	if isResizing(pvc) {
 		log.FromContext(ctx).Info("PVC resizing without a pod, classifying as dangling",
 			"pvc", pvc.Name)

--- a/pkg/reconciler/persistentvolumeclaim/status.go
+++ b/pkg/reconciler/persistentvolumeclaim/status.go
@@ -270,7 +270,7 @@ func classifyPVC(
 		return healthy
 	}
 
-	// PVC is resizing without a pod — classify as dangling so a pod is
+	// PVC is resizing without a pod, classify as dangling so a pod is
 	// created.  This is safe because volumes remain usable during
 	// expansion, and filesystem resize actually requires a mounted pod
 	// (kubelet performs it).  Without this, a simultaneous storage +

--- a/pkg/reconciler/persistentvolumeclaim/status.go
+++ b/pkg/reconciler/persistentvolumeclaim/status.go
@@ -62,7 +62,7 @@ const (
 	// List of PVCs that are being initialized (they have a corresponding Job but not a corresponding Pod)
 	initializing status = "initializing"
 
-	// List of PVCs with resizing condition that have a running pod.
+	// List of PVCs with resizing condition that have a corresponding pod.
 	// Podless resizing PVCs are classified as dangling instead (see #9786).
 	//
 	// INFO: https://kubernetes.io/blog/2018/07/12/resizing-persistent-volumes-using-kubernetes/

--- a/pkg/reconciler/persistentvolumeclaim/status_test.go
+++ b/pkg/reconciler/persistentvolumeclaim/status_test.go
@@ -31,11 +31,110 @@ import (
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/internal/scheme"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/specs"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
+
+var _ = Describe("PVC detection", func() {
+	It("will list PVCs with Jobs or Pods or which are Ready", func(ctx SpecContext) {
+		clusterName := "myCluster"
+		makeClusterPVC := func(serial string, isResizing bool) corev1.PersistentVolumeClaim {
+			return makePVC(clusterName, serial, serial, NewPgDataCalculator(), isResizing)
+		}
+		pvcs := []corev1.PersistentVolumeClaim{
+			makeClusterPVC("1", false), // has a Pod
+			makeClusterPVC("2", false), // has a Job
+			makeClusterPVC("3", true),  // resizing
+			makeClusterPVC("4", false), // dangling
+		}
+		cluster := &apiv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: clusterName,
+			},
+		}
+		EnrichStatus(
+			ctx,
+			cluster,
+			[]corev1.Pod{
+				makePod(clusterName, "1", specs.ClusterRoleLabelPrimary),
+				makePod(clusterName, "3", specs.ClusterRoleLabelReplica),
+			},
+			[]batchv1.Job{makeJob(clusterName, "2")},
+			pvcs,
+		)
+
+		Expect(cluster.Status.PVCCount).Should(BeEquivalentTo(4))
+		Expect(cluster.Status.InstanceNames).Should(Equal([]string{
+			clusterName + "-1",
+			clusterName + "-2",
+			clusterName + "-3",
+			clusterName + "-4",
+		}))
+		Expect(cluster.Status.InitializingPVC).Should(Equal([]string{
+			clusterName + "-2",
+		}))
+		Expect(cluster.Status.ResizingPVC).Should(Equal([]string{
+			clusterName + "-3",
+		}))
+		Expect(cluster.Status.DanglingPVC).Should(Equal([]string{
+			clusterName + "-4",
+		}))
+		Expect(cluster.Status.HealthyPVC).Should(Equal([]string{
+			clusterName + "-1",
+		}))
+		Expect(cluster.Status.UnusablePVC).Should(BeEmpty())
+	})
+})
+
+var _ = Describe("PVC classification with resizing PVCs", func() {
+	clusterName := "myCluster"
+	makeCluster := func() *apiv1.Cluster {
+		return &apiv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{Name: clusterName},
+		}
+	}
+
+	It("classifies resizing PVC without pod and with FileSystemResizePending as dangling", func(ctx SpecContext) {
+		pvc := makePVC(clusterName, "1", "1", NewPgDataCalculator(), true)
+		pvc.Status.Conditions = append(pvc.Status.Conditions, corev1.PersistentVolumeClaimCondition{
+			Type: corev1.PersistentVolumeClaimFileSystemResizePending, Status: corev1.ConditionTrue,
+		})
+		cluster := makeCluster()
+		EnrichStatus(ctx, cluster, []corev1.Pod{}, []batchv1.Job{}, []corev1.PersistentVolumeClaim{pvc})
+		Expect(cluster.Status.DanglingPVC).Should(Equal([]string{clusterName + "-1"}))
+		Expect(cluster.Status.ResizingPVC).Should(BeEmpty())
+	})
+
+	It("classifies resizing PVC without pod and without FileSystemResizePending as dangling", func(ctx SpecContext) {
+		pvc := makePVC(clusterName, "1", "1", NewPgDataCalculator(), true)
+		cluster := makeCluster()
+		EnrichStatus(ctx, cluster, []corev1.Pod{}, []batchv1.Job{}, []corev1.PersistentVolumeClaim{pvc})
+		Expect(cluster.Status.DanglingPVC).Should(Equal([]string{clusterName + "-1"}))
+		Expect(cluster.Status.ResizingPVC).Should(BeEmpty())
+	})
+
+	It("classifies resizing PVC as dangling when pod was deleted during rollout (#9786)", func(ctx SpecContext) {
+		// Simulate simultaneous storage + resource change:
+		// instance-1 has a running pod (primary), instance-2's pod was deleted
+		// for a rolling update while both PVCs are resizing.
+		pvc1 := makePVC(clusterName, "1", "1", NewPgDataCalculator(), true) // resizing, has pod
+		pvc2 := makePVC(clusterName, "2", "2", NewPgDataCalculator(), true) // resizing, pod deleted
+		cluster := makeCluster()
+		EnrichStatus(
+			ctx,
+			cluster,
+			[]corev1.Pod{makePod(clusterName, "1", specs.ClusterRoleLabelPrimary)},
+			[]batchv1.Job{},
+			[]corev1.PersistentVolumeClaim{pvc1, pvc2},
+		)
+		Expect(cluster.Status.ResizingPVC).Should(Equal([]string{clusterName + "-1"}))
+		Expect(cluster.Status.DanglingPVC).Should(Equal([]string{clusterName + "-2"}))
+		Expect(cluster.Status.Instances).Should(BeEquivalentTo(2))
+	})
+})
 
 var _ = Describe("EnsureHealthyPVCsAnnotation", func() {
 	var (

--- a/pkg/reconciler/persistentvolumeclaim/status_test.go
+++ b/pkg/reconciler/persistentvolumeclaim/status_test.go
@@ -47,7 +47,7 @@ var _ = Describe("PVC detection", func() {
 		pvcs := []corev1.PersistentVolumeClaim{
 			makeClusterPVC("1", false), // has a Pod
 			makeClusterPVC("2", false), // has a Job
-			makeClusterPVC("3", true),  // resizing
+			makeClusterPVC("3", true),  // resizing, has a Pod so stays "resizing" (not affected by #9786 fix)
 			makeClusterPVC("4", false), // dangling
 		}
 		cluster := &apiv1.Cluster{
@@ -114,6 +114,23 @@ var _ = Describe("PVC classification with resizing PVCs", func() {
 		EnrichStatus(ctx, cluster, []corev1.Pod{}, []batchv1.Job{}, []corev1.PersistentVolumeClaim{pvc})
 		Expect(cluster.Status.DanglingPVC).Should(Equal([]string{clusterName + "-1"}))
 		Expect(cluster.Status.ResizingPVC).Should(BeEmpty())
+	})
+
+	// isResizing check takes precedence over hasJob: a resizing PVC with
+	// a Job but no Pod is classified as dangling, not initializing.
+	It("classifies resizing PVC with a job but no pod as dangling", func(ctx SpecContext) {
+		pvc := makePVC(clusterName, "1", "1", NewPgDataCalculator(), true)
+		cluster := makeCluster()
+		EnrichStatus(
+			ctx,
+			cluster,
+			[]corev1.Pod{},
+			[]batchv1.Job{makeJob(clusterName, "1")},
+			[]corev1.PersistentVolumeClaim{pvc},
+		)
+		Expect(cluster.Status.DanglingPVC).Should(Equal([]string{clusterName + "-1"}))
+		Expect(cluster.Status.ResizingPVC).Should(BeEmpty())
+		Expect(cluster.Status.InitializingPVC).Should(BeEmpty())
 	})
 
 	It("classifies resizing PVC as dangling when pod was deleted during rollout (#9786)", func(ctx SpecContext) {


### PR DESCRIPTION
When both storage.size and resources are changed in a single patch, the operator resizes PVCs and then immediately starts a rolling update that deletes a pod. The orphaned PVC was classified as "resizing" instead of "dangling", preventing the pod from being recreated and leaving the cluster stuck.

Fix by always classifying podless resizing PVCs as "dangling" so a replacement pod is created. This is safe because volumes are usable during expansion and filesystem resize requires a mounted pod anyway.

Also remove the now-unused isFileSystemResizePending helper, which was only called from the removed conditional branch in classifyPVC.

Closes #9786 