### PR TITLE
feat: reload CNPG-i plugins automatically when their pods are rolled

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -114,6 +114,14 @@ rules:
   - update
   - watch
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - monitoring.coreos.com
   resources:
   - podmonitors

--- a/internal/cmd/manager/controller/controller.go
+++ b/internal/cmd/manager/controller/controller.go
@@ -28,9 +28,11 @@ import (
 
 	"github.com/cloudnative-pg/machinery/pkg/log"
 	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -128,6 +130,29 @@ func RunController(
 		// if you are doing or is intended to do any operation such as perform cleanups
 		// after the manager stops then its usage might be unsafe.
 		LeaderElectionReleaseOnCancel: true,
+	}
+
+	// EndpointSlices are watched only to detect CNPG-i plugin rollouts, and
+	// plugins are deployed in the operator namespace. Restricting the informer
+	// to that namespace avoids listing and watching every EndpointSlice in the
+	// cluster (one or more per Service in every namespace), which would
+	// otherwise be cached just to be dropped by the controller predicate.
+	//
+	// The restriction is only applied when the operator namespace is known: an
+	// empty namespace key is interpreted by controller-runtime as "all
+	// namespaces", which would silently widen the cache instead of narrowing
+	// it. When the namespace is unknown (e.g. local development without
+	// OPERATOR_NAMESPACE set) we simply fall back to the default caching.
+	if conf.OperatorNamespace != "" {
+		managerOptions.Cache = cache.Options{
+			ByObject: map[client.Object]cache.ByObject{
+				&discoveryv1.EndpointSlice{}: {
+					Namespaces: map[string]cache.Config{
+						conf.OperatorNamespace: {},
+					},
+				},
+			},
+		}
 	}
 
 	if conf.WatchNamespace != "" {

--- a/internal/cmd/manager/controller/controller.go
+++ b/internal/cmd/manager/controller/controller.go
@@ -153,6 +153,8 @@ func RunController(
 				},
 			},
 		}
+	} else {
+		setupLog.Info("Plugin EndpointSlice watch disabled: OPERATOR_NAMESPACE not set")
 	}
 
 	if conf.WatchNamespace != "" {

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -1384,7 +1384,7 @@ func (r *ClusterReconciler) createFieldIndexes(ctx context.Context, mgr ctrl.Man
 		return err
 	}
 
-	// Create a new index fields that allows mapping a cluster to all the
+	// Create a new index field that allows mapping a cluster to all the
 	// plugins that are required to reconcile it
 	if err := mgr.GetFieldIndexer().IndexField(
 		ctx,

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -32,6 +32,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	coordinationv1 "k8s.io/api/coordination/v1"
 	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -75,6 +76,7 @@ const (
 	disableDefaultQueriesSpecPath = ".spec.monitoring.disableDefaultQueries"
 	imageCatalogKey               = ".spec.imageCatalog.name"
 	databaseRoleClusterKey        = ".spec.cluster.name"
+	usedPluginsClusterKey         = ".spec.usedPlugins"
 )
 
 var apiSGVString = apiv1.SchemeGroupVersion.String()
@@ -128,6 +130,7 @@ var ErrNextLoop = utils.ErrNextLoop
 // +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=validatingwebhookconfigurations,verbs=get;patch
 // +kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;delete;patch;create;watch
 // +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;watch;create;update
+// +kubebuilder:rbac:groups=discovery.k8s.io,resources=endpointslices,verbs=get;list;watch
 // +kubebuilder:rbac:groups=monitoring.coreos.com,resources=podmonitors,verbs=get;create;list;watch;delete;patch
 // +kubebuilder:rbac:groups=policy,resources=poddisruptionbudgets,verbs=create;delete;get;list;watch;update;patch
 // +kubebuilder:rbac:groups=postgresql.cnpg.io,resources=clusters,verbs=get;list;watch;create;update;patch;delete
@@ -199,11 +202,7 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	ctx = cluster.SetInContext(ctx)
 
 	// Load the plugins required to bootstrap and reconcile this cluster
-	enabledPluginNames := apiv1.GetPluginConfigurationEnabledPluginNames(cluster.Spec.Plugins)
-	enabledPluginNames = append(
-		enabledPluginNames,
-		apiv1.GetExternalClustersEnabledPluginNames(cluster.Spec.ExternalClusters)...,
-	)
+	enabledPluginNames := getPluginsNeededForReconcile(cluster)
 
 	pluginLoadingContext, cancelPluginLoading := context.WithTimeout(ctx, 5*time.Second)
 	defer cancelPluginLoading()
@@ -269,6 +268,18 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return ctrl.Result{}, err
 	}
 	return result, nil
+}
+
+// getPluginsNeededForReconcile returns the names of the plugins that must be
+// loaded for the reconciliation loop to interact with this cluster, collected
+// from both the cluster's plugin configuration and its external clusters.
+func getPluginsNeededForReconcile(cluster *apiv1.Cluster) []string {
+	names := apiv1.GetPluginConfigurationEnabledPluginNames(cluster.Spec.Plugins)
+	names = append(
+		names,
+		apiv1.GetExternalClustersEnabledPluginNames(cluster.Spec.ExternalClusters)...,
+	)
+	return stringset.From(names).ToSortedList()
 }
 
 // Inner reconcile loop. Anything inside can require the reconciliation loop to stop by returning ErrNextLoop
