### PR TITLE
chore: add native fuzz tests and a `make fuzz` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,7 @@ OPM_VERSION ?= v1.65.0
 PREFLIGHT_VERSION ?= 1.17.1
 OPENSHIFT_VERSIONS ?= v4.16-v4.21
 ARCH ?= amd64
+FUZZ_TIME ?= 30s
 
 export CONTROLLER_IMG
 export BUILD_IMAGE
@@ -130,6 +131,10 @@ test-race: generate fmt vet manifests envtest ## Run tests enabling race detecti
 	source <(${ENVTEST} use -p env --bin-dir ${ENVTEST_ASSETS_DIR} ${ENVTEST_K8S_VERSION}) ;\
 	go run github.com/onsi/ginkgo/v2/ginkgo -r -p --skip-package=e2e \
 	  --race --keep-going --fail-on-empty --randomize-all --randomize-suites
+
+fuzz: ## Run native fuzzing targets.
+	go test -run=^$$ ./pkg/postgres -fuzz=FuzzCreatePostgresqlConfigurationSanitization -fuzztime=$(FUZZ_TIME)
+	go test -run=^$$ ./internal/configuration/... -fuzz=FuzzConfigurationParsing -fuzztime=$(FUZZ_TIME)
 
 e2e-test-kind: ## Run e2e tests locally using kind.
 	CLUSTER_ENGINE=kind hack/e2e/run-e2e-local.sh

--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,7 @@ OPM_VERSION ?= v1.69.0
 PREFLIGHT_VERSION ?= 1.18.0
 OPENSHIFT_VERSIONS ?= v4.16-v4.21
 ARCH ?= amd64
+FUZZ_TIME ?= 30s
 
 export CONTROLLER_IMG
 export BUILD_IMAGE
@@ -130,6 +131,10 @@ test-race: generate fmt vet manifests envtest ## Run tests enabling race detecti
 	source <(${ENVTEST} use -p env --bin-dir ${ENVTEST_ASSETS_DIR} ${ENVTEST_K8S_VERSION}) ;\
 	go run github.com/onsi/ginkgo/v2/ginkgo -r -p --skip-package=e2e \
 	  --race --keep-going --fail-on-empty --randomize-all --randomize-suites
+
+fuzz: ## Run native fuzzing targets.
+	go test -run=^$$ ./pkg/postgres -fuzz=FuzzCreatePostgresqlConfigurationSanitization -fuzztime=$(FUZZ_TIME)
+	go test -run=^$$ ./internal/configuration/... -fuzz=FuzzConfigurationParsing -fuzztime=$(FUZZ_TIME)
 
 e2e-test-kind: ## Run e2e tests locally using kind.
 	CLUSTER_ENGINE=kind hack/e2e/run-e2e-local.sh

--- a/Makefile
+++ b/Makefile
@@ -132,9 +132,22 @@ test-race: generate fmt vet manifests envtest ## Run tests enabling race detecti
 	go run github.com/onsi/ginkgo/v2/ginkgo -r -p --skip-package=e2e \
 	  --race --keep-going --fail-on-empty --randomize-all --randomize-suites
 
-fuzz: ## Run native fuzzing targets.
-	go test -run=^$$ ./pkg/postgres -fuzz=FuzzCreatePostgresqlConfigurationSanitization -fuzztime=$(FUZZ_TIME)
-	go test -run=^$$ ./internal/configuration/... -fuzz=FuzzConfigurationParsing -fuzztime=$(FUZZ_TIME)
+.PHONY: fuzz
+fuzz: ## Run every native fuzz target discovered in the tree.
+	trap 'exit 130' INT ;\
+	rc=0 ;\
+	pairs=$$(go test -list '^Fuzz' ./... | awk '\
+		/^ok[ \t]/ { for (i in p) print $$2, p[i]; delete p; next } \
+		/^Fuzz/    { p[NR] = $$0 }') ;\
+	if [ -z "$$pairs" ]; then \
+		echo "No fuzz targets found." ;\
+		exit 0 ;\
+	fi ;\
+	while read -r pkg name; do \
+		echo "==> $$pkg::$$name (FUZZ_TIME=$(FUZZ_TIME))" ;\
+		go test -run=^$$ "$$pkg" -fuzz="^$$name$$" -fuzztime=$(FUZZ_TIME) || rc=$$? ;\
+	done <<< "$$pairs" ;\
+	exit $$rc
 
 e2e-test-kind: ## Run e2e tests locally using kind.
 	CLUSTER_ENGINE=kind hack/e2e/run-e2e-local.sh

