### PR TITLE
chore(instance-manager): make the pre-shutdown CHECKPOINT explicit

### DIFF
--- a/internal/management/controller/instance_controller.go
+++ b/internal/management/controller/instance_controller.go
@@ -628,8 +628,9 @@ func (r *InstanceReconciler) reconcileOldPrimary(
 
 	contextLogger.Info("This is the former primary instance. Shutting it down to allow it to be demoted to a replica.")
 
+	r.instance.TryCheckpointIfPrimary(ctx)
+
 	// Perform a fast shutdown on the instance and wait for the instance manager to stop.
-	// The fast shutdown process will be preceded by a CHECKPOINT.
 	// When the Pod restarts, it will be demoted to act as a replica of the new primary.
 	r.Instance().RequestFastImmediateShutdown()
 

--- a/pkg/management/postgres/instance.go
+++ b/pkg/management/postgres/instance.go
@@ -579,7 +579,6 @@ func (instance *Instance) ShutdownConnections() {
 }
 
 // Shutdown stops a PostgreSQL instance that was previously started with Startup.
-// Before shutting down, it attempts to execute a CHECKPOINT.
 // The function returns an error if PostgreSQL remains running after the shutdown request.
 func (instance *Instance) Shutdown(ctx context.Context, options shutdownOptions) error {
 	contextLogger := log.FromContext(ctx)
@@ -589,7 +588,6 @@ func (instance *Instance) Shutdown(ctx context.Context, options shutdownOptions)
 		return fmt.Errorf("instance is not running")
 	}
 
-	instance.tryCheckpointBeforeShutdown(ctx, options.Mode)
 	instance.ShutdownConnections()
 
 	pgCtlOptions := []string{
@@ -626,6 +624,34 @@ func (instance *Instance) Shutdown(ctx context.Context, options shutdownOptions)
 	return nil
 }
 
+// TryCheckpointIfPrimary issues a best-effort checkpoint if the instance is currently a
+// primary.
+func (instance *Instance) TryCheckpointIfPrimary(ctx context.Context) {
+	contextLogger := log.FromContext(ctx)
+
+	isPrimary, err := instance.IsPrimary()
+	if err != nil {
+		contextLogger.Warning("Failed to determine instance role, skipping opportunistic checkpoint", "err", err)
+		return
+	}
+	if !isPrimary {
+		return
+	}
+
+	db, err := instance.GetSuperUserDB()
+	if err != nil {
+		contextLogger.Warning("Failed to get superuser DB connection, skipping opportunistic checkpoint", "err", err)
+		return
+	}
+
+	contextLogger.Info("Requesting an opportunistic checkpoint")
+	if _, err := db.ExecContext(ctx, "CHECKPOINT"); err != nil {
+		contextLogger.Warning("Failed to execute opportunistic checkpoint", "err", err)
+		return
+	}
+	contextLogger.Info("Opportunistic checkpoint completed")
+}
+
 // TryShuttingDownSmartFast first attempts to shut down the instance using the "smart" mode,
 // which is preceded by a CHECKPOINT. If this fails or the specified timeout expires,
 // it issues an "fast" shutdown request and waits for completion.
@@ -644,6 +670,8 @@ func (instance *Instance) TryShuttingDownSmartFast(ctx context.Context) error {
 		)
 		smartTimeout = 0
 	}
+
+	instance.TryCheckpointIfPrimary(ctx)
 
 	if smartTimeout > 0 {
 		contextLogger.Info("Requesting smart shutdown of the PostgreSQL instance")
@@ -683,9 +711,9 @@ func (instance *Instance) TryShuttingDownSmartFast(ctx context.Context) error {
 	return nil
 }
 
-// TryShuttingDownFastImmediate first attempts to shut down the instance using the "fast" mode,
-// which is preceded by a CHECKPOINT. If this fails or the specified timeout expires,
-// it issues an "immediate" shutdown request and waits for completion.
+// TryShuttingDownFastImmediate first attempts to shut down the instance using the "fast" mode.
+// If this fails or the specified timeout expires, it issues an "immediate" shutdown request
+// and waits for completion.
 // Note: an immediate shutdown may lead to data loss.
 func (instance *Instance) TryShuttingDownFastImmediate(ctx context.Context) error {
 	contextLogger := log.FromContext(ctx)
@@ -1614,6 +1642,7 @@ func (instance *Instance) HandleInstanceCommandRequests(
 	case fenceOn:
 		contextLogger.Info("Fencing request received, will proceed shutting down the instance")
 		instance.SetFencing(true)
+		instance.TryCheckpointIfPrimary(ctx)
 		if err := instance.TryShuttingDownFastImmediate(ctx); err != nil {
 			return false, fmt.Errorf("while shutting down the instance to fence it: %w", err)
 		}
@@ -1628,44 +1657,4 @@ func (instance *Instance) HandleInstanceCommandRequests(
 	default:
 		return false, fmt.Errorf("unrecognized request: %s", req)
 	}
-}
-
-// tryCheckpointBeforeShutdown attempts to issue a checkpoint before shutdown.
-// This is skipped if the instance is not a primary or if an immediate shutdown is requested.
-// This reduces shutdown time and subsequent promotion time for replicas, especially for systems with high
-// checkpoint_timeout.
-// All outcomes (success, failure, or skipped) are logged appropriately.
-func (instance *Instance) tryCheckpointBeforeShutdown(ctx context.Context, mode shutdownMode) {
-	contextLogger := log.FromContext(ctx).WithName("checkpoint_before_shutdown")
-	contextLogger.Info("Attempting checkpoint before shutdown")
-
-	if mode == shutdownModeImmediate {
-		contextLogger.Info("Skipping checkpoint: immediate shutdown requested")
-		return
-	}
-
-	isPrimary, err := instance.IsPrimary()
-	if err != nil {
-		contextLogger.Error(err, "Failed to determine instance role, skipping checkpoint")
-		return
-	}
-
-	if !isPrimary {
-		contextLogger.Info("Skipping checkpoint: instance is not primary")
-		return
-	}
-
-	db, err := instance.GetSuperUserDB()
-	if err != nil {
-		contextLogger.Error(err, "Failed to get superuser DB connection, skipping checkpoint")
-		return
-	}
-
-	contextLogger.Info("Executing CHECKPOINT command before shutdown")
-	if _, err = db.ExecContext(ctx, "CHECKPOINT"); err != nil {
-		contextLogger.Error(err, "Failed to execute CHECKPOINT command")
-		return
-	}
-
-	contextLogger.Info("Checkpoint completed successfully")
 }


### PR DESCRIPTION
PostgreSQL's shutdown behavior is unchanged: fencing, switchover
demotion, and ordinary restarts still checkpoint beforehand exactly as
before. What changes is how that checkpoint is requested instead of
being silently baked into every non-immediate shutdown.

This makes room for a future fast-immediate shutdown path that skips
the checkpoint entirely, without touching the callers that still need
it.