### PR TITLE
fix: unblock deletion of Database, Publication and Subscription

### DIFF
--- a/docs/src/declarative_database_management.md
+++ b/docs/src/declarative_database_management.md
@@ -156,6 +156,11 @@ spec:
 Deleting this `Database` object will automatically remove the `two` database
 from the `cluster-example` cluster.
 
+On a replica cluster the database is read-only, so deleting a `Database` object
+releases its finalizer and removes the Kubernetes object without dropping the
+PostgreSQL database, even with `databaseReclaimPolicy: delete`. Dropping the
+database is left to the primary cluster, which owns it.
+
 ### Declaratively Setting `ensure: absent`
 
 To remove a database, set the `ensure` field to `absent` like in the following

--- a/docs/src/logical_replication.md
+++ b/docs/src/logical_replication.md
@@ -197,6 +197,11 @@ spec:
 In this case, deleting the `Publication` object also removes the `publisher`
 publication from the `app` database of the `freddie` cluster.
 
+On a replica cluster the database is read-only, so deleting a `Publication`
+object releases its finalizer and removes the Kubernetes object without dropping
+the publication in PostgreSQL, even with `publicationReclaimPolicy: delete`.
+Dropping the publication is left to the primary cluster, which owns it.
+
 ## Subscriptions
 
 In PostgreSQL's publish-and-subscribe replication model, a
@@ -340,6 +345,11 @@ spec:
 
 In this case, deleting the `Subscription` object also removes the `subscriber`
 subscription from the `app` database of the `king` cluster.
+
+On a replica cluster the database is read-only, so deleting a `Subscription`
+object releases its finalizer and removes the Kubernetes object without dropping
+the subscription in PostgreSQL, even with `subscriptionReclaimPolicy: delete`.
+Dropping the subscription is left to the primary cluster, which owns it.
 
 ### Resilience to Failovers
 

--- a/internal/management/controller/database_controller.go
+++ b/internal/management/controller/database_controller.go
@@ -115,8 +115,11 @@ func (r *DatabaseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		return ctrl.Result{}, nil
 	}
 