@@ -1304,6 +1315,15 @@ func (r *ClusterReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manag
 			// instance RBAC), so status-only changes are irrelevant here.
 			builder.WithPredicates(predicate.GenerationChangedPredicate{}),
 		).
+		Watches(
+			&discoveryv1.EndpointSlice{},
+			handler.EnqueueRequestsFromMapFunc(
+				r.mapPluginEndpointSlicesToClusters(configuration.Current.OperatorNamespace),
+			),
+			builder.WithPredicates(
+				operatorNamespaceServiceEndpointSlicePredicate(configuration.Current.OperatorNamespace),
+			),
+		).
 		Complete(r)
 }
 
@@ -1354,6 +1374,19 @@ func (r *ClusterReconciler) createFieldIndexes(ctx context.Context, mgr ctrl.Man
 			}
 			return []string{"true"}
 		}); err != nil {
+		return err
+	}
+
+	// Create a new index fields that allows mapping a cluster to all the
+	// plugins that are required to reconcile it
+	if err := mgr.GetFieldIndexer().IndexField(
+		ctx,
+		&apiv1.Cluster{},
+		usedPluginsClusterKey, func(rawObj client.Object) []string {
+			cluster := rawObj.(*apiv1.Cluster)
+			return getPluginsNeededForReconcile(cluster)
+		},
+	); err != nil {
 		return err
 	}
 

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -76,7 +76,9 @@ const (
 	disableDefaultQueriesSpecPath = ".spec.monitoring.disableDefaultQueries"
 	imageCatalogKey               = ".spec.imageCatalog.name"
 	databaseRoleClusterKey        = ".spec.cluster.name"
-	usedPluginsClusterKey         = ".spec.usedPlugins"
+	// usedPluginsClusterKey is a synthetic index key, not a real Cluster spec field;
+	// it is populated by getPluginsNeededForReconcile.
+	usedPluginsClusterKey = ".spec.usedPlugins"
 )
 
 var apiSGVString = apiv1.SchemeGroupVersion.String()

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -1260,7 +1260,7 @@ func (r *ClusterReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manag
 		return err
 	}
 
-	return ctrl.NewControllerManagedBy(mgr).
+	ctrlBuilder := ctrl.NewControllerManagedBy(mgr).
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: maxConcurrentReconciles,
 		}).
