### PR TITLE
chore: generate supported releases tables from a JSON data file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -283,7 +283,7 @@ go-mod-check: ## Check if there's any dirty change after `go mod tidy`
 run-govulncheck: govulncheck ## Check if there's any known vulnerabilities with the currently installed Go modules
 	$(GOVULNCHECK) ./...
 
-checks: go-mod-check generate manifests apidoc fmt spellcheck wordlist-ordered woke vet lint run-govulncheck ## Runs all the checks on the project.
+checks: go-mod-check generate manifests apidoc generate-release-table fmt spellcheck wordlist-ordered woke vet lint run-govulncheck ## Runs all the checks on the project.
 
 ##@ Documentation
 
@@ -294,6 +294,9 @@ licenses: go-licenses ## Generate the licenses folder.
 		--save_path licenses/go-licenses --force || true
 	chmod a+rw -R licenses/go-licenses
 	find licenses/go-licenses \( -name '*.mod' -or -name '*.go' \) -delete
+
+generate-release-table: ## Regenerate the supported releases tables from docs/releases.json.
+	python3 hack/generate-supported-releases.py
 
 apidoc: crd-ref-docs ## Update the API Reference section of the documentation.
 	$(CRDREFDOCS) --source-path api/v1 \

--- a/contribute/release-notes-template.md
+++ b/contribute/release-notes-template.md
@@ -30,17 +30,17 @@ on the release branch in GitHub.
 
 **Release date:** Mon DD, 20YY
 
-### Important changes:
+### Important changes
 
 - OPTIONAL
 - OPTIONAL
 
-### Features:
+### Features
 
 - **MAIN FEATURE #1**: short description
 - **MAIN FEATURE #2**: short description
 
-### Enhancements:
+### Enhancements
 
 - Added ...
 - Introduced ...
@@ -50,12 +50,12 @@ on the release branch in GitHub.
     - Enhanced ...
     - Added ...
 
-### Security:
+### Security
 
 - Added ...
 - Improved ...
 
-### Fixes:
+### Fixes
 
 - Enhanced ...
 - Disabled ...

--- a/contribute/release_procedure.md
+++ b/contribute/release_procedure.md
@@ -46,9 +46,19 @@ activities:
   put the focus on finishing those in time. No new features should land in the
   last few days without previous validation from the team.
 
-- **Supported releases:** Make sure that you update the supported releases page
-  in [`docs/src/supported_releases.md`](../docs/src/supported_releases.md),
-  and that the maintainers approve the changes.
+- **Supported releases:** Make sure that you update
+  [`docs/releases.json`](../docs/releases.json), which is the single source of
+  truth for release metadata (dates, EOL, Kubernetes and PostgreSQL version
+  support). After editing it, regenerate the tables with:
+
+  ```bash
+  make generate-release-table
+  ```
+
+  Commit both `docs/releases.json` and the updated
+  [`docs/src/supported_releases.md`](../docs/src/supported_releases.md),
+  and make sure the maintainers approve the changes. Do **not** edit the
+  Markdown tables in `supported_releases.md` by hand — they are generated.
 
 - **Check on backporting:** Make sure to cherry-pick any code that requires
   backporting to the various release branches ahead of time. Doing that will

