### PR TITLE
fix(exec): use FallbackExecutor to restore OpenShift compatibility

### DIFF
--- a/pkg/utils/exec.go
+++ b/pkg/utils/exec.go
@@ -202,7 +202,17 @@ func execCommandOnce(
 		Stderr:    true,
 	}, scheme.ParameterCodec)
 
-	executor, err := remotecommand.NewWebSocketExecutor(&newConfig, "POST", req.URL().String())
+	wsExecutor, err := remotecommand.NewWebSocketExecutor(&newConfig, "POST", req.URL().String())
+	if err != nil {
+		return "", "", err
+	}
+	spdyExecutor, err := remotecommand.NewSPDYExecutor(&newConfig, "POST", req.URL())
+	if err != nil {
+		return "", "", err
+	}
+	executor, err := remotecommand.NewFallbackExecutor(wsExecutor, spdyExecutor, func(err error) bool {
+		return strings.Contains(err.Error(), "websocket: bad handshake")
+	})
 	if err != nil {
 		return "", "", err
 	}

--- a/pkg/utils/exec.go
+++ b/pkg/utils/exec.go
@@ -39,6 +39,7 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/remotecommand"
+	"k8s.io/streaming/pkg/httpstream"
 )
 
 const (
@@ -172,6 +173,17 @@ func ExecCommand(
 	return stdout, stderr, execErr
 }
 
+// shouldFallbackToSPDY reports whether a failed WebSocket streaming attempt
+// should be retried over SPDY. This mirrors kubectl's own fallback predicate:
+// a WebSocket upgrade failure (e.g. an API server or container runtime that
+// does not support the V5 WebSocket subprotocol, as on some OpenShift
+// versions) is wrapped as an httpstream.UpgradeFailureError, and an HTTPS
+// proxy dial failure is detected separately. Both indicate the connection was
+// never established over WebSocket and is safe to retry over SPDY.
+func shouldFallbackToSPDY(err error) bool {
+	return httpstream.IsUpgradeFailure(err) || httpstream.IsHTTPSProxyError(err)
+}
+
 // execCommandOnce performs a single kubectl exec operation without retries
 func execCommandOnce(
 	ctx context.Context,
@@ -210,9 +222,7 @@ func execCommandOnce(
 	if err != nil {
 		return "", "", err
 	}
-	executor, err := remotecommand.NewFallbackExecutor(wsExecutor, spdyExecutor, func(err error) bool {
-		return strings.Contains(err.Error(), "websocket: bad handshake")
-	})
+	executor, err := remotecommand.NewFallbackExecutor(wsExecutor, spdyExecutor, shouldFallbackToSPDY)
 	if err != nil {
 		return "", "", err
 	}

--- a/pkg/utils/exec_test.go
+++ b/pkg/utils/exec_test.go
@@ -21,9 +21,12 @@ package utils
 
 import (
 	"errors"
+	"fmt"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/streaming/pkg/httpstream"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -158,5 +161,46 @@ var _ = Describe("isRetryableExecError", func() {
 			err := errors.New("I/O TIMEOUT")
 			Expect(isRetryableExecError(err)).To(BeTrue())
 		})
+	})
+})
+
+var _ = Describe("shouldFallbackToSPDY", func() {
+	It("should return false for a nil error", func() {
+		Expect(shouldFallbackToSPDY(nil)).To(BeFalse())
+	})
+
+	It("should return true for a WebSocket upgrade failure (bad handshake)", func() {
+		err := &httpstream.UpgradeFailureError{Cause: errors.New("websocket: bad handshake")}
+		Expect(shouldFallbackToSPDY(err)).To(BeTrue())
+	})
+
+	It("should return true when the upgrade failure is wrapped", func() {
+		err := fmt.Errorf("error streaming: %w",
+			&httpstream.UpgradeFailureError{Cause: errors.New("websocket: bad handshake")})
+		Expect(shouldFallbackToSPDY(err)).To(BeTrue())
+	})
+
+	It("should return true even when the handshake cause is a decoded Kubernetes status", func() {
+		// The WebSocket round tripper replaces the bad-handshake cause with a
+		// StatusError when the server returns a decodable metav1.Status, so the
+		// error string no longer mentions "bad handshake". The fallback must
+		// still trigger off the UpgradeFailureError wrapper.
+		statusErr := &apierrors.StatusError{ErrStatus: metav1.Status{
+			Message: "the server does not allow this method on the requested resource",
+			Reason:  metav1.StatusReasonBadRequest,
+		}}
+		err := &httpstream.UpgradeFailureError{Cause: statusErr}
+		Expect(err.Error()).NotTo(ContainSubstring("bad handshake"))
+		Expect(shouldFallbackToSPDY(err)).To(BeTrue())
+	})
+
+	It("should return true for an HTTPS proxy dial error", func() {
+		err := errors.New("proxy: unknown scheme: https")
+		Expect(shouldFallbackToSPDY(err)).To(BeTrue())
+	})
+
+	It("should return false for an unrelated error", func() {
+		err := errors.New("command terminated with exit code 1")
+		Expect(shouldFallbackToSPDY(err)).To(BeFalse())
 	})
 })


### PR DESCRIPTION
Switch `execCommandOnce` from `NewWebSocketExecutor` to `NewFallbackExecutor`, which tries WebSocket first and falls back to SPDY when the handshake is rejected. OpenShift rejects WebSocket exec upgrades with 403 Forbidden, causing every exec call through this path to fail.

Closes #10931