### PR TITLE
fix: schema-qualify catalog references in monitoring queries

### DIFF
--- a/config/manager/default-monitoring.yaml
+++ b/config/manager/default-monitoring.yaml
@@ -461,7 +461,7 @@ data:
     pg_extensions:
       query: |
         SELECT
-         current_database() as datname,
+         pg_catalog.current_database() as datname,
          name as extname,
          default_version,
          installed_version,

--- a/config/manager/default-monitoring.yaml
+++ b/config/manager/default-monitoring.yaml
@@ -27,8 +27,8 @@ data:
                    , state
                    , usename
                    , COALESCE(application_name, '') AS application_name
-                   , COUNT(*)
-                   , COALESCE(EXTRACT (EPOCH FROM (max(now() - xact_start))), 0) AS max_tx_secs
+                   , pg_catalog.count(*)
+                   , COALESCE(EXTRACT (EPOCH FROM (pg_catalog.max(pg_catalog.now() - xact_start))), 0) AS max_tx_secs
                FROM pg_catalog.pg_stat_activity
                GROUP BY datname, state, usename, application_name
            ) sa ON states.state = sa.state
@@ -55,7 +55,7 @@ data:
 
     backends_waiting:
       query: |
-       SELECT count(*) AS total
+       SELECT pg_catalog.count(*) AS total
        FROM pg_catalog.pg_locks blocked_locks
        JOIN pg_catalog.pg_locks blocking_locks
          ON blocking_locks.locktype = blocked_locks.locktype
@@ -113,11 +113,11 @@ data:
                 OR pg_catalog.pg_last_wal_receive_lsn() = pg_catalog.pg_last_wal_replay_lsn())
               THEN 0
               ELSE GREATEST (0,
-                EXTRACT(EPOCH FROM (now() - pg_catalog.pg_last_xact_replay_timestamp())))
+                EXTRACT(EPOCH FROM (pg_catalog.now() - pg_catalog.pg_last_xact_replay_timestamp())))
               END AS lag,
               pg_catalog.pg_is_in_recovery() AS in_recovery,
               EXISTS (TABLE pg_stat_wal_receiver) AS is_wal_receiver_up,
-              (SELECT count(*) FROM pg_catalog.pg_stat_replication) AS streaming_replicas"
+              (SELECT pg_catalog.count(*) FROM pg_catalog.pg_stat_replication) AS streaming_replicas"
       metrics:
         - lag:
             usage: "GAUGE"
@@ -165,8 +165,8 @@ data:
       query: |
         SELECT archived_count
           , failed_count
-          , COALESCE(EXTRACT(EPOCH FROM (now() - last_archived_time)), -1) AS seconds_since_last_archival
-          , COALESCE(EXTRACT(EPOCH FROM (now() - last_failed_time)), -1) AS seconds_since_last_failure
+          , COALESCE(EXTRACT(EPOCH FROM (pg_catalog.now() - last_archived_time)), -1) AS seconds_since_last_archival
+          , COALESCE(EXTRACT(EPOCH FROM (pg_catalog.now() - last_failed_time)), -1) AS seconds_since_last_failure
           , COALESCE(EXTRACT(EPOCH FROM last_archived_time), -1) AS last_archived_time
           , COALESCE(EXTRACT(EPOCH FROM last_failed_time), -1) AS last_failed_time
           , COALESCE(CAST(CAST('x'||pg_catalog.right(pg_catalog.split_part(last_archived_wal, '.', 1), 16) AS pg_catalog.bit(64)) AS pg_catalog.int8), -1) AS last_archived_wal_start_lsn

--- a/config/manager/default-monitoring.yaml
+++ b/config/manager/default-monitoring.yaml
@@ -28,10 +28,10 @@ data:
                    , usename
                    , COALESCE(application_name, '') AS application_name
                    , pg_catalog.count(*)
