### PR TITLE
fix(plugin): use UTC time zone for default backup name

### DIFF
--- a/internal/cmd/plugin/backup/cmd.go
+++ b/internal/cmd/plugin/backup/cmd.go
@@ -92,7 +92,7 @@ func NewCmd() *cobra.Command {
 				backupName = fmt.Sprintf(
 					"%s-%s",
 					clusterName,
-					pgTime.ToCompactISO8601(time.Now()),
+					pgTime.ToCompactISO8601(time.Now().UTC()),
 				)
 			}
 


### PR DESCRIPTION
The `cnpg backup` plugin generated the default `Backup` resource name using `time.Now()`, which returns the current time in the client's local time zone. Since the `backupId` is normalised to UTC internally, this caused the generated name to diverge from the server-side value whenever the client wasn't running in UTC.

Closes #11328

Assisted-by: Claude