### PR TITLE
chore: migrate threat-modeling artifacts to Gemara v1

### DIFF
--- a/.github/capability-catalog.yaml
+++ b/.github/capability-catalog.yaml
@@ -2,7 +2,7 @@ title: CloudNativePG Operator Capability Catalog
 metadata:
   id: CNPG.CAPABILITIES
   type: CapabilityCatalog
-  gemara-version: "1.0.0"
+  gemara-version: "1.2.0"
   description: >
     Capabilities provided by the CloudNativePG operator for managing
     PostgreSQL clusters on Kubernetes.

--- a/.github/capability-catalog.yaml
+++ b/.github/capability-catalog.yaml
@@ -1,0 +1,249 @@
+title: CloudNativePG Operator Capability Catalog
+metadata:
+  id: CNPG.CAPABILITIES
+  type: CapabilityCatalog
+  gemara-version: "1.0.0"
+  description: >
+    Capabilities provided by the CloudNativePG operator for managing
+    PostgreSQL clusters on Kubernetes.
+  version: v2026.03-1
+  author:
+    id: cnpg-maintainers
+    name: CloudNativePG Maintainers
+    type: Human
+  mapping-references:
+    - id: CCC
+      title: Common Cloud Controls Core
+      version: v2025.10
+      url: https://github.com/finos/common-cloud-controls/releases/download/v2025.10/CCC.Core_v2025.10.yaml
+      description: |
+        Foundational repository of reusable security controls, capabilities,
+        and threat models maintained by FINOS.
+
+groups:
+  - id: availability
+    title: Availability
+    description: >
+      Capabilities that ensure PostgreSQL cluster uptime, resilience,
+      and graceful lifecycle management.
+  - id: security
+    title: Security
+    description: >
+      Capabilities that enforce security boundaries, validate
+      configurations, and harden the runtime environment.
+  - id: data-management
+    title: Data Management
+    description: >
+      Capabilities for connection handling, declarative schema
+      management, and backup scheduling.
+
+imports:
+  - reference-id: CCC
+    entries:
+      - reference-id: CCC.Core.CP01
+        remarks: Encryption in Transit Enabled by Default
+      - reference-id: CCC.Core.CP02
+        remarks: |
+          Encryption at Rest: the operator does not manage encryption at
+          rest directly. It is delegated entirely to the underlying storage
+          provider for PGDATA, WAL, and tablespace volumes, and to the
+          object store provider for backups and WAL archives.
+      - reference-id: CCC.Core.CP03
+        remarks: |
+          Access Log Publication: PGAudit integration is supported when
+          the pgaudit extension is configured. Audit logs are emitted as
+          a separate JSON channel on stdout, distinct from regular
+          PostgreSQL logs.
+      - reference-id: CCC.Core.CP06
+        remarks: |
+          Access Control: database-level access is controlled via pg_hba.conf
+          with fixed rules for replication and PgBouncer, and user-defined
+          rules for application access. Kubernetes RBAC governs access to
+          CRDs, secrets, and pod operations. The operator creates per-cluster
+          service accounts with namespace-scoped RBAC roles for instance
+          managers.
+      - reference-id: CCC.Core.CP07
+        remarks: |
+          Event Publication: the operator emits Kubernetes events for
+          failovers, switchovers, promotions, backup completions, and
+          other lifecycle state changes.
+      - reference-id: CCC.Core.CP08
+        remarks: |
+          Data Replication: PostgreSQL native streaming replication,
+          including synchronous (quorum and priority).
+      - reference-id: CCC.Core.CP09
+        remarks: Metrics publication via native Prometheus exporter
+      - reference-id: CCC.Core.CP10
+        remarks: |
+          Log Publication: Database log publication via stdout in JSON format.
+          No log is stored on volumes. Each component logs on a different channel
+          (e.g. audit logs are on a different channel).
+      - reference-id: CCC.Core.CP11
+        remarks: |
+          Backup: PostgreSQL continuous online backup support through
+          CNPG-I plugins. Support for native volume snapshots, both
+          online and offline.
+      - reference-id: CCC.Core.CP12
+        remarks: |
+          Recovery: PostgreSQL Point In Time Recovery (PITR) support through
+          CNPG-I plugins (including WAL archive restoration from object
+          stores) and volume snapshots.
+      - reference-id: CCC.Core.CP14
+        remarks: |
+          API Access: the primary API is the Kubernetes API via CRDs (Cluster,
+          Backup, Pooler, Database, Publication, Subscription, etc.). The
+          CNPG-I plugin interface provides an extension API for backup,
+          WAL archiving, and other pluggable operations.
+      - reference-id: CCC.Core.CP18
+        remarks: |
+          Resource Versioning: the operator supports PostgreSQL major
+          version upgrades via pg_upgrade Jobs, and ImageCatalog /
+          ClusterImageCatalog CRDs to control which PostgreSQL images
+          are allowed. Minor version upgrades are performed via rolling
+          updates.
+      - reference-id: CCC.Core.CP19
+        remarks: |
+          Resource Scaling: the operator supports horizontal scaling by
+          changing the instance count in the Cluster spec, and vertical
+          scaling by modifying CPU/memory resource requests and limits.
+          Scaling is on-demand only, with no built-in auto-scaling.
+      - reference-id: CCC.Core.CP20
+        remarks: |
+          Resource Tagging: the operator manages Kubernetes labels and
+          annotations on pods, services, PVCs, and other resources to
+          identify cluster membership, instance roles (primary/replica),
+          and operational state. Users can add custom labels and
+          annotations via the Cluster spec.
+      - reference-id: CCC.Core.CP21
+        remarks: |
+          Resource Replication: the operator supports replica clusters
+          that replicate from external PostgreSQL sources or from other
+          CloudNativePG clusters via streaming replication or WAL
+          shipping, enabling cross-cluster and cross-region topologies.
+          Distributed topology support allows promoting replica clusters
+          to primary.
+      - reference-id: CCC.Core.CP22
+        remarks: |
+          Location Lock-In: Postgres workloads can be assigned on specific
+          locations, such as nodes or availability zones, via taints/tolerations,
+          node selectors and topology constraints
+      - reference-id: CCC.Core.CP23
+        remarks: |
+          Network Access Rules: the operator creates ClusterIP services for
+          read-write (primary only), read-only (replicas only), and read
+          (all ready instances). The any-service (including non-ready) is
+          not created by default. All default services including read-write
+          can be disabled, and users can define additional custom services
+          using managed service templates. Database-level access is
+          controlled via pg_hba.conf with fixed rules enforcing certificate
+          authentication for streaming replication and PgBouncer connections.
+          Users can add custom pg_hba rules, including pod selector references.
+          The operator does not create NetworkPolicies.
+      - reference-id: CCC.Core.CP26
+        remarks: |
+          Persistent Storage: the operator manages PVCs for PGDATA, an optional
+          separate WAL volume, and per-tablespace volumes. Storage class
+          selection and full PVC template customization are supported. Online
+          volume expansion is enabled by default. Encryption at rest is
+          delegated entirely to the underlying storage provider.
+      - reference-id: CCC.Core.CP28
+        remarks: |
+          Command Line Interface: the `cnpg` kubectl plugin provides
+          operational commands including cluster status, promotion, restart,
+          fencing, maintenance mode, backup requests, hibernation,
+          certificate generation, psql sessions, logical replication
+          management, diagnostic reports, and performance benchmarking
+          tools (pgbench job creation).
+      - reference-id: CCC.Core.CP29
+        remarks: |
+          Active Ingestion: the instance manager in every pod receives
+          instructions from the operator via Cluster status fields
+          (target primary, phase, secret/configmap versions, topology),
+          annotations (fencing), HTTP endpoints (backup mode, online
+          upgrades), and promotion tokens. At the operator level,
+          CNPG-I plugins provide data ingestion capabilities. At the
+          database level, logical replication subscriptions enable
+          data ingestion from external sources.
+
+capabilities:
+  - id: CNPG.CP01
+    title: Automated Failover and Switchover
+    group: availability
+    description: |
+      The operator provides automated failover when the primary becomes
+      unhealthy, using a two-phase procedure with fencing to prevent
+      split-brain. Planned switchovers allow graceful primary transitions
+      with minimal downtime. Failover quorum prevents promotion unless
+      it is guaranteed that the promoted instance has all committed data.
+
+  - id: CNPG.CP02
+    title: Admission Webhooks
+    group: security
+    description: |
+      Validating and mutating admission webhooks are deployed for core CRDs
+      (Cluster, Backup, Database, Pooler, ScheduledBackup) with
+      failurePolicy set to Fail. Webhooks cover create and update
+      operations only (not delete). Publication, Subscription,
+      ImageCatalog, and ClusterImageCatalog CRDs do not have admission
+      webhooks. Webhooks enforce configuration validity and set defaults.
+
+  - id: CNPG.CP03
+    title: Connection Pooling
+    group: data-management
+    description: |
+      The Pooler CRD manages PgBouncer-based connection pooling deployments,
+      including Deployments, Services, and RBAC resources. PgBouncer
+      authenticates to PostgreSQL via client certificates.
+
+  - id: CNPG.CP04
+    title: Declarative Database Objects
+    group: data-management
+    description: |
+      The operator manages declarative databases, publications, and
+      subscriptions as dedicated CRDs, and managed roles within the
+      Cluster spec. These are reconciled continuously to match the
+      desired state.
+
+  - id: CNPG.CP05
+    title: Pod Security Hardening
+    group: security
+    description: |
+      PostgreSQL pods run as non-root with a read-only root filesystem,
+      all Linux capabilities dropped, privilege escalation disabled, and
+      seccomp profiles applied. These are defaults that can be weakened
+      via the Cluster spec SecurityContext field. The operator creates
+      per-cluster service accounts with namespace-scoped RBAC roles.
+
+  - id: CNPG.CP06
+    title: Hibernation and Fencing
+    group: availability
+    description: |
+      Clusters can be hibernated to suspend all instances while preserving
+      PVCs, and resumed later. Individual instances can be fenced to
+      isolate them from the cluster without deletion.
+
+  - id: CNPG.CP07
+    title: Health Probes
+    group: availability
+    description: |
+      The instance manager configures startup, readiness, and liveness
+      probes for PostgreSQL pods via the status port (8000, TLS). These
+      probes drive Kubernetes service endpoint updates and detect
+      instance failures.
+
+  - id: CNPG.CP08
+    title: Rolling Updates
+    group: availability
+    description: |
+      The operator performs rolling updates of PostgreSQL instances when
+      the pod spec changes (image upgrades, configuration changes
+      requiring restart), updating replicas first and the primary last
+      via a switchover to minimize downtime.
+
+  - id: CNPG.CP09
+    title: Scheduled Backups
+    group: data-management
+    description: |
+      The ScheduledBackup CRD provides cron-based backup scheduling,
+      supporting object store backups via CNPG-I plugins or the
+      built-in barman-cloud integration, and volume snapshot backups.

