### PR TITLE
docs: update release notes for 1.30.0, 1.29.2, and 1.28.4

### DIFF
--- a/.wordlist-en-custom.txt
+++ b/.wordlist-en-custom.txt
@@ -1422,6 +1422,7 @@ reportNonRedacted
 reportRedacted
 req
 requestTimeout
+requeued
 requiredDuringSchedulingIgnoredDuringExecution
 resizeInUseVolumes
 resizingPVC

--- a/docs/src/release_notes.md
+++ b/docs/src/release_notes.md
@@ -18,8 +18,8 @@ refer to ["Supported releases"](supported_releases.md).
 
 Older releases:
 
-- [CloudNativePG 1.28](release_notes/v1.28.md)
-- [CloudNativePG 1.27](release_notes/v1.27.md)
+- [CloudNativePG 1.28](release_notes/old/v1.28.md)
+- [CloudNativePG 1.27](release_notes/old/v1.27.md)
 - [CloudNativePG 1.26](release_notes/old/v1.26.md)
 - [CloudNativePG 1.25](release_notes/old/v1.25.md)
 - [CloudNativePG 1.24](release_notes/old/v1.24.md)

--- a/docs/src/release_notes/old/v1.27.md
+++ b/docs/src/release_notes/old/v1.27.md
@@ -506,8 +506,8 @@ on the release branch in GitHub.
 
 ### Important changes
 
