### PR TITLE
fix: run the empty WAL archive check when an archiver is enabled on an existing cluster

### DIFF
--- a/api/v1/cluster_funcs.go
+++ b/api/v1/cluster_funcs.go
@@ -1601,6 +1601,25 @@ func (cluster *Cluster) GetEnabledWALArchivePluginName() string {
 	return ""
 }
 
+// HasPotentialWALArchiver returns true when the cluster configuration includes
+// anything that could archive WAL files: the in-tree Barman Cloud object store
+// or any enabled CNPG-i plugin. Every enabled plugin counts as a potential
+// archiver, even without `isWALArchiver`, because the WAL archiving process
+// invokes all enabled plugins for backward compatibility.
+func (cluster *Cluster) HasPotentialWALArchiver() bool {
+	if cluster.Spec.Backup != nil && cluster.Spec.Backup.BarmanObjectStore != nil {
+		return true
+	}
+
+	for _, plugin := range cluster.Spec.Plugins {
+		if plugin.IsEnabled() {
+			return true
+		}
+	}
+
+	return false
+}
+
 // IsFailoverQuorumActive check if we should enable the
 // quorum failover protection alpha-feature.
 func (cluster *Cluster) IsFailoverQuorumActive() bool {

--- a/api/v1/cluster_funcs_test.go
+++ b/api/v1/cluster_funcs_test.go
@@ -2018,3 +2018,63 @@ var _ = Describe("IsInitialized", func() {
 		Expect(cluster.IsInitialized()).To(BeFalse())
 	})
 })
+
+var _ = Describe("HasPotentialWALArchiver", func() {
+	It("is false with neither a barman object store nor plugins", func() {
+		cluster := &Cluster{}
+		Expect(cluster.HasPotentialWALArchiver()).To(BeFalse())
+	})
+
+	It("is false when the backup section has no barman object store", func() {
+		cluster := &Cluster{
+			Spec: ClusterSpec{
+				Backup: &BackupConfiguration{},
+			},
+		}
+		Expect(cluster.HasPotentialWALArchiver()).To(BeFalse())
+	})
+
+	It("is true with a barman object store", func() {
+		cluster := &Cluster{
+			Spec: ClusterSpec{
+				Backup: &BackupConfiguration{
+					BarmanObjectStore: &BarmanObjectStoreConfiguration{},
+				},
+			},
+		}
+		Expect(cluster.HasPotentialWALArchiver()).To(BeTrue())
+	})
+
+	It("is true with an enabled plugin, even without isWALArchiver", func() {
+		cluster := &Cluster{
+			Spec: ClusterSpec{
+				Plugins: []PluginConfiguration{
+					{Name: "some-plugin", Enabled: ptr.To(true)},
+				},
+			},
+		}
+		Expect(cluster.HasPotentialWALArchiver()).To(BeTrue())
+	})
+
+	It("is true with a plugin not declaring the enabled field", func() {
+		cluster := &Cluster{
+			Spec: ClusterSpec{
+				Plugins: []PluginConfiguration{
+					{Name: "some-plugin"},
+				},
+			},
+		}
+		Expect(cluster.HasPotentialWALArchiver()).To(BeTrue())
+	})
+
+	It("is false when every plugin is explicitly disabled", func() {
+		cluster := &Cluster{
+			Spec: ClusterSpec{
+				Plugins: []PluginConfiguration{
+					{Name: "some-plugin", Enabled: ptr.To(false)},
+				},
+			},
+		}
+		Expect(cluster.HasPotentialWALArchiver()).To(BeFalse())
+	})
+})

