### PR TITLE
fix: remove `ssl_ecdh_curve` from fixed parameters

### DIFF
--- a/docs/src/postgresql_conf.md
+++ b/docs/src/postgresql_conf.md
@@ -767,7 +767,6 @@ Users are not allowed to set the following configuration parameters in the
 - `ssl_cert_file`
 - `ssl_crl_file`
 - `ssl_dh_params_file`
-- `ssl_ecdh_curve`
 - `ssl_key_file`
 - `ssl_passphrase_command`
 - `ssl_passphrase_command_supports_reload`

--- a/pkg/postgres/configuration.go
+++ b/pkg/postgres/configuration.go
@@ -541,7 +541,6 @@ var (
 		"ssl_cert_file":                          fixedConfigurationParameter,
 		"ssl_crl_file":                           fixedConfigurationParameter,
 		"ssl_dh_params_file":                     fixedConfigurationParameter,
-		"ssl_ecdh_curve":                         fixedConfigurationParameter,
 		"ssl_key_file":                           fixedConfigurationParameter,
 		"ssl_passphrase_command":                 fixedConfigurationParameter,
 		"ssl_passphrase_command_supports_reload": fixedConfigurationParameter,


### PR DESCRIPTION
Enable users to configure `ssl_ecdh_curve` (since it should never have been blocked).

Closes: #11310