### PR TITLE
chore: update all the GitHub actions together in Renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -211,10 +211,11 @@
       matchUpdateTypes: [
         'digest',
         'pinDigest',
+        'major',
         'minor',
         'patch',
       ],
-      groupName: 'all non-major github action',
+      groupName: 'all github action',
       pinDigests: true,
     },
     {


### PR DESCRIPTION
Update all the versions major, minor and patch to avoid having lots of PRs opened

Closes #10525 