### PR TITLE
test(e2e): gate operator install on owner-reference admission readiness

### DIFF
--- a/tests/e2e/upgrade_test.go
+++ b/tests/e2e/upgrade_test.go
@@ -799,7 +799,7 @@ var _ = Describe("Upgrade", Label(tests.LabelUpgrade, tests.LabelNoOpenshift), O
 			Expect(err).NotTo(HaveOccurred())
 
 			GinkgoWriter.Printf("installing the recent CNPG tag %s\n", mostRecentTag)
-			operator.InstallLatest(env.Client, mostRecentTag)
+			operator.InstallLatest(env.Ctx, env.Client, env.RestClientConfig, mostRecentTag)
 			DeferCleanup(cleanupOperatorAndObjectStore)
 
 			upgradeNamespace := assertCreateNamespace(upgradeNamespacePrefix)
@@ -816,7 +816,7 @@ var _ = Describe("Upgrade", Label(tests.LabelUpgrade, tests.LabelNoOpenshift), O
 			Expect(err).NotTo(HaveOccurred())
 
 			GinkgoWriter.Printf("installing the recent CNPG tag %s\n", mostRecentTag)
-			operator.InstallLatest(env.Client, mostRecentTag)
+			operator.InstallLatest(env.Ctx, env.Client, env.RestClientConfig, mostRecentTag)
 			DeferCleanup(cleanupOperatorAndObjectStore)
 
 			upgradeNamespace := assertCreateNamespace(upgradeNamespacePrefix)

--- a/tests/utils/operator/upgrade.go
+++ b/tests/utils/operator/upgrade.go
@@ -29,6 +29,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	k8sscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
@@ -80,9 +83,15 @@ func CreateConfigMap(
 	})
 }
 
+// operatorServiceAccount is the operator's ServiceAccount, used to probe the
+// admission path that the operator itself exercises while bootstrapping a cluster.
+const operatorServiceAccount = "system:serviceaccount:cnpg-system:cnpg-manager"
+
 // InstallLatest installs an operator version with the most recent release tag
 func InstallLatest(
+	ctx context.Context,
 	crudClient client.Client,
+	restConfig *rest.Config,
 	releaseTag string,
 ) {
 	mostRecentReleasePath := "../../releases/cnpg-" + releaseTag + ".yaml"
@@ -124,4 +133,51 @@ func InstallLatest(
 				"deployments cnpg-controller-manager")
 		return err
 	}, 150).ShouldNot(HaveOccurred())
+
+	// The OwnerReferencesPermissionEnforcement admission plugin (enabled on the
+	// test apiservers) resolves the owner GroupVersionKind through the apiserver's
+	// own RESTMapper, which is a different cache from the client RESTMapper checked
+	// above and refreshes from discovery on an interval (~30s). Until it picks up
+	// the freshly installed Cluster CRD, any object created with a blockOwnerDeletion
+	// owner reference to a Cluster is rejected with "no matches for kind Cluster",
+	// and the operator hits this the moment it creates the bootstrap Job.
+	//
+	// The check is only enforced for callers that are not cluster-admin, so probe
+	// while impersonating the operator's ServiceAccount: a privileged client (like
+	// the one used elsewhere in the suite) bypasses the plugin and would not gate
+	// on anything.
+	impersonatedConfig := rest.CopyConfig(restConfig)
+	impersonatedConfig.Impersonate = rest.ImpersonationConfig{UserName: operatorServiceAccount}
+	// Use a self-contained scheme: the probe only needs the core ConfigMap type,
+	// and relying on the caller's scheme to have registered it would be brittle.
+	probeClient, err := client.New(impersonatedConfig, client.Options{Scheme: k8sscheme.Scheme})
+	Expect(err).NotTo(HaveOccurred())
+
+	Eventually(func() error {
+		probe := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "owner-ref-probe-",
+				Namespace:    "cnpg-system",
+				OwnerReferences: []metav1.OwnerReference{
+					// BlockOwnerDeletion is what the admission plugin enforces; Controller
+					// is set only to mirror ctrl.SetControllerReference on the real
+					// bootstrap Job.
+					{
+						APIVersion:         apiv1.SchemeGroupVersion.String(),
+						Kind:               apiv1.ClusterKind,
+						Name:               "owner-ref-probe",
+						UID:                types.UID("00000000-0000-0000-0000-000000000000"),
+						BlockOwnerDeletion: ptr.To(true),
+						Controller:         ptr.To(true),
+					},
+				},
+			},
+		}
+		if err := probeClient.Create(ctx, probe); err != nil {
+			return err
+		}
+		// The probe references a Cluster that does not exist, so the garbage
+		// collector may delete it before we do; a NotFound here is success.
+		return client.IgnoreNotFound(probeClient.Delete(ctx, probe))
+	}, 90).ShouldNot(HaveOccurred())
 }


### PR DESCRIPTION
The rolling-upgrade test installs the latest released operator and immediately creates a cluster. With the OwnerReferencesPermissionEnforcement admission plugin now enabled on the test apiservers, the apiserver resolves owner GroupVersionKinds through its own RESTMapper, which refreshes from discovery only on an interval and is a separate cache from the client RESTMapper InstallLatest already waits on. Until that cache discovers the freshly installed Cluster CRD, the operator's bootstrap Job is rejected with "no matches for kind Cluster", the released operator never recovers, and the cluster stays stuck with no pods until the readiness timeout.

Gate InstallLatest on a probe that creates a throwaway object with a blockOwnerDeletion owner reference to a Cluster, exercising the same admission path the operator will hit. The plugin only enforces the check for callers that are not cluster-admin, so the probe impersonates the operator's ServiceAccount; a privileged client would bypass the plugin and gate on nothing.

Confirmed against the enabled plugin: a non-cluster-admin caller with clusters/finalizers permission is rejected with the exact "cannot set blockOwnerDeletion ... no matches for kind Cluster" error for ~30s after the CRD is applied, then accepted, while a cluster-admin client is never rejected.

Closes #11021
