### PR TITLE
fix: stop publishing zeros for silent instances in InstancesReportedState

### DIFF
--- a/docs/src/failover.md
+++ b/docs/src/failover.md
@@ -43,10 +43,14 @@ standby fails while Kubernetes still reports its pod as `Ready`, the operator
 cannot tell whether the WAL receiver is really down or the pod is simply
 unreachable, so it conservatively assumes the WAL receiver might still be
 running and defers the election, raising a `WalReceiverStatusUnknown` event
-naming the affected pod(s). Once Kubernetes stops reporting the pod as
-`Ready` (bounded by `.spec.livenessProbeTimeout`), the standby is treated as
-down, since a genuinely dead pod cannot still be streaming and blocking on it
-would stall failover after an actual node failure.
+naming the affected pod(s). Kubernetes stops reporting the pod as `Ready`
+when the instance's own readiness check (a local `pg_isready`) fails or the
+node goes away, which is what covers the case of an actual node failure. A
+standby whose PostgreSQL is still answering locally while the operator's own
+status probe keeps failing (for example due to a NetworkPolicy or a TLS
+problem) stays in this deferred state for as long as that condition lasts,
+with the election blocked and the `WalReceiverStatusUnknown` event
+recurring.
 
 During the time the failing primary is being shut down:
 

--- a/docs/src/failover.md
+++ b/docs/src/failover.md
@@ -37,6 +37,17 @@ controller will initiate the failover process, in two steps:
     and the replicas.
 :::
 
+To decide whether a standby's WAL receiver has actually stopped, the operator
+needs to hear back from that standby. If the operator's status probe to a
+standby fails while Kubernetes still reports its pod as `Ready`, the operator
+cannot tell whether the WAL receiver is really down or the pod is simply
+unreachable, so it conservatively assumes the WAL receiver might still be
+running and defers the election, raising a `WalReceiverStatusUnknown` event
+naming the affected pod(s). Once Kubernetes stops reporting the pod as
+`Ready` (bounded by `.spec.livenessProbeTimeout`), the standby is treated as
+down, since a genuinely dead pod cannot still be streaming and blocking on it
+would stall failover after an actual node failure.
+
 During the time the failing primary is being shut down:
 
 1. It will first try a PostgreSQL's *fast shutdown* with

