### PR TITLE
ci(backport): auto-resolve go.mod/go.sum conflicts and Go bumps

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -90,27 +90,7 @@ jobs:
           ref: ${{ env.BRANCH }}
           token: ${{ secrets.REPO_GHA_PAT }}
       -
-        name: Install Go
-        if: contains( github.event.pull_request.labels.*.name, env.BRANCH )
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
-        with:
-          go-version-file: go.mod
-          check-latest: true
-          cache: false
-      -
-        name: Cache Go modules
-        if: contains( github.event.pull_request.labels.*.name, env.BRANCH )
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
-        with:
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
-          key: backport-go-${{ runner.os }}-${{ matrix.branch }}-${{ hashFiles('go.sum') }}
-          restore-keys: |
-            backport-go-${{ runner.os }}-${{ matrix.branch }}-
-            backport-go-${{ runner.os }}-
-      -
-        name: Check commits
+        name: Check commits and detect Go version
         if: contains( github.event.pull_request.labels.*.name, env.BRANCH )
         id: check_commits
         env:
@@ -127,13 +107,59 @@ jobs:
           author_name=$(git show -s --format='%an' "${commit}" | head -n1)
           author_email=$(git show -s --format='%ae' "${commit}" | head -n1)
 
+          # Detect the Go version to install. If the picked commit changes the
+          # `go` or `toolchain` directive, use the picked value (so Go-version
+          # bumps cherry-pick cleanly); otherwise use the release branch's
+          # current value. Install whichever of the two is set (toolchain wins
+          # because it is always >= the go directive by Go's invariants).
+          parent_go=$(git show "${commit}^:go.mod" 2>/dev/null | sed -n 's/^go //p' | head -1)
+          picked_go=$(git show "${commit}:go.mod"  2>/dev/null | sed -n 's/^go //p' | head -1)
+          branch_go=$(sed -n 's/^go //p' go.mod | head -1)
+          parent_tc=$(git show "${commit}^:go.mod" 2>/dev/null | sed -n 's/^toolchain go//p' | head -1)
+          picked_tc=$(git show "${commit}:go.mod"  2>/dev/null | sed -n 's/^toolchain go//p' | head -1)
+          branch_tc=$(sed -n 's/^toolchain go//p' go.mod | head -1)
+          if [ -n "${picked_go}" ] && [ "${picked_go}" != "${parent_go}" ]; then
+            eff_go=${picked_go}
+          else
+            eff_go=${branch_go}
+          fi
+          if [ "${picked_tc}" != "${parent_tc}" ]; then
+            eff_tc=${picked_tc}
+          else
+            eff_tc=${branch_tc}
+          fi
+          go_version=${eff_tc:-$eff_go}
+
           echo "commit=${commit}" >> $GITHUB_OUTPUT
-          echo "cherry-pick commit ${commit} to branch ${BRANCH}"
+          echo "go_version=${go_version}" >> $GITHUB_OUTPUT
+          echo "cherry-pick commit ${commit} to branch ${BRANCH} with Go ${go_version}"
 
           echo "AUTHOR_NAME=${author_name}" >> $GITHUB_ENV
           echo "AUTHOR_EMAIL=${author_email}" >> $GITHUB_ENV
       -
-        name: cherry pick
+        name: Install Go
+        if: |
+          contains( github.event.pull_request.labels.*.name, env.BRANCH ) && steps.check_commits.outputs.commit != ''
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version: ${{ steps.check_commits.outputs.go_version }}
+          check-latest: true
+          cache: false
+      -
+        name: Cache Go modules
+        if: |
+          contains( github.event.pull_request.labels.*.name, env.BRANCH ) && steps.check_commits.outputs.commit != ''
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: backport-go-${{ runner.os }}-${{ matrix.branch }}-${{ hashFiles('go.sum') }}
+          restore-keys: |
+            backport-go-${{ runner.os }}-${{ matrix.branch }}-
+            backport-go-${{ runner.os }}-
+      -
+        name: cherry pick and push
         env:
           COMMIT: ${{ steps.check_commits.outputs.commit }}
         if: |
