### PR TITLE
ci(docs): let Renovate manage the `curl` image in monitoring docs

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -12,7 +12,9 @@
     'main',
   ],
   ignorePaths: [
-    'docs/**',
+    // Keep the example manifests pinned, but allow custom managers below to
+    // update specific tool images referenced elsewhere in the docs.
+    'docs/src/samples/**',
     'releases/**',
     'contribute/**',
     'licenses/**',
@@ -107,6 +109,17 @@
       ],
       datasourceTemplate: 'docker',
       versioningTemplate: 'semver',
+    },
+    {
+      customType: 'regex',
+      managerFilePatterns: [
+        '/^docs\\/src\\/monitoring\\.md$/',
+      ],
+      matchStrings: [
+        'image: (?<depName>curlimages/curl):(?<currentValue>\\S+)',
+      ],
+      datasourceTemplate: 'docker',
+      versioningTemplate: 'docker',
     },
     {
       customType: 'regex',
@@ -281,6 +294,15 @@
         'getwoke{/,}**',
         'jonasbn/github-action-spellcheck',
         'registry',
+      ],
+      pinDigests: false,
+      separateMajorMinor: false,
+    },
+    {
+      // The curl image is only used in a documentation example, so keep it as a
+      // readable tag without a pinned digest.
+      matchPackageNames: [
+        'curlimages/curl',
       ],
       pinDigests: false,
       separateMajorMinor: false,

--- a/docs/src/monitoring.md
+++ b/docs/src/monitoring.md
@@ -1004,7 +1004,7 @@ metadata:
 spec:
   containers:
   - name: curl
-    image: curlimages/curl:8.17.0
+    image: curlimages/curl:8.20.0
     command: ['sleep', '3600']
 EOF
 ```


### PR DESCRIPTION
Add a custom Renovate manager for the curlimages/curl image referenced in the monitoring documentation example so its version is bumped automatically instead of by hand. Narrow the docs ignore path to the sample manifests so the file is scannable, and disable digest pinning to keep the example tag readable.

Assisted-by: Claude