### PR TITLE
ci: cancel superseded in-progress runs on pull requests

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -16,6 +16,10 @@ on:
 
 permissions: read-all
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 # set up environment variables to be used across all the jobs
 env:
   # renovate: datasource=github-releases depName=golangci/golangci-lint versioning=loose


### PR DESCRIPTION
Fixes #10861

## What's the problem?

When you push multiple times to a PR during review, every push starts a fresh CI run and they all run to completion simultaneously. This clogs up the shared runner pool and means you're waiting on feedback from commits that are already outdated.

## What I changed

Added a top-level `concurrency:` block to `continuous-integration.yml`:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

- On **pull requests** — when a new push comes in, the old in-progress run is cancelled immediately and the new one starts fresh
- On **pushes to main, release branches, scheduled runs** — `cancel-in-progress` evaluates to `false`, so those always run to completion

## Why not just rely on the existing `duplicate_runs` job?

The existing `duplicate_runs` job explicitly lists `pull_request` in its `do_not_skip` set, so it never cancels PR runs. It also only deduplicates identical content, not superseded runs. This concurrency group handles a completely different case.
