### PR TITLE
Add a size limit to the scratch-data volume of the operator

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -99,7 +99,8 @@ spec:
               - "ALL"
       volumes:
         - name: scratch-data
-          emptyDir: {}
+          emptyDir:
+            sizeLimit: 10Mi
         - name: webhook-certificates
           secret:
             optional: true


### PR DESCRIPTION
This volume is only used to store a passfile for external secrets as docuemented at https://cloudnative-pg.io/docs/devel/bootstrap#password-files.

Adding a limit makes it easier to manage ephemeral node storage on clusters.

Vaguely related: https://github.com/cloudnative-pg/cloudnative-pg/issues/6823