### PR TITLE
ci: let snyk vulnerability scan fetch a newer Go toolchain

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -55,6 +55,9 @@ jobs:
         continue-on-error: true
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+          # snyk/snyk:golang bundles a fixed Go toolchain that can lag behind
+          # go.mod's toolchain requirement; let 'go list' fetch a newer one.
+          GOTOOLCHAIN: auto
         with:
           args: --sarif-file-output=snyk-test.sarif
 


### PR DESCRIPTION
The Vulnerability scan step in the Snyk workflow runs 'go list' inside
the snyk/snyk:golang container, which bundles a fixed Go version. When
go.mod's toolchain requirement moves past that version, GOTOOLCHAIN=local
makes 'go list' fail outright instead of downloading a matching
toolchain, so snyk-test.sarif is never produced and the following
upload step errors with "Path does not exist".

Set GOTOOLCHAIN=auto for that step so Go fetches the toolchain
go.mod asks for.