### PR TITLE
fix(databaserole): grant finalizers permission for client cert issuance

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -188,6 +188,7 @@ rules:
   - postgresql.cnpg.io
   resources:
   - clusters/finalizers
+  - databaseroles/finalizers
   - poolers/finalizers
   verbs:
   - update

--- a/internal/controller/databaserole_controller.go
+++ b/internal/controller/databaserole_controller.go
@@ -58,6 +58,7 @@ const clientCertReconcileInterval = time.Hour
 
 // +kubebuilder:rbac:groups=postgresql.cnpg.io,resources=databaseroles,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=postgresql.cnpg.io,resources=databaseroles/status,verbs=get;update;patch;watch
+// +kubebuilder:rbac:groups=postgresql.cnpg.io,resources=databaseroles/finalizers,verbs=update
 // +kubebuilder:rbac:groups=postgresql.cnpg.io,resources=clusters,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;patch;delete
 


### PR DESCRIPTION
The DatabaseRole controller sets a controller owner reference on the client certificate Secret it creates. On clusters with the OwnerReferencesPermissionEnforcement admission plugin enabled, such as OpenShift, creating an object with such a reference requires update permission on the owner's finalizers subresource. The operator role did not grant it, so the Secret creation was rejected and the certificate was never issued.

Add the missing databaseroles/finalizers permission and regenerate the RBAC manifests.

Closes #10973