### PR TITLE
fix(ci): use go.mod version for govulncheck instead of stable

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -207,6 +207,11 @@ jobs:
         uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1
         with:
           go-version-file: go.mod
+          # Override the default value of "stable" for go-version-input.
+          # Without this, setup-go receives both go-version=stable and
+          # go-version-file=go.mod, and ignores the file.
+          # See https://github.com/golang/go/issues/70036
+          go-version-input: ""
           check-latest: true
 
   shellcheck:


### PR DESCRIPTION
The govulncheck-action defaults go-version-input to "stable". When go-version-file is also set, setup-go receives both and silently ignores the file in favor of the explicit version. This means govulncheck was running against the latest stable Go instead of the version declared in go.mod, making the check unreliable.

Set go-version-input to an empty string to override the default and let go-version-file take effect. This is a known issue with the upstream action (https://github.com/golang/go/issues/70036).

Closes #10450 