### PR TITLE
fix(probes): treat a PostgreSQL rejecting connections as started up

### DIFF
--- a/docs/src/instance_manager.md
+++ b/docs/src/instance_manager.md
@@ -50,8 +50,11 @@ The `.spec.startDelay` parameter specifies the maximum time, in seconds,
 allowed for the startup probe to succeed.
 
 By default, the `startDelay` is set to `3600` seconds. It is recommended to
-adjust this setting based on the time PostgreSQL needs to fully initialize in
-your specific environment.
+adjust this setting based on the time PostgreSQL needs to start in your
+specific environment. With the default `pg_isready` strategy, this only
+needs to cover the time required for the postmaster to come alive, while
+with the `query` and `streaming` strategies it must also account for the
+time needed to complete recovery and accept connections.
 
 :::warning
     Setting `.spec.startDelay` too low can cause the liveness probe to activate

--- a/docs/src/instance_manager.md
+++ b/docs/src/instance_manager.md
@@ -25,7 +25,7 @@ of the Pod, the instance manager acts as a backend to handle the
 ## Startup Probe
 
 The startup probe ensures that a PostgreSQL instance, whether a primary or
-standby, has fully started.
+standby, has started up.
 
 :::info
     By default, the startup probe uses
@@ -33,6 +33,14 @@ standby, has fully started.
     However, the behavior can be customized by specifying a different startup
     strategy.
 :::
+
+With the default `pg_isready` strategy, an instance is considered started as
+soon as PostgreSQL is alive, even if it is still rejecting connections while
+it completes its startup sequence (for example, a standby performing crash
+recovery or replaying WAL). This prevents the kubelet from repeatedly
+restarting an instance that is legitimately recovering. The instance remains
+unready, and therefore excluded from the ready endpoints of the services,
+until the readiness probe reports that it accepts connections.
 
 While the startup probe is running, the liveness and readiness probes remain
 disabled. Following Kubernetes standards, if the startup probe fails, the
@@ -105,8 +113,13 @@ To accommodate these requirements, CloudNativePG extends the
 - `type`: specifies the criteria for considering the probe successful. Accepted
   values, in increasing order of complexity/depth, include:
 
-    - `pg_isready`: marks the probe as successful when the `pg_isready` command
-      exits with `0`. This is the default for primary instances and replicas.
+    - `pg_isready`: relies on the exit code of the `pg_isready` command. The
+      startup probe is successful when the server is either accepting
+      connections or alive but rejecting them, which happens while PostgreSQL
+      completes its startup sequence (for example, a standby replaying WAL
+      after a crash). The readiness probe is successful only when the server
+      is accepting connections. This is the default for primary instances and
+      replicas.
     - `query`: marks the probe as successful when a basic query is executed on
       the `postgres` database locally.
     - `streaming`: marks the probe as successful when the replica begins
