### PR TITLE
docs: fix typos in comments, docstrings, and CLI help

### DIFF
--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -704,7 +704,7 @@ const (
 	// PhaseFirstPrimary for an starting cluster
 	PhaseFirstPrimary = "Setting up primary"
 
-	// PhaseCreatingReplica everytime we add a new replica
+	// PhaseCreatingReplica every time we add a new replica
 	PhaseCreatingReplica = "Creating a new replica"
 
 	// PhaseUpgrade upgrade in process

--- a/docs/src/kubectl-plugin.md
+++ b/docs/src/kubectl-plugin.md
@@ -1407,7 +1407,7 @@ The `cnpg subscription drop` command seamlessly complements the `create` command
 You can drop a `SUBSCRIPTION` with the following command structure:
 
 ```sh
-kubectl cnpg subcription drop \
+kubectl cnpg subscription drop \
   --subscription SUBSCRIPTION_NAME \
   LOCAL_CLUSTER [options]
 ```

--- a/internal/cmd/manager/instance/run/lifecycle/reaper.go
+++ b/internal/cmd/manager/instance/run/lifecycle/reaper.go
@@ -43,7 +43,7 @@ import (
 // 1 - a child process we manually executed via `exec.Cmd` (i.e. the postmaster) exited
 // 2 - a postmaster worker process terminated after the postmaster itself
 //
-// The second condition may seem unlikely but it unfortunately happens everytime
+// The second condition may seem unlikely but it unfortunately happens every time
 // the postmaster ends, even if just for the logging collector subprocess.
 //
 // As we can see in the postgres codebase (see [1]) the logging collector process
@@ -52,7 +52,7 @@ import (
 // postmaster and we'll receive a SIGCHLD.
 //
 // If we don't collect the logging collector exit code we would get a
-// zombie process everytime we restart the postmaster.
+// zombie process every time we restart the postmaster.
 //
 // Anyway, if we just accept any SIGCHLD signal, we would break the internals
 // of `os.exec.Command` preventing the detection of the exit code of the child

--- a/internal/cmd/plugin/logical/subscription/drop/doc.go
+++ b/internal/cmd/plugin/logical/subscription/drop/doc.go
@@ -17,5 +17,5 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 */
 
-// Package drop contains the implementatoin of the cnpg subscription drop command
+// Package drop contains the implementation of the cnpg subscription drop command
 package drop

--- a/internal/cmd/plugin/pgadmin/cmd.go
+++ b/internal/cmd/plugin/pgadmin/cmd.go
@@ -135,7 +135,7 @@ func NewCmd() *cobra.Command {
 		&pgadminImage,
 		"image",
 		"dpage/pgadmin4:latest",
-		"Specifes the pgadmin4 image to use, e.g. for internal registries.",
+		"Specifies the pgadmin4 image to use, e.g. for internal registries.",
 	)
 
 	return pgadminCmd

--- a/internal/cnpi/plugin/client/contracts.go
+++ b/internal/cnpi/plugin/client/contracts.go
@@ -113,8 +113,8 @@ type ReconcilerHookResult struct {
 	Identifier         string      `json:"identifier"`
 }
 
-// ClusterReconcilerHooks decsribes a set of behavior needed to enhance
-// the login of the Cluster reconcicliation loop
+// ClusterReconcilerHooks describes a set of behavior needed to enhance
+// the login of the Cluster reconciliation loop
 type ClusterReconcilerHooks interface {
 	// PreReconcile is executed after we get the resources and update the status
 	PreReconcile(

--- a/internal/controller/cluster_create.go
+++ b/internal/controller/cluster_create.go
@@ -263,7 +263,7 @@ func createOrPatchClusterCredentialSecret(
 	patchedSecret := currentSecret.DeepCopy()
 	utils.MergeObjectsMetadata(patchedSecret, proposed)
 
-	// we cannot compare the data due to the password being randomly generated everytime
+	// we cannot compare the data due to the password being randomly generated every time
 	if reflect.DeepEqual(patchedSecret.Labels, currentSecret.Labels) &&
 		reflect.DeepEqual(patchedSecret.Annotations, currentSecret.Annotations) {
 		return nil

--- a/internal/controller/replicas.go
+++ b/internal/controller/replicas.go
@@ -164,7 +164,7 @@ func (r *ClusterReconciler) reconcileTargetPrimaryForNonReplicaCluster(
 		return "", ErrWalReceiversRunning
 	}
 
-	// This may be tha last step of a failover if target primary is set to apiv1.PendingFailoverMarker
+	// This may be the last step of a failover if target primary is set to apiv1.PendingFailoverMarker
 	// or change the target primary if the current one is not valid anymore.
 	if cluster.Status.TargetPrimary == apiv1.PendingFailoverMarker {
 		contextLogger.Info("Failing over", "newPrimary", mostAdvancedInstance.Pod.Name)

--- a/internal/management/controller/roles/runnable.go
+++ b/internal/management/controller/roles/runnable.go
@@ -158,7 +158,7 @@ func (sr *RoleSynchronizer) reconcile(ctx context.Context, config *apiv1.Managed
 	}
 	appliedState, unreconciledRoles, err := sr.synchronizeRoles(ctx, superUserDB, config, rolePasswords)
 	if err != nil {
-		return fmt.Errorf("while syncrhonizing managed roles: %w", err)
+		return fmt.Errorf("while synchronizing managed roles: %w", err)
 	}
 
 	if err = sr.client.Get(ctx, types.NamespacedName{

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -21,7 +21,7 @@ SPDX-License-Identifier: Apache-2.0
 */
 
 // Package tools is used to track dependencies of tools we use in our
-// developement process. DO NOT REMOVE
+// development process. DO NOT REMOVE
 package tools
 
 import (

--- a/pkg/management/postgres/configuration.go
+++ b/pkg/management/postgres/configuration.go
@@ -436,13 +436,13 @@ func selectAdditionalExtensions(
 		nil
 }
 
-// configurePostgresForImport configures Postgres to be optimized for the firt import
+// configurePostgresForImport configures Postgres to be optimized for the first import
 // process, by writing dedicated options the override.conf file just for this phase
 func configurePostgresForImport(ctx context.Context, pgData string) (changed bool, err error) {
 	contextLogger := log.FromContext(ctx)
 	targetFile := path.Join(pgData, constants.PostgresqlOverrideConfigurationFile)
 
-	// Force the following GUCs to optmize the loading process
+	// Force the following GUCs to optimize the loading process
 	options := map[string]string{
 		"archive_mode":     "off",
 		"fsync":            "off",

--- a/pkg/reconciler/instance/certificate/reconciler.go
+++ b/pkg/reconciler/instance/certificate/reconciler.go
@@ -272,7 +272,7 @@ func (r *Reconciler) refreshServerCA(ctx context.Context, cluster *apiv1.Cluster
 // in the plugin-barman-cloud project
 func (r *Reconciler) refreshBarmanEndpointCA(ctx context.Context, cluster *apiv1.Cluster) (bool, error) {
 	// refreshFileFromSecret receive a secret and rewrite the file corresponding to
-	// the key to the provided location. Implementated with an inner function to discourage
+	// the key to the provided location. Implemented with an inner function to discourage
 	// reuse.
 	refreshFileFromSecret := func(
 		secret *corev1.Secret,


### PR DESCRIPTION
This PR fixes a set of genuine English spelling typos found in code comments, godoc, an error message, a CLI flag description, and a documentation command example. No functional changes.

| File | Before | After |
| --- | --- | --- |
| `internal/cmd/plugin/pgadmin/cmd.go` | Specifes | Specifies |
| `internal/cmd/plugin/logical/subscription/drop/doc.go` | implementatoin | implementation |
| `internal/cmd/manager/instance/run/lifecycle/reaper.go` | everytime (x2) | every time |
| `internal/tools/tools.go` | developement | development |
| `internal/management/controller/roles/runnable.go` | syncrhonizing | synchronizing |
| `internal/controller/cluster_create.go` | everytime | every time |
| `internal/controller/replicas.go` | tha | the |
| `internal/cnpi/plugin/client/contracts.go` | decsribes / reconcicliation | describes / reconciliation |
| `api/v1/cluster_types.go` | everytime | every time |
| `pkg/management/postgres/configuration.go` | firt / optmize | first / optimize |
| `pkg/reconciler/instance/certificate/reconciler.go` | Implementated | Implemented |
| `docs/src/kubectl-plugin.md` | `kubectl cnpg subcription drop` | `kubectl cnpg subscription drop` |

The last one also corrects a broken example: the actual plugin command is `subscription` (as documented in the surrounding text and `--help` example).

Commit is DCO signed-off.