### PR TITLE
feat (webhook): emit admission warnings for reserved inherited labels

### DIFF
--- a/internal/webhook/v1/cluster_webhook.go
+++ b/internal/webhook/v1/cluster_webhook.go
@@ -2662,7 +2662,38 @@ func (v *ClusterCustomValidator) getAdmissionWarnings(r *apiv1.Cluster) admissio
 	list = append(list, getStorageWarnings(r)...)
 	list = append(list, getSharedBuffersWarnings(r)...)
 	list = append(list, getMonitoringFieldsWarnings(r)...)
-	return append(list, getDeprecatedMonitoringFieldsWarnings(r)...)
+	list = append(list, getDeprecatedMonitoringFieldsWarnings(r)...)
+	return append(list, getReservedLabelsWarnings(r)...)
+}
+
+// getReservedLabelsWarnings warns when spec.inheritedMetadata.labels overrides a
+// label that CloudNativePG relies on internally for Service selectors, resource
+// discovery, and reconciliation. Overriding these can disrupt operator behavior.
+func getReservedLabelsWarnings(r *apiv1.Cluster) admission.Warnings {
+	if r.Spec.InheritedMetadata == nil || len(r.Spec.InheritedMetadata.Labels) == 0 {
+		return nil
+	}
+
+	reservedLabels := []string{
+		utils.ClusterLabelName,
+		utils.PodRoleLabelName,
+		utils.ClusterInstanceRoleLabelName,
+		utils.InstanceNameLabelName,
+		utils.PvcRoleLabelName,
+	}
+
+	var result admission.Warnings
+	for _, label := range reservedLabels {
+		if _, ok := r.Spec.InheritedMetadata.Labels[label]; ok {
+			result = append(result, fmt.Sprintf(
+				"label `%s` in spec.inheritedMetadata.labels is used internally by CloudNativePG and "+
+					"may cause unexpected behavior when overridden. Remove it from spec.inheritedMetadata.labels.",
+				label,
+			))
+		}
+	}
+
+	return result
 }
 
 func getMonitoringFieldsWarnings(r *apiv1.Cluster) admission.Warnings {

--- a/internal/webhook/v1/cluster_webhook_test.go
+++ b/internal/webhook/v1/cluster_webhook_test.go
@@ -6565,6 +6565,54 @@ var _ = Describe("getRetentionPolicyWarnings", func() {
 	})
 })
 
+var _ = Describe("getReservedLabelsWarnings", func() {
+	It("returns no warnings when inheritedMetadata is not set", func() {
+		cluster := &apiv1.Cluster{
+			Spec: apiv1.ClusterSpec{},
+		}
+		Expect(getReservedLabelsWarnings(cluster)).To(BeEmpty())
+	})
+
+	It("returns no warnings for non-reserved labels", func() {
+		cluster := &apiv1.Cluster{
+			Spec: apiv1.ClusterSpec{
+				InheritedMetadata: &apiv1.EmbeddedObjectMetadata{
+					Labels: map[string]string{"team": "platform"},
+				},
+			},
+		}
+		Expect(getReservedLabelsWarnings(cluster)).To(BeEmpty())
+	})
+
+	It("returns one warning for a single reserved label", func() {
+		cluster := &apiv1.Cluster{
+			Spec: apiv1.ClusterSpec{
+				InheritedMetadata: &apiv1.EmbeddedObjectMetadata{
+					Labels: map[string]string{utils.ClusterLabelName: "value"},
+				},
+			},
+		}
+		warnings := getReservedLabelsWarnings(cluster)
+		Expect(warnings).To(HaveLen(1))
+		Expect(warnings[0]).To(ContainSubstring(utils.ClusterLabelName))
+	})
+
+	It("returns a warning for each reserved label", func() {
+		cluster := &apiv1.Cluster{
+			Spec: apiv1.ClusterSpec{
+				InheritedMetadata: &apiv1.EmbeddedObjectMetadata{
+					Labels: map[string]string{
+						utils.ClusterLabelName: "value",
+						utils.PodRoleLabelName: "value",
+					},
+				},
+			},
+		}
+		warnings := getReservedLabelsWarnings(cluster)
+		Expect(warnings).To(HaveLen(2))
+	})
+})
+
 var _ = Describe("getStorageWarnings", func() {
 	It("returns no warnings when storage is properly configured", func() {
 		cluster := &apiv1.Cluster{


### PR DESCRIPTION
## Summary

Add admission warnings when `spec.inheritedMetadata.labels` contains labels that CloudNativePG relies on internally.

These labels are used for resource discovery, selectors, and reconciliation. Overriding them through inherited metadata can lead to unexpected operator behavior.

The warning is emitted during admission and does not block resource creation or updates.

Refs #10439

## Changes

* Add `getReservedLabelsWarnings()` to the Cluster webhook validation logic
* Emit one warning per reserved label found in `spec.inheritedMetadata.labels`
* Register the warning helper in `getAdmissionWarnings()`
* Add unit tests covering:

  * no inherited metadata
  * non-reserved labels
  * a single reserved label
  * multiple reserved labels

## Reserved labels

The warning currently applies to:

* `cnpg.io/cluster`
* `cnpg.io/podRole`
* `cnpg.io/instanceRole`
* `cnpg.io/instanceName`
* `cnpg.io/pvcRole`

## Rationale

During investigation, I reviewed the labels used by CloudNativePG for resource selection, discovery, and reconciliation.

The warning scope is intentionally limited to the operator-critical `cnpg.io/*` identity labels. Labels such as `app.kubernetes.io/component` and `app.kubernetes.io/part-of` were evaluated and excluded because:

* `app.kubernetes.io/part-of` is not used by CloudNativePG
* `app.kubernetes.io/component` is operator-managed and self-healing, and is not used in critical selectors

As a result, the warning focuses only on labels whose override can materially affect operator behavior.

## Testing

```bash
go test ./internal/webhook/v1/... -v
```

Result:

* 445/445 specs passed

No API, CRD, or controller changes were made.
