### PR TITLE
ci: authenticate raw.githubusercontent.com fetches in CD/CI

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -1246,6 +1246,12 @@ jobs:
         # It can still take a while to deploy rook.
         name: Set up Rook
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
+        env:
+          # Authenticates the raw.githubusercontent.com fetches below: anonymous
+          # requests share a per-IP rate limit across all GitHub Actions runners
+          # and can 429 during a nightly burst; an authenticated request gets its
+          # own, much higher quota.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           timeout_minutes: 27
           max_attempts: 1
@@ -1254,12 +1260,12 @@ jobs:
             # renovate: datasource=github-releases depName=mikefarah/yq
             go install github.com/mikefarah/yq/v4@v4
             ROOK_BASE_URL=https://raw.githubusercontent.com/rook/rook/${{ env.ROOK_VERSION }}/deploy/examples
-            kubectl apply -f ${ROOK_BASE_URL}/crds.yaml
-            kubectl apply -f ${ROOK_BASE_URL}/common.yaml
+            curl -H "Authorization: Bearer ${GITHUB_TOKEN}" --retry 5 --retry-delay 2 -fsSL ${ROOK_BASE_URL}/crds.yaml | kubectl apply -f -
+            curl -H "Authorization: Bearer ${GITHUB_TOKEN}" --retry 5 --retry-delay 2 -fsSL ${ROOK_BASE_URL}/common.yaml | kubectl apply -f -
             # csi-operator.yaml defines the csi.ceph.io CRDs that operator.yaml's CRs rely on
-            kubectl apply -f ${ROOK_BASE_URL}/csi-operator.yaml
-            kubectl apply -f ${ROOK_BASE_URL}/operator.yaml
-            curl ${ROOK_BASE_URL}/cluster-on-pvc.yaml | \
+            curl -H "Authorization: Bearer ${GITHUB_TOKEN}" --retry 5 --retry-delay 2 -fsSL ${ROOK_BASE_URL}/csi-operator.yaml | kubectl apply -f -
+            curl -H "Authorization: Bearer ${GITHUB_TOKEN}" --retry 5 --retry-delay 2 -fsSL ${ROOK_BASE_URL}/operator.yaml | kubectl apply -f -
+            curl -H "Authorization: Bearer ${GITHUB_TOKEN}" --retry 5 --retry-delay 2 -fsSL ${ROOK_BASE_URL}/cluster-on-pvc.yaml | \
               sed '/^ *#/d;/^ *$/d' | \
               yq e ".spec.storage.storageClassDeviceSets[].volumeClaimTemplates[].spec.resources.requests.storage = \"50Gi\" |
                 .spec.storage.storageClassDeviceSets[].volumeClaimTemplates[].spec.storageClassName = \"${STORAGECLASSNAME}\" |
@@ -1273,8 +1279,8 @@ jobs:
             done
             echo "Waiting for Rook OSDs to be available"
             kubectl wait deploy -n rook-ceph --for condition=available --timeout 480s -l app=rook-ceph-osd
-            kubectl apply -f ${ROOK_BASE_URL}/csi/rbd/storageclass.yaml
-            kubectl apply -f ${ROOK_BASE_URL}/csi/rbd/snapshotclass.yaml
+            curl -H "Authorization: Bearer ${GITHUB_TOKEN}" --retry 5 --retry-delay 2 -fsSL ${ROOK_BASE_URL}/csi/rbd/storageclass.yaml | kubectl apply -f -
+            curl -H "Authorization: Bearer ${GITHUB_TOKEN}" --retry 5 --retry-delay 2 -fsSL ${ROOK_BASE_URL}/csi/rbd/snapshotclass.yaml | kubectl apply -f -
             kubectl annotate storageclass ${{env.E2E_DEFAULT_STORAGE_CLASS}} storage.kubernetes.io/default-snapshot-class=${{env.E2E_DEFAULT_VOLUMESNAPSHOT_CLASS}} --overwrite
       -
         name: Prepare patch for customization
