### PR TITLE
fix: delete running pods whose postgres container is gone

### DIFF
--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -1046,9 +1046,7 @@ func isPodStuckWithTerminatedPostgres(pod *corev1.Pod, now time.Time) bool {
 		}
 
 		if terminated.FinishedAt.IsZero() {
-			// A terminated container should always carry a termination
-			// timestamp; without one the grace period cannot be evaluated,
-			// so keep the conservative behavior
+			// no timestamp to evaluate the grace period against
 			return false
 		}
 

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -956,6 +956,14 @@ func (r *ClusterReconciler) reconcileResources(
 	return ctrl.Result{}, nil
 }
 
+// terminatedPostgresGracePeriod is how long deleteTerminatedPods waits, after
+// the postgres container of a running Pod terminated, before considering the
+// Pod stuck and deleting it. In the normal case the kubelet restarts the
+// terminated container within seconds (the container-level restart backoff is
+// capped at 5 minutes), so a container that stays terminated longer than this
+// period is not going to come back on its own.
+const terminatedPostgresGracePeriod = 5 * time.Minute
+
 // deleteTerminatedPods will delete the Pods that are terminated
 func (r *ClusterReconciler) deleteTerminatedPods(
 	ctx context.Context,
@@ -972,7 +980,8 @@ func (r *ClusterReconciler) deleteTerminatedPods(
 			continue
 		}
 
-		if pod.Status.Phase != corev1.PodSucceeded && pod.Status.Phase != corev1.PodFailed {
+		isTerminated := pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodFailed
+		if !isTerminated && !isPodStuckWithTerminatedPostgres(pod, time.Now()) {
 			continue
 		}
 
@@ -998,6 +1007,48 @@ func (r *ClusterReconciler) deleteTerminatedPods(
 	}
 
 	return nil, nil
+}
+
+// isPodStuckWithTerminatedPostgres detects an instance Pod whose postgres
+// container terminated and was never restarted by the kubelet, while another
+// container (typically a CNPG-I plugin sidecar, injected as a restartable
+// init container) keeps the Pod phase Running.
+//
+// In this state the Pod is beyond recovery without being recreated: the
+// instance manager is gone, so the operator cannot extract the instance
+// status, and the rollout logic skips non-ready Pods. At the same time the
+// Pod never reaches the Succeeded or Failed phase, so the phase-based branch
+// of deleteTerminatedPods does not catch it either, and the cluster remains
+// in "Waiting for the instances to become active" indefinitely (see #9770).
+// The kubelet is expected to restart such a container, but that can fail to
+// happen, for instance after a kubelet restart on Kubernetes versions
+// affected by kubernetes/kubernetes#137146.
+//
+// The grace period leaves the kubelet every opportunity to restart the
+// container on its own: a restart decision would move the container to a
+// Waiting state, which makes this predicate return false.
+func isPodStuckWithTerminatedPostgres(pod *corev1.Pod, now time.Time) bool {
+	if pod.Status.Phase != corev1.PodRunning {
+		return false
+	}
+
+	for i := range pod.Status.ContainerStatuses {
+		status := &pod.Status.ContainerStatuses[i]
+		if status.Name != specs.PostgresContainerName {
+			continue
+		}
+
+		terminated := status.State.Terminated
+		if terminated == nil {
+			// The container is running, or the kubelet already planned a
+			// restart (waiting state, e.g. CrashLoopBackOff)
+			return false
+		}
+
+		return now.Sub(terminated.FinishedAt.Time) > terminatedPostgresGracePeriod
+	}
+
+	return false
 }
 
 // processUnschedulableInstances will delete the Pods that cannot schedule

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -1045,6 +1045,13 @@ func isPodStuckWithTerminatedPostgres(pod *corev1.Pod, now time.Time) bool {
 			return false
 		}
 
+		if terminated.FinishedAt.IsZero() {
+			// A terminated container should always carry a termination
+			// timestamp; without one the grace period cannot be evaluated,
+			// so keep the conservative behavior
+			return false
+		}
+
 		return now.Sub(terminated.FinishedAt.Time) > terminatedPostgresGracePeriod
 	}
 

--- a/internal/controller/cluster_controller_test.go
+++ b/internal/controller/cluster_controller_test.go
@@ -1124,6 +1124,13 @@ var _ = Describe("isPodStuckWithTerminatedPostgres", func() {
 		Expect(isPodStuckWithTerminatedPostgres(pod, now)).To(BeFalse())
 	})
 
