### PR TITLE
ci: fix automated k8s & pg version update PRs sign-off and metadata

### DIFF
--- a/.github/workflows/k8s-versions-check.yml
+++ b/.github/workflows/k8s-versions-check.yml
@@ -132,12 +132,14 @@ jobs:
         if: github.ref == 'refs/heads/main'
         with:
           token: ${{ secrets.REPO_GHA_PAT }}
-          title: "feat: Public Cloud K8S versions update"
+          title: "chore: Public Cloud K8S versions update"
           body: "Update the versions used to test the operator on public cloud providers"
           branch: "k8s-cloud-versions-update"
           author: "public-cloud-k8s-versions-check <public-cloud-k8s-versions-check@users.noreply.github.com>"
+          committer: "public-cloud-k8s-versions-check <public-cloud-k8s-versions-check@users.noreply.github.com>"
+          labels: "no-issue"
           add-paths: |
             .github/**
             Makefile
-          commit-message: "feat: Updated public cloud k8s tested versions"
+          commit-message: "chore: Updated public cloud k8s tested versions"
           signoff: true

--- a/.github/workflows/latest-postgres-version-check.yml
+++ b/.github/workflows/latest-postgres-version-check.yml
@@ -85,6 +85,8 @@ jobs:
           body: "Update default PostgreSQL version from ${{ env.CURRENT_POSTGRES_VERSION }} to ${{ env.LATEST_POSTGRES_VERSION }}"
           branch: "postgres-versions-update"
           author: "postgres-versions-updater <postgres-versions-updater@users.noreply.github.com>"
+          committer: "postgres-versions-updater <postgres-versions-updater@users.noreply.github.com>"
+          labels: "no-issue"
           commit-message: "feat: update default PostgreSQL version to ${{ env.LATEST_POSTGRES_VERSION }}"
           signoff: true
 
@@ -99,6 +101,8 @@ jobs:
           body: "Update the Postgres versions used in E2E tests"
           branch: "postgres-versions-update"
           author: "postgres-versions-updater <postgres-versions-updater@users.noreply.github.com>"
+          committer: "postgres-versions-updater <postgres-versions-updater@users.noreply.github.com>"
+          labels: "no-issue"
           add-paths: ".github/"
           commit-message: "test: Updated Postgres versions used in E2E tests"
           signoff: true


### PR DESCRIPTION
The public cloud k8s versions workflow created PRs that failed DCO because peter-evans/create-pull-request derives the sign-off from the committer (github-actions[bot]) while the author was set to public-cloud-k8s-versions-check. Set the committer to match the author so the generated sign-off matches, add the no-issue label so the linked-issue check is satisfied automatically, and use a chore prefix that reflects the change.