### PR TITLE
test(e2e): port replica cluster switchover test to plugin-barman-cloud

### DIFF
--- a/tests/e2e/fixtures/replica_mode_cluster/pbc-promotion-demotion/cluster-replica-switchover-restart-1.yaml.template
+++ b/tests/e2e/fixtures/replica_mode_cluster/pbc-promotion-demotion/cluster-replica-switchover-restart-1.yaml.template
@@ -1,0 +1,36 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: replica-switchover-restart-a
+spec:
+  instances: 3
+  primaryUpdateStrategy: unsupervised
+  primaryUpdateMethod: restart
+
+  storage:
+    storageClass: ${E2E_DEFAULT_STORAGE_CLASS}
+    size: 1Gi
+
+  plugins:
+    - name: barman-cloud.cloudnative-pg.io
+      isWALArchiver: true
+      parameters:
+        barmanObjectName: replica-cluster-backups
+
+  replica:
+    primary: replica-switchover-restart-a
+    source: replica-switchover-restart-b
+
+  externalClusters:
+  - name: replica-switchover-restart-a
+    plugin:
+      name: barman-cloud.cloudnative-pg.io
+      parameters:
+        barmanObjectName: replica-cluster-backups
+        serverName: replica-switchover-restart-a
+  - name: replica-switchover-restart-b
+    plugin:
+      name: barman-cloud.cloudnative-pg.io
+      parameters:
+        barmanObjectName: replica-cluster-backups
+        serverName: replica-switchover-restart-b

--- a/tests/e2e/fixtures/replica_mode_cluster/pbc-promotion-demotion/cluster-replica-switchover-restart-2.yaml.template
+++ b/tests/e2e/fixtures/replica_mode_cluster/pbc-promotion-demotion/cluster-replica-switchover-restart-2.yaml.template
@@ -1,0 +1,40 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: replica-switchover-restart-b
+spec:
+  instances: 3
+  primaryUpdateStrategy: unsupervised
+  primaryUpdateMethod: restart
+
+  storage:
+    storageClass: ${E2E_DEFAULT_STORAGE_CLASS}
+    size: 1Gi
+
+  plugins:
+    - name: barman-cloud.cloudnative-pg.io
+      isWALArchiver: true
+      parameters:
+        barmanObjectName: replica-cluster-backups
+
+  bootstrap:
+    recovery:
+      source: replica-switchover-restart-a
+
+  replica:
+    primary: replica-switchover-restart-a
+    source: replica-switchover-restart-a
+
+  externalClusters:
+  - name: replica-switchover-restart-a
+    plugin:
+      name: barman-cloud.cloudnative-pg.io
+      parameters:
+        barmanObjectName: replica-cluster-backups
+        serverName: replica-switchover-restart-a
+  - name: replica-switchover-restart-b
+    plugin:
+      name: barman-cloud.cloudnative-pg.io
+      parameters:
+        barmanObjectName: replica-cluster-backups
+        serverName: replica-switchover-restart-b

--- a/tests/e2e/fixtures/replica_mode_cluster/pbc-promotion-demotion/cluster-replica-switchover-switchover-1.yaml.template
+++ b/tests/e2e/fixtures/replica_mode_cluster/pbc-promotion-demotion/cluster-replica-switchover-switchover-1.yaml.template
@@ -1,0 +1,36 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: replica-switchover-switchover-a
+spec:
+  instances: 3
+  primaryUpdateStrategy: unsupervised
+  primaryUpdateMethod: switchover
+
+  storage:
+    storageClass: ${E2E_DEFAULT_STORAGE_CLASS}
+    size: 1Gi
+
+  plugins:
+    - name: barman-cloud.cloudnative-pg.io
+      isWALArchiver: true
+      parameters:
+        barmanObjectName: replica-cluster-backups
+
+  replica:
+    primary: replica-switchover-switchover-a
+    source: replica-switchover-switchover-b
+
+  externalClusters:
+  - name: replica-switchover-switchover-a
+    plugin:
+      name: barman-cloud.cloudnative-pg.io
+      parameters:
+        barmanObjectName: replica-cluster-backups
+        serverName: replica-switchover-switchover-a
+  - name: replica-switchover-switchover-b
+    plugin:
+      name: barman-cloud.cloudnative-pg.io
+      parameters:
+        barmanObjectName: replica-cluster-backups
+        serverName: replica-switchover-switchover-b

