### PR TITLE
fix: prevent instance recreation deadlock when the previous PVC is still terminating

### DIFF
--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -1130,7 +1130,7 @@ func (r *ClusterReconciler) reconcilePods(
 		return ctrl.Result{RequeueAfter: 1 * time.Second}, ErrNextLoop
 	}
 
-	// Are there missing nodes? Let's create one
+	// Are there missing instances? Let's create one
 	if res, err := r.reconcileMissingInstance(ctx, cluster, resources, instancesStatus); !res.IsZero() || err != nil {
 		return res, err
 	}

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -1131,10 +1131,8 @@ func (r *ClusterReconciler) reconcilePods(
 	}
 
 	// Are there missing nodes? Let's create one
-	if cluster.Status.Instances < cluster.Spec.Instances &&
-		instancesStatus.InstancesReportingStatus() == cluster.Status.Instances {
-		newNodeSerial := r.generateNodeSerial(cluster)
-		return r.joinReplicaInstance(ctx, newNodeSerial, cluster)
+	if res, err := r.reconcileMissingInstance(ctx, cluster, resources, instancesStatus); !res.IsZero() || err != nil {
+		return res, err
 	}
 
 	// Should we scale down the cluster?

--- a/internal/controller/cluster_controller_test.go
+++ b/internal/controller/cluster_controller_test.go
@@ -125,6 +125,64 @@ var _ = Describe("reconcilePods instance recreation while a PVC is terminating (
 	})
 })
 
