### PR TITLE
feat(database): skip finalizer for resources with databaseReclaimPolicy retain

### DIFF
--- a/internal/management/controller/database_controller.go
+++ b/internal/management/controller/database_controller.go
@@ -213,6 +213,7 @@ func NewDatabaseReconciler(
 		mgr.GetClient(),
 		utils.DatabaseFinalizerName,
 		dr.evaluateDropDatabase,
+		func(db *apiv1.Database) bool { return db.Spec.ReclaimPolicy == apiv1.DatabaseReclaimDelete },
 	)
 
 	return dr

--- a/internal/management/controller/database_controller_test.go
+++ b/internal/management/controller/database_controller_test.go
@@ -111,6 +111,7 @@ var _ = Describe("Managed Database status", func() {
 			fakeClient,
 			utils.DatabaseFinalizerName,
 			r.evaluateDropDatabase,
+			func(db *apiv1.Database) bool { return db.Spec.ReclaimPolicy == apiv1.DatabaseReclaimDelete },
 		)
 	})
 
@@ -205,7 +206,7 @@ var _ = Describe("Managed Database status", func() {
 	})
 
 	When("reclaim policy is retain", func() {
-		It("on deletion it removes finalizers and does NOT drop the DB", func(ctx SpecContext) {
+		It("on deletion it does NOT add a finalizer and does NOT drop the DB", func(ctx SpecContext) {
 			database.Spec.ReclaimPolicy = apiv1.DatabaseReclaimRetain
 			Expect(fakeClient.Update(ctx, database)).To(Succeed())
 
@@ -226,19 +227,12 @@ var _ = Describe("Managed Database status", func() {
 			err := reconcileDatabase(ctx, fakeClient, r, database)
 			Expect(err).ToNot(HaveOccurred())
 
-			// Plain successful reconciliation, finalizers have been created
-			Expect(database.GetFinalizers()).NotTo(BeEmpty())
+			// No finalizer added — retain policy means the DB is not owned by the operator lifecycle
+			Expect(database.GetFinalizers()).To(BeEmpty())
 			Expect(database.Status.Applied).Should(HaveValue(BeTrue()))
 			Expect(database.Status.Message).Should(BeEmpty())
 
-			// The next 2 lines are a hacky bit to make sure the next reconciler
-			// call doesn't skip on account of Generation == ObservedGeneration.
-			// See fake.Client known issues with `Generation`
-			// https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/client/fake@v0.19.0#NewClientBuilder
-			database.SetGeneration(database.GetGeneration() + 1)
-			Expect(fakeClient.Update(ctx, database)).To(Succeed())
-
-			// We now look at the behavior when we delete the Database object
+			// Deleting the k8s object succeeds immediately with no finalizer blocking it
 			Expect(fakeClient.Delete(ctx, database)).To(Succeed())
 
 			err = reconcileDatabase(ctx, fakeClient, r, database)

--- a/internal/management/controller/finalizers.go
+++ b/internal/management/controller/finalizers.go
@@ -27,26 +27,31 @@ import (
 )
 
 type finalizerReconciler[T client.Object] struct {
-	cli           client.Client
-	finalizerName string
-	onRemoveFunc  func(ctx context.Context, resource T) error
+	cli                  client.Client
+	finalizerName        string
+	onRemoveFunc         func(ctx context.Context, resource T) error
+	shouldAddFinalizer   func(resource T) bool
 }
 
 func newFinalizerReconciler[T client.Object](
 	cli client.Client,
 	finalizerName string,
 	onRemoveFunc func(ctx context.Context, resource T) error,
+	shouldAddFinalizer func(resource T) bool,
 ) *finalizerReconciler[T] {
 	return &finalizerReconciler[T]{
-		cli:           cli,
-		finalizerName: finalizerName,
-		onRemoveFunc:  onRemoveFunc,
+		cli:                cli,
+		finalizerName:      finalizerName,
+		onRemoveFunc:       onRemoveFunc,
+		shouldAddFinalizer: shouldAddFinalizer,
 	}
 }
 
 func (f finalizerReconciler[T]) reconcile(ctx context.Context, resource T) error {
-	// add finalizer in non-deleted publications if not present
 	if resource.GetDeletionTimestamp().IsZero() {
+		if f.shouldAddFinalizer != nil && !f.shouldAddFinalizer(resource) {
+			return nil
+		}
 		if !controllerutil.AddFinalizer(resource, f.finalizerName) {
 			return nil
 		}

--- a/internal/management/controller/publication_controller.go
+++ b/internal/management/controller/publication_controller.go
@@ -183,6 +183,7 @@ func NewPublicationReconciler(
 		mgr.GetClient(),
 		utils.PublicationFinalizerName,
 		pr.evaluateDropPublication,
+		func(pub *apiv1.Publication) bool { return pub.Spec.ReclaimPolicy == apiv1.PublicationReclaimDelete },
 	)
 
 	return pr

--- a/internal/management/controller/publication_controller_test.go
+++ b/internal/management/controller/publication_controller_test.go
@@ -116,6 +116,7 @@ var _ = Describe("Managed publication controller tests", func() {
 			fakeClient,
 			utils.PublicationFinalizerName,
 			r.evaluateDropPublication,
+			func(pub *apiv1.Publication) bool { return pub.Spec.ReclaimPolicy == apiv1.PublicationReclaimDelete },
 		)
 	})
 
@@ -207,7 +208,7 @@ var _ = Describe("Managed publication controller tests", func() {
 	})
 
 	When("reclaim policy is retain", func() {
-		It("on deletion it removes finalizers and does NOT drop the Publication", func(ctx SpecContext) {
+		It("on deletion it does NOT add a finalizer and does NOT drop the Publication", func(ctx SpecContext) {
 			publication.Spec.ReclaimPolicy = apiv1.PublicationReclaimRetain
 			Expect(fakeClient.Update(ctx, publication)).To(Succeed())
 
@@ -227,19 +228,12 @@ var _ = Describe("Managed publication controller tests", func() {
 			err := reconcilePublication(ctx, fakeClient, r, publication)
 			Expect(err).ToNot(HaveOccurred())
 
-			// Plain successful reconciliation, finalizers have been created
-			Expect(publication.GetFinalizers()).NotTo(BeEmpty())
+			// No finalizer added — retain policy means the publication is not owned by the operator lifecycle
+			Expect(publication.GetFinalizers()).To(BeEmpty())
 			Expect(publication.Status.Applied).Should(HaveValue(BeTrue()))
 			Expect(publication.Status.Message).Should(BeEmpty())
 
-			// The next 2 lines are a hacky bit to make sure the next reconciler
-			// call doesn't skip on account of Generation == ObservedGeneration.
-			// See fake.Client known issues with `Generation`
-			// https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/client/fake@v0.19.0#NewClientBuilder
-			publication.SetGeneration(publication.GetGeneration() + 1)
-			Expect(fakeClient.Update(ctx, publication)).To(Succeed())
-
-			// We now look at the behavior when we delete the Database object
+			// Deleting the k8s object succeeds immediately with no finalizer blocking it
 			Expect(fakeClient.Delete(ctx, publication)).To(Succeed())
 
 			err = reconcilePublication(ctx, fakeClient, r, publication)

--- a/internal/management/controller/subscription_controller.go
+++ b/internal/management/controller/subscription_controller.go
@@ -200,6 +200,7 @@ func NewSubscriptionReconciler(
 		mgr.GetClient(),
 		utils.SubscriptionFinalizerName,
 		sr.evaluateDropSubscription,
+		func(sub *apiv1.Subscription) bool { return sub.Spec.ReclaimPolicy == apiv1.SubscriptionReclaimDelete },
 	)
 
 	return sr

--- a/internal/management/controller/subscription_controller_test.go
+++ b/internal/management/controller/subscription_controller_test.go
@@ -133,6 +133,7 @@ var _ = Describe("Managed subscription controller tests", func() {
 			fakeClient,
 			utils.SubscriptionFinalizerName,
 			r.evaluateDropSubscription,
+			func(sub *apiv1.Subscription) bool { return sub.Spec.ReclaimPolicy == apiv1.SubscriptionReclaimDelete },
 		)
 	})
 
@@ -237,7 +238,7 @@ var _ = Describe("Managed subscription controller tests", func() {
 	})
 
 	When("reclaim policy is retain", func() {
-		It("on deletion it removes finalizers and does NOT drop the subscription", func(ctx SpecContext) {
+		It("on deletion it does NOT add a finalizer and does NOT drop the subscription", func(ctx SpecContext) {
 			subscription.Spec.ReclaimPolicy = apiv1.SubscriptionReclaimRetain
 			Expect(fakeClient.Update(ctx, subscription)).To(Succeed())
 
@@ -259,19 +260,12 @@ var _ = Describe("Managed subscription controller tests", func() {
 			err = reconcileSubscription(ctx, fakeClient, r, subscription)
 			Expect(err).ToNot(HaveOccurred())
 
-			// Plain successful reconciliation, finalizers have been created
-			Expect(subscription.GetFinalizers()).NotTo(BeEmpty())
+			// No finalizer added — retain policy means the subscription is not owned by the operator lifecycle
+			Expect(subscription.GetFinalizers()).To(BeEmpty())
 			Expect(subscription.Status.Applied).Should(HaveValue(BeTrue()))
 			Expect(subscription.Status.Message).Should(BeEmpty())
 
-			// The next 2 lines are a hacky bit to make sure the next reconciler
-			// call doesn't skip on account of Generation == ObservedGeneration.
-			// See fake.Client known issues with `Generation`
-			// https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/client/fake@v0.19.0#NewClientBuilder
-			subscription.SetGeneration(subscription.GetGeneration() + 1)
-			Expect(fakeClient.Update(ctx, subscription)).To(Succeed())
-
-			// We now look at the behavior when we delete the Database object
+			// Deleting the k8s object succeeds immediately with no finalizer blocking it
 			Expect(fakeClient.Delete(ctx, subscription)).To(Succeed())
 
 			err = reconcileSubscription(ctx, fakeClient, r, subscription)


### PR DESCRIPTION
Fixes #10535

Database, Publication and Subscription resources with a retain reclaim policy no longer receive a finalizer. This prevents the resource from getting stuck with a deletionTimestamp when the operator or operand is unavailable, which would block namespace deletion.