--- a/internal/cmd/plugin/status/status.go
+++ b/internal/cmd/plugin/status/status.go
@@ -627,7 +627,11 @@ func isBarmanCloudPluginEnabled(cluster *apiv1.Cluster) (bool, map[string]string
 func (fullStatus *PostgresqlStatus) printWALArchivingStatus(status *tabby.Tabby) {
 	primaryInstanceStatus := fullStatus.tryGetPrimaryInstance()
 	if primaryInstanceStatus == nil {
-		status.AddLine("No Primary instance found")
+		if fullStatus.primaryIsSilent() {
+			status.AddLine("Primary instance status unknown: the operator cannot currently reach it")
+		} else {
+			status.AddLine("No Primary instance found")
+		}
 		return
 	}
 	isWalArchivingDisabled := fullStatus.Cluster != nil &&
@@ -778,7 +782,11 @@ func (fullStatus *PostgresqlStatus) printReplicaStatus(verbosity int) {
 
 	primaryInstanceStatus := fullStatus.tryGetPrimaryInstance()
 	if primaryInstanceStatus == nil {
-		fmt.Println(aurora.Yellow("Primary instance not found").String())
+		if fullStatus.primaryIsSilent() {
+			fmt.Println(aurora.Yellow("Primary instance status unknown: the operator cannot currently reach it").String())
+		} else {
+			fmt.Println(aurora.Yellow("Primary instance not found").String())
+		}
 		fmt.Println()
 		return
 	}
@@ -941,15 +949,43 @@ func (fullStatus *PostgresqlStatus) printCertificatesStatus() {
 	fmt.Println()
 }
 
+// tryGetPrimaryInstance returns the observed status of the primary instance,
+// or nil if no reporting instance matches. It only looks at instances whose
+// status probe succeeded: an errored instance's IsPrimary would read as its
+// Go zero value (false), so considering it here could either miss the real
+// primary or, worse, misidentify a standby. Use primaryIsSilent to tell
+// apart "there is no primary" from "the primary is there, but we cannot see
+// it".
 func (fullStatus *PostgresqlStatus) tryGetPrimaryInstance() *postgres.PostgresqlStatus {
-	for idx, instanceStatus := range fullStatus.InstanceStatus.Items {
+	reporting := fullStatus.InstanceStatus.Partition().Reporting
+	for idx := range reporting.Items {
+		instanceStatus := &reporting.Items[idx]
 		if instanceStatus.IsPrimary || len(instanceStatus.ReplicationInfo) > 0 ||
-			fullStatus.isReplicaClusterDesignatedPrimary(instanceStatus) {
-			return &fullStatus.InstanceStatus.Items[idx]
+			fullStatus.isReplicaClusterDesignatedPrimary(*instanceStatus) {
+			return instanceStatus
 		}
 	}
 
 	return nil
+}
+
+// primaryIsSilent reports whether tryGetPrimaryInstance returned nil because
+// the primary instance is known (by Pod name) but its status probe failed,
+// rather than because there is genuinely no primary. Callers use this to
+// print an explicit "unknown" instead of a "not found" that would otherwise
+// look identical to the case of an actually missing primary.
+func (fullStatus *PostgresqlStatus) primaryIsSilent() bool {
+	instanceSet := fullStatus.InstanceStatus.Partition()
+	silentGroups := [][]postgres.SilentInstance{instanceSet.ReadyButSilent, instanceSet.NotReady}
+	for _, group := range silentGroups {
+		for _, instance := range group {
+			if instance.Pod.Name == fullStatus.PrimaryPod.Name {
+				return true
+			}
+		}
+	}
+
+	return false
 }
 
 func getCurrentLSN(instance postgres.PostgresqlStatus) types.LSN {
@@ -1127,7 +1163,11 @@ func (fullStatus *PostgresqlStatus) printBasebackupStatus(verbosity int) {
 	primaryInstanceStatus := fullStatus.tryGetPrimaryInstance()
 	if primaryInstanceStatus == nil {
 		fmt.Println(aurora.Red(header))
-		fmt.Println(aurora.Red("Primary instance not found").String())
+		if fullStatus.primaryIsSilent() {
+			fmt.Println(aurora.Red("Primary instance status unknown: the operator cannot currently reach it").String())
+		} else {
+			fmt.Println(aurora.Red("Primary instance not found").String())
+		}
 		fmt.Println()
 		return
 	}

--- a/internal/cmd/plugin/status/status.go
+++ b/internal/cmd/plugin/status/status.go
@@ -978,7 +978,8 @@ func (fullStatus *PostgresqlStatus) primaryIsSilent() bool {
 	instanceSet := fullStatus.InstanceStatus.Partition()
 	silentGroups := [][]postgres.SilentInstance{instanceSet.ReadyButSilent, instanceSet.NotReady}
 	for _, group := range silentGroups {
-		for _, instance := range group {
+		for i := range group {
+			instance := &group[i]
 			if instance.Pod.Name == fullStatus.PrimaryPod.Name {
 				return true
 			}

--- a/internal/controller/backup_controller.go
+++ b/internal/controller/backup_controller.go
@@ -935,13 +935,18 @@ func (r *BackupReconciler) getBackupTargetPod(ctx context.Context, //nolint: goc
 		targetPod = &pod
 	}
 
-	// Get status for the elected pod
+	// Get status for the elected pod. We only accept it if it is actually
+	// reporting: a silent instance's SessionID would read as the empty
+	// string, which the caller cannot tell apart from a genuine (if
+	// unlikely) empty session ID, so a silent instance must never be handed
+	// back as the backup target.
 	statusResult := r.instanceStatusClient.GetStatusFromInstances(ctx, corev1.PodList{Items: []corev1.Pod{*targetPod}})
-	if len(statusResult.Items) == 0 {
+	reporting := statusResult.Partition().Reporting
+	if len(reporting.Items) == 0 {
 		return nil, fmt.Errorf("could not get instance status for pod %s: %w", targetPod.Name, ErrInstanceStatusUnavailable)
 	}
 
-	return &statusResult.Items[0], nil
+	return &reporting.Items[0], nil
 }
 
 // getPostgresContainerStatus returns the container status for the postgres container in a pod

--- a/internal/controller/backup_controller.go
+++ b/internal/controller/backup_controller.go
@@ -769,7 +769,7 @@ func (r *BackupReconciler) getSnapshotTargetPod(
 	contextLogger := log.FromContext(ctx)
 
 	// If the backup already has a target pod assigned (on a previous reconciliation loop)
-	// it will keep it. Otherwise, will use the pod computed by r.getBackupTargetPod()
+	// it will keep it. Otherwise, will use the pod computed by r.electBackupTargetPod()
 	targetPod, err := backup.GetAssignedInstance(ctx, r.Client)
 	if err != nil {
 		return nil, err
@@ -781,15 +781,16 @@ func (r *BackupReconciler) getSnapshotTargetPod(
 	}
 
 	// If no good running backups are found we elect a pod for the backup
-	// Note: we only need the Pod from the status for volume snapshot backups
-	// (they are managed by the operator, not instance manager)
-	podStatus, err := r.getBackupTargetPod(ctx, cluster, backup)
+	// Note: for volume snapshot backups we only need the Pod, since they are
+	// managed by the operator and not the instance manager, so we skip the
+	// reporting probe entirely and elect the pod directly.
+	targetPod, err = r.electBackupTargetPod(ctx, cluster, backup)
 	if err != nil {
 		return nil, err
 	}
-	contextLogger.Debug("Found pod for backup", "pod", podStatus.Pod.Name)
+	contextLogger.Debug("Found pod for backup", "pod", targetPod.Name)
 
-	return podStatus.Pod, nil
+	return targetPod, nil
 }
 
 // updateClusterWithSnapshotsBackupTimes updates a cluster's FirstRecoverabilityPoint
@@ -833,13 +834,13 @@ func updateClusterWithSnapshotsBackupTimes(
 	return nil
 }
 
-// getBackupTargetPod returns the PostgresqlStatus for the pod that should run the backup
-// according to the current cluster's target policy. The status includes the Pod reference
-// and the SessionID needed for tracking instance manager identity.
-func (r *BackupReconciler) getBackupTargetPod(ctx context.Context, //nolint: gocognit
+// electBackupTargetPod elects the pod that should run the backup according to
+// the current cluster's target policy, without probing it for its reported
+// status.
+func (r *BackupReconciler) electBackupTargetPod(ctx context.Context, //nolint: gocognit
 	cluster *apiv1.Cluster,
 	backup *apiv1.Backup,
-) (*postgresStatus.PostgresqlStatus, error) {
+) (*corev1.Pod, error) {
 	contextLogger := log.FromContext(ctx)
 
 	podHasLatestMajorImage := func(pod *corev1.Pod) bool {
@@ -933,6 +934,21 @@ func (r *BackupReconciler) getBackupTargetPod(ctx context.Context, //nolint: goc
 			return nil, ErrPrimaryImageNeedsUpdate
 		}
 		targetPod = &pod
+	}
+
+	return targetPod, nil
+}
+
+// getBackupTargetPod returns the PostgresqlStatus for the pod that should run the backup
+// according to the current cluster's target policy. The status includes the Pod reference
+// and the SessionID needed for tracking instance manager identity.
+func (r *BackupReconciler) getBackupTargetPod(ctx context.Context,
+	cluster *apiv1.Cluster,
+	backup *apiv1.Backup,
+) (*postgresStatus.PostgresqlStatus, error) {
+	targetPod, err := r.electBackupTargetPod(ctx, cluster, backup)
+	if err != nil {
+		return nil, err
 	}
 
 	// Get status for the elected pod. We only accept it if it is actually

--- a/internal/controller/backup_controller_test.go
+++ b/internal/controller/backup_controller_test.go
@@ -27,6 +27,7 @@ import (
 	volumesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -260,6 +261,28 @@ func (f *fakeInstanceStatusClient) GetStatusFromInstances(
 		items = append(items, postgres.PostgresqlStatus{
 			Pod:       &pods.Items[i],
 			SessionID: f.sessionID,
+		})
+	}
+	return postgres.PostgresqlStatusList{Items: items}
+}
+
+// fakeSilentInstanceStatusClient reports every queried pod as Ready but with
+// a failed /pg/status probe, mirroring the pod-answers-but-operator-can't-reach-it
+// scenario the volume-snapshot backup path must tolerate.
+type fakeSilentInstanceStatusClient struct {
+	remote.InstanceClient
+}
+
+func (f *fakeSilentInstanceStatusClient) GetStatusFromInstances(
+	_ context.Context,
+	pods corev1.PodList,
+) postgres.PostgresqlStatusList {
+	items := make([]postgres.PostgresqlStatus, 0, len(pods.Items))
+	for i := range pods.Items {
+		items = append(items, postgres.PostgresqlStatus{
+			Pod:        &pods.Items[i],
+			IsPodReady: true,
+			Error:      errors.New("simulated /pg/status probe failure"),
 		})
 	}
 	return postgres.PostgresqlStatusList{Items: items}
@@ -829,5 +852,86 @@ var _ = Describe("backup pending state", func() {
 			Expect(env.client.Get(ctx, client.ObjectKeyFromObject(completedBackup), &stored)).To(Succeed())
 			Expect(stored.Status.Phase).To(BeEquivalentTo(apiv1.BackupPhaseCompleted))
 		})
+	})
+})
+
+var _ = Describe("getSnapshotTargetPod", func() {
+	// Volume-snapshot backups are managed by the operator, not the instance
+	// manager, so the pod they need only has to be elected: it must not be
+	// discarded because its /pg/status probe is silent.
+	It("elects the pod even when its status probe failed", func(ctx context.Context) {
+		scheme := schemeBuilder.BuildWithAllKnownScheme()
+		k8sClient := fake.NewClientBuilder().WithScheme(scheme).
+			WithStatusSubresource(&apiv1.Cluster{}, &apiv1.Backup{}).
+			WithIndex(&corev1.Pod{}, podOwnerKey, func(rawObj client.Object) []string {
+				if ownerName, ok := IsOwnedByCluster(rawObj); ok {
+					return []string{ownerName}
+				}
+				return nil
+			}).
+			Build()
+
+		r := &BackupReconciler{
+			Client:               k8sClient,
+			Scheme:               scheme,
+			Recorder:             record.NewFakeRecorder(120),
+			instanceStatusClient: &fakeSilentInstanceStatusClient{},
+		}
+
+		ns := newFakeNamespace(k8sClient)
+
+		cluster := &apiv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "cluster-example",
+				Namespace: ns,
+			},
+			Status: apiv1.ClusterStatus{
+				TargetPrimary: "cluster-example-1",
+				Image:         "postgres:17",
+			},
+		}
+		Expect(r.Create(ctx, cluster)).To(Succeed())
+		// upstream issue, go client cleans typemeta: https://github.com/kubernetes/client-go/issues/308
+		cluster.TypeMeta = metav1.TypeMeta{
+			Kind:       apiv1.ClusterKind,
+			APIVersion: apiv1.SchemeGroupVersion.String(),
+		}
+
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      cluster.Status.TargetPrimary,
+				Namespace: ns,
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{Name: "postgres", Image: cluster.Status.Image},
+				},
+			},
+		}
+		Expect(ctrl.SetControllerReference(cluster, pod, scheme)).To(Succeed())
+		Expect(r.Create(ctx, pod)).To(Succeed())
+		pod.Status = corev1.PodStatus{
+			Conditions: []corev1.PodCondition{
+				{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+			},
+		}
+		Expect(r.Status().Update(ctx, pod)).To(Succeed())
+
+		backup := &apiv1.Backup{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "backup-example",
+				Namespace: ns,
+			},
+			Spec: apiv1.BackupSpec{
+				Cluster: apiv1.LocalObjectReference{Name: cluster.Name},
+				Method:  apiv1.BackupMethodVolumeSnapshot,
+			},
+		}
+		Expect(r.Create(ctx, backup)).To(Succeed())
+
+		targetPod, err := r.getSnapshotTargetPod(ctx, cluster, backup)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(targetPod).ToNot(BeNil())
+		Expect(targetPod.Name).To(Equal(pod.Name))
 	})
 })

--- a/internal/controller/cluster_status.go
+++ b/internal/controller/cluster_status.go
@@ -750,7 +750,10 @@ func (r *ClusterReconciler) updateClusterStatusThatRequiresInstancesState(
 	cluster *apiv1.Cluster,
 	statuses postgres.PostgresqlStatusList,
 ) error {
-	existingClusterStatus := cluster.Status
+	// This must be a deep copy: InstancesReportedState is mutated in place
+	// below, and a shallow copy would share the same map, making the change
+	// undetectable to the DeepEqual comparison further down.
+	existingClusterStatus := *cluster.Status.DeepCopy()
 
 	// InstancesReportedState is preserved across reconciliations, not rebuilt
 	// from scratch: a silent instance's entry (its status probe failed) must

--- a/internal/controller/cluster_status.go
+++ b/internal/controller/cluster_status.go
@@ -757,17 +757,22 @@ func (r *ClusterReconciler) updateClusterStatusThatRequiresInstancesState(
 	// be left untouched rather than overwritten with zeros, because "we do
 	// not know" must not erase the last thing we did know.
 	//
-	// Membership in statuses.Items this pass is what tells apart "silent but
-	// still part of the cluster" from "no longer part of the cluster"
-	// (scaled down, or the pod was replaced under the same name). AddPod
-	// (pkg/postgres/status.go) runs unconditionally regardless of the probe
-	// outcome, and GetStatusFromInstances keeps one item per pod that
-	// survives filtering rather than dropping the ones whose probe failed,
-	// so every instance that still belongs to the cluster appears in
-	// statuses.Items this pass, silent or not. Only names absent from
-	// statuses.Items entirely are pruned below, which keeps
-	// ensureInstancesAreReachable (pkg/management/postgres/webserver/probes/pinger.go)
-	// from pinging the IP of a pod that is actually gone.
+	// Membership in statuses.Items this pass is what keeps a silent instance
+	// from being pruned. Every pod that gets probed lands in statuses.Items
+	// whatever the probe outcome, because AddPod (pkg/postgres/status.go)
+	// fills in the pod-derived fields regardless and extractInstancesStatus
+	// appends the item even when the probe errored, so an instance that is
+	// merely not answering right now keeps its entry.
+	//
+	// A pod is absent from statuses.Items when it is gone (scaled down) and
+	// also while it is being replaced, because GetStatusFromInstances probes
+	// only the pods accepted by utils.IsPodActive, which rules out the pending
+	// and terminating ones. Pruning in that window is what we want: the entry
+	// goes away before the replacement pod exists, so a preserved entry can
+	// never hand ensureInstancesAreReachable
+	// (pkg/management/postgres/webserver/probes/pinger.go) the IP of a pod
+	// that is gone, nor one that has since been reassigned to a different pod
+	// carrying the same name.
 	if cluster.Status.InstancesReportedState == nil {
 		cluster.Status.InstancesReportedState = make(map[apiv1.PodName]apiv1.InstanceReportedState, len(statuses.Items))
 	}

--- a/internal/controller/cluster_status.go
+++ b/internal/controller/cluster_status.go
@@ -751,20 +751,59 @@ func (r *ClusterReconciler) updateClusterStatusThatRequiresInstancesState(
 	statuses postgres.PostgresqlStatusList,
 ) error {
 	existingClusterStatus := cluster.Status
-	cluster.Status.InstancesReportedState = make(map[apiv1.PodName]apiv1.InstanceReportedState, len(statuses.Items))
 
-	// we extract the instances reported state
-	for _, item := range statuses.Items {
+	// InstancesReportedState is preserved across reconciliations, not rebuilt
+	// from scratch: a silent instance's entry (its status probe failed) must
+	// be left untouched rather than overwritten with zeros, because "we do
+	// not know" must not erase the last thing we did know.
+	//
+	// Membership in statuses.Items this pass is what tells apart "silent but
+	// still part of the cluster" from "no longer part of the cluster"
+	// (scaled down, or the pod was replaced under the same name). AddPod
+	// (pkg/postgres/status.go) runs unconditionally regardless of the probe
+	// outcome, and GetStatusFromInstances keeps one item per pod that
+	// survives filtering rather than dropping the ones whose probe failed,
+	// so every instance that still belongs to the cluster appears in
+	// statuses.Items this pass, silent or not. Only names absent from
+	// statuses.Items entirely are pruned below, which keeps
+	// ensureInstancesAreReachable (pkg/management/postgres/webserver/probes/pinger.go)
+	// from pinging the IP of a pod that is actually gone.
+	if cluster.Status.InstancesReportedState == nil {
+		cluster.Status.InstancesReportedState = make(map[apiv1.PodName]apiv1.InstanceReportedState, len(statuses.Items))
+	}
+
+	instanceSet := statuses.Partition()
+	currentNames := stringset.New()
+
+	// we extract the instances reported state from the instances actually
+	// reporting their status; a silent instance keeps whatever entry (if
+	// any) it already had.
+	for i := range instanceSet.Reporting.Items {
+		item := &instanceSet.Reporting.Items[i]
+		currentNames.Put(item.Pod.Name)
 		cluster.Status.InstancesReportedState[apiv1.PodName(item.Pod.Name)] = apiv1.InstanceReportedState{
 			IsPrimary:  item.IsPrimary,
 			TimeLineID: item.TimeLineID,
 			IP:         item.Pod.Status.PodIP,
 		}
 	}
+	for _, silent := range instanceSet.ReadyButSilent {
+		currentNames.Put(silent.Pod.Name)
+	}
+	for _, silent := range instanceSet.NotReady {
+		currentNames.Put(silent.Pod.Name)
+	}
+
+	for name := range cluster.Status.InstancesReportedState {
+		if !currentNames.Has(string(name)) {
+			delete(cluster.Status.InstancesReportedState, name)
+		}
+	}
 
 	// we update any relevant cluster status that depends on the primary instance
 	detectedSystemID := stringset.New()
-	for _, item := range statuses.Items {
+	for i := range instanceSet.Reporting.Items {
+		item := &instanceSet.Reporting.Items[i]
 		// we refresh the last known timeline on the status root.
 		// This avoids to have a zero timeline id in case that no primary instance is up during reconciliation.
 		if item.IsPrimary && item.TimeLineID != 0 {

--- a/internal/controller/cluster_status_test.go
+++ b/internal/controller/cluster_status_test.go
@@ -485,6 +485,55 @@ var _ = Describe("updateClusterStatusThatRequiresInstancesState tests", func() {
 		Expect(state2.TimeLineID).To(Equal(456))
 	})
 
+	It("ignores the fields carried by a silent instance, not just the zeroed ones", func(ctx SpecContext) {
+		statusErr := fmt.Errorf("status endpoint failing")
+
+		firstPass := postgres.PostgresqlStatusList{
+			Items: []postgres.PostgresqlStatus{
+				{
+					Pod: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{Name: "pod-1"},
+						Status:     corev1.PodStatus{PodIP: "192.168.1.1"},
+					},
+					IsPrimary:  true,
+					TimeLineID: 123,
+				},
+			},
+		}
+		err := env.clusterReconciler.updateClusterStatusThatRequiresInstancesState(ctx, cluster, firstPass)
+		Expect(err).ToNot(HaveOccurred())
+
+		// pod-1's probe fails, but this time the status it carries is not
+		// zero-valued: it disagrees with the last known observation on every
+		// field. Whether an entry is written must depend on Error alone, never
+		// on the values happening to look empty.
+		secondPass := postgres.PostgresqlStatusList{
+			Items: []postgres.PostgresqlStatus{
+				{
+					Pod: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{Name: "pod-1"},
+						Status:     corev1.PodStatus{PodIP: "192.168.1.99"},
+					},
+					IsPrimary:  false,
+					TimeLineID: 999,
+					IsPodReady: true,
+					Error:      statusErr,
+				},
+			},
+		}
+		err = env.clusterReconciler.updateClusterStatusThatRequiresInstancesState(ctx, cluster, secondPass)
+		Expect(err).ToNot(HaveOccurred())
+
+		state1 := cluster.Status.InstancesReportedState["pod-1"]
+		Expect(state1.IsPrimary).To(BeTrue())
+		Expect(state1.TimeLineID).To(Equal(123))
+		Expect(state1.IP).To(Equal("192.168.1.1"))
+
+		// the timeline on the status root is fed from the same reporting set,
+		// so an unreported timeline must not reach it either.
+		Expect(cluster.Status.TimelineID).To(Equal(123))
+	})
+
 	It("removes the entry of an instance that no longer belongs to the cluster", func(ctx SpecContext) {
 		firstPass := postgres.PostgresqlStatusList{
 			Items: []postgres.PostgresqlStatus{

--- a/internal/controller/cluster_status_test.go
+++ b/internal/controller/cluster_status_test.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/certs"
@@ -264,7 +265,9 @@ var _ = Describe("updateClusterStatusThatRequiresInstancesState tests", func() {
 		err := env.clusterReconciler.updateClusterStatusThatRequiresInstancesState(ctx, cluster, statuses)
 		Expect(err).ToNot(HaveOccurred())
 
-		Expect(cluster.Status.InstancesReportedState).To(HaveLen(2))
+		var persisted apiv1.Cluster
+		Expect(env.client.Get(ctx, client.ObjectKeyFromObject(cluster), &persisted)).To(Succeed())
+		Expect(persisted.Status.InstancesReportedState).To(HaveLen(2))
 		Expect(cluster.Status.TimelineID).To(Equal(123))
 		Expect(cluster.Status.SystemID).To(BeEmpty())
 
@@ -302,7 +305,9 @@ var _ = Describe("updateClusterStatusThatRequiresInstancesState tests", func() {
 		err := env.clusterReconciler.updateClusterStatusThatRequiresInstancesState(ctx, cluster, statuses)
 		Expect(err).ToNot(HaveOccurred())
 
-		Expect(cluster.Status.InstancesReportedState).To(HaveLen(2))
+		var persisted apiv1.Cluster
+		Expect(env.client.Get(ctx, client.ObjectKeyFromObject(cluster), &persisted)).To(Succeed())
+		Expect(persisted.Status.InstancesReportedState).To(HaveLen(2))
 		Expect(cluster.Status.TimelineID).To(Equal(123))
 		Expect(cluster.Status.SystemID).To(Equal(systemID))
 
@@ -339,7 +344,9 @@ var _ = Describe("updateClusterStatusThatRequiresInstancesState tests", func() {
 		err := env.clusterReconciler.updateClusterStatusThatRequiresInstancesState(ctx, cluster, statuses)
 		Expect(err).ToNot(HaveOccurred())
 
-		Expect(cluster.Status.InstancesReportedState).To(HaveLen(2))
+		var persisted apiv1.Cluster
+		Expect(env.client.Get(ctx, client.ObjectKeyFromObject(cluster), &persisted)).To(Succeed())
+		Expect(persisted.Status.InstancesReportedState).To(HaveLen(2))
 		Expect(cluster.Status.TimelineID).To(Equal(123))
 		Expect(cluster.Status.SystemID).To(BeEmpty())
 
@@ -408,14 +415,16 @@ var _ = Describe("updateClusterStatusThatRequiresInstancesState tests", func() {
 		err := env.clusterReconciler.updateClusterStatusThatRequiresInstancesState(ctx, cluster, statuses)
 		Expect(err).ToNot(HaveOccurred())
 
-		Expect(cluster.Status.InstancesReportedState).To(HaveLen(2))
+		var persisted apiv1.Cluster
+		Expect(env.client.Get(ctx, client.ObjectKeyFromObject(cluster), &persisted)).To(Succeed())
+		Expect(persisted.Status.InstancesReportedState).To(HaveLen(2))
 
-		state1 := cluster.Status.InstancesReportedState["pod-1"]
+		state1 := persisted.Status.InstancesReportedState["pod-1"]
 		Expect(state1.IsPrimary).To(BeTrue())
 		Expect(state1.TimeLineID).To(Equal(123))
 		Expect(state1.IP).To(Equal("192.168.1.1"))
 
-		state2 := cluster.Status.InstancesReportedState["pod-2"]
+		state2 := persisted.Status.InstancesReportedState["pod-2"]
 		Expect(state2.IsPrimary).To(BeFalse())
 		Expect(state2.TimeLineID).To(Equal(123))
 		Expect(state2.IP).To(Equal("192.168.1.2"))
@@ -471,17 +480,19 @@ var _ = Describe("updateClusterStatusThatRequiresInstancesState tests", func() {
 		err = env.clusterReconciler.updateClusterStatusThatRequiresInstancesState(ctx, cluster, secondPass)
 		Expect(err).ToNot(HaveOccurred())
 
-		Expect(cluster.Status.InstancesReportedState).To(HaveLen(2))
+		var persisted apiv1.Cluster
+		Expect(env.client.Get(ctx, client.ObjectKeyFromObject(cluster), &persisted)).To(Succeed())
+		Expect(persisted.Status.InstancesReportedState).To(HaveLen(2))
 
 		// pod-1's entry is untouched: still the last known good observation,
 		// not zeroed out because its current probe failed.
-		state1 := cluster.Status.InstancesReportedState["pod-1"]
+		state1 := persisted.Status.InstancesReportedState["pod-1"]
 		Expect(state1.IsPrimary).To(BeTrue())
 		Expect(state1.TimeLineID).To(Equal(123))
 		Expect(state1.IP).To(Equal("192.168.1.1"))
 
 		// pod-2 keeps being refreshed normally.
-		state2 := cluster.Status.InstancesReportedState["pod-2"]
+		state2 := persisted.Status.InstancesReportedState["pod-2"]
 		Expect(state2.TimeLineID).To(Equal(456))
 	})
 
@@ -524,14 +535,17 @@ var _ = Describe("updateClusterStatusThatRequiresInstancesState tests", func() {
 		err = env.clusterReconciler.updateClusterStatusThatRequiresInstancesState(ctx, cluster, secondPass)
 		Expect(err).ToNot(HaveOccurred())
 
-		state1 := cluster.Status.InstancesReportedState["pod-1"]
+		var persisted apiv1.Cluster
+		Expect(env.client.Get(ctx, client.ObjectKeyFromObject(cluster), &persisted)).To(Succeed())
+
+		state1 := persisted.Status.InstancesReportedState["pod-1"]
 		Expect(state1.IsPrimary).To(BeTrue())
 		Expect(state1.TimeLineID).To(Equal(123))
 		Expect(state1.IP).To(Equal("192.168.1.1"))
 
 		// the timeline on the status root is fed from the same reporting set,
 		// so an unreported timeline must not reach it either.
-		Expect(cluster.Status.TimelineID).To(Equal(123))
+		Expect(persisted.Status.TimelineID).To(Equal(123))
 	})
 
 	It("removes the entry of an instance that no longer belongs to the cluster", func(ctx SpecContext) {
@@ -576,9 +590,11 @@ var _ = Describe("updateClusterStatusThatRequiresInstancesState tests", func() {
 		err = env.clusterReconciler.updateClusterStatusThatRequiresInstancesState(ctx, cluster, secondPass)
 		Expect(err).ToNot(HaveOccurred())
 
-		Expect(cluster.Status.InstancesReportedState).To(HaveLen(1))
-		Expect(cluster.Status.InstancesReportedState).To(HaveKey(apiv1.PodName("pod-1")))
-		Expect(cluster.Status.InstancesReportedState).ToNot(HaveKey(apiv1.PodName("pod-2")))
+		var persisted apiv1.Cluster
+		Expect(env.client.Get(ctx, client.ObjectKeyFromObject(cluster), &persisted)).To(Succeed())
+		Expect(persisted.Status.InstancesReportedState).To(HaveLen(1))
+		Expect(persisted.Status.InstancesReportedState).To(HaveKey(apiv1.PodName("pod-1")))
+		Expect(persisted.Status.InstancesReportedState).ToNot(HaveKey(apiv1.PodName("pod-2")))
 	})
 
 	It("does not create an entry for an instance whose first-ever observation is silent", func(ctx SpecContext) {
@@ -597,7 +613,59 @@ var _ = Describe("updateClusterStatusThatRequiresInstancesState tests", func() {
 		err := env.clusterReconciler.updateClusterStatusThatRequiresInstancesState(ctx, cluster, statuses)
 		Expect(err).ToNot(HaveOccurred())
 
-		Expect(cluster.Status.InstancesReportedState).ToNot(HaveKey(apiv1.PodName("pod-1")))
+		var persisted apiv1.Cluster
+		Expect(env.client.Get(ctx, client.ObjectKeyFromObject(cluster), &persisted)).To(Succeed())
+		Expect(persisted.Status.InstancesReportedState).ToNot(HaveKey(apiv1.PodName("pod-1")))
+	})
+
+	It("persists a newly-joined instance added on a later pass", func(ctx SpecContext) {
+		firstPass := postgres.PostgresqlStatusList{
+			Items: []postgres.PostgresqlStatus{
+				{
+					Pod: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{Name: "pod-1"},
+						Status:     corev1.PodStatus{PodIP: "192.168.1.1"},
+					},
+					IsPrimary:  true,
+					TimeLineID: 123,
+				},
+			},
+		}
+		err := env.clusterReconciler.updateClusterStatusThatRequiresInstancesState(ctx, cluster, firstPass)
+		Expect(err).ToNot(HaveOccurred())
+
+		// pod-2 joins on the second pass, it was not present at all in the first.
+		secondPass := postgres.PostgresqlStatusList{
+			Items: []postgres.PostgresqlStatus{
+				{
+					Pod: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{Name: "pod-1"},
+						Status:     corev1.PodStatus{PodIP: "192.168.1.1"},
+					},
+					IsPrimary:  true,
+					TimeLineID: 123,
+				},
+				{
+					Pod: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{Name: "pod-2"},
+						Status:     corev1.PodStatus{PodIP: "192.168.1.2"},
+					},
+					IsPrimary:  false,
+					TimeLineID: 123,
+				},
+			},
+		}
+		err = env.clusterReconciler.updateClusterStatusThatRequiresInstancesState(ctx, cluster, secondPass)
+		Expect(err).ToNot(HaveOccurred())
+
+		// This is the regression check: the second pass mutates the same map
+		// in place, so it must be read back through the client to prove the
+		// change actually reached the API server rather than only the
+		// in-memory object.
+		var persisted apiv1.Cluster
+		Expect(env.client.Get(ctx, client.ObjectKeyFromObject(cluster), &persisted)).To(Succeed())
+		Expect(persisted.Status.InstancesReportedState).To(HaveKey(apiv1.PodName("pod-1")))
+		Expect(persisted.Status.InstancesReportedState).To(HaveKey(apiv1.PodName("pod-2")))
 	})
 
 	Context("Pod termination reason detection", func() {

--- a/internal/controller/cluster_status_test.go
+++ b/internal/controller/cluster_status_test.go
@@ -421,6 +421,136 @@ var _ = Describe("updateClusterStatusThatRequiresInstancesState tests", func() {
 		Expect(state2.IP).To(Equal("192.168.1.2"))
 	})
 
+	It("preserves the entry of a previously-reporting instance that goes silent", func(ctx SpecContext) {
+		statusErr := fmt.Errorf("status endpoint failing")
+
+		firstPass := postgres.PostgresqlStatusList{
+			Items: []postgres.PostgresqlStatus{
+				{
+					Pod: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{Name: "pod-1"},
+						Status:     corev1.PodStatus{PodIP: "192.168.1.1"},
+					},
+					IsPrimary:  true,
+					TimeLineID: 123,
+				},
+				{
+					Pod: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{Name: "pod-2"},
+						Status:     corev1.PodStatus{PodIP: "192.168.1.2"},
+					},
+					IsPrimary:  false,
+					TimeLineID: 123,
+				},
+			},
+		}
+		err := env.clusterReconciler.updateClusterStatusThatRequiresInstancesState(ctx, cluster, firstPass)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(cluster.Status.InstancesReportedState).To(HaveLen(2))
+
+		// pod-1 goes silent (its probe fails) but is still present in the
+		// cluster (it appears in this pass's Items, ready and unreachable),
+		// while pod-2 keeps reporting normally.
+		secondPass := postgres.PostgresqlStatusList{
+			Items: []postgres.PostgresqlStatus{
+				{
+					Pod:        &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-1"}},
+					IsPodReady: true,
+					Error:      statusErr,
+				},
+				{
+					Pod: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{Name: "pod-2"},
+						Status:     corev1.PodStatus{PodIP: "192.168.1.2"},
+					},
+					IsPrimary:  false,
+					TimeLineID: 456,
+				},
+			},
+		}
+		err = env.clusterReconciler.updateClusterStatusThatRequiresInstancesState(ctx, cluster, secondPass)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(cluster.Status.InstancesReportedState).To(HaveLen(2))
+
+		// pod-1's entry is untouched: still the last known good observation,
+		// not zeroed out because its current probe failed.
+		state1 := cluster.Status.InstancesReportedState["pod-1"]
+		Expect(state1.IsPrimary).To(BeTrue())
+		Expect(state1.TimeLineID).To(Equal(123))
+		Expect(state1.IP).To(Equal("192.168.1.1"))
+
+		// pod-2 keeps being refreshed normally.
+		state2 := cluster.Status.InstancesReportedState["pod-2"]
+		Expect(state2.TimeLineID).To(Equal(456))
+	})
+
+	It("removes the entry of an instance that no longer belongs to the cluster", func(ctx SpecContext) {
+		firstPass := postgres.PostgresqlStatusList{
+			Items: []postgres.PostgresqlStatus{
+				{
+					Pod: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{Name: "pod-1"},
+						Status:     corev1.PodStatus{PodIP: "192.168.1.1"},
+					},
+					IsPrimary:  true,
+					TimeLineID: 123,
+				},
+				{
+					Pod: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{Name: "pod-2"},
+						Status:     corev1.PodStatus{PodIP: "192.168.1.2"},
+					},
+					IsPrimary:  false,
+					TimeLineID: 123,
+				},
+			},
+		}
+		err := env.clusterReconciler.updateClusterStatusThatRequiresInstancesState(ctx, cluster, firstPass)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(cluster.Status.InstancesReportedState).To(HaveLen(2))
+
+		// The cluster is scaled down: pod-2 no longer appears at all, not
+		// even as a silent entry.
+		secondPass := postgres.PostgresqlStatusList{
+			Items: []postgres.PostgresqlStatus{
+				{
+					Pod: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{Name: "pod-1"},
+						Status:     corev1.PodStatus{PodIP: "192.168.1.1"},
+					},
+					IsPrimary:  true,
+					TimeLineID: 123,
+				},
+			},
+		}
+		err = env.clusterReconciler.updateClusterStatusThatRequiresInstancesState(ctx, cluster, secondPass)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(cluster.Status.InstancesReportedState).To(HaveLen(1))
+		Expect(cluster.Status.InstancesReportedState).To(HaveKey(apiv1.PodName("pod-1")))
+		Expect(cluster.Status.InstancesReportedState).ToNot(HaveKey(apiv1.PodName("pod-2")))
+	})
+
+	It("does not create an entry for an instance whose first-ever observation is silent", func(ctx SpecContext) {
+		statusErr := fmt.Errorf("status endpoint failing")
+
+		statuses := postgres.PostgresqlStatusList{
+			Items: []postgres.PostgresqlStatus{
+				{
+					Pod:        &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-1"}},
+					IsPodReady: true,
+					Error:      statusErr,
+				},
+			},
+		}
+
+		err := env.clusterReconciler.updateClusterStatusThatRequiresInstancesState(ctx, cluster, statuses)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(cluster.Status.InstancesReportedState).ToNot(HaveKey(apiv1.PodName("pod-1")))
+	})
+
 	Context("Pod termination reason detection", func() {
 		It("should detect when a pod has no PostgreSQL container", func() {
 			pod := &corev1.Pod{

--- a/internal/controller/replicas.go
+++ b/internal/controller/replicas.go
@@ -163,8 +163,7 @@ func (r *ClusterReconciler) reconcileTargetPrimaryForNonReplicaCluster(
 	if down, unknownStandbys := status.Partition().AreWalReceiversDown(cluster.Status.CurrentPrimary); !down {
 		if len(unknownStandbys) > 0 {
 			r.Recorder.Eventf(cluster, "Warning", "WalReceiverStatusUnknown",
-				"Deferring failover: cannot confirm the WAL receiver is down on Ready standby(s) %v; "+
-					"the operator's /pg/status check is failing for them. See operator logs for the underlying error.",
+				"Deferring failover: cannot confirm the WAL receiver is down on Ready standby(s) %v",
 				unknownStandbys)
 		}
 		return "", ErrWalReceiversRunning
@@ -382,8 +381,7 @@ func (r *ClusterReconciler) reconcileTargetPrimaryForReplicaCluster(
 	if down, unknownStandbys := status.Partition().AreWalReceiversDown(cluster.Status.CurrentPrimary); !down {
 		if len(unknownStandbys) > 0 {
 			r.Recorder.Eventf(cluster, "Warning", "WalReceiverStatusUnknown",
-				"Deferring failover: cannot confirm the WAL receiver is down on Ready standby(s) %v; "+
-					"the operator's /pg/status check is failing for them. See operator logs for the underlying error.",
+				"Deferring failover: cannot confirm the WAL receiver is down on Ready standby(s) %v",
 				unknownStandbys)
 		}
 		return "", ErrWalReceiversRunning

--- a/internal/controller/replicas.go
+++ b/internal/controller/replicas.go
@@ -160,7 +160,13 @@ func (r *ClusterReconciler) reconcileTargetPrimaryForNonReplicaCluster(
 
 	// Wait until all the WAL receivers are down. This is needed to avoid losing the WAL
 	// data that is being received (think about a switchover).
-	if !status.AreWalReceiversDown(cluster.Status.CurrentPrimary) {
+	if down, unknownStandbys := status.Partition().AreWalReceiversDown(cluster.Status.CurrentPrimary); !down {
+		if len(unknownStandbys) > 0 {
+			r.Recorder.Eventf(cluster, "Warning", "WalReceiverStatusUnknown",
+				"Deferring failover: cannot confirm the WAL receiver is down on Ready standby(s) %v; "+
+					"the operator's /pg/status check is failing for them. See operator logs for the underlying error.",
+				unknownStandbys)
+		}
 		return "", ErrWalReceiversRunning
 	}
 
@@ -295,8 +301,14 @@ func (r *ClusterReconciler) setPrimaryOnSchedulableNode(
 	// and the operator would be waiting for it to be rescheduled to a different node indefinitely if the PVC used can not
 	// be moved between nodes, e.g. local-path-provisioner on Kind.
 
-	// Start looking for the next primary among the pods
-	for _, candidate := range podsOnOtherNodes.Items {
+	// Start looking for the next primary among the pods that are actually
+	// reporting their status: a silent instance's IsWalReceiverActive would
+	// read as its Go zero value (false), which is indistinguishable from an
+	// observed disconnection, so it must never be considered a candidate.
+	reportingCandidates := podsOnOtherNodes.Partition().Reporting
+	for i := range reportingCandidates.Items {
+		candidate := &reportingCandidates.Items[i]
+
 		// If candidate on an unschedulable node too, skip it
 		if status, _ := r.isNodeUnschedulableOrBeingDrained(ctx, candidate.Node); status {
 			continue
@@ -367,7 +379,13 @@ func (r *ClusterReconciler) reconcileTargetPrimaryForReplicaCluster(
 	// but before doing that we need to wait for all the WAL receivers to be
 	// terminated. This is needed to avoid losing the WAL data that is being received
 	// (think about a switchover).
-	if !status.AreWalReceiversDown(cluster.Status.CurrentPrimary) {
+	if down, unknownStandbys := status.Partition().AreWalReceiversDown(cluster.Status.CurrentPrimary); !down {
+		if len(unknownStandbys) > 0 {
+			r.Recorder.Eventf(cluster, "Warning", "WalReceiverStatusUnknown",
+				"Deferring failover: cannot confirm the WAL receiver is down on Ready standby(s) %v; "+
+					"the operator's /pg/status check is failing for them. See operator logs for the underlying error.",
+				unknownStandbys)
+		}
 		return "", ErrWalReceiversRunning
 	}
 

--- a/pkg/postgres/instance_set.go
+++ b/pkg/postgres/instance_set.go
@@ -1,0 +1,95 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package postgres
+
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
+// SilentInstance is an instance whose /pg/status probe failed. Only the
+// fields that are populated regardless of the probe outcome (see AddPod)
+// are available here, so a caller cannot accidentally read an unobserved
+// field as if it were real data.
+type SilentInstance struct {
+	// Pod is the instance's Pod, as known independently of the probe.
+	Pod *corev1.Pod
+
+	// Node is the name of the node the Pod is running on.
+	Node string
+
+	// Error is the error returned by the failed probe.
+	Error error
+}
+
+// InstanceSet partitions a PostgresqlStatusList by what is actually known
+// about each instance, so that decision code cannot read an observed field
+// (e.g. IsWalReceiverActive, IsPrimary, TimeLineID) off an instance whose
+// status probe failed.
+type InstanceSet struct {
+	// Reporting are the instances whose /pg/status probe succeeded. Every
+	// field on these items is a real observation.
+	Reporting PostgresqlStatusList
+
+	// ReadyButSilent are instances whose probe failed while kubelet still
+	// reports the Pod as Ready: the operator cannot tell whether PostgreSQL
+	// stopped or the pod merely became unreachable, so these must be treated
+	// as unknown, not as "down".
+	ReadyButSilent []SilentInstance
+
+	// NotReady are instances whose probe failed and kubelet no longer
+	// reports the Pod as Ready: kubelet's readiness verdict is trusted over
+	// the failing probe, so these can be treated as gone.
+	NotReady []SilentInstance
+}
+
+// Partition splits the status list into the instances we actually heard
+// from (Reporting) and the instances whose probe failed, further divided by
+// whether kubelet still considers the Pod Ready (ReadyButSilent) or not
+// (NotReady).
+func (list PostgresqlStatusList) Partition() InstanceSet {
+	set := InstanceSet{
+		Reporting: PostgresqlStatusList{
+			IsReplicaCluster: list.IsReplicaCluster,
+			CurrentPrimary:   list.CurrentPrimary,
+		},
+	}
+
+	for idx := range list.Items {
+		item := &list.Items[idx]
+
+		if item.Error == nil {
+			set.Reporting.Items = append(set.Reporting.Items, *item)
+			continue
+		}
+
+		silent := SilentInstance{
+			Pod:   item.Pod,
+			Node:  item.Node,
+			Error: item.Error,
+		}
+		if item.IsPodReady {
+			set.ReadyButSilent = append(set.ReadyButSilent, silent)
+		} else {
+			set.NotReady = append(set.NotReady, silent)
+		}
+	}
+
+	return set
+}

--- a/pkg/postgres/instance_set_test.go
+++ b/pkg/postgres/instance_set_test.go
@@ -1,0 +1,131 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package postgres
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Partition", func() {
+	errStatusEndpointFailing := fmt.Errorf("status endpoint failing")
+
+	It("puts an all-reporting list entirely into Reporting", func() {
+		list := PostgresqlStatusList{
+			Items: []PostgresqlStatus{
+				{Pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "one"}}},
+				{Pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "two"}}},
+			},
+		}
+
+		set := list.Partition()
+		Expect(set.Reporting.Items).To(HaveLen(2))
+		Expect(set.ReadyButSilent).To(BeEmpty())
+		Expect(set.NotReady).To(BeEmpty())
+	})
+
+	It("puts an all-silent list entirely into ReadyButSilent or NotReady", func() {
+		list := PostgresqlStatusList{
+			Items: []PostgresqlStatus{
+				{
+					Pod:        &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "ready-silent"}},
+					IsPodReady: true,
+					Error:      errStatusEndpointFailing,
+				},
+				{
+					Pod:        &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "not-ready-silent"}},
+					IsPodReady: false,
+					Error:      errStatusEndpointFailing,
+				},
+			},
+		}
+
+		set := list.Partition()
+		Expect(set.Reporting.Items).To(BeEmpty())
+		Expect(set.ReadyButSilent).To(HaveLen(1))
+		Expect(set.NotReady).To(HaveLen(1))
+	})
+
+	It("handles an empty list", func() {
+		set := PostgresqlStatusList{}.Partition()
+		Expect(set.Reporting.Items).To(BeEmpty())
+		Expect(set.ReadyButSilent).To(BeEmpty())
+		Expect(set.NotReady).To(BeEmpty())
+	})
+
+	It("splits a mixed list correctly", func() {
+		list := PostgresqlStatusList{
+			Items: []PostgresqlStatus{
+				{
+					Pod:  &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "reporting"}},
+					Node: "node-1",
+				},
+				{
+					Pod:        &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "ready-silent"}},
+					Node:       "node-2",
+					IsPodReady: true,
+					Error:      errStatusEndpointFailing,
+				},
+				{
+					Pod:        &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "not-ready-silent"}},
+					Node:       "node-3",
+					IsPodReady: false,
+					Error:      errStatusEndpointFailing,
+				},
+			},
+		}
+
+		set := list.Partition()
+		Expect(set.Reporting.Items).To(HaveLen(1))
+		Expect(set.Reporting.Items[0].Pod.Name).To(Equal("reporting"))
+
+		Expect(set.ReadyButSilent).To(HaveLen(1))
+		Expect(set.ReadyButSilent[0].Pod.Name).To(Equal("ready-silent"))
+		Expect(set.ReadyButSilent[0].Node).To(Equal("node-2"))
+		Expect(set.ReadyButSilent[0].Error).To(MatchError(errStatusEndpointFailing))
+
+		Expect(set.NotReady).To(HaveLen(1))
+		Expect(set.NotReady[0].Pod.Name).To(Equal("not-ready-silent"))
+		Expect(set.NotReady[0].Node).To(Equal("node-3"))
+		Expect(set.NotReady[0].Error).To(MatchError(errStatusEndpointFailing))
+	})
+
+	It("never lets a reporting item leak into either silent group", func() {
+		list := PostgresqlStatusList{
+			Items: []PostgresqlStatus{
+				{
+					Pod:        &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "reporting-but-not-ready"}},
+					IsPodReady: false,
+					Error:      nil,
+				},
+			},
+		}
+
+		set := list.Partition()
+		Expect(set.Reporting.Items).To(HaveLen(1))
+		Expect(set.ReadyButSilent).To(BeEmpty())
+		Expect(set.NotReady).To(BeEmpty())
+	})
+})

--- a/pkg/postgres/status.go
+++ b/pkg/postgres/status.go
@@ -361,7 +361,8 @@ func (set InstanceSet) AreWalReceiversDown(primaryName string) (bool, []string) 
 	}
 
 	var unknownStandbys []string
-	for _, silent := range set.ReadyButSilent {
+	for i := range set.ReadyButSilent {
+		silent := &set.ReadyButSilent[i]
 		if silent.Pod.Name == primaryName {
 			continue
 		}

--- a/pkg/postgres/status.go
+++ b/pkg/postgres/status.go
@@ -325,20 +325,62 @@ func (list *PostgresqlStatusList) Less(i, j int) bool {
 	return list.Items[i].Pod.Name < list.Items[j].Pod.Name
 }
 
-// AreWalReceiversDown checks if every WAL receiver of the cluster is down
+// AreWalReceiversDown checks if every WAL receiver of the cluster is down,
 // ignoring the status of the primary, that does not matter during
-// a switchover or a failover
-func (list PostgresqlStatusList) AreWalReceiversDown(primaryName string) bool {
-	for idx := range list.Items {
-		if list.Items[idx].Pod.Name == primaryName {
+// a switchover or a failover.
+//
+// A standby whose /pg/status call errored is not automatically treated as
+// "receiver down": if kubelet still reports the pod Ready, the operator has
+// no way to tell whether the WAL receiver is actually down or it simply lost
+// connectivity to the pod, so the standby is conservatively assumed to still
+// be streaming and the gate blocks (mirroring the primary-side guard in
+// evaluatePodReadinessGuards, which trusts kubelet readiness over a failing
+// probe). Only once kubelet stops reporting the pod as Ready is it treated
+// as down, since a dead standby cannot be streaming and blocking on it would
+// stall failovers triggered by an actual node failure. This is why the
+// method partitions its input first: reading IsWalReceiverActive off an
+// instance whose probe failed would silently read the Go zero value (false)
+// as an observation, and InstanceSet is what makes that unrepresentable.
+//
+// The second return value lists the names of the standbys whose WAL
+// receiver status is unknown (errored but still Ready) and are therefore
+// the reason the gate is blocked; it is empty whenever the gate is not
+// blocked for this reason.
+func (set InstanceSet) AreWalReceiversDown(primaryName string) (bool, []string) {
+	for idx := range set.Reporting.Items {
+		item := &set.Reporting.Items[idx]
+		if item.Pod.Name == primaryName {
 			continue
 		}
-		if list.Items[idx].IsWalReceiverActive {
-			return false
+
+		if item.IsWalReceiverActive {
+			return false, nil
 		}
 	}
 
-	return true
+	var unknownStandbys []string
+	for _, silent := range set.ReadyButSilent {
+		if silent.Pod.Name == primaryName {
+			continue
+		}
+		// Unreachable, not confirmed down: kubelet says the pod is alive,
+		// we just could not query it.
+		unknownStandbys = append(unknownStandbys, silent.Pod.Name)
+	}
+
+	// NotReady standbys are ignored here: kubelet says the pod is gone, so
+	// its WAL receiver cannot possibly still be streaming. This extends to
+	// standbys the same kubelet-readiness convention already applied to the
+	// primary in evaluatePodReadinessGuards
+	// (internal/controller/cluster_controller.go); a liveness-probe failure
+	// gets kubelet to flip readiness off, which is what bounds how long the
+	// ReadyButSilent case above can block.
+
+	if len(unknownStandbys) > 0 {
+		return false, unknownStandbys
+	}
+
+	return true, nil
 }
 
 // IsPodReporting if a pod is ready

--- a/pkg/postgres/status.go
+++ b/pkg/postgres/status.go
@@ -333,14 +333,16 @@ func (list *PostgresqlStatusList) Less(i, j int) bool {
 // "receiver down": if kubelet still reports the pod Ready, the operator has
 // no way to tell whether the WAL receiver is actually down or it simply lost
 // connectivity to the pod, so the standby is conservatively assumed to still
-// be streaming and the gate blocks (mirroring the primary-side guard in
-// evaluatePodReadinessGuards, which trusts kubelet readiness over a failing
-// probe). Only once kubelet stops reporting the pod as Ready is it treated
-// as down, since a dead standby cannot be streaming and blocking on it would
-// stall failovers triggered by an actual node failure. This is why the
-// method partitions its input first: reading IsWalReceiverActive off an
-// instance whose probe failed would silently read the Go zero value (false)
-// as an observation, and InstanceSet is what makes that unrepresentable.
+// be streaming and the gate blocks. This treats a failing probe on a Ready
+// pod the same way evaluatePodReadinessGuards treats one on the primary
+// (trusting kubelet readiness over the failing probe), though that guard
+// does not bound how long this wait can last either. Only once kubelet
+// stops reporting the pod as Ready is it treated as down, since a dead
+// standby cannot be streaming and blocking on it would stall failovers
+// triggered by an actual node failure. This is why the method partitions
+// its input first: reading IsWalReceiverActive off an instance whose probe
+// failed would silently read the Go zero value (false) as an observation,
+// and InstanceSet is what makes that unrepresentable.
 //
 // The second return value lists the names of the standbys whose WAL
 // receiver status is unknown (errored but still Ready) and are therefore
@@ -372,9 +374,12 @@ func (set InstanceSet) AreWalReceiversDown(primaryName string) (bool, []string) 
 	// its WAL receiver cannot possibly still be streaming. This extends to
 	// standbys the same kubelet-readiness convention already applied to the
 	// primary in evaluatePodReadinessGuards
-	// (internal/controller/cluster_controller.go); a liveness-probe failure
-	// gets kubelet to flip readiness off, which is what bounds how long the
-	// ReadyButSilent case above can block.
+	// (internal/controller/cluster_controller.go). A NotReady standby is
+	// what a real node failure looks like, and ignoring it is what lets that
+	// case fail over; the ReadyButSilent case above, by contrast, is not
+	// bounded by anything, since a standby's own PostgreSQL can keep
+	// answering pg_isready (and so stay Ready) indefinitely while the
+	// operator's status probe to it keeps failing.
 
 	if len(unknownStandbys) > 0 {
 		return false, unknownStandbys

--- a/pkg/postgres/status_test.go
+++ b/pkg/postgres/status_test.go
@@ -421,6 +421,64 @@ var _ = Describe("AreWalReceiversDown", func() {
 		Expect(down).To(BeFalse())
 		Expect(unknown).To(ConsistOf("standby-ahead-unknown"))
 	})
+
+	// newSilentStandby builds a PostgresqlStatus for an instance whose
+	// /pg/status probe failed, going through AddPod so IsPodReady is derived
+	// from a real Ready condition on the Pod rather than hardcoded, which is
+	// what the production code path (partitioning by Reporting/ReadyButSilent)
+	// actually relies on.
+	newSilentStandby := func(name string, probeErr error) PostgresqlStatus {
+		status := PostgresqlStatus{Error: probeErr}
+		status.AddPod(corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Status: corev1.PodStatus{
+				Conditions: []corev1.PodCondition{
+					{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+				},
+			},
+		})
+		return status
+	}
+
+	It("does not block on the primary's own silence", func() {
+		silentPrimary := newSilentStandby(primary.Pod.Name, errStatusEndpointFailing)
+		silentPrimary.IsPrimary = true
+
+		list := newList(
+			silentPrimary,
+			PostgresqlStatus{
+				Pod:                 &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "standby-1"}},
+				IsWalReceiverActive: false,
+			},
+		)
+
+		down, unknown := list.Partition().AreWalReceiversDown(silentPrimary.Pod.Name)
+		Expect(down).To(BeTrue())
+		Expect(unknown).ToNot(ContainElement(silentPrimary.Pod.Name))
+	})
+
+	It("blocks on the active receiver before it would even consider a silent standby", func() {
+		list := newList(
+			primary,
+			PostgresqlStatus{
+				Pod:                 &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "standby-active"}},
+				IsWalReceiverActive: true,
+			},
+			newSilentStandby("standby-silent", errStatusEndpointFailing),
+		)
+
+		down, unknown := list.Partition().AreWalReceiversDown(primary.Pod.Name)
+		Expect(down).To(BeFalse())
+		Expect(unknown).To(BeEmpty())
+	})
+
+	It("does not block a primary-only, single-instance cluster", func() {
+		list := newList(primary)
+
+		down, unknown := list.Partition().AreWalReceiversDown(primary.Pod.Name)
+		Expect(down).To(BeTrue())
+		Expect(unknown).To(BeEmpty())
+	})
 })
 
 var _ = Describe("Configuration report", func() {

--- a/pkg/postgres/status_test.go
+++ b/pkg/postgres/status_test.go
@@ -287,6 +287,142 @@ var _ = Describe("IsPodReadyAndNotReporting", func() {
 	})
 })
 
+var _ = Describe("AreWalReceiversDown", func() {
+	errStatusEndpointFailing := fmt.Errorf("status endpoint failing")
+
+	newList := func(items ...PostgresqlStatus) PostgresqlStatusList {
+		return PostgresqlStatusList{Items: items}
+	}
+
+	primary := PostgresqlStatus{
+		Pod:       &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "primary"}},
+		IsPrimary: true,
+	}
+
+	It("returns true when every standby has reported its WAL receiver as down", func() {
+		list := newList(
+			primary,
+			PostgresqlStatus{
+				Pod:                 &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "standby-1"}},
+				IsWalReceiverActive: false,
+			},
+		)
+
+		down, unknown := list.Partition().AreWalReceiversDown(primary.Pod.Name)
+		Expect(down).To(BeTrue())
+		Expect(unknown).To(BeEmpty())
+	})
+
+	It("returns false when a standby is confirmed to still have an active WAL receiver", func() {
+		list := newList(
+			primary,
+			PostgresqlStatus{
+				Pod:                 &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "standby-1"}},
+				IsWalReceiverActive: true,
+			},
+		)
+
+		down, unknown := list.Partition().AreWalReceiversDown(primary.Pod.Name)
+		Expect(down).To(BeFalse())
+		Expect(unknown).To(BeEmpty())
+	})
+
+	It("returns false and reports the standby when its status is unknown (errored but Ready)", func() {
+		list := newList(
+			primary,
+			PostgresqlStatus{
+				Pod:        &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "standby-1"}},
+				IsPodReady: true,
+				Error:      errStatusEndpointFailing,
+			},
+		)
+
+		down, unknown := list.Partition().AreWalReceiversDown(primary.Pod.Name)
+		Expect(down).To(BeFalse())
+		Expect(unknown).To(ConsistOf("standby-1"))
+	})
+
+	It("treats an errored and not-Ready standby as confirmed down, not unknown", func() {
+		list := newList(
+			primary,
+			PostgresqlStatus{
+				Pod:        &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "standby-1"}},
+				IsPodReady: false,
+				Error:      errStatusEndpointFailing,
+			},
+		)
+
+		down, unknown := list.Partition().AreWalReceiversDown(primary.Pod.Name)
+		Expect(down).To(BeTrue())
+		Expect(unknown).To(BeEmpty())
+	})
+
+	It("blocks on the mix of one confirmed-down standby and one Ready-but-erroring standby", func() {
+		list := newList(
+			primary,
+			PostgresqlStatus{
+				Pod:                 &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "standby-confirmed-down"}},
+				IsWalReceiverActive: false,
+			},
+			PostgresqlStatus{
+				Pod:        &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "standby-unknown"}},
+				IsPodReady: true,
+				Error:      errStatusEndpointFailing,
+			},
+		)
+
+		down, unknown := list.Partition().AreWalReceiversDown(primary.Pod.Name)
+		Expect(down).To(BeFalse())
+		Expect(unknown).To(ConsistOf("standby-unknown"))
+	})
+
+	It("does not stall a genuine node-failure failover, where the dead standby is errored and not Ready", func() {
+		list := newList(
+			primary,
+			PostgresqlStatus{
+				Pod:                 &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "standby-alive"}},
+				IsWalReceiverActive: false,
+			},
+			PostgresqlStatus{
+				Pod:        &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "standby-dead-node"}},
+				IsPodReady: false,
+				Error:      errStatusEndpointFailing,
+			},
+		)
+
+		down, unknown := list.Partition().AreWalReceiversDown(primary.Pod.Name)
+		Expect(down).To(BeTrue())
+		Expect(unknown).To(BeEmpty())
+	})
+
+	It("does not finalize the failover even when the unknown standby holds the highest last-seen LSN", func() {
+		// Adversarial: the errored standby is the one that would otherwise be
+		// elected first by Less() (highest ReceivedLsn/ReplayLsn), but since
+		// its status is unknown the gate must still block on it rather than
+		// letting the sort order imply it is safe to proceed.
+		list := newList(
+			primary,
+			PostgresqlStatus{
+				Pod:                 &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "standby-behind"}},
+				IsWalReceiverActive: false,
+				ReceivedLsn:         "1/10",
+				ReplayLsn:           "1/10",
+			},
+			PostgresqlStatus{
+				Pod:         &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "standby-ahead-unknown"}},
+				IsPodReady:  true,
+				Error:       errStatusEndpointFailing,
+				ReceivedLsn: "1/99",
+				ReplayLsn:   "1/99",
+			},
+		)
+
+		down, unknown := list.Partition().AreWalReceiversDown(primary.Pod.Name)
+		Expect(down).To(BeFalse())
+		Expect(unknown).To(ConsistOf("standby-ahead-unknown"))
+	})
+})
+
 var _ = Describe("Configuration report", func() {
 	DescribeTable(
 		"Configuration report",

--- a/pkg/reconciler/replicaclusterswitch/reconciler.go
+++ b/pkg/reconciler/replicaclusterswitch/reconciler.go
@@ -64,8 +64,20 @@ func Reconcile(
 	}
 
 	if !containsPrimaryInstance(instances) {
-		// no primary instance present means that we have no work to do
-		return nil, nil
+		// An instance that did not report its status looks exactly like one
+		// that is not a primary, so a failing probe would have us skip the
+		// demotion of a primary that is still accepting writes. Fall back on
+		// what we last knew about it: fencing goes through the API server, so
+		// stopping that primary does not require the operator to reach it.
+		if !lastKnownPrimaryIsSilent(cluster, instances) {
+			// no primary instance present means that we have no work to do
+			return nil, nil
+		}
+
+		contextLogger.Info(
+			"the instance last known as the primary is not reporting its status, "+
+				"starting the transition to replica cluster on its last known state",
+			"currentPrimary", cluster.Status.CurrentPrimary)
 	}
 
 	return startTransition(ctx, cli, cluster)
@@ -76,6 +88,48 @@ func containsPrimaryInstance(instances postgres.PostgresqlStatusList) bool {
 		if item.IsPrimary {
 			return true
 		}
+	}
+
+	return false
+}
+
+// lastKnownPrimaryIsSilent returns true when the instance the operator last
+// observed as the primary is still part of the cluster but failed to report its
+// status, leaving the absence of a reporting primary unproven.
+//
+// The verdict rests on .status.instancesReportedState, which keeps the last
+// observation of an instance that has gone silent. A designated primary never
+// qualifies: it runs with a standby.signal file, so Instance.IsPrimary
+// (pkg/management/postgres/instance.go) reports it as a replica and no
+// observation of it ever recorded a primary. A cluster that has already been
+// demoted is excluded through its stored demotion token, which is emptied only
+// when the cluster stops being a replica, so a probe failing right after a
+// completed transition cannot start a second one.
+func lastKnownPrimaryIsSilent(cluster *apiv1.Cluster, instances postgres.PostgresqlStatusList) bool {
+	if cluster.Status.DemotionToken != "" {
+		return false
+	}
+
+	primaryName := cluster.Status.CurrentPrimary
+	if primaryName == "" {
+		return false
+	}
+
+	if lastKnown, ok := cluster.Status.InstancesReportedState[apiv1.PodName(primaryName)]; !ok ||
+		!lastKnown.IsPrimary {
+		return false
+	}
+
+	// The instance must still be part of the probed ones. An instance missing
+	// from the status list has no PostgreSQL to stop: its pod is being deleted
+	// or recreated, or it is gone from the cluster altogether.
+	for i := range instances.Items {
+		item := &instances.Items[i]
+		if item.Pod == nil || item.Pod.Name != primaryName {
+			continue
+		}
+
+		return item.Error != nil
 	}
 
 	return false

--- a/pkg/reconciler/replicaclusterswitch/reconciler_test.go
+++ b/pkg/reconciler/replicaclusterswitch/reconciler_test.go
@@ -21,15 +21,18 @@ package replicaclusterswitch
 
 import (
 	"context"
+	"errors"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	schemeBuilder "github.com/cloudnative-pg/cloudnative-pg/internal/scheme"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres/webserver/client/remote"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/postgres"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/reconciler/replicaclusterswitch/conditions"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -146,5 +149,153 @@ var _ = Describe("reconcileDemotionToken", func() {
 		Expect(cluster.Status.DemotionToken).To(Equal(expectedToken))
 		// The partial WAL is archived only when a fresh token is generated.
 		Expect(instanceClient.archiveCalls).To(BeZero())
+	})
+})
+
+var _ = Describe("Reconcile of a replica cluster whose primary is silent", func() {
+	const primaryPodName = "cluster-a-1"
+
+	// buildCluster returns a cluster that has just been switched to replica
+	// cluster mode: no transition condition is set yet, and the last known
+	// state of its primary is whatever the caller passes.
+	buildCluster := func(lastKnown map[apiv1.PodName]apiv1.InstanceReportedState) *apiv1.Cluster {
+		return &apiv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{Name: "cluster-a", Namespace: "default"},
+			Spec: apiv1.ClusterSpec{
+				Instances: 1,
+				ReplicaCluster: &apiv1.ReplicaClusterConfiguration{
+					Primary: "cluster-b",
+					Source:  "cluster-b",
+				},
+			},
+			Status: apiv1.ClusterStatus{
+				CurrentPrimary:         primaryPodName,
+				TargetPrimary:          primaryPodName,
+				InstancesReportedState: lastKnown,
+			},
+		}
+	}
+
+	lastKnownPrimary := map[apiv1.PodName]apiv1.InstanceReportedState{
+		primaryPodName: {IsPrimary: true, TimeLineID: 1, IP: "10.0.0.1"},
+	}
+
+	// silentPrimary is the status list of a pod that is still probed, still
+	// kubelet-ready, but whose /pg/status call failed: every observed field,
+	// IsPrimary included, is left at its zero value.
+	silentPrimary := postgres.PostgresqlStatusList{
+		Items: []postgres.PostgresqlStatus{
+			{
+				Pod:        &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: primaryPodName}},
+				IsPodReady: true,
+				Error:      errors.New("connection refused"),
+			},
+		},
+	}
+
+	buildClient := func(cluster *apiv1.Cluster) client.Client {
+		return fake.NewClientBuilder().
+			WithScheme(schemeBuilder.BuildWithAllKnownScheme()).
+			WithObjects(cluster).
+			WithStatusSubresource(cluster).
+			Build()
+	}
+
+	// expectTransitionStarted asserts on the persisted object, since fencing
+	// and the conditions are written through the client.
+	expectTransitionStarted := func(ctx context.Context, cli client.Client, started bool) {
+		var persisted apiv1.Cluster
+		Expect(cli.Get(ctx, client.ObjectKey{Name: "cluster-a", Namespace: "default"}, &persisted)).To(Succeed())
+		Expect(persisted.IsInstanceFenced(primaryPodName)).To(Equal(started))
+		Expect(conditions.IsDesignatedPrimaryTransitionRequested(&persisted)).To(Equal(started))
+	}
+
+	It("starts the transition on the last known state of a silent primary", func(ctx SpecContext) {
+		cluster := buildCluster(lastKnownPrimary)
+		cli := buildClient(cluster)
+
+		res, err := Reconcile(ctx, cli, cluster, nil, silentPrimary)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(res).ToNot(BeNil())
+		expectTransitionStarted(ctx, cli, true)
+	})
+
+	It("keeps starting the transition for a primary that does report", func(ctx SpecContext) {
+		cluster := buildCluster(lastKnownPrimary)
+		cli := buildClient(cluster)
+		reporting := postgres.PostgresqlStatusList{
+			Items: []postgres.PostgresqlStatus{
+				{
+					Pod:       &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: primaryPodName}},
+					IsPrimary: true,
+				},
+			},
+		}
+
+		res, err := Reconcile(ctx, cli, cluster, nil, reporting)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(res).ToNot(BeNil())
+		expectTransitionStarted(ctx, cli, true)
+	})
+
+	It("does nothing when the silent instance was never observed as a primary", func(ctx SpecContext) {
+		// This is a cluster created as a replica cluster: its designated
+		// primary runs with a standby.signal file, so it is always observed as
+		// a replica. A failing probe must not be read as a primary to demote.
+		cluster := buildCluster(map[apiv1.PodName]apiv1.InstanceReportedState{
+			primaryPodName: {IsPrimary: false, TimeLineID: 1, IP: "10.0.0.1"},
+		})
+		cli := buildClient(cluster)
+
+		res, err := Reconcile(ctx, cli, cluster, nil, silentPrimary)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(res).To(BeNil())
+		expectTransitionStarted(ctx, cli, false)
+	})
+
+	It("does nothing when the silent instance has no last known state at all", func(ctx SpecContext) {
+		cluster := buildCluster(nil)
+		cli := buildClient(cluster)
+
+		res, err := Reconcile(ctx, cli, cluster, nil, silentPrimary)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(res).To(BeNil())
+		expectTransitionStarted(ctx, cli, false)
+	})
+
+	It("does not start a second transition after the cluster has been demoted", func(ctx SpecContext) {
+		// A completed transition leaves a demotion token behind and removes its
+		// conditions, so a probe failing right afterwards must not fence the
+		// whole cluster again: the last known state still says primary until
+		// the demoted instance reports as a replica.
+		cluster := buildCluster(lastKnownPrimary)
+		cluster.Status.DemotionToken = "a-previously-generated-token"
+		cli := buildClient(cluster)
+
+		res, err := Reconcile(ctx, cli, cluster, nil, silentPrimary)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(res).To(BeNil())
+		expectTransitionStarted(ctx, cli, false)
+	})
+
+	It("does nothing when the last known primary is no longer among the probed instances", func(ctx SpecContext) {
+		// The pod is being deleted or recreated, so it is filtered out of the
+		// status list. There is no PostgreSQL left to stop by fencing it.
+		cluster := buildCluster(lastKnownPrimary)
+		cli := buildClient(cluster)
+		otherInstanceOnly := postgres.PostgresqlStatusList{
+			Items: []postgres.PostgresqlStatus{
+				{
+					Pod:        &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "cluster-a-2"}},
+					IsPodReady: true,
+					Error:      errors.New("connection refused"),
+				},
+			},
+		}
+
+		res, err := Reconcile(ctx, cli, cluster, nil, otherInstanceOnly)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(res).To(BeNil())
+		expectTransitionStarted(ctx, cli, false)
 	})
 })


