### PR TITLE
test(e2e): enable plugin-barman-cloud E2E tests on cloud-providers

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -22,9 +22,9 @@ on:
         description: >
           Feature Type (backup-restore, basic, cluster-metadata, declarative-database-roles, declarative-databases,
           disruptive, image-volume-extensions, importing-databases, maintenance, no-openshift, observability, operator,
-          performance, plugin, pod-scheduling, postgres-configuration, postgres-major-upgrade, publication-subscription,
-          recovery, replication, security, self-healing, service-connectivity, smoke, snapshot, storage, tablespaces,
-          upgrade)
+          performance, plugin, plugin-barman-cloud, pod-scheduling, postgres-configuration, postgres-major-upgrade,
+          publication-subscription, recovery, replication, security, self-healing, service-connectivity, smoke, snapshot,
+          storage, tablespaces, upgrade)
         required: false
       log_level:
         description: 'Log level for operator (error, warning, info, debug(default), trace)'

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -39,7 +39,7 @@ on:
           - manifest
           - helm
       barman_plugin:
-        description: 'plugin-barman-cloud version to install (kind/k3d only): release (default), main, a pinned version like v0.12.0, pr-<number> for a pull request, or a branch name'
+        description: 'plugin-barman-cloud version to install: release (default), main, a pinned version like v0.12.0, pr-<number> for a pull request, or a branch name'
         required: false
         default: 'release'
   schedule:
@@ -1126,6 +1126,8 @@ jobs:
       TEST_DEPTH: ${{ needs.evaluate_options.outputs.test_level }}
       # FEATURE_TYPE, when defined, determines the subset of E2E tests that will be executed, divided by feature type
       FEATURE_TYPE: ${{ needs.evaluate_options.outputs.feature_type }}
+      # BARMAN_PLUGIN_VERSION selects the plugin-barman-cloud build to install for the plugin-based backup tests
+      BARMAN_PLUGIN_VERSION: ${{ needs.evaluate_options.outputs.barman_plugin_version }}
 
       K8S_VERSION: "${{ matrix.k8s_version }}"
       POSTGRES_VERSION: ${{ matrix.postgres_version }}
@@ -1479,6 +1481,8 @@ jobs:
       TEST_DEPTH: ${{ needs.evaluate_options.outputs.test_level }}
       # FEATURE_TYPE, when defined, determines the subset of E2E tests that will be executed, divided by feature type
       FEATURE_TYPE: ${{ needs.evaluate_options.outputs.feature_type }}
+      # BARMAN_PLUGIN_VERSION selects the plugin-barman-cloud build to install for the plugin-based backup tests
+      BARMAN_PLUGIN_VERSION: ${{ needs.evaluate_options.outputs.barman_plugin_version }}
 
       K8S_VERSION: "${{ matrix.k8s_version }}"
       POSTGRES_VERSION: ${{ matrix.postgres_version }}
@@ -1883,6 +1887,8 @@ jobs:
       TEST_DEPTH: ${{ needs.evaluate_options.outputs.test_level }}
       # FEATURE_TYPE, when defined, determines the subset of E2E tests that will be executed, divided by feature type
       FEATURE_TYPE: ${{ needs.evaluate_options.outputs.feature_type }}
+      # BARMAN_PLUGIN_VERSION selects the plugin-barman-cloud build to install for the plugin-based backup tests
+      BARMAN_PLUGIN_VERSION: ${{ needs.evaluate_options.outputs.barman_plugin_version }}
 
       K8S_VERSION: "${{ matrix.k8s_version }}"
       POSTGRES_VERSION: ${{ matrix.postgres_version }}

--- a/contribute/e2e_testing_environment/README.md
+++ b/contribute/e2e_testing_environment/README.md
@@ -190,8 +190,8 @@ The script can be configured through the following environment variables:
 - `CNPG_CHART_VERSION`: when `CNPG_DEPLOYMENT_METHOD=helm`, pin the chart to
   this version (passed as `--version`). Unset by default, in which case the
   latest published chart is installed.
