### PR TITLE
feat: Emit ReplicaCaughtUp event when streaming replica lag drops to zero

### DIFF
--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -27,6 +27,7 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/cloudnative-pg/machinery/pkg/log"
@@ -105,6 +106,13 @@ type ClusterReconciler struct {
 	drainTaints    []string
 	rolloutManager *rolloutManager.Manager
 	admission      *guard.Admission[*apiv1.Cluster]
+
+	// replicationLagMu guards replicationLagTracker
+	replicationLagMu sync.Mutex
+	// replicationLagTracker records, per cluster, whether each streaming replica
+	// had non-zero replay_lag on the previous reconciliation loop.
+	// Used to emit a ReplicaCaughtUp event exactly once per lag→zero transition.
+	replicationLagTracker map[types.NamespacedName]map[apiv1.PodName]bool
 }
 
 // NewClusterReconciler creates a new ClusterReconciler initializing it

--- a/internal/controller/cluster_status.go
+++ b/internal/controller/cluster_status.go
@@ -35,6 +35,7 @@ import (
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
@@ -812,10 +813,54 @@ func (r *ClusterReconciler) updateClusterStatusThatRequiresInstancesState(
 		})
 	}
 
+	r.detectAndEmitReplicaCaughtUpEvents(cluster, statuses)
+
 	if !reflect.DeepEqual(existingClusterStatus, cluster.Status) {
 		return r.Status().Update(ctx, cluster)
 	}
 	return nil
+}
+
+// detectAndEmitReplicaCaughtUpEvents emits a ReplicaCaughtUp event when a streaming replica's
+// replay_lag drops to zero after having been non-zero in the previous reconciliation loop.
+// Lag state is tracked in-memory on the reconciler (never written to the API status) so
+// that no internal bookkeeping bleeds into the public CRD schema.
+func (r *ClusterReconciler) detectAndEmitReplicaCaughtUpEvents(
+	cluster *apiv1.Cluster,
+	statuses postgres.PostgresqlStatusList,
+) {
+	clusterKey := client.ObjectKeyFromObject(cluster)
+
+	r.replicationLagMu.Lock()
+	if r.replicationLagTracker == nil {
+		r.replicationLagTracker = make(map[types.NamespacedName]map[apiv1.PodName]bool)
+	}
+	prevLag := r.replicationLagTracker[clusterKey]
+	r.replicationLagMu.Unlock()
+
+	newLag := make(map[apiv1.PodName]bool)
+
+	for i := range statuses.Items {
+		item := &statuses.Items[i]
+		if !item.IsPrimary {
+			continue
+		}
+		for _, repl := range item.ReplicationInfo {
+			podName := apiv1.PodName(repl.ApplicationName)
+			caughtUp := repl.State == "streaming" && repl.ReplayLag == "00:00:00"
+			newLag[podName] = !caughtUp
+
+			if prevLag[podName] && caughtUp {
+				r.Recorder.Eventf(cluster, "Normal", "ReplicaCaughtUp",
+					"Replica %v has caught up to the primary", repl.ApplicationName)
+			}
+		}
+		break
+	}
+
+	r.replicationLagMu.Lock()
+	r.replicationLagTracker[clusterKey] = newLag
+	r.replicationLagMu.Unlock()
 }
 
 // getPodsTopology returns a map with all the information about the pods topology

--- a/internal/controller/cluster_status_test.go
+++ b/internal/controller/cluster_status_test.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/client-go/tools/record"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/certs"
@@ -550,5 +551,145 @@ var _ = Describe("updateClusterStatusThatRequiresInstancesState tests", func() {
 
 			Expect(isWALSpaceAvailableOnPod(pod)).To(BeFalse())
 		})