-                   , COALESCE(EXTRACT (EPOCH FROM (pg_catalog.max(pg_catalog.now() - xact_start))), 0) AS max_tx_secs
+                   , COALESCE(EXTRACT (EPOCH FROM (pg_catalog.max(pg_catalog.now() OPERATOR(pg_catalog.-) xact_start))), 0) AS max_tx_secs
                FROM pg_catalog.pg_stat_activity
                GROUP BY datname, state, usename, application_name
-           ) sa ON states.state = sa.state
+           ) sa ON states.state OPERATOR(pg_catalog.=) sa.state
            WHERE sa.usename IS NOT NULL
       metrics:
         - datname:
@@ -58,7 +58,7 @@ data:
        SELECT pg_catalog.count(*) AS total
        FROM pg_catalog.pg_locks blocked_locks
        JOIN pg_catalog.pg_locks blocking_locks
-         ON blocking_locks.locktype = blocked_locks.locktype
+         ON blocking_locks.locktype OPERATOR(pg_catalog.=) blocked_locks.locktype
          AND blocking_locks.database IS NOT DISTINCT FROM blocked_locks.database
          AND blocking_locks.relation IS NOT DISTINCT FROM blocked_locks.relation
          AND blocking_locks.page IS NOT DISTINCT FROM blocked_locks.page
@@ -68,8 +68,8 @@ data:
          AND blocking_locks.classid IS NOT DISTINCT FROM blocked_locks.classid
          AND blocking_locks.objid IS NOT DISTINCT FROM blocked_locks.objid
          AND blocking_locks.objsubid IS NOT DISTINCT FROM blocked_locks.objsubid
-         AND blocking_locks.pid != blocked_locks.pid
-       JOIN pg_catalog.pg_stat_activity blocking_activity ON blocking_activity.pid = blocking_locks.pid
+         AND blocking_locks.pid OPERATOR(pg_catalog.<>) blocked_locks.pid
+       JOIN pg_catalog.pg_stat_activity blocking_activity ON blocking_activity.pid OPERATOR(pg_catalog.=) blocking_locks.pid
        WHERE NOT blocked_locks.granted
       metrics:
         - total:
@@ -110,10 +110,10 @@ data:
     pg_replication:
       query: "SELECT CASE WHEN (
                 NOT pg_catalog.pg_is_in_recovery()
-                OR pg_catalog.pg_last_wal_receive_lsn() = pg_catalog.pg_last_wal_replay_lsn())
+                OR pg_catalog.pg_last_wal_receive_lsn() OPERATOR(pg_catalog.=) pg_catalog.pg_last_wal_replay_lsn())
               THEN 0
               ELSE GREATEST (0,
-                EXTRACT(EPOCH FROM (pg_catalog.now() - pg_catalog.pg_last_xact_replay_timestamp())))
+                EXTRACT(EPOCH FROM (pg_catalog.now() OPERATOR(pg_catalog.-) pg_catalog.pg_last_xact_replay_timestamp())))
               END AS lag,
               pg_catalog.pg_is_in_recovery() AS in_recovery,
               EXISTS (TABLE pg_stat_wal_receiver) AS is_wal_receiver_up,
@@ -165,17 +165,17 @@ data:
       query: |
         SELECT archived_count
           , failed_count
-          , COALESCE(EXTRACT(EPOCH FROM (pg_catalog.now() - last_archived_time)), -1) AS seconds_since_last_archival
-          , COALESCE(EXTRACT(EPOCH FROM (pg_catalog.now() - last_failed_time)), -1) AS seconds_since_last_failure
+          , COALESCE(EXTRACT(EPOCH FROM (pg_catalog.now() OPERATOR(pg_catalog.-) last_archived_time)), -1) AS seconds_since_last_archival
+          , COALESCE(EXTRACT(EPOCH FROM (pg_catalog.now() OPERATOR(pg_catalog.-) last_failed_time)), -1) AS seconds_since_last_failure
           , COALESCE(EXTRACT(EPOCH FROM last_archived_time), -1) AS last_archived_time
           , COALESCE(EXTRACT(EPOCH FROM last_failed_time), -1) AS last_failed_time
