### PR TITLE
fix(backups): concurrent backups election logic

### DIFF
--- a/api/v1/backup_funcs.go
+++ b/api/v1/backup_funcs.go
@@ -142,17 +142,23 @@ func (backupStatus *BackupStatus) IsInProgress() bool {
 		backupStatus.Phase == BackupPhaseRunning
 }
 
+// IsExecuting check if a certain backup is being executed
+func (backupStatus *BackupStatus) IsExecuting() bool {
+	return backupStatus.Phase == BackupPhaseStarted ||
+		backupStatus.Phase == BackupPhaseRunning
+}
+
 // GetPendingBackupNames returns the pending backup list
 func (list BackupList) GetPendingBackupNames() []string {
 	// Retry the backup if another backup is running
 	pendingBackups := make([]string, 0, len(list.Items))
 	for _, concurrentBackup := range list.Items {
-		if concurrentBackup.Status.IsDone() {
+		if concurrentBackup.Status.IsDone() ||
+			concurrentBackup.Status.IsExecuting() {
 			continue
 		}
-		if !concurrentBackup.Status.IsInProgress() {
-			pendingBackups = append(pendingBackups, concurrentBackup.Name)
-		}
+
+		pendingBackups = append(pendingBackups, concurrentBackup.Name)
 	}
 
 	return pendingBackups
@@ -161,34 +167,25 @@ func (list BackupList) GetPendingBackupNames() []string {
 // CanExecuteBackup control if we can start a reconciliation loop for a certain backup.
 //
 // A reconciliation loop can start if:
-// - there's no backup running, and if the first of the sorted list of backups
+// - there's no backup running, and the backup is the first of the sorted list of backups
 // - the current backup is running and is the first running backup of the list
 //
 // As a side effect, this function will sort the backup list
 func (list *BackupList) CanExecuteBackup(backupName string) bool {
-	var foundRunningBackup bool
-
-	list.SortByName()
+	list.SortByCreationTimeAndName()
 
 	for _, concurrentBackup := range list.Items {
-		if concurrentBackup.Status.IsInProgress() {
-			if backupName == concurrentBackup.Name && !foundRunningBackup {
-				return true
-			}
-
-			foundRunningBackup = true
-			if backupName != concurrentBackup.Name {
-				return false
-			}
+		if concurrentBackup.Status.IsExecuting() {
+			return backupName == concurrentBackup.Name
 		}
 	}
 
 	pendingBackups := list.GetPendingBackupNames()
-	if len(pendingBackups) > 0 && pendingBackups[0] != backupName {
-		return false
+	if len(pendingBackups) > 0 && pendingBackups[0] == backupName {
+		return true
 	}
 
-	return true
+	return false
 }
 
 // SortByName sorts the backup items in alphabetical order
@@ -204,6 +201,19 @@ func (list *BackupList) SortByReverseCreationTime() {
 	// Sort the list of backups in reverse creation time
 	sort.Slice(list.Items, func(i, j int) bool {
 		return list.Items[i].CreationTimestamp.Compare(list.Items[j].CreationTimestamp.Time) > 0
+	})
+}
+
+// SortByCreationTimeAndName sorts the backup items in creation time order and,
+// in case of backups with the same creation time, in alphabetical order
+func (list *BackupList) SortByCreationTimeAndName() {
+	sort.Slice(list.Items, func(i, j int) bool {
+		ti := list.Items[i].CreationTimestamp.Time
+		tj := list.Items[j].CreationTimestamp.Time
+		if ti.Equal(tj) {
+			return list.Items[i].Name < list.Items[j].Name
+		}
+		return ti.Before(tj)
 	})
 }
 

--- a/api/v1/backup_funcs.go
+++ b/api/v1/backup_funcs.go
@@ -167,10 +167,11 @@ func (list BackupList) GetPendingBackupNames() []string {
 // CanExecuteBackup control if we can start a reconciliation loop for a certain backup.
 //
 // A reconciliation loop can start if:
-// - there's no backup running, and the backup is the first of the sorted list of backups
-// - the current backup is running and is the first running backup of the list
+//   - the backup is currently being executed (Started or Running), or
+//   - no other backup is being executed and the backup is the oldest pending one
+//     (with backup name used as a tie-breaker for backups created at the same time).
 //
-// As a side effect, this function will sort the backup list
+// As a side effect, this function will sort the backup list by creation time.
 func (list *BackupList) CanExecuteBackup(backupName string) bool {
 	list.SortByCreationTimeAndName()
 

--- a/api/v1/backup_funcs_test.go
+++ b/api/v1/backup_funcs_test.go
@@ -40,6 +40,7 @@ var _ = Describe("BackupStatus structure", func() {
 		status.SetAsPending()
 		Expect(status.Phase).To(BeEquivalentTo(BackupPhasePending))
 		Expect(status.IsInProgress()).To(BeTrue())
+		Expect(status.IsExecuting()).To(BeFalse())
 		Expect(status.IsDone()).To(BeFalse())
 	})
 
@@ -131,6 +132,7 @@ var _ = Describe("BackupStatus structure", func() {
 					Phase: BackupPhaseRunning,
 				}
 				Expect(b.IsInProgress()).To(BeTrue())
+				Expect(b.IsExecuting()).To(BeTrue())
 				Expect(b.IsDone()).To(BeFalse())
 			})
 		})
@@ -141,6 +143,7 @@ var _ = Describe("BackupStatus structure", func() {
 					Phase: BackupPhasePending,
 				}
 				Expect(b.IsInProgress()).To(BeTrue())
+				Expect(b.IsExecuting()).To(BeFalse())
 				Expect(b.IsDone()).To(BeFalse())
 			})
 		})
@@ -151,6 +154,7 @@ var _ = Describe("BackupStatus structure", func() {
 					Phase: BackupPhaseCompleted,
 				}
 				Expect(b.IsInProgress()).To(BeFalse())
+				Expect(b.IsExecuting()).To(BeFalse())
 				Expect(b.IsDone()).To(BeTrue())
 			})
 		})
