### PR TITLE
fix(external): reject path traversal in external cluster secret dump

### DIFF
--- a/internal/cmd/plugin/logical/externalcluster.go
+++ b/internal/cmd/plugin/logical/externalcluster.go
@@ -57,5 +57,9 @@ func GetConnectionString(
 		return "", fmt.Errorf("external cluster not existent in the cluster definition")
 	}
 
-	return external.GetServerConnectionString(&externalCluster, databaseName)
+	connString, err := external.GetServerConnectionString(&externalCluster, databaseName)
+	if err != nil {
+		return "", fmt.Errorf("while building connection string for external cluster %q: %w", externalClusterName, err)
+	}
+	return connString, nil
 }

--- a/internal/cmd/plugin/logical/externalcluster.go
+++ b/internal/cmd/plugin/logical/externalcluster.go
@@ -57,5 +57,5 @@ func GetConnectionString(
 		return "", fmt.Errorf("external cluster not existent in the cluster definition")
 	}
 
-	return external.GetServerConnectionString(&externalCluster, databaseName), nil
+	return external.GetServerConnectionString(&externalCluster, databaseName)
 }

--- a/internal/management/controller/subscription_controller.go
+++ b/internal/management/controller/subscription_controller.go
@@ -273,5 +273,9 @@ func getSubscriptionConnectionString(
 		return "", fmt.Errorf("externalCluster '%s' not declared in cluster %s", externalClusterName, cluster.Name)
 	}
 
-	return external.GetServerConnectionString(&externalCluster, databaseName)
+	connString, err := external.GetServerConnectionString(&externalCluster, databaseName)
+	if err != nil {
+		return "", fmt.Errorf("while building connection string for external cluster %q: %w", externalClusterName, err)
+	}
+	return connString, nil
 }

--- a/internal/management/controller/subscription_controller.go
+++ b/internal/management/controller/subscription_controller.go
@@ -273,5 +273,5 @@ func getSubscriptionConnectionString(
 		return "", fmt.Errorf("externalCluster '%s' not declared in cluster %s", externalClusterName, cluster.Name)
 	}
 
-	return external.GetServerConnectionString(&externalCluster, databaseName), nil
+	return external.GetServerConnectionString(&externalCluster, databaseName)
 }

--- a/internal/webhook/v1/cluster_webhook.go
+++ b/internal/webhook/v1/cluster_webhook.go
@@ -1960,7 +1960,47 @@ func (v *ClusterCustomValidator) validateExternalCluster(
 				"one of connectionParameters, plugin and barmanObjectStore is required"))
 	}
 
+	// The external cluster name and the referenced secret selectors are joined
+	// into filesystem paths under the external secrets directory when the
+	// instance manager dumps the connection material, so they cannot contain a
+	// path separator or a parent-directory reference.
+	const pathComponentMsg = "cannot contain a path separator or a '..' component"
+	if isUnsafePathComponent(externalCluster.Name) {
+		result = append(result, field.Invalid(path.Child("name"), externalCluster.Name, pathComponentMsg))
+	}
+
+	selectors := []struct {
+		name     string
+		selector *corev1.SecretKeySelector
+	}{
+		{"sslCert", externalCluster.SSLCert},
+		{"sslKey", externalCluster.SSLKey},
+		{"sslRootCert", externalCluster.SSLRootCert},
+		{"password", externalCluster.Password},
+	}
+	for _, s := range selectors {
+		if s.selector == nil {
+			continue
+		}
+		if isUnsafePathComponent(s.selector.Name) {
+			result = append(result,
+				field.Invalid(path.Child(s.name, "name"), s.selector.Name, pathComponentMsg))
+		}
+		if isUnsafePathComponent(s.selector.Key) {
+			result = append(result,
+				field.Invalid(path.Child(s.name, "key"), s.selector.Key, pathComponentMsg))
+		}
+	}
+
 	return result
