### PR TITLE
test(e2e): port timeline divergence protection test to plugin-barman-cloud

### DIFF
--- a/tests/e2e/backup_restore_objectstore_test.go
+++ b/tests/e2e/backup_restore_objectstore_test.go
@@ -721,7 +721,10 @@ var _ = Describe("Object storage - Backup and restore", Label(tests.LabelBackupR
 			By("verifying second cluster is on timeline 2", func() {
 				Eventually(func() (int, error) {
 					cluster, err := clusterutils.Get(env.Ctx, env.Client, namespace, secondClusterName)
-					return cluster.Status.TimelineID, err
+					if err != nil {
+						return 0, err
+					}
+					return cluster.Status.TimelineID, nil
 				}, 60).Should(BeEquivalentTo(2))
 			})
 
@@ -759,6 +762,12 @@ var _ = Describe("Object storage - Backup and restore", Label(tests.LabelBackupR
 					firstClusterName,
 					testTimeouts[timeouts.ClusterIsReadyQuick],
 				)
+			})
+
+			By("verifying first cluster stayed on timeline 1", func() {
+				cluster, err := clusterutils.Get(env.Ctx, env.Client, namespace, firstClusterName)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(cluster.Status.TimelineID).To(BeEquivalentTo(1))
 			})
 
 			By("deleting the first cluster", func() {

--- a/tests/e2e/fixtures/plugin_barman_cloud/timeline_divergence/backup-plugin-tl-divergence.yaml
+++ b/tests/e2e/fixtures/plugin_barman_cloud/timeline_divergence/backup-plugin-tl-divergence.yaml
@@ -1,0 +1,10 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Backup
+metadata:
+  name: backup-plugin-tl-divergence
+spec:
+  cluster:
+    name: cluster-timeline-1
+  method: plugin
+  pluginConfiguration:
+    name: barman-cloud.cloudnative-pg.io

--- a/tests/e2e/fixtures/plugin_barman_cloud/timeline_divergence/cluster-plugin-tl-divergence-1.yaml.template
+++ b/tests/e2e/fixtures/plugin_barman_cloud/timeline_divergence/cluster-plugin-tl-divergence-1.yaml.template
@@ -1,0 +1,27 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: cluster-timeline-1
+spec:
+  instances: 1
+
+  postgresql:
+    parameters:
+      log_checkpoints: "on"
+      log_lock_waits: "on"
+      log_min_duration_statement: '1000'
+      log_statement: 'ddl'
+      log_temp_files: '1024'
+      log_autovacuum_min_duration: '1s'
+      log_replication_commands: 'on'
+
+  storage:
+    storageClass: ${E2E_DEFAULT_STORAGE_CLASS}
+    size: 1Gi
+
+  plugins:
+    - name: barman-cloud.cloudnative-pg.io
+      isWALArchiver: true
+      parameters:
+        barmanObjectName: shared-timeline
+        serverName: shared-timeline-test

--- a/tests/e2e/fixtures/plugin_barman_cloud/timeline_divergence/cluster-plugin-tl-divergence-2.yaml.template
+++ b/tests/e2e/fixtures/plugin_barman_cloud/timeline_divergence/cluster-plugin-tl-divergence-2.yaml.template
@@ -1,0 +1,41 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: cluster-timeline-2
+  annotations:
+    cnpg.io/skipEmptyWalArchiveCheck: enabled
+spec:
+  instances: 1
+
+  postgresql:
+    parameters:
+      log_checkpoints: "on"
+      log_lock_waits: "on"
+      log_min_duration_statement: '1000'
+      log_statement: 'ddl'
+      log_temp_files: '1024'
+      log_autovacuum_min_duration: '1s'
+      log_replication_commands: 'on'
+
+  storage:
+    storageClass: ${E2E_DEFAULT_STORAGE_CLASS}
+    size: 1Gi
+
+  bootstrap:
+    recovery:
+      source: source
+
+  externalClusters:
+    - name: source
+      plugin:
+        name: barman-cloud.cloudnative-pg.io
+        parameters:
+          barmanObjectName: shared-timeline
+          serverName: shared-timeline-test
+
+  plugins:
+    - name: barman-cloud.cloudnative-pg.io
+      isWALArchiver: true
+      parameters:
+        barmanObjectName: shared-timeline
+        serverName: shared-timeline-test

--- a/tests/e2e/plugin_barman_cloud_tl_divergence_test.go
+++ b/tests/e2e/plugin_barman_cloud_tl_divergence_test.go
@@ -100,7 +100,10 @@ var _ = Describe("plugin-barman-cloud timeline divergence protection",
 			By("verifying second cluster is on timeline 2", func() {
 				Eventually(func() (int, error) {
 					cluster, err := clusterutils.Get(env.Ctx, env.Client, namespace, secondClusterName)
-					return cluster.Status.TimelineID, err
+					if err != nil {
+						return 0, err
+					}
+					return cluster.Status.TimelineID, nil
 				}, 60).Should(BeEquivalentTo(2))
 			})
 
@@ -132,6 +135,12 @@ var _ = Describe("plugin-barman-cloud timeline divergence protection",
 					firstClusterName,
 					testTimeouts[timeouts.ClusterIsReadyQuick],
 				)
+			})
+
+			By("verifying first cluster stayed on timeline 1", func() {
+				cluster, err := clusterutils.Get(env.Ctx, env.Client, namespace, firstClusterName)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(cluster.Status.TimelineID).To(BeEquivalentTo(1))
 			})
 
 			By("deleting the first cluster", func() {

--- a/tests/e2e/plugin_barman_cloud_tl_divergence_test.go
+++ b/tests/e2e/plugin_barman_cloud_tl_divergence_test.go
@@ -36,14 +36,11 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-// Plugin port of the "timeline divergence" scenario:
-// two clusters archive through plugin-barman-cloud to a shared archive.
-// The second Cluster is on timeline 2 and archived a `00000002.history`
-// history file.
-// The test validates that the first Cluster can be scaled to 2 instances
-// successfully, preventing the new replica from downloading timeline history
-// files with timeline IDs greater than the first cluster's current timeline.
-// Runs on kind/k3d only, where the plugin and the shared object store are installed.
+// Plugin port of the in-core "timeline divergence protection" test:
+// verifies a replica refuses to adopt a timeline-history file for a
+// timeline ahead of its own cluster's, from an object store shared
+// with a second, already-diverged cluster.
+// Runs on kind/k3d only, where the plugin and shared store are set up.
 var _ = Describe("plugin-barman-cloud timeline divergence protection",
 	Label(tests.LabelPluginBarmanCloud, tests.LabelBackupRestore), func() {
 		const (
@@ -123,12 +120,10 @@ var _ = Describe("plugin-barman-cloud timeline divergence protection",
 			})
 
 			By("verifying new replica is streaming", func() {
-				// Critical: This verifies the replica successfully joins despite timeline 2
-				// history file existing in the shared archive. If the replica were to download
-				// the incompatible timeline 2 history file, PostgreSQL would crash with
-				// "requested timeline 2 is not a child of this server's history" and enter
-				// a crash-loop, causing this assertion to timeout. The validation logic must
-				// reject the future timeline file to allow the replica to join successfully.
+				// Confirms the timeline guard held: if the replica adopted the shared
+				// archive's timeline-2 history file, Postgres would crash-loop on
+				// "requested timeline 2 is not a child of this server's history",
+				// and this streaming check would time out instead of passing.
 				replicationasserts.AssertClusterStandbysAreStreaming(
 					env,
 					namespace,

--- a/tests/e2e/plugin_barman_cloud_tl_divergence_test.go
+++ b/tests/e2e/plugin_barman_cloud_tl_divergence_test.go
@@ -20,8 +20,6 @@ SPDX-License-Identifier: Apache-2.0
 package e2e
 
 import (
-	"k8s.io/client-go/util/retry"
-
 	"github.com/cloudnative-pg/cloudnative-pg/tests"
 	backupasserts "github.com/cloudnative-pg/cloudnative-pg/tests/internal/asserts/backup"
 	clusterasserts "github.com/cloudnative-pg/cloudnative-pg/tests/internal/asserts/cluster"
@@ -117,14 +115,7 @@ var _ = Describe("plugin-barman-cloud timeline divergence protection",
 			})
 
 			By("scaling first cluster to 2 instances", func() {
-				err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-					cluster, err := clusterutils.Get(env.Ctx, env.Client, namespace, firstClusterName)
-					if err != nil {
-						return err
-					}
-					cluster.Spec.Instances = 2
-					return env.Client.Update(env.Ctx, cluster)
-				})
+				err := clusterutils.ScaleSize(env.Ctx, env.Client, namespace, firstClusterName, 2)
 				Expect(err).ToNot(HaveOccurred())
 			})
 

--- a/tests/e2e/plugin_barman_cloud_tl_divergence_test.go
+++ b/tests/e2e/plugin_barman_cloud_tl_divergence_test.go
@@ -1,0 +1,155 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package e2e
+
+import (
+	"k8s.io/client-go/util/retry"
+
+	"github.com/cloudnative-pg/cloudnative-pg/tests"
+	backupasserts "github.com/cloudnative-pg/cloudnative-pg/tests/internal/asserts/backup"
+	clusterasserts "github.com/cloudnative-pg/cloudnative-pg/tests/internal/asserts/cluster"
+	objectstoreasserts "github.com/cloudnative-pg/cloudnative-pg/tests/internal/asserts/objectstore"
+	replicationasserts "github.com/cloudnative-pg/cloudnative-pg/tests/internal/asserts/replication"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/internal/resources"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/backups"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/clusterutils"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/objectstore"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/timeouts"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/yaml"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// Plugin port of the "timeline divergence" scenario:
+// two clusters archive through plugin-barman-cloud to a shared archive.
+// The second Cluster is on timeline 2 and archived a `00000002.history`
+// history file.
+// The test validates that the first Cluster can be scaled to 2 instances
+// successfully, preventing the new replica from downloading timeline history
+// files with timeline IDs greater than the first cluster's current timeline.
+// Runs on kind/k3d only, where the plugin and the shared object store are installed.
+var _ = Describe("plugin-barman-cloud timeline divergence protection", Label(tests.LabelPluginBarmanCloud), func() {
+	const (
+		level                 = tests.High
+		sharedObjectStoreName = "shared-timeline"
+		sharedArchiveName     = "shared-timeline-test"
+		timelineFixturesDir   = fixturesDir + "/plugin_barman_cloud/timeline_divergence"
+		firstClusterFile      = timelineFixturesDir + "/cluster-plugin-tl-divergence-1.yaml.template"
+		secondClusterFile     = timelineFixturesDir + "/cluster-plugin-tl-divergence-2.yaml.template"
+		backupFile            = timelineFixturesDir + "/backup-plugin-tl-divergence.yaml"
+	)
+
+	BeforeEach(func() {
+		if testLevelEnv.Depth < int(level) {
+			Skip("Test depth is lower than the amount requested for this test")
+		}
+		if !(IsKind() || IsK3D()) {
+			Skip("This test only runs on kind or k3d clusters")
+		}
+	})
+
+	It("protects replicas from downloading future timeline history files", func() {
+		const namespacePrefix = "timeline-divergence"
+		namespace, err := env.CreateUniqueTestNamespace(env.Ctx, env.Client, namespacePrefix)
+		Expect(err).ToNot(HaveOccurred())
+
+		firstClusterName, err := yaml.GetResourceNameFromYAML(env.Scheme, firstClusterFile)
+		Expect(err).ToNot(HaveOccurred())
+		secondClusterName, err := yaml.GetResourceNameFromYAML(env.Scheme, secondClusterFile)
+		Expect(err).ToNot(HaveOccurred())
+
+		setupPluginObjectStore(namespace, sharedObjectStoreName)
+
+		By("creating first cluster with 1 instance", func() {
+			clusterasserts.AssertCreateCluster(env, testTimeouts, namespace, firstClusterName, firstClusterFile)
+		})
+
+		By("verifying WAL archiving through the plugin is working on the first Cluster", func() {
+			backupasserts.AssertArchiveConditionMet(env, namespace, firstClusterName, 120)
+		})
+
+		By("creating backup", func() {
+			backups.Execute(env.Ctx, env.Client, env.Scheme, namespace, backupFile, false,
+				testTimeouts[timeouts.BackupIsReady])
+		})
+
+		By("creating second cluster from backup", func() {
+			clusterasserts.AssertCreateCluster(env, testTimeouts, namespace, secondClusterName, secondClusterFile)
+		})
+
+		By("verifying WAL archiving through the plugin is working on the second Cluster", func() {
+			backupasserts.AssertArchiveConditionMet(env, namespace, secondClusterName, 120)
+		})
+
+		By("verifying second cluster is on timeline 2", func() {
+			Eventually(func() (int, error) {
+				cluster, err := clusterutils.Get(env.Ctx, env.Client, namespace, secondClusterName)
+				return cluster.Status.TimelineID, err
+			}, 60).Should(BeEquivalentTo(2))
+		})
+
+		By("verifying timeline 2 history file is archived", func() {
+			objectstoreasserts.AssertArchiveWalOnObjectStore(
+				env, testTimeouts, objectStoreEnv, namespace, secondClusterName, sharedArchiveName,
+			)
+			Eventually(func() (int, error) {
+				return objectstore.CountFiles(objectStoreEnv, objectstore.GetFilePath(sharedArchiveName, "00000002.history*"))
+			}, 60).Should(BeNumerically(">", 0))
+		})
+
+		By("scaling first cluster to 2 instances", func() {
+			err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+				cluster, err := clusterutils.Get(env.Ctx, env.Client, namespace, firstClusterName)
+				if err != nil {
+					return err
+				}
+				cluster.Spec.Instances = 2
+				return env.Client.Update(env.Ctx, cluster)
+			})
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		By("verifying new replica is streaming", func() {
+			// Critical: This verifies the replica successfully joins despite timeline 2
+			// history file existing in the shared archive. If the replica were to download
+			// the incompatible timeline 2 history file, PostgreSQL would crash with
+			// "requested timeline 2 is not a child of this server's history" and enter
+			// a crash-loop, causing this assertion to timeout. The validation logic must
+			// reject the future timeline file to allow the replica to join successfully.
+			replicationasserts.AssertClusterStandbysAreStreaming(
+				env,
+				namespace,
+				firstClusterName,
+				testTimeouts[timeouts.ClusterIsReadyQuick],
+			)
+		})
+
+		By("deleting the first cluster", func() {
+			err = resources.DeleteResourcesFromFile(env, namespace, firstClusterFile)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		By("deleting the second cluster", func() {
+			err = resources.DeleteResourcesFromFile(env, namespace, secondClusterFile)
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+})

--- a/tests/e2e/plugin_barman_cloud_tl_divergence_test.go
+++ b/tests/e2e/plugin_barman_cloud_tl_divergence_test.go
@@ -83,6 +83,9 @@ var _ = Describe("plugin-barman-cloud timeline divergence protection", Label(tes
 		})
 
 		By("verifying WAL archiving through the plugin is working on the first Cluster", func() {
+			objectstoreasserts.AssertArchiveWalOnObjectStore(
+				env, testTimeouts, objectStoreEnv, namespace, firstClusterName, sharedArchiveName,
+			)
 			backupasserts.AssertArchiveConditionMet(env, namespace, firstClusterName, 120)
 		})
 
@@ -93,10 +96,6 @@ var _ = Describe("plugin-barman-cloud timeline divergence protection", Label(tes
 
 		By("creating second cluster from backup", func() {
 			clusterasserts.AssertCreateCluster(env, testTimeouts, namespace, secondClusterName, secondClusterFile)
-		})
-
-		By("verifying WAL archiving through the plugin is working on the second Cluster", func() {
-			backupasserts.AssertArchiveConditionMet(env, namespace, secondClusterName, 120)
 		})
 
 		By("verifying second cluster is on timeline 2", func() {
@@ -110,6 +109,7 @@ var _ = Describe("plugin-barman-cloud timeline divergence protection", Label(tes
 			objectstoreasserts.AssertArchiveWalOnObjectStore(
 				env, testTimeouts, objectStoreEnv, namespace, secondClusterName, sharedArchiveName,
 			)
+			backupasserts.AssertArchiveConditionMet(env, namespace, secondClusterName, 120)
 			Eventually(func() (int, error) {
 				return objectstore.CountFiles(objectStoreEnv, objectstore.GetFilePath(sharedArchiveName, "00000002.history*"))
 			}, 60).Should(BeNumerically(">", 0))

--- a/tests/e2e/plugin_barman_cloud_tl_divergence_test.go
+++ b/tests/e2e/plugin_barman_cloud_tl_divergence_test.go
@@ -46,110 +46,111 @@ import (
 // successfully, preventing the new replica from downloading timeline history
 // files with timeline IDs greater than the first cluster's current timeline.
 // Runs on kind/k3d only, where the plugin and the shared object store are installed.
-var _ = Describe("plugin-barman-cloud timeline divergence protection", Label(tests.LabelPluginBarmanCloud), func() {
-	const (
-		level                 = tests.High
-		sharedObjectStoreName = "shared-timeline"
-		sharedArchiveName     = "shared-timeline-test"
-		timelineFixturesDir   = fixturesDir + "/plugin_barman_cloud/timeline_divergence"
-		firstClusterFile      = timelineFixturesDir + "/cluster-plugin-tl-divergence-1.yaml.template"
-		secondClusterFile     = timelineFixturesDir + "/cluster-plugin-tl-divergence-2.yaml.template"
-		backupFile            = timelineFixturesDir + "/backup-plugin-tl-divergence.yaml"
-	)
+var _ = Describe("plugin-barman-cloud timeline divergence protection",
+	Label(tests.LabelPluginBarmanCloud, tests.LabelBackupRestore), func() {
+		const (
+			level                 = tests.High
+			sharedObjectStoreName = "shared-timeline"
+			sharedArchiveName     = "shared-timeline-test"
+			timelineFixturesDir   = fixturesDir + "/plugin_barman_cloud/timeline_divergence"
+			firstClusterFile      = timelineFixturesDir + "/cluster-plugin-tl-divergence-1.yaml.template"
+			secondClusterFile     = timelineFixturesDir + "/cluster-plugin-tl-divergence-2.yaml.template"
+			backupFile            = timelineFixturesDir + "/backup-plugin-tl-divergence.yaml"
+		)
 
-	BeforeEach(func() {
-		if testLevelEnv.Depth < int(level) {
-			Skip("Test depth is lower than the amount requested for this test")
-		}
-		if !(IsKind() || IsK3D()) {
-			Skip("This test only runs on kind or k3d clusters")
-		}
-	})
-
-	It("protects replicas from downloading future timeline history files", func() {
-		const namespacePrefix = "timeline-divergence"
-		namespace, err := env.CreateUniqueTestNamespace(env.Ctx, env.Client, namespacePrefix)
-		Expect(err).ToNot(HaveOccurred())
-
-		firstClusterName, err := yaml.GetResourceNameFromYAML(env.Scheme, firstClusterFile)
-		Expect(err).ToNot(HaveOccurred())
-		secondClusterName, err := yaml.GetResourceNameFromYAML(env.Scheme, secondClusterFile)
-		Expect(err).ToNot(HaveOccurred())
-
-		setupPluginObjectStore(namespace, sharedObjectStoreName)
-
-		By("creating first cluster with 1 instance", func() {
-			clusterasserts.AssertCreateCluster(env, testTimeouts, namespace, firstClusterName, firstClusterFile)
+		BeforeEach(func() {
+			if testLevelEnv.Depth < int(level) {
+				Skip("Test depth is lower than the amount requested for this test")
+			}
+			if !(IsKind() || IsK3D()) {
+				Skip("This test only runs on kind or k3d clusters")
+			}
 		})
 
-		By("verifying WAL archiving through the plugin is working on the first Cluster", func() {
-			objectstoreasserts.AssertArchiveWalOnObjectStore(
-				env, testTimeouts, objectStoreEnv, namespace, firstClusterName, sharedArchiveName,
-			)
-			backupasserts.AssertArchiveConditionMet(env, namespace, firstClusterName, 120)
-		})
+		It("protects replicas from downloading future timeline history files", func() {
+			const namespacePrefix = "timeline-divergence"
+			namespace, err := env.CreateUniqueTestNamespace(env.Ctx, env.Client, namespacePrefix)
+			Expect(err).ToNot(HaveOccurred())
 
-		By("creating backup", func() {
-			backups.Execute(env.Ctx, env.Client, env.Scheme, namespace, backupFile, false,
-				testTimeouts[timeouts.BackupIsReady])
-		})
+			firstClusterName, err := yaml.GetResourceNameFromYAML(env.Scheme, firstClusterFile)
+			Expect(err).ToNot(HaveOccurred())
+			secondClusterName, err := yaml.GetResourceNameFromYAML(env.Scheme, secondClusterFile)
+			Expect(err).ToNot(HaveOccurred())
 
-		By("creating second cluster from backup", func() {
-			clusterasserts.AssertCreateCluster(env, testTimeouts, namespace, secondClusterName, secondClusterFile)
-		})
+			setupPluginObjectStore(namespace, sharedObjectStoreName)
 
-		By("verifying second cluster is on timeline 2", func() {
-			Eventually(func() (int, error) {
-				cluster, err := clusterutils.Get(env.Ctx, env.Client, namespace, secondClusterName)
-				return cluster.Status.TimelineID, err
-			}, 60).Should(BeEquivalentTo(2))
-		})
-
-		By("verifying timeline 2 history file is archived", func() {
-			objectstoreasserts.AssertArchiveWalOnObjectStore(
-				env, testTimeouts, objectStoreEnv, namespace, secondClusterName, sharedArchiveName,
-			)
-			backupasserts.AssertArchiveConditionMet(env, namespace, secondClusterName, 120)
-			Eventually(func() (int, error) {
-				return objectstore.CountFiles(objectStoreEnv, objectstore.GetFilePath(sharedArchiveName, "00000002.history*"))
-			}, 60).Should(BeNumerically(">", 0))
-		})
-
-		By("scaling first cluster to 2 instances", func() {
-			err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-				cluster, err := clusterutils.Get(env.Ctx, env.Client, namespace, firstClusterName)
-				if err != nil {
-					return err
-				}
-				cluster.Spec.Instances = 2
-				return env.Client.Update(env.Ctx, cluster)
+			By("creating first cluster with 1 instance", func() {
+				clusterasserts.AssertCreateCluster(env, testTimeouts, namespace, firstClusterName, firstClusterFile)
 			})
-			Expect(err).ToNot(HaveOccurred())
-		})
 
-		By("verifying new replica is streaming", func() {
-			// Critical: This verifies the replica successfully joins despite timeline 2
-			// history file existing in the shared archive. If the replica were to download
-			// the incompatible timeline 2 history file, PostgreSQL would crash with
-			// "requested timeline 2 is not a child of this server's history" and enter
-			// a crash-loop, causing this assertion to timeout. The validation logic must
-			// reject the future timeline file to allow the replica to join successfully.
-			replicationasserts.AssertClusterStandbysAreStreaming(
-				env,
-				namespace,
-				firstClusterName,
-				testTimeouts[timeouts.ClusterIsReadyQuick],
-			)
-		})
+			By("verifying WAL archiving through the plugin is working on the first Cluster", func() {
+				objectstoreasserts.AssertArchiveWalOnObjectStore(
+					env, testTimeouts, objectStoreEnv, namespace, firstClusterName, sharedArchiveName,
+				)
+				backupasserts.AssertArchiveConditionMet(env, namespace, firstClusterName, 120)
+			})
 
-		By("deleting the first cluster", func() {
-			err = resources.DeleteResourcesFromFile(env, namespace, firstClusterFile)
-			Expect(err).ToNot(HaveOccurred())
-		})
+			By("creating backup", func() {
+				backups.Execute(env.Ctx, env.Client, env.Scheme, namespace, backupFile, false,
+					testTimeouts[timeouts.BackupIsReady])
+			})
 
-		By("deleting the second cluster", func() {
-			err = resources.DeleteResourcesFromFile(env, namespace, secondClusterFile)
-			Expect(err).ToNot(HaveOccurred())
+			By("creating second cluster from backup", func() {
+				clusterasserts.AssertCreateCluster(env, testTimeouts, namespace, secondClusterName, secondClusterFile)
+			})
+
+			By("verifying second cluster is on timeline 2", func() {
+				Eventually(func() (int, error) {
+					cluster, err := clusterutils.Get(env.Ctx, env.Client, namespace, secondClusterName)
+					return cluster.Status.TimelineID, err
+				}, 60).Should(BeEquivalentTo(2))
+			})
+
+			By("verifying timeline 2 history file is archived", func() {
+				objectstoreasserts.AssertArchiveWalOnObjectStore(
+					env, testTimeouts, objectStoreEnv, namespace, secondClusterName, sharedArchiveName,
+				)
+				backupasserts.AssertArchiveConditionMet(env, namespace, secondClusterName, 120)
+				Eventually(func() (int, error) {
+					return objectstore.CountFiles(objectStoreEnv, objectstore.GetFilePath(sharedArchiveName, "00000002.history*"))
+				}, 60).Should(BeNumerically(">", 0))
+			})
+
+			By("scaling first cluster to 2 instances", func() {
+				err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+					cluster, err := clusterutils.Get(env.Ctx, env.Client, namespace, firstClusterName)
+					if err != nil {
+						return err
+					}
+					cluster.Spec.Instances = 2
+					return env.Client.Update(env.Ctx, cluster)
+				})
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			By("verifying new replica is streaming", func() {
+				// Critical: This verifies the replica successfully joins despite timeline 2
+				// history file existing in the shared archive. If the replica were to download
+				// the incompatible timeline 2 history file, PostgreSQL would crash with
+				// "requested timeline 2 is not a child of this server's history" and enter
+				// a crash-loop, causing this assertion to timeout. The validation logic must
+				// reject the future timeline file to allow the replica to join successfully.
+				replicationasserts.AssertClusterStandbysAreStreaming(
+					env,
+					namespace,
+					firstClusterName,
+					testTimeouts[timeouts.ClusterIsReadyQuick],
+				)
+			})
+
+			By("deleting the first cluster", func() {
+				err = resources.DeleteResourcesFromFile(env, namespace, firstClusterFile)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			By("deleting the second cluster", func() {
+				err = resources.DeleteResourcesFromFile(env, namespace, secondClusterFile)
+				Expect(err).ToNot(HaveOccurred())
+			})
 		})
 	})
-})


### PR DESCRIPTION
This ports the `timeline divergence protection` scenario from the in-core Barman Cloud integration to the plugin-barman-cloud CNPG-I plugin. The in-core variant is left in place until in-core Barman Cloud support is removed.

Also fixes a nil-pointer dereference risk in the timeline-check retry loop and adds a direct assertion that the first cluster's timeline doesn't advance, applied to both the new test and the in-core original.

Closes #11081