### PR TITLE
fix: avoid spurious failovers when the primary status endpoint fails transiently

### DIFF
--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -621,7 +621,7 @@ func (r *ClusterReconciler) evaluatePodReadinessGuards(
 			"instanceName", firstInstance.Pod.Name,
 			"hasHTTPStatus", hasHTTPStatus,
 			"isPodReady", isPodReady)
-		return &ctrl.Result{RequeueAfter: 1 * time.Second}
+		return &ctrl.Result{RequeueAfter: 10 * time.Second}
 	}
 
 	if cluster.Status.CurrentPrimary != "" &&
@@ -630,7 +630,7 @@ func (r *ClusterReconciler) evaluatePodReadinessGuards(
 		contextLogger.Info(
 			"Primary pod is ready but status endpoint is failing, requeueing",
 			"primaryPodName", cluster.Status.CurrentPrimary)
-		return &ctrl.Result{RequeueAfter: 1 * time.Second}
+		return &ctrl.Result{RequeueAfter: 10 * time.Second}
 	}
 
 	return nil

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -505,50 +505,8 @@ func (r *ClusterReconciler) reconcile(ctx context.Context, cluster *apiv1.Cluste
 		return ctrl.Result{}, err
 	}
 
-	// The instance list is sorted and will present the primary as the first
-	// element, followed by the replicas, the most updated coming first.
-	// Pods that are not responding will be at the end of the list. We use
-	// the information reported by the instance manager to sort the
-	// instances. When we need to elect a new primary, we take the first item
-	// on this list.
-	//
-	// Here we check the readiness status of the first Pod as we can't
-	// promote an instance that is not ready from the Kubernetes
-	// point-of-view: the services will not forward traffic to it even if
-	// PostgreSQL is up and running.
-	//
-	// An instance can be up and running even if the readiness probe is
-	// negative: this is going to happen, i.e., when an instance is
-	// un-fenced, and the Kubelet still hasn't refreshed the status of the
-	// readiness probe.
-	if instancesStatus.Len() > 0 {
-		mostAdvancedInstance := instancesStatus.Items[0]
-		hasHTTPStatus := mostAdvancedInstance.HasHTTPStatus()
-		isPodReady := mostAdvancedInstance.IsPodReady
-
-		if hasHTTPStatus && !isPodReady {
-			// The readiness probe status from the Kubelet is not updated, so
-			// we need to wait for it to be refreshed
-			contextLogger.Info(
-				"Waiting for the Kubelet to refresh the readiness probe",
-				"mostAdvancedInstanceName", mostAdvancedInstance.Pod.Name,
-				"hasHTTPStatus", hasHTTPStatus,
-				"isPodReady", isPodReady)
-			return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
-		}
-
-		// If the current primary is ready from the Kubernetes perspective but
-		// its status endpoint is failing, the failure is likely transient (e.g.
-		// a network hiccup between the operator and the pod). Requeue instead
-		// of proceeding with a potentially spurious failover.
-		if cluster.Status.CurrentPrimary != "" &&
-			cluster.Status.CurrentPrimary == cluster.Status.TargetPrimary &&
-			instancesStatus.IsPodReadyAndNotReporting(cluster.Status.CurrentPrimary) {
-			contextLogger.Info(
-				"Primary pod is ready but status endpoint is failing, requeueing",
-				"primaryPodName", cluster.Status.CurrentPrimary)
-			return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
-		}
+	if res := r.evaluatePodReadinessGuards(ctx, cluster, instancesStatus); res != nil {
+		return *res, nil
 	}
 
 	// If the user has requested to hibernate the cluster, we do that before
@@ -609,6 +567,71 @@ func (r *ClusterReconciler) reconcile(ctx context.Context, cluster *apiv1.Cluste
 	}
 
 	return setStatusPluginHook(ctx, r.Client, cnpgiClient.GetPluginClientFromContext(ctx), cluster)
+}
+
+// evaluatePodReadinessGuards short-circuits the reconciliation loop with a
+// requeue when the readiness information reported by the instance managers is
+// not consistent with a promotion or failover being safe.
+//
+// We can only promote an instance that is Ready from the Kubernetes point of
+// view, otherwise the services will not route traffic to it even if PostgreSQL
+// is up and running. Two cases are covered:
+//
+//   - The first element of the (post-sort) instance list is reporting a
+//     healthy /pg/status but the kubelet has not yet refreshed the readiness
+//     probe (typical after un-fencing an instance). Wait for the kubelet to
+//     catch up rather than electing a new primary that will immediately be
+//     unreachable.
+//
+//   - The current primary is Ready from the kubelet's perspective, but the
+//     operator's call to /pg/status is failing. The sort in PostgresqlStatusList
+//     pushes the primary to the tail when its endpoint errors, so Items[0]
+//     becomes a healthy replica and the usual failover-election path would
+//     promote it. Since a successful /pg/status implies a passing readiness
+//     probe but not vice versa, a failing /pg/status on an otherwise Ready pod
+//     is a strong signal of a transient condition (e.g. a network hiccup
+//     between the operator and the pod) rather than a genuine PostgreSQL
+//     health problem. Requeue and wait for the next reconciliation rather than
+//     triggering a spurious failover.
+//
+// Returns nil when the caller can proceed with the rest of the reconciliation.
+func (r *ClusterReconciler) evaluatePodReadinessGuards(
+	ctx context.Context,
+	cluster *apiv1.Cluster,
+	instancesStatus postgres.PostgresqlStatusList,
+) *ctrl.Result {
+	if instancesStatus.Len() == 0 {
+		return nil
+	}
+
+	contextLogger := log.FromContext(ctx)
+
+	firstInstance := instancesStatus.Items[0]
+	hasHTTPStatus := firstInstance.HasHTTPStatus()
+	isPodReady := firstInstance.IsPodReady
+
+	if hasHTTPStatus && !isPodReady {
+		// The readiness probe status from the kubelet has not been refreshed
+		// yet, so we wait rather than electing a primary that Kubernetes will
+		// refuse to route traffic to.
+		contextLogger.Info(
+			"Waiting for the Kubelet to refresh the readiness probe",
+			"instanceName", firstInstance.Pod.Name,
+			"hasHTTPStatus", hasHTTPStatus,
+			"isPodReady", isPodReady)
+		return &ctrl.Result{RequeueAfter: 1 * time.Second}
+	}
+
+	if cluster.Status.CurrentPrimary != "" &&
+		cluster.Status.CurrentPrimary == cluster.Status.TargetPrimary &&
+		instancesStatus.IsPodReadyAndNotReporting(cluster.Status.CurrentPrimary) {
+		contextLogger.Info(
+			"Primary pod is ready but status endpoint is failing, requeueing",
+			"primaryPodName", cluster.Status.CurrentPrimary)
+		return &ctrl.Result{RequeueAfter: 1 * time.Second}
+	}
+
+	return nil
 }
 
 func (r *ClusterReconciler) ensureNoFailoverOnFullDisk(

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -571,28 +571,30 @@ func (r *ClusterReconciler) reconcile(ctx context.Context, cluster *apiv1.Cluste
 
 // evaluatePodReadinessGuards short-circuits the reconciliation loop with a
 // requeue when the readiness information reported by the instance managers is
-// not consistent with a promotion or failover being safe.
+// not consistent with a promotion or failover being safe. We can only promote
+// an instance that is Ready from the Kubernetes point of view, otherwise the
+// read-write service will not route traffic to it even if PostgreSQL is up
+// and running.
 //
-// We can only promote an instance that is Ready from the Kubernetes point of
-// view, otherwise the services will not route traffic to it even if PostgreSQL
-// is up and running. Two cases are covered:
+// Two branches are checked in order:
 //
-//   - The first element of the (post-sort) instance list is reporting a
-//     healthy /pg/status but the kubelet has not yet refreshed the readiness
-//     probe (typical after un-fencing an instance). Wait for the kubelet to
-//     catch up rather than electing a new primary that will immediately be
-//     unreachable.
+//   - Kubelet has not refreshed the readiness probe yet. The first element of
+//     the (post-sort) instance list is reporting a healthy /pg/status but the
+//     kubelet has not yet flipped the readiness probe to True (typical for a
+//     short window after un-fencing an instance). Waiting here prevents
+//     electing a primary that Kubernetes will refuse to route traffic to.
 //
-//   - The current primary is Ready from the kubelet's perspective, but the
-//     operator's call to /pg/status is failing. The sort in PostgresqlStatusList
-//     pushes the primary to the tail when its endpoint errors, so Items[0]
-//     becomes a healthy replica and the usual failover-election path would
-//     promote it. Since a successful /pg/status implies a passing readiness
-//     probe but not vice versa, a failing /pg/status on an otherwise Ready pod
-//     is a strong signal of a transient condition (e.g. a network hiccup
-//     between the operator and the pod) rather than a genuine PostgreSQL
-//     health problem. Requeue and wait for the next reconciliation rather than
-//     triggering a spurious failover.
+//   - Primary pod is Ready but its /pg/status endpoint is failing. A failing
+//     /pg/status on an otherwise Ready pod usually indicates an
+//     operator-to-pod connectivity issue rather than a genuine PostgreSQL
+//     health problem. The operator trusts the kubelet's readiness probe as
+//     the source of truth and defers its own failover decision until
+//     Kubernetes agrees the primary is not Ready.
+//
+//     Without this branch the failover-election path would promote the
+//     healthiest replica: PostgresqlStatusList.Less pushes items with an
+//     Error to the tail, so the erroring primary ends up behind a healthy
+//     replica at Items[0] and gets supplanted on a mere network hiccup.
 //
 // Returns nil when the caller can proceed with the rest of the reconciliation.
 func (r *ClusterReconciler) evaluatePodReadinessGuards(

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -536,6 +536,19 @@ func (r *ClusterReconciler) reconcile(ctx context.Context, cluster *apiv1.Cluste
 				"isPodReady", isPodReady)
 			return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
 		}
+
+		// If the current primary is ready from the Kubernetes perspective but
+		// its status endpoint is failing, the failure is likely transient (e.g.
+		// a network hiccup between the operator and the pod). Requeue instead
+		// of proceeding with a potentially spurious failover.
+		if cluster.Status.CurrentPrimary != "" &&
+			cluster.Status.CurrentPrimary == cluster.Status.TargetPrimary &&
+			instancesStatus.IsPodReadyAndNotReporting(cluster.Status.CurrentPrimary) {
+			contextLogger.Info(
+				"Primary pod is ready but status endpoint is failing, requeueing",
+				"primaryPodName", cluster.Status.CurrentPrimary)
+			return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
+		}
 	}
 
 	// If the user has requested to hibernate the cluster, we do that before

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -627,7 +627,7 @@ func (r *ClusterReconciler) evaluatePodReadinessGuards(
 	if cluster.Status.CurrentPrimary != "" &&
 		cluster.Status.CurrentPrimary == cluster.Status.TargetPrimary &&
 		instancesStatus.IsPodReadyAndNotReporting(cluster.Status.CurrentPrimary) {
-		contextLogger.Info(
+		contextLogger.Warning(
 			"Primary pod is ready but status endpoint is failing, requeueing",
 			"primaryPodName", cluster.Status.CurrentPrimary)
 		return &ctrl.Result{RequeueAfter: 10 * time.Second}

--- a/internal/controller/cluster_controller_test.go
+++ b/internal/controller/cluster_controller_test.go
@@ -20,11 +20,13 @@ SPDX-License-Identifier: Apache-2.0
 package controller
 
 import (
+	"fmt"
 	"time"
 
 	cnpgTypes "github.com/cloudnative-pg/machinery/pkg/types"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -366,4 +368,49 @@ var _ = Describe("isNodeUnschedulableOrBeingDrained", func() {
 		Entry("node is tainted", nodeTainted, true),
 		Entry("node has an unknown taint", nodeWithUnknownTaint, false),
 	)
+})
+
+var _ = Describe("evaluatePodReadinessGuards", func() {
+	const (
+		primaryName = "cluster-1"
+		replicaName = "cluster-2"
+	)
+
+	var (
+		env     *testingEnvironment
+		cluster *apiv1.Cluster
+	)
+
+	BeforeEach(func() {
+		env = buildTestEnvironment()
+		namespace := newFakeNamespace(env.client)
+		cluster = newFakeCNPGCluster(env.client, namespace)
+		cluster.Status.CurrentPrimary = primaryName
+		cluster.Status.TargetPrimary = primaryName
+	})
+
+	It("requeues when the primary is Ready but /pg/status is failing", func(ctx SpecContext) {
+		// Mirror what the production sort does: an erroring instance is
+		// pushed below the healthy ones, so Items[0] is a healthy replica
+		// and the erroring primary is in the tail. Without the guard, the
+		// election logic would then pick the replica as the new primary.
+		statusList := postgres.PostgresqlStatusList{
+			Items: []postgres.PostgresqlStatus{
+				{
+					Pod:        &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: replicaName}},
+					IsPodReady: true,
+				},
+				{
+					Pod:        &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: primaryName}},
+					IsPodReady: true,
+					Error:      fmt.Errorf("status endpoint failing"),
+				},
+			},
+		}
+
+		result := env.clusterReconciler.evaluatePodReadinessGuards(ctx, cluster, statusList)
+
+		Expect(result).NotTo(BeNil())
+		Expect(result.RequeueAfter).To(Equal(1 * time.Second))
+	})
 })

