### PR TITLE
fix(walrestore): use timeline-aware barman-cloud end-of-WAL markers

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -69,6 +69,9 @@ linters:
       replace-local: true
       replace-allow-list:
         - github.com/cloudnative-pg/cloudnative-pg
+        # Temporary, remove together with the barman-cloud replace in go.mod
+        # once cloudnative-pg/barman-cloud#277 is merged and released.
+        - github.com/cloudnative-pg/barman-cloud
     gosec:
       excludes:
         - G101

--- a/config/crd/bases/postgresql.cnpg.io_clusters.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_clusters.yaml
@@ -1184,6 +1184,25 @@ spec:
                             format: int32
                             minimum: 1
                             type: integer
+                          restoreAdditionalCommandArgs:
+                            description: |-
+                              Additional arguments that can be appended to the 'barman-cloud-restore'
+                              command-line invocation. These arguments provide flexibility to customize
+                              the data restore process further, according to specific requirements or
+                              configurations.
+
+                              Example:
+                              In a scenario where specialized restore options are required, such as setting
+                              a specific read timeout or defining custom behavior, users can use this field
+                              to specify additional command arguments.
+
+                              Note:
+                              It's essential to ensure that the provided arguments are valid and supported
+                              by the 'barman-cloud-restore' command, to avoid potential errors or unintended
+                              behavior during execution.
+                            items:
+                              type: string
+                            type: array
                         type: object
                       destinationPath:
                         description: |-
@@ -2777,6 +2796,25 @@ spec:
                               format: int32
                               minimum: 1
                               type: integer
+                            restoreAdditionalCommandArgs:
+                              description: |-
+                                Additional arguments that can be appended to the 'barman-cloud-restore'
+                                command-line invocation. These arguments provide flexibility to customize
+                                the data restore process further, according to specific requirements or
+                                configurations.
+
+                                Example:
+                                In a scenario where specialized restore options are required, such as setting
+                                a specific read timeout or defining custom behavior, users can use this field
+                                to specify additional command arguments.
+
+                                Note:
+                                It's essential to ensure that the provided arguments are valid and supported
+                                by the 'barman-cloud-restore' command, to avoid potential errors or unintended
+                                behavior during execution.
+                              items:
+                                type: string
+                              type: array
                           type: object
                         destinationPath:
                           description: |-

--- a/go.mod
+++ b/go.mod
@@ -122,3 +122,5 @@ require (
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.4.0 // indirect
 )
+
+replace github.com/cloudnative-pg/barman-cloud => github.com/ardentperf/barman-cloud v0.0.0-20260708130229-a40d41ab4e97

--- a/go.mod
+++ b/go.mod
@@ -123,4 +123,4 @@ require (
 	sigs.k8s.io/structured-merge-diff/v6 v6.4.0 // indirect
 )
 
-replace github.com/cloudnative-pg/barman-cloud => github.com/ardentperf/barman-cloud v0.0.0-20260708130229-a40d41ab4e97
+replace github.com/cloudnative-pg/barman-cloud => github.com/ardentperf/barman-cloud v0.0.0-20260706155341-1953fc7a9396

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/Masterminds/semver/v3 v3.5.0 h1:kQceYJfbupGfZOKZQg0kou0DgAKhzDg2NZPAw
 github.com/Masterminds/semver/v3 v3.5.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/acobaugh/osrelease v0.1.0 h1:Yb59HQDGGNhCj4suHaFQQfBps5wyoKLSSX/J/+UifRE=
 github.com/acobaugh/osrelease v0.1.0/go.mod h1:4bFEs0MtgHNHBrmHCt67gNisnabCRAlzdVasCEGHTWY=
