### PR TITLE
chore: enable OCI artifact type for attestation manifests

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -96,7 +96,7 @@ target "default" {
   }
 
   output = [
-    "type=image,registry.insecure=${insecure}",
+    "type=image,registry.insecure=${insecure},oci-mediatypes=true,oci-artifact=true",
   ]
 
   attest = [


### PR DESCRIPTION
BuildKit's default image exporter does not set `artifactType` or the OCI 1.1 Referrers `subject` backlink on attestation manifests. Setting `oci-artifact=true` adds both, so SBOM and provenance attestations become discoverable through the OCI Referrers API.

`oci-mediatypes=true` is redundant (BuildKit already defaults it to true when pushing to a registry, which is why the top-level index has been `application/vnd.oci.image.index.v1+json` for a while) but kept for clarity.

GUAC is mentioned in the linked issue, but it has a separate bug with multi-arch images that include attestations and will not pick up the change on its own. This PR makes the manifests Referrers-compliant; GUAC discovery needs a fix upstream.

Refs #10600