@@ -1314,8 +1314,10 @@ func (r *ClusterReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manag
 			// The cluster only consumes spec.passwordSecret (to maintain the
 			// instance RBAC), so status-only changes are irrelevant here.
 			builder.WithPredicates(predicate.GenerationChangedPredicate{}),
-		).
-		Watches(
+		)
+
+	if configuration.Current.OperatorNamespace != "" {
+		ctrlBuilder = ctrlBuilder.Watches(
 			&discoveryv1.EndpointSlice{},
 			handler.EnqueueRequestsFromMapFunc(
 				r.mapPluginEndpointSlicesToClusters(configuration.Current.OperatorNamespace),
@@ -1324,8 +1326,10 @@ func (r *ClusterReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manag
 				predicate.GenerationChangedPredicate{},
 				operatorNamespaceServiceEndpointSlicePredicate(configuration.Current.OperatorNamespace),
 			),
-		).
-		Complete(r)
+		)
+	}
+
+	return ctrlBuilder.Complete(r)
 }
 
 // jobOwnerIndexFunc maps a job definition to its owning cluster and

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -1321,6 +1321,7 @@ func (r *ClusterReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manag
 				r.mapPluginEndpointSlicesToClusters(configuration.Current.OperatorNamespace),
 			),
 			builder.WithPredicates(
+				predicate.GenerationChangedPredicate{},
 				operatorNamespaceServiceEndpointSlicePredicate(configuration.Current.OperatorNamespace),
 			),
 		).

--- a/internal/controller/cluster_controller_test.go
+++ b/internal/controller/cluster_controller_test.go
@@ -548,3 +548,112 @@ var _ = Describe("evaluatePodReadinessGuards", func() {
 			"kubelet-stale branch must stay event-less to avoid noise")
 	})
 })
+
+var _ = Describe("getPluginsNeededForReconcile", func() {
+	ptrBool := func(b bool) *bool { return &b }
+
+	It("returns an empty slice when no plugins or external clusters are configured", func() {
+		cluster := &apiv1.Cluster{}
+		Expect(getPluginsNeededForReconcile(cluster)).To(BeEmpty())
+	})
+
+	It("returns the names of enabled plugins from Spec.Plugins", func() {
+		cluster := &apiv1.Cluster{
+			Spec: apiv1.ClusterSpec{
+				Plugins: []apiv1.PluginConfiguration{
+					{Name: "plugin-a"},
+					{Name: "plugin-b", Enabled: ptrBool(true)},
+				},
+			},
+		}
+		Expect(getPluginsNeededForReconcile(cluster)).
+			To(ConsistOf("plugin-a", "plugin-b"))
+	})
+
+	It("skips plugins that are explicitly disabled", func() {
+		cluster := &apiv1.Cluster{
+			Spec: apiv1.ClusterSpec{
+				Plugins: []apiv1.PluginConfiguration{
+					{Name: "plugin-a"},
+					{Name: "plugin-b", Enabled: ptrBool(false)},
+				},
+			},
+		}
+		Expect(getPluginsNeededForReconcile(cluster)).
+			To(ConsistOf("plugin-a"))
+	})
+
+	It("includes plugins referenced by external clusters", func() {
+		cluster := &apiv1.Cluster{
+			Spec: apiv1.ClusterSpec{
+				ExternalClusters: []apiv1.ExternalCluster{
+					{
+						Name:                "source",
+						PluginConfiguration: &apiv1.PluginConfiguration{Name: "plugin-ext"},
+					},
+					{Name: "no-plugin"},
+				},
+			},
+		}
+		Expect(getPluginsNeededForReconcile(cluster)).
+			To(ConsistOf("plugin-ext"))
+	})
+
+	It("merges plugins from Spec.Plugins and Spec.ExternalClusters", func() {
+		cluster := &apiv1.Cluster{
+			Spec: apiv1.ClusterSpec{
+				Plugins: []apiv1.PluginConfiguration{
+					{Name: "plugin-a"},
+					{Name: "plugin-disabled", Enabled: ptrBool(false)},
+				},
+				ExternalClusters: []apiv1.ExternalCluster{
+					{
+						Name:                "source",
+						PluginConfiguration: &apiv1.PluginConfiguration{Name: "plugin-ext"},
+					},
+				},
+			},
+		}
+		Expect(getPluginsNeededForReconcile(cluster)).
+			To(ConsistOf("plugin-a", "plugin-ext"))
+	})
+
+	It("includes external-cluster plugins even when explicitly disabled", func() {
+		// GetExternalClustersEnabledPluginNames does not consult
+		// PluginConfiguration.Enabled — any non-nil PluginConfiguration on an
+		// external cluster contributes its name. This test locks that in.
+		cluster := &apiv1.Cluster{
+			Spec: apiv1.ClusterSpec{
+				ExternalClusters: []apiv1.ExternalCluster{
+					{
+						Name: "source",
+						PluginConfiguration: &apiv1.PluginConfiguration{
+							Name:    "plugin-ext",
+							Enabled: ptrBool(false),
+						},
+					},
+				},
+			},
+		}
+		Expect(getPluginsNeededForReconcile(cluster)).
+			To(ConsistOf("plugin-ext"))
+	})
+
+	It("deduplicates plugin names that appear in both Spec.Plugins and external clusters", func() {
+		cluster := &apiv1.Cluster{
+			Spec: apiv1.ClusterSpec{
+				Plugins: []apiv1.PluginConfiguration{
+					{Name: "plugin-shared"},
+				},
+				ExternalClusters: []apiv1.ExternalCluster{
+					{
+						Name:                "source",
+						PluginConfiguration: &apiv1.PluginConfiguration{Name: "plugin-shared"},
+					},
+				},
+			},
+		}
+		Expect(getPluginsNeededForReconcile(cluster)).
+			To(Equal([]string{"plugin-shared"}))
+	})
+})

