### PR TITLE
feat: Add condition for tracking recovery failures due to WAL replay issues

### DIFF
--- a/.wordlist-en-custom.txt
+++ b/.wordlist-en-custom.txt
@@ -426,6 +426,7 @@ RPO
 RTO
 RUNTIME
 ReadWriteOnce
+RecoveryTargetReached
 RedHat
 RelabelConfig
 ReplicaClusterConfiguration

--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -1112,6 +1112,9 @@ const (
 	// ConditionConsistentSystemID is true when the all the instances of the
 	// cluster report the same System ID.
 	ConditionConsistentSystemID ClusterConditionType = "ConsistentSystemID"
+	// ConditionRecoveryTargetReached represents whether a recovery bootstrap
+	// has reached its configured recovery target.
+	ConditionRecoveryTargetReached ClusterConditionType = "RecoveryTargetReached"
 )
 
 // ConditionStatus defines conditions of resources
@@ -1151,6 +1154,14 @@ const (
 	// ConditionReasonContinuousArchivingFailing means that the condition has changed because
 	// the WAL archiving is not working correctly
 	ConditionReasonContinuousArchivingFailing ConditionReason = "ContinuousArchivingFailing"
+
+	// ConditionReasonRecoveryEndedBeforeReachingTarget means that recovery ended before
+	// reaching the configured target because no WAL at or after it was available
+	ConditionReasonRecoveryEndedBeforeReachingTarget ConditionReason = "RecoveryEndedBeforeReachingTarget"
+
+	// ConditionReasonRecoveryTargetReached means that recovery reached the
+	// configured target and the instance was promoted
+	ConditionReasonRecoveryTargetReached ConditionReason = "RecoveryTargetReached"
 
 	// ClusterReady means that the condition changed because the cluster is ready and working properly
 	ClusterReady ConditionReason = "ClusterIsReady"

--- a/docs/src/troubleshooting.md
+++ b/docs/src/troubleshooting.md
@@ -494,6 +494,7 @@ event to occur instead of relying on the overall cluster health state. Available
 - LastBackupSucceeded
 - ContinuousArchiving
 - Ready
+- RecoveryTargetReached
 
 `LastBackupSucceeded` is reporting the status of the latest backup. If set to `True` the
 last backup has been taken correctly, it is set to `False` otherwise.
@@ -504,6 +505,12 @@ last WAL archival process has been terminated correctly, it is set to `False` ot
 `Ready` is `True` when the cluster has the number of instances specified by the user
 and the primary instance is ready. This condition can be used in scripts to wait for
 the cluster to be created.
+
+`RecoveryTargetReached` is `True` when a cluster that has been point in time recovered to
+a specific target has successfully reached the target. This can be `False` when a WAL has
+not (yet) been archived that covers the recovery target, or if WAL replaying fails. This
+condition is _only_ set for clusters that have been restored with a specific PITR recovery
+target.
 
 ### How to wait for a particular condition
 

--- a/pkg/management/postgres/restore.go
+++ b/pkg/management/postgres/restore.go
@@ -60,6 +60,7 @@ import (
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/external"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres/constants"
 	postgresSpec "github.com/cloudnative-pg/cloudnative-pg/pkg/postgres"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/resources/status"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/system"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 )
@@ -220,7 +221,81 @@ func (info InitInfo) concludeRestore(
 		return err
 	}
 
-	return info.ConfigureInstanceAfterRestore(ctx, cluster, envs)
+	err := info.ConfigureInstanceAfterRestore(ctx, cluster, envs)
+	info.reportRecoveryTargetOutcome(ctx, cli, cluster, err)
+	return err
+}
+
+// hasRecoveryTarget reports whether the cluster bootstraps to an explicit
+// recovery target.
+func hasRecoveryTarget(cluster *apiv1.Cluster) bool {
+	return cluster != nil &&
+		cluster.Spec.Bootstrap != nil &&
+		cluster.Spec.Bootstrap.Recovery != nil &&
+		cluster.Spec.Bootstrap.Recovery.RecoveryTarget != nil
+}
+
+// recoveryEndedInRecoveryState reports whether a pg_controldata cluster state
+// indicates recovery stopped without promoting. A recovery that reached its
+// target promotes (leaving "shut down" once stopped); one that ran out of WAL
+// first is left in a recovery state.
+func recoveryEndedInRecoveryState(state string) bool {
+	switch state {
+	case "shut down in recovery", "in archive recovery":
+		return true
+	default:
+		return false
+	}
+}
+
+// reportRecoveryTargetOutcome maintains the RecoveryTargetReached condition for a
+// recovery to an explicit target: True once the target is reached (the instance
+// promoted), False when recovery ran out of WAL first (for example targetTime is
+// beyond the last archived WAL). The failure is confirmed from the pg_controldata
+// cluster state, not the PostgreSQL log, and only when the data directory is still
+// in a recovery state, so a failure after a successful promotion is not mislabeled.
+// It is best-effort: any error here is logged and the recovery error left to propagate.
+func (info InitInfo) reportRecoveryTargetOutcome(
+	ctx context.Context,
+	cli client.Client,
+	cluster *apiv1.Cluster,
+	recoveryErr error,
+) {
+	contextLogger := log.FromContext(ctx)
+
+	if !hasRecoveryTarget(cluster) {
+		return
+	}
+
+	condition := metav1.Condition{
+		Type:    string(apiv1.ConditionRecoveryTargetReached),
+		Status:  metav1.ConditionTrue,
+		Reason:  string(apiv1.ConditionReasonRecoveryTargetReached),
+		Message: "Recovery reached the configured target",
+	}
+
+	if recoveryErr != nil {
+		out, err := info.GetInstance(cluster).GetPgControldata()
+		if err != nil {
+			contextLogger.Error(err, "while reading pg_controldata to classify a recovery failure")
+			return
+		}
+
+		state := utils.ParsePgControldataOutput(out).GetDatabaseClusterState()
+		if !recoveryEndedInRecoveryState(state) {
+			return
+		}
+
+		condition.Status = metav1.ConditionFalse
+		condition.Reason = string(apiv1.ConditionReasonRecoveryEndedBeforeReachingTarget)
+		condition.Message = fmt.Sprintf(
+			"PostgreSQL exited while still in recovery (pg_controldata state %q), so the configured recovery target "+
+				"was not reached. Recovery error: %v", state, recoveryErr)
+	}
+
+	if patchErr := status.PatchConditionsWithOptimisticLock(ctx, cli, cluster, condition); patchErr != nil {
+		contextLogger.Error(patchErr, "while reporting the recovery target outcome")
+	}
 }
 
 // createEnvAndConfigForSnapshotRestore creates env and config for snapshot restore

