### PR TITLE
test(e2e): widen backup-cleanup deadline margin against reconcile lag

### DIFF
--- a/tests/e2e/volume_snapshot_test.go
+++ b/tests/e2e/volume_snapshot_test.go
@@ -979,7 +979,7 @@ var _ = Describe("Verify Volume Snapshot",
 						g.Expect(failedBackup.Status.Phase).ToNot(BeEquivalentTo(apiv1.BackupPhaseFailed))
 					}, "30s", "5s").Should(Succeed())
 
-					// Allow extra margin over RetryTimeout for the 10s reconcile
+					// Allow extra margin over RetryTimeout for the reconcile
 					// polling interval.
 					Eventually(func(g Gomega) {
 						err = env.Client.Get(env.Ctx, types.NamespacedName{
@@ -989,7 +989,7 @@ var _ = Describe("Verify Volume Snapshot",
 						g.Expect(err).ToNot(HaveOccurred())
 						g.Expect(failedBackup.Status.Phase).To(BeEquivalentTo(apiv1.BackupPhaseFailed))
 						g.Expect(failedBackup.Status.Error).To(ContainSubstring("Failed to get snapshot class"))
-					}, RetryTimeout+30).Should(Succeed())
+					}, RetryTimeout+90).Should(Succeed())
 				})
 
 				By("verifying that the backup connection is cleaned up", func() {


### PR DESCRIPTION
The "should clean up unused backup connections" spec waits RetryTimeout+30s for a failed backup to reach the Failed phase, but RetryTimeout is only 60s, leaving roughly 30s of slack over the reconciler's own ~10s polling interval. That margin has proven too tight under nightly CI load, flaking repeatedly. Widen it to RetryTimeout+90s.