### PR TITLE
fix(backup): tolerate pre-existing VolumeSnapshot on snapshot backup

### DIFF
--- a/pkg/reconciler/backup/volumesnapshot/reconciler.go
+++ b/pkg/reconciler/backup/volumesnapshot/reconciler.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cloudnative-pg/machinery/pkg/log"
 	volumesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
@@ -508,7 +509,30 @@ func (se *Reconciler) createSnapshot(
 	}
 
 	if err := se.cli.Create(ctx, &snapshot); err != nil {
-		return fmt.Errorf("while creating VolumeSnapshot %s: %w", snapshot.Name, err)
+		if !apierrs.IsAlreadyExists(err) {
+			return fmt.Errorf("while creating VolumeSnapshot %s: %w", snapshot.Name, err)
+		}
+
+		// A VolumeSnapshot with this name already exists. This can happen when
+		// the cached VolumeSnapshot list used to decide whether to create the
+		// snapshots lags behind a snapshot we created in a previous
+		// reconciliation cycle. If the existing object is the one we manage for
+		// this backup, the error is harmless: the reconciliation loop will
+		// requeue and pick it up through the backup label selector. Otherwise
+		// the name collides with a foreign object and we must surface the error
+		// instead of silently looping.
+		var existing volumesnapshotv1.VolumeSnapshot
+		if err := se.cli.Get(ctx, client.ObjectKeyFromObject(&snapshot), &existing); err != nil {
+			return fmt.Errorf("while verifying pre-existing VolumeSnapshot %s: %w", snapshot.Name, err)
+		}
+		if existing.Labels[utils.BackupNameLabelName] != backup.Name {
+			return fmt.Errorf("while creating VolumeSnapshot %s: %w", snapshot.Name, err)
+		}
+
+		log.FromContext(ctx).Info(
+			"VolumeSnapshot for this backup already exists, reusing it",
+			"snapshotName", snapshot.Name,
+			"backupName", backup.Name)
 	}
 
 	return nil

