### PR TITLE
fix(plugin): fix memory leak when following logs with kubectl cnpg logs -f

### DIFF
--- a/internal/cmd/plugin/logs/pretty/pretty.go
+++ b/internal/cmd/plugin/logs/pretty/pretty.go
@@ -159,10 +159,17 @@ func (bf *prettyCmd) group(ctx context.Context, logChannel <-chan logRecord, gro
 		buffer = bufferArray[0:0]
 	}
 
+	// A single timer is reused across iterations and reset at the top of each
+	// one. This preserves the original "flush the buffer after one second of
+	// inactivity" behaviour while avoiding the allocation of a new timer (and a
+	// piled-up deferred Stop) on every received log record, which previously
+	// grew unbounded for the lifetime of the stream.
+	timer := time.NewTimer(1 * time.Second)
+	defer timer.Stop()
+
 logLoop:
 	for {
-		timer := time.NewTimer(1 * time.Second)
-		defer timer.Stop()
+		timer.Reset(1 * time.Second)
 
 		select {
 		case <-ctx.Done():

--- a/internal/cmd/plugin/logs/pretty/pretty_test.go
+++ b/internal/cmd/plugin/logs/pretty/pretty_test.go
@@ -1,0 +1,107 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package pretty
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("group", func() {
+	// collectGroups feeds the given records into group() and returns the
+	// emitted groups once the input channel is closed.
+	collectGroups := func(bf *prettyCmd, records []logRecord) [][]logRecord {
+		GinkgoHelper()
+
+		logChannel := make(chan logRecord)
+		groupChannel := make(chan []logRecord)
+
+		go bf.group(context.Background(), logChannel, groupChannel)
+
+		go func() {
+			defer GinkgoRecover()
+			for _, record := range records {
+				logChannel <- record
+			}
+			close(logChannel)
+		}()
+
+		var groups [][]logRecord
+		for group := range groupChannel {
+			groups = append(groups, group)
+		}
+		return groups
+	}
+
+	makeRecords := func(messages ...string) []logRecord {
+		records := make([]logRecord, len(messages))
+		for i, msg := range messages {
+			records[i] = logRecord{Msg: msg}
+		}
+		return records
+	}
+
+	It("emits a full group as soon as groupSize records are buffered", func() {
+		bf := &prettyCmd{groupSize: 2}
+
+		groups := collectGroups(bf, makeRecords("a", "b", "c", "d"))
+
+		Expect(groups).To(HaveLen(2))
+		Expect(groups[0]).To(HaveLen(2))
+		Expect(groups[0][0].Msg).To(Equal("a"))
+		Expect(groups[0][1].Msg).To(Equal("b"))
+		Expect(groups[1][0].Msg).To(Equal("c"))
+		Expect(groups[1][1].Msg).To(Equal("d"))
+	})
+
+	It("flushes the remaining partial buffer when the input is closed", func() {
+		bf := &prettyCmd{groupSize: 10}
+
+		groups := collectGroups(bf, makeRecords("a", "b", "c"))
+
+		Expect(groups).To(HaveLen(1))
+		Expect(groups[0]).To(HaveLen(3))
+		Expect(groups[0][0].Msg).To(Equal("a"))
+		Expect(groups[0][2].Msg).To(Equal("c"))
+	})
+
+	It("emits nothing and closes the output when no records are received", func() {
+		bf := &prettyCmd{groupSize: 4}
+
+		groups := collectGroups(bf, nil)
+
+		Expect(groups).To(BeEmpty())
+	})
+
+	It("terminates and closes the output channel when the context is cancelled", func() {
+		bf := &prettyCmd{groupSize: 4}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		logChannel := make(chan logRecord)
+		groupChannel := make(chan []logRecord)
+
+		go bf.group(ctx, logChannel, groupChannel)
+		cancel()
+
+		Eventually(groupChannel).Should(BeClosed())
+	})
+})

--- a/internal/cmd/plugin/logs/pretty/suite_test.go
+++ b/internal/cmd/plugin/logs/pretty/suite_test.go
@@ -1,0 +1,32 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package pretty
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestPretty(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Pretty Suite")
+}


### PR DESCRIPTION
Running `kubectl cnpg logs -f` on a busy cluster would cause the plugin
process to grow in memory without bound over time. Each log group
allocated a new timer that was never released until the stream ended,
so memory accumulated for as long as the follow was running.

Timers are now reused across iterations, keeping memory usage stable
regardless of how long the log stream runs.

Closes #10893