@@ -1562,6 +1568,12 @@ jobs:
           envsubst < hack/e2e/eks-cluster.yaml.template > hack/e2e/eks-cluster.yaml
       -
         name: Setup EKS
+        env:
+          # Authenticates the raw.githubusercontent.com fetches below: anonymous
+          # requests share a per-IP rate limit across all GitHub Actions runners
+          # and can 429 during a nightly burst; an authenticated request gets its
+          # own, much higher quota.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Setting up EKS cluster
           echo "create cluster"
@@ -1580,13 +1592,13 @@ jobs:
 
           # Installing CRD for support volumeSnapshot
           SNAPSHOTTER_BASE_URL=https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/${{env.EXTERNAL_SNAPSHOTTER_VERSION}}
-          kubectl apply -f ${SNAPSHOTTER_BASE_URL}/client/config/crd/snapshot.storage.k8s.io_volumesnapshotclasses.yaml
-          kubectl apply -f ${SNAPSHOTTER_BASE_URL}/client/config/crd/snapshot.storage.k8s.io_volumesnapshotcontents.yaml
-          kubectl apply -f ${SNAPSHOTTER_BASE_URL}/client/config/crd/snapshot.storage.k8s.io_volumesnapshots.yaml
+          curl -H "Authorization: Bearer ${GITHUB_TOKEN}" --retry 5 --retry-delay 2 -fsSL ${SNAPSHOTTER_BASE_URL}/client/config/crd/snapshot.storage.k8s.io_volumesnapshotclasses.yaml | kubectl apply -f -
+          curl -H "Authorization: Bearer ${GITHUB_TOKEN}" --retry 5 --retry-delay 2 -fsSL ${SNAPSHOTTER_BASE_URL}/client/config/crd/snapshot.storage.k8s.io_volumesnapshotcontents.yaml | kubectl apply -f -
+          curl -H "Authorization: Bearer ${GITHUB_TOKEN}" --retry 5 --retry-delay 2 -fsSL ${SNAPSHOTTER_BASE_URL}/client/config/crd/snapshot.storage.k8s.io_volumesnapshots.yaml | kubectl apply -f -
 
           ## Controller
-          kubectl apply -f ${SNAPSHOTTER_BASE_URL}/deploy/kubernetes/snapshot-controller/rbac-snapshot-controller.yaml
-          kubectl apply -f ${SNAPSHOTTER_BASE_URL}/deploy/kubernetes/snapshot-controller/setup-snapshot-controller.yaml
+          curl -H "Authorization: Bearer ${GITHUB_TOKEN}" --retry 5 --retry-delay 2 -fsSL ${SNAPSHOTTER_BASE_URL}/deploy/kubernetes/snapshot-controller/rbac-snapshot-controller.yaml | kubectl apply -f -
+          curl -H "Authorization: Bearer ${GITHUB_TOKEN}" --retry 5 --retry-delay 2 -fsSL ${SNAPSHOTTER_BASE_URL}/deploy/kubernetes/snapshot-controller/setup-snapshot-controller.yaml | kubectl apply -f -
 
           # Install volume snapshot class
           kubectl apply -f hack/e2e/volumesnapshotclass-ebs-csi.yaml

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -951,10 +951,12 @@ jobs:
           username: ${{ env.REGISTRY_USER }}
           password: ${{ env.REGISTRY_PASSWORD }}
       - name: Install K3D
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           K3D_URL="https://github.com/k3d-io/k3d/releases/download/${{ env.K3D_VERSION }}"
-          curl -sL "${K3D_URL}/k3d-linux-amd64" -o /tmp/k3d
-          curl -sL "${K3D_URL}/checksums.txt" -o /tmp/k3d-checksums.txt
+          curl -H "Authorization: Bearer ${GITHUB_TOKEN}" --retry 5 --retry-delay 2 -fsSL "${K3D_URL}/k3d-linux-amd64" -o /tmp/k3d
+          curl -H "Authorization: Bearer ${GITHUB_TOKEN}" --retry 5 --retry-delay 2 -fsSL "${K3D_URL}/checksums.txt" -o /tmp/k3d-checksums.txt
           grep '_dist/k3d-linux-amd64$' /tmp/k3d-checksums.txt | sed 's|_dist/k3d-linux-amd64|/tmp/k3d|' | sha256sum -c -
           install /tmp/k3d /usr/local/bin/k3d
           k3d version
