### PR TITLE
chore(Makefile): Remove `install`, `uninstall`, and `deploy` targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -219,15 +219,6 @@ olm-catalog: olm-bundle opm ## Build and push the index image for OLM Catalog
        - cnpg-pull-secret" | envsubst > cloudnative-pg-catalog.yaml ;\
 
 ##@ Deployment
-install: manifests kustomize ## Install CRDs into a cluster.
-	$(KUSTOMIZE) build config/crd | kubectl apply --server-side -f -
-
-uninstall: manifests kustomize ## Uninstall CRDs from a cluster.
-	$(KUSTOMIZE) build config/crd | kubectl delete -f -
-
-deploy: generate-manifest ## Deploy controller in the configured Kubernetes cluster in ~/.kube/config.
-	kubectl apply --server-side --force-conflicts -f ${OPERATOR_MANIFEST_PATH}
-
 generate-manifest: manifests kustomize ## Generate manifest used for deployment.
 	set -e ;\
 	CONFIG_TMP_DIR=$$(mktemp -d) ;\


### PR DESCRIPTION
Remove the unnecessary `install`, `uninstall`, and `deploy` targets from the `Makefile`. These targets were created initially but are no longer used. This effort aims to simplify and reduce the complexity of the testing environment setup.

Closes #10521