+}
+
+// isUnsafePathComponent reports whether a spec-provided value would escape the
+// directory it is meant to be joined into, either through a path separator or a
+// parent-directory reference. The instance manager enforces the same rule at the
+// write site, since it reads the spec directly and can bypass admission.
+func isUnsafePathComponent(value string) bool {
+	return value == "." || value == ".." || strings.ContainsAny(value, `/\`)
 }
 
 func (v *ClusterCustomValidator) validateReplicaClusterChange(r, old *apiv1.Cluster) field.ErrorList {

--- a/internal/webhook/v1/cluster_webhook.go
+++ b/internal/webhook/v1/cluster_webhook.go
@@ -1976,7 +1976,6 @@ func (v *ClusterCustomValidator) validateExternalCluster(
 		{"sslCert", externalCluster.SSLCert},
 		{"sslKey", externalCluster.SSLKey},
 		{"sslRootCert", externalCluster.SSLRootCert},
-		{"password", externalCluster.Password},
 	}
 	for _, s := range selectors {
 		if s.selector == nil {

--- a/internal/webhook/v1/cluster_webhook_test.go
+++ b/internal/webhook/v1/cluster_webhook_test.go
@@ -2501,7 +2501,33 @@ var _ = Describe("validation of an external cluster", func() {
 				Key:                  "tls.crt",
 			}
 		}),
+		Entry("traversal in the sslCert secret key", func(ec *apiv1.ExternalCluster) {
+			ec.SSLCert = &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{Name: "cert"},
+				Key:                  "../pwned",
+			}
+		}),
 	)
+
+	It("does not reject a password selector whose value would be unsafe as a path", func() {
+		// The password selector name and key are never joined into a
+		// filesystem path, so the webhook must leave them untouched.
+		cluster := &apiv1.Cluster{
+			Spec: apiv1.ClusterSpec{
+				ExternalClusters: []apiv1.ExternalCluster{
+					{
+						Name:                 "one",
+						ConnectionParameters: map[string]string{"dbname": "postgres"},
+						Password: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "../pwned"},
+							Key:                  "../pwned",
+						},
+					},
+				},
+			},
+		}
+		Expect(v.validateExternalClusters(cluster)).To(BeEmpty())
+	})
 
 	It("accepts a well-formed name and secret selectors", func() {
 		cluster := &apiv1.Cluster{

--- a/internal/webhook/v1/cluster_webhook_test.go
+++ b/internal/webhook/v1/cluster_webhook_test.go
@@ -2501,12 +2501,6 @@ var _ = Describe("validation of an external cluster", func() {
 				Key:                  "tls.crt",
 			}
 		}),
-		Entry("traversal in the password secret key", func(ec *apiv1.ExternalCluster) {
-			ec.Password = &corev1.SecretKeySelector{
-				LocalObjectReference: corev1.LocalObjectReference{Name: "creds"},
-				Key:                  "../pwned",
-			}
-		}),
 	)
 
 	It("accepts a well-formed name and secret selectors", func() {

--- a/internal/webhook/v1/cluster_webhook_test.go
+++ b/internal/webhook/v1/cluster_webhook_test.go
@@ -2476,6 +2476,60 @@ var _ = Describe("validation of an external cluster", func() {
 		cluster.Spec.ExternalClusters[0].BarmanObjectStore = &apiv1.BarmanObjectStoreConfiguration{}
 		Expect(v.validateExternalClusters(cluster)).To(BeEmpty())
 	})
+
+	DescribeTable("rejects names and secret selectors that would escape the secrets directory",
+		func(mutate func(*apiv1.ExternalCluster)) {
+			ec := apiv1.ExternalCluster{
+				Name:                 "one",
+				ConnectionParameters: map[string]string{"dbname": "postgres"},
+			}
+			mutate(&ec)
+			cluster := &apiv1.Cluster{
+				Spec: apiv1.ClusterSpec{ExternalClusters: []apiv1.ExternalCluster{ec}},
+			}
+			Expect(v.validateExternalClusters(cluster)).ToNot(BeEmpty())
+		},
+		Entry("traversal in the name", func(ec *apiv1.ExternalCluster) {
+			ec.Name = "../pwned"
+		}),
+		Entry("separator in the name", func(ec *apiv1.ExternalCluster) {
+			ec.Name = "nested/pwned"
+		}),
+		Entry("traversal in the sslCert secret name", func(ec *apiv1.ExternalCluster) {
+			ec.SSLCert = &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{Name: "../pwned"},
+				Key:                  "tls.crt",
+			}
+		}),
+		Entry("traversal in the password secret key", func(ec *apiv1.ExternalCluster) {
+			ec.Password = &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{Name: "creds"},
+				Key:                  "../pwned",
+			}
+		}),
+	)
+
+	It("accepts a well-formed name and secret selectors", func() {
+		cluster := &apiv1.Cluster{
+			Spec: apiv1.ClusterSpec{
+				ExternalClusters: []apiv1.ExternalCluster{
+					{
+						Name:                 "one",
+						ConnectionParameters: map[string]string{"dbname": "postgres"},
+						SSLCert: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "cert"},
+							Key:                  "tls.crt",
+						},
+						Password: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "creds"},
+							Key:                  "password",
+						},
+					},
+				},
+			},
+		}
+		Expect(v.validateExternalClusters(cluster)).To(BeEmpty())
+	})
 })
 
 var _ = Describe("bootstrap base backup validation", func() {

--- a/pkg/management/external/external.go
+++ b/pkg/management/external/external.go
@@ -35,26 +35,38 @@ import (
 func GetServerConnectionString(
 	server *apiv1.ExternalCluster,
 	databaseName string,
-) string {
+) (string, error) {
 	connectionParameters := maps.Clone(server.ConnectionParameters)
 
 	if server.SSLCert != nil {
-		name := getSecretKeyRefFileName(server.Name, server.SSLCert)
+		name, err := getSecretKeyRefFileName(server.Name, server.SSLCert)
+		if err != nil {
+			return "", err
+		}
 		connectionParameters["sslcert"] = name
 	}
 
 	if server.SSLKey != nil {
-		name := getSecretKeyRefFileName(server.Name, server.SSLKey)
+		name, err := getSecretKeyRefFileName(server.Name, server.SSLKey)
+		if err != nil {
+			return "", err
+		}
 		connectionParameters["sslkey"] = name
 	}
 
 	if server.SSLRootCert != nil {
-		name := getSecretKeyRefFileName(server.Name, server.SSLRootCert)
+		name, err := getSecretKeyRefFileName(server.Name, server.SSLRootCert)
+		if err != nil {
+			return "", err
+		}
 		connectionParameters["sslrootcert"] = name
 	}
 
 	if server.Password != nil {
-		pgpassfile := getPgPassFilePath(server.Name)
+		pgpassfile, err := getPgPassFilePath(server.Name)
+		if err != nil {
+			return "", err
+		}
 		connectionParameters["passfile"] = pgpassfile
 	}
 
@@ -62,7 +74,7 @@ func GetServerConnectionString(
 		connectionParameters["dbname"] = databaseName
 	}
 
-	return configfile.CreateConnectionString(connectionParameters)
+	return configfile.CreateConnectionString(connectionParameters), nil
 }
 
 // ConfigureConnectionToServer creates a connection string to the external

--- a/pkg/management/external/external.go
+++ b/pkg/management/external/external.go
@@ -36,37 +36,29 @@ func GetServerConnectionString(
 	server *apiv1.ExternalCluster,
 	databaseName string,
 ) (string, error) {
+	if err := validateExternalClusterPaths(server); err != nil {
+		return "", err
+	}
+
 	connectionParameters := maps.Clone(server.ConnectionParameters)
 
 	if server.SSLCert != nil {
-		name, err := getSecretKeyRefFileName(server.Name, server.SSLCert)
-		if err != nil {
-			return "", err
-		}
+		name := getSecretKeyRefFileName(server.Name, server.SSLCert)
 		connectionParameters["sslcert"] = name
 	}
 
 	if server.SSLKey != nil {
-		name, err := getSecretKeyRefFileName(server.Name, server.SSLKey)
-		if err != nil {
-			return "", err
-		}
+		name := getSecretKeyRefFileName(server.Name, server.SSLKey)
 		connectionParameters["sslkey"] = name
 	}
 
 	if server.SSLRootCert != nil {
-		name, err := getSecretKeyRefFileName(server.Name, server.SSLRootCert)
-		if err != nil {
-			return "", err
-		}
+		name := getSecretKeyRefFileName(server.Name, server.SSLRootCert)
 		connectionParameters["sslrootcert"] = name
 	}
 
 	if server.Password != nil {
-		pgpassfile, err := getPgPassFilePath(server.Name)
-		if err != nil {
-			return "", err
-		}
+		pgpassfile := getPgPassFilePath(server.Name)
 		connectionParameters["passfile"] = pgpassfile
 	}
 
@@ -87,6 +79,10 @@ func ConfigureConnectionToServer(
 	namespace string,
 	server *apiv1.ExternalCluster,
 ) (string, error) {
+	if err := validateExternalClusterPaths(server); err != nil {
+		return "", err
+	}
+
 	connectionParameters := maps.Clone(server.ConnectionParameters)
 
 	if server.SSLCert != nil {

--- a/pkg/management/external/external_test.go
+++ b/pkg/management/external/external_test.go
@@ -1,0 +1,80 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package external
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	schemeBuilder "github.com/cloudnative-pg/cloudnative-pg/internal/scheme"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("ConfigureConnectionToServer", func() {
+	const namespace = "test-namespace"
+
+	var base string
+
+	BeforeEach(func() {
+		base = GinkgoT().TempDir()
+		customExternalSecretsPath = base
+		DeferCleanup(func() { customExternalSecretsPath = "" })
+	})
+
+	// The exhaustive set of rejected values is covered by the
+	// validateExternalClusterPaths unit tests; this spec only verifies that the
+	// write entry point actually enforces the guard before touching the disk, so
+	// the security boundary cannot be silently lost by dropping the call.
+	It("rejects a path-traversal server name before writing anything to disk", func() {
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(schemeBuilder.BuildWithAllKnownScheme()).
+			WithObjects(&corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: "cert-secret", Namespace: namespace},
+				Data:       map[string][]byte{"tls.crt": []byte("payload")},
+			}).
+			Build()
+
+		server := &apiv1.ExternalCluster{
+			Name: "../pwned",
+			SSLCert: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{Name: "cert-secret"},
+				Key:                  "tls.crt",
+			},
+		}
+
+		_, err := ConfigureConnectionToServer(context.Background(), fakeClient, namespace, server)
+		Expect(err).To(MatchError(ErrInvalidPathComponent))
+
+		// The guard must fire before any directory or file is created, both
+		// inside the secrets directory and as a sibling reachable via traversal.
+		entries, readErr := os.ReadDir(base)
+		Expect(readErr).ToNot(HaveOccurred())
+		Expect(entries).To(BeEmpty(), "the external secrets directory must stay empty")
+		Expect(filepath.Join(filepath.Dir(base), "pwned")).ToNot(BeAnExistingFile())
+	})
+})

--- a/pkg/management/external/utils.go
+++ b/pkg/management/external/utils.go
@@ -91,14 +91,22 @@ func readSecretKeyRef(
 }
 
 // getSecretKeyRefFileName get the name of the file where the content of the
-// connection secret will be dumped
+// connection secret will be dumped. The server name and the secret selector are
+// joined into the path, so they are validated to make sure they cannot escape
+// the external secrets directory.
 func getSecretKeyRefFileName(
 	serverName string,
 	selector *corev1.SecretKeySelector,
-) string {
+) (string, error) {
+	for _, component := range []string{serverName, selector.Name, selector.Key} {
+		if err := validatePathComponent(component); err != nil {
+			return "", err
+		}
+	}
+
 	directory := filepath.Join(getExternalSecretsPath(), serverName)
 	filePath := filepath.Join(directory, fmt.Sprintf("%v_%v", selector.Name, selector.Key))
-	return filePath
+	return filePath, nil
 }
 
 // dumpSecretKeyRefToFile dumps a certain secret to a file inside a temporary folder
@@ -111,16 +119,13 @@ func dumpSecretKeyRefToFile(
 	ctx context.Context, client ctrl.Client,
 	namespace string, serverName string, selector *corev1.SecretKeySelector,
 ) (string, error) {
-	for _, component := range []string{serverName, selector.Name, selector.Key} {
-		if err := validatePathComponent(component); err != nil {
-			return "", err
-		}
+	filePath, err := getSecretKeyRefFileName(serverName, selector)
+	if err != nil {
+		return "", err
 	}
 
 	var secret corev1.Secret
-
-	err := client.Get(ctx, ctrl.ObjectKey{Namespace: namespace, Name: selector.Name}, &secret)
-	if err != nil {
+	if err := client.Get(ctx, ctrl.ObjectKey{Namespace: namespace, Name: selector.Name}, &secret); err != nil {
 		return "", err
 	}
 
@@ -129,12 +134,10 @@ func dumpSecretKeyRefToFile(
 		return "", fmt.Errorf("missing key %v in secret %v", selector.Key, selector.Name)
 	}
 
-	directory := filepath.Join(getExternalSecretsPath(), serverName)
-	if err := os.MkdirAll(directory, 0o700); err != nil {
+	if err := os.MkdirAll(filepath.Dir(filePath), 0o700); err != nil {
 		return "", err
 	}
 
-	filePath := filepath.Join(directory, fmt.Sprintf("%v_%v", selector.Name, selector.Key))
 	// Write atomically: this file is reused across reconciliations and read
 	// concurrently by libpq, so an in-place rewrite could expose a partial file
 	// or leave stale bytes behind when the secret rotates to shorter content.
@@ -145,11 +148,17 @@ func dumpSecretKeyRefToFile(
 	return filePath, nil
 }
 
-// getPgPassFilePath gets the path where the pgpass file will be stored
-func getPgPassFilePath(serverName string) string {
+// getPgPassFilePath gets the path where the pgpass file will be stored. The
+// server name is joined into the path, so it is validated to make sure it cannot
+// escape the external secrets directory.
+func getPgPassFilePath(serverName string) (string, error) {
+	if err := validatePathComponent(serverName); err != nil {
+		return "", err
+	}
+
 	directory := filepath.Join(getExternalSecretsPath(), serverName)
 	filePath := filepath.Join(directory, "pgpass")
-	return filePath
+	return filePath, nil
 }
 
 // createPgPassFile creates a pgpass file inside the user home directory
@@ -158,17 +167,16 @@ func createPgPassFile(
 	connectionParameters map[string]string,
 	password string,
 ) (string, error) {
+	filePath, err := getPgPassFilePath(serverName)
+	if err != nil {
+		return "", err
+	}
+
 	pgpassLine := pgpass.NewConnectionInfo(connectionParameters, password)
 
-	if err := validatePathComponent(serverName); err != nil {
+	if err := os.MkdirAll(filepath.Dir(filePath), 0o700); err != nil {
 		return "", err
 	}
-
-	directory := filepath.Join(getExternalSecretsPath(), serverName)
-	if err := os.MkdirAll(directory, 0o700); err != nil {
-		return "", err
-	}
-	filePath := filepath.Join(directory, "pgpass")
 
 	return filePath, pgpass.From(pgpassLine).Write(filePath)
 }

--- a/pkg/management/external/utils.go
+++ b/pkg/management/external/utils.go
@@ -21,9 +21,11 @@ package external
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/cloudnative-pg/machinery/pkg/fileutils"
 	corev1 "k8s.io/api/core/v1"
@@ -49,6 +51,22 @@ func getExternalSecretsPath() string {
 	}
 
 	return defaultExternalSecretsPath
+}
+
+// ErrInvalidPathComponent is returned when a value that is used as a filesystem
+// path component contains a path separator or a parent-directory reference, both
+// of which could be used to escape the external secrets directory.
+var ErrInvalidPathComponent = errors.New("value cannot be used as a filesystem path component")
+
+// validatePathComponent ensures that a spec-provided value can be safely joined
+// into the external secrets path without escaping it. The admission webhook
+// rejects these values too, but the instance manager reads the spec directly, so
+// the check is repeated here as a defense-in-depth guard.
+func validatePathComponent(value string) error {
+	if value == "." || value == ".." || strings.ContainsAny(value, `/\`) {
+		return fmt.Errorf("%w: %q", ErrInvalidPathComponent, value)
+	}
+	return nil
 }
 
 // readSecretKeyRef reads the passed secret selector into a string.
@@ -93,6 +111,12 @@ func dumpSecretKeyRefToFile(
 	ctx context.Context, client ctrl.Client,
 	namespace string, serverName string, selector *corev1.SecretKeySelector,
 ) (string, error) {
+	for _, component := range []string{serverName, selector.Name, selector.Key} {
+		if err := validatePathComponent(component); err != nil {
+			return "", err
+		}
+	}
+
 	var secret corev1.Secret
 
 	err := client.Get(ctx, ctrl.ObjectKey{Namespace: namespace, Name: selector.Name}, &secret)
@@ -135,6 +159,10 @@ func createPgPassFile(
 	password string,
 ) (string, error) {
 	pgpassLine := pgpass.NewConnectionInfo(connectionParameters, password)
+
+	if err := validatePathComponent(serverName); err != nil {
+		return "", err
+	}
 
 	directory := filepath.Join(getExternalSecretsPath(), serverName)
 	if err := os.MkdirAll(directory, 0o700); err != nil {

--- a/pkg/management/external/utils.go
+++ b/pkg/management/external/utils.go
@@ -31,6 +31,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
 
+	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/external/internal/pgpass"
 )
 
@@ -69,6 +70,25 @@ func validatePathComponent(value string) error {
 	return nil
 }
 
+// validateExternalClusterPaths ensures that all ExternalCluster fields used as
+// filesystem path components are safe to join into the external secrets directory.
+func validateExternalClusterPaths(server *apiv1.ExternalCluster) error {
+	if err := validatePathComponent(server.Name); err != nil {
+		return err
+	}
+	for _, selector := range []*corev1.SecretKeySelector{server.SSLCert, server.SSLKey, server.SSLRootCert} {
+		if selector == nil {
+			continue
+		}
+		for _, component := range []string{selector.Name, selector.Key} {
+			if err := validatePathComponent(component); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
 // readSecretKeyRef reads the passed secret selector into a string.
 // This function is mainly useful to get a PostgreSQL's role password
 // from a Kubernetes secret
@@ -91,22 +111,14 @@ func readSecretKeyRef(
 }
 
 // getSecretKeyRefFileName get the name of the file where the content of the
-// connection secret will be dumped. The server name and the secret selector are
-// joined into the path, so they are validated to make sure they cannot escape
-// the external secrets directory.
+// connection secret will be dumped.
 func getSecretKeyRefFileName(
 	serverName string,
 	selector *corev1.SecretKeySelector,
-) (string, error) {
-	for _, component := range []string{serverName, selector.Name, selector.Key} {
-		if err := validatePathComponent(component); err != nil {
-			return "", err
-		}
-	}
-
+) string {
 	directory := filepath.Join(getExternalSecretsPath(), serverName)
 	filePath := filepath.Join(directory, fmt.Sprintf("%v_%v", selector.Name, selector.Key))
-	return filePath, nil
+	return filePath
 }
 
 // dumpSecretKeyRefToFile dumps a certain secret to a file inside a temporary folder
@@ -119,13 +131,10 @@ func dumpSecretKeyRefToFile(
 	ctx context.Context, client ctrl.Client,
 	namespace string, serverName string, selector *corev1.SecretKeySelector,
 ) (string, error) {
-	filePath, err := getSecretKeyRefFileName(serverName, selector)
-	if err != nil {
-		return "", err
-	}
-
 	var secret corev1.Secret
-	if err := client.Get(ctx, ctrl.ObjectKey{Namespace: namespace, Name: selector.Name}, &secret); err != nil {
+
+	err := client.Get(ctx, ctrl.ObjectKey{Namespace: namespace, Name: selector.Name}, &secret)
+	if err != nil {
 		return "", err
 	}
 
@@ -134,6 +143,7 @@ func dumpSecretKeyRefToFile(
 		return "", fmt.Errorf("missing key %v in secret %v", selector.Key, selector.Name)
 	}
 
+	filePath := getSecretKeyRefFileName(serverName, selector)
 	if err := os.MkdirAll(filepath.Dir(filePath), 0o700); err != nil {
 		return "", err
 	}
@@ -148,17 +158,11 @@ func dumpSecretKeyRefToFile(
 	return filePath, nil
 }
 
-// getPgPassFilePath gets the path where the pgpass file will be stored. The
-// server name is joined into the path, so it is validated to make sure it cannot
-// escape the external secrets directory.
-func getPgPassFilePath(serverName string) (string, error) {
-	if err := validatePathComponent(serverName); err != nil {
-		return "", err
-	}
-
+// getPgPassFilePath gets the path where the pgpass file will be stored.
+func getPgPassFilePath(serverName string) string {
 	directory := filepath.Join(getExternalSecretsPath(), serverName)
 	filePath := filepath.Join(directory, "pgpass")
-	return filePath, nil
+	return filePath
 }
 
 // createPgPassFile creates a pgpass file inside the user home directory
@@ -167,13 +171,9 @@ func createPgPassFile(
 	connectionParameters map[string]string,
 	password string,
 ) (string, error) {
-	filePath, err := getPgPassFilePath(serverName)
-	if err != nil {
-		return "", err
-	}
-
 	pgpassLine := pgpass.NewConnectionInfo(connectionParameters, password)
 
+	filePath := getPgPassFilePath(serverName)
 	if err := os.MkdirAll(filepath.Dir(filePath), 0o700); err != nil {
 		return "", err
 	}

--- a/pkg/management/external/utils_test.go
+++ b/pkg/management/external/utils_test.go
@@ -132,27 +132,47 @@ var _ = Describe("dumpSecretKeyRefToFile", func() {
 			_, err := dumpSecretKeyRefToFile(ctx, fakeClient, namespace, serverNameValue, selector)
 			Expect(err).To(MatchError(ErrInvalidPathComponent))
 
-			// nothing must have been written outside the base directory
-			outside := filepath.Join(filepath.Dir(base), "pwned")
-			Expect(outside).ToNot(BeAnExistingFile())
+			// validation fires before any filesystem operation, so nothing must
+			// have been created either inside the base directory or alongside it
+			expectNothingWritten(base)
 		},
 		Entry("traversal in the server name", "../pwned", secretName, secretKey),
 		Entry("separator in the server name", "nested/pwned", secretName, secretKey),
+		Entry("backslash in the server name", `nested\pwned`, secretName, secretKey),
+		Entry("absolute path as the server name", "/etc/pwned", secretName, secretKey),
+		Entry("dot component as the server name", ".", secretName, secretKey),
+		Entry("parent-dir component as the server name", "..", secretName, secretKey),
 		Entry("traversal in the secret name", serverName, "../pwned", secretKey),
 		Entry("traversal in the secret key", serverName, secretName, "../pwned"),
 	)
 })
 
 var _ = Describe("createPgPassFile", func() {
-	It("rejects a server name that would escape the secrets directory", func() {
-		base := GinkgoT().TempDir()
-		customExternalSecretsPath = base
-		DeferCleanup(func() { customExternalSecretsPath = "" })
+	DescribeTable("rejects a server name that would escape the secrets directory",
+		func(serverNameValue string) {
+			base := GinkgoT().TempDir()
+			customExternalSecretsPath = base
+			DeferCleanup(func() { customExternalSecretsPath = "" })
 
-		_, err := createPgPassFile("../pwned", map[string]string{"host": "example"}, "secret")
-		Expect(err).To(MatchError(ErrInvalidPathComponent))
+			_, err := createPgPassFile(serverNameValue, map[string]string{"host": "example"}, "secret")
+			Expect(err).To(MatchError(ErrInvalidPathComponent))
 
-		outside := filepath.Join(filepath.Dir(base), "pwned")
-		Expect(outside).ToNot(BeAnExistingFile())
-	})
+			expectNothingWritten(base)
+		},
+		Entry("traversal", "../pwned"),
+		Entry("separator", "nested/pwned"),
+		Entry("absolute path", "/etc/pwned"),
+		Entry("dot component", "."),
+	)
 })
+
+// expectNothingWritten asserts that the dump validation prevented any directory
+// or file from being created, both inside the base directory and as a sibling
+// reachable through a traversal sequence.
+func expectNothingWritten(base string) {
+	GinkgoHelper()
+	entries, err := os.ReadDir(base)
+	Expect(err).ToNot(HaveOccurred())
+	Expect(entries).To(BeEmpty(), "the base secrets directory must stay empty")
+	Expect(filepath.Join(filepath.Dir(base), "pwned")).ToNot(BeAnExistingFile())
+}

--- a/pkg/management/external/utils_test.go
+++ b/pkg/management/external/utils_test.go
@@ -22,13 +22,13 @@ package external
 import (
 	"context"
 	"os"
-	"path/filepath"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	schemeBuilder "github.com/cloudnative-pg/cloudnative-pg/internal/scheme"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -116,63 +116,67 @@ var _ = Describe("dumpSecretKeyRefToFile", func() {
 		Expect(content).To(Equal(shortValue))
 		Expect(content).ToNot(ContainSubstring("BBBB"))
 	})
+})
+
+var _ = Describe("validateExternalClusterPaths", func() {
+	sslSelector := func(name, key string) *corev1.SecretKeySelector {
+		return &corev1.SecretKeySelector{
+			LocalObjectReference: corev1.LocalObjectReference{Name: name},
+			Key:                  key,
+		}
+	}
+
+	It("accepts a valid cluster with all SSL selectors set", func() {
+		cluster := &apiv1.ExternalCluster{
+			Name:        "my-server",
+			SSLCert:     sslSelector("cert-secret", "tls.crt"),
+			SSLKey:      sslSelector("cert-secret", "tls.key"),
+			SSLRootCert: sslSelector("ca-secret", "ca.crt"),
+			Password:    sslSelector("pass-secret", "password"),
+		}
+		Expect(validateExternalClusterPaths(cluster)).To(Succeed())
+	})
+
+	It("accepts a valid cluster with no SSL selectors set", func() {
+		cluster := &apiv1.ExternalCluster{Name: "my-server"}
+		Expect(validateExternalClusterPaths(cluster)).To(Succeed())
+	})
+
+	It("does not validate the password selector (not used as a path component)", func() {
+		cluster := &apiv1.ExternalCluster{
+			Name:     "my-server",
+			Password: sslSelector("../pwned", "../pwned"),
+		}
+		Expect(validateExternalClusterPaths(cluster)).To(Succeed())
+	})
 
 	DescribeTable("rejects path components that would escape the secrets directory",
-		func(serverNameValue, selectorName, selectorKey string) {
-			base := GinkgoT().TempDir()
-			customExternalSecretsPath = base
-			DeferCleanup(func() { customExternalSecretsPath = "" })
-
-			selector := &corev1.SecretKeySelector{
-				LocalObjectReference: corev1.LocalObjectReference{Name: selectorName},
-				Key:                  selectorKey,
-			}
-			fakeClient = buildClient([]byte("payload"))
-
-			_, err := dumpSecretKeyRefToFile(ctx, fakeClient, namespace, serverNameValue, selector)
-			Expect(err).To(MatchError(ErrInvalidPathComponent))
-
-			// validation fires before any filesystem operation, so nothing must
-			// have been created either inside the base directory or alongside it
-			expectNothingWritten(base)
+		func(cluster *apiv1.ExternalCluster) {
+			Expect(validateExternalClusterPaths(cluster)).To(MatchError(ErrInvalidPathComponent))
 		},
-		Entry("traversal in the server name", "../pwned", secretName, secretKey),
-		Entry("separator in the server name", "nested/pwned", secretName, secretKey),
-		Entry("backslash in the server name", `nested\pwned`, secretName, secretKey),
-		Entry("absolute path as the server name", "/etc/pwned", secretName, secretKey),
-		Entry("dot component as the server name", ".", secretName, secretKey),
-		Entry("parent-dir component as the server name", "..", secretName, secretKey),
-		Entry("traversal in the secret name", serverName, "../pwned", secretKey),
-		Entry("traversal in the secret key", serverName, secretName, "../pwned"),
+		Entry("traversal in server name",
+			&apiv1.ExternalCluster{Name: "../pwned"}),
+		Entry("separator in server name",
+			&apiv1.ExternalCluster{Name: "nested/pwned"}),
+		Entry("backslash in server name",
+			&apiv1.ExternalCluster{Name: `nested\pwned`}),
+		Entry("absolute path as server name",
+			&apiv1.ExternalCluster{Name: "/etc/pwned"}),
+		Entry("dot as server name",
+			&apiv1.ExternalCluster{Name: "."}),
+		Entry("parent-dir as server name",
+			&apiv1.ExternalCluster{Name: ".."}),
+		Entry("traversal in SSLCert secret name",
+			&apiv1.ExternalCluster{Name: "ok", SSLCert: sslSelector("../pwned", "tls.crt")}),
+		Entry("traversal in SSLCert key",
+			&apiv1.ExternalCluster{Name: "ok", SSLCert: sslSelector("cert-secret", "../pwned")}),
+		Entry("traversal in SSLKey secret name",
+			&apiv1.ExternalCluster{Name: "ok", SSLKey: sslSelector("../pwned", "tls.key")}),
+		Entry("traversal in SSLKey key",
+			&apiv1.ExternalCluster{Name: "ok", SSLKey: sslSelector("cert-secret", "../pwned")}),
+		Entry("traversal in SSLRootCert secret name",
+			&apiv1.ExternalCluster{Name: "ok", SSLRootCert: sslSelector("../pwned", "ca.crt")}),
+		Entry("traversal in SSLRootCert key",
+			&apiv1.ExternalCluster{Name: "ok", SSLRootCert: sslSelector("ca-secret", "../pwned")}),
 	)
 })
-
-var _ = Describe("createPgPassFile", func() {
-	DescribeTable("rejects a server name that would escape the secrets directory",
-		func(serverNameValue string) {
-			base := GinkgoT().TempDir()
-			customExternalSecretsPath = base
-			DeferCleanup(func() { customExternalSecretsPath = "" })
-
-			_, err := createPgPassFile(serverNameValue, map[string]string{"host": "example"}, "secret")
-			Expect(err).To(MatchError(ErrInvalidPathComponent))
-
-			expectNothingWritten(base)
-		},
-		Entry("traversal", "../pwned"),
-		Entry("separator", "nested/pwned"),
-		Entry("absolute path", "/etc/pwned"),
-		Entry("dot component", "."),
-	)
-})
-
-// expectNothingWritten asserts that the dump validation prevented any directory
-// or file from being created, both inside the base directory and as a sibling
-// reachable through a traversal sequence.
-func expectNothingWritten(base string) {
-	GinkgoHelper()
-	entries, err := os.ReadDir(base)
-	Expect(err).ToNot(HaveOccurred())
-	Expect(entries).To(BeEmpty(), "the base secrets directory must stay empty")
-	Expect(filepath.Join(filepath.Dir(base), "pwned")).ToNot(BeAnExistingFile())
-}

--- a/pkg/management/external/utils_test.go
+++ b/pkg/management/external/utils_test.go
@@ -22,6 +22,7 @@ package external
 import (
 	"context"
 	"os"
+	"path/filepath"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -114,5 +115,44 @@ var _ = Describe("dumpSecretKeyRefToFile", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(content).To(Equal(shortValue))
 		Expect(content).ToNot(ContainSubstring("BBBB"))
+	})
+
+	DescribeTable("rejects path components that would escape the secrets directory",
+		func(serverNameValue, selectorName, selectorKey string) {
+			base := GinkgoT().TempDir()
+			customExternalSecretsPath = base
+			DeferCleanup(func() { customExternalSecretsPath = "" })
+
+			selector := &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{Name: selectorName},
+				Key:                  selectorKey,
+			}
+			fakeClient = buildClient([]byte("payload"))
+
+			_, err := dumpSecretKeyRefToFile(ctx, fakeClient, namespace, serverNameValue, selector)
+			Expect(err).To(MatchError(ErrInvalidPathComponent))
+
+			// nothing must have been written outside the base directory
+			outside := filepath.Join(filepath.Dir(base), "pwned")
+			Expect(outside).ToNot(BeAnExistingFile())
+		},
+		Entry("traversal in the server name", "../pwned", secretName, secretKey),
+		Entry("separator in the server name", "nested/pwned", secretName, secretKey),
+		Entry("traversal in the secret name", serverName, "../pwned", secretKey),
+		Entry("traversal in the secret key", serverName, secretName, "../pwned"),
+	)
+})
+
+var _ = Describe("createPgPassFile", func() {
+	It("rejects a server name that would escape the secrets directory", func() {
+		base := GinkgoT().TempDir()
+		customExternalSecretsPath = base
+		DeferCleanup(func() { customExternalSecretsPath = "" })
+
+		_, err := createPgPassFile("../pwned", map[string]string{"host": "example"}, "secret")
+		Expect(err).To(MatchError(ErrInvalidPathComponent))
+
+		outside := filepath.Join(filepath.Dir(base), "pwned")
+		Expect(outside).ToNot(BeAnExistingFile())
 	})
 })


### PR DESCRIPTION
The external cluster name and the referenced TLS secret selectors (`sslCert`, `sslKey`, `sslRootCert`) are joined into filesystem paths under the external secrets directory (`/controller/external`) when the instance manager dumps the connection material. None of these values were validated, so a name or selector containing a path separator or a `..` component could escape the intended directory and write into other volumes mounted writable in the instance container.

This stays within the trust boundary of a principal who can already create or update a Cluster (and therefore already controls the resulting Pod and its volumes), so it is a hardening fix rather than a privilege escalation. It is still a free-form string flowing into `filepath.Join`, which we validate by policy regardless of who can reach it.

Reject these values both in the cluster validating webhook and in the instance manager, which reads the spec directly and can bypass admission. The password secret reference is intentionally left unchecked, since it is only read from the API server and never joined into a path. The name is only ever used as a string-equality lookup key, so rejecting a path separator or a `..` component is non-breaking; no positive allowlist is imposed on the pre-existing field.

Because the same validator runs at the start of the instance manager reconcile loop through the admission guard, a Cluster that already has a non-conforming external cluster name or secret selector persisted (created before this fix, or through a webhook bypass) will have its reconciliation stopped until the value is corrected. Such a configuration could not have connected correctly before, since the value would have resolved to an unintended path.

Reported by @r0binak.

Closes #11043

----

- Rejected external cluster names and secret selector references containing a path separator or `..`, closing a path-traversal file write through `externalClusters` when the instance manager dumps connection secrets.
