### PR TITLE
feat(warn): alert users when a multi-instance cluster has no synchronous replication

### DIFF
--- a/docs/src/quickstart.md
+++ b/docs/src/quickstart.md
@@ -99,6 +99,11 @@ metadata:
 spec:
   instances: 3
 
+  postgresql:
+    synchronous:
+      method: any
+      number: 1
+
   storage:
     size: 1Gi
 ```

--- a/docs/src/replication.md
+++ b/docs/src/replication.md
@@ -151,6 +151,16 @@ defined). When defined, two options are mandatory:
 - `number`: the number of synchronous standby servers that transactions must
   wait for responses from
 
+:::info[Important]
+    Before enabling synchronous replication, make sure the cluster has enough
+    standby servers to tolerate the loss of one of them, or write operations
+    will be suspended whenever the number of available synchronous standbys
+    drops below the requested one. As a general rule, plan for synchronous
+    replication in clusters with at least three instances. In smaller
+    clusters, consider setting `dataDurability` to `preferred` if self-healing
+    is more important than strict data durability in your environment.
+:::
+
 ### Quorum-based Synchronous Replication
 
 In PostgreSQL, quorum-based synchronous replication ensures that transaction

--- a/docs/src/replication.md
+++ b/docs/src/replication.md
@@ -125,9 +125,12 @@ CloudNativePG supports both
     By default, synchronous replication pauses write operations if the required
     number of standby nodes for WAL replication during transaction commits is
     unavailable. This behavior prioritizes data durability and aligns with
-    PostgreSQL DBA best practices. However, if self-healing is a higher priority
+    PostgreSQL DBA best practices. As a general rule, plan for synchronous
+    replication in clusters with at least three instances, to tolerate the loss
+    of one of them. However, if self-healing is a higher priority
     than strict data durability in your setup, this setting can be adjusted. For
-    details on managing this behavior, refer to the [Data Durability and Synchronous Replication](#data-durability-and-synchronous-replication)
+    details on managing this behavior, refer to the
+    [Data Durability and Synchronous Replication](#data-durability-and-synchronous-replication)
     section.
 :::
 
@@ -150,16 +153,6 @@ defined). When defined, two options are mandatory:
 - `method`: either `any` (quorum) or `first` (priority)
 - `number`: the number of synchronous standby servers that transactions must
   wait for responses from
-
-:::info[Important]
-    Before enabling synchronous replication, make sure the cluster has enough
-    standby servers to tolerate the loss of one of them (see the note on write
-    pauses above). As a general rule, plan for synchronous replication in
-    clusters with at least three instances. In smaller clusters (one
-    synchronous standby), consider setting `dataDurability` to `preferred` if
-    self-healing is more important than strict data durability in your
-    environment.
-:::
 
 ### Quorum-based Synchronous Replication
 

--- a/docs/src/replication.md
+++ b/docs/src/replication.md
@@ -153,12 +153,12 @@ defined). When defined, two options are mandatory:
 
 :::info[Important]
     Before enabling synchronous replication, make sure the cluster has enough
-    standby servers to tolerate the loss of one of them, or write operations
-    will be suspended whenever the number of available synchronous standbys
-    drops below the requested one. As a general rule, plan for synchronous
-    replication in clusters with at least three instances. In smaller
-    clusters, consider setting `dataDurability` to `preferred` if self-healing
-    is more important than strict data durability in your environment.
+    standby servers to tolerate the loss of one of them (see the note on write
+    pauses above). As a general rule, plan for synchronous replication in
+    clusters with at least three instances. In smaller clusters (one
+    synchronous standby), consider setting `dataDurability` to `preferred` if
+    self-healing is more important than strict data durability in your
+    environment.
 :::
 
 ### Quorum-based Synchronous Replication

--- a/docs/src/samples/cluster-example.yaml
+++ b/docs/src/samples/cluster-example.yaml
@@ -4,7 +4,12 @@ metadata:
   name: cluster-example
 spec:
   instances: 3
-  
+
+  postgresql:
+    synchronous:
+      method: any
+      number: 1
+
   storage:
     size: 1Gi
 

--- a/internal/webhook/v1/cluster_webhook.go
+++ b/internal/webhook/v1/cluster_webhook.go
@@ -114,6 +114,10 @@ func (v *ClusterCustomValidator) ValidateCreate(_ context.Context, cluster *apiv
 	allErrs := v.validate(cluster)
 	allWarnings := v.getAdmissionWarnings(cluster)
 
+	// Raised at creation time only, to avoid repeating the warning on every
+	// update of an already accepted configuration
+	allWarnings = append(allWarnings, getSynchronousReplicationWarnings(cluster)...)
+
 	if len(allErrs) == 0 {
 		return allWarnings, nil
 	}
@@ -2662,8 +2666,7 @@ func (v *ClusterCustomValidator) getAdmissionWarnings(r *apiv1.Cluster) admissio
 	list = append(list, getStorageWarnings(r)...)
 	list = append(list, getSharedBuffersWarnings(r)...)
 	list = append(list, getMonitoringFieldsWarnings(r)...)
-	list = append(list, getDeprecatedMonitoringFieldsWarnings(r)...)
-	return append(list, getSynchronousReplicationWarnings(r)...)
+	return append(list, getDeprecatedMonitoringFieldsWarnings(r)...)
 }
 
 func getMonitoringFieldsWarnings(r *apiv1.Cluster) admission.Warnings {

--- a/internal/webhook/v1/cluster_webhook.go
+++ b/internal/webhook/v1/cluster_webhook.go
@@ -114,10 +114,6 @@ func (v *ClusterCustomValidator) ValidateCreate(_ context.Context, cluster *apiv
 	allErrs := v.validate(cluster)
 	allWarnings := v.getAdmissionWarnings(cluster)
 
-	// Raised at creation time only, to avoid repeating the warning on every
-	// update of an already accepted configuration
-	allWarnings = append(allWarnings, getSynchronousReplicationWarnings(cluster)...)
-
 	if len(allErrs) == 0 {
 		return allWarnings, nil
 	}
@@ -2659,10 +2655,6 @@ func (v *ClusterCustomValidator) validatePgFailoverSlots(r *apiv1.Cluster) field
 	return result
 }
 
-// getAdmissionWarnings collects warnings shared by ValidateCreate and
-// ValidateUpdate. The synchronous replication warning is intentionally not
-// included here: it is raised by ValidateCreate only, see
-// getSynchronousReplicationWarnings.
 func (v *ClusterCustomValidator) getAdmissionWarnings(r *apiv1.Cluster) admission.Warnings {
 	list := getMaintenanceWindowsAdmissionWarnings(r)
 	list = append(list, getInTreeBarmanWarnings(r)...)
@@ -2670,7 +2662,8 @@ func (v *ClusterCustomValidator) getAdmissionWarnings(r *apiv1.Cluster) admissio
 	list = append(list, getStorageWarnings(r)...)
 	list = append(list, getSharedBuffersWarnings(r)...)
 	list = append(list, getMonitoringFieldsWarnings(r)...)
-	return append(list, getDeprecatedMonitoringFieldsWarnings(r)...)
+	list = append(list, getDeprecatedMonitoringFieldsWarnings(r)...)
+	return append(list, getSynchronousReplicationWarnings(r)...)
 }
 
 func getMonitoringFieldsWarnings(r *apiv1.Cluster) admission.Warnings {
@@ -3158,9 +3151,7 @@ func getSynchronousReplicationWarnings(r *apiv1.Cluster) admission.Warnings {
 		return nil
 	}
 
-	// The legacy API enables synchronous replication through maxSyncReplicas:
-	// minSyncReplicas is only the floor used when not enough replicas are ready
-	if r.Spec.MaxSyncReplicas > 0 {
+	if r.Spec.MinSyncReplicas > 0 {
 		return nil
 	}
 

--- a/internal/webhook/v1/cluster_webhook.go
+++ b/internal/webhook/v1/cluster_webhook.go
@@ -2662,7 +2662,8 @@ func (v *ClusterCustomValidator) getAdmissionWarnings(r *apiv1.Cluster) admissio
 	list = append(list, getStorageWarnings(r)...)
 	list = append(list, getSharedBuffersWarnings(r)...)
 	list = append(list, getMonitoringFieldsWarnings(r)...)
-	return append(list, getDeprecatedMonitoringFieldsWarnings(r)...)
+	list = append(list, getDeprecatedMonitoringFieldsWarnings(r)...)
+	return append(list, getSynchronousReplicationWarnings(r)...)
 }
 
 func getMonitoringFieldsWarnings(r *apiv1.Cluster) admission.Warnings {
@@ -3133,4 +3134,24 @@ func (v *ClusterCustomValidator) validateServiceAccountConfig(r *apiv1.Cluster) 
 		}
 	}
 	return nil
+}
+
+func getSynchronousReplicationWarnings(r *apiv1.Cluster) admission.Warnings {
+	if r.Spec.Instances < 2 {
+		return nil
+	}
+
+	if r.Spec.PostgresConfiguration.Synchronous != nil {
+		return nil
+	}
+
+	if r.Spec.MinSyncReplicas > 0 {
+		return nil
+	}
+
+	return admission.Warnings{
+		"This cluster has no synchronous replication configured. " +
+			"A primary failure can cause data loss for transactions not yet replicated. " +
+			"Consider configuring .spec.postgresql.synchronous to protect against data loss.",
+	}
 }

--- a/internal/webhook/v1/cluster_webhook.go
+++ b/internal/webhook/v1/cluster_webhook.go
@@ -3145,7 +3145,9 @@ func getSynchronousReplicationWarnings(r *apiv1.Cluster) admission.Warnings {
 		return nil
 	}
 
-	if r.Spec.MinSyncReplicas > 0 {
+	// The legacy API enables synchronous replication through maxSyncReplicas:
+	// minSyncReplicas is only the floor used when not enough replicas are ready
+	if r.Spec.MaxSyncReplicas > 0 {
 		return nil
 	}
 

--- a/internal/webhook/v1/cluster_webhook.go
+++ b/internal/webhook/v1/cluster_webhook.go
@@ -3144,6 +3144,12 @@ func getSynchronousReplicationWarnings(r *apiv1.Cluster) admission.Warnings {
 		return nil
 	}
 
+	// A replica cluster replays data from another cluster: losing its
+	// designated primary doesn't lose data from the topology
+	if r.IsReplica() {
+		return nil
+	}
+
 	if r.Spec.PostgresConfiguration.Synchronous != nil {
 		return nil
 	}

--- a/internal/webhook/v1/cluster_webhook.go
+++ b/internal/webhook/v1/cluster_webhook.go
@@ -2659,6 +2659,10 @@ func (v *ClusterCustomValidator) validatePgFailoverSlots(r *apiv1.Cluster) field
 	return result
 }
 
+// getAdmissionWarnings collects warnings shared by ValidateCreate and
+// ValidateUpdate. The synchronous replication warning is intentionally not
+// included here: it is raised by ValidateCreate only, see
+// getSynchronousReplicationWarnings.
 func (v *ClusterCustomValidator) getAdmissionWarnings(r *apiv1.Cluster) admission.Warnings {
 	list := getMaintenanceWindowsAdmissionWarnings(r)
 	list = append(list, getInTreeBarmanWarnings(r)...)

--- a/internal/webhook/v1/cluster_webhook_test.go
+++ b/internal/webhook/v1/cluster_webhook_test.go
@@ -20,6 +20,7 @@ SPDX-License-Identifier: Apache-2.0
 package v1
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -7090,5 +7091,18 @@ var _ = Describe("getSynchronousReplicationWarnings", func() {
 			},
 		}
 		Expect(getSynchronousReplicationWarnings(cluster)).To(BeEmpty())
+	})
+
+	It("is raised on creation but not on update", func() {
+		cluster := &apiv1.Cluster{
+			Spec: apiv1.ClusterSpec{Instances: 3},
+		}
+		v := &ClusterCustomValidator{}
+
+		createWarnings, _ := v.ValidateCreate(context.Background(), cluster)
+		Expect(createWarnings).To(ContainElement(ContainSubstring("no synchronous replication configured")))
+
+		updateWarnings, _ := v.ValidateUpdate(context.Background(), cluster, cluster)
+		Expect(updateWarnings).NotTo(ContainElement(ContainSubstring("no synchronous replication configured")))
 	})
 })

--- a/internal/webhook/v1/cluster_webhook_test.go
+++ b/internal/webhook/v1/cluster_webhook_test.go
@@ -7083,6 +7083,18 @@ var _ = Describe("getSynchronousReplicationWarnings", func() {
 		Expect(getSynchronousReplicationWarnings(cluster)).To(BeEmpty())
 	})
 
+	It("returns no warning for a replica cluster", func() {
+		cluster := &apiv1.Cluster{
+			Spec: apiv1.ClusterSpec{
+				Instances: 3,
+				ReplicaCluster: &apiv1.ReplicaClusterConfiguration{
+					Enabled: ptr.To(true),
+				},
+			},
+		}
+		Expect(getSynchronousReplicationWarnings(cluster)).To(BeEmpty())
+	})
+
 	It("returns no warning when the legacy API sets maxSyncReplicas only", func() {
 		cluster := &apiv1.Cluster{
 			Spec: apiv1.ClusterSpec{

--- a/internal/webhook/v1/cluster_webhook_test.go
+++ b/internal/webhook/v1/cluster_webhook_test.go
@@ -20,6 +20,7 @@ SPDX-License-Identifier: Apache-2.0
 package v1
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -7081,6 +7082,21 @@ var _ = Describe("getSynchronousReplicationWarnings", func() {
 		Expect(getSynchronousReplicationWarnings(cluster)).To(BeEmpty())
 	})
 
+	It("returns a warning when only maxSyncReplicas is set", func() {
+		// minSyncReplicas is the floor that self-healing can't erase: with it
+		// left at zero, a transient shortfall of ready replicas collapses the
+		// effective synchronous requirement to zero (see getSyncReplicasData
+		// in pkg/postgres/replication/legacy.go), so maxSyncReplicas alone does
+		// not guarantee durability.
+		cluster := &apiv1.Cluster{
+			Spec: apiv1.ClusterSpec{
+				Instances:       3,
+				MaxSyncReplicas: 2,
+			},
+		}
+		Expect(getSynchronousReplicationWarnings(cluster)).To(HaveLen(1))
+	})
+
 	It("returns no warning for a replica cluster", func() {
 		cluster := &apiv1.Cluster{
 			Spec: apiv1.ClusterSpec{
@@ -7091,5 +7107,25 @@ var _ = Describe("getSynchronousReplicationWarnings", func() {
 			},
 		}
 		Expect(getSynchronousReplicationWarnings(cluster)).To(BeEmpty())
+	})
+
+	It("returns a warning for a two-instance cluster with no synchronous replication", func() {
+		cluster := &apiv1.Cluster{
+			Spec: apiv1.ClusterSpec{Instances: 2},
+		}
+		Expect(getSynchronousReplicationWarnings(cluster)).To(HaveLen(1))
+	})
+
+	It("is raised on both creation and update", func() {
+		cluster := &apiv1.Cluster{
+			Spec: apiv1.ClusterSpec{Instances: 3},
+		}
+		v := &ClusterCustomValidator{}
+
+		createWarnings, _ := v.ValidateCreate(context.Background(), cluster)
+		Expect(createWarnings).To(ContainElement(ContainSubstring("no synchronous replication configured")))
+
+		updateWarnings, _ := v.ValidateUpdate(context.Background(), cluster, cluster)
+		Expect(updateWarnings).To(ContainElement(ContainSubstring("no synchronous replication configured")))
 	})
 })

--- a/internal/webhook/v1/cluster_webhook_test.go
+++ b/internal/webhook/v1/cluster_webhook_test.go
@@ -7040,3 +7040,44 @@ var _ = Describe("ServiceAccount configuration validation", func() {
 		Expect(result[0].Detail).To(ContainSubstring("mutually exclusive"))
 	})
 })
+
+var _ = Describe("getSynchronousReplicationWarnings", func() {
+	It("returns no warning for a single-instance cluster", func() {
+		cluster := &apiv1.Cluster{
+			Spec: apiv1.ClusterSpec{Instances: 1},
+		}
+		Expect(getSynchronousReplicationWarnings(cluster)).To(BeEmpty())
+	})
+
+	It("returns a warning for a multi-instance cluster with no synchronous replication", func() {
+		cluster := &apiv1.Cluster{
+			Spec: apiv1.ClusterSpec{Instances: 3},
+		}
+		Expect(getSynchronousReplicationWarnings(cluster)).To(HaveLen(1))
+	})
+
+	It("returns no warning when the current synchronous replication API is configured", func() {
+		cluster := &apiv1.Cluster{
+			Spec: apiv1.ClusterSpec{
+				Instances: 3,
+				PostgresConfiguration: apiv1.PostgresConfiguration{
+					Synchronous: &apiv1.SynchronousReplicaConfiguration{
+						Method: apiv1.SynchronousReplicaConfigurationMethodAny,
+						Number: 1,
+					},
+				},
+			},
+		}
+		Expect(getSynchronousReplicationWarnings(cluster)).To(BeEmpty())
+	})
+
+	It("returns no warning when the legacy synchronous replication API is configured", func() {
+		cluster := &apiv1.Cluster{
+			Spec: apiv1.ClusterSpec{
+				Instances:       3,
+				MinSyncReplicas: 1,
+			},
+		}
+		Expect(getSynchronousReplicationWarnings(cluster)).To(BeEmpty())
+	})
+})

--- a/internal/webhook/v1/cluster_webhook_test.go
+++ b/internal/webhook/v1/cluster_webhook_test.go
@@ -7076,6 +7076,17 @@ var _ = Describe("getSynchronousReplicationWarnings", func() {
 			Spec: apiv1.ClusterSpec{
 				Instances:       3,
 				MinSyncReplicas: 1,
+				MaxSyncReplicas: 2,
+			},
+		}
+		Expect(getSynchronousReplicationWarnings(cluster)).To(BeEmpty())
+	})
+
+	It("returns no warning when the legacy API sets maxSyncReplicas only", func() {
+		cluster := &apiv1.Cluster{
+			Spec: apiv1.ClusterSpec{
+				Instances:       3,
+				MaxSyncReplicas: 2,
 			},
 		}
 		Expect(getSynchronousReplicationWarnings(cluster)).To(BeEmpty())

--- a/internal/webhook/v1/cluster_webhook_test.go
+++ b/internal/webhook/v1/cluster_webhook_test.go
@@ -20,7 +20,6 @@ SPDX-License-Identifier: Apache-2.0
 package v1
 
 import (
-	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -7077,7 +7076,6 @@ var _ = Describe("getSynchronousReplicationWarnings", func() {
 			Spec: apiv1.ClusterSpec{
 				Instances:       3,
 				MinSyncReplicas: 1,
-				MaxSyncReplicas: 2,
 			},
 		}
 		Expect(getSynchronousReplicationWarnings(cluster)).To(BeEmpty())
@@ -7093,28 +7091,5 @@ var _ = Describe("getSynchronousReplicationWarnings", func() {
 			},
 		}
 		Expect(getSynchronousReplicationWarnings(cluster)).To(BeEmpty())
-	})
-
-	It("returns no warning when the legacy API sets maxSyncReplicas only", func() {
-		cluster := &apiv1.Cluster{
-			Spec: apiv1.ClusterSpec{
-				Instances:       3,
-				MaxSyncReplicas: 2,
-			},
-		}
-		Expect(getSynchronousReplicationWarnings(cluster)).To(BeEmpty())
-	})
-
-	It("is raised on creation but not on update", func() {
-		cluster := &apiv1.Cluster{
-			Spec: apiv1.ClusterSpec{Instances: 3},
-		}
-		v := &ClusterCustomValidator{}
-
-		createWarnings, _ := v.ValidateCreate(context.Background(), cluster)
-		Expect(createWarnings).To(ContainElement(ContainSubstring("no synchronous replication configured")))
-
-		updateWarnings, _ := v.ValidateUpdate(context.Background(), cluster, cluster)
-		Expect(updateWarnings).NotTo(ContainElement(ContainSubstring("no synchronous replication configured")))
 	})
 })

--- a/tests/internal/asserts/cluster/cluster.go
+++ b/tests/internal/asserts/cluster/cluster.go
@@ -416,8 +416,14 @@ func AssertClusterDefault(
 
 		validator := webhookv1.ClusterCustomValidator{}
 		validationWarn, validationErr := validator.ValidateCreate(env.Ctx, cluster)
-		Expect(validationWarn).To(BeEmpty())
 		Expect(validationErr).ToNot(HaveOccurred())
+		// The fixtures used by this test intentionally omit synchronous
+		// replication, so the only warning they can legitimately raise is
+		// the one about that.
+		Expect(validationWarn).To(Or(
+			BeEmpty(),
+			HaveEach(ContainSubstring("no synchronous replication configured")),
+		))
 	})
 }
 


### PR DESCRIPTION
Multi-instance clusters without synchronous replication are silently exposed to data loss on primary failure: transactions not yet replicated to a standby will be lost when the primary's availability zone goes down.

Add a webhook warning to make this risk visible at apply time. The warning is suppressed when either the current (.spec.postgresql.synchronous) or the legacy (.spec.minSyncReplicas) synchronous replication API is configured.

Closes #11180 