### PR TITLE
fix: don't treat an unreachable standby as WAL-receiver-down

### DIFF
--- a/docs/src/failover.md
+++ b/docs/src/failover.md
@@ -37,6 +37,17 @@ controller will initiate the failover process, in two steps:
     and the replicas.
 :::
 
+To decide whether a standby's WAL receiver has actually stopped, the operator
+needs to hear back from that standby. If the operator's status probe to a
+standby fails while Kubernetes still reports its pod as `Ready`, the operator
+cannot tell whether the WAL receiver is really down or the pod is simply
+unreachable, so it conservatively assumes the WAL receiver might still be
+running and defers the election, raising a `WalReceiverStatusUnknown` event
+naming the affected pod(s). Once Kubernetes stops reporting the pod as
+`Ready` (bounded by `.spec.livenessProbeTimeout`), the standby is treated as
+down, since a genuinely dead pod cannot still be streaming and blocking on it
+would stall failover after an actual node failure.
+
 During the time the failing primary is being shut down:
 
 1. It will first try a PostgreSQL's *fast shutdown* with

--- a/internal/cmd/plugin/status/status.go
+++ b/internal/cmd/plugin/status/status.go
@@ -627,7 +627,11 @@ func isBarmanCloudPluginEnabled(cluster *apiv1.Cluster) (bool, map[string]string
 func (fullStatus *PostgresqlStatus) printWALArchivingStatus(status *tabby.Tabby) {
 	primaryInstanceStatus := fullStatus.tryGetPrimaryInstance()
 	if primaryInstanceStatus == nil {
-		status.AddLine("No Primary instance found")
+		if fullStatus.primaryIsSilent() {
+			status.AddLine("Primary instance status unknown: the operator cannot currently reach it")
+		} else {
+			status.AddLine("No Primary instance found")
+		}
 		return
 	}
 	isWalArchivingDisabled := fullStatus.Cluster != nil &&
@@ -778,7 +782,11 @@ func (fullStatus *PostgresqlStatus) printReplicaStatus(verbosity int) {
 
 	primaryInstanceStatus := fullStatus.tryGetPrimaryInstance()
 	if primaryInstanceStatus == nil {
-		fmt.Println(aurora.Yellow("Primary instance not found").String())
+		if fullStatus.primaryIsSilent() {
+			fmt.Println(aurora.Yellow("Primary instance status unknown: the operator cannot currently reach it").String())
+		} else {
+			fmt.Println(aurora.Yellow("Primary instance not found").String())
+		}
 		fmt.Println()
 		return
 	}
@@ -941,15 +949,43 @@ func (fullStatus *PostgresqlStatus) printCertificatesStatus() {
 	fmt.Println()
 }
 
+// tryGetPrimaryInstance returns the observed status of the primary instance,
+// or nil if no reporting instance matches. It only looks at instances whose
+// status probe succeeded: an errored instance's IsPrimary would read as its
+// Go zero value (false), so considering it here could either miss the real
+// primary or, worse, misidentify a standby. Use primaryIsSilent to tell
+// apart "there is no primary" from "the primary is there, but we cannot see
+// it".
 func (fullStatus *PostgresqlStatus) tryGetPrimaryInstance() *postgres.PostgresqlStatus {
-	for idx, instanceStatus := range fullStatus.InstanceStatus.Items {
+	reporting := fullStatus.InstanceStatus.Partition().Reporting
+	for idx := range reporting.Items {
+		instanceStatus := &reporting.Items[idx]
 		if instanceStatus.IsPrimary || len(instanceStatus.ReplicationInfo) > 0 ||
-			fullStatus.isReplicaClusterDesignatedPrimary(instanceStatus) {
-			return &fullStatus.InstanceStatus.Items[idx]
+			fullStatus.isReplicaClusterDesignatedPrimary(*instanceStatus) {
+			return instanceStatus
 		}
 	}
 
 	return nil
+}
+
+// primaryIsSilent reports whether tryGetPrimaryInstance returned nil because
+// the primary instance is known (by Pod name) but its status probe failed,
+// rather than because there is genuinely no primary. Callers use this to
+// print an explicit "unknown" instead of a "not found" that would otherwise
+// look identical to the case of an actually missing primary.
+func (fullStatus *PostgresqlStatus) primaryIsSilent() bool {
+	instanceSet := fullStatus.InstanceStatus.Partition()
+	silentGroups := [][]postgres.SilentInstance{instanceSet.ReadyButSilent, instanceSet.NotReady}
+	for _, group := range silentGroups {
+		for _, instance := range group {
+			if instance.Pod.Name == fullStatus.PrimaryPod.Name {
+				return true
+			}
+		}
+	}
+
+	return false
 }
 
 func getCurrentLSN(instance postgres.PostgresqlStatus) types.LSN {
@@ -1127,7 +1163,11 @@ func (fullStatus *PostgresqlStatus) printBasebackupStatus(verbosity int) {
 	primaryInstanceStatus := fullStatus.tryGetPrimaryInstance()
 	if primaryInstanceStatus == nil {
 		fmt.Println(aurora.Red(header))
-		fmt.Println(aurora.Red("Primary instance not found").String())
+		if fullStatus.primaryIsSilent() {
+			fmt.Println(aurora.Red("Primary instance status unknown: the operator cannot currently reach it").String())
+		} else {
+			fmt.Println(aurora.Red("Primary instance not found").String())
+		}
 		fmt.Println()
 		return
 	}

--- a/internal/controller/backup_controller.go
+++ b/internal/controller/backup_controller.go
@@ -935,13 +935,18 @@ func (r *BackupReconciler) getBackupTargetPod(ctx context.Context, //nolint: goc
 		targetPod = &pod
 	}
 
-	// Get status for the elected pod
+	// Get status for the elected pod. We only accept it if it is actually
+	// reporting: a silent instance's SessionID would read as the empty
+	// string, which the caller cannot tell apart from a genuine (if
+	// unlikely) empty session ID, so a silent instance must never be handed
+	// back as the backup target.
 	statusResult := r.instanceStatusClient.GetStatusFromInstances(ctx, corev1.PodList{Items: []corev1.Pod{*targetPod}})
-	if len(statusResult.Items) == 0 {
+	reporting := statusResult.Partition().Reporting
+	if len(reporting.Items) == 0 {
 		return nil, fmt.Errorf("could not get instance status for pod %s: %w", targetPod.Name, ErrInstanceStatusUnavailable)
 	}
 
-	return &statusResult.Items[0], nil
+	return &reporting.Items[0], nil
 }
 
 // getPostgresContainerStatus returns the container status for the postgres container in a pod

--- a/internal/controller/cluster_status.go
+++ b/internal/controller/cluster_status.go
@@ -751,20 +751,59 @@ func (r *ClusterReconciler) updateClusterStatusThatRequiresInstancesState(
 	statuses postgres.PostgresqlStatusList,
 ) error {
 	existingClusterStatus := cluster.Status
-	cluster.Status.InstancesReportedState = make(map[apiv1.PodName]apiv1.InstanceReportedState, len(statuses.Items))
 
-	// we extract the instances reported state
-	for _, item := range statuses.Items {
+	// InstancesReportedState is preserved across reconciliations, not rebuilt
+	// from scratch: a silent instance's entry (its status probe failed) must
+	// be left untouched rather than overwritten with zeros, because "we do
+	// not know" must not erase the last thing we did know.
+	//
+	// Membership in statuses.Items this pass is what tells apart "silent but
+	// still part of the cluster" from "no longer part of the cluster"
+	// (scaled down, or the pod was replaced under the same name). AddPod
+	// (pkg/postgres/status.go) runs unconditionally regardless of the probe
+	// outcome, and GetStatusFromInstances keeps one item per pod that
+	// survives filtering rather than dropping the ones whose probe failed,
+	// so every instance that still belongs to the cluster appears in
+	// statuses.Items this pass, silent or not. Only names absent from
+	// statuses.Items entirely are pruned below, which keeps
+	// ensureInstancesAreReachable (pkg/management/postgres/webserver/probes/pinger.go)
+	// from pinging the IP of a pod that is actually gone.
+	if cluster.Status.InstancesReportedState == nil {
+		cluster.Status.InstancesReportedState = make(map[apiv1.PodName]apiv1.InstanceReportedState, len(statuses.Items))
+	}
+
+	instanceSet := statuses.Partition()
+	currentNames := stringset.New()
+
+	// we extract the instances reported state from the instances actually
+	// reporting their status; a silent instance keeps whatever entry (if
+	// any) it already had.
+	for i := range instanceSet.Reporting.Items {
+		item := &instanceSet.Reporting.Items[i]
+		currentNames.Put(item.Pod.Name)
 		cluster.Status.InstancesReportedState[apiv1.PodName(item.Pod.Name)] = apiv1.InstanceReportedState{
 			IsPrimary:  item.IsPrimary,
 			TimeLineID: item.TimeLineID,
 			IP:         item.Pod.Status.PodIP,
 		}
 	}
+	for _, silent := range instanceSet.ReadyButSilent {
+		currentNames.Put(silent.Pod.Name)
+	}
+	for _, silent := range instanceSet.NotReady {
+		currentNames.Put(silent.Pod.Name)
+	}
+
+	for name := range cluster.Status.InstancesReportedState {
+		if !currentNames.Has(string(name)) {
+			delete(cluster.Status.InstancesReportedState, name)
+		}
+	}
 
 	// we update any relevant cluster status that depends on the primary instance
 	detectedSystemID := stringset.New()
-	for _, item := range statuses.Items {
+	for i := range instanceSet.Reporting.Items {
+		item := &instanceSet.Reporting.Items[i]
 		// we refresh the last known timeline on the status root.
 		// This avoids to have a zero timeline id in case that no primary instance is up during reconciliation.
 		if item.IsPrimary && item.TimeLineID != 0 {

--- a/internal/controller/cluster_status_test.go
+++ b/internal/controller/cluster_status_test.go
@@ -421,6 +421,136 @@ var _ = Describe("updateClusterStatusThatRequiresInstancesState tests", func() {
 		Expect(state2.IP).To(Equal("192.168.1.2"))
 	})
 
+	It("preserves the entry of a previously-reporting instance that goes silent", func(ctx SpecContext) {
+		statusErr := fmt.Errorf("status endpoint failing")
+
+		firstPass := postgres.PostgresqlStatusList{
+			Items: []postgres.PostgresqlStatus{
+				{
+					Pod: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{Name: "pod-1"},
+						Status:     corev1.PodStatus{PodIP: "192.168.1.1"},
+					},
+					IsPrimary:  true,
+					TimeLineID: 123,
+				},
+				{
+					Pod: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{Name: "pod-2"},
+						Status:     corev1.PodStatus{PodIP: "192.168.1.2"},
+					},
+					IsPrimary:  false,
+					TimeLineID: 123,
+				},
+			},
+		}
+		err := env.clusterReconciler.updateClusterStatusThatRequiresInstancesState(ctx, cluster, firstPass)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(cluster.Status.InstancesReportedState).To(HaveLen(2))
+
+		// pod-1 goes silent (its probe fails) but is still present in the
+		// cluster (it appears in this pass's Items, ready and unreachable),
+		// while pod-2 keeps reporting normally.
+		secondPass := postgres.PostgresqlStatusList{
+			Items: []postgres.PostgresqlStatus{
+				{
+					Pod:        &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-1"}},
+					IsPodReady: true,
+					Error:      statusErr,
+				},
+				{
+					Pod: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{Name: "pod-2"},
+						Status:     corev1.PodStatus{PodIP: "192.168.1.2"},
+					},
+					IsPrimary:  false,
+					TimeLineID: 456,
+				},
+			},
+		}
+		err = env.clusterReconciler.updateClusterStatusThatRequiresInstancesState(ctx, cluster, secondPass)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(cluster.Status.InstancesReportedState).To(HaveLen(2))
+
+		// pod-1's entry is untouched: still the last known good observation,
+		// not zeroed out because its current probe failed.
+		state1 := cluster.Status.InstancesReportedState["pod-1"]
+		Expect(state1.IsPrimary).To(BeTrue())
+		Expect(state1.TimeLineID).To(Equal(123))
+		Expect(state1.IP).To(Equal("192.168.1.1"))
+
+		// pod-2 keeps being refreshed normally.
+		state2 := cluster.Status.InstancesReportedState["pod-2"]
+		Expect(state2.TimeLineID).To(Equal(456))
+	})
+
+	It("removes the entry of an instance that no longer belongs to the cluster", func(ctx SpecContext) {
+		firstPass := postgres.PostgresqlStatusList{
+			Items: []postgres.PostgresqlStatus{
+				{
+					Pod: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{Name: "pod-1"},
+						Status:     corev1.PodStatus{PodIP: "192.168.1.1"},
+					},
+					IsPrimary:  true,
+					TimeLineID: 123,
+				},
+				{
+					Pod: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{Name: "pod-2"},
+						Status:     corev1.PodStatus{PodIP: "192.168.1.2"},
+					},
+					IsPrimary:  false,
+					TimeLineID: 123,
+				},
+			},
+		}
+		err := env.clusterReconciler.updateClusterStatusThatRequiresInstancesState(ctx, cluster, firstPass)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(cluster.Status.InstancesReportedState).To(HaveLen(2))
+
+		// The cluster is scaled down: pod-2 no longer appears at all, not
+		// even as a silent entry.
+		secondPass := postgres.PostgresqlStatusList{
+			Items: []postgres.PostgresqlStatus{
+				{
+					Pod: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{Name: "pod-1"},
+						Status:     corev1.PodStatus{PodIP: "192.168.1.1"},
+					},
+					IsPrimary:  true,
+					TimeLineID: 123,
+				},
+			},
+		}
+		err = env.clusterReconciler.updateClusterStatusThatRequiresInstancesState(ctx, cluster, secondPass)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(cluster.Status.InstancesReportedState).To(HaveLen(1))
+		Expect(cluster.Status.InstancesReportedState).To(HaveKey(apiv1.PodName("pod-1")))
+		Expect(cluster.Status.InstancesReportedState).ToNot(HaveKey(apiv1.PodName("pod-2")))
+	})
+
+	It("does not create an entry for an instance whose first-ever observation is silent", func(ctx SpecContext) {
+		statusErr := fmt.Errorf("status endpoint failing")
+
+		statuses := postgres.PostgresqlStatusList{
+			Items: []postgres.PostgresqlStatus{
+				{
+					Pod:        &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-1"}},
+					IsPodReady: true,
+					Error:      statusErr,
+				},
+			},
+		}
+
+		err := env.clusterReconciler.updateClusterStatusThatRequiresInstancesState(ctx, cluster, statuses)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(cluster.Status.InstancesReportedState).ToNot(HaveKey(apiv1.PodName("pod-1")))
+	})
+
 	Context("Pod termination reason detection", func() {
 		It("should detect when a pod has no PostgreSQL container", func() {
 			pod := &corev1.Pod{

--- a/internal/controller/replicas.go
+++ b/internal/controller/replicas.go
@@ -160,7 +160,7 @@ func (r *ClusterReconciler) reconcileTargetPrimaryForNonReplicaCluster(
 
 	// Wait until all the WAL receivers are down. This is needed to avoid losing the WAL
 	// data that is being received (think about a switchover).
-	if down, unknownStandbys := status.AreWalReceiversDown(cluster.Status.CurrentPrimary); !down {
+	if down, unknownStandbys := status.Partition().AreWalReceiversDown(cluster.Status.CurrentPrimary); !down {
 		if len(unknownStandbys) > 0 {
 			r.Recorder.Eventf(cluster, "Warning", "WalReceiverStatusUnknown",
 				"Deferring failover: cannot confirm the WAL receiver is down on Ready standby(s) %v; "+
@@ -373,7 +373,7 @@ func (r *ClusterReconciler) reconcileTargetPrimaryForReplicaCluster(
 	// but before doing that we need to wait for all the WAL receivers to be
 	// terminated. This is needed to avoid losing the WAL data that is being received
 	// (think about a switchover).
-	if down, unknownStandbys := status.AreWalReceiversDown(cluster.Status.CurrentPrimary); !down {
+	if down, unknownStandbys := status.Partition().AreWalReceiversDown(cluster.Status.CurrentPrimary); !down {
 		if len(unknownStandbys) > 0 {
 			r.Recorder.Eventf(cluster, "Warning", "WalReceiverStatusUnknown",
 				"Deferring failover: cannot confirm the WAL receiver is down on Ready standby(s) %v; "+

--- a/internal/controller/replicas.go
+++ b/internal/controller/replicas.go
@@ -301,8 +301,14 @@ func (r *ClusterReconciler) setPrimaryOnSchedulableNode(
 	// and the operator would be waiting for it to be rescheduled to a different node indefinitely if the PVC used can not
 	// be moved between nodes, e.g. local-path-provisioner on Kind.
 
-	// Start looking for the next primary among the pods
-	for _, candidate := range podsOnOtherNodes.Items {
+	// Start looking for the next primary among the pods that are actually
+	// reporting their status: a silent instance's IsWalReceiverActive would
+	// read as its Go zero value (false), which is indistinguishable from an
+	// observed disconnection, so it must never be considered a candidate.
+	reportingCandidates := podsOnOtherNodes.Partition().Reporting
+	for i := range reportingCandidates.Items {
+		candidate := &reportingCandidates.Items[i]
+
 		// If candidate on an unschedulable node too, skip it
 		if status, _ := r.isNodeUnschedulableOrBeingDrained(ctx, candidate.Node); status {
 			continue

--- a/internal/controller/replicas.go
+++ b/internal/controller/replicas.go
@@ -160,7 +160,13 @@ func (r *ClusterReconciler) reconcileTargetPrimaryForNonReplicaCluster(
 
 	// Wait until all the WAL receivers are down. This is needed to avoid losing the WAL
 	// data that is being received (think about a switchover).
-	if !status.AreWalReceiversDown(cluster.Status.CurrentPrimary) {
+	if down, unknownStandbys := status.AreWalReceiversDown(cluster.Status.CurrentPrimary); !down {
+		if len(unknownStandbys) > 0 {
+			r.Recorder.Eventf(cluster, "Warning", "WalReceiverStatusUnknown",
+				"Deferring failover: cannot confirm the WAL receiver is down on Ready standby(s) %v; "+
+					"the operator's /pg/status check is failing for them. See operator logs for the underlying error.",
+				unknownStandbys)
+		}
 		return "", ErrWalReceiversRunning
 	}
 
@@ -367,7 +373,13 @@ func (r *ClusterReconciler) reconcileTargetPrimaryForReplicaCluster(
 	// but before doing that we need to wait for all the WAL receivers to be
 	// terminated. This is needed to avoid losing the WAL data that is being received
 	// (think about a switchover).
-	if !status.AreWalReceiversDown(cluster.Status.CurrentPrimary) {
+	if down, unknownStandbys := status.AreWalReceiversDown(cluster.Status.CurrentPrimary); !down {
+		if len(unknownStandbys) > 0 {
+			r.Recorder.Eventf(cluster, "Warning", "WalReceiverStatusUnknown",
+				"Deferring failover: cannot confirm the WAL receiver is down on Ready standby(s) %v; "+
+					"the operator's /pg/status check is failing for them. See operator logs for the underlying error.",
+				unknownStandbys)
+		}
 		return "", ErrWalReceiversRunning
 	}
 

--- a/pkg/postgres/instance_set.go
+++ b/pkg/postgres/instance_set.go
@@ -1,0 +1,95 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package postgres
+
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
+// SilentInstance is an instance whose /pg/status probe failed. Only the
+// fields that are populated regardless of the probe outcome (see AddPod)
+// are available here, so a caller cannot accidentally read an unobserved
+// field as if it were real data.
+type SilentInstance struct {
+	// Pod is the instance's Pod, as known independently of the probe.
+	Pod *corev1.Pod
+
+	// Node is the name of the node the Pod is running on.
+	Node string
+
+	// Error is the error returned by the failed probe.
+	Error error
+}
+
+// InstanceSet partitions a PostgresqlStatusList by what is actually known
+// about each instance, so that decision code cannot read an observed field
+// (e.g. IsWalReceiverActive, IsPrimary, TimeLineID) off an instance whose
+// status probe failed.
+type InstanceSet struct {
+	// Reporting are the instances whose /pg/status probe succeeded. Every
+	// field on these items is a real observation.
+	Reporting PostgresqlStatusList
+
+	// ReadyButSilent are instances whose probe failed while kubelet still
+	// reports the Pod as Ready: the operator cannot tell whether PostgreSQL
+	// stopped or the pod merely became unreachable, so these must be treated
+	// as unknown, not as "down".
+	ReadyButSilent []SilentInstance
+
+	// NotReady are instances whose probe failed and kubelet no longer
+	// reports the Pod as Ready: kubelet's readiness verdict is trusted over
+	// the failing probe, so these can be treated as gone.
+	NotReady []SilentInstance
+}
+
+// Partition splits the status list into the instances we actually heard
+// from (Reporting) and the instances whose probe failed, further divided by
+// whether kubelet still considers the Pod Ready (ReadyButSilent) or not
+// (NotReady).
+func (list PostgresqlStatusList) Partition() InstanceSet {
+	set := InstanceSet{
+		Reporting: PostgresqlStatusList{
+			IsReplicaCluster: list.IsReplicaCluster,
+			CurrentPrimary:   list.CurrentPrimary,
+		},
+	}
+
+	for idx := range list.Items {
+		item := &list.Items[idx]
+
+		if item.Error == nil {
+			set.Reporting.Items = append(set.Reporting.Items, *item)
+			continue
+		}
+
+		silent := SilentInstance{
+			Pod:   item.Pod,
+			Node:  item.Node,
+			Error: item.Error,
+		}
+		if item.IsPodReady {
+			set.ReadyButSilent = append(set.ReadyButSilent, silent)
+		} else {
+			set.NotReady = append(set.NotReady, silent)
+		}
+	}
+
+	return set
+}

--- a/pkg/postgres/instance_set_test.go
+++ b/pkg/postgres/instance_set_test.go
@@ -1,0 +1,131 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package postgres
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Partition", func() {
+	errStatusEndpointFailing := fmt.Errorf("status endpoint failing")
+
+	It("puts an all-reporting list entirely into Reporting", func() {
+		list := PostgresqlStatusList{
+			Items: []PostgresqlStatus{
+				{Pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "one"}}},
+				{Pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "two"}}},
+			},
+		}
+
+		set := list.Partition()
+		Expect(set.Reporting.Items).To(HaveLen(2))
+		Expect(set.ReadyButSilent).To(BeEmpty())
+		Expect(set.NotReady).To(BeEmpty())
+	})
+
+	It("puts an all-silent list entirely into ReadyButSilent or NotReady", func() {
+		list := PostgresqlStatusList{
+			Items: []PostgresqlStatus{
+				{
+					Pod:        &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "ready-silent"}},
+					IsPodReady: true,
+					Error:      errStatusEndpointFailing,
+				},
+				{
+					Pod:        &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "not-ready-silent"}},
+					IsPodReady: false,
+					Error:      errStatusEndpointFailing,
+				},
+			},
+		}
+
+		set := list.Partition()
+		Expect(set.Reporting.Items).To(BeEmpty())
+		Expect(set.ReadyButSilent).To(HaveLen(1))
+		Expect(set.NotReady).To(HaveLen(1))
+	})
+
+	It("handles an empty list", func() {
+		set := PostgresqlStatusList{}.Partition()
+		Expect(set.Reporting.Items).To(BeEmpty())
+		Expect(set.ReadyButSilent).To(BeEmpty())
+		Expect(set.NotReady).To(BeEmpty())
+	})
+
+	It("splits a mixed list correctly", func() {
+		list := PostgresqlStatusList{
+			Items: []PostgresqlStatus{
+				{
+					Pod:  &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "reporting"}},
+					Node: "node-1",
+				},
+				{
+					Pod:        &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "ready-silent"}},
+					Node:       "node-2",
+					IsPodReady: true,
+					Error:      errStatusEndpointFailing,
+				},
+				{
+					Pod:        &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "not-ready-silent"}},
+					Node:       "node-3",
+					IsPodReady: false,
+					Error:      errStatusEndpointFailing,
+				},
+			},
+		}
+
+		set := list.Partition()
+		Expect(set.Reporting.Items).To(HaveLen(1))
+		Expect(set.Reporting.Items[0].Pod.Name).To(Equal("reporting"))
+
+		Expect(set.ReadyButSilent).To(HaveLen(1))
+		Expect(set.ReadyButSilent[0].Pod.Name).To(Equal("ready-silent"))
+		Expect(set.ReadyButSilent[0].Node).To(Equal("node-2"))
+		Expect(set.ReadyButSilent[0].Error).To(MatchError(errStatusEndpointFailing))
+
+		Expect(set.NotReady).To(HaveLen(1))
+		Expect(set.NotReady[0].Pod.Name).To(Equal("not-ready-silent"))
+		Expect(set.NotReady[0].Node).To(Equal("node-3"))
+		Expect(set.NotReady[0].Error).To(MatchError(errStatusEndpointFailing))
+	})
+
+	It("never lets a reporting item leak into either silent group", func() {
+		list := PostgresqlStatusList{
+			Items: []PostgresqlStatus{
+				{
+					Pod:        &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "reporting-but-not-ready"}},
+					IsPodReady: false,
+					Error:      nil,
+				},
+			},
+		}
+
+		set := list.Partition()
+		Expect(set.Reporting.Items).To(HaveLen(1))
+		Expect(set.ReadyButSilent).To(BeEmpty())
+		Expect(set.NotReady).To(BeEmpty())
+	})
+})

--- a/pkg/postgres/status.go
+++ b/pkg/postgres/status.go
@@ -325,20 +325,54 @@ func (list *PostgresqlStatusList) Less(i, j int) bool {
 	return list.Items[i].Pod.Name < list.Items[j].Pod.Name
 }
 
-// AreWalReceiversDown checks if every WAL receiver of the cluster is down
+// AreWalReceiversDown checks if every WAL receiver of the cluster is down,
 // ignoring the status of the primary, that does not matter during
-// a switchover or a failover
-func (list PostgresqlStatusList) AreWalReceiversDown(primaryName string) bool {
+// a switchover or a failover.
+//
+// A standby whose /pg/status call errored is not automatically treated as
+// "receiver down": if kubelet still reports the pod Ready, the operator has
+// no way to tell whether the WAL receiver is actually down or it simply lost
+// connectivity to the pod, so the standby is conservatively assumed to still
+// be streaming and the gate blocks (mirroring the primary-side guard in
+// evaluatePodReadinessGuards, which trusts kubelet readiness over a failing
+// probe). Only once kubelet stops reporting the pod as Ready is it treated
+// as down, since a dead standby cannot be streaming and blocking on it would
+// stall failovers triggered by an actual node failure.
+//
+// The second return value lists the names of the standbys whose WAL
+// receiver status is unknown (errored but still Ready) and are therefore
+// the reason the gate is blocked; it is empty whenever the gate is not
+// blocked for this reason.
+func (list PostgresqlStatusList) AreWalReceiversDown(primaryName string) (bool, []string) {
+	var unknownStandbys []string
+
 	for idx := range list.Items {
-		if list.Items[idx].Pod.Name == primaryName {
+		item := &list.Items[idx]
+		if item.Pod.Name == primaryName {
 			continue
 		}
-		if list.Items[idx].IsWalReceiverActive {
-			return false
+
+		if item.Error != nil {
+			if item.IsPodReady {
+				// Unreachable, not confirmed down: kubelet says the pod is
+				// alive, we just could not query it.
+				unknownStandbys = append(unknownStandbys, item.Pod.Name)
+			}
+			// Errored and not Ready: kubelet says the pod is gone, so its
+			// WAL receiver cannot possibly still be streaming.
+			continue
+		}
+
+		if item.IsWalReceiverActive {
+			return false, nil
 		}
 	}
 
-	return true
+	if len(unknownStandbys) > 0 {
+		return false, unknownStandbys
+	}
+
+	return true, nil
 }
 
 // IsPodReporting if a pod is ready

--- a/pkg/postgres/status.go
+++ b/pkg/postgres/status.go
@@ -337,34 +337,19 @@ func (list *PostgresqlStatusList) Less(i, j int) bool {
 // evaluatePodReadinessGuards, which trusts kubelet readiness over a failing
 // probe). Only once kubelet stops reporting the pod as Ready is it treated
 // as down, since a dead standby cannot be streaming and blocking on it would
-// stall failovers triggered by an actual node failure.
+// stall failovers triggered by an actual node failure. This is why the
+// method partitions its input first: reading IsWalReceiverActive off an
+// instance whose probe failed would silently read the Go zero value (false)
+// as an observation, and InstanceSet is what makes that unrepresentable.
 //
 // The second return value lists the names of the standbys whose WAL
 // receiver status is unknown (errored but still Ready) and are therefore
 // the reason the gate is blocked; it is empty whenever the gate is not
 // blocked for this reason.
-func (list PostgresqlStatusList) AreWalReceiversDown(primaryName string) (bool, []string) {
-	var unknownStandbys []string
-
-	for idx := range list.Items {
-		item := &list.Items[idx]
+func (set InstanceSet) AreWalReceiversDown(primaryName string) (bool, []string) {
+	for idx := range set.Reporting.Items {
+		item := &set.Reporting.Items[idx]
 		if item.Pod.Name == primaryName {
-			continue
-		}
-
-		if item.Error != nil {
-			if item.IsPodReady {
-				// Unreachable, not confirmed down: kubelet says the pod is
-				// alive, we just could not query it.
-				unknownStandbys = append(unknownStandbys, item.Pod.Name)
-			}
-			// Errored and not Ready: kubelet says the pod is gone, so its
-			// WAL receiver cannot possibly still be streaming. This extends
-			// to standbys the same kubelet-readiness convention already
-			// applied to the primary in evaluatePodReadinessGuards
-			// (internal/controller/cluster_controller.go); a liveness-probe
-			// failure gets kubelet to flip readiness off, which is what
-			// bounds how long the errored-but-Ready case above can block.
 			continue
 		}
 
@@ -372,6 +357,24 @@ func (list PostgresqlStatusList) AreWalReceiversDown(primaryName string) (bool, 
 			return false, nil
 		}
 	}
+
+	var unknownStandbys []string
+	for _, silent := range set.ReadyButSilent {
+		if silent.Pod.Name == primaryName {
+			continue
+		}
+		// Unreachable, not confirmed down: kubelet says the pod is alive,
+		// we just could not query it.
+		unknownStandbys = append(unknownStandbys, silent.Pod.Name)
+	}
+
+	// NotReady standbys are ignored here: kubelet says the pod is gone, so
+	// its WAL receiver cannot possibly still be streaming. This extends to
+	// standbys the same kubelet-readiness convention already applied to the
+	// primary in evaluatePodReadinessGuards
+	// (internal/controller/cluster_controller.go); a liveness-probe failure
+	// gets kubelet to flip readiness off, which is what bounds how long the
+	// ReadyButSilent case above can block.
 
 	if len(unknownStandbys) > 0 {
 		return false, unknownStandbys

--- a/pkg/postgres/status.go
+++ b/pkg/postgres/status.go
@@ -359,7 +359,12 @@ func (list PostgresqlStatusList) AreWalReceiversDown(primaryName string) (bool, 
 				unknownStandbys = append(unknownStandbys, item.Pod.Name)
 			}
 			// Errored and not Ready: kubelet says the pod is gone, so its
-			// WAL receiver cannot possibly still be streaming.
+			// WAL receiver cannot possibly still be streaming. This extends
+			// to standbys the same kubelet-readiness convention already
+			// applied to the primary in evaluatePodReadinessGuards
+			// (internal/controller/cluster_controller.go); a liveness-probe
+			// failure gets kubelet to flip readiness off, which is what
+			// bounds how long the errored-but-Ready case above can block.
 			continue
 		}
 

--- a/pkg/postgres/status_test.go
+++ b/pkg/postgres/status_test.go
@@ -308,7 +308,7 @@ var _ = Describe("AreWalReceiversDown", func() {
 			},
 		)
 
-		down, unknown := list.AreWalReceiversDown(primary.Pod.Name)
+		down, unknown := list.Partition().AreWalReceiversDown(primary.Pod.Name)
 		Expect(down).To(BeTrue())
 		Expect(unknown).To(BeEmpty())
 	})
@@ -322,7 +322,7 @@ var _ = Describe("AreWalReceiversDown", func() {
 			},
 		)
 
-		down, unknown := list.AreWalReceiversDown(primary.Pod.Name)
+		down, unknown := list.Partition().AreWalReceiversDown(primary.Pod.Name)
 		Expect(down).To(BeFalse())
 		Expect(unknown).To(BeEmpty())
 	})
@@ -337,7 +337,7 @@ var _ = Describe("AreWalReceiversDown", func() {
 			},
 		)
 
-		down, unknown := list.AreWalReceiversDown(primary.Pod.Name)
+		down, unknown := list.Partition().AreWalReceiversDown(primary.Pod.Name)
 		Expect(down).To(BeFalse())
 		Expect(unknown).To(ConsistOf("standby-1"))
 	})
@@ -352,7 +352,7 @@ var _ = Describe("AreWalReceiversDown", func() {
 			},
 		)
 
-		down, unknown := list.AreWalReceiversDown(primary.Pod.Name)
+		down, unknown := list.Partition().AreWalReceiversDown(primary.Pod.Name)
 		Expect(down).To(BeTrue())
 		Expect(unknown).To(BeEmpty())
 	})
@@ -371,7 +371,7 @@ var _ = Describe("AreWalReceiversDown", func() {
 			},
 		)
 
-		down, unknown := list.AreWalReceiversDown(primary.Pod.Name)
+		down, unknown := list.Partition().AreWalReceiversDown(primary.Pod.Name)
 		Expect(down).To(BeFalse())
 		Expect(unknown).To(ConsistOf("standby-unknown"))
 	})
@@ -390,7 +390,7 @@ var _ = Describe("AreWalReceiversDown", func() {
 			},
 		)
 
-		down, unknown := list.AreWalReceiversDown(primary.Pod.Name)
+		down, unknown := list.Partition().AreWalReceiversDown(primary.Pod.Name)
 		Expect(down).To(BeTrue())
 		Expect(unknown).To(BeEmpty())
 	})
@@ -417,7 +417,7 @@ var _ = Describe("AreWalReceiversDown", func() {
 			},
 		)
 
-		down, unknown := list.AreWalReceiversDown(primary.Pod.Name)
+		down, unknown := list.Partition().AreWalReceiversDown(primary.Pod.Name)
 		Expect(down).To(BeFalse())
 		Expect(unknown).To(ConsistOf("standby-ahead-unknown"))
 	})

--- a/pkg/postgres/status_test.go
+++ b/pkg/postgres/status_test.go
@@ -287,6 +287,142 @@ var _ = Describe("IsPodReadyAndNotReporting", func() {
 	})
 })
 
+var _ = Describe("AreWalReceiversDown", func() {
+	errStatusEndpointFailing := fmt.Errorf("status endpoint failing")
+
+	newList := func(items ...PostgresqlStatus) PostgresqlStatusList {
+		return PostgresqlStatusList{Items: items}
+	}
+
+	primary := PostgresqlStatus{
+		Pod:       &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "primary"}},
+		IsPrimary: true,
+	}
+
+	It("returns true when every standby has reported its WAL receiver as down", func() {
+		list := newList(
+			primary,
+			PostgresqlStatus{
+				Pod:                 &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "standby-1"}},
+				IsWalReceiverActive: false,
+			},
+		)
+
+		down, unknown := list.AreWalReceiversDown(primary.Pod.Name)
+		Expect(down).To(BeTrue())
+		Expect(unknown).To(BeEmpty())
+	})
+
+	It("returns false when a standby is confirmed to still have an active WAL receiver", func() {
+		list := newList(
+			primary,
+			PostgresqlStatus{
+				Pod:                 &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "standby-1"}},
+				IsWalReceiverActive: true,
+			},
+		)
+
+		down, unknown := list.AreWalReceiversDown(primary.Pod.Name)
+		Expect(down).To(BeFalse())
+		Expect(unknown).To(BeEmpty())
+	})
+
+	It("returns false and reports the standby when its status is unknown (errored but Ready)", func() {
+		list := newList(
+			primary,
+			PostgresqlStatus{
+				Pod:        &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "standby-1"}},
+				IsPodReady: true,
+				Error:      errStatusEndpointFailing,
+			},
+		)
+
+		down, unknown := list.AreWalReceiversDown(primary.Pod.Name)
+		Expect(down).To(BeFalse())
+		Expect(unknown).To(ConsistOf("standby-1"))
+	})
+
+	It("treats an errored and not-Ready standby as confirmed down, not unknown", func() {
+		list := newList(
+			primary,
+			PostgresqlStatus{
+				Pod:        &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "standby-1"}},
+				IsPodReady: false,
+				Error:      errStatusEndpointFailing,
+			},
+		)
+
+		down, unknown := list.AreWalReceiversDown(primary.Pod.Name)
+		Expect(down).To(BeTrue())
+		Expect(unknown).To(BeEmpty())
+	})
+
+	It("blocks on the mix of one confirmed-down standby and one Ready-but-erroring standby", func() {
+		list := newList(
+			primary,
+			PostgresqlStatus{
+				Pod:                 &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "standby-confirmed-down"}},
+				IsWalReceiverActive: false,
+			},
+			PostgresqlStatus{
+				Pod:        &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "standby-unknown"}},
+				IsPodReady: true,
+				Error:      errStatusEndpointFailing,
+			},
+		)
+
+		down, unknown := list.AreWalReceiversDown(primary.Pod.Name)
+		Expect(down).To(BeFalse())
+		Expect(unknown).To(ConsistOf("standby-unknown"))
+	})
+
+	It("does not stall a genuine node-failure failover, where the dead standby is errored and not Ready", func() {
+		list := newList(
+			primary,
+			PostgresqlStatus{
+				Pod:                 &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "standby-alive"}},
+				IsWalReceiverActive: false,
+			},
+			PostgresqlStatus{
+				Pod:        &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "standby-dead-node"}},
+				IsPodReady: false,
+				Error:      errStatusEndpointFailing,
+			},
+		)
+
+		down, unknown := list.AreWalReceiversDown(primary.Pod.Name)
+		Expect(down).To(BeTrue())
+		Expect(unknown).To(BeEmpty())
+	})
+
+	It("does not finalize the failover even when the unknown standby holds the highest last-seen LSN", func() {
+		// Adversarial: the errored standby is the one that would otherwise be
+		// elected first by Less() (highest ReceivedLsn/ReplayLsn), but since
+		// its status is unknown the gate must still block on it rather than
+		// letting the sort order imply it is safe to proceed.
+		list := newList(
+			primary,
+			PostgresqlStatus{
+				Pod:                 &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "standby-behind"}},
+				IsWalReceiverActive: false,
+				ReceivedLsn:         "1/10",
+				ReplayLsn:           "1/10",
+			},
+			PostgresqlStatus{
+				Pod:         &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "standby-ahead-unknown"}},
+				IsPodReady:  true,
+				Error:       errStatusEndpointFailing,
+				ReceivedLsn: "1/99",
+				ReplayLsn:   "1/99",
+			},
+		)
+
+		down, unknown := list.AreWalReceiversDown(primary.Pod.Name)
+		Expect(down).To(BeFalse())
+		Expect(unknown).To(ConsistOf("standby-ahead-unknown"))
+	})
+})
+
 var _ = Describe("Configuration report", func() {
 	DescribeTable(
 		"Configuration report",


### PR DESCRIPTION
Stacked on #11260 and targets that branch, so the first commit in the diff
belongs there and is not part of this review. Refs #11251, which fixes the
opposite failure of the same gate.

**The problem.** When the operator cannot reach a standby, it concludes that
the standby's WAL receiver is down. It cannot tell "this standby told me its
receiver is down" apart from "this standby told me nothing", because a failed
`/pg/status` probe leaves `IsWalReceiverActive` at its Go zero value, `false`,
which is the same value a genuinely stopped receiver reports.

**Why it matters.** That conclusion is what the operator uses to decide a
failover is safe to finalize. So a standby that is streaming happily from the
old primary, but that the operator momentarily could not reach, is counted as
proof that nothing is still advancing. The operator promotes a less advanced
candidate, the standby it could not see ends up ahead of the new primary, and
we get exactly the divergence this gate exists to prevent. It takes nothing
exotic: probe timeouts are not retried, so one slow or dropped probe is enough.

**What this PR does.** It makes the gate treat unreachable as unknown rather
than as down, deciding by kubelet readiness when our own probe fails:

| Standby's status | Before | After |
|---|---|---|
| Reports receiver up | blocks | blocks |
| Reports receiver down | proceeds | proceeds |
| Probe failed, pod still Ready per kubelet | **proceeds** | **blocks, warning event** |
| Probe failed, pod not Ready per kubelet | proceeds | proceeds |

Only the third row changes. The fourth deliberately still proceeds: if kubelet
says the pod is gone, a dead standby is not streaming, and blocking there would
stall every ordinary node-failure failover.

This is the same signal we already trust for a primary that is Ready but not
reporting. That guard has the right instinct and was simply never generalized
to standbys, which is the hole being closed.

**Does blocking on unknown introduce a new hang?** No unbounded one. A wedged
standby fails its liveness probe, kubelet restarts the container, the pod stops
being Ready, and the fourth row reclassifies it, bounded by the existing
`.spec.livenessProbeTimeout`. What remains is the narrow case where kubelet can
reach a pod that the operator cannot, and there blocking is the correct answer:
the operator provably does not know that standby's LSN, so it has no sound
basis on which to finalize an election. The warning event makes the wait
visible in `kubectl describe cluster` instead of looking like a hang.

**The rest of the diff.** The same conflation was live at three other call
sites, each fixed on top of the `InstanceSet` partition from the base branch:
the switchover target could be chosen from an instance whose status was never
observed, a backup could be assigned to one, and `kubectl cnpg status` printed
confident blanks for an unreachable primary rather than saying the status is
unknown.
