### PR TITLE
docs: add a procedure to reduce a cluster's volume size

### DIFF
--- a/docs/src/storage.md
+++ b/docs/src/storage.md
@@ -348,9 +348,10 @@ cluster-example-4              1/1     Running     0          10s
 ## Volume reduction
 
 Kubernetes does not provide an API to shrink a PVC, and CloudNativePG's
-validating webhook rejects any attempt to decrease `.spec.storage.size` or
-`.spec.walStorage.size`. You can still reduce the storage of a cluster, but
-only by recreating each instance with a smaller volume, as described below.
+validating webhook rejects any attempt to decrease `.spec.storage.size`,
+`.spec.walStorage.size` or any tablespace storage size in `.spec.tablespaces`.
+You can still reduce the storage of a cluster, but only by recreating
+each instance with a smaller volume, as described below.
 
 :::warning
 CloudNativePG does not support automated volume shrinking, as it is a
@@ -362,17 +363,18 @@ While validation is disabled, the operator accepts spec changes that would
 normally be rejected, including unsafe or destructive ones. Proceed with
 caution and at your own risk, and re-enable validation as soon as possible.
 
-Before you start, make sure the cluster's current data and WAL comfortably fit
-within the new, smaller size. If they don't, the instances recreated on the
-smaller volumes will fail to rejoin or will quickly run out of space.
+Before you start, make sure the cluster's current data, WAL, and any tablespace
+data comfortably fit within the new, smaller sizes. If they don't, the instances
+recreated on smaller volumes can fail to rejoin or quickly run out of space.
 :::
 
 To reduce the size of the persistent volumes:
 
 1. Disable the validating webhook by setting the `cnpg.io/validation: disabled`
    annotation on the `Cluster`, set `.spec.storage.size` (and, if present,
-   `.spec.walStorage.size`) to the new, smaller value, and increase
-   `.spec.instances` by 1 to provide a spare instance during the rollout.
+   `.spec.walStorage.size` or tablespace storage size in `.spec.tablespaces`)
+   to the new, smaller value, and increase `.spec.instances` by 1 to provide a
+   spare instance during the rollout.
 2. Re-enable validation by removing the `cnpg.io/validation` annotation (or
    setting it to `enabled`). The new, smaller size is now stored in the spec
    and is applied to every instance the operator recreates from this point on.

--- a/docs/src/storage.md
+++ b/docs/src/storage.md
@@ -361,6 +361,10 @@ This procedure requires you to temporarily disable the validating webhook.
 While validation is disabled, the operator accepts spec changes that would
 normally be rejected, including unsafe or destructive ones. Proceed with
 caution and at your own risk, and re-enable validation as soon as possible.
+
+Before you start, make sure the cluster's current data and WAL comfortably fit
+within the new, smaller size. If they don't, the instances recreated on the
+smaller volumes will fail to rejoin or will quickly run out of space.
 :::
 
 To reduce the size of the persistent volumes:
@@ -372,8 +376,12 @@ To reduce the size of the persistent volumes:
 2. Re-enable validation by removing the `cnpg.io/validation` annotation (or
    setting it to `enabled`). The new, smaller size is now stored in the spec
    and is applied to every instance the operator recreates from this point on.
+   Existing instances keep their current volumes; for each one, the operator
+   logs an informational `cannot decrease storage requirement` message until
+   that instance is recreated. This is expected and harmless.
 3. Destroy one standby that still has a volume of the old size. The operator
-   recreates it with the new, smaller volume:
+   provisions a replacement instance — created with the next available name,
+   not the one you destroyed — on the new, smaller volume:
 
    ```sh
    kubectl-cnpg destroy CLUSTER INSTANCE
@@ -391,8 +399,8 @@ To reduce the size of the persistent volumes:
    ```
 
 7. Destroy the former primary (now a standby with an old-size volume) so the
-   operator recreates it with the new, smaller volume, and wait until all
-   instances are healthy.
+   operator provisions its replacement on the new, smaller volume, and wait
+   until all instances are healthy.
 8. Decrease `.spec.instances` back to its original value.
 
 ## Static provisioning of persistent volumes

--- a/docs/src/storage.md
+++ b/docs/src/storage.md
@@ -345,6 +345,33 @@ cluster-example-4-join-v2      0/1     Completed   0          17s
 cluster-example-4              1/1     Running     0          10s
 ```
 
+## Volume decrease
+
+Kubernetes does not provide an API allowing decreasing PVC's and CloudNativePG's validating webhook prohibit to decrease the value of `.spec.storage.size` / `.spec.walStorage.size`.
+However there is a procedure that allows you to decrese the size of your PVC's.
+
+:::info[Important]
+    ⚠️ WARNING: If you follow this procedure, you will temporarily disable the validating webhook. Disabling validation may permit unsafe or destructive operations. Use this setting with caution and at your own risk.
+:::
+
+To decrease the persistent volume:
+
+1. disable the validating webhook by setting `.metadata.annotations:cnpg.io/validation: disabled`, change `.spec.storage.size` / `.spec.walStorage.size` to the new value and increase `.spec.instnaces` by 1.
+2. enable the validation webhook
+3. remove one standby instance that has the old PVC size
+```
+kubectl-cnpg destroy CLUSTER INSTANCE
+```
+4. wait for the operator create a new instance
+5. repeate this step for every other standby instance
+6. promote one of the new standby instances
+```
+kubectl-cnpg promote CLUSTER INSTANCE
+```
+7. wait until all instances are healthy
+8. decrease `.spec.instnaces` to the initial value
+
+
 ## Static provisioning of persistent volumes
 
 CloudNativePG was designed to work with dynamic volume provisioning. This

--- a/docs/src/storage.md
+++ b/docs/src/storage.md
@@ -345,32 +345,51 @@ cluster-example-4-join-v2      0/1     Completed   0          17s
 cluster-example-4              1/1     Running     0          10s
 ```
 
