### PR TITLE
fix: demote a primary that stopped reporting its status

### DIFF
--- a/internal/controller/cluster_status.go
+++ b/internal/controller/cluster_status.go
@@ -757,17 +757,22 @@ func (r *ClusterReconciler) updateClusterStatusThatRequiresInstancesState(
 	// be left untouched rather than overwritten with zeros, because "we do
 	// not know" must not erase the last thing we did know.
 	//
-	// Membership in statuses.Items this pass is what tells apart "silent but
-	// still part of the cluster" from "no longer part of the cluster"
-	// (scaled down, or the pod was replaced under the same name). AddPod
-	// (pkg/postgres/status.go) runs unconditionally regardless of the probe
-	// outcome, and GetStatusFromInstances keeps one item per pod that
-	// survives filtering rather than dropping the ones whose probe failed,
-	// so every instance that still belongs to the cluster appears in
-	// statuses.Items this pass, silent or not. Only names absent from
-	// statuses.Items entirely are pruned below, which keeps
-	// ensureInstancesAreReachable (pkg/management/postgres/webserver/probes/pinger.go)
-	// from pinging the IP of a pod that is actually gone.
+	// Membership in statuses.Items this pass is what keeps a silent instance
+	// from being pruned. Every pod that gets probed lands in statuses.Items
+	// whatever the probe outcome, because AddPod (pkg/postgres/status.go)
+	// fills in the pod-derived fields regardless and extractInstancesStatus
+	// appends the item even when the probe errored, so an instance that is
+	// merely not answering right now keeps its entry.
+	//
+	// A pod is absent from statuses.Items when it is gone (scaled down) and
+	// also while it is being replaced, because GetStatusFromInstances probes
+	// only the pods accepted by utils.IsPodActive, which rules out the pending
+	// and terminating ones. Pruning in that window is what we want: the entry
+	// goes away before the replacement pod exists, so a preserved entry can
+	// never hand ensureInstancesAreReachable
+	// (pkg/management/postgres/webserver/probes/pinger.go) the IP of a pod
+	// that is gone, nor one that has since been reassigned to a different pod
+	// carrying the same name.
 	if cluster.Status.InstancesReportedState == nil {
 		cluster.Status.InstancesReportedState = make(map[apiv1.PodName]apiv1.InstanceReportedState, len(statuses.Items))
 	}

--- a/internal/controller/cluster_status.go
+++ b/internal/controller/cluster_status.go
@@ -751,20 +751,59 @@ func (r *ClusterReconciler) updateClusterStatusThatRequiresInstancesState(
 	statuses postgres.PostgresqlStatusList,
 ) error {
 	existingClusterStatus := cluster.Status
-	cluster.Status.InstancesReportedState = make(map[apiv1.PodName]apiv1.InstanceReportedState, len(statuses.Items))
 
-	// we extract the instances reported state
-	for _, item := range statuses.Items {
+	// InstancesReportedState is preserved across reconciliations, not rebuilt
+	// from scratch: a silent instance's entry (its status probe failed) must
+	// be left untouched rather than overwritten with zeros, because "we do
+	// not know" must not erase the last thing we did know.
+	//
+	// Membership in statuses.Items this pass is what tells apart "silent but
+	// still part of the cluster" from "no longer part of the cluster"
+	// (scaled down, or the pod was replaced under the same name). AddPod
+	// (pkg/postgres/status.go) runs unconditionally regardless of the probe
+	// outcome, and GetStatusFromInstances keeps one item per pod that
+	// survives filtering rather than dropping the ones whose probe failed,
+	// so every instance that still belongs to the cluster appears in
+	// statuses.Items this pass, silent or not. Only names absent from
+	// statuses.Items entirely are pruned below, which keeps
+	// ensureInstancesAreReachable (pkg/management/postgres/webserver/probes/pinger.go)
+	// from pinging the IP of a pod that is actually gone.
+	if cluster.Status.InstancesReportedState == nil {
+		cluster.Status.InstancesReportedState = make(map[apiv1.PodName]apiv1.InstanceReportedState, len(statuses.Items))
+	}
+
+	instanceSet := statuses.Partition()
+	currentNames := stringset.New()
+
+	// we extract the instances reported state from the instances actually
+	// reporting their status; a silent instance keeps whatever entry (if
+	// any) it already had.
+	for i := range instanceSet.Reporting.Items {
+		item := &instanceSet.Reporting.Items[i]
+		currentNames.Put(item.Pod.Name)
 		cluster.Status.InstancesReportedState[apiv1.PodName(item.Pod.Name)] = apiv1.InstanceReportedState{
 			IsPrimary:  item.IsPrimary,
 			TimeLineID: item.TimeLineID,
 			IP:         item.Pod.Status.PodIP,
 		}
 	}
+	for _, silent := range instanceSet.ReadyButSilent {
+		currentNames.Put(silent.Pod.Name)
+	}
+	for _, silent := range instanceSet.NotReady {
+		currentNames.Put(silent.Pod.Name)
+	}
+
+	for name := range cluster.Status.InstancesReportedState {
+		if !currentNames.Has(string(name)) {
+			delete(cluster.Status.InstancesReportedState, name)
+		}
+	}
 
 	// we update any relevant cluster status that depends on the primary instance
 	detectedSystemID := stringset.New()
-	for _, item := range statuses.Items {
+	for i := range instanceSet.Reporting.Items {
+		item := &instanceSet.Reporting.Items[i]
 		// we refresh the last known timeline on the status root.
 		// This avoids to have a zero timeline id in case that no primary instance is up during reconciliation.
 		if item.IsPrimary && item.TimeLineID != 0 {

--- a/internal/controller/cluster_status_test.go
+++ b/internal/controller/cluster_status_test.go
@@ -485,6 +485,55 @@ var _ = Describe("updateClusterStatusThatRequiresInstancesState tests", func() {
 		Expect(state2.TimeLineID).To(Equal(456))
 	})
 
+	It("ignores the fields carried by a silent instance, not just the zeroed ones", func(ctx SpecContext) {
+		statusErr := fmt.Errorf("status endpoint failing")
+
+		firstPass := postgres.PostgresqlStatusList{
+			Items: []postgres.PostgresqlStatus{
+				{
+					Pod: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{Name: "pod-1"},
+						Status:     corev1.PodStatus{PodIP: "192.168.1.1"},
+					},
+					IsPrimary:  true,
+					TimeLineID: 123,
+				},
+			},
+		}
+		err := env.clusterReconciler.updateClusterStatusThatRequiresInstancesState(ctx, cluster, firstPass)
+		Expect(err).ToNot(HaveOccurred())
+
+		// pod-1's probe fails, but this time the status it carries is not
+		// zero-valued: it disagrees with the last known observation on every
+		// field. Whether an entry is written must depend on Error alone, never
+		// on the values happening to look empty.
+		secondPass := postgres.PostgresqlStatusList{
+			Items: []postgres.PostgresqlStatus{
+				{
+					Pod: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{Name: "pod-1"},
+						Status:     corev1.PodStatus{PodIP: "192.168.1.99"},
+					},
+					IsPrimary:  false,
+					TimeLineID: 999,
+					IsPodReady: true,
+					Error:      statusErr,
+				},
+			},
+		}
+		err = env.clusterReconciler.updateClusterStatusThatRequiresInstancesState(ctx, cluster, secondPass)
+		Expect(err).ToNot(HaveOccurred())
+
+		state1 := cluster.Status.InstancesReportedState["pod-1"]
+		Expect(state1.IsPrimary).To(BeTrue())
+		Expect(state1.TimeLineID).To(Equal(123))
+		Expect(state1.IP).To(Equal("192.168.1.1"))
+
+		// the timeline on the status root is fed from the same reporting set,
+		// so an unreported timeline must not reach it either.
+		Expect(cluster.Status.TimelineID).To(Equal(123))
+	})
+
 	It("removes the entry of an instance that no longer belongs to the cluster", func(ctx SpecContext) {
 		firstPass := postgres.PostgresqlStatusList{
 			Items: []postgres.PostgresqlStatus{

--- a/internal/controller/cluster_status_test.go
+++ b/internal/controller/cluster_status_test.go
@@ -421,6 +421,136 @@ var _ = Describe("updateClusterStatusThatRequiresInstancesState tests", func() {
 		Expect(state2.IP).To(Equal("192.168.1.2"))
 	})
 
+	It("preserves the entry of a previously-reporting instance that goes silent", func(ctx SpecContext) {
+		statusErr := fmt.Errorf("status endpoint failing")
+
+		firstPass := postgres.PostgresqlStatusList{
+			Items: []postgres.PostgresqlStatus{
+				{
+					Pod: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{Name: "pod-1"},
+						Status:     corev1.PodStatus{PodIP: "192.168.1.1"},
+					},
+					IsPrimary:  true,
+					TimeLineID: 123,
+				},
+				{
+					Pod: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{Name: "pod-2"},
+						Status:     corev1.PodStatus{PodIP: "192.168.1.2"},
+					},
+					IsPrimary:  false,
+					TimeLineID: 123,
+				},
+			},
+		}
+		err := env.clusterReconciler.updateClusterStatusThatRequiresInstancesState(ctx, cluster, firstPass)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(cluster.Status.InstancesReportedState).To(HaveLen(2))
+
+		// pod-1 goes silent (its probe fails) but is still present in the
+		// cluster (it appears in this pass's Items, ready and unreachable),
+		// while pod-2 keeps reporting normally.
+		secondPass := postgres.PostgresqlStatusList{
+			Items: []postgres.PostgresqlStatus{
+				{
+					Pod:        &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-1"}},
+					IsPodReady: true,
+					Error:      statusErr,
+				},
+				{
+					Pod: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{Name: "pod-2"},
+						Status:     corev1.PodStatus{PodIP: "192.168.1.2"},
+					},
+					IsPrimary:  false,
+					TimeLineID: 456,
+				},
+			},
+		}
+		err = env.clusterReconciler.updateClusterStatusThatRequiresInstancesState(ctx, cluster, secondPass)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(cluster.Status.InstancesReportedState).To(HaveLen(2))
+
+		// pod-1's entry is untouched: still the last known good observation,
+		// not zeroed out because its current probe failed.
+		state1 := cluster.Status.InstancesReportedState["pod-1"]
+		Expect(state1.IsPrimary).To(BeTrue())
+		Expect(state1.TimeLineID).To(Equal(123))
+		Expect(state1.IP).To(Equal("192.168.1.1"))
+
+		// pod-2 keeps being refreshed normally.
+		state2 := cluster.Status.InstancesReportedState["pod-2"]
+		Expect(state2.TimeLineID).To(Equal(456))
+	})
+
+	It("removes the entry of an instance that no longer belongs to the cluster", func(ctx SpecContext) {
+		firstPass := postgres.PostgresqlStatusList{
+			Items: []postgres.PostgresqlStatus{
+				{
+					Pod: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{Name: "pod-1"},
+						Status:     corev1.PodStatus{PodIP: "192.168.1.1"},
+					},
+					IsPrimary:  true,
+					TimeLineID: 123,
+				},
+				{
+					Pod: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{Name: "pod-2"},
+						Status:     corev1.PodStatus{PodIP: "192.168.1.2"},
+					},
+					IsPrimary:  false,
+					TimeLineID: 123,
+				},
+			},
+		}
+		err := env.clusterReconciler.updateClusterStatusThatRequiresInstancesState(ctx, cluster, firstPass)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(cluster.Status.InstancesReportedState).To(HaveLen(2))
+
+		// The cluster is scaled down: pod-2 no longer appears at all, not
+		// even as a silent entry.
+		secondPass := postgres.PostgresqlStatusList{
+			Items: []postgres.PostgresqlStatus{
+				{
+					Pod: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{Name: "pod-1"},
+						Status:     corev1.PodStatus{PodIP: "192.168.1.1"},
+					},
+					IsPrimary:  true,
+					TimeLineID: 123,
+				},
+			},
+		}
+		err = env.clusterReconciler.updateClusterStatusThatRequiresInstancesState(ctx, cluster, secondPass)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(cluster.Status.InstancesReportedState).To(HaveLen(1))
+		Expect(cluster.Status.InstancesReportedState).To(HaveKey(apiv1.PodName("pod-1")))
+		Expect(cluster.Status.InstancesReportedState).ToNot(HaveKey(apiv1.PodName("pod-2")))
+	})
+
+	It("does not create an entry for an instance whose first-ever observation is silent", func(ctx SpecContext) {
+		statusErr := fmt.Errorf("status endpoint failing")
+
+		statuses := postgres.PostgresqlStatusList{
+			Items: []postgres.PostgresqlStatus{
+				{
+					Pod:        &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-1"}},
+					IsPodReady: true,
+					Error:      statusErr,
+				},
+			},
+		}
+
+		err := env.clusterReconciler.updateClusterStatusThatRequiresInstancesState(ctx, cluster, statuses)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(cluster.Status.InstancesReportedState).ToNot(HaveKey(apiv1.PodName("pod-1")))
+	})
+
 	Context("Pod termination reason detection", func() {
 		It("should detect when a pod has no PostgreSQL container", func() {
 			pod := &corev1.Pod{

--- a/pkg/postgres/instance_set.go
+++ b/pkg/postgres/instance_set.go
@@ -1,0 +1,95 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package postgres
+
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
+// SilentInstance is an instance whose /pg/status probe failed. Only the
+// fields that are populated regardless of the probe outcome (see AddPod)
+// are available here, so a caller cannot accidentally read an unobserved
+// field as if it were real data.
+type SilentInstance struct {
+	// Pod is the instance's Pod, as known independently of the probe.
+	Pod *corev1.Pod
+
+	// Node is the name of the node the Pod is running on.
+	Node string
+
+	// Error is the error returned by the failed probe.
+	Error error
+}
+
+// InstanceSet partitions a PostgresqlStatusList by what is actually known
+// about each instance, so that decision code cannot read an observed field
+// (e.g. IsWalReceiverActive, IsPrimary, TimeLineID) off an instance whose
+// status probe failed.
+type InstanceSet struct {
+	// Reporting are the instances whose /pg/status probe succeeded. Every
+	// field on these items is a real observation.
+	Reporting PostgresqlStatusList
+
+	// ReadyButSilent are instances whose probe failed while kubelet still
+	// reports the Pod as Ready: the operator cannot tell whether PostgreSQL
+	// stopped or the pod merely became unreachable, so these must be treated
+	// as unknown, not as "down".
+	ReadyButSilent []SilentInstance
+
+	// NotReady are instances whose probe failed and kubelet no longer
+	// reports the Pod as Ready: kubelet's readiness verdict is trusted over
+	// the failing probe, so these can be treated as gone.
+	NotReady []SilentInstance
+}
+
+// Partition splits the status list into the instances we actually heard
+// from (Reporting) and the instances whose probe failed, further divided by
+// whether kubelet still considers the Pod Ready (ReadyButSilent) or not
+// (NotReady).
+func (list PostgresqlStatusList) Partition() InstanceSet {
+	set := InstanceSet{
+		Reporting: PostgresqlStatusList{
+			IsReplicaCluster: list.IsReplicaCluster,
+			CurrentPrimary:   list.CurrentPrimary,
+		},
+	}
+
+	for idx := range list.Items {
+		item := &list.Items[idx]
+
+		if item.Error == nil {
+			set.Reporting.Items = append(set.Reporting.Items, *item)
+			continue
+		}
+
+		silent := SilentInstance{
+			Pod:   item.Pod,
+			Node:  item.Node,
+			Error: item.Error,
+		}
+		if item.IsPodReady {
+			set.ReadyButSilent = append(set.ReadyButSilent, silent)
+		} else {
+			set.NotReady = append(set.NotReady, silent)
+		}
+	}
+
+	return set
+}

--- a/pkg/postgres/instance_set_test.go
+++ b/pkg/postgres/instance_set_test.go
@@ -1,0 +1,131 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package postgres
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Partition", func() {
+	errStatusEndpointFailing := fmt.Errorf("status endpoint failing")
+
+	It("puts an all-reporting list entirely into Reporting", func() {
+		list := PostgresqlStatusList{
+			Items: []PostgresqlStatus{
+				{Pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "one"}}},
+				{Pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "two"}}},
+			},
+		}
+
+		set := list.Partition()
+		Expect(set.Reporting.Items).To(HaveLen(2))
+		Expect(set.ReadyButSilent).To(BeEmpty())
+		Expect(set.NotReady).To(BeEmpty())
+	})
+
+	It("puts an all-silent list entirely into ReadyButSilent or NotReady", func() {
+		list := PostgresqlStatusList{
+			Items: []PostgresqlStatus{
+				{
+					Pod:        &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "ready-silent"}},
+					IsPodReady: true,
+					Error:      errStatusEndpointFailing,
+				},
+				{
+					Pod:        &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "not-ready-silent"}},
+					IsPodReady: false,
+					Error:      errStatusEndpointFailing,
+				},
+			},
+		}
+
+		set := list.Partition()
+		Expect(set.Reporting.Items).To(BeEmpty())
+		Expect(set.ReadyButSilent).To(HaveLen(1))
+		Expect(set.NotReady).To(HaveLen(1))
+	})
+
+	It("handles an empty list", func() {
+		set := PostgresqlStatusList{}.Partition()
+		Expect(set.Reporting.Items).To(BeEmpty())
+		Expect(set.ReadyButSilent).To(BeEmpty())
+		Expect(set.NotReady).To(BeEmpty())
+	})
+
+	It("splits a mixed list correctly", func() {
+		list := PostgresqlStatusList{
+			Items: []PostgresqlStatus{
+				{
+					Pod:  &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "reporting"}},
+					Node: "node-1",
+				},
+				{
+					Pod:        &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "ready-silent"}},
+					Node:       "node-2",
+					IsPodReady: true,
+					Error:      errStatusEndpointFailing,
+				},
+				{
+					Pod:        &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "not-ready-silent"}},
+					Node:       "node-3",
+					IsPodReady: false,
+					Error:      errStatusEndpointFailing,
+				},
+			},
+		}
+
+		set := list.Partition()
+		Expect(set.Reporting.Items).To(HaveLen(1))
+		Expect(set.Reporting.Items[0].Pod.Name).To(Equal("reporting"))
+
+		Expect(set.ReadyButSilent).To(HaveLen(1))
+		Expect(set.ReadyButSilent[0].Pod.Name).To(Equal("ready-silent"))
+		Expect(set.ReadyButSilent[0].Node).To(Equal("node-2"))
+		Expect(set.ReadyButSilent[0].Error).To(MatchError(errStatusEndpointFailing))
+
+		Expect(set.NotReady).To(HaveLen(1))
+		Expect(set.NotReady[0].Pod.Name).To(Equal("not-ready-silent"))
+		Expect(set.NotReady[0].Node).To(Equal("node-3"))
+		Expect(set.NotReady[0].Error).To(MatchError(errStatusEndpointFailing))
+	})
+
+	It("never lets a reporting item leak into either silent group", func() {
+		list := PostgresqlStatusList{
+			Items: []PostgresqlStatus{
+				{
+					Pod:        &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "reporting-but-not-ready"}},
+					IsPodReady: false,
+					Error:      nil,
+				},
+			},
+		}
+
+		set := list.Partition()
+		Expect(set.Reporting.Items).To(HaveLen(1))
+		Expect(set.ReadyButSilent).To(BeEmpty())
+		Expect(set.NotReady).To(BeEmpty())
+	})
+})

