### PR TITLE
docs(plugin): added note about verbose mode requirement

### DIFF
--- a/docs/src/tablespaces.md
+++ b/docs/src/tablespaces.md
@@ -366,6 +366,8 @@ Instances status
 [...]
 ```
 
+Please note that above output is available in verbose mode only (`kubectl cnpg status -v`).
+
 ## Limitations
 
 Currently, you can't remove tablespaces from an existing CloudNativePG


### PR DESCRIPTION
The `status` command provides detailed information about the tablespaces in the cluster, but it operates only in verbose mode.

Closes #10380