--- a/internal/configuration/fuzz_test.go
+++ b/internal/configuration/fuzz_test.go
@@ -1,0 +1,78 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package configuration
+
+import (
+	"slices"
+	"strings"
+	"testing"
+)
+
+func FuzzConfigurationParsing(f *testing.F) {
+	f.Add("qa.test.com/*,prod.test.com/*", "qa.test.com/one", ",  ,pg ,pg_staging   ,  pg_prod, ", "a,,,b , c")
+	f.Add("[abc,prod.testing.com/*", "prod.testing.com/two", ",  ,,", "")
+	f.Add("one,two", "three", "pg", "plugin-a,plugin-b")
+
+	f.Fuzz(func(t *testing.T, rawPatterns, value, watchNamespace, includePlugins string) {
+		patterns := strings.Split(rawPatterns, ",")
+
+		config := Data{
+			InheritedAnnotations: patterns,
+			InheritedLabels:      patterns,
+			WatchNamespace:       watchNamespace,
+			IncludePlugins:       includePlugins,
+		}
+
+		expectedMatch := evaluateGlobPatterns(patterns, value)
+		if got := config.IsAnnotationInherited(value); got != expectedMatch {
+			t.Fatalf("annotation inheritance mismatch: got %t want %t", got, expectedMatch)
+		}
+		if got := config.IsLabelInherited(value); got != expectedMatch {
+			t.Fatalf("label inheritance mismatch: got %t want %t", got, expectedMatch)
+		}
+
+		watchedNamespaces := config.WatchedNamespaces()
+		expectedNamespaces := cleanNamespaceList(watchNamespace)
+		if !slices.Equal(watchedNamespaces, expectedNamespaces) {
+			t.Fatalf("watched namespaces mismatch: got %#v want %#v", watchedNamespaces, expectedNamespaces)
+		}
+		for _, namespace := range watchedNamespaces {
+			if namespace == "" {
+				t.Fatalf("empty namespace returned from %q", watchNamespace)
+			}
+			if namespace != strings.TrimSpace(namespace) {
+				t.Fatalf("namespace is not trimmed: %q", namespace)
+			}
+		}
+
+		plugins := config.GetIncludePlugins()
+		if !slices.Equal(plugins, config.GetIncludePlugins()) {
+			t.Fatalf("plugin parsing must be deterministic")
+		}
+		for _, plugin := range plugins {
+			if plugin == "" {
+				t.Fatalf("empty plugin returned from %q", includePlugins)
+			}
+			if plugin != strings.TrimSpace(plugin) {
+				t.Fatalf("plugin is not trimmed: %q", plugin)
+			}
+		}
+	})
+}