+var _ = Describe("ensureInstancesAreCreated reattachment while a PVC is terminating (#10985)", func() {
+	var env *testingEnvironment
+	var namespace string
+
+	BeforeEach(func() {
+		env = buildTestEnvironment()
+		namespace = newFakeNamespace(env.client)
+	})
+
+	It("defers reattaching a Pod while one of the instance's PVCs is still terminating", func(ctx SpecContext) {
+		cluster := newFakeCNPGCluster(env.client, namespace, func(c *apiv1.Cluster) {
+			c.Spec.WalStorage = &apiv1.StorageConfiguration{Size: "1G"}
+		})
+		cluster.Status.ReadyInstances = 2
+
+		readyPod := func(serial int) *corev1.Pod {
+			pod, err := specs.NewInstance(ctx, *cluster, serial, true)
+			Expect(err).ToNot(HaveOccurred())
+			pod.Status = corev1.PodStatus{
+				Phase:      corev1.PodRunning,
+				Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}},
+			}
+			return pod
+		}
+		pod1, pod2 := readyPod(1), readyPod(2)
+
+		// Instance 3 has a podless data PVC (so it is a candidate for
+		// reattachment) while its WAL PVC is still terminating.
+		thirdGroup := newFakePVC(env.client, cluster, 3, persistentvolumeclaim.StatusReady)
+		walName := specs.GetInstanceName(cluster.Name, 3) + apiv1.WalArchiveVolumeSuffix
+		for i := range thirdGroup {
+			if thirdGroup[i].Name == walName {
+				thirdGroup[i].DeletionTimestamp = ptr.To(metav1.Now())
+			}
+		}
+		cluster.Status.UnusablePVC = []string{specs.GetInstanceName(cluster.Name, 3)}
+
+		resources := &managedResources{
+			instances: corev1.PodList{Items: []corev1.Pod{*pod1, *pod2}},
+			pvcs:      corev1.PersistentVolumeClaimList{Items: thirdGroup},
+		}
+		statusList := postgres.PostgresqlStatusList{
+			Items: []postgres.PostgresqlStatus{
+				{Pod: pod1, IsPodReady: true, IsPrimary: true},
+				{Pod: pod2, IsPodReady: true},
+			},
+		}
+
+		res, err := env.clusterReconciler.ensureInstancesAreCreated(ctx, cluster, resources, statusList)
+		Expect(err).To(MatchError(ErrNextLoop))
+		Expect(res.RequeueAfter).To(Equal(time.Second))
+
+		var pods corev1.PodList
+		Expect(env.client.List(ctx, &pods)).To(Succeed())
+		Expect(pods.Items).To(BeEmpty(), "no Pod should be reattached while one of its PVCs is terminating")
+	})
+})
+
 var _ = Describe("Filtering cluster", func() {
 	metrics := make(map[string]string, 1)
 	metrics["a-secret"] = "test-version"

--- a/internal/controller/cluster_controller_test.go
+++ b/internal/controller/cluster_controller_test.go
@@ -30,6 +30,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
@@ -41,6 +42,88 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
+
+var _ = Describe("reconcilePods instance recreation while a PVC is terminating (#10985)", func() {
+	var env *testingEnvironment
+	var namespace string
+
+	BeforeEach(func() {
+		env = buildTestEnvironment()
+		namespace = newFakeNamespace(env.client)
+	})
+
+	// Builds a 3-instance cluster with WAL storage where instance serial 1 is
+	// missing while instances 2 and 3 are up and reporting ready. This is the
+	// state in which reconcilePods decides to recreate serial 1.
+	newRecreatingCluster := func(ctx SpecContext) (*apiv1.Cluster, *managedResources, postgres.PostgresqlStatusList) {
+		cluster := newFakeCNPGCluster(env.client, namespace, func(c *apiv1.Cluster) {
+			c.Spec.WalStorage = &apiv1.StorageConfiguration{Size: "1G"}
+		})
+		cluster.Status.Instances = 2
+		cluster.Status.ReadyInstances = 2
+		cluster.Status.InstanceNames = []string{
+			specs.GetInstanceName(cluster.Name, 2),
+			specs.GetInstanceName(cluster.Name, 3),
+		}
+
+		readyPod := func(serial int) *corev1.Pod {
+			pod, err := specs.NewInstance(ctx, *cluster, serial, true)
+			Expect(err).ToNot(HaveOccurred())
+			pod.Status = corev1.PodStatus{
+				Phase:      corev1.PodRunning,
+				Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}},
+			}
+			return pod
+		}
+		pod2 := readyPod(2)
+		pod3 := readyPod(3)
+
+		resources := &managedResources{
+			instances: corev1.PodList{Items: []corev1.Pod{*pod2, *pod3}},
+		}
+		statusList := postgres.PostgresqlStatusList{
+			Items: []postgres.PostgresqlStatus{
+				{Pod: pod2, IsPodReady: true},
+				{Pod: pod3, IsPodReady: true, IsPrimary: true},
+			},
+		}
+		return cluster, resources, statusList
+	}
+
+	It("creates the join Job when no previous PVC is terminating", func(ctx SpecContext) {
+		cluster, resources, statusList := newRecreatingCluster(ctx)
+
+		res, err := env.clusterReconciler.reconcilePods(ctx, cluster, resources, statusList)
+		Expect(err).To(MatchError(ErrNextLoop))
+		Expect(res.RequeueAfter).To(Equal(30 * time.Second))
+
+		var jobs batchv1.JobList
+		Expect(env.client.List(ctx, &jobs)).To(Succeed())
+		Expect(jobs.Items).To(HaveLen(1), "the join Job for the recreated instance should have been created")
+	})
+
+	It("defers recreation while a previous PVC for the same serial is still terminating", func(ctx SpecContext) {
+		cluster, resources, statusList := newRecreatingCluster(ctx)
+		// The WAL PVC of serial 1 has not finished terminating yet.
+		resources.pvcs = corev1.PersistentVolumeClaimList{Items: []corev1.PersistentVolumeClaim{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              specs.GetInstanceName(cluster.Name, 1) + apiv1.WalArchiveVolumeSuffix,
+					Namespace:         namespace,
+					DeletionTimestamp: ptr.To(metav1.Now()),
+				},
+			},
+		}}
+
+		res, err := env.clusterReconciler.reconcilePods(ctx, cluster, resources, statusList)
+		Expect(err).To(MatchError(ErrNextLoop))
+		Expect(res.RequeueAfter).To(Equal(time.Second))
+
+		var jobs batchv1.JobList
+		Expect(env.client.List(ctx, &jobs)).To(Succeed())
+		Expect(jobs.Items).To(BeEmpty(), "no join Job should be created while the previous PVC is terminating")
+	})
+})
 
 var _ = Describe("Filtering cluster", func() {
 	metrics := make(map[string]string, 1)

--- a/internal/controller/cluster_create.go
+++ b/internal/controller/cluster_create.go
@@ -1331,6 +1331,50 @@ func (r *ClusterReconciler) ensureJobAdoptable(
 	return ctrl.Result{}, nil
 }
 
+// reconcileMissingInstance creates the next missing instance when the cluster
+// has fewer instances than desired and every reported instance is ready.
+//
+// It returns a non-zero result (or an error) when the caller should stop and
+// requeue, and a zero result with no error when there is nothing to do.
+func (r *ClusterReconciler) reconcileMissingInstance(
+	ctx context.Context,
+	cluster *apiv1.Cluster,
+	resources *managedResources,
+	instancesStatus postgres.PostgresqlStatusList,
+) (ctrl.Result, error) {
+	if cluster.Status.Instances >= cluster.Spec.Instances ||
+		instancesStatus.InstancesReportingStatus() != cluster.Status.Instances {
+		return ctrl.Result{}, nil
+	}
+
+	newNodeSerial := r.generateNodeSerial(cluster)
+	instanceName := specs.GetInstanceName(cluster.Name, newNodeSerial)
+
+	// A serial stops being counted in the status while its PVCs are still
+	// terminating, so it can be picked here before the previous instance has
+	// been fully torn down. Creating the Job now would bind it to a PVC about
+	// to be garbage-collected, leaving the Pod permanently unschedulable while
+	// the running-job guard blocks any further reconciliation (see #10985).
+	// Wait for the previous PVCs to disappear before recreating the instance.
+	if pvcName := persistentvolumeclaim.GetTerminatingInstancePVCName(
+		cluster, instanceName, resources.pvcs.Items,
+	); pvcName != "" {
+		log.FromContext(ctx).Debug(
+			"Deferring instance recreation until the previous PVC finishes terminating",
+			"instance", instanceName,
+			"pvc", pvcName,
+		)
+		if err := r.RegisterPhase(ctx, cluster, apiv1.PhaseCreatingReplica,
+			fmt.Sprintf("Waiting for PVC %q to be removed before recreating instance %q", pvcName, instanceName),
+		); err != nil {
+			return ctrl.Result{}, err
+		}
+		return ctrl.Result{RequeueAfter: time.Second}, ErrNextLoop
+	}
+
+	return r.joinReplicaInstance(ctx, newNodeSerial, cluster)
+}
+
 func (r *ClusterReconciler) joinReplicaInstance(
 	ctx context.Context,
 	nodeSerial int,

--- a/internal/controller/cluster_create.go
+++ b/internal/controller/cluster_create.go
@@ -1364,7 +1364,11 @@ func (r *ClusterReconciler) reconcileMissingInstance(
 			"instance", instanceName,
 			"pvc", pvcName,
 		)
-		if err := r.RegisterPhase(ctx, cluster, apiv1.PhaseCreatingReplica,
+
+		if err := r.RegisterPhase(
+			ctx,
+			cluster,
+			apiv1.PhaseCreatingReplica,
 			fmt.Sprintf("Waiting for PVC %q to be removed before recreating instance %q", pvcName, instanceName),
 		); err != nil {
 			return ctrl.Result{}, err

--- a/internal/controller/cluster_create.go
+++ b/internal/controller/cluster_create.go
@@ -1480,6 +1480,21 @@ func (r *ClusterReconciler) ensureInstancesAreCreated(
 		return ctrl.Result{}, nil
 	}
 
+	// Reattaching an instance whose group of PVCs is incomplete because one of
+	// them is still terminating would create a Pod bound to a volume about to be
+	// garbage-collected, leaving it unschedulable. Wait for the previous PVC to
+	// disappear before reattaching (see #10985).
+	if pvcName := persistentvolumeclaim.GetTerminatingInstancePVCName(
+		cluster, instanceToCreate.Name, resources.pvcs.Items,
+	); pvcName != "" {
+		contextLogger.Debug(
+			"Deferring instance reattachment until the previous PVC finishes terminating",
+			"instance", instanceToCreate.Name,
+			"pvc", pvcName,
+		)
+		return ctrl.Result{RequeueAfter: 1 * time.Second}, ErrNextLoop
+	}
+
 	if !cluster.IsNodeMaintenanceWindowInProgress() &&
 		instancesStatus.InstancesReportingStatus() != cluster.Status.ReadyInstances {
 		// A pod is not ready, let's retry

--- a/pkg/reconciler/persistentvolumeclaim/create.go
+++ b/pkg/reconciler/persistentvolumeclaim/create.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 
 	"github.com/cloudnative-pg/machinery/pkg/log"
+	corev1 "k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -57,12 +58,54 @@ func createIfNotExists(
 		)
 	}
 
-	if err = c.Create(ctx, pvc); err != nil && !apierrs.IsAlreadyExists(err) {
+	err = c.Create(ctx, pvc)
+	if err == nil {
+		return nil
+	}
+	if !apierrs.IsAlreadyExists(err) {
 		return fmt.Errorf("unable to create a PVC: %s for this node (nodeSerial: %d): %w",
 			pvc.Name,
 			configuration.NodeSerial,
 			err,
 		)
+	}
+
+	// The PVC already exists, but it may still be terminating: a previous
+	// instance's PVC that has not finished being garbage-collected yet. Treating
+	// that as success would bind the instance to a volume about to vanish,
+	// leaving its Pod unschedulable (see #10985). Wait for it to be removed
+	// instead of swallowing the error.
+	return waitForTerminatingPVC(ctx, c, pvc, configuration.NodeSerial)
+}
+
+// waitForTerminatingPVC inspects an already-existing PVC and returns
+// utils.ErrNextLoop when it is still terminating (or has just been removed), so
+// the caller retries once the name is free again. It returns nil when the PVC
+// exists and is not terminating.
+func waitForTerminatingPVC(
+	ctx context.Context,
+	c client.Client,
+	pvc *corev1.PersistentVolumeClaim,
+	nodeSerial int,
+) error {
+	contextLogger := log.FromContext(ctx)
+
+	var existing corev1.PersistentVolumeClaim
+	if err := c.Get(ctx, client.ObjectKeyFromObject(pvc), &existing); err != nil {
+		if apierrs.IsNotFound(err) {
+			// It finished terminating between Create and Get: retry next loop.
+			return utils.ErrNextLoop
+		}
+		return fmt.Errorf("unable to verify existing PVC %s (nodeSerial: %d): %w", pvc.Name, nodeSerial, err)
+	}
+
+	if existing.DeletionTimestamp != nil {
+		contextLogger.Info(
+			"Waiting for the previous PVC to be removed before recreating it",
+			"pvc", pvc.Name,
+			"nodeSerial", nodeSerial,
+		)
+		return utils.ErrNextLoop
 	}
 
 	return nil

--- a/pkg/reconciler/persistentvolumeclaim/create_test.go
+++ b/pkg/reconciler/persistentvolumeclaim/create_test.go
@@ -100,6 +100,28 @@ var _ = Describe("testing create function", func() {
 		})
 	})
 
+	Context("when a PVC with the same name is still terminating", func() {
+		It("should return ErrNextLoop instead of silently succeeding", func() {
+			terminating := &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      pvcName,
+					Namespace: "default",
+					// A finalizer keeps the object around after Delete, so the
+					// fake client reports it as terminating (DeletionTimestamp set).
+					Finalizers: []string{"cnpg.io/test"},
+				},
+			}
+			cli = fake.NewClientBuilder().
+				WithScheme(schemeBuilder.BuildWithAllKnownScheme()).
+				WithObjects(terminating).
+				Build()
+			Expect(cli.Delete(ctx, terminating)).To(Succeed())
+
+			err := createIfNotExists(ctx, cli, cluster, cc)
+			Expect(err).To(Equal(utils.ErrNextLoop))
+		})
+	})
+
 	It("should return ErrNextLoop on invalid size", func() {
 		cc.Storage.Size = "typo"
 		err := createIfNotExists(ctx, cli, cluster, cc)

--- a/pkg/reconciler/persistentvolumeclaim/resources.go
+++ b/pkg/reconciler/persistentvolumeclaim/resources.go
@@ -86,15 +86,13 @@ func BelongToInstance(cluster *apiv1.Cluster, instanceName, pvcName string) bool
 }
 
 // GetTerminatingInstancePVCName returns the name of a PVC that the given
-// instance expects (and would (re)mount) which is still terminating — its
-// DeletionTimestamp is set — or "" if none is found.
+// instance expects (and would (re)mount) which is still terminating (its
+// DeletionTimestamp is set), or "" if none is found.
 //
-// A serial stops being counted in the cluster status while its PVCs are still
-// terminating, so recreating the instance at that point binds it to a volume
-// about to be garbage-collected, leaving the Pod permanently unschedulable
-// (see #10985). Callers should wait until this returns "" before (re)creating
-// the instance. PVCs the instance no longer expects (e.g. a dropped tablespace)
-// are ignored: they will not be remounted, so they need not hold up recreation.
+// Callers should wait until this returns "" before (re)creating the instance,
+// to avoid binding it to a volume about to be garbage-collected (see #10985).
+// PVCs the instance no longer expects (e.g. a dropped tablespace) are ignored:
+// they will not be remounted, so they need not hold up recreation.
 func GetTerminatingInstancePVCName(
 	cluster *apiv1.Cluster,
 	instanceName string,

--- a/pkg/reconciler/persistentvolumeclaim/resources.go
+++ b/pkg/reconciler/persistentvolumeclaim/resources.go
@@ -85,6 +85,32 @@ func BelongToInstance(cluster *apiv1.Cluster, instanceName, pvcName string) bool
 	return slices.Contains(expectedPVCs, pvcName)
 }
 
+// GetTerminatingInstancePVCName returns the name of a PVC that the given
+// instance expects (and would (re)mount) which is still terminating — its
+// DeletionTimestamp is set — or "" if none is found.
+//
+// A serial stops being counted in the cluster status while its PVCs are still
+// terminating, so recreating the instance at that point binds it to a volume
+// about to be garbage-collected, leaving the Pod permanently unschedulable
+// (see #10985). Callers should wait until this returns "" before (re)creating
+// the instance. PVCs the instance no longer expects (e.g. a dropped tablespace)
+// are ignored: they will not be remounted, so they need not hold up recreation.
+func GetTerminatingInstancePVCName(
+	cluster *apiv1.Cluster,
+	instanceName string,
+	pvcs []corev1.PersistentVolumeClaim,
+) string {
+	for i := range pvcs {
+		if pvcs[i].DeletionTimestamp == nil {
+			continue
+		}
+		if BelongToInstance(cluster, instanceName, pvcs[i].Name) {
+			return pvcs[i].Name
+		}
+	}
+	return ""
+}
+
 func filterByInstanceExpectedPVCs(
 	cluster *apiv1.Cluster,
 	instanceName string,

--- a/pkg/reconciler/persistentvolumeclaim/resources_test.go
+++ b/pkg/reconciler/persistentvolumeclaim/resources_test.go
@@ -20,7 +20,9 @@ SPDX-License-Identifier: Apache-2.0
 package persistentvolumeclaim
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 
@@ -52,6 +54,71 @@ var _ = Describe("PVCs used by instance", func() {
 	It("fails when trying to get a pvc that doesn't belong to the instance", func() {
 		res := BelongToInstance(cluster, instanceName, instanceName+"-nil")
 		Expect(res).To(BeFalse())
+	})
+})
+
+var _ = Describe("GetTerminatingInstancePVCName", func() {
+	const clusterName = "cluster-terminating-pvc"
+	instanceName := clusterName + "-1"
+
+	cluster := &apiv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{Name: clusterName},
+		Spec: apiv1.ClusterSpec{
+			WalStorage: &apiv1.StorageConfiguration{},
+		},
+	}
+
+	pvc := func(name string, terminating bool) corev1.PersistentVolumeClaim {
+		p := corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: name}}
+		if terminating {
+			p.DeletionTimestamp = ptr.To(metav1.Now())
+		}
+		return p
+	}
+
+	It("returns empty for an empty list", func() {
+		Expect(GetTerminatingInstancePVCName(cluster, instanceName, nil)).To(BeEmpty())
+	})
+
+	It("returns empty when no expected PVC is terminating", func() {
+		pvcs := []corev1.PersistentVolumeClaim{
+			pvc(instanceName, false),
+			pvc(instanceName+"-wal", false),
+		}
+		Expect(GetTerminatingInstancePVCName(cluster, instanceName, pvcs)).To(BeEmpty())
+	})
+
+	It("returns the name of a terminating data PVC the instance expects", func() {
+		pvcs := []corev1.PersistentVolumeClaim{pvc(instanceName, true)}
+		Expect(GetTerminatingInstancePVCName(cluster, instanceName, pvcs)).To(Equal(instanceName))
+	})
+
+	It("returns the name of a terminating WAL PVC the instance expects", func() {
+		pvcs := []corev1.PersistentVolumeClaim{pvc(instanceName+"-wal", true)}
+		Expect(GetTerminatingInstancePVCName(cluster, instanceName, pvcs)).To(Equal(instanceName + "-wal"))
+	})
+
+	It("ignores a terminating PVC of a different instance", func() {
+		pvcs := []corev1.PersistentVolumeClaim{pvc(clusterName+"-2-wal", true)}
+		Expect(GetTerminatingInstancePVCName(cluster, instanceName, pvcs)).To(BeEmpty())
+	})
+
+	// A PVC the instance will NOT remount (e.g. a tablespace that has been
+	// dropped from the spec) must not hold up recreation, even if terminating.
+	It("ignores a terminating PVC the instance no longer expects", func() {
+		pvcs := []corev1.PersistentVolumeClaim{pvc(instanceName+"-tbs-removed", true)}
+		Expect(GetTerminatingInstancePVCName(cluster, instanceName, pvcs)).To(BeEmpty())
+	})
+
+	// The #10985 scenario: the data PVC has finished terminating and been
+	// recreated fresh, while the WAL PVC of the same instance is still
+	// terminating.
+	It("detects a terminating WAL PVC even when the data PVC was recreated", func() {
+		pvcs := []corev1.PersistentVolumeClaim{
+			pvc(instanceName, false),
+			pvc(instanceName+"-wal", true),
+		}
+		Expect(GetTerminatingInstancePVCName(cluster, instanceName, pvcs)).To(Equal(instanceName + "-wal"))
 	})
 })
 

