### PR TITLE
test(e2e): run the RustFS object store under OpenShift's restricted SCC

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -103,6 +103,7 @@
       matchStrings: [
         'rustfsImage = "(?<depName>.+?):(?<currentValue>.*?)"',
         'awsCliImage = "(?<depName>.+?):(?<currentValue>.*?)"',
+        'busyboxImage = "(?<depName>.+?):(?<currentValue>.*?)"',
       ],
       datasourceTemplate: 'docker',
       versioningTemplate: 'semver',

--- a/hack/testing-tools/common/10-config.sh
+++ b/hack/testing-tools/common/10-config.sh
@@ -45,6 +45,9 @@ export RUSTFS_IMG=${RUSTFS_IMG:-$(grep 'rustfsImage.*=' "${ROOT_DIR}/tests/utils
 # AWS CLI Image (S3 client used by the e2e object storage tests)
 export AWSCLI_IMG=${AWSCLI_IMG:-$(grep 'awsCliImage.*=' "${ROOT_DIR}/tests/utils/objectstore/objectstore.go" | awk -F '"' '{print $2}' | tr -d '[:space:]')}
 
+# Busybox Image (init container that prepares the object storage volumes)
+export BUSYBOX_IMG=${BUSYBOX_IMG:-$(grep 'busyboxImage.*=' "${ROOT_DIR}/tests/utils/objectstore/objectstore.go" | awk -F '"' '{print $2}' | tr -d '[:space:]')}
+
 # Apache Image (Hardcoded stable default)
 export APACHE_IMG=${APACHE_IMG:-"httpd"}
 
@@ -72,9 +75,13 @@ if [ -z "${AWSCLI_IMG}" ]; then
   echo "ERROR: Failed to extract AWSCLI_IMG from ${ROOT_DIR}/tests/utils/objectstore/objectstore.go" >&2
   exit 1
 fi
+if [ -z "${BUSYBOX_IMG}" ]; then
+  echo "ERROR: Failed to extract BUSYBOX_IMG from ${ROOT_DIR}/tests/utils/objectstore/objectstore.go" >&2
+  exit 1
+fi
 
 # Define the full array of helper images used by load-helper-images
-HELPER_IMGS=("$POSTGRES_IMG" "$E2E_PRE_ROLLING_UPDATE_IMG" "$PGBOUNCER_IMG" "$RUSTFS_IMG" "$AWSCLI_IMG" "$APACHE_IMG")
+HELPER_IMGS=("$POSTGRES_IMG" "$E2E_PRE_ROLLING_UPDATE_IMG" "$PGBOUNCER_IMG" "$RUSTFS_IMG" "$AWSCLI_IMG" "$BUSYBOX_IMG" "$APACHE_IMG")
 export HELPER_IMGS
 
 # Testing the upgrade will require generating a second operator image, `-prime`

--- a/tests/utils/objectstore/objectstore.go
+++ b/tests/utils/objectstore/objectstore.go
@@ -391,6 +391,11 @@ func sslSetup(namespace string) (Setup, error) {
 			Name: tlsVolumeName,
 			VolumeSource: corev1.VolumeSource{
 				Projected: &corev1.ProjectedVolumeSource{
+					// DefaultMode is intentionally left at Kubernetes' 0644
+					// default: the non-root RustFS server must read the cert
+					// and key whatever UID it runs as, and the pod sets no
+					// fsGroup, so a tighter mode would make them unreadable on
+					// clusters that don't auto-assign one.
 					Sources: []corev1.VolumeProjection{
 						{
 							Secret: &corev1.SecretProjection{

--- a/tests/utils/objectstore/objectstore.go
+++ b/tests/utils/objectstore/objectstore.go
@@ -55,6 +55,9 @@ const (
 	rustfsImage = "docker.io/rustfs/rustfs:1.0.0-beta.8"
 	// awsCliImage is the image used to run the AWS CLI S3 client
 	awsCliImage = "docker.io/amazon/aws-cli:2.35.4"
+	// busyboxImage is used by the init container that prepares writable
+	// working directories for the RustFS server
+	busyboxImage = "docker.io/library/busybox:1.37.0"
 
 	// AccessKeyID is the access key used to authenticate against the object store
 	AccessKeyID = "objectstore"
@@ -152,6 +155,13 @@ func defaultDeployment(namespace string, pvc corev1.PersistentVolumeClaim) appsv
 		Type: corev1.SeccompProfileTypeRuntimeDefault,
 	}
 
+	// RustFS runs as a non-root user and writes its data and logs to these
+	// subdirectories, which the init container creates and makes writable.
+	const (
+		dataDir = "/data/rustfs"
+		logDir  = "/logs/rustfs"
+	)
+
 	deployment := appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "object-store",
@@ -183,6 +193,35 @@ func defaultDeployment(namespace string, pvc corev1.PersistentVolumeClaim) appsv
 							},
 						},
 					},
+					// RustFS runs as a non-root user but the PVC is root-owned, and
+					// a non-root init container cannot chown it on OpenShift.
+					// Instead the init creates a subdirectory it owns and makes it
+					// world-writable, which works as root (kind, cloud) or as the
+					// SCC-assigned UID (OpenShift).
+					InitContainers: []corev1.Container{
+						{
+							Name:  "init-permissions",
+							Image: busyboxImage,
+							Command: []string{
+								"sh", "-c",
+								fmt.Sprintf("mkdir -p %[1]s %[2]s && chmod 0777 %[1]s %[2]s", dataDir, logDir),
+							},
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "data",
+									MountPath: "/data",
+								},
+								{
+									Name:      "logs",
+									MountPath: "/logs",
+								},
+							},
+							SecurityContext: &corev1.SecurityContext{
+								AllowPrivilegeEscalation: ptr.To(false),
+								SeccompProfile:           seccompProfile,
+							},
+						},
+					},
 					Containers: []corev1.Container{
 						{
 							Name:    "object-store",
@@ -200,7 +239,7 @@ func defaultDeployment(namespace string, pvc corev1.PersistentVolumeClaim) appsv
 								},
 								{
 									Name:  "RUSTFS_VOLUMES",
-									Value: "/data",
+									Value: dataDir,
 								},
 								{
 									Name:  "RUSTFS_REGION",
@@ -220,7 +259,7 @@ func defaultDeployment(namespace string, pvc corev1.PersistentVolumeClaim) appsv
 								},
 								{
 									Name:  "RUSTFS_OBS_LOG_DIRECTORY",
-									Value: "/logs",
+									Value: logDir,
 								},
 							},
 							VolumeMounts: []corev1.VolumeMount{
@@ -261,12 +300,10 @@ func defaultDeployment(namespace string, pvc corev1.PersistentVolumeClaim) appsv
 							},
 						},
 					},
+					// No fsGroup/runAsUser: let OpenShift's restricted SCC assign
+					// the UID; elsewhere the server runs as its image default user.
 					SecurityContext: &corev1.PodSecurityContext{
 						SeccompProfile: seccompProfile,
-						// The RustFS image runs as the non-root `rustfs`
-						// user (10001): make the data volume and the
-						// projected TLS certificates group-accessible
-						FSGroup: ptr.To(int64(10001)),
 					},
 				},
 			},
