### PR TITLE
fix(ci): label release PRs as do not backport

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -35,5 +35,5 @@ jobs:
           destination_branch: ${{ env.DEST }}
           github_token: ${{ secrets.REPO_GHA_PAT }}
           pr_body: "Automated PR. Will trigger the ${{ env.TAG }} release when approved."
-          pr_label: release
+          pr_label: "release,do not backport,no-issue"
           pr_title: "Version tag to ${{ env.TAG }}"


### PR DESCRIPTION
Release-candidate PRs target main because their tag does not match the final-release regex, so the backport labeler auto-applies backport and release-branch labels and opens a spurious backport on merge. Create the release PR already carrying `do not backport` and `no-issue` so the labeler skips it.

Closes #10961