### PR TITLE
test(e2e): guard MinIO backup cleanup against a skipped suite

### DIFF
--- a/tests/e2e/backup_restore_minio_test.go
+++ b/tests/e2e/backup_restore_minio_test.go
@@ -121,6 +121,12 @@ var _ = Describe("MinIO - Backup and restore", Label(tests.LabelBackupRestore), 
 		})
 
 		AfterAll(func() {
+			// The AfterAll runs even when the BeforeAll skipped before
+			// creating the namespace; with no namespace there is nothing to
+			// clean up.
+			if namespace == "" {
+				return
+			}
 			// While namespace deletion would handle this implicitly, explicit deletion helps:
 			// - Identify any deletion issues early and in a more clear way rather than waiting for namespace cleanup
 			err := resources.DeleteResourcesFromFile(env, namespace, clusterWithMinioSampleFile)


### PR DESCRIPTION
The MinIO backup/restore e2e suite skips its `BeforeAll` on clusters other than kind or k3d, so the namespace is never created. The `AfterAll` still runs and calls `DeleteResourcesFromFile` against an empty namespace, which fails and reds the job even when every spec passed. This was the sole reason the AKS cloud nightly went red on 2026-06-08 (all 189 run specs passed, the suite reported green, yet the job exited 1), and it also tacks a spurious cleanup failure onto the EKS and GKE cloud runs.

Guard the `AfterAll` so it returns early when the namespace was never created.