### PR TITLE
chore(deps): update dependency go to v1.26.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cloudnative-pg/cloudnative-pg
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2


### PR DESCRIPTION
Bumps the `go` directive in `go.mod` to 1.26.3 (security release, 2026-05-07).

Pre-empts Renovate, which hasn't surfaced 1.26.3 yet because the hosted datasource cache is still serving 1.26.2. Will be cherry-picked to release branches.