### PR TITLE
chore(renovate): don't pin a digest for the cuelang/cue image

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -294,6 +294,7 @@
         'getwoke{/,}**',
         'jonasbn/github-action-spellcheck',
         'registry',
+        'cuelang/cue',
       ],
       pinDigests: false,
       separateMajorMinor: false,


### PR DESCRIPTION
The cuelang/cue image is build tooling used only to vet SECURITY-INSIGHTS.yml, so a pinned digest adds noise without value. Add it to the Containers no-digests group so Renovate tracks the readable tag and stops retrying the rate-limited digest-pin PR.