### PR TITLE
test(e2e): stop losing transient-error retries to a conflict-only predicate

### DIFF
--- a/tests/e2e/backup_restore_objectstore_test.go
+++ b/tests/e2e/backup_restore_objectstore_test.go
@@ -739,7 +739,7 @@ var _ = Describe("Object storage - Backup and restore", Label(tests.LabelBackupR
 			})
 
 			By("scaling first cluster to 2 instances", func() {
-				err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+				err := retry.OnError(retry.DefaultBackoff, objects.IsRetryableConflictOrTransientError, func() error {
 					cluster, err := clusterutils.Get(env.Ctx, env.Client, namespace, firstClusterName)
 					if err != nil {
 						return err

--- a/tests/e2e/certificates_test.go
+++ b/tests/e2e/certificates_test.go
@@ -34,6 +34,7 @@ import (
 	clusterasserts "github.com/cloudnative-pg/cloudnative-pg/tests/internal/asserts/cluster"
 	secretsasserts "github.com/cloudnative-pg/cloudnative-pg/tests/internal/asserts/secrets"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/clusterutils"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/objects"
 	podutils "github.com/cloudnative-pg/cloudnative-pg/tests/utils/pods"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/run"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/yaml"
@@ -170,7 +171,7 @@ var _ = Describe("Certificates", func() {
 		)
 
 		cleanClusterCertification := func() {
-			err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+			err := retry.OnError(retry.DefaultBackoff, objects.IsRetryableConflictOrTransientError, func() error {
 				cluster, err := clusterutils.Get(env.Ctx, env.Client, namespace, clusterName)
 				Expect(err).ToNot(HaveOccurred())
 				cluster.Spec.Certificates.ServerTLSSecret = ""

--- a/tests/e2e/cluster_major_upgrade_test.go
+++ b/tests/e2e/cluster_major_upgrade_test.go
@@ -529,7 +529,7 @@ var _ = Describe("Postgres Major Upgrade", Ordered, ContinueOnFailure, Label(tes
 
 		cluster := scenario.startingCluster
 		clusterutils.AddTopologySpreadConstraint(cluster)
-		err := env.Client.Create(env.Ctx, cluster)
+		_, err := objects.Create(env.Ctx, env.Client, cluster)
 		Expect(err).NotTo(HaveOccurred())
 		clusterasserts.AssertClusterIsReady(env, cluster.Namespace, cluster.Name, testTimeouts[timeouts.ClusterIsReady])
 

--- a/tests/e2e/configuration_update_test.go
+++ b/tests/e2e/configuration_update_test.go
@@ -281,7 +281,7 @@ var _ = Describe("Configuration update", Label(tests.LabelClusterMetadata), func
 			cluster.Spec.ImageName = env.MinimalImageName(targetTag)
 			cluster.Spec.PrimaryUpdateMethod = apiv1.PrimaryUpdateMethodSwitchover
 			clusterutils.AddTopologySpreadConstraint(cluster)
-			err = env.Client.Create(env.Ctx, cluster)
+			_, err = objects.Create(env.Ctx, env.Client, cluster)
 			Expect(err).NotTo(HaveOccurred())
 			clusterasserts.AssertClusterIsReady(env, cluster.Namespace, cluster.Name, testTimeouts[timeouts.ClusterIsReady])
 		})
@@ -504,7 +504,7 @@ var _ = Describe("Configuration update", Label(tests.LabelClusterMetadata), func
 			cluster.Spec.ImageName = env.MinimalImageName(targetTag)
 			cluster.Spec.PrimaryUpdateMethod = apiv1.PrimaryUpdateMethodRestart
 			clusterutils.AddTopologySpreadConstraint(cluster)
-			err = env.Client.Create(env.Ctx, cluster)
+			_, err = objects.Create(env.Ctx, env.Client, cluster)
 			Expect(err).NotTo(HaveOccurred())
 			clusterasserts.AssertClusterIsReady(env, cluster.Namespace, cluster.Name, testTimeouts[timeouts.ClusterIsReady])
 		})

--- a/tests/e2e/configuration_update_test.go
+++ b/tests/e2e/configuration_update_test.go
@@ -76,7 +76,7 @@ var _ = Describe("Configuration update", Label(tests.LabelClusterMetadata), func
 	}
 	updateClusterPostgresParams := func(paramsMap map[string]string, namespace string) {
 		cluster := &apiv1.Cluster{}
-		err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		err := retry.OnError(retry.DefaultBackoff, objects.IsRetryableConflictOrTransientError, func() error {
 			var err error
 			cluster, err = clusterutils.Get(env.Ctx, env.Client, namespace, clusterName)
 			Expect(err).ToNot(HaveOccurred())
@@ -88,7 +88,7 @@ var _ = Describe("Configuration update", Label(tests.LabelClusterMetadata), func
 
 	updateClusterPostgresPgHBA := func(namespace string) {
 		cluster := &apiv1.Cluster{}
-		err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		err := retry.OnError(retry.DefaultBackoff, objects.IsRetryableConflictOrTransientError, func() error {
 			var err error
 			cluster, err = clusterutils.Get(env.Ctx, env.Client, namespace, clusterName)
 			Expect(err).ToNot(HaveOccurred())
@@ -100,7 +100,7 @@ var _ = Describe("Configuration update", Label(tests.LabelClusterMetadata), func
 
 	updateClusterPostgresPgIdent := func(namespace string) {
 		cluster := &apiv1.Cluster{}
-		err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		err := retry.OnError(retry.DefaultBackoff, objects.IsRetryableConflictOrTransientError, func() error {
 			var err error
 			cluster, err = clusterutils.Get(env.Ctx, env.Client, namespace, clusterName)
 			Expect(err).ToNot(HaveOccurred())
@@ -113,7 +113,7 @@ var _ = Describe("Configuration update", Label(tests.LabelClusterMetadata), func
 	checkErrorOutFixedAndBlockedConfigurationParameter := func(params map[string]string, namespace string) {
 		// Update the configuration
 		cluster := &apiv1.Cluster{}
-		err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		err := retry.OnError(retry.DefaultBackoff, objects.IsRetryableConflictOrTransientError, func() error {
 			var err error
 			cluster, err = clusterutils.Get(env.Ctx, env.Client, namespace, clusterName)
 			Expect(err).NotTo(HaveOccurred())
@@ -224,7 +224,7 @@ var _ = Describe("Configuration update", Label(tests.LabelClusterMetadata), func
 		}
 
 		cluster := &apiv1.Cluster{}
-		err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		err = retry.OnError(retry.DefaultBackoff, objects.IsRetryableConflictOrTransientError, func() error {
 			cluster, err = clusterutils.Get(env.Ctx, env.Client, namespace, clusterName)
 			Expect(err).NotTo(HaveOccurred())
 			cluster.Spec.ImageName = env.StandardImageName(targetTag)

--- a/tests/e2e/fastswitchover_test.go
+++ b/tests/e2e/fastswitchover_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/clusterutils"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/deployments"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/exec"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/objects"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/postgres"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/run"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/timeouts"
@@ -189,7 +190,7 @@ func assertFastSwitchover(namespace, sampleFile, clusterName, webTestFile, webTe
 
 	By("setting the TargetPrimary to node2 to trigger a switchover", func() {
 		targetPrimary = clusterName + "-2"
-		err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		err := retry.OnError(retry.DefaultBackoff, objects.IsRetryableConflictOrTransientError, func() error {
 			cluster, err := clusterutils.Get(env.Ctx, env.Client, namespace, clusterName)
 			Expect(err).ToNot(HaveOccurred())
 			cluster.Status.TargetPrimary = targetPrimary

--- a/tests/e2e/imagevolume_extensions_test.go
+++ b/tests/e2e/imagevolume_extensions_test.go
@@ -373,7 +373,7 @@ var _ = Describe("ImageVolume Extensions", Label(tests.LabelImageVolumeExtension
 			err := env.Client.Create(env.Ctx, catalog)
 			Expect(err).ToNot(HaveOccurred())
 			clusterutils.AddTopologySpreadConstraint(cluster)
-			err = env.Client.Create(env.Ctx, cluster)
+			_, err = objects.Create(env.Ctx, env.Client, cluster)
 			Expect(err).ToNot(HaveOccurred())
 			clusterasserts.AssertClusterIsReady(env, namespace, clusterName, testTimeouts[timeouts.ClusterIsReady])
 			resources.CreateResourceFromFile(env, namespace, databaseManifest)

--- a/tests/e2e/initdb_test.go
+++ b/tests/e2e/initdb_test.go
@@ -180,13 +180,14 @@ var _ = Describe("InitDB settings", Label(tests.LabelSmoke, tests.LabelBasic), f
 			// function has been invoked in the application database. The query
 			// is fully schema-qualified so it cannot itself trigger the shadow.
 			shadowCalls := func() string {
-				stdout, _, err := exec.QueryInInstancePod(
+				stdout, _, err := exec.EventuallyExecQueryInInstancePod(
 					env.Ctx, env.Client, env.Interface, env.RestClientConfig,
 					exec.PodLocator{
 						Namespace: namespace,
 						PodName:   primary.Name,
 					}, "app",
-					"SELECT pg_catalog.count(*)::text FROM public.shadow_calls")
+					"SELECT pg_catalog.count(*)::text FROM public.shadow_calls",
+					RetryTimeout, PollingTime)
 				Expect(err).ToNot(HaveOccurred())
 				return strings.TrimSpace(stdout)
 			}

--- a/tests/e2e/pg_wal_volume_test.go
+++ b/tests/e2e/pg_wal_volume_test.go
@@ -37,6 +37,7 @@ import (
 	storageasserts "github.com/cloudnative-pg/cloudnative-pg/tests/internal/asserts/storage"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/clusterutils"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/exec"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/objects"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/timeouts"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -101,7 +102,7 @@ var _ = Describe("Separate pg_wal volume", Label(tests.LabelStorage), func() {
 
 	// Inline function to patch walStorage in existing cluster
 	updateWalStorage := func(namespace, clusterName string) {
-		err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		err := retry.OnError(retry.DefaultBackoff, objects.IsRetryableConflictOrTransientError, func() error {
 			cluster, err := clusterutils.Get(env.Ctx, env.Client, namespace, clusterName)
 			Expect(err).NotTo(HaveOccurred())
 			WalStorageClass := os.Getenv("E2E_DEFAULT_STORAGE_CLASS")

--- a/tests/e2e/pgbouncer_test.go
+++ b/tests/e2e/pgbouncer_test.go
@@ -38,6 +38,7 @@ import (
 	secretsasserts "github.com/cloudnative-pg/cloudnative-pg/tests/internal/asserts/secrets"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/clusterutils"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/exec"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/objects"
 	testsUtils "github.com/cloudnative-pg/cloudnative-pg/tests/utils/postgres"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/secrets"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/yaml"
@@ -218,7 +219,7 @@ var _ = Describe("PGBouncer Connections", Label(tests.LabelServiceConnectivity),
 
 			By("updating pg_hba and pg_ident of the Cluster to allow cert authentication for the app user", func() {
 				cluster := &apiv1.Cluster{}
-				err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+				err = retry.OnError(retry.DefaultBackoff, objects.IsRetryableConflictOrTransientError, func() error {
 					var err error
 					cluster, err = clusterutils.Get(env.Ctx, env.Client, namespace, clusterName)
 					Expect(err).ToNot(HaveOccurred())

--- a/tests/e2e/plugin_barman_cloud_major_upgrade_test.go
+++ b/tests/e2e/plugin_barman_cloud_major_upgrade_test.go
@@ -159,7 +159,8 @@ var _ = Describe("plugin-barman-cloud across a Postgres major upgrade",
 					},
 				}
 				clusterutils.AddTopologySpreadConstraint(cluster)
-				Expect(env.Client.Create(env.Ctx, cluster)).To(Succeed())
+				_, err := objects.Create(env.Ctx, env.Client, cluster)
+				Expect(err).To(Succeed())
 				clusterasserts.AssertClusterIsReady(env, namespace, clusterName, testTimeouts[timeouts.ClusterIsReady])
 			})
 

--- a/tests/e2e/pod_selector_refs_test.go
+++ b/tests/e2e/pod_selector_refs_test.go
@@ -32,6 +32,7 @@ import (
 	clusterasserts "github.com/cloudnative-pg/cloudnative-pg/tests/internal/asserts/cluster"
 	pgasserts "github.com/cloudnative-pg/cloudnative-pg/tests/internal/asserts/postgres"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/clusterutils"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/objects"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/postgres"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/timeouts"
 
@@ -224,7 +225,7 @@ var _ = Describe("Pod selector refs for pg_hba", Label(tests.LabelPostgresConfig
 
 		It("updates pg_hba when podSelectorRefs are added to an existing cluster", func() {
 			By("removing existing podSelectorRefs and pg_hba rules", func() {
-				err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+				err := retry.OnError(retry.DefaultBackoff, objects.IsRetryableConflictOrTransientError, func() error {
 					cluster, err := clusterutils.Get(env.Ctx, env.Client, namespace, clusterName)
 					if err != nil {
 						return err
@@ -245,7 +246,7 @@ var _ = Describe("Pod selector refs for pg_hba", Label(tests.LabelPostgresConfig
 			})
 
 			By("re-adding podSelectorRefs with a new pg_hba rule", func() {
-				err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+				err := retry.OnError(retry.DefaultBackoff, objects.IsRetryableConflictOrTransientError, func() error {
 					cluster, err := clusterutils.Get(env.Ctx, env.Client, namespace, clusterName)
 					if err != nil {
 						return err

--- a/tests/e2e/pod_selector_refs_test.go
+++ b/tests/e2e/pod_selector_refs_test.go
@@ -97,7 +97,7 @@ var _ = Describe("Pod selector refs for pg_hba", Label(tests.LabelPostgresConfig
 					},
 				},
 			}
-			err = env.Client.Create(env.Ctx, cluster)
+			_, err = objects.Create(env.Ctx, env.Client, cluster)
 			Expect(err).NotTo(HaveOccurred())
 			clusterasserts.AssertClusterIsReady(env, namespace, clusterName, testTimeouts[timeouts.ClusterIsReady])
 		})

--- a/tests/e2e/pooler_imagecatalog_test.go
+++ b/tests/e2e/pooler_imagecatalog_test.go
@@ -122,7 +122,8 @@ var _ = Describe("Pooler ImageCatalog", Label(tests.LabelBasic), func() {
 					},
 					Key: catalogKey,
 				})
-				Expect(env.Client.Create(env.Ctx, pooler)).To(Succeed())
+				_, err := objects.Create(env.Ctx, env.Client, pooler)
+				Expect(err).To(Succeed())
 			})
 
 			By("verifying the pooler status reflects the catalog image", func() {
@@ -223,7 +224,8 @@ var _ = Describe("Pooler ImageCatalog", Label(tests.LabelBasic), func() {
 					},
 					Key: catalogKey,
 				})
-				Expect(env.Client.Create(env.Ctx, pooler)).To(Succeed())
+				_, err := objects.Create(env.Ctx, env.Client, pooler)
+				Expect(err).To(Succeed())
 			})
 
 			By("verifying the pooler status reflects the cluster catalog image", func() {
@@ -288,7 +290,8 @@ var _ = Describe("Pooler ImageCatalog", Label(tests.LabelBasic), func() {
 					},
 					Key: "nonexistent-key",
 				})
-				Expect(env.Client.Create(env.Ctx, pooler)).To(Succeed())
+				_, err := objects.Create(env.Ctx, env.Client, pooler)
+				Expect(err).To(Succeed())
 			})
 
 			By("verifying the pooler phase is set to failed", func() {

--- a/tests/e2e/replica_mode_cluster_test.go
+++ b/tests/e2e/replica_mode_cluster_test.go
@@ -113,7 +113,7 @@ var _ = Describe("Replica Mode", Label(tests.LabelReplication), func() {
 			assertReplicaClusterTopology(replicaNamespace, replicaName)
 
 			By("increasing max_connections to 120 on the replica cluster", func() {
-				err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+				err := retry.OnError(retry.DefaultBackoff, objects.IsRetryableConflictOrTransientError, func() error {
 					cluster, err := clusterutils.Get(env.Ctx, env.Client, replicaNamespace, replicaName)
 					if err != nil {
 						return err
@@ -151,7 +151,7 @@ var _ = Describe("Replica Mode", Label(tests.LabelReplication), func() {
 			})
 
 			By("decreasing max_connections to 110 on the replica cluster", func() {
-				err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+				err := retry.OnError(retry.DefaultBackoff, objects.IsRetryableConflictOrTransientError, func() error {
 					cluster, err := clusterutils.Get(env.Ctx, env.Client, replicaNamespace, replicaName)
 					if err != nil {
 						return err

--- a/tests/e2e/rolling_update_test.go
+++ b/tests/e2e/rolling_update_test.go
@@ -383,7 +383,7 @@ var _ = Describe("Rolling updates", Label(tests.LabelPostgresConfiguration), fun
 		err := env.Client.Create(env.Ctx, catalog)
 		Expect(err).ToNot(HaveOccurred())
 		clusterutils.AddTopologySpreadConstraint(cluster)
-		err = env.Client.Create(env.Ctx, cluster)
+		_, err = objects.Create(env.Ctx, env.Client, cluster)
 		Expect(err).ToNot(HaveOccurred())
 		clusterasserts.AssertClusterIsReady(env, namespace, clusterName, testTimeouts[timeouts.ClusterIsReady])
 

--- a/tests/e2e/volume_snapshot_test.go
+++ b/tests/e2e/volume_snapshot_test.go
@@ -81,7 +81,7 @@ var _ = Describe("Verify Volume Snapshot",
 
 		updateClusterSnapshotClass := func(namespace, clusterName, className string) {
 			cluster := &apiv1.Cluster{}
-			err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+			err := retry.OnError(retry.DefaultBackoff, objects.IsRetryableConflictOrTransientError, func() error {
 				var err error
 				cluster, err = clusterutils.Get(env.Ctx, env.Client, namespace, clusterName)
 				Expect(err).ToNot(HaveOccurred())

--- a/tests/internal/asserts/cluster/cluster.go
+++ b/tests/internal/asserts/cluster/cluster.go
@@ -123,7 +123,7 @@ func assertSwitchoverWithHistory(
 	})
 
 	By(fmt.Sprintf("setting the TargetPrimary node to trigger a switchover to %s", targetPrimary), func() {
-		err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		err := retry.OnError(retry.DefaultBackoff, objects.IsRetryableConflictOrTransientError, func() error {
 			cluster, err := clusterutils.Get(env.Ctx, env.Client, namespace, clusterName)
 			Expect(err).ToNot(HaveOccurred())
 			cluster.Status.TargetPrimary = targetPrimary

--- a/tests/internal/asserts/secrets/secrets.go
+++ b/tests/internal/asserts/secrets/secrets.go
@@ -39,6 +39,7 @@ import (
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/clusterutils"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/environment"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/exec"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/objects"
 	secretsutils "github.com/cloudnative-pg/cloudnative-pg/tests/utils/secrets"
 
 	. "github.com/onsi/ginkgo/v2" //nolint
@@ -64,7 +65,7 @@ func AssertUpdateSecret(
 	}).Should(Succeed())
 
 	secret.Data[field] = []byte(value)
-	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+	err := retry.OnError(retry.DefaultBackoff, objects.IsRetryableConflictOrTransientError, func() error {
 		return env.Client.Update(env.Ctx, &secret)
 	})
 	Expect(err).ToNot(HaveOccurred())

--- a/tests/utils/fencing/fencing.go
+++ b/tests/utils/fencing/fencing.go
@@ -23,12 +23,16 @@ package fencing
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/objects"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/run"
 )
 
@@ -41,6 +45,17 @@ const (
 	// UsingPlugin it is a keyword to use while fencing on/off the instances using plugin method
 	UsingPlugin Method = "plugin"
 )
+
+// retryBackoff matches the fixed delay/attempt count tests/utils/objects
+// already uses for retrying transient write failures (e.g. AKS Konnectivity
+// proxy 500s reaching the admission webhook). client-go's own
+// retry.DefaultBackoff is tuned for a near-instantaneous conflict race
+// (~1.5s total), too short to survive a several-second proxy blip.
+var retryBackoff = wait.Backoff{
+	Steps:    objects.RetryAttempts,
+	Duration: objects.PollingTime * time.Second,
+	Factor:   1.0,
+}
 
 // On marks an instance in a cluster as fenced
 func On(
@@ -59,10 +74,18 @@ func On(
 			return err
 		}
 	case UsingAnnotation:
-		err := utils.NewFencingMetadataExecutor(crudClient).
-			AddFencing().
-			ForInstance(serverName).
-			Execute(ctx, types.NamespacedName{Name: clusterName, Namespace: namespace}, &apiv1.Cluster{})
+		// Execute is a self-contained get-mutate-patch: retrying the whole
+		// call is safe (AddFencedInstance is a no-op if already applied) and
+		// covers both a concurrent-modification Conflict and a transient
+		// proxy-hop failure (e.g. AKS Konnectivity 500s reaching the
+		// admission webhook), neither of which a bare single attempt would
+		// survive.
+		err := retry.OnError(retryBackoff, objects.IsRetryableConflictOrTransientError, func() error {
+			return utils.NewFencingMetadataExecutor(crudClient).
+				AddFencing().
+				ForInstance(serverName).
+				Execute(ctx, types.NamespacedName{Name: clusterName, Namespace: namespace}, &apiv1.Cluster{})
+		})
 		if err != nil {
 			return err
 		}
@@ -89,10 +112,12 @@ func Off(
 			return err
 		}
 	case UsingAnnotation:
-		err := utils.NewFencingMetadataExecutor(crudClient).
-			RemoveFencing().
-			ForInstance(serverName).
-			Execute(ctx, types.NamespacedName{Name: clusterName, Namespace: namespace}, &apiv1.Cluster{})
+		err := retry.OnError(retryBackoff, objects.IsRetryableConflictOrTransientError, func() error {
+			return utils.NewFencingMetadataExecutor(crudClient).
+				RemoveFencing().
+				ForInstance(serverName).
+				Execute(ctx, types.NamespacedName{Name: clusterName, Namespace: namespace}, &apiv1.Cluster{})
+		})
 		if err != nil {
 			return err
 		}

--- a/tests/utils/objects/objects.go
+++ b/tests/utils/objects/objects.go
@@ -106,6 +106,16 @@ func isRetryableWriteError(err error) bool {
 		!errors.IsBadRequest(err)
 }
 
+// IsRetryableConflictOrTransientError reports whether err is a Conflict or a
+// transient write failure (see isRetryableWriteError). Callers running their
+// own read-modify-write retry loop (get the object, mutate it, write it
+// back) should retry on both: a Conflict means another writer raced this one
+// and a fresh read will succeed, while a transient failure means the same
+// attempt is worth repeating unchanged.
+func IsRetryableConflictOrTransientError(err error) bool {
+	return errors.IsConflict(err) || isRetryableWriteError(err)
+}
+
 // Patch patches an object in the Kubernetes cluster, retrying on transient
 // errors. Forwarding a mutation to an admission webhook can intermittently
 // fail with a 500/503 on any cluster that routes that hop through a proxy

--- a/tests/utils/openshift/openshift.go
+++ b/tests/utils/openshift/openshift.go
@@ -86,7 +86,7 @@ func PatchStatusCondition(
 ) error {
 	cluster := &apiv1.Cluster{}
 	var err error
-	err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+	err = retry.OnError(retry.DefaultBackoff, objects.IsRetryableConflictOrTransientError, func() error {
 		cluster, err = clusterutils.Get(ctx, crudClient, namespace, clusterName)
 		if err != nil {
 			return err


### PR DESCRIPTION
client-go's retry.RetryOnConflict retries only on HTTP 409 Conflict, so a
transient webhook-proxy 500 (the AKS Konnectivity flake that tests/utils/objects
already retries around for Patch/PatchStatus/Update) passes straight through
instead of being retried, and these read-modify-write loops bail on the
first hit. RetryOnConflict was chosen assuming the only failure mode was a
concurrent-write race; it silently gives zero protection against the other one.

Export the same transient-write predicate objects.Patch/Update rely on,
combined with a Conflict check, and switch these loops from
retry.RetryOnConflict to retry.OnError with it. Each loop already re-fetches
and reapplies its mutation on every attempt, so retrying on either condition
is safe.