### PR TITLE
fix(recovery): symlink pg_wal to the WAL volume during plugin recovery

### DIFF
--- a/pkg/management/postgres/restore.go
+++ b/pkg/management/postgres/restore.go
@@ -170,10 +170,6 @@ func (info InitInfo) RestoreSnapshot(ctx context.Context, cli client.Client, imm
 		}
 	}
 
-	if _, err := info.restoreCustomWalDir(ctx); err != nil {
-		return err
-	}
-
 	return info.concludeRestore(ctx, cli, cluster, config, envs)
 }
 
@@ -184,6 +180,12 @@ func (info InitInfo) concludeRestore(
 	config string,
 	envs []string,
 ) error {
+	// Set up the pg_wal symlink to the dedicated WAL volume before PostgreSQL
+	// replays WALs, otherwise recovery would accumulate WALs on the data volume.
+	if _, err := info.restoreCustomWalDir(ctx); err != nil {
+		return err
+	}
+
 	if err := info.WriteInitialPostgresqlConf(ctx, cluster); err != nil {
 		return err
 	}
@@ -330,10 +332,6 @@ func (info InitInfo) Restore(ctx context.Context, cli client.Client) error {
 		}
 
 		if err := info.restoreDataDir(ctx, backup, env); err != nil {
-			return err
-		}
-
-		if _, err := info.restoreCustomWalDir(ctx); err != nil {
 			return err
 		}
 

--- a/tests/e2e/fixtures/backup/cluster-from-restore.yaml.template
+++ b/tests/e2e/fixtures/backup/cluster-from-restore.yaml.template
@@ -18,6 +18,9 @@ spec:
   storage:
     size: 1Gi
     storageClass: ${E2E_DEFAULT_STORAGE_CLASS}
+  walStorage:
+    size: 1Gi
+    storageClass: ${E2E_DEFAULT_STORAGE_CLASS}
 
   bootstrap:
     recovery:


### PR DESCRIPTION
Plugin-based recovery restored PGDATA with pg_wal as a real directory on the data volume and never created the symlink to the dedicated WAL volume. WAL replay then ran inside the recovery job with pg_wal on the data volume, which could exhaust it on a large PITR even when the WAL volume had plenty of free space. The symlink was only established later, when the instance restarted as a normal pod.

Move the restoreCustomWalDir call into concludeRestore so every recovery path sets up the symlink before PostgreSQL replays WALs.

Closes #11125