-          , COALESCE(CAST(CAST('x'||pg_catalog.right(pg_catalog.split_part(last_archived_wal, '.', 1), 16) AS pg_catalog.bit(64)) AS pg_catalog.int8), -1) AS last_archived_wal_start_lsn
-          , COALESCE(CAST(CAST('x'||pg_catalog.right(pg_catalog.split_part(last_failed_wal, '.', 1), 16) AS pg_catalog.bit(64)) AS pg_catalog.int8), -1) AS last_failed_wal_start_lsn
+          , COALESCE(CAST(CAST('x' OPERATOR(pg_catalog.||) pg_catalog.right(pg_catalog.split_part(last_archived_wal, '.', 1), 16) AS pg_catalog.bit(64)) AS pg_catalog.int8), -1) AS last_archived_wal_start_lsn
+          , COALESCE(CAST(CAST('x' OPERATOR(pg_catalog.||) pg_catalog.right(pg_catalog.split_part(last_failed_wal, '.', 1), 16) AS pg_catalog.bit(64)) AS pg_catalog.int8), -1) AS last_failed_wal_start_lsn
           , EXTRACT(EPOCH FROM stats_reset) AS stats_reset_time
         FROM pg_catalog.pg_stat_archiver
       predicate_query: |
         SELECT NOT pg_catalog.pg_is_in_recovery()
-          OR pg_catalog.current_setting('archive_mode') = 'always'
+          OR pg_catalog.current_setting('archive_mode') OPERATOR(pg_catalog.=) 'always'
       metrics:
         - archived_count:
             usage: "COUNTER"
@@ -466,7 +466,7 @@ data:
          default_version,
          installed_version,
          CASE
-           WHEN default_version = installed_version THEN 0
+           WHEN default_version OPERATOR(pg_catalog.=) installed_version THEN 0
            ELSE 1
         END AS update_available
         FROM pg_catalog.pg_available_extensions

--- a/config/manager/default-monitoring.yaml
+++ b/config/manager/default-monitoring.yaml
@@ -116,7 +116,7 @@ data:
                 EXTRACT(EPOCH FROM (pg_catalog.now() OPERATOR(pg_catalog.-) pg_catalog.pg_last_xact_replay_timestamp())))
               END AS lag,
               pg_catalog.pg_is_in_recovery() AS in_recovery,
-              EXISTS (TABLE pg_stat_wal_receiver) AS is_wal_receiver_up,
+              EXISTS (TABLE pg_catalog.pg_stat_wal_receiver) AS is_wal_receiver_up,
               (SELECT pg_catalog.count(*) FROM pg_catalog.pg_stat_replication) AS streaming_replicas"
       metrics:
         - lag:

--- a/docs/src/monitoring.md
+++ b/docs/src/monitoring.md
@@ -510,14 +510,14 @@ metadata:
 data:
   custom-queries: |
     pg_replication:
-      query: "SELECT CASE WHEN NOT pg_is_in_recovery()
+      query: "SELECT CASE WHEN NOT pg_catalog.pg_is_in_recovery()
               THEN 0
               ELSE GREATEST (0,
-                EXTRACT(EPOCH FROM (now() - pg_last_xact_replay_timestamp())))
+                EXTRACT(EPOCH FROM (pg_catalog.now() OPERATOR(pg_catalog.-) pg_catalog.pg_last_xact_replay_timestamp())))
               END AS lag,
