### PR TITLE
fix(backup): allow backup from primary with old minor image during su…

### DIFF
--- a/internal/controller/backup_controller.go
+++ b/internal/controller/backup_controller.go
@@ -927,7 +927,15 @@ func (r *BackupReconciler) getBackupTargetPod(ctx context.Context, //nolint: goc
 			return nil, err
 		}
 
-		if !podHasLatestMajorImage(&pod) {
+		// Block backup only when a major-version upgrade is in progress; the
+		// primary's data directory is incompatible with the new image until
+		// pg_upgrade completes. During a minor image update with
+		// primaryUpdateStrategy=supervised the primary may still run the old
+		// minor image while cluster.Status.Image has already advanced; minor
+		// version differences do not affect backup correctness because the
+		// PostgreSQL data format is compatible within the same major version.
+		if cluster.Status.PGDataImageInfo != nil &&
+			cluster.Status.Image != cluster.Status.PGDataImageInfo.Image {
 			return nil, ErrPrimaryImageNeedsUpdate
 		}
 		targetPod = &pod

--- a/internal/controller/backup_controller_test.go
+++ b/internal/controller/backup_controller_test.go
@@ -265,6 +265,125 @@ func (f *fakeInstanceStatusClient) GetStatusFromInstances(
 	return postgres.PostgresqlStatusList{Items: items}
 }
 
+var _ = Describe("getBackupTargetPod supervised image update", func() {
+	var env *testingEnvironment
+	BeforeEach(func() {
+		env = buildTestEnvironment()
+		env.backupReconciler.instanceStatusClient = &fakeInstanceStatusClient{}
+	})
+
+	It("allows backup from primary with old minor image when cluster is mid-minor-update", func(ctx context.Context) {
+		namespace := newFakeNamespace(env.client)
+
+		oldImage := "postgres:16.1"
+		newImage := "postgres:16.2"
+
+		cluster := &apiv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "cluster-example",
+				Namespace: namespace,
+			},
+			Status: apiv1.ClusterStatus{
+				TargetPrimary: "cluster-example-1",
+				Image:         newImage,
+				PGDataImageInfo: &apiv1.ImageInfo{
+					// Minor update: PGDataImageInfo and Image are updated together to newImage
+					Image:        newImage,
+					MajorVersion: 16,
+				},
+			},
+		}
+		Expect(env.backupReconciler.Create(ctx, cluster)).To(Succeed())
+		Expect(env.backupReconciler.Status().Update(ctx, cluster)).To(Succeed())
+
+		backup := &apiv1.Backup{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "backup-example",
+				Namespace: namespace,
+			},
+			Spec: apiv1.BackupSpec{
+				Cluster: apiv1.LocalObjectReference{Name: cluster.Name},
+				Target:  apiv1.BackupTargetPrimary,
+			},
+		}
+		Expect(env.backupReconciler.Create(ctx, backup)).To(Succeed())
+
+		// Primary pod still runs the old minor image (supervised update not yet applied)
+		primaryPod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "cluster-example-1",
+				Namespace: namespace,
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{Name: "postgres", Image: oldImage},
+				},
+			},
+		}
+		Expect(env.backupReconciler.Create(ctx, primaryPod)).To(Succeed())
+
+		// Minor image mismatch must not block backup: same major version, data format compatible
+		podStatus, err := env.backupReconciler.getBackupTargetPod(ctx, cluster, backup)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(podStatus).ToNot(BeNil())
+		Expect(podStatus.Pod.Name).To(Equal("cluster-example-1"))
+	})
+
+	It("blocks backup when a major-version upgrade is in progress", func(ctx context.Context) {
+		namespace := newFakeNamespace(env.client)
+
+		oldMajorImage := "postgres:16.6"
+		newMajorImage := "postgres:17.0"
+
+		cluster := &apiv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "cluster-example",
+				Namespace: namespace,
+			},
+			Status: apiv1.ClusterStatus{
+				TargetPrimary: "cluster-example-1",
+				Image:         newMajorImage,
+				PGDataImageInfo: &apiv1.ImageInfo{
+					// Major upgrade: PGDataImageInfo stays at old image until pg_upgrade completes
+					Image:        oldMajorImage,
+					MajorVersion: 16,
+				},
+			},
+		}
+		Expect(env.backupReconciler.Create(ctx, cluster)).To(Succeed())
+		Expect(env.backupReconciler.Status().Update(ctx, cluster)).To(Succeed())
+
+		backup := &apiv1.Backup{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "backup-example",
+				Namespace: namespace,
+			},
+			Spec: apiv1.BackupSpec{
+				Cluster: apiv1.LocalObjectReference{Name: cluster.Name},
+				Target:  apiv1.BackupTargetPrimary,
+			},
+		}
+		Expect(env.backupReconciler.Create(ctx, backup)).To(Succeed())
+
+		primaryPod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "cluster-example-1",
+				Namespace: namespace,
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{Name: "postgres", Image: oldMajorImage},
+				},
+			},
+		}
+		Expect(env.backupReconciler.Create(ctx, primaryPod)).To(Succeed())
+
+		// Major version upgrade must block backup entirely
+		_, err := env.backupReconciler.getBackupTargetPod(ctx, cluster, backup)
+		Expect(errors.Is(err, ErrPrimaryImageNeedsUpdate)).To(BeTrue())
+	})
+})
+
 var _ = Describe("backup_controller volumeSnapshot unit tests", func() {
 	When("there's a running backup", func() {
 		It("prevents concurrent backups", func() {

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -79,6 +79,12 @@ func buildTestEnvironment() *testingEnvironment {
 		WithStatusSubresource(&apiv1.Cluster{}, &apiv1.Backup{}, &apiv1.Pooler{}, &corev1.Service{},
 			&corev1.ConfigMap{}, &corev1.Secret{}).
 		WithIndex(&batchv1.Job{}, jobOwnerKey, jobOwnerIndexFunc).
+		WithIndex(&corev1.Pod{}, podOwnerKey, func(rawObj client.Object) []string {
+			if ownerName, ok := IsOwnedByCluster(rawObj); ok {
+				return []string{ownerName}
+			}
+			return nil
+		}).
 		WithIndex(&apiv1.Backup{}, ".spec.cluster.name", func(rawObj client.Object) []string {
 			return []string{rawObj.(*apiv1.Backup).Spec.Cluster.Name}
 		}).


### PR DESCRIPTION
…pervised update

When primaryUpdateStrategy=supervised is in use, the primary pod keeps the old image while cluster.Status.Image has already been bumped to the new minor (or digest-only) image. getBackupTargetPod used podHasLatestMajorImage in the primary fallback path, which checks the pod's container image against cluster.Status.Image and returns ErrPrimaryImageNeedsUpdate for any mismatch — not just major-version upgrades.

This caused backups to remain in Pending state indefinitely and retry every 30 s until the supervised switchover completed, breaking RPO commitments on clusters with hourly backup schedules.

Fix: in the fallback path, only block backup when cluster.Status.PGDataImageInfo and cluster.Status.Image differ (the definitive signal for a major-version upgrade in progress). Minor image differences are safe because PostgreSQL data-directory format is compatible within the same major version, and WAL archiving already continues from the same primary pod in this state.

Add two unit tests that cover the new behaviour:
  - minor image update: primary with old minor image must be elected
  - major upgrade: primary must still be rejected

Closes #10863