@@ -141,8 +167,47 @@ jobs:
         run: |
           git config user.email "${AUTHOR_EMAIL}"
           git config user.name "${AUTHOR_NAME}"
-          git fetch
-          git cherry-pick -x --mainline 1 "${COMMIT}"
+
+          # Register a no-op merge driver and apply it to go.mod / go.sum so
+          # the cherry-pick never duplicates singleton directives or hashes:
+          # conflicting regions keep the release branch's version unchanged
+          # (the driver is `true`, which leaves the target file untouched).
+          # The picked commit's intent is then replayed semantically below
+          # via `go mod edit`, ignoring any line context that may have
+          # diverged. `--keep-redundant-commits` lets the cherry-pick create
+          # an empty commit when the driver discards every change in the
+          # picked commit (e.g. a pure go.mod bump on a divergent branch);
+          # the replay then re-adds the intended change and the Reconcile
+          # step amends it onto that commit.
+          git config merge.keep-ours.name "Keep ours (release branch) version"
+          git config merge.keep-ours.driver "true"
+          mkdir -p .git/info
+          cat > .git/info/attributes <<'EOF'
+          go.mod merge=keep-ours
+          go.sum merge=keep-ours
+          EOF
+
+          git cherry-pick -x --mainline 1 --keep-redundant-commits "${COMMIT}"
+
+          # Replay the picked commit's go.mod intent surgically (no-op when
+          # the picked commit doesn't touch go.mod).
+          hack/replay-gomod.sh "${COMMIT}"
+
+          # If the cherry-pick commit or the semantic replay above touched
+          # go.mod/go.sum, settle go.sum with `go mod tidy`, verify hashes,
+          # and fold the result into the cherry-pick commit so it lands as
+          # a single commit. The replay leaves go.mod modified in the
+          # working tree without staging it, so we also check that.
+          if git diff-tree --no-commit-id --name-only -r HEAD | grep -qE '^go\.(mod|sum)$' \
+             || ! git diff --quiet -- go.mod go.sum; then
+            go mod tidy
+            go mod verify
+            if ! git diff --quiet go.mod go.sum; then
+              git add go.mod go.sum
+              git commit --amend --no-edit
+            fi
+          fi
+
           make fmt vet generate apidoc wordlist-ordered
           if ! git diff --exit-code --quiet
           then

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -123,7 +123,7 @@ jobs:
           else
             eff_go=${branch_go}
           fi
-          if [ "${picked_tc}" != "${parent_tc}" ]; then
+          if [ -n "${picked_tc}" ] && [ "${picked_tc}" != "${parent_tc}" ]; then
             eff_tc=${picked_tc}
           else
             eff_tc=${branch_tc}
@@ -187,7 +187,7 @@ jobs:
           go.sum merge=keep-ours
           EOF
 
-          git cherry-pick -x --mainline 1 --keep-redundant-commits "${COMMIT}"
+          git cherry-pick -x --mainline 1 --empty=keep "${COMMIT}"
 
           # Replay the picked commit's go.mod intent surgically (no-op when
           # the picked commit doesn't touch go.mod).

