### PR TITLE
docs: release note for walrestore bootstrap recovery fix

### DIFF
--- a/.wordlist-en-custom.txt
+++ b/.wordlist-en-custom.txt
@@ -874,6 +874,7 @@ de
 declaratively
 defaultMode
 demotionToken
+dennispidun
 deploymentStrategy
 dereference
 destinationPath

--- a/docs/src/release_notes/v1.30.md
+++ b/docs/src/release_notes/v1.30.md
@@ -257,6 +257,14 @@ on the release branch in GitHub.
   configuration set `enabled: false`.
   ([#10932](https://github.com/cloudnative-pg/cloudnative-pg/pull/10932)) <!-- 1.29 1.28 1.25 -->
 
+- Fixed bootstrap recovery from an object store stopping at the base backup's
+  timeline and silently dropping transactions committed on later timelines.
+  While the cluster timeline is still unset, `.history` files are no longer
+  blocked by the split-brain guard, so PostgreSQL walks forward across every
+  timeline switch during recovery.
+  Contributed by @dennispidun.
+  ([#10818](https://github.com/cloudnative-pg/cloudnative-pg/pull/10818)) <!-- 1.29 1.28 1.25 -->
+
 ### Supported versions
 
 - Kubernetes 1.36, 1.35, and 1.34

--- a/docs/src/release_notes/v1.30.md
+++ b/docs/src/release_notes/v1.30.md
@@ -257,11 +257,12 @@ on the release branch in GitHub.
   configuration set `enabled: false`.
   ([#10932](https://github.com/cloudnative-pg/cloudnative-pg/pull/10932)) <!-- 1.29 1.28 1.25 -->
 
-- Fixed bootstrap recovery from an object store stopping at the base backup's
-  timeline and silently dropping transactions committed on later timelines.
-  While the cluster timeline is still unset, `.history` files are no longer
-  blocked by the split-brain guard, so PostgreSQL walks forward across every
-  timeline switch during recovery.
+- Fixed a race during bootstrap recovery from an object store where the restore
+  job could read a stale `Cluster` (primary not yet recorded and timeline still
+  unset) and have its `.history` files rejected by the split-brain guard. When
+  this happened, recovery stopped at the base backup's timeline and silently
+  dropped transactions committed on later timelines. History files are now
+  allowed while the cluster timeline is unset.
   Contributed by @dennispidun.
   ([#10818](https://github.com/cloudnative-pg/cloudnative-pg/pull/10818)) <!-- 1.29 1.28 1.25 -->
 


### PR DESCRIPTION
Adds the 1.30.0-rc1 release note for #10818, kept out of that PR because it is backported and the rc1 section does not exist on the release branches.