### PR TITLE
test(e2e): port volume-snapshot and major-upgrade backup tests to plugin-barman-cloud

### DIFF
--- a/tests/e2e/fixtures/volume_snapshot/cluster-pvc-hot-restore-plugin.yaml.template
+++ b/tests/e2e/fixtures/volume_snapshot/cluster-pvc-hot-restore-plugin.yaml.template
@@ -1,0 +1,40 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: cluster-pvc-hot-recovery-plugin
+spec:
+  instances: 2
+  primaryUpdateStrategy: unsupervised
+  imageName: "${POSTGRES_IMG}"
+
+  # Persistent storage configuration
+  storage:
+    storageClass: ${E2E_CSI_STORAGE_CLASS}
+    size: 1Gi
+  walStorage:
+    storageClass: ${E2E_CSI_STORAGE_CLASS}
+    size: 1Gi
+
+  bootstrap:
+    recovery:
+      source: cluster-pvc-hot-snapshot-plugin
+      volumeSnapshots:
+        storage:
+          name: ${SNAPSHOT_PLUGIN_HOT_PGDATA}
+          kind: VolumeSnapshot
+          apiGroup: snapshot.storage.k8s.io
+        walStorage:
+          name: ${SNAPSHOT_PLUGIN_HOT_PGWAL}
+          kind: VolumeSnapshot
+          apiGroup: snapshot.storage.k8s.io
+
+  # Fetch the WALs needed to finalize recovery through plugin-barman-cloud, from
+  # the same ObjectStore the source archived to (serverName matches the source
+  # cluster name).
+  externalClusters:
+    - name: cluster-pvc-hot-snapshot-plugin
+      plugin:
+        name: barman-cloud.cloudnative-pg.io
+        parameters:
+          barmanObjectName: cluster-pvc-hot-snapshot-plugin
+          serverName: cluster-pvc-hot-snapshot-plugin

--- a/tests/e2e/fixtures/volume_snapshot/cluster-pvc-hot-snapshot-plugin.yaml.template
+++ b/tests/e2e/fixtures/volume_snapshot/cluster-pvc-hot-snapshot-plugin.yaml.template
@@ -1,0 +1,34 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: cluster-pvc-hot-snapshot-plugin
+spec:
+  instances: 1
+  primaryUpdateStrategy: unsupervised
+  imageName: "${POSTGRES_IMG}"
+
+  # Persistent storage configuration
+  storage:
+    storageClass: ${E2E_CSI_STORAGE_CLASS}
+    size: 1Gi
+  walStorage:
+    storageClass: ${E2E_CSI_STORAGE_CLASS}
+    size: 1Gi
+
+  backup:
+    # Online (hot) volume-snapshot base backups. WAL archiving is delegated to
+    # plugin-barman-cloud below (no in-core barmanObjectStore).
+    volumeSnapshot:
+      className: ${E2E_DEFAULT_VOLUMESNAPSHOT_CLASS}
+      online: true
+      onlineConfiguration:
+        immediateCheckpoint: true
+        waitForArchive: true
+
+  # Use plugin-barman-cloud as the WAL archiver. The referenced ObjectStore is
+  # created by the test.
+  plugins:
+    - name: barman-cloud.cloudnative-pg.io
+      isWALArchiver: true
+      parameters:
+        barmanObjectName: cluster-pvc-hot-snapshot-plugin

--- a/tests/e2e/fixtures/volume_snapshot/cluster-pvc-snapshot-plugin.yaml.template
+++ b/tests/e2e/fixtures/volume_snapshot/cluster-pvc-snapshot-plugin.yaml.template
@@ -1,0 +1,29 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: cluster-pvc-snapshot-plugin
+spec:
+  instances: 2
+  primaryUpdateStrategy: unsupervised
+
+  # Persistent storage configuration
+  storage:
+    storageClass: ${E2E_CSI_STORAGE_CLASS}
+    size: 1Gi
+  walStorage:
+    storageClass: ${E2E_CSI_STORAGE_CLASS}
+    size: 1Gi
+
+  backup:
+    # Cold volume-snapshot base backups. WAL archiving is delegated to
+    # plugin-barman-cloud below (no in-core barmanObjectStore).
+    volumeSnapshot:
+      className: ${E2E_DEFAULT_VOLUMESNAPSHOT_CLASS}
+
+  # Use plugin-barman-cloud as the WAL archiver. The referenced ObjectStore is
+  # created by the test.
+  plugins:
+    - name: barman-cloud.cloudnative-pg.io
+      isWALArchiver: true
+      parameters:
+        barmanObjectName: cluster-pvc-snapshot-plugin

--- a/tests/e2e/fixtures/volume_snapshot/cluster-pvc-snapshot-restore-plugin.yaml.template
+++ b/tests/e2e/fixtures/volume_snapshot/cluster-pvc-snapshot-restore-plugin.yaml.template
@@ -1,0 +1,41 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: cluster-pvc-snapshot-plugin-recovery
+spec:
+  instances: 2
+  primaryUpdateStrategy: unsupervised
+
+  # Persistent storage configuration
+  storage:
+    storageClass: ${E2E_CSI_STORAGE_CLASS}
+    size: 1Gi
+  walStorage:
+    storageClass: ${E2E_CSI_STORAGE_CLASS}
+    size: 1Gi
+
+  bootstrap:
+    recovery:
+      source: cluster-pvc-snapshot-plugin
+      volumeSnapshots:
+        storage:
+          name: ${SNAPSHOT_PLUGIN_PITR_PGDATA}
+          kind: VolumeSnapshot
+          apiGroup: snapshot.storage.k8s.io
+        walStorage:
+          name: ${SNAPSHOT_PLUGIN_PITR_PGWAL}
+          kind: VolumeSnapshot
+          apiGroup: snapshot.storage.k8s.io
+      recoveryTarget:
+        targetTime: ${SNAPSHOT_PLUGIN_PITR}
+
+  # Fetch the WALs needed to reach the recovery target through
+  # plugin-barman-cloud, from the same ObjectStore the source archived to
+  # (serverName matches the source cluster name).
+  externalClusters:
+    - name: cluster-pvc-snapshot-plugin
+      plugin:
+        name: barman-cloud.cloudnative-pg.io
+        parameters:
+          barmanObjectName: cluster-pvc-snapshot-plugin
+          serverName: cluster-pvc-snapshot-plugin

