### PR TITLE
fix(bootstrap): defer instance serial bump until resources are committed

### DIFF
--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -781,7 +781,7 @@ func (r *ClusterReconciler) reconcileResources(
 		return *result, err
 	}
 
-	runningJobs := resources.runningJobNames()
+	runningJobs := resources.runningJobNames(cluster)
 
 	// Act on Pods and PVCs only if there is nothing that is currently being created or deleted
 

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -1047,11 +1047,7 @@ func (r *ClusterReconciler) reconcilePods(
 	// Are there missing nodes? Let's create one
 	if cluster.Status.Instances < cluster.Spec.Instances &&
 		instancesStatus.InstancesReportingStatus() == cluster.Status.Instances {
-		newNodeSerial, err := r.generateNodeSerial(ctx, cluster)
-		if err != nil {
-			return ctrl.Result{}, fmt.Errorf("cannot generate node serial: %w", err)
-		}
-		return r.joinReplicaInstance(ctx, newNodeSerial, cluster)
+		return r.joinReplicaInstance(ctx, nextNodeSerial(cluster), cluster)
 	}
 
 	// Should we scale down the cluster?

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -852,7 +852,7 @@ func (r *ClusterReconciler) reconcileResources(
 		return *result, err
 	}
 
-	runningJobs := resources.runningJobNames()
+	runningJobs := resources.runningJobNames(cluster)
 
 	// Act on Pods and PVCs only if there is nothing that is currently being created or deleted
 

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -1118,11 +1118,7 @@ func (r *ClusterReconciler) reconcilePods(
 	// Are there missing nodes? Let's create one
 	if cluster.Status.Instances < cluster.Spec.Instances &&
 		instancesStatus.InstancesReportingStatus() == cluster.Status.Instances {
-		newNodeSerial, err := r.generateNodeSerial(ctx, cluster)
-		if err != nil {
-			return ctrl.Result{}, fmt.Errorf("cannot generate node serial: %w", err)
-		}
-		return r.joinReplicaInstance(ctx, newNodeSerial, cluster)
+		return r.joinReplicaInstance(ctx, nextNodeSerial(cluster), cluster)
 	}
 
 	// Should we scale down the cluster?

--- a/internal/controller/cluster_create.go
+++ b/internal/controller/cluster_create.go
@@ -1086,6 +1086,31 @@ func nextNodeSerial(cluster *apiv1.Cluster) int {
 	return cluster.Status.LatestGeneratedNode + 1
 }
 
+// ensureJobAdoptable verifies that an existing Job with the given name is
+// owned by this cluster and may be adopted by the reconciler. A NotFound
+// on the Get means the cache lags behind the AlreadyExists just reported
+// by Create: short-requeue rather than proceed with unverified adoption.
+func (r *ClusterReconciler) ensureJobAdoptable(
+	ctx context.Context,
+	cluster *apiv1.Cluster,
+	jobName string,
+) (ctrl.Result, error) {
+	var existing batchv1.Job
+	if err := r.Get(ctx, client.ObjectKey{
+		Namespace: cluster.Namespace,
+		Name:      jobName,
+	}, &existing); err != nil {
+		if apierrs.IsNotFound(err) {
+			return ctrl.Result{RequeueAfter: time.Second}, nil
+		}
+		return ctrl.Result{}, fmt.Errorf("cannot get existing job %q for adoption: %w", jobName, err)
+	}
+	if owner, ok := IsOwnedByCluster(&existing); !ok || owner != cluster.Name {
+		return ctrl.Result{}, fmt.Errorf("refusing to adopt job %q: not owned by cluster %q", jobName, cluster.Name)
+	}
+	return ctrl.Result{}, nil
+}
+
 // recordGeneratedNodeSerial persists cluster.Status.LatestGeneratedNode under
 // an optimistic-lock patch. No-op when already at or past nodeSerial, so safe
 // for retries that re-derive the same serial after adopting an existing Job.
@@ -1237,19 +1262,21 @@ func (r *ClusterReconciler) createPrimaryInstance(
 	utils.InheritLabels(&job.Spec.Template.ObjectMeta, cluster.Labels,
 		cluster.GetFixedInheritedLabels(), configuration.Current)
 
-	if err := r.Create(ctx, job); err != nil {
-		if apierrs.IsAlreadyExists(err) {
-			// A previous reconcile created the Job but did not run to
-			// completion. Adopt it so we can persist the counter bump for
-			// this serial.
-			contextLogger.Info("Job already exists, adopting it", "job", job.Name)
-		} else {
-			contextLogger.Error(err, "Unable to create job", "job", job)
-			return ctrl.Result{}, err
-		}
-	} else {
+	switch err := r.Create(ctx, job); {
+	case err == nil:
 		contextLogger.Info("Created new Job", "job", job.Name, "primary", true)
 		r.Recorder.Event(cluster, "Normal", "CreatingInstance", eventMessage)
+	case apierrs.IsAlreadyExists(err):
+		// A previous reconcile created the Job but did not run to
+		// completion. Adopt it so we can persist the counter bump for
+		// this serial.
+		if result, adoptErr := r.ensureJobAdoptable(ctx, cluster, job.Name); adoptErr != nil || !result.IsZero() {
+			return result, adoptErr
+		}
+		contextLogger.Info("Job already exists, adopting it", "job", job.Name)
+	default:
+		contextLogger.Error(err, "Unable to create job", "job", job)
+		return ctrl.Result{}, err
 	}
 
 	if err := r.recordGeneratedNodeSerial(ctx, cluster, nodeSerial); err != nil {
@@ -1332,18 +1359,8 @@ func (r *ClusterReconciler) joinReplicaInstance(
 	utils.InheritLabels(&job.Spec.Template.ObjectMeta, cluster.Labels,
 		cluster.GetFixedInheritedLabels(), configuration.Current)
 
-	if err := r.Create(ctx, job); err != nil {
-		if apierrs.IsAlreadyExists(err) {
-			// A previous reconcile created the Job but did not run to
-			// completion (e.g. a later status patch conflicted). Adopt it
-			// so we can finish creating the PVCs and persist the counter
-			// bump for this serial.
-			contextLogger.Info("Job already exists, adopting it", "job", job.Name)
-		} else {
-			contextLogger.Error(err, "Unable to create Job", "job", job)
-			return ctrl.Result{}, err
-		}
-	} else {
+	switch err := r.Create(ctx, job); {
+	case err == nil:
 		contextLogger.Info("Created new Job",
 			"job", job.Name,
 			"primary", false,
@@ -1352,6 +1369,18 @@ func (r *ClusterReconciler) joinReplicaInstance(
 		)
 		r.Recorder.Eventf(cluster, "Normal", "CreatingInstance",
 			"Creating instance %v-%v", cluster.Name, nodeSerial)
+	case apierrs.IsAlreadyExists(err):
+		// A previous reconcile created the Job but did not run to
+		// completion (e.g. a later status patch conflicted). Adopt it
+		// so we can finish creating the PVCs and persist the counter
+		// bump for this serial.
+		if result, adoptErr := r.ensureJobAdoptable(ctx, cluster, job.Name); adoptErr != nil || !result.IsZero() {
+			return result, adoptErr
+		}
+		contextLogger.Info("Job already exists, adopting it", "job", job.Name)
+	default:
+		contextLogger.Error(err, "Unable to create Job", "job", job)
+		return ctrl.Result{}, err
 	}
 
 	if err := persistentvolumeclaim.CreateInstancePVCs(

--- a/internal/controller/cluster_create.go
+++ b/internal/controller/cluster_create.go
@@ -47,6 +47,7 @@ import (
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/certs"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/postgres"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/reconciler/persistentvolumeclaim"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/resources/status"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/servicespec"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/specs"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
@@ -1077,14 +1078,32 @@ func (r *ClusterReconciler) createRoleBinding(ctx context.Context, cluster *apiv
 	return nil
 }
 
-// generateNodeSerial extracts the first free node serial in this pods
-func (r *ClusterReconciler) generateNodeSerial(ctx context.Context, cluster *apiv1.Cluster) (int, error) {
-	cluster.Status.LatestGeneratedNode++
-	if err := r.Status().Update(ctx, cluster); err != nil {
-		return 0, err
-	}
+// nextNodeSerial returns the next serial without persisting it. Callers must
+// only persist via recordGeneratedNodeSerial after the Job and PVCs for this
+// serial have been committed; persisting earlier leaks the serial on a later
+// reconcile failure.
+func nextNodeSerial(cluster *apiv1.Cluster) int {
+	return cluster.Status.LatestGeneratedNode + 1
+}
 
-	return cluster.Status.LatestGeneratedNode, nil
+// recordGeneratedNodeSerial persists cluster.Status.LatestGeneratedNode under
+// an optimistic-lock patch. No-op when already at or past nodeSerial, so safe
+// for retries that re-derive the same serial after adopting an existing Job.
+func (r *ClusterReconciler) recordGeneratedNodeSerial(
+	ctx context.Context,
+	cluster *apiv1.Cluster,
+	nodeSerial int,
+) error {
+	if cluster.Status.LatestGeneratedNode >= nodeSerial {
+		return nil
+	}
+	return status.PatchWithOptimisticLock(ctx, r.Client, cluster,
+		func(c *apiv1.Cluster) {
+			if c.Status.LatestGeneratedNode < nodeSerial {
+				c.Status.LatestGeneratedNode = nodeSerial
+			}
+		},
+	)
 }
 
 func (r *ClusterReconciler) createPrimaryInstance(
@@ -1144,11 +1163,7 @@ func (r *ClusterReconciler) createPrimaryInstance(
 		recoverySnapshot = persistentvolumeclaim.GetCandidateStorageSourceForPrimary(cluster, backup)
 	}
 
-	// Generate a new node serial
-	nodeSerial, err := r.generateNodeSerial(ctx, cluster)
-	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("cannot generate node serial: %w", err)
-	}
+	nodeSerial := nextNodeSerial(cluster)
 
 	// Create the PVCs from the cluster definition, and if bootstrapping from
 	// recoverySnapshot, use that as the source
@@ -1163,7 +1178,10 @@ func (r *ClusterReconciler) createPrimaryInstance(
 	}
 
 	// We are bootstrapping a cluster and in need to create the first node
-	var job *batchv1.Job
+	var (
+		job          *batchv1.Job
+		eventMessage string
+	)
 
 	isBootstrappingFromRecovery := cluster.Spec.Bootstrap != nil && cluster.Spec.Bootstrap.Recovery != nil
 	isBootstrappingFromBaseBackup := cluster.Spec.Bootstrap != nil && cluster.Spec.Bootstrap.PgBaseBackup != nil
@@ -1178,19 +1196,19 @@ func (r *ClusterReconciler) createPrimaryInstance(
 		if err != nil {
 			return ctrl.Result{}, err
 		}
-		r.Recorder.Event(cluster, "Normal", "CreatingInstance", "Primary instance (from volumeSnapshots)")
+		eventMessage = "Primary instance (from volumeSnapshots)"
 		job = specs.CreatePrimaryJobViaRestoreSnapshot(*cluster, nodeSerial, metadata, backup)
 
 	case isBootstrappingFromRecovery:
-		r.Recorder.Event(cluster, "Normal", "CreatingInstance", "Primary instance (from backup)")
+		eventMessage = "Primary instance (from backup)"
 		job = specs.CreatePrimaryJobViaRecovery(*cluster, nodeSerial, backup)
 
 	case isBootstrappingFromBaseBackup:
-		r.Recorder.Event(cluster, "Normal", "CreatingInstance", "Primary instance (from physical backup)")
+		eventMessage = "Primary instance (from physical backup)"
 		job = specs.CreatePrimaryJobViaPgBaseBackup(*cluster, nodeSerial)
 
 	default:
-		r.Recorder.Event(cluster, "Normal", "CreatingInstance", "Primary instance (initdb)")
+		eventMessage = "Primary instance (initdb)"
 		job = specs.CreatePrimaryJobViaInitdb(*cluster, nodeSerial)
 	}
 
@@ -1200,20 +1218,15 @@ func (r *ClusterReconciler) createPrimaryInstance(
 	}
 
 	podName := fmt.Sprintf("%v-%v", cluster.Name, nodeSerial)
-	if err = r.setPrimaryInstance(ctx, cluster, podName); err != nil {
+	if err := r.setPrimaryInstance(ctx, cluster, podName); err != nil {
 		contextLogger.Error(err, "Unable to set the primary instance name")
 		return ctrl.Result{}, err
 	}
 
-	err = r.RegisterPhase(ctx, cluster, apiv1.PhaseFirstPrimary,
-		fmt.Sprintf("Creating primary instance %v", podName))
-	if err != nil {
+	if err := r.RegisterPhase(ctx, cluster, apiv1.PhaseFirstPrimary,
+		fmt.Sprintf("Creating primary instance %v", podName)); err != nil {
 		return ctrl.Result{}, err
 	}
-
-	contextLogger.Info("Creating new Job",
-		"jobName", job.Name,
-		"primary", true)
 
 	utils.InheritAnnotations(&job.ObjectMeta, cluster.Annotations,
 		cluster.GetFixedInheritedAnnotations(), configuration.Current)
@@ -1224,14 +1237,23 @@ func (r *ClusterReconciler) createPrimaryInstance(
 	utils.InheritLabels(&job.Spec.Template.ObjectMeta, cluster.Labels,
 		cluster.GetFixedInheritedLabels(), configuration.Current)
 
-	if err = r.Create(ctx, job); err != nil {
+	if err := r.Create(ctx, job); err != nil {
 		if apierrs.IsAlreadyExists(err) {
-			// This Job was already created, maybe the cache is stale.
-			return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+			// A previous reconcile created the Job but did not run to
+			// completion. Adopt it so we can persist the counter bump for
+			// this serial.
+			contextLogger.Info("Job already exists, adopting it", "job", job.Name)
+		} else {
+			contextLogger.Error(err, "Unable to create job", "job", job)
+			return ctrl.Result{}, err
 		}
+	} else {
+		contextLogger.Info("Created new Job", "job", job.Name, "primary", true)
+		r.Recorder.Event(cluster, "Normal", "CreatingInstance", eventMessage)
+	}
 
-		contextLogger.Error(err, "Unable to create job", "job", job)
-		return ctrl.Result{}, err
+	if err := r.recordGeneratedNodeSerial(ctx, cluster, nodeSerial); err != nil {
+		return ctrl.Result{}, fmt.Errorf("cannot persist generated node serial: %w", err)
 	}
 
 	return ctrl.Result{RequeueAfter: 30 * time.Second}, ErrNextLoop
@@ -1290,16 +1312,6 @@ func (r *ClusterReconciler) joinReplicaInstance(
 		job = specs.RestoreReplicaInstance(*cluster, nodeSerial)
 	}
 
-	contextLogger.Info("Creating new Job",
-		"job", job.Name,
-		"primary", false,
-		"storageSource", storageSource,
-		"role", job.Spec.Template.Labels[utils.JobRoleLabelName],
-	)
-
-	r.Recorder.Eventf(cluster, "Normal", "CreatingInstance",
-		"Creating instance %v-%v", cluster.Name, nodeSerial)
-
 	if err := r.RegisterPhase(ctx, cluster,
 		apiv1.PhaseCreatingReplica,
 		fmt.Sprintf("Creating replica %v", job.Name)); err != nil {
@@ -1322,13 +1334,24 @@ func (r *ClusterReconciler) joinReplicaInstance(
 
 	if err := r.Create(ctx, job); err != nil {
 		if apierrs.IsAlreadyExists(err) {
-			// This Job was already created, maybe the cache is stale.
-			contextLogger.Info("Job already exist, maybe the cache is stale", "pod", job.Name)
-			return ctrl.Result{RequeueAfter: 30 * time.Second}, ErrNextLoop
+			// A previous reconcile created the Job but did not run to
+			// completion (e.g. a later status patch conflicted). Adopt it
+			// so we can finish creating the PVCs and persist the counter
+			// bump for this serial.
+			contextLogger.Info("Job already exists, adopting it", "job", job.Name)
+		} else {
+			contextLogger.Error(err, "Unable to create Job", "job", job)
+			return ctrl.Result{}, err
 		}
-
-		contextLogger.Error(err, "Unable to create Job", "job", job)
-		return ctrl.Result{}, err
+	} else {
+		contextLogger.Info("Created new Job",
+			"job", job.Name,
+			"primary", false,
+			"storageSource", storageSource,
+			"role", job.Spec.Template.Labels[utils.JobRoleLabelName],
+		)
+		r.Recorder.Eventf(cluster, "Normal", "CreatingInstance",
+			"Creating instance %v-%v", cluster.Name, nodeSerial)
 	}
 
 	if err := persistentvolumeclaim.CreateInstancePVCs(
@@ -1339,6 +1362,10 @@ func (r *ClusterReconciler) joinReplicaInstance(
 		nodeSerial,
 	); err != nil {
 		return ctrl.Result{}, fmt.Errorf("cannot create replica instance PVCs: %w", err)
+	}
+
+	if err := r.recordGeneratedNodeSerial(ctx, cluster, nodeSerial); err != nil {
+		return ctrl.Result{}, fmt.Errorf("cannot persist generated node serial: %w", err)
 	}
 
 	return ctrl.Result{RequeueAfter: 30 * time.Second}, ErrNextLoop

--- a/internal/controller/cluster_create.go
+++ b/internal/controller/cluster_create.go
@@ -1125,6 +1125,31 @@ func nextNodeSerial(cluster *apiv1.Cluster) int {
 	return cluster.Status.LatestGeneratedNode + 1
 }
 
+// ensureJobAdoptable verifies that an existing Job with the given name is
+// owned by this cluster and may be adopted by the reconciler. A NotFound
+// on the Get means the cache lags behind the AlreadyExists just reported
+// by Create: short-requeue rather than proceed with unverified adoption.
+func (r *ClusterReconciler) ensureJobAdoptable(
+	ctx context.Context,
+	cluster *apiv1.Cluster,
+	jobName string,
+) (ctrl.Result, error) {
+	var existing batchv1.Job
+	if err := r.Get(ctx, client.ObjectKey{
+		Namespace: cluster.Namespace,
+		Name:      jobName,
+	}, &existing); err != nil {
+		if apierrs.IsNotFound(err) {
+			return ctrl.Result{RequeueAfter: time.Second}, nil
+		}
+		return ctrl.Result{}, fmt.Errorf("cannot get existing job %q for adoption: %w", jobName, err)
+	}
+	if owner, ok := IsOwnedByCluster(&existing); !ok || owner != cluster.Name {
+		return ctrl.Result{}, fmt.Errorf("refusing to adopt job %q: not owned by cluster %q", jobName, cluster.Name)
+	}
+	return ctrl.Result{}, nil
+}
+
 // recordGeneratedNodeSerial persists cluster.Status.LatestGeneratedNode under
 // an optimistic-lock patch. No-op when already at or past nodeSerial, so safe
 // for retries that re-derive the same serial after adopting an existing Job.
@@ -1276,19 +1301,21 @@ func (r *ClusterReconciler) createPrimaryInstance(
 	utils.InheritLabels(&job.Spec.Template.ObjectMeta, cluster.Labels,
 		cluster.GetFixedInheritedLabels(), configuration.Current)
 
-	if err := r.Create(ctx, job); err != nil {
-		if apierrs.IsAlreadyExists(err) {
-			// A previous reconcile created the Job but did not run to
-			// completion. Adopt it so we can persist the counter bump for
-			// this serial.
-			contextLogger.Info("Job already exists, adopting it", "job", job.Name)
-		} else {
-			contextLogger.Error(err, "Unable to create job", "job", job)
-			return ctrl.Result{}, err
-		}
-	} else {
+	switch err := r.Create(ctx, job); {
+	case err == nil:
 		contextLogger.Info("Created new Job", "job", job.Name, "primary", true)
 		r.Recorder.Event(cluster, "Normal", "CreatingInstance", eventMessage)
+	case apierrs.IsAlreadyExists(err):
+		// A previous reconcile created the Job but did not run to
+		// completion. Adopt it so we can persist the counter bump for
+		// this serial.
+		if result, adoptErr := r.ensureJobAdoptable(ctx, cluster, job.Name); adoptErr != nil || !result.IsZero() {
+			return result, adoptErr
+		}
+		contextLogger.Info("Job already exists, adopting it", "job", job.Name)
+	default:
+		contextLogger.Error(err, "Unable to create job", "job", job)
+		return ctrl.Result{}, err
 	}
 
 	if err := r.recordGeneratedNodeSerial(ctx, cluster, nodeSerial); err != nil {
@@ -1371,18 +1398,8 @@ func (r *ClusterReconciler) joinReplicaInstance(
 	utils.InheritLabels(&job.Spec.Template.ObjectMeta, cluster.Labels,
 		cluster.GetFixedInheritedLabels(), configuration.Current)
 
-	if err := r.Create(ctx, job); err != nil {
-		if apierrs.IsAlreadyExists(err) {
-			// A previous reconcile created the Job but did not run to
-			// completion (e.g. a later status patch conflicted). Adopt it
-			// so we can finish creating the PVCs and persist the counter
-			// bump for this serial.
-			contextLogger.Info("Job already exists, adopting it", "job", job.Name)
-		} else {
-			contextLogger.Error(err, "Unable to create Job", "job", job)
-			return ctrl.Result{}, err
-		}
-	} else {
+	switch err := r.Create(ctx, job); {
+	case err == nil:
 		contextLogger.Info("Created new Job",
 			"job", job.Name,
 			"primary", false,
@@ -1391,6 +1408,18 @@ func (r *ClusterReconciler) joinReplicaInstance(
 		)
 		r.Recorder.Eventf(cluster, "Normal", "CreatingInstance",
 			"Creating instance %v-%v", cluster.Name, nodeSerial)
+	case apierrs.IsAlreadyExists(err):
+		// A previous reconcile created the Job but did not run to
+		// completion (e.g. a later status patch conflicted). Adopt it
+		// so we can finish creating the PVCs and persist the counter
+		// bump for this serial.
+		if result, adoptErr := r.ensureJobAdoptable(ctx, cluster, job.Name); adoptErr != nil || !result.IsZero() {
+			return result, adoptErr
+		}
+		contextLogger.Info("Job already exists, adopting it", "job", job.Name)
+	default:
+		contextLogger.Error(err, "Unable to create Job", "job", job)
+		return ctrl.Result{}, err
 	}
 
 	if err := persistentvolumeclaim.CreateInstancePVCs(

--- a/internal/controller/cluster_create.go
+++ b/internal/controller/cluster_create.go
@@ -47,6 +47,7 @@ import (
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/certs"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/postgres"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/reconciler/persistentvolumeclaim"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/resources/status"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/servicespec"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/specs"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
@@ -1116,14 +1117,32 @@ func (r *ClusterReconciler) createRoleBinding(ctx context.Context, cluster *apiv
 	return nil
 }
 
-// generateNodeSerial extracts the first free node serial in this pods
-func (r *ClusterReconciler) generateNodeSerial(ctx context.Context, cluster *apiv1.Cluster) (int, error) {
-	cluster.Status.LatestGeneratedNode++
-	if err := r.Status().Update(ctx, cluster); err != nil {
-		return 0, err
-	}
+// nextNodeSerial returns the next serial without persisting it. Callers must
+// only persist via recordGeneratedNodeSerial after the Job and PVCs for this
+// serial have been committed; persisting earlier leaks the serial on a later
+// reconcile failure.
+func nextNodeSerial(cluster *apiv1.Cluster) int {
+	return cluster.Status.LatestGeneratedNode + 1
+}
 
-	return cluster.Status.LatestGeneratedNode, nil
+// recordGeneratedNodeSerial persists cluster.Status.LatestGeneratedNode under
+// an optimistic-lock patch. No-op when already at or past nodeSerial, so safe
+// for retries that re-derive the same serial after adopting an existing Job.
+func (r *ClusterReconciler) recordGeneratedNodeSerial(
+	ctx context.Context,
+	cluster *apiv1.Cluster,
+	nodeSerial int,
+) error {
+	if cluster.Status.LatestGeneratedNode >= nodeSerial {
+		return nil
+	}
+	return status.PatchWithOptimisticLock(ctx, r.Client, cluster,
+		func(c *apiv1.Cluster) {
+			if c.Status.LatestGeneratedNode < nodeSerial {
+				c.Status.LatestGeneratedNode = nodeSerial
+			}
+		},
+	)
 }
 
 func (r *ClusterReconciler) createPrimaryInstance(
@@ -1183,11 +1202,7 @@ func (r *ClusterReconciler) createPrimaryInstance(
 		recoverySnapshot = persistentvolumeclaim.GetCandidateStorageSourceForPrimary(cluster, backup)
 	}
 
-	// Generate a new node serial
-	nodeSerial, err := r.generateNodeSerial(ctx, cluster)
-	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("cannot generate node serial: %w", err)
-	}
+	nodeSerial := nextNodeSerial(cluster)
 
 	// Create the PVCs from the cluster definition, and if bootstrapping from
 	// recoverySnapshot, use that as the source
@@ -1202,7 +1217,10 @@ func (r *ClusterReconciler) createPrimaryInstance(
 	}
 
 	// We are bootstrapping a cluster and in need to create the first node
-	var job *batchv1.Job
+	var (
+		job          *batchv1.Job
+		eventMessage string
+	)
 
 	isBootstrappingFromRecovery := cluster.Spec.Bootstrap != nil && cluster.Spec.Bootstrap.Recovery != nil
 	isBootstrappingFromBaseBackup := cluster.Spec.Bootstrap != nil && cluster.Spec.Bootstrap.PgBaseBackup != nil
@@ -1217,19 +1235,19 @@ func (r *ClusterReconciler) createPrimaryInstance(
 		if err != nil {
 			return ctrl.Result{}, err
 		}
-		r.Recorder.Event(cluster, "Normal", "CreatingInstance", "Primary instance (from volumeSnapshots)")
+		eventMessage = "Primary instance (from volumeSnapshots)"
 		job = specs.CreatePrimaryJobViaRestoreSnapshot(*cluster, nodeSerial, metadata, backup)
 
 	case isBootstrappingFromRecovery:
-		r.Recorder.Event(cluster, "Normal", "CreatingInstance", "Primary instance (from backup)")
+		eventMessage = "Primary instance (from backup)"
 		job = specs.CreatePrimaryJobViaRecovery(*cluster, nodeSerial, backup)
 
 	case isBootstrappingFromBaseBackup:
-		r.Recorder.Event(cluster, "Normal", "CreatingInstance", "Primary instance (from physical backup)")
+		eventMessage = "Primary instance (from physical backup)"
 		job = specs.CreatePrimaryJobViaPgBaseBackup(*cluster, nodeSerial)
 
 	default:
-		r.Recorder.Event(cluster, "Normal", "CreatingInstance", "Primary instance (initdb)")
+		eventMessage = "Primary instance (initdb)"
 		job = specs.CreatePrimaryJobViaInitdb(*cluster, nodeSerial)
 	}
 
@@ -1239,20 +1257,15 @@ func (r *ClusterReconciler) createPrimaryInstance(
 	}
 
 	podName := fmt.Sprintf("%v-%v", cluster.Name, nodeSerial)
-	if err = r.setPrimaryInstance(ctx, cluster, podName); err != nil {
+	if err := r.setPrimaryInstance(ctx, cluster, podName); err != nil {
 		contextLogger.Error(err, "Unable to set the primary instance name")
 		return ctrl.Result{}, err
 	}
 
-	err = r.RegisterPhase(ctx, cluster, apiv1.PhaseFirstPrimary,
-		fmt.Sprintf("Creating primary instance %v", podName))
-	if err != nil {
+	if err := r.RegisterPhase(ctx, cluster, apiv1.PhaseFirstPrimary,
+		fmt.Sprintf("Creating primary instance %v", podName)); err != nil {
 		return ctrl.Result{}, err
 	}
-
-	contextLogger.Info("Creating new Job",
-		"jobName", job.Name,
-		"primary", true)
 
 	utils.InheritAnnotations(&job.ObjectMeta, cluster.Annotations,
 		cluster.GetFixedInheritedAnnotations(), configuration.Current)
@@ -1263,14 +1276,23 @@ func (r *ClusterReconciler) createPrimaryInstance(
 	utils.InheritLabels(&job.Spec.Template.ObjectMeta, cluster.Labels,
 		cluster.GetFixedInheritedLabels(), configuration.Current)
 
-	if err = r.Create(ctx, job); err != nil {
+	if err := r.Create(ctx, job); err != nil {
 		if apierrs.IsAlreadyExists(err) {
-			// This Job was already created, maybe the cache is stale.
-			return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+			// A previous reconcile created the Job but did not run to
+			// completion. Adopt it so we can persist the counter bump for
+			// this serial.
+			contextLogger.Info("Job already exists, adopting it", "job", job.Name)
+		} else {
+			contextLogger.Error(err, "Unable to create job", "job", job)
+			return ctrl.Result{}, err
 		}
+	} else {
+		contextLogger.Info("Created new Job", "job", job.Name, "primary", true)
+		r.Recorder.Event(cluster, "Normal", "CreatingInstance", eventMessage)
+	}
 
-		contextLogger.Error(err, "Unable to create job", "job", job)
-		return ctrl.Result{}, err
+	if err := r.recordGeneratedNodeSerial(ctx, cluster, nodeSerial); err != nil {
+		return ctrl.Result{}, fmt.Errorf("cannot persist generated node serial: %w", err)
 	}
 
 	return ctrl.Result{RequeueAfter: 30 * time.Second}, ErrNextLoop
@@ -1329,16 +1351,6 @@ func (r *ClusterReconciler) joinReplicaInstance(
 		job = specs.RestoreReplicaInstance(*cluster, nodeSerial)
 	}
 
-	contextLogger.Info("Creating new Job",
-		"job", job.Name,
-		"primary", false,
-		"storageSource", storageSource,
-		"role", job.Spec.Template.Labels[utils.JobRoleLabelName],
-	)
-
-	r.Recorder.Eventf(cluster, "Normal", "CreatingInstance",
-		"Creating instance %v-%v", cluster.Name, nodeSerial)
-
 	if err := r.RegisterPhase(ctx, cluster,
 		apiv1.PhaseCreatingReplica,
 		fmt.Sprintf("Creating replica %v", job.Name)); err != nil {
@@ -1361,13 +1373,24 @@ func (r *ClusterReconciler) joinReplicaInstance(
 
 	if err := r.Create(ctx, job); err != nil {
 		if apierrs.IsAlreadyExists(err) {
-			// This Job was already created, maybe the cache is stale.
-			contextLogger.Info("Job already exist, maybe the cache is stale", "pod", job.Name)
-			return ctrl.Result{RequeueAfter: 30 * time.Second}, ErrNextLoop
+			// A previous reconcile created the Job but did not run to
+			// completion (e.g. a later status patch conflicted). Adopt it
+			// so we can finish creating the PVCs and persist the counter
+			// bump for this serial.
+			contextLogger.Info("Job already exists, adopting it", "job", job.Name)
+		} else {
+			contextLogger.Error(err, "Unable to create Job", "job", job)
+			return ctrl.Result{}, err
 		}
-
-		contextLogger.Error(err, "Unable to create Job", "job", job)
-		return ctrl.Result{}, err
+	} else {
+		contextLogger.Info("Created new Job",
+			"job", job.Name,
+			"primary", false,
+			"storageSource", storageSource,
+			"role", job.Spec.Template.Labels[utils.JobRoleLabelName],
+		)
+		r.Recorder.Eventf(cluster, "Normal", "CreatingInstance",
+			"Creating instance %v-%v", cluster.Name, nodeSerial)
 	}
 
 	if err := persistentvolumeclaim.CreateInstancePVCs(
@@ -1378,6 +1401,10 @@ func (r *ClusterReconciler) joinReplicaInstance(
 		nodeSerial,
 	); err != nil {
 		return ctrl.Result{}, fmt.Errorf("cannot create replica instance PVCs: %w", err)
+	}
+
+	if err := r.recordGeneratedNodeSerial(ctx, cluster, nodeSerial); err != nil {
+		return ctrl.Result{}, fmt.Errorf("cannot persist generated node serial: %w", err)
 	}
 
 	return ctrl.Result{RequeueAfter: 30 * time.Second}, ErrNextLoop

--- a/internal/controller/cluster_create.go
+++ b/internal/controller/cluster_create.go
@@ -1163,6 +1163,9 @@ func (r *ClusterReconciler) recordGeneratedNodeSerial(
 	}
 	return status.PatchWithOptimisticLock(ctx, r.Client, cluster,
 		func(c *apiv1.Cluster) {
+			// Re-checked on the server-fresh copy PatchWithOptimisticLock
+			// refetches: the outer guard only saw the stale in-memory value,
+			// so this also guards a concurrent reconcile that already advanced it.
 			if c.Status.LatestGeneratedNode < nodeSerial {
 				c.Status.LatestGeneratedNode = nodeSerial
 			}

--- a/internal/controller/cluster_create_test.go
+++ b/internal/controller/cluster_create_test.go
@@ -1592,10 +1592,20 @@ var _ = Describe("node serial allocation", func() {
 		})
 	})
 
-	Describe("joinReplicaInstance counter safety", func() {
+	Describe("Job adoption safety", func() {
 		scheme := schemeBuilder.BuildWithAllKnownScheme()
 
-		newCluster := func() *apiv1.Cluster {
+		clusterOwnerRef := func(cluster *apiv1.Cluster) metav1.OwnerReference {
+			return metav1.OwnerReference{
+				APIVersion: apiv1.SchemeGroupVersion.String(),
+				Kind:       apiv1.ClusterKind,
+				Name:       cluster.Name,
+				UID:        cluster.UID,
+				Controller: ptr.To(true),
+			}
+		}
+
+		newReplicaCluster := func() *apiv1.Cluster {
 			cluster := &apiv1.Cluster{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       apiv1.ClusterKind,
@@ -1619,6 +1629,14 @@ var _ = Describe("node serial allocation", func() {
 			return cluster
 		}
 
+		newPrimaryCluster := func() *apiv1.Cluster {
+			cluster := newReplicaCluster()
+			cluster.Spec.Instances = 1
+			cluster.Status.LatestGeneratedNode = 0
+			cluster.Status.Instances = 0
+			return cluster
+		}
+
 		buildClient := func(cluster *apiv1.Cluster, extraObjs []k8client.Object,
 			fns interceptor.Funcs,
 		) k8client.WithWatch {
@@ -1635,77 +1653,215 @@ var _ = Describe("node serial allocation", func() {
 				Build()
 		}
 
-		It("does not advance LatestGeneratedNode when the status patch fails", func(ctx SpecContext) {
-			cluster := newCluster()
+		forceStatusConflict := interceptor.Funcs{
+			SubResourcePatch: func(
+				ctx context.Context,
+				cl k8client.Client,
+				subResourceName string,
+				obj k8client.Object,
+				patch k8client.Patch,
+				opts ...k8client.SubResourcePatchOption,
+			) error {
+				if _, isCluster := obj.(*apiv1.Cluster); isCluster && subResourceName == "status" {
+					return apierrs.NewConflict(
+						schema.GroupResource{
+							Group:    apiv1.SchemeGroupVersion.Group,
+							Resource: "clusters",
+						},
+						obj.GetName(),
+						fmt.Errorf("forced conflict"),
+					)
+				}
+				return cl.SubResource(subResourceName).Patch(ctx, obj, patch, opts...)
+			},
+			SubResourceUpdate: func(
+				ctx context.Context,
+				cl k8client.Client,
+				subResourceName string,
+				obj k8client.Object,
+				opts ...k8client.SubResourceUpdateOption,
+			) error {
+				if _, isCluster := obj.(*apiv1.Cluster); isCluster && subResourceName == "status" {
+					return apierrs.NewConflict(
+						schema.GroupResource{
+							Group:    apiv1.SchemeGroupVersion.Group,
+							Resource: "clusters",
+						},
+						obj.GetName(),
+						fmt.Errorf("forced conflict"),
+					)
+				}
+				return cl.SubResource(subResourceName).Update(ctx, obj, opts...)
+			},
+		}
 
-			cl := buildClient(cluster, nil, interceptor.Funcs{
-				SubResourcePatch: func(
-					ctx context.Context,
-					cl k8client.Client,
-					subResourceName string,
-					obj k8client.Object,
-					patch k8client.Patch,
-					opts ...k8client.SubResourcePatchOption,
-				) error {
-					if _, isCluster := obj.(*apiv1.Cluster); isCluster && subResourceName == "status" {
-						return apierrs.NewConflict(
-							schema.GroupResource{
-								Group:    apiv1.SchemeGroupVersion.Group,
-								Resource: "clusters",
-							},
-							obj.GetName(),
-							fmt.Errorf("forced conflict"),
-						)
-					}
-					return cl.SubResource(subResourceName).Patch(ctx, obj, patch, opts...)
-				},
+		Context("joinReplicaInstance", func() {
+			It("does not advance LatestGeneratedNode when a status write fails", func(ctx SpecContext) {
+				cluster := newReplicaCluster()
+				cl := buildClient(cluster, nil, forceStatusConflict)
+
+				r := &ClusterReconciler{
+					Client:   cl,
+					Scheme:   scheme,
+					Recorder: record.NewFakeRecorder(10),
+				}
+
+				_, err := r.joinReplicaInstance(ctx, nextNodeSerial(cluster), cluster)
+				Expect(err).To(HaveOccurred())
+
+				var fetched apiv1.Cluster
+				Expect(cl.Get(ctx, k8client.ObjectKeyFromObject(cluster), &fetched)).To(Succeed())
+				Expect(fetched.Status.LatestGeneratedNode).To(Equal(1))
 			})
 
-			r := &ClusterReconciler{
-				Client:   cl,
-				Scheme:   scheme,
-				Recorder: record.NewFakeRecorder(10),
-			}
+			It("adopts an owned existing Job and persists the serial bump", func(ctx SpecContext) {
+				cluster := newReplicaCluster()
+				existingJob := &batchv1.Job{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            specs.GetInstanceName(cluster.Name, 2) + "-join",
+						Namespace:       cluster.Namespace,
+						OwnerReferences: []metav1.OwnerReference{clusterOwnerRef(cluster)},
+					},
+				}
 
-			_, err := r.joinReplicaInstance(ctx, nextNodeSerial(cluster), cluster)
-			Expect(err).To(HaveOccurred())
+				cl := buildClient(cluster, []k8client.Object{existingJob}, interceptor.Funcs{})
 
-			var fetched apiv1.Cluster
-			Expect(cl.Get(ctx, k8client.ObjectKeyFromObject(cluster), &fetched)).To(Succeed())
-			Expect(fetched.Status.LatestGeneratedNode).To(Equal(1))
+				r := &ClusterReconciler{
+					Client:   cl,
+					Scheme:   scheme,
+					Recorder: record.NewFakeRecorder(10),
+				}
+
+				_, err := r.joinReplicaInstance(ctx, nextNodeSerial(cluster), cluster)
+				Expect(errors.Is(err, ErrNextLoop)).To(BeTrue(), "expected ErrNextLoop, got %v", err)
+
+				var fetched apiv1.Cluster
+				Expect(cl.Get(ctx, k8client.ObjectKeyFromObject(cluster), &fetched)).To(Succeed())
+				Expect(fetched.Status.LatestGeneratedNode).To(Equal(2))
+
+				var pvcs corev1.PersistentVolumeClaimList
+				Expect(cl.List(ctx, &pvcs, k8client.InNamespace(cluster.Namespace))).To(Succeed())
+				pvcNames := make([]string, 0, len(pvcs.Items))
+				for i := range pvcs.Items {
+					pvcNames = append(pvcNames, pvcs.Items[i].Name)
+				}
+				Expect(pvcNames).To(ContainElement(specs.GetInstanceName(cluster.Name, 2)))
+			})
+
+			It("refuses to adopt a Job not owned by the cluster", func(ctx SpecContext) {
+				cluster := newReplicaCluster()
+				existingJob := &batchv1.Job{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      specs.GetInstanceName(cluster.Name, 2) + "-join",
+						Namespace: cluster.Namespace,
+					},
+				}
+
+				cl := buildClient(cluster, []k8client.Object{existingJob}, interceptor.Funcs{})
+
+				r := &ClusterReconciler{
+					Client:   cl,
+					Scheme:   scheme,
+					Recorder: record.NewFakeRecorder(10),
+				}
+
+				_, err := r.joinReplicaInstance(ctx, nextNodeSerial(cluster), cluster)
+				Expect(err).To(MatchError(ContainSubstring("refusing to adopt job")))
+
+				var fetched apiv1.Cluster
+				Expect(cl.Get(ctx, k8client.ObjectKeyFromObject(cluster), &fetched)).To(Succeed())
+				Expect(fetched.Status.LatestGeneratedNode).To(Equal(1))
+			})
+
+			It("requeues without error when the cache lags behind AlreadyExists", func(ctx SpecContext) {
+				cluster := newReplicaCluster()
+				jobName := specs.GetInstanceName(cluster.Name, 2) + "-join"
+				staleCache := interceptor.Funcs{
+					Create: func(
+						ctx context.Context,
+						_ k8client.WithWatch,
+						obj k8client.Object,
+						_ ...k8client.CreateOption,
+					) error {
+						if j, ok := obj.(*batchv1.Job); ok && j.Name == jobName {
+							return apierrs.NewAlreadyExists(
+								schema.GroupResource{Group: "batch", Resource: "jobs"},
+								j.Name,
+							)
+						}
+						return nil
+					},
+				}
+
+				cl := buildClient(cluster, nil, staleCache)
+
+				r := &ClusterReconciler{
+					Client:   cl,
+					Scheme:   scheme,
+					Recorder: record.NewFakeRecorder(10),
+				}
+
+				result, err := r.joinReplicaInstance(ctx, nextNodeSerial(cluster), cluster)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result.RequeueAfter).To(BeNumerically(">", 0))
+
+				var fetched apiv1.Cluster
+				Expect(cl.Get(ctx, k8client.ObjectKeyFromObject(cluster), &fetched)).To(Succeed())
+				Expect(fetched.Status.LatestGeneratedNode).To(Equal(1))
+			})
 		})
 
-		It("adopts an existing Job and persists the serial bump", func(ctx SpecContext) {
-			cluster := newCluster()
-			existingJob := &batchv1.Job{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      specs.GetInstanceName(cluster.Name, 2) + "-join",
-					Namespace: cluster.Namespace,
-				},
-			}
+		Context("createPrimaryInstance", func() {
+			It("adopts an owned existing Job and persists the serial bump", func(ctx SpecContext) {
+				cluster := newPrimaryCluster()
+				existingJob := &batchv1.Job{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            specs.GetInstanceName(cluster.Name, 1) + "-initdb",
+						Namespace:       cluster.Namespace,
+						OwnerReferences: []metav1.OwnerReference{clusterOwnerRef(cluster)},
+					},
+				}
 
-			cl := buildClient(cluster, []k8client.Object{existingJob}, interceptor.Funcs{})
+				cl := buildClient(cluster, []k8client.Object{existingJob}, interceptor.Funcs{})
 
-			r := &ClusterReconciler{
-				Client:   cl,
-				Scheme:   scheme,
-				Recorder: record.NewFakeRecorder(10),
-			}
+				r := &ClusterReconciler{
+					Client:   cl,
+					Scheme:   scheme,
+					Recorder: record.NewFakeRecorder(10),
+				}
 
-			_, err := r.joinReplicaInstance(ctx, nextNodeSerial(cluster), cluster)
-			Expect(errors.Is(err, ErrNextLoop)).To(BeTrue(), "expected ErrNextLoop, got %v", err)
+				_, err := r.createPrimaryInstance(ctx, cluster)
+				Expect(errors.Is(err, ErrNextLoop)).To(BeTrue(), "expected ErrNextLoop, got %v", err)
 
-			var fetched apiv1.Cluster
-			Expect(cl.Get(ctx, k8client.ObjectKeyFromObject(cluster), &fetched)).To(Succeed())
-			Expect(fetched.Status.LatestGeneratedNode).To(Equal(2))
+				var fetched apiv1.Cluster
+				Expect(cl.Get(ctx, k8client.ObjectKeyFromObject(cluster), &fetched)).To(Succeed())
+				Expect(fetched.Status.LatestGeneratedNode).To(Equal(1))
+			})
 
-			var pvcs corev1.PersistentVolumeClaimList
-			Expect(cl.List(ctx, &pvcs, k8client.InNamespace(cluster.Namespace))).To(Succeed())
-			pvcNames := make([]string, 0, len(pvcs.Items))
-			for i := range pvcs.Items {
-				pvcNames = append(pvcNames, pvcs.Items[i].Name)
-			}
-			Expect(pvcNames).To(ContainElement(specs.GetInstanceName(cluster.Name, 2)))
+			It("refuses to adopt a primary Job not owned by the cluster", func(ctx SpecContext) {
+				cluster := newPrimaryCluster()
+				existingJob := &batchv1.Job{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      specs.GetInstanceName(cluster.Name, 1) + "-initdb",
+						Namespace: cluster.Namespace,
+					},
+				}
+
+				cl := buildClient(cluster, []k8client.Object{existingJob}, interceptor.Funcs{})
+
+				r := &ClusterReconciler{
+					Client:   cl,
+					Scheme:   scheme,
+					Recorder: record.NewFakeRecorder(10),
+				}
+
+				_, err := r.createPrimaryInstance(ctx, cluster)
+				Expect(err).To(MatchError(ContainSubstring("refusing to adopt job")))
+
+				var fetched apiv1.Cluster
+				Expect(cl.Get(ctx, k8client.ObjectKeyFromObject(cluster), &fetched)).To(Succeed())
+				Expect(fetched.Status.LatestGeneratedNode).To(Equal(0))
+			})
 		})
 	})
 })

--- a/internal/controller/cluster_create_test.go
+++ b/internal/controller/cluster_create_test.go
@@ -21,14 +21,18 @@ package controller
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
 	volumesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/discovery"
@@ -38,6 +42,7 @@ import (
 	"k8s.io/utils/ptr"
 	k8client "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
@@ -1538,5 +1543,169 @@ var _ = Describe("ServiceAccount with custom name", func() {
 		Expect(rb.Subjects[0].Kind).To(Equal("ServiceAccount"))
 		Expect(rb.Subjects[0].Name).To(Equal("shared-sa"))
 		Expect(rb.Subjects[0].Namespace).To(Equal(namespace))
+	})
+})
+
+var _ = Describe("node serial allocation", func() {
+	var env *testingEnvironment
+	BeforeEach(func() {
+		env = buildTestEnvironment()
+	})
+
+	Describe("nextNodeSerial", func() {
+		It("returns LatestGeneratedNode + 1 without mutating the cluster", func() {
+			cluster := &apiv1.Cluster{
+				Status: apiv1.ClusterStatus{LatestGeneratedNode: 5},
+			}
+			Expect(nextNodeSerial(cluster)).To(Equal(6))
+			Expect(cluster.Status.LatestGeneratedNode).To(Equal(5))
+		})
+
+		It("returns 1 for a fresh cluster", func() {
+			Expect(nextNodeSerial(&apiv1.Cluster{})).To(Equal(1))
+		})
+	})
+
+	Describe("recordGeneratedNodeSerial", func() {
+		It("advances and persists the counter when below the target", func(ctx SpecContext) {
+			namespace := newFakeNamespace(env.client)
+			cluster := newFakeCNPGCluster(env.client, namespace, func(c *apiv1.Cluster) {
+				c.Status.LatestGeneratedNode = 1
+			})
+
+			Expect(env.clusterReconciler.recordGeneratedNodeSerial(ctx, cluster, 2)).To(Succeed())
+			Expect(cluster.Status.LatestGeneratedNode).To(Equal(2))
+
+			var fetched apiv1.Cluster
+			Expect(env.client.Get(ctx, k8client.ObjectKeyFromObject(cluster), &fetched)).To(Succeed())
+			Expect(fetched.Status.LatestGeneratedNode).To(Equal(2))
+		})
+
+		It("is a no-op when the counter already matches the target", func(ctx SpecContext) {
+			namespace := newFakeNamespace(env.client)
+			cluster := newFakeCNPGCluster(env.client, namespace, func(c *apiv1.Cluster) {
+				c.Status.LatestGeneratedNode = 3
+			})
+
+			Expect(env.clusterReconciler.recordGeneratedNodeSerial(ctx, cluster, 3)).To(Succeed())
+			Expect(cluster.Status.LatestGeneratedNode).To(Equal(3))
+		})
+	})
+
+	Describe("joinReplicaInstance counter safety", func() {
+		scheme := schemeBuilder.BuildWithAllKnownScheme()
+
+		newCluster := func() *apiv1.Cluster {
+			cluster := &apiv1.Cluster{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       apiv1.ClusterKind,
+					APIVersion: apiv1.SchemeGroupVersion.String(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "default",
+					UID:       "test-cluster-uid",
+				},
+				Spec: apiv1.ClusterSpec{
+					Instances:            2,
+					StorageConfiguration: apiv1.StorageConfiguration{Size: "1Gi"},
+				},
+				Status: apiv1.ClusterStatus{
+					LatestGeneratedNode: 1,
+					Instances:           1,
+				},
+			}
+			cluster.SetDefaults()
+			return cluster
+		}
+
+		buildClient := func(cluster *apiv1.Cluster, extraObjs []k8client.Object,
+			fns interceptor.Funcs,
+		) k8client.WithWatch {
+			objs := append([]k8client.Object{cluster}, extraObjs...)
+			return fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithStatusSubresource(&apiv1.Cluster{}).
+				WithIndex(&batchv1.Job{}, jobOwnerKey, jobOwnerIndexFunc).
+				WithIndex(&apiv1.Backup{}, ".spec.cluster.name", func(rawObj k8client.Object) []string {
+					return []string{rawObj.(*apiv1.Backup).Spec.Cluster.Name}
+				}).
+				WithObjects(objs...).
+				WithInterceptorFuncs(fns).
+				Build()
+		}
+
+		It("does not advance LatestGeneratedNode when the status patch fails", func(ctx SpecContext) {
+			cluster := newCluster()
+
+			cl := buildClient(cluster, nil, interceptor.Funcs{
+				SubResourcePatch: func(
+					ctx context.Context,
+					cl k8client.Client,
+					subResourceName string,
+					obj k8client.Object,
+					patch k8client.Patch,
+					opts ...k8client.SubResourcePatchOption,
+				) error {
+					if _, isCluster := obj.(*apiv1.Cluster); isCluster && subResourceName == "status" {
+						return apierrs.NewConflict(
+							schema.GroupResource{
+								Group:    apiv1.SchemeGroupVersion.Group,
+								Resource: "clusters",
+							},
+							obj.GetName(),
+							fmt.Errorf("forced conflict"),
+						)
+					}
+					return cl.SubResource(subResourceName).Patch(ctx, obj, patch, opts...)
+				},
+			})
+
+			r := &ClusterReconciler{
+				Client:   cl,
+				Scheme:   scheme,
+				Recorder: record.NewFakeRecorder(10),
+			}
+
+			_, err := r.joinReplicaInstance(ctx, nextNodeSerial(cluster), cluster)
+			Expect(err).To(HaveOccurred())
+
+			var fetched apiv1.Cluster
+			Expect(cl.Get(ctx, k8client.ObjectKeyFromObject(cluster), &fetched)).To(Succeed())
+			Expect(fetched.Status.LatestGeneratedNode).To(Equal(1))
+		})
+
+		It("adopts an existing Job and persists the serial bump", func(ctx SpecContext) {
+			cluster := newCluster()
+			existingJob := &batchv1.Job{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      specs.GetInstanceName(cluster.Name, 2) + "-join",
+					Namespace: cluster.Namespace,
+				},
+			}
+
+			cl := buildClient(cluster, []k8client.Object{existingJob}, interceptor.Funcs{})
+
+			r := &ClusterReconciler{
+				Client:   cl,
+				Scheme:   scheme,
+				Recorder: record.NewFakeRecorder(10),
+			}
+
+			_, err := r.joinReplicaInstance(ctx, nextNodeSerial(cluster), cluster)
+			Expect(errors.Is(err, ErrNextLoop)).To(BeTrue(), "expected ErrNextLoop, got %v", err)
+
+			var fetched apiv1.Cluster
+			Expect(cl.Get(ctx, k8client.ObjectKeyFromObject(cluster), &fetched)).To(Succeed())
+			Expect(fetched.Status.LatestGeneratedNode).To(Equal(2))
+
+			var pvcs corev1.PersistentVolumeClaimList
+			Expect(cl.List(ctx, &pvcs, k8client.InNamespace(cluster.Namespace))).To(Succeed())
+			pvcNames := make([]string, 0, len(pvcs.Items))
+			for i := range pvcs.Items {
+				pvcNames = append(pvcNames, pvcs.Items[i].Name)
+			}
+			Expect(pvcNames).To(ContainElement(specs.GetInstanceName(cluster.Name, 2)))
+		})
 	})
 })

--- a/internal/controller/cluster_create_test.go
+++ b/internal/controller/cluster_create_test.go
@@ -1653,7 +1653,12 @@ var _ = Describe("node serial allocation", func() {
 				Build()
 		}
 
-		forceStatusConflict := interceptor.Funcs{
+		// conflictOnSerialBump forces an optimistic-lock conflict only on the
+		// status write that advances LatestGeneratedNode to serial 2 (the value
+		// recordGeneratedNodeSerial persists for this 1->2 scale-up). The earlier
+		// RegisterPhase write, which leaves the counter at 1, is let through, so
+		// the Job and PVCs are created and only the final counter persist fails.
+		conflictOnSerialBump := interceptor.Funcs{
 			SubResourcePatch: func(
 				ctx context.Context,
 				cl k8client.Client,
@@ -1662,7 +1667,8 @@ var _ = Describe("node serial allocation", func() {
 				patch k8client.Patch,
 				opts ...k8client.SubResourcePatchOption,
 			) error {
-				if _, isCluster := obj.(*apiv1.Cluster); isCluster && subResourceName == "status" {
+				if c, isCluster := obj.(*apiv1.Cluster); isCluster && subResourceName == "status" &&
+					c.Status.LatestGeneratedNode >= 2 {
 					return apierrs.NewConflict(
 						schema.GroupResource{
 							Group:    apiv1.SchemeGroupVersion.Group,
@@ -1681,7 +1687,8 @@ var _ = Describe("node serial allocation", func() {
 				obj k8client.Object,
 				opts ...k8client.SubResourceUpdateOption,
 			) error {
-				if _, isCluster := obj.(*apiv1.Cluster); isCluster && subResourceName == "status" {
+				if c, isCluster := obj.(*apiv1.Cluster); isCluster && subResourceName == "status" &&
+					c.Status.LatestGeneratedNode >= 2 {
 					return apierrs.NewConflict(
 						schema.GroupResource{
 							Group:    apiv1.SchemeGroupVersion.Group,
@@ -1696,9 +1703,10 @@ var _ = Describe("node serial allocation", func() {
 		}
 
 		Context("joinReplicaInstance", func() {
-			It("does not advance LatestGeneratedNode when a status write fails", func(ctx SpecContext) {
+			It("does not advance LatestGeneratedNode when persisting the serial fails "+
+				"after the Job and PVCs are created", func(ctx SpecContext) {
 				cluster := newReplicaCluster()
-				cl := buildClient(cluster, nil, forceStatusConflict)
+				cl := buildClient(cluster, nil, conflictOnSerialBump)
 
 				r := &ClusterReconciler{
 					Client:   cl,
@@ -1708,6 +1716,17 @@ var _ = Describe("node serial allocation", func() {
 
 				_, err := r.joinReplicaInstance(ctx, nextNodeSerial(cluster), cluster)
 				Expect(err).To(HaveOccurred())
+
+				// The PVC for the new serial was created before the counter
+				// persist failed: resources are committed but the counter stays
+				// put. EnrichStatus reconciles this gap on a later loop.
+				var pvcs corev1.PersistentVolumeClaimList
+				Expect(cl.List(ctx, &pvcs, k8client.InNamespace(cluster.Namespace))).To(Succeed())
+				pvcNames := make([]string, 0, len(pvcs.Items))
+				for i := range pvcs.Items {
+					pvcNames = append(pvcNames, pvcs.Items[i].Name)
+				}
+				Expect(pvcNames).To(ContainElement(specs.GetInstanceName(cluster.Name, 2)))
 
 				var fetched apiv1.Cluster
 				Expect(cl.Get(ctx, k8client.ObjectKeyFromObject(cluster), &fetched)).To(Succeed())
@@ -1778,7 +1797,7 @@ var _ = Describe("node serial allocation", func() {
 				jobName := specs.GetInstanceName(cluster.Name, 2) + "-join"
 				staleCache := interceptor.Funcs{
 					Create: func(
-						ctx context.Context,
+						_ context.Context,
 						_ k8client.WithWatch,
 						obj k8client.Object,
 						_ ...k8client.CreateOption,

--- a/internal/controller/cluster_status.go
+++ b/internal/controller/cluster_status.go
@@ -58,13 +58,42 @@ type managedResources struct {
 	jobs      batchv1.JobList
 }
 
-// Count the number of jobs that are still running
-func (resources *managedResources) runningJobNames() []string {
+// Count the number of jobs that are still running.
+//
+// A Job whose instance PGDATA PVC is missing AND whose serial is not yet
+// covered by cluster.Status.LatestGeneratedNode is excluded: its Pod cannot
+// make progress without a volume to mount, and the instance-creation path
+// must reach the adoption branch to create the missing PVC. Treating it as
+// "running" would wedge the reconciler in the 5s requeue loop.
+//
+// When the PVC is missing from cache but the serial is already covered by
+// LatestGeneratedNode, we know the PVC exists on the API server (the
+// counter persists only after both the Job and the PVC are committed);
+// the PVC informer is simply stale, so the Job still counts as running.
+func (resources *managedResources) runningJobNames(cluster *apiv1.Cluster) []string {
+	pvcNames := make(map[string]struct{}, len(resources.pvcs.Items))
+	for _, pvc := range resources.pvcs.Items {
+		pvcNames[pvc.Name] = struct{}{}
+	}
 	result := make([]string, 0, len(resources.jobs.Items))
 	for _, job := range resources.jobs.Items {
-		if !utils.JobHasOneCompletion(job) {
-			result = append(result, job.Name)
+		if utils.JobHasOneCompletion(job) {
+			continue
 		}
+		instanceName, hasLabel := job.Labels[utils.InstanceNameLabelName]
+		if !hasLabel {
+			result = append(result, job.Name)
+			continue
+		}
+		if _, hasPVC := pvcNames[instanceName]; hasPVC {
+			result = append(result, job.Name)
+			continue
+		}
+		if serial, err := specs.GetNodeSerial(job.ObjectMeta); err == nil &&
+			serial > cluster.Status.LatestGeneratedNode {
+			continue
+		}
+		result = append(result, job.Name)
 	}
 	return result
 }

--- a/internal/controller/cluster_status.go
+++ b/internal/controller/cluster_status.go
@@ -67,9 +67,11 @@ type managedResources struct {
 // "running" would wedge the reconciler in the 5s requeue loop.
 //
 // When the PVC is missing from cache but the serial is already covered by
-// LatestGeneratedNode, we know the PVC exists on the API server (the
-// counter persists only after both the Job and the PVC are committed);
-// the PVC informer is simply stale, so the Job still counts as running.
+// LatestGeneratedNode, the operator has already committed it (the counter
+// persists only after both the Job and the PVC are committed), so a cache
+// miss is just a stale informer and the Job still counts as running. This
+// holds only for operator-managed PVCs: one deleted out of band leaves the
+// Job counted as running.
 func (resources *managedResources) runningJobNames(cluster *apiv1.Cluster) []string {
 	pvcNames := make(map[string]struct{}, len(resources.pvcs.Items))
 	for _, pvc := range resources.pvcs.Items {

--- a/internal/controller/cluster_status_test.go
+++ b/internal/controller/cluster_status_test.go
@@ -21,6 +21,7 @@ package controller
 
 import (
 	"context"
+	"strconv"
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -33,6 +34,7 @@ import (
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/certs"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/postgres"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/reconciler/persistentvolumeclaim"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -583,5 +585,88 @@ var _ = Describe("updateClusterStatusThatRequiresInstancesState tests", func() {
 
 			Expect(isTerminatedBecauseOfMissingWALArchivePlugin(pod)).To(BeFalse())
 		})
+	})
+})
+
+var _ = Describe("runningJobNames", func() {
+	cluster := &apiv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+		Status:     apiv1.ClusterStatus{LatestGeneratedNode: 1},
+	}
+	makeJob := func(name, instanceName string, serial int, succeeded int32) batchv1.Job {
+		labels := map[string]string{}
+		annotations := map[string]string{}
+		if instanceName != "" {
+			labels[utils.InstanceNameLabelName] = instanceName
+		}
+		if serial > 0 {
+			annotations[utils.ClusterSerialAnnotationName] = strconv.Itoa(serial)
+		}
+		return batchv1.Job{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Labels: labels, Annotations: annotations},
+			Status:     batchv1.JobStatus{Succeeded: succeeded},
+		}
+	}
+	makePVC := func(name string) corev1.PersistentVolumeClaim {
+		return corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+		}
+	}
+
+	It("counts a non-complete Job whose instance PVC exists", func() {
+		resources := &managedResources{
+			jobs: batchv1.JobList{Items: []batchv1.Job{
+				makeJob("cluster-1-initdb", "cluster-1", 1, 0),
+			}},
+			pvcs: corev1.PersistentVolumeClaimList{Items: []corev1.PersistentVolumeClaim{
+				makePVC("cluster-1"),
+			}},
+		}
+		Expect(resources.runningJobNames(cluster)).To(ConsistOf("cluster-1-initdb"))
+	})
+
+	It("skips a Job whose PVC is missing and whose serial is past LatestGeneratedNode", func() {
+		resources := &managedResources{
+			jobs: batchv1.JobList{Items: []batchv1.Job{
+				makeJob("cluster-2-join", "cluster-2", 2, 0),
+			}},
+			pvcs: corev1.PersistentVolumeClaimList{Items: []corev1.PersistentVolumeClaim{
+				makePVC("cluster-1"),
+			}},
+		}
+		Expect(resources.runningJobNames(cluster)).To(BeEmpty())
+	})
+
+	It("counts a Job whose PVC is missing from cache but covered by LatestGeneratedNode", func() {
+		// Stale PVC informer: the counter persisted past this serial, so the
+		// PVC is guaranteed to exist on the API server.
+		resources := &managedResources{
+			jobs: batchv1.JobList{Items: []batchv1.Job{
+				makeJob("cluster-1-initdb", "cluster-1", 1, 0),
+			}},
+			pvcs: corev1.PersistentVolumeClaimList{},
+		}
+		Expect(resources.runningJobNames(cluster)).To(ConsistOf("cluster-1-initdb"))
+	})
+
+	It("skips a Job that has completed", func() {
+		resources := &managedResources{
+			jobs: batchv1.JobList{Items: []batchv1.Job{
+				makeJob("cluster-1-initdb", "cluster-1", 1, 1),
+			}},
+			pvcs: corev1.PersistentVolumeClaimList{Items: []corev1.PersistentVolumeClaim{
+				makePVC("cluster-1"),
+			}},
+		}
+		Expect(resources.runningJobNames(cluster)).To(BeEmpty())
+	})
+
+	It("counts a Job without the instanceName label (defensive)", func() {
+		resources := &managedResources{
+			jobs: batchv1.JobList{Items: []batchv1.Job{
+				makeJob("unlabeled-job", "", 0, 0),
+			}},
+		}
+		Expect(resources.runningJobNames(cluster)).To(ConsistOf("unlabeled-job"))
 	})
 })

--- a/internal/controller/cluster_status_test.go
+++ b/internal/controller/cluster_status_test.go
@@ -22,6 +22,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -616,5 +617,88 @@ var _ = Describe("updateClusterStatusThatRequiresInstancesState tests", func() {
 
 			Expect(isTerminatedBecauseOfMissingWALArchivePlugin(pod)).To(BeFalse())
 		})
+	})
+})
+
+var _ = Describe("runningJobNames", func() {
+	cluster := &apiv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+		Status:     apiv1.ClusterStatus{LatestGeneratedNode: 1},
+	}
+	makeJob := func(name, instanceName string, serial int, succeeded int32) batchv1.Job {
+		labels := map[string]string{}
+		annotations := map[string]string{}
+		if instanceName != "" {
+			labels[utils.InstanceNameLabelName] = instanceName
+		}
+		if serial > 0 {
+			annotations[utils.ClusterSerialAnnotationName] = strconv.Itoa(serial)
+		}
+		return batchv1.Job{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Labels: labels, Annotations: annotations},
+			Status:     batchv1.JobStatus{Succeeded: succeeded},
+		}
+	}
+	makePVC := func(name string) corev1.PersistentVolumeClaim {
+		return corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+		}
+	}
+
+	It("counts a non-complete Job whose instance PVC exists", func() {
+		resources := &managedResources{
+			jobs: batchv1.JobList{Items: []batchv1.Job{
+				makeJob("cluster-1-initdb", "cluster-1", 1, 0),
+			}},
+			pvcs: corev1.PersistentVolumeClaimList{Items: []corev1.PersistentVolumeClaim{
+				makePVC("cluster-1"),
+			}},
+		}
+		Expect(resources.runningJobNames(cluster)).To(ConsistOf("cluster-1-initdb"))
+	})
+
+	It("skips a Job whose PVC is missing and whose serial is past LatestGeneratedNode", func() {
+		resources := &managedResources{
+			jobs: batchv1.JobList{Items: []batchv1.Job{
+				makeJob("cluster-2-join", "cluster-2", 2, 0),
+			}},
+			pvcs: corev1.PersistentVolumeClaimList{Items: []corev1.PersistentVolumeClaim{
+				makePVC("cluster-1"),
+			}},
+		}
+		Expect(resources.runningJobNames(cluster)).To(BeEmpty())
+	})
+
+	It("counts a Job whose PVC is missing from cache but covered by LatestGeneratedNode", func() {
+		// Stale PVC informer: the counter persisted past this serial, so the
+		// PVC is guaranteed to exist on the API server.
+		resources := &managedResources{
+			jobs: batchv1.JobList{Items: []batchv1.Job{
+				makeJob("cluster-1-initdb", "cluster-1", 1, 0),
+			}},
+			pvcs: corev1.PersistentVolumeClaimList{},
+		}
+		Expect(resources.runningJobNames(cluster)).To(ConsistOf("cluster-1-initdb"))
+	})
+
+	It("skips a Job that has completed", func() {
+		resources := &managedResources{
+			jobs: batchv1.JobList{Items: []batchv1.Job{
+				makeJob("cluster-1-initdb", "cluster-1", 1, 1),
+			}},
+			pvcs: corev1.PersistentVolumeClaimList{Items: []corev1.PersistentVolumeClaim{
+				makePVC("cluster-1"),
+			}},
+		}
+		Expect(resources.runningJobNames(cluster)).To(BeEmpty())
+	})
+
+	It("counts a Job without the instanceName label (defensive)", func() {
+		resources := &managedResources{
+			jobs: batchv1.JobList{Items: []batchv1.Job{
+				makeJob("unlabeled-job", "", 0, 0),
+			}},
+		}
+		Expect(resources.runningJobNames(cluster)).To(ConsistOf("unlabeled-job"))
 	})
 })

--- a/pkg/reconciler/persistentvolumeclaim/status.go
+++ b/pkg/reconciler/persistentvolumeclaim/status.go
@@ -190,6 +190,7 @@ func EnrichStatus(
 	// First we iterate over all the PVCs building the instances map.
 	// It contains the PVCSs grouped by instance serial
 	instancesPVCs := make(map[string][]corev1.PersistentVolumeClaim)
+	maxSerial := 0
 	for _, pvc := range managedPVCs {
 		// Ignore PVCs that is in the wrong state
 		if pvc.Status.Phase != corev1.ClaimPending &&
@@ -208,8 +209,23 @@ func EnrichStatus(
 		if err != nil {
 			continue
 		}
+		if serial > maxSerial {
+			maxSerial = serial
+		}
 		instanceName := specs.GetInstanceName(cluster.Name, serial)
 		instancesPVCs[instanceName] = append(instancesPVCs[instanceName], pvc)
+	}
+
+	// Self-heal LatestGeneratedNode. The serial counter is persisted only after
+	// the Job and PVCs for a serial are committed (see recordGeneratedNodeSerial),
+	// so a crash in that window can leave the counter behind a serial that already
+	// owns a PVC. Realigning it to the highest observed serial keeps the next
+	// allocation from colliding with an existing instance. We only ever move it
+	// forward: a committed serial is one the operator generated, so this never
+	// introduces gaps, and never rolls back a counter that a stale PVC informer
+	// has not caught up with.
+	if maxSerial > cluster.Status.LatestGeneratedNode {
+		cluster.Status.LatestGeneratedNode = maxSerial
 	}
 
 	// For every instance we have we validate the list of PVCs

--- a/pkg/reconciler/persistentvolumeclaim/status_test.go
+++ b/pkg/reconciler/persistentvolumeclaim/status_test.go
@@ -592,3 +592,37 @@ var _ = Describe("MarkPVCReadyForCompletedJobs", func() {
 		Expect(updatedPVC2.Annotations[utils.PVCStatusAnnotationName]).To(Equal(StatusReady))
 	})
 })
+
+var _ = Describe("LatestGeneratedNode self-heal", func() {
+	clusterName := "myCluster"
+	makeClusterPVC := func(serial string) corev1.PersistentVolumeClaim {
+		return makePVC(clusterName, serial, serial, NewPgDataCalculator(), false)
+	}
+
+	It("raises LatestGeneratedNode to the highest observed instance serial", func(ctx SpecContext) {
+		cluster := &apiv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{Name: clusterName},
+			Status:     apiv1.ClusterStatus{LatestGeneratedNode: 0},
+		}
+		EnrichStatus(ctx, cluster, nil, nil, []corev1.PersistentVolumeClaim{
+			makeClusterPVC("1"),
+			makeClusterPVC("2"),
+		})
+		Expect(cluster.Status.LatestGeneratedNode).To(Equal(2))
+	})
+
+	It("never lowers LatestGeneratedNode below the persisted value", func(ctx SpecContext) {
+		// Stale PVC informer: the counter was already advanced past the PVCs
+		// currently visible (the higher PVC has not reached the cache yet).
+		// Rolling the counter back would re-allocate a serial that is already
+		// in flight, so the self-heal must only ever move it forward.
+		cluster := &apiv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{Name: clusterName},
+			Status:     apiv1.ClusterStatus{LatestGeneratedNode: 5},
+		}
+		EnrichStatus(ctx, cluster, nil, nil, []corev1.PersistentVolumeClaim{
+			makeClusterPVC("2"),
+		})
+		Expect(cluster.Status.LatestGeneratedNode).To(Equal(5))
+	})
+})

--- a/pkg/specs/jobs.go
+++ b/pkg/specs/jobs.go
@@ -21,6 +21,7 @@ package specs
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/cloudnative-pg/machinery/pkg/log"
 	"github.com/kballard/go-shellquote"
@@ -351,6 +352,9 @@ func CreatePrimaryJob(
 				utils.KubernetesAppVersionLabelName:   fmt.Sprint(version),
 				utils.KubernetesAppComponentLabelName: utils.DatabaseComponentName,
 				utils.KubernetesAppManagedByLabelName: utils.ManagerName,
+			},
+			Annotations: map[string]string{
+				utils.ClusterSerialAnnotationName: strconv.Itoa(nodeSerial),
 			},
 		},
 		Spec: batchv1.JobSpec{


### PR DESCRIPTION
generateNodeSerial used to persist a LatestGeneratedNode++ before the Job and PVCs for that serial were created. A status patch conflict in the same reconcile (RegisterPhase) left the counter advanced with no resources to recover. The next reconcile saw Status.Instances unchanged (it is computed from PVC count), bumped the counter again, and produced a cluster with non-sequential pod names (e.g. -1, -3).

Compute the next serial as a pure value and persist the bump only after the Job and PVCs are created, under an optimistic-lock patch. Treat AlreadyExists on the Job Create as adoption so a retry that re-derives the same serial completes naturally.

As a safety net, realign LatestGeneratedNode to the highest serial that already owns a PVC while enriching the status. A crash between committing the resources and recording the bump then self-heals on the next reconcile instead of re-deriving a stale serial and colliding with the existing instance.

Closes #10486