### PR TITLE
fix(backup): always retry VolumeSnapshot errors until the deadline

### DIFF
--- a/docs/src/appendixes/backup_volumesnapshot.md
+++ b/docs/src/appendixes/backup_volumesnapshot.md
@@ -283,22 +283,20 @@ If not specified, the default retry deadline is **10 minutes**.
 
 ### Error Handling
 
-When a retryable error occurs during a volume snapshot operation:
+When an error occurs during a volume snapshot operation:
 
 1. CloudNativePG records the time of the first error.
 2. The system retries the operation every **10 seconds**.
 3. If the error persists beyond the specified deadline (or the default 10
    minutes), the backup is marked as **failed**.
 
-### Retryable Errors
-
-CloudNativePG treats the following types of errors as retryable:
-
-- **Server timeout errors** (HTTP 408, 429, 500, 502, 503, 504)
-- **Conflicts** (optimistic locking errors)
-- **Internal errors**
-- **Context deadline exceeded errors**
-- **Timeout errors from the CSI snapshot controller**
+The CSI driver reports snapshot errors as free text, with no reliable way to
+tell a permanent condition (for example, a missing `VolumeSnapshotClass` or
+invalid credentials) from a transient one, and a condition that looks
+permanent can become resolvable at any point, for example if someone creates
+the missing class or fixes the credentials while CloudNativePG is retrying.
+For this reason, CloudNativePG retries every volume snapshot error the same
+way, until the deadline is reached.
 
 ### Examples
 

--- a/docs/src/appendixes/backup_volumesnapshot.md
+++ b/docs/src/appendixes/backup_volumesnapshot.md
@@ -266,12 +266,12 @@ for details on this standard behavior.
 
 ## Backup Volume Snapshot Deadlines
 
-CloudNativePG supports backups using the volume snapshot method. In some
-environments, volume snapshots may encounter temporary issues that can be
-retried.
+CloudNativePG supports backups using the volume snapshot method. Volume
+snapshot operations may encounter errors, which CloudNativePG retries for a
+configurable amount of time before giving up.
 
 The `backup.cnpg.io/volumeSnapshotDeadline` annotation defines how long
-CloudNativePG should continue retrying recoverable errors before marking the
+CloudNativePG should continue retrying these errors before marking the
 backup as failed.
 
 You can add the `backup.cnpg.io/volumeSnapshotDeadline` annotation to both
@@ -320,7 +320,7 @@ When you define a `ScheduledBackup` with the annotation, any `Backup` resources
 created from this schedule automatically inherit the specified timeout value.
 
 In the following example, all backups created from the schedule will have a
