### PR TITLE
feat: in-place resource resize of instance pods

### DIFF
--- a/.wordlist-en-custom.txt
+++ b/.wordlist-en-custom.txt
@@ -461,6 +461,9 @@ ReplicationTLSSecret
 ResizingPVC
 ResourceRequirements
 ResourceVersion
+ResourcesUpdateStrategy
+ResourcesUpdateStrategyInPlace
+ResourcesUpdateStrategyRecreate
 RestoreJobHook
 RestoreJobHookCapabilities
 RetentionPolicy
@@ -1033,6 +1036,7 @@ img
 immediateCheckpoint
 impactful
 importsource
+inPlace
 inProgress
 inRoles
 indistinctively
@@ -1429,6 +1433,8 @@ resizingPVC
 resourceRequirements
 resourceVersion
 resourcerequirements
+resourcesUpdateStrategy
+resourcesupdatestrategy
 restoreAdditionalCommandArgs
 restoreJobHookCapabilities
 resync

--- a/api/v1/cluster_funcs.go
+++ b/api/v1/cluster_funcs.go
@@ -822,6 +822,17 @@ func (cluster *Cluster) GetPrimaryUpdateMethod() PrimaryUpdateMethod {
 	return strategy
 }
 
+// GetResourcesUpdateStrategy get the strategy used to apply changes to
+// the resources of the instance containers, defaulting to recreate
+func (cluster *Cluster) GetResourcesUpdateStrategy() ResourcesUpdateStrategy {
+	strategy := cluster.Spec.ResourcesUpdateStrategy
+	if strategy == "" {
+		return ResourcesUpdateStrategyRecreate
+	}
+
+	return strategy
+}
+
 // GetEnablePDB get the cluster EnablePDB value, defaults to true
 func (cluster *Cluster) GetEnablePDB() bool {
 	if cluster.Spec.EnablePDB == nil {

--- a/api/v1/cluster_funcs_test.go
+++ b/api/v1/cluster_funcs_test.go
@@ -112,6 +112,22 @@ var _ = Describe("Primary update strategy", func() {
 	})
 })
 
