### PR TITLE
fix(backup): recover backups orphaned in the started phase

### DIFF
--- a/internal/controller/backup_controller.go
+++ b/internal/controller/backup_controller.go
@@ -235,12 +235,15 @@ func (r *BackupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		return hookResult.Result, hookResult.Err
 	}
 
-	// A backup in the "started" phase has been handed over to the instance
-	// manager, and only its progress updates will generate new reconciliations.
-	// If the instance manager is restarted before the backup moves forward, no
-	// update will ever arrive, so check back to give isValidBackupRunning a
-	// chance to detect the lost backup; from then on the running-backup branch
-	// above keeps requeuing.
+	// A backup in the "started" phase advances only through the instance
+	// manager's progress updates. If the instance manager is restarted before
+	// the backup moves forward, for example during an operator in-place
+	// upgrade, no update arrives, so requeue to re-enter Reconcile. The
+	// isCurrentBackupRunning check above then re-validates the session and
+	// fails the backup if the instance manager is gone; otherwise the
+	// running-backup branch above takes over the requeuing. This relies on that
+	// check running before the start switch, and it is the only re-check for
+	// plugin backups, which never transition to the "running" phase.
 	if backup.Status.Phase == apiv1.BackupPhaseStarted {
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 	}

--- a/internal/controller/backup_controller.go
+++ b/internal/controller/backup_controller.go
@@ -208,7 +208,7 @@ func (r *BackupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 
 	switch {
 	case backup.Spec.Method.IsManagedByInstance():
-		res, err := r.startBackupManagedByInstance(ctx, cluster, backup)
+		res, err := r.startBackupManagedByInstance(ctx, cluster, &backup)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
@@ -231,37 +231,54 @@ func (r *BackupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	contextLogger.Debug(fmt.Sprintf("object %#q has been reconciled", req.NamespacedName))
 
 	hookResult := postReconcilePluginHooks(ctx, &cluster, &backup)
-	return hookResult.Result, hookResult.Err
+	if hookResult.Err != nil || !hookResult.Result.IsZero() {
+		return hookResult.Result, hookResult.Err
+	}
+
+	// A backup in the "started" phase has been handed over to the instance
+	// manager, and only its progress updates will generate new reconciliations.
+	// If the instance manager is restarted before the backup moves forward, no
+	// update will ever arrive, so check back to give isValidBackupRunning a
+	// chance to detect the lost backup; from then on the running-backup branch
+	// above keeps requeuing.
+	if backup.Status.Phase == apiv1.BackupPhaseStarted {
+		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+	}
+
+	return ctrl.Result{}, nil
 }
 
+// startBackupManagedByInstance receives the backup by pointer: it updates the
+// backup status as the start progresses, and the caller relies on seeing the
+// "started" phase to schedule the safety requeue at the end of Reconcile.
 func (r *BackupReconciler) startBackupManagedByInstance(
 	ctx context.Context,
 	cluster apiv1.Cluster,
-	backup apiv1.Backup,
+	backup *apiv1.Backup,
 ) (*ctrl.Result, error) {
 	contextLogger, ctx := log.SetupLogger(ctx)
 
 	origBackup := backup.DeepCopy()
 
 	// If no good running backups are found we elect a pod for the backup
-	podStatus, err := r.getBackupTargetPod(ctx, &cluster, &backup)
+	podStatus, err := r.getBackupTargetPod(ctx, &cluster, backup)
 	if apierrs.IsNotFound(err) ||
 		errors.Is(err, ErrPrimaryImageNeedsUpdate) ||
 		errors.Is(err, ErrInstanceStatusUnavailable) {
-		r.Recorder.Eventf(&backup, "Warning", "FindingPod",
+		r.Recorder.Eventf(backup, "Warning", "FindingPod",
 			"Couldn't find target pod %s, will retry in 30 seconds", cluster.Status.TargetPrimary)
 		contextLogger.Info("Couldn't find target pod, will retry in 30 seconds", "target",
 			cluster.Status.TargetPrimary)
 		backup.Status.SetAsPending()
-		if err := r.Status().Patch(ctx, &backup, client.MergeFrom(origBackup)); err != nil {
+		if err := r.Status().Patch(ctx, backup, client.MergeFrom(origBackup)); err != nil {
 			return nil, err
 		}
 		return &ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 	}
 
 	if err != nil {
-		_ = resourcestatus.FlagBackupAsFailed(ctx, r.Client, &backup, &cluster, fmt.Errorf("while getting pod: %w", err))
-		r.Recorder.Eventf(&backup, "Warning", "FindingPod", "Error getting target pod: %s",
+		_ = resourcestatus.FlagBackupAsFailed(ctx, r.Client, backup, &cluster, fmt.Errorf("while getting pod: %w", err))
+		r.Recorder.Eventf(backup, "Warning", "FindingPod", "Error getting target pod: %s",
 			cluster.Status.TargetPrimary)
 		return &ctrl.Result{}, reconcile.TerminalError(err)
 	}
@@ -272,9 +289,9 @@ func (r *BackupReconciler) startBackupManagedByInstance(
 	if !utils.IsPodReady(*pod) {
 		contextLogger.Info("Backup target is not ready, will retry in 30 seconds", "target", pod.Name)
 		backup.Status.SetAsPending()
-		r.Recorder.Eventf(&backup, "Warning", "BackupPending", "Backup target pod not ready: %s",
+		r.Recorder.Eventf(backup, "Warning", "BackupPending", "Backup target pod not ready: %s",
 			cluster.Status.TargetPrimary)
-		if err := r.Status().Patch(ctx, &backup, client.MergeFrom(origBackup)); err != nil {
+		if err := r.Status().Patch(ctx, backup, client.MergeFrom(origBackup)); err != nil {
 			return nil, err
 		}
 		return &ctrl.Result{RequeueAfter: 30 * time.Second}, nil
@@ -284,14 +301,14 @@ func (r *BackupReconciler) startBackupManagedByInstance(
 		"cluster", cluster.Name,
 		"pod", pod.Name)
 
-	r.Recorder.Eventf(&backup, "Normal", "Starting",
+	r.Recorder.Eventf(backup, "Normal", "Starting",
 		"Starting backup for cluster %v", cluster.Name)
 
 	// This backup can be started. The SessionID from podStatus is used to detect
 	// if the instance manager was restarted during the backup.
-	if err := startInstanceManagerBackup(ctx, r.Client, &backup, pod, &cluster, podStatus.SessionID); err != nil {
-		r.Recorder.Eventf(&backup, "Warning", "Error", "Backup exit with error %v", err)
-		_ = resourcestatus.FlagBackupAsFailed(ctx, r.Client, &backup, &cluster,
+	if err := startInstanceManagerBackup(ctx, r.Client, backup, pod, &cluster, podStatus.SessionID); err != nil {
+		r.Recorder.Eventf(backup, "Warning", "Error", "Backup exit with error %v", err)
+		_ = resourcestatus.FlagBackupAsFailed(ctx, r.Client, backup, &cluster,
 			fmt.Errorf("encountered an error while taking the backup: %w", err))
 		return &ctrl.Result{}, reconcile.TerminalError(err)
 	}

--- a/internal/controller/backup_controller_test.go
+++ b/internal/controller/backup_controller_test.go
@@ -35,6 +35,8 @@ import (
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	schemeBuilder "github.com/cloudnative-pg/cloudnative-pg/internal/scheme"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres/webserver/client/remote"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/postgres"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -209,8 +211,59 @@ var _ = Describe("backup_controller barmanObjectStore unit tests", func() {
 			Expect(err).To(HaveOccurred())
 			Expect(res).To(BeFalse())
 		})
+
+		It("failing the backup when the instance manager was restarted during it", func(ctx context.Context) {
+			backup.Spec.Method = apiv1.BackupMethodPlugin
+			backup.Status.Phase = apiv1.BackupPhaseStarted
+			backup.Status.InstanceID.SessionID = "session-before-restart"
+			env.backupReconciler.instanceStatusClient = &fakeInstanceStatusClient{
+				sessionID: "session-after-restart",
+			}
+
+			res, err := env.backupReconciler.isValidBackupRunning(ctx, backup, cluster)
+			Expect(err).To(HaveOccurred())
+			Expect(res).To(BeFalse())
+
+			var stored apiv1.Backup
+			Expect(env.client.Get(ctx, client.ObjectKeyFromObject(backup), &stored)).To(Succeed())
+			Expect(stored.Status.Phase).To(BeEquivalentTo(apiv1.BackupPhaseFailed))
+		})
+
+		It("considering the backup running when the instance manager session is unchanged", func(ctx context.Context) {
+			backup.Spec.Method = apiv1.BackupMethodPlugin
+			backup.Status.InstanceID.SessionID = "session-stable"
+			env.backupReconciler.instanceStatusClient = &fakeInstanceStatusClient{
+				sessionID: "session-stable",
+			}
+
+			res, err := env.backupReconciler.isValidBackupRunning(ctx, backup, cluster)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(res).To(BeTrue())
+		})
 	})
 })
+
+// fakeInstanceStatusClient reports a fixed instance manager session ID for
+// every queried pod. The other InstanceClient methods are inherited from the
+// embedded nil interface and panic if called.
+type fakeInstanceStatusClient struct {
+	remote.InstanceClient
+	sessionID string
+}
+
+func (f *fakeInstanceStatusClient) GetStatusFromInstances(
+	_ context.Context,
+	pods corev1.PodList,
+) postgres.PostgresqlStatusList {
+	items := make([]postgres.PostgresqlStatus, 0, len(pods.Items))
+	for i := range pods.Items {
+		items = append(items, postgres.PostgresqlStatus{
+			Pod:       &pods.Items[i],
+			SessionID: f.sessionID,
+		})
+	}
+	return postgres.PostgresqlStatusList{Items: items}
+}
 
 var _ = Describe("backup_controller volumeSnapshot unit tests", func() {
 	When("there's a running backup", func() {

--- a/internal/controller/backup_predicates.go
+++ b/internal/controller/backup_predicates.go
@@ -35,34 +35,41 @@ import (
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 )
 
+// clusterCanHaveBackups tells whether a cluster can be the target of backups:
+// either it has an in-core backup configuration or its backups are managed
+// through a CNPG-I plugin, which requires no backup section.
+func clusterCanHaveBackups(cluster *apiv1.Cluster) bool {
+	return cluster.Spec.Backup != nil || len(cluster.Spec.Plugins) > 0
+}
+
 var clustersWithBackupPredicate = predicate.Funcs{
 	CreateFunc: func(e event.CreateEvent) bool {
 		cluster, ok := e.Object.(*apiv1.Cluster)
 		if !ok {
 			return false
 		}
-		return cluster.Spec.Backup != nil
+		return clusterCanHaveBackups(cluster)
 	},
 	DeleteFunc: func(e event.DeleteEvent) bool {
 		cluster, ok := e.Object.(*apiv1.Cluster)
 		if !ok {
 			return false
 		}
-		return cluster.Spec.Backup != nil
+		return clusterCanHaveBackups(cluster)
 	},
 	GenericFunc: func(e event.GenericEvent) bool {
 		cluster, ok := e.Object.(*apiv1.Cluster)
 		if !ok {
 			return false
 		}
-		return cluster.Spec.Backup != nil
+		return clusterCanHaveBackups(cluster)
 	},
 	UpdateFunc: func(e event.UpdateEvent) bool {
 		cluster, ok := e.ObjectNew.(*apiv1.Cluster)
 		if !ok {
 			return false
 		}
-		return cluster.Spec.Backup != nil
+		return clusterCanHaveBackups(cluster)
 	},
 }
 
@@ -72,28 +79,35 @@ func (r *BackupReconciler) mapClustersToBackup() handler.MapFunc {
 		if !ok {
 			return nil
 		}
-		var backups apiv1.BackupList
-		err := r.List(ctx, &backups,
-			client.MatchingFields{
-				backupPhase: apiv1.BackupPhaseRunning,
-			},
-			client.InNamespace(cluster.GetNamespace()))
-		if err != nil {
-			log.FromContext(ctx).Error(err, "while getting running backups for cluster", "cluster", cluster.GetName())
-		}
 		var requests []reconcile.Request
-		for _, backup := range backups.Items {
-			if backup.Spec.Cluster.Name == cluster.Name {
+		// Backups in the "started" phase are included because the instance
+		// manager running them may die before they move to "running"; a
+		// cluster event is then the earliest chance to detect the loss.
+		for _, phase := range []string{apiv1.BackupPhaseStarted, apiv1.BackupPhaseRunning} {
+			var backups apiv1.BackupList
+			err := r.List(ctx, &backups,
+				client.MatchingFields{
+					backupPhase: phase,
+				},
+				client.InNamespace(cluster.GetNamespace()))
+			if err != nil {
+				log.FromContext(ctx).Error(err, "while getting in-progress backups for cluster",
+					"cluster", cluster.GetName(), "phase", phase)
 				continue
 			}
-			requests = append(requests,
-				reconcile.Request{
-					NamespacedName: types.NamespacedName{
-						Name:      backup.Name,
-						Namespace: backup.Namespace,
+			for i := range backups.Items {
+				if backups.Items[i].Spec.Cluster.Name != cluster.Name {
+					continue
+				}
+				requests = append(requests,
+					reconcile.Request{
+						NamespacedName: types.NamespacedName{
+							Name:      backups.Items[i].Name,
+							Namespace: backups.Items[i].Namespace,
+						},
 					},
-				},
-			)
+				)
+			}
 		}
 		return requests
 	}

--- a/internal/controller/backup_predicates_test.go
+++ b/internal/controller/backup_predicates_test.go
@@ -22,13 +22,80 @@ package controller
 import (
 	volumesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
+
+var _ = Describe("clustersWithBackupPredicate", func() {
+	It("matches clusters with an in-core backup configuration", func() {
+		cluster := &apiv1.Cluster{
+			Spec: apiv1.ClusterSpec{
+				Backup: &apiv1.BackupConfiguration{},
+			},
+		}
+		Expect(clustersWithBackupPredicate.Update(event.UpdateEvent{ObjectNew: cluster})).To(BeTrue())
+	})
+
+	It("matches clusters whose backups are managed through a plugin", func() {
+		cluster := &apiv1.Cluster{
+			Spec: apiv1.ClusterSpec{
+				Plugins: []apiv1.PluginConfiguration{{Name: "barman-cloud.cloudnative-pg.io"}},
+			},
+		}
+		Expect(clustersWithBackupPredicate.Create(event.CreateEvent{Object: cluster})).To(BeTrue())
+		Expect(clustersWithBackupPredicate.Update(event.UpdateEvent{ObjectNew: cluster})).To(BeTrue())
+		Expect(clustersWithBackupPredicate.Delete(event.DeleteEvent{Object: cluster})).To(BeTrue())
+		Expect(clustersWithBackupPredicate.Generic(event.GenericEvent{Object: cluster})).To(BeTrue())
+	})
+
+	It("ignores clusters with no backup configuration at all", func() {
+		cluster := &apiv1.Cluster{}
+		Expect(clustersWithBackupPredicate.Update(event.UpdateEvent{ObjectNew: cluster})).To(BeFalse())
+	})
+})
+
+var _ = Describe("mapClustersToBackup", func() {
+	var env *testingEnvironment
+	BeforeEach(func() {
+		env = buildTestEnvironment()
+	})
+
+	It("enqueues the started and running backups of the cluster that changed and no others", func(ctx SpecContext) {
+		ns := newFakeNamespace(env.client)
+		clusterA := newFakeCNPGCluster(env.client, ns)
+		clusterB := newFakeCNPGCluster(env.client, ns)
+
+		createBackupWithPhase := func(name, clusterName string, phase apiv1.BackupPhase) {
+			backup := &apiv1.Backup{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+				Spec: apiv1.BackupSpec{
+					Cluster: apiv1.LocalObjectReference{Name: clusterName},
+				},
+			}
+			Expect(env.client.Create(ctx, backup)).To(Succeed())
+			backup.Status.Phase = phase
+			Expect(env.client.Status().Update(ctx, backup)).To(Succeed())
+		}
+
+		createBackupWithPhase("backup-a-running", clusterA.Name, apiv1.BackupPhaseRunning)
+		createBackupWithPhase("backup-a-started", clusterA.Name, apiv1.BackupPhaseStarted)
+		createBackupWithPhase("backup-a-completed", clusterA.Name, apiv1.BackupPhaseCompleted)
+		createBackupWithPhase("backup-b-running", clusterB.Name, apiv1.BackupPhaseRunning)
+
+		requests := env.backupReconciler.mapClustersToBackup()(ctx, clusterA)
+		Expect(requests).To(ConsistOf(
+			reconcile.Request{NamespacedName: types.NamespacedName{Namespace: ns, Name: "backup-a-running"}},
+			reconcile.Request{NamespacedName: types.NamespacedName{Namespace: ns, Name: "backup-a-started"}},
+		))
+	})
+})
 
 var _ = Describe("backup_controller volumeSnapshots predicates", func() {
 	Context("volumeSnapshotHasBackuplabel and relative predicate", func() {

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -82,6 +82,9 @@ func buildTestEnvironment() *testingEnvironment {
 		WithIndex(&apiv1.Backup{}, ".spec.cluster.name", func(rawObj client.Object) []string {
 			return []string{rawObj.(*apiv1.Backup).Spec.Cluster.Name}
 		}).
+		WithIndex(&apiv1.Backup{}, backupPhase, func(rawObj client.Object) []string {
+			return []string{string(rawObj.(*apiv1.Backup).Status.Phase)}
+		}).
 		Build()
 	Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
A backup in the "started" phase only moves forward through the status updates of the instance manager that is running it. When that instance manager is restarted before the backup reaches the "running" phase, for example by the in-place upgrade that follows an operator upgrade, no update ever arrives and nothing reschedules the backup: the controller scheduled no requeue after starting it, and the watch on clusters could not re-enqueue it either, so the backup stayed in the "started" phase and the session ID check introduced by #9370 never had a chance to run.

Requeue the reconciliation while a backup is in the "started" phase so the lost instance manager session is detected and the backup is marked as failed. The backup is now passed to startBackupManagedByInstance by pointer so the phase transition stays visible to that check.

The cluster-to-backup mapper, the other path that could have re-enqueued the backup, had two further problems. It enqueued the running backups of every cluster in the namespace except the one that actually changed, so invert that condition; and it only considered "running" backups, so include "started" ones too, since the cluster event from the failure that orphaned the backup is the earliest chance to detect it. The predicate gating those events only matched clusters with an in-core backup section, which clusters backed up through a CNPG-I plugin do not have; match those too.