+github.com/ardentperf/barman-cloud v0.0.0-20260708130229-a40d41ab4e97 h1:JPF9DaAB6CMe6qTi5Lupn5nktGn635U2SPw6DyMrggw=
+github.com/ardentperf/barman-cloud v0.0.0-20260708130229-a40d41ab4e97/go.mod h1:PSCttn1xs8qNmwoTemDtVTqz9FMhSfKO2bSow8O+u5s=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/avast/retry-go/v5 v5.0.0 h1:kf1Qc2UsTZ4qq8elDymqfbISvkyMuhgRxuJqX2NHP7k=
@@ -18,8 +20,6 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cheynewallace/tabby v1.1.1 h1:JvUR8waht4Y0S3JF17G6Vhyt+FRhnqVCkk8l4YrOU54=
 github.com/cheynewallace/tabby v1.1.1/go.mod h1:Pba/6cUL8uYqvOc9RkyvFbHGrQ9wShyrn6/S/1OYVys=
-github.com/cloudnative-pg/barman-cloud v0.5.1 h1:vjkXrrxo2DQXHT9u9usqhtaHiPZ/lTfDVs/pIWYTepQ=
-github.com/cloudnative-pg/barman-cloud v0.5.1/go.mod h1:XPc5IUFP1y4cZX1sg+Pd8j9V4tmUEVnv3BGCpfQOOg8=
 github.com/cloudnative-pg/cnpg-i v0.5.0 h1:/TOzpNT6cwNgrpftTtrnLKdoHgMwd+88vZgXjlVgXeE=
 github.com/cloudnative-pg/cnpg-i v0.5.0/go.mod h1:7Gh4+UzhBpGhr4DreB1GN9wGYfvxwXCXZUyVt3zE/3I=
 github.com/cloudnative-pg/machinery v0.5.0 h1:hhTnkzn+AiN3NmbjCQ6RXj5rfqV3K6arzq6kdXAzcnQ=

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/Masterminds/semver/v3 v3.5.0 h1:kQceYJfbupGfZOKZQg0kou0DgAKhzDg2NZPAw
 github.com/Masterminds/semver/v3 v3.5.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/acobaugh/osrelease v0.1.0 h1:Yb59HQDGGNhCj4suHaFQQfBps5wyoKLSSX/J/+UifRE=
 github.com/acobaugh/osrelease v0.1.0/go.mod h1:4bFEs0MtgHNHBrmHCt67gNisnabCRAlzdVasCEGHTWY=
-github.com/ardentperf/barman-cloud v0.0.0-20260708130229-a40d41ab4e97 h1:JPF9DaAB6CMe6qTi5Lupn5nktGn635U2SPw6DyMrggw=
-github.com/ardentperf/barman-cloud v0.0.0-20260708130229-a40d41ab4e97/go.mod h1:PSCttn1xs8qNmwoTemDtVTqz9FMhSfKO2bSow8O+u5s=
+github.com/ardentperf/barman-cloud v0.0.0-20260706155341-1953fc7a9396 h1:EaZf7WY4neviFAoEdKLlRBDiD+HQmRya5A/k0Fcjw2g=
+github.com/ardentperf/barman-cloud v0.0.0-20260706155341-1953fc7a9396/go.mod h1:PSCttn1xs8qNmwoTemDtVTqz9FMhSfKO2bSow8O+u5s=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/avast/retry-go/v5 v5.0.0 h1:kf1Qc2UsTZ4qq8elDymqfbISvkyMuhgRxuJqX2NHP7k=

--- a/internal/cmd/manager/walrestore/cmd.go
+++ b/internal/cmd/manager/walrestore/cmd.go
@@ -192,9 +192,13 @@ func run(ctx context.Context, pgData string, podName string, args []string) erro
 	}
 
 	// Step 2: return error if the end-of-wal-stream flag is set.
