### PR TITLE
chore(e2e): drop obsolete plugin Service finalizer workaround from upgrade test

### DIFF
--- a/hack/testing-tools/common/20-utils-k8s.sh
+++ b/hack/testing-tools/common/20-utils-k8s.sh
@@ -187,11 +187,15 @@ function print_operator_image() {
 # reset_operator_namespace: deletes the cnpg-system namespace and any
 # cluster-scoped resources left by a previous operator installation, then waits
 # for finalization so the next apply doesn't race a terminating namespace.
-# Plugin services are deleted first so the operator can still clear their
-# cnpg.io/cleanupPlugin finalizer. Cluster-scoped resources (webhooks,
-# ClusterRoles, ClusterRoleBindings) must be removed explicitly because they
-# survive namespace deletion and would block Helm from adopting them (missing
-# ownership labels).
+# Plugin services are deleted first because deploy_operator_from_manifest can
+# target an arbitrary released operator version, and every version released so
+# far still puts a cnpg.io/cleanupPlugin finalizer on the plugin Service; that
+# finalizer only got removed on unreleased main/branch tips (#10940), so
+# deleting cnpg-system wholesale can still wedge the namespace against a
+# released operator. Safe to drop once no supported release predates that fix.
+# Cluster-scoped resources (webhooks, ClusterRoles, ClusterRoleBindings) must be
+# removed explicitly because they survive namespace deletion and would block Helm
+# from adopting them (missing ownership labels).
 function reset_operator_namespace() {
     # Must run before "helm uninstall": that would tear down a helm-deployed
     # operator first, leaving nothing to clear the finalizer below.

--- a/hack/testing-tools/common/20-utils-k8s.sh
+++ b/hack/testing-tools/common/20-utils-k8s.sh
@@ -192,7 +192,8 @@ function print_operator_image() {
 # far still puts a cnpg.io/cleanupPlugin finalizer on the plugin Service; that
 # finalizer only got removed on unreleased main/branch tips (#10940), so
 # deleting cnpg-system wholesale can still wedge the namespace against a
-# released operator. Safe to drop once no supported release predates that fix.
+# released operator. 1.30 is the newest release branch and still predates the
+# fix, so this is safe to drop once 1.30 reaches EOL.
 # Cluster-scoped resources (webhooks, ClusterRoles, ClusterRoleBindings) must be
 # removed explicitly because they survive namespace deletion and would block Helm
 # from adopting them (missing ownership labels).

--- a/tests/e2e/upgrade_test.go
+++ b/tests/e2e/upgrade_test.go
@@ -880,11 +880,7 @@ var _ = Describe("Upgrade", Label(tests.LabelUpgrade, tests.LabelNoOpenshift), O
 				// This spec owns its operator lifecycle, so it tears down cnpg-system
 				// itself. cleanupOperatorAndObjectStore is not reused: it also cleans
 				// object store paths that only the in-core upgrade specs create, which
-				// would fail here. The plugin is removed before cnpg-system because the operator
-				// puts a cnpg.io/cleanupPlugin finalizer on the plugin Service, so
-				// deleting cnpg-system wholesale would otherwise wedge the namespace
-				// on that finalizer; removing the plugin while the operator is still
-				// up lets it be cleared.
+				// would fail here.
 				DeferCleanup(func() {
 					if CurrentSpecReport().Failed() {
 						namespaces.DumpNamespaceObjects(env.Ctx, env.Client,
@@ -892,11 +888,6 @@ var _ = Describe("Upgrade", Label(tests.LabelUpgrade, tests.LabelNoOpenshift), O
 						operator.Dump(env.Ctx, env.Client,
 							operatorNamespace, "out/"+CurrentSpecReport().LeafNodeText+"operator.log")
 					}
-					_, stderr, err := run.Run(fmt.Sprintf(
-						"kubectl delete deployment,service barman-cloud -n %s "+
-							"--ignore-not-found --wait=true --timeout=2m",
-						operatorNamespace))
-					Expect(err).NotTo(HaveOccurred(), "stderr: "+stderr)
 					Expect(namespaces.DeleteNamespaceAndWait(env.Ctx, env.Client, operatorNamespace, 120)).
 						To(Succeed())
 				})


### PR DESCRIPTION
PR #10850 worked around the operator setting a cnpg.io/cleanupPlugin finalizer on the plugin barman-cloud Service, which would otherwise wedge cnpg-system in Terminating state on namespace deletion. The plugin upgrade e2e spec deleted the plugin Service ahead of time to let the operator clear it first.

PR #10940 removed that finalizer from new Services entirely, but the spec always upgrades between operator builds generated from the current source tree, so it already carries the fix and the workaround is stale there.

reset_operator_namespace in hack/testing-tools keeps the same pre-deletion step, since deploy_operator_from_manifest can target an arbitrary released operator version, and every version released so far still sets the old finalizer.