### PR TITLE
test: pick the previous release for upgrade tests when HEAD is a release tag

### DIFF
--- a/tests/utils/operator/release.go
+++ b/tests/utils/operator/release.go
@@ -53,9 +53,33 @@ func GetMostRecentReleaseTag(releasesPath string) (string, error) {
 		return versions[1].String(), nil
 	}
 
+	// The morning after a release tag is cut, the latest release is built from the
+	// same commit as the code under test, so the instance manager binary is identical
+	// and no upgrade would be performed. When HEAD is exactly the latest release tag,
+	// fall back to the previous release so the upgrade test always has something to
+	// upgrade from. This self-clears as soon as any commit lands on top of the tag.
+	if len(versions) > 1 {
+		if tag := headExactReleaseTag(); tag != "" {
+			if v, err := semver.NewVersion(tag); err == nil && versions[0].Equal(v) {
+				return versions[1].String(), nil
+			}
+		}
+	}
+
 	// otherwise, we take for granted it's on a dev branch (or just one release available),
 	// so just return the latest release tag
 	return versions[0].String(), nil
+}
+
+// headExactReleaseTag returns the tag that points exactly at HEAD, or an empty
+// string if HEAD is not exactly on a tag. It is a variable so tests can stub the
+// git lookup.
+var headExactReleaseTag = func() string {
+	out, err := exec.Command("git", "describe", "--tags", "--exact-match", "HEAD").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
 }
 
 // GetAvailableReleases retrieves all the available releases from

--- a/tests/utils/operator/release_test.go
+++ b/tests/utils/operator/release_test.go
@@ -68,6 +68,12 @@ var _ = Describe("Most recent tag", func() {
 		releasesDir, err := filepath.Abs(releaseDirectoryPath)
 		Expect(err).ToNot(HaveOccurred())
 
+		// simulate the common case where HEAD is not exactly on a release tag,
+		// so the result doesn't depend on which commit the checkout sits on
+		original := headExactReleaseTag
+		DeferCleanup(func() { headExactReleaseTag = original })
+		headExactReleaseTag = func() string { return "" }
+
 		GinkgoT().Setenv("BRANCH_NAME", "dev/"+versions.Version)
 
 		tag, err := GetMostRecentReleaseTag(releasesDir)
@@ -79,6 +85,53 @@ var _ = Describe("Most recent tag", func() {
 		} else {
 			Expect(tag).To(BeEquivalentTo(versions.Version))
 		}
+	})
+})
+
+var _ = Describe("Most recent tag when HEAD is on a release tag", func() {
+	var tmpDir string
+
+	BeforeEach(func() {
+		// a dev branch, so the release-branch path is not taken
+		GinkgoT().Setenv("BRANCH_NAME", "dev/test")
+
+		tmpDir = GinkgoT().TempDir()
+		for _, file := range []string{
+			"cnpg-1.29.0.yaml",
+			"cnpg-1.29.1.yaml",
+			"cnpg-1.30.0.yaml",
+		} {
+			f, err := os.Create(filepath.Clean(filepath.Join(tmpDir, file)))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(f.Close()).ToNot(HaveOccurred())
+		}
+
+		original := headExactReleaseTag
+		DeferCleanup(func() { headExactReleaseTag = original })
+	})
+
+	It("falls back to the previous release when HEAD is exactly the latest release tag", func() {
+		headExactReleaseTag = func() string { return "v1.30.0" }
+
+		tag, err := GetMostRecentReleaseTag(tmpDir)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(tag).To(Equal("1.29.1"))
+	})
+
+	It("keeps the latest release once a commit lands on top of the tag", func() {
+		headExactReleaseTag = func() string { return "" }
+
+		tag, err := GetMostRecentReleaseTag(tmpDir)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(tag).To(Equal("1.30.0"))
+	})
+
+	It("keeps the latest release when HEAD is on an rc tag", func() {
+		headExactReleaseTag = func() string { return "v1.30.0-rc1" }
+
+		tag, err := GetMostRecentReleaseTag(tmpDir)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(tag).To(Equal("1.30.0"))
 	})
 })
 


### PR DESCRIPTION
The morning after a release tag is cut, the latest release is built from the same commit as the code under test, so the instance manager binary is identical and the online upgrade test performs no upgrade at all, failing with "upgrade was successful, but was not an online upgrade".

When HEAD points exactly at the latest release tag, fall back to the previous release so the upgrade always has a binary difference to apply. The check self-clears as soon as any commit lands on top of the tag, and degrades gracefully (reverts to the latest release) when run outside a git checkout.