### PR TITLE
ci: run scheduled e2e on k3d via helm

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -861,7 +861,6 @@ jobs:
     name: Run E2E on K3D
     if: |
       (always() && !cancelled()) &&
-      github.event_name == 'workflow_dispatch' ||
       vars.K3D_ENABLED == 'true' &&
       needs.generate-jobs.outputs.k3dEnabled == 'true' &&
       needs.generate-jobs.result == 'success'

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -861,7 +861,8 @@ jobs:
     name: Run E2E on K3D
     if: |
       (always() && !cancelled()) &&
-      github.event_name == 'workflow_dispatch' &&
+      github.event_name == 'workflow_dispatch' ||
+      vars.K3D_ENABLED == 'true' &&
       needs.generate-jobs.outputs.k3dEnabled == 'true' &&
       needs.generate-jobs.result == 'success'
     needs:

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -901,7 +901,7 @@ jobs:
       LOG_DIR: ${{ github.workspace }}/k3d-logs/
       DOCKER_REGISTRY_MIRROR: https://mirror.gcr.io
       TEST_CLOUD_VENDOR: "k3d"
-      CNPG_DEPLOYMENT_METHOD: ${{ needs.evaluate_options.outputs.cnpg_deployment_method }}
+      CNPG_DEPLOYMENT_METHOD: ${{ github.event_name == 'schedule' && 'helm' || needs.evaluate_options.outputs.cnpg_deployment_method }}
     steps:
       - name: Cleanup Disk
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1

--- a/hack/testing-tools/common/20-utils-k8s.sh
+++ b/hack/testing-tools/common/20-utils-k8s.sh
@@ -397,6 +397,10 @@ function deploy_operator_with_helm() {
         --set "additionalArgs[0]=--secret-name=cnpg-controller-manager-config"
     )
 
+    if ${K8S_CLI} get secret cnpg-pull-secret -n cnpg-system >/dev/null 2>&1; then
+        helm_args+=(--set "imagePullSecrets[0].name=cnpg-pull-secret")
+    fi
+
     if [[ -n "${CNPG_CHART_VERSION:-}" ]]; then
         helm_args+=(--version "${CNPG_CHART_VERSION}")
     fi


### PR DESCRIPTION
Add the K3D e2e job to scheduled runs. Opt-in via the new
`vars.K3D_ENABLED` repository variable, matching the gate already
used by AKS, EKS, GKE, and OpenShift. On scheduled runs the
operator is deployed via Helm, enabling continuous coverage of the
Helm install path.

Also pass `cnpg-pull-secret` to the Helm deploy path when present,
mirroring the kustomize overlay so private-registry runs can pull
the operator image.

Closes #10653