### PR TITLE
fix: delegate in-tree barman WAL recovery to the instance manager

### DIFF
--- a/internal/cmd/manager/walrestore/cmd.go
+++ b/internal/cmd/manager/walrestore/cmd.go
@@ -338,18 +338,16 @@ func getWALRestoreSettings(
 	cluster *apiv1.Cluster,
 	podName string,
 ) (options []string, env []string, maxParallel int, err error) {
-	// Only the bootstrap recovery Job pre-populates these options, and only while
-	// no primary has been elected yet. Gating on CurrentPrimary keeps this lookup
-	// off the hot path of a running instance, where the key is never set and the
-	// webserver cache miss would otherwise retry on every WAL.
+	// During a bootstrap recovery no primary has been elected yet and there is no
+	// instance-manager cache. The Job resolves the recovery source object store
+	// (for a recovery.backup reference it lives only in the referenced Backup CR,
+	// so it is not derivable from the cluster spec here) and caches it for us.
+	// Gating on CurrentPrimary keeps this lookup off a running instance's hot
+	// path, where the key is never set.
 	if cluster.Status.CurrentPrimary == "" {
-		bootstrapOptions, optionsErr := cacheClient.GetEnv(cache.WALRestoreOptionsKey)
-		if optionsErr == nil {
-			env, err = cacheClient.GetEnv(cache.WALRestoreKey)
-			if err != nil {
-				return nil, nil, 0, fmt.Errorf("failed to get envs: %w", err)
-			}
-			return bootstrapOptions, env, bootstrapMaxParallel(cluster), nil
+		barmanConfiguration, configErr := cacheClient.GetBarmanObjectStore(cache.WALRestoreConfigKey)
+		if configErr == nil {
+			return walRestoreSettingsFromStore(ctx, cacheClient, barmanConfiguration, barmanConfiguration.ServerName, nil)
 		}
 	}
 
@@ -362,7 +360,23 @@ func getWALRestoreSettings(
 		return nil, nil, 0, fmt.Errorf("while getting recover configuration: %w", err)
 	}
 
-	options, err = barmanCommand.CloudWalRestoreOptions(ctx, barmanConfiguration, recoverClusterName)
+	return walRestoreSettingsFromStore(ctx, cacheClient, barmanConfiguration, recoverClusterName, recoverEnv)
+}
+
+// walRestoreSettingsFromStore builds the barman-cloud-wal-restore options, loads
+// the credentials environment, and computes the prefetch parallelism from a
+// resolved object store configuration. recoverEnv carries extra environment
+// (e.g. the endpoint CA bundle location) to merge on top of the cached
+// credentials; it is nil for a bootstrap recovery, whose cached credentials
+// already include it.
+func walRestoreSettingsFromStore(
+	ctx context.Context,
+	cacheClient local.CacheClient,
+	barmanConfiguration *apiv1.BarmanObjectStoreConfiguration,
+	serverName string,
+	recoverEnv []string,
+) (options []string, env []string, maxParallel int, err error) {
+	options, err = barmanCommand.CloudWalRestoreOptions(ctx, barmanConfiguration, serverName)
 	if err != nil {
 		return nil, nil, 0, fmt.Errorf("while getting barman-cloud-wal-restore options: %w", err)
 	}
@@ -379,28 +393,6 @@ func getWALRestoreSettings(
 	}
 
 	return options, env, maxParallel, nil
-}
-
-// bootstrapMaxParallel returns the WAL prefetch parallelism to use during a
-// bootstrap recovery. It mirrors the regular path, which reads it from the
-// object store being restored from: here that is the recovery source store.
-// Parallelism is only configurable for an external-cluster recovery source; a
-// recovery.backup reference carries no such setting, so it falls back to 1.
-func bootstrapMaxParallel(cluster *apiv1.Cluster) int {
-	if cluster.Spec.Bootstrap == nil || cluster.Spec.Bootstrap.Recovery == nil {
-		return 1
-	}
-
-	externalCluster, found := cluster.ExternalCluster(cluster.Spec.Bootstrap.Recovery.Source)
-	if !found || externalCluster.BarmanObjectStore == nil || externalCluster.BarmanObjectStore.Wal == nil {
-		return 1
-	}
-
-	if maxParallel := externalCluster.BarmanObjectStore.Wal.MaxParallel; maxParallel > 1 {
-		return maxParallel
-	}
-
-	return 1
 }
 
 // GetRecoverConfiguration get the appropriate recover Configuration for a given cluster

--- a/internal/cmd/manager/walrestore/cmd.go
+++ b/internal/cmd/manager/walrestore/cmd.go
@@ -344,10 +344,23 @@ func getWALRestoreSettings(
 	// so it is not derivable from the cluster spec here) and caches it for us.
 	// Gating on CurrentPrimary keeps this lookup off a running instance's hot
 	// path, where the key is never set.
+	//
+	// This gate relies on CurrentPrimary never reverting to empty once set.
+	// If that ever stopped being true, a long-running instance could
+	// re-enter this branch and, on a cache miss, silently fall through to
+	// GetRecoverConfiguration below instead of hitting its intended hot-path
+	// resolution.
 	if cluster.Status.CurrentPrimary == "" {
 		barmanConfiguration, configErr := cacheClient.GetBarmanObjectStore(cache.WALRestoreConfigKey)
-		if configErr == nil {
+		switch {
+		case configErr == nil:
 			return walRestoreSettingsFromStore(ctx, cacheClient, barmanConfiguration, barmanConfiguration.ServerName, nil)
+		case !errors.Is(configErr, cache.ErrCacheMiss):
+			// A real failure resolving the bootstrap-cached recovery source store
+			// must not be mistaken for "nothing cached yet": falling through here
+			// would silently restore WALs from the cluster's own (unrelated, and
+			// possibly empty) backup destination instead of the recovery source.
+			return nil, nil, 0, fmt.Errorf("while getting the cached recovery source object store: %w", configErr)
 		}
 	}
 

--- a/internal/cmd/manager/walrestore/cmd.go
+++ b/internal/cmd/manager/walrestore/cmd.go
@@ -322,16 +322,8 @@ func mergeEnv(env []string, incomingEnv []string) {
 
 // getWALRestoreSettings resolves the barman-cloud-wal-restore command-line
 // options, the environment carrying the object store credentials, and the
-// prefetch parallelism to use for a WAL restore.
-//
-// During the bootstrap recovery Job no primary has been elected yet
-// (cluster.Status.CurrentPrimary is empty) and there is no instance-manager
-// cache. The Job, which is the only component able to resolve the recovery
-// source object store (for a recovery.backup reference the store lives only in
-// the referenced Backup CR and is not derivable from the cluster spec),
-// pre-populates the local webserver cache with the wal-restore options and
-// credentials. We honor those here so the recovery replay restores WALs from
-// the source store, just like a replica does.
+// prefetch parallelism to use for a WAL restore. See the bootstrap-recovery
+// gate below for how a Job-populated cache fits into this.
 func getWALRestoreSettings(
 	ctx context.Context,
 	cacheClient local.CacheClient,
@@ -354,6 +346,9 @@ func getWALRestoreSettings(
 		barmanConfiguration, configErr := cacheClient.GetBarmanObjectStore(cache.WALRestoreConfigKey)
 		switch {
 		case configErr == nil:
+			// The cached recovery-source store's ServerName is always populated by
+			// loadBackup (from the Backup CR, or from the external cluster's
+			// GetServerName()), so passing it again here is not a real fallback.
 			return walRestoreSettingsFromStore(ctx, cacheClient, barmanConfiguration, barmanConfiguration.ServerName, nil)
 		case !errors.Is(configErr, cache.ErrCacheMiss):
 			// A real failure resolving the bootstrap-cached recovery source store

--- a/internal/cmd/manager/walrestore/cmd.go
+++ b/internal/cmd/manager/walrestore/cmd.go
@@ -146,7 +146,7 @@ func run(ctx context.Context, pgData string, podName string, args []string) erro
 		return nil
 	}
 
-	recoverClusterName, recoverEnv, barmanConfiguration, err := GetRecoverConfiguration(cluster, podName)
+	options, env, maxParallel, err := getWALRestoreSettings(ctx, cacheClient, cluster, podName)
 	if errors.Is(err, ErrNoBackupConfigured) {
 		// Backup not configured, skipping WAL
 		contextLog.Trace("Skipping WAL restore, there is no backup configuration",
@@ -157,20 +157,8 @@ func run(ctx context.Context, pgData string, podName string, args []string) erro
 		return err
 	}
 	if err != nil {
-		return fmt.Errorf("while getting recover configuration: %w", err)
+		return err
 	}
-
-	options, err := barmanCommand.CloudWalRestoreOptions(ctx, barmanConfiguration, recoverClusterName)
-	if err != nil {
-		return fmt.Errorf("while getting barman-cloud-wal-restore options: %w", err)
-	}
-
-	env, err := cacheClient.GetEnv(cache.WALRestoreKey)
-	if err != nil {
-		return fmt.Errorf("failed to get envs: %w", err)
-	}
-
-	mergeEnv(env, recoverEnv)
 
 	// Create the restorer
 	var walRestorer *barmanRestorer.WALRestorer
@@ -201,10 +189,6 @@ func run(ctx context.Context, pgData string, podName string, args []string) erro
 
 	// Step 3: gather the WAL files names to restore. If the required file isn't a regular WAL, we download it directly.
 	var walFilesList []string
-	maxParallel := 1
-	if barmanConfiguration.Wal != nil && barmanConfiguration.Wal.MaxParallel > 1 {
-		maxParallel = barmanConfiguration.Wal.MaxParallel
-	}
 	if postgres.IsWALFile(walName) {
 		// If this is a regular WAL file, we try to prefetch
 		if walFilesList, err = gatherWALFilesToRestore(walName, maxParallel); err != nil {
@@ -334,6 +318,89 @@ func mergeEnv(env []string, incomingEnv []string) {
 			}
 		}
 	}
+}
+
+// getWALRestoreSettings resolves the barman-cloud-wal-restore command-line
+// options, the environment carrying the object store credentials, and the
+// prefetch parallelism to use for a WAL restore.
+//
+// During the bootstrap recovery Job no primary has been elected yet
+// (cluster.Status.CurrentPrimary is empty) and there is no instance-manager
+// cache. The Job, which is the only component able to resolve the recovery
+// source object store (for a recovery.backup reference the store lives only in
+// the referenced Backup CR and is not derivable from the cluster spec),
+// pre-populates the local webserver cache with the wal-restore options and
+// credentials. We honor those here so the recovery replay restores WALs from
+// the source store, just like a replica does.
+func getWALRestoreSettings(
+	ctx context.Context,
+	cacheClient local.CacheClient,
+	cluster *apiv1.Cluster,
+	podName string,
+) (options []string, env []string, maxParallel int, err error) {
+	// Only the bootstrap recovery Job pre-populates these options, and only while
+	// no primary has been elected yet. Gating on CurrentPrimary keeps this lookup
+	// off the hot path of a running instance, where the key is never set and the
+	// webserver cache miss would otherwise retry on every WAL.
+	if cluster.Status.CurrentPrimary == "" {
+		bootstrapOptions, optionsErr := cacheClient.GetEnv(cache.WALRestoreOptionsKey)
+		if optionsErr == nil {
+			env, err = cacheClient.GetEnv(cache.WALRestoreKey)
+			if err != nil {
+				return nil, nil, 0, fmt.Errorf("failed to get envs: %w", err)
+			}
+			return bootstrapOptions, env, bootstrapMaxParallel(cluster), nil
+		}
+	}
+
+	recoverClusterName, recoverEnv, barmanConfiguration, err := GetRecoverConfiguration(cluster, podName)
+	if err != nil {
+		if errors.Is(err, ErrNoBackupConfigured) {
+			// returned unwrapped so the caller can detect it and skip the WAL
+			return nil, nil, 0, err
+		}
+		return nil, nil, 0, fmt.Errorf("while getting recover configuration: %w", err)
+	}
+
+	options, err = barmanCommand.CloudWalRestoreOptions(ctx, barmanConfiguration, recoverClusterName)
+	if err != nil {
+		return nil, nil, 0, fmt.Errorf("while getting barman-cloud-wal-restore options: %w", err)
+	}
+
+	env, err = cacheClient.GetEnv(cache.WALRestoreKey)
+	if err != nil {
+		return nil, nil, 0, fmt.Errorf("failed to get envs: %w", err)
+	}
+	mergeEnv(env, recoverEnv)
+
+	maxParallel = 1
+	if barmanConfiguration.Wal != nil && barmanConfiguration.Wal.MaxParallel > 1 {
+		maxParallel = barmanConfiguration.Wal.MaxParallel
+	}
+
+	return options, env, maxParallel, nil
+}
+
+// bootstrapMaxParallel returns the WAL prefetch parallelism to use during a
+// bootstrap recovery. It mirrors the regular path, which reads it from the
+// object store being restored from: here that is the recovery source store.
+// Parallelism is only configurable for an external-cluster recovery source; a
+// recovery.backup reference carries no such setting, so it falls back to 1.
+func bootstrapMaxParallel(cluster *apiv1.Cluster) int {
+	if cluster.Spec.Bootstrap == nil || cluster.Spec.Bootstrap.Recovery == nil {
+		return 1
+	}
+
+	externalCluster, found := cluster.ExternalCluster(cluster.Spec.Bootstrap.Recovery.Source)
+	if !found || externalCluster.BarmanObjectStore == nil || externalCluster.BarmanObjectStore.Wal == nil {
+		return 1
+	}
+
+	if maxParallel := externalCluster.BarmanObjectStore.Wal.MaxParallel; maxParallel > 1 {
+		return maxParallel
+	}
+
+	return 1
 }
 
 // GetRecoverConfiguration get the appropriate recover Configuration for a given cluster

--- a/internal/cmd/manager/walrestore/cmd.go
+++ b/internal/cmd/manager/walrestore/cmd.go
@@ -351,18 +351,16 @@ func getWALRestoreSettings(
 	podName string,
 	rewindMode bool,
 ) (options []string, env []string, maxParallel int, err error) {
-	// Only the bootstrap recovery Job pre-populates these options, and only while
-	// no primary has been elected yet. Gating on CurrentPrimary keeps this lookup
-	// off the hot path of a running instance, where the key is never set and the
-	// webserver cache miss would otherwise retry on every WAL.
+	// During a bootstrap recovery no primary has been elected yet and there is no
+	// instance-manager cache. The Job resolves the recovery source object store
+	// (for a recovery.backup reference it lives only in the referenced Backup CR,
+	// so it is not derivable from the cluster spec here) and caches it for us.
+	// Gating on CurrentPrimary keeps this lookup off a running instance's hot
+	// path, where the key is never set.
 	if cluster.Status.CurrentPrimary == "" {
-		bootstrapOptions, optionsErr := cacheClient.GetEnv(cache.WALRestoreOptionsKey)
-		if optionsErr == nil {
-			env, err = cacheClient.GetEnv(cache.WALRestoreKey)
-			if err != nil {
-				return nil, nil, 0, fmt.Errorf("failed to get envs: %w", err)
-			}
-			return bootstrapOptions, env, bootstrapMaxParallel(cluster, rewindMode), nil
+		barmanConfiguration, configErr := cacheClient.GetBarmanObjectStore(cache.WALRestoreConfigKey)
+		if configErr == nil {
+			return walRestoreSettingsFromStore(ctx, cacheClient, barmanConfiguration, barmanConfiguration.ServerName, nil, rewindMode)
 		}
 	}
 
@@ -375,7 +373,24 @@ func getWALRestoreSettings(
 		return nil, nil, 0, fmt.Errorf("while getting recover configuration: %w", err)
 	}
 
-	options, err = barmanCommand.CloudWalRestoreOptions(ctx, barmanConfiguration, recoverClusterName)
+	return walRestoreSettingsFromStore(ctx, cacheClient, barmanConfiguration, recoverClusterName, recoverEnv, rewindMode)
+}
+
+// walRestoreSettingsFromStore builds the barman-cloud-wal-restore options, loads
+// the credentials environment, and computes the prefetch parallelism from a
+// resolved object store configuration. recoverEnv carries extra environment
+// (e.g. the endpoint CA bundle location) to merge on top of the cached
+// credentials; it is nil for a bootstrap recovery, whose cached credentials
+// already include it.
+func walRestoreSettingsFromStore(
+	ctx context.Context,
+	cacheClient local.CacheClient,
+	barmanConfiguration *apiv1.BarmanObjectStoreConfiguration,
+	serverName string,
+	recoverEnv []string,
+	rewindMode bool,
+) (options []string, env []string, maxParallel int, err error) {
+	options, err = barmanCommand.CloudWalRestoreOptions(ctx, barmanConfiguration, serverName)
 	if err != nil {
 		return nil, nil, 0, fmt.Errorf("while getting barman-cloud-wal-restore options: %w", err)
 	}
@@ -392,31 +407,6 @@ func getWALRestoreSettings(
 	}
 
 	return options, env, maxParallel, nil
-}
-
-// bootstrapMaxParallel returns the WAL prefetch parallelism to use during a
-// bootstrap recovery. It mirrors the regular path, which reads it from the
-// object store being restored from: here that is the recovery source store.
-// Parallelism is only configurable for an external-cluster recovery source; a
-// recovery.backup reference carries no such setting, so it falls back to 1.
-// Prefetching is always disabled when restoring on behalf of pg_rewind, which
-// walks the WAL backward: the following segments would never be requested,
-// and past the end of the timeline they do not even exist.
-func bootstrapMaxParallel(cluster *apiv1.Cluster, rewindMode bool) int {
-	if rewindMode || cluster.Spec.Bootstrap == nil || cluster.Spec.Bootstrap.Recovery == nil {
-		return 1
-	}
-
-	externalCluster, found := cluster.ExternalCluster(cluster.Spec.Bootstrap.Recovery.Source)
-	if !found || externalCluster.BarmanObjectStore == nil || externalCluster.BarmanObjectStore.Wal == nil {
-		return 1
-	}
-
-	if maxParallel := externalCluster.BarmanObjectStore.Wal.MaxParallel; maxParallel > 1 {
-		return maxParallel
-	}
-
-	return 1
 }
 
 // GetRecoverConfiguration get the appropriate recover Configuration for a given cluster

--- a/internal/cmd/manager/walrestore/cmd.go
+++ b/internal/cmd/manager/walrestore/cmd.go
@@ -334,16 +334,8 @@ func mergeEnv(env []string, incomingEnv []string) {
 
 // getWALRestoreSettings resolves the barman-cloud-wal-restore command-line
 // options, the environment carrying the object store credentials, and the
-// prefetch parallelism to use for a WAL restore.
-//
-// During the bootstrap recovery Job no primary has been elected yet
-// (cluster.Status.CurrentPrimary is empty) and there is no instance-manager
-// cache. The Job, which is the only component able to resolve the recovery
-// source object store (for a recovery.backup reference the store lives only in
-// the referenced Backup CR and is not derivable from the cluster spec),
-// pre-populates the local webserver cache with the wal-restore options and
-// credentials. We honor those here so the recovery replay restores WALs from
-// the source store, just like a replica does.
+// prefetch parallelism to use for a WAL restore. See the bootstrap-recovery
+// gate below for how a Job-populated cache fits into this.
 func getWALRestoreSettings(
 	ctx context.Context,
 	cacheClient local.CacheClient,
@@ -367,6 +359,9 @@ func getWALRestoreSettings(
 		barmanConfiguration, configErr := cacheClient.GetBarmanObjectStore(cache.WALRestoreConfigKey)
 		switch {
 		case configErr == nil:
+			// The cached recovery-source store's ServerName is always populated by
+			// loadBackup (from the Backup CR, or from the external cluster's
+			// GetServerName()), so passing it again here is not a real fallback.
 			return walRestoreSettingsFromStore(ctx, cacheClient, barmanConfiguration, barmanConfiguration.ServerName, nil, rewindMode)
 		case !errors.Is(configErr, cache.ErrCacheMiss):
 			// A real failure resolving the bootstrap-cached recovery source store

--- a/internal/cmd/manager/walrestore/cmd.go
+++ b/internal/cmd/manager/walrestore/cmd.go
@@ -150,7 +150,7 @@ func run(ctx context.Context, pgData string, podName string, rewindMode bool, ar
 		return nil
 	}
 
-	recoverClusterName, recoverEnv, barmanConfiguration, err := GetRecoverConfiguration(cluster, podName)
+	options, env, maxParallel, err := getWALRestoreSettings(ctx, cacheClient, cluster, podName, rewindMode)
 	if errors.Is(err, ErrNoBackupConfigured) {
 		// Backup not configured, skipping WAL
 		contextLog.Trace("Skipping WAL restore, there is no backup configuration",
@@ -161,20 +161,8 @@ func run(ctx context.Context, pgData string, podName string, rewindMode bool, ar
 		return err
 	}
 	if err != nil {
-		return fmt.Errorf("while getting recover configuration: %w", err)
+		return err
 	}
-
-	options, err := barmanCommand.CloudWalRestoreOptions(ctx, barmanConfiguration, recoverClusterName)
-	if err != nil {
-		return fmt.Errorf("while getting barman-cloud-wal-restore options: %w", err)
-	}
-
-	env, err := cacheClient.GetEnv(cache.WALRestoreKey)
-	if err != nil {
-		return fmt.Errorf("failed to get envs: %w", err)
-	}
-
-	mergeEnv(env, recoverEnv)
 
 	// Create the restorer
 	var walRestorer *barmanRestorer.WALRestorer
@@ -206,7 +194,6 @@ func run(ctx context.Context, pgData string, podName string, rewindMode bool, ar
 
 	// Step 3: gather the WAL files names to restore. If the required file isn't a regular WAL, we download it directly.
 	var walFilesList []string
-	maxParallel := maxWALFilesPerInvocation(barmanConfiguration, rewindMode)
 	if postgres.IsWALFile(walName) {
 		// If this is a regular WAL file, we try to prefetch
 		if walFilesList, err = gatherWALFilesToRestore(walName, maxParallel); err != nil {
@@ -345,6 +332,93 @@ func mergeEnv(env []string, incomingEnv []string) {
 	}
 }
 
+// getWALRestoreSettings resolves the barman-cloud-wal-restore command-line
+// options, the environment carrying the object store credentials, and the
+// prefetch parallelism to use for a WAL restore.
+//
+// During the bootstrap recovery Job no primary has been elected yet
+// (cluster.Status.CurrentPrimary is empty) and there is no instance-manager
+// cache. The Job, which is the only component able to resolve the recovery
+// source object store (for a recovery.backup reference the store lives only in
+// the referenced Backup CR and is not derivable from the cluster spec),
+// pre-populates the local webserver cache with the wal-restore options and
+// credentials. We honor those here so the recovery replay restores WALs from
+// the source store, just like a replica does.
+func getWALRestoreSettings(
+	ctx context.Context,
+	cacheClient local.CacheClient,
+	cluster *apiv1.Cluster,
+	podName string,
+	rewindMode bool,
+) (options []string, env []string, maxParallel int, err error) {
+	// Only the bootstrap recovery Job pre-populates these options, and only while
+	// no primary has been elected yet. Gating on CurrentPrimary keeps this lookup
+	// off the hot path of a running instance, where the key is never set and the
+	// webserver cache miss would otherwise retry on every WAL.
+	if cluster.Status.CurrentPrimary == "" {
+		bootstrapOptions, optionsErr := cacheClient.GetEnv(cache.WALRestoreOptionsKey)
+		if optionsErr == nil {
+			env, err = cacheClient.GetEnv(cache.WALRestoreKey)
+			if err != nil {
+				return nil, nil, 0, fmt.Errorf("failed to get envs: %w", err)
+			}
+			return bootstrapOptions, env, bootstrapMaxParallel(cluster, rewindMode), nil
+		}
+	}
+
+	recoverClusterName, recoverEnv, barmanConfiguration, err := GetRecoverConfiguration(cluster, podName)
+	if err != nil {
+		if errors.Is(err, ErrNoBackupConfigured) {
+			// returned unwrapped so the caller can detect it and skip the WAL
+			return nil, nil, 0, err
+		}
+		return nil, nil, 0, fmt.Errorf("while getting recover configuration: %w", err)
+	}
+
+	options, err = barmanCommand.CloudWalRestoreOptions(ctx, barmanConfiguration, recoverClusterName)
+	if err != nil {
+		return nil, nil, 0, fmt.Errorf("while getting barman-cloud-wal-restore options: %w", err)
+	}
+
+	env, err = cacheClient.GetEnv(cache.WALRestoreKey)
+	if err != nil {
+		return nil, nil, 0, fmt.Errorf("failed to get envs: %w", err)
+	}
+	mergeEnv(env, recoverEnv)
+
+	maxParallel = 1
+	if !rewindMode && barmanConfiguration.Wal != nil && barmanConfiguration.Wal.MaxParallel > 1 {
+		maxParallel = barmanConfiguration.Wal.MaxParallel
+	}
+
+	return options, env, maxParallel, nil
+}
+
+// bootstrapMaxParallel returns the WAL prefetch parallelism to use during a
+// bootstrap recovery. It mirrors the regular path, which reads it from the
+// object store being restored from: here that is the recovery source store.
+// Parallelism is only configurable for an external-cluster recovery source; a
+// recovery.backup reference carries no such setting, so it falls back to 1.
+// Prefetching is always disabled when restoring on behalf of pg_rewind, which
+// walks the WAL backward: the following segments would never be requested,
+// and past the end of the timeline they do not even exist.
+func bootstrapMaxParallel(cluster *apiv1.Cluster, rewindMode bool) int {
+	if rewindMode || cluster.Spec.Bootstrap == nil || cluster.Spec.Bootstrap.Recovery == nil {
+		return 1
+	}
+
+	externalCluster, found := cluster.ExternalCluster(cluster.Spec.Bootstrap.Recovery.Source)
+	if !found || externalCluster.BarmanObjectStore == nil || externalCluster.BarmanObjectStore.Wal == nil {
+		return 1
+	}
+
+	if maxParallel := externalCluster.BarmanObjectStore.Wal.MaxParallel; maxParallel > 1 {
+		return maxParallel
+	}
+
+	return 1
+}
+
 // GetRecoverConfiguration get the appropriate recover Configuration for a given cluster
 func GetRecoverConfiguration(
 	cluster *apiv1.Cluster,
@@ -413,24 +487,6 @@ func gatherWALFilesToRestore(walName string, parallel int) (walList []string, er
 	}
 
 	return walList, err
-}
-
-// maxWALFilesPerInvocation returns how many WAL files a single wal-restore
-// invocation may fetch: the requested one, plus the ones that follow it up to
-// the configured maxParallel, to be prefetched into the spool. Prefetching is
-// disabled when restoring on behalf of pg_rewind, which walks the WAL
-// backward: the following segments would never be requested, and past the end
-// of the timeline they do not even exist
-func maxWALFilesPerInvocation(barmanConfiguration *apiv1.BarmanObjectStoreConfiguration, rewindMode bool) int {
-	if rewindMode {
-		return 1
-	}
-
-	if barmanConfiguration.Wal != nil && barmanConfiguration.Wal.MaxParallel > 1 {
-		return barmanConfiguration.Wal.MaxParallel
-	}
-
-	return 1
 }
 
 // shouldUseEndOfWALStreamFlag returns true when the end-of-wal-stream flag

--- a/internal/cmd/manager/walrestore/cmd.go
+++ b/internal/cmd/manager/walrestore/cmd.go
@@ -357,10 +357,23 @@ func getWALRestoreSettings(
 	// so it is not derivable from the cluster spec here) and caches it for us.
 	// Gating on CurrentPrimary keeps this lookup off a running instance's hot
 	// path, where the key is never set.
+	//
+	// This gate relies on CurrentPrimary never reverting to empty once set.
+	// If that ever stopped being true, a long-running instance could
+	// re-enter this branch and, on a cache miss, silently fall through to
+	// GetRecoverConfiguration below instead of hitting its intended hot-path
+	// resolution.
 	if cluster.Status.CurrentPrimary == "" {
 		barmanConfiguration, configErr := cacheClient.GetBarmanObjectStore(cache.WALRestoreConfigKey)
-		if configErr == nil {
+		switch {
+		case configErr == nil:
 			return walRestoreSettingsFromStore(ctx, cacheClient, barmanConfiguration, barmanConfiguration.ServerName, nil, rewindMode)
+		case !errors.Is(configErr, cache.ErrCacheMiss):
+			// A real failure resolving the bootstrap-cached recovery source store
+			// must not be mistaken for "nothing cached yet": falling through here
+			// would silently restore WALs from the cluster's own (unrelated, and
+			// possibly empty) backup destination instead of the recovery source.
+			return nil, nil, 0, fmt.Errorf("while getting the cached recovery source object store: %w", configErr)
 		}
 	}
 

--- a/internal/cmd/manager/walrestore/cmd.go
+++ b/internal/cmd/manager/walrestore/cmd.go
@@ -362,7 +362,8 @@ func getWALRestoreSettings(
 			// The cached recovery-source store's ServerName is always populated by
 			// loadBackup (from the Backup CR, or from the external cluster's
 			// GetServerName()), so passing it again here is not a real fallback.
-			return walRestoreSettingsFromStore(ctx, cacheClient, barmanConfiguration, barmanConfiguration.ServerName, nil, rewindMode)
+			return walRestoreSettingsFromStore(
+				ctx, cacheClient, barmanConfiguration, barmanConfiguration.ServerName, nil, rewindMode)
 		case !errors.Is(configErr, cache.ErrCacheMiss):
 			// A real failure resolving the bootstrap-cached recovery source store
 			// must not be mistaken for "nothing cached yet": falling through here

--- a/internal/cmd/manager/walrestore/cmd_test.go
+++ b/internal/cmd/manager/walrestore/cmd_test.go
@@ -36,6 +36,10 @@ import (
 type fakeCacheClient struct {
 	envs   map[string][]string
 	stores map[string]*apiv1.BarmanObjectStoreConfiguration
+	// storeErr, when set, is returned by GetBarmanObjectStore instead of
+	// cache.ErrCacheMiss, simulating a genuine cache-service failure (as
+	// opposed to the key simply never having been populated).
+	storeErr error
 }
 
 func (f fakeCacheClient) GetCluster() (*apiv1.Cluster, error) {
@@ -52,6 +56,9 @@ func (f fakeCacheClient) GetEnv(key string) ([]string, error) {
 func (f fakeCacheClient) GetBarmanObjectStore(key string) (*apiv1.BarmanObjectStoreConfiguration, error) {
 	if v, ok := f.stores[key]; ok {
 		return v, nil
+	}
+	if f.storeErr != nil {
+		return nil, f.storeErr
 	}
 	return nil, cache.ErrCacheMiss
 }
@@ -208,6 +215,31 @@ var _ = Describe("getWALRestoreSettings", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(maxParallel).To(Equal(2))
 		Expect(options).To(ContainElement("--read-timeout=60"))
+	})
+
+	It("fails instead of falling back to the cluster's own store when the cached "+
+		"bootstrap store lookup fails for a reason other than a cache miss", func(ctx SpecContext) {
+		// No primary elected yet, so this is still within the bootstrap window,
+		// but the cache lookup fails with something other than a miss: a real
+		// failure that has already survived the cache client's own
+		// retry-with-backoff, as opposed to the key simply never having been
+		// populated. Falling through to the cluster's own backup store here
+		// would silently restore WALs from the wrong (and possibly unrelated
+		// or empty) destination instead of failing loudly.
+		cluster := clusterWithOwnBackup("")
+		injectedErr := errors.New("simulated cache-service failure")
+		cacheClient := fakeCacheClient{
+			envs: map[string][]string{cache.WALRestoreKey: {"AWS_ACCESS_KEY_ID=own-key"}},
+			// This must never be used: a genuine cache error must not be
+			// treated the same as "nothing cached yet".
+			stores:   map[string]*apiv1.BarmanObjectStoreConfiguration{},
+			storeErr: injectedErr,
+		}
+
+		options, _, _, err := getWALRestoreSettings(ctx, cacheClient, cluster, podName)
+		Expect(err).To(HaveOccurred())
+		Expect(errors.Is(err, injectedErr)).To(BeTrue())
+		Expect(options).To(BeNil())
 	})
 
 	It("ignores the cached bootstrap store once a primary has been elected", func(ctx SpecContext) {

--- a/internal/cmd/manager/walrestore/cmd_test.go
+++ b/internal/cmd/manager/walrestore/cmd_test.go
@@ -20,14 +20,33 @@ SPDX-License-Identifier: Apache-2.0
 package walrestore
 
 import (
+	"errors"
+
 	barmanRestorer "github.com/cloudnative-pg/barman-cloud/pkg/restorer"
 	"k8s.io/utils/ptr"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	"github.com/cloudnative-pg/cloudnative-pg/internal/management/cache"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
+
+// fakeCacheClient is an in-memory implementation of local.CacheClient for tests.
+type fakeCacheClient struct {
+	envs map[string][]string
+}
+
+func (f fakeCacheClient) GetCluster() (*apiv1.Cluster, error) {
+	return nil, errors.New("GetCluster not implemented in fakeCacheClient")
+}
+
+func (f fakeCacheClient) GetEnv(key string) ([]string, error) {
+	if v, ok := f.envs[key]; ok {
+		return v, nil
+	}
+	return nil, cache.ErrCacheMiss
+}
 
 var _ = Describe("Function isStreamingAvailable", func() {
 	It("returns false if cluster is nil", func() {
@@ -112,6 +131,120 @@ var _ = Describe("Function isStreamingAvailable", func() {
 			},
 		}
 		Expect(isStreamingAvailable(&cluster, "primaryPod")).To(BeTrue())
+	})
+})
+
+var _ = Describe("getWALRestoreSettings", func() {
+	const podName = "cluster-1"
+
+	clusterWithOwnBackup := func(currentPrimary string) *apiv1.Cluster {
+		return &apiv1.Cluster{
+			Status: apiv1.ClusterStatus{CurrentPrimary: currentPrimary},
+			Spec: apiv1.ClusterSpec{
+				Backup: &apiv1.BackupConfiguration{
+					BarmanObjectStore: &apiv1.BarmanObjectStoreConfiguration{
+						BarmanCredentials: apiv1.BarmanCredentials{AWS: &apiv1.S3Credentials{}},
+						DestinationPath:   "s3://own-backup/path",
+						ServerName:        "own-server",
+						Wal:               &apiv1.WalBackupConfiguration{MaxParallel: 3},
+					},
+				},
+			},
+		}
+	}
+
+	It("uses the cached bootstrap options and credentials during a recovery Job", func(ctx SpecContext) {
+		// recovery.backup reference: no primary elected yet, and the source store
+		// carries no parallelism setting, so prefetch defaults to a single segment.
+		cluster := &apiv1.Cluster{
+			Status: apiv1.ClusterStatus{CurrentPrimary: ""},
+			Spec: apiv1.ClusterSpec{
+				Bootstrap: &apiv1.BootstrapConfiguration{
+					Recovery: &apiv1.BootstrapRecovery{
+						Backup: &apiv1.BackupSource{
+							LocalObjectReference: apiv1.LocalObjectReference{Name: "a-backup"},
+						},
+					},
+				},
+			},
+		}
+		bootstrapOptions := []string{"--endpoint-url", "https://source", "s3://source/path", "source-server"}
+		creds := []string{"AWS_ACCESS_KEY_ID=source-key"}
+		cacheClient := fakeCacheClient{envs: map[string][]string{
+			cache.WALRestoreOptionsKey: bootstrapOptions,
+			cache.WALRestoreKey:        creds,
+		}}
+
+		options, env, maxParallel, err := getWALRestoreSettings(ctx, cacheClient, cluster, podName)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(options).To(Equal(bootstrapOptions))
+		Expect(env).To(Equal(creds))
+		Expect(maxParallel).To(Equal(1))
+	})
+
+	It("honors the recovery source store maxParallel during a recovery Job", func(ctx SpecContext) {
+		// recovery.source: prefetch parallelism comes from the source external
+		// cluster's object store, just like a replica restoring from that store.
+		cluster := &apiv1.Cluster{
+			Status: apiv1.ClusterStatus{CurrentPrimary: ""},
+			Spec: apiv1.ClusterSpec{
+				Bootstrap: &apiv1.BootstrapConfiguration{
+					Recovery: &apiv1.BootstrapRecovery{Source: "origin"},
+				},
+				ExternalClusters: []apiv1.ExternalCluster{
+					{
+						Name: "origin",
+						BarmanObjectStore: &apiv1.BarmanObjectStoreConfiguration{
+							Wal: &apiv1.WalBackupConfiguration{MaxParallel: 2},
+						},
+					},
+				},
+			},
+		}
+		cacheClient := fakeCacheClient{envs: map[string][]string{
+			cache.WALRestoreOptionsKey: {"s3://source/path", "origin"},
+			cache.WALRestoreKey:        {"AWS_ACCESS_KEY_ID=source-key"},
+		}}
+
+		_, _, maxParallel, err := getWALRestoreSettings(ctx, cacheClient, cluster, podName)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(maxParallel).To(Equal(2))
+	})
+
+	It("ignores cached bootstrap options once a primary has been elected", func(ctx SpecContext) {
+		cluster := clusterWithOwnBackup(podName)
+		cacheClient := fakeCacheClient{envs: map[string][]string{
+			// This must never be used: a running instance resolves the store from
+			// the cluster spec, not from the bootstrap options cache.
+			cache.WALRestoreOptionsKey: {"POISON-MUST-NOT-BE-USED"},
+			cache.WALRestoreKey:        {"AWS_ACCESS_KEY_ID=own-key"},
+		}}
+
+		options, _, maxParallel, err := getWALRestoreSettings(ctx, cacheClient, cluster, podName)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(options).ToNot(ContainElement("POISON-MUST-NOT-BE-USED"))
+		Expect(options).To(ContainElement("s3://own-backup/path"))
+		Expect(maxParallel).To(Equal(3))
+	})
+
+	It("falls back to the cluster store during bootstrap when no options are cached", func(ctx SpecContext) {
+		cluster := clusterWithOwnBackup("")
+		cacheClient := fakeCacheClient{envs: map[string][]string{
+			cache.WALRestoreKey: {"AWS_ACCESS_KEY_ID=own-key"},
+		}}
+
+		options, _, maxParallel, err := getWALRestoreSettings(ctx, cacheClient, cluster, podName)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(options).To(ContainElement("s3://own-backup/path"))
+		Expect(maxParallel).To(Equal(3))
+	})
+
+	It("returns ErrNoBackupConfigured when nothing is available", func(ctx SpecContext) {
+		cluster := &apiv1.Cluster{Status: apiv1.ClusterStatus{CurrentPrimary: podName}}
+		cacheClient := fakeCacheClient{envs: map[string][]string{}}
+
+		_, _, _, err := getWALRestoreSettings(ctx, cacheClient, cluster, podName)
+		Expect(err).To(MatchError(ErrNoBackupConfigured))
 	})
 })
 

--- a/internal/cmd/manager/walrestore/cmd_test.go
+++ b/internal/cmd/manager/walrestore/cmd_test.go
@@ -34,7 +34,8 @@ import (
 
 // fakeCacheClient is an in-memory implementation of local.CacheClient for tests.
 type fakeCacheClient struct {
-	envs map[string][]string
+	envs   map[string][]string
+	stores map[string]*apiv1.BarmanObjectStoreConfiguration
 }
 
 func (f fakeCacheClient) GetCluster() (*apiv1.Cluster, error) {
@@ -43,6 +44,13 @@ func (f fakeCacheClient) GetCluster() (*apiv1.Cluster, error) {
 
 func (f fakeCacheClient) GetEnv(key string) ([]string, error) {
 	if v, ok := f.envs[key]; ok {
+		return v, nil
+	}
+	return nil, cache.ErrCacheMiss
+}
+
+func (f fakeCacheClient) GetBarmanObjectStore(key string) (*apiv1.BarmanObjectStoreConfiguration, error) {
+	if v, ok := f.stores[key]; ok {
 		return v, nil
 	}
 	return nil, cache.ErrCacheMiss
@@ -153,85 +161,78 @@ var _ = Describe("getWALRestoreSettings", func() {
 		}
 	}
 
-	It("uses the cached bootstrap options and credentials during a recovery Job", func(ctx SpecContext) {
-		// recovery.backup reference: no primary elected yet, and the source store
-		// carries no parallelism setting, so prefetch defaults to a single segment.
-		cluster := &apiv1.Cluster{
-			Status: apiv1.ClusterStatus{CurrentPrimary: ""},
-			Spec: apiv1.ClusterSpec{
-				Bootstrap: &apiv1.BootstrapConfiguration{
-					Recovery: &apiv1.BootstrapRecovery{
-						Backup: &apiv1.BackupSource{
-							LocalObjectReference: apiv1.LocalObjectReference{Name: "a-backup"},
-						},
-					},
-				},
-			},
+	It("uses the cached bootstrap source store and credentials during a recovery Job", func(ctx SpecContext) {
+		// No primary elected yet, and the cached source store carries no
+		// parallelism setting, so prefetch defaults to a single segment.
+		cluster := &apiv1.Cluster{Status: apiv1.ClusterStatus{CurrentPrimary: ""}}
+		sourceStore := &apiv1.BarmanObjectStoreConfiguration{
+			BarmanCredentials: apiv1.BarmanCredentials{AWS: &apiv1.S3Credentials{}},
+			EndpointURL:       "https://source",
+			DestinationPath:   "s3://source/path",
+			ServerName:        "source-server",
 		}
-		bootstrapOptions := []string{"--endpoint-url", "https://source", "s3://source/path", "source-server"}
 		creds := []string{"AWS_ACCESS_KEY_ID=source-key"}
-		cacheClient := fakeCacheClient{envs: map[string][]string{
-			cache.WALRestoreOptionsKey: bootstrapOptions,
-			cache.WALRestoreKey:        creds,
-		}}
+		cacheClient := fakeCacheClient{
+			envs:   map[string][]string{cache.WALRestoreKey: creds},
+			stores: map[string]*apiv1.BarmanObjectStoreConfiguration{cache.WALRestoreConfigKey: sourceStore},
+		}
 
 		options, env, maxParallel, err := getWALRestoreSettings(ctx, cacheClient, cluster, podName)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(options).To(Equal(bootstrapOptions))
+		Expect(options).To(ContainElement("s3://source/path"))
+		Expect(options).To(ContainElement("source-server"))
+		Expect(options).To(ContainElement("https://source"))
 		Expect(env).To(Equal(creds))
 		Expect(maxParallel).To(Equal(1))
 	})
 
-	It("honors the recovery source store maxParallel during a recovery Job", func(ctx SpecContext) {
-		// recovery.source: prefetch parallelism comes from the source external
-		// cluster's object store, just like a replica restoring from that store.
-		cluster := &apiv1.Cluster{
-			Status: apiv1.ClusterStatus{CurrentPrimary: ""},
-			Spec: apiv1.ClusterSpec{
-				Bootstrap: &apiv1.BootstrapConfiguration{
-					Recovery: &apiv1.BootstrapRecovery{Source: "origin"},
-				},
-				ExternalClusters: []apiv1.ExternalCluster{
-					{
-						Name: "origin",
-						BarmanObjectStore: &apiv1.BarmanObjectStoreConfiguration{
-							Wal: &apiv1.WalBackupConfiguration{MaxParallel: 2},
-						},
-					},
-				},
+	It("honors the cached source store Wal config during a recovery Job", func(ctx SpecContext) {
+		// Prefetch parallelism and the additional command-line arguments come from
+		// the cached source store's Wal config, just like a running instance
+		// derives them from the store it restores from.
+		cluster := &apiv1.Cluster{Status: apiv1.ClusterStatus{CurrentPrimary: ""}}
+		sourceStore := &apiv1.BarmanObjectStoreConfiguration{
+			DestinationPath: "s3://source/path",
+			ServerName:      "source-server",
+			Wal: &apiv1.WalBackupConfiguration{
+				MaxParallel:                  2,
+				RestoreAdditionalCommandArgs: []string{"--read-timeout=60"},
 			},
 		}
-		cacheClient := fakeCacheClient{envs: map[string][]string{
-			cache.WALRestoreOptionsKey: {"s3://source/path", "origin"},
-			cache.WALRestoreKey:        {"AWS_ACCESS_KEY_ID=source-key"},
-		}}
-
-		_, _, maxParallel, err := getWALRestoreSettings(ctx, cacheClient, cluster, podName)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(maxParallel).To(Equal(2))
-	})
-
-	It("ignores cached bootstrap options once a primary has been elected", func(ctx SpecContext) {
-		cluster := clusterWithOwnBackup(podName)
-		cacheClient := fakeCacheClient{envs: map[string][]string{
-			// This must never be used: a running instance resolves the store from
-			// the cluster spec, not from the bootstrap options cache.
-			cache.WALRestoreOptionsKey: {"POISON-MUST-NOT-BE-USED"},
-			cache.WALRestoreKey:        {"AWS_ACCESS_KEY_ID=own-key"},
-		}}
+		cacheClient := fakeCacheClient{
+			envs:   map[string][]string{cache.WALRestoreKey: {"AWS_ACCESS_KEY_ID=source-key"}},
+			stores: map[string]*apiv1.BarmanObjectStoreConfiguration{cache.WALRestoreConfigKey: sourceStore},
+		}
 
 		options, _, maxParallel, err := getWALRestoreSettings(ctx, cacheClient, cluster, podName)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(options).ToNot(ContainElement("POISON-MUST-NOT-BE-USED"))
+		Expect(maxParallel).To(Equal(2))
+		Expect(options).To(ContainElement("--read-timeout=60"))
+	})
+
+	It("ignores the cached bootstrap store once a primary has been elected", func(ctx SpecContext) {
+		cluster := clusterWithOwnBackup(podName)
+		cacheClient := fakeCacheClient{
+			envs: map[string][]string{cache.WALRestoreKey: {"AWS_ACCESS_KEY_ID=own-key"}},
+			// This must never be used: a running instance resolves the store from
+			// the cluster spec, not from the bootstrap cache.
+			stores: map[string]*apiv1.BarmanObjectStoreConfiguration{
+				cache.WALRestoreConfigKey: {DestinationPath: "s3://POISON-MUST-NOT-BE-USED"},
+			},
+		}
+
+		options, _, maxParallel, err := getWALRestoreSettings(ctx, cacheClient, cluster, podName)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(options).ToNot(ContainElement("s3://POISON-MUST-NOT-BE-USED"))
 		Expect(options).To(ContainElement("s3://own-backup/path"))
 		Expect(maxParallel).To(Equal(3))
 	})
 
-	It("falls back to the cluster store during bootstrap when no options are cached", func(ctx SpecContext) {
+	It("falls back to the cluster store during bootstrap when no store is cached", func(ctx SpecContext) {
 		cluster := clusterWithOwnBackup("")
-		cacheClient := fakeCacheClient{envs: map[string][]string{
-			cache.WALRestoreKey: {"AWS_ACCESS_KEY_ID=own-key"},
-		}}
+		cacheClient := fakeCacheClient{
+			envs: map[string][]string{cache.WALRestoreKey: {"AWS_ACCESS_KEY_ID=own-key"}},
+		}
 
 		options, _, maxParallel, err := getWALRestoreSettings(ctx, cacheClient, cluster, podName)
 		Expect(err).ToNot(HaveOccurred())
@@ -241,7 +242,7 @@ var _ = Describe("getWALRestoreSettings", func() {
 
 	It("returns ErrNoBackupConfigured when nothing is available", func(ctx SpecContext) {
 		cluster := &apiv1.Cluster{Status: apiv1.ClusterStatus{CurrentPrimary: podName}}
-		cacheClient := fakeCacheClient{envs: map[string][]string{}}
+		cacheClient := fakeCacheClient{}
 
 		_, _, _, err := getWALRestoreSettings(ctx, cacheClient, cluster, podName)
 		Expect(err).To(MatchError(ErrNoBackupConfigured))

--- a/internal/cmd/manager/walrestore/cmd_test.go
+++ b/internal/cmd/manager/walrestore/cmd_test.go
@@ -27,10 +27,27 @@ import (
 	"k8s.io/utils/ptr"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	"github.com/cloudnative-pg/cloudnative-pg/internal/management/cache"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
+
+// fakeCacheClient is an in-memory implementation of local.CacheClient for tests.
+type fakeCacheClient struct {
+	envs map[string][]string
+}
+
+func (f fakeCacheClient) GetCluster() (*apiv1.Cluster, error) {
+	return nil, errors.New("GetCluster not implemented in fakeCacheClient")
+}
+
+func (f fakeCacheClient) GetEnv(key string) ([]string, error) {
+	if v, ok := f.envs[key]; ok {
+		return v, nil
+	}
+	return nil, cache.ErrCacheMiss
+}
 
 var _ = Describe("Function isStreamingAvailable", func() {
 	It("returns false if cluster is nil", func() {
@@ -136,30 +153,6 @@ var _ = Describe("Function shouldUseEndOfWALStreamFlag", func() {
 	})
 })
 
-var _ = Describe("Function maxWALFilesPerInvocation", func() {
-	It("returns 1 when no parallel WAL configuration is present", func() {
-		Expect(maxWALFilesPerInvocation(&apiv1.BarmanObjectStoreConfiguration{}, false)).To(Equal(1))
-	})
-
-	It("returns the configured maxParallel", func() {
-		configuration := &apiv1.BarmanObjectStoreConfiguration{
-			Wal: &apiv1.WalBackupConfiguration{
-				MaxParallel: 3,
-			},
-		}
-		Expect(maxWALFilesPerInvocation(configuration, false)).To(Equal(3))
-	})
-
-	It("returns 1 in rewind mode, ignoring the configured maxParallel", func() {
-		configuration := &apiv1.BarmanObjectStoreConfiguration{
-			Wal: &apiv1.WalBackupConfiguration{
-				MaxParallel: 3,
-			},
-		}
-		Expect(maxWALFilesPerInvocation(configuration, true)).To(Equal(1))
-	})
-})
-
 var _ = Describe("Function isEndOfWALStream", func() {
 	It("returns true when the requested WAL was not found", func() {
 		results := []barmanRestorer.Result{
@@ -189,6 +182,158 @@ var _ = Describe("Function isEndOfWALStream", func() {
 			{Err: errors.New("connection reset by peer")},
 		}
 		Expect(isEndOfWALStream(results)).To(BeFalse())
+	})
+})
+
+var _ = Describe("getWALRestoreSettings", func() {
+	const podName = "cluster-1"
+
+	clusterWithOwnBackup := func(currentPrimary string) *apiv1.Cluster {
+		return &apiv1.Cluster{
+			Status: apiv1.ClusterStatus{CurrentPrimary: currentPrimary},
+			Spec: apiv1.ClusterSpec{
+				Backup: &apiv1.BackupConfiguration{
+					BarmanObjectStore: &apiv1.BarmanObjectStoreConfiguration{
+						BarmanCredentials: apiv1.BarmanCredentials{AWS: &apiv1.S3Credentials{}},
+						DestinationPath:   "s3://own-backup/path",
+						ServerName:        "own-server",
+						Wal:               &apiv1.WalBackupConfiguration{MaxParallel: 3},
+					},
+				},
+			},
+		}
+	}
+
+	It("uses the cached bootstrap options and credentials during a recovery Job", func(ctx SpecContext) {
+		// recovery.backup reference: no primary elected yet, and the source store
+		// carries no parallelism setting, so prefetch defaults to a single segment.
+		cluster := &apiv1.Cluster{
+			Status: apiv1.ClusterStatus{CurrentPrimary: ""},
+			Spec: apiv1.ClusterSpec{
+				Bootstrap: &apiv1.BootstrapConfiguration{
+					Recovery: &apiv1.BootstrapRecovery{
+						Backup: &apiv1.BackupSource{
+							LocalObjectReference: apiv1.LocalObjectReference{Name: "a-backup"},
+						},
+					},
+				},
+			},
+		}
+		bootstrapOptions := []string{"--endpoint-url", "https://source", "s3://source/path", "source-server"}
+		creds := []string{"AWS_ACCESS_KEY_ID=source-key"}
+		cacheClient := fakeCacheClient{envs: map[string][]string{
+			cache.WALRestoreOptionsKey: bootstrapOptions,
+			cache.WALRestoreKey:        creds,
+		}}
+
+		options, env, maxParallel, err := getWALRestoreSettings(ctx, cacheClient, cluster, podName, false)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(options).To(Equal(bootstrapOptions))
+		Expect(env).To(Equal(creds))
+		Expect(maxParallel).To(Equal(1))
+	})
+
+	It("honors the recovery source store maxParallel during a recovery Job", func(ctx SpecContext) {
+		// recovery.source: prefetch parallelism comes from the source external
+		// cluster's object store, just like a replica restoring from that store.
+		cluster := &apiv1.Cluster{
+			Status: apiv1.ClusterStatus{CurrentPrimary: ""},
+			Spec: apiv1.ClusterSpec{
+				Bootstrap: &apiv1.BootstrapConfiguration{
+					Recovery: &apiv1.BootstrapRecovery{Source: "origin"},
+				},
+				ExternalClusters: []apiv1.ExternalCluster{
+					{
+						Name: "origin",
+						BarmanObjectStore: &apiv1.BarmanObjectStoreConfiguration{
+							Wal: &apiv1.WalBackupConfiguration{MaxParallel: 2},
+						},
+					},
+				},
+			},
+		}
+		cacheClient := fakeCacheClient{envs: map[string][]string{
+			cache.WALRestoreOptionsKey: {"s3://source/path", "origin"},
+			cache.WALRestoreKey:        {"AWS_ACCESS_KEY_ID=source-key"},
+		}}
+
+		_, _, maxParallel, err := getWALRestoreSettings(ctx, cacheClient, cluster, podName, false)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(maxParallel).To(Equal(2))
+	})
+
+	It("disables prefetch in rewind mode, even with a configured maxParallel", func(ctx SpecContext) {
+		cluster := &apiv1.Cluster{
+			Status: apiv1.ClusterStatus{CurrentPrimary: ""},
+			Spec: apiv1.ClusterSpec{
+				Bootstrap: &apiv1.BootstrapConfiguration{
+					Recovery: &apiv1.BootstrapRecovery{Source: "origin"},
+				},
+				ExternalClusters: []apiv1.ExternalCluster{
+					{
+						Name: "origin",
+						BarmanObjectStore: &apiv1.BarmanObjectStoreConfiguration{
+							Wal: &apiv1.WalBackupConfiguration{MaxParallel: 2},
+						},
+					},
+				},
+			},
+		}
+		cacheClient := fakeCacheClient{envs: map[string][]string{
+			cache.WALRestoreOptionsKey: {"s3://source/path", "origin"},
+			cache.WALRestoreKey:        {"AWS_ACCESS_KEY_ID=source-key"},
+		}}
+
+		_, _, maxParallel, err := getWALRestoreSettings(ctx, cacheClient, cluster, podName, true)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(maxParallel).To(Equal(1))
+	})
+
+	It("ignores cached bootstrap options once a primary has been elected", func(ctx SpecContext) {
+		cluster := clusterWithOwnBackup(podName)
+		cacheClient := fakeCacheClient{envs: map[string][]string{
+			// This must never be used: a running instance resolves the store from
+			// the cluster spec, not from the bootstrap options cache.
+			cache.WALRestoreOptionsKey: {"POISON-MUST-NOT-BE-USED"},
+			cache.WALRestoreKey:        {"AWS_ACCESS_KEY_ID=own-key"},
+		}}
+
+		options, _, maxParallel, err := getWALRestoreSettings(ctx, cacheClient, cluster, podName, false)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(options).ToNot(ContainElement("POISON-MUST-NOT-BE-USED"))
+		Expect(options).To(ContainElement("s3://own-backup/path"))
+		Expect(maxParallel).To(Equal(3))
+	})
+
+	It("falls back to the cluster store during bootstrap when no options are cached", func(ctx SpecContext) {
+		cluster := clusterWithOwnBackup("")
+		cacheClient := fakeCacheClient{envs: map[string][]string{
+			cache.WALRestoreKey: {"AWS_ACCESS_KEY_ID=own-key"},
+		}}
+
+		options, _, maxParallel, err := getWALRestoreSettings(ctx, cacheClient, cluster, podName, false)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(options).To(ContainElement("s3://own-backup/path"))
+		Expect(maxParallel).To(Equal(3))
+	})
+
+	It("disables prefetch in rewind mode for a cluster with its own backup configured", func(ctx SpecContext) {
+		cluster := clusterWithOwnBackup(podName)
+		cacheClient := fakeCacheClient{envs: map[string][]string{
+			cache.WALRestoreKey: {"AWS_ACCESS_KEY_ID=own-key"},
+		}}
+
+		_, _, maxParallel, err := getWALRestoreSettings(ctx, cacheClient, cluster, podName, true)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(maxParallel).To(Equal(1))
+	})
+
+	It("returns ErrNoBackupConfigured when nothing is available", func(ctx SpecContext) {
+		cluster := &apiv1.Cluster{Status: apiv1.ClusterStatus{CurrentPrimary: podName}}
+		cacheClient := fakeCacheClient{envs: map[string][]string{}}
+
+		_, _, _, err := getWALRestoreSettings(ctx, cacheClient, cluster, podName, false)
+		Expect(err).To(MatchError(ErrNoBackupConfigured))
 	})
 })
 

--- a/internal/cmd/manager/walrestore/cmd_test.go
+++ b/internal/cmd/manager/walrestore/cmd_test.go
@@ -35,7 +35,8 @@ import (
 
 // fakeCacheClient is an in-memory implementation of local.CacheClient for tests.
 type fakeCacheClient struct {
-	envs map[string][]string
+	envs   map[string][]string
+	stores map[string]*apiv1.BarmanObjectStoreConfiguration
 }
 
 func (f fakeCacheClient) GetCluster() (*apiv1.Cluster, error) {
@@ -44,6 +45,13 @@ func (f fakeCacheClient) GetCluster() (*apiv1.Cluster, error) {
 
 func (f fakeCacheClient) GetEnv(key string) ([]string, error) {
 	if v, ok := f.envs[key]; ok {
+		return v, nil
+	}
+	return nil, cache.ErrCacheMiss
+}
+
+func (f fakeCacheClient) GetBarmanObjectStore(key string) (*apiv1.BarmanObjectStoreConfiguration, error) {
+	if v, ok := f.stores[key]; ok {
 		return v, nil
 	}
 	return nil, cache.ErrCacheMiss
@@ -204,58 +212,48 @@ var _ = Describe("getWALRestoreSettings", func() {
 		}
 	}
 
-	It("uses the cached bootstrap options and credentials during a recovery Job", func(ctx SpecContext) {
-		// recovery.backup reference: no primary elected yet, and the source store
-		// carries no parallelism setting, so prefetch defaults to a single segment.
-		cluster := &apiv1.Cluster{
-			Status: apiv1.ClusterStatus{CurrentPrimary: ""},
-			Spec: apiv1.ClusterSpec{
-				Bootstrap: &apiv1.BootstrapConfiguration{
-					Recovery: &apiv1.BootstrapRecovery{
-						Backup: &apiv1.BackupSource{
-							LocalObjectReference: apiv1.LocalObjectReference{Name: "a-backup"},
-						},
-					},
-				},
-			},
+	It("uses the cached bootstrap source store and credentials during a recovery Job", func(ctx SpecContext) {
+		// No primary elected yet, and the cached source store carries no
+		// parallelism setting, so prefetch defaults to a single segment.
+		cluster := &apiv1.Cluster{Status: apiv1.ClusterStatus{CurrentPrimary: ""}}
+		sourceStore := &apiv1.BarmanObjectStoreConfiguration{
+			BarmanCredentials: apiv1.BarmanCredentials{AWS: &apiv1.S3Credentials{}},
+			EndpointURL:       "https://source",
+			DestinationPath:   "s3://source/path",
+			ServerName:        "source-server",
 		}
-		bootstrapOptions := []string{"--endpoint-url", "https://source", "s3://source/path", "source-server"}
 		creds := []string{"AWS_ACCESS_KEY_ID=source-key"}
-		cacheClient := fakeCacheClient{envs: map[string][]string{
-			cache.WALRestoreOptionsKey: bootstrapOptions,
-			cache.WALRestoreKey:        creds,
-		}}
+		cacheClient := fakeCacheClient{
+			envs:   map[string][]string{cache.WALRestoreKey: creds},
+			stores: map[string]*apiv1.BarmanObjectStoreConfiguration{cache.WALRestoreConfigKey: sourceStore},
+		}
 
 		options, env, maxParallel, err := getWALRestoreSettings(ctx, cacheClient, cluster, podName, false)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(options).To(Equal(bootstrapOptions))
+		Expect(options).To(ContainElement("s3://source/path"))
+		Expect(options).To(ContainElement("source-server"))
+		Expect(options).To(ContainElement("https://source"))
 		Expect(env).To(Equal(creds))
 		Expect(maxParallel).To(Equal(1))
 	})
 
-	It("honors the recovery source store maxParallel during a recovery Job", func(ctx SpecContext) {
-		// recovery.source: prefetch parallelism comes from the source external
-		// cluster's object store, just like a replica restoring from that store.
-		cluster := &apiv1.Cluster{
-			Status: apiv1.ClusterStatus{CurrentPrimary: ""},
-			Spec: apiv1.ClusterSpec{
-				Bootstrap: &apiv1.BootstrapConfiguration{
-					Recovery: &apiv1.BootstrapRecovery{Source: "origin"},
-				},
-				ExternalClusters: []apiv1.ExternalCluster{
-					{
-						Name: "origin",
-						BarmanObjectStore: &apiv1.BarmanObjectStoreConfiguration{
-							Wal: &apiv1.WalBackupConfiguration{MaxParallel: 2},
-						},
-					},
-				},
+	It("honors the cached source store Wal config during a recovery Job", func(ctx SpecContext) {
+		// Prefetch parallelism and the additional command-line arguments come from
+		// the cached source store's Wal config, just like a running instance
+		// derives them from the store it restores from.
+		cluster := &apiv1.Cluster{Status: apiv1.ClusterStatus{CurrentPrimary: ""}}
+		sourceStore := &apiv1.BarmanObjectStoreConfiguration{
+			DestinationPath: "s3://source/path",
+			ServerName:      "source-server",
+			Wal: &apiv1.WalBackupConfiguration{
+				MaxParallel:                  2,
+				RestoreAdditionalCommandArgs: []string{"--read-timeout=60"},
 			},
 		}
-		cacheClient := fakeCacheClient{envs: map[string][]string{
-			cache.WALRestoreOptionsKey: {"s3://source/path", "origin"},
-			cache.WALRestoreKey:        {"AWS_ACCESS_KEY_ID=source-key"},
-		}}
+		cacheClient := fakeCacheClient{
+			envs:   map[string][]string{cache.WALRestoreKey: {"AWS_ACCESS_KEY_ID=source-key"}},
+			stores: map[string]*apiv1.BarmanObjectStoreConfiguration{cache.WALRestoreConfigKey: sourceStore},
+		}
 
 		_, _, maxParallel, err := getWALRestoreSettings(ctx, cacheClient, cluster, podName, false)
 		Expect(err).ToNot(HaveOccurred())
@@ -263,53 +261,45 @@ var _ = Describe("getWALRestoreSettings", func() {
 	})
 
 	It("disables prefetch in rewind mode, even with a configured maxParallel", func(ctx SpecContext) {
-		cluster := &apiv1.Cluster{
-			Status: apiv1.ClusterStatus{CurrentPrimary: ""},
-			Spec: apiv1.ClusterSpec{
-				Bootstrap: &apiv1.BootstrapConfiguration{
-					Recovery: &apiv1.BootstrapRecovery{Source: "origin"},
-				},
-				ExternalClusters: []apiv1.ExternalCluster{
-					{
-						Name: "origin",
-						BarmanObjectStore: &apiv1.BarmanObjectStoreConfiguration{
-							Wal: &apiv1.WalBackupConfiguration{MaxParallel: 2},
-						},
-					},
-				},
-			},
+		cluster := &apiv1.Cluster{Status: apiv1.ClusterStatus{CurrentPrimary: ""}}
+		sourceStore := &apiv1.BarmanObjectStoreConfiguration{
+			DestinationPath: "s3://source/path",
+			ServerName:      "source-server",
+			Wal:             &apiv1.WalBackupConfiguration{MaxParallel: 2},
 		}
-		cacheClient := fakeCacheClient{envs: map[string][]string{
-			cache.WALRestoreOptionsKey: {"s3://source/path", "origin"},
-			cache.WALRestoreKey:        {"AWS_ACCESS_KEY_ID=source-key"},
-		}}
+		cacheClient := fakeCacheClient{
+			envs:   map[string][]string{cache.WALRestoreKey: {"AWS_ACCESS_KEY_ID=source-key"}},
+			stores: map[string]*apiv1.BarmanObjectStoreConfiguration{cache.WALRestoreConfigKey: sourceStore},
+		}
 
 		_, _, maxParallel, err := getWALRestoreSettings(ctx, cacheClient, cluster, podName, true)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(maxParallel).To(Equal(1))
 	})
 
-	It("ignores cached bootstrap options once a primary has been elected", func(ctx SpecContext) {
+	It("ignores the cached bootstrap store once a primary has been elected", func(ctx SpecContext) {
 		cluster := clusterWithOwnBackup(podName)
-		cacheClient := fakeCacheClient{envs: map[string][]string{
+		cacheClient := fakeCacheClient{
+			envs: map[string][]string{cache.WALRestoreKey: {"AWS_ACCESS_KEY_ID=own-key"}},
 			// This must never be used: a running instance resolves the store from
-			// the cluster spec, not from the bootstrap options cache.
-			cache.WALRestoreOptionsKey: {"POISON-MUST-NOT-BE-USED"},
-			cache.WALRestoreKey:        {"AWS_ACCESS_KEY_ID=own-key"},
-		}}
+			// the cluster spec, not from the bootstrap cache.
+			stores: map[string]*apiv1.BarmanObjectStoreConfiguration{
+				cache.WALRestoreConfigKey: {DestinationPath: "s3://POISON-MUST-NOT-BE-USED"},
+			},
+		}
 
 		options, _, maxParallel, err := getWALRestoreSettings(ctx, cacheClient, cluster, podName, false)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(options).ToNot(ContainElement("POISON-MUST-NOT-BE-USED"))
+		Expect(options).ToNot(ContainElement("s3://POISON-MUST-NOT-BE-USED"))
 		Expect(options).To(ContainElement("s3://own-backup/path"))
 		Expect(maxParallel).To(Equal(3))
 	})
 
-	It("falls back to the cluster store during bootstrap when no options are cached", func(ctx SpecContext) {
+	It("falls back to the cluster store during bootstrap when no store is cached", func(ctx SpecContext) {
 		cluster := clusterWithOwnBackup("")
-		cacheClient := fakeCacheClient{envs: map[string][]string{
-			cache.WALRestoreKey: {"AWS_ACCESS_KEY_ID=own-key"},
-		}}
+		cacheClient := fakeCacheClient{
+			envs: map[string][]string{cache.WALRestoreKey: {"AWS_ACCESS_KEY_ID=own-key"}},
+		}
 
 		options, _, maxParallel, err := getWALRestoreSettings(ctx, cacheClient, cluster, podName, false)
 		Expect(err).ToNot(HaveOccurred())
@@ -330,7 +320,7 @@ var _ = Describe("getWALRestoreSettings", func() {
 
 	It("returns ErrNoBackupConfigured when nothing is available", func(ctx SpecContext) {
 		cluster := &apiv1.Cluster{Status: apiv1.ClusterStatus{CurrentPrimary: podName}}
-		cacheClient := fakeCacheClient{envs: map[string][]string{}}
+		cacheClient := fakeCacheClient{}
 
 		_, _, _, err := getWALRestoreSettings(ctx, cacheClient, cluster, podName, false)
 		Expect(err).To(MatchError(ErrNoBackupConfigured))

--- a/internal/cmd/manager/walrestore/cmd_test.go
+++ b/internal/cmd/manager/walrestore/cmd_test.go
@@ -37,6 +37,10 @@ import (
 type fakeCacheClient struct {
 	envs   map[string][]string
 	stores map[string]*apiv1.BarmanObjectStoreConfiguration
+	// storeErr, when set, is returned by GetBarmanObjectStore instead of
+	// cache.ErrCacheMiss, simulating a genuine cache-service failure (as
+	// opposed to the key simply never having been populated).
+	storeErr error
 }
 
 func (f fakeCacheClient) GetCluster() (*apiv1.Cluster, error) {
@@ -53,6 +57,9 @@ func (f fakeCacheClient) GetEnv(key string) ([]string, error) {
 func (f fakeCacheClient) GetBarmanObjectStore(key string) (*apiv1.BarmanObjectStoreConfiguration, error) {
 	if v, ok := f.stores[key]; ok {
 		return v, nil
+	}
+	if f.storeErr != nil {
+		return nil, f.storeErr
 	}
 	return nil, cache.ErrCacheMiss
 }
@@ -275,6 +282,31 @@ var _ = Describe("getWALRestoreSettings", func() {
 		_, _, maxParallel, err := getWALRestoreSettings(ctx, cacheClient, cluster, podName, true)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(maxParallel).To(Equal(1))
+	})
+
+	It("fails instead of falling back to the cluster's own store when the cached "+
+		"bootstrap store lookup fails for a reason other than a cache miss", func(ctx SpecContext) {
+		// No primary elected yet, so this is still within the bootstrap window,
+		// but the cache lookup fails with something other than a miss: a real
+		// failure that has already survived the cache client's own
+		// retry-with-backoff, as opposed to the key simply never having been
+		// populated. Falling through to the cluster's own backup store here
+		// would silently restore WALs from the wrong (and possibly unrelated
+		// or empty) destination instead of failing loudly.
+		cluster := clusterWithOwnBackup("")
+		injectedErr := errors.New("simulated cache-service failure")
+		cacheClient := fakeCacheClient{
+			envs: map[string][]string{cache.WALRestoreKey: {"AWS_ACCESS_KEY_ID=own-key"}},
+			// This must never be used: a genuine cache error must not be
+			// treated the same as "nothing cached yet".
+			stores:   map[string]*apiv1.BarmanObjectStoreConfiguration{},
+			storeErr: injectedErr,
+		}
+
+		options, _, _, err := getWALRestoreSettings(ctx, cacheClient, cluster, podName, false)
+		Expect(err).To(HaveOccurred())
+		Expect(errors.Is(err, injectedErr)).To(BeTrue())
+		Expect(options).To(BeNil())
 	})
 
 	It("ignores the cached bootstrap store once a primary has been elected", func(ctx SpecContext) {

--- a/internal/management/cache/cache.go
+++ b/internal/management/cache/cache.go
@@ -49,3 +49,14 @@ func LoadEnv(c string) ([]string, error) {
 
 	return nil, ErrUnsupportedObject
 }
+
+// Load reads an arbitrary object from the local cache. It returns ErrCacheMiss
+// when the key is not present.
+func Load(c string) (any, error) {
+	value, ok := cache.Load(c)
+	if !ok {
+		return nil, ErrCacheMiss
+	}
+
+	return value, nil
+}

--- a/internal/management/cache/keys.go
+++ b/internal/management/cache/keys.go
@@ -26,4 +26,10 @@ const (
 	WALArchiveKey = "wal-archive"
 	// WALRestoreKey is the key to be used to access the cached envs for wal-restore
 	WALRestoreKey = "wal-restore"
+	// WALRestoreOptionsKey is the key to be used to access the cached
+	// barman-cloud-wal-restore command-line options. It is populated only by the
+	// bootstrap recovery Job, which resolves the recovery source object store
+	// (not derivable from the cluster spec for a recovery.backup reference) and
+	// hands the options to the wal-restore command via the local webserver cache.
+	WALRestoreOptionsKey = "wal-restore-options"
 )

--- a/internal/management/cache/keys.go
+++ b/internal/management/cache/keys.go
@@ -26,10 +26,10 @@ const (
 	WALArchiveKey = "wal-archive"
 	// WALRestoreKey is the key to be used to access the cached envs for wal-restore
 	WALRestoreKey = "wal-restore"
-	// WALRestoreOptionsKey is the key to be used to access the cached
-	// barman-cloud-wal-restore command-line options. It is populated only by the
-	// bootstrap recovery Job, which resolves the recovery source object store
-	// (not derivable from the cluster spec for a recovery.backup reference) and
-	// hands the options to the wal-restore command via the local webserver cache.
-	WALRestoreOptionsKey = "wal-restore-options"
+	// WALRestoreConfigKey is the key to be used to access the cached recovery
+	// source object store configuration. It is populated only by the bootstrap
+	// recovery Job, which resolves that store (not derivable from the cluster
+	// spec for a recovery.backup reference) and hands it to the wal-restore
+	// command via the local webserver cache.
+	WALRestoreConfigKey = "wal-restore-config"
 )

--- a/pkg/management/postgres/restore.go
+++ b/pkg/management/postgres/restore.go
@@ -359,13 +359,7 @@ func (info InitInfo) ensureArchiveContainsLastCheckpointRedoWAL(
 		return err
 	}
 
-	opts, err := barmanCommand.CloudWalRestoreOptions(ctx, &apiv1.BarmanObjectStoreConfiguration{
-		BarmanCredentials: backup.Status.BarmanCredentials,
-		EndpointCA:        backup.Status.EndpointCA,
-		EndpointURL:       backup.Status.EndpointURL,
-		DestinationPath:   backup.Status.DestinationPath,
-		ServerName:        backup.Status.ServerName,
-	}, cluster.Name)
+	opts, err := barmanCommand.CloudWalRestoreOptions(ctx, barmanObjectStoreFromBackup(backup), cluster.Name)
 	if err != nil {
 		return err
 	}
@@ -585,13 +579,7 @@ func (info InitInfo) loadBackupFromReference(
 		ctx,
 		typedClient,
 		cluster.Namespace,
-		&apiv1.BarmanObjectStoreConfiguration{
-			BarmanCredentials: backup.Status.BarmanCredentials,
-			EndpointCA:        backup.Status.EndpointCA,
-			EndpointURL:       backup.Status.EndpointURL,
-			DestinationPath:   backup.Status.DestinationPath,
-			ServerName:        backup.Status.ServerName,
-		},
+		barmanObjectStoreFromBackup(&backup),
 		os.Environ())
 	if err != nil {
 		return nil, nil, err
@@ -649,6 +637,18 @@ func setupBootstrapWALRestoreCache(cluster *apiv1.Cluster, backup *apiv1.Backup,
 	cache.Store(cache.WALRestoreConfigKey, recoverySourceObjectStore(cluster, backup))
 }
 
+// barmanObjectStoreFromBackup maps the object store coordinates recorded in
+// the status of a Backup back to a barman object store configuration.
+func barmanObjectStoreFromBackup(backup *apiv1.Backup) *apiv1.BarmanObjectStoreConfiguration {
+	return &apiv1.BarmanObjectStoreConfiguration{
+		BarmanCredentials: backup.Status.BarmanCredentials,
+		EndpointCA:        backup.Status.EndpointCA,
+		EndpointURL:       backup.Status.EndpointURL,
+		DestinationPath:   backup.Status.DestinationPath,
+		ServerName:        backup.Status.ServerName,
+	}
+}
+
 // recoverySourceObjectStore returns the object store to restore WALs from during
 // a bootstrap recovery. The endpoint, destination, server name and credentials
 // come from the resolved Backup. For a recovery.source the source store's Wal
@@ -657,13 +657,7 @@ func setupBootstrapWALRestoreCache(cluster *apiv1.Cluster, backup *apiv1.Backup,
 // external cluster definition, so it is carried over here to mirror what the
 // Barman Cloud plugin does with its own ObjectStore resource.
 func recoverySourceObjectStore(cluster *apiv1.Cluster, backup *apiv1.Backup) *apiv1.BarmanObjectStoreConfiguration {
-	store := &apiv1.BarmanObjectStoreConfiguration{
-		BarmanCredentials: backup.Status.BarmanCredentials,
-		EndpointCA:        backup.Status.EndpointCA,
-		EndpointURL:       backup.Status.EndpointURL,
-		DestinationPath:   backup.Status.DestinationPath,
-		ServerName:        backup.Status.ServerName,
-	}
+	store := barmanObjectStoreFromBackup(backup)
 
 	source := cluster.Spec.Bootstrap.Recovery.Source
 	if source == "" {

--- a/pkg/management/postgres/restore.go
+++ b/pkg/management/postgres/restore.go
@@ -41,7 +41,6 @@ import (
 	barmanRestorer "github.com/cloudnative-pg/barman-cloud/pkg/restorer"
 	barmanUtils "github.com/cloudnative-pg/barman-cloud/pkg/utils"
 	"github.com/cloudnative-pg/cnpg-i/pkg/postgres"
-	restore "github.com/cloudnative-pg/cnpg-i/pkg/restore/job"
 	"github.com/cloudnative-pg/machinery/pkg/envmap"
 	"github.com/cloudnative-pg/machinery/pkg/execlog"
 	"github.com/cloudnative-pg/machinery/pkg/fileutils"
@@ -263,8 +262,6 @@ func (info InitInfo) createEnvAndConfigForSnapshotRestore(
 
 // Restore restores a PostgreSQL cluster from a backup into the object storage
 func (info InitInfo) Restore(ctx context.Context, cli client.Client) error {
-	contextLogger := log.FromContext(ctx)
-
 	cluster, err := info.loadCluster(ctx, cli)
 	if err != nil {
 		return err
@@ -280,57 +277,15 @@ func (info InitInfo) Restore(ctx context.Context, cli client.Client) error {
 		info.ApplicationDatabase = cluster.GetApplicationDatabaseName()
 	}
 
-	var envs []string
 	var config string
-
-	//nolint:nestif
+	var envs []string
 	if pluginConfiguration := cluster.GetRecoverySourcePlugin(); pluginConfiguration != nil {
-		contextLogger.Info("Restore through plugin detected, proceeding...")
-		res, err := restoreViaPlugin(ctx, cluster, pluginConfiguration)
-		if err != nil {
-			return err
-		}
-		if res == nil {
-			return errors.New("empty response from restoreViaPlugin, programmatic error")
-		}
-
-		processEnvironment, err := envmap.ParseEnviron()
-		if err != nil {
-			return fmt.Errorf("error while parsing the process environment: %w", err)
-		}
-
-		pluginEnvironment, err := envmap.Parse(res.Envs)
-		if err != nil {
-			return fmt.Errorf("error while parsing the plugin environment: %w", err)
-		}
-
-		envs = envmap.Merge(processEnvironment, pluginEnvironment).StringSlice()
-		config = res.RestoreConfig
+		config, envs, err = restoreViaPlugin(ctx, cluster, pluginConfiguration)
 	} else {
-		// Before starting the restore we check if the archive destination is safe to use
-		// otherwise, we stop creating the cluster
-		err = info.checkBackupDestination(ctx, cli, cluster)
-		if err != nil {
-			return err
-		}
-
-		// If we need to download data from a backup, we do it
-		backup, env, err := info.loadBackup(ctx, cli, cluster)
-		if err != nil {
-			return err
-		}
-
-		if err := info.ensureArchiveContainsLastCheckpointRedoWAL(ctx, cluster, env, backup); err != nil {
-			return err
-		}
-
-		if err := info.restoreDataDir(ctx, backup, env); err != nil {
-			return err
-		}
-
-		setupBootstrapWALRestoreCache(cluster, backup, env)
-		config = getRestoreWalConfig()
-		envs = env
+		config, envs, err = info.restoreViaBarmanObjectStore(ctx, cli, cluster)
+	}
+	if err != nil {
+		return err
 	}
 
 	return info.concludeRestore(ctx, cli, cluster, config, envs)
@@ -1076,14 +1031,16 @@ func waitUntilRecoveryFinishes(db *sql.DB) error {
 	})
 }
 
-// restoreViaPlugin tries to restore the cluster using a plugin if available and enabled.
-// Returns true if a restore plugin was found and any error encountered.
+// restoreViaPlugin restores the cluster using the configured recovery source
+// plugin, returning the restore configuration and the environment the plugin
+// produced.
 func restoreViaPlugin(
 	ctx context.Context,
 	cluster *apiv1.Cluster,
 	plugin *apiv1.PluginConfiguration,
-) (*restore.RestoreResponse, error) {
+) (config string, envs []string, err error) {
 	contextLogger := log.FromContext(ctx)
+	contextLogger.Info("Restore through plugin detected, proceeding...")
 
 	plugins := repository.New()
 	defer plugins.Close()
@@ -1093,9 +1050,60 @@ func restoreViaPlugin(
 	pClient, err := pluginClient.NewClient(ctx, pluginEnabledSet)
 	if err != nil {
 		contextLogger.Error(err, "Error while loading required plugins")
-		return nil, err
+		return "", nil, err
 	}
 	defer pClient.Close(ctx)
 
-	return pClient.Restore(ctx, cluster)
+	res, err := pClient.Restore(ctx, cluster)
+	if err != nil {
+		return "", nil, err
+	}
+	if res == nil {
+		return "", nil, errors.New("empty response from restoreViaPlugin, programmatic error")
+	}
+
+	processEnvironment, err := envmap.ParseEnviron()
+	if err != nil {
+		return "", nil, fmt.Errorf("error while parsing the process environment: %w", err)
+	}
+
+	pluginEnvironment, err := envmap.Parse(res.Envs)
+	if err != nil {
+		return "", nil, fmt.Errorf("error while parsing the plugin environment: %w", err)
+	}
+
+	return res.RestoreConfig, envmap.Merge(processEnvironment, pluginEnvironment).StringSlice(), nil
+}
+
+// restoreViaBarmanObjectStore restores the base backup from a Barman Cloud
+// object store, primes the bootstrap WAL-restore cache, and returns the
+// WAL-restore configuration and environment for the recovery phase.
+func (info InitInfo) restoreViaBarmanObjectStore(
+	ctx context.Context,
+	cli client.Client,
+	cluster *apiv1.Cluster,
+) (config string, envs []string, err error) {
+	// Before starting the restore we check if the archive destination is safe to
+	// use, otherwise we stop creating the cluster.
+	if err := info.checkBackupDestination(ctx, cli, cluster); err != nil {
+		return "", nil, err
+	}
+
+	// If we need to download data from a backup, we do it.
+	backup, env, err := info.loadBackup(ctx, cli, cluster)
+	if err != nil {
+		return "", nil, err
+	}
+
+	if err := info.ensureArchiveContainsLastCheckpointRedoWAL(ctx, cluster, env, backup); err != nil {
+		return "", nil, err
+	}
+
+	if err := info.restoreDataDir(ctx, backup, env); err != nil {
+		return "", nil, err
+	}
+
+	setupBootstrapWALRestoreCache(cluster, backup, env)
+
+	return getRestoreWalConfig(), env, nil
 }

--- a/pkg/management/postgres/restore.go
+++ b/pkg/management/postgres/restore.go
@@ -641,16 +641,10 @@ func getRestoreWalConfig() string {
 // resolve it here, where it is already available, and cache the whole store so
 // the wal-restore command can derive its options and prefetch parallelism from
 // it, exactly as it does for a running instance.
+//
+// For a replica cluster the Job configures streaming replication instead of
+// replaying WAL, so the cached values are simply never read there.
 func setupBootstrapWALRestoreCache(cluster *apiv1.Cluster, backup *apiv1.Backup, env []string) {
-	// A replica cluster configures streaming replication and does not replay WAL
-	// in this Job: concludeRestore returns before starting PostgreSQL, so the
-	// wal-restore command is never invoked here and this cache would never be
-	// read. Its WALs are restored later by the running instance, using the cache
-	// the reconciler populates in that pod.
-	if cluster.IsReplica() {
-		return
-	}
-
 	cache.Store(cache.WALRestoreKey, env)
 	cache.Store(cache.WALRestoreConfigKey, recoverySourceObjectStore(cluster, backup))
 }

--- a/pkg/management/postgres/restore.go
+++ b/pkg/management/postgres/restore.go
@@ -148,19 +148,18 @@ func (info InitInfo) RestoreSnapshot(ctx context.Context, cli client.Client, imm
 	}
 
 	var envs []string
-	config := getRestoreWalConfig()
 
 	if pluginConfiguration := cluster.GetRecoverySourcePlugin(); pluginConfiguration == nil {
 		server, found := cluster.ExternalCluster(cluster.Spec.Bootstrap.Recovery.Source)
 		if found && server.BarmanObjectStore != nil {
-			envs, config, err = info.createEnvAndConfigForSnapshotRestore(ctx, cli, cluster, &server)
+			envs, err = info.createEnvAndConfigForSnapshotRestore(ctx, cli, cluster, &server)
 			if err != nil {
 				return err
 			}
 		}
 	}
 
-	return info.concludeRestore(ctx, cli, cluster, config, envs)
+	return info.concludeRestore(ctx, cli, cluster, getRestoreWalConfig(), envs)
 }
 
 func (info InitInfo) concludeRestore(
@@ -215,13 +214,16 @@ func (info InitInfo) concludeRestore(
 	return info.ConfigureInstanceAfterRestore(ctx, cluster, envs)
 }
 
-// createEnvAndConfigForSnapshotRestore creates env and config for snapshot restore
+// createEnvAndConfigForSnapshotRestore builds the WAL-restore environment for a
+// snapshot restore from an external object store and primes the bootstrap
+// WAL-restore cache. The restore configuration itself is path-independent, so
+// the caller obtains it from getRestoreWalConfig.
 func (info InitInfo) createEnvAndConfigForSnapshotRestore(
 	ctx context.Context,
 	typedClient client.Client,
 	cluster *apiv1.Cluster,
 	server *apiv1.ExternalCluster,
-) ([]string, string, error) {
+) ([]string, error) {
 	contextLogger := log.FromContext(ctx)
 
 	contextLogger.Info("Recovering from external cluster", "sourceName", server.Name)
@@ -235,7 +237,7 @@ func (info InitInfo) createEnvAndConfigForSnapshotRestore(
 		server.BarmanObjectStore,
 		os.Environ())
 	if err != nil {
-		return nil, "", err
+		return nil, err
 	}
 
 	backup := &apiv1.Backup{
@@ -256,7 +258,7 @@ func (info InitInfo) createEnvAndConfigForSnapshotRestore(
 
 	setupBootstrapWALRestoreCache(cluster, backup, env)
 
-	return env, getRestoreWalConfig(), nil
+	return env, nil
 }
 
 // Restore restores a PostgreSQL cluster from a backup into the object storage

--- a/pkg/management/postgres/restore.go
+++ b/pkg/management/postgres/restore.go
@@ -649,6 +649,15 @@ func setupBootstrapWALRestoreCache(
 	backup *apiv1.Backup,
 	env []string,
 ) error {
+	// A replica cluster configures streaming replication and does not replay WAL
+	// in this Job: concludeRestore returns before starting PostgreSQL, so the
+	// wal-restore command is never invoked here and this cache would never be
+	// read. Its WALs are restored later by the running instance, using the cache
+	// the reconciler populates in that pod.
+	if cluster.IsReplica() {
+		return nil
+	}
+
 	sourceStore := recoverySourceObjectStore(cluster, backup)
 
 	options, err := barmanCommand.CloudWalRestoreOptions(ctx, sourceStore, backup.Status.ServerName)

--- a/pkg/management/postgres/restore.go
+++ b/pkg/management/postgres/restore.go
@@ -254,9 +254,7 @@ func (info InitInfo) createEnvAndConfigForSnapshotRestore(
 		},
 	}
 
-	if err := setupBootstrapWALRestoreCache(ctx, cluster, backup, env); err != nil {
-		return nil, "", err
-	}
+	setupBootstrapWALRestoreCache(cluster, backup, env)
 
 	return env, getRestoreWalConfig(), nil
 }
@@ -328,9 +326,7 @@ func (info InitInfo) Restore(ctx context.Context, cli client.Client) error {
 			return err
 		}
 
-		if err := setupBootstrapWALRestoreCache(ctx, cluster, backup, env); err != nil {
-			return err
-		}
+		setupBootstrapWALRestoreCache(cluster, backup, env)
 		config = getRestoreWalConfig()
 		envs = env
 	}
@@ -636,48 +632,36 @@ func getRestoreWalConfig() string {
 }
 
 // setupBootstrapWALRestoreCache populates the local webserver cache with the
-// recovery source object store options and credentials. During the bootstrap
-// recovery Job the instance-manager reconciler that normally fills this cache is
-// not running, so PostgreSQL's restore_command (`/controller/manager
+// recovery source object store configuration and credentials. During the
+// bootstrap recovery Job the instance-manager reconciler that normally fills
+// this cache is not running, so PostgreSQL's restore_command (`/controller/manager
 // wal-restore`) would otherwise be unable to resolve the recovery source. The
 // source store is not always derivable from the cluster spec (for a
 // recovery.backup reference it lives only in the referenced Backup CR), so we
-// resolve it here, where it is already available, and cache it for wal-restore.
-func setupBootstrapWALRestoreCache(
-	ctx context.Context,
-	cluster *apiv1.Cluster,
-	backup *apiv1.Backup,
-	env []string,
-) error {
+// resolve it here, where it is already available, and cache the whole store so
+// the wal-restore command can derive its options and prefetch parallelism from
+// it, exactly as it does for a running instance.
+func setupBootstrapWALRestoreCache(cluster *apiv1.Cluster, backup *apiv1.Backup, env []string) {
 	// A replica cluster configures streaming replication and does not replay WAL
 	// in this Job: concludeRestore returns before starting PostgreSQL, so the
 	// wal-restore command is never invoked here and this cache would never be
 	// read. Its WALs are restored later by the running instance, using the cache
 	// the reconciler populates in that pod.
 	if cluster.IsReplica() {
-		return nil
-	}
-
-	sourceStore := recoverySourceObjectStore(cluster, backup)
-
-	options, err := barmanCommand.CloudWalRestoreOptions(ctx, sourceStore, backup.Status.ServerName)
-	if err != nil {
-		return fmt.Errorf("while building the wal-restore options for the recovery source: %w", err)
+		return
 	}
 
 	cache.Store(cache.WALRestoreKey, env)
-	cache.Store(cache.WALRestoreOptionsKey, options)
-
-	return nil
+	cache.Store(cache.WALRestoreConfigKey, recoverySourceObjectStore(cluster, backup))
 }
 
 // recoverySourceObjectStore returns the object store to restore WALs from during
 // a bootstrap recovery. The endpoint, destination, server name and credentials
 // come from the resolved Backup. For a recovery.source the source store's Wal
-// configuration (the additional barman-cloud-wal-restore command-line arguments,
-// and the prefetch parallelism honored separately by the wal-restore command) is
-// recorded only in the external cluster definition, so it is carried over here
-// to mirror what the Barman Cloud plugin does with its own ObjectStore resource.
+// configuration (the prefetch parallelism and the additional
+// barman-cloud-wal-restore command-line arguments) is recorded only in the
+// external cluster definition, so it is carried over here to mirror what the
+// Barman Cloud plugin does with its own ObjectStore resource.
 func recoverySourceObjectStore(cluster *apiv1.Cluster, backup *apiv1.Backup) *apiv1.BarmanObjectStoreConfiguration {
 	store := &apiv1.BarmanObjectStoreConfiguration{
 		BarmanCredentials: backup.Status.BarmanCredentials,

--- a/pkg/management/postgres/restore.go
+++ b/pkg/management/postgres/restore.go
@@ -47,7 +47,6 @@ import (
 	"github.com/cloudnative-pg/machinery/pkg/fileutils"
 	"github.com/cloudnative-pg/machinery/pkg/log"
 	"github.com/cloudnative-pg/machinery/pkg/stringset"
-	"github.com/kballard/go-shellquote"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
@@ -56,6 +55,7 @@ import (
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	pluginClient "github.com/cloudnative-pg/cloudnative-pg/internal/cnpi/plugin/client"
 	"github.com/cloudnative-pg/cloudnative-pg/internal/cnpi/plugin/repository"
+	"github.com/cloudnative-pg/cloudnative-pg/internal/management/cache"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/configfile"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/external"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres/constants"
@@ -148,17 +148,7 @@ func (info InitInfo) RestoreSnapshot(ctx context.Context, cli client.Client, imm
 	}
 
 	var envs []string
-	// Operator-controlled command: LogPath and LogFileName are operator
-	// constants, so no shell-quoting layer is needed here. The config-file
-	// literal escaping is still applied for consistency with the WAL-restore
-	// path in getRestoreWalConfig.
-	restoreCmd := fmt.Sprintf(
-		"/controller/manager wal-restore --log-destination %s/%s.json %%f %%p",
-		postgresSpec.LogPath, postgresSpec.LogFileName)
-	config := configfile.RenderPostgresConfiguration(map[string]string{
-		"recovery_target_action": "promote",
-		"restore_command":        restoreCmd,
-	})
+	config := getRestoreWalConfig()
 
 	if pluginConfiguration := cluster.GetRecoverySourcePlugin(); pluginConfiguration == nil {
 		server, found := cluster.ExternalCluster(cluster.Spec.Bootstrap.Recovery.Source)
@@ -264,8 +254,11 @@ func (info InitInfo) createEnvAndConfigForSnapshotRestore(
 		},
 	}
 
-	config, err := getRestoreWalConfig(ctx, backup)
-	return env, config, err
+	if err := setupBootstrapWALRestoreCache(ctx, cluster, backup, env); err != nil {
+		return nil, "", err
+	}
+
+	return env, getRestoreWalConfig(), nil
 }
 
 // Restore restores a PostgreSQL cluster from a backup into the object storage
@@ -335,11 +328,10 @@ func (info InitInfo) Restore(ctx context.Context, cli client.Client) error {
 			return err
 		}
 
-		conf, err := getRestoreWalConfig(ctx, backup)
-		if err != nil {
+		if err := setupBootstrapWALRestoreCache(ctx, cluster, backup, env); err != nil {
 			return err
 		}
-		config = conf
+		config = getRestoreWalConfig()
 		envs = env
 	}
 
@@ -625,29 +617,77 @@ func (info InitInfo) writeCustomRestoreWalConfig(cluster *apiv1.Cluster, conf st
 
 // getRestoreWalConfig obtains the content to append to `custom.conf` allowing PostgreSQL
 // to complete the WAL recovery from the object storage and then start
-// as a new primary
-func getRestoreWalConfig(ctx context.Context, backup *apiv1.Backup) (string, error) {
-	var err error
-
-	cmd := []string{barmanUtils.BarmanCloudWalRestore}
-	if backup.Status.EndpointURL != "" {
-		cmd = append(cmd, "--endpoint-url", backup.Status.EndpointURL)
-	}
-	cmd = append(cmd, backup.Status.DestinationPath)
-	cmd = append(cmd, backup.Status.ServerName)
-
-	cmd, err = barmanCommand.AppendCloudProviderOptionsFromBackup(
-		ctx, cmd, backup.Status.BarmanCredentials)
-	if err != nil {
-		return "", err
-	}
-
-	cmd = append(cmd, "%f", "%p")
+// as a new primary.
+//
+// WAL recovery is delegated to `/controller/manager wal-restore`, the same
+// command HA replicas and CNPG-I plugin restores use. The recovery source
+// object store and its credentials never end up in the command line: they are
+// handed to that command through the local webserver cache, populated by
+// setupBootstrapWALRestoreCache.
+func getRestoreWalConfig() string {
+	restoreCommand := fmt.Sprintf(
+		"/controller/manager wal-restore --log-destination %s/%s.json %%f %%p",
+		postgresSpec.LogPath, postgresSpec.LogFileName)
 
 	return configfile.RenderPostgresConfiguration(map[string]string{
 		"recovery_target_action": "promote",
-		"restore_command":        shellquote.Join(cmd...),
-	}), nil
+		"restore_command":        restoreCommand,
+	})
+}
+
+// setupBootstrapWALRestoreCache populates the local webserver cache with the
+// recovery source object store options and credentials. During the bootstrap
+// recovery Job the instance-manager reconciler that normally fills this cache is
+// not running, so PostgreSQL's restore_command (`/controller/manager
+// wal-restore`) would otherwise be unable to resolve the recovery source. The
+// source store is not always derivable from the cluster spec (for a
+// recovery.backup reference it lives only in the referenced Backup CR), so we
+// resolve it here, where it is already available, and cache it for wal-restore.
+func setupBootstrapWALRestoreCache(
+	ctx context.Context,
+	cluster *apiv1.Cluster,
+	backup *apiv1.Backup,
+	env []string,
+) error {
+	sourceStore := recoverySourceObjectStore(cluster, backup)
+
+	options, err := barmanCommand.CloudWalRestoreOptions(ctx, sourceStore, backup.Status.ServerName)
+	if err != nil {
+		return fmt.Errorf("while building the wal-restore options for the recovery source: %w", err)
+	}
+
+	cache.Store(cache.WALRestoreKey, env)
+	cache.Store(cache.WALRestoreOptionsKey, options)
+
+	return nil
+}
+
+// recoverySourceObjectStore returns the object store to restore WALs from during
+// a bootstrap recovery. The endpoint, destination, server name and credentials
+// come from the resolved Backup. For a recovery.source the source store's Wal
+// configuration (the additional barman-cloud-wal-restore command-line arguments,
+// and the prefetch parallelism honored separately by the wal-restore command) is
+// recorded only in the external cluster definition, so it is carried over here
+// to mirror what the Barman Cloud plugin does with its own ObjectStore resource.
+func recoverySourceObjectStore(cluster *apiv1.Cluster, backup *apiv1.Backup) *apiv1.BarmanObjectStoreConfiguration {
+	store := &apiv1.BarmanObjectStoreConfiguration{
+		BarmanCredentials: backup.Status.BarmanCredentials,
+		EndpointCA:        backup.Status.EndpointCA,
+		EndpointURL:       backup.Status.EndpointURL,
+		DestinationPath:   backup.Status.DestinationPath,
+		ServerName:        backup.Status.ServerName,
+	}
+
+	source := cluster.Spec.Bootstrap.Recovery.Source
+	if source == "" {
+		// recovery.backup reference: the Backup CR records no Wal configuration.
+		return store
+	}
+	if externalCluster, found := cluster.ExternalCluster(source); found && externalCluster.BarmanObjectStore != nil {
+		store.Wal = externalCluster.BarmanObjectStore.Wal
+	}
+
+	return store
 }
 
 func (info InitInfo) writeRecoveryConfiguration(cluster *apiv1.Cluster, recoveryFileContents string) error {

--- a/pkg/management/postgres/restore_test.go
+++ b/pkg/management/postgres/restore_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/cloudnative-pg/machinery/pkg/fileutils"
 	"github.com/thoas/go-funk"
+	"k8s.io/utils/ptr"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/internal/management/cache"
@@ -302,5 +303,32 @@ var _ = Describe("setupBootstrapWALRestoreCache", func() {
 			options, err := cache.LoadEnv(cache.WALRestoreOptionsKey)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(options).To(ContainElement("--read-timeout=60"))
+		})
+
+	It("does not populate the cache for a replica cluster",
+		func(ctx SpecContext) {
+			// A replica cluster does not replay WAL in the recovery Job, so this
+			// cache would never be read; populating it is pointless.
+			cluster := &apiv1.Cluster{
+				Spec: apiv1.ClusterSpec{
+					Bootstrap: &apiv1.BootstrapConfiguration{
+						Recovery: &apiv1.BootstrapRecovery{Source: "origin"},
+					},
+					ExternalClusters: []apiv1.ExternalCluster{
+						{Name: "origin", BarmanObjectStore: &apiv1.BarmanObjectStoreConfiguration{}},
+					},
+					ReplicaCluster: &apiv1.ReplicaClusterConfiguration{
+						Enabled: ptr.To(true),
+						Source:  "origin",
+					},
+				},
+			}
+
+			Expect(setupBootstrapWALRestoreCache(ctx, cluster, backup(), []string{"X=y"})).To(Succeed())
+
+			_, err := cache.LoadEnv(cache.WALRestoreOptionsKey)
+			Expect(err).To(MatchError(cache.ErrCacheMiss))
+			_, err = cache.LoadEnv(cache.WALRestoreKey)
+			Expect(err).To(MatchError(cache.ErrCacheMiss))
 		})
 })

--- a/pkg/management/postgres/restore_test.go
+++ b/pkg/management/postgres/restore_test.go
@@ -230,7 +230,7 @@ var _ = Describe("getRestoreWalConfig", func() {
 var _ = Describe("setupBootstrapWALRestoreCache", func() {
 	AfterEach(func() {
 		cache.Delete(cache.WALRestoreKey)
-		cache.Delete(cache.WALRestoreOptionsKey)
+		cache.Delete(cache.WALRestoreConfigKey)
 	})
 
 	backup := func() *apiv1.Backup {
@@ -244,91 +244,97 @@ var _ = Describe("setupBootstrapWALRestoreCache", func() {
 		}
 	}
 
-	It("caches the recovery source store options and credentials for a recovery.backup reference",
-		func(ctx SpecContext) {
-			// recovery.backup: no Source, so no Wal config is available.
-			cluster := &apiv1.Cluster{
-				Spec: apiv1.ClusterSpec{
-					Bootstrap: &apiv1.BootstrapConfiguration{
-						Recovery: &apiv1.BootstrapRecovery{
-							Backup: &apiv1.BackupSource{
-								LocalObjectReference: apiv1.LocalObjectReference{Name: "a-backup"},
+	loadCachedStore := func() *apiv1.BarmanObjectStoreConfiguration {
+		cached, err := cache.Load(cache.WALRestoreConfigKey)
+		Expect(err).ToNot(HaveOccurred())
+		store, ok := cached.(*apiv1.BarmanObjectStoreConfiguration)
+		Expect(ok).To(BeTrue())
+		return store
+	}
+
+	It("caches the recovery source store and credentials for a recovery.backup reference", func() {
+		// recovery.backup: no Source, so no Wal config is available.
+		cluster := &apiv1.Cluster{
+			Spec: apiv1.ClusterSpec{
+				Bootstrap: &apiv1.BootstrapConfiguration{
+					Recovery: &apiv1.BootstrapRecovery{
+						Backup: &apiv1.BackupSource{
+							LocalObjectReference: apiv1.LocalObjectReference{Name: "a-backup"},
+						},
+					},
+				},
+			},
+		}
+		env := []string{"AWS_ACCESS_KEY_ID=source-key"}
+
+		setupBootstrapWALRestoreCache(cluster, backup(), env)
+
+		cachedEnv, err := cache.LoadEnv(cache.WALRestoreKey)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(cachedEnv).To(Equal(env))
+
+		// The cached store must target the recovery SOURCE, not the cluster's own
+		// backup store, and carries no Wal config for a recovery.backup reference.
+		store := loadCachedStore()
+		Expect(store.DestinationPath).To(Equal("s3://source/path"))
+		Expect(store.ServerName).To(Equal("source-server"))
+		Expect(store.EndpointURL).To(Equal("https://source-endpoint"))
+		Expect(store.Wal).To(BeNil())
+	})
+
+	It("carries the source store's Wal config for a recovery.source", func() {
+		// recovery.source: the source store's Wal config lives in the external
+		// cluster definition and must be carried over, just like the plugin does.
+		cluster := &apiv1.Cluster{
+			Spec: apiv1.ClusterSpec{
+				Bootstrap: &apiv1.BootstrapConfiguration{
+					Recovery: &apiv1.BootstrapRecovery{Source: "origin"},
+				},
+				ExternalClusters: []apiv1.ExternalCluster{
+					{
+						Name: "origin",
+						BarmanObjectStore: &apiv1.BarmanObjectStoreConfiguration{
+							Wal: &apiv1.WalBackupConfiguration{
+								MaxParallel:                  2,
+								RestoreAdditionalCommandArgs: []string{"--read-timeout=60"},
 							},
 						},
 					},
 				},
-			}
-			env := []string{"AWS_ACCESS_KEY_ID=source-key"}
+			},
+		}
 
-			Expect(setupBootstrapWALRestoreCache(ctx, cluster, backup(), env)).To(Succeed())
+		setupBootstrapWALRestoreCache(cluster, backup(), []string{"X=y"})
 
-			cachedEnv, err := cache.LoadEnv(cache.WALRestoreKey)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(cachedEnv).To(Equal(env))
+		store := loadCachedStore()
+		Expect(store.Wal).ToNot(BeNil())
+		Expect(store.Wal.MaxParallel).To(Equal(2))
+		Expect(store.Wal.RestoreAdditionalCommandArgs).To(ContainElement("--read-timeout=60"))
+	})
 
-			options, err := cache.LoadEnv(cache.WALRestoreOptionsKey)
-			Expect(err).ToNot(HaveOccurred())
-			// Options must target the recovery SOURCE store, not the cluster's
-			// own backup store.
-			Expect(options).To(ContainElement("s3://source/path"))
-			Expect(options).To(ContainElement("source-server"))
-			Expect(options).To(ContainElement("https://source-endpoint"))
-			Expect(options).To(ContainElement("aws-s3"))
-		})
-
-	It("carries the source store's additional command args for a recovery.source",
-		func(ctx SpecContext) {
-			// recovery.source: the source store's Wal config lives in the external
-			// cluster definition and must be applied, just like the plugin does.
-			cluster := &apiv1.Cluster{
-				Spec: apiv1.ClusterSpec{
-					Bootstrap: &apiv1.BootstrapConfiguration{
-						Recovery: &apiv1.BootstrapRecovery{Source: "origin"},
-					},
-					ExternalClusters: []apiv1.ExternalCluster{
-						{
-							Name: "origin",
-							BarmanObjectStore: &apiv1.BarmanObjectStoreConfiguration{
-								Wal: &apiv1.WalBackupConfiguration{
-									RestoreAdditionalCommandArgs: []string{"--read-timeout=60"},
-								},
-							},
-						},
-					},
+	It("does not populate the cache for a replica cluster", func() {
+		// A replica cluster does not replay WAL in the recovery Job, so this
+		// cache would never be read; populating it is pointless.
+		cluster := &apiv1.Cluster{
+			Spec: apiv1.ClusterSpec{
+				Bootstrap: &apiv1.BootstrapConfiguration{
+					Recovery: &apiv1.BootstrapRecovery{Source: "origin"},
 				},
-			}
-
-			Expect(setupBootstrapWALRestoreCache(ctx, cluster, backup(), []string{"X=y"})).To(Succeed())
-
-			options, err := cache.LoadEnv(cache.WALRestoreOptionsKey)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(options).To(ContainElement("--read-timeout=60"))
-		})
-
-	It("does not populate the cache for a replica cluster",
-		func(ctx SpecContext) {
-			// A replica cluster does not replay WAL in the recovery Job, so this
-			// cache would never be read; populating it is pointless.
-			cluster := &apiv1.Cluster{
-				Spec: apiv1.ClusterSpec{
-					Bootstrap: &apiv1.BootstrapConfiguration{
-						Recovery: &apiv1.BootstrapRecovery{Source: "origin"},
-					},
-					ExternalClusters: []apiv1.ExternalCluster{
-						{Name: "origin", BarmanObjectStore: &apiv1.BarmanObjectStoreConfiguration{}},
-					},
-					ReplicaCluster: &apiv1.ReplicaClusterConfiguration{
-						Enabled: ptr.To(true),
-						Source:  "origin",
-					},
+				ExternalClusters: []apiv1.ExternalCluster{
+					{Name: "origin", BarmanObjectStore: &apiv1.BarmanObjectStoreConfiguration{}},
 				},
-			}
+				ReplicaCluster: &apiv1.ReplicaClusterConfiguration{
+					Enabled: ptr.To(true),
+					Source:  "origin",
+				},
+			},
+		}
 
-			Expect(setupBootstrapWALRestoreCache(ctx, cluster, backup(), []string{"X=y"})).To(Succeed())
+		setupBootstrapWALRestoreCache(cluster, backup(), []string{"X=y"})
 
-			_, err := cache.LoadEnv(cache.WALRestoreOptionsKey)
-			Expect(err).To(MatchError(cache.ErrCacheMiss))
-			_, err = cache.LoadEnv(cache.WALRestoreKey)
-			Expect(err).To(MatchError(cache.ErrCacheMiss))
-		})
+		_, err := cache.Load(cache.WALRestoreConfigKey)
+		Expect(err).To(MatchError(cache.ErrCacheMiss))
+		_, err = cache.LoadEnv(cache.WALRestoreKey)
+		Expect(err).To(MatchError(cache.ErrCacheMiss))
+	})
 })

--- a/pkg/management/postgres/restore_test.go
+++ b/pkg/management/postgres/restore_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/thoas/go-funk"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	"github.com/cloudnative-pg/cloudnative-pg/internal/management/cache"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -209,69 +210,97 @@ var _ = Describe("testing restore InitInfo methods", func() {
 })
 
 var _ = Describe("getRestoreWalConfig", func() {
-	It("escapes quotes and backslashes across both shell and config layers",
+	It("delegates WAL recovery to the instance manager wal-restore command", func() {
+		out := getRestoreWalConfig()
+
+		// restore_command must invoke the in-tree controller rather than
+		// barman-cloud directly: the recovery source store and credentials are
+		// provided through the local webserver cache instead of being embedded
+		// in (and shell-quoted into) the command line.
+		Expect(out).To(ContainSubstring("/controller/manager wal-restore"))
+		Expect(out).To(ContainSubstring("%f"))
+		Expect(out).To(ContainSubstring("%p"))
+		Expect(out).To(ContainSubstring("recovery_target_action"))
+		Expect(out).To(ContainSubstring("promote"))
+		Expect(out).ToNot(ContainSubstring("barman-cloud-wal-restore"))
+	})
+})
+
+var _ = Describe("setupBootstrapWALRestoreCache", func() {
+	AfterEach(func() {
+		cache.Delete(cache.WALRestoreKey)
+		cache.Delete(cache.WALRestoreOptionsKey)
+	})
+
+	backup := func() *apiv1.Backup {
+		return &apiv1.Backup{
+			Status: apiv1.BackupStatus{
+				BarmanCredentials: apiv1.BarmanCredentials{AWS: &apiv1.S3Credentials{}},
+				EndpointURL:       "https://source-endpoint",
+				DestinationPath:   "s3://source/path",
+				ServerName:        "source-server",
+			},
+		}
+	}
+
+	It("caches the recovery source store options and credentials for a recovery.backup reference",
 		func(ctx SpecContext) {
-			backup := &apiv1.Backup{
-				Status: apiv1.BackupStatus{
-					DestinationPath: "s3://bucket/has'quote",
-					ServerName:      `server\name`,
+			// recovery.backup: no Source, so no Wal config is available.
+			cluster := &apiv1.Cluster{
+				Spec: apiv1.ClusterSpec{
+					Bootstrap: &apiv1.BootstrapConfiguration{
+						Recovery: &apiv1.BootstrapRecovery{
+							Backup: &apiv1.BackupSource{
+								LocalObjectReference: apiv1.LocalObjectReference{Name: "a-backup"},
+							},
+						},
+					},
 				},
 			}
-			out, err := getRestoreWalConfig(ctx, backup)
+			env := []string{"AWS_ACCESS_KEY_ID=source-key"}
+
+			Expect(setupBootstrapWALRestoreCache(ctx, cluster, backup(), env)).To(Succeed())
+
+			cachedEnv, err := cache.LoadEnv(cache.WALRestoreKey)
 			Expect(err).ToNot(HaveOccurred())
+			Expect(cachedEnv).To(Equal(env))
 
-			// shellQuote wraps the value as has\'quote (escape).
-			// configfile.EscapePostgresConfLiteral then doubles every ' and \,
-			// yielding the exact form below at the config-file layer.
-			Expect(out).To(ContainSubstring(`s3://bucket/has\\''quote`))
-			// shellQuote quotes `\` to `\\` — config layer doubles the
-			// backslash.
-			Expect(out).To(ContainSubstring(`server\\\\name`))
-
-			// Raw unescaped forms must not appear — either would let the user
-			// break out of the config-file string literal.
-			Expect(out).NotTo(ContainSubstring("has'quote"))
-			Expect(out).NotTo(MatchRegexp(`server\\[^\\]name`),
-				"backslash in server name must be doubled")
+			options, err := cache.LoadEnv(cache.WALRestoreOptionsKey)
+			Expect(err).ToNot(HaveOccurred())
+			// Options must target the recovery SOURCE store, not the cluster's
+			// own backup store.
+			Expect(options).To(ContainElement("s3://source/path"))
+			Expect(options).To(ContainElement("source-server"))
+			Expect(options).To(ContainElement("https://source-endpoint"))
+			Expect(options).To(ContainElement("aws-s3"))
 		})
 
-	It("shell-quotes cmd args so whitespace in user-controlled fields does not word-split",
+	It("carries the source store's additional command args for a recovery.source",
 		func(ctx SpecContext) {
-			backup := &apiv1.Backup{
-				Status: apiv1.BackupStatus{
-					DestinationPath: "s3://my bucket/wal",
-					ServerName:      "server-a",
+			// recovery.source: the source store's Wal config lives in the external
+			// cluster definition and must be applied, just like the plugin does.
+			cluster := &apiv1.Cluster{
+				Spec: apiv1.ClusterSpec{
+					Bootstrap: &apiv1.BootstrapConfiguration{
+						Recovery: &apiv1.BootstrapRecovery{Source: "origin"},
+					},
+					ExternalClusters: []apiv1.ExternalCluster{
+						{
+							Name: "origin",
+							BarmanObjectStore: &apiv1.BarmanObjectStoreConfiguration{
+								Wal: &apiv1.WalBackupConfiguration{
+									RestoreAdditionalCommandArgs: []string{"--read-timeout=60"},
+								},
+							},
+						},
+					},
 				},
 			}
-			out, err := getRestoreWalConfig(ctx, backup)
+
+			Expect(setupBootstrapWALRestoreCache(ctx, cluster, backup(), []string{"X=y"})).To(Succeed())
+
+			options, err := cache.LoadEnv(cache.WALRestoreOptionsKey)
 			Expect(err).ToNot(HaveOccurred())
-			// After shell-quoting, the DestinationPath is wrapped in single quotes.
-			// The outer configfile.EscapePostgresConfLiteral layer then doubles
-			// each of those single quotes, so the value appears as ''...'' in
-			// the config file.
-			Expect(out).To(ContainSubstring("''s3://my bucket/wal''"))
-
-			// PostgreSQL will replace %f %p with proper quoting when needed.
-			Expect(out).To(ContainSubstring("%f"))
-			Expect(out).To(ContainSubstring("%p"))
-		})
-
-	It("nests an obvious shell-injection payload inside both quoting layers",
-		func(ctx SpecContext) {
-			backup := &apiv1.Backup{
-				Status: apiv1.BackupStatus{
-					DestinationPath: `s3://bucket"; rm -rf /; "`,
-					ServerName:      "server-a",
-				},
-			}
-			out, err := getRestoreWalConfig(ctx, backup)
-			Expect(err).ToNot(HaveOccurred())
-
-			// shellquote.Join wraps the whole arg in single quotes (because
-			// of the embedded `;` and spaces); EscapePostgresConfLiteral
-			// then doubles each of those quotes. The payload must arrive at
-			// the shell as one argument, not as a `;`-separated command.
-			Expect(out).To(ContainSubstring(
-				`''s3://bucket"; rm -rf /; "''`))
+			Expect(options).To(ContainElement("--read-timeout=60"))
 		})
 })

--- a/pkg/management/postgres/restore_test.go
+++ b/pkg/management/postgres/restore_test.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/cloudnative-pg/machinery/pkg/fileutils"
 	"github.com/thoas/go-funk"
-	"k8s.io/utils/ptr"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/internal/management/cache"
@@ -310,31 +309,5 @@ var _ = Describe("setupBootstrapWALRestoreCache", func() {
 		Expect(store.Wal).ToNot(BeNil())
 		Expect(store.Wal.MaxParallel).To(Equal(2))
 		Expect(store.Wal.RestoreAdditionalCommandArgs).To(ContainElement("--read-timeout=60"))
-	})
-
-	It("does not populate the cache for a replica cluster", func() {
-		// A replica cluster does not replay WAL in the recovery Job, so this
-		// cache would never be read; populating it is pointless.
-		cluster := &apiv1.Cluster{
-			Spec: apiv1.ClusterSpec{
-				Bootstrap: &apiv1.BootstrapConfiguration{
-					Recovery: &apiv1.BootstrapRecovery{Source: "origin"},
-				},
-				ExternalClusters: []apiv1.ExternalCluster{
-					{Name: "origin", BarmanObjectStore: &apiv1.BarmanObjectStoreConfiguration{}},
-				},
-				ReplicaCluster: &apiv1.ReplicaClusterConfiguration{
-					Enabled: ptr.To(true),
-					Source:  "origin",
-				},
-			},
-		}
-
-		setupBootstrapWALRestoreCache(cluster, backup(), []string{"X=y"})
-
-		_, err := cache.Load(cache.WALRestoreConfigKey)
-		Expect(err).To(MatchError(cache.ErrCacheMiss))
-		_, err = cache.LoadEnv(cache.WALRestoreKey)
-		Expect(err).To(MatchError(cache.ErrCacheMiss))
 	})
 })

--- a/pkg/management/postgres/webserver/client/local/cache.go
+++ b/pkg/management/postgres/webserver/client/local/cache.go
@@ -37,6 +37,7 @@ import (
 type CacheClient interface {
 	GetCluster() (*apiv1.Cluster, error)
 	GetEnv(key string) ([]string, error)
+	GetBarmanObjectStore(key string) (*apiv1.BarmanObjectStoreConfiguration, error)
 }
 
 type cacheClientImpl struct {
@@ -57,6 +58,21 @@ func (c *cacheClientImpl) GetCluster() (*apiv1.Cluster, error) {
 	}
 
 	return cluster, nil
+}
+
+// GetBarmanObjectStore gets a cached barman object store configuration from cache
+func (c *cacheClientImpl) GetBarmanObjectStore(key string) (*apiv1.BarmanObjectStoreConfiguration, error) {
+	bytes, err := c.httpCacheGet(key)
+	if err != nil {
+		return nil, err
+	}
+
+	configuration := &apiv1.BarmanObjectStoreConfiguration{}
+	if err := json.Unmarshal(bytes, configuration); err != nil {
+		return nil, err
+	}
+
+	return configuration, nil
 }
 
 // GetEnv gets the environment variables from cache

--- a/pkg/management/postgres/webserver/local.go
+++ b/pkg/management/postgres/webserver/local.go
@@ -100,7 +100,7 @@ func (ws *localWebserverEndpoints) serveCache(w http.ResponseWriter, r *http.Req
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
-	case cache.WALRestoreKey, cache.WALArchiveKey, cache.WALRestoreOptionsKey:
+	case cache.WALRestoreKey, cache.WALArchiveKey:
 		response, err := cache.LoadEnv(requestedObject)
 		if errors.Is(err, cache.ErrCacheMiss) {
 			w.WriteHeader(http.StatusNotFound)
@@ -114,6 +114,23 @@ func (ws *localWebserverEndpoints) serveCache(w http.ResponseWriter, r *http.Req
 		js, err = json.Marshal(response)
 		if err != nil {
 			log.Error(err, "while marshalling cached env")
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+	case cache.WALRestoreConfigKey:
+		response, err := cache.Load(requestedObject)
+		if errors.Is(err, cache.ErrCacheMiss) {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		} else if err != nil {
+			log.Error(err, "while loading cached barman object store configuration")
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		js, err = json.Marshal(response)
+		if err != nil {
+			log.Error(err, "while marshalling cached barman object store configuration")
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}

--- a/pkg/management/postgres/webserver/local.go
+++ b/pkg/management/postgres/webserver/local.go
@@ -100,7 +100,7 @@ func (ws *localWebserverEndpoints) serveCache(w http.ResponseWriter, r *http.Req
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
-	case cache.WALRestoreKey, cache.WALArchiveKey:
+	case cache.WALRestoreKey, cache.WALArchiveKey, cache.WALRestoreOptionsKey:
 		response, err := cache.LoadEnv(requestedObject)
 		if errors.Is(err, cache.ErrCacheMiss) {
 			w.WriteHeader(http.StatusNotFound)

--- a/pkg/management/postgres/webserver/local_test.go
+++ b/pkg/management/postgres/webserver/local_test.go
@@ -1,0 +1,91 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package webserver
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+
+	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	"github.com/cloudnative-pg/cloudnative-pg/internal/management/cache"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/url"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("serveCache", func() {
+	var ws localWebserverEndpoints
+
+	get := func(key string) *httptest.ResponseRecorder {
+		req := httptest.NewRequest(http.MethodGet, url.PathCache+key, nil)
+		w := httptest.NewRecorder()
+		ws.serveCache(w, req)
+		return w
+	}
+
+	AfterEach(func() {
+		cache.Delete(cache.WALRestoreConfigKey)
+	})
+
+	It("returns not-found when no recovery source store is cached", func() {
+		w := get(cache.WALRestoreConfigKey)
+		Expect(w.Code).To(Equal(http.StatusNotFound))
+	})
+
+	It("serves the cached recovery source store as JSON the cache client can decode", func() {
+		stored := &apiv1.BarmanObjectStoreConfiguration{
+			BarmanCredentials: apiv1.BarmanCredentials{
+				AWS: &apiv1.S3Credentials{
+					AccessKeyIDReference: &apiv1.SecretKeySelector{
+						LocalObjectReference: apiv1.LocalObjectReference{Name: "source-creds"},
+						Key:                  "ACCESS_KEY_ID",
+					},
+					SecretAccessKeyReference: &apiv1.SecretKeySelector{
+						LocalObjectReference: apiv1.LocalObjectReference{Name: "source-creds"},
+						Key:                  "SECRET_ACCESS_KEY",
+					},
+				},
+			},
+			EndpointCA: &apiv1.SecretKeySelector{
+				LocalObjectReference: apiv1.LocalObjectReference{Name: "source-ca"},
+				Key:                  "ca.crt",
+			},
+			EndpointURL:     "https://source-endpoint:9000",
+			DestinationPath: "s3://source/path",
+			ServerName:      "source-server",
+			Wal: &apiv1.WalBackupConfiguration{
+				MaxParallel:                  4,
+				RestoreAdditionalCommandArgs: []string{"--read-timeout=60"},
+			},
+		}
+		cache.Store(cache.WALRestoreConfigKey, stored)
+
+		w := get(cache.WALRestoreConfigKey)
+		Expect(w.Code).To(Equal(http.StatusOK))
+
+		// Decode exactly like the local cache client does, so this covers the
+		// serialization contract between the Job webserver and wal-restore.
+		decoded := &apiv1.BarmanObjectStoreConfiguration{}
+		Expect(json.Unmarshal(w.Body.Bytes(), decoded)).To(Succeed())
+		Expect(decoded).To(Equal(stored))
+	})
+})


### PR DESCRIPTION
`wal.maxParallel` and `wal.restoreAdditionalCommandArgs` were silently ignored during a `bootstrap.recovery` from a Barman Cloud object store: the recovery Job composed `restore_command` directly, fetching one WAL at a time regardless of the configured parallelism. Recovery of large clusters could therefore take hours, even though the documentation states these settings apply to the recovery phase and running replicas already honor them.

The recovery Job now sets `restore_command` to `/controller/manager wal-restore`, the same command HA replicas, volume snapshot recovery, and CNPG-I plugin restores already use. Recovery from a `recovery.source` picks up the source's `wal.maxParallel` (parallel WAL prefetch during the replay) and `wal.restoreAdditionalCommandArgs`, matching the Barman Cloud plugin. A `recovery.backup` reference records no WAL configuration, so it still restores one segment at a time.

The recovery Job is the only component that can resolve the recovery source object store (for a `recovery.backup` reference the store lives only in the referenced Backup resource), so it pre-populates the local webserver cache with the resolved store configuration and credentials. When no primary has been elected yet, `wal-restore` reads its options, credentials, and prefetch parallelism from that cached store; in every other situation it behaves as before.

Two further consequences of routing through the shared command: `restore_command` no longer embeds any user-controlled field, removing the need for shell quoting in the recovery configuration, and WAL restore logs during the bootstrap replay are now structured and routed like on running instances.

The serialization of the recovery source store between the Job webserver and the wal-restore command is covered by a dedicated unit test, and the object-store recovery end-to-end tests (recovery from an external cluster, PITR, and replica cluster recovery, plus recovery from a Backup resource) pass against this change.

Closes #3459
