### PR TITLE
fix(security): pin `search_path` on operator-issued connections

### DIFF
--- a/.wordlist-en-custom.txt
+++ b/.wordlist-en-custom.txt
@@ -69,6 +69,7 @@ CSV
 CSVs
 CVE
 CVEs
+CWE
 CannotReconcile
 Canovai
 CatalogComponentImage
@@ -557,6 +558,7 @@ URIs
 UTF
 Uncomment
 Unrealizable
+Untrusted
 UpdateStrategy
 UsageSpec
 UsageSpecType

--- a/docs/src/bootstrap.md
+++ b/docs/src/bootstrap.md
@@ -384,6 +384,16 @@ Objects in each list will be processed sequentially.
     leaving the cluster incomplete and requiring manual intervention.
 :::
 
+:::note
+These queries run with the standard `"$user", public` `search_path`, even
+though operator-issued connections otherwise pin a fixed `search_path` for
+security reasons.
+See [Schema resolution and `search_path` hardening](security.md#schema-resolution-and-search_path-hardening)
+for details.
+Schema-qualify object references if you need them to be independent of the
+`search_path`.
+:::
+
 :::info[Important]
     Ensure the existence of entries inside the ConfigMaps or Secrets specified
     in `postInitSQLRefs`, `postInitTemplateSQLRefs`, and

--- a/docs/src/connection_pooling.md
+++ b/docs/src/connection_pooling.md
@@ -198,14 +198,25 @@ GRANT CONNECT ON DATABASE postgres TO cnpg_pooler_pgbouncer;
 
 Create the lookup function for password verification. This function is created
 in the `postgres` database with `SECURITY DEFINER` privileges and is used by
-PgBouncer’s `auth_query` option:
+PgBouncer’s `auth_query` option. Because it runs as the function owner, its
+`search_path` is pinned to `pg_catalog, pg_temp` so that the function body
+cannot resolve operators or objects through a caller- or
+tenant-controlled `search_path`:
 
 ```sql
 CREATE OR REPLACE FUNCTION public.user_search(uname TEXT)
   RETURNS TABLE (usename name, passwd text)
-  LANGUAGE sql SECURITY DEFINER AS
+  LANGUAGE sql SECURITY DEFINER
+  SET search_path = pg_catalog, pg_temp AS
   'SELECT usename, passwd FROM pg_catalog.pg_shadow WHERE usename=$1;';
 ```
+
+:::note
+Clusters created with an earlier version of CloudNativePG carry a
+`user_search` function without the pinned `search_path`. The operator
+recreates the function with the `SET search_path` clause automatically
+during reconciliation when the cluster is upgraded.
+:::
 
 Restrict and grant permissions on the lookup function:
 

--- a/docs/src/installation_upgrade.md
+++ b/docs/src/installation_upgrade.md
@@ -317,6 +317,26 @@ according to its own `password_encryption` GUC.
 See ["Opting out of operator-side encoding"](declarative_role_management.md#opting-out-of-operator-side-encoding)
 for details.
 
+Also starting from versions 1.30.0 and 1.29.2, for security reasons,
+CloudNativePG pins the `search_path` to a fixed `pg_catalog, public,
+pg_temp` on every connection it opens to PostgreSQL, so that a
+tenant-controlled `ALTER DATABASE`/`ALTER ROLE` setting can no longer
+influence how operator-issued queries resolve unqualified object names.
+The `SECURITY DEFINER` lookup function used by the PgBouncer integration
+is recreated automatically with its own pinned `search_path` during the
+first reconciliation after the upgrade.
+See [Schema resolution and `search_path` hardening](security.md#schema-resolution-and-search_path-hardening)
+for the rationale.
+
+This change also affects custom monitoring queries, which now run inside
+a transaction whose `search_path` is pinned to `pg_catalog, public,
+pg_temp`. If any of your custom metrics reference objects that live in
+other user-defined schemas through an unqualified name, schema-qualify
+them (for example `myschema.mytable`) so they keep resolving after the
+upgrade. User-authored bootstrap (`postInit*`) and logical-import
+post-import SQL are unaffected: they continue to run with the standard
+`"$user", public` resolution.
+
 -->
 
 ### Upgrading to 1.29.1 or 1.28.3

--- a/docs/src/monitoring.md
+++ b/docs/src/monitoring.md
@@ -535,6 +535,14 @@ Take care that the referred resources have to be created **in the same namespace
     Schema-qualify catalog references (`pg_catalog.now()`,
     `pg_catalog.current_database()`) to prevent `search_path` shadowing
     by user-owned objects.
+
+    Custom monitoring queries run inside a transaction whose
+    `search_path` is pinned to `pg_catalog, public, pg_temp`,
+    regardless of any `search_path` configured on the database or the
+    role. Unqualified references to objects in other user-defined
+    schemas will therefore fail to resolve: schema-qualify them (e.g.
+    `myschema.mytable`) so the query does not depend on the
+    `search_path`.
 :::
 
 #### Example of a user defined metric

--- a/docs/src/security.md
+++ b/docs/src/security.md
@@ -850,6 +850,45 @@ For further detail on how `pg_ident.conf` is managed by the operator, see the
     Examples assume that the Kubernetes cluster runs in a private and secure network.
 :::
 
+#### Schema resolution and `search_path` hardening
+
+A user with privileges on a database can plant objects (functions,
+operators, tables, or types) in a writable schema such as `public` and
+change the database- or role-level `search_path` (for example with
+`ALTER DATABASE ... SET search_path` or `ALTER ROLE ... SET
+search_path`). A privileged session that later connects to that database
+inherits the tenant-controlled `search_path`, so an unqualified
+reference in one of its queries could resolve to the planted object
+instead of the intended one. This is a privilege-escalation vector
+analogous to
+[CWE-426 (Untrusted Search Path)](https://cwe.mitre.org/data/definitions/426.html),
+and the same class of issue as the well-known
+[CVE-2018-1058](https://www.postgresql.org/support/security/CVE-2018-1058/).
+
+To prevent this, CloudNativePG pins the `search_path` on every
+connection it opens to PostgreSQL to a fixed value of
+`pg_catalog, public, pg_temp`, regardless of any `search_path`
+configured on the database or the connecting role:
+
+- `pg_catalog` is searched first, so a built-in object always takes
+  precedence over a same-named object planted in another schema;
+- `pg_temp` (the session-private temporary schema) is searched last
+  rather than first, so it cannot shadow relations or data types.
+
+In addition, the `SECURITY DEFINER` lookup function used by the
+PgBouncer integration is created with its own pinned `search_path`, and
+the monitoring queries run inside a transaction whose `search_path` is
+pinned as described in the ["Monitoring" page](monitoring.md).
+
+:::note
+User-authored SQL — `postInitSQL`/`postInitApplicationSQL`/`postInitTemplateSQL`
+during bootstrap, and the post-import queries of a logical import — runs
+with the standard `"$user", public` resolution so that it keeps behaving
+as it would in a plain PostgreSQL session. Schema-qualify object
+references in those scripts if you need them to be independent of the
+`search_path`.
+:::
+
 ### Storage
 
 CloudNativePG delegates encryption at rest to the underlying storage class. For

--- a/internal/management/controller/database_controller_sql.go
+++ b/internal/management/controller/database_controller_sql.go
@@ -278,10 +278,10 @@ func createDatabaseExtension(ctx context.Context, db *sql.DB, ext apiv1.Extensio
 
 	// The pool pins search_path with pg_catalog first; under that pin a
 	// relocatable extension without an explicit SCHEMA would target
-	// pg_catalog (the first writable schema for the superuser). Acquire
-	// a dedicated *sql.Conn and SET search_path to "$user", public so
-	// extensions land in the standard user-data schema, matching the
-	// pre-pin default behavior.
+	// pg_catalog, where object creation is denied, so CREATE EXTENSION
+	// would fail. Acquire a dedicated *sql.Conn and SET search_path to
+	// "$user", public so extensions land in the standard user-data
+	// schema, matching the pre-pin default behavior.
 	conn, err := db.Conn(ctx)
 	if err != nil {
 		return fmt.Errorf("acquiring dedicated connection for CREATE EXTENSION: %w", err)

--- a/internal/management/controller/database_controller_sql.go
+++ b/internal/management/controller/database_controller_sql.go
@@ -276,8 +276,25 @@ func createDatabaseExtension(ctx context.Context, db *sql.DB, ext apiv1.Extensio
 		fmt.Fprintf(&sqlCreateExtension, " SCHEMA %s", pgx.Identifier{ext.Schema}.Sanitize())
 	}
 
-	_, err := db.ExecContext(ctx, sqlCreateExtension.String())
+	// The pool pins search_path with pg_catalog first; under that pin a
+	// relocatable extension without an explicit SCHEMA would target
+	// pg_catalog (the first writable schema for the superuser). Acquire
+	// a dedicated *sql.Conn and SET search_path to "$user", public so
+	// extensions land in the standard user-data schema, matching the
+	// pre-pin default behavior.
+	conn, err := db.Conn(ctx)
 	if err != nil {
+		return fmt.Errorf("acquiring dedicated connection for CREATE EXTENSION: %w", err)
+	}
+	defer func() {
+		_ = conn.Close()
+	}()
+
+	if _, err := conn.ExecContext(ctx, `SET search_path TO "$user", public`); err != nil {
+		return fmt.Errorf("setting search_path before CREATE EXTENSION: %w", err)
+	}
+
+	if _, err := conn.ExecContext(ctx, sqlCreateExtension.String()); err != nil {
 		contextLogger.Error(err, "while creating extension", "query", sqlCreateExtension.String())
 		return err
 	}

--- a/internal/management/controller/database_controller_sql.go
+++ b/internal/management/controller/database_controller_sql.go
@@ -287,6 +287,14 @@ func createDatabaseExtension(ctx context.Context, db *sql.DB, ext apiv1.Extensio
 		return fmt.Errorf("acquiring dedicated connection for CREATE EXTENSION: %w", err)
 	}
 	defer func() {
+		// Restore the pinned search_path before the connection returns
+		// to the pool. The pgx stdlib driver does not reset session GUCs
+		// on release, so without this RESET a subsequent operator query
+		// reusing this connection would run with the "$user", public
+		// search_path and could resolve objects planted by a tenant.
+		if _, resetErr := conn.ExecContext(ctx, `RESET search_path`); resetErr != nil {
+			contextLogger.Error(resetErr, "while resetting search_path after CREATE EXTENSION")
+		}
 		_ = conn.Close()
 	}()
 

--- a/internal/management/controller/database_controller_sql_test.go
+++ b/internal/management/controller/database_controller_sql_test.go
@@ -290,9 +290,13 @@ var _ = Describe("Managed Extensions SQL", func() {
 	})
 
 	Context("createDatabaseExtension", func() {
+		setSearchPathSQL := `SET search_path TO "$user", public`
 		createExtensionSQL := "CREATE EXTENSION \"testext\" VERSION \"1.0\" SCHEMA \"default\""
 
 		It("returns success when the extension has been created", func(ctx SpecContext) {
+			dbMock.
+				ExpectExec(setSearchPathSQL).
+				WillReturnResult(sqlmock.NewResult(0, 0))
 			dbMock.
 				ExpectExec(createExtensionSQL).
 				WillReturnResult(sqlmock.NewResult(0, 1))
@@ -300,6 +304,9 @@ var _ = Describe("Managed Extensions SQL", func() {
 		})
 
 		It("fails when the extension could not be created", func(ctx SpecContext) {
+			dbMock.
+				ExpectExec(setSearchPathSQL).
+				WillReturnResult(sqlmock.NewResult(0, 0))
 			dbMock.
 				ExpectExec(createExtensionSQL).
 				WillReturnError(testError)

--- a/internal/management/controller/database_controller_sql_test.go
+++ b/internal/management/controller/database_controller_sql_test.go
@@ -291,6 +291,7 @@ var _ = Describe("Managed Extensions SQL", func() {
 
 	Context("createDatabaseExtension", func() {
 		setSearchPathSQL := `SET search_path TO "$user", public`
+		resetSearchPathSQL := `RESET search_path`
 		createExtensionSQL := "CREATE EXTENSION \"testext\" VERSION \"1.0\" SCHEMA \"default\""
 
 		It("returns success when the extension has been created", func(ctx SpecContext) {
@@ -300,6 +301,9 @@ var _ = Describe("Managed Extensions SQL", func() {
 			dbMock.
 				ExpectExec(createExtensionSQL).
 				WillReturnResult(sqlmock.NewResult(0, 1))
+			dbMock.
+				ExpectExec(resetSearchPathSQL).
+				WillReturnResult(sqlmock.NewResult(0, 0))
 			Expect(createDatabaseExtension(ctx, db, ext)).Error().NotTo(HaveOccurred())
 		})
 
@@ -310,6 +314,11 @@ var _ = Describe("Managed Extensions SQL", func() {
 			dbMock.
 				ExpectExec(createExtensionSQL).
 				WillReturnError(testError)
+			// search_path is reset even when CREATE EXTENSION fails, so the
+			// connection returns to the pool with the pinned default.
+			dbMock.
+				ExpectExec(resetSearchPathSQL).
+				WillReturnResult(sqlmock.NewResult(0, 0))
 			Expect(createDatabaseExtension(ctx, db, ext)).Error().To(Equal(testError))
 		})
 	})

--- a/internal/management/controller/instance_controller.go
+++ b/internal/management/controller/instance_controller.go
@@ -740,6 +740,17 @@ func (r *InstanceReconciler) reconcileExtensions(
 		// a DDL when it is not really needed.
 
 		if !extension.SkipCreateExtension && extensionIsUsed && !extensionIsInstalled {
+			// The pool pins search_path with pg_catalog first. Under that pin a
+			// relocatable extension without an explicit SCHEMA targets pg_catalog,
+			// where object creation is denied ("System catalog modifications are
+			// currently disallowed"), so CREATE EXTENSION would fail. Set the
+			// standard "$user", public resolution for the statement so the
+			// extension lands in the user-data schema, matching pre-pin behavior.
+			// SET LOCAL is reverted at COMMIT, so the connection returns to the
+			// pool with the pinned search_path.
+			if _, err = tx.Exec(`SET LOCAL search_path TO "$user", public`); err != nil {
+				break
+			}
 			_, err = tx.Exec(fmt.Sprintf("CREATE EXTENSION %s", extension.Name))
 		} else if !extensionIsUsed && extensionIsInstalled {
 			_, err = tx.Exec(fmt.Sprintf("DROP EXTENSION %s", extension.Name))

--- a/internal/management/controller/instance_controller.go
+++ b/internal/management/controller/instance_controller.go
@@ -811,7 +811,11 @@ func (r *InstanceReconciler) reconcilePgbouncerAuthUser(
 	}
 
 	var existsFunction bool
-	row = tx.QueryRow(fmt.Sprintf("SELECT COUNT(*) > 0 FROM pg_catalog.pg_proc WHERE proname='%s' and prosrc='%s'",
+	// proconfig holds the function's SET clauses; we require the pinned
+	// search_path to be present so old (pre-pin) function definitions
+	// are re-created on upgrade.
+	row = tx.QueryRow(fmt.Sprintf("SELECT COUNT(*) > 0 FROM pg_catalog.pg_proc "+
+		"WHERE proname='%s' AND prosrc='%s' AND proconfig IS NOT NULL",
 		userSearchFunctionName,
 		userSearchFunction))
 	err = row.Scan(&existsFunction)
@@ -819,10 +823,15 @@ func (r *InstanceReconciler) reconcilePgbouncerAuthUser(
 		return err
 	}
 	if !existsFunction {
+		// The function is SECURITY DEFINER and runs as the cluster
+		// superuser. Pin search_path on the function so calls coming in
+		// over the pgbouncer auth connection cannot resolve operators
+		// inside the body through a tenant-controlled search_path.
 		_, err = tx.Exec(fmt.Sprintf("CREATE OR REPLACE FUNCTION %s.%s(uname TEXT) "+
 			"RETURNS TABLE (usename name, passwd text) "+
 			"as '%s' "+
-			"LANGUAGE sql SECURITY DEFINER",
+			"LANGUAGE sql SECURITY DEFINER "+
+			"SET search_path = pg_catalog, pg_temp",
 			userSearchFunctionSchema,
 			userSearchFunctionName,
 			userSearchFunction))

--- a/internal/management/controller/instance_controller_sql_test.go
+++ b/internal/management/controller/instance_controller_sql_test.go
@@ -1,0 +1,103 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package controller
+
+import (
+	"database/sql"
+	"fmt"
+
+	"github.com/DATA-DOG/go-sqlmock"
+
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/postgres"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("reconcileExtensions search_path", func() {
+	const existenceQuery = "SELECT COUNT(*) > 0 FROM pg_catalog.pg_extension WHERE extname = $1"
+
+	var (
+		dbMock sqlmock.Sqlmock
+		db     *sql.DB
+		err    error
+	)
+
+	BeforeEach(func() {
+		db, dbMock, err = sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		Expect(dbMock.ExpectationsWereMet()).To(Succeed())
+		_ = db.Close()
+	})
+
+	It("brackets CREATE EXTENSION with the standard \"$user\", public search_path", func(ctx SpecContext) {
+		// Pick a managed extension that the operator creates explicitly
+		// (not shared-preload only) so the CREATE EXTENSION branch runs.
+		var target postgres.ManagedExtension
+		for _, ext := range postgres.ManagedExtensions {
+			if !ext.SkipCreateExtension && len(ext.Namespaces) > 0 {
+				target = ext
+				break
+			}
+		}
+		Expect(target.Name).ToNot(BeEmpty(), "expected at least one creatable managed extension")
+
+		// Enable only the target extension via its configuration namespace.
+		userSettings := map[string]string{target.Namespaces[0] + ".max": "1000"}
+
+		dbMock.ExpectBegin()
+		for _, ext := range postgres.ManagedExtensions {
+			// Report every extension as not yet installed.
+			dbMock.ExpectQuery(existenceQuery).WithArgs(ext.Name).
+				WillReturnRows(sqlmock.NewRows([]string{"?column?"}).AddRow(false))
+
+			if ext.Name == target.Name {
+				// The fix: search_path is set to the standard resolution
+				// immediately before CREATE EXTENSION so the relocatable
+				// extension is not created against the pinned pg_catalog.
+				dbMock.ExpectExec(`SET LOCAL search_path TO "$user", public`).
+					WillReturnResult(sqlmock.NewResult(0, 0))
+				dbMock.ExpectExec(fmt.Sprintf("CREATE EXTENSION %s", ext.Name)).
+					WillReturnResult(sqlmock.NewResult(0, 0))
+			}
+		}
+		dbMock.ExpectCommit()
+
+		r := &InstanceReconciler{}
+		Expect(r.reconcileExtensions(ctx, db, userSettings)).To(Succeed())
+	})
+
+	It("does not touch search_path when no extension needs to be created", func(ctx SpecContext) {
+		// No user settings -> no managed extension is in use. Each extension is
+		// only probed for existence; no SET LOCAL / CREATE EXTENSION is issued.
+		dbMock.ExpectBegin()
+		for _, ext := range postgres.ManagedExtensions {
+			dbMock.ExpectQuery(existenceQuery).WithArgs(ext.Name).
+				WillReturnRows(sqlmock.NewRows([]string{"?column?"}).AddRow(false))
+		}
+		dbMock.ExpectCommit()
+
+		r := &InstanceReconciler{}
+		Expect(r.reconcileExtensions(ctx, db, map[string]string{})).To(Succeed())
+	})
+})

--- a/pkg/management/postgres/initdb.go
+++ b/pkg/management/postgres/initdb.go
@@ -436,12 +436,34 @@ func (info InitInfo) executeQueries(sqlUser *sql.DB, queries []string) error {
 		return nil
 	}
 
+	// The pool pins search_path to pg_catalog. User-authored init scripts
+	// expect the standard `"$user", public` resolution, so we set that
+	// once at the start of the batch on a dedicated *sql.Conn and reset
+	// at the end. Any user SET inside the script persists across
+	// statements within the same batch, matching PostgreSQL's default
+	// session semantics.
+	ctx := context.Background()
+	conn, err := sqlUser.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("acquiring dedicated connection for init queries: %w", err)
+	}
+	defer func() {
+		_ = conn.Close()
+	}()
+
+	if _, err := conn.ExecContext(ctx, `SET search_path TO "$user", public`); err != nil {
+		return fmt.Errorf("setting search_path before init queries: %w", err)
+	}
+
 	for _, sqlQuery := range queries {
 		log.Debug("Executing query", "sqlQuery", sqlQuery)
-		_, err := sqlUser.Exec(sqlQuery)
-		if err != nil {
+		if _, err := conn.ExecContext(ctx, sqlQuery); err != nil {
 			return err
 		}
+	}
+
+	if _, err := conn.ExecContext(ctx, `RESET search_path`); err != nil {
+		return fmt.Errorf("resetting search_path after init queries: %w", err)
 	}
 
 	return nil

--- a/pkg/management/postgres/initdb.go
+++ b/pkg/management/postgres/initdb.go
@@ -448,6 +448,11 @@ func (info InitInfo) executeQueries(sqlUser *sql.DB, queries []string) error {
 		return fmt.Errorf("acquiring dedicated connection for init queries: %w", err)
 	}
 	defer func() {
+		// Reset in a defer so the pin is restored even if a query fails;
+		// pooled pgx connections keep session GUCs across reuse.
+		if _, resetErr := conn.ExecContext(ctx, `RESET search_path`); resetErr != nil {
+			log.Error(resetErr, "while resetting search_path after init queries")
+		}
 		_ = conn.Close()
 	}()
 
@@ -460,10 +465,6 @@ func (info InitInfo) executeQueries(sqlUser *sql.DB, queries []string) error {
 		if _, err := conn.ExecContext(ctx, sqlQuery); err != nil {
 			return err
 		}
-	}
-
-	if _, err := conn.ExecContext(ctx, `RESET search_path`); err != nil {
-		return fmt.Errorf("resetting search_path after init queries: %w", err)
 	}
 
 	return nil

--- a/pkg/management/postgres/initdb_test.go
+++ b/pkg/management/postgres/initdb_test.go
@@ -172,8 +172,14 @@ var _ = Describe("ConfigureNewInstance role creation", func() {
 		mockSuperUser.ExpectExec(`CREATE ROLE \"app_user\" LOGIN`).
 			WillReturnResult(sqlmock.NewResult(1, 1))
 
+		// executeQueries brackets the batch with SET / RESET search_path
+		// so user-authored DDL still resolves into "$user", public.
+		mockSuperUser.ExpectExec(regexp.QuoteMeta(`SET search_path TO "$user", public`)).
+			WillReturnResult(sqlmock.NewResult(0, 0))
 		mockSuperUser.ExpectExec("CREATE ROLE post_init_role LOGIN").
 			WillReturnResult(sqlmock.NewResult(1, 1))
+		mockSuperUser.ExpectExec(regexp.QuoteMeta(`RESET search_path`)).
+			WillReturnResult(sqlmock.NewResult(0, 0))
 
 		err := info.ConfigureNewInstance(mi)
 
@@ -188,8 +194,12 @@ var _ = Describe("ConfigureNewInstance role creation", func() {
 
 		// No direct role creation expected
 
+		mockSuperUser.ExpectExec(regexp.QuoteMeta(`SET search_path TO "$user", public`)).
+			WillReturnResult(sqlmock.NewResult(0, 0))
 		mockSuperUser.ExpectExec("CREATE ROLE post_init_role LOGIN").
 			WillReturnResult(sqlmock.NewResult(1, 1))
+		mockSuperUser.ExpectExec(regexp.QuoteMeta(`RESET search_path`)).
+			WillReturnResult(sqlmock.NewResult(0, 0))
 
 		// Execute function under test
 		err := info.ConfigureNewInstance(mi)
@@ -197,5 +207,55 @@ var _ = Describe("ConfigureNewInstance role creation", func() {
 		// Verify results
 		Expect(err).NotTo(HaveOccurred())
 		Expect(mockSuperUser.ExpectationsWereMet()).NotTo(HaveOccurred())
+	})
+})
+
+var _ = Describe("executeQueries search_path bracketing", func() {
+	DescribeTable("wraps the whole batch with one SET / RESET search_path",
+		func(queries []string) {
+			db, mock, err := sqlmock.New()
+			Expect(err).NotTo(HaveOccurred())
+			defer func() {
+				_ = db.Close()
+			}()
+
+			mock.MatchExpectationsInOrder(true)
+			mock.ExpectExec(regexp.QuoteMeta(`SET search_path TO "$user", public`)).
+				WillReturnResult(sqlmock.NewResult(0, 0))
+			for _, q := range queries {
+				mock.ExpectExec(regexp.QuoteMeta(q)).
+					WillReturnResult(sqlmock.NewResult(0, 0))
+			}
+			mock.ExpectExec(regexp.QuoteMeta(`RESET search_path`)).
+				WillReturnResult(sqlmock.NewResult(0, 0))
+
+			info := InitInfo{}
+			Expect(info.executeQueries(db, queries)).To(Succeed())
+			Expect(mock.ExpectationsWereMet()).NotTo(HaveOccurred())
+		},
+		Entry("with independent statements", []string{
+			"CREATE TABLE foo (id int)",
+			"GRANT ALL ON foo TO app",
+		}),
+		// Verifies that a user-issued SET inside the batch persists for
+		// subsequent statements (matches pre-pin PostgreSQL semantics).
+		Entry("with a user-issued SET search_path inside", []string{
+			"SET search_path TO my_schema",
+			"CREATE TABLE foo (id int)",
+		}),
+	)
+
+	It("is a no-op when there are no queries", func() {
+		db, mock, err := sqlmock.New()
+		Expect(err).NotTo(HaveOccurred())
+		defer func() {
+			_ = db.Close()
+		}()
+
+		info := InitInfo{}
+		err = info.executeQueries(db, nil)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(mock.ExpectationsWereMet()).NotTo(HaveOccurred())
 	})
 })

--- a/pkg/management/postgres/instance.go
+++ b/pkg/management/postgres/instance.go
@@ -1122,7 +1122,7 @@ func (instance *Instance) WaitForPrimaryAvailable(ctx context.Context) error {
 	log.Info("Waiting for the new primary to be available",
 		"primaryConnInfo", primaryConnInfo)
 
-	db, err := sql.Open("pgx", primaryConnInfo)
+	db, err := pool.NewDBConnection(primaryConnInfo, pool.ConnectionProfilePostgresql)
 	if err != nil {
 		return err
 	}

--- a/pkg/management/postgres/logicalimport/database.go
+++ b/pkg/management/postgres/logicalimport/database.go
@@ -287,11 +287,31 @@ func (ds *databaseSnapshotter) executePostImportQueries(
 		return err
 	}
 
+	// The pool pins search_path to pg_catalog. User-authored import
+	// scripts expect the standard `"$user", public` resolution, so we
+	// set that once at the start of the batch on a dedicated *sql.Conn
+	// and reset at the end. Any user SET inside the script persists
+	// across statements within the same batch.
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("acquiring dedicated connection for post-import queries: %w", err)
+	}
+	defer func() {
+		_ = conn.Close()
+	}()
+
+	if _, err := conn.ExecContext(ctx, `SET search_path TO "$user", public`); err != nil {
+		return fmt.Errorf("setting search_path before post-import queries: %w", err)
+	}
+
 	for _, query := range postImportQueries {
-		_, err := db.Exec(query)
-		if err != nil {
+		if _, err := conn.ExecContext(ctx, query); err != nil {
 			return err
 		}
+	}
+
+	if _, err := conn.ExecContext(ctx, `RESET search_path`); err != nil {
+		return fmt.Errorf("resetting search_path after post-import queries: %w", err)
 	}
 
 	return nil

--- a/pkg/management/postgres/logicalimport/database.go
+++ b/pkg/management/postgres/logicalimport/database.go
@@ -297,6 +297,11 @@ func (ds *databaseSnapshotter) executePostImportQueries(
 		return fmt.Errorf("acquiring dedicated connection for post-import queries: %w", err)
 	}
 	defer func() {
+		// Reset in a defer so the pin is restored even if a query fails;
+		// pooled pgx connections keep session GUCs across reuse.
+		if _, resetErr := conn.ExecContext(ctx, `RESET search_path`); resetErr != nil {
+			contextLogger.Error(resetErr, "while resetting search_path after post-import queries")
+		}
 		_ = conn.Close()
 	}()
 
@@ -308,10 +313,6 @@ func (ds *databaseSnapshotter) executePostImportQueries(
 		if _, err := conn.ExecContext(ctx, query); err != nil {
 			return err
 		}
-	}
-
-	if _, err := conn.ExecContext(ctx, `RESET search_path`); err != nil {
-		return fmt.Errorf("resetting search_path after post-import queries: %w", err)
 	}
 
 	return nil

--- a/pkg/management/postgres/logicalimport/database_test.go
+++ b/pkg/management/postgres/logicalimport/database_test.go
@@ -126,8 +126,12 @@ var _ = Describe("databaseSnapshotter methods test", func() {
 			mock.ExpectExec(`SET search_path TO "$user", public`).
 				WillReturnResult(sqlmock.NewResult(0, 0))
 			mock.ExpectExec(createQuery).WillReturnError(expectedErr)
+			// RESET runs even when the query fails
+			mock.ExpectExec(`RESET search_path`).
+				WillReturnResult(sqlmock.NewResult(0, 0))
 			err := ds.executePostImportQueries(ctx, fp, "test")
 			Expect(err).To(Equal(expectedErr))
+			Expect(mock.ExpectationsWereMet()).To(Succeed())
 		})
 	})
 

--- a/pkg/management/postgres/logicalimport/database_test.go
+++ b/pkg/management/postgres/logicalimport/database_test.go
@@ -110,13 +110,21 @@ var _ = Describe("databaseSnapshotter methods test", func() {
 		})
 
 		It("should execute the query properly", func(ctx SpecContext) {
+			// Each user query is bracketed with SET / RESET search_path
+			// so user-authored DDL still resolves into "$user", public.
+			mock.ExpectExec(`SET search_path TO "$user", public`).
+				WillReturnResult(sqlmock.NewResult(0, 0))
 			mock.ExpectExec(createQuery).WillReturnResult(sqlmock.NewResult(0, 0))
+			mock.ExpectExec(`RESET search_path`).
+				WillReturnResult(sqlmock.NewResult(0, 0))
 			err := ds.executePostImportQueries(ctx, fp, "test")
 			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("should return any error encountered", func(ctx SpecContext) {
 			expectedErr := fmt.Errorf("will fail")
+			mock.ExpectExec(`SET search_path TO "$user", public`).
+				WillReturnResult(sqlmock.NewResult(0, 0))
 			mock.ExpectExec(createQuery).WillReturnError(expectedErr)
 			err := ds.executePostImportQueries(ctx, fp, "test")
 			Expect(err).To(Equal(expectedErr))

--- a/pkg/management/postgres/metrics/collector.go
+++ b/pkg/management/postgres/metrics/collector.go
@@ -592,9 +592,11 @@ func createMonitoringTx(conn *sql.DB) (*sql.Tx, error) {
 	// queries may reference unqualified objects in public, so we
 	// widen the search_path inside the read-only monitoring
 	// transaction. pg_catalog stays first, defeating shadow-object
-	// attacks; SET LOCAL is rolled back at COMMIT so the connection
-	// returns to the pool with the pinned default.
-	_, err = tx.Exec("SET LOCAL search_path = pg_catalog, public")
+	// attacks; pg_temp is listed last so the session temp schema is
+	// not searched ahead of pg_catalog/public for relations and types.
+	// SET LOCAL is rolled back at COMMIT so the connection returns to
+	// the pool with the pinned default.
+	_, err = tx.Exec("SET LOCAL search_path = pg_catalog, public, pg_temp")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/management/postgres/metrics/collector.go
+++ b/pkg/management/postgres/metrics/collector.go
@@ -588,12 +588,13 @@ func createMonitoringTx(conn *sql.DB) (*sql.Tx, error) {
 		}
 	}()
 
-	// Prepend pg_catalog to the connection's search_path so unqualified
-	// catalog references (e.g. current_database()) cannot be shadowed by
-	// objects planted in user-owned schemas.
-	_, err = tx.Exec(
-		"SELECT pg_catalog.set_config('search_path', " +
-			"'pg_catalog, ' OPERATOR(pg_catalog.||) pg_catalog.current_setting('search_path'), true)")
+	// The pool pins search_path to pg_catalog. Custom monitoring
+	// queries may reference unqualified objects in public, so we
+	// widen the search_path inside the read-only monitoring
+	// transaction. pg_catalog stays first, defeating shadow-object
+	// attacks; SET LOCAL is rolled back at COMMIT so the connection
+	// returns to the pool with the pinned default.
+	_, err = tx.Exec("SET LOCAL search_path = pg_catalog, public")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/management/postgres/metrics/collector.go
+++ b/pkg/management/postgres/metrics/collector.go
@@ -588,14 +588,13 @@ func createMonitoringTx(conn *sql.DB) (*sql.Tx, error) {
 		}
 	}()
 
-	// The pool pins search_path to pg_catalog. Custom monitoring
-	// queries may reference unqualified objects in public, so we
-	// widen the search_path inside the read-only monitoring
-	// transaction. pg_catalog stays first, defeating shadow-object
-	// attacks; pg_temp is listed last so the session temp schema is
-	// not searched ahead of pg_catalog/public for relations and types.
-	// SET LOCAL is rolled back at COMMIT so the connection returns to
-	// the pool with the pinned default.
+	// The pool already pins search_path to pg_catalog, public, pg_temp in
+	// the startup packet. This SET LOCAL reinforces the same value inside
+	// the read-only monitoring transaction as defense-in-depth: pg_catalog
+	// stays first, defeating shadow-object attacks; pg_temp is listed last
+	// so the session temp schema is not searched ahead of pg_catalog/public
+	// for relations and types. SET LOCAL is rolled back at COMMIT so the
+	// connection returns to the pool with the pinned default.
 	_, err = tx.Exec("SET LOCAL search_path = pg_catalog, public, pg_temp")
 	if err != nil {
 		return nil, err

--- a/pkg/management/postgres/metrics/collector_test.go
+++ b/pkg/management/postgres/metrics/collector_test.go
@@ -220,9 +220,7 @@ var _ = Describe("QueryRunner tests", func() {
 			}
 			_ = metricMap
 			dbMock.ExpectBegin()
-			dbMock.ExpectExec(
-				"SELECT pg_catalog.set_config('search_path', 'pg_catalog, ' OPERATOR(pg_catalog.||)" +
-					" pg_catalog.current_setting('search_path'), true)").WillReturnResult(sqlmock.NewResult(0, 1))
+			dbMock.ExpectExec("SET LOCAL search_path = pg_catalog, public").WillReturnResult(sqlmock.NewResult(0, 1))
 			dbMock.ExpectExec("SET standard_conforming_strings TO on").WillReturnResult(sqlmock.NewResult(0, 1))
 			dbMock.ExpectQuery(loPagesQuery).WillReturnRows(sqlmock.NewRows(
 				[]string{"datname", "lo_pages"}).

--- a/pkg/management/postgres/metrics/collector_test.go
+++ b/pkg/management/postgres/metrics/collector_test.go
@@ -220,7 +220,8 @@ var _ = Describe("QueryRunner tests", func() {
 			}
 			_ = metricMap
 			dbMock.ExpectBegin()
-			dbMock.ExpectExec("SET LOCAL search_path = pg_catalog, public").WillReturnResult(sqlmock.NewResult(0, 1))
+			dbMock.ExpectExec("SET LOCAL search_path = pg_catalog, public, pg_temp").
+				WillReturnResult(sqlmock.NewResult(0, 1))
 			dbMock.ExpectExec("SET standard_conforming_strings TO on").WillReturnResult(sqlmock.NewResult(0, 1))
 			dbMock.ExpectQuery(loPagesQuery).WillReturnRows(sqlmock.NewRows(
 				[]string{"datname", "lo_pages"}).

--- a/pkg/management/postgres/pool/profiles.go
+++ b/pkg/management/postgres/pool/profiles.go
@@ -51,9 +51,9 @@ type connectionProfilePostgresqlPhysicalReplication profile
 func (connectionProfilePostgresqlPhysicalReplication) Enrich(config *pgx.ConnConfig) {
 	fillDefaultParameters(config)
 
-	// The simple query protocol is needed since we're going to use
-	// this function to connect to the PgBouncer administrative
-	// interface, which doesn't support the extended one.
+	// The simple query protocol is needed since this connection issues
+	// physical replication commands (such as IDENTIFY_SYSTEM), which are
+	// not supported over the extended query protocol.
 	config.DefaultQueryExecMode = pgx.QueryExecModeSimpleProtocol
 
 	// To initiate streaming replication, the frontend sends the replication parameter

--- a/pkg/management/postgres/pool/profiles.go
+++ b/pkg/management/postgres/pool/profiles.go
@@ -94,11 +94,19 @@ func fillDefaultParameters(config *pgx.ConnConfig) {
 
 	// Pin search_path so a tenant-controlled ALTER DATABASE / ALTER ROLE
 	// setting cannot influence operator-issued queries. pg_catalog is
-	// first so any built-in overload defeats a planted shadow in public.
-	// public stays in the path so CREATE EXTENSION (in initdb post-init
-	// and the Database controller) can resolve required-extension types
-	// — PostgreSQL's CREATE EXTENSION uses the connection-level value
-	// when computing the install-time search_path, not the session-level
-	// SET.
-	config.RuntimeParams["search_path"] = "pg_catalog, public"
+	// first so any built-in overload defeats an operator/function shadow
+	// planted in public.
+	//
+	// public is kept in the path so that the common case keeps working
+	// for queries that legitimately reference unqualified objects there;
+	// the CREATE EXTENSION paths (initdb post-init and the Database
+	// controller) do not rely on this default — they SET search_path on
+	// their own connection before issuing CREATE EXTENSION so a
+	// relocatable extension lands in the user-data schema.
+	//
+	// pg_temp is listed last so the session temp schema is searched after
+	// pg_catalog and public for relation and data-type names; by default
+	// (when pg_temp is not listed) it is searched first, even before
+	// pg_catalog.
+	config.RuntimeParams["search_path"] = "pg_catalog, public, pg_temp"
 }

--- a/pkg/management/postgres/pool/profiles.go
+++ b/pkg/management/postgres/pool/profiles.go
@@ -73,6 +73,13 @@ func (connectionProfilePgbouncer) Enrich(config *pgx.ConnConfig) {
 	// this function to connect to the PgBouncer administrative
 	// interface, which doesn't support the extended one.
 	config.DefaultQueryExecMode = pgx.QueryExecModeSimpleProtocol
+
+	// The PgBouncer admin console does not execute catalog SQL and
+	// only accepts the startup parameters listed in
+	// ignore_startup_parameters (extra_float_digits,options by default).
+	// The pinned search_path is therefore unnecessary here and would
+	// cause the admin connection to be rejected.
+	delete(config.RuntimeParams, "search_path")
 }
 
 func fillDefaultParameters(config *pgx.ConnConfig) {
@@ -84,4 +91,14 @@ func fillDefaultParameters(config *pgx.ConnConfig) {
 	// a standard date format for the operator to manage the dates
 	// when it's needed
 	config.RuntimeParams["datestyle"] = "ISO"
+
+	// Pin search_path so a tenant-controlled ALTER DATABASE / ALTER ROLE
+	// setting cannot influence operator-issued queries. pg_catalog is
+	// first so any built-in overload defeats a planted shadow in public.
+	// public stays in the path so CREATE EXTENSION (in initdb post-init
+	// and the Database controller) can resolve required-extension types
+	// — PostgreSQL's CREATE EXTENSION uses the connection-level value
+	// when computing the install-time search_path, not the session-level
+	// SET.
+	config.RuntimeParams["search_path"] = "pg_catalog, public"
 }

--- a/pkg/management/postgres/pool/profiles_test.go
+++ b/pkg/management/postgres/pool/profiles_test.go
@@ -42,8 +42,9 @@ var _ = Describe("Connection profile defaults", func() {
 			// search_path so that no tenant-controlled ALTER DATABASE /
 			// ALTER ROLE setting can influence operator queries.
 			// pg_catalog must be first so built-in overloads defeat
-			// shadows planted in public.
-			Expect(cfg.RuntimeParams).To(HaveKeyWithValue("search_path", "pg_catalog, public"))
+			// shadows planted in public; pg_temp must be last so the
+			// session temp schema is not searched ahead of pg_catalog.
+			Expect(cfg.RuntimeParams).To(HaveKeyWithValue("search_path", "pg_catalog, public, pg_temp"))
 
 			// The pre-existing defaults are still present.
 			Expect(cfg.RuntimeParams).To(HaveKeyWithValue("client_encoding", "UTF8"))

--- a/pkg/management/postgres/pool/profiles_test.go
+++ b/pkg/management/postgres/pool/profiles_test.go
@@ -1,0 +1,81 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package pool
+
+import (
+	"github.com/jackc/pgx/v5"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Connection profile defaults", func() {
+	parseConfig := func() *pgx.ConnConfig {
+		cfg, err := pgx.ParseConfig("host=/tmp")
+		Expect(err).ToNot(HaveOccurred())
+		return cfg
+	}
+
+	DescribeTable("pin search_path with pg_catalog first in the startup packet",
+		func(profile ConnectionProfile) {
+			cfg := parseConfig()
+			profile.Enrich(cfg)
+
+			// Every operator-issued connection must carry a fixed
+			// search_path so that no tenant-controlled ALTER DATABASE /
+			// ALTER ROLE setting can influence operator queries.
+			// pg_catalog must be first so built-in overloads defeat
+			// shadows planted in public.
+			Expect(cfg.RuntimeParams).To(HaveKeyWithValue("search_path", "pg_catalog, public"))
+
+			// The pre-existing defaults are still present.
+			Expect(cfg.RuntimeParams).To(HaveKeyWithValue("client_encoding", "UTF8"))
+			Expect(cfg.RuntimeParams).To(HaveKeyWithValue("datestyle", "ISO"))
+		},
+		Entry("ConnectionProfilePostgresql", ConnectionProfilePostgresql),
+		Entry("ConnectionProfilePostgresqlPhysicalReplication", ConnectionProfilePostgresqlPhysicalReplication),
+	)
+
+	It("does not pin search_path on the pgbouncer profile", func() {
+		// PgBouncer rejects startup parameters that are neither tracked
+		// by default nor listed in ignore_startup_parameters; the admin
+		// console does not run catalog SQL, so pinning is unnecessary.
+		cfg := parseConfig()
+		ConnectionProfilePgbouncer.Enrich(cfg)
+
+		Expect(cfg.RuntimeParams).ToNot(HaveKey("search_path"))
+		Expect(cfg.RuntimeParams).To(HaveKeyWithValue("client_encoding", "UTF8"))
+		Expect(cfg.RuntimeParams).To(HaveKeyWithValue("datestyle", "ISO"))
+	})
+
+	It("preserves the synchronous_commit override on the postgresql profile", func() {
+		cfg := parseConfig()
+		ConnectionProfilePostgresql.Enrich(cfg)
+
+		Expect(cfg.RuntimeParams).To(HaveKeyWithValue("synchronous_commit", "local"))
+	})
+
+	It("preserves the replication=1 override on the physical-replication profile", func() {
+		cfg := parseConfig()
+		ConnectionProfilePostgresqlPhysicalReplication.Enrich(cfg)
+
+		Expect(cfg.RuntimeParams).To(HaveKeyWithValue("replication", "1"))
+	})
+})

--- a/pkg/management/postgres/wal.go
+++ b/pkg/management/postgres/wal.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
 
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres/pool"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/resources"
 )
 
@@ -63,10 +64,7 @@ type walArchiveAnalyzer struct {
 func newWalArchiveAnalyzerForReplicaInstance(primaryConnInfo string) *walArchiveAnalyzer {
 	return &walArchiveAnalyzer{
 		dbFactory: func() (*sql.DB, error) {
-			db, openErr := sql.Open(
-				"pgx",
-				primaryConnInfo,
-			)
+			db, openErr := pool.NewDBConnection(primaryConnInfo, pool.ConnectionProfilePostgresql)
 			if openErr != nil {
 				log.Error(openErr, "can not open postgres database")
 				return nil, openErr
@@ -129,12 +127,12 @@ func newWalArchiveBootstrapperForPrimary() *walArchiveBootstrapper {
 	return &walArchiveBootstrapper{
 		walArchiveAnalyzer: walArchiveAnalyzer{
 			dbFactory: func() (*sql.DB, error) {
-				db, openErr := sql.Open(
-					"pgx",
+				db, openErr := pool.NewDBConnection(
 					fmt.Sprintf("host=%s port=%v dbname=postgres user=postgres sslmode=disable",
 						GetSocketDir(),
 						GetServerPort(),
 					),
+					pool.ConnectionProfilePostgresql,
 				)
 				if openErr != nil {
 					log.Error(openErr, "can not open postgres database")

--- a/tests/e2e/fixtures/initdb/cluster-postinit-search-path-hijack.yaml.template
+++ b/tests/e2e/fixtures/initdb/cluster-postinit-search-path-hijack.yaml.template
@@ -5,9 +5,11 @@
 # database-level search_path so that the planted operator is resolved
 # before pg_catalog. With the operator's connection-level search_path
 # pin in place, every operator-issued query to `app` carries
-# search_path = pg_catalog, so the planted operator must never be
-# invoked. The shadow body inserts into public.shadow_calls; the e2e
-# test asserts that table stays empty after a reconcile window.
+# search_path = pg_catalog, public, pg_temp with pg_catalog first, so
+# the built-in `=` operator always resolves ahead of the planted one
+# and the shadow must never be invoked. The shadow body inserts into
+# public.shadow_calls; the e2e test asserts that table stays empty
+# after a reconcile window.
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:

--- a/tests/e2e/fixtures/initdb/cluster-postinit-search-path-hijack.yaml.template
+++ b/tests/e2e/fixtures/initdb/cluster-postinit-search-path-hijack.yaml.template
@@ -1,14 +1,17 @@
 # Cluster used by the search_path operator hijack regression test (CWE-426).
 #
-# postInitApplicationSQL plants an attacker-controlled `=` (name, text)
+# postInitApplicationSQL plants an attacker-controlled `=` (name, name)
 # operator in the application database's `public` schema and flips the
 # database-level search_path so that the planted operator is resolved
-# before pg_catalog. With the operator's connection-level search_path
-# pin in place, every operator-issued query to `app` carries
-# search_path = pg_catalog, public, pg_temp with pg_catalog first, so
-# the built-in `=` operator always resolves ahead of the planted one
-# and the shadow must never be invoked. The shadow body inserts into
-# public.shadow_calls; the e2e test asserts that table stays empty
+# before pg_catalog. The (name, name) signature matches what the
+# operator's catalog probes resolve to (e.g. `... WHERE extname = $1`);
+# a (name, text) overload would never be reached, leaving the test unable
+# to tell a working pin from a dead trigger. With the operator's
+# connection-level search_path pin in place, every operator-issued query
+# to `app` carries search_path = pg_catalog, public, pg_temp with
+# pg_catalog first, so the built-in `=(name,name)` resolves ahead of the
+# planted one and the shadow is never invoked. The shadow body inserts
+# into public.shadow_calls; the e2e test asserts that table stays empty
 # after a reconcile window.
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
@@ -29,8 +32,10 @@ spec:
         # as the escape for a literal $ in container command/args, which would
         # corrupt $$ ... $$ dollar-quoted blocks before the operator even sees
         # them. $1 / $2 parameter references survive that processing.
-        - CREATE OR REPLACE FUNCTION public.shadow_eq(a name, b text) RETURNS boolean LANGUAGE sql AS 'INSERT INTO public.shadow_calls DEFAULT VALUES; SELECT $1::text = $2;';
-        - CREATE OPERATOR public.= (LEFTARG=name, RIGHTARG=text, FUNCTION=public.shadow_eq);
+        # Reference the built-in operator explicitly: a bare name=name here
+        # would re-enter the planted public.=(name,name) and recurse forever.
+        - CREATE OR REPLACE FUNCTION public.shadow_eq(a name, b name) RETURNS boolean LANGUAGE sql AS 'INSERT INTO public.shadow_calls DEFAULT VALUES; SELECT $1 OPERATOR(pg_catalog.=) $2;';
+        - CREATE OPERATOR public.= (LEFTARG=name, RIGHTARG=name, FUNCTION=public.shadow_eq);
         - ALTER DATABASE app SET search_path = public, pg_catalog;
 
   storage:

--- a/tests/e2e/fixtures/initdb/cluster-postinit-search-path-hijack.yaml.template
+++ b/tests/e2e/fixtures/initdb/cluster-postinit-search-path-hijack.yaml.template
@@ -1,0 +1,36 @@
+# Cluster used by the search_path operator hijack regression test (CWE-426).
+#
+# postInitApplicationSQL plants an attacker-controlled `=` (name, text)
+# operator in the application database's `public` schema and flips the
+# database-level search_path so that the planted operator is resolved
+# before pg_catalog. With the operator's connection-level search_path
+# pin in place, every operator-issued query to `app` carries
+# search_path = pg_catalog, so the planted operator must never be
+# invoked. The shadow body inserts into public.shadow_calls; the e2e
+# test asserts that table stays empty after a reconcile window.
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: p-search-path-hijack
+spec:
+  instances: 1
+
+  bootstrap:
+    initdb:
+      database: app
+      owner: app
+      postInitApplicationSQL:
+        - CREATE TABLE public.shadow_calls (called_at timestamptz NOT NULL DEFAULT clock_timestamp());
+        - GRANT INSERT ON public.shadow_calls TO PUBLIC;
+        # Use LANGUAGE sql with a single-quoted body so the function definition
+        # does not rely on dollar-quoting. Kubernetes argv expansion treats $$
+        # as the escape for a literal $ in container command/args, which would
+        # corrupt $$ ... $$ dollar-quoted blocks before the operator even sees
+        # them. $1 / $2 parameter references survive that processing.
+        - CREATE OR REPLACE FUNCTION public.shadow_eq(a name, b text) RETURNS boolean LANGUAGE sql AS 'INSERT INTO public.shadow_calls DEFAULT VALUES; SELECT $1::text = $2;';
+        - CREATE OPERATOR public.= (LEFTARG=name, RIGHTARG=text, FUNCTION=public.shadow_eq);
+        - ALTER DATABASE app SET search_path = public, pg_catalog;
+
+  storage:
+    storageClass: ${E2E_DEFAULT_STORAGE_CLASS}
+    size: 1Gi

--- a/tests/e2e/initdb_test.go
+++ b/tests/e2e/initdb_test.go
@@ -176,18 +176,48 @@ var _ = Describe("InitDB settings", Label(tests.LabelSmoke, tests.LabelBasic), f
 			primary, err := clusterutils.GetPrimary(env.Ctx, env.Client, namespace, clusterName)
 			Expect(err).ToNot(HaveOccurred())
 
-			By("verifying public.shadow_calls stays empty across a reconcile window", func() {
-				Consistently(func() string {
-					stdout, _, err := exec.QueryInInstancePod(
-						env.Ctx, env.Client, env.Interface, env.RestClientConfig,
-						exec.PodLocator{
-							Namespace: namespace,
-							PodName:   primary.Name,
-						}, "app",
-						"SELECT pg_catalog.count(*)::text FROM public.shadow_calls")
-					Expect(err).ToNot(HaveOccurred())
-					return strings.TrimSpace(stdout)
-				}, "30s", "5s").Should(Equal("0"))
+			// shadowCalls returns how many times the planted public.shadow_eq
+			// function has been invoked in the application database. The query
+			// is fully schema-qualified so it cannot itself trigger the shadow.
+			shadowCalls := func() string {
+				stdout, _, err := exec.QueryInInstancePod(
+					env.Ctx, env.Client, env.Interface, env.RestClientConfig,
+					exec.PodLocator{
+						Namespace: namespace,
+						PodName:   primary.Name,
+					}, "app",
+					"SELECT pg_catalog.count(*)::text FROM public.shadow_calls")
+				Expect(err).ToNot(HaveOccurred())
+				return strings.TrimSpace(stdout)
+			}
+
+			By("verifying operator-issued queries never invoke the planted shadow operator", func() {
+				// The operator connects to `app` (e.g. the managed-extension
+				// probe runs `... WHERE extname = $1`). The connection-level
+				// search_path pin keeps pg_catalog first, so the planted
+				// public.=(name,text) operator must never be resolved.
+				//
+				// To validate this test red/green: remove the search_path pin
+				// in pkg/management/postgres/pool/profiles.go (fillDefaultParameters)
+				// and re-run; this assertion must then fail with shadow_calls > 0.
+				Consistently(shadowCalls, "30s", "5s").Should(Equal("0"))
+			})
+
+			By("confirming the planted shadow operator is actually reachable (positive control)", func() {
+				// Guard against a false pass where shadow_calls stays 0 only
+				// because the shadow is unreachable. A name=text comparison
+				// issued through psql under the tenant-controlled search_path
+				// (public, pg_catalog) resolves to public.=(name,text) and must
+				// increment shadow_calls, proving the detector is live.
+				_, _, err := exec.QueryInInstancePod(
+					env.Ctx, env.Client, env.Interface, env.RestClientConfig,
+					exec.PodLocator{
+						Namespace: namespace,
+						PodName:   primary.Name,
+					}, "app",
+					"SELECT 'x'::name = 'y'::text")
+				Expect(err).ToNot(HaveOccurred())
+				Eventually(shadowCalls, "10s", "2s").ShouldNot(Equal("0"))
 			})
 		})
 	})

--- a/tests/e2e/initdb_test.go
+++ b/tests/e2e/initdb_test.go
@@ -151,6 +151,47 @@ var _ = Describe("InitDB settings", Label(tests.LabelSmoke, tests.LabelBasic), f
 		})
 	})
 
+	// Regression test for CWE-426 search_path operator hijack.
+	// postInitApplicationSQL plants a `=` (name, text) overload in
+	// public and flips ALTER DATABASE app SET search_path = public,
+	// pg_catalog. The operator's connection-level search_path pin
+	// must keep operator-issued queries on pg_catalog so the planted
+	// shadow is never invoked.
+	Context("search_path operator hijack regression", func() {
+		const (
+			clusterName    = "p-search-path-hijack"
+			clusterFixture = fixturesInitdbDir + "/cluster-postinit-search-path-hijack.yaml.template"
+		)
+
+		var namespace string
+
+		It("does not invoke shadow operators planted in the application database", func() {
+			const namespacePrefix = "initdb-search-path-hijack"
+			var err error
+			namespace, err = env.CreateUniqueTestNamespace(env.Ctx, env.Client, namespacePrefix)
+			Expect(err).ToNot(HaveOccurred())
+
+			AssertCreateCluster(namespace, clusterName, clusterFixture, env)
+
+			primary, err := clusterutils.GetPrimary(env.Ctx, env.Client, namespace, clusterName)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("verifying public.shadow_calls stays empty across a reconcile window", func() {
+				Consistently(func() string {
+					stdout, _, err := exec.QueryInInstancePod(
+						env.Ctx, env.Client, env.Interface, env.RestClientConfig,
+						exec.PodLocator{
+							Namespace: namespace,
+							PodName:   primary.Name,
+						}, "app",
+						"SELECT pg_catalog.count(*)::text FROM public.shadow_calls")
+					Expect(err).ToNot(HaveOccurred())
+					return strings.TrimSpace(stdout)
+				}, "30s", "5s").Should(Equal("0"))
+			})
+		})
+	})
+
 	Context("custom default locale", func() {
 		const (
 			clusterName        = "p-locale"

--- a/tests/e2e/initdb_test.go
+++ b/tests/e2e/initdb_test.go
@@ -152,7 +152,7 @@ var _ = Describe("InitDB settings", Label(tests.LabelSmoke, tests.LabelBasic), f
 	})
 
 	// Regression test for CWE-426 search_path operator hijack.
-	// postInitApplicationSQL plants a `=` (name, text) overload in
+	// postInitApplicationSQL plants a `=` (name, name) overload in
 	// public and flips ALTER DATABASE app SET search_path = public,
 	// pg_catalog. The operator's connection-level search_path pin
 	// must keep operator-issued queries on pg_catalog so the planted
@@ -192,30 +192,34 @@ var _ = Describe("InitDB settings", Label(tests.LabelSmoke, tests.LabelBasic), f
 			}
 
 			By("verifying operator-issued queries never invoke the planted shadow operator", func() {
-				// The operator connects to `app` (e.g. the managed-extension
-				// probe runs `... WHERE extname = $1`). The connection-level
-				// search_path pin keeps pg_catalog first, so the planted
-				// public.=(name,text) operator must never be resolved.
+				// The operator's catalog probes against `app` resolve to name
+				// equality (e.g. `... WHERE extname = $1`, extname being `name`
+				// and $1 inferred as `name`). The connection-level pin keeps
+				// pg_catalog first, so they hit pg_catalog.=(name,name) and never
+				// reach the planted public.=(name,name).
 				//
-				// To validate this test red/green: remove the search_path pin
-				// in pkg/management/postgres/pool/profiles.go (fillDefaultParameters)
-				// and re-run; this assertion must then fail with shadow_calls > 0.
+				// To validate red/green: remove the pin in
+				// pkg/management/postgres/pool/profiles.go (fillDefaultParameters)
+				// and re-run; the probes then inherit the tenant search_path and
+				// this assertion fails with shadow_calls > 0.
 				Consistently(shadowCalls, "30s", "5s").Should(Equal("0"))
 			})
 
 			By("confirming the planted shadow operator is actually reachable (positive control)", func() {
 				// Guard against a false pass where shadow_calls stays 0 only
-				// because the shadow is unreachable. A name=text comparison
-				// issued through psql under the tenant-controlled search_path
-				// (public, pg_catalog) resolves to public.=(name,text) and must
-				// increment shadow_calls, proving the detector is live.
+				// because the shadow is unreachable. Mirror the operator's
+				// resolution path with an inferred $1 (PREPARE infers it just
+				// like the extended protocol), which under the tenant search_path
+				// (public, pg_catalog) resolves to public.=(name,name) and must
+				// increment shadow_calls. PREPARE and EXECUTE share one psql -c
+				// command so the prepared plan survives.
 				_, _, err := exec.QueryInInstancePod(
 					env.Ctx, env.Client, env.Interface, env.RestClientConfig,
 					exec.PodLocator{
 						Namespace: namespace,
 						PodName:   primary.Name,
 					}, "app",
-					"SELECT 'x'::name = 'y'::text")
+					"PREPARE shadow_probe AS SELECT 'x'::name = $1; EXECUTE shadow_probe('y')")
 				Expect(err).ToNot(HaveOccurred())
 				Eventually(shadowCalls, "10s", "2s").ShouldNot(Equal("0"))
 			})

--- a/tests/e2e/initdb_test.go
+++ b/tests/e2e/initdb_test.go
@@ -171,7 +171,7 @@ var _ = Describe("InitDB settings", Label(tests.LabelSmoke, tests.LabelBasic), f
 			namespace, err = env.CreateUniqueTestNamespace(env.Ctx, env.Client, namespacePrefix)
 			Expect(err).ToNot(HaveOccurred())
 
-			AssertCreateCluster(namespace, clusterName, clusterFixture, env)
+			clusterasserts.AssertCreateCluster(env, testTimeouts, namespace, clusterName, clusterFixture)
 
 			primary, err := clusterutils.GetPrimary(env.Ctx, env.Client, namespace, clusterName)
 			Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
A database owner could plant overloaded built-in operators (`=`, `>`, ...) in the `public` schema and `ALTER DATABASE` / `ALTER ROLE` the `search_path` so that operator introspection probes, running as the cluster superuser, resolved those overloads before `pg_catalog`, yielding superuser access and in-pod RCE via `COPY ... FROM PROGRAM` (`CWE-426`, same class as `CVE-2018-1058`).

Pin `search_path = pg_catalog, public, pg_temp` as a `pgx` `RuntimeParam` on every pooled operator connection so it ships in the `StartupMessage` and takes precedence over tenant-controlled database/role defaults: `pg_catalog` first defeats any planted shadow, `public` stays writable for `CREATE EXTENSION`, and `pg_temp` is searched last. The `pgbouncer` profile opts out, as its admin console rejects unknown startup parameters.

Close the remaining bypasses and user-facing paths:

- Route the three direct `sql.Open("pgx", ...)` callsites (`WaitForPrimaryAvailable`, the two WAL-archive helpers) through `pool.NewDBConnection` so they inherit the pin.
- Bracket user-authored scripts (`postInit*`, logical-import `PostImportApplicationSQL`) and `CREATE EXTENSION` with a dedicated connection that `SET`s `"$user", public` and `RESET`s back to the pinned default,
  so they keep standard resolution without leaking it to the pool.
- Pin `search_path = pg_catalog, pg_temp` on the `public.user_search` `SECURITY DEFINER` function (reached by `pgbouncer` via `libpq`, outside the pool) and require `proconfig IS NOT NULL` so existing clusters are upgraded.
- Replace the monitoring transaction's `set_config` workaround with an explicit `SET LOCAL search_path = pg_catalog, public, pg_temp`.

Add an e2e regression test that plants a shadow `=` operator and flips the database `search_path`, plus unit tests.

Updates the documentation accordingly.