+	})
+})
+
+var _ = Describe("detectAndEmitReplicaCaughtUpEvents", func() {
+	var (
+		env          *testingEnvironment
+		cluster      *apiv1.Cluster
+		clusterKey   types.NamespacedName
+		fakeRecorder *record.FakeRecorder
+	)
+
+	// seedLag pre-populates the in-memory tracker to simulate previous reconcile state
+	seedLag := func(pods map[apiv1.PodName]bool) {
+		env.clusterReconciler.replicationLagMu.Lock()
+		defer env.clusterReconciler.replicationLagMu.Unlock()
+		if env.clusterReconciler.replicationLagTracker == nil {
+			env.clusterReconciler.replicationLagTracker = make(map[types.NamespacedName]map[apiv1.PodName]bool)
+		}
+		env.clusterReconciler.replicationLagTracker[clusterKey] = pods
+	}
+
+	// trackedLag reads the in-memory tracker after a call
+	trackedLag := func(pod apiv1.PodName) bool {
+		env.clusterReconciler.replicationLagMu.Lock()
+		defer env.clusterReconciler.replicationLagMu.Unlock()
+		return env.clusterReconciler.replicationLagTracker[clusterKey][pod]
+	}
+
+	BeforeEach(func() {
+		env = buildTestEnvironment()
+		cluster = newFakeCNPGCluster(env.client, newFakeNamespace(env.client))
+		clusterKey = types.NamespacedName{Namespace: cluster.Namespace, Name: cluster.Name}
+		fakeRecorder = env.clusterReconciler.Recorder.(*record.FakeRecorder)
+	})
+
+	It("emits ReplicaCaughtUp when replay_lag drops to zero from non-zero", func() {
+		seedLag(map[apiv1.PodName]bool{"pod-2": true})
+
+		statuses := postgres.PostgresqlStatusList{
+			Items: []postgres.PostgresqlStatus{
+				{
+					Pod:       &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-1"}},
+					IsPrimary: true,
+					ReplicationInfo: postgres.PgStatReplicationList{
+						{ApplicationName: "pod-2", State: "streaming", ReplayLag: "00:00:00"},
+					},
+				},
+			},
+		}
+
+		env.clusterReconciler.detectAndEmitReplicaCaughtUpEvents(cluster, statuses)
+
+		Expect(fakeRecorder.Events).To(Receive(And(
+			ContainSubstring("Normal"),
+			ContainSubstring("ReplicaCaughtUp"),
+			ContainSubstring("pod-2"),
+		)))
+		Expect(trackedLag("pod-2")).To(BeFalse())
+	})
+
+	It("does not emit an event when the replica was already caught up", func() {
+		seedLag(map[apiv1.PodName]bool{"pod-2": false})
+
+		statuses := postgres.PostgresqlStatusList{
+			Items: []postgres.PostgresqlStatus{
+				{
+					Pod:       &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-1"}},
+					IsPrimary: true,
+					ReplicationInfo: postgres.PgStatReplicationList{
+						{ApplicationName: "pod-2", State: "streaming", ReplayLag: "00:00:00"},
+					},
+				},
+			},
+		}
+
+		env.clusterReconciler.detectAndEmitReplicaCaughtUpEvents(cluster, statuses)
+
+		Expect(fakeRecorder.Events).ShouldNot(Receive())
+		Expect(trackedLag("pod-2")).To(BeFalse())
+	})
+
+	It("does not emit an event when the replica is still lagging", func() {
+		seedLag(map[apiv1.PodName]bool{"pod-2": true})
+
+		statuses := postgres.PostgresqlStatusList{
+			Items: []postgres.PostgresqlStatus{
+				{
+					Pod:       &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-1"}},
+					IsPrimary: true,
+					ReplicationInfo: postgres.PgStatReplicationList{
+						{ApplicationName: "pod-2", State: "streaming", ReplayLag: "00:00:05.123"},
+					},
+				},
+			},
+		}
+
+		env.clusterReconciler.detectAndEmitReplicaCaughtUpEvents(cluster, statuses)
+
+		Expect(fakeRecorder.Events).ShouldNot(Receive())
+		Expect(trackedLag("pod-2")).To(BeTrue())
+	})
+
+	It("does not emit an event when the replica state is not streaming", func() {
+		seedLag(map[apiv1.PodName]bool{"pod-2": true})
+
+		statuses := postgres.PostgresqlStatusList{
+			Items: []postgres.PostgresqlStatus{
+				{
+					Pod:       &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-1"}},
+					IsPrimary: true,
+					ReplicationInfo: postgres.PgStatReplicationList{
+						{ApplicationName: "pod-2", State: "catchup", ReplayLag: "00:00:00"},
+					},
+				},
+			},
+		}
+
+		env.clusterReconciler.detectAndEmitReplicaCaughtUpEvents(cluster, statuses)
+
+		Expect(fakeRecorder.Events).ShouldNot(Receive())
+	})
+
+	It("does not emit an event for a newly observed replica with zero lag", func() {
+		// no seedLag call — tracker has no entry for pod-2 (first time seen)
+		statuses := postgres.PostgresqlStatusList{
+			Items: []postgres.PostgresqlStatus{
+				{
+					Pod:       &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-1"}},
+					IsPrimary: true,
+					ReplicationInfo: postgres.PgStatReplicationList{
+						{ApplicationName: "pod-2", State: "streaming", ReplayLag: "00:00:00"},
+					},
+				},
+			},
+		}
+
+		env.clusterReconciler.detectAndEmitReplicaCaughtUpEvents(cluster, statuses)
+
+		Expect(fakeRecorder.Events).ShouldNot(Receive())
+		Expect(trackedLag("pod-2")).To(BeFalse())
 	})
 })

--- a/internal/controller/cluster_status_test.go
+++ b/internal/controller/cluster_status_test.go
@@ -692,4 +692,49 @@ var _ = Describe("detectAndEmitReplicaCaughtUpEvents", func() {
 		Expect(fakeRecorder.Events).ShouldNot(Receive())
 		Expect(trackedLag("pod-2")).To(BeFalse())
 	})