@@ -1554,12 +1556,15 @@ jobs:
       -
         name: Install eksctl
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           timeout_minutes: 1
           max_attempts: 3
           command: |
             mkdir -p "$HOME/.local/bin"
-            curl -sL "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" \
+            curl -H "Authorization: Bearer ${GITHUB_TOKEN}" --retry 5 --retry-delay 2 \
+              -fsSL "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" \
               | tar xz -C $HOME/.local/bin
             echo "$HOME/.local/bin" >> $GITHUB_PATH
       -
@@ -1613,6 +1618,7 @@ jobs:
         name: Setup Velero
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # renovate: datasource=github-releases depName=vmware-tanzu/velero
           VELERO_VERSION: "v1.18.2"
           # renovate: datasource=github-releases depName=vmware-tanzu/velero-plugin-for-aws
@@ -1647,7 +1653,8 @@ jobs:
               --create-bucket-configuration LocationConstraint="${AWS_REGION}"
 
             # Download Velero, extract and place it in $PATH
-            curl -sL "https://github.com/vmware-tanzu/velero/releases/download/${VELERO_VERSION}/velero-${VELERO_VERSION}-linux-amd64.tar.gz" | tar xz
+            curl -H "Authorization: Bearer ${GITHUB_TOKEN}" --retry 5 --retry-delay 2 \
+              -fsSL "https://github.com/vmware-tanzu/velero/releases/download/${VELERO_VERSION}/velero-${VELERO_VERSION}-linux-amd64.tar.gz" | tar xz
             mv velero-${VELERO_VERSION}-linux-amd64/velero $HOME/.local/bin
 
             # Set Velero-specific credentials

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -986,5 +986,15 @@ jobs:
           rm -fr bundle.Dockerfile *.zip bundle/
 
       - name: Test bundle
+        env:
+          # Authenticates the raw.githubusercontent.com fetch below: anonymous
+          # requests share a per-IP rate limit across all GitHub Actions runners
+          # and can 429 during a burst; an authenticated request gets its own,
+          # much higher quota. Downloading to a file first (rather than piping
+          # into `bash <(curl ...)`) also means a failed fetch aborts the step
+          # instead of silently running an empty script.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          bash <(curl -sL "https://raw.githubusercontent.com/redhat-openshift-ecosystem/community-operators-pipeline/${OPP_SCRIPT_VERSION}/ci/scripts/opp.sh") "${TEST}" "operators/cloudnative-pg/${VERSION}/"
+          curl -H "Authorization: Bearer ${GITHUB_TOKEN}" --retry 5 --retry-delay 2 -fsSL \
+            -o opp.sh "https://raw.githubusercontent.com/redhat-openshift-ecosystem/community-operators-pipeline/${OPP_SCRIPT_VERSION}/ci/scripts/opp.sh"
+          bash opp.sh "${TEST}" "operators/cloudnative-pg/${VERSION}/"

--- a/hack/testing-tools/common/20-utils-k8s.sh
+++ b/hack/testing-tools/common/20-utils-k8s.sh
@@ -35,6 +35,16 @@ function _curl_github() {
   curl -H "${auth_header}" "$@"
 }
 