--- a/.github/capability-catalog.yaml
+++ b/.github/capability-catalog.yaml
@@ -6,7 +6,7 @@ metadata:
   description: >
     Capabilities provided by the CloudNativePG operator for managing
     PostgreSQL clusters on Kubernetes.
-  version: v2026.03-1
+  version: v2026.06-1
   author:
     id: cnpg-maintainers
     name: CloudNativePG Maintainers

--- a/.github/threat-catalog.yaml
+++ b/.github/threat-catalog.yaml
@@ -6,7 +6,7 @@ metadata:
   description: >
     Threat catalog for the CloudNativePG operator, documenting threats
     specific to operating PostgreSQL clusters on Kubernetes.
-  version: v2026.03-1
+  version: v2026.06-1
   author:
     id: cnpg-maintainers
     name: CloudNativePG Maintainers
@@ -21,7 +21,7 @@ metadata:
         and threat models maintained by FINOS.
     - id: CNPG.CAPABILITIES
       title: CloudNativePG Operator Capability Catalog
-      version: v2026.03-1
+      version: v2026.06-1
       description: >
         Capabilities provided by the CloudNativePG operator for managing
         PostgreSQL clusters on Kubernetes.

--- a/.github/threat-catalog.yaml
+++ b/.github/threat-catalog.yaml
@@ -2,7 +2,7 @@ title: CloudNativePG Operator Threat Catalog
 metadata:
   id: CNPG.THREATS
   type: ThreatCatalog
