### PR TITLE
ci: add release-1.30 branch support, drop EOL release-1.25

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -48,7 +48,7 @@ body:
       label: Version
       description: What is the version of CloudNativePG you are running?
       options:
-        - "1.30.0-rc1"
+        - "1.30.0"
         - "1.29 (latest patch)"
         - "1.28 (latest patch)"
         - "trunk (main)"

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -32,9 +32,9 @@ jobs:
           number:  ${{ github.event.pull_request.number }}
           labels: |
             backport-requested :arrow_backward:
-            release-1.25
             release-1.28
             release-1.29
+            release-1.30
       -
         name: Create comment
         uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5
@@ -56,9 +56,9 @@ jobs:
           github_token: ${{ secrets.REPO_GHA_PAT }}
           labels: |
             backport-requested :arrow_backward:
-            release-1.25
             release-1.28
             release-1.29
+            release-1.30
 
   ## backport pull request in condition when pr contains 'backport-requested' label and contains target branches labels
   back-porting-pr:
@@ -74,7 +74,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: [release-1.25, release-1.28, release-1.29]
+        branch: [release-1.28, release-1.29, release-1.30]
     env:
       PR: ${{ github.event.pull_request.number }}
       BRANCH: ${{ matrix.branch }}

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -87,7 +87,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: [release-1.25, release-1.28, release-1.29]
+        branch: [release-1.28, release-1.29, release-1.30]
     env:
       BRANCH: ${{ matrix.branch }}
     steps:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -70,7 +70,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: [release-1.25, release-1.28, release-1.29]
+        branch: [release-1.28, release-1.29, release-1.30]
     env:
       BRANCH: ${{ matrix.branch }}
     steps:

--- a/contribute/release_procedure.md
+++ b/contribute/release_procedure.md
@@ -141,9 +141,8 @@ This procedure must happen immediately before starting the release.
 Once the new release branch is created, go back to `main` and submit a pull
 request to update the
 [backport](https://github.com/cloudnative-pg/cloudnative-pg/blob/main/.github/workflows/backport.yml),
-[continuous delivery](https://github.com/cloudnative-pg/cloudnative-pg/blob/main/.github/workflows/continuous-delivery.yml),
-[continuous integration](https://github.com/cloudnative-pg/cloudnative-pg/blob/main/.github/workflows/continuous-integration.yml)
-and [Renovate](https://github.com/cloudnative-pg/cloudnative-pg/blob/main/.github/renovate.json5)
+[continuous delivery](https://github.com/cloudnative-pg/cloudnative-pg/blob/main/.github/workflows/continuous-delivery.yml)
+and [continuous integration](https://github.com/cloudnative-pg/cloudnative-pg/blob/main/.github/workflows/continuous-integration.yml)
 workflows to support the new release branch.
 And also remember to update the [github issue template](https://github.com/cloudnative-pg/cloudnative-pg/blob/main/.github/ISSUE_TEMPLATE/bug.yml).
 

--- a/contribute/release_procedure.md
+++ b/contribute/release_procedure.md
@@ -272,7 +272,7 @@ The following artifacts are produced **once** per release cycle, regardless of
 how many supported versions are released together:
 
 - The release announcement (blog post) on the
-  [CloudNativePG website](https://cloudnative-pg.io/blog/).
+  [CloudNativePG website](https://cloudnative-pg.io/releases/).
 - The Helm chart for the newest released version — only one chart is
   published per release cycle, even when multiple versions are released —
   from the [`cloudnative-pg/charts`](https://github.com/cloudnative-pg/charts)


### PR DESCRIPTION
Following the 1.30.0 release and the creation of the `release-1.30` branch, update the backport, continuous delivery, and continuous integration workflows and the bug issue template to target the new branch, and drop `release-1.25`, now end of life, also on the EDB side.

Also remove the obsolete Renovate step from the release procedure. Renovate targets only `main` and the backport workflow carries dependency bumps onto the release branches, so its per-branch configuration no longer needs updating when a release branch is created.