-              pg_is_in_recovery() AS in_recovery,
-              EXISTS (TABLE pg_stat_wal_receiver) AS is_wal_receiver_up,
-              (SELECT count(*) FROM pg_stat_replication) AS streaming_replicas"
+              pg_catalog.pg_is_in_recovery() AS in_recovery,
+              EXISTS (TABLE pg_catalog.pg_stat_wal_receiver) AS is_wal_receiver_up,
+              (SELECT pg_catalog.count(*) FROM pg_catalog.pg_stat_replication) AS streaming_replicas"
 
       metrics:
         - lag:
@@ -553,7 +553,7 @@ some_query: |
     FROM some_table
   query: |
     SELECT
-     count(*) as rows
+     pg_catalog.count(*) as rows
     FROM some_table
   metrics:
     - rows:
@@ -586,8 +586,8 @@ as in the following example:
 some_query: |
   query: |
     SELECT
-     current_database() as datname,
-     count(*) as rows
+     pg_catalog.current_database() as datname,
+     pg_catalog.count(*) as rows
     FROM some_table
   metrics:
     - datname:
@@ -618,8 +618,8 @@ aforementioned query):
 some_query: |
   query: |
     SELECT
-     current_database() as datname,
-     count(*) as rows
+     pg_catalog.current_database() as datname,
+     pg_catalog.count(*) as rows
     FROM some_table
   metrics:
     - datname:

--- a/docs/src/samples/cluster-example-monitoring.yaml
+++ b/docs/src/samples/cluster-example-monitoring.yaml
@@ -192,7 +192,7 @@ data:
                 END
               )::bigint AS bucket
             FROM
-              pg_stat_activity,
+              pg_catalog.pg_stat_activity,
               UNNEST(ARRAY[1, 2, 5, 15, 30, 60, 90, 120, 300]) AS le
             GROUP BY application_name, le
             ORDER BY application_name, le

--- a/docs/src/samples/cluster-example-monitoring.yaml
+++ b/docs/src/samples/cluster-example-monitoring.yaml
@@ -40,7 +40,7 @@ data:
       - "*"
       query: |
        SELECT
-         current_database() datname,
+         pg_catalog.current_database() datname,
          schemaname,
          relname,
          seq_scan,
@@ -63,7 +63,7 @@ data:
          analyze_count,
          autoanalyze_count
        FROM
-         pg_stat_user_tables
+         pg_catalog.pg_stat_user_tables
       metrics:
         - datname:
             usage: "LABEL"
@@ -133,7 +133,7 @@ data:
             description: "Number of times this table has been analyzed by the autovacuum daemon"
 
     pg_statio_user_tables:
-      query: "SELECT current_database() datname, schemaname, relname, heap_blks_read, heap_blks_hit, idx_blks_read, idx_blks_hit, toast_blks_read, toast_blks_hit, tidx_blks_read, tidx_blks_hit FROM pg_statio_user_tables"
+      query: "SELECT pg_catalog.current_database() datname, schemaname, relname, heap_blks_read, heap_blks_hit, idx_blks_read, idx_blks_hit, toast_blks_read, toast_blks_hit, tidx_blks_read, tidx_blks_hit FROM pg_catalog.pg_statio_user_tables"
       metrics:
         - datname:
             usage: "LABEL"
@@ -177,7 +177,7 @@ data:
               application_name,
               SUM(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - state_change))::bigint)::float AS process_idle_seconds_sum,
               COUNT(*) AS process_idle_seconds_count
-            FROM pg_stat_activity
+            FROM pg_catalog.pg_stat_activity
             WHERE state = 'idle'
             GROUP BY application_name
           ),
@@ -222,7 +222,7 @@ metadata:
 stringData:
   pg-database: |
     pg_database:
-      query: "SELECT pg_database.datname, pg_database_size(pg_database.datname) as size_bytes FROM pg_database"
+      query: "SELECT pg_database.datname, pg_catalog.pg_database_size(pg_database.datname) as size_bytes FROM pg_catalog.pg_database"
       primary: true
       cache_seconds: 30
       metrics:

--- a/tests/e2e/fixtures/metrics/custom-queries-with-target-databases.yaml
+++ b/tests/e2e/fixtures/metrics/custom-queries-with-target-databases.yaml
@@ -9,7 +9,7 @@ data:
     some_query:
       query: |
         SELECT
-         current_database() as datname,
+         pg_catalog.current_database() as datname,
          count(*) as rows
         FROM test_table
       metrics:
@@ -35,7 +35,7 @@ stringData:
     some_query_test:
       query: |
         SELECT
-         current_database() as datname,
+         pg_catalog.current_database() as datname,
          count(*) as rows
       metrics:
         - datname:

--- a/tests/e2e/fixtures/metrics/custom-queries.yaml
+++ b/tests/e2e/fixtures/metrics/custom-queries.yaml
@@ -7,7 +7,7 @@ metadata:
 data:
   queries.yaml: |
     pg_postmaster: # wokeignore:rule=master
-      query: "SELECT EXTRACT(EPOCH FROM (now() - pg_postmaster_start_time())) AS start_time_seconds" # wokeignore:rule=master
+      query: "SELECT EXTRACT(EPOCH FROM (pg_catalog.now() - pg_catalog.pg_postmaster_start_time())) AS start_time_seconds" # wokeignore:rule=master
       primary: false
       metrics:
         - start_time_seconds:
@@ -15,7 +15,7 @@ data:
             description: "Seconds since the postgres server start"
   additional-queries: |
     pg_wal_files:
-      query: "SELECT COALESCE(sum(1), 0) AS total FROM pg_ls_waldir() AS d (file) WHERE file ~ '^[0-9A-F]{8}[0-9A-F]{8}[0-9A-F]{8}$'"
+      query: "SELECT COALESCE(pg_catalog.sum(1), 0) AS total FROM pg_catalog.pg_ls_waldir() AS d (file) WHERE file ~ '^[0-9A-F]{8}[0-9A-F]{8}[0-9A-F]{8}$'"
       primary: false
       metrics:
         - total:
@@ -47,7 +47,7 @@ metadata:
 data:
   queries.yaml: |
     pg_database:
-      query: "SELECT pg_database.datname, pg_database_size(pg_database.datname) as size_bytes FROM pg_database"
+      query: "SELECT pg_database.datname, pg_catalog.pg_database_size(pg_database.datname) as size_bytes FROM pg_catalog.pg_database"
       primary: false
       metrics:
         - datname:
@@ -59,7 +59,7 @@ data:
 
   additional-queries: |
     e2e_tests_replication_slots_status:
-      query: "SELECT count(*) AS inactive FROM pg_replication_slots WHERE NOT active"
+      query: "SELECT pg_catalog.count(*) AS inactive FROM pg_catalog.pg_replication_slots WHERE NOT active"
       primary: false
       metrics:
         - inactive:
@@ -75,7 +75,7 @@ metadata:
 stringData:
   queries.yaml: |
     pg_stat_archiver:
-      query: "SELECT archived_count, failed_count FROM pg_stat_archiver"
+      query: "SELECT archived_count, failed_count FROM pg_catalog.pg_stat_archiver"
       primary: false
       metrics:
         - archived_count:
@@ -88,7 +88,7 @@ stringData:
   additional-queries: |
     pg_locks:
       query: |
-        SELECT count(*) as blocked_queries
+        SELECT pg_catalog.count(*) as blocked_queries
         FROM pg_catalog.pg_locks blocked_locks
         JOIN pg_catalog.pg_locks blocking_locks
           ON blocking_locks.locktype = blocked_locks.locktype


### PR DESCRIPTION
Unqualified references to `pg_catalog` functions and views are resolved via `search_path`, which can be manipulated by a database user to shadow built-in objects. Use explicit `pg_catalog`. qualification throughout the shipped default-monitoring config and documentation samples.

Closes #10575

Assisted-by: Claude Sonnet 4.6