-  gemara-version: "1.0.0"
+  gemara-version: "1.2.0"
   description: >
     Threat catalog for the CloudNativePG operator, documenting threats
     specific to operating PostgreSQL clusters on Kubernetes.

--- a/.github/threat-catalog.yaml
+++ b/.github/threat-catalog.yaml
@@ -1,9 +1,11 @@
-title: CloudNativePG Operator Project Self-Assessment
+title: CloudNativePG Operator Threat Catalog
 metadata:
-  id: CNPG.OPERATOR
+  id: CNPG.THREATS
   type: ThreatCatalog
-  gemara-version: "0.20.0"
-  description: Threat catalog for CloudNativePG Operator security assessment
+  gemara-version: "1.0.0"
+  description: >
+    Threat catalog for the CloudNativePG operator, documenting threats
+    specific to operating PostgreSQL clusters on Kubernetes.
   version: v2026.03-1
   author:
     id: cnpg-maintainers
@@ -17,136 +19,31 @@ metadata:
       description: |
         Foundational repository of reusable security controls, capabilities,
         and threat models maintained by FINOS.
+    - id: CNPG.CAPABILITIES
+      title: CloudNativePG Operator Capability Catalog
+      version: v2026.03-1
+      description: >
+        Capabilities provided by the CloudNativePG operator for managing
+        PostgreSQL clusters on Kubernetes.
 
