### PR TITLE
fix(wal-restore): improve WAL restoration during pg_rewind

### DIFF
--- a/internal/cmd/manager/walrestore/cmd.go
+++ b/internal/cmd/manager/walrestore/cmd.go
@@ -30,6 +30,7 @@ import (
 
 	barmanCommand "github.com/cloudnative-pg/barman-cloud/pkg/command"
 	barmanRestorer "github.com/cloudnative-pg/barman-cloud/pkg/restorer"
+	"github.com/cloudnative-pg/cnpg-i/pkg/wal"
 	"github.com/cloudnative-pg/machinery/pkg/log"
 	"github.com/cloudnative-pg/machinery/pkg/stringset"
 	"github.com/spf13/cobra"
@@ -131,7 +132,7 @@ func run(ctx context.Context, pgData string, podName string, rewindMode bool, ar
 		return err
 	}
 
-	walFound, err := restoreWALViaPlugins(ctx, cluster, walName, pgData, destinationPath)
+	walFound, err := restoreWALViaPlugins(ctx, cluster, walName, pgData, destinationPath, rewindMode)
 	if err != nil {
 		// With the current implementation, this happens when both of the following conditions are met:
 		//
@@ -270,6 +271,7 @@ func restoreWALViaPlugins(
 	walName string,
 	pgData string,
 	destinationPathName string,
+	rewindMode bool,
 ) (bool, error) {
 	contextLogger := log.FromContext(ctx)
 
@@ -289,7 +291,12 @@ func restoreWALViaPlugins(
 	}
 	defer client.Close(ctx)
 
-	return client.RestoreWAL(ctx, cluster, walName, postgres.BuildWALPath(pgData, destinationPathName))
+	mode := wal.WALRestoreRequest_MODE_RECOVERY
+	if rewindMode {
+		mode = wal.WALRestoreRequest_MODE_REWIND
+	}
+
+	return client.RestoreWAL(ctx, cluster, walName, postgres.BuildWALPath(pgData, destinationPathName), mode)
 }
 
 // checkEndOfWALStreamFlag returns ErrEndOfWALStreamReached if the flag is set in the restorer

--- a/internal/cmd/manager/walrestore/cmd.go
+++ b/internal/cmd/manager/walrestore/cmd.go
@@ -65,6 +65,7 @@ const (
 func NewCmd() *cobra.Command {
 	var podName string
 	var pgData string
+	var rewindMode bool
 
 	cmd := cobra.Command{
 		Use:           "wal-restore [name]",
@@ -75,7 +76,7 @@ func NewCmd() *cobra.Command {
 			// TODO: We need to implement a logpipe to prevent this.
 			contextLog := log.WithName("wal-restore")
 			ctx := log.IntoContext(cobraCmd.Context(), contextLog)
-			err := run(ctx, pgData, podName, args)
+			err := run(ctx, pgData, podName, rewindMode, args)
 			if err == nil {
 				return nil
 			}
@@ -103,11 +104,13 @@ func NewCmd() *cobra.Command {
 	cmd.Flags().StringVar(&podName, "pod-name", os.Getenv("POD_NAME"), "The name of the "+
 		"current pod in k8s")
 	cmd.Flags().StringVar(&pgData, "pg-data", os.Getenv("PGDATA"), "The PGDATA to be used")
+	cmd.Flags().BoolVar(&rewindMode, "rewind", false, "Set when the restore is executed on behalf "+
+		"of pg_rewind: disables WAL prefetching and the end-of-wal-stream flag machinery")
 
 	return &cmd
 }
 
-func run(ctx context.Context, pgData string, podName string, args []string) error {
+func run(ctx context.Context, pgData string, podName string, rewindMode bool, args []string) error {
 	contextLog := log.FromContext(ctx)
 	startTime := time.Now()
 	walName := args[0]
@@ -192,8 +195,9 @@ func run(ctx context.Context, pgData string, podName string, args []string) erro
 	}
 
 	// Step 2: return error if the end-of-wal-stream flag is set.
-	// We skip this step if streaming connection is not available
-	if isStreamingAvailable(cluster, podName) {
+	// We skip this step if the flag machinery does not apply to this invocation
+	useEndOfWALStreamFlag := shouldUseEndOfWALStreamFlag(cluster, podName, rewindMode)
+	if useEndOfWALStreamFlag {
 		if err := checkEndOfWALStreamFlag(walRestorer); err != nil {
 			return err
 		}
@@ -204,6 +208,11 @@ func run(ctx context.Context, pgData string, podName string, args []string) erro
 	maxParallel := 1
 	if barmanConfiguration.Wal != nil && barmanConfiguration.Wal.MaxParallel > 1 {
 		maxParallel = barmanConfiguration.Wal.MaxParallel
+	}
+	if rewindMode {
+		// pg_rewind walks the WAL backward, so prefetching the segments
+		// that follow the requested one would be useless
+		maxParallel = 1
 	}
 	if postgres.IsWALFile(walName) {
 		// If this is a regular WAL file, we try to prefetch
@@ -227,9 +236,9 @@ func run(ctx context.Context, pgData string, podName string, args []string) erro
 	}
 
 	// Step 5: set end-of-wal-stream flag if any download job returned file-not-found
-	// We skip this step if streaming connection is not available
+	// We skip this step if the flag machinery does not apply to this invocation
 	endOfWALStream := isEndOfWALStream(walStatus)
-	if isStreamingAvailable(cluster, podName) && endOfWALStream {
+	if useEndOfWALStreamFlag && endOfWALStream {
 		contextLog.Info(
 			"Set end-of-wal-stream flag as one of the WAL files to be prefetched was not found")
 
@@ -404,6 +413,21 @@ func gatherWALFilesToRestore(walName string, parallel int) (walList []string, er
 	}
 
 	return walList, err
+}
+
+// shouldUseEndOfWALStreamFlag returns true when the end-of-wal-stream flag
+// machinery applies to the current invocation. The flag makes the following
+// invocation fail, so that PostgreSQL stops polling the WAL archive and
+// switches to streaming replication. It does not apply when no streaming
+// connection is available, nor when restoring on behalf of pg_rewind:
+// pg_rewind cannot fall back to streaming replication, and a stale flag would
+// make it abort on a segment that is available in the archive
+func shouldUseEndOfWALStreamFlag(cluster *apiv1.Cluster, podName string, rewindMode bool) bool {
+	if rewindMode {
+		return false
+	}
+
+	return isStreamingAvailable(cluster, podName)
 }
 
 // isStreamingAvailable checks if this pod can replicate via streaming connection

--- a/internal/cmd/manager/walrestore/cmd.go
+++ b/internal/cmd/manager/walrestore/cmd.go
@@ -205,15 +205,7 @@ func run(ctx context.Context, pgData string, podName string, rewindMode bool, ar
 
 	// Step 3: gather the WAL files names to restore. If the required file isn't a regular WAL, we download it directly.
 	var walFilesList []string
-	maxParallel := 1
-	if barmanConfiguration.Wal != nil && barmanConfiguration.Wal.MaxParallel > 1 {
-		maxParallel = barmanConfiguration.Wal.MaxParallel
-	}
-	if rewindMode {
-		// pg_rewind walks the WAL backward, so prefetching the segments
-		// that follow the requested one would be useless
-		maxParallel = 1
-	}
+	maxParallel := maxWALFilesPerInvocation(barmanConfiguration, rewindMode)
 	if postgres.IsWALFile(walName) {
 		// If this is a regular WAL file, we try to prefetch
 		if walFilesList, err = gatherWALFilesToRestore(walName, maxParallel); err != nil {
@@ -413,6 +405,24 @@ func gatherWALFilesToRestore(walName string, parallel int) (walList []string, er
 	}
 
 	return walList, err
+}
+
+// maxWALFilesPerInvocation returns how many WAL files a single wal-restore
+// invocation may fetch: the requested one, plus the ones that follow it up to
+// the configured maxParallel, to be prefetched into the spool. Prefetching is
+// disabled when restoring on behalf of pg_rewind, which walks the WAL
+// backward: the following segments would never be requested, and past the end
+// of the timeline they do not even exist
+func maxWALFilesPerInvocation(barmanConfiguration *apiv1.BarmanObjectStoreConfiguration, rewindMode bool) int {
+	if rewindMode {
+		return 1
+	}
+
+	if barmanConfiguration.Wal != nil && barmanConfiguration.Wal.MaxParallel > 1 {
+		return barmanConfiguration.Wal.MaxParallel
+	}
+
+	return 1
 }
 
 // shouldUseEndOfWALStreamFlag returns true when the end-of-wal-stream flag

--- a/internal/cmd/manager/walrestore/cmd.go
+++ b/internal/cmd/manager/walrestore/cmd.go
@@ -250,6 +250,7 @@ func run(ctx context.Context, pgData string, podName string, rewindMode bool, ar
 
 	contextLog.Info("WAL restore command completed (parallel)",
 		"walName", walName,
+		"rewindMode", rewindMode,
 		"maxParallel", maxParallel,
 		"successfulWalRestore", successfulWalRestore,
 		"failedWalRestore", maxParallel-successfulWalRestore,

--- a/internal/cmd/manager/walrestore/cmd_test.go
+++ b/internal/cmd/manager/walrestore/cmd_test.go
@@ -136,6 +136,30 @@ var _ = Describe("Function shouldUseEndOfWALStreamFlag", func() {
 	})
 })
 
+var _ = Describe("Function maxWALFilesPerInvocation", func() {
+	It("returns 1 when no parallel WAL configuration is present", func() {
+		Expect(maxWALFilesPerInvocation(&apiv1.BarmanObjectStoreConfiguration{}, false)).To(Equal(1))
+	})
+
+	It("returns the configured maxParallel", func() {
+		configuration := &apiv1.BarmanObjectStoreConfiguration{
+			Wal: &apiv1.WalBackupConfiguration{
+				MaxParallel: 3,
+			},
+		}
+		Expect(maxWALFilesPerInvocation(configuration, false)).To(Equal(3))
+	})
+
+	It("returns 1 in rewind mode, ignoring the configured maxParallel", func() {
+		configuration := &apiv1.BarmanObjectStoreConfiguration{
+			Wal: &apiv1.WalBackupConfiguration{
+				MaxParallel: 3,
+			},
+		}
+		Expect(maxWALFilesPerInvocation(configuration, true)).To(Equal(1))
+	})
+})
+
 var _ = Describe("Function isEndOfWALStream", func() {
 	It("returns true when the requested WAL was not found", func() {
 		results := []barmanRestorer.Result{

--- a/internal/cmd/manager/walrestore/cmd_test.go
+++ b/internal/cmd/manager/walrestore/cmd_test.go
@@ -20,6 +20,9 @@ SPDX-License-Identifier: Apache-2.0
 package walrestore
 
 import (
+	"errors"
+	"fmt"
+
 	barmanRestorer "github.com/cloudnative-pg/barman-cloud/pkg/restorer"
 	"k8s.io/utils/ptr"
 
@@ -112,6 +115,56 @@ var _ = Describe("Function isStreamingAvailable", func() {
 			},
 		}
 		Expect(isStreamingAvailable(&cluster, "primaryPod")).To(BeTrue())
+	})
+})
+
+var _ = Describe("Function shouldUseEndOfWALStreamFlag", func() {
+	cluster := apiv1.Cluster{
+		Status: apiv1.ClusterStatus{
+			CurrentPrimary: "primaryPod",
+		},
+	}
+
+	It("returns false in rewind mode, even when streaming is available", func() {
+		Expect(isStreamingAvailable(&cluster, "replicaPod")).To(BeTrue())
+		Expect(shouldUseEndOfWALStreamFlag(&cluster, "replicaPod", true)).To(BeFalse())
+	})
+
+	It("follows streaming availability when not in rewind mode", func() {
+		Expect(shouldUseEndOfWALStreamFlag(&cluster, "replicaPod", false)).To(BeTrue())
+		Expect(shouldUseEndOfWALStreamFlag(&cluster, "primaryPod", false)).To(BeFalse())
+	})
+})
+
+var _ = Describe("Function isEndOfWALStream", func() {
+	It("returns true when the requested WAL was not found", func() {
+		results := []barmanRestorer.Result{
+			{Err: barmanRestorer.ErrWALNotFound},
+		}
+		Expect(isEndOfWALStream(results)).To(BeTrue())
+	})
+
+	It("returns true when only a prefetched WAL was not found", func() {
+		results := []barmanRestorer.Result{
+			{Err: nil},
+			{Err: fmt.Errorf("while restoring the prefetched WAL: %w", barmanRestorer.ErrWALNotFound)},
+		}
+		Expect(isEndOfWALStream(results)).To(BeTrue())
+	})
+
+	It("returns false when every WAL was restored", func() {
+		results := []barmanRestorer.Result{
+			{Err: nil},
+			{Err: nil},
+		}
+		Expect(isEndOfWALStream(results)).To(BeFalse())
+	})
+
+	It("returns false when a restore failed with an error other than not-found", func() {
+		results := []barmanRestorer.Result{
+			{Err: errors.New("connection reset by peer")},
+		}
+		Expect(isEndOfWALStream(results)).To(BeFalse())
 	})
 })
 

--- a/internal/cnpi/plugin/client/contracts.go
+++ b/internal/cnpi/plugin/client/contracts.go
@@ -23,6 +23,7 @@ import (
 	"context"
 
 	restore "github.com/cloudnative-pg/cnpg-i/pkg/restore/job"
+	"github.com/cloudnative-pg/cnpg-i/pkg/wal"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -154,12 +155,14 @@ type WalCapabilities interface {
 
 	// RestoreWAL calls the loaded plugins to archive a WAL file.
 	// This call returns a boolean indicating if the WAL was restored
-	// by a plugin and the occurred error.
+	// by a plugin and the occurred error. The mode tells the plugins
+	// the context the WAL file is being restored in.
 	RestoreWAL(
 		ctx context.Context,
 		cluster client.Object,
 		sourceWALName string,
 		destinationFileName string,
+		mode wal.WALRestoreRequest_Mode,
 	) (bool, error)
 }
 

--- a/internal/cnpi/plugin/client/wal.go
+++ b/internal/cnpi/plugin/client/wal.go
@@ -87,8 +87,9 @@ func (data *data) RestoreWAL(
 	cluster client.Object,
 	sourceWALName string,
 	destinationFileName string,
+	mode wal.WALRestoreRequest_Mode,
 ) (bool, error) {
-	b, err := data.innerRestoreWAL(ctx, cluster, sourceWALName, destinationFileName)
+	b, err := data.innerRestoreWAL(ctx, cluster, sourceWALName, destinationFileName, mode)
 	return b, wrapAsPluginErrorIfNeeded(err)
 }
 
@@ -97,6 +98,7 @@ func (data *data) innerRestoreWAL(
 	cluster client.Object,
 	sourceWALName string,
 	destinationFileName string,
+	mode wal.WALRestoreRequest_Mode,
 ) (bool, error) {
 	var errorCollector error
 
@@ -123,6 +125,7 @@ func (data *data) innerRestoreWAL(
 			ClusterDefinition:   serializedCluster,
 			SourceWalName:       sourceWALName,
 			DestinationFileName: destinationFileName,
+			Mode:                mode,
 		}
 
 		pluginLogger.Trace(
@@ -130,6 +133,7 @@ func (data *data) innerRestoreWAL(
 			"clusterDefinition", request.ClusterDefinition,
 			"sourceWALName", sourceWALName,
 			"destinationFileName", destinationFileName,
+			"mode", mode,
 		)
 		if _, err := plugin.WALClient().Restore(ctx, &request); err != nil {
 			pluginLogger.Trace("WAL restore via plugin failed, trying next one", "err", err)

--- a/pkg/management/postgres/configuration.go
+++ b/pkg/management/postgres/configuration.go
@@ -270,11 +270,36 @@ func UpdateReplicaConfiguration(pgData, primaryConnInfo, slotName string) (chang
 // empty.
 // Returns a boolean indicating if any changes were done and any errors encountered
 func configurePostgresOverrideConfFile(pgData, primaryConnInfo, slotName string) (changed bool, err error) {
+	restoreCommand := fmt.Sprintf(
+		"/controller/manager wal-restore --log-destination %s/%s.json %%f %%p",
+		postgres.LogPath, postgres.LogFileName)
+
+	return writePostgresOverrideConfFile(pgData, primaryConnInfo, slotName, restoreCommand)
+}
+
+// configurePostgresOverrideConfFileForRewind writes the content of override.conf file
+// to be used while running `pg_rewind --restore-target-wal`. The restore_command invokes
+// wal-restore in rewind mode, disabling WAL prefetching and the end-of-wal-stream flag
+// machinery: pg_rewind requests the segments it needs walking the WAL backward, and
+// aborts on the first failed restore instead of falling back to streaming replication.
+// This file is replaced with the standard replica configuration when the instance
+// is demoted, right after a successful rewind.
+// Returns a boolean indicating if any changes were done and any errors encountered
+func configurePostgresOverrideConfFileForRewind(pgData, primaryConnInfo string) (changed bool, err error) {
+	restoreCommand := fmt.Sprintf(
+		"/controller/manager wal-restore --log-destination %s/%s.json --rewind %%f %%p",
+		postgres.LogPath, postgres.LogFileName)
+
+	return writePostgresOverrideConfFile(pgData, primaryConnInfo, "", restoreCommand)
+}
+
+// writePostgresOverrideConfFile writes the content of override.conf file, using the
+// given restore_command and replication information.
+// Returns a boolean indicating if any changes were done and any errors encountered
+func writePostgresOverrideConfFile(pgData, primaryConnInfo, slotName, restoreCommand string) (changed bool, err error) {
 	targetFile := path.Join(pgData, constants.PostgresqlOverrideConfigurationFile)
 	options := map[string]string{
-		"restore_command": fmt.Sprintf(
-			"/controller/manager wal-restore --log-destination %s/%s.json %%f %%p",
-			postgres.LogPath, postgres.LogFileName),
+		"restore_command":          restoreCommand,
 		"recovery_target_timeline": "latest",
 		"primary_conninfo":         primaryConnInfo,
 	}

--- a/pkg/management/postgres/configuration_test.go
+++ b/pkg/management/postgres/configuration_test.go
@@ -21,10 +21,12 @@ package postgres
 
 import (
 	"fmt"
+	"path/filepath"
 	"strings"
 	"time"
 
 	"github.com/cloudnative-pg/cnpg-i/pkg/postgres"
+	"github.com/cloudnative-pg/machinery/pkg/fileutils"
 	"github.com/cloudnative-pg/machinery/pkg/image/reference"
 	"github.com/cloudnative-pg/machinery/pkg/postgres/version"
 	corev1 "k8s.io/api/core/v1"
@@ -33,6 +35,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres/constants"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/versions"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -335,5 +338,62 @@ var _ = Describe("selectAdditionalExtensions", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(exts).To(BeNil())
 		Expect(baseDir).To(Equal("/extensions"))
+	})
+})
+
+var _ = Describe("the override.conf file writers", func() {
+	var pgData string
+	const primaryConnInfo = "host=cluster-example-rw user=streaming_replica"
+
+	readOverrideConf := func() string {
+		content, err := fileutils.ReadFile(filepath.Join(pgData, constants.PostgresqlOverrideConfigurationFile))
+		Expect(err).ToNot(HaveOccurred())
+		return string(content)
+	}
+
+	BeforeEach(func() {
+		pgData = GinkgoT().TempDir()
+	})
+
+	It("writes the replica restore_command and the replication slot", func() {
+		changed, err := configurePostgresOverrideConfFile(pgData, primaryConnInfo, "_cnpg_test")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(changed).To(BeTrue())
+
+		content := readOverrideConf()
+		Expect(content).To(ContainSubstring("wal-restore"))
+		Expect(content).ToNot(ContainSubstring("--rewind"))
+		Expect(content).To(ContainSubstring("primary_slot_name = '_cnpg_test'"))
+		Expect(content).To(ContainSubstring(primaryConnInfo))
+	})
+
+	It("omits the replication slot when the slot name is empty", func() {
+		_, err := configurePostgresOverrideConfFile(pgData, primaryConnInfo, "")
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(readOverrideConf()).ToNot(ContainSubstring("primary_slot_name"))
+	})
+
+	It("writes a rewind-mode restore_command with no replication slot", func() {
+		changed, err := configurePostgresOverrideConfFileForRewind(pgData, primaryConnInfo)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(changed).To(BeTrue())
+
+		content := readOverrideConf()
+		Expect(content).To(ContainSubstring("--rewind %f %p"))
+		Expect(content).ToNot(ContainSubstring("primary_slot_name"))
+	})
+
+	It("removes the rewind-mode restore_command when demoting after a rewind", func() {
+		_, err := configurePostgresOverrideConfFileForRewind(pgData, primaryConnInfo)
+		Expect(err).ToNot(HaveOccurred())
+
+		changed, err := UpdateReplicaConfiguration(pgData, primaryConnInfo, "_cnpg_test")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(changed).To(BeTrue())
+
+		content := readOverrideConf()
+		Expect(content).ToNot(ContainSubstring("--rewind"))
+		Expect(content).To(ContainSubstring("primary_slot_name = '_cnpg_test'"))
 	})
 })

--- a/pkg/management/postgres/instance.go
+++ b/pkg/management/postgres/instance.go
@@ -1281,12 +1281,14 @@ func (instance *Instance) Rewind(ctx context.Context) error {
 		"pgdata", instance.PgData,
 		"options", options)
 
-	// pg_rewind writes nothing into the target data directory until it has
-	// collected every WAL segment it needs, so a run aborted by a failed WAL
-	// restoration can be safely retried from scratch, reusing the segments
-	// that were already fetched. Retrying here avoids handing a transient
-	// failure back to the reconciliation loop, whose exponential backoff
-	// would keep the instance down for much longer.
+	// pg_rewind does not start copying anything into the target data directory
+	// until it has collected every WAL segment it needs (its only writes before
+	// that point come from the ordinary crash recovery it runs on a target that
+	// was not shut down cleanly), so a run aborted by a failed WAL restoration
+	// can be safely retried from scratch, reusing the segments that were
+	// already fetched. Retrying here avoids handing a transient failure back
+	// to the reconciliation loop, whose exponential backoff would keep the
+	// instance down for much longer.
 	retryUntilContextCancelled := func(_ error) bool {
 		return ctx.Err() == nil
 	}

--- a/pkg/management/postgres/instance.go
+++ b/pkg/management/postgres/instance.go
@@ -1271,12 +1271,6 @@ func (instance *Instance) Rewind(ctx context.Context) error {
 
 	options = append(options, "--restore-target-wal")
 
-	// Make sure PostgreSQL control file is not empty
-	err := instance.managePgControlFileBackup()
-	if err != nil {
-		return err
-	}
-
 	contextLogger.Info("Starting up pg_rewind",
 		"pgdata", instance.PgData,
 		"options", options)
@@ -1293,8 +1287,15 @@ func (instance *Instance) Rewind(ctx context.Context) error {
 		return ctx.Err() == nil
 	}
 	attempt := 0
-	err = retry.OnError(pgRewindRetry, retryUntilContextCancelled, func() error {
+	err := retry.OnError(pgRewindRetry, retryUntilContextCancelled, func() error {
 		attempt++
+
+		// Runs on every attempt, not just the first: a failed pg_rewind is
+		// exactly what can leave this needing repair before the next one.
+		if err := instance.managePgControlFileBackup(); err != nil {
+			return err
+		}
+
 		pgRewindCmd := exec.Command(pgRewindName, options...) // #nosec
 		pgRewindCmd.Env = instance.buildPostgresEnv()
 		if err := execlog.RunStreaming(pgRewindCmd, pgRewindName); err != nil {

--- a/pkg/management/postgres/instance.go
+++ b/pkg/management/postgres/instance.go
@@ -1234,8 +1234,17 @@ func (instance *Instance) removePgControlFileBackup() error {
 	return nil
 }
 
-// Rewind uses pg_rewind to align this data directory with the contents of the primary node.
-// If postgres major version is >= 13, add "--restore-target-wal" option
+// pgRewindRetry is the retry configuration for transient pg_rewind failures,
+// such as a WAL segment whose restoration from the archive failed
+var pgRewindRetry = wait.Backoff{
+	Duration: 5 * time.Second,
+	Factor:   2,
+	Steps:    4,
+}
+
+// Rewind uses pg_rewind to align this data directory with the contents of the primary
+// node, using the "--restore-target-wal" option to fetch from the WAL archive any
+// segment that was already recycled locally
 func (instance *Instance) Rewind(ctx context.Context) error {
 	contextLogger := log.FromContext(ctx)
 
@@ -1272,11 +1281,26 @@ func (instance *Instance) Rewind(ctx context.Context) error {
 		"pgdata", instance.PgData,
 		"options", options)
 
-	pgRewindCmd := exec.Command(pgRewindName, options...) // #nosec
-	pgRewindCmd.Env = instance.buildPostgresEnv()
-	err = execlog.RunStreaming(pgRewindCmd, pgRewindName)
+	// pg_rewind writes nothing into the target data directory until it has
+	// collected every WAL segment it needs, so a run aborted by a failed WAL
+	// restoration can be safely retried from scratch, reusing the segments
+	// that were already fetched. Retrying here avoids handing a transient
+	// failure back to the reconciliation loop, whose exponential backoff
+	// would keep the instance down for much longer.
+	retryUntilContextCancelled := func(_ error) bool {
+		return ctx.Err() == nil
+	}
+	err = retry.OnError(pgRewindRetry, retryUntilContextCancelled, func() error {
+		pgRewindCmd := exec.Command(pgRewindName, options...) // #nosec
+		pgRewindCmd.Env = instance.buildPostgresEnv()
+		if err := execlog.RunStreaming(pgRewindCmd, pgRewindName); err != nil {
+			contextLogger.Error(err, "Failed to execute pg_rewind", "options", options)
+			return err
+		}
+
+		return nil
+	})
 	if err != nil {
-		contextLogger.Error(err, "Failed to execute pg_rewind", "options", options)
 		return fmt.Errorf("error executing pg_rewind: %w", err)
 	}
 

--- a/pkg/management/postgres/instance.go
+++ b/pkg/management/postgres/instance.go
@@ -1283,6 +1283,11 @@ func (instance *Instance) Rewind(ctx context.Context) error {
 	// already fetched. Retrying here avoids handing a transient failure back
 	// to the reconciliation loop, whose exponential backoff would keep the
 	// instance down for much longer.
+	//
+	// This retries every pg_rewind failure, not just a failed WAL restoration:
+	// pg_rewind doesn't expose a way to tell the two apart, so a permanent
+	// failure (e.g. a bad connection string) also gets retried here before
+	// surfacing, rather than failing immediately.
 	retryUntilContextCancelled := func(_ error) bool {
 		return ctx.Err() == nil
 	}

--- a/pkg/management/postgres/instance.go
+++ b/pkg/management/postgres/instance.go
@@ -1255,8 +1255,8 @@ func (instance *Instance) Rewind(ctx context.Context) error {
 		"--target-pgdata", instance.PgData,
 	)
 
-	// make sure restore_command is set in override.conf
-	if _, err := configurePostgresOverrideConfFile(instance.PgData, primaryConnInfo, ""); err != nil {
+	// make sure a rewind-mode restore_command is set in override.conf
+	if _, err := configurePostgresOverrideConfFileForRewind(instance.PgData, primaryConnInfo); err != nil {
 		return err
 	}
 

--- a/pkg/management/postgres/instance.go
+++ b/pkg/management/postgres/instance.go
@@ -1242,19 +1242,10 @@ var pgRewindRetry = wait.Backoff{
 	Steps:    4,
 }
 
-// pgRewindShouldRetry reports whether a failed pg_rewind attempt should be
-// retried. pg_rewind does not start copying anything into the target data
-// directory until it has collected every WAL segment it needs (its only
-// writes before that point come from the ordinary crash recovery it runs on
-// a target that was not shut down cleanly), so a run aborted by a failed WAL
-// restoration can be safely retried from scratch, reusing the segments that
-// were already fetched.
-//
-// This retries every pg_rewind failure, not just a failed WAL restoration:
-// pg_rewind doesn't expose a way to tell the two apart, so a permanent
-// failure (e.g. a bad connection string) also gets retried here before
-// surfacing, rather than failing immediately. The only thing that stops the
-// retries is the context being cancelled.
+// pgRewindShouldRetry retries every pg_rewind failure, not just a failed WAL
+// restoration: pg_rewind doesn't expose a way to tell the two apart, so a
+// permanent failure (e.g. a bad connection string) also gets retried before
+// surfacing. The only thing that stops the retries is context cancellation.
 func pgRewindShouldRetry(ctx context.Context, _ error) bool {
 	return ctx.Err() == nil
 }
@@ -1292,9 +1283,14 @@ func (instance *Instance) Rewind(ctx context.Context) error {
 		"pgdata", instance.PgData,
 		"options", options)
 
-	// Retrying here avoids handing a transient failure back to the
-	// reconciliation loop, whose exponential backoff would keep the instance
-	// down for much longer.
+	// pg_rewind does not start copying anything into the target data directory
+	// until it has collected every WAL segment it needs (its only writes before
+	// that point come from the ordinary crash recovery it runs on a target that
+	// was not shut down cleanly), so a run aborted by a failed WAL restoration
+	// can be safely retried from scratch, reusing the segments that were
+	// already fetched. Retrying here avoids handing a transient failure back
+	// to the reconciliation loop, whose exponential backoff would keep the
+	// instance down for much longer.
 	attempt := 0
 	err := retry.OnError(pgRewindRetry, func(err error) bool {
 		return pgRewindShouldRetry(ctx, err)

--- a/pkg/management/postgres/instance.go
+++ b/pkg/management/postgres/instance.go
@@ -1292,11 +1292,13 @@ func (instance *Instance) Rewind(ctx context.Context) error {
 	retryUntilContextCancelled := func(_ error) bool {
 		return ctx.Err() == nil
 	}
+	attempt := 0
 	err = retry.OnError(pgRewindRetry, retryUntilContextCancelled, func() error {
+		attempt++
 		pgRewindCmd := exec.Command(pgRewindName, options...) // #nosec
 		pgRewindCmd.Env = instance.buildPostgresEnv()
 		if err := execlog.RunStreaming(pgRewindCmd, pgRewindName); err != nil {
-			contextLogger.Error(err, "Failed to execute pg_rewind", "options", options)
+			contextLogger.Error(err, "Failed to execute pg_rewind", "attempt", attempt, "options", options)
 			return err
 		}
 

--- a/pkg/management/postgres/instance.go
+++ b/pkg/management/postgres/instance.go
@@ -1283,14 +1283,16 @@ func (instance *Instance) Rewind(ctx context.Context) error {
 		"pgdata", instance.PgData,
 		"options", options)
 
-	// pg_rewind does not start copying anything into the target data directory
-	// until it has collected every WAL segment it needs (its only writes before
-	// that point come from the ordinary crash recovery it runs on a target that
-	// was not shut down cleanly), so a run aborted by a failed WAL restoration
-	// can be safely retried from scratch, reusing the segments that were
-	// already fetched. Retrying here avoids handing a transient failure back
-	// to the reconciliation loop, whose exponential backoff would keep the
-	// instance down for much longer.
+	// pg_rewind is a single-pass tool: it invokes restore_command itself to fetch
+	// the WAL it needs, but if one of those calls fails it aborts instead of
+	// retrying, even for transient errors. It does not start copying anything
+	// into the target data directory until it has collected every WAL segment
+	// it needs (its only writes before that point come from the ordinary crash
+	// recovery it runs on a target that was not shut down cleanly), so a run
+	// aborted by a failed WAL restoration can be safely retried from scratch
+	// here, reusing the segments that were already fetched. Retrying here
+	// avoids handing a transient failure back to the reconciliation loop, whose
+	// exponential backoff would keep the instance down for much longer.
 	attempt := 0
 	err := retry.OnError(pgRewindRetry, func(err error) bool {
 		return pgRewindShouldRetry(ctx, err)

--- a/pkg/management/postgres/instance.go
+++ b/pkg/management/postgres/instance.go
@@ -1242,6 +1242,23 @@ var pgRewindRetry = wait.Backoff{
 	Steps:    4,
 }
 
+// pgRewindShouldRetry reports whether a failed pg_rewind attempt should be
+// retried. pg_rewind does not start copying anything into the target data
+// directory until it has collected every WAL segment it needs (its only
+// writes before that point come from the ordinary crash recovery it runs on
+// a target that was not shut down cleanly), so a run aborted by a failed WAL
+// restoration can be safely retried from scratch, reusing the segments that
+// were already fetched.
+//
+// This retries every pg_rewind failure, not just a failed WAL restoration:
+// pg_rewind doesn't expose a way to tell the two apart, so a permanent
+// failure (e.g. a bad connection string) also gets retried here before
+// surfacing, rather than failing immediately. The only thing that stops the
+// retries is the context being cancelled.
+func pgRewindShouldRetry(ctx context.Context, _ error) bool {
+	return ctx.Err() == nil
+}
+
 // Rewind uses pg_rewind to align this data directory with the contents of the primary
 // node, using the "--restore-target-wal" option to fetch from the WAL archive any
 // segment that was already recycled locally
@@ -1275,24 +1292,13 @@ func (instance *Instance) Rewind(ctx context.Context) error {
 		"pgdata", instance.PgData,
 		"options", options)
 
-	// pg_rewind does not start copying anything into the target data directory
-	// until it has collected every WAL segment it needs (its only writes before
-	// that point come from the ordinary crash recovery it runs on a target that
-	// was not shut down cleanly), so a run aborted by a failed WAL restoration
-	// can be safely retried from scratch, reusing the segments that were
-	// already fetched. Retrying here avoids handing a transient failure back
-	// to the reconciliation loop, whose exponential backoff would keep the
-	// instance down for much longer.
-	//
-	// This retries every pg_rewind failure, not just a failed WAL restoration:
-	// pg_rewind doesn't expose a way to tell the two apart, so a permanent
-	// failure (e.g. a bad connection string) also gets retried here before
-	// surfacing, rather than failing immediately.
-	retryUntilContextCancelled := func(_ error) bool {
-		return ctx.Err() == nil
-	}
+	// Retrying here avoids handing a transient failure back to the
+	// reconciliation loop, whose exponential backoff would keep the instance
+	// down for much longer.
 	attempt := 0
-	err := retry.OnError(pgRewindRetry, retryUntilContextCancelled, func() error {
+	err := retry.OnError(pgRewindRetry, func(err error) bool {
+		return pgRewindShouldRetry(ctx, err)
+	}, func() error {
 		attempt++
 
 		// Runs on every attempt, not just the first: a failed pg_rewind is

--- a/pkg/management/postgres/instance_test.go
+++ b/pkg/management/postgres/instance_test.go
@@ -666,3 +666,19 @@ var _ = Describe("EnrichMetricsConnError", func() {
 		Expect(EnrichMetricsConnError(original)).To(Equal(original))
 	})
 })
+
+var _ = Describe("pgRewindShouldRetry", func() {
+	It("retries regardless of the error while the context is live", func() {
+		ctx := context.Background()
+		Expect(pgRewindShouldRetry(ctx, nil)).To(BeTrue())
+		Expect(pgRewindShouldRetry(ctx, errors.New("could not restore file from archive"))).To(BeTrue())
+		Expect(pgRewindShouldRetry(ctx, errors.New("connection refused"))).To(BeTrue())
+	})
+
+	It("stops retrying once the context is cancelled, regardless of the error", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		Expect(pgRewindShouldRetry(ctx, nil)).To(BeFalse())
+		Expect(pgRewindShouldRetry(ctx, errors.New("could not restore file from archive"))).To(BeFalse())
+	})
+})

--- a/tests/e2e/wal_restore_parallel_test.go
+++ b/tests/e2e/wal_restore_parallel_test.go
@@ -21,6 +21,7 @@ package e2e
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/manager/walrestore"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/specs"
@@ -390,11 +391,26 @@ var _ = Describe("Wal-restore in parallel", Label(tests.LabelBackupRestore), fun
 				ShouldNot(HaveOccurred())
 		})
 
+		// listSpoolContents returns the exact content of the spool directory,
+		// one file name per line. The TestFileExist/TestDirectoryEmpty helpers
+		// cannot express "the spool contains no WAL files": kubectl exec runs
+		// the command with no shell, so glob patterns are never expanded.
+		listSpoolContents := func() (string, error) {
+			stdout, _, err := exec.CommandInInstancePod(
+				env.Ctx, env.Client, env.Interface, env.RestClientConfig,
+				exec.PodLocator{
+					Namespace: namespace,
+					PodName:   standby,
+				}, nil,
+				"ls", "-A", SpoolDirectory)
+			return strings.TrimSpace(stdout), err
+		}
+
 		// Invoke the wal-restore command in rewind mode requesting the #7 file,
 		// with the end-of-wal-stream flag still set.
 		// Expected outcome:
-		//		exit code 0, #7 is in the output location, no files in the spool directory.
-		//		The flag is neither consumed nor unset.
+		//		exit code 0, #7 is in the output location, nothing is prefetched
+		//		into the spool directory, and the flag is neither consumed nor unset.
 		By("invoking the wal-restore command in rewind mode with a stale end-of-wal-stream flag", func() {
 			_, _, err := exec.CommandInInstancePod(
 				env.Ctx, env.Client, env.Interface, env.RestClientConfig,
@@ -409,17 +425,11 @@ var _ = Describe("Wal-restore in parallel", Label(tests.LabelBackupRestore), fun
 				WithTimeout(RetryTimeout).
 				Should(BeTrue(),
 					"#7 wal is in the output location")
-			Eventually(func() bool { return testUtils.TestFileExist(namespace, standby, SpoolDirectory, "00000001*") }).
+			Eventually(listSpoolContents).
 				WithTimeout(RetryTimeout).
-				Should(BeFalse(),
-					"no wals in the spool directory, rewind mode does not prefetch")
-			Eventually(func() bool {
-				return testUtils.TestFileExist(namespace, standby, SpoolDirectory,
-					"end-of-wal-stream")
-			}).
-				WithTimeout(RetryTimeout).
-				Should(BeTrue(),
-					"end-of-wal-stream flag is not consumed by the rewind mode")
+				Should(Equal("end-of-wal-stream"),
+					"the spool directory contains the untouched end-of-wal-stream flag "+
+						"and no prefetched wals")
 		})
 
 		// Invoke the wal-restore command through exec requesting the #8 file.
@@ -435,13 +445,10 @@ var _ = Describe("Wal-restore in parallel", Label(tests.LabelBackupRestore), fun
 				}, nil,
 				"/controller/manager", "wal-restore", walFile8, PgWalPath+"/"+walFile8)
 			Expect(err).To(HaveOccurred(), "exit code should be 1 since the flag is set")
-			Eventually(func() bool {
-				return testUtils.TestFileExist(namespace, standby, SpoolDirectory,
-					"end-of-wal-stream")
-			}).
+			Eventually(listSpoolContents).
 				WithTimeout(RetryTimeout).
-				Should(BeFalse(),
-					"end-of-wal-stream flag is unset")
+				Should(BeEmpty(),
+					"end-of-wal-stream flag is consumed and unset")
 		})
 
 		// Generate a new wal file; the archive also contains WAL #8.
@@ -470,10 +477,11 @@ var _ = Describe("Wal-restore in parallel", Label(tests.LabelBackupRestore), fun
 				WithTimeout(RetryTimeout).
 				Should(BeTrue(),
 					"#8 wal is in the output location")
-			Eventually(func() bool { return testUtils.TestDirectoryEmpty(namespace, standby, SpoolDirectory) }).
+			Eventually(listSpoolContents).
 				WithTimeout(RetryTimeout).
-				Should(BeTrue(),
-					"spool directory is empty, end-of-wal-stream flag is not set by the rewind mode")
+				Should(BeEmpty(),
+					"the spool directory is empty: no prefetched wals, and no "+
+						"end-of-wal-stream flag set by the rewind mode")
 		})
 	})
 })

--- a/tests/e2e/wal_restore_parallel_test.go
+++ b/tests/e2e/wal_restore_parallel_test.go
@@ -50,7 +50,8 @@ var _ = Describe("Wal-restore in parallel", Label(tests.LabelBackupRestore), fun
 	)
 
 	var namespace string
-	var primary, standby, latestWAL, walFile1, walFile2, walFile3, walFile4, walFile5, walFile6 string
+	var primary, standby, latestWAL string
+	var walFile1, walFile2, walFile3, walFile4, walFile5, walFile6, walFile7, walFile8 string
 
 	BeforeEach(func() {
 		if testLevelEnv.Depth < int(level) {
@@ -378,6 +379,101 @@ var _ = Describe("Wal-restore in parallel", Label(tests.LabelBackupRestore), fun
 				WithTimeout(RetryTimeout).
 				Should(BeTrue(),
 					"end-of-wal-stream flag is set for #7 and #8 wal is not present")
+		})
+
+		// Generate a new wal file; the archive also contains WAL #7.
+		By("forging a new wal file, the #7 wal", func() {
+			walFile7 = "0000000100000000000000F7"
+			Expect(testUtils.ForgeArchiveWalOnObjectStore(
+				objectStoreEnv.Namespace, clusterName, objectStoreEnv.ClientPodRef(), latestWAL,
+				walFile7)).
+				ShouldNot(HaveOccurred())
+		})
+
+		// Invoke the wal-restore command in rewind mode requesting the #7 file,
+		// with the end-of-wal-stream flag still set.
+		// Expected outcome:
+		//		exit code 0, #7 is in the output location, no files in the spool directory.
+		//		The flag is neither consumed nor unset.
+		By("invoking the wal-restore command in rewind mode with a stale end-of-wal-stream flag", func() {
+			_, _, err := exec.CommandInInstancePod(
+				env.Ctx, env.Client, env.Interface, env.RestClientConfig,
+				exec.PodLocator{
+					Namespace: namespace,
+					PodName:   standby,
+				}, nil,
+				"/controller/manager", "wal-restore", "--rewind", walFile7, PgWalPath+"/"+walFile7)
+			Expect(err).ToNot(HaveOccurred(),
+				"exit code should be 0: in rewind mode a stale flag must not abort the restore")
+			Eventually(func() bool { return testUtils.TestFileExist(namespace, standby, PgWalPath, walFile7) }).
+				WithTimeout(RetryTimeout).
+				Should(BeTrue(),
+					"#7 wal is in the output location")
+			Eventually(func() bool { return testUtils.TestFileExist(namespace, standby, SpoolDirectory, "00000001*") }).
+				WithTimeout(RetryTimeout).
+				Should(BeFalse(),
+					"no wals in the spool directory, rewind mode does not prefetch")
+			Eventually(func() bool {
+				return testUtils.TestFileExist(namespace, standby, SpoolDirectory,
+					"end-of-wal-stream")
+			}).
+				WithTimeout(RetryTimeout).
+				Should(BeTrue(),
+					"end-of-wal-stream flag is not consumed by the rewind mode")
+		})
+
+		// Invoke the wal-restore command through exec requesting the #8 file.
+		// Expected outcome:
+		//		exit code 1, the flag is consumed and unset.
+		By("consuming the end-of-wal-stream flag with a regular invocation", func() {
+			walFile8 = "0000000100000000000000F8"
+			_, _, err := exec.CommandInInstancePod(
+				env.Ctx, env.Client, env.Interface, env.RestClientConfig,
+				exec.PodLocator{
+					Namespace: namespace,
+					PodName:   standby,
+				}, nil,
+				"/controller/manager", "wal-restore", walFile8, PgWalPath+"/"+walFile8)
+			Expect(err).To(HaveOccurred(), "exit code should be 1 since the flag is set")
+			Eventually(func() bool {
+				return testUtils.TestFileExist(namespace, standby, SpoolDirectory,
+					"end-of-wal-stream")
+			}).
+				WithTimeout(RetryTimeout).
+				Should(BeFalse(),
+					"end-of-wal-stream flag is unset")
+		})
+
+		// Generate a new wal file; the archive also contains WAL #8.
+		By("forging a new wal file, the #8 wal", func() {
+			Expect(testUtils.ForgeArchiveWalOnObjectStore(
+				objectStoreEnv.Namespace, clusterName, objectStoreEnv.ClientPodRef(), latestWAL,
+				walFile8)).
+				ShouldNot(HaveOccurred())
+		})
+
+		// Invoke the wal-restore command in rewind mode requesting the #8 file,
+		// while #9 and #10 are not in the archive.
+		// Expected outcome:
+		//		exit code 0, #8 is in the output location, no files in the spool directory.
+		//		The flag is not set, while a regular invocation would have set it.
+		By("invoking the wal-restore command in rewind mode does not set the flag", func() {
+			_, _, err := exec.CommandInInstancePod(
+				env.Ctx, env.Client, env.Interface, env.RestClientConfig,
+				exec.PodLocator{
+					Namespace: namespace,
+					PodName:   standby,
+				}, nil,
+				"/controller/manager", "wal-restore", "--rewind", walFile8, PgWalPath+"/"+walFile8)
+			Expect(err).ToNot(HaveOccurred(), "exit code should be 0")
+			Eventually(func() bool { return testUtils.TestFileExist(namespace, standby, PgWalPath, walFile8) }).
+				WithTimeout(RetryTimeout).
+				Should(BeTrue(),
+					"#8 wal is in the output location")
+			Eventually(func() bool { return testUtils.TestDirectoryEmpty(namespace, standby, SpoolDirectory) }).
+				WithTimeout(RetryTimeout).
+				Should(BeTrue(),
+					"spool directory is empty, end-of-wal-stream flag is not set by the rewind mode")
 		})
 	})
 })

--- a/tests/e2e/wal_restore_parallel_test.go
+++ b/tests/e2e/wal_restore_parallel_test.go
@@ -432,7 +432,9 @@ var _ = Describe("Wal-restore in parallel", Label(tests.LabelBackupRestore), fun
 						"and no prefetched wals")
 		})
 
-		// Invoke the wal-restore command through exec requesting the #8 file.
+		// Reset state for the next scenario: this plain (non-rewind) invocation
+		// clears the stale flag from the step above. It does not fetch
+		// walFile8 itself; #8 is forged onto the archive and restored below.
 		// Expected outcome:
 		//		exit code 1, the flag is consumed and unset.
 		By("consuming the end-of-wal-stream flag with a regular invocation", func() {


### PR DESCRIPTION
When a demoted primary rejoins the cluster after a failover, the instance manager runs `pg_rewind --restore-target-wal` so the WAL segments no longer in its `pg_wal` can be fetched from the archive. The `restore_command` handed to pg_rewind was the same `manager wal-restore` invocation used during normal recovery, WAL prefetching included. pg_rewind walks the timeline backwards, fetches every file it needs exactly once, and treats any restore failure as fatal: with `wal.maxParallel > 1` a prefetch miss is practically guaranteed, the miss records the end-of-wal-stream flag on disk, and the next invocation consumes the flag and fails without even contacting the object store, aborting the whole rewind. A flag left over from the pod's previous life aborts even the first invocation. To make things worse, a failed pg_rewind was only retried by restarting the whole join under the reconcile exponential backoff, which grows to roughly 1000 seconds, so a transient restore failure could stall the rejoin for hours.

`manager wal-restore` now has a `--rewind` flag that disables prefetching and the end-of-wal-stream flag machinery. The instance manager writes a rewind-specific `restore_command` into `override.conf` right before running pg_rewind, and the demotion path rewrites the standard configuration immediately after, so the flag never leaks into normal recovery. pg_rewind itself is now retried in-process with a bounded backoff before the error surfaces, which is safe because pg_rewind collects every WAL segment it needs before writing anything into the target data directory: a failed run leaves the target unchanged.

The same context is conveyed to WAL restore plugins through the new `mode` field of `WALRestoreRequest` (cloudnative-pg/cnpg-i#351), and plugin-barman-cloud honors it in cloudnative-pg/plugin-barman-cloud#1007. Plugins that ignore the field keep their current behavior, helped by the in-process retry advancing one segment per attempt. The cnpg-i dependency points to a pseudo-version of that pull request and will move to the next tagged release once it is available.

Related to #10419, which shares the flag machinery but is a distinct failure mode and is not closed here.

Closes #11200