--- a/tests/e2e/plugin_barman_cloud_major_upgrade_test.go
+++ b/tests/e2e/plugin_barman_cloud_major_upgrade_test.go
@@ -22,6 +22,7 @@ package e2e
 import (
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/cloudnative-pg/machinery/pkg/image/reference"
@@ -83,16 +84,26 @@ var _ = Describe("plugin-barman-cloud across a Postgres major upgrade",
 			targetVersion, err := version.FromTag(reference.New(versions.DefaultImageName).Tag)
 			Expect(err).ToNot(HaveOccurred())
 			targetMajor := targetVersion.Major()
+			targetTag := strconv.FormatUint(targetMajor, 10)
 
 			currentVersion, err := version.FromTag(env.PostgresImageTag)
 			Expect(err).ToNot(HaveOccurred())
 			startMajor := currentVersion.Major()
-			if startMajor >= targetMajor {
+
+			switch {
+			case startMajor == targetMajor:
 				startMajor = targetMajor - 1
+			case startMajor > targetMajor:
+				// env.PostgresImageTag is a not-yet-released beta ahead of the
+				// operator's default: upgrade to it instead of ignoring it, keeping
+				// its raw tag (e.g. "19beta1") since beta images aren't published
+				// under a plain major-number tag.
+				startMajor, targetMajor = targetMajor, startMajor
+				targetTag = strings.Split(env.PostgresImageTag, "-")[0]
 			}
 
 			startImage := env.OfficialMinimalImageName(strconv.FormatUint(startMajor, 10))
-			targetImage := env.MinimalImageName(strconv.FormatUint(targetMajor, 10))
+			targetImage := env.MinimalImageName(targetTag)
 
 			namespace, err := env.CreateUniqueTestNamespace(env.Ctx, env.Client, namespacePrefix)
 			Expect(err).ToNot(HaveOccurred())

--- a/tests/e2e/plugin_barman_cloud_major_upgrade_test.go
+++ b/tests/e2e/plugin_barman_cloud_major_upgrade_test.go
@@ -1,0 +1,193 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package e2e
+
+import (
+	"os"
+	"strconv"
+
+	"github.com/cloudnative-pg/machinery/pkg/image/reference"
+	"github.com/cloudnative-pg/machinery/pkg/postgres/version"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/versions"
+	"github.com/cloudnative-pg/cloudnative-pg/tests"
+	backupasserts "github.com/cloudnative-pg/cloudnative-pg/tests/internal/asserts/backup"
+	clusterasserts "github.com/cloudnative-pg/cloudnative-pg/tests/internal/asserts/cluster"
+	objectstoreasserts "github.com/cloudnative-pg/cloudnative-pg/tests/internal/asserts/objectstore"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/clusterutils"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/exec"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/objects"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/postgres"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/timeouts"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// Plugin counterpart of the in-core "PostgreSQL system" major-upgrade scenario,
+// which is the only one wiring up object-store archiving: it verifies that WAL
+// archiving keeps working after a Postgres major version upgrade. Here the
+// archiver is plugin-barman-cloud rather than the in-core barmanObjectStore. The
+// in-core variant (and the other upgrade scenarios it covers) is left in place.
+// Runs on kind/k3d only, where the plugin and the shared object store are
+// installed.
+var _ = Describe("plugin-barman-cloud across a Postgres major upgrade",
+	Label(tests.LabelPluginBarmanCloud, tests.LabelPostgresMajorUpgrade, tests.LabelBackupRestore), func() {
+		const (
+			level      = tests.High
+			pluginName = "barman-cloud.cloudnative-pg.io"
+		)
+
+		BeforeEach(func() {
+			if testLevelEnv.Depth < int(level) {
+				Skip("Test depth is lower than the amount requested for this test")
+			}
+			if !(IsKind() || IsK3D()) {
+				Skip("This test only runs on kind or k3d clusters")
+			}
+		})
+
+		It("keeps WAL archiving working across a Postgres major upgrade", func() {
+			const (
+				namespacePrefix = "plugin-major-upgrade"
+				clusterName     = "pg-major-upgrade-plugin"
+			)
+
+			// Upgrade from one major behind the operator's default to the default.
+			// The target major comes from versions.DefaultImageName; the starting
+			// major is the env image's major when it is older, otherwise the major
+			// right before the target, so there is always a real upgrade to run.
+			// Starting images come from the official registry, the target from the
+			// (possibly overridden) test one, as in cluster_major_upgrade_test.go.
+			targetVersion, err := version.FromTag(reference.New(versions.DefaultImageName).Tag)
+			Expect(err).ToNot(HaveOccurred())
+			targetMajor := targetVersion.Major()
+
+			currentVersion, err := version.FromTag(env.PostgresImageTag)
+			Expect(err).ToNot(HaveOccurred())
+			startMajor := currentVersion.Major()
+			if startMajor >= targetMajor {
+				startMajor = targetMajor - 1
+			}
+
+			startImage := env.OfficialSystemImageName(strconv.FormatUint(startMajor, 10))
+			targetImage := env.SystemImageName(strconv.FormatUint(targetMajor, 10))
+
+			namespace, err := env.CreateUniqueTestNamespace(env.Ctx, env.Client, namespacePrefix)
+			Expect(err).ToNot(HaveOccurred())
+
+			setupPluginObjectStore(namespace, clusterName)
+
+			storageClass := os.Getenv("E2E_DEFAULT_STORAGE_CLASS")
+			Expect(storageClass).ToNot(BeEmpty())
+
+			By("creating a cluster on the starting major that archives through the plugin", func() {
+				cluster := &apiv1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: namespace},
+					Spec: apiv1.ClusterSpec{
+						Instances: 2,
+						ImageName: startImage,
+						StorageConfiguration: apiv1.StorageConfiguration{
+							StorageClass: &storageClass,
+							Size:         "1Gi",
+						},
+						WalStorage: &apiv1.StorageConfiguration{
+							StorageClass: &storageClass,
+							Size:         "1Gi",
+						},
+						Plugins: []apiv1.PluginConfiguration{
+							{
+								Name:          pluginName,
+								IsWALArchiver: ptr.To(true),
+								Parameters:    map[string]string{"barmanObjectName": clusterName},
+							},
+						},
+					},
+				}
+				Expect(env.Client.Create(env.Ctx, cluster)).To(Succeed())
+				clusterasserts.AssertClusterIsReady(env, namespace, clusterName, testTimeouts[timeouts.ClusterIsReady])
+			})
+
+			By("verifying WAL archiving through the plugin is working before the upgrade", func() {
+				backupasserts.AssertArchiveConditionMet(env, namespace, clusterName, 120)
+			})
+
+			primary, err := clusterutils.GetPrimary(env.Ctx, env.Client, namespace, clusterName)
+			Expect(err).ToNot(HaveOccurred())
+
+			var oldVersion string
+			By("checking the cluster starts on the older major version", func() {
+				stdOut, stdErr, err := exec.EventuallyExecQueryInInstancePod(env.Ctx, env.Client, env.Interface,
+					env.RestClientConfig,
+					exec.PodLocator{Namespace: primary.GetNamespace(), PodName: primary.GetName()}, postgres.AppDBName,
+					"SELECT version();", 60, objects.PollingTime)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(stdErr).To(BeEmpty())
+				Expect(stdOut).To(ContainSubstring(strconv.FormatUint(startMajor, 10)))
+				oldVersion = stdOut
+			})
+
+			By("triggering the major upgrade by updating the image", func() {
+				Eventually(func() error {
+					cluster, err := clusterutils.Get(env.Ctx, env.Client, namespace, clusterName)
+					if err != nil {
+						return err
+					}
+					cluster.Spec.ImageName = targetImage
+					return env.Client.Update(env.Ctx, cluster)
+				}, 60).Should(Succeed())
+			})
+
+			By("waiting for the cluster to enter the major upgrade phase", func() {
+				Eventually(func(g Gomega) {
+					cluster, err := clusterutils.Get(env.Ctx, env.Client, namespace, clusterName)
+					g.Expect(err).ToNot(HaveOccurred())
+					g.Expect(cluster.Status.Phase).To(Equal(apiv1.PhaseMajorUpgrade))
+				}, 120).Should(Succeed())
+			})
+
+			By("waiting for the upgraded cluster to become ready", func() {
+				clusterasserts.AssertClusterIsReady(env, namespace, clusterName, testTimeouts[timeouts.ClusterIsReady])
+			})
+
+			By("verifying the cluster now runs the target major version", func() {
+				primary, err := clusterutils.GetPrimary(env.Ctx, env.Client, namespace, clusterName)
+				Expect(err).ToNot(HaveOccurred())
+				Eventually(func(g Gomega) {
+					stdOut, stdErr, err := exec.EventuallyExecQueryInInstancePod(env.Ctx, env.Client, env.Interface,
+						env.RestClientConfig,
+						exec.PodLocator{Namespace: primary.GetNamespace(), PodName: primary.GetName()}, postgres.AppDBName,
+						"SELECT version();", 60, objects.PollingTime)
+					g.Expect(err).ToNot(HaveOccurred())
+					g.Expect(stdErr).To(BeEmpty())
+					g.Expect(stdOut).ToNot(Equal(oldVersion))
+					g.Expect(stdOut).To(ContainSubstring(strconv.FormatUint(targetMajor, 10)))
+				}, 120).Should(Succeed())
+			})
+
+			By("verifying WAL archiving through the plugin still works after the upgrade", func() {
+				objectstoreasserts.AssertArchiveWalOnObjectStore(env, testTimeouts, objectStoreEnv,
+					namespace, clusterName, clusterName)
+			})
+		})
+	})

--- a/tests/e2e/plugin_barman_cloud_major_upgrade_test.go
+++ b/tests/e2e/plugin_barman_cloud_major_upgrade_test.go
@@ -22,6 +22,7 @@ package e2e
 import (
 	"os"
 	"strconv"
+	"time"
 
 	"github.com/cloudnative-pg/machinery/pkg/image/reference"
 	"github.com/cloudnative-pg/machinery/pkg/postgres/version"
@@ -54,7 +55,7 @@ import (
 var _ = Describe("plugin-barman-cloud across a Postgres major upgrade",
 	Label(tests.LabelPluginBarmanCloud, tests.LabelPostgresMajorUpgrade, tests.LabelBackupRestore), func() {
 		const (
-			level      = tests.High
+			level      = tests.Medium
 			pluginName = "barman-cloud.cloudnative-pg.io"
 		)
 
@@ -90,8 +91,8 @@ var _ = Describe("plugin-barman-cloud across a Postgres major upgrade",
 				startMajor = targetMajor - 1
 			}
 
-			startImage := env.OfficialSystemImageName(strconv.FormatUint(startMajor, 10))
-			targetImage := env.SystemImageName(strconv.FormatUint(targetMajor, 10))
+			startImage := env.OfficialMinimalImageName(strconv.FormatUint(startMajor, 10))
+			targetImage := env.MinimalImageName(strconv.FormatUint(targetMajor, 10))
 
 			namespace, err := env.CreateUniqueTestNamespace(env.Ctx, env.Client, namespacePrefix)
 			Expect(err).ToNot(HaveOccurred())
@@ -107,6 +108,16 @@ var _ = Describe("plugin-barman-cloud across a Postgres major upgrade",
 					Spec: apiv1.ClusterSpec{
 						Instances: 2,
 						ImageName: startImage,
+						Bootstrap: &apiv1.BootstrapConfiguration{
+							InitDB: &apiv1.BootstrapInitDB{
+								PostInitSQL: []string{
+									"CREATE EXTENSION IF NOT EXISTS pg_stat_statements;",
+									"CREATE EXTENSION IF NOT EXISTS pg_trgm;",
+								},
+								DataChecksums:  ptr.To(true),
+								WalSegmentSize: 32,
+							},
+						},
 						StorageConfiguration: apiv1.StorageConfiguration{
 							StorageClass: &storageClass,
 							Size:         "1Gi",
@@ -114,6 +125,18 @@ var _ = Describe("plugin-barman-cloud across a Postgres major upgrade",
 						WalStorage: &apiv1.StorageConfiguration{
 							StorageClass: &storageClass,
 							Size:         "1Gi",
+						},
+						PostgresConfiguration: apiv1.PostgresConfiguration{
+							Parameters: map[string]string{
+								"log_checkpoints":             "on",
+								"log_lock_waits":              "on",
+								"log_min_duration_statement":  "1000",
+								"log_statement":               "ddl",
+								"log_temp_files":              "1024",
+								"log_autovacuum_min_duration": "1000",
+								"log_replication_commands":    "on",
+								"pg_stat_statements.track":    "top",
+							},
 						},
 						Plugins: []apiv1.PluginConfiguration{
 							{
@@ -124,6 +147,7 @@ var _ = Describe("plugin-barman-cloud across a Postgres major upgrade",
 						},
 					},
 				}
+				clusterutils.AddTopologySpreadConstraint(cluster)
 				Expect(env.Client.Create(env.Ctx, cluster)).To(Succeed())
 				clusterasserts.AssertClusterIsReady(env, namespace, clusterName, testTimeouts[timeouts.ClusterIsReady])
 			})
@@ -155,7 +179,12 @@ var _ = Describe("plugin-barman-cloud across a Postgres major upgrade",
 					}
 					cluster.Spec.ImageName = targetImage
 					return env.Client.Update(env.Ctx, cluster)
-				}, 60).Should(Succeed())
+				}).WithTimeout(1*time.Minute).WithPolling(10*time.Second).Should(
+					Succeed(),
+					"Failed to update cluster image from %s to %s",
+					startImage,
+					targetImage,
+				)
 			})
 
 			By("waiting for the cluster to enter the major upgrade phase", func() {
@@ -163,7 +192,7 @@ var _ = Describe("plugin-barman-cloud across a Postgres major upgrade",
 					cluster, err := clusterutils.Get(env.Ctx, env.Client, namespace, clusterName)
 					g.Expect(err).ToNot(HaveOccurred())
 					g.Expect(cluster.Status.Phase).To(Equal(apiv1.PhaseMajorUpgrade))
-				}, 120).Should(Succeed())
+				}).WithTimeout(1 * time.Minute).WithPolling(10 * time.Second).Should(Succeed())
 			})
 
 			By("waiting for the upgraded cluster to become ready", func() {

--- a/tests/e2e/plugin_barman_cloud_snapshot_test.go
+++ b/tests/e2e/plugin_barman_cloud_snapshot_test.go
@@ -22,6 +22,7 @@ package e2e
 import (
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	volumesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
@@ -39,6 +40,7 @@ import (
 	pgasserts "github.com/cloudnative-pg/cloudnative-pg/tests/internal/asserts/postgres"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/backups"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/clusterutils"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/exec"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/postgres"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/storage"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/timeouts"
@@ -437,27 +439,38 @@ var _ = Describe("plugin-barman-cloud volume snapshots",
 				By("checking the new replicas have been created using the snapshot", func() {
 					pvcList, err := storage.GetPVCList(env.Ctx, env.Client, namespace)
 					Expect(err).ToNot(HaveOccurred())
+					matched := 0
 					for _, pvc := range pvcList.Items {
 						if pvc.Labels[utils.ClusterInstanceRoleLabelName] == specs.ClusterRoleLabelReplica &&
 							pvc.Labels[utils.ClusterLabelName] == clusterName {
 							Expect(pvc.Spec.DataSource.Kind).To(Equal(apiv1.VolumeSnapshotKind))
 							Expect(pvc.Spec.DataSourceRef.Kind).To(Equal(apiv1.VolumeSnapshotKind))
+							matched++
 						}
 					}
+					// Each new replica has both a PGDATA and a WAL PVC (this
+					// cluster configures separate walStorage), so 2 replicas
+					// means 4 matching PVCs, not 2.
+					Expect(matched).To(Equal(4), "expected 4 replica PVCs (PGDATA + WAL, x2 replicas) provisioned from the snapshot")
 				})
 
-				// we need to verify the streaming replica continue works
+				// Query each replica pod directly: a cluster-wide service
+				// connection always resolves to the primary, and would not
+				// confirm that a specific replica has caught up.
 				By("verifying the correct data exists in the new pod of the scaled cluster", func() {
 					podList, err := clusterutils.GetReplicas(env.Ctx, env.Client, namespace, clusterName)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(podList.Items).To(HaveLen(2))
-					tableLocator := pgasserts.TableLocator{
-						Namespace:    namespace,
-						ClusterName:  clusterName,
-						DatabaseName: postgres.AppDBName,
-						TableName:    tableName,
+					query := fmt.Sprintf("SELECT count(*) FROM %s", tableName)
+					for _, pod := range podList.Items {
+						Eventually(func() (string, error) {
+							stdOut, _, err := exec.QueryInInstancePod(
+								env.Ctx, env.Client, env.Interface, env.RestClientConfig,
+								exec.PodLocator{Namespace: pod.Namespace, PodName: pod.Name},
+								postgres.AppDBName, query)
+							return strings.TrimSpace(stdOut), err
+						}, RetryTimeout).Should(Equal("6"), "replica pod %s did not catch up", pod.Name)
 					}
-					pgasserts.AssertDataExpectedCount(env, tableLocator, 6)
 				})
 			})
 		})

--- a/tests/e2e/plugin_barman_cloud_snapshot_test.go
+++ b/tests/e2e/plugin_barman_cloud_snapshot_test.go
@@ -355,9 +355,15 @@ var _ = Describe("plugin-barman-cloud volume snapshots",
 				})
 
 				By("verifying WAL archiving through the plugin is working", func() {
-					// The online backup waits for the WAL archiver to process the last
-					// segment, so fail early if the plugin cannot archive.
-					backupasserts.AssertArchiveConditionMet(env, namespace, clusterName, 120)
+					// This source cluster is single-instance and idle here: no replica
+					// bootstrap or workload forces a WAL switch, so archive_command would
+					// only fire once archive_timeout (5m) elapses, making a wait on the
+					// ContinuousArchiving condition flaky. Force a switch and verify the
+					// WAL reaches the object store, so we fail fast and deterministically
+					// if the plugin cannot archive before the online backup (which waits
+					// for the WAL archiver) runs.
+					objectstoreasserts.AssertArchiveWalOnObjectStore(
+						env, testTimeouts, objectStoreEnv, namespace, clusterName, clusterName)
 				})
 			})
 

