### PR TITLE
build(Makefile): add more versatility for manual dev builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ IMAGE_NAME ?= ghcr.io/cloudnative-pg/cloudnative-pg-testing
 # Prevent e2e tests to proceed with empty tag which
 # will be considered as "latest".
 ifeq (,$(CONTROLLER_IMG))
-IMAGE_TAG = $(shell (git symbolic-ref -q --short HEAD || git describe --tags --exact-match) | tr / -)
+IMAGE_TAG ?= $(shell (git symbolic-ref -q --short HEAD || git describe --tags --exact-match) | tr / -)
 ifneq (,${IMAGE_TAG})
 CONTROLLER_IMG = ${IMAGE_NAME}:${IMAGE_TAG}
 endif
@@ -191,7 +191,7 @@ docker-build: go-releaser ## Build the docker image.
 	  builder_name_option="--builder ${BUILDER_NAME}"; \
 	fi; \
 	DOCKER_BUILDKIT=1 buildVersion=${VERSION} revision=${COMMIT} \
-	  docker buildx bake $${builder_name_option} --set=*.platform="linux/${ARCH}" \
+	  docker buildx bake $(ADDITIONAL_BUILDER_OPTIONS) $${builder_name_option} --set=*.platform="linux/${ARCH}" \
 	  --set distroless.tags="$${CONTROLLER_IMG}" \
 	  --push distroless
 


### PR DESCRIPTION
make IMAGE_TAG overwritable and allow passing ADDITIONAL_BUILDER_OPTIONS.

This allows dev builds to be more flexible, improving DX.

An example command that is now possible and wasn't before:
```
IMAGE_NAME=my-registry.example.com/docker/cloudnative-pg IMAGE_TAG=(git log --pretty=format:'%p' | head -n1)-with-my-changes ADDITIONAL_BUILDER_OPTIONS="--provenance=false" make docker-build
```

Fixes #10920 