### PR TITLE
fix(deps): bump go toolchain to 1.26.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cloudnative-pg/cloudnative-pg
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -1,6 +1,6 @@
 module github.com/cloudnative-pg/cloudnative-pg/tests
 
-go 1.26.4
+go 1.26.5
 
 replace github.com/cloudnative-pg/cloudnative-pg => ../
 


### PR DESCRIPTION
crypto/tls in go1.26.4 has GO-2026-5856, an Encrypted Client Hello privacy leak fixed upstream in go1.26.5.