### PR TITLE
fix(psql): support Windows execution

### DIFF
--- a/internal/cmd/plugin/psql/exec_unix.go
+++ b/internal/cmd/plugin/psql/exec_unix.go
@@ -1,0 +1,33 @@
+//go:build !windows
+
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package psql
+
+import (
+	"os"
+	"syscall"
+)
+
+// execKubectl replaces the current process with kubectl.
+// This function does not return on success.
+func execKubectl(kubectlPath string, kubectlExec []string) error {
+	return syscall.Exec(kubectlPath, kubectlExec, os.Environ()) // #nosec
+}

--- a/internal/cmd/plugin/psql/exec_windows.go
+++ b/internal/cmd/plugin/psql/exec_windows.go
@@ -1,0 +1,49 @@
+//go:build windows
+
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package psql
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+)
+
+// execKubectl runs kubectl as a child process with interactive stdio.
+// On success it exits the process with kubectl's exit code, matching
+// the Unix syscall.Exec behavior as closely as possible.
+func execKubectl(kubectlPath string, kubectlExec []string) error {
+	cmd := exec.Command(kubectlPath, kubectlExec[1:]...) //nolint:gosec
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Run(); err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			os.Exit(exitErr.ExitCode())
+		}
+		return err
+	}
+
+	os.Exit(0)
+	return nil
+}

--- a/internal/cmd/plugin/psql/psql.go
+++ b/internal/cmd/plugin/psql/psql.go
@@ -159,8 +159,8 @@ func (psql *Command) getPodName() (string, error) {
 	return "", &ErrMissingPod{role: targetPodRole}
 }
 
-// Exec replaces the current process with a `kubectl Exec` invocation.
-// This function won't return
+// Exec invokes `kubectl exec` and transfers control to it.
+// This function does not return on success.
 func (psql *Command) Exec() error {
 	kubectlExec, err := psql.getKubectlInvocation()
 	if err != nil {

--- a/internal/cmd/plugin/psql/psql.go
+++ b/internal/cmd/plugin/psql/psql.go
@@ -25,7 +25,6 @@ import (
 	"os"
 	"os/exec"
 	"slices"
-	"syscall"
 
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -168,7 +167,7 @@ func (psql *Command) Exec() error {
 		return err
 	}
 
-	err = syscall.Exec(psql.kubectlPath, kubectlExec, os.Environ()) // #nosec
+	err = execKubectl(psql.kubectlPath, kubectlExec)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The psql plugin replaced the current process with a `kubectl exec` invocation through `syscall.Exec`, which is not available on Windows. As a result `kubectl cnpg psql` failed there with "not supported by windows".

Execution is now platform-specific: Unix-like systems keep using `syscall.Exec`, while Windows launches `kubectl exec` as a child process via `exec.Command`.

Closes #10553
