### PR TITLE
fix(backup): don't regress backup phase back to pending

### DIFF
--- a/internal/controller/backup_controller.go
+++ b/internal/controller/backup_controller.go
@@ -1107,6 +1107,15 @@ func (r *BackupReconciler) waitIfOtherBackupsRunning(
 ) (ctrl.Result, error) {
 	contextLogger := log.FromContext(ctx)
 
+	// Only gate a backup that is still waiting to start. Once it has begun,
+	// the contention check is a no-op for it, but the SetAsPending below would
+	// regress a phase that may have advanced concurrently: the instance manager
+	// writes the terminal phase asynchronously, so a stale read here could flip
+	// an already-completed plugin backup back to pending.
+	if len(backup.Status.Phase) != 0 && backup.Status.Phase != apiv1.BackupPhasePending {
+		return ctrl.Result{}, nil
+	}
+
 	// Validate we don't have other running backups
 	var clusterBackups apiv1.BackupList
 	if err := r.List(

--- a/internal/controller/backup_controller_test.go
+++ b/internal/controller/backup_controller_test.go
@@ -769,5 +769,65 @@ var _ = Describe("backup pending state", func() {
 			// Phase should still be empty since we didn't need to set it as pending
 			Expect(stored.Status.Phase).To(BeEmpty())
 		})
+
+		It("does not regress a backup that already moved past pending", func(ctx context.Context) {
+			ns := newFakeNamespace(env.client)
+
+			cluster := newFakeCNPGCluster(env.client, ns, func(c *apiv1.Cluster) {
+				c.Spec.Backup = &apiv1.BackupConfiguration{
+					BarmanObjectStore: &apiv1.BarmanObjectStoreConfiguration{
+						BarmanCredentials: apiv1.BarmanCredentials{
+							AWS: &apiv1.S3Credentials{
+								AccessKeyIDReference: &apiv1.SecretKeySelector{
+									LocalObjectReference: apiv1.LocalObjectReference{Name: "aws-creds"},
+									Key:                  "ACCESS_KEY_ID",
+								},
+								SecretAccessKeyReference: &apiv1.SecretKeySelector{
+									LocalObjectReference: apiv1.LocalObjectReference{Name: "aws-creds"},
+									Key:                  "SECRET_ACCESS_KEY",
+								},
+							},
+						},
+						DestinationPath: "s3://bucket/path",
+					},
+				}
+			})
+
+			// Another backup is running, so CanExecuteBackup would return false
+			// for any other backup and the pre-guard code would set it as pending.
+			runningBackup := &apiv1.Backup{
+				ObjectMeta: metav1.ObjectMeta{Name: "backup-1-running", Namespace: ns},
+				Spec: apiv1.BackupSpec{
+					Cluster: apiv1.LocalObjectReference{Name: cluster.Name},
+					Method:  apiv1.BackupMethodBarmanObjectStore,
+				},
+				Status: apiv1.BackupStatus{
+					Phase: apiv1.BackupPhaseRunning,
+				},
+			}
+			Expect(env.client.Create(ctx, runningBackup)).To(Succeed())
+
+			// A backup whose phase the instance manager has already advanced to
+			// completed. Reconciling it must not flip it back to pending.
+			completedBackup := &apiv1.Backup{
+				ObjectMeta: metav1.ObjectMeta{Name: "backup-2-completed", Namespace: ns},
+				Spec: apiv1.BackupSpec{
+					Cluster: apiv1.LocalObjectReference{Name: cluster.Name},
+					Method:  apiv1.BackupMethodBarmanObjectStore,
+				},
+				Status: apiv1.BackupStatus{
+					Phase: apiv1.BackupPhaseCompleted,
+				},
+			}
+			Expect(env.client.Create(ctx, completedBackup)).To(Succeed())
+
+			res, err := env.backupReconciler.waitIfOtherBackupsRunning(ctx, completedBackup, cluster)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(res.IsZero()).To(BeTrue())
+
+			var stored apiv1.Backup
+			Expect(env.client.Get(ctx, client.ObjectKeyFromObject(completedBackup), &stored)).To(Succeed())
+			Expect(stored.Status.Phase).To(BeEquivalentTo(apiv1.BackupPhaseCompleted))
+		})
 	})
 })


### PR DESCRIPTION
waitIfOtherBackupsRunning ran the concurrent-backup gate on every reconcile and set the backup to pending whenever the gate denied it, without first checking the current phase. For plugin backups the instance manager writes the terminal phase asynchronously, so this could overwrite an already-completed backup with pending and leave a successful backup stuck in pending forever. Run the gate only while the backup is still unset or pending.

Closes #11010

----

### Release note

Fixed a regression where a plugin `Backup` could have its `status.phase` silently reverted from `completed` back to `pending`, leaving a successful backup stuck in pending forever.
