### PR TITLE
fix(backup): honor Backup `spec.online` when finalizing volume snapshots

### DIFF
--- a/pkg/reconciler/backup/volumesnapshot/reconciler.go
+++ b/pkg/reconciler/backup/volumesnapshot/reconciler.go
@@ -267,7 +267,7 @@ func (se *Reconciler) finalizeSnapshotBackupStep(
 	targetPod *corev1.Pod,
 ) (*ctrl.Result, error) {
 	contextLogger := log.FromContext(ctx).WithValues("podName", targetPod.Name)
-	volumeSnapshotConfig := cluster.Spec.Backup.VolumeSnapshot
+	volumeSnapshotConfig := backup.GetVolumeSnapshotConfiguration(*cluster.Spec.Backup.VolumeSnapshot)
 
 	if res, err := exec.finalize(ctx, cluster, backup, targetPod); res != nil || err != nil {
 		return res, err

--- a/pkg/reconciler/backup/volumesnapshot/reconciler.go
+++ b/pkg/reconciler/backup/volumesnapshot/reconciler.go
@@ -131,7 +131,7 @@ func (se *Reconciler) enrichSnapshot(
 	// the backup status is only filled in when the backup is finalized, which happens
 	// after the snapshots have been created: the effective online setting has to be
 	// taken from the configuration, as the status is still empty at this point
-	vs.Annotations[utils.IsOnlineBackupLabelName] = strconv.FormatBool(snapshotConfig.GetOnline())
+	vs.Annotations[utils.IsOnlineBackupLabelName] = strconv.FormatBool(backup.GetOnlineOrDefault(cluster))
 
 	rawCluster, err := json.Marshal(cluster)
 	if err != nil {
@@ -206,9 +206,7 @@ func (se *Reconciler) internalReconcile(
 	if err != nil {
 		return nil, err
 	}
-	volumeSnapshotConfig := backup.GetVolumeSnapshotConfiguration(*cluster.Spec.Backup.VolumeSnapshot)
-
-	exec := se.newExecutor(volumeSnapshotConfig.GetOnline())
+	exec := se.newExecutor(backup.GetOnlineOrDefault(cluster))
 
 	// Step 1: backup preparation.
 	// This will set PostgreSQL in backup mode for hot snapshots, or fence the Pods for cold snapshots.
@@ -270,14 +268,13 @@ func (se *Reconciler) finalizeSnapshotBackupStep(
 	targetPod *corev1.Pod,
 ) (*ctrl.Result, error) {
 	contextLogger := log.FromContext(ctx).WithValues("podName", targetPod.Name)
-	volumeSnapshotConfig := backup.GetVolumeSnapshotConfiguration(*cluster.Spec.Backup.VolumeSnapshot)
 
 	if res, err := exec.finalize(ctx, cluster, backup, targetPod); res != nil || err != nil {
 		return res, err
 	}
 
 	backup.Status.SetAsFinalizing()
-	backup.Status.Online = ptr.To(volumeSnapshotConfig.GetOnline())
+	backup.Status.Online = ptr.To(backup.GetOnlineOrDefault(cluster))
 	snapshots, err := getBackupVolumeSnapshots(ctx, se.cli, backup.Namespace, backup.Name)
 	if err != nil {
 		return nil, err

--- a/pkg/reconciler/backup/volumesnapshot/reconciler.go
+++ b/pkg/reconciler/backup/volumesnapshot/reconciler.go
@@ -128,7 +128,10 @@ func (se *Reconciler) enrichSnapshot(
 	vs.Labels[utils.BackupDateLabelName] = now.Format("20060102")
 	vs.Labels[utils.BackupMonthLabelName] = now.Format("200601")
 	vs.Labels[utils.BackupYearLabelName] = strconv.Itoa(now.Year())
-	vs.Annotations[utils.IsOnlineBackupLabelName] = strconv.FormatBool(backup.Status.GetOnline())
+	// the backup status is only filled in when the backup is finalized, which happens
+	// after the snapshots have been created: the effective online setting has to be
+	// taken from the configuration, as the status is still empty at this point
+	vs.Annotations[utils.IsOnlineBackupLabelName] = strconv.FormatBool(snapshotConfig.GetOnline())
 
 	rawCluster, err := json.Marshal(cluster)
 	if err != nil {

--- a/pkg/reconciler/backup/volumesnapshot/reconciler.go
+++ b/pkg/reconciler/backup/volumesnapshot/reconciler.go
@@ -128,9 +128,9 @@ func (se *Reconciler) enrichSnapshot(
 	vs.Labels[utils.BackupDateLabelName] = now.Format("20060102")
 	vs.Labels[utils.BackupMonthLabelName] = now.Format("200601")
 	vs.Labels[utils.BackupYearLabelName] = strconv.Itoa(now.Year())
-	// the backup status is only filled in when the backup is finalized, which happens
+	// backup.Status.Online is only set once the backup is finalized, which happens
 	// after the snapshots have been created: the effective online setting has to be
-	// taken from the configuration, as the status is still empty at this point
+	// taken from the configuration, as Status.Online is still empty at this point
 	vs.Annotations[utils.IsOnlineBackupLabelName] = strconv.FormatBool(backup.GetOnlineOrDefault(cluster))
 
 	rawCluster, err := json.Marshal(cluster)

--- a/pkg/reconciler/backup/volumesnapshot/reconciler_test.go
+++ b/pkg/reconciler/backup/volumesnapshot/reconciler_test.go
@@ -60,9 +60,10 @@ var _ = Describe("getSnapshotName", func() {
 	})
 })
 
-// newProvisionedSnapshots builds a VolumeSnapshotList for a PG_DATA/PG_WAL pair
-// of snapshots belonging to the given backup, with the given readiness.
-func newProvisionedSnapshots(namespace, backupName string, readyToUse bool) volumesnapshotv1.VolumeSnapshotList {
+// newSnapshotPair builds a VolumeSnapshotList for a PG_DATA/PG_WAL pair of
+// snapshots belonging to the given backup. The snapshots have been provisioned,
+// and readyToUse tells whether they are also ready to be used.
+func newSnapshotPair(namespace, backupName string, readyToUse bool) volumesnapshotv1.VolumeSnapshotList {
 	return volumesnapshotv1.VolumeSnapshotList{
 		Items: []volumesnapshotv1.VolumeSnapshot{
 			{
@@ -261,7 +262,7 @@ var _ = Describe("Volumesnapshot reconciler", func() {
 	})
 
 	It("should unfence the target pod when the snapshots have been provisioned", func(ctx SpecContext) {
-		snapshots := newProvisionedSnapshots(namespace, backup.Name, false)
+		snapshots := newSnapshotPair(namespace, backup.Name, false)
 
 		cluster.Annotations[utils.FencedInstanceAnnotation] = fmt.Sprintf(`["%s"]`, targetPod.Name)
 
@@ -298,7 +299,7 @@ var _ = Describe("Volumesnapshot reconciler", func() {
 	})
 
 	It("should mark the backup as completed when the snapshots are ready", func(ctx SpecContext) {
-		snapshots := newProvisionedSnapshots(namespace, backup.Name, true)
+		snapshots := newSnapshotPair(namespace, backup.Name, true)
 
 		cluster.Annotations[utils.FencedInstanceAnnotation] = fmt.Sprintf(`["%s"]`, targetPod.Name)
 
@@ -334,7 +335,7 @@ var _ = Describe("Volumesnapshot reconciler", func() {
 		// but this specific Backup requests a cold (offline) backup
 		backup.Spec.Online = ptr.To(false)
 
-		snapshots := newProvisionedSnapshots(namespace, backup.Name, false)
+		snapshots := newSnapshotPair(namespace, backup.Name, false)
 
 		cluster.Annotations[utils.FencedInstanceAnnotation] = fmt.Sprintf(`["%s"]`, targetPod.Name)
 
@@ -358,7 +359,35 @@ var _ = Describe("Volumesnapshot reconciler", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		Expect(latestBackup.Status.Phase).To(BeEquivalentTo(apiv1.BackupPhaseFinalizing))
-		Expect(latestBackup.Status.GetOnline()).To(BeFalse())
+		Expect(latestBackup.Status.Online).To(HaveValue(BeFalse()))
+	})
+
+	It("should annotate the snapshots with the effective online setting", func(ctx SpecContext) {
+		// the cluster requests cold backups, but this specific Backup asks for a hot one
+		cluster.Spec.Backup.VolumeSnapshot.Online = ptr.To(false)
+		backup.Spec.Online = ptr.To(true)
+
+		mockClient := fake.NewClientBuilder().
+			WithScheme(scheme.BuildWithAllKnownScheme()).
+			WithObjects(backup, cluster, targetPod).
+			Build()
+
+		executor := NewReconcilerBuilder(mockClient, record.NewFakeRecorder(3)).
+			Build()
+
+		// the snapshots are created before the backup is finalized, so the backup
+		// status is still empty at this point
+		Expect(backup.Status.Online).To(BeNil())
+		Expect(executor.createSnapshot(ctx, cluster, backup, targetPod, &pvcs[0])).To(Succeed())
+
+		var snapshotList volumesnapshotv1.VolumeSnapshotList
+		err := mockClient.List(ctx, &snapshotList)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(snapshotList.Items).ToNot(BeEmpty())
+
+		for _, snapshot := range snapshotList.Items {
+			Expect(snapshot.Annotations).To(HaveKeyWithValue(utils.IsOnlineBackupLabelName, "true"))
+		}
 	})
 
 	It("should properly enrich the backup with labels", func(ctx SpecContext) {

--- a/pkg/reconciler/backup/volumesnapshot/reconciler_test.go
+++ b/pkg/reconciler/backup/volumesnapshot/reconciler_test.go
@@ -171,6 +171,9 @@ var _ = Describe("Volumesnapshot reconciler", func() {
 				Namespace: namespace,
 				Name:      backupName,
 			},
+			Spec: apiv1.BackupSpec{
+				Method: apiv1.BackupMethodVolumeSnapshot,
+			},
 			Status: apiv1.BackupStatus{
 				StartedAt:    ptr.To(startedAt),
 				StoppedAt:    ptr.To(stoppedAt),

--- a/pkg/reconciler/backup/volumesnapshot/reconciler_test.go
+++ b/pkg/reconciler/backup/volumesnapshot/reconciler_test.go
@@ -60,6 +60,51 @@ var _ = Describe("getSnapshotName", func() {
 	})
 })
 
+// newProvisionedSnapshots builds a VolumeSnapshotList for a PG_DATA/PG_WAL pair
+// of snapshots belonging to the given backup, with the given readiness.
+func newProvisionedSnapshots(namespace, backupName string, readyToUse bool) volumesnapshotv1.VolumeSnapshotList {
+	return volumesnapshotv1.VolumeSnapshotList{
+		Items: []volumesnapshotv1.VolumeSnapshot{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      backupName,
+					Labels: map[string]string{
+						utils.BackupNameLabelName: backupName,
+					},
+					Annotations: map[string]string{
+						"avoid": "nil",
+					},
+				},
+				Status: &volumesnapshotv1.VolumeSnapshotStatus{
+					ReadyToUse:                     ptr.To(readyToUse),
+					Error:                          nil,
+					BoundVolumeSnapshotContentName: ptr.To(fmt.Sprintf("%s-content", backupName)),
+					CreationTime:                   ptr.To(metav1.Now()),
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      backupName + "-wal",
+					Labels: map[string]string{
+						utils.BackupNameLabelName: backupName,
+					},
+					Annotations: map[string]string{
+						"avoid": "nil",
+					},
+				},
+				Status: &volumesnapshotv1.VolumeSnapshotStatus{
+					ReadyToUse:                     ptr.To(readyToUse),
+					Error:                          nil,
+					BoundVolumeSnapshotContentName: ptr.To(fmt.Sprintf("%s-wal-content", backupName)),
+					CreationTime:                   ptr.To(metav1.Now()),
+				},
+			},
+		},
+	}
+}
+
 var _ = Describe("Volumesnapshot reconciler", func() {
 	const (
 		namespace   = "test-namespace"
@@ -216,46 +261,7 @@ var _ = Describe("Volumesnapshot reconciler", func() {
 	})
 
 	It("should unfence the target pod when the snapshots have been provisioned", func(ctx SpecContext) {
-		snapshots := volumesnapshotv1.VolumeSnapshotList{
-			Items: []volumesnapshotv1.VolumeSnapshot{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: namespace,
-						Name:      backup.Name,
-						Labels: map[string]string{
-							utils.BackupNameLabelName: backup.Name,
-						},
-						Annotations: map[string]string{
-							"avoid": "nil",
-						},
-					},
-					Status: &volumesnapshotv1.VolumeSnapshotStatus{
-						ReadyToUse:                     ptr.To(false),
-						Error:                          nil,
-						BoundVolumeSnapshotContentName: ptr.To(fmt.Sprintf("%s-content", backup.Name)),
-						CreationTime:                   ptr.To(metav1.Now()),
-					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: namespace,
-						Name:      backup.Name + "-wal",
-						Labels: map[string]string{
-							utils.BackupNameLabelName: backup.Name,
-						},
-						Annotations: map[string]string{
-							"avoid": "nil",
-						},
-					},
-					Status: &volumesnapshotv1.VolumeSnapshotStatus{
-						ReadyToUse:                     ptr.To(false),
-						Error:                          nil,
-						BoundVolumeSnapshotContentName: ptr.To(fmt.Sprintf("%s-wal-content", backup.Name)),
-						CreationTime:                   ptr.To(metav1.Now()),
-					},
-				},
-			},
-		}
+		snapshots := newProvisionedSnapshots(namespace, backup.Name, false)
 
 		cluster.Annotations[utils.FencedInstanceAnnotation] = fmt.Sprintf(`["%s"]`, targetPod.Name)
 
@@ -292,46 +298,7 @@ var _ = Describe("Volumesnapshot reconciler", func() {
 	})
 
 	It("should mark the backup as completed when the snapshots are ready", func(ctx SpecContext) {
-		snapshots := volumesnapshotv1.VolumeSnapshotList{
-			Items: []volumesnapshotv1.VolumeSnapshot{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: namespace,
-						Name:      backup.Name,
-						Labels: map[string]string{
-							utils.BackupNameLabelName: backup.Name,
-						},
-						Annotations: map[string]string{
-							"avoid": "nil",
-						},
-					},
-					Status: &volumesnapshotv1.VolumeSnapshotStatus{
-						BoundVolumeSnapshotContentName: ptr.To(fmt.Sprintf("%s-content", backup.Name)),
-						ReadyToUse:                     ptr.To(true),
-						Error:                          nil,
-						CreationTime:                   ptr.To(metav1.Now()),
-					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: namespace,
-						Name:      backup.Name + "-wal",
-						Labels: map[string]string{
-							utils.BackupNameLabelName: backup.Name,
-						},
-						Annotations: map[string]string{
-							"avoid": "nil",
-						},
-					},
-					Status: &volumesnapshotv1.VolumeSnapshotStatus{
-						BoundVolumeSnapshotContentName: ptr.To(fmt.Sprintf("%s-wal-content", backup.Name)),
-						ReadyToUse:                     ptr.To(true),
-						Error:                          nil,
-						CreationTime:                   ptr.To(metav1.Now()),
-					},
-				},
-			},
-		}
+		snapshots := newProvisionedSnapshots(namespace, backup.Name, true)
 
 		cluster.Annotations[utils.FencedInstanceAnnotation] = fmt.Sprintf(`["%s"]`, targetPod.Name)
 
@@ -359,6 +326,39 @@ var _ = Describe("Volumesnapshot reconciler", func() {
 		data, err := utils.GetFencedInstances(latestCluster.Annotations)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(data.Len()).To(Equal(0))
+	})
+
+	It("should honor the Backup's spec.online over the cluster default when finalizing", func(ctx SpecContext) {
+		// the cluster has no explicit online setting, which defaults to true (hot backup)
+		cluster.Spec.Backup.VolumeSnapshot.Online = nil
+		// but this specific Backup requests a cold (offline) backup
+		backup.Spec.Online = ptr.To(false)
+
+		snapshots := newProvisionedSnapshots(namespace, backup.Name, false)
+
+		cluster.Annotations[utils.FencedInstanceAnnotation] = fmt.Sprintf(`["%s"]`, targetPod.Name)
+
+		mockClient := fake.NewClientBuilder().
+			WithScheme(scheme.BuildWithAllKnownScheme()).
+			WithObjects(cluster, targetPod, backup).
+			WithStatusSubresource(backup).
+			WithLists(&snapshots).
+			Build()
+		fakeRecorder := record.NewFakeRecorder(3)
+
+		executor := NewReconcilerBuilder(mockClient, fakeRecorder).
+			Build()
+
+		result, err := executor.Reconcile(ctx, cluster, backup, targetPod, pvcs)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result).ToNot(BeNil())
+
+		var latestBackup apiv1.Backup
+		err = mockClient.Get(ctx, types.NamespacedName{Name: backupName, Namespace: namespace}, &latestBackup)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(latestBackup.Status.Phase).To(BeEquivalentTo(apiv1.BackupPhaseFinalizing))
+		Expect(latestBackup.Status.GetOnline()).To(BeFalse())
 	})
 
 	It("should properly enrich the backup with labels", func(ctx SpecContext) {


### PR DESCRIPTION
`status.online` was recomputed from the cluster-level default instead of the Backup's own spec, so a cold backup (`online: false`) could be reported as online in status.

The same issue affected the `cnpg.io/onlineBackup` annotation on the VolumeSnapshot objects: it was read from the Backup's status, which is only populated at finalization time, so every snapshot ended up annotated as a cold backup regardless of the actual setting.

Closes #11275

Assisted-by: Claude