--- a/tests/e2e/pg_data_corruption_test.go
+++ b/tests/e2e/pg_data_corruption_test.go
@@ -22,10 +22,12 @@ package e2e
 import (
 	"fmt"
 
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/specs"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
@@ -247,6 +249,131 @@ var _ = Describe("PGDATA Corruption", Label(tests.LabelRecovery), Ordered, func(
 				_ = resources.DeleteResourcesFromFile(env, namespace, sampleFile)
 			})
 			testDataCorruption(namespace, sampleFile)
+		})
+	})
+
+	// This deterministically reproduces #10985: when an instance's data PVC has
+	// been removed but its WAL PVC is still terminating, the instance must not be
+	// recreated yet (a Job bound to the vanishing WAL PVC would wedge the Pod and
+	// block reconciliation). We force the race by pinning the WAL PVC with a
+	// finalizer so it lingers Terminating, and assert no recreation happens until
+	// it is released, after which the instance rejoins.
+	Context("when a previous PVC is slow to terminate", func() {
+		It("defers recreating the instance until the terminating PVC is gone, then rejoins", func() {
+			const sampleFile = fixturesDir + "/pg_data_corruption/cluster-pg-data-corruption.yaml.template"
+			const holdFinalizer = "cnpg.io/e2e-hold-terminating"
+
+			clusterName, err := yaml.GetResourceNameFromYAML(env.Scheme, sampleFile)
+			Expect(err).ToNot(HaveOccurred())
+			DeferCleanup(func() {
+				_ = resources.DeleteResourcesFromFile(env, namespace, sampleFile)
+			})
+
+			clusterasserts.AssertCreateCluster(env, testTimeouts, namespace, clusterName, sampleFile)
+
+			tableLocator := pgasserts.TableLocator{
+				Namespace:    namespace,
+				ClusterName:  clusterName,
+				DatabaseName: postgres.AppDBName,
+				TableName:    "test_pg_data_corruption_race",
+			}
+			pgasserts.AssertCreateTestData(env, tableLocator)
+
+			walStorageEnabled, err := storage.IsWalStorageEnabled(env.Ctx, env.Client, namespace, clusterName)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(walStorageEnabled).To(BeTrue(), "this test requires a cluster with walStorage")
+
+			var victimName string
+			By("selecting a standby instance to lose", func() {
+				podList, err := clusterutils.ListPods(env.Ctx, env.Client, namespace, clusterName)
+				Expect(err).ToNot(HaveOccurred())
+				for i := range podList.Items {
+					if specs.IsPodStandby(podList.Items[i]) {
+						victimName = podList.Items[i].Name
+						break
+					}
+				}
+				Expect(victimName).ToNot(BeEmpty(), "expected at least one standby")
+			})
+
+			walPVCName := fmt.Sprintf("%s-wal", victimName)
+			walPVCKey := types.NamespacedName{Namespace: namespace, Name: walPVCName}
+
+			By("pinning the standby's WAL PVC so it lingers Terminating", func() {
+				walPVC := &corev1.PersistentVolumeClaim{}
+				Expect(env.Client.Get(env.Ctx, walPVCKey, walPVC)).To(Succeed())
+				controllerutil.AddFinalizer(walPVC, holdFinalizer)
+				Expect(env.Client.Update(env.Ctx, walPVC)).To(Succeed())
+			})
+			// Always release the WAL PVC, otherwise namespace teardown would hang.
+			DeferCleanup(func() {
+				walPVC := &corev1.PersistentVolumeClaim{}
+				if err := env.Client.Get(env.Ctx, walPVCKey, walPVC); err == nil {
+					if controllerutil.RemoveFinalizer(walPVC, holdFinalizer) {
+						_ = env.Client.Update(env.Ctx, walPVC)
+					}
+				}
+			})
+
+			quickDelete := &client.DeleteOptions{GracePeriodSeconds: &quickDeletionPeriod}
+			By("deleting the standby pod, its data PVC and its WAL PVC", func() {
+				dataPVC := &corev1.PersistentVolumeClaim{}
+				Expect(env.Client.Get(env.Ctx,
+					types.NamespacedName{Namespace: namespace, Name: victimName}, dataPVC)).To(Succeed())
+				Expect(env.Client.Delete(env.Ctx, dataPVC, quickDelete)).To(Succeed())
+
+				walPVC := &corev1.PersistentVolumeClaim{}
+				Expect(env.Client.Get(env.Ctx, walPVCKey, walPVC)).To(Succeed())
+				Expect(env.Client.Delete(env.Ctx, walPVC, quickDelete)).To(Succeed())
+
+				Expect(podutils.Delete(env.Ctx, env.Client, namespace, victimName, quickDelete)).To(Succeed())
+			})
+
+			By("waiting for the data PVC to be gone while the WAL PVC stays Terminating", func() {
+				Eventually(func() bool {
+					err := env.Client.Get(env.Ctx,
+						types.NamespacedName{Namespace: namespace, Name: victimName},
+						&corev1.PersistentVolumeClaim{})
+					return apierrs.IsNotFound(err)
+				}, 120).Should(BeTrue(), "the data PVC should be garbage-collected")
+
+				walPVC := &corev1.PersistentVolumeClaim{}
+				Expect(env.Client.Get(env.Ctx, walPVCKey, walPVC)).To(Succeed())
+				Expect(walPVC.DeletionTimestamp).ToNot(BeNil(), "the WAL PVC should be terminating")
+			})
+
+			joinJobKey := types.NamespacedName{Namespace: namespace, Name: victimName + "-join"}
+			By("verifying the instance is NOT recreated while the WAL PVC is terminating", func() {
+				// Without the fix the operator creates the join Job immediately and
+				// its Pod stays Pending; with the fix no Job is created until the
+				// previous WAL PVC is gone.
+				Consistently(func() bool {
+					err := env.Client.Get(env.Ctx, joinJobKey, &batchv1.Job{})
+					return apierrs.IsNotFound(err)
+				}, 30, 3).Should(BeTrue(), "a join Job must not be created while the previous WAL PVC is terminating")
+			})
+
+			By("releasing the WAL PVC", func() {
+				walPVC := &corev1.PersistentVolumeClaim{}
+				Expect(env.Client.Get(env.Ctx, walPVCKey, walPVC)).To(Succeed())
+				controllerutil.RemoveFinalizer(walPVC, holdFinalizer)
+				Expect(env.Client.Update(env.Ctx, walPVC)).To(Succeed())
+			})
+
+			By("verifying the instance is recreated and rejoins as a ready standby", func() {
+				Eventually(func() (bool, error) {
+					pod := &corev1.Pod{}
+					if err := env.Client.Get(env.Ctx,
+						types.NamespacedName{Namespace: namespace, Name: victimName}, pod); err != nil {
+						return false, client.IgnoreNotFound(err)
+					}
+					return utils.IsPodActive(*pod) && utils.IsPodReady(*pod) && specs.IsPodStandby(*pod), nil
+				}, 300).Should(BeTrue())
+			})
+
+			clusterasserts.AssertClusterIsReady(env, namespace, clusterName, testTimeouts[testsUtils.ClusterIsReadyQuick])
+			pgasserts.AssertDataExpectedCount(env, tableLocator, 2)
+			replicationasserts.AssertClusterStandbysAreStreaming(env, namespace, clusterName, 140)
 		})
 	})
 })


