### PR TITLE
fix: treat a missing empty-valued key as not a subset in IsMapSubset

### DIFF
--- a/pkg/utils/operations.go
+++ b/pkg/utils/operations.go
@@ -56,9 +56,9 @@ func IsMapSubset(mapSet map[string]string, mapSubset map[string]string) bool {
 	}
 
 	for subMapKey, subMapValue := range mapSubset {
-		mapValue := mapSet[subMapKey]
+		mapValue, ok := mapSet[subMapKey]
 
-		if mapValue != subMapValue {
+		if !ok || mapValue != subMapValue {
 			return false
 		}
 	}

--- a/pkg/utils/operations_test.go
+++ b/pkg/utils/operations_test.go
@@ -66,6 +66,20 @@ var _ = Describe("Set relationship between maps", func() {
 	It("Two equal maps are subsets", func() {
 		Expect(IsMapSubset(map[string]string{"one": "1"}, map[string]string{"one": "1"})).To(BeTrue())
 	})
+
+	It("A key with an empty value that is missing from the superset breaks the subset relationship", func() {
+		Expect(IsMapSubset(
+			map[string]string{"one": "1", "two": "2"},
+			map[string]string{"one": "1", "missing": ""},
+		)).To(BeFalse())
+	})
+
+	It("A key with an empty value that is present in the superset keeps the subset relationship", func() {
+		Expect(IsMapSubset(
+			map[string]string{"one": "1", "empty": ""},
+			map[string]string{"empty": ""},
+		)).To(BeTrue())
+	})
 })
 
 var _ = Describe("Testing Annotations and labels subset", func() {


### PR DESCRIPTION
While reading the label and annotation reconciliation path I noticed that `IsMapSubset` can report a subset when it should not.

The loop reads `mapSet[key]` with the single-return map index, so a key that is absent from `mapSet` comes back as the empty string. If `mapSubset` holds a key with an empty value that `mapSet` does not contain, the comparison `"" != ""` is false and the key is treated as present, so the function returns true even though the key is not in the superset. The length guard does not catch this when the two maps have the same size but differ by such a key, for example `mapSet={one:1,two:2}` against `mapSubset={one:1,missing:""}`.

This surfaces through `IsLabelSubset` and `IsAnnotationSubset`, which the pod, PVC and service reconcilers use to decide whether inherited labels and annotations are already applied (`pkg/reconciler/instance/metadata.go`, `pkg/reconciler/persistentvolumeclaim/metadata.go`, `internal/controller/cluster_create.go`). Kubernetes allows empty label and annotation values, so an inherited label with an empty value would be reported as already present and never propagated to the managed object. It is a silent drift-detection miss, not a crash.

The fix switches to the comma-ok form and returns false when the key is missing. I added two cases to the existing spec: one where a missing empty-valued key breaks the relationship, and one where an empty-valued key that is present keeps it, so we do not over-correct into rejecting legitimate empty values.

Verified locally with `go test ./pkg/utils/`: the first new case fails before the one-line change (116 passed, 1 failed) and the package passes after. `gofmt -l` is clean on both touched files.