### PR TITLE
fix: trigger failover when the primary node becomes unreachable

### DIFF
--- a/api/v1/base_funcs_test.go
+++ b/api/v1/base_funcs_test.go
@@ -71,7 +71,7 @@ var _ = Describe("Properly builds ListStatusPods", func() {
 		Status: corev1.PodStatus{
 			Conditions: []corev1.PodCondition{
 				{
-					Type:   corev1.ContainersReady,
+					Type:   corev1.PodReady,
 					Status: corev1.ConditionTrue,
 				},
 			},
@@ -85,7 +85,7 @@ var _ = Describe("Properly builds ListStatusPods", func() {
 			Phase: corev1.PodRunning,
 			Conditions: []corev1.PodCondition{
 				{
-					Type:   corev1.ContainersReady,
+					Type:   corev1.PodReady,
 					Status: corev1.ConditionFalse,
 				},
 			},
@@ -99,7 +99,7 @@ var _ = Describe("Properly builds ListStatusPods", func() {
 			Phase: corev1.PodFailed,
 			Conditions: []corev1.PodCondition{
 				{
-					Type:   corev1.ContainersReady,
+					Type:   corev1.PodReady,
 					Status: corev1.ConditionFalse,
 				},
 			},
@@ -116,7 +116,7 @@ var _ = Describe("Properly builds ListStatusPods", func() {
 			Phase: corev1.PodRunning,
 			Conditions: []corev1.PodCondition{
 				{
-					Type:   corev1.ContainersReady,
+					Type:   corev1.PodReady,
 					Status: corev1.ConditionTrue,
 				},
 			},

--- a/docs/src/failover.md
+++ b/docs/src/failover.md
@@ -103,6 +103,44 @@ expected outage.
 Enabling a new configuration option to delay failover provides a mechanism to
 prevent premature failover for short-lived network or node instability.
 
+## Detection of node-level failures
+
+When the node hosting the primary becomes unreachable (for example, due to a
+kubelet crash or a network partition between the node and the Kubernetes API
+server), the operator relies on the pod's `Ready` condition to decide that the
+primary is no longer serviceable. While the node is healthy the kubelet keeps
+that condition up to date from the readiness probe; once the node stops
+reporting, the Kubernetes node lifecycle controller is the one that flips the
+condition to `False` (reason `NodeNotReady`) as soon as it declares the node
+`Unknown`.
+
+With stock kube-controller-manager settings, the transition is governed by
+`--node-monitor-grace-period` (default `40s`): after that window the controller
+marks the node `Unknown` and, in the same monitoring pass, issues a patch per
+pod on that node to flip the `Ready` condition. In practice the operator
+observes the primary as unready about **40 to 45 seconds** after the node
+becomes unreachable (the grace period plus up to one `--node-monitor-period`
+poll, default `5s`), after which the failover procedure starts (further gated
+by `.spec.failoverDelay`). Managed Kubernetes
+distributions (GKE, EKS, AKS) may tune these values; consult the provider's
+documentation if the observed timing does not match.
+
+The `Ready` condition flip is not subject to the rate limiters that throttle
+pod *eviction* during partial-zonal or large-cluster disruptions
+(`--node-eviction-rate`, `--secondary-node-eviction-rate`,
+`--unhealthy-zone-threshold`). The operator reacts to the condition flip as
+soon as the controller emits the patch, regardless of the zone or cluster-wide
+health state.
+
+Pod *eviction* (actual deletion from the unreachable node) is a separate
+mechanism, driven by `tolerationSeconds` on the
+`node.kubernetes.io/unreachable:NoExecute` taint (`300s` by default). That
+timer does not hold up the operator's failover decision; CloudNativePG
+promotes a new primary as soon as the `Ready` condition flips, while the old
+pod is still present on the unreachable node. Full high availability
+(recreation of the old primary on a healthy node by the operator) is only
+restored once the taint-based eviction actually deletes the pod.
+
 ## Failover Quorum (Quorum-based Failover)
 
 Failover quorum is a mechanism that enhances data durability and safety during

--- a/docs/src/failover.md
+++ b/docs/src/failover.md
@@ -111,19 +111,19 @@ server), the operator relies on the pod's `Ready` condition to decide that the
 primary is no longer serviceable. While the node is healthy the kubelet keeps
 that condition up to date from the readiness probe; once the node stops
 reporting, the Kubernetes node lifecycle controller is the one that flips the
-condition to `False` (reason `NodeNotReady`) as soon as it declares the node
-`Unknown`.
+condition to `False` as soon as it declares the node `Unknown`.
 
 With stock kube-controller-manager settings, the transition is governed by
-`--node-monitor-grace-period` (default `40s`): after that window the controller
-marks the node `Unknown` and, in the same monitoring pass, issues a patch per
-pod on that node to flip the `Ready` condition. In practice the operator
-observes the primary as unready about **40 to 45 seconds** after the node
-becomes unreachable (the grace period plus up to one `--node-monitor-period`
-poll, default `5s`), after which the failover procedure starts (further gated
-by `.spec.failoverDelay`). Managed Kubernetes
-distributions (GKE, EKS, AKS) may tune these values; consult the provider's
-documentation if the observed timing does not match.
+`--node-monitor-grace-period` (default `40s` on Kubernetes 1.29-1.31, raised
+to `50s` in 1.32 and later): after that window the controller marks the node
+`Unknown` and, in the same monitoring pass, issues a patch per pod on that
+node to flip the `Ready` condition. In practice the operator observes the
+primary as unready about **40 to 55 seconds** after the node becomes
+unreachable (the grace period plus up to one `--node-monitor-period` poll,
+default `5s`). Managed Kubernetes distributions (GKE, EKS, AKS) may tune
+these values; consult the provider's documentation if the observed timing
+does not match. After that, the failover procedure starts (further gated by
+`.spec.failoverDelay`).
 
 The `Ready` condition flip is not subject to the rate limiters that throttle
 pod *eviction* during partial-zonal or large-cluster disruptions
@@ -134,12 +134,17 @@ health state.
 
 Pod *eviction* (actual deletion from the unreachable node) is a separate
 mechanism, driven by `tolerationSeconds` on the
-`node.kubernetes.io/unreachable:NoExecute` taint (`300s` by default). That
+`node.kubernetes.io/unreachable` `NoExecute` taint (`300s` by default). That
 timer does not hold up the operator's failover decision; CloudNativePG
-promotes a new primary as soon as the `Ready` condition flips, while the old
-pod is still present on the unreachable node. Full high availability
-(recreation of the old primary on a healthy node by the operator) is only
-restored once the taint-based eviction actually deletes the pod.
+promotes a new primary as soon as the `Ready` condition flips. By that point
+the kubelet on the isolated node has already stopped the old PostgreSQL
+container locally: with the default
+`.spec.probes.liveness.isolationCheck.enabled: true`, the instance manager
+fails its own liveness probe once it can reach neither the API server nor
+the rest of the cluster, and the kubelet kills the container within
+approximately three probe periods (`~30s`). Full high availability
+(recreation of the old primary on a healthy node by the operator) is still
+gated on the taint-based eviction actually deleting the pod.
 
 ## Failover Quorum (Quorum-based Failover)
 

--- a/internal/controller/replicas_test.go
+++ b/internal/controller/replicas_test.go
@@ -111,6 +111,31 @@ var _ = Describe("Sacrificial Pod detection", func() {
 		},
 	}
 
+	// unreachable mimics a Pod whose node has stopped reporting to the API
+	// server: the node lifecycle controller flips PodReady to False, but the
+	// stale ContainersReady left by the kubelet remains True.
+	unreachable := corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "unreachable",
+			Namespace: "default",
+			Annotations: map[string]string{
+				utils.ClusterSerialAnnotationName: "5",
+			},
+		},
+		Status: corev1.PodStatus{
+			Conditions: []corev1.PodCondition{
+				{
+					Type:   corev1.ContainersReady,
+					Status: corev1.ConditionTrue,
+				},
+				{
+					Type:   corev1.PodReady,
+					Status: corev1.ConditionFalse,
+				},
+			},
+		},
+	}
+
 	It("detects if the list of Pods is empty", func() {
 		var podList []corev1.Pod
 		Expect(findDeletableInstance(&apiv1.Cluster{}, podList)).To(BeEmpty())
@@ -132,6 +157,12 @@ var _ = Describe("Sacrificial Pod detection", func() {
 		podList := []corev1.Pod{car2, foo, bar, car1}
 		resultName := findDeletableInstance(&apiv1.Cluster{}, podList)
 		Expect(resultName).ToNot(BeEmpty())
+		Expect(resultName).To(Equal("car-2"))
+	})
+
+	It("skips a Pod whose node is unreachable even if it has the highest serial", func() {
+		podList := []corev1.Pod{car1, car2, unreachable}
+		resultName := findDeletableInstance(&apiv1.Cluster{}, podList)
 		Expect(resultName).To(Equal("car-2"))
 	})
 })

--- a/internal/controller/replicas_test.go
+++ b/internal/controller/replicas_test.go
@@ -50,7 +50,7 @@ var _ = Describe("Sacrificial Pod detection", func() {
 		Status: corev1.PodStatus{
 			Conditions: []corev1.PodCondition{
 				{
-					Type:   corev1.ContainersReady,
+					Type:   corev1.PodReady,
 					Status: corev1.ConditionTrue,
 				},
 			},
@@ -68,7 +68,7 @@ var _ = Describe("Sacrificial Pod detection", func() {
 		Status: corev1.PodStatus{
 			Conditions: []corev1.PodCondition{
 				{
-					Type:   corev1.ContainersReady,
+					Type:   corev1.PodReady,
 					Status: corev1.ConditionTrue,
 				},
 			},
@@ -86,7 +86,7 @@ var _ = Describe("Sacrificial Pod detection", func() {
 		Status: corev1.PodStatus{
 			Conditions: []corev1.PodCondition{
 				{
-					Type:   corev1.ContainersReady,
+					Type:   corev1.PodReady,
 					Status: corev1.ConditionFalse,
 				},
 			},
@@ -104,7 +104,7 @@ var _ = Describe("Sacrificial Pod detection", func() {
 		Status: corev1.PodStatus{
 			Conditions: []corev1.PodCondition{
 				{
-					Type:   corev1.ContainersReady,
+					Type:   corev1.PodReady,
 					Status: corev1.ConditionFalse,
 				},
 			},

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -333,7 +333,7 @@ func generateFakeClusterPods(
 				Phase: corev1.PodRunning,
 				Conditions: []corev1.PodCondition{
 					{
-						Type:   corev1.ContainersReady,
+						Type:   corev1.PodReady,
 						Status: corev1.ConditionTrue,
 					},
 				},

--- a/pkg/postgres/status.go
+++ b/pkg/postgres/status.go
@@ -92,12 +92,14 @@ type PostgresqlStatus struct {
 	// allowing detection of restarts that don't change the container ID or executable hash.
 	SessionID string `json:"sessionID"`
 
-	// This field represents the Kubelet point-of-view of the readiness
-	// status of this instance and may be slightly stale when the Kubelet has
-	// not still invoked the readiness probe.
+	// IsPodReady mirrors the Pod's PodReady condition, as set by the kubelet
+	// while the node is healthy and by the node lifecycle controller once the
+	// node stops reporting. It is a readiness signal driven by the readiness
+	// probe plus any readiness gates, so it may be briefly stale compared to
+	// the actual PostgreSQL state.
 	//
-	// If you want to check the latest detected status of PostgreSQL, you
-	// need to call HasHTTPStatus().
+	// For the latest PostgreSQL health as seen by the instance manager, use
+	// HasHTTPStatus() instead.
 	//
 	// This field is never populated in the instance manager.
 	IsPodReady bool `json:"isPodReady"`

--- a/pkg/reconciler/backup/volumesnapshot/offline_test.go
+++ b/pkg/reconciler/backup/volumesnapshot/offline_test.go
@@ -53,7 +53,7 @@ var _ = Describe("offlineExecutor", func() {
 			Status: corev1.PodStatus{
 				Conditions: []corev1.PodCondition{
 					{
-						Type:   corev1.ContainersReady,
+						Type:   corev1.PodReady,
 						Status: corev1.ConditionTrue,
 					},
 				},

--- a/pkg/utils/pod_conditions.go
+++ b/pkg/utils/pod_conditions.go
@@ -26,7 +26,31 @@ import (
 
 var utilsLog = log.WithName("utils")
 
-// IsPodReady check if a Pod is ready or not
+// IsPodReady reports whether the Pod has its PodReady condition set to True.
+//
+// The PodReady condition is kept up-to-date by two independent control-plane
+// actors:
+//
+//   - the kubelet on the pod's node, while the node is healthy: the transition
+//     from True to False happens within FailureThreshold consecutive probe
+//     periods of the underlying container becoming unhealthy (about 30s with
+//     CNPG defaults: PeriodSeconds=10, FailureThreshold=3).
+//   - the node lifecycle controller when the node stops reporting to the API
+//     server; once the node transitions to `Unknown` (after
+//     `--node-monitor-grace-period`, 40s by default) the controller calls
+//     `MarkPodsNotReady`, which synchronously sets PodReady to False with
+//     reason `NodeNotReady` on every pod of that node. With stock defaults the
+//     operator observes the flip about 40 to 45 seconds after the node becomes
+//     unreachable.
+//
+// Note that `tolerationSeconds` on the `node.kubernetes.io/unreachable` taint
+// (300s by default) controls pod eviction, not this condition: PodReady has
+// already flipped to False well before eviction happens.
+//
+// This helper is the source of truth for "is this pod serviceable right now?"
+// across the operator: failover election, backup target selection,
+// failover-quorum reachability, offline volume-snapshot fencing, and
+// user-visible cluster health classification.
 func IsPodReady(pod corev1.Pod) bool {
 	for _, c := range pod.Status.Conditions {
 		if c.Type == corev1.PodReady && c.Status == corev1.ConditionTrue {

--- a/pkg/utils/pod_conditions.go
+++ b/pkg/utils/pod_conditions.go
@@ -29,7 +29,7 @@ var utilsLog = log.WithName("utils")
 // IsPodReady check if a Pod is ready or not
 func IsPodReady(pod corev1.Pod) bool {
 	for _, c := range pod.Status.Conditions {
-		if c.Type == corev1.ContainersReady && c.Status == corev1.ConditionTrue {
+		if c.Type == corev1.PodReady && c.Status == corev1.ConditionTrue {
 			return true
 		}
 	}

--- a/pkg/utils/pod_conditions.go
+++ b/pkg/utils/pod_conditions.go
@@ -34,14 +34,14 @@ var utilsLog = log.WithName("utils")
 //   - the kubelet on the pod's node, while the node is healthy: the transition
 //     from True to False happens within FailureThreshold consecutive probe
 //     periods of the underlying container becoming unhealthy (about 30s with
-//     CNPG defaults: PeriodSeconds=10, FailureThreshold=3).
+//     stock defaults: PeriodSeconds=10, FailureThreshold=3).
 //   - the node lifecycle controller when the node stops reporting to the API
 //     server; once the node transitions to `Unknown` (after
-//     `--node-monitor-grace-period`, 40s by default) the controller calls
-//     `MarkPodsNotReady`, which synchronously sets PodReady to False with
-//     reason `NodeNotReady` on every pod of that node. With stock defaults the
-//     operator observes the flip about 40 to 45 seconds after the node becomes
-//     unreachable.
+//     `--node-monitor-grace-period`, 40s by default on Kubernetes 1.29-1.31
+//     and 50s on 1.32+) the controller calls `MarkPodsNotReady`, which flips
+//     PodReady to False on every pod of that node. With stock defaults the
+//     operator observes the flip about 40 to 55 seconds after the node
+//     becomes unreachable.
 //
 // Note that `tolerationSeconds` on the `node.kubernetes.io/unreachable` taint
 // (300s by default) controls pod eviction, not this condition: PodReady has

--- a/pkg/utils/pod_conditions.go
+++ b/pkg/utils/pod_conditions.go
@@ -34,7 +34,8 @@ var utilsLog = log.WithName("utils")
 //   - the kubelet on the pod's node, while the node is healthy: the transition
 //     from True to False happens within FailureThreshold consecutive probe
 //     periods of the underlying container becoming unhealthy (about 30s with
-//     stock defaults: PeriodSeconds=10, FailureThreshold=3).
+//     stock defaults: PeriodSeconds=10, FailureThreshold=3, unless the user
+//     overrides them via `.spec.probes.readiness`).
 //   - the node lifecycle controller when the node stops reporting to the API
 //     server; once the node transitions to `Unknown` (after
 //     `--node-monitor-grace-period`, 40s by default on Kubernetes 1.29-1.31

--- a/pkg/utils/pod_conditions_test.go
+++ b/pkg/utils/pod_conditions_test.go
@@ -43,7 +43,7 @@ var _ = Describe("Pod conditions test suite", func() {
 				Status: corev1.PodStatus{
 					Conditions: []corev1.PodCondition{
 						{
-							Type:   corev1.ContainersReady,
+							Type:   corev1.PodReady,
 							Status: corev1.ConditionTrue,
 						},
 					},
@@ -57,7 +57,7 @@ var _ = Describe("Pod conditions test suite", func() {
 				Status: corev1.PodStatus{
 					Conditions: []corev1.PodCondition{
 						{
-							Type:   corev1.ContainersReady,
+							Type:   corev1.PodReady,
 							Status: corev1.ConditionFalse,
 						},
 					},
@@ -80,7 +80,7 @@ var _ = Describe("Pod conditions test suite", func() {
 				Status: corev1.PodStatus{
 					Conditions: []corev1.PodCondition{
 						{
-							Type:   corev1.ContainersReady,
+							Type:   corev1.PodReady,
 							Status: corev1.ConditionTrue,
 						},
 					},
@@ -95,7 +95,7 @@ var _ = Describe("Pod conditions test suite", func() {
 				Status: corev1.PodStatus{
 					Conditions: []corev1.PodCondition{
 						{
-							Type:   corev1.ContainersReady,
+							Type:   corev1.PodReady,
 							Status: corev1.ConditionTrue,
 						},
 					},
@@ -110,7 +110,7 @@ var _ = Describe("Pod conditions test suite", func() {
 				Status: corev1.PodStatus{
 					Conditions: []corev1.PodCondition{
 						{
-							Type:   corev1.ContainersReady,
+							Type:   corev1.PodReady,
 							Status: corev1.ConditionFalse,
 						},
 					},
@@ -125,7 +125,7 @@ var _ = Describe("Pod conditions test suite", func() {
 				Status: corev1.PodStatus{
 					Conditions: []corev1.PodCondition{
 						{
-							Type:   corev1.ContainersReady,
+							Type:   corev1.PodReady,
 							Status: corev1.ConditionFalse,
 						},
 					},
@@ -157,7 +157,7 @@ var _ = Describe("Pod conditions test suite", func() {
 				Phase: corev1.PodRunning,
 				Conditions: []corev1.PodCondition{
 					{
-						Type:   corev1.ContainersReady,
+						Type:   corev1.PodReady,
 						Status: corev1.ConditionTrue,
 					},
 				},

--- a/pkg/utils/pod_conditions_test.go
+++ b/pkg/utils/pod_conditions_test.go
@@ -66,6 +66,24 @@ var _ = Describe("Pod conditions test suite", func() {
 			Expect(IsPodReady(pod)).To(BeFalse())
 		})
 
+		It("Returns false when ContainersReady is True but PodReady is False", func() {
+			pod := corev1.Pod{
+				Status: corev1.PodStatus{
+					Conditions: []corev1.PodCondition{
+						{
+							Type:   corev1.ContainersReady,
+							Status: corev1.ConditionTrue,
+						},
+						{
+							Type:   corev1.PodReady,
+							Status: corev1.ConditionFalse,
+						},
+					},
+				},
+			}
+			Expect(IsPodReady(pod)).To(BeFalse())
+		})
+
 		It("return 0 if the list of Pods is empty", func() {
 			var list []corev1.Pod
 			Expect(CountReadyPods(list)).To(Equal(0))


### PR DESCRIPTION
When the node hosting the primary loses network connectivity, the kubelet can no longer update the pod status. The pod's ContainersReady condition is left stale as True, while Kubernetes actively sets Ready to False via the node controller. By checking Ready instead of ContainersReady, the operator can now correctly detect that the primary is unavailable and proceed with a failover.

This change is safe in combination with the previous patch: when the status endpoint fails transiently the pod's Ready condition is still True, so the operator requeues rather than triggering a spurious failover.

See #10403 