### PR TITLE
feat: support runtime recovery_target_* on post-bootstrap clusters

### DIFF
--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -305,6 +305,29 @@ type ClusterSpec struct {
 	// +optional
 	ReplicaCluster *ReplicaClusterConfiguration `json:"replica,omitempty"`
 
+	// RecoveryTarget specifies a runtime PostgreSQL recovery target
+	// (`recovery_target_time`, `recovery_target_lsn`, `recovery_target_xid`,
+	// `recovery_target_name`) for an already-bootstrapped standby cluster.
+	// When set, the operator renders the corresponding `recovery_target_*`
+	// GUCs into the generated PostgreSQL configuration and triggers a
+	// rolling restart of the instance(s) so the GUCs take effect at server
+	// start (PostgreSQL requires `recovery_target_*` to be set at start).
+	// On reaching the target, replay pauses (default `targetAction = pause`),
+	// allowing operators to verify state before promoting via
+	// `replica.enabled = false` or by setting `targetAction = promote`.
+	// This field is meaningful only while the cluster is in recovery
+	// (i.e. `replica.enabled = true`); it is ignored for primaries.
+	// +optional
+	RecoveryTarget *RecoveryTarget `json:"recoveryTarget,omitempty"`
+
+	// RecoveryTargetAction specifies what action the server should take
+	// once the recovery target is reached. One of `pause`, `promote`,
+	// `shutdown`. Defaults to `pause` when `RecoveryTarget` is set.
+	// Maps to PostgreSQL `recovery_target_action`.
+	// +optional
+	// +kubebuilder:validation:Enum=pause;promote;shutdown
+	RecoveryTargetAction string `json:"recoveryTargetAction,omitempty"`
+
 	// The secret containing the superuser password. If not defined a new
 	// secret will be created with a randomly generated password
 	// +optional

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -736,6 +736,11 @@ func (in *ClusterSpec) DeepCopyInto(out *ClusterSpec) {
 		*out = new(ReplicaClusterConfiguration)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.RecoveryTarget != nil {
+		in, out := &in.RecoveryTarget, &out.RecoveryTarget
+		*out = new(RecoveryTarget)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.SuperuserSecret != nil {
 		in, out := &in.SuperuserSecret, &out.SuperuserSecret
 		*out = new(LocalObjectReference)

--- a/config/crd/bases/postgresql.cnpg.io_clusters.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_clusters.yaml
@@ -5438,6 +5438,67 @@ spec:
                     type: array
                     x-kubernetes-list-type: atomic
                 type: object
+              recoveryTarget:
+                description: |-
+                  RecoveryTarget specifies a runtime PostgreSQL recovery target
+                  (`recovery_target_time`, `recovery_target_lsn`, `recovery_target_xid`,
+                  `recovery_target_name`) for an already-bootstrapped standby cluster.
+                  When set, the operator renders the corresponding `recovery_target_*`
+                  GUCs into the generated PostgreSQL configuration and triggers a
+                  rolling restart of the instance(s) so the GUCs take effect at server
+                  start (PostgreSQL requires `recovery_target_*` to be set at start).
+                  On reaching the target, replay pauses (default `targetAction = pause`),
+                  allowing operators to verify state before promoting via
+                  `replica.enabled = false` or by setting `targetAction = promote`.
+                  This field is meaningful only while the cluster is in recovery
+                  (i.e. `replica.enabled = true`); it is ignored for primaries.
+                properties:
+                  backupID:
+                    description: |-
+                      The ID of the backup from which to start the recovery process.
+                      If empty (default) the operator will automatically detect the backup
+                      based on targetTime or targetLSN if specified. Otherwise use the
+                      latest available backup in chronological order.
+                    type: string
+                  exclusive:
+                    description: |-
+                      Set the target to be exclusive. If omitted, defaults to false, so that
+                      in Postgres, `recovery_target_inclusive` will be true
+                    type: boolean
+                  targetImmediate:
+                    description: End recovery as soon as a consistent state is reached
+                    type: boolean
+                  targetLSN:
+                    description: The target LSN (Log Sequence Number)
+                    type: string
+                  targetName:
+                    description: |-
+                      The target name (to be previously created
+                      with `pg_create_restore_point`)
+                    type: string
+                  targetTLI:
+                    description: The target timeline ("latest" or a positive integer)
+                    type: string
+                  targetTime:
+                    description: |-
+                      The target time as a timestamp in RFC3339 format or PostgreSQL timestamp format.
+                      Timestamps without an explicit timezone are interpreted as UTC.
+                    type: string
+                  targetXID:
+                    description: The target transaction ID
+                    type: string
+                type: object
+              recoveryTargetAction:
+                description: |-
+                  RecoveryTargetAction specifies what action the server should take
+                  once the recovery target is reached. One of `pause`, `promote`,
+                  `shutdown`. Defaults to `pause` when `RecoveryTarget` is set.
+                  Maps to PostgreSQL `recovery_target_action`.
+                enum:
+                - pause
+                - promote
+                - shutdown
+                type: string
               replica:
                 description: Replica cluster configuration
                 properties:

--- a/pkg/management/postgres/configuration.go
+++ b/pkg/management/postgres/configuration.go
@@ -31,6 +31,7 @@ import (
 	postgresClient "github.com/cloudnative-pg/cnpg-i/pkg/postgres"
 	"github.com/cloudnative-pg/machinery/pkg/fileutils"
 	"github.com/cloudnative-pg/machinery/pkg/log"
+	pgTime "github.com/cloudnative-pg/machinery/pkg/postgres/time"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/configfile"
@@ -361,6 +362,26 @@ func createPostgresqlConfiguration(
 	// Setup minimum replay delay if we're on a replica cluster
 	if cluster.IsReplica() && cluster.Spec.ReplicaCluster.MinApplyDelay != nil {
 		info.RecoveryMinApplyDelay = cluster.Spec.ReplicaCluster.MinApplyDelay.Duration
+	}
+
+	// Apply runtime recovery target (post-bootstrap) only on replica
+	// clusters, where it's meaningful. PostgreSQL silently ignores
+	// recovery_target_* on a primary not in recovery, but populating the
+	// config there would still trigger needless restarts; gate on IsReplica.
+	if cluster.IsReplica() && cluster.Spec.RecoveryTarget != nil {
+		rt := cluster.Spec.RecoveryTarget
+		info.RecoveryTargetTime = pgTime.ConvertToPostgresFormat(rt.TargetTime)
+		info.RecoveryTargetLSN = rt.TargetLSN
+		info.RecoveryTargetXID = rt.TargetXID
+		info.RecoveryTargetName = rt.TargetName
+		if rt.TargetImmediate != nil && *rt.TargetImmediate {
+			info.RecoveryTargetImmediate = true
+		}
+		info.RecoveryTargetTLI = rt.TargetTLI
+		if rt.Exclusive != nil && *rt.Exclusive {
+			info.RecoveryTargetExclusive = true
+		}
+		info.RecoveryTargetAction = cluster.Spec.RecoveryTargetAction
 	}
 
 	if isSynchronizeLogicalDecodingEnabled(cluster) {

--- a/pkg/postgres/configuration.go
+++ b/pkg/postgres/configuration.go
@@ -392,6 +392,32 @@ type ConfigurationInfo struct {
 	// Minimum apply delay of transaction
 	RecoveryMinApplyDelay time.Duration
 
+	// Recovery target (post-bootstrap) — populated from
+	// cluster.Spec.RecoveryTarget. When any of these are set,
+	// the corresponding recovery_target_* GUCs are written into the
+	// generated PostgreSQL configuration. PostgreSQL requires these
+	// parameters to be set at server start, so the operator triggers
+	// a controlled rolling restart when they change.
+	//
+	// Exactly one of RecoveryTargetTime / RecoveryTargetLSN /
+	// RecoveryTargetXID / RecoveryTargetName / RecoveryTargetImmediate
+	// should be set; this is enforced at the cluster spec level.
+	RecoveryTargetTime      string
+	RecoveryTargetLSN       string
+	RecoveryTargetXID       string
+	RecoveryTargetName      string
+	RecoveryTargetImmediate bool
+	// RecoveryTargetTLI sets recovery_target_timeline (e.g. "latest" or
+	// a numeric timeline ID).
+	RecoveryTargetTLI string
+	// RecoveryTargetExclusive, when true, sets
+	// recovery_target_inclusive = false. Default is inclusive (true).
+	RecoveryTargetExclusive bool
+	// RecoveryTargetAction sets recovery_target_action: pause | promote |
+	// shutdown. When empty and any other RecoveryTarget* is set, defaults
+	// to "pause" so DR automation can verify state before promoting.
+	RecoveryTargetAction string
+
 	// The list of additional extensions to be loaded into the PostgreSQL configuration
 	AdditionalExtensions []AdditionalExtensionConfiguration
 }
@@ -403,6 +429,19 @@ func (c ConfigurationInfo) getAlterSystemEnabledValue() string {
 	}
 
 	return "off"
+}
+
+// anyRecoveryTargetSet returns true when any of the runtime recovery target
+// fields on ConfigurationInfo is set. Used to gate the rendering of the
+// recovery_target_* GUCs in the generated PostgreSQL configuration.
+func anyRecoveryTargetSet(info ConfigurationInfo) bool {
+	return info.RecoveryTargetTime != "" ||
+		info.RecoveryTargetLSN != "" ||
+		info.RecoveryTargetXID != "" ||
+		info.RecoveryTargetName != "" ||
+		info.RecoveryTargetImmediate ||
+		info.RecoveryTargetTLI != "" ||
+		info.RecoveryTargetAction != ""
 }
 
 // ManagedExtension defines all the information about a managed extension
@@ -786,6 +825,48 @@ func CreatePostgresqlConfiguration(info ConfigurationInfo) *PgConfiguration {
 		configuration.OverwriteConfig(
 			ParameterRecoveryMinApplyDelay,
 			fmt.Sprintf("%vs", math.Floor(info.RecoveryMinApplyDelay.Seconds())))
+	}
+
+	// Apply the runtime recovery target (post-bootstrap), if any.
+	//
+	// PostgreSQL requires recovery_target_* parameters to be set at server
+	// start (PGC_POSTMASTER), so any change here will be reflected in the
+	// next cnpg.config_sha256 and trigger pg_settings.pending_restart, which
+	// the operator's existing rollout machinery picks up to perform a
+	// controlled restart of the instance(s).
+	//
+	// Only meaningful for clusters in recovery (replica clusters); ignored
+	// otherwise by PostgreSQL itself.
+	if anyRecoveryTargetSet(info) {
+		if info.RecoveryTargetTime != "" {
+			configuration.OverwriteConfig("recovery_target_time", info.RecoveryTargetTime)
+		}
+		if info.RecoveryTargetLSN != "" {
+			configuration.OverwriteConfig("recovery_target_lsn", info.RecoveryTargetLSN)
+		}
+		if info.RecoveryTargetXID != "" {
+			configuration.OverwriteConfig("recovery_target_xid", info.RecoveryTargetXID)
+		}
+		if info.RecoveryTargetName != "" {
+			configuration.OverwriteConfig("recovery_target_name", info.RecoveryTargetName)
+		}
+		if info.RecoveryTargetImmediate {
+			configuration.OverwriteConfig("recovery_target", "immediate")
+		}
+		if info.RecoveryTargetTLI != "" {
+			configuration.OverwriteConfig("recovery_target_timeline", info.RecoveryTargetTLI)
+		}
+		if info.RecoveryTargetExclusive {
+			configuration.OverwriteConfig("recovery_target_inclusive", "false")
+		} else {
+			configuration.OverwriteConfig("recovery_target_inclusive", "true")
+		}
+		action := info.RecoveryTargetAction
+		if action == "" {
+			// Default to pause so DR automation can verify before promoting.
+			action = "pause"
+		}
+		configuration.OverwriteConfig("recovery_target_action", action)
 	}
 
 	if info.IncludingSharedPreloadLibraries {


### PR DESCRIPTION
## Summary

Adds a runtime `spec.recoveryTarget` field that takes effect on a
post-bootstrap CNPG cluster, allowing operators to apply
`recovery_target_time` (or `_lsn` / `_xid` / `_name`) to an
already-running standby and have it pause at exactly that point —
without re-bootstrapping the cluster.

Closes #10634

## Motivation

See the linked issue for full motivation. TL;DR: today no in-cluster
option exists for applying a recovery target to a running standby.
`spec.replica.minApplyDelay` doesn't bound apply at promotion;
`bootstrap.recovery.recoveryTarget` requires re-bootstrap;
`ALTER SYSTEM SET recovery_target_time` is blocked by CNPG hardening
of `postgresql.auto.conf`.

## Design

- New `spec.recoveryTarget` (reuses existing `RecoveryTarget` struct)
  and `spec.recoveryTargetAction` (defaults to `pause`).
- Operator renders `recovery_target_*` GUCs into `custom.conf` (which
  CNPG already owns and writes freely), gated on `IsReplica()`.
- `cnpg.config_sha256` changes → Postgres reload marks
  `pg_settings.pending_restart=true` (these GUCs are `PGC_POSTMASTER`).
- Existing `isInstanceNeedingRollout` machinery handles the controlled
  in-place restart.
- After promotion (`replica.enabled=false`), `IsReplica()` returns
  false and the GUCs are dropped from the rendered config — no
  leftover state on the new primary.

## End-to-end validation

Tested on a live cluster:

| Step | Result |
|---|---|
| Patch `spec.recoveryTarget.targetTime` | Operator triggers in-place restart (~12s) |
| `recovery_target_*` GUCs in `custom.conf` | Present while standby, gated on IsReplica |
| Replay reaches target | Paused **before** first commit past targetTime |
| `pg_get_wal_replay_pause_state()` | `paused` |
| Promote via `replica.enabled=false` | New timeline at paused LSN |
| Post-target transactions in new primary | None (post-target CREATE TABLE was excluded) |
| GUCs after promotion | Dropped from custom.conf (gated by IsReplica) |

## Deferred (happy to add in follow-ups)

- Webhook validation (one-of mutual exclusion on
  `targetTime`/`targetLSN`/etc.).
- Populate `status.recoveryTargetStatus` from instance manager probes.
- E2E test under `tests/e2e/`.

## Checklist

- [x] `feat:` Conventional Commits title
- [x] DCO `Signed-off-by:` on every commit
- [x] `make generate` + `make manifests` regenerated artifacts
- [x] `go build ./...`, `go vet`, existing unit tests pass
- [ ] Webhook validation (follow-up)
- [ ] Status reporting (follow-up)
- [ ] E2E test (follow-up)

Open to feedback on field placement and API shape before adding the
follow-ups.