--- a/internal/controller/cluster_plugins.go
+++ b/internal/controller/cluster_plugins.go
@@ -24,10 +24,18 @@ import (
 	"context"
 	"reflect"
 
+	"github.com/cloudnative-pg/machinery/pkg/log"
+	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	cnpgiclient "github.com/cloudnative-pg/cloudnative-pg/internal/cnpi/plugin/client"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 )
 
 // updatePluginsStatus ensures that we load the plugins that are required to reconcile
@@ -56,4 +64,77 @@ func (r *ClusterReconciler) updatePluginsStatus(ctx context.Context, cluster *ap
 	}
 
 	return r.Client.Status().Patch(ctx, cluster, client.MergeFrom(oldCluster))
+}
+
+// mapPluginEndpointSlicesToClusters enqueues a reconcile request for every
+// cluster that uses a plugin whose backing Service has its endpoints changing.
+// EndpointSlice events fire when Pods behind the Service become Ready or
+// NotReady, so the operator picks up plugin rollouts after the new Pods are
+// actually serving traffic.
+func (r *ClusterReconciler) mapPluginEndpointSlicesToClusters(
+	operatorNamespace string,
+) handler.MapFunc {
+	return func(ctx context.Context, obj client.Object) []reconcile.Request {
+		logger := log.FromContext(ctx)
+
+		slice, ok := obj.(*discoveryv1.EndpointSlice)
+		if !ok {
+			return nil
+		}
+
+		serviceName := slice.Labels[discoveryv1.LabelServiceName]
+		if serviceName == "" {
+			return nil
+		}
+
+		var service corev1.Service
+		err := r.Get(
+			ctx,
+			types.NamespacedName{Namespace: slice.Namespace, Name: serviceName},
+			&service,
+		)
+		if apierrs.IsNotFound(err) {
+			return nil
+		}
+		if err != nil {
+			logger.Error(
+				err,
+				"Error while resolving the Service owning a plugin EndpointSlice, skipping",
+				"endpointSlice", client.ObjectKeyFromObject(slice),
+				"serviceName", serviceName,
+			)
+			return nil
+		}
+
+		if !isPluginService(&service, operatorNamespace) {
+			return nil
+		}
+
+		pluginName := service.Labels[utils.PluginNameLabelName]
+		if pluginName == "" {
+			return nil
+		}
+
+		var clusterList apiv1.ClusterList
+		if err := r.List(
+			ctx,
+			&clusterList,
+			client.MatchingFields{usedPluginsClusterKey: pluginName},
+		); err != nil {
+			logger.Error(
+				err,
+				"Error while looking up clusters using a plugin whose endpoints changed, skipping",
+				"endpointSlice", client.ObjectKeyFromObject(slice),
+				"pluginName", pluginName,
+			)
+			return nil
+		}
+
+		result := make([]reconcile.Request, len(clusterList.Items))
+		for i := range clusterList.Items {
+			result[i].Name = clusterList.Items[i].Name
+			result[i].Namespace = clusterList.Items[i].Namespace
+		}
+		return result
+	}
 }

