### PR TITLE
docs: fix missing space in GetInstanceRole GoDoc comment

### DIFF
--- a/pkg/utils/labels_annotations.go
+++ b/pkg/utils/labels_annotations.go
@@ -556,7 +556,7 @@ func IsPasswordPassthroughEnabled(object *metav1.ObjectMeta) bool {
 	return object.Annotations[PasswordPassthroughAnnotationName] == string(annotationStatusEnabled)
 }
 
-// GetInstanceRole tries to fetch the ClusterRoleLabelName andClusterInstanceRoleLabelName value from a given labels map
+// GetInstanceRole tries to fetch the ClusterRoleLabelName and ClusterInstanceRoleLabelName value from a given labels map
 func GetInstanceRole(labels map[string]string) (string, bool) {
 	if value := labels[ClusterRoleLabelName]; value != "" {
 		return value, true


### PR DESCRIPTION
## Description

Fixes a minor typo in the GoDoc comment for `GetInstanceRole` in
`pkg/utils/labels_annotations.go` where `and` and
`ClusterInstanceRoleLabelName` were concatenated without a space.

## Motivation

The `GetInstanceRole` function is part of the public `utils` package API.
Its GoDoc comment has `andClusterInstanceRoleLabelName` which renders
incorrectly in generated documentation and IDE tooltips.

## Changes

- **`pkg/utils/labels_annotations.go`** (line 559): Added missing space between
  `and` and `ClusterInstanceRoleLabelName` in the `GetInstanceRole` function's
  GoDoc comment.

**Before:**
```go
// GetInstanceRole tries to fetch the ClusterRoleLabelName andClusterInstanceRoleLabelName value from a given labels map

Signed-off-by:saiashok103@gmail.com