### PR TITLE
fix: honor unrecoverable annotation on pending and terminating instances

### DIFF
--- a/docs/src/labels_annotations.md
+++ b/docs/src/labels_annotations.md
@@ -303,8 +303,19 @@ CloudNativePG manages the following predefined annotations:
 :   Experimental annotation applied to a `Pod` running a PostgreSQL instance.
     It instructs the operator to delete the `Pod` and all its associated PVCs.
     The instance will then be recreated according to the configured join
-    strategy. This annotation can only be used on instances that are neither the
-    current primary nor the designated target primary.
+    strategy. The annotation is honored regardless of the instance's state, so
+    it also takes effect on a `Pod` that is Pending, Running but not ready, or
+    Terminating. When a Terminating `Pod` has passed its deletion deadline (the
+    deletion request time plus its termination grace period), the operator force
+    removes it so that its PVCs can be deleted and the instance recreated. This
+    annotation can only be used on instances that are neither the current primary
+    nor the designated target primary, which stay excluded even when marked
+    unrecoverable.
+
+    **⚠️ WARNING:** Force removing a `Pod` on an unreachable node does not stop
+    any process that might still be running there, and whether the underlying
+    volumes are detached depends on the storage driver. This is acceptable for
+    this annotation, whose contract already forfeits the instance's data.
 
 ## Prerequisites
 

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -886,6 +886,16 @@ func (r *ClusterReconciler) reconcileResources(
 		return *result, err
 	}
 