-imported-capabilities:
-  - reference-id: CCC
-    entries:
-      - reference-id: CCC.Core.CP01
-        remarks: Encryption in Transit Enabled by Default
-      - reference-id: CCC.Core.CP02
-        remarks: |
-          Encryption at Rest: the operator does not manage encryption at
-          rest directly. It is delegated entirely to the underlying storage
-          provider for PGDATA, WAL, and tablespace volumes, and to the
-          object store provider for backups and WAL archives.
-      - reference-id: CCC.Core.CP03
-        remarks: |
-          Access Log Publication: PGAudit integration is supported when
-          the pgaudit extension is configured. Audit logs are emitted as
-          a separate JSON channel on stdout, distinct from regular
-          PostgreSQL logs.
-      - reference-id: CCC.Core.CP06
-        remarks: |
-          Access Control: database-level access is controlled via pg_hba.conf
-          with fixed rules for replication and PgBouncer, and user-defined
-          rules for application access. Kubernetes RBAC governs access to
-          CRDs, secrets, and pod operations. The operator creates per-cluster
-          service accounts with namespace-scoped RBAC roles for instance
-          managers.
-      - reference-id: CCC.Core.CP07
-        remarks: |
-          Event Publication: the operator emits Kubernetes events for
-          failovers, switchovers, promotions, backup completions, and
-          other lifecycle state changes.
-      - reference-id: CCC.Core.CP08
-        remarks: |
-          Data Replication: PostgreSQL native streaming replication,
-          including synchronous (quorum and priority).
-      - reference-id: CCC.Core.CP09
-        remarks: Metrics publication via native Prometheus exporter
-      - reference-id: CCC.Core.CP10
-        remarks: |
-          Log Publication: Database log publication via stdout in JSON format.
-          No log is stored on volumes. Each component logs on a different channel
-          (e.g. audit logs are on a different channel).
-      - reference-id: CCC.Core.CP11
-        remarks: |
-          Backup: PostgreSQL continuous online backup support through
-          CNPG-I plugins. Support for native volume snapshots, both
-          online and offline.
-      - reference-id: CCC.Core.CP12
-        remarks: |
-          Recovery: PostgreSQL Point In Time Recovery (PITR) support through
-          CNPG-I plugins (including WAL archive restoration from object
-          stores) and volume snapshots.
-      - reference-id: CCC.Core.CP14
-        remarks: |
-          API Access: the primary API is the Kubernetes API via CRDs (Cluster,
-          Backup, Pooler, Database, Publication, Subscription, etc.). The
-          CNPG-I plugin interface provides an extension API for backup,
-          WAL archiving, and other pluggable operations.
-      - reference-id: CCC.Core.CP18
-        remarks: |
-          Resource Versioning: the operator supports PostgreSQL major
-          version upgrades via pg_upgrade Jobs, and ImageCatalog /
-          ClusterImageCatalog CRDs to control which PostgreSQL images
-          are allowed. Minor version upgrades are performed via rolling
-          updates.
-      - reference-id: CCC.Core.CP19
-        remarks: |
-          Resource Scaling: the operator supports horizontal scaling by
-          changing the instance count in the Cluster spec, and vertical
-          scaling by modifying CPU/memory resource requests and limits.
-          Scaling is on-demand only, with no built-in auto-scaling.
-      - reference-id: CCC.Core.CP20
-        remarks: |
-          Resource Tagging: the operator manages Kubernetes labels and
-          annotations on pods, services, PVCs, and other resources to
-          identify cluster membership, instance roles (primary/replica),
-          and operational state. Users can add custom labels and
-          annotations via the Cluster spec.
-      - reference-id: CCC.Core.CP21
-        remarks: |
-          Resource Replication: the operator supports replica clusters
-          that replicate from external PostgreSQL sources or from other
-          CloudNativePG clusters via streaming replication or WAL
-          shipping, enabling cross-cluster and cross-region topologies.
-          Distributed topology support allows promoting replica clusters
-          to primary.
-      - reference-id: CCC.Core.CP22
-        remarks: |
-          Location Lock-In: Postgres workloads can be assigned on specific
-          locations, such as nodes or availability zones, via taints/tolerations,
-          node selectors and topology constraints
-      - reference-id: CCC.Core.CP23
-        remarks: |
-          Network Access Rules: the operator creates ClusterIP services for
-          read-write (primary only), read-only (replicas only), and read
-          (all ready instances). The any-service (including non-ready) is
-          not created by default. All default services including read-write
-          can be disabled, and users can define additional custom services
-          using managed service templates. Database-level access is
-          controlled via pg_hba.conf with fixed rules enforcing certificate
-          authentication for streaming replication and PgBouncer connections.
-          Users can add custom pg_hba rules, including pod selector references.
-          The operator does not create NetworkPolicies.
-      - reference-id: CCC.Core.CP26
-        remarks: |
-          Persistent Storage: the operator manages PVCs for PGDATA, an optional
-          separate WAL volume, and per-tablespace volumes. Storage class
-          selection and full PVC template customization are supported. Online
-          volume expansion is enabled by default. Encryption at rest is
-          delegated entirely to the underlying storage provider.
-      - reference-id: CCC.Core.CP28
-        remarks: |
-          Command Line Interface: the `cnpg` kubectl plugin provides
-          operational commands including cluster status, promotion, restart,
-          fencing, maintenance mode, backup requests, hibernation,
-          certificate generation, psql sessions, logical replication
-          management, diagnostic reports, and performance benchmarking
-          tools (pgbench job creation).
-      - reference-id: CCC.Core.CP29
-        remarks: |
-          Active Ingestion: the instance manager in every pod receives
-          instructions from the operator via Cluster status fields
-          (target primary, phase, secret/configmap versions, topology),
-          annotations (fencing), HTTP endpoints (backup mode, online
-          upgrades), and promotion tokens. At the operator level,
-          CNPG-I plugins provide data ingestion capabilities. At the
-          database level, logical replication subscriptions enable
-          data ingestion from external sources.
+groups:
+  - id: supply-chain
+    title: Supply Chain
+    description: >
+      Threats related to the integrity and provenance of software
+      components, container images, and plugins consumed by the operator.
+  - id: credential-and-cryptography
+    title: Credential and Cryptography
+    description: >
+      Threats related to the exposure, lifecycle, and management of
+      secrets, certificates, and cryptographic material.
+  - id: access-control
+    title: Access Control
+    description: >
+      Threats related to excessive permissions, privilege escalation,
+      and unauthorized access to operator or cluster resources.
 
