### PR TITLE
fix: unblock deletion of Database, Publication and Subscription on a replica

### DIFF
--- a/docs/src/declarative_database_management.md
+++ b/docs/src/declarative_database_management.md
@@ -156,6 +156,11 @@ spec:
 Deleting this `Database` object will automatically remove the `two` database
 from the `cluster-example` cluster.
 
+On a replica cluster the database is read-only, so deleting a `Database` object
+releases its finalizer and removes the Kubernetes object without dropping the
+PostgreSQL database, even with `databaseReclaimPolicy: delete`. Dropping the
+database is left to the primary cluster, which owns it.
+
 ### Declaratively Setting `ensure: absent`
 
 To remove a database, set the `ensure` field to `absent` like in the following

--- a/docs/src/logical_replication.md
+++ b/docs/src/logical_replication.md
@@ -197,6 +197,11 @@ spec:
 In this case, deleting the `Publication` object also removes the `publisher`
 publication from the `app` database of the `freddie` cluster.
 
+On a replica cluster the database is read-only, so deleting a `Publication`
+object releases its finalizer and removes the Kubernetes object without dropping
+the publication in PostgreSQL, even with `publicationReclaimPolicy: delete`.
+Dropping the publication is left to the primary cluster, which owns it.
+
 ## Subscriptions
 
 In PostgreSQL's publish-and-subscribe replication model, a
@@ -340,6 +345,11 @@ spec:
 
 In this case, deleting the `Subscription` object also removes the `subscriber`
 subscription from the `app` database of the `king` cluster.
+
+On a replica cluster the database is read-only, so deleting a `Subscription`
+object releases its finalizer and removes the Kubernetes object without dropping
+the subscription in PostgreSQL, even with `subscriptionReclaimPolicy: delete`.
+Dropping the subscription is left to the primary cluster, which owns it.
 
 ### Resilience to Failovers
 

--- a/internal/management/controller/database_controller.go
+++ b/internal/management/controller/database_controller.go
@@ -141,8 +141,11 @@ func (r *DatabaseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		return ctrl.Result{RequeueAfter: databaseReconciliationInterval}, nil
 	}
 
-	// Cannot do anything on a replica cluster
-	if cluster.IsReplica() {
+	// A replica cluster is read-only, so the apply path is gated here. Deletion
+	// is still allowed through: an object that acquired its finalizer while this
+	// cluster was primary must release it after a demotion. The drop itself is
+	// skipped on a replica (see evaluateDropDatabase).
+	if cluster.IsReplica() && database.GetDeletionTimestamp().IsZero() {
 		if err := markAsUnknown(ctx, r.Client, &database, errClusterIsReplica); err != nil {
 			return ctrl.Result{}, err
 		}
@@ -183,6 +186,16 @@ func (r *DatabaseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 
 func (r *DatabaseReconciler) evaluateDropDatabase(ctx context.Context, db *apiv1.Database) error {
 	if db.Spec.ReclaimPolicy != apiv1.DatabaseReclaimDelete {
+		return nil
+	}
+	// On a replica we cannot drop the database: return without touching
+	// PostgreSQL so the finalizer is released. Dropping it is left to the
+	// primary cluster's own Database object, if any.
+	cluster, err := r.GetCluster(ctx)
+	if err != nil {
+		return fmt.Errorf("while fetching the cluster: %w", err)
+	}
+	if cluster.IsReplica() {
 		return nil
 	}
 	sqlDB, err := r.getSuperUserDB()

--- a/internal/management/controller/database_controller_test.go
+++ b/internal/management/controller/database_controller_test.go
@@ -412,6 +412,9 @@ var _ = Describe("Managed Database status", func() {
 
 		Expect(database.Status.Applied).Should(BeNil())
 		Expect(database.Status.Message).Should(ContainSubstring("waiting for the cluster to become primary"))
+		// The replica gate runs before the finalizer reconciler, so no
+		// finalizer is added while the cluster is a replica.
+		Expect(database.GetFinalizers()).Should(BeEmpty())
 	})
 })
 

--- a/internal/management/controller/database_controller_test.go
+++ b/internal/management/controller/database_controller_test.go
@@ -246,6 +246,49 @@ var _ = Describe("Managed Database status", func() {
 		})
 	})
 
