### PR TITLE
fix: report failed instance creation jobs instead of waiting forever

### DIFF
--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -876,16 +876,16 @@ func (r *ClusterReconciler) reconcileResources(
 	// A Job that creates an instance (bootstrap, recovery or replica creation)
 	// is counted as "running" until it succeeds, so a Job that has exhausted its
 	// backoff limit would otherwise keep the cluster waiting forever. Surface the
-	// failure in the phase instead: it requires manual intervention.
+	// failure in the phase instead. The cause is in the job logs and has to be
+	// investigated: there is no predefined recipe.
 	if failedJobs := resources.failedJobNames(); len(failedJobs) > 0 {
 		contextLogger.Warning("An instance creation job has failed", "failedJobs", failedJobs)
-		if err := r.RegisterPhase(
-			ctx,
-			cluster,
-			apiv1.PhaseUnrecoverable,
-			fmt.Sprintf("Instance creation failed for the following jobs: %s. "+
-				"Check the job logs to find the cause of the failure.", strings.Join(failedJobs, ", ")),
-		); err != nil {
+
+		reason := fmt.Sprintf("Instance creation failed for the following jobs: %s. "+
+			"Check the job logs to investigate the cause of the failure.",
+			strings.Join(failedJobs, ", "))
+
+		if err := r.RegisterPhase(ctx, cluster, apiv1.PhaseUnrecoverable, reason); err != nil {
 			return ctrl.Result{}, err
 		}
 		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -26,6 +26,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strings"
 	"time"
 
 	"github.com/cloudnative-pg/machinery/pkg/log"
@@ -870,6 +871,24 @@ func (r *ClusterReconciler) reconcileResources(
 		return ctrl.Result{}, fmt.Errorf("cannot reconcile in-place major version upgrades: %w", err)
 	} else if result != nil {
 		return *result, err
+	}
+
+	// A Job that creates an instance (bootstrap, recovery or replica creation)
+	// is counted as "running" until it succeeds, so a Job that has exhausted its
+	// backoff limit would otherwise keep the cluster waiting forever. Surface the
+	// failure in the phase instead: it requires manual intervention.
+	if failedJobs := resources.failedJobNames(); len(failedJobs) > 0 {
+		contextLogger.Warning("An instance creation job has failed", "failedJobs", failedJobs)
+		if err := r.RegisterPhase(
+			ctx,
+			cluster,
+			apiv1.PhaseUnrecoverable,
+			fmt.Sprintf("Instance creation failed for the following jobs: %s. "+
+				"Check the job logs to find the cause of the failure.", strings.Join(failedJobs, ", ")),
+		); err != nil {
+			return ctrl.Result{}, err
+		}
+		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 	}
 
 	runningJobs := resources.runningJobNames()

--- a/internal/controller/cluster_controller_test.go
+++ b/internal/controller/cluster_controller_test.go
@@ -795,3 +795,65 @@ var _ = Describe("getPluginsNeededForReconcile", func() {
 			To(Equal([]string{"plugin-shared"}))
 	})
 })
+
+var _ = Describe("reconcileResources surfaces a permanently failed instance creation job", func() {
+	var env *testingEnvironment
+	var namespace string
+
+	BeforeEach(func() {
+		env = buildTestEnvironment()
+		namespace = newFakeNamespace(env.client)
+	})
+
+	// recoveryJob returns a recovery Job owned by the cluster with the given
+	// status, mimicking the bootstrap/recovery Job the operator creates.
+	recoveryJob := func(cluster *apiv1.Cluster, status batchv1.JobStatus) batchv1.Job {
+		return batchv1.Job{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      cluster.Name + "-1-full-recovery",
+				Namespace: namespace,
+			},
+			Status: status,
+		}
+	}
+
+	It("reports the unrecoverable phase when a recovery job reaches its backoff limit", func(ctx SpecContext) {
+		cluster := newFakeCNPGCluster(env.client, namespace)
+		failedJob := recoveryJob(cluster, batchv1.JobStatus{
+			Failed: 7,
+			Conditions: []batchv1.JobCondition{
+				{Type: batchv1.JobFailed, Status: corev1.ConditionTrue, Reason: "BackoffLimitExceeded"},
+			},
+		})
+
+		resources := &managedResources{jobs: batchv1.JobList{Items: []batchv1.Job{failedJob}}}
+
+		res, err := env.clusterReconciler.reconcileResources(ctx, cluster, resources, postgres.PostgresqlStatusList{})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(res.RequeueAfter).To(BeNumerically(">", 0))
+
+		var updated apiv1.Cluster
+		Expect(env.client.Get(ctx, types.NamespacedName{Name: cluster.Name, Namespace: namespace}, &updated)).
+			To(Succeed())
+		Expect(updated.Status.Phase).To(Equal(apiv1.PhaseUnrecoverable))
+		Expect(updated.Status.PhaseReason).To(ContainSubstring(failedJob.Name))
+	})
+
+	It("keeps waiting while a job is still retrying within its backoff limit", func(ctx SpecContext) {
+		cluster := newFakeCNPGCluster(env.client, namespace)
+		// One pod has failed, but the Job has not reached its backoff limit:
+		// there is no terminal JobFailed condition yet.
+		runningJob := recoveryJob(cluster, batchv1.JobStatus{Failed: 1})
+
+		resources := &managedResources{jobs: batchv1.JobList{Items: []batchv1.Job{runningJob}}}
+
+		res, err := env.clusterReconciler.reconcileResources(ctx, cluster, resources, postgres.PostgresqlStatusList{})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(res.RequeueAfter).To(Equal(5 * time.Second))
+
+		var updated apiv1.Cluster
+		Expect(env.client.Get(ctx, types.NamespacedName{Name: cluster.Name, Namespace: namespace}, &updated)).
+			To(Succeed())
+		Expect(updated.Status.Phase).ToNot(Equal(apiv1.PhaseUnrecoverable))
+	})
+})

