### PR TITLE
fix(bootstrap): set up metrics-exporter role in a separate transaction

### DIFF
--- a/internal/cmd/manager/instance/run/lifecycle/run.go
+++ b/internal/cmd/manager/instance/run/lifecycle/run.go
@@ -197,9 +197,13 @@ func configureInstancePermissions(ctx context.Context, instance *postgres.Instan
 		return err
 	}
 
+	// Set up the metrics-exporter role in a separate transaction: the
+	// InstanceReconciler also creates this role on the primary, so a
+	// duplicate-key race here must not roll back the replication-user setup
+	// committed above (see issue #10748).
 	tx, err = db.BeginTx(ctx, nil)
 	if err != nil {
-		return fmt.Errorf("creating a new transaction to setup the instance: %w", err)
+		return fmt.Errorf("creating a new transaction to set up the metrics exporter role: %w", err)
 	}
 
 	if err = postgres.SetupMetricsExporterRole(ctx, tx); err != nil {

--- a/internal/cmd/manager/instance/run/lifecycle/run.go
+++ b/internal/cmd/manager/instance/run/lifecycle/run.go
@@ -194,7 +194,10 @@ func configureInstancePermissions(ctx context.Context, instance *postgres.Instan
 		return err
 	}
 
-	tx.Commit()
+	if err = tx.Commit(); err != nil {
+		return err
+	}
+
 	tx, err = db.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("creating a new transaction to setup the instance: %w", err)

--- a/internal/cmd/manager/instance/run/lifecycle/run.go
+++ b/internal/cmd/manager/instance/run/lifecycle/run.go
@@ -194,6 +194,12 @@ func configureInstancePermissions(ctx context.Context, instance *postgres.Instan
 		return err
 	}
 
+	tx.Commit()
+	tx, err = db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("creating a new transaction to setup the instance: %w", err)
+	}
+
 	if err = postgres.SetupMetricsExporterRole(ctx, tx); err != nil {
 		_ = tx.Rollback()
 		return err

--- a/internal/cmd/manager/instance/run/lifecycle/run.go
+++ b/internal/cmd/manager/instance/run/lifecycle/run.go
@@ -178,7 +178,6 @@ func configureInstancePermissions(ctx context.Context, instance *postgres.Instan
 
 	contextLogger.Debug("Validating DB configuration")
 
-	// A transaction is required to temporarily disable synchronous replication
 	tx, err := db.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("creating a new transaction to setup the instance: %w", err)


### PR DESCRIPTION
The bootstrap step on the primary used to run `streaming_replica` creation, pg_rewind grants, and `SetupMetricsExporterRole` in a single transaction. A failure during metrics-exporter setup (commonly a duplicate-key race with the controller reconciler) rolled the whole thing back, dropping `streaming_replica` and wedging replica joins until pod restart.

Split the bootstrap into two transactions so the metrics-exporter step can fail in isolation without touching the replication setup.

Closes #10748