### PR TITLE
test(e2e): use default storage class in tablespaces test

### DIFF
--- a/tests/e2e/cluster_major_upgrade_test.go
+++ b/tests/e2e/cluster_major_upgrade_test.go
@@ -487,9 +487,6 @@ var _ = Describe("Postgres Major Upgrade", Ordered, ContinueOnFailure, Label(tes
 		namespace, err := env.CreateUniqueTestNamespace(env.Ctx, env.Client, namespacePrefix)
 		Expect(err).ToNot(HaveOccurred())
 
-		storageClass := os.Getenv("E2E_DEFAULT_STORAGE_CLASS")
-		Expect(storageClass).ToNot(BeEmpty())
-
 		By("creating the certificates for the object store", func() {
 			err := objectStoreEnv.CreateCaSecret(env, namespace)
 			Expect(err).ToNot(HaveOccurred())
@@ -510,7 +507,7 @@ var _ = Describe("Postgres Major Upgrade", Ordered, ContinueOnFailure, Label(tes
 		// We cannot use generated entries in the DescribeTable, so we use the scenario key as a constant, but
 		// define the actual content here.
 		// See https://onsi.github.io/ginkgo/#mental-model-table-specs-are-just-syntactic-sugar
-		scenarios = buildScenarios(namespace, storageClass, versionInfo)
+		scenarios = buildScenarios(namespace, env.DefaultStorageClass, versionInfo)
 	})
 
 	DescribeTable("can upgrade a Cluster to a newer major version", func(scenarioName string) {

--- a/tests/e2e/configuration_update_test.go
+++ b/tests/e2e/configuration_update_test.go
@@ -21,7 +21,6 @@ package e2e
 
 import (
 	"fmt"
-	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -34,6 +33,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
@@ -159,9 +159,6 @@ var _ = Describe("Configuration update", Label(tests.LabelClusterMetadata), func
 	}
 
 	generateBaseCluster := func(namespace string) *apiv1.Cluster {
-		storageClass := os.Getenv("E2E_DEFAULT_STORAGE_CLASS")
-		Expect(storageClass).ToNot(BeEmpty())
-
 		return &apiv1.Cluster{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      clusterName,
@@ -170,11 +167,11 @@ var _ = Describe("Configuration update", Label(tests.LabelClusterMetadata), func
 			Spec: apiv1.ClusterSpec{
 				Instances: 3,
 				StorageConfiguration: apiv1.StorageConfiguration{
-					StorageClass: &storageClass,
+					StorageClass: ptr.To(env.DefaultStorageClass),
 					Size:         "1Gi",
 				},
 				WalStorage: &apiv1.StorageConfiguration{
-					StorageClass: &storageClass,
+					StorageClass: ptr.To(env.DefaultStorageClass),
 					Size:         "1Gi",
 				},
 				PostgresConfiguration: apiv1.PostgresConfiguration{

--- a/tests/e2e/imagevolume_extensions_test.go
+++ b/tests/e2e/imagevolume_extensions_test.go
@@ -21,7 +21,6 @@ package e2e
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -32,6 +31,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/postgres"
@@ -291,7 +291,6 @@ var _ = Describe("ImageVolume Extensions", Label(tests.LabelImageVolumeExtension
 	})
 
 	It("via ImageCatalog", func() {
-		storageClass := os.Getenv("E2E_DEFAULT_STORAGE_CLASS")
 		clusterName = "postgresql-with-extensions"
 		catalogName := "catalog-with-extensions"
 
@@ -362,11 +361,11 @@ var _ = Describe("ImageVolume Extensions", Label(tests.LabelImageVolumeExtension
 					}},
 					StorageConfiguration: apiv1.StorageConfiguration{
 						Size:         "1Gi",
-						StorageClass: &storageClass,
+						StorageClass: ptr.To(env.DefaultStorageClass),
 					},
 					WalStorage: &apiv1.StorageConfiguration{
 						Size:         "1Gi",
-						StorageClass: &storageClass,
+						StorageClass: ptr.To(env.DefaultStorageClass),
 					},
 				},
 			}

--- a/tests/e2e/pg_wal_volume_test.go
+++ b/tests/e2e/pg_wal_volume_test.go
@@ -21,7 +21,6 @@ package e2e
 
 import (
 	"fmt"
-	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -29,6 +28,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
+	"k8s.io/utils/ptr"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/specs"
@@ -105,10 +105,9 @@ var _ = Describe("Separate pg_wal volume", Label(tests.LabelStorage), func() {
 		err := retry.OnError(retry.DefaultBackoff, objects.IsRetryableConflictOrTransientError, func() error {
 			cluster, err := clusterutils.Get(env.Ctx, env.Client, namespace, clusterName)
 			Expect(err).NotTo(HaveOccurred())
-			WalStorageClass := os.Getenv("E2E_DEFAULT_STORAGE_CLASS")
 			cluster.Spec.WalStorage = &apiv1.StorageConfiguration{
 				Size:         "1Gi",
-				StorageClass: &WalStorageClass,
+				StorageClass: ptr.To(env.DefaultStorageClass),
 			}
 			return env.Client.Update(env.Ctx, cluster)
 		})

--- a/tests/e2e/plugin_barman_cloud_major_upgrade_test.go
+++ b/tests/e2e/plugin_barman_cloud_major_upgrade_test.go
@@ -20,7 +20,6 @@ SPDX-License-Identifier: Apache-2.0
 package e2e
 
 import (
-	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -105,9 +104,6 @@ var _ = Describe("plugin-barman-cloud across a Postgres major upgrade",
 
 			setupPluginObjectStore(namespace, clusterName)
 
-			storageClass := os.Getenv("E2E_DEFAULT_STORAGE_CLASS")
-			Expect(storageClass).ToNot(BeEmpty())
-
 			By("creating a cluster on the starting major that archives through the plugin", func() {
 				cluster := &apiv1.Cluster{
 					ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: namespace},
@@ -125,11 +121,11 @@ var _ = Describe("plugin-barman-cloud across a Postgres major upgrade",
 							},
 						},
 						StorageConfiguration: apiv1.StorageConfiguration{
-							StorageClass: &storageClass,
+							StorageClass: ptr.To(env.DefaultStorageClass),
 							Size:         "1Gi",
 						},
 						WalStorage: &apiv1.StorageConfiguration{
-							StorageClass: &storageClass,
+							StorageClass: ptr.To(env.DefaultStorageClass),
 							Size:         "1Gi",
 						},
 						PostgresConfiguration: apiv1.PostgresConfiguration{

--- a/tests/e2e/pod_selector_refs_test.go
+++ b/tests/e2e/pod_selector_refs_test.go
@@ -21,11 +21,11 @@ package e2e
 
 import (
 	"fmt"
-	"os"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
+	"k8s.io/utils/ptr"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/tests"
@@ -62,9 +62,6 @@ var _ = Describe("Pod selector refs for pg_hba", Label(tests.LabelPostgresConfig
 			namespace, err = env.CreateUniqueTestNamespace(env.Ctx, env.Client, "pod-selector-refs-e2e")
 			Expect(err).ToNot(HaveOccurred())
 
-			storageClass := os.Getenv("E2E_DEFAULT_STORAGE_CLASS")
-			Expect(storageClass).ToNot(BeEmpty())
-
 			cluster := &apiv1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      clusterName,
@@ -73,7 +70,7 @@ var _ = Describe("Pod selector refs for pg_hba", Label(tests.LabelPostgresConfig
 				Spec: apiv1.ClusterSpec{
 					Instances: 1,
 					StorageConfiguration: apiv1.StorageConfiguration{
-						StorageClass: &storageClass,
+						StorageClass: ptr.To(env.DefaultStorageClass),
 						Size:         "1Gi",
 					},
 					PodSelectorRefs: []apiv1.PodSelectorRef{

--- a/tests/e2e/rolling_update_test.go
+++ b/tests/e2e/rolling_update_test.go
@@ -501,7 +501,7 @@ var _ = Describe("Rolling updates", Label(tests.LabelPostgresConfiguration), fun
 		var updatedImageName string
 		var pgVersion version.Data
 		BeforeEach(func() {
-			storageClass = os.Getenv("E2E_DEFAULT_STORAGE_CLASS")
+			storageClass = env.DefaultStorageClass
 			preRollingImg = os.Getenv("E2E_PRE_ROLLING_UPDATE_IMG")
 			updatedImageName = os.Getenv("POSTGRES_IMG")
 			if updatedImageName == "" {

--- a/tests/e2e/storage_expansion_test.go
+++ b/tests/e2e/storage_expansion_test.go
@@ -46,17 +46,16 @@ var _ = Describe("Verify storage", Label(tests.LabelStorage), func() {
 		level       = tests.Lowest
 	)
 	// Initializing a global namespace variable to be used in each test case
-	var namespace, namespacePrefix string
+	var namespace, namespacePrefix, defaultStorageClass string
 
 	BeforeEach(func() {
 		if testLevelEnv.Depth < int(level) {
 			Skip("Test depth is lower than the amount requested for this test")
 		}
+		// Gathering default storage class requires to check whether the value
+		// of 'allowVolumeExpansion' is true or false
+		defaultStorageClass = env.DefaultStorageClass
 	})
-
-	// Gathering default storage class requires to check whether the value
-	// of 'allowVolumeExpansion' is true or false
-	defaultStorageClass := env.DefaultStorageClass
 
 	Context("can be expanded", func() {
 		BeforeEach(func() {

--- a/tests/e2e/storage_expansion_test.go
+++ b/tests/e2e/storage_expansion_test.go
@@ -21,7 +21,6 @@ package e2e
 
 import (
 	"fmt"
-	"os"
 
 	corev1 "k8s.io/api/core/v1"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -57,7 +56,7 @@ var _ = Describe("Verify storage", Label(tests.LabelStorage), func() {
 
 	// Gathering default storage class requires to check whether the value
 	// of 'allowVolumeExpansion' is true or false
-	defaultStorageClass := os.Getenv("E2E_DEFAULT_STORAGE_CLASS")
+	defaultStorageClass := env.DefaultStorageClass
 
 	Context("can be expanded", func() {
 		BeforeEach(func() {

--- a/tests/e2e/tablespaces_test.go
+++ b/tests/e2e/tablespaces_test.go
@@ -34,6 +34,7 @@ import (
 	volumesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
@@ -77,8 +78,6 @@ var _ = Describe("Tablespaces tests", Label(tests.LabelTablespaces,
 		clusterName string
 		cluster     *apiv1.Cluster
 	)
-
-	storageClassName := os.Getenv("E2E_DEFAULT_STORAGE_CLASS")
 
 	BeforeEach(func() {
 		if testLevelEnv.Depth < int(level) {
@@ -249,7 +248,7 @@ var _ = Describe("Tablespaces tests", Label(tests.LabelTablespaces,
 						},
 						Storage: apiv1.StorageConfiguration{
 							Size:         "1Gi",
-							StorageClass: &storageClassName,
+							StorageClass: ptr.To(env.DefaultStorageClass),
 						},
 					},
 				})


### PR DESCRIPTION
Avoids reading E2E_DEFAULT_STORAGE_CLASS from the environment directly and reuses the value already exposed on the test environment.