### PR TITLE
feat: add WEBHOOK_PREFIX for webhook object names

### DIFF
--- a/internal/cmd/manager/controller/controller.go
+++ b/internal/cmd/manager/controller/controller.go
@@ -396,6 +396,8 @@ func ensurePKI(
 		return nil
 	}
 
+	mutatingWebhook, validatingWebhook := getWebhookConfigurationNames(conf.WebhookPrefix)
+
 	// We need to self-manage required PKI infrastructure and install the certificates into
 	// the webhooks configuration
 	pkiConfig := certs.PublicKeyInfrastructure{
@@ -404,8 +406,8 @@ func ensurePKI(
 		SecretName:                         WebhookSecretName,
 		ServiceName:                        WebhookServiceName,
 		OperatorNamespace:                  conf.OperatorNamespace,
-		MutatingWebhookConfigurationName:   MutatingWebhookConfigurationName,
-		ValidatingWebhookConfigurationName: ValidatingWebhookConfigurationName,
+		MutatingWebhookConfigurationName:   mutatingWebhook,
+		ValidatingWebhookConfigurationName: validatingWebhook,
 		OperatorDeploymentLabelSelector:    "app.kubernetes.io/name=cloudnative-pg",
 	}
 	err := pkiConfig.Setup(ctx, kubeClient)
@@ -413,6 +415,18 @@ func ensurePKI(
 		setupLog.Error(err, "unable to setup PKI infrastructure")
 	}
 	return err
+}
+
+func getWebhookConfigurationNames(webhookPrefix string) (string, string) {
+	mutatingWebhook := MutatingWebhookConfigurationName
+	validatingWebhook := ValidatingWebhookConfigurationName
+
+	if webhookPrefix != "" {
+		mutatingWebhook = webhookPrefix + mutatingWebhook
+		validatingWebhook = webhookPrefix + validatingWebhook
+	}
+
+	return mutatingWebhook, validatingWebhook
 }
 
 // readConfigMap reads the configMap and returns its content as map

--- a/internal/cmd/manager/controller/controller_test.go
+++ b/internal/cmd/manager/controller/controller_test.go
@@ -1,0 +1,61 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package controller
+
+import "testing"
+
+func TestGetWebhookConfigurationNames(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name               string
+		prefix             string
+		expectedMutating   string
+		expectedValidating string
+	}{
+		{
+			name:               "returns default names without prefix",
+			prefix:             "",
+			expectedMutating:   MutatingWebhookConfigurationName,
+			expectedValidating: ValidatingWebhookConfigurationName,
+		},
+		{
+			name:               "prepends configured prefix",
+			prefix:             "my-prefix-",
+			expectedMutating:   "my-prefix-" + MutatingWebhookConfigurationName,
+			expectedValidating: "my-prefix-" + ValidatingWebhookConfigurationName,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			mutating, validating := getWebhookConfigurationNames(tc.prefix)
+			if mutating != tc.expectedMutating {
+				t.Fatalf("unexpected mutating webhook name, got %q, want %q", mutating, tc.expectedMutating)
+			}
+			if validating != tc.expectedValidating {
+				t.Fatalf("unexpected validating webhook name, got %q, want %q", validating, tc.expectedValidating)
+			}
+		})
+	}
+}

--- a/internal/configuration/configuration.go
+++ b/internal/configuration/configuration.go
@@ -175,6 +175,12 @@ type Data struct {
 
 	// DrainTaints is a list of taints the operator will watch and treat as Unschedule
 	DrainTaints []string `json:"drainTaints" env:"DRAIN_TAINTS"`
+
+	// WEBHOOK_PREFIX is an optional setting that if specified will be
+	// prepended to the object names of the mutating and validating webhooks. i.e.
+	// they will be created as `${WEBHOOK_PREFIX}cnpg-mutating-webhook-configuration`
+	// and `${WEBHOOK_PREFIX}cnpg-validating-webhook-configuration`
+	WebhookPrefix string `json:"webhookPrefix" env:"WEBHOOK_PREFIX"`
 }
 
 // Current is the configuration used by the operator


### PR DESCRIPTION
## Summary
- add `WEBHOOK_PREFIX`, an optional configuration string prepended to webhook object names
- apply the prefix to mutating/validating webhook configuration names during PKI setup
- keep existing behavior unchanged when `WEBHOOK_PREFIX` is not set
- add focused unit tests for both prefixed and default naming behavior

Closes #10792

## Test plan
- [x] `GOTOOLCHAIN=auto go test ./internal/cmd/manager/controller/...`