### PR TITLE
fix(controller): ensure old primary is shutdown before picking new primary in unschedulable node switchovers

### DIFF
--- a/internal/controller/cluster_controller_test.go
+++ b/internal/controller/cluster_controller_test.go
@@ -558,6 +558,83 @@ var _ = Describe("Updating target primary", func() {
 			Expect(instanceToCreate).ToNot(BeNil())
 			Expect(instanceToCreate.Name).To(Equal(instance2Name))
 		})
+
+	It("does not select a new primary until the old one on the unschedulable node has shut down", func(ctx SpecContext) {
+		namespace := newFakeNamespace(env.client)
+		cluster := newFakeCNPGCluster(env.client, namespace, func(c *apiv1.Cluster) {
+			c.Status.Instances = 3
+			c.Status.ReadyInstances = 3
+			primaryName := specs.GetInstanceName(c.Name, 1)
+			c.Status.CurrentPrimary = primaryName
+			c.Status.TargetPrimary = primaryName
+		})
+
+		instances := generateFakeClusterPods(env.client, cluster, true)
+		managedResources := &managedResources{
+			instances: corev1.PodList{Items: instances},
+		}
+
+		By("placing the primary on an unschedulable node and the replicas on schedulable ones", func() {
+			primaryNode := corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: "primary-node"},
+				Spec:       corev1.NodeSpec{Unschedulable: true},
+			}
+			replicaNode1 := corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "replica-node-1"}}
+			replicaNode2 := corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "replica-node-2"}}
+			Expect(env.client.Create(ctx, &primaryNode)).To(Succeed())
+			Expect(env.client.Create(ctx, &replicaNode1)).To(Succeed())
+			Expect(env.client.Create(ctx, &replicaNode2)).To(Succeed())
+		})
+
+		primaryStatus := postgres.PostgresqlStatus{
+			IsPrimary: true,
+			Node:      "primary-node",
+			Pod:       &instances[0],
+		}
+		replica1Status := postgres.PostgresqlStatus{
+			Node:                "replica-node-1",
+			Pod:                 &instances[1],
+			IsWalReceiverActive: true,
+		}
+		replica2Status := postgres.PostgresqlStatus{
+			Node:                "replica-node-2",
+			Pod:                 &instances[2],
+			IsWalReceiverActive: true,
+		}
+
+		By("reconciling while the old primary is still up and its replicas are connected to it", func() {
+			statusList := postgres.PostgresqlStatusList{
+				Items: []postgres.PostgresqlStatus{primaryStatus, replica1Status, replica2Status},
+			}
+
+			selectedPrimary, err := env.clusterReconciler.reconcileTargetPrimaryForNonReplicaCluster(
+				ctx, cluster, statusList, managedResources,
+			)
+
+			Expect(err).To(MatchError(ErrWalReceiversRunning))
+			Expect(selectedPrimary).To(BeEmpty())
+			Expect(cluster.Status.TargetPrimary).To(Equal(apiv1.PendingFailoverMarker))
+			Expect(cluster.Status.CurrentPrimary).To(Equal(instances[0].Name))
+		})
+
+		By("reconciling again once the old primary's WAL receivers have stopped", func() {
+			// The old primary has shut down: its replicas are no longer streaming from  it, and a fresh status
+			// collection would no longer sort it first.
+			replica1Status.IsWalReceiverActive = false
+			replica2Status.IsWalReceiverActive = false
+			statusList := postgres.PostgresqlStatusList{
+				Items: []postgres.PostgresqlStatus{replica1Status, replica2Status},
+			}
+
+			selectedPrimary, err := env.clusterReconciler.reconcileTargetPrimaryForNonReplicaCluster(
+				ctx, cluster, statusList, managedResources,
+			)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(selectedPrimary).To(Equal(instances[1].Name))
+			Expect(cluster.Status.TargetPrimary).To(Equal(instances[1].Name))
+		})
+	})
 })
 
 var _ = Describe("isNodeUnschedulableOrBeingDrained", func() {

--- a/internal/controller/cluster_controller_test.go
+++ b/internal/controller/cluster_controller_test.go
@@ -618,8 +618,6 @@ var _ = Describe("Updating target primary", func() {
 		})
 
 		By("reconciling again once the old primary's WAL receivers have stopped", func() {
-			// The old primary has shut down: its replicas are no longer streaming from  it, and a fresh status
-			// collection would no longer sort it first.
 			replica1Status.IsWalReceiverActive = false
 			replica2Status.IsWalReceiverActive = false
 			statusList := postgres.PostgresqlStatusList{
@@ -633,6 +631,67 @@ var _ = Describe("Updating target primary", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(selectedPrimary).To(Equal(instances[1].Name))
 			Expect(cluster.Status.TargetPrimary).To(Equal(instances[1].Name))
+		})
+	})
+
+	It("switches over a designated primary that is running on an unschedulable node", func(ctx SpecContext) {
+		namespace := newFakeNamespace(env.client)
+		cluster := newFakeCNPGCluster(env.client, namespace, func(c *apiv1.Cluster) {
+			c.Spec.ReplicaCluster = &apiv1.ReplicaClusterConfiguration{
+				Source:  "external-cluster",
+				Enabled: new(true),
+			}
+			c.Status.Instances = 3
+			c.Status.ReadyInstances = 3
+			designatedPrimaryName := specs.GetInstanceName(c.Name, 1)
+			c.Status.CurrentPrimary = designatedPrimaryName
+			c.Status.TargetPrimary = designatedPrimaryName
+		})
+		Expect(cluster.IsReplica()).To(BeTrue())
+
+		instances := generateFakeClusterPods(env.client, cluster, true)
+		managedResources := &managedResources{
+			instances: corev1.PodList{Items: instances},
+		}
+
+		By("placing the designated primary on an unschedulable node and the replicas on schedulable ones", func() {
+			primaryNode := corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: "primary-node"},
+				Spec:       corev1.NodeSpec{Unschedulable: true},
+			}
+			replicaNode1 := corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "replica-node-1"}}
+			replicaNode2 := corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "replica-node-2"}}
+			Expect(env.client.Create(ctx, &primaryNode)).To(Succeed())
+			Expect(env.client.Create(ctx, &replicaNode1)).To(Succeed())
+			Expect(env.client.Create(ctx, &replicaNode2)).To(Succeed())
+		})
+
+		designatedPrimaryStatus := postgres.PostgresqlStatus{
+			Node: "primary-node",
+			Pod:  &instances[0],
+		}
+		replica1Status := postgres.PostgresqlStatus{
+			Node: "replica-node-1",
+			Pod:  &instances[1],
+		}
+		replica2Status := postgres.PostgresqlStatus{
+			Node: "replica-node-2",
+			Pod:  &instances[2],
+		}
+		statusList := postgres.PostgresqlStatusList{
+			IsReplicaCluster: true,
+			Items:            []postgres.PostgresqlStatus{designatedPrimaryStatus, replica1Status, replica2Status},
+		}
+
+		By("reconciling while the designated primary is still healthy and reachable", func() {
+			selectedPrimary, err := env.clusterReconciler.reconcileTargetPrimaryForReplicaCluster(
+				ctx, cluster, statusList, managedResources,
+			)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(selectedPrimary).To(Equal(instances[1].Name))
+			Expect(cluster.Status.TargetPrimary).To(Equal(instances[1].Name))
+			Expect(cluster.Status.CurrentPrimary).To(Equal(instances[0].Name))
 		})
 	})
 })

