### PR TITLE
fix(controller): re-run owned resource finalizer cleanup after a restart

### DIFF
--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -1346,6 +1346,11 @@ func (r *ClusterReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manag
 			&apiv1.Subscription{},
 			handler.EnqueueRequestsFromMapFunc(mapClusterOwnedResourceToCluster),
 			builder.WithPredicates(isBeingDeletedPredicate),
+		).
+		Watches(
+			&apiv1.DatabaseRole{},
+			handler.EnqueueRequestsFromMapFunc(mapClusterOwnedResourceToCluster),
+			builder.WithPredicates(isBeingDeletedPredicate),
 		)
 
 	if configuration.Current.OperatorNamespace != "" {
@@ -1628,11 +1633,9 @@ func (r *ClusterReconciler) mapDatabaseRolesToClusters() handler.MapFunc {
 }
 
 // mapClusterOwnedResourceToCluster maps a namespaced resource that references its
-// Cluster through the `cluster` field (Database, Publication, Subscription) to a
-// reconcile request for that Cluster. It resolves the reference by name instead of
-// through an owner reference, so it keeps working after the Cluster object is gone:
-// that is what allows notifyDeletionToOwnedResources to strip a lingering finalizer
-// when the operator sees the resource again after a restart.
+// Cluster through the `cluster` field to a reconcile request for that Cluster.
+// It resolves the cluster reference by the spec instead of through an owner reference,
+// so it keeps working after the Cluster object is gone.
 func mapClusterOwnedResourceToCluster(_ context.Context, obj client.Object) []reconcile.Request {
 	owned, ok := obj.(interface {
 		GetClusterRef() corev1.LocalObjectReference

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -1323,6 +1323,29 @@ func (r *ClusterReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manag
 			// The cluster only consumes spec.passwordSecret (to maintain the
 			// instance RBAC), so status-only changes are irrelevant here.
 			builder.WithPredicates(predicate.GenerationChangedPredicate{}),
+		).
+		// Watch the owned Database, Publication and Subscription resources only
+		// while they are being deleted. Their reconcilers run in the instance
+		// manager, so when the cluster is torn down together with its pods the
+		// finalizer can only be removed by notifyDeletionToOwnedResources during
+		// the cluster's own deletion. If the operator is down while the namespace
+		// is deleted, the Cluster object is gone and nothing would ever re-trigger
+		// that cleanup after a restart; these watches deliver the lingering
+		// resources on the initial cache sync so the cleanup runs.
+		Watches(
+			&apiv1.Database{},
+			handler.EnqueueRequestsFromMapFunc(mapClusterOwnedResourceToCluster),
+			builder.WithPredicates(isBeingDeletedPredicate),
+		).
+		Watches(
+			&apiv1.Publication{},
+			handler.EnqueueRequestsFromMapFunc(mapClusterOwnedResourceToCluster),
+			builder.WithPredicates(isBeingDeletedPredicate),
+		).
+		Watches(
+			&apiv1.Subscription{},
+			handler.EnqueueRequestsFromMapFunc(mapClusterOwnedResourceToCluster),
+			builder.WithPredicates(isBeingDeletedPredicate),
 		)
 
 	if configuration.Current.OperatorNamespace != "" {
@@ -1601,6 +1624,34 @@ func (r *ClusterReconciler) mapDatabaseRolesToClusters() handler.MapFunc {
 				},
 			},
 		}
+	}
+}
+
+// mapClusterOwnedResourceToCluster maps a namespaced resource that references its
+// Cluster through the `cluster` field (Database, Publication, Subscription) to a
+// reconcile request for that Cluster. It resolves the reference by name instead of
+// through an owner reference, so it keeps working after the Cluster object is gone:
+// that is what allows notifyDeletionToOwnedResources to strip a lingering finalizer
+// when the operator sees the resource again after a restart.
+func mapClusterOwnedResourceToCluster(_ context.Context, obj client.Object) []reconcile.Request {
+	owned, ok := obj.(interface {
+		GetClusterRef() corev1.LocalObjectReference
+	})
+	if !ok {
+		return nil
+	}
+	clusterName := owned.GetClusterRef().Name
+	if clusterName == "" {
+		return nil
+	}
+
+	return []reconcile.Request{
+		{
+			NamespacedName: types.NamespacedName{
+				Namespace: obj.GetNamespace(),
+				Name:      clusterName,
+			},
+		},
 	}
 }
 

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -1321,9 +1321,9 @@ func (r *ClusterReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manag
 			&apiv1.DatabaseRole{},
 			handler.EnqueueRequestsFromMapFunc(mapClusterOwnedResourceToCluster),
 			// The cluster only consumes spec.passwordSecret (to maintain the
-			// instance RBAC), so status-only changes are irrelevant here. ORed with
-			// isBeingDeletedPredicate so this watch also covers what the
-			// Database/Publication/Subscription watches below covers.
+			// instance RBAC), so status-only changes are irrelevant here. OR-ed with
+			// isBeingDeletedPredicate so a reconciliation loop can be enqueued
+			// to remove the finalizer from the resource.
 			builder.WithPredicates(predicate.Or(
 				predicate.GenerationChangedPredicate{},
 				isBeingDeletedPredicate,
@@ -1332,9 +1332,9 @@ func (r *ClusterReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manag
 		// Watch the owned Database, Publication and Subscription resources only
 		// while they are being deleted. Their reconcilers run in the instance
 		// manager, so when the cluster is torn down together with its pods the
-		// finalizer can only be removed by notifyDeletionToOwnedResources during
-		// the cluster's own deletion. If the operator is down while the namespace
-		// is deleted, the Cluster object is gone and nothing would ever re-trigger
+		// finalizer can only be removed by the operator controller.
+		// If the operator is down while the namespace is deleted,
+		// the Cluster object is gone and nothing would ever re-trigger
 		// that cleanup after a restart; these watches deliver the lingering
 		// resources on the initial cache sync so the cleanup runs.
 		Watches(
@@ -1615,10 +1615,7 @@ func (r *ClusterReconciler) mapPoolersToClusters() handler.MapFunc {
 
 // mapClusterOwnedResourceToCluster maps a namespaced resource that references its
 // Cluster through the `cluster` field to a reconcile request for that Cluster.
-// It resolves the cluster reference by name instead of through an owner reference,
-// so it keeps working after the Cluster object is gone: that is what allows
-// notifyDeletionToOwnedResources to strip a lingering finalizer when the operator
-// sees the resource again after a restart.
+// It resolves the cluster reference by name instead of through an owner reference.
 func mapClusterOwnedResourceToCluster(_ context.Context, obj client.Object) []reconcile.Request {
 	owned, ok := obj.(interface {
 		GetClusterRef() corev1.LocalObjectReference

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -1319,10 +1319,15 @@ func (r *ClusterReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manag
 		).
 		Watches(
 			&apiv1.DatabaseRole{},
-			handler.EnqueueRequestsFromMapFunc(r.mapDatabaseRolesToClusters()),
+			handler.EnqueueRequestsFromMapFunc(mapClusterOwnedResourceToCluster),
 			// The cluster only consumes spec.passwordSecret (to maintain the
-			// instance RBAC), so status-only changes are irrelevant here.
-			builder.WithPredicates(predicate.GenerationChangedPredicate{}),
+			// instance RBAC), so status-only changes are irrelevant here. ORed with
+			// isBeingDeletedPredicate so this watch also covers what the
+			// Database/Publication/Subscription watches below covers.
+			builder.WithPredicates(predicate.Or(
+				predicate.GenerationChangedPredicate{},
+				isBeingDeletedPredicate,
+			)),
 		).
 		// Watch the owned Database, Publication and Subscription resources only
 		// while they are being deleted. Their reconcilers run in the instance
@@ -1344,11 +1349,6 @@ func (r *ClusterReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manag
 		).
 		Watches(
 			&apiv1.Subscription{},
-			handler.EnqueueRequestsFromMapFunc(mapClusterOwnedResourceToCluster),
-			builder.WithPredicates(isBeingDeletedPredicate),
-		).
-		Watches(
-			&apiv1.DatabaseRole{},
 			handler.EnqueueRequestsFromMapFunc(mapClusterOwnedResourceToCluster),
 			builder.WithPredicates(isBeingDeletedPredicate),
 		)
@@ -1613,29 +1613,12 @@ func (r *ClusterReconciler) mapPoolersToClusters() handler.MapFunc {
 	}
 }
 
-// mapDatabaseRolesToClusters returns a function mapping roles to their corresponding cluster
-func (r *ClusterReconciler) mapDatabaseRolesToClusters() handler.MapFunc {
-	return func(_ context.Context, obj client.Object) []reconcile.Request {
-		role, ok := obj.(*apiv1.DatabaseRole)
-		if !ok || role.Spec.ClusterRef.Name == "" {
-			return nil
-		}
-
-		return []reconcile.Request{
-			{
-				NamespacedName: types.NamespacedName{
-					Namespace: role.GetNamespace(),
-					Name:      role.Spec.ClusterRef.Name,
-				},
-			},
-		}
-	}
-}
-
 // mapClusterOwnedResourceToCluster maps a namespaced resource that references its
 // Cluster through the `cluster` field to a reconcile request for that Cluster.
-// It resolves the cluster reference by the spec instead of through an owner reference,
-// so it keeps working after the Cluster object is gone.
+// It resolves the cluster reference by name instead of through an owner reference,
+// so it keeps working after the Cluster object is gone: that is what allows
+// notifyDeletionToOwnedResources to strip a lingering finalizer when the operator
+// sees the resource again after a restart.
 func mapClusterOwnedResourceToCluster(_ context.Context, obj client.Object) []reconcile.Request {
 	owned, ok := obj.(interface {
 		GetClusterRef() corev1.LocalObjectReference

--- a/internal/controller/cluster_controller_test.go
+++ b/internal/controller/cluster_controller_test.go
@@ -929,3 +929,47 @@ var _ = Describe("reconcileResources surfaces a permanently failed instance crea
 			Expect(updated.Status.PhaseReason).To(ContainSubstring(failedJob.Name))
 		})
 })
+
+var _ = Describe("mapClusterOwnedResourceToCluster", func() {
+	const (
+		ns             = "ns"
+		referencedName = "referenced-cluster"
+	)
+	expectedRequest := reconcile.Request{
+		NamespacedName: types.NamespacedName{Namespace: ns, Name: referencedName},
+	}
+	clusterRef := corev1.LocalObjectReference{Name: referencedName}
+
+	It("maps a Database to a reconcile request for the referenced cluster", func(ctx SpecContext) {
+		db := &apiv1.Database{
+			ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: "db"},
+			Spec:       apiv1.DatabaseSpec{ClusterRef: clusterRef},
+		}
+		Expect(mapClusterOwnedResourceToCluster(ctx, db)).To(ConsistOf(expectedRequest))
+	})
+
+	It("maps a Publication to a reconcile request for the referenced cluster", func(ctx SpecContext) {
+		pub := &apiv1.Publication{
+			ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: "pub"},
+			Spec:       apiv1.PublicationSpec{ClusterRef: clusterRef},
+		}
+		Expect(mapClusterOwnedResourceToCluster(ctx, pub)).To(ConsistOf(expectedRequest))
+	})
+
+	It("maps a Subscription to a reconcile request for the referenced cluster", func(ctx SpecContext) {
+		sub := &apiv1.Subscription{
+			ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: "sub"},
+			Spec:       apiv1.SubscriptionSpec{ClusterRef: clusterRef},
+		}
+		Expect(mapClusterOwnedResourceToCluster(ctx, sub)).To(ConsistOf(expectedRequest))
+	})
+
+	It("returns nil when the cluster reference is empty", func(ctx SpecContext) {
+		db := &apiv1.Database{ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: "db"}}
+		Expect(mapClusterOwnedResourceToCluster(ctx, db)).To(BeNil())
+	})
+
+	It("returns nil for an object that does not reference a cluster", func(ctx SpecContext) {
+		Expect(mapClusterOwnedResourceToCluster(ctx, &corev1.Secret{})).To(BeNil())
+	})
+})

--- a/internal/controller/cluster_controller_test.go
+++ b/internal/controller/cluster_controller_test.go
@@ -964,6 +964,14 @@ var _ = Describe("mapClusterOwnedResourceToCluster", func() {
 		Expect(mapClusterOwnedResourceToCluster(ctx, sub)).To(ConsistOf(expectedRequest))
 	})
 
+	It("maps a DatabaseRole to a reconcile request for the referenced cluster", func(ctx SpecContext) {
+		sub := &apiv1.DatabaseRole{
+			ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: "sub"},
+			Spec:       apiv1.DatabaseRoleSpec{ClusterRef: clusterRef},
+		}
+		Expect(mapClusterOwnedResourceToCluster(ctx, sub)).To(ConsistOf(expectedRequest))
+	})
+
 	It("returns nil when the cluster reference is empty", func(ctx SpecContext) {
 		db := &apiv1.Database{ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: "db"}}
 		Expect(mapClusterOwnedResourceToCluster(ctx, db)).To(BeNil())

--- a/internal/controller/cluster_predicates.go
+++ b/internal/controller/cluster_predicates.go
@@ -75,14 +75,26 @@ var (
 		},
 	}
 
-	// isBeingDeletedPredicate admits only objects that already carry a
-	// deletionTimestamp. The cluster controller watches the owned Database,
-	// Publication and Subscription resources solely to re-run the deletion
-	// cleanup after a restart, so resources that are not being deleted must not
-	// enqueue a Cluster reconcile.
-	isBeingDeletedPredicate = predicate.NewPredicateFuncs(func(object client.Object) bool {
+	isBeingDeleted = func(object client.Object) bool {
 		return !object.GetDeletionTimestamp().IsZero()
-	})
+	}
+
+	// isBeingDeletedPredicate admits owned resources that are being deleted,
+	// plus everything delivered by the initial cache sync.
+	isBeingDeletedPredicate = predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			return e.IsInInitialList || isBeingDeleted(e.Object)
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return isBeingDeleted(e.Object)
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			return isBeingDeleted(e.Object)
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return isBeingDeleted(e.ObjectNew)
+		},
+	}
 )
 
 func (r *ClusterReconciler) nodesPredicate() predicate.Funcs {

--- a/internal/controller/cluster_predicates.go
+++ b/internal/controller/cluster_predicates.go
@@ -74,6 +74,15 @@ var (
 			return isUsefulClusterSecret(e.ObjectNew)
 		},
 	}
+
+	// isBeingDeletedPredicate admits only objects that already carry a
+	// deletionTimestamp. The cluster controller watches the owned Database,
+	// Publication and Subscription resources solely to re-run the deletion
+	// cleanup after a restart, so resources that are not being deleted must not
+	// enqueue a Cluster reconcile.
+	isBeingDeletedPredicate = predicate.NewPredicateFuncs(func(object client.Object) bool {
+		return !object.GetDeletionTimestamp().IsZero()
+	})
 )
 
 func (r *ClusterReconciler) nodesPredicate() predicate.Funcs {

--- a/internal/controller/cluster_predicates_test.go
+++ b/internal/controller/cluster_predicates_test.go
@@ -171,6 +171,13 @@ var _ = Describe("isBeingDeletedPredicate", func() {
 		Expect(isBeingDeletedPredicate.Generic(event.GenericEvent{Object: beingDeleted})).To(BeTrue())
 	})
 
+	It("admits an object that is not being deleted but belongs to the initialization scan", func() {
+		Expect(isBeingDeletedPredicate.Create(event.CreateEvent{
+			Object:          notBeingDeleted,
+			IsInInitialList: true,
+		})).To(BeTrue())
+	})
+
 	It("rejects an object that is not being deleted on every event type", func() {
 		Expect(isBeingDeletedPredicate.Create(event.CreateEvent{Object: notBeingDeleted})).To(BeFalse())
 		Expect(isBeingDeletedPredicate.Update(event.UpdateEvent{ObjectNew: notBeingDeleted})).To(BeFalse())

--- a/internal/controller/cluster_predicates_test.go
+++ b/internal/controller/cluster_predicates_test.go
@@ -21,10 +21,13 @@ package controller
 
 import (
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 
+	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/internal/configuration"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -146,4 +149,32 @@ var _ = Describe("nodesPredicate", func() {
 		Entry("when a node taints changed",
 			nodeWithKarpenterNoSchedulableTaint, nodeWithAutoscalerTaint, true),
 	)
+})
+
+var _ = Describe("isBeingDeletedPredicate", func() {
+	deletionTime := metav1.Now()
+	beingDeleted := &apiv1.Database{
+		ObjectMeta: metav1.ObjectMeta{
+			DeletionTimestamp: &deletionTime,
+			Finalizers:        []string{utils.DatabaseFinalizerName},
+		},
+	}
+	notBeingDeleted := &apiv1.Database{}
+
+	// The create event matters most: on an operator restart the initial cache
+	// sync delivers lingering resources as create events, and that is the moment
+	// the deletion cleanup must be re-triggered.
+	It("admits an object carrying a deletionTimestamp on every event type", func() {
+		Expect(isBeingDeletedPredicate.Create(event.CreateEvent{Object: beingDeleted})).To(BeTrue())
+		Expect(isBeingDeletedPredicate.Update(event.UpdateEvent{ObjectNew: beingDeleted})).To(BeTrue())
+		Expect(isBeingDeletedPredicate.Delete(event.DeleteEvent{Object: beingDeleted})).To(BeTrue())
+		Expect(isBeingDeletedPredicate.Generic(event.GenericEvent{Object: beingDeleted})).To(BeTrue())
+	})
+
+	It("rejects an object that is not being deleted on every event type", func() {
+		Expect(isBeingDeletedPredicate.Create(event.CreateEvent{Object: notBeingDeleted})).To(BeFalse())
+		Expect(isBeingDeletedPredicate.Update(event.UpdateEvent{ObjectNew: notBeingDeleted})).To(BeFalse())
+		Expect(isBeingDeletedPredicate.Delete(event.DeleteEvent{Object: notBeingDeleted})).To(BeFalse())
+		Expect(isBeingDeletedPredicate.Generic(event.GenericEvent{Object: notBeingDeleted})).To(BeFalse())
+	})
 })


### PR DESCRIPTION
The Database, Publication and Subscription finalizers are removed either by their reconcilers in the instance manager when the object itself is deleted, or by the cluster controller through `notifyDeletionToOwnedResources` when the owning Cluster is deleted. The latter is the only path left once the instance pods are gone, and it runs exclusively while the cluster controller is reconciling the deleted Cluster.

Nothing adds a finalizer to the Cluster object, so when a namespace holding the Cluster and these resources is deleted the Cluster disappears at once. If the operator is not running during that window, on restart it never observes the Cluster again: the object is gone, the cluster controller does not watch these resources, and every other object it maps has already been removed. The cleanup is never triggered, the finalizers remain, and the namespace hangs in Terminating until someone removes them by hand.

This change makes the cluster controller watch the owned Database, Publication and Subscription resources, restricted to the objects that are being deleted. On the initial cache sync after a restart the lingering resources are delivered as create events, which enqueue a reconcile for their referenced Cluster and let `notifyDeletionToOwnedResources` strip the finalizers. The reference is resolved by name rather than through an owner reference, so it still points at the Cluster after the object itself is gone.

Refs #10535
