### PR TITLE
feat: add EXCLUDE_NAMESPACES support for cluster-wide operators

### DIFF
--- a/docs/src/operator_conf.md
+++ b/docs/src/operator_conf.md
@@ -50,6 +50,7 @@ Name | Description
 `CREATE_ANY_SERVICE` | When set to `true`, will create `-any` service for the cluster. Default is `false`
 `DRAIN_TAINTS` | Specifies the taint keys that should be interpreted as indicators of node drain. By default, it includes the taints commonly applied by [kubectl](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/), [Cluster Autoscaler](https://github.com/kubernetes/autoscaler), and [Karpenter](https://github.com/aws/karpenter-provider-aws): `node.kubernetes.io/unschedulable`, `ToBeDeletedByClusterAutoscaler`, `karpenter.sh/disrupted`, `karpenter.sh/disruption`.
 `ENABLE_INSTANCE_MANAGER_INPLACE_UPDATES` | When set to `true`, enables in-place updates of the instance manager after an update of the operator, avoiding rolling updates of the cluster (default `false`)
+`EXCLUDE_NAMESPACES` | Comma-separated list of namespace names or glob patterns to exclude from reconciliation when running in cluster-wide mode. Ignored when `WATCH_NAMESPACE` is set.
 `EXPIRING_CHECK_THRESHOLD` | Determines the threshold, in days, for identifying a certificate as expiring. Default is 7.
 `INCLUDE_PLUGINS` | A comma-separated list of plugins to be always included in the Cluster's reconciliation.
 `INHERITED_ANNOTATIONS` | List of annotation names that, when defined in a `Cluster` metadata, will be inherited by all the generated resources, including pods

--- a/internal/cmd/manager/controller/controller.go
+++ b/internal/cmd/manager/controller/controller.go
@@ -32,7 +32,9 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	"github.com/cloudnative-pg/cloudnative-pg/internal/cnpi/plugin/repository"
@@ -140,6 +142,14 @@ func RunController(
 		setupLog.Info("Listening for changes on all namespaces")
 	}
 
+	if conf.ExcludeNamespaces != "" {
+		setupLog.Info("Not listening for changes", "excludeNamespaces", conf.ExcludeNamespaces)
+	}
+
+	if conf.WatchNamespace != "" && conf.ExcludeNamespaces != "" {
+		setupLog.Info("Warning: ExcludeNamespaces is ignored when WatchNamespace is set")
+	}
+
 	if conf.WebhookCertDir != "" {
 		// If OLM will generate certificates for us, let's just
 		// use those
@@ -220,12 +230,14 @@ func RunController(
 	}
 	defer pluginRepository.Close()
 
+	nsFilter := newNamespaceIgnorePredicate(conf)
+
 	if err = controller.NewClusterReconciler(
 		mgr,
 		discoveryClient,
 		pluginRepository,
 		conf.DrainTaints,
-	).SetupWithManager(ctx, mgr, maxConcurrentReconciles); err != nil {
+	).SetupWithManager(ctx, mgr, maxConcurrentReconciles, nsFilter); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Cluster")
 		return err
 	}
@@ -234,13 +246,13 @@ func RunController(
 		mgr,
 		discoveryClient,
 		pluginRepository,
-	).SetupWithManager(ctx, mgr); err != nil {
+	).SetupWithManager(ctx, mgr, nsFilter); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Backup")
 		return err
 	}
 
 	if err = controller.NewPluginReconciler(mgr, conf.OperatorNamespace, pluginRepository).
-		SetupWithManager(mgr, maxConcurrentReconciles); err != nil {
+		SetupWithManager(mgr, maxConcurrentReconciles, nsFilter); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Plugin")
 		return err
 	}
@@ -249,7 +261,7 @@ func RunController(
 		Client:   mgr.GetClient(),
 		Scheme:   mgr.GetScheme(),
 		Recorder: mgr.GetEventRecorderFor("cloudnative-pg-scheduledbackup"), //nolint:staticcheck
-	}).SetupWithManager(ctx, mgr, maxConcurrentReconciles); err != nil {
+	}).SetupWithManager(ctx, mgr, maxConcurrentReconciles, nsFilter); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ScheduledBackup")
 		return err
 	}
