### PR TITLE
docs(webhook): update Barman Cloud notice to 1.31.0

### DIFF
--- a/internal/webhook/v1/cluster_webhook.go
+++ b/internal/webhook/v1/cluster_webhook.go
@@ -2748,7 +2748,7 @@ func getInTreeBarmanWarnings(r *apiv1.Cluster) admission.Warnings {
 		result = append(
 			result,
 			fmt.Sprintf("Native support for Barman Cloud backups and recovery is deprecated and will be "+
-				"completely removed in CloudNativePG 1.30.0. Found usage in: %s. "+
+				"completely removed in CloudNativePG 1.31.0. Found usage in: %s. "+
 				"Please migrate existing clusters to the new Barman Cloud Plugin to ensure a smooth transition.",
 				pathsStr),
 		)


### PR DESCRIPTION
The removal of native (in-tree) Barman Cloud support has been postponed again. This updates the admission warning to point to 1.31.0 instead of 1.30.0, mirroring #10167 which previously moved it from 1.29.0 to 1.30.0.

Backport to release-1.29 and release-1.28 only; release-1.25 does not carry this warning.