### PR TITLE
docs: remove obsolete `--enable-leader-election` flag reference

### DIFF
--- a/docs/src/operator_conf.md
+++ b/docs/src/operator_conf.md
@@ -169,7 +169,7 @@ Add `--pprof-server=true` to the args list, for example:
       containers:
       - args:
         - controller
-        - --enable-leader-election
+        - --leader-elect
         - --config-map-name=cnpg-controller-manager-config
         - --secret-name=cnpg-controller-manager-config
         - --log-level=info


### PR DESCRIPTION
The `operator_conf.md` page mentions `--enable-leader-election` in the pprof YAML example; however, this flag was renamed to `--leader-elect` in release 1.17.0. As a result, users following the documentation to enable high availability for the operator may encounter a `CrashLoopBackOff` without any visible error messages.

Fixes #10431

Signed-off-by: gabriele.quaresima@enterprisedb.com