### PR TITLE
fix(plugin,status): recognize CNPG-I WAL archiver plugins in status

### DIFF
--- a/internal/cmd/plugin/status/status.go
+++ b/internal/cmd/plugin/status/status.go
@@ -524,18 +524,22 @@ func (fullStatus *PostgresqlStatus) printPostgresConfiguration(
 func (fullStatus *PostgresqlStatus) printBackupStatus() {
 	cluster := fullStatus.Cluster
 
-	// Check if Barman Cloud plugin is configured
 	isBarmanPluginEnabled, pluginParams := isBarmanCloudPluginEnabled(cluster)
+	walArchiverPluginName := cluster.GetEnabledWALArchivePluginName()
+
+	if !hasContinuousBackupConfigured(cluster) {
+		fmt.Println(aurora.Yellow("Continuous Backup not configured"))
+		fmt.Println()
+		return
+	}
 
 	switch {
 	case isBarmanPluginEnabled:
 		fmt.Println(aurora.Green("Continuous Backup status (Barman Cloud Plugin)"))
-	case cluster.Spec.Backup != nil:
-		fmt.Println(aurora.Green("Continuous Backup status"))
+	case walArchiverPluginName != "":
+		fmt.Println(aurora.Green(fmt.Sprintf("Continuous Backup status (%s)", walArchiverPluginName)))
 	default:
-		fmt.Println(aurora.Yellow("Continuous Backup not configured"))
-		fmt.Println()
-		return
+		fmt.Println(aurora.Green("Continuous Backup status"))
 	}
 
 	status := tabby.New()
@@ -560,6 +564,11 @@ func (fullStatus *PostgresqlStatus) printBackupStatus() {
 		}
 
 		fullStatus.printBarmanObjectStoreStatus(status, objectStore, pluginParams)
+	} else if walArchiverPluginName != "" {
+		status.AddLine("WAL archiver plugin:", walArchiverPluginName)
+		if pluginStatus := getPluginStatusByName(cluster, walArchiverPluginName); pluginStatus != "" {
+			status.AddLine("Plugin status:", pluginStatus)
+		}
 	} else if cluster.Spec.Backup != nil {
 		// FirstRecoverabilityPoint is deprecated and will be removed together
 		// with native Barman Cloud support. It is only shown when the backup
@@ -621,6 +630,33 @@ func isBarmanCloudPluginEnabled(cluster *apiv1.Cluster) (bool, map[string]string
 		}
 	}
 	return false, nil
+}
+
+// getPluginStatusByName returns the status string reported by the plugin via SetStatusInCluster,
+// or an empty string when the plugin did not report any status.
+func getPluginStatusByName(cluster *apiv1.Cluster, pluginName string) string {
+	for _, plg := range cluster.Status.PluginStatus {
+		if plg.Name == pluginName {
+			return plg.Status
+		}
+	}
+	return ""
+}
+
+// hasContinuousBackupConfigured reports whether continuous backup is configured either
+// via a native .spec.backup section or via an enabled CNPG-I WAL archiver plugin.
+func hasContinuousBackupConfigured(cluster *apiv1.Cluster) bool {
+	if cluster == nil {
+		return false
+	}
+	isBarmanPluginEnabled, _ := isBarmanCloudPluginEnabled(cluster)
+	if isBarmanPluginEnabled {
+		return true
+	}
+	if cluster.GetEnabledWALArchivePluginName() != "" {
+		return true
+	}
+	return cluster.Spec.Backup != nil
 }
 
 // printWALArchivingStatus prints the WAL archiving status to the provided tabby table

