### PR TITLE
test(e2e): tolerate pod recreation with same name in data corruption test

### DIFF
--- a/tests/e2e/pg_data_corruption_test.go
+++ b/tests/e2e/pg_data_corruption_test.go
@@ -69,6 +69,7 @@ var _ = Describe("PGDATA Corruption", Label(tests.LabelRecovery), Ordered, func(
 		sampleFile string,
 	) {
 		var oldPrimaryPodName, oldPrimaryPVCName string
+		var oldPrimaryPodUID types.UID
 		var err error
 		tableName := "test_pg_data_corruption"
 		clusterName, err := yaml.GetResourceNameFromYAML(env.Scheme, sampleFile)
@@ -86,6 +87,7 @@ var _ = Describe("PGDATA Corruption", Label(tests.LabelRecovery), Ordered, func(
 			oldPrimaryPod, err := clusterutils.GetPrimary(env.Ctx, env.Client, namespace, clusterName)
 			Expect(err).ToNot(HaveOccurred())
 			oldPrimaryPodName = oldPrimaryPod.GetName()
+			oldPrimaryPodUID = oldPrimaryPod.GetUID()
 			// Get the PVC related to the pod
 			pvcName := oldPrimaryPod.Spec.Volumes[0].PersistentVolumeClaim.ClaimName
 			pvc := &corev1.PersistentVolumeClaim{}
@@ -191,14 +193,25 @@ var _ = Describe("PGDATA Corruption", Label(tests.LabelRecovery), Ordered, func(
 			err = podutils.Delete(env.Ctx, env.Client, namespace, oldPrimaryPodName, quickDelete)
 			Expect(err).ToNot(HaveOccurred())
 
-			// checking that the old primary pod is eventually gone
+			// Checking that the old primary pod gets replaced. With in-process
+			// bootstrap the operator reuses the freed serial and recreates a pod
+			// with the same name within seconds, so the name may never be observed
+			// absent: assert the pod is either gone or has been replaced by a new
+			// one carrying a different UID.
 			namespacedName := types.NamespacedName{
 				Namespace: namespace,
 				Name:      oldPrimaryPodName,
 			}
-			Eventually(func() bool {
-				err := env.Client.Get(env.Ctx, namespacedName, &corev1.Pod{})
-				return apierrs.IsNotFound(err)
+			Eventually(func() (bool, error) {
+				pod := &corev1.Pod{}
+				err := env.Client.Get(env.Ctx, namespacedName, pod)
+				if apierrs.IsNotFound(err) {
+					return true, nil
+				}
+				if err != nil {
+					return false, err
+				}
+				return pod.GetUID() != oldPrimaryPodUID, nil
 			}, 300).Should(BeTrue())
 
 			By("verifying new pod should join as standby", func() {


### PR DESCRIPTION
With in-process bootstrap, the operator can reuse the freed serial and recreate a pod with the same name within seconds, so the old primary pod's name may never be observed as absent. Track the old pod's UID and consider it replaced once a pod with the same name has a different UID, not just when the name disappears.