### PR TITLE
feat: pass the check_empty_wal_archive decision to plugins

### DIFF
--- a/internal/cnpi/plugin/client/contracts.go
+++ b/internal/cnpi/plugin/client/contracts.go
@@ -146,11 +146,15 @@ type LifecycleCapabilities interface {
 // WalCapabilities describes a set of behavior needed to archive and recover WALs
 type WalCapabilities interface {
 	// ArchiveWAL calls the loaded plugins to archive a WAL file.
-	// This call is a no-op if there's no plugin implementing WAL archiving
+	// This call is a no-op if there's no plugin implementing WAL archiving.
+	// checkEmptyWalArchive tells the plugin whether it should verify the
+	// archive destination is empty before this upload; the caller already
+	// combines the Cluster's annotation with the first-archive marker file.
 	ArchiveWAL(
 		ctx context.Context,
 		cluster client.Object,
 		sourceFileName string,
+		checkEmptyWalArchive bool,
 	) error
 
 	// RestoreWAL calls the loaded plugins to archive a WAL file.

--- a/internal/cnpi/plugin/client/restore_job.go
+++ b/internal/cnpi/plugin/client/restore_job.go
@@ -26,7 +26,10 @@ import (
 	"slices"
 
 	restore "github.com/cloudnative-pg/cnpg-i/pkg/restore/job"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 )
 
 // ErrNoPluginSupportsRestoreJobHooksCapability is raised when no plugin supports the restore job hooks capability
@@ -62,8 +65,15 @@ func (data *data) innerRestore(
 		if err != nil {
 			return nil, err
 		}
+
+		// Computed here so the plugin gets the operator's decision instead
+		// of re-deriving it independently (e.g. from a Cluster annotation).
+		checkEmptyWalArchive := utils.IsEmptyWalArchiveCheckEnabled(
+			&metav1.ObjectMeta{Annotations: cluster.GetAnnotations()})
+
 		request := restore.RestoreRequest{
-			ClusterDefinition: clusterDefinition,
+			ClusterDefinition:    clusterDefinition,
+			CheckEmptyWalArchive: &checkEmptyWalArchive,
 		}
 		res, err := plugin.RestoreJobHooksClient().Restore(ctx, &request)
 		if err != nil {

--- a/internal/cnpi/plugin/client/wal.go
+++ b/internal/cnpi/plugin/client/wal.go
@@ -35,14 +35,16 @@ func (data *data) ArchiveWAL(
 	ctx context.Context,
 	cluster client.Object,
 	sourceFileName string,
+	checkEmptyWalArchive bool,
 ) error {
-	return wrapAsPluginErrorIfNeeded(data.innerArchiveWAL(ctx, cluster, sourceFileName))
+	return wrapAsPluginErrorIfNeeded(data.innerArchiveWAL(ctx, cluster, sourceFileName, checkEmptyWalArchive))
 }
 
 func (data *data) innerArchiveWAL(
 	ctx context.Context,
 	cluster client.Object,
 	sourceFileName string,
+	checkEmptyWalArchive bool,
 ) error {
 	contextLogger := log.FromContext(ctx)
 
@@ -64,8 +66,9 @@ func (data *data) innerArchiveWAL(
 
 		pluginLogger := contextLogger.WithValues("pluginName", plugin.Name())
 		request := wal.WALArchiveRequest{
-			ClusterDefinition: serializedCluster,
-			SourceFileName:    sourceFileName,
+			ClusterDefinition:    serializedCluster,
+			SourceFileName:       sourceFileName,
+			CheckEmptyWalArchive: &checkEmptyWalArchive,
 		}
 
 		pluginLogger.Trace(

--- a/pkg/management/postgres/archiver/archiver.go
+++ b/pkg/management/postgres/archiver/archiver.go
@@ -204,8 +204,8 @@ func internalRun(
 	}
 
 	// Step 1: Check if the archive location is safe to perform archiving
-	if utils.IsEmptyWalArchiveCheckEnabled(&cluster.ObjectMeta) {
-		if err := checkWalArchive(ctx, cluster, walArchiver, pgData); err != nil {
+	if shouldCheckEmptyWalArchive(ctx, cluster, pgData) {
+		if err := checkWalArchive(ctx, cluster, walArchiver); err != nil {
 			return err
 		}
 	}
@@ -301,7 +301,21 @@ func archiveWALViaPlugins(
 		}
 	}
 
-	return client.ArchiveWAL(ctx, cluster, postgres.BuildWALPath(pgData, walName))
+	// The marker file is ours to manage (created after bootstrap, removed
+	// once the first WAL archives), so we resolve the full decision here
+	// rather than asking the plugin to inspect it too.
+	checkEmptyWalArchive := shouldCheckEmptyWalArchive(ctx, cluster, pgData)
+
+	return client.ArchiveWAL(ctx, cluster, postgres.BuildWALPath(pgData, walName), checkEmptyWalArchive)
+}
+
+// shouldCheckEmptyWalArchive combines the Cluster's annotation with the
+// first-archive marker file to decide whether the WAL archive destination
+// should be verified before this upload. Used identically by the in-tree
+// archiving path and by archiveWALViaPlugins, so the composition rule lives
+// in exactly one place.
+func shouldCheckEmptyWalArchive(ctx context.Context, cluster *apiv1.Cluster, pgData string) bool {
+	return utils.IsEmptyWalArchiveCheckEnabled(&cluster.ObjectMeta) && isCheckWalArchiveFlagFilePresent(ctx, pgData)
 }
 
 // isCheckWalArchiveFlagFilePresent returns true if the file CheckEmptyWalArchiveFile is present in the PGDATA directory
@@ -326,7 +340,6 @@ func checkWalArchive(
 	ctx context.Context,
 	cluster *apiv1.Cluster,
 	walArchiver *barmanArchiver.WALArchiver,
-	pgData string,
 ) error {
 	contextLogger := log.FromContext(ctx)
 	checkWalOptions, err := walArchiver.BarmanCloudCheckWalArchiveOptions(
@@ -334,10 +347,6 @@ func checkWalArchive(
 	if err != nil {
 		contextLogger.Error(err, "while getting barman-cloud-wal-archive options")
 		return err
-	}
-
-	if !isCheckWalArchiveFlagFilePresent(ctx, pgData) {
-		return nil
 	}
 
 	if err := walArchiver.CheckWalArchiveDestination(ctx, checkWalOptions); err != nil {

--- a/pkg/management/postgres/archiver/archiver_test.go
+++ b/pkg/management/postgres/archiver/archiver_test.go
@@ -1,0 +1,95 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package archiver
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+
+	"k8s.io/utils/ptr"
+
+	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres/constants"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// skipEmptyWalArchiveCheckAnnotation mirrors the unexported constant in
+// pkg/utils; the tests deliberately hard-code the literal so a divergence
+// between the annotation the operator honors and the one documented here
+// would surface as a failure.
+const skipEmptyWalArchiveCheckAnnotation = "cnpg.io/skipEmptyWalArchiveCheck"
+
+func writeMarkerFile(pgData string) {
+	markerPath := filepath.Join(pgData, constants.CheckEmptyWalArchiveFile)
+	Expect(os.WriteFile(markerPath, []byte{}, 0o600)).To(Succeed())
+}
+
+var _ = Describe("shouldCheckEmptyWalArchive", func() {
+	DescribeTable(
+		"combines the skip annotation with the first-archive marker file",
+		func(annotationValue *string, createMarker bool, expected bool) {
+			pgData := GinkgoT().TempDir()
+			if createMarker {
+				writeMarkerFile(pgData)
+			}
+
+			cluster := &apiv1.Cluster{}
+			if annotationValue != nil {
+				cluster.Annotations = map[string]string{
+					skipEmptyWalArchiveCheckAnnotation: *annotationValue,
+				}
+			}
+
+			Expect(shouldCheckEmptyWalArchive(context.Background(), cluster, pgData)).To(Equal(expected))
+		},
+		Entry("no annotation and marker present: check runs", nil, true, true),
+		Entry("no annotation and marker absent: check skipped", nil, false, false),
+		Entry("opt-out annotation and marker present: check skipped", ptr.To("enabled"), true, false),
+		Entry("opt-out annotation and marker absent: check skipped", ptr.To("enabled"), false, false),
+		Entry("unrelated annotation value and marker present: check runs", ptr.To("something-else"), true, true),
+		Entry("unrelated annotation value and marker absent: check skipped", ptr.To("something-else"), false, false),
+		Entry("empty annotation value and marker present: check runs", ptr.To(""), true, true),
+	)
+})
+
+var _ = Describe("isCheckWalArchiveFlagFilePresent", func() {
+	It("returns true when the marker file exists in PGDATA", func() {
+		pgData := GinkgoT().TempDir()
+		writeMarkerFile(pgData)
+
+		Expect(isCheckWalArchiveFlagFilePresent(context.Background(), pgData)).To(BeTrue())
+	})
+
+	It("returns false when the marker file is absent", func() {
+		pgData := GinkgoT().TempDir()
+
+		Expect(isCheckWalArchiveFlagFilePresent(context.Background(), pgData)).To(BeFalse())
+	})
+
+	It("returns false when only an unrelated file is present", func() {
+		pgData := GinkgoT().TempDir()
+		Expect(os.WriteFile(filepath.Join(pgData, "PG_VERSION"), []byte{}, 0o600)).To(Succeed())
+
+		Expect(isCheckWalArchiveFlagFilePresent(context.Background(), pgData)).To(BeFalse())
+	})
+})

--- a/pkg/management/postgres/archiver/suite_test.go
+++ b/pkg/management/postgres/archiver/suite_test.go
@@ -1,0 +1,32 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package archiver
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestArchiver(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Postgres Archiver test suite")
+}


### PR DESCRIPTION
The empty-WAL-archive check depends on the Cluster's annotation and, for archiving, on a first-archive marker file whose lifecycle the operator owns. A plugin re-deriving this decision on its own (e.g. by reading the annotation directly) duplicates policy that belongs here.

Compute the decision once and pass it explicitly to plugins through cnpg-i's new CheckEmptyWalArchive field, for both WAL archiving and the restore job hooks. The in-tree archiving path is refactored to share the same composition rule via shouldCheckEmptyWalArchive, instead of computing it twice.

Closes #11217

Related: cloudnative-pg/cnpg-i#353 adds the field; cloudnative-pg/plugin-barman-cloud#1009 is the plugin-side counterpart.
