### PR TITLE
fix(ci): scope change-triage to the pushed branch

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -123,7 +123,7 @@ jobs:
         id: filter
         # Remember to add new folders in the operator-changed filter if needed
         with:
-          base: ${{ (github.event_name == 'schedule') && 'main' || '' }}
+          base: ${{ (github.event_name == 'schedule' && 'main') || ((github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref_name) || '' }}
           filters: |
             docs-changed:
               - '**/*.md'


### PR DESCRIPTION
On release branches, the `change-triage` job in continuous-integration fails on every push with `fatal: shallow file has changed since we read it` (git exit 128).

The `dorny/paths-filter` step uses an empty `base` for non-schedule events. With an empty base the action defaults to the repository default branch (`main`). On `main` that equals the head, so it compares the last commit. On a release branch base (`main`) differs from head, so it switches to merge-base mode: it diffs the whole divergence of the release branch from `main` and has to deepen the shallow checkout, which trips the git 2.54.0 `shallow file has changed` bug and exits 128. This is both a misclassification of changed files and a hard, deterministic failure for every commit on a release branch.

Setting the base to the pushed branch (`github.ref_name`) for `push` and `workflow_dispatch` keeps base equal to head, so detection stays on the last commit regardless of the target branch. `pull_request` keeps the empty base (paths-filter uses the PR base itself) and `schedule` keeps comparing against `main`.