--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -1223,6 +1223,10 @@ const (
 	// the WAL archiving is not working correctly
 	ConditionReasonContinuousArchivingFailing ConditionReason = "ContinuousArchivingFailing"
 
+	// ConditionReasonContinuousArchivingNotConfigured means that the WAL archiving
+	// succeeded as a no-op because the cluster has no WAL archiver configured
+	ConditionReasonContinuousArchivingNotConfigured ConditionReason = "ContinuousArchivingNotConfigured"
+
 	// ClusterReady means that the condition changed because the cluster is ready and working properly
 	ClusterReady ConditionReason = "ClusterIsReady"
 

--- a/internal/cmd/manager/walarchive/cmd.go
+++ b/internal/cmd/manager/walarchive/cmd.go
@@ -29,6 +29,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres/archiver"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres/webserver"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres/webserver/client/local"
 )
 
@@ -69,13 +70,18 @@ func NewCmd() *cobra.Command {
 				} else {
 					contextLog.Error(err, logErrorMessage)
 				}
-				if reqErr := localClient.Cluster().SetWALArchiveStatusCondition(ctx, err.Error()); reqErr != nil {
+				asr := webserver.ArchiveStatusRequest{Error: err.Error()}
+				if reqErr := localClient.Cluster().SetWALArchiveStatusCondition(ctx, asr); reqErr != nil {
 					contextLog.Error(reqErr, "while invoking the set wal archive condition endpoint")
 				}
 				return err
 			}
 
