### PR TITLE
chore: rename k9s plugin file

### DIFF
--- a/docs/src/kubectl-plugin.md
+++ b/docs/src/kubectl-plugin.md
@@ -1473,7 +1473,7 @@ kubectl cnpg subscription sync-sequences destination-cluster \
 The `cnpg` plugin can be easily integrated in [K9s](https://k9scli.io/), a
 popular terminal-based UI to interact with Kubernetes clusters.
 
-See [`k9s/plugins.yml`](samples/k9s/plugins.yml) for details.
+See [`k9s/cloudnative-pg.yaml`](samples/k9s/cloudnative-pg.yaml) for details.
 
 ## Permissions required by the plugin
 

--- a/docs/src/samples/k9s/cloudnative-pg.yaml
+++ b/docs/src/samples/k9s/cloudnative-pg.yaml
@@ -1,4 +1,4 @@
-# Move/add to $XDG_CONFIG_HOME/k9s/plugins.yaml
+# Move/add to $XDG_CONFIG_HOME/k9s/plugins/cloudnative-pg.yaml
 # Requires the cnpg kubectl plugin. See https://cloudnative-pg.io/docs/devel/kubectl-plugin/
 #
 # Cluster actions:


### PR DESCRIPTION
closes: #9210

This PR renames the k9s plugin file from plugins.yml to cloudnative-pg.yaml and advises to copy it to the `plugins` subdirectory  $XDG_CONFIG_HOME/k9s/plugins/cloudnative-pg.yaml
so that it matches with other 
https://github.com/derailed/k9s/tree/master/plugins#k9s-community-plugins

Signed-off-by: Daniel Chambre <smiyc@pm.me>