+	When("the cluster is a replica", func() {
+		It("on deletion it releases the finalizer without dropping the DB", func(ctx SpecContext) {
+			// Mocking DetectDB
+			expectedValue := sqlmock.NewRows([]string{""}).AddRow("0")
+			dbMock.ExpectQuery(databaseDetectionQuery).WithArgs(database.Spec.Name).
+				WillReturnRows(expectedValue)
+
+			// Mocking CreateDB
+			expectedCreate := sqlmock.NewResult(0, 1)
+			expectedQuery := fmt.Sprintf(
+				"CREATE DATABASE %s OWNER %s",
+				pgx.Identifier{database.Spec.Name}.Sanitize(),
+				pgx.Identifier{database.Spec.Owner}.Sanitize(),
+			)
+			dbMock.ExpectExec(expectedQuery).WillReturnResult(expectedCreate)
+
+			err := reconcileDatabase(ctx, fakeClient, r, database)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(database.GetFinalizers()).NotTo(BeEmpty())
+
+			// Demote the cluster to a replica after the finalizer was added.
+			cluster.Spec.ReplicaCluster = &apiv1.ReplicaClusterConfiguration{
+				Enabled: ptr.To(true),
+			}
+			Expect(fakeClient.Update(ctx, cluster)).To(Succeed())
+
+			// A real apiserver bumps the generation when deletionTimestamp is
+			// set, which the fake client does not; simulate it so the reconciler
+			// does not skip on Generation == ObservedGeneration.
+			database.SetGeneration(database.GetGeneration() + 1)
+			Expect(fakeClient.Update(ctx, database)).To(Succeed())
+
+			// Deleting on a replica must release the finalizer without issuing a
+			// DROP: no DROP is mocked, so any attempt would fail the AfterEach
+			// ExpectationsWereMet check.
+			Expect(fakeClient.Delete(ctx, database)).To(Succeed())
+
+			err = reconcileDatabase(ctx, fakeClient, r, database)
+			Expect(err).To(HaveOccurred())
+			Expect(apierrors.IsNotFound(err)).To(BeTrue())
+		})
+	})
+
 	It("fails reconciliation if cluster isn't found (deleted cluster)", func(ctx SpecContext) {
 		// Since the fakeClient has the `cluster-example` cluster, let's reference
 		// another cluster `cluster-other` that is not found by the fakeClient

--- a/internal/management/controller/finalizers_test.go
+++ b/internal/management/controller/finalizers_test.go
@@ -1,0 +1,130 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package controller
+
+import (
+	"context"
+	"errors"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	schemeBuilder "github.com/cloudnative-pg/cloudnative-pg/internal/scheme"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("finalizerReconciler", func() {
+	const finalizerName = "test.cnpg.io/finalizer"
+
+	var (
+		fakeClient  client.Client
+		database    *apiv1.Database
+		removeCalls int
+		removeErr   error
+		reconciler  *finalizerReconciler[*apiv1.Database]
+	)
+
+	BeforeEach(func() {
+		removeCalls = 0
+		removeErr = nil
+		database = &apiv1.Database{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "db-one",
+				Namespace: "default",
+			},
+		}
+		fakeClient = fake.NewClientBuilder().
+			WithScheme(schemeBuilder.BuildWithAllKnownScheme()).
+			WithObjects(database).
+			Build()
+		reconciler = newFinalizerReconciler(
+			fakeClient,
+			finalizerName,
+			func(_ context.Context, _ *apiv1.Database) error {
+				removeCalls++
+				return removeErr
+			},
+		)
+	})
+
+	It("adds the finalizer when the object is not being deleted", func(ctx SpecContext) {
+		Expect(reconciler.reconcile(ctx, database)).To(Succeed())
+
+		Expect(controllerutil.ContainsFinalizer(database, finalizerName)).To(BeTrue())
+		Expect(removeCalls).To(BeZero())
+	})
+
+	It("does nothing when the finalizer is already present", func(ctx SpecContext) {
+		Expect(controllerutil.AddFinalizer(database, finalizerName)).To(BeTrue())
+		Expect(fakeClient.Update(ctx, database)).To(Succeed())
+
+		Expect(reconciler.reconcile(ctx, database)).To(Succeed())
+
+		Expect(controllerutil.ContainsFinalizer(database, finalizerName)).To(BeTrue())
+		Expect(removeCalls).To(BeZero())
+	})
+
+	It("runs onRemove and removes the finalizer when the object is being deleted", func(ctx SpecContext) {
+		Expect(controllerutil.AddFinalizer(database, finalizerName)).To(BeTrue())
+		Expect(fakeClient.Update(ctx, database)).To(Succeed())
+		Expect(fakeClient.Delete(ctx, database)).To(Succeed())
+		Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(database), database)).To(Succeed())
+
+		Expect(reconciler.reconcile(ctx, database)).To(Succeed())
+
+		Expect(removeCalls).To(Equal(1))
+		// With the finalizer gone, the deleted object is garbage collected.
+		err := fakeClient.Get(ctx, client.ObjectKeyFromObject(database), database)
+		Expect(apierrors.IsNotFound(err)).To(BeTrue())
+	})
+
+	It("keeps the finalizer when onRemove fails", func(ctx SpecContext) {
+		removeErr = errors.New("drop failed")
+		Expect(controllerutil.AddFinalizer(database, finalizerName)).To(BeTrue())
+		Expect(fakeClient.Update(ctx, database)).To(Succeed())
+		Expect(fakeClient.Delete(ctx, database)).To(Succeed())
+		Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(database), database)).To(Succeed())
+
+		Expect(reconciler.reconcile(ctx, database)).To(MatchError(removeErr))
+
+		Expect(removeCalls).To(Equal(1))
+		Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(database), database)).To(Succeed())
+		Expect(controllerutil.ContainsFinalizer(database, finalizerName)).To(BeTrue())
+	})
+
+	It("does nothing when a deleted object does not carry the finalizer", func(ctx SpecContext) {
+		const otherFinalizer = "other.cnpg.io/keep"
+		Expect(controllerutil.AddFinalizer(database, otherFinalizer)).To(BeTrue())
+		Expect(fakeClient.Update(ctx, database)).To(Succeed())
+		Expect(fakeClient.Delete(ctx, database)).To(Succeed())
+		Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(database), database)).To(Succeed())
+
+		Expect(reconciler.reconcile(ctx, database)).To(Succeed())
+
+		Expect(removeCalls).To(BeZero())
+		Expect(controllerutil.ContainsFinalizer(database, otherFinalizer)).To(BeTrue())
+	})
+})

