### PR TITLE
Use WebSocket protocol for streaming connections

### DIFF
--- a/pkg/utils/exec.go
+++ b/pkg/utils/exec.go
@@ -202,7 +202,7 @@ func execCommandOnce(
 		Stderr:    true,
 	}, scheme.ParameterCodec)
 
-	executor, err := remotecommand.NewSPDYExecutor(&newConfig, "POST", req.URL())
+	executor, err := remotecommand.NewWebSocketExecutor(&newConfig, "POST", req.URL().String())
 	if err != nil {
 		return "", "", err
 	}


### PR DESCRIPTION
Instead of the deprecated SPDY protocol, use WebSocket for streaming connections. Since the kubectl cnpg status uses the exec command it has to use the WebSocket protocol.

Fixes #10873 