### PR TITLE
fix(switchover): detect missing WAL-archiver native sidecars

### DIFF
--- a/internal/controller/cluster_upgrade.go
+++ b/internal/controller/cluster_upgrade.go
@@ -770,9 +770,10 @@ func (r *ClusterReconciler) recreatePrimaryInPlace(
 // so it must be recreated to gain the sidecar rather than demoted via a
 // switchover, which would dead-lock on archiving (see issue #10981).
 //
-// Detection diffs the Pod's containers against a freshly evaluated instance
-// spec: NewInstance runs the plugins' OperationVerbEvaluate lifecycle hook, so
-// its containers already include any injected sidecars. The check is a
+// Detection diffs the Pod's containers (regular and native-sidecar init
+// containers) against a freshly evaluated instance spec: NewInstance runs the
+// plugins' OperationVerbEvaluate lifecycle hook, so its containers already
+// include any injected sidecars. The check is a
 // deliberate over-approximation. We cannot map a sidecar back to the specific
 // plugin that injected it, so when several sidecar-injecting plugins are enabled
 // this may recreate the primary even if only a non-archiver sidecar is missing.
@@ -798,12 +799,29 @@ func archiverSidecarMissingOnPrimary(
 		return false, err
 	}
 
-	current := make(map[string]struct{}, len(pod.Spec.Containers))
-	for _, container := range pod.Spec.Containers {
-		current[container.Name] = struct{}{}
+	// Plugins inject their sidecars either as regular containers or, for native
+	// sidecars, as init containers with RestartPolicy=Always. Compare both, so a
+	// missing native sidecar is detected too. Run-once init containers (including
+	// the bootstrap controller) are skipped: they are not long-running, so they
+	// are never the archiver sidecar.
+	collectContainerNames := func(target *corev1.Pod) map[string]struct{} {
+		names := make(map[string]struct{}, len(target.Spec.Containers))
+		for _, container := range target.Spec.Containers {
+			names[container.Name] = struct{}{}
+		}
+		for _, container := range target.Spec.InitContainers {
+			if container.RestartPolicy == nil ||
+				*container.RestartPolicy != corev1.ContainerRestartPolicyAlways {
+				continue
+			}
+			names[container.Name] = struct{}{}
+		}
+		return names
 	}
-	for _, container := range targetPod.Spec.Containers {
-		if _, found := current[container.Name]; !found {
+
+	current := collectContainerNames(pod)
+	for name := range collectContainerNames(targetPod) {
+		if _, found := current[name]; !found {
 			return true, nil
 		}
 	}

--- a/internal/controller/cluster_upgrade_test.go
+++ b/internal/controller/cluster_upgrade_test.go
@@ -1198,11 +1198,14 @@ var _ = Describe("archiverSidecarMissingOnPrimary", func() {
 
 	// withArchiverSidecar returns a copy of pod with an extra container,
 	// mimicking the sidecar a WAL-archiver plugin injects at evaluation time.
+	// Real plugins (e.g. plugin-barman-cloud) inject it as a native sidecar: an
+	// init container with RestartPolicy=Always.
 	withArchiverSidecar := func(pod *corev1.Pod) *corev1.Pod {
 		out := pod.DeepCopy()
-		out.Spec.Containers = append(out.Spec.Containers, corev1.Container{
-			Name:  sidecarName,
-			Image: "plugin-barman-cloud:latest",
+		out.Spec.InitContainers = append(out.Spec.InitContainers, corev1.Container{
+			Name:          sidecarName,
+			Image:         "plugin-barman-cloud:latest",
+			RestartPolicy: ptr.To(corev1.ContainerRestartPolicyAlways),
 		})
 		return out
 	}
@@ -1248,6 +1251,26 @@ var _ = Describe("archiverSidecarMissingOnPrimary", func() {
 			fakePluginClientRollout{returnedPod: podWithSidecar})
 
 		Expect(archiverSidecarMissingOnPrimary(ctx, podWithSidecar, &cluster)).To(BeFalse())
+	})
+
+	It("ignores a missing run-once init container, only native sidecars matter", func() {
+		enableArchiverPlugin()
+
+		pod, err := specs.NewInstance(context.TODO(), cluster, 1, true)
+		Expect(err).ToNot(HaveOccurred())
+
+		// The evaluated target adds a plain run-once init container (no
+		// RestartPolicy=Always). A missing one of those is not an archiver
+		// sidecar and must not force an in-place recreate.
+		target := pod.DeepCopy()
+		target.Spec.InitContainers = append(target.Spec.InitContainers, corev1.Container{
+			Name:  "some-run-once-init",
+			Image: "init:latest",
+		})
+		ctx := pluginClient.SetPluginClientInContext(context.TODO(),
+			fakePluginClientRollout{returnedPod: target})
+
+		Expect(archiverSidecarMissingOnPrimary(ctx, pod, &cluster)).To(BeFalse())
 	})
 
 	It("propagates evaluation errors instead of degrading to a switchover decision", func() {


### PR DESCRIPTION
archiverSidecarMissingOnPrimary compared only Spec.Containers, so a WAL-archiver plugin that injects its sidecar as a native sidecar (an init container with RestartPolicy=Always, as plugin-barman-cloud does) was never detected. The primary was then rolled out through a switchover that dead-locks, because a clean demotion archives pending WAL with the very sidecar that is still missing.

Compare native-sidecar init containers as well, so the missing sidecar is detected and the primary is recreated in place instead.

This completes the fix from #11032, which addressed #10981 but missed plugins that inject the archiver as a native sidecar.