--- a/pkg/management/postgres/restore_test.go
+++ b/pkg/management/postgres/restore_test.go
@@ -275,3 +275,36 @@ var _ = Describe("getRestoreWalConfig", func() {
 				`''s3://bucket"; rm -rf /; "''`))
 		})
 })
+
+var _ = Describe("recovery target failure classification", func() {
+	DescribeTable("recoveryEndedInRecoveryState classifies the pg_controldata cluster state",
+		func(state string, expected bool) {
+			Expect(recoveryEndedInRecoveryState(state)).To(Equal(expected))
+		},
+		// A clone that never promoted is left in a recovery state.
+		Entry("shut down in recovery -> target not reached", "shut down in recovery", true),
+		Entry("in archive recovery -> target not reached", "in archive recovery", true),
+		// A clone that reached its target promotes and is then cleanly stopped.
+		Entry("shut down -> promoted then stopped", "shut down", false),
+		Entry("in production -> promoted and running", "in production", false),
+		// Transient/unknown states are inconclusive.
+		Entry("starting up -> inconclusive", "starting up", false),
+		Entry("empty -> inconclusive", "", false),
+	)
+
+	DescribeTable("hasRecoveryTarget detects an explicit recovery target",
+		func(cluster *apiv1.Cluster, expected bool) {
+			Expect(hasRecoveryTarget(cluster)).To(Equal(expected))
+		},
+		Entry("nil cluster", (*apiv1.Cluster)(nil), false),
+		Entry("no bootstrap", &apiv1.Cluster{}, false),
+		Entry("recovery without target", &apiv1.Cluster{Spec: apiv1.ClusterSpec{
+			Bootstrap: &apiv1.BootstrapConfiguration{Recovery: &apiv1.BootstrapRecovery{}},
+		}}, false),
+		Entry("recovery with target", &apiv1.Cluster{Spec: apiv1.ClusterSpec{
+			Bootstrap: &apiv1.BootstrapConfiguration{Recovery: &apiv1.BootstrapRecovery{
+				RecoveryTarget: &apiv1.RecoveryTarget{TargetTime: "2026-06-01 00:00:00"},
+			}},
+		}}, true),
+	)
+})


### PR DESCRIPTION
Restoring clusters with PITR to a specific replay target can fail under several conditions:
* No WAL archive is available yet that covers the target (for example, a date in the future, or the source cluster for the backup has been idle for less than the `archive_timeout` time)
* The object store is missing WAL archives
* WAL archives are corrupted

This detects the failure mode by reading `pg_controldata`, and checking to see if the cluster was in recovery when the recovery job fails. If it is, then a new `RecoveryTargetReached` status condition is set on the cluster, explaining that the target wasn't reached.

This should make the failures described in https://github.com/cloudnative-pg/cloudnative-pg/issues/5177 much more obvious to operators. Personally I'm looking to use this to detect the first case, which can happen when "cloning" infrequently-changed clusters (backup followed by an immediate restore).

See #5177

Assisted-by: Claude Opus 4.8