### PR TITLE
fix(logpipe): prevent pgaudit records being silently dropped by zap sampler

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/evanphx/json-patch/v5 v5.9.11
 	github.com/go-logr/logr v1.4.3
+	github.com/go-logr/zapr v1.3.0
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.3
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/jackc/puddle/v2 v2.2.2
@@ -57,7 +58,6 @@ require (
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.2 // indirect
 	github.com/go-errors/errors v1.5.1 // indirect
-	github.com/go-logr/zapr v1.3.0 // indirect
 	github.com/go-openapi/jsonpointer v0.23.1 // indirect
 	github.com/go-openapi/jsonreference v0.21.5 // indirect
 	github.com/go-openapi/swag v0.26.0 // indirect

--- a/pkg/management/postgres/logpipe/logpipe.go
+++ b/pkg/management/postgres/logpipe/logpipe.go
@@ -130,8 +130,8 @@ func (p *LogPipe) Start(ctx context.Context) error {
 }
 
 // collectLogsFromFile opens (blocking) the FIFO file, then starts reading the csv file line by line
-// until the end of the file or an error. recordLogger is the unsampled logger
-// built once by Start, reused across every retry.
+// until the end of the file or an error. recordLogger is built once by Start
+// and passed through.
 func (p *LogPipe) collectLogsFromFile(ctx context.Context, recordLogger logr.Logger) error {
 	filenameLog := log.FromContext(ctx).WithValues("fileName", p.fileName)
 

--- a/pkg/management/postgres/logpipe/logpipe.go
+++ b/pkg/management/postgres/logpipe/logpipe.go
@@ -35,6 +35,8 @@ import (
 	"github.com/cloudnative-pg/machinery/pkg/fileutils"
 	"github.com/cloudnative-pg/machinery/pkg/fileutils/compatibility"
 	"github.com/cloudnative-pg/machinery/pkg/log"
+	"github.com/go-logr/logr"
+	"go.uber.org/zap/zapcore"
 
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/concurrency"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/postgres"
@@ -89,6 +91,10 @@ func (p *LogPipe) GetExitedCondition() *concurrency.Executed {
 func (p *LogPipe) Start(ctx context.Context) error {
 	filenameLog := log.FromContext(ctx).WithValues("fileName", p.fileName)
 	defer filenameLog.Info("Exited log pipe")
+	// Built once here, before the collection goroutine starts, and reused by
+	// every retry of collectLogsFromFile so audit records don't rebuild their
+	// unsampled logger on every reconnect.
+	recordLogger := buildUnsampledLogger(zapcore.AddSync(os.Stderr))
 	go func() {
 		defer p.exited.Broadcast()
 		for {
@@ -110,7 +116,7 @@ func (p *LogPipe) Start(ctx context.Context) error {
 			}
 			p.initialized.Broadcast()
 
-			if err := p.collectLogsFromFile(ctx); err != nil {
+			if err := p.collectLogsFromFile(ctx, recordLogger); err != nil {
 				if errors.Is(err, context.Canceled) {
 					return
 				}
@@ -124,8 +130,9 @@ func (p *LogPipe) Start(ctx context.Context) error {
 }
 
 // collectLogsFromFile opens (blocking) the FIFO file, then starts reading the csv file line by line
-// until the end of the file or an error.
-func (p *LogPipe) collectLogsFromFile(ctx context.Context) error {
+// until the end of the file or an error. recordLogger is the unsampled logger
+// built once by Start, reused across every retry.
+func (p *LogPipe) collectLogsFromFile(ctx context.Context, recordLogger logr.Logger) error {
 	filenameLog := log.FromContext(ctx).WithValues("fileName", p.fileName)
 
 	defer func() {
@@ -151,7 +158,7 @@ func (p *LogPipe) collectLogsFromFile(ctx context.Context) error {
 	// the cancellation signal happened
 	go func() {
 		defer close(errChan)
-		errChan <- p.streamLogFromCSVFile(ctx, f, &LogRecordWriter{})
+		errChan <- p.streamLogFromCSVFile(ctx, f, NewLogRecordWriter(recordLogger))
 	}()
 	select {
 	case <-ctx.Done():

--- a/pkg/management/postgres/logpipe/writer.go
+++ b/pkg/management/postgres/logpipe/writer.go
@@ -20,6 +20,14 @@ SPDX-License-Identifier: Apache-2.0
 package logpipe
 
 import (
+	"os"
+	"sync"
+
+	"github.com/go-logr/logr"
+	"github.com/go-logr/zapr"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+
 	"github.com/cloudnative-pg/machinery/pkg/log"
 )
 
@@ -36,7 +44,47 @@ type RecordWriter interface {
 // instance manager logger
 type LogRecordWriter struct{}
 
+var (
+	recordLogOnce sync.Once
+	recordLogr    logr.Logger
+)
+
+// getRecordLogger returns a logr.Logger with sampling disabled.
+// controller-runtime enables a zap sampler in production mode that silently
+// drops repeated log entries sharing the same message. Every PostgreSQL audit
+// record emits msg="record", so a burst of audit activity causes subsequent
+// records — including security-relevant events — to be dropped. This logger
+// bypasses that sampler so every record is forwarded unconditionally.
+func getRecordLogger() logr.Logger {
+	recordLogOnce.Do(func() {
+		recordLogr = buildUnsampledLogger()
+	})
+	return recordLogr
+}
+
+// buildUnsampledLogger constructs a JSON logger that writes to stderr without
+// any sampling. The format intentionally mirrors the default instance-manager
+// logger (RFC3339 timestamps, JSON encoding) so log aggregators see a
+// consistent schema across all pod log lines.
+func buildUnsampledLogger() logr.Logger {
+	cfg := zap.NewProductionConfig()
+	cfg.Sampling = nil // disable sampling — audit records must never be dropped
+	cfg.EncoderConfig.EncodeTime = zapcore.RFC3339NanoTimeEncoder
+
+	zapLogger, err := cfg.Build()
+	if err != nil {
+		// Fallback: global logger may still sample, but is better than nothing
+		return log.GetLogger().GetLogger()
+	}
+
+	l := zapr.NewLogger(zapLogger)
+	if podName := os.Getenv("POD_NAME"); podName != "" {
+		l = l.WithValues("logging_pod", podName)
+	}
+	return l
+}
+
 // Write writes the PostgreSQL log record to the instance manager logger
 func (writer *LogRecordWriter) Write(record NamedRecord) {
-	log.WithName(record.GetName()).Info(logRecordKey, logRecordKey, record)
+	getRecordLogger().WithName(record.GetName()).Info(logRecordKey, logRecordKey, record)
 }

--- a/pkg/management/postgres/logpipe/writer.go
+++ b/pkg/management/postgres/logpipe/writer.go
@@ -21,6 +21,7 @@ package logpipe
 
 import (
 	"os"
+	"strings"
 	"sync"
 
 	"github.com/cloudnative-pg/machinery/pkg/log"
@@ -56,31 +57,58 @@ var (
 // bypasses that sampler so every record is forwarded unconditionally.
 func getRecordLogger() logr.Logger {
 	recordLogOnce.Do(func() {
-		recordLogr = buildUnsampledLogger()
+		recordLogr = buildUnsampledLogger(zapcore.AddSync(os.Stderr))
 	})
 	return recordLogr
 }
 
-// buildUnsampledLogger constructs a JSON logger that writes to stderr without
-// any sampling. The format intentionally mirrors the default instance-manager
-// logger (RFC3339 timestamps, JSON encoding) so log aggregators see a
-// consistent schema across all pod log lines.
-func buildUnsampledLogger() logr.Logger {
-	cfg := zap.NewProductionConfig()
-	cfg.Sampling = nil // disable sampling — audit records must never be dropped
-	cfg.EncoderConfig.EncodeTime = zapcore.RFC3339NanoTimeEncoder
+// buildUnsampledLogger constructs a JSON logger writing to out without any
+// sampling. It otherwise mirrors the global instance-manager logger built by
+// machinery/pkg/log.Flags.ConfigureLogging: same JSON/RFC3339Nano encoding,
+// the same effective --log-level, and the same --log-field-level/
+// --log-field-timestamp remapping, so audit records only differ from the
+// rest of the pod's log lines in that they're never sampler-dropped.
+//
+// --log-destination is intentionally not honored here: it's only ever passed
+// to the short-lived wal-archive/wal-restore subcommands, never to the
+// long-running `instance run` process that owns this writer, so stderr is
+// always the correct destination in practice.
+func buildUnsampledLogger(out zapcore.WriteSyncer) logr.Logger {
+	encoderConfig := zap.NewProductionEncoderConfig()
+	encoderConfig.EncodeTime = zapcore.RFC3339NanoTimeEncoder
+	applyFieldRemap(&encoderConfig)
 
-	zapLogger, err := cfg.Build()
-	if err != nil {
-		// Fallback: global logger may still sample, but is better than nothing
-		return log.GetLogger().GetLogger()
-	}
-
-	l := zapr.NewLogger(zapLogger)
+	core := zapcore.NewCore(zapcore.NewJSONEncoder(encoderConfig), out, globalLoggerLevel())
+	l := zapr.NewLogger(zap.New(core))
 	if podName := os.Getenv("POD_NAME"); podName != "" {
 		l = l.WithValues("logging_pod", podName)
 	}
 	return l
+}
+
+// globalLoggerLevel returns the effective level of the global instance-manager
+// logger, so the unsampled audit logger honors the same --log-level flag
+// instead of hardcoding one. Falls back to Info if the global logger isn't a
+// zap logger, which shouldn't happen once ConfigureLogging has run.
+func globalLoggerLevel() zapcore.Level {
+	if u, ok := log.GetLogger().GetLogger().GetSink().(zapr.Underlier); ok {
+		return u.GetUnderlying().Level()
+	}
+	return zapcore.InfoLevel
+}
+
+// applyFieldRemap mirrors the --log-field-level/--log-field-timestamp
+// remapping machinery/pkg/log applies to the global logger's encoder, so the
+// audit logger's JSON schema doesn't diverge from the rest of the pod's logs.
+func applyFieldRemap(enc *zapcore.EncoderConfig) {
+	for _, flag := range log.GetFieldsRemapFlags() {
+		switch {
+		case strings.HasPrefix(flag, "--log-field-level="):
+			enc.LevelKey = strings.TrimPrefix(flag, "--log-field-level=")
+		case strings.HasPrefix(flag, "--log-field-timestamp="):
+			enc.TimeKey = strings.TrimPrefix(flag, "--log-field-timestamp=")
+		}
+	}
 }
 
 // Write writes the PostgreSQL log record to the instance manager logger

--- a/pkg/management/postgres/logpipe/writer.go
+++ b/pkg/management/postgres/logpipe/writer.go
@@ -22,7 +22,6 @@ package logpipe
 import (
 	"os"
 	"strings"
-	"sync"
 
 	"github.com/cloudnative-pg/machinery/pkg/log"
 	"github.com/go-logr/logr"
@@ -42,24 +41,18 @@ type RecordWriter interface {
 
 // LogRecordWriter implements the `RecordWriter` interface writing to the
 // instance manager logger
-type LogRecordWriter struct{}
+type LogRecordWriter struct {
+	logger logr.Logger
+}
 
-var (
-	recordLogOnce sync.Once
-	recordLogr    logr.Logger
-)
-
-// getRecordLogger returns a logr.Logger with sampling disabled.
-// controller-runtime enables a zap sampler in production mode that silently
-// drops repeated log entries sharing the same message. Every PostgreSQL audit
-// record emits msg="record", so a burst of audit activity causes subsequent
-// records — including security-relevant events — to be dropped. This logger
-// bypasses that sampler so every record is forwarded unconditionally.
-func getRecordLogger() logr.Logger {
-	recordLogOnce.Do(func() {
-		recordLogr = buildUnsampledLogger(zapcore.AddSync(os.Stderr))
-	})
-	return recordLogr
+// NewLogRecordWriter builds a LogRecordWriter writing through logger.
+// Callers should build logger via buildUnsampledLogger: controller-runtime
+// enables a zap sampler in production mode that silently drops repeated log
+// entries sharing the same message, and every PostgreSQL audit record emits
+// msg="record", so a burst of audit activity would otherwise cause
+// subsequent records — including security-relevant events — to be dropped.
+func NewLogRecordWriter(logger logr.Logger) *LogRecordWriter {
+	return &LogRecordWriter{logger: logger}
 }
 
 // buildUnsampledLogger constructs a JSON logger writing to out without any
@@ -118,5 +111,5 @@ func applyFieldRemap(enc *zapcore.EncoderConfig, flags []string) {
 
 // Write writes the PostgreSQL log record to the instance manager logger
 func (writer *LogRecordWriter) Write(record NamedRecord) {
-	getRecordLogger().WithName(record.GetName()).Info(logRecordKey, logRecordKey, record)
+	writer.logger.WithName(record.GetName()).Info(logRecordKey, logRecordKey, record)
 }

--- a/pkg/management/postgres/logpipe/writer.go
+++ b/pkg/management/postgres/logpipe/writer.go
@@ -45,12 +45,8 @@ type LogRecordWriter struct {
 	logger logr.Logger
 }
 
-// NewLogRecordWriter builds a LogRecordWriter writing through logger.
-// Callers should build logger via buildUnsampledLogger: controller-runtime
-// enables a zap sampler in production mode that silently drops repeated log
-// entries sharing the same message, and every PostgreSQL audit record emits
-// msg="record", so a burst of audit activity would otherwise cause
-// subsequent records — including security-relevant events — to be dropped.
+// NewLogRecordWriter builds a LogRecordWriter that logs through logger,
+// which should be built via buildUnsampledLogger.
 func NewLogRecordWriter(logger logr.Logger) *LogRecordWriter {
 	return &LogRecordWriter{logger: logger}
 }
@@ -65,10 +61,10 @@ func NewLogRecordWriter(logger logr.Logger) *LogRecordWriter {
 // custom level-name encoding ConfigureLogging installs for Warning/Debug/
 // Trace (see machinery/pkg/log.getLogLevelString) isn't replicated here.
 //
-// --log-destination is intentionally not honored here: it's only ever passed
-// to the short-lived wal-archive/wal-restore subcommands, never to the
-// long-running `instance run` process that owns this writer, so stderr is
-// always the correct destination in practice.
+// --log-destination isn't honored here: in practice it's only ever set for
+// the wal-archive/wal-restore subcommands, never for `instance run` (which
+// owns this writer), so stderr is correct today — though nothing enforces
+// that stays true.
 func buildUnsampledLogger(out zapcore.WriteSyncer) logr.Logger {
 	encoderConfig := zap.NewProductionEncoderConfig()
 	encoderConfig.EncodeTime = zapcore.RFC3339NanoTimeEncoder
@@ -93,11 +89,9 @@ func globalLoggerLevel() zapcore.Level {
 	return zapcore.InfoLevel
 }
 
-// applyFieldRemap applies the --log-field-level/--log-field-timestamp field-name
-// remapping machinery/pkg/log applies to the global logger's encoder (flags in
-// the same "--log-field-level=X"/"--log-field-timestamp=X" form GetFieldsRemapFlags
-// returns), so the audit logger's JSON schema doesn't diverge from the rest of
-// the pod's logs.
+// applyFieldRemap sets enc.LevelKey/TimeKey from flags in the
+// "--log-field-level=X"/"--log-field-timestamp=X" form GetFieldsRemapFlags
+// returns.
 func applyFieldRemap(enc *zapcore.EncoderConfig, flags []string) {
 	for _, flag := range flags {
 		switch {
@@ -109,7 +103,7 @@ func applyFieldRemap(enc *zapcore.EncoderConfig, flags []string) {
 	}
 }
 
-// Write writes the PostgreSQL log record to the instance manager logger
+// Write logs record through the writer's logger.
 func (writer *LogRecordWriter) Write(record NamedRecord) {
 	writer.logger.WithName(record.GetName()).Info(logRecordKey, logRecordKey, record)
 }

--- a/pkg/management/postgres/logpipe/writer.go
+++ b/pkg/management/postgres/logpipe/writer.go
@@ -23,12 +23,11 @@ import (
 	"os"
 	"sync"
 
+	"github.com/cloudnative-pg/machinery/pkg/log"
 	"github.com/go-logr/logr"
 	"github.com/go-logr/zapr"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
-
-	"github.com/cloudnative-pg/machinery/pkg/log"
 )
 
 const (

--- a/pkg/management/postgres/logpipe/writer.go
+++ b/pkg/management/postgres/logpipe/writer.go
@@ -64,10 +64,13 @@ func getRecordLogger() logr.Logger {
 
 // buildUnsampledLogger constructs a JSON logger writing to out without any
 // sampling. It otherwise mirrors the global instance-manager logger built by
-// machinery/pkg/log.Flags.ConfigureLogging: same JSON/RFC3339Nano encoding,
-// the same effective --log-level, and the same --log-field-level/
-// --log-field-timestamp remapping, so audit records only differ from the
-// rest of the pod's log lines in that they're never sampler-dropped.
+// machinery/pkg/log.Flags.ConfigureLogging for Info-level output: same
+// JSON/RFC3339Nano encoding, the same effective --log-level, and the same
+// --log-field-level/--log-field-timestamp field-name remapping, so audit
+// records only differ from the rest of the pod's log lines in that they're
+// never sampler-dropped. LogRecordWriter only ever logs at Info, so the
+// custom level-name encoding ConfigureLogging installs for Warning/Debug/
+// Trace (see machinery/pkg/log.getLogLevelString) isn't replicated here.
 //
 // --log-destination is intentionally not honored here: it's only ever passed
 // to the short-lived wal-archive/wal-restore subcommands, never to the
@@ -76,7 +79,7 @@ func getRecordLogger() logr.Logger {
 func buildUnsampledLogger(out zapcore.WriteSyncer) logr.Logger {
 	encoderConfig := zap.NewProductionEncoderConfig()
 	encoderConfig.EncodeTime = zapcore.RFC3339NanoTimeEncoder
-	applyFieldRemap(&encoderConfig)
+	applyFieldRemap(&encoderConfig, log.GetFieldsRemapFlags())
 
 	core := zapcore.NewCore(zapcore.NewJSONEncoder(encoderConfig), out, globalLoggerLevel())
 	l := zapr.NewLogger(zap.New(core))
@@ -97,11 +100,13 @@ func globalLoggerLevel() zapcore.Level {
 	return zapcore.InfoLevel
 }
 
-// applyFieldRemap mirrors the --log-field-level/--log-field-timestamp
-// remapping machinery/pkg/log applies to the global logger's encoder, so the
-// audit logger's JSON schema doesn't diverge from the rest of the pod's logs.
-func applyFieldRemap(enc *zapcore.EncoderConfig) {
-	for _, flag := range log.GetFieldsRemapFlags() {
+// applyFieldRemap applies the --log-field-level/--log-field-timestamp field-name
+// remapping machinery/pkg/log applies to the global logger's encoder (flags in
+// the same "--log-field-level=X"/"--log-field-timestamp=X" form GetFieldsRemapFlags
+// returns), so the audit logger's JSON schema doesn't diverge from the rest of
+// the pod's logs.
+func applyFieldRemap(enc *zapcore.EncoderConfig, flags []string) {
+	for _, flag := range flags {
 		switch {
 		case strings.HasPrefix(flag, "--log-field-level="):
 			enc.LevelKey = strings.TrimPrefix(flag, "--log-field-level=")

--- a/pkg/management/postgres/logpipe/writer_test.go
+++ b/pkg/management/postgres/logpipe/writer_test.go
@@ -24,10 +24,11 @@ import (
 	"strings"
 	"time"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
 // buildTestCore constructs a zapcore.Core that writes JSON to buf.

--- a/pkg/management/postgres/logpipe/writer_test.go
+++ b/pkg/management/postgres/logpipe/writer_test.go
@@ -1,0 +1,85 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package logpipe
+
+import (
+	"bytes"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+// buildTestCore constructs a zapcore.Core that writes JSON to buf.
+// When sampled is true it wraps the core in the same sampler that
+// controller-runtime adds in production mode (100 initial, 100 thereafter
+// per second). When sampled is false no sampler is applied — this mirrors
+// what buildUnsampledLogger does.
+func buildTestCore(buf *bytes.Buffer, sampled bool) zapcore.Core {
+	enc := zapcore.NewJSONEncoder(zap.NewProductionEncoderConfig())
+	ws := zapcore.AddSync(buf)
+	core := zapcore.NewCore(enc, ws, zap.InfoLevel)
+	if sampled {
+		return zapcore.NewSamplerWithOptions(core, time.Second, 100, 100)
+	}
+	return core
+}
+
+var _ = Describe("LogRecordWriter", func() {
+	const burst = 200 // must exceed the sampler's initial-pass threshold of 100
+
+	Context("unsampled logger (the fix)", func() {
+		It("forwards every audit record even during a burst", func() {
+			buf := &bytes.Buffer{}
+			logger := zap.New(buildTestCore(buf, false))
+
+			for i := 0; i < burst; i++ {
+				logger.Info(logRecordKey)
+			}
+			Expect(logger.Sync()).To(Succeed())
+
+			lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+			Expect(lines).To(HaveLen(burst),
+				"unsampled logger must emit all %d records; got %d — sampler may still be active", burst, len(lines))
+		})
+	})
+
+	Context("sampled logger (the bug)", func() {
+		It("drops audit records after the first 100 within a second", func() {
+			buf := &bytes.Buffer{}
+			logger := zap.New(buildTestCore(buf, true))
+
+			for i := 0; i < burst; i++ {
+				logger.Info(logRecordKey)
+			}
+			Expect(logger.Sync()).To(Succeed())
+
+			lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+			// Sampler allows first 100 through, then 1-in-100 afterwards.
+			// With 200 identical messages in a single second we expect well
+			// under 200 lines — the exact count varies but is always < burst.
+			Expect(len(lines)).To(BeNumerically("<", burst),
+				"sampled logger should drop messages beyond 100/s; got %d lines for %d messages", len(lines), burst)
+		})
+	})
+})

--- a/pkg/management/postgres/logpipe/writer_test.go
+++ b/pkg/management/postgres/logpipe/writer_test.go
@@ -93,12 +93,33 @@ var _ = Describe("LogRecordWriter", func() {
 			)
 			log.SetLogger(zapr.NewLogger(zap.New(errorOnlyCore)))
 
+			Expect(globalLoggerLevel()).To(Equal(zapcore.ErrorLevel))
+
 			buf := &bytes.Buffer{}
 			logger := buildUnsampledLogger(zapcore.AddSync(buf))
 			logger.Info(logRecordKey)
 
 			Expect(buf.String()).To(BeEmpty(),
 				"an Info-level record should have been filtered out by the global logger's Error level")
+		})
+	})
+
+	Context("applyFieldRemap", func() {
+		It("leaves the default level/timestamp keys untouched when no remap flags are set", func() {
+			enc := zap.NewProductionEncoderConfig()
+			applyFieldRemap(&enc, nil)
+			Expect(enc.LevelKey).To(Equal(zap.NewProductionEncoderConfig().LevelKey))
+			Expect(enc.TimeKey).To(Equal(zap.NewProductionEncoderConfig().TimeKey))
+		})
+
+		It("renames the level and timestamp keys from --log-field-* flags", func() {
+			enc := zap.NewProductionEncoderConfig()
+			applyFieldRemap(&enc, []string{
+				"--log-field-level=severity",
+				"--log-field-timestamp=timestamp",
+			})
+			Expect(enc.LevelKey).To(Equal("severity"))
+			Expect(enc.TimeKey).To(Equal("timestamp"))
 		})
 	})
 })

--- a/pkg/management/postgres/logpipe/writer_test.go
+++ b/pkg/management/postgres/logpipe/writer_test.go
@@ -24,6 +24,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cloudnative-pg/machinery/pkg/log"
+	"github.com/go-logr/zapr"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
@@ -31,46 +33,26 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-// buildTestCore constructs a zapcore.Core that writes JSON to buf.
-// When sampled is true it wraps the core in the same sampler that
-// controller-runtime adds in production mode (100 initial, 100 thereafter
-// per second). When sampled is false no sampler is applied — this mirrors
-// what buildUnsampledLogger does.
-func buildTestCore(buf *bytes.Buffer, sampled bool) zapcore.Core {
+// buildTestCore constructs a sampled zapcore.Core writing JSON to buf, using
+// the same sampler controller-runtime installs in production mode (100
+// initial, 100 thereafter per second). It demonstrates the bug this PR fixes:
+// it does not exercise buildUnsampledLogger itself.
+func buildTestCore(buf *bytes.Buffer) zapcore.Core {
 	enc := zapcore.NewJSONEncoder(zap.NewProductionEncoderConfig())
 	ws := zapcore.AddSync(buf)
 	core := zapcore.NewCore(enc, ws, zap.InfoLevel)
-	if sampled {
-		return zapcore.NewSamplerWithOptions(core, time.Second, 100, 100)
-	}
-	return core
+	return zapcore.NewSamplerWithOptions(core, time.Second, 100, 100)
 }
 
 var _ = Describe("LogRecordWriter", func() {
 	const burst = 200 // must exceed the sampler's initial-pass threshold of 100
 
-	Context("unsampled logger (the fix)", func() {
-		It("forwards every audit record even during a burst", func() {
-			buf := &bytes.Buffer{}
-			logger := zap.New(buildTestCore(buf, false))
-
-			for i := 0; i < burst; i++ {
-				logger.Info(logRecordKey)
-			}
-			Expect(logger.Sync()).To(Succeed())
-
-			lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
-			Expect(lines).To(HaveLen(burst),
-				"unsampled logger must emit all %d records; got %d — sampler may still be active", burst, len(lines))
-		})
-	})
-
 	Context("sampled logger (the bug)", func() {
 		It("drops audit records after the first 100 within a second", func() {
 			buf := &bytes.Buffer{}
-			logger := zap.New(buildTestCore(buf, true))
+			logger := zap.New(buildTestCore(buf))
 
-			for i := 0; i < burst; i++ {
+			for range burst {
 				logger.Info(logRecordKey)
 			}
 			Expect(logger.Sync()).To(Succeed())
@@ -81,6 +63,42 @@ var _ = Describe("LogRecordWriter", func() {
 			// under 200 lines — the exact count varies but is always < burst.
 			Expect(len(lines)).To(BeNumerically("<", burst),
 				"sampled logger should drop messages beyond 100/s; got %d lines for %d messages", len(lines), burst)
+		})
+	})
+
+	Context("buildUnsampledLogger (the fix)", func() {
+		It("forwards every audit record even during a burst", func() {
+			buf := &bytes.Buffer{}
+			logger := buildUnsampledLogger(zapcore.AddSync(buf))
+
+			for range burst {
+				logger.Info(logRecordKey)
+			}
+
+			lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+			Expect(lines).To(HaveLen(burst),
+				"unsampled logger must emit all %d records; got %d", burst, len(lines))
+		})
+
+		It("honors the effective level of the global instance-manager logger", func() {
+			originalLogger := log.GetLogger().GetLogger()
+			DeferCleanup(func() {
+				log.SetLogger(originalLogger)
+			})
+
+			errorOnlyCore := zapcore.NewCore(
+				zapcore.NewJSONEncoder(zap.NewProductionEncoderConfig()),
+				zapcore.AddSync(&bytes.Buffer{}),
+				zap.ErrorLevel,
+			)
+			log.SetLogger(zapr.NewLogger(zap.New(errorOnlyCore)))
+
+			buf := &bytes.Buffer{}
+			logger := buildUnsampledLogger(zapcore.AddSync(buf))
+			logger.Info(logRecordKey)
+
+			Expect(buf.String()).To(BeEmpty(),
+				"an Info-level record should have been filtered out by the global logger's Error level")
 		})
 	})
 })


### PR DESCRIPTION
Fixes a silent audit-log loss in `LogRecordWriter`. Every PostgreSQL audit record it emits shares the same log message key (`"record"`), so the zap sampler controller-runtime installs in production mode (passing the first 100 identical messages per second, then roughly 1 in 100 after that) treats a burst of audit activity as duplicates and drops most of it, including security-relevant events such as DDL errors or privilege escalations, with no indication of the gap.

`LogRecordWriter` now writes through a dedicated logger with sampling disabled, built once when the log pipe starts and reused across every reconnect. That logger otherwise mirrors the global instance-manager logger for Info-level output: the same JSON/RFC3339Nano encoding, the same effective `--log-level`, and the same `--log-field-level`/`--log-field-timestamp` remapping, so audit records only differ from the rest of the pod's log lines in that they're never sampler-dropped.

Fixes #10815

----

**Root cause**

```go
// writer.go (before)
const logRecordKey = "record" // constant — never varies

func (writer *LogRecordWriter) Write(record NamedRecord) {
    log.WithName(record.GetName()).Info(logRecordKey, logRecordKey, record)
    //                                  ^^^^^^^^^^^^
    //             every audit record uses msg="record" → sampler treats all as duplicates
}
```

controller-runtime v0.24.1 adds this sampler automatically when `Development=false`:

```go
zap.WrapCore(func(core zapcore.Core) zapcore.Core {
    return zapcore.NewSamplerWithOptions(core, time.Second, 100, 100)
})
```

That's fine for operator reconcile-loop noise. It's not fine for audit records, where every entry represents a distinct real-world database event.

**How to verify**

1. Deploy a cluster with `pgaudit.log: all` and `shared_preload_libraries: pgaudit`
2. Fire a burst of 500+ SQL statements within a single second:
   ```sql
   DO $$ DECLARE i INT; BEGIN
     FOR i IN 1..500 LOOP EXECUTE 'SELECT ' || i; END LOOP;
   END $$;
   CREAT TABLE marker_should_appear(id int); -- intentional typo
   ```
3. Check pod logs: `kubectl logs <pod> -c postgres | grep marker_should_appear`
   - **Before fix**: 0 results (marker event dropped by sampler)
   - **After fix**: 1 result (all records forwarded)

**Tests**

`writer_test.go` calls `buildUnsampledLogger` directly: one spec floods it with a burst and confirms every record is forwarded, another confirms it honors the effective level of the global instance-manager logger, and two more cover `applyFieldRemap`'s key-renaming logic. A separate spec demonstrates the underlying zap sampler dropping records in isolation (not through CNPG code) to document why the bug is real.

Add to the release notes:

Fixed an issue where a burst of PostgreSQL audit activity (`pgaudit`) could cause most audit records to be silently dropped from the pod's log stream due to log sampling.