--- a/internal/controller/replicas.go
+++ b/internal/controller/replicas.go
@@ -270,8 +270,8 @@ func (r *ClusterReconciler) setPrimaryOnSchedulableNode(
 	// Checking failed pods, e.g. pending pods due to missing PVCs
 	_, hasFailedPods := cluster.Status.InstancesStatus[apiv1.PodFailed]
 
-	// Checking whether there are pods on other nodes
-	podsOnOtherNodes := GetPodsNotOnPrimaryNode(status, primaryPod)
+	// Checking whether there are pods on other, schedulable nodes
+	podsOnSchedulableNodes := r.getSchedulablePodsNotOnPrimaryNode(ctx, status, primaryPod)
 
 	// If no failed pods are found, but not all instances are ready or not all replicas have been moved to a
 	// schedulable instance, wait, because something is in progress
@@ -279,10 +279,10 @@ func (r *ClusterReconciler) setPrimaryOnSchedulableNode(
 		// e.g an instance is being joined
 		(cluster.Spec.Instances != cluster.Status.ReadyInstances ||
 			// e.g. we want all instances to be moved to a schedulable node before triggering the switchover
-			len(podsOnOtherNodes.Items) < cluster.Spec.Instances-1) {
+			len(podsOnSchedulableNodes.Items) < cluster.Spec.Instances-1) {
 		contextLogger.Info("Current primary is running on unschedulable node and something is already in progress",
 			"currentPrimary", primaryPod.Pod.Name,
-			"podsOnOtherNodes", len(podsOnOtherNodes.Items),
+			"podsOnSchedulableNodes", len(podsOnSchedulableNodes.Items),
 			"instances", cluster.Spec.Instances,
 			"readyInstances", cluster.Status.ReadyInstances,
 			"primaryNode", primaryPod.Node)
@@ -296,12 +296,7 @@ func (r *ClusterReconciler) setPrimaryOnSchedulableNode(
 	// be moved between nodes, e.g. local-path-provisioner on Kind.
 
 	// Start looking for the next primary among the pods
-	for _, candidate := range podsOnOtherNodes.Items {
-		// If candidate on an unschedulable node too, skip it
-		if status, _ := r.isNodeUnschedulableOrBeingDrained(ctx, candidate.Node); status {
-			continue
-		}
-
+	for _, candidate := range podsOnSchedulableNodes.Items {
 		if !utils.IsPodReady(*candidate.Pod) {
 			continue
 		}
@@ -391,8 +386,10 @@ func (r *ClusterReconciler) reconcileTargetPrimaryForReplicaCluster(
 	return status.Items[0].Pod.Name, r.setPrimaryInstance(ctx, cluster, status.Items[0].Pod.Name)
 }
 
-// GetPodsNotOnPrimaryNode filters out only pods that are not on the same node as the primary one
-func GetPodsNotOnPrimaryNode(
+// getSchedulablePodsNotOnPrimaryNode filters out only pods that are not on the same node as the
+// primary one and are not themselves running on an unschedulable or draining node.
+func (r *ClusterReconciler) getSchedulablePodsNotOnPrimaryNode(
+	ctx context.Context,
 	status postgres.PostgresqlStatusList,
 	primaryPod *postgres.PostgresqlStatus,
 ) postgres.PostgresqlStatusList {
@@ -404,9 +401,13 @@ func GetPodsNotOnPrimaryNode(
 		return podsOnOtherNodes
 	}
 	for _, candidate := range status.Items {
-		if candidate.Pod.Name != primaryPod.Pod.Name && candidate.Node != primaryPod.Node {
-			podsOnOtherNodes.Items = append(podsOnOtherNodes.Items, candidate)
+		if candidate.Pod.Name == primaryPod.Pod.Name || candidate.Node == primaryPod.Node {
+			continue
 		}
+		if unschedulable, _ := r.isNodeUnschedulableOrBeingDrained(ctx, candidate.Node); unschedulable {
+			continue
+		}
+		podsOnOtherNodes.Items = append(podsOnOtherNodes.Items, candidate)
 	}
 	return podsOnOtherNodes
 }

--- a/internal/controller/replicas.go
+++ b/internal/controller/replicas.go
@@ -281,6 +281,8 @@ func (r *ClusterReconciler) shouldSetPrimaryToSchedulableNode(
 	podsOnSchedulableNodes := r.getSchedulablePodsNotOnPrimaryNode(ctx, status, primaryPod)
 
 	if len(podsOnSchedulableNodes.Items) == 0 {
+		contextLogger.Info("Current primary is running on unschedulable node, but no other pods are running on schedulable nodes",
+			"currentPrimary", primaryPod.Pod.Name, "primaryNode", primaryPod.Node)
 		// No other pods to switchover to
 		return false
 	}

--- a/internal/controller/replicas.go
+++ b/internal/controller/replicas.go
@@ -280,6 +280,11 @@ func (r *ClusterReconciler) shouldSetPrimaryToSchedulableNode(
 	// Checking whether there are pods on other, schedulable nodes
 	podsOnSchedulableNodes := r.getSchedulablePodsNotOnPrimaryNode(ctx, status, primaryPod)
 
+	if len(podsOnSchedulableNodes.Items) == 0 {
+		// No other pods to switchover to
+		return false
+	}
+
 	// If no failed pods are found, but not all instances are ready or not all replicas have been moved to a
 	// schedulable instance, wait, because something is in progress
 	if !hasFailedPods &&

--- a/internal/controller/replicas.go
+++ b/internal/controller/replicas.go
@@ -54,31 +54,12 @@ func (r *ClusterReconciler) reconcileTargetPrimaryFromPods(
 	status postgres.PostgresqlStatusList,
 	resources *managedResources,
 ) (string, error) {
-	contextLogger := log.FromContext(ctx)
-
 	if len(status.Items) == 0 {
 		// We have no status to check and we can't make a
 		// switchover under those conditions
 		return "", nil
 	}
 
-	// First step: check if the current primary is running in an unschedulable node
-	// and issue a switchover if that's the case
-	if primary := status.Items[0]; (primary.IsPrimary || (cluster.IsReplica() && primary.IsPodReady)) &&
-		primary.Pod.Name == cluster.Status.CurrentPrimary &&
-		cluster.Status.TargetPrimary == cluster.Status.CurrentPrimary {
-		isPrimaryOnUnschedulableNode, err := r.isNodeUnschedulableOrBeingDrained(ctx, primary.Node)
-		if err != nil {
-			contextLogger.Error(err, "while checking if current primary is on an unschedulable node")
-			// in case of error it's better to proceed with the normal target primary reconciliation
-		} else if isPrimaryOnUnschedulableNode {
-			contextLogger.Info("Primary is running on an unschedulable node, will try switching over",
-				"node", primary.Node, "primary", primary.Pod.Name)
-			return r.triggerSwitchoverToSchedulableNodes(ctx, cluster, status, resources, &primary)
-		}
-	}
-
-	// Second step: check if the first element of the sorted list is the primary
 	if cluster.IsReplica() {
 		return r.reconcileTargetPrimaryForReplicaCluster(ctx, cluster, status, resources)
 	}
@@ -97,8 +78,20 @@ func (r *ClusterReconciler) reconcileTargetPrimaryForNonReplicaCluster(
 	contextLogger := log.FromContext(ctx)
 
 	mostAdvancedInstance := status.Items[0]
+	var shouldMovePrimary bool
 	if cluster.Status.TargetPrimary == mostAdvancedInstance.Pod.Name {
-		return "", nil
+		if cluster.Status.CurrentPrimary != mostAdvancedInstance.Pod.Name {
+			return "", nil
+		}
+		shouldMovePrimary = r.shouldSetPrimaryToSchedulableNode(ctx, cluster, status, &mostAdvancedInstance)
+		if shouldMovePrimary && len(status.Items) > 1 {
+			// mostAdvancedInstance is the current primary we want to move away from, change it to the most advanced
+			// replica. shouldSetPrimaryToSchedulableNode has already confirmed all other healthy replicas are on
+			// schedulable nodes.
+			mostAdvancedInstance = status.Items[1]
+		} else {
+			return "", nil
+		}
 	}
 
 	// If the first pod of the list has no reported status we can't evaluate the failover logic.
@@ -127,11 +120,15 @@ func (r *ClusterReconciler) reconcileTargetPrimaryForNonReplicaCluster(
 	// (if is still alive) to shut down by setting the apiv1.PendingFailoverMarker as
 	// target primary.
 	if cluster.Status.TargetPrimary == cluster.Status.CurrentPrimary {
-		contextLogger.Info("Current primary isn't healthy, initiating a failover")
+		failoverReason := "Current primary isn't healthy"
+		if shouldMovePrimary {
+			failoverReason = "Current primary is on an unschedulable node"
+		}
+		contextLogger.Info(failoverReason+", initiating a failover", "currentPrimary", cluster.Status.CurrentPrimary)
 		status.LogStatus(ctx)
 		contextLogger.Debug("Cluster status before initiating the failover", "instances", resources.instances)
 		r.Recorder.Eventf(cluster, "Normal", "FailingOver",
-			"Current primary isn't healthy, initiating a failover from %v", cluster.Status.CurrentPrimary)
+			"%s, initiating a failover from %v", failoverReason, cluster.Status.CurrentPrimary)
 		if err := r.RegisterPhase(ctx, cluster, apiv1.PhaseFailOver,
 			fmt.Sprintf("Initiating a failover from %v", cluster.Status.CurrentPrimary)); err != nil {
 			return "", err
@@ -257,16 +254,25 @@ func (r *ClusterReconciler) isNodeUnschedulableOrBeingDrained(
 	return isNodeUnschedulableOrBeingDrained(&node, r.drainTaints), nil
 }
 
-// triggerSwitchoverToSchedulableNodes Triggers an unschedulable node switchover if all replicas are on schedulable nodes
-// and failover quorum is satisfied
-func (r *ClusterReconciler) triggerSwitchoverToSchedulableNodes(
+// shouldSetPrimaryToSchedulableNode checks if the current primary is running on an unschedulable node and if there are
+// other pods are running on schedulable nodes. Returns true if the primary should a switchover should be triggered
+// to move the primary to a schedulable node.
+func (r *ClusterReconciler) shouldSetPrimaryToSchedulableNode(
 	ctx context.Context,
 	cluster *apiv1.Cluster,
 	status postgres.PostgresqlStatusList,
-	resources *managedResources,
 	primaryPod *postgres.PostgresqlStatus,
-) (string, error) {
+) bool {
 	contextLogger := log.FromContext(ctx)
+
+	isPrimaryOnUnschedulableNode, err := r.isNodeUnschedulableOrBeingDrained(ctx, primaryPod.Node)
+	if !isPrimaryOnUnschedulableNode {
+		if err != nil {
+			contextLogger.Error(err, "while checking if current primary is on an unschedulable node")
+		}
+		// Don't disrupt the primary if we can't get its node's status
+		return false
+	}
 
 	// Checking failed pods, e.g. pending pods due to missing PVCs
 	_, hasFailedPods := cluster.Status.InstancesStatus[apiv1.PodFailed]
@@ -287,7 +293,7 @@ func (r *ClusterReconciler) triggerSwitchoverToSchedulableNodes(
 			"instances", cluster.Spec.Instances,
 			"readyInstances", cluster.Status.ReadyInstances,
 			"primaryNode", primaryPod.Node)
-		return "", nil
+		return false
 	}
 
 	// In case we have failed pods, we try to do a switchover, because pods could be in this state
@@ -296,44 +302,7 @@ func (r *ClusterReconciler) triggerSwitchoverToSchedulableNodes(
 	// and the operator would be waiting for it to be rescheduled to a different node indefinitely if the PVC used can not
 	// be moved between nodes, e.g. local-path-provisioner on Kind.
 
-	// If quorum check is active, ensure we don't trigger a switchover if not enough replicas are available.
-	if cluster.IsFailoverQuorumActive() {
-		if status, err := r.evaluateQuorumCheck(ctx, cluster, status); err != nil {
-			return "", err
-		} else if !status {
-			// Prevent a failover from happening
-			return "", nil
-		}
-	}
-
-	contextLogger.Info("Current primary is running on unschedulable node, triggering a switchover",
-		"currentPrimary", primaryPod.Pod.Name, "currentPrimaryNode", primaryPod.Node)
-	status.LogStatus(ctx)
-	r.Recorder.Eventf(cluster, "Normal", "SwitchingOver",
-		"Current primary is running on unschedulable node %v, triggering a switchover",
-		primaryPod.Node)
-	if err := r.RegisterPhase(ctx, cluster, apiv1.PhaseSwitchover,
-		fmt.Sprintf("Triggering switchover because primary instance %v is running on unschedulable node %v",
-			primaryPod.Pod.Name,
-			primaryPod.Node)); err != nil {
-		return "", err
-	}
-	if err := r.setPrimaryInstance(ctx, cluster, apiv1.PendingFailoverMarker); err != nil {
-		return "", err
-	}
-
-	if !status.IsReplicaCluster {
-		if err := r.markOldPrimaryAsUnhealthy(
-			ctx,
-			cluster.Status.CurrentPrimary,
-			resources.instances.Items,
-		); err != nil {
-			contextLogger.Error(err, "Failed to strip primary label from old primary, continuing with failover",
-				"oldPrimary", cluster.Status.CurrentPrimary)
-		}
-	}
-
-	return "", nil
+	return true
 }
 
 // reconcileTargetPrimaryForReplicaCluster sets the name of the target designated
@@ -350,10 +319,30 @@ func (r *ClusterReconciler) reconcileTargetPrimaryForReplicaCluster(
 	// When replica mode is active, the designated primary may not be the first element
 	// in this list, since from the PostgreSQL point-of-view it's not the real primary.
 
+	mostAdvancedInstance := status.Items[0]
+
+	var targetPrimary postgres.PostgresqlStatus
+	targetPrimaryFound := false
 	for _, statusRecord := range status.Items {
 		if statusRecord.Pod.Name == cluster.Status.TargetPrimary {
-			// Everything fine, the current designated primary is active
+			targetPrimary = statusRecord
+			targetPrimaryFound = true
+			break
+		}
+	}
+
+	var shouldMovePrimary bool
+	if targetPrimaryFound {
+		if cluster.Status.CurrentPrimary != targetPrimary.Pod.Name {
+			// Failover in progress and target primary is already set
 			return "", nil
+		}
+		shouldMovePrimary = r.shouldSetPrimaryToSchedulableNode(ctx, cluster, status, &targetPrimary)
+		if shouldMovePrimary && len(status.Items) > 1 {
+			// mostAdvancedInstance is the current primary we want to move away from, change it to the most advanced
+			// replica. shouldSetPrimaryToSchedulableNode has already confirmed all other healthy replicas are on
+			// schedulable nodes.
+			mostAdvancedInstance = status.Items[1]
 		}
 	}
 
@@ -369,15 +358,19 @@ func (r *ClusterReconciler) reconcileTargetPrimaryForReplicaCluster(
 		return "", ErrWalReceiversRunning
 	}
 
-	contextLogger.Info("Current target primary isn't healthy, failing over",
-		"newPrimary", status.Items[0].Pod.Name)
+	failoverReason := "Current primary isn't healthy"
+	if shouldMovePrimary {
+		failoverReason = "Current primary is on an unschedulable node"
+	}
+	contextLogger.Info(failoverReason+", failing over",
+		"newPrimary", mostAdvancedInstance.Pod.Name)
 	status.LogStatus(ctx)
 	contextLogger.Debug("Cluster status before failover", "instances", resources.instances)
 	r.Recorder.Eventf(cluster, "Normal", "FailingOver",
-		"Current target primary isn't healthy, failing over from %v to %v",
-		cluster.Status.TargetPrimary, status.Items[0].Pod.Name)
+		failoverReason+", failing over from %v to %v",
+		cluster.Status.TargetPrimary, mostAdvancedInstance.Pod.Name)
 	if err := r.RegisterPhase(ctx, cluster, apiv1.PhaseFailOver,
-		fmt.Sprintf("Failing over to %v", status.Items[0].Pod.Name)); err != nil {
+		fmt.Sprintf("Failing over to %v", mostAdvancedInstance.Pod.Name)); err != nil {
 		return "", err
 	}
 
@@ -386,7 +379,7 @@ func (r *ClusterReconciler) reconcileTargetPrimaryForReplicaCluster(
 	// service, so the split-brain window #10403 guards against does not
 	// apply. The retryable call in the reconcile loop's failover guard still
 	// relabels the pod on its next pass.
-	return status.Items[0].Pod.Name, r.setPrimaryInstance(ctx, cluster, status.Items[0].Pod.Name)
+	return mostAdvancedInstance.Pod.Name, r.setPrimaryInstance(ctx, cluster, mostAdvancedInstance.Pod.Name)
 }
 
 // getSchedulablePodsNotOnPrimaryNode filters out only pods that are not on the same node as the
@@ -396,6 +389,8 @@ func (r *ClusterReconciler) getSchedulablePodsNotOnPrimaryNode(
 	status postgres.PostgresqlStatusList,
 	primaryPod *postgres.PostgresqlStatus,
 ) postgres.PostgresqlStatusList {
+	contextLogger := log.FromContext(ctx)
+
 	podsOnOtherNodes := postgres.PostgresqlStatusList{
 		IsReplicaCluster: status.IsReplicaCluster,
 		CurrentPrimary:   status.CurrentPrimary,
@@ -407,7 +402,13 @@ func (r *ClusterReconciler) getSchedulablePodsNotOnPrimaryNode(
 		if candidate.Pod.Name == primaryPod.Pod.Name || candidate.Node == primaryPod.Node {
 			continue
 		}
-		if unschedulable, _ := r.isNodeUnschedulableOrBeingDrained(ctx, candidate.Node); unschedulable {
+		unschedulable, err := r.isNodeUnschedulableOrBeingDrained(ctx, candidate.Node)
+		if err != nil {
+			contextLogger.Error(err, "while checking if node is unschedulable or being drained",
+				"node", candidate.Node, "pod", candidate.Pod.Name)
+			continue
+		}
+		if unschedulable {
 			continue
 		}
 		podsOnOtherNodes.Items = append(podsOnOtherNodes.Items, candidate)

--- a/internal/controller/replicas.go
+++ b/internal/controller/replicas.go
@@ -74,7 +74,7 @@ func (r *ClusterReconciler) reconcileTargetPrimaryFromPods(
 		} else if isPrimaryOnUnschedulableNode {
 			contextLogger.Info("Primary is running on an unschedulable node, will try switching over",
 				"node", primary.Node, "primary", primary.Pod.Name)
-			return r.setPrimaryOnSchedulableNode(ctx, cluster, status, &primary)
+			return r.triggerSwitchoverToSchedulableNodes(ctx, cluster, status, resources, &primary)
 		}
 	}
 
@@ -257,12 +257,13 @@ func (r *ClusterReconciler) isNodeUnschedulableOrBeingDrained(
 	return isNodeUnschedulableOrBeingDrained(&node, r.drainTaints), nil
 }
 
-// Pick the next primary on a schedulable node, if the current is running on an unschedulable one,
-// e.g. in case a drain is in progress
-func (r *ClusterReconciler) setPrimaryOnSchedulableNode(
+// triggerSwitchoverToSchedulableNodes Triggers an unschedulable node switchover if all replicas are on schedulable nodes
+// and failover quorum is satisfied
+func (r *ClusterReconciler) triggerSwitchoverToSchedulableNodes(
 	ctx context.Context,
 	cluster *apiv1.Cluster,
 	status postgres.PostgresqlStatusList,
+	resources *managedResources,
 	primaryPod *postgres.PostgresqlStatus,
 ) (string, error) {
 	contextLogger := log.FromContext(ctx)
@@ -295,41 +296,43 @@ func (r *ClusterReconciler) setPrimaryOnSchedulableNode(
 	// and the operator would be waiting for it to be rescheduled to a different node indefinitely if the PVC used can not
 	// be moved between nodes, e.g. local-path-provisioner on Kind.
 
-	// Start looking for the next primary among the pods
-	for _, candidate := range podsOnSchedulableNodes.Items {
-		if !utils.IsPodReady(*candidate.Pod) {
-			continue
-		}
-
-		// If the candidate has not established a connection to the current primary, skip it
-		if !candidate.IsWalReceiverActive {
-			continue
-		}
-
-		// Set the current candidate as targetPrimary
-		contextLogger.Info("Current primary is running on unschedulable node, triggering a switchover",
-			"currentPrimary", primaryPod.Pod.Name, "currentPrimaryNode", primaryPod.Node,
-			"targetPrimary", candidate.Pod.Name, "targetPrimaryNode", candidate.Node)
-		status.LogStatus(ctx)
-		r.Recorder.Eventf(cluster, "Normal", "SwitchingOver",
-			"Current primary is running on unschedulable node %v, switching over from %v to %v",
-			primaryPod.Node, cluster.Status.TargetPrimary, candidate.Pod.Name)
-		if err := r.RegisterPhase(ctx, cluster, apiv1.PhaseSwitchover,
-			fmt.Sprintf("Switching over to %v, because primary instance "+
-				"was running on unschedulable node %v",
-				candidate.Pod.Name,
-				primaryPod.Node)); err != nil {
+	// If quorum check is active, ensure we don't trigger a switchover if not enough replicas are available.
+	if cluster.IsFailoverQuorumActive() {
+		if status, err := r.evaluateQuorumCheck(ctx, cluster, status); err != nil {
 			return "", err
+		} else if !status {
+			// Prevent a failover from happening
+			return "", nil
 		}
-		return candidate.Pod.Name, r.setPrimaryInstance(ctx, cluster, candidate.Pod.Name)
 	}
 
-	// if we are here this means no new primary has been chosen
-	contextLogger.Info("Current primary is running on unschedulable node, but there are no valid candidates",
-		"currentPrimary", status.Items[0].Pod.Name,
-		"primaryNode", status.Items[0].Node,
-		"instances", status.Items)
+	contextLogger.Info("Current primary is running on unschedulable node, triggering a switchover",
+		"currentPrimary", primaryPod.Pod.Name, "currentPrimaryNode", primaryPod.Node)
 	status.LogStatus(ctx)
+	r.Recorder.Eventf(cluster, "Normal", "SwitchingOver",
+		"Current primary is running on unschedulable node %v, triggering a switchover",
+		primaryPod.Node)
+	if err := r.RegisterPhase(ctx, cluster, apiv1.PhaseSwitchover,
+		fmt.Sprintf("Triggering switchover because primary instance %v is running on unschedulable node %v",
+			primaryPod.Pod.Name,
+			primaryPod.Node)); err != nil {
+		return "", err
+	}
+	if err := r.setPrimaryInstance(ctx, cluster, apiv1.PendingFailoverMarker); err != nil {
+		return "", err
+	}
+
+	if !status.IsReplicaCluster {
+		if err := r.markOldPrimaryAsUnhealthy(
+			ctx,
+			cluster.Status.CurrentPrimary,
+			resources.instances.Items,
+		); err != nil {
+			contextLogger.Error(err, "Failed to strip primary label from old primary, continuing with failover",
+				"oldPrimary", cluster.Status.CurrentPrimary)
+		}
+	}
+
 	return "", nil
 }
 

--- a/internal/controller/replicas.go
+++ b/internal/controller/replicas.go
@@ -324,7 +324,7 @@ func (r *ClusterReconciler) reconcileTargetPrimaryForReplicaCluster(
 	// When replica mode is active, the designated primary may not be the first element
 	// in this list, since from the PostgreSQL point-of-view it's not the real primary.
 
-	mostAdvancedInstance := status.Items[0]
+	candidate := status.Items[0]
 
 	var targetPrimary postgres.PostgresqlStatus
 	targetPrimaryFound := false
@@ -336,21 +336,34 @@ func (r *ClusterReconciler) reconcileTargetPrimaryForReplicaCluster(
 		}
 	}
 
-	var shouldMovePrimary bool
 	if targetPrimaryFound {
 		if cluster.Status.CurrentPrimary != targetPrimary.Pod.Name {
 			// Failover in progress and target primary is already set
 			return "", nil
 		}
-		shouldMovePrimary = r.shouldSetPrimaryToSchedulableNode(ctx, cluster, status, &targetPrimary)
+		shouldMovePrimary := r.shouldSetPrimaryToSchedulableNode(ctx, cluster, status, &targetPrimary)
 		if shouldMovePrimary && len(status.Items) > 1 {
-			// mostAdvancedInstance is the current primary we want to move away from, change it to the most advanced
-			// replica. shouldSetPrimaryToSchedulableNode has already confirmed all other healthy replicas are on
-			// schedulable nodes.
-			mostAdvancedInstance = status.Items[1]
-		} else {
-			return "", nil
+			// candidate is the current primary we want to move away from, change it to the most advanced replica.
+			// shouldSetPrimaryToSchedulableNode has already confirmed all other healthy replicas are on schedulable
+			// nodes.
+			candidate = status.Items[1]
+			contextLogger.Info("Current primary is running on unschedulable node, triggering a switchover",
+				"currentPrimary", targetPrimary.Pod.Name, "currentPrimaryNode", targetPrimary.Node,
+				"targetPrimary", candidate.Pod.Name, "targetPrimaryNode", candidate.Node)
+			status.LogStatus(ctx)
+			r.Recorder.Eventf(cluster, "Normal", "SwitchingOver",
+				"Current primary is running on unschedulable node %v, switching over from %v to %v",
+				targetPrimary.Node, cluster.Status.TargetPrimary, candidate.Pod.Name)
+			if err := r.RegisterPhase(ctx, cluster, apiv1.PhaseSwitchover,
+				fmt.Sprintf("Switching over to %v, because primary instance was running on unschedulable node %v",
+					candidate.Pod.Name, targetPrimary.Node)); err != nil {
+				return "", err
+			}
+			return candidate.Pod.Name, r.setPrimaryInstance(ctx, cluster, candidate.Pod.Name)
 		}
+
+		// Everything fine, the current designated primary is active
+		return "", nil
 	}
 
 	if err := r.enforceFailoverDelay(ctx, cluster); err != nil {
@@ -365,19 +378,15 @@ func (r *ClusterReconciler) reconcileTargetPrimaryForReplicaCluster(
 		return "", ErrWalReceiversRunning
 	}
 
-	failoverReason := "Current primary isn't healthy"
-	if shouldMovePrimary {
-		failoverReason = "Current primary is on an unschedulable node"
-	}
-	contextLogger.Info(failoverReason+", failing over",
-		"newPrimary", mostAdvancedInstance.Pod.Name)
+	contextLogger.Info("Current primary isn't healthy, failing over",
+		"newPrimary", candidate.Pod.Name)
 	status.LogStatus(ctx)
 	contextLogger.Debug("Cluster status before failover", "instances", resources.instances)
 	r.Recorder.Eventf(cluster, "Normal", "FailingOver",
-		failoverReason+", failing over from %v to %v",
-		cluster.Status.TargetPrimary, mostAdvancedInstance.Pod.Name)
+		"Current primary isn't healthy, failing over from %v to %v",
+		cluster.Status.TargetPrimary, candidate.Pod.Name)
 	if err := r.RegisterPhase(ctx, cluster, apiv1.PhaseFailOver,
-		fmt.Sprintf("Failing over to %v", mostAdvancedInstance.Pod.Name)); err != nil {
+		fmt.Sprintf("Failing over to %v", candidate.Pod.Name)); err != nil {
 		return "", err
 	}
 
@@ -386,7 +395,7 @@ func (r *ClusterReconciler) reconcileTargetPrimaryForReplicaCluster(
 	// service, so the split-brain window #10403 guards against does not
 	// apply. The retryable call in the reconcile loop's failover guard still
 	// relabels the pod on its next pass.
-	return mostAdvancedInstance.Pod.Name, r.setPrimaryInstance(ctx, cluster, mostAdvancedInstance.Pod.Name)
+	return candidate.Pod.Name, r.setPrimaryInstance(ctx, cluster, candidate.Pod.Name)
 }
 
 // getSchedulablePodsNotOnPrimaryNode filters out only pods that are not on the same node as the

--- a/internal/controller/replicas.go
+++ b/internal/controller/replicas.go
@@ -348,6 +348,8 @@ func (r *ClusterReconciler) reconcileTargetPrimaryForReplicaCluster(
 			// replica. shouldSetPrimaryToSchedulableNode has already confirmed all other healthy replicas are on
 			// schedulable nodes.
 			mostAdvancedInstance = status.Items[1]
+		} else {
+			return "", nil
 		}
 	}
 

--- a/internal/controller/replicas_test.go
+++ b/internal/controller/replicas_test.go
@@ -277,7 +277,13 @@ var _ = Describe("markOldPrimaryAsUnhealthy", func() {
 	})
 })
 
-var _ = Describe("Check pods not on primary node", func() {
+var _ = Describe("Check schedulable pods not on primary node", func() {
+	var env *testingEnvironment
+
+	BeforeEach(func() {
+		env = buildTestEnvironment()
+	})
+
 	item1 := postgres.PostgresqlStatus{
 		IsPrimary: false,
 		Node:      "node-1",
@@ -292,13 +298,54 @@ var _ = Describe("Check pods not on primary node", func() {
 	statusList := postgres.PostgresqlStatusList{Items: []postgres.PostgresqlStatus{item1, item2}}
 
 	It("if primary is nil", func() {
-		Expect(GetPodsNotOnPrimaryNode(statusList, nil).Items).To(BeEmpty())
+		ctx := context.Background()
+		Expect(env.clusterReconciler.getSchedulablePodsNotOnPrimaryNode(ctx, statusList, nil).Items).To(BeEmpty())
 	})
 
 	item1.IsPrimary = true
 	statusList2 := postgres.PostgresqlStatusList{Items: []postgres.PostgresqlStatus{item1, item2}}
 
 	It("first status element is primary", func() {
-		Expect(GetPodsNotOnPrimaryNode(statusList2, &statusList2.Items[0]).Items).ToNot(BeEmpty())
+		ctx := context.Background()
+		Expect(env.clusterReconciler.getSchedulablePodsNotOnPrimaryNode(ctx, statusList2, &statusList2.Items[0]).Items).
+			ToNot(BeEmpty())
+	})
+
+	It("excludes pods on unschedulable nodes", func() {
+		ctx := context.Background()
+
+		primaryNode := corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: "primary-node"},
+			Spec:       corev1.NodeSpec{Unschedulable: true},
+		}
+		cordonedNode := corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: "cordoned-node"},
+			Spec:       corev1.NodeSpec{Unschedulable: true},
+		}
+		Expect(env.client.Create(ctx, &primaryNode)).To(Succeed())
+		Expect(env.client.Create(ctx, &cordonedNode)).To(Succeed())
+
+		primary := postgres.PostgresqlStatus{
+			IsPrimary: true,
+			Node:      "primary-node",
+			Pod:       &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-primary"}},
+		}
+		onCordonedNode := postgres.PostgresqlStatus{
+			IsPrimary: false,
+			Node:      "cordoned-node",
+			Pod:       &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-cordoned"}},
+		}
+		onMissingNode := postgres.PostgresqlStatus{
+			IsPrimary: false,
+			Node:      "missing-node",
+			Pod:       &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-missing-node"}},
+		}
+		list := postgres.PostgresqlStatusList{
+			Items: []postgres.PostgresqlStatus{primary, onCordonedNode, onMissingNode},
+		}
+
+		result := env.clusterReconciler.getSchedulablePodsNotOnPrimaryNode(ctx, list, &primary)
+		Expect(result.Items).To(HaveLen(1))
+		Expect(result.Items[0].Pod.Name).To(Equal("pod-missing-node"))
 	})
 })

--- a/internal/controller/replicas_test.go
+++ b/internal/controller/replicas_test.go
@@ -364,3 +364,142 @@ var _ = Describe("Check schedulable pods not on primary node", func() {
 		Expect(result.Items[0].Pod.Name).To(Equal("pod-healthy"))
 	})
 })
+
+var _ = Describe("shouldSetPrimaryToSchedulableNode", func() {
+	var env *testingEnvironment
+
+	BeforeEach(func() {
+		env = buildTestEnvironment()
+	})
+
+	newStatus := func(podName, node string, isPrimary bool) postgres.PostgresqlStatus {
+		return postgres.PostgresqlStatus{
+			IsPrimary: isPrimary,
+			Node:      node,
+			Pod:       &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: podName}},
+		}
+	}
+
+	It("returns false when the primary is not on an unschedulable node", func() {
+		ctx := context.Background()
+		schedulableNode := corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "primary-node"}}
+		Expect(env.client.Create(ctx, &schedulableNode)).To(Succeed())
+
+		primary := newStatus("pod-primary", "primary-node", true)
+		cluster := &apiv1.Cluster{
+			Spec:   apiv1.ClusterSpec{Instances: 3},
+			Status: apiv1.ClusterStatus{ReadyInstances: 3},
+		}
+		list := postgres.PostgresqlStatusList{Items: []postgres.PostgresqlStatus{primary}}
+
+		Expect(env.clusterReconciler.shouldSetPrimaryToSchedulableNode(ctx, cluster, list, &primary)).To(BeFalse())
+	})
+
+	It("returns false when the primary's node can't be found", func() {
+		ctx := context.Background()
+
+		primary := newStatus("pod-primary", "missing-node", true)
+		cluster := &apiv1.Cluster{
+			Spec:   apiv1.ClusterSpec{Instances: 3},
+			Status: apiv1.ClusterStatus{ReadyInstances: 3},
+		}
+		list := postgres.PostgresqlStatusList{Items: []postgres.PostgresqlStatus{primary}}
+
+		Expect(env.clusterReconciler.shouldSetPrimaryToSchedulableNode(ctx, cluster, list, &primary)).To(BeFalse())
+	})
+
+	It("returns false when the primary is on an unschedulable node but it is the only instance in the cluster", func() {
+		ctx := context.Background()
+
+		primaryNode := corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: "primary-node"},
+			Spec:       corev1.NodeSpec{Unschedulable: true},
+		}
+		Expect(env.client.Create(ctx, &primaryNode)).To(Succeed())
+
+		primary := newStatus("pod-primary", "primary-node", true)
+		cluster := &apiv1.Cluster{
+			Spec:   apiv1.ClusterSpec{Instances: 1},
+			Status: apiv1.ClusterStatus{ReadyInstances: 1},
+		}
+		list := postgres.PostgresqlStatusList{Items: []postgres.PostgresqlStatus{primary}}
+
+		Expect(env.clusterReconciler.shouldSetPrimaryToSchedulableNode(ctx, cluster, list, &primary)).To(BeFalse())
+	})
+
+	It("returns false when the primary is on an unschedulable node but instances are still becoming ready", func() {
+		ctx := context.Background()
+		primaryNode := corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: "primary-node"},
+			Spec:       corev1.NodeSpec{Unschedulable: true},
+		}
+		healthyNode := corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "healthy-node"}}
+		Expect(env.client.Create(ctx, &primaryNode)).To(Succeed())
+		Expect(env.client.Create(ctx, &healthyNode)).To(Succeed())
+
+		primary := newStatus("pod-primary", "primary-node", true)
+		replica := newStatus("pod-replica", "healthy-node", false)
+		cluster := &apiv1.Cluster{
+			Spec: apiv1.ClusterSpec{Instances: 3},
+			// one instance is still joining, so we shouldn't disrupt the primary yet
+			Status: apiv1.ClusterStatus{ReadyInstances: 2},
+		}
+		list := postgres.PostgresqlStatusList{Items: []postgres.PostgresqlStatus{primary, replica}}
+
+		Expect(env.clusterReconciler.shouldSetPrimaryToSchedulableNode(ctx, cluster, list, &primary)).To(BeFalse())
+	})
+
+	It("returns false when not all the replicas have moved to a schedulable node yet", func() {
+		ctx := context.Background()
+		primaryNode := corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: "primary-node"},
+			Spec:       corev1.NodeSpec{Unschedulable: true},
+		}
+		unhealthyNode := corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: "unhealthy-node"},
+			Spec:       corev1.NodeSpec{Unschedulable: true},
+		}
+		healthyNode := corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "healthy-node"}}
+		Expect(env.client.Create(ctx, &primaryNode)).To(Succeed())
+		Expect(env.client.Create(ctx, &unhealthyNode)).To(Succeed())
+		Expect(env.client.Create(ctx, &healthyNode)).To(Succeed())
+
+		primary := newStatus("pod-primary", "primary-node", true)
+		// still stuck on the primary's (unschedulable) node
+		replicaNotYetMoved := newStatus("pod-replica-1", "unhealthy-node", false)
+		replicaMoved := newStatus("pod-replica-2", "healthy-node", false)
+		list := postgres.PostgresqlStatusList{
+			Items: []postgres.PostgresqlStatus{primary, replicaNotYetMoved, replicaMoved},
+		}
+		cluster := &apiv1.Cluster{
+			Spec:   apiv1.ClusterSpec{Instances: 3},
+			Status: apiv1.ClusterStatus{ReadyInstances: 3},
+		}
+
+		Expect(env.clusterReconciler.shouldSetPrimaryToSchedulableNode(ctx, cluster, list, &primary)).To(BeFalse())
+	})
+
+	It("returns true when the primary is unschedulable and all replicas have moved to schedulable nodes", func() {
+		ctx := context.Background()
+		primaryNode := corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: "primary-node"},
+			Spec:       corev1.NodeSpec{Unschedulable: true},
+		}
+		healthyNode1 := corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "healthy-node-1"}}
+		healthyNode2 := corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "healthy-node-2"}}
+		Expect(env.client.Create(ctx, &primaryNode)).To(Succeed())
+		Expect(env.client.Create(ctx, &healthyNode1)).To(Succeed())
+		Expect(env.client.Create(ctx, &healthyNode2)).To(Succeed())
+
+		primary := newStatus("pod-primary", "primary-node", true)
+		replica1 := newStatus("pod-replica-1", "healthy-node-1", false)
+		replica2 := newStatus("pod-replica-2", "healthy-node-2", false)
+		list := postgres.PostgresqlStatusList{Items: []postgres.PostgresqlStatus{primary, replica1, replica2}}
+		cluster := &apiv1.Cluster{
+			Spec:   apiv1.ClusterSpec{Instances: 3},
+			Status: apiv1.ClusterStatus{ReadyInstances: 3},
+		}
+
+		Expect(env.clusterReconciler.shouldSetPrimaryToSchedulableNode(ctx, cluster, list, &primary)).To(BeTrue())
+	})
+})

