### PR TITLE
fix(switchover): recreate primary when WAL-archiver sidecar is missing

### DIFF
--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -119,11 +119,6 @@ const (
 	// MissingWALDiskSpaceExitCode is the exit code the instance manager
 	// will use to signal that there's no more WAL disk space
 	MissingWALDiskSpaceExitCode = 4
-
-	// MissingWALArchivePlugin is the exit code used by the instance manager
-	// to indicate that it started successfully, but the configured WAL
-	// archiving plugin is not available.
-	MissingWALArchivePlugin = 5
 )
 
 // SnapshotOwnerReference defines the reference type for the owner of the snapshot.

--- a/internal/cmd/manager/instance/run/cmd.go
+++ b/internal/cmd/manager/instance/run/cmd.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"slices"
 
 	"github.com/cloudnative-pg/machinery/pkg/log"
 	"github.com/spf13/cobra"
@@ -68,13 +67,7 @@ import (
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/versions"
 )
 
-var (
-	scheme = runtime.NewScheme()
-
-	// errWALArchivePluginNotAvailable is returned when the configured
-	// WAL archiving plugin is not available or cannot be found.
-	errWALArchivePluginNotAvailable = fmt.Errorf("WAL archive plugin not available")
-)
+var scheme = runtime.NewScheme()
 
 func init() {
 	_ = clientgoscheme.AddToScheme(scheme)
@@ -128,9 +121,6 @@ func NewCmd() *cobra.Command {
 
 			if errors.Is(err, postgres.ErrNoFreeWALSpace) {
 				os.Exit(apiv1.MissingWALDiskSpaceExitCode)
-			}
-			if errors.Is(err, errWALArchivePluginNotAvailable) {
-				os.Exit(apiv1.MissingWALArchivePlugin)
 			}
 
 			return err
@@ -254,9 +244,8 @@ func runSubCommand( //nolint: gocyclo,gocognit
 	postgresStartConditions := concurrency.MultipleExecuted{}
 	exitedConditions := concurrency.MultipleExecuted{}
 
-	var loadedPluginNames []string
 	pluginRepository := repository.New()
-	if loadedPluginNames, err = pluginRepository.RegisterUnixSocketPluginsInPath(
+	if _, err = pluginRepository.RegisterUnixSocketPluginsInPath(
 		configuration.Current.PluginSocketDir,
 	); err != nil {
 		contextLogger.Error(err, "Unable to load sidecar CNPG-i plugins, skipping")
@@ -463,15 +452,6 @@ func runSubCommand( //nolint: gocyclo,gocognit
 	} else if !hasDiskSpaceForWals {
 		contextLogger.Info("Detected low-disk space condition")
 		return makeUnretryableError(postgres.ErrNoFreeWALSpace)
-	}
-
-	enabledArchiverPluginName := instance.GetClusterOrDefault().GetEnabledWALArchivePluginName()
-	if enabledArchiverPluginName != "" && !slices.Contains(loadedPluginNames, enabledArchiverPluginName) {
-		contextLogger.Info(
-			"Detected missing WAL archiver plugin, waiting for the operator to rollout a new instance Pod",
-			"enabledArchiverPluginName", enabledArchiverPluginName,
-			"loadedPluginNames", loadedPluginNames)
-		return makeUnretryableError(errWALArchivePluginNotAvailable)
 	}
 
 	return nil

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -535,10 +535,6 @@ func (r *ClusterReconciler) reconcile(ctx context.Context, cluster *apiv1.Cluste
 		return res, err
 	}
 
-	if res, err := r.requireWALArchivingPluginOrDelete(ctx, instancesStatus); err != nil || !res.IsZero() {
-		return res, err
-	}
-
 	if res, err := replicaclusterswitch.Reconcile(
 		ctx, r.Client, cluster, r.InstanceClient, instancesStatus); res != nil || err != nil {
 		if res != nil {
@@ -723,30 +719,6 @@ func (r *ClusterReconciler) ensureNoFailoverOnFullDisk(
 		return ctrl.Result{}, err
 	}
 	return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
-}
-
-func (r *ClusterReconciler) requireWALArchivingPluginOrDelete(
-	ctx context.Context,
-	instances postgres.PostgresqlStatusList,
-) (ctrl.Result, error) {
-	contextLogger := log.FromContext(ctx).WithName("require_wal_archiving_plugin_delete")
-
-	for _, state := range instances.Items {
-		if isTerminatedBecauseOfMissingWALArchivePlugin(state.Pod) {
-			contextLogger.Warning(
-				"Detected instance manager initialization procedure that failed "+
-					"because the required WAL archive plugin is missing. Deleting it to trigger rollout",
-				"targetPod", state.Pod.Name)
-			if err := r.Delete(ctx, state.Pod); err != nil {
-				contextLogger.Error(err, "Cannot delete the pod", "pod", state.Pod.Name)
-				return ctrl.Result{}, err
-			}
-
-			return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
-		}
-	}
-
-	return ctrl.Result{}, nil
 }
 
 func (r *ClusterReconciler) handleSwitchover(

--- a/internal/controller/cluster_status.go
+++ b/internal/controller/cluster_status.go
@@ -861,16 +861,6 @@ func isWALSpaceAvailableOnPod(pod *corev1.Pod) bool {
 	return !hasPostgresContainerTerminationReason(pod, isTerminatedForMissingWALDiskSpace)
 }
 
-// isTerminatedBecauseOfMissingWALArchivePlugin check if a Pod terminated because the
-// WAL archiving plugin was missing when the Pod started
-func isTerminatedBecauseOfMissingWALArchivePlugin(pod *corev1.Pod) bool {
-	isTerminatedForMissingWALArchivePlugin := func(state *corev1.ContainerState) bool {
-		return state.Terminated != nil && state.Terminated.ExitCode == apiv1.MissingWALArchivePlugin
-	}
-	// Return true if the pod IS terminated because of missing WAL archive plugin
-	return hasPostgresContainerTerminationReason(pod, isTerminatedForMissingWALArchivePlugin)
-}
-
 func hasPostgresContainerTerminationReason(pod *corev1.Pod, reason func(state *corev1.ContainerState) bool) bool {
 	var pgContainerStatus *corev1.ContainerStatus
 	for i := range pod.Status.ContainerStatuses {

--- a/internal/controller/cluster_status_test.go
+++ b/internal/controller/cluster_status_test.go
@@ -462,33 +462,6 @@ var _ = Describe("updateClusterStatusThatRequiresInstancesState tests", func() {
 			Expect(result).To(BeTrue())
 		})
 
-		It("should detect termination with specific exit code in last termination state", func() {
-			pod := &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{Name: "test-pod"},
-				Status: corev1.PodStatus{
-					ContainerStatuses: []corev1.ContainerStatus{
-						{
-							Name: "postgres",
-							State: corev1.ContainerState{
-								Running: &corev1.ContainerStateRunning{},
-							},
-							Ready: false,
-							LastTerminationState: corev1.ContainerState{
-								Terminated: &corev1.ContainerStateTerminated{
-									ExitCode: apiv1.MissingWALArchivePlugin,
-								},
-							},
-						},
-					},
-				},
-			}
-
-			result := hasPostgresContainerTerminationReason(pod, func(state *corev1.ContainerState) bool {
-				return state.Terminated != nil && state.Terminated.ExitCode == apiv1.MissingWALArchivePlugin
-			})
-			Expect(result).To(BeTrue())
-		})
-
 		It("should return false when termination reason does not match", func() {
 			pod := &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{Name: "test-pod"},
@@ -576,45 +549,6 @@ var _ = Describe("updateClusterStatusThatRequiresInstancesState tests", func() {
 			}
 
 			Expect(isWALSpaceAvailableOnPod(pod)).To(BeFalse())
-		})
-
-		It("isTerminatedBecauseOfMissingWALArchivePlugin should return true when terminated due to missing plugin", func() {
-			pod := &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{Name: "test-pod"},
-				Status: corev1.PodStatus{
-					ContainerStatuses: []corev1.ContainerStatus{
-						{
-							Name: "postgres",
-							State: corev1.ContainerState{
-								Terminated: &corev1.ContainerStateTerminated{
-									ExitCode: apiv1.MissingWALArchivePlugin,
-								},
-							},
-						},
-					},
-				},
-			}
-
-			Expect(isTerminatedBecauseOfMissingWALArchivePlugin(pod)).To(BeTrue())
-		})
-
-		It("isTerminatedBecauseOfMissingWALArchivePlugin should return false when not terminated", func() {
-			pod := &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{Name: "test-pod"},
-				Status: corev1.PodStatus{
-					ContainerStatuses: []corev1.ContainerStatus{
-						{
-							Name: "postgres",
-							State: corev1.ContainerState{
-								Running: &corev1.ContainerStateRunning{},
-							},
-							Ready: true,
-						},
-					},
-				},
-			}
-
-			Expect(isTerminatedBecauseOfMissingWALArchivePlugin(pod)).To(BeFalse())
 		})
 	})
 })

--- a/internal/controller/cluster_upgrade.go
+++ b/internal/controller/cluster_upgrade.go
@@ -772,11 +772,14 @@ func (r *ClusterReconciler) recreatePrimaryInPlace(
 //
 // Detection diffs the Pod's containers against a freshly evaluated instance
 // spec: NewInstance runs the plugins' OperationVerbEvaluate lifecycle hook, so
-// its containers already include any injected sidecars. We cannot map a sidecar
-// back to the specific plugin that injected it, so when several sidecar-injecting
-// plugins are enabled this may recreate the primary even if only a non-archiver
-// sidecar is missing. That is a safe over-approximation: it trades a switchover
-// for an in-place restart, never the other way around.
+// its containers already include any injected sidecars. The check is a
+// deliberate over-approximation. We cannot map a sidecar back to the specific
+// plugin that injected it, so when several sidecar-injecting plugins are enabled
+// this may recreate the primary even if only a non-archiver sidecar is missing.
+// Likewise any container the evaluated spec adds but the running primary lacks
+// (for example one introduced by a newer operator version) triggers the same
+// in-place restart. Both cases are safe: they trade a switchover for an in-place
+// restart, never the other way around.
 //
 // An error stops the caller rather than degrading to a decision: evaluating the
 // instance spec to false would route the primary into the very switchover that

--- a/internal/controller/cluster_upgrade.go
+++ b/internal/controller/cluster_upgrade.go
@@ -211,6 +211,21 @@ func (r *ClusterReconciler) updatePrimaryPod(
 
 	// if the cluster has more than one instance, we should trigger a switchover before upgrading
 	if cluster.Status.Instances > 1 && len(podList.Items) > 1 {
+		// A WAL-archiver plugin was enabled on a cluster whose primary Pod predates
+		// it, so the primary lacks the injected sidecar and cannot archive WAL. A
+		// switchover cannot roll it out: demoting the primary runs ArchiveAllReadyWALs
+		// before pg_rewind (see instance_startup.go), and that archiving needs the
+		// sidecar that is still missing, so the demotion would never complete.
+		// Recreate the Pod in place instead: it comes back as primary with the
+		// sidecar, archiving resumes, and no demotion or rewind is involved.
+		sidecarMissing, err := archiverSidecarMissingOnPrimary(ctx, &primaryPod, cluster)
+		if err != nil {
+			return false, err
+		}
+		if sidecarMissing {
+			return r.recreatePrimaryInPlace(ctx, cluster, &primaryPod, reason)
+		}
+
 		// If this is not a replica cluster, podList.Items[1] is the first replica,
 		// as the pod list is sorted in the same order we use for switchover / failover.
 		// This may not be true for replica clusters, where every instance is a replica
@@ -709,6 +724,77 @@ func checkPodSpecIsOutdated(
 	}
 
 	return rollout{}, nil
+}
+
+// recreatePrimaryInPlace deletes the primary Pod so the operator recreates it
+// with the up-to-date spec, without a switchover. Used when a switchover would
+// dead-lock because the primary lacks the WAL-archiver sidecar it needs to
+// demote (see updatePrimaryPod and issue #10981).
+func (r *ClusterReconciler) recreatePrimaryInPlace(
+	ctx context.Context,
+	cluster *apiv1.Cluster,
+	primaryPod *corev1.Pod,
+	reason rolloutReason,
+) (bool, error) {
+	log.FromContext(ctx).Info(
+		"Primary is missing the WAL-archiver sidecar; recreating it in place instead of switching over",
+		"reason", reason,
+		"primaryPod", primaryPod.Name)
+	if err := r.RegisterPhase(ctx, cluster, apiv1.PhaseInplaceDeletePrimaryRestart, reason); err != nil {
+		return false, err
+	}
+	err := r.upgradePod(ctx, cluster, primaryPod, reason)
+	return err == nil, err
+}
+
+// archiverSidecarMissingOnPrimary reports whether the cluster has an enabled
+// WAL-archiver plugin while the given primary Pod is missing one or more of the
+// containers that the enabled plugins inject. Such a primary cannot archive WAL,
+// so it must be recreated to gain the sidecar rather than demoted via a
+// switchover, which would dead-lock on archiving (see issue #10981).
+//
+// Detection diffs the Pod's containers against a freshly evaluated instance
+// spec: NewInstance runs the plugins' OperationVerbEvaluate lifecycle hook, so
+// its containers already include any injected sidecars. We cannot map a sidecar
+// back to the specific plugin that injected it, so when several sidecar-injecting
+// plugins are enabled this may recreate the primary even if only a non-archiver
+// sidecar is missing. That is a safe over-approximation: it trades a switchover
+// for an in-place restart, never the other way around.
+//
+// An error stops the caller rather than degrading to a decision: evaluating the
+// instance spec to false would route the primary into the very switchover that
+// dead-locks here, so a transient failure must requeue and retry instead.
+func archiverSidecarMissingOnPrimary(
+	ctx context.Context,
+	pod *corev1.Pod,
+	cluster *apiv1.Cluster,
+) (bool, error) {
+	if cluster.GetEnabledWALArchivePluginName() == "" {
+		return false, nil
+	}
+
+	serial, err := utils.GetClusterSerialValue(pod.Annotations)
+	if err != nil {
+		return false, err
+	}
+
+	tlsEnabled := remote.GetStatusSchemeFromPod(pod).IsHTTPS()
+	targetPod, err := specs.NewInstance(ctx, *cluster, serial, tlsEnabled)
+	if err != nil {
+		return false, err
+	}
+
+	current := make(map[string]struct{}, len(pod.Spec.Containers))
+	for _, container := range pod.Spec.Containers {
+		current[container.Name] = struct{}{}
+	}
+	for _, container := range targetPod.Spec.Containers {
+		if _, found := current[container.Name]; !found {
+			return true, nil
+		}
+	}
+
+	return false, nil
 }
 
 // upgradePod deletes a Pod to let the operator recreate it using an

--- a/internal/controller/cluster_upgrade.go
+++ b/internal/controller/cluster_upgrade.go
@@ -671,6 +671,30 @@ func checkPodEnvironmentIsOutdated(_ context.Context, pod *corev1.Pod, cluster *
 	return rollout{}, nil
 }
 
+// newInstanceForRunningPod evaluates the instance specification that the given
+// running Pod should currently match. It derives the node serial and status
+// scheme from the Pod, then calls specs.NewInstance, which runs the plugins'
+// OperationVerbEvaluate lifecycle hook so the returned spec already includes any
+// sidecars they inject.
+func newInstanceForRunningPod(
+	ctx context.Context,
+	pod *corev1.Pod,
+	cluster *apiv1.Cluster,
+) (*corev1.Pod, error) {
+	serial, err := utils.GetClusterSerialValue(pod.Annotations)
+	if err != nil {
+		return nil, fmt.Errorf("while getting the pod serial value: %w", err)
+	}
+
+	tlsEnabled := remote.GetStatusSchemeFromPod(pod).IsHTTPS()
+	targetPod, err := specs.NewInstance(ctx, *cluster, serial, tlsEnabled)
+	if err != nil {
+		return nil, fmt.Errorf("while creating a new instance pod: %w", err)
+	}
+
+	return targetPod, nil
+}
+
 func checkPodSpecIsOutdated(
 	ctx context.Context,
 	pod *corev1.Pod,
@@ -687,16 +711,9 @@ func checkPodSpecIsOutdated(
 		return rollout{}, fmt.Errorf("while unmarshaling the pod resources annotation: %w", err)
 	}
 
-	tlsEnabled := remote.GetStatusSchemeFromPod(pod).IsHTTPS()
-
-	serial, err := utils.GetClusterSerialValue(pod.Annotations)
+	targetPod, err := newInstanceForRunningPod(ctx, pod, cluster)
 	if err != nil {
-		return rollout{}, fmt.Errorf("while getting the pod serial value: %w", err)
-	}
-
-	targetPod, err := specs.NewInstance(ctx, *cluster, serial, tlsEnabled)
-	if err != nil {
-		return rollout{}, fmt.Errorf("while creating a new pod to check podSpec: %w", err)
+		return rollout{}, fmt.Errorf("while building the target instance to check podSpec: %w", err)
 	}
 
 	// the bootstrap init-container could change image after an operator upgrade.
@@ -773,13 +790,7 @@ func archiverSidecarMissingOnPrimary(
 		return false, nil
 	}
 
-	serial, err := utils.GetClusterSerialValue(pod.Annotations)
-	if err != nil {
-		return false, err
-	}
-
-	tlsEnabled := remote.GetStatusSchemeFromPod(pod).IsHTTPS()
-	targetPod, err := specs.NewInstance(ctx, *cluster, serial, tlsEnabled)
+	targetPod, err := newInstanceForRunningPod(ctx, pod, cluster)
 	if err != nil {
 		return false, err
 	}

--- a/internal/controller/cluster_upgrade_test.go
+++ b/internal/controller/cluster_upgrade_test.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/ptr"
 	k8client "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -1179,5 +1180,72 @@ var _ = Describe("Supervised primary update strategy and rollout slots", func() 
 		result := rm.CoordinateRollout(secondCluster, "other-pod")
 		Expect(result.RolloutAllowed).To(BeFalse(),
 			"unsupervised strategy should consume the rollout slot")
+	})
+})
+
+var _ = Describe("archiverSidecarMissingOnPrimary", func() {
+	const sidecarName = "plugin-barman-cloud"
+
+	var cluster apiv1.Cluster
+
+	BeforeEach(func() {
+		cluster = apiv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{Name: "test"},
+			Spec:       apiv1.ClusterSpec{ImageName: "postgres:17.0"},
+		}
+	})
+
+	// withArchiverSidecar returns a copy of pod with an extra container,
+	// mimicking the sidecar a WAL-archiver plugin injects at evaluation time.
+	withArchiverSidecar := func(pod *corev1.Pod) *corev1.Pod {
+		out := pod.DeepCopy()
+		out.Spec.Containers = append(out.Spec.Containers, corev1.Container{
+			Name:  sidecarName,
+			Image: "plugin-barman-cloud:latest",
+		})
+		return out
+	}
+
+	enableArchiverPlugin := func() {
+		cluster.Spec.Plugins = []apiv1.PluginConfiguration{
+			{
+				Name:          "barman-cloud.cloudnative-pg.io",
+				Enabled:       ptr.To(true),
+				IsWALArchiver: ptr.To(true),
+			},
+		}
+	}
+
+	It("returns false when no WAL-archiver plugin is enabled", func() {
+		pod, err := specs.NewInstance(context.TODO(), cluster, 1, true)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(archiverSidecarMissingOnPrimary(context.TODO(), pod, &cluster)).To(BeFalse())
+	})
+
+	It("returns true when the primary is missing the injected sidecar", func() {
+		enableArchiverPlugin()
+
+		pod, err := specs.NewInstance(context.TODO(), cluster, 1, true)
+		Expect(err).ToNot(HaveOccurred())
+
+		// The freshly evaluated spec carries the sidecar, the running primary does not.
+		ctx := pluginClient.SetPluginClientInContext(context.TODO(),
+			fakePluginClientRollout{returnedPod: withArchiverSidecar(pod)})
+
+		Expect(archiverSidecarMissingOnPrimary(ctx, pod, &cluster)).To(BeTrue())
+	})
+
+	It("returns false when the primary already has the injected sidecar", func() {
+		enableArchiverPlugin()
+
+		pod, err := specs.NewInstance(context.TODO(), cluster, 1, true)
+		Expect(err).ToNot(HaveOccurred())
+		podWithSidecar := withArchiverSidecar(pod)
+
+		ctx := pluginClient.SetPluginClientInContext(context.TODO(),
+			fakePluginClientRollout{returnedPod: podWithSidecar})
+
+		Expect(archiverSidecarMissingOnPrimary(ctx, podWithSidecar, &cluster)).To(BeFalse())
 	})
 })

--- a/internal/controller/cluster_upgrade_test.go
+++ b/internal/controller/cluster_upgrade_test.go
@@ -22,6 +22,7 @@ package controller
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -1247,5 +1248,22 @@ var _ = Describe("archiverSidecarMissingOnPrimary", func() {
 			fakePluginClientRollout{returnedPod: podWithSidecar})
 
 		Expect(archiverSidecarMissingOnPrimary(ctx, podWithSidecar, &cluster)).To(BeFalse())
+	})
+
+	It("propagates evaluation errors instead of degrading to a switchover decision", func() {
+		enableArchiverPlugin()
+
+		pod, err := specs.NewInstance(context.TODO(), cluster, 1, true)
+		Expect(err).ToNot(HaveOccurred())
+
+		evalErr := errors.New("plugin evaluation failed")
+		ctx := pluginClient.SetPluginClientInContext(context.TODO(),
+			fakePluginClientRollout{returnedError: evalErr})
+
+		missing, err := archiverSidecarMissingOnPrimary(ctx, pod, &cluster)
+		Expect(err).To(HaveOccurred())
+		Expect(errors.Is(err, evalErr)).To(BeTrue(),
+			"the evaluation error must surface so the caller requeues instead of switching over")
+		Expect(missing).To(BeFalse())
 	})
 })


### PR DESCRIPTION
Enabling a WAL-archiver plugin on an existing cluster leaves the primary Pod without the injected sidecar, so it cannot archive WAL. When `primaryUpdateMethod` is set to `switchover`, the operator rolls the primary out by demoting it, but a clean demotion archives all pending WAL before pg_rewind, and that archiving needs the very sidecar that is still missing. The switchover never completes, the primary is marked unhealthy and dropped from the -rw service, and the cluster dead-locks.

Detect this case in `updatePrimaryPod` and recreate the primary Pod in place instead of switching over. It comes back as primary with the sidecar, archiving resumes, and no demotion or rewind is involved.

Detecting the missing sidecar from instance status during reconciliation replaces the previous mechanism, where the instance manager exited with a dedicated code and the controller deleted the Pod, so that code is removed.

Closes #10981
Closes cloudnative-pg/plugin-barman-cloud#901
