### PR TITLE
fix(pgbasebackup): guard against pre-existing PGDATA before bootstrapping

### DIFF
--- a/internal/cmd/manager/instance/pgbasebackup/cmd.go
+++ b/internal/cmd/manager/instance/pgbasebackup/cmd.go
@@ -82,6 +82,10 @@ func NewCmd() *cobra.Command {
 				client: client,
 			}
 
+			if err := env.info.EnsureTargetDirectoriesDoNotExist(ctx); err != nil {
+				return err
+			}
+
 			if err = env.bootstrapUsingPgbasebackup(ctx); err != nil {
 				contextLogger.Error(err, "Unable to bootstrap cluster")
 			}


### PR DESCRIPTION
The pg_basebackup bootstrap path was the only one among initdb, restore, and join that did not call EnsureTargetDirectoriesDoNotExist before running. This left a gap where a replica Pod restarted after a previous pg_basebackup run had already written (or partially written) PGDATA, causing the new run to fail or produce a corrupt instance.

With this fix, the same pre-flight check applied by all other bootstrap paths is now enforced: if PGDATA already contains a valid control file, the directory is renamed out of the way before retrying; if it looks like a failed partial run, it is removed. This also protects statically provisioned PVCs from being silently overwritten.

Closes: #11005 