### PR TITLE
fix: stop caching Helm release secrets in the operator

### DIFF
--- a/internal/cmd/manager/controller/controller.go
+++ b/internal/cmd/manager/controller/controller.go
@@ -32,6 +32,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/discovery"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -77,6 +78,10 @@ const (
 	// operatorClientCertCommonName is the fallback CN for the operator's in-memory
 	// client certificate when the Pod hostname cannot be determined.
 	operatorClientCertCommonName = "cloudnative-pg-operator"
+
+	// helmReleaseSecretType is the Secret type Helm uses to store release
+	// manifests (one revision per Secret).
+	helmReleaseSecretType corev1.SecretType = "helm.sh/release.v1"
 )
 
 // leaderElectionConfiguration contains the leader parameters that will be passed to controllerruntime.Options.
@@ -132,6 +137,19 @@ func RunController(
 		LeaderElectionReleaseOnCancel: true,
 	}
 
+	byObject := map[client.Object]cache.ByObject{
+		// Helm stores each release revision as a Secret containing the full
+		// (compressed, base64-encoded) manifest. These can be large, and
+		// CNPG has no use for them, but the default cache would otherwise
+		// list, watch, and store every one of them in every watched
+		// namespace. Excluding them at the informer level, rather than via
+		// a controller predicate, means they never get listed/watched/stored
+		// at all.
+		&corev1.Secret{}: {
+			Field: fields.OneTermNotEqualSelector("type", string(helmReleaseSecretType)),
+		},
+	}
+
 	// EndpointSlices are watched only to detect CNPG-i plugin rollouts, and
 	// plugins are deployed in the operator namespace. Restricting the informer
 	// to that namespace avoids listing and watching every EndpointSlice in the
@@ -144,18 +162,16 @@ func RunController(
 	// it. When the namespace is unknown (e.g. local development without
 	// OPERATOR_NAMESPACE set) we simply fall back to the default caching.
 	if conf.OperatorNamespace != "" {
-		managerOptions.Cache = cache.Options{
-			ByObject: map[client.Object]cache.ByObject{
-				&discoveryv1.EndpointSlice{}: {
-					Namespaces: map[string]cache.Config{
-						conf.OperatorNamespace: {},
-					},
-				},
+		byObject[&discoveryv1.EndpointSlice{}] = cache.ByObject{
+			Namespaces: map[string]cache.Config{
+				conf.OperatorNamespace: {},
 			},
 		}
 	} else {
 		setupLog.Info("Plugin EndpointSlice watch disabled: OPERATOR_NAMESPACE not set")
 	}
+
+	managerOptions.Cache = cache.Options{ByObject: byObject}
 
 	if conf.WatchNamespace != "" {
 		namespaces := conf.WatchedNamespaces()

--- a/internal/cmd/manager/controller/controller.go
+++ b/internal/cmd/manager/controller/controller.go
@@ -137,7 +137,7 @@ func RunController(
 		LeaderElectionReleaseOnCancel: true,
 	}
 
-	byObject := map[client.Object]cache.ByObject{
+	cacheFilters := map[client.Object]cache.ByObject{
 		// Helm stores each release revision as a Secret containing the full
 		// (compressed, base64-encoded) manifest. These can be large, and
 		// CNPG has no use for them, but the default cache would otherwise
@@ -163,7 +163,7 @@ func RunController(
 	// OPERATOR_NAMESPACE set) we simply fall back to the default (unrestricted)
 	// EndpointSlice caching.
 	if conf.OperatorNamespace != "" {
-		byObject[&discoveryv1.EndpointSlice{}] = cache.ByObject{
+		cacheFilters[&discoveryv1.EndpointSlice{}] = cache.ByObject{
 			Namespaces: map[string]cache.Config{
 				conf.OperatorNamespace: {},
 			},
@@ -172,7 +172,7 @@ func RunController(
 		setupLog.Info("Plugin EndpointSlice watch disabled: OPERATOR_NAMESPACE not set")
 	}
 
-	managerOptions.Cache = cache.Options{ByObject: byObject}
+	managerOptions.Cache = cache.Options{ByObject: cacheFilters}
 
 	if conf.WatchNamespace != "" {
 		namespaces := conf.WatchedNamespaces()

--- a/internal/cmd/manager/controller/controller.go
+++ b/internal/cmd/manager/controller/controller.go
@@ -160,7 +160,8 @@ func RunController(
 	// empty namespace key is interpreted by controller-runtime as "all
 	// namespaces", which would silently widen the cache instead of narrowing
 	// it. When the namespace is unknown (e.g. local development without
-	// OPERATOR_NAMESPACE set) we simply fall back to the default caching.
+	// OPERATOR_NAMESPACE set) we simply fall back to the default (unrestricted)
+	// EndpointSlice caching.
 	if conf.OperatorNamespace != "" {
 		byObject[&discoveryv1.EndpointSlice{}] = cache.ByObject{
 			Namespaces: map[string]cache.Config{


### PR DESCRIPTION
Clusters with large Helm releases installed alongside CloudNativePG were seeing the operator's memory usage spike and, in some cases, crashloop. The operator's controller-runtime cache was keeping a full copy of every Secret in the watched namespace(s), including the large Helm release manifests Helm stores as Secrets, even though the operator never reads them.

Helm release Secrets are now excluded from the cache, so they are no longer listed, watched, or held in memory. This covers the Helm release scenario specifically; the general case of large Secrets of other types filling the cache is not addressed here.

Refs #10924