+
+	It("emits event only for the replica that caught up when multiple replicas exist", func() {
+		seedLag(map[apiv1.PodName]bool{"pod-2": true, "pod-3": false})
+
+		statuses := postgres.PostgresqlStatusList{
+			Items: []postgres.PostgresqlStatus{
+				{
+					Pod:       &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-1"}},
+					IsPrimary: true,
+					ReplicationInfo: postgres.PgStatReplicationList{
+						{ApplicationName: "pod-2", State: "streaming", ReplayLag: "00:00:00"},
+						{ApplicationName: "pod-3", State: "streaming", ReplayLag: "00:00:00"},
+					},
+				},
+			},
+		}
+
+		env.clusterReconciler.detectAndEmitReplicaCaughtUpEvents(cluster, statuses)
+
+		Expect(fakeRecorder.Events).To(Receive(And(
+			ContainSubstring("ReplicaCaughtUp"),
+			ContainSubstring("pod-2"),
+		)))
+		Expect(fakeRecorder.Events).ShouldNot(Receive())
+		Expect(trackedLag("pod-2")).To(BeFalse())
+		Expect(trackedLag("pod-3")).To(BeFalse())
+	})
+
+	It("does not emit an event when the primary has no replication info", func() {
+		seedLag(map[apiv1.PodName]bool{"pod-2": true})
+
+		statuses := postgres.PostgresqlStatusList{
+			Items: []postgres.PostgresqlStatus{
+				{
+					Pod:             &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-1"}},
+					IsPrimary:       true,
+					ReplicationInfo: postgres.PgStatReplicationList{},
+				},
+			},
+		}
+
+		env.clusterReconciler.detectAndEmitReplicaCaughtUpEvents(cluster, statuses)
+
+		Expect(fakeRecorder.Events).ShouldNot(Receive())
+	})
 })


### PR DESCRIPTION
Closes #11292

## What this PR does

Emits a `Normal/ReplicaCaughtUp` Kubernetes event on the `Cluster` object the moment a streaming replica's `replay_lag` transitions from non-zero to zero — i.e., the first reconcile loop that observes the replica fully caught up after it had been lagging.

## Why is it needed

Currently, when a replica recovers from lag (after a network partition, pod restart, or heavy write burst), there is no signal emitted. Operators must continuously poll `pg_stat_replication` or watch metrics dashboards to know when recovery is complete. A single-fire Kubernetes event makes this transition observable without any additional tooling — it integrates naturally with `kubectl get events`, Alertmanager, and any event-driven pipeline.

## Changes

- **`internal/controller/cluster_controller.go`** — added `replicationLagMu sync.Mutex` and `replicationLagTracker map[types.NamespacedName]map[apiv1.PodName]bool` to `ClusterReconciler`. The tracker is in-memory only; it is never written to the public CRD status so the API schema stays clean.

- **`internal/controller/cluster_status.go`** — added `detectAndEmitReplicaCaughtUpEvents`, called from `updateClusterStatusThatRequiresInstancesState` on every reconcile. For each primary, it iterates `ReplicationInfo`, compares the current lag state against the previous reconcile's state, and emits the event exactly once per `lag→zero` transition per replica. The mutex protects the tracker for safe concurrent reconciliation of multiple clusters.

- **`internal/controller/cluster_status_test.go`** — seven unit tests covering all transition cases:
  - emits event when lag drops to zero
  - no event when replica was already at zero
  - no event when replica is still lagging
  - no event when replica state is not `streaming`
  - no event for a newly observed replica (no prior state)
  - emits event only for the replica that caught up when multiple replicas exist
  - no event when the primary has no replication info (empty `ReplicationInfo`)

## How to verify

```bash
# On the replica pod, pause WAL replay to simulate lag
kubectl exec -it <replica-pod> -n <namespace> -- \
  psql -U postgres -c "SELECT pg_wal_replay_pause();"

# Write some data on primary to build lag
kubectl exec -it <primary-pod> -n <namespace> -- \
  psql -U postgres -c "INSERT INTO t SELECT generate_series(1,10000);"

# Wait one reconcile cycle (~30s), then resume replay
kubectl exec -it <replica-pod> -n <namespace> -- \
  psql -U postgres -c "SELECT pg_wal_replay_resume();"

# After next reconcile, the event appears
kubectl get events -n <namespace> --field-selector reason=ReplicaCaughtUp
# Normal  ReplicaCaughtUp  cluster/<name>  Replica <pod> has caught up to the primary
```

## Implementation notes

- **No API changes.** `InstanceReportedState` and all public types are untouched.
- **Operator restart behaviour.** The tracker resets on restart; the first reconcile after restart treats all replicas as having no prior state, so no spurious events fire. Normal tracking resumes from the second reconcile.
- **Zero-lag detection.** The CNPG probe query uses `coalesce(replay_lag, '0'::interval)`, so a fully caught-up replica reports exactly `"00:00:00"`. String comparison is precise — any non-zero lag (even 1 µs) renders as `"00:00:00.000001"`.
- **Thread safety.** Multiple clusters reconcile concurrently; the mutex ensures the shared tracker map is never written to from two goroutines simultaneously.
