### PR TITLE
feat: Capture shutdown diagnostics before immediate PostgreSQL shutdown

### DIFF
--- a/pkg/management/postgres/instance.go
+++ b/pkg/management/postgres/instance.go
@@ -682,6 +682,7 @@ func (instance *Instance) TryShuttingDownFastImmediate(ctx context.Context) erro
 	)
 	var exitError *exec.ExitError
 	if errors.As(err, &exitError) {
+		logShutdownDiagnostics(ctx)
 		contextLogger.Info("Graceful shutdown failed. Issuing immediate shutdown",
 			"exitCode", exitError.ExitCode())
 		err = instance.Shutdown(ctx,

--- a/pkg/management/postgres/shutdown_diagnostics.go
+++ b/pkg/management/postgres/shutdown_diagnostics.go
@@ -29,22 +29,64 @@ import (
 	"github.com/cloudnative-pg/machinery/pkg/log"
 )
 
-func logShutdownDiagnostics(ctx context.Context) {
-	diagCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
+const (
+	shutdownDiagnosticsSamples  = 3
+	shutdownDiagnosticsInterval = 3 * time.Second
+	// shutdownDiagnosticsFirstSampleWait caps how long the shutdown escalation
+	// waits for the first sample: reads of /proc/[pid]/{cmdline,status} can
+	// block in the kernel and cannot be cancelled from Go.
+	shutdownDiagnosticsFirstSampleWait = 3 * time.Second
+)
 
+// logShutdownDiagnostics logs a few samples of the state of the processes
+// still running in the container. It waits for the first sample, so that the
+// processes that resisted the fast shutdown are captured before the immediate
+// shutdown starts killing them, while the remaining samples are collected in
+// the background: the processes that survive them are the ones worth
+// investigating.
+func logShutdownDiagnostics(ctx context.Context) {
 	contextLogger := log.FromContext(ctx)
-	contextLogger.Info("PostgreSQL shutdown diagnostics",
-		"sample", 1,
-		"processes", collectProcDiagnostics(diagCtx, "/proc"))
-	time.Sleep(3 * time.Second)
-	contextLogger.Info("PostgreSQL shutdown diagnostics",
-		"sample", 2,
-		"processes", collectProcDiagnostics(diagCtx, "/proc"))
-	time.Sleep(3 * time.Second)
-	contextLogger.Info("PostgreSQL shutdown diagnostics",
-		"sample", 3,
-		"processes", collectProcDiagnostics(diagCtx, "/proc"))
+
+	firstSampleLogged := make(chan struct{})
+	go func() {
+		// The collection is detached from the caller's cancellation on
+		// purpose: the samples must survive the manager teardown that may
+		// be in progress while this code runs.
+		diagCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
+		defer cancel()
+
+		for sample := 1; sample <= shutdownDiagnosticsSamples; sample++ {
+			processes := collectProcDiagnostics(diagCtx, "/proc")
+			for i := range processes {
+				// One record per process: a single record with every process
+				// would exceed the 16KiB line limit enforced by the container
+				// runtimes, and would be split into fragments of invalid JSON.
+				contextLogger.Info("PostgreSQL shutdown diagnostics",
+					"sample", sample,
+					"pid", processes[i].PID,
+					"files", processes[i].Files)
+			}
+			if sample == 1 {
+				close(firstSampleLogged)
+			}
+			if sample == shutdownDiagnosticsSamples {
+				return
+			}
+
+			select {
+			case <-time.After(shutdownDiagnosticsInterval):
+			case <-diagCtx.Done():
+				return
+			}
+		}
+	}()
+
+	select {
+	case <-firstSampleLogged:
+	case <-time.After(shutdownDiagnosticsFirstSampleWait):
+		contextLogger.Info(
+			"Shutdown diagnostics collection is still running, proceeding with the immediate shutdown")
+	}
 }
 
 type procDiagnostics struct {
@@ -92,7 +134,7 @@ func collectProcDiagnostics(ctx context.Context, procRoot string) []procDiagnost
 }
 
 func readProcLines(fileName string, maxLines int, nullSeparated bool) []string {
-	data, err := os.ReadFile(fileName)
+	data, err := os.ReadFile(filepath.Clean(fileName))
 	if err != nil {
 		return []string{err.Error()}
 	}

--- a/pkg/management/postgres/shutdown_diagnostics.go
+++ b/pkg/management/postgres/shutdown_diagnostics.go
@@ -1,0 +1,112 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package postgres
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/cloudnative-pg/machinery/pkg/log"
+)
+
+func logShutdownDiagnostics(ctx context.Context) {
+	diagCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	contextLogger := log.FromContext(ctx)
+	contextLogger.Info("PostgreSQL shutdown diagnostics",
+		"sample", 1,
+		"processes", collectProcDiagnostics(diagCtx, "/proc"))
+	time.Sleep(3 * time.Second)
+	contextLogger.Info("PostgreSQL shutdown diagnostics",
+		"sample", 2,
+		"processes", collectProcDiagnostics(diagCtx, "/proc"))
+	time.Sleep(3 * time.Second)
+	contextLogger.Info("PostgreSQL shutdown diagnostics",
+		"sample", 3,
+		"processes", collectProcDiagnostics(diagCtx, "/proc"))
+}
+
+type procDiagnostics struct {
+	PID   string              `json:"pid"`
+	Files map[string][]string `json:"files"`
+}
+
+func collectProcDiagnostics(ctx context.Context, procRoot string) []procDiagnostics {
+	pids, err := filepath.Glob(filepath.Join(procRoot, "[0-9]*"))
+	if err != nil {
+		return []procDiagnostics{{
+			Files: map[string][]string{
+				"proc": {err.Error()},
+			},
+		}}
+	}
+
+	processes := make([]procDiagnostics, 0, len(pids))
+	for _, pidDir := range pids {
+		if err := ctx.Err(); err != nil {
+			return append(processes, procDiagnostics{
+				Files: map[string][]string{
+					"collection": {err.Error()},
+				},
+			})
+		}
+
+		pid := filepath.Base(pidDir)
+		processes = append(processes, procDiagnostics{
+			PID: pid,
+			Files: map[string][]string{
+				"cmdline": readProcLines(filepath.Join(pidDir, "cmdline"), 0, true),
+				"comm":    readProcLines(filepath.Join(pidDir, "comm"), 0, false),
+				"status":  readProcLines(filepath.Join(pidDir, "status"), 90, false),
+				"wchan":   readProcLines(filepath.Join(pidDir, "wchan"), 0, false),
+				"io":      readProcLines(filepath.Join(pidDir, "io"), 0, false),
+				// stack and syscall are often ptrace/capability gated; log read errors inline.
+				"syscall": readProcLines(filepath.Join(pidDir, "syscall"), 0, false),
+				"stack":   readProcLines(filepath.Join(pidDir, "stack"), 0, false),
+				"sched":   readProcLines(filepath.Join(pidDir, "sched"), 35, false),
+			},
+		})
+	}
+	return processes
+}
+
+func readProcLines(fileName string, maxLines int, nullSeparated bool) []string {
+	data, err := os.ReadFile(fileName)
+	if err != nil {
+		return []string{err.Error()}
+	}
+
+	content := string(data)
+	if nullSeparated {
+		content = strings.ReplaceAll(content, "\x00", " ")
+	}
+	var result []string
+	for lineNumber, line := range strings.Split(strings.TrimRight(content, "\n"), "\n") {
+		if maxLines > 0 && lineNumber >= maxLines {
+			break
+		}
+		result = append(result, strings.Join(strings.Fields(line), " "))
+	}
+	return result
+}

--- a/pkg/management/postgres/shutdown_diagnostics_test.go
+++ b/pkg/management/postgres/shutdown_diagnostics_test.go
@@ -32,7 +32,7 @@ var _ = Describe("shutdown diagnostics", func() {
 	It("collects process information from procfs", func() {
 		procRoot := GinkgoT().TempDir()
 		pidDir := filepath.Join(procRoot, "123")
-		Expect(os.Mkdir(pidDir, 0o755)).To(Succeed())
+		Expect(os.Mkdir(pidDir, 0o750)).To(Succeed())
 
 		files := map[string]string{
 			"cmdline": "postgres\x00autovacuum worker\x00",
@@ -40,7 +40,6 @@ var _ = Describe("shutdown diagnostics", func() {
 			"status":  "Name:\tpostgres\nState:\tT (stopped)\n",
 			"wchan":   "do_signal_stop\n",
 			"io":      "read_bytes: 0\n",
-			"limits":  "Limit Soft Limit Hard Limit Units\n",
 			"syscall": "operation not permitted\n",
 			"stack":   "permission denied\n",
 			"sched":   "postgres (123, #threads: 1)\n",

--- a/pkg/management/postgres/shutdown_diagnostics_test.go
+++ b/pkg/management/postgres/shutdown_diagnostics_test.go
@@ -1,0 +1,60 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package postgres
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("shutdown diagnostics", func() {
+	It("collects process information from procfs", func() {
+		procRoot := GinkgoT().TempDir()
+		pidDir := filepath.Join(procRoot, "123")
+		Expect(os.Mkdir(pidDir, 0o755)).To(Succeed())
+
+		files := map[string]string{
+			"cmdline": "postgres\x00autovacuum worker\x00",
+			"comm":    "postgres\n",
+			"status":  "Name:\tpostgres\nState:\tT (stopped)\n",
+			"wchan":   "do_signal_stop\n",
+			"io":      "read_bytes: 0\n",
+			"limits":  "Limit Soft Limit Hard Limit Units\n",
+			"syscall": "operation not permitted\n",
+			"stack":   "permission denied\n",
+			"sched":   "postgres (123, #threads: 1)\n",
+		}
+		for name, content := range files {
+			Expect(os.WriteFile(filepath.Join(pidDir, name), []byte(content), 0o600)).To(Succeed())
+		}
+
+		processes := collectProcDiagnostics(context.Background(), procRoot)
+
+		Expect(processes).To(HaveLen(1))
+		Expect(processes[0]).To(HaveField("PID", "123"))
+		Expect(processes[0].Files["cmdline"]).To(Equal([]string{"postgres autovacuum worker"}))
+		Expect(processes[0].Files["status"]).To(ContainElement("State: T (stopped)"))
+		Expect(processes[0].Files["wchan"]).To(Equal([]string{"do_signal_stop"}))
+	})
+})


### PR DESCRIPTION
## Summary

This change adds a minimal instance-manager diagnostics collector that runs only when a fast PostgreSQL shutdown fails and CloudNativePG is about to issue `pg_ctl -m immediate stop`.

The collector logs three structured diagnostics records, one immediately and two more at three-second intervals, under the existing short diagnostics timeout. Each record contains a `sample` number and a `processes` payload collected from `/proc/[0-9]*`.

A related PostgreSQL hackers thread documents a real-world shutdown stall involving autovacuum which occurred on CNPG: https://www.postgresql.org/message-id/flat/CA%2BfnDAa8Kbbx3KkqpfxutTx41RchJsT3Lykqwcedm0CVr5Tw%3DA%40mail.gmail.com

The goal here is not to change shutdown semantics. It is to preserve diagnostic evidence immediately before CNPG requests abortive PostgreSQL shutdown. Currently, when shutdown hangs until CloudNativePG escalates to immediate shutdown, the remaining PostgreSQL process state is the most useful evidence but is often lost as the pod exits or is killed.

- Adds `pkg/management/postgres/shutdown_diagnostics.go`.
- Calls `logShutdownDiagnostics(ctx)` only from `TryShuttingDownFastImmediate`, after fast shutdown returns an `exec.ExitError` and before issuing immediate shutdown.
- Reads procfs directly instead of depending on `ps` or a process-listing library.
- Emits three structured log records:
  - `message`: `PostgreSQL shutdown diagnostics`
  - `sample`: `1`, `2`, or `3`
  - `processes`: array of `{ pid, files }`
- Collects `cmdline`, `comm`, `status`, `wchan`, `io`, `syscall`, `stack`, and `sched`.
- Trims leading/trailing whitespace from collected procfs lines to reduce payload size while preserving internal formatting.
- Stores proc read failures directly in the relevant field value, for example:
  - `"stack": ["open /proc/123/stack: permission denied"]`
- Keeps `stack` and `syscall` reads best-effort because they are often ptrace/capability gated.
- Keeps `io` and `sched` because three samples make per-process IO and scheduling counters useful for identifying whether a stuck backend is making progress.

Example shape:

```json
{
  "msg": "PostgreSQL shutdown diagnostics",
  "sample": 1,
  "processes": [
    {
      "pid": "123",
      "files": {
        "cmdline": ["postgres autovacuum worker"],
        "comm": ["postgres"],
        "status": ["Name:\tpostgres", "State:\tT (stopped)"],
        "io": ["rchar: 208321", "write_bytes: 0"],
        "sched": ["postgres (123, #threads: 1)", "nr_switches : 8"],
        "wchan": ["do_signal_stop"]
      }
    }
  ]
}
```

## Testing

Ran:

```console
go test ./pkg/management/postgres/...
```

The test coverage verifies that:

- procfs process data is collected into the structured payload;
- null-separated `cmdline` content is normalized;
- leading/trailing whitespace is removed from collected lines.

Also validated manually in AKS with a custom CNPG image:

- Built the modified manager and overlaid it on `ghcr.io/cloudnative-pg/cloudnative-pg:1.29.2`.
- Deployed the custom image as both the operator image and `OPERATOR_IMAGE_NAME`.
- Created a one-instance cluster with `stopDelay: 30` and `switchoverDelay: 30`.
- Started a user `psql` session, found its PostgreSQL backend, and sent `SIGSTOP`.
- Confirmed `/proc/<pid>/status` showed `State: T (stopped)` and `/proc/<pid>/wchan` showed `do_signal_stop`.
- Fenced the instance to trigger the fast-then-immediate shutdown path.
- Verified fast shutdown timed out, three diagnostics records were emitted, the stopped backend appeared in all samples, and immediate shutdown followed.

Closes #11136 