+	// Handle instances explicitly marked as unrecoverable before the active-instances
+	// gate below. A Pod that is Pending or Terminating is never "active", so the gate
+	// would otherwise return early and the alpha.cnpg.io/unrecoverable annotation would
+	// have no effect on exactly those states. This mirrors the unschedulable-instances
+	// handling above, which sits before the same gate for the same structural reason
+	// (its target Pods are Pending too).
+	if res, err := r.reconcileUnrecoverableInstances(ctx, cluster, resources); !res.IsZero() || err != nil {
+		return res, err
+	}
+
 	if !resources.allInstancesAreActive() {
 		contextLogger = contextLogger.WithValues(
 			"inactiveInstances", resources.inactiveInstanceNames())
@@ -1101,14 +1111,6 @@ func (r *ClusterReconciler) reconcilePods(
 	// pods joining the node that we already have.
 	if cluster.Status.Instances == 0 {
 		return r.createPrimaryInstance(ctx, cluster)
-	}
-
-	// Handle instances marked as unrecoverable before waiting for pods to be ready.
-	// This ensures pods annotated with alpha.cnpg.io/unrecoverable=true are
-	// deleted even when they can't report their status (e.g., postgres process
-	// not running, startup probe failing).
-	if res, err := r.reconcileUnrecoverableInstances(ctx, cluster, resources); !res.IsZero() || err != nil {
-		return res, err
 	}
 
 	// Stop acting here if there are non-ready Pods unless in maintenance reusing PVCs.

--- a/internal/controller/cluster_unrecoverable.go
+++ b/internal/controller/cluster_unrecoverable.go
@@ -27,7 +27,9 @@ import (
 	"github.com/cloudnative-pg/machinery/pkg/log"
 	"github.com/cloudnative-pg/machinery/pkg/stringset"
 	corev1 "k8s.io/api/core/v1"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
@@ -43,18 +45,57 @@ func (r *ClusterReconciler) reconcileUnrecoverableInstances(
 	logger := log.FromContext(ctx)
 
 	targetInstances := collectNamesOfUnrecoverableInstances(ctx, cluster, resources)
-	if len(targetInstances) > 0 {
-		podName := targetInstances[0]
-
-		logger.Info("Deleting unrecoverable instance", "podName", podName)
-		if err := r.ensureInstanceIsDeleted(ctx, cluster, podName); err != nil {
-			return ctrl.Result{}, err
-		}
-
-		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+	if len(targetInstances) == 0 {
+		return ctrl.Result{}, nil
 	}
 
-	return ctrl.Result{}, nil
+	podName := targetInstances[0]
+
+	logger.Info("Deleting unrecoverable instance", "podName", podName)
+	r.Recorder.Eventf(cluster, "Normal", "DeleteUnrecoverableInstance",
+		"Deleting unrecoverable instance %v (pods and PVCs)", podName)
+
+	// A graceful delete is a no-op on a Pod that is already Terminating, so a Pod
+	// stuck past its own deletion deadline would never be removed and its PVCs
+	// (blocked by the pvc-protection finalizer) could never be deleted. Force-remove
+	// such a Pod first so that ensureInstanceIsDeleted below can make progress.
+	if pod := findInstancePodByName(resources, podName); pod != nil && isPodStuckTerminating(pod) {
+		logger.Info(
+			"Force-removing unrecoverable instance stuck past its deletion deadline",
+			"podName", podName,
+			"deletionTimestamp", pod.DeletionTimestamp,
+		)
+		if err := r.Delete(ctx, pod, client.GracePeriodSeconds(0)); err != nil && !apierrs.IsNotFound(err) {
+			return ctrl.Result{}, err
+		}
+	}
+
+	if err := r.ensureInstanceIsDeleted(ctx, cluster, podName); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+}
+
+// findInstancePodByName returns the managed instance Pod with the given name, or
+// nil when no such Pod is present in the managed resources.
+func findInstancePodByName(resources *managedResources, name string) *corev1.Pod {
+	for i := range resources.instances.Items {
+		if resources.instances.Items[i].Name == name {
+			return &resources.instances.Items[i]
+		}
+	}
+	return nil
+}
+
+// isPodStuckTerminating reports whether a Pod has been asked to terminate but is
+// still present past its own deletion deadline. DeletionTimestamp is the moment
+// (deletion request time plus the termination grace period) at which the object
+// is expected to be gone. A Pod that lingers past it has already been given its
+// entire termination budget, so it will not disappear on another graceful delete
+// and has to be force-removed.
+func isPodStuckTerminating(pod *corev1.Pod) bool {
+	return pod.DeletionTimestamp != nil && time.Now().After(pod.DeletionTimestamp.Time)
 }
 
 func collectNamesOfUnrecoverableInstances(

--- a/internal/controller/cluster_unrecoverable.go
+++ b/internal/controller/cluster_unrecoverable.go
@@ -52,14 +52,12 @@ func (r *ClusterReconciler) reconcileUnrecoverableInstances(
 	podName := targetInstances[0]
 
 	logger.Info("Deleting unrecoverable instance", "podName", podName)
-	r.Recorder.Eventf(cluster, "Normal", "DeleteUnrecoverableInstance",
-		"Deleting unrecoverable instance %v (pods and PVCs)", podName)
 
 	// A graceful delete is a no-op on a Pod that is already Terminating, so a Pod
 	// stuck past its own deletion deadline would never be removed and its PVCs
 	// (blocked by the pvc-protection finalizer) could never be deleted. Force-remove
 	// such a Pod first so that ensureInstanceIsDeleted below can make progress.
-	if pod := findInstancePodByName(resources, podName); pod != nil && isPodStuckTerminating(pod) {
+	if pod := findInstancePodByName(resources, podName); pod != nil && utils.IsPodStuckTerminating(pod) {
 		logger.Info(
 			"Force-removing unrecoverable instance stuck past its deletion deadline",
 			"podName", podName,
@@ -74,6 +72,9 @@ func (r *ClusterReconciler) reconcileUnrecoverableInstances(
 		return ctrl.Result{}, err
 	}
 
+	r.Recorder.Eventf(cluster, "Normal", "DeleteUnrecoverableInstance",
+		"Deleted unrecoverable instance %v (pods and PVCs)", podName)
+
 	return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 }
 
@@ -86,16 +87,6 @@ func findInstancePodByName(resources *managedResources, name string) *corev1.Pod
 		}
 	}
 	return nil
-}
-
-// isPodStuckTerminating reports whether a Pod has been asked to terminate but is
-// still present past its own deletion deadline. DeletionTimestamp is the moment
-// (deletion request time plus the termination grace period) at which the object
-// is expected to be gone. A Pod that lingers past it has already been given its
-// entire termination budget, so it will not disappear on another graceful delete
-// and has to be force-removed.
-func isPodStuckTerminating(pod *corev1.Pod) bool {
-	return pod.DeletionTimestamp != nil && time.Now().After(pod.DeletionTimestamp.Time)
 }
 
 func collectNamesOfUnrecoverableInstances(

--- a/internal/controller/cluster_unrecoverable_test.go
+++ b/internal/controller/cluster_unrecoverable_test.go
@@ -20,15 +20,69 @@ SPDX-License-Identifier: Apache-2.0
 package controller
 
 import (
+	"context"
+	"time"
+
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	schemeBuilder "github.com/cloudnative-pg/cloudnative-pg/internal/scheme"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/postgres"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
+
+// newUnrecoverableReconciler builds a ClusterReconciler backed by a fake client.
+// The job owner index is required because the deletion path lists the instance
+// jobs; the interceptor lets tests observe the delete options passed to the client.
+func newUnrecoverableReconciler(
+	interceptorFuncs interceptor.Funcs,
+	initObjs ...client.Object,
+) (*ClusterReconciler, *record.FakeRecorder) {
+	scheme := schemeBuilder.BuildWithAllKnownScheme()
+	recorder := record.NewFakeRecorder(120)
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&apiv1.Cluster{}).
+		WithIndex(&batchv1.Job{}, jobOwnerKey, jobOwnerIndexFunc).
+		WithInterceptorFuncs(interceptorFuncs).
+		WithObjects(initObjs...).
+		Build()
+
+	return &ClusterReconciler{
+		Client:   fakeClient,
+		Scheme:   scheme,
+		Recorder: recorder,
+	}, recorder
+}
+
+// unrecoverablePod builds an instance pod annotated as unrecoverable in the given
+// phase. A non-nil deletionTime marks the pod as Terminating with that deadline.
+func unrecoverablePod(name string, phase corev1.PodPhase, deletionTime *metav1.Time) corev1.Pod {
+	return corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+			Annotations: map[string]string{
+				utils.UnrecoverableInstanceAnnotationName: "true",
+			},
+			DeletionTimestamp: deletionTime,
+		},
+		Status: corev1.PodStatus{
+			Phase: phase,
+		},
+	}
+}
 
 var _ = Describe("Unrecoverable replicas", func() {
 	DescribeTable(
@@ -182,4 +236,213 @@ var _ = Describe("Unrecoverable replicas", func() {
 
 		Expect(result).To(ConsistOf("cluster-example-2"))
 	})
+
+	DescribeTable(
+		"Protects the primary even when it is not active",
+		func(ctx SpecContext, primaryField string, phase corev1.PodPhase, deletionTime *metav1.Time) {
+			cluster := &apiv1.Cluster{
+				Spec: apiv1.ClusterSpec{Instances: 2},
+				Status: apiv1.ClusterStatus{
+					CurrentPrimary: "cluster-example-2",
+					TargetPrimary:  "cluster-example-2",
+				},
+			}
+			if primaryField == "target" {
+				cluster.Status.CurrentPrimary = "cluster-example-1"
+			}
+
+			// The protected primary is annotated unrecoverable and in a non-active state
+			protectedPrimary := unrecoverablePod("cluster-example-2", phase, deletionTime)
+			// A plain unrecoverable replica that must still be collected
+			replica := unrecoverablePod("cluster-example-3", corev1.PodPending, nil)
+
+			result := collectNamesOfUnrecoverableInstances(
+				ctx,
+				cluster,
+				&managedResources{
+					instances: corev1.PodList{
+						Items: []corev1.Pod{protectedPrimary, replica},
+					},
+				},
+			)
+
+			Expect(result).To(ConsistOf("cluster-example-3"))
+			Expect(result).NotTo(ContainElement("cluster-example-2"))
+		},
+		Entry("current primary, Pending", "current", corev1.PodPending, nil),
+		Entry("current primary, Terminating", "current", corev1.PodRunning,
+			&metav1.Time{Time: time.Now().Add(-time.Minute)}),
+		Entry("target primary, Pending", "target", corev1.PodPending, nil),
+		Entry("target primary, Terminating", "target", corev1.PodRunning,
+			&metav1.Time{Time: time.Now().Add(-time.Minute)}),
+	)
+
+	It("Deletes an annotated Pending instance", func(ctx SpecContext) {
+		pendingPod := unrecoverablePod("cluster-example-2", corev1.PodPending, nil)
+		cluster := &apiv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{Name: "cluster-example", Namespace: "default"},
+			Status: apiv1.ClusterStatus{
+				CurrentPrimary: "cluster-example-1",
+				TargetPrimary:  "cluster-example-1",
+			},
+		}
+
+		r, recorder := newUnrecoverableReconciler(interceptor.Funcs{}, &pendingPod)
+		resources := &managedResources{
+			instances: corev1.PodList{Items: []corev1.Pod{pendingPod}},
+		}
+
+		Expect(collectNamesOfUnrecoverableInstances(ctx, cluster, resources)).
+			To(ConsistOf("cluster-example-2"))
+
+		result, err := r.reconcileUnrecoverableInstances(ctx, cluster, resources)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result.RequeueAfter).To(Equal(5 * time.Second))
+
+		// The Pending pod has been deleted
+		var fetched corev1.Pod
+		err = r.Get(ctx, client.ObjectKeyFromObject(&pendingPod), &fetched)
+		Expect(apierrors.IsNotFound(err)).To(BeTrue())
+
+		// An observability event has been recorded
+		Expect(recorder.Events).To(Receive(ContainSubstring("DeleteUnrecoverableInstance")))
+	})
+
+	It("Force-removes an annotated Terminating instance past its deadline", func(ctx SpecContext) {
+		const podName = "cluster-example-2"
+		stuckPod := unrecoverablePod(podName, corev1.PodRunning, &metav1.Time{Time: time.Now().Add(-time.Minute)})
+		cluster := &apiv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{Name: "cluster-example", Namespace: "default"},
+			Status: apiv1.ClusterStatus{
+				CurrentPrimary: "cluster-example-1",
+				TargetPrimary:  "cluster-example-1",
+			},
+		}
+
+		forceDeleteCount := 0
+		r, _ := newUnrecoverableReconciler(interceptor.Funcs{
+			Delete: func(
+				ctx context.Context,
+				c client.WithWatch,
+				obj client.Object,
+				opts ...client.DeleteOption,
+			) error {
+				if pod, ok := obj.(*corev1.Pod); ok && pod.Name == podName {
+					deleteOpts := client.DeleteOptions{}
+					deleteOpts.ApplyOptions(opts)
+					if deleteOpts.GracePeriodSeconds != nil && *deleteOpts.GracePeriodSeconds == 0 {
+						forceDeleteCount++
+					}
+				}
+				return c.Delete(ctx, obj, opts...)
+			},
+		})
+		resources := &managedResources{
+			instances: corev1.PodList{Items: []corev1.Pod{stuckPod}},
+		}
+
+		result, err := r.reconcileUnrecoverableInstances(ctx, cluster, resources)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result.RequeueAfter).To(Equal(5 * time.Second))
+
+		// Exactly one grace-period-zero delete has been issued for the stuck pod
+		Expect(forceDeleteCount).To(Equal(1))
+	})
+
+	It("Does not force-remove a Terminating instance still within its deadline", func(ctx SpecContext) {
+		const podName = "cluster-example-2"
+		terminatingPod := unrecoverablePod(podName, corev1.PodRunning, &metav1.Time{Time: time.Now().Add(time.Hour)})
+		cluster := &apiv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{Name: "cluster-example", Namespace: "default"},
+			Status: apiv1.ClusterStatus{
+				CurrentPrimary: "cluster-example-1",
+				TargetPrimary:  "cluster-example-1",
+			},
+		}
+
+		forceDeleteCount := 0
+		podDeleteCount := 0
+		r, _ := newUnrecoverableReconciler(interceptor.Funcs{
+			Delete: func(
+				ctx context.Context,
+				c client.WithWatch,
+				obj client.Object,
+				opts ...client.DeleteOption,
+			) error {
+				if pod, ok := obj.(*corev1.Pod); ok && pod.Name == podName {
+					podDeleteCount++
+					deleteOpts := client.DeleteOptions{}
+					deleteOpts.ApplyOptions(opts)
+					if deleteOpts.GracePeriodSeconds != nil && *deleteOpts.GracePeriodSeconds == 0 {
+						forceDeleteCount++
+					}
+				}
+				return c.Delete(ctx, obj, opts...)
+			},
+		})
+		resources := &managedResources{
+			instances: corev1.PodList{Items: []corev1.Pod{terminatingPod}},
+		}
+
+		result, err := r.reconcileUnrecoverableInstances(ctx, cluster, resources)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result.RequeueAfter).To(Equal(5 * time.Second))
+
+		// The pod is still handled (a graceful delete is issued) but never force-removed
+		Expect(podDeleteCount).To(BeNumerically(">", 0))
+		Expect(forceDeleteCount).To(Equal(0))
+	})
+
+	It("Deletes an annotated Pending instance even when not all instances are active", func(ctx SpecContext) {
+		// This pins the gate-ordering fix: with a single Pending instance
+		// allInstancesAreActive() is false, which used to make reconcileResources
+		// return before the unrecoverable handling could run.
+		pendingPod := unrecoverablePod("cluster-example-2", corev1.PodPending, nil)
+		cluster := &apiv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{Name: "cluster-example", Namespace: "default"},
+			Spec: apiv1.ClusterSpec{
+				ImageName: "postgres:17.2",
+				Instances: 1,
+			},
+			Status: apiv1.ClusterStatus{
+				CurrentPrimary: "cluster-example-1",
+				TargetPrimary:  "cluster-example-1",
+			},
+		}
+
+		r, _ := newUnrecoverableReconciler(interceptor.Funcs{}, cluster, &pendingPod)
+		resources := &managedResources{
+			instances: corev1.PodList{Items: []corev1.Pod{pendingPod}},
+		}
+
+		// Precondition of the bug: the gate would otherwise short-circuit here.
+		// The cluster is seeded so the pre-fix gate path (RegisterPhase) would run
+		// cleanly and this test would fail on the substantive assertions below.
+		Expect(resources.allInstancesAreActive()).To(BeFalse())
+
+		result, err := r.reconcileResources(ctx, cluster, resources, postgres.PostgresqlStatusList{})
+		Expect(err).ToNot(HaveOccurred())
+
+		// The unrecoverable handling ran (5s requeue) rather than the active-instances
+		// gate (1s requeue), and the Pending pod has been deleted.
+		Expect(result).To(Equal(ctrl.Result{RequeueAfter: 5 * time.Second}))
+		Expect(cluster.Status.Phase).ToNot(Equal(apiv1.PhaseWaitingForInstancesToBeActive))
+
+		var fetched corev1.Pod
+		err = r.Get(ctx, client.ObjectKeyFromObject(&pendingPod), &fetched)
+		Expect(apierrors.IsNotFound(err)).To(BeTrue())
+	})
+
+	DescribeTable(
+		"isPodStuckTerminating",
+		func(deletionTime *metav1.Time, expected bool) {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{DeletionTimestamp: deletionTime},
+			}
+			Expect(isPodStuckTerminating(pod)).To(Equal(expected))
+		},
+		Entry("no deletion timestamp", nil, false),
+		Entry("deletion deadline in the past", &metav1.Time{Time: time.Now().Add(-time.Minute)}, true),
+		Entry("deletion deadline in the future", &metav1.Time{Time: time.Now().Add(time.Hour)}, false),
+	)
 })