--- a/hack/replay-gomod.sh
+++ b/hack/replay-gomod.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+##
+## Copyright © contributors to CloudNativePG, established as
+## CloudNativePG a Series of LF Projects, LLC.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##     http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+
+##
+## Replay a commit's go.mod intent onto the current working tree.
+##
+## When cherry-picking a commit that changes go.mod and the release branch
+## has diverged on context, git's textual merge gives up or produces noisy
+## output. This script applies the picked commit's go.mod operations
+## semantically (via `go mod edit`), regardless of line context:
+##
+##   - Apply the `go` directive if the commit changed it
+##   - Apply the `toolchain` directive if the commit changed it
+##   - Apply each require addition or version change
+##   - Drop requires the commit removed
+##
+## Used by the backport workflow and available for maintainers finishing a
+## backport by hand. Does not regenerate go.sum; run `go mod tidy` and
+## `go mod verify` afterwards to settle hashes.
+##
+## Usage: hack/replay-gomod.sh <commit-sha>
+
+set -euo pipefail
+
+if [ $# -ne 1 ]; then
+    echo "Usage: $0 <commit-sha>" >&2
+    exit 1
+fi
+
+commit=$1
+
+if ! git diff-tree --no-commit-id --name-only -r "${commit}" | grep -qE '^go\.mod$'; then
+    echo "Commit ${commit} does not touch go.mod; nothing to replay." >&2
+    exit 0
+fi
+
+PARENT_GO_MOD=$(mktemp)
+PICKED_GO_MOD=$(mktemp)
+trap 'rm -f "${PARENT_GO_MOD}" "${PICKED_GO_MOD}"' EXIT
+
+git show "${commit}^:go.mod" > "${PARENT_GO_MOD}"
+git show "${commit}:go.mod"  > "${PICKED_GO_MOD}"
+
+# go directive
+PICKED_GO=$(go mod edit -json "${PICKED_GO_MOD}" | jq -r '.Go // ""')
+PARENT_GO=$(go mod edit -json "${PARENT_GO_MOD}" | jq -r '.Go // ""')
+if [ "${PICKED_GO}" != "${PARENT_GO}" ] && [ -n "${PICKED_GO}" ]; then
+    go mod edit -go="${PICKED_GO}"
+fi
+
+# toolchain directive
+PICKED_TC=$(go mod edit -json "${PICKED_GO_MOD}" | jq -r '.Toolchain // ""')
+PARENT_TC=$(go mod edit -json "${PARENT_GO_MOD}" | jq -r '.Toolchain // ""')
+if [ "${PICKED_TC}" != "${PARENT_TC}" ]; then
+    if [ -n "${PICKED_TC}" ]; then
+        go mod edit -toolchain="${PICKED_TC}"
+    else
+        go mod edit -droptoolchain
+    fi
+fi
+
+# require directives: additions and version changes
+EXTRACT='[.Require[]? | "\(.Path)@\(.Version)"] | sort | .[]'
+while IFS= read -r req; do
+    [ -z "${req}" ] && continue
+    go mod edit -require="${req}"
+done < <(comm -23 \
+    <(go mod edit -json "${PICKED_GO_MOD}" | jq -r "${EXTRACT}") \
+    <(go mod edit -json "${PARENT_GO_MOD}" | jq -r "${EXTRACT}"))
+
+# require directives: removals
+EXTRACT_PATH='[.Require[]? | .Path] | sort | unique | .[]'
+while IFS= read -r path; do
+    [ -z "${path}" ] && continue
+    go mod edit -droprequire="${path}" 2>/dev/null || true
+done < <(comm -23 \
+    <(go mod edit -json "${PARENT_GO_MOD}" | jq -r "${EXTRACT_PATH}") \
+    <(go mod edit -json "${PICKED_GO_MOD}" | jq -r "${EXTRACT_PATH}"))


### PR DESCRIPTION
Cherry-picks that conflicted on go.mod or go.sum forced a maintainer to finish backports by hand, and Go-version bumps failed because setup-go installed the release branch's Go before the cherry-pick.

Apply a `keep-ours` merge driver to go.mod and go.sum during the cherry-pick so conflicting regions keep the release branch's version, then replay the picked commit's intent semantically via `go mod edit` so the change applies regardless of line context. The replay logic lives in `hack/replay-gomod.sh` so maintainers can also call it when finishing a backport by hand. Detect the picked commit's target Go directive up front and install that version with setup-go, so the rest of the workflow runs on the right toolchain. Settle go.sum with `go mod tidy` and verify hashes.

Closes #10709