+	It("ignores a terminated postgres container without a termination timestamp", func() {
+		pod := podWithPostgresState(corev1.PodRunning, corev1.ContainerState{
+			Terminated: &corev1.ContainerStateTerminated{ExitCode: 0},
+		})
+		Expect(isPodStuckWithTerminatedPostgres(pod, now)).To(BeFalse())
+	})
+
 	It("ignores Pods without a postgres container", func() {
 		pod := &corev1.Pod{Status: corev1.PodStatus{Phase: corev1.PodRunning}}
 		Expect(isPodStuckWithTerminatedPostgres(pod, now)).To(BeFalse())

--- a/internal/controller/cluster_controller_test.go
+++ b/internal/controller/cluster_controller_test.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
@@ -979,5 +980,152 @@ var _ = Describe("mapClusterOwnedResourceToCluster", func() {
 
 	It("returns nil for an object that does not reference a cluster", func(ctx SpecContext) {
 		Expect(mapClusterOwnedResourceToCluster(ctx, &corev1.Secret{})).To(BeNil())
+	})
+})
+
+var _ = Describe("deleteTerminatedPods with a stuck running Pod (#9770)", func() {
+	var env *testingEnvironment
+	var namespace string
+	var cluster *apiv1.Cluster
+
+	BeforeEach(func() {
+		env = buildTestEnvironment()
+		namespace = newFakeNamespace(env.client)
+		cluster = newFakeCNPGCluster(env.client, namespace)
+	})
+
+	// newInstancePod builds an instance Pod, stores it in the fake client and
+	// applies the given status.
+	newInstancePod := func(ctx SpecContext, serial int, status corev1.PodStatus) *corev1.Pod {
+		pod, err := specs.NewInstance(ctx, *cluster, serial, true)
+		Expect(err).ToNot(HaveOccurred())
+		pod.Namespace = namespace
+		Expect(env.client.Create(ctx, pod)).To(Succeed())
+		pod.Status = status
+		return pod
+	}
+
+	stuckStatus := func(finishedAgo time.Duration) corev1.PodStatus {
+		return corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name: specs.PostgresContainerName,
+					State: corev1.ContainerState{
+						Terminated: &corev1.ContainerStateTerminated{
+							ExitCode:   0,
+							Reason:     "Completed",
+							FinishedAt: metav1.NewTime(time.Now().Add(-finishedAgo)),
+						},
+					},
+				},
+			},
+			InitContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name:    "plugin-sidecar",
+					Started: ptr.To(true),
+					State: corev1.ContainerState{
+						Running: &corev1.ContainerStateRunning{},
+					},
+				},
+			},
+		}
+	}
+
+	It("deletes a running Pod whose postgres container terminated beyond the grace period", func(ctx SpecContext) {
+		pod := newInstancePod(ctx, 1, stuckStatus(10*time.Minute))
+		resources := &managedResources{instances: corev1.PodList{Items: []corev1.Pod{*pod}}}
+
+		res, err := env.clusterReconciler.deleteTerminatedPods(ctx, cluster, resources)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(res).ToNot(BeNil())
+
+		var pods corev1.PodList
+		Expect(env.client.List(ctx, &pods, client.InNamespace(namespace))).To(Succeed())
+		Expect(pods.Items).To(BeEmpty(), "the stuck Pod should have been deleted")
+	})
+
+	It("leaves a Pod alone while the postgres container is within the grace period", func(ctx SpecContext) {
+		pod := newInstancePod(ctx, 1, stuckStatus(time.Minute))
+		resources := &managedResources{instances: corev1.PodList{Items: []corev1.Pod{*pod}}}
+
+		res, err := env.clusterReconciler.deleteTerminatedPods(ctx, cluster, resources)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(res).To(BeNil())
+
+		var pods corev1.PodList
+		Expect(env.client.List(ctx, &pods, client.InNamespace(namespace))).To(Succeed())
+		Expect(pods.Items).To(HaveLen(1))
+	})
+
+	It("still deletes Pods in a terminated phase", func(ctx SpecContext) {
+		pod := newInstancePod(ctx, 1, corev1.PodStatus{Phase: corev1.PodSucceeded})
+		resources := &managedResources{instances: corev1.PodList{Items: []corev1.Pod{*pod}}}
+
+		res, err := env.clusterReconciler.deleteTerminatedPods(ctx, cluster, resources)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(res).ToNot(BeNil())
+
+		var pods corev1.PodList
+		Expect(env.client.List(ctx, &pods, client.InNamespace(namespace))).To(Succeed())
+		Expect(pods.Items).To(BeEmpty())
+	})
+})
+
+var _ = Describe("isPodStuckWithTerminatedPostgres", func() {
+	now := time.Now()
+
+	podWithPostgresState := func(phase corev1.PodPhase, state corev1.ContainerState) *corev1.Pod {
+		return &corev1.Pod{
+			Status: corev1.PodStatus{
+				Phase: phase,
+				ContainerStatuses: []corev1.ContainerStatus{
+					{Name: specs.PostgresContainerName, State: state},
+				},
+			},
+		}
+	}
+
+	terminated := func(finishedAgo time.Duration) corev1.ContainerState {
+		return corev1.ContainerState{
+			Terminated: &corev1.ContainerStateTerminated{
+				ExitCode:   0,
+				FinishedAt: metav1.NewTime(now.Add(-finishedAgo)),
+			},
+		}
+	}
+
+	It("detects a postgres container terminated beyond the grace period", func() {
+		pod := podWithPostgresState(corev1.PodRunning, terminated(10*time.Minute))
+		Expect(isPodStuckWithTerminatedPostgres(pod, now)).To(BeTrue())
+	})
+
+	It("ignores a postgres container terminated within the grace period", func() {
+		pod := podWithPostgresState(corev1.PodRunning, terminated(time.Minute))
+		Expect(isPodStuckWithTerminatedPostgres(pod, now)).To(BeFalse())
+	})
+
+	It("ignores a running postgres container", func() {
+		pod := podWithPostgresState(corev1.PodRunning, corev1.ContainerState{
+			Running: &corev1.ContainerStateRunning{},
+		})
+		Expect(isPodStuckWithTerminatedPostgres(pod, now)).To(BeFalse())
+	})
+
+	It("ignores a postgres container waiting to be restarted by the kubelet", func() {
+		pod := podWithPostgresState(corev1.PodRunning, corev1.ContainerState{
+			Waiting: &corev1.ContainerStateWaiting{Reason: "CrashLoopBackOff"},
+		})
+		Expect(isPodStuckWithTerminatedPostgres(pod, now)).To(BeFalse())
+	})
+
+	It("ignores Pods in a non-running phase", func() {
+		pod := podWithPostgresState(corev1.PodSucceeded, terminated(10*time.Minute))
+		Expect(isPodStuckWithTerminatedPostgres(pod, now)).To(BeFalse())
+	})
+
+	It("ignores Pods without a postgres container", func() {
+		pod := &corev1.Pod{Status: corev1.PodStatus{Phase: corev1.PodRunning}}
+		Expect(isPodStuckWithTerminatedPostgres(pod, now)).To(BeFalse())
 	})
 })


