### PR TITLE
refactor: extract a shared GRANT/REVOKE primitive for object privileges

### DIFF
--- a/internal/management/controller/database_controller_sql.go
+++ b/internal/management/controller/database_controller_sql.go
@@ -534,10 +534,6 @@ func applyObjectPrivilege(
 ) error {
 	contextLogger := log.FromContext(ctx)
 
-	if len(grantees) == 0 {
-		return nil
-	}
-
 	for _, grantee := range grantees {
 		sanitizedObject := pgx.Identifier{objectName}.Sanitize()
 		sanitizedGrantee := sanitizeGrantee(grantee.Name)

--- a/internal/management/controller/database_controller_sql.go
+++ b/internal/management/controller/database_controller_sql.go
@@ -516,10 +516,14 @@ func sanitizeGrantee(name string) string {
 	return pgx.Identifier{name}.Sanitize()
 }
 
-// applyObjectPrivilege grants or revoke a single privilege keyword (e.g. USAGE,
+// applyObjectPrivilege grants or revokes a single privilege keyword (e.g. USAGE,
 // CREATE, CONNECT, TEMPORARY) on the given object for the listed grantees. It is
 // the shared primitive behind object-level privilege management; callers wrap it
 // with the privilege and object type relevant to their resource.
+//
+// The privilege and objectType arguments are interpolated into the SQL verbatim
+// (they are not escapable identifiers), so callers MUST pass trusted, in-code
+// constants for them and never user-controlled input.
 func applyObjectPrivilege(
 	ctx context.Context,
 	db *sql.DB,

--- a/internal/management/controller/database_controller_sql.go
+++ b/internal/management/controller/database_controller_sql.go
@@ -501,6 +501,71 @@ func updateDatabaseForeignServerUsage(ctx context.Context, db *sql.DB, server *a
 	return applyUsagePermissions(ctx, db, objectTypeForeignServer, server.Name, server.Usages)
 }
 
+// publicRole is the special PostgreSQL grantee `PUBLIC`, which grants or
+// revokes a privilege for all roles at once. It must be emitted verbatim as a
+// keyword and never quoted as an identifier: quoting it would target a role
+// literally named "public", which does not (and cannot) exist.
+const publicRole = "PUBLIC"
+
+// sanitizeGrantee renders a grantee for use in a GRANT/REVOKE statement,
+// special-casing the PUBLIC pseudo-role.
+func sanitizeGrantee(name string) string {
+	if strings.EqualFold(name, publicRole) {
+		return publicRole
+	}
+	return pgx.Identifier{name}.Sanitize()
+}
+
+// applyObjectPrivilege grants or revoke a single privilege keyword (e.g. USAGE,
+// CREATE, CONNECT, TEMPORARY) on the given object for the listed grantees. It is
+// the shared primitive behind object-level privilege management; callers wrap it
+// with the privilege and object type relevant to their resource.
+func applyObjectPrivilege(
+	ctx context.Context,
+	db *sql.DB,
+	privilege string,
+	objectType string,
+	objectName string,
+	grantees []apiv1.UsageSpec,
+) error {
+	contextLogger := log.FromContext(ctx)
+
+	if len(grantees) == 0 {
+		return nil
+	}
+
+	for _, grantee := range grantees {
+		sanitizedObject := pgx.Identifier{objectName}.Sanitize()
+		sanitizedGrantee := sanitizeGrantee(grantee.Name)
+
+		switch grantee.Type {
+		case apiv1.GrantUsageSpecType:
+			mutation := fmt.Sprintf("GRANT %s ON %s %s TO %s", //nolint:gosec
+				privilege, objectType, sanitizedObject, sanitizedGrantee)
+			if _, err := db.ExecContext(ctx, mutation); err != nil {
+				return fmt.Errorf("granting %s on %s: %w", privilege, objectType, err)
+			}
+			contextLogger.Info("granted privilege",
+				"privilege", privilege, "type", objectType, "name", objectName, "grantee", grantee.Name)
+
+		case apiv1.RevokeUsageSpecType:
+			mutation := fmt.Sprintf("REVOKE %s ON %s %s FROM %s", //nolint:gosec
+				privilege, objectType, sanitizedObject, sanitizedGrantee)
+			if _, err := db.ExecContext(ctx, mutation); err != nil {
+				return fmt.Errorf("revoking %s on %s: %w", privilege, objectType, err)
+			}
+			contextLogger.Info("revoked privilege",
+				"privilege", privilege, "type", objectType, "name", objectName, "grantee", grantee.Name)
+
+		default:
+			contextLogger.Warning("unknown privilege type",
+				"type", grantee.Type, "privilege", privilege, "objectType", objectType, "name", objectName)
+		}
+	}
+
+	return nil
+}
+
 // applyUsagePermissions is a generic helper to grant or revoke USAGE permissions
 // for FOREIGN DATA WRAPPER / FOREIGN SERVER objects, avoiding duplicated logic.
 func applyUsagePermissions(
@@ -510,38 +575,7 @@ func applyUsagePermissions(
 	objectName string,
 	usages []apiv1.UsageSpec,
 ) error {
-	contextLogger := log.FromContext(ctx)
-
-	if len(usages) == 0 {
-		return nil
-	}
-
-	for _, usageSpec := range usages {
-		sanitizedObject := pgx.Identifier{objectName}.Sanitize()
-		sanitizedUser := pgx.Identifier{usageSpec.Name}.Sanitize()
-
-		switch usageSpec.Type {
-		case apiv1.GrantUsageSpecType:
-			mutation := fmt.Sprintf("GRANT USAGE ON %s %s TO %s", objectType, sanitizedObject, sanitizedUser)
-			if _, err := db.ExecContext(ctx, mutation); err != nil {
-				return fmt.Errorf("granting usage of %s: %w", objectType, err)
-			}
-			contextLogger.Info("granted usage", "type", objectType, "name", objectName, "user", usageSpec.Name)
-
-		case apiv1.RevokeUsageSpecType:
-			mutation := fmt.Sprintf("REVOKE USAGE ON %s %s FROM %s", objectType, sanitizedObject, sanitizedUser) //nolint:gosec
-			if _, err := db.ExecContext(ctx, mutation); err != nil {
-				return fmt.Errorf("revoking usage of %s: %w", objectType, err)
-			}
-			contextLogger.Info("revoked usage", "type", objectType, "name", objectName, "user", usageSpec.Name)
-
-		default:
-			contextLogger.Warning(
-				"unknown usage type", "type", usageSpec.Type, "objectType", objectType, "name", objectName)
-		}
-	}
-
-	return nil
+	return applyObjectPrivilege(ctx, db, "USAGE", objectType, objectName, usages)
 }
 
 func createDatabaseFDW(ctx context.Context, db *sql.DB, fdw apiv1.FDWSpec) error {

--- a/internal/management/controller/database_controller_sql_test.go
+++ b/internal/management/controller/database_controller_sql_test.go
@@ -1050,7 +1050,6 @@ var _ = Describe("applyObjectPrivilege", func() {
 
 	AfterEach(func() {
 		Expect(dbMock.ExpectationsWereMet()).To(Succeed())
-		Expect(db.Close()).To(Succeed())
 	})
 
 	It("is a no-op when there are no grantees", func(ctx SpecContext) {

--- a/internal/management/controller/database_controller_sql_test.go
+++ b/internal/management/controller/database_controller_sql_test.go
@@ -1016,3 +1016,101 @@ var _ = Describe("Managed Foreign Server SQL", func() {
 		})
 	})
 })
+
+var _ = Describe("sanitizeGrantee", func() {
+	It("renders the PUBLIC pseudo-role verbatim, case-insensitively", func() {
+		Expect(sanitizeGrantee("public")).To(Equal("PUBLIC"))
+		Expect(sanitizeGrantee("PUBLIC")).To(Equal("PUBLIC"))
+		Expect(sanitizeGrantee("Public")).To(Equal("PUBLIC"))
+	})
+
+	It("quotes ordinary roles as identifiers", func() {
+		Expect(sanitizeGrantee("app")).To(Equal("\"app\""))
+	})
+
+	It("safely quotes roles containing special characters", func() {
+		Expect(sanitizeGrantee("weird\"name")).To(Equal("\"weird\"\"name\""))
+	})
+})
+
+var _ = Describe("applyObjectPrivilege", func() {
+	var (
+		dbMock sqlmock.Sqlmock
+		db     *sql.DB
+		err    error
+
+		testError error
+	)
+
+	BeforeEach(func() {
+		db, dbMock, err = sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+		Expect(err).ToNot(HaveOccurred())
+		testError = fmt.Errorf("test error")
+	})
+
+	AfterEach(func() {
+		Expect(dbMock.ExpectationsWereMet()).To(Succeed())
+		Expect(db.Close()).To(Succeed())
+	})
+
+	It("is a no-op when there are no grantees", func(ctx SpecContext) {
+		Expect(applyObjectPrivilege(ctx, db, "CONNECT", "DATABASE", "app", nil)).
+			Error().NotTo(HaveOccurred())
+	})
+
+	It("emits the supplied privilege keyword on GRANT", func(ctx SpecContext) {
+		dbMock.ExpectExec("GRANT CONNECT ON DATABASE \"app\" TO \"angus\"").
+			WillReturnResult(sqlmock.NewResult(0, 1))
+
+		grantees := []apiv1.UsageSpec{{Name: "angus", Type: apiv1.GrantUsageSpecType}}
+		Expect(applyObjectPrivilege(ctx, db, "CONNECT", "DATABASE", "app", grantees)).
+			Error().NotTo(HaveOccurred())
+	})
+
+	It("emits the supplied privilege keyword on REVOKE", func(ctx SpecContext) {
+		dbMock.ExpectExec("REVOKE CREATE ON DATABASE \"app\" FROM \"brian\"").
+			WillReturnResult(sqlmock.NewResult(0, 1))
+
+		grantees := []apiv1.UsageSpec{{Name: "brian", Type: apiv1.RevokeUsageSpecType}}
+		Expect(applyObjectPrivilege(ctx, db, "CREATE", "DATABASE", "app", grantees)).
+			Error().NotTo(HaveOccurred())
+	})
+
+	It("revokes a privilege from PUBLIC without quoting the pseudo-role", func(ctx SpecContext) {
+		dbMock.ExpectExec("REVOKE CONNECT ON DATABASE \"app\" FROM PUBLIC").
+			WillReturnResult(sqlmock.NewResult(0, 1))
+
+		grantees := []apiv1.UsageSpec{{Name: "public", Type: apiv1.RevokeUsageSpecType}}
+		Expect(applyObjectPrivilege(ctx, db, "CONNECT", "DATABASE", "app", grantees)).
+			Error().NotTo(HaveOccurred())
+	})
+
+	It("applies each grantee in order", func(ctx SpecContext) {
+		dbMock.ExpectExec("REVOKE CONNECT ON DATABASE \"app\" FROM PUBLIC").
+			WillReturnResult(sqlmock.NewResult(0, 1))
+		dbMock.ExpectExec("GRANT CONNECT ON DATABASE \"app\" TO \"app\"").
+			WillReturnResult(sqlmock.NewResult(0, 1))
+
+		grantees := []apiv1.UsageSpec{
+			{Name: "public", Type: apiv1.RevokeUsageSpecType},
+			{Name: "app", Type: apiv1.GrantUsageSpecType},
+		}
+		Expect(applyObjectPrivilege(ctx, db, "CONNECT", "DATABASE", "app", grantees)).
+			Error().NotTo(HaveOccurred())
+	})
+
+	It("wraps the privilege keyword in the error on failure", func(ctx SpecContext) {
+		dbMock.ExpectExec("GRANT CONNECT ON DATABASE \"app\" TO \"angus\"").
+			WillReturnError(testError)
+
+		grantees := []apiv1.UsageSpec{{Name: "angus", Type: apiv1.GrantUsageSpecType}}
+		Expect(applyObjectPrivilege(ctx, db, "CONNECT", "DATABASE", "app", grantees)).
+			Error().To(MatchError(testError))
+	})
+
+	It("ignores entries with an unknown type", func(ctx SpecContext) {
+		grantees := []apiv1.UsageSpec{{Name: "angus", Type: "bogus"}}
+		Expect(applyObjectPrivilege(ctx, db, "CONNECT", "DATABASE", "app", grantees)).
+			Error().NotTo(HaveOccurred())
+	})
+})


### PR DESCRIPTION
Generalise the database reconciler's privilege handling in preparation for schema-level and database-level grants.

Extract applyObjectPrivilege from applyUsagePermissions, lifting the hardcoded USAGE keyword into a privilege parameter and making the log and error messages privilege-agnostic. applyUsagePermissions becomes a thin wrapper over it, so the FOREIGN DATA WRAPPER and FOREIGN SERVER callers and their tests are unchanged.

Add a sanitizeGrantee helper (and a publicRole constant) that emits the PUBLIC pseudo-role verbatim rather than quoting it as the non-existent role "public". This is a minor, deliberate behaviour change on the existing USAGE path and is required to support REVOKE ... FROM PUBLIC, the most common database-hardening operation.

Closes #10828

Assisted-by: Claude