--- a/internal/controller/cluster_unrecoverable_test.go
+++ b/internal/controller/cluster_unrecoverable_test.go
@@ -432,17 +432,4 @@ var _ = Describe("Unrecoverable replicas", func() {
 		err = r.Get(ctx, client.ObjectKeyFromObject(&pendingPod), &fetched)
 		Expect(apierrors.IsNotFound(err)).To(BeTrue())
 	})
-
-	DescribeTable(
-		"isPodStuckTerminating",
-		func(deletionTime *metav1.Time, expected bool) {
-			pod := &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{DeletionTimestamp: deletionTime},
-			}
-			Expect(isPodStuckTerminating(pod)).To(Equal(expected))
-		},
-		Entry("no deletion timestamp", nil, false),
-		Entry("deletion deadline in the past", &metav1.Time{Time: time.Now().Add(-time.Minute)}, true),
-		Entry("deletion deadline in the future", &metav1.Time{Time: time.Now().Add(time.Hour)}, false),
-	)
 })

--- a/pkg/utils/pod_conditions.go
+++ b/pkg/utils/pod_conditions.go
@@ -20,6 +20,8 @@ SPDX-License-Identifier: Apache-2.0
 package utils
 
 import (
+	"time"
+
 	"github.com/cloudnative-pg/machinery/pkg/log"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -102,6 +104,16 @@ func IsPodAlive(p corev1.Pod) bool {
 		}
 	}
 	return IsPodActive(p)
