### PR TITLE
fix: avoid panic while reconciling the Pooler reconciler when its Cluster is deleted

### DIFF
--- a/api/v1/pooler_funcs.go
+++ b/api/v1/pooler_funcs.go
@@ -52,9 +52,6 @@ func (in *Pooler) GetServerCASecretNameOrDefault(cluster *Cluster) string {
 	if in.Spec.PgBouncer != nil && in.Spec.PgBouncer.ServerCASecret != nil {
 		return in.Spec.PgBouncer.ServerCASecret.Name
 	}
-	if cluster == nil {
-		return ""
-	}
 
 	return cluster.GetServerCASecretName()
 }
@@ -65,9 +62,6 @@ func (in *Pooler) GetClientCASecretNameOrDefault(cluster *Cluster) string {
 	if in.Spec.PgBouncer != nil && in.Spec.PgBouncer.ClientCASecret != nil {
 		return in.Spec.PgBouncer.ClientCASecret.Name
 	}
-	if cluster == nil {
-		return ""
-	}
 
 	return cluster.GetClientCASecretName()
 }
@@ -77,9 +71,6 @@ func (in *Pooler) GetClientCASecretNameOrDefault(cluster *Cluster) string {
 func (in *Pooler) GetClientTLSSecretNameOrDefault(cluster *Cluster) string {
 	if in.Spec.PgBouncer != nil && in.Spec.PgBouncer.ClientTLSSecret != nil {
 		return in.Spec.PgBouncer.ClientTLSSecret.Name
-	}
-	if cluster == nil {
-		return ""
 	}
 
 	return cluster.GetServerTLSSecretName()

--- a/api/v1/pooler_funcs.go
+++ b/api/v1/pooler_funcs.go
@@ -52,6 +52,9 @@ func (in *Pooler) GetServerCASecretNameOrDefault(cluster *Cluster) string {
 	if in.Spec.PgBouncer != nil && in.Spec.PgBouncer.ServerCASecret != nil {
 		return in.Spec.PgBouncer.ServerCASecret.Name
 	}
+	if cluster == nil {
+		return ""
+	}
 
 	return cluster.GetServerCASecretName()
 }
@@ -62,6 +65,9 @@ func (in *Pooler) GetClientCASecretNameOrDefault(cluster *Cluster) string {
 	if in.Spec.PgBouncer != nil && in.Spec.PgBouncer.ClientCASecret != nil {
 		return in.Spec.PgBouncer.ClientCASecret.Name
 	}
+	if cluster == nil {
+		return ""
+	}
 
 	return cluster.GetClientCASecretName()
 }
@@ -71,6 +77,9 @@ func (in *Pooler) GetClientCASecretNameOrDefault(cluster *Cluster) string {
 func (in *Pooler) GetClientTLSSecretNameOrDefault(cluster *Cluster) string {
 	if in.Spec.PgBouncer != nil && in.Spec.PgBouncer.ClientTLSSecret != nil {
 		return in.Spec.PgBouncer.ClientTLSSecret.Name
+	}
+	if cluster == nil {
+		return ""
 	}
 
 	return cluster.GetServerTLSSecretName()

--- a/internal/controller/pooler_controller.go
+++ b/internal/controller/pooler_controller.go
@@ -94,8 +94,21 @@ func (r *PoolerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		return ctrl.Result{}, nil
 	}
 
+	// Resolve the referenced Cluster up front: it gates the rest of the
+	// reconciliation and is required by getManagedResources.
+	cluster, err := getClusterOrNil(
+		ctx, r.Client, client.ObjectKey{Name: pooler.Spec.Cluster.Name, Namespace: pooler.Namespace})
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("while getting referenced cluster: %w", err)
+	}
+	if cluster == nil {
+		contextLogger.Info("Cluster not found, will retry in 30 seconds",
+			"cluster", pooler.Spec.Cluster.Name)
+		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+	}
+
 	// Get the set of resources we directly manage and their status
-	resources, err := r.getManagedResources(ctx, &pooler)
+	resources, err := r.getManagedResources(ctx, &pooler, cluster)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("while getting managed resources: %w", err)
 	}
@@ -219,12 +232,6 @@ func (r *PoolerReconciler) waitForPrerequisites(
 ) *ctrl.Result {
 	contextLogger := log.FromContext(ctx)
 	waitResult := &ctrl.Result{RequeueAfter: 30 * time.Second}
-
-	if resources.Cluster == nil {
-		contextLogger.Info("Cluster not found, will retry in 30 seconds",
-			"cluster", pooler.Spec.Cluster.Name)
-		return waitResult
-	}
 
 	// For automated integration, we need AuthUserSecret
 	if pooler.IsAutomatedIntegration() && resources.AuthUserSecret == nil {

--- a/internal/controller/pooler_controller_test.go
+++ b/internal/controller/pooler_controller_test.go
@@ -21,6 +21,7 @@ package controller
 
 import (
 	"context"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -191,6 +192,31 @@ var _ = Describe("pooler_controller unit tests", func() {
 				Expect(reReqs).ToNot(ContainElement(nonExpectedRequest))
 			}
 		})
+	})
+
+	It("should requeue without panicking when the referenced cluster is missing", func() {
+		ctx := context.Background()
+		namespace := newFakeNamespace(env.client)
+
+		// cluster is intentionally not persisted: the Pooler references
+		// a Cluster that does not exist (e.g., it has been deleted while
+		// the Pooler still existed).
+		cluster := &apiv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "missing-cluster",
+				Namespace: namespace,
+			},
+		}
+		pooler := newFakePooler(env.client, cluster)
+
+		result, err := env.poolerReconciler.Reconcile(ctx, ctrl.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      pooler.Name,
+				Namespace: pooler.Namespace,
+			},
+		})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result.RequeueAfter).To(Equal(30 * time.Second))
 	})
 
 	It("should make sure that isOwnedByPoolerKind works correctly", func() {

--- a/internal/controller/pooler_resources.go
+++ b/internal/controller/pooler_resources.go
@@ -68,20 +68,15 @@ type poolerManagedResources struct {
 	Role           *rbacv1.Role
 }
 
-// getManagedResources detects the list of the resources created and manager
-// by this pooler
+// getManagedResources detects the list of the resources created and managed
+// by this pooler. The caller is responsible for resolving the referenced
+// Cluster and passing it in: this function requires a non-nil Cluster.
 func (r *PoolerReconciler) getManagedResources(
 	ctx context.Context,
 	pooler *apiv1.Pooler,
+	cluster *apiv1.Cluster,
 ) (result *poolerManagedResources, err error) {
-	result = &poolerManagedResources{}
-
-	// Get the referenced cluster
-	result.Cluster, err = getClusterOrNil(
-		ctx, r.Client, client.ObjectKey{Name: pooler.Spec.Cluster.Name, Namespace: pooler.Namespace})
-	if err != nil {
-		return nil, err
-	}
+	result = &poolerManagedResources{Cluster: cluster}
 
 	// Get the auth query secret if any
 	result.AuthUserSecret, err = getSecretOrNil(

--- a/internal/controller/pooler_resources.go
+++ b/internal/controller/pooler_resources.go
@@ -82,6 +82,9 @@ func (r *PoolerReconciler) getManagedResources(
 	if err != nil {
 		return nil, err
 	}
+	if result.Cluster == nil {
+		return result, nil
+	}
 
 	// Get the auth query secret if any
 	result.AuthUserSecret, err = getSecretOrNil(

--- a/internal/controller/pooler_resources.go
+++ b/internal/controller/pooler_resources.go
@@ -82,9 +82,6 @@ func (r *PoolerReconciler) getManagedResources(
 	if err != nil {
 		return nil, err
 	}
-	if result.Cluster == nil {
-		return result, nil
-	}
 
 	// Get the auth query secret if any
 	result.AuthUserSecret, err = getSecretOrNil(


### PR DESCRIPTION
Fixing a `nil pointer` that would happen when reconciling a Pooler while its Cluster has been deleted.

Closes #10665 