### PR TITLE
fix(external): prevent stale certificate data and partial reads after secret rotation

### DIFF
--- a/pkg/management/external/suite_test.go
+++ b/pkg/management/external/suite_test.go
@@ -1,0 +1,32 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package external
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestExternal(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "External Suite")
+}

--- a/pkg/management/external/utils.go
+++ b/pkg/management/external/utils.go
@@ -111,14 +111,9 @@ func dumpSecretKeyRefToFile(
 	}
 
 	filePath := filepath.Join(directory, fmt.Sprintf("%v_%v", selector.Name, selector.Key))
-	// Write the file atomically (temp file + rename), as the sibling pgpass
-	// writer in this package already does. This file lives on a stable path and
-	// is reused across reconciliations: an in-place write would leave stale
-	// trailing bytes (e.g. a removed certificate from a CA bundle) when the
-	// secret is rotated to shorter content, and would expose a window where a
-	// concurrent libpq read of sslcert/sslkey/sslrootcert observes a truncated
-	// or partially written file. WriteFileAtomic also fsyncs and skips the write
-	// when the content is unchanged.
+	// Write atomically: this file is reused across reconciliations and read
+	// concurrently by libpq, so an in-place rewrite could expose a partial file
+	// or leave stale bytes behind when the secret rotates to shorter content.
 	if _, err := fileutils.WriteFileAtomic(filePath, value, 0o600); err != nil {
 		return "", err
 	}

--- a/pkg/management/external/utils.go
+++ b/pkg/management/external/utils.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/cloudnative-pg/machinery/pkg/fileutils"
 	corev1 "k8s.io/api/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -110,20 +111,19 @@ func dumpSecretKeyRefToFile(
 	}
 
 	filePath := filepath.Join(directory, fmt.Sprintf("%v_%v", selector.Name, selector.Key))
-	f, err := os.OpenFile(filepath.Clean(filePath), os.O_WRONLY|os.O_CREATE, 0o600)
-	if err != nil {
+	// Write the file atomically (temp file + rename), as the sibling pgpass
+	// writer in this package already does. This file lives on a stable path and
+	// is reused across reconciliations: an in-place write would leave stale
+	// trailing bytes (e.g. a removed certificate from a CA bundle) when the
+	// secret is rotated to shorter content, and would expose a window where a
+	// concurrent libpq read of sslcert/sslkey/sslrootcert observes a truncated
+	// or partially written file. WriteFileAtomic also fsyncs and skips the write
+	// when the content is unchanged.
+	if _, err := fileutils.WriteFileAtomic(filePath, value, 0o600); err != nil {
 		return "", err
 	}
-	defer func() {
-		_ = f.Close()
-	}()
 
-	_, err = f.Write(value)
-	if err != nil {
-		return "", err
-	}
-
-	return f.Name(), nil
+	return filePath, nil
 }
 
 // getPgPassFilePath gets the path where the pgpass file will be stored

--- a/pkg/management/external/utils_test.go
+++ b/pkg/management/external/utils_test.go
@@ -1,0 +1,118 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package external
+
+import (
+	"context"
+	"os"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	schemeBuilder "github.com/cloudnative-pg/cloudnative-pg/internal/scheme"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("dumpSecretKeyRefToFile", func() {
+	const (
+		namespace  = "test-namespace"
+		serverName = "test-server"
+		secretName = "test-secret"
+		secretKey  = "sslrootcert"
+	)
+
+	var (
+		ctx        context.Context
+		fakeClient client.Client
+		selector   *corev1.SecretKeySelector
+	)
+
+	buildClient := func(value []byte) client.Client {
+		return fake.NewClientBuilder().
+			WithScheme(schemeBuilder.BuildWithAllKnownScheme()).
+			WithObjects(&corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      secretName,
+					Namespace: namespace,
+				},
+				Data: map[string][]byte{
+					secretKey: value,
+				},
+			}).
+			Build()
+	}
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		// redirect the dump directory to an isolated temporary path
+		customExternalSecretsPath = GinkgoT().TempDir()
+		DeferCleanup(func() { customExternalSecretsPath = "" })
+
+		selector = &corev1.SecretKeySelector{
+			LocalObjectReference: corev1.LocalObjectReference{Name: secretName},
+			Key:                  secretKey,
+		}
+	})
+
+	It("writes the secret content to a file with 0600 permissions", func() {
+		value := []byte("first-version")
+		fakeClient = buildClient(value)
+
+		path, err := dumpSecretKeyRefToFile(ctx, fakeClient, namespace, serverName, selector)
+		Expect(err).ToNot(HaveOccurred())
+
+		content, err := os.ReadFile(path) //nolint:gosec
+		Expect(err).ToNot(HaveOccurred())
+		Expect(content).To(Equal(value))
+
+		info, err := os.Stat(path)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(info.Mode().Perm()).To(Equal(os.FileMode(0o600)))
+	})
+
+	It("fully overwrites the file when the secret rotates to shorter content", func() {
+		// First reconciliation: a longer value (e.g. a two-certificate CA bundle)
+		longValue := []byte(
+			"-----BEGIN CERTIFICATE-----\nAAAA\n-----END CERTIFICATE-----\n" +
+				"-----BEGIN CERTIFICATE-----\nBBBB\n-----END CERTIFICATE-----\n")
+		path, err := dumpSecretKeyRefToFile(
+			ctx, buildClient(longValue), namespace, serverName, selector)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Second reconciliation: the secret is rotated to a shorter value
+		// (a single certificate) written to the very same path.
+		shortValue := []byte("-----BEGIN CERTIFICATE-----\nAAAA\n-----END CERTIFICATE-----\n")
+		path2, err := dumpSecretKeyRefToFile(
+			ctx, buildClient(shortValue), namespace, serverName, selector)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(path2).To(Equal(path))
+
+		// The file must contain exactly the new value, with no stale trailing
+		// bytes left over from the previous, longer content.
+		content, err := os.ReadFile(path2) //nolint:gosec
+		Expect(err).ToNot(HaveOccurred())
+		Expect(content).To(Equal(shortValue))
+		Expect(content).ToNot(ContainSubstring("BBBB"))
+	})
+})


### PR DESCRIPTION
When an external server's secret was rotated to shorter content - for
example, a CA bundle shrinking from two certificates to one - the
previous certificate bytes could remain visible on disk, causing libpq
to reject the connection or trust an unintended CA.

The same in-place write also left a window where libpq could read a
partially written file during a streaming reconnect, leading to
transient connection failures at rotation time.
  
Both problems are fixed by writing the file atomically: the new content
is written to a temporary file and renamed into place, so readers always
see either the old or the new value, never a mix.

Closes #10892
