### PR TITLE
ci: install Rook ceph-csi CRDs before applying their CRs

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -1241,8 +1241,9 @@ jobs:
             ROOK_BASE_URL=https://raw.githubusercontent.com/rook/rook/${{ env.ROOK_VERSION }}/deploy/examples
             kubectl apply -f ${ROOK_BASE_URL}/crds.yaml
             kubectl apply -f ${ROOK_BASE_URL}/common.yaml
-            kubectl apply -f ${ROOK_BASE_URL}/operator.yaml
+            # csi-operator.yaml defines the csi.ceph.io CRDs that operator.yaml's CRs rely on
             kubectl apply -f ${ROOK_BASE_URL}/csi-operator.yaml
+            kubectl apply -f ${ROOK_BASE_URL}/operator.yaml
             curl ${ROOK_BASE_URL}/cluster-on-pvc.yaml | \
               sed '/^ *#/d;/^ *$/d' | \
               yq e ".spec.storage.storageClassDeviceSets[].volumeClaimTemplates[].spec.resources.requests.storage = \"50Gi\" |


### PR DESCRIPTION
Rook v1.20.1 added the csi.ceph.io OperatorConfig and Driver custom resources to operator.yaml, while the CRDs that define those kinds ship in csi-operator.yaml. Applying operator.yaml first left the CRs rejected with "no matches for kind", so ceph-csi never configured RBD provisioning and the AKS object-store PVC never bound, hanging the E2E BeforeSuite for the full suite timeout. Apply csi-operator.yaml first.

Closes #11025