### PR DESCRIPTION
The operator publishes a per-instance summary into
`.status.instancesReportedState`, built once per reconciliation from the
status list it collects by probing every instance's `/pg/status` endpoint.
That map was rebuilt from scratch on every pass and given an entry for
every item in the list, unconditionally. When a probe fails the resulting
`PostgresqlStatus` carries an error and leaves every other field at its Go
zero value, so an instance the operator simply could not reach had
`IsPrimary: false`, `TimeLineID: 0` and an empty `IP` written into the CRD
as though those had been observed. A single dropped or slow probe was
enough, since probe timeouts are not retried.

The values are not merely cosmetic. `ensureInstancesAreReachable`, part of
the primary's isolation check, walks that map and pings each recorded IP,
returning on the first failure with no quorum or threshold. An empty
address can never be pinged, so one unreachable instance was enough to make
the whole check fail, and when the primary could not reach the API server
either that verdict fails its own liveness probe and has kubelet restart it.

The map is now preserved across reconciliations instead of rebuilt, and
only an instance that actually reported its status writes or overwrites an
entry. Two consequences worth knowing when reading the CRD: an instance
that has gone silent keeps its last known entry rather than being
overwritten with zeros, so the field can now hold stale-but-true data in
place of fresh-but-fabricated data; and an instance whose first ever
observation is a failed probe gets no entry at all rather than a zeroed
one.

