### PR TITLE
fix(walrestore): allow history files when cluster timeline is unset

### DIFF
--- a/internal/cmd/manager/walrestore/cmd.go
+++ b/internal/cmd/manager/walrestore/cmd.go
@@ -466,6 +466,13 @@ func validateTimelineHistoryFile(ctx context.Context, walName string, cluster *a
 	}
 
 	clusterTimeline := cluster.Status.TimelineID
+
+	if clusterTimeline == 0 {
+		contextLog.Trace("Allowing timeline history file: cluster timeline not yet established",
+			"walName", walName,
+			"fileTimeline", fileTimeline)
+		return nil
+	}
 	if fileTimeline > clusterTimeline {
 		contextLog.Warning("Refusing to restore future timeline history file",
 			"walName", walName,

--- a/internal/cmd/manager/walrestore/cmd.go
+++ b/internal/cmd/manager/walrestore/cmd.go
@@ -467,12 +467,18 @@ func validateTimelineHistoryFile(ctx context.Context, walName string, cluster *a
 
 	clusterTimeline := cluster.Status.TimelineID
 
+	// clusterTimeline == 0 means no primary has promoted yet and TimelineID has
+	// never been written to the cluster status. This can also happen when the
+	// local cache is stale during bootstrap recovery. The split-brain scenario
+	// this guard protects against requires an active primary, so allowing all
+	// history files here is safe.
 	if clusterTimeline == 0 {
 		contextLog.Trace("Allowing timeline history file: cluster timeline not yet established",
 			"walName", walName,
 			"fileTimeline", fileTimeline)
 		return nil
 	}
+
 	if fileTimeline > clusterTimeline {
 		contextLog.Warning("Refusing to restore future timeline history file",
 			"walName", walName,

--- a/internal/cmd/manager/walrestore/cmd.go
+++ b/internal/cmd/manager/walrestore/cmd.go
@@ -468,10 +468,10 @@ func validateTimelineHistoryFile(ctx context.Context, walName string, cluster *a
 	clusterTimeline := cluster.Status.TimelineID
 
 	// clusterTimeline == 0 means no primary has promoted yet and TimelineID has
-	// never been written to the cluster status. This can also happen when the
-	// local cache is stale during bootstrap recovery. The split-brain scenario
-	// this guard protects against requires an active primary, so allowing all
-	// history files here is safe.
+	// never been written to the cluster status, as happens during bootstrap
+	// recovery from an external archive. The split-brain scenario this guard
+	// protects against requires an active primary, which cannot exist while
+	// TimelineID is unset, so allowing all history files here is safe.
 	if clusterTimeline == 0 {
 		contextLog.Trace("Allowing timeline history file: cluster timeline not yet established",
 			"walName", walName,

--- a/internal/cmd/manager/walrestore/cmd_test.go
+++ b/internal/cmd/manager/walrestore/cmd_test.go
@@ -227,7 +227,7 @@ var _ = Describe("validateTimelineHistoryFile", func() {
 			Expect(err).To(Equal(barmanRestorer.ErrWALNotFound))
 		})
 
-	It("should allow any history file when cluster timeline is not yet established (bootstrap recovery)", func(ctx SpecContext) {
+	It("should allow any history file when cluster timeline is not yet established", func(ctx SpecContext) {
 		cluster := &apiv1.Cluster{
 			Status: apiv1.ClusterStatus{
 				CurrentPrimary: "primary-pod",

--- a/internal/cmd/manager/walrestore/cmd_test.go
+++ b/internal/cmd/manager/walrestore/cmd_test.go
@@ -213,7 +213,21 @@ var _ = Describe("validateTimelineHistoryFile", func() {
 		Expect(err).To(Equal(barmanRestorer.ErrWALNotFound))
 	})
 
-	It("should reject any timeline when cluster timeline is not yet set", func(ctx SpecContext) {
+	It("should reject a future timeline history file for an established replica",
+		func(ctx SpecContext) {
+			cluster := &apiv1.Cluster{
+				Status: apiv1.ClusterStatus{
+					CurrentPrimary: "primary-pod",
+					TargetPrimary:  "primary-pod",
+					TimelineID:     20,
+				},
+			}
+
+			err := validateTimelineHistoryFile(ctx, "00000015.history", cluster, "replica-pod")
+			Expect(err).To(Equal(barmanRestorer.ErrWALNotFound))
+		})
+
+	It("should allow any history file when cluster timeline is not yet established (bootstrap recovery)", func(ctx SpecContext) {
 		cluster := &apiv1.Cluster{
 			Status: apiv1.ClusterStatus{
 				CurrentPrimary: "primary-pod",
@@ -221,7 +235,18 @@ var _ = Describe("validateTimelineHistoryFile", func() {
 			},
 		}
 
-		err := validateTimelineHistoryFile(ctx, "00000001.history", cluster, "replica-pod")
-		Expect(err).To(Equal(barmanRestorer.ErrWALNotFound))
+		err := validateTimelineHistoryFile(ctx, "00000014.history", cluster, "replica-pod")
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("should allow any history file when no primary has been elected yet (empty cluster status)", func(ctx SpecContext) {
+		cluster := &apiv1.Cluster{
+			Status: apiv1.ClusterStatus{
+				TimelineID: 0,
+			},
+		}
+
+		err := validateTimelineHistoryFile(ctx, "00000014.history", cluster, "restore-pod")
+		Expect(err).ToNot(HaveOccurred())
 	})
 })

--- a/tests/e2e/backup_restore_objectstore_test.go
+++ b/tests/e2e/backup_restore_objectstore_test.go
@@ -271,6 +271,11 @@ var _ = Describe("Object storage - Backup and restore", Label(tests.LabelBackupR
 			Expect(err).ToNot(HaveOccurred())
 			metricsasserts.AssertMetricsData(env, testTimeouts, namespace, targetDBOne, targetDBTwo, targetDBSecret, cluster)
 
+			By("deleting the first restored cluster", func() {
+				err = resources.DeleteResourcesFromFile(env, namespace, clusterRestoreSampleFile)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
 			previous := 0
 			latestGZ := filepath.Join("*", clusterName, "*", "*.history.gz")
 			By(fmt.Sprintf("checking the previous number of .history files in the object store, history file name is %v",
@@ -279,12 +284,53 @@ var _ = Describe("Object storage - Backup and restore", Label(tests.LabelBackupR
 				Expect(err).ToNot(HaveOccurred())
 			})
 
-			clusterasserts.AssertSwitchover(env, testTimeouts, namespace, clusterName)
+			By("performing a switchover", func() {
+				clusterasserts.AssertSwitchover(env, testTimeouts, namespace, clusterName)
+			})
 
 			By("checking the number of .history after switchover", func() {
 				Eventually(func() (int, error) {
 					return objectstore.CountFiles(objectStoreEnv, latestGZ)
 				}, 60).Should(BeNumerically(">", previous))
+			})
+
+			const postSwitchoverTableName = "to_restore_post_switchover"
+
+			By("inserting data into source cluster after switchover", func() {
+				postSwitchoverTableLocator := pgasserts.TableLocator{
+					Namespace:    namespace,
+					ClusterName:  clusterName,
+					DatabaseName: postgres.AppDBName,
+					TableName:    postSwitchoverTableName,
+				}
+				pgasserts.AssertCreateTestData(env, postSwitchoverTableLocator)
+				objectstoreasserts.AssertArchiveWalOnObjectStore(
+					env, testTimeouts, objectStoreEnv, namespace, clusterName, clusterName)
+			})
+
+			By("restoring cluster again and verifying data written after switchover is present", func() {
+				resources.CreateResourceFromFile(env, namespace, clusterRestoreSampleFile)
+				restoreClusterName, err := yaml.GetResourceNameFromYAML(env.Scheme, clusterRestoreSampleFile)
+				Expect(err).ToNot(HaveOccurred())
+				clusterasserts.AssertClusterIsReady(
+					env, namespace, restoreClusterName, testTimeouts[timeouts.ClusterIsReadySlow],
+				)
+
+				origTableLocator := pgasserts.TableLocator{
+					Namespace:    namespace,
+					ClusterName:  restoreClusterName,
+					DatabaseName: postgres.AppDBName,
+					TableName:    tableName,
+				}
+				pgasserts.AssertDataExpectedCount(env, origTableLocator, 2)
+
+				postSwitchoverTableLocator := pgasserts.TableLocator{
+					Namespace:    namespace,
+					ClusterName:  restoreClusterName,
+					DatabaseName: postgres.AppDBName,
+					TableName:    postSwitchoverTableName,
+				}
+				pgasserts.AssertDataExpectedCount(env, postSwitchoverTableLocator, 2)
 			})
 
 			By("deleting the restored cluster", func() {

--- a/tests/e2e/backup_restore_objectstore_test.go
+++ b/tests/e2e/backup_restore_objectstore_test.go
@@ -23,10 +23,12 @@ import (
 	"fmt"
 	"path/filepath"
 
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/util/retry"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 	"github.com/cloudnative-pg/cloudnative-pg/tests"
 	backupasserts "github.com/cloudnative-pg/cloudnative-pg/tests/internal/asserts/backup"
 	clusterasserts "github.com/cloudnative-pg/cloudnative-pg/tests/internal/asserts/cluster"
@@ -43,6 +45,7 @@ import (
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/pods"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/postgres"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/secrets"
+	storageutils "github.com/cloudnative-pg/cloudnative-pg/tests/utils/storage"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/timeouts"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/yaml"
 
@@ -271,9 +274,29 @@ var _ = Describe("Object storage - Backup and restore", Label(tests.LabelBackupR
 			Expect(err).ToNot(HaveOccurred())
 			metricsasserts.AssertMetricsData(env, testTimeouts, namespace, targetDBOne, targetDBTwo, targetDBSecret, cluster)
 
-			By("deleting the first restored cluster", func() {
+			By("deleting the first restored cluster and waiting for its resources to be removed", func() {
+				firstRestoreClusterName, err := yaml.GetResourceNameFromYAML(env.Scheme, clusterRestoreSampleFile)
+				Expect(err).ToNot(HaveOccurred())
+
 				err = resources.DeleteResourcesFromFile(env, namespace, clusterRestoreSampleFile)
 				Expect(err).ToNot(HaveOccurred())
+
+				// The restored cluster is recreated later with the same name, so wait for
+				// the cluster and its PVCs to be fully removed first. Otherwise the
+				// recreated cluster could adopt stale PVCs instead of performing a fresh
+				// restore from the object store, masking or breaking the assertions below.
+				Eventually(func() bool {
+					_, err := clusterutils.Get(env.Ctx, env.Client, namespace, firstRestoreClusterName)
+					return apierrs.IsNotFound(err)
+				}, testTimeouts[timeouts.ClusterIsReady]).Should(BeTrue())
+
+				Eventually(func(g Gomega) {
+					pvcList, err := storageutils.GetPVCList(env.Ctx, env.Client, namespace)
+					g.Expect(err).ToNot(HaveOccurred())
+					for _, pvc := range pvcList.Items {
+						g.Expect(pvc.Labels[utils.ClusterLabelName]).ToNot(Equal(firstRestoreClusterName))
+					}
+				}, testTimeouts[timeouts.ClusterIsReady]).Should(Succeed())
 			})
 
 			previous := 0


### PR DESCRIPTION
During bootstrap recovery from an external archive, the recovering pod is not yet `CurrentPrimary` or `TargetPrimary` and `cluster.Status.TimelineID` is 0, because no primary has promoted and reported its timeline. The existing guard (`fileTimeline > clusterTimeline`) therefore blocks every `.history` file, causing PostgreSQL to stop recovery at the basebackup's timeline and silently drop transactions on newer timelines.

Add an early-return exemption when `clusterTimeline == 0`: the split-brain scenario the guard protects against requires an active primary, which cannot exist when `TimelineID` is unset. Allowing history files in this state lets PostgreSQL walk forward across all timeline switches during bootstrap recovery.

This PR also adds an e2e test that restores across a post-switchover timeline and verifies data written on the newer timeline is recovered.

Closes #10442
Closes #10817

Assisted-by: Claude Opus 4.8