### PR TITLE
ci(setup-cluster): allow single-node k3d clusters to schedule workloads

### DIFF
--- a/hack/testing-tools/k8s-engines/k3d/setup.sh
+++ b/hack/testing-tools/k8s-engines/k3d/setup.sh
@@ -84,13 +84,16 @@ EOF
   fi
 
   local agents=()
+  local taint_args=()
   if [ "$NODES" -gt 1 ]; then
     agents=(-a "${NODES}")
+    # Only taint the server when agent nodes exist to schedule workloads
+    taint_args=(--k3s-arg "--node-taint=node-role.kubernetes.io/master:NoSchedule@server:0") #wokeignore:rule=master
   fi
 
   K3D_FIX_MOUNTS=1 k3d cluster create "${options[@]}" "${agents[@]}" -i "rancher/k3s:${latest_k3s_tag}" --no-lb "${cluster_name}" \
     --k3s-arg "--disable=traefik@server:0" --k3s-arg "--disable=metrics-server@server:0" \
-    --k3s-arg "--node-taint=node-role.kubernetes.io/master:NoSchedule@server:0" #wokeignore:rule=master
+    "${taint_args[@]}"
 
   docker network connect "k3d-${cluster_name}" "${registry_name}" &>/dev/null || true
 }


### PR DESCRIPTION
When using k3d with a single node, the server was always tainted with `node-role.kubernetes.io/master:NoSchedule`, preventing any pods from being scheduled. The taint is now only applied when agent nodes are present to handle the workload.