-## Volume decrease
+## Volume reduction
 
-Kubernetes does not provide an API allowing decreasing PVC's and CloudNativePG's validating webhook prohibit to decrease the value of `.spec.storage.size` / `.spec.walStorage.size`.
-However there is a procedure that allows you to decrese the size of your PVC's.
+Kubernetes does not provide an API to shrink a PVC, and CloudNativePG's
+validating webhook rejects any attempt to decrease `.spec.storage.size` or
+`.spec.walStorage.size`. You can still reduce the storage of a cluster, but
+only by recreating each instance with a smaller volume, as described below.
 
-:::info[Important]
-    ⚠️ WARNING: If you follow this procedure, you will temporarily disable the validating webhook. Disabling validation may permit unsafe or destructive operations. Use this setting with caution and at your own risk.
+:::warning
+This procedure requires you to temporarily disable the validating webhook.
+While validation is disabled, the operator accepts spec changes that would
+normally be rejected, including unsafe or destructive ones. Proceed with
+caution and at your own risk, and re-enable validation as soon as possible.
 :::
 
-To decrease the persistent volume:
+To reduce the size of the persistent volumes:
 
-1. disable the validating webhook by setting `.metadata.annotations:cnpg.io/validation: disabled`, change `.spec.storage.size` / `.spec.walStorage.size` to the new value and increase `.spec.instnaces` by 1.
-2. enable the validation webhook
-3. remove one standby instance that has the old PVC size
-```
-kubectl-cnpg destroy CLUSTER INSTANCE
-```
-4. wait for the operator create a new instance
-5. repeate this step for every other standby instance
-6. promote one of the new standby instances
-```
-kubectl-cnpg promote CLUSTER INSTANCE
-```
-7. wait until all instances are healthy
-8. decrease `.spec.instnaces` to the initial value
+1. Disable the validating webhook by setting the `cnpg.io/validation: disabled`
+   annotation on the `Cluster`, set `.spec.storage.size` (and, if present,
+   `.spec.walStorage.size`) to the new, smaller value, and increase
+   `.spec.instances` by 1 to provide a spare instance during the rollout.
+2. Re-enable validation by removing the `cnpg.io/validation` annotation (or
+   setting it to `enabled`). The new, smaller size is now stored in the spec
+   and is applied to every instance the operator recreates from this point on.
+3. Destroy one standby that still has a volume of the old size. The operator
+   recreates it with the new, smaller volume:
 
+   ```sh
+   kubectl-cnpg destroy CLUSTER INSTANCE
+   ```
+
+4. Wait for the operator to create the replacement instance and for it to
+   become healthy.
+5. Repeat steps 3 and 4 for every remaining standby that still has an
+   old-size volume.
+6. Promote one of the newly created standbys so that the current primary —
+   which still has an old-size volume — is demoted to a standby:
+
+   ```sh
+   kubectl-cnpg promote CLUSTER INSTANCE
+   ```
+
+7. Destroy the former primary (now a standby with an old-size volume) so the
+   operator recreates it with the new, smaller volume, and wait until all
+   instances are healthy.
+8. Decrease `.spec.instances` back to its original value.
 
 ## Static provisioning of persistent volumes
 

--- a/docs/src/storage.md
+++ b/docs/src/storage.md
@@ -353,6 +353,10 @@ validating webhook rejects any attempt to decrease `.spec.storage.size` or
 only by recreating each instance with a smaller volume, as described below.
 
 :::warning
+CloudNativePG does not support automated volume shrinking, as it is a
+delicate operation that can lead to data loss if performed incorrectly. For
+the time being, it can only be achieved manually, through the supervised
+procedure described below.
 This procedure requires you to temporarily disable the validating webhook.
 While validation is disabled, the operator accepts spec changes that would
 normally be rejected, including unsafe or destructive ones. Proceed with


### PR DESCRIPTION
Kubernetes provides no API to shrink a PVC, and CloudNativePG's validating
webhook rejects any decrease of `.spec.storage.size`, `.spec.walStorage.size`,
or a tablespace size in `.spec.tablespaces`. As a result there was no
documented way to reduce the storage allocated to a cluster.

This adds a "Volume reduction" section to `storage.md` describing a manual,
supervised procedure: temporarily disable validation to record the smaller
size, then roll the cluster one instance at a time — destroy each old-size
standby so the operator rebuilds it on a smaller volume, promote a recreated
standby, and finally replace the former primary — until every instance sits
on the new, smaller volume. It also documents the prerequisites and risks:
the data must fit within the new size, validation must be re-enabled as soon
as possible, and existing volumes are left untouched until their instance is
recreated.

Closes #10852

Signed-off-by: Daniel Chambre <smiyc@pm.me>