### PR TITLE
fix(plugin): replace finalizer with in-memory cleanup on service deletion

### DIFF
--- a/internal/controller/plugin_controller.go
+++ b/internal/controller/plugin_controller.go
@@ -106,13 +106,13 @@ func (r *PluginReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		return ctrl.Result{}, fmt.Errorf("cannot get the resource: %w", err)
 	}
 
-	// Remove the legacy finalizer (e.g., after upgrade from an older version)
-	// before any plugin service check: a Service that no longer matches the
-	// plugin label or annotations would otherwise keep the finalizer forever,
-	// blocking its deletion.
-	if controllerutil.ContainsFinalizer(&service, utils.PluginFinalizerName) {
+	// Remove the legacy finalizer (see PluginFinalizerName for why it's
+	// kept around) before any plugin service check: a Service that no
+	// longer matches the plugin label or annotations would otherwise keep
+	// the finalizer forever, blocking its deletion.
+	if controllerutil.ContainsFinalizer(&service, utils.PluginFinalizerName) { //nolint:staticcheck
 		contextLogger.Debug("Removing legacy finalizer from plugin service")
-		controllerutil.RemoveFinalizer(&service, utils.PluginFinalizerName)
+		controllerutil.RemoveFinalizer(&service, utils.PluginFinalizerName) //nolint:staticcheck
 		if err := r.Update(ctx, &service); err != nil {
 			contextLogger.Error(err, "Error while removing legacy finalizer from plugin service")
 			r.Recorder.Eventf(&service, "Warning", "FinalizerRemovalFailed",

--- a/internal/controller/plugin_controller.go
+++ b/internal/controller/plugin_controller.go
@@ -28,6 +28,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/cloudnative-pg/machinery/pkg/log"
@@ -56,6 +57,10 @@ type PluginReconciler struct {
 	Plugins  repository.Interface
 
 	OperatorNamespace string
+
+	// pluginNames maps service keys ("namespace/name") to plugin names
+	// for cleanup when the service is deleted without a finalizer
+	pluginNames sync.Map
 }
 
 // NewPluginReconciler creates a new PluginReconciler initializing it
@@ -86,6 +91,11 @@ func (r *PluginReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	if err := r.Get(ctx, req.NamespacedName, &service); err != nil {
 		// This also happens when you delete a resource in k8s
 		if apierrs.IsNotFound(err) {
+			if name, ok := r.pluginNames.LoadAndDelete(req.NamespacedName.String()); ok {
+				contextLogger.Info("Plugin service deleted, removing from pool",
+					"pluginName", name)
+				r.Plugins.ForgetPlugin(name.(string))
+			}
 			return ctrl.Result{}, nil
 		}
 
@@ -105,21 +115,21 @@ func (r *PluginReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		return ctrl.Result{}, nil
 	}
 
+	// Cache the service→plugin mapping for cleanup on deletion without finalizer
+	r.pluginNames.Store(req.NamespacedName.String(), pluginName)
+
 	// Handle deletion
 	if !service.DeletionTimestamp.IsZero() {
 		return ctrl.Result{}, r.handleDeletion(ctx, &service, pluginName)
 	}
 
-	// Add finalizer if not present
-	if !controllerutil.ContainsFinalizer(&service, utils.PluginFinalizerName) {
-		contextLogger.Debug("Adding finalizer to plugin service")
-		controllerutil.AddFinalizer(&service, utils.PluginFinalizerName)
+	// Remove finalizer if still present (e.g., after upgrade from older version)
+	if controllerutil.ContainsFinalizer(&service, utils.PluginFinalizerName) {
+		contextLogger.Debug("Removing legacy finalizer from plugin service")
+		controllerutil.RemoveFinalizer(&service, utils.PluginFinalizerName)
 		if err := r.Update(ctx, &service); err != nil {
-			contextLogger.Error(err, "Error while adding finalizer to plugin service")
 			return ctrl.Result{}, err
 		}
-		r.Recorder.Eventf(&service, "Normal", "FinalizerAdded",
-			"Added finalizer to manage plugin %s lifecycle", pluginName)
 		return ctrl.Result{RequeueAfter: time.Second}, nil
 	}
 

--- a/internal/controller/plugin_controller.go
+++ b/internal/controller/plugin_controller.go
@@ -91,7 +91,7 @@ func (r *PluginReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	if err := r.Get(ctx, req.NamespacedName, &service); err != nil {
 		// This also happens when you delete a resource in k8s
 		if apierrs.IsNotFound(err) {
-			if name, ok := r.pluginNames.LoadAndDelete(req.NamespacedName.String()); ok {
+			if name, ok := r.pluginNames.LoadAndDelete(req.String()); ok {
 				contextLogger.Info("Plugin service deleted, removing from pool",
 					"pluginName", name)
 				r.Plugins.ForgetPlugin(name.(string))
@@ -101,6 +101,19 @@ func (r *PluginReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 
 		// This is a real error, maybe the RBAC configuration is wrong?
 		return ctrl.Result{}, fmt.Errorf("cannot get the resource: %w", err)
+	}
+
+	// Remove the legacy finalizer (e.g., after upgrade from an older version)
+	// before any plugin service check: a Service that no longer matches the
+	// plugin label or annotations would otherwise keep the finalizer forever,
+	// blocking its deletion.
+	if controllerutil.ContainsFinalizer(&service, utils.PluginFinalizerName) {
+		contextLogger.Debug("Removing legacy finalizer from plugin service")
+		controllerutil.RemoveFinalizer(&service, utils.PluginFinalizerName)
+		if err := r.Update(ctx, &service); err != nil {
+			return ctrl.Result{}, err
+		}
+		return ctrl.Result{RequeueAfter: time.Second}, nil
 	}
 
 	if !isPluginService(&service, r.OperatorNamespace) {
@@ -115,22 +128,14 @@ func (r *PluginReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		return ctrl.Result{}, nil
 	}
 
-	// Cache the service→plugin mapping for cleanup on deletion without finalizer
-	r.pluginNames.Store(req.NamespacedName.String(), pluginName)
+	// Cache the service→plugin mapping for cleanup on deletion
+	r.pluginNames.Store(req.String(), pluginName)
 
-	// Handle deletion
+	// A service being deleted has nothing to reconcile: the plugin is
+	// removed from the pool by the NotFound branch above as soon as the
+	// object disappears.
 	if !service.DeletionTimestamp.IsZero() {
-		return ctrl.Result{}, r.handleDeletion(ctx, &service, pluginName)
-	}
-
-	// Remove finalizer if still present (e.g., after upgrade from older version)
-	if controllerutil.ContainsFinalizer(&service, utils.PluginFinalizerName) {
-		contextLogger.Debug("Removing legacy finalizer from plugin service")
-		controllerutil.RemoveFinalizer(&service, utils.PluginFinalizerName)
-		if err := r.Update(ctx, &service); err != nil {
-			return ctrl.Result{}, err
-		}
-		return ctrl.Result{RequeueAfter: time.Second}, nil
+		return ctrl.Result{}, nil
 	}
 
 	res, err := r.reconcile(ctx, &service, pluginName)
@@ -294,32 +299,6 @@ func (r *PluginReconciler) reconcile(
 		"Successfully registered plugin %s at %s", pluginName, pluginAddress)
 
 	return ctrl.Result{}, nil
-}
-
-func (r *PluginReconciler) handleDeletion(
-	ctx context.Context,
-	service *corev1.Service,
-	pluginName string,
-) error {
-	contextLogger := log.FromContext(ctx).WithValues("pluginName", pluginName)
-
-	if controllerutil.ContainsFinalizer(service, utils.PluginFinalizerName) {
-		contextLogger.Info("Removing plugin from pool due to service deletion")
-		r.Recorder.Eventf(service, "Normal", "PluginCleanup",
-			"Removing plugin %s from pool due to service deletion", pluginName)
-		r.Plugins.ForgetPlugin(pluginName)
-
-		contextLogger.Debug("Removing finalizer from plugin service")
-		controllerutil.RemoveFinalizer(service, utils.PluginFinalizerName)
-		if err := r.Update(ctx, service); err != nil {
-			contextLogger.Error(err, "Error while removing finalizer from plugin service")
-			r.Recorder.Eventf(service, "Warning", "FinalizerRemovalFailed",
-				"Failed to remove finalizer: %v. Check RBAC permissions or API server connectivity", err)
-			return err
-		}
-	}
-
-	return nil
 }
 
 func (r *PluginReconciler) getSecret(

--- a/internal/controller/plugin_controller.go
+++ b/internal/controller/plugin_controller.go
@@ -92,6 +92,9 @@ func (r *PluginReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		// This also happens when you delete a resource in k8s
 		if apierrs.IsNotFound(err) {
 			if name, ok := r.pluginNames.LoadAndDelete(req.String()); ok {
+				// No Kubernetes event: the Service is already gone, and an
+				// event on a reconstructed reference risks landing on a
+				// future Service with the same name.
 				contextLogger.Info("Plugin service deleted, removing from pool",
 					"pluginName", name)
 				r.Plugins.ForgetPlugin(name.(string))
@@ -131,7 +134,6 @@ func (r *PluginReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		return ctrl.Result{}, nil
 	}
 
-	// Cache the service→plugin mapping for cleanup on deletion
 	r.pluginNames.Store(req.String(), pluginName)
 
 	// A service being deleted has nothing to reconcile: the plugin is

--- a/internal/controller/plugin_controller.go
+++ b/internal/controller/plugin_controller.go
@@ -111,6 +111,9 @@ func (r *PluginReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		contextLogger.Debug("Removing legacy finalizer from plugin service")
 		controllerutil.RemoveFinalizer(&service, utils.PluginFinalizerName)
 		if err := r.Update(ctx, &service); err != nil {
+			contextLogger.Error(err, "Error while removing legacy finalizer from plugin service")
+			r.Recorder.Eventf(&service, "Warning", "FinalizerRemovalFailed",
+				"Failed to remove legacy finalizer: %v", err)
 			return ctrl.Result{}, err
 		}
 		return ctrl.Result{RequeueAfter: time.Second}, nil

--- a/internal/controller/plugin_controller_test.go
+++ b/internal/controller/plugin_controller_test.go
@@ -348,7 +348,7 @@ var _ = Describe("PluginReconciler", func() {
 	})
 
 	Context("when handling plugin service lifecycle with finalizers", func() {
-		It("should not add finalizer when reconciling a new plugin service", func() {
+		It("should not add finalizer when reconciling a new plugin service (regression guard)", func() {
 			annotations := map[string]string{
 				utils.PluginServerSecretAnnotationName: serverSecretName,
 				utils.PluginClientSecretAnnotationName: clientSecretName,
@@ -372,7 +372,7 @@ var _ = Describe("PluginReconciler", func() {
 			// Verify no finalizer was added
 			var updatedService corev1.Service
 			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(service), &updatedService)).To(Succeed())
-			Expect(updatedService.Finalizers).ToNot(ContainElement(utils.PluginFinalizerName))
+			Expect(updatedService.Finalizers).ToNot(ContainElement(utils.PluginFinalizerName)) //nolint:staticcheck
 
 			// Verify plugin was registered
 			Expect(pluginRepository.registeredPlugins).To(HaveKey(pluginName))
@@ -386,7 +386,7 @@ var _ = Describe("PluginReconciler", func() {
 			}
 
 			service := createPluginService(annotations)
-			service.Finalizers = []string{utils.PluginFinalizerName}
+			service.Finalizers = []string{utils.PluginFinalizerName} //nolint:staticcheck
 			serverSecret := createSecret(serverSecretName, serverCertPEM, serverKeyPEM)
 			clientSecret := createSecret(clientSecretName, clientCertPEM, clientKeyPEM)
 
@@ -403,14 +403,14 @@ var _ = Describe("PluginReconciler", func() {
 			// Verify finalizer was removed
 			var updatedService corev1.Service
 			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(service), &updatedService)).To(Succeed())
-			Expect(updatedService.Finalizers).ToNot(ContainElement(utils.PluginFinalizerName))
+			Expect(updatedService.Finalizers).ToNot(ContainElement(utils.PluginFinalizerName)) //nolint:staticcheck
 		})
 
 		It("should remove the legacy finalizer even when the service no longer matches the plugin checks", func() {
 			// No annotations: isPluginService fails, but the finalizer must
 			// still be removed or the service could never be deleted
 			service := createPluginService(nil)
-			service.Finalizers = []string{utils.PluginFinalizerName}
+			service.Finalizers = []string{utils.PluginFinalizerName} //nolint:staticcheck
 			Expect(fakeClient.Create(ctx, service)).To(Succeed())
 
 			req := ctrl.Request{NamespacedName: client.ObjectKeyFromObject(service)}
@@ -420,7 +420,7 @@ var _ = Describe("PluginReconciler", func() {
 
 			var updatedService corev1.Service
 			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(service), &updatedService)).To(Succeed())
-			Expect(updatedService.Finalizers).ToNot(ContainElement(utils.PluginFinalizerName))
+			Expect(updatedService.Finalizers).ToNot(ContainElement(utils.PluginFinalizerName)) //nolint:staticcheck
 		})
 
 		It("should keep the plugin registered while the service is terminating with a foreign finalizer", func() {

--- a/internal/controller/plugin_controller_test.go
+++ b/internal/controller/plugin_controller_test.go
@@ -348,7 +348,7 @@ var _ = Describe("PluginReconciler", func() {
 	})
 
 	Context("when handling plugin service lifecycle with finalizers", func() {
-		It("should add finalizer when reconciling a new plugin service", func() {
+		It("should not add finalizer when reconciling a new plugin service", func() {
 			annotations := map[string]string{
 				utils.PluginServerSecretAnnotationName: serverSecretName,
 				utils.PluginClientSecretAnnotationName: clientSecretName,
@@ -363,27 +363,22 @@ var _ = Describe("PluginReconciler", func() {
 			Expect(fakeClient.Create(ctx, serverSecret)).To(Succeed())
 			Expect(fakeClient.Create(ctx, clientSecret)).To(Succeed())
 
-			// First reconcile should add the finalizer
+			// Reconcile should register the plugin without adding a finalizer
 			req := ctrl.Request{NamespacedName: client.ObjectKeyFromObject(service)}
 			result, err := reconciler.Reconcile(ctx, req)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(result.RequeueAfter).To(Equal(time.Second))
+			Expect(result.RequeueAfter).To(BeZero())
 
-			// Verify finalizer was added
+			// Verify no finalizer was added
 			var updatedService corev1.Service
 			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(service), &updatedService)).To(Succeed())
-			Expect(updatedService.Finalizers).To(ContainElement(utils.PluginFinalizerName))
-
-			// Second reconcile should register the plugin
-			result, err = reconciler.Reconcile(ctx, req)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(result.RequeueAfter).To(BeZero())
+			Expect(updatedService.Finalizers).ToNot(ContainElement(utils.PluginFinalizerName))
 
 			// Verify plugin was registered
 			Expect(pluginRepository.registeredPlugins).To(HaveKey(pluginName))
 		})
 
-		It("should cleanup plugin and remove finalizer when service is deleted", func() {
+		It("should remove legacy finalizer from service", func() {
 			annotations := map[string]string{
 				utils.PluginServerSecretAnnotationName: serverSecretName,
 				utils.PluginClientSecretAnnotationName: clientSecretName,
@@ -399,29 +394,48 @@ var _ = Describe("PluginReconciler", func() {
 			Expect(fakeClient.Create(ctx, serverSecret)).To(Succeed())
 			Expect(fakeClient.Create(ctx, clientSecret)).To(Succeed())
 
+			// Reconcile should remove the legacy finalizer
+			req := ctrl.Request{NamespacedName: client.ObjectKeyFromObject(service)}
+			result, err := reconciler.Reconcile(ctx, req)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(time.Second))
+
+			// Verify finalizer was removed
+			var updatedService corev1.Service
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(service), &updatedService)).To(Succeed())
+			Expect(updatedService.Finalizers).ToNot(ContainElement(utils.PluginFinalizerName))
+		})
+
+		It("should cleanup plugin when service is deleted (NotFound path)", func() {
+			annotations := map[string]string{
+				utils.PluginServerSecretAnnotationName: serverSecretName,
+				utils.PluginClientSecretAnnotationName: clientSecretName,
+				utils.PluginPortAnnotationName:         pluginPort,
+			}
+
+			service := createPluginService(annotations)
+			serverSecret := createSecret(serverSecretName, serverCertPEM, serverKeyPEM)
+			clientSecret := createSecret(clientSecretName, clientCertPEM, clientKeyPEM)
+
+			Expect(fakeClient.Create(ctx, service)).To(Succeed())
+			Expect(fakeClient.Create(ctx, serverSecret)).To(Succeed())
+			Expect(fakeClient.Create(ctx, clientSecret)).To(Succeed())
+
 			// First reconcile to register the plugin
 			req := ctrl.Request{NamespacedName: client.ObjectKeyFromObject(service)}
 			_, err := reconciler.Reconcile(ctx, req)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(pluginRepository.registeredPlugins).To(HaveKey(pluginName))
 
-			// Delete the service (this will set DeletionTimestamp since it has a finalizer)
+			// Delete the service fully (no finalizer, so it disappears)
 			Expect(fakeClient.Delete(ctx, service)).To(Succeed())
 
-			// Reconcile should cleanup the plugin and remove finalizer
+			// Reconcile should detect NotFound and cleanup the plugin via cached mapping
 			_, err = reconciler.Reconcile(ctx, req)
 			Expect(err).ToNot(HaveOccurred())
 
 			// Verify plugin was forgotten
 			Expect(pluginRepository.registeredPlugins).ToNot(HaveKey(pluginName))
-
-			// After reconcile, the finalizer should be removed and service should be gone
-			var updatedService corev1.Service
-			err = fakeClient.Get(ctx, client.ObjectKeyFromObject(service), &updatedService)
-			// Service should either be gone (NotFound) or have no finalizer
-			if err == nil {
-				Expect(updatedService.Finalizers).ToNot(ContainElement(utils.PluginFinalizerName))
-			}
 		})
 
 		It("should not cleanup plugin if finalizer is not present on deletion", func() {

--- a/internal/controller/plugin_controller_test.go
+++ b/internal/controller/plugin_controller_test.go
@@ -31,7 +31,6 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
-	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -422,42 +421,6 @@ var _ = Describe("PluginReconciler", func() {
 			var updatedService corev1.Service
 			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(service), &updatedService)).To(Succeed())
 			Expect(updatedService.Finalizers).ToNot(ContainElement(utils.PluginFinalizerName))
-		})
-
-		It("should unblock deletion of a service still carrying the legacy finalizer", func() {
-			annotations := map[string]string{
-				utils.PluginServerSecretAnnotationName: serverSecretName,
-				utils.PluginClientSecretAnnotationName: clientSecretName,
-				utils.PluginPortAnnotationName:         pluginPort,
-			}
-
-			service := createPluginService(annotations)
-			service.Finalizers = []string{utils.PluginFinalizerName}
-			serverSecret := createSecret(serverSecretName, serverCertPEM, serverKeyPEM)
-			clientSecret := createSecret(clientSecretName, clientCertPEM, clientKeyPEM)
-
-			Expect(fakeClient.Create(ctx, service)).To(Succeed())
-			Expect(fakeClient.Create(ctx, serverSecret)).To(Succeed())
-			Expect(fakeClient.Create(ctx, clientSecret)).To(Succeed())
-
-			// Delete: the finalizer keeps the object around, terminating
-			Expect(fakeClient.Delete(ctx, service)).To(Succeed())
-			var terminating corev1.Service
-			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(service), &terminating)).To(Succeed())
-			Expect(terminating.DeletionTimestamp.IsZero()).To(BeFalse())
-
-			// Reconcile strips the finalizer, letting the deletion complete
-			req := ctrl.Request{NamespacedName: client.ObjectKeyFromObject(service)}
-			_, err := reconciler.Reconcile(ctx, req)
-			Expect(err).ToNot(HaveOccurred())
-
-			err = fakeClient.Get(ctx, client.ObjectKeyFromObject(service), &corev1.Service{})
-			Expect(apierrs.IsNotFound(err)).To(BeTrue())
-
-			// The follow-up reconcile of the deleted service is a clean no-op
-			_, err = reconciler.Reconcile(ctx, req)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(pluginRepository.registeredPlugins).ToNot(HaveKey(pluginName))
 		})
 
 		It("should keep the plugin registered while the service is terminating with a foreign finalizer", func() {

--- a/internal/controller/plugin_controller_test.go
+++ b/internal/controller/plugin_controller_test.go
@@ -31,6 +31,7 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -406,6 +407,100 @@ var _ = Describe("PluginReconciler", func() {
 			Expect(updatedService.Finalizers).ToNot(ContainElement(utils.PluginFinalizerName))
 		})
 
+		It("should remove the legacy finalizer even when the service no longer matches the plugin checks", func() {
+			// No annotations: isPluginService fails, but the finalizer must
+			// still be removed or the service could never be deleted
+			service := createPluginService(nil)
+			service.Finalizers = []string{utils.PluginFinalizerName}
+			Expect(fakeClient.Create(ctx, service)).To(Succeed())
+
+			req := ctrl.Request{NamespacedName: client.ObjectKeyFromObject(service)}
+			result, err := reconciler.Reconcile(ctx, req)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(time.Second))
+
+			var updatedService corev1.Service
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(service), &updatedService)).To(Succeed())
+			Expect(updatedService.Finalizers).ToNot(ContainElement(utils.PluginFinalizerName))
+		})
+
+		It("should unblock deletion of a service still carrying the legacy finalizer", func() {
+			annotations := map[string]string{
+				utils.PluginServerSecretAnnotationName: serverSecretName,
+				utils.PluginClientSecretAnnotationName: clientSecretName,
+				utils.PluginPortAnnotationName:         pluginPort,
+			}
+
+			service := createPluginService(annotations)
+			service.Finalizers = []string{utils.PluginFinalizerName}
+			serverSecret := createSecret(serverSecretName, serverCertPEM, serverKeyPEM)
+			clientSecret := createSecret(clientSecretName, clientCertPEM, clientKeyPEM)
+
+			Expect(fakeClient.Create(ctx, service)).To(Succeed())
+			Expect(fakeClient.Create(ctx, serverSecret)).To(Succeed())
+			Expect(fakeClient.Create(ctx, clientSecret)).To(Succeed())
+
+			// Delete: the finalizer keeps the object around, terminating
+			Expect(fakeClient.Delete(ctx, service)).To(Succeed())
+			var terminating corev1.Service
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(service), &terminating)).To(Succeed())
+			Expect(terminating.DeletionTimestamp.IsZero()).To(BeFalse())
+
+			// Reconcile strips the finalizer, letting the deletion complete
+			req := ctrl.Request{NamespacedName: client.ObjectKeyFromObject(service)}
+			_, err := reconciler.Reconcile(ctx, req)
+			Expect(err).ToNot(HaveOccurred())
+
+			err = fakeClient.Get(ctx, client.ObjectKeyFromObject(service), &corev1.Service{})
+			Expect(apierrs.IsNotFound(err)).To(BeTrue())
+
+			// The follow-up reconcile of the deleted service is a clean no-op
+			_, err = reconciler.Reconcile(ctx, req)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(pluginRepository.registeredPlugins).ToNot(HaveKey(pluginName))
+		})
+
+		It("should keep the plugin registered while the service is terminating with a foreign finalizer", func() {
+			annotations := map[string]string{
+				utils.PluginServerSecretAnnotationName: serverSecretName,
+				utils.PluginClientSecretAnnotationName: clientSecretName,
+				utils.PluginPortAnnotationName:         pluginPort,
+			}
+
+			service := createPluginService(annotations)
+			service.Finalizers = []string{"example.com/other-controller"}
+			serverSecret := createSecret(serverSecretName, serverCertPEM, serverKeyPEM)
+			clientSecret := createSecret(clientSecretName, clientCertPEM, clientKeyPEM)
+
+			Expect(fakeClient.Create(ctx, service)).To(Succeed())
+			Expect(fakeClient.Create(ctx, serverSecret)).To(Succeed())
+			Expect(fakeClient.Create(ctx, clientSecret)).To(Succeed())
+
+			// First reconcile to register the plugin
+			req := ctrl.Request{NamespacedName: client.ObjectKeyFromObject(service)}
+			_, err := reconciler.Reconcile(ctx, req)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(pluginRepository.registeredPlugins).To(HaveKey(pluginName))
+
+			// Delete: the foreign finalizer keeps the object terminating,
+			// and the plugin must stay registered until it disappears
+			Expect(fakeClient.Delete(ctx, service)).To(Succeed())
+			_, err = reconciler.Reconcile(ctx, req)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(pluginRepository.registeredPlugins).To(HaveKey(pluginName))
+
+			// Once the foreign finalizer goes away the object disappears and
+			// the next reconcile cleans up the plugin
+			var terminating corev1.Service
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(service), &terminating)).To(Succeed())
+			terminating.Finalizers = nil
+			Expect(fakeClient.Update(ctx, &terminating)).To(Succeed())
+
+			_, err = reconciler.Reconcile(ctx, req)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(pluginRepository.registeredPlugins).ToNot(HaveKey(pluginName))
+		})
+
 		It("should cleanup plugin when service is deleted (NotFound path)", func() {
 			annotations := map[string]string{
 				utils.PluginServerSecretAnnotationName: serverSecretName,
@@ -438,7 +533,7 @@ var _ = Describe("PluginReconciler", func() {
 			Expect(pluginRepository.registeredPlugins).ToNot(HaveKey(pluginName))
 		})
 
-		It("should not cleanup plugin if finalizer is not present on deletion", func() {
+		It("should not cleanup plugin when the service was never tracked by the reconciler", func() {
 			annotations := map[string]string{
 				utils.PluginServerSecretAnnotationName: serverSecretName,
 				utils.PluginClientSecretAnnotationName: clientSecretName,
@@ -467,14 +562,14 @@ var _ = Describe("PluginReconciler", func() {
 			_, err := reconciler.Reconcile(ctx, req)
 			Expect(err).ToNot(HaveOccurred())
 
-			// Since there was no finalizer, the reconciler doesn't handle deletion cleanup
-			// This demonstrates why the finalizer is important
-			// In real scenarios, without the finalizer, plugins would be orphaned
+			// The plugin was registered out of band, so the reconciler has no
+			// service-to-plugin mapping for it: the NotFound reconcile cannot
+			// know which plugin the service was serving and leaves the pool alone
 			Expect(pluginRepository.registeredPlugins).To(HaveKey(pluginName))
 		})
 
 		It("should return nil when service is not found (already deleted)", func() {
-			// This simulates the case where the service has been fully deleted after finalizer cleanup
+			// This simulates a reconcile request for a service that never existed
 			req := ctrl.Request{
 				NamespacedName: client.ObjectKey{
 					Namespace: testNamespace,

--- a/pkg/utils/finalizers.go
+++ b/pkg/utils/finalizers.go
@@ -32,8 +32,13 @@ const (
 	// triggering the deletion of the subscription
 	SubscriptionFinalizerName = MetadataNamespace + "/deleteSubscription"
 
-	// PluginFinalizerName is the name of the finalizer
-	// triggering the cleanup of a plugin when its service is deleted
+	// PluginFinalizerName is the name of the legacy finalizer that used to
+	// trigger the cleanup of a plugin when its service was deleted.
+	//
+	// Deprecated: no longer added to new plugin Services; the operator
+	// only strips it for backward compatibility with objects created by
+	// an older version. Safe to remove once version 1.30 reaches end of
+	// support.
 	PluginFinalizerName = MetadataNamespace + "/cleanupPlugin"
 
 	// RoleFinalizerName is the name of the finalizer


### PR DESCRIPTION
Remove the plugin Service finalizer (cnpg.io/cleanupPlugin) which caused namespaces to hang in Terminating state when the operator and plugins were co-located. The operator pod would be killed during namespace deletion before it could remove the finalizer.

Instead, cache service-to-plugin name mappings in the reconciler and clean up the plugin pool immediately when the controller receives a NotFound event for a deleted Service. This provides equivalent cleanup without blocking namespace deletion.

Existing Services with the legacy finalizer will have it automatically removed on the next reconciliation.

Partially fixes #10535