### PR TITLE
fix: re-evaluate applied objects after the cluster is demoted

### DIFF
--- a/api/v1/database_funcs.go
+++ b/api/v1/database_funcs.go
@@ -48,6 +48,11 @@ func (db *Database) GetStatusMessage() string {
 	return db.Status.Message
 }
 
+// GetStatusApplied returns the applied status of the database
+func (db *Database) GetStatusApplied() *bool {
+	return db.Status.Applied
+}
+
 // GetClusterRef returns the cluster reference of the database
 func (db *Database) GetClusterRef() corev1.LocalObjectReference {
 	return db.Spec.ClusterRef

--- a/api/v1/publication_funcs.go
+++ b/api/v1/publication_funcs.go
@@ -48,6 +48,11 @@ func (pub *Publication) GetStatusMessage() string {
 	return pub.Status.Message
 }
 
+// GetStatusApplied returns the applied status of the publication
+func (pub *Publication) GetStatusApplied() *bool {
+	return pub.Status.Applied
+}
+
 // GetClusterRef returns the cluster reference of the publication
 func (pub *Publication) GetClusterRef() corev1.LocalObjectReference {
 	return pub.Spec.ClusterRef

--- a/api/v1/subscription_funcs.go
+++ b/api/v1/subscription_funcs.go
@@ -48,6 +48,11 @@ func (sub *Subscription) GetStatusMessage() string {
 	return sub.Status.Message
 }
 
+// GetStatusApplied returns the applied status of the subscription
+func (sub *Subscription) GetStatusApplied() *bool {
+	return sub.Status.Applied
+}
+
 // GetClusterRef returns the cluster reference of the subscription
 func (sub *Subscription) GetClusterRef() corev1.LocalObjectReference {
 	return sub.Spec.ClusterRef

--- a/internal/management/controller/common.go
+++ b/internal/management/controller/common.go
@@ -86,24 +86,57 @@ func markAsUnknown(
 	return cli.Status().Update(ctx, resource)
 }
 
-type markableAsUnknownAndForgettable interface {
+type replicaTransitionAware interface {
 	markableAsUnknown
-	SetStatusObservedGeneration(obsGeneration int64)
+	GetStatusApplied() *bool
 }
 
-// markAsUnknownAndForget reports the replica condition on an object that was
-// applied before its cluster was demoted, and voids the recorded
-// reconciliation so the object is evaluated again once the cluster is
-// promoted back to primary.
-func markAsUnknownAndForget(
+// handleReplicaRoleTransition decides what to do with a resource whose
+// current generation has already been reconciled, reacting to its cluster
+// moving in or out of the replica role.
+//
+// When the cluster is demoted, the designated primary reports the replica
+// condition on the resource, keeping the recorded reconciliation so the
+// resource retains the ownership of the Postgres object it manages. When the
+// cluster is promoted back (or the last evaluation didn't succeed), it asks
+// the caller to evaluate the resource again by returning proceed=true; the
+// regular reconciliation flow then decides which pod acts.
+func handleReplicaRoleTransition(
 	ctx context.Context,
 	cli client.Client,
-	resource markableAsUnknownAndForgettable,
-	err error,
-) error {
-	resource.SetAsUnknown(err)
-	resource.SetStatusObservedGeneration(0)
-	return cli.Status().Update(ctx, resource)
+	instance instanceInterface,
+	cluster *apiv1.Cluster,
+	resource replicaTransitionAware,
+	requeueAfter time.Duration,
+) (result ctrl.Result, proceed bool, err error) {
+	if !resource.GetDeletionTimestamp().IsZero() {
+		return ctrl.Result{}, false, nil
+	}
+
+	applied := resource.GetStatusApplied()
+
+	if !cluster.IsReplica() {
+		proceed := applied == nil || !*applied
+		return ctrl.Result{}, proceed, nil
+	}
+
+	isDesignatedPrimary := cluster.Status.CurrentPrimary == instance.GetPodName()
+
+	if isDesignatedPrimary && applied != nil {
+		if err := markAsUnknown(ctx, cli, resource, errClusterIsReplica); err != nil {
+			return ctrl.Result{}, false, err
+		}
+	}
+
+	// Keep polling while the designated primary awaits the promotion, or
+	// while the primary recorded in the cluster status is still settling
+	// (e.g. a failover concurrent with the demotion): status-only updates
+	// don't retrigger the cluster watch.
+	if isDesignatedPrimary || applied != nil {
+		return ctrl.Result{RequeueAfter: requeueAfter}, false, nil
+	}
+
+	return ctrl.Result{}, false, nil
 }
 
 type markableAsReady interface {

--- a/internal/management/controller/common.go
+++ b/internal/management/controller/common.go
@@ -32,9 +32,13 @@ import (
 	"github.com/cloudnative-pg/machinery/pkg/log"
 	"github.com/jackc/pgx/v5"
 	"github.com/lib/pq"
+	corev1 "k8s.io/api/core/v1"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 )
@@ -82,6 +86,26 @@ func markAsUnknown(
 	return cli.Status().Update(ctx, resource)
 }
 
+type markableAsUnknownAndForgettable interface {
+	markableAsUnknown
+	SetStatusObservedGeneration(obsGeneration int64)
+}
+
+// markAsUnknownAndForget reports the replica condition on an object that was
+// applied before its cluster was demoted, and voids the recorded
+// reconciliation so the object is evaluated again once the cluster is
+// promoted back to primary.
+func markAsUnknownAndForget(
+	ctx context.Context,
+	cli client.Client,
+	resource markableAsUnknownAndForgettable,
+	err error,
+) error {
+	resource.SetAsUnknown(err)
+	resource.SetStatusObservedGeneration(0)
+	return cli.Status().Update(ctx, resource)
+}
+
 type markableAsReady interface {
 	client.Object
 	SetAsReady()
@@ -95,6 +119,59 @@ func markAsReady(
 ) error {
 	resource.SetAsReady()
 	return cli.Status().Update(ctx, resource)
+}
+
+// clusterScopedResource is a resource bound to a Cluster through a local
+// object reference.
+type clusterScopedResource interface {
+	client.Object
+	GetClusterRef() corev1.LocalObjectReference
+}
+
+// mapClusterToManagedResources builds a watch mapper that enqueues every item
+// of the given list type targeting this instance's cluster, to react to
+// cluster spec changes (e.g. a demotion to replica).
+func mapClusterToManagedResources(
+	instance instanceInterface,
+	cli client.Client,
+	newList func() client.ObjectList,
+) handler.MapFunc {
+	return func(ctx context.Context, obj client.Object) []reconcile.Request {
+		if obj.GetName() != instance.GetClusterName() ||
+			obj.GetNamespace() != instance.GetNamespaceName() {
+			return nil
+		}
+
+		list := newList()
+		if err := cli.List(ctx, list, client.InNamespace(obj.GetNamespace())); err != nil {
+			log.FromContext(ctx).Error(err, "while listing resources to react to a cluster change",
+				"kind", fmt.Sprintf("%T", list))
+			return nil
+		}
+
+		items, err := apimeta.ExtractList(list)
+		if err != nil {
+			log.FromContext(ctx).Error(err, "while extracting the resource list",
+				"kind", fmt.Sprintf("%T", list))
+			return nil
+		}
+
+		requests := make([]reconcile.Request, 0, len(items))
+		for _, item := range items {
+			resource, ok := item.(clusterScopedResource)
+			if !ok || resource.GetClusterRef().Name != obj.GetName() {
+				continue
+			}
+			requests = append(requests, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: resource.GetNamespace(),
+					Name:      resource.GetName(),
+				},
+			})
+		}
+
+		return requests
+	}
 }
 
 func getClusterFromInstance(

--- a/internal/management/controller/database_controller.go
+++ b/internal/management/controller/database_controller.go
@@ -126,19 +126,14 @@ func (r *DatabaseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 
 	// If everything is reconciled, we're done here
 	if database.Generation == database.Status.ObservedGeneration {
-		// ...unless the cluster was demoted to a replica after the database
-		// was applied: report the replica condition and void the recorded
-		// reconciliation, so the database is evaluated again once the
-		// cluster is promoted back to primary.
-		if database.DeletionTimestamp.IsZero() &&
-			cluster.Status.CurrentPrimary == r.instance.GetPodName() &&
-			cluster.IsReplica() {
-			if err := markAsUnknownAndForget(ctx, r.Client, &database, errClusterIsReplica); err != nil {
-				return ctrl.Result{}, err
-			}
-			return ctrl.Result{RequeueAfter: databaseReconciliationInterval}, nil
+		// ...unless the cluster moved in or out of the replica role after
+		// the database was applied: report the demotion on the status, and
+		// evaluate the database again after the promotion.
+		result, proceed, err := handleReplicaRoleTransition(
+			ctx, r.Client, r.instance, cluster, &database, databaseReconciliationInterval)
+		if err != nil || !proceed {
+			return result, err
 		}
-		return ctrl.Result{}, nil
 	}
 
 	contextLogger.Info("Reconciling database")

--- a/internal/management/controller/database_controller.go
+++ b/internal/management/controller/database_controller.go
@@ -121,6 +121,11 @@ func (r *DatabaseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	// Fetch the Cluster from the cache
 	cluster, err := r.GetCluster(ctx)
 	if err != nil {
+		// A reconciled database keeps its status: the cluster may be gone
+		// or unreadable while it is being deleted.
+		if database.Generation == database.Status.ObservedGeneration {
+			return ctrl.Result{}, client.IgnoreNotFound(err)
+		}
 		return ctrl.Result{}, markAsFailed(ctx, r.Client, &database, fmt.Errorf("while fetching the cluster: %w", err))
 	}
 

--- a/internal/management/controller/database_controller.go
+++ b/internal/management/controller/database_controller.go
@@ -28,8 +28,11 @@ import (
 	"github.com/cloudnative-pg/machinery/pkg/log"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres"
@@ -115,15 +118,27 @@ func (r *DatabaseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		return ctrl.Result{}, nil
 	}
 
-	// If everything is reconciled, we're done here
-	if database.Generation == database.Status.ObservedGeneration {
-		return ctrl.Result{}, nil
-	}
-
 	// Fetch the Cluster from the cache
 	cluster, err := r.GetCluster(ctx)
 	if err != nil {
 		return ctrl.Result{}, markAsFailed(ctx, r.Client, &database, fmt.Errorf("while fetching the cluster: %w", err))
+	}
+
+	// If everything is reconciled, we're done here
+	if database.Generation == database.Status.ObservedGeneration {
+		// ...unless the cluster was demoted to a replica after the database
+		// was applied: report the replica condition and void the recorded
+		// reconciliation, so the database is evaluated again once the
+		// cluster is promoted back to primary.
+		if database.DeletionTimestamp.IsZero() &&
+			cluster.Status.CurrentPrimary == r.instance.GetPodName() &&
+			cluster.IsReplica() {
+			if err := markAsUnknownAndForget(ctx, r.Client, &database, errClusterIsReplica); err != nil {
+				return ctrl.Result{}, err
+			}
+			return ctrl.Result{RequeueAfter: databaseReconciliationInterval}, nil
+		}
+		return ctrl.Result{}, nil
 	}
 
 	contextLogger.Info("Reconciling database")
@@ -244,6 +259,13 @@ func NewDatabaseReconciler(
 func (r *DatabaseReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&apiv1.Database{}).
+		Watches(
+			&apiv1.Cluster{},
+			handler.EnqueueRequestsFromMapFunc(mapClusterToManagedResources(
+				r.instance, mgr.GetClient(),
+				func() client.ObjectList { return &apiv1.DatabaseList{} })),
+			builder.WithPredicates(predicate.GenerationChangedPredicate{}),
+		).
 		Named("instance-database").
 		Complete(r)
 }

--- a/internal/management/controller/database_controller_test.go
+++ b/internal/management/controller/database_controller_test.go
@@ -596,6 +596,37 @@ var _ = Describe("Managed Database status", func() {
 		Expect(dbDuplicate.Status.Message).To(ContainSubstring(expectedError))
 	})
 
+	// The cluster-fetch behavior is identical across the three
+	// managed-object controllers, and so are its tests.
+	It("keeps a reconciled database status when the cluster cannot be fetched", func(ctx SpecContext) { //nolint:dupl
+		database.Status.Applied = ptr.To(true)
+		database.Status.ObservedGeneration = database.Generation
+		Expect(fakeClient.Status().Update(ctx, database)).To(Succeed())
+
+		Expect(fakeClient.Delete(ctx, cluster)).To(Succeed())
+
+		result, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{
+			Namespace: database.GetNamespace(),
+			Name:      database.GetName(),
+		}})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result).To(Equal(ctrl.Result{}))
+
+		Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(database), database)).To(Succeed())
+		Expect(database.Status.Applied).To(HaveValue(BeTrue()))
+		Expect(database.Status.Message).To(BeEmpty())
+	})
+
+	It("marks an unreconciled database as failed when the cluster cannot be fetched", func(ctx SpecContext) {
+		Expect(fakeClient.Delete(ctx, cluster)).To(Succeed())
+
+		err := reconcileDatabase(ctx, fakeClient, r, database)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(database.Status.Applied).To(HaveValue(BeFalse()))
+		Expect(database.Status.Message).To(ContainSubstring("while fetching the cluster"))
+	})
+
 	It("enqueues only the Databases of this instance's cluster on cluster events", func(ctx SpecContext) {
 		mapFn := mapClusterToManagedResources(r.instance, fakeClient,
 			func() client.ObjectList { return &apiv1.DatabaseList{} })

--- a/internal/management/controller/database_controller_test.go
+++ b/internal/management/controller/database_controller_test.go
@@ -436,7 +436,7 @@ var _ = Describe("Managed Database status", func() {
 
 	// The demotion behavior is identical across the three managed-object
 	// controllers, and so are its tests.
-	It("voids the recorded reconciliation when the cluster is demoted after apply", func(ctx SpecContext) { //nolint:dupl
+	It("reports the replica condition when the cluster is demoted after apply", func(ctx SpecContext) { //nolint:dupl
 		database.Status.Applied = ptr.To(true)
 		database.Status.ObservedGeneration = database.Generation
 		Expect(fakeClient.Status().Update(ctx, database)).To(Succeed())
@@ -457,7 +457,9 @@ var _ = Describe("Managed Database status", func() {
 		Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(database), database)).To(Succeed())
 		Expect(database.Status.Applied).To(BeNil())
 		Expect(database.Status.Message).To(ContainSubstring("waiting for the cluster to become primary"))
-		Expect(database.Status.ObservedGeneration).To(BeZero())
+		// the recorded reconciliation is kept, so the database retains the
+		// ownership of the managed Postgres database
+		Expect(database.Status.ObservedGeneration).To(Equal(database.Generation))
 	})
 
 	It("keeps an applied database untouched on pods other than the designated primary", func(ctx SpecContext) {
@@ -479,42 +481,135 @@ var _ = Describe("Managed Database status", func() {
 			Name:      database.GetName(),
 		}})
 		Expect(err).ToNot(HaveOccurred())
-		Expect(result).To(Equal(ctrl.Result{}))
+		// the demotion may be racing a failover: poll until the designated
+		// primary has reported the replica condition
+		Expect(result.RequeueAfter).To(Equal(databaseReconciliationInterval))
 
 		Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(database), database)).To(Succeed())
 		Expect(database.Status.Applied).To(HaveValue(BeTrue()))
 		Expect(database.Status.ObservedGeneration).NotTo(BeZero())
 	})
 
+	It("re-applies a database when the cluster is promoted back", func(ctx SpecContext) {
+		database.Status.Applied = ptr.To(true)
+		database.Status.ObservedGeneration = database.Generation
+		Expect(fakeClient.Status().Update(ctx, database)).To(Succeed())
+
+		initialCluster := cluster.DeepCopy()
+		cluster.Spec.ReplicaCluster = &apiv1.ReplicaClusterConfiguration{
+			Enabled: ptr.To(true),
+		}
+		Expect(fakeClient.Patch(ctx, cluster, client.MergeFrom(initialCluster))).To(Succeed())
+
+		err := reconcileDatabase(ctx, fakeClient, r, database)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(database.Status.Applied).To(BeNil())
+
+		demotedCluster := cluster.DeepCopy()
+		cluster.Spec.ReplicaCluster.Enabled = ptr.To(false)
+		Expect(fakeClient.Patch(ctx, cluster, client.MergeFrom(demotedCluster))).To(Succeed())
+
+		expectedValue := sqlmock.NewRows([]string{""}).AddRow("1")
+		dbMock.ExpectQuery(databaseDetectionQuery).WithArgs(database.Spec.Name).
+			WillReturnRows(expectedValue)
+		expectedQuery := fmt.Sprintf("ALTER DATABASE %s OWNER TO %s",
+			pgx.Identifier{database.Spec.Name}.Sanitize(),
+			pgx.Identifier{database.Spec.Owner}.Sanitize(),
+		)
+		dbMock.ExpectExec(expectedQuery).WillReturnResult(sqlmock.NewResult(0, 1))
+
+		err = reconcileDatabase(ctx, fakeClient, r, database)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(database.Status.Applied).To(HaveValue(BeTrue()))
+		Expect(database.Status.Message).To(BeEmpty())
+		Expect(database.Status.ObservedGeneration).To(Equal(database.Generation))
+	})
+
+	It("retries the apply at the same generation after a failed reconciliation", func(ctx SpecContext) {
+		// A previously failed reconciliation that left the recorded
+		// reconciliation in place: the generation gate must not let it sit
+		// at applied=false, the object has to be evaluated again.
+		database.Status.Applied = ptr.To(false)
+		database.Status.ObservedGeneration = database.Generation
+		Expect(fakeClient.Status().Update(ctx, database)).To(Succeed())
+
+		expectedValue := sqlmock.NewRows([]string{""}).AddRow("1")
+		dbMock.ExpectQuery(databaseDetectionQuery).WithArgs(database.Spec.Name).
+			WillReturnRows(expectedValue)
+		expectedQuery := fmt.Sprintf("ALTER DATABASE %s OWNER TO %s",
+			pgx.Identifier{database.Spec.Name}.Sanitize(),
+			pgx.Identifier{database.Spec.Owner}.Sanitize(),
+		)
+		dbMock.ExpectExec(expectedQuery).WillReturnResult(sqlmock.NewResult(0, 1))
+
+		err := reconcileDatabase(ctx, fakeClient, r, database)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(database.Status.Applied).To(HaveValue(BeTrue()))
+		Expect(database.Status.Message).To(BeEmpty())
+	})
+
+	It("retains the ownership of the managed database across a demotion", func(ctx SpecContext) {
+		database.Status.Applied = ptr.To(true)
+		database.Status.ObservedGeneration = database.Generation
+		Expect(fakeClient.Status().Update(ctx, database)).To(Succeed())
+
+		initialCluster := cluster.DeepCopy()
+		cluster.Spec.ReplicaCluster = &apiv1.ReplicaClusterConfiguration{
+			Enabled: ptr.To(true),
+		}
+		Expect(fakeClient.Patch(ctx, cluster, client.MergeFrom(initialCluster))).To(Succeed())
+
+		err := reconcileDatabase(ctx, fakeClient, r, database)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(database.Status.Applied).To(BeNil())
+
+		// A second object targeting the same Postgres database, created
+		// while the cluster is demoted
+		dbDuplicate := &apiv1.Database{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "db-duplicate",
+				Namespace:  "default",
+				Generation: 1,
+			},
+			Spec: apiv1.DatabaseSpec{
+				ClusterRef: corev1.LocalObjectReference{
+					Name: cluster.Name,
+				},
+				Name:  database.Spec.Name,
+				Owner: "app",
+			},
+		}
+		Expect(fakeClient.Create(ctx, dbDuplicate)).To(Succeed())
+
+		demotedCluster := cluster.DeepCopy()
+		cluster.Spec.ReplicaCluster.Enabled = ptr.To(false)
+		Expect(fakeClient.Patch(ctx, cluster, client.MergeFrom(demotedCluster))).To(Succeed())
+
+		err = reconcileDatabase(ctx, fakeClient, r, dbDuplicate)
+		Expect(err).ToNot(HaveOccurred())
+
+		expectedError := fmt.Sprintf("%q is already managed by object %q",
+			dbDuplicate.Spec.Name, database.Name)
+		Expect(dbDuplicate.Status.Applied).To(HaveValue(BeFalse()))
+		Expect(dbDuplicate.Status.Message).To(ContainSubstring(expectedError))
+	})
+
 	It("enqueues only the Databases of this instance's cluster on cluster events", func(ctx SpecContext) {
 		mapFn := mapClusterToManagedResources(r.instance, fakeClient,
 			func() client.ObjectList { return &apiv1.DatabaseList{} })
 
+		// A database targeting another cluster in the same namespace
 		other := database.DeepCopy()
 		other.Name = "obj-other-cluster"
 		other.ResourceVersion = ""
 		other.Spec.ClusterRef.Name = "another-cluster"
 		Expect(fakeClient.Create(ctx, other)).To(Succeed())
 
-		// Same cluster name, different namespace: only the namespace guard
-		// in the mapper keeps this one out.
-		foreign := database.DeepCopy()
-		foreign.Name = "obj-other-namespace"
-		foreign.Namespace = "other-ns"
-		foreign.ResourceVersion = ""
-		Expect(fakeClient.Create(ctx, foreign)).To(Succeed())
-
 		Expect(mapFn(ctx, cluster)).To(ConsistOf(reconcile.Request{
 			NamespacedName: types.NamespacedName{Namespace: database.GetNamespace(), Name: database.GetName()},
 		}))
-
-		otherCluster := cluster.DeepCopy()
-		otherCluster.Name = "another-cluster"
-		Expect(mapFn(ctx, otherCluster)).To(BeEmpty())
-
-		foreignCluster := cluster.DeepCopy()
-		foreignCluster.Namespace = "other-ns"
-		Expect(mapFn(ctx, foreignCluster)).To(BeEmpty())
 	})
 })
 

--- a/internal/management/controller/database_controller_test.go
+++ b/internal/management/controller/database_controller_test.go
@@ -34,6 +34,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	schemeBuilder "github.com/cloudnative-pg/cloudnative-pg/internal/scheme"
@@ -431,6 +432,89 @@ var _ = Describe("Managed Database status", func() {
 		// The replica gate runs before the finalizer reconciler, so no
 		// finalizer is added while the cluster is a replica.
 		Expect(database.GetFinalizers()).Should(BeEmpty())
+	})
+
+	// The demotion behavior is identical across the three managed-object
+	// controllers, and so are its tests.
+	It("voids the recorded reconciliation when the cluster is demoted after apply", func(ctx SpecContext) { //nolint:dupl
+		database.Status.Applied = ptr.To(true)
+		database.Status.ObservedGeneration = database.Generation
+		Expect(fakeClient.Status().Update(ctx, database)).To(Succeed())
+
+		initialCluster := cluster.DeepCopy()
+		cluster.Spec.ReplicaCluster = &apiv1.ReplicaClusterConfiguration{
+			Enabled: ptr.To(true),
+		}
+		Expect(fakeClient.Patch(ctx, cluster, client.MergeFrom(initialCluster))).To(Succeed())
+
+		result, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{
+			Namespace: database.GetNamespace(),
+			Name:      database.GetName(),
+		}})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result.RequeueAfter).To(Equal(databaseReconciliationInterval))
+
+		Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(database), database)).To(Succeed())
+		Expect(database.Status.Applied).To(BeNil())
+		Expect(database.Status.Message).To(ContainSubstring("waiting for the cluster to become primary"))
+		Expect(database.Status.ObservedGeneration).To(BeZero())
+	})
+
+	It("keeps an applied database untouched on pods other than the designated primary", func(ctx SpecContext) {
+		database.Status.Applied = ptr.To(true)
+		database.Status.ObservedGeneration = database.Generation
+		Expect(fakeClient.Status().Update(ctx, database)).To(Succeed())
+
+		initialCluster := cluster.DeepCopy()
+		cluster.Spec.ReplicaCluster = &apiv1.ReplicaClusterConfiguration{
+			Enabled: ptr.To(true),
+		}
+		Expect(fakeClient.Patch(ctx, cluster, client.MergeFrom(initialCluster))).To(Succeed())
+		cluster.Status.CurrentPrimary = "another-pod"
+		cluster.Status.TargetPrimary = "another-pod"
+		Expect(fakeClient.Status().Update(ctx, cluster)).To(Succeed())
+
+		result, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{
+			Namespace: database.GetNamespace(),
+			Name:      database.GetName(),
+		}})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result).To(Equal(ctrl.Result{}))
+
+		Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(database), database)).To(Succeed())
+		Expect(database.Status.Applied).To(HaveValue(BeTrue()))
+		Expect(database.Status.ObservedGeneration).NotTo(BeZero())
+	})
+
+	It("enqueues only the Databases of this instance's cluster on cluster events", func(ctx SpecContext) {
+		mapFn := mapClusterToManagedResources(r.instance, fakeClient,
+			func() client.ObjectList { return &apiv1.DatabaseList{} })
+
+		other := database.DeepCopy()
+		other.Name = "obj-other-cluster"
+		other.ResourceVersion = ""
+		other.Spec.ClusterRef.Name = "another-cluster"
+		Expect(fakeClient.Create(ctx, other)).To(Succeed())
+
+		// Same cluster name, different namespace: only the namespace guard
+		// in the mapper keeps this one out.
+		foreign := database.DeepCopy()
+		foreign.Name = "obj-other-namespace"
+		foreign.Namespace = "other-ns"
+		foreign.ResourceVersion = ""
+		Expect(fakeClient.Create(ctx, foreign)).To(Succeed())
+
+		Expect(mapFn(ctx, cluster)).To(ConsistOf(reconcile.Request{
+			NamespacedName: types.NamespacedName{Namespace: database.GetNamespace(), Name: database.GetName()},
+		}))
+
+		otherCluster := cluster.DeepCopy()
+		otherCluster.Name = "another-cluster"
+		Expect(mapFn(ctx, otherCluster)).To(BeEmpty())
+
+		foreignCluster := cluster.DeepCopy()
+		foreignCluster.Namespace = "other-ns"
+		Expect(mapFn(ctx, foreignCluster)).To(BeEmpty())
 	})
 })
 