--- a/tests/e2e/plugin_barman_cloud_snapshot_test.go
+++ b/tests/e2e/plugin_barman_cloud_snapshot_test.go
@@ -1,0 +1,458 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package e2e
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	volumesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	k8client "sigs.k8s.io/controller-runtime/pkg/client"
+
+	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/specs"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
+	"github.com/cloudnative-pg/cloudnative-pg/tests"
+	backupasserts "github.com/cloudnative-pg/cloudnative-pg/tests/internal/asserts/backup"
+	clusterasserts "github.com/cloudnative-pg/cloudnative-pg/tests/internal/asserts/cluster"
+	objectstoreasserts "github.com/cloudnative-pg/cloudnative-pg/tests/internal/asserts/objectstore"
+	pgasserts "github.com/cloudnative-pg/cloudnative-pg/tests/internal/asserts/postgres"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/backups"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/clusterutils"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/postgres"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/storage"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/timeouts"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/yaml"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// Plugin counterparts of the in-core volume-snapshot scenarios: the data base
+// backup is still taken with the native volumeSnapshot method, but WAL archiving
+// (and the WAL source used during recovery) goes through plugin-barman-cloud
+// rather than the deprecated in-core barmanObjectStore. The in-core variants are
+// left in place. Runs on kind/k3d only, where the plugin and the shared object
+// store are installed.
+var _ = Describe("plugin-barman-cloud volume snapshots",
+	Label(tests.LabelPluginBarmanCloud, tests.LabelSnapshot, tests.LabelBackupRestore), func() {
+		const level = tests.High
+
+		BeforeEach(func() {
+			if testLevelEnv.Depth < int(level) {
+				Skip("Test depth is lower than the amount requested for this test")
+			}
+			if !(IsKind() || IsK3D()) {
+				Skip("This test only runs on kind or k3d clusters")
+			}
+		})
+
+		// getSnapshots lists the VolumeSnapshots produced by a given backup of a
+		// cluster, so their names can be fed to the recovery manifests.
+		getSnapshots := func(
+			backupName string,
+			clusterName string,
+			namespace string,
+		) (volumesnapshotv1.VolumeSnapshotList, error) {
+			var snapshotList volumesnapshotv1.VolumeSnapshotList
+			err := env.Client.List(env.Ctx, &snapshotList, k8client.InNamespace(namespace),
+				k8client.MatchingLabels{
+					utils.ClusterLabelName:    clusterName,
+					utils.BackupNameLabelName: backupName,
+				})
+			if err != nil {
+				return snapshotList, err
+			}
+
+			return snapshotList, nil
+		}
+
+		// takeVolumeSnapshotBackup creates a volumeSnapshot-method backup of the
+		// cluster on the given target and waits for it to complete with two snapshot
+		// elements (PGDATA and WAL). WAL archiving is provided by plugin-barman-cloud.
+		// A cold snapshot needs a checkpoint to reach a consistent stop point; an
+		// online (hot) one is expected to produce a backup label file.
+		takeVolumeSnapshotBackup := func(
+			namespace, clusterName, backupName string,
+			target apiv1.BackupTarget,
+			triggerCheckpoint, requireBackupLabelFile bool,
+		) *apiv1.Backup {
+			GinkgoHelper()
+			backup, err := backups.Create(env.Ctx, env.Client, apiv1.Backup{
+				ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: backupName},
+				Spec: apiv1.BackupSpec{
+					Target:  target,
+					Method:  apiv1.BackupMethodVolumeSnapshot,
+					Cluster: apiv1.LocalObjectReference{Name: clusterName},
+				},
+			})
+			Expect(err).ToNot(HaveOccurred())
+
+			if triggerCheckpoint {
+				objectstoreasserts.CheckPointAndSwitchWalOnPrimary(env, namespace, clusterName)
+			}
+
+			Eventually(func(g Gomega) {
+				g.Expect(env.Client.Get(env.Ctx, types.NamespacedName{
+					Namespace: namespace,
+					Name:      backupName,
+				}, backup)).To(Succeed())
+				g.Expect(backup.Status.Phase).To(
+					BeEquivalentTo(apiv1.BackupPhaseCompleted),
+					"Backup should be completed correctly, error message is '%s'",
+					backup.Status.Error)
+				g.Expect(backup.Status.BackupSnapshotStatus.Elements).To(HaveLen(2))
+				if requireBackupLabelFile {
+					g.Expect(backup.Status.BackupLabelFile).ToNot(BeEmpty())
+				}
+			}, testTimeouts[timeouts.VolumeSnapshotIsReady]).Should(Succeed())
+
+			return backup
+		}
+
+		// captureSnapshotNames lists the snapshots a backup produced and exports
+		// their names as the given env vars, so the recovery manifests can reference
+		// them through template substitution.
+		captureSnapshotNames := func(backup *apiv1.Backup, clusterName, namespace, dataEnv, walEnv string) {
+			GinkgoHelper()
+			snapshotList, err := getSnapshots(backup.Name, clusterName, namespace)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(snapshotList.Items).To(HaveLen(len(backup.Status.BackupSnapshotStatus.Elements)))
+
+			Expect(storage.SetSnapshotNameAsEnv(&snapshotList, backup, storage.EnvVarsForSnapshots{
+				DataSnapshot: dataEnv,
+				WalSnapshot:  walEnv,
+			})).To(Succeed())
+		}
+
+		// insertDataAndArchiveWAL writes rows into tableName (optionally creating it
+		// with rows 1,2 first) and forces the closing WAL to be archived through the
+		// plugin, so a later recovery can reach a consistent point.
+		insertDataAndArchiveWAL := func(namespace, clusterName, tableName string, createTable bool, extraRows ...int) {
+			GinkgoHelper()
+			if createTable {
+				pgasserts.AssertCreateTestData(env, pgasserts.TableLocator{
+					Namespace:    namespace,
+					ClusterName:  clusterName,
+					DatabaseName: postgres.AppDBName,
+					TableName:    tableName,
+				})
+			}
+
+			if len(extraRows) > 0 {
+				forward, conn, err := postgres.ForwardPSQLConnection(
+					env.Ctx, env.Client, env.Interface, env.RestClientConfig,
+					namespace, clusterName, postgres.AppDBName, apiv1.ApplicationUserSecretSuffix,
+				)
+				defer func() {
+					_ = conn.Close()
+					forward.Close()
+				}()
+				Expect(err).ToNot(HaveOccurred())
+				for _, row := range extraRows {
+					pgasserts.InsertRecordIntoTable(tableName, row, conn)
+				}
+			}
+
+			objectstoreasserts.AssertArchiveWalOnObjectStore(
+				env, testTimeouts, objectStoreEnv, namespace, clusterName, clusterName)
+		}
+
+		Context("PITR from a cold volume snapshot", Ordered, func() {
+			const (
+				namespacePrefix = "plugin-snapshot-recovery"
+				filesDir        = fixturesDir + "/volume_snapshot"
+
+				clusterManifest = filesDir + "/cluster-pvc-snapshot-plugin.yaml.template"
+				restoreManifest = filesDir + "/cluster-pvc-snapshot-restore-plugin.yaml.template"
+
+				snapshotDataEnv       = "SNAPSHOT_PLUGIN_PITR_PGDATA"
+				snapshotWalEnv        = "SNAPSHOT_PLUGIN_PITR_PGWAL"
+				recoveryTargetTimeEnv = "SNAPSHOT_PLUGIN_PITR"
+
+				tableName = "test"
+			)
+
+			var namespace, clusterName string
+
+			BeforeAll(func() {
+				var err error
+				namespace, err = env.CreateUniqueTestNamespace(env.Ctx, env.Client, namespacePrefix)
+				Expect(err).ToNot(HaveOccurred())
+
+				clusterName, err = yaml.GetResourceNameFromYAML(env.Scheme, clusterManifest)
+				Expect(err).ToNot(HaveOccurred())
+
+				setupPluginObjectStore(namespace, clusterName)
+			})
+
+			It("correctly executes PITR with a cold snapshot", func() {
+				DeferCleanup(func() error {
+					for _, envvar := range []string{
+						snapshotDataEnv,
+						snapshotWalEnv,
+						recoveryTargetTimeEnv,
+					} {
+						if err := os.Unsetenv(envvar); err != nil {
+							return err
+						}
+					}
+					return nil
+				})
+
+				By("creating the cluster to snapshot, archiving through the plugin", func() {
+					clusterasserts.AssertCreateCluster(env, testTimeouts, namespace, clusterName, clusterManifest)
+				})
+
+				By("verifying WAL archiving through the plugin is working", func() {
+					// The cold snapshot relies on the archived WALs to reach the
+					// recovery target, so fail early if the plugin cannot archive.
+					backupasserts.AssertArchiveConditionMet(env, namespace, clusterName, 120)
+				})
+
+				var backup *apiv1.Backup
+				By("creating a snapshot and waiting until it's completed", func() {
+					backup = takeVolumeSnapshotBackup(namespace, clusterName,
+						fmt.Sprintf("%s-example", clusterName), apiv1.BackupTargetStandby, true, false)
+				})
+
+				By("fetching the volume snapshots", func() {
+					captureSnapshotNames(backup, clusterName, namespace, snapshotDataEnv, snapshotWalEnv)
+				})
+
+				By("inserting test data and creating WALs on the cluster to be snapshotted", func() {
+					// Create a "test" table with values 1,2
+					tableLocator := pgasserts.TableLocator{
+						Namespace:    namespace,
+						ClusterName:  clusterName,
+						DatabaseName: postgres.AppDBName,
+						TableName:    tableName,
+					}
+					pgasserts.AssertCreateTestData(env, tableLocator)
+
+					// Because GetCurrentTimestamp() rounds down to the second and is executed
+					// right after the creation of the test data, we wait for 1s to avoid not
+					// including the newly created data within the recovery_target_time
+					time.Sleep(1 * time.Second)
+					// Get the recovery_target_time and pass it to the template engine
+					recoveryTargetTime, err := postgres.GetCurrentTimestamp(
+						env.Ctx, env.Client, env.Interface, env.RestClientConfig,
+						namespace, clusterName,
+					)
+					Expect(err).ToNot(HaveOccurred())
+					err = os.Setenv(recoveryTargetTimeEnv, recoveryTargetTime)
+					Expect(err).ToNot(HaveOccurred())
+
+					forward, conn, err := postgres.ForwardPSQLConnection(
+						env.Ctx,
+						env.Client,
+						env.Interface,
+						env.RestClientConfig,
+						namespace,
+						clusterName,
+						postgres.AppDBName,
+						apiv1.ApplicationUserSecretSuffix,
+					)
+					defer func() {
+						_ = conn.Close()
+						forward.Close()
+					}()
+					Expect(err).ToNot(HaveOccurred())
+					// Insert 2 more rows which we expect not to be present at the end of the recovery
+					pgasserts.InsertRecordIntoTable(tableName, 3, conn)
+					pgasserts.InsertRecordIntoTable(tableName, 4, conn)
+
+					// Close and archive the current WAL file
+					objectstoreasserts.AssertArchiveWalOnObjectStore(
+						env,
+						testTimeouts,
+						objectStoreEnv,
+						namespace,
+						clusterName,
+						clusterName,
+					)
+				})
+
+				// A single restore to a Postgres-timestamp recovery target fully
+				// exercises volume-snapshot PITR through the plugin. The in-core
+				// suite additionally covers the RFC3339 recovery-target-time format;
+				// that is a core recovery_target_time parsing concern, independent of
+				// the WAL archiver, so it is not duplicated here.
+				clusterToRestoreName, err := yaml.GetResourceNameFromYAML(env.Scheme, restoreManifest)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("creating the cluster to be restored through snapshot and PITR", func() {
+					clusterasserts.AssertCreateCluster(env, testTimeouts, namespace, clusterToRestoreName, restoreManifest)
+					clusterasserts.AssertClusterIsReady(
+						env,
+						namespace,
+						clusterToRestoreName,
+						testTimeouts[timeouts.ClusterIsReadySlow],
+					)
+				})
+
+				By("verifying the correct data exists in the restored cluster", func() {
+					tableLocator := pgasserts.TableLocator{
+						Namespace:    namespace,
+						ClusterName:  clusterToRestoreName,
+						DatabaseName: postgres.AppDBName,
+						TableName:    tableName,
+					}
+					pgasserts.AssertDataExpectedCount(env, tableLocator, 2)
+				})
+			})
+		})
+
+		Context("online hot volume snapshot and scale-up", Ordered, func() {
+			const (
+				namespacePrefix = "plugin-snapshot-hot"
+				filesDir        = fixturesDir + "/volume_snapshot"
+
+				clusterManifest = filesDir + "/cluster-pvc-hot-snapshot-plugin.yaml.template"
+				restoreManifest = filesDir + "/cluster-pvc-hot-restore-plugin.yaml.template"
+
+				snapshotDataEnv = "SNAPSHOT_PLUGIN_HOT_PGDATA"
+				snapshotWalEnv  = "SNAPSHOT_PLUGIN_HOT_PGWAL"
+
+				tableName = "online_test"
+			)
+
+			var namespace, clusterName string
+			var backupTaken *apiv1.Backup
+
+			BeforeAll(func() {
+				var err error
+				namespace, err = env.CreateUniqueTestNamespace(env.Ctx, env.Client, namespacePrefix)
+				Expect(err).ToNot(HaveOccurred())
+
+				clusterName, err = yaml.GetResourceNameFromYAML(env.Scheme, clusterManifest)
+				Expect(err).ToNot(HaveOccurred())
+
+				setupPluginObjectStore(namespace, clusterName)
+
+				By("creating the cluster to snapshot, archiving through the plugin", func() {
+					clusterasserts.AssertCreateCluster(env, testTimeouts, namespace, clusterName, clusterManifest)
+				})
+
+				By("verifying WAL archiving through the plugin is working", func() {
+					// The online backup waits for the WAL archiver to process the last
+					// segment, so fail early if the plugin cannot archive.
+					backupasserts.AssertArchiveConditionMet(env, namespace, clusterName, 120)
+				})
+			})
+
+			It("should execute a backup with online set to true", func() {
+				DeferCleanup(func() error {
+					if err := os.Unsetenv(snapshotDataEnv); err != nil {
+						return err
+					}
+
+					return os.Unsetenv(snapshotWalEnv)
+				})
+
+				By("inserting test data and creating WALs on the cluster to be snapshotted", func() {
+					// Create the table with rows 1,2 then add 3,4; the hot backup is
+					// expected to capture them all.
+					insertDataAndArchiveWAL(namespace, clusterName, tableName, true, 3, 4)
+				})
+
+				By("creating a snapshot and waiting until it's completed", func() {
+					backupTaken = takeVolumeSnapshotBackup(namespace, clusterName,
+						fmt.Sprintf("%s-online", clusterName), apiv1.BackupTargetPrimary, false, true)
+				})
+
+				By("fetching the volume snapshots", func() {
+					captureSnapshotNames(backupTaken, clusterName, namespace, snapshotDataEnv, snapshotWalEnv)
+				})
+
+				clusterToRestoreName, err := yaml.GetResourceNameFromYAML(env.Scheme, restoreManifest)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("creating the cluster to be restored through snapshot", func() {
+					clusterasserts.AssertCreateCluster(env, testTimeouts, namespace, clusterToRestoreName, restoreManifest)
+					clusterasserts.AssertClusterIsReady(
+						env, namespace, clusterToRestoreName, testTimeouts[timeouts.ClusterIsReadySlow],
+					)
+				})
+
+				By("verifying the correct data exists in the restored cluster", func() {
+					tableLocator := pgasserts.TableLocator{
+						Namespace:    namespace,
+						ClusterName:  clusterToRestoreName,
+						DatabaseName: postgres.AppDBName,
+						TableName:    tableName,
+					}
+					pgasserts.AssertDataExpectedCount(env, tableLocator, 4)
+				})
+			})
+
+			It("should scale up the cluster with volume snapshot", func() {
+				// insert some data after the snapshot is taken, we want to verify the data exists in
+				// the new pod when cluster scaled up
+				By("inserting more test data and creating WALs on the cluster snapshotted", func() {
+					insertDataAndArchiveWAL(namespace, clusterName, tableName, false, 5, 6)
+				})
+
+				// reuse the snapshot taken from the clusterToSnapshot cluster
+				By("fetching the volume snapshots", func() {
+					captureSnapshotNames(backupTaken, clusterName, namespace, snapshotDataEnv, snapshotWalEnv)
+				})
+
+				By("scale up the cluster", func() {
+					err := clusterutils.ScaleSize(env.Ctx, env.Client, namespace, clusterName, 3)
+					Expect(err).ToNot(HaveOccurred())
+				})
+
+				By("checking the cluster is working", func() {
+					// Setting up a cluster with three pods is slow, usually 200-600s
+					clusterasserts.AssertClusterIsReady(env, namespace, clusterName, testTimeouts[timeouts.ClusterIsReady])
+				})
+
+				By("checking the new replicas have been created using the snapshot", func() {
+					pvcList, err := storage.GetPVCList(env.Ctx, env.Client, namespace)
+					Expect(err).ToNot(HaveOccurred())
+					for _, pvc := range pvcList.Items {
+						if pvc.Labels[utils.ClusterInstanceRoleLabelName] == specs.ClusterRoleLabelReplica &&
+							pvc.Labels[utils.ClusterLabelName] == clusterName {
+							Expect(pvc.Spec.DataSource.Kind).To(Equal(apiv1.VolumeSnapshotKind))
+							Expect(pvc.Spec.DataSourceRef.Kind).To(Equal(apiv1.VolumeSnapshotKind))
+						}
+					}
+				})
+
+				// we need to verify the streaming replica continue works
+				By("verifying the correct data exists in the new pod of the scaled cluster", func() {
+					podList, err := clusterutils.GetReplicas(env.Ctx, env.Client, namespace, clusterName)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(podList.Items).To(HaveLen(2))
+					tableLocator := pgasserts.TableLocator{
+						Namespace:    namespace,
+						ClusterName:  clusterName,
+						DatabaseName: postgres.AppDBName,
+						TableName:    tableName,
+					}
+					pgasserts.AssertDataExpectedCount(env, tableLocator, 6)
+				})
+			})
+		})
+	})