--- a/internal/management/controller/publication_controller.go
+++ b/internal/management/controller/publication_controller.go
@@ -112,8 +112,11 @@ func (r *PublicationReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		contextLogger.Info("Reconciliation loop of publication exited")
 	}()
 
-	// Cannot do anything on a replica cluster
-	if cluster.IsReplica() {
+	// A replica cluster is read-only, so the apply path is gated here. Deletion
+	// is still allowed through: an object that acquired its finalizer while this
+	// cluster was primary must release it after a demotion. The drop itself is
+	// skipped on a replica (see evaluateDropPublication).
+	if cluster.IsReplica() && publication.GetDeletionTimestamp().IsZero() {
 		if err := markAsUnknown(ctx, r.Client, &publication, errClusterIsReplica); err != nil {
 			return ctrl.Result{}, err
 		}
@@ -156,6 +159,16 @@ func (r *PublicationReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 func (r *PublicationReconciler) evaluateDropPublication(ctx context.Context, pub *apiv1.Publication) error {
 	if pub.Spec.ReclaimPolicy != apiv1.PublicationReclaimDelete {
+		return nil
+	}
+	// On a replica we cannot drop the publication: return without touching
+	// PostgreSQL so the finalizer is released. Dropping it is left to the
+	// primary cluster's own Publication object, if any.
+	cluster, err := r.GetCluster(ctx)
+	if err != nil {
+		return fmt.Errorf("while fetching the cluster: %w", err)
+	}
+	if cluster.IsReplica() {
 		return nil
 	}
 	db, err := r.getDB(pub.Spec.DBName)

--- a/internal/management/controller/publication_controller.go
+++ b/internal/management/controller/publication_controller.go
@@ -123,9 +123,15 @@ func (r *PublicationReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		return ctrl.Result{RequeueAfter: publicationReconciliationInterval}, nil
 	}
 
-	if res, err := detectConflictingManagers(ctx, r.Client, &publication, &apiv1.PublicationList{}); err != nil ||
-		!res.IsZero() {
-		return res, err
+	// The detection only gates the apply path: a publication being deleted
+	// must release its finalizer regardless of conflicting managers. It stays
+	// ahead of the finalizer reconciler so that a conflicting publication
+	// never acquires the finalizer.
+	if publication.GetDeletionTimestamp().IsZero() {
+		if res, err := detectConflictingManagers(ctx, r.Client, &publication, &apiv1.PublicationList{}); err != nil ||
+			!res.IsZero() {
+			return res, err
+		}
 	}
 
 	if err := r.finalizerReconciler.reconcile(ctx, &publication); err != nil {

--- a/internal/management/controller/publication_controller_test.go
+++ b/internal/management/controller/publication_controller_test.go
@@ -248,6 +248,48 @@ var _ = Describe("Managed publication controller tests", func() {
 		})
 	})
 
+	When("the cluster is a replica", func() {
+		It("on deletion it releases the finalizer without dropping the Publication", func(ctx SpecContext) {
+			// Mocking Detect publication
+			expectedValue := sqlmock.NewRows([]string{""}).AddRow("0")
+			dbMock.ExpectQuery(publicationDetectionQuery).WithArgs(publication.Spec.Name).
+				WillReturnRows(expectedValue)
+
+			// Mocking Create publication
+			expectedCreate := sqlmock.NewResult(0, 1)
+			expectedQuery := fmt.Sprintf(
+				"CREATE PUBLICATION %s FOR ALL TABLES",
+				pgx.Identifier{publication.Spec.Name}.Sanitize(),
+			)
+			dbMock.ExpectExec(expectedQuery).WillReturnResult(expectedCreate)
+
+			err := reconcilePublication(ctx, fakeClient, r, publication)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(publication.GetFinalizers()).NotTo(BeEmpty())
+
+			// Demote the cluster to a replica after the finalizer was added.
+			cluster.Spec.ReplicaCluster = &apiv1.ReplicaClusterConfiguration{
+				Enabled: ptr.To(true),
+			}
+			Expect(fakeClient.Update(ctx, cluster)).To(Succeed())
+
+			// A real apiserver bumps the generation when deletionTimestamp is
+			// set, which the fake client does not; simulate it so the reconciler
+			// does not skip on Generation == ObservedGeneration.
+			publication.SetGeneration(publication.GetGeneration() + 1)
+			Expect(fakeClient.Update(ctx, publication)).To(Succeed())
+
+			// Deleting on a replica must release the finalizer without issuing a
+			// DROP: no DROP is mocked, so any attempt would fail the AfterEach
+			// ExpectationsWereMet check.
+			Expect(fakeClient.Delete(ctx, publication)).To(Succeed())
+
+			err = reconcilePublication(ctx, fakeClient, r, publication)
+			Expect(err).To(HaveOccurred())
+			Expect(apierrors.IsNotFound(err)).To(BeTrue())
+		})
+	})
+
 	It("fails reconciliation if cluster isn't found (deleted cluster)", func(ctx SpecContext) {
 		// Since the fakeClient has the `cluster-example` cluster, let's reference
 		// another cluster `cluster-other` that is not found by the fakeClient

--- a/internal/management/controller/publication_controller_test.go
+++ b/internal/management/controller/publication_controller_test.go
@@ -377,6 +377,43 @@ var _ = Describe("Managed publication controller tests", func() {
 		Expect(pubDuplicate.Status.Applied).To(HaveValue(BeFalse()))
 		Expect(pubDuplicate.Status.Message).To(ContainSubstring(expectedError))
 		Expect(pubDuplicate.Status.ObservedGeneration).To(BeZero())
+		// The conflicting managers detection runs before the finalizer
+		// reconciler, so a conflicting publication never acquires the
+		// finalizer and its deletion never drops the contested publication.
+		Expect(pubDuplicate.GetFinalizers()).To(BeEmpty())
+	})
+
+	It("releases the finalizer on deletion even if the publication is managed by another object", func(ctx SpecContext) {
+		// Let's force the publication to have a past reconciliation
+		publication.Status.ObservedGeneration = 2
+		Expect(fakeClient.Status().Update(ctx, publication)).To(Succeed())
+
+		// A conflicting Publication targeting the same "pub-all": it carries
+		// the finalizer but was never reconciled, so it doesn't short-circuit
+		// the conflicting managers detection.
+		pubDuplicate := &apiv1.Publication{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "pub-duplicate",
+				Namespace:  "default",
+				Generation: 1,
+				Finalizers: []string{utils.PublicationFinalizerName},
+			},
+			Spec: apiv1.PublicationSpec{
+				ClusterRef: corev1.LocalObjectReference{
+					Name: cluster.Name,
+				},
+				Name:          "pub-all",
+				ReclaimPolicy: apiv1.PublicationReclaimRetain,
+			},
+		}
+		Expect(fakeClient.Create(ctx, pubDuplicate)).To(Succeed())
+		Expect(fakeClient.Delete(ctx, pubDuplicate)).To(Succeed())
+
+		// Deletion must release the finalizer instead of being re-marked as
+		// failed by the conflicting managers detection.
+		err := reconcilePublication(ctx, fakeClient, r, pubDuplicate)
+		Expect(err).To(HaveOccurred())
+		Expect(apierrors.IsNotFound(err)).To(BeTrue())
 	})
 
 	It("properly signals a publication is on a replica cluster", func(ctx SpecContext) {

--- a/internal/management/controller/publication_controller_test.go
+++ b/internal/management/controller/publication_controller_test.go
@@ -428,6 +428,9 @@ var _ = Describe("Managed publication controller tests", func() {
 
 		Expect(publication.Status.Applied).Should(BeNil())
 		Expect(publication.Status.Message).Should(ContainSubstring("waiting for the cluster to become primary"))
+		// The replica gate runs before the finalizer reconciler, so no
+		// finalizer is added while the cluster is a replica.
+		Expect(publication.GetFinalizers()).Should(BeEmpty())
 	})
 })
 

--- a/internal/management/controller/subscription_controller.go
+++ b/internal/management/controller/subscription_controller.go
@@ -106,8 +106,11 @@ func (r *SubscriptionReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		contextLogger.Info("Reconciliation loop of subscription exited")
 	}()
 
-	// Cannot do anything on a replica cluster
-	if cluster.IsReplica() {
+	// A replica cluster is read-only, so the apply path is gated here. Deletion
+	// is still allowed through: an object that acquired its finalizer while this
+	// cluster was primary must release it after a demotion. The drop itself is
+	// skipped on a replica (see evaluateDropSubscription).
+	if cluster.IsReplica() && subscription.GetDeletionTimestamp().IsZero() {
 		if err := markAsUnknown(ctx, r.Client, &subscription, errClusterIsReplica); err != nil {
 			return ctrl.Result{}, err
 		}
@@ -172,7 +175,16 @@ func (r *SubscriptionReconciler) evaluateDropSubscription(ctx context.Context, s
 	if sub.Spec.ReclaimPolicy != apiv1.SubscriptionReclaimDelete {
 		return nil
 	}
-
+	// On a replica we cannot drop the subscription: return without touching
+	// PostgreSQL so the finalizer is released. Dropping it is left to the
+	// primary cluster's own Subscription object, if any.
+	cluster, err := r.GetCluster(ctx)
+	if err != nil {
+		return fmt.Errorf("while fetching the cluster: %w", err)
+	}
+	if cluster.IsReplica() {
+		return nil
+	}
 	db, err := r.getDB(sub.Spec.DBName)
 	if err != nil {
 		return fmt.Errorf("while getting DB connection: %w", err)

--- a/internal/management/controller/subscription_controller_test.go
+++ b/internal/management/controller/subscription_controller_test.go
@@ -280,6 +280,50 @@ var _ = Describe("Managed subscription controller tests", func() {
 		})
 	})
 
+	When("the cluster is a replica", func() {
+		It("on deletion it releases the finalizer without dropping the subscription", func(ctx SpecContext) {
+			// Mocking detection of subscriptions
+			expectedValue := sqlmock.NewRows([]string{""}).AddRow("0")
+			dbMock.ExpectQuery(subscriptionDetectionQuery).WithArgs(subscription.Spec.Name).
+				WillReturnRows(expectedValue)
+
+			// Mocking create subscription
+			expectedCreate := sqlmock.NewResult(0, 1)
+			expectedQuery := fmt.Sprintf(
+				"CREATE SUBSCRIPTION %s CONNECTION %s PUBLICATION %s",
+				pgx.Identifier{subscription.Spec.Name}.Sanitize(),
+				pq.QuoteLiteral(connString),
+				pgx.Identifier{subscription.Spec.PublicationName}.Sanitize(),
+			)
+			dbMock.ExpectExec(expectedQuery).WillReturnResult(expectedCreate)
+
+			err = reconcileSubscription(ctx, fakeClient, r, subscription)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(subscription.GetFinalizers()).NotTo(BeEmpty())
+
+			// Demote the cluster to a replica after the finalizer was added.
+			cluster.Spec.ReplicaCluster = &apiv1.ReplicaClusterConfiguration{
+				Enabled: ptr.To(true),
+			}
+			Expect(fakeClient.Update(ctx, cluster)).To(Succeed())
+
+			// A real apiserver bumps the generation when deletionTimestamp is
+			// set, which the fake client does not; simulate it so the reconciler
+			// does not skip on Generation == ObservedGeneration.
+			subscription.SetGeneration(subscription.GetGeneration() + 1)
+			Expect(fakeClient.Update(ctx, subscription)).To(Succeed())
+
+			// Deleting on a replica must release the finalizer without issuing a
+			// DROP: no DROP is mocked, so any attempt would fail the AfterEach
+			// ExpectationsWereMet check.
+			Expect(fakeClient.Delete(ctx, subscription)).To(Succeed())
+
+			err = reconcileSubscription(ctx, fakeClient, r, subscription)
+			Expect(err).To(HaveOccurred())
+			Expect(apierrors.IsNotFound(err)).To(BeTrue())
+		})
+	})
+
 	It("fails reconciliation if cluster isn't found (deleted cluster)", func(ctx SpecContext) {
 		// Since the fakeClient has the `cluster-example` cluster, let's reference
 		// another cluster `cluster-other` that is not found by the fakeClient

--- a/internal/management/controller/subscription_controller_test.go
+++ b/internal/management/controller/subscription_controller_test.go
@@ -427,6 +427,9 @@ var _ = Describe("Managed subscription controller tests", func() {
 
 		Expect(subscription.Status.Applied).Should(BeNil())
 		Expect(subscription.Status.Message).Should(ContainSubstring("waiting for the cluster to become primary"))
+		// The replica gate runs before the finalizer reconciler, so no
+		// finalizer is added while the cluster is a replica.
+		Expect(subscription.GetFinalizers()).Should(BeEmpty())
 	})
 })
 


### PR DESCRIPTION
On a cluster that is a replica (for example one demoted in a distributed topology), deleting a `Database`, `Publication` or `Subscription` that already carries its finalizer gets stuck in `Terminating`: the `IsReplica` gate runs before the finalizer reconciler, so the object is marked "waiting for the cluster to become primary" and the finalizer is never released.

Let deletion proceed past the replica gate so the finalizer is released. On a replica the object is read-only, so the drop is skipped; dropping the PostgreSQL object is left to the primary cluster's own object.

Also adds direct unit coverage for the shared `finalizerReconciler`, which previously had none.

Closes #10868

Assisted-by: Claude
