### PR TITLE
ci(testing): enable OwnerReferencesPermissionEnforcement admission plugin

### DIFF
--- a/hack/testing-tools/k8s-engines/k3d/setup.sh
+++ b/hack/testing-tools/k8s-engines/k3d/setup.sh
@@ -93,6 +93,7 @@ EOF
 
   K3D_FIX_MOUNTS=1 k3d cluster create "${options[@]}" "${agents[@]}" -i "rancher/k3s:${latest_k3s_tag}" --no-lb "${cluster_name}" \
     --k3s-arg "--disable=traefik@server:0" --k3s-arg "--disable=metrics-server@server:0" \
+    --k3s-arg "--kube-apiserver-arg=enable-admission-plugins=OwnerReferencesPermissionEnforcement@server:0" \
     "${taint_args[@]}"
 
   docker network connect "k3d-${cluster_name}" "${registry_name}" &>/dev/null || true

--- a/hack/testing-tools/k8s-engines/kind/setup.sh
+++ b/hack/testing-tools/k8s-engines/kind/setup.sh
@@ -69,6 +69,12 @@ kubeadmConfigPatchesJSON6902:
         value: docker
 nodes:
 - role: control-plane
+  kubeadmConfigPatches:
+  - |
+    kind: ClusterConfiguration
+    apiServer:
+        extraArgs:
+          enable-admission-plugins: OwnerReferencesPermissionEnforcement
 EOF
 
   if [ "${ENABLE_APISERVER_AUDIT}" = "true" ]; then
@@ -77,7 +83,6 @@ EOF
     mkdir -p "${LOG_DIR}/apiserver"
     touch "${LOG_DIR}/apiserver/kube-apiserver-audit.log"
     cat >>"${config_file}" <<-EOF
-  kubeadmConfigPatches:
   - |
     kind: ClusterConfiguration
     apiServer:


### PR DESCRIPTION
Enable the OwnerReferencesPermissionEnforcement admission plugin in both Kind and k3d test clusters so that ownership and cross-namespace reference rules are enforced during E2E tests, matching stricter production cluster configurations.