### PR TITLE
fix: reset superuser secret version

### DIFF
--- a/internal/controller/cluster_status.go
+++ b/internal/controller/cluster_status.go
@@ -566,6 +566,9 @@ func (r *ClusterReconciler) refreshSecretResourceVersions(ctx context.Context, c
 			return err
 		}
 		versions.SuperuserSecretVersion = version
+	} else {
+		// Resets the version when superuser access is disabled
+		versions.SuperuserSecretVersion = ""
 	}
 
 	version, err = r.getSecretResourceVersion(ctx, cluster, cluster.GetApplicationSecretName())

--- a/internal/controller/cluster_status_test.go
+++ b/internal/controller/cluster_status_test.go
@@ -585,3 +585,58 @@ var _ = Describe("updateClusterStatusThatRequiresInstancesState tests", func() {
 		})
 	})
 })
+
+var _ = Describe("refreshSecretResourceVersions tests", func() {
+	var (
+		env     *testingEnvironment
+		cluster *apiv1.Cluster
+	)
+
+	BeforeEach(func() {
+		env = buildTestEnvironment()
+		cluster = newFakeCNPGCluster(env.client, newFakeNamespace(env.client))
+	})
+
+	It("should set superuser secret version", func(ctx SpecContext) {
+		// set up superuser secret and grab the resource version from it
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-secret",
+				Namespace: cluster.Namespace,
+			},
+		}
+		err := env.clusterReconciler.Client.Create(context.TODO(), secret)
+		Expect(err).To(BeNil())
+		err = env.clusterReconciler.Client.Get(context.TODO(), types.NamespacedName{Name: "test-secret", Namespace: cluster.Namespace}, secret)
+		Expect(err).To(BeNil())
+		expectedResourceVersion := secret.ObjectMeta.ResourceVersion
+		Expect(expectedResourceVersion).NotTo(BeEmpty())
+
+		cluster.Status.SecretsResourceVersion = apiv1.SecretsResourceVersion{
+			SuperuserSecretVersion: "",
+		}
+		val := true
+		cluster.Spec.EnableSuperuserAccess = &val
+		cluster.Spec.SuperuserSecret = &apiv1.LocalObjectReference{
+			Name: "test-secret",
+		}
+
+		err = env.clusterReconciler.refreshSecretResourceVersions(ctx, cluster)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(cluster.Status.SecretsResourceVersion.SuperuserSecretVersion).To(Equal(expectedResourceVersion))
+	})
+
+	It("should reset superuser secret version", func(ctx SpecContext) {
+		cluster.Status.SecretsResourceVersion = apiv1.SecretsResourceVersion{
+			SuperuserSecretVersion: "42",
+		}
+		val := false
+		cluster.Spec.EnableSuperuserAccess = &val
+
+		err := env.clusterReconciler.refreshSecretResourceVersions(ctx, cluster)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(cluster.Status.SecretsResourceVersion.SuperuserSecretVersion).To(BeEmpty())
+	})
+})


### PR DESCRIPTION
Clear superuser secret version, when superuser access is disabled (fixes #9721)

Implementation gotten from https://github.com/cloudnative-pg/cloudnative-pg/pull/9765