### PR TITLE
chore: fix renovate linter validation error

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -176,7 +176,6 @@
         'major',
       ],
       matchPackageNames: [
-        '*',
         '!k8s.io{/,}**',
         '!sigs.k8s.io{/,}**',
         '!github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring{/,}**',
@@ -193,7 +192,6 @@
       ],
       groupName: 'all non-major go dependencies',
       matchPackageNames: [
-        '*',
         '!k8s.io{/,}**',
         '!sigs.k8s.io{/,}**',
         '!github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring{/,}**',


### PR DESCRIPTION
Removed standalone `*` pattern mixed with other negation patterns in `matchPackageNames` for two `packageRules` entries.
The linter was complaining because negation-only patterns already implicitly match everything except the negated ones.

From https://docs.renovatebot.com/string-pattern-matching/#special-case-match-everything:
> The value * is a special case which means "match everything". It is not valid to combine * with any other positive or negative match.