--- a/pkg/reconciler/backup/volumesnapshot/reconciler.go
+++ b/pkg/reconciler/backup/volumesnapshot/reconciler.go
@@ -538,6 +538,10 @@ func (se *Reconciler) handleSnapshotCreateError(
 		// so treat the collision as harmless and let a later cycle re-evaluate
 		// ownership once the cache catches up.
 		if apierrs.IsNotFound(getErr) {
+			log.FromContext(ctx).Trace(
+				"VolumeSnapshot creation collided but the cache still hides it, requeuing",
+				"snapshotName", snapshot.Name,
+				"backupName", backup.Name)
 			return nil
 		}
 		return fmt.Errorf("while verifying pre-existing VolumeSnapshot %s: %w", snapshot.Name, getErr)

--- a/pkg/reconciler/backup/volumesnapshot/reconciler.go
+++ b/pkg/reconciler/backup/volumesnapshot/reconciler.go
@@ -453,8 +453,7 @@ func (se *Reconciler) waitSnapshotToBeReadyStep(
 	return nil, nil
 }
 
-// createSnapshot creates a VolumeSnapshot resource for the given PVC and
-// add it to the command status
+// createSnapshot creates a VolumeSnapshot resource for the given PVC
 func (se *Reconciler) createSnapshot(
 	ctx context.Context,
 	cluster *apiv1.Cluster,
@@ -509,31 +508,49 @@ func (se *Reconciler) createSnapshot(
 	}
 
 	if err := se.cli.Create(ctx, &snapshot); err != nil {
-		if !apierrs.IsAlreadyExists(err) {
-			return fmt.Errorf("while creating VolumeSnapshot %s: %w", snapshot.Name, err)
-		}
-
-		// A VolumeSnapshot with this name already exists. This can happen when
-		// the cached VolumeSnapshot list used to decide whether to create the
-		// snapshots lags behind a snapshot we created in a previous
-		// reconciliation cycle. If the existing object is the one we manage for
-		// this backup, the error is harmless: the reconciliation loop will
-		// requeue and pick it up through the backup label selector. Otherwise
-		// the name collides with a foreign object and we must surface the error
-		// instead of silently looping.
-		var existing volumesnapshotv1.VolumeSnapshot
-		if err := se.cli.Get(ctx, client.ObjectKeyFromObject(&snapshot), &existing); err != nil {
-			return fmt.Errorf("while verifying pre-existing VolumeSnapshot %s: %w", snapshot.Name, err)
-		}
-		if existing.Labels[utils.BackupNameLabelName] != backup.Name {
-			return fmt.Errorf("while creating VolumeSnapshot %s: %w", snapshot.Name, err)
-		}
-
-		log.FromContext(ctx).Info(
-			"VolumeSnapshot for this backup already exists, reusing it",
-			"snapshotName", snapshot.Name,
-			"backupName", backup.Name)
+		return se.handleSnapshotCreateError(ctx, err, &snapshot, backup)
 	}
+
+	return nil
+}
+
+// handleSnapshotCreateError decides whether a failed VolumeSnapshot creation can
+// be tolerated. An AlreadyExists collision against a snapshot we manage for this
+// backup is harmless, because the cached VolumeSnapshot list used to decide
+// whether to create the snapshots can lag behind a snapshot we created in a
+// previous reconciliation cycle. In that case this reconciliation requeues and a
+// later cycle picks the snapshot up through the backup label selector. Any other
+// error, or a collision with a foreign object, is returned to the caller.
+func (se *Reconciler) handleSnapshotCreateError(
+	ctx context.Context,
+	err error,
+	snapshot *volumesnapshotv1.VolumeSnapshot,
+	backup *apiv1.Backup,
+) error {
+	if !apierrs.IsAlreadyExists(err) {
+		return fmt.Errorf("while creating VolumeSnapshot %s: %w", snapshot.Name, err)
+	}
+
+	var existing volumesnapshotv1.VolumeSnapshot
+	if getErr := se.cli.Get(ctx, client.ObjectKeyFromObject(snapshot), &existing); getErr != nil {
+		// The same cache lag that triggered the spurious Create can also hide
+		// the object from this Get. The API server already confirmed it exists,
+		// so treat the collision as harmless and let a later cycle re-evaluate
+		// ownership once the cache catches up.
+		if apierrs.IsNotFound(getErr) {
+			return nil
+		}
+		return fmt.Errorf("while verifying pre-existing VolumeSnapshot %s: %w", snapshot.Name, getErr)
+	}
+	if existing.Labels[utils.BackupNameLabelName] != backup.Name {
+		return fmt.Errorf("VolumeSnapshot %s already exists and is not owned by backup %s: %w",
+			snapshot.Name, backup.Name, err)
+	}
+
+	log.FromContext(ctx).Info(
+		"VolumeSnapshot for this backup already exists, reusing it",
+		"snapshotName", snapshot.Name,
+		"backupName", backup.Name)
 
 	return nil
 }

--- a/pkg/reconciler/backup/volumesnapshot/reconciler_test.go
+++ b/pkg/reconciler/backup/volumesnapshot/reconciler_test.go
@@ -391,6 +391,53 @@ var _ = Describe("Volumesnapshot reconciler", func() {
 			Expect(snapshot.Labels).To(HaveKeyWithValue(utils.MajorVersionLabelName, "18"))
 		}
 	})
