### PR TITLE
fix: delete Pooler PodMonitor when monitoring is disabled

### DIFF
--- a/internal/controller/cluster_create.go
+++ b/internal/controller/cluster_create.go
@@ -1044,9 +1044,13 @@ func createOrPatchPodMonitor(
 	// Pod monitor disabled and no pod monitor - nothing to do
 	case !manager.IsPodMonitorEnabled() && podMonitor == nil:
 		return nil
-	// Pod monitor disabled and pod monitor present - delete it
+	// Pod monitor disabled and pod monitor present - delete it only when
+	// the operator owns it (Cluster or Pooler). Manually created PodMonitors
+	// that share the same name must be left alone.
 	case !manager.IsPodMonitorEnabled() && podMonitor != nil:
-		if _, owned := IsOwnedByCluster(podMonitor); owned {
+		_, ownedByCluster := IsOwnedByCluster(podMonitor)
+		_, ownedByPooler := isOwnedByPoolerKind(podMonitor)
+		if ownedByCluster || ownedByPooler {
 			contextLogger.Info("Deleting PodMonitor")
 			if err := cli.Delete(ctx, podMonitor); err != nil {
 				if !apierrs.IsNotFound(err) {

--- a/internal/controller/cluster_create_test.go
+++ b/internal/controller/cluster_create_test.go
@@ -805,7 +805,41 @@ var _ = Describe("CreateOrPatchPodMonitor", func() {
 		Expect(apierrs.IsNotFound(err)).To(BeTrue())
 	})
 
-	It("should NOT remove the PodMonitor if it is not owned by a cluster", func() {
+	It("should remove the PodMonitor if it is disabled and is owned by a pooler", func() {
+		pooler := apiv1.Pooler{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       apiv1.PoolerKind,
+				APIVersion: apiSGVString,
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-pooler",
+				Namespace: "default",
+				UID:       "pooler-uid",
+			},
+		}
+		utils.SetAsOwnedBy(&manager.podMonitor.ObjectMeta, pooler.ObjectMeta, pooler.TypeMeta)
+
+		err := fakeCli.Create(ctx, manager.podMonitor)
+		Expect(err).ToNot(HaveOccurred())
+
+		manager.isEnabled = false
+		err = createOrPatchPodMonitor(ctx, fakeCli, fakeDiscoveryClient, manager)
+		Expect(err).ToNot(HaveOccurred())
+
+		podMonitor := &monitoringv1.PodMonitor{}
+		err = fakeCli.Get(
+			ctx,
+			types.NamespacedName{
+				Name:      manager.podMonitor.Name,
+				Namespace: manager.podMonitor.Namespace,
+			},
+			podMonitor,
+		)
+		Expect(err).To(HaveOccurred())
+		Expect(apierrs.IsNotFound(err)).To(BeTrue())
+	})
+
+	It("should NOT remove the PodMonitor if it is not owned by a cluster or pooler", func() {
 		unownedPodMonitor := &monitoringv1.PodMonitor{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test",


### PR DESCRIPTION
## Summary

Fix the deletion path for Pooler-managed PodMonitors when
`spec.monitoring.enablePodMonitor` is changed from `true` to `false`.

Previously, the shared PodMonitor reconciliation logic only deleted
Cluster-owned PodMonitors, leaving Pooler-owned PodMonitors orphaned
after monitoring was disabled.

This change extends the ownership check to correctly handle
Pooler-owned PodMonitors while preserving the existing safeguard
against deleting manually managed PodMonitors.

Fixes #11244.

## Testing

- Added unit tests covering Pooler-owned PodMonitor deletion.
- Verified existing Cluster behavior remains unchanged.
- Ran:

```bash
go test ./internal/controller/...