### PR TITLE
ci: build the operator image in parallel with unit-tests and linters

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,8 +1,15 @@
 # This workflow executes the following actions:
-# - Runs Golang and ShellCheck linters
+# - Runs Golang, ShellCheck and Renovate linters
+# - Runs Govulncheck
 # - Runs Unit tests
 # - Verifies API doc and CRDs are up to date
-# - Builds the operator image (no push)
+# - Verifies documentation website builds
+# - Builds and pushes the operator image (no push if the PR has been opened from a fork)
+# - Generates SLSA3+ provenance for the operator image
+# - Creates and pushes an operator's OLM bundle and catalog
+# - Runs openshift-preflight test
+# - Runs OLM scorecard test
+# - Runs community-operators OPP tests (kiwi,lemon,orange)
 name: continuous-integration
 on:
   push:
@@ -331,6 +338,20 @@ jobs:
         run: |
           echo "Unit test coverage: $(tail -n 1 coverage.out | awk '{print $3}')" >> $GITHUB_STEP_SUMMARY
 
+  unit-tests:
+    name: Unit tests
+    needs:
+      - tests
+    if: always() && !cancelled()
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Report matrix result
+        env:
+          RESULT: ${{ needs.tests.result }}
+        run: |
+          echo "Aggregated unit tests result: ${RESULT}"
+          [[ "${RESULT}" == "success" || "${RESULT}" == "skipped" ]]
+
   apidoc:
     name: Verify API doc is up to date
     needs:
@@ -424,17 +445,9 @@ jobs:
   buildx:
     name: Build containers
     needs:
-      - go-linters
-      - shellcheck
-      - tests
-      - apidoc
-      - crd
       - duplicate_runs
       - change-triage
-    # Build containers:
-    #   if there have been any code changes OR it is a scheduled execution
-    #   AND
-    #   none of the preceding jobs failed
+    # Build containers if there have been any code changes OR it is a scheduled execution
     if: |
       (always() && !cancelled()) &&
       (
@@ -445,12 +458,7 @@ jobs:
           needs.change-triage.outputs.shell-script-changed == 'true' ||
           needs.change-triage.outputs.go-code-changed == 'true'
         )
-      ) &&
-      (needs.go-linters.result == 'success' || needs.go-linters.result == 'skipped') &&
-      (needs.shellcheck.result == 'success' || needs.shellcheck.result == 'skipped') &&
-      (needs.tests.result == 'success' || needs.tests.result == 'skipped') &&
-      (needs.apidoc.result == 'success' || needs.apidoc.result == 'skipped') &&
-      (needs.crd.result == 'success' || needs.crd.result == 'skipped')
+      )
     runs-on: ${{ github.repository_owner == 'cloudnative-pg' && 'ubuntu-latest-16-cores' || 'ubuntu-24.04' }}
     permissions:
       actions: read


### PR DESCRIPTION
Build the operator image in parallel with unit-tests and linters.
Add a unit-tests job aggregate to allow adding unit-tests as a required status check of the PR.
Update outdated comment describing the workflow's summary.

Closes #10862 