### PR TITLE
docs: document automatic plugin reload on pod rollout

### DIFF
--- a/.wordlist-en-custom.txt
+++ b/.wordlist-en-custom.txt
@@ -168,6 +168,8 @@ EmbeddedObjectMetadata
 EnablePDB
 Endevir
 EndpointCA
+EndpointSlice
+EndpointSlices
 EnsureOption
 EnterpriseDB
 Enum

--- a/docs/src/cnpg_i.md
+++ b/docs/src/cnpg_i.md
@@ -94,6 +94,12 @@ TCP gRPC endpoint behind a Service, with **mTLS** for secure communication.
 Standalone plugins are discovered dynamically by watching for Services with the
 required labels and annotations — no operator restart is needed.
 
+When a standalone plugin's pods are rolled (for example, after upgrading its
+image), the operator detects the change through the EndpointSlices backing the
+plugin Service and reconciles every cluster using that plugin, so they start
+interacting with the new pods promptly instead of waiting for the periodic
+resync.
+
 Example Deployment:
 
 ```yaml


### PR DESCRIPTION
Follow-up to #10836. That PR made the operator reconcile clusters when a CNPG-i plugin's pods are rolled, but the CNPG-i documentation still only described how new plugins are discovered, not what happens when an existing plugin is upgraded.

This adds a short note to the standalone deployment section explaining that the operator detects plugin pod rollouts through the backing EndpointSlices and promptly reconciles the affected clusters, so they reconnect to the new pods without waiting for the periodic resync.