### PR TITLE
docs: add boto3 S3 data integrity workaround for object stores

### DIFF
--- a/.wordlist-en-custom.txt
+++ b/.wordlist-en-custom.txt
@@ -728,6 +728,7 @@ bootstrapconfiguration
 bootstrapinitdb
 bootstrappgbasebackup
 bootstraprecovery
+boto
 bozkayasalihx
 br
 bs

--- a/docs/src/appendixes/object_stores.md
+++ b/docs/src/appendixes/object_stores.md
@@ -168,6 +168,26 @@ spec:
         [...]
 ```
 
+:::note
+Recent changes to the [boto3 implementation](https://github.com/boto/boto3/issues/4392)
+of [Amazon S3 Data Integrity Protections](https://docs.aws.amazon.com/sdkref/latest/guide/feature-dataintegrity.html)
+may lead to the `x-amz-content-sha256` error. If you encounter this issue, you
+can apply the following workaround by setting specific environment variables at
+the cluster level through `spec.env`:
+
+```yaml
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+[...]
+spec:
+  env:
+    - name: AWS_REQUEST_CHECKSUM_CALCULATION
+      value: when_required
+    - name: AWS_RESPONSE_CHECKSUM_VALIDATION
+      value: when_required
+```
+:::
+
 ### Using Object Storage with a private CA
 
 Suppose you configure an Object Storage provider which uses a certificate


### PR DESCRIPTION
Recent changes to the boto3 implementation of Amazon S3 Data Integrity Protections may lead to the x-amz-content-sha256 error with S3-compatible object stores. Document the workaround of setting the `AWS_REQUEST_CHECKSUM_CALCULATION` and `AWS_RESPONSE_CHECKSUM_VALIDATION` environment variables via `spec.env`.

Closes #8427