### PR TITLE
ci: align E2E cluster node sizing across cloud providers

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -1209,7 +1209,7 @@ jobs:
             az aks create --resource-group ${{ secrets.AZURE_RESOURCEGROUP }} \
               --name ${AZURE_AKS} \
               --tier standard \
-              --node-count 3 -k v${K8S_VERSION} --generate-ssh-keys --enable-addons monitoring \
+              --node-count 3 --node-vm-size Standard_D4s_v5 -k v${K8S_VERSION} --generate-ssh-keys --enable-addons monitoring \
               --workspace-resource-id ${{ secrets.AZURE_WORKSPACE_RESOURCE_ID }} \
               --aks-custom-headers EnableAzureDiskFileCSIDriver=true
             az aks get-credentials --resource-group ${{ secrets.AZURE_RESOURCEGROUP }} \
@@ -1945,8 +1945,8 @@ jobs:
               --num-nodes=1 \
               --cluster-version=${{ env.K8S_VERSION }} \
               --region=${{ env.REGION }} \
-              --disk-size=20 \
-              --machine-type=e2-standard-2 \
+              --disk-size=80 \
+              --machine-type=e2-standard-4 \
               --labels=cluster=${{ env.CLUSTER_NAME }}
             then
               exit 0

--- a/hack/e2e/eks-cluster.yaml.template
+++ b/hack/e2e/eks-cluster.yaml.template
@@ -11,7 +11,7 @@ iam:
 
 managedNodeGroups:
   - name: default
-    instanceType: c6a.xlarge
+    instanceType: m6a.xlarge
     desiredCapacity: 3
 
 addons:


### PR DESCRIPTION
GKE nightly E2E fails intermittently when a replica pod cannot be scheduled: the zonal PD is pinned to a node that the kubelet has tainted under disk pressure caused by the container image cache filling the 20 GiB boot disk. AKS occasionally picks Standard_D4plds_v5 (arm64) when --node-vm-size is unset, mixing architectures across the matrix and reducing test consistency.

Pin all three managed providers to x86_64 4-vCPU SKUs and raise GKE's boot disk to match EKS: e2-standard-4 with 80 GiB on GKE, Standard_D4s_v5 on AKS, m6a.xlarge on EKS.

Closes #8331 