### PR TITLE
fix(webhook): reject extension paths that escape via absolute traversal

### DIFF
--- a/internal/webhook/v1/cluster_webhook.go
+++ b/internal/webhook/v1/cluster_webhook.go
@@ -2964,8 +2964,6 @@ func (v *ClusterCustomValidator) validateExtensions(r *apiv1.Cluster) field.Erro
 		var result field.ErrorList
 		pathSet := stringset.New()
 
-		const extensionPathBasePlaceholder = "/mount"
-
 		for j, path := range paths {
 			if validateErr := ensureNotEmptyOrDuplicate(
 				fieldPath.Index(j),
@@ -2976,14 +2974,15 @@ func (v *ClusterCustomValidator) validateExtensions(r *apiv1.Cluster) field.Erro
 				continue
 			}
 
-			// Join the path under a placeholder mount point, mirroring what the
-			// instance manager does at runtime, and verify the result stays
-			// within it. This catches embedded traversal such as
-			// "/a/../../etc". The separator boundary is required
-			// to reject paths like "/mount-evil".
-			resolvedPath := filepath.Join(extensionPathBasePlaceholder, path)
-			if resolvedPath != extensionPathBasePlaceholder &&
-				!strings.HasPrefix(resolvedPath, extensionPathBasePlaceholder+string(filepath.Separator)) {
+			// filepath.IsLocal reports whether the path, after joining it under
+			// "." and resolving "..", would stay within that base. Joining
+			// under "." first (rather than a placeholder mount point) makes
+			// this independent of the extension mount point's actual depth:
+			// CollectBinPaths and absolutizePaths join these paths under a
+			// real, multi-segment mount point at runtime, and a placeholder
+			// base shallower than that real path would wrongly accept some
+			// escaping paths (e.g. "../mount/lib").
+			if !filepath.IsLocal(filepath.Join(".", path)) {
 				result = append(result, field.Invalid(
 					fieldPath.Index(j),
 					path,

--- a/internal/webhook/v1/cluster_webhook.go
+++ b/internal/webhook/v1/cluster_webhook.go
@@ -2939,19 +2939,6 @@ func (v *ClusterCustomValidator) validateLivenessPingerProbe(r *apiv1.Cluster) f
 }
 
 func (v *ClusterCustomValidator) validateExtensions(r *apiv1.Cluster) field.ErrorList {
-	// extensionPathContainmentBase is a synthetic placeholder standing in for
-	// an extension's mount point, used only to check that a user-supplied
-	// path stays contained once joined the same way the instance manager
-	// joins it at runtime (see CollectBinPaths and absolutizePaths). The
-	// webhook validates the Cluster spec at admission time, before any Pod
-	// exists, so the real mount point isn't available yet, and it doesn't
-	// need to be: filepath.Join's ".." resolution is purely syntactic, so
-	// whether the result stays under the base depends only on the shape of
-	// the joined path, not on what the base actually is. Any fixed
-	// placeholder therefore gives the same containment answer the real mount
-	// point would.
-	const extensionPathContainmentBase = "/mount"
-
 	ensureNotEmptyOrDuplicate := func(path *field.Path, list *stringset.Data, value string) *field.Error {
 		if value == "" {
 			return field.Invalid(
@@ -2977,6 +2964,8 @@ func (v *ClusterCustomValidator) validateExtensions(r *apiv1.Cluster) field.Erro
 		var result field.ErrorList
 		pathSet := stringset.New()
 
+		const extensionPathBasePlaceholder = "/mount"
+
 		for j, path := range paths {
 			if validateErr := ensureNotEmptyOrDuplicate(
 				fieldPath.Index(j),
@@ -2987,21 +2976,14 @@ func (v *ClusterCustomValidator) validateExtensions(r *apiv1.Cluster) field.Erro
 				continue
 			}
 
-			// Resolve the path the same way CollectBinPaths and absolutizePaths
-			// join it under the extension's mount point at runtime, then check
-			// containment on the result. This also catches an absolute path with
-			// embedded traversal, such as "/a/../../../../etc": filepath.Join
-			// treats a leading separator as just another path segment, so that
-			// value resolves to "/etc" and escapes the mount point, even though
-			// checking the raw, unstripped path for a ".." prefix would miss it.
-			// The comparison requires a separator boundary (an exact match, or a
-			// prefix match followed by a separator) rather than a bare
-			// strings.HasPrefix, so that a sibling directory sharing the base as
-			// a string prefix (e.g. a path resolving to the containment base plus
-			// "-evil") is not wrongly accepted as contained.
-			resolvedPath := filepath.Join(extensionPathContainmentBase, path)
-			if resolvedPath != extensionPathContainmentBase &&
-				!strings.HasPrefix(resolvedPath, extensionPathContainmentBase+string(filepath.Separator)) {
+			// Join the path under a placeholder mount point, mirroring what the
+			// instance manager does at runtime, and verify the result stays
+			// within it. This catches embedded traversal such as
+			// "/a/../../etc". The separator boundary is required
+			// to reject paths like "/mount-evil".
+			resolvedPath := filepath.Join(extensionPathBasePlaceholder, path)
+			if resolvedPath != extensionPathBasePlaceholder &&
+				!strings.HasPrefix(resolvedPath, extensionPathBasePlaceholder+string(filepath.Separator)) {
 				result = append(result, field.Invalid(
 					fieldPath.Index(j),
 					path,

--- a/internal/webhook/v1/cluster_webhook.go
+++ b/internal/webhook/v1/cluster_webhook.go
@@ -61,6 +61,18 @@ const sharedBuffersParameter = "shared_buffers"
 // walLevelMinimal is the "minimal" wal level
 const walLevelMinimal = "minimal"
 
+// extensionPathContainmentBase is a synthetic placeholder standing in for an
+// extension's mount point, used only to check that a user-supplied path
+// stays contained once joined the same way the instance manager joins it at
+// runtime (see CollectBinPaths and absolutizePaths). The webhook validates
+// the Cluster spec at admission time, before any Pod exists, so the real
+// mount point isn't available yet, and it doesn't need to be: filepath.Join's
+// ".." resolution is purely syntactic, so whether the result stays under the
+// base depends only on the shape of the joined path, not on what the base
+// actually is. Any fixed placeholder therefore gives the same containment
+// answer the real mount point would.
+const extensionPathContainmentBase = "/mount"
+
 // clusterLog is for logging in this package.
 var clusterLog = log.WithName("cluster-resource").WithValues("version", "v1")
 
@@ -2974,7 +2986,21 @@ func (v *ClusterCustomValidator) validateExtensions(r *apiv1.Cluster) field.Erro
 				continue
 			}
 
-			if strings.HasPrefix(filepath.Clean(path), "..") {
+			// Resolve the path the same way CollectBinPaths and absolutizePaths
+			// join it under the extension's mount point at runtime, then check
+			// containment on the result. This also catches an absolute path with
+			// embedded traversal, such as "/a/../../../../etc": filepath.Join
+			// treats a leading separator as just another path segment, so that
+			// value resolves to "/etc" and escapes the mount point, even though
+			// checking the raw, unstripped path for a ".." prefix would miss it.
+			// The comparison requires a separator boundary (an exact match, or a
+			// prefix match followed by a separator) rather than a bare
+			// strings.HasPrefix, so that a sibling directory sharing the base as
+			// a string prefix (e.g. a path resolving to the containment base plus
+			// "-evil") is not wrongly accepted as contained.
+			resolvedPath := filepath.Join(extensionPathContainmentBase, path)
+			if resolvedPath != extensionPathContainmentBase &&
+				!strings.HasPrefix(resolvedPath, extensionPathContainmentBase+string(filepath.Separator)) {
 				result = append(result, field.Invalid(
 					fieldPath.Index(j),
 					path,

--- a/internal/webhook/v1/cluster_webhook.go
+++ b/internal/webhook/v1/cluster_webhook.go
@@ -61,18 +61,6 @@ const sharedBuffersParameter = "shared_buffers"
 // walLevelMinimal is the "minimal" wal level
 const walLevelMinimal = "minimal"
 
-// extensionPathContainmentBase is a synthetic placeholder standing in for an
-// extension's mount point, used only to check that a user-supplied path
-// stays contained once joined the same way the instance manager joins it at
-// runtime (see CollectBinPaths and absolutizePaths). The webhook validates
-// the Cluster spec at admission time, before any Pod exists, so the real
-// mount point isn't available yet, and it doesn't need to be: filepath.Join's
-// ".." resolution is purely syntactic, so whether the result stays under the
-// base depends only on the shape of the joined path, not on what the base
-// actually is. Any fixed placeholder therefore gives the same containment
-// answer the real mount point would.
-const extensionPathContainmentBase = "/mount"
-
 // clusterLog is for logging in this package.
 var clusterLog = log.WithName("cluster-resource").WithValues("version", "v1")
 
@@ -2951,6 +2939,19 @@ func (v *ClusterCustomValidator) validateLivenessPingerProbe(r *apiv1.Cluster) f
 }
 
 func (v *ClusterCustomValidator) validateExtensions(r *apiv1.Cluster) field.ErrorList {
+	// extensionPathContainmentBase is a synthetic placeholder standing in for
+	// an extension's mount point, used only to check that a user-supplied
+	// path stays contained once joined the same way the instance manager
+	// joins it at runtime (see CollectBinPaths and absolutizePaths). The
+	// webhook validates the Cluster spec at admission time, before any Pod
+	// exists, so the real mount point isn't available yet, and it doesn't
+	// need to be: filepath.Join's ".." resolution is purely syntactic, so
+	// whether the result stays under the base depends only on the shape of
+	// the joined path, not on what the base actually is. Any fixed
+	// placeholder therefore gives the same containment answer the real mount
+	// point would.
+	const extensionPathContainmentBase = "/mount"
+
 	ensureNotEmptyOrDuplicate := func(path *field.Path, list *stringset.Data, value string) *field.Error {
 		if value == "" {
 			return field.Invalid(

--- a/internal/webhook/v1/cluster_webhook_test.go
+++ b/internal/webhook/v1/cluster_webhook_test.go
@@ -6174,7 +6174,7 @@ var _ = Describe("validateExtensions", func() {
 		Expect(v.validateExtensions(cluster)).To(BeEmpty())
 	})
 
-	It("returns an error for a path resolving to a sibling directory sharing the mount point as a string prefix", func() {
+	It("returns an error for a relative path that escapes via leading traversal", func() {
 		cluster := &apiv1.Cluster{
 			Spec: apiv1.ClusterSpec{
 				PostgresConfiguration: apiv1.PostgresConfiguration{
@@ -6196,6 +6196,38 @@ var _ = Describe("validateExtensions", func() {
 		err := v.validateExtensions(cluster)
 		Expect(err).To(HaveLen(1))
 		Expect(err[0].Field).To(ContainSubstring("extension_control_path[0]"))
+	})
+
+	It("returns an error for a path that escapes only once joined under a deeper, realistic mount point", func() {
+		// CollectBinPaths and absolutizePaths join these paths under a
+		// multi-segment mount point at runtime (e.g. "/extensions/<name>"),
+		// not a single-segment one. A containment check resolved against a
+		// shallower placeholder base would wrongly accept these.
+		cluster := &apiv1.Cluster{
+			Spec: apiv1.ClusterSpec{
+				PostgresConfiguration: apiv1.PostgresConfiguration{
+					Extensions: []apiv1.ExtensionConfiguration{
+						{
+							Name: "extOne",
+							ImageVolumeSource: corev1.ImageVolumeSource{
+								Reference: "extOne",
+							},
+							ExtensionControlPath: []string{
+								"../mount/lib",
+							},
+							DynamicLibraryPath: []string{
+								"../../../mount/x",
+							},
+						},
+					},
+				},
+			},
+		}
+
+		err := v.validateExtensions(cluster)
+		Expect(err).To(HaveLen(2))
+		Expect(err[0].Field).To(ContainSubstring("extension_control_path[0]"))
+		Expect(err[1].Field).To(ContainSubstring("dynamic_library_path[0]"))
 	})
 
 	It("returns errors for duplicates in both LdLibraryPath and BinPath", func() {

--- a/internal/webhook/v1/cluster_webhook_test.go
+++ b/internal/webhook/v1/cluster_webhook_test.go
@@ -6181,6 +6181,35 @@ var _ = Describe("validateExtensions", func() {
 		Expect(v.validateExtensions(cluster)).To(BeEmpty())
 	})
 
+	It("returns an error for a path resolving to a sibling directory sharing the mount point as a string prefix", func() {
+		// "../../mount-evil" resolves to a directory named "mount-evil" next to
+		// the containment placeholder, e.g. "/mount-evil" alongside "/mount".
+		// That string shares "/mount" as a prefix, so a containment check using
+		// a bare strings.HasPrefix (without requiring a separator boundary)
+		// would wrongly accept it as contained.
+		cluster := &apiv1.Cluster{
+			Spec: apiv1.ClusterSpec{
+				PostgresConfiguration: apiv1.PostgresConfiguration{
+					Extensions: []apiv1.ExtensionConfiguration{
+						{
+							Name: "extOne",
+							ImageVolumeSource: corev1.ImageVolumeSource{
+								Reference: "extOne",
+							},
+							ExtensionControlPath: []string{
+								"../../mount-evil",
+							},
+						},
+					},
+				},
+			},
+		}
+
+		err := v.validateExtensions(cluster)
+		Expect(err).To(HaveLen(1))
+		Expect(err[0].Field).To(ContainSubstring("extension_control_path[0]"))
+	})
+
 	It("returns errors for duplicates in both LdLibraryPath and BinPath", func() {
 		cluster := &apiv1.Cluster{
 			Spec: apiv1.ClusterSpec{

--- a/internal/webhook/v1/cluster_webhook_test.go
+++ b/internal/webhook/v1/cluster_webhook_test.go
@@ -6125,6 +6125,62 @@ var _ = Describe("validateExtensions", func() {
 		Expect(err[3].Field).To(ContainSubstring("bin_path[0]"))
 	})
 
+	It("returns an error for an absolute path with embedded traversal", func() {
+		// "/a/../../../../etc" cleans to "/etc", which does not start with
+		// "..", so a check that only cleans the raw path would accept it.
+		// Both CollectBinPaths and absolutizePaths join this path under the
+		// extension's mount point with filepath.Join, which strips the
+		// leading separator and then resolves the embedded "..", so this
+		// value still escapes the mount point at runtime.
+		cluster := &apiv1.Cluster{
+			Spec: apiv1.ClusterSpec{
+				PostgresConfiguration: apiv1.PostgresConfiguration{
+					Extensions: []apiv1.ExtensionConfiguration{
+						{
+							Name: "extOne",
+							ImageVolumeSource: corev1.ImageVolumeSource{
+								Reference: "extOne",
+							},
+							ExtensionControlPath: []string{
+								"/a/../../../../etc",
+							},
+						},
+					},
+				},
+			},
+		}
+
+		err := v.validateExtensions(cluster)
+		Expect(err).To(HaveLen(1))
+		Expect(err[0].Field).To(ContainSubstring("extension_control_path[0]"))
+	})
+
+	It("returns no error for a path prefixed with a path separator that does not escape", func() {
+		// A leading "/" is intentionally accepted as equivalent to no leading
+		// separator (see the CollectBinPaths doc comment): filepath.Join
+		// treats "/opt/custom/lib" the same as "opt/custom/lib" when joining
+		// it under the extension's mount point, so it never escapes.
+		cluster := &apiv1.Cluster{
+			Spec: apiv1.ClusterSpec{
+				PostgresConfiguration: apiv1.PostgresConfiguration{
+					Extensions: []apiv1.ExtensionConfiguration{
+						{
+							Name: "extOne",
+							ImageVolumeSource: corev1.ImageVolumeSource{
+								Reference: "extOne",
+							},
+							ExtensionControlPath: []string{
+								"/opt/custom/share",
+							},
+						},
+					},
+				},
+			},
+		}
+
+		Expect(v.validateExtensions(cluster)).To(BeEmpty())
+	})
+
 	It("returns errors for duplicates in both LdLibraryPath and BinPath", func() {
 		cluster := &apiv1.Cluster{
 			Spec: apiv1.ClusterSpec{

--- a/internal/webhook/v1/cluster_webhook_test.go
+++ b/internal/webhook/v1/cluster_webhook_test.go
@@ -6160,6 +6160,10 @@ var _ = Describe("validateExtensions", func() {
 		// separator (see the CollectBinPaths doc comment): filepath.Join
 		// treats "/opt/custom/lib" the same as "opt/custom/lib" when joining
 		// it under the extension's mount point, so it never escapes.
+		// "a/b/../../share" is also valid for the same reason: the embedded
+		// ".." components resolve to "share" without ever climbing above the
+		// mount point, so a path is only rejected when it actually escapes,
+		// not merely because it contains "..".
 		cluster := &apiv1.Cluster{
 			Spec: apiv1.ClusterSpec{
 				PostgresConfiguration: apiv1.PostgresConfiguration{
@@ -6171,6 +6175,9 @@ var _ = Describe("validateExtensions", func() {
 							},
 							ExtensionControlPath: []string{
 								"/opt/custom/share",
+							},
+							DynamicLibraryPath: []string{
+								"a/b/../../share",
 							},
 						},
 					},

--- a/internal/webhook/v1/cluster_webhook_test.go
+++ b/internal/webhook/v1/cluster_webhook_test.go
@@ -6125,13 +6125,7 @@ var _ = Describe("validateExtensions", func() {
 		Expect(err[3].Field).To(ContainSubstring("bin_path[0]"))
 	})
 
-	It("returns an error for an absolute path with embedded traversal", func() {
-		// "/a/../../../../etc" cleans to "/etc", which does not start with
-		// "..", so a check that only cleans the raw path would accept it.
-		// Both CollectBinPaths and absolutizePaths join this path under the
-		// extension's mount point with filepath.Join, which strips the
-		// leading separator and then resolves the embedded "..", so this
-		// value still escapes the mount point at runtime.
+	It("returns an error for an absolute path with embedded traversal that escapes", func() {
 		cluster := &apiv1.Cluster{
 			Spec: apiv1.ClusterSpec{
 				PostgresConfiguration: apiv1.PostgresConfiguration{
@@ -6155,15 +6149,7 @@ var _ = Describe("validateExtensions", func() {
 		Expect(err[0].Field).To(ContainSubstring("extension_control_path[0]"))
 	})
 
-	It("returns no error for a path prefixed with a path separator that does not escape", func() {
-		// A leading "/" is intentionally accepted as equivalent to no leading
-		// separator (see the CollectBinPaths doc comment): filepath.Join
-		// treats "/opt/custom/lib" the same as "opt/custom/lib" when joining
-		// it under the extension's mount point, so it never escapes.
-		// "a/b/../../share" is also valid for the same reason: the embedded
-		// ".." components resolve to "share" without ever climbing above the
-		// mount point, so a path is only rejected when it actually escapes,
-		// not merely because it contains "..".
+	It("returns no error for a path traversal that does not escape", func() {
 		cluster := &apiv1.Cluster{
 			Spec: apiv1.ClusterSpec{
 				PostgresConfiguration: apiv1.PostgresConfiguration{
@@ -6189,11 +6175,6 @@ var _ = Describe("validateExtensions", func() {
 	})
 
 	It("returns an error for a path resolving to a sibling directory sharing the mount point as a string prefix", func() {
-		// "../../mount-evil" resolves to a directory named "mount-evil" next to
-		// the containment placeholder, e.g. "/mount-evil" alongside "/mount".
-		// That string shares "/mount" as a prefix, so a containment check using
-		// a bare strings.HasPrefix (without requiring a separator boundary)
-		// would wrongly accept it as contained.
 		cluster := &apiv1.Cluster{
 			Spec: apiv1.ClusterSpec{
 				PostgresConfiguration: apiv1.PostgresConfiguration{

--- a/pkg/postgres/configuration.go
+++ b/pkg/postgres/configuration.go
@@ -915,6 +915,15 @@ type AdditionalExtensionConfiguration struct {
 func (ext *AdditionalExtensionConfiguration) absolutizePaths(paths []string) iter.Seq[string] {
 	return func(yield func(string) bool) {
 		for _, path := range paths {
+			// The webhook rejects escaping paths at admission time; this is a
+			// second, independent check for callers that read the Cluster
+			// spec directly without going through admission (e.g. a Job).
+			if !filepath.IsLocal(filepath.Join(".", path)) {
+				log.Warning("Skipping extension path that escapes the extension directory",
+					"mountPath", ext.MountPath, "path", path)
+				continue
+			}
+
 			if !yield(filepath.Join(ext.MountPath, path)) {
 				break
 			}

--- a/pkg/postgres/configuration_test.go
+++ b/pkg/postgres/configuration_test.go
@@ -579,5 +579,28 @@ var _ = Describe("PostgreSQL Extensions", func() {
 			Expect(config.GetConfig(ExtensionControlPath)).To(BeEquivalentTo("$system:" + sharePaths))
 			Expect(config.GetConfig(DynamicLibraryPath)).To(BeEquivalentTo("$libdir:" + libPaths))
 		})
+
+		It("skips paths that escape the extension directory instead of including them", func() {
+			// The webhook already rejects these at admission time; this
+			// guards callers that read the Cluster spec directly, without
+			// going through admission.
+			info := ConfigurationInfo{
+				Settings:           CnpgConfigurationSettings,
+				MajorVersion:       18,
+				IncludingMandatory: true,
+				AdditionalExtensions: []AdditionalExtensionConfiguration{
+					{
+						MountPath:            ExtensionsBaseDirectory + "/postgis",
+						ExtensionControlPath: []string{"share", "../../etc"},
+						DynamicLibraryPath:   []string{"lib", "../mount/lib"},
+					},
+				},
+			}
+			config := CreatePostgresqlConfiguration(info)
+			Expect(config.GetConfig(ExtensionControlPath)).
+				To(BeEquivalentTo("$system:" + ExtensionsBaseDirectory + "/postgis/share"))
+			Expect(config.GetConfig(DynamicLibraryPath)).
+				To(BeEquivalentTo("$libdir:" + ExtensionsBaseDirectory + "/postgis/lib"))
+		})
 	})
 })

--- a/pkg/utils/extensions/extensions.go
+++ b/pkg/utils/extensions/extensions.go
@@ -152,6 +152,15 @@ func CollectLibraryPaths(extensionList []apiv1.ExtensionConfiguration, baseDir s
 
 	for _, extension := range extensionList {
 		for _, libraryPath := range extension.LdLibraryPath {
+			// The webhook rejects escaping paths at admission time; this is a
+			// second, independent check for callers that read the Cluster
+			// spec directly without going through admission (e.g. a Job).
+			if !filepath.IsLocal(filepath.Join(".", libraryPath)) {
+				log.Warning("Skipping extension LdLibraryPath entry that escapes the extension directory",
+					"extension", extension.Name, "path", libraryPath)
+				continue
+			}
+
 			result = append(
 				result,
 				filepath.Join(baseDir, extension.Name, libraryPath),
@@ -229,6 +238,15 @@ func CollectBinPaths(extensionList []apiv1.ExtensionConfiguration, baseDir strin
 
 	for _, extension := range extensionList {
 		for _, binPath := range extension.BinPath {
+			// The webhook rejects escaping paths at admission time; this is a
+			// second, independent check for callers that read the Cluster
+			// spec directly without going through admission (e.g. a Job).
+			if !filepath.IsLocal(filepath.Join(".", binPath)) {
+				log.Warning("Skipping extension BinPath entry that escapes the extension directory",
+					"extension", extension.Name, "path", binPath)
+				continue
+			}
+
 			result = append(
 				result,
 				filepath.Join(baseDir, extension.Name, binPath),

--- a/pkg/utils/extensions/extensions_test.go
+++ b/pkg/utils/extensions/extensions_test.go
@@ -597,4 +597,20 @@ var _ = Describe("CollectLibraryPaths and CollectBinPaths", func() {
 		Expect(CollectBinPaths(exts, postgres.UpgradeTargetExtensionsBaseDirectory)).
 			To(ConsistOf("/new-extensions/ext1/bin"))
 	})
+
+	It("skips entries that escape the extension directory instead of returning them", func() {
+		// The webhook already rejects these at admission time; this guards
+		// callers (e.g. the major-upgrade Job) that read the Cluster spec
+		// directly, without going through admission.
+		exts := []apiv1.ExtensionConfiguration{{
+			Name:          "ext1",
+			LdLibraryPath: []string{"lib", "../../etc"},
+			BinPath:       []string{"bin", "../mount/lib"},
+		}}
+
+		Expect(CollectLibraryPaths(exts, postgres.ExtensionsBaseDirectory)).
+			To(ConsistOf("/extensions/ext1/lib"))
+		Expect(CollectBinPaths(exts, postgres.ExtensionsBaseDirectory)).
+			To(ConsistOf("/extensions/ext1/bin"))
+	})
 })


### PR DESCRIPTION
`validateExtensions` accepted absolute paths with embedded traversal (e.g. "/a/../../../../etc") because it only checked the cleaned raw path for a ".." prefix. `CollectBinPaths` and `absolutizePaths` join these paths under the extension's mount point at runtime, and that join resolves the embedded ".." against the real mount point, so the accepted value still escaped it.

Resolve each path against "." with `filepath.Join`, then check the result with `filepath.IsLocal`. This is independent of the extension mount point's actual depth, since `IsLocal` guarantees containment against any base rather than requiring the check to mirror the real (multi-segment) mount point. Plain absolute-looking paths (e.g. /opt/custom/lib) keep working, since joining under "." first strips a leading separator the same way the runtime join does.

`CollectLibraryPaths`, `CollectBinPaths`, and `absolutizePaths` apply the same check directly, skipping any entry that fails it. This covers callers that read the Cluster spec without going through admission, such as the major-upgrade Job, and Clusters whose spec was already persisted before this fix.

This check is lexical, on the path string only; it doesn't cover symlinks inside the extension's own image content, which is a separate trust boundary tied to the image reference itself.

Closes #11208