+}
+
+// IsPodStuckTerminating reports whether a Pod has been asked to terminate but is
+// still present past its own deletion deadline. The API server sets
+// DeletionTimestamp to the deletion request time plus the termination grace
+// period, so the grace period is already accounted for in the value. A Pod that
+// is still around after that instant has already been given its entire
+// termination budget.
+func IsPodStuckTerminating(pod *corev1.Pod) bool {
+	return pod.DeletionTimestamp != nil && time.Now().After(pod.DeletionTimestamp.Time)
 }
 
 // FilterActivePods returns pods that have not terminated.

--- a/pkg/utils/pod_conditions_test.go
+++ b/pkg/utils/pod_conditions_test.go
@@ -20,6 +20,8 @@ SPDX-License-Identifier: Apache-2.0
 package utils
 
 import (
+	"time"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -183,4 +185,17 @@ var _ = Describe("Pod conditions test suite", func() {
 		}
 		Expect(IsPodUnschedulable(pod)).To(BeFalse())
 	})
+
+	DescribeTable(
+		"IsPodStuckTerminating",
+		func(deletionTime *metav1.Time, expected bool) {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{DeletionTimestamp: deletionTime},
+			}
+			Expect(IsPodStuckTerminating(pod)).To(Equal(expected))
+		},
+		Entry("no deletion timestamp", nil, false),
+		Entry("deletion deadline in the past", &metav1.Time{Time: time.Now().Add(-time.Minute)}, true),
+		Entry("deletion deadline in the future", &metav1.Time{Time: time.Now().Add(time.Hour)}, false),
+	)
 })

