### PR TITLE
docs(monitoring): add operator reconcile-errors alert sample

### DIFF
--- a/docs/src/samples/monitoring/prometheusrule.yaml
+++ b/docs/src/samples/monitoring/prometheusrule.yaml
@@ -69,3 +69,14 @@ spec:
       for: 1m
       labels:
         severity: warning
+  - name: cnp-operator.rules
+    rules:
+    - alert: CNPGReconcileErrors
+      annotations:
+        description: The {{ $labels.controller }} controller of the CloudNativePG operator is failing to reconcile its resources.
+        summary: The CloudNativePG operator is failing to reconcile.
+      expr: |-
+        rate(controller_runtime_reconcile_errors_total{controller=~"cluster|backup|scheduled-backup|pooler|database|publication|subscription|plugin|imagecatalog|clusterimagecatalog"}[10m]) > 0
+      for: 10m
+      labels:
+        severity: warning


### PR DESCRIPTION
The sample `prometheusrule.yaml` only covers data-plane (Postgres) metrics. When the operator itself stops reconciling — for example when the barman-cloud plugin mTLS certificates are rotated by cert-manager but the operator/plugin pods do not hot-reload them (#7947), breaking gRPC plugin discovery — every `Cluster` goes `Ready=False` and scheduled backups silently stop, yet **none** of the existing `cnp-default.rules` fire: the Postgres pods stay `Running` and WAL archiving keeps working, so the data-plane alerts never trigger.

This adds a small sample alert group `cnp-operator.rules` with `CNPGReconcileErrors`, built on `controller_runtime_reconcile_errors_total` (already exposed by the operator) and scoped via the `controller` label to the CNPG controllers. In a recent incident this signal would have surfaced the problem within minutes, while the cluster-status and backup alerts stayed green.

The scoping is done by `controller` label rather than `job`/`namespace` to keep the sample portable; happy to switch to a job-based filter if that fits the docs conventions better.