### PR TITLE
feat: pass restoreAdditionalCommandArgs to barman-cloud-restore

### DIFF
--- a/config/crd/bases/postgresql.cnpg.io_clusters.yaml
+++ b/config/crd/bases/postgresql.cnpg.io_clusters.yaml
@@ -1189,6 +1189,25 @@ spec:
                             format: int32
                             minimum: 1
                             type: integer
+                          restoreAdditionalCommandArgs:
+                            description: |-
+                              Additional arguments that can be appended to the 'barman-cloud-restore'
+                              command-line invocation. These arguments provide flexibility to customize
+                              the data restore process further, according to specific requirements or
+                              configurations.
+
+                              Example:
+                              In a scenario where specialized restore options are required, such as setting
+                              a specific read timeout or defining custom behavior, users can use this field
+                              to specify additional command arguments.
+
+                              Note:
+                              It's essential to ensure that the provided arguments are valid and supported
+                              by the 'barman-cloud-restore' command, to avoid potential errors or unintended
+                              behavior during execution.
+                            items:
+                              type: string
+                            type: array
                         type: object
                       destinationPath:
                         description: |-
@@ -2782,6 +2801,25 @@ spec:
                               format: int32
                               minimum: 1
                               type: integer
+                            restoreAdditionalCommandArgs:
+                              description: |-
+                                Additional arguments that can be appended to the 'barman-cloud-restore'
+                                command-line invocation. These arguments provide flexibility to customize
+                                the data restore process further, according to specific requirements or
+                                configurations.
+
+                                Example:
+                                In a scenario where specialized restore options are required, such as setting
+                                a specific read timeout or defining custom behavior, users can use this field
+                                to specify additional command arguments.
+
+                                Note:
+                                It's essential to ensure that the provided arguments are valid and supported
+                                by the 'barman-cloud-restore' command, to avoid potential errors or unintended
+                                behavior during execution.
+                              items:
+                                type: string
+                              type: array
                           type: object
                         destinationPath:
                           description: |-

--- a/docs/src/appendixes/backup_barmanobjectstore.md
+++ b/docs/src/appendixes/backup_barmanobjectstore.md
@@ -285,7 +285,9 @@ spec:
         - "--min-chunk-size=5MB"
         - "--read-timeout=60"
 ```
-For restores:
+For restores, the `restoreAdditionalCommandArgs` are taken from the `barmanObjectStore`
+of the external cluster the recovery is reading from, that is the entry named by
+`.spec.bootstrap.recovery.source`, not from `.spec.backup`:
 
 ```yaml
 apiVersion: postgresql.cnpg.io/v1
@@ -294,11 +296,11 @@ kind: Cluster
 spec:
   externalClusters:
     - name: clusterBackup
-    barmanObjectStore:
-      [...]
-      data:
-        restoreAdditionalCommandArgs:
-        - "--read-timeout=60"
+      barmanObjectStore:
+        [...]
+        data:
+          restoreAdditionalCommandArgs:
+          - "--read-timeout=60"
 ```
 
 For WAL Archiving files:
@@ -326,11 +328,11 @@ kind: Cluster
 spec:
   externalClusters:
     - name: clusterBackup
-    barmanObjectStore:
-      [...]
-      wal:
-        restoreAdditionalCommandArgs:
-        - "--read-timeout=60"
+      barmanObjectStore:
+        [...]
+        wal:
+          restoreAdditionalCommandArgs:
+          - "--read-timeout=60"
 ```
 
 ## Recovery from an object store

