### PR TITLE
ci: partial go cache fallback in backport workflow

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -96,6 +96,19 @@ jobs:
         with:
           go-version-file: go.mod
           check-latest: true
+          cache: false
+      -
+        name: Cache Go modules
+        if: contains( github.event.pull_request.labels.*.name, env.BRANCH )
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: backport-go-${{ runner.os }}-${{ matrix.branch }}-${{ hashFiles('go.sum') }}
+          restore-keys: |
+            backport-go-${{ runner.os }}-${{ matrix.branch }}-
+            backport-go-${{ runner.os }}-
       -
         name: Check commits
         if: contains( github.event.pull_request.labels.*.name, env.BRANCH )


### PR DESCRIPTION
actions/setup-go's built-in cache uses a single key derived from `hash(go.sum)` with no `restore-keys` fallback, so any divergence between a release branch's `go.sum` and `main` is a full miss. `release-1.25` hits this almost every time and re-downloads the full module set, adding roughly two minutes per backport.

Disable the built-in cache and use `actions/cache` with a per-branch key plus a two-level `restore-keys` ladder, so a diverged `go.sum` reuses the most recent cache for the same branch (or any branch) and only the delta is downloaded.

Closes #10657