### PR TITLE
fix(plugins): honour enabled flag on external cluster plugin configurations

### DIFF
--- a/api/v1/cluster_funcs.go
+++ b/api/v1/cluster_funcs.go
@@ -140,7 +140,7 @@ func (cluster *Cluster) GetJobEnabledPluginNames() (result []string) {
 func GetExternalClustersEnabledPluginNames(externalClusters []ExternalCluster) (result []string) {
 	pluginNames := make([]string, 0, len(externalClusters))
 	for _, externalCluster := range externalClusters {
-		if externalCluster.PluginConfiguration != nil {
+		if externalCluster.PluginConfiguration != nil && externalCluster.PluginConfiguration.IsEnabled() {
 			pluginNames = append(pluginNames, externalCluster.PluginConfiguration.Name)
 		}
 	}

--- a/api/v1/cluster_funcs_test.go
+++ b/api/v1/cluster_funcs_test.go
@@ -1866,3 +1866,28 @@ var _ = Describe("RecoveryTarget.BuildPostgresOptions", func() {
 		Expect(out).To(ContainSubstring(`recovery_target_lsn = '0/1\\6'` + "\n"))
 	})
 })
+
+var _ = Describe("GetExternalClustersEnabledPluginNames", func() {
+	falseVal := false
+
+	It("includes plugins with nil Enabled (defaults to enabled)", func() {
+		clusters := []ExternalCluster{
+			{PluginConfiguration: &PluginConfiguration{Name: "plugin-a"}},
+		}
+		Expect(GetExternalClustersEnabledPluginNames(clusters)).To(ConsistOf("plugin-a"))
+	})
+
+	It("excludes plugins with Enabled=false", func() {
+		clusters := []ExternalCluster{
+			{PluginConfiguration: &PluginConfiguration{Name: "plugin-a", Enabled: &falseVal}},
+		}
+		Expect(GetExternalClustersEnabledPluginNames(clusters)).To(BeEmpty())
+	})
+
+	It("excludes external clusters without a plugin configuration", func() {
+		clusters := []ExternalCluster{
+			{ConnectionParameters: map[string]string{"host": "pg.example.com"}},
+		}
+		Expect(GetExternalClustersEnabledPluginNames(clusters)).To(BeEmpty())
+	})
+})

--- a/internal/controller/cluster_controller_test.go
+++ b/internal/controller/cluster_controller_test.go
@@ -618,10 +618,10 @@ var _ = Describe("getPluginsNeededForReconcile", func() {
 			To(ConsistOf("plugin-a", "plugin-ext"))
 	})
 
-	It("includes external-cluster plugins even when explicitly disabled", func() {
-		// GetExternalClustersEnabledPluginNames does not consult
-		// PluginConfiguration.Enabled — any non-nil PluginConfiguration on an
-		// external cluster contributes its name. This test locks that in.
+	It("excludes external-cluster plugins that are explicitly disabled", func() {
+		// GetExternalClustersEnabledPluginNames honours
+		// PluginConfiguration.Enabled, so a disabled plugin on an external
+		// cluster does not contribute its name.
 		cluster := &apiv1.Cluster{
 			Spec: apiv1.ClusterSpec{
 				ExternalClusters: []apiv1.ExternalCluster{
@@ -635,8 +635,7 @@ var _ = Describe("getPluginsNeededForReconcile", func() {
 				},
 			},
 		}
-		Expect(getPluginsNeededForReconcile(cluster)).
-			To(ConsistOf("plugin-ext"))
+		Expect(getPluginsNeededForReconcile(cluster)).To(BeEmpty())
 	})
 
 	It("deduplicates plugin names that appear in both Spec.Plugins and external clusters", func() {


### PR DESCRIPTION
The function checked only whether `PluginConfiguration` was non-nil, skipping the `IsEnabled()` call that the sibling function `GetPluginConfigurationEnabledPluginNames` already makes. An explicitly-disabled external-cluster plugin was therefore still returned as active.

Closes #10930

----

**Release note:** Fixed a bug where setting `enabled: false` on an external cluster plugin configuration was not honoured.