--- a/internal/controller/cluster_plugins_test.go
+++ b/internal/controller/cluster_plugins_test.go
@@ -143,7 +143,7 @@ var _ = Describe("mapPluginEndpointSlicesToClusters", func() {
 	})
 
 	It("returns nil when the owning Service does not look like a plugin", func() {
-		// Service exists but is missing the plugin annotations.
+		// Service exists but is missing the plugin label.
 		nonPlugin := &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      pluginServiceName,

--- a/internal/controller/cluster_plugins_test.go
+++ b/internal/controller/cluster_plugins_test.go
@@ -1,0 +1,157 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package controller
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	schemeBuilder "github.com/cloudnative-pg/cloudnative-pg/internal/scheme"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("mapPluginEndpointSlicesToClusters", func() {
+	const (
+		operatorNamespace = "cnpg-system"
+		pluginName        = "plugin-a"
+		pluginServiceName = "plugin-a-svc"
+	)
+
+	var (
+		ctx        context.Context
+		reconciler *ClusterReconciler
+	)
+
+	pluginService := func() *corev1.Service {
+		return &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      pluginServiceName,
+				Namespace: operatorNamespace,
+				Labels: map[string]string{
+					utils.PluginNameLabelName: pluginName,
+				},
+				Annotations: map[string]string{
+					utils.PluginClientSecretAnnotationName: "client-secret",
+					utils.PluginServerSecretAnnotationName: "server-secret",
+					utils.PluginPortAnnotationName:         "9090",
+				},
+			},
+		}
+	}
+
+	endpointSlice := func() *discoveryv1.EndpointSlice {
+		return &discoveryv1.EndpointSlice{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      pluginServiceName + "-abcde",
+				Namespace: operatorNamespace,
+				Labels: map[string]string{
+					discoveryv1.LabelServiceName: pluginServiceName,
+				},
+			},
+		}
+	}
+
+	clusterUsingPlugin := func(namespace, name string) *apiv1.Cluster {
+		return &apiv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+			Spec: apiv1.ClusterSpec{
+				Plugins: []apiv1.PluginConfiguration{{Name: pluginName}},
+			},
+		}
+	}
+
+	buildReconciler := func(objects ...client.Object) *ClusterReconciler {
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(schemeBuilder.BuildWithAllKnownScheme()).
+			WithIndex(&apiv1.Cluster{}, usedPluginsClusterKey, func(rawObj client.Object) []string {
+				return getPluginsNeededForReconcile(rawObj.(*apiv1.Cluster))
+			}).
+			WithObjects(objects...).
+			Build()
+		return &ClusterReconciler{Client: fakeClient}
+	}
+
+	BeforeEach(func() {
+		ctx = context.Background()
+	})
+
+	It("enqueues every cluster using the plugin when its EndpointSlice changes", func() {
+		reconciler = buildReconciler(
+			pluginService(),
+			clusterUsingPlugin("app-ns-1", "cluster-1"),
+			clusterUsingPlugin("app-ns-2", "cluster-2"),
+		)
+		mapFn := reconciler.mapPluginEndpointSlicesToClusters(operatorNamespace)
+
+		requests := mapFn(ctx, endpointSlice())
+		Expect(requests).To(ConsistOf(
+			reconcile.Request{NamespacedName: types.NamespacedName{Namespace: "app-ns-1", Name: "cluster-1"}},
+			reconcile.Request{NamespacedName: types.NamespacedName{Namespace: "app-ns-2", Name: "cluster-2"}},
+		))
+	})
+
+	It("returns nil when the owning Service does not look like a plugin", func() {
+		// Service exists but is missing the plugin annotations.
+		nonPlugin := &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      pluginServiceName,
+				Namespace: operatorNamespace,
+			},
+		}
+		reconciler = buildReconciler(nonPlugin, clusterUsingPlugin("app-ns", "cluster"))
+		mapFn := reconciler.mapPluginEndpointSlicesToClusters(operatorNamespace)
+
+		Expect(mapFn(ctx, endpointSlice())).To(BeNil())
+	})
+
+	It("returns nil when the owning Service has been deleted", func() {
+		reconciler = buildReconciler(clusterUsingPlugin("app-ns", "cluster"))
+		mapFn := reconciler.mapPluginEndpointSlicesToClusters(operatorNamespace)
+
+		Expect(mapFn(ctx, endpointSlice())).To(BeNil())
+	})
+
+	It("returns nil when the EndpointSlice has no service-name label", func() {
+		reconciler = buildReconciler(pluginService(), clusterUsingPlugin("app-ns", "cluster"))
+		mapFn := reconciler.mapPluginEndpointSlicesToClusters(operatorNamespace)
+
+		slice := endpointSlice()
+		slice.Labels = nil
+		Expect(mapFn(ctx, slice)).To(BeNil())
+	})
+
+	It("returns no requests when no cluster references the plugin", func() {
+		reconciler = buildReconciler(pluginService())
+		mapFn := reconciler.mapPluginEndpointSlicesToClusters(operatorNamespace)
+
+		Expect(mapFn(ctx, endpointSlice())).To(BeEmpty())
+	})
+})

