### PR TITLE
fix: don't stop replication slot reconciliation at the first failing slot

### DIFF
--- a/internal/management/controller/slots/reconciler/replicationslot.go
+++ b/internal/management/controller/slots/reconciler/replicationslot.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/cloudnative-pg/machinery/pkg/log"
+	"go.uber.org/multierr"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
@@ -62,7 +63,9 @@ func ReconcileReplicationSlots(
 	return reconcile.Result{}, nil
 }
 
-// reconcilePrimaryHAReplicationSlots reconciles the HA replication slots of the primary instance
+// reconcilePrimaryHAReplicationSlots reconciles the HA replication slots of the primary instance.
+// A failure on a single slot doesn't stop the reconciliation: the remaining
+// slots are still processed, and the errors are collected and returned together.
 func reconcilePrimaryHAReplicationSlots(
 	ctx context.Context,
 	db *sql.DB,
@@ -79,6 +82,7 @@ func reconcilePrimaryHAReplicationSlots(
 	expectedSlots := make(map[string]bool)
 
 	// Add every slot that is missing
+	var errs error
 	for _, instanceName := range cluster.Status.InstanceNames {
 		if instanceName == cluster.Status.CurrentPrimary {
 			continue
@@ -93,7 +97,8 @@ func reconcilePrimaryHAReplicationSlots(
 
 		// At this point, the cluster instance does not have a HA replication slot
 		if err := infrastructure.Create(ctx, db, infrastructure.ReplicationSlot{SlotName: slotName}); err != nil {
-			return reconcile.Result{}, fmt.Errorf("creating primary HA replication slots: %w", err)
+			errs = multierr.Append(errs,
+				fmt.Errorf("creating replication slot %q: %w", slotName, err))
 		}
 	}
 
@@ -120,9 +125,14 @@ func reconcilePrimaryHAReplicationSlots(
 			contextLogger.Trace("Attempt to delete replication slot",
 				"slot", slot)
 			if err := infrastructure.Delete(ctx, db, slot); err != nil {
-				return reconcile.Result{}, fmt.Errorf("failure deleting replication slot %q: %w", slot.SlotName, err)
+				errs = multierr.Append(errs,
+					fmt.Errorf("dropping replication slot %q: %w", slot.SlotName, err))
 			}
 		}
+	}
+
+	if errs != nil {
+		return reconcile.Result{}, errs
 	}
 
 	if needToReschedule {
@@ -135,6 +145,8 @@ func reconcilePrimaryHAReplicationSlots(
 // dropReplicationSlots cleans up the HA replication slots when the feature is disabled.
 // If both the HA replication slots and the user defined replication slots features are disabled,
 // we also clean up the slots that fall under the user defined replication slots feature here.
+// A failure on a single slot doesn't stop the cleanup: the remaining slots are
+// still processed, and the errors are collected and returned together.
 func dropReplicationSlots(
 	ctx context.Context,
 	db *sql.DB,
@@ -153,6 +165,7 @@ func dropReplicationSlots(
 		return reconcile.Result{}, err
 	}
 
+	var errs error
 	needToReschedule := false
 	for _, slot := range slots.Items {
 		// On the primary,  we only drop the HA replication slots
@@ -174,8 +187,13 @@ func dropReplicationSlots(
 		contextLogger.Trace("Attempt to delete replication slot",
 			"slot", slot)
 		if err := infrastructure.Delete(ctx, db, slot); err != nil {
-			return reconcile.Result{}, fmt.Errorf("while disabling standby HA replication slots: %w", err)
+			errs = multierr.Append(errs,
+				fmt.Errorf("dropping replication slot %q: %w", slot.SlotName, err))
 		}
+	}
+
+	if errs != nil {
+		return reconcile.Result{}, errs
 	}
 
 	if needToReschedule {

--- a/internal/management/controller/slots/reconciler/replicationslot.go
+++ b/internal/management/controller/slots/reconciler/replicationslot.go
@@ -64,8 +64,7 @@ func ReconcileReplicationSlots(
 }
 
 // reconcilePrimaryHAReplicationSlots reconciles the HA replication slots of the primary instance.
-// A failure on a single slot doesn't stop the reconciliation: the remaining
-// slots are still processed, and the errors are collected and returned together.
+// A failure on one slot doesn't stop the rest; errors are collected and returned together.
 func reconcilePrimaryHAReplicationSlots(
 	ctx context.Context,
 	db *sql.DB,
@@ -131,22 +130,17 @@ func reconcilePrimaryHAReplicationSlots(
 		}
 	}
 
-	if errs != nil {
-		return reconcile.Result{}, errs
-	}
-
 	if needToReschedule {
-		return reconcile.Result{RequeueAfter: time.Second}, nil
+		return reconcile.Result{RequeueAfter: time.Second}, errs
 	}
 
-	return reconcile.Result{}, nil
+	return reconcile.Result{}, errs
 }
 
 // dropReplicationSlots cleans up the HA replication slots when the feature is disabled.
 // If both the HA replication slots and the user defined replication slots features are disabled,
 // we also clean up the slots that fall under the user defined replication slots feature here.
-// A failure on a single slot doesn't stop the cleanup: the remaining slots are
-// still processed, and the errors are collected and returned together.
+// A failure on one slot doesn't stop the rest; errors are collected and returned together.
 func dropReplicationSlots(
 	ctx context.Context,
 	db *sql.DB,
@@ -192,13 +186,9 @@ func dropReplicationSlots(
 		}
 	}
 
-	if errs != nil {
-		return reconcile.Result{}, errs
-	}
-
 	if needToReschedule {
-		return reconcile.Result{RequeueAfter: time.Second}, nil
+		return reconcile.Result{RequeueAfter: time.Second}, errs
 	}
 
-	return reconcile.Result{}, nil
+	return reconcile.Result{}, errs
 }

--- a/internal/management/controller/slots/reconciler/replicationslot_test.go
+++ b/internal/management/controller/slots/reconciler/replicationslot_test.go
@@ -126,6 +126,57 @@ var _ = Describe("HA Replication Slots reconciliation in Primary", func() {
 		_, err := ReconcileReplicationSlots(ctx, "instance1", db, &cluster)
 		Expect(err).ShouldNot(HaveOccurred())
 	})
+
+	It("continues creating the other slots and cleaning up stale ones after a create failure", func(ctx SpecContext) {
+		rows := sqlmock.NewRows(repSlotColumns).
+			AddRow(newRepSlot("instance2", true, "lsn2")...).
+			AddRow(newRepSlot("instance9", false, "lsn9")...)
+
+		mock.ExpectQuery("^SELECT (.+) FROM pg_catalog.pg_replication_slots").
+			WillReturnRows(rows)
+
+		mock.ExpectExec("SELECT pg_catalog.pg_create_physical_replication_slot").
+			WithArgs(slotPrefix+"instance3", false).
+			WillReturnError(errors.New("mock create failure"))
+
+		// the slot for instance4 is still created, and the stale slot
+		// of instance9 is still dropped
+		mock.ExpectExec("SELECT pg_catalog.pg_create_physical_replication_slot").
+			WithArgs(slotPrefix+"instance4", false).
+			WillReturnResult(sqlmock.NewResult(1, 1))
+		mock.ExpectExec("SELECT pg_catalog.pg_drop_replication_slot").WithArgs(slotPrefix + "instance9").
+			WillReturnResult(sqlmock.NewResult(1, 1))
+
+		cluster := makeClusterWithInstanceNames(
+			[]string{"instance1", "instance2", "instance3", "instance4"}, "instance1")
+
+		res, err := ReconcileReplicationSlots(ctx, "instance1", db, &cluster)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring(`creating replication slot "_cnpg_instance3": mock create failure`))
+		Expect(res.IsZero()).To(BeTrue())
+	})
+
+	It("continues dropping the remaining stale slots after a drop failure", func(ctx SpecContext) {
+		rows := sqlmock.NewRows(repSlotColumns).
+			AddRow(newRepSlot("instance2", true, "lsn2")...).
+			AddRow(newRepSlot("instance8", false, "lsn8")...).
+			AddRow(newRepSlot("instance9", false, "lsn9")...)
+
+		mock.ExpectQuery("^SELECT (.+) FROM pg_catalog.pg_replication_slots").
+			WillReturnRows(rows)
+
+		mock.ExpectExec("SELECT pg_catalog.pg_drop_replication_slot").WithArgs(slotPrefix + "instance8").
+			WillReturnError(errors.New("mock drop failure"))
+		mock.ExpectExec("SELECT pg_catalog.pg_drop_replication_slot").WithArgs(slotPrefix + "instance9").
+			WillReturnResult(sqlmock.NewResult(1, 1))
+
+		cluster := makeClusterWithInstanceNames([]string{"instance1", "instance2"}, "instance1")
+
+		_, err := ReconcileReplicationSlots(ctx, "instance1", db, &cluster)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring(`dropping replication slot "_cnpg_instance8": mock drop failure`))
+		Expect(err.Error()).NotTo(ContainSubstring("instance9"))
+	})
 })
 
 var _ = Describe("dropReplicationSlots", func() {
@@ -208,5 +259,25 @@ var _ = Describe("dropReplicationSlots", func() {
 		res, err := dropReplicationSlots(ctx, db, &cluster, true)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res.RequeueAfter).To(Equal(time.Duration(0)))
+	})
+
+	It("continues dropping the remaining slots after a drop failure", func(ctx SpecContext) {
+		rows := sqlmock.NewRows(repSlotColumns).
+			AddRow(newRepSlot("instance1", false, "lsn1")...).
+			AddRow(newRepSlot("instance2", false, "lsn2")...)
+		mock.ExpectQuery(selectPgRepSlot).WillReturnRows(rows)
+
+		mock.ExpectExec("SELECT pg_catalog.pg_drop_replication_slot").WithArgs(slotPrefix + "instance1").
+			WillReturnError(errors.New("mock drop failure"))
+		mock.ExpectExec("SELECT pg_catalog.pg_drop_replication_slot").WithArgs(slotPrefix + "instance2").
+			WillReturnResult(sqlmock.NewResult(1, 1))
+
+		cluster := makeClusterWithInstanceNames([]string{}, "")
+
+		res, err := dropReplicationSlots(ctx, db, &cluster, true)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring(`dropping replication slot "_cnpg_instance1": mock drop failure`))
+		Expect(err.Error()).NotTo(ContainSubstring("_cnpg_instance2"))
+		Expect(res.IsZero()).To(BeTrue())
 	})
 })

