### PR TITLE
ci: run Snyk scans only when SNYK_TOKEN is configured

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -451,6 +451,8 @@ jobs:
       catalog_img: ${{ env.CATALOG_IMG }}
       push: ${{ env.PUSH }}
       images_matrix: ${{ steps.images_matrix.outputs.images_matrix }}
+    env:
+      SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -637,11 +639,9 @@ jobs:
 
       - name: Run Snyk to check Docker image for vulnerabilities
         uses: snyk/actions/docker@8e119fbb6c251787721d34ba683ed48eba792766 # master
-        if: |
-          !github.event.repository.fork &&
-          !github.event.pull_request.head.repo.fork
-        env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        # Only run when a Snyk token is configured. Forks and downstream
+        # repositories without the secret skip this step automatically.
+        if: env.SNYK_TOKEN != ''
         with:
           image: ${{ env.CONTROLLER_IMG }}
           args: --severity-threshold=high --file=Dockerfile --username=${{ env.REGISTRY_USER }} --password=${{ env.REGISTRY_PASSWORD }}

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -11,8 +11,23 @@ on:
 permissions: read-all
 
 jobs:
+  # Expose whether a Snyk token is configured so the security job can gate
+  # on it. The secrets context is not available in a job-level 'if', so it
+  # is checked here and surfaced as a job output.
+  check-secret:
+    name: Check for Snyk token
+    runs-on: ubuntu-24.04
+    outputs:
+      has_token: ${{ steps.check.outputs.has_token }}
+    steps:
+      - id: check
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        run: echo "has_token=${{ env.SNYK_TOKEN != '' }}" >> "$GITHUB_OUTPUT"
+
   security:
-    if: ${{ github.repository_owner == 'cloudnative-pg' }}
+    needs: check-secret
+    if: ${{ needs.check-secret.outputs.has_token == 'true' }}
     name: Security scan
     runs-on: ubuntu-24.04
     permissions:


### PR DESCRIPTION
Gate both Snyk integrations on the presence of the SNYK_TOKEN secret. The Docker image scan in continuous-integration.yml previously keyed off the repository fork flag, and the Snyk scanning workflow keyed off the repository owner. Repositories that do not configure the secret now skip the scans automatically.