--- a/internal/controller/replicas_test.go
+++ b/internal/controller/replicas_test.go
@@ -307,6 +307,12 @@ var _ = Describe("Check schedulable pods not on primary node", func() {
 
 	It("first status element is primary", func() {
 		ctx := context.Background()
+
+		node2 := corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: "node-2"},
+		}
+		Expect(env.client.Create(ctx, &node2)).To(Succeed())
+
 		Expect(env.clusterReconciler.getSchedulablePodsNotOnPrimaryNode(ctx, statusList2, &statusList2.Items[0]).Items).
 			ToNot(BeEmpty())
 	})
@@ -322,8 +328,12 @@ var _ = Describe("Check schedulable pods not on primary node", func() {
 			ObjectMeta: metav1.ObjectMeta{Name: "cordoned-node"},
 			Spec:       corev1.NodeSpec{Unschedulable: true},
 		}
+		schedulableNode := corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: "healthy-node"},
+		}
 		Expect(env.client.Create(ctx, &primaryNode)).To(Succeed())
 		Expect(env.client.Create(ctx, &cordonedNode)).To(Succeed())
+		Expect(env.client.Create(ctx, &schedulableNode)).To(Succeed())
 
 		primary := postgres.PostgresqlStatus{
 			IsPrimary: true,
@@ -340,12 +350,17 @@ var _ = Describe("Check schedulable pods not on primary node", func() {
 			Node:      "missing-node",
 			Pod:       &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-missing-node"}},
 		}
+		onHealthyNode := postgres.PostgresqlStatus{
+			IsPrimary: false,
+			Node:      "healthy-node",
+			Pod:       &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-healthy"}},
+		}
 		list := postgres.PostgresqlStatusList{
-			Items: []postgres.PostgresqlStatus{primary, onCordonedNode, onMissingNode},
+			Items: []postgres.PostgresqlStatus{primary, onCordonedNode, onMissingNode, onHealthyNode},
 		}
 
 		result := env.clusterReconciler.getSchedulablePodsNotOnPrimaryNode(ctx, list, &primary)
 		Expect(result.Items).To(HaveLen(1))
-		Expect(result.Items[0].Pod.Name).To(Equal("pod-missing-node"))
+		Expect(result.Items[0].Pod.Name).To(Equal("pod-healthy"))
 	})
 })


