### PR TITLE
feat: emit a Warning event when the primary /pg/status check fails

### DIFF
--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -706,6 +706,12 @@ const (
 	// PhaseWaitingForInstancesToBeActive is a waiting phase that is triggered when an instance pod is not active
 	PhaseWaitingForInstancesToBeActive = "Waiting for the instances to become active"
 
+	// PhaseWaitingForPrimaryStatus is set when the current primary pod is
+	// Ready from the kubelet's perspective but the operator is failing to
+	// collect its status via the /pg/status endpoint. Failover is deferred
+	// until Kubernetes marks the primary pod as not Ready.
+	PhaseWaitingForPrimaryStatus = "Waiting to re-establish contact with the primary instance"
+
 	// PhaseOnlineUpgrading for when the instance manager is being upgraded in place
 	PhaseOnlineUpgrading = "Online upgrade in progress"
 

--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -706,12 +706,6 @@ const (
 	// PhaseWaitingForInstancesToBeActive is a waiting phase that is triggered when an instance pod is not active
 	PhaseWaitingForInstancesToBeActive = "Waiting for the instances to become active"
 
-	// PhaseWaitingForPrimaryStatus is set when the current primary pod is
-	// Ready from the kubelet's perspective but the operator is failing to
-	// collect its status via the /pg/status endpoint. Failover is deferred
-	// until Kubernetes marks the primary pod as not Ready.
-	PhaseWaitingForPrimaryStatus = "Waiting to re-establish contact with the primary instance"
-
 	// PhaseOnlineUpgrading for when the instance manager is being upgraded in place
 	PhaseOnlineUpgrading = "Online upgrade in progress"
 

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -589,7 +589,7 @@ func (r *ClusterReconciler) reconcile(ctx context.Context, cluster *apiv1.Cluste
 //     operator-to-pod connectivity issue rather than a genuine PostgreSQL
 //     health problem. The operator trusts the kubelet's readiness probe as
 //     the source of truth and defers its own failover decision until
-//     Kubernetes agrees the primary is not Ready. A PrimaryStatusUnreachable
+//     Kubernetes agrees the primary is not Ready. A PrimaryStatusCheckFailed
 //     Warning event is emitted so the deferral is visible via
 //     `kubectl describe cluster` and the events API; the Kubernetes event
 //     recorder dedupes by reason + message, so a sustained outage rolls up
@@ -635,14 +635,14 @@ func (r *ClusterReconciler) evaluatePodReadinessGuards(
 			cluster.Status.CurrentPrimary,
 		); unreachable {
 			contextLogger.Warning(
-				"Primary pod is Ready but /pg/status is failing, deferring failover",
+				"Primary pod is Ready but /pg/status is failing, short-circuiting reconcile",
 				"instanceName", cluster.Status.CurrentPrimary,
 				"err", statusErr)
 			r.Recorder.Eventf(
 				cluster,
 				"Warning",
-				"PrimaryStatusUnreachable",
-				"Primary pod %s is Ready but the operator cannot reach its /pg/status endpoint; "+
+				"PrimaryStatusCheckFailed",
+				"Primary pod %s is Ready but the operator's /pg/status check failed; "+
 					"failover deferred until Kubernetes marks the primary as not Ready. "+
 					"See operator logs for the underlying error.",
 				cluster.Status.CurrentPrimary,

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -505,8 +505,8 @@ func (r *ClusterReconciler) reconcile(ctx context.Context, cluster *apiv1.Cluste
 		return ctrl.Result{}, err
 	}
 
-	if res, err := r.evaluatePodReadinessGuards(ctx, cluster, instancesStatus); err != nil || !res.IsZero() {
-		return res, err
+	if res := r.evaluatePodReadinessGuards(ctx, cluster, instancesStatus); !res.IsZero() {
+		return res, nil
 	}
 
 	// If the user has requested to hibernate the cluster, we do that before
@@ -589,7 +589,11 @@ func (r *ClusterReconciler) reconcile(ctx context.Context, cluster *apiv1.Cluste
 //     operator-to-pod connectivity issue rather than a genuine PostgreSQL
 //     health problem. The operator trusts the kubelet's readiness probe as
 //     the source of truth and defers its own failover decision until
-//     Kubernetes agrees the primary is not Ready.
+//     Kubernetes agrees the primary is not Ready. A PrimaryStatusUnreachable
+//     Warning event is emitted so the deferral is visible via
+//     `kubectl describe cluster` and the events API; the Kubernetes event
+//     recorder dedupes by reason + message, so a sustained outage rolls up
+//     into one logical event with a growing count.
 //
 //     Without this branch the failover-election path would promote the
 //     healthiest replica: PostgresqlStatusList.Less pushes items with an
@@ -602,9 +606,9 @@ func (r *ClusterReconciler) evaluatePodReadinessGuards(
 	ctx context.Context,
 	cluster *apiv1.Cluster,
 	instancesStatus postgres.PostgresqlStatusList,
-) (ctrl.Result, error) {
+) ctrl.Result {
 	if instancesStatus.Len() == 0 {
-		return ctrl.Result{}, nil
+		return ctrl.Result{}
 	}
 
 	contextLogger := log.FromContext(ctx)
@@ -622,28 +626,32 @@ func (r *ClusterReconciler) evaluatePodReadinessGuards(
 			"instanceName", firstInstance.Pod.Name,
 			"hasHTTPStatus", hasHTTPStatus,
 			"isPodReady", isPodReady)
-		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+		return ctrl.Result{RequeueAfter: 10 * time.Second}
 	}
 
 	if cluster.Status.CurrentPrimary != "" &&
-		cluster.Status.CurrentPrimary == cluster.Status.TargetPrimary &&
-		instancesStatus.IsPodReadyAndNotReporting(cluster.Status.CurrentPrimary) {
-		contextLogger.Warning(
-			"Primary pod is ready but status endpoint is failing, requeueing",
-			"instanceName", cluster.Status.CurrentPrimary)
-		if err := r.RegisterPhase(
-			ctx,
-			cluster,
-			apiv1.PhaseWaitingForPrimaryStatus,
-			"The primary pod is Ready but the operator cannot reach its /pg/status endpoint. "+
-				"Failover is deferred until Kubernetes marks the primary as not Ready.",
-		); err != nil {
-			return ctrl.Result{}, err
+		cluster.Status.CurrentPrimary == cluster.Status.TargetPrimary {
+		if unreachable, statusErr := instancesStatus.IsPodReadyAndNotReporting(
+			cluster.Status.CurrentPrimary,
+		); unreachable {
+			contextLogger.Warning(
+				"Primary pod is Ready but /pg/status is failing, deferring failover",
+				"instanceName", cluster.Status.CurrentPrimary,
+				"err", statusErr)
+			r.Recorder.Eventf(
+				cluster,
+				"Warning",
+				"PrimaryStatusUnreachable",
+				"Primary pod %s is Ready but the operator cannot reach its /pg/status endpoint; "+
+					"failover deferred until Kubernetes marks the primary as not Ready. "+
+					"See operator logs for the underlying error.",
+				cluster.Status.CurrentPrimary,
+			)
+			return ctrl.Result{RequeueAfter: 10 * time.Second}
 		}
-		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 	}
 
-	return ctrl.Result{}, nil
+	return ctrl.Result{}
 }
 
 func (r *ClusterReconciler) ensureNoFailoverOnFullDisk(

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -505,8 +505,8 @@ func (r *ClusterReconciler) reconcile(ctx context.Context, cluster *apiv1.Cluste
 		return ctrl.Result{}, err
 	}
 
-	if res := r.evaluatePodReadinessGuards(ctx, cluster, instancesStatus); res != nil {
-		return *res, nil
+	if res, err := r.evaluatePodReadinessGuards(ctx, cluster, instancesStatus); err != nil || !res.IsZero() {
+		return res, err
 	}
 
 	// If the user has requested to hibernate the cluster, we do that before
@@ -596,14 +596,15 @@ func (r *ClusterReconciler) reconcile(ctx context.Context, cluster *apiv1.Cluste
 //     Error to the tail, so the erroring primary ends up behind a healthy
 //     replica at Items[0] and gets supplanted on a mere network hiccup.
 //
-// Returns nil when the caller can proceed with the rest of the reconciliation.
+// Returns a zero Result when the caller can proceed with the rest of the
+// reconciliation.
 func (r *ClusterReconciler) evaluatePodReadinessGuards(
 	ctx context.Context,
 	cluster *apiv1.Cluster,
 	instancesStatus postgres.PostgresqlStatusList,
-) *ctrl.Result {
+) (ctrl.Result, error) {
 	if instancesStatus.Len() == 0 {
-		return nil
+		return ctrl.Result{}, nil
 	}
 
 	contextLogger := log.FromContext(ctx)
@@ -621,7 +622,7 @@ func (r *ClusterReconciler) evaluatePodReadinessGuards(
 			"instanceName", firstInstance.Pod.Name,
 			"hasHTTPStatus", hasHTTPStatus,
 			"isPodReady", isPodReady)
-		return &ctrl.Result{RequeueAfter: 10 * time.Second}
+		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 	}
 
 	if cluster.Status.CurrentPrimary != "" &&
@@ -629,11 +630,20 @@ func (r *ClusterReconciler) evaluatePodReadinessGuards(
 		instancesStatus.IsPodReadyAndNotReporting(cluster.Status.CurrentPrimary) {
 		contextLogger.Warning(
 			"Primary pod is ready but status endpoint is failing, requeueing",
-			"primaryPodName", cluster.Status.CurrentPrimary)
-		return &ctrl.Result{RequeueAfter: 10 * time.Second}
+			"instanceName", cluster.Status.CurrentPrimary)
+		if err := r.RegisterPhase(
+			ctx,
+			cluster,
+			apiv1.PhaseWaitingForPrimaryStatus,
+			"The primary pod is Ready but the operator cannot reach its /pg/status endpoint. "+
+				"Failover is deferred until Kubernetes marks the primary as not Ready.",
+		); err != nil {
+			return ctrl.Result{}, err
+		}
+		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 	}
 
-	return nil
+	return ctrl.Result{}, nil
 }
 
 func (r *ClusterReconciler) ensureNoFailoverOnFullDisk(

--- a/internal/controller/cluster_controller_test.go
+++ b/internal/controller/cluster_controller_test.go
@@ -423,6 +423,11 @@ var _ = Describe("evaluatePodReadinessGuards", func() {
 		IsPodReady: false,
 	}
 
+	// DescribeTable entries assert state (requeue vs. proceed) only. They also
+	// regression-lock event absence: none of these scenarios should emit an
+	// event. Event-emission assertions live in separate It blocks below — that
+	// is why the "transient /pg/status failure" case (which fires + emits)
+	// lives there rather than here.
 	DescribeTable(
 		"guards behaviour",
 		func(ctx SpecContext, currentPrimary, targetPrimary string, items []postgres.PostgresqlStatus, requeue bool) {
@@ -438,6 +443,11 @@ var _ = Describe("evaluatePodReadinessGuards", func() {
 			} else {
 				Expect(result.IsZero()).To(BeTrue())
 			}
+
+			fakeRecorder, ok := env.clusterReconciler.Recorder.(*record.FakeRecorder)
+			Expect(ok).To(BeTrue())
+			Expect(fakeRecorder.Events).ShouldNot(Receive(),
+				"DescribeTable entries must not emit events; if a new branch needs one, add a dedicated It")
 		},
 		Entry("happy path: primary Ready and reporting, no guard fires",
 			primaryName, primaryName,
@@ -445,9 +455,6 @@ var _ = Describe("evaluatePodReadinessGuards", func() {
 		Entry("kubelet has not refreshed the readiness probe yet",
 			primaryName, primaryName,
 			[]postgres.PostgresqlStatus{kubeletStaleReporting, readyReportingReplica}, true),
-		Entry("transient /pg/status failure on Ready primary requeues",
-			primaryName, primaryName,
-			[]postgres.PostgresqlStatus{readyReportingReplica, readyErroringPrimary}, true),
 		Entry("guard is scoped to steady-state (CurrentPrimary == TargetPrimary)",
 			primaryName, newPrimaryName,
 			[]postgres.PostgresqlStatus{readyReportingReplica, readyErroringPrimary}, false),
@@ -517,7 +524,7 @@ var _ = Describe("evaluatePodReadinessGuards", func() {
 
 		var recorded string
 		Eventually(fakeRecorder.Events, "1s").Should(Receive(&recorded))
-		Expect(recorded).To(HavePrefix("Warning PrimaryStatusUnreachable"))
+		Expect(recorded).To(HavePrefix("Warning PrimaryStatusCheckFailed"))
 		Expect(recorded).To(ContainSubstring(primaryName))
 		Expect(recorded).To(ContainSubstring("See operator logs"))
 	})
@@ -537,7 +544,7 @@ var _ = Describe("evaluatePodReadinessGuards", func() {
 		fakeRecorder, ok := env.clusterReconciler.Recorder.(*record.FakeRecorder)
 		Expect(ok).To(BeTrue())
 
-		Consistently(fakeRecorder.Events, "100ms").ShouldNot(Receive(),
+		Expect(fakeRecorder.Events).ShouldNot(Receive(),
 			"kubelet-stale branch must stay event-less to avoid noise")
 	})
 })

--- a/internal/controller/cluster_controller_test.go
+++ b/internal/controller/cluster_controller_test.go
@@ -428,15 +428,15 @@ var _ = Describe("evaluatePodReadinessGuards", func() {
 			cluster.Status.CurrentPrimary = currentPrimary
 			cluster.Status.TargetPrimary = targetPrimary
 
-			result := env.clusterReconciler.evaluatePodReadinessGuards(
+			result, err := env.clusterReconciler.evaluatePodReadinessGuards(
 				ctx, cluster, postgres.PostgresqlStatusList{Items: items},
 			)
+			Expect(err).NotTo(HaveOccurred())
 
 			if requeue {
-				Expect(result).NotTo(BeNil())
 				Expect(result.RequeueAfter).To(Equal(10 * time.Second))
 			} else {
-				Expect(result).To(BeNil())
+				Expect(result.IsZero()).To(BeTrue())
 			}
 		},
 		Entry("happy path: primary Ready and reporting, no guard fires",
@@ -496,8 +496,8 @@ var _ = Describe("evaluatePodReadinessGuards", func() {
 		cluster.Status.CurrentPrimary = primaryName
 		cluster.Status.TargetPrimary = primaryName
 
-		result := env.clusterReconciler.evaluatePodReadinessGuards(ctx, cluster, statusList)
-		Expect(result).NotTo(BeNil())
+		result, err := env.clusterReconciler.evaluatePodReadinessGuards(ctx, cluster, statusList)
+		Expect(err).NotTo(HaveOccurred())
 		Expect(result.RequeueAfter).To(Equal(10 * time.Second))
 	})
 })

--- a/internal/controller/cluster_controller_test.go
+++ b/internal/controller/cluster_controller_test.go
@@ -29,6 +29,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
@@ -428,10 +429,9 @@ var _ = Describe("evaluatePodReadinessGuards", func() {
 			cluster.Status.CurrentPrimary = currentPrimary
 			cluster.Status.TargetPrimary = targetPrimary
 
-			result, err := env.clusterReconciler.evaluatePodReadinessGuards(
+			result := env.clusterReconciler.evaluatePodReadinessGuards(
 				ctx, cluster, postgres.PostgresqlStatusList{Items: items},
 			)
-			Expect(err).NotTo(HaveOccurred())
 
 			if requeue {
 				Expect(result.RequeueAfter).To(Equal(10 * time.Second))
@@ -496,8 +496,48 @@ var _ = Describe("evaluatePodReadinessGuards", func() {
 		cluster.Status.CurrentPrimary = primaryName
 		cluster.Status.TargetPrimary = primaryName
 
-		result, err := env.clusterReconciler.evaluatePodReadinessGuards(ctx, cluster, statusList)
-		Expect(err).NotTo(HaveOccurred())
+		result := env.clusterReconciler.evaluatePodReadinessGuards(ctx, cluster, statusList)
 		Expect(result.RequeueAfter).To(Equal(10 * time.Second))
+	})
+
+	It("emits a Warning event when the primary is Ready but /pg/status is failing", func(ctx SpecContext) {
+		cluster.Status.CurrentPrimary = primaryName
+		cluster.Status.TargetPrimary = primaryName
+
+		result := env.clusterReconciler.evaluatePodReadinessGuards(
+			ctx, cluster,
+			postgres.PostgresqlStatusList{Items: []postgres.PostgresqlStatus{
+				readyReportingReplica, readyErroringPrimary,
+			}},
+		)
+		Expect(result.RequeueAfter).To(Equal(10 * time.Second))
+
+		fakeRecorder, ok := env.clusterReconciler.Recorder.(*record.FakeRecorder)
+		Expect(ok).To(BeTrue(), "test environment must wire a FakeRecorder")
+
+		var recorded string
+		Eventually(fakeRecorder.Events, "1s").Should(Receive(&recorded))
+		Expect(recorded).To(HavePrefix("Warning PrimaryStatusUnreachable"))
+		Expect(recorded).To(ContainSubstring(primaryName))
+		Expect(recorded).To(ContainSubstring("See operator logs"))
+	})
+
+	It("does not emit an event on the kubelet-stale branch", func(ctx SpecContext) {
+		cluster.Status.CurrentPrimary = primaryName
+		cluster.Status.TargetPrimary = primaryName
+
+		result := env.clusterReconciler.evaluatePodReadinessGuards(
+			ctx, cluster,
+			postgres.PostgresqlStatusList{Items: []postgres.PostgresqlStatus{
+				kubeletStaleReporting, readyReportingReplica,
+			}},
+		)
+		Expect(result.RequeueAfter).To(Equal(10 * time.Second))
+
+		fakeRecorder, ok := env.clusterReconciler.Recorder.(*record.FakeRecorder)
+		Expect(ok).To(BeTrue())
+
+		Consistently(fakeRecorder.Events, "100ms").ShouldNot(Receive(),
+			"kubelet-stale branch must stay event-less to avoid noise")
 	})
 })

--- a/pkg/postgres/status.go
+++ b/pkg/postgres/status.go
@@ -356,18 +356,22 @@ func (list PostgresqlStatusList) IsPodReporting(podname string) bool {
 // marked as ready by the kubelet but is not successfully reporting its status
 // via the /pg/status endpoint. This indicates a likely transient failure
 // (e.g. a network hiccup between the operator and the pod) rather than a
-// genuine PostgreSQL health problem.
+// genuine PostgreSQL health problem. The second return value is the
+// underlying /pg/status error, meaningful only when the boolean is true.
 //
 // "Not reporting" is the negation of IsPodReporting: the /pg/status call
 // against the pod returned an error.
-func (list PostgresqlStatusList) IsPodReadyAndNotReporting(podname string) bool {
+func (list PostgresqlStatusList) IsPodReadyAndNotReporting(podname string) (bool, error) {
 	for _, item := range list.Items {
 		if item.Pod.Name == podname {
-			return item.IsPodReady && item.Error != nil
+			if item.IsPodReady && item.Error != nil {
+				return true, item.Error
+			}
+			return false, nil
 		}
 	}
 
-	return false
+	return false, nil
 }
 
 // IsComplete checks the PostgreSQL status list for Pods which

--- a/pkg/postgres/status_test.go
+++ b/pkg/postgres/status_test.go
@@ -262,20 +262,28 @@ var _ = Describe("IsPodReadyAndNotReporting", func() {
 		},
 	}
 
-	It("returns true when the pod is ready but the status endpoint is failing", func() {
-		Expect(podList.IsPodReadyAndNotReporting("primary")).To(BeTrue())
+	It("returns true and the underlying error when the pod is ready but the status endpoint is failing", func() {
+		ok, err := podList.IsPodReadyAndNotReporting("primary")
+		Expect(ok).To(BeTrue())
+		Expect(err).To(MatchError(errStatusEndpointFailing))
 	})
 
-	It("returns false when the pod is ready and reporting", func() {
-		Expect(podList.IsPodReadyAndNotReporting("replica-reporting")).To(BeFalse())
+	It("returns false and a nil error when the pod is ready and reporting", func() {
+		ok, err := podList.IsPodReadyAndNotReporting("replica-reporting")
+		Expect(ok).To(BeFalse())
+		Expect(err).ToNot(HaveOccurred())
 	})
 
-	It("returns false when the pod is not ready and not reporting", func() {
-		Expect(podList.IsPodReadyAndNotReporting("replica-not-ready")).To(BeFalse())
+	It("returns false and a nil error when the pod is not ready and not reporting", func() {
+		ok, err := podList.IsPodReadyAndNotReporting("replica-not-ready")
+		Expect(ok).To(BeFalse())
+		Expect(err).ToNot(HaveOccurred())
 	})
 
-	It("returns false when the pod is not in the list", func() {
-		Expect(podList.IsPodReadyAndNotReporting("unknown")).To(BeFalse())
+	It("returns false and a nil error when the pod is not in the list", func() {
+		ok, err := podList.IsPodReadyAndNotReporting("unknown")
+		Expect(ok).To(BeFalse())
+		Expect(err).ToNot(HaveOccurred())
 	})
 })
 


### PR DESCRIPTION
When the current primary pod is Ready from the kubelet's perspective but the
operator's `/pg/status` check fails, the parent PR (#10445) defers failover
and requeues on a 10s loop. Previously this loop was silent from the user's
point of view. This PR surfaces the deferral as a `Warning`
`PrimaryStatusCheckFailed` event on the Cluster, emitted from
`evaluatePodReadinessGuards`.

Users see the event in `kubectl describe cluster` and via the events API;
the Kubernetes event recorder deduplicates by (involvedObject, reason,
message), so a sustained outage aggregates into a single Event object with
a growing count. The event message is kept stable (no error interpolation)
to preserve dedup; the underlying error is logged at the guard site via
`contextLogger.Warning(..., "err", statusErr)` and the event message points
users there.

Closes #10516