-- The default behavior of the [liveness probe](../instance_manager.md#liveness-probe) has been updated.
-  An [isolated primary is now forcibly shut down](../instance_manager.md#primary-isolation)
+- The default behavior of the [liveness probe](../../instance_manager.md#liveness-probe) has been updated.
+  An [isolated primary is now forcibly shut down](../../instance_manager.md#primary-isolation)
   within the configured `livenessProbeTimeout` (default: 30 seconds).
 
 ### Features

--- a/docs/src/release_notes/old/v1.28.md
+++ b/docs/src/release_notes/old/v1.28.md
@@ -308,9 +308,9 @@ is no longer supported.
     or use `target_databases: '*'` against databases where
     `PUBLIC CONNECT` has been revoked, need explicit `GRANT` statements to
     `cnpg_metrics_exporter`. See ["Custom query privileges and
-    safety"](../monitoring.md#custom-query-privileges-and-safety) and ["Manually
+    safety"](../../monitoring.md#custom-query-privileges-and-safety) and ["Manually
     creating the metrics exporter
-    role"](../monitoring.md#manually-creating-the-metrics-exporter-role)
+    role"](../../monitoring.md#manually-creating-the-metrics-exporter-role)
     in the monitoring documentation.
 
     For replica clusters, upgrade the source primary cluster before any

--- a/docs/src/release_notes/v1.28.md
+++ b/docs/src/release_notes/v1.28.md
@@ -23,6 +23,11 @@ is no longer supported.
 
 ### Important changes
 
+- Updated the deprecation notice for native (in-tree) Barman Cloud support to
+  reflect that it will now be removed in CloudNativePG 1.31.0, rather than
+  1.30.0. Users are still encouraged to migrate to the Barman Cloud Plugin.
+  ([#11083](https://github.com/cloudnative-pg/cloudnative-pg/pull/11083)) <!-- 1.29 1.28 -->
+
 - The `cluster` reference is now immutable on the `Database`, `Pooler`,
   `Publication`, `Subscription`, and `ScheduledBackup` resources. Pointing
   one of these objects at a different cluster has no well-defined semantics and
@@ -84,7 +89,8 @@ is no longer supported.
 - Updated the Kubernetes versions used to test the operator on public cloud
   providers.
   ([#10720](https://github.com/cloudnative-pg/cloudnative-pg/pull/10720), <!-- 1.29 1.28 1.25 -->
-  [#10563](https://github.com/cloudnative-pg/cloudnative-pg/pull/10563)) <!-- 1.29 1.28 1.25 -->
+  [#10563](https://github.com/cloudnative-pg/cloudnative-pg/pull/10563), <!-- 1.29 1.28 1.25 -->
+  [#11033](https://github.com/cloudnative-pg/cloudnative-pg/pull/11033)) <!-- 1.29 1.28 1.25 -->
 
 ### Fixes
 
@@ -108,8 +114,11 @@ is no longer supported.
   existing cluster: with `primaryUpdateMethod: switchover` the primary could
   not be rolled out because a clean demotion needs the archiver sidecar that is
   still missing. The operator now recreates the primary Pod in place so the
-  sidecar is injected and archiving resumes.
-  ([#11032](https://github.com/cloudnative-pg/cloudnative-pg/pull/11032)) <!-- 1.29 1.28 1.25 -->
+  sidecar is injected and archiving resumes. The check also covers plugins
+  that inject the archiver as a native sidecar (an init container with
+  `restartPolicy: Always`), such as the Barman Cloud plugin.
+  ([#11032](https://github.com/cloudnative-pg/cloudnative-pg/pull/11032), <!-- 1.29 1.28 1.25 -->
+  [#11059](https://github.com/cloudnative-pg/cloudnative-pg/pull/11059)) <!-- 1.29 1.28 1.25 -->
 
 - Fixed a cluster staying in `Setting up primary` indefinitely when the
   instance-creation Job exhausted its backoff limit; the operator now detects
@@ -247,6 +256,26 @@ is no longer supported.
   webhook and re-checked at the write site.
   Reported by @r0binak.
   ([#11045](https://github.com/cloudnative-pg/cloudnative-pg/pull/11045)) <!-- 1.29 1.28 1.25 -->
+
+- Fixed a declarative `VolumeSnapshot` backup being permanently marked as
+  failed when a stale cache made the operator re-create a snapshot it had
+  already provisioned, failing with `AlreadyExists`. The operator now tolerates
+  the collision when the existing snapshot carries this backup's label and
+  adopts it; a collision with a foreign snapshot still surfaces as an error.
+  ([#11071](https://github.com/cloudnative-pg/cloudnative-pg/pull/11071)) <!-- 1.29 1.28 1.25 -->
+
+- Fixed a volume snapshot backup being discarded on a transient
+  instance-manager connection error (for example a dial timeout from a brief
+  pod-network disruption) during the finalize step, even when its snapshots
+  were already provisioned; such network errors are now retried instead of
+  treated as terminal.
+  ([#11069](https://github.com/cloudnative-pg/cloudnative-pg/pull/11069)) <!-- 1.29 1.28 1.25 -->
+
+- Fixed a replica switchover losing its `status.demotionToken` when a reconcile
+  was requeued between storing the token and cleaning up the transition
+  metadata (for example a cleanup patch failing against a flaky webhook); the
+  empty no-change token is no longer patched back over the stored value.
+  ([#11075](https://github.com/cloudnative-pg/cloudnative-pg/pull/11075)) <!-- 1.29 1.28 1.25 -->
 
 - `cnpg` plugin:
 

--- a/docs/src/release_notes/v1.29.md
+++ b/docs/src/release_notes/v1.29.md
@@ -17,6 +17,11 @@ on the release branch in GitHub.
 
 ### Important changes
 
+- Updated the deprecation notice for native (in-tree) Barman Cloud support to
+  reflect that it will now be removed in CloudNativePG 1.31.0, rather than
+  1.30.0. Users are still encouraged to migrate to the Barman Cloud Plugin.
+  ([#11083](https://github.com/cloudnative-pg/cloudnative-pg/pull/11083)) <!-- 1.29 1.28 -->
+
 - The `cluster` reference is now immutable on the `Database`, `Pooler`,
   `Publication`, `Subscription`, and `ScheduledBackup` resources. Pointing
   one of these objects at a different cluster has no well-defined semantics and
@@ -85,7 +90,8 @@ on the release branch in GitHub.
 - Updated the Kubernetes versions used to test the operator on public cloud
   providers.
   ([#10720](https://github.com/cloudnative-pg/cloudnative-pg/pull/10720), <!-- 1.29 1.28 1.25 -->
-  [#10563](https://github.com/cloudnative-pg/cloudnative-pg/pull/10563)) <!-- 1.29 1.28 1.25 -->
+  [#10563](https://github.com/cloudnative-pg/cloudnative-pg/pull/10563), <!-- 1.29 1.28 1.25 -->
+  [#11033](https://github.com/cloudnative-pg/cloudnative-pg/pull/11033)) <!-- 1.29 1.28 1.25 -->
 
 ### Fixes
 
@@ -109,8 +115,11 @@ on the release branch in GitHub.
   existing cluster: with `primaryUpdateMethod: switchover` the primary could
   not be rolled out because a clean demotion needs the archiver sidecar that is
   still missing. The operator now recreates the primary Pod in place so the
-  sidecar is injected and archiving resumes.
-  ([#11032](https://github.com/cloudnative-pg/cloudnative-pg/pull/11032)) <!-- 1.29 1.28 1.25 -->
+  sidecar is injected and archiving resumes. The check also covers plugins
+  that inject the archiver as a native sidecar (an init container with
+  `restartPolicy: Always`), such as the Barman Cloud plugin.
+  ([#11032](https://github.com/cloudnative-pg/cloudnative-pg/pull/11032), <!-- 1.29 1.28 1.25 -->
+  [#11059](https://github.com/cloudnative-pg/cloudnative-pg/pull/11059)) <!-- 1.29 1.28 1.25 -->
 
 - Fixed a cluster staying in `Setting up primary` indefinitely when the
   instance-creation Job exhausted its backoff limit; the operator now detects
@@ -255,6 +264,32 @@ on the release branch in GitHub.
   webhook and re-checked at the write site.
   Reported by @r0binak.
   ([#11045](https://github.com/cloudnative-pg/cloudnative-pg/pull/11045)) <!-- 1.29 1.28 1.25 -->
+
+- Fixed a backup getting stuck in `pending` forever: the concurrent-backup
+  gate ran on every reconcile and could overwrite an already-completed phase
+  written asynchronously by the instance manager. The gate now runs only while
+  the backup phase is still unset or `pending`.
+  ([#11056](https://github.com/cloudnative-pg/cloudnative-pg/pull/11056)) <!-- 1.29 -->
+
+- Fixed a declarative `VolumeSnapshot` backup being permanently marked as
+  failed when a stale cache made the operator re-create a snapshot it had
+  already provisioned, failing with `AlreadyExists`. The operator now tolerates
+  the collision when the existing snapshot carries this backup's label and
+  adopts it; a collision with a foreign snapshot still surfaces as an error.
+  ([#11071](https://github.com/cloudnative-pg/cloudnative-pg/pull/11071)) <!-- 1.29 1.28 1.25 -->
+
+- Fixed a volume snapshot backup being discarded on a transient
+  instance-manager connection error (for example a dial timeout from a brief
+  pod-network disruption) during the finalize step, even when its snapshots
+  were already provisioned; such network errors are now retried instead of
+  treated as terminal.
+  ([#11069](https://github.com/cloudnative-pg/cloudnative-pg/pull/11069)) <!-- 1.29 1.28 1.25 -->
+
+- Fixed a replica switchover losing its `status.demotionToken` when a reconcile
+  was requeued between storing the token and cleaning up the transition
+  metadata (for example a cleanup patch failing against a flaky webhook); the
+  empty no-change token is no longer patched back over the stored value.
+  ([#11075](https://github.com/cloudnative-pg/cloudnative-pg/pull/11075)) <!-- 1.29 1.28 1.25 -->
 
 - `cnpg` plugin:
 

--- a/docs/src/release_notes/v1.30.md
+++ b/docs/src/release_notes/v1.30.md
@@ -17,6 +17,11 @@ on the release branch in GitHub.
 
 ### Important changes
 
+- Updated the deprecation notice for native (in-tree) Barman Cloud support to
+  reflect that it will now be removed in CloudNativePG 1.31.0, rather than
+  1.30.0. Users are still encouraged to migrate to the Barman Cloud Plugin.
+  ([#11083](https://github.com/cloudnative-pg/cloudnative-pg/pull/11083)) <!-- 1.29 1.28 -->
+
 - The `cluster` reference is now immutable on the `Database`, `Pooler`,
   `Publication`, `Subscription`, and `ScheduledBackup` resources. Pointing
   one of these objects at a different cluster has no well-defined semantics and
@@ -167,7 +172,8 @@ on the release branch in GitHub.
 - Updated the Kubernetes versions used to test the operator on public cloud
   providers.
   ([#10720](https://github.com/cloudnative-pg/cloudnative-pg/pull/10720), <!-- 1.29 1.28 1.25 -->
-  [#10563](https://github.com/cloudnative-pg/cloudnative-pg/pull/10563)) <!-- 1.29 1.28 1.25 -->
+  [#10563](https://github.com/cloudnative-pg/cloudnative-pg/pull/10563), <!-- 1.29 1.28 1.25 -->
+  [#11033](https://github.com/cloudnative-pg/cloudnative-pg/pull/11033)) <!-- 1.29 1.28 1.25 -->
 
 ### Fixes
 
@@ -323,8 +329,11 @@ on the release branch in GitHub.
   existing cluster: with `primaryUpdateMethod: switchover` the primary could
   not be rolled out because a clean demotion needs the archiver sidecar that is
   still missing. The operator now recreates the primary Pod in place so the
-  sidecar is injected and archiving resumes.
-  ([#11032](https://github.com/cloudnative-pg/cloudnative-pg/pull/11032)) <!-- 1.29 1.28 1.25 -->
+  sidecar is injected and archiving resumes. The check also covers plugins
+  that inject the archiver as a native sidecar (an init container with
+  `restartPolicy: Always`), such as the Barman Cloud plugin.
+  ([#11032](https://github.com/cloudnative-pg/cloudnative-pg/pull/11032), <!-- 1.29 1.28 1.25 -->
+  [#11059](https://github.com/cloudnative-pg/cloudnative-pg/pull/11059)) <!-- 1.29 1.28 1.25 -->
 
 - Fixed a cluster staying in `Setting up primary` indefinitely when the
   instance-creation Job exhausted its backoff limit; the operator now detects
@@ -346,6 +355,32 @@ on the release branch in GitHub.
   webhook and re-checked at the write site.
   Reported by @r0binak.
   ([#11045](https://github.com/cloudnative-pg/cloudnative-pg/pull/11045)) <!-- 1.29 1.28 1.25 -->
+
+- Fixed a backup getting stuck in `pending` forever: the concurrent-backup
+  gate ran on every reconcile and could overwrite an already-completed phase
+  written asynchronously by the instance manager. The gate now runs only while
+  the backup phase is still unset or `pending`.
+  ([#11056](https://github.com/cloudnative-pg/cloudnative-pg/pull/11056)) <!-- 1.29 -->
+
+- Fixed a declarative `VolumeSnapshot` backup being permanently marked as
+  failed when a stale cache made the operator re-create a snapshot it had
+  already provisioned, failing with `AlreadyExists`. The operator now tolerates
+  the collision when the existing snapshot carries this backup's label and
+  adopts it; a collision with a foreign snapshot still surfaces as an error.
+  ([#11071](https://github.com/cloudnative-pg/cloudnative-pg/pull/11071)) <!-- 1.29 1.28 1.25 -->
+
+- Fixed a volume snapshot backup being discarded on a transient
+  instance-manager connection error (for example a dial timeout from a brief
+  pod-network disruption) during the finalize step, even when its snapshots
+  were already provisioned; such network errors are now retried instead of
+  treated as terminal.
+  ([#11069](https://github.com/cloudnative-pg/cloudnative-pg/pull/11069)) <!-- 1.29 1.28 1.25 -->
+
+- Fixed a replica switchover losing its `status.demotionToken` when a reconcile
+  was requeued between storing the token and cleaning up the transition
+  metadata (for example a cleanup patch failing against a flaky webhook); the
+  empty no-change token is no longer patched back over the stored value.
+  ([#11075](https://github.com/cloudnative-pg/cloudnative-pg/pull/11075)) <!-- 1.29 1.28 1.25 -->
 
 - `cnpg` plugin:
 


### PR DESCRIPTION
Cover the user-facing changes merged after the initial release notes PR, propagated to the 1.29.2 and 1.28.4 sections according to their backport markers.

Also archive the now-EOL 1.27 and 1.28 release notes to the old directory.