### PR TITLE
[#9920]: pkg: fix backup reconciliation by overriding managed-by label

### DIFF
--- a/pkg/reconciler/persistentvolumeclaim/metadata.go
+++ b/pkg/reconciler/persistentvolumeclaim/metadata.go
@@ -209,14 +209,17 @@ func newLabelReconciler(cluster *apiv1.Cluster) metadataReconciler { //nolint: g
 				return false
 			}
 
-			// Check common labels
-			commonLabels := []string{
-				utils.KubernetesAppManagedByLabelName,
-				utils.KubernetesAppLabelName,
-				utils.KubernetesAppComponentLabelName,
+			// Check common labels have the expected operator-owned values.
+			// The values (not just the presence) must be verified so that PVCs
+			// created with an inherited managed-by value (e.g. "Helm") are
+			// detected as out-of-date and corrected.
+			expectedCommonLabels := map[string]string{
+				utils.KubernetesAppManagedByLabelName: utils.ManagerName,
+				utils.KubernetesAppLabelName:          utils.AppName,
+				utils.KubernetesAppComponentLabelName: utils.DatabaseComponentName,
 			}
-			for _, label := range commonLabels {
-				if _, found := pvc.Labels[label]; !found {
+			for label, expected := range expectedCommonLabels {
+				if pvc.Labels[label] != expected {
 					return false
 				}
 			}

--- a/pkg/utils/labels_annotations.go
+++ b/pkg/utils/labels_annotations.go
@@ -458,14 +458,33 @@ func InheritLabels(
 	}
 
 	for key, value := range fixedLabels {
+		// The managed-by label is owned by the operator (see below) and must
+		// never be inherited from the Cluster's metadata.
+		if key == KubernetesAppManagedByLabelName {
+			continue
+		}
 		object.Labels[key] = value
 	}
 
 	for key, value := range labels {
+		// The managed-by label is owned by the operator (see below) and must
+		// never be inherited from the Cluster's metadata.
+		if key == KubernetesAppManagedByLabelName {
+			continue
+		}
 		if controller.IsLabelInherited(key) {
 			object.Labels[key] = value
 		}
 	}
+
+	// The app.kubernetes.io/managed-by label must always identify the operator
+	// as the manager of the resources it creates. It is intentionally never
+	// inherited from the Cluster's own labels: when the Cluster is deployed
+	// through a Helm chart (or any other tool) this label is set to a different
+	// value (e.g. "Helm"), and inheriting it would break the label selectors
+	// that rely on it — most notably the one used to find the PVCs to include
+	// in a volume snapshot backup, which would silently match nothing.
+	object.Labels[KubernetesAppManagedByLabelName] = ManagerName
 }
 
 func getAnnotationAppArmor(spec *corev1.PodSpec, annotations map[string]string) map[string]string {

--- a/pkg/utils/labels_annotations_test.go
+++ b/pkg/utils/labels_annotations_test.go
@@ -101,13 +101,37 @@ var _ = Describe("Label management", func() {
 	It("must inherit labels to be inherited", func() {
 		pod := &corev1.Pod{}
 		InheritLabels(&pod.ObjectMeta, toBeMatchedMap, nil, config)
-		Expect(pod.Labels).To(Equal(map[string]string{"alpha": "1", "beta": "2"}))
+		Expect(pod.Labels).To(Equal(map[string]string{
+			"alpha":                         "1",
+			"beta":                          "2",
+			KubernetesAppManagedByLabelName: ManagerName,
+		}))
 	})
 	It("must inherit labels to be inherited with fixed ones passed", func() {
 		pod := &corev1.Pod{}
 		InheritLabels(&pod.ObjectMeta, toBeMatchedMap,
 			fixedMap, config)
-		Expect(pod.Labels).To(Equal(map[string]string{"alpha": "1", "beta": "2", "delta": "4", "epsilon": "5"}))
+		Expect(pod.Labels).To(Equal(map[string]string{
+			"alpha":                         "1",
+			"beta":                          "2",
+			"delta":                         "4",
+			"epsilon":                       "5",
+			KubernetesAppManagedByLabelName: ManagerName,
+		}))
+	})
+	It("must never inherit the managed-by label and always force the operator value", func() {
+		config := &fakeInhericanceController{
+			labels: []string{"alpha", KubernetesAppManagedByLabelName},
+		}
+		pod := &corev1.Pod{}
+		InheritLabels(&pod.ObjectMeta,
+			map[string]string{"alpha": "1", KubernetesAppManagedByLabelName: "Helm"},
+			map[string]string{KubernetesAppManagedByLabelName: "Helm"},
+			config)
+		Expect(pod.Labels).To(Equal(map[string]string{
+			"alpha":                         "1",
+			KubernetesAppManagedByLabelName: ManagerName,
+		}))
 	})
 })
 

--- a/pkg/utils/operations.go
+++ b/pkg/utils/operations.go
@@ -80,10 +80,20 @@ func IsLabelSubset(
 	mapToEvaluate := map[string]string{}
 
 	for key, value := range fixedInheritedLabels {
+		// The managed-by label is owned by the operator and is never inherited
+		// from the Cluster (see InheritLabels), so it must not be part of the
+		// subset check, otherwise resources would be perpetually flagged as
+		// out-of-date.
+		if key == KubernetesAppManagedByLabelName {
+			continue
+		}
 		mapToEvaluate[key] = value
 	}
 
 	for key, value := range clusterLabels {
+		if key == KubernetesAppManagedByLabelName {
+			continue
+		}
 		if controller.IsLabelInherited(key) {
 			mapToEvaluate[key] = value
 		}

--- a/pkg/utils/operations_test.go
+++ b/pkg/utils/operations_test.go
@@ -147,4 +147,17 @@ var _ = Describe("Testing Annotations and labels subset", func() {
 			map[string]string{department: "finance"}, ctrl)
 		Expect(isSubset).To(BeFalse())
 	})
+
+	It("should ignore the managed-by label, which is never inherited", func() {
+		ctrl := &fakeInhericanceController{
+			labels: []string{KubernetesAppManagedByLabelName},
+		}
+		// The object keeps the operator-owned managed-by value while the cluster
+		// carries a different one (e.g. set to "Helm"). Since managed-by is never
+		// inherited it must still be recognized as a subset, otherwise resources
+		// would be perpetually flagged as out-of-date.
+		obj := map[string]string{KubernetesAppManagedByLabelName: ManagerName}
+		clusterLabels := map[string]string{KubernetesAppManagedByLabelName: "Helm"}
+		Expect(IsLabelSubset(obj, clusterLabels, nil, ctrl)).To(BeTrue())
+	})
 })


### PR DESCRIPTION
https://github.com/cloudnative-pg/cloudnative-pg/pull/8087 introduced a change to set `app.kubernetes.io/managed-by: cloudnative-pg` label key and value on all objects managed by cnpg. However when `Cluster` object is being deployed via helm, it will automatically get `app.kubernetes.io/managed-by: Helm` label which will be propagated to child items (for example to PVCs). This breaks at least VolumeSnapshot logic as labelSelector used to fine PVC tries to use `app.kubernetes.io/managed-by=cloudnative-pg` and cannot find any PVC. This in turn leads to a deadlock during backup creation.

This PR is adding an override in controller logic to prevent propagation of `app.kubernetes.io/managed-by` from `Cluster` `.metadata.labels` to child items and instead override it with `app.kubernetes.io/managed-by: cloudnative-pg`.

I believe similar override is needed for `app.kubernetes.io/name` as it is also statically set to `postgresql`, however at least in my case, helm wasn't setting this label and thus everything worked as expected.


PR is spawned from  #9920 and fixes issue described there.

Fixes #9920