--- a/internal/controller/cluster_controller_test.go
+++ b/internal/controller/cluster_controller_test.go
@@ -805,8 +805,8 @@ var _ = Describe("reconcileResources surfaces a permanently failed instance crea
 		namespace = newFakeNamespace(env.client)
 	})
 
-	// recoveryJob returns a recovery Job owned by the cluster with the given
-	// status, mimicking the bootstrap/recovery Job the operator creates.
+	// recoveryJob returns a recovery Job for the cluster with the given status,
+	// mimicking the bootstrap/recovery Job the operator creates.
 	recoveryJob := func(cluster *apiv1.Cluster, status batchv1.JobStatus) batchv1.Job {
 		return batchv1.Job{
 			ObjectMeta: metav1.ObjectMeta{
@@ -817,43 +817,26 @@ var _ = Describe("reconcileResources surfaces a permanently failed instance crea
 		}
 	}
 
-	It("reports the unrecoverable phase when a recovery job reaches its backoff limit", func(ctx SpecContext) {
-		cluster := newFakeCNPGCluster(env.client, namespace)
-		failedJob := recoveryJob(cluster, batchv1.JobStatus{
-			Failed: 7,
-			Conditions: []batchv1.JobCondition{
-				{Type: batchv1.JobFailed, Status: corev1.ConditionTrue, Reason: "BackoffLimitExceeded"},
-			},
+	It("reports the unrecoverable phase when a job reaches its backoff limit",
+		func(ctx SpecContext) {
+			cluster := newFakeCNPGCluster(env.client, namespace)
+			failedJob := recoveryJob(cluster, batchv1.JobStatus{
+				Failed: 7,
+				Conditions: []batchv1.JobCondition{
+					{Type: batchv1.JobFailed, Status: corev1.ConditionTrue, Reason: "BackoffLimitExceeded"},
+				},
+			})
+
+			resources := &managedResources{jobs: batchv1.JobList{Items: []batchv1.Job{failedJob}}}
+
+			res, err := env.clusterReconciler.reconcileResources(ctx, cluster, resources, postgres.PostgresqlStatusList{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(res.RequeueAfter).To(BeNumerically(">", 0))
+
+			var updated apiv1.Cluster
+			Expect(env.client.Get(ctx, types.NamespacedName{Name: cluster.Name, Namespace: namespace}, &updated)).
+				To(Succeed())
+			Expect(updated.Status.Phase).To(Equal(apiv1.PhaseUnrecoverable))
+			Expect(updated.Status.PhaseReason).To(ContainSubstring(failedJob.Name))
 		})
-
-		resources := &managedResources{jobs: batchv1.JobList{Items: []batchv1.Job{failedJob}}}
-
-		res, err := env.clusterReconciler.reconcileResources(ctx, cluster, resources, postgres.PostgresqlStatusList{})
-		Expect(err).ToNot(HaveOccurred())
-		Expect(res.RequeueAfter).To(BeNumerically(">", 0))
-
-		var updated apiv1.Cluster
-		Expect(env.client.Get(ctx, types.NamespacedName{Name: cluster.Name, Namespace: namespace}, &updated)).
-			To(Succeed())
-		Expect(updated.Status.Phase).To(Equal(apiv1.PhaseUnrecoverable))
-		Expect(updated.Status.PhaseReason).To(ContainSubstring(failedJob.Name))
-	})
-
-	It("keeps waiting while a job is still retrying within its backoff limit", func(ctx SpecContext) {
-		cluster := newFakeCNPGCluster(env.client, namespace)
-		// One pod has failed, but the Job has not reached its backoff limit:
-		// there is no terminal JobFailed condition yet.
-		runningJob := recoveryJob(cluster, batchv1.JobStatus{Failed: 1})
-
-		resources := &managedResources{jobs: batchv1.JobList{Items: []batchv1.Job{runningJob}}}
-
-		res, err := env.clusterReconciler.reconcileResources(ctx, cluster, resources, postgres.PostgresqlStatusList{})
-		Expect(err).ToNot(HaveOccurred())
-		Expect(res.RequeueAfter).To(Equal(5 * time.Second))
-
-		var updated apiv1.Cluster
-		Expect(env.client.Get(ctx, types.NamespacedName{Name: cluster.Name, Namespace: namespace}, &updated)).
-			To(Succeed())
-		Expect(updated.Status.Phase).ToNot(Equal(apiv1.PhaseUnrecoverable))
-	})
 })

--- a/internal/controller/cluster_status.go
+++ b/internal/controller/cluster_status.go
@@ -69,6 +69,18 @@ func (resources *managedResources) runningJobNames() []string {
 	return result
 }
 
+// failedJobNames returns the names of the jobs that have permanently failed,
+// i.e. they have exhausted their backoff limit
+func (resources *managedResources) failedJobNames() []string {
+	result := make([]string, 0, len(resources.jobs.Items))
+	for _, job := range resources.jobs.Items {
+		if utils.JobHasFailed(job) {
+			result = append(result, job.Name)
+		}
+	}
+	return result
+}
+
 // Check if every managed Pod is active and will be schedules
 func (resources *managedResources) inactiveInstanceNames() []string {
 	result := make([]string, 0, len(resources.instances.Items))

--- a/pkg/utils/job_conditions.go
+++ b/pkg/utils/job_conditions.go
@@ -33,10 +33,10 @@ func JobHasOneCompletion(job batchv1.Job) bool {
 	return job.Status.Succeeded == requestedCompletions
 }
 
-// JobHasFailed checks whether a job has permanently failed, i.e. it has
+// JobHasFailed checks whether a Job has permanently failed, i.e. it has
 // exhausted its backoff limit. It keys off the terminal JobFailed condition
-// rather than Status.Failed because the latter is non-zero while the job is
-// still legitimately retrying within its backoff limit.
+// rather than Status.Failed because the latter is non-zero while the Job is
+// still retrying within its backoff limit.
 func JobHasFailed(job batchv1.Job) bool {
 	// job.Status.Conditions is []batchv1.JobCondition, not []metav1.Condition,
 	// so meta.FindStatusCondition cannot be used here.

--- a/pkg/utils/job_conditions.go
+++ b/pkg/utils/job_conditions.go
@@ -21,6 +21,7 @@ package utils
 
 import (
 	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
 )
 
 // JobHasOneCompletion Completion check if a certain job is complete
@@ -30,6 +31,19 @@ func JobHasOneCompletion(job batchv1.Job) bool {
 		requestedCompletions = *job.Spec.Completions
 	}
 	return job.Status.Succeeded == requestedCompletions
+}
+
+// JobHasFailed checks whether a job has permanently failed, i.e. it has
+// exhausted its backoff limit. It keys off the terminal JobFailed condition
+// rather than Status.Failed because the latter is non-zero while the job is
+// still legitimately retrying within its backoff limit.
+func JobHasFailed(job batchv1.Job) bool {
+	for _, condition := range job.Status.Conditions {
+		if condition.Type == batchv1.JobFailed && condition.Status == corev1.ConditionTrue {
+			return true
+		}
+	}
+	return false
 }
 
 // FilterJobsWithOneCompletion returns jobs that have one completion

--- a/pkg/utils/job_conditions.go
+++ b/pkg/utils/job_conditions.go
@@ -38,6 +38,8 @@ func JobHasOneCompletion(job batchv1.Job) bool {
 // rather than Status.Failed because the latter is non-zero while the job is
 // still legitimately retrying within its backoff limit.
 func JobHasFailed(job batchv1.Job) bool {
+	// job.Status.Conditions is []batchv1.JobCondition, not []metav1.Condition,
+	// so meta.FindStatusCondition cannot be used here.
 	for _, condition := range job.Status.Conditions {
 		if condition.Type == batchv1.JobFailed && condition.Status == corev1.ConditionTrue {
 			return true

--- a/pkg/utils/job_conditions_test.go
+++ b/pkg/utils/job_conditions_test.go
@@ -21,6 +21,7 @@ package utils
 
 import (
 	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -43,4 +44,38 @@ var _ = Describe("Job conditions", func() {
 		Expect(JobHasOneCompletion(nonCompleteJob)).To(BeFalse())
 		Expect(JobHasOneCompletion(completeJob)).To(BeTrue())
 	})
+
+	DescribeTable("detects if a job has permanently failed",
+		func(job batchv1.Job, expected bool) {
+			Expect(JobHasFailed(job)).To(Equal(expected))
+		},
+		Entry("a job that has not started yet", batchv1.Job{}, false),
+		Entry("a running job with one failed pod still within its backoff limit",
+			batchv1.Job{Status: batchv1.JobStatus{Failed: 1}}, false),
+		Entry("a successfully completed job",
+			batchv1.Job{Status: batchv1.JobStatus{
+				Conditions: []batchv1.JobCondition{
+					{Type: batchv1.JobComplete, Status: corev1.ConditionTrue},
+				},
+			}}, false),
+		Entry("a job that reached its backoff limit",
+			batchv1.Job{Status: batchv1.JobStatus{
+				Failed: 7,
+				Conditions: []batchv1.JobCondition{
+					{Type: batchv1.JobFailed, Status: corev1.ConditionTrue, Reason: "BackoffLimitExceeded"},
+				},
+			}}, true),
+		Entry("a job whose failure condition is not active",
+			batchv1.Job{Status: batchv1.JobStatus{
+				Conditions: []batchv1.JobCondition{
+					{Type: batchv1.JobFailed, Status: corev1.ConditionFalse},
+				},
+			}}, false),
+		Entry("a job that is past its backoff limit but whose pods are still terminating",
+			batchv1.Job{Status: batchv1.JobStatus{
+				Conditions: []batchv1.JobCondition{
+					{Type: batchv1.JobFailureTarget, Status: corev1.ConditionTrue, Reason: "BackoffLimitExceeded"},
+				},
+			}}, false),
+	)
 })


### PR DESCRIPTION
When bootstrapping, restoring, or adding a replica, an instance creation Job can exhaust its backoff limit and end in a BackoffLimitExceeded failure. When that happened the cluster stayed in a transient creation phase (for example "Setting up primary") forever: the operator counted the failed Job as still running, so reconciliation kept waiting on it and never reported the failure.

A Job is treated as running until it reports one successful completion. A Job that has permanently failed never reaches that state, so it looked the same as one still in progress, and the running-job guard returned early on every reconciliation without updating the phase.

This change detects the terminal JobFailed condition and moves the cluster into the existing unrecoverable phase, with a reason that names the failed Job and points to its logs. Detection keys off the JobFailed condition, not the failed-pod count, so a Job that is still retrying within its backoff limit is left alone. The check runs after the major version upgrade reconciliation, which owns its own Job lifecycle, so upgrade Jobs are not affected.

The failed Job and its Pods are left in place so their logs stay available. There is no single recipe to recover: the cause has to be found in the logs and fixed before the instance can be created again.

Unit tests cover the new Job failure detection, and a controller test verifies that a Job past its backoff limit moves the cluster to the unrecoverable phase.

Closes #11042
Refs #10733
