### PR TITLE
feat: add an option to bypass the -rw service in primary_conninfo

### DIFF
--- a/pkg/management/postgres/conninfo.go
+++ b/pkg/management/postgres/conninfo.go
@@ -21,6 +21,8 @@ package postgres
 
 import (
 	"fmt"
+	"os"
+	"strings"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/postgres"
@@ -38,6 +40,16 @@ func buildPrimaryConnInfo(primaryHostname, applicationName string) string {
 		fmt.Sprintf("sslcert=%v ", postgres.StreamingReplicaCertificateLocation) +
 		fmt.Sprintf("sslrootcert=%v ", postgres.ServerCACertificateLocation) +
 		fmt.Sprintf("application_name=%v ", applicationName) +
-		"sslmode=verify-ca"
+		"sslmode=verify-ca dbname=postgres"
+
+	standbyTCPUserTimeout := os.Getenv("CNPG_STANDBY_TCP_USER_TIMEOUT")
+	if len(standbyTCPUserTimeout) == 0 {
+		// Default to 5000ms (5 seconds) if not explicitly set
+		standbyTCPUserTimeout = "5000"
+	}
+
+	primaryConnInfo = fmt.Sprintf("%s tcp_user_timeout='%s'", primaryConnInfo,
+		strings.ReplaceAll(strings.ReplaceAll(standbyTCPUserTimeout, `\`, `\\`), `'`, `\'`))
+
 	return primaryConnInfo
 }

--- a/pkg/management/postgres/instance.go
+++ b/pkg/management/postgres/instance.go
@@ -1608,18 +1608,22 @@ func (instance *Instance) DropConnections() error {
 
 // GetPrimaryConnInfo returns the DSN to reach the primary
 func (instance *Instance) GetPrimaryConnInfo() string {
-	result := buildPrimaryConnInfo(instance.GetClusterName()+"-rw", instance.GetPodName()) + " dbname=postgres"
-
-	standbyTCPUserTimeout := os.Getenv("CNPG_STANDBY_TCP_USER_TIMEOUT")
-	if len(standbyTCPUserTimeout) == 0 {
-		// Default to 5000ms (5 seconds) if not explicitly set
-		standbyTCPUserTimeout = "5000"
+	if instance.useDirectPrimaryConnections() {
+		if instance.Cluster.Status.TargetPrimary == apiv1.PendingFailoverMarker {
+			return "" // stop streaming while the operator is choosing the new primary
+		}
+		primaryHostname := fmt.Sprintf("%s.%s-any", instance.Cluster.Status.TargetPrimary, instance.Cluster.Name)
+		return buildPrimaryConnInfo(primaryHostname, instance.GetPodName())
 	}
+	return buildPrimaryConnInfo(instance.GetClusterName()+"-rw", instance.GetPodName())
+}
 
-	result = fmt.Sprintf("%s tcp_user_timeout='%s'", result,
-		strings.ReplaceAll(strings.ReplaceAll(standbyTCPUserTimeout, `\`, `\\`), `'`, `\'`))
-
-	return result
+func (instance *Instance) useDirectPrimaryConnections() bool {
+	if instance.Cluster == nil {
+		return false // happens in tests...
+	}
+	value, _ := strconv.ParseBool(instance.Cluster.Annotations[utils.DirectPrimaryConnectionsAnnotationName])
+	return value
 }
 
 // HandleInstanceCommandRequests execute a command requested by the reconciliation

--- a/pkg/management/postgres/instance_test.go
+++ b/pkg/management/postgres/instance_test.go
@@ -48,6 +48,11 @@ var _ = Describe("testing primary instance methods", Ordered, func() {
 
 	instance := Instance{
 		PgData: filepath.Join(tempDir, "/testdata/primary"),
+		Cluster: &apiv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-cluster",
+			},
+		},
 	}
 
 	signalPath := filepath.Join(instance.PgData, "standby.signal")

--- a/pkg/management/postgres/join.go
+++ b/pkg/management/postgres/join.go
@@ -74,8 +74,8 @@ func ClonePgData(ctx context.Context, connectionString, targetPgData, walDir str
 }
 
 // Join creates a new instance joined to an existing PostgreSQL cluster
-func (info InitInfo) Join(ctx context.Context, cluster *apiv1.Cluster) error {
-	primaryConnInfo := buildPrimaryConnInfo(info.ParentNode, info.PodName) + " dbname=postgres connect_timeout=5"
+func (info *InitInfo) Join(ctx context.Context, cluster *apiv1.Cluster) error {
+	primaryConnInfo := info.GetPrimaryConnInfo() + " connect_timeout=5"
 
 	// We explicitly disable wal_sender_timeout for join-related pg_basebackup executions.
 	// A short timeout could not be enough in case the instance is slow to send data,

--- a/pkg/management/postgres/restore.go
+++ b/pkg/management/postgres/restore.go
@@ -31,7 +31,6 @@ import (
 	"path"
 	"path/filepath"
 	"strconv"
-	"strings"
 	"time"
 
 	barmanArchiver "github.com/cloudnative-pg/barman-cloud/pkg/archiver"
@@ -962,19 +961,8 @@ func (info InitInfo) ConfigureInstanceAfterRestore(ctx context.Context, cluster 
 }
 
 // GetPrimaryConnInfo returns the DSN to reach the primary
-func (info InitInfo) GetPrimaryConnInfo() string {
-	result := buildPrimaryConnInfo(info.ClusterName+"-rw", info.PodName) + " dbname=postgres"
-
-	standbyTCPUserTimeout := os.Getenv("CNPG_STANDBY_TCP_USER_TIMEOUT")
-	if len(standbyTCPUserTimeout) == 0 {
-		// Default to 5000ms (5 seconds) if not explicitly set
-		standbyTCPUserTimeout = "5000"
-	}
-
-	result = fmt.Sprintf("%s tcp_user_timeout='%s'", result,
-		strings.ReplaceAll(strings.ReplaceAll(standbyTCPUserTimeout, `\`, `\\`), `'`, `\'`))
-
-	return result
+func (info *InitInfo) GetPrimaryConnInfo() string {
+	return buildPrimaryConnInfo(info.ParentNode, info.PodName)
 }
 
 func (info *InitInfo) checkBackupDestination(

--- a/pkg/specs/podspec_diff.go
+++ b/pkg/specs/podspec_diff.go
@@ -95,6 +95,7 @@ func ComparePodSpecs(
 		"hostname": func() bool {
 			return currentPodSpec.Hostname == targetPodSpec.Hostname
 		},
+		"subdomain": func() bool { return currentPodSpec.Subdomain == targetPodSpec.Subdomain },
 		"termination-grace-period": func() bool {
 			return (currentPodSpec.TerminationGracePeriodSeconds == nil && targetPodSpec.TerminationGracePeriodSeconds == nil) ||
 				(currentPodSpec.TerminationGracePeriodSeconds != nil && targetPodSpec.TerminationGracePeriodSeconds != nil &&

--- a/pkg/utils/labels_annotations.go
+++ b/pkg/utils/labels_annotations.go
@@ -332,6 +332,12 @@ const (
 	// password_encryption setting, restoring the behavior the operator had
 	// before client-side encoding was introduced.
 	PasswordPassthroughAnnotationName = MetadataNamespace + "/passwordPassthrough"
+
+	// DirectPrimaryConnectionsAnnotationName is the name of the annotation that tells instance
+	// controllers to specify the hostname of the primary in primary_conninfo instead of the -rw service.
+	// This requires CREATE_ANY_SERVICES to be enabled in the operator, or else pods will be unresolvable!
+	// Also, check that all pods have "Subdomain" set to "<cluster-name>-any" before enabling.
+	DirectPrimaryConnectionsAnnotationName = AlphaMetadataNamespace + "/directPrimaryConnections"
 )
 
 type annotationStatus string


### PR DESCRIPTION
Even with the new feature that removes the primary label from the old primary as soon as promotion starts (see #10403), routing information takes time to propagate, so we are still experiencing forked timelines due to a replica fetching data from the old primary while failover is underway. There is no way to guarantee that the -rw service will point to the new primary within any timeframe, nor really a way to check which primary the replica is connecting to.

We've successfully resolved all our forked timelines by patching cloudnative-pg, and this PR is half of that fix: it ensures that streaming replication will react to the failover process quickly by shutting down walreceivers and keeping them down until a new primary is selected. As a bonus, it ensures observability, since changes to the config are all logged. The downside is that it requires -any services to be enabled to make individual pods routable.