### PR TITLE
feat(plugin): add `--dry-run` option to the `backup` command

### DIFF
--- a/docs/src/kubectl-plugin.md
+++ b/docs/src/kubectl-plugin.md
@@ -1061,6 +1061,13 @@ to request an online/hot backup or an offline/cold one: additionally, you can
 also tune online backups by explicitly setting the `--immediate-checkpoint` and
 `--wait-for-archive` options.
 
+You can use the `--dry-run` option to preview the `Backup` resource that would
+be created, without actually submitting it to the API server:
+
+```sh
+kubectl cnpg backup CLUSTER --dry-run
+```
+
 The ["Backup" section](./backup.md) contains more information about
 the configuration settings.
 

--- a/internal/cmd/plugin/backup/cmd.go
+++ b/internal/cmd/plugin/backup/cmd.go
@@ -22,6 +22,7 @@ package backup
 import (
 	"context"
 	"fmt"
+	"os"
 	"slices"
 	"strconv"
 	"strings"
@@ -50,6 +51,7 @@ type backupCommandOptions struct {
 	waitForArchive      *bool
 	pluginName          string
 	pluginParameters    pluginParameters
+	dryRun              bool
 }
 
 func (options backupCommandOptions) getOnlineConfiguration() *apiv1.OnlineConfiguration {
@@ -67,6 +69,7 @@ func (options backupCommandOptions) getOnlineConfiguration() *apiv1.OnlineConfig
 func NewCmd() *cobra.Command {
 	var backupName, backupTarget, backupMethod, online, immediateCheckpoint, waitForArchive, pluginName string
 	var pluginParameters pluginParameters
+	var dryRun bool
 
 	backupMethods := []string{
 		string(apiv1.BackupMethodBarmanObjectStore),
@@ -166,6 +169,7 @@ func NewCmd() *cobra.Command {
 					waitForArchive:      parsedWaitForArchive,
 					pluginName:          pluginName,
 					pluginParameters:    pluginParameters,
+					dryRun:              dryRun,
 				})
 		},
 	}
@@ -228,12 +232,21 @@ func NewCmd() *cobra.Command {
 			"is allowed only when the backup method is set to 'plugin'",
 	)
 
+	backupSubcommand.Flags().BoolVar(&dryRun, "dry-run", false,
+		"If specified, the Backup resource is not created, "+
+			"and its manifest is printed instead",
+	)
+
 	return backupSubcommand
 }
 
 // createBackup handles the Backup resource creation
 func createBackup(ctx context.Context, options backupCommandOptions) error {
 	backup := apiv1.Backup{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: apiv1.SchemeGroupVersion.String(),
+			Kind:       apiv1.BackupKind,
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: plugin.Namespace,
 			Name:      options.backupName,
@@ -255,6 +268,10 @@ func createBackup(ctx context.Context, options backupCommandOptions) error {
 			Name:       options.pluginName,
 			Parameters: options.pluginParameters,
 		}
+	}
+
+	if options.dryRun {
+		return plugin.Print(&backup, plugin.OutputFormatYAML, os.Stdout)
 	}
 
 	err := plugin.Client.Create(ctx, &backup)

--- a/internal/cmd/plugin/backup/cmd.go
+++ b/internal/cmd/plugin/backup/cmd.go
@@ -233,8 +233,7 @@ func NewCmd() *cobra.Command {
 	)
 
 	backupSubcommand.Flags().BoolVar(&dryRun, "dry-run", false,
-		"If specified, the Backup resource is not created, "+
-			"and its manifest is printed instead",
+		"When true prints the Backup manifest instead of creating it",
 	)
 
 	return backupSubcommand

--- a/internal/cmd/plugin/backup/cmd_test.go
+++ b/internal/cmd/plugin/backup/cmd_test.go
@@ -1,0 +1,114 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package backup
+
+import (
+	"io"
+	"os"
+
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/plugin"
+	"github.com/cloudnative-pg/cloudnative-pg/internal/scheme"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func captureStdout(f func()) string {
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	f()
+
+	_ = w.Close()
+	os.Stdout = old
+
+	out, _ := io.ReadAll(r)
+	return string(out)
+}
+
+var _ = Describe("NewCmd", func() {
+	It("should register the dry-run flag with a false default", func() {
+		cmd := NewCmd()
+
+		dryRunFlag := cmd.Flag("dry-run")
+		Expect(dryRunFlag).ToNot(BeNil())
+		Expect(dryRunFlag.DefValue).To(Equal("false"))
+	})
+})
+
+var _ = Describe("createBackup", func() {
+	const (
+		clusterName = "cluster-example"
+		namespace   = "test-ns"
+		backupName  = "cluster-example-backup"
+	)
+
+	BeforeEach(func() {
+		plugin.Namespace = namespace
+	})
+
+	It("should not create the Backup resource when dry-run is set", func(ctx SpecContext) {
+		plugin.Client = fake.NewClientBuilder().
+			WithScheme(scheme.BuildWithAllKnownScheme()).
+			Build()
+
+		var err error
+		stdout := captureStdout(func() {
+			err = createBackup(ctx, backupCommandOptions{
+				backupName:  backupName,
+				clusterName: clusterName,
+				dryRun:      true,
+			})
+		})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(stdout).To(ContainSubstring("kind: Backup"))
+		Expect(stdout).To(ContainSubstring("name: " + backupName))
+
+		var created apiv1.Backup
+		err = plugin.Client.Get(ctx,
+			types.NamespacedName{Name: backupName, Namespace: namespace},
+			&created,
+		)
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("should create the Backup resource when dry-run is not set", func(ctx SpecContext) {
+		plugin.Client = fake.NewClientBuilder().
+			WithScheme(scheme.BuildWithAllKnownScheme()).
+			Build()
+
+		Expect(createBackup(ctx, backupCommandOptions{
+			backupName:  backupName,
+			clusterName: clusterName,
+		})).To(Succeed())
+
+		var created apiv1.Backup
+		Expect(plugin.Client.Get(ctx,
+			types.NamespacedName{Name: backupName, Namespace: namespace},
+			&created,
+		)).To(Succeed())
+		Expect(created.Spec.Cluster.Name).To(Equal(clusterName))
+	})
+})

--- a/internal/cmd/plugin/backup/cmd_test.go
+++ b/internal/cmd/plugin/backup/cmd_test.go
@@ -39,13 +39,16 @@ func captureStdout(f func()) string {
 	old := os.Stdout
 	r, w, _ := os.Pipe()
 	os.Stdout = w
+	DeferCleanup(func() {
+		os.Stdout = old
+		_ = r.Close()
+	})
 
 	f()
 
-	_ = w.Close()
-	os.Stdout = old
-
-	out, _ := io.ReadAll(r)
+	Expect(w.Close()).To(Succeed())
+	out, err := io.ReadAll(r)
+	Expect(err).ToNot(HaveOccurred())
 	return string(out)
 }
 

--- a/internal/cmd/plugin/backup/cmd_test.go
+++ b/internal/cmd/plugin/backup/cmd_test.go
@@ -44,12 +44,18 @@ func captureStdout(f func()) string {
 		_ = r.Close()
 	})
 
+	// Drain concurrently so f() can't block if it writes more than the
+	// OS pipe buffer can hold.
+	outCh := make(chan string, 1)
+	go func() {
+		out, _ := io.ReadAll(r)
+		outCh <- string(out)
+	}()
+
 	f()
 
 	Expect(w.Close()).To(Succeed())
-	out, err := io.ReadAll(r)
-	Expect(err).ToNot(HaveOccurred())
-	return string(out)
+	return <-outCh
 }
 
 var _ = Describe("NewCmd", func() {

--- a/internal/cmd/plugin/backup/cmd_test.go
+++ b/internal/cmd/plugin/backup/cmd_test.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"os"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -91,7 +92,7 @@ var _ = Describe("createBackup", func() {
 			types.NamespacedName{Name: backupName, Namespace: namespace},
 			&created,
 		)
-		Expect(err).To(HaveOccurred())
+		Expect(apierrors.IsNotFound(err)).To(BeTrue())
 	})
 
 	It("should create the Backup resource when dry-run is not set", func(ctx SpecContext) {


### PR DESCRIPTION
Allow previewing the Backup resource that `kubectl cnpg backup` would submit, without creating it, following the same client-side dry-run convention already used by the pgbench, fio, and pgadmin plugin subcommands.

Closes #11232

Assisted-by: Claude