-- `BARMAN_PLUGIN_VERSION`: the `plugin-barman-cloud` build to install (kind/k3d
-  only) for the plugin-based backup tests: `release` (default) for the latest
+- `BARMAN_PLUGIN_VERSION`: the `plugin-barman-cloud` build to install for the
+  plugin-based backup tests: `release` (default) for the latest
   published release, `main` for the current snapshot, a pinned version such
   as `v0.12.0`, `pr-<number>` to install the testing images its CI publishes
   for a pull request, or the name of a `plugin-barman-cloud` branch to install

--- a/hack/e2e/run-e2e.sh
+++ b/hack/e2e/run-e2e.sh
@@ -166,17 +166,8 @@ if [[ "${TEST_CLOUD_VENDOR}" != "ocp" ]]; then
     deploy_operator_from_source
   fi
 
-  # Install plugin-barman-cloud for the plugin-based backup tests. Restricted to
-  # local engines (kind/k3d) for now; cloud-vendor coverage will follow with the
-  # backup test ports.
-  case "${TEST_CLOUD_VENDOR:-}" in
-    kind | k3d)
-      install_barman_cloud_plugin
-      ;;
-    *)
-      echo "Skipping plugin-barman-cloud install on '${TEST_CLOUD_VENDOR:-}' (only kind/k3d for now)."
-      ;;
-  esac
+  # Install plugin-barman-cloud for the plugin-based backup tests.
+  install_barman_cloud_plugin
 fi
 
 # Run the main (non-upgrade) test suite via run-e2e-suite.sh,