Preserving the map instead of rebuilding it also broke how the field reaches
the API server, which is worth spelling out because the effect was silence
rather than a wrong value. The function compares the status it has built
against a baseline copy taken on entry, and issues an update only when the two
differ. That baseline was a shallow copy, so it shared the very map being
mutated in place: the comparison could never see a difference, the write was
skipped, and the field froze at whatever the first reconciliation had
persisted, never gaining the other instances. The baseline is now a deep copy.
That also makes condition-only changes detectable, since
`meta.SetStatusCondition` rewrites an existing condition through the shared
slice backing array and was equally invisible before.

The isolation check was the visible victim of that freeze: with a map holding
only the primary's own entry, an isolated primary pinged nothing but itself,
succeeded, and never fenced. The tests did not catch it either, because they
asserted on the in-memory Cluster, which is updated correctly throughout; they
now read the object back after the call.

Entries are still pruned, but only once an instance stops appearing in the
status list altogether. That happens when the instance is scaled down, and
also while its pod is being replaced, because only the pods accepted by
`utils.IsPodActive` are probed and a pending or terminating pod never
enters the list. Pruning in that window is the behaviour we want: the entry
goes away before the replacement pod exists, so a preserved entry can never
hand the isolation check an address that has meanwhile moved to a different
pod. An instance that is merely not answering right now does keep appearing,
because the pod is attached to its status entry regardless of the probe
outcome.