-	// If everything is reconciled, we're done here
-	if database.Generation == database.Status.ObservedGeneration {
+	// Skip when fully reconciled, except during deletion: Kubernetes does not
+	// bump metadata.generation when it sets deletionTimestamp, so without the
+	// deletionTimestamp check the finalizer would never run and the object
+	// would stay stuck in Terminating.
+	if database.Generation == database.Status.ObservedGeneration && database.GetDeletionTimestamp().IsZero() {
 		return ctrl.Result{}, nil
 	}
 
@@ -141,8 +144,11 @@ func (r *DatabaseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		return ctrl.Result{RequeueAfter: databaseReconciliationInterval}, nil
 	}
 
-	// Cannot do anything on a replica cluster
-	if cluster.IsReplica() {
+	// Gate the apply path on a replica, but let deletion through: an object
+	// that acquired its finalizer while this cluster was primary must release
+	// it after a demotion. The drop itself is skipped on a replica (see
+	// evaluateDropDatabase).
+	if cluster.IsReplica() && database.GetDeletionTimestamp().IsZero() {
 		if err := markAsUnknown(ctx, r.Client, &database, errClusterIsReplica); err != nil {
 			return ctrl.Result{}, err
 		}
@@ -183,6 +189,16 @@ func (r *DatabaseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 
 func (r *DatabaseReconciler) evaluateDropDatabase(ctx context.Context, db *apiv1.Database) error {
 	if db.Spec.ReclaimPolicy != apiv1.DatabaseReclaimDelete {
+		return nil
+	}
+	// On a replica we cannot drop the database: return without touching
+	// PostgreSQL so the finalizer is released. Dropping it is left to the
+	// primary cluster's own Database object, if any.
+	cluster, err := r.GetCluster(ctx)
+	if err != nil {
+		return fmt.Errorf("while fetching the cluster: %w", err)
+	}
+	if cluster.IsReplica() {
 		return nil
 	}
 	sqlDB, err := r.getSuperUserDB()

--- a/internal/management/controller/database_controller_test.go
+++ b/internal/management/controller/database_controller_test.go
@@ -188,14 +188,8 @@ var _ = Describe("Managed Database status", func() {
 			Expect(database.Status.Applied).Should(HaveValue(BeTrue()))
 			Expect(database.Status.Message).Should(BeEmpty())
 
-			// The next 2 lines are a hacky bit to make sure the next reconciler
-			// call doesn't skip on account of Generation == ObservedGeneration.
-			// See fake.Client known issues with `Generation`
-			// https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/client/fake@v0.19.0#NewClientBuilder
-			database.SetGeneration(database.GetGeneration() + 1)
-			Expect(fakeClient.Update(ctx, database)).To(Succeed())
-
-			// We now look at the behavior when we delete the Database object
+			// Delete while fully reconciled (Generation == ObservedGeneration):
+			// the finalizer must still run.
 			Expect(fakeClient.Delete(ctx, database)).To(Succeed())
 
 			err = reconcileDatabase(ctx, fakeClient, r, database)
@@ -231,17 +225,51 @@ var _ = Describe("Managed Database status", func() {
 			Expect(database.Status.Applied).Should(HaveValue(BeTrue()))
 			Expect(database.Status.Message).Should(BeEmpty())
 
-			// The next 2 lines are a hacky bit to make sure the next reconciler
-			// call doesn't skip on account of Generation == ObservedGeneration.
-			// See fake.Client known issues with `Generation`
-			// https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/client/fake@v0.19.0#NewClientBuilder
-			database.SetGeneration(database.GetGeneration() + 1)
-			Expect(fakeClient.Update(ctx, database)).To(Succeed())
-
-			// We now look at the behavior when we delete the Database object
+			// Delete while fully reconciled (Generation == ObservedGeneration):
+			// the finalizer must still run.
 			Expect(fakeClient.Delete(ctx, database)).To(Succeed())
 
 			err = reconcileDatabase(ctx, fakeClient, r, database)
+			Expect(err).To(HaveOccurred())
+			Expect(apierrors.IsNotFound(err)).To(BeTrue())
+		})
+	})
+
+	When("reclaim policy is delete but the cluster is a replica", func() {
+		It("on deletion it releases the finalizer without dropping the DB", func(ctx SpecContext) {
+			// Mocking DetectDB
+			expectedValue := sqlmock.NewRows([]string{""}).AddRow("0")
+			dbMock.ExpectQuery(databaseDetectionQuery).WithArgs(database.Spec.Name).
+				WillReturnRows(expectedValue)
+
+			// Mocking CreateDB
+			expectedCreate := sqlmock.NewResult(0, 1)
+			expectedQuery := fmt.Sprintf(
+				"CREATE DATABASE %s OWNER %s",
+				pgx.Identifier{database.Spec.Name}.Sanitize(),
+				pgx.Identifier{database.Spec.Owner}.Sanitize(),
+			)
+			dbMock.ExpectExec(expectedQuery).WillReturnResult(expectedCreate)
+
+			// Reconcile while the cluster is still primary: the finalizer is added.
+			err := reconcileDatabase(ctx, fakeClient, r, database)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(database.GetFinalizers()).NotTo(BeEmpty())
+
+			// Demote the cluster to a replica after the finalizer was added.
+			initialCluster := cluster.DeepCopy()
+			cluster.Spec.ReplicaCluster = &apiv1.ReplicaClusterConfiguration{
+				Enabled: ptr.To(true),
+			}
+			Expect(fakeClient.Patch(ctx, cluster, client.MergeFrom(initialCluster))).To(Succeed())
+
+			// Deleting on a replica must release the finalizer without issuing a
+			// DROP: no DROP is mocked, so any attempt would fail the AfterEach
+			// ExpectationsWereMet check.
+			Expect(fakeClient.Delete(ctx, database)).To(Succeed())
+
+			err = reconcileDatabase(ctx, fakeClient, r, database)
+			Expect(err).To(HaveOccurred())
 			Expect(apierrors.IsNotFound(err)).To(BeTrue())
 		})
 	})

--- a/internal/management/controller/database_controller_test.go
+++ b/internal/management/controller/database_controller_test.go
@@ -236,42 +236,53 @@ var _ = Describe("Managed Database status", func() {
 	})
 
 	When("reclaim policy is delete but the cluster is a replica", func() {
-		It("on deletion it releases the finalizer without dropping the DB", func(ctx SpecContext) {
-			// Mocking DetectDB
-			expectedValue := sqlmock.NewRows([]string{""}).AddRow("0")
-			dbMock.ExpectQuery(databaseDetectionQuery).WithArgs(database.Spec.Name).
-				WillReturnRows(expectedValue)
+		DescribeTable("on deletion it releases the finalizer without dropping the DB",
+			func(ctx SpecContext, demote func()) {
+				// Mocking DetectDB
+				expectedValue := sqlmock.NewRows([]string{""}).AddRow("0")
+				dbMock.ExpectQuery(databaseDetectionQuery).WithArgs(database.Spec.Name).
+					WillReturnRows(expectedValue)
 
-			// Mocking CreateDB
-			expectedCreate := sqlmock.NewResult(0, 1)
-			expectedQuery := fmt.Sprintf(
-				"CREATE DATABASE %s OWNER %s",
-				pgx.Identifier{database.Spec.Name}.Sanitize(),
-				pgx.Identifier{database.Spec.Owner}.Sanitize(),
-			)
-			dbMock.ExpectExec(expectedQuery).WillReturnResult(expectedCreate)
+				// Mocking CreateDB
+				expectedCreate := sqlmock.NewResult(0, 1)
+				expectedQuery := fmt.Sprintf(
+					"CREATE DATABASE %s OWNER %s",
+					pgx.Identifier{database.Spec.Name}.Sanitize(),
+					pgx.Identifier{database.Spec.Owner}.Sanitize(),
+				)
+				dbMock.ExpectExec(expectedQuery).WillReturnResult(expectedCreate)
 
-			// Reconcile while the cluster is still primary: the finalizer is added.
-			err := reconcileDatabase(ctx, fakeClient, r, database)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(database.GetFinalizers()).NotTo(BeEmpty())
+				// Reconcile while the cluster is still primary: the finalizer is added.
+				err := reconcileDatabase(ctx, fakeClient, r, database)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(database.GetFinalizers()).NotTo(BeEmpty())
 
-			// Demote the cluster to a replica after the finalizer was added.
-			initialCluster := cluster.DeepCopy()
-			cluster.Spec.ReplicaCluster = &apiv1.ReplicaClusterConfiguration{
-				Enabled: ptr.To(true),
-			}
-			Expect(fakeClient.Patch(ctx, cluster, client.MergeFrom(initialCluster))).To(Succeed())
+				// Demote the cluster to a replica after the finalizer was added.
+				initialCluster := cluster.DeepCopy()
+				demote()
+				Expect(fakeClient.Patch(ctx, cluster, client.MergeFrom(initialCluster))).To(Succeed())
 
-			// Deleting on a replica must release the finalizer without issuing a
-			// DROP: no DROP is mocked, so any attempt would fail the AfterEach
-			// ExpectationsWereMet check.
-			Expect(fakeClient.Delete(ctx, database)).To(Succeed())
+				// Deleting on a replica must release the finalizer without issuing a
+				// DROP: no DROP is mocked, so any attempt would fail the AfterEach
+				// ExpectationsWereMet check.
+				Expect(fakeClient.Delete(ctx, database)).To(Succeed())
 
-			err = reconcileDatabase(ctx, fakeClient, r, database)
-			Expect(err).To(HaveOccurred())
-			Expect(apierrors.IsNotFound(err)).To(BeTrue())
-		})
+				err = reconcileDatabase(ctx, fakeClient, r, database)
+				Expect(err).To(HaveOccurred())
+				Expect(apierrors.IsNotFound(err)).To(BeTrue())
+			},
+			Entry("via the legacy enabled flag", func() {
+				cluster.Spec.ReplicaCluster = &apiv1.ReplicaClusterConfiguration{
+					Enabled: ptr.To(true),
+				}
+			}),
+			Entry("via distributed topology", func() {
+				cluster.Spec.ReplicaCluster = &apiv1.ReplicaClusterConfiguration{
+					Self:    cluster.Name,
+					Primary: "cluster-elsewhere",
+				}
+			}),
+		)
 	})
 
 	It("fails reconciliation if cluster isn't found (deleted cluster)", func(ctx SpecContext) {

--- a/internal/management/controller/finalizers_test.go
+++ b/internal/management/controller/finalizers_test.go
@@ -1,0 +1,130 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package controller
+
+import (
+	"context"
+	"errors"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	schemeBuilder "github.com/cloudnative-pg/cloudnative-pg/internal/scheme"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("finalizerReconciler", func() {
+	const finalizerName = "test.cnpg.io/finalizer"
+
+	var (
+		fakeClient  client.Client
+		database    *apiv1.Database
+		removeCalls int
+		removeErr   error
+		reconciler  *finalizerReconciler[*apiv1.Database]
+	)
+
+	BeforeEach(func() {
+		removeCalls = 0
+		removeErr = nil
+		database = &apiv1.Database{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "db-one",
+				Namespace: "default",
+			},
+		}
+		fakeClient = fake.NewClientBuilder().
+			WithScheme(schemeBuilder.BuildWithAllKnownScheme()).
+			WithObjects(database).
+			Build()
+		reconciler = newFinalizerReconciler(
+			fakeClient,
+			finalizerName,
+			func(_ context.Context, _ *apiv1.Database) error {
+				removeCalls++
+				return removeErr
+			},
+		)
+	})
+
+	It("adds the finalizer when the object is not being deleted", func(ctx SpecContext) {
+		Expect(reconciler.reconcile(ctx, database)).To(Succeed())
+
+		Expect(controllerutil.ContainsFinalizer(database, finalizerName)).To(BeTrue())
+		Expect(removeCalls).To(BeZero())
+	})
+
+	It("does nothing when the finalizer is already present", func(ctx SpecContext) {
+		Expect(controllerutil.AddFinalizer(database, finalizerName)).To(BeTrue())
+		Expect(fakeClient.Update(ctx, database)).To(Succeed())
+
+		Expect(reconciler.reconcile(ctx, database)).To(Succeed())
+
+		Expect(controllerutil.ContainsFinalizer(database, finalizerName)).To(BeTrue())
+		Expect(removeCalls).To(BeZero())
+	})
+
+	It("runs onRemove and removes the finalizer when the object is being deleted", func(ctx SpecContext) {
+		Expect(controllerutil.AddFinalizer(database, finalizerName)).To(BeTrue())
+		Expect(fakeClient.Update(ctx, database)).To(Succeed())
+		Expect(fakeClient.Delete(ctx, database)).To(Succeed())
+		Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(database), database)).To(Succeed())
+
+		Expect(reconciler.reconcile(ctx, database)).To(Succeed())
+
+		Expect(removeCalls).To(Equal(1))
+		// With the finalizer gone, the deleted object is garbage collected.
+		err := fakeClient.Get(ctx, client.ObjectKeyFromObject(database), database)
+		Expect(apierrors.IsNotFound(err)).To(BeTrue())
+	})
+
+	It("keeps the finalizer when onRemove fails", func(ctx SpecContext) {
+		removeErr = errors.New("drop failed")
+		Expect(controllerutil.AddFinalizer(database, finalizerName)).To(BeTrue())
+		Expect(fakeClient.Update(ctx, database)).To(Succeed())
+		Expect(fakeClient.Delete(ctx, database)).To(Succeed())
+		Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(database), database)).To(Succeed())
+
+		Expect(reconciler.reconcile(ctx, database)).To(MatchError(removeErr))
+
+		Expect(removeCalls).To(Equal(1))
+		Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(database), database)).To(Succeed())
+		Expect(controllerutil.ContainsFinalizer(database, finalizerName)).To(BeTrue())
+	})
+
+	It("does nothing when a deleted object does not carry the finalizer", func(ctx SpecContext) {
+		const otherFinalizer = "other.cnpg.io/keep"
+		Expect(controllerutil.AddFinalizer(database, otherFinalizer)).To(BeTrue())
+		Expect(fakeClient.Update(ctx, database)).To(Succeed())
+		Expect(fakeClient.Delete(ctx, database)).To(Succeed())
+		Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(database), database)).To(Succeed())
+
+		Expect(reconciler.reconcile(ctx, database)).To(Succeed())
+
+		Expect(removeCalls).To(BeZero())
+		Expect(controllerutil.ContainsFinalizer(database, otherFinalizer)).To(BeTrue())
+	})
+})