--- a/internal/controller/cluster_controller_test.go
+++ b/internal/controller/cluster_controller_test.go
@@ -434,7 +434,7 @@ var _ = Describe("evaluatePodReadinessGuards", func() {
 
 			if requeue {
 				Expect(result).NotTo(BeNil())
-				Expect(result.RequeueAfter).To(Equal(1 * time.Second))
+				Expect(result.RequeueAfter).To(Equal(10 * time.Second))
 			} else {
 				Expect(result).To(BeNil())
 			}
@@ -498,6 +498,6 @@ var _ = Describe("evaluatePodReadinessGuards", func() {
 
 		result := env.clusterReconciler.evaluatePodReadinessGuards(ctx, cluster, statusList)
 		Expect(result).NotTo(BeNil())
-		Expect(result.RequeueAfter).To(Equal(1 * time.Second))
+		Expect(result.RequeueAfter).To(Equal(10 * time.Second))
 	})
 })

--- a/internal/controller/cluster_controller_test.go
+++ b/internal/controller/cluster_controller_test.go
@@ -21,6 +21,7 @@ package controller
 
 import (
 	"fmt"
+	"sort"
 	"time"
 
 	cnpgTypes "github.com/cloudnative-pg/machinery/pkg/types"
@@ -372,8 +373,9 @@ var _ = Describe("isNodeUnschedulableOrBeingDrained", func() {
 
 var _ = Describe("evaluatePodReadinessGuards", func() {
 	const (
-		primaryName = "cluster-1"
-		replicaName = "cluster-2"
+		primaryName    = "cluster-1"
+		replicaName    = "cluster-2"
+		newPrimaryName = "cluster-3"
 	)
 
 	var (
@@ -385,31 +387,116 @@ var _ = Describe("evaluatePodReadinessGuards", func() {
 		env = buildTestEnvironment()
 		namespace := newFakeNamespace(env.client)
 		cluster = newFakeCNPGCluster(env.client, namespace)
-		cluster.Status.CurrentPrimary = primaryName
-		cluster.Status.TargetPrimary = primaryName
 	})
 
-	It("requeues when the primary is Ready but /pg/status is failing", func(ctx SpecContext) {
-		// Mirror what the production sort does: an erroring instance is
-		// pushed below the healthy ones, so Items[0] is a healthy replica
-		// and the erroring primary is in the tail. Without the guard, the
-		// election logic would then pick the replica as the new primary.
+	errStatusFailing := fmt.Errorf("status endpoint failing")
+
+	readyReportingReplica := postgres.PostgresqlStatus{
+		Pod:        &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: replicaName}},
+		IsPodReady: true,
+	}
+	readyReportingPrimary := postgres.PostgresqlStatus{
+		Pod:        &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: primaryName}},
+		IsPodReady: true,
+	}
+	readyErroringPrimary := postgres.PostgresqlStatus{
+		Pod:        &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: primaryName}},
+		IsPodReady: true,
+		Error:      errStatusFailing,
+	}
+	unreadyErroringPrimary := postgres.PostgresqlStatus{
+		Pod:        &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: primaryName}},
+		IsPodReady: false,
+		Error:      errStatusFailing,
+	}
+	readyErroringReplica := postgres.PostgresqlStatus{
+		Pod:        &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: replicaName}},
+		IsPodReady: true,
+		Error:      errStatusFailing,
+	}
+	// kubeletStaleReporting is the "kubelet has not refreshed the probe yet"
+	// shape: instance manager reports success (Error==nil, so HasHTTPStatus
+	// returns true) but the pod is not yet Ready from the kubelet.
+	kubeletStaleReporting := postgres.PostgresqlStatus{
+		Pod:        &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: primaryName}},
+		IsPodReady: false,
+	}
+
+	DescribeTable(
+		"guards behaviour",
+		func(ctx SpecContext, currentPrimary, targetPrimary string, items []postgres.PostgresqlStatus, requeue bool) {
+			cluster.Status.CurrentPrimary = currentPrimary
+			cluster.Status.TargetPrimary = targetPrimary
+
+			result := env.clusterReconciler.evaluatePodReadinessGuards(
+				ctx, cluster, postgres.PostgresqlStatusList{Items: items},
+			)
+
+			if requeue {
+				Expect(result).NotTo(BeNil())
+				Expect(result.RequeueAfter).To(Equal(1 * time.Second))
+			} else {
+				Expect(result).To(BeNil())
+			}
+		},
+		Entry("happy path: primary Ready and reporting, no guard fires",
+			primaryName, primaryName,
+			[]postgres.PostgresqlStatus{readyReportingPrimary, readyReportingReplica}, false),
+		Entry("kubelet has not refreshed the readiness probe yet",
+			primaryName, primaryName,
+			[]postgres.PostgresqlStatus{kubeletStaleReporting, readyReportingReplica}, true),
+		Entry("transient /pg/status failure on Ready primary requeues",
+			primaryName, primaryName,
+			[]postgres.PostgresqlStatus{readyReportingReplica, readyErroringPrimary}, true),
+		Entry("guard is scoped to steady-state (CurrentPrimary == TargetPrimary)",
+			primaryName, newPrimaryName,
+			[]postgres.PostgresqlStatus{readyReportingReplica, readyErroringPrimary}, false),
+		Entry("bootstrap: no primary elected yet",
+			"", "",
+			[]postgres.PostgresqlStatus{}, false),
+		Entry("primary absent from status list (defensive)",
+			primaryName, primaryName,
+			[]postgres.PostgresqlStatus{readyReportingReplica}, false),
+		Entry("current primary set but target primary cleared: guard does not fire",
+			primaryName, "",
+			[]postgres.PostgresqlStatus{readyReportingPrimary, readyErroringReplica}, false),
+		Entry("erroring replica with reporting primary does not fire the guard",
+			primaryName, primaryName,
+			[]postgres.PostgresqlStatus{readyReportingPrimary, readyErroringReplica}, false),
+		Entry("primary unready and not reporting (genuine failover case)",
+			primaryName, primaryName,
+			[]postgres.PostgresqlStatus{readyReportingReplica, unreadyErroringPrimary}, false),
+		Entry("empty status list",
+			primaryName, primaryName,
+			[]postgres.PostgresqlStatus{}, false),
+	)
+
+	It("fires after the production sort pushes the erroring primary to the tail", func(ctx SpecContext) {
+		// Build the list in "primary first" order as the instance manager
+		// would populate it, then rely on PostgresqlStatusList.Less to push
+		// the erroring primary to the tail. This locks the guard's
+		// rationale against a regression in the sort.
 		statusList := postgres.PostgresqlStatusList{
 			Items: []postgres.PostgresqlStatus{
+				{
+					Pod:        &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: primaryName}},
+					IsPodReady: true,
+					Error:      errStatusFailing,
+				},
 				{
 					Pod:        &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: replicaName}},
 					IsPodReady: true,
 				},
