### PR TITLE
fix(backup): retry volume snapshot backups on transient instance-manager connection errors

### DIFF
--- a/pkg/reconciler/backup/volumesnapshot/errors.go
+++ b/pkg/reconciler/backup/volumesnapshot/errors.go
@@ -22,6 +22,7 @@ package volumesnapshot
 import (
 	"context"
 	"errors"
+	"net"
 	"regexp"
 	"strconv"
 	"strings"
@@ -45,8 +46,17 @@ var (
 // It is not designed to check errors raised by the CSI driver and
 // exposed by the CSI snapshotter sidecar.
 func isNetworkErrorRetryable(err error) bool {
+	// A transport-level failure to reach the instance manager (dial timeout,
+	// connection refused or reset, DNS error) surfaces as a net.Error. It means a
+	// brief network disruption rather than a response the instance manager
+	// produced, so the backup should be retried rather than failed. This matters in
+	// the finalize step, where the snapshots are already provisioned and a single
+	// blip would otherwise discard an otherwise complete backup.
+	var netErr net.Error
+
 	return apierrs.IsServerTimeout(err) || apierrs.IsConflict(err) || apierrs.IsInternalError(err) ||
-		errors.Is(err, context.DeadlineExceeded) || remote.IsTransientAuthError(err)
+		errors.Is(err, context.DeadlineExceeded) || remote.IsTransientAuthError(err) ||
+		errors.As(err, &netErr)
 }
 
 // isCSIErrorMessageRetriable detects if a certain error message

--- a/pkg/reconciler/backup/volumesnapshot/errors.go
+++ b/pkg/reconciler/backup/volumesnapshot/errors.go
@@ -46,12 +46,19 @@ var (
 // It is not designed to check errors raised by the CSI driver and
 // exposed by the CSI snapshotter sidecar.
 func isNetworkErrorRetryable(err error) bool {
-	// A transport-level failure to reach the instance manager (dial timeout,
-	// connection refused or reset, DNS error) surfaces as a net.Error: the
-	// connection never produced an authenticated response, so it is safe to
-	// requeue. In the common case this is a transient blip, and it matters most
-	// in the finalize step, where the snapshots are already provisioned and a
-	// single failure would otherwise discard an otherwise complete backup.
+	// A transport-level failure to reach the instance manager surfaces as a
+	// net.Error. The HTTP client wraps every such failure in a *net/url.Error,
+	// which itself satisfies net.Error, so this matches all of them: dial
+	// timeout, connection refused or reset, DNS failure, and TLS or certificate
+	// errors. In each case the connection never produced an authenticated
+	// response, so requeuing is safe. It matters most in the finalize step,
+	// where the snapshots are already provisioned and a single failure would
+	// otherwise discard an otherwise complete backup.
+	//
+	// This is intentionally the opposite of the in-request retry in
+	// remote.getReplicaStatusFromPodViaHTTP, which treats a net.Error timeout as
+	// non-retryable: that path retries within a single reconcile, whereas here we
+	// requeue the whole reconcile.
 	var netErr net.Error
 
 	return apierrs.IsServerTimeout(err) || apierrs.IsConflict(err) || apierrs.IsInternalError(err) ||

--- a/pkg/reconciler/backup/volumesnapshot/errors.go
+++ b/pkg/reconciler/backup/volumesnapshot/errors.go
@@ -37,7 +37,7 @@ var (
 	httpStatusCodeRegex  = regexp.MustCompile(`HTTPStatusCode:\s(\d{3})`)
 )
 
-// isErrorRetryable detects is an error is retryable or not.
+// isNetworkErrorRetryable detects if an error is retryable or not.
 //
 // Important: this function is intended for detecting errors that
 // occur during communication between the operator and the Kubernetes
@@ -47,11 +47,11 @@ var (
 // exposed by the CSI snapshotter sidecar.
 func isNetworkErrorRetryable(err error) bool {
 	// A transport-level failure to reach the instance manager (dial timeout,
-	// connection refused or reset, DNS error) surfaces as a net.Error. It means a
-	// brief network disruption rather than a response the instance manager
-	// produced, so the backup should be retried rather than failed. This matters in
-	// the finalize step, where the snapshots are already provisioned and a single
-	// blip would otherwise discard an otherwise complete backup.
+	// connection refused or reset, DNS error) surfaces as a net.Error: the
+	// connection never produced an authenticated response, so it is safe to
+	// requeue. In the common case this is a transient blip, and it matters most
+	// in the finalize step, where the snapshots are already provisioned and a
+	// single failure would otherwise discard an otherwise complete backup.
 	var netErr net.Error
 
 	return apierrs.IsServerTimeout(err) || apierrs.IsConflict(err) || apierrs.IsInternalError(err) ||

--- a/pkg/reconciler/backup/volumesnapshot/errors_test.go
+++ b/pkg/reconciler/backup/volumesnapshot/errors_test.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
@@ -101,6 +102,21 @@ var _ = Describe("isNetworkErrorRetryable", func() {
 	It("retries a wrapped transient instance manager rejection (production path)", func() {
 		err := fmt.Errorf("while trying to start the backup: %w",
 			&remote.StatusError{StatusCode: http.StatusServiceUnavailable, Body: "operator certificate not recognized"})
+		Expect(isNetworkErrorRetryable(err)).To(BeTrue())
+	})
+
+	It("retries a transport-level dial timeout to the instance manager (production path)", func() {
+		// Mirrors the error chain produced when the finalize status read cannot reach
+		// the instance manager: a *net.OpError wrapped by the HTTP client and the
+		// reconciler.
+		err := fmt.Errorf("while getting status while finalizing: %w",
+			fmt.Errorf("while executing http request: %w",
+				&net.OpError{Op: "dial", Net: "tcp", Err: errors.New("i/o timeout")}))
+		Expect(isNetworkErrorRetryable(err)).To(BeTrue())
+	})
+
+	It("retries a transport-level connection error", func() {
+		err := &net.OpError{Op: "dial", Net: "tcp", Err: errors.New("connection refused")}
 		Expect(isNetworkErrorRetryable(err)).To(BeTrue())
 	})
 

--- a/pkg/reconciler/backup/volumesnapshot/errors_test.go
+++ b/pkg/reconciler/backup/volumesnapshot/errors_test.go
@@ -116,6 +116,9 @@ var _ = Describe("isNetworkErrorRetryable", func() {
 	})
 
 	It("retries a transport-level connection error", func() {
+		// The bare, unwrapped net.OpError, and a connection refused rather than a
+		// timeout: errors.As must match the type directly, without relying on a
+		// Timeout()/Temporary() check.
 		err := &net.OpError{Op: "dial", Net: "tcp", Err: errors.New("connection refused")}
 		Expect(isNetworkErrorRetryable(err)).To(BeTrue())
 	})


### PR DESCRIPTION
A transport-level failure to reach the instance manager, for example a dial timeout caused by a brief pod-network disruption, was treated as a terminal error and failed a volume snapshot backup even when its snapshots were already provisioned. `isNetworkErrorRetryable`, which already requeues operator to instance-manager communication errors, did not recognize a `net.Error`, so the failure escaped as fatal during the finalize step.

Detect `net.Error` there so these failures requeue and the backup is retried instead of discarded.

Closes #11068

----

VolumeSnapshot backups are no longer failed by a transient connection error to the instance manager: the operator now requeues and retries instead of discarding a backup whose snapshots are already provisioned.