To make the distinction hard to get wrong at other call sites, this adds
`InstanceSet`, which partitions a status list into the instances that
reported and the ones that did not, the latter split further by whether
kubelet still considers the pod Ready. A silent instance exposes only the
fields that are populated regardless of the probe, so reading an
unobserved field off one is no longer expressible.

## Demoting a primary that stopped reporting

Once the map holds what was actually observed, it can answer a question the
operator was getting wrong. When a cluster is switched to replica cluster
mode, `replicaclusterswitch` looks for a primary among the instances that
reported their status and, when it finds one, fences the cluster to demote
it. An instance whose probe failed reports no role at all, `IsPrimary`
included, so a single failing probe made `containsPrimaryInstance` return
false and the reconciler take its "no primary instance present means that we
have no work to do" branch, skipping the transition while that primary kept
accepting writes.

Nothing else in that pass fences it either.
`AllReadyInstancesStatusUnreachable` only trips when every ready instance is
silent, and the `IsComplete` gate that does stop the reconcile sits further
down, past the point where the demotion would have started. The pass is
requeued about ten seconds later by `evaluatePodReadinessGuards`, so the
demotion does eventually happen, but only once the probe answers again: for
as long as the operator could not reach an instance that clients could, the
cluster was a replica cluster on paper with a writable primary behind it.