--- a/docs/releases.json
+++ b/docs/releases.json
@@ -1,0 +1,184 @@
+{
+  "releases": [
+    {
+      "minor": "1.29",
+      "release_date": "2026-03-31",
+      "release_date_approximate": false,
+      "end_of_life": "2026-09-30",
+      "end_of_life_approximate": true,
+      "kubernetes": {
+        "supported": ["1.33", "1.34", "1.35"],
+        "tested": ["1.29", "1.30", "1.31", "1.32"]
+      },
+      "postgres": { "min": 14, "max": 18 }
+    },
+    {
+      "minor": "1.28",
+      "release_date": "2025-12-09",
+      "release_date_approximate": false,
+      "end_of_life": "2026-06-30",
+      "end_of_life_approximate": false,
+      "kubernetes": {
+        "supported": ["1.32", "1.33", "1.34"],
+        "tested": ["1.29", "1.30", "1.31", "1.35"]
+      },
+      "postgres": { "min": 14, "max": 18 }
+    },
+    {
+      "minor": "1.30",
+      "release_date": "2026-06-01",
+      "release_date_approximate": true,
+      "end_of_life": "2026-12-01",
+      "end_of_life_approximate": true
+    },
+    {
+      "minor": "1.31",
+      "release_date": "2026-09-01",
+      "release_date_approximate": true,
+      "end_of_life": "2027-03-01",
+      "end_of_life_approximate": true
+    },
+    {
+      "minor": "1.32",
+      "release_date": "2026-12-01",
+      "release_date_approximate": true,
+      "end_of_life": "2027-06-01",
+      "end_of_life_approximate": true
+    },
+    {
+      "minor": "1.27",
+      "release_date": "2025-08-12",
+      "release_date_approximate": false,
+      "end_of_life": "2026-03-09",
+      "end_of_life_approximate": false,
+      "kubernetes": {
+        "supported": ["1.31", "1.32", "1.33"]
+      }
+    },
+    {
+      "minor": "1.26",
+      "release_date": "2025-05-23",
+      "release_date_approximate": false,
+      "end_of_life": "2025-11-12",
+      "end_of_life_approximate": false,
+      "kubernetes": {
+        "supported": ["1.30", "1.31", "1.32", "1.33"]
+      }
+    },
+    {
+      "minor": "1.25",
+      "release_date": "2024-12-23",
+      "release_date_approximate": false,
+      "end_of_life": "2025-08-22",
+      "end_of_life_approximate": false,
+      "kubernetes": {
+        "supported": ["1.29", "1.30", "1.31", "1.32"]
+      }
+    },
+    {
+      "minor": "1.24",
+      "release_date": "2024-08-22",
+      "release_date_approximate": false,
+      "end_of_life": "2025-05-23",
+      "end_of_life_approximate": false,
+      "kubernetes": {
+        "supported": ["1.28", "1.29", "1.30", "1.31"]
+      }
+    },
+    {
+      "minor": "1.23",
+      "release_date": "2024-04-24",
+      "release_date_approximate": false,
+      "end_of_life": "2024-11-24",
+      "end_of_life_approximate": false,
+      "kubernetes": {
+        "supported": ["1.27", "1.28", "1.29"]
+      }
+    },
+    {
+      "minor": "1.22",
+      "release_date": "2023-12-21",
+      "release_date_approximate": false,
+      "end_of_life": "2024-07-24",
+      "end_of_life_approximate": false,
+      "kubernetes": {
+        "supported": ["1.26", "1.27", "1.28"]
+      }
+    },
+    {
+      "minor": "1.21",
+      "release_date": "2023-10-12",
+      "release_date_approximate": false,
+      "end_of_life": "2024-06-12",
+      "end_of_life_approximate": false,
+      "kubernetes": {
+        "supported": ["1.25", "1.26", "1.27", "1.28"]
+      }
+    },
+    {
+      "minor": "1.20",
+      "release_date": "2023-04-27",
+      "release_date_approximate": false,
+      "end_of_life": "2024-01-21",
+      "end_of_life_approximate": false,
+      "kubernetes": {
+        "supported": ["1.24", "1.25", "1.26", "1.27"]
+      }
+    },
+    {
+      "minor": "1.19",
+      "release_date": "2023-02-14",
+      "release_date_approximate": false,
+      "end_of_life": "2023-11-03",
+      "end_of_life_approximate": false,
+      "kubernetes": {
+        "supported": ["1.23", "1.24", "1.25", "1.26"]
+      }
+    },
+    {
+      "minor": "1.18",
+      "release_date": "2022-11-10",
+      "release_date_approximate": false,
+      "end_of_life": "2023-06-12",
+      "end_of_life_approximate": false,
+      "kubernetes": {
+        "supported": ["1.23", "1.24", "1.25", "1.26", "1.27"]
+      }
+    },
+    {
+      "minor": "1.17",
+      "release_date": "2022-09-06",
+      "release_date_approximate": false,
+      "end_of_life": "2023-03-20",
+      "end_of_life_approximate": false,
+      "kubernetes": {
+        "supported": ["1.22", "1.23", "1.24"]
+      }
+    },
+    {
+      "minor": "1.16",
+      "release_date": "2022-07-07",
+      "release_date_approximate": false,
+      "end_of_life": "2022-12-21",
+      "end_of_life_approximate": false,
+      "kubernetes": {
+        "supported": ["1.22", "1.23", "1.24"]
+      }
+    },
+    {
+      "minor": "1.15",
+      "release_date": "2022-04-21",
+      "release_date_approximate": false,
+      "end_of_life": "2022-10-06",
+      "end_of_life_approximate": false,
+      "kubernetes": {
+        "supported": ["1.21", "1.22", "1.23"]
+      }
+    },
+    {
+      "minor": "main",
+      "development": true,
+      "postgres": { "min": 14, "max": 18 }
+    }
+  ]
+}