@@ -259,7 +271,7 @@ func RunController(
 		DiscoveryClient: discoveryClient,
 		Scheme:          mgr.GetScheme(),
 		Recorder:        mgr.GetEventRecorderFor("cloudnative-pg-pooler"), //nolint:staticcheck
-	}).SetupWithManager(ctx, mgr, maxConcurrentReconciles); err != nil {
+	}).SetupWithManager(ctx, mgr, maxConcurrentReconciles, nsFilter); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Pooler")
 		return err
 	}
@@ -488,4 +500,33 @@ func getPprofServerAddress(enabled bool) string {
 	}
 
 	return ""
+}
+
+func newNamespaceIgnorePredicate(conf *configuration.Data) predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			if e.Object == nil {
+				return false
+			}
+			return !conf.IsNamespaceExcluded(e.Object.GetNamespace())
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			if e.ObjectNew == nil {
+				return false
+			}
+			return !conf.IsNamespaceExcluded(e.ObjectNew.GetNamespace())
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			if e.Object == nil {
+				return false
+			}
+			return !conf.IsNamespaceExcluded(e.Object.GetNamespace())
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			if e.Object == nil {
+				return false
+			}
+			return !conf.IsNamespaceExcluded(e.Object.GetNamespace())
+		},
+	}
 }