--- a/pkg/reconciler/replicaclusterswitch/reconciler.go
+++ b/pkg/reconciler/replicaclusterswitch/reconciler.go
@@ -64,8 +64,20 @@ func Reconcile(
 	}
 
 	if !containsPrimaryInstance(instances) {
-		// no primary instance present means that we have no work to do
-		return nil, nil
+		// An instance that did not report its status looks exactly like one
+		// that is not a primary, so a failing probe would have us skip the
+		// demotion of a primary that is still accepting writes. Fall back on
+		// what we last knew about it: fencing goes through the API server, so
+		// stopping that primary does not require the operator to reach it.
+		if !lastKnownPrimaryIsSilent(cluster, instances) {
+			// no primary instance present means that we have no work to do
+			return nil, nil
+		}
+
+		contextLogger.Info(
+			"the instance last known as the primary is not reporting its status, "+
+				"starting the transition to replica cluster on its last known state",
+			"currentPrimary", cluster.Status.CurrentPrimary)
 	}
 
 	return startTransition(ctx, cli, cluster)
@@ -76,6 +88,48 @@ func containsPrimaryInstance(instances postgres.PostgresqlStatusList) bool {
 		if item.IsPrimary {
 			return true
 		}
+	}
+
+	return false
+}
+
+// lastKnownPrimaryIsSilent returns true when the instance the operator last
+// observed as the primary is still part of the cluster but failed to report its
+// status, leaving the absence of a reporting primary unproven.
+//
+// The verdict rests on .status.instancesReportedState, which keeps the last
+// observation of an instance that has gone silent. A designated primary never
+// qualifies: it runs with a standby.signal file, so Instance.IsPrimary
+// (pkg/management/postgres/instance.go) reports it as a replica and no
+// observation of it ever recorded a primary. A cluster that has already been
+// demoted is excluded through its stored demotion token, which is emptied only
+// when the cluster stops being a replica, so a probe failing right after a
+// completed transition cannot start a second one.
+func lastKnownPrimaryIsSilent(cluster *apiv1.Cluster, instances postgres.PostgresqlStatusList) bool {
+	if cluster.Status.DemotionToken != "" {
+		return false
+	}
+
+	primaryName := cluster.Status.CurrentPrimary
+	if primaryName == "" {
+		return false
+	}
+
+	if lastKnown, ok := cluster.Status.InstancesReportedState[apiv1.PodName(primaryName)]; !ok ||
+		!lastKnown.IsPrimary {
+		return false
+	}
+
+	// The instance must still be part of the probed ones. An instance missing
+	// from the status list has no PostgreSQL to stop: its pod is being deleted
+	// or recreated, or it is gone from the cluster altogether.
+	for i := range instances.Items {
+		item := &instances.Items[i]
+		if item.Pod == nil || item.Pod.Name != primaryName {
+			continue
+		}
+
+		return item.Error != nil
 	}
 
 	return false

--- a/pkg/reconciler/replicaclusterswitch/reconciler_test.go
+++ b/pkg/reconciler/replicaclusterswitch/reconciler_test.go
@@ -21,15 +21,18 @@ package replicaclusterswitch
 
 import (
 	"context"
+	"errors"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	schemeBuilder "github.com/cloudnative-pg/cloudnative-pg/internal/scheme"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres/webserver/client/remote"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/postgres"
+	"github.com/cloudnative-pg/cloudnative-pg/pkg/reconciler/replicaclusterswitch/conditions"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -146,5 +149,153 @@ var _ = Describe("reconcileDemotionToken", func() {
 		Expect(cluster.Status.DemotionToken).To(Equal(expectedToken))
 		// The partial WAL is archived only when a fresh token is generated.
 		Expect(instanceClient.archiveCalls).To(BeZero())
+	})
+})
+
+var _ = Describe("Reconcile of a replica cluster whose primary is silent", func() {
+	const primaryPodName = "cluster-a-1"
+
+	// buildCluster returns a cluster that has just been switched to replica
+	// cluster mode: no transition condition is set yet, and the last known
+	// state of its primary is whatever the caller passes.
+	buildCluster := func(lastKnown map[apiv1.PodName]apiv1.InstanceReportedState) *apiv1.Cluster {
+		return &apiv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{Name: "cluster-a", Namespace: "default"},
+			Spec: apiv1.ClusterSpec{
+				Instances: 1,
+				ReplicaCluster: &apiv1.ReplicaClusterConfiguration{
+					Primary: "cluster-b",
+					Source:  "cluster-b",
+				},
+			},
+			Status: apiv1.ClusterStatus{
+				CurrentPrimary:         primaryPodName,
+				TargetPrimary:          primaryPodName,
+				InstancesReportedState: lastKnown,
+			},
+		}
+	}
+
+	lastKnownPrimary := map[apiv1.PodName]apiv1.InstanceReportedState{
+		primaryPodName: {IsPrimary: true, TimeLineID: 1, IP: "10.0.0.1"},
+	}
+
+	// silentPrimary is the status list of a pod that is still probed, still
+	// kubelet-ready, but whose /pg/status call failed: every observed field,
+	// IsPrimary included, is left at its zero value.
+	silentPrimary := postgres.PostgresqlStatusList{
+		Items: []postgres.PostgresqlStatus{
+			{
+				Pod:        &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: primaryPodName}},
+				IsPodReady: true,
+				Error:      errors.New("connection refused"),
+			},
+		},
+	}
+
+	buildClient := func(cluster *apiv1.Cluster) client.Client {
+		return fake.NewClientBuilder().
+			WithScheme(schemeBuilder.BuildWithAllKnownScheme()).
+			WithObjects(cluster).
+			WithStatusSubresource(cluster).
+			Build()
+	}
+
+	// expectTransitionStarted asserts on the persisted object, since fencing
+	// and the conditions are written through the client.
+	expectTransitionStarted := func(ctx context.Context, cli client.Client, started bool) {
+		var persisted apiv1.Cluster
+		Expect(cli.Get(ctx, client.ObjectKey{Name: "cluster-a", Namespace: "default"}, &persisted)).To(Succeed())
+		Expect(persisted.IsInstanceFenced(primaryPodName)).To(Equal(started))
+		Expect(conditions.IsDesignatedPrimaryTransitionRequested(&persisted)).To(Equal(started))
+	}
+
+	It("starts the transition on the last known state of a silent primary", func(ctx SpecContext) {
+		cluster := buildCluster(lastKnownPrimary)
+		cli := buildClient(cluster)
+
+		res, err := Reconcile(ctx, cli, cluster, nil, silentPrimary)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(res).ToNot(BeNil())
+		expectTransitionStarted(ctx, cli, true)
+	})
+
+	It("keeps starting the transition for a primary that does report", func(ctx SpecContext) {
+		cluster := buildCluster(lastKnownPrimary)
+		cli := buildClient(cluster)
+		reporting := postgres.PostgresqlStatusList{
+			Items: []postgres.PostgresqlStatus{
+				{
+					Pod:       &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: primaryPodName}},
+					IsPrimary: true,
+				},
+			},
+		}
+
+		res, err := Reconcile(ctx, cli, cluster, nil, reporting)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(res).ToNot(BeNil())
+		expectTransitionStarted(ctx, cli, true)
+	})
+
+	It("does nothing when the silent instance was never observed as a primary", func(ctx SpecContext) {
+		// This is a cluster created as a replica cluster: its designated
+		// primary runs with a standby.signal file, so it is always observed as
+		// a replica. A failing probe must not be read as a primary to demote.
+		cluster := buildCluster(map[apiv1.PodName]apiv1.InstanceReportedState{
+			primaryPodName: {IsPrimary: false, TimeLineID: 1, IP: "10.0.0.1"},
+		})
+		cli := buildClient(cluster)
+
+		res, err := Reconcile(ctx, cli, cluster, nil, silentPrimary)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(res).To(BeNil())
+		expectTransitionStarted(ctx, cli, false)
+	})
+
+	It("does nothing when the silent instance has no last known state at all", func(ctx SpecContext) {
+		cluster := buildCluster(nil)
+		cli := buildClient(cluster)
+
+		res, err := Reconcile(ctx, cli, cluster, nil, silentPrimary)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(res).To(BeNil())
+		expectTransitionStarted(ctx, cli, false)
+	})
+
+	It("does not start a second transition after the cluster has been demoted", func(ctx SpecContext) {
+		// A completed transition leaves a demotion token behind and removes its
+		// conditions, so a probe failing right afterwards must not fence the
+		// whole cluster again: the last known state still says primary until
+		// the demoted instance reports as a replica.
+		cluster := buildCluster(lastKnownPrimary)
+		cluster.Status.DemotionToken = "a-previously-generated-token"
+		cli := buildClient(cluster)
+
+		res, err := Reconcile(ctx, cli, cluster, nil, silentPrimary)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(res).To(BeNil())
+		expectTransitionStarted(ctx, cli, false)
+	})
+
+	It("does nothing when the last known primary is no longer among the probed instances", func(ctx SpecContext) {
+		// The pod is being deleted or recreated, so it is filtered out of the
+		// status list. There is no PostgreSQL left to stop by fencing it.
+		cluster := buildCluster(lastKnownPrimary)
+		cli := buildClient(cluster)
+		otherInstanceOnly := postgres.PostgresqlStatusList{
+			Items: []postgres.PostgresqlStatus{
+				{
+					Pod:        &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "cluster-a-2"}},
+					IsPodReady: true,
+					Error:      errors.New("connection refused"),
+				},
+			},
+		}
+
+		res, err := Reconcile(ctx, cli, cluster, nil, otherInstanceOnly)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(res).To(BeNil())
+		expectTransitionStarted(ctx, cli, false)
 	})
 })


