### PR TITLE
chore(renovate): pin digests for the Makefile container images

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -49,7 +49,7 @@
         '/^hack/testing-tools/common/40-utils-registry\\.sh$/'
       ],
       matchStrings: [
-        '# renovate: datasource=(?<datasource>[a-z-.]+?) depName=(?<depName>[^\\s]+?)(?: (?:lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?\\s+[A-Za-z0-9_]+?_VERSION\\s*\\??=\\s*["\']?(?<currentValue>.+?)["\']?\\s',
+        '# renovate: datasource=(?<datasource>[a-z-.]+?) depName=(?<depName>[^\\s]+?)(?: (?:lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?\\s+[A-Za-z0-9_]+?_VERSION\\s*\\??=\\s*["\']?(?<currentValue>[^@"\'\\s]+?)(?:@(?<currentDigest>sha256:[a-f0-9]+))?["\']?\\s',
       ],
     },
     {
@@ -291,10 +291,7 @@
       groupName: 'Containers no-digests',
       matchPackageNames: [
         'kindest{/,}**',
-        'getwoke{/,}**',
-        'jonasbn/github-action-spellcheck',
         'registry',
-        'cuelang/cue',
       ],
       pinDigests: false,
       separateMajorMinor: false,

--- a/Makefile
+++ b/Makefile
@@ -61,9 +61,9 @@ CRDREFDOCS_VERSION ?= v0.3.0
 # renovate: datasource=go depName=github.com/goreleaser/goreleaser
 GORELEASER_VERSION ?= v2.16.0
 # renovate: datasource=docker depName=jonasbn/github-action-spellcheck versioning=docker
-SPELLCHECK_VERSION ?= 0.62.0
+SPELLCHECK_VERSION ?= 0.62.0@sha256:ca8f6ef6da2dd0a23ef4abe51ae36cdc8e551a0feb1cbc849e6342af6d8c4da7
 # renovate: datasource=docker depName=getwoke/woke versioning=docker
-WOKE_VERSION ?= 0.19.0
+WOKE_VERSION ?= 0.19.0@sha256:5cdd550a166c9e11f2f53c3f6c23dfafdf879e9bcaffd07c2f8bfef095c1b579
 # renovate: datasource=github-releases depName=operator-framework/operator-sdk versioning=loose
 OPERATOR_SDK_VERSION ?= v1.42.3
 # renovate: datasource=github-tags depName=operator-framework/operator-registry
@@ -71,7 +71,7 @@ OPM_VERSION ?= v1.72.0
 # renovate: datasource=github-tags depName=redhat-openshift-ecosystem/openshift-preflight
 PREFLIGHT_VERSION ?= 1.19.1
 # renovate: datasource=docker depName=cuelang/cue versioning=docker
-CUE_VERSION ?= 0.16.1
+CUE_VERSION ?= 0.16.1@sha256:02a15644a421cbbb91a6137d980b061b1f93ccf3504c8efcd091ec8060e6a406
 # renovate: datasource=go depName=github.com/gemaraproj/gemara
 GEMARA_VERSION ?= v1.3.0
 ARCH ?= amd64


### PR DESCRIPTION
The spellcheck, woke and cue images run by the Makefile were kept as bare tags. Teach the Makefile custom manager to capture an optional digest, pin the three images, and drop their no-digest carve-outs so docker:pinDigests keeps the digests current.