### PR TITLE
test: add unit tests for IsPowerOfTwo and ToBytes in pkg/utils/math.go

### DIFF
--- a/pkg/utils/math_test.go
+++ b/pkg/utils/math_test.go
@@ -1,0 +1,68 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package utils
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("IsPowerOfTwo", func() {
+	It("returns true for powers of two", func() {
+		powersOfTwo := []int{1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096}
+		for _, n := range powersOfTwo {
+			Expect(IsPowerOfTwo(n)).To(BeTrue(), "expected %d to be a power of two", n)
+		}
+	})
+
+	It("returns false for non-powers of two", func() {
+		nonPowersOfTwo := []int{3, 5, 6, 7, 9, 10, 12, 15, 100, 1000}
+		for _, n := range nonPowersOfTwo {
+			Expect(IsPowerOfTwo(n)).To(BeFalse(), "expected %d to not be a power of two", n)
+		}
+	})
+
+	It("returns false for zero", func() {
+		Expect(IsPowerOfTwo(0)).To(BeFalse(), "expected 0 to not be a power of two")
+	})
+
+	It("returns false for negative numbers", func() {
+		negatives := []int{-1, -2, -4, -8, -1024}
+		for _, n := range negatives {
+			Expect(IsPowerOfTwo(n)).To(BeFalse(), "expected %d to not be a power of two", n)
+		}
+	})
+})
+
+var _ = Describe("ToBytes", func() {
+	It("converts megabytes to bytes correctly", func() {
+		Expect(ToBytes(1)).To(BeNumerically("==", 1048576))
+		Expect(ToBytes(0)).To(BeNumerically("==", 0))
+		Expect(ToBytes(100)).To(BeNumerically("==", 104857600))
+		Expect(ToBytes(1024)).To(BeNumerically("==", 1073741824))
+	})
+
+	It("works with different numeric types", func() {
+		Expect(ToBytes(int32(1))).To(BeNumerically("==", 1048576))
+		Expect(ToBytes(int64(1))).To(BeNumerically("==", 1048576))
+		Expect(ToBytes(uint(1))).To(BeNumerically("==", 1048576))
+		Expect(ToBytes(float64(0.5))).To(BeNumerically("==", 524288))
+	})
+})


### PR DESCRIPTION
Description
Adds comprehensive unit tests for the IsPowerOfTwo and ToBytes functions in pkg/utils/math.go, which previously had zero test coverage.

Motivation
The math utility functions IsPowerOfTwo and ToBytes are used across the codebase but lack dedicated unit tests. This gap means regressions could be introduced without CI catching them. This PR adds structured test coverage using the project's standard Ginkgo/Gomega framework.

Changes
pkg/utils/math_test.go [NEW]: Added test suites covering:
IsPowerOfTwo: Tests for powers of two (1, 2, 4, 8, 16, ..., 4096), non-powers (3, 5, 6, 7, 9, 10, 12, 15, 100, 1000), zero, and negative numbers (-1, -2, -4, -8, -1024).
ToBytes: Tests for standard conversions (0 MB → 0 bytes, 1 MB → 1048576 bytes, 100 MB → 104857600 bytes, 1024 MB → 1073741824 bytes) and verifies the generic type constraint works with int32, int64, uint, and float64.

Signed-off-by:saiashok103@gmail.com