--- a/docs/src/supported_releases.md
+++ b/docs/src/supported_releases.md
@@ -86,12 +86,13 @@ Git tags for versions are prefixed with `v`.
 
 ## Support status of CloudNativePG releases
 
-<!-- TODO: Complete dates and versions below -->
-| Version         | Currently supported  | Release date | End of life     | Supported Kubernetes versions | Tested, but not supported | Supported Postgres versions |
-|-----------------|----------------------|--------------|-----------------|-------------------------------|---------------------------|-----------------------------|
-| 1.29.x          | Yes                  | 31 Mar 2026  | ~  Sep 2026     | 1.33, 1.34, 1.35              | 1.32, 1.31, 1.30, 1.29    | 14 - 18                     |
-| 1.28.x          | Yes                  |  9 Dec 2025  | 30 Jun 2026     | 1.32, 1.33, 1.34              | 1.35, 1.31, 1.30, 1.29    | 14 - 18                     |
-| main            | No, development only |              |                 |                               |                           | 13 - 18                     |
+<!-- BEGIN ACTIVE_RELEASES_TABLE -->
+| Version | Currently supported | Release date | End of life | Supported Kubernetes versions | Tested, but not supported | Supported Postgres versions |
+|---------|---------------------|--------------|-------------|-------------------------------|---------------------------|-----------------------------|
+| 1.29.x | Yes | Mar 31, 2026 | ~ Sep 2026 | 1.33, 1.34, 1.35 | 1.29, 1.30, 1.31, 1.32 | 14 - 18 |
+| 1.28.x | Yes | Dec 9, 2025 | Jun 30, 2026 | 1.32, 1.33, 1.34 | 1.29, 1.30, 1.31, 1.35 | 14 - 18 |
+| main | No, development only |  |  |  |  | 14 - 18 |
+<!-- END ACTIVE_RELEASES_TABLE -->
 
 The list of supported Kubernetes versions in the table depends on what
 the CloudNativePG maintainers think is reasonable to support and to test.
@@ -125,11 +126,13 @@ version of PostgreSQL, we might not be able to help you.
 
 ## Upcoming releases
 
+<!-- BEGIN UPCOMING_RELEASES_TABLE -->
 | Version | Release date | End of life |
 |---------|--------------|-------------|
-| 1.30.0  | ~ Jun, 2026  | ~ Dec, 2026 |
-| 1.31.0  | ~ Sep, 2026  | ~ Mar, 2027 |
-| 1.32.0  | ~ Dec, 2026  | ~ Jun, 2027 |
+| 1.30.0 | ~ Jun 2026 | ~ Dec 2026 |
+| 1.31.0 | ~ Sep 2026 | ~ Mar 2027 |
+| 1.32.0 | ~ Dec 2026 | ~ Jun 2027 |
+<!-- END UPCOMING_RELEASES_TABLE -->
 
 :::note
     Feature freeze occurs 1-2 weeks before the release, at which point a
@@ -146,21 +149,23 @@ version of PostgreSQL, we might not be able to help you.
 
 ## Old releases
 