@@ -142,6 +155,14 @@ probes:
     type: streaming
     maximumLag: 16Mi
 ```
+
+:::info
+    The `query` and `streaming` strategies require PostgreSQL to accept
+    connections, so a startup probe using them keeps failing while an
+    instance replays WAL after a crash. When using these strategies, make
+    sure that `startDelay` (or your custom `failureThreshold`) allows enough
+    time for recovery to complete.
+:::
 
 ## Liveness Probe
 

--- a/docs/src/instance_manager.md
+++ b/docs/src/instance_manager.md
@@ -57,9 +57,8 @@ with the `query` and `streaming` strategies it must also account for the
 time needed to complete recovery and accept connections.
 
 :::warning
-    Setting `.spec.startDelay` too low can cause the liveness probe to activate
-    prematurely, potentially resulting in unnecessary Pod restarts if PostgreSQL
-    hasn’t fully initialized.
+    Setting `.spec.startDelay` too low can cause the startup probe to fail
+    before PostgreSQL has started up, resulting in unnecessary Pod restarts.
 :::
 
 CloudNativePG configures the startup probe with the following default parameters:
@@ -118,11 +117,9 @@ To accommodate these requirements, CloudNativePG extends the
 
     - `pg_isready`: relies on the exit code of the `pg_isready` command. The
       startup probe is successful when the server is either accepting
-      connections or alive but rejecting them, which happens while PostgreSQL
-      completes its startup sequence (for example, a standby replaying WAL
-      after a crash). The readiness probe is successful only when the server
-      is accepting connections. This is the default for primary instances and
-      replicas.
+      connections or alive but rejecting them, as described above. The
+      readiness probe is successful only when the server is accepting
+      connections. This is the default for primary instances and replicas.
     - `query`: marks the probe as successful when a basic query is executed on
       the `postgres` database locally.
     - `streaming`: marks the probe as successful when the replica begins

--- a/pkg/management/postgres/webserver/probes/checker.go
+++ b/pkg/management/postgres/webserver/probes/checker.go
@@ -149,9 +149,7 @@ func getProbeRunnerFromCluster(probeType probeType, cluster apiv1.Cluster) runne
 }
 
 // newPgIsReadyChecker creates the pg_isready strategy runner for the passed
-// probe type. The startup probe considers a server that is alive but
-// rejecting connections as already started up, while the readiness probe
-// requires it to accept connections.
+// probe type, wrapping it in startupPgIsReadyChecker for the startup probe.
 func newPgIsReadyChecker(probeType probeType) runner {
 	if probeType == probeTypeStartup {
 		return startupPgIsReadyChecker{inner: pgIsReadyChecker{}}

--- a/pkg/management/postgres/webserver/probes/checker.go
+++ b/pkg/management/postgres/webserver/probes/checker.go
@@ -132,9 +132,9 @@ func getProbeRunnerFromCluster(probeType probeType, cluster apiv1.Cluster) runne
 
 	switch {
 	case probe == nil:
-		return pgIsReadyChecker{}
+		return newPgIsReadyChecker(probeType)
 	case probe.Type == apiv1.ProbeStrategyPgIsReady:
-		return pgIsReadyChecker{}
+		return newPgIsReadyChecker(probeType)
 	case probe.Type == apiv1.ProbeStrategyQuery:
 		return pgQueryChecker{}
 	case probe.Type == apiv1.ProbeStrategyStreaming:
@@ -145,5 +145,16 @@ func getProbeRunnerFromCluster(probeType probeType, cluster apiv1.Cluster) runne
 		return result
 	}
 
+	return newPgIsReadyChecker(probeType)
+}
+
+// newPgIsReadyChecker creates the pg_isready strategy runner for the passed
+// probe type. The startup probe considers a server that is alive but
+// rejecting connections as already started up, while the readiness probe
+// requires it to accept connections.
+func newPgIsReadyChecker(probeType probeType) runner {
+	if probeType == probeTypeStartup {
+		return startupPgIsReadyChecker{inner: pgIsReadyChecker{}}
+	}
 	return pgIsReadyChecker{}
 }

--- a/pkg/management/postgres/webserver/probes/checker_test.go
+++ b/pkg/management/postgres/webserver/probes/checker_test.go
@@ -1,0 +1,123 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package probes
+
+import (
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/utils/ptr"
+
+	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("getProbeRunnerFromCluster", func() {
+	startupTolerantChecker := startupPgIsReadyChecker{inner: pgIsReadyChecker{}}
+
+	It("uses the pg_isready strategy when no probe is configured", func() {
+		cluster := apiv1.Cluster{}
+		Expect(getProbeRunnerFromCluster(probeTypeStartup, cluster)).To(Equal(startupTolerantChecker))
+		Expect(getProbeRunnerFromCluster(probeTypeReadiness, cluster)).To(Equal(pgIsReadyChecker{}))
+	})
+
+	It("tolerates a server rejecting connections only in the startup probe", func() {
+		cluster := apiv1.Cluster{
+			Spec: apiv1.ClusterSpec{
+				Probes: &apiv1.ProbesConfiguration{
+					Startup:   &apiv1.ProbeWithStrategy{Type: apiv1.ProbeStrategyPgIsReady},
+					Readiness: &apiv1.ProbeWithStrategy{Type: apiv1.ProbeStrategyPgIsReady},
+				},
+			},
+		}
+		Expect(getProbeRunnerFromCluster(probeTypeStartup, cluster)).To(Equal(startupTolerantChecker))
+		Expect(getProbeRunnerFromCluster(probeTypeReadiness, cluster)).To(Equal(pgIsReadyChecker{}))
+	})
+
+	It("defaults to the pg_isready strategy when the probe is configured without a type", func() {
+		cluster := apiv1.Cluster{
+			Spec: apiv1.ClusterSpec{
+				Probes: &apiv1.ProbesConfiguration{
+					Startup:   &apiv1.ProbeWithStrategy{},
+					Readiness: &apiv1.ProbeWithStrategy{},
+				},
+			},
+		}
+		Expect(getProbeRunnerFromCluster(probeTypeStartup, cluster)).To(Equal(startupTolerantChecker))
+		Expect(getProbeRunnerFromCluster(probeTypeReadiness, cluster)).To(Equal(pgIsReadyChecker{}))
+	})
+
+	It("uses the query strategy when configured", func() {
+		cluster := apiv1.Cluster{
+			Spec: apiv1.ClusterSpec{
+				Probes: &apiv1.ProbesConfiguration{
+					Startup: &apiv1.ProbeWithStrategy{Type: apiv1.ProbeStrategyQuery},
+				},
+			},
+		}
+		Expect(getProbeRunnerFromCluster(probeTypeStartup, cluster)).To(Equal(pgQueryChecker{}))
+	})
+
+	It("uses the streaming strategy when configured, propagating the maximum lag", func() {
+		cluster := apiv1.Cluster{
+			Spec: apiv1.ClusterSpec{
+				Probes: &apiv1.ProbesConfiguration{
+					Startup: &apiv1.ProbeWithStrategy{
+						Type:       apiv1.ProbeStrategyStreaming,
+						MaximumLag: ptr.To(resource.MustParse("100")),
+					},
+				},
+			},
+		}
+		Expect(getProbeRunnerFromCluster(probeTypeStartup, cluster)).To(Equal(
+			pgStreamingChecker{maximumLag: ptr.To(uint64(100))}))
+	})
+
+	It("uses the streaming strategy without a lag limit when none is configured", func() {
+		cluster := apiv1.Cluster{
+			Spec: apiv1.ClusterSpec{
+				Probes: &apiv1.ProbesConfiguration{
+					Startup: &apiv1.ProbeWithStrategy{Type: apiv1.ProbeStrategyStreaming},
+				},
+			},
+		}
+		Expect(getProbeRunnerFromCluster(probeTypeStartup, cluster)).To(Equal(pgStreamingChecker{}))
+	})
+
+	It("does not leak the configuration of one probe into the other", func() {
+		cluster := apiv1.Cluster{
+			Spec: apiv1.ClusterSpec{
+				Probes: &apiv1.ProbesConfiguration{
+					Startup: &apiv1.ProbeWithStrategy{Type: apiv1.ProbeStrategyQuery},
+				},
+			},
+		}
+		Expect(getProbeRunnerFromCluster(probeTypeReadiness, cluster)).To(Equal(pgIsReadyChecker{}))
+
+		cluster = apiv1.Cluster{
+			Spec: apiv1.ClusterSpec{
+				Probes: &apiv1.ProbesConfiguration{
+					Readiness: &apiv1.ProbeWithStrategy{Type: apiv1.ProbeStrategyQuery},
+				},
+			},
+		}
+		Expect(getProbeRunnerFromCluster(probeTypeStartup, cluster)).To(Equal(startupTolerantChecker))
+	})
+})

--- a/pkg/management/postgres/webserver/probes/isready.go
+++ b/pkg/management/postgres/webserver/probes/isready.go
@@ -38,7 +38,7 @@ func (pgIsReadyChecker) IsHealthy(_ context.Context, instance *postgres.Instance
 
 // startupPgIsReadyChecker is the pg_isready strategy for the startup probe.
 // A server that is alive but rejecting connections has already started up
-// and is completing its startup sequence (i.e. crash recovery or WAL
+// and is completing its startup sequence (e.g. crash recovery or WAL
 // replay): reporting it as started prevents the kubelet from killing it
 // while it recovers. The readiness probe keeps failing until the server
 // accepts connections.

--- a/pkg/management/postgres/webserver/probes/isready.go
+++ b/pkg/management/postgres/webserver/probes/isready.go
@@ -21,6 +21,9 @@ package probes
 
 import (
 	"context"
+	"errors"
+
+	"github.com/cloudnative-pg/machinery/pkg/log"
 
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres"
 )
@@ -31,4 +34,25 @@ type pgIsReadyChecker struct{}
 // IsHealthy implements the runner interface
 func (pgIsReadyChecker) IsHealthy(_ context.Context, instance *postgres.Instance) error {
 	return instance.IsReady()
+}
+
+// startupPgIsReadyChecker is the pg_isready strategy for the startup probe.
+// A server that is alive but rejecting connections has already started up
+// and is completing its startup sequence (i.e. crash recovery or WAL
+// replay): reporting it as started prevents the kubelet from killing it
+// while it recovers. The readiness probe keeps failing until the server
+// accepts connections.
+type startupPgIsReadyChecker struct {
+	inner runner
+}
+
+// IsHealthy implements the runner interface
+func (c startupPgIsReadyChecker) IsHealthy(ctx context.Context, instance *postgres.Instance) error {
+	err := c.inner.IsHealthy(ctx, instance)
+	if errors.Is(err, postgres.ErrPgRejectingConnection) {
+		log.FromContext(ctx).Info(
+			"PostgreSQL is alive but rejecting connections, considering the instance as started up")
+		return nil
+	}
+	return err
 }

--- a/pkg/management/postgres/webserver/probes/isready_test.go
+++ b/pkg/management/postgres/webserver/probes/isready_test.go
@@ -1,0 +1,76 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package probes
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// staticResultRunner is a runner returning a fixed result
+type staticResultRunner struct {
+	err error
+}
+
+func (r staticResultRunner) IsHealthy(_ context.Context, _ *postgres.Instance) error {
+	return r.err
+}
+
+var _ = Describe("startupPgIsReadyChecker", func() {
+	var ctx context.Context
+
+	BeforeEach(func() {
+		ctx = context.Background()
+	})
+
+	It("succeeds when the server is accepting connections", func() {
+		checker := startupPgIsReadyChecker{inner: staticResultRunner{}}
+		Expect(checker.IsHealthy(ctx, nil)).To(Succeed())
+	})
+
+	It("succeeds when the server is alive but rejecting connections", func() {
+		checker := startupPgIsReadyChecker{inner: staticResultRunner{err: postgres.ErrPgRejectingConnection}}
+		Expect(checker.IsHealthy(ctx, nil)).To(Succeed())
+	})
+
+	It("succeeds when the rejecting-connections error is wrapped", func() {
+		checker := startupPgIsReadyChecker{
+			inner: staticResultRunner{err: fmt.Errorf("wrapped: %w", postgres.ErrPgRejectingConnection)},
+		}
+		Expect(checker.IsHealthy(ctx, nil)).To(Succeed())
+	})
+
+	It("fails when no connection can be established", func() {
+		checker := startupPgIsReadyChecker{inner: staticResultRunner{err: postgres.ErrNoConnectionEstablished}}
+		Expect(checker.IsHealthy(ctx, nil)).To(MatchError(postgres.ErrNoConnectionEstablished))
+	})
+
+	It("fails on any other error", func() {
+		expectedError := errors.New("pg_isready usage error")
+		checker := startupPgIsReadyChecker{inner: staticResultRunner{err: expectedError}}
+		Expect(checker.IsHealthy(ctx, nil)).To(MatchError(expectedError))
+	})
+})


### PR DESCRIPTION
When a PostgreSQL instance has to replay a large amount of WAL before reaching consistency (for example a standby restarting after a crash, as reported in #11024), `pg_isready` reports that the server is alive but rejecting connections until recovery completes. The startup probe treated that state as a failure, so when recovery outlasted `startDelay` the kubelet killed the pod. Every restart threw away the replay progress and the instance could never catch up, looping forever.

With the default `pg_isready` strategy, the startup probe now considers a server that is alive but rejecting connections as already started up:

- The liveness probe will not restart it, because it returns OK unconditionally for a non-primary instance.
- The readiness probe keeps failing on a server that rejects connections, so a recovering instance stays out of the ready endpoints of the services and is not eligible for promotion until it accepts connections.

The `query` and `streaming` startup strategies are unchanged: they require PostgreSQL to accept connections by design, and the documentation now points out that `startDelay` must account for recovery time when using them.

One trade-off worth noting: the startup probe was previously the only mechanism that restarted a pod whose PostgreSQL was permanently stuck while rejecting connections, even though in the #11024 scenario those restarts were exactly what prevented recovery from completing. With this change such an instance is reported as started and left to continue attempting recovery, with no automatic restart if it never completes. A specific form of this, repeated WAL-replay error loops, is proposed in #11135, which does not cover a replica silently stalled with no matching errors.

This was verified on a kind cluster by reproducing the scenario from the issue: a two-instance cluster with `startDelay: 10`, one-second probe periods, and `checkpoint_timeout: 5h` so that the standby takes no restartpoints. After writing about 4.7GiB of WAL and deleting the standby pod, the instance came back in `shut down in recovery`, the first startup probe reported it as started, the pod stayed not ready while replaying (readiness failing with HTTP 500), and it became ready about 40 seconds later with zero container restarts. The same configuration on the previous build restarted the pod every 10 seconds.

Unit tests cover the new startup checker and the probe runner selection, which previously had no coverage.

Thanks to Jeremy Schneider for reporting this issue and providing a detailed analysis of the failure.

Closes #11024
