### PR TITLE
fix(scheduledbackup): adopt existing Backup instead of looping on AlreadyExists

### DIFF
--- a/api/v1/scheduledbackup_funcs.go
+++ b/api/v1/scheduledbackup_funcs.go
@@ -20,6 +20,10 @@ SPDX-License-Identifier: Apache-2.0
 package v1
 
 import (
+	"fmt"
+	"time"
+
+	pgTime "github.com/cloudnative-pg/machinery/pkg/postgres/time"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/cloudnative-pg/cloudnative-pg/internal/configuration"
@@ -62,6 +66,14 @@ func (scheduledBackup *ScheduledBackup) GetSchedule() string {
 // GetStatus gets the status that the caller may update
 func (scheduledBackup *ScheduledBackup) GetStatus() *ScheduledBackupStatus {
 	return &scheduledBackup.Status
+}
+
+// BackupName returns the deterministic name of the Backup that this
+// ScheduledBackup creates for an iteration scheduled at the given time.
+// The name is unique per (ScheduledBackup, scheduledTime) pair, which is
+// what makes the controller idempotent against retries.
+func (scheduledBackup *ScheduledBackup) BackupName(scheduledTime time.Time) string {
+	return fmt.Sprintf("%s-%s", scheduledBackup.Name, pgTime.ToCompactISO8601(scheduledTime))
 }
 
 // CreateBackup creates a backup from this scheduled backup

--- a/api/v1/scheduledbackup_funcs.go
+++ b/api/v1/scheduledbackup_funcs.go
@@ -70,8 +70,8 @@ func (scheduledBackup *ScheduledBackup) GetStatus() *ScheduledBackupStatus {
 
 // BackupName returns the deterministic name of the Backup that this
 // ScheduledBackup creates for an iteration scheduled at the given time.
-// The name is unique per (ScheduledBackup, scheduledTime) pair, which is
-// what makes the controller idempotent against retries.
+// The name is unique per (ScheduledBackup, scheduledTime) pair at second
+// resolution, which is what makes the controller idempotent against retries.
 func (scheduledBackup *ScheduledBackup) BackupName(scheduledTime time.Time) string {
 	return fmt.Sprintf("%s-%s", scheduledBackup.Name, pgTime.ToCompactISO8601(scheduledTime))
 }

--- a/internal/controller/scheduledbackup_controller.go
+++ b/internal/controller/scheduledbackup_controller.go
@@ -270,17 +270,20 @@ func createBackup(
 
 	contextLogger.Info("Creating backup", "backupName", backup.Name)
 	if err := cli.Create(ctx, backup); err != nil {
-		if apierrs.IsConflict(err) {
-			// Retry later, the cache is stale
-			contextLogger.Debug("Conflict while creating backup", "error", err)
-			return ctrl.Result{}, nil
+		if apierrs.IsAlreadyExists(err) {
+			// A Backup with this deterministic name already exists. This can happen
+			// when a previous reconcile persisted the Backup but the subsequent
+			// status patch did not land (lost response or transient error), so
+			// LastCheckTime never advanced. Treat as a no-op success and proceed
+			// to update the status; the next reconcile will compute a new schedule.
+			contextLogger.Debug("Backup already exists, treating as no-op", "error", err)
+		} else {
+			contextLogger.Error(
+				err, "Error while creating backup object",
+				"backupName", backup.GetName())
+			event.Event(scheduledBackup, "Warning", "BackupCreation", "Error while creating backup object")
+			return ctrl.Result{}, err
 		}
-
-		contextLogger.Error(
-			err, "Error while creating backup object",
-			"backupName", backup.GetName())
-		event.Event(scheduledBackup, "Warning", "BackupCreation", "Error while creating backup object")
-		return ctrl.Result{}, err
 	}
 
 	// Ok, now update the latest check to now

--- a/internal/controller/scheduledbackup_controller.go
+++ b/internal/controller/scheduledbackup_controller.go
@@ -27,7 +27,6 @@ import (
 	"time"
 
 	"github.com/cloudnative-pg/machinery/pkg/log"
-	pgTime "github.com/cloudnative-pg/machinery/pkg/postgres/time"
 	"github.com/robfig/cron"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -186,6 +185,26 @@ func ReconcileScheduledBackup(
 	}
 
 	if scheduledBackup.Status.LastCheckTime == nil && scheduledBackup.IsImmediate() {
+		// Operator-restart guard: if a previous reconcile already created the
+		// immediate Backup but did not land the status patch, time.Now() on
+		// retry differs from the first attempt, so a name-based check would
+		// miss the orphan. List by parent + immediate label to catch any
+		// existing immediate Backup regardless of its scheduled-time suffix.
+		var existingImmediate apiv1.BackupList
+		if err := cli.List(ctx, &existingImmediate,
+			client.InNamespace(scheduledBackup.Namespace),
+			client.MatchingLabels{
+				utils.ParentScheduledBackupLabelName: scheduledBackup.GetName(),
+				utils.ImmediateBackupLabelName:       "true",
+			},
+		); err != nil {
+			return ctrl.Result{}, err
+		}
+		if len(existingImmediate.Items) > 0 {
+			adopted := existingImmediate.Items[0].CreationTimestamp.Time
+			return advanceScheduledBackupStatus(ctx, event, cli, scheduledBackup, adopted, now, schedule)
+		}
+
 		// we populate the status (lastCheckTime...) by following the same rules of the scheduled backup
 		event.Eventf(scheduledBackup, "Normal", "BackupSchedule", "Scheduled immediate backup now: %v", now)
 		return createBackup(ctx, event, cli, scheduledBackup, now, now, schedule, true)
@@ -224,10 +243,9 @@ func ReconcileScheduledBackup(
 	// look it up directly. If it already exists, a previous reconcile created
 	// it but did not land the status patch — adopt that observation and advance
 	// the status. Otherwise, create the Backup.
-	expectedName := fmt.Sprintf("%s-%s", scheduledBackup.GetName(), pgTime.ToCompactISO8601(nextTime))
 	var existing apiv1.Backup
 	switch err := cli.Get(ctx, types.NamespacedName{
-		Name:      expectedName,
+		Name:      scheduledBackup.BackupName(nextTime),
 		Namespace: scheduledBackup.Namespace,
 	}, &existing); {
 	case apierrs.IsNotFound(err):
@@ -253,8 +271,7 @@ func createBackup(
 	contextLogger := log.FromContext(ctx)
 
 	// Deterministic name so retries do not produce duplicates.
-	name := fmt.Sprintf("%s-%s", scheduledBackup.GetName(), pgTime.ToCompactISO8601(backupTime))
-	backup := scheduledBackup.CreateBackup(name)
+	backup := scheduledBackup.CreateBackup(scheduledBackup.BackupName(backupTime))
 	metadata := &backup.ObjectMeta
 	if metadata.Labels == nil {
 		metadata.Labels = make(map[string]string)

--- a/internal/controller/scheduledbackup_controller.go
+++ b/internal/controller/scheduledbackup_controller.go
@@ -219,7 +219,24 @@ func ReconcileScheduledBackup(
 		return ctrl.Result{RequeueAfter: nextTime.Sub(now)}, nil
 	}
 
-	return createBackup(ctx, event, cli, scheduledBackup, nextTime, now, schedule, false)
+	// Observe the apiserver state for this iteration before acting. The Backup
+	// name is deterministic (<sb-name>-<compactISO8601(nextTime)>), so we can
+	// look it up directly. If it already exists, a previous reconcile created
+	// it but did not land the status patch — adopt that observation and advance
+	// the status. Otherwise, create the Backup.
+	expectedName := fmt.Sprintf("%s-%s", scheduledBackup.GetName(), pgTime.ToCompactISO8601(nextTime))
+	var existing apiv1.Backup
+	switch err := cli.Get(ctx, types.NamespacedName{
+		Name:      expectedName,
+		Namespace: scheduledBackup.Namespace,
+	}, &existing); {
+	case apierrs.IsNotFound(err):
+		return createBackup(ctx, event, cli, scheduledBackup, nextTime, now, schedule, false)
+	case err != nil:
+		return ctrl.Result{}, err
+	default:
+		return advanceScheduledBackupStatus(ctx, event, cli, scheduledBackup, nextTime, now, schedule)
+	}
 }
 
 // createBackup creates a scheduled backup for a backuptime, updating the ScheduledBackup accordingly
@@ -235,11 +252,7 @@ func createBackup(
 ) (ctrl.Result, error) {
 	contextLogger := log.FromContext(ctx)
 
-	origScheduled := scheduledBackup.DeepCopy()
-
-	// So we have no backup running, let's create a backup.
-	// Let's have deterministic names to avoid creating the job two
-	// times
+	// Deterministic name so retries do not produce duplicates.
 	name := fmt.Sprintf("%s-%s", scheduledBackup.GetName(), pgTime.ToCompactISO8601(backupTime))
 	backup := scheduledBackup.CreateBackup(name)
 	metadata := &backup.ObjectMeta
@@ -271,43 +284,53 @@ func createBackup(
 	contextLogger.Info("Creating backup", "backupName", backup.Name)
 	if err := cli.Create(ctx, backup); err != nil {
 		if apierrs.IsAlreadyExists(err) {
-			// A Backup with this deterministic name already exists. This can happen
-			// when a previous reconcile persisted the Backup but the subsequent
-			// status patch did not land (lost response or transient error), so
-			// LastCheckTime never advanced. Treat as a no-op success and proceed
-			// to update the status; the next reconcile will compute a new schedule.
-			contextLogger.Debug("Backup already exists, treating as no-op", "error", err)
-		} else {
-			contextLogger.Error(
-				err, "Error while creating backup object",
-				"backupName", backup.GetName())
-			event.Event(scheduledBackup, "Warning", "BackupCreation", "Error while creating backup object")
-			return ctrl.Result{}, err
+			// Cache was stale at the Get-first observation in ReconcileScheduledBackup
+			// (or another reconcile won the race). Requeue so the next pass observes
+			// the existing Backup and advances the status from there.
+			contextLogger.Debug("Backup already exists, requeuing for re-observation", "error", err)
+			return ctrl.Result{RequeueAfter: time.Second}, nil
 		}
+		contextLogger.Error(
+			err, "Error while creating backup object",
+			"backupName", backup.GetName())
+		event.Event(scheduledBackup, "Warning", "BackupCreation", "Error while creating backup object")
+		return ctrl.Result{}, err
 	}
 
-	// Ok, now update the latest check to now
-	scheduledBackup.Status.LastCheckTime = &metav1.Time{
-		Time: now,
-	}
-	scheduledBackup.Status.LastScheduleTime = &metav1.Time{
-		Time: backupTime,
-	}
+	return advanceScheduledBackupStatus(ctx, event, cli, scheduledBackup, backupTime, now, schedule)
+}
+
+// advanceScheduledBackupStatus records that a Backup for backupTime exists in
+// the apiserver and schedules the next iteration. It is the single point that
+// patches the ScheduledBackup status; both the Get-first observation path and
+// the createBackup path funnel through here so the invariants stay aligned.
+func advanceScheduledBackupStatus(
+	ctx context.Context,
+	event record.EventRecorder,
+	cli client.Client,
+	scheduledBackup *apiv1.ScheduledBackup,
+	backupTime time.Time,
+	now time.Time,
+	schedule cron.Schedule,
+) (ctrl.Result, error) {
+	contextLogger := log.FromContext(ctx)
+
+	origScheduled := scheduledBackup.DeepCopy()
+	scheduledBackup.Status.LastCheckTime = &metav1.Time{Time: now}
+	scheduledBackup.Status.LastScheduleTime = &metav1.Time{Time: backupTime}
 	nextBackupTime := schedule.Next(now)
-	scheduledBackup.Status.NextScheduleTime = &metav1.Time{
-		Time: nextBackupTime,
-	}
+	scheduledBackup.Status.NextScheduleTime = &metav1.Time{Time: nextBackupTime}
 
 	if err := cli.Status().Patch(ctx, scheduledBackup, client.MergeFrom(origScheduled)); err != nil {
 		if apierrs.IsConflict(err) {
-			// Retry later, the cache is stale
-			contextLogger.Debug("Conflict while updating scheduled backup", "error", err)
-			return ctrl.Result{}, nil
+			// Stale view of the resource; let the next reconcile re-read and retry.
+			contextLogger.Debug("Conflict while updating scheduled backup status", "error", err)
+			return ctrl.Result{RequeueAfter: time.Second}, nil
 		}
 		return ctrl.Result{}, err
 	}
 
-	contextLogger.Info("Next backup schedule", "next", backupTime)
+	contextLogger.Info("Next backup schedule", "next", nextBackupTime)
 	event.Eventf(scheduledBackup, "Normal", "BackupSchedule", "Next backup scheduled by %v", nextBackupTime)
 	return ctrl.Result{RequeueAfter: nextBackupTime.Sub(now)}, nil
 }

--- a/internal/controller/scheduledbackup_controller.go
+++ b/internal/controller/scheduledbackup_controller.go
@@ -119,14 +119,12 @@ func (r *ScheduledBackupReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		}
 	}
 
-	return ReconcileScheduledBackup(ctx, r.Recorder, r.Client, &scheduledBackup)
+	return r.reconcileScheduledBackup(ctx, &scheduledBackup)
 }
 
-// ReconcileScheduledBackup is the main reconciliation logic for a scheduled backup
-func ReconcileScheduledBackup(
+// reconcileScheduledBackup is the main reconciliation logic for a scheduled backup
+func (r *ScheduledBackupReconciler) reconcileScheduledBackup(
 	ctx context.Context,
-	event record.EventRecorder,
-	cli client.Client,
 	scheduledBackup *apiv1.ScheduledBackup,
 ) (ctrl.Result, error) {
 	contextLogger := log.FromContext(ctx)
@@ -145,11 +143,11 @@ func ReconcileScheduledBackup(
 	isVolumeSnapshot := scheduledBackup.Spec.Method == apiv1.BackupMethodVolumeSnapshot
 	if isVolumeSnapshot && scheduledBackup.Status.LastCheckTime == nil && scheduledBackup.IsImmediate() {
 		var cluster apiv1.Cluster
-		if err := cli.Get(ctx, client.ObjectKey{
+		if err := r.Get(ctx, client.ObjectKey{
 			Namespace: scheduledBackup.Namespace,
 			Name:      scheduledBackup.Spec.Cluster.Name,
 		}, &cluster); err != nil {
-			event.Eventf(
+			r.Recorder.Eventf(
 				scheduledBackup,
 				"Normal",
 				"InvalidCluster",
@@ -161,7 +159,7 @@ func ReconcileScheduledBackup(
 		}
 
 		if cluster.Status.Phase != apiv1.PhaseHealthy {
-			event.Eventf(
+			r.Recorder.Eventf(
 				scheduledBackup,
 				"Warning",
 				"ClusterNotHealthy",
@@ -176,7 +174,7 @@ func ReconcileScheduledBackup(
 	if schedule.Next(now).IsZero() {
 		// No time satisfying the schedule have been found.
 		// We cannot proceed reconciling it.
-		event.Eventf(
+		r.Recorder.Eventf(
 			scheduledBackup,
 			"Warning",
 			"NoSchedule",
@@ -191,7 +189,7 @@ func ReconcileScheduledBackup(
 		// miss the orphan. List by parent + immediate label to catch any
 		// existing immediate Backup regardless of its scheduled-time suffix.
 		var existingImmediate apiv1.BackupList
-		if err := cli.List(ctx, &existingImmediate,
+		if err := r.List(ctx, &existingImmediate,
 			client.InNamespace(scheduledBackup.Namespace),
 			client.MatchingLabels{
 				utils.ParentScheduledBackupLabelName: scheduledBackup.GetName(),
@@ -202,12 +200,12 @@ func ReconcileScheduledBackup(
 		}
 		if len(existingImmediate.Items) > 0 {
 			adopted := existingImmediate.Items[0].CreationTimestamp.Time
-			return advanceScheduledBackupStatus(ctx, event, cli, scheduledBackup, adopted, now, schedule)
+			return r.advanceScheduledBackupStatus(ctx, scheduledBackup, adopted, now, schedule)
 		}
 
 		// we populate the status (lastCheckTime...) by following the same rules of the scheduled backup
-		event.Eventf(scheduledBackup, "Normal", "BackupSchedule", "Scheduled immediate backup now: %v", now)
-		return createBackup(ctx, event, cli, scheduledBackup, now, now, schedule, true)
+		r.Recorder.Eventf(scheduledBackup, "Normal", "BackupSchedule", "Scheduled immediate backup now: %v", now)
+		return r.createBackup(ctx, scheduledBackup, now, now, schedule, true)
 	}
 
 	if scheduledBackup.Status.LastCheckTime == nil {
@@ -218,14 +216,14 @@ func ReconcileScheduledBackup(
 		scheduledBackup.Status.LastCheckTime = &metav1.Time{
 			Time: now,
 		}
-		err := cli.Status().Patch(ctx, scheduledBackup, client.MergeFrom(origScheduled))
+		err := r.Status().Patch(ctx, scheduledBackup, client.MergeFrom(origScheduled))
 		if err != nil {
 			return ctrl.Result{}, err
 		}
 
 		nextTime := schedule.Next(now)
 		contextLogger.Info("Next backup schedule", "next", nextTime)
-		event.Eventf(scheduledBackup, "Normal", "BackupSchedule", "Scheduled first backup by %v", nextTime)
+		r.Recorder.Eventf(scheduledBackup, "Normal", "BackupSchedule", "Scheduled first backup by %v", nextTime)
 		return ctrl.Result{RequeueAfter: nextTime.Sub(now)}, nil
 	}
 
@@ -244,24 +242,22 @@ func ReconcileScheduledBackup(
 	// it but did not land the status patch — adopt that observation and advance
 	// the status. Otherwise, create the Backup.
 	var existing apiv1.Backup
-	switch err := cli.Get(ctx, types.NamespacedName{
+	switch err := r.Get(ctx, types.NamespacedName{
 		Name:      scheduledBackup.BackupName(nextTime),
 		Namespace: scheduledBackup.Namespace,
 	}, &existing); {
 	case apierrs.IsNotFound(err):
-		return createBackup(ctx, event, cli, scheduledBackup, nextTime, now, schedule, false)
+		return r.createBackup(ctx, scheduledBackup, nextTime, now, schedule, false)
 	case err != nil:
 		return ctrl.Result{}, err
 	default:
-		return advanceScheduledBackupStatus(ctx, event, cli, scheduledBackup, nextTime, now, schedule)
+		return r.advanceScheduledBackupStatus(ctx, scheduledBackup, nextTime, now, schedule)
 	}
 }
 
 // createBackup creates a scheduled backup for a backuptime, updating the ScheduledBackup accordingly
-func createBackup(
+func (r *ScheduledBackupReconciler) createBackup(
 	ctx context.Context,
-	event record.EventRecorder,
-	cli client.Client,
 	scheduledBackup *apiv1.ScheduledBackup,
 	backupTime time.Time,
 	now time.Time,
@@ -283,7 +279,7 @@ func createBackup(
 	switch scheduledBackup.Spec.BackupOwnerReference {
 	case "cluster":
 		var cluster apiv1.Cluster
-		if err := cli.Get(
+		if err := r.Get(
 			ctx,
 			types.NamespacedName{Name: scheduledBackup.Spec.Cluster.Name, Namespace: scheduledBackup.Namespace},
 			&cluster,
@@ -299,9 +295,9 @@ func createBackup(
 	}
 
 	contextLogger.Info("Creating backup", "backupName", backup.Name)
-	if err := cli.Create(ctx, backup); err != nil {
+	if err := r.Create(ctx, backup); err != nil {
 		if apierrs.IsAlreadyExists(err) {
-			// Cache was stale at the Get-first observation in ReconcileScheduledBackup
+			// Cache was stale at the Get-first observation in reconcileScheduledBackup
 			// (or another reconcile won the race). Requeue so the next pass observes
 			// the existing Backup and advances the status from there.
 			contextLogger.Debug("Backup already exists, requeuing for re-observation", "error", err)
@@ -310,21 +306,19 @@ func createBackup(
 		contextLogger.Error(
 			err, "Error while creating backup object",
 			"backupName", backup.GetName())
-		event.Event(scheduledBackup, "Warning", "BackupCreation", "Error while creating backup object")
+		r.Recorder.Event(scheduledBackup, "Warning", "BackupCreation", "Error while creating backup object")
 		return ctrl.Result{}, err
 	}
 
-	return advanceScheduledBackupStatus(ctx, event, cli, scheduledBackup, backupTime, now, schedule)
+	return r.advanceScheduledBackupStatus(ctx, scheduledBackup, backupTime, now, schedule)
 }
 
 // advanceScheduledBackupStatus records that a Backup for backupTime exists in
 // the apiserver and schedules the next iteration. It is the single point that
 // patches the ScheduledBackup status; both the Get-first observation path and
 // the createBackup path funnel through here so the invariants stay aligned.
-func advanceScheduledBackupStatus(
+func (r *ScheduledBackupReconciler) advanceScheduledBackupStatus(
 	ctx context.Context,
-	event record.EventRecorder,
-	cli client.Client,
 	scheduledBackup *apiv1.ScheduledBackup,
 	backupTime time.Time,
 	now time.Time,
@@ -338,7 +332,7 @@ func advanceScheduledBackupStatus(
 	nextBackupTime := schedule.Next(now)
 	scheduledBackup.Status.NextScheduleTime = &metav1.Time{Time: nextBackupTime}
 
-	if err := cli.Status().Patch(ctx, scheduledBackup, client.MergeFrom(origScheduled)); err != nil {
+	if err := r.Status().Patch(ctx, scheduledBackup, client.MergeFrom(origScheduled)); err != nil {
 		if apierrs.IsConflict(err) {
 			// Stale view of the resource; let the next reconcile re-read and retry.
 			contextLogger.Debug("Conflict while updating scheduled backup status", "error", err)
@@ -348,7 +342,7 @@ func advanceScheduledBackupStatus(
 	}
 
 	contextLogger.Info("Next backup schedule", "next", nextBackupTime)
-	event.Eventf(scheduledBackup, "Normal", "BackupSchedule", "Next backup scheduled by %v", nextBackupTime)
+	r.Recorder.Eventf(scheduledBackup, "Normal", "BackupSchedule", "Next backup scheduled by %v", nextBackupTime)
 	return ctrl.Result{RequeueAfter: nextBackupTime.Sub(now)}, nil
 }
 

--- a/internal/controller/scheduledbackup_controller.go
+++ b/internal/controller/scheduledbackup_controller.go
@@ -238,9 +238,9 @@ func (r *ScheduledBackupReconciler) reconcileScheduledBackup(
 
 	// Observe the apiserver state for this iteration before acting. The Backup
 	// name is deterministic (<sb-name>-<compactISO8601(nextTime)>), so we can
-	// look it up directly. If it already exists, a previous reconcile created
-	// it but did not land the status patch — adopt that observation and advance
-	// the status. Otherwise, create the Backup.
+	// look it up directly. If it already exists and carries our parent label,
+	// a previous reconcile created it but did not land the status patch: adopt
+	// that observation and advance the status. Otherwise, create the Backup.
 	var existing apiv1.Backup
 	switch err := r.Get(ctx, types.NamespacedName{
 		Name:      scheduledBackup.BackupName(nextTime),
@@ -251,8 +251,47 @@ func (r *ScheduledBackupReconciler) reconcileScheduledBackup(
 	case err != nil:
 		return ctrl.Result{}, err
 	default:
+		if existing.Labels[utils.ParentScheduledBackupLabelName] != scheduledBackup.GetName() {
+			return r.skipIterationOnNameCollision(ctx, scheduledBackup, &existing, nextTime, now, schedule.Next(now))
+		}
 		return r.advanceScheduledBackupStatus(ctx, scheduledBackup, nextTime, now, schedule)
 	}
+}
+
+// skipIterationOnNameCollision handles a Backup that occupies this iteration's
+// deterministic name but was not created by this ScheduledBackup. Adopting it
+// would advance the schedule over a backup we did not run; creating ours would
+// loop on AlreadyExists. We skip the colliding slot and resume at the next
+// slot from now (cron semantics: missed slots are not retroactively run).
+// LastScheduleTime is left untouched so the user can see we did not run this
+// iteration. Recovery (deleting the conflicting Backup, retroactively running
+// the missed backup) is left to the operator.
+func (r *ScheduledBackupReconciler) skipIterationOnNameCollision(
+	ctx context.Context,
+	scheduledBackup *apiv1.ScheduledBackup,
+	existing *apiv1.Backup,
+	iteration time.Time,
+	now time.Time,
+	nextBackupTime time.Time,
+) (ctrl.Result, error) {
+	contextLogger := log.FromContext(ctx)
+
+	contextLogger.Warning("Backup name collision; not adopting",
+		"backupName", existing.Name, "iteration", iteration)
+	r.Recorder.Eventf(scheduledBackup, "Warning", "BackupAdoptionRefused",
+		"Backup %q exists but is not owned by this ScheduledBackup; skipping iteration %s",
+		existing.Name, iteration.Format(time.RFC3339))
+
+	origScheduled := scheduledBackup.DeepCopy()
+	scheduledBackup.Status.LastCheckTime = &metav1.Time{Time: now}
+	scheduledBackup.Status.NextScheduleTime = &metav1.Time{Time: nextBackupTime}
+	if err := r.Status().Patch(ctx, scheduledBackup, client.MergeFrom(origScheduled)); err != nil {
+		if apierrs.IsConflict(err) {
+			return ctrl.Result{RequeueAfter: time.Second}, nil
+		}
+		return ctrl.Result{}, err
+	}
+	return ctrl.Result{RequeueAfter: nextBackupTime.Sub(now)}, nil
 }
 
 // createBackup creates a scheduled backup for a backuptime, updating the ScheduledBackup accordingly
@@ -314,9 +353,9 @@ func (r *ScheduledBackupReconciler) createBackup(
 }
 
 // advanceScheduledBackupStatus records that a Backup for backupTime exists in
-// the apiserver and schedules the next iteration. It is the single point that
-// patches the ScheduledBackup status; both the Get-first observation path and
-// the createBackup path funnel through here so the invariants stay aligned.
+// the apiserver and requeues for the next iteration. Both the Get-first
+// observation path and the createBackup path funnel through here so the
+// invariants stay aligned.
 func (r *ScheduledBackupReconciler) advanceScheduledBackupStatus(
 	ctx context.Context,
 	scheduledBackup *apiv1.ScheduledBackup,

--- a/internal/controller/scheduledbackup_controller.go
+++ b/internal/controller/scheduledbackup_controller.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"strconv"
 	"time"
 
@@ -199,8 +200,14 @@ func (r *ScheduledBackupReconciler) reconcileScheduledBackup(
 			return ctrl.Result{}, err
 		}
 		if len(existingImmediate.Items) > 0 {
+			// Upgrade from a pre-fix operator may have created several immediate
+			// Backups for the same SB (one per failed status patch). Pick the
+			// oldest so LastScheduleTime is stable across reconciles.
+			sort.Slice(existingImmediate.Items, func(i, j int) bool {
+				return existingImmediate.Items[i].CreationTimestamp.Before(&existingImmediate.Items[j].CreationTimestamp)
+			})
 			adopted := existingImmediate.Items[0].CreationTimestamp.Time
-			return r.advanceScheduledBackupStatus(ctx, scheduledBackup, adopted, now, schedule)
+			return r.advanceScheduledBackupStatus(ctx, scheduledBackup, adopted, now, schedule.Next(now))
 		}
 
 		// we populate the status (lastCheckTime...) by following the same rules of the scheduled backup
@@ -254,7 +261,7 @@ func (r *ScheduledBackupReconciler) reconcileScheduledBackup(
 		if existing.Labels[utils.ParentScheduledBackupLabelName] != scheduledBackup.GetName() {
 			return r.skipIterationOnNameCollision(ctx, scheduledBackup, &existing, nextTime, now, schedule.Next(now))
 		}
-		return r.advanceScheduledBackupStatus(ctx, scheduledBackup, nextTime, now, schedule)
+		return r.advanceScheduledBackupStatus(ctx, scheduledBackup, nextTime, now, schedule.Next(now))
 	}
 }
 
@@ -349,7 +356,7 @@ func (r *ScheduledBackupReconciler) createBackup(
 		return ctrl.Result{}, err
 	}
 
-	return r.advanceScheduledBackupStatus(ctx, scheduledBackup, backupTime, now, schedule)
+	return r.advanceScheduledBackupStatus(ctx, scheduledBackup, backupTime, now, schedule.Next(now))
 }
 
 // advanceScheduledBackupStatus records that a Backup for backupTime exists in
@@ -361,14 +368,13 @@ func (r *ScheduledBackupReconciler) advanceScheduledBackupStatus(
 	scheduledBackup *apiv1.ScheduledBackup,
 	backupTime time.Time,
 	now time.Time,
-	schedule cron.Schedule,
+	nextBackupTime time.Time,
 ) (ctrl.Result, error) {
 	contextLogger := log.FromContext(ctx)
 
 	origScheduled := scheduledBackup.DeepCopy()
 	scheduledBackup.Status.LastCheckTime = &metav1.Time{Time: now}
 	scheduledBackup.Status.LastScheduleTime = &metav1.Time{Time: backupTime}
-	nextBackupTime := schedule.Next(now)
 	scheduledBackup.Status.NextScheduleTime = &metav1.Time{Time: nextBackupTime}
 
 	if err := r.Status().Patch(ctx, scheduledBackup, client.MergeFrom(origScheduled)); err != nil {

--- a/internal/controller/scheduledbackup_controller_test.go
+++ b/internal/controller/scheduledbackup_controller_test.go
@@ -21,19 +21,22 @@ package controller
 
 import (
 	"context"
-	"fmt"
 	"time"
 
-	pgTime "github.com/cloudnative-pg/machinery/pkg/postgres/time"
 	"github.com/robfig/cron"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	schemeBuilder "github.com/cloudnative-pg/cloudnative-pg/internal/scheme"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -88,7 +91,7 @@ var _ = Describe("scheduledbackup createBackup", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(result.RequeueAfter).To(BeNumerically(">", time.Duration(0)))
 
-		backupName := fmt.Sprintf("%s-%s", sb.Name, pgTime.ToCompactISO8601(backupTime))
+		backupName := sb.BackupName(backupTime)
 		var backup apiv1.Backup
 		Expect(cli.Get(ctx, types.NamespacedName{Name: backupName, Namespace: ns}, &backup)).To(Succeed())
 
@@ -107,7 +110,7 @@ var _ = Describe("scheduledbackup createBackup", func() {
 		// only when the cache was stale at Get time but the Backup is already
 		// in the apiserver — a transient race. We requeue so the next reconcile
 		// observes the existing Backup and advances the status from there.
-		backupName := fmt.Sprintf("%s-%s", sb.Name, pgTime.ToCompactISO8601(backupTime))
+		backupName := sb.BackupName(backupTime)
 		existing := &apiv1.Backup{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      backupName,
@@ -190,7 +193,7 @@ var _ = Describe("scheduledbackup ReconcileScheduledBackup", func() {
 			schedule, err := cron.Parse(sb.Spec.Schedule)
 			Expect(err).ToNot(HaveOccurred())
 			expectedBackupTime := schedule.Next(originalLastCheck)
-			expectedName := fmt.Sprintf("%s-%s", sb.Name, pgTime.ToCompactISO8601(expectedBackupTime))
+			expectedName := sb.BackupName(expectedBackupTime)
 
 			existing := &apiv1.Backup{
 				ObjectMeta: metav1.ObjectMeta{
@@ -224,4 +227,112 @@ var _ = Describe("scheduledbackup ReconcileScheduledBackup", func() {
 			Expect(stored.Status.LastScheduleTime).ToNot(BeNil())
 			Expect(stored.Status.LastScheduleTime.Time).To(BeTemporally("==", expectedBackupTime))
 		})
+})
+
+var _ = Describe("scheduledbackup ReconcileScheduledBackup immediate", func() {
+	It("adopts an existing immediate Backup instead of creating a duplicate", func(ctx context.Context) {
+		// Operator-restart corner case: a previous reconcile created the
+		// immediate Backup but did not land the status patch, so
+		// LastCheckTime is still nil. On retry, time.Now() differs from the
+		// previous attempt, so the deterministic name is different. Without
+		// observing what's already there, the controller would create a
+		// second immediate Backup. This test pins that the existing
+		// immediate Backup is adopted instead.
+		cli := newScheduledBackupTestClient()
+		ns := newFakeNamespace(cli)
+
+		sb := &apiv1.ScheduledBackup{
+			ObjectMeta: metav1.ObjectMeta{Name: "sb-test", Namespace: ns},
+			Spec: apiv1.ScheduledBackupSpec{
+				Schedule:  "0 0 0 * * *",
+				Cluster:   apiv1.LocalObjectReference{Name: "cluster-x"},
+				Immediate: ptr.To(true),
+			},
+		}
+		Expect(cli.Create(ctx, sb)).To(Succeed())
+
+		// Pre-create an immediate Backup as if a previous reconcile had
+		// created it. The compactISO8601 time intentionally differs from
+		// what time.Now() would produce now, to mimic the restart-after-Create
+		// scenario.
+		existing := &apiv1.Backup{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      sb.BackupName(time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)),
+				Namespace: ns,
+				Labels: map[string]string{
+					ParentScheduledBackupLabelName: sb.Name,
+					utils.ImmediateBackupLabelName: "true",
+					utils.ClusterLabelName:         sb.Spec.Cluster.Name,
+				},
+			},
+			Spec: apiv1.BackupSpec{Cluster: sb.Spec.Cluster},
+		}
+		Expect(cli.Create(ctx, existing)).To(Succeed())
+
+		recorder := record.NewFakeRecorder(10)
+		result, err := ReconcileScheduledBackup(ctx, recorder, cli, sb)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result.RequeueAfter).To(BeNumerically(">", time.Duration(0)))
+
+		// Only the pre-existing Backup remains; the controller did not create a duplicate.
+		var backups apiv1.BackupList
+		Expect(cli.List(ctx, &backups, client.InNamespace(ns))).To(Succeed())
+		Expect(backups.Items).To(HaveLen(1))
+		Expect(backups.Items[0].Name).To(Equal(existing.Name))
+
+		var stored apiv1.ScheduledBackup
+		Expect(cli.Get(ctx, types.NamespacedName{Name: sb.Name, Namespace: ns}, &stored)).To(Succeed())
+		Expect(stored.Status.LastCheckTime).ToNot(BeNil())
+	})
+})
+
+var _ = Describe("scheduledbackup advanceScheduledBackupStatus", func() {
+	It("requeues without error when the status patch hits a Conflict", func(ctx context.Context) {
+		scheme := schemeBuilder.BuildWithAllKnownScheme()
+		cli := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithStatusSubresource(&apiv1.ScheduledBackup{}, &apiv1.Backup{}).
+			WithInterceptorFuncs(interceptor.Funcs{
+				SubResourcePatch: func(
+					_ context.Context,
+					_ client.Client,
+					subResourceName string,
+					obj client.Object,
+					_ client.Patch,
+					_ ...client.SubResourcePatchOption,
+				) error {
+					if subResourceName == "status" {
+						if _, ok := obj.(*apiv1.ScheduledBackup); ok {
+							return apierrs.NewConflict(
+								schema.GroupResource{Group: apiv1.SchemeGroupVersion.Group, Resource: "scheduledbackups"},
+								obj.GetName(),
+								nil,
+							)
+						}
+					}
+					return nil
+				},
+			}).
+			Build()
+		ns := newFakeNamespace(cli)
+
+		sb := &apiv1.ScheduledBackup{
+			ObjectMeta: metav1.ObjectMeta{Name: "sb-test", Namespace: ns},
+			Spec: apiv1.ScheduledBackupSpec{
+				Schedule: "0 0 0 * * *",
+				Cluster:  apiv1.LocalObjectReference{Name: "cluster-x"},
+			},
+		}
+		Expect(cli.Create(ctx, sb)).To(Succeed())
+
+		schedule, err := cron.Parse(sb.Spec.Schedule)
+		Expect(err).ToNot(HaveOccurred())
+		recorder := record.NewFakeRecorder(10)
+		now := time.Now()
+		backupTime := schedule.Next(now)
+
+		result, err := advanceScheduledBackupStatus(ctx, recorder, cli, sb, backupTime, now, schedule)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result.RequeueAfter).To(Equal(time.Second))
+	})
 })

--- a/internal/controller/scheduledbackup_controller_test.go
+++ b/internal/controller/scheduledbackup_controller_test.go
@@ -39,6 +39,14 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+func newScheduledBackupTestClient() client.Client {
+	scheme := schemeBuilder.BuildWithAllKnownScheme()
+	return fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&apiv1.ScheduledBackup{}, &apiv1.Backup{}).
+		Build()
+}
+
 var _ = Describe("scheduledbackup createBackup", func() {
 	var (
 		cli        client.Client
@@ -51,11 +59,7 @@ var _ = Describe("scheduledbackup createBackup", func() {
 	)
 
 	BeforeEach(func(ctx context.Context) {
-		scheme := schemeBuilder.BuildWithAllKnownScheme()
-		cli = fake.NewClientBuilder().
-			WithScheme(scheme).
-			WithStatusSubresource(&apiv1.ScheduledBackup{}, &apiv1.Backup{}).
-			Build()
+		cli = newScheduledBackupTestClient()
 		ns = newFakeNamespace(cli)
 
 		sb = &apiv1.ScheduledBackup{
@@ -79,7 +83,7 @@ var _ = Describe("scheduledbackup createBackup", func() {
 		now = time.Date(2026, 4, 18, 0, 0, 0, 0, time.UTC)
 	})
 
-	It("creates a backup and advances status when no backup exists", func(ctx context.Context) {
+	It("creates a backup and advances status", func(ctx context.Context) {
 		result, err := createBackup(ctx, recorder, cli, sb, backupTime, now, sched, false)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(result.RequeueAfter).To(BeNumerically(">", time.Duration(0)))
@@ -97,34 +101,127 @@ var _ = Describe("scheduledbackup createBackup", func() {
 		Expect(stored.Status.NextScheduleTime).ToNot(BeNil())
 	})
 
-	It("does not loop when a backup with the deterministic name already exists", func(ctx context.Context) {
-		// Reproduces issue #10562: a previous iteration persisted the Backup but
-		// its scheduled-backup status patch never landed (lost response or transient
-		// error), so LastCheckTime is still at its pre-creation value. The next
-		// reconcile recomputes the same deterministic backup name, so apiserver
-		// returns AlreadyExists. The controller must treat that as a no-op success
-		// and advance LastCheckTime, otherwise reconciliation loops forever.
+	It("requeues without advancing status when Create races with an existing backup", func(ctx context.Context) {
+		// In production, the up-front Get in ReconcileScheduledBackup catches a
+		// pre-existing Backup before reaching createBackup. This branch fires
+		// only when the cache was stale at Get time but the Backup is already
+		// in the apiserver — a transient race. We requeue so the next reconcile
+		// observes the existing Backup and advances the status from there.
 		backupName := fmt.Sprintf("%s-%s", sb.Name, pgTime.ToCompactISO8601(backupTime))
 		existing := &apiv1.Backup{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      backupName,
 				Namespace: ns,
 			},
-			Spec: apiv1.BackupSpec{
-				Cluster: sb.Spec.Cluster,
-			},
+			Spec: apiv1.BackupSpec{Cluster: sb.Spec.Cluster},
 		}
 		Expect(cli.Create(ctx, existing)).To(Succeed())
 
 		result, err := createBackup(ctx, recorder, cli, sb, backupTime, now, sched, false)
 		Expect(err).ToNot(HaveOccurred())
+		Expect(result.RequeueAfter).To(Equal(time.Second))
+
+		var stored apiv1.ScheduledBackup
+		Expect(cli.Get(ctx, types.NamespacedName{Name: sb.Name, Namespace: ns}, &stored)).To(Succeed())
+		Expect(stored.Status.LastCheckTime).To(BeNil())
+		Expect(stored.Status.LastScheduleTime).To(BeNil())
+	})
+})
+
+var _ = Describe("scheduledbackup ReconcileScheduledBackup", func() {
+	var (
+		cli      client.Client
+		ns       string
+		sb       *apiv1.ScheduledBackup
+		recorder *record.FakeRecorder
+	)
+
+	BeforeEach(func(ctx context.Context) {
+		cli = newScheduledBackupTestClient()
+		ns = newFakeNamespace(cli)
+
+		sb = &apiv1.ScheduledBackup{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "sb-test",
+				Namespace: ns,
+			},
+			Spec: apiv1.ScheduledBackupSpec{
+				Schedule: "0 0 0 * * *",
+				Cluster:  apiv1.LocalObjectReference{Name: "cluster-x"},
+			},
+			// Pre-populated status so we skip the first-time-init path. The
+			// schedule next-fire from this moment is in the past relative to
+			// time.Now(), so the reconciler proceeds to the Get-first/createBackup
+			// branch instead of waiting.
+			Status: apiv1.ScheduledBackupStatus{
+				LastCheckTime: &metav1.Time{Time: time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)},
+			},
+		}
+		Expect(cli.Create(ctx, sb)).To(Succeed())
+		Expect(cli.Status().Update(ctx, sb)).To(Succeed())
+
+		recorder = record.NewFakeRecorder(10)
+	})
+
+	It("creates a Backup and advances status when none exists for the iteration", func(ctx context.Context) {
+		originalLastCheck := sb.Status.LastCheckTime.Time
+
+		result, err := ReconcileScheduledBackup(ctx, recorder, cli, sb)
+		Expect(err).ToNot(HaveOccurred())
 		Expect(result.RequeueAfter).To(BeNumerically(">", time.Duration(0)))
+
+		var backups apiv1.BackupList
+		Expect(cli.List(ctx, &backups, client.InNamespace(ns))).To(Succeed())
+		Expect(backups.Items).To(HaveLen(1))
 
 		var stored apiv1.ScheduledBackup
 		Expect(cli.Get(ctx, types.NamespacedName{Name: sb.Name, Namespace: ns}, &stored)).To(Succeed())
 		Expect(stored.Status.LastCheckTime).ToNot(BeNil())
-		Expect(stored.Status.LastCheckTime.Time).To(BeTemporally("==", now))
-		Expect(stored.Status.LastScheduleTime).ToNot(BeNil())
-		Expect(stored.Status.LastScheduleTime.Time).To(BeTemporally("==", backupTime))
+		Expect(stored.Status.LastCheckTime.Time).To(BeTemporally(">", originalLastCheck))
 	})
+
+	It("adopts an already-existing Backup for the upcoming iteration and advances status (#10562)",
+		func(ctx context.Context) {
+			// Reproduces the #10562 stuck loop. Compute the deterministic name the
+			// reconciler will derive from the scheduled-iteration time and
+			// pre-create that Backup. The Get-first observation must adopt it and
+			// advance the status; no new Backup must be created.
+			originalLastCheck := sb.Status.LastCheckTime.Time
+			schedule, err := cron.Parse(sb.Spec.Schedule)
+			Expect(err).ToNot(HaveOccurred())
+			expectedBackupTime := schedule.Next(originalLastCheck)
+			expectedName := fmt.Sprintf("%s-%s", sb.Name, pgTime.ToCompactISO8601(expectedBackupTime))
+
+			existing := &apiv1.Backup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      expectedName,
+					Namespace: ns,
+					Labels: map[string]string{
+						ParentScheduledBackupLabelName: sb.Name,
+					},
+				},
+				Spec: apiv1.BackupSpec{Cluster: sb.Spec.Cluster},
+			}
+			Expect(cli.Create(ctx, existing)).To(Succeed())
+
+			result, err := ReconcileScheduledBackup(ctx, recorder, cli, sb)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.RequeueAfter).To(BeNumerically(">", time.Duration(0)))
+
+			// No additional Backup created.
+			var backups apiv1.BackupList
+			Expect(cli.List(ctx, &backups, client.InNamespace(ns))).To(Succeed())
+			Expect(backups.Items).To(HaveLen(1))
+			Expect(backups.Items[0].Name).To(Equal(expectedName))
+
+			// Status advanced: LastCheckTime moved past the original, and
+			// LastScheduleTime matches the deterministic backupTime of the
+			// observed Backup. This is what breaks the loop on the next pass.
+			var stored apiv1.ScheduledBackup
+			Expect(cli.Get(ctx, types.NamespacedName{Name: sb.Name, Namespace: ns}, &stored)).To(Succeed())
+			Expect(stored.Status.LastCheckTime).ToNot(BeNil())
+			Expect(stored.Status.LastCheckTime.Time).To(BeTemporally(">", originalLastCheck))
+			Expect(stored.Status.LastScheduleTime).ToNot(BeNil())
+			Expect(stored.Status.LastScheduleTime.Time).To(BeTemporally("==", expectedBackupTime))
+		})
 })

--- a/internal/controller/scheduledbackup_controller_test.go
+++ b/internal/controller/scheduledbackup_controller_test.go
@@ -1,0 +1,130 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	pgTime "github.com/cloudnative-pg/machinery/pkg/postgres/time"
+	"github.com/robfig/cron"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	schemeBuilder "github.com/cloudnative-pg/cloudnative-pg/internal/scheme"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("scheduledbackup createBackup", func() {
+	var (
+		cli        client.Client
+		ns         string
+		sb         *apiv1.ScheduledBackup
+		sched      cron.Schedule
+		recorder   *record.FakeRecorder
+		backupTime time.Time
+		now        time.Time
+	)
+
+	BeforeEach(func(ctx context.Context) {
+		scheme := schemeBuilder.BuildWithAllKnownScheme()
+		cli = fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithStatusSubresource(&apiv1.ScheduledBackup{}, &apiv1.Backup{}).
+			Build()
+		ns = newFakeNamespace(cli)
+
+		sb = &apiv1.ScheduledBackup{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "sb-test",
+				Namespace: ns,
+			},
+			Spec: apiv1.ScheduledBackupSpec{
+				Schedule: "0 0 0 * * *",
+				Cluster:  apiv1.LocalObjectReference{Name: "cluster-x"},
+			},
+		}
+		Expect(cli.Create(ctx, sb)).To(Succeed())
+
+		var err error
+		sched, err = cron.Parse(sb.Spec.Schedule)
+		Expect(err).ToNot(HaveOccurred())
+
+		recorder = record.NewFakeRecorder(10)
+		backupTime = time.Date(2026, 4, 17, 22, 35, 42, 0, time.UTC)
+		now = time.Date(2026, 4, 18, 0, 0, 0, 0, time.UTC)
+	})
+
+	It("creates a backup and advances status when no backup exists", func(ctx context.Context) {
+		result, err := createBackup(ctx, recorder, cli, sb, backupTime, now, sched, false)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result.RequeueAfter).To(BeNumerically(">", time.Duration(0)))
+
+		backupName := fmt.Sprintf("%s-%s", sb.Name, pgTime.ToCompactISO8601(backupTime))
+		var backup apiv1.Backup
+		Expect(cli.Get(ctx, types.NamespacedName{Name: backupName, Namespace: ns}, &backup)).To(Succeed())
+
+		var stored apiv1.ScheduledBackup
+		Expect(cli.Get(ctx, types.NamespacedName{Name: sb.Name, Namespace: ns}, &stored)).To(Succeed())
+		Expect(stored.Status.LastCheckTime).ToNot(BeNil())
+		Expect(stored.Status.LastCheckTime.Time).To(BeTemporally("==", now))
+		Expect(stored.Status.LastScheduleTime).ToNot(BeNil())
+		Expect(stored.Status.LastScheduleTime.Time).To(BeTemporally("==", backupTime))
+		Expect(stored.Status.NextScheduleTime).ToNot(BeNil())
+	})
+
+	It("does not loop when a backup with the deterministic name already exists", func(ctx context.Context) {
+		// Reproduces issue #10562: a previous iteration persisted the Backup but
+		// its scheduled-backup status patch never landed (lost response or transient
+		// error), so LastCheckTime is still at its pre-creation value. The next
+		// reconcile recomputes the same deterministic backup name, so apiserver
+		// returns AlreadyExists. The controller must treat that as a no-op success
+		// and advance LastCheckTime, otherwise reconciliation loops forever.
+		backupName := fmt.Sprintf("%s-%s", sb.Name, pgTime.ToCompactISO8601(backupTime))
+		existing := &apiv1.Backup{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      backupName,
+				Namespace: ns,
+			},
+			Spec: apiv1.BackupSpec{
+				Cluster: sb.Spec.Cluster,
+			},
+		}
+		Expect(cli.Create(ctx, existing)).To(Succeed())
+
+		result, err := createBackup(ctx, recorder, cli, sb, backupTime, now, sched, false)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result.RequeueAfter).To(BeNumerically(">", time.Duration(0)))
+
+		var stored apiv1.ScheduledBackup
+		Expect(cli.Get(ctx, types.NamespacedName{Name: sb.Name, Namespace: ns}, &stored)).To(Succeed())
+		Expect(stored.Status.LastCheckTime).ToNot(BeNil())
+		Expect(stored.Status.LastCheckTime.Time).To(BeTemporally("==", now))
+		Expect(stored.Status.LastScheduleTime).ToNot(BeNil())
+		Expect(stored.Status.LastScheduleTime.Time).To(BeTemporally("==", backupTime))
+	})
+})

--- a/internal/controller/scheduledbackup_controller_test.go
+++ b/internal/controller/scheduledbackup_controller_test.go
@@ -53,6 +53,7 @@ func newScheduledBackupTestClient() client.Client {
 var _ = Describe("scheduledbackup createBackup", func() {
 	var (
 		cli        client.Client
+		r          *ScheduledBackupReconciler
 		ns         string
 		sb         *apiv1.ScheduledBackup
 		sched      cron.Schedule
@@ -82,12 +83,13 @@ var _ = Describe("scheduledbackup createBackup", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		recorder = record.NewFakeRecorder(10)
+		r = &ScheduledBackupReconciler{Client: cli, Recorder: recorder}
 		backupTime = time.Date(2026, 4, 17, 22, 35, 42, 0, time.UTC)
 		now = time.Date(2026, 4, 18, 0, 0, 0, 0, time.UTC)
 	})
 
 	It("creates a backup and advances status", func(ctx context.Context) {
-		result, err := createBackup(ctx, recorder, cli, sb, backupTime, now, sched, false)
+		result, err := r.createBackup(ctx, sb, backupTime, now, sched, false)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(result.RequeueAfter).To(BeNumerically(">", time.Duration(0)))
 
@@ -105,7 +107,7 @@ var _ = Describe("scheduledbackup createBackup", func() {
 	})
 
 	It("requeues without advancing status when Create races with an existing backup", func(ctx context.Context) {
-		// In production, the up-front Get in ReconcileScheduledBackup catches a
+		// In production, the up-front Get in reconcileScheduledBackup catches a
 		// pre-existing Backup before reaching createBackup. This branch fires
 		// only when the cache was stale at Get time but the Backup is already
 		// in the apiserver — a transient race. We requeue so the next reconcile
@@ -120,7 +122,7 @@ var _ = Describe("scheduledbackup createBackup", func() {
 		}
 		Expect(cli.Create(ctx, existing)).To(Succeed())
 
-		result, err := createBackup(ctx, recorder, cli, sb, backupTime, now, sched, false)
+		result, err := r.createBackup(ctx, sb, backupTime, now, sched, false)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(result.RequeueAfter).To(Equal(time.Second))
 
@@ -131,9 +133,10 @@ var _ = Describe("scheduledbackup createBackup", func() {
 	})
 })
 
-var _ = Describe("scheduledbackup ReconcileScheduledBackup", func() {
+var _ = Describe("scheduledbackup reconcileScheduledBackup", func() {
 	var (
 		cli      client.Client
+		r        *ScheduledBackupReconciler
 		ns       string
 		sb       *apiv1.ScheduledBackup
 		recorder *record.FakeRecorder
@@ -164,12 +167,13 @@ var _ = Describe("scheduledbackup ReconcileScheduledBackup", func() {
 		Expect(cli.Status().Update(ctx, sb)).To(Succeed())
 
 		recorder = record.NewFakeRecorder(10)
+		r = &ScheduledBackupReconciler{Client: cli, Recorder: recorder}
 	})
 
 	It("creates a Backup and advances status when none exists for the iteration", func(ctx context.Context) {
 		originalLastCheck := sb.Status.LastCheckTime.Time
 
-		result, err := ReconcileScheduledBackup(ctx, recorder, cli, sb)
+		result, err := r.reconcileScheduledBackup(ctx, sb)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(result.RequeueAfter).To(BeNumerically(">", time.Duration(0)))
 
@@ -207,7 +211,7 @@ var _ = Describe("scheduledbackup ReconcileScheduledBackup", func() {
 			}
 			Expect(cli.Create(ctx, existing)).To(Succeed())
 
-			result, err := ReconcileScheduledBackup(ctx, recorder, cli, sb)
+			result, err := r.reconcileScheduledBackup(ctx, sb)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(result.RequeueAfter).To(BeNumerically(">", time.Duration(0)))
 
@@ -269,8 +273,8 @@ var _ = Describe("scheduledbackup ReconcileScheduledBackup immediate", func() {
 		}
 		Expect(cli.Create(ctx, existing)).To(Succeed())
 
-		recorder := record.NewFakeRecorder(10)
-		result, err := ReconcileScheduledBackup(ctx, recorder, cli, sb)
+		r := &ScheduledBackupReconciler{Client: cli, Recorder: record.NewFakeRecorder(10)}
+		result, err := r.reconcileScheduledBackup(ctx, sb)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(result.RequeueAfter).To(BeNumerically(">", time.Duration(0)))
 
@@ -327,11 +331,11 @@ var _ = Describe("scheduledbackup advanceScheduledBackupStatus", func() {
 
 		schedule, err := cron.Parse(sb.Spec.Schedule)
 		Expect(err).ToNot(HaveOccurred())
-		recorder := record.NewFakeRecorder(10)
+		r := &ScheduledBackupReconciler{Client: cli, Recorder: record.NewFakeRecorder(10)}
 		now := time.Now()
 		backupTime := schedule.Next(now)
 
-		result, err := advanceScheduledBackupStatus(ctx, recorder, cli, sb, backupTime, now, schedule)
+		result, err := r.advanceScheduledBackupStatus(ctx, sb, backupTime, now, schedule)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(result.RequeueAfter).To(Equal(time.Second))
 	})

--- a/internal/controller/scheduledbackup_controller_test.go
+++ b/internal/controller/scheduledbackup_controller_test.go
@@ -110,7 +110,7 @@ var _ = Describe("scheduledbackup createBackup", func() {
 		// In production, the up-front Get in reconcileScheduledBackup catches a
 		// pre-existing Backup before reaching createBackup. This branch fires
 		// only when the cache was stale at Get time but the Backup is already
-		// in the apiserver — a transient race. We requeue so the next reconcile
+		// in the apiserver (a transient race). We requeue so the next reconcile
 		// observes the existing Backup and advances the status from there.
 		backupName := sb.BackupName(backupTime)
 		existing := &apiv1.Backup{
@@ -282,15 +282,12 @@ var _ = Describe("scheduledbackup reconcileScheduledBackup", func() {
 	)
 })
 
-var _ = Describe("scheduledbackup ReconcileScheduledBackup immediate", func() {
+var _ = Describe("scheduledbackup reconcileScheduledBackup immediate", func() {
 	It("adopts an existing immediate Backup instead of creating a duplicate", func(ctx context.Context) {
-		// Operator-restart corner case: a previous reconcile created the
-		// immediate Backup but did not land the status patch, so
-		// LastCheckTime is still nil. On retry, time.Now() differs from the
-		// previous attempt, so the deterministic name is different. Without
-		// observing what's already there, the controller would create a
-		// second immediate Backup. This test pins that the existing
-		// immediate Backup is adopted instead.
+		// Operator-restart case: a previous reconcile created the immediate
+		// Backup but did not land the status patch. LastCheckTime is still
+		// nil, and time.Now() on retry produces a different deterministic
+		// name, so the orphan must be discovered via the label-based List.
 		cli := newScheduledBackupTestClient()
 		ns := newFakeNamespace(cli)
 
@@ -304,14 +301,15 @@ var _ = Describe("scheduledbackup ReconcileScheduledBackup immediate", func() {
 		}
 		Expect(cli.Create(ctx, sb)).To(Succeed())
 
-		// Pre-create an immediate Backup as if a previous reconcile had
-		// created it. The compactISO8601 time intentionally differs from
-		// what time.Now() would produce now, to mimic the restart-after-Create
-		// scenario.
+		// The real apiserver sets CreationTimestamp on Create; the fake client
+		// does not, so we set it explicitly. The reconciler uses it as the
+		// adopted iteration's timestamp.
+		createdAt := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
 		existing := &apiv1.Backup{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      sb.BackupName(time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)),
-				Namespace: ns,
+				Name:              sb.BackupName(createdAt),
+				Namespace:         ns,
+				CreationTimestamp: metav1.Time{Time: createdAt},
 				Labels: map[string]string{
 					ParentScheduledBackupLabelName: sb.Name,
 					utils.ImmediateBackupLabelName: "true",
@@ -327,7 +325,6 @@ var _ = Describe("scheduledbackup ReconcileScheduledBackup immediate", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(result.RequeueAfter).To(BeNumerically(">", time.Duration(0)))
 
-		// Only the pre-existing Backup remains; the controller did not create a duplicate.
 		var backups apiv1.BackupList
 		Expect(cli.List(ctx, &backups, client.InNamespace(ns))).To(Succeed())
 		Expect(backups.Items).To(HaveLen(1))
@@ -336,6 +333,8 @@ var _ = Describe("scheduledbackup ReconcileScheduledBackup immediate", func() {
 		var stored apiv1.ScheduledBackup
 		Expect(cli.Get(ctx, types.NamespacedName{Name: sb.Name, Namespace: ns}, &stored)).To(Succeed())
 		Expect(stored.Status.LastCheckTime).ToNot(BeNil())
+		Expect(stored.Status.LastScheduleTime).ToNot(BeNil())
+		Expect(stored.Status.LastScheduleTime.Time).To(BeTemporally("==", existing.CreationTimestamp.Time))
 	})
 })
 
@@ -378,13 +377,12 @@ var _ = Describe("scheduledbackup advanceScheduledBackupStatus", func() {
 		}
 		Expect(cli.Create(ctx, sb)).To(Succeed())
 
-		schedule, err := cron.Parse(sb.Spec.Schedule)
-		Expect(err).ToNot(HaveOccurred())
 		r := &ScheduledBackupReconciler{Client: cli, Recorder: record.NewFakeRecorder(10)}
 		now := time.Now()
-		backupTime := schedule.Next(now)
+		backupTime := now
+		nextBackupTime := now.Add(24 * time.Hour)
 
-		result, err := r.advanceScheduledBackupStatus(ctx, sb, backupTime, now, schedule)
+		result, err := r.advanceScheduledBackupStatus(ctx, sb, backupTime, now, nextBackupTime)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(result.RequeueAfter).To(Equal(time.Second))
 	})

--- a/internal/controller/scheduledbackup_controller_test.go
+++ b/internal/controller/scheduledbackup_controller_test.go
@@ -231,6 +231,55 @@ var _ = Describe("scheduledbackup reconcileScheduledBackup", func() {
 			Expect(stored.Status.LastScheduleTime).ToNot(BeNil())
 			Expect(stored.Status.LastScheduleTime.Time).To(BeTemporally("==", expectedBackupTime))
 		})
+
+	DescribeTable("skips the iteration when an unrelated Backup occupies the deterministic name",
+		func(ctx context.Context, squatterLabels map[string]string) {
+			// A Backup with this iteration's deterministic name exists but does
+			// not carry our parent label (squatter, manual creation, leftover
+			// from a different SB with the same name pattern). The reconciler
+			// must not adopt it, must not loop on AlreadyExists, and must
+			// advance LastCheckTime so the schedule resumes at the next slot.
+			originalLastCheck := sb.Status.LastCheckTime.Time
+			schedule, err := cron.Parse(sb.Spec.Schedule)
+			Expect(err).ToNot(HaveOccurred())
+			expectedBackupTime := schedule.Next(originalLastCheck)
+			expectedName := sb.BackupName(expectedBackupTime)
+
+			squatter := &apiv1.Backup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      expectedName,
+					Namespace: ns,
+					Labels:    squatterLabels,
+				},
+				Spec: apiv1.BackupSpec{Cluster: sb.Spec.Cluster},
+			}
+			Expect(cli.Create(ctx, squatter)).To(Succeed())
+
+			result, err := r.reconcileScheduledBackup(ctx, sb)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.RequeueAfter).To(BeNumerically(">", time.Duration(0)))
+
+			var backups apiv1.BackupList
+			Expect(cli.List(ctx, &backups, client.InNamespace(ns))).To(Succeed())
+			Expect(backups.Items).To(HaveLen(1))
+			Expect(backups.Items[0].Name).To(Equal(expectedName))
+
+			// LastCheckTime advanced (so the next reconcile computes a different
+			// nextTime), but LastScheduleTime is unchanged: we did not run this
+			// iteration.
+			var stored apiv1.ScheduledBackup
+			Expect(cli.Get(ctx, types.NamespacedName{Name: sb.Name, Namespace: ns}, &stored)).To(Succeed())
+			Expect(stored.Status.LastCheckTime).ToNot(BeNil())
+			Expect(stored.Status.LastCheckTime.Time).To(BeTemporally(">", originalLastCheck))
+			Expect(stored.Status.LastScheduleTime).To(BeNil())
+
+			Expect(recorder.Events).To(Receive(ContainSubstring("BackupAdoptionRefused")))
+		},
+		Entry("no labels", nil),
+		Entry("parent label points to a different SB", map[string]string{
+			ParentScheduledBackupLabelName: "other-sb",
+		}),
+	)
 })
 
 var _ = Describe("scheduledbackup ReconcileScheduledBackup immediate", func() {


### PR DESCRIPTION
If a previous reconcile created a Backup but the status patch never landed
(lost response from the apiserver, transient error), the controller got
stuck. The next Backup name is deterministic, so every retry recomputed
the same name, the apiserver replied AlreadyExists, and the controller
looped forever — emitting a warning event each time. The only way out was
deleting the orphan Backup by hand.

The reconcile now reads the apiserver state before acting: if a Backup
for the next scheduled iteration is already there, it's adopted and the
schedule moves forward. Creating a new Backup happens only when there
isn't one. If a race ever leaves us with an unexpected duplicate, the
controller requeues briefly and the next pass picks it up.

Existing ScheduledBackup resources unblock themselves once the orphan
Backup reaches a terminal phase (Completed or Failed). If the orphan
is stuck in an earlier phase, the SB still waits on it; that case is
unchanged by this PR.

Closes #10562