### PR DESCRIPTION
When an instance's PVCs are deleted and the instance is recreated, the data and
WAL PVCs terminate independently. If the data PVC finishes terminating first
while the WAL PVC is still being garbage-collected, the instance stops being
counted in the cluster status and its serial appears free, so the operator
recreates it right away. The new join Job is bound to the WAL PVC that is about
to disappear, which leaves its Pod permanently unschedulable; the running-job
guard then returns early on every subsequent reconciliation, so the instance
never recovers. The failure was also silent: nothing in the operator log
pointed at the missing WAL PVC.

The fix is to not start recreating an instance while any PVC it will (re)mount
is still terminating. Before creating the join Job, and before reattaching a
Pod to a dangling PVC, the operator now checks whether an expected PVC for the
chosen instance is still terminating and, if so, waits for it to be removed
instead of proceeding. Only the PVCs the instance will actually mount are
considered, so a volume it no longer expects (for example a dropped tablespace)
does not hold up recreation. The recreation wait is surfaced through the cluster
phase and a log line, so the situation is no longer silent. Once the previous
PVCs are gone the instance is recreated with fresh volumes and rejoins as a
standby.

As a backstop, createIfNotExists no longer treats an AlreadyExists result as
success when the existing PVC is terminating: it logs the condition and
requeues until the volume is actually removed. This covers cases the
higher-level guards cannot observe, such as a claim whose owner reference was
removed, and gives the previously silent failure a log line regardless of the
path that hit it.

The change is scoped to instance creation and reattachment, and it only defers
when a same-instance PVC is mid-deletion, so normal scale-up and recovery are
unaffected. This is a regression specific to main and is not backported: #10548
switched serial assignment to reuse the lowest free serial, which is exactly
what lets a recreated instance collide with its own still-terminating PVC. The
release branches keep the counter-based assignment from #10491, where a freed
serial is never reused, so the race cannot occur there.

Unit and integration tests cover the new helper and both guards; the guard
tests fail against pre-patch code, plus a baseline test that pins the
no-deferral path when no PVC is terminating. A deterministic end-to-end test
forces the race by pinning a standby's WAL PVC with a finalizer so it lingers
terminating after the data PVC is gone; it asserts the instance is not recreated
until the PVC is released, then rejoins with the data intact. It fails against
an operator without the fix, where the instance is recreated prematurely.

Closes #10985
