### PR TITLE
fix(kubectl-cnpg): only call DetectSecurityContextConstraints when necessary

### DIFF
--- a/internal/cmd/plugin/fio/fio.go
+++ b/internal/cmd/plugin/fio/fio.go
@@ -81,6 +81,11 @@ func newFioCommand(
 }
 
 func (cmd *fioCommand) execute(ctx context.Context) error {
+	// Populate utils.HaveSecurityContextConstraints()
+	if err := utils.DetectSecurityContextConstraints(plugin.ClientInterface.Discovery()); err != nil {
+		return err
+	}
+
 	pvc, err := cmd.generatePVCObject()
 	if err != nil {
 		return err

--- a/internal/cmd/plugin/plugin.go
+++ b/internal/cmd/plugin/plugin.go
@@ -107,7 +107,7 @@ func SetupKubernetesClient(configFlags *genericclioptions.ConfigFlags) error {
 
 	ClientInterface = kubernetes.NewForConfigOrDie(Config)
 
-	return utils.DetectSecurityContextConstraints(ClientInterface.Discovery())
+	return nil
 }
 
 func createClient(cfg *rest.Config) error {

--- a/pkg/utils/discovery.go
+++ b/pkg/utils/discovery.go
@@ -147,7 +147,7 @@ func DetectSecurityContextConstraints(client discovery.DiscoveryInterface) (err 
 
 // HaveSecurityContextConstraints returns true if we're running under a system that implements
 // OpenShift Security Context Constraints
-// It panics if called before DetectSecurityContextConstraints
+// Always returns false if called before DetectSecurityContextConstraints
 func HaveSecurityContextConstraints() bool {
 	return haveSCC
 }


### PR DESCRIPTION
Fixes #10889

It’s not a complete fix, but if fixes completion for most subcommands.