### PR TITLE
chore: consolidate on Masterminds/semver and drop blang/semver

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,9 +4,9 @@ go 1.26.4
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2
+	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/acobaugh/osrelease v0.1.0
 	github.com/avast/retry-go/v5 v5.0.0
-	github.com/blang/semver v3.5.1+incompatible
 	github.com/cheynewallace/tabby v1.1.1
 	github.com/cloudnative-pg/barman-cloud v0.5.1
 	github.com/cloudnative-pg/cnpg-i v0.5.0
@@ -50,7 +50,6 @@ require (
 
 require (
 	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect
-	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,6 @@ github.com/avast/retry-go/v5 v5.0.0 h1:kf1Qc2UsTZ4qq8elDymqfbISvkyMuhgRxuJqX2NHP
 github.com/avast/retry-go/v5 v5.0.0/go.mod h1://d+usmKWio1agtZfS1H/ltTqwtIfBnRq9zEwjc3eH8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
-github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=

--- a/internal/management/controller/instance_controller.go
+++ b/internal/management/controller/instance_controller.go
@@ -1079,7 +1079,7 @@ func (r *InstanceReconciler) reconcilePostgreSQLAutoConfFilePermissions(ctx cont
 		return
 	}
 
-	if version.Major >= 17 {
+	if version.Major() >= 17 {
 		// PostgreSQL 17 and newer versions allow preventing ALTER SYSTEM
 		// usages using a GUC. We don't need to do anything on the file
 		// system side.

--- a/internal/management/controller/subscription_controller.go
+++ b/internal/management/controller/subscription_controller.go
@@ -229,7 +229,7 @@ func NewSubscriptionReconciler(
 		},
 		getPostgresMajorVersion: func() (int, error) {
 			version, err := instance.GetPgVersion()
-			return int(version.Major), err //nolint:gosec
+			return int(version.Major()), err //nolint:gosec
 		},
 	}
 	sr.finalizerReconciler = newFinalizerReconciler(

--- a/pkg/management/postgres/instance.go
+++ b/pkg/management/postgres/instance.go
@@ -38,7 +38,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/blang/semver"
+	"github.com/Masterminds/semver/v3"
 	"github.com/cloudnative-pg/machinery/pkg/envmap"
 	"github.com/cloudnative-pg/machinery/pkg/execlog"
 	"github.com/cloudnative-pg/machinery/pkg/fileutils"

--- a/pkg/management/postgres/logicalimport/role.go
+++ b/pkg/management/postgres/logicalimport/role.go
@@ -25,7 +25,7 @@ import (
 	"fmt"
 	"slices"
 
-	"github.com/blang/semver"
+	"github.com/Masterminds/semver/v3"
 	"github.com/cloudnative-pg/machinery/pkg/log"
 	"github.com/jackc/pgx/v5"
 	"github.com/lib/pq"
@@ -152,7 +152,7 @@ func (rs *roleManager) getRoles(ctx context.Context) ([]Role, error) {
 
 	// Retrieve the roles excluding those that are owned by the postgres catalog
 	// see FirstNormalObjectId in https://github.com/postgres/postgres/blob/662dbe2/src/include/access/transam.h#L197
-	if vers.GTE(semver.Version{Major: 9, Minor: 5}) {
+	if vers.GreaterThanEqual(semver.New(9, 5, 0, "", "")) {
 		query = "SELECT oid, rolname, rolsuper, rolinherit, " +
 			"rolcreaterole, rolcreatedb, " +
 			"rolcanlogin, rolconnlimit, rolpassword, " +

--- a/pkg/management/postgres/metrics/collector.go
+++ b/pkg/management/postgres/metrics/collector.go
@@ -31,7 +31,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/blang/semver"
+	"github.com/Masterminds/semver/v3"
 	"github.com/cloudnative-pg/cnpg-i/pkg/metrics"
 	"github.com/cloudnative-pg/machinery/pkg/log"
 	"github.com/prometheus/client_golang/prometheus"
@@ -237,14 +237,14 @@ func (q *QueriesCollector) checkRunOnServerMatches(runOnServer string, name stri
 		return false, err
 	}
 
-	isVersionInRange, err := semver.ParseRange(runOnServer)
+	versionRange, err := semver.NewConstraint(runOnServer)
 	if err != nil {
 		log.Error(err, "while parsing runOnServer version range",
 			"runOnServer", runOnServer, "query", name)
 		return false, err
 	}
 
-	return isVersionInRange(pgVersion), nil
+	return versionRange.Check(&pgVersion), nil
 }
 
 func (q *QueriesCollector) expandTargetDatabases(

--- a/pkg/management/postgres/probes.go
+++ b/pkg/management/postgres/probes.go
@@ -284,7 +284,7 @@ func (instance *Instance) fillBasebackupStats(
 	superUserDB *sql.DB,
 	result *postgres.PostgresqlStatus,
 ) error {
-	if ver, _ := instance.GetPgVersion(); ver.Major < 13 {
+	if ver, _ := instance.GetPgVersion(); ver.Major() < 13 {
 		return nil
 	}
 
@@ -390,7 +390,7 @@ func (instance *Instance) fillReplicationSlotsStatus(result *postgres.Postgresql
 	if !result.IsPrimary {
 		return nil
 	}
-	if ver, _ := instance.GetPgVersion(); ver.Major < 13 {
+	if ver, _ := instance.GetPgVersion(); ver.Major() < 13 {
 		return nil
 	}
 
@@ -600,7 +600,7 @@ type PgStatWal struct {
 // TryGetPgStatWAL retrieves pg_stat_wal on pg version 14 and further
 func (instance *Instance) TryGetPgStatWAL() (*PgStatWal, error) {
 	version, err := instance.GetPgVersion()
-	if err != nil || version.Major < 14 {
+	if err != nil || version.Major() < 14 {
 		return nil, err
 	}
 
@@ -613,7 +613,7 @@ func (instance *Instance) TryGetPgStatWAL() (*PgStatWal, error) {
 	// `wal_sync_time` have been removed.
 	// See https://github.com/postgres/postgres/commit/2421e9a51d20bb83154e54a16ce628f9249fa907
 	var pgWalStat PgStatWal
-	if version.Major < 18 {
+	if version.Major() < 18 {
 		row := db.QueryRow(
 			`SELECT
 			wal_records,
@@ -641,7 +641,7 @@ func (instance *Instance) TryGetPgStatWAL() (*PgStatWal, error) {
 		}
 	}
 
-	if version.Major >= 18 {
+	if version.Major() >= 18 {
 		row := db.QueryRow(
 			`SELECT
         	wal_records,

--- a/pkg/management/postgres/probes_test.go
+++ b/pkg/management/postgres/probes_test.go
@@ -24,7 +24,7 @@ import (
 	"regexp"
 
 	"github.com/DATA-DOG/go-sqlmock"
-	"github.com/blang/semver"
+	"github.com/Masterminds/semver/v3"
 	"k8s.io/utils/ptr"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
@@ -218,7 +218,7 @@ var _ = Describe("probes", func() {
 	Context("Fill basebackup stats", func() {
 		It("set the information", func() {
 			instance := (&Instance{
-				pgVersion: &semver.Version{Major: 13},
+				pgVersion: semver.New(13, 0, 0, "", ""),
 			}).WithPodName("test-1")
 			status := &postgres.PostgresqlStatus{
 				IsPrimary: false,

--- a/pkg/management/postgres/utils/version.go
+++ b/pkg/management/postgres/utils/version.go
@@ -26,7 +26,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/blang/semver"
+	"github.com/Masterminds/semver/v3"
 )
 
 // GetPgVersion returns the version of postgres in a semantic format or an error
@@ -46,11 +46,13 @@ func parseVersionNum(versionNum string) (*semver.Version, error) {
 		return nil, err
 	}
 
-	return &semver.Version{
-		Major: versionInt / 10000,
-		Minor: (versionInt / 100) % 100,
-		Patch: versionInt % 100,
-	}, nil
+	return semver.New(
+		versionInt/10000,
+		(versionInt/100)%100,
+		versionInt%100,
+		"",
+		"",
+	), nil
 }
 
 // GetMajorVersionFromPgData read the PG_VERSION file in the data directory

--- a/pkg/management/postgres/utils/version_test.go
+++ b/pkg/management/postgres/utils/version_test.go
@@ -20,7 +20,7 @@ SPDX-License-Identifier: Apache-2.0
 package utils
 
 import (
-	"github.com/blang/semver"
+	"github.com/Masterminds/semver/v3"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -35,12 +35,12 @@ var _ = Describe("Parsing versions", func() {
 	It("properly works when version is well-formed and >= 10", func() {
 		v, err := parseVersionNum("120034")
 		Expect(err).ToNot(HaveOccurred())
-		Expect(v).To(Equal(&semver.Version{Major: 12, Patch: 34}))
+		Expect(v).To(Equal(semver.New(12, 0, 34, "", "")))
 	})
 
 	It("properly works when version is well-formed and < 10", func() {
 		v, err := parseVersionNum("090807")
 		Expect(err).ToNot(HaveOccurred())
-		Expect(v).To(Equal(&semver.Version{Major: 9, Minor: 8, Patch: 7}))
+		Expect(v).To(Equal(semver.New(9, 8, 7, "", "")))
 	})
 })

--- a/pkg/management/postgres/webserver/backup_connection.go
+++ b/pkg/management/postgres/webserver/backup_connection.go
@@ -95,7 +95,7 @@ func newBackupConnection(
 		immediateCheckpoint:  immediateCheckpoint,
 		waitForArchive:       waitForArchive,
 		conn:                 conn,
-		postgresMajorVersion: vers.Major,
+		postgresMajorVersion: vers.Major(),
 		data: BackupResultData{
 			BackupName: backupName,
 			Phase:      Starting,

--- a/pkg/management/postgres/webserver/metricserver/pg_collector.go
+++ b/pkg/management/postgres/webserver/metricserver/pg_collector.go
@@ -297,12 +297,12 @@ func (e *Exporter) Describe(ch chan<- *prometheus.Desc) {
 		e.queries.Describe(ch)
 	}
 
-	if version, _ := e.instance.GetPgVersion(); version.Major >= 14 {
+	if version, _ := e.instance.GetPgVersion(); version.Major() >= 14 {
 		e.Metrics.PgStatWalMetrics.WalRecords.Describe(ch)
 		e.Metrics.PgStatWalMetrics.WalFpi.Describe(ch)
 		e.Metrics.PgStatWalMetrics.WalBytes.Describe(ch)
 		e.Metrics.PgStatWalMetrics.WALBuffersFull.Describe(ch)
-		if version.Major < 18 {
+		if version.Major() < 18 {
 			e.Metrics.PgStatWalMetrics.WalWrite.Describe(ch)
 			e.Metrics.PgStatWalMetrics.WalSync.Describe(ch)
 			e.Metrics.PgStatWalMetrics.WalWriteTime.Describe(ch)
@@ -376,12 +376,12 @@ func (e *Exporter) collectInstanceMetrics(ch chan<- prometheus.Metric) {
 	e.Metrics.LastAvailableBackupTimestamp.Collect(ch)
 	e.Metrics.NodesUsed.Collect(ch)
 
-	if version, _ := e.instance.GetPgVersion(); version.Major >= 14 {
+	if version, _ := e.instance.GetPgVersion(); version.Major() >= 14 {
 		e.Metrics.PgStatWalMetrics.WalRecords.Collect(ch)
 		e.Metrics.PgStatWalMetrics.WalFpi.Collect(ch)
 		e.Metrics.PgStatWalMetrics.WalBytes.Collect(ch)
 		e.Metrics.PgStatWalMetrics.WALBuffersFull.Collect(ch)
-		if version.Major < 18 {
+		if version.Major() < 18 {
 			e.Metrics.PgStatWalMetrics.WalWrite.Collect(ch)
 			e.Metrics.PgStatWalMetrics.WalSync.Collect(ch)
 			e.Metrics.PgStatWalMetrics.WalWriteTime.Collect(ch)
@@ -477,7 +477,7 @@ func (e *Exporter) updateInstanceMetrics() {
 		e.Metrics.PgVersion.Reset()
 	}
 
-	if version, _ := e.instance.GetPgVersion(); version.Major >= 14 {
+	if version, _ := e.instance.GetPgVersion(); version.Major() >= 14 {
 		if err := collectPGStatWAL(e); err != nil {
 			log.Error(err, "while collecting pg_stat_wal")
 			e.Metrics.Error.Set(1)
@@ -591,7 +591,7 @@ func collectPGVersion(e *Exporter) error {
 	}
 
 	// we use patch instead of minor because postgres doesn't use semantic versioning
-	majorMinor := fmt.Sprintf("%d.%d", semanticVersion.Major, semanticVersion.Patch)
+	majorMinor := fmt.Sprintf("%d.%d", semanticVersion.Major(), semanticVersion.Patch())
 	version, err := strconv.ParseFloat(majorMinor, 64)
 	if err != nil {
 		return err

--- a/pkg/management/postgres/webserver/metricserver/wal.go
+++ b/pkg/management/postgres/webserver/metricserver/wal.go
@@ -54,7 +54,7 @@ func collectPGStatWAL(e *Exporter) error {
 	walMetrics.WalFpi.WithLabelValues(walStat.StatsReset).Set(float64(walStat.WalFpi))
 	walMetrics.WalBytes.WithLabelValues(walStat.StatsReset).Set(float64(walStat.WalBytes))
 	walMetrics.WALBuffersFull.WithLabelValues(walStat.StatsReset).Set(float64(walStat.WALBuffersFull))
-	if version, _ := e.instance.GetPgVersion(); version.Major < 18 {
+	if version, _ := e.instance.GetPgVersion(); version.Major() < 18 {
 		walMetrics.WalWrite.WithLabelValues(walStat.StatsReset).Set(float64(walStat.WalWrite))
 		walMetrics.WalSync.WithLabelValues(walStat.StatsReset).Set(float64(walStat.WalSync))
 		walMetrics.WalWriteTime.WithLabelValues(walStat.StatsReset).Set(walStat.WalWriteTime)

--- a/tests/e2e/imagevolume_extensions_test.go
+++ b/tests/e2e/imagevolume_extensions_test.go
@@ -26,7 +26,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/blang/semver"
+	"github.com/Masterminds/semver/v3"
 	"github.com/cloudnative-pg/machinery/pkg/image/reference"
 	"github.com/cloudnative-pg/machinery/pkg/postgres/version"
 	corev1 "k8s.io/api/core/v1"
@@ -79,11 +79,11 @@ var _ = Describe("ImageVolume Extensions", Label(tests.LabelImageVolumeExtension
 		// Require K8S 1.33 or greater
 		versionInfo, err := env.Interface.Discovery().ServerVersion()
 		Expect(err).NotTo(HaveOccurred())
-		currentVersion, err := semver.Parse(strings.TrimPrefix(versionInfo.String(), "v"))
+		currentVersion, err := semver.NewVersion(strings.TrimPrefix(versionInfo.String(), "v"))
 		Expect(err).NotTo(HaveOccurred())
-		k8s133, err := semver.Parse("1.33.0")
+		k8s133, err := semver.NewVersion("1.33.0")
 		Expect(err).NotTo(HaveOccurred())
-		if currentVersion.LT(k8s133) {
+		if currentVersion.LessThan(k8s133) {
 			Skip("This test runs only on Kubernetes 1.33 or greater")
 		}
 	})

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -7,7 +7,6 @@ replace github.com/cloudnative-pg/cloudnative-pg => ../
 require (
 	github.com/Masterminds/semver/v3 v3.5.0
 	github.com/avast/retry-go/v5 v5.0.0
-	github.com/blang/semver v3.5.1+incompatible
 	github.com/cheynewallace/tabby v1.1.1
 	github.com/cloudnative-pg/cloudnative-pg v0.0.0-00010101000000-000000000000
 	github.com/cloudnative-pg/machinery v0.5.0

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -8,8 +8,6 @@ github.com/avast/retry-go/v5 v5.0.0 h1:kf1Qc2UsTZ4qq8elDymqfbISvkyMuhgRxuJqX2NHP
 github.com/avast/retry-go/v5 v5.0.0/go.mod h1://d+usmKWio1agtZfS1H/ltTqwtIfBnRq9zEwjc3eH8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
-github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cheynewallace/tabby v1.1.1 h1:JvUR8waht4Y0S3JF17G6Vhyt+FRhnqVCkk8l4YrOU54=

--- a/tests/utils/openshift/openshift.go
+++ b/tests/utils/openshift/openshift.go
@@ -25,7 +25,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/blang/semver"
+	"github.com/Masterminds/semver/v3"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -122,7 +122,11 @@ func GetOpenshiftVersion(ctx context.Context, restConfig *rest.Config) (semver.V
 		return semver.Version{}, err
 	}
 
-	return semver.Make(version)
+	parsedVersion, err := semver.NewVersion(version)
+	if err != nil {
+		return semver.Version{}, err
+	}
+	return *parsedVersion, nil
 }
 
 // CreateSubscription creates a subscription object inside openshift with a fixed name


### PR DESCRIPTION
The dependency graph carried two overlapping semver libraries. Masterminds/semver/v3 is pulled in transitively by ginkgo, controller-runtime and machinery, so it cannot be dropped; blang/semver was present only because our own code imported it. This migrates every remaining blang/semver use to Masterminds/semver/v3 so a single library covers the codebase.

The runOnServer range check moves from blang's ParseRange to a Masterminds constraint; both accept the documented comparator and space-separated AND syntax, so existing configurations keep working. The blang/semver/v4 indirect dependency stays: it is required by kustomize via cli-runtime.

Closes #10991