@@ -161,6 +165,7 @@ var _ = Describe("BackupStatus structure", func() {
 					Phase: BackupPhaseFailed,
 				}
 				Expect(b.IsInProgress()).To(BeFalse())
+				Expect(b.IsExecuting()).To(BeFalse())
 				Expect(b.IsDone()).To(BeTrue())
 			})
 		})
@@ -228,6 +233,70 @@ var _ = Describe("BackupList structure", func() {
 		Expect(backupList.Items[2].Name).To(Equal("backup-ten-minutes"))
 	})
 
+	It("can be sorted by creation time and name", func() {
+		now := time.Now()
+		backupList := BackupList{
+			Items: []Backup{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "backup-now",
+						CreationTimestamp: metav1.NewTime(now),
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "backup-ten-minutes",
+						CreationTimestamp: metav1.NewTime(now.Add(-10 * time.Minute)),
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "backup-five-minutes",
+						CreationTimestamp: metav1.NewTime(now.Add(-5 * time.Minute)),
+					},
+				},
+			},
+		}
+		backupList.SortByCreationTimeAndName()
+
+		Expect(backupList.Items).To(HaveLen(3))
+		Expect(backupList.Items[0].Name).To(Equal("backup-ten-minutes"))
+		Expect(backupList.Items[1].Name).To(Equal("backup-five-minutes"))
+		Expect(backupList.Items[2].Name).To(Equal("backup-now"))
+	})
+
+	It("breaks ties by name when creation times are equal", func() {
+		now := time.Now()
+		backupList := BackupList{
+			Items: []Backup{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "backup-c",
+						CreationTimestamp: metav1.NewTime(now),
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "backup-a",
+						CreationTimestamp: metav1.NewTime(now),
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "backup-b",
+						CreationTimestamp: metav1.NewTime(now),
+					},
+				},
+			},
+		}
+		backupList.SortByCreationTimeAndName()
+
+		Expect(backupList.Items).To(HaveLen(3))
+		Expect(backupList.Items[0].Name).To(Equal("backup-a"))
+		Expect(backupList.Items[1].Name).To(Equal("backup-b"))
+		Expect(backupList.Items[2].Name).To(Equal("backup-c"))
+	})
+
 	It("can isolate pending backups", func() {
 		backupList := BackupList{
 			Items: []Backup{
@@ -265,12 +334,20 @@ var _ = Describe("BackupList structure", func() {
 						Phase: BackupPhaseFailed,
 					},
 				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "backup-7",
+					},
+					Status: BackupStatus{
+						Phase: BackupPhasePending,
+					},
+				},
 			},
 		}
 		backupList.SortByName()
 
 		pendingBackups := backupList.GetPendingBackupNames()
-		Expect(pendingBackups).To(ConsistOf("backup-1", "backup-2"))
+		Expect(pendingBackups).To(ConsistOf("backup-1", "backup-2", "backup-7"))
 	})
 })
 

