### PR TITLE
chore: replace deprecated ctrl.Result.Requeue with RequeueAfter

### DIFF
--- a/internal/cnpi/plugin/client/reconciler.go
+++ b/internal/cnpi/plugin/client/reconciler.go
@@ -54,7 +54,7 @@ func newReconcilerRequeueResult(identifier string, after int64) ReconcilerHookRe
 	return ReconcilerHookResult{
 		Err:                nil,
 		StopReconciliation: true,
-		Result:             ctrl.Result{Requeue: true, RequeueAfter: time.Second * time.Duration(after)},
+		Result:             ctrl.Result{RequeueAfter: time.Second * time.Duration(after)},
 		Identifier:         identifier,
 	}
 }

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -233,16 +233,15 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	if err != nil {
 		var errUnknownPlugin *repository.ErrUnknownPlugin
 		if errors.As(err, &errUnknownPlugin) {
-			return ctrl.Result{
-					RequeueAfter: 10 * time.Second,
-				}, r.RegisterPhase(
-					ctx,
-					cluster,
-					apiv1.PhaseUnknownPlugin,
-					fmt.Sprintf("Unknown plugin: '%s'. "+
-						"This may be caused by the plugin not being loaded correctly by the operator. "+
-						"Check the operator and plugin logs for errors", errUnknownPlugin.Name),
-				)
+			regErr := r.RegisterPhase(
+				ctx,
+				cluster,
+				apiv1.PhaseUnknownPlugin,
+				fmt.Sprintf("Unknown plugin: '%s'. "+
+					"This may be caused by the plugin not being loaded correctly by the operator. "+
+					"Check the operator and plugin logs for errors", errUnknownPlugin.Name),
+			)
+			return ctrl.Result{RequeueAfter: 10 * time.Second}, regErr
 		}
 
 		if regErr := r.RegisterPhase(
@@ -393,7 +392,7 @@ func (r *ClusterReconciler) reconcile(ctx context.Context, cluster *apiv1.Cluste
 			// Requeue a new reconciliation cycle, as in this point we need
 			// to quickly react the changes
 			contextLogger.Debug("Conflict error while reconciling resource status", "error", err)
-			return ctrl.Result{Requeue: true}, nil
+			return ctrl.Result{RequeueAfter: time.Second}, nil
 		}
 
 		return ctrl.Result{}, fmt.Errorf("cannot update the resource status: %w", err)
@@ -460,7 +459,7 @@ func (r *ClusterReconciler) reconcile(ctx context.Context, cluster *apiv1.Cluste
 		if apierrs.IsConflict(err) {
 			contextLogger.Debug("Conflict error while reconciling cluster status and instance state",
 				"error", err)
-			return ctrl.Result{Requeue: true}, nil
+			return ctrl.Result{RequeueAfter: time.Second}, nil
 		}
 		return ctrl.Result{}, fmt.Errorf("cannot update the instances status on the cluster: %w", err)
 	}
@@ -577,7 +576,7 @@ func (r *ClusterReconciler) reconcile(ctx context.Context, cluster *apiv1.Cluste
 			// Requeue a new reconciliation cycle, as in this point we need
 			// to quickly react the changes
 			contextLogger.Debug("Conflict error while reconciling online update", "error", err)
-			return ctrl.Result{Requeue: true}, nil
+			return ctrl.Result{RequeueAfter: time.Second}, nil
 		}
 
 		return ctrl.Result{}, fmt.Errorf("cannot update the resource status: %w", err)
@@ -763,7 +762,7 @@ func (r *ClusterReconciler) handleSwitchover(
 		contextLogger.Info("Cannot update target primary: operation cannot be fulfilled. "+
 			"An immediate retry will be scheduled",
 			"error", err)
-		return &ctrl.Result{Requeue: true}, nil
+		return &ctrl.Result{RequeueAfter: 1 * time.Second}, nil
 	}
 	if selectedPrimary != "" {
 		// If we selected a new primary, stop the reconciliation loop here

--- a/internal/controller/cluster_create.go
+++ b/internal/controller/cluster_create.go
@@ -1930,19 +1930,13 @@ func (r *ClusterReconciler) checkReadyForRecovery(
 		if backup == nil {
 			contextLogger.Info("Missing backup object, can't continue full recovery",
 				"backup", cluster.Spec.Bootstrap.Recovery.Backup)
-			return ctrl.Result{
-				Requeue:      true,
-				RequeueAfter: time.Minute,
-			}, nil
+			return ctrl.Result{RequeueAfter: time.Minute}, nil
 		}
 		if backup.Status.Phase != apiv1.BackupPhaseCompleted {
 			contextLogger.Info("The source backup object is not completed, can't continue full recovery",
 				"backup", cluster.Spec.Bootstrap.Recovery.Backup,
 				"backupPhase", backup.Status.Phase)
-			return ctrl.Result{
-				Requeue:      true,
-				RequeueAfter: time.Minute,
-			}, nil
+			return ctrl.Result{RequeueAfter: time.Minute}, nil
 		}
 	}
 
@@ -1957,10 +1951,7 @@ func (r *ClusterReconciler) checkReadyForRecovery(
 			contextLogger.Warning(
 				"Volume snapshots verification failed, retrying",
 				"status", status)
-			return ctrl.Result{
-				Requeue:      true,
-				RequeueAfter: 5 * time.Second,
-			}, nil
+			return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 		}
 		if status.ContainsWarnings() {
 			contextLogger.Warning("Volume snapshots verification warnings",

--- a/internal/controller/cluster_operator_cert.go
+++ b/internal/controller/cluster_operator_cert.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"crypto/x509"
 	"fmt"
+	"time"
 
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -61,7 +62,7 @@ func (r *ClusterReconciler) reconcileOperatorCertificateFingerprint(
 		return ctrl.Result{}, fmt.Errorf("patching operator certificate fingerprint: %w", err)
 	}
 
-	return ctrl.Result{Requeue: true}, nil
+	return ctrl.Result{RequeueAfter: time.Second}, nil
 }
 
 // operatorCertificateFingerprint returns the SHA-256 public key fingerprint of

--- a/internal/controller/pooler_controller.go
+++ b/internal/controller/pooler_controller.go
@@ -142,7 +142,7 @@ func (r *PoolerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 			// Requeue a reconciliation loop since the resource
 			// changed while we were synchronizing it
 			contextLogger.Debug("Conflict while reconciling pooler status", "error", err)
-			return ctrl.Result{Requeue: true}, nil
+			return ctrl.Result{RequeueAfter: time.Second}, nil
 		}
 		return ctrl.Result{}, fmt.Errorf("while updating pooler status: %w", err)
 	}

--- a/internal/webhook/v1/pooler_webhook_test.go
+++ b/internal/webhook/v1/pooler_webhook_test.go
@@ -168,8 +168,8 @@ var _ = Describe("Pooler validateMonitoring", func() {
 				PgBouncer: &apiv1.PgBouncerSpec{
 					ClientTLSSecret: clientTLSSecret,
 				},
-				Monitoring: &apiv1.PoolerMonitoringConfiguration{ //nolint:staticcheck
-					EnablePodMonitor: enablePodMonitor,
+				Monitoring: &apiv1.PoolerMonitoringConfiguration{
+					EnablePodMonitor: enablePodMonitor, //nolint:staticcheck
 					TLSConfig:        &apiv1.PoolerMonitoringTLSConfiguration{Enabled: true},
 				},
 			},
@@ -211,8 +211,8 @@ var _ = Describe("Pooler validateMonitoring", func() {
 	It("rejects when pgbouncer is nil", func() {
 		pooler := &apiv1.Pooler{
 			Spec: apiv1.PoolerSpec{
-				Monitoring: &apiv1.PoolerMonitoringConfiguration{ //nolint:staticcheck
-					EnablePodMonitor: true,
+				Monitoring: &apiv1.PoolerMonitoringConfiguration{
+					EnablePodMonitor: true, //nolint:staticcheck
 					TLSConfig:        &apiv1.PoolerMonitoringTLSConfiguration{Enabled: true},
 				},
 			},

--- a/pkg/management/postgres/webserver/metricserver/pg_collector_test.go
+++ b/pkg/management/postgres/webserver/metricserver/pg_collector_test.go
@@ -78,9 +78,9 @@ var _ = Describe("test metrics parsing", func() {
 				Name: "cluster-example",
 			},
 			Status: apiv1.ClusterStatus{
-				FirstRecoverabilityPoint: "2023-02-16T22:44:56Z",
-				LastSuccessfulBackup:     "2023-02-16T22:44:56Z",
-				LastFailedBackup:         "2023-02-16T22:44:56Z",
+				FirstRecoverabilityPoint: "2023-02-16T22:44:56Z", //nolint:staticcheck
+				LastSuccessfulBackup:     "2023-02-16T22:44:56Z", //nolint:staticcheck
+				LastFailedBackup:         "2023-02-16T22:44:56Z", //nolint:staticcheck
 			},
 		}
 

--- a/pkg/reconciler/majorupgrade/reconciler.go
+++ b/pkg/reconciler/majorupgrade/reconciler.go
@@ -373,7 +373,7 @@ func majorVersionUpgradeHandleCompletion(
 		return nil, err
 	}
 
-	return &ctrl.Result{Requeue: true}, nil
+	return &ctrl.Result{RequeueAfter: time.Second}, nil
 }
 
 // handleRollbackIfNeeded checks whether the user rolled back the image

--- a/pkg/reconciler/majorupgrade/reconciler_test.go
+++ b/pkg/reconciler/majorupgrade/reconciler_test.go
@@ -89,7 +89,7 @@ var _ = Describe("Major upgrade job status reconciliation", func() {
 		)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(result).ToNot(BeNil())
-		Expect(*result).To(Equal(ctrl.Result{Requeue: true}))
+		Expect(*result).To(Equal(ctrl.Result{RequeueAfter: time.Second}))
 
 		// the replica PVCs have been deleted
 		for i := range pvcs {

--- a/pkg/reconciler/persistentvolumeclaim/reconciler.go
+++ b/pkg/reconciler/persistentvolumeclaim/reconciler.go
@@ -21,6 +21,7 @@ package persistentvolumeclaim
 
 import (
 	"context"
+	"time"
 
 	"github.com/cloudnative-pg/machinery/pkg/log"
 	corev1 "k8s.io/api/core/v1"
@@ -48,7 +49,7 @@ func Reconcile(
 	if err := reconcileExistingPVCs(ctx, c, cluster, pvcs); err != nil {
 		if apierrs.IsConflict(err) {
 			contextLogger.Debug("Conflict error while reconciling PVCs", "error", err)
-			return ctrl.Result{Requeue: true}, nil
+			return ctrl.Result{RequeueAfter: time.Second}, nil
 		}
 
 		return ctrl.Result{}, err

--- a/pkg/specs/pgbouncer/deployments_test.go
+++ b/pkg/specs/pgbouncer/deployments_test.go
@@ -63,7 +63,7 @@ var _ = Describe("Deployment", func() {
 					Type: appsv1.RollingUpdateDeploymentStrategyType,
 				},
 				Monitoring: &apiv1.PoolerMonitoringConfiguration{
-					EnablePodMonitor: true,
+					EnablePodMonitor: true, //nolint:staticcheck
 				},
 			},
 			Status: apiv1.PoolerStatus{

--- a/pkg/specs/pgbouncer/podmonitor_test.go
+++ b/pkg/specs/pgbouncer/podmonitor_test.go
@@ -46,7 +46,7 @@ var _ = Describe("PoolerPodMonitorManager", func() {
 			},
 			Spec: apiv1.PoolerSpec{
 				Monitoring: &apiv1.PoolerMonitoringConfiguration{
-					EnablePodMonitor: false,
+					EnablePodMonitor: false, //nolint:staticcheck
 				},
 			},
 		}

--- a/pkg/specs/podmonitor_test.go
+++ b/pkg/specs/podmonitor_test.go
@@ -136,7 +136,7 @@ var _ = Describe("PodMonitor test", func() {
 			Spec: apiv1.ClusterSpec{
 				ImageName: "postgres:18.0",
 				Monitoring: &apiv1.MonitoringConfiguration{
-					EnablePodMonitor: true,
+					EnablePodMonitor: true, //nolint:staticcheck
 				},
 			},
 		}
@@ -154,7 +154,7 @@ var _ = Describe("PodMonitor test", func() {
 			Spec: apiv1.ClusterSpec{
 				ImageName: "postgres:18.0",
 				Monitoring: &apiv1.MonitoringConfiguration{
-					EnablePodMonitor: true,
+					EnablePodMonitor: true, //nolint:staticcheck
 					TLSConfig: &apiv1.ClusterMonitoringTLSConfiguration{
 						Enabled: true,
 					},

--- a/tests/e2e/cluster_major_upgrade_test.go
+++ b/tests/e2e/cluster_major_upgrade_test.go
@@ -254,7 +254,7 @@ var _ = Describe("Postgres Major Upgrade", Ordered, ContinueOnFailure, Label(tes
 
 		// If same version, choose a previous one for testing
 		if currentMajor == targetMajor {
-			currentMajor = targetMajor - (uint64(rand.Int() % 4)) - 1
+			currentMajor = targetMajor - uint64(rand.Int()%4) - 1
 			GinkgoWriter.Printf("Using %v as the current major version instead.\n", currentMajor)
 		}
 

--- a/tests/utils/clusterutils/cluster.go
+++ b/tests/utils/clusterutils/cluster.go
@@ -181,7 +181,7 @@ func GetPrimary(
 			}
 		}
 		err = fmt.Errorf("all pod with primary role has deletion timestamp")
-		return &(podList.Items[0]), err
+		return &podList.Items[0], err
 	}
 	err = fmt.Errorf("no primary found")
 	return &corev1.Pod{}, err


### PR DESCRIPTION
controller-runtime deprecated the Requeue field of ctrl.Result in favor of RequeueAfter, which golangci-lint's staticcheck (SA1019) now flags on every remaining use.

Replace every remaining Requeue: true with an equivalent RequeueAfter duration, matching the interval already used by neighboring call sites in the same function. Also restructure the unknown-plugin early return in ClusterReconciler.Reconcile, whose combined multi-line composite-literal-and-call return was toggling between two gofumpt-preferred indentations across successive lint runs.