--- a/internal/controller/cluster_plugins_test.go
+++ b/internal/controller/cluster_plugins_test.go
@@ -118,6 +118,30 @@ var _ = Describe("mapPluginEndpointSlicesToClusters", func() {
 		))
 	})
 
+	It("enqueues only the clusters using the plugin whose EndpointSlice changed", func() {
+		// A cluster wired to a different plugin must not be enqueued. This is
+		// what the usedPlugins field-index filter guarantees: without it, every
+		// cluster would be reconciled on any plugin rollout. The ConsistOf below
+		// is exact, so it fails if the unrelated cluster leaks into the result.
+		clusterUsingOtherPlugin := &apiv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{Name: "other-cluster", Namespace: "app-ns-other"},
+			Spec: apiv1.ClusterSpec{
+				Plugins: []apiv1.PluginConfiguration{{Name: "some-other-plugin"}},
+			},
+		}
+		reconciler = buildReconciler(
+			pluginService(),
+			clusterUsingPlugin("app-ns-1", "cluster-1"),
+			clusterUsingOtherPlugin,
+		)
+		mapFn := reconciler.mapPluginEndpointSlicesToClusters(operatorNamespace)
+
+		requests := mapFn(ctx, endpointSlice())
+		Expect(requests).To(ConsistOf(
+			reconcile.Request{NamespacedName: types.NamespacedName{Namespace: "app-ns-1", Name: "cluster-1"}},
+		))
+	})
+
 	It("returns nil when the owning Service does not look like a plugin", func() {
 		// Service exists but is missing the plugin annotations.
 		nonPlugin := &corev1.Service{

--- a/internal/controller/plugin_predicates.go
+++ b/internal/controller/plugin_predicates.go
@@ -20,10 +20,27 @@ SPDX-License-Identifier: Apache-2.0
 package controller
 
 import (
+	discoveryv1 "k8s.io/api/discovery/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 )
+
+// operatorNamespaceServiceEndpointSlicePredicate is a cheap pre-filter that
+// drops EndpointSlice events for slices outside the operator namespace and
+// those not backing a Service. Slices that pass still need to be matched
+// against isPluginService by resolving the owning Service: this predicate is
+// only here to keep the workqueue from being woken up by every EndpointSlice
+// in the cluster.
+func operatorNamespaceServiceEndpointSlicePredicate(operatorNamespace string) predicate.Predicate {
+	return predicate.NewPredicateFuncs(func(object client.Object) bool {
+		if object.GetNamespace() != operatorNamespace {
+			return false
+		}
+		return object.GetLabels()[discoveryv1.LabelServiceName] != ""
+	})
+}
 
 func isPluginService(object client.Object, operatorNamespace string) bool {
 	if object.GetNamespace() != operatorNamespace {

--- a/internal/controller/plugin_predicates_test.go
+++ b/internal/controller/plugin_predicates_test.go
@@ -91,4 +91,14 @@ var _ = Describe("operatorNamespaceServiceEndpointSlicePredicate", func() {
 			ObjectNew: newSlice("other-namespace", "some-plugin"),
 		})).To(BeFalse())
 	})
+
+	It("rejects all slices when operatorNamespace is empty", func() {
+		emptyNsPredicate := operatorNamespaceServiceEndpointSlicePredicate("")
+		slice := newSlice("cnpg-system", "some-plugin")
+		Expect(emptyNsPredicate.Create(event.CreateEvent{Object: slice})).To(BeFalse())
+		Expect(emptyNsPredicate.Update(event.UpdateEvent{
+			ObjectOld: slice,
+			ObjectNew: slice,
+		})).To(BeFalse())
+	})
 })

--- a/internal/controller/plugin_predicates_test.go
+++ b/internal/controller/plugin_predicates_test.go
@@ -68,4 +68,22 @@ var _ = Describe("operatorNamespaceServiceEndpointSlicePredicate", func() {
 		slice.Labels = map[string]string{discoveryv1.LabelServiceName: ""}
 		Expect(predicate.Create(event.CreateEvent{Object: slice})).To(BeFalse())
 	})
+
+	// A plugin rollout does not create the EndpointSlice from scratch: the
+	// slice already exists and its endpoints transition Ready/NotReady, so in
+	// production the triggering event is almost always an Update. These cases
+	// lock in that the predicate is evaluated against the updated object.
+	It("accepts an update when the new slice is in the operator namespace and backs a Service", func() {
+		Expect(predicate.Update(event.UpdateEvent{
+			ObjectOld: newSlice(operatorNamespace, "some-plugin"),
+			ObjectNew: newSlice(operatorNamespace, "some-plugin"),
+		})).To(BeTrue())
+	})
+
+	It("rejects an update when the new slice is outside the operator namespace", func() {
+		Expect(predicate.Update(event.UpdateEvent{
+			ObjectOld: newSlice("other-namespace", "some-plugin"),
+			ObjectNew: newSlice("other-namespace", "some-plugin"),
+		})).To(BeFalse())
+	})
 })

