### PR TITLE
test(e2e): retry on transient proxy-hop errors

### DIFF
--- a/tests/e2e/managed_roles_test.go
+++ b/tests/e2e/managed_roles_test.go
@@ -293,7 +293,7 @@ var _ = Describe("Managed roles tests", Label(tests.LabelSmoke, tests.LabelBasic
 				updated.Spec.Managed.Roles[0].CreateDB = expectedCreateDB
 				updated.Spec.Managed.Roles[0].CreateRole = expectedCreateRole
 				updated.Spec.Managed.Roles[0].ConnectionLimit = expectedConnLmt
-				err = env.Client.Patch(env.Ctx, updated, client.MergeFrom(cluster))
+				err = objects.Patch(env.Ctx, env.Client, updated, client.MergeFrom(cluster))
 				Expect(err).ToNot(HaveOccurred())
 			})
 
@@ -325,7 +325,7 @@ var _ = Describe("Managed roles tests", Label(tests.LabelSmoke, tests.LabelBasic
 				Expect(err).ToNot(HaveOccurred())
 				updated := cluster.DeepCopy()
 				updated.Spec.Managed.Roles[0].Login = true
-				err = env.Client.Patch(env.Ctx, updated, client.MergeFrom(cluster))
+				err = objects.Patch(env.Ctx, env.Client, updated, client.MergeFrom(cluster))
 				Expect(err).ToNot(HaveOccurred())
 			})
 
@@ -364,7 +364,7 @@ var _ = Describe("Managed roles tests", Label(tests.LabelSmoke, tests.LabelBasic
 					Name: newUserName,
 				}
 				updated.Spec.Managed.Roles = append(updated.Spec.Managed.Roles, role)
-				err = env.Client.Patch(env.Ctx, updated, client.MergeFrom(cluster))
+				err = objects.Patch(env.Ctx, env.Client, updated, client.MergeFrom(cluster))
 				Expect(err).ToNot(HaveOccurred())
 			})
 
@@ -394,7 +394,7 @@ var _ = Describe("Managed roles tests", Label(tests.LabelSmoke, tests.LabelBasic
 						updated.Spec.Managed.Roles[i].Comment = ""
 					}
 				}
-				err = env.Client.Patch(env.Ctx, updated, client.MergeFrom(cluster))
+				err = objects.Patch(env.Ctx, env.Client, updated, client.MergeFrom(cluster))
 				Expect(err).ToNot(HaveOccurred())
 			})
 
@@ -427,7 +427,7 @@ var _ = Describe("Managed roles tests", Label(tests.LabelSmoke, tests.LabelBasic
 						updated.Spec.Managed.Roles[i].InRoles = []string{username}
 					}
 				}
