### PR TITLE
chore(makefile): isolate OPENSHIFT_VERSIONS to reduce cherry-pick conflicts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,9 +74,13 @@ PREFLIGHT_VERSION ?= 1.19.1
 CUE_VERSION ?= 0.16.1
 # renovate: datasource=go depName=github.com/gemaraproj/gemara
 GEMARA_VERSION ?= v1.3.0
-OPENSHIFT_VERSIONS ?= v4.18-v4.22
 ARCH ?= amd64
 FUZZ_TIME ?= 30s
+
+# OPENSHIFT_VERSIONS differs per release branch, unlike the renovate-managed
+# versions above that stay identical. The blank lines around it keep it out of
+# their diff context, so backport cherry-picks of a version bump don't conflict.
+OPENSHIFT_VERSIONS ?= v4.18-v4.22
 
 export CONTROLLER_IMG
 export BUILD_IMAGE


### PR DESCRIPTION
`OPENSHIFT_VERSIONS` was wedged inside the renovate-managed version block in the Makefile, between versions that are kept identical across release branches. Since this value diverges per branch, every bump of a neighbouring version made backport cherry-picks conflict on it.

This moves it into its own blank-line-padded stanza so it falls outside the diff context of the surrounding versions, letting version bumps cherry-pick cleanly.

The layout on each release branch converges the first time a backport touches this region, so no separate per-branch change is needed.