+
+	It("reuses a pre-existing VolumeSnapshot that belongs to the backup", func(ctx SpecContext) {
+		// Simulate the cached-list-lag race: a VolumeSnapshot we created in a
+		// previous reconciliation cycle already exists, carrying this backup's
+		// label, but the Create call collides with it.
+		existing := &volumesnapshotv1.VolumeSnapshot{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: namespace,
+				Name:      persistentvolumeclaim.NewPgDataCalculator().GetSnapshotName(backup.Name),
+				Labels: map[string]string{
+					utils.BackupNameLabelName: backup.Name,
+				},
+			},
+		}
+
+		mockClient := fake.NewClientBuilder().
+			WithScheme(scheme.BuildWithAllKnownScheme()).
+			WithObjects(backup, cluster, targetPod, existing).
+			Build()
+
+		executor := NewReconcilerBuilder(mockClient, record.NewFakeRecorder(3)).Build()
+
+		err := executor.createSnapshot(ctx, cluster, backup, targetPod, &pvcs[0])
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("fails when a foreign VolumeSnapshot collides with the backup name", func(ctx SpecContext) {
+		// A VolumeSnapshot with the same name exists but does not belong to
+		// this backup: the collision must surface as an error instead of
+		// looping forever.
+		existing := &volumesnapshotv1.VolumeSnapshot{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: namespace,
+				Name:      persistentvolumeclaim.NewPgDataCalculator().GetSnapshotName(backup.Name),
+			},
+		}
+
+		mockClient := fake.NewClientBuilder().
+			WithScheme(scheme.BuildWithAllKnownScheme()).
+			WithObjects(backup, cluster, targetPod, existing).
+			Build()
+
+		executor := NewReconcilerBuilder(mockClient, record.NewFakeRecorder(3)).Build()
+
+		err := executor.createSnapshot(ctx, cluster, backup, targetPod, &pvcs[0])
+		Expect(err).To(HaveOccurred())
+	})
 })
 
 var _ = Describe("transferLabelsToAnnotations", func() {

--- a/pkg/reconciler/backup/volumesnapshot/reconciler_test.go
+++ b/pkg/reconciler/backup/volumesnapshot/reconciler_test.go
@@ -28,12 +28,15 @@ import (
 
 	volumesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
 	k8client "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/internal/scheme"
@@ -436,7 +439,42 @@ var _ = Describe("Volumesnapshot reconciler", func() {
 		executor := NewReconcilerBuilder(mockClient, record.NewFakeRecorder(3)).Build()
 
 		err := executor.createSnapshot(ctx, cluster, backup, targetPod, &pvcs[0])
-		Expect(err).To(HaveOccurred())
+		Expect(apierrs.IsAlreadyExists(err)).To(BeTrue())
+		Expect(err.Error()).To(ContainSubstring("is not owned by backup"))
+	})
+
+	It("tolerates an AlreadyExists collision the cache still hides on Get", func(ctx SpecContext) {
+		// The cache lag that made the reconciler attempt the Create can also
+		// keep the object hidden from the follow-up Get. The API server already
+		// confirmed it exists via AlreadyExists, so the collision must be
+		// tolerated instead of failing the backup.
+		mockClient := interceptor.NewClient(
+			fake.NewClientBuilder().
+				WithScheme(scheme.BuildWithAllKnownScheme()).
+				WithObjects(backup, cluster, targetPod).
+				Build(),
+			interceptor.Funcs{
+				Create: func(
+					_ context.Context, _ k8client.WithWatch, obj k8client.Object, _ ...k8client.CreateOption,
+				) error {
+					return apierrs.NewAlreadyExists(
+						schema.GroupResource{Group: volumesnapshotv1.GroupName, Resource: "volumesnapshots"},
+						obj.GetName())
+				},
+				Get: func(
+					_ context.Context, _ k8client.WithWatch, key k8client.ObjectKey,
+					_ k8client.Object, _ ...k8client.GetOption,
+				) error {
+					return apierrs.NewNotFound(
+						schema.GroupResource{Group: volumesnapshotv1.GroupName, Resource: "volumesnapshots"},
+						key.Name)
+				},
+			})
+
+		executor := NewReconcilerBuilder(mockClient, record.NewFakeRecorder(3)).Build()
+
+		err := executor.createSnapshot(ctx, cluster, backup, targetPod, &pvcs[0])
+		Expect(err).ToNot(HaveOccurred())
 	})
 })
 


### PR DESCRIPTION
To decide whether to create the snapshots for a declarative VolumeSnapshot backup, the operator lists the existing snapshots through the cached client. When that cached list lags behind a snapshot created in a previous reconciliation cycle, the operator issues a Create that fails with AlreadyExists. Since volume snapshot errors are treated as non retryable, the backup was permanently marked as failed.

Tolerate AlreadyExists when the colliding snapshot carries this backup's label: the reconciliation loop requeues and adopts it through the label selector. A name collision with a foreign snapshot still surfaces as an error instead of looping forever.

Closes #11070
