### PR TITLE
chore(deps): update dependency go to v1.26.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cloudnative-pg/cloudnative-pg
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2


### PR DESCRIPTION
## Summary

Bumps the Go toolchain from `1.26.3` to `1.26.4` to resolve three Go standard library advisories flagged by `govulncheck`:

- **GO-2026-5039** — unescaped arbitrary inputs in errors (`net/textproto`)
- **GO-2026-5038** — quadratic complexity in `WordDecoder.DecodeHeader` (`mime`)
- **GO-2026-5037** — inefficient candidate hostname parsing (`crypto/x509`)

All three are fixed in `go1.26.4`. CI keys off `go-version-file: go.mod`, so the single `go.mod` change drives the whole pipeline.

## Verification

- `make run-govulncheck` → `No vulnerabilities found.`
- `go mod tidy` → no changes
- `golangci-lint run` (v2.12.2, the CI-pinned version) → `0 issues`