### PR TITLE
fix(instance): align enforced parameters on the demotion path (#10716)

### DIFF
--- a/internal/controller/cluster_upgrade.go
+++ b/internal/controller/cluster_upgrade.go
@@ -127,6 +127,12 @@ func (r *ClusterReconciler) rolloutRequiredInstances(
 
 	// If the primary update strategy is supervised, we should not consume a rollout slot.
 	// The user must issue a switchover manually.
+	//
+	// NOTE: the decrease of a hot standby sensitive parameter is handled earlier
+	// (PendingRestartForDecrease returns above) by the instance manager, which asks
+	// for an in-place primary restart instead of a switchover. This branch covers
+	// the remaining supervised rollouts (e.g. image upgrades) where a switchover is
+	// the correct action.
 	if cluster.GetPrimaryUpdateStrategy() == apiv1.PrimaryUpdateStrategySupervised {
 		contextLogger := log.FromContext(ctx)
 		contextLogger.Info("Waiting for the user to request a switchover to complete the rolling update",

--- a/internal/management/controller/instance_controller.go
+++ b/internal/management/controller/instance_controller.go
@@ -1128,11 +1128,22 @@ func (r *InstanceReconciler) processConfigReloadAndManageRestart(ctx context.Con
 			return r.triggerRestartForDecrease(ctx, cluster)
 		}
 		reason := "decrease of hot standby sensitive parameters"
-		contextLogger.Info("Waiting for the user to request a restart of the primary instance or a switchover "+
+		contextLogger.Info("Waiting for the user to request a restart of the primary instance "+
 			"to complete the rolling update",
 			"cluster", cluster.Name, "primaryPod", status.Pod.Name, "reason", reason)
 		phase = apiv1.PhaseWaitingForUser
-		phaseReason = "User must issue a supervised switchover"
+		// A decrease of hot standby sensitive parameters is applied by restarting
+		// the primary in place: a switchover does not help, because the promoted
+		// replica still carries the higher value (it is kept aligned upwards while
+		// it follows the primary). Point the user to the action that actually
+		// converges the cluster.
+		//
+		// NOTE: this guidance is intentionally specific to a parameter decrease.
+		// Other supervised rollouts (e.g. image upgrades) are handled in
+		// internal/controller/cluster_upgrade.go, which keeps PhaseWaitingForUser
+		// with the "User must issue a supervised switchover" reason. Keep the two
+		// messages in sync with their respective scenarios.
+		phaseReason = "User must issue a restart of the primary instance to apply the decreased parameters"
 	}
 	if phase == apiv1.PhaseApplyingConfiguration &&
 		(cluster.Status.Phase == apiv1.PhaseApplyingConfiguration ||

--- a/internal/management/controller/instance_controller.go
+++ b/internal/management/controller/instance_controller.go
@@ -504,6 +504,11 @@ func (r *InstanceReconciler) initialize(ctx context.Context, cluster *apiv1.Clus
 		return err
 	}
 
+	// verifyPgDataCoherenceForPrimary may demote this instance (writing
+	// standby.signal) during a supervised switchover. When it does, it re-aligns
+	// the enforced parameters for the freshly demoted follower itself, so there
+	// is no need to repeat that here (see alignEnforcedParametersForFollower and
+	// https://github.com/cloudnative-pg/cloudnative-pg/issues/10716).
 	if err := r.verifyPgDataCoherenceForPrimary(ctx, cluster); err != nil {
 		return err
 	}
@@ -550,6 +555,28 @@ func (r *InstanceReconciler) verifyParametersForFollower(
 		return err
 	}
 	contextLogger.Info("Found previous run flag", "filename", filename)
+
+	return r.alignEnforcedParametersForFollower(ctx, cluster)
+}
+
+// alignEnforcedParametersForFollower writes the enforced parameter values taken
+// from `pg_controldata` into the local PostgreSQL configuration whenever they are
+// higher than the values declared in the cluster spec. This keeps a follower able
+// to start when an enforced parameter was decreased on the spec: a standby must
+// not start with a value lower than the primary's, otherwise it aborts recovery
+// with "insufficient parameter settings".
+//
+// Unlike verifyParametersForFollower, this does not consult the startup flag
+// file: callers use it when the instance has just become a follower (e.g. right
+// after a demotion) and the alignment must happen even on a pod that was never a
+// follower before, which therefore has no startup flag yet
+// (https://github.com/cloudnative-pg/cloudnative-pg/issues/10716).
+func (r *InstanceReconciler) alignEnforcedParametersForFollower(
+	ctx context.Context,
+	cluster *apiv1.Cluster,
+) error {
+	contextLogger := log.FromContext(ctx)
+
 	controldataParams, err := postgresManagement.LoadEnforcedParametersFromPgControldata(r.instance.PgData)
 	if err != nil {
 		return err

--- a/internal/management/controller/instance_startup.go
+++ b/internal/management/controller/instance_startup.go
@@ -67,7 +67,12 @@ func (r *InstanceReconciler) verifyPgDataCoherenceForPrimary(ctx context.Context
 		// In this case, we're demoting the cluster immediately.
 		contextLogger.Info("Detected transition to replica cluster after reconciliation " +
 			"of the cluster is resumed, demoting immediately")
-		return r.instance.Demote(ctx, cluster)
+		if err := r.instance.Demote(ctx, cluster); err != nil {
+			return err
+		}
+		// We are now a follower: align the enforced parameters so we do not abort
+		// recovery if one of them was decreased on the spec while we were primary.
+		return r.alignEnforcedParametersForFollower(ctx, cluster)
 
 	case targetPrimary == r.instance.GetPodName():
 		if currentPrimary == "" {
@@ -143,7 +148,13 @@ func (r *InstanceReconciler) verifyPgDataCoherenceForPrimary(ctx context.Context
 		}
 
 		// Now I can demote myself
-		return r.instance.Demote(ctx, cluster)
+		if err := r.instance.Demote(ctx, cluster); err != nil {
+			return err
+		}
+		// We are now a follower of the new primary: align the enforced parameters
+		// so we do not abort recovery with "insufficient parameter settings" if one
+		// of them carried a higher value while we were the primary (issue #10716).
+		return r.alignEnforcedParametersForFollower(ctx, cluster)
 	}
 }
 

--- a/tests/e2e/fixtures/switchover/cluster-switchover-supervised.yaml.template
+++ b/tests/e2e/fixtures/switchover/cluster-switchover-supervised.yaml.template
@@ -1,0 +1,30 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: cluster-switchover-supervised
+spec:
+  instances: 2
+
+  postgresql:
+    parameters:
+      # Enforced (hot standby sensitive) parameter that will be decreased
+      # before the switchover to trigger issue #10716.
+      max_connections: '150'
+
+  # supervised: the operator never restarts the primary on its own, it
+  # waits for the user to trigger the switchover. This is the path that
+  # demotes the old primary and triggers issue #10716.
+  primaryUpdateStrategy: supervised
+
+  bootstrap:
+    initdb:
+      database: app
+      owner: app
+
+  # Persistent storage configuration
+  storage:
+    storageClass: ${E2E_DEFAULT_STORAGE_CLASS}
+    size: 1Gi
+  walStorage:
+    storageClass: ${E2E_DEFAULT_STORAGE_CLASS}
+    size: 1Gi

--- a/tests/e2e/supervised_switchover_param_test.go
+++ b/tests/e2e/supervised_switchover_param_test.go
@@ -1,0 +1,203 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package e2e
+
+import (
+	"sort"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
+
+	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/specs"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
+	"github.com/cloudnative-pg/cloudnative-pg/tests"
+	clusterasserts "github.com/cloudnative-pg/cloudnative-pg/tests/internal/asserts/cluster"
+	pgasserts "github.com/cloudnative-pg/cloudnative-pg/tests/internal/asserts/postgres"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/clusterutils"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/logs"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/postgres"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/timeouts"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/yaml"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// Tests for https://github.com/cloudnative-pg/cloudnative-pg/issues/10716
+//
+// Decreasing an enforced (hot-standby sensitive) parameter such as
+// max_connections while primaryUpdateStrategy is "supervised" puts the cluster
+// in "Waiting for user action": the value can only be lowered by restarting the
+// primary in place (which applies it first; followers then catch up). A
+// switchover does NOT converge the cluster, because the promoted replica still
+// carries the higher value (verifyParametersForFollower keeps followers aligned
+// upwards). If a switchover happens anyway, the demoted old primary must not
+// abort recovery with "insufficient parameter settings".
+var _ = Describe("Supervised decrease of an enforced parameter", Serial,
+	Label(tests.LabelSelfHealing), func() {
+		const (
+			sampleFile = fixturesDir + "/switchover/cluster-switchover-supervised.yaml.template"
+			level      = tests.Medium
+		)
+		var namespace string
+
+		BeforeEach(func() {
+			if testLevelEnv.Depth < int(level) {
+				Skip("Test depth is lower than the amount requested for this test")
+			}
+		})
+
+		// setupClusterWithPendingDecrease creates the supervised cluster running
+		// with max_connections=150, lowers it to 100 and waits until the cluster
+		// asks for user action. It returns the cluster name.
+		setupClusterWithPendingDecrease := func(namespacePrefix string) string {
+			var err error
+			namespace, err = env.CreateUniqueTestNamespace(env.Ctx, env.Client, namespacePrefix)
+			Expect(err).ToNot(HaveOccurred())
+			clusterName, err := yaml.GetResourceNameFromYAML(env.Scheme, sampleFile)
+			Expect(err).ToNot(HaveOccurred())
+
+			clusterasserts.AssertCreateCluster(env, testTimeouts, namespace, clusterName, sampleFile)
+
+			By("starting with max_connections=150 on every instance", func() {
+				podList, err := clusterutils.ListPods(env.Ctx, env.Client, namespace, clusterName)
+				Expect(err).ToNot(HaveOccurred())
+				for i := range podList.Items {
+					Eventually(pgasserts.QueryMatchExpectationPredicate(env, &podList.Items[i],
+						postgres.PostgresDBName, "SHOW max_connections", "150"),
+						RetryTimeout).Should(Succeed())
+				}
+			})
+
+			By("decreasing max_connections to 100", func() {
+				err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+					cluster, err := clusterutils.Get(env.Ctx, env.Client, namespace, clusterName)
+					if err != nil {
+						return err
+					}
+					cluster.Spec.PostgresConfiguration.Parameters["max_connections"] = "100"
+					return env.Client.Update(env.Ctx, cluster)
+				})
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			// With a supervised strategy the operator does not restart the primary
+			// on its own: it waits for the user.
+			clusterasserts.AssertClusterEventuallyReachesPhase(env, namespace, clusterName,
+				[]string{apiv1.PhaseWaitingForUser}, 120)
+
+			return clusterName
+		}
+
+		It("does not abort recovery on the old primary if a switchover happens during the pending decrease",
+			func() {
+				clusterName := setupClusterWithPendingDecrease("supervised-decrease-switchover")
+
+				// NOTE: we trigger the switchover by hand instead of reusing
+				// clusterasserts.AssertSwitchover because that helper ends by waiting
+				// for the cluster to reach PhaseHealthy. Here the decrease is still
+				// pending after the switchover, so the cluster stays in
+				// PhaseWaitingForUser; the regression we guard against is purely that
+				// the demoted old primary rejoins as a ready standby.
+				var oldPrimary, targetPrimary string
+				By("triggering a supervised switchover while the decrease is pending", func() {
+					cluster, err := clusterutils.Get(env.Ctx, env.Client, namespace, clusterName)
+					Expect(err).ToNot(HaveOccurred())
+					oldPrimary = cluster.Status.CurrentPrimary
+
+					podList, err := clusterutils.ListPods(env.Ctx, env.Client, namespace, clusterName)
+					Expect(err).ToNot(HaveOccurred())
+					pods := make([]string, 0, len(podList.Items))
+					for _, p := range podList.Items {
+						pods = append(pods, p.Name)
+					}
+					sort.Strings(pods)
+					Expect(pods[0]).To(BeEquivalentTo(oldPrimary))
+					targetPrimary = pods[1]
+
+					err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+						cluster, err := clusterutils.Get(env.Ctx, env.Client, namespace, clusterName)
+						if err != nil {
+							return err
+						}
+						cluster.Status.TargetPrimary = targetPrimary
+						return env.Client.Status().Update(env.Ctx, cluster)
+					})
+					Expect(err).ToNot(HaveOccurred())
+				})
+
+				By("waiting for the new primary to take over", func() {
+					Eventually(func(g Gomega) {
+						cluster, err := clusterutils.Get(env.Ctx, env.Client, namespace, clusterName)
+						g.Expect(err).ToNot(HaveOccurred())
+						g.Expect(cluster.Status.CurrentPrimary).To(BeEquivalentTo(targetPrimary))
+					}, testTimeouts[timeouts.NewPrimaryAfterSwitchover]).Should(Succeed())
+				})
+
+				// The regression for #10716: the demoted old primary must rejoin
+				// as a standby instead of looping on
+				// "recovery aborted because of insufficient parameter settings".
+				By("having the old primary rejoin as a ready standby", func() {
+					namespacedName := types.NamespacedName{Namespace: namespace, Name: oldPrimary}
+					Eventually(func() (bool, error) {
+						pod := corev1.Pod{}
+						err := env.Client.Get(env.Ctx, namespacedName, &pod)
+						return utils.IsPodActive(pod) && utils.IsPodReady(pod) && specs.IsPodStandby(pod), err
+					}, 180).Should(BeTrue())
+				})
+
+				By("not aborting recovery with insufficient parameter settings", func() {
+					// The demoted old primary must rejoin without ever logging the
+					// fatal recovery abort. We inspect both the current container
+					// logs and, when present, the previously terminated container:
+					// if the fix regressed, the failed standby start would surface
+					// "insufficient parameter settings" in one of the two.
+					const fatalAbort = "insufficient parameter settings"
+
+					assertNoAbort := func(logEntries []map[string]interface{}) {
+						for _, entry := range logEntries {
+							record, ok := entry["record"].(map[string]interface{})
+							if !ok {
+								continue
+							}
+							message, _ := record["message"].(string)
+							Expect(message).ToNot(ContainSubstring(fatalAbort))
+						}
+					}
+
+					currentLogs, err := logs.ParseJSONLogs(env.Ctx, env.Interface, namespace, oldPrimary)
+					Expect(err).ToNot(HaveOccurred())
+					assertNoAbort(currentLogs)
+
+					// Previous-container logs exist only if the container restarted.
+					// When the demoted primary came up clean there is nothing (or only
+					// the healthy old-primary container) to inspect, so a retrieval
+					// error here is not a failure; on a regression the crashed standby
+					// start is captured here even after the container restarted.
+					previousLogs, err := logs.ParseJSONLogsWithOptions(env.Ctx, env.Interface, namespace, oldPrimary,
+						&corev1.PodLogOptions{Previous: true})
+					if err == nil {
+						assertNoAbort(previousLogs)
+					}
+				})
+			})
+	})

--- a/tests/e2e/supervised_switchover_param_test.go
+++ b/tests/e2e/supervised_switchover_param_test.go
@@ -108,6 +108,49 @@ var _ = Describe("Supervised decrease of an enforced parameter", Serial,
 			return clusterName
 		}
 
+		It("asks for a primary restart (not a switchover) and converges after one", func() {
+			clusterName := setupClusterWithPendingDecrease("supervised-decrease-restart")
+
+			// The status must point the user to the action that actually
+			// converges the cluster: an in-place primary restart, not a switchover.
+			By("reporting that the user must restart the primary", func() {
+				cluster, err := clusterutils.Get(env.Ctx, env.Client, namespace, clusterName)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(cluster.Status.PhaseReason).To(ContainSubstring("restart of the primary instance"))
+			})
+
+			// The documented action for a decrease is an in-place restart of the
+			// primary. This is what `kubectl cnpg restart <cluster> <primary>`
+			// does for the primary: it sets the cluster phase to
+			// PhaseInplacePrimaryRestart, which the operator then performs.
+			By("requesting an in-place restart of the primary", func() {
+				err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+					cluster, err := clusterutils.Get(env.Ctx, env.Client, namespace, clusterName)
+					if err != nil {
+						return err
+					}
+					cluster.Status.Phase = apiv1.PhaseInplacePrimaryRestart
+					cluster.Status.PhaseReason = "Requested by the e2e test"
+					return env.Client.Status().Update(env.Ctx, cluster)
+				})
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			// After the restart the cluster must become ready again and every
+			// instance must run with the decreased value.
+			clusterasserts.AssertClusterIsReady(env, namespace, clusterName, testTimeouts[timeouts.ClusterIsReady])
+
+			By("every instance converged to max_connections=100", func() {
+				podList, err := clusterutils.ListPods(env.Ctx, env.Client, namespace, clusterName)
+				Expect(err).ToNot(HaveOccurred())
+				for i := range podList.Items {
+					Eventually(pgasserts.QueryMatchExpectationPredicate(env, &podList.Items[i],
+						postgres.PostgresDBName, "SHOW max_connections", "100"),
+						RetryTimeout).Should(Succeed())
+				}
+			})
+		})
+
 		It("does not abort recovery on the old primary if a switchover happens during the pending decrease",
 			func() {
 				clusterName := setupClusterWithPendingDecrease("supervised-decrease-switchover")

--- a/tests/utils/logs/logs.go
+++ b/tests/utils/logs/logs.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/pods"
@@ -39,8 +40,20 @@ func ParseJSONLogs(
 	kubeInterface kubernetes.Interface,
 	namespace string, podName string,
 ) ([]map[string]interface{}, error) {
+	return ParseJSONLogsWithOptions(ctx, kubeInterface, namespace, podName, &corev1.PodLogOptions{})
+}
+
+// ParseJSONLogsWithOptions returns the pod's logs of a given pod name honoring the
+// provided PodLogOptions (e.g. Previous: true to inspect a crashed container),
+// in the form of a list of JSON entries
+func ParseJSONLogsWithOptions(
+	ctx context.Context,
+	kubeInterface kubernetes.Interface,
+	namespace string, podName string,
+	options *corev1.PodLogOptions,
+) ([]map[string]interface{}, error) {
 	// Gather pod logs
-	podLogs, err := pods.Logs(ctx, kubeInterface, namespace, podName)
+	podLogs, err := pods.LogsWithOptions(ctx, kubeInterface, namespace, podName, options)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/utils/pods/pod.go
+++ b/tests/utils/pods/pod.go
@@ -119,7 +119,18 @@ func Logs(
 	kubeInterface kubernetes.Interface,
 	namespace, podName string,
 ) (string, error) {
-	req := kubeInterface.CoreV1().Pods(namespace).GetLogs(podName, &corev1.PodLogOptions{})
+	return LogsWithOptions(ctx, kubeInterface, namespace, podName, &corev1.PodLogOptions{})
+}
+
+// LogsWithOptions gathers pod logs honoring the given PodLogOptions (e.g. to
+// retrieve the logs of the previously terminated container via Previous: true)
+func LogsWithOptions(
+	ctx context.Context,
+	kubeInterface kubernetes.Interface,
+	namespace, podName string,
+	options *corev1.PodLogOptions,
+) (string, error) {
+	req := kubeInterface.CoreV1().Pods(namespace).GetLogs(podName, options)
 	podLogs, err := req.Stream(ctx)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
When a hot-standby-sensitive ("enforced") parameter such as `max_connections` is decreased in the spec under `primaryUpdateStrategy: supervised` and a switchover then happens, the demoted old primary cannot rejoin: it starts as a standby with the lower value while `pg_controldata` still holds the higher one, and PostgreSQL aborts recovery. The pod stays in `CrashLoopBackOff` and the only way out is to wipe its PVC and let CNPG re-bootstrap it.

```
FATAL:  recovery aborted because of insufficient parameter settings
DETAIL: max_connections = 100 is a lower setting than on the primary server, where its value was 150.
```

**Root cause.** `initialize()` runs `verifyParametersForFollower` before `verifyPgDataCoherenceForPrimary`. On the demoting pod `IsPrimary()` is still true at that point (`standby.signal` is written later, inside `Demote()`), so the follower parameter alignment short-circuits and never runs. `Demote()` only writes `standby.signal`/`primary_conninfo` and does not touch the enforced parameters, so the standby comes up with the decreased value and aborts recovery.

**Fix.**

- Align the enforced parameters from `pg_controldata` right after `Demote()` (both demotion branches of `verifyPgDataCoherenceForPrimary`), through a dedicated `alignEnforcedParametersForFollower`. It intentionally bypasses the `cnpg_initialized` startup-flag guard used by `verifyParametersForFollower`: a former primary that was never a follower has no such flag, so merely re-running `verifyParametersForFollower` after `Demote()` would short-circuit again and silently skip the alignment. Calling the alignment directly makes it run on the first standby start, before recovery begins.
- For a decrease under the supervised strategy, the `PhaseWaitingForUser` reason now points to an in-place primary restart instead of a switchover: a switchover does not converge a decrease (the promoted replica still carries the higher value, since followers are kept aligned upward), an in-place restart of the primary does.

Covered by a new e2e suite (`supervised_switchover_param_test.go`).

Closes #10716
