### PR TITLE
chore: enable ImageVolume featureGate on K3D 1.33/1.34

### DIFF
--- a/hack/testing-tools/common/20-utils-k8s.sh
+++ b/hack/testing-tools/common/20-utils-k8s.sh
@@ -61,6 +61,13 @@ function retry {
   return 0
 }
 
+# version_gte: returns 0 (true) if version >= threshold
+function version_gte() {
+  local threshold=$1
+  local version=$2
+  [[ "$(printf '%s\n' "$threshold" "$version" | sort -V | head -n1)" == "$threshold" ]]
+}
+
 # get_default_storage_class detects the default K8s storage class
 function get_default_storage_class() {
     ${K8S_CLI} get storageclass -o json | jq -r 'first(.items[] | select (.metadata.annotations["storageclass.kubernetes.io/is-default-class"] == "true") | .metadata.name)'

--- a/hack/testing-tools/k8s-engines/k3d/setup.sh
+++ b/hack/testing-tools/k8s-engines/k3d/setup.sh
@@ -51,7 +51,7 @@ function create_cluster_k3d() {
   local cluster_name=$2
 
   local latest_k3s_tag
-  latest_k3s_tag=$(k3d version list k3s | grep -- "^${k8s_version//./\\.}"'\+-k3s[0-9]$' | tail -n 1)
+  latest_k3s_tag=$(k3d version list k3s | { grep -- "^${k8s_version//./\\.}"'\+-k3s[0-9]$' || true; } | tail -n 1)
   if [[ -z "${latest_k3s_tag}" ]]; then
     echo "ERROR: No k3s image found for version ${k8s_version}" >&2
     exit 1
@@ -75,6 +75,13 @@ EOF
   fi
 
   options+=(--registry-config "${config_file}")
+
+  # Enable ImageVolume support from k3s v1.33.5 up to v1.34.x (defaults to true in v1.35.0+)
+  if version_gte "1.33.5" "${k8s_version#v}" && ! version_gte "1.35.0" "${k8s_version#v}"; then
+    options+=(--k3s-arg "--kube-apiserver-arg=feature-gates=ImageVolume=true@server:0")
+    options+=(--k3s-arg "--kubelet-arg=feature-gates=ImageVolume=true@server:0")
+    options+=(--k3s-arg "--kubelet-arg=feature-gates=ImageVolume=true@agent:*")
+  fi
 
   local agents=()
   if [ "$NODES" -gt 1 ]; then

--- a/hack/testing-tools/k8s-engines/k3d/setup.sh
+++ b/hack/testing-tools/k8s-engines/k3d/setup.sh
@@ -51,7 +51,7 @@ function create_cluster_k3d() {
   local cluster_name=$2
 
   local latest_k3s_tag
-  latest_k3s_tag=$(k3d version list k3s | { grep -- "^${k8s_version//./\\.}"'\+-k3s[0-9]$' || true; } | tail -n 1)
+  latest_k3s_tag=$(k3d version list k3s -l1 -s desc --include "^${k8s_version}.*")
   if [[ -z "${latest_k3s_tag}" ]]; then
     echo "ERROR: No k3s image found for version ${k8s_version}" >&2
     exit 1

--- a/hack/testing-tools/k8s-engines/kind/setup.sh
+++ b/hack/testing-tools/k8s-engines/kind/setup.sh
@@ -113,8 +113,8 @@ EOF
     done
   fi
 
-  # Enable ImageVolume support from kindest/node v1.33.1
-  if [[ "$(printf '%s\n' "1.33.1" "${k8s_version#v}" | sort -V | head -n1)" == "1.33.1" ]]; then
+  # Enable ImageVolume support from kindest/node v1.33.1 up to v1.34.x (defaults to true in v1.35.0+)
+  if version_gte "1.33.1" "${k8s_version#v}" && ! version_gte "1.35.0" "${k8s_version#v}"; then
     cat >>"${config_file}" <<-EOF
 
 featureGates:


### PR DESCRIPTION
* Enable the ImageVolume featureGate on K3D Clusters (only from 1.33.5 or newer, because older minor versions of 1.33 do not carry a `containerd` version that's new enough `>= 2.1.0 `)
* Added an upper-bound check so the ImageVolume featureGate block is skipped on 1.35.0+ (for both kind and k3d). Since K8S 1.35, ImageVolume is enabled by default.
* Simplified the version check into a reusable function
* Fixed an issue with grep swallowing an error message when attempting a K3D deploy with a version of K3S that doesn't exist (`set -eEuo pipefail` would kill the script before the error msg is fired because grep would exit with status 1)

Closes #10652