### PR TITLE
fix: don't generate invalid IPv6 URLs

### DIFF
--- a/pkg/management/postgres/webserver/probes/pinger.go
+++ b/pkg/management/postgres/webserver/probes/pinger.go
@@ -25,14 +25,13 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	"net/url"
 	"os"
 	"path/filepath"
 	"time"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/certs"
-	cnpgUrl "github.com/cloudnative-pg/cloudnative-pg/pkg/management/url"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/url"
 	postgresSpec "github.com/cloudnative-pg/cloudnative-pg/pkg/postgres"
 )
 
@@ -84,15 +83,11 @@ func buildInstanceReachabilityChecker(cfg *apiv1.IsolationCheckConfiguration) (*
 // ping checks if the instance with the passed coordinates is reachable
 // by calling the failsafe endpoint.
 func (e *pinger) ping(host, ip string) error {
-	failsafeURL := url.URL{
-		Scheme: "https",
-		Host:   fmt.Sprintf("%s:%d", ip, cnpgUrl.StatusPort),
-		Path:   cnpgUrl.PathFailSafe,
-	}
+	failsafeURL := url.Build("https", ip, url.PathFailSafe, url.StatusPort)
 
 	var res *http.Response
 	var err error
-	if res, err = e.client.Get(failsafeURL.String()); err != nil {
+	if res, err = e.client.Get(failsafeURL); err != nil {
 		return &pingError{
 			host:   host,
 			ip:     ip,

--- a/pkg/management/url/suite_test.go
+++ b/pkg/management/url/suite_test.go
@@ -1,0 +1,32 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package url
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestUrl(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Url Suite")
+}

--- a/pkg/management/url/url.go
+++ b/pkg/management/url/url.go
@@ -21,7 +21,9 @@ SPDX-License-Identifier: Apache-2.0
 package url
 
 import (
-	"fmt"
+	"net"
+	neturl "net/url"
+	"strconv"
 )
 
 const (
@@ -84,9 +86,10 @@ func Local(path string, port int32) string {
 
 // Build builds an url given the hostname and the path, pointing to the status web server
 func Build(scheme, hostname, path string, port int32) string {
-	// If path already starts with '/' we remove it
-	if path[0] == '/' {
-		path = path[1:]
+	url := neturl.URL{
+		Scheme: scheme,
+		Host:   net.JoinHostPort(hostname, strconv.Itoa(int(port))),
+		Path:   path,
 	}
-	return fmt.Sprintf("%s://%s:%d/%s", scheme, hostname, port, path)
+	return url.String()
 }

--- a/pkg/management/url/url_test.go
+++ b/pkg/management/url/url_test.go
@@ -1,0 +1,93 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package url
+
+import (
+	"net"
+	neturl "net/url"
+	"strconv"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("URL", func() {
+	cases := []struct {
+		scheme string
+		host   string
+		port   int32
+		path   string
+		expect string
+	}{
+		{
+			// path has leading slash
+			scheme: "http",
+			host:   "localhost",
+			port:   1234,
+			path:   "/foo",
+			expect: "http://localhost:1234/foo",
+		},
+		{
+			// path has no leading slash
+			scheme: "http",
+			host:   "localhost",
+			port:   1234,
+			path:   "foo",
+			expect: "http://localhost:1234/foo",
+		},
+		{
+			// ipv4 address
+			scheme: "http",
+			host:   "1.2.3.4",
+			port:   1234,
+			path:   "foo",
+			expect: "http://1.2.3.4:1234/foo",
+		},
+		{
+			// ipv6 address
+			scheme: "http",
+			host:   "1:2:3::4",
+			port:   1234,
+			path:   "foo",
+			expect: "http://[1:2:3::4]:1234/foo",
+		},
+	}
+
+	It("generates the expected url", func() {
+		for _, unit := range cases {
+			Expect(Build(unit.scheme, unit.host, unit.path, unit.port)).To(Equal(unit.expect))
+		}
+	})
+
+	It("roundtrips", func() {
+		for _, unit := range cases {
+			url := Build(unit.scheme, unit.host, unit.path, unit.port)
+			parsed, err := neturl.Parse(url)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(parsed.Scheme).To(Equal(unit.scheme))
+			port := strconv.Itoa(int(unit.port))
+			Expect(parsed.Host).To(Equal(net.JoinHostPort(unit.host, port)))
+			Expect(parsed.Port()).To(Equal(port))
+			// parsed.Path always has a leading slash
+			Expect(parsed.Path).To(Equal("/" + strings.TrimPrefix(unit.path, "/")))
+		}
+	})
+})


### PR DESCRIPTION
When connecting to an IPv6 address via URL, the address must be in square brackets.  Use standard library functions that do the right thing.

Closes #10679