### PR TITLE
ci(e2e): make e2e runner and ginkgo parallelism scale together

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -274,7 +274,7 @@ jobs:
       log_level: ${{ env.LOG_LEVEL }}
       cnpg_deployment_method: ${{ env.CNPG_DEPLOYMENT_METHOD }}
       barman_plugin_version: ${{ env.BARMAN_PLUGIN_VERSION }}
-      runs_on: ${{ steps.set-runner.outputs.runs_on }}
+      runs_on: ${{ vars.E2E_RUNNER || 'ubuntu-latest' }}
     steps:
       - name: From command
         env:
@@ -315,17 +315,6 @@ jobs:
             echo "LOG_LEVEL=${IC_LOG_LEVEL}" >> $GITHUB_ENV
             echo "CNPG_DEPLOYMENT_METHOD=${IC_CNPG_DEPLOYMENT_METHOD}" >> $GITHUB_ENV
             echo "BARMAN_PLUGIN_VERSION=${IC_BARMAN_PLUGIN_VERSION}" >> $GITHUB_ENV
-          fi
-
-      - name: Set runner based on organization
-        env:
-          REPO_OWNER: ${{ github.repository_owner }}
-        id: set-runner
-        run: |
-          if [[ "${REPO_OWNER}" == "cloudnative-pg" ]]; then
-            echo "runs_on=ubuntu-latest-16-cores" >> $GITHUB_OUTPUT
-          else
-            echo "runs_on=ubuntu-24.04" >> $GITHUB_OUTPUT
           fi
 
   buildx:

--- a/hack/e2e/run-e2e-suite.sh
+++ b/hack/e2e/run-e2e-suite.sh
@@ -66,7 +66,21 @@ mkdir -p "${ROOT_DIR}/tests/e2e/out"
 RC_GINKGO=0
 export TEST_SKIP_UPGRADE=true
 cd "${ROOT_DIR}/tests"
-ginkgo --nodes=4 --timeout 3h --poll-progress-after=1200s --poll-progress-interval=150s \
+
+# Size ginkgo's parallelism to the runner instead of a fixed value, so we
+# don't starve the kind control plane (apiserver/etcd/kubelet/containerd) on
+# small runners while leaving most of a big runner's CPUs idle. Reserve
+# ~25% of the available cores for the control plane and system pods, and
+# use the rest as ginkgo workers.
+AVAILABLE_CORES=$(nproc)
+RESERVED_CORES=$(( (AVAILABLE_CORES + 3) / 4 ))
+GINKGO_NODES=$(( AVAILABLE_CORES - RESERVED_CORES ))
+if [ "${GINKGO_NODES}" -lt 1 ]; then
+  GINKGO_NODES=1
+fi
+echo "Detected ${AVAILABLE_CORES} CPU(s); running ginkgo with ${GINKGO_NODES} node(s)"
+
+ginkgo --nodes="${GINKGO_NODES}" --timeout 3h --poll-progress-after=1200s --poll-progress-interval=150s \
       ${LABEL_FILTERS:+--label-filter "${LABEL_FILTERS}"} \
       ${GITHUB_ACTIONS:+--github-output} --force-newlines \
       --output-dir "${ROOT_DIR}/tests/e2e/out/" \


### PR DESCRIPTION
The kind e2e runner was hardcoded to a bigger 16-core class only for the cloudnative-pg org, so any fork running this workflow gets a plain 4-core runner while ginkgo parallelism stays a fixed --nodes=4 regardless of runner size. On a smaller runner this leaves zero CPU headroom for the kind control plane once all cores are claimed by test workers, which can cascade into apiserver/RBAC failures under load.

Make the runner selectable via an E2E_RUNNER repository variable, falling back to ubuntu-latest when unset, so any fork can pick its own runner class. Size ginkgo's --nodes from the runner's actual core count instead of a fixed value, reserving roughly a quarter of the cores for the control plane and system pods.