### PR TITLE
fix(webhook): reject slotPrefix that overflows the replication slot n…

### DIFF
--- a/internal/webhook/v1/cluster_webhook.go
+++ b/internal/webhook/v1/cluster_webhook.go
@@ -2325,16 +2325,39 @@ func (v *ClusterCustomValidator) validateReplicationSlots(r *apiv1.Cluster) fiel
 		return nil
 	}
 
-	if err := r.Spec.ReplicationSlots.SynchronizeReplicas.ValidateRegex(); err != nil {
-		return field.ErrorList{
-			field.Invalid(
-				field.NewPath("spec", "replicationSlots", "synchronizeReplicas", "excludePatterns"),
-				err,
-				"Cannot configure synchronizeReplicas. Invalid regexes were found"),
-		}
+	var result field.ErrorList
+
+	if err := replicationSlots.SynchronizeReplicas.ValidateRegex(); err != nil {
+		result = append(result, field.Invalid(
+			field.NewPath("spec", "replicationSlots", "synchronizeReplicas", "excludePatterns"),
+			err,
+			"Cannot configure synchronizeReplicas. Invalid regexes were found"))
 	}
 
-	return nil
+	// When HA replication slots are enabled the operator derives a slot name for
+	// every instance as "<slotPrefix><instanceName>". PostgreSQL rejects
+	// replication slot names longer than NAMEDATALEN-1 (63) characters, so reject
+	// at admission a slotPrefix that would push the longest possible slot name
+	// past that limit. The highest node serial a cluster can assign equals its
+	// number of instances: serials are kept contiguous because new instances
+	// fill the lowest free serial (generateNodeSerial) and scale-down always
+	// removes the highest serial (findDeletableInstance). The instance with the
+	// highest serial therefore has the longest instance name, and so the longest
+	// slot name, the cluster can produce. GetSlotNameFromInstanceName returns an
+	// empty string when HA slots are disabled, so this is a no-op in that case.
+	longestInstanceName := specs.GetInstanceName(r.Name, r.Spec.Instances)
+	if slotName := r.GetSlotNameFromInstanceName(longestInstanceName); len(slotName) > postgres.PostgresIdentifierMaxLen {
+		result = append(result, field.Invalid(
+			field.NewPath("spec", "replicationSlots", "highAvailability", "slotPrefix"),
+			replicationSlots.HighAvailability.SlotPrefix,
+			fmt.Sprintf(
+				"the generated replication slot name %q is %d characters long, which exceeds the "+
+					"PostgreSQL limit of %d: use a shorter slotPrefix",
+				slotName, len(slotName), postgres.PostgresIdentifierMaxLen),
+		))
+	}
+
+	return result
 }
 
 func (v *ClusterCustomValidator) validateSynchronizeLogicalDecoding(r *apiv1.Cluster) field.ErrorList {

--- a/internal/webhook/v1/cluster_webhook_test.go
+++ b/internal/webhook/v1/cluster_webhook_test.go
@@ -3881,6 +3881,103 @@ var _ = Describe("validation of replication slots configuration", func() {
 		Expect(result).To(BeEmpty())
 	})
 
+	It("rejects a slotPrefix that makes the HA slot name exceed the PostgreSQL limit", func() {
+		cluster := &apiv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{Name: "cluster-name"},
+			Spec: apiv1.ClusterSpec{
+				Instances: 3,
+				ReplicationSlots: &apiv1.ReplicationSlotsConfiguration{
+					HighAvailability: &apiv1.ReplicationSlotsHAConfiguration{
+						Enabled:    ptr.To(true),
+						SlotPrefix: strings.Repeat("a", 60),
+					},
+				},
+			},
+		}
+
+		result := v.validateReplicationSlots(cluster)
+		Expect(result).To(HaveLen(1))
+		Expect(result[0].Field).To(Equal("spec.replicationSlots.highAvailability.slotPrefix"))
+	})
+
+	// Boundary: with cluster name "c" and a single instance the instance name is
+	// "c-1" (3 characters), so a 60-character prefix yields a 63-character slot
+	// name (the maximum PostgreSQL allows) and a 61-character prefix yields 64.
+	It("accepts a slotPrefix whose slot name is exactly at the 63-character limit", func() {
+		cluster := &apiv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{Name: "c"},
+			Spec: apiv1.ClusterSpec{
+				Instances: 1,
+				ReplicationSlots: &apiv1.ReplicationSlotsConfiguration{
+					HighAvailability: &apiv1.ReplicationSlotsHAConfiguration{
+						Enabled:    ptr.To(true),
+						SlotPrefix: strings.Repeat("a", 60),
+					},
+				},
+			},
+		}
+
+		result := v.validateReplicationSlots(cluster)
+		Expect(result).To(BeEmpty())
+	})
+
+	It("rejects a slotPrefix whose slot name is one character over the limit", func() {
+		cluster := &apiv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{Name: "c"},
+			Spec: apiv1.ClusterSpec{
+				Instances: 1,
+				ReplicationSlots: &apiv1.ReplicationSlotsConfiguration{
+					HighAvailability: &apiv1.ReplicationSlotsHAConfiguration{
+						Enabled:    ptr.To(true),
+						SlotPrefix: strings.Repeat("a", 61),
+					},
+				},
+			},
+		}
+
+		result := v.validateReplicationSlots(cluster)
+		Expect(result).To(HaveLen(1))
+		Expect(result[0].Field).To(Equal("spec.replicationSlots.highAvailability.slotPrefix"))
+	})
+
+	It("accepts the default slotPrefix with a maximum-length cluster name", func() {
+		cluster := &apiv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{Name: strings.Repeat("a", 50)},
+			Spec: apiv1.ClusterSpec{
+				Instances: 3,
+				ReplicationSlots: &apiv1.ReplicationSlotsConfiguration{
+					HighAvailability: &apiv1.ReplicationSlotsHAConfiguration{
+						Enabled: ptr.To(true),
+					},
+				},
+			},
+		}
+
+		result := v.validateReplicationSlots(cluster)
+		Expect(result).To(BeEmpty())
+	})
+
+	It("ignores slotPrefix length when HA replication slots are disabled", func() {
+		cluster := &apiv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{Name: "cluster-name"},
+			Spec: apiv1.ClusterSpec{
+				Instances: 3,
+				ReplicationSlots: &apiv1.ReplicationSlotsConfiguration{
+					HighAvailability: &apiv1.ReplicationSlotsHAConfiguration{
+						Enabled:    ptr.To(false),
+						SlotPrefix: strings.Repeat("a", 60),
+					},
+					SynchronizeReplicas: &apiv1.SynchronizeReplicasConfiguration{
+						Enabled: ptr.To(true),
+					},
+				},
+			},
+		}
+
+		result := v.validateReplicationSlots(cluster)
+		Expect(result).To(BeEmpty())
+	})
+
 	It("allows enabling replication slots on the fly", func() {
 		oldCluster := &apiv1.Cluster{
 			Spec: apiv1.ClusterSpec{

--- a/pkg/postgres/identifier.go
+++ b/pkg/postgres/identifier.go
@@ -28,8 +28,9 @@ import (
 )
 
 const (
-	// postgresIdentifierMaxLen is the maximum length PostgreSQL allows for identifiers
-	postgresIdentifierMaxLen int = 63
+	// PostgresIdentifierMaxLen is the maximum length PostgreSQL allows for identifiers
+	// (NAMEDATALEN - 1). It also bounds the length of replication slot names.
+	PostgresIdentifierMaxLen int = 63
 
 	// SystemTablespacesPrefix is the prefix denoting tablespaces managed by the Postgres system
 	// see https://www.postgresql.org/docs/current/sql-createtablespace.html
@@ -51,7 +52,7 @@ func IsTablespaceNameValid(name string) (bool, error) {
 			"alphanumeric characters, '_', '$', and must start with a letter or an underscore")
 	}
 
-	if len(name) > postgresIdentifierMaxLen {
+	if len(name) > PostgresIdentifierMaxLen {
 		return false, fmt.Errorf("the maximum length of an identifier is 63 characters")
 	}
 


### PR DESCRIPTION
…ame length

The Cluster name is capped at 50 characters so derived object names stay within PostgreSQL limits, but spec.replicationSlots.highAvailability.slotPrefix was only validated for allowed characters, not for length. HA replication slot names are built as "<slotPrefix><instanceName>" with no truncation, so a long prefix produced a slot name longer than PostgreSQL's 63-character limit (NAMEDATALEN-1). The webhook accepted the spec, but pg_create_physical_replication_slot rejected the name at runtime, so the HA slots were never created.

Validate in validateReplicationSlots that the longest slot name the cluster can generate (using the highest assignable node serial, which equals the instance count) stays within the limit, and reject the slotPrefix otherwise. Export the existing PostgresIdentifierMaxLen constant as the single source for the 63-char bound. Add unit tests covering overflow, the default prefix at the maximum cluster-name length, and the HA-disabled no-op case.

Closes #11072