### PR TITLE
fix(validation): validate PostgreSQL parameter name shape

### DIFF
--- a/internal/webhook/v1/cluster_webhook.go
+++ b/internal/webhook/v1/cluster_webhook.go
@@ -24,6 +24,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"path/filepath"
+	"regexp"
 	"slices"
 	"strconv"
 	"strings"
@@ -1026,6 +1027,13 @@ func (v *ClusterCustomValidator) validateFailoverQuorum(r *apiv1.Cluster) field.
 	return result
 }
 
+// postgresParameterNameRegex matches a valid PostgreSQL configuration
+// parameter name: a plain GUC name or a custom (namespaced) one with a
+// single dot. Keys are rendered verbatim into postgresql.conf, so any
+// other character (most importantly a newline) could inject an
+// arbitrary directive.
+var postgresParameterNameRegex = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)?$`)
+
 // validateConfiguration determines whether a PostgreSQL configuration is valid
 func (v *ClusterCustomValidator) validateConfiguration(r *apiv1.Cluster) field.ErrorList {
 	var result field.ErrorList
@@ -1066,6 +1074,16 @@ func (v *ClusterCustomValidator) validateConfiguration(r *apiv1.Cluster) field.E
 	sanitizedParameters := postgres.CreatePostgresqlConfiguration(info).GetConfigurationParameters()
 
 	for key, value := range r.Spec.PostgresConfiguration.Parameters {
+		if !postgresParameterNameRegex.MatchString(key) {
+			result = append(
+				result,
+				field.Invalid(
+					field.NewPath("spec", "postgresql", "parameters", key),
+					key,
+					"Invalid PostgreSQL configuration parameter name"))
+			continue
+		}
+
 		_, isFixed := postgres.FixedConfigurationParameters[key]
 		sanitizedValue, presentInSanitizedConfiguration := sanitizedParameters[key]
 		if isFixed && (!presentInSanitizedConfiguration || value != sanitizedValue) {

--- a/internal/webhook/v1/cluster_webhook.go
+++ b/internal/webhook/v1/cluster_webhook.go
@@ -1029,10 +1029,15 @@ func (v *ClusterCustomValidator) validateFailoverQuorum(r *apiv1.Cluster) field.
 
 // postgresParameterNameRegex matches a valid PostgreSQL configuration
 // parameter name: a plain GUC name or a custom (namespaced) one with a
-// single dot. Keys are rendered verbatim into postgresql.conf, so any
-// other character (most importantly a newline) could inject an
-// arbitrary directive.
-var postgresParameterNameRegex = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)?$`)
+// single dot. Keys are rendered verbatim into postgresql.conf, so a
+// newline or other unexpected character could inject an arbitrary
+// directive.
+//
+// The pattern follows PostgreSQL's configuration-file lexer (guc-file.l),
+// including the dollar sign it allows in identifiers. It is intentionally
+// restricted to ASCII: the lexer also accepts high-bit bytes, but no real
+// GUC relies on them.
+var postgresParameterNameRegex = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_$]*(\.[A-Za-z_][A-Za-z0-9_$]*)?$`)
 
 // validateConfiguration determines whether a PostgreSQL configuration is valid
 func (v *ClusterCustomValidator) validateConfiguration(r *apiv1.Cluster) field.ErrorList {
@@ -1080,7 +1085,8 @@ func (v *ClusterCustomValidator) validateConfiguration(r *apiv1.Cluster) field.E
 				field.Invalid(
 					field.NewPath("spec", "postgresql", "parameters", key),
 					key,
-					"Invalid PostgreSQL configuration parameter name"))
+					"must be a valid PostgreSQL configuration parameter name "+
+						"(a GUC name, optionally namespaced with a single dot)"))
 			continue
 		}
 

--- a/internal/webhook/v1/cluster_webhook_test.go
+++ b/internal/webhook/v1/cluster_webhook_test.go
@@ -514,6 +514,39 @@ var _ = Describe("configuration change validation", func() {
 		v = &ClusterCustomValidator{}
 	})
 
+	It("accepts well-formed parameter names, including namespaced custom GUCs", func() {
+		clusterNew := &apiv1.Cluster{
+			Spec: apiv1.ClusterSpec{
+				PostgresConfiguration: apiv1.PostgresConfiguration{
+					Parameters: map[string]string{
+						"work_mem":                      "16MB",
+						"auto_explain.log_min_duration": "100ms",
+					},
+				},
+				StorageConfiguration: apiv1.StorageConfiguration{
+					Size: "10Gi",
+				},
+			},
+		}
+		Expect(v.validateConfiguration(clusterNew)).To(BeEmpty())
+	})
+
+	It("rejects a parameter name that injects a directive through a newline", func() {
+		clusterNew := &apiv1.Cluster{
+			Spec: apiv1.ClusterSpec{
+				PostgresConfiguration: apiv1.PostgresConfiguration{
+					Parameters: map[string]string{
+						"#\narchive_command": "/bin/evil",
+					},
+				},
+				StorageConfiguration: apiv1.StorageConfiguration{
+					Size: "10Gi",
+				},
+			},
+		}
+		Expect(v.validateConfiguration(clusterNew)).To(HaveLen(1))
+	})
+
 	It("produces no error when WAL size settings are correct", func() {
 		clusterNew := &apiv1.Cluster{
 			Spec: apiv1.ClusterSpec{

--- a/internal/webhook/v1/cluster_webhook_test.go
+++ b/internal/webhook/v1/cluster_webhook_test.go
@@ -556,6 +556,7 @@ var _ = Describe("configuration change validation", func() {
 		// rejected by the end anchor, which in Go matches end-of-text
 		// rather than end-of-line.
 		Entry("valid name with a trailing newline injection", "archive_command\nrestart_after = 0"),
+		Entry("trailing newline only", "archive_command\n"),
 		Entry("carriage return", "archive_command\rrestart_after = 0"),
 	)
 

--- a/internal/webhook/v1/cluster_webhook_test.go
+++ b/internal/webhook/v1/cluster_webhook_test.go
@@ -521,6 +521,7 @@ var _ = Describe("configuration change validation", func() {
 					Parameters: map[string]string{
 						"work_mem":                      "16MB",
 						"auto_explain.log_min_duration": "100ms",
+						"some$ext.param$1":              "value",
 					},
 				},
 				StorageConfiguration: apiv1.StorageConfiguration{
@@ -531,21 +532,32 @@ var _ = Describe("configuration change validation", func() {
 		Expect(v.validateConfiguration(clusterNew)).To(BeEmpty())
 	})
 
-	It("rejects a parameter name that injects a directive through a newline", func() {
-		clusterNew := &apiv1.Cluster{
-			Spec: apiv1.ClusterSpec{
-				PostgresConfiguration: apiv1.PostgresConfiguration{
-					Parameters: map[string]string{
-						"#\narchive_command": "/bin/evil",
+	DescribeTable("rejects a parameter name that could inject a directive",
+		func(key string) {
+			clusterNew := &apiv1.Cluster{
+				Spec: apiv1.ClusterSpec{
+					PostgresConfiguration: apiv1.PostgresConfiguration{
+						Parameters: map[string]string{
+							key: "/bin/evil",
+						},
+					},
+					StorageConfiguration: apiv1.StorageConfiguration{
+						Size: "10Gi",
 					},
 				},
-				StorageConfiguration: apiv1.StorageConfiguration{
-					Size: "10Gi",
-				},
-			},
-		}
-		Expect(v.validateConfiguration(clusterNew)).To(HaveLen(1))
-	})
+			}
+			errs := v.validateConfiguration(clusterNew)
+			Expect(errs).To(HaveLen(1))
+			Expect(errs[0].Type).To(Equal(field.ErrorTypeInvalid))
+			Expect(errs[0].Field).To(HavePrefix("spec.postgresql.parameters"))
+		},
+		Entry("leading comment then newline", "#\narchive_command"),
+		// A trailing newline after an otherwise valid name must be
+		// rejected by the end anchor, which in Go matches end-of-text
+		// rather than end-of-line.
+		Entry("valid name with a trailing newline injection", "archive_command\nrestart_after = 0"),
+		Entry("carriage return", "archive_command\rrestart_after = 0"),
+	)
 
 	It("produces no error when WAL size settings are correct", func() {
 		clusterNew := &apiv1.Cluster{

--- a/internal/webhook/v1/cluster_webhook_test.go
+++ b/internal/webhook/v1/cluster_webhook_test.go
@@ -552,12 +552,38 @@ var _ = Describe("configuration change validation", func() {
 			Expect(errs[0].Field).To(HavePrefix("spec.postgresql.parameters"))
 		},
 		Entry("leading comment then newline", "#\narchive_command"),
-		// A trailing newline after an otherwise valid name must be
-		// rejected by the end anchor, which in Go matches end-of-text
-		// rather than end-of-line.
 		Entry("valid name with a trailing newline injection", "archive_command\nrestart_after = 0"),
-		Entry("trailing newline only", "archive_command\n"),
 		Entry("carriage return", "archive_command\rrestart_after = 0"),
+	)
+
+	DescribeTable("rejects a malformed parameter name",
+		func(key string) {
+			clusterNew := &apiv1.Cluster{
+				Spec: apiv1.ClusterSpec{
+					PostgresConfiguration: apiv1.PostgresConfiguration{
+						Parameters: map[string]string{
+							key: "value",
+						},
+					},
+					StorageConfiguration: apiv1.StorageConfiguration{
+						Size: "10Gi",
+					},
+				},
+			}
+			errs := v.validateConfiguration(clusterNew)
+			Expect(errs).To(HaveLen(1))
+			Expect(errs[0].Type).To(Equal(field.ErrorTypeInvalid))
+			Expect(errs[0].Field).To(HavePrefix("spec.postgresql.parameters"))
+		},
+		// The end anchor in the name regex matches end-of-text, not end-of-line,
+		// so a trailing newline is caught even though it carries no injected directive.
+		Entry("trailing newline", "archive_command\n"),
+		Entry("embedded NUL byte", "work_mem\x00"),
+		Entry("equals sign", "work_mem=128MB"),
+		Entry("leading whitespace", " work_mem"),
+		Entry("space in the middle", "work mem"),
+		Entry("hash character", "work#mem"),
+		Entry("empty string", ""),
 	)
 
 	It("produces no error when WAL size settings are correct", func() {


### PR DESCRIPTION
PostgreSQL configuration parameter keys from `spec.postgresql.parameters` were rendered verbatim into `postgresql.conf` without any shape validation. A key containing a newline, such as `"#\narchive_command"`, produced two physical lines and injected an arbitrary directive, bypassing the fixed-parameter filter (an exact-key map lookup).

Validate each parameter name against the PostgreSQL GUC naming format at the admission webhook so malformed keys are rejected before they reach the renderer.

Because the same validator runs at the start of the instance manager reconcile loop through the admission guard, a Cluster that already has a malformed key persisted (created before this fix, or through a webhook bypass) will have its reconciliation stopped until the key is corrected.

Closes #11028

----

- Rejected PostgreSQL configuration parameters whose name does not match the GUC naming format, closing a configuration-injection path through `spec.postgresql.parameters` keys.

