### PR TITLE
fix: stop abandoning the fast shutdown after 60 seconds

### DIFF
--- a/pkg/management/postgres/instance.go
+++ b/pkg/management/postgres/instance.go
@@ -666,6 +666,11 @@ func (instance *Instance) TryShuttingDownSmartFast(ctx context.Context) error {
 			shutdownOptions{
 				Mode: shutdownModeFast,
 				Wait: true,
+				// Without an explicit timeout pg_ctl would fall back to its own implicit 60
+				// seconds, give up, and let us exit while PostgreSQL is still shutting down.
+				// stopDelay is the Pod's termination grace period, so waiting for it leaves
+				// the decision to terminate to the kubelet.
+				Timeout: &maxStopDelay,
 			},
 		)
 	}


### PR DESCRIPTION
The fast shutdown request carried no explicit timeout, so pg_ctl fell back to its own implicit 60 seconds and exited nonzero once that elapsed. The instance manager logged the error and returned, and being PID 1 in the container it took PostgreSQL down mid-shutdown. A cluster configured with a large stopDelay never got to use it.

The fast phase now waits for stopDelay, the Pod's termination grace period, so the kubelet decides when time is up.

The same call also backs the reconciler-triggered restart, which has no Pod termination behind it. There the missing timeout only produced a misleading error log, since that path's own timeout (RequestAndWaitRestartSmartFast) already governs completion independently. The finite timeout keeps the log accurate.

Deliberately out of scope, to keep this to the one line that is actually broken: docs/src/instance_manager.md says the process will "then forcibly shut down" after the fast phase. The instance manager itself does not escalate to immediate mode there; if the timeout is reached, it's the kubelet that ends things once the Pod's termination grace period expires.

Worth reading alongside #11265, which changes `Shutdown` itself so that the
pre-shutdown CHECKPOINT and the `pg_ctl` call share a single deadline. The two do
not overlap: that PR touches the switchover path and the budget arithmetic, this
one the pod termination path, and they merge cleanly. They do compose, though.
Once both are in, the CHECKPOINT on this path stops being unbounded and shares
the `stopDelay` budget introduced here with `pg_ctl`, rather than running for as
long as it likes before `pg_ctl` starts its own clock.
