### PR TITLE
fix(instance): always serve health probes regardless of Cluster validity

### DIFF
--- a/internal/management/controller/instance_controller.go
+++ b/internal/management/controller/instance_controller.go
@@ -121,6 +121,14 @@ func (r *InstanceReconciler) Reconcile(
 		return reconcile.Result{}, fmt.Errorf("could not fetch Cluster: %w", err)
 	}
 
+	// Load the probe server certificate before the admission guard: the kubelet
+	// TLS probes must keep working even when the cached Cluster fails validation
+	// and the guard short-circuits the rest of the loop. See
+	// EnsureServerCertificateLoaded for the full rationale.
+	if err := r.certificateReconciler.EnsureServerCertificateLoaded(ctx, cluster); err != nil {
+		return reconcile.Result{}, fmt.Errorf("while loading the server certificate: %w", err)
+	}
+
 	if result, err := r.admission.EnsureResourceIsAdmitted(
 		ctx,
 		guard.AdmissionParams[*apiv1.Cluster]{

--- a/internal/management/controller/instance_controller_test.go
+++ b/internal/management/controller/instance_controller_test.go
@@ -1,0 +1,115 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package controller
+
+import (
+	"context"
+	"errors"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	schemeBuilder "github.com/cloudnative-pg/cloudnative-pg/internal/scheme"
+	"github.com/cloudnative-pg/cloudnative-pg/internal/webhook/guard"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/certs"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres"
+	instancecertificate "github.com/cloudnative-pg/cloudnative-pg/pkg/reconciler/instance/certificate"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// invalidClusterValidator drives the admission guard's validation-failure path,
+// so EnsureResourceIsAdmitted short-circuits the reconcile loop with a requeue,
+// reproducing an invalid cached Cluster.
+type invalidClusterValidator struct{}
+
+func (invalidClusterValidator) ValidateCreate(context.Context, *apiv1.Cluster) (admission.Warnings, error) {
+	return nil, errors.New("cluster is invalid")
+}
+
+func (invalidClusterValidator) ValidateUpdate(
+	context.Context, *apiv1.Cluster, *apiv1.Cluster,
+) (admission.Warnings, error) {
+	return nil, nil
+}
+
+func (invalidClusterValidator) ValidateDelete(context.Context, *apiv1.Cluster) (admission.Warnings, error) {
+	return nil, nil
+}
+
+var _ = Describe("instance reconciler health probe certificate", func() {
+	It("loads the server certificate even when the cached Cluster fails admission validation",
+		func(ctx SpecContext) {
+			const (
+				namespace        = "default"
+				clusterName      = "cluster-example"
+				serverSecretName = clusterName + "-server"
+			)
+
+			root, err := certs.CreateRootCA("common-name", "organization-unit")
+			Expect(err).ToNot(HaveOccurred())
+			pair, err := root.CreateAndSignPair("host", certs.CertTypeServer, nil)
+			Expect(err).ToNot(HaveOccurred())
+			serverSecret := pair.GenerateCertificateSecret(namespace, serverSecretName)
+
+			cluster := &apiv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: clusterName},
+				Status: apiv1.ClusterStatus{
+					Certificates: apiv1.CertificatesStatus{
+						CertificatesConfiguration: apiv1.CertificatesConfiguration{
+							ServerTLSSecret: serverSecretName,
+						},
+					},
+				},
+			}
+
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(schemeBuilder.BuildWithAllKnownScheme()).
+				WithObjects(cluster, serverSecret).
+				Build()
+
+			pgInstance := postgres.NewInstance().
+				WithNamespace(namespace).
+				WithPodName(clusterName + "-1").
+				WithClusterName(clusterName)
+
+			reconciler := &InstanceReconciler{
+				client:                fakeClient,
+				instance:              pgInstance,
+				certificateReconciler: instancecertificate.NewReconciler(fakeClient, pgInstance),
+				admission:             &guard.Admission[*apiv1.Cluster]{Validator: invalidClusterValidator{}},
+			}
+
+			result, err := reconciler.Reconcile(ctx, reconcile.Request{})
+
+			// The guard requeued without error: the loop short-circuited, so
+			// nothing below the guard (RefreshSecrets included) ran.
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.RequeueAfter).To(BeNumerically(">", 0))
+
+			// The probe certificate was still loaded, because the load runs
+			// before the guard. This fails if the call is moved back below it.
+			Expect(pgInstance.GetServerCertificate()).ToNot(BeNil())
+		})
+})