--- a/internal/cmd/plugin/status/status_test.go
+++ b/internal/cmd/plugin/status/status_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 
@@ -110,5 +111,132 @@ var _ = Describe("getWalArchivingStatus", func() {
 		// Even if archiving is working, disabled should take precedence
 		result := getWalArchivingStatus(true, "", true)
 		Expect(result).To(ContainSubstring("Disabled"))
+	})
+})
+
+var _ = Describe("hasContinuousBackupConfigured", func() {
+	It("returns false when neither backup nor WAL archiver plugin is configured", func() {
+		cluster := &apiv1.Cluster{}
+		Expect(hasContinuousBackupConfigured(cluster)).To(BeFalse())
+	})
+
+	It("returns true when native .spec.backup is set", func() {
+		cluster := &apiv1.Cluster{
+			Spec: apiv1.ClusterSpec{
+				Backup: &apiv1.BackupConfiguration{},
+			},
+		}
+		Expect(hasContinuousBackupConfigured(cluster)).To(BeTrue())
+	})
+
+	It("returns true when the barman-cloud plugin is enabled", func() {
+		cluster := &apiv1.Cluster{
+			Spec: apiv1.ClusterSpec{
+				Plugins: []apiv1.PluginConfiguration{
+					{Name: "barman-cloud.cloudnative-pg.io"},
+				},
+			},
+		}
+		Expect(hasContinuousBackupConfigured(cluster)).To(BeTrue())
+	})
+
+	It("returns true when a third-party WAL archiver plugin is enabled", func() {
+		cluster := &apiv1.Cluster{
+			Spec: apiv1.ClusterSpec{
+				Plugins: []apiv1.PluginConfiguration{
+					{
+						Name:          "wal-archiver.example.com",
+						Enabled:       ptr.To(true),
+						IsWALArchiver: ptr.To(true),
+					},
+				},
+			},
+		}
+		Expect(hasContinuousBackupConfigured(cluster)).To(BeTrue())
+		Expect(cluster.GetEnabledWALArchivePluginName()).To(Equal("wal-archiver.example.com"))
+	})
+
+	It("returns false when a plugin is present but is not a WAL archiver", func() {
+		cluster := &apiv1.Cluster{
+			Spec: apiv1.ClusterSpec{
+				Plugins: []apiv1.PluginConfiguration{
+					{
+						Name:          "wal-archiver.example.com",
+						Enabled:       ptr.To(true),
+						IsWALArchiver: ptr.To(false),
+					},
+				},
+			},
+		}
+		Expect(hasContinuousBackupConfigured(cluster)).To(BeFalse())
+	})
+
+	It("returns false for a nil cluster", func() {
+		Expect(hasContinuousBackupConfigured(nil)).To(BeFalse())
+	})
+})
+
+var _ = Describe("getPluginStatusByName", func() {
+	It("returns the reported status for a matching plugin", func() {
+		cluster := &apiv1.Cluster{
+			Status: apiv1.ClusterStatus{
+				PluginStatus: []apiv1.PluginStatus{
+					{Name: "wal-archiver.example.com", Status: `{"ok":true}`},
+				},
+			},
+		}
+		Expect(getPluginStatusByName(cluster, "wal-archiver.example.com")).To(Equal(`{"ok":true}`))
+	})
+
+	It("returns an empty string when the plugin has no status", func() {
+		cluster := &apiv1.Cluster{
+			Status: apiv1.ClusterStatus{
+				PluginStatus: []apiv1.PluginStatus{
+					{Name: "wal-archiver.example.com"},
+				},
+			},
+		}
+		Expect(getPluginStatusByName(cluster, "wal-archiver.example.com")).To(Equal(""))
+	})
+
+	It("returns an empty string when the plugin is not present", func() {
+		cluster := &apiv1.Cluster{}
+		Expect(getPluginStatusByName(cluster, "missing")).To(Equal(""))
+	})
+})
+
+var _ = Describe("isBarmanCloudPluginEnabled", func() {
+	It("returns true and parameters when the plugin is enabled", func() {
+		cluster := &apiv1.Cluster{
+			Spec: apiv1.ClusterSpec{
+				Plugins: []apiv1.PluginConfiguration{
+					{
+						Name: "barman-cloud.cloudnative-pg.io",
+						Parameters: map[string]string{
+							"barmanObjectName": "minio-store",
+						},
+					},
+				},
+			},
+		}
+		enabled, params := isBarmanCloudPluginEnabled(cluster)
+		Expect(enabled).To(BeTrue())
+		Expect(params["barmanObjectName"]).To(Equal("minio-store"))
+	})
+
+	It("returns false when the plugin is explicitly disabled", func() {
+		cluster := &apiv1.Cluster{
+			Spec: apiv1.ClusterSpec{
+				Plugins: []apiv1.PluginConfiguration{
+					{
+						Name:    "barman-cloud.cloudnative-pg.io",
+						Enabled: ptr.To(false),
+					},
+				},
+			},
+		}
+		enabled, params := isBarmanCloudPluginEnabled(cluster)
+		Expect(enabled).To(BeFalse())
+		Expect(params).To(BeNil())
 	})
 })


### PR DESCRIPTION
## What

Make `kubectl cnpg status` aware of any enabled CNPG-I WAL archiver
plugin (`spec.plugins[].isWALArchiver: true`), not only the hardcoded
`barman-cloud.cloudnative-pg.io` plugin or native `.spec.backup`.

## Why

With a third-party WAL archiver plugin, continuous backup can be
working while `status` still prints `Continuous Backup not configured`
and skips WAL archiving details because of an early return in
`printBackupStatus()`.

Closes #11139

## How

- Detect the WAL archiver via `Cluster.GetEnabledWALArchivePluginName()`
- Print a continuous backup header with the plugin name and WAL
  archiving status (plus optional plugin status from
  `SetStatusInCluster` when present)
- Keep the existing Barman Cloud ObjectStore path first / unchanged
- Keep the native `.spec.backup` path unchanged

## Example output

Before:

```
Continuous Backup not configured
```

After:

```
Continuous Backup status (wal-archiver.example.com)
WAL archiver plugin:          wal-archiver.example.com
Working WAL archiving:        OK
WALs waiting to be archived:  0
Last Archived WAL:            000000010000000000000003.00000028.backup   @   2026-08-06T11:36:09.489771Z
Last Failed WAL:              000000010000000000000001                   @   2026-08-06T11:35:27.158824Z
```

## Test plan

- [x] Unit tests in `internal/cmd/plugin/status` covering:
  - no backup / no plugin → not configured
  - native `.spec.backup` → configured
  - `barman-cloud` plugin → configured
  - third-party WAL archiver (`isWALArchiver: true`) → configured
  - plugin present but not a WAL archiver → not configured
- [x] Manual: cluster with a third-party WAL archiver plugin and
  `isWALArchiver: true` — continuous backup section and WAL status shown
- [x] Manual: same cluster with an older `kubectl cnpg` build — still
  shows `Continuous Backup not configured`
- [ ] Manual/CI: cluster with Barman Cloud plugin — ObjectStore /
  recovery window path unchanged
- [ ] Manual: cluster without backup/plugins — still
  `Continuous Backup not configured`

## Notes

- Plugins status column showing `N/A` when a plugin does not implement
  `SetStatusInCluster` is out of scope for this PR.