@@ -334,7 +371,6 @@ func sslSetup(namespace string) (Setup, error) {
 	}
 	const tlsVolumeName = "secret-volume"
 	const tlsVolumeMountPath = "/etc/secrets/certs"
-	var secretMode int32 = 0o600
 	// RustFS enables TLS when it finds `rustfs_cert.pem` and `rustfs_key.pem`
 	// in the directory pointed to by RUSTFS_TLS_PATH
 	setup.Deployment.Spec.Template.Spec.Containers[0].Env = append(
@@ -374,7 +410,6 @@ func sslSetup(namespace string) (Setup, error) {
 							},
 						},
 					},
-					DefaultMode: &secretMode,
 				},
 			},
 		},


### PR DESCRIPTION
The RustFS test object store introduced in #10865 hardcoded a pod `fsGroup` of 10001. OpenShift's restricted SCC assigns the pod an arbitrary UID and rejects an out-of-range `fsGroup`, so no pod was ever admitted, the e2e `SynchronizedBeforeSuite` hung waiting for the object store to become ready, and every OpenShift job ran to the 180-minute timeout with no specs executed. This only surfaces under a restricted SCC, which the community kind-based CI does not exercise.

Drop the fixed `fsGroup` so the SCC can assign a compliant UID. On OpenShift the SCC then makes the volumes group-writable through the assigned `fsGroup`. On kind and the cloud providers, where the PVC is root-owned and no `fsGroup` is applied, an init container creates the working subdirectories and makes them writable, so the non-root RustFS user can use them whatever UID it runs as. The projected TLS certificate drops its explicit `0600` mode and uses the default `0644`, so it stays readable when no `fsGroup` is present.

This is a test-harness change only; it does not touch the operator or any production manifest.

Validated on a live OpenShift 4.21 cluster (the pod is rejected before, runs 1/1 with TLS ready after), against a simulated cloud CSI volume (`root:root 0755`, where an fsGroup-only fix CrashLoops the server with a permission-denied on the data dir), and on a plain kind cluster.