--- a/docs/src/appendixes/backup_barmanobjectstore.md
+++ b/docs/src/appendixes/backup_barmanobjectstore.md
@@ -248,23 +248,25 @@ spec:
         backupRetentionPolicy: "keep"
 ```
 
-## Extra options for the backup and WAL commands
+## Extra options for the backup, WAL Archiving, and Restore
 
-You can append additional options to the `barman-cloud-backup` and `barman-cloud-wal-archive` commands by using
-the `additionalCommandArgs` property in the
-`.spec.backup.barmanObjectStore.data` and `.spec.backup.barmanObjectStore.wal` sections respectively.
-These properties are lists of strings that will be appended to the
-`barman-cloud-backup` and `barman-cloud-wal-archive` commands.
+You can append additional options to the underlying `barman-cloud-*` commands using
+the corresponding fields in the `barmanObjectStore` section of the `Cluster` resource.
+
+- `.barmanObjectStore.data.additionalCommandArgs` for the `barman-cloud-backup`
+- `.barmanObjectStore.data.restoreAdditionalCommandArgs` for the `barman-cloud-restore`
+- `.barmanObjectStore.wal.archiveAdditionalCommandArgs` for the `barman-cloud-wal-archive`
+- `.barmanObjectStore.wal.restoreAdditionalCommandArgs` for the `barman-cloud-wal-restore`
+
+
+Each field accepts a list of string arguments. If an argument conflicts with one already
+present in the declared options in its section, the user-provided value will be ignored.
 
 For example, you can use the `--read-timeout=60` to customize the connection
 reading timeout.
 
-For additional options supported by `barman-cloud-backup` and `barman-cloud-wal-archive` commands you can refer to the
+For additional options supported by `barman-cloud-*` commands you can refer to the
 official barman documentation [here](https://www.pgbarman.org/documentation/).
-
-If an option provided in `additionalCommandArgs` is already present in the
-declared options in its section (`.spec.backup.barmanObjectStore.data` or `.spec.backup.barmanObjectStore.wal`), the extra option will be
-ignored.
 
 The following is an example of how to use this property:
 
@@ -283,8 +285,23 @@ spec:
         - "--min-chunk-size=5MB"
         - "--read-timeout=60"
 ```
+For restores:
 
-For WAL files:
+```yaml
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+[...]
+spec:
+  externalClusters:
+    - name: clusterBackup
+    barmanObjectStore:
+      [...]
+      data:
+        restoreAdditionalCommandArgs:
+        - "--read-timeout=60"
+```
+
+For WAL Archiving files:
 
 ```yaml
 apiVersion: postgresql.cnpg.io/v1
@@ -295,8 +312,24 @@ spec:
     barmanObjectStore:
       [...]
       wal:
-        additionalCommandArgs:
+        archiveAdditionalCommandArgs:
         - "--max-concurrency=1"
+        - "--read-timeout=60"
+```
+
+For WAL Restoring files:
+
+```yaml
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+[...]
+spec:
+  externalClusters:
+    - name: clusterBackup
+    barmanObjectStore:
+      [...]
+      wal:
+        restoreAdditionalCommandArgs:
         - "--read-timeout=60"
 ```
 

