### PR TITLE
feat: add ToMegabytes generic function for byte-to-MB conversion

### DIFF
--- a/pkg/utils/math.go
+++ b/pkg/utils/math.go
@@ -45,3 +45,11 @@ func ToBytes[T anyNumber](mb T) float64 {
 	multiplier := float64(1024)
 	return float64(mb) * multiplier * multiplier
 }
+
+// ToMegabytes converts an input value in bytes to MB
+// Input: value - a number representing size in bytes
+// Output: the size in megabytes, calculated by dividing the input value by 1024 * 1024
+func ToMegabytes[T anyNumber](bytes T) float64 {
+	divisor := float64(1024)
+	return float64(bytes) / (divisor * divisor)
+}


### PR DESCRIPTION
## Description

Adds a `ToMegabytes[T anyNumber]` generic function to `pkg/utils/math.go` as the
inverse of the existing `ToBytes[T]` function.

## Motivation

The `pkg/utils/math.go` utility package provides `ToBytes` for MB → bytes
conversion but lacks the inverse bytes → MB operation. This creates an
asymmetric API surface where callers must write ad-hoc division logic.

This PR completes the conversion pair, following the same generic constraint
pattern and documentation style.

## Changes

- **`pkg/utils/math.go`**: Added `ToMegabytes[T anyNumber](<bytes T>) float64`
  that divides by `1024 * 1024` to convert bytes to mebibytes.

## Testing

- [x] `go build ./...` passes
- [x] Verified the function produces correct results:
  - `ToMegabytes(1048576)` → `1.0`
  - `ToMegabytes(0)` → `0.0`
  - `ToMegabytes(ToBytes(5))` → `5.0` (round-trip)

## Checklist

- [x] Code follows the project's style guidelines
- [x] GoDoc comments added following existing patterns
- [x] No breaking changes introduced
- [x] Signed-off-by line included in commit

Signed-off-by:saiashok103@gmail.com
