### PR TITLE
feat(pooler): make auth_user configurable

### DIFF
--- a/config/crd/bases/postgresql.cnpg.io_poolers.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_poolers.yaml
@@ -353,11 +353,6 @@ spec:
                     required:
                     - name
                     type: object
-                  authUser:
-                    description: |-
-                      The username used by the pooler to execute the AuthQuery.
-                      By default this will be extracted from the AuthQuerySecret.
-                    type: string
                   clientCASecret:
                     description: |-
                       ClientCASecret provides PgBouncer’s client_tls_ca_file, the root

--- a/config/crd/bases/postgresql.cnpg.io_poolers.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_poolers.yaml
@@ -353,6 +353,11 @@ spec:
                     required:
                     - name
                     type: object
+                  authUser:
+                    description: |-
+                      The username used by the pooler to execute the AuthQuery.
+                      By default this will be extracted from the AuthQuerySecret.
+                    type: string
                   clientCASecret:
                     description: |-
                       ClientCASecret provides PgBouncer’s client_tls_ca_file, the root

--- a/docs/src/connection_pooling.md
+++ b/docs/src/connection_pooling.md
@@ -523,8 +523,14 @@ documentation for each parameter. Unless stated otherwise, the default values
 are the ones directly set by PgBouncer.
 
 - [`auth_type`](https://www.pgbouncer.org/config.html#auth_type)
-- [`auth_user`](https://www.pgbouncer.org/config.html#auth_user): by default
-  exctracted from AuthQuerySecret.
+- [`auth_user`](https://www.pgbouncer.org/config.html#auth_user): overrides the
+  user PgBouncer connects with to run the authentication query. By default it is
+  derived from the auth query secret (the `username` key for basic-auth secrets,
+  the certificate common name for TLS secrets). Setting it is meant for setups
+  with a custom `authQuerySecret`, since the built-in integration provisions
+  everything for the default `cnpg_pooler_pgbouncer` user; with a basic-auth
+  secret only the username changes, the password still comes from the secret. An
+  empty value is ignored.
 - [`application_name_add_host`](https://www.pgbouncer.org/config.html#application_name_add_host)
 - [`autodb_idle_timeout`](https://www.pgbouncer.org/config.html#autodb_idle_timeout)
 - [`cancel_wait_timeout`](https://www.pgbouncer.org/config.html#cancel_wait_timeout)

--- a/docs/src/connection_pooling.md
+++ b/docs/src/connection_pooling.md
@@ -236,6 +236,10 @@ This gives you the flexibility — and responsibility — to manage the
 authentication process yourself. You can follow the instructions above to
 replicate similar behavior to the default setup.
 
+If PgBouncer needs to authenticate as a different user than the one derived
+from your secret, you can override it with the `auth_user` parameter (see
+[PgBouncer configuration options](#pgbouncer-configuration-options)).
+
 ## Pod templates
 
 

--- a/docs/src/connection_pooling.md
+++ b/docs/src/connection_pooling.md
@@ -523,6 +523,8 @@ documentation for each parameter. Unless stated otherwise, the default values
 are the ones directly set by PgBouncer.
 
 - [`auth_type`](https://www.pgbouncer.org/config.html#auth_type)
+- [`auth_user`](https://www.pgbouncer.org/config.html#auth_user): by default
+  exctracted from AuthQuerySecret.
 - [`application_name_add_host`](https://www.pgbouncer.org/config.html#application_name_add_host)
 - [`autodb_idle_timeout`](https://www.pgbouncer.org/config.html#autodb_idle_timeout)
 - [`cancel_wait_timeout`](https://www.pgbouncer.org/config.html#cancel_wait_timeout)

--- a/docs/src/connection_pooling.md
+++ b/docs/src/connection_pooling.md
@@ -537,6 +537,28 @@ are the ones directly set by PgBouncer.
   empty value is ignored. Once you customize the `auth_user`, ensure that the
   user exists in PostgreSQL and has the necessary privileges to run the
   `auth_query` (see ["Authentication"](#authentication)).
+
+  If the auth query secret is certificate-based, overriding `auth_user` only
+  changes the role PgBouncer requests during the auth query; it does not
+  change the certificate PgBouncer presents. The operator's built-in
+  `pg_hba`/`pg_ident` rules only match the literal `cnpg_pooler_pgbouncer`
+  user, so a custom `auth_user` needs its own `pg_hba` rule and a matching
+  `pg_ident` entry on the `Cluster` to map the certificate's common name to
+  the new role (see the [`pg_hba`](postgresql_conf.md#the-pg_hba-section) and
+  [`pg_ident`](postgresql_conf.md#the-pg_ident-section) sections), for
+  example:
+
+  ```yaml
+  postgresql:
+    pg_ident:
+      - poolermap pooler-client-cn pgbouncer
+    pg_hba:
+      - hostssl all pgbouncer all cert map=poolermap
+  ```
+
+  Without this mapping, the auth_query connection will fail authentication
+  once `auth_user` no longer matches the certificate identity recognized by
+  the fixed rules.
 - [`application_name_add_host`](https://www.pgbouncer.org/config.html#application_name_add_host)
 - [`autodb_idle_timeout`](https://www.pgbouncer.org/config.html#autodb_idle_timeout)
 - [`cancel_wait_timeout`](https://www.pgbouncer.org/config.html#cancel_wait_timeout)

--- a/docs/src/connection_pooling.md
+++ b/docs/src/connection_pooling.md
@@ -533,8 +533,11 @@ are the ones directly set by PgBouncer.
   the certificate common name for TLS secrets). Setting it is meant for setups
   with a custom `authQuerySecret`, since the built-in integration provisions
   everything for the default `cnpg_pooler_pgbouncer` user; with a basic-auth
-  secret only the username changes, the password still comes from the secret. An
-  empty value is ignored. Once you customize the `auth_user`, ensure that the
+  secret only the username changes. PgBouncer still uses the secret's password
+  field to authenticate its own auth_query connection, so that field must
+  contain the actual PostgreSQL password for the overridden `auth_user` role,
+  not the password of the secret's original username. An empty value is
+  ignored. Once you customize the `auth_user`, ensure that the
   user exists in PostgreSQL and has the necessary privileges to run the
   `auth_query` (see ["Authentication"](#authentication)).
 

--- a/docs/src/connection_pooling.md
+++ b/docs/src/connection_pooling.md
@@ -534,7 +534,9 @@ are the ones directly set by PgBouncer.
   with a custom `authQuerySecret`, since the built-in integration provisions
   everything for the default `cnpg_pooler_pgbouncer` user; with a basic-auth
   secret only the username changes, the password still comes from the secret. An
-  empty value is ignored.
+  empty value is ignored. Once you customize the `auth_user`, ensure that the
+  user exists in PostgreSQL and has the necessary privileges to run the
+  `auth_query` (see ["Authentication"](#authentication)).
 - [`application_name_add_host`](https://www.pgbouncer.org/config.html#application_name_add_host)
 - [`autodb_idle_timeout`](https://www.pgbouncer.org/config.html#autodb_idle_timeout)
 - [`cancel_wait_timeout`](https://www.pgbouncer.org/config.html#cancel_wait_timeout)

--- a/docs/src/connection_pooling.md
+++ b/docs/src/connection_pooling.md
@@ -526,7 +526,11 @@ These are the PgBouncer options you can customize, with links to the PgBouncer
 documentation for each parameter. Unless stated otherwise, the default values
 are the ones directly set by PgBouncer.
 
-- [`auth_type`](https://www.pgbouncer.org/config.html#auth_type)
+- [`auth_type`](https://www.pgbouncer.org/config.html#auth_type): the default,
+  `hba`, resolves each client's authentication method from the Pooler's own
+  `.spec.pgbouncer.pg_hba` list (not to be confused with the `Cluster`'s
+  `.spec.postgresql.pg_hba`, which governs PostgreSQL's own client
+  authentication).
 - [`auth_user`](https://www.pgbouncer.org/config.html#auth_user): overrides the
   user PgBouncer connects with to run the authentication query. By default it is
   derived from the auth query secret (the `username` key for basic-auth secrets,
@@ -562,6 +566,11 @@ are the ones directly set by PgBouncer.
   Without this mapping, the auth_query connection will fail authentication
   once `auth_user` no longer matches the certificate identity recognized by
   the fixed rules.
+
+  PgBouncer only consults `auth_query`/`auth_user` when the client-facing
+  method resolved by `auth_type` is password-based (`md5`/`scram`); with a
+  `peer`, `cert`, or `trust` rule in the Pooler's own `pg_hba`, the override
+  has no effect for that client.
 - [`application_name_add_host`](https://www.pgbouncer.org/config.html#application_name_add_host)
 - [`autodb_idle_timeout`](https://www.pgbouncer.org/config.html#autodb_idle_timeout)
 - [`cancel_wait_timeout`](https://www.pgbouncer.org/config.html#cancel_wait_timeout)

--- a/docs/src/security.md
+++ b/docs/src/security.md
@@ -323,6 +323,15 @@ allows `superuser: true` and membership of any existing role through
 access on the PostgreSQL clusters in that namespace, and deserves the same
 care as write access to the `Cluster` resource.
 
+A similar consideration applies to the `Pooler` resource: its `authQuery`
+field accepts arbitrary SQL that PgBouncer runs against the `postgres`
+database to authenticate client connections, and the `auth_user` parameter (see
+[Connection Pooling](connection_pooling.md#pgbouncer-configuration-options))
+selects the role that query runs as. Write access to a `Pooler` therefore
+already implies the ability to run arbitrary SQL as any role for which
+PostgreSQL authentication succeeds, and deserves the same care as write
+access to the `Cluster` resource.
+
 Treat write access to these resources as a high-privilege grant: for
 multi-tenant deployments, isolate tenants in separate namespaces and scope it
 per namespace with Kubernetes RBAC, relying on

--- a/internal/webhook/v1/pooler_webhook.go
+++ b/internal/webhook/v1/pooler_webhook.go
@@ -39,6 +39,7 @@ import (
 var AllowedPgbouncerGenericConfigurationParameters = stringset.From([]string{
 	"application_name_add_host",
 	"auth_type",
+	"auth_user",
 	"autodb_idle_timeout",
 	"cancel_wait_timeout",
 	"client_idle_timeout",

--- a/internal/webhook/v1/pooler_webhook_test.go
+++ b/internal/webhook/v1/pooler_webhook_test.go
@@ -139,6 +139,17 @@ var _ = Describe("Pooler validation", func() {
 		}
 		Expect(v.validatePgbouncerGenericParameters(pooler)).To(BeEmpty())
 	})
+
+	It("does not complain when overriding auth_user", func() {
+		pooler := &apiv1.Pooler{
+			Spec: apiv1.PoolerSpec{
+				PgBouncer: &apiv1.PgBouncerSpec{
+					Parameters: map[string]string{"auth_user": "pgbouncer"},
+				},
+			},
+		}
+		Expect(v.validatePgbouncerGenericParameters(pooler)).To(BeEmpty())
+	})
 })
 
 var _ = Describe("Pooler validateMonitoring", func() {

--- a/pkg/management/pgbouncer/config/config.go
+++ b/pkg/management/pgbouncer/config/config.go
@@ -201,6 +201,10 @@ func BuildConfigurationFiles(pooler *apiv1.Pooler, secrets *Secrets) (Configurat
 		parameters["auth_file"] = authFilePath
 	}
 
+	if explicitAuthUser, ok := parameters["auth_user"]; ok {
+		authQueryUser = explicitAuthUser
+	}
+
 	if secrets.ServerTLS != nil {
 		parameters["server_tls_cert_file"] = serverTLSCertPath
 		parameters["server_tls_key_file"] = serverTLSKeyPath

--- a/pkg/management/pgbouncer/config/config.go
+++ b/pkg/management/pgbouncer/config/config.go
@@ -201,9 +201,14 @@ func BuildConfigurationFiles(pooler *apiv1.Pooler, secrets *Secrets) (Configurat
 		parameters["auth_file"] = authFilePath
 	}
 
-	if explicitAuthUser, ok := parameters["auth_user"]; ok {
+	// auth_user has its own slot in the pgbouncer.ini template, so an override
+	// is applied to that value and the key is removed from the generic
+	// parameters block to avoid emitting the setting twice. An empty value is
+	// ignored so it cannot blank the user derived from the auth query secret.
+	if explicitAuthUser := parameters["auth_user"]; explicitAuthUser != "" {
 		authQueryUser = explicitAuthUser
 	}
+	delete(parameters, "auth_user")
 
 	if secrets.ServerTLS != nil {
 		parameters["server_tls_cert_file"] = serverTLSCertPath

--- a/pkg/management/pgbouncer/config/config.go
+++ b/pkg/management/pgbouncer/config/config.go
@@ -23,7 +23,6 @@ import (
 	"bytes"
 	"fmt"
 	"path/filepath"
-	"strings"
 	"text/template"
 
 	corev1 "k8s.io/api/core/v1"
@@ -169,7 +168,7 @@ func BuildConfigurationFiles(pooler *apiv1.Pooler, secrets *Secrets) (Configurat
 		switch authQuerySecretType {
 		case corev1.SecretTypeBasicAuth:
 			authQueryUser = string(authQuerySecret.Data["username"])
-			authQueryPassword = strings.ReplaceAll(string(authQuerySecret.Data["password"]), "\"", "\"\"")
+			authQueryPassword = escapePgBouncerUserListValue(string(authQuerySecret.Data["password"]))
 
 		case corev1.SecretTypeTLS:
 			keyPair, err := certs.ParseServerSecret(authQuerySecret)
@@ -209,6 +208,7 @@ func BuildConfigurationFiles(pooler *apiv1.Pooler, secrets *Secrets) (Configurat
 		authQueryUser = explicitAuthUser
 	}
 	delete(parameters, "auth_user")
+	authQueryUser = escapePgBouncerUserListValue(authQueryUser)
 
 	if secrets.ServerTLS != nil {
 		parameters["server_tls_cert_file"] = serverTLSCertPath

--- a/pkg/management/pgbouncer/config/config.go
+++ b/pkg/management/pgbouncer/config/config.go
@@ -193,13 +193,6 @@ func BuildConfigurationFiles(pooler *apiv1.Pooler, secrets *Secrets) (Configurat
 
 	parameters := buildPgBouncerParameters(pooler.Spec.PgBouncer.Parameters)
 
-	if isCertAuth {
-		parameters["server_tls_cert_file"] = authUserCrtPath
-		parameters["server_tls_key_file"] = authUserKeyPath
-	} else {
-		parameters["auth_file"] = authFilePath
-	}
-
 	// auth_user has its own slot in the pgbouncer.ini template, so an override
 	// is applied to that value and the key is removed from the generic
 	// parameters block to avoid emitting the setting twice. An empty value is
@@ -209,6 +202,13 @@ func BuildConfigurationFiles(pooler *apiv1.Pooler, secrets *Secrets) (Configurat
 	}
 	delete(parameters, "auth_user")
 	authQueryUser = escapePgBouncerUserListValue(authQueryUser)
+
+	if isCertAuth {
+		parameters["server_tls_cert_file"] = authUserCrtPath
+		parameters["server_tls_key_file"] = authUserKeyPath
+	} else {
+		parameters["auth_file"] = authFilePath
+	}
 
 	if secrets.ServerTLS != nil {
 		parameters["server_tls_cert_file"] = serverTLSCertPath

--- a/pkg/management/pgbouncer/config/config_test.go
+++ b/pkg/management/pgbouncer/config/config_test.go
@@ -1,0 +1,110 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package config
+
+import (
+	"path/filepath"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("BuildConfigurationFiles", func() {
+	iniPath := filepath.Join(ConfigsDir, PgBouncerIniFileName)
+	userListPath := filepath.Join(ConfigsDir, PgBouncerUserListFileName)
+
+	// newSecrets returns a Secrets value backed by a basic-auth auth query
+	// secret. BuildConfigurationFiles dereferences the crypto-material secrets
+	// unconditionally, so they are populated with placeholder, non-nil content.
+	newSecrets := func() *Secrets {
+		return &Secrets{
+			AuthQuery: &corev1.Secret{
+				Type: corev1.SecretTypeBasicAuth,
+				Data: map[string][]byte{
+					corev1.BasicAuthUsernameKey: []byte("test-username"),
+					corev1.BasicAuthPasswordKey: []byte("test-password"),
+				},
+			},
+			ServerCA:  &corev1.Secret{Data: map[string][]byte{}},
+			ClientCA:  &corev1.Secret{Data: map[string][]byte{}},
+			ClientTLS: &corev1.Secret{Data: map[string][]byte{}},
+		}
+	}
+
+	// newPooler returns a minimal Pooler carrying the given generic parameters.
+	newPooler := func(parameters map[string]string) *apiv1.Pooler {
+		return &apiv1.Pooler{
+			ObjectMeta: metav1.ObjectMeta{Name: "pooler-example"},
+			Spec: apiv1.PoolerSpec{
+				Cluster: apiv1.LocalObjectReference{Name: "cluster-example"},
+				Type:    apiv1.PoolerTypeRW,
+				PgBouncer: &apiv1.PgBouncerSpec{
+					PoolMode:   apiv1.PgBouncerPoolModeSession,
+					Parameters: parameters,
+				},
+			},
+		}
+	}
+
+	It("derives auth_user from the auth query secret when no override is set", func() {
+		files, err := BuildConfigurationFiles(newPooler(nil), newSecrets())
+		Expect(err).ToNot(HaveOccurred())
+
+		ini := string(files[iniPath])
+		Expect(ini).To(ContainSubstring("auth_user = test-username"))
+		Expect(strings.Count(ini, "auth_user")).To(Equal(1))
+		Expect(string(files[userListPath])).To(ContainSubstring(`"test-username" "test-password"`))
+	})
+
+	It("applies the auth_user override without emitting the key twice", func() {
+		files, err := BuildConfigurationFiles(
+			newPooler(map[string]string{"auth_user": "pgbouncer"}),
+			newSecrets(),
+		)
+		Expect(err).ToNot(HaveOccurred())
+
+		ini := string(files[iniPath])
+		Expect(ini).To(ContainSubstring("auth_user = pgbouncer"))
+		// auth_user has a dedicated template line, so it must appear exactly
+		// once and never leak through the generic parameters block.
+		Expect(strings.Count(ini, "auth_user")).To(Equal(1))
+		// The password is still taken from the auth query secret.
+		Expect(string(files[userListPath])).To(ContainSubstring(`"pgbouncer" "test-password"`))
+	})
+
+	It("ignores an empty auth_user override and keeps the derived user", func() {
+		files, err := BuildConfigurationFiles(
+			newPooler(map[string]string{"auth_user": ""}),
+			newSecrets(),
+		)
+		Expect(err).ToNot(HaveOccurred())
+
+		ini := string(files[iniPath])
+		Expect(ini).To(ContainSubstring("auth_user = test-username"))
+		Expect(strings.Count(ini, "auth_user")).To(Equal(1))
+		Expect(ini).ToNot(ContainSubstring("auth_user = \n"))
+	})
+})

--- a/pkg/management/pgbouncer/config/config_test.go
+++ b/pkg/management/pgbouncer/config/config_test.go
@@ -107,4 +107,14 @@ var _ = Describe("BuildConfigurationFiles", func() {
 		Expect(strings.Count(ini, "auth_user")).To(Equal(1))
 		Expect(ini).ToNot(ContainSubstring("auth_user = \n"))
 	})
+
+	It("escapes double quotes in the auth_user override for userlist.txt", func() {
+		files, err := BuildConfigurationFiles(
+			newPooler(map[string]string{"auth_user": `pg"bouncer`}),
+			newSecrets(),
+		)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(string(files[userListPath])).To(ContainSubstring(`"pg""bouncer" "test-password"`))
+	})
 })

--- a/pkg/management/pgbouncer/config/strings.go
+++ b/pkg/management/pgbouncer/config/strings.go
@@ -83,3 +83,10 @@ func cleanupPgBouncerValue(parameter string) (escaped string) {
 	// so we are just removing from the value
 	return newlineRegexp.ReplaceAllString(parameter, "")
 }
+
+// escapePgBouncerUserListValue doubles any double quote in a value so it can
+// be safely placed inside one of userlist.txt's double-quoted fields without
+// desyncing the line.
+func escapePgBouncerUserListValue(value string) string {
+	return strings.ReplaceAll(value, "\"", "\"\"")
+}


### PR DESCRIPTION
Adds an auth_user parameter to override the user PgBouncer uses to run the auth_query, instead of always deriving it from the auth query secret. This is meant for setups with a custom authQuerySecret where the desired role differs from what the secret implies.

Closes #10898