### PR TITLE
test(e2e): adopt retriable object Patch/PatchStatus/Update helpers suite-wide

### DIFF
--- a/tests/e2e/configuration_update_test.go
+++ b/tests/e2e/configuration_update_test.go
@@ -44,6 +44,7 @@ import (
 	pgasserts "github.com/cloudnative-pg/cloudnative-pg/tests/internal/asserts/postgres"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/clusterutils"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/exec"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/objects"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/postgres"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/timeouts"
 
@@ -566,7 +567,7 @@ var _ = Describe("Configuration update", Label(tests.LabelClusterMetadata), func
 				updated := cluster.DeepCopy()
 				updated.Spec.PostgresConfiguration.Parameters["max_connections"] = fmt.Sprintf("%v",
 					newMaxConnectionsValue)
-				err = env.Client.Patch(env.Ctx, updated, client.MergeFrom(cluster))
+				err = objects.Patch(env.Ctx, env.Client, updated, client.MergeFrom(cluster))
 				Expect(err).ToNot(HaveOccurred())
 			})
 

--- a/tests/e2e/declarative_database_role_management_test.go
+++ b/tests/e2e/declarative_database_role_management_test.go
@@ -318,7 +318,7 @@ var _ = Describe("Declarative role management", Label(tests.LabelSmoke, tests.La
 					updatedValidUntil := metav1.NewTime(time.Date(2050, 6, 15, 12, 0, 0, 0, time.UTC))
 					role.Spec.ValidUntil = &updatedValidUntil
 					role.Spec.Comment = "updated comment"
-					Expect(env.Client.Patch(env.Ctx, role, client.MergeFrom(oldRole))).To(Succeed())
+					Expect(objects.Patch(env.Ctx, env.Client, role, client.MergeFrom(oldRole))).To(Succeed())
 				})
 
 				By("verifying updated attributes in PostgreSQL", func() {
@@ -526,7 +526,7 @@ var _ = Describe("Declarative role management", Label(tests.LabelSmoke, tests.La
 					role.Spec.PasswordSecret = &apiv1.LocalObjectReference{
 						Name: secretName,
 					}
-					Expect(env.Client.Update(env.Ctx, role)).To(Succeed())
+					Expect(objects.Update(env.Ctx, env.Client, role)).To(Succeed())
 				})
 
 				By("ensuring the CR has been reconciled", func() {
@@ -558,7 +558,7 @@ var _ = Describe("Declarative role management", Label(tests.LabelSmoke, tests.La
 
 					newPassword = fmt.Sprintf("newpassword-%d", funk.RandomInt(0, 9999))
 					passwordSecret.Data["password"] = []byte(newPassword)
-					Expect(env.Client.Update(env.Ctx, passwordSecret)).To(Succeed())
+					Expect(objects.Update(env.Ctx, env.Client, passwordSecret)).To(Succeed())
 				})
 
 				By("checking if we can connect to PostgreSQL using the new password", func() {
@@ -789,7 +789,7 @@ var _ = Describe("Declarative role management", Label(tests.LabelSmoke, tests.La
 					Expect(env.Client.Get(env.Ctx, roleKey, role)).To(Succeed())
 					oldRole := role.DeepCopy()
 					role.Spec.ClientCertificate.Enabled = ptr.To(false)
-					Expect(env.Client.Patch(env.Ctx, role, client.MergeFrom(oldRole))).To(Succeed())
+					Expect(objects.Patch(env.Ctx, env.Client, role, client.MergeFrom(oldRole))).To(Succeed())
 
 					Eventually(func(g Gomega) {
 						var secret corev1.Secret
@@ -809,7 +809,7 @@ var _ = Describe("Declarative role management", Label(tests.LabelSmoke, tests.La
 					Expect(env.Client.Get(env.Ctx, roleKey, role)).To(Succeed())
 					oldRole := role.DeepCopy()
 					role.Spec.ClientCertificate.Enabled = ptr.To(true)
-					Expect(env.Client.Patch(env.Ctx, role, client.MergeFrom(oldRole))).To(Succeed())
+					Expect(objects.Patch(env.Ctx, env.Client, role, client.MergeFrom(oldRole))).To(Succeed())
 
 					Eventually(func(g Gomega) {
 						var secret corev1.Secret

--- a/tests/e2e/declarative_hibernation_test.go
+++ b/tests/e2e/declarative_hibernation_test.go
@@ -30,6 +30,7 @@ import (
 	clusterasserts "github.com/cloudnative-pg/cloudnative-pg/tests/internal/asserts/cluster"
 	pgasserts "github.com/cloudnative-pg/cloudnative-pg/tests/internal/asserts/postgres"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/clusterutils"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/objects"
 	testsUtils "github.com/cloudnative-pg/cloudnative-pg/tests/utils/postgres"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/yaml"
 
@@ -51,7 +52,7 @@ var _ = Describe("Cluster declarative hibernation", func() {
 		}
 	})
 
-	It("hibernates an existing cluster", func(ctx SpecContext) {
+	It("hibernates an existing cluster", func() {
 		const namespacePrefix = "declarative-hibernation"
 
 		clusterName, err := yaml.GetResourceNameFromYAML(env.Scheme, sampleFileCluster)
@@ -81,7 +82,7 @@ var _ = Describe("Cluster declarative hibernation", func() {
 			originCluster := cluster.DeepCopy()
 			cluster.Annotations[utils.HibernationAnnotationName] = hibernation.HibernationOn
 
-			Expect(env.Client.Patch(ctx, cluster, ctrlclient.MergeFrom(originCluster))).To(Succeed())
+			Expect(objects.Patch(env.Ctx, env.Client, cluster, ctrlclient.MergeFrom(originCluster))).To(Succeed())
 		})
 
 		By("waiting for the cluster to be hibernated correctly", func() {
@@ -106,7 +107,7 @@ var _ = Describe("Cluster declarative hibernation", func() {
 			}
 			originCluster := cluster.DeepCopy()
 			cluster.Annotations[utils.HibernationAnnotationName] = hibernation.HibernationOff
-			Expect(env.Client.Patch(ctx, cluster, ctrlclient.MergeFrom(originCluster))).To(Succeed())
+			Expect(objects.Patch(env.Ctx, env.Client, cluster, ctrlclient.MergeFrom(originCluster))).To(Succeed())
 		})
 
 		var cluster *apiv1.Cluster

--- a/tests/e2e/destroy_instance_test.go
+++ b/tests/e2e/destroy_instance_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cloudnative-pg/cloudnative-pg/tests"
 	clusterasserts "github.com/cloudnative-pg/cloudnative-pg/tests/internal/asserts/cluster"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/clusterutils"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/objects"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/storage"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/timeouts"
 
@@ -106,7 +107,7 @@ var _ = Describe("Test destroy instance", func() {
 				originalPod := pod.DeepCopy()
 				pod.Annotations[utils.UnrecoverableInstanceAnnotationName] = "true"
 
-				err = env.Client.Patch(env.Ctx, &pod, ctrlclient.MergeFrom(originalPod))
+				err = objects.Patch(env.Ctx, env.Client, &pod, ctrlclient.MergeFrom(originalPod))
 				Expect(err).ToNot(
 					HaveOccurred(),
 					"failed to patch pod with unrecoverable instance annotation")

--- a/tests/e2e/disk_space_test.go
+++ b/tests/e2e/disk_space_test.go
@@ -34,6 +34,7 @@ import (
 	clusterasserts "github.com/cloudnative-pg/cloudnative-pg/tests/internal/asserts/cluster"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/clusterutils"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/exec"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/objects"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/pods"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/postgres"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/timeouts"
@@ -146,7 +147,7 @@ var _ = Describe("Volume space unavailable", Label(tests.LabelStorage), func() {
 			originPVC := primaryWALPVC.DeepCopy()
 			newSize := *resource.NewScaledQuantity(2, resource.Giga)
 			primaryWALPVC.Spec.Resources.Requests[corev1.ResourceStorage] = newSize
-			Expect(env.Client.Patch(env.Ctx, primaryWALPVC, ctrlclient.MergeFrom(originPVC))).To(Succeed())
+			Expect(objects.Patch(env.Ctx, env.Client, primaryWALPVC, ctrlclient.MergeFrom(originPVC))).To(Succeed())
 			Eventually(func(g Gomega) int64 {
 				err := env.Client.Get(env.Ctx,
 					types.NamespacedName{Namespace: primaryPod.Namespace, Name: primaryWALPVC.Name},

--- a/tests/e2e/drain_node_test.go
+++ b/tests/e2e/drain_node_test.go
@@ -35,6 +35,7 @@ import (
 	replicationasserts "github.com/cloudnative-pg/cloudnative-pg/tests/internal/asserts/replication"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/clusterutils"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/nodes"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/objects"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/pods"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/postgres"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/run"
@@ -598,7 +599,7 @@ var _ = Describe("E2E Drain Node", Serial, Label(tests.LabelDisruptive, tests.La
 
 					updated := cluster.DeepCopy()
 					updated.Spec.EnablePDB = ptr.To(true)
-					err = env.Client.Patch(env.Ctx, updated, client.MergeFrom(cluster))
+					err = objects.Patch(env.Ctx, env.Client, updated, client.MergeFrom(cluster))
 					Expect(err).ToNot(HaveOccurred())
 				})
 

--- a/tests/e2e/eviction_test.go
+++ b/tests/e2e/eviction_test.go
@@ -34,6 +34,7 @@ import (
 	clusterasserts "github.com/cloudnative-pg/cloudnative-pg/tests/internal/asserts/cluster"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/clusterutils"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/environment"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/objects"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/run"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/timeouts"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/yaml"
@@ -81,7 +82,7 @@ var _ = Describe("Pod eviction", Serial, Label(tests.LabelDisruptive), func() {
 		pod.Status.Phase = "Failed"
 		pod.Status.Reason = "Evicted"
 		// Patching the Pod status
-		err = env.Client.Status().Patch(env.Ctx, &pod, patch)
+		err = objects.PatchStatus(env.Ctx, env.Client, &pod, patch)
 		if err != nil {
 			return fmt.Errorf("failed to patch status for Pod: %v", pod.Name)
 		}

--- a/tests/e2e/imagevolume_extensions_test.go
+++ b/tests/e2e/imagevolume_extensions_test.go
@@ -42,6 +42,7 @@ import (
 	pgasserts "github.com/cloudnative-pg/cloudnative-pg/tests/internal/asserts/postgres"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/internal/resources"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/clusterutils"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/objects"
 	postgresutils "github.com/cloudnative-pg/cloudnative-pg/tests/utils/postgres"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/timeouts"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/yaml"
@@ -404,7 +405,7 @@ var _ = Describe("ImageVolume Extensions", Label(tests.LabelImageVolumeExtension
 					Reference: fmt.Sprintf("ghcr.io/cloudnative-pg/pgvector:0.8.1-%d-trixie", env.PostgresVersion),
 				},
 			})
-			err = env.Client.Update(env.Ctx, catalog)
+			err = objects.Update(env.Ctx, env.Client, catalog)
 			Expect(err).ToNot(HaveOccurred())
 
 			extensionConfig := apiv1.ExtensionConfiguration{Name: "pgvector"}

--- a/tests/e2e/pg_data_corruption_test.go
+++ b/tests/e2e/pg_data_corruption_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/cloudnative-pg/cloudnative-pg/tests/internal/resources"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/clusterutils"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/exec"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/objects"
 	podutils "github.com/cloudnative-pg/cloudnative-pg/tests/utils/pods"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/postgres"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/storage"
@@ -303,14 +304,14 @@ var _ = Describe("PGDATA Corruption", Label(tests.LabelRecovery), Ordered, func(
 				walPVC := &corev1.PersistentVolumeClaim{}
 				Expect(env.Client.Get(env.Ctx, walPVCKey, walPVC)).To(Succeed())
 				controllerutil.AddFinalizer(walPVC, holdFinalizer)
-				Expect(env.Client.Update(env.Ctx, walPVC)).To(Succeed())
+				Expect(objects.Update(env.Ctx, env.Client, walPVC)).To(Succeed())
 			})
 			// Always release the WAL PVC, otherwise namespace teardown would hang.
 			DeferCleanup(func() {
 				walPVC := &corev1.PersistentVolumeClaim{}
 				if err := env.Client.Get(env.Ctx, walPVCKey, walPVC); err == nil {
 					if controllerutil.RemoveFinalizer(walPVC, holdFinalizer) {
-						_ = env.Client.Update(env.Ctx, walPVC)
+						_ = objects.Update(env.Ctx, env.Client, walPVC)
 					}
 				}
 			})
@@ -357,7 +358,7 @@ var _ = Describe("PGDATA Corruption", Label(tests.LabelRecovery), Ordered, func(
 				walPVC := &corev1.PersistentVolumeClaim{}
 				Expect(env.Client.Get(env.Ctx, walPVCKey, walPVC)).To(Succeed())
 				controllerutil.RemoveFinalizer(walPVC, holdFinalizer)
-				Expect(env.Client.Update(env.Ctx, walPVC)).To(Succeed())
+				Expect(objects.Update(env.Ctx, env.Client, walPVC)).To(Succeed())
 			})
 
 			By("verifying the instance is recreated and rejoins as a ready standby", func() {

--- a/tests/e2e/pod_patch_test.go
+++ b/tests/e2e/pod_patch_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cloudnative-pg/cloudnative-pg/tests"
 	clusterasserts "github.com/cloudnative-pg/cloudnative-pg/tests/internal/asserts/cluster"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/clusterutils"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/objects"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -72,7 +73,7 @@ var _ = Describe("Pod patch", Label(tests.LabelSmoke, tests.LabelBasic), func() 
 					]
 				`,
 			})
-			err = env.Client.Patch(env.Ctx, patchedCluster, client.MergeFrom(cluster))
+			err = objects.Patch(env.Ctx, env.Client, patchedCluster, client.MergeFrom(cluster))
 			Expect(err).ToNot(HaveOccurred())
 		})
 

--- a/tests/e2e/pooler_imagecatalog_test.go
+++ b/tests/e2e/pooler_imagecatalog_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/versions"
 	"github.com/cloudnative-pg/cloudnative-pg/tests"
 	clusterasserts "github.com/cloudnative-pg/cloudnative-pg/tests/internal/asserts/cluster"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/objects"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/yaml"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -153,7 +154,7 @@ var _ = Describe("Pooler ImageCatalog", Label(tests.LabelBasic), func() {
 					client.ObjectKey{Namespace: namespace, Name: catalogName},
 					&catalog)).To(Succeed())
 				catalog.Spec.ComponentImages[0].Image = updatedImage
-				Expect(env.Client.Update(env.Ctx, &catalog)).To(Succeed())
+				Expect(objects.Update(env.Ctx, env.Client, &catalog)).To(Succeed())
 			})
 
 			By("verifying the pooler status image is updated after the catalog change", func() {
@@ -316,7 +317,7 @@ var _ = Describe("Pooler ImageCatalog", Label(tests.LabelBasic), func() {
 				catalog.Spec.ComponentImages = []apiv1.CatalogComponentImage{
 					{Key: "nonexistent-key", Image: pgbouncerImage},
 				}
-				Expect(env.Client.Update(env.Ctx, &catalog)).To(Succeed())
+				Expect(objects.Update(env.Ctx, env.Client, &catalog)).To(Succeed())
 			})
 
 			By("verifying the pooler recovers to active and the deployment is created", func() {

--- a/tests/e2e/probes_test.go
+++ b/tests/e2e/probes_test.go
@@ -123,7 +123,7 @@ var _ = Describe("Probes configuration tests", Label(tests.LabelBasic), func() {
 			originalCluster := cluster.DeepCopy()
 			cluster.Spec.Probes = probesConfiguration.DeepCopy()
 
-			err = objects.Patch(env.Ctx, env.Client, &cluster, client.MergeFrom(originalCluster))
+			err = objects.Patch(ctx, env.Client, &cluster, client.MergeFrom(originalCluster))
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -166,7 +166,7 @@ var _ = Describe("Probes configuration tests", Label(tests.LabelBasic), func() {
 			originalCluster := cluster.DeepCopy()
 			cluster.Spec.Probes = &apiv1.ProbesConfiguration{}
 
-			err = objects.Patch(env.Ctx, env.Client, &cluster, client.MergeFrom(originalCluster))
+			err = objects.Patch(ctx, env.Client, &cluster, client.MergeFrom(originalCluster))
 			Expect(err).ToNot(HaveOccurred())
 		})
 

--- a/tests/e2e/probes_test.go
+++ b/tests/e2e/probes_test.go
@@ -28,6 +28,7 @@ import (
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/tests"
 	clusterasserts "github.com/cloudnative-pg/cloudnative-pg/tests/internal/asserts/cluster"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/objects"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/timeouts"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -122,7 +123,7 @@ var _ = Describe("Probes configuration tests", Label(tests.LabelBasic), func() {
 			originalCluster := cluster.DeepCopy()
 			cluster.Spec.Probes = probesConfiguration.DeepCopy()
 
-			err = env.Client.Patch(ctx, &cluster, client.MergeFrom(originalCluster))
+			err = objects.Patch(env.Ctx, env.Client, &cluster, client.MergeFrom(originalCluster))
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -165,7 +166,7 @@ var _ = Describe("Probes configuration tests", Label(tests.LabelBasic), func() {
 			originalCluster := cluster.DeepCopy()
 			cluster.Spec.Probes = &apiv1.ProbesConfiguration{}
 
-			err = env.Client.Patch(ctx, &cluster, client.MergeFrom(originalCluster))
+			err = objects.Patch(env.Ctx, env.Client, &cluster, client.MergeFrom(originalCluster))
 			Expect(err).ToNot(HaveOccurred())
 		})
 

--- a/tests/e2e/replica_mode_cluster_test.go
+++ b/tests/e2e/replica_mode_cluster_test.go
@@ -259,7 +259,7 @@ var _ = Describe("Replica Mode", Label(tests.LabelReplication), func() {
 				Expect(err).ToNot(HaveOccurred())
 				updateTime := time.Now().Truncate(time.Second)
 				cluster.Spec.ReplicaCluster.Enabled = ptr.To(true)
-				err = objects.Update(env.Ctx, env.Client, cluster)
+				err = objects.Update(ctx, env.Client, cluster)
 				Expect(err).ToNot(HaveOccurred())
 				Eventually(func(g Gomega) {
 					cluster, err := clusterutils.Get(env.Ctx, env.Client, namespace, clusterOneName)
@@ -286,7 +286,7 @@ var _ = Describe("Replica Mode", Label(tests.LabelReplication), func() {
 				cluster, err := clusterutils.Get(env.Ctx, env.Client, namespace, clusterTwoName)
 				Expect(err).ToNot(HaveOccurred())
 				cluster.Spec.ReplicaCluster.Enabled = ptr.To(false)
-				err = objects.Update(env.Ctx, env.Client, cluster)
+				err = objects.Update(ctx, env.Client, cluster)
 				Expect(err).ToNot(HaveOccurred())
 				clusterasserts.AssertClusterIsReady(env, namespace, clusterTwoName, testTimeouts[timeouts.ClusterIsReady])
 			})

--- a/tests/e2e/replica_mode_cluster_test.go
+++ b/tests/e2e/replica_mode_cluster_test.go
@@ -47,6 +47,7 @@ import (
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/backups"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/clusterutils"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/exec"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/objects"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/objectstore"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/postgres"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/secrets"
@@ -258,7 +259,7 @@ var _ = Describe("Replica Mode", Label(tests.LabelReplication), func() {
 				Expect(err).ToNot(HaveOccurred())
 				updateTime := time.Now().Truncate(time.Second)
 				cluster.Spec.ReplicaCluster.Enabled = ptr.To(true)
-				err = env.Client.Update(ctx, cluster)
+				err = objects.Update(env.Ctx, env.Client, cluster)
 				Expect(err).ToNot(HaveOccurred())
 				Eventually(func(g Gomega) {
 					cluster, err := clusterutils.Get(env.Ctx, env.Client, namespace, clusterOneName)
@@ -285,7 +286,7 @@ var _ = Describe("Replica Mode", Label(tests.LabelReplication), func() {
 				cluster, err := clusterutils.Get(env.Ctx, env.Client, namespace, clusterTwoName)
 				Expect(err).ToNot(HaveOccurred())
 				cluster.Spec.ReplicaCluster.Enabled = ptr.To(false)
-				err = env.Client.Update(ctx, cluster)
+				err = objects.Update(env.Ctx, env.Client, cluster)
 				Expect(err).ToNot(HaveOccurred())
 				clusterasserts.AssertClusterIsReady(env, namespace, clusterTwoName, testTimeouts[timeouts.ClusterIsReady])
 			})
@@ -790,7 +791,7 @@ var _ = Describe("Replica switchover", Label(tests.LabelReplication, tests.Label
 				Expect(err).ToNot(HaveOccurred())
 				oldCluster := cluster.DeepCopy()
 				cluster.Spec.ReplicaCluster.Primary = clusterBName
-				Expect(env.Client.Patch(env.Ctx, cluster, k8client.MergeFrom(oldCluster))).To(Succeed())
+				Expect(objects.Patch(env.Ctx, env.Client, cluster, k8client.MergeFrom(oldCluster))).To(Succeed())
 				podList, err := clusterutils.ListPods(env.Ctx, env.Client, namespace, clusterAName)
 				Expect(err).ToNot(HaveOccurred())
 				for _, pod := range podList.Items {
@@ -821,7 +822,7 @@ var _ = Describe("Replica switchover", Label(tests.LabelReplication, tests.Label
 				oldCluster := cluster.DeepCopy()
 				cluster.Spec.ReplicaCluster.PromotionToken = invalidToken
 				cluster.Spec.ReplicaCluster.Primary = clusterBName
-				Expect(env.Client.Patch(env.Ctx, cluster, k8client.MergeFrom(oldCluster))).To(Succeed())
+				Expect(objects.Patch(env.Ctx, env.Client, cluster, k8client.MergeFrom(oldCluster))).To(Succeed())
 			})
 
 			By("failing to promote B with the invalid token", func() {
@@ -850,7 +851,7 @@ var _ = Describe("Replica switchover", Label(tests.LabelReplication, tests.Label
 				oldCluster := cluster.DeepCopy()
 				cluster.Spec.ReplicaCluster.PromotionToken = token
 				cluster.Spec.ReplicaCluster.Primary = clusterBName
-				Expect(env.Client.Patch(env.Ctx, cluster, k8client.MergeFrom(oldCluster))).To(Succeed())
+				Expect(objects.Patch(env.Ctx, env.Client, cluster, k8client.MergeFrom(oldCluster))).To(Succeed())
 			})
 
 			By("reaching the target timeline", func() {

--- a/tests/e2e/rolling_update_test.go
+++ b/tests/e2e/rolling_update_test.go
@@ -39,6 +39,7 @@ import (
 	storageasserts "github.com/cloudnative-pg/cloudnative-pg/tests/internal/asserts/storage"
 	testsUtils "github.com/cloudnative-pg/cloudnative-pg/tests/utils"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/clusterutils"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/objects"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/timeouts"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/yaml"
 
@@ -402,7 +403,7 @@ var _ = Describe("Rolling updates", Label(tests.LabelPostgresConfiguration), fun
 		By("updating the catalog", func() {
 			// Update to the latest minor
 			catalog.GetSpec().Images[0].Image = updatedImageName
-			err := env.Client.Update(env.Ctx, catalog)
+			err := objects.Update(env.Ctx, env.Client, catalog)
 			Expect(err).ToNot(HaveOccurred())
 		})
 		AssertPodsRunOnImage(namespace, clusterName, updatedImageName, cluster.Spec.Instances, 900)

--- a/tests/e2e/syncreplicas_test.go
+++ b/tests/e2e/syncreplicas_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/exec"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/fencing"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/logs"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/objects"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/run"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/yaml"
 
@@ -215,14 +216,14 @@ var _ = Describe("Synchronous Replicas", Label(tests.LabelReplication), func() {
 				Expect(err).ToNot(HaveOccurred())
 				// Expect an error. MaxSyncReplicas must be lower than the number of instances
 				cluster.Spec.MaxSyncReplicas = 2
-				err = env.Client.Update(env.Ctx, cluster)
+				err = objects.Update(env.Ctx, env.Client, cluster)
 				Expect(err).To(HaveOccurred())
 
 				cluster, err = clusterutils.Get(env.Ctx, env.Client, namespace, clusterName)
 				Expect(err).ToNot(HaveOccurred())
 				// Expect an error. MinSyncReplicas must be lower than MaxSyncReplicas
 				cluster.Spec.MinSyncReplicas = 2
-				err = env.Client.Update(env.Ctx, cluster)
+				err = objects.Update(env.Ctx, env.Client, cluster)
 				Expect(err).To(HaveOccurred())
 			})
 		})
@@ -437,7 +438,7 @@ var _ = Describe("Synchronous Replicas", Label(tests.LabelReplication), func() {
 					}
 					cluster.Annotations[utils.ReconciliationLoopAnnotationName] = "disabled"
 
-					err = env.Client.Patch(env.Ctx, cluster, client.MergeFrom(origCluster))
+					err = objects.Patch(env.Ctx, env.Client, cluster, client.MergeFrom(origCluster))
 					Expect(err).ToNot(HaveOccurred())
 				})
 
@@ -466,7 +467,7 @@ var _ = Describe("Synchronous Replicas", Label(tests.LabelReplication), func() {
 					}
 					delete(cluster.Annotations, utils.ReconciliationLoopAnnotationName)
 
-					err = env.Client.Patch(env.Ctx, cluster, client.MergeFrom(origCluster))
+					err = objects.Patch(env.Ctx, env.Client, cluster, client.MergeFrom(origCluster))
 					Expect(err).ToNot(HaveOccurred())
 				})
 

--- a/tests/e2e/tablespaces_test.go
+++ b/tests/e2e/tablespaces_test.go
@@ -50,6 +50,7 @@ import (
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/clusterutils"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/exec"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/fencing"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/objects"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/objectstore"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/postgres"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/run"
@@ -192,7 +193,7 @@ var _ = Describe("Tablespaces tests", Label(tests.LabelTablespaces,
 				Expect(cluster.Spec.Tablespaces[0].Temporary).To(BeFalse())
 				updatedCluster := cluster.DeepCopy()
 				updatedCluster.Spec.Tablespaces[0].Temporary = true
-				err = env.Client.Patch(env.Ctx, updatedCluster, client.MergeFrom(cluster))
+				err = objects.Patch(env.Ctx, env.Client, updatedCluster, client.MergeFrom(cluster))
 				Expect(err).ToNot(HaveOccurred())
 
 				cluster = updatedCluster
@@ -848,7 +849,7 @@ var _ = Describe("Tablespaces tests", Label(tests.LabelTablespaces,
 
 				updated := cluster.DeepCopy()
 				updated.Spec.PrimaryUpdateMethod = apiv1.PrimaryUpdateMethodSwitchover
-				err = env.Client.Patch(env.Ctx, updated, client.MergeFrom(cluster))
+				err = objects.Patch(env.Ctx, env.Client, updated, client.MergeFrom(cluster))
 				Expect(err).ToNot(HaveOccurred())
 			})
 			By("waiting for the cluster to be ready", func() {
@@ -874,7 +875,7 @@ var _ = Describe("Tablespaces tests", Label(tests.LabelTablespaces,
 						},
 					},
 				}
-				err = env.Client.Patch(env.Ctx, updated, client.MergeFrom(cluster))
+				err = objects.Patch(env.Ctx, env.Client, updated, client.MergeFrom(cluster))
 				Expect(err).ToNot(HaveOccurred())
 
 				cluster, err = clusterutils.Get(env.Ctx, env.Client, namespace, clusterName)
@@ -912,7 +913,7 @@ func addTablespaces(cluster *apiv1.Cluster, tbsSlice []apiv1.TablespaceConfigura
 	updated := cluster.DeepCopy()
 	updated.Spec.Tablespaces = append(updated.Spec.Tablespaces, tbsSlice...)
 
-	err := env.Client.Patch(env.Ctx, updated, client.MergeFrom(cluster))
+	err := objects.Patch(env.Ctx, env.Client, updated, client.MergeFrom(cluster))
 	Expect(err).ToNot(HaveOccurred())
 }
 
@@ -923,7 +924,7 @@ func updateTablespaceOwner(cluster *apiv1.Cluster, tablespaceName, newOwner stri
 			updated.Spec.Tablespaces[idx].Owner.Name = newOwner
 		}
 	}
-	err := env.Client.Patch(env.Ctx, updated, client.MergeFrom(cluster))
+	err := objects.Patch(env.Ctx, env.Client, updated, client.MergeFrom(cluster))
 	Expect(err).ToNot(HaveOccurred())
 }
 
@@ -1323,7 +1324,7 @@ func hibernateOn(
 		originCluster := cluster.DeepCopy()
 		cluster.Annotations[utils.HibernationAnnotationName] = hibernation.HibernationOn
 
-		err = crudClient.Patch(context.Background(), cluster, client.MergeFrom(originCluster))
+		err = objects.Patch(context.Background(), crudClient, cluster, client.MergeFrom(originCluster))
 		return err
 	default:
 		return fmt.Errorf("unknown method: %v", method)
@@ -1349,7 +1350,7 @@ func hibernateOff(
 		originCluster := cluster.DeepCopy()
 		cluster.Annotations[utils.HibernationAnnotationName] = hibernation.HibernationOff
 
-		err = crudClient.Patch(context.Background(), cluster, client.MergeFrom(originCluster))
+		err = objects.Patch(context.Background(), crudClient, cluster, client.MergeFrom(originCluster))
 		return err
 	default:
 		return fmt.Errorf("unknown method: %v", method)

--- a/tests/e2e/upgrade_test.go
+++ b/tests/e2e/upgrade_test.go
@@ -48,6 +48,7 @@ import (
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/clusterutils"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/exec"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/namespaces"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/objects"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/objectstore"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/operator"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/postgres"
@@ -181,7 +182,7 @@ var _ = Describe("Upgrade", Label(tests.LabelUpgrade, tests.LabelNoOpenshift), O
 		cluster.Spec.PostgresConfiguration.Parameters["max_replication_slots"] = "16"
 		cluster.Spec.PostgresConfiguration.Parameters["maintenance_work_mem"] = "256MB"
 		cluster.Spec.PostgresConfiguration.PgHBA[0] = "host all all all trust"
-		return env.Client.Patch(env.Ctx, cluster, ctrlclient.MergeFrom(oldCluster))
+		return objects.Patch(env.Ctx, env.Client, cluster, ctrlclient.MergeFrom(oldCluster))
 	}
 
 	AssertConfUpgrade := func(clusterName, upgradeNamespace string) {

--- a/tests/e2e/volume_snapshot_test.go
+++ b/tests/e2e/volume_snapshot_test.go
@@ -45,6 +45,7 @@ import (
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/backups"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/clusterutils"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/exec"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/objects"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/objectstore"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/postgres"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/secrets"
@@ -589,7 +590,7 @@ var _ = Describe("Verify Volume Snapshot",
 
 					updated := cluster.DeepCopy()
 					updated.Spec.Instances = 1
-					err = env.Client.Patch(env.Ctx, updated, k8client.MergeFrom(cluster))
+					err = objects.Patch(env.Ctx, env.Client, updated, k8client.MergeFrom(cluster))
 					Expect(err).ToNot(HaveOccurred())
 				})
 

--- a/tests/utils/clusterutils/cluster.go
+++ b/tests/utils/clusterutils/cluster.go
@@ -259,7 +259,7 @@ func ScaleSize(
 	}
 	originalCluster := cluster.DeepCopy()
 	cluster.Spec.Instances = newClusterSize
-	err = crudClient.Patch(ctx, cluster, client.MergeFrom(originalCluster))
+	err = objects.Patch(ctx, crudClient, cluster, client.MergeFrom(originalCluster))
 	if err != nil {
 		return err
 	}

--- a/tests/utils/objects/objects.go
+++ b/tests/utils/objects/objects.go
@@ -89,11 +89,7 @@ func List(
 		retry.DelayType(retry.FixedDelay)).
 		Do(
 			func() error {
-				err := crudClient.List(ctx, objectList, opts...)
-				if err != nil {
-					return err
-				}
-				return nil
+				return crudClient.List(ctx, objectList, opts...)
 			},
 		)
 	return err
@@ -123,12 +119,14 @@ func Patch(
 	return err
 }
 
-// Get retrieves an object for the given object key from the Kubernetes Cluster
-func Get(
+// PatchStatus patches an object's status subresource in the Kubernetes cluster,
+// retrying on transient errors. See Patch for the rationale behind retrying.
+func PatchStatus(
 	ctx context.Context,
 	crudClient client.Client,
-	objectKey client.ObjectKey,
 	object client.Object,
+	patch client.Patch,
+	opts ...client.SubResourcePatchOption,
 ) error {
 	err := retry.New(
 		retry.Delay(PollingTime*time.Second),
@@ -136,11 +134,46 @@ func Get(
 		retry.DelayType(retry.FixedDelay)).
 		Do(
 			func() error {
-				err := crudClient.Get(ctx, objectKey, object)
-				if err != nil {
-					return err
-				}
-				return nil
+				return crudClient.Status().Patch(ctx, object, patch, opts...)
+			},
+		)
+	return err
+}
+
+// Get retrieves an object for the given object key from the Kubernetes Cluster
+func Get(
+	ctx context.Context,
+	crudClient client.Client,
+	objectKey client.ObjectKey,
+	object client.Object,
+	opts ...client.GetOption,
+) error {
+	err := retry.New(
+		retry.Delay(PollingTime*time.Second),
+		retry.Attempts(RetryAttempts),
+		retry.DelayType(retry.FixedDelay)).
+		Do(
+			func() error {
+				return crudClient.Get(ctx, objectKey, object, opts...)
+			},
+		)
+	return err
+}
+
+// Update updates an object in the Kubernetes Cluster
+func Update(
+	ctx context.Context,
+	crudClient client.Client,
+	object client.Object,
+	opts ...client.UpdateOption,
+) error {
+	err := retry.New(
+		retry.Delay(PollingTime*time.Second),
+		retry.Attempts(RetryAttempts),
+		retry.DelayType(retry.FixedDelay)).
+		Do(
+			func() error {
+				return crudClient.Update(ctx, object, opts...)
 			},
 		)
 	return err

--- a/tests/utils/objects/objects.go
+++ b/tests/utils/objects/objects.go
@@ -95,6 +95,17 @@ func List(
 	return err
 }
 
+// isRetryableWriteError reports whether err is a transient failure worth
+// retrying, as opposed to a decisive rejection from the API server (a stale
+// resourceVersion, a validation failure, an RBAC denial) that would recur
+// unchanged on a subsequent attempt with the same request.
+func isRetryableWriteError(err error) bool {
+	return !errors.IsConflict(err) &&
+		!errors.IsInvalid(err) &&
+		!errors.IsForbidden(err) &&
+		!errors.IsBadRequest(err)
+}
+
 // Patch patches an object in the Kubernetes cluster, retrying on transient
 // errors. Forwarding a mutation to an admission webhook can intermittently
 // fail with a 500/503 on any cluster that routes that hop through a proxy
@@ -110,7 +121,8 @@ func Patch(
 	err := retry.New(
 		retry.Delay(PollingTime*time.Second),
 		retry.Attempts(RetryAttempts),
-		retry.DelayType(retry.FixedDelay)).
+		retry.DelayType(retry.FixedDelay),
+		retry.RetryIf(isRetryableWriteError)).
 		Do(
 			func() error {
 				return crudClient.Patch(ctx, object, patch, opts...)
@@ -131,7 +143,8 @@ func PatchStatus(
 	err := retry.New(
 		retry.Delay(PollingTime*time.Second),
 		retry.Attempts(RetryAttempts),
-		retry.DelayType(retry.FixedDelay)).
+		retry.DelayType(retry.FixedDelay),
+		retry.RetryIf(isRetryableWriteError)).
 		Do(
 			func() error {
 				return crudClient.Status().Patch(ctx, object, patch, opts...)
@@ -160,7 +173,11 @@ func Get(
 	return err
 }
 
-// Update updates an object in the Kubernetes Cluster
+// Update updates an object in the Kubernetes Cluster, retrying on transient
+// errors. Unlike Patch, Update sends the object's resourceVersion, so a retry
+// after a successful-but-unacknowledged write would otherwise surface as a
+// spurious conflict rather than a no-op; isRetryableWriteError avoids
+// retrying that case.
 func Update(
 	ctx context.Context,
 	crudClient client.Client,
@@ -170,7 +187,8 @@ func Update(
 	err := retry.New(
 		retry.Delay(PollingTime*time.Second),
 		retry.Attempts(RetryAttempts),
-		retry.DelayType(retry.FixedDelay)).
+		retry.DelayType(retry.FixedDelay),
+		retry.RetryIf(isRetryableWriteError)).
 		Do(
 			func() error {
 				return crudClient.Update(ctx, object, opts...)

--- a/tests/utils/openshift/openshift.go
+++ b/tests/utils/openshift/openshift.go
@@ -93,7 +93,7 @@ func PatchStatusCondition(
 		}
 		clusterNoConditions := cluster.DeepCopy()
 		clusterNoConditions.Status.Conditions = nil
-		return crudClient.Patch(ctx, clusterNoConditions, client.MergeFrom(cluster))
+		return objects.Patch(ctx, crudClient, clusterNoConditions, client.MergeFrom(cluster))
 	})
 	if err != nil {
 		return err
@@ -264,5 +264,5 @@ func UpgradeSubscription(
 		return err
 	}
 
-	return crudClient.Patch(ctx, newSubscription, client.MergeFrom(subscription))
+	return objects.Patch(ctx, crudClient, newSubscription, client.MergeFrom(subscription))
 }

--- a/tests/utils/operator/operator.go
+++ b/tests/utils/operator/operator.go
@@ -250,7 +250,7 @@ func ScaleOperatorDeployment(
 	updatedOperatorDeployment := *operatorDeployment.DeepCopy()
 	updatedOperatorDeployment.Spec.Replicas = ptr.To(replicas)
 
-	err = crudClient.Patch(ctx, &updatedOperatorDeployment, client.MergeFrom(&operatorDeployment))
+	err = objects.Patch(ctx, crudClient, &updatedOperatorDeployment, client.MergeFrom(&operatorDeployment))
 	if err != nil {
 		return err
 	}

--- a/tests/utils/replicationslot/replication_slots.go
+++ b/tests/utils/replicationslot/replication_slots.go
@@ -39,6 +39,7 @@ import (
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/clusterutils"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/exec"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/objects"
 )
 
 // PrintReplicationSlots prints replications slots with their restart_lsn
@@ -227,7 +228,7 @@ func ToggleHAReplicationSlots(
 	}
 
 	clusterToggle.Spec.ReplicationSlots.HighAvailability.Enabled = ptr.To(enable)
-	err = crudClient.Patch(ctx, clusterToggle, client.MergeFrom(cluster))
+	err = objects.Patch(ctx, crudClient, clusterToggle, client.MergeFrom(cluster))
 	if err != nil {
 		return err
 	}
@@ -255,7 +256,7 @@ func ToggleSynchronizeReplicationSlots(
 	}
 
 	clusterToggle.Spec.ReplicationSlots.SynchronizeReplicas.Enabled = ptr.To(enable)
-	err = crudClient.Patch(ctx, clusterToggle, client.MergeFrom(cluster))
+	err = objects.Patch(ctx, crudClient, clusterToggle, client.MergeFrom(cluster))
 	if err != nil {
 		return err
 	}

--- a/tests/utils/secrets/secrets.go
+++ b/tests/utils/secrets/secrets.go
@@ -173,7 +173,7 @@ func CopyOperatorPullSecretToServiceAccount(
 	sa.ImagePullSecrets = append(sa.ImagePullSecrets, corev1.LocalObjectReference{
 		Name: pullSecretName,
 	})
-	if err := crudClient.Patch(ctx, &sa, client.MergeFrom(original)); err != nil {
+	if err := objects.Patch(ctx, crudClient, &sa, client.MergeFrom(original)); err != nil {
 		return fmt.Errorf("while patching service account with pull secret: %w", err)
 	}
 


### PR DESCRIPTION
Adopt `test/utils/object` helpers suite-wide to consistently retry on API server failures when doing `Patch`, `PatchStatus` or `Update` operations.
CRUD operations already wrapped by an `Eventually` or a `RetryOnConflict` are left intact.