### PR TITLE
docs: warning about running multiple namespaced deployments

### DIFF
--- a/docs/src/operator_conf.md
+++ b/docs/src/operator_conf.md
@@ -79,6 +79,14 @@ The namespace where the operator looks for the `PULL_SECRET_NAME` secret is wher
 you installed the operator. If the operator is not able to find that secret, it
 will ignore the configuration parameter.
 
+!!! Warning
+    CloudNativePG does NOT currently support running multiple operators on
+    the same cluster. While this can be achieved through the use of namespaced
+    deployments using `ENABLE_WEBHOOK_NAMESPACE_SUFFIX` and `WATCH_NAMESPACE`,
+    multiple operators still use the same set of shared CRDs. We cannot
+    guarantee a backwards compatible upgrade across multiple concurrently
+    running operators.
+
 ## Defining an operator config map
 
 The example below customizes the behavior of the operator, by defining
@@ -222,14 +230,3 @@ You can also access pprof using the browser at [http://localhost:6060/debug/ppro
     Treat pprof as a sensitive debugging interface and never expose it publicly.
     If you must access it remotely, secure it with proper network policies and access controls.
 :::
-
-
-## Multiple Namespaced Deployments
-
-!!! Warning
-    CloudNativePG does NOT currently support running multiple operators on
-    the same cluster. While this can be achieved through the use of namespaced
-    deployments using `ENABLE_WEBHOOK_NAMESPACE_SUFFIX` and `WATCH_NAMESPACE`,
-    multiple operators still use the same set of shared CRDs. We cannot
-    guarantee a backwards compatible upgrade across multiple concurrently
-    running operators.

--- a/docs/src/operator_conf.md
+++ b/docs/src/operator_conf.md
@@ -68,6 +68,15 @@ Name | Description
 `STANDBY_TCP_USER_TIMEOUT` | Defines the [`TCP_USER_TIMEOUT` socket option](https://www.postgresql.org/docs/current/runtime-config-connection.html#GUC-TCP-USER-TIMEOUT) in milliseconds for replication connections from standby instances to the primary. Default is 5000 (5 seconds). Set to `0` to use the system's default.
 `WATCH_NAMESPACE` | Specifies the namespace(s) where the operator should watch for resources. Multiple namespaces can be specified separated by commas. If not set, the operator watches all namespaces (cluster-wide mode).
 
+:::warning
+    CloudNativePG does NOT currently support running multiple operators on
+    the same cluster. While this can be achieved through the use of namespaced
+    deployments using `ENABLE_WEBHOOK_NAMESPACE_SUFFIX` and `WATCH_NAMESPACE`,
+    multiple operators still use the same set of shared CRDs. We cannot
+    guarantee a backwards compatible upgrade across multiple concurrently
+    running operators.
+:::
+
 Values in `INHERITED_ANNOTATIONS` and `INHERITED_LABELS` support path-like wildcards. For example, the value `example.com/*` will match
 both the value `example.com/one` and `example.com/two`.
 
@@ -78,14 +87,6 @@ cluster. That secret will be named `<cluster-name>-pull`.
 The namespace where the operator looks for the `PULL_SECRET_NAME` secret is where
 you installed the operator. If the operator is not able to find that secret, it
 will ignore the configuration parameter.
-
-!!! Warning
-    CloudNativePG does NOT currently support running multiple operators on
-    the same cluster. While this can be achieved through the use of namespaced
-    deployments using `ENABLE_WEBHOOK_NAMESPACE_SUFFIX` and `WATCH_NAMESPACE`,
-    multiple operators still use the same set of shared CRDs. We cannot
-    guarantee a backwards compatible upgrade across multiple concurrently
-    running operators.
 
 ## Defining an operator config map
 

--- a/docs/src/operator_conf.md
+++ b/docs/src/operator_conf.md
@@ -222,3 +222,14 @@ You can also access pprof using the browser at [http://localhost:6060/debug/ppro
     Treat pprof as a sensitive debugging interface and never expose it publicly.
     If you must access it remotely, secure it with proper network policies and access controls.
 :::
+
+
+## Multiple Namespaced Deployments
+
+!!! Warning
+    CloudNativePG does NOT currently support running multiple operators on
+    the same cluster. While this can be achieved through the use of namespaced
+    deployments using `ENABLE_WEBHOOK_NAMESPACE_SUFFIX` and `WATCH_NAMESPACE`,
+    multiple operators still use the same set of shared CRDs. We cannot
+    guarantee a backwards compatible upgrade across multiple concurrently
+    running operators.


### PR DESCRIPTION
CloudNativePG does not support running multiple operators on the same Kubernetes cluster. Namespaced deployments via `ENABLE_WEBHOOK_NAMESPACE_SUFFIX` and `WATCH_NAMESPACE` make this technically possible, but all operator instances still share the same cluster-scoped CRDs, so a backwards-compatible upgrade across concurrently running operators cannot be guaranteed.

This adds a warning to the operator configuration documentation to make that limitation explicit.