-| Version         | Release date      | End of life         | Supported Kubernetes versions  |
-|-----------------|-------------------|---------------------|--------------------------------|
-| 1.27.x          | August, 12 2025   | March 9, 2026       | 1.31, 1.32, 1.33               |
-| 1.26.x          | May 23, 2025      | November 12, 2025   | 1.30, 1.31, 1.32, 1.33         |
-| 1.25.x          | Dec 23, 2024      | August 22, 2025     | 1.29, 1.30, 1.31, 1.32         |
-| 1.24.x          | Aug 22, 2024      | May 23, 2025        | 1.28, 1.29, 1.30, 1.31         |
-| 1.23.x          | April 24, 2024    | November 24, 2024   | 1.27, 1.28, 1.29               |
-| 1.22.x          | December 21, 2023 | July 24, 2024       | 1.26, 1.27, 1.28               |
-| 1.21.x          | October 12, 2023  | Jun 12, 2024        | 1.25, 1.26, 1.27, 1.28         |
-| 1.20.x          | April 27, 2023    | January 21, 2024    | 1.24, 1.25, 1.26, 1.27         |
-| 1.19.x          | February 14, 2023 | November 3, 2023    | 1.23, 1.24, 1.25, 1.26         |
-| 1.18.x          | Nov 10, 2022      | June 12, 2023       | 1.23, 1.24, 1.25, 1.26, 1.27   |
-| 1.17.x          | September 6, 2022 | March 20, 2023      | 1.22, 1.23, 1.24               |
-| 1.16.x          | July 7, 2022      | December 21, 2022   | 1.22, 1.23, 1.24               |
-| 1.15.x          | April 21, 2022    | October 6, 2022     | 1.21, 1.22, 1.23               |
+<!-- BEGIN OLD_RELEASES_TABLE -->
+| Version | Release date | End of life | Supported Kubernetes versions |
+|---------|--------------|-------------|-------------------------------|
+| 1.27.x | Aug 12, 2025 | Mar 9, 2026 | 1.31, 1.32, 1.33 |
+| 1.26.x | May 23, 2025 | Nov 12, 2025 | 1.30, 1.31, 1.32, 1.33 |
+| 1.25.x | Dec 23, 2024 | Aug 22, 2025 | 1.29, 1.30, 1.31, 1.32 |
+| 1.24.x | Aug 22, 2024 | May 23, 2025 | 1.28, 1.29, 1.30, 1.31 |
+| 1.23.x | Apr 24, 2024 | Nov 24, 2024 | 1.27, 1.28, 1.29 |
+| 1.22.x | Dec 21, 2023 | Jul 24, 2024 | 1.26, 1.27, 1.28 |
+| 1.21.x | Oct 12, 2023 | Jun 12, 2024 | 1.25, 1.26, 1.27, 1.28 |
+| 1.20.x | Apr 27, 2023 | Jan 21, 2024 | 1.24, 1.25, 1.26, 1.27 |
+| 1.19.x | Feb 14, 2023 | Nov 3, 2023 | 1.23, 1.24, 1.25, 1.26 |
+| 1.18.x | Nov 10, 2022 | Jun 12, 2023 | 1.23, 1.24, 1.25, 1.26, 1.27 |
+| 1.17.x | Sep 6, 2022 | Mar 20, 2023 | 1.22, 1.23, 1.24 |
+| 1.16.x | Jul 7, 2022 | Dec 21, 2022 | 1.22, 1.23, 1.24 |
+| 1.15.x | Apr 21, 2022 | Oct 6, 2022 | 1.21, 1.22, 1.23 |
+<!-- END OLD_RELEASES_TABLE -->
 
 ## What we mean by support
 