--- a/tests/e2e/unrecoverable_pending_instance_test.go
+++ b/tests/e2e/unrecoverable_pending_instance_test.go
@@ -1,0 +1,201 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package e2e
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
+	"github.com/cloudnative-pg/cloudnative-pg/tests"
+	clusterasserts "github.com/cloudnative-pg/cloudnative-pg/tests/internal/asserts/cluster"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/clusterutils"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/nodes"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/objects"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/pods"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/run"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/storage"
+	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/timeouts"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// This test covers the unrecoverable annotation on an instance that is stuck
+// Pending. The healthy-Running case lives in destroy_instance_test.go; here we
+// force a Pending instance by cordoning the node its PVC is pinned to, which is
+// the state that the active-instances gate used to short-circuit.
+var _ = Describe("Unrecoverable pending instance", Serial,
+	Label(tests.LabelDisruptive, tests.LabelMaintenance), func() {
+		const (
+			level           = tests.High
+			namespacePrefix = "unrecoverable-pending"
+			sampleFile      = fixturesDir + "/base/cluster-storage-class.yaml.template"
+			clusterName     = "postgresql-storage-class"
+		)
+		var namespace string
+
+		BeforeEach(func() {
+			if testLevelEnv.Depth < int(level) {
+				Skip("Test depth is lower than the amount requested for this test")
+			}
+		})
+
+		AfterEach(func() {
+			// Always uncordon, even on failure, so a cordoned node does not leak
+			// into other specs.
+			err := nodes.UncordonAll(env.Ctx, env.Client)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("honors the annotation on a Pending instance", func() {
+			collectPVCUIDs := func(instanceName string) map[string]string {
+				GinkgoHelper()
+				pvcs, err := storage.GetPVCList(env.Ctx, env.Client, namespace)
+				Expect(err).ToNot(HaveOccurred(), "failed to list PVCs")
+
+				result := map[string]string{}
+				for i := range pvcs.Items {
+					if pvcs.Items[i].Labels[utils.InstanceNameLabelName] == instanceName {
+						result[pvcs.Items[i].Name] = string(pvcs.Items[i].UID)
+					}
+				}
+				return result
+			}
+
+			By("creating a CNPG cluster", func() {
+				var err error
+				namespace, err = env.CreateUniqueTestNamespace(env.Ctx, env.Client, namespacePrefix)
+				Expect(err).ToNot(HaveOccurred())
+				clusterasserts.AssertCreateCluster(env, testTimeouts, namespace, clusterName, sampleFile)
+			})
+
+			var instanceName, cordonedNode string
+			var originalPVCUIDs map[string]string
+
+			By("cordoning a replica's node and deleting the replica pod", func() {
+				replicas, err := clusterutils.GetReplicas(env.Ctx, env.Client, namespace, clusterName)
+				Expect(err).ToNot(HaveOccurred(), "failed to get the list of replicas")
+				Expect(replicas.Items).ToNot(BeEmpty())
+
+				instanceName = replicas.Items[0].Name
+				cordonedNode = replicas.Items[0].Spec.NodeName
+				Expect(cordonedNode).ToNot(BeEmpty())
+
+				originalPVCUIDs = collectPVCUIDs(instanceName)
+				Expect(originalPVCUIDs).ToNot(BeEmpty(), "expected at least one PVC for the instance")
+
+				// Cordoning the node makes it unschedulable. The instance's PVs are
+				// pinned to it (local-path with WaitForFirstConsumer), so the pod
+				// recreated after the deletion below cannot be scheduled anywhere and
+				// stays Pending.
+				_, _, err = run.Run(fmt.Sprintf("kubectl cordon %v", cordonedNode))
+				Expect(err).ToNot(HaveOccurred())
+
+				err = pods.Delete(env.Ctx, env.Client, namespace, instanceName)
+				Expect(err).ToNot(HaveOccurred(), "failed to delete the replica pod")
+			})
+
+			By("waiting for the instance to be stuck Pending", func() {
+				Eventually(func(g Gomega) {
+					var pod corev1.Pod
+					err := env.Client.Get(env.Ctx,
+						types.NamespacedName{Namespace: namespace, Name: instanceName}, &pod)
+					g.Expect(err).ToNot(HaveOccurred())
+					// Make sure this is the recreated pod, not the one being deleted.
+					g.Expect(pod.DeletionTimestamp).To(BeNil())
+					g.Expect(pod.Status.Phase).To(Equal(corev1.PodPending))
+				}, 180).Should(Succeed())
+			})
+
+			By("marking the Pending instance as unrecoverable", func() {
+				var pod corev1.Pod
+				err := env.Client.Get(env.Ctx,
+					types.NamespacedName{Namespace: namespace, Name: instanceName}, &pod)
+				Expect(err).ToNot(HaveOccurred(), "failed to get the Pending pod")
+
+				originalPod := pod.DeepCopy()
+				if pod.Annotations == nil {
+					pod.Annotations = map[string]string{}
+				}
+				pod.Annotations[utils.UnrecoverableInstanceAnnotationName] = "true"
+
+				err = objects.Patch(env.Ctx, env.Client, &pod, ctrlclient.MergeFrom(originalPod))
+				Expect(err).ToNot(HaveOccurred(),
+					"failed to patch the pod with the unrecoverable annotation")
+			})
+
+			By("recording a DeleteUnrecoverableInstance event on the Cluster", func() {
+				Eventually(func(g Gomega) {
+					eventList := corev1.EventList{}
+					err := env.Client.List(env.Ctx, &eventList,
+						ctrlclient.InNamespace(namespace),
+						ctrlclient.MatchingFields{
+							"involvedObject.kind": "Cluster",
+							"involvedObject.name": clusterName,
+						})
+					g.Expect(err).ToNot(HaveOccurred())
+
+					reasons := make([]string, 0, len(eventList.Items))
+					for i := range eventList.Items {
+						reasons = append(reasons, eventList.Items[i].Reason)
+					}
+					g.Expect(reasons).To(ContainElement("DeleteUnrecoverableInstance"))
+				}, 180).Should(Succeed())
+			})
+
+			By("recreating the instance PVCs with fresh UIDs", func() {
+				// The instance keeps its name (serials are reused), so each PVC must
+				// come back under the same name with a fresh UID. Checking the full
+				// set guards against leaks of secondary PVCs (wal) that share only the
+				// instance label.
+				Eventually(func(g Gomega) {
+					currentUIDs := collectPVCUIDs(instanceName)
+					g.Expect(currentUIDs).To(HaveLen(len(originalPVCUIDs)))
+					for name, originalUID := range originalPVCUIDs {
+						currentUID, ok := currentUIDs[name]
+						g.Expect(ok).To(BeTrue(),
+							"expected PVC %q to exist after recreation", name)
+						g.Expect(currentUID).ToNot(Equal(originalUID),
+							"PVC %q kept its original UID instead of being recreated", name)
+					}
+				}, 300).Should(Succeed())
+			})
+
+			By("scheduling the recreated instance onto a schedulable node", func() {
+				Eventually(func(g Gomega) {
+					var pod corev1.Pod
+					err := env.Client.Get(env.Ctx,
+						types.NamespacedName{Namespace: namespace, Name: instanceName}, &pod)
+					g.Expect(err).ToNot(HaveOccurred())
+					g.Expect(pod.Status.Phase).To(Equal(corev1.PodRunning))
+					g.Expect(pod.Spec.NodeName).ToNot(Equal(cordonedNode))
+				}, 300).Should(Succeed())
+			})
+
+			By("bringing the cluster back to healthy", func() {
+				clusterasserts.AssertClusterIsReady(env, namespace, clusterName,
+					testTimeouts[timeouts.ClusterIsReady])
+			})
+		})
+	})


### PR DESCRIPTION
The alpha.cnpg.io/unrecoverable annotation deletes an instance's Pod and PVCs so the instance is recreated, but it did nothing while the Pod was Pending or Terminating. reconcileResources returns early at the active-instances gate whenever an instance is not active, and the unrecoverable handling lived downstream of that gate (in reconcilePods), so it was never reached for exactly the states where a stuck instance most needs it. A Terminating Pod needs more than reaching the delete: a graceful delete is a no-op on it, so its PVCs stay blocked by the pvc-protection finalizer.

This moves the unrecoverable handling ahead of the active-instances gate, alongside the unschedulable-instances handling that already runs there for the same structural reason. A Pod stuck Terminating past its deletion deadline is force-removed first so its PVCs can be released, and deleting an unrecoverable instance now emits a Kubernetes event. The current primary and the designated target primary stay excluded in every state.

Closes #10926