### PR TITLE
feat(security): authenticate operator calls to the instance manager

### DIFF
--- a/.wordlist-en-custom.txt
+++ b/.wordlist-en-custom.txt
@@ -334,6 +334,7 @@ OpenSSL
 OpenShift
 Openshift
 OperatorCapabilities
+OperatorCertificateFingerprint
 OperatorHub
 OptionSpec
 OwnNamespace

--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -1081,6 +1081,12 @@ type ClusterStatus struct {
 	// +optional
 	OperatorHash string `json:"cloudNativePGOperatorHash,omitempty"`
 
+	// OperatorCertificateFingerprint is the SHA256 fingerprint of the operator's
+	// in-memory client certificate public key. The instance manager uses this to
+	// authenticate requests from the operator via mTLS.
+	// +optional
+	OperatorCertificateFingerprint string `json:"operatorCertificateFingerprint,omitempty"`
+
 	// AvailableArchitectures reports the available architectures of a cluster
 	// +optional
 	AvailableArchitectures []AvailableArchitecture `json:"availableArchitectures,omitempty"`

--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -1082,8 +1082,8 @@ type ClusterStatus struct {
 	OperatorHash string `json:"cloudNativePGOperatorHash,omitempty"`
 
 	// OperatorCertificateFingerprint is the SHA256 fingerprint of the operator's
-	// in-memory client certificate public key. The instance manager uses this to
-	// authenticate requests from the operator via mTLS.
+	// in-memory client certificate public key. The instance manager pins this
+	// fingerprint to authenticate requests from the operator.
 	// +optional
 	OperatorCertificateFingerprint string `json:"operatorCertificateFingerprint,omitempty"`
 

--- a/config/crd/bases/postgresql.cnpg.io_clusters.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_clusters.yaml
@@ -7177,6 +7177,12 @@ spec:
                 description: OnlineUpdateEnabled shows if the online upgrade is enabled
                   inside the cluster
                 type: boolean
+              operatorCertificateFingerprint:
+                description: |-
+                  OperatorCertificateFingerprint is the SHA256 fingerprint of the operator's
+                  in-memory client certificate public key. The instance manager uses this to
+                  authenticate requests from the operator via mTLS.
+                type: string
               pgDataImageInfo:
                 description: PGDataImageInfo contains the details of the latest image
                   that has run on the current data directory.

--- a/config/crd/bases/postgresql.cnpg.io_clusters.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_clusters.yaml
@@ -7180,8 +7180,8 @@ spec:
               operatorCertificateFingerprint:
                 description: |-
                   OperatorCertificateFingerprint is the SHA256 fingerprint of the operator's
-                  in-memory client certificate public key. The instance manager uses this to
-                  authenticate requests from the operator via mTLS.
+                  in-memory client certificate public key. The instance manager pins this
+                  fingerprint to authenticate requests from the operator.
                 type: string
               pgDataImageInfo:
                 description: PGDataImageInfo contains the details of the latest image

--- a/docs/src/certificates.md
+++ b/docs/src/certificates.md
@@ -41,6 +41,14 @@ generated outside CNPG.
     communication within the cluster.
 :::
 
+:::note
+    Beyond the CA-managed certificates listed above, the operator also uses a
+    self-signed client certificate, generated in memory, to authenticate to the
+    instance manager's status port. This certificate is not signed by the client
+    CA: the instance manager trusts it by pinning its public-key fingerprint. See
+    [Operator-to-instance authentication](security.md#operator-to-instance-authentication).
+:::
+
 ## Operator-Managed Mode
 
 By default, the operator automatically generates a single Certificate Authority

--- a/docs/src/cloudnative-pg.v1.md
+++ b/docs/src/cloudnative-pg.v1.md
@@ -732,6 +732,7 @@ _Appears in:_
 | `targetPrimaryTimestamp` _string_ | The timestamp when the last request for a new primary has occurred |  |  |  |
 | `poolerIntegrations` _[PoolerIntegrations](#poolerintegrations)_ | The integration needed by poolers referencing the cluster |  |  |  |
 | `cloudNativePGOperatorHash` _string_ | The hash of the binary of the operator |  |  |  |
+| `operatorCertificateFingerprint` _string_ | OperatorCertificateFingerprint is the SHA256 fingerprint of the operator's<br />in-memory client certificate public key. The instance manager uses this to<br />authenticate requests from the operator via mTLS. |  |  |  |
 | `availableArchitectures` _[AvailableArchitecture](#availablearchitecture) array_ | AvailableArchitectures reports the available architectures of a cluster |  |  |  |
 | `conditions` _[Condition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#condition-v1-meta) array_ | Conditions for cluster object |  |  |  |
 | `instanceNames` _string array_ | List of instance names in the cluster |  |  |  |

--- a/docs/src/cloudnative-pg.v1.md
+++ b/docs/src/cloudnative-pg.v1.md
@@ -732,7 +732,7 @@ _Appears in:_
 | `targetPrimaryTimestamp` _string_ | The timestamp when the last request for a new primary has occurred |  |  |  |
 | `poolerIntegrations` _[PoolerIntegrations](#poolerintegrations)_ | The integration needed by poolers referencing the cluster |  |  |  |
 | `cloudNativePGOperatorHash` _string_ | The hash of the binary of the operator |  |  |  |
-| `operatorCertificateFingerprint` _string_ | OperatorCertificateFingerprint is the SHA256 fingerprint of the operator's<br />in-memory client certificate public key. The instance manager uses this to<br />authenticate requests from the operator via mTLS. |  |  |  |
+| `operatorCertificateFingerprint` _string_ | OperatorCertificateFingerprint is the SHA256 fingerprint of the operator's<br />in-memory client certificate public key. The instance manager pins this<br />fingerprint to authenticate requests from the operator. |  |  |  |
 | `availableArchitectures` _[AvailableArchitecture](#availablearchitecture) array_ | AvailableArchitectures reports the available architectures of a cluster |  |  |  |
 | `conditions` _[Condition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#condition-v1-meta) array_ | Conditions for cluster object |  |  |  |
 | `instanceNames` _string array_ | List of instance names in the cluster |  |  |  |

--- a/docs/src/installation_upgrade.md
+++ b/docs/src/installation_upgrade.md
@@ -276,10 +276,16 @@ only the operator itself.
     (e.g., 1.29.2).
 :::
 
-Versions 1.30.0 and 1.29.2 introduce four changes worth reviewing before you
+Versions 1.30.0 and 1.29.2 introduce five changes worth reviewing before you
 upgrade: operator-side password encoding, `search_path` hardening, the new
-`DatabaseRole` resource for declarative role management, and safe primary
-election via a per-cluster Lease. Each is covered in its own subsection below.
+`DatabaseRole` resource for declarative role management, safe primary
+election via a per-cluster Lease, and operator-to-instance authentication on
+the instance manager's status port. Each is covered in its own subsection below.
+
+Not all of these affect both releases: operator-side password encoding and
+`search_path` hardening ship in both 1.30.0 and 1.29.2, while the `DatabaseRole`
+resource, safe primary election, and operator-to-instance authentication are
+introduced in 1.30.0 only. Each subsection states the versions it applies to.
 
 #### Operator-side password encoding
 
@@ -383,6 +389,27 @@ chart grant the required permissions automatically. If you manage the
 operator's RBAC yourself, you must add the `create`, `get`, `list`, `update`
 and `watch` verbs on `leases` in the `coordination.k8s.io` API group before
 upgrading, otherwise primaries will be unable to promote.
+:::
+
+#### Operator-to-instance authentication
+
+Starting from version 1.30.0, the operator authenticates its calls to the
+sensitive endpoints of the instance manager's status port (backup,
+`pg_controldata`, partial WAL archive, and instance-manager upgrade) by pinning
+an in-memory client certificate. This is enabled automatically and requires no
+configuration. Status, health, and probe endpoints remain unauthenticated. See
+[Operator-to-instance authentication](security.md#operator-to-instance-authentication)
+for details.
+
+:::warning
+This protection has a hard requirement: the status port **must** be served over
+TLS, which has been the default since v1.24. Instances created by an operator
+older than v1.24 serve the status port over plain HTTP; once their instance
+manager is upgraded to 1.30.0 the operator can no longer authenticate to them
+and every call to the protected endpoints is **permanently** rejected with
+`401 Unauthorized`. If you still run such instances, perform a rolling update so
+their Pods are recreated with a TLS-enabled status port. Instances created by
+v1.24 or later are unaffected.
 :::
 
 -->

--- a/docs/src/security.md
+++ b/docs/src/security.md
@@ -807,8 +807,24 @@ unauthenticated.
 
 The certificate is never written to disk and is regenerated on every operator
 restart, so trust derives from fingerprint pinning rather than CA validation.
-This protection requires the status port to be served over TLS, which has been
-the default since v1.24.
+
+This protection has a hard requirement: the status port **must** be served over
+TLS, which has been the default since v1.24. A client certificate can only be
+presented over a TLS connection, so the protected endpoints are reachable by the
+operator only when the status port uses TLS.
+
+:::warning
+If the status port is not served over TLS, the instance manager cannot
+authenticate the operator and **permanently** rejects every call to its
+protected endpoints (backup, `pg_controldata`, partial WAL archive, and
+instance-manager upgrade) with `401 Unauthorized`. This is not a transient
+condition and will not resolve on its own. It can affect instances created by an
+operator older than v1.24 (whose status port serves plain HTTP) once their
+instance manager is upgraded to a version that enforces this authentication: such
+instances must be rolled out so their Pods are recreated with a TLS-enabled status
+port. Newly created instances always enable TLS on the status port and are
+unaffected.
+:::
 
 ### PostgreSQL
 

--- a/docs/src/security.md
+++ b/docs/src/security.md
@@ -786,8 +786,29 @@ levels, as listed in the table below:
 | operator         | 9443        | webhook server      | `webhook-server` | Yes      | Yes            |
 | operator         | 8080        | metrics             | `metrics`        | No       | No             |
 | instance manager | 9187        | metrics             | `metrics`        | Optional | No             |
-| instance manager | 8000        | status              | `status`         | Yes      | No             |
+| instance manager | 8000        | status              | `status`         | Yes      | Partial (1)    |
 | operand          | 5432        | PostgreSQL instance | `postgresql`     | Optional | Yes            |
+
+(1) Status, health, and probe endpoints are unauthenticated. Sensitive
+endpoints (backup, `pg_controldata`, partial WAL archive, and instance-manager
+upgrade) require the operator's client certificate, as described in
+[Operator-to-instance authentication](#operator-to-instance-authentication)
+below.
+
+#### Operator-to-instance authentication
+
+The operator generates a self-signed ECDSA client certificate in memory at
+startup and publishes its SHA-256 public-key fingerprint in the cluster's
+`.status.operatorCertificateFingerprint`. The instance manager pins that
+fingerprint and rejects any call to its sensitive endpoints (backup,
+`pg_controldata`, partial WAL archive, and instance-manager upgrade) that does
+not present a matching certificate. Status, health, and probe endpoints remain
+unauthenticated.
+
+The certificate is never written to disk and is regenerated on every operator
+restart, so trust derives from fingerprint pinning rather than CA validation.
+This protection requires the status port to be served over TLS, which has been
+the default since v1.24.
 
 ### PostgreSQL
 

--- a/internal/cmd/manager/controller/controller.go
+++ b/internal/cmd/manager/controller/controller.go
@@ -33,6 +33,7 @@ import (
 	discoveryv1 "k8s.io/api/discovery/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/discovery"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -257,7 +258,44 @@ func RunController(
 	}
 	defer pluginRepository.Close()
 
-	if err = controller.NewClusterReconciler(
+	if err = setupReconcilers(
+		ctx,
+		mgr,
+		discoveryClient,
+		pluginRepository,
+		operatorClientCert,
+		conf,
+		maxConcurrentReconciles,
+	); err != nil {
+		return err
+	}
+
+	if err = setupWebhooks(mgr); err != nil {
+		return err
+	}
+
+	// +kubebuilder:scaffold:builder
+
+	setupLog.Info("starting manager")
+	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
+		setupLog.Error(err, "problem running manager")
+		return err
+	}
+
+	return nil
+}
+
+// setupReconcilers registers every operator reconciler with the manager.
+func setupReconcilers(
+	ctx context.Context,
+	mgr ctrl.Manager,
+	discoveryClient discovery.DiscoveryInterface,
+	pluginRepository repository.Interface,
+	operatorClientCert *tls.Certificate,
+	conf *configuration.Data,
+	maxConcurrentReconciles int,
+) error {
+	if err := controller.NewClusterReconciler(
 		mgr,
 		discoveryClient,
 		pluginRepository,
@@ -268,7 +306,7 @@ func RunController(
 		return err
 	}
 
-	if err = controller.NewBackupReconciler(
+	if err := controller.NewBackupReconciler(
 		mgr,
 		discoveryClient,
 		pluginRepository,
@@ -278,13 +316,13 @@ func RunController(
 		return err
 	}
 
-	if err = controller.NewPluginReconciler(mgr, conf.OperatorNamespace, pluginRepository).
+	if err := controller.NewPluginReconciler(mgr, conf.OperatorNamespace, pluginRepository).
 		SetupWithManager(mgr, maxConcurrentReconciles); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Plugin")
 		return err
 	}
 
-	if err = (&controller.ScheduledBackupReconciler{
+	if err := (&controller.ScheduledBackupReconciler{
 		Client:   mgr.GetClient(),
 		Scheme:   mgr.GetScheme(),
 		Recorder: mgr.GetEventRecorderFor("cloudnative-pg-scheduledbackup"), //nolint:staticcheck
@@ -293,7 +331,7 @@ func RunController(
 		return err
 	}
 
-	if err = (&controller.PoolerReconciler{
+	if err := (&controller.PoolerReconciler{
 		Client:          mgr.GetClient(),
 		DiscoveryClient: discoveryClient,
 		Scheme:          mgr.GetScheme(),
@@ -303,7 +341,7 @@ func RunController(
 		return err
 	}
 
-	if err = (&controller.DatabaseRoleReconciler{
+	if err := (&controller.DatabaseRoleReconciler{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr, maxConcurrentReconciles); err != nil {
@@ -311,27 +349,32 @@ func RunController(
 		return err
 	}
 
-	if err = webhookv1.SetupClusterWebhookWithManager(mgr); err != nil {
+	return nil
+}
+
+// setupWebhooks registers every admission webhook with the manager.
+func setupWebhooks(mgr ctrl.Manager) error {
+	if err := webhookv1.SetupClusterWebhookWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create webhook", "webhook", "Cluster", "version", "v1")
 		return err
 	}
 
-	if err = webhookv1.SetupBackupWebhookWithManager(mgr); err != nil {
+	if err := webhookv1.SetupBackupWebhookWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create webhook", "webhook", "Backup", "version", "v1")
 		return err
 	}
 
-	if err = webhookv1.SetupScheduledBackupWebhookWithManager(mgr); err != nil {
+	if err := webhookv1.SetupScheduledBackupWebhookWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create webhook", "webhook", "ScheduledBackup", "version", "v1")
 		return err
 	}
 
-	if err = webhookv1.SetupPoolerWebhookWithManager(mgr); err != nil {
+	if err := webhookv1.SetupPoolerWebhookWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create webhook", "webhook", "Pooler", "version", "v1")
 		return err
 	}
 
-	if err = webhookv1.SetupDatabaseWebhookWithManager(mgr); err != nil {
+	if err := webhookv1.SetupDatabaseWebhookWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create webhook", "webhook", "Database", "version", "v1")
 		return err
 	}
@@ -347,15 +390,7 @@ func RunController(
 	//
 	// 2. the webhook service and/or the CNI are being updated, e.g. when a POD is
 	//    deleted. In that case we could get a "Connection refused" error message.
-	webhookServer.WebhookMux().HandleFunc("/readyz", readinessProbeHandler)
-
-	// +kubebuilder:scaffold:builder
-
-	setupLog.Info("starting manager")
-	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
-		setupLog.Error(err, "problem running manager")
-		return err
-	}
+	mgr.GetWebhookServer().WebhookMux().HandleFunc("/readyz", readinessProbeHandler)
 
 	return nil
 }

--- a/internal/cmd/manager/controller/controller.go
+++ b/internal/cmd/manager/controller/controller.go
@@ -22,8 +22,10 @@ package controller
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/cloudnative-pg/machinery/pkg/log"
@@ -71,6 +73,9 @@ const (
 	// CaSecretName is the name of the secret which is hosting the Operator CA
 	CaSecretName = "cnpg-ca-secret" // #nosec
 
+	// operatorClientCertCommonName is the fallback CN for the operator's in-memory
+	// client certificate when the Pod hostname cannot be determined.
+	operatorClientCertCommonName = "cloudnative-pg-operator"
 )
 
 // leaderElectionConfiguration contains the leader parameters that will be passed to controllerruntime.Options.
@@ -238,6 +243,12 @@ func RunController(
 		return err
 	}
 
+	operatorClientCert, err := generateOperatorClientCertificate()
+	if err != nil {
+		setupLog.Error(err, "unable to generate operator client certificate")
+		return err
+	}
+
 	pluginRepository := repository.New()
 	if _, err := pluginRepository.RegisterUnixSocketPluginsInPath(
 		conf.PluginSocketDir,
@@ -251,6 +262,7 @@ func RunController(
 		discoveryClient,
 		pluginRepository,
 		conf.DrainTaints,
+		operatorClientCert,
 	).SetupWithManager(ctx, mgr, maxConcurrentReconciles); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Cluster")
 		return err
@@ -260,6 +272,7 @@ func RunController(
 		mgr,
 		discoveryClient,
 		pluginRepository,
+		operatorClientCert,
 	).SetupWithManager(ctx, mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Backup")
 		return err
@@ -514,6 +527,27 @@ func readSecret(
 	}
 
 	return data, nil
+}
+
+func generateOperatorClientCertificate() (*tls.Certificate, error) {
+	commonName, err := os.Hostname()
+	if err != nil {
+		setupLog.Info(
+			"Unable to determine hostname for operator client certificate, falling back to default common name",
+			"fallback", operatorClientCertCommonName,
+			"error", err.Error(),
+		)
+		commonName = operatorClientCertCommonName
+	}
+	pair, err := certs.GenerateSelfSignedClientCertificate(commonName)
+	if err != nil {
+		return nil, err
+	}
+	cert, err := pair.TLSCertificate()
+	if err != nil {
+		return nil, err
+	}
+	return &cert, nil
 }
 
 func getPprofServerAddress(enabled bool) string {

--- a/internal/cmd/manager/instance/status/cmd.go
+++ b/internal/cmd/manager/instance/status/cmd.go
@@ -65,11 +65,12 @@ func statusSubCommand(ctx context.Context) error {
 		return err
 	}
 
-	ctx, err = certs.NewTLSConfigForContext(
-		ctx,
-		cli,
-		cluster.GetServerCASecretObjectKey(),
-	)
+	// No client certificate: this command runs inside the Pod and only reads
+	// the local instance status; it has no access to the operator's private key.
+	ctx, err = certs.NewTLSConfigForContext(ctx, certs.TLSConfigOptions{
+		Client:   cli,
+		CASecret: cluster.GetServerCASecretObjectKey(),
+	})
 	if err != nil {
 		contextLogger.Error(err, "Error while building the TLS context")
 		return err

--- a/internal/controller/backup_controller.go
+++ b/internal/controller/backup_controller.go
@@ -21,6 +21,7 @@ package controller
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"reflect"
@@ -77,9 +78,10 @@ type BackupReconciler struct {
 	client.Client
 	DiscoveryClient discovery.DiscoveryInterface
 
-	Scheme   *runtime.Scheme
-	Recorder record.EventRecorder
-	Plugins  repository.Interface
+	Scheme             *runtime.Scheme
+	Recorder           record.EventRecorder
+	Plugins            repository.Interface
+	OperatorClientCert *tls.Certificate
 
 	instanceStatusClient remote.InstanceClient
 	vsr                  *volumesnapshot.Reconciler
@@ -90,6 +92,7 @@ func NewBackupReconciler(
 	mgr manager.Manager,
 	discoveryClient *discovery.DiscoveryClient,
 	plugins repository.Interface,
+	operatorClientCert *tls.Certificate,
 ) *BackupReconciler {
 	cli := mgr.GetClient()
 	recorder := mgr.GetEventRecorderFor("cloudnative-pg-backup") //nolint:staticcheck
@@ -98,6 +101,7 @@ func NewBackupReconciler(
 		DiscoveryClient:      discoveryClient,
 		Scheme:               mgr.GetScheme(),
 		Recorder:             recorder,
+		OperatorClientCert:   operatorClientCert,
 		instanceStatusClient: remote.NewClient().Instance(),
 		Plugins:              plugins,
 		vsr:                  volumesnapshot.NewReconcilerBuilder(cli, recorder).Build(),
@@ -170,12 +174,13 @@ func (r *BackupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 
 	contextLogger.Debug("Found cluster for backup", "cluster", cluster.Name)
 
-	// Store in the context the TLS configuration required communicating with the Pods
-	ctx, err = certs.NewTLSConfigForContext(
-		ctx,
-		r.Client,
-		cluster.GetServerCASecretObjectKey(),
-	)
+	// Store in the context the TLS configuration required communicating with the Pods.
+	// The operator client certificate is presented to authenticate with the instance manager.
+	ctx, err = certs.NewTLSConfigForContext(ctx, certs.TLSConfigOptions{
+		Client:     r.Client,
+		CASecret:   cluster.GetServerCASecretObjectKey(),
+		ClientCert: r.OperatorClientCert,
+	})
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/internal/controller/backup_controller.go
+++ b/internal/controller/backup_controller.go
@@ -90,7 +90,7 @@ type BackupReconciler struct {
 // NewBackupReconciler properly initializes the BackupReconciler
 func NewBackupReconciler(
 	mgr manager.Manager,
-	discoveryClient *discovery.DiscoveryClient,
+	discoveryClient discovery.DiscoveryInterface,
 	plugins repository.Interface,
 	operatorClientCert *tls.Certificate,
 ) *BackupReconciler {

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -1252,6 +1252,12 @@ func (r *ClusterReconciler) handleRollingUpdate(
 	// Execute online update, if enabled and if not already executing
 	if cluster.Status.OnlineUpdateEnabled && cluster.Status.Phase != apiv1.PhaseOnlineUpgrading {
 		if err := r.upgradeInstanceManager(ctx, cluster, &instancesStatus); err != nil {
+			if remote.IsTransientAuthError(err) {
+				contextLogger.Info(
+					"Waiting for the operator certificate fingerprint to propagate " +
+						"before upgrading the instance manager")
+				return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+			}
 			return ctrl.Result{}, err
 		}
 		// Stop the reconciliation loop if upgradeInstanceManager initiated an upgrade

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -22,6 +22,7 @@ package controller
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"reflect"
@@ -92,11 +93,12 @@ var errOldPrimaryDetected = errors.New("old primary detected")
 type ClusterReconciler struct {
 	client.Client
 
-	DiscoveryClient discovery.DiscoveryInterface
-	Scheme          *runtime.Scheme
-	Recorder        record.EventRecorder
-	InstanceClient  remote.InstanceClient
-	Plugins         repository.Interface
+	DiscoveryClient    discovery.DiscoveryInterface
+	Scheme             *runtime.Scheme
+	Recorder           record.EventRecorder
+	InstanceClient     remote.InstanceClient
+	Plugins            repository.Interface
+	OperatorClientCert *tls.Certificate
 
 	drainTaints    []string
 	rolloutManager *rolloutManager.Manager
@@ -108,14 +110,16 @@ func NewClusterReconciler(
 	discoveryClient *discovery.DiscoveryClient,
 	plugins repository.Interface,
 	drainTaints []string,
+	operatorClientCert *tls.Certificate,
 ) *ClusterReconciler {
 	return &ClusterReconciler{
-		InstanceClient:  remote.NewClient().Instance(),
-		DiscoveryClient: discoveryClient,
-		Client:          operatorclient.NewExtendedClient(mgr.GetClient()),
-		Scheme:          mgr.GetScheme(),
-		Recorder:        mgr.GetEventRecorderFor("cloudnative-pg"), //nolint:staticcheck
-		Plugins:         plugins,
+		InstanceClient:     remote.NewClient().Instance(),
+		DiscoveryClient:    discoveryClient,
+		Client:             operatorclient.NewExtendedClient(mgr.GetClient()),
+		Scheme:             mgr.GetScheme(),
+		Recorder:           mgr.GetEventRecorderFor("cloudnative-pg"), //nolint:staticcheck
+		Plugins:            plugins,
+		OperatorClientCert: operatorClientCert,
 		rolloutManager: rolloutManager.New(
 			configuration.Current.GetClustersRolloutDelay(),
 			configuration.Current.GetInstancesRolloutDelay(),
@@ -315,6 +319,12 @@ func (r *ClusterReconciler) reconcile(ctx context.Context, cluster *apiv1.Cluste
 		return ctrl.Result{}, err
 	}
 
+	// Ensure the operator's client certificate fingerprint is up to date in the
+	// cluster status before making any authenticated call to the instance manager.
+	if result, err := r.reconcileOperatorCertificateFingerprint(ctx, cluster); err != nil || !result.IsZero() {
+		return result, err
+	}
+
 	// Discover the image to be used and set it into the status
 	if result, err := r.reconcileImage(ctx, cluster); result != nil || err != nil {
 		if result != nil {
@@ -415,12 +425,13 @@ func (r *ClusterReconciler) reconcile(ctx context.Context, cluster *apiv1.Cluste
 		return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
 	}
 
-	// Store in the context the TLS configuration required communicating with the Pods
-	ctx, err = certs.NewTLSConfigForContext(
-		ctx,
-		r.Client,
-		cluster.GetServerCASecretObjectKey(),
-	)
+	// Store in the context the TLS configuration required communicating with the Pods.
+	// The operator client certificate is presented to authenticate with the instance manager.
+	ctx, err = certs.NewTLSConfigForContext(ctx, certs.TLSConfigOptions{
+		Client:     r.Client,
+		CASecret:   cluster.GetServerCASecretObjectKey(),
+		ClientCert: r.OperatorClientCert,
+	})
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -107,7 +107,7 @@ type ClusterReconciler struct {
 // NewClusterReconciler creates a new ClusterReconciler initializing it
 func NewClusterReconciler(
 	mgr manager.Manager,
-	discoveryClient *discovery.DiscoveryClient,
+	discoveryClient discovery.DiscoveryInterface,
 	plugins repository.Interface,
 	drainTaints []string,
 	operatorClientCert *tls.Certificate,

--- a/internal/controller/cluster_operator_cert.go
+++ b/internal/controller/cluster_operator_cert.go
@@ -1,0 +1,74 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package controller
+
+import (
+	"context"
+	"crypto/x509"
+	"fmt"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/certs"
+)
+
+// reconcileOperatorCertificateFingerprint ensures the cluster status contains the
+// SHA-256 fingerprint of the operator's current in-memory client certificate.
+// If the fingerprint is missing or stale, it patches the status and requests an
+// immediate requeue so that the rest of the reconciliation does not run with a
+// cluster whose status the instance manager's local cache has not observed yet.
+func (r *ClusterReconciler) reconcileOperatorCertificateFingerprint(
+	ctx context.Context,
+	cluster *apiv1.Cluster,
+) (ctrl.Result, error) {
+	fingerprint, err := r.operatorCertificateFingerprint()
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	if cluster.Status.OperatorCertificateFingerprint == fingerprint {
+		return ctrl.Result{}, nil
+	}
+
+	orig := cluster.DeepCopy()
+	cluster.Status.OperatorCertificateFingerprint = fingerprint
+	if err := r.Status().Patch(ctx, cluster, client.MergeFrom(orig)); err != nil {
+		return ctrl.Result{}, fmt.Errorf("patching operator certificate fingerprint: %w", err)
+	}
+
+	return ctrl.Result{Requeue: true}, nil
+}
+
+// operatorCertificateFingerprint returns the SHA-256 public key fingerprint of
+// the operator's in-memory client certificate.
+func (r *ClusterReconciler) operatorCertificateFingerprint() (string, error) {
+	if r.OperatorClientCert == nil || len(r.OperatorClientCert.Certificate) == 0 {
+		return "", fmt.Errorf("operator client certificate is not set")
+	}
+
+	cert, err := x509.ParseCertificate(r.OperatorClientCert.Certificate[0])
+	if err != nil {
+		return "", fmt.Errorf("parsing operator client certificate: %w", err)
+	}
+
+	return certs.PublicKeyFingerprint(cert), nil
+}

--- a/internal/controller/cluster_operator_cert.go
+++ b/internal/controller/cluster_operator_cert.go
@@ -36,6 +36,12 @@ import (
 // If the fingerprint is missing or stale, it patches the status and requests an
 // immediate requeue so that the rest of the reconciliation does not run with a
 // cluster whose status the instance manager's local cache has not observed yet.
+//
+// The certificate is per-process: each operator instance generates its own at
+// startup. After a leader-election failover the new leader re-patches the
+// fingerprint of every cluster, briefly reopening the propagation window until
+// each instance manager observes the new value. This is self-healing and
+// expected, not a bug.
 func (r *ClusterReconciler) reconcileOperatorCertificateFingerprint(
 	ctx context.Context,
 	cluster *apiv1.Cluster,

--- a/internal/controller/cluster_operator_cert_test.go
+++ b/internal/controller/cluster_operator_cert_test.go
@@ -21,7 +21,6 @@ package controller
 
 import (
 	"context"
-	"crypto/tls"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -40,7 +39,7 @@ var _ = Describe("reconcileOperatorCertificateFingerprint", func() {
 		cluster *apiv1.Cluster
 	)
 
-	newReconcilerWithCert := func() (*ClusterReconciler, *tls.Certificate) {
+	newReconcilerWithCert := func() *ClusterReconciler {
 		pair, err := certs.GenerateSelfSignedClientCertificate("test-operator")
 		Expect(err).ToNot(HaveOccurred())
 		tlsCert, err := pair.TLSCertificate()
@@ -52,13 +51,11 @@ var _ = Describe("reconcileOperatorCertificateFingerprint", func() {
 		return &ClusterReconciler{
 			Client:             fakeClient,
 			OperatorClientCert: &tlsCert,
-		}, &tlsCert
+		}
 	}
 
 	BeforeEach(func() {
-		var tlsCert *tls.Certificate
-		r, tlsCert = newReconcilerWithCert()
-		_ = tlsCert
+		r = newReconcilerWithCert()
 
 		cluster = &apiv1.Cluster{
 			ObjectMeta: metav1.ObjectMeta{

--- a/internal/controller/cluster_operator_cert_test.go
+++ b/internal/controller/cluster_operator_cert_test.go
@@ -1,0 +1,105 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package controller
+
+import (
+	"context"
+	"crypto/tls"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	schemeBuilder "github.com/cloudnative-pg/cloudnative-pg/internal/scheme"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/certs"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("reconcileOperatorCertificateFingerprint", func() {
+	var (
+		r       *ClusterReconciler
+		cluster *apiv1.Cluster
+	)
+
+	newReconcilerWithCert := func() (*ClusterReconciler, *tls.Certificate) {
+		pair, err := certs.GenerateSelfSignedClientCertificate("test-operator")
+		Expect(err).ToNot(HaveOccurred())
+		tlsCert, err := pair.TLSCertificate()
+		Expect(err).ToNot(HaveOccurred())
+
+		scheme := schemeBuilder.BuildWithAllKnownScheme()
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(&apiv1.Cluster{}).Build()
+
+		return &ClusterReconciler{
+			Client:             fakeClient,
+			OperatorClientCert: &tlsCert,
+		}, &tlsCert
+	}
+
+	BeforeEach(func() {
+		var tlsCert *tls.Certificate
+		r, tlsCert = newReconcilerWithCert()
+		_ = tlsCert
+
+		cluster = &apiv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-cluster",
+				Namespace: "default",
+			},
+		}
+		Expect(r.Client.Create(context.Background(), cluster)).To(Succeed())
+	})
+
+	It("patches the status and requeues when the fingerprint is missing", func() {
+		result, err := r.reconcileOperatorCertificateFingerprint(context.Background(), cluster)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result.IsZero()).To(BeFalse())
+		Expect(cluster.Status.OperatorCertificateFingerprint).ToNot(BeEmpty())
+	})
+
+	It("does not requeue when the fingerprint already matches", func() {
+		// First call sets the fingerprint
+		_, err := r.reconcileOperatorCertificateFingerprint(context.Background(), cluster)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Second call finds it already correct
+		result, err := r.reconcileOperatorCertificateFingerprint(context.Background(), cluster)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result.IsZero()).To(BeTrue())
+	})
+
+	It("patches the status and requeues when the fingerprint is stale", func() {
+		// Set a stale fingerprint
+		cluster.Status.OperatorCertificateFingerprint = "stale-fingerprint"
+
+		result, err := r.reconcileOperatorCertificateFingerprint(context.Background(), cluster)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result.IsZero()).To(BeFalse())
+		Expect(cluster.Status.OperatorCertificateFingerprint).ToNot(Equal("stale-fingerprint"))
+	})
+
+	It("returns an error when no client certificate is set", func() {
+		r.OperatorClientCert = nil
+		_, err := r.reconcileOperatorCertificateFingerprint(context.Background(), cluster)
+		Expect(err).To(HaveOccurred())
+	})
+})

--- a/internal/controller/cluster_upgrade.go
+++ b/internal/controller/cluster_upgrade.go
@@ -827,6 +827,13 @@ func (r *ClusterReconciler) upgradeInstanceManager(
 				operatorHash[:6],
 				err)
 
+			// A transient rejection while the operator certificate fingerprint
+			// propagates is not a real failure: skip the event and let the caller
+			// requeue quietly.
+			if remote.IsTransientAuthError(err) {
+				return enrichedError
+			}
+
 			r.Recorder.Event(cluster, "Warning", "InstanceManagerUpgradeFailed",
 				fmt.Sprintf("Error %s", enrichedError))
 			return enrichedError

--- a/pkg/certs/selfsigned.go
+++ b/pkg/certs/selfsigned.go
@@ -1,0 +1,92 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package certs
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/hex"
+	"fmt"
+	"math/big"
+	"time"
+)
+
+// GenerateSelfSignedClientCertificate generates an in-memory self-signed ECDSA P-256
+// certificate with ExtKeyUsageClientAuth. The certificate is never written to disk.
+func GenerateSelfSignedClientCertificate(commonName string) (*KeyPair, error) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, err
+	}
+
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+	if err != nil {
+		return nil, fmt.Errorf("can't generate serial number: %w", err)
+	}
+
+	notBefore := time.Now().Add(-5 * time.Minute)
+	notAfter := notBefore.Add(getCertificateDuration())
+
+	template := x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			CommonName: commonName,
+		},
+		NotBefore:             notBefore,
+		NotAfter:              notAfter,
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		BasicConstraintsValid: true,
+	}
+
+	certBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &key.PublicKey, key)
+	if err != nil {
+		return nil, err
+	}
+
+	privateKey, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		return nil, err
+	}
+
+	return &KeyPair{
+		Private:     encodePrivateKey(privateKey),
+		Certificate: encodeCertificate(certBytes),
+	}, nil
+}
+
+// TLSCertificate converts the key pair to a tls.Certificate.
+func (pair KeyPair) TLSCertificate() (tls.Certificate, error) {
+	return tls.X509KeyPair(pair.Certificate, pair.Private)
+}
+
+// PublicKeyFingerprint returns the hex-encoded SHA-256 digest of the certificate's
+// SubjectPublicKeyInfo, which is stable across certificate renewals that reuse the
+// same key.
+func PublicKeyFingerprint(cert *x509.Certificate) string {
+	digest := sha256.Sum256(cert.RawSubjectPublicKeyInfo)
+	return hex.EncodeToString(digest[:])
+}

--- a/pkg/certs/selfsigned.go
+++ b/pkg/certs/selfsigned.go
@@ -48,7 +48,12 @@ func GenerateSelfSignedClientCertificate(commonName string) (*KeyPair, error) {
 	}
 
 	notBefore := time.Now().Add(-5 * time.Minute)
-	notAfter := notBefore.Add(getCertificateDuration())
+	// Trust in this certificate comes from pinning its SHA-256 public-key
+	// fingerprint, not from its validity period: the private key never leaves the
+	// operator's memory and a fresh certificate is generated on every restart.
+	// Nothing verifies the expiry, so we use the RFC 5280 "no well-defined
+	// expiration date" value to avoid rejecting a long-running operator process.
+	notAfter := time.Date(9999, 12, 31, 23, 59, 59, 0, time.UTC)
 
 	template := x509.Certificate{
 		SerialNumber: serialNumber,

--- a/pkg/certs/selfsigned.go
+++ b/pkg/certs/selfsigned.go
@@ -89,8 +89,9 @@ func (pair KeyPair) TLSCertificate() (tls.Certificate, error) {
 }
 
 // PublicKeyFingerprint returns the hex-encoded SHA-256 digest of the certificate's
-// SubjectPublicKeyInfo, which is stable across certificate renewals that reuse the
-// same key.
+// SubjectPublicKeyInfo. It depends only on the public key, so two certificates that
+// share a key produce the same fingerprint. Note that the operator generates a fresh
+// key on every restart, so its fingerprint is not stable across restarts.
 func PublicKeyFingerprint(cert *x509.Certificate) string {
 	digest := sha256.Sum256(cert.RawSubjectPublicKeyInfo)
 	return hex.EncodeToString(digest[:])

--- a/pkg/certs/selfsigned_test.go
+++ b/pkg/certs/selfsigned_test.go
@@ -1,0 +1,135 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package certs
+
+import (
+	"crypto/x509"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Self-signed client certificate", func() {
+	Describe("GenerateSelfSignedClientCertificate", func() {
+		It("should generate a valid self-signed certificate", func() {
+			pair, err := GenerateSelfSignedClientCertificate("test-cn")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(pair).ToNot(BeNil())
+		})
+
+		It("should set the requested common name", func() {
+			pair, err := GenerateSelfSignedClientCertificate("my-operator")
+			Expect(err).ToNot(HaveOccurred())
+
+			cert, err := pair.ParseCertificate()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(cert.Subject.CommonName).To(Equal("my-operator"))
+		})
+
+		It("should produce a certificate with client auth extended key usage", func() {
+			pair, err := GenerateSelfSignedClientCertificate("test-cn")
+			Expect(err).ToNot(HaveOccurred())
+
+			cert, err := pair.ParseCertificate()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(cert.ExtKeyUsage).To(ContainElement(x509.ExtKeyUsageClientAuth))
+			Expect(cert.ExtKeyUsage).ToNot(ContainElement(x509.ExtKeyUsageServerAuth))
+		})
+
+		It("should produce a certificate that is not a CA", func() {
+			pair, err := GenerateSelfSignedClientCertificate("test-cn")
+			Expect(err).ToNot(HaveOccurred())
+
+			cert, err := pair.ParseCertificate()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(cert.IsCA).To(BeFalse())
+		})
+
+		It("should produce a currently valid certificate", func() {
+			pair, err := GenerateSelfSignedClientCertificate("test-cn")
+			Expect(err).ToNot(HaveOccurred())
+
+			cert, err := pair.ParseCertificate()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(cert.NotBefore).To(BeTemporally("<", time.Now()))
+			Expect(cert.NotAfter).To(BeTemporally(">", time.Now()))
+		})
+
+		It("should produce two distinct certificates on successive calls", func() {
+			pair1, err := GenerateSelfSignedClientCertificate("test-cn")
+			Expect(err).ToNot(HaveOccurred())
+			pair2, err := GenerateSelfSignedClientCertificate("test-cn")
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(pair1.Certificate).ToNot(Equal(pair2.Certificate))
+			Expect(pair1.Private).ToNot(Equal(pair2.Private))
+		})
+	})
+
+	Describe("TLSCertificate", func() {
+		It("should convert a key pair to a tls.Certificate without error", func() {
+			pair, err := GenerateSelfSignedClientCertificate("test-cn")
+			Expect(err).ToNot(HaveOccurred())
+
+			tlsCert, err := pair.TLSCertificate()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(tlsCert.Certificate).ToNot(BeEmpty())
+		})
+	})
+
+	Describe("PublicKeyFingerprint", func() {
+		It("should return a non-empty hex string", func() {
+			pair, err := GenerateSelfSignedClientCertificate("test-cn")
+			Expect(err).ToNot(HaveOccurred())
+
+			cert, err := pair.ParseCertificate()
+			Expect(err).ToNot(HaveOccurred())
+
+			fp := PublicKeyFingerprint(cert)
+			Expect(fp).ToNot(BeEmpty())
+			Expect(fp).To(HaveLen(64)) // SHA-256 hex is always 64 chars
+		})
+
+		It("should return the same fingerprint for the same key", func() {
+			pair, err := GenerateSelfSignedClientCertificate("test-cn")
+			Expect(err).ToNot(HaveOccurred())
+
+			cert, err := pair.ParseCertificate()
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(PublicKeyFingerprint(cert)).To(Equal(PublicKeyFingerprint(cert)))
+		})
+
+		It("should return different fingerprints for different keys", func() {
+			pair1, err := GenerateSelfSignedClientCertificate("test-cn")
+			Expect(err).ToNot(HaveOccurred())
+			pair2, err := GenerateSelfSignedClientCertificate("test-cn")
+			Expect(err).ToNot(HaveOccurred())
+
+			cert1, err := pair1.ParseCertificate()
+			Expect(err).ToNot(HaveOccurred())
+			cert2, err := pair2.ParseCertificate()
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(PublicKeyFingerprint(cert1)).ToNot(Equal(PublicKeyFingerprint(cert2)))
+		})
+	})
+})

--- a/pkg/certs/tls.go
+++ b/pkg/certs/tls.go
@@ -35,21 +35,31 @@ type contextKey string
 // contextKeyTLSConfig is the context key holding the TLS configuration
 const contextKeyTLSConfig contextKey = "tlsConfig"
 
+// TLSConfigOptions holds the parameters required to build a TLS client configuration.
+type TLSConfigOptions struct {
+	// Client is the Kubernetes client used to fetch the CA secret.
+	Client client.Client
+
+	// CASecret is the namespaced name of the secret containing the server CA certificate.
+	CASecret types.NamespacedName
+
+	// ClientCert is the certificate presented to the server during the TLS handshake.
+	// Pass nil when the caller does not need to authenticate itself (e.g. isolation
+	// probes, diagnostic commands).
+	ClientCert *tls.Certificate
+}
+
 // newTLSConfigFromSecret creates a tls.Config from the given CA secret.
-func newTLSConfigFromSecret(
-	ctx context.Context,
-	cli client.Client,
-	caSecret types.NamespacedName,
-) (*tls.Config, error) {
+func newTLSConfigFromSecret(ctx context.Context, opts TLSConfigOptions) (*tls.Config, error) {
 	secret := &corev1.Secret{}
-	err := cli.Get(ctx, caSecret, secret)
+	err := opts.Client.Get(ctx, opts.CASecret, secret)
 	if err != nil {
-		return nil, fmt.Errorf("while getting caSecret %s: %w", caSecret.Name, err)
+		return nil, fmt.Errorf("while getting caSecret %s: %w", opts.CASecret.Name, err)
 	}
 
 	caCertificate, ok := secret.Data[CACertKey]
 	if !ok {
-		return nil, fmt.Errorf("missing %s entry in secret %s", CACertKey, caSecret.Name)
+		return nil, fmt.Errorf("missing %s entry in secret %s", CACertKey, opts.CASecret.Name)
 	}
 
 	// The operator will verify the certificates only against the CA, ignoring the DNS name.
@@ -101,16 +111,16 @@ func NewTLSConfigFromCertPool(
 	return &tlsConfig
 }
 
-// NewTLSConfigForContext creates a tls.config with the provided data and returns an expanded context that contains
-// the *tls.Config
-func NewTLSConfigForContext(
-	ctx context.Context,
-	cli client.Client,
-	caSecret types.NamespacedName,
-) (context.Context, error) {
-	conf, err := newTLSConfigFromSecret(ctx, cli, caSecret)
+// NewTLSConfigForContext creates a tls.Config from the given options and stores it
+// in the returned context.
+func NewTLSConfigForContext(ctx context.Context, opts TLSConfigOptions) (context.Context, error) {
+	conf, err := newTLSConfigFromSecret(ctx, opts)
 	if err != nil {
 		return ctx, err
+	}
+
+	if opts.ClientCert != nil {
+		conf.Certificates = []tls.Certificate{*opts.ClientCert}
 	}
 
 	return context.WithValue(ctx, contextKeyTLSConfig, conf), nil

--- a/pkg/certs/tls_test.go
+++ b/pkg/certs/tls_test.go
@@ -114,7 +114,7 @@ IRh7fVEH8WBfMA8GA1UdEwEB/wQFMAMBAf8wCgYIKoZIzj0EAwIDaAAwZQIwBdrw
 		})
 
 		It("should return a valid tls.Config", func(ctx context.Context) {
-			tlsConfig, err := newTLSConfigFromSecret(ctx, c, caSecret)
+			tlsConfig, err := newTLSConfigFromSecret(ctx, TLSConfigOptions{Client: c, CASecret: caSecret})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(tlsConfig).NotTo(BeNil())
 			Expect(tlsConfig.MinVersion).To(Equal(uint16(tls.VersionTLS13)))
@@ -122,7 +122,7 @@ IRh7fVEH8WBfMA8GA1UdEwEB/wQFMAMBAf8wCgYIKoZIzj0EAwIDaAAwZQIwBdrw
 		})
 
 		It("should reject connections with no certificates", func(ctx context.Context) {
-			tlsConfig, err := newTLSConfigFromSecret(ctx, c, caSecret)
+			tlsConfig, err := newTLSConfigFromSecret(ctx, TLSConfigOptions{Client: c, CASecret: caSecret})
 			Expect(err).NotTo(HaveOccurred())
 			err = tlsConfig.VerifyConnection(tls.ConnectionState{})
 			Expect(err).To(HaveOccurred())
@@ -130,7 +130,7 @@ IRh7fVEH8WBfMA8GA1UdEwEB/wQFMAMBAf8wCgYIKoZIzj0EAwIDaAAwZQIwBdrw
 		})
 
 		It("should validate good certificates", func(ctx context.Context) {
-			tlsConfig, err := newTLSConfigFromSecret(ctx, c, caSecret)
+			tlsConfig, err := newTLSConfigFromSecret(ctx, TLSConfigOptions{Client: c, CASecret: caSecret})
 			Expect(err).NotTo(HaveOccurred())
 			serverBlock, _ := pem.Decode([]byte(`
 Certificate:
@@ -209,7 +209,7 @@ Zxj1fxVSmUy1TBXz6H0sUvtFh/Fgb6v4qUPdRE6xNJw3lbZUZxHr2xXk5Op/Cw6O
 		})
 
 		It("should reject bad certificates", func(ctx context.Context) {
-			tlsConfig, err := newTLSConfigFromSecret(ctx, c, caSecret)
+			tlsConfig, err := newTLSConfigFromSecret(ctx, TLSConfigOptions{Client: c, CASecret: caSecret})
 			Expect(err).NotTo(HaveOccurred())
 			badServerBlock, _ := pem.Decode([]byte(`Certificate:
     Data:
@@ -295,7 +295,7 @@ MQCKGqId+Xj6O6gnoi9xhu0rbzSnMjrURoa1v2d5+O5XssE7LGtJdIKrd2p7EuwE
 		})
 
 		It("should return an error", func(ctx SpecContext) {
-			tlsConfig, err := newTLSConfigFromSecret(ctx, c, caSecret)
+			tlsConfig, err := newTLSConfigFromSecret(ctx, TLSConfigOptions{Client: c, CASecret: caSecret})
 			Expect(err).To(HaveOccurred())
 			Expect(tlsConfig).To(BeNil())
 			Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("while getting caSecret %s", caSecret.Name)))
@@ -314,7 +314,7 @@ MQCKGqId+Xj6O6gnoi9xhu0rbzSnMjrURoa1v2d5+O5XssE7LGtJdIKrd2p7EuwE
 		})
 
 		It("should return an error", func(ctx SpecContext) {
-			tlsConfig, err := newTLSConfigFromSecret(ctx, c, caSecret)
+			tlsConfig, err := newTLSConfigFromSecret(ctx, TLSConfigOptions{Client: c, CASecret: caSecret})
 			Expect(err).To(HaveOccurred())
 			Expect(tlsConfig).To(BeNil())
 			Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("missing %s entry in secret %s", CACertKey, caSecret.Name)))

--- a/pkg/management/postgres/instance.go
+++ b/pkg/management/postgres/instance.go
@@ -231,7 +231,10 @@ type Instance struct {
 
 	// cluster is the cached cluster this instance belongs to.
 	// Access via GetClusterOrDefault() which returns an empty cluster if nil.
-	cluster *apiv1.Cluster
+	// It is read from HTTP handler goroutines (e.g. the remote webserver
+	// authentication middleware) while being written by the reconciliation loop,
+	// so access is synchronized through an atomic pointer.
+	cluster atomic.Pointer[apiv1.Cluster]
 }
 
 type serverCertificateHandler struct {
@@ -305,16 +308,16 @@ func (instance *Instance) SetCanCheckReadiness(enabled bool) {
 // GetClusterOrDefault returns the cached cluster, or an empty cluster if not set.
 // The empty cluster provides safe defaults via getter methods.
 func (instance *Instance) GetClusterOrDefault() *apiv1.Cluster {
-	if instance.cluster == nil {
-		return &apiv1.Cluster{}
+	if cluster := instance.cluster.Load(); cluster != nil {
+		return cluster
 	}
-	return instance.cluster
+	return &apiv1.Cluster{}
 }
 
 // SetCluster updates the cached cluster for use outside the reconciliation
 // cycle when the API client is not available
 func (instance *Instance) SetCluster(cluster *apiv1.Cluster) {
-	instance.cluster = cluster
+	instance.cluster.Store(cluster)
 }
 
 // RequiresDesignatedPrimaryTransition checks if this instance is a primary

--- a/pkg/management/postgres/webserver/client/remote/instance.go
+++ b/pkg/management/postgres/webserver/client/remote/instance.go
@@ -101,6 +101,23 @@ func (i StatusError) Error() string {
 	return fmt.Sprintf("error status code: %v, body: %v", i.StatusCode, i.Body)
 }
 
+// IsTransientAuthError reports whether err is a transient instance manager rejection of
+// the operator's client certificate. The instance manager replies 503 while it does not
+// (yet) recognize the presented certificate — either no operator fingerprint has been
+// registered in the cluster status, or the cached fingerprint does not match it yet. This
+// resolves as the operator certificate fingerprint propagates to the instance's cached
+// cluster (for example right after an operator restart), so the caller should retry.
+//
+// A 401 (no usable client certificate, e.g. a status port not served over TLS) is NOT
+// transient and is intentionally excluded: the caller should fail rather than retry.
+func IsTransientAuthError(err error) bool {
+	var statusErr *StatusError
+	if !errors.As(err, &statusErr) {
+		return false
+	}
+	return statusErr.StatusCode == http.StatusServiceUnavailable
+}
+
 // extractInstancesStatus extracts the status of the underlying PostgreSQL instance from
 // the requested Pod, via the instance manager. In case of failure, errors are passed
 // in the result list

--- a/pkg/management/postgres/webserver/client/remote/request.go
+++ b/pkg/management/postgres/webserver/client/remote/request.go
@@ -60,7 +60,8 @@ func executeRequestWithError[T any](
 		return nil, fmt.Errorf("encountered an internal server error status code 500 with body: %s", string(body))
 	}
 
-	// The instance manager guards its protected endpoints with mTLS: it replies 401 when
+	// The instance manager guards its protected endpoints by pinning the operator's client
+	// certificate fingerprint: it replies 401 when
 	// no usable client certificate is presented (permanent, e.g. a status port not served
 	// over TLS) and 503 while a presented certificate is not yet recognized (transient
 	// during operator certificate fingerprint propagation). Surface both as a typed

--- a/pkg/management/postgres/webserver/client/remote/request.go
+++ b/pkg/management/postgres/webserver/client/remote/request.go
@@ -60,6 +60,16 @@ func executeRequestWithError[T any](
 		return nil, fmt.Errorf("encountered an internal server error status code 500 with body: %s", string(body))
 	}
 
+	// The instance manager guards its protected endpoints with mTLS: it replies 401 when
+	// no usable client certificate is presented (permanent, e.g. a status port not served
+	// over TLS) and 503 while a presented certificate is not yet recognized (transient
+	// during operator certificate fingerprint propagation). Surface both as a typed
+	// StatusError so callers can tell them apart (see IsTransientAuthError) instead of
+	// failing on an opaque body-unmarshalling error.
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusServiceUnavailable {
+		return nil, &StatusError{StatusCode: resp.StatusCode, Body: string(body)}
+	}
+
 	var result webserver.Response[T]
 	if err := json.Unmarshal(body, &result); err != nil {
 		return nil, fmt.Errorf("while unmarshalling the body, body: %s err: %w", string(body), err)

--- a/pkg/management/postgres/webserver/client/remote/request_test.go
+++ b/pkg/management/postgres/webserver/client/remote/request_test.go
@@ -1,0 +1,86 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package remote
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres/webserver"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("executeRequestWithError", func() {
+	newServer := func(statusCode int, body string) *httptest.Server {
+		return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			http.Error(w, body, statusCode)
+		}))
+	}
+
+	It("surfaces a 503 instance manager rejection as a transient StatusError", func(ctx SpecContext) {
+		srv := newServer(http.StatusServiceUnavailable, "operator certificate not recognized")
+		defer srv.Close()
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL, nil)
+		Expect(err).ToNot(HaveOccurred())
+
+		_, err = executeRequestWithError[webserver.BackupResultData](ctx, srv.Client(), req, true)
+		Expect(err).To(HaveOccurred())
+
+		var statusErr *StatusError
+		Expect(errors.As(err, &statusErr)).To(BeTrue())
+		Expect(statusErr.StatusCode).To(Equal(http.StatusServiceUnavailable))
+		Expect(IsTransientAuthError(err)).To(BeTrue())
+	})
+
+	It("surfaces a 401 no-client-certificate rejection as a non-transient StatusError", func(ctx SpecContext) {
+		srv := newServer(http.StatusUnauthorized, "client certificate required")
+		defer srv.Close()
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL, nil)
+		Expect(err).ToNot(HaveOccurred())
+
+		_, err = executeRequestWithError[webserver.BackupResultData](ctx, srv.Client(), req, true)
+		Expect(err).To(HaveOccurred())
+
+		var statusErr *StatusError
+		Expect(errors.As(err, &statusErr)).To(BeTrue())
+		Expect(statusErr.StatusCode).To(Equal(http.StatusUnauthorized))
+		Expect(IsTransientAuthError(err)).To(BeFalse())
+	})
+
+	It("does not wrap a successful response in a StatusError", func(ctx SpecContext) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{}`))
+		}))
+		defer srv.Close()
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL, nil)
+		Expect(err).ToNot(HaveOccurred())
+
+		result, err := executeRequestWithError[webserver.BackupResultData](ctx, srv.Client(), req, true)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result).ToNot(BeNil())
+	})
+})

--- a/pkg/management/postgres/webserver/client/remote/suite_test.go
+++ b/pkg/management/postgres/webserver/client/remote/suite_test.go
@@ -1,0 +1,32 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package remote
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestRemote(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Remote instance client test suite")
+}

--- a/pkg/management/postgres/webserver/middleware_test.go
+++ b/pkg/management/postgres/webserver/middleware_test.go
@@ -1,0 +1,135 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package webserver
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"net/http"
+	"net/http/httptest"
+
+	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/certs"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// parsedCert generates a self-signed cert and returns the parsed x509 leaf.
+func parsedCert(cn string) *x509.Certificate {
+	pair, err := certs.GenerateSelfSignedClientCertificate(cn)
+	ExpectWithOffset(1, err).ToNot(HaveOccurred())
+	tlsCert, err := pair.TLSCertificate()
+	ExpectWithOffset(1, err).ToNot(HaveOccurred())
+	leaf, err := x509.ParseCertificate(tlsCert.Certificate[0])
+	ExpectWithOffset(1, err).ToNot(HaveOccurred())
+	return leaf
+}
+
+var _ = Describe("withOperatorAuth", func() {
+	var (
+		ws          remoteWebserverEndpoints
+		nextCalled  bool
+		nextHandler http.HandlerFunc
+	)
+
+	newInstance := func(fingerprint string) *postgres.Instance {
+		instance := &postgres.Instance{}
+		cluster := &apiv1.Cluster{}
+		cluster.Status.OperatorCertificateFingerprint = fingerprint
+		instance.SetCluster(cluster)
+		return instance
+	}
+
+	BeforeEach(func() {
+		nextCalled = false
+		nextHandler = func(_ http.ResponseWriter, _ *http.Request) {
+			nextCalled = true
+		}
+	})
+
+	It("rejects a request with no TLS state", func() {
+		ws = remoteWebserverEndpoints{instance: newInstance("some-fingerprint")}
+		req := httptest.NewRequest(http.MethodGet, "/backup", nil)
+		// req.TLS is nil by default
+		w := httptest.NewRecorder()
+
+		ws.withOperatorAuth(nextHandler)(w, req)
+
+		Expect(w.Code).To(Equal(http.StatusUnauthorized))
+		Expect(nextCalled).To(BeFalse())
+	})
+
+	It("rejects a request with TLS but no peer certificates", func() {
+		ws = remoteWebserverEndpoints{instance: newInstance("some-fingerprint")}
+		req := httptest.NewRequest(http.MethodGet, "/backup", nil)
+		req.TLS = &tls.ConnectionState{} // no PeerCertificates
+		w := httptest.NewRecorder()
+
+		ws.withOperatorAuth(nextHandler)(w, req)
+
+		Expect(w.Code).To(Equal(http.StatusUnauthorized))
+		Expect(nextCalled).To(BeFalse())
+	})
+
+	It("returns 503 when no fingerprint is stored in the cluster status", func() {
+		ws = remoteWebserverEndpoints{instance: newInstance("")}
+
+		leaf := parsedCert("test")
+		req := httptest.NewRequest(http.MethodGet, "/backup", nil)
+		req.TLS = &tls.ConnectionState{PeerCertificates: []*x509.Certificate{leaf}}
+		w := httptest.NewRecorder()
+
+		ws.withOperatorAuth(nextHandler)(w, req)
+
+		Expect(w.Code).To(Equal(http.StatusServiceUnavailable))
+		Expect(nextCalled).To(BeFalse())
+	})
+
+	It("rejects a request whose certificate fingerprint does not match", func() {
+		ws = remoteWebserverEndpoints{instance: newInstance("wrong-fingerprint")}
+
+		leaf := parsedCert("test")
+		req := httptest.NewRequest(http.MethodGet, "/backup", nil)
+		req.TLS = &tls.ConnectionState{PeerCertificates: []*x509.Certificate{leaf}}
+		w := httptest.NewRecorder()
+
+		ws.withOperatorAuth(nextHandler)(w, req)
+
+		Expect(w.Code).To(Equal(http.StatusUnauthorized))
+		Expect(nextCalled).To(BeFalse())
+	})
+
+	It("calls the next handler when the fingerprint matches", func() {
+		leaf := parsedCert("test")
+		fingerprint := certs.PublicKeyFingerprint(leaf)
+		ws = remoteWebserverEndpoints{instance: newInstance(fingerprint)}
+
+		req := httptest.NewRequest(http.MethodGet, "/backup", nil)
+		req.TLS = &tls.ConnectionState{PeerCertificates: []*x509.Certificate{leaf}}
+		w := httptest.NewRecorder()
+
+		ws.withOperatorAuth(nextHandler)(w, req)
+
+		Expect(w.Code).To(Equal(http.StatusOK))
+		Expect(nextCalled).To(BeTrue())
+	})
+})

--- a/pkg/management/postgres/webserver/middleware_test.go
+++ b/pkg/management/postgres/webserver/middleware_test.go
@@ -104,7 +104,7 @@ var _ = Describe("withOperatorAuth", func() {
 		Expect(nextCalled).To(BeFalse())
 	})
 
-	It("rejects a request whose certificate fingerprint does not match", func() {
+	It("returns 503 for a request whose certificate fingerprint does not match", func() {
 		ws = remoteWebserverEndpoints{instance: newInstance("wrong-fingerprint")}
 
 		leaf := parsedCert("test")
@@ -114,7 +114,7 @@ var _ = Describe("withOperatorAuth", func() {
 
 		ws.withOperatorAuth(nextHandler)(w, req)
 
-		Expect(w.Code).To(Equal(http.StatusUnauthorized))
+		Expect(w.Code).To(Equal(http.StatusServiceUnavailable))
 		Expect(nextCalled).To(BeFalse())
 	})
 

--- a/pkg/management/postgres/webserver/remote.go
+++ b/pkg/management/postgres/webserver/remote.go
@@ -41,6 +41,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/certs"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/concurrency"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres"
@@ -59,6 +60,43 @@ func IsRetryableError(err *Error) bool {
 		return false
 	}
 	return err.Code == errCodeAnotherRequestInProgress
+}
+
+// withOperatorAuth wraps a handler to enforce mTLS fingerprint authentication.
+// It reads the expected fingerprint from the instance's cached cluster (updated by
+// the reconciliation loop) and compares it against the SHA-256 public key fingerprint
+// of the peer certificate presented by the caller.
+func (ws *remoteWebserverEndpoints) withOperatorAuth(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		contextLogger := log.FromContext(r.Context())
+
+		if r.TLS == nil || len(r.TLS.PeerCertificates) == 0 {
+			contextLogger.Debug("Rejecting unauthenticated request to protected endpoint",
+				"path", r.URL.Path)
+			http.Error(w, "client certificate required", http.StatusUnauthorized)
+			return
+		}
+
+		expectedFingerprint := ws.instance.GetClusterOrDefault().Status.OperatorCertificateFingerprint
+		if expectedFingerprint == "" {
+			contextLogger.Debug("No operator certificate fingerprint in cluster status; rejecting request",
+				"path", r.URL.Path)
+			http.Error(w, "operator certificate not registered", http.StatusServiceUnavailable)
+			return
+		}
+
+		peerCert := r.TLS.PeerCertificates[0]
+		actualFingerprint := certs.PublicKeyFingerprint(peerCert)
+		if actualFingerprint != expectedFingerprint {
+			contextLogger.Debug("Rejecting request with unknown operator certificate",
+				"path", r.URL.Path,
+				"fingerprint", actualFingerprint)
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+
+		next(w, r)
+	}
 }
 
 type remoteWebserverEndpoints struct {
@@ -115,15 +153,29 @@ func NewRemoteWebServer(
 	}
 
 	serveMux := http.NewServeMux()
-	serveMux.HandleFunc(url.PathFailSafe, endpoints.failSafe)
-	serveMux.HandleFunc(url.PathPgModeBackup, endpoints.backup)
-	serveMux.HandleFunc(url.PathHealth, endpoints.isServerHealthy)
-	serveMux.HandleFunc(url.PathReady, endpoints.isServerReady)
-	serveMux.HandleFunc(url.PathStartup, endpoints.isServerStartedUp)
+
+	// Unauthenticated: used by the Kubernetes API server ProxyGet (kubectl cnpg status).
 	serveMux.HandleFunc(url.PathPgStatus, endpoints.pgStatus)
-	serveMux.HandleFunc(url.PathPgArchivePartial, endpoints.pgArchivePartial)
-	serveMux.HandleFunc(url.PathPGControlData, endpoints.pgControlData)
-	serveMux.HandleFunc(url.PathUpdate, endpoints.updateInstanceManager(cancelFunc, exitedConditions))
+	// Unauthenticated: kubelet liveness probe; must be reachable without client cert.
+	serveMux.HandleFunc(url.PathHealth, endpoints.isServerHealthy)
+	// Unauthenticated: kubelet readiness probe; must be reachable without client cert.
+	serveMux.HandleFunc(url.PathReady, endpoints.isServerReady)
+	// Unauthenticated: kubelet startup probe; must be reachable without client cert.
+	serveMux.HandleFunc(url.PathStartup, endpoints.isServerStartedUp)
+	// Unauthenticated: failsafe is a lightweight no-op called only by the operator.
+	// It does not perform any sensitive operation and needs no authentication.
+	serveMux.HandleFunc(url.PathFailSafe, endpoints.failSafe)
+
+	// Authenticated: backup drives a PostgreSQL pg_start/stop_backup session.
+	serveMux.HandleFunc(url.PathPgModeBackup, endpoints.withOperatorAuth(endpoints.backup))
+	// Authenticated: spawns a pg_controldata process per call; only the operator should invoke it.
+	serveMux.HandleFunc(url.PathPGControlData, endpoints.withOperatorAuth(endpoints.pgControlData))
+	// Authenticated: pgarchivepartial triggers WAL archival and must not be callable by arbitrary clients.
+	serveMux.HandleFunc(url.PathPgArchivePartial, endpoints.withOperatorAuth(endpoints.pgArchivePartial))
+	// Authenticated: update replaces the running instance manager binary.
+	serveMux.HandleFunc(
+		url.PathUpdate,
+		endpoints.withOperatorAuth(endpoints.updateInstanceManager(cancelFunc, exitedConditions)))
 
 	server := &http.Server{
 		Addr:              fmt.Sprintf(":%d", url.StatusPort),
@@ -138,6 +190,9 @@ func NewRemoteWebServer(
 			GetCertificate: func(_ *tls.ClientHelloInfo) (*tls.Certificate, error) {
 				return instance.GetServerCertificate(), nil
 			},
+			// RequestClientCert asks the client to send a certificate but does not require it.
+			// Authentication is enforced per-endpoint by withOperatorAuth.
+			ClientAuth: tls.RequestClientCert,
 		}
 	}
 

--- a/pkg/management/postgres/webserver/remote.go
+++ b/pkg/management/postgres/webserver/remote.go
@@ -66,6 +66,12 @@ func IsRetryableError(err *Error) bool {
 // It reads the expected fingerprint from the instance's cached cluster (updated by
 // the reconciliation loop) and compares it against the SHA-256 public key fingerprint
 // of the peer certificate presented by the caller.
+//
+// Rejections use distinct status codes so callers can tell permanent from transient
+// failures: 401 means no usable client certificate was presented (for example the
+// status port is not served over TLS) and is permanent; 503 means a certificate was
+// presented but is not (yet) recognized, which is transient while the operator
+// certificate fingerprint propagates to the instance's cached cluster.
 func (ws *remoteWebserverEndpoints) withOperatorAuth(next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		contextLogger := log.FromContext(r.Context())
@@ -91,7 +97,7 @@ func (ws *remoteWebserverEndpoints) withOperatorAuth(next http.HandlerFunc) http
 			contextLogger.Debug("Rejecting request with unknown operator certificate",
 				"path", r.URL.Path,
 				"fingerprint", actualFingerprint)
-			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			http.Error(w, "operator certificate not recognized", http.StatusServiceUnavailable)
 			return
 		}
 

--- a/pkg/management/postgres/webserver/remote.go
+++ b/pkg/management/postgres/webserver/remote.go
@@ -62,10 +62,10 @@ func IsRetryableError(err *Error) bool {
 	return err.Code == errCodeAnotherRequestInProgress
 }
 
-// withOperatorAuth wraps a handler to enforce mTLS fingerprint authentication.
-// It reads the expected fingerprint from the instance's cached cluster (updated by
-// the reconciliation loop) and compares it against the SHA-256 public key fingerprint
-// of the peer certificate presented by the caller.
+// withOperatorAuth wraps a handler to authenticate the operator by pinning its client
+// certificate's public key. It reads the expected fingerprint from the instance's cached
+// cluster (updated by the reconciliation loop) and compares it against the SHA-256 public
+// key fingerprint of the peer certificate presented by the caller.
 //
 // Rejections use distinct status codes so callers can tell permanent from transient
 // failures: 401 means no usable client certificate was presented (for example the

--- a/pkg/management/postgres/webserver/suite_test.go
+++ b/pkg/management/postgres/webserver/suite_test.go
@@ -1,0 +1,32 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package webserver
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestWebserver(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Postgres Webserver test suite")
+}

--- a/pkg/reconciler/backup/volumesnapshot/errors.go
+++ b/pkg/reconciler/backup/volumesnapshot/errors.go
@@ -27,6 +27,8 @@ import (
 	"strings"
 
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
+
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres/webserver/client/remote"
 )
 
 var (
@@ -44,7 +46,7 @@ var (
 // exposed by the CSI snapshotter sidecar.
 func isNetworkErrorRetryable(err error) bool {
 	return apierrs.IsServerTimeout(err) || apierrs.IsConflict(err) || apierrs.IsInternalError(err) ||
-		errors.Is(err, context.DeadlineExceeded)
+		errors.Is(err, context.DeadlineExceeded) || remote.IsTransientAuthError(err)
 }
 
 // isCSIErrorMessageRetriable detects if a certain error message

--- a/pkg/reconciler/backup/volumesnapshot/errors_test.go
+++ b/pkg/reconciler/backup/volumesnapshot/errors_test.go
@@ -23,9 +23,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres/webserver/client/remote"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -88,6 +91,27 @@ var _ = Describe("isNetworkErrorRetryable", func() {
 	It("recognizes context deadline exceeded errors", func() {
 		err := context.DeadlineExceeded
 		Expect(isNetworkErrorRetryable(err)).To(BeTrue())
+	})
+
+	It("retries a transient instance manager rejection (503, certificate not recognized)", func() {
+		err := &remote.StatusError{StatusCode: http.StatusServiceUnavailable, Body: "operator certificate not recognized"}
+		Expect(isNetworkErrorRetryable(err)).To(BeTrue())
+	})
+
+	It("retries a wrapped transient instance manager rejection (production path)", func() {
+		err := fmt.Errorf("while trying to start the backup: %w",
+			&remote.StatusError{StatusCode: http.StatusServiceUnavailable, Body: "operator certificate not recognized"})
+		Expect(isNetworkErrorRetryable(err)).To(BeTrue())
+	})
+
+	It("does not retry a 401 (no client certificate, e.g. non-TLS status port)", func() {
+		err := &remote.StatusError{StatusCode: http.StatusUnauthorized, Body: "client certificate required"}
+		Expect(isNetworkErrorRetryable(err)).To(BeFalse())
+	})
+
+	It("does not retry on other instance manager status errors", func() {
+		err := &remote.StatusError{StatusCode: http.StatusNotFound, Body: "not found"}
+		Expect(isNetworkErrorRetryable(err)).To(BeFalse())
 	})
 
 	It("does not retry on not found errors", func() {

--- a/pkg/reconciler/backup/volumesnapshot/reconciler.go
+++ b/pkg/reconciler/backup/volumesnapshot/reconciler.go
@@ -174,7 +174,13 @@ func (se *Reconciler) Reconcile(
 
 	res, err := se.internalReconcile(ctx, cluster, backup, targetPod, pvcs)
 	if isNetworkErrorRetryable(err) {
-		contextLogger.Error(err, "detected retryable error while executing snapshot backup, retrying...")
+		if remote.IsTransientAuthError(err) {
+			contextLogger.Info(
+				"Waiting for the operator certificate fingerprint to propagate " +
+					"before executing the snapshot backup")
+		} else {
+			contextLogger.Error(err, "detected retryable error while executing snapshot backup, retrying...")
+		}
 		return &ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 	}
 

--- a/pkg/reconciler/replicaclusterswitch/reconciler.go
+++ b/pkg/reconciler/replicaclusterswitch/reconciler.go
@@ -178,6 +178,15 @@ func reconcileDemotionToken(
 			}, nil
 		}
 
+		if remote.IsTransientAuthError(err) {
+			contextLogger.Info(
+				"Waiting for the operator certificate fingerprint to propagate " +
+					"before generating the demotion token")
+			return &ctrl.Result{
+				RequeueAfter: 10 * time.Second,
+			}, nil
+		}
+
 		return nil, err
 	}
 

--- a/tests/e2e/operator_mtls_test.go
+++ b/tests/e2e/operator_mtls_test.go
@@ -1,0 +1,88 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package e2e
+
+import (
+	remoteClient "github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres/webserver/client/remote"
+	"github.com/cloudnative-pg/cloudnative-pg/tests"
+	clusterasserts "github.com/cloudnative-pg/cloudnative-pg/tests/internal/asserts/cluster"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/clusterutils"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/proxy"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/timeouts"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/yaml"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Operator mTLS authentication", Label(tests.LabelSecurity), func() {
+	const (
+		clusterFile     = fixturesDir + "/base/cluster-storage-class.yaml.template"
+		namespacePrefix = "operator-mtls"
+		level           = tests.High
+	)
+
+	BeforeEach(func() {
+		if testLevelEnv.Depth < int(level) {
+			Skip("Test depth is lower than the amount requested for this test")
+		}
+	})
+
+	It("sets the operator certificate fingerprint and protects sensitive endpoints", func() {
+		namespace, err := env.CreateUniqueTestNamespace(env.Ctx, env.Client, namespacePrefix)
+		Expect(err).ToNot(HaveOccurred())
+
+		clusterName, err := yaml.GetResourceNameFromYAML(env.Scheme, clusterFile)
+		Expect(err).ToNot(HaveOccurred())
+
+		clusterasserts.AssertCreateCluster(env, testTimeouts, namespace, clusterName, clusterFile)
+
+		By("verifying the operator certificate fingerprint is set in cluster status", func() {
+			cluster, err := clusterutils.Get(env.Ctx, env.Client, namespace, clusterName)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(cluster.Status.OperatorCertificateFingerprint).ToNot(BeEmpty())
+		})
+
+		By("verifying that unauthenticated access is rejected on protected endpoints", func() {
+			podList, err := clusterutils.ListPods(env.Ctx, env.Client, namespace, clusterName)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(podList.Items).ToNot(BeEmpty())
+
+			pod := podList.Items[0]
+			tlsEnabled := remoteClient.GetStatusSchemeFromPod(&pod).IsHTTPS()
+
+			// /pg/status is unauthenticated: proves the pod is reachable and the API
+			// server proxy credentials are valid. If this fails, the next assertion
+			// would be meaningless.
+			By("confirming the unauthenticated status endpoint is reachable", func() {
+				_, err := proxy.RetrievePgStatusFromInstance(env.Ctx, env.Interface, pod, tlsEnabled)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			// /pg/controldata is authenticated: a request without a client certificate
+			// must be rejected. Since /pg/status succeeded above, any error here is
+			// caused by our middleware, not by a network or credentials issue.
+			By("confirming the authenticated pgcontroldata endpoint rejects unauthenticated access", func() {
+				_, err := proxy.RetrievePgControlDataFromInstance(env.Ctx, env.Interface, pod, tlsEnabled)
+				Expect(err).To(HaveOccurred())
+			})
+		})
+	}, NodeTimeout(testTimeouts[timeouts.ClusterIsReady]))
+})

--- a/tests/e2e/operator_mtls_test.go
+++ b/tests/e2e/operator_mtls_test.go
@@ -20,6 +20,8 @@ SPDX-License-Identifier: Apache-2.0
 package e2e
 
 import (
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
 	remoteClient "github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres/webserver/client/remote"
 	"github.com/cloudnative-pg/cloudnative-pg/tests"
 	clusterasserts "github.com/cloudnative-pg/cloudnative-pg/tests/internal/asserts/cluster"
@@ -82,6 +84,8 @@ var _ = Describe("Operator mTLS authentication", Label(tests.LabelSecurity), fun
 			By("confirming the authenticated pgcontroldata endpoint rejects unauthenticated access", func() {
 				_, err := proxy.RetrievePgControlDataFromInstance(env.Ctx, env.Interface, pod, tlsEnabled)
 				Expect(err).To(HaveOccurred())
+				Expect(apierrors.IsUnauthorized(err)).To(BeTrue(),
+					"expected a 401 from the operator-auth middleware, got: %v", err)
 			})
 		})
 	}, NodeTimeout(testTimeouts[timeouts.ClusterIsReady]))

--- a/tests/utils/proxy/proxy.go
+++ b/tests/utils/proxy/proxy.go
@@ -87,3 +87,14 @@ func RetrievePgStatusFromInstance(
 	body, err := runProxyRequest(ctx, kubeInterface, &pod, tlsEnabled, url.PathPgStatus, int(url.StatusPort))
 	return string(body), err
 }
+
+// RetrievePgControlDataFromInstance makes a GET request to the pgcontroldata endpoint on a
+// PostgreSQL instance pod via the Kubernetes API server proxy.
+func RetrievePgControlDataFromInstance(
+	ctx context.Context,
+	kubeInterface kubernetes.Interface,
+	pod corev1.Pod,
+	tlsEnabled bool,
+) ([]byte, error) {
+	return runProxyRequest(ctx, kubeInterface, &pod, tlsEnabled, url.PathPGControlData, int(url.StatusPort))
+}


### PR DESCRIPTION
The instance manager's remote webserver previously had no caller authentication, meaning any process with access to the pod network could trigger backups, instance manager upgrades, or WAL archival operations.

The operator now generates an in-memory ECDSA P-256 client certificate on startup and reconciles its SHA-256 public key fingerprint into the cluster status. The instance manager reads the expected fingerprint from its cached cluster object and rejects requests to sensitive endpoints that do not present a matching certificate.

Closes #10941
