### PR TITLE
docs: add troubleshooting for CRD annotation size error during installation

### DIFF
--- a/docs/src/installation_upgrade.md
+++ b/docs/src/installation_upgrade.md
@@ -29,6 +29,27 @@ kubectl rollout status deployment \
   -n cnpg-system cnpg-controller-manager
 ```
 
+#### Troubleshooting: CRD annotation size error
+
+If you omit the `--server-side` flag during installation and use client-side apply instead, the process might fail in certain environments (such as Windows with PowerShell and newer `kubectl` versions) with the following error:
+
+```text
+metadata.annotations: Too long: may not be more than 262144 bytes
+```
+
+This prevents the operator from starting and leads to a `CrashLoopBackOff` status. The failure happens because client-side apply attempts to store the entire manifest in the `kubectl.kubernetes.io/last-applied-configuration` annotation, which has a strict size limit.
+
+To fix this issue, simply use the `--server-side` flag as shown in the installation instructions:
+
+```sh
+kubectl apply --server-side -f <cnpg-manifest>
+```
+
+:::note
+We strongly recommend always using `--server-side` apply when installing or upgrading large CRDs to prevent annotation size limit issues.
+:::
+
+
 ### Using the `cnpg` plugin for `kubectl`
 
 You can use the `cnpg` plugin to override the default configuration options


### PR DESCRIPTION
## What kind of change does this PR introduce?
Documentation update.

## What is the current behavior?
When users try to install CloudNativePG omitting the `--server-side` flag using older commands or specific environments (like Windows + PowerShell with newer `kubectl` versions), the installation fails with the following error:
`metadata.annotations: Too long: may not be more than 262144 bytes`

This leads to a `CrashLoopBackOff` state unassociated with an obvious fix. It happens because Kubernetes client-side apply attempts to store the entire manifest containing the large CNPG CRDs inside the `kubectl.kubernetes.io/last-applied-configuration` annotation, surpassing the strict size limits.

## What is the new behavior?
This PR introduces a dedicated **"Troubleshooting: CRD annotation size error"** section in the `Installation and upgrades` guide. 
It helps users by:
1. Highlighting the exact error message so it is easily searchable.
2. Explaining the architectural reason behind the failure to clarify the issue.
3. Providing the direct solution and strongly emphasizing the importance of `--server-side` apply as recommended in our default installation commands.

## Additional Context
This will significantly improve the initial developer experience, particularly for Minikube and Windows users who frequently stumble onto this generic Kubernetes friction.

Fixes #10520
