### PR TITLE
fix(plugin): update plugin address to use FQDN

### DIFF
--- a/internal/controller/plugin_controller.go
+++ b/internal/controller/plugin_controller.go
@@ -244,7 +244,9 @@ func (r *PluginReconciler) reconcile(
 		return ctrl.Result{}, err
 	}
 
-	pluginAddress := fmt.Sprintf("%s:%d", service.Name, pluginPort)
+	// Use the in-cluster service FQDN to match common NO_PROXY patterns
+	// in managed environments where proxy env vars are injected.
+	pluginAddress := fmt.Sprintf("%s.%s.svc:%d", service.Name, service.Namespace, pluginPort)
 
 	// Use custom server name if provided, otherwise default to service name
 	serverName := service.Annotations[utils.PluginServerNameAnnotationName]

--- a/internal/controller/plugin_controller_test.go
+++ b/internal/controller/plugin_controller_test.go
@@ -117,6 +117,7 @@ var _ = Describe("PluginReconciler", func() {
 		serverSecretName = "plugin-server-secret"
 		clientSecretName = "plugin-client-secret"
 		pluginPort       = "9090"
+		serviceFQDN      = serviceName + "." + testNamespace + ".svc"
 	)
 
 	var (
@@ -215,7 +216,7 @@ var _ = Describe("PluginReconciler", func() {
 			Expect(pluginRepository.registeredPlugins).To(HaveKey(pluginName))
 			registration := pluginRepository.registeredPlugins[pluginName]
 			Expect(registration.tlsConfig.ServerName).To(Equal(serviceName))
-			Expect(registration.address).To(Equal(serviceName + ":" + pluginPort))
+			Expect(registration.address).To(Equal(serviceFQDN + ":" + pluginPort))
 		})
 
 		It("should use custom ServerName when annotation is provided", func() {
@@ -246,7 +247,7 @@ var _ = Describe("PluginReconciler", func() {
 			Expect(pluginRepository.registeredPlugins).To(HaveKey(pluginName))
 			registration := pluginRepository.registeredPlugins[pluginName]
 			Expect(registration.tlsConfig.ServerName).To(Equal(customServerName))
-			Expect(registration.address).To(Equal(serviceName + ":" + pluginPort))
+			Expect(registration.address).To(Equal(serviceFQDN + ":" + pluginPort))
 		})
 
 		It("should skip reconciliation when server secret annotation is missing", func() {
@@ -441,7 +442,7 @@ var _ = Describe("PluginReconciler", func() {
 
 			// Manually register the plugin
 			pluginRepository.registeredPlugins[pluginName] = &pluginRegistration{
-				address: serviceName + ":" + pluginPort,
+				address: serviceFQDN + ":" + pluginPort,
 			}
 
 			// Delete the service (without finalizer, it's immediately deleted)


### PR DESCRIPTION
Use FQDN instead of short name to connect to plugins. This is a best practice and avoids issues when a proxy is set at cluster level and automatically injected in pods.

Closes #7947 