-				err = env.Client.Patch(env.Ctx, updated, client.MergeFrom(cluster))
+				err = objects.Patch(env.Ctx, env.Client, updated, client.MergeFrom(cluster))
 				Expect(err).ToNot(HaveOccurred())
 				Eventually(func() int {
 					cluster, err := clusterutils.Get(env.Ctx, env.Client, namespace, clusterName)
@@ -452,7 +452,7 @@ var _ = Describe("Managed roles tests", Label(tests.LabelSmoke, tests.LabelBasic
 						}
 					}
 				}
-				err = env.Client.Patch(env.Ctx, updated, client.MergeFrom(cluster))
+				err = objects.Patch(env.Ctx, env.Client, updated, client.MergeFrom(cluster))
 				Expect(err).ToNot(HaveOccurred())
 				Eventually(func(g Gomega) {
 					cluster, err := clusterutils.Get(env.Ctx, env.Client, namespace, clusterName)
@@ -474,7 +474,7 @@ var _ = Describe("Managed roles tests", Label(tests.LabelSmoke, tests.LabelBasic
 						}
 					}
 				}
-				err = env.Client.Patch(env.Ctx, updated, client.MergeFrom(cluster))
+				err = objects.Patch(env.Ctx, env.Client, updated, client.MergeFrom(cluster))
 				Expect(err).ToNot(HaveOccurred())
 				Eventually(func(g Gomega) {
 					cluster, err := clusterutils.Get(env.Ctx, env.Client, namespace, clusterName)
@@ -494,7 +494,7 @@ var _ = Describe("Managed roles tests", Label(tests.LabelSmoke, tests.LabelBasic
 						updated.Spec.Managed.Roles[i].InRoles = []string{unrealizableUser}
 					}
 				}
-				err = env.Client.Patch(env.Ctx, updated, client.MergeFrom(cluster))
+				err = objects.Patch(env.Ctx, env.Client, updated, client.MergeFrom(cluster))
 				Expect(err).ToNot(HaveOccurred())
 				// user not changed
 				Eventually(pgasserts.QueryMatchExpectationPredicate(env, primaryPod, postgres.PostgresDBName,
@@ -578,7 +578,7 @@ var _ = Describe("Managed roles tests", Label(tests.LabelSmoke, tests.LabelBasic
 					}
 				}
 
-				err = env.Client.Patch(env.Ctx, updated, client.MergeFrom(cluster))
+				err = objects.Patch(env.Ctx, env.Client, updated, client.MergeFrom(cluster))
 				Expect(err).ToNot(HaveOccurred())
 			})
 
@@ -608,7 +608,7 @@ var _ = Describe("Managed roles tests", Label(tests.LabelSmoke, tests.LabelBasic
 						updated.Spec.Managed.Roles[i].Ensure = apiv1.EnsureAbsent
 					}
 				}
-				err = env.Client.Patch(env.Ctx, updated, client.MergeFrom(cluster))
+				err = objects.Patch(env.Ctx, env.Client, updated, client.MergeFrom(cluster))
 				Expect(err).ToNot(HaveOccurred())
 			})
 

--- a/tests/e2e/pgbouncer_metrics_test.go
+++ b/tests/e2e/pgbouncer_metrics_test.go
@@ -32,6 +32,7 @@ import (
 	clusterasserts "github.com/cloudnative-pg/cloudnative-pg/tests/internal/asserts/cluster"
 	pgbouncerasserts "github.com/cloudnative-pg/cloudnative-pg/tests/internal/asserts/pgbouncer"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/proxy"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/timeouts"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/yaml"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -103,15 +104,18 @@ var _ = Describe("PGBouncer Metrics", Label(tests.LabelObservability), func() {
 
 			for _, pod := range podList.Items {
 				podName := pod.GetName()
-				out, err := proxy.RetrieveMetricsFromPgBouncer(env.Ctx, env.Interface, pod, false)
-				Expect(err).ToNot(HaveOccurred())
-				matches := metricsRegexp.FindAllString(out, -1)
-				Expect(matches).To(
-					HaveLen(len(promMetrics)),
-					"Metric collection issues on %v.\nCollected metrics:\n%v",
-					podName,
-					out,
-				)
+				Eventually(func(g Gomega) error {
+					out, err := proxy.RetrieveMetricsFromPgBouncer(env.Ctx, env.Interface, pod, false)
+					g.Expect(err).ToNot(HaveOccurred())
+					matches := metricsRegexp.FindAllString(out, -1)
+					g.Expect(matches).To(
+						HaveLen(len(promMetrics)),
+						"Metric collection issues on %v.\nCollected metrics:\n%v",
+						podName,
+						out,
+					)
+					return nil
+				}, testTimeouts[timeouts.Short]).Should(Succeed())
 			}
 		})
 
@@ -144,11 +148,14 @@ var _ = Describe("PGBouncer Metrics", Label(tests.LabelObservability), func() {
 				Expect(errHTTP).To(HaveOccurred(),
 					"HTTP scrape of %v must fail when monitoring.tls.enabled=true", podName)
 
-				out, err := proxy.RetrieveMetricsFromPgBouncer(env.Ctx, env.Interface, pod, true)
-				Expect(err).ToNot(HaveOccurred(),
-					"HTTPS scrape of %v must succeed when monitoring.tls.enabled=true", podName)
-				Expect(out).To(ContainSubstring("cnpg_pgbouncer_"),
-					"HTTPS scrape of %v did not return pgbouncer metrics; got:\n%v", podName, out)
+				Eventually(func(g Gomega) error {
+					out, err := proxy.RetrieveMetricsFromPgBouncer(env.Ctx, env.Interface, pod, true)
+					g.Expect(err).ToNot(HaveOccurred(),
+						"HTTPS scrape of %v must succeed when monitoring.tls.enabled=true", podName)
+					g.Expect(out).To(ContainSubstring("cnpg_pgbouncer_"),
+						"HTTPS scrape of %v did not return pgbouncer metrics; got:\n%v", podName, out)
+					return nil
+				}, testTimeouts[timeouts.Short]).Should(Succeed())
 			}
 		})
 })

--- a/tests/utils/objects/objects.go
+++ b/tests/utils/objects/objects.go
@@ -99,6 +99,30 @@ func List(
 	return err
 }
 
+// Patch patches an object in the Kubernetes cluster, retrying on transient
+// errors. Forwarding a mutation to an admission webhook can intermittently
+// fail with a 500/503 on any cluster that routes that hop through a proxy
+// layer (for example an apiserver-network-proxy/konnectivity), so the patch
+// is worth retrying just like objects.Get and objects.List retry reads.
+func Patch(
+	ctx context.Context,
+	crudClient client.Client,
+	object client.Object,
+	patch client.Patch,
+	opts ...client.PatchOption,
+) error {
+	err := retry.New(
+		retry.Delay(PollingTime*time.Second),
+		retry.Attempts(RetryAttempts),
+		retry.DelayType(retry.FixedDelay)).
+		Do(
+			func() error {
+				return crudClient.Patch(ctx, object, patch, opts...)
+			},
+		)
+	return err
+}
+
 // Get retrieves an object for the given object key from the Kubernetes Cluster
 func Get(
 	ctx context.Context,


### PR DESCRIPTION
Two places in the e2e suite send a request through a proxy hop that can intermittently come back with a transient 500/503: the Cluster admission webhook chain, and the pod-proxy subresource used to scrape PgBouncer metrics. This isn't specific to one distribution (any cluster that routes these hops through an apiserver-network-proxy/konnectivity, a service mesh, or a load balancer can hit it); we've observed it on AKS.

For the webhook hop, add an objects.Patch helper that retries a patch the same way objects.Get and objects.List already retry reads, and route managed_roles_test.go through it. Retrying is safe here because each call re-applies a merge patch that pins the Cluster fields to their final desired values, so re-sending it after a transient failure is a no-op if the mutation actually landed server-side.

For the pod-proxy hop, wrap the PgBouncer metrics scrape in pgbouncer_metrics_test.go in an Eventually, the same retry shape metrics_test.go already uses around its instance-metrics scrape (added there for cache-population latency, which happens to also absorb this class of transient error).