### PR TITLE
chore(security-insights): set accepts-automated-change-request to true

### DIFF
--- a/SECURITY-INSIGHTS.yml
+++ b/SECURITY-INSIGHTS.yml
@@ -96,7 +96,7 @@ repository:
   url: https://github.com/cloudnative-pg/cloudnative-pg
   status: active
   accepts-change-request: true
-  accepts-automated-change-request: false
+  accepts-automated-change-request: true
   no-third-party-packages: false
   core-team:
     - name: Gabriele Bartolini


### PR DESCRIPTION
SECURITY-INSIGHTS.yml declared accepts-automated-change-request: false, but the project runs Renovate (.github/renovate.json5) and regularly merges its automated dependency-update PRs, so per the OSSF Security Insights spec the field should be true.

Closes #11197