### PR TITLE
docs: add CloudNativePG talks from KubeCon Europe 2026 in Amsterdam

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,9 @@ organization to this list!
 
 ### CloudNativePG at KubeCon
 
+- March 25, 2026, KubeCon Europe 2026 in Amsterdam: ["Cloud Native Theater / Data on Kubernetes Day: From VMs to Kubernetes in a Large Global Bank: A DBA's Journey"](https://kccnceu2026.sched.com/event/2EG01/cloud-native-theater-data-on-kubernetes-day-from-vms-to-kubernetes-in-a-large-global-bank-a-dbas-journey-gabriele-bartolini-edb-laurent-parodi-hsbc) - Gabriele Bartolini, EDB & Laurent Parodi, HSBC
+- March 23, 2026, Data on Kubernetes Day at KubeCon Europe 2026 in Amsterdam: ["Beyond the DBaaS Trap: Achieving Data Sovereignty with Kubernetes and CloudNativePG"](https://colocatedeventseu2026.sched.com/event/2H5Uc/beyond-the-dbaas-trap-achieving-data-sovereignty-with-kubernetes-and-cloudnativepg-floor-drees-gabriele-bartolini-edb) - Floor Drees & Gabriele Bartolini, EDB
+- March 23, 2026, KubeCon Europe 2026 in Amsterdam: ["Project Lightning Talk: Five Minutes by CloudNativePG River"](https://kccnceu2026.sched.com/event/2EWIB/project-lightning-talk-five-minutes-by-cloudnativepg-river-gabriele-quaresima-contributor) - Gabriele Quaresima, Contributor
 - November 10, 2025, KubeCon North America 2025 in Atlanta: ["Project Lightning Talk: CloudNativePG: Running Postgres The Kubernetes Way"](https://www.youtube.com/watch?v=pYwYwehQX3U&t=4s) - Gabriele Bartolini, EDB
 - November 11, 2025, KubeCon North America 2025 in Atlanta: ["Modern PostgreSQL Authorization With Keycloak: Cloud Native Identity Meets Database Security"](https://www.youtube.com/watch?v=TYgPemq06fg) - Yoshiyuki Tabata, Hitachi, Ltd. & Gabriele Bartolini, EDB
 - November 13, 2025, KubeCon North America 2025 in Atlanta: ["Quorum-Based Consistency for Cluster Changes With CloudNativePG Operator"](https://www.youtube.com/watch?v=iQUOO3-JRK4&list=PLj6h78yzYM2MLSW4tUDO2gs2pR5UpiD0C&index=67) - Jeremy Schneider, GEICO Tech & Gabriele Bartolini, EDB


### PR DESCRIPTION
## Summary

Add three talks delivered at KubeCon + CloudNativeCon Europe 2026 in Amsterdam to the `CloudNativePG at KubeCon` section of the README:

- March 23, Data on Kubernetes Day: ["Beyond the DBaaS Trap: Achieving Data Sovereignty with Kubernetes and CloudNativePG"](https://colocatedeventseu2026.sched.com/event/2H5Uc/beyond-the-dbaas-trap-achieving-data-sovereignty-with-kubernetes-and-cloudnativepg-floor-drees-gabriele-bartolini-edb) - Floor Drees & Gabriele Bartolini, EDB
- March 23: ["Project Lightning Talk: Five Minutes by CloudNativePG River"](https://kccnceu2026.sched.com/event/2EWIB/project-lightning-talk-five-minutes-by-cloudnativepg-river-gabriele-quaresima-contributor) - Gabriele Quaresima, Contributor
- March 25, Cloud Native Theater / Data on Kubernetes Day: ["From VMs to Kubernetes in a Large Global Bank: A DBA's Journey"](https://kccnceu2026.sched.com/event/2EG01/cloud-native-theater-data-on-kubernetes-day-from-vms-to-kubernetes-in-a-large-global-bank-a-dbas-journey-gabriele-bartolini-edb-laurent-parodi-hsbc) - Gabriele Bartolini, EDB & Laurent Parodi, HSBC

Assisted-by: Claude Sonnet 4.6