--- a/internal/management/controller/databaserole_controller.go
+++ b/internal/management/controller/databaserole_controller.go
@@ -337,85 +337,60 @@ func (r *DatabaseRoleReconciler) unknownReconciliation(
 	}, nil
 }
 
-// shadowedReconciliation marks a previously-applied role as taken over by an
-// inline managed.roles entry, voiding the recorded reconciliation so the
-// DatabaseRole reconciles again (and can adopt the role back) once the
-// inline entry is removed.
-func (r *DatabaseRoleReconciler) shadowedReconciliation(
-	ctx context.Context,
-	role *apiv1.DatabaseRole,
-) (ctrl.Result, error) {
-	oldRole := role.DeepCopy()
-	role.SetAsFailed(errClusterIsManagingRole)
-	role.Status.ObservedGeneration = 0
-
-	if patchErr := r.Client.Status().Patch(ctx, role, client.MergeFrom(oldRole)); patchErr != nil {
-		return ctrl.Result{}, fmt.Errorf(
-			"while setting the shadowed status: %w, original error: %w",
-			patchErr, errClusterIsManagingRole)
-	}
-
-	return ctrl.Result{
-		RequeueAfter: databaseRoleReconciliationInterval,
-	}, nil
-}
-
 // reconcileAppliedRole re-evaluates the status of an already-reconciled role