--- a/pkg/reconciler/instance/certificate/reconciler.go
+++ b/pkg/reconciler/instance/certificate/reconciler.go
@@ -162,7 +162,7 @@ func (r *Reconciler) EnsureServerCertificateLoaded(ctx context.Context, cluster 
 	}
 
 	log.FromContext(ctx).Info(
-		"Loaded the status-port server certificate ahead of admission validation",
+		"Preloaded TLS certificate for the health probe server",
 		"secret", secretName,
 	)
 

--- a/pkg/reconciler/instance/certificate/reconciler.go
+++ b/pkg/reconciler/instance/certificate/reconciler.go
@@ -115,6 +115,51 @@ func (r *Reconciler) RefreshSecrets(
 	return changed, nil
 }
 
+// EnsureServerCertificateLoaded makes sure the status-port web server has a
+// server certificate loaded in memory, reading it from its secret when missing.
+// It does not write the on-disk certificate files and does not signal a
+// PostgreSQL reload: those remain the responsibility of RefreshSecrets.
+//
+// The instance reconciler calls this before the admission guard so the kubelet
+// liveness/readiness/startup probes, served over TLS, keep working even when
+// the cached Cluster fails in-pod validation and the guard short-circuits the
+// rest of the reconcile loop (RefreshSecrets included). Without it
+// GetServerCertificate() stays nil, every probe handshake fails and the pod can
+// never recover.
+//
+// It short-circuits once a certificate is loaded: the probe server only needs a
+// usable certificate to be present, and ongoing rotation is handled by
+// RefreshSecrets when the cluster is valid. This avoids re-reading the secret on
+// every reconcile, since it is never cached in the instance manager.
+func (r *Reconciler) EnsureServerCertificateLoaded(ctx context.Context, cluster *apiv1.Cluster) error {
+	if r.serverCertificateHandler.GetServerCertificate() != nil {
+		return nil
+	}
+
+	secretName := cluster.Status.Certificates.ServerTLSSecret
+	if secretName == "" {
+		// The operator has not populated the certificate status yet; a later
+		// reconcile loads the certificate once the secret name is known.
+		return nil
+	}
+
+	var secret corev1.Secret
+	if err := r.cli.Get(
+		ctx,
+		client.ObjectKey{Namespace: cluster.Namespace, Name: secretName},
+		&secret,
+	); err != nil {
+		// Tolerate a missing secret as RefreshSecrets does: a later reconcile
+		// loads the certificate once the secret exists.
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+
+	return r.refreshInstanceCertificateFromSecret(&secret)
+}
+
 // refreshServerCertificateFiles updates the latest server certificate files
 // from the secrets and updates the instance certificate if it is missing or
 // outdated.

--- a/pkg/reconciler/instance/certificate/reconciler.go
+++ b/pkg/reconciler/instance/certificate/reconciler.go
@@ -157,7 +157,16 @@ func (r *Reconciler) EnsureServerCertificateLoaded(ctx context.Context, cluster 
 		return err
 	}
 
-	return r.refreshInstanceCertificateFromSecret(&secret)
+	if err := r.refreshInstanceCertificateFromSecret(&secret); err != nil {
+		return err
+	}
+
+	log.FromContext(ctx).Info(
+		"Loaded the status-port server certificate ahead of admission validation",
+		"secret", secretName,
+	)
+
+	return nil
 }
 
 // refreshServerCertificateFiles updates the latest server certificate files

--- a/pkg/reconciler/instance/certificate/reconciler_test.go
+++ b/pkg/reconciler/instance/certificate/reconciler_test.go
@@ -25,7 +25,11 @@ import (
 
 	"github.com/cloudnative-pg/machinery/pkg/fileutils"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	schemeBuilder "github.com/cloudnative-pg/cloudnative-pg/internal/scheme"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/certs"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -174,5 +178,92 @@ var _ = Describe("server certificate refresh handler", func() {
 			cert := fakeReconciler.serverCertificateHandler.GetServerCertificate()
 			Expect(cert).ToNot(BeNil())
 		})