--- a/tests/e2e/fixtures/replica_mode_cluster/pbc-promotion-demotion/cluster-replica-switchover-switchover-2.yaml.template
+++ b/tests/e2e/fixtures/replica_mode_cluster/pbc-promotion-demotion/cluster-replica-switchover-switchover-2.yaml.template
@@ -1,0 +1,40 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: replica-switchover-switchover-b
+spec:
+  instances: 3
+  primaryUpdateStrategy: unsupervised
+  primaryUpdateMethod: switchover
+
+  storage:
+    storageClass: ${E2E_DEFAULT_STORAGE_CLASS}
+    size: 1Gi
+
+  plugins:
+    - name: barman-cloud.cloudnative-pg.io
+      isWALArchiver: true
+      parameters:
+        barmanObjectName: replica-cluster-backups
+
+  bootstrap:
+    recovery:
+      source: replica-switchover-switchover-a
+
+  replica:
+    primary: replica-switchover-switchover-a
+    source: replica-switchover-switchover-a
+
+  externalClusters:
+  - name: replica-switchover-switchover-a
+    plugin:
+      name: barman-cloud.cloudnative-pg.io
+      parameters:
+        barmanObjectName: replica-cluster-backups
+        serverName: replica-switchover-switchover-a
+  - name: replica-switchover-switchover-b
+    plugin:
+      name: barman-cloud.cloudnative-pg.io
+      parameters:
+        barmanObjectName: replica-cluster-backups
+        serverName: replica-switchover-switchover-b

--- a/tests/e2e/plugin_barman_cloud_replica_test.go
+++ b/tests/e2e/plugin_barman_cloud_replica_test.go
@@ -246,8 +246,7 @@ var _ = Describe("plugin-barman-cloud replica cluster promotion/demotion",
 							case <-stopLoad:
 								GinkgoWriter.Println("Terminating load")
 								return
-							default:
-								continue
+							case <-time.After(100 * time.Millisecond):
 							}
 						}
 					}()

