### PR TITLE
chore(ci): use the bug emoji label in the bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,7 +1,7 @@
 name: Bug Report
 description: File a bug report
 title: "[Bug]: "
-labels: ["triage", "bug"]
+labels: ["triage", "bug :bug:"]
 projects: ["cloudnative-pg/cloudnative-pg"]
 assignees:
   - gbartolini


### PR DESCRIPTION
The Bug Report issue template applies a plain `bug` label that is distinct from the `bug :bug:` label used everywhere else, so every form-filed bug report ends up tagged with a duplicate, description-less label.

Point the template at the canonical `bug :bug:` label so new reports get the right one. The orphaned plain `bug` label can be retired separately once existing issues are migrated.
