### PR TITLE
ci: reduce unit-test Kubernetes matrix on pull requests

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -256,25 +256,34 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-
       - name: Get k8s versions for unit test
         id: get-k8s-versions
         shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
         run: |
-          k8s_versions=$(jq -c '
-            .unit_test.max as $max |
-            .unit_test.min as $min |
-            $min | [ while(. <= $max;
-                . | split(".") | .[1] |= (.|tonumber|.+1|tostring) | join(".")
-              )
-            ] |
-            .[] |= .+".x"
-          ' < .github/k8s_versions_scope.json)
+          if [[ "${EVENT_NAME}" == "pull_request" ]]; then
+            # On pull requests, only test against the lowest and highest supported
+            # versions to bracket the support window, keeping CI fast.
+            k8s_versions=$(jq -c '
+              [.unit_test.min + ".x", .unit_test.max + ".x"]
+            ' < .github/k8s_versions_scope.json)
+          else
+            # On pushes to main/release branches and scheduled runs, run the full
+            # matrix so cross-version regressions are caught before a release.
+            k8s_versions=$(jq -c '
+              .unit_test.max as $max |
+              .unit_test.min as $min |
+              $min | [ while(. <= $max;
+                  . | split(".") | .[1] |= (.|tonumber|.+1|tostring) | join(".")
+                )
+              ] |
+              .[] |= .+".x"
+            ' < .github/k8s_versions_scope.json)
+          fi
           echo "k8s_versions=${k8s_versions}" >> $GITHUB_OUTPUT
-
           latest_k8s_version=$(jq -r '.|last' <<< $k8s_versions)
           echo "latest_k8s_version=${latest_k8s_version}" >> $GITHUB_OUTPUT
-
   tests:
     name: Run unit tests
     needs:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -256,6 +256,7 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
       - name: Get k8s versions for unit test
         id: get-k8s-versions
         shell: bash
@@ -282,8 +283,10 @@ jobs:
             ' < .github/k8s_versions_scope.json)
           fi
           echo "k8s_versions=${k8s_versions}" >> $GITHUB_OUTPUT
+
           latest_k8s_version=$(jq -r '.|last' <<< $k8s_versions)
           echo "latest_k8s_version=${latest_k8s_version}" >> $GITHUB_OUTPUT
+
   tests:
     name: Run unit tests
     needs:


### PR DESCRIPTION
Fixes #10860

## What's the problem?

Right now, every pull request runs unit tests against all 7 Kubernetes versions (1.29 through 1.35). But since these jobs only swap the envtest binary, they almost always produce the same result. So a PR ends up spending ~35 runner-minutes doing largely the same work 7 times.

## What I changed

In the `generate-unit-tests-jobs` step inside `continuous-integration.yml`, I added a check on the triggering event:

- **On pull requests** → only runs against the lowest and highest supported versions (`1.29.x` and `1.35.x`), which brackets the support window with just 2 jobs
- **On pushes to main/release branches, scheduled runs, and workflow_dispatch** → the full 7-version matrix runs as before, so nothing changes for release coverage

`k8s_versions_scope.json` is untouched — the existing `min` and `max` values are reused directly.

## What stays the same

- Coverage summary and step summary still run on the latest version (`1.35.x`) as before
- The full matrix still runs everywhere it matters (main, release branches, nightly)
- No changes to how tests themselves run — only which versions trigger them on PRs

Happy to make any changes based on feedback!