### PR TITLE
chore(test): pipe captured stdout to GinkgoWriter

### DIFF
--- a/internal/cmd/plugin/fence/fence_test.go
+++ b/internal/cmd/plugin/fence/fence_test.go
@@ -21,6 +21,8 @@ package fence
 
 import (
 	"encoding/json"
+	"io"
+	"os"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -35,6 +37,17 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+func redirectStdoutToGinkgoWriter() {
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	DeferCleanup(func() {
+		_ = w.Close()
+		os.Stdout = old
+		_, _ = io.Copy(GinkgoWriter, r)
+	})
+}
+
 var _ = Describe("fencingOn", func() {
 	const (
 		clusterName = "cluster-example"
@@ -43,6 +56,7 @@ var _ = Describe("fencingOn", func() {
 
 	BeforeEach(func() {
 		plugin.Namespace = namespace
+		redirectStdoutToGinkgoWriter()
 	})
 
 	It("should fence a known instance", func(ctx SpecContext) {
@@ -139,6 +153,7 @@ var _ = Describe("fencingOff", func() {
 
 	BeforeEach(func() {
 		plugin.Namespace = namespace
+		redirectStdoutToGinkgoWriter()
 	})
 
 	It("should unfence a known fenced instance", func(ctx SpecContext) {

--- a/internal/cmd/plugin/promote/promote_test.go
+++ b/internal/cmd/plugin/promote/promote_test.go
@@ -20,6 +20,9 @@ SPDX-License-Identifier: Apache-2.0
 package promote
 
 import (
+	"io"
+	"os"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -38,6 +41,15 @@ var _ = Describe("promote subcommand tests", func() {
 	var client k8client.Client
 	const namespace = "theNamespace"
 	BeforeEach(func() {
+		old := os.Stdout
+		r, w, _ := os.Pipe()
+		os.Stdout = w
+		DeferCleanup(func() {
+			_ = w.Close()
+			os.Stdout = old
+			_, _ = io.Copy(GinkgoWriter, r)
+		})
+
 		cluster1 := apiv1.Cluster{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "cluster1",

--- a/internal/cmd/plugin/report/operator_report_test.go
+++ b/internal/cmd/plugin/report/operator_report_test.go
@@ -56,7 +56,7 @@ var _ = Describe("configureRedactors", func() {
 		// Restore stdout
 		_ = w.Close()
 		os.Stdout = oldStdout
-		_, _ = io.Copy(io.Discard, r)
+		_, _ = io.Copy(GinkgoWriter, r)
 
 		// Verify they are pass-through functions
 		secret := corev1.Secret{Data: map[string][]byte{"key": []byte("value")}}
@@ -90,7 +90,7 @@ var _ = Describe("tryCollectConfigurations", func() {
 		// Restore stdout
 		_ = w.Close()
 		os.Stdout = oldStdout
-		_, _ = io.Copy(io.Discard, r)
+		_, _ = io.Copy(GinkgoWriter, r)
 
 		// When errors occur, function returns nil slices (not empty slices)
 		// This is acceptable as writeToZip checks for nil/empty


### PR DESCRIPTION
Wrap the BeforeEach of the fence and promote plugin suites in the same stdout-to-pipe redirect already used by the report suite, copying the captured bytes into GinkgoWriter so Ginkgo no longer prints per-spec "Captured StdOut/StdErr Output" blocks under `make test-race`. Also switch the report suite's own redirect from `io.Discard` to `GinkgoWriter` so captured output stays available on failure.