--- a/tests/e2e/plugin_barman_cloud_replica_test.go
+++ b/tests/e2e/plugin_barman_cloud_replica_test.go
@@ -103,6 +103,8 @@ var _ = Describe("plugin-barman-cloud replica cluster from backup",
 // In this test we create a replica cluster from a backup and then promote it to a primary.
 // We expect the original primary to be demoted to a replica and be able to follow the new primary.
 // Runs on kind/k3d only, where the plugin and the shared object store are installed.
+//
+//nolint:dupl // TODO: remove once in-tree counterpart is removed
 var _ = Describe("plugin-barman-cloud replica cluster promotion/demotion",
 	Label(tests.LabelPluginBarmanCloud, tests.LabelReplication, tests.LabelBackupRestore), Ordered, func() {
 		const (

--- a/tests/e2e/plugin_barman_cloud_replica_test.go
+++ b/tests/e2e/plugin_barman_cloud_replica_test.go
@@ -164,8 +164,8 @@ var _ = Describe("plugin-barman-cloud replica cluster promotion/demotion",
 			}, testTimeouts[timeouts.ClusterIsReadyQuick]).Should(Succeed())
 		}
 
-		waitForTimelineIncrease := func(namespace, clusterName string, expectedTimeline int) bool {
-			return Eventually(func(g Gomega) {
+		waitForExpectedTimeline := func(namespace, clusterName string, expectedTimeline int) {
+			Eventually(func(g Gomega) {
 				primary, err := clusterutils.GetPrimary(env.Ctx, env.Client, namespace, clusterName)
 				g.Expect(err).ToNot(HaveOccurred())
 				stdout, _, err := exec.QueryInInstancePod(
@@ -198,15 +198,11 @@ var _ = Describe("plugin-barman-cloud replica cluster promotion/demotion",
 				DeferCleanup(func() error {
 					// Since we use multiple times the same cluster names for the same object store instance, we need
 					// to clean it up between tests
-					_, err = objectstore.CleanFiles(objectStoreEnv, path.Join(objectStoreName, clusterAName))
-					if err != nil {
+					if _, err := objectstore.CleanFiles(objectStoreEnv, path.Join(objectStoreName, clusterAName)); err != nil {
 						return err
 					}
-					_, err = objectstore.CleanFiles(objectStoreEnv, path.Join(objectStoreName, clusterBName))
-					if err != nil {
-						return err
-					}
-					return nil
+					_, err := objectstore.CleanFiles(objectStoreEnv, path.Join(objectStoreName, clusterBName))
+					return err
 				})
 
 				stopLoad := make(chan struct{})
@@ -276,7 +272,6 @@ var _ = Describe("plugin-barman-cloud replica cluster promotion/demotion",
 					primary, err := clusterutils.GetPrimary(env.Ctx, env.Client, namespace, clusterAName)
 					Expect(err).ToNot(HaveOccurred())
 					_ = objectstoreasserts.SwitchWalAndGetLatestArchive(env, namespace, primary.Name)
-					Expect(err).ToNot(HaveOccurred())
 
 					Eventually(func() (apiv1.BackupPhase, error) {
 						err = env.Client.Get(env.Ctx, types.NamespacedName{
@@ -366,7 +361,7 @@ var _ = Describe("plugin-barman-cloud replica cluster promotion/demotion",
 				})
 
 				By("reaching the target timeline", func() {
-					waitForTimelineIncrease(namespace, clusterBName, expectedTimeline)
+					waitForExpectedTimeline(namespace, clusterBName, expectedTimeline)
 				})
 
 				By("verifying B contains the primary", func() {

--- a/tests/e2e/plugin_barman_cloud_replica_test.go
+++ b/tests/e2e/plugin_barman_cloud_replica_test.go
@@ -20,11 +20,29 @@ SPDX-License-Identifier: Apache-2.0
 package e2e
 
 import (
+	"fmt"
+	"path"
+	"strings"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	k8client "sigs.k8s.io/controller-runtime/pkg/client"
+
+	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 	"github.com/cloudnative-pg/cloudnative-pg/tests"
 	clusterasserts "github.com/cloudnative-pg/cloudnative-pg/tests/internal/asserts/cluster"
+	objectstoreasserts "github.com/cloudnative-pg/cloudnative-pg/tests/internal/asserts/objectstore"
+	pgasserts "github.com/cloudnative-pg/cloudnative-pg/tests/internal/asserts/postgres"
 	replicationasserts "github.com/cloudnative-pg/cloudnative-pg/tests/internal/asserts/replication"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/backups"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/clusterutils"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/exec"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/objectstore"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/postgres"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/timeouts"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/yaml"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -79,4 +97,282 @@ var _ = Describe("plugin-barman-cloud replica cluster from backup",
 					srcClusterName, srcDBName, replicaManifest, testTableName)
 			})
 		})
+	})
+
+// Plugin port of the "Replica switchover" scenario:
+// In this test we create a replica cluster from a backup and then promote it to a primary.
+// We expect the original primary to be demoted to a replica and be able to follow the new primary.
+// Runs on kind/k3d only, where the plugin and the shared object store are installed.
+var _ = Describe("plugin-barman-cloud replica cluster promotion/demotion",
+	Label(tests.LabelPluginBarmanCloud, tests.LabelReplication, tests.LabelBackupRestore), Ordered, func() {
+		const (
+			localFixturesDir       = fixturesDir + "/replica_mode_cluster/pbc-promotion-demotion/"
+			clusterAFileRestart    = localFixturesDir + "cluster-replica-switchover-restart-1.yaml.template"
+			clusterBFileRestart    = localFixturesDir + "cluster-replica-switchover-restart-2.yaml.template"
+			clusterAFileSwitchover = localFixturesDir + "cluster-replica-switchover-switchover-1.yaml.template"
+			clusterBFileSwitchover = localFixturesDir + "cluster-replica-switchover-switchover-2.yaml.template"
+			objectStoreName        = "replica-cluster-backups"
+			level                  = tests.Medium
+		)
+
+		BeforeAll(func() {
+			if testLevelEnv.Depth < int(level) {
+				Skip("Test depth is lower than the amount requested for this test")
+			}
+			if !(IsKind() || IsK3D()) {
+				Skip("This test only runs on kind or k3d clusters")
+			}
+		})
+
+		validateReplication := func(namespace, clusterAName, clusterBName string) {
+			primary, err := clusterutils.GetPrimary(env.Ctx, env.Client, namespace, clusterBName)
+			Expect(err).ToNot(HaveOccurred())
+
+			_, _, err = exec.QueryInInstancePod(
+				env.Ctx, env.Client, env.Interface, env.RestClientConfig,
+				exec.PodLocator{Namespace: namespace, PodName: primary.Name},
+				"postgres",
+				"CREATE TABLE test_replication AS SELECT 1;",
+			)
+			Expect(err).ToNot(HaveOccurred())
+			_ = objectstoreasserts.SwitchWalAndGetLatestArchive(env, namespace, primary.Name)
+
+			Eventually(func(g Gomega) {
+				podListA, err := clusterutils.ListPods(env.Ctx, env.Client, namespace, clusterAName)
+				g.Expect(err).ToNot(HaveOccurred())
+				podListB, err := clusterutils.ListPods(env.Ctx, env.Client, namespace, clusterBName)
+				g.Expect(err).ToNot(HaveOccurred())
+
+				for _, podA := range podListA.Items {
+					_, _, err = exec.QueryInInstancePod(
+						env.Ctx, env.Client, env.Interface, env.RestClientConfig,
+						exec.PodLocator{Namespace: namespace, PodName: podA.Name},
+						"postgres",
+						"SELECT * FROM test_replication;",
+					)
+					g.Expect(err).ToNot(HaveOccurred())
+				}
+
+				for _, podB := range podListB.Items {
+					_, _, err = exec.QueryInInstancePod(
+						env.Ctx, env.Client, env.Interface, env.RestClientConfig,
+						exec.PodLocator{Namespace: namespace, PodName: podB.Name},
+						"postgres",
+						"SELECT * FROM test_replication;",
+					)
+					g.Expect(err).ToNot(HaveOccurred())
+				}
+			}, testTimeouts[timeouts.ClusterIsReadyQuick]).Should(Succeed())
+		}
+
+		waitForTimelineIncrease := func(namespace, clusterName string, expectedTimeline int) bool {
+			return Eventually(func(g Gomega) {
+				primary, err := clusterutils.GetPrimary(env.Ctx, env.Client, namespace, clusterName)
+				g.Expect(err).ToNot(HaveOccurred())
+				stdout, _, err := exec.QueryInInstancePod(
+					env.Ctx, env.Client, env.Interface, env.RestClientConfig,
+					exec.PodLocator{Namespace: namespace, PodName: primary.Name},
+					"postgres",
+					"SELECT timeline_id FROM pg_catalog.pg_control_checkpoint()",
+				)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(strings.TrimSpace(stdout)).To(Equal(fmt.Sprintf("%d", expectedTimeline)))
+			}, testTimeouts[timeouts.ClusterIsReadyQuick]).Should(Succeed())
+		}
+
+		DescribeTable(
+			"should demote and promote the clusters correctly",
+			func(clusterAFile string, clusterBFile string, expectedTimeline int) {
+				const namespacePrefix = "replica-cluster-switchover"
+				namespace, err := env.CreateUniqueTestNamespace(env.Ctx, env.Client, namespacePrefix)
+				Expect(err).ToNot(HaveOccurred())
+
+				clusterAName, err := yaml.GetResourceNameFromYAML(env.Scheme, clusterAFile)
+				Expect(err).ToNot(HaveOccurred())
+				clusterBName, err := yaml.GetResourceNameFromYAML(env.Scheme, clusterBFile)
+				Expect(err).ToNot(HaveOccurred())
+
+				DeferCleanup(func() error {
+					// Since we use multiple times the same cluster names for the same object store instance, we need
+					// to clean it up between tests
+					_, err = objectstore.CleanFiles(objectStoreEnv, path.Join(objectStoreName, clusterAName))
+					if err != nil {
+						return err
+					}
+					_, err = objectstore.CleanFiles(objectStoreEnv, path.Join(objectStoreName, clusterBName))
+					if err != nil {
+						return err
+					}
+					return nil
+				})
+
+				stopLoad := make(chan struct{})
+				DeferCleanup(func() { close(stopLoad) })
+
+				setupPluginObjectStore(namespace, objectStoreName)
+
+				By("creating the A cluster", func() {
+					clusterasserts.AssertCreateCluster(env, testTimeouts, namespace, clusterAName, clusterAFile)
+				})
+
+				By("creating some load on the A cluster", func() {
+					primary, err := clusterutils.GetPrimary(env.Ctx, env.Client, namespace, clusterAName)
+					Expect(err).ToNot(HaveOccurred())
+					_, _, err = exec.QueryInInstancePod(
+						env.Ctx, env.Client, env.Interface, env.RestClientConfig,
+						exec.PodLocator{Namespace: namespace, PodName: primary.Name},
+						"postgres",
+						"CREATE TABLE switchover_load (i int);",
+					)
+					Expect(err).ToNot(HaveOccurred())
+
+					go func() {
+						for {
+							_, _, _ = exec.QueryInInstancePod(
+								env.Ctx, env.Client, env.Interface, env.RestClientConfig,
+								exec.PodLocator{Namespace: namespace, PodName: primary.Name},
+								"postgres",
+								"INSERT INTO switchover_load SELECT generate_series(1, 10000)",
+							)
+							select {
+							case <-stopLoad:
+								GinkgoWriter.Println("Terminating load")
+								return
+							default:
+								continue
+							}
+						}
+					}()
+				})
+
+				By("backing up the A cluster", func() {
+					backup, err := backups.Create(
+						env.Ctx, env.Client,
+						apiv1.Backup{
+							ObjectMeta: metav1.ObjectMeta{
+								Namespace: namespace,
+								Name:      clusterAName,
+							},
+							Spec: apiv1.BackupSpec{
+								Target:  apiv1.BackupTargetPrimary,
+								Method:  apiv1.BackupMethodPlugin,
+								Cluster: apiv1.LocalObjectReference{Name: clusterAName},
+								PluginConfiguration: &apiv1.BackupPluginConfiguration{
+									Name: "barman-cloud.cloudnative-pg.io",
+								},
+							},
+						},
+					)
+					Expect(err).ToNot(HaveOccurred())
+
+					// Speed up backup finalization
+					primary, err := clusterutils.GetPrimary(env.Ctx, env.Client, namespace, clusterAName)
+					Expect(err).ToNot(HaveOccurred())
+					_ = objectstoreasserts.SwitchWalAndGetLatestArchive(env, namespace, primary.Name)
+					Expect(err).ToNot(HaveOccurred())
+
+					Eventually(func() (apiv1.BackupPhase, error) {
+						err = env.Client.Get(env.Ctx, types.NamespacedName{
+							Namespace: namespace,
+							Name:      clusterAName,
+						}, backup)
+						return backup.Status.Phase, err
+					}, testTimeouts[timeouts.BackupIsReady]).WithPolling(10 * time.Second).
+						Should(BeEquivalentTo(apiv1.BackupPhaseCompleted))
+				})
+
+				By("creating the B cluster from the backup", func() {
+					clusterasserts.AssertCreateCluster(env, testTimeouts, namespace, clusterBName, clusterBFile)
+				})
+
+				By("demoting A to a replica", func() {
+					cluster, err := clusterutils.Get(env.Ctx, env.Client, namespace, clusterAName)
+					Expect(err).ToNot(HaveOccurred())
+					oldCluster := cluster.DeepCopy()
+					cluster.Spec.ReplicaCluster.Primary = clusterBName
+					Expect(env.Client.Patch(env.Ctx, cluster, k8client.MergeFrom(oldCluster))).To(Succeed())
+					podList, err := clusterutils.ListPods(env.Ctx, env.Client, namespace, clusterAName)
+					Expect(err).ToNot(HaveOccurred())
+					for _, pod := range podList.Items {
+						pgasserts.AssertPgRecoveryMode(env, &pod, true)
+					}
+				})
+
+				var token, invalidToken string
+				By("getting the demotion token", func() {
+					cluster, err := clusterutils.Get(env.Ctx, env.Client, namespace, clusterAName)
+					Expect(err).ToNot(HaveOccurred())
+					token = cluster.Status.DemotionToken
+				})
+
+				By("forging an invalid token", func() {
+					tokenContent, err := utils.ParsePgControldataToken(token)
+					Expect(err).ToNot(HaveOccurred())
+					tokenContent.LatestCheckpointREDOLocation = "0/0"
+					Expect(tokenContent.IsValid()).To(Succeed())
+					invalidToken, err = tokenContent.Encode()
+					Expect(err).ToNot(HaveOccurred())
+				})
+
+				By("promoting B with the invalid token", func() {
+					cluster, err := clusterutils.Get(env.Ctx, env.Client, namespace, clusterBName)
+					Expect(err).ToNot(HaveOccurred())
+
+					oldCluster := cluster.DeepCopy()
+					cluster.Spec.ReplicaCluster.PromotionToken = invalidToken
+					cluster.Spec.ReplicaCluster.Primary = clusterBName
+					Expect(env.Client.Patch(env.Ctx, cluster, k8client.MergeFrom(oldCluster))).To(Succeed())
+				})
+
+				By("failing to promote B with the invalid token", func() {
+					Consistently(func(g Gomega) {
+						pod, err := clusterutils.GetPrimary(env.Ctx, env.Client, namespace, clusterBName)
+						g.Expect(err).ToNot(HaveOccurred())
+						stdOut, _, err := exec.QueryInInstancePod(
+							env.Ctx, env.Client, env.Interface, env.RestClientConfig,
+							exec.PodLocator{
+								Namespace: pod.Namespace,
+								PodName:   pod.Name,
+							},
+							postgres.PostgresDBName,
+							"select pg_catalog.pg_is_in_recovery()")
+						g.Expect(err).ToNot(HaveOccurred())
+						g.Expect(strings.Trim(stdOut, "\n")).To(Equal("t"))
+					}, 60, 10).Should(Succeed())
+					cluster, err := clusterutils.Get(env.Ctx, env.Client, namespace, clusterBName)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(cluster.Status.Phase).To(BeEquivalentTo(apiv1.PhaseUnrecoverable))
+				})
+
+				By("promoting B with the right token", func() {
+					cluster, err := clusterutils.Get(env.Ctx, env.Client, namespace, clusterBName)
+					Expect(err).ToNot(HaveOccurred())
+					oldCluster := cluster.DeepCopy()
+					cluster.Spec.ReplicaCluster.PromotionToken = token
+					cluster.Spec.ReplicaCluster.Primary = clusterBName
+					Expect(env.Client.Patch(env.Ctx, cluster, k8client.MergeFrom(oldCluster))).To(Succeed())
+				})
+
+				By("reaching the target timeline", func() {
+					waitForTimelineIncrease(namespace, clusterBName, expectedTimeline)
+				})
+
+				By("verifying B contains the primary", func() {
+					primary, err := clusterutils.GetPrimary(env.Ctx, env.Client, namespace, clusterBName)
+					Expect(err).ToNot(HaveOccurred())
+					pgasserts.AssertPgRecoveryMode(env, primary, false)
+					podList, err := clusterutils.GetReplicas(env.Ctx, env.Client, namespace, clusterBName)
+					Expect(err).ToNot(HaveOccurred())
+					for _, pod := range podList.Items {
+						pgasserts.AssertPgRecoveryMode(env, &pod, true)
+					}
+				})
+
+				By("verifying replication from new primary works everywhere", func() {
+					validateReplication(namespace, clusterAName, clusterBName)
+				})
+			},
+			Entry("when primaryUpdateMethod is set to restart", clusterAFileRestart, clusterBFileRestart, 2),
+			Entry("when primaryUpdateMethod is set to switchover", clusterAFileSwitchover, clusterBFileSwitchover, 3),
+		)
 	})

--- a/tests/e2e/plugin_barman_cloud_replica_test.go
+++ b/tests/e2e/plugin_barman_cloud_replica_test.go
@@ -176,6 +176,10 @@ var _ = Describe("plugin-barman-cloud replica cluster promotion/demotion",
 				)
 				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(strings.TrimSpace(stdout)).To(Equal(fmt.Sprintf("%d", expectedTimeline)))
+				// Check the Cluster's status is aligned
+				cluster, err := clusterutils.Get(env.Ctx, env.Client, namespace, clusterName)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(cluster.Status.TimelineID).To(Equal(expectedTimeline))
 			}, testTimeouts[timeouts.ClusterIsReadyQuick]).Should(Succeed())
 		}
 

--- a/tests/e2e/plugin_barman_cloud_replica_test.go
+++ b/tests/e2e/plugin_barman_cloud_replica_test.go
@@ -128,6 +128,9 @@ var _ = Describe("plugin-barman-cloud replica cluster promotion/demotion",
 		})
 
 		validateReplication := func(namespace, clusterAName, clusterBName string) {
+			const replicationTable = "test_replication"
+			marker := fmt.Sprintf("replication-check-%d", time.Now().UnixNano())
+
 			primary, err := clusterutils.GetPrimary(env.Ctx, env.Client, namespace, clusterBName)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -135,35 +138,28 @@ var _ = Describe("plugin-barman-cloud replica cluster promotion/demotion",
 				env.Ctx, env.Client, env.Interface, env.RestClientConfig,
 				exec.PodLocator{Namespace: namespace, PodName: primary.Name},
 				"postgres",
-				"CREATE TABLE test_replication AS SELECT 1;",
+				fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s (marker text); INSERT INTO %s VALUES ('%s');",
+					replicationTable, replicationTable, marker),
 			)
 			Expect(err).ToNot(HaveOccurred())
 			_ = objectstoreasserts.SwitchWalAndGetLatestArchive(env, namespace, primary.Name)
 
+			selectMarker := fmt.Sprintf("SELECT marker FROM %s WHERE marker = '%s';", replicationTable, marker)
 			Eventually(func(g Gomega) {
 				podListA, err := clusterutils.ListPods(env.Ctx, env.Client, namespace, clusterAName)
 				g.Expect(err).ToNot(HaveOccurred())
 				podListB, err := clusterutils.ListPods(env.Ctx, env.Client, namespace, clusterBName)
 				g.Expect(err).ToNot(HaveOccurred())
 
-				for _, podA := range podListA.Items {
-					_, _, err = exec.QueryInInstancePod(
+				for _, pod := range append(podListA.Items, podListB.Items...) {
+					stdOut, _, err := exec.QueryInInstancePod(
 						env.Ctx, env.Client, env.Interface, env.RestClientConfig,
-						exec.PodLocator{Namespace: namespace, PodName: podA.Name},
+						exec.PodLocator{Namespace: namespace, PodName: pod.Name},
 						"postgres",
-						"SELECT * FROM test_replication;",
+						selectMarker,
 					)
 					g.Expect(err).ToNot(HaveOccurred())
-				}
-
-				for _, podB := range podListB.Items {
-					_, _, err = exec.QueryInInstancePod(
-						env.Ctx, env.Client, env.Interface, env.RestClientConfig,
-						exec.PodLocator{Namespace: namespace, PodName: podB.Name},
-						"postgres",
-						"SELECT * FROM test_replication;",
-					)
-					g.Expect(err).ToNot(HaveOccurred())
+					g.Expect(strings.TrimSpace(stdOut)).To(Equal(marker))
 				}
 			}, testTimeouts[timeouts.ClusterIsReadyQuick]).Should(Succeed())
 		}

--- a/tests/e2e/plugin_barman_cloud_replica_test.go
+++ b/tests/e2e/plugin_barman_cloud_replica_test.go
@@ -333,6 +333,14 @@ var _ = Describe("plugin-barman-cloud replica cluster promotion/demotion",
 				})
 
 				By("failing to promote B with the invalid token", func() {
+					// The Unrecoverable phase proves the operator has evaluated and
+					// rejected the token; only after that it makes sense to check
+					// that the designated primary keeps running in recovery.
+					Eventually(func(g Gomega) {
+						cluster, err := clusterutils.Get(env.Ctx, env.Client, namespace, clusterBName)
+						g.Expect(err).ToNot(HaveOccurred())
+						g.Expect(cluster.Status.Phase).To(BeEquivalentTo(apiv1.PhaseUnrecoverable))
+					}, testTimeouts[timeouts.ClusterIsReadyQuick]).Should(Succeed())
 					Consistently(func(g Gomega) {
 						pod, err := clusterutils.GetPrimary(env.Ctx, env.Client, namespace, clusterBName)
 						g.Expect(err).ToNot(HaveOccurred())
@@ -347,9 +355,6 @@ var _ = Describe("plugin-barman-cloud replica cluster promotion/demotion",
 						g.Expect(err).ToNot(HaveOccurred())
 						g.Expect(strings.Trim(stdOut, "\n")).To(Equal("t"))
 					}, 60, 10).Should(Succeed())
-					cluster, err := clusterutils.Get(env.Ctx, env.Client, namespace, clusterBName)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(cluster.Status.Phase).To(BeEquivalentTo(apiv1.PhaseUnrecoverable))
 				})
 
 				By("promoting B with the right token", func() {

--- a/tests/e2e/plugin_barman_cloud_replica_test.go
+++ b/tests/e2e/plugin_barman_cloud_replica_test.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 	k8client "sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -211,7 +212,12 @@ var _ = Describe("plugin-barman-cloud replica cluster promotion/demotion",
 				stopLoad := make(chan struct{})
 				DeferCleanup(func() { close(stopLoad) })
 
-				setupPluginObjectStore(namespace, objectStoreName)
+				setupPluginObjectStore(namespace, objectStoreName, func(objectStore *unstructured.Unstructured) {
+					Expect(unstructured.SetNestedField(objectStore.Object, true,
+						"spec", "configuration", "data", "immediateCheckpoint")).To(Succeed())
+					Expect(unstructured.SetNestedField(objectStore.Object, int64(6),
+						"spec", "configuration", "wal", "maxParallel")).To(Succeed())
+				})
 
 				By("creating the A cluster", func() {
 					clusterasserts.AssertCreateCluster(env, testTimeouts, namespace, clusterAName, clusterAFile)

--- a/tests/e2e/plugin_barman_cloud_replica_test.go
+++ b/tests/e2e/plugin_barman_cloud_replica_test.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"path"
 	"strings"
+	"sync"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -206,7 +207,11 @@ var _ = Describe("plugin-barman-cloud replica cluster promotion/demotion",
 				})
 
 				stopLoad := make(chan struct{})
-				DeferCleanup(func() { close(stopLoad) })
+				var loadWG sync.WaitGroup
+				DeferCleanup(func() {
+					close(stopLoad)
+					loadWG.Wait()
+				})
 
 				setupPluginObjectStore(namespace, objectStoreName, func(objectStore *unstructured.Unstructured) {
 					Expect(unstructured.SetNestedField(objectStore.Object, true,
@@ -230,7 +235,10 @@ var _ = Describe("plugin-barman-cloud replica cluster promotion/demotion",
 					)
 					Expect(err).ToNot(HaveOccurred())
 
+					loadWG.Add(1)
 					go func() {
+						defer GinkgoRecover()
+						defer loadWG.Done()
 						for {
 							_, _, _ = exec.QueryInInstancePod(
 								env.Ctx, env.Client, env.Interface, env.RestClientConfig,

--- a/tests/e2e/plugin_barman_cloud_replica_test.go
+++ b/tests/e2e/plugin_barman_cloud_replica_test.go
@@ -196,8 +196,8 @@ var _ = Describe("plugin-barman-cloud replica cluster promotion/demotion",
 				Expect(err).ToNot(HaveOccurred())
 
 				DeferCleanup(func() error {
-					// Since we use multiple times the same cluster names for the same object store instance, we need
-					// to clean it up between tests
+					// The object store isn't wiped between runs, so leftover files from a
+					// previous run of this test need cleaning up here
 					if _, err := objectstore.CleanFiles(objectStoreEnv, path.Join(objectStoreName, clusterAName)); err != nil {
 						return err
 					}
@@ -310,6 +310,8 @@ var _ = Describe("plugin-barman-cloud replica cluster promotion/demotion",
 				By("forging an invalid token", func() {
 					tokenContent, err := utils.ParsePgControldataToken(token)
 					Expect(err).ToNot(HaveOccurred())
+					// A REDO location behind the replica's actual position is rejected outright
+					// (PhaseUnrecoverable); one ahead of it is retried instead, as "not yet caught up".
 					tokenContent.LatestCheckpointREDOLocation = "0/0"
 					Expect(tokenContent.IsValid()).To(Succeed())
 					invalidToken, err = tokenContent.Encode()
@@ -379,6 +381,10 @@ var _ = Describe("plugin-barman-cloud replica cluster promotion/demotion",
 					validateReplication(namespace, clusterAName, clusterBName)
 				})
 			},
+			// B's own promotion is one timeline switch, common to both entries. Leaving
+			// replica-cluster mode then flips B's archive_mode GUC, forcing a primary restart:
+			// "restart" applies it in place (timeline 2); "switchover" instead promotes a
+			// different instance to apply it, costing a second switch (timeline 3).
 			Entry("when primaryUpdateMethod is set to restart", clusterAFileRestart, clusterBFileRestart, 2),
 			Entry("when primaryUpdateMethod is set to switchover", clusterAFileSwitchover, clusterBFileSwitchover, 3),
 		)

--- a/tests/e2e/plugin_barman_cloud_test.go
+++ b/tests/e2e/plugin_barman_cloud_test.go
@@ -132,7 +132,9 @@ const barmanCloudCredentialSecret = "backup-storage-creds"
 // setupPluginObjectStore prepares a namespace for plugin-barman-cloud
 // archiving against the shared object store: the CA secret, the credentials
 // secret, and an ObjectStore named after the cluster that uses them.
-func setupPluginObjectStore(namespace, name string) {
+// Optional mutators can be passed to customize the ObjectStore spec before
+// it is created (e.g. to enable immediateCheckpoint).
+func setupPluginObjectStore(namespace, name string, mutators ...func(*unstructured.Unstructured)) {
 	GinkgoHelper()
 
 	By("creating the object store CA secret", func() {
@@ -147,8 +149,7 @@ func setupPluginObjectStore(namespace, name string) {
 	})
 
 	By("creating the ObjectStore pointing at the shared object store", func() {
-		Expect(env.Client.Create(env.Ctx, newObjectStore(namespace, name))).
-			To(Succeed())
+		Expect(env.Client.Create(env.Ctx, newObjectStore(namespace, name, mutators...))).To(Succeed())
 	})
 }
 
@@ -156,7 +157,9 @@ func setupPluginObjectStore(namespace, name string) {
 // (barmancloud.cnpg.io/v1) pointing at the shared e2e object store. It is built
 // as an unstructured object because the CRD lives in the external plugin and is
 // not registered in the operator's scheme.
-func newObjectStore(namespace, name string) *unstructured.Unstructured {
+// Optional mutators are applied to the resulting object right before it is returned,
+// allowing callers to customize the spec.
+func newObjectStore(namespace, name string, mutators ...func(*unstructured.Unstructured)) *unstructured.Unstructured {
 	objectStore := &unstructured.Unstructured{}
 	objectStore.SetGroupVersionKind(schema.GroupVersionKind{
 		Group:   "barmancloud.cnpg.io",
@@ -188,5 +191,10 @@ func newObjectStore(namespace, name string) *unstructured.Unstructured {
 			},
 		},
 	}
+
+	for _, mutate := range mutators {
+		mutate(objectStore)
+	}
+
 	return objectStore
 }

--- a/tests/e2e/replica_mode_cluster_test.go
+++ b/tests/e2e/replica_mode_cluster_test.go
@@ -588,6 +588,8 @@ var _ = Describe("Replica Mode", Label(tests.LabelReplication), func() {
 
 // In this test we create a replica cluster from a backup and then promote it to a primary.
 // We expect the original primary to be demoted to a replica and be able to follow the new primary.
+//
+//nolint:dupl
 var _ = Describe("Replica switchover", Label(tests.LabelReplication, tests.LabelBackupRestore), Ordered, func() {
 	const (
 		replicaSwitchoverClusterDir = "/replica_mode_cluster/"

--- a/tests/e2e/replica_mode_cluster_test.go
+++ b/tests/e2e/replica_mode_cluster_test.go
@@ -676,8 +676,8 @@ var _ = Describe("Replica switchover", Label(tests.LabelReplication, tests.Label
 			namespace, err = env.CreateUniqueTestNamespace(env.Ctx, env.Client, namespacePrefix)
 			Expect(err).ToNot(HaveOccurred())
 			DeferCleanup(func() error {
-				// Since we use multiple times the same cluster names for the same object store instance, we need to clean it up
-				// between tests
+				// The object store isn't wiped between runs, so leftover files from a
+				// previous run of this test need cleaning up here
 				_, err = objectstore.CleanFiles(objectStoreEnv, path.Join("cluster-backups", clusterAName))
 				if err != nil {
 					return err
@@ -811,6 +811,8 @@ var _ = Describe("Replica switchover", Label(tests.LabelReplication, tests.Label
 			By("forging an invalid token", func() {
 				tokenContent, err := utils.ParsePgControldataToken(token)
 				Expect(err).ToNot(HaveOccurred())
+				// A REDO location behind the replica's actual position is rejected outright
+				// (PhaseUnrecoverable); one ahead of it is retried instead, as "not yet caught up".
 				tokenContent.LatestCheckpointREDOLocation = "0/0"
 				Expect(tokenContent.IsValid()).To(Succeed())
 				invalidToken, err = tokenContent.Encode()
@@ -875,6 +877,10 @@ var _ = Describe("Replica switchover", Label(tests.LabelReplication, tests.Label
 				validateReplication(namespace, clusterAName, clusterBName)
 			})
 		},
+		// B's own promotion is one timeline switch, common to both entries. Leaving
+		// replica-cluster mode then flips B's archive_mode GUC, forcing a primary restart:
+		// "restart" applies it in place (timeline 2); "switchover" instead promotes a
+		// different instance to apply it, costing a second switch (timeline 3).
 		Entry("when primaryUpdateMethod is set to restart", clusterAFileRestart, clusterBFileRestart, 2),
 		Entry("when primaryUpdateMethod is set to switchover", clusterAFileSwitchover, clusterBFileSwitchover, 3),
 	)

--- a/tests/e2e/replica_mode_cluster_test.go
+++ b/tests/e2e/replica_mode_cluster_test.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"path"
 	"strings"
+	"sync"
 	"time"
 
 	volumesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
@@ -690,7 +691,11 @@ var _ = Describe("Replica switchover", Label(tests.LabelReplication, tests.Label
 			})
 
 			stopLoad := make(chan struct{})
-			DeferCleanup(func() { close(stopLoad) })
+			var loadWG sync.WaitGroup
+			DeferCleanup(func() {
+				close(stopLoad)
+				loadWG.Wait()
+			})
 
 			By("creating the credentials for the object store", func() {
 				_, err = secrets.CreateObjectStorageSecret(
@@ -726,7 +731,10 @@ var _ = Describe("Replica switchover", Label(tests.LabelReplication, tests.Label
 				)
 				Expect(err).ToNot(HaveOccurred())
 
+				loadWG.Add(1)
 				go func() {
+					defer GinkgoRecover()
+					defer loadWG.Done()
 					for {
 						_, _, _ = exec.QueryInInstancePod(
 							env.Ctx, env.Client, env.Interface, env.RestClientConfig,


### PR DESCRIPTION
Adds a plugin-barman-cloud variant of the replica cluster switchover test; the in-core version stays until in-core Barman Cloud support is removed.

Closes #11107