### PR TITLE
fix(instance): skip startup probe during active WAL replay

### DIFF
--- a/internal/cmd/manager/instance/run/cmd.go
+++ b/internal/cmd/manager/instance/run/cmd.go
@@ -308,6 +308,7 @@ func runSubCommand( //nolint: gocyclo,gocognit
 	// postgres CSV logs handler (PGAudit too)
 	postgresLogPipe := logpipe.NewLogPipe(logpipe.MultiRecordWriter{
 		newWALReplayErrorDetector(instance),
+		newWALReplayProgressDetector(instance),
 		&logpipe.LogRecordWriter{},
 	})
 	if err := mgr.Add(postgresLogPipe); err != nil {

--- a/internal/cmd/manager/instance/run/cmd.go
+++ b/internal/cmd/manager/instance/run/cmd.go
@@ -306,8 +306,10 @@ func runSubCommand( //nolint: gocyclo,gocognit
 	}
 
 	// postgres CSV logs handler (PGAudit too)
-	postgresLogPipe := logpipe.NewLogPipe(
-		newWALReplayErrorDetector(instance, &logpipe.LogRecordWriter{}))
+	postgresLogPipe := logpipe.NewLogPipe(logpipe.MultiRecordWriter{
+		newWALReplayErrorDetector(instance),
+		&logpipe.LogRecordWriter{},
+	})
 	if err := mgr.Add(postgresLogPipe); err != nil {
 		contextLogger.Error(err, "unable to add CSV logs handler")
 		return err

--- a/internal/cmd/manager/instance/run/cmd.go
+++ b/internal/cmd/manager/instance/run/cmd.go
@@ -306,7 +306,8 @@ func runSubCommand( //nolint: gocyclo,gocognit
 	}
 
 	// postgres CSV logs handler (PGAudit too)
-	postgresLogPipe := logpipe.NewLogPipe()
+	postgresLogPipe := logpipe.NewLogPipe(
+		newWALReplayErrorDetector(instance, &logpipe.LogRecordWriter{}))
 	if err := mgr.Add(postgresLogPipe); err != nil {
 		contextLogger.Error(err, "unable to add CSV logs handler")
 		return err

--- a/internal/cmd/manager/instance/run/wal_replay_detector.go
+++ b/internal/cmd/manager/instance/run/wal_replay_detector.go
@@ -1,0 +1,107 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package run
+
+import (
+	"fmt"
+	"regexp"
+	"time"
+
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres/logpipe"
+)
+
+const (
+	walReplayErrorThreshold = 3
+	walReplayErrorWindow    = 10 * time.Minute
+	walReplayStalledError   = "unrecoverable WAL replay error loop detected"
+)
+
+var (
+	incorrectPrevLinkRegex = regexp.MustCompile(`record with incorrect prev-link [0-9A-F]+/[0-9A-F]+ at ([0-9A-F]+/[0-9A-F]+)`)
+	contrecordRegex        = regexp.MustCompile(`contrecord is requested by ([0-9A-F]+/[0-9A-F]+)`)
+)
+
+type walReplayErrorDetector struct {
+	instance *postgres.Instance
+	next     logpipe.RecordWriter
+	now      func() time.Time
+
+	lsn       string
+	count     int
+	firstSeen time.Time
+}
+
+func newWALReplayErrorDetector(instance *postgres.Instance, next logpipe.RecordWriter) logpipe.RecordWriter {
+	return &walReplayErrorDetector{
+		instance: instance,
+		next:     next,
+		now:      time.Now,
+	}
+}
+
+func (d *walReplayErrorDetector) Write(record logpipe.NamedRecord) {
+	d.next.Write(record)
+
+	logRecord, ok := record.(*logpipe.LoggingRecord)
+	if !ok {
+		return
+	}
+
+	lsn := walReplayFailureLSN(logRecord.Message)
+	if lsn == "" {
+		return
+	}
+
+	primary, err := d.instance.IsPrimary()
+	if err != nil || primary {
+		return
+	}
+
+	now := d.now()
+	if d.lsn != lsn || now.Sub(d.firstSeen) > walReplayErrorWindow {
+		d.lsn = lsn
+		d.count = 1
+		d.firstSeen = now
+		return
+	}
+
+	d.count++
+	if d.count != walReplayErrorThreshold {
+		return
+	}
+
+	d.instance.SetCanCheckReadiness(false)
+	d.instance.SetStatusError(fmt.Sprintf(
+		"%s after %d repeated errors at the same LSN",
+		walReplayStalledError,
+		d.count,
+	))
+}
+
+func walReplayFailureLSN(message string) string {
+	if match := incorrectPrevLinkRegex.FindStringSubmatch(message); len(match) == 2 {
+		return match[1]
+	}
+	if match := contrecordRegex.FindStringSubmatch(message); len(match) == 2 {
+		return match[1]
+	}
+	return ""
+}

--- a/internal/cmd/manager/instance/run/wal_replay_detector.go
+++ b/internal/cmd/manager/instance/run/wal_replay_detector.go
@@ -41,7 +41,6 @@ var (
 
 type walReplayErrorDetector struct {
 	instance *postgres.Instance
-	next     logpipe.RecordWriter
 	now      func() time.Time
 
 	lsn       string
@@ -49,17 +48,14 @@ type walReplayErrorDetector struct {
 	firstSeen time.Time
 }
 
-func newWALReplayErrorDetector(instance *postgres.Instance, next logpipe.RecordWriter) logpipe.RecordWriter {
+func newWALReplayErrorDetector(instance *postgres.Instance) logpipe.RecordWriter {
 	return &walReplayErrorDetector{
 		instance: instance,
-		next:     next,
 		now:      time.Now,
 	}
 }
 
 func (d *walReplayErrorDetector) Write(record logpipe.NamedRecord) {
-	d.next.Write(record)
-
 	logRecord, ok := record.(*logpipe.LoggingRecord)
 	if !ok {
 		return

--- a/internal/cmd/manager/instance/run/wal_replay_detector_test.go
+++ b/internal/cmd/manager/instance/run/wal_replay_detector_test.go
@@ -1,0 +1,114 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package run
+
+import (
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres/logpipe"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+type spyRecordWriter struct {
+	count int
+}
+
+func (s *spyRecordWriter) Write(logpipe.NamedRecord) {
+	s.count++
+}
+
+var _ = Describe("newWALReplayErrorDetector", func() {
+	var (
+		instance *postgres.Instance
+		writer   *spyRecordWriter
+		detector *walReplayErrorDetector
+		now      time.Time
+	)
+
+	BeforeEach(func() {
+		pgData := GinkgoT().TempDir()
+		Expect(os.WriteFile(filepath.Join(pgData, "standby.signal"), nil, 0o600)).To(Succeed())
+		instance = &postgres.Instance{PgData: pgData}
+		instance.SetCanCheckReadiness(true)
+		writer = &spyRecordWriter{}
+		now = time.Date(2026, 7, 5, 0, 0, 0, 0, time.UTC)
+		detector = newWALReplayErrorDetector(instance, writer).(*walReplayErrorDetector)
+		detector.now = func() time.Time { return now }
+	})
+
+	writeMessage := func(message string) {
+		detector.Write(&logpipe.LoggingRecord{Message: message})
+	}
+
+	It("should mark a replica unhealthy after three errors at the same LSN", func() {
+		writeMessage("record with incorrect prev-link 0/59002E00 at 0/5A000028")
+		writeMessage("contrecord is requested by 0/5A000028")
+		writeMessage("record with incorrect prev-link 0/59002E00 at 0/5A000028")
+
+		Expect(instance.CanCheckReadiness()).To(BeFalse())
+		Expect(instance.StatusError()).To(ContainSubstring(walReplayStalledError))
+		Expect(instance.StatusError()).To(ContainSubstring("same LSN"))
+		Expect(writer.count).To(Equal(3))
+	})
+
+	It("should reset the counter when the failure LSN changes", func() {
+		writeMessage("record with incorrect prev-link 0/59002E00 at 0/5A000028")
+		writeMessage("record with incorrect prev-link 0/59002E00 at 0/5A000030")
+		writeMessage("record with incorrect prev-link 0/59002E00 at 0/5A000030")
+
+		Expect(instance.CanCheckReadiness()).To(BeTrue())
+		Expect(instance.StatusError()).To(BeEmpty())
+	})
+
+	It("should reset the counter when the repeated error is outside the window", func() {
+		writeMessage("contrecord is requested by 0/5A000028")
+		writeMessage("contrecord is requested by 0/5A000028")
+		now = now.Add(walReplayErrorWindow + time.Second)
+		writeMessage("contrecord is requested by 0/5A000028")
+
+		Expect(instance.CanCheckReadiness()).To(BeTrue())
+		Expect(instance.StatusError()).To(BeEmpty())
+	})
+
+	It("should not mark primaries unhealthy", func() {
+		instance.PgData = GinkgoT().TempDir()
+
+		writeMessage("record with incorrect prev-link 0/59002E00 at 0/5A000028")
+		writeMessage("record with incorrect prev-link 0/59002E00 at 0/5A000028")
+		writeMessage("record with incorrect prev-link 0/59002E00 at 0/5A000028")
+
+		Expect(instance.CanCheckReadiness()).To(BeTrue())
+		Expect(instance.StatusError()).To(BeEmpty())
+	})
+
+	It("should ignore generic PANIC messages", func() {
+		writeMessage("PANIC: could not locate a valid checkpoint record")
+		writeMessage("PANIC: could not locate a valid checkpoint record")
+		writeMessage("PANIC: could not locate a valid checkpoint record")
+
+		Expect(instance.CanCheckReadiness()).To(BeTrue())
+		Expect(instance.StatusError()).To(BeEmpty())
+	})
+})

--- a/internal/cmd/manager/instance/run/wal_replay_detector_test.go
+++ b/internal/cmd/manager/instance/run/wal_replay_detector_test.go
@@ -31,18 +31,9 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-type spyRecordWriter struct {
-	count int
-}
-
-func (s *spyRecordWriter) Write(logpipe.NamedRecord) {
-	s.count++
-}
-
 var _ = Describe("newWALReplayErrorDetector", func() {
 	var (
 		instance *postgres.Instance
-		writer   *spyRecordWriter
 		detector *walReplayErrorDetector
 		now      time.Time
 	)
@@ -52,9 +43,8 @@ var _ = Describe("newWALReplayErrorDetector", func() {
 		Expect(os.WriteFile(filepath.Join(pgData, "standby.signal"), nil, 0o600)).To(Succeed())
 		instance = &postgres.Instance{PgData: pgData}
 		instance.SetCanCheckReadiness(true)
-		writer = &spyRecordWriter{}
 		now = time.Date(2026, 7, 5, 0, 0, 0, 0, time.UTC)
-		detector = newWALReplayErrorDetector(instance, writer).(*walReplayErrorDetector)
+		detector = newWALReplayErrorDetector(instance).(*walReplayErrorDetector)
 		detector.now = func() time.Time { return now }
 	})
 
@@ -70,7 +60,6 @@ var _ = Describe("newWALReplayErrorDetector", func() {
 		Expect(instance.CanCheckReadiness()).To(BeFalse())
 		Expect(instance.StatusError()).To(ContainSubstring(walReplayStalledError))
 		Expect(instance.StatusError()).To(ContainSubstring("same LSN"))
-		Expect(writer.count).To(Equal(3))
 	})
 
 	It("should reset the counter when the failure LSN changes", func() {

--- a/internal/cmd/manager/instance/run/wal_replay_progress_detector.go
+++ b/internal/cmd/manager/instance/run/wal_replay_progress_detector.go
@@ -1,0 +1,65 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package run
+
+import (
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres/logpipe"
+)
+
+var walReplayProgressRegex = regexp.MustCompile(`redo in progress, elapsed time: .* current LSN: [0-9A-F]+/[0-9A-F]+`)
+
+type walReplayProgressDetector struct {
+	instance *postgres.Instance
+}
+
+func newWALReplayProgressDetector(instance *postgres.Instance) logpipe.RecordWriter {
+	return &walReplayProgressDetector{
+		instance: instance,
+	}
+}
+
+func (d *walReplayProgressDetector) Write(record logpipe.NamedRecord) {
+	// Once startup completed, this detector is permanently disabled for this
+	// process and should avoid doing any more per-log-message work.
+	if d.instance.IsWALReplayProgressDetectionStopped() {
+		return
+	}
+
+	logRecord, ok := record.(*logpipe.LoggingRecord)
+	if !ok {
+		return
+	}
+
+	if strings.Contains(logRecord.Message, "database system is ready to accept") {
+		d.instance.StopWALReplayProgressDetection()
+		return
+	}
+
+	if !walReplayProgressRegex.MatchString(logRecord.Message) {
+		return
+	}
+
+	d.instance.SetWALReplayProgressLastObservedAt(time.Now())
+}

--- a/internal/cmd/manager/instance/run/wal_replay_progress_detector_test.go
+++ b/internal/cmd/manager/instance/run/wal_replay_progress_detector_test.go
@@ -1,0 +1,89 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package run
+
+import (
+	"time"
+
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres/logpipe"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("newWALReplayProgressDetector", func() {
+	var (
+		instance *postgres.Instance
+		detector *walReplayProgressDetector
+	)
+
+	BeforeEach(func() {
+		instance = &postgres.Instance{}
+		detector = newWALReplayProgressDetector(instance).(*walReplayProgressDetector)
+	})
+
+	writeMessage := func(message string) {
+		detector.Write(&logpipe.LoggingRecord{Message: message})
+	}
+
+	It("records progress when it sees a redo progress message", func() {
+		before := time.Now()
+		writeMessage("redo in progress, elapsed time: 1.00 s, current LSN: 0/3000000")
+		after := time.Now()
+
+		lastObservedAt := instance.GetWALReplayProgressLastObservedAt()
+		Expect(lastObservedAt).To(BeTemporally(">=", before))
+		Expect(lastObservedAt).To(BeTemporally("<=", after))
+	})
+
+	It("refreshes progress when it sees another redo progress message", func() {
+		writeMessage("redo in progress, elapsed time: 1.00 s, current LSN: 0/3000000")
+		before := time.Now()
+		writeMessage("redo in progress, elapsed time: 11.00 s, current LSN: 0/3000000")
+		after := time.Now()
+
+		lastObservedAt := instance.GetWALReplayProgressLastObservedAt()
+		Expect(lastObservedAt).To(BeTemporally(">=", before))
+		Expect(lastObservedAt).To(BeTemporally("<=", after))
+	})
+
+	It("ignores non-progress messages", func() {
+		writeMessage("redo starts at 0/3000000")
+		writeMessage("database system was interrupted; last known up at 2026-07-06 00:00:00 UTC")
+
+		lastObservedAt := instance.GetWALReplayProgressLastObservedAt()
+		Expect(lastObservedAt).To(BeTemporally("==", time.Unix(0, 0)))
+	})
+
+	It("stops detecting progress once the startup probe has succeeded", func() {
+		instance.StopWALReplayProgressDetection()
+		writeMessage("redo in progress, elapsed time: 1.00 s, current LSN: 0/3000000")
+
+		Expect(instance.IsWALReplayProgressDetectionStopped()).To(BeTrue())
+	})
+
+	It("stops detecting progress once PostgreSQL accepts connections", func() {
+		writeMessage("database system is ready to accept connections")
+		writeMessage("redo in progress, elapsed time: 1.00 s, current LSN: 0/3000000")
+
+		Expect(instance.IsWALReplayProgressDetectionStopped()).To(BeTrue())
+	})
+})

--- a/pkg/management/postgres/instance.go
+++ b/pkg/management/postgres/instance.go
@@ -208,6 +208,12 @@ type Instance struct {
 	// mightBeUnavailable specifies whether we expect the instance to be down
 	mightBeUnavailable atomic.Bool
 
+	// statusError causes GetStatus to fail when non-empty; an empty string means no error.
+	// It is currently only used by the WAL replay detector, which expects this
+	// process-local state to be cleared by restarting the Pod. Future use cases
+	// need to carefully define when this value should be cleared.
+	statusError atomic.String
+
 	// fenced specifies whether fencing is on for the instance
 	// fenced entails mightBeUnavailable ( entails as in logical consequence)
 	fenced atomic.Bool
@@ -275,6 +281,14 @@ func (instance *Instance) SetPostgreSQLAutoConfWritable(writeable bool) error {
 // IsReady runs PgIsReady
 func (instance *Instance) IsReady() error {
 	return PgIsReady()
+}
+
+func (instance *Instance) SetStatusError(message string) {
+	instance.statusError.Store(message)
+}
+
+func (instance *Instance) StatusError() string {
+	return instance.statusError.Load()
 }
 
 // IsFenced checks whether the instance is marked as fenced
@@ -824,7 +838,7 @@ func (instance *Instance) WithActiveInstance(inner func() error) error {
 	// back to creating regular files, and their log output is silently lost.
 	ctx, ctxCancel := context.WithCancel(context.Background())
 
-	csvPipe := logpipe.NewLogPipe()
+	csvPipe := logpipe.NewLogPipe(&logpipe.LogRecordWriter{})
 	go func() {
 		if err := csvPipe.Start(ctx); err != nil {
 			log.Info("csv log pipe encountered an error", "err", err)

--- a/pkg/management/postgres/instance.go
+++ b/pkg/management/postgres/instance.go
@@ -76,6 +76,8 @@ const (
 	pqPingReject     = 1 // server is alive but rejecting connections
 	pqPingNoResponse = 2 // could not establish connection
 	pgPingNoAttempt  = 3 // connection not attempted (bad params)
+
+	walReplayProgressDetectionStopped = math.MaxInt64
 )
 
 // GetPostgresExecutableName returns the name of the PostgreSQL executable
@@ -214,6 +216,10 @@ type Instance struct {
 	// need to carefully define when this value should be cleared.
 	statusError atomic.String
 
+	// walReplayProgressLastObservedAtUnixNano specifies when PostgreSQL last reported WAL replay progress
+	// Uses walReplayProgressDetectionStopped when progress detection can stop
+	walReplayProgressLastObservedAtUnixNano atomic.Int64
+
 	// fenced specifies whether fencing is on for the instance
 	// fenced entails mightBeUnavailable ( entails as in logical consequence)
 	fenced atomic.Bool
@@ -289,6 +295,30 @@ func (instance *Instance) SetStatusError(message string) {
 
 func (instance *Instance) StatusError() string {
 	return instance.statusError.Load()
+}
+
+// SetWALReplayProgressLastObservedAt records when PostgreSQL last reported WAL
+// replay progress during startup.
+func (instance *Instance) SetWALReplayProgressLastObservedAt(observedAt time.Time) {
+	instance.walReplayProgressLastObservedAtUnixNano.Store(observedAt.UnixNano())
+}
+
+// StopWALReplayProgressDetection marks WAL replay progress detection as no
+// longer needed for this process.
+func (instance *Instance) StopWALReplayProgressDetection() {
+	instance.walReplayProgressLastObservedAtUnixNano.Store(walReplayProgressDetectionStopped)
+}
+
+// IsWALReplayProgressDetectionStopped returns true when WAL replay progress
+// detection has been stopped for this process.
+func (instance *Instance) IsWALReplayProgressDetectionStopped() bool {
+	return instance.walReplayProgressLastObservedAtUnixNano.Load() == walReplayProgressDetectionStopped
+}
+
+// GetWALReplayProgressLastObservedAt returns the latest PostgreSQL startup
+// progress log observation timestamp.
+func (instance *Instance) GetWALReplayProgressLastObservedAt() time.Time {
+	return time.Unix(0, instance.walReplayProgressLastObservedAtUnixNano.Load())
 }
 
 // IsFenced checks whether the instance is marked as fenced

--- a/pkg/management/postgres/instance_test.go
+++ b/pkg/management/postgres/instance_test.go
@@ -26,6 +26,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/cloudnative-pg/machinery/pkg/fileutils"
 	"github.com/jackc/pgx/v5/pgconn"
@@ -247,6 +248,33 @@ var _ = Describe("status error state", func() {
 		status, err := instance.GetStatus()
 		Expect(err).To(MatchError(ContainSubstring("WAL replay error")))
 		Expect(status.Pod.Name).To(BeEmpty())
+	})
+})
+
+var _ = Describe("WAL replay progress", func() {
+	It("stores when WAL replay progress was last observed", func() {
+		instance := &Instance{}
+		now := time.Date(2026, 7, 6, 0, 0, 0, 0, time.UTC)
+
+		instance.SetWALReplayProgressLastObservedAt(now)
+
+		lastObservedAt := instance.GetWALReplayProgressLastObservedAt()
+		Expect(lastObservedAt).To(BeTemporally("==", now))
+	})
+
+	It("returns the Unix epoch when WAL replay progress has not been observed", func() {
+		instance := &Instance{}
+
+		lastObservedAt := instance.GetWALReplayProgressLastObservedAt()
+		Expect(lastObservedAt).To(BeTemporally("==", time.Unix(0, 0)))
+	})
+
+	It("tracks when WAL replay progress detection has stopped", func() {
+		instance := &Instance{}
+
+		instance.StopWALReplayProgressDetection()
+
+		Expect(instance.IsWALReplayProgressDetectionStopped()).To(BeTrue())
 	})
 })
 

--- a/pkg/management/postgres/instance_test.go
+++ b/pkg/management/postgres/instance_test.go
@@ -237,6 +237,19 @@ var _ = Describe("check atomic bool", func() {
 	})
 })
 
+var _ = Describe("status error state", func() {
+	It("should make status fail with the stored error", func() {
+		instance := Instance{}
+		instance.SetStatusError("unrecoverable WAL replay error loop detected")
+
+		Expect(instance.StatusError()).To(ContainSubstring("WAL replay error"))
+
+		status, err := instance.GetStatus()
+		Expect(err).To(MatchError(ContainSubstring("WAL replay error")))
+		Expect(status.Pod.Name).To(BeEmpty())
+	})
+})
+
 var _ = Describe("ALTER SYSTEM enable and disable in PostgreSQL <17", func() {
 	var instance Instance
 	var autoConfFile string

--- a/pkg/management/postgres/logpipe/logpipe.go
+++ b/pkg/management/postgres/logpipe/logpipe.go
@@ -44,6 +44,7 @@ import (
 type LogPipe struct {
 	fileName        string
 	record          CSVRecordParser
+	writer          RecordWriter
 	fieldsValidator FieldsValidator
 
 	initialized *concurrency.Executed
@@ -56,11 +57,12 @@ var tagRegex = regexp.MustCompile(`(?s)(?P<Tag>^[a-zA-Z]+): (?P<Record>.*)$`)
 // for a specific log line to be parsed
 type FieldsValidator func(int) *ErrFieldCountExtended
 
-// NewLogPipe returns a new LogPipe
-func NewLogPipe() *LogPipe {
+// NewLogPipe returns a new LogPipe using the passed record writer
+func NewLogPipe(writer RecordWriter) *LogPipe {
 	return &LogPipe{
 		fileName:        filepath.Join(postgres.LogPath, postgres.LogFileName+".csv"),
 		record:          NewPgAuditLoggingDecorator(),
+		writer:          writer,
 		fieldsValidator: LogFieldValidator,
 
 		initialized: concurrency.NewExecuted(),
@@ -151,7 +153,7 @@ func (p *LogPipe) collectLogsFromFile(ctx context.Context) error {
 	// the cancellation signal happened
 	go func() {
 		defer close(errChan)
-		errChan <- p.streamLogFromCSVFile(ctx, f, &LogRecordWriter{})
+		errChan <- p.streamLogFromCSVFile(ctx, f, p.writer)
 	}()
 	select {
 	case <-ctx.Done():

--- a/pkg/management/postgres/logpipe/logpipe_test.go
+++ b/pkg/management/postgres/logpipe/logpipe_test.go
@@ -40,6 +40,17 @@ func (writer *SpyRecordWriter) Write(record NamedRecord) {
 }
 
 var _ = Describe("CSV file reader", func() {
+	It("can write records to multiple writers", func() {
+		record := &LoggingRecord{Message: "test"}
+		writerOne := SpyRecordWriter{}
+		writerTwo := SpyRecordWriter{}
+
+		MultiRecordWriter{&writerOne, &writerTwo}.Write(record)
+
+		Expect(writerOne.records).To(ConsistOf(record))
+		Expect(writerTwo.records).To(ConsistOf(record))
+	})
+
 	When("given CSV logs from logging_collector", func() {
 		It("can read multiple CSV lines", func(ctx SpecContext) {
 			f, err := os.Open("testdata/two_lines.csv")

--- a/pkg/management/postgres/logpipe/writer.go
+++ b/pkg/management/postgres/logpipe/writer.go
@@ -32,6 +32,16 @@ type RecordWriter interface {
 	Write(r NamedRecord)
 }
 
+// MultiRecordWriter writes each record to every configured writer
+type MultiRecordWriter []RecordWriter
+
+// Write writes the PostgreSQL log record to every configured writer
+func (writer MultiRecordWriter) Write(record NamedRecord) {
+	for _, item := range writer {
+		item.Write(record)
+	}
+}
+
 // LogRecordWriter implements the `RecordWriter` interface writing to the
 // instance manager logger
 type LogRecordWriter struct{}

--- a/pkg/management/postgres/probes.go
+++ b/pkg/management/postgres/probes.go
@@ -46,6 +46,10 @@ func (instance *Instance) GetStatus() (result *postgres.PostgresqlStatus, err er
 		MightBeUnavailable:     instance.MightBeUnavailable(),
 	}
 
+	if statusError := instance.StatusError(); statusError != "" {
+		return result, errors.New(statusError)
+	}
+
 	// this deferred function may override the error returned. Take extra care.
 	defer func() {
 		if !result.MightBeUnavailable {

--- a/pkg/management/postgres/webserver/remote.go
+++ b/pkg/management/postgres/webserver/remote.go
@@ -293,6 +293,14 @@ func (ws *remoteWebserverEndpoints) isServerStartedUp(w http.ResponseWriter, req
 		return
 	}
 
+	lastObservedAt := ws.instance.GetWALReplayProgressLastObservedAt()
+	if !ws.instance.IsWALReplayProgressDetectionStopped() && time.Since(lastObservedAt) <= 5*time.Minute {
+		log.Trace("Startup probe skipped")
+		_, _ = fmt.Fprint(w, "Skipped")
+		return
+	}
+
+	ws.instance.StopWALReplayProgressDetection()
 	ws.startupChecker.IsHealthy(req.Context(), w)
 }
 


### PR DESCRIPTION
The startup probe currently depends on PostgreSQL accepting connections. That can make a replica look failed while PostgreSQL is still making forward progress through crash recovery or WAL replay, causing Kubernetes to restart the pod and repeat the same work. This builds on the logpipe infrastructure from https://github.com/cloudnative-pg/cloudnative-pg/pull/11135 and records the timestamp of PostgreSQL `redo in progress` log messages that include the current LSN. While one of those messages was seen in the last five minutes, `/startupz` reports `Skipped` instead of failing the startup probe. If the signal is stale or absent, the code stops replay-progress detection for this process and falls back to the existing startup checker. The detector also stops as soon as PostgreSQL logs that the database system is ready to accept connections. At that point replay-progress detection is no longer useful, and stopping it avoids running the regex against later log messages.

Prerequisite: #11135
Fixes: #11024