### PR TITLE
fix: recover log streaming when a stale non-FIFO blocks the log pipe

### DIFF
--- a/internal/cmd/manager/instance/run/cmd.go
+++ b/internal/cmd/manager/instance/run/cmd.go
@@ -333,6 +333,14 @@ func runSubCommand( //nolint: gocyclo,gocognit
 	postgresStartConditions = append(postgresStartConditions, jsonPipe.GetExecutedCondition())
 	exitedConditions = append(exitedConditions, jsonPipe.GetExitedCondition())
 
+	// Give Rewind the same log-pipe readiness conditions, so pg_rewind
+	// never races these readers for the log-destination FIFOs.
+	instance.SetLogPipesReadyCondition(concurrency.MultipleExecuted{
+		postgresLogPipe.GetInitializedCondition(),
+		rawPipe.GetExecutedCondition(),
+		jsonPipe.GetExecutedCondition(),
+	})
+
 	if err := instancestorage.ReconcileWalDirectory(ctx); err != nil {
 		contextLogger.Error(err, "unable to move `pg_wal` directory to the attached volume")
 		return err

--- a/internal/cmd/manager/instance/run/cmd.go
+++ b/internal/cmd/manager/instance/run/cmd.go
@@ -271,7 +271,7 @@ func runSubCommand( //nolint: gocyclo,gocognit
 		contextLogger.Error(err, "unable to create instance controller")
 		return err
 	}
-	postgresStartConditions = append(postgresStartConditions, reconciler.GetExecutedCondition())
+	postgresStartConditions = append(postgresStartConditions, reconciler.GetInitializedCondition())
 
 	// database reconciler
 	dbReconciler := controller.NewDatabaseReconciler(
@@ -321,7 +321,7 @@ func runSubCommand( //nolint: gocyclo,gocognit
 		contextLogger.Error(err, "unable to add raw logs handler")
 		return err
 	}
-	postgresStartConditions = append(postgresStartConditions, rawPipe.GetExecutedCondition())
+	postgresStartConditions = append(postgresStartConditions, rawPipe.GetInitializedCondition())
 	exitedConditions = append(exitedConditions, rawPipe.GetExitedCondition())
 
 	// json logs handler
@@ -330,15 +330,16 @@ func runSubCommand( //nolint: gocyclo,gocognit
 		contextLogger.Error(err, "unable to add JSON logs handler")
 		return err
 	}
-	postgresStartConditions = append(postgresStartConditions, jsonPipe.GetExecutedCondition())
+	postgresStartConditions = append(postgresStartConditions, jsonPipe.GetInitializedCondition())
 	exitedConditions = append(exitedConditions, jsonPipe.GetExitedCondition())
 
-	// Give Rewind the same log-pipe readiness conditions, so pg_rewind
-	// never races these readers for the log-destination FIFOs.
+	// Record these readiness conditions on the instance, so the reconciler can
+	// wait on them before pg_rewind's restore_command or a WAL-archive plugin
+	// invocation could race these readers for the log-destination FIFOs.
 	instance.SetLogPipesReadyCondition(concurrency.MultipleExecuted{
 		postgresLogPipe.GetInitializedCondition(),
-		rawPipe.GetExecutedCondition(),
-		jsonPipe.GetExecutedCondition(),
+		rawPipe.GetInitializedCondition(),
+		jsonPipe.GetInitializedCondition(),
 	})
 
 	if err := instancestorage.ReconcileWalDirectory(ctx); err != nil {

--- a/internal/management/controller/instance_startup.go
+++ b/internal/management/controller/instance_startup.go
@@ -126,7 +126,10 @@ func (r *InstanceReconciler) verifyPgDataCoherenceForPrimary(ctx context.Context
 				err, "Error while changing mode of the postgresql.auto.conf file before pg_rewind, skipped")
 		}
 
-		// Ensure the FIFO is created by logpipes before calling archive_command/restore_command
+		// Wait for the log-destination FIFOs before pg_rewind's restore_command
+		// (which shells out and writes there) runs, and before invoking any
+		// WAL-archive plugin below, since a third-party plugin's internals
+		// aren't ours to assume about.
 		r.instance.WaitForLogPipesReady()
 
 		// We archive every WAL that have not been archived from the latest postmaster invocation.

--- a/internal/management/controller/instance_startup.go
+++ b/internal/management/controller/instance_startup.go
@@ -126,6 +126,9 @@ func (r *InstanceReconciler) verifyPgDataCoherenceForPrimary(ctx context.Context
 				err, "Error while changing mode of the postgresql.auto.conf file before pg_rewind, skipped")
 		}
 
+		// Ensure the FIFO is created by logpipes before calling archive_command/restore_command
+		r.instance.WaitForLogPipesReady()
+
 		// We archive every WAL that have not been archived from the latest postmaster invocation.
 		if err := archiver.ArchiveAllReadyWALs(ctx, cluster, r.instance.PgData); err != nil {
 			var missingPluginError archiver.ErrMissingWALArchiverPlugin

--- a/internal/management/controller/manager.go
+++ b/internal/management/controller/manager.go
@@ -91,9 +91,9 @@ func NewInstanceReconciler(
 	}
 }
 
-// GetExecutedCondition returns the condition that can be checked in order to
+// GetInitializedCondition returns the condition that can be checked in order to
 // be sure initialization has been done
-func (r *InstanceReconciler) GetExecutedCondition() *concurrency.Executed {
+func (r *InstanceReconciler) GetInitializedCondition() *concurrency.Executed {
 	return r.systemInitialization
 }
 

--- a/pkg/management/postgres/instance.go
+++ b/pkg/management/postgres/instance.go
@@ -310,9 +310,14 @@ func (instance *Instance) SetCanCheckReadiness(enabled bool) {
 }
 
 // SetLogPipesReadyCondition records the conditions that indicate when the log-destination
-// FIFOs are ready. PGRewind waits on this condition as pg_rewind invokes restore_command.
+// FIFOs are ready.
 func (instance *Instance) SetLogPipesReadyCondition(conditions concurrency.MultipleExecuted) {
 	instance.logPipesReady = conditions
+}
+
+// WaitForLogPipesReady waits until the log-destination FIFOs are ready.
+func (instance *Instance) WaitForLogPipesReady() {
+	instance.logPipesReady.Wait()
 }
 
 // GetClusterOrDefault returns the cached cluster, or an empty cluster if not set.
@@ -1274,10 +1279,6 @@ func pgRewindShouldRetry(ctx context.Context, _ error) bool {
 // segment that was already recycled locally
 func (instance *Instance) Rewind(ctx context.Context) error {
 	contextLogger := log.FromContext(ctx)
-
-	// pg_rewind invokes restore_command, wait for the log-destination FIFOs
-	// to be ready first here.
-	instance.logPipesReady.Wait()
 
 	// Signal the liveness probe that we are running pg_rewind before starting postgres
 	instance.PgRewindIsRunning = true

--- a/pkg/management/postgres/instance.go
+++ b/pkg/management/postgres/instance.go
@@ -877,8 +877,8 @@ func (instance *Instance) WithActiveInstance(inner func() error) error {
 	// a regular file at the log path first.
 	concurrency.MultipleExecuted{
 		csvPipe.GetInitializedCondition(),
-		rawPipe.GetExecutedCondition(),
-		jsonPipe.GetExecutedCondition(),
+		rawPipe.GetInitializedCondition(),
+		jsonPipe.GetInitializedCondition(),
 	}.Wait()
 
 	err := instance.Startup()

--- a/pkg/management/postgres/instance.go
+++ b/pkg/management/postgres/instance.go
@@ -201,6 +201,9 @@ type Instance struct {
 	// PgRewindIsRunning tells if there is a `pg_rewind` process running
 	PgRewindIsRunning bool
 
+	// logPipesReady becomes satisfied once the log-destination FIFOs are ready.
+	logPipesReady concurrency.MultipleExecuted
+
 	// canCheckReadiness specifies whether the instance can start being checked for readiness
 	// Is set to true before the instance is run and to false once it exits,
 	// it's used by the readiness probe to know whether it should be short-circuited
@@ -304,6 +307,12 @@ func (instance *Instance) SetFencing(enabled bool) {
 // SetCanCheckReadiness marks whether the instance should be checked for readiness
 func (instance *Instance) SetCanCheckReadiness(enabled bool) {
 	instance.canCheckReadiness.Store(enabled)
+}
+
+// SetLogPipesReadyCondition records the conditions that indicate when the log-destination
+// FIFOs are ready. PGRewind waits on this condition as pg_rewind invokes restore_command.
+func (instance *Instance) SetLogPipesReadyCondition(conditions concurrency.MultipleExecuted) {
+	instance.logPipesReady = conditions
 }
 
 // GetClusterOrDefault returns the cached cluster, or an empty cluster if not set.
@@ -1265,6 +1274,10 @@ func pgRewindShouldRetry(ctx context.Context, _ error) bool {
 // segment that was already recycled locally
 func (instance *Instance) Rewind(ctx context.Context) error {
 	contextLogger := log.FromContext(ctx)
+
+	// pg_rewind invokes restore_command, wait for the log-destination FIFOs
+	// to be ready first here.
+	instance.logPipesReady.Wait()
 
 	// Signal the liveness probe that we are running pg_rewind before starting postgres
 	instance.PgRewindIsRunning = true

--- a/pkg/management/postgres/instance.go
+++ b/pkg/management/postgres/instance.go
@@ -51,6 +51,7 @@ import (
 	"k8s.io/client-go/util/retry"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/concurrency"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres/logpipe"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres/pool"
 	postgresutils "github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres/utils"
@@ -856,6 +857,15 @@ func (instance *Instance) WithActiveInstance(inner func() error) error {
 		rawPipe.GetExitedCondition().Wait()
 		jsonPipe.GetExitedCondition().Wait()
 	}()
+
+	// Wait for every reader to have its FIFO created here.
+	// To avoid the archive/restore command win the race and create
+	// a regular file at the log path first.
+	concurrency.MultipleExecuted{
+		csvPipe.GetInitializedCondition(),
+		rawPipe.GetExecutedCondition(),
+		jsonPipe.GetExecutedCondition(),
+	}.Wait()
 
 	err := instance.Startup()
 	if err != nil {

--- a/pkg/management/postgres/logpipe/fifo.go
+++ b/pkg/management/postgres/logpipe/fifo.go
@@ -1,0 +1,72 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package logpipe
+
+import (
+	"context"
+	"errors"
+	"os"
+	"time"
+
+	"github.com/cloudnative-pg/machinery/pkg/fileutils/compatibility"
+	"github.com/cloudnative-pg/machinery/pkg/log"
+)
+
+// retryBackoff is the delay observed by the log pipe loops between a failed
+// attempt (directory missing, FIFO creation, or log streaming) and the next
+// one, to avoid busy-spinning and flooding the logs when the error persists.
+const retryBackoff = time.Second
+
+// ensureLogFifo makes sure a FIFO exists at fileName, creating it if needed.
+// If a filesystem entry already exists at that path but isn't a FIFO (e.g. a
+// wal-archive/wal-restore invocation created a regular file there before the
+// reader had a chance to create the FIFO), it is removed so the FIFO can be
+// created on a following call. The removal is racy: an in-flight writer
+// keeping the old inode open loses its buffered lines, but the next writer
+// invocation opens the freshly created FIFO. This is convergent and
+// acceptable, and is not something we try to eliminate further.
+func ensureLogFifo(logger log.Logger, fileName string) error {
+	err := compatibility.CreateFifo(fileName)
+	if err == nil {
+		return nil
+	}
+
+	if errors.Is(err, compatibility.ErrExistsNotFifo) {
+		logger.Warning("Log FIFO path held by a non-FIFO entry; removing it to restore log streaming")
+		if rmErr := os.Remove(fileName); rmErr != nil {
+			logger.Error(rmErr, "Failed to remove stale non-FIFO log path")
+		}
+		return err
+	}
+
+	logger.Error(err, "Error creating log FIFO")
+	return err
+}
+
+// waitBeforeRetry pauses for retryBackoff before a loop retries after an
+// error, returning early if the context is cancelled in the meantime.
+func waitBeforeRetry(ctx context.Context) {
+	timer := time.NewTimer(retryBackoff)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+	case <-timer.C:
+	}
+}

--- a/pkg/management/postgres/logpipe/fifo_test.go
+++ b/pkg/management/postgres/logpipe/fifo_test.go
@@ -1,0 +1,150 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package logpipe
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/cloudnative-pg/machinery/pkg/fileutils/compatibility"
+	"github.com/cloudnative-pg/machinery/pkg/log"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func isFifo(path string) bool {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return false
+	}
+	return info.Mode()&os.ModeNamedPipe != 0
+}
+
+var _ = Describe("ensureLogFifo", func() {
+	var (
+		dir      string
+		fileName string
+		logger   log.Logger
+	)
+
+	BeforeEach(func() {
+		dir = GinkgoT().TempDir()
+		fileName = filepath.Join(dir, "postgres.json")
+		logger = log.FromContext(context.Background())
+	})
+
+	When("no filesystem entry exists at the path", func() {
+		It("creates a FIFO", func() {
+			Expect(ensureLogFifo(logger, fileName)).To(Succeed())
+			Expect(isFifo(fileName)).To(BeTrue())
+		})
+	})
+
+	When("a FIFO already exists at the path", func() {
+		It("succeeds without touching it", func() {
+			Expect(ensureLogFifo(logger, fileName)).To(Succeed())
+			info, err := os.Lstat(fileName)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(ensureLogFifo(logger, fileName)).To(Succeed())
+			infoAfter, err := os.Lstat(fileName)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(infoAfter.ModTime()).To(Equal(info.ModTime()))
+		})
+	})
+
+	When("a stale regular file is planted at the path (the #11201 scenario)", func() {
+		It("reports ErrExistsNotFifo and removes the stale file, so a following call creates the FIFO", func() {
+			Expect(os.WriteFile(fileName, []byte("not a fifo"), 0o600)).To(Succeed())
+
+			err := ensureLogFifo(logger, fileName)
+			Expect(err).To(HaveOccurred())
+			Expect(errors.Is(err, compatibility.ErrExistsNotFifo)).To(BeTrue())
+
+			_, statErr := os.Lstat(fileName)
+			Expect(os.IsNotExist(statErr)).To(BeTrue())
+
+			Expect(ensureLogFifo(logger, fileName)).To(Succeed())
+			Expect(isFifo(fileName)).To(BeTrue())
+		})
+	})
+
+	When("a symlink points at a genuine FIFO (Lstat is not followed)", func() {
+		It("removes the symlink itself, leaving the target FIFO untouched", func() {
+			targetFifo := filepath.Join(dir, "target.fifo")
+			Expect(ensureLogFifo(logger, targetFifo)).To(Succeed())
+			Expect(isFifo(targetFifo)).To(BeTrue())
+
+			symlinkPath := filepath.Join(dir, "postgres.json")
+			Expect(os.Symlink(targetFifo, symlinkPath)).To(Succeed())
+
+			err := ensureLogFifo(logger, symlinkPath)
+			Expect(err).To(HaveOccurred())
+			Expect(errors.Is(err, compatibility.ErrExistsNotFifo)).To(BeTrue())
+
+			// the symlink name is gone...
+			_, statErr := os.Lstat(symlinkPath)
+			Expect(os.IsNotExist(statErr)).To(BeTrue())
+
+			// ...but the FIFO it pointed to is untouched
+			Expect(isFifo(targetFifo)).To(BeTrue())
+		})
+	})
+
+	When("the parent directory does not exist", func() {
+		It("returns an error without attempting to remove anything", func() {
+			missingParent := filepath.Join(dir, "does-not-exist", "postgres.json")
+			err := ensureLogFifo(logger, missingParent)
+			Expect(err).To(HaveOccurred())
+			Expect(errors.Is(err, compatibility.ErrExistsNotFifo)).To(BeFalse())
+		})
+	})
+})
+
+var _ = Describe("waitBeforeRetry", func() {
+	When("the context is already cancelled", func() {
+		It("returns immediately", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+
+			start := time.Now()
+			waitBeforeRetry(ctx)
+			Expect(time.Since(start)).To(BeNumerically("<", retryBackoff))
+		})
+	})
+
+	When("the context is cancelled while waiting", func() {
+		It("returns before the full backoff elapses", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			go func() {
+				time.Sleep(10 * time.Millisecond)
+				cancel()
+			}()
+
+			start := time.Now()
+			waitBeforeRetry(ctx)
+			Expect(time.Since(start)).To(BeNumerically("<", retryBackoff))
+		})
+	})
+})

--- a/pkg/management/postgres/logpipe/fifo_test.go
+++ b/pkg/management/postgres/logpipe/fifo_test.go
@@ -90,8 +90,8 @@ var _ = Describe("ensureLogFifo", func() {
 		})
 	})
 
-	When("a symlink points at a genuine FIFO (Lstat is not followed)", func() {
-		It("removes the symlink itself, leaving the target FIFO untouched", func() {
+	When("a symlink resolves to a genuine FIFO (Stat follows it)", func() {
+		It("accepts it without removing anything, since the resolved path is a usable FIFO", func() {
 			targetFifo := filepath.Join(dir, "target.fifo")
 			Expect(ensureLogFifo(logger, targetFifo)).To(Succeed())
 			Expect(isFifo(targetFifo)).To(BeTrue())
@@ -99,16 +99,37 @@ var _ = Describe("ensureLogFifo", func() {
 			symlinkPath := filepath.Join(dir, "postgres.json")
 			Expect(os.Symlink(targetFifo, symlinkPath)).To(Succeed())
 
+			// CreateFifo now resolves the path (os.Stat), matching the reader
+			// that opens it, so a link to a real FIFO is a valid stream: keep it.
+			Expect(ensureLogFifo(logger, symlinkPath)).To(Succeed())
+
+			// both the symlink and its target survive untouched
+			_, statErr := os.Lstat(symlinkPath)
+			Expect(statErr).ToNot(HaveOccurred())
+			Expect(isFifo(targetFifo)).To(BeTrue())
+		})
+	})
+
+	When("a symlink resolves to a regular file (Stat follows it to a non-FIFO)", func() {
+		It("reports ErrExistsNotFifo and removes the symlink, leaving the target untouched", func() {
+			target := filepath.Join(dir, "target.txt")
+			Expect(os.WriteFile(target, []byte("not a fifo"), 0o600)).To(Succeed())
+
+			symlinkPath := filepath.Join(dir, "postgres.json")
+			Expect(os.Symlink(target, symlinkPath)).To(Succeed())
+
 			err := ensureLogFifo(logger, symlinkPath)
 			Expect(err).To(HaveOccurred())
 			Expect(errors.Is(err, compatibility.ErrExistsNotFifo)).To(BeTrue())
 
-			// the symlink name is gone...
+			// os.Remove drops the symlink name, not its target...
 			_, statErr := os.Lstat(symlinkPath)
 			Expect(os.IsNotExist(statErr)).To(BeTrue())
 
-			// ...but the FIFO it pointed to is untouched
-			Expect(isFifo(targetFifo)).To(BeTrue())
+			// ...so the file it pointed at survives (os.Remove cannot have
+			// touched the target through the link)
+			_, statErr = os.Lstat(target)
+			Expect(statErr).ToNot(HaveOccurred())
 		})
 	})
 

--- a/pkg/management/postgres/logpipe/linelogpipe.go
+++ b/pkg/management/postgres/logpipe/linelogpipe.go
@@ -32,7 +32,6 @@ import (
 	"time"
 
 	"github.com/cloudnative-pg/machinery/pkg/fileutils"
-	"github.com/cloudnative-pg/machinery/pkg/fileutils/compatibility"
 	"github.com/cloudnative-pg/machinery/pkg/log"
 
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/concurrency"
@@ -110,10 +109,11 @@ func (p *LineLogPipe) Start(ctx context.Context) error {
 			// check if the directory exists
 			if err := fileutils.EnsureParentDirectoryExists(p.fileName); err != nil {
 				filenameLog.Error(err, "Error checking if the directory exists")
+				waitBeforeRetry(ctx)
 				continue
 			}
-			if err := compatibility.CreateFifo(p.fileName); err != nil {
-				filenameLog.Error(err, "Error creating log FIFO")
+			if err := ensureLogFifo(filenameLog, p.fileName); err != nil {
+				waitBeforeRetry(ctx)
 				continue
 			}
 			p.initialized.Broadcast()
@@ -123,6 +123,7 @@ func (p *LineLogPipe) Start(ctx context.Context) error {
 					return
 				}
 				filenameLog.Error(err, "Error consuming log stream")
+				waitBeforeRetry(ctx)
 				continue
 			}
 		}

--- a/pkg/management/postgres/logpipe/linelogpipe.go
+++ b/pkg/management/postgres/logpipe/linelogpipe.go
@@ -48,9 +48,9 @@ type LineLogPipe struct {
 	exited      *concurrency.Executed
 }
 
-// GetExecutedCondition returns the condition that can be checked in order to
+// GetInitializedCondition returns the condition that can be checked in order to
 // be sure initialization has been done
-func (p *LineLogPipe) GetExecutedCondition() *concurrency.Executed {
+func (p *LineLogPipe) GetInitializedCondition() *concurrency.Executed {
 	return p.initialized
 }
 

--- a/pkg/management/postgres/logpipe/linelogpipe.go
+++ b/pkg/management/postgres/logpipe/linelogpipe.go
@@ -99,6 +99,11 @@ func (p *LineLogPipe) Start(ctx context.Context) error {
 	defer filenameLog.Info("Exited log pipe")
 	go func() {
 		defer p.exited.Broadcast()
+		// Broadcast the initialization error if the context is canceled before
+		// the initialization is done
+		defer func() {
+			p.initialized.BroadcastError(ctx.Err())
+		}()
 		for {
 			// If the context has been cancelled, let's avoid starting reading
 			// again from the log file

--- a/pkg/management/postgres/logpipe/linelogpipe_test.go
+++ b/pkg/management/postgres/logpipe/linelogpipe_test.go
@@ -44,7 +44,7 @@ var _ = Describe("LineLogPipe", func() {
 			}
 
 			Expect(p.Start(ctx)).To(Succeed())
-			Expect(waitForCondition(p.GetExecutedCondition())).To(MatchError(context.Canceled))
+			Expect(waitForCondition(p.GetInitializedCondition())).To(MatchError(context.Canceled))
 			Expect(waitForCondition(p.GetExitedCondition())).ToNot(HaveOccurred())
 		})
 
@@ -67,14 +67,14 @@ var _ = Describe("LineLogPipe", func() {
 
 			// The FIFO gets created with no interference here, so initialized
 			// must resolve with a nil error before the context is cancelled.
-			Expect(waitForCondition(p.GetExecutedCondition())).ToNot(HaveOccurred())
+			Expect(waitForCondition(p.GetInitializedCondition())).ToNot(HaveOccurred())
 
 			cancel()
 			Eventually(startExited, 5*time.Second, 10*time.Millisecond).Should(BeClosed())
 
 			// The deferred BroadcastError(ctx.Err()) on exit must not clobber
 			// the success already recorded above.
-			Expect(p.GetExecutedCondition().Err()).ToNot(HaveOccurred())
+			Expect(p.GetInitializedCondition().Err()).ToNot(HaveOccurred())
 		})
 	})
 })

--- a/pkg/management/postgres/logpipe/linelogpipe_test.go
+++ b/pkg/management/postgres/logpipe/linelogpipe_test.go
@@ -1,0 +1,80 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package logpipe
+
+import (
+	"context"
+	"path/filepath"
+	"time"
+
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/concurrency"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("LineLogPipe", func() {
+	When("used as a log pipe", func() {
+		It("resolves the initialized condition with the context error when cancelled ", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+
+			p := &LineLogPipe{
+				fileName:    filepath.Join(GinkgoT().TempDir(), "postgres.json"),
+				handler:     func([]byte) {},
+				initialized: concurrency.NewExecuted(),
+				exited:      concurrency.NewExecuted(),
+			}
+
+			Expect(p.Start(ctx)).To(Succeed())
+			Expect(waitForCondition(p.GetExecutedCondition())).To(MatchError(context.Canceled))
+			Expect(waitForCondition(p.GetExitedCondition())).ToNot(HaveOccurred())
+		})
+
+		It("keeps the recorded success once the FIFO is ready, even after the context is later cancelled", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			p := &LineLogPipe{
+				fileName:    filepath.Join(GinkgoT().TempDir(), "postgres.json"),
+				handler:     func([]byte) {},
+				initialized: concurrency.NewExecuted(),
+				exited:      concurrency.NewExecuted(),
+			}
+
+			startExited := make(chan struct{})
+			go func() {
+				defer close(startExited)
+				_ = p.Start(ctx)
+			}()
+
+			// The FIFO gets created with no interference here, so initialized
+			// must resolve with a nil error before the context is cancelled.
+			Expect(waitForCondition(p.GetExecutedCondition())).ToNot(HaveOccurred())
+
+			cancel()
+			Eventually(startExited, 5*time.Second, 10*time.Millisecond).Should(BeClosed())
+
+			// The deferred BroadcastError(ctx.Err()) on exit must not clobber
+			// the success already recorded above.
+			Expect(p.GetExecutedCondition().Err()).ToNot(HaveOccurred())
+		})
+	})
+})

--- a/pkg/management/postgres/logpipe/logpipe.go
+++ b/pkg/management/postgres/logpipe/logpipe.go
@@ -33,7 +33,6 @@ import (
 	"time"
 
 	"github.com/cloudnative-pg/machinery/pkg/fileutils"
-	"github.com/cloudnative-pg/machinery/pkg/fileutils/compatibility"
 	"github.com/cloudnative-pg/machinery/pkg/log"
 
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/concurrency"
@@ -101,11 +100,12 @@ func (p *LogPipe) Start(ctx context.Context) error {
 			// check if the directory exists
 			if err := fileutils.EnsureParentDirectoryExists(p.fileName); err != nil {
 				filenameLog.Error(err, "Error checking if the directory exists")
+				waitBeforeRetry(ctx)
 				continue
 			}
 
-			if err := compatibility.CreateFifo(p.fileName); err != nil {
-				filenameLog.Error(err, "Error creating log FIFO")
+			if err := ensureLogFifo(filenameLog, p.fileName); err != nil {
+				waitBeforeRetry(ctx)
 				continue
 			}
 			p.initialized.Broadcast()
@@ -115,6 +115,7 @@ func (p *LogPipe) Start(ctx context.Context) error {
 					return
 				}
 				filenameLog.Error(err, "Error consuming log stream")
+				waitBeforeRetry(ctx)
 				continue
 			}
 		}

--- a/pkg/management/postgres/logpipe/logpipe.go
+++ b/pkg/management/postgres/logpipe/logpipe.go
@@ -90,6 +90,11 @@ func (p *LogPipe) Start(ctx context.Context) error {
 	defer filenameLog.Info("Exited log pipe")
 	go func() {
 		defer p.exited.Broadcast()
+		// Broadcast the initialization error if the context is canceled before
+		// the initialization is done
+		defer func() {
+			p.initialized.BroadcastError(ctx.Err())
+		}()
 		for {
 			// If the context has been cancelled, let's avoid starting reading
 			// again from the log file

--- a/pkg/management/postgres/logpipe/logpipe_test.go
+++ b/pkg/management/postgres/logpipe/logpipe_test.go
@@ -20,13 +20,29 @@ SPDX-License-Identifier: Apache-2.0
 package logpipe
 
 import (
+	"context"
 	"errors"
 	"os"
+	"path/filepath"
 	"strings"
+	"time"
+
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/concurrency"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
+
+// waitForCondition waits, in a separate goroutine, for cond to resolve.
+func waitForCondition(cond *concurrency.Executed) error {
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		cond.Wait()
+	}()
+	Eventually(done, 5*time.Second, 10*time.Millisecond).Should(BeClosed())
+	return cond.Err()
+}
 
 // SpyRecordWriter is an implementation of the RecordWriter interface
 // keeping track of the generated records
@@ -175,6 +191,54 @@ var _ = Describe("CSV file reader", func() {
 			}
 			Expect(p.streamLogFromCSVFile(ctx, strings.NewReader(""), &spy)).To(Succeed())
 			Expect(spy.records).To(BeEmpty())
+		})
+	})
+	When("used as a log pipe", func() {
+		It("resolves the initialized condition with the context error when cancelled ", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+
+			p := &LogPipe{
+				fileName:        filepath.Join(GinkgoT().TempDir(), "postgres.csv"),
+				record:          NewPgAuditLoggingDecorator(),
+				fieldsValidator: LogFieldValidator,
+				initialized:     concurrency.NewExecuted(),
+				exited:          concurrency.NewExecuted(),
+			}
+
+			Expect(p.Start(ctx)).To(Succeed())
+			Expect(waitForCondition(p.GetInitializedCondition())).To(MatchError(context.Canceled))
+			Expect(waitForCondition(p.GetExitedCondition())).ToNot(HaveOccurred())
+		})
+
+		It("keeps the recorded success once the FIFO is ready, even after the context is later cancelled", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			p := &LogPipe{
+				fileName:        filepath.Join(GinkgoT().TempDir(), "postgres.csv"),
+				record:          NewPgAuditLoggingDecorator(),
+				fieldsValidator: LogFieldValidator,
+				initialized:     concurrency.NewExecuted(),
+				exited:          concurrency.NewExecuted(),
+			}
+
+			startExited := make(chan struct{})
+			go func() {
+				defer close(startExited)
+				_ = p.Start(ctx)
+			}()
+
+			// The FIFO gets created with no interference here, so initialized
+			// must resolve with a nil error before the context is cancelled.
+			Expect(waitForCondition(p.GetInitializedCondition())).ToNot(HaveOccurred())
+
+			cancel()
+			Eventually(startExited, 5*time.Second, 10*time.Millisecond).Should(BeClosed())
+
+			// The deferred BroadcastError(ctx.Err()) on exit must not clobber
+			// the success already recorded above.
+			Expect(p.GetInitializedCondition().Err()).ToNot(HaveOccurred())
 		})
 	})
 })


### PR DESCRIPTION
`wal-archive` and `wal-restore` run as separate `/controller/manager` processes and are told to write their logs to `--log-destination <LogPath>/postgres.json`, the same path the instance manager's JSON log pipe uses for its FIFO. If one of those commands opens the destination before the pipe has created the FIFO, `customDestination` creates a plain regular file there (it opens with `O_CREATE`). The pipe then finds a non-FIFO at the path; until now it silently accepted it, so the reader opened a static file, reached EOF, and no `wal-archive`/`wal-restore` output was ever captured. That is the silence reported in #11201.

Now that `CreateFifo` reports `ErrExistsNotFifo` for a non-FIFO, the pipe reacts to it: it removes the stale entry and lets the next iteration create the FIFO, so streaming recovers without operator action. The path lives on an `emptyDir` that outlives container restarts, so without this the only recovery is recreating the pod. The removal is deliberately narrow: it fires only on `ErrExistsNotFifo`, logs a warning first, and drops just the name at the path (a symlink is removed, never its target). An in-flight writer holding the old inode loses its buffered lines, but the next invocation opens the fresh FIFO; that is convergent and acceptable for a transient log-staging path. The retry loops also gain a short, cancellable backoff so a persistent failure no longer busy-spins.

The machinery dependency is pinned (operator and e2e modules) to machinery's `main` tip, which carries the `ErrExistsNotFifo` fix (cloudnative-pg/machinery#301, merged) ahead of a tagged release; re-pin to a tagged release once machinery cuts one.

Closes #11201

