### PR TITLE
fix(pvc): use `ptr.Equal` for `VolumeAttributesClass` equality check

### DIFF
--- a/pkg/reconciler/persistentvolumeclaim/existing.go
+++ b/pkg/reconciler/persistentvolumeclaim/existing.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/cloudnative-pg/machinery/pkg/log"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
@@ -108,7 +109,7 @@ func reconcileVolumeAttributeClass(
 	}
 
 	expectedVolumeAttributesClassName := storageConfiguration.PersistentVolumeClaimTemplate.VolumeAttributesClassName
-	if expectedVolumeAttributesClassName == pvc.Spec.VolumeAttributesClassName {
+	if ptr.Equal(expectedVolumeAttributesClassName, pvc.Spec.VolumeAttributesClassName) {
 		return nil
 	}
 

--- a/pkg/reconciler/persistentvolumeclaim/reconciler_test.go
+++ b/pkg/reconciler/persistentvolumeclaim/reconciler_test.go
@@ -649,7 +649,7 @@ var _ = Describe("Reconcile Volume Attribute Class", func() {
 		storage := &apiv1.StorageConfiguration{
 			Size: "1Gi",
 			PersistentVolumeClaimTemplate: &corev1.PersistentVolumeClaimSpec{
-				VolumeAttributesClassName: new("fast-class"),
+				VolumeAttributesClassName: ptr.To("fast-class"),
 			},
 		}
 

--- a/pkg/reconciler/persistentvolumeclaim/reconciler_test.go
+++ b/pkg/reconciler/persistentvolumeclaim/reconciler_test.go
@@ -600,6 +600,7 @@ var _ = Describe("Reconcile Volume Attribute Class", func() {
 		pvc         corev1.PersistentVolumeClaim
 		cli         client.Client
 		ctx         context.Context
+		patchCount  int
 	)
 
 	BeforeEach(func() {
@@ -610,9 +611,18 @@ var _ = Describe("Reconcile Volume Attribute Class", func() {
 			},
 		}
 		pvc = makePVC(clusterName, "1", "1", NewPgDataCalculator(), false)
+		patchCount = 0
 		cli = fake.NewClientBuilder().
 			WithScheme(scheme.BuildWithAllKnownScheme()).
 			WithObjects(cluster, &pvc).
+			WithInterceptorFuncs(interceptor.Funcs{
+				Patch: func(ctx context.Context, c client.WithWatch, obj client.Object,
+					patch client.Patch, opts ...client.PatchOption,
+				) error {
+					patchCount++
+					return c.Patch(ctx, obj, patch, opts...)
+				},
+			}).
 			Build()
 	})
 
@@ -631,25 +641,10 @@ var _ = Describe("Reconcile Volume Attribute Class", func() {
 		className := "fast-class"
 		pvc.Spec.VolumeAttributesClassName = &className
 
-		// Rebuild the fake client for this test to count Patch calls
-		patchCount := 0
-		cli = fake.NewClientBuilder().
-			WithScheme(scheme.BuildWithAllKnownScheme()).
-			WithObjects(cluster, &pvc).
-			WithInterceptorFuncs(interceptor.Funcs{
-				Patch: func(ctx context.Context, c client.WithWatch, obj client.Object,
-					patch client.Patch, opts ...client.PatchOption,
-				) error {
-					patchCount++
-					return c.Patch(ctx, obj, patch, opts...)
-				},
-			}).
-			Build()
-
 		storage := &apiv1.StorageConfiguration{
 			Size: "1Gi",
 			PersistentVolumeClaimTemplate: &corev1.PersistentVolumeClaimSpec{
-				VolumeAttributesClassName: ptr.To("fast-class"),
+				VolumeAttributesClassName: ptr.To(className),
 			},
 		}
 
@@ -674,6 +669,7 @@ var _ = Describe("Reconcile Volume Attribute Class", func() {
 		err := reconcileVolumeAttributeClass(ctx, cli, storage, &pvc)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(*pvc.Spec.VolumeAttributesClassName).To(Equal(expectedClassName))
+		Expect(patchCount).To(Equal(1))
 	})
 
 	It("sets VolumeAttributesClassName to nil when template specifies nil", func() {
@@ -690,5 +686,6 @@ var _ = Describe("Reconcile Volume Attribute Class", func() {
 		err := reconcileVolumeAttributeClass(ctx, cli, storage, &pvc)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(pvc.Spec.VolumeAttributesClassName).To(BeNil())
+		Expect(patchCount).To(Equal(1))
 	})
 })

--- a/pkg/reconciler/persistentvolumeclaim/reconciler_test.go
+++ b/pkg/reconciler/persistentvolumeclaim/reconciler_test.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/internal/configuration"
@@ -630,16 +631,32 @@ var _ = Describe("Reconcile Volume Attribute Class", func() {
 		className := "fast-class"
 		pvc.Spec.VolumeAttributesClassName = &className
 
+		// Rebuild the fake client for this test to count Patch calls
+		patchCount := 0
+		cli = fake.NewClientBuilder().
+			WithScheme(scheme.BuildWithAllKnownScheme()).
+			WithObjects(cluster, &pvc).
+			WithInterceptorFuncs(interceptor.Funcs{
+				Patch: func(ctx context.Context, c client.WithWatch, obj client.Object,
+					patch client.Patch, opts ...client.PatchOption,
+				) error {
+					patchCount++
+					return c.Patch(ctx, obj, patch, opts...)
+				},
+			}).
+			Build()
+
 		storage := &apiv1.StorageConfiguration{
 			Size: "1Gi",
 			PersistentVolumeClaimTemplate: &corev1.PersistentVolumeClaimSpec{
-				VolumeAttributesClassName: &className,
+				VolumeAttributesClassName: new("fast-class"),
 			},
 		}
 
 		err := reconcileVolumeAttributeClass(ctx, cli, storage, &pvc)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(*pvc.Spec.VolumeAttributesClassName).To(Equal(className))
+		Expect(pvc.Spec.VolumeAttributesClassName).To(HaveValue(Equal(className)))
+		Expect(patchCount).To(BeZero(), "no patch should be issued for an already-correct PVC")
 	})
 
 	It("updates VolumeAttributesClassName when it differs from the expected value", func() {


### PR DESCRIPTION
The guard in `reconcileVolumeAttributeClass` compared two *string pointers with `==`. Any cluster with a `volumeAttributesClass` set in its `pvcTemplate` failed the check on every reconciliation, issuing a redundant empty `PATCH` against the API server even when the PVC already carried the expected value.

Use `ptr.Equal` to compare the values instead and strengthen the existing test: it previously assigned the same pointer to both the PVC and the template, masking the bug. It now uses distinct allocations and asserts that no Patch call is issued for an already-correct PVC.

Fixes #11194