### PR TITLE
fix: drop only objects the deleted CR actually reconciled

### DIFF
--- a/internal/management/controller/database_controller.go
+++ b/internal/management/controller/database_controller.go
@@ -188,6 +188,7 @@ func (r *DatabaseReconciler) evaluateDropDatabase(ctx context.Context, db *apiv1
 	if db.Spec.ReclaimPolicy != apiv1.DatabaseReclaimDelete {
 		return nil
 	}
+
 	// On a replica we cannot drop the database: return without touching
 	// PostgreSQL so the finalizer is released. Dropping it is left to the
 	// primary cluster's own Database object, if any.
@@ -198,6 +199,14 @@ func (r *DatabaseReconciler) evaluateDropDatabase(ctx context.Context, db *apiv1
 	if cluster.IsReplica() {
 		return nil
 	}
+
+	// An object that never reconciled does not own the database: a
+	// conflicting duplicate is blocked before applying anything, and its
+	// deletion must not drop the database owned by the surviving object.
+	if !db.HasReconciliations() {
+		return nil
+	}
+
 	sqlDB, err := r.getSuperUserDB()
 	if err != nil {
 		return fmt.Errorf("while getting DB connection: %w", err)

--- a/internal/management/controller/database_controller_test.go
+++ b/internal/management/controller/database_controller_test.go
@@ -204,6 +204,22 @@ var _ = Describe("Managed Database status", func() {
 		})
 	})
 
+	When("reclaim policy is delete but the object never reconciled", func() {
+		It("on deletion it removes finalizers and does NOT drop the DB", func(ctx SpecContext) {
+			// Model the state of a conflicting duplicate: it carries the
+			// finalizer, but the exclusivity check blocked it before it could
+			// apply anything, so it has no recorded reconciliation.
+			database.Finalizers = []string{utils.DatabaseFinalizerName}
+			Expect(fakeClient.Update(ctx, database)).To(Succeed())
+			Expect(fakeClient.Delete(ctx, database)).To(Succeed())
+
+			// No SQL is expected: dbMock would fail on any statement.
+			err := reconcileDatabase(ctx, fakeClient, r, database)
+			Expect(err).To(HaveOccurred())
+			Expect(apierrors.IsNotFound(err)).To(BeTrue())
+		})
+	})
+
 	When("reclaim policy is retain", func() {
 		It("on deletion it removes finalizers and does NOT drop the DB", func(ctx SpecContext) {
 			database.Spec.ReclaimPolicy = apiv1.DatabaseReclaimRetain

--- a/internal/management/controller/publication_controller.go
+++ b/internal/management/controller/publication_controller.go
@@ -167,6 +167,7 @@ func (r *PublicationReconciler) evaluateDropPublication(ctx context.Context, pub
 	if pub.Spec.ReclaimPolicy != apiv1.PublicationReclaimDelete {
 		return nil
 	}
+
 	// On a replica we cannot drop the publication: return without touching
 	// PostgreSQL so the finalizer is released. Dropping it is left to the
 	// primary cluster's own Publication object, if any.
@@ -177,6 +178,14 @@ func (r *PublicationReconciler) evaluateDropPublication(ctx context.Context, pub
 	if cluster.IsReplica() {
 		return nil
 	}
+
+	// An object that never reconciled does not own the publication: a
+	// conflicting duplicate is blocked before applying anything, and its
+	// deletion must not drop the publication owned by the surviving object.
+	if !pub.HasReconciliations() {
+		return nil
+	}
+
 	db, err := r.getDB(pub.Spec.DBName)
 	if err != nil {
 		return fmt.Errorf("while getting DB connection: %w", err)

--- a/internal/management/controller/publication_controller_test.go
+++ b/internal/management/controller/publication_controller_test.go
@@ -206,6 +206,22 @@ var _ = Describe("Managed publication controller tests", func() {
 		})
 	})
 
+	When("reclaim policy is delete but the object never reconciled", func() {
+		It("on deletion it removes finalizers and does NOT drop the Publication", func(ctx SpecContext) {
+			// Model the state of a conflicting duplicate: it carries the
+			// finalizer, but the exclusivity check blocked it before it could
+			// apply anything, so it has no recorded reconciliation.
+			publication.Finalizers = []string{utils.PublicationFinalizerName}
+			Expect(fakeClient.Update(ctx, publication)).To(Succeed())
+			Expect(fakeClient.Delete(ctx, publication)).To(Succeed())
+
+			// No SQL is expected: dbMock would fail on any statement.
+			err := reconcilePublication(ctx, fakeClient, r, publication)
+			Expect(err).To(HaveOccurred())
+			Expect(apierrors.IsNotFound(err)).To(BeTrue())
+		})
+	})
+
 	When("reclaim policy is retain", func() {
 		It("on deletion it removes finalizers and does NOT drop the Publication", func(ctx SpecContext) {
 			publication.Spec.ReclaimPolicy = apiv1.PublicationReclaimRetain

--- a/internal/management/controller/subscription_controller.go
+++ b/internal/management/controller/subscription_controller.go
@@ -175,6 +175,7 @@ func (r *SubscriptionReconciler) evaluateDropSubscription(ctx context.Context, s
 	if sub.Spec.ReclaimPolicy != apiv1.SubscriptionReclaimDelete {
 		return nil
 	}
+
 	// On a replica we cannot drop the subscription: return without touching
 	// PostgreSQL so the finalizer is released. Dropping it is left to the
 	// primary cluster's own Subscription object, if any.
@@ -185,6 +186,14 @@ func (r *SubscriptionReconciler) evaluateDropSubscription(ctx context.Context, s
 	if cluster.IsReplica() {
 		return nil
 	}
+
+	// An object that never reconciled does not own the subscription: a
+	// conflicting duplicate is blocked before applying anything, and its
+	// deletion must not drop the subscription owned by the surviving object.
+	if !sub.HasReconciliations() {
+		return nil
+	}
+
 	db, err := r.getDB(sub.Spec.DBName)
 	if err != nil {
 		return fmt.Errorf("while getting DB connection: %w", err)

--- a/internal/management/controller/subscription_controller_test.go
+++ b/internal/management/controller/subscription_controller_test.go
@@ -236,6 +236,22 @@ var _ = Describe("Managed subscription controller tests", func() {
 		})
 	})
 
+	When("reclaim policy is delete but the object never reconciled", func() {
+		It("on deletion it removes finalizers and does NOT drop the subscription", func(ctx SpecContext) {
+			// Model the state of a conflicting duplicate: it carries the
+			// finalizer, but the exclusivity check blocked it before it could
+			// apply anything, so it has no recorded reconciliation.
+			subscription.Finalizers = []string{utils.SubscriptionFinalizerName}
+			Expect(fakeClient.Update(ctx, subscription)).To(Succeed())
+			Expect(fakeClient.Delete(ctx, subscription)).To(Succeed())
+
+			// No SQL is expected: dbMock would fail on any statement.
+			err := reconcileSubscription(ctx, fakeClient, r, subscription)
+			Expect(err).To(HaveOccurred())
+			Expect(apierrors.IsNotFound(err)).To(BeTrue())
+		})
+	})
+
 	When("reclaim policy is retain", func() {
 		It("on deletion it removes finalizers and does NOT drop the subscription", func(ctx SpecContext) {
 			subscription.Spec.ReclaimPolicy = apiv1.SubscriptionReclaimRetain


### PR DESCRIPTION
A conflicting duplicate Database or Subscription acquires the finalizer before the exclusivity check blocks it, so deleting it with a delete reclaim policy dropped the object owned by the surviving CR. Gate the drop on a recorded reconciliation, the same signal the exclusivity check uses. The Publication controller checks conflicts before adding the finalizer, but its drop hook gets the same guard for consistency and defense in depth.

Closes #10866

Assisted-by: Claude