--- a/tests/e2e/volume_snapshot_test.go
+++ b/tests/e2e/volume_snapshot_test.go
@@ -901,28 +901,39 @@ var _ = Describe("Verify Volume Snapshot",
 				By("checking the new replicas have been created using the snapshot", func() {
 					pvcList, err := storage.GetPVCList(env.Ctx, env.Client, namespace)
 					Expect(err).ToNot(HaveOccurred())
+					matched := 0
 					for _, pvc := range pvcList.Items {
 						if pvc.Labels[utils.ClusterInstanceRoleLabelName] == specs.ClusterRoleLabelReplica &&
 							pvc.Labels[utils.ClusterLabelName] == clusterToSnapshotName {
 							Expect(pvc.Spec.DataSource.Kind).To(Equal(apiv1.VolumeSnapshotKind))
 							Expect(pvc.Spec.DataSourceRef.Kind).To(Equal(apiv1.VolumeSnapshotKind))
+							matched++
 						}
 					}
+					// Each new replica has both a PGDATA and a WAL PVC (this
+					// cluster configures separate walStorage), so 2 replicas
+					// means 4 matching PVCs, not 2.
+					Expect(matched).To(Equal(4), "expected 4 replica PVCs (PGDATA + WAL, x2 replicas) provisioned from the snapshot")
 				})
 
-				// we need to verify the streaming replica continue works
+				// Query each replica pod directly: a cluster-wide service
+				// connection always resolves to the primary, and would not
+				// confirm that a specific replica has caught up.
 				By("verifying the correct data exists in the new pod of the scaled cluster", func() {
 					podList, err := clusterutils.GetReplicas(env.Ctx, env.Client, namespace,
 						clusterToSnapshotName)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(podList.Items).To(HaveLen(2))
-					tableLocator := pgasserts.TableLocator{
-						Namespace:    namespace,
-						ClusterName:  clusterToSnapshotName,
-						DatabaseName: postgres.AppDBName,
-						TableName:    tableName,
+					query := fmt.Sprintf("SELECT count(*) FROM %s", tableName)
+					for _, pod := range podList.Items {
+						Eventually(func() (string, error) {
+							stdOut, _, err := exec.QueryInInstancePod(
+								env.Ctx, env.Client, env.Interface, env.RestClientConfig,
+								exec.PodLocator{Namespace: pod.Namespace, PodName: pod.Name},
+								postgres.AppDBName, query)
+							return strings.TrimSpace(stdOut), err
+						}, RetryTimeout).Should(Equal("6"), "replica pod %s did not catch up", pod.Name)
 					}
-					pgasserts.AssertDataExpectedCount(env, tableLocator, 6)
 				})
 			})
 