--- a/tests/e2e/plugin_barman_cloud_backup_test.go
+++ b/tests/e2e/plugin_barman_cloud_backup_test.go
@@ -59,9 +59,6 @@ var _ = Describe("plugin-barman-cloud scheduled backups, standby target and PITR
 			if testLevelEnv.Depth < int(level) {
 				Skip("Test depth is lower than the amount requested for this test")
 			}
-			if IsOpenshift() {
-				Skip("This test case is not applicable on OpenShift clusters")
-			}
 		})
 
 		Context("on a cluster archiving through the plugin", Ordered, func() {

--- a/tests/e2e/plugin_barman_cloud_backup_test.go
+++ b/tests/e2e/plugin_barman_cloud_backup_test.go
@@ -38,8 +38,7 @@ import (
 // Plugin counterparts of the in-core object-store backup scenarios that go
 // beyond a plain backup/restore round-trip: scheduled backups, choosing the
 // backup target, and point-in-time recovery. They share one cluster archiving
-// through plugin-barman-cloud; the in-core variants are left in place. Runs on
-// kind/k3d only.
+// through plugin-barman-cloud; the in-core variants are left in place.
 var _ = Describe("plugin-barman-cloud scheduled backups, standby target and PITR",
 	Label(tests.LabelPluginBarmanCloud, tests.LabelBackupRestore), func() {
 		const (
@@ -60,8 +59,8 @@ var _ = Describe("plugin-barman-cloud scheduled backups, standby target and PITR
 			if testLevelEnv.Depth < int(level) {
 				Skip("Test depth is lower than the amount requested for this test")
 			}
-			if !(IsKind() || IsK3D()) {
-				Skip("This test only runs on kind or k3d clusters")
+			if IsOpenshift() {
+				Skip("This test case is not applicable on OpenShift clusters")
 			}
 		})
 

--- a/tests/e2e/plugin_barman_cloud_major_upgrade_test.go
+++ b/tests/e2e/plugin_barman_cloud_major_upgrade_test.go
@@ -62,9 +62,6 @@ var _ = Describe("plugin-barman-cloud across a Postgres major upgrade",
 			if testLevelEnv.Depth < int(level) {
 				Skip("Test depth is lower than the amount requested for this test")
 			}
-			if IsOpenshift() {
-				Skip("This test case is not applicable on OpenShift clusters")
-			}
 		})
 
 		It("keeps WAL archiving working across a Postgres major upgrade", func() {

--- a/tests/e2e/plugin_barman_cloud_major_upgrade_test.go
+++ b/tests/e2e/plugin_barman_cloud_major_upgrade_test.go
@@ -51,8 +51,6 @@ import (
 // archiving keeps working after a Postgres major version upgrade. Here the
 // archiver is plugin-barman-cloud rather than the in-core barmanObjectStore. The
 // in-core variant (and the other upgrade scenarios it covers) is left in place.
-// Runs on kind/k3d only, where the plugin and the shared object store are
-// installed.
 var _ = Describe("plugin-barman-cloud across a Postgres major upgrade",
 	Label(tests.LabelPluginBarmanCloud, tests.LabelPostgresMajorUpgrade, tests.LabelBackupRestore), func() {
 		const (
@@ -64,8 +62,8 @@ var _ = Describe("plugin-barman-cloud across a Postgres major upgrade",
 			if testLevelEnv.Depth < int(level) {
 				Skip("Test depth is lower than the amount requested for this test")
 			}
-			if !(IsKind() || IsK3D()) {
-				Skip("This test only runs on kind or k3d clusters")
+			if IsOpenshift() {
+				Skip("This test case is not applicable on OpenShift clusters")
 			}
 		})
 

--- a/tests/e2e/plugin_barman_cloud_replica_test.go
+++ b/tests/e2e/plugin_barman_cloud_replica_test.go
@@ -100,7 +100,6 @@ var _ = Describe("plugin-barman-cloud replica cluster from backup",
 // Plugin port of the "Replica switchover" scenario:
 // In this test we create a replica cluster from a backup and then promote it to a primary.
 // We expect the original primary to be demoted to a replica and be able to follow the new primary.
-// Runs on kind/k3d only, where the plugin and the shared object store are installed.
 //
 //nolint:dupl // TODO: remove once in-tree counterpart is removed
 var _ = Describe("plugin-barman-cloud replica cluster promotion/demotion",
@@ -118,9 +117,6 @@ var _ = Describe("plugin-barman-cloud replica cluster promotion/demotion",
 		BeforeAll(func() {
 			if testLevelEnv.Depth < int(level) {
 				Skip("Test depth is lower than the amount requested for this test")
-			}
-			if !(IsKind() || IsK3D()) {
-				Skip("This test only runs on kind or k3d clusters")
 			}
 		})
 

--- a/tests/e2e/plugin_barman_cloud_replica_test.go
+++ b/tests/e2e/plugin_barman_cloud_replica_test.go
@@ -55,8 +55,7 @@ import (
 // is bootstrapped from that backup via externalClusters[].plugin and streams
 // from the source. It is added alongside the in-core variant (which shares its
 // source cluster with a volume-snapshot test), and stays until the in-core
-// Barman Cloud support is removed. Runs on kind/k3d only, where the plugin and
-// the shared object store are installed.
+// Barman Cloud support is removed.
 var _ = Describe("plugin-barman-cloud replica cluster from backup",
 	Label(tests.LabelPluginBarmanCloud, tests.LabelReplication, tests.LabelBackupRestore), func() {
 		const (
@@ -73,8 +72,8 @@ var _ = Describe("plugin-barman-cloud replica cluster from backup",
 			if testLevelEnv.Depth < int(level) {
 				Skip("Test depth is lower than the amount requested for this test")
 			}
-			if !(IsKind() || IsK3D()) {
-				Skip("This test only runs on kind or k3d clusters")
+			if IsOpenshift() {
+				Skip("This test case is not applicable on OpenShift clusters")
 			}
 		})
 

--- a/tests/e2e/plugin_barman_cloud_replica_test.go
+++ b/tests/e2e/plugin_barman_cloud_replica_test.go
@@ -72,9 +72,6 @@ var _ = Describe("plugin-barman-cloud replica cluster from backup",
 			if testLevelEnv.Depth < int(level) {
 				Skip("Test depth is lower than the amount requested for this test")
 			}
-			if IsOpenshift() {
-				Skip("This test case is not applicable on OpenShift clusters")
-			}
 		})
 
 		It("bootstraps a replica cluster from a plugin backup", func() {

--- a/tests/e2e/plugin_barman_cloud_snapshot_test.go
+++ b/tests/e2e/plugin_barman_cloud_snapshot_test.go
@@ -63,9 +63,6 @@ var _ = Describe("plugin-barman-cloud volume snapshots",
 			if testLevelEnv.Depth < int(level) {
 				Skip("Test depth is lower than the amount requested for this test")
 			}
-			if IsOpenshift() {
-				Skip("This test case is not applicable on OpenShift clusters")
-			}
 		})
 
 		// getSnapshots lists the VolumeSnapshots produced by a given backup of a

--- a/tests/e2e/plugin_barman_cloud_snapshot_test.go
+++ b/tests/e2e/plugin_barman_cloud_snapshot_test.go
@@ -54,8 +54,7 @@ import (
 // backup is still taken with the native volumeSnapshot method, but WAL archiving
 // (and the WAL source used during recovery) goes through plugin-barman-cloud
 // rather than the deprecated in-core barmanObjectStore. The in-core variants are
-// left in place. Runs on kind/k3d only, where the plugin and the shared object
-// store are installed.
+// left in place.
 var _ = Describe("plugin-barman-cloud volume snapshots",
 	Label(tests.LabelPluginBarmanCloud, tests.LabelSnapshot, tests.LabelBackupRestore), func() {
 		const level = tests.High
@@ -64,8 +63,8 @@ var _ = Describe("plugin-barman-cloud volume snapshots",
 			if testLevelEnv.Depth < int(level) {
 				Skip("Test depth is lower than the amount requested for this test")
 			}
-			if !(IsKind() || IsK3D()) {
-				Skip("This test only runs on kind or k3d clusters")
+			if IsOpenshift() {
+				Skip("This test case is not applicable on OpenShift clusters")
 			}
 		})
 

--- a/tests/e2e/plugin_barman_cloud_tablespaces_test.go
+++ b/tests/e2e/plugin_barman_cloud_tablespaces_test.go
@@ -40,7 +40,6 @@ import (
 // recreated from the backup. It verifies tablespaces survive a plugin
 // backup/restore round-trip; the in-core variant (which shares its cluster with
 // owner/temporary-tablespace and volume-snapshot sub-tests) is left in place.
-// Runs on kind/k3d only.
 var _ = Describe("plugin-barman-cloud tablespaces backup and restore",
 	Label(tests.LabelPluginBarmanCloud, tests.LabelTablespaces, tests.LabelBackupRestore), func() {
 		const (
@@ -59,8 +58,8 @@ var _ = Describe("plugin-barman-cloud tablespaces backup and restore",
 			if testLevelEnv.Depth < int(level) {
 				Skip("Test depth is lower than the amount requested for this test")
 			}
-			if !(IsKind() || IsK3D()) {
-				Skip("This test only runs on kind or k3d clusters")
+			if IsOpenshift() {
+				Skip("This test case is not applicable on OpenShift clusters")
 			}
 		})
 

--- a/tests/e2e/plugin_barman_cloud_tablespaces_test.go
+++ b/tests/e2e/plugin_barman_cloud_tablespaces_test.go
@@ -58,9 +58,6 @@ var _ = Describe("plugin-barman-cloud tablespaces backup and restore",
 			if testLevelEnv.Depth < int(level) {
 				Skip("Test depth is lower than the amount requested for this test")
 			}
-			if IsOpenshift() {
-				Skip("This test case is not applicable on OpenShift clusters")
-			}
 		})
 
 		It("backs up and restores a cluster with tablespaces through the plugin", func() {

--- a/tests/e2e/plugin_barman_cloud_test.go
+++ b/tests/e2e/plugin_barman_cloud_test.go
@@ -62,9 +62,6 @@ var _ = Describe("plugin-barman-cloud",
 			if testLevelEnv.Depth < int(level) {
 				Skip("Test depth is lower than the amount requested for this test")
 			}
-			if IsOpenshift() {
-				Skip("This test case is not applicable on OpenShift clusters")
-			}
 		})
 
 		It("backs up and restores a cluster through the selected plugin-barman-cloud", func() {

--- a/tests/e2e/plugin_barman_cloud_test.go
+++ b/tests/e2e/plugin_barman_cloud_test.go
@@ -62,10 +62,8 @@ var _ = Describe("plugin-barman-cloud",
 			if testLevelEnv.Depth < int(level) {
 				Skip("Test depth is lower than the amount requested for this test")
 			}
-			// The plugin (and the shared object store it backs up to) is only
-			// installed on local kind/k3d engines; see hack/e2e/run-e2e.sh.
-			if !(IsKind() || IsK3D()) {
-				Skip("This test only runs on kind or k3d clusters")
+			if IsOpenshift() {
+				Skip("This test case is not applicable on OpenShift clusters")
 			}
 		})
 

--- a/tests/e2e/plugin_barman_cloud_tl_divergence_test.go
+++ b/tests/e2e/plugin_barman_cloud_tl_divergence_test.go
@@ -40,7 +40,6 @@ import (
 // verifies a replica refuses to adopt a timeline-history file for a
 // timeline ahead of its own cluster's, from an object store shared
 // with a second, already-diverged cluster.
-// Runs on kind/k3d only, where the plugin and shared store are set up.
 var _ = Describe("plugin-barman-cloud timeline divergence protection",
 	Label(tests.LabelPluginBarmanCloud, tests.LabelBackupRestore), func() {
 		const (
@@ -57,8 +56,8 @@ var _ = Describe("plugin-barman-cloud timeline divergence protection",
 			if testLevelEnv.Depth < int(level) {
 				Skip("Test depth is lower than the amount requested for this test")
 			}
-			if !(IsKind() || IsK3D()) {
-				Skip("This test only runs on kind or k3d clusters")
+			if IsOpenshift() {
+				Skip("This test case is not applicable on OpenShift clusters")
 			}
 		})
 

--- a/tests/e2e/plugin_barman_cloud_tl_divergence_test.go
+++ b/tests/e2e/plugin_barman_cloud_tl_divergence_test.go
@@ -56,9 +56,6 @@ var _ = Describe("plugin-barman-cloud timeline divergence protection",
 			if testLevelEnv.Depth < int(level) {
 				Skip("Test depth is lower than the amount requested for this test")
 			}
-			if IsOpenshift() {
-				Skip("This test case is not applicable on OpenShift clusters")
-			}
 		})
 
 		It("protects replicas from downloading future timeline history files", func() {

--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -24,6 +24,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -217,6 +218,15 @@ E2E test configuration:
 	}
 
 	objectStoreEnv.Client = objs["object-store"]
+})
+
+// plugin-barman-cloud is not installed on OpenShift clusters since it isn't
+// available yet via OLM, see https://github.com/cloudnative-pg/plugin-barman-cloud/issues/554.
+// Every test running on Openshift and carrying the plugin-barman-cloud label should be skipped.
+var _ = BeforeEach(func() {
+	if IsOpenshift() && slices.Contains(CurrentSpecReport().Labels(), tests.LabelPluginBarmanCloud) {
+		Skip("plugin-barman-cloud tests are not applicable on OpenShift clusters")
+	}
 })
 
 var _ = BeforeEach(func() {


### PR DESCRIPTION
Enable E2Es featuring plugin-barman-cloud also on cloud-providers, using the local rustfs as the object store.
Openshift is excluded given that plugin-barman-cloud is not yet installable via OLM.

Closes #11176 