--- a/internal/management/controller/slots/runner/runner.go
+++ b/internal/management/controller/slots/runner/runner.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/cloudnative-pg/machinery/pkg/log"
+	"go.uber.org/multierr"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/internal/management/controller/slots/infrastructure"
@@ -146,7 +147,9 @@ func (sr *Replicator) reconcile(ctx context.Context, config *apiv1.ReplicationSl
 	return err
 }
 
-// synchronizeReplicationSlots aligns the slots in the local instance with those in the primary
+// synchronizeReplicationSlots aligns the slots in the local instance with those in the primary.
+// A failure on a single slot doesn't stop the synchronization: the remaining
+// slots are still processed, and the errors are collected and returned together.
 //
 //nolint:gocognit
 func synchronizeReplicationSlots(
@@ -172,6 +175,7 @@ func synchronizeReplicationSlots(
 
 	mySlotName := config.HighAvailability.GetSlotNameFromInstanceName(podName)
 
+	var errs error
 	for _, slot := range slotsInPrimary.Items {
 		if slot.SlotName == mySlotName {
 			continue
@@ -191,14 +195,15 @@ func synchronizeReplicationSlots(
 		}
 
 		if !slotsInLocal.Has(slot.SlotName) {
-			err := infrastructure.Create(ctx, localDB, slot)
-			if err != nil {
-				return err
+			if err := infrastructure.Create(ctx, localDB, slot); err != nil {
+				errs = multierr.Append(errs,
+					fmt.Errorf("creating replication slot %q: %w", slot.SlotName, err))
+				continue
 			}
 		}
-		err := infrastructure.Update(ctx, localDB, slot)
-		if err != nil {
-			return err
+		if err := infrastructure.Update(ctx, localDB, slot); err != nil {
+			errs = multierr.Append(errs,
+				fmt.Errorf("updating replication slot %q: %w", slot.SlotName, err))
 		}
 	}
 	for _, slot := range slotsInLocal.Items {
@@ -207,19 +212,21 @@ func synchronizeReplicationSlots(
 		//  * the slot used by this node
 		//  * slots holding xmin (this can happen on a former primary, and will prevent VACUUM from
 		//      removing tuples deleted by any later transaction.)
-		if !slotsInPrimary.Has(slot.SlotName) || slot.SlotName == mySlotName || slot.HoldsXmin {
-			if err := infrastructure.Delete(ctx, localDB, slot); err != nil {
-				return err
-			}
+		//  * slots that aren't from HA, when the user turns off the synchronization of user defined
+		//      replication slots
+		shouldDelete := !slotsInPrimary.Has(slot.SlotName) ||
+			slot.SlotName == mySlotName ||
+			slot.HoldsXmin ||
+			(!slot.IsHA && !config.SynchronizeReplicas.GetEnabled())
+		if !shouldDelete {
+			continue
 		}
 
-		// when the user turns off the feature we should delete all the created replication slots that aren't from HA
-		if !slot.IsHA && !config.SynchronizeReplicas.GetEnabled() {
-			if err := infrastructure.Delete(ctx, localDB, slot); err != nil {
-				return err
-			}
+		if err := infrastructure.Delete(ctx, localDB, slot); err != nil {
+			errs = multierr.Append(errs,
+				fmt.Errorf("dropping replication slot %q: %w", slot.SlotName, err))
 		}
 	}
 
-	return nil
+	return errs
 }

--- a/internal/management/controller/slots/runner/runner.go
+++ b/internal/management/controller/slots/runner/runner.go
@@ -106,9 +106,13 @@ func (sr *Replicator) Start(ctx context.Context) error {
 	return nil
 }
 
-func (sr *Replicator) reconcile(ctx context.Context, config *apiv1.ReplicationSlotsConfiguration) error {
-	var err error
-
+// reconcile aligns the replication slots of this instance with those of the primary.
+// The error is a named return value, so that the deferred recover can report
+// a panic to the caller instead of discarding it.
+func (sr *Replicator) reconcile(
+	ctx context.Context,
+	config *apiv1.ReplicationSlotsConfiguration,
+) (err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			err = fmt.Errorf("recovered from a panic: %s", r)

--- a/internal/management/controller/slots/runner/runner.go
+++ b/internal/management/controller/slots/runner/runner.go
@@ -106,9 +106,8 @@ func (sr *Replicator) Start(ctx context.Context) error {
 	return nil
 }
 
-// reconcile aligns the replication slots of this instance with those of the primary.
-// The error is a named return value, so that the deferred recover can report
-// a panic to the caller instead of discarding it.
+// reconcile's error is a named return value, so that the deferred recover
+// can report a panic to the caller instead of discarding it.
 func (sr *Replicator) reconcile(
 	ctx context.Context,
 	config *apiv1.ReplicationSlotsConfiguration,
@@ -152,8 +151,7 @@ func (sr *Replicator) reconcile(
 }
 
 // synchronizeReplicationSlots aligns the slots in the local instance with those in the primary.
-// A failure on a single slot doesn't stop the synchronization: the remaining
-// slots are still processed, and the errors are collected and returned together.
+// A failure on one slot doesn't stop the rest; errors are collected and returned together.
 //
 //nolint:gocognit
 func synchronizeReplicationSlots(
@@ -216,8 +214,7 @@ func synchronizeReplicationSlots(
 		//  * the slot used by this node
 		//  * slots holding xmin (this can happen on a former primary, and will prevent VACUUM from
 		//      removing tuples deleted by any later transaction.)
-		//  * slots that aren't from HA, when the user turns off the synchronization of user defined
-		//      replication slots
+		//  * non-HA slots, when synchronizeReplicas is disabled
 		shouldDelete := !slotsInPrimary.Has(slot.SlotName) ||
 			slot.SlotName == mySlotName ||
 			slot.HoldsXmin ||

--- a/internal/management/controller/slots/runner/runner_test.go
+++ b/internal/management/controller/slots/runner/runner_test.go
@@ -187,7 +187,8 @@ var _ = Describe("Slot synchronization", Ordered, func() {
 			WillReturnError(errors.New("mock create failure"))
 
 		// no advance is expected for slot3: creating it failed. slot4 is
-		// still created and advanced, and the stale slot is still dropped.
+		// still created and advanced, and the stale slot's deletion is
+		// still attempted (and also fails, to prove both errors are collected).
 		mockLocal.ExpectExec("SELECT pg_catalog.pg_create_physical_replication_slot").
 			WithArgs(slot4, true).
 			WillReturnResult(sqlmock.NewResult(1, 1))

--- a/internal/management/controller/slots/runner/runner_test.go
+++ b/internal/management/controller/slots/runner/runner_test.go
@@ -288,3 +288,14 @@ var _ = Describe("Slot synchronization", Ordered, func() {
 		Expect(err).ShouldNot(HaveOccurred())
 	})
 })
+
+var _ = Describe("Replicator reconcile", func() {
+	It("returns the recovered error when the reconciliation panics", func(ctx SpecContext) {
+		// a Replicator with a nil instance panics as soon as it dereferences it
+		sr := NewReplicator(nil)
+
+		err := sr.reconcile(ctx, &apiv1.ReplicationSlotsConfiguration{})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("recovered from a panic"))
+	})
+})

--- a/internal/management/controller/slots/runner/runner_test.go
+++ b/internal/management/controller/slots/runner/runner_test.go
@@ -21,6 +21,7 @@ package runner
 
 import (
 	"database/sql"
+	"errors"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"k8s.io/utils/ptr"
@@ -164,6 +165,126 @@ var _ = Describe("Slot synchronization", Ordered, func() {
 			WillReturnResult(sqlmock.NewResult(1, 1))
 
 		err := synchronizeReplicationSlots(ctx, dbPrimary, dbLocal, localPodName, &config)
+		Expect(err).ShouldNot(HaveOccurred())
+	})
+
+	It("continues after a slot fails to be created, and still runs the cleanup", func(ctx SpecContext) {
+		staleSlot := "cluster-5"
+
+		mockPrimary.ExpectQuery(selectPgReplicationSlots).
+			WillReturnRows(sqlmock.NewRows(columns).
+				AddRow(localSlotName, string(infrastructure.SlotTypePhysical), true, "0/301C4D8", false).
+				AddRow(slot3, string(infrastructure.SlotTypePhysical), true, lsnSlot3, false).
+				AddRow(slot4, string(infrastructure.SlotTypePhysical), true, lsnSlot4, false))
+
+		// the local instance has a stale slot to be dropped and none of the primary ones
+		mockLocal.ExpectQuery(selectPgReplicationSlots).
+			WillReturnRows(sqlmock.NewRows(columns).
+				AddRow(staleSlot, string(infrastructure.SlotTypePhysical), false, lsnSlot4, false))
+
+		mockLocal.ExpectExec("SELECT pg_catalog.pg_create_physical_replication_slot").
+			WithArgs(slot3, true).
+			WillReturnError(errors.New("mock create failure"))
+
+		// no advance is expected for slot3: creating it failed. slot4 is
+		// still created and advanced, and the stale slot is still dropped.
+		mockLocal.ExpectExec("SELECT pg_catalog.pg_create_physical_replication_slot").
+			WithArgs(slot4, true).
+			WillReturnResult(sqlmock.NewResult(1, 1))
+		mockLocal.ExpectExec(selectPgSlotAdvance).
+			WithArgs(slot4, lsnSlot4).
+			WillReturnResult(sqlmock.NewResult(1, 1))
+		mockLocal.ExpectExec("SELECT pg_catalog.pg_drop_replication_slot").WithArgs(staleSlot).
+			WillReturnError(errors.New("mock drop failure"))
+
+		err := synchronizeReplicationSlots(ctx, dbPrimary, dbLocal, localPodName, &config)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring(`creating replication slot "cluster-3": mock create failure`))
+		Expect(err.Error()).To(ContainSubstring(`dropping replication slot "cluster-5": mock drop failure`))
+	})
+
+	It("continues after a slot fails to be advanced, and still runs the cleanup", func(ctx SpecContext) {
+		staleSlot := "cluster-5"
+
+		mockPrimary.ExpectQuery(selectPgReplicationSlots).
+			WillReturnRows(sqlmock.NewRows(columns).
+				AddRow(localSlotName, string(infrastructure.SlotTypePhysical), true, "0/301C4D8", false).
+				AddRow(slot3, string(infrastructure.SlotTypePhysical), true, lsnSlot3, false).
+				AddRow(slot4, string(infrastructure.SlotTypePhysical), true, lsnSlot4, false))
+
+		mockLocal.ExpectQuery(selectPgReplicationSlots).
+			WillReturnRows(sqlmock.NewRows(columns).
+				AddRow(slot3, string(infrastructure.SlotTypePhysical), true, lsnSlot3, false).
+				AddRow(slot4, string(infrastructure.SlotTypePhysical), true, lsnSlot4, false).
+				AddRow(staleSlot, string(infrastructure.SlotTypePhysical), false, lsnSlot4, false))
+
+		mockLocal.ExpectExec(selectPgSlotAdvance).
+			WithArgs(slot3, lsnSlot3).
+			WillReturnError(errors.New("mock advance failure"))
+
+		mockLocal.ExpectExec(selectPgSlotAdvance).
+			WithArgs(slot4, lsnSlot4).
+			WillReturnResult(sqlmock.NewResult(1, 1))
+		mockLocal.ExpectExec("SELECT pg_catalog.pg_drop_replication_slot").WithArgs(staleSlot).
+			WillReturnResult(sqlmock.NewResult(1, 1))
+
+		err := synchronizeReplicationSlots(ctx, dbPrimary, dbLocal, localPodName, &config)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring(`updating replication slot "cluster-3": mock advance failure`))
+		Expect(err.Error()).NotTo(ContainSubstring("cluster-4"))
+		Expect(err.Error()).NotTo(ContainSubstring("cluster-5"))
+	})
+
+	It("continues dropping the remaining stale slots after a drop failure", func(ctx SpecContext) {
+		staleSlot5 := "cluster-5"
+		staleSlot6 := "cluster-6"
+
+		mockPrimary.ExpectQuery(selectPgReplicationSlots).
+			WillReturnRows(sqlmock.NewRows(columns).
+				AddRow(localSlotName, string(infrastructure.SlotTypePhysical), true, "0/301C4D8", false))
+
+		mockLocal.ExpectQuery(selectPgReplicationSlots).
+			WillReturnRows(sqlmock.NewRows(columns).
+				AddRow(staleSlot5, string(infrastructure.SlotTypePhysical), false, lsnSlot4, false).
+				AddRow(staleSlot6, string(infrastructure.SlotTypePhysical), false, lsnSlot4, false))
+
+		mockLocal.ExpectExec("SELECT pg_catalog.pg_drop_replication_slot").WithArgs(staleSlot5).
+			WillReturnError(errors.New("mock drop failure"))
+		mockLocal.ExpectExec("SELECT pg_catalog.pg_drop_replication_slot").WithArgs(staleSlot6).
+			WillReturnResult(sqlmock.NewResult(1, 1))
+
+		err := synchronizeReplicationSlots(ctx, dbPrimary, dbLocal, localPodName, &config)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring(`dropping replication slot "cluster-5": mock drop failure`))
+		Expect(err.Error()).NotTo(ContainSubstring("cluster-6"))
+	})
+
+	It("drops a stale user slot only once when synchronizeReplicas is disabled", func(ctx SpecContext) {
+		configNoUserSlots := apiv1.ReplicationSlotsConfiguration{
+			HighAvailability: &apiv1.ReplicationSlotsHAConfiguration{
+				Enabled:    ptr.To(true),
+				SlotPrefix: "_cnpg_",
+			},
+			SynchronizeReplicas: &apiv1.SynchronizeReplicasConfiguration{
+				Enabled: ptr.To(false),
+			},
+		}
+		userSlot := "userslot"
+
+		mockPrimary.ExpectQuery(selectPgReplicationSlots).
+			WillReturnRows(sqlmock.NewRows(columns).
+				AddRow(localSlotName, string(infrastructure.SlotTypePhysical), true, "0/301C4D8", false))
+
+		// the local slot is both missing from the primary and a user slot
+		// while synchronizeReplicas is disabled: it must be dropped exactly once
+		mockLocal.ExpectQuery(selectPgReplicationSlots).
+			WillReturnRows(sqlmock.NewRows(columns).
+				AddRow(userSlot, string(infrastructure.SlotTypePhysical), false, lsnSlot4, false))
+
+		mockLocal.ExpectExec("SELECT pg_catalog.pg_drop_replication_slot").WithArgs(userSlot).
+			WillReturnResult(sqlmock.NewResult(1, 1))
+
+		err := synchronizeReplicationSlots(ctx, dbPrimary, dbLocal, localPodName, &configNoUserSlots)
 		Expect(err).ShouldNot(HaveOccurred())
 	})
 })


### PR DESCRIPTION
The replication slot synchronization on the standby returned at the first error raised while creating, advancing, or dropping a slot. A single problematic slot would block the synchronization of every other slot and prevent the stale-slot cleanup pass from running at all. Since the synchronization runs on a fixed ticker, the same slot failed the same way on every cycle, making the outage permanent until the offending slot was removed out-of-band. The HA slot reconciliation on the primary, and the cleanup performed when the feature is disabled, suffered from the same weakness.

Every slot is now processed independently: per-slot errors are collected and returned together at the end, each one wrapped with the slot name so the resulting log message points at the offending slot.

Two related defects surfaced while restructuring these loops and are fixed here as well. Dropping an already-dropped slot failed harmlessly on its own, but combined with the abort-on-first-error bug above it could be the actual trigger behind some of these permanent stalls, and would otherwise keep resurfacing as a spurious error every cycle. Separately, a panic during standby slot synchronization was being silently discarded instead of logged, leaving synchronization broken with no operator-visible signal.

Closes #11113

Assisted-by: Claude

----

Add to the release notes:

```
Fixed replication slot reconciliation aborting at the first slot that
failed to be created, advanced, or dropped, which could permanently
block synchronization and cleanup of every other slot on both the
primary and the standby. Every slot is now processed independently.
```