### PR DESCRIPTION
Fixes #11293.

There is a race condition in the current switch over logic when the operator detects the primary is running on an unschedulable node. The operator picks the new primary before waiting for the old primary to fully shutdown. The old primary can still commit transactions and replicate them to any replicas. These transactions may not be replicated to the chosen new primary, especially when quorum-based synchronous replication is configured (i.e. `method: any`), and are "lost" when it is promoted. The more advanced replica enters a crash-loop because it is ahead of the new primary's fork point of the new timeline.

This PR fixes it by reusing the code path for failovers. The failover code path sets the target primary to a pending marker, which triggers the shutdown of the old primary, but waits until the primary is fully shutdown before picking the new primary. Reusing the failover code path also ensures that we perform the failover quorum check. This is only required for non-replica clusters. The designated primary of a replica cluster does not need to be shut down before a switchover.

This fix was inspired by #11185, but I've chosen not to introduce a separate pending switchover marker. I don't think we need to distinguish a failover from a switchover as their mechanics should be the same. The only difference is in how they are triggered, a failover is unintentional and a switchover is intentional. In fact, I think one of the causes of this bug and #11114 is that there are separate code paths for each. Happy to change it if this is wrong.

As mentioned in this [comment](https://github.com/cloudnative-pg/cloudnative-pg/issues/11114#issuecomment-4870867123), the failover primary selection can be further improved using the primary lease. The operator can try to acquire the primary lease before selecting the new primary, which should give better guarantees that the old primary is fully shutdown before picking the new primary. I've decided not to implement that improvement in this PR.

Appreciate any feedback as this is my first contribution to the project.