-				{
-					Pod:        &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: primaryName}},
-					IsPodReady: true,
-					Error:      fmt.Errorf("status endpoint failing"),
-				},
 			},
 		}
+		sort.Sort(&statusList)
+		Expect(statusList.Items[0].Pod.Name).To(Equal(replicaName),
+			"sort must push the erroring primary to the tail")
+
+		cluster.Status.CurrentPrimary = primaryName
+		cluster.Status.TargetPrimary = primaryName
 
 		result := env.clusterReconciler.evaluatePodReadinessGuards(ctx, cluster, statusList)
-
 		Expect(result).NotTo(BeNil())
 		Expect(result.RequeueAfter).To(Equal(1 * time.Second))
 	})

--- a/pkg/postgres/status.go
+++ b/pkg/postgres/status.go
@@ -357,6 +357,9 @@ func (list PostgresqlStatusList) IsPodReporting(podname string) bool {
 // via the /pg/status endpoint. This indicates a likely transient failure
 // (e.g. a network hiccup between the operator and the pod) rather than a
 // genuine PostgreSQL health problem.
+//
+// "Not reporting" is the negation of IsPodReporting: the /pg/status call
+// against the pod returned an error.
 func (list PostgresqlStatusList) IsPodReadyAndNotReporting(podname string) bool {
 	for _, item := range list.Items {
 		if item.Pod.Name == podname {

--- a/pkg/postgres/status.go
+++ b/pkg/postgres/status.go
@@ -352,6 +352,21 @@ func (list PostgresqlStatusList) IsPodReporting(podname string) bool {
 	return false
 }
 
+// IsPodReadyAndNotReporting returns true if the pod with the given name is
+// marked as ready by the kubelet but is not successfully reporting its status
+// via the /pg/status endpoint. This indicates a likely transient failure
+// (e.g. a network hiccup between the operator and the pod) rather than a
+// genuine PostgreSQL health problem.
+func (list PostgresqlStatusList) IsPodReadyAndNotReporting(podname string) bool {
+	for _, item := range list.Items {
+		if item.Pod.Name == podname {
+			return item.IsPodReady && item.Error != nil
+		}
+	}
+
+	return false
+}
+
 // IsComplete checks the PostgreSQL status list for Pods which
 // contain errors. Returns true if everything is green and
 // false otherwise

--- a/pkg/postgres/status_test.go
+++ b/pkg/postgres/status_test.go
@@ -239,6 +239,46 @@ var _ = Describe("PostgreSQL status real", func() {
 	})
 })
 
+var _ = Describe("IsPodReadyAndNotReporting", func() {
+	errStatusEndpointFailing := fmt.Errorf("status endpoint failing")
+
+	podList := PostgresqlStatusList{
+		Items: []PostgresqlStatus{
+			{
+				Pod:        &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "primary"}},
+				IsPodReady: true,
+				Error:      errStatusEndpointFailing,
+			},
+			{
+				Pod:        &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "replica-reporting"}},
+				IsPodReady: true,
+				Error:      nil,
+			},
+			{
+				Pod:        &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "replica-not-ready"}},
+				IsPodReady: false,
+				Error:      errStatusEndpointFailing,
+			},
+		},
+	}
+
+	It("returns true when the pod is ready but the status endpoint is failing", func() {
+		Expect(podList.IsPodReadyAndNotReporting("primary")).To(BeTrue())
+	})
+
+	It("returns false when the pod is ready and reporting", func() {
+		Expect(podList.IsPodReadyAndNotReporting("replica-reporting")).To(BeFalse())
+	})
+
+	It("returns false when the pod is not ready and not reporting", func() {
+		Expect(podList.IsPodReadyAndNotReporting("replica-not-ready")).To(BeFalse())
+	})
+
+	It("returns false when the pod is not in the list", func() {
+		Expect(podList.IsPodReadyAndNotReporting("unknown")).To(BeFalse())
+	})
+})
+
 var _ = Describe("Configuration report", func() {
 	DescribeTable(
 		"Configuration report",


### PR DESCRIPTION
When the operator calls /pg/status on the primary during a reconciliation loop and the request fails, a failover could be triggered even if the primary pod was still Ready from the kubelet's perspective.

Since a successful /pg/status implies a passing readiness probe but not vice versa, a failing /pg/status on an otherwise Ready pod is a strong signal of a transient condition (e.g. a network hiccup between the operator and the pod) rather than a genuine PostgreSQL health problem.

The reconciliation loop now requeues instead of proceeding when the current primary equals the target primary, the pod is Ready, but /pg/status is failing, applying the same conservative approach already used when the kubelet has not yet refreshed a positive readiness probe.

A follow-up PR (#10509) will surface the deferred failover as a cluster phase so the state is visible via `kubectl get cluster`.

See #10403 