### PR DESCRIPTION
Based on #11260, whose commits are included here: the fallback below reads
`.status.instancesReportedState`, which only becomes trustworthy once a failed
probe stops overwriting an instance's entry with zeros.

When a cluster is switched to replica cluster mode, `replicaclusterswitch`
looks for a primary among the instances that reported their status and, when it
finds one, fences the cluster to demote it. An instance whose `/pg/status`
probe failed reports no role at all, `IsPrimary` included, so a single failing
probe made `containsPrimaryInstance` return false and the reconciler take its
"no primary instance present means that we have no work to do" branch, skipping
the transition while that primary kept accepting writes.

Nothing else in that pass fences it either. `AllReadyInstancesStatusUnreachable`
only trips when every ready instance is silent, and the `IsComplete` gate that
does stop the reconcile sits further down, past the point where the demotion
would have started. The pass is requeued about ten seconds later by
`evaluatePodReadinessGuards`, so the demotion does eventually happen, but only
once the probe answers again: for as long as the operator could not reach an
instance that clients could, the cluster was a replica cluster on paper with a
writable primary behind it.

The decision now falls back on the last state observed for the instance
recorded as the current primary. Fencing is a metadata write that goes through
the API server, so stopping that primary never required reaching it in the
first place, and the transition completes on the instance manager's own watch of
the Cluster object rather than on an operator probe.

The fallback is deliberately narrow, so that it fires only where a primary
really is at stake:

- it asks for an instance that was actually observed as a primary, which a
  designated primary never is since it runs with a `standby.signal` file, so a
  replica cluster created from scratch is left alone when its designated primary
  goes quiet;
- it requires the instance to still be among the probed ones, because one that
  has left the status list has no PostgreSQL left to stop;
- it steps aside once a demotion token exists, so a probe failing right after a
  completed transition cannot start a second one and fence a healthy replica
  cluster.

The package had no coverage of `Reconcile` at all, so the tests come with it:
the silent-primary case, the reporting-primary case that must keep working, and
one case per carve-out above.

There is no issue tracking this. It came out of reviewing #11260, which fixes
the fabricated data this fallback relies on not being fabricated.
