### PR TITLE
fix(controller): recover owned resource cleanup for deleted clusters

### DIFF
--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -1346,6 +1346,11 @@ func (r *ClusterReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manag
 			&apiv1.Subscription{},
 			handler.EnqueueRequestsFromMapFunc(mapClusterOwnedResourceToCluster),
 			builder.WithPredicates(isBeingDeletedPredicate),
+		).
+		Watches(
+			&apiv1.DatabaseRole{},
+			handler.EnqueueRequestsFromMapFunc(mapClusterOwnedResourceToCluster),
+			builder.WithPredicates(isBeingDeletedPredicate),
 		)
 
 	if configuration.Current.OperatorNamespace != "" {
@@ -1628,11 +1633,9 @@ func (r *ClusterReconciler) mapDatabaseRolesToClusters() handler.MapFunc {
 }
 
 // mapClusterOwnedResourceToCluster maps a namespaced resource that references its
-// Cluster through the `cluster` field (Database, Publication, Subscription) to a
-// reconcile request for that Cluster. It resolves the reference by name instead of
-// through an owner reference, so it keeps working after the Cluster object is gone:
-// that is what allows notifyDeletionToOwnedResources to strip a lingering finalizer
-// when the operator sees the resource again after a restart.
+// Cluster through the `cluster` field to a reconcile request for that Cluster.
+// It resolves the cluster reference by the spec instead of through an owner reference,
+// so it keeps working after the Cluster object is gone.
 func mapClusterOwnedResourceToCluster(_ context.Context, obj client.Object) []reconcile.Request {
 	owned, ok := obj.(interface {
 		GetClusterRef() corev1.LocalObjectReference

--- a/internal/controller/cluster_controller_test.go
+++ b/internal/controller/cluster_controller_test.go
@@ -964,6 +964,14 @@ var _ = Describe("mapClusterOwnedResourceToCluster", func() {
 		Expect(mapClusterOwnedResourceToCluster(ctx, sub)).To(ConsistOf(expectedRequest))
 	})
 
+	It("maps a DatabaseRole to a reconcile request for the referenced cluster", func(ctx SpecContext) {
+		sub := &apiv1.DatabaseRole{
+			ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: "sub"},
+			Spec:       apiv1.DatabaseRoleSpec{ClusterRef: clusterRef},
+		}
+		Expect(mapClusterOwnedResourceToCluster(ctx, sub)).To(ConsistOf(expectedRequest))
+	})
+
 	It("returns nil when the cluster reference is empty", func(ctx SpecContext) {
 		db := &apiv1.Database{ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: "db"}}
 		Expect(mapClusterOwnedResourceToCluster(ctx, db)).To(BeNil())

--- a/internal/controller/cluster_predicates.go
+++ b/internal/controller/cluster_predicates.go
@@ -75,14 +75,26 @@ var (
 		},
 	}
 
-	// isBeingDeletedPredicate admits only objects that already carry a
-	// deletionTimestamp. The cluster controller watches the owned Database,
-	// Publication and Subscription resources solely to re-run the deletion
-	// cleanup after a restart, so resources that are not being deleted must not
-	// enqueue a Cluster reconcile.
-	isBeingDeletedPredicate = predicate.NewPredicateFuncs(func(object client.Object) bool {
+	isBeingDeleted = func(object client.Object) bool {
 		return !object.GetDeletionTimestamp().IsZero()
-	})
+	}
+
+	// isBeingDeletedPredicate admits owned resources that are being deleted,
+	// plus everything delivered by the initial cache sync.
+	isBeingDeletedPredicate = predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			return e.IsInInitialList || isBeingDeleted(e.Object)
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return isBeingDeleted(e.Object)
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			return isBeingDeleted(e.Object)
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return isBeingDeleted(e.ObjectNew)
+		},
+	}
 )
 
 func (r *ClusterReconciler) nodesPredicate() predicate.Funcs {

--- a/internal/controller/cluster_predicates_test.go
+++ b/internal/controller/cluster_predicates_test.go
@@ -171,6 +171,13 @@ var _ = Describe("isBeingDeletedPredicate", func() {
 		Expect(isBeingDeletedPredicate.Generic(event.GenericEvent{Object: beingDeleted})).To(BeTrue())
 	})
 
+	It("admits an object that is not being deleted but belongs to the initialization scan", func() {
+		Expect(isBeingDeletedPredicate.Create(event.CreateEvent{
+			Object:          notBeingDeleted,
+			IsInInitialList: true,
+		})).To(BeTrue())
+	})
+
 	It("rejects an object that is not being deleted on every event type", func() {
 		Expect(isBeingDeletedPredicate.Create(event.CreateEvent{Object: notBeingDeleted})).To(BeFalse())
 		Expect(isBeingDeletedPredicate.Update(event.UpdateEvent{ObjectNew: notBeingDeleted})).To(BeFalse())


### PR DESCRIPTION
The owned-resource watches that re-run `notifyDeletionToOwnedResources` after a restart only fired for resources already carrying a deletionTimestamp. Because the Cluster has no finalizer, deleting only the Cluster (rather than the whole namespace) leaves the `Database`, `Publication`, `Subscription` and `DatabaseRole` objects without a deletionTimestamp of their own. On restart their initial cache-sync events were dropped by the predicate, the Cluster was already gone so nothing else enqueued a reconcile, and the finalizers were never stripped.

Admit the initial-list create events so the cleanup runs on restart regardless of whether the owned resource is itself being deleted;

Also watch DatabaseRole,
whose finalizer is likewise managed by the instance manager and carries the same orphan risk.

Refs #10535