+	// PostgreSQL treats a restore_command failure as "WAL not available from
+	// archive" and can then try streaming via primary_conninfo. When prefetch has
+	// already observed archive exhaustion for this timeline, return one failure to
+	// let PostgreSQL switch sources instead of repeatedly probing the archive.
 	// We skip this step if streaming connection is not available
 	if isStreamingAvailable(cluster, podName) {
-		if err := checkEndOfWALStreamFlag(walRestorer); err != nil {
+		if err := checkEndOfWALStreamFlag(walRestorer, walName); err != nil {
 			return err
 		}
 	}
@@ -226,16 +230,16 @@ func run(ctx context.Context, pgData string, podName string, args []string) erro
 		return walStatus[0].Err
 	}
 
-	// Step 5: set end-of-wal-stream flag if any download job returned file-not-found
+	// Step 5: set end-of-wal-stream flag if any regular WAL download job returned file-not-found
 	// We skip this step if streaming connection is not available
-	endOfWALStream := isEndOfWALStream(walStatus)
-	if isStreamingAvailable(cluster, podName) && endOfWALStream {
-		contextLog.Info(
-			"Set end-of-wal-stream flag as one of the WAL files to be prefetched was not found")
-
-		err = walRestorer.SetEndOfWALStream()
-		if err != nil {
+	endOfWALStream := false
+	if isStreamingAvailable(cluster, podName) {
+		if endOfWALStream, err = walRestorer.SetEndOfWALStreamFromResults(walStatus); err != nil {
 			return err
+		}
+		if endOfWALStream {
+			contextLog.Info(
+				"Set end-of-wal-stream flag as one of the WAL files to be prefetched was not found")
 		}
 	}
 
@@ -291,34 +295,16 @@ func restoreWALViaPlugins(
 	return client.RestoreWAL(ctx, cluster, walName, postgres.BuildWALPath(pgData, destinationPathName))
 }
 
-// checkEndOfWALStreamFlag returns ErrEndOfWALStreamReached if the flag is set in the restorer
-func checkEndOfWALStreamFlag(walRestorer *barmanRestorer.WALRestorer) error {
-	contain, err := walRestorer.IsEndOfWALStream()
+// checkEndOfWALStreamFlag returns ErrEndOfWALStreamReached if the flag is set for the requested WAL timeline.
+func checkEndOfWALStreamFlag(walRestorer *barmanRestorer.WALRestorer, walName string) error {
+	contains, err := walRestorer.ConsumeEndOfWALStreamForWAL(walName)
 	if err != nil {
 		return err
 	}
-
-	if contain {
-		err := walRestorer.ResetEndOfWalStream()
-		if err != nil {
-			return err
-		}
-
+	if contains {
 		return ErrEndOfWALStreamReached
 	}
 	return nil
-}
-
-// isEndOfWALStream returns true if one of the downloads has returned
-// a file-not-found error
-func isEndOfWALStream(results []barmanRestorer.Result) bool {
-	for _, result := range results {
-		if errors.Is(result.Err, barmanRestorer.ErrWALNotFound) {
-			return true
-		}
-	}
-
-	return false
 }
 
 // mergeEnv merges all the values inside incomingEnv into env

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -116,3 +116,5 @@ require (
 	sigs.k8s.io/structured-merge-diff/v6 v6.4.0 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
+
+replace github.com/cloudnative-pg/barman-cloud => github.com/ardentperf/barman-cloud v0.0.0-20260708130229-a40d41ab4e97

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -117,4 +117,4 @@ require (
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
-replace github.com/cloudnative-pg/barman-cloud => github.com/ardentperf/barman-cloud v0.0.0-20260708130229-a40d41ab4e97
+replace github.com/cloudnative-pg/barman-cloud => github.com/ardentperf/barman-cloud v0.0.0-20260706155341-1953fc7a9396

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -2,6 +2,8 @@ github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7Oputl
 github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
 github.com/Masterminds/semver/v3 v3.5.0 h1:kQceYJfbupGfZOKZQg0kou0DgAKhzDg2NZPAwZ/2OOE=
 github.com/Masterminds/semver/v3 v3.5.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
+github.com/ardentperf/barman-cloud v0.0.0-20260708130229-a40d41ab4e97 h1:JPF9DaAB6CMe6qTi5Lupn5nktGn635U2SPw6DyMrggw=
+github.com/ardentperf/barman-cloud v0.0.0-20260708130229-a40d41ab4e97/go.mod h1:PSCttn1xs8qNmwoTemDtVTqz9FMhSfKO2bSow8O+u5s=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/avast/retry-go/v5 v5.0.0 h1:kf1Qc2UsTZ4qq8elDymqfbISvkyMuhgRxuJqX2NHP7k=
@@ -12,8 +14,6 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cheynewallace/tabby v1.1.1 h1:JvUR8waht4Y0S3JF17G6Vhyt+FRhnqVCkk8l4YrOU54=
 github.com/cheynewallace/tabby v1.1.1/go.mod h1:Pba/6cUL8uYqvOc9RkyvFbHGrQ9wShyrn6/S/1OYVys=
-github.com/cloudnative-pg/barman-cloud v0.5.1 h1:vjkXrrxo2DQXHT9u9usqhtaHiPZ/lTfDVs/pIWYTepQ=
-github.com/cloudnative-pg/barman-cloud v0.5.1/go.mod h1:XPc5IUFP1y4cZX1sg+Pd8j9V4tmUEVnv3BGCpfQOOg8=
 github.com/cloudnative-pg/cnpg-i v0.5.0 h1:/TOzpNT6cwNgrpftTtrnLKdoHgMwd+88vZgXjlVgXeE=
 github.com/cloudnative-pg/cnpg-i v0.5.0/go.mod h1:7Gh4+UzhBpGhr4DreB1GN9wGYfvxwXCXZUyVt3zE/3I=
 github.com/cloudnative-pg/machinery v0.5.0 h1:hhTnkzn+AiN3NmbjCQ6RXj5rfqV3K6arzq6kdXAzcnQ=

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -2,8 +2,8 @@ github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7Oputl
 github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
 github.com/Masterminds/semver/v3 v3.5.0 h1:kQceYJfbupGfZOKZQg0kou0DgAKhzDg2NZPAwZ/2OOE=
 github.com/Masterminds/semver/v3 v3.5.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
-github.com/ardentperf/barman-cloud v0.0.0-20260708130229-a40d41ab4e97 h1:JPF9DaAB6CMe6qTi5Lupn5nktGn635U2SPw6DyMrggw=
-github.com/ardentperf/barman-cloud v0.0.0-20260708130229-a40d41ab4e97/go.mod h1:PSCttn1xs8qNmwoTemDtVTqz9FMhSfKO2bSow8O+u5s=
+github.com/ardentperf/barman-cloud v0.0.0-20260706155341-1953fc7a9396 h1:EaZf7WY4neviFAoEdKLlRBDiD+HQmRya5A/k0Fcjw2g=
+github.com/ardentperf/barman-cloud v0.0.0-20260706155341-1953fc7a9396/go.mod h1:PSCttn1xs8qNmwoTemDtVTqz9FMhSfKO2bSow8O+u5s=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/avast/retry-go/v5 v5.0.0 h1:kf1Qc2UsTZ4qq8elDymqfbISvkyMuhgRxuJqX2NHP7k=


### PR DESCRIPTION
A global end-of-WAL marker can be set by a parent-timeline prefetch miss and then consumed by a child-timeline restore request. In snapshot-restored replica flows, that can cause PostgreSQL to miss valid child-timeline WAL and replay wrong parent-timeline bytes. Reference https://github.com/cloudnative-pg/barman-cloud/issues/276

Update in-tree `wal-restore` to use the new `barman-cloud` restorer APIs:

- `ConsumeEndOfWALStreamForWAL`
- `SetEndOfWALStreamFromResults`

Depends on https://github.com/cloudnative-pg/barman-cloud/pull/277