-// when the cluster changed underneath it. Only the designated primary writes
-// status, and only while the role is not being deleted; otherwise it is a
-// no-op.
+// when its cluster moved in or out of the replica role, or an inline
+// managed.roles entry took it over. The recorded reconciliation is always
+// kept, so the object retains ownership of the PostgreSQL role it manages and
+// a conflicting DatabaseRole cannot take over while the role is reported as not
+// applied. A nil result asks the caller to re-apply the role through the
+// regular flow.
 func (r *DatabaseRoleReconciler) reconcileAppliedRole(
 	ctx context.Context,
 	role *apiv1.DatabaseRole,
 	cluster *apiv1.Cluster,
 ) (*ctrl.Result, error) {
-	if !role.DeletionTimestamp.IsZero() ||
-		cluster.Status.CurrentPrimary != r.instance.GetPodName() {
+	// Deletion is handled by the caller.
+	if !role.DeletionTimestamp.IsZero() {
 		return &ctrl.Result{}, nil
 	}
 
-	switch {
-	case isClusterManagingRole(cluster, role.Spec.Name):
-		// The role was added to cluster.spec.managed.roles after the apply:
-		// the inline synchronizer takes over, so surface the conflict and void
-		// the recorded reconciliation instead of keeping a stale Applied=true.
-		// Voiding it lets the normal flow re-apply (adopt the role back) once
-		// the inline entry is removed.
-		result, err := r.shadowedReconciliation(ctx, role)
+	isDesignatedPrimary := cluster.Status.CurrentPrimary == r.instance.GetPodName()
+	applied := role.Status.Applied
+
+	// An inline managed.roles entry took over the role after it was applied:
+	// the designated primary reports the conflict. Re-applying (adopting the
+	// role back) once the inline entry is removed is handled by the re-apply
+	// path below.
+	if isDesignatedPrimary && isClusterManagingRole(cluster, role.Spec.Name) {
+		result, err := r.failedReconciliation(ctx, role, errClusterIsManagingRole)
 		return &result, err
-	case cluster.IsReplica():
+	}
+
+	if cluster.IsReplica() {
 		// The cluster was demoted to a replica after the apply: the role is
-		// now owned by the primary cluster. Report Unknown and void the
-		// recorded reconciliation, so the role is re-applied once the cluster
-		// is promoted back to primary.
-		result, err := r.demotedReconciliation(ctx, role)
-		return &result, err
-	default:
+		// owned by the primary cluster. The designated primary reports the
+		// replica condition (Applied=nil).
+		if isDesignatedPrimary && applied != nil {
+			result, err := r.unknownReconciliation(ctx, role, errClusterIsReplica)
+			return &result, err
+		}
+		// Keep polling while the designated primary awaits promotion, or while
+		// the cluster status is still settling (for example a failover
+		// concurrent with the demotion): status-only updates don't retrigger
+		// the cluster watch.
+		if isDesignatedPrimary || applied != nil {
+			return &ctrl.Result{RequeueAfter: databaseRoleReconciliationInterval}, nil
+		}
 		return &ctrl.Result{}, nil
 	}
-}
 
-// demotedReconciliation marks a previously-applied role as Unknown because its
-// cluster was demoted to a replica, voiding the recorded reconciliation so the
-// DatabaseRole reconciles again (and re-applies the role) once the cluster is
-// promoted back to primary.
-func (r *DatabaseRoleReconciler) demotedReconciliation(
-	ctx context.Context,
-	role *apiv1.DatabaseRole,
-) (ctrl.Result, error) {
-	oldRole := role.DeepCopy()
-	role.SetAsUnknown(errClusterIsReplica)
-	role.Status.ObservedGeneration = 0
-
-	if patchErr := r.Client.Status().Patch(ctx, role, client.MergeFrom(oldRole)); patchErr != nil {
-		return ctrl.Result{}, fmt.Errorf(
-			"while setting the demoted status: %w, original error: %w",
-			patchErr, errClusterIsReplica)
+	// Primary and not shadowed: if a previous transition (the replica
+	// condition or an inline takeover) left the role not applied, re-apply it
+	// through the regular flow.
+	if isDesignatedPrimary && (applied == nil || !*applied) {
+		return nil, nil
 	}
-
-	return ctrl.Result{
-		RequeueAfter: databaseRoleReconciliationInterval,
-	}, nil
+	return &ctrl.Result{}, nil
 }
 
 // succeededReconciliation marks the reconciliation as succeeded

--- a/internal/management/controller/databaserole_controller_test.go
+++ b/internal/management/controller/databaserole_controller_test.go
@@ -216,9 +216,10 @@ var _ = Describe("DatabaseRole shouldReconcile", func() {
 		},
 		Entry("proceeds for a fresh role on the primary",
 			func(_ *apiv1.DatabaseRole, _ *apiv1.Cluster) {}, nil),
-		Entry("stops when the role is already reconciled",
+		Entry("stops when the role is already reconciled and applied",
 			func(role *apiv1.DatabaseRole, _ *apiv1.Cluster) {
 				role.Status.ObservedGeneration = role.Generation
+				role.Status.Applied = ptr.To(true)
 			}, &ctrl.Result{}),
 		Entry("requeues when this pod is not the primary",
 			func(_ *apiv1.DatabaseRole, cluster *apiv1.Cluster) {
@@ -269,7 +270,7 @@ var _ = Describe("DatabaseRole shouldReconcile", func() {
 		Expect(got.Status.Applied).To(Equal(ptr.To(false)))
 	})
 
-	It("voids the recorded reconciliation when shadowed after a successful apply", func() {
+	It("reports the conflict but keeps the recorded reconciliation when shadowed after a successful apply", func() {
 		role := newTestDatabaseRole()
 		markReconciled(role)
 		role.Status.Applied = ptr.To(true)
@@ -285,10 +286,12 @@ var _ = Describe("DatabaseRole shouldReconcile", func() {
 		Expect(r.Get(context.Background(), client.ObjectKeyFromObject(role), got)).To(Succeed())
 		Expect(got.Status.Applied).To(Equal(ptr.To(false)))
 		Expect(got.Status.Message).To(ContainSubstring("managed by the CNPG cluster"))
-		Expect(got.Status.ObservedGeneration).To(BeZero())
+		// The reconciliation is kept so a conflicting DatabaseRole cannot take
+		// over the role while it is shadowed.
+		Expect(got.Status.ObservedGeneration).To(Equal(got.Generation))
 	})
 
-	It("voids the recorded reconciliation when the cluster is demoted after a successful apply", func() {
+	It("reports the replica condition but keeps the recorded reconciliation when the cluster is demoted", func() {
 		role := newTestDatabaseRole()
 		markReconciled(role)
 		role.Status.Applied = ptr.To(true)
@@ -304,7 +307,42 @@ var _ = Describe("DatabaseRole shouldReconcile", func() {
 		Expect(r.Get(context.Background(), client.ObjectKeyFromObject(role), got)).To(Succeed())
 		Expect(got.Status.Applied).To(BeNil())
 		Expect(got.Status.Message).To(ContainSubstring("waiting for the cluster to become primary"))
-		Expect(got.Status.ObservedGeneration).To(BeZero())
+		// Ownership is retained across the demotion: the role still counts as
+		// reconciled, so a conflicting DatabaseRole created meanwhile cannot
+		// take it over once the cluster is promoted back.
+		Expect(got.Status.ObservedGeneration).To(Equal(got.Generation))
+	})
+
+	It("re-applies after a promotion, when a previous demotion left the role unapplied", func() {
+		role := newTestDatabaseRole()
+		markReconciled(role)
+		role.Status.Applied = nil // left as Unknown by a previous demotion
+		cluster := newTestCluster()
+		r := reconcilerFor(role)
+
+		result, err := r.shouldReconcile(context.Background(), role, cluster)
+		Expect(err).NotTo(HaveOccurred())
+		// A nil result asks the caller to proceed with the regular apply flow.
+		Expect(result).To(BeNil())
+	})
+
+	It("keeps polling without writing on a replica while the cluster status is still settling", func() {
+		role := newTestDatabaseRole()
+		markReconciled(role)
+		role.Status.Applied = ptr.To(true) // stale, not yet cleared
+		cluster := newTestCluster()
+		makeReplica(cluster)
+		cluster.Status.CurrentPrimary = "other-pod" // this pod is not (yet) the designated primary
+		r := reconcilerFor(role)
+
+		result, err := r.shouldReconcile(context.Background(), role, cluster)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(requeue))
+
+		// A non-designated pod must not write the status.
+		got := &apiv1.DatabaseRole{}
+		Expect(r.Get(context.Background(), client.ObjectKeyFromObject(role), got)).To(Succeed())
+		Expect(got.Status.Applied).To(Equal(ptr.To(true)))
 	})
 
 	It("persists Applied=Unknown (nil) on a replica cluster", func() {

--- a/internal/management/controller/publication_controller.go
+++ b/internal/management/controller/publication_controller.go
@@ -97,19 +97,14 @@ func (r *PublicationReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 	// If everything is reconciled, we're done here
 	if publication.Generation == publication.Status.ObservedGeneration {
-		// ...unless the cluster was demoted to a replica after the
-		// publication was applied: report the replica condition and void the
-		// recorded reconciliation, so the publication is evaluated again
-		// once the cluster is promoted back to primary.
-		if publication.DeletionTimestamp.IsZero() &&
-			cluster.Status.CurrentPrimary == r.instance.GetPodName() &&
-			cluster.IsReplica() {
-			if err := markAsUnknownAndForget(ctx, r.Client, &publication, errClusterIsReplica); err != nil {
-				return ctrl.Result{}, err
-			}
-			return ctrl.Result{RequeueAfter: publicationReconciliationInterval}, nil
+		// ...unless the cluster moved in or out of the replica role after
+		// the publication was applied: report the demotion on the status,
+		// and evaluate the publication again after the promotion.
+		result, proceed, err := handleReplicaRoleTransition(
+			ctx, r.Client, r.instance, cluster, &publication, publicationReconciliationInterval)
+		if err != nil || !proceed {
+			return result, err
 		}
-		return ctrl.Result{}, nil
 	}
 
 	// Still not for me, we're waiting for a switchover

--- a/internal/management/controller/publication_controller.go
+++ b/internal/management/controller/publication_controller.go
@@ -92,6 +92,11 @@ func (r *PublicationReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	// Fetch the Cluster from the cache
 	cluster, err := r.GetCluster(ctx)
 	if err != nil {
+		// A reconciled publication keeps its status: the cluster may be
+		// gone or unreadable while it is being deleted.
+		if publication.Generation == publication.Status.ObservedGeneration {
+			return ctrl.Result{}, client.IgnoreNotFound(err)
+		}
 		return ctrl.Result{}, markAsFailed(ctx, r.Client, &publication, fmt.Errorf("while fetching the cluster: %w", err))
 	}
 

--- a/internal/management/controller/publication_controller.go
+++ b/internal/management/controller/publication_controller.go
@@ -28,8 +28,11 @@ import (
 	"github.com/cloudnative-pg/machinery/pkg/log"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres"
@@ -86,15 +89,27 @@ func (r *PublicationReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		return ctrl.Result{}, nil
 	}
 
-	// If everything is reconciled, we're done here
-	if publication.Generation == publication.Status.ObservedGeneration {
-		return ctrl.Result{}, nil
-	}
-
 	// Fetch the Cluster from the cache
 	cluster, err := r.GetCluster(ctx)
 	if err != nil {
 		return ctrl.Result{}, markAsFailed(ctx, r.Client, &publication, fmt.Errorf("while fetching the cluster: %w", err))
+	}
+
+	// If everything is reconciled, we're done here
+	if publication.Generation == publication.Status.ObservedGeneration {
+		// ...unless the cluster was demoted to a replica after the
+		// publication was applied: report the replica condition and void the
+		// recorded reconciliation, so the publication is evaluated again
+		// once the cluster is promoted back to primary.
+		if publication.DeletionTimestamp.IsZero() &&
+			cluster.Status.CurrentPrimary == r.instance.GetPodName() &&
+			cluster.IsReplica() {
+			if err := markAsUnknownAndForget(ctx, r.Client, &publication, errClusterIsReplica); err != nil {
+				return ctrl.Result{}, err
+			}
+			return ctrl.Result{RequeueAfter: publicationReconciliationInterval}, nil
+		}
+		return ctrl.Result{}, nil
 	}
 
 	// Still not for me, we're waiting for a switchover
@@ -220,6 +235,13 @@ func NewPublicationReconciler(
 func (r *PublicationReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&apiv1.Publication{}).
+		Watches(
+			&apiv1.Cluster{},
+			handler.EnqueueRequestsFromMapFunc(mapClusterToManagedResources(
+				r.instance, mgr.GetClient(),
+				func() client.ObjectList { return &apiv1.PublicationList{} })),
+			builder.WithPredicates(predicate.GenerationChangedPredicate{}),
+		).
 		Named("instance-publication").
 		Complete(r)
 }

--- a/internal/management/controller/publication_controller_test.go
+++ b/internal/management/controller/publication_controller_test.go
@@ -451,7 +451,7 @@ var _ = Describe("Managed publication controller tests", func() {
 
 	// The demotion behavior is identical across the three managed-object
 	// controllers, and so are its tests.
-	It("voids the recorded reconciliation when the cluster is demoted after apply", func(ctx SpecContext) { //nolint:dupl
+	It("reports the replica condition when the cluster is demoted after apply", func(ctx SpecContext) { //nolint:dupl
 		publication.Status.Applied = ptr.To(true)
 		publication.Status.ObservedGeneration = publication.Generation
 		Expect(fakeClient.Status().Update(ctx, publication)).To(Succeed())
@@ -472,7 +472,9 @@ var _ = Describe("Managed publication controller tests", func() {
 		Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(publication), publication)).To(Succeed())
 		Expect(publication.Status.Applied).To(BeNil())
 		Expect(publication.Status.Message).To(ContainSubstring("waiting for the cluster to become primary"))
-		Expect(publication.Status.ObservedGeneration).To(BeZero())
+		// the recorded reconciliation is kept, so the publication retains
+		// the ownership of the managed Postgres publication
+		Expect(publication.Status.ObservedGeneration).To(Equal(publication.Generation))
 	})
 
 	It("keeps an applied publication untouched on pods other than the designated primary", func(ctx SpecContext) {
@@ -494,7 +496,9 @@ var _ = Describe("Managed publication controller tests", func() {
 			Name:      publication.GetName(),
 		}})
 		Expect(err).ToNot(HaveOccurred())
-		Expect(result).To(Equal(ctrl.Result{}))
+		// the demotion may be racing a failover: poll until the designated
+		// primary has reported the replica condition
+		Expect(result.RequeueAfter).To(Equal(publicationReconciliationInterval))
 
 		Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(publication), publication)).To(Succeed())
 		Expect(publication.Status.Applied).To(HaveValue(BeTrue()))

--- a/internal/management/controller/publication_controller_test.go
+++ b/internal/management/controller/publication_controller_test.go
@@ -504,6 +504,27 @@ var _ = Describe("Managed publication controller tests", func() {
 		Expect(publication.Status.Applied).To(HaveValue(BeTrue()))
 		Expect(publication.Status.ObservedGeneration).NotTo(BeZero())
 	})
+
+	// The cluster-fetch behavior is identical across the three
+	// managed-object controllers, and so are its tests.
+	It("keeps a reconciled publication status when the cluster cannot be fetched", func(ctx SpecContext) { //nolint:dupl
+		publication.Status.Applied = ptr.To(true)
+		publication.Status.ObservedGeneration = publication.Generation
+		Expect(fakeClient.Status().Update(ctx, publication)).To(Succeed())
+
+		Expect(fakeClient.Delete(ctx, cluster)).To(Succeed())
+
+		result, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{
+			Namespace: publication.GetNamespace(),
+			Name:      publication.GetName(),
+		}})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result).To(Equal(ctrl.Result{}))
+
+		Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(publication), publication)).To(Succeed())
+		Expect(publication.Status.Applied).To(HaveValue(BeTrue()))
+		Expect(publication.Status.Message).To(BeEmpty())
+	})
 })
 
 func reconcilePublication(

--- a/internal/management/controller/publication_controller_test.go
+++ b/internal/management/controller/publication_controller_test.go
@@ -448,6 +448,58 @@ var _ = Describe("Managed publication controller tests", func() {
 		// finalizer is added while the cluster is a replica.
 		Expect(publication.GetFinalizers()).Should(BeEmpty())
 	})
+
+	// The demotion behavior is identical across the three managed-object
+	// controllers, and so are its tests.
+	It("voids the recorded reconciliation when the cluster is demoted after apply", func(ctx SpecContext) { //nolint:dupl
+		publication.Status.Applied = ptr.To(true)
+		publication.Status.ObservedGeneration = publication.Generation
+		Expect(fakeClient.Status().Update(ctx, publication)).To(Succeed())
+
+		initialCluster := cluster.DeepCopy()
+		cluster.Spec.ReplicaCluster = &apiv1.ReplicaClusterConfiguration{
+			Enabled: ptr.To(true),
+		}
+		Expect(fakeClient.Patch(ctx, cluster, client.MergeFrom(initialCluster))).To(Succeed())
+
+		result, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{
+			Namespace: publication.GetNamespace(),
+			Name:      publication.GetName(),
+		}})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result.RequeueAfter).To(Equal(publicationReconciliationInterval))
+
+		Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(publication), publication)).To(Succeed())
+		Expect(publication.Status.Applied).To(BeNil())
+		Expect(publication.Status.Message).To(ContainSubstring("waiting for the cluster to become primary"))
+		Expect(publication.Status.ObservedGeneration).To(BeZero())
+	})
+
+	It("keeps an applied publication untouched on pods other than the designated primary", func(ctx SpecContext) {
+		publication.Status.Applied = ptr.To(true)
+		publication.Status.ObservedGeneration = publication.Generation
+		Expect(fakeClient.Status().Update(ctx, publication)).To(Succeed())
+
+		initialCluster := cluster.DeepCopy()
+		cluster.Spec.ReplicaCluster = &apiv1.ReplicaClusterConfiguration{
+			Enabled: ptr.To(true),
+		}
+		Expect(fakeClient.Patch(ctx, cluster, client.MergeFrom(initialCluster))).To(Succeed())
+		cluster.Status.CurrentPrimary = "another-pod"
+		cluster.Status.TargetPrimary = "another-pod"
+		Expect(fakeClient.Status().Update(ctx, cluster)).To(Succeed())
+
+		result, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{
+			Namespace: publication.GetNamespace(),
+			Name:      publication.GetName(),
+		}})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result).To(Equal(ctrl.Result{}))
+
+		Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(publication), publication)).To(Succeed())
+		Expect(publication.Status.Applied).To(HaveValue(BeTrue()))
+		Expect(publication.Status.ObservedGeneration).NotTo(BeZero())
+	})
 })
 
 func reconcilePublication(

--- a/internal/management/controller/subscription_controller.go
+++ b/internal/management/controller/subscription_controller.go
@@ -86,6 +86,11 @@ func (r *SubscriptionReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	// Fetch the Cluster from the cache
 	cluster, err := r.GetCluster(ctx)
 	if err != nil {
+		// A reconciled subscription keeps its status: the cluster may be
+		// gone or unreadable while it is being deleted.
+		if subscription.Generation == subscription.Status.ObservedGeneration {
+			return ctrl.Result{}, client.IgnoreNotFound(err)
+		}
 		return ctrl.Result{}, markAsFailed(ctx, r.Client, &subscription, fmt.Errorf("while fetching the cluster: %w", err))
 	}
 

--- a/internal/management/controller/subscription_controller.go
+++ b/internal/management/controller/subscription_controller.go
@@ -28,8 +28,11 @@ import (
 	"github.com/cloudnative-pg/machinery/pkg/log"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/external"
@@ -80,15 +83,27 @@ func (r *SubscriptionReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{}, nil
 	}
 
-	// If everything is reconciled, we're done here
-	if subscription.Generation == subscription.Status.ObservedGeneration {
-		return ctrl.Result{}, nil
-	}
-
 	// Fetch the Cluster from the cache
 	cluster, err := r.GetCluster(ctx)
 	if err != nil {
 		return ctrl.Result{}, markAsFailed(ctx, r.Client, &subscription, fmt.Errorf("while fetching the cluster: %w", err))
+	}
+
+	// If everything is reconciled, we're done here
+	if subscription.Generation == subscription.Status.ObservedGeneration {
+		// ...unless the cluster was demoted to a replica after the
+		// subscription was applied: report the replica condition and void
+		// the recorded reconciliation, so the subscription is evaluated
+		// again once the cluster is promoted back to primary.
+		if subscription.DeletionTimestamp.IsZero() &&
+			cluster.Status.CurrentPrimary == r.instance.GetPodName() &&
+			cluster.IsReplica() {
+			if err := markAsUnknownAndForget(ctx, r.Client, &subscription, errClusterIsReplica); err != nil {
+				return ctrl.Result{}, err
+			}
+			return ctrl.Result{RequeueAfter: subscriptionReconciliationInterval}, nil
+		}
+		return ctrl.Result{}, nil
 	}
 
 	// Still not for me, we're waiting for a switchover
@@ -230,6 +245,13 @@ func NewSubscriptionReconciler(
 func (r *SubscriptionReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&apiv1.Subscription{}).
+		Watches(
+			&apiv1.Cluster{},
+			handler.EnqueueRequestsFromMapFunc(mapClusterToManagedResources(
+				r.instance, mgr.GetClient(),
+				func() client.ObjectList { return &apiv1.SubscriptionList{} })),
+			builder.WithPredicates(predicate.GenerationChangedPredicate{}),
+		).
 		Named("instance-subscription").
 		Complete(r)
 }

--- a/internal/management/controller/subscription_controller.go
+++ b/internal/management/controller/subscription_controller.go
@@ -91,19 +91,14 @@ func (r *SubscriptionReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 	// If everything is reconciled, we're done here
 	if subscription.Generation == subscription.Status.ObservedGeneration {
-		// ...unless the cluster was demoted to a replica after the
-		// subscription was applied: report the replica condition and void
-		// the recorded reconciliation, so the subscription is evaluated
-		// again once the cluster is promoted back to primary.
-		if subscription.DeletionTimestamp.IsZero() &&
-			cluster.Status.CurrentPrimary == r.instance.GetPodName() &&
-			cluster.IsReplica() {
-			if err := markAsUnknownAndForget(ctx, r.Client, &subscription, errClusterIsReplica); err != nil {
-				return ctrl.Result{}, err
-			}
-			return ctrl.Result{RequeueAfter: subscriptionReconciliationInterval}, nil
+		// ...unless the cluster moved in or out of the replica role after
+		// the subscription was applied: report the demotion on the status,
+		// and evaluate the subscription again after the promotion.
+		result, proceed, err := handleReplicaRoleTransition(
+			ctx, r.Client, r.instance, cluster, &subscription, subscriptionReconciliationInterval)
+		if err != nil || !proceed {
+			return result, err
 		}
-		return ctrl.Result{}, nil
 	}
 
 	// Still not for me, we're waiting for a switchover

--- a/internal/management/controller/subscription_controller_test.go
+++ b/internal/management/controller/subscription_controller_test.go
@@ -450,7 +450,7 @@ var _ = Describe("Managed subscription controller tests", func() {
 
 	// The demotion behavior is identical across the three managed-object
 	// controllers, and so are its tests.
-	It("voids the recorded reconciliation when the cluster is demoted after apply", func(ctx SpecContext) { //nolint:dupl
+	It("reports the replica condition when the cluster is demoted after apply", func(ctx SpecContext) { //nolint:dupl
 		subscription.Status.Applied = ptr.To(true)
 		subscription.Status.ObservedGeneration = subscription.Generation
 		Expect(fakeClient.Status().Update(ctx, subscription)).To(Succeed())
@@ -471,7 +471,9 @@ var _ = Describe("Managed subscription controller tests", func() {
 		Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(subscription), subscription)).To(Succeed())
 		Expect(subscription.Status.Applied).To(BeNil())
 		Expect(subscription.Status.Message).To(ContainSubstring("waiting for the cluster to become primary"))
-		Expect(subscription.Status.ObservedGeneration).To(BeZero())
+		// the recorded reconciliation is kept, so the subscription retains
+		// the ownership of the managed Postgres subscription
+		Expect(subscription.Status.ObservedGeneration).To(Equal(subscription.Generation))
 	})
 
 	It("keeps an applied subscription untouched on pods other than the designated primary", func(ctx SpecContext) {
@@ -493,7 +495,9 @@ var _ = Describe("Managed subscription controller tests", func() {
 			Name:      subscription.GetName(),
 		}})
 		Expect(err).ToNot(HaveOccurred())
-		Expect(result).To(Equal(ctrl.Result{}))
+		// the demotion may be racing a failover: poll until the designated
+		// primary has reported the replica condition
+		Expect(result.RequeueAfter).To(Equal(subscriptionReconciliationInterval))
 
 		Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(subscription), subscription)).To(Succeed())
 		Expect(subscription.Status.Applied).To(HaveValue(BeTrue()))

--- a/internal/management/controller/subscription_controller_test.go
+++ b/internal/management/controller/subscription_controller_test.go
@@ -447,6 +447,58 @@ var _ = Describe("Managed subscription controller tests", func() {
 		// finalizer is added while the cluster is a replica.
 		Expect(subscription.GetFinalizers()).Should(BeEmpty())
 	})
+
+	// The demotion behavior is identical across the three managed-object
+	// controllers, and so are its tests.
+	It("voids the recorded reconciliation when the cluster is demoted after apply", func(ctx SpecContext) { //nolint:dupl
+		subscription.Status.Applied = ptr.To(true)
+		subscription.Status.ObservedGeneration = subscription.Generation
+		Expect(fakeClient.Status().Update(ctx, subscription)).To(Succeed())
+
+		initialCluster := cluster.DeepCopy()
+		cluster.Spec.ReplicaCluster = &apiv1.ReplicaClusterConfiguration{
+			Enabled: ptr.To(true),
+		}
+		Expect(fakeClient.Patch(ctx, cluster, client.MergeFrom(initialCluster))).To(Succeed())
+
+		result, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{
+			Namespace: subscription.GetNamespace(),
+			Name:      subscription.GetName(),
+		}})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result.RequeueAfter).To(Equal(subscriptionReconciliationInterval))
+
+		Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(subscription), subscription)).To(Succeed())
+		Expect(subscription.Status.Applied).To(BeNil())
+		Expect(subscription.Status.Message).To(ContainSubstring("waiting for the cluster to become primary"))
+		Expect(subscription.Status.ObservedGeneration).To(BeZero())
+	})
+
+	It("keeps an applied subscription untouched on pods other than the designated primary", func(ctx SpecContext) {
+		subscription.Status.Applied = ptr.To(true)
+		subscription.Status.ObservedGeneration = subscription.Generation
+		Expect(fakeClient.Status().Update(ctx, subscription)).To(Succeed())
+
+		initialCluster := cluster.DeepCopy()
+		cluster.Spec.ReplicaCluster = &apiv1.ReplicaClusterConfiguration{
+			Enabled: ptr.To(true),
+		}
+		Expect(fakeClient.Patch(ctx, cluster, client.MergeFrom(initialCluster))).To(Succeed())
+		cluster.Status.CurrentPrimary = "another-pod"
+		cluster.Status.TargetPrimary = "another-pod"
+		Expect(fakeClient.Status().Update(ctx, cluster)).To(Succeed())
+
+		result, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{
+			Namespace: subscription.GetNamespace(),
+			Name:      subscription.GetName(),
+		}})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result).To(Equal(ctrl.Result{}))
+
+		Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(subscription), subscription)).To(Succeed())
+		Expect(subscription.Status.Applied).To(HaveValue(BeTrue()))
+		Expect(subscription.Status.ObservedGeneration).NotTo(BeZero())
+	})
 })
 
 func reconcileSubscription(

--- a/internal/management/controller/subscription_controller_test.go
+++ b/internal/management/controller/subscription_controller_test.go
@@ -503,6 +503,27 @@ var _ = Describe("Managed subscription controller tests", func() {
 		Expect(subscription.Status.Applied).To(HaveValue(BeTrue()))
 		Expect(subscription.Status.ObservedGeneration).NotTo(BeZero())
 	})
+
+	// The cluster-fetch behavior is identical across the three
+	// managed-object controllers, and so are its tests.
+	It("keeps a reconciled subscription status when the cluster cannot be fetched", func(ctx SpecContext) { //nolint:dupl
+		subscription.Status.Applied = ptr.To(true)
+		subscription.Status.ObservedGeneration = subscription.Generation
+		Expect(fakeClient.Status().Update(ctx, subscription)).To(Succeed())
+
+		Expect(fakeClient.Delete(ctx, cluster)).To(Succeed())
+
+		result, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{
+			Namespace: subscription.GetNamespace(),
+			Name:      subscription.GetName(),
+		}})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result).To(Equal(ctrl.Result{}))
+
+		Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(subscription), subscription)).To(Succeed())
+		Expect(subscription.Status.Applied).To(HaveValue(BeTrue()))
+		Expect(subscription.Status.Message).To(BeEmpty())
+	})
 })
 
 func reconcileSubscription(


### PR DESCRIPTION
Once a Database, Publication, Subscription, or DatabaseRole was reconciled, the controller exited before the replica gate and never requeued, so a cluster demoted to a replica kept reporting the stale primary-side status forever. Re-check the replica condition inside the already-reconciled exit and watch the Cluster spec so the demotion is detected promptly.

The recorded reconciliation is kept while the replica condition is reported, so the object retains ownership of the PostgreSQL entity it manages and a conflicting object created meanwhile cannot take it over once the cluster is promoted back; re-application is driven off the applied status instead. For DatabaseRole the same applies when an inline managed.roles entry takes over an already-applied role.

This moves the Cluster fetch above the already-reconciled gate, so it overlaps with #10853 in the test files; whichever lands second needs a trivial rebase.

Closes #10867

Assisted-by: Claude