--- a/internal/management/controller/publication_controller.go
+++ b/internal/management/controller/publication_controller.go
@@ -86,8 +86,11 @@ func (r *PublicationReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		return ctrl.Result{}, nil
 	}
 
-	// If everything is reconciled, we're done here
-	if publication.Generation == publication.Status.ObservedGeneration {
+	// Skip when fully reconciled, except during deletion: Kubernetes does not
+	// bump metadata.generation when it sets deletionTimestamp, so without the
+	// deletionTimestamp check the finalizer would never run and the object
+	// would stay stuck in Terminating.
+	if publication.Generation == publication.Status.ObservedGeneration && publication.GetDeletionTimestamp().IsZero() {
 		return ctrl.Result{}, nil
 	}
 
@@ -112,8 +115,11 @@ func (r *PublicationReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		contextLogger.Info("Reconciliation loop of publication exited")
 	}()
 
-	// Cannot do anything on a replica cluster
-	if cluster.IsReplica() {
+	// Gate the apply path on a replica, but let deletion through: an object
+	// that acquired its finalizer while this cluster was primary must release
+	// it after a demotion. The drop itself is skipped on a replica (see
+	// evaluateDropPublication).
+	if cluster.IsReplica() && publication.GetDeletionTimestamp().IsZero() {
 		if err := markAsUnknown(ctx, r.Client, &publication, errClusterIsReplica); err != nil {
 			return ctrl.Result{}, err
 		}
@@ -156,6 +162,16 @@ func (r *PublicationReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 func (r *PublicationReconciler) evaluateDropPublication(ctx context.Context, pub *apiv1.Publication) error {
 	if pub.Spec.ReclaimPolicy != apiv1.PublicationReclaimDelete {
+		return nil
+	}
+	// On a replica we cannot drop the publication: return without touching
+	// PostgreSQL so the finalizer is released. Dropping it is left to the
+	// primary cluster's own Publication object, if any.
+	cluster, err := r.GetCluster(ctx)
+	if err != nil {
+		return fmt.Errorf("while fetching the cluster: %w", err)
+	}
+	if cluster.IsReplica() {
 		return nil
 	}
 	db, err := r.getDB(pub.Spec.DBName)

--- a/internal/management/controller/publication_controller_test.go
+++ b/internal/management/controller/publication_controller_test.go
@@ -190,14 +190,8 @@ var _ = Describe("Managed publication controller tests", func() {
 			Expect(publication.Status.Applied).Should(HaveValue(BeTrue()))
 			Expect(publication.Status.Message).Should(BeEmpty())
 
-			// The next 2 lines are a hacky bit to make sure the next reconciler
-			// call doesn't skip on account of Generation == ObservedGeneration.
-			// See fake.Client known issues with `Generation`
-			// https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/client/fake@v0.19.0#NewClientBuilder
-			publication.SetGeneration(publication.GetGeneration() + 1)
-			Expect(fakeClient.Update(ctx, publication)).To(Succeed())
-
-			// We now look at the behavior when we delete the Database object
+			// Delete while fully reconciled (Generation == ObservedGeneration):
+			// the finalizer must still run.
 			Expect(fakeClient.Delete(ctx, publication)).To(Succeed())
 
 			err = reconcilePublication(ctx, fakeClient, r, publication)
@@ -232,14 +226,8 @@ var _ = Describe("Managed publication controller tests", func() {
 			Expect(publication.Status.Applied).Should(HaveValue(BeTrue()))
 			Expect(publication.Status.Message).Should(BeEmpty())
 
-			// The next 2 lines are a hacky bit to make sure the next reconciler
-			// call doesn't skip on account of Generation == ObservedGeneration.
-			// See fake.Client known issues with `Generation`
-			// https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/client/fake@v0.19.0#NewClientBuilder
-			publication.SetGeneration(publication.GetGeneration() + 1)
-			Expect(fakeClient.Update(ctx, publication)).To(Succeed())
-
-			// We now look at the behavior when we delete the Database object
+			// Delete while fully reconciled (Generation == ObservedGeneration):
+			// the finalizer must still run.
 			Expect(fakeClient.Delete(ctx, publication)).To(Succeed())
 
 			err = reconcilePublication(ctx, fakeClient, r, publication)
@@ -349,6 +337,44 @@ var _ = Describe("Managed publication controller tests", func() {
 
 		Expect(publication.Status.Applied).Should(BeNil())
 		Expect(publication.Status.Message).Should(ContainSubstring("waiting for the cluster to become primary"))
+	})
+
+	When("reclaim policy is delete but the cluster is a replica", func() {
+		It("on deletion it releases the finalizer without dropping the Publication", func(ctx SpecContext) {
+			// Mocking Detect publication
+			expectedValue := sqlmock.NewRows([]string{""}).AddRow("0")
+			dbMock.ExpectQuery(publicationDetectionQuery).WithArgs(publication.Spec.Name).
+				WillReturnRows(expectedValue)
+
+			// Mocking Create publication
+			expectedCreate := sqlmock.NewResult(0, 1)
+			expectedQuery := fmt.Sprintf(
+				"CREATE PUBLICATION %s FOR ALL TABLES",
+				pgx.Identifier{publication.Spec.Name}.Sanitize(),
+			)
+			dbMock.ExpectExec(expectedQuery).WillReturnResult(expectedCreate)
+
+			// Reconcile while the cluster is still primary: the finalizer is added.
+			err := reconcilePublication(ctx, fakeClient, r, publication)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(publication.GetFinalizers()).NotTo(BeEmpty())
+
+			// Demote the cluster to a replica after the finalizer was added.
+			initialCluster := cluster.DeepCopy()
+			cluster.Spec.ReplicaCluster = &apiv1.ReplicaClusterConfiguration{
+				Enabled: ptr.To(true),
+			}
+			Expect(fakeClient.Patch(ctx, cluster, client.MergeFrom(initialCluster))).To(Succeed())
+
+			// Deleting on a replica must release the finalizer without issuing a
+			// DROP: no DROP is mocked, so any attempt would fail the AfterEach
+			// ExpectationsWereMet check.
+			Expect(fakeClient.Delete(ctx, publication)).To(Succeed())
+
+			err = reconcilePublication(ctx, fakeClient, r, publication)
+			Expect(err).To(HaveOccurred())
+			Expect(apierrors.IsNotFound(err)).To(BeTrue())
+		})
 	})
 })
 

--- a/internal/management/controller/publication_controller_test.go
+++ b/internal/management/controller/publication_controller_test.go
@@ -340,41 +340,52 @@ var _ = Describe("Managed publication controller tests", func() {
 	})
 
 	When("reclaim policy is delete but the cluster is a replica", func() {
-		It("on deletion it releases the finalizer without dropping the Publication", func(ctx SpecContext) {
-			// Mocking Detect publication
-			expectedValue := sqlmock.NewRows([]string{""}).AddRow("0")
-			dbMock.ExpectQuery(publicationDetectionQuery).WithArgs(publication.Spec.Name).
-				WillReturnRows(expectedValue)
+		DescribeTable("on deletion it releases the finalizer without dropping the Publication",
+			func(ctx SpecContext, demote func()) {
+				// Mocking Detect publication
+				expectedValue := sqlmock.NewRows([]string{""}).AddRow("0")
+				dbMock.ExpectQuery(publicationDetectionQuery).WithArgs(publication.Spec.Name).
+					WillReturnRows(expectedValue)
 
-			// Mocking Create publication
-			expectedCreate := sqlmock.NewResult(0, 1)
-			expectedQuery := fmt.Sprintf(
-				"CREATE PUBLICATION %s FOR ALL TABLES",
-				pgx.Identifier{publication.Spec.Name}.Sanitize(),
-			)
-			dbMock.ExpectExec(expectedQuery).WillReturnResult(expectedCreate)
+				// Mocking Create publication
+				expectedCreate := sqlmock.NewResult(0, 1)
+				expectedQuery := fmt.Sprintf(
+					"CREATE PUBLICATION %s FOR ALL TABLES",
+					pgx.Identifier{publication.Spec.Name}.Sanitize(),
+				)
+				dbMock.ExpectExec(expectedQuery).WillReturnResult(expectedCreate)
 
-			// Reconcile while the cluster is still primary: the finalizer is added.
-			err := reconcilePublication(ctx, fakeClient, r, publication)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(publication.GetFinalizers()).NotTo(BeEmpty())
+				// Reconcile while the cluster is still primary: the finalizer is added.
+				err := reconcilePublication(ctx, fakeClient, r, publication)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(publication.GetFinalizers()).NotTo(BeEmpty())
 
-			// Demote the cluster to a replica after the finalizer was added.
-			initialCluster := cluster.DeepCopy()
-			cluster.Spec.ReplicaCluster = &apiv1.ReplicaClusterConfiguration{
-				Enabled: ptr.To(true),
-			}
-			Expect(fakeClient.Patch(ctx, cluster, client.MergeFrom(initialCluster))).To(Succeed())
+				// Demote the cluster to a replica after the finalizer was added.
+				initialCluster := cluster.DeepCopy()
+				demote()
+				Expect(fakeClient.Patch(ctx, cluster, client.MergeFrom(initialCluster))).To(Succeed())
 
-			// Deleting on a replica must release the finalizer without issuing a
-			// DROP: no DROP is mocked, so any attempt would fail the AfterEach
-			// ExpectationsWereMet check.
-			Expect(fakeClient.Delete(ctx, publication)).To(Succeed())
+				// Deleting on a replica must release the finalizer without issuing a
+				// DROP: no DROP is mocked, so any attempt would fail the AfterEach
+				// ExpectationsWereMet check.
+				Expect(fakeClient.Delete(ctx, publication)).To(Succeed())
 
-			err = reconcilePublication(ctx, fakeClient, r, publication)
-			Expect(err).To(HaveOccurred())
-			Expect(apierrors.IsNotFound(err)).To(BeTrue())
-		})
+				err = reconcilePublication(ctx, fakeClient, r, publication)
+				Expect(err).To(HaveOccurred())
+				Expect(apierrors.IsNotFound(err)).To(BeTrue())
+			},
+			Entry("via the legacy enabled flag", func() {
+				cluster.Spec.ReplicaCluster = &apiv1.ReplicaClusterConfiguration{
+					Enabled: ptr.To(true),
+				}
+			}),
+			Entry("via distributed topology", func() {
+				cluster.Spec.ReplicaCluster = &apiv1.ReplicaClusterConfiguration{
+					Self:    cluster.Name,
+					Primary: "cluster-elsewhere",
+				}
+			}),
+		)
 	})
 })
 

--- a/internal/management/controller/subscription_controller.go
+++ b/internal/management/controller/subscription_controller.go
@@ -80,8 +80,11 @@ func (r *SubscriptionReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{}, nil
 	}
 
-	// If everything is reconciled, we're done here
-	if subscription.Generation == subscription.Status.ObservedGeneration {
+	// Skip when fully reconciled, except during deletion: Kubernetes does not
+	// bump metadata.generation when it sets deletionTimestamp, so without the
+	// deletionTimestamp check the finalizer would never run and the object
+	// would stay stuck in Terminating.
+	if subscription.Generation == subscription.Status.ObservedGeneration && subscription.GetDeletionTimestamp().IsZero() {
 		return ctrl.Result{}, nil
 	}
 
@@ -106,8 +109,11 @@ func (r *SubscriptionReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		contextLogger.Info("Reconciliation loop of subscription exited")
 	}()
 
-	// Cannot do anything on a replica cluster
-	if cluster.IsReplica() {
+	// Gate the apply path on a replica, but let deletion through: an object
+	// that acquired its finalizer while this cluster was primary must release
+	// it after a demotion. The drop itself is skipped on a replica (see
+	// evaluateDropSubscription).
+	if cluster.IsReplica() && subscription.GetDeletionTimestamp().IsZero() {
 		if err := markAsUnknown(ctx, r.Client, &subscription, errClusterIsReplica); err != nil {
 			return ctrl.Result{}, err
 		}
@@ -172,7 +178,16 @@ func (r *SubscriptionReconciler) evaluateDropSubscription(ctx context.Context, s
 	if sub.Spec.ReclaimPolicy != apiv1.SubscriptionReclaimDelete {
 		return nil
 	}
-
+	// On a replica we cannot drop the subscription: return without touching
+	// PostgreSQL so the finalizer is released. Dropping it is left to the
+	// primary cluster's own Subscription object, if any.
+	cluster, err := r.GetCluster(ctx)
+	if err != nil {
+		return fmt.Errorf("while fetching the cluster: %w", err)
+	}
+	if cluster.IsReplica() {
+		return nil
+	}
 	db, err := r.getDB(sub.Spec.DBName)
 	if err != nil {
 		return fmt.Errorf("while getting DB connection: %w", err)

--- a/internal/management/controller/subscription_controller_test.go
+++ b/internal/management/controller/subscription_controller_test.go
@@ -220,14 +220,8 @@ var _ = Describe("Managed subscription controller tests", func() {
 			Expect(subscription.Status.Applied).Should(HaveValue(BeTrue()))
 			Expect(subscription.Status.Message).Should(BeEmpty())
 
-			// The next 2 lines are a hacky bit to make sure the next reconciler
-			// call doesn't skip on account of Generation == ObservedGeneration.
-			// See fake.Client known issues with `Generation`
-			// https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/client/fake@v0.19.0#NewClientBuilder
-			subscription.SetGeneration(subscription.GetGeneration() + 1)
-			Expect(fakeClient.Update(ctx, subscription)).To(Succeed())
-
-			// We now look at the behavior when we delete the Database object
+			// Delete while fully reconciled (Generation == ObservedGeneration):
+			// the finalizer must still run.
 			Expect(fakeClient.Delete(ctx, subscription)).To(Succeed())
 
 			err = reconcileSubscription(ctx, fakeClient, r, subscription)
@@ -264,14 +258,8 @@ var _ = Describe("Managed subscription controller tests", func() {
 			Expect(subscription.Status.Applied).Should(HaveValue(BeTrue()))
 			Expect(subscription.Status.Message).Should(BeEmpty())
 
-			// The next 2 lines are a hacky bit to make sure the next reconciler
-			// call doesn't skip on account of Generation == ObservedGeneration.
-			// See fake.Client known issues with `Generation`
-			// https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/client/fake@v0.19.0#NewClientBuilder
-			subscription.SetGeneration(subscription.GetGeneration() + 1)
-			Expect(fakeClient.Update(ctx, subscription)).To(Succeed())
-
-			// We now look at the behavior when we delete the Database object
+			// Delete while fully reconciled (Generation == ObservedGeneration):
+			// the finalizer must still run.
 			Expect(fakeClient.Delete(ctx, subscription)).To(Succeed())
 
 			err = reconcileSubscription(ctx, fakeClient, r, subscription)
@@ -383,6 +371,46 @@ var _ = Describe("Managed subscription controller tests", func() {
 
 		Expect(subscription.Status.Applied).Should(BeNil())
 		Expect(subscription.Status.Message).Should(ContainSubstring("waiting for the cluster to become primary"))
+	})
+
+	When("reclaim policy is delete but the cluster is a replica", func() {
+		It("on deletion it releases the finalizer without dropping the subscription", func(ctx SpecContext) {
+			// Mocking detection of subscriptions
+			expectedValue := sqlmock.NewRows([]string{""}).AddRow("0")
+			dbMock.ExpectQuery(subscriptionDetectionQuery).WithArgs(subscription.Spec.Name).
+				WillReturnRows(expectedValue)
+
+			// Mocking create subscription
+			expectedCreate := sqlmock.NewResult(0, 1)
+			expectedQuery := fmt.Sprintf(
+				"CREATE SUBSCRIPTION %s CONNECTION %s PUBLICATION %s",
+				pgx.Identifier{subscription.Spec.Name}.Sanitize(),
+				pq.QuoteLiteral(connString),
+				pgx.Identifier{subscription.Spec.PublicationName}.Sanitize(),
+			)
+			dbMock.ExpectExec(expectedQuery).WillReturnResult(expectedCreate)
+
+			// Reconcile while the cluster is still primary: the finalizer is added.
+			err = reconcileSubscription(ctx, fakeClient, r, subscription)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(subscription.GetFinalizers()).NotTo(BeEmpty())
+
+			// Demote the cluster to a replica after the finalizer was added.
+			initialCluster := cluster.DeepCopy()
+			cluster.Spec.ReplicaCluster = &apiv1.ReplicaClusterConfiguration{
+				Enabled: ptr.To(true),
+			}
+			Expect(fakeClient.Patch(ctx, cluster, client.MergeFrom(initialCluster))).To(Succeed())
+
+			// Deleting on a replica must release the finalizer without issuing a
+			// DROP: no DROP is mocked, so any attempt would fail the AfterEach
+			// ExpectationsWereMet check.
+			Expect(fakeClient.Delete(ctx, subscription)).To(Succeed())
+
+			err = reconcileSubscription(ctx, fakeClient, r, subscription)
+			Expect(err).To(HaveOccurred())
+			Expect(apierrors.IsNotFound(err)).To(BeTrue())
+		})
 	})
 })
 

--- a/internal/management/controller/subscription_controller_test.go
+++ b/internal/management/controller/subscription_controller_test.go
@@ -374,43 +374,54 @@ var _ = Describe("Managed subscription controller tests", func() {
 	})
 
 	When("reclaim policy is delete but the cluster is a replica", func() {
-		It("on deletion it releases the finalizer without dropping the subscription", func(ctx SpecContext) {
-			// Mocking detection of subscriptions
-			expectedValue := sqlmock.NewRows([]string{""}).AddRow("0")
-			dbMock.ExpectQuery(subscriptionDetectionQuery).WithArgs(subscription.Spec.Name).
-				WillReturnRows(expectedValue)
+		DescribeTable("on deletion it releases the finalizer without dropping the subscription",
+			func(ctx SpecContext, demote func()) {
+				// Mocking detection of subscriptions
+				expectedValue := sqlmock.NewRows([]string{""}).AddRow("0")
+				dbMock.ExpectQuery(subscriptionDetectionQuery).WithArgs(subscription.Spec.Name).
+					WillReturnRows(expectedValue)
 
-			// Mocking create subscription
-			expectedCreate := sqlmock.NewResult(0, 1)
-			expectedQuery := fmt.Sprintf(
-				"CREATE SUBSCRIPTION %s CONNECTION %s PUBLICATION %s",
-				pgx.Identifier{subscription.Spec.Name}.Sanitize(),
-				pq.QuoteLiteral(connString),
-				pgx.Identifier{subscription.Spec.PublicationName}.Sanitize(),
-			)
-			dbMock.ExpectExec(expectedQuery).WillReturnResult(expectedCreate)
+				// Mocking create subscription
+				expectedCreate := sqlmock.NewResult(0, 1)
+				expectedQuery := fmt.Sprintf(
+					"CREATE SUBSCRIPTION %s CONNECTION %s PUBLICATION %s",
+					pgx.Identifier{subscription.Spec.Name}.Sanitize(),
+					pq.QuoteLiteral(connString),
+					pgx.Identifier{subscription.Spec.PublicationName}.Sanitize(),
+				)
+				dbMock.ExpectExec(expectedQuery).WillReturnResult(expectedCreate)
 
-			// Reconcile while the cluster is still primary: the finalizer is added.
-			err = reconcileSubscription(ctx, fakeClient, r, subscription)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(subscription.GetFinalizers()).NotTo(BeEmpty())
+				// Reconcile while the cluster is still primary: the finalizer is added.
+				err = reconcileSubscription(ctx, fakeClient, r, subscription)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(subscription.GetFinalizers()).NotTo(BeEmpty())
 
-			// Demote the cluster to a replica after the finalizer was added.
-			initialCluster := cluster.DeepCopy()
-			cluster.Spec.ReplicaCluster = &apiv1.ReplicaClusterConfiguration{
-				Enabled: ptr.To(true),
-			}
-			Expect(fakeClient.Patch(ctx, cluster, client.MergeFrom(initialCluster))).To(Succeed())
+				// Demote the cluster to a replica after the finalizer was added.
+				initialCluster := cluster.DeepCopy()
+				demote()
+				Expect(fakeClient.Patch(ctx, cluster, client.MergeFrom(initialCluster))).To(Succeed())
 
-			// Deleting on a replica must release the finalizer without issuing a
-			// DROP: no DROP is mocked, so any attempt would fail the AfterEach
-			// ExpectationsWereMet check.
-			Expect(fakeClient.Delete(ctx, subscription)).To(Succeed())
+				// Deleting on a replica must release the finalizer without issuing a
+				// DROP: no DROP is mocked, so any attempt would fail the AfterEach
+				// ExpectationsWereMet check.
+				Expect(fakeClient.Delete(ctx, subscription)).To(Succeed())
 
-			err = reconcileSubscription(ctx, fakeClient, r, subscription)
-			Expect(err).To(HaveOccurred())
-			Expect(apierrors.IsNotFound(err)).To(BeTrue())
-		})
+				err = reconcileSubscription(ctx, fakeClient, r, subscription)
+				Expect(err).To(HaveOccurred())
+				Expect(apierrors.IsNotFound(err)).To(BeTrue())
+			},
+			Entry("via the legacy enabled flag", func() {
+				cluster.Spec.ReplicaCluster = &apiv1.ReplicaClusterConfiguration{
+					Enabled: ptr.To(true),
+				}
+			}),
+			Entry("via distributed topology", func() {
+				cluster.Spec.ReplicaCluster = &apiv1.ReplicaClusterConfiguration{
+					Self:    cluster.Name,
+					Primary: "cluster-elsewhere",
+				}
+			}),
+		)
 	})
 })
 

--- a/tests/e2e/declarative_database_management_test.go
+++ b/tests/e2e/declarative_database_management_test.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"time"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
@@ -184,6 +185,18 @@ var _ = Describe("Declarative database management", Label(tests.LabelSmoke, test
 
 			By("removing the Database object", func() {
 				Expect(objects.Delete(env.Ctx, env.Client, &database)).To(Succeed())
+			})
+
+			By("verifying the Database object is removed from Kubernetes", func() {
+				// The object is deleted while fully reconciled
+				// (Generation == ObservedGeneration), so this asserts the
+				// finalizer is released rather than left stuck in Terminating.
+				Eventually(func(g Gomega) {
+					err := env.Client.Get(env.Ctx,
+						types.NamespacedName{Namespace: namespace, Name: databaseObjectName},
+						&apiv1.Database{})
+					g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
+				}, 120).WithPolling(5 * time.Second).Should(Succeed())
 			})
 
 			By("verifying the retention policy in the postgres database", func() {

--- a/tests/e2e/publication_subscription_test.go
+++ b/tests/e2e/publication_subscription_test.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"time"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
@@ -311,6 +312,25 @@ var _ = Describe("Publication and Subscription", Label(tests.LabelPublicationSub
 				}, 60, 5).Should(Succeed())
 			})
 
+			By("ensuring the reclaim policy change has been reconciled", func() {
+				// Delete must act on a fully reconciled object
+				// (Generation == ObservedGeneration); otherwise the reclaim
+				// policy update would mask the finalizer path under test.
+				Eventually(func(g Gomega) {
+					g.Expect(objects.Get(env.Ctx, env.Client,
+						types.NamespacedName{Namespace: namespace, Name: publication.Name},
+						&publication)).To(Succeed())
+					g.Expect(publication.Status.Applied).Should(HaveValue(BeTrue()))
+					g.Expect(publication.Status.ObservedGeneration).To(Equal(publication.Generation))
+
+					g.Expect(objects.Get(env.Ctx, env.Client,
+						types.NamespacedName{Namespace: namespace, Name: subscription.Name},
+						&subscription)).To(Succeed())
+					g.Expect(subscription.Status.Applied).Should(HaveValue(BeTrue()))
+					g.Expect(subscription.Status.ObservedGeneration).To(Equal(subscription.Generation))
+				}, 60, 5).Should(Succeed())
+			})
+
 			By("checking that the data is present inside the destination cluster database", func() {
 				tableLocator := pgasserts.TableLocator{
 					Namespace:    namespace,
@@ -342,6 +362,22 @@ var _ = Describe("Publication and Subscription", Label(tests.LabelPublicationSub
 			By("removing the objects", func() {
 				Expect(objects.Delete(env.Ctx, env.Client, &publication)).To(Succeed())
 				Expect(objects.Delete(env.Ctx, env.Client, &subscription)).To(Succeed())
+			})
+
+			By("verifying the Publication and Subscription objects are removed from Kubernetes", func() {
+				// The objects are deleted while fully reconciled, so this
+				// asserts their finalizers are released rather than left stuck
+				// in Terminating.
+				Eventually(func(g Gomega) {
+					err := objects.Get(env.Ctx, env.Client,
+						types.NamespacedName{Namespace: namespace, Name: publication.Name},
+						&apiv1.Publication{})
+					g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
+					err = objects.Get(env.Ctx, env.Client,
+						types.NamespacedName{Namespace: namespace, Name: subscription.Name},
+						&apiv1.Subscription{})
+					g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
+				}, 120, 5).Should(Succeed())
 			})
 
 			By("verifying the publication reclaim policy outcome", func() {


### PR DESCRIPTION
A fully reconciled object (Generation == ObservedGeneration) that was then deleted hit the early "already reconciled" return and never reached the finalizer reconciler, because Kubernetes does not bump metadata.generation when it sets deletionTimestamp. The object stayed in Terminating and, under reclaimPolicy: delete, its PostgreSQL counterpart was never dropped. The replica-cluster gate had the same effect for an object whose cluster was demoted after the finalizer had been added.

Guard the generation check with a deletionTimestamp check, and let deletion proceed past the replica gate, so deletion always reaches the finalizer. On a replica the object is read-only, so the finalizer is released without dropping the PostgreSQL object; the drop is left to the primary cluster's own object.

The deletion unit tests bumped the generation by hand to sidestep the first gate; drop that workaround so they exercise the real steady-state path, and add a replica-deletion case for each of the three controllers. The declarative database and logical replication guides document the replica deletion behavior.

Assisted-by: Claude