+var _ = Describe("Resources update strategy", func() {
+	It("defaults to recreate", func() {
+		emptyCluster := Cluster{}
+		Expect(emptyCluster.GetResourcesUpdateStrategy()).To(BeEquivalentTo(ResourcesUpdateStrategyRecreate))
+	})
+
+	It("respects the preference of the user", func() {
+		cluster := Cluster{
+			Spec: ClusterSpec{
+				ResourcesUpdateStrategy: ResourcesUpdateStrategyInPlace,
+			},
+		}
+		Expect(cluster.GetResourcesUpdateStrategy()).To(BeEquivalentTo(ResourcesUpdateStrategyInPlace))
+	})
+})
+
 var _ = Describe("Node maintenance window", func() {
 	It("default maintenance not in progress", func() {
 		cluster := Cluster{}

--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -409,6 +409,17 @@ type ClusterSpec struct {
 	// +optional
 	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
 
+	// ResourcesUpdateStrategy selects how changes to the resources of the
+	// instance containers are applied to running instances: `recreate` (the
+	// default) replaces the Pods with a rolling update, while `inPlace`
+	// resizes running Pods through the Kubernetes `resize` subresource
+	// whenever possible, falling back to a rolling update otherwise.
+	// In-place resize requires Kubernetes 1.33 or later. Memory limit
+	// decreases are always applied with a rolling update.
+	// +kubebuilder:validation:Enum=recreate;inPlace
+	// +optional
+	ResourcesUpdateStrategy ResourcesUpdateStrategy `json:"resourcesUpdateStrategy,omitempty"`
+
 	// EphemeralVolumesSizeLimit allows the user to set the limits for the ephemeral
 	// volumes
 	// +optional
@@ -1421,7 +1432,23 @@ type PrimaryUpdateStrategy string
 // The default method is "restart"
 type PrimaryUpdateMethod string
 
+// ResourcesUpdateStrategy defines how changes to the resources of the
+// instance containers are applied to running instances.
+// The default strategy is "recreate"
+type ResourcesUpdateStrategy string
+
 const (
+	// ResourcesUpdateStrategyRecreate means that a change to the resources of
+	// the instance containers is applied by replacing the Pods with a rolling
+	// update (`recreate`, default)
+	ResourcesUpdateStrategyRecreate ResourcesUpdateStrategy = "recreate"
+
+	// ResourcesUpdateStrategyInPlace means that a change to the resources of
+	// the instance containers is applied to the running Pods through the
+	// Kubernetes `resize` subresource whenever possible, falling back to a
+	// rolling update otherwise (`inPlace`)
+	ResourcesUpdateStrategyInPlace ResourcesUpdateStrategy = "inPlace"
+
 	// PrimaryUpdateStrategySupervised means that the operator need to wait for the
 	// user to manually issue a switchover request before updating the primary
 	// server (`supervised`)

--- a/config/crd/bases/postgresql.cnpg.io_clusters.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_clusters.yaml
@@ -5665,6 +5665,19 @@ spec:
                       More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                     type: object
                 type: object
+              resourcesUpdateStrategy:
+                description: |-
+                  ResourcesUpdateStrategy selects how changes to the resources of the
+                  instance containers are applied to running instances: `recreate` (the
+                  default) replaces the Pods with a rolling update, while `inPlace`
+                  resizes running Pods through the Kubernetes `resize` subresource
+                  whenever possible, falling back to a rolling update otherwise.
+                  In-place resize requires Kubernetes 1.33 or later. Memory limit
+                  decreases are always applied with a rolling update.
+                enum:
+                - recreate
+                - inPlace
+                type: string
               schedulerName:
                 description: |-
                   If specified, the pod will be dispatched by specified Kubernetes

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -58,6 +58,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - pods/resize
+  verbs:
+  - patch
+- apiGroups:
+  - ""
+  resources:
   - pods/status
   verbs:
   - get

--- a/docs/src/cloudnative-pg.v1.md
+++ b/docs/src/cloudnative-pg.v1.md
@@ -655,6 +655,7 @@ _Appears in:_
 | `affinity` _[AffinityConfiguration](#affinityconfiguration)_ | Affinity/Anti-affinity rules for Pods |  |  |  |
 | `topologySpreadConstraints` _[TopologySpreadConstraint](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#topologyspreadconstraint-v1-core) array_ | TopologySpreadConstraints specifies how to spread matching pods among the given topology.<br />More info:<br />https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/ |  |  |  |
 | `resources` _[ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#resourcerequirements-v1-core)_ | Resources requirements of every generated Pod. Please refer to<br />https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/<br />for more information. |  |  |  |
+| `resourcesUpdateStrategy` _[ResourcesUpdateStrategy](#resourcesupdatestrategy)_ | ResourcesUpdateStrategy selects how changes to the resources of the<br />instance containers are applied to running instances: `recreate` (the<br />default) replaces the Pods with a rolling update, while `inPlace`<br />resizes running Pods through the Kubernetes `resize` subresource<br />whenever possible, falling back to a rolling update otherwise.<br />In-place resize requires Kubernetes 1.33 or later. Memory limit<br />decreases are always applied with a rolling update. |  |  | Enum: [recreate inPlace] <br /> |
 | `ephemeralVolumesSizeLimit` _[EphemeralVolumesSizeLimitConfiguration](#ephemeralvolumessizelimitconfiguration)_ | EphemeralVolumesSizeLimit allows the user to set the limits for the ephemeral<br />volumes |  |  |  |
 | `priorityClassName` _string_ | Name of the priority class which will be used in every generated Pod, if the PriorityClass<br />specified does not exist, the pod will not be able to schedule.  Please refer to<br />https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#priorityclass<br />for more information |  |  |  |
 | `primaryUpdateStrategy` _[PrimaryUpdateStrategy](#primaryupdatestrategy)_ | Deployment strategy to follow to upgrade the primary server during a rolling<br />update procedure, after all replicas have been successfully updated:<br />it can be automated (`unsupervised` - default) or manual (`supervised`) |  | unsupervised | Enum: [unsupervised supervised] <br /> |
@@ -2642,6 +2643,26 @@ _Appears in:_
 | `enabled` _boolean_ | If enabled (default), the operator will automatically manage replication slots<br />on the primary instance and use them in streaming replication<br />connections with all the standby instances that are part of the HA<br />cluster. If disabled, the operator will not take advantage<br />of replication slots in streaming connections with the replicas.<br />This feature also controls replication slots in replica cluster,<br />from the designated primary to its cascading replicas. |  | true |  |
 | `slotPrefix` _string_ | Prefix for replication slots managed by the operator for HA.<br />It may only contain lower case letters, numbers, and the underscore character.<br />This can only be set at creation time. By default set to `_cnpg_`. |  | _cnpg_ | Pattern: `^[0-9a-z_]*$` <br /> |
 | `synchronizeLogicalDecoding` _boolean_ | When enabled, the operator automatically manages synchronization of logical<br />decoding (replication) slots across high-availability clusters.<br />Requires one of the following conditions:<br />- PostgreSQL version 17 or later<br />- PostgreSQL version < 17 with pg_failover_slots extension enabled |  |  |  |
+
+
+#### ResourcesUpdateStrategy
+
+_Underlying type:_ _string_
+
+ResourcesUpdateStrategy defines how changes to the resources of the
+instance containers are applied to running instances.
+The default strategy is "recreate"
+
+
+
+_Appears in:_
+
+- [ClusterSpec](#clusterspec)
+
+| Field | Description |
+| --- | --- |
+| `recreate` | ResourcesUpdateStrategyRecreate means that a change to the resources of<br />the instance containers is applied by replacing the Pods with a rolling<br />update (`recreate`, default)<br /> |
+| `inPlace` | ResourcesUpdateStrategyInPlace means that a change to the resources of<br />the instance containers is applied to the running Pods through the<br />Kubernetes `resize` subresource whenever possible, falling back to a<br />rolling update otherwise (`inPlace`)<br /> |
 
 
 #### RoleConfiguration

--- a/docs/src/resource_management.md
+++ b/docs/src/resource_management.md
@@ -169,11 +169,17 @@ This happens when:
 
 - The Kubernetes cluster does not expose the resize subresource of the pods
   (the feature requires Kubernetes 1.33 or later, and became stable in 1.35).
-- A **memory limit is decreased**. The kubelet applies memory limit decreases
-  only when the current usage is below the new limit, and PostgreSQL never
-  releases its shared memory, so such a resize would remain pending
-  indefinitely. A fresh pod starting under the new limit is the deterministic
-  option.
+- A **memory limit is decreased**. The kubelet applies a memory limit
+  decrease only when the current usage of the container is below the new
+  limit, and PostgreSQL keeps its shared memory (`shared_buffers` above all)
+  allocated for the whole life of the instance, so on a warmed-up instance
+  such a resize would remain pending indefinitely, without any error being
+  reported. Even if the usage momentarily dropped below the target and the
+  decrease were applied, the instance would then be running with a memory
+  configuration sized for the old limit inside a smaller cgroup, exposed to
+  an out-of-memory termination at the next spike of activity. A fresh pod
+  starting under the new limit, with memory parameters reviewed accordingly,
+  is the deterministic option.
 - Resource entries are added or removed, rather than changed: Kubernetes does
   not allow a resize to add or remove `requests` and `limits` entries.
 - Resources other than `cpu` and `memory` (for example, hugepages) are

--- a/docs/src/resource_management.md
+++ b/docs/src/resource_management.md
@@ -204,11 +204,14 @@ point an in-place vertical autoscaler at the instance pods of a cluster using
 this strategy.
 :::
 
-Remember that PostgreSQL does not adapt its memory configuration to the
-container limits: increasing the memory of the instances does not change
-`shared_buffers` or the other memory-related parameters, which you should
-review and update consistently with the new resources. Note that changing
-`shared_buffers` requires a restart of PostgreSQL.
+PostgreSQL benefits from an in-place memory increase right away: the kernel
+page cache can grow within the new limit, caching more relation data, and
+the backends gain headroom for their working memory. What does not adapt
+automatically is the statically-sized configuration: `shared_buffers`
+(typically sized at about 25% of the available memory) keeps its configured
+value, and raising it requires a restart of PostgreSQL. Parameters that only
+inform the planner, like `effective_cache_size`, can instead be updated
+without a restart.
 
 ## Integration with the Vertical Pod Autoscaler (VPA)
 

--- a/docs/src/resource_management.md
+++ b/docs/src/resource_management.md
@@ -176,7 +176,7 @@ This happens when:
   option.
 - Resource entries are added or removed, rather than changed: Kubernetes does
   not allow a resize to add or remove `requests` and `limits` entries.
-- Resources other than `cpu` and `memory` (for example, HugePages) are
+- Resources other than `cpu` and `memory` (for example, hugepages) are
   changed.
 - The change would alter the pod QoS class, which Kubernetes forbids: the API
   server rejects the resize and the operator recreates the pod.

--- a/docs/src/resource_management.md
+++ b/docs/src/resource_management.md
@@ -117,6 +117,93 @@ section in the PostgreSQL documentation.
     page from the Kubernetes documentation.
 :::
 
+## In-place resource updates
+
+By default, changing the `resources` section of a `Cluster` triggers a rolling
+update of the instances: every pod is recreated with the new resources, and the
+primary is updated last through a switchover (or a restart, depending on
+`primaryUpdateMethod`).
+
+Starting from Kubernetes 1.33, pods can be resized in place through the
+[resize subresource](https://kubernetes.io/docs/tasks/configure-pod-container/resize-container-resources/),
+without recreating them. CloudNativePG can take advantage of this feature when
+you set the `resourcesUpdateStrategy` field to `inPlace`:
+
+```yaml
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: postgresql-resize-inplace
+spec:
+  instances: 3
+
+  resourcesUpdateStrategy: inPlace
+
+  resources:
+    requests:
+      memory: "1Gi"
+      cpu: 1
+    limits:
+      memory: "1Gi"
+      cpu: 1
+
+  storage:
+    size: 1Gi
+```
+
+With this strategy, when the only difference between a running instance and
+its desired specification is in the container resources, the operator applies
+the change through the resize subresource: CPU and memory of the running
+containers are updated with no restart, no switchover, and no interruption of
+the client connections. This applies to the `postgres` container and to any
+sidecar container injected by CNPG-I plugins.
+
+The default value of the field is `recreate`, which preserves the rolling
+update behavior described above.
+
+### When a rolling update is still used
+
+The `inPlace` strategy is best-effort by design: whenever the change cannot be
+applied in place, the operator falls back to the standard rolling update.
+This happens when:
+
+- The Kubernetes cluster does not expose the resize subresource of the pods
+  (the feature requires Kubernetes 1.33 or later, and became stable in 1.35).
+- A **memory limit is decreased**. The kubelet applies memory limit decreases
+  only when the current usage is below the new limit, and PostgreSQL never
+  releases its shared memory, so such a resize would remain pending
+  indefinitely. A fresh pod starting under the new limit is the deterministic
+  option.
+- Resource entries are added or removed, rather than changed: Kubernetes does
+  not allow a resize to add or remove `requests` and `limits` entries.
+- Resources other than `cpu` and `memory` (for example, HugePages) are
+  changed.
+- The change would alter the pod QoS class, which Kubernetes forbids: the API
+  server rejects the resize and the operator recreates the pod.
+- The kubelet reports the resize as *infeasible* because the node can never
+  satisfy the new request: the operator recreates the pod, letting the
+  scheduler place it on a suitable node.
+- The resources change together with any other part of the pod specification:
+  the pod is recreated to apply the whole change.
+
+Run-once init containers cannot be resized and have already terminated when a
+resize takes place, so their recorded resources are left untouched: they will
+pick up the new values the next time the pod is naturally recreated.
+
+:::warning
+With `resourcesUpdateStrategy: inPlace`, the operator treats the resources of
+the running pods as fully declarative: a resize applied to an instance pod by
+any other actor is reverted to match `spec.resources` of the `Cluster`. Do not
+point an in-place vertical autoscaler at the instance pods of a cluster using
+this strategy.
+:::
+
+Remember that PostgreSQL does not adapt its memory configuration to the
+container limits: increasing the memory of the instances does not change
+`shared_buffers` or the other memory-related parameters, which you should
+review and update consistently with the new resources. Note that changing
+`shared_buffers` requires a restart of PostgreSQL.
+
 ## Integration with the Vertical Pod Autoscaler (VPA)
 
 The `Cluster` CRD exposes the `scale` subresource together with the label
@@ -150,11 +237,12 @@ spec:
 ```
 
 :::warning
-Do not use `updateMode: Auto`, `Recreate`, or `Initial` against a
-CloudNativePG-managed `Cluster`. The operator owns the pod specification and
-treats `spec.resources` of the `Cluster` as the source of truth: it does not
-adopt the resources VPA writes onto a running pod, so the live pod and the
-declared `spec.resources` silently diverge. Any tuning you sized against the
+Do not use `updateMode: Auto`, `Recreate`, `InPlaceOrRecreate`, or `Initial`
+against a CloudNativePG-managed `Cluster`. The operator owns the pod
+specification and treats `spec.resources` of the `Cluster` as the source of
+truth: it does not adopt the resources VPA writes onto a running pod, so the
+live pod and the declared `spec.resources` silently diverge (and with
+`resourcesUpdateStrategy: inPlace` the operator actively reverts them). Any tuning you sized against the
 declared resources (for example a `shared_buffers` value the operator
 validated against the memory request) no longer matches the pod's actual
 limits. VPA also evicts pods through the Kubernetes eviction API, bypassing

--- a/docs/src/samples/cluster-example-resize-inplace.yaml
+++ b/docs/src/samples/cluster-example-resize-inplace.yaml
@@ -1,0 +1,23 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: cluster-example-resize-inplace
+spec:
+  instances: 3
+
+  # Apply changes to `resources` through the Kubernetes resize subresource
+  # whenever possible, without recreating the pods (requires Kubernetes 1.33
+  # or later). Changes that cannot be applied in place, such as memory limit
+  # decreases, fall back to a rolling update.
+  resourcesUpdateStrategy: inPlace
+
+  resources:
+    requests:
+      memory: "1Gi"
+      cpu: 1
+    limits:
+      memory: "1Gi"
+      cpu: 1
+
+  storage:
+    size: 1Gi

--- a/internal/cmd/manager/controller/controller.go
+++ b/internal/cmd/manager/controller/controller.go
@@ -228,6 +228,12 @@ func RunController(
 		return err
 	}
 
+	// Detect if the API server supports in-place pod resize
+	if err = utils.DetectPodsResize(discoveryClient); err != nil {
+		setupLog.Error(err, "unable to detect if the cluster supports the resize subresource of the pods")
+		return err
+	}
+
 	// Detect the available architectures
 	if err = utils.DetectAvailableArchitectures(); err != nil {
 		setupLog.Error(err, "unable to detect the available instance's architectures")
@@ -237,6 +243,7 @@ func RunController(
 	setupLog.Info("Kubernetes system metadata",
 		"haveSCC", utils.HaveSecurityContextConstraints(),
 		"haveVolumeSnapshot", utils.HaveVolumeSnapshot(),
+		"havePodsResize", utils.HavePodsResize(),
 		"availableArchitectures", utils.GetAvailableArchitectures(),
 	)
 

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -155,6 +155,7 @@ var ErrNextLoop = utils.ErrNextLoop
 // +kubebuilder:rbac:groups="",resources=nodes,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=get;list;create;watch;delete;patch
 // +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;delete;patch;create;watch
+// +kubebuilder:rbac:groups="",resources=pods/resize,verbs=patch
 // +kubebuilder:rbac:groups="",resources=pods/status,verbs=get
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=create;list;get;watch;delete
 // +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=create;patch;update;list;watch;get

--- a/internal/controller/cluster_resize.go
+++ b/internal/controller/cluster_resize.go
@@ -1,0 +1,144 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package controller
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/cloudnative-pg/machinery/pkg/log"
+	corev1 "k8s.io/api/core/v1"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/specs"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
+)
+
+// errInPlaceResizeRejected is raised when the API server rejects an in-place
+// resize of the resources of an instance pod, for example because the change
+// would alter the pod QoS class. The caller reacts by falling back to the
+// standard rollout, recreating the pod.
+var errInPlaceResizeRejected = errors.New("in-place pod resize rejected")
+
+// resizeInstanceInPlace applies a resource-only drift to a running instance
+// pod through the resize subresource, then refreshes the pod spec annotation
+// so that the drift detection quiesces. A failure to refresh the annotation
+// is tolerated: the next reconciliation finds the live resources already
+// up-to-date and only repairs the annotation.
+func (r *ClusterReconciler) resizeInstanceInPlace(
+	ctx context.Context,
+	cluster *apiv1.Cluster,
+	pod *corev1.Pod,
+	reason string,
+) error {
+	contextLogger := log.FromContext(ctx)
+
+	targetPod, err := newInstanceForRunningPod(ctx, pod, cluster)
+	if err != nil {
+		return fmt.Errorf("while building the target instance to resize the pod: %w", err)
+	}
+
+	if drifts := specs.GetResizableContainerResourceDrifts(&pod.Spec, &targetPod.Spec); len(drifts) > 0 {
+		contextLogger.Info("Resizing instance pod in place",
+			"pod", pod.Name,
+			"reason", reason)
+
+		patchedPod := pod.DeepCopy()
+		applyContainerResourceDrifts(&patchedPod.Spec, drifts)
+		if err := r.SubResource("resize").Patch(ctx, patchedPod, client.MergeFrom(pod)); err != nil {
+			if apierrs.IsInvalid(err) || apierrs.IsBadRequest(err) || apierrs.IsForbidden(err) {
+				r.Recorder.Eventf(cluster, "Warning", "InPlaceResizeFailed",
+					"In-place resize of pod %s rejected, falling back to a rolling update: %v", pod.Name, err)
+				return fmt.Errorf("%w: %v", errInPlaceResizeRejected, err)
+			}
+			return err
+		}
+
+		r.Recorder.Eventf(cluster, "Normal", "InPlaceResize",
+			"Resized instance pod %s in place", pod.Name)
+	}
+
+	if err := r.refreshPodSpecAnnotationResources(ctx, pod, targetPod); err != nil {
+		contextLogger.Info(
+			"Cannot refresh the pod spec annotation after the in-place resize, will retry",
+			"pod", pod.Name,
+			"error", err.Error())
+	}
+
+	return nil
+}
+
+// refreshPodSpecAnnotationResources aligns the container resources recorded
+// in the pod spec annotation with the target instance. Only the resources are
+// overwritten: the rest of the stored spec is preserved, as it may
+// legitimately differ from a freshly built instance (for example, the
+// bootstrap init container image when in-place instance manager updates are
+// enabled).
+func (r *ClusterReconciler) refreshPodSpecAnnotationResources(
+	ctx context.Context,
+	pod *corev1.Pod,
+	targetPod *corev1.Pod,
+) error {
+	podSpecAnnotation, ok := pod.Annotations[utils.PodSpecAnnotationName]
+	if !ok {
+		return nil
+	}
+
+	var storedPodSpec corev1.PodSpec
+	if err := json.Unmarshal([]byte(podSpecAnnotation), &storedPodSpec); err != nil {
+		return fmt.Errorf("while unmarshalling the pod spec annotation: %w", err)
+	}
+
+	drifts := specs.GetContainerResourceDrifts(&storedPodSpec, &targetPod.Spec)
+	if len(drifts) == 0 {
+		return nil
+	}
+	applyContainerResourceDrifts(&storedPodSpec, drifts)
+
+	podSpecMarshaled, err := json.Marshal(storedPodSpec)
+	if err != nil {
+		return fmt.Errorf("while marshalling the pod spec annotation: %w", err)
+	}
+
+	patchedPod := pod.DeepCopy()
+	patchedPod.Annotations[utils.PodSpecAnnotationName] = string(podSpecMarshaled)
+	return r.Patch(ctx, patchedPod, client.MergeFrom(pod))
+}
+
+// applyContainerResourceDrifts sets the resources of the drifted containers
+// of the given pod spec to their target value
+func applyContainerResourceDrifts(spec *corev1.PodSpec, drifts []specs.ContainerResourceDrift) {
+	for _, drift := range drifts {
+		containers := spec.Containers
+		if drift.InitContainer {
+			containers = spec.InitContainers
+		}
+		for i := range containers {
+			if containers[i].Name == drift.Name {
+				containers[i].Resources = drift.Target
+				break
+			}
+		}
+	}
+}

--- a/internal/controller/cluster_resize_test.go
+++ b/internal/controller/cluster_resize_test.go
@@ -1,0 +1,211 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package controller
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/tools/record"
+	k8client "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	schemeBuilder "github.com/cloudnative-pg/cloudnative-pg/internal/scheme"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/specs"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("In-place resize of an instance pod", func() {
+	var cluster *apiv1.Cluster
+	var pod *corev1.Pod
+	var recorder *record.FakeRecorder
+
+	BeforeEach(func(ctx SpecContext) {
+		cluster = &apiv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "cluster-resize",
+				Namespace: "default",
+			},
+			Spec: apiv1.ClusterSpec{
+				ImageName:               "postgres:13.11",
+				ResourcesUpdateStrategy: apiv1.ResourcesUpdateStrategyInPlace,
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						"cpu":    resource.MustParse("500m"),
+						"memory": resource.MustParse("1Gi"),
+					},
+					Limits: corev1.ResourceList{
+						"cpu":    resource.MustParse("1"),
+						"memory": resource.MustParse("2Gi"),
+					},
+				},
+			},
+			Status: apiv1.ClusterStatus{
+				Image: "postgres:13.11",
+			},
+		}
+
+		// Build the pod from a deep copy: NewInstance shares the resource
+		// maps of the passed cluster, and mutating them afterwards would
+		// silently change the "live" pod too
+		var err error
+		pod, err = specs.NewInstance(ctx, *cluster.DeepCopy(), 1, true)
+		Expect(err).ToNot(HaveOccurred())
+
+		recorder = record.NewFakeRecorder(120)
+	})
+
+	newReconciler := func(funcs interceptor.Funcs) *ClusterReconciler {
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(schemeBuilder.BuildWithAllKnownScheme()).
+			WithObjects(pod).
+			WithInterceptorFuncs(funcs).
+			Build()
+
+		return &ClusterReconciler{
+			Client:   fakeClient,
+			Recorder: recorder,
+		}
+	}
+
+	getPostgresResources := func(spec *corev1.PodSpec) corev1.ResourceRequirements {
+		for i := range spec.Containers {
+			if spec.Containers[i].Name == specs.PostgresContainerName {
+				return spec.Containers[i].Resources
+			}
+		}
+		return corev1.ResourceRequirements{}
+	}
+
+	It("patches the resize subresource and refreshes the annotation", func(ctx SpecContext) {
+		r := newReconciler(interceptor.Funcs{})
+
+		cluster.Spec.Resources.Limits["cpu"] = resource.MustParse("2")
+		Expect(r.resizeInstanceInPlace(ctx, cluster, pod, "unit test")).To(Succeed())
+
+		var currentPod corev1.Pod
+		Expect(r.Get(ctx, k8client.ObjectKeyFromObject(pod), &currentPod)).To(Succeed())
+
+		liveResources := getPostgresResources(&currentPod.Spec)
+		Expect(liveResources.Limits["cpu"]).To(Equal(resource.MustParse("2")))
+
+		var storedPodSpec corev1.PodSpec
+		Expect(json.Unmarshal(
+			[]byte(currentPod.Annotations[utils.PodSpecAnnotationName]), &storedPodSpec)).To(Succeed())
+		storedResources := getPostgresResources(&storedPodSpec)
+		Expect(storedResources.Limits["cpu"]).To(Equal(resource.MustParse("2")))
+
+		Expect(recorder.Events).To(Receive(ContainSubstring("InPlaceResize")))
+	})
+
+	It("only repairs the annotation when the live resources already match", func(ctx SpecContext) {
+		// Make the stored annotation stale while the live spec matches the target
+		var storedPodSpec corev1.PodSpec
+		Expect(json.Unmarshal(
+			[]byte(pod.Annotations[utils.PodSpecAnnotationName]), &storedPodSpec)).To(Succeed())
+		for i := range storedPodSpec.Containers {
+			if storedPodSpec.Containers[i].Name == specs.PostgresContainerName {
+				storedPodSpec.Containers[i].Resources.Limits["cpu"] = resource.MustParse("250m")
+			}
+		}
+		staleAnnotation, err := json.Marshal(storedPodSpec)
+		Expect(err).ToNot(HaveOccurred())
+		pod.Annotations[utils.PodSpecAnnotationName] = string(staleAnnotation)
+
+		resizeCalled := false
+		r := newReconciler(interceptor.Funcs{
+			SubResourcePatch: func(
+				ctx context.Context,
+				cl k8client.Client,
+				subResourceName string,
+				obj k8client.Object,
+				patch k8client.Patch,
+				opts ...k8client.SubResourcePatchOption,
+			) error {
+				resizeCalled = true
+				return cl.SubResource(subResourceName).Patch(ctx, obj, patch, opts...)
+			},
+		})
+
+		Expect(r.resizeInstanceInPlace(ctx, cluster, pod, "unit test")).To(Succeed())
+		Expect(resizeCalled).To(BeFalse())
+
+		var currentPod corev1.Pod
+		Expect(r.Get(ctx, k8client.ObjectKeyFromObject(pod), &currentPod)).To(Succeed())
+		var refreshedPodSpec corev1.PodSpec
+		Expect(json.Unmarshal(
+			[]byte(currentPod.Annotations[utils.PodSpecAnnotationName]), &refreshedPodSpec)).To(Succeed())
+		refreshedResources := getPostgresResources(&refreshedPodSpec)
+		Expect(refreshedResources.Limits["cpu"]).To(Equal(resource.MustParse("1")))
+	})
+
+	It("reports a rejected resize so the caller can fall back", func(ctx SpecContext) {
+		r := newReconciler(interceptor.Funcs{
+			SubResourcePatch: func(
+				_ context.Context,
+				_ k8client.Client,
+				_ string,
+				_ k8client.Object,
+				_ k8client.Patch,
+				_ ...k8client.SubResourcePatchOption,
+			) error {
+				return apierrs.NewForbidden(
+					schema.GroupResource{Resource: "pods"}, pod.Name,
+					errors.New("the resize would change the pod QoS class"))
+			},
+		})
+
+		cluster.Spec.Resources.Limits["cpu"] = resource.MustParse("2")
+		err := r.resizeInstanceInPlace(ctx, cluster, pod, "unit test")
+		Expect(errors.Is(err, errInPlaceResizeRejected)).To(BeTrue())
+		Expect(recorder.Events).To(Receive(ContainSubstring("InPlaceResizeFailed")))
+	})
+
+	It("propagates transient errors without falling back", func(ctx SpecContext) {
+		r := newReconciler(interceptor.Funcs{
+			SubResourcePatch: func(
+				_ context.Context,
+				_ k8client.Client,
+				_ string,
+				_ k8client.Object,
+				_ k8client.Patch,
+				_ ...k8client.SubResourcePatchOption,
+			) error {
+				return apierrs.NewInternalError(errors.New("etcd timeout"))
+			},
+		})
+
+		cluster.Spec.Resources.Limits["cpu"] = resource.MustParse("2")
+		err := r.resizeInstanceInPlace(ctx, cluster, pod, "unit test")
+		Expect(err).To(HaveOccurred())
+		Expect(errors.Is(err, errInPlaceResizeRejected)).To(BeFalse())
+	})
+})

--- a/internal/controller/cluster_upgrade.go
+++ b/internal/controller/cluster_upgrade.go
@@ -122,8 +122,17 @@ func (r *ClusterReconciler) rolloutRequiredInstances(
 		return false, fmt.Errorf("expected 1 primary PostgreSQL but none found")
 	}
 
-	// from now on we know we have a primary instance
+	return r.rolloutRequiredPrimary(ctx, cluster, podList, primaryPostgresqlStatus)
+}
 
+// rolloutRequiredPrimary rolls out the primary instance of the cluster when
+// its current state differs from the desired one
+func (r *ClusterReconciler) rolloutRequiredPrimary(
+	ctx context.Context,
+	cluster *apiv1.Cluster,
+	podList *postgres.PostgresqlStatusList,
+	primaryPostgresqlStatus *postgres.PostgresqlStatus,
+) (bool, error) {
 	if cluster.IsInstanceFenced(primaryPostgresqlStatus.Pod.Name) {
 		return false, nil
 	}

--- a/internal/controller/cluster_upgrade.go
+++ b/internal/controller/cluster_upgrade.go
@@ -79,6 +79,21 @@ func (r *ClusterReconciler) rolloutRequiredInstances(
 			continue
 		}
 
+		// A resource-only drift is applied through the resize subresource:
+		// nothing restarts, so no rollout slot is consumed and the loop
+		// proceeds to the next instance. A resize the API server rejects
+		// (e.g. it would change the pod QoS class) degrades to the standard
+		// rollout below.
+		if podRollout.canBeResizedInPlace {
+			err := r.resizeInstanceInPlace(ctx, cluster, postgresqlStatus.Pod, podRollout.reason)
+			if err == nil {
+				continue
+			}
+			if !errors.Is(err, errInPlaceResizeRejected) {
+				return false, err
+			}
+		}
+
 		managerResult := r.rolloutManager.CoordinateRollout(client.ObjectKeyFromObject(cluster), postgresqlStatus.Pod.Name)
 		if !managerResult.RolloutAllowed {
 			r.Recorder.Eventf(
@@ -117,6 +132,19 @@ func (r *ClusterReconciler) rolloutRequiredInstances(
 	podRollout := isInstanceNeedingRollout(ctx, *primaryPostgresqlStatus, cluster)
 	if !podRollout.required {
 		return false, nil
+	}
+
+	// A resize does not restart anything, so the primary is treated like any
+	// replica: no switchover, no supervised-strategy involvement. If the API
+	// server rejects the resize, the standard rollout below takes over.
+	if podRollout.canBeResizedInPlace {
+		err := r.resizeInstanceInPlace(ctx, cluster, primaryPostgresqlStatus.Pod, podRollout.reason)
+		if err == nil {
+			return false, nil
+		}
+		if !errors.Is(err, errInPlaceResizeRejected) {
+			return false, err
+		}
 	}
 
 	// if the primary instance is marked for restart due to hot standby sensitive parameter decrease,
@@ -304,6 +332,12 @@ type rollout struct {
 	required     bool
 	canBeInPlace bool
 
+	// canBeResizedInPlace is true when the drift is limited to container
+	// resources that can be applied through the resize subresource, with
+	// no restart involved (not to be confused with canBeInPlace, which
+	// refers to an in-place restart of PostgreSQL)
+	canBeResizedInPlace bool
+
 	needsToChangeOperatorImage bool
 	needsToChangeOperandImage  bool
 
@@ -433,6 +467,7 @@ func isPodNeedingRollout(
 		"pod projected volume is outdated":         checkProjectedVolumeIsOutdated,
 		"pod image is outdated":                    checkPodImageIsOutdated,
 		"cluster has different restart annotation": checkClusterHasDifferentRestartAnnotation,
+		"pod resize is infeasible":                 checkPodResizeStuckInfeasible,
 	}
 
 	podRollout := applyCheckers(checkers)
@@ -477,6 +512,31 @@ func hasValidPodSpec(pod *corev1.Pod) bool {
 	}
 	err := json.Unmarshal([]byte(podSpecAnnotation), &corev1.PodSpec{})
 	return err == nil
+}
+
+// checkPodResizeStuckInfeasible detects instances whose in-place resize was
+// accepted by the API server but reported as infeasible by the kubelet: the
+// node can never satisfy the new resources, so the only way forward is
+// recreating the pod, letting the scheduler place it on a suitable node
+func checkPodResizeStuckInfeasible(_ context.Context, pod *corev1.Pod, cluster *apiv1.Cluster) (rollout, error) {
+	if cluster.GetResourcesUpdateStrategy() != apiv1.ResourcesUpdateStrategyInPlace {
+		return rollout{}, nil
+	}
+
+	for _, condition := range pod.Status.Conditions {
+		if condition.Type == corev1.PodResizePending &&
+			condition.Status == corev1.ConditionTrue &&
+			condition.Reason == corev1.PodReasonInfeasible {
+			return rollout{
+				required: true,
+				reason: fmt.Sprintf(
+					"the in-place resize of pod '%s' is infeasible on its node, recreating the pod: %s",
+					pod.Name, condition.Message),
+			}, nil
+		}
+	}
+
+	return rollout{}, nil
 }
 
 func checkPodNeedsUpdatedTopology(_ context.Context, pod *corev1.Pod, cluster *apiv1.Cluster) (rollout, error) {
@@ -733,14 +793,58 @@ func checkPodSpecIsOutdated(
 	}
 
 	match, diff := specs.ComparePodSpecs(storedPodSpec, targetPod.Spec)
-	if !match {
-		return rollout{
-			required: true,
-			reason:   "original and target PodSpec differ in " + diff,
-		}, nil
+	if match {
+		// The stored pod spec is up-to-date. With the in-place strategy the
+		// live resources are still authoritative: a resize applied before a
+		// change of the desired resources was reverted, or issued by an
+		// external actor, leaves the annotation aligned while the running
+		// containers are not.
+		if cluster.GetResourcesUpdateStrategy() != apiv1.ResourcesUpdateStrategyInPlace {
+			return rollout{}, nil
+		}
+		if len(specs.GetResizableContainerResourceDrifts(&pod.Spec, &targetPod.Spec)) == 0 {
+			return rollout{}, nil
+		}
+		return evaluateResourcesOnlyDrift(pod, targetPod), nil
 	}
 
-	return rollout{}, nil
+	if cluster.GetResourcesUpdateStrategy() == apiv1.ResourcesUpdateStrategyInPlace {
+		if restMatch, _ := specs.ComparePodSpecsIgnoringContainerResources(storedPodSpec, targetPod.Spec); restMatch {
+			return evaluateResourcesOnlyDrift(pod, targetPod), nil
+		}
+	}
+
+	return rollout{
+		required: true,
+		reason:   "original and target PodSpec differ in " + diff,
+	}, nil
+}
+
+// evaluateResourcesOnlyDrift decides how to reconcile an instance pod whose
+// only drift from the target spec is in the container resources: resized in
+// place when the cluster supports it and the delta allows it, recreated
+// otherwise
+func evaluateResourcesOnlyDrift(pod *corev1.Pod, targetPod *corev1.Pod) rollout {
+	if !utils.HavePodsResize() {
+		return rollout{
+			required: true,
+			reason: "container resources changed, recreating the pod: " +
+				"the cluster does not support in-place pod resize",
+		}
+	}
+
+	if ok, reason := specs.CanResizeInPlace(&pod.Spec, &targetPod.Spec); !ok {
+		return rollout{
+			required: true,
+			reason:   "container resources changed, recreating the pod: " + reason,
+		}
+	}
+
+	return rollout{
+		required:            true,
+		canBeResizedInPlace: true,
+		reason:              "container resources changed, resizing the pod in place",
+	}
 }
 
 // recreatePrimaryInPlace deletes the primary Pod so the operator recreates it

--- a/internal/controller/cluster_upgrade_test.go
+++ b/internal/controller/cluster_upgrade_test.go
@@ -344,6 +344,192 @@ var _ = Describe("Pod upgrade", Ordered, func() {
 		})
 	})
 
+	When("the cluster uses the inPlace resources update strategy", func() {
+		var clusterInPlace apiv1.Cluster
+
+		BeforeEach(func() {
+			utils.SetPodsResize(true)
+			clusterInPlace = apiv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-inplace",
+				},
+				Spec: apiv1.ClusterSpec{
+					ImageName:               "postgres:13.11",
+					ResourcesUpdateStrategy: apiv1.ResourcesUpdateStrategyInPlace,
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							"cpu":    resource.MustParse("500m"),
+							"memory": resource.MustParse("1Gi"),
+						},
+						Limits: corev1.ResourceList{
+							"cpu":    resource.MustParse("1"),
+							"memory": resource.MustParse("2Gi"),
+						},
+					},
+				},
+				Status: apiv1.ClusterStatus{
+					Image: "postgres:13.11",
+				},
+			}
+		})
+
+		AfterEach(func() {
+			utils.SetPodsResize(false)
+		})
+
+		makeStatus := func(pod *corev1.Pod) postgres.PostgresqlStatus {
+			return postgres.PostgresqlStatus{
+				Pod:            pod,
+				IsPodReady:     true,
+				ExecutableHash: "test_hash",
+			}
+		}
+
+		It("resizes in place when only cpu and memory grow", func(ctx SpecContext) {
+			// Build the pod from a deep copy: NewInstance shares the resource
+			// maps of the passed cluster, and mutating them afterwards would
+			// silently change the "live" pod too
+			pod, err := specs.NewInstance(ctx, *clusterInPlace.DeepCopy(), 1, true)
+			Expect(err).ToNot(HaveOccurred())
+
+			clusterInPlace.Spec.Resources.Limits["cpu"] = resource.MustParse("2")
+			clusterInPlace.Spec.Resources.Limits["memory"] = resource.MustParse("4Gi")
+
+			rollout := isInstanceNeedingRollout(ctx, makeStatus(pod), &clusterInPlace)
+			Expect(rollout.required).To(BeTrue())
+			Expect(rollout.canBeResizedInPlace).To(BeTrue())
+			Expect(rollout.reason).To(ContainSubstring("resizing the pod in place"))
+		})
+
+		It("recreates the pod when the memory limit decreases", func(ctx SpecContext) {
+			// Build the pod from a deep copy: NewInstance shares the resource
+			// maps of the passed cluster, and mutating them afterwards would
+			// silently change the "live" pod too
+			pod, err := specs.NewInstance(ctx, *clusterInPlace.DeepCopy(), 1, true)
+			Expect(err).ToNot(HaveOccurred())
+
+			clusterInPlace.Spec.Resources.Limits["memory"] = resource.MustParse("1Gi")
+
+			rollout := isInstanceNeedingRollout(ctx, makeStatus(pod), &clusterInPlace)
+			Expect(rollout.required).To(BeTrue())
+			Expect(rollout.canBeResizedInPlace).To(BeFalse())
+			Expect(rollout.reason).To(ContainSubstring("memory limit"))
+		})
+
+		It("recreates the pod when the drift is not limited to resources", func(ctx SpecContext) {
+			// Build the pod from a deep copy: NewInstance shares the resource
+			// maps of the passed cluster, and mutating them afterwards would
+			// silently change the "live" pod too
+			pod, err := specs.NewInstance(ctx, *clusterInPlace.DeepCopy(), 1, true)
+			Expect(err).ToNot(HaveOccurred())
+
+			clusterInPlace.Spec.Resources.Limits["cpu"] = resource.MustParse("2")
+			clusterInPlace.Spec.SchedulerName = "custom-scheduler"
+
+			rollout := isInstanceNeedingRollout(ctx, makeStatus(pod), &clusterInPlace)
+			Expect(rollout.required).To(BeTrue())
+			Expect(rollout.canBeResizedInPlace).To(BeFalse())
+			Expect(rollout.reason).To(ContainSubstring("original and target PodSpec differ"))
+		})
+
+		It("recreates the pod when the cluster does not support pod resize", func(ctx SpecContext) {
+			utils.SetPodsResize(false)
+
+			// Build the pod from a deep copy: NewInstance shares the resource
+			// maps of the passed cluster, and mutating them afterwards would
+			// silently change the "live" pod too
+			pod, err := specs.NewInstance(ctx, *clusterInPlace.DeepCopy(), 1, true)
+			Expect(err).ToNot(HaveOccurred())
+
+			clusterInPlace.Spec.Resources.Limits["cpu"] = resource.MustParse("2")
+
+			rollout := isInstanceNeedingRollout(ctx, makeStatus(pod), &clusterInPlace)
+			Expect(rollout.required).To(BeTrue())
+			Expect(rollout.canBeResizedInPlace).To(BeFalse())
+			Expect(rollout.reason).To(ContainSubstring("does not support in-place pod resize"))
+		})
+
+		It("resizes in place when the live resources drift with an aligned annotation", func(ctx SpecContext) {
+			// Build the pod from a deep copy: NewInstance shares the resource
+			// maps of the passed cluster, and mutating them afterwards would
+			// silently change the "live" pod too
+			pod, err := specs.NewInstance(ctx, *clusterInPlace.DeepCopy(), 1, true)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Simulate a resize issued outside the operator: the pod spec
+			// changes, the annotation stays aligned with the target
+			for i := range pod.Spec.Containers {
+				if pod.Spec.Containers[i].Name == specs.PostgresContainerName {
+					pod.Spec.Containers[i].Resources.Limits["cpu"] = resource.MustParse("4")
+				}
+			}
+
+			rollout := isInstanceNeedingRollout(ctx, makeStatus(pod), &clusterInPlace)
+			Expect(rollout.required).To(BeTrue())
+			Expect(rollout.canBeResizedInPlace).To(BeTrue())
+		})
+
+		It("does not resize when the strategy is recreate", func(ctx SpecContext) {
+			clusterInPlace.Spec.ResourcesUpdateStrategy = apiv1.ResourcesUpdateStrategyRecreate
+
+			// Build the pod from a deep copy: NewInstance shares the resource
+			// maps of the passed cluster, and mutating them afterwards would
+			// silently change the "live" pod too
+			pod, err := specs.NewInstance(ctx, *clusterInPlace.DeepCopy(), 1, true)
+			Expect(err).ToNot(HaveOccurred())
+
+			clusterInPlace.Spec.Resources.Limits["cpu"] = resource.MustParse("2")
+
+			rollout := isInstanceNeedingRollout(ctx, makeStatus(pod), &clusterInPlace)
+			Expect(rollout.required).To(BeTrue())
+			Expect(rollout.canBeResizedInPlace).To(BeFalse())
+			Expect(rollout.reason).To(ContainSubstring("original and target PodSpec differ"))
+		})
+
+		It("recreates the pod when the resize is reported infeasible", func(ctx SpecContext) {
+			// Build the pod from a deep copy: NewInstance shares the resource
+			// maps of the passed cluster, and mutating them afterwards would
+			// silently change the "live" pod too
+			pod, err := specs.NewInstance(ctx, *clusterInPlace.DeepCopy(), 1, true)
+			Expect(err).ToNot(HaveOccurred())
+
+			pod.Status.Conditions = []corev1.PodCondition{
+				{
+					Type:    corev1.PodResizePending,
+					Status:  corev1.ConditionTrue,
+					Reason:  corev1.PodReasonInfeasible,
+					Message: "Node didn't have enough capacity",
+				},
+			}
+
+			rollout := isInstanceNeedingRollout(ctx, makeStatus(pod), &clusterInPlace)
+			Expect(rollout.required).To(BeTrue())
+			Expect(rollout.canBeResizedInPlace).To(BeFalse())
+			Expect(rollout.reason).To(ContainSubstring("infeasible"))
+		})
+
+		It("ignores the infeasible condition when the strategy is recreate", func(ctx SpecContext) {
+			clusterInPlace.Spec.ResourcesUpdateStrategy = apiv1.ResourcesUpdateStrategyRecreate
+
+			// Build the pod from a deep copy: NewInstance shares the resource
+			// maps of the passed cluster, and mutating them afterwards would
+			// silently change the "live" pod too
+			pod, err := specs.NewInstance(ctx, *clusterInPlace.DeepCopy(), 1, true)
+			Expect(err).ToNot(HaveOccurred())
+
+			pod.Status.Conditions = []corev1.PodCondition{
+				{
+					Type:   corev1.PodResizePending,
+					Status: corev1.ConditionTrue,
+					Reason: corev1.PodReasonInfeasible,
+				},
+			}
+
+			rollout := isInstanceNeedingRollout(ctx, makeStatus(pod), &clusterInPlace)
+			Expect(rollout.required).To(BeFalse())
+		})
+	})
+
 	When("the PodSpec annotation is not available", func() {
 		It("detects when a new custom environment variable is set", func(ctx SpecContext) {
 			pod, err := specs.NewInstance(ctx, cluster, 1, true)

--- a/pkg/specs/podspec_resize.go
+++ b/pkg/specs/podspec_resize.go
@@ -1,0 +1,195 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package specs
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// ContainerResourceDrift describes a container whose resources differ
+// between the current and the target pod spec
+type ContainerResourceDrift struct {
+	Name          string
+	InitContainer bool
+	Target        corev1.ResourceRequirements
+}
+
+// ComparePodSpecsIgnoringContainerResources compares two pod specs like
+// ComparePodSpecs, but ignoring any difference in the resources of their
+// containers and init containers
+func ComparePodSpecsIgnoringContainerResources(
+	currentPodSpec, targetPodSpec corev1.PodSpec,
+) (bool, string) {
+	stripResources := func(spec corev1.PodSpec) corev1.PodSpec {
+		stripped := *spec.DeepCopy()
+		for i := range stripped.Containers {
+			stripped.Containers[i].Resources = corev1.ResourceRequirements{}
+		}
+		for i := range stripped.InitContainers {
+			stripped.InitContainers[i].Resources = corev1.ResourceRequirements{}
+		}
+		return stripped
+	}
+
+	return ComparePodSpecs(stripResources(currentPodSpec), stripResources(targetPodSpec))
+}
+
+// GetContainerResourceDrifts returns the containers of the current pod spec
+// whose resources differ from the same-named container of the target pod
+// spec. Containers present on one side only are ignored: that is a spec
+// drift, not a resource drift, and is detected by the pod spec comparison.
+func GetContainerResourceDrifts(current, target *corev1.PodSpec) []ContainerResourceDrift {
+	var drifts []ContainerResourceDrift
+
+	collect := func(currentContainers, targetContainers []corev1.Container, initContainer bool) {
+		targetByName := make(map[string]*corev1.Container, len(targetContainers))
+		for i := range targetContainers {
+			targetByName[targetContainers[i].Name] = &targetContainers[i]
+		}
+		for i := range currentContainers {
+			targetContainer, found := targetByName[currentContainers[i].Name]
+			if !found {
+				continue
+			}
+			if resourceListsEqual(currentContainers[i].Resources.Requests, targetContainer.Resources.Requests) &&
+				resourceListsEqual(currentContainers[i].Resources.Limits, targetContainer.Resources.Limits) {
+				continue
+			}
+			drifts = append(drifts, ContainerResourceDrift{
+				Name:          currentContainers[i].Name,
+				InitContainer: initContainer,
+				Target:        targetContainer.Resources,
+			})
+		}
+	}
+
+	collect(current.Containers, target.Containers, false)
+	collect(current.InitContainers, target.InitContainers, true)
+
+	return drifts
+}
+
+// CanResizeInPlace verifies that the resource drifts between the current and
+// the target pod spec can be applied through the resize subresource without
+// disrupting the pod: only cpu and memory values may change, no entry may be
+// added or removed, memory limits may not be decreased (PostgreSQL never
+// releases its shared memory, so the kubelet would keep the resize pending
+// forever), and init containers must be native sidecars. The QoS class
+// invariant is not checked here: the API server enforces it and a rejected
+// patch makes the operator fall back to recreating the pod.
+func CanResizeInPlace(current, target *corev1.PodSpec) (bool, string) {
+	for _, drift := range GetContainerResourceDrifts(current, target) {
+		if drift.InitContainer && !isNativeSidecar(current.InitContainers, drift.Name) {
+			return false, fmt.Sprintf(
+				"container %s is a run-once init container and cannot be resized in place", drift.Name)
+		}
+
+		currentResources := getContainerResources(current, drift.Name, drift.InitContainer)
+		if ok, reason := canResizeResources(drift.Name, currentResources, drift.Target); !ok {
+			return false, reason
+		}
+	}
+
+	return true, ""
+}
+
+func canResizeResources(containerName string, current, target corev1.ResourceRequirements) (bool, string) {
+	if ok, reason := canResizeResourceList(containerName, "requests", current.Requests, target.Requests); !ok {
+		return false, reason
+	}
+	if ok, reason := canResizeResourceList(containerName, "limits", current.Limits, target.Limits); !ok {
+		return false, reason
+	}
+
+	currentMemoryLimit, hasCurrentMemoryLimit := current.Limits[corev1.ResourceMemory]
+	targetMemoryLimit, hasTargetMemoryLimit := target.Limits[corev1.ResourceMemory]
+	if hasCurrentMemoryLimit && hasTargetMemoryLimit && targetMemoryLimit.Cmp(currentMemoryLimit) < 0 {
+		return false, fmt.Sprintf(
+			"container %s: the memory limit cannot be decreased in place", containerName)
+	}
+
+	return true, ""
+}
+
+func canResizeResourceList(containerName, listName string, current, target corev1.ResourceList) (bool, string) {
+	for name := range current {
+		if _, found := target[name]; !found {
+			return false, fmt.Sprintf(
+				"container %s: the %s entry for %s cannot be removed in place", containerName, listName, name)
+		}
+	}
+	for name, targetValue := range target {
+		currentValue, found := current[name]
+		if !found {
+			return false, fmt.Sprintf(
+				"container %s: the %s entry for %s cannot be added in place", containerName, listName, name)
+		}
+		if currentValue.Cmp(targetValue) == 0 {
+			continue
+		}
+		if name != corev1.ResourceCPU && name != corev1.ResourceMemory {
+			return false, fmt.Sprintf(
+				"container %s: %s cannot be resized in place", containerName, name)
+		}
+	}
+
+	return true, ""
+}
+
+// resourceListsEqual compares two resource lists semantically, treating nil
+// and empty lists as equal
+func resourceListsEqual(current, target corev1.ResourceList) bool {
+	if len(current) != len(target) {
+		return false
+	}
+	for name, currentValue := range current {
+		targetValue, found := target[name]
+		if !found || currentValue.Cmp(targetValue) != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func isNativeSidecar(initContainers []corev1.Container, name string) bool {
+	for i := range initContainers {
+		if initContainers[i].Name != name {
+			continue
+		}
+		return initContainers[i].RestartPolicy != nil &&
+			*initContainers[i].RestartPolicy == corev1.ContainerRestartPolicyAlways
+	}
+	return false
+}
+
+func getContainerResources(spec *corev1.PodSpec, name string, initContainer bool) corev1.ResourceRequirements {
+	containers := spec.Containers
+	if initContainer {
+		containers = spec.InitContainers
+	}
+	for i := range containers {
+		if containers[i].Name == name {
+			return containers[i].Resources
+		}
+	}
+	return corev1.ResourceRequirements{}
+}

--- a/pkg/specs/podspec_resize.go
+++ b/pkg/specs/podspec_resize.go
@@ -88,21 +88,34 @@ func GetContainerResourceDrifts(current, target *corev1.PodSpec) []ContainerReso
 	return drifts
 }
 
+// GetResizableContainerResourceDrifts returns the resource drifts of the
+// containers that Kubernetes can resize in place: regular containers and
+// native sidecars. Run-once init containers are excluded: they have already
+// terminated, cannot be resized, and their resources only matter when the
+// pod is created, so their drift is left to the next pod recreation.
+func GetResizableContainerResourceDrifts(current, target *corev1.PodSpec) []ContainerResourceDrift {
+	drifts := GetContainerResourceDrifts(current, target)
+	resizable := make([]ContainerResourceDrift, 0, len(drifts))
+	for _, drift := range drifts {
+		if drift.InitContainer && !isNativeSidecar(current.InitContainers, drift.Name) {
+			continue
+		}
+		resizable = append(resizable, drift)
+	}
+	return resizable
+}
+
 // CanResizeInPlace verifies that the resource drifts between the current and
 // the target pod spec can be applied through the resize subresource without
 // disrupting the pod: only cpu and memory values may change, no entry may be
-// added or removed, memory limits may not be decreased (PostgreSQL never
+// added or removed, and memory limits may not be decreased (PostgreSQL never
 // releases its shared memory, so the kubelet would keep the resize pending
-// forever), and init containers must be native sidecars. The QoS class
-// invariant is not checked here: the API server enforces it and a rejected
-// patch makes the operator fall back to recreating the pod.
+// forever). Run-once init container drifts are ignored, being deferred to
+// the next pod recreation. The QoS class invariant is not checked here: the
+// API server enforces it and a rejected patch makes the operator fall back
+// to recreating the pod.
 func CanResizeInPlace(current, target *corev1.PodSpec) (bool, string) {
-	for _, drift := range GetContainerResourceDrifts(current, target) {
-		if drift.InitContainer && !isNativeSidecar(current.InitContainers, drift.Name) {
-			return false, fmt.Sprintf(
-				"container %s is a run-once init container and cannot be resized in place", drift.Name)
-		}
-
+	for _, drift := range GetResizableContainerResourceDrifts(current, target) {
 		currentResources := getContainerResources(current, drift.Name, drift.InitContainer)
 		if ok, reason := canResizeResources(drift.Name, currentResources, drift.Target); !ok {
 			return false, reason

--- a/pkg/specs/podspec_resize.go
+++ b/pkg/specs/podspec_resize.go
@@ -133,6 +133,17 @@ func canResizeResources(containerName string, current, target corev1.ResourceReq
 		return false, reason
 	}
 
+	// A memory limit decrease is never applied in place. The kubelet lowers
+	// the cgroup limit only when the current usage of the container is
+	// already below the new value, and PostgreSQL keeps its shared memory
+	// (shared_buffers above all) allocated for the whole life of the
+	// postmaster, so on a warmed-up instance the resize would stay pending
+	// indefinitely without reporting any error. Should the usage momentarily
+	// dip below the target and the decrease land, the instance would then
+	// run with a memory configuration sized for the old limit inside a
+	// smaller cgroup, one allocation spike away from an OOM kill. A
+	// recreated pod starts under the new limit from the beginning, making
+	// the outcome deterministic.
 	currentMemoryLimit, hasCurrentMemoryLimit := current.Limits[corev1.ResourceMemory]
 	targetMemoryLimit, hasTargetMemoryLimit := target.Limits[corev1.ResourceMemory]
 	if hasCurrentMemoryLimit && hasTargetMemoryLimit && targetMemoryLimit.Cmp(currentMemoryLimit) < 0 {

--- a/pkg/specs/podspec_resize_test.go
+++ b/pkg/specs/podspec_resize_test.go
@@ -288,7 +288,7 @@ var _ = Describe("CanResizeInPlace", func() {
 		Expect(reason).To(ContainSubstring("hugepages-2Mi"))
 	})
 
-	It("refuses run-once init container changes", func() {
+	It("ignores run-once init container changes, deferring them to the next recreation", func() {
 		current := corev1.PodSpec{
 			InitContainers: []corev1.Container{
 				{Name: "init", Resources: makeResources("100m", "", "", "")},
@@ -299,9 +299,13 @@ var _ = Describe("CanResizeInPlace", func() {
 				{Name: "init", Resources: makeResources("200m", "", "", "")},
 			},
 		}
-		ok, reason := CanResizeInPlace(&current, &target)
-		Expect(ok).To(BeFalse())
-		Expect(reason).To(ContainSubstring("init"))
+
+		Expect(GetResizableContainerResourceDrifts(&current, &target)).To(BeEmpty())
+		// the drift is still visible to the full detection
+		Expect(GetContainerResourceDrifts(&current, &target)).To(HaveLen(1))
+
+		ok, _ := CanResizeInPlace(&current, &target)
+		Expect(ok).To(BeTrue())
 	})
 
 	It("accepts native sidecar changes", func() {

--- a/pkg/specs/podspec_resize_test.go
+++ b/pkg/specs/podspec_resize_test.go
@@ -1,0 +1,338 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package specs
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func makeResources(cpuRequest, memoryRequest, cpuLimit, memoryLimit string) corev1.ResourceRequirements {
+	requirements := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{},
+		Limits:   corev1.ResourceList{},
+	}
+	if cpuRequest != "" {
+		requirements.Requests[corev1.ResourceCPU] = resource.MustParse(cpuRequest)
+	}
+	if memoryRequest != "" {
+		requirements.Requests[corev1.ResourceMemory] = resource.MustParse(memoryRequest)
+	}
+	if cpuLimit != "" {
+		requirements.Limits[corev1.ResourceCPU] = resource.MustParse(cpuLimit)
+	}
+	if memoryLimit != "" {
+		requirements.Limits[corev1.ResourceMemory] = resource.MustParse(memoryLimit)
+	}
+	return requirements
+}
+
+var _ = Describe("ComparePodSpecsIgnoringContainerResources", func() {
+	basePodSpec := func() corev1.PodSpec {
+		return corev1.PodSpec{
+			InitContainers: []corev1.Container{
+				{
+					Name:      "init",
+					Image:     "init:1",
+					Resources: makeResources("100m", "100Mi", "100m", "100Mi"),
+				},
+			},
+			Containers: []corev1.Container{
+				{
+					Name:      PostgresContainerName,
+					Image:     "postgres:17.0",
+					Resources: makeResources("500m", "1Gi", "500m", "1Gi"),
+				},
+			},
+		}
+	}
+
+	It("matches specs that differ only in container resources", func() {
+		current := basePodSpec()
+		target := basePodSpec()
+		target.Containers[0].Resources = makeResources("1", "2Gi", "1", "2Gi")
+		target.InitContainers[0].Resources = makeResources("200m", "100Mi", "200m", "100Mi")
+
+		match, _ := ComparePodSpecsIgnoringContainerResources(current, target)
+		Expect(match).To(BeTrue())
+	})
+
+	It("detects any other difference", func() {
+		current := basePodSpec()
+		target := basePodSpec()
+		target.Containers[0].Image = "postgres:17.1"
+		target.Containers[0].Resources = makeResources("1", "2Gi", "1", "2Gi")
+
+		match, diff := ComparePodSpecsIgnoringContainerResources(current, target)
+		Expect(match).To(BeFalse())
+		Expect(diff).To(ContainSubstring("image"))
+	})
+
+	It("does not modify the compared specs", func() {
+		current := basePodSpec()
+		target := basePodSpec()
+
+		match, _ := ComparePodSpecsIgnoringContainerResources(current, target)
+		Expect(match).To(BeTrue())
+		Expect(current.Containers[0].Resources.Requests).ToNot(BeEmpty())
+		Expect(target.Containers[0].Resources.Requests).ToNot(BeEmpty())
+	})
+})
+
+var _ = Describe("GetContainerResourceDrifts", func() {
+	It("returns nothing when the resources are semantically equal", func() {
+		current := corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "a", Resources: makeResources("1", "1Gi", "1", "1Gi")},
+			},
+		}
+		target := corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "a", Resources: makeResources("1000m", "1024Mi", "1000m", "1024Mi")},
+			},
+		}
+
+		Expect(GetContainerResourceDrifts(&current, &target)).To(BeEmpty())
+	})
+
+	It("treats nil and empty resource lists as equal", func() {
+		current := corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "a"},
+			},
+		}
+		target := corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "a", Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{},
+					Limits:   corev1.ResourceList{},
+				}},
+			},
+		}
+
+		Expect(GetContainerResourceDrifts(&current, &target)).To(BeEmpty())
+	})
+
+	It("reports drifted containers and init containers", func() {
+		current := corev1.PodSpec{
+			InitContainers: []corev1.Container{
+				{Name: "sidecar", Resources: makeResources("100m", "100Mi", "100m", "100Mi")},
+			},
+			Containers: []corev1.Container{
+				{Name: "a", Resources: makeResources("500m", "1Gi", "500m", "1Gi")},
+				{Name: "b", Resources: makeResources("500m", "1Gi", "500m", "1Gi")},
+			},
+		}
+		target := corev1.PodSpec{
+			InitContainers: []corev1.Container{
+				{Name: "sidecar", Resources: makeResources("200m", "100Mi", "200m", "100Mi")},
+			},
+			Containers: []corev1.Container{
+				{Name: "a", Resources: makeResources("1", "1Gi", "1", "1Gi")},
+				{Name: "b", Resources: makeResources("500m", "1Gi", "500m", "1Gi")},
+			},
+		}
+
+		drifts := GetContainerResourceDrifts(&current, &target)
+		Expect(drifts).To(HaveLen(2))
+		names := make(map[string]bool)
+		for _, drift := range drifts {
+			names[drift.Name] = drift.InitContainer
+		}
+		Expect(names).To(HaveKeyWithValue("a", false))
+		Expect(names).To(HaveKeyWithValue("sidecar", true))
+	})
+
+	It("ignores containers present on one side only", func() {
+		current := corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "a", Resources: makeResources("500m", "1Gi", "500m", "1Gi")},
+			},
+		}
+		target := corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "a", Resources: makeResources("500m", "1Gi", "500m", "1Gi")},
+				{Name: "extra", Resources: makeResources("1", "1Gi", "1", "1Gi")},
+			},
+		}
+
+		Expect(GetContainerResourceDrifts(&current, &target)).To(BeEmpty())
+	})
+})
+
+var _ = Describe("CanResizeInPlace", func() {
+	always := corev1.ContainerRestartPolicyAlways
+
+	makeSpecs := func(currentResources, targetResources corev1.ResourceRequirements) (corev1.PodSpec, corev1.PodSpec) {
+		current := corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: PostgresContainerName, Resources: currentResources},
+			},
+		}
+		target := corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: PostgresContainerName, Resources: targetResources},
+			},
+		}
+		return current, target
+	}
+
+	It("accepts an empty drift", func() {
+		current, target := makeSpecs(
+			makeResources("500m", "1Gi", "500m", "1Gi"),
+			makeResources("500m", "1Gi", "500m", "1Gi"))
+		ok, _ := CanResizeInPlace(&current, &target)
+		Expect(ok).To(BeTrue())
+	})
+
+	It("accepts cpu changes in both directions", func() {
+		current, target := makeSpecs(
+			makeResources("500m", "1Gi", "1", "1Gi"),
+			makeResources("250m", "1Gi", "2", "1Gi"))
+		ok, _ := CanResizeInPlace(&current, &target)
+		Expect(ok).To(BeTrue())
+	})
+
+	It("accepts memory increases", func() {
+		current, target := makeSpecs(
+			makeResources("500m", "1Gi", "500m", "1Gi"),
+			makeResources("500m", "2Gi", "500m", "2Gi"))
+		ok, _ := CanResizeInPlace(&current, &target)
+		Expect(ok).To(BeTrue())
+	})
+
+	It("refuses memory limit decreases", func() {
+		current, target := makeSpecs(
+			makeResources("500m", "1Gi", "500m", "2Gi"),
+			makeResources("500m", "1Gi", "500m", "1Gi"))
+		ok, reason := CanResizeInPlace(&current, &target)
+		Expect(ok).To(BeFalse())
+		Expect(reason).To(ContainSubstring("memory limit"))
+	})
+
+	It("accepts memory request decreases", func() {
+		current, target := makeSpecs(
+			makeResources("500m", "2Gi", "500m", "2Gi"),
+			makeResources("500m", "1Gi", "500m", "2Gi"))
+		ok, _ := CanResizeInPlace(&current, &target)
+		Expect(ok).To(BeTrue())
+	})
+
+	It("refuses added resource entries", func() {
+		current := corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: PostgresContainerName,
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("500m"),
+						},
+					},
+				},
+			},
+		}
+		target := corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: PostgresContainerName,
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("500m"),
+							corev1.ResourceMemory: resource.MustParse("1Gi"),
+						},
+					},
+				},
+			},
+		}
+		ok, _ := CanResizeInPlace(&current, &target)
+		Expect(ok).To(BeFalse())
+	})
+
+	It("refuses removed resource entries", func() {
+		current, target := makeSpecs(
+			makeResources("500m", "1Gi", "500m", "1Gi"),
+			corev1.ResourceRequirements{})
+		ok, _ := CanResizeInPlace(&current, &target)
+		Expect(ok).To(BeFalse())
+	})
+
+	It("refuses changes to resources other than cpu and memory", func() {
+		currentResources := makeResources("500m", "1Gi", "500m", "1Gi")
+		currentResources.Limits["hugepages-2Mi"] = resource.MustParse("256Mi")
+		targetResources := makeResources("500m", "1Gi", "500m", "1Gi")
+		targetResources.Limits["hugepages-2Mi"] = resource.MustParse("512Mi")
+
+		current, target := makeSpecs(currentResources, targetResources)
+		ok, reason := CanResizeInPlace(&current, &target)
+		Expect(ok).To(BeFalse())
+		Expect(reason).To(ContainSubstring("hugepages-2Mi"))
+	})
+
+	It("refuses run-once init container changes", func() {
+		current := corev1.PodSpec{
+			InitContainers: []corev1.Container{
+				{Name: "init", Resources: makeResources("100m", "", "", "")},
+			},
+		}
+		target := corev1.PodSpec{
+			InitContainers: []corev1.Container{
+				{Name: "init", Resources: makeResources("200m", "", "", "")},
+			},
+		}
+		ok, reason := CanResizeInPlace(&current, &target)
+		Expect(ok).To(BeFalse())
+		Expect(reason).To(ContainSubstring("init"))
+	})
+
+	It("accepts native sidecar changes", func() {
+		current := corev1.PodSpec{
+			InitContainers: []corev1.Container{
+				{Name: "sidecar", RestartPolicy: &always, Resources: makeResources("100m", "", "", "")},
+			},
+		}
+		target := corev1.PodSpec{
+			InitContainers: []corev1.Container{
+				{Name: "sidecar", RestartPolicy: &always, Resources: makeResources("200m", "", "", "")},
+			},
+		}
+		ok, _ := CanResizeInPlace(&current, &target)
+		Expect(ok).To(BeTrue())
+	})
+
+	It("evaluates every drifted container", func() {
+		current := corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "a", Resources: makeResources("500m", "1Gi", "500m", "1Gi")},
+				{Name: "b", Resources: makeResources("500m", "1Gi", "500m", "2Gi")},
+			},
+		}
+		target := corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "a", Resources: makeResources("1", "1Gi", "1", "1Gi")},
+				{Name: "b", Resources: makeResources("500m", "1Gi", "500m", "1Gi")},
+			},
+		}
+		ok, _ := CanResizeInPlace(&current, &target)
+		Expect(ok).To(BeFalse())
+	})
+})

--- a/pkg/utils/discovery.go
+++ b/pkg/utils/discovery.go
@@ -42,6 +42,9 @@ var haveSCC bool
 // haveVolumeSnapshot stores the result of the VolumeSnapshotExist function
 var haveVolumeSnapshot bool
 
+// havePodsResize stores the result of the DetectPodsResize check
+var havePodsResize bool
+
 // olmPlatform specifies whether we are running on a platform with OLM support
 var olmPlatform bool
 
@@ -173,6 +176,30 @@ func SetVolumeSnapshot(value bool) {
 // having the VolumeSnapshot CRD
 func HaveVolumeSnapshot() bool {
 	return haveVolumeSnapshot
+}
+
+// DetectPodsResize connects to the discovery API and finds out if
+// the API server exposes the resize subresource of the pods
+// (in-place pod resize, Kubernetes 1.33+)
+func DetectPodsResize(client discovery.DiscoveryInterface) (err error) {
+	havePodsResize, err = resourceExist(client, "v1", "pods/resize")
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// SetPodsResize sets the havePodsResize variable to a specific value for testing purposes
+// IMPORTANT: use it only in the unit tests
+func SetPodsResize(value bool) {
+	havePodsResize = value
+}
+
+// HavePodsResize returns true if the API server exposes the resize
+// subresource of the pods
+func HavePodsResize() bool {
+	return havePodsResize
 }
 
 // PodMonitorExist tries to find the PodMonitor resource in the current cluster

--- a/pkg/utils/discovery_test.go
+++ b/pkg/utils/discovery_test.go
@@ -126,6 +126,48 @@ var _ = Describe("Detect resources properly when", func() {
 
 		Expect(HaveVolumeSnapshot()).To(BeTrue())
 	})
+
+	It("should not detect the resize subresource of the pods", func() {
+		resources := []*metav1.APIResourceList{
+			{
+				GroupVersion: "v1",
+				APIResources: []metav1.APIResource{
+					{
+						Name: "pods",
+					},
+					{
+						Name: "pods/status",
+					},
+				},
+			},
+		}
+		fakeDiscovery.Resources = resources
+		err := DetectPodsResize(client.Discovery())
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(HavePodsResize()).To(BeFalse())
+	})
+
+	It("should detect the resize subresource of the pods", func() {
+		resources := []*metav1.APIResourceList{
+			{
+				GroupVersion: "v1",
+				APIResources: []metav1.APIResource{
+					{
+						Name: "pods",
+					},
+					{
+						Name: "pods/resize",
+					},
+				},
+			},
+		}
+		fakeDiscovery.Resources = resources
+		err := DetectPodsResize(client.Discovery())
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(HavePodsResize()).To(BeTrue())
+	})
 })
 
 var _ = Describe("AvailableArchitecture", func() {

--- a/tests/e2e/fixtures/inplace_resize/cluster-inplace-resize.yaml.template
+++ b/tests/e2e/fixtures/inplace_resize/cluster-inplace-resize.yaml.template
@@ -1,0 +1,20 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: cluster-inplace-resize
+spec:
+  instances: 3
+
+  resourcesUpdateStrategy: inPlace
+
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 200m
+      memory: 512Mi
+
+  storage:
+    size: 1Gi
+    storageClass: ${E2E_DEFAULT_STORAGE_CLASS}

--- a/tests/e2e/inplace_resize_test.go
+++ b/tests/e2e/inplace_resize_test.go
@@ -1,0 +1,199 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package e2e
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/specs"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
+	"github.com/cloudnative-pg/cloudnative-pg/tests"
+	clusterasserts "github.com/cloudnative-pg/cloudnative-pg/tests/internal/asserts/cluster"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/clusterutils"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/timeouts"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// Set of tests for the inPlace resources update strategy: resource-only
+// changes are applied to the running instance pods through the resize
+// subresource, without recreating them; changes that cannot be applied in
+// place, like memory limit decreases, fall back to the usual rolling update.
+var _ = Describe("In-place resource updates", Label(tests.LabelPostgresConfiguration), func() {
+	const (
+		sampleFile      = fixturesDir + "/inplace_resize/cluster-inplace-resize.yaml.template"
+		clusterName     = "cluster-inplace-resize"
+		namespacePrefix = "inplace-resize"
+		level           = tests.Medium
+	)
+
+	BeforeEach(func() {
+		if testLevelEnv.Depth < int(level) {
+			Skip("Test depth is lower than the amount requested for this test")
+		}
+		Expect(utils.DetectPodsResize(env.APIExtensionClient.Discovery())).To(Succeed())
+		if !utils.HavePodsResize() {
+			Skip("This test requires in-place pod resize support (Kubernetes 1.33+)")
+		}
+	})
+
+	getPostgresResources := func(pod *corev1.Pod) corev1.ResourceRequirements {
+		for i := range pod.Spec.Containers {
+			if pod.Spec.Containers[i].Name == specs.PostgresContainerName {
+				return pod.Spec.Containers[i].Resources
+			}
+		}
+		return corev1.ResourceRequirements{}
+	}
+
+	getPostgresContainerStatus := func(pod *corev1.Pod) *corev1.ContainerStatus {
+		for i := range pod.Status.ContainerStatuses {
+			if pod.Status.ContainerStatuses[i].Name == specs.PostgresContainerName {
+				return &pod.Status.ContainerStatuses[i]
+			}
+		}
+		return nil
+	}
+
+	updateClusterResources := func(namespace string, resources corev1.ResourceRequirements) {
+		Eventually(func(g Gomega) error {
+			cluster, err := clusterutils.Get(env.Ctx, env.Client, namespace, clusterName)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			cluster.Spec.Resources = resources
+			return env.Client.Update(env.Ctx, cluster)
+		}, RetryTimeout, PollingTime).Should(Succeed())
+	}
+
+	It("applies resource changes without recreating the pods", func() {
+		namespace, err := env.CreateUniqueTestNamespace(env.Ctx, env.Client, namespacePrefix)
+		Expect(err).ToNot(HaveOccurred())
+		clusterasserts.AssertCreateCluster(env, testTimeouts, namespace, clusterName, sampleFile)
+
+		originalPodUIDs := make(map[string]types.UID)
+		originalRestartCounts := make(map[string]int32)
+
+		By("gathering the current pods", func() {
+			podList, err := clusterutils.ListPods(env.Ctx, env.Client, namespace, clusterName)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(podList.Items).To(HaveLen(3))
+			for i := range podList.Items {
+				pod := &podList.Items[i]
+				originalPodUIDs[pod.Name] = pod.UID
+				containerStatus := getPostgresContainerStatus(pod)
+				Expect(containerStatus).ToNot(BeNil())
+				originalRestartCounts[pod.Name] = containerStatus.RestartCount
+			}
+		})
+
+		increasedResources := corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("150m"),
+				corev1.ResourceMemory: resource.MustParse("320Mi"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("400m"),
+				corev1.ResourceMemory: resource.MustParse("768Mi"),
+			},
+		}
+
+		By("increasing cpu and memory of the cluster", func() {
+			updateClusterResources(namespace, increasedResources)
+		})
+
+		By("waiting for the new resources to be applied to the running containers", func() {
+			Eventually(func(g Gomega) {
+				podList, err := clusterutils.ListPods(env.Ctx, env.Client, namespace, clusterName)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(podList.Items).To(HaveLen(3))
+
+				for i := range podList.Items {
+					pod := &podList.Items[i]
+
+					liveResources := getPostgresResources(pod)
+					g.Expect(liveResources.Limits.Cpu().Cmp(*increasedResources.Limits.Cpu())).
+						To(BeZero(), "pod %s cpu limit", pod.Name)
+					g.Expect(liveResources.Limits.Memory().Cmp(*increasedResources.Limits.Memory())).
+						To(BeZero(), "pod %s memory limit", pod.Name)
+
+					// the kubelet reports the resources actually applied to
+					// the running container
+					containerStatus := getPostgresContainerStatus(pod)
+					g.Expect(containerStatus).ToNot(BeNil())
+					g.Expect(containerStatus.Resources).ToNot(BeNil())
+					g.Expect(containerStatus.Resources.Limits.Memory().Cmp(*increasedResources.Limits.Memory())).
+						To(BeZero(), "pod %s applied memory limit", pod.Name)
+				}
+			}, testTimeouts[timeouts.PodRollout]).Should(Succeed())
+		})
+
+		By("verifying no pod was recreated or restarted", func() {
+			// the resize must leave the drift detection quiescent: no pod
+			// recreation may happen after the resources have been applied
+			Consistently(func(g Gomega) {
+				podList, err := clusterutils.ListPods(env.Ctx, env.Client, namespace, clusterName)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(podList.Items).To(HaveLen(3))
+
+				for i := range podList.Items {
+					pod := &podList.Items[i]
+					g.Expect(pod.UID).To(Equal(originalPodUIDs[pod.Name]),
+						"pod %s has been recreated", pod.Name)
+					containerStatus := getPostgresContainerStatus(pod)
+					g.Expect(containerStatus).ToNot(BeNil())
+					g.Expect(containerStatus.RestartCount).To(Equal(originalRestartCounts[pod.Name]),
+						"container of pod %s has been restarted", pod.Name)
+				}
+			}, 30, 5).Should(Succeed())
+
+			clusterasserts.AssertClusterIsReady(env, namespace, clusterName, testTimeouts[timeouts.ClusterIsReady])
+		})
+
+		By("decreasing the memory limit", func() {
+			decreasedResources := *increasedResources.DeepCopy()
+			decreasedResources.Limits[corev1.ResourceMemory] = resource.MustParse("512Mi")
+			decreasedResources.Requests[corev1.ResourceMemory] = resource.MustParse("256Mi")
+			updateClusterResources(namespace, decreasedResources)
+		})
+
+		By("waiting for the pods to be recreated by a rolling update", func() {
+			Eventually(func(g Gomega) {
+				podList, err := clusterutils.ListPods(env.Ctx, env.Client, namespace, clusterName)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(podList.Items).To(HaveLen(3))
+
+				for i := range podList.Items {
+					pod := &podList.Items[i]
+					g.Expect(pod.UID).ToNot(Equal(originalPodUIDs[pod.Name]),
+						"pod %s was expected to be recreated", pod.Name)
+
+					liveResources := getPostgresResources(pod)
+					g.Expect(liveResources.Limits.Memory().Cmp(resource.MustParse("512Mi"))).
+						To(BeZero(), "pod %s memory limit", pod.Name)
+				}
+			}, testTimeouts[timeouts.ClusterIsReady]).Should(Succeed())
+
+			clusterasserts.AssertClusterIsReady(env, namespace, clusterName, testTimeouts[timeouts.ClusterIsReady])
+		})
+	})
+})


### PR DESCRIPTION
Kubernetes 1.33 introduced in-place pod resize (stable in 1.35): the
resources of a running container can be changed through the `resize`
subresource without recreating the pod. Until now, any change to
`.spec.resources` triggered a rolling update of every instance, with a
switchover for the primary.

The cluster spec now has a `resourcesUpdateStrategy` field. With the default
value, `recreate`, nothing changes. With `inPlace`, when the only difference
between a running instance and its target pod spec is in the container
resources, the operator patches the `resize` subresource and refreshes the
`cnpg.io/podSpec` annotation instead of deleting the pod. Nothing restarts,
so the primary is treated like any replica: no switchover, no rollout slot
consumed, no involvement of `primaryUpdateMethod`. This covers the `postgres`
container as well as the sidecar containers injected by plugins.

The strategy is best-effort by design and degrades to the usual rolling
update whenever the change cannot be applied in place: the API server does
not expose `pods/resize` (detected once at operator startup), resource
entries are added or removed, resources other than cpu and memory change,
the delta would alter the pod QoS class (the API server rejects the patch
and the operator falls back), or the kubelet reports the resize as
infeasible for its node, in which case the pod is recreated so that the
scheduler can place it on a suitable one. Run-once init containers cannot be
resized and have already terminated, so their recorded resources are left
untouched and picked up at the next natural recreation.

Memory limit decreases always use a rolling update, even under `inPlace`.
The kubelet applies a limit decrease only when the current usage of the
container is below the new value, and PostgreSQL keeps its shared memory
(shared_buffers above all) allocated for the whole life of the postmaster,
so on a warmed-up instance the resize would stay pending indefinitely,
without reporting any error anywhere. And if the usage momentarily dipped
below the target and the decrease landed, the instance would be running with
a memory configuration sized for the old limit inside a smaller cgroup, one
allocation spike away from an OOM kill, which is an unclean crash of every
backend followed by crash recovery. A recreated pod starts under the new
limit from the very beginning and fails fast if the configuration does not
fit, which is the deterministic behavior users already expect from a
resource change.

With `inPlace` the operator treats the resources of the running pods as
fully declarative: the live values, not only the stored pod spec annotation,
are compared against the target, and a resize issued by any other actor is
reverted. This closes the window where a resize applied shortly before a
rollback of `.spec.resources` would leave the pod permanently drifted, and
is documented as an incompatibility with in-place vertical autoscalers.

Closes #8070
