### PR TITLE
test(e2e): use a distinct server name for plugin-barman-cloud timeline divergence test

### DIFF
--- a/tests/e2e/backup_restore_objectstore_test.go
+++ b/tests/e2e/backup_restore_objectstore_test.go
@@ -666,6 +666,7 @@ var _ = Describe("Object storage - Backup and restore", Label(tests.LabelBackupR
 
 	Context("timeline divergence protection", Ordered, func() {
 		var namespace string
+		const sharedArchiveName = "shared-timeline-test"
 
 		BeforeAll(func() {
 			if !(IsKind() || IsK3D()) {
@@ -730,10 +731,10 @@ var _ = Describe("Object storage - Backup and restore", Label(tests.LabelBackupR
 
 			By("verifying timeline 2 history file is archived", func() {
 				objectstoreasserts.AssertArchiveWalOnObjectStore(
-					env, testTimeouts, objectStoreEnv, namespace, secondClusterName, "shared-timeline-test",
+					env, testTimeouts, objectStoreEnv, namespace, secondClusterName, sharedArchiveName,
 				)
 				Eventually(func() (int, error) {
-					return objectstore.CountFiles(objectStoreEnv, objectstore.GetFilePath("shared-timeline-test", "00000002.history*"))
+					return objectstore.CountFiles(objectStoreEnv, objectstore.GetFilePath(sharedArchiveName, "00000002.history*"))
 				}, 60).Should(BeNumerically(">", 0))
 			})
 

--- a/tests/e2e/fixtures/plugin_barman_cloud/timeline_divergence/cluster-plugin-tl-divergence-1.yaml.template
+++ b/tests/e2e/fixtures/plugin_barman_cloud/timeline_divergence/cluster-plugin-tl-divergence-1.yaml.template
@@ -24,4 +24,4 @@ spec:
       isWALArchiver: true
       parameters:
         barmanObjectName: shared-timeline
-        serverName: shared-timeline-test
+        serverName: shared-timeline-test-plugin

--- a/tests/e2e/fixtures/plugin_barman_cloud/timeline_divergence/cluster-plugin-tl-divergence-2.yaml.template
+++ b/tests/e2e/fixtures/plugin_barman_cloud/timeline_divergence/cluster-plugin-tl-divergence-2.yaml.template
@@ -31,11 +31,11 @@ spec:
         name: barman-cloud.cloudnative-pg.io
         parameters:
           barmanObjectName: shared-timeline
-          serverName: shared-timeline-test
+          serverName: shared-timeline-test-plugin
 
   plugins:
     - name: barman-cloud.cloudnative-pg.io
       isWALArchiver: true
       parameters:
         barmanObjectName: shared-timeline
-        serverName: shared-timeline-test
+        serverName: shared-timeline-test-plugin

--- a/tests/e2e/plugin_barman_cloud_tl_divergence_test.go
+++ b/tests/e2e/plugin_barman_cloud_tl_divergence_test.go
@@ -46,7 +46,7 @@ var _ = Describe("plugin-barman-cloud timeline divergence protection",
 		const (
 			level                 = tests.High
 			sharedObjectStoreName = "shared-timeline"
-			sharedArchiveName     = "shared-timeline-test"
+			sharedArchiveName     = "shared-timeline-test-plugin"
 			timelineFixturesDir   = fixturesDir + "/plugin_barman_cloud/timeline_divergence"
 			firstClusterFile      = timelineFixturesDir + "/cluster-plugin-tl-divergence-1.yaml.template"
 			secondClusterFile     = timelineFixturesDir + "/cluster-plugin-tl-divergence-2.yaml.template"


### PR DESCRIPTION
The plugin-barman-cloud port of the timeline divergence protection test reused the same Barman serverName ("shared-timeline-test") as the pre-existing in-core variant. Both specs write their timeline-2 cluster's WAL segments to separate buckets, but CountFiles matches across every bucket in the shared object store, keyed only by serverName and file name. Since both specs bootstrap an identical, minimal cluster, they reliably reach the same WAL segment number on timeline 2, so whichever spec runs second in a given job finds its own archived file plus the other spec's identically named one and fails the archive-count assertion with 2 matches instead of 1.

Giving the plugin variant its own serverName removes the collision.