-30-minute timeout for retrying recoverable snapshot errors.
+30-minute timeout for retrying snapshot errors.
 
 ```yaml
 apiVersion: postgresql.cnpg.io/v1

--- a/internal/controller/backup_controller.go
+++ b/internal/controller/backup_controller.go
@@ -730,8 +730,10 @@ func (r *BackupReconciler) reconcileSnapshotBackup(
 
 	res, err := r.vsr.Reconcile(ctx, cluster, backup, targetPod, pvcs)
 	if err != nil {
-		// Volume Snapshot errors are not retryable, we need to set this backup as failed
-		// and un-fence the Pod
+		// The reconciler already retried what it could: network errors are
+		// requeued, and snapshot errors reported by the CSI driver are retried
+		// until the volumeSnapshotDeadline elapses. An error here is final, so
+		// we need to set this backup as failed and un-fence the Pod
 		contextLogger.Error(err, "while executing snapshot backup")
 		r.Recorder.Eventf(backup, "Warning", "Error", "snapshot backup failed: %v", err)
 		_ = resourcestatus.FlagBackupAsFailed(ctx, r.Client, backup, cluster,

--- a/pkg/reconciler/backup/volumesnapshot/errors.go
+++ b/pkg/reconciler/backup/volumesnapshot/errors.go
@@ -23,18 +23,10 @@ import (
 	"context"
 	"errors"
 	"net"
-	"regexp"
-	"strconv"
-	"strings"
 
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres/webserver/client/remote"
-)
-
-var (
-	retryableStatusCodes = []int{408, 429, 500, 502, 503, 504}
-	httpStatusCodeRegex  = regexp.MustCompile(`HTTPStatusCode:\s(\d{3})`)
 )
 
 // isNetworkErrorRetryable detects if an error is retryable or not.
@@ -64,75 +56,4 @@ func isNetworkErrorRetryable(err error) bool {
 	return apierrs.IsServerTimeout(err) || apierrs.IsConflict(err) || apierrs.IsInternalError(err) ||
 		errors.Is(err, context.DeadlineExceeded) || remote.IsTransientAuthError(err) ||
 		errors.As(err, &netErr)
-}
-
-// isCSIErrorMessageRetriable detects if a certain error message
-// raised by the CSI driver corresponds to a retriable error or
-// not.
-//
-// It relies on heuristics, as this information is not available in
-// the Kubernetes VolumeSnapshot API, and the CSI driver does not
-// expose it either.
-func isCSIErrorMessageRetriable(msg string) bool {
-	isRetryableFuncs := []func(string) bool{
-		isExplicitlyRetriableError,
-		isRetryableHTTPError,
-		isConflictError,
-		isContextDeadlineExceededError,
-	}
-
-	for _, isRetryableFunc := range isRetryableFuncs {
-		if isRetryableFunc(msg) {
-			return true
-		}
-	}
-
-	return false
-}
-
-// isContextDeadlineExceededError detects context deadline exceeded errors
-// These are timeouts that may be retried by the Kubernetes CSI controller
-func isContextDeadlineExceededError(msg string) bool {
-	return strings.Contains(msg, "deadline exceeded") || strings.Contains(msg, "timed out")
-}
-
-// isConflictError detects optimistic locking errors
-func isConflictError(msg string) bool {
-	// Obviously this is a heuristic, but unfortunately we don't have
-	// the information we need.
-	// We're trying to handle the cases where the external-snapshotter
-	// controller failed on a conflict with the following error:
-	//
-	// > the object has been modified; please apply your changes to the
-	// > latest version and try again
-
-	return strings.Contains(msg, "the object has been modified")
-}
-
-// isExplicitlyRetriableError detects explicitly retriable errors as raised
-// by the Azure CSI driver. These errors contain the "Retriable: true"
-// string.
-func isExplicitlyRetriableError(msg string) bool {
-	return strings.Contains(msg, "Retriable: true")
-}
-
-// isRetryableHTTPError, will return a retry on the following status codes:
-// - 408: Request Timeout
-// - 429: Too Many Requests
-// - 500: Internal Server Error
-// - 502: Bad Gateway
-// - 503: Service Unavailable
-// - 504: Gateway Timeout
-func isRetryableHTTPError(msg string) bool {
-	if matches := httpStatusCodeRegex.FindStringSubmatch(msg); len(matches) == 2 {
-		if code, err := strconv.Atoi(matches[1]); err == nil {
-			for _, retryableCode := range retryableStatusCodes {
-				if code == retryableCode {
-					return true
-				}
-			}
-		}
-	}
-
-	return false
 }

--- a/pkg/reconciler/backup/volumesnapshot/errors_test.go
+++ b/pkg/reconciler/backup/volumesnapshot/errors_test.go
@@ -35,44 +35,6 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Retriable error messages", func() {
-	DescribeTable(
-		"Retriable error messages",
-		func(msg string, isRetriable bool) {
-			Expect(isCSIErrorMessageRetriable(msg)).To(Equal(isRetriable))
-		},
-		Entry("conflict", "Hey, the object has been modified!", true),
-		Entry("non-retriable error", "VolumeSnapshotClass not found", false),
-		Entry("explicitly retriable error", "Retriable: true, the storage is gone away forever", true),
-		Entry("explicitly non-retriable error", "Retriable: false because my pod is working", false),
-		Entry("error code 502 - retriable", "RetryAfter: 0s, HTTPStatusCode: 502, RawError: Internal Server Error", true),
-		Entry("error code 404 - non retriable", "RetryAfter: 0s, HTTPStatusCode: 404, RawError: Not found", false),
-		Entry("context deadline exceeded - retriable", "context deadline exceeded waiting for snapshot creation", true),
-		Entry("deadline exceeded - retriable", "deadline exceeded during Azure snapshot creation", true),
-		Entry("timed out - retriable", "operation timed out for csi-disk-handler", true),
-	)
-
-	Describe("isContextDeadlineExceededError", func() {
-		It("detects 'context deadline exceeded' error messages", func() {
-			Expect(isContextDeadlineExceededError("context deadline exceeded")).To(BeTrue())
-		})
-
-		It("detects 'deadline exceeded' error messages", func() {
-			Expect(isContextDeadlineExceededError("deadline exceeded")).To(BeTrue())
-		})
-
-		It("detects 'timed out' error messages", func() {
-			Expect(isContextDeadlineExceededError("operation timed out")).To(BeTrue())
-		})
-
-		It("rejects non-timeout error messages", func() {
-			Expect(isContextDeadlineExceededError("not found")).To(BeFalse())
-			Expect(isContextDeadlineExceededError("permission denied")).To(BeFalse())
-			Expect(isContextDeadlineExceededError("invalid input")).To(BeFalse())
-		})
-	})
-})
-
 var _ = Describe("isNetworkErrorRetryable", func() {
 	It("recognizes server timeout errors", func() {
 		err := apierrs.NewServerTimeout(schema.GroupResource{}, "test", 1)

--- a/pkg/reconciler/backup/volumesnapshot/reconciler.go
+++ b/pkg/reconciler/backup/volumesnapshot/reconciler.go
@@ -647,6 +647,15 @@ func (se *Reconciler) waitSnapshotToBeReady(
 	return nil, nil
 }
 
+// handleSnapshotErrors reacts to a VolumeSnapshot.Status.Error reported by
+// the CSI driver. There's no reliable way to tell a permanent condition (a
+// missing VolumeSnapshotClass, bad credentials, an error with no message at
+// all, ...) from a transient one, and a condition that looks permanent
+// today can become resolvable at any point (someone creates the missing
+// class, fixes the credentials, ...). So every error is retried the same
+// way, requeuing until backup.cnpg.io/volumeSnapshotDeadline elapses. The
+// external-snapshotter sidecar itself keeps retrying CreateSnapshot on its
+// own regardless of what CNPG does here.
 func (se *Reconciler) handleSnapshotErrors(
 	ctx context.Context,
 	backup *apiv1.Backup,
@@ -654,10 +663,6 @@ func (se *Reconciler) handleSnapshotErrors(
 ) (*ctrl.Result, error) {
 	contextLogger := log.FromContext(ctx).
 		WithName("handle_snapshot_errors")
-
-	if !snapshotErr.isRetryable() {
-		return nil, snapshotErr
-	}
 
 	if err := addDeadlineStatus(ctx, se.cli, backup); err != nil {
 		return nil, fmt.Errorf("while adding deadline status: %w", err)

--- a/pkg/reconciler/backup/volumesnapshot/reconciler_test.go
+++ b/pkg/reconciler/backup/volumesnapshot/reconciler_test.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
 	k8client "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
@@ -684,6 +685,80 @@ var _ = Describe("isDeadlineExceeded", func() {
 		exceeded, err := isDeadlineExceeded(backup)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(exceeded).To(BeTrue())
+	})
+})
+
+var _ = Describe("handleSnapshotErrors", func() {
+	var (
+		ctx      context.Context
+		backup   *apiv1.Backup
+		cli      k8client.Client
+		executor *Reconciler
+	)
+
+	BeforeEach(func() {
+		ctx = context.TODO()
+		backup = &apiv1.Backup{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "test-namespace",
+				Name:      "test-backup",
+			},
+			Status: apiv1.BackupStatus{
+				PluginMetadata: make(map[string]string),
+			},
+		}
+		cli = fake.NewClientBuilder().WithScheme(scheme.BuildWithAllKnownScheme()).
+			WithObjects(backup).
+			WithStatusSubresource(&apiv1.Backup{}).
+			Build()
+		executor = NewReconcilerBuilder(cli, record.NewFakeRecorder(3)).Build()
+	})
+
+	It("requeues a message that would previously have been treated as permanent", func() {
+		snapshotErr := &volumeSnapshotError{
+			InternalError: volumesnapshotv1.VolumeSnapshotError{
+				Message: ptr.To("Failed to get snapshot class with name wrongSnapshotClass"),
+			},
+			Name:      "snapshot",
+			Namespace: backup.Namespace,
+		}
+
+		res, err := executor.handleSnapshotErrors(ctx, backup, snapshotErr)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(res).To(BeEquivalentTo(&ctrl.Result{RequeueAfter: 10 * time.Second}))
+	})
+
+	It("requeues an error with no message at all", func() {
+		snapshotErr := &volumeSnapshotError{
+			InternalError: volumesnapshotv1.VolumeSnapshotError{Message: nil},
+			Name:          "snapshot",
+			Namespace:     backup.Namespace,
+		}
+
+		res, err := executor.handleSnapshotErrors(ctx, backup, snapshotErr)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(res).To(BeEquivalentTo(&ctrl.Result{RequeueAfter: 10 * time.Second}))
+	})
+
+	It("fails the backup once the deadline is exceeded, regardless of the message", func() {
+		data := metadata{VolumeSnapshotFirstDetectedFailure: time.Now().Add(-20 * time.Minute).Unix()}
+		rawData, err := json.Marshal(data)
+		Expect(err).ToNot(HaveOccurred())
+		backup.Status.PluginMetadata[pluginName] = string(rawData)
+		Expect(cli.Status().Update(ctx, backup)).To(Succeed())
+
+		snapshotErr := &volumeSnapshotError{
+			InternalError: volumesnapshotv1.VolumeSnapshotError{
+				Message: ptr.To("Failed to get snapshot class with name wrongSnapshotClass"),
+			},
+			Name:      "snapshot",
+			Namespace: backup.Namespace,
+		}
+
+		res, err := executor.handleSnapshotErrors(ctx, backup, snapshotErr)
+		Expect(res).To(BeNil())
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("deadline exceeded"))
 	})
 })
 

--- a/pkg/reconciler/backup/volumesnapshot/resources.go
+++ b/pkg/reconciler/backup/volumesnapshot/resources.go
@@ -70,20 +70,6 @@ func (err volumeSnapshotError) Error() string {
 	return *err.InternalError.Message
 }
 
-// IsRetryable returns true if the external snapshotter controller
-// will retry taking the snapshot
-func (err volumeSnapshotError) isRetryable() bool {
-	// The Kubernetes CSI driver/controller will automatically retry snapshot creation
-	// for certain errors, including timeouts. We use pattern matching to identify
-	// these retryable errors and handle them appropriately.
-
-	if err.InternalError.Message == nil {
-		return false
-	}
-
-	return isCSIErrorMessageRetriable(*err.InternalError.Message)
-}
-
 // slice represents a slice of []volumesnapshotv1.VolumeSnapshot
 type slice []volumesnapshotv1.VolumeSnapshot
 

--- a/pkg/reconciler/backup/volumesnapshot/resources_test.go
+++ b/pkg/reconciler/backup/volumesnapshot/resources_test.go
@@ -64,10 +64,9 @@ var _ = Describe("parseVolumeSnapshotInfo", func() {
 		Expect(err.InternalError).To(BeEquivalentTo(*volumeSnapshot.Status.Error))
 		Expect(err.Name).To(BeEquivalentTo("snapshot"))
 		Expect(err.Namespace).To(BeEquivalentTo("default"))
-		Expect(err.isRetryable()).To(BeFalse())
 	})
 
-	It("should detect retryable errors", func() {
+	It("should capture the message on a snapshot error", func() {
 		volumeSnapshot := &volumesnapshotv1.VolumeSnapshot{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "snapshot",
@@ -84,7 +83,6 @@ var _ = Describe("parseVolumeSnapshotInfo", func() {
 		info := parseVolumeSnapshotInfo(volumeSnapshot)
 
 		Expect(info.error).To(HaveOccurred())
-		Expect(info.error.isRetryable()).To(BeTrue())
 		Expect(info.ready).To(BeFalse())
 		Expect(info.provisioned).To(BeFalse())
 

--- a/tests/e2e/volume_snapshot_test.go
+++ b/tests/e2e/volume_snapshot_test.go
@@ -939,6 +939,13 @@ var _ = Describe("Verify Volume Snapshot",
 							ObjectMeta: metav1.ObjectMeta{
 								Namespace: namespace,
 								Name:      backupName,
+								Annotations: map[string]string{
+									// This now retries like any other volume snapshot
+									// error (see handleSnapshotErrors), so shorten the
+									// deadline to keep the test fast instead of waiting
+									// out the 10-minute default.
+									utils.BackupVolumeSnapshotDeadlineAnnotationName: "1",
+								},
 							},
 							Spec: apiv1.BackupSpec{
 								Target:  apiv1.BackupTargetPrimary,
@@ -949,6 +956,19 @@ var _ = Describe("Verify Volume Snapshot",
 					)
 					Expect(err).ToNot(HaveOccurred())
 
+					// The 1-minute deadline above means the backup should still be
+					// retrying, not failed, for at least the first half of that window.
+					Consistently(func(g Gomega) {
+						err = env.Client.Get(env.Ctx, types.NamespacedName{
+							Namespace: namespace,
+							Name:      backupName,
+						}, failedBackup)
+						g.Expect(err).ToNot(HaveOccurred())
+						g.Expect(failedBackup.Status.Phase).ToNot(BeEquivalentTo(apiv1.BackupPhaseFailed))
+					}, "30s", "5s").Should(Succeed())
+
+					// Allow extra margin over RetryTimeout for the 10s reconcile
+					// polling interval.
 					Eventually(func(g Gomega) {
 						err = env.Client.Get(env.Ctx, types.NamespacedName{
 							Namespace: namespace,
@@ -957,7 +977,7 @@ var _ = Describe("Verify Volume Snapshot",
 						g.Expect(err).ToNot(HaveOccurred())
 						g.Expect(failedBackup.Status.Phase).To(BeEquivalentTo(apiv1.BackupPhaseFailed))
 						g.Expect(failedBackup.Status.Error).To(ContainSubstring("Failed to get snapshot class"))
-					}, RetryTimeout).Should(Succeed())
+					}, RetryTimeout+30).Should(Succeed())
 				})
 
 				By("verifying that the backup connection is cleaned up", func() {


### PR DESCRIPTION
VolumeSnapshot.Status.Error is free text from the CSI driver, with no structured code, and its shape is provider-specific. CNPG classified some of these messages as permanent and failed the Backup instead of letting the existing volumeSnapshotDeadline-bounded retry loop run, but the pattern list only recognized Azure's wording: OCI's 409 "backup in progress" (#8608) and GCP's transient 502 both fell through and killed backups the CSI driver was about to complete on its own.

There's no reliable way to tell a permanent condition from a transient one in this text, and what looks permanent today, like a missing VolumeSnapshotClass or bad credentials, can resolve itself while CNPG is retrying. Always retry until the deadline (10 minutes by default) elapses instead of trying to classify the message, and drop the pattern matching entirely.

Closes #8608

Assisted-by: Claude

----

Add to the release notes:

```
Fixed a bug where a VolumeSnapshot backup could fail immediately on a transient error from some CSI drivers (for example OCI's "backup in progress" conflict, or a transient error from the GCP Persistent Disk driver) instead of retrying until the configured deadline.
```
