### PR TITLE
chore: sync CODEOWNERS with cnpg-infra policy

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,20 +1,14 @@
-# The CODEOWNERS file is used to define individuals or teams that are
-# responsible for code in a repository. For details, please refer to
-# https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/about-code-owners
+# This file is generated from componentowners-policy.yaml in
+# cloudnative-pg/cnpg-infra — do not hand-edit, propose changes there instead.
+#
+# Path-scoped rules below always include the repo's own general owners
+# (the "*" line) in addition to their own specific teams/users, since
+# CODEOWNERS only honors the LAST matching pattern for a given path —
+# it does not merge an earlier, less-specific rule into a later one.
 
-* @cloudnative-pg/maintainers
-
-# Component owners
-# See https://github.com/cloudnative-pg/governance/blob/main/COMPONENT-OWNERS.md#cloudnative-pg
-
-# OLM
-/config/olm-*/ @cloudnative-pg/maintainers @NiccoloFei
-
-# Documentation
-/docs/ @cloudnative-pg/maintainers @jsilvela
-
-# Tests
-/.github/ @cloudnative-pg/maintainers @jsilvela @NiccoloFei @litaocdl
-/hack/ @cloudnative-pg/maintainers @jsilvela @NiccoloFei @litaocdl
-/tests/ @cloudnative-pg/maintainers @jsilvela @NiccoloFei @litaocdl
-
+* @cloudnative-pg/cloudnative-pg-owners
+/docs/ @cloudnative-pg/cloudnative-pg-owners @jsilvela
+/config/olm-*/ @cloudnative-pg/cloudnative-pg-owners @NiccoloFei
+/.github/ @cloudnative-pg/cloudnative-pg-owners @NiccoloFei @litaocdl @jsilvela
+/hack/ @cloudnative-pg/cloudnative-pg-owners @NiccoloFei @litaocdl @jsilvela
+/tests/ @cloudnative-pg/cloudnative-pg-owners @NiccoloFei @litaocdl @jsilvela


### PR DESCRIPTION
Regenerates this repo's CODEOWNERS from cloudnative-pg/cnpg-infra's `componentowners-policy.yaml`, the org's tracked desired state for CODEOWNERS content.

- Routes ownership through this repo's dedicated GitHub owners team instead of hardcoded usernames, so membership changes are picked up automatically.
- Any path-scoped rule now also includes the repo's general owners, so a path rule adds reviewers rather than silently replacing the `*` rule's owners for that subtree (CODEOWNERS only honors the last matching pattern, it does not merge).

See cloudnative-pg/cnpg-infra for the policy this is generated from.

Assisted-by: Claude