### PR TITLE
fix: correct grammar in PhaseUpgradeDelayed status messages

### DIFF
--- a/docs/src/security.md
+++ b/docs/src/security.md
@@ -241,6 +241,34 @@ Pod is created. Installing a plugin is therefore an explicit trust decision
 made by the cluster administrator, on par with granting write access to a
 Cluster resource.
 
+The same authority extends into the database itself: because the operator
+reconciles PostgreSQL as the superuser, a Cluster writer gains superuser-level
+influence over the resulting cluster through documented, intended fields,
+including:
+
+- the bootstrap SQL hooks `postInitSQL`, `postInitApplicationSQL`, and
+  `postInitTemplateSQL`, executed as the `postgres` superuser at initialization
+  (see [Executing Queries After Initialization](bootstrap.md#executing-queries-after-initialization));
+- [inline managed roles](declarative_role_management.md#inline-managed-roles)
+  (`spec.managed.roles`), which may set `superuser: true` or grant membership of
+  existing roles, and can use PostgreSQL features such as `COPY ... FROM PROGRAM`
+  to run commands inside the operand Pod;
+- custom PostgreSQL configuration parameters.
+
+This is the intended trust model, not a privilege escalation.
+
+Code running in the operand Pod also runs under its mounted `ServiceAccount`,
+which can read the Secrets associated with its own cluster (see
+[Calls to the API server made by the instance manager](#calls-to-the-api-server-made-by-the-instance-manager)
+and ["Secrets"](applications.md#secrets)). A Cluster writer can therefore read
+those Secrets, confined by [Namespace Isolation](#namespace-isolation) to the
+Cluster's own namespace.
+
+:::note
+These trust boundaries are also covered in the project's
+[self security assessment](https://github.com/cloudnative-pg/cloudnative-pg/blob/main/.github/threat-catalog.yaml).
+:::
+
 #### Kubernetes Admission Control
 
 The operator creates Pods through the standard Kubernetes API, meaning every
@@ -290,6 +318,11 @@ allows `superuser: true` and membership of any existing role through
 `DatabaseRole` objects in a namespace is therefore equivalent to superuser
 access on the PostgreSQL clusters in that namespace, and deserves the same
 care as write access to the `Cluster` resource.
+
+Treat write access to these resources as a high-privilege grant: for
+multi-tenant deployments, isolate tenants in separate namespaces and scope it
+per namespace with Kubernetes RBAC, relying on
+[Namespace Isolation](#namespace-isolation) to bound the impact.
 
 The RBAC discussed here governs access to CloudNativePG's own custom resources.
 The next section covers the complementary side: the RBAC that the operator

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -1218,13 +1218,13 @@ func (r *ClusterReconciler) handleRollingUpdate(
 		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 	case errors.Is(err, errRolloutDelayed):
 		contextLogger.Warning(
-			"A Pod need to be rolled out, but the rollout is being delayed",
+			"A Pod needs to be rolled out, but the rollout is being delayed",
 		)
 		if err := r.RegisterPhase(
 			ctx,
 			cluster,
 			apiv1.PhaseUpgradeDelayed,
-			"The cluster need to be update, but the operator is configured to delay "+
+			"The cluster needs to be updated, but the operator is configured to delay "+
 				"the operation",
 		); err != nil {
 			return ctrl.Result{}, err


### PR DESCRIPTION
## Summary

Fixes two grammar mistakes in the rollout-delay messages emitted by `handleRollingUpdate` in `internal/controller/cluster_controller.go`.

Changes:

* "A Pod need to be rolled out, but the rollout is being delayed"
  → "A Pod needs to be rolled out, but the rollout is being delayed"
* "The cluster need to be update, but the operator is configured to delay the operation"
  → "The cluster needs to be updated, but the operator is configured to delay the operation"

These messages are surfaced through operator logs, Cluster status, ArgoCD health details, and `kubectl describe` output.

Closes #10781.