### PR TITLE
fix: escape backslashes and control chars in PostgreSQL config values

### DIFF
--- a/api/v1/cluster_funcs.go
+++ b/api/v1/cluster_funcs.go
@@ -41,6 +41,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/cloudnative-pg/cloudnative-pg/internal/configuration"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/configfile"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/system"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 	contextutils "github.com/cloudnative-pg/cloudnative-pg/pkg/utils/context"
@@ -1480,28 +1481,28 @@ func (target *RecoveryTarget) BuildPostgresOptions() string {
 
 	if target.TargetTLI != "" {
 		result += fmt.Sprintf(
-			"recovery_target_timeline = '%v'\n",
-			target.TargetTLI)
+			"recovery_target_timeline = %s\n",
+			configfile.EscapePostgresConfLiteral(target.TargetTLI))
 	}
 	if target.TargetXID != "" {
 		result += fmt.Sprintf(
-			"recovery_target_xid = '%v'\n",
-			target.TargetXID)
+			"recovery_target_xid = %s\n",
+			configfile.EscapePostgresConfLiteral(target.TargetXID))
 	}
 	if target.TargetName != "" {
 		result += fmt.Sprintf(
-			"recovery_target_name = '%v'\n",
-			target.TargetName)
+			"recovery_target_name = %s\n",
+			configfile.EscapePostgresConfLiteral(target.TargetName))
 	}
 	if target.TargetLSN != "" {
 		result += fmt.Sprintf(
-			"recovery_target_lsn = '%v'\n",
-			target.TargetLSN)
+			"recovery_target_lsn = %s\n",
+			configfile.EscapePostgresConfLiteral(target.TargetLSN))
 	}
 	if target.TargetTime != "" {
 		result += fmt.Sprintf(
-			"recovery_target_time = '%v'\n",
-			pgTime.ConvertToPostgresFormat(target.TargetTime))
+			"recovery_target_time = %s\n",
+			configfile.EscapePostgresConfLiteral(pgTime.ConvertToPostgresFormat(target.TargetTime)))
 	}
 	if target.TargetImmediate != nil && *target.TargetImmediate {
 		result += "recovery_target = immediate\n"

--- a/api/v1/cluster_funcs.go
+++ b/api/v1/cluster_funcs.go
@@ -1473,37 +1473,34 @@ func (cluster *Cluster) EnsureGVKIsPresent() {
 // should be added to the PostgreSQL configuration to
 // recover given a certain target
 func (target *RecoveryTarget) BuildPostgresOptions() string {
-	result := ""
-
 	if target == nil {
-		return result
+		return ""
 	}
 
+	// String-typed recovery targets go through the parser so that any
+	// user-supplied value is correctly escaped.
+	options := map[string]string{}
 	if target.TargetTLI != "" {
-		result += fmt.Sprintf(
-			"recovery_target_timeline = %s\n",
-			configfile.EscapePostgresConfLiteral(target.TargetTLI))
+		options["recovery_target_timeline"] = target.TargetTLI
 	}
 	if target.TargetXID != "" {
-		result += fmt.Sprintf(
-			"recovery_target_xid = %s\n",
-			configfile.EscapePostgresConfLiteral(target.TargetXID))
+		options["recovery_target_xid"] = target.TargetXID
 	}
 	if target.TargetName != "" {
-		result += fmt.Sprintf(
-			"recovery_target_name = %s\n",
-			configfile.EscapePostgresConfLiteral(target.TargetName))
+		options["recovery_target_name"] = target.TargetName
 	}
 	if target.TargetLSN != "" {
-		result += fmt.Sprintf(
-			"recovery_target_lsn = %s\n",
-			configfile.EscapePostgresConfLiteral(target.TargetLSN))
+		options["recovery_target_lsn"] = target.TargetLSN
 	}
 	if target.TargetTime != "" {
-		result += fmt.Sprintf(
-			"recovery_target_time = %s\n",
-			configfile.EscapePostgresConfLiteral(pgTime.ConvertToPostgresFormat(target.TargetTime)))
+		options["recovery_target_time"] = pgTime.ConvertToPostgresFormat(target.TargetTime)
 	}
+
+	result := configfile.RenderPostgresConfiguration(options)
+
+	// Enum-typed recovery targets are emitted as barewords to preserve the
+	// legacy on-disk format. Their values come from a fixed, non-user-
+	// controlled set (immediate / true / false), so escaping is unnecessary.
 	if target.TargetImmediate != nil && *target.TargetImmediate {
 		result += "recovery_target = immediate\n"
 	}

--- a/api/v1/cluster_funcs.go
+++ b/api/v1/cluster_funcs.go
@@ -1477,8 +1477,6 @@ func (target *RecoveryTarget) BuildPostgresOptions() string {
 		return ""
 	}
 
-	// String-typed recovery targets go through the parser so that any
-	// user-supplied value is correctly escaped.
 	options := map[string]string{}
 	if target.TargetTLI != "" {
 		options["recovery_target_timeline"] = target.TargetTLI
@@ -1495,22 +1493,16 @@ func (target *RecoveryTarget) BuildPostgresOptions() string {
 	if target.TargetTime != "" {
 		options["recovery_target_time"] = pgTime.ConvertToPostgresFormat(target.TargetTime)
 	}
-
-	result := configfile.RenderPostgresConfiguration(options)
-
-	// Enum-typed recovery targets are emitted as barewords to preserve the
-	// legacy on-disk format. Their values come from a fixed, non-user-
-	// controlled set (immediate / true / false), so escaping is unnecessary.
 	if target.TargetImmediate != nil && *target.TargetImmediate {
-		result += "recovery_target = immediate\n"
+		options["recovery_target"] = "immediate"
 	}
 	if target.Exclusive != nil && *target.Exclusive {
-		result += "recovery_target_inclusive = false\n"
+		options["recovery_target_inclusive"] = "false"
 	} else {
-		result += "recovery_target_inclusive = true\n"
+		options["recovery_target_inclusive"] = "true"
 	}
 
-	return result
+	return configfile.RenderPostgresConfiguration(options)
 }
 
 // ApplyInto applies the content of the probe configuration in a Kubernetes

--- a/api/v1/cluster_funcs_test.go
+++ b/api/v1/cluster_funcs_test.go
@@ -1824,3 +1824,45 @@ var _ = Describe("GetServiceAccountName", func() {
 		Expect(cluster.GetServiceAccountName()).To(Equal("my-cluster"))
 	})
 })
+
+var _ = Describe("RecoveryTarget.BuildPostgresOptions", func() {
+	It("returns an empty string for a nil receiver", func() {
+		var target *RecoveryTarget
+		Expect(target.BuildPostgresOptions()).To(Equal(""))
+	})
+
+	It("escapes single quotes in the target name", func() {
+		target := &RecoveryTarget{TargetName: "my'restore'point"}
+		Expect(target.BuildPostgresOptions()).To(ContainSubstring(
+			"recovery_target_name = 'my''restore''point'\n",
+		))
+	})
+
+	It("escapes backslashes in the target name", func() {
+		target := &RecoveryTarget{TargetName: `path\to\restore`}
+		Expect(target.BuildPostgresOptions()).To(ContainSubstring(
+			`recovery_target_name = 'path\\to\\restore'` + "\n",
+		))
+	})
+
+	It("escapes literal newlines in the target name", func() {
+		// pg_create_restore_point accepts any string, including one with a
+		// literal newline. The config file must stay line-oriented.
+		target := &RecoveryTarget{TargetName: "line1\nline2"}
+		Expect(target.BuildPostgresOptions()).To(ContainSubstring(
+			`recovery_target_name = 'line1\nline2'` + "\n",
+		))
+	})
+
+	It("escapes every other target field", func() {
+		target := &RecoveryTarget{
+			TargetTLI: `l\a'test`,
+			TargetXID: "1'2",
+			TargetLSN: `0/1\6`,
+		}
+		out := target.BuildPostgresOptions()
+		Expect(out).To(ContainSubstring(`recovery_target_timeline = 'l\\a''test'` + "\n"))
+		Expect(out).To(ContainSubstring(`recovery_target_xid = '1''2'` + "\n"))
+		Expect(out).To(ContainSubstring(`recovery_target_lsn = '0/1\\6'` + "\n"))
+	})
+})

--- a/pkg/configfile/configfile.go
+++ b/pkg/configfile/configfile.go
@@ -120,6 +120,24 @@ func UpdateConfigurationContents(lines []string, options map[string]string) ([]s
 	return lines, nil
 }
 
+// RenderPostgresConfiguration returns a PostgreSQL configuration fragment as
+// a single string: one `key = 'escaped value'\n` line per entry in options,
+// sorted by key. The returned string is safe to concatenate with other
+// fragments and to embed directly into a `postgresql.conf`-style file.
+//
+// This is the canonical way to produce a config fragment in-memory: callers
+// that build strings by hand can forget to escape values, while this funnels
+// every value through the same escaping that the on-disk parser uses.
+func RenderPostgresConfiguration(options map[string]string) string {
+	lines, _ := UpdateConfigurationContents(nil, options)
+	var b strings.Builder
+	for _, l := range lines {
+		b.WriteString(l)
+		b.WriteByte('\n')
+	}
+	return b.String()
+}
+
 // WritePostgresConfiguration replaces the content of a PostgreSQL configuration
 // file with the provided options
 func WritePostgresConfiguration(

--- a/pkg/configfile/configfile.go
+++ b/pkg/configfile/configfile.go
@@ -29,42 +29,26 @@ import (
 	"github.com/cloudnative-pg/machinery/pkg/stringset"
 )
 
+// postgresConfLiteralReplacer escapes every character the PostgreSQL config
+// file lexer (`guc-file.l`) interprets specially inside a single-quoted value.
+var postgresConfLiteralReplacer = strings.NewReplacer(
+	`\`, `\\`,
+	`'`, `''`,
+	"\n", `\n`,
+	"\r", `\r`,
+	"\t", `\t`,
+	"\b", `\b`,
+	"\f", `\f`,
+)
+
 // EscapePostgresConfLiteral escapes an arbitrary string so it can be used as a
-// value in a PostgreSQL configuration file. The returned string is wrapped in
-// single quotes and any character that the PostgreSQL config file lexer would
-// interpret specially is escaped: backslash becomes `\\`, single quote becomes
-// `”`, and control characters (LF, CR, TAB, BS, FF) become their `\n`, `\r`,
-// `\t`, `\b`, `\f` two-character equivalents.
+// value in a PostgreSQL configuration file, wrapped in single quotes.
 //
-// pq.QuoteLiteral is unsuitable here because it emits ` E'...'` when the value
+// pq.QuoteLiteral is unsuitable here: it emits ` E'...'` when the value
 // contains a backslash, and the PostgreSQL config parser does not recognise
 // the `E'...'` syntax.
 func EscapePostgresConfLiteral(value string) string {
-	var b strings.Builder
-	b.Grow(len(value) + 2)
-	b.WriteByte('\'')
-	for i := 0; i < len(value); i++ {
-		switch value[i] {
-		case '\\':
-			b.WriteString(`\\`)
-		case '\'':
-			b.WriteString(`''`)
-		case '\n':
-			b.WriteString(`\n`)
-		case '\r':
-			b.WriteString(`\r`)
-		case '\t':
-			b.WriteString(`\t`)
-		case '\b':
-			b.WriteString(`\b`)
-		case '\f':
-			b.WriteString(`\f`)
-		default:
-			b.WriteByte(value[i])
-		}
-	}
-	b.WriteByte('\'')
-	return b.String()
+	return "'" + postgresConfLiteralReplacer.Replace(value) + "'"
 }
 
 // UpdatePostgresConfigurationFile search and replace options in a Postgres configuration file.

--- a/pkg/configfile/configfile.go
+++ b/pkg/configfile/configfile.go
@@ -41,13 +41,13 @@ var postgresConfLiteralReplacer = strings.NewReplacer(
 	"\f", `\f`,
 )
 
-// EscapePostgresConfLiteral escapes an arbitrary string so it can be used as a
+// escapePostgresConfLiteral escapes an arbitrary string so it can be used as a
 // value in a PostgreSQL configuration file, wrapped in single quotes.
 //
 // pq.QuoteLiteral is unsuitable here: it emits ` E'...'` when the value
 // contains a backslash, and the PostgreSQL config parser does not recognise
 // the `E'...'` syntax.
-func EscapePostgresConfLiteral(value string) string {
+func escapePostgresConfLiteral(value string) string {
 	return "'" + postgresConfLiteralReplacer.Replace(value) + "'"
 }
 
@@ -71,17 +71,13 @@ func UpdatePostgresConfigurationFile(
 		}
 	}
 	lines = RemoveOptionsFromConfigurationContents(lines, optionsToRemove...)
-
-	lines, err = UpdateConfigurationContents(lines, options)
-	if err != nil {
-		return false, fmt.Errorf("error while updating configuration from %v: %w", fileName, err)
-	}
+	lines = UpdateConfigurationContents(lines, options)
 	return fileutils.WriteLinesToFile(fileName, lines)
 }
 
 // UpdateConfigurationContents search and replace options in a configuration file whose
 // content is passed
-func UpdateConfigurationContents(lines []string, options map[string]string) ([]string, error) {
+func UpdateConfigurationContents(lines []string, options map[string]string) []string {
 	foundKeys := stringset.New()
 	index := 0
 	for _, line := range lines {
@@ -98,7 +94,7 @@ func UpdateConfigurationContents(lines []string, options map[string]string) ([]s
 			}
 
 			foundKeys.Put(key)
-			lines[index] = fmt.Sprintf("%s = %s", key, EscapePostgresConfLiteral(value))
+			lines[index] = fmt.Sprintf("%s = %s", key, escapePostgresConfLiteral(value))
 			index++
 			continue
 		}
@@ -113,11 +109,11 @@ func UpdateConfigurationContents(lines []string, options map[string]string) ([]s
 	for _, key := range keysList {
 		if !foundKeys.Has(key) {
 			value := options[key]
-			lines = append(lines, fmt.Sprintf("%s = %s", key, EscapePostgresConfLiteral(value)))
+			lines = append(lines, fmt.Sprintf("%s = %s", key, escapePostgresConfLiteral(value)))
 		}
 	}
 
-	return lines, nil
+	return lines
 }
 
 // RenderPostgresConfiguration returns a PostgreSQL configuration fragment as
@@ -129,9 +125,8 @@ func UpdateConfigurationContents(lines []string, options map[string]string) ([]s
 // that build strings by hand can forget to escape values, while this funnels
 // every value through the same escaping that the on-disk parser uses.
 func RenderPostgresConfiguration(options map[string]string) string {
-	lines, _ := UpdateConfigurationContents(nil, options)
 	var b strings.Builder
-	for _, l := range lines {
+	for _, l := range UpdateConfigurationContents(nil, options) {
 		b.WriteString(l)
 		b.WriteByte('\n')
 	}
@@ -144,11 +139,7 @@ func WritePostgresConfiguration(
 	fileName string,
 	options map[string]string,
 ) (changed bool, err error) {
-	lines, err := UpdateConfigurationContents(nil, options)
-	if err != nil {
-		return false, fmt.Errorf("error while writing configuration to %v: %w", fileName, err)
-	}
-	return fileutils.WriteLinesToFile(fileName, lines)
+	return fileutils.WriteLinesToFile(fileName, UpdateConfigurationContents(nil, options))
 }
 
 // RemoveOptionsFromConfigurationContents deletes all the lines containing one of the given options

--- a/pkg/configfile/configfile.go
+++ b/pkg/configfile/configfile.go
@@ -27,8 +27,45 @@ import (
 
 	"github.com/cloudnative-pg/machinery/pkg/fileutils"
 	"github.com/cloudnative-pg/machinery/pkg/stringset"
-	"github.com/lib/pq"
 )
+
+// EscapePostgresConfLiteral escapes an arbitrary string so it can be used as a
+// value in a PostgreSQL configuration file. The returned string is wrapped in
+// single quotes and any character that the PostgreSQL config file lexer would
+// interpret specially is escaped: backslash becomes `\\`, single quote becomes
+// `”`, and control characters (LF, CR, TAB, BS, FF) become their `\n`, `\r`,
+// `\t`, `\b`, `\f` two-character equivalents.
+//
+// pq.QuoteLiteral is unsuitable here because it emits ` E'...'` when the value
+// contains a backslash, and the PostgreSQL config parser does not recognise
+// the `E'...'` syntax.
+func EscapePostgresConfLiteral(value string) string {
+	var b strings.Builder
+	b.Grow(len(value) + 2)
+	b.WriteByte('\'')
+	for i := 0; i < len(value); i++ {
+		switch value[i] {
+		case '\\':
+			b.WriteString(`\\`)
+		case '\'':
+			b.WriteString(`''`)
+		case '\n':
+			b.WriteString(`\n`)
+		case '\r':
+			b.WriteString(`\r`)
+		case '\t':
+			b.WriteString(`\t`)
+		case '\b':
+			b.WriteString(`\b`)
+		case '\f':
+			b.WriteString(`\f`)
+		default:
+			b.WriteByte(value[i])
+		}
+	}
+	b.WriteByte('\'')
+	return b.String()
+}
 
 // UpdatePostgresConfigurationFile search and replace options in a Postgres configuration file.
 // If any managedOptions is passed, it will be removed unless present in the options map.
@@ -77,7 +114,7 @@ func UpdateConfigurationContents(lines []string, options map[string]string) ([]s
 			}
 
 			foundKeys.Put(key)
-			lines[index] = fmt.Sprintf("%s = %s", key, pq.QuoteLiteral(value))
+			lines[index] = fmt.Sprintf("%s = %s", key, EscapePostgresConfLiteral(value))
 			index++
 			continue
 		}
@@ -92,7 +129,7 @@ func UpdateConfigurationContents(lines []string, options map[string]string) ([]s
 	for _, key := range keysList {
 		if !foundKeys.Has(key) {
 			value := options[key]
-			lines = append(lines, fmt.Sprintf("%s = %s", key, pq.QuoteLiteral(value)))
+			lines = append(lines, fmt.Sprintf("%s = %s", key, EscapePostgresConfLiteral(value)))
 		}
 	}
 

--- a/pkg/configfile/configfile_test.go
+++ b/pkg/configfile/configfile_test.go
@@ -249,6 +249,132 @@ var _ = Describe("Update configuration files", func() {
 	})
 })
 
+var _ = Describe("EscapePostgresConfLiteral", func() {
+	DescribeTable("produces a value that round-trips through the PostgreSQL config file parser",
+		func(input, expected string) {
+			Expect(EscapePostgresConfLiteral(input)).To(Equal(expected))
+		},
+		Entry("plain string", "hello", "'hello'"),
+		Entry("empty string", "", "''"),
+		Entry("single quote", "hello'world", "'hello''world'"),
+		Entry("backslash", `hello\world`, `'hello\\world'`),
+		Entry("backslash followed by n (two chars)", `a\nb`, `'a\\nb'`),
+		Entry("literal newline", "a\nb", `'a\nb'`),
+		Entry("literal carriage return", "a\rb", `'a\rb'`),
+		Entry("literal tab", "a\tb", `'a\tb'`),
+		Entry("literal backspace", "a\bb", `'a\bb'`),
+		Entry("literal form feed", "a\fb", `'a\fb'`),
+		Entry("backslash and quote together",
+			`a'\b`,
+			`'a''\\b'`),
+		Entry("everything at once",
+			"a'b\\c\nd\te",
+			`'a''b\\c\nd\te'`),
+	)
+
+	It("produces a quoted literal that PostgreSQL reverses back to the original", func() {
+		// The config file parser applies these rules inside single-quoted strings:
+		//   ''   -> '
+		//   \\   -> \
+		//   \n   -> newline
+		//   \r   -> CR
+		//   \t   -> tab
+		//   \b   -> backspace
+		//   \f   -> form feed
+		//   \X   -> X (backslash stripped for any other X)
+		reverse := func(quoted string) string {
+			// Expect surrounding single quotes
+			Expect(quoted[:1]).To(Equal("'"))
+			Expect(quoted[len(quoted)-1:]).To(Equal("'"))
+			inner := quoted[1 : len(quoted)-1]
+			var b []byte
+			for i := 0; i < len(inner); i++ {
+				switch inner[i] {
+				case '\'':
+					Expect(i+1 < len(inner)).To(BeTrue())
+					Expect(inner[i+1]).To(Equal(byte('\'')))
+					b = append(b, '\'')
+					i++
+				case '\\':
+					Expect(i+1 < len(inner)).To(BeTrue())
+					switch inner[i+1] {
+					case '\\':
+						b = append(b, '\\')
+					case 'n':
+						b = append(b, '\n')
+					case 'r':
+						b = append(b, '\r')
+					case 't':
+						b = append(b, '\t')
+					case 'b':
+						b = append(b, '\b')
+					case 'f':
+						b = append(b, '\f')
+					default:
+						b = append(b, inner[i+1])
+					}
+					i++
+				default:
+					b = append(b, inner[i])
+				}
+			}
+			return string(b)
+		}
+
+		cases := []string{
+			"hello",
+			"",
+			"hello'world",
+			`hello\world`,
+			`a\nb`,
+			"a\nb",
+			"a\rb",
+			"a\tb",
+			"a'b\\c\nd\te",
+			`multiple 'quotes' and \back\slashes`,
+		}
+		for _, value := range cases {
+			Expect(reverse(EscapePostgresConfLiteral(value))).To(Equal(value),
+				"round-trip failed for input %q", value)
+		}
+	})
+})
+
+var _ = Describe("UpdateConfigurationContents with special characters", func() {
+	It("escapes single quotes in values", func() {
+		updated, err := UpdateConfigurationContents(nil, map[string]string{
+			"recovery_target_name": "my'restore'point",
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(updated).To(ConsistOf(
+			"recovery_target_name = 'my''restore''point'",
+		))
+	})
+
+	It("escapes backslashes without generating E-strings", func() {
+		// pq.QuoteLiteral generates `E'...'` when the input contains a backslash,
+		// which the postgresql.conf lexer does not understand. We must produce
+		// the plain single-quoted form with doubled backslashes.
+		updated, err := UpdateConfigurationContents(nil, map[string]string{
+			"archive_command": `test \ command`,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(updated).To(ConsistOf(
+			`archive_command = 'test \\ command'`,
+		))
+	})
+
+	It("escapes literal newlines", func() {
+		updated, err := UpdateConfigurationContents(nil, map[string]string{
+			"recovery_target_name": "line1\nline2",
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(updated).To(ConsistOf(
+			`recovery_target_name = 'line1\nline2'`,
+		))
+	})
+})
+
 var _ = Describe("Remove configuration files option", func() {
 	It("keeps the initial input if the option to be removed is not matched", func() {
 		initialContent := []string{

--- a/pkg/configfile/configfile_test.go
+++ b/pkg/configfile/configfile_test.go
@@ -207,7 +207,7 @@ var _ = Describe("Update configuration files", func() {
 			"recovery_target_timeline = 'latest'",
 		}
 
-		updatedContent, _ := UpdateConfigurationContents(initialContent, map[string]string{
+		updatedContent := UpdateConfigurationContents(initialContent, map[string]string{
 			"test.key": "test.value",
 		})
 
@@ -233,7 +233,7 @@ var _ = Describe("Update configuration files", func() {
 			"primary_conninfo = 'host=someHost2 user=someUser2 application_name=nodeName2'",
 		}
 
-		updatedContent, _ := UpdateConfigurationContents(initialContent, map[string]string{
+		updatedContent := UpdateConfigurationContents(initialContent, map[string]string{
 			"primary_conninfo": "host=someHost user=someUser application_name=nodeName",
 		})
 
@@ -249,10 +249,10 @@ var _ = Describe("Update configuration files", func() {
 	})
 })
 
-var _ = Describe("EscapePostgresConfLiteral", func() {
+var _ = Describe("escapePostgresConfLiteral", func() {
 	DescribeTable("produces a value that round-trips through the PostgreSQL config file parser",
 		func(input, expected string) {
-			Expect(EscapePostgresConfLiteral(input)).To(Equal(expected))
+			Expect(escapePostgresConfLiteral(input)).To(Equal(expected))
 		},
 		Entry("plain string", "hello", "'hello'"),
 		Entry("empty string", "", "''"),
@@ -334,7 +334,7 @@ var _ = Describe("EscapePostgresConfLiteral", func() {
 			`multiple 'quotes' and \back\slashes`,
 		}
 		for _, value := range cases {
-			Expect(reverse(EscapePostgresConfLiteral(value))).To(Equal(value),
+			Expect(reverse(escapePostgresConfLiteral(value))).To(Equal(value),
 				"round-trip failed for input %q", value)
 		}
 	})
@@ -342,10 +342,9 @@ var _ = Describe("EscapePostgresConfLiteral", func() {
 
 var _ = Describe("UpdateConfigurationContents with special characters", func() {
 	It("escapes single quotes in values", func() {
-		updated, err := UpdateConfigurationContents(nil, map[string]string{
+		updated := UpdateConfigurationContents(nil, map[string]string{
 			"recovery_target_name": "my'restore'point",
 		})
-		Expect(err).NotTo(HaveOccurred())
 		Expect(updated).To(ConsistOf(
 			"recovery_target_name = 'my''restore''point'",
 		))
@@ -355,20 +354,18 @@ var _ = Describe("UpdateConfigurationContents with special characters", func() {
 		// pq.QuoteLiteral generates `E'...'` when the input contains a backslash,
 		// which the postgresql.conf lexer does not understand. We must produce
 		// the plain single-quoted form with doubled backslashes.
-		updated, err := UpdateConfigurationContents(nil, map[string]string{
+		updated := UpdateConfigurationContents(nil, map[string]string{
 			"archive_command": `test \ command`,
 		})
-		Expect(err).NotTo(HaveOccurred())
 		Expect(updated).To(ConsistOf(
 			`archive_command = 'test \\ command'`,
 		))
 	})
 
 	It("escapes literal newlines", func() {
-		updated, err := UpdateConfigurationContents(nil, map[string]string{
+		updated := UpdateConfigurationContents(nil, map[string]string{
 			"recovery_target_name": "line1\nline2",
 		})
-		Expect(err).NotTo(HaveOccurred())
 		Expect(updated).To(ConsistOf(
 			`recovery_target_name = 'line1\nline2'`,
 		))

--- a/pkg/management/postgres/restore.go
+++ b/pkg/management/postgres/restore.go
@@ -148,10 +148,10 @@ func (info InitInfo) RestoreSnapshot(ctx context.Context, cli client.Client, imm
 	restoreCmd := fmt.Sprintf(
 		"/controller/manager wal-restore --log-destination %s/%s.json %%f %%p",
 		postgresSpec.LogPath, postgresSpec.LogFileName)
-	config := fmt.Sprintf(
-		"recovery_target_action = promote\n"+
-			"restore_command = %s\n",
-		configfile.EscapePostgresConfLiteral(restoreCmd))
+	config := configfile.RenderPostgresConfiguration(map[string]string{
+		"recovery_target_action": "promote",
+		"restore_command":        restoreCmd,
+	})
 
 	if pluginConfiguration := cluster.GetRecoverySourcePlugin(); pluginConfiguration == nil {
 		server, found := cluster.ExternalCluster(cluster.Spec.Bootstrap.Recovery.Source)
@@ -639,12 +639,10 @@ func getRestoreWalConfig(ctx context.Context, backup *apiv1.Backup) (string, err
 
 	cmd = append(cmd, "%f", "%p")
 
-	recoveryFileContents := fmt.Sprintf(
-		"recovery_target_action = promote\n"+
-			"restore_command = %s\n",
-		configfile.EscapePostgresConfLiteral(strings.Join(cmd, " ")))
-
-	return recoveryFileContents, nil
+	return configfile.RenderPostgresConfiguration(map[string]string{
+		"recovery_target_action": "promote",
+		"restore_command":        strings.Join(cmd, " "),
+	}), nil
 }
 
 func (info InitInfo) writeRecoveryConfiguration(cluster *apiv1.Cluster, recoveryFileContents string) error {

--- a/pkg/management/postgres/restore.go
+++ b/pkg/management/postgres/restore.go
@@ -150,8 +150,8 @@ func (info InitInfo) RestoreSnapshot(ctx context.Context, cli client.Client, imm
 		postgresSpec.LogPath, postgresSpec.LogFileName)
 	config := fmt.Sprintf(
 		"recovery_target_action = promote\n"+
-			"restore_command = '%s'\n",
-		restoreCmd)
+			"restore_command = %s\n",
+		configfile.EscapePostgresConfLiteral(restoreCmd))
 
 	if pluginConfiguration := cluster.GetRecoverySourcePlugin(); pluginConfiguration == nil {
 		server, found := cluster.ExternalCluster(cluster.Spec.Bootstrap.Recovery.Source)
@@ -641,8 +641,8 @@ func getRestoreWalConfig(ctx context.Context, backup *apiv1.Backup) (string, err
 
 	recoveryFileContents := fmt.Sprintf(
 		"recovery_target_action = promote\n"+
-			"restore_command = '%s'\n",
-		strings.Join(cmd, " "))
+			"restore_command = %s\n",
+		configfile.EscapePostgresConfLiteral(strings.Join(cmd, " ")))
 
 	return recoveryFileContents, nil
 }

--- a/pkg/management/postgres/restore_test.go
+++ b/pkg/management/postgres/restore_test.go
@@ -207,3 +207,24 @@ var _ = Describe("testing restore InitInfo methods", func() {
 		Expect(enforcedParamsInPGData["max_connections"]).To(Equal(200))
 	})
 })
+
+var _ = Describe("getRestoreWalConfig", func() {
+	It("escapes quotes and backslashes so user-controlled backup fields cannot corrupt custom.conf",
+		func(ctx SpecContext) {
+			backup := &apiv1.Backup{
+				Status: apiv1.BackupStatus{
+					DestinationPath: "s3://bucket/has'quote",
+					ServerName:      `server\name`,
+				},
+			}
+			out, err := getRestoreWalConfig(ctx, backup)
+			Expect(err).ToNot(HaveOccurred())
+			// Embedded single quote must be doubled; backslash must be doubled.
+			Expect(out).To(ContainSubstring("s3://bucket/has''quote"))
+			Expect(out).To(ContainSubstring(`server\\name`))
+			// And the raw unescaped form must NOT appear anywhere in the output.
+			Expect(out).NotTo(ContainSubstring("has'quote"))
+			Expect(out).NotTo(MatchRegexp(`server\\[^\\]name`),
+				"backslash in server name must be doubled")
+		})
+})

--- a/pkg/postgres/configuration.go
+++ b/pkg/postgres/configuration.go
@@ -873,37 +873,33 @@ func (p *PgConfiguration) setUserSharedPreloadLibraries(info ConfigurationInfo) 
 
 // CreatePostgresqlConfFile creates the contents of the postgresql.conf file
 func CreatePostgresqlConfFile(configuration *PgConfiguration) (string, string) {
-	// We need to be able to compare two configurations generated
-	// by operator to know if they are different or not. To do
-	// that we sort the configuration by parameter name as order
-	// is really irrelevant for our purposes
-	parameters := configuration.GetSortedList()
-	var postgresConf strings.Builder
-	var cnpgConf strings.Builder
-	for _, parameter := range parameters {
-		line := fmt.Sprintf(
-			"%v = %v\n",
-			parameter,
-			escapePostgresConfValue(configuration.configs[parameter]))
-		if strings.HasPrefix(parameter, "cnpg.") {
-			cnpgConf.WriteString(line)
+	// Split the parameters into the regular PostgreSQL section (whose hash
+	// defines the identity of the configuration) and the cnpg.* section (which
+	// carries operator-internal state and must not contribute to the hash).
+	pgOptions := map[string]string{}
+	cnpgOptions := map[string]string{}
+	for name, value := range configuration.configs {
+		if strings.HasPrefix(name, "cnpg.") {
+			cnpgOptions[name] = value
 		} else {
-			postgresConf.WriteString(line)
+			pgOptions[name] = value
 		}
 	}
 
-	sha256sum := fmt.Sprintf("%x", sha256.Sum256([]byte(postgresConf.String())))
-	postgresConf.WriteString(cnpgConf.String())
-	fmt.Fprintf(&postgresConf, "%v = %v\n", CNPGConfigSha256,
-		escapePostgresConfValue(sha256sum))
+	pgPart := configfile.RenderPostgresConfiguration(pgOptions)
+	sha256sum := fmt.Sprintf("%x", sha256.Sum256([]byte(pgPart)))
 
-	return postgresConf.String(), sha256sum
-}
+	// Emit the cnpg.* keys (sorted), then always emit the sha256 line LAST.
+	// The sha256-last layout is legacy behaviour; preserving it prevents a
+	// byte-level diff in postgresql.conf (and an avoidable pg_reload_conf())
+	// on operator upgrade for clusters that already have other cnpg.* keys
+	// such as cnpg.synchronous_standby_names_metadata.
+	cnpgPart := configfile.RenderPostgresConfiguration(cnpgOptions)
+	sha256Line := configfile.RenderPostgresConfiguration(map[string]string{
+		CNPGConfigSha256: sha256sum,
+	})
 
-// escapePostgresConfValue escapes a value to make its representation
-// directly embeddable in the PostgreSQL configuration file
-func escapePostgresConfValue(value string) string {
-	return configfile.EscapePostgresConfLiteral(value)
+	return pgPart + cnpgPart + sha256Line, sha256sum
 }
 
 // AdditionalExtensionConfiguration is the configuration for an Extension added via ImageVolume

--- a/pkg/postgres/configuration.go
+++ b/pkg/postgres/configuration.go
@@ -35,6 +35,7 @@ import (
 
 	"github.com/cloudnative-pg/machinery/pkg/log"
 
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/configfile"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/postgres/hba"
 )
 
@@ -902,7 +903,7 @@ func CreatePostgresqlConfFile(configuration *PgConfiguration) (string, string) {
 // escapePostgresConfValue escapes a value to make its representation
 // directly embeddable in the PostgreSQL configuration file
 func escapePostgresConfValue(value string) string {
-	return fmt.Sprintf("'%v'", strings.ReplaceAll(value, "'", "''"))
+	return configfile.EscapePostgresConfLiteral(value)
 }
 
 // AdditionalExtensionConfiguration is the configuration for an Extension added via ImageVolume

--- a/pkg/postgres/configuration.go
+++ b/pkg/postgres/configuration.go
@@ -28,7 +28,6 @@ import (
 	"math"
 	"path/filepath"
 	"slices"
-	"sort"
 	"strings"
 	"text/template"
 	"time"
@@ -692,18 +691,6 @@ func (p *PgConfiguration) AddSharedPreloadLibrary(newLibrary string) {
 // GetConfig retrieves a configuration from the map of configurations, given the key
 func (p *PgConfiguration) GetConfig(key string) string {
 	return p.configs[key]
-}
-
-// GetSortedList returns a sorted list of configurations
-func (p *PgConfiguration) GetSortedList() []string {
-	parameters := make([]string, len(p.configs))
-	i := 0
-	for key := range p.configs {
-		parameters[i] = key
-		i++
-	}
-	sort.Strings(parameters)
-	return parameters
 }
 
 // CreatePostgresqlConfiguration creates the configuration from the settings

--- a/pkg/postgres/configuration_test.go
+++ b/pkg/postgres/configuration_test.go
@@ -101,6 +101,16 @@ var _ = Describe("PostgreSQL configuration creation", func() {
 		Expect(confFile).To(ContainSubstring("log_destination = 'stderr'\nshared_buffers = '128KB'\n"))
 	})
 
+	It("escapes backslashes, quotes and control characters in parameter values", func() {
+		settings := map[string]string{
+			"log_line_prefix": `%m [%p] \'%u\'` + "\n",
+		}
+		confFile, _ := CreatePostgresqlConfFile(&PgConfiguration{settings})
+		Expect(confFile).To(ContainSubstring(
+			`log_line_prefix = '%m [%p] \\''%u\\''\n'` + "\n",
+		))
+	})
+
 	When("version is 13", func() {
 		It("will use appropriate settings", func() {
 			info := ConfigurationInfo{

--- a/pkg/postgres/configuration_test.go
+++ b/pkg/postgres/configuration_test.go
@@ -118,11 +118,15 @@ var _ = Describe("PostgreSQL configuration creation", func() {
 		//   3. cnpg.config_sha256 ALWAYS last
 		// The sha256 hash is computed over (1) only. Any deviation from this
 		// layout changes every cluster's config-file bytes on upgrade and
-		// must be done deliberately.
+		// must be done deliberately. cnpg.synchronous_standby_names_metadata
+		// is included to anchor the sha256-last invariant: alphabetically it
+		// would sort after cnpg.config_sha256, and reordering would rewrite
+		// every sync-replication cluster's postgresql.conf on upgrade.
 		settings := map[string]string{
-			"max_connections":    "100",
-			"shared_buffers":     "128MB",
-			"cnpg.some_internal": "value",
+			"max_connections":                         "100",
+			"shared_buffers":                          "128MB",
+			"cnpg.some_internal":                      "value",
+			"cnpg.synchronous_standby_names_metadata": "ANY 1 (a, b)",
 		}
 		confFile, sum := CreatePostgresqlConfFile(&PgConfiguration{settings})
 
@@ -130,6 +134,7 @@ var _ = Describe("PostgreSQL configuration creation", func() {
 		expected := "max_connections = '100'\n" +
 			"shared_buffers = '128MB'\n" +
 			"cnpg.some_internal = 'value'\n" +
+			"cnpg.synchronous_standby_names_metadata = 'ANY 1 (a, b)'\n" +
 			"cnpg.config_sha256 = '" + expectedHash + "'\n"
 
 		Expect(sum).To(Equal(expectedHash))

--- a/pkg/postgres/configuration_test.go
+++ b/pkg/postgres/configuration_test.go
@@ -111,6 +111,31 @@ var _ = Describe("PostgreSQL configuration creation", func() {
 		))
 	})
 
+	It("produces a byte-exact, reproducible layout", func() {
+		// Lock the on-disk layout of postgresql.conf:
+		//   1. non-cnpg keys sorted alphabetically
+		//   2. cnpg.* keys (other than the sha256) sorted alphabetically
+		//   3. cnpg.config_sha256 ALWAYS last
+		// The sha256 hash is computed over (1) only. Any deviation from this
+		// layout changes every cluster's config-file bytes on upgrade and
+		// must be done deliberately.
+		settings := map[string]string{
+			"max_connections":    "100",
+			"shared_buffers":     "128MB",
+			"cnpg.some_internal": "value",
+		}
+		confFile, sum := CreatePostgresqlConfFile(&PgConfiguration{settings})
+
+		const expectedHash = "61d267eaf0cf58ed4279ce5fdd3866b1d9874ff4f63539f6933df62450933d8a"
+		expected := "max_connections = '100'\n" +
+			"shared_buffers = '128MB'\n" +
+			"cnpg.some_internal = 'value'\n" +
+			"cnpg.config_sha256 = '" + expectedHash + "'\n"
+
+		Expect(sum).To(Equal(expectedHash))
+		Expect(confFile).To(Equal(expected))
+	})
+
 	When("version is 13", func() {
 		It("will use appropriate settings", func() {
 			info := ConfigurationInfo{


### PR DESCRIPTION
Values written into custom.conf were only escaped for single quotes. Backslashes and control characters (LF, CR, TAB, BS, FF) passed through unescaped, which either corrupted the configuration (e.g. a user-supplied recovery_target_name containing ' or a newline) or silently mangled the runtime value (a \ in log_line_prefix stripped by PostgreSQL's config lexer).

Introduce configfile.RenderPostgresConfiguration as the single canonical helper that emits a postgresql.conf-style fragment from a map[string]string, with values escaped according to the guc-file.l rules (\, ', \n, \r, \t, \b, \f). Migrate every config-file-emitting site to it: pkg/configfile.UpdateConfigurationContents (replacing pq.QuoteLiteral, which emits an E'...' SQL-style literal that the config lexer rejects when the value contains a backslash), pkg/postgres.CreatePostgresqlConfFile, api/v1.(*RecoveryTarget).BuildPostgresOptions (previously did no escaping at all for recovery_target_name/_xid/_lsn/_timeline/_time), and pkg/management/postgres.getRestoreWalConfig and RestoreSnapshot's restore_command construction. After this change the inner escapePostgresConfLiteral is private to pkg/configfile.

Upgrade impact: clusters whose PostgreSQL parameters contain \ or a control character (most commonly a literal tab in log_line_prefix) will see one pg_reload_conf() on the first reconcile after upgrade because the config-file SHA256 changes. No restart, no connection drops. Clusters with only default or quote-only special values are unaffected.

Related #10518
Closes #10506

Reported-by: Koda Reef <kodareef5@users.noreply.github.com>
