### PR TITLE
tests(e2e): fix core-count detection on macOS

### DIFF
--- a/hack/e2e/run-e2e-suite.sh
+++ b/hack/e2e/run-e2e-suite.sh
@@ -90,7 +90,8 @@ else
     *)
       # Reserve ~25% of the available cores for the control plane and system
       # pods, and use the rest as ginkgo workers.
-      AVAILABLE_CORES=$(nproc)
+      # nproc is Linux-only; getconf _NPROCESSORS_ONLN works on both Linux and macOS.
+      AVAILABLE_CORES=$(getconf _NPROCESSORS_ONLN)
       RESERVED_CORES=$(( (AVAILABLE_CORES + 3) / 4 ))
       GINKGO_NODES=$(( AVAILABLE_CORES - RESERVED_CORES ))
       if [ "${GINKGO_NODES}" -lt 1 ]; then


### PR DESCRIPTION
The e2e suite script failed on macOS because it relied on nproc, which isn't available there. Use getconf _NPROCESSORS_ONLN instead, which works the same way on both Linux and macOS.