--- a/docs/src/appendixes/backup_barmanobjectstore.md
+++ b/docs/src/appendixes/backup_barmanobjectstore.md
@@ -285,6 +285,7 @@ spec:
         - "--min-chunk-size=5MB"
         - "--read-timeout=60"
 ```
+
 For restores, the `restoreAdditionalCommandArgs` are taken from the `barmanObjectStore`
 of the external cluster the recovery is reading from, that is the entry named by
 `.spec.bootstrap.recovery.source`, not from `.spec.backup`:

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/acobaugh/osrelease v0.1.0
 	github.com/avast/retry-go/v5 v5.0.0
 	github.com/cheynewallace/tabby v1.1.1
-	github.com/cloudnative-pg/barman-cloud v0.5.1
+	github.com/cloudnative-pg/barman-cloud v0.5.2-0.20260720143032-950b0f57e122
 	github.com/cloudnative-pg/cnpg-i v0.6.0
 	github.com/cloudnative-pg/machinery v0.5.1-0.20260728155247-4d1e61111d7c
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cheynewallace/tabby v1.1.1 h1:JvUR8waht4Y0S3JF17G6Vhyt+FRhnqVCkk8l4YrOU54=
 github.com/cheynewallace/tabby v1.1.1/go.mod h1:Pba/6cUL8uYqvOc9RkyvFbHGrQ9wShyrn6/S/1OYVys=
-github.com/cloudnative-pg/barman-cloud v0.5.1 h1:vjkXrrxo2DQXHT9u9usqhtaHiPZ/lTfDVs/pIWYTepQ=
-github.com/cloudnative-pg/barman-cloud v0.5.1/go.mod h1:XPc5IUFP1y4cZX1sg+Pd8j9V4tmUEVnv3BGCpfQOOg8=
+github.com/cloudnative-pg/barman-cloud v0.5.2-0.20260720143032-950b0f57e122 h1:NuOztBdp+bUr/xYtaAw8o/x880hvWDRhJGl+R1YsZNw=
+github.com/cloudnative-pg/barman-cloud v0.5.2-0.20260720143032-950b0f57e122/go.mod h1:ZQLkdpk44FW5/BGWzABTOEcV9qPbwC+rbdscg2I8mBI=
 github.com/cloudnative-pg/cnpg-i v0.6.0 h1:LA//DLkFOLIjU0ASOpFkydZhGir9IAIDfgSsTTX9IpU=
 github.com/cloudnative-pg/cnpg-i v0.6.0/go.mod h1:4kcpLAj+feMTnh0TVadXRASdVnEhBytNSm/BvktLgmI=
 github.com/cloudnative-pg/machinery v0.5.1-0.20260728155247-4d1e61111d7c h1:Oq8J4W7QtGk1dUoNtnnKiR7Sw1iSc7T3ZzvcP7q+46A=

--- a/pkg/management/postgres/restore.go
+++ b/pkg/management/postgres/restore.go
@@ -364,24 +364,47 @@ func (info InitInfo) restoreCustomWalDir(ctx context.Context) (bool, error) {
 	return true, os.Symlink(info.PgWal, pgDataWal)
 }
 
-// restoreDataDir restores PGDATA from an existing backup
-func (info InitInfo) restoreDataDir(ctx context.Context, backup *apiv1.Backup, env []string) error {
-	contextLogger := log.FromContext(ctx)
+// buildRestoreDataDirOptions builds the command line options for barman-cloud-restore
+func (info InitInfo) buildRestoreDataDirOptions(
+	ctx context.Context,
+	backup *apiv1.Backup,
+	cluster *apiv1.Cluster,
+) ([]string, error) {
 	var options []string
 
 	if backup.Status.EndpointURL != "" {
 		options = append(options, "--endpoint-url", backup.Status.EndpointURL)
 	}
+
+	if cluster.Spec.Backup != nil && cluster.Spec.Backup.BarmanObjectStore != nil {
+		options = cluster.Spec.Backup.BarmanObjectStore.Data.AppendRestoreAdditionalCommandArgs(options)
+	}
+
 	options = append(options, backup.Status.DestinationPath)
 	options = append(options, backup.Status.ServerName)
 	options = append(options, backup.Status.BackupID)
 
 	options, err := barmanCommand.AppendCloudProviderOptionsFromBackup(ctx, options, backup.Status.BarmanCredentials)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	options = append(options, info.PgData)
+	return append(options, info.PgData), nil
+}
+
+// restoreDataDir restores PGDATA from an existing backup
+func (info InitInfo) restoreDataDir(
+	ctx context.Context,
+	backup *apiv1.Backup,
+	env []string,
+	cluster *apiv1.Cluster,
+) error {
+	contextLogger := log.FromContext(ctx)
+
+	options, err := info.buildRestoreDataDirOptions(ctx, backup, cluster)
+	if err != nil {
+		return err
+	}
 
 	contextLogger.Info("Starting barman-cloud-restore",
 		"options", options)

--- a/pkg/management/postgres/restore.go
+++ b/pkg/management/postgres/restore.go
@@ -368,16 +368,12 @@ func (info InitInfo) restoreCustomWalDir(ctx context.Context) (bool, error) {
 func (info InitInfo) buildRestoreDataDirOptions(
 	ctx context.Context,
 	backup *apiv1.Backup,
-	cluster *apiv1.Cluster,
+	barmanConfiguration *apiv1.BarmanObjectStoreConfiguration,
 ) ([]string, error) {
 	var options []string
 
 	if backup.Status.EndpointURL != "" {
 		options = append(options, "--endpoint-url", backup.Status.EndpointURL)
-	}
-
-	if cluster.Spec.Backup != nil && cluster.Spec.Backup.BarmanObjectStore != nil {
-		options = cluster.Spec.Backup.BarmanObjectStore.Data.AppendRestoreAdditionalCommandArgs(options)
 	}
 
 	options = append(options, backup.Status.DestinationPath)
@@ -389,6 +385,10 @@ func (info InitInfo) buildRestoreDataDirOptions(
 		return nil, err
 	}
 
+	if barmanConfiguration != nil {
+		options = barmanConfiguration.Data.AppendRestoreAdditionalCommandArgs(options)
+	}
+
 	return append(options, info.PgData), nil
 }
 
@@ -397,11 +397,11 @@ func (info InitInfo) restoreDataDir(
 	ctx context.Context,
 	backup *apiv1.Backup,
 	env []string,
-	cluster *apiv1.Cluster,
+	barmanConfiguration *apiv1.BarmanObjectStoreConfiguration,
 ) error {
 	contextLogger := log.FromContext(ctx)
 
-	options, err := info.buildRestoreDataDirOptions(ctx, backup, cluster)
+	options, err := info.buildRestoreDataDirOptions(ctx, backup, barmanConfiguration)
 	if err != nil {
 		return err
 	}
@@ -442,7 +442,7 @@ func (info InitInfo) loadBackup(
 	ctx context.Context,
 	typedClient client.Client,
 	cluster *apiv1.Cluster,
-) (*apiv1.Backup, []string, error) {
+) (*apiv1.Backup, []string, *apiv1.BarmanObjectStoreConfiguration, error) {
 	// Recovery given an existing backup
 	if cluster.Spec.Bootstrap.Recovery.Backup != nil {
 		return info.loadBackupFromReference(ctx, typedClient, cluster)
@@ -457,23 +457,23 @@ func (info InitInfo) loadBackupObjectFromExternalCluster(
 	ctx context.Context,
 	typedClient client.Client,
 	cluster *apiv1.Cluster,
-) (*apiv1.Backup, []string, error) {
+) (*apiv1.Backup, []string, *apiv1.BarmanObjectStoreConfiguration, error) {
 	contextLogger := log.FromContext(ctx)
 	sourceName := cluster.Spec.Bootstrap.Recovery.Source
 
 	if sourceName == "" {
-		return nil, nil, fmt.Errorf("recovery source not specified")
+		return nil, nil, nil, fmt.Errorf("recovery source not specified")
 	}
 
 	contextLogger.Info("Recovering from external cluster", "sourceName", sourceName)
 
 	server, found := cluster.ExternalCluster(sourceName)
 	if !found {
-		return nil, nil, fmt.Errorf("missing external cluster: %v", sourceName)
+		return nil, nil, nil, fmt.Errorf("missing external cluster: %v", sourceName)
 	}
 
 	if server.BarmanObjectStore == nil {
-		return nil, nil, fmt.Errorf("missing barman object store configuration for source: %v", sourceName)
+		return nil, nil, nil, fmt.Errorf("missing barman object store configuration for source: %v", sourceName)
 	}
 
 	serverName := server.GetServerName()
@@ -485,12 +485,12 @@ func (info InitInfo) loadBackupObjectFromExternalCluster(
 		server.BarmanObjectStore,
 		os.Environ())
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	backupCatalog, err := barmanCommand.GetBackupList(ctx, server.BarmanObjectStore, serverName, env)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	// We are now choosing the right backup to restore
@@ -501,13 +501,13 @@ func (info InitInfo) loadBackupObjectFromExternalCluster(
 			cluster.Spec.Bootstrap.Recovery.RecoveryTarget,
 		)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
 	} else {
 		targetBackup = backupCatalog.LatestBackupInfo()
 	}
 	if targetBackup == nil {
-		return nil, nil, fmt.Errorf("no target backup found")
+		return nil, nil, nil, fmt.Errorf("no target backup found")
 	}
 
 	contextLogger.Info("Target backup found", "backup", targetBackup)
@@ -536,7 +536,7 @@ func (info InitInfo) loadBackupObjectFromExternalCluster(
 			CommandOutput:     "",
 			CommandError:      "",
 		},
-	}, env, nil
+	}, env, server.BarmanObjectStore, nil
 }
 
 // loadBackupFromReference loads a backup object and the required credentials given the backup object resource
@@ -544,7 +544,7 @@ func (info InitInfo) loadBackupFromReference(
 	ctx context.Context,
 	typedClient client.Client,
 	cluster *apiv1.Cluster,
-) (*apiv1.Backup, []string, error) {
+) (*apiv1.Backup, []string, *apiv1.BarmanObjectStoreConfiguration, error) {
 	contextLogger := log.FromContext(ctx)
 	var backup apiv1.Backup
 	err := typedClient.Get(
@@ -552,21 +552,33 @@ func (info InitInfo) loadBackupFromReference(
 		client.ObjectKey{Namespace: info.Namespace, Name: cluster.Spec.Bootstrap.Recovery.Backup.Name},
 		&backup)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
+	}
+
+	barmanConfiguration := &apiv1.BarmanObjectStoreConfiguration{
+		BarmanCredentials: backup.Status.BarmanCredentials,
+		EndpointCA:        backup.Status.EndpointCA,
+		EndpointURL:       backup.Status.EndpointURL,
+		DestinationPath:   backup.Status.DestinationPath,
+		ServerName:        backup.Status.ServerName,
 	}
 
 	env, err := barmanCredentials.EnvSetRestoreCloudCredentials(
 		ctx,
 		typedClient,
 		cluster.Namespace,
+<<<<<<< HEAD
 		barmanObjectStoreFromBackup(&backup),
+=======
+		barmanConfiguration,
+>>>>>>> 4fc441f47 (fix: source barman-cloud-restore arguments from the recovery object store)
 		os.Environ())
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	contextLogger.Info("Recovering existing backup", "backup", backup)
-	return &backup, env, nil
+	return &backup, env, barmanConfiguration, nil
 }
 
 func (info InitInfo) writeCustomRestoreWalConfig(cluster *apiv1.Cluster, conf string) error {

--- a/pkg/management/postgres/restore.go
+++ b/pkg/management/postgres/restore.go
@@ -555,23 +555,13 @@ func (info InitInfo) loadBackupFromReference(
 		return nil, nil, nil, err
 	}
 
-	barmanConfiguration := &apiv1.BarmanObjectStoreConfiguration{
-		BarmanCredentials: backup.Status.BarmanCredentials,
-		EndpointCA:        backup.Status.EndpointCA,
-		EndpointURL:       backup.Status.EndpointURL,
-		DestinationPath:   backup.Status.DestinationPath,
-		ServerName:        backup.Status.ServerName,
-	}
+	barmanConfiguration := barmanObjectStoreFromBackup(&backup)
 
 	env, err := barmanCredentials.EnvSetRestoreCloudCredentials(
 		ctx,
 		typedClient,
 		cluster.Namespace,
-<<<<<<< HEAD
-		barmanObjectStoreFromBackup(&backup),
-=======
 		barmanConfiguration,
->>>>>>> 4fc441f47 (fix: source barman-cloud-restore arguments from the recovery object store)
 		os.Environ())
 	if err != nil {
 		return nil, nil, nil, err
@@ -1125,7 +1115,7 @@ func (info InitInfo) restoreViaBarmanObjectStore(
 	}
 
 	// If we need to download data from a backup, we do it.
-	backup, env, err := info.loadBackup(ctx, cli, cluster)
+	backup, env, barmanConfiguration, err := info.loadBackup(ctx, cli, cluster)
 	if err != nil {
 		return "", nil, err
 	}
@@ -1134,7 +1124,7 @@ func (info InitInfo) restoreViaBarmanObjectStore(
 		return "", nil, err
 	}
 
-	if err := info.restoreDataDir(ctx, backup, env); err != nil {
+	if err := info.restoreDataDir(ctx, backup, env, barmanConfiguration); err != nil {
 		return "", nil, err
 	}
 

--- a/pkg/management/postgres/restore_test.go
+++ b/pkg/management/postgres/restore_test.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"path"
 	"slices"
+	"strings"
 
 	"github.com/cloudnative-pg/machinery/pkg/fileutils"
 	"github.com/thoas/go-funk"
@@ -207,6 +208,50 @@ var _ = Describe("testing restore InitInfo methods", func() {
 		Expect(enforcedParamsInPGData).To(HaveLen(1))
 		Expect(enforcedParamsInPGData[maxConnectionsParameter]).To(Equal(200))
 	})
+})
+
+var _ = Describe("buildRestoreDataDirOptions", func() {
+	baseBackup := &apiv1.Backup{
+		Status: apiv1.BackupStatus{
+			DestinationPath: "s3://bucket/path",
+			ServerName:      "server-a",
+			BackupID:        "20230101T000000",
+		},
+	}
+	info := InitInfo{PgData: "/pgdata"}
+
+	DescribeTable("building the barman-cloud-restore options",
+		func(ctx SpecContext, cluster *apiv1.Cluster, expected string) {
+			options, err := info.buildRestoreDataDirOptions(ctx, baseBackup, cluster)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(strings.Join(options, " ")).To(Equal(expected))
+		},
+		Entry("no barman object store configured",
+			&apiv1.Cluster{},
+			"s3://bucket/path server-a 20230101T000000 /pgdata"),
+		Entry("barman object store with no restore additional args",
+			&apiv1.Cluster{
+				Spec: apiv1.ClusterSpec{
+					Backup: &apiv1.BackupConfiguration{
+						BarmanObjectStore: &apiv1.BarmanObjectStoreConfiguration{},
+					},
+				},
+			},
+			"s3://bucket/path server-a 20230101T000000 /pgdata"),
+		Entry("barman object store with restore additional args",
+			&apiv1.Cluster{
+				Spec: apiv1.ClusterSpec{
+					Backup: &apiv1.BackupConfiguration{
+						BarmanObjectStore: &apiv1.BarmanObjectStoreConfiguration{
+							Data: &apiv1.DataBackupConfiguration{
+								RestoreAdditionalCommandArgs: []string{"--read-timeout=60"},
+							},
+						},
+					},
+				},
+			},
+			"--read-timeout=60 s3://bucket/path server-a 20230101T000000 /pgdata"),
+	)
 })
 
 var _ = Describe("getRestoreWalConfig", func() {

--- a/pkg/management/postgres/restore_test.go
+++ b/pkg/management/postgres/restore_test.go
@@ -25,6 +25,7 @@ import (
 	"slices"
 	"strings"
 
+	barmanApi "github.com/cloudnative-pg/barman-cloud/pkg/api"
 	"github.com/cloudnative-pg/machinery/pkg/fileutils"
 	"github.com/thoas/go-funk"
 
@@ -221,36 +222,77 @@ var _ = Describe("buildRestoreDataDirOptions", func() {
 	info := InitInfo{PgData: "/pgdata"}
 
 	DescribeTable("building the barman-cloud-restore options",
-		func(ctx SpecContext, cluster *apiv1.Cluster, expected string) {
-			options, err := info.buildRestoreDataDirOptions(ctx, baseBackup, cluster)
+		func(
+			ctx SpecContext,
+			backup *apiv1.Backup,
+			barmanConfiguration *apiv1.BarmanObjectStoreConfiguration,
+			expected string,
+		) {
+			options, err := info.buildRestoreDataDirOptions(ctx, backup, barmanConfiguration)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(strings.Join(options, " ")).To(Equal(expected))
 		},
-		Entry("no barman object store configured",
-			&apiv1.Cluster{},
+		Entry("nil barman configuration",
+			baseBackup, nil,
 			"s3://bucket/path server-a 20230101T000000 /pgdata"),
-		Entry("barman object store with no restore additional args",
-			&apiv1.Cluster{
-				Spec: apiv1.ClusterSpec{
-					Backup: &apiv1.BackupConfiguration{
-						BarmanObjectStore: &apiv1.BarmanObjectStoreConfiguration{},
+		Entry("barman configuration with nil data",
+			baseBackup, &apiv1.BarmanObjectStoreConfiguration{},
+			"s3://bucket/path server-a 20230101T000000 /pgdata"),
+		Entry("barman configuration with data set but no restore additional args",
+			baseBackup, &apiv1.BarmanObjectStoreConfiguration{
+				Data: &apiv1.DataBackupConfiguration{},
+			},
+			"s3://bucket/path server-a 20230101T000000 /pgdata"),
+		Entry("barman configuration with restore additional args, placed after the positional arguments",
+			baseBackup, &apiv1.BarmanObjectStoreConfiguration{
+				Data: &apiv1.DataBackupConfiguration{
+					RestoreAdditionalCommandArgs: []string{"--read-timeout=60"},
+				},
+			},
+			"s3://bucket/path server-a 20230101T000000 --read-timeout=60 /pgdata"),
+		Entry("endpoint URL placement is unchanged",
+			&apiv1.Backup{
+				Status: apiv1.BackupStatus{
+					DestinationPath: "s3://bucket/path",
+					ServerName:      "server-a",
+					BackupID:        "20230101T000000",
+					EndpointURL:     "https://example.com",
+				},
+			},
+			nil,
+			"--endpoint-url https://example.com s3://bucket/path server-a 20230101T000000 /pgdata"),
+		Entry("a user-supplied duplicate of the endpoint URL is dropped",
+			&apiv1.Backup{
+				Status: apiv1.BackupStatus{
+					DestinationPath: "s3://bucket/path",
+					ServerName:      "server-a",
+					BackupID:        "20230101T000000",
+					EndpointURL:     "https://example.com",
+				},
+			},
+			&apiv1.BarmanObjectStoreConfiguration{
+				Data: &apiv1.DataBackupConfiguration{
+					RestoreAdditionalCommandArgs: []string{"--endpoint-url=https://attacker.example.com", "--read-timeout=60"},
+				},
+			},
+			"--endpoint-url https://example.com s3://bucket/path server-a 20230101T000000 --read-timeout=60 /pgdata"),
+		Entry("a user-supplied duplicate of a cloud-provider option is dropped",
+			&apiv1.Backup{
+				Status: apiv1.BackupStatus{
+					DestinationPath: "s3://bucket/path",
+					ServerName:      "server-a",
+					BackupID:        "20230101T000000",
+					BarmanCredentials: barmanApi.BarmanCredentials{
+						AWS: &barmanApi.S3Credentials{},
 					},
 				},
 			},
-			"s3://bucket/path server-a 20230101T000000 /pgdata"),
-		Entry("barman object store with restore additional args",
-			&apiv1.Cluster{
-				Spec: apiv1.ClusterSpec{
-					Backup: &apiv1.BackupConfiguration{
-						BarmanObjectStore: &apiv1.BarmanObjectStoreConfiguration{
-							Data: &apiv1.DataBackupConfiguration{
-								RestoreAdditionalCommandArgs: []string{"--read-timeout=60"},
-							},
-						},
-					},
+			&apiv1.BarmanObjectStoreConfiguration{
+				Data: &apiv1.DataBackupConfiguration{
+					RestoreAdditionalCommandArgs: []string{"--cloud-provider=aws-s3", "--read-timeout=60"},
 				},
 			},
-			"--read-timeout=60 s3://bucket/path server-a 20230101T000000 /pgdata"),
+			"s3://bucket/path server-a 20230101T000000 --cloud-provider aws-s3 --read-timeout=60 /pgdata"),
 	)
 })
 

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -31,7 +31,7 @@ require (
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
-	github.com/cloudnative-pg/barman-cloud v0.5.1 // indirect
+	github.com/cloudnative-pg/barman-cloud v0.5.2-0.20260720143032-950b0f57e122 // indirect
 	github.com/cloudnative-pg/cnpg-i v0.6.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/emicklei/go-restful/v3 v3.13.0 // indirect

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -12,8 +12,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cheynewallace/tabby v1.1.1 h1:JvUR8waht4Y0S3JF17G6Vhyt+FRhnqVCkk8l4YrOU54=
 github.com/cheynewallace/tabby v1.1.1/go.mod h1:Pba/6cUL8uYqvOc9RkyvFbHGrQ9wShyrn6/S/1OYVys=
-github.com/cloudnative-pg/barman-cloud v0.5.1 h1:vjkXrrxo2DQXHT9u9usqhtaHiPZ/lTfDVs/pIWYTepQ=
-github.com/cloudnative-pg/barman-cloud v0.5.1/go.mod h1:XPc5IUFP1y4cZX1sg+Pd8j9V4tmUEVnv3BGCpfQOOg8=
+github.com/cloudnative-pg/barman-cloud v0.5.2-0.20260720143032-950b0f57e122 h1:NuOztBdp+bUr/xYtaAw8o/x880hvWDRhJGl+R1YsZNw=
+github.com/cloudnative-pg/barman-cloud v0.5.2-0.20260720143032-950b0f57e122/go.mod h1:ZQLkdpk44FW5/BGWzABTOEcV9qPbwC+rbdscg2I8mBI=
 github.com/cloudnative-pg/cnpg-i v0.6.0 h1:LA//DLkFOLIjU0ASOpFkydZhGir9IAIDfgSsTTX9IpU=
 github.com/cloudnative-pg/cnpg-i v0.6.0/go.mod h1:4kcpLAj+feMTnh0TVadXRASdVnEhBytNSm/BvktLgmI=
 github.com/cloudnative-pg/machinery v0.5.1-0.20260728155247-4d1e61111d7c h1:Oq8J4W7QtGk1dUoNtnnKiR7Sw1iSc7T3ZzvcP7q+46A=


### PR DESCRIPTION
pass restoreAdditionalCommandArgs to barman-cloud-restore via `.barmanObjectStore.data.restoreAdditionalCommandArgs` for the 
native Barman Cloud Support.

Closes: #11277