### PR TITLE
ci: fix VerifyIssue check for "Closes #N" without trailing whitespace

### DIFF
--- a/.github/workflows/pr_verify_linked_issue.yml
+++ b/.github/workflows/pr_verify_linked_issue.yml
@@ -49,16 +49,6 @@ jobs:
               }
             }
 
-            const events = await github.paginate(github.rest.issues.listEvents, {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.payload.pull_request.number,
-            });
-            if (events.some((e) => e.event === 'connected')) {
-              core.notice('Success! Connected issue found.');
-              return;
-            }
-
             const message =
               'Build Error! No Linked Issue found. Please link an issue or mention it in the body using #<issue_id>';
             await github.rest.issues.createComment({

--- a/.github/workflows/pr_verify_linked_issue.yml
+++ b/.github/workflows/pr_verify_linked_issue.yml
@@ -87,8 +87,16 @@ jobs:
             }
 
             if (existing.length === 0) {
-              const message =
-                `${marker}\nBuild Error! No linked issue found. Please reference one in the PR body using a keyword (Closes/Fixes/Resolves/Refs/See) followed by #<issue_id> or owner/repo#<issue_id>.`;
+              const message = [
+                marker,
+                '',
+                '> [!WARNING]',
+                '> **Linked issue missing.**',
+                '>',
+                '> Reference one in the PR body using a keyword (Closes / Fixes / Resolves / Refs / See) followed by `#<issue_id>` or `owner/repo#<issue_id>`.',
+                '>',
+                '> Alternatively, apply the `no-issue` label to skip this check.',
+              ].join('\n');
               await github.rest.issues.createComment({
                 issue_number: context.payload.pull_request.number,
                 owner: context.repo.owner,

--- a/.github/workflows/pr_verify_linked_issue.yml
+++ b/.github/workflows/pr_verify_linked_issue.yml
@@ -30,31 +30,70 @@ jobs:
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
+            const marker = '<!-- verify-linked-issue -->';
             const body = context.payload.pull_request.body || '';
             core.debug(`Checking PR body: "${body}"`);
 
-            const matches = [...body.matchAll(/#(\d+)/g)];
-            for (const m of matches) {
-              const issueNumber = parseInt(m[1], 10);
+            // Match a GitHub-style issue reference preceded by a linking keyword
+            // at the start of a line, e.g. "Closes #123" or "Fixes owner/repo#45".
+            const keywords = 'close[sd]?|fix(?:es|ed)?|resolve[sd]?|refs?|refers?|see';
+            const name = '[\\w.-]+';
+            const pattern = [
+              '^\\s*',                           // start of line, optional indent
+              `(?:${keywords})\\b`,              // keyword (case-insensitive via flag)
+              '[:\\s]+',                         // colon and/or whitespace
+              `(?:(${name})\\/(${name}))?`,      // optional owner/repo prefix
+              '#(\\d+)',                         // issue number
+            ].join('');
+            const re = new RegExp(pattern, 'gim');
+            let linked = false;
+            for (const m of body.matchAll(re)) {
+              const owner = m[1] || context.repo.owner;
+              const repo = m[2] || context.repo.repo;
+              const issueNumber = parseInt(m[3], 10);
               try {
                 await github.rest.issues.get({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
+                  owner,
+                  repo,
                   issue_number: issueNumber,
                 });
-                core.notice(`Success! Linked issue #${issueNumber} found in body.`);
-                return;
+                core.notice(`Success! Linked issue ${owner}/${repo}#${issueNumber} found in body.`);
+                linked = true;
+                break;
               } catch {
-                core.debug(`#${issueNumber} is not a valid issue.`);
+                core.debug(`${owner}/${repo}#${issueNumber} is not a valid issue.`);
               }
             }
 
-            const message =
-              'Build Error! No Linked Issue found. Please link an issue or mention it in the body using #<issue_id>';
-            await github.rest.issues.createComment({
-              issue_number: context.payload.pull_request.number,
+            const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: message,
+              issue_number: context.payload.pull_request.number,
+              per_page: 100,
             });
+            const existing = comments.filter(
+              (c) => c.user.login === 'github-actions[bot]' && c.body.includes(marker),
+            );
+
+            if (linked) {
+              for (const c of existing) {
+                await github.rest.issues.deleteComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: c.id,
+                });
+              }
+              return;
+            }
+
+            if (existing.length === 0) {
+              const message =
+                `${marker}\nBuild Error! No linked issue found. Please reference one in the PR body using a keyword (Closes/Fixes/Resolves/Refs/See) followed by #<issue_id> or owner/repo#<issue_id>.`;
+              await github.rest.issues.createComment({
+                issue_number: context.payload.pull_request.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: message,
+              });
+            }
             core.setFailed('No Linked Issue Found!');

--- a/.github/workflows/pr_verify_linked_issue.yml
+++ b/.github/workflows/pr_verify_linked_issue.yml
@@ -22,8 +22,49 @@ jobs:
     runs-on: ubuntu-latest
     name: Ensure Pull Request has a linked issue.
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-issue') }}
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - name: Verify Linked Issue
-        uses: hattan/verify-linked-issue-action@2d8e2e47a462cc7b07ba5e6cab6f9d57bd36672e # v1.1.5
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        with:
+          script: |
+            const body = context.payload.pull_request.body || '';
+            core.debug(`Checking PR body: "${body}"`);
+
+            const matches = [...body.matchAll(/#(\d+)/g)];
+            for (const m of matches) {
+              const issueNumber = parseInt(m[1], 10);
+              try {
+                await github.rest.issues.get({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                });
+                core.notice(`Success! Linked issue #${issueNumber} found in body.`);
+                return;
+              } catch {
+                core.debug(`#${issueNumber} is not a valid issue.`);
+              }
+            }
+
+            const events = await github.paginate(github.rest.issues.listEvents, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+            });
+            if (events.some((e) => e.event === 'connected')) {
+              core.notice('Success! Connected issue found.');
+              return;
+            }
+
+            const message =
+              'Build Error! No Linked Issue found. Please link an issue or mention it in the body using #<issue_id>';
+            await github.rest.issues.createComment({
+              issue_number: context.payload.pull_request.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: message,
+            });
+            core.setFailed('No Linked Issue Found!');


### PR DESCRIPTION
Replace hattan/verify-linked-issue-action with an inline actions/github-script step using /#(\d+)/g, matching issue references regardless of what follows the number. The upstream action has a long-standing bug (hattan/verify-linked-issue-action#5) where its regex requires a whitespace character after the issue number, so a PR body ending exactly with "Closes #N" is never recognised.

Closes #10488