--- a/internal/configuration/configuration.go
+++ b/internal/configuration/configuration.go
@@ -93,6 +93,13 @@ type Data struct {
 	// Multiple namespaces can be specified separated by comma
 	WatchNamespace string `json:"watchNamespace" env:"WATCH_NAMESPACE"`
 
+	// ExcludeNamespaces is a comma-separated list of namespace names or glob patterns
+	// the operator should ignore. It only applies when WatchNamespace is empty.
+	ExcludeNamespaces string `json:"excludeNamespaces" env:"EXCLUDE_NAMESPACES"`
+
+	// ExcludedNamespacePatterns holds the parsed exclusion list.
+	ExcludedNamespacePatterns []string `json:"-"`
+
 	// OperatorNamespace is the namespace where the operator is installed
 	OperatorNamespace string `json:"operatorNamespace" env:"OPERATOR_NAMESPACE"`
 
@@ -208,6 +215,7 @@ func NewConfiguration() *Data {
 // ReadConfigMap reads the configuration from the environment and the passed in data map
 func (config *Data) ReadConfigMap(data map[string]string) {
 	configparser.ReadConfigMap(config, newDefaultConfig(), data)
+	config.ExcludedNamespacePatterns = cleanNamespaceList(config.ExcludeNamespaces)
 }
 
 // IsAnnotationInherited checks if an annotation with a certain name should
@@ -238,6 +246,15 @@ func (config *Data) GetInstancesRolloutDelay() time.Duration {
 // each namespace is separated by comma
 func (config *Data) WatchedNamespaces() []string {
 	return cleanNamespaceList(config.WatchNamespace)
+}
+
+// IsNamespaceExcluded checks if a namespace should be excluded from reconciliation.
+func (config *Data) IsNamespaceExcluded(namespace string) bool {
+	if namespace == "" || len(config.ExcludedNamespacePatterns) == 0 {
+		return false
+	}
+
+	return evaluateGlobPatterns(config.ExcludedNamespacePatterns, namespace)
 }
 
 // GetIncludePlugins gets the list of plugins to be always

--- a/internal/configuration/configuration_test.go
+++ b/internal/configuration/configuration_test.go
@@ -133,6 +133,29 @@ var _ = Describe("Annotation and label inheritance", func() {
 		})
 	})
 
+	When("excluded namespaces are specified", func() {
+		It("matches exact names and glob patterns", func() {
+			config := Data{}
+			config.ReadConfigMap(map[string]string{
+				"EXCLUDE_NAMESPACES": "qa, team-*, prod",
+			})
+
+			Expect(config.IsNamespaceExcluded("qa")).To(BeTrue())
+			Expect(config.IsNamespaceExcluded("team-app")).To(BeTrue())
+			Expect(config.IsNamespaceExcluded("prod")).To(BeTrue())
+			Expect(config.IsNamespaceExcluded("dev")).To(BeFalse())
+		})
+
+		It("returns false for empty namespaces", func() {
+			config := Data{}
+			config.ReadConfigMap(map[string]string{
+				"EXCLUDE_NAMESPACES": "qa,*-tmp",
+			})
+
+			Expect(config.IsNamespaceExcluded("")).To(BeFalse())
+		})
+	})
+
 	Context("included plugin list", func() {
 		It("is empty by default", func() {
 			Expect(newDefaultConfig().GetIncludePlugins()).To(BeEmpty())

--- a/internal/controller/backup_controller.go
+++ b/internal/controller/backup_controller.go
@@ -42,6 +42,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
@@ -966,7 +967,11 @@ func startInstanceManagerBackup(
 }
 
 // SetupWithManager sets up this controller given a controller manager
-func (r *BackupReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
+func (r *BackupReconciler) SetupWithManager(
+	ctx context.Context,
+	mgr ctrl.Manager,
+	extraPredicates ...predicate.Predicate,
+) error {
 	if err := mgr.GetFieldIndexer().IndexField(
 		ctx,
 		&apiv1.Backup{},
@@ -985,7 +990,11 @@ func (r *BackupReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manage
 		return err
 	}
 
-	controllerBuilder := ctrl.NewControllerManagedBy(mgr).
+	controllerBuilder := ctrl.NewControllerManagedBy(mgr)
+	for _, p := range extraPredicates {
+		controllerBuilder = controllerBuilder.WithEventFilter(p)
+	}
+	controllerBuilder = controllerBuilder.
 		For(&apiv1.Backup{}).
 		Named("backup").
 		Watches(&apiv1.Cluster{},

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -151,6 +151,10 @@ var ErrNextLoop = utils.ErrNextLoop
 
 // Reconcile is the operator reconcile loop
 func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	if configuration.Current.IsNamespaceExcluded(req.Namespace) {
+		return ctrl.Result{}, nil
+	}
+
 	contextLogger, ctx := log.SetupLogger(ctx)
 
 	contextLogger.Debug("Reconciliation loop start")
@@ -1241,13 +1245,18 @@ func (r *ClusterReconciler) handleRollingUpdate(
 }
 
 // SetupWithManager creates a ClusterReconciler
-func (r *ClusterReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, maxConcurrentReconciles int) error {
+func (r *ClusterReconciler) SetupWithManager(
+	ctx context.Context,
+	mgr ctrl.Manager,
+	maxConcurrentReconciles int,
+	extraPredicates ...predicate.Predicate,
+) error {
 	err := r.createFieldIndexes(ctx, mgr)
 	if err != nil {
 		return err
 	}
 
-	return ctrl.NewControllerManagedBy(mgr).
+	newController := ctrl.NewControllerManagedBy(mgr).
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: maxConcurrentReconciles,
 		}).
@@ -1293,8 +1302,13 @@ func (r *ClusterReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manag
 			&apiv1.ClusterImageCatalog{},
 			handler.EnqueueRequestsFromMapFunc(r.mapClusterImageCatalogsToClusters()),
 			builder.WithPredicates(predicate.ResourceVersionChangedPredicate{}),
-		).
-		Complete(r)
+		)
+
+	for _, p := range extraPredicates {
+		newController = newController.WithEventFilter(p)
+	}
+
+	return newController.Complete(r)
 }
 
 // jobOwnerIndexFunc maps a job definition to its owning cluster and

--- a/internal/controller/plugin_controller.go
+++ b/internal/controller/plugin_controller.go
@@ -41,6 +41,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/cloudnative-pg/cloudnative-pg/internal/cnpi/plugin/repository"
@@ -367,14 +368,18 @@ func (r *PluginReconciler) mapSecretToPlugin(ctx context.Context, obj client.Obj
 func (r *PluginReconciler) SetupWithManager(
 	mgr ctrl.Manager,
 	maxConcurrentReconciles int,
+	extraPredicates ...predicate.Predicate,
 ) error {
-	return ctrl.NewControllerManagedBy(mgr).
+	newController := ctrl.NewControllerManagedBy(mgr).
 		WithOptions(controller.Options{MaxConcurrentReconciles: maxConcurrentReconciles}).
 		For(&corev1.Service{}).
 		Named("plugin").
 		Watches(
 			&corev1.Secret{},
 			handler.EnqueueRequestsFromMapFunc(r.mapSecretToPlugin),
-		).
-		Complete(r)
+		)
+	for _, p := range extraPredicates {
+		newController = newController.WithEventFilter(p)
+	}
+	return newController.Complete(r)
 }

--- a/internal/controller/pooler_controller.go
+++ b/internal/controller/pooler_controller.go
@@ -44,6 +44,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	"github.com/cloudnative-pg/cloudnative-pg/internal/configuration"
 )
 
 // PoolerReconciler reconciles a Pooler object
@@ -64,6 +65,10 @@ type PoolerReconciler struct {
 
 // Reconcile implements the main reconciliation loop for pooler objects
 func (r *PoolerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	if configuration.Current.IsNamespaceExcluded(req.Namespace) {
+		return ctrl.Result{}, nil
+	}
+
 	contextLogger, ctx := log.SetupLogger(ctx)
 
 	var pooler apiv1.Pooler
@@ -143,12 +148,17 @@ func (r *PoolerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 }
 
 // SetupWithManager setup this controller inside the controller manager
-func (r *PoolerReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, maxConcurrentReconciles int) error {
+func (r *PoolerReconciler) SetupWithManager(
+	ctx context.Context,
+	mgr ctrl.Manager,
+	maxConcurrentReconciles int,
+	extraPredicates ...predicate.Predicate,
+) error {
 	if err := r.createFieldIndexes(ctx, mgr); err != nil {
 		return err
 	}
 
-	return ctrl.NewControllerManagedBy(mgr).
+	newController := ctrl.NewControllerManagedBy(mgr).
 		WithOptions(controller.Options{MaxConcurrentReconciles: maxConcurrentReconciles}).
 		For(&apiv1.Pooler{}).
 		Named("pooler").
@@ -171,8 +181,11 @@ func (r *PoolerReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manage
 			&apiv1.ClusterImageCatalog{},
 			handler.EnqueueRequestsFromMapFunc(r.mapClusterImageCatalogToPoolers()),
 			builder.WithPredicates(predicate.ResourceVersionChangedPredicate{}),
-		).
-		Complete(r)
+		)
+	for _, p := range extraPredicates {
+		newController = newController.WithEventFilter(p)
+	}
+	return newController.Complete(r)
 }
 
 // poolerImageCatalogKey is the field index key for Poolers referencing an image catalog.

--- a/internal/controller/scheduledbackup_controller.go
+++ b/internal/controller/scheduledbackup_controller.go
@@ -37,6 +37,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
@@ -415,6 +416,7 @@ func (r *ScheduledBackupReconciler) SetupWithManager(
 	ctx context.Context,
 	mgr ctrl.Manager,
 	maxConcurrentReconciles int,
+	extraPredicates ...predicate.Predicate,
 ) error {
 	// Create a field indexer on the parent ScheduledBackup label to efficiently
 	// find all backups created by a ScheduledBackup, regardless of the
@@ -436,9 +438,12 @@ func (r *ScheduledBackupReconciler) SetupWithManager(
 		return err
 	}
 
-	return ctrl.NewControllerManagedBy(mgr).
+	newController := ctrl.NewControllerManagedBy(mgr).
 		WithOptions(controller.Options{MaxConcurrentReconciles: maxConcurrentReconciles}).
 		For(&apiv1.ScheduledBackup{}).
-		Named("scheduled-backup").
-		Complete(r)
+		Named("scheduled-backup")
+	for _, p := range extraPredicates {
+		newController = newController.WithEventFilter(p)
+	}
+	return newController.Complete(r)
 }


### PR DESCRIPTION
Closes #10787

## Summary
- add `EXCLUDE_NAMESPACES` operator configuration (comma-separated names/globs) and parse it into reusable namespace exclusion patterns
- wire a namespace exclusion event predicate into cluster, backup, plugin, scheduled backup, and pooler controllers
- short-circuit cluster and pooler reconciliations for excluded namespaces and document the new option in operator configuration docs

## Test plan
- [x] `GOTOOLCHAIN=auto go test ./internal/configuration/... ./internal/controller/... ./internal/cmd/manager/controller/...`
- [x] verify no linter errors in changed files
- [ ] manual migration flow validation on a cluster