### PR TITLE
refactor(tls): switch verification to VerifyConnection

### DIFF
--- a/pkg/certs/tls.go
+++ b/pkg/certs/tls.go
@@ -61,9 +61,10 @@ func newTLSConfigFromSecret(
 	return NewTLSConfigFromCertPool(caCertPool), nil
 }
 
-// verifyCertificates it must be used with tls.Config in VerifyPeerCertificate and VerifyConnection
-// this is to have a consistent verification in both places, even if this is not a problem helps
-// to avoid introducing two different process in two important places.
+// verifyCertificates validates the peer certificate chain against the trusted CA pool.
+// It is called from VerifyConnection, which runs on every completed handshake —
+// including resumed sessions where no certificate exchange occurs but the original
+// peer certificates are still available in tls.ConnectionState.
 func verifyCertificates(certPool *x509.CertPool, certs []*x509.Certificate) error {
 	opts := x509.VerifyOptions{
 		Roots:         certPool,
@@ -89,23 +90,6 @@ func NewTLSConfigFromCertPool(
 		MinVersion:         tls.VersionTLS13,
 		RootCAs:            certPool,
 		InsecureSkipVerify: true, //#nosec G402 -- we are verifying the certificate ourselves
-		VerifyPeerCertificate: func(rawCerts [][]byte, _ [][]*x509.Certificate) error {
-			// Code adapted from https://go.dev/src/crypto/tls/handshake_client.go#L986
-			if len(rawCerts) == 0 {
-				return fmt.Errorf("no raw certificates provided")
-			}
-
-			certs := make([]*x509.Certificate, len(rawCerts))
-			for i, rawCert := range rawCerts {
-				cert, err := x509.ParseCertificate(rawCert)
-				if err != nil {
-					return fmt.Errorf("failed to parse certificate: %v", err)
-				}
-				certs[i] = cert
-			}
-
-			return verifyCertificates(certPool, certs)
-		},
 		VerifyConnection: func(conn tls.ConnectionState) error {
 			if len(conn.PeerCertificates) == 0 {
 				return fmt.Errorf("no certificates provided")

--- a/pkg/certs/tls.go
+++ b/pkg/certs/tls.go
@@ -62,10 +62,10 @@ func newTLSConfigFromSecret(
 }
 
 // verifyCertificates validates the peer certificate chain against the trusted CA pool.
-// It is called from VerifyConnection, which runs on every completed handshake —
-// including resumed sessions where no certificate exchange occurs but the original
-// peer certificates are still available in tls.ConnectionState.
 func verifyCertificates(certPool *x509.CertPool, certs []*x509.Certificate) error {
+	if len(certs) == 0 {
+		return fmt.Errorf("no certificates provided")
+	}
 	opts := x509.VerifyOptions{
 		Roots:         certPool,
 		Intermediates: x509.NewCertPool(),
@@ -90,11 +90,10 @@ func NewTLSConfigFromCertPool(
 		MinVersion:         tls.VersionTLS13,
 		RootCAs:            certPool,
 		InsecureSkipVerify: true, //#nosec G402 -- we are verifying the certificate ourselves
+		// VerifyConnection runs on every completed handshake, including resumed
+		// TLS 1.3 sessions where no certificate exchange occurs but the original
+		// peer certificates remain available in tls.ConnectionState.
 		VerifyConnection: func(conn tls.ConnectionState) error {
-			if len(conn.PeerCertificates) == 0 {
-				return fmt.Errorf("no certificates provided")
-			}
-
 			return verifyCertificates(certPool, conn.PeerCertificates)
 		},
 	}

--- a/pkg/certs/tls.go
+++ b/pkg/certs/tls.go
@@ -107,6 +107,10 @@ func NewTLSConfigFromCertPool(
 			return verifyCertificates(certPool, certs)
 		},
 		VerifyConnection: func(conn tls.ConnectionState) error {
+			if len(conn.PeerCertificates) == 0 {
+				return fmt.Errorf("no certificates provided")
+			}
+
 			return verifyCertificates(certPool, conn.PeerCertificates)
 		},
 	}

--- a/pkg/certs/tls.go
+++ b/pkg/certs/tls.go
@@ -61,6 +61,25 @@ func newTLSConfigFromSecret(
 	return NewTLSConfigFromCertPool(caCertPool), nil
 }
 
+// verifyCertificates it must be used with tls.Config in VerifyPeerCertificate and VerifyConnection
+// this is to have a consistent verification in both places, even if this is not a problem helps
+// to avoid introducing two different process in two important places.
+func verifyCertificates(certPool *x509.CertPool, certs []*x509.Certificate) error {
+	opts := x509.VerifyOptions{
+		Roots:         certPool,
+		Intermediates: x509.NewCertPool(),
+	}
+	for _, cert := range certs[1:] {
+		opts.Intermediates.AddCert(cert)
+	}
+	_, err := certs[0].Verify(opts)
+	if err != nil {
+		return &tls.CertificateVerificationError{UnverifiedCertificates: certs, Err: err}
+	}
+
+	return nil
+}
+
 // NewTLSConfigFromCertPool creates a tls.Config object from X509 cert pool
 // containing the expected server CA
 func NewTLSConfigFromCertPool(
@@ -85,20 +104,10 @@ func NewTLSConfigFromCertPool(
 				certs[i] = cert
 			}
 
-			opts := x509.VerifyOptions{
-				Roots:         certPool,
-				Intermediates: x509.NewCertPool(),
-			}
-
-			for _, cert := range certs[1:] {
-				opts.Intermediates.AddCert(cert)
-			}
-			_, err := certs[0].Verify(opts)
-			if err != nil {
-				return &tls.CertificateVerificationError{UnverifiedCertificates: certs, Err: err}
-			}
-
-			return nil
+			return verifyCertificates(certPool, certs)
+		},
+		VerifyConnection: func(conn tls.ConnectionState) error {
+			return verifyCertificates(certPool, conn.PeerCertificates)
 		},
 	}
 

--- a/pkg/certs/tls_test.go
+++ b/pkg/certs/tls_test.go
@@ -22,6 +22,7 @@ package certs
 import (
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"encoding/pem"
 	"errors"
 	"fmt"
@@ -120,6 +121,14 @@ IRh7fVEH8WBfMA8GA1UdEwEB/wQFMAMBAf8wCgYIKoZIzj0EAwIDaAAwZQIwBdrw
 			Expect(tlsConfig.RootCAs).ToNot(BeNil())
 		})
 
+		It("should reject connections with no certificates", func(ctx context.Context) {
+			tlsConfig, err := newTLSConfigFromSecret(ctx, c, caSecret)
+			Expect(err).NotTo(HaveOccurred())
+			err = tlsConfig.VerifyConnection(tls.ConnectionState{})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("no certificates provided"))
+		})
+
 		It("should validate good certificates", func(ctx context.Context) {
 			tlsConfig, err := newTLSConfigFromSecret(ctx, c, caSecret)
 			Expect(err).NotTo(HaveOccurred())
@@ -191,7 +200,11 @@ rx8M7UTZeZJC1KjcnJuxJl7+6A8fjqHdZh/y/IFyiZNC9XRqouqWTT3JqI7BQAIw
 Zxj1fxVSmUy1TBXz6H0sUvtFh/Fgb6v4qUPdRE6xNJw3lbZUZxHr2xXk5Op/Cw6O
 -----END CERTIFICATE-----
 `))
-			err = tlsConfig.VerifyPeerCertificate([][]byte{serverBlock.Bytes}, nil)
+			cert, err := x509.ParseCertificate(serverBlock.Bytes)
+			Expect(err).NotTo(HaveOccurred())
+			err = tlsConfig.VerifyConnection(tls.ConnectionState{
+				PeerCertificates: []*x509.Certificate{cert},
+			})
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 
@@ -266,7 +279,11 @@ MQCKGqId+Xj6O6gnoi9xhu0rbzSnMjrURoa1v2d5+O5XssE7LGtJdIKrd2p7EuwE
 6dk=
 -----END CERTIFICATE-----
 `))
-			err = tlsConfig.VerifyPeerCertificate([][]byte{badServerBlock.Bytes}, nil)
+			badCert, err := x509.ParseCertificate(badServerBlock.Bytes)
+			Expect(err).NotTo(HaveOccurred())
+			err = tlsConfig.VerifyConnection(tls.ConnectionState{
+				PeerCertificates: []*x509.Certificate{badCert},
+			})
 			var certError *tls.CertificateVerificationError
 			Expect(errors.As(err, &certError)).To(BeTrue())
 		})


### PR DESCRIPTION
Go's `VerifyPeerCertificate` callback is skipped on resumed TLS 1.3 sessions (PSK / session tickets), while `VerifyConnection` runs on every completed handshake. Session resumption is not enabled anywhere in the codebase today (no `ClientSessionCache` is configured), so this has no observable effect, but it aligns the verification hook with the one the Go team documents as resumption-safe and satisfies the golangci-lint 2.11.4 check that flagged the combination.

Closes #10477