The decision now falls back on the last state observed for the instance
recorded as the current primary. Fencing is a metadata write that goes
through the API server, so stopping that primary never required reaching it
in the first place, and the transition completes on the instance manager's
own watch of the Cluster object rather than on an operator probe.

The fallback is deliberately narrow, so that it fires only where a primary
really is at stake:

- it asks for an instance that was actually observed as a primary, which a
  designated primary never is since it runs with a `standby.signal` file, so
  a replica cluster created from scratch is left alone when its designated
  primary goes quiet;
- it requires the instance to still be among the probed ones, because one
  that has left the status list has no PostgreSQL left to stop;
- it steps aside once a demotion token exists, so a probe failing right
  after a completed transition cannot start a second one and fence a healthy
  replica cluster.

The package had no coverage of `Reconcile` at all, so the tests come with
it: the silent-primary case, the reporting-primary case that must keep
working, and one case per carve-out above.

## Not reporting is not the same as down

The same fabrication reached other decisions, which read observed fields off an
instance whose probe had failed and got a Go zero value back as though it were
an observation.

`AreWalReceiversDown`, the failover gate, only looked at
`IsWalReceiverActive`, so an operator-to-standby hiccup was
indistinguishable from a genuinely stopped WAL receiver and the gate let a
failover through while that standby could still be streaming from the old
primary. It now weighs the per-pod status error together with kubelet's
readiness verdict: a standby that is Ready but silent counts as unknown and
keeps the gate blocked, with a `WalReceiverStatusUnknown` warning event so the
deferral is visible through `kubectl describe`, while one kubelet no longer
considers Ready is still treated as down so a node failure keeps failing over.
The gate moves onto `InstanceSet`, which is what gives that type its second
consumer.

Three more readers follow the same reasoning: `setPrimaryOnSchedulableNode`
scanned `IsWalReceiverActive` on candidates it had not heard from (a silent one
read false and so happened to be skipped, but nothing guaranteed it),
`getBackupTargetPod` returned a pod without checking its error and let the
caller read an empty `SessionID`, and `kubectl cnpg status` matched the primary
on `Pod.Name` and printed zeros and blanks for WAL archiving, replication and
basebackups instead of saying the primary's state is unknown.

The failover documentation gains the distinction too, since a failover
deferred because a standby is unreachable otherwise reads as a stall.

There is no issue tracking this specific bug. It surfaced as prerequisite
work while looking into the wider problem of the operator conflating "this
instance is not reporting" with "this instance is down", which is what the
sections above address.