--- a/internal/controller/plugin_predicates_test.go
+++ b/internal/controller/plugin_predicates_test.go
@@ -23,6 +23,7 @@ import (
 	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -31,7 +32,11 @@ import (
 var _ = Describe("operatorNamespaceServiceEndpointSlicePredicate", func() {
 	const operatorNamespace = "cnpg-system"
 
-	predicate := operatorNamespaceServiceEndpointSlicePredicate(operatorNamespace)
+	var slicePredicate predicate.Predicate
+
+	BeforeEach(func() {
+		slicePredicate = operatorNamespaceServiceEndpointSlicePredicate(operatorNamespace)
+	})
 
 	newSlice := func(namespace, serviceName string) *discoveryv1.EndpointSlice {
 		slice := &discoveryv1.EndpointSlice{
@@ -50,23 +55,23 @@ var _ = Describe("operatorNamespaceServiceEndpointSlicePredicate", func() {
 
 	It("accepts slices in the operator namespace that back a Service", func() {
 		slice := newSlice(operatorNamespace, "some-plugin")
-		Expect(predicate.Create(event.CreateEvent{Object: slice})).To(BeTrue())
+		Expect(slicePredicate.Create(event.CreateEvent{Object: slice})).To(BeTrue())
 	})
 
 	It("rejects slices outside the operator namespace", func() {
 		slice := newSlice("other-namespace", "some-plugin")
-		Expect(predicate.Create(event.CreateEvent{Object: slice})).To(BeFalse())
+		Expect(slicePredicate.Create(event.CreateEvent{Object: slice})).To(BeFalse())
 	})
 
 	It("rejects slices without the kubernetes.io/service-name label", func() {
 		slice := newSlice(operatorNamespace, "")
-		Expect(predicate.Create(event.CreateEvent{Object: slice})).To(BeFalse())
+		Expect(slicePredicate.Create(event.CreateEvent{Object: slice})).To(BeFalse())
 	})
 
 	It("rejects slices whose kubernetes.io/service-name label is empty", func() {
 		slice := newSlice(operatorNamespace, "")
 		slice.Labels = map[string]string{discoveryv1.LabelServiceName: ""}
-		Expect(predicate.Create(event.CreateEvent{Object: slice})).To(BeFalse())
+		Expect(slicePredicate.Create(event.CreateEvent{Object: slice})).To(BeFalse())
 	})
 
 	// A plugin rollout does not create the EndpointSlice from scratch: the
@@ -74,14 +79,14 @@ var _ = Describe("operatorNamespaceServiceEndpointSlicePredicate", func() {
 	// production the triggering event is almost always an Update. These cases
 	// lock in that the predicate is evaluated against the updated object.
 	It("accepts an update when the new slice is in the operator namespace and backs a Service", func() {
-		Expect(predicate.Update(event.UpdateEvent{
+		Expect(slicePredicate.Update(event.UpdateEvent{
 			ObjectOld: newSlice(operatorNamespace, "some-plugin"),
 			ObjectNew: newSlice(operatorNamespace, "some-plugin"),
 		})).To(BeTrue())
 	})
 
 	It("rejects an update when the new slice is outside the operator namespace", func() {
-		Expect(predicate.Update(event.UpdateEvent{
+		Expect(slicePredicate.Update(event.UpdateEvent{
 			ObjectOld: newSlice("other-namespace", "some-plugin"),
 			ObjectNew: newSlice("other-namespace", "some-plugin"),
 		})).To(BeFalse())

--- a/internal/controller/plugin_predicates_test.go
+++ b/internal/controller/plugin_predicates_test.go
@@ -1,0 +1,71 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package controller
+
+import (
+	discoveryv1 "k8s.io/api/discovery/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("operatorNamespaceServiceEndpointSlicePredicate", func() {
+	const operatorNamespace = "cnpg-system"
+
+	predicate := operatorNamespaceServiceEndpointSlicePredicate(operatorNamespace)
+
+	newSlice := func(namespace, serviceName string) *discoveryv1.EndpointSlice {
+		slice := &discoveryv1.EndpointSlice{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "example-abcde",
+				Namespace: namespace,
+			},
+		}
+		if serviceName != "" {
+			slice.Labels = map[string]string{
+				discoveryv1.LabelServiceName: serviceName,
+			}
+		}
+		return slice
+	}
+
+	It("accepts slices in the operator namespace that back a Service", func() {
+		slice := newSlice(operatorNamespace, "some-plugin")
+		Expect(predicate.Create(event.CreateEvent{Object: slice})).To(BeTrue())
+	})
+
+	It("rejects slices outside the operator namespace", func() {
+		slice := newSlice("other-namespace", "some-plugin")
+		Expect(predicate.Create(event.CreateEvent{Object: slice})).To(BeFalse())
+	})
+
+	It("rejects slices without the kubernetes.io/service-name label", func() {
+		slice := newSlice(operatorNamespace, "")
+		Expect(predicate.Create(event.CreateEvent{Object: slice})).To(BeFalse())
+	})
+
+	It("rejects slices whose kubernetes.io/service-name label is empty", func() {
+		slice := newSlice(operatorNamespace, "")
+		slice.Labels = map[string]string{discoveryv1.LabelServiceName: ""}
+		Expect(predicate.Create(event.CreateEvent{Object: slice})).To(BeFalse())
+	})
+})


### PR DESCRIPTION
Previously, after upgrading a CNPG-i plugin (re-applying its manifest with a new image), the operator kept talking to the plugin through the connection it had opened during the most recent reconciliation. Clusters using that plugin would not see the new version until something else triggered a reconcile (a spec change, the periodic resync, or an operator restart), which could leave clusters running against an old plugin implementation for a long time (up to 10 hours, the default cache resync period).

With this change, the operator watches the EndpointSlices that back CNPG-i plugin Services in the operator namespace. When the plugin Deployment finishes rolling out and the new Pods become Ready, the EndpointSlice changes and every cluster using that plugin is enqueued for reconciliation, ensuring the operator interacts with the updated plugin promptly.

A new field index on Cluster (".spec.usedPlugins") is used to look up all clusters affected by a given plugin without scanning the full cluster list on every EndpointSlice event.