### PR TITLE
chore: trace reconciliation loop start and end in backup reconcilers

### DIFF
--- a/internal/controller/backup_controller.go
+++ b/internal/controller/backup_controller.go
@@ -126,7 +126,11 @@ func NewBackupReconciler(
 //nolint:gocognit,gocyclo
 func (r *BackupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	contextLogger, ctx := log.SetupLogger(ctx)
-	contextLogger.Debug(fmt.Sprintf("reconciling object %#q", req.NamespacedName))
+
+	contextLogger.Debug("Reconciliation loop start")
+	defer func() {
+		contextLogger.Debug("Reconciliation loop end")
+	}()
 
 	var backup apiv1.Backup
 	if err := r.Get(ctx, req.NamespacedName, &backup); err != nil {
@@ -255,9 +259,6 @@ func (r *BackupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	default:
 		return ctrl.Result{}, fmt.Errorf("unrecognized method: %s", backup.Spec.Method)
 	}
-
-	// plugin post hooks
-	contextLogger.Debug(fmt.Sprintf("object %#q has been reconciled", req.NamespacedName))
 
 	hookResult := postReconcilePluginHooks(ctx, &cluster, &backup)
 	if hookResult.Err != nil || !hookResult.Result.IsZero() {

--- a/internal/controller/scheduledbackup_controller.go
+++ b/internal/controller/scheduledbackup_controller.go
@@ -73,10 +73,9 @@ type ScheduledBackupReconciler struct {
 func (r *ScheduledBackupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	contextLogger, ctx := log.SetupLogger(ctx)
 
-	contextLogger.Debug(fmt.Sprintf("reconciling object %#q", req.NamespacedName))
-
+	contextLogger.Debug("Reconciliation loop start")
 	defer func() {
-		contextLogger.Debug(fmt.Sprintf("object %#q has been reconciled", req.NamespacedName))
+		contextLogger.Debug("Reconciliation loop end")
 	}()
 
 	var scheduledBackup apiv1.ScheduledBackup


### PR DESCRIPTION
Aligns the Backup and ScheduledBackup reconcilers with the "Reconciliation loop start"/"end" debug-logging convention already used by the Cluster, Plugin, and Role reconcilers, logging loop exit via a deferred call instead of a trailing statement that earlier returns could skip.