-			if err := localClient.Cluster().SetWALArchiveStatusCondition(ctx, ""); err != nil {
+			// The flag is computed from the same cached cluster the archiver
+			// ran with, so a spec change landing between the archiving attempt
+			// and this report cannot make a no-op pass as a real success.
+			asr := webserver.ArchiveStatusRequest{NotConfigured: !cluster.HasPotentialWALArchiver()}
+			if err := localClient.Cluster().SetWALArchiveStatusCondition(ctx, asr); err != nil {
 				contextLog.Error(err, "while invoking the set wal archive condition endpoint")
 			}
 			return nil

--- a/internal/management/controller/instance_controller.go
+++ b/internal/management/controller/instance_controller.go
@@ -1097,12 +1097,29 @@ func (r *InstanceReconciler) reconcilePostgreSQLAutoConfFilePermissions(ctx cont
 // If `.check-empty-wal-archive` is present, the WAL archiver verifies
 // that the backup object store is empty.
 // The file is created immediately after initdb and removed after the
-// first WAL is archived
+// first WAL is archived by a configured archiver. While the cluster has
+// no WAL archiver, the file is kept in place (and re-created if needed)
+// so that an archiver enabled later still runs the empty-archive check.
 func (r *InstanceReconciler) reconcileCheckWalArchiveFile(cluster *apiv1.Cluster) error {
 	filePath := filepath.Join(r.instance.PgData, constants.CheckEmptyWalArchiveFile)
+
+	if !cluster.HasPotentialWALArchiver() {
+		exists, err := fileutils.FileExists(filePath)
+		if err != nil || exists {
+			return err
+		}
+		return fileutils.CreateEmptyFile(filePath)
+	}
+
 	for _, condition := range cluster.Status.Conditions {
-		// If our current condition is archiving we can delete the file
-		if condition.Type == string(apiv1.ConditionContinuousArchiving) && condition.Status == metav1.ConditionTrue {
+		// Only a successful archiving performed by a real archiver consumes
+		// the file: the no-op success reported by archiver-less clusters
+		// (ConditionReasonContinuousArchivingNotConfigured) must not, or a
+		// stale condition would disarm the check right after an archiver
+		// is added, before its first archiving attempt.
+		if condition.Type == string(apiv1.ConditionContinuousArchiving) &&
+			condition.Status == metav1.ConditionTrue &&
+			condition.Reason == string(apiv1.ConditionReasonContinuousArchivingSuccess) {
 			return fileutils.RemoveFile(filePath)
 		}
 	}

--- a/internal/management/controller/instance_controller_test.go
+++ b/internal/management/controller/instance_controller_test.go
@@ -22,6 +22,8 @@ package controller
 import (
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -33,6 +35,7 @@ import (
 	"github.com/cloudnative-pg/cloudnative-pg/internal/webhook/guard"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/certs"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres/constants"
 	instancecertificate "github.com/cloudnative-pg/cloudnative-pg/pkg/reconciler/instance/certificate"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -112,4 +115,126 @@ var _ = Describe("instance reconciler health probe certificate", func() {
 			// before the guard. This fails if the call is moved back below it.
 			Expect(pgInstance.GetServerCertificate()).ToNot(BeNil())
 		})
+})
+
+var _ = Describe("reconcileCheckWalArchiveFile", func() {
+	var (
+		pgData     string
+		filePath   string
+		reconciler *InstanceReconciler
+	)
+
+	BeforeEach(func() {
+		pgData = GinkgoT().TempDir()
+		filePath = filepath.Join(pgData, constants.CheckEmptyWalArchiveFile)
+
+		pgInstance := postgres.NewInstance()
+		pgInstance.PgData = pgData
+		reconciler = &InstanceReconciler{instance: pgInstance}
+	})
+
+	writeMarkerFile := func() {
+		Expect(os.WriteFile(filePath, []byte{}, 0o600)).To(Succeed())
+	}
+
+	archivingCondition := func(status metav1.ConditionStatus, reason apiv1.ConditionReason) metav1.Condition {
+		return metav1.Condition{
+			Type:   string(apiv1.ConditionContinuousArchiving),
+			Status: status,
+			Reason: string(reason),
+		}
+	}
+
+	clusterWithBarman := func(conditions ...metav1.Condition) *apiv1.Cluster {
+		cluster := &apiv1.Cluster{
+			Spec: apiv1.ClusterSpec{
+				Backup: &apiv1.BackupConfiguration{
+					BarmanObjectStore: &apiv1.BarmanObjectStoreConfiguration{},
+				},
+			},
+		}
+		cluster.Status.Conditions = conditions
+		return cluster
+	}
+
+	clusterWithoutArchiver := func(conditions ...metav1.Condition) *apiv1.Cluster {
+		cluster := &apiv1.Cluster{}
+		cluster.Status.Conditions = conditions
+		return cluster
+	}
+
+	When("the cluster has a WAL archiver configured", func() {
+		It("removes the marker file after a real archiving success", func() {
+			writeMarkerFile()
+			cluster := clusterWithBarman(
+				archivingCondition(metav1.ConditionTrue, apiv1.ConditionReasonContinuousArchivingSuccess))
+
+			Expect(reconciler.reconcileCheckWalArchiveFile(cluster)).To(Succeed())
+			Expect(filePath).NotTo(BeAnExistingFile())
+		})
+
+		It("keeps the marker file while archiving is failing", func() {
+			writeMarkerFile()
+			cluster := clusterWithBarman(
+				archivingCondition(metav1.ConditionFalse, apiv1.ConditionReasonContinuousArchivingFailing))
+
+			Expect(reconciler.reconcileCheckWalArchiveFile(cluster)).To(Succeed())
+			Expect(filePath).To(BeAnExistingFile())
+		})
+
+		It("keeps the marker file when no archiving condition is present", func() {
+			writeMarkerFile()
+
+			Expect(reconciler.reconcileCheckWalArchiveFile(clusterWithBarman())).To(Succeed())
+			Expect(filePath).To(BeAnExistingFile())
+		})
+
+		It("keeps the marker file when the condition is a stale archiver-less no-op", func() {
+			// Regression: right after an archiver is added, the condition still
+			// holds True/NotConfigured from the archiver-less era. Consuming the
+			// marker file here would skip the empty-archive check on the very first
+			// real archiving attempt.
+			writeMarkerFile()
+			cluster := clusterWithBarman(
+				archivingCondition(metav1.ConditionTrue, apiv1.ConditionReasonContinuousArchivingNotConfigured))
+
+			Expect(reconciler.reconcileCheckWalArchiveFile(cluster)).To(Succeed())
+			Expect(filePath).To(BeAnExistingFile())
+		})
+
+		It("treats an enabled plugin as a potential archiver", func() {
+			writeMarkerFile()
+			cluster := clusterWithoutArchiver(
+				archivingCondition(metav1.ConditionTrue, apiv1.ConditionReasonContinuousArchivingNotConfigured))
+			cluster.Spec.Plugins = []apiv1.PluginConfiguration{{Name: "some-plugin"}}
+
+			Expect(reconciler.reconcileCheckWalArchiveFile(cluster)).To(Succeed())
+			Expect(filePath).To(BeAnExistingFile())
+		})
+	})
+
+	When("the cluster has no WAL archiver configured", func() {
+		It("re-creates a missing marker file", func() {
+			Expect(reconciler.reconcileCheckWalArchiveFile(clusterWithoutArchiver())).To(Succeed())
+			Expect(filePath).To(BeAnExistingFile())
+		})
+
+		It("leaves an existing marker file in place", func() {
+			writeMarkerFile()
+
+			Expect(reconciler.reconcileCheckWalArchiveFile(clusterWithoutArchiver())).To(Succeed())
+			Expect(filePath).To(BeAnExistingFile())
+		})
+
+		It("does not consume the marker file on a stale success condition", func() {
+			// Upgrade path: a cluster created by an operator predating the
+			// NotConfigured reason reports True/Success for its no-op archiving.
+			writeMarkerFile()
+			cluster := clusterWithoutArchiver(
+				archivingCondition(metav1.ConditionTrue, apiv1.ConditionReasonContinuousArchivingSuccess))
+
+			Expect(reconciler.reconcileCheckWalArchiveFile(cluster)).To(Succeed())
+			Expect(filePath).To(BeAnExistingFile())
+		})
+	})
 })

--- a/pkg/management/postgres/archiver/archiver.go
+++ b/pkg/management/postgres/archiver/archiver.go
@@ -302,8 +302,9 @@ func archiveWALViaPlugins(
 	}
 
 	// The marker file is ours to manage (created after bootstrap, removed
-	// once the first WAL archives), so we resolve the full decision here
-	// rather than asking the plugin to inspect it too.
+	// once a configured archiver reports its first archiving success), so we
+	// resolve the full decision here rather than asking the plugin to inspect
+	// it too.
 	checkEmptyWalArchive := shouldCheckEmptyWalArchive(ctx, cluster, pgData)
 
 	return client.ArchiveWAL(ctx, cluster, postgres.BuildWALPath(pgData, walName), checkEmptyWalArchive)

--- a/pkg/management/postgres/webserver/client/local/cluster.go
+++ b/pkg/management/postgres/webserver/client/local/cluster.go
@@ -33,10 +33,10 @@ import (
 
 // ClusterClient is the interface to interact with the uncategorized endpoints
 type ClusterClient interface {
-	// SetWALArchiveStatusCondition sets the wal-archive status condition.
-	// An empty errMessage means that the archive process was successful.
+	// SetWALArchiveStatusCondition sets the wal-archive status condition
+	// from the outcome of an archiving attempt.
 	// Returns any error encountered during the request.
-	SetWALArchiveStatusCondition(ctx context.Context, errMessage string) error
+	SetWALArchiveStatusCondition(ctx context.Context, asr webserver.ArchiveStatusRequest) error
 }
 
 // clusterClientImpl a client to interact with the uncategorized endpoints
@@ -44,12 +44,11 @@ type clusterClientImpl struct {
 	cli *http.Client
 }
 
-func (c *clusterClientImpl) SetWALArchiveStatusCondition(ctx context.Context, errMessage string) error {
+func (c *clusterClientImpl) SetWALArchiveStatusCondition(
+	ctx context.Context,
+	asr webserver.ArchiveStatusRequest,
+) error {
 	contextLogger := log.FromContext(ctx).WithValues("endpoint", url.PathWALArchiveStatusCondition)
-
-	asr := webserver.ArchiveStatusRequest{
-		Error: errMessage,
-	}
 
 	encoded, err := json.Marshal(&asr)
 	if err != nil {

--- a/pkg/management/postgres/webserver/local.go
+++ b/pkg/management/postgres/webserver/local.go
@@ -242,6 +242,11 @@ func (ws *localWebserverEndpoints) startPluginBackup(
 // ArchiveStatusRequest is the request body for the archive status endpoint
 type ArchiveStatusRequest struct {
 	Error string `json:"error,omitempty"`
+
+	// NotConfigured reports that the archiving attempt succeeded as a no-op
+	// because the cluster has no WAL archiver configured. It is ignored when
+	// Error is set.
+	NotConfigured bool `json:"notConfigured,omitempty"`
 }
 
 func (asr *ArchiveStatusRequest) getContinuousArchivingCondition() metav1.Condition {
@@ -251,6 +256,18 @@ func (asr *ArchiveStatusRequest) getContinuousArchivingCondition() metav1.Condit
 			Status:  metav1.ConditionFalse,
 			Reason:  string(apiv1.ConditionReasonContinuousArchivingFailing),
 			Message: asr.Error,
+		}
+	}
+
+	// The status stays True so that consumers waiting on the condition
+	// (e.g. `kubectl wait`) behave the same on archiver-less clusters;
+	// only the reason tells the no-op apart from a real archiving success.
+	if asr.NotConfigured {
+		return metav1.Condition{
+			Type:    string(apiv1.ConditionContinuousArchiving),
+			Status:  metav1.ConditionTrue,
+			Reason:  string(apiv1.ConditionReasonContinuousArchivingNotConfigured),
+			Message: "WAL archiving is not configured",
 		}
 	}
 

--- a/pkg/management/postgres/webserver/local_test.go
+++ b/pkg/management/postgres/webserver/local_test.go
@@ -1,0 +1,64 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package webserver
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("getContinuousArchivingCondition", func() {
+	It("reports a failure when an error is set", func() {
+		asr := ArchiveStatusRequest{Error: "boom"}
+
+		condition := asr.getContinuousArchivingCondition()
+		Expect(condition.Status).To(Equal(metav1.ConditionFalse))
+		Expect(condition.Reason).To(Equal(string(apiv1.ConditionReasonContinuousArchivingFailing)))
+		Expect(condition.Message).To(Equal("boom"))
+	})
+
+	It("gives the error precedence over the not-configured flag", func() {
+		asr := ArchiveStatusRequest{Error: "boom", NotConfigured: true}
+
+		condition := asr.getContinuousArchivingCondition()
+		Expect(condition.Status).To(Equal(metav1.ConditionFalse))
+		Expect(condition.Reason).To(Equal(string(apiv1.ConditionReasonContinuousArchivingFailing)))
+	})
+
+	It("reports an archiver-less no-op as True with a distinct reason", func() {
+		asr := ArchiveStatusRequest{NotConfigured: true}
+
+		condition := asr.getContinuousArchivingCondition()
+		Expect(condition.Status).To(Equal(metav1.ConditionTrue))
+		Expect(condition.Reason).To(Equal(string(apiv1.ConditionReasonContinuousArchivingNotConfigured)))
+	})
+
+	It("reports a real archiving success as True/Success", func() {
+		asr := ArchiveStatusRequest{}
+
+		condition := asr.getContinuousArchivingCondition()
+		Expect(condition.Status).To(Equal(metav1.ConditionTrue))
+		Expect(condition.Reason).To(Equal(string(apiv1.ConditionReasonContinuousArchivingSuccess)))
+	})
+})


### PR DESCRIPTION
Closes #11126

## Problem

A `Cluster` created without a WAL archiver and given one later never runs the empty-archive check, and starts archiving into a destination that may already hold another cluster's WALs. With the archiver present at bootstrap, the same final spec does run the check — ordering alone decides whether the protection applies.
The check is gated on the `.check-empty-wal-archive` marker in PGDATA, which `reconcileCheckWalArchiveFile` removes as soon as `ContinuousArchiving` turns `True`. On an archiver-less cluster `archive_mode` is still `on`, and `wal-archive` succeeds as a no-op while reporting that condition with the same `ContinuousArchivingSuccess` reason a real success uses. The marker is therefore consumed within seconds of bootstrap, and nothing re-creates it when an archiver is enabled later.

## Changes
Two commits, 70 lines of non-test code added, 14 removed.
1. **`fix(walarchive)`** — report the archiver-less no-op with a new `ContinuousArchivingNotConfigured` reason. `Status` stays `True`, so `kubectl wait --for=condition=ContinuousArchiving`, alerting rules and the e2e helpers are unaffected; only `reason`/`message` change.

2. **`fix(instance)`** — while the cluster has no potential WAL archiver, keep the marker in place (re-creating it if missing); consume it only on a `True` condition whose reason is `ContinuousArchivingSuccess`.
   The second half is load-bearing: re-creating the marker alone is not enough, because the stale `True/Success` condition left from the archiver-less era deletes the fresh marker on the next reconcile, before the newly enabled archiver runs its first check. I could observe that ordering in the reproduction.

`HasPotentialWALArchiver()` is deliberately broader than `GetEnabledWALArchivePluginName()` — any enabled plugin counts, even without `isWALArchiver`, because `archiveWALViaPlugins` invokes every enabled plugin declaring the `ARCHIVE_WAL` capability. A false "has archiver" only costs one extra check; a false "no archiver" could re-arm a check on a working setup.

## Relationship to #11216
This builds on #11216 rather than overlapping with it: that PR centralised *where* the decision is computed (`shouldCheckEmptyWalArchive`), not *what* it evaluates, and left the marker's lifecycle untouched. This PR supplies it with a correct marker state. The only overlap with #11216's footprint is a comment update in `archiveWALViaPlugins`, aligning its description of the marker's lifecycle with the new behaviour.

## Verification

kind (1 node, k8s v1.36.1) + MinIO, `plugin-barman-cloud` **v0.13.0 unmodified** —the fix is operator-only. Scenario: plugin-less cluster, destination seeded with a foreign object, plugin added later.

| | before (`8046d243d`, unpatched, includes #11216) | after (this PR) |
|---|---|---|
| condition on an archiver-less cluster | `True(ContinuousArchivingSuccess)` | `True(ContinuousArchivingNotConfigured)` |
| marker lifetime | already gone 23s after Ready | still there after 5 WAL switches / 2 min |
| check after enabling the plugin | never runs (no trace in the sidecar log) | fires 12s after the pod is recreated |
| WALs into the non-empty destination | 2 × 16 MiB, silently | none; `ContinuousArchiving=False(Failing)` |
| control: plugin present at bootstrap | check fires, archiving blocked | unchanged |
| control: empty destination | — | check runs **once**, passes, marker consumed, archiving proceeds |

The last row is the regression I was most worried about — the marker must still be consumed on a genuine success, or the check would repeat forever. It is.

`reconcileCheckWalArchiveFile` had no unit coverage; this adds 8 cases, including the stale-condition race and a cluster upgraded from an operator predating the new reason, plus 10 more for `HasPotentialWALArchiver` and the condition mapping. `make lint` 0 issues, `make test` green, `make generate manifests` produces no diff.

## Known limitation
A cluster upgraded from an older operator, where the no-op archiving has not run even once before a plugin is added, still carries a stale `True/Success` condition and behaves as it does today (check skipped). Not a regression, and it self-heals on the next archiving attempt since the condition is rewritten on every reconcile.

## Two design points I'd like a nod on

Raised in the issue; I went with my own judgement so there is something concrete to review, and I'm happy to change either.

1. **The new reason for archiver-less clusters.** `Status` stays `True` and existing clusters converge on the next reconcile with no migration. If you'd rather keep `Success` and gate the marker's removal on state persisted elsewhere, I'll rework it.
2. **Removing an archiver re-arms the check for a later re-add.** That falls out of the reconciler logic as written; `cnpg.io/skipEmptyWalArchiveCheck` remains the escape hatch for deliberate destination re-use. If the intended behaviour is the opposite, it is a one-line change.