### PR TITLE
chore(devcontainer): remove obsolete IPVS /lib/modules mount

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,10 +17,6 @@
     "ghcr.io/devcontainers-extra/features/kubectx-kubens:1": {},
     "ghcr.io/dhoeric/features/stern:1": {}
   },
-
-  // Needed by kind to enable kube-proxy's ipvs mode
-  "mounts":["type=bind,source=/lib/modules,target=/lib/modules"],
-
   // Enable kubectl short alias with completion
   "postCreateCommand": "echo 'alias k=kubectl; complete -F __start_kubectl k' >> ~/.bash_aliases; git clone https://github.com/magicmonty/bash-git-prompt.git ~/.bash-git-prompt --depth=1; echo 'if [ -f \"$HOME/.bash-git-prompt/gitprompt.sh\" ]; then . \"$HOME/.bash-git-prompt/gitprompt.sh\"; fi' >> ~/.bashrc"
 }


### PR DESCRIPTION
The /lib/modules bind mount was needed to enable kube-proxy's IPVS mode in kind clusters. Since the E2E tests no longer use IPVS mode (which is now deprecated in Kubernetes v1.35), the mount and its comment are no longer necessary.