--- a/hack/generate-supported-releases.py
+++ b/hack/generate-supported-releases.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+# Copyright © contributors to CloudNativePG, established as
+# CloudNativePG a Series of LF Projects, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Regenerate the release tables in docs/src/supported_releases.md from docs/releases.json.
+
+Run from the repo root:
+    python3 hack/generate-supported-releases.py
+"""
+
+import json
+import re
+import sys
+from datetime import date
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+DATA_FILE = REPO_ROOT / "docs" / "releases.json"
+OUTPUT_FILE = REPO_ROOT / "docs" / "src" / "supported_releases.md"
+
+MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun",
+          "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]
+
+
+def parse_date(s):
+    return date.fromisoformat(s) if s else None
+
+
+def fmt_date(d, approximate=False):
+    if d is None:
+        return ""
+    if approximate:
+        return f"~ {MONTHS[d.month - 1]} {d.year}"
+    return f"{MONTHS[d.month - 1]} {d.day}, {d.year}"
+
+
+def minor_key(r):
+    """Sort key: parse '1.29' → (1, 29); 'main' sorts lowest."""
+    m = r["minor"]
+    if m == "main":
+        return (0, 0)
+    major, minor = m.split(".")
+    return (int(major), int(minor))
+
+
+def status(r, today):
+    if r.get("development"):
+        return "development"
+    rd = parse_date(r.get("release_date"))
+    eol = parse_date(r.get("end_of_life"))
+    if rd is None or rd > today:
+        return "upcoming"
+    if eol is None or eol > today:
+        return "active"
+    return "eol"
+
+
+def fmt_k8s(versions):
+    return ", ".join(versions) if versions else ""
+
+
+def fmt_pg(r):
+    pg = r.get("postgres")
+    if not pg:
+        return ""
+    return f"{pg['min']} - {pg['max']}"
+
+
+def active_table(releases, today):
+    rows = sorted(
+        [r for r in releases if status(r, today) in ("active", "development")],
+        key=minor_key,
+        reverse=True,
+    )
+    # development (main) always last
+    rows.sort(key=lambda r: 1 if r.get("development") else 0)
+
+    lines = [
+        "| Version | Currently supported | Release date | End of life | Supported Kubernetes versions | Tested, but not supported | Supported Postgres versions |",
+        "|---------|---------------------|--------------|-------------|-------------------------------|---------------------------|-----------------------------|",
+    ]
+    for r in rows:
+        if r.get("development"):
+            lines.append(
+                f"| {r['minor']} | No, development only |  |  |  |  | {fmt_pg(r)} |"
+            )
+            continue
+        k8s = r.get("kubernetes", {})
+        lines.append(
+            f"| {r['minor']}.x"
+            f" | Yes"
+            f" | {fmt_date(parse_date(r.get('release_date')), r.get('release_date_approximate', False))}"
+            f" | {fmt_date(parse_date(r.get('end_of_life')), r.get('end_of_life_approximate', False))}"
+            f" | {fmt_k8s(k8s.get('supported', []))}"
+            f" | {fmt_k8s(k8s.get('tested', []))}"
+            f" | {fmt_pg(r)}"
+            f" |"
+        )
+    return "\n".join(lines)
+
+
+def upcoming_table(releases, today):
+    rows = sorted(
+        [r for r in releases if status(r, today) == "upcoming"],
+        key=minor_key,
+    )
+    lines = [
+        "| Version | Release date | End of life |",
+        "|---------|--------------|-------------|",
+    ]
+    for r in rows:
+        lines.append(
+            f"| {r['minor']}.0"
+            f" | {fmt_date(parse_date(r.get('release_date')), r.get('release_date_approximate', True))}"
+            f" | {fmt_date(parse_date(r.get('end_of_life')), r.get('end_of_life_approximate', True))}"
+            f" |"
+        )
+    return "\n".join(lines)
+
+
+def old_table(releases, today):
+    rows = sorted(
+        [r for r in releases if status(r, today) == "eol"],
+        key=minor_key,
+        reverse=True,
+    )
+    lines = [
+        "| Version | Release date | End of life | Supported Kubernetes versions |",
+        "|---------|--------------|-------------|-------------------------------|",
+    ]
+    for r in rows:
+        k8s = r.get("kubernetes", {})
+        lines.append(
+            f"| {r['minor']}.x"
+            f" | {fmt_date(parse_date(r.get('release_date')), r.get('release_date_approximate', False))}"
+            f" | {fmt_date(parse_date(r.get('end_of_life')), r.get('end_of_life_approximate', False))}"
+            f" | {fmt_k8s(k8s.get('supported', []))}"
+            f" |"
+        )
+    return "\n".join(lines)
+
+
+def replace_section(content, marker, new_table):
+    begin = f"<!-- BEGIN {marker} -->"
+    end = f"<!-- END {marker} -->"
+    pattern = re.compile(
+        re.escape(begin) + r".*?" + re.escape(end),
+        re.DOTALL,
+    )
+    replacement = f"{begin}\n{new_table}\n{end}"
+    updated, count = pattern.subn(replacement, content)
+    if count == 0:
+        print(f"ERROR: marker {marker!r} not found in {OUTPUT_FILE}", file=sys.stderr)
+        sys.exit(1)
+    return updated
+
+
+def main():
+    today = date.today()
+
+    with open(DATA_FILE) as f:
+        data = json.load(f)
+
+    releases = data["releases"]
+
+    content = OUTPUT_FILE.read_text()
+    content = replace_section(content, "ACTIVE_RELEASES_TABLE", active_table(releases, today))
+    content = replace_section(content, "UPCOMING_RELEASES_TABLE", upcoming_table(releases, today))
+    content = replace_section(content, "OLD_RELEASES_TABLE", old_table(releases, today))
+    OUTPUT_FILE.write_text(content)
+
+    print(f"Updated {OUTPUT_FILE}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Introduce `docs/releases.json` as the single source of truth for release metadata (dates, EOL, Kubernetes and PostgreSQL version support) and add `hack/generate-supported-releases.py` to regenerate the three Markdown tables in `docs/src/supported_releases.md` from that file.

Add a `generate-release-table` Makefile target so contributors can regenerate the tables with a single command.

Assisted-by: Claude Sonnet 4.6