--- a/internal/configuration/fuzz_test.go
+++ b/internal/configuration/fuzz_test.go
@@ -29,6 +29,8 @@ func FuzzConfigurationParsing(f *testing.F) {
 	f.Add("qa.test.com/*,prod.test.com/*", "qa.test.com/one", ",  ,pg ,pg_staging   ,  pg_prod, ", "a,,,b , c")
 	f.Add("[abc,prod.testing.com/*", "prod.testing.com/two", ",  ,,", "")
 	f.Add("one,two", "three", "pg", "plugin-a,plugin-b")
+	f.Add("a*", "abc", "", "")
+	f.Add("\x00", "\x00", "ns\x00", "p\x00")
 
 	f.Fuzz(func(t *testing.T, rawPatterns, value, watchNamespace, includePlugins string) {
 		patterns := strings.Split(rawPatterns, ",")
@@ -40,38 +42,42 @@ func FuzzConfigurationParsing(f *testing.F) {
 			IncludePlugins:       includePlugins,
 		}
 
-		expectedMatch := evaluateGlobPatterns(patterns, value)
-		if got := config.IsAnnotationInherited(value); got != expectedMatch {
-			t.Fatalf("annotation inheritance mismatch: got %t want %t", got, expectedMatch)
-		}
-		if got := config.IsLabelInherited(value); got != expectedMatch {
-			t.Fatalf("label inheritance mismatch: got %t want %t", got, expectedMatch)
+		matched := config.IsAnnotationInherited(value)
+		for _, pattern := range patterns {
+			// pattern has no glob metacharacters; path.Match must treat it literally
+			if pattern == value && !strings.ContainsAny(pattern, "*?[\\") {
+				if !matched {
+					t.Fatalf("exact-match pattern %q did not match value %q", pattern, value)
+				}
+				break
+			}
 		}
 
-		watchedNamespaces := config.WatchedNamespaces()
-		expectedNamespaces := cleanNamespaceList(watchNamespace)
-		if !slices.Equal(watchedNamespaces, expectedNamespaces) {
-			t.Fatalf("watched namespaces mismatch: got %#v want %#v", watchedNamespaces, expectedNamespaces)
+		namespaces := config.WatchedNamespaces()
+		rejoined := Data{WatchNamespace: strings.Join(namespaces, ",")}
+		if got := rejoined.WatchedNamespaces(); !slices.Equal(got, namespaces) {
+			t.Fatalf("WatchedNamespaces not idempotent: %#v -> %#v", namespaces, got)
 		}
-		for _, namespace := range watchedNamespaces {
+		for _, namespace := range namespaces {
 			if namespace == "" {
 				t.Fatalf("empty namespace returned from %q", watchNamespace)
 			}
 			if namespace != strings.TrimSpace(namespace) {
-				t.Fatalf("namespace is not trimmed: %q", namespace)
+				t.Fatalf("namespace not trimmed: %q (from %q)", namespace, watchNamespace)
 			}
 		}
 
 		plugins := config.GetIncludePlugins()
-		if !slices.Equal(plugins, config.GetIncludePlugins()) {
-			t.Fatalf("plugin parsing must be deterministic")
+		rejoinedPlugins := Data{IncludePlugins: strings.Join(plugins, ",")}
+		if got := rejoinedPlugins.GetIncludePlugins(); !slices.Equal(got, plugins) {
+			t.Fatalf("GetIncludePlugins not idempotent: %#v -> %#v", plugins, got)
 		}
 		for _, plugin := range plugins {
 			if plugin == "" {
 				t.Fatalf("empty plugin returned from %q", includePlugins)
 			}
 			if plugin != strings.TrimSpace(plugin) {
-				t.Fatalf("plugin is not trimmed: %q", plugin)
+				t.Fatalf("plugin not trimmed: %q (from %q)", plugin, includePlugins)
 			}
 		}
 	})

--- a/pkg/postgres/configuration_fuzz_test.go
+++ b/pkg/postgres/configuration_fuzz_test.go
@@ -1,0 +1,116 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package postgres
+
+import "testing"
+
+func FuzzCreatePostgresqlConfigurationSanitization(f *testing.F) { //nolint: gocognit
+	f.Add(uint8(17), "off", "target_name", "128MB", "internal'value", true, false, false, false, false)
+	f.Add(uint8(14), "on", "", "256MB", "", false, true, true, false, false)
+	f.Add(uint8(16), "off", "restore_target", "512MB", "quoted'value", false, false, false, true, true)
+
+	f.Fuzz(func(
+		t *testing.T,
+		majorSeed uint8,
+		sslValue, recoveryTargetName, sharedBuffers, internalValue string,
+		includingMandatory, preserveFixedSettingsFromUser, isReplicaCluster, isWalArchivingDisabled, alterSystemEnabled bool,
+	) {
+		majorVersion := 13 + int(majorSeed%6)
+
+		cfg := CreatePostgresqlConfiguration(ConfigurationInfo{
+			Settings:                      CnpgConfigurationSettings,
+			MajorVersion:                  majorVersion,
+			IncludingMandatory:            includingMandatory,
+			PreserveFixedSettingsFromUser: preserveFixedSettingsFromUser,
+			IsReplicaCluster:              isReplicaCluster,
+			IsWalArchivingDisabled:        isWalArchivingDisabled,
+			IsAlterSystemEnabled:          alterSystemEnabled,
+			UserSettings: map[string]string{
+				"ssl":                  sslValue,
+				"recovery_target_name": recoveryTargetName,
+				"shared_buffers":       sharedBuffers,
+			},
+		})
+
+		if got := cfg.GetConfig("shared_buffers"); got != sharedBuffers {
+			t.Fatalf("non-fixed parameter changed: got %q want %q", got, sharedBuffers)
+		}
+
+		switch {
+		case includingMandatory:
+			if got := cfg.GetConfig("ssl"); got != "on" {
+				t.Fatalf("ssl must be sanitized to mandatory value, got %q", got)
+			}
+			if got := cfg.GetConfig("recovery_target_name"); got != "" {
+				t.Fatalf("recovery_target_name must be dropped, got %q", got)
+			}
+		case preserveFixedSettingsFromUser:
+			if got := cfg.GetConfig("ssl"); got != sslValue {
+				t.Fatalf("ssl user value not preserved: got %q want %q", got, sslValue)
+			}
+			if got := cfg.GetConfig("recovery_target_name"); got != recoveryTargetName {
+				t.Fatalf(
+					"recovery_target_name user value not preserved: got %q want %q",
+					got,
+					recoveryTargetName,
+				)
+			}
+		default:
+			if got := cfg.GetConfig("ssl"); got != "" {
+				t.Fatalf("ssl should be removed when fixed settings are not preserved, got %q", got)
+			}
+			if got := cfg.GetConfig("recovery_target_name"); got != "" {
+				t.Fatalf("recovery_target_name should be removed, got %q", got)
+			}
+		}
+
+		expectedArchiveMode := "on"
+		switch {
+		case isWalArchivingDisabled:
+			expectedArchiveMode = "off"
+		case isReplicaCluster:
+			expectedArchiveMode = "always"
+		}
+		if got := cfg.GetConfig("archive_mode"); got != expectedArchiveMode {
+			t.Fatalf("archive_mode mismatch: got %q want %q", got, expectedArchiveMode)
+		}
+
+		if includingMandatory && majorVersion >= 17 {
+			want := "off"
+			if alterSystemEnabled {
+				want = "on"
+			}
+			if got := cfg.GetConfig("allow_alter_system"); got != want {
+				t.Fatalf("allow_alter_system mismatch: got %q want %q", got, want)
+			}
+		}
+
+		_, sha1 := CreatePostgresqlConfFile(cfg)
+		cfg.OverwriteConfig("cnpg.fuzz_internal", internalValue)
+		_, sha2 := CreatePostgresqlConfFile(cfg)
+
+		if sha1 == "" || sha2 == "" {
+			t.Fatalf("empty config hash")
+		}
+		if sha1 != sha2 {
+			t.Fatalf("cnpg.* entries must not affect config hash")
+		}
+	})
+}

--- a/pkg/postgres/configuration_fuzz_test.go
+++ b/pkg/postgres/configuration_fuzz_test.go
@@ -19,12 +19,16 @@ SPDX-License-Identifier: Apache-2.0
 
 package postgres
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
-func FuzzCreatePostgresqlConfigurationSanitization(f *testing.F) { //nolint: gocognit
+func FuzzCreatePostgresqlConfigurationSanitization(f *testing.F) {
 	f.Add(uint8(17), "off", "target_name", "128MB", "internal'value", true, false, false, false, false)
 	f.Add(uint8(14), "on", "", "256MB", "", false, true, true, false, false)
 	f.Add(uint8(16), "off", "restore_target", "512MB", "quoted'value", false, false, false, true, true)
+	f.Add(uint8(15), "on", "", "64MB", "with\nnewline\tand\\backslash", true, false, false, false, true)
 
 	f.Fuzz(func(
 		t *testing.T,
@@ -49,68 +53,110 @@ func FuzzCreatePostgresqlConfigurationSanitization(f *testing.F) { //nolint: goc
 			},
 		})
 
-		if got := cfg.GetConfig("shared_buffers"); got != sharedBuffers {
-			t.Fatalf("non-fixed parameter changed: got %q want %q", got, sharedBuffers)
-		}
+		checkFixedSettings(t, cfg, sslValue, recoveryTargetName, includingMandatory, preserveFixedSettingsFromUser)
+		checkArchiveMode(t, cfg, isWalArchivingDisabled, isReplicaCluster)
+		checkAlterSystem(t, cfg, majorVersion, includingMandatory, alterSystemEnabled)
 
-		switch {
-		case includingMandatory:
-			if got := cfg.GetConfig("ssl"); got != "on" {
-				t.Fatalf("ssl must be sanitized to mandatory value, got %q", got)
-			}
-			if got := cfg.GetConfig("recovery_target_name"); got != "" {
-				t.Fatalf("recovery_target_name must be dropped, got %q", got)
-			}
-		case preserveFixedSettingsFromUser:
-			if got := cfg.GetConfig("ssl"); got != sslValue {
-				t.Fatalf("ssl user value not preserved: got %q want %q", got, sslValue)
-			}
-			if got := cfg.GetConfig("recovery_target_name"); got != recoveryTargetName {
-				t.Fatalf(
-					"recovery_target_name user value not preserved: got %q want %q",
-					got,
-					recoveryTargetName,
-				)
-			}
-		default:
-			if got := cfg.GetConfig("ssl"); got != "" {
-				t.Fatalf("ssl should be removed when fixed settings are not preserved, got %q", got)
-			}
-			if got := cfg.GetConfig("recovery_target_name"); got != "" {
-				t.Fatalf("recovery_target_name should be removed, got %q", got)
-			}
-		}
-
-		expectedArchiveMode := "on"
-		switch {
-		case isWalArchivingDisabled:
-			expectedArchiveMode = "off"
-		case isReplicaCluster:
-			expectedArchiveMode = "always"
-		}
-		if got := cfg.GetConfig("archive_mode"); got != expectedArchiveMode {
-			t.Fatalf("archive_mode mismatch: got %q want %q", got, expectedArchiveMode)
-		}
-
-		if includingMandatory && majorVersion >= 17 {
-			want := "off"
-			if alterSystemEnabled {
-				want = "on"
-			}
-			if got := cfg.GetConfig("allow_alter_system"); got != want {
-				t.Fatalf("allow_alter_system mismatch: got %q want %q", got, want)
-			}
-		}
-
+		cfg.OverwriteConfig("custom.fuzz_value", internalValue)
 		_, sha1 := CreatePostgresqlConfFile(cfg)
 		cfg.OverwriteConfig("cnpg.fuzz_internal", internalValue)
-		_, sha2 := CreatePostgresqlConfFile(cfg)
-
+		rendered, sha2 := CreatePostgresqlConfFile(cfg)
 		if sha1 == "" || sha2 == "" {
 			t.Fatalf("empty config hash")
 		}
 		if sha1 != sha2 {
 			t.Fatalf("cnpg.* entries must not affect config hash")
 		}
+
+		checkRenderedConfWellFormed(t, rendered)
 	})
+}
+
+func checkFixedSettings(
+	t *testing.T,
+	cfg *PgConfiguration,
+	sslValue, recoveryTargetName string,
+	includingMandatory, preserveFixedSettingsFromUser bool,
+) {
+	t.Helper()
+	switch {
+	case includingMandatory:
+		if got := cfg.GetConfig("ssl"); got != "on" {
+			t.Fatalf("ssl must be sanitized to mandatory value, got %q", got)
+		}
+		if got := cfg.GetConfig("recovery_target_name"); got != "" {
+			t.Fatalf("recovery_target_name must be dropped, got %q", got)
+		}
+	case preserveFixedSettingsFromUser:
+		if got := cfg.GetConfig("ssl"); got != sslValue {
+			t.Fatalf("ssl user value not preserved: got %q want %q", got, sslValue)
+		}
+		if got := cfg.GetConfig("recovery_target_name"); got != recoveryTargetName {
+			t.Fatalf("recovery_target_name user value not preserved: got %q want %q", got, recoveryTargetName)
+		}
+	default:
+		if got := cfg.GetConfig("ssl"); got != "" {
+			t.Fatalf("ssl should be removed when fixed settings are not preserved, got %q", got)
+		}
+		if got := cfg.GetConfig("recovery_target_name"); got != "" {
+			t.Fatalf("recovery_target_name should be removed, got %q", got)
+		}
+	}
+}
+
+func checkArchiveMode(t *testing.T, cfg *PgConfiguration, isWalArchivingDisabled, isReplicaCluster bool) {
+	t.Helper()
+	want := "on"
+	switch {
+	case isWalArchivingDisabled:
+		want = "off"
+	case isReplicaCluster:
+		want = "always"
+	}
+	if got := cfg.GetConfig("archive_mode"); got != want {
+		t.Fatalf("archive_mode mismatch: got %q want %q", got, want)
+	}
+}
+
+func checkAlterSystem(
+	t *testing.T,
+	cfg *PgConfiguration,
+	majorVersion int,
+	includingMandatory, alterSystemEnabled bool,
+) {
+	t.Helper()
+	if !includingMandatory || majorVersion < 17 {
+		return
+	}
+	want := "off"
+	if alterSystemEnabled {
+		want = "on"
+	}
+	if got := cfg.GetConfig("allow_alter_system"); got != want {
+		t.Fatalf("allow_alter_system mismatch: got %q want %q", got, want)
+	}
+}
+
+// checkRenderedConfWellFormed enforces the postgresql.conf injection
+// invariant: a user-controlled value cannot break out of its `key = 'value'`
+// line through an unescaped newline or quote.
+func checkRenderedConfWellFormed(t *testing.T, rendered string) {
+	t.Helper()
+	for i, line := range strings.Split(rendered, "\n") {
+		if line == "" {
+			continue
+		}
+		eq := strings.Index(line, " = ")
+		if eq < 0 {
+			t.Fatalf("line %d has no `key = value` separator: %q", i, line)
+		}
+		key := line[:eq]
+		value := line[eq+len(" = "):]
+		if key == "" || strings.ContainsAny(key, " \t'\"") {
+			t.Fatalf("line %d has malformed key %q", i, key)
+		}
+		if len(value) < 2 || value[0] != '\'' || value[len(value)-1] != '\'' {
+			t.Fatalf("line %d value not single-quoted: %q", i, value)
+		}
+	}
 }

--- a/pkg/postgres/configuration_fuzz_test.go
+++ b/pkg/postgres/configuration_fuzz_test.go
@@ -146,12 +146,10 @@ func checkRenderedConfWellFormed(t *testing.T, rendered string) {
 		if line == "" {
 			continue
 		}
-		eq := strings.Index(line, " = ")
-		if eq < 0 {
+		key, value, ok := strings.Cut(line, " = ")
+		if !ok {
 			t.Fatalf("line %d has no `key = value` separator: %q", i, line)
 		}
-		key := line[:eq]
-		value := line[eq+len(" = "):]
 		if key == "" || strings.ContainsAny(key, " \t'\"") {
 			t.Fatalf("line %d has malformed key %q", i, key)
 		}

--- a/pkg/postgres/configuration_fuzz_test.go
+++ b/pkg/postgres/configuration_fuzz_test.go
@@ -153,7 +153,7 @@ func checkRenderedConfWellFormed(t *testing.T, rendered string) {
 		if key == "" || strings.ContainsAny(key, " \t'\"") {
 			t.Fatalf("line %d has malformed key %q", i, key)
 		}
-		if len(value) < 2 || value[0] != '\'' || value[len(value)-1] != '\'' {
+		if len(value) < 2 || !strings.HasPrefix(value, "'") || !strings.HasSuffix(value, "'") {
 			t.Fatalf("line %d value not single-quoted: %q", i, value)
 		}
 	}


### PR DESCRIPTION
Adds a first batch of native fuzz targets and a `make fuzz` target that
discovers them automatically; new fuzz functions are picked up without
touching the Makefile. Default fuzz time is 30s, overridable via
`FUZZ_TIME`.

Not wired into CI: manual hardening runs and an OSS-Fuzz integration
seed. The current targets cover annotation/label inheritance, namespace
and plugin list parsing, and the postgresql.conf rendering pipeline
including a well-formedness check on the output.

Closes #10459