### PR TITLE
fix(bootstrap): instances stuck with a ready PVC but no bootstrap Job

### DIFF
--- a/internal/controller/cluster_controller_test.go
+++ b/internal/controller/cluster_controller_test.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	cnpgTypes "github.com/cloudnative-pg/machinery/pkg/types"
+	volumesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -309,12 +310,14 @@ var _ = Describe("ensureInstancesAreCreated recovers a lost bootstrap Job", func
 
 		res, err := env.clusterReconciler.ensureInstancesAreCreated(ctx, cluster, resources, statusList)
 		Expect(err).To(MatchError(ErrNextLoop))
-		Expect(res.RequeueAfter).To(Equal(30 * time.Second))
+		Expect(res.RequeueAfter).To(Equal(time.Second))
 
 		var jobs batchv1.JobList
 		Expect(env.client.List(ctx, &jobs)).To(Succeed())
 		Expect(jobs.Items).To(HaveLen(1), "the join Job for the replica should have been recreated")
 		Expect(jobs.Items[0].Labels[utils.InstanceNameLabelName]).To(Equal(replicaName))
+		Expect(jobs.Items[0].Labels[utils.JobRoleLabelName]).To(Equal("join"),
+			"an empty PVC must be advanced by a join Job")
 
 		var pvcs corev1.PersistentVolumeClaimList
 		Expect(env.client.List(ctx, &pvcs)).To(Succeed())
@@ -323,6 +326,214 @@ var _ = Describe("ensureInstancesAreCreated recovers a lost bootstrap Job", func
 			Expect(serr).ToNot(HaveOccurred())
 			Expect(serial).To(Equal(2), "no PVC for a different serial should have been created")
 		}
+	})
+
+	It("recreates a snapshot-restore Job when the replica PVC was cloned from a volume snapshot", func(ctx SpecContext) {
+		cluster := newFakeCNPGCluster(env.client, namespace, func(c *apiv1.Cluster) {
+			c.Spec.Instances = 2
+		})
+
+		primaryName := specs.GetInstanceName(cluster.Name, 1)
+		replicaName := specs.GetInstanceName(cluster.Name, 2)
+		cluster.Status.Instances = 2
+		cluster.Status.ReadyInstances = 1
+		cluster.Status.InstanceNames = []string{primaryName, replicaName}
+		cluster.Status.CurrentPrimary = primaryName
+		cluster.Status.TargetPrimary = primaryName
+		cluster.Status.DanglingPVC = []string{replicaName}
+
+		primaryPod, err := specs.NewInstance(ctx, *cluster, 1, true)
+		Expect(err).ToNot(HaveOccurred())
+		primaryPod.Status = corev1.PodStatus{
+			Phase:      corev1.PodRunning,
+			Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}},
+		}
+
+		// The replica PVC records it was cloned from a volume snapshot. The
+		// snapshot, and the backup it came from, no longer exist: the PVC's own
+		// DataSource is the only truthful record of what is on the volume, and
+		// must win over any recomputation from the current backups.
+		pvc, err := persistentvolumeclaim.Build(cluster, &persistentvolumeclaim.CreateConfiguration{
+			Status:     persistentvolumeclaim.StatusInitializing,
+			NodeSerial: 2,
+			Calculator: persistentvolumeclaim.NewPgDataCalculator(),
+			Storage:    cluster.Spec.StorageConfiguration,
+			Source: &corev1.TypedLocalObjectReference{
+				APIGroup: ptr.To(volumesnapshotv1.GroupName),
+				Kind:     apiv1.VolumeSnapshotKind,
+				Name:     "deleted-backup-snapshot",
+			},
+		})
+		Expect(err).ToNot(HaveOccurred())
+		cluster.SetInheritedDataAndOwnership(&pvc.ObjectMeta)
+		Expect(env.client.Create(ctx, pvc)).To(Succeed())
+
+		resources := &managedResources{
+			instances: corev1.PodList{Items: []corev1.Pod{*primaryPod}},
+			pvcs:      corev1.PersistentVolumeClaimList{Items: []corev1.PersistentVolumeClaim{*pvc}},
+		}
+		statusList := postgres.PostgresqlStatusList{
+			Items: []postgres.PostgresqlStatus{
+				{Pod: primaryPod, IsPodReady: true, IsPrimary: true},
+			},
+		}
+
+		res, err := env.clusterReconciler.ensureInstancesAreCreated(ctx, cluster, resources, statusList)
+		Expect(err).To(MatchError(ErrNextLoop))
+		Expect(res.RequeueAfter).To(Equal(time.Second))
+
+		var jobs batchv1.JobList
+		Expect(env.client.List(ctx, &jobs)).To(Succeed())
+		Expect(jobs.Items).To(HaveLen(1))
+		Expect(jobs.Items[0].Labels[utils.InstanceNameLabelName]).To(Equal(replicaName))
+		Expect(jobs.Items[0].Labels[utils.JobRoleLabelName]).To(Equal("snapshot-recovery"),
+			"a snapshot-cloned PVC must be advanced by a snapshot-restore Job")
+	})
+
+	It("recreates a join Job for an empty replica PVC even when a snapshot candidate exists", func(ctx SpecContext) {
+		cluster := newFakeCNPGCluster(env.client, namespace, func(c *apiv1.Cluster) {
+			c.Spec.Instances = 2
+			// WAL archiving is active and the cluster was bootstrapped from a
+			// volume snapshot that still exists: recomputing the candidate
+			// storage source would pick the snapshot-restore path.
+			c.Spec.Plugins = []apiv1.PluginConfiguration{{
+				Name:          "wal-archiver.example.com",
+				Enabled:       ptr.To(true),
+				IsWALArchiver: ptr.To(true),
+			}}
+			c.Spec.Bootstrap = &apiv1.BootstrapConfiguration{
+				Recovery: &apiv1.BootstrapRecovery{
+					VolumeSnapshots: &apiv1.DataSource{
+						Storage: corev1.TypedLocalObjectReference{
+							APIGroup: ptr.To(volumesnapshotv1.GroupName),
+							Kind:     apiv1.VolumeSnapshotKind,
+							Name:     "bootstrap-snapshot",
+						},
+					},
+				},
+			}
+		})
+
+		snapshot := &volumesnapshotv1.VolumeSnapshot{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "bootstrap-snapshot",
+				Namespace: namespace,
+			},
+		}
+		Expect(env.client.Create(ctx, snapshot)).To(Succeed())
+
+		primaryName := specs.GetInstanceName(cluster.Name, 1)
+		replicaName := specs.GetInstanceName(cluster.Name, 2)
+		cluster.Status.Instances = 2
+		cluster.Status.ReadyInstances = 1
+		cluster.Status.InstanceNames = []string{primaryName, replicaName}
+		cluster.Status.CurrentPrimary = primaryName
+		cluster.Status.TargetPrimary = primaryName
+		cluster.Status.DanglingPVC = []string{replicaName}
+
+		primaryPod, err := specs.NewInstance(ctx, *cluster, 1, true)
+		Expect(err).ToNot(HaveOccurred())
+		primaryPod.Status = corev1.PodStatus{
+			Phase:      corev1.PodRunning,
+			Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}},
+		}
+
+		// The replica PVC was created without any data source: whatever
+		// candidate the current cluster state suggests, its content is what a
+		// join Job expects, not what a snapshot-restore Job assumes.
+		pvcGroup := newFakePVC(env.client, cluster, 2, persistentvolumeclaim.StatusInitializing)
+
+		resources := &managedResources{
+			instances: corev1.PodList{Items: []corev1.Pod{*primaryPod}},
+			pvcs:      corev1.PersistentVolumeClaimList{Items: pvcGroup},
+		}
+		statusList := postgres.PostgresqlStatusList{
+			Items: []postgres.PostgresqlStatus{
+				{Pod: primaryPod, IsPodReady: true, IsPrimary: true},
+			},
+		}
+
+		res, err := env.clusterReconciler.ensureInstancesAreCreated(ctx, cluster, resources, statusList)
+		Expect(err).To(MatchError(ErrNextLoop))
+		Expect(res.RequeueAfter).To(Equal(time.Second))
+
+		var jobs batchv1.JobList
+		Expect(env.client.List(ctx, &jobs)).To(Succeed())
+		Expect(jobs.Items).To(HaveLen(1))
+		Expect(jobs.Items[0].Labels[utils.JobRoleLabelName]).To(Equal("join"),
+			"an empty PVC must be advanced by a join Job even when a snapshot candidate is available")
+	})
+
+	It("rebuilds an incomplete replica PVC group through a join Job", func(ctx SpecContext) {
+		cluster := newFakeCNPGCluster(env.client, namespace, func(c *apiv1.Cluster) {
+			c.Spec.Instances = 2
+			c.Spec.WalStorage = &apiv1.StorageConfiguration{Size: "1G"}
+		})
+
+		primaryName := specs.GetInstanceName(cluster.Name, 1)
+		replicaName := specs.GetInstanceName(cluster.Name, 2)
+		cluster.Status.Instances = 2
+		cluster.Status.ReadyInstances = 1
+		cluster.Status.InstanceNames = []string{primaryName, replicaName}
+		cluster.Status.CurrentPrimary = primaryName
+		cluster.Status.TargetPrimary = primaryName
+		// An incomplete PVC group is classified unusable, not dangling.
+		cluster.Status.UnusablePVC = []string{replicaName}
+
+		primaryPod, err := specs.NewInstance(ctx, *cluster, 1, true)
+		Expect(err).ToNot(HaveOccurred())
+		primaryPod.Status = corev1.PodStatus{
+			Phase:      corev1.PodRunning,
+			Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}},
+		}
+
+		// Only the PGDATA PVC of the group exists, and it was cloned from a
+		// snapshot. The sources of the missing WAL PVC cannot be reconstructed,
+		// so the replica must be rebuilt from scratch through a join Job.
+		pvc, err := persistentvolumeclaim.Build(cluster, &persistentvolumeclaim.CreateConfiguration{
+			Status:     persistentvolumeclaim.StatusInitializing,
+			NodeSerial: 2,
+			Calculator: persistentvolumeclaim.NewPgDataCalculator(),
+			Storage:    cluster.Spec.StorageConfiguration,
+			Source: &corev1.TypedLocalObjectReference{
+				APIGroup: ptr.To(volumesnapshotv1.GroupName),
+				Kind:     apiv1.VolumeSnapshotKind,
+				Name:     "deleted-backup-snapshot",
+			},
+		})
+		Expect(err).ToNot(HaveOccurred())
+		cluster.SetInheritedDataAndOwnership(&pvc.ObjectMeta)
+		Expect(env.client.Create(ctx, pvc)).To(Succeed())
+
+		resources := &managedResources{
+			instances: corev1.PodList{Items: []corev1.Pod{*primaryPod}},
+			pvcs:      corev1.PersistentVolumeClaimList{Items: []corev1.PersistentVolumeClaim{*pvc}},
+		}
+		statusList := postgres.PostgresqlStatusList{
+			Items: []postgres.PostgresqlStatus{
+				{Pod: primaryPod, IsPodReady: true, IsPrimary: true},
+			},
+		}
+
+		res, err := env.clusterReconciler.ensureInstancesAreCreated(ctx, cluster, resources, statusList)
+		Expect(err).To(MatchError(ErrNextLoop))
+		Expect(res.RequeueAfter).To(Equal(time.Second))
+
+		var jobs batchv1.JobList
+		Expect(env.client.List(ctx, &jobs)).To(Succeed())
+		Expect(jobs.Items).To(HaveLen(1))
+		Expect(jobs.Items[0].Labels[utils.JobRoleLabelName]).To(Equal("join"),
+			"an incomplete PVC group must be rebuilt from scratch through a join Job")
+
+		var walPVC corev1.PersistentVolumeClaim
+		Expect(env.client.Get(ctx, types.NamespacedName{
+			Namespace: namespace,
+			Name:      replicaName + "-wal",
+		}, &walPVC)).To(Succeed(), "the missing WAL PVC should have been recreated")
+		Expect(walPVC.Spec.DataSource).To(BeNil(), "the recreated WAL PVC must be empty")
+		serial, err := specs.GetNodeSerial(walPVC.ObjectMeta)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(serial).To(Equal(2))
 	})
 })
 

