### PR TITLE
ci(openshift): fix stale version bound in router pinning comment

### DIFF
--- a/hack/e2e/run-e2e-ocp.sh
+++ b/hack/e2e/run-e2e-ocp.sh
@@ -174,8 +174,8 @@ done
 # Move OCP ingress routers off worker nodes for the duration of this test
 # job, so the drain_node e2e does not strand router-default's PDB. The
 # placement is non-production but the OCP cluster is destroyed at end-of-job.
-# OCP through 4.21 still applies the legacy control-plane taint; the key
-# is kept in a shell variable so the JSON literal does not contain a woke
+# OCP still applies the legacy control-plane taint by default; the key is
+# kept in a shell variable so the JSON literal does not contain a woke
 # trigger word.
 echo "Pinning router-default to control plane nodes"
 LEGACY_TAINT_KEY="node-role.kubernetes.io/master" # wokeignore:rule=master


### PR DESCRIPTION
The router-pinning comment in `run-e2e-ocp.sh` said OCP "through 4.21" still applies the legacy control-plane taint. That read as a version bound (4.21 being the latest OCP at the time the comment was written), but Red Hat keeps that taint as the default on control-plane nodes well beyond 4.21, so the bound is misleading and would look stale on every OCP bump.

Drop the version number so the comment stops looking stale on each OCP bump. The wording deliberately avoids the literal taint key so the line stays clear of the woke linter. The toleration logic already covers both keys, so this is a comment-only change with no behavioral effect.