### PR TITLE
test(e2e): export image overrides to setup-cluster.sh

### DIFF
--- a/hack/e2e/run-e2e.sh
+++ b/hack/e2e/run-e2e.sh
@@ -31,8 +31,8 @@ CONTROLLER_IMG=${CONTROLLER_IMG:-$("${ROOT_DIR}/hack/setup-cluster.sh" print-ima
 CONTROLLER_IMG_DIGEST=${CONTROLLER_IMG_DIGEST:-""}
 CONTROLLER_IMG_PRIME_DIGEST=${CONTROLLER_IMG_PRIME_DIGEST:-""}
 TEST_UPGRADE_TO_V1=${TEST_UPGRADE_TO_V1:-true}
-POSTGRES_IMG=${POSTGRES_IMG:-$(grep 'DefaultImageName.*=' "${ROOT_DIR}/pkg/versions/versions.go" | cut -f 2 -d \")}
-PGBOUNCER_IMG=${PGBOUNCER_IMG:-$(grep 'DefaultPgbouncerImage.*=' "${ROOT_DIR}/pkg/versions/versions.go" | cut -f 2 -d \")}
+export POSTGRES_IMG=${POSTGRES_IMG:-$(grep 'DefaultImageName.*=' "${ROOT_DIR}/pkg/versions/versions.go" | cut -f 2 -d \")}
+export PGBOUNCER_IMG=${PGBOUNCER_IMG:-$(grep 'DefaultPgbouncerImage.*=' "${ROOT_DIR}/pkg/versions/versions.go" | cut -f 2 -d \")}
 OPERATOR="${OPERATOR:-local}"
 CNPG_DEPLOYMENT_METHOD="${CNPG_DEPLOYMENT_METHOD:-manifest}"
 export OPERATOR_MANIFEST_PATH="${OPERATOR_MANIFEST_PATH:-${ROOT_DIR}/dist/operator-manifest.yaml}"


### PR DESCRIPTION
run-e2e.sh sets POSTGRES_IMG and PGBOUNCER_IMG without exporting them, then invokes setup-cluster.sh generate-manifest as a subprocess to render the operator manifest. The subprocess sources hack/testing-tools/common/10-config.sh, which falls back to the defaults from pkg/versions/versions.go because the parent variables are not visible.

This is a no-op upstream (no override is set), but downstream forks that override PGBOUNCER_IMG_REPOSITORY have the override silently dropped: the manifest is generated with the default image and pooler tests fail with ImagePullBackOff when the default registry requires authentication.

Export both variables at definition. The PGBOUNCER_IMG_REPOSITORY override block reassigns PGBOUNCER_IMG without re-exporting, but the export attribute is preserved across reassignment in bash.