--- a/internal/controller/cluster_controller_test.go
+++ b/internal/controller/cluster_controller_test.go
@@ -500,6 +500,80 @@ var _ = Describe("ensureInstancesAreCreated recovers a lost bootstrap Job", func
 		Expect(jobs.Items).To(BeEmpty(), "no Job should be created when the recovery source is gone")
 	})
 
+	It("fails cleanly when the missing WAL PVC would be recreated from a different "+
+		"snapshot than the one PGDATA already holds", func(ctx SpecContext) {
+		cluster := newFakeCNPGCluster(env.client, namespace, func(c *apiv1.Cluster) {
+			c.Spec.Instances = 1
+			c.Spec.WalStorage = &apiv1.StorageConfiguration{Size: "1G"}
+			c.Spec.Bootstrap = &apiv1.BootstrapConfiguration{
+				Recovery: &apiv1.BootstrapRecovery{
+					VolumeSnapshots: &apiv1.DataSource{
+						Storage: corev1.TypedLocalObjectReference{
+							APIGroup: ptr.To(volumesnapshotv1.GroupName),
+							Kind:     apiv1.VolumeSnapshotKind,
+							Name:     "current-bootstrap-snapshot",
+						},
+					},
+				},
+			}
+		})
+
+		currentSnapshot := &volumesnapshotv1.VolumeSnapshot{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "current-bootstrap-snapshot",
+				Namespace: namespace,
+			},
+		}
+		Expect(env.client.Create(ctx, currentSnapshot)).To(Succeed())
+
+		primaryName := specs.GetInstanceName(cluster.Name, 1)
+		cluster.Status.Instances = 1
+		cluster.Status.ReadyInstances = 0
+		cluster.Status.InstanceNames = []string{primaryName}
+		cluster.Status.TargetPrimary = primaryName
+		// An incomplete PVC group is classified unusable, not dangling.
+		cluster.Status.UnusablePVC = []string{primaryName}
+
+		// The PGDATA PVC was actually cloned from a different snapshot than the
+		// one the cluster's bootstrap configuration currently names (for example
+		// the recovery source was edited after the PVC was created): recreating
+		// the missing WAL PVC from the resolved snapshot would pair it with a
+		// PGDATA volume that came from somewhere else entirely.
+		pvc, err := persistentvolumeclaim.Build(cluster, &persistentvolumeclaim.CreateConfiguration{
+			Status:     persistentvolumeclaim.StatusInitializing,
+			NodeSerial: 1,
+			Calculator: persistentvolumeclaim.NewPgDataCalculator(),
+			Storage:    cluster.Spec.StorageConfiguration,
+			Source: &corev1.TypedLocalObjectReference{
+				APIGroup: ptr.To(volumesnapshotv1.GroupName),
+				Kind:     apiv1.VolumeSnapshotKind,
+				Name:     "original-bootstrap-snapshot",
+			},
+		})
+		Expect(err).ToNot(HaveOccurred())
+		cluster.SetInheritedDataAndOwnership(&pvc.ObjectMeta)
+		Expect(env.client.Create(ctx, pvc)).To(Succeed())
+
+		resources := &managedResources{
+			pvcs: corev1.PersistentVolumeClaimList{Items: []corev1.PersistentVolumeClaim{*pvc}},
+		}
+
+		_, err = env.clusterReconciler.ensureInstancesAreCreated(ctx, cluster, resources, postgres.PostgresqlStatusList{})
+		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(MatchError(ErrNextLoop))
+		Expect(err.Error()).To(ContainSubstring("disagrees"))
+
+		var walPVC corev1.PersistentVolumeClaim
+		Expect(env.client.Get(ctx, types.NamespacedName{
+			Namespace: namespace,
+			Name:      primaryName + "-wal",
+		}, &walPVC)).ToNot(Succeed(), "the WAL PVC must not be created from a disagreeing source")
+
+		var jobs batchv1.JobList
+		Expect(env.client.List(ctx, &jobs)).To(Succeed())
+		Expect(jobs.Items).To(BeEmpty(), "no Job should be created when the recovery source disagrees with PGDATA")
+	})
+
 	It("fails cleanly when the Backup the primary recovers from no longer exists", func(ctx SpecContext) {
 		cluster := newFakeCNPGCluster(env.client, namespace, func(c *apiv1.Cluster) {
 			c.Spec.Instances = 1

--- a/internal/controller/cluster_controller_test.go
+++ b/internal/controller/cluster_controller_test.go
@@ -328,6 +328,97 @@ var _ = Describe("ensureInstancesAreCreated recovers a lost bootstrap Job", func
 		}
 	})
 
+	It("fails cleanly when the primary PVC's snapshot source no longer exists", func(ctx SpecContext) {
+		cluster := newFakeCNPGCluster(env.client, namespace, func(c *apiv1.Cluster) {
+			c.Spec.Instances = 1
+			c.Spec.Bootstrap = &apiv1.BootstrapConfiguration{
+				Recovery: &apiv1.BootstrapRecovery{
+					VolumeSnapshots: &apiv1.DataSource{
+						Storage: corev1.TypedLocalObjectReference{
+							APIGroup: ptr.To(volumesnapshotv1.GroupName),
+							Kind:     apiv1.VolumeSnapshotKind,
+							Name:     "bootstrap-snapshot",
+						},
+					},
+				},
+			}
+		})
+
+		primaryName := specs.GetInstanceName(cluster.Name, 1)
+		cluster.Status.Instances = 1
+		cluster.Status.ReadyInstances = 0
+		cluster.Status.InstanceNames = []string{primaryName}
+		cluster.Status.TargetPrimary = primaryName
+		cluster.Status.DanglingPVC = []string{primaryName}
+
+		// The PGDATA PVC was cloned from a snapshot that has since been
+		// deleted: the bootstrap Job cannot be rebuilt without its metadata,
+		// and the reconciler must fail with a clear error instead of
+		// dereferencing the missing source.
+		pvc, err := persistentvolumeclaim.Build(cluster, &persistentvolumeclaim.CreateConfiguration{
+			Status:     persistentvolumeclaim.StatusInitializing,
+			NodeSerial: 1,
+			Calculator: persistentvolumeclaim.NewPgDataCalculator(),
+			Storage:    cluster.Spec.StorageConfiguration,
+			Source: &corev1.TypedLocalObjectReference{
+				APIGroup: ptr.To(volumesnapshotv1.GroupName),
+				Kind:     apiv1.VolumeSnapshotKind,
+				Name:     "bootstrap-snapshot",
+			},
+		})
+		Expect(err).ToNot(HaveOccurred())
+		cluster.SetInheritedDataAndOwnership(&pvc.ObjectMeta)
+		Expect(env.client.Create(ctx, pvc)).To(Succeed())
+
+		resources := &managedResources{
+			pvcs: corev1.PersistentVolumeClaimList{Items: []corev1.PersistentVolumeClaim{*pvc}},
+		}
+
+		_, err = env.clusterReconciler.ensureInstancesAreCreated(ctx, cluster, resources, postgres.PostgresqlStatusList{})
+		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(MatchError(ErrNextLoop))
+		Expect(err.Error()).To(ContainSubstring("no longer exists"))
+
+		var jobs batchv1.JobList
+		Expect(env.client.List(ctx, &jobs)).To(Succeed())
+		Expect(jobs.Items).To(BeEmpty(), "no Job should be created when the recovery source is gone")
+	})
+
+	It("fails cleanly when the Backup the primary recovers from no longer exists", func(ctx SpecContext) {
+		cluster := newFakeCNPGCluster(env.client, namespace, func(c *apiv1.Cluster) {
+			c.Spec.Instances = 1
+			c.Spec.Bootstrap = &apiv1.BootstrapConfiguration{
+				Recovery: &apiv1.BootstrapRecovery{
+					Backup: &apiv1.BackupSource{
+						LocalObjectReference: apiv1.LocalObjectReference{Name: "vanished-backup"},
+					},
+				},
+			}
+		})
+
+		primaryName := specs.GetInstanceName(cluster.Name, 1)
+		cluster.Status.Instances = 1
+		cluster.Status.ReadyInstances = 0
+		cluster.Status.InstanceNames = []string{primaryName}
+		cluster.Status.TargetPrimary = primaryName
+		cluster.Status.DanglingPVC = []string{primaryName}
+
+		pvcGroup := newFakePVC(env.client, cluster, 1, persistentvolumeclaim.StatusInitializing)
+
+		resources := &managedResources{
+			pvcs: corev1.PersistentVolumeClaimList{Items: pvcGroup},
+		}
+
+		_, err := env.clusterReconciler.ensureInstancesAreCreated(ctx, cluster, resources, postgres.PostgresqlStatusList{})
+		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(MatchError(ErrNextLoop))
+		Expect(err.Error()).To(ContainSubstring("vanished-backup"))
+
+		var jobs batchv1.JobList
+		Expect(env.client.List(ctx, &jobs)).To(Succeed())
+		Expect(jobs.Items).To(BeEmpty(), "no Job should be created when the origin Backup is gone")
+	})
+
 	It("recreates a snapshot-restore Job when the replica PVC was cloned from a volume snapshot", func(ctx SpecContext) {
 		cluster := newFakeCNPGCluster(env.client, namespace, func(c *apiv1.Cluster) {
 			c.Spec.Instances = 2

--- a/internal/controller/cluster_controller_test.go
+++ b/internal/controller/cluster_controller_test.go
@@ -194,6 +194,69 @@ var _ = Describe("ensureInstancesAreCreated recovers a lost bootstrap Job", func
 		namespace = newFakeNamespace(env.client)
 	})
 
+	It("bootstraps the first primary through the real PVC classifier handoff", func(ctx SpecContext) {
+		cluster := newFakeCNPGCluster(env.client, namespace, func(c *apiv1.Cluster) {
+			c.Spec.Instances = 1
+			c.Spec.WalStorage = &apiv1.StorageConfiguration{Size: "1G"}
+		})
+
+		// Fresh bootstrap: no instance exists yet.
+		cluster.Status.Instances = 0
+		cluster.Status.ReadyInstances = 0
+		cluster.Status.InstanceNames = nil
+		cluster.Status.TargetPrimary = ""
+		cluster.Status.CurrentPrimary = ""
+
+		// First pass: createPrimaryInstance creates the PVC group, records the
+		// target primary and defers Job creation to the PVC-driven path.
+		res, err := env.clusterReconciler.createPrimaryInstance(ctx, cluster)
+		Expect(err).To(MatchError(ErrNextLoop))
+		Expect(res.RequeueAfter).To(Equal(time.Second))
+
+		primaryName := specs.GetInstanceName(cluster.Name, 1)
+		Expect(cluster.Status.TargetPrimary).To(Equal(primaryName))
+
+		var pvcs corev1.PersistentVolumeClaimList
+		Expect(env.client.List(ctx, &pvcs)).To(Succeed())
+		Expect(pvcs.Items).To(HaveLen(2), "the PGDATA and WAL PVCs should have been created")
+
+		var jobs batchv1.JobList
+		Expect(env.client.List(ctx, &jobs)).To(Succeed())
+		Expect(jobs.Items).To(BeEmpty(), "createPrimaryInstance must not create the Job itself")
+
+		// Any client write-back strips TypeMeta from the in-memory object (see
+		// the note in newFakeCNPGCluster): restore it as the fresh Get of the
+		// next reconciliation pass would see it, since the Job ownership set by
+		// the specs builders copies it verbatim.
+		cluster.TypeMeta = metav1.TypeMeta{
+			Kind:       apiv1.ClusterKind,
+			APIVersion: apiv1.SchemeGroupVersion.String(),
+		}
+
+		// Next pass: the production classifier computes the PVC buckets the
+		// routing consumes. The PVC phase is set by the PV controller in a real
+		// cluster; mirror it in memory before classifying.
+		for i := range pvcs.Items {
+			pvcs.Items[i].Status.Phase = corev1.ClaimBound
+		}
+		persistentvolumeclaim.EnrichStatus(ctx, cluster, nil, nil, pvcs.Items)
+		Expect(cluster.Status.Instances).To(Equal(1))
+		Expect(cluster.Status.DanglingPVC).ToNot(BeEmpty())
+
+		resources := &managedResources{pvcs: pvcs}
+		res, err = env.clusterReconciler.ensureInstancesAreCreated(ctx, cluster, resources, postgres.PostgresqlStatusList{})
+		Expect(err).To(MatchError(ErrNextLoop))
+		Expect(res.RequeueAfter).To(Equal(time.Second))
+
+		Expect(env.client.List(ctx, &jobs)).To(Succeed())
+		Expect(jobs.Items).To(HaveLen(1), "the init Job should be created off the classified PVC state")
+		Expect(jobs.Items[0].Labels[utils.InstanceNameLabelName]).To(Equal(primaryName))
+		Expect(jobs.Items[0].Labels[utils.JobRoleLabelName]).To(Equal("initdb"))
+		Expect(persistentvolumeclaim.IsUsedByPodSpec(
+			jobs.Items[0].Spec.Template.Spec, primaryName, primaryName+"-wal",
+		)).To(BeTrue(), "the init Job must mount the whole PVC group")
+	})
+
 	It("recreates the initdb Job reusing serial 1 when the primary PVC is stuck initializing", func(ctx SpecContext) {
 		cluster := newFakeCNPGCluster(env.client, namespace, func(c *apiv1.Cluster) {
 			c.Spec.Instances = 1

--- a/internal/controller/cluster_controller_test.go
+++ b/internal/controller/cluster_controller_test.go
@@ -328,6 +328,59 @@ var _ = Describe("ensureInstancesAreCreated recovers a lost bootstrap Job", func
 		}
 	})
 
+	It("recreates the missing WAL PVC of the primary before creating the init Job", func(ctx SpecContext) {
+		cluster := newFakeCNPGCluster(env.client, namespace, func(c *apiv1.Cluster) {
+			c.Spec.Instances = 1
+			c.Spec.WalStorage = &apiv1.StorageConfiguration{Size: "1G"}
+		})
+
+		primaryName := specs.GetInstanceName(cluster.Name, 1)
+		cluster.Status.Instances = 1
+		cluster.Status.ReadyInstances = 0
+		cluster.Status.InstanceNames = []string{primaryName}
+		cluster.Status.TargetPrimary = primaryName
+		// An incomplete PVC group is classified unusable, not dangling.
+		cluster.Status.UnusablePVC = []string{primaryName}
+
+		// The first-primary bootstrap was interrupted after creating the PGDATA
+		// PVC but before the WAL PVC: creating the init Job in this state would
+		// leave its Pod pending forever on a volume that does not exist.
+		pvc, err := persistentvolumeclaim.Build(cluster, &persistentvolumeclaim.CreateConfiguration{
+			Status:     persistentvolumeclaim.StatusInitializing,
+			NodeSerial: 1,
+			Calculator: persistentvolumeclaim.NewPgDataCalculator(),
+			Storage:    cluster.Spec.StorageConfiguration,
+		})
+		Expect(err).ToNot(HaveOccurred())
+		cluster.SetInheritedDataAndOwnership(&pvc.ObjectMeta)
+		Expect(env.client.Create(ctx, pvc)).To(Succeed())
+
+		resources := &managedResources{
+			pvcs: corev1.PersistentVolumeClaimList{Items: []corev1.PersistentVolumeClaim{*pvc}},
+		}
+
+		res, err := env.clusterReconciler.ensureInstancesAreCreated(ctx, cluster, resources, postgres.PostgresqlStatusList{})
+		Expect(err).To(MatchError(ErrNextLoop))
+		Expect(res.RequeueAfter).To(Equal(time.Second))
+
+		var walPVC corev1.PersistentVolumeClaim
+		Expect(env.client.Get(ctx, types.NamespacedName{
+			Namespace: namespace,
+			Name:      primaryName + "-wal",
+		}, &walPVC)).To(Succeed(), "the missing WAL PVC should have been recreated")
+		serial, err := specs.GetNodeSerial(walPVC.ObjectMeta)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(serial).To(Equal(1))
+
+		var jobs batchv1.JobList
+		Expect(env.client.List(ctx, &jobs)).To(Succeed())
+		Expect(jobs.Items).To(HaveLen(1))
+		Expect(jobs.Items[0].Labels[utils.JobRoleLabelName]).To(Equal("initdb"))
+		Expect(persistentvolumeclaim.IsUsedByPodSpec(
+			jobs.Items[0].Spec.Template.Spec, primaryName, primaryName+"-wal",
+		)).To(BeTrue(), "the init Job must mount the whole PVC group")
+	})
+
 	It("fails cleanly when the primary PVC's snapshot source no longer exists", func(ctx SpecContext) {
 		cluster := newFakeCNPGCluster(env.client, namespace, func(c *apiv1.Cluster) {
 			c.Spec.Instances = 1

--- a/internal/controller/cluster_controller_test.go
+++ b/internal/controller/cluster_controller_test.go
@@ -184,7 +184,7 @@ var _ = Describe("ensureInstancesAreCreated reattachment while a PVC is terminat
 	})
 })
 
-var _ = Describe("ensureInstancesAreCreated recovers a lost first-primary bootstrap Job (#11036)", func() {
+var _ = Describe("ensureInstancesAreCreated recovers a lost bootstrap Job", func() {
 	var env *testingEnvironment
 	var namespace string
 
@@ -269,6 +269,60 @@ var _ = Describe("ensureInstancesAreCreated recovers a lost first-primary bootst
 		var jobs batchv1.JobList
 		Expect(env.client.List(ctx, &jobs)).To(Succeed())
 		Expect(jobs.Items).To(BeEmpty(), "the pre-existing Job lives only in resources, none should be created")
+	})
+
+	It("recreates the join Job for a replica whose PVC exists but never got a Job", func(ctx SpecContext) {
+		cluster := newFakeCNPGCluster(env.client, namespace, func(c *apiv1.Cluster) {
+			c.Spec.Instances = 2
+		})
+
+		// A running primary and a replica whose data PVC was created but, for
+		// whatever reason (e.g. a lost race analogous to #11036), the join Job
+		// never was: no Pod and no Job exist for it (see #7709).
+		primaryName := specs.GetInstanceName(cluster.Name, 1)
+		replicaName := specs.GetInstanceName(cluster.Name, 2)
+		cluster.Status.Instances = 2
+		cluster.Status.ReadyInstances = 1
+		cluster.Status.InstanceNames = []string{primaryName, replicaName}
+		cluster.Status.CurrentPrimary = primaryName
+		cluster.Status.TargetPrimary = primaryName
+		cluster.Status.DanglingPVC = []string{replicaName}
+
+		primaryPod, err := specs.NewInstance(ctx, *cluster, 1, true)
+		Expect(err).ToNot(HaveOccurred())
+		primaryPod.Status = corev1.PodStatus{
+			Phase:      corev1.PodRunning,
+			Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}},
+		}
+
+		pvcGroup := newFakePVC(env.client, cluster, 2, persistentvolumeclaim.StatusInitializing)
+
+		resources := &managedResources{
+			instances: corev1.PodList{Items: []corev1.Pod{*primaryPod}},
+			pvcs:      corev1.PersistentVolumeClaimList{Items: pvcGroup},
+		}
+		statusList := postgres.PostgresqlStatusList{
+			Items: []postgres.PostgresqlStatus{
+				{Pod: primaryPod, IsPodReady: true, IsPrimary: true},
+			},
+		}
+
+		res, err := env.clusterReconciler.ensureInstancesAreCreated(ctx, cluster, resources, statusList)
+		Expect(err).To(MatchError(ErrNextLoop))
+		Expect(res.RequeueAfter).To(Equal(30 * time.Second))
+
+		var jobs batchv1.JobList
+		Expect(env.client.List(ctx, &jobs)).To(Succeed())
+		Expect(jobs.Items).To(HaveLen(1), "the join Job for the replica should have been recreated")
+		Expect(jobs.Items[0].Labels[utils.InstanceNameLabelName]).To(Equal(replicaName))
+
+		var pvcs corev1.PersistentVolumeClaimList
+		Expect(env.client.List(ctx, &pvcs)).To(Succeed())
+		for _, pvc := range pvcs.Items {
+			serial, serr := specs.GetNodeSerial(pvc.ObjectMeta)
+			Expect(serr).ToNot(HaveOccurred())
+			Expect(serial).To(Equal(2), "no PVC for a different serial should have been created")
+		}
 	})
 })
 

--- a/internal/controller/cluster_create.go
+++ b/internal/controller/cluster_create.go
@@ -1526,6 +1526,63 @@ func (r *ClusterReconciler) joinReplicaInstance(
 	return ctrl.Result{RequeueAfter: 30 * time.Second}, ErrNextLoop
 }
 
+// recreateReplicaBootstrapJob rebuilds the bootstrap Job of a replica whose
+// PVCs exist but have no Job advancing them. Mirroring buildPrimaryInstanceJob,
+// the Job variant is decided by the PGDATA PVC's own DataSource, the
+// authoritative record of what is really on the volume: recomputing the
+// candidate storage source from the live Backup list could disagree with the
+// volume's actual content when backups or snapshots changed after the PVCs
+// were created, and a snapshot-restore Job completes successfully even against
+// a volume that was never cloned, leaving a broken replica behind an
+// apparently successful bootstrap.
+//
+// When part of the PVC group is missing, the snapshot sources the absent
+// volumes were meant to be cloned from cannot be reconstructed: recreate the
+// missing PVCs empty and rebuild the whole replica through a join, which
+// discards any existing content and takes a fresh copy from the primary.
+func (r *ClusterReconciler) recreateReplicaBootstrapJob(
+	ctx context.Context,
+	cluster *apiv1.Cluster,
+	serial int,
+	pgdataDataSource *corev1.TypedLocalObjectReference,
+	pvcGroupComplete bool,
+) (ctrl.Result, error) {
+	contextLogger := log.FromContext(ctx)
+
+	if !pvcGroupComplete {
+		pgdataDataSource = nil
+		if err := persistentvolumeclaim.CreateInstancePVCs(ctx, r.Client, cluster, nil, serial); err != nil {
+			return ctrl.Result{}, fmt.Errorf("cannot recreate the missing PVCs of instance %v: %w",
+				specs.GetInstanceName(cluster.Name, serial), err)
+		}
+	}
+
+	job := specs.JoinReplicaInstance(*cluster, serial)
+	if pgdataDataSource != nil {
+		job = specs.RestoreReplicaInstance(*cluster, serial)
+	}
+
+	contextLogger.Info("Recreating the bootstrap Job for a replica whose PVCs are not ready",
+		"job", job.Name,
+		"role", job.Labels[utils.JobRoleLabelName],
+	)
+
+	r.Recorder.Eventf(cluster, "Normal", "CreatingInstance",
+		"Recreating instance %v-%v", cluster.Name, serial)
+
+	if err := r.RegisterPhase(ctx, cluster,
+		apiv1.PhaseCreatingReplica,
+		fmt.Sprintf("Creating replica %v", job.Name)); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	if res, err := r.createInstanceJob(ctx, cluster, job, false); err != nil || !res.IsZero() {
+		return res, err
+	}
+
+	return ctrl.Result{RequeueAfter: time.Second}, ErrNextLoop
+}
+
 // ensureInstancesAreCreated recreates any missing instance
 func (r *ClusterReconciler) ensureInstancesAreCreated(
 	ctx context.Context,
@@ -1700,13 +1757,24 @@ func (r *ClusterReconciler) ensureInstanceBootstrapJob(
 	}
 
 	instancePVCNames := make([]string, 0)
-	var primaryDataSource *corev1.TypedLocalObjectReference
+	var pgdataDataSource *corev1.TypedLocalObjectReference
 	for _, pvc := range persistentvolumeclaim.FilterByPodSpec(resources.pvcs.Items, instanceToCreate.Spec) {
 		instancePVCNames = append(instancePVCNames, pvc.Name)
 		if pvc.Name == instanceToCreate.Name {
-			primaryDataSource = pvc.Spec.DataSource
+			pgdataDataSource = pvc.Spec.DataSource
 		}
 	}
+
+	// A previous attempt may have been interrupted between creating the PVCs:
+	// compare the existing PVCs with the volumes the instance mounts to detect
+	// a PVC group that is missing some of its members.
+	expectedPVCCount := 0
+	for _, volume := range instanceToCreate.Spec.Volumes {
+		if volume.PersistentVolumeClaim != nil {
+			expectedPVCCount++
+		}
+	}
+	pvcGroupComplete := len(instancePVCNames) == expectedPVCCount
 
 	// If a Job is already advancing these PVCs, wait for it to complete.
 	for i := range resources.jobs.Items {
@@ -1729,11 +1797,9 @@ func (r *ClusterReconciler) ensureInstanceBootstrapJob(
 	// guards against. Once a primary is running, joinReplicaInstance owns Job
 	// creation for replicas (it creates the Job and then the PVCs), so a
 	// podless replica PVC without a Job means a previous attempt did not get
-	// that far; recreate the join Job there.
+	// that far; recreate its bootstrap Job there.
 	if cluster.Status.CurrentPrimary != "" && instanceToCreate.Name != cluster.Status.TargetPrimary {
-		contextLogger.Info("Recreating the join Job for an instance whose PVCs are not ready",
-			"instance", instanceToCreate.Name)
-		return r.joinReplicaInstance(ctx, serial, cluster)
+		return r.recreateReplicaBootstrapJob(ctx, cluster, serial, pgdataDataSource, pvcGroupComplete)
 	}
 
 	// Set TargetPrimary defensively: if it is not set the instance manager would
@@ -1744,7 +1810,7 @@ func (r *ClusterReconciler) ensureInstanceBootstrapJob(
 		}
 	}
 
-	job, err := r.buildPrimaryInstanceJob(ctx, cluster, serial, primaryDataSource)
+	job, err := r.buildPrimaryInstanceJob(ctx, cluster, serial, pgdataDataSource)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/internal/controller/cluster_create.go
+++ b/internal/controller/cluster_create.go
@@ -1164,16 +1164,66 @@ func (r *ClusterReconciler) createPrimaryInstance(
 		return ctrl.Result{}, nil
 	}
 
-	// If the cluster is bootstrapping from recovery, resolve the source backup
-	// or volume snapshot and make sure it is ready before proceeding.
-	backup, recoverySnapshot, res, err := r.resolvePrimaryRecoverySource(ctx, cluster)
-	if !res.IsZero() || err != nil {
-		return res, err
-	}
-
 	// Generate a new node serial
 	nodeSerial := r.generateNodeSerial(cluster)
 	contextLogger.Debug("allocated node serial", "serial", nodeSerial)
+
+	// Ensure the PVCs for the first node exist, picking the right storage
+	// source if we are bootstrapping from a backup or a volume snapshot. This
+	// blocks until the source is ready.
+	if res, err := r.ensurePrimaryInstancePVCs(ctx, cluster, nodeSerial); !res.IsZero() || err != nil {
+		return res, err
+	}
+
+	// Record the intended primary in the cluster status *before* the init Job
+	// promotes the Pod. reconcileOldPrimary self-demotes a primary whose name
+	// does not match Status.TargetPrimary, so TargetPrimary must be set first.
+	podName := specs.GetInstanceName(cluster.Name, nodeSerial)
+	if err := r.setPrimaryInstance(ctx, cluster, podName); err != nil {
+		contextLogger.Error(err, "Unable to set the primary instance name")
+		return ctrl.Result{}, err
+	}
+
+	if err := r.RegisterPhase(ctx, cluster, apiv1.PhaseFirstPrimary,
+		fmt.Sprintf("Creating primary instance %v", podName)); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// Creation of the init Job is owned by the unified PVC-state-driven path
+	// (ensureInstancesAreCreated): an initializing PVC with no Job gets one
+	// created there. We just requeue so that path runs. Gating Job creation
+	// here behind a status patch that may lose an optimistic-lock conflict was
+	// the source of the first-primary bootstrap deadlock (see #11036).
+	return ctrl.Result{RequeueAfter: time.Second}, ErrNextLoop
+}
+
+// ensurePrimaryInstancePVCs makes sure the PVCs of the first node exist,
+// selecting the proper storage source when bootstrapping from a backup or a
+// volume snapshot. A non-zero result means the bootstrap source is not ready
+// yet and the caller should requeue.
+func (r *ClusterReconciler) ensurePrimaryInstancePVCs(
+	ctx context.Context,
+	cluster *apiv1.Cluster,
+	nodeSerial int,
+) (ctrl.Result, error) {
+	var recoverySnapshot *persistentvolumeclaim.StorageSource
+
+	// If the cluster is bootstrapping from recovery, it may do so from:
+	//  1 - a backup object, which may be done with volume snapshots or object storage
+	//  2 - volume snapshots
+	// We need to check that whichever alternative is used, the backup/snapshot is completed.
+	if cluster.Spec.Bootstrap != nil && cluster.Spec.Bootstrap.Recovery != nil {
+		backup, err := r.getOriginBackup(ctx, cluster)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+
+		if res, err := r.checkReadyForRecovery(ctx, backup, cluster); !res.IsZero() || err != nil {
+			return res, err
+		}
+
+		recoverySnapshot = persistentvolumeclaim.GetCandidateStorageSourceForPrimary(cluster, backup)
+	}
 
 	// Create the PVCs from the cluster definition, and if bootstrapping from
 	// recoverySnapshot, use that as the source
@@ -1187,97 +1237,46 @@ func (r *ClusterReconciler) createPrimaryInstance(
 		return ctrl.Result{}, fmt.Errorf("cannot create primary instance PVCs: %w", err)
 	}
 
-	// We are bootstrapping a cluster and in need to create the first node
-	job, err := r.buildPrimaryInstanceJob(ctx, cluster, nodeSerial, backup, recoverySnapshot)
-	if err != nil {
-		return ctrl.Result{}, err
-	}
-
-	if err := ctrl.SetControllerReference(cluster, job, r.Scheme); err != nil {
-		contextLogger.Error(err, "Unable to set the owner reference for instance")
-		return ctrl.Result{}, err
-	}
-
-	podName := fmt.Sprintf("%v-%v", cluster.Name, nodeSerial)
-	if err := r.setPrimaryInstance(ctx, cluster, podName); err != nil {
-		contextLogger.Error(err, "Unable to set the primary instance name")
-		return ctrl.Result{}, err
-	}
-
-	if err := r.RegisterPhase(ctx, cluster, apiv1.PhaseFirstPrimary,
-		fmt.Sprintf("Creating primary instance %v", podName)); err != nil {
-		return ctrl.Result{}, err
-	}
-
-	contextLogger.Info("Creating new Job",
-		"jobName", job.Name,
-		"primary", true)
-
-	inheritJobMetadata(cluster, job)
-
-	if err := r.Create(ctx, job); err != nil {
-		if apierrs.IsAlreadyExists(err) {
-			// This Job was already created, maybe the cache is stale.
-			return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
-		}
-
-		contextLogger.Error(err, "Unable to create job", "job", job)
-		return ctrl.Result{}, err
-	}
-
-	return ctrl.Result{RequeueAfter: 30 * time.Second}, ErrNextLoop
-}
-
-// resolvePrimaryRecoverySource resolves the backup or volume snapshot used to
-// bootstrap the first primary, when the cluster bootstraps from recovery. It
-// returns a non-zero result (to be propagated to the caller) when the source is
-// not ready yet.
-func (r *ClusterReconciler) resolvePrimaryRecoverySource(
-	ctx context.Context,
-	cluster *apiv1.Cluster,
-) (*apiv1.Backup, *persistentvolumeclaim.StorageSource, ctrl.Result, error) {
-	// If the cluster is bootstrapping from recovery, it may do so from:
-	//  1 - a backup object, which may be done with volume snapshots or object storage
-	//  2 - volume snapshots
-	// We need to check that whichever alternative is used, the backup/snapshot is completed.
-	if cluster.Spec.Bootstrap == nil ||
-		cluster.Spec.Bootstrap.Recovery == nil {
-		return nil, nil, ctrl.Result{}, nil
-	}
-
-	backup, err := r.getOriginBackup(ctx, cluster)
-	if err != nil {
-		return nil, nil, ctrl.Result{}, err
-	}
-
-	if res, err := r.checkReadyForRecovery(ctx, backup, cluster); !res.IsZero() || err != nil {
-		return nil, nil, res, err
-	}
-
-	recoverySnapshot := persistentvolumeclaim.GetCandidateStorageSourceForPrimary(cluster, backup)
-	return backup, recoverySnapshot, ctrl.Result{}, nil
+	return ctrl.Result{}, nil
 }
 
 // buildPrimaryInstanceJob builds the bootstrap Job for the first primary
 // instance, selecting the variant (initdb, recovery, pgBaseBackup or volume
-// snapshot restore) according to the cluster bootstrap configuration.
+// snapshot restore) according to the cluster bootstrap configuration. It is
+// invoked both at first-primary creation and from the unified
+// PVC-state-driven path when an initializing primary PVC has no Job yet.
+//
+// dataSource is the PGDATA PVC's own Spec.DataSource, if any: since the PVC
+// already exists by the time this runs, its DataSource is the authoritative
+// record of whether it was actually restored from a snapshot. Using it
+// instead of recomputing the candidate source from the current Backup object
+// keeps the Job variant consistent with what is really on the PVC, even if
+// the Backup has changed or been deleted since the PVC was created.
 func (r *ClusterReconciler) buildPrimaryInstanceJob(
 	ctx context.Context,
 	cluster *apiv1.Cluster,
 	nodeSerial int,
-	backup *apiv1.Backup,
-	recoverySnapshot *persistentvolumeclaim.StorageSource,
+	dataSource *corev1.TypedLocalObjectReference,
 ) (*batchv1.Job, error) {
 	isBootstrappingFromRecovery := cluster.Spec.Bootstrap != nil && cluster.Spec.Bootstrap.Recovery != nil
 	isBootstrappingFromBaseBackup := cluster.Spec.Bootstrap != nil && cluster.Spec.Bootstrap.PgBaseBackup != nil
 
+	var backup *apiv1.Backup
+	if isBootstrappingFromRecovery {
+		var err error
+		backup, err = r.getOriginBackup(ctx, cluster)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	switch {
-	case isBootstrappingFromRecovery && recoverySnapshot != nil:
+	case isBootstrappingFromRecovery && dataSource != nil:
 		metadata, err := persistentvolumeclaim.GetSourceMetadataOrNil(
 			ctx,
 			r.Client,
 			cluster.Namespace,
-			recoverySnapshot.DataSource,
+			*dataSource,
 		)
 		if err != nil {
 			return nil, err
@@ -1310,6 +1309,44 @@ func inheritJobMetadata(cluster *apiv1.Cluster, job *batchv1.Job) {
 		cluster.GetFixedInheritedLabels(), configuration.Current)
 	utils.InheritLabels(&job.Spec.Template.ObjectMeta, cluster.Labels,
 		cluster.GetFixedInheritedLabels(), configuration.Current)
+}
+
+// createInstanceJob sets the owner reference, inherits annotations and labels,
+// and creates the given bootstrap Job. If the Job already exists, it adopts
+// it (mirroring joinReplicaInstance) instead of blindly assuming it is ours.
+func (r *ClusterReconciler) createInstanceJob(
+	ctx context.Context,
+	cluster *apiv1.Cluster,
+	job *batchv1.Job,
+	primary bool,
+) (ctrl.Result, error) {
+	contextLogger := log.FromContext(ctx)
+
+	if err := ctrl.SetControllerReference(cluster, job, r.Scheme); err != nil {
+		contextLogger.Error(err, "Unable to set the owner reference for instance")
+		return ctrl.Result{}, err
+	}
+
+	contextLogger.Info("Creating new Job",
+		"jobName", job.Name,
+		"primary", primary)
+
+	inheritJobMetadata(cluster, job)
+
+	if err := r.Create(ctx, job); err != nil {
+		if !apierrs.IsAlreadyExists(err) {
+			contextLogger.Error(err, "Unable to create job", "job", job)
+			return ctrl.Result{}, err
+		}
+
+		if result, adoptErr := r.ensureJobAdoptable(ctx, cluster, job.Name); adoptErr != nil || !result.IsZero() {
+			return result, adoptErr
+		}
+		contextLogger.Debug("Job already existed, adopted it", "jobName", job.Name)
+		return ctrl.Result{}, nil
+	}
+
+	return ctrl.Result{}, nil
 }
 
 // getOriginBackup gets the backup that is used to bootstrap a new PostgreSQL cluster
@@ -1534,35 +1571,20 @@ func (r *ClusterReconciler) ensureInstancesAreCreated(
 		return ctrl.Result{RequeueAfter: 1 * time.Second}, ErrNextLoop
 	}
 
-	// TODO: this logic eventually should be moved elsewhere
+	// The PVC is the managed state; a Job (or, once ready, a Pod) is just the
+	// means to advance it. If any PVC of this instance is not ready yet, the
+	// resource that advances it is a bootstrap Job, not a Pod. When that Job is
+	// missing we must create it here, otherwise the PVC has no way of ever
+	// becoming ready and reconciliation deadlocks (see #11036). When the Job
+	// already exists we simply wait for it to complete.
 	instancePVCs := persistentvolumeclaim.FilterByPodSpec(resources.pvcs.Items, instanceToCreate.Spec)
 	for _, instancePVC := range instancePVCs {
-		// This should not happen. However, we put this guard here
-		// as an assertion to catch unexpected events.
 		pvcStatus := instancePVC.Annotations[utils.PVCStatusAnnotationName]
-		if pvcStatus != persistentvolumeclaim.StatusReady {
-			// A PVC only becomes ready once the Job that initializes it completes,
-			// or once a Pod attaches to it. When the bootstrap of the first primary
-			// loses a status-patch optimistic-lock race after the data PVC has been
-			// created but before the initialization Job is created, the orphan PVC
-			// is counted as an instance and the cluster never re-enters the
-			// bootstrap gate, so no Job is ever created and this branch would wait
-			// forever (see #11036). If the instance owning this PVC is the intended
-			// primary and no initialization Job exists for it, (re)create it reusing
-			// the serial already assigned to the PVC.
-			if res, handled, err := r.ensurePrimaryBootstrapJob(
-				ctx, cluster, instanceToCreate, &instancePVC, resources.jobs.Items,
-			); err != nil || handled {
-				return res, err
-			}
-
-			contextLogger.Info("Selected PVC is not ready yet, waiting for 1 second",
-				"pvc", instancePVC.Name,
-				"status", pvcStatus,
-				"instance", instanceToCreate.Name,
-			)
-			return ctrl.Result{RequeueAfter: 1 * time.Second}, ErrNextLoop
+		if pvcStatus == persistentvolumeclaim.StatusReady {
+			continue
 		}
+
+		return r.ensureInstanceBootstrapJob(ctx, cluster, instanceToCreate, resources)
 	}
 
 	// If this cluster has been restarted, mark the Pod with the latest restart time
@@ -1655,90 +1677,87 @@ func findInstancePodToCreate(
 	return nil, nil
 }
 
-// ensurePrimaryBootstrapJob recovers the first-primary bootstrap when the data
-// PVC has been created but the initialization Job was never created (for
-// instance because a status-patch optimistic-lock conflict aborted
-// createPrimaryInstance after the PVC creation, see #11036). When the instance
-// owning the not-ready PVC is the intended primary and no Job exists for it, it
-// (re)creates the bootstrap Job reusing the serial already assigned to the PVC.
+// ensureInstanceBootstrapJob makes sure that an instance whose PVCs are not yet
+// ready has a bootstrap Job advancing them. If a Job already exists for the
+// instance we simply wait for it to complete; otherwise we create it, reusing
+// the serial already stamped on the PVCs.
 //
-// It returns handled=true when it took over the reconciliation (the returned
-// result must be propagated), and handled=false to let the caller fall back to
-// the regular wait-and-requeue behavior.
-func (r *ClusterReconciler) ensurePrimaryBootstrapJob(
+// This consolidates init-Job creation, off the PVC state, for both the first
+// primary (originally the fix for the bootstrap deadlock in #11036, now
+// carried by this unified path) and a replica whose join Job was lost,
+// self-healing the #7709 scenario.
+func (r *ClusterReconciler) ensureInstanceBootstrapJob(
 	ctx context.Context,
 	cluster *apiv1.Cluster,
 	instanceToCreate *corev1.Pod,
-	instancePVC *corev1.PersistentVolumeClaim,
-	jobs []batchv1.Job,
-) (ctrl.Result, bool, error) {
+	resources *managedResources,
+) (ctrl.Result, error) {
 	contextLogger := log.FromContext(ctx)
 
-	// Only the primary instance bootstraps a brand-new data directory through a
-	// Job; standby instances are joined via their own path. We treat the
-	// instance as the intended primary when it matches the TargetPrimary or when
-	// its PVC still carries the primary role label.
-	isPrimary := instanceToCreate.Name == cluster.Status.TargetPrimary ||
-		specs.IsPrimary(instancePVC.ObjectMeta)
-	if !isPrimary {
-		return ctrl.Result{}, false, nil
+	serial, err := specs.GetNodeSerial(instanceToCreate.ObjectMeta)
+	if err != nil {
+		return ctrl.Result{}, err
 	}
 
-	// If an initialization Job already exists for this instance, the regular
-	// wait path is correct: the PVC will turn ready once the Job completes.
-	for i := range jobs {
-		if jobs[i].Labels[utils.InstanceNameLabelName] == instanceToCreate.Name {
-			return ctrl.Result{}, false, nil
+	instancePVCNames := make([]string, 0)
+	var primaryDataSource *corev1.TypedLocalObjectReference
+	for _, pvc := range persistentvolumeclaim.FilterByPodSpec(resources.pvcs.Items, instanceToCreate.Spec) {
+		instancePVCNames = append(instancePVCNames, pvc.Name)
+		if pvc.Name == instanceToCreate.Name {
+			primaryDataSource = pvc.Spec.DataSource
 		}
 	}
 
-	// Reuse the serial already assigned to the PVC: allocating a new one would
-	// orphan this PVC and create a second instance.
-	nodeSerial, err := specs.GetNodeSerial(instancePVC.ObjectMeta)
-	if err != nil {
-		return ctrl.Result{}, false, err
+	// If a Job is already advancing these PVCs, wait for it to complete.
+	for i := range resources.jobs.Items {
+		job := &resources.jobs.Items[i]
+		if persistentvolumeclaim.IsUsedByPodSpec(job.Spec.Template.Spec, instancePVCNames...) {
+			contextLogger.Debug("Bootstrap Job already exists, waiting for it to complete",
+				"job", job.Name,
+				"instance", instanceToCreate.Name,
+			)
+			return ctrl.Result{RequeueAfter: 1 * time.Second}, ErrNextLoop
+		}
 	}
 
-	contextLogger.Info(
-		"Recreating the missing bootstrap Job for the primary instance",
-		"instance", instanceToCreate.Name,
-		"serial", nodeSerial,
-	)
+	// The first primary is the only instance whose init Job is owned by this
+	// PVC-driven path. A replica is never created before a primary exists, so
+	// while the cluster has no established primary (CurrentPrimary == "") a
+	// podless PVC needing a Job is the first primary's init Job. This holds
+	// even if the status patch that set TargetPrimary in createPrimaryInstance
+	// lost an optimistic-lock conflict, which is exactly the deadlock #11036
+	// guards against. Once a primary is running, joinReplicaInstance owns Job
+	// creation for replicas (it creates the Job and then the PVCs), so a
+	// podless replica PVC without a Job means a previous attempt did not get
+	// that far; recreate the join Job there.
+	if cluster.Status.CurrentPrimary != "" && instanceToCreate.Name != cluster.Status.TargetPrimary {
+		contextLogger.Info("Recreating the join Job for an instance whose PVCs are not ready",
+			"instance", instanceToCreate.Name)
+		return r.joinReplicaInstance(ctx, serial, cluster)
+	}
 
 	// Set TargetPrimary defensively: if it is not set the instance manager would
 	// shut the primary down as soon as it starts (see reconcileOldPrimary).
 	if cluster.Status.TargetPrimary != instanceToCreate.Name {
 		if err := r.setPrimaryInstance(ctx, cluster, instanceToCreate.Name); err != nil {
-			return ctrl.Result{}, false, fmt.Errorf("unable to set the primary instance name: %w", err)
+			return ctrl.Result{}, fmt.Errorf("unable to set the primary instance name: %w", err)
 		}
 	}
 
-	backup, recoverySnapshot, res, err := r.resolvePrimaryRecoverySource(ctx, cluster)
-	if !res.IsZero() || err != nil {
-		return res, true, err
-	}
-
-	job, err := r.buildPrimaryInstanceJob(ctx, cluster, nodeSerial, backup, recoverySnapshot)
+	job, err := r.buildPrimaryInstanceJob(ctx, cluster, serial, primaryDataSource)
 	if err != nil {
-		return ctrl.Result{}, true, err
+		return ctrl.Result{}, err
 	}
 
-	if err := ctrl.SetControllerReference(cluster, job, r.Scheme); err != nil {
-		return ctrl.Result{}, true, fmt.Errorf("unable to set the owner reference for the bootstrap Job: %w", err)
+	contextLogger.Info("Creating the bootstrap Job for the primary instance",
+		"instance", instanceToCreate.Name,
+		"job", job.Name,
+	)
+	if res, err := r.createInstanceJob(ctx, cluster, job, true); err != nil || !res.IsZero() {
+		return res, err
 	}
 
-	inheritJobMetadata(cluster, job)
-
-	if err := r.Create(ctx, job); err != nil {
-		if apierrs.IsAlreadyExists(err) {
-			// This Job was already created, maybe the cache is stale.
-			return ctrl.Result{RequeueAfter: 1 * time.Second}, true, nil
-		}
-		contextLogger.Error(err, "Unable to create the bootstrap Job", "job", job)
-		return ctrl.Result{}, true, err
-	}
-
-	return ctrl.Result{RequeueAfter: 1 * time.Second}, true, ErrNextLoop
+	return ctrl.Result{RequeueAfter: time.Second}, ErrNextLoop
 }
 
 // checkReadyForRecovery checks if the backup or volumeSnapshots are ready, and

--- a/internal/controller/cluster_create.go
+++ b/internal/controller/cluster_create.go
@@ -1783,15 +1783,21 @@ func (r *ClusterReconciler) ensureInstanceBootstrapJob(
 	}
 
 	// A previous attempt may have been interrupted between creating the PVCs:
-	// compare the existing PVCs with the volumes the instance mounts to detect
-	// a PVC group that is missing some of its members.
-	expectedPVCCount := 0
-	for _, volume := range instanceToCreate.Spec.Volumes {
-		if volume.PersistentVolumeClaim != nil {
-			expectedPVCCount++
+	// detect a PVC group that is missing some of its members. The expected
+	// group is derived from the cluster specification, the same source the
+	// PVC classifier uses, so that a pod template customized through the
+	// podPatch annotation cannot skew the comparison.
+	pvcGroupComplete := true
+	for _, expectedName := range persistentvolumeclaim.GetExpectedInstancePVCNamesFromCluster(
+		cluster, instanceToCreate.Name,
+	) {
+		if !slices.ContainsFunc(resources.pvcs.Items, func(pvc corev1.PersistentVolumeClaim) bool {
+			return pvc.Name == expectedName
+		}) {
+			pvcGroupComplete = false
+			break
 		}
 	}
-	pvcGroupComplete := len(instancePVCNames) == expectedPVCCount
 
 	// If a Job is already advancing these PVCs, wait for it to complete.
 	for i := range resources.jobs.Items {

--- a/internal/controller/cluster_create.go
+++ b/internal/controller/cluster_create.go
@@ -1171,7 +1171,7 @@ func (r *ClusterReconciler) createPrimaryInstance(
 	// Ensure the PVCs for the first node exist, picking the right storage
 	// source if we are bootstrapping from a backup or a volume snapshot. This
 	// blocks until the source is ready.
-	if res, err := r.ensurePrimaryInstancePVCs(ctx, cluster, nodeSerial); !res.IsZero() || err != nil {
+	if res, err := r.ensurePrimaryInstancePVCs(ctx, cluster, nodeSerial, nil); !res.IsZero() || err != nil {
 		return res, err
 	}
 
@@ -1201,10 +1201,19 @@ func (r *ClusterReconciler) createPrimaryInstance(
 // selecting the proper storage source when bootstrapping from a backup or a
 // volume snapshot. A non-zero result means the bootstrap source is not ready
 // yet and the caller should requeue.
+//
+// existingDataSource is the PGDATA PVC's own Spec.DataSource, if the PGDATA
+// PVC already exists (a previous attempt got at least that far). When set, it
+// must agree with the storage source resolved here: the PGDATA PVC's
+// DataSource is fixed at creation time, while the resolution below re-reads
+// the current Backup/cluster state, and the two must not be allowed to
+// silently diverge (for example a sibling PVC being recreated from a
+// different snapshot than the one PGDATA actually holds).
 func (r *ClusterReconciler) ensurePrimaryInstancePVCs(
 	ctx context.Context,
 	cluster *apiv1.Cluster,
 	nodeSerial int,
+	existingDataSource *corev1.TypedLocalObjectReference,
 ) (ctrl.Result, error) {
 	var recoverySnapshot *persistentvolumeclaim.StorageSource
 
@@ -1225,6 +1234,12 @@ func (r *ClusterReconciler) ensurePrimaryInstancePVCs(
 		recoverySnapshot = persistentvolumeclaim.GetCandidateStorageSourceForPrimary(cluster, backup)
 	}
 
+	if err := validateStorageSourceAgreesWithExisting(
+		recoverySnapshot, existingDataSource, cluster.Name, nodeSerial,
+	); err != nil {
+		return ctrl.Result{}, err
+	}
+
 	// Create the PVCs from the cluster definition, and if bootstrapping from
 	// recoverySnapshot, use that as the source
 	if err := persistentvolumeclaim.CreateInstancePVCs(
@@ -1238,6 +1253,40 @@ func (r *ClusterReconciler) ensurePrimaryInstancePVCs(
 	}
 
 	return ctrl.Result{}, nil
+}
+
+// validateStorageSourceAgreesWithExisting fails cleanly instead of recreating
+// a sibling PVC (typically WAL) from a storage source that disagrees with the
+// PGDATA PVC already on disk. existingDataSource is nil when the PGDATA PVC
+// does not exist yet (fresh bootstrap): there is nothing to compare against,
+// and candidate is free to be whatever the current cluster/Backup state
+// resolves to.
+func validateStorageSourceAgreesWithExisting(
+	candidate *persistentvolumeclaim.StorageSource,
+	existingDataSource *corev1.TypedLocalObjectReference,
+	clusterName string,
+	nodeSerial int,
+) error {
+	if existingDataSource == nil {
+		return nil
+	}
+
+	var candidateDataSource *corev1.TypedLocalObjectReference
+	if candidate != nil {
+		candidateDataSource = &candidate.DataSource
+	}
+
+	if candidateDataSource != nil && reflect.DeepEqual(*candidateDataSource, *existingDataSource) {
+		return nil
+	}
+
+	return fmt.Errorf(
+		"cannot recreate the missing PVCs of instance %v: the resolved recovery source (%v) "+
+			"disagrees with the data source already recorded on its PGDATA PVC (%v)",
+		specs.GetInstanceName(clusterName, nodeSerial),
+		candidateDataSource,
+		existingDataSource,
+	)
 }
 
 // buildPrimaryInstanceJob builds the bootstrap Job for the first primary
@@ -1830,9 +1879,11 @@ func (r *ClusterReconciler) ensureInstanceBootstrapJob(
 	// bootstrap configuration, before creating the Job. A Job whose Pod
 	// references a PVC that does not exist stays pending forever, and its
 	// presence blocks the rest of the reconciliation behind the running-jobs
-	// guard.
+	// guard. When the PGDATA PVC already exists, the resolved source must
+	// agree with what PGDATA actually holds, or the sibling PVC would be
+	// recreated from a different snapshot than the one already restored.
 	if !pvcGroupComplete {
-		if res, err := r.ensurePrimaryInstancePVCs(ctx, cluster, serial); !res.IsZero() || err != nil {
+		if res, err := r.ensurePrimaryInstancePVCs(ctx, cluster, serial, pgdataDataSource); !res.IsZero() || err != nil {
 			return res, err
 		}
 	}

--- a/internal/controller/cluster_create.go
+++ b/internal/controller/cluster_create.go
@@ -1243,8 +1243,8 @@ func (r *ClusterReconciler) ensurePrimaryInstancePVCs(
 // buildPrimaryInstanceJob builds the bootstrap Job for the first primary
 // instance, selecting the variant (initdb, recovery, pgBaseBackup or volume
 // snapshot restore) according to the cluster bootstrap configuration. It is
-// invoked both at first-primary creation and from the unified
-// PVC-state-driven path when an initializing primary PVC has no Job yet.
+// invoked from the unified PVC-state-driven path (ensureInstanceBootstrapJob)
+// when an initializing primary PVC has no Job advancing it.
 //
 // dataSource is the PGDATA PVC's own Spec.DataSource, if any: since the PVC
 // already exists by the time this runs, its DataSource is the authoritative
@@ -1268,6 +1268,16 @@ func (r *ClusterReconciler) buildPrimaryInstanceJob(
 		if err != nil {
 			return nil, err
 		}
+		// getOriginBackup tolerates a missing Backup object by returning nil:
+		// fail here rather than building a Job that points to a recovery
+		// source that no longer exists.
+		if backup == nil && cluster.Spec.Bootstrap.Recovery.Backup != nil {
+			return nil, fmt.Errorf(
+				"cannot build the bootstrap Job for instance %v: the Backup %q it recovers from no longer exists",
+				specs.GetInstanceName(cluster.Name, nodeSerial),
+				cluster.Spec.Bootstrap.Recovery.Backup.Name,
+			)
+		}
 	}
 
 	switch {
@@ -1280,6 +1290,13 @@ func (r *ClusterReconciler) buildPrimaryInstanceJob(
 		)
 		if err != nil {
 			return nil, err
+		}
+		if metadata == nil {
+			return nil, fmt.Errorf(
+				"cannot build the bootstrap Job for instance %v: the data source %q of its PGDATA PVC no longer exists",
+				specs.GetInstanceName(cluster.Name, nodeSerial),
+				dataSource.Name,
+			)
 		}
 		r.Recorder.Event(cluster, "Normal", "CreatingInstance", "Primary instance (from volumeSnapshots)")
 		return specs.CreatePrimaryJobViaRestoreSnapshot(*cluster, nodeSerial, metadata, backup), nil

--- a/internal/controller/cluster_create.go
+++ b/internal/controller/cluster_create.go
@@ -1819,6 +1819,18 @@ func (r *ClusterReconciler) ensureInstanceBootstrapJob(
 		return r.recreateReplicaBootstrapJob(ctx, cluster, serial, pgdataDataSource, pvcGroupComplete)
 	}
 
+	// A previous attempt may have been interrupted while creating the PVC
+	// group: recreate any missing PVC, choosing the storage source from the
+	// bootstrap configuration, before creating the Job. A Job whose Pod
+	// references a PVC that does not exist stays pending forever, and its
+	// presence blocks the rest of the reconciliation behind the running-jobs
+	// guard.
+	if !pvcGroupComplete {
+		if res, err := r.ensurePrimaryInstancePVCs(ctx, cluster, serial); !res.IsZero() || err != nil {
+			return res, err
+		}
+	}
+
 	// Set TargetPrimary defensively: if it is not set the instance manager would
 	// shut the primary down as soon as it starts (see reconcileOldPrimary).
 	if cluster.Status.TargetPrimary != instanceToCreate.Name {

--- a/pkg/reconciler/persistentvolumeclaim/resources.go
+++ b/pkg/reconciler/persistentvolumeclaim/resources.go
@@ -81,7 +81,7 @@ func isResizing(pvc corev1.PersistentVolumeClaim) bool {
 
 // BelongToInstance returns a boolean indicating if that given PVC belongs to an instance
 func BelongToInstance(cluster *apiv1.Cluster, instanceName, pvcName string) bool {
-	expectedPVCs := getExpectedInstancePVCNamesFromCluster(cluster, instanceName)
+	expectedPVCs := GetExpectedInstancePVCNamesFromCluster(cluster, instanceName)
 	return slices.Contains(expectedPVCs, pvcName)
 }
 
@@ -114,7 +114,7 @@ func filterByInstanceExpectedPVCs(
 	instanceName string,
 	pvcs []corev1.PersistentVolumeClaim,
 ) []corev1.PersistentVolumeClaim {
-	expectedInstancePVCs := getExpectedInstancePVCNamesFromCluster(cluster, instanceName)
+	expectedInstancePVCs := GetExpectedInstancePVCNamesFromCluster(cluster, instanceName)
 	var belongingPVCs []corev1.PersistentVolumeClaim
 	for i := range pvcs {
 		pvc := pvcs[i]
@@ -137,7 +137,7 @@ func getNamesFromPVCList(pvcs []corev1.PersistentVolumeClaim) []string {
 
 // InstanceHasMissingMounts returns true if the instance has expected PVCs that are not mounted
 func InstanceHasMissingMounts(cluster *apiv1.Cluster, instance *corev1.Pod) bool {
-	for _, pvcName := range getExpectedInstancePVCNamesFromCluster(cluster, instance.Name) {
+	for _, pvcName := range GetExpectedInstancePVCNamesFromCluster(cluster, instance.Name) {
 		if !IsUsedByPodSpec(instance.Spec, pvcName) {
 			return true
 		}
@@ -178,8 +178,8 @@ func getExpectedPVCsFromCluster(cluster *apiv1.Cluster, instanceName string) []e
 	return buildExpectedPVCs(instanceName, roles)
 }
 
-// getExpectedInstancePVCNamesFromCluster gets all the PVC names for a given instance
-func getExpectedInstancePVCNamesFromCluster(cluster *apiv1.Cluster, instanceName string) []string {
+// GetExpectedInstancePVCNamesFromCluster gets all the PVC names for a given instance
+func GetExpectedInstancePVCNamesFromCluster(cluster *apiv1.Cluster, instanceName string) []string {
 	expectedPVCs := getExpectedPVCsFromCluster(cluster, instanceName)
 	expectedPVCNames := make([]string, len(expectedPVCs))
 	for idx, mount := range expectedPVCs {

--- a/pkg/reconciler/persistentvolumeclaim/status.go
+++ b/pkg/reconciler/persistentvolumeclaim/status.go
@@ -254,7 +254,7 @@ func classifyPVC(
 		return ignored
 	}
 
-	expectedPVCs := getExpectedInstancePVCNamesFromCluster(cluster, instanceName)
+	expectedPVCs := GetExpectedInstancePVCNamesFromCluster(cluster, instanceName)
 	pvcNames := getNamesFromPVCList(pvcList)
 
 	// PVC is part of an incomplete group


### PR DESCRIPTION
Instances can get permanently stuck during bootstrap or replica creation:
the PVC is provisioned and Bound in Kubernetes, but the operator's own
`cnpg.io/pvcStatus` annotation stays `initializing` forever, and the logs
just repeat "Selected PVC is not ready yet, waiting for 1 second" with
no error, and no Pod ever appearing (#7709).

This happens because PVC creation and the bootstrap Job that populates
it are two separate steps, and nothing recovers if something interrupts
the flow between them.

Previously, only the first primary had logic to recreate a missing bootstrap Job
(#11036); any other instance (replicas in particular) left in this
state had no recovery path at all and would wait indefinitely, requiring
manual PVC deletion.

This PR makes Job recreation PVC-state-driven for every instance, not
just the first primary, and hardens the several edge cases that
surfaced once replicas went through the same self-healing path.

Closes #7709
Refs #11036