--- a/api/v1/backup_funcs_test.go
+++ b/api/v1/backup_funcs_test.go
@@ -481,6 +481,71 @@ var _ = Describe("backup_controller volumeSnapshot unit tests", func() {
 			Expect(backupList.CanExecuteBackup("backup-3")).To(BeFalse())
 		})
 	})
+
+	When("a newer pending backup sorts alphabetically before an older started one", func() {
+		// Regression guard for the preemption bug fixed in this change:
+		// an alphabetically-earlier Pending backup must not preempt an
+		// older Started backup that has already acquired resources.
+		It("keeps the older started backup as the elected one", func() {
+			now := time.Now()
+			backupList := BackupList{
+				Items: []Backup{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:              "backup-a-newer",
+							CreationTimestamp: metav1.NewTime(now),
+						},
+						Status: BackupStatus{
+							Phase: BackupPhasePending,
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:              "backup-z-older",
+							CreationTimestamp: metav1.NewTime(now.Add(-10 * time.Minute)),
+						},
+						Status: BackupStatus{
+							Phase: BackupPhaseStarted,
+						},
+					},
+				},
+			}
+
+			Expect(backupList.CanExecuteBackup("backup-z-older")).To(BeTrue())
+			Expect(backupList.CanExecuteBackup("backup-a-newer")).To(BeFalse())
+		})
+	})
+
+	When("the only pending backups have diverging name and creation order", func() {
+		It("elects the oldest pending backup regardless of name", func() {
+			now := time.Now()
+			backupList := BackupList{
+				Items: []Backup{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:              "backup-a-newer",
+							CreationTimestamp: metav1.NewTime(now),
+						},
+						Status: BackupStatus{
+							Phase: BackupPhasePending,
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:              "backup-z-older",
+							CreationTimestamp: metav1.NewTime(now.Add(-10 * time.Minute)),
+						},
+						Status: BackupStatus{
+							Phase: BackupPhasePending,
+						},
+					},
+				},
+			}
+
+			Expect(backupList.CanExecuteBackup("backup-z-older")).To(BeTrue())
+			Expect(backupList.CanExecuteBackup("backup-a-newer")).To(BeFalse())
+		})
+	})
 })
 
 var _ = Describe("IsCompletedVolumeSnapshot", func() {


### PR DESCRIPTION
## Summary

  - Fix backup election logic in `CanExecuteBackup()` that could preempt an
  already-started backup in favor of a newer one whose name sorts earlier
  alphabetically
  - Sort backups by creation time (oldest first) instead of alphabetically, so
  the backup that started first always wins the election
  - Introduce `IsExecuting()` helper to distinguish backups that have acquired
  resources (started/running) from those still waiting (pending), without
  changing the existing IsInProgress() semantics

The fix replaces alphabetical sorting with creation-time sorting (`SortByCreationTimeAndName`), ensuring the oldest backup always sorts first. This ensures a newer backup can never reach started phase while an older one is still in progress — the older one would have blocked it via the election check.

Closes #10622