+	})
+})
+
+var _ = Describe("ensure the status-port server certificate is loaded", func() {
+	const serverSecretName = "cluster-server"
+
+	var (
+		cluster      *apiv1.Cluster
+		serverSecret *corev1.Secret
+	)
+
+	BeforeEach(func() {
+		root, err := certs.CreateRootCA("common-name", "organization-unit")
+		Expect(err).ToNot(HaveOccurred())
+
+		pair, err := root.CreateAndSignPair("host", certs.CertTypeServer, nil)
+		Expect(err).ToNot(HaveOccurred())
+
+		serverSecret = pair.GenerateCertificateSecret("default", serverSecretName)
+
+		cluster = &apiv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "cluster"},
+			Status: apiv1.ClusterStatus{
+				Certificates: apiv1.CertificatesStatus{
+					CertificatesConfiguration: apiv1.CertificatesConfiguration{
+						ServerTLSSecret: serverSecretName,
+					},
+				},
+			},
+		}
+	})
+
+	It("loads the certificate from the secret when none is in memory", func(ctx SpecContext) {
+		handler := &fakeServerCertificateHandler{}
+		r := &Reconciler{
+			cli: fake.NewClientBuilder().
+				WithScheme(schemeBuilder.BuildWithAllKnownScheme()).
+				WithObjects(serverSecret).
+				Build(),
+			serverCertificateHandler: handler,
+		}
+
+		Expect(r.EnsureServerCertificateLoaded(ctx, cluster)).To(Succeed())
+		Expect(handler.GetServerCertificate()).ToNot(BeNil())
+	})
+
+	It("short-circuits without reading the secret when one is already loaded", func(ctx SpecContext) {
+		loaded := &tls.Certificate{}
+		handler := &fakeServerCertificateHandler{certificate: loaded}
+		// No objects in the client: a read would fail, proving we never issue one.
+		r := &Reconciler{
+			cli: fake.NewClientBuilder().
+				WithScheme(schemeBuilder.BuildWithAllKnownScheme()).
+				Build(),
+			serverCertificateHandler: handler,
+		}
+
+		Expect(r.EnsureServerCertificateLoaded(ctx, cluster)).To(Succeed())
+		Expect(handler.GetServerCertificate()).To(BeIdenticalTo(loaded))
+	})
+
+	It("tolerates a missing secret, leaving nothing loaded", func(ctx SpecContext) {
+		handler := &fakeServerCertificateHandler{}
+		r := &Reconciler{
+			cli: fake.NewClientBuilder().
+				WithScheme(schemeBuilder.BuildWithAllKnownScheme()).
+				Build(),
+			serverCertificateHandler: handler,
+		}
+
+		Expect(r.EnsureServerCertificateLoaded(ctx, cluster)).To(Succeed())
+		Expect(handler.GetServerCertificate()).To(BeNil())
+	})
+
+	It("is a no-op when the certificate status is not populated yet", func(ctx SpecContext) {
+		cluster.Status.Certificates.ServerTLSSecret = ""
+		handler := &fakeServerCertificateHandler{}
+		// No objects in the client: a read would fail, proving we never issue one.
+		r := &Reconciler{
+			cli: fake.NewClientBuilder().
+				WithScheme(schemeBuilder.BuildWithAllKnownScheme()).
+				Build(),
+			serverCertificateHandler: handler,
+		}
+
+		Expect(r.EnsureServerCertificateLoaded(ctx, cluster)).To(Succeed())
+		Expect(handler.GetServerCertificate()).To(BeNil())
 	})
 })


### PR DESCRIPTION
The status-port web server serves the kubelet probes over TLS using a certificate installed during the Cluster reconcile loop. That loop now runs in-pod admission validation before refreshing the certificate, and the guard returns early whenever the cached Cluster fails validation, so the certificate is never loaded, every probe handshake fails and the pod can never recover.

Load the in-memory server certificate before the admission guard, so the probes keep working even when the cached Cluster is invalid. Writing the on-disk files and reloading PostgreSQL stay gated by the guard. The load short-circuits once a certificate is present to avoid an extra read of the secret, which is never cached in the instance manager.

Closes #10977