-imported-threats:
+imports:
   - reference-id: CCC
     entries:
       - reference-id: CCC.Core.TH01
@@ -394,83 +291,10 @@ imported-threats:
           authentication at the network or proxy layer if metrics are
           exposed beyond the cluster.
 
-capabilities:
-  - id: CNPG.CP01
-    title: Automated Failover and Switchover
-    description: |
-      The operator provides automated failover when the primary becomes
-      unhealthy, using a two-phase procedure with fencing to prevent
-      split-brain. Planned switchovers allow graceful primary transitions
-      with minimal downtime. Failover quorum prevents promotion unless
-      it is guaranteed that the promoted instance has all committed data.
-
-  - id: CNPG.CP02
-    title: Admission Webhooks
-    description: |
-      Validating and mutating admission webhooks are deployed for core CRDs
-      (Cluster, Backup, Database, Pooler, ScheduledBackup) with
-      failurePolicy set to Fail. Webhooks cover create and update
-      operations only (not delete). Publication, Subscription,
-      ImageCatalog, and ClusterImageCatalog CRDs do not have admission
-      webhooks. Webhooks enforce configuration validity and set defaults.
-
-  - id: CNPG.CP03
-    title: Connection Pooling
-    description: |
-      The Pooler CRD manages PgBouncer-based connection pooling deployments,
-      including Deployments, Services, and RBAC resources. PgBouncer
-      authenticates to PostgreSQL via client certificates.
-
-  - id: CNPG.CP04
-    title: Declarative Database Objects
-    description: |
-      The operator manages declarative databases, publications, and
-      subscriptions as dedicated CRDs, and managed roles within the
-      Cluster spec. These are reconciled continuously to match the
-      desired state.
-
-  - id: CNPG.CP05
-    title: Pod Security Hardening
-    description: |
-      PostgreSQL pods run as non-root with a read-only root filesystem,
-      all Linux capabilities dropped, privilege escalation disabled, and
-      seccomp profiles applied. These are defaults that can be weakened
-      via the Cluster spec SecurityContext field. The operator creates
-      per-cluster service accounts with namespace-scoped RBAC roles.
-
-  - id: CNPG.CP06
-    title: Hibernation and Fencing
-    description: |
-      Clusters can be hibernated to suspend all instances while preserving
-      PVCs, and resumed later. Individual instances can be fenced to
-      isolate them from the cluster without deletion.
-
-  - id: CNPG.CP07
-    title: Health Probes
-    description: |
-      The instance manager configures startup, readiness, and liveness
-      probes for PostgreSQL pods via the status port (8000, TLS). These
-      probes drive Kubernetes service endpoint updates and detect
-      instance failures.
-
-  - id: CNPG.CP08
-    title: Rolling Updates
-    description: |
-      The operator performs rolling updates of PostgreSQL instances when
-      the pod spec changes (image upgrades, configuration changes
-      requiring restart), updating replicas first and the primary last
-      via a switchover to minimize downtime.
-
-  - id: CNPG.CP09
-    title: Scheduled Backups
-    description: |
-      The ScheduledBackup CRD provides cron-based backup scheduling,
-      supporting object store backups via CNPG-I plugins or the
-      built-in barman-cloud integration, and volume snapshot backups.
-
 threats:
   - id: CNPG.TH01
     title: Supply Chain Compromise of Container Images
