### PR TITLE
ci(renovate): target only main, drop per-branch PR fan-out

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -10,9 +10,6 @@
   prConcurrentLimit: 5,
   baseBranchPatterns: [
     'main',
-    'release-1.25',
-    'release-1.28',
-    'release-1.29',
   ],
   ignorePaths: [
     'docs/**',
@@ -27,7 +24,6 @@
   semanticCommits: 'enabled',
   labels: [
     'automated',
-    'do not backport',
     'no-issue',
   ],
   'pip-compile': {


### PR DESCRIPTION
Renovate currently opens a separate dependency-bump PR on each active release branch (plus main) and labels its own PRs with `do not backport` so the backport workflow leaves them alone.

Drop the `release-*` entries from `baseBranchPatterns` and the `do not backport` label. Renovate now opens dependency PRs only on `main`; the standard `backport-requested` labelling carries the merge onto release branches via the backport workflow.

Depends on #10709 landing first so the backport workflow can carry `go.mod` / `go.sum` and Go-directive changes.

Closes #10710
