### PR TITLE
docs(security): document trust model and security boundaries

### DIFF
--- a/.wordlist-en-custom.txt
+++ b/.wordlist-en-custom.txt
@@ -332,6 +332,7 @@ PGSQL
 PKI
 PODNAME
 PPROF
+PSA
 PV
 PVCs
 PascalBourdier

--- a/docs/src/labels_annotations.md
+++ b/docs/src/labels_annotations.md
@@ -219,10 +219,19 @@ CloudNativePG manages the following predefined annotations:
 `cnpg.io/podPatch`
 :   Annotation can be applied on a `Cluster` resource.
 
-    When set to JSON-patch formatted patch, the patch will be applied on the instance Pods.
+    When set to a JSON-patch formatted patch, the patch will be applied to the
+    instance Pods. The patch can modify any field of the Pod specification,
+    including security-sensitive fields. The operator validates only that the
+    patch is syntactically correct and applicable.
+
+    As with all Cluster fields that affect Pod specifications, enforcement of
+    security constraints is delegated to the Kubernetes admission control chain.
+    See the
+    [Trust Model and Security Boundaries](security.md#trust-model-and-security-boundaries)
+    section for details.
 
     **⚠️ WARNING:** This feature may introduce discrepancies between the
-    operator’s expectations and Kubernetes behavior. Use with caution and only as a
+    operator's expectations and Kubernetes behavior. Use with caution and only as a
     last resort.
 
     **IMPORTANT**: adding or changing this annotation won't trigger a rolling deployment

--- a/docs/src/security.md
+++ b/docs/src/security.md
@@ -52,76 +52,6 @@ can be found below.
 
 ---
 
-## Trust Model and Security Boundaries
-
-CloudNativePG follows a clear separation of responsibilities between the
-operator and the Kubernetes platform for enforcing security policies.
-
-### Trusted Cluster Resource Writers
-
-Any user with create or update permissions on the `Cluster` custom resource is
-trusted to define the full specification of the PostgreSQL Pods that the
-operator manages. This includes security-sensitive fields such as
-`spec.securityContext`, `spec.podSecurityContext`, and
-`spec.serviceAccountName`. The operator applies these settings as instructed.
-When a Cluster writer does not override them, the operator applies a hardened
-default Pod and container security context (see
-[Pod and Container Security Contexts](#pod-and-container-security-contexts)).
-
-This is consistent with how all Kubernetes operators work: the operator acts as
-a privileged agent that translates high-level intent into low-level Kubernetes
-resources. Granting someone write access to a Cluster resource is equivalent
-to granting them control over the resulting Pods, Services, PVCs, and other
-managed resources.
-
-The same principle applies to [CNPG-I plugins](cnpg_i.md). A plugin hooks into
-the Pod lifecycle and can modify any field of the Pod specification before the
-Pod is created. Installing a plugin is therefore an explicit trust decision
-made by the cluster administrator, on par with granting write access to a
-Cluster resource.
-
-### Kubernetes Admission Control
-
-The operator creates Pods through the standard Kubernetes API, meaning every
-Pod goes through the full admission control chain configured on the cluster.
-This includes
-[Pod Security Admission](https://kubernetes.io/docs/concepts/security/pod-security-admission/)
-(PSA), the built-in Kubernetes mechanism that enforces
-[Pod Security Standards](https://kubernetes.io/docs/concepts/security/pod-security-standards/)
-at the namespace level, as well as any third-party policy engine in use. If a
-namespace enforces the PSA `restricted` or `baseline` profile, the Kubernetes
-API server rejects any Pod that violates the policy, including Pods created by
-the operator.
-
-### RBAC on Custom Resources
-
-Access to CloudNativePG custom resources is governed by standard Kubernetes
-RBAC. Since write access to a Cluster resource implies control over the
-resulting Pods, annotations like `cnpg.io/podPatch` (which applies a
-user-supplied patch to the managed Pods), `cnpg.io/validation`, and
-`cnpg.io/reconciliationLoop` are subject to the same RBAC rules as the
-Cluster resource itself.
-
-In particular, setting `cnpg.io/validation` to `disabled` bypasses the
-operator's own validating admission webhook for that Cluster, including the
-syntactic and applicability checks performed on `cnpg.io/podPatch`.
-CloudNativePG's webhook validation is therefore advisory: it can be turned off
-by the same actor who can write the Cluster, so it is not a security boundary.
-Kubernetes admission control still applies to the resulting Pods regardless of
-this annotation.
-
-### Namespace Isolation
-
-The operator enforces namespace boundaries for all managed resources. Instance
-Pods are always created in the same namespace as their parent Cluster, and that
-namespace is set explicitly and deterministically rather than inferred from any
-other relationship. As an additional safeguard, before creating a managed
-resource the operator verifies that it shares its owning Cluster's namespace and
-aborts with an error on any mismatch, so it cannot be induced to create or own
-resources outside the Cluster's namespace.
-
----
-
 ## Code
 
 CloudNativePG's source code undergoes systematic static analysis, including
@@ -277,9 +207,93 @@ container-level security:
 
 Security at the cluster level takes into account all Kubernetes components that
 form both the control plane and the nodes, as well as the applications that run in
-the cluster (PostgreSQL included).
+the cluster (PostgreSQL included). We start by defining the trust model and the
+security boundaries that frame the rest of this section.
+
+### Trust Model and Security Boundaries
+
+CloudNativePG follows a clear separation of responsibilities between the
+operator and the Kubernetes platform for enforcing security policies. The
+subsections below describe who is trusted to influence the PostgreSQL Pods,
+where the enforcement boundary actually lies, how the operator confines the
+resources it manages, and how access to all of this is governed by RBAC.
+
+#### Trusted Cluster Resource Writers
+
+Any user with create or update permissions on the `Cluster` custom resource is
+trusted to define the full specification of the PostgreSQL Pods that the
+operator manages. This includes security-sensitive fields such as
+`spec.securityContext`, `spec.podSecurityContext`, and
+`spec.serviceAccountName`. The operator applies these settings as instructed.
+When a Cluster writer does not override them, the operator applies a hardened
+default Pod and container security context (see
+[Pod and Container Security Contexts](#pod-and-container-security-contexts)).
+
+This is consistent with how all Kubernetes operators work: the operator acts as
+a privileged agent that translates high-level intent into low-level Kubernetes
+resources. Granting someone write access to a Cluster resource is equivalent
+to granting them control over the resulting Pods, Services, PVCs, and other
+managed resources.
+
+The same principle applies to [CNPG-I plugins](cnpg_i.md). A plugin hooks into
+the Pod lifecycle and can modify any field of the Pod specification before the
+Pod is created. Installing a plugin is therefore an explicit trust decision
+made by the cluster administrator, on par with granting write access to a
+Cluster resource.
+
+#### Kubernetes Admission Control
+
+The operator creates Pods through the standard Kubernetes API, meaning every
+Pod goes through the full admission control chain configured on the cluster.
+This includes
+[Pod Security Admission](https://kubernetes.io/docs/concepts/security/pod-security-admission/)
+(PSA), the built-in Kubernetes mechanism that enforces
+[Pod Security Standards](https://kubernetes.io/docs/concepts/security/pod-security-standards/)
+at the namespace level, as well as any third-party policy engine in use. If a
+namespace enforces the PSA `restricted` or `baseline` profile, the Kubernetes
+API server rejects any Pod that violates the policy, including Pods created by
+the operator.
+
+Because the trusted Cluster writers described above can set any Pod field, this
+admission control chain — not the operator — is the boundary that enforces Pod
+security policies in your environment.
+
+#### Namespace Isolation
+
+The operator confines all managed resources to the namespace of their parent
+Cluster. Instance Pods are always created in the same namespace as their
+Cluster, set explicitly and deterministically rather than inferred from any
+other relationship. Because Kubernetes owner references cannot cross namespace
+boundaries, the operator cannot be induced to create or own resources outside
+the Cluster's namespace.
+
+#### RBAC on Custom Resources
+
+Access to CloudNativePG custom resources is governed by standard Kubernetes
+RBAC. Since write access to a Cluster resource implies control over the
+resulting Pods, annotations like `cnpg.io/podPatch` (which applies a
+user-supplied patch to the managed Pods), `cnpg.io/validation`, and
+`cnpg.io/reconciliationLoop` are subject to the same RBAC rules as the
+Cluster resource itself.
+
+In particular, setting `cnpg.io/validation` to `disabled` bypasses the
+operator's own validating admission webhook for that Cluster, including the
+syntactic and applicability checks performed on `cnpg.io/podPatch`.
+CloudNativePG's webhook validation is therefore advisory: it can be turned off
+by the same actor who can write the Cluster, so it is not a security boundary.
+Kubernetes admission control still applies to the resulting Pods regardless of
+this annotation.
+
+The RBAC discussed here governs access to CloudNativePG's own custom resources.
+The next section covers the complementary side: the RBAC that the operator
+itself relies on to manage Kubernetes resources on your behalf.
 
 ### Role Based Access Control (RBAC)
+
+This section covers the operator's *own* RBAC — the service account and roles it
+uses to manage Kubernetes resources on your behalf — as opposed to the user
+access to custom resources discussed in
+[RBAC on Custom Resources](#rbac-on-custom-resources) above.
 
 The operator interacts with the Kubernetes API server using a dedicated service
 account named `cnpg-manager`. This service account is typically installed in
@@ -683,7 +697,10 @@ spec:
     These fields are particularly useful when working with the
     [Pod Security Standards](https://kubernetes.io/docs/concepts/security/pod-security-standards/)
     `restricted` profile, which has strict requirements for pod and container
-    security contexts.
+    security contexts. As described in
+    [Kubernetes Admission Control](#kubernetes-admission-control), it is this
+    admission chain — not the operator — that enforces such profiles on the
+    resulting Pods.
 :::
 
 #### Security Context Constraints

--- a/docs/src/security.md
+++ b/docs/src/security.md
@@ -255,7 +255,7 @@ API server rejects any Pod that violates the policy, including Pods created by
 the operator.
 
 Because the trusted Cluster writers described above can set any Pod field, this
-admission control chain — not the operator — is the boundary that enforces Pod
+admission control chain (not the operator) is the boundary that enforces Pod
 security policies in your environment.
 
 #### Namespace Isolation
@@ -263,9 +263,9 @@ security policies in your environment.
 The operator confines all managed resources to the namespace of their parent
 Cluster. Instance Pods are always created in the same namespace as their
 Cluster, set explicitly and deterministically rather than inferred from any
-other relationship. Because Kubernetes owner references cannot cross namespace
-boundaries, the operator cannot be induced to create or own resources outside
-the Cluster's namespace.
+other relationship. Because Kubernetes owner references are confined to a
+single namespace, the operator also cannot establish ownership of resources in
+any other namespace.
 
 #### RBAC on Custom Resources
 
@@ -290,8 +290,8 @@ itself relies on to manage Kubernetes resources on your behalf.
 
 ### Role Based Access Control (RBAC)
 
-This section covers the operator's *own* RBAC — the service account and roles it
-uses to manage Kubernetes resources on your behalf — as opposed to the user
+This section covers the operator's *own* RBAC (the service account and roles it
+uses to manage Kubernetes resources on your behalf), as opposed to the user
 access to custom resources discussed in
 [RBAC on Custom Resources](#rbac-on-custom-resources) above.
 
@@ -699,7 +699,7 @@ spec:
     `restricted` profile, which has strict requirements for pod and container
     security contexts. As described in
     [Kubernetes Admission Control](#kubernetes-admission-control), it is this
-    admission chain — not the operator — that enforces such profiles on the
+    admission chain (not the operator) that enforces such profiles on the
     resulting Pods.
 :::
 

--- a/docs/src/security.md
+++ b/docs/src/security.md
@@ -52,6 +52,76 @@ can be found below.
 
 ---
 
+## Trust Model and Security Boundaries
+
+CloudNativePG follows a clear separation of responsibilities between the
+operator and the Kubernetes platform for enforcing security policies.
+
+### Trusted Cluster Resource Writers
+
+Any user with create or update permissions on the `Cluster` custom resource is
+trusted to define the full specification of the PostgreSQL Pods that the
+operator manages. This includes security-sensitive fields such as
+`spec.securityContext`, `spec.podSecurityContext`, and
+`spec.serviceAccountName`. The operator applies these settings as instructed.
+When a Cluster writer does not override them, the operator applies a hardened
+default Pod and container security context (see
+[Pod and Container Security Contexts](#pod-and-container-security-contexts)).
+
+This is consistent with how all Kubernetes operators work: the operator acts as
+a privileged agent that translates high-level intent into low-level Kubernetes
+resources. Granting someone write access to a Cluster resource is equivalent
+to granting them control over the resulting Pods, Services, PVCs, and other
+managed resources.
+
+The same principle applies to [CNPG-I plugins](cnpg_i.md). A plugin hooks into
+the Pod lifecycle and can modify any field of the Pod specification before the
+Pod is created. Installing a plugin is therefore an explicit trust decision
+made by the cluster administrator, on par with granting write access to a
+Cluster resource.
+
+### Kubernetes Admission Control
+
+The operator creates Pods through the standard Kubernetes API, meaning every
+Pod goes through the full admission control chain configured on the cluster.
+This includes
+[Pod Security Admission](https://kubernetes.io/docs/concepts/security/pod-security-admission/)
+(PSA), the built-in Kubernetes mechanism that enforces
+[Pod Security Standards](https://kubernetes.io/docs/concepts/security/pod-security-standards/)
+at the namespace level, as well as any third-party policy engine in use. If a
+namespace enforces the PSA `restricted` or `baseline` profile, the Kubernetes
+API server rejects any Pod that violates the policy, including Pods created by
+the operator.
+
+### RBAC on Custom Resources
+
+Access to CloudNativePG custom resources is governed by standard Kubernetes
+RBAC. Since write access to a Cluster resource implies control over the
+resulting Pods, annotations like `cnpg.io/podPatch` (which applies a
+user-supplied patch to the managed Pods), `cnpg.io/validation`, and
+`cnpg.io/reconciliationLoop` are subject to the same RBAC rules as the
+Cluster resource itself.
+
+In particular, setting `cnpg.io/validation` to `disabled` bypasses the
+operator's own validating admission webhook for that Cluster, including the
+syntactic and applicability checks performed on `cnpg.io/podPatch`.
+CloudNativePG's webhook validation is therefore advisory: it can be turned off
+by the same actor who can write the Cluster, so it is not a security boundary.
+Kubernetes admission control still applies to the resulting Pods regardless of
+this annotation.
+
+### Namespace Isolation
+
+The operator enforces namespace boundaries for all managed resources. Instance
+Pods are always created in the same namespace as their parent Cluster, and that
+namespace is set explicitly and deterministically rather than inferred from any
+other relationship. As an additional safeguard, before creating a managed
+resource the operator verifies that it shares its owning Cluster's namespace and
+aborts with an error on any mismatch, so it cannot be induced to create or own
+resources outside the Cluster's namespace.
+
+---
+
 ## Code
 
 CloudNativePG's source code undergoes systematic static analysis, including


### PR DESCRIPTION
Add a "Trust Model and Security Boundaries" section to the security documentation, making explicit that Cluster resource writers are trusted to define Pod specifications, that Kubernetes admission control (PSA, Kyverno, Gatekeeper) is the enforcement boundary for Pod security policies, and that the operator confines managed Pods to the parent Cluster's namespace.

Also improve the cnpg.io/podPatch annotation documentation to clarify that it can modify any Pod field and that security enforcement is delegated to Kubernetes admission control.