### PR DESCRIPTION
Closes #9770

## What this PR does

Teaches `deleteTerminatedPods` to also delete instance Pods that stay in the `Running` phase while their `postgres` container has been terminated for longer than a grace period (5 minutes), so the Pod is recreated on its existing PVC and rejoins the cluster.

## The problem

When the `postgres` container of an instance Pod terminates and the kubelet never restarts it, while a CNPG-I plugin sidecar (a restartable init container) keeps running, the Pod stays in the `Running` phase with a dead main container. In this state the operator is deadlocked:

- `deleteTerminatedPods` (introduced in #2056 for #1593) only reacts to the `Succeeded`/`Failed` phases — never reached, because the live sidecar keeps the phase at `Running`;
- the rollout logic skips the Pod: `isInstanceNeedingRollout` returns early for non-ready Pods;
- the instance status cannot be extracted (the instance manager is gone), so every reconcile logs `Cannot extract Pod status ... connect: connection refused` and requeues.

The Pod is simultaneously "too alive" for `deleteTerminatedPods` and "too dead" for the rollout logic. The cluster remains in `Waiting for the instances to become active` until a human deletes the Pod — we observed 5 hours of this in production, and reporters in #9770 saw 44+ hours.

## How to get into this state

Reproduced deterministically on a scratch cluster (CNPG 1.28.1, plugin-barman-cloud 0.13.0):

1. Kubernetes 1.35.0–1.35.3 node (we used kubelet 1.35.2): these versions carry a kubelet regression — after a kubelet restart, main containers of pods with restartable init containers and a startup probe are not restarted after exiting (kubernetes/kubernetes#137146, fixed in ~1.35.4).
2. Restart the kubelet on the node hosting the primary (any config-management run can do this), with the instance Pod created before the restart.
3. Trigger a rolling update (we changed `resources`; an image change works too).
4. Replicas are recreated fine; after the switchover the demoted primary's instance manager exits (exit 0), the kubelet never restarts the container, the barman plugin sidecar keeps running — the Pod is now `1/2 Running` with kubectl showing `Completed`, and the cluster is stuck.

The kubelet regression is one arming path; #9770/#9107 reports suggest others (e.g. transient network issues), so recovering at the operator level is worth having regardless.

## The fix

A new predicate `isPodStuckWithTerminatedPostgres` detects the state: phase `Running`, `postgres` container in `Terminated` state (not `Waiting` — a kubelet that plans a restart moves the container to `Waiting`, which keeps the predicate false) for longer than 5 minutes (the kubelet's container restart backoff is capped at 5 minutes, so a container that stays terminated longer is not coming back). `deleteTerminatedPods` then deletes the Pod exactly like it already does for `Succeeded`/`Failed` Pods; the PVC survives and the recreated Pod rejoins via streaming.

Validated live against a stuck cluster: the patched operator deleted the stuck Pod 6 seconds after startup, the Pod rejoined from its PVC, and the interrupted rollout completed to `Cluster in healthy state`.

## Notes

- No data-loss concern: the sidecar next to a dead instance manager is an idle gRPC server (its only client is gone), WAL files live on the PVC, and archiving duties are already on the new primary.
- Unit tests cover the predicate and the new `deleteTerminatedPods` branch.


## Reproducer

A self-contained kind-based script that reproduces the stall end-to-end (verified on `kindest/node:v1.35.1`; the same sequence completes cleanly on `v1.35.5`):
https://gist.github.com/IgorOhrimenko/7d08e575e2fecb84c6072da6867a3022
