### PR TITLE
fix(metrics): handle NULL stats_reset in pg_stat_wal

### DIFF
--- a/pkg/management/postgres/probes.go
+++ b/pkg/management/postgres/probes.go
@@ -619,7 +619,7 @@ func (instance *Instance) TryGetPgStatWAL() (*PgStatWal, error) {
 			wal_sync,
 			wal_write_time,
 			wal_sync_time,
-			stats_reset
+			COALESCE(stats_reset, '-infinity')
 			FROM pg_catalog.pg_stat_wal`)
 		if err := row.Scan(
 			&pgWalStat.WalRecords,
@@ -643,7 +643,7 @@ func (instance *Instance) TryGetPgStatWAL() (*PgStatWal, error) {
 		wal_fpi,
 		wal_bytes,
 		wal_buffers_full,
-		stats_reset
+		COALESCE(stats_reset, '-infinity')
 	    FROM pg_catalog.pg_stat_wal`)
 		if err := row.Scan(
 			&pgWalStat.WalRecords,

--- a/pkg/management/postgres/probes_test.go
+++ b/pkg/management/postgres/probes_test.go
@@ -156,6 +156,81 @@ var _ = Describe("updateResultForDecrease", func() {
 })
 
 var _ = Describe("probes", func() {
+	Context("pg_stat_wal", func() {
+		// A never-reset instance (or PostgreSQL 18+, where stats_reset starts as
+		// NULL) is coalesced to '-infinity' in the query, so the value always
+		// scans into the plain string field instead of failing on a NULL.
+		It("scans the coalesced stats_reset before PostgreSQL 18", func() {
+			db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+			Expect(err).ToNot(HaveOccurred())
+			DeferCleanup(func() {
+				_ = db.Close()
+			})
+
+			const query = "SELECT pg_stat_wal"
+			rows := sqlmock.NewRows([]string{
+				"wal_records",
+				"wal_fpi",
+				"wal_bytes",
+				"wal_buffers_full",
+				"wal_write",
+				"wal_sync",
+				"wal_write_time",
+				"wal_sync_time",
+				"stats_reset",
+			}).AddRow(int64(1), int64(2), int64(3), int64(4), int64(5), int64(6), 7.5, 8.5, "-infinity")
+
+			mock.ExpectQuery(query).WillReturnRows(rows)
+
+			var walStat PgStatWal
+			err = db.QueryRow(query).Scan(
+				&walStat.WalRecords,
+				&walStat.WalFpi,
+				&walStat.WalBytes,
+				&walStat.WALBuffersFull,
+				&walStat.WalWrite,
+				&walStat.WalSync,
+				&walStat.WalWriteTime,
+				&walStat.WalSyncTime,
+				&walStat.StatsReset,
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(walStat.StatsReset).To(Equal("-infinity"))
+			Expect(mock.ExpectationsWereMet()).To(Succeed())
+		})
+
+		It("scans the coalesced stats_reset from PostgreSQL 18", func() {
+			db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+			Expect(err).ToNot(HaveOccurred())
+			DeferCleanup(func() {
+				_ = db.Close()
+			})
+
+			rows := sqlmock.NewRows([]string{
+				"wal_records",
+				"wal_fpi",
+				"wal_bytes",
+				"wal_buffers_full",
+				"stats_reset",
+			}).AddRow(int64(1), int64(2), int64(3), int64(4), "-infinity")
+
+			const query = "SELECT pg_stat_wal"
+			mock.ExpectQuery(query).WillReturnRows(rows)
+
+			var walStat PgStatWal
+			err = db.QueryRow(query).Scan(
+				&walStat.WalRecords,
+				&walStat.WalFpi,
+				&walStat.WalBytes,
+				&walStat.WALBuffersFull,
+				&walStat.StatsReset,
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(walStat.StatsReset).To(Equal("-infinity"))
+			Expect(mock.ExpectationsWereMet()).To(Succeed())
+		})
+	})
+
 	It("fillWalStatus should properly handle errors", func() {
 		instance := &Instance{}
 		status := &postgres.PostgresqlStatus{

--- a/pkg/management/postgres/probes_test.go
+++ b/pkg/management/postgres/probes_test.go
@@ -160,75 +160,69 @@ var _ = Describe("probes", func() {
 		// A never-reset instance (or PostgreSQL 18+, where stats_reset starts as
 		// NULL) is coalesced to '-infinity' in the query, so the value always
 		// scans into the plain string field instead of failing on a NULL.
-		It("scans the coalesced stats_reset before PostgreSQL 18", func() {
-			db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
-			Expect(err).ToNot(HaveOccurred())
-			DeferCleanup(func() {
-				_ = db.Close()
-			})
+		DescribeTable("scans the coalesced stats_reset",
+			func(isPG18OrNewer bool) {
+				db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+				Expect(err).ToNot(HaveOccurred())
+				DeferCleanup(func() {
+					_ = db.Close()
+				})
 
-			const query = "SELECT pg_stat_wal"
-			rows := sqlmock.NewRows([]string{
-				"wal_records",
-				"wal_fpi",
-				"wal_bytes",
-				"wal_buffers_full",
-				"wal_write",
-				"wal_sync",
-				"wal_write_time",
-				"wal_sync_time",
-				"stats_reset",
-			}).AddRow(int64(1), int64(2), int64(3), int64(4), int64(5), int64(6), 7.5, 8.5, "-infinity")
+				const query = "SELECT pg_stat_wal"
+				var walStat PgStatWal
+				var rows *sqlmock.Rows
+				var scanArgs []any
 
-			mock.ExpectQuery(query).WillReturnRows(rows)
+				if isPG18OrNewer {
+					rows = sqlmock.NewRows([]string{
+						"wal_records",
+						"wal_fpi",
+						"wal_bytes",
+						"wal_buffers_full",
+						"stats_reset",
+					}).AddRow(int64(1), int64(2), int64(3), int64(4), "-infinity")
+					scanArgs = []any{
+						&walStat.WalRecords,
+						&walStat.WalFpi,
+						&walStat.WalBytes,
+						&walStat.WALBuffersFull,
+						&walStat.StatsReset,
+					}
+				} else {
+					rows = sqlmock.NewRows([]string{
+						"wal_records",
+						"wal_fpi",
+						"wal_bytes",
+						"wal_buffers_full",
+						"wal_write",
+						"wal_sync",
+						"wal_write_time",
+						"wal_sync_time",
+						"stats_reset",
+					}).AddRow(int64(1), int64(2), int64(3), int64(4), int64(5), int64(6), 7.5, 8.5, "-infinity")
+					scanArgs = []any{
+						&walStat.WalRecords,
+						&walStat.WalFpi,
+						&walStat.WalBytes,
+						&walStat.WALBuffersFull,
+						&walStat.WalWrite,
+						&walStat.WalSync,
+						&walStat.WalWriteTime,
+						&walStat.WalSyncTime,
+						&walStat.StatsReset,
+					}
+				}
 
-			var walStat PgStatWal
-			err = db.QueryRow(query).Scan(
-				&walStat.WalRecords,
-				&walStat.WalFpi,
-				&walStat.WalBytes,
-				&walStat.WALBuffersFull,
-				&walStat.WalWrite,
-				&walStat.WalSync,
-				&walStat.WalWriteTime,
-				&walStat.WalSyncTime,
-				&walStat.StatsReset,
-			)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(walStat.StatsReset).To(Equal("-infinity"))
-			Expect(mock.ExpectationsWereMet()).To(Succeed())
-		})
+				mock.ExpectQuery(query).WillReturnRows(rows)
 
-		It("scans the coalesced stats_reset from PostgreSQL 18", func() {
-			db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
-			Expect(err).ToNot(HaveOccurred())
-			DeferCleanup(func() {
-				_ = db.Close()
-			})
-
-			rows := sqlmock.NewRows([]string{
-				"wal_records",
-				"wal_fpi",
-				"wal_bytes",
-				"wal_buffers_full",
-				"stats_reset",
-			}).AddRow(int64(1), int64(2), int64(3), int64(4), "-infinity")
-
-			const query = "SELECT pg_stat_wal"
-			mock.ExpectQuery(query).WillReturnRows(rows)
-
-			var walStat PgStatWal
-			err = db.QueryRow(query).Scan(
-				&walStat.WalRecords,
-				&walStat.WalFpi,
-				&walStat.WalBytes,
-				&walStat.WALBuffersFull,
-				&walStat.StatsReset,
-			)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(walStat.StatsReset).To(Equal("-infinity"))
-			Expect(mock.ExpectationsWereMet()).To(Succeed())
-		})
+				err = db.QueryRow(query).Scan(scanArgs...)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(walStat.StatsReset).To(Equal("-infinity"))
+				Expect(mock.ExpectationsWereMet()).To(Succeed())
+			},
+			Entry("before PostgreSQL 18", false),
+			Entry("from PostgreSQL 18", true),
+		)
 	})
 
 	It("fillWalStatus should properly handle errors", func() {


### PR DESCRIPTION
Since PostgreSQL 18, pg_stat_wal.stats_reset can be NULL. The metrics exporter scanned it into a non-nullable Go string, so metric collection failed with "converting NULL to string is unsupported", breaking Prometheus scrapes on otherwise-healthy clusters.

Coalesce stats_reset to '-infinity' in both pg_stat_wal queries in TryGetPgStatWAL, matching how fillArchiverStatus already handles the nullable last_archived_time and last_failed_time columns in this same file. Keeping the column as timestamptz rather than casting to ::text leaves the metric label format unchanged for non-NULL values.

Closes #9106

----

## Summary

Since PostgreSQL 18, `pg_stat_wal.stats_reset` can be `NULL`. The metrics
exporter scanned it into a non-nullable Go `string`, so metric collection
failed with:

```
sql: Scan error on column index 4, name "stats_reset": converting NULL to string is unsupported
```

This broke Prometheus scrapes on otherwise-healthy clusters running PostgreSQL 18.

## Fix

Coalesce `stats_reset` to `'-infinity'` in both `pg_stat_wal` queries in
`TryGetPgStatWAL`. This matches how `fillArchiverStatus` already handles the
nullable `last_archived_time` / `last_failed_time` columns in this same file
(`COALESCE(col, '-infinity')` into a plain string), so `TryGetPgStatWAL` is no
longer the odd one out scanning a nullable timestamptz directly.

Keeping the column as a `timestamptz` (rather than casting to `::text`) leaves
the metric label format unchanged for non-`NULL` values and is consistent with
the sibling archiver fields.

Thanks to @mnencia for pointing to the existing pattern.

## Testing

- Unit tests cover the coalesced `stats_reset` value scanning into the string
  field for both the pre-18 and 18+ query shapes.
- `go build`, `go vet`, and `go test` pass for `pkg/management/postgres` and
  `pkg/management/postgres/webserver/metricserver`.