+    group: supply-chain
     description: |
       Tampered or vulnerable container images for PostgreSQL or the operator
       could introduce malicious code or known vulnerabilities. CloudNativePG
@@ -482,7 +306,7 @@ threats:
       at deploy time. Users must integrate image verification into their
       admission pipeline (e.g., via Kyverno or Sigstore policy-controller).
     capabilities:
-      - reference-id: CNPG.OPERATOR
+      - reference-id: CNPG.CAPABILITIES
         entries:
           - reference-id: CNPG.CP05
       - reference-id: CCC
@@ -491,6 +315,7 @@ threats:
 
   - id: CNPG.TH02
     title: Kubernetes Secret Exposure
+    group: credential-and-cryptography
     description: |
       Database credentials, replication certificates, cloud provider
       credentials for object store access (AWS keys, Azure storage
@@ -504,7 +329,7 @@ threats:
       external secret managers if needed, and implementing credential rotation
       procedures.
     capabilities:
-      - reference-id: CNPG.OPERATOR
+      - reference-id: CNPG.CAPABILITIES
         entries:
           - reference-id: CNPG.CP01
           - reference-id: CNPG.CP03
@@ -515,6 +340,7 @@ threats:
 
   - id: CNPG.TH03
     title: Internal Certificate Lifecycle Weaknesses
+    group: credential-and-cryptography
     description: |
       The operator manages an internal PKI with operator-level and per-cluster
       CA certificates. Both CA and leaf certificates default to 90-day validity,
@@ -537,6 +363,7 @@ threats:
 
   - id: CNPG.TH04
     title: Untrusted Plugin Execution via CNPG-I
+    group: supply-chain
     description: |
       CNPG-I plugins perform privileged operations including backup, WAL
       archiving, lifecycle hooks, reconciliation hooks, cluster mutations,
@@ -549,7 +376,7 @@ threats:
       are responsible for vetting plugin sources, restricting which images
       run as sidecars, and auditing plugin behavior.
     capabilities:
-      - reference-id: CNPG.OPERATOR
+      - reference-id: CNPG.CAPABILITIES
         entries:
           - reference-id: CNPG.CP01
           - reference-id: CNPG.CP05
@@ -561,6 +388,7 @@ threats:
 
   - id: CNPG.TH05
     title: Operator Privilege Escalation
+    group: access-control
     description: |
       The operator runs with a cluster-scoped ClusterRole that includes
       permissions across all watched namespaces: pods and pods/exec
@@ -580,7 +408,7 @@ threats:
       pod, monitoring service account token usage, and considering
       namespace isolation to limit blast radius.
     capabilities:
-      - reference-id: CNPG.OPERATOR
+      - reference-id: CNPG.CAPABILITIES
         entries:
           - reference-id: CNPG.CP01
           - reference-id: CNPG.CP02

--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,10 @@ OPERATOR_SDK_VERSION ?= v1.42.2
 OPM_VERSION ?= v1.69.0
 # renovate: datasource=github-tags depName=redhat-openshift-ecosystem/openshift-preflight
 PREFLIGHT_VERSION ?= 1.19.0
+# renovate: datasource=docker depName=cuelang/cue versioning=docker
+CUE_VERSION ?= 0.16.1
+# renovate: datasource=go depName=github.com/gemaraproj/gemara
+GEMARA_VERSION ?= v1.2.0
 OPENSHIFT_VERSIONS ?= v4.18-v4.21
 ARCH ?= amd64
 FUZZ_TIME ?= 30s
@@ -290,6 +294,16 @@ spellcheck: ## Runs the spellcheck on the project.
 woke: ## Runs the woke checks on project.
 	docker run --rm -v $(PWD):/src:Z -w /src getwoke/woke:$(WOKE_VERSION) woke -c .woke.yaml
 
+validate-gemara: validate-threat-model ## Alias for validate-threat-model.
+
+validate-threat-model: ## Validate Gemara threat-model artifacts against the schema.
+	docker run --rm -v $(PWD):/src:Z -w /src cuelang/cue:$(CUE_VERSION) \
+		vet -c -d '#ThreatCatalog' \
+		github.com/gemaraproj/gemara@$(GEMARA_VERSION) .github/threat-catalog.yaml
+	docker run --rm -v $(PWD):/src:Z -w /src cuelang/cue:$(CUE_VERSION) \
+		vet -c -d '#CapabilityCatalog' \
+		github.com/gemaraproj/gemara@$(GEMARA_VERSION) .github/capability-catalog.yaml
+
 wordlist-ordered: ## Order the wordlist using sort
 	LANG=C LC_ALL=C sort .wordlist-en-custom.txt > .wordlist-en-custom.txt.new && \
 	mv -f .wordlist-en-custom.txt.new .wordlist-en-custom.txt
@@ -301,7 +315,7 @@ go-mod-check: ## Check if there's any dirty change after `go mod tidy`
 run-govulncheck: govulncheck ## Check if there's any known vulnerabilities with the currently installed Go modules
 	$(GOVULNCHECK) ./...
 
-checks: go-mod-check generate manifests apidoc fmt spellcheck wordlist-ordered woke vet lint run-govulncheck ## Runs all the checks on the project.
+checks: go-mod-check generate manifests apidoc fmt spellcheck wordlist-ordered woke vet lint run-govulncheck validate-threat-model ## Runs all the checks on the project.
 
 ##@ Documentation
 

--- a/SECURITY-INSIGHTS.yml
+++ b/SECURITY-INSIGHTS.yml
@@ -210,7 +210,8 @@ repository:
     assessments:
       self:
         evidence-url:
-          - https://github.com/cloudnative-pg/cloudnative-pg/blob/main/.github/threat-assessment.yaml
+          - https://github.com/cloudnative-pg/cloudnative-pg/blob/main/.github/threat-catalog.yaml
+          - https://github.com/cloudnative-pg/cloudnative-pg/blob/main/.github/capability-catalog.yaml
         comment: >-
           Gemara-compatible threat self-assessment covering capabilities
           and threats mapped to FINOS Common Cloud Controls (CCC) Core


### PR DESCRIPTION
Migrate the threat-modeling self-assessment to the Gemara v1 schema (artifacts declared at gemara-version 1.2.0), which splits the single `.github/threat-assessment.yaml` into two files:

- `.github/capability-catalog.yaml`: the CNPG.CAPABILITIES catalog (CCC imports plus the CNPG.CPxx capabilities, grouped into availability, security, and data-management).
- `.github/threat-catalog.yaml`: the CNPG.THREATS catalog (renamed from threat-assessment.yaml), with threats grouped into supply-chain, credential-and-cryptography, and access-control, and capability references repointed from CNPG.OPERATOR to CNPG.CAPABILITIES.

Update `SECURITY-INSIGHTS.yml` to reference both migrated artifacts.

Add a `validate-threat-model` Makefile target (alias: `validate-gemara`) that validates both artifacts against the Gemara CUE schema via the official `cuelang/cue` image, and wire it into `make checks`. The schema version (GEMARA_VERSION) and cue image tag (CUE_VERSION) are pinned and Renovate-tracked. Validation is not gated on changes to the catalog files, since the schema is an independent input and a file-path gate would miss schema-drift breakage.

Migration performed with the Gemara MCP server `migrate_gemara_artifact`.

Fixes #10735