### PR DESCRIPTION
This ports four end-to-end backup scenarios from the in-core Barman Cloud integration to the plugin-barman-cloud CNPG-I plugin, alongside the existing plugin smoke, backup/restore, replica and tablespaces ports. The in-core variants are left in place until in-core Barman Cloud support is removed.

The scenarios covered are point-in-time recovery from a cold volume snapshot, an online (hot) volume snapshot backup and restore, scaling a cluster up from a volume snapshot, and WAL archiving continuing to work across a Postgres major version upgrade.

In every case the physical base backup is still taken with the native volumeSnapshot method (the major-upgrade spec takes no base backup at all); only WAL archiving, and the WAL source used during recovery, move from the in-core `spec.backup.barmanObjectStore` to the plugin. The source clusters archive through `spec.plugins` with `isWALArchiver: true`, and the recovery clusters fetch WALs through `externalClusters[].plugin`. The shared plugin test helper provisions the object store credentials and the `ObjectStore` resource.

The cold-snapshot spec restores to a single Postgres-timestamp recovery target. The in-core suite additionally exercises the RFC3339 recovery-target-time format; that is a core `recovery_target_time` parsing concern, independent of the WAL archiver, so it is not duplicated here.

The specs are gated to kind/k3d, at the high test depth for the volume-snapshot scenarios and medium for the major-upgrade one, where the plugin and the shared object store are installed. All four were run on a local kind cluster against plugin-barman-cloud v0.13.0 and pass.

Closes #10958
Closes #10957
Closes #10955
Closes #10956