+# _apply_github: fetches a manifest from a raw.githubusercontent.com URL
+# (authenticated via _curl_github when GITHUB_TOKEN is set, which is what
+# actually avoids the anonymous per-IP rate limit shared by GitHub Actions
+# runners) and applies it. The retry is only a fallback for genuine transient
+# network errors, not the fix for 429s.
+function _apply_github() {
+  local url=$1
+  _curl_github -fsSL --retry 5 --retry-delay 2 "${url}" | "${K8S_CLI}" apply -f -
+}
+
 # wait_for(type, namespace, name, interval, retries)
 # Waits until a specified Kubernetes object exists.
 function wait_for() {
@@ -274,25 +284,25 @@ function deploy_csi_host_path() {
   # --- 1. Install External Snapshotter CRDs and Controller (Versions sourced from 10-config.sh) ---
 
   ## Apply CRDs
-  "${K8S_CLI}" apply -f "${CSI_BASE_URL}"/external-snapshotter/"${EXTERNAL_SNAPSHOTTER_VERSION}"/client/config/crd/snapshot.storage.k8s.io_volumesnapshotclasses.yaml
-  "${K8S_CLI}" apply -f "${CSI_BASE_URL}"/external-snapshotter/"${EXTERNAL_SNAPSHOTTER_VERSION}"/client/config/crd/snapshot.storage.k8s.io_volumesnapshotcontents.yaml
-  "${K8S_CLI}" apply -f "${CSI_BASE_URL}"/external-snapshotter/"${EXTERNAL_SNAPSHOTTER_VERSION}"/client/config/crd/snapshot.storage.k8s.io_volumesnapshots.yaml
+  _apply_github "${CSI_BASE_URL}/external-snapshotter/${EXTERNAL_SNAPSHOTTER_VERSION}/client/config/crd/snapshot.storage.k8s.io_volumesnapshotclasses.yaml"
+  _apply_github "${CSI_BASE_URL}/external-snapshotter/${EXTERNAL_SNAPSHOTTER_VERSION}/client/config/crd/snapshot.storage.k8s.io_volumesnapshotcontents.yaml"
+  _apply_github "${CSI_BASE_URL}/external-snapshotter/${EXTERNAL_SNAPSHOTTER_VERSION}/client/config/crd/snapshot.storage.k8s.io_volumesnapshots.yaml"
 
   ## Apply RBAC and Controller
-  "${K8S_CLI}" apply -f "${CSI_BASE_URL}"/external-snapshotter/"${EXTERNAL_SNAPSHOTTER_VERSION}"/deploy/kubernetes/snapshot-controller/rbac-snapshot-controller.yaml
-  "${K8S_CLI}" apply -f "${CSI_BASE_URL}"/external-snapshotter/"${EXTERNAL_SNAPSHOTTER_VERSION}"/deploy/kubernetes/snapshot-controller/setup-snapshot-controller.yaml
-  "${K8S_CLI}" apply -f "${CSI_BASE_URL}"/external-snapshotter/"${EXTERNAL_SNAPSHOTTER_VERSION}"/deploy/kubernetes/csi-snapshotter/rbac-csi-snapshotter.yaml
+  _apply_github "${CSI_BASE_URL}/external-snapshotter/${EXTERNAL_SNAPSHOTTER_VERSION}/deploy/kubernetes/snapshot-controller/rbac-snapshot-controller.yaml"
+  _apply_github "${CSI_BASE_URL}/external-snapshotter/${EXTERNAL_SNAPSHOTTER_VERSION}/deploy/kubernetes/snapshot-controller/setup-snapshot-controller.yaml"
+  _apply_github "${CSI_BASE_URL}/external-snapshotter/${EXTERNAL_SNAPSHOTTER_VERSION}/deploy/kubernetes/csi-snapshotter/rbac-csi-snapshotter.yaml"
 
   # --- 2. Install External Sidecar Components ---
 
   ## Install external provisioner
-  "${K8S_CLI}" apply -f "${CSI_BASE_URL}"/external-provisioner/"${EXTERNAL_PROVISIONER_VERSION}"/deploy/kubernetes/rbac.yaml
+  _apply_github "${CSI_BASE_URL}/external-provisioner/${EXTERNAL_PROVISIONER_VERSION}/deploy/kubernetes/rbac.yaml"
 
   ## Install external attacher
-  "${K8S_CLI}" apply -f "${CSI_BASE_URL}"/external-attacher/"${EXTERNAL_ATTACHER_VERSION}"/deploy/kubernetes/rbac.yaml
+  _apply_github "${CSI_BASE_URL}/external-attacher/${EXTERNAL_ATTACHER_VERSION}/deploy/kubernetes/rbac.yaml"
 
   ## Install external resizer
-  "${K8S_CLI}" apply -f "${CSI_BASE_URL}"/external-resizer/"${EXTERNAL_RESIZER_VERSION}"/deploy/kubernetes/rbac.yaml
+  _apply_github "${CSI_BASE_URL}/external-resizer/${EXTERNAL_RESIZER_VERSION}/deploy/kubernetes/rbac.yaml"
 
   # --- 3. Install Driver and Plugin ---
 
@@ -302,21 +312,21 @@ function deploy_csi_host_path() {
     sed "s|registry.k8s.io/sig-storage/hostpathplugin:.*|registry.k8s.io/sig-storage/hostpathplugin:${CSI_DRIVER_HOST_PATH_VERSION}|g" > "${plugin_file}"
 
   # Apply driver info and plugin deployment
-  "${K8S_CLI}" apply -f "${CSI_BASE_URL}"/csi-driver-host-path/"${CSI_DRIVER_HOST_PATH_VERSION}"/deploy/kubernetes-1.30/hostpath/csi-hostpath-driverinfo.yaml
+  _apply_github "${CSI_BASE_URL}/csi-driver-host-path/${CSI_DRIVER_HOST_PATH_VERSION}/deploy/kubernetes-1.30/hostpath/csi-hostpath-driverinfo.yaml"
   "${K8S_CLI}" apply -f "${plugin_file}"
   rm "${plugin_file}"
 
   # --- 4. Configure Storage Classes ---
 
   ## Create VolumeSnapshotClass
-  "${K8S_CLI}" apply -f "${CSI_BASE_URL}"/csi-driver-host-path/"${CSI_DRIVER_HOST_PATH_VERSION}"/deploy/kubernetes-1.30/hostpath/csi-hostpath-snapshotclass.yaml
+  _apply_github "${CSI_BASE_URL}/csi-driver-host-path/${CSI_DRIVER_HOST_PATH_VERSION}/deploy/kubernetes-1.30/hostpath/csi-hostpath-snapshotclass.yaml"
 
   ## Patch VolumeSnapshotClass to allow snapshots of running PostgreSQL instances
   ## by ignoring read failures during snapshot creation
   "${K8S_CLI}" patch volumesnapshotclass csi-hostpath-snapclass -p '{"parameters":{"ignoreFailedRead":"true"}}' --type merge
 
   ## Create StorageClass
-  "${K8S_CLI}" apply -f "${CSI_BASE_URL}"/csi-driver-host-path/"${CSI_DRIVER_HOST_PATH_VERSION}"/examples/csi-storageclass.yaml
+  _apply_github "${CSI_BASE_URL}/csi-driver-host-path/${CSI_DRIVER_HOST_PATH_VERSION}/examples/csi-storageclass.yaml"
 
   ## Annotate the StorageClass to set the default snapshot class
   "${K8S_CLI}" annotate storageclass csi-hostpath-sc storage.kubernetes.io/default-snapshot-class=csi-hostpath-snapclass


### PR DESCRIPTION
Anonymous requests to raw.githubusercontent.com share a per-IP rate limit across all GitHub Actions runners and can 429 during a nightly burst, as seen on the EKS external-snapshotter CRD fetch. An authenticated request gets its own, much higher quota, so route every unauthenticated fetch of that kind through the ambient GITHUB_TOKEN: the kind/k3d hostpath CSI driver setup (deploy_csi_host_path, the widest blast radius since it runs on every kind and k3d job), the EKS snapshotter setup, the AKS Rook setup, and the OpenShift bundle test.

Retry is kept only as a fallback for genuine transient network errors; it doesn't help with sustained rate-limiting the way authentication does.