### PR TITLE
feat: conditionally add readOnlyService to the status

### DIFF
--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -933,6 +933,10 @@ type ClusterStatus struct {
 	// +optional
 	ReadService string `json:"readService,omitempty"`
 
+	// Current list of read-only pods
+	// +optional
+	ReadOnlyService string `json:"readOnlyService,omitempty"`
+
 	// Current phase of the cluster
 	// +optional
 	Phase string `json:"phase,omitempty"`

--- a/internal/controller/cluster_status.go
+++ b/internal/controller/cluster_status.go
@@ -246,7 +246,7 @@ func (r *ClusterReconciler) updateResourceStatus(
 	// Services
 	cluster.Status.WriteService = cluster.GetServiceReadWriteName()
 	cluster.Status.ReadService = cluster.GetServiceReadName()
-	if cluster.IsReadOnlyServiceEnabled() {
+	if cluster.IsReadOnlyServiceEnabled() && cluster.Spec.Instances > 1 {
 		cluster.Status.ReadOnlyService = cluster.GetServiceReadOnlyName()
 	}
 

--- a/internal/controller/cluster_status.go
+++ b/internal/controller/cluster_status.go
@@ -246,6 +246,9 @@ func (r *ClusterReconciler) updateResourceStatus(
 	// Services
 	cluster.Status.WriteService = cluster.GetServiceReadWriteName()
 	cluster.Status.ReadService = cluster.GetServiceReadName()
+	if cluster.IsReadOnlyServiceEnabled() {
+		cluster.Status.ReadOnlyService = cluster.GetServiceReadOnlyName()
+	}
 
 	// If we are switching, check if the target primary is still active
 	// Ignore this check if current primary is empty (it happens during the bootstrap)


### PR DESCRIPTION
**Summary**

- Adds `ReadOnlyService` to `ClusterStatus` mimicking the existing `ReadService`
- Conditionally fills the information for `ReadOnlyService` with the `read-only` service when the cluster has more than one node

Resolves: https://github.com/cloudnative-pg/cloudnative-pg/issues/10440