### PR TITLE
fix(instance-manager): bound the primary lease take-over Get call

### DIFF
--- a/internal/cmd/manager/instance/run/lease/runnable.go
+++ b/internal/cmd/manager/instance/run/lease/runnable.go
@@ -90,7 +90,7 @@ func defaultConfig() Config {
 // It starts idle and enters the acquisition/renewal loop only after Acquire is called.
 type Runnable struct {
 	instance *postgres.Instance
-	lock     *resourcelock.LeaseLock
+	lock     resourcelock.Interface
 
 	// config holds the lease timings. It is initialised to the defaults by New
 	// and overwritten by the first Acquire call before the runnable activates.
@@ -201,7 +201,7 @@ func (r *Runnable) Release(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	if record.HolderIdentity != r.lock.LockConfig.Identity {
+	if record.HolderIdentity != r.lock.Identity() {
 		contextLogger.Debug("Primary lease held by another identity, nothing to release",
 			"holder", record.HolderIdentity)
 		return nil
@@ -293,7 +293,13 @@ func classifyLeaseAfterRun(
 // clock (the same limitation client-go's elector has); it only adds latency in
 // the rare case of a restart mid-take-over, never correctness.
 func (r *Runnable) tryTakeOver(ctx context.Context) (bool, error) {
-	record, _, err := r.lock.Get(ctx)
+	// Bounded so a Get against an unreachable API server fails fast and
+	// retries at RetryPeriod cadence, instead of blocking the whole
+	// take-over loop for however long the underlying transport takes to
+	// give up on its own.
+	getCtx, cancel := context.WithTimeout(ctx, r.config.RetryPeriod)
+	record, _, err := r.lock.Get(getCtx)
+	cancel()
 	if errors.IsNotFound(err) {
 		// The cluster controller owns lease creation; nothing to take over yet.
 		r.observedRecord = nil
@@ -303,7 +309,7 @@ func (r *Runnable) tryTakeOver(ctx context.Context) (bool, error) {
 		return false, err
 	}
 
-	identity := r.lock.LockConfig.Identity
+	identity := r.lock.Identity()
 
 	// Already ours: nothing to do here, le.Run will refresh the RenewTime.
 	if record.HolderIdentity == identity {
@@ -348,7 +354,7 @@ func sameHolder(a, b *resourcelock.LeaderElectionRecord) bool {
 func (r *Runnable) claim(ctx context.Context, current *resourcelock.LeaderElectionRecord) (bool, error) {
 	now := metav1.NewTime(time.Now())
 	if err := r.lock.Update(ctx, resourcelock.LeaderElectionRecord{
-		HolderIdentity:       r.lock.LockConfig.Identity,
+		HolderIdentity:       r.lock.Identity(),
 		LeaseDurationSeconds: int(r.config.LeaseDuration / time.Second),
 		RenewTime:            now,
 		AcquireTime:          now,
@@ -490,7 +496,7 @@ func (r *Runnable) runLeaderElection(ctx context.Context) error {
 		record, _, checkErr := r.lock.Get(checkCtx)
 		checkCancel()
 
-		switch classifyLeaseAfterRun(checkErr, record, r.lock.LockConfig.Identity) {
+		switch classifyLeaseAfterRun(checkErr, record, r.lock.Identity()) {
 		case leaseMissing:
 			// The lease object is gone (e.g. someone deleted it). The cluster
 			// controller will recreate it on its next reconcile; loop and let

--- a/internal/cmd/manager/instance/run/lease/runnable.go
+++ b/internal/cmd/manager/instance/run/lease/runnable.go
@@ -193,6 +193,12 @@ func (r *Runnable) Release(ctx context.Context) error {
 		return nil
 	}
 
+	// Unlike tryTakeOver/runLeaderElection, this Get is deliberately not
+	// bounded by RetryPeriod: Release makes no retry of its own, so any
+	// deadline here could return before the Update below ever runs. The
+	// caller in cmd.go avoids a timeout on the whole call for the same
+	// reason: giving up early would abandon the release and force replicas
+	// onto the slow TTL-expiry path instead of the fast empty-holder hand-over.
 	record, _, err := r.lock.Get(ctx)
 	if errors.IsNotFound(err) {
 		contextLogger.Debug("Primary lease does not exist, nothing to release")

--- a/internal/cmd/manager/instance/run/lease/runnable.go
+++ b/internal/cmd/manager/instance/run/lease/runnable.go
@@ -299,11 +299,14 @@ func classifyLeaseAfterRun(
 // clock (the same limitation client-go's elector has); it only adds latency in
 // the rare case of a restart mid-take-over, never correctness.
 func (r *Runnable) tryTakeOver(ctx context.Context) (bool, error) {
-	// Bounded so a Get against an unreachable API server fails fast and
-	// retries at RetryPeriod cadence, instead of blocking the whole
-	// take-over loop for however long the underlying transport takes to
-	// give up on its own.
-	getCtx, cancel := context.WithTimeout(ctx, r.config.RetryPeriod)
+	// Bounded so a Get against an unreachable API server fails instead of
+	// blocking the whole take-over loop for however long the underlying
+	// transport takes to give up on its own. The budget is RenewDeadline, not
+	// the RetryPeriod cadence at which the caller polls: an API server that
+	// answers, but more slowly than that cadence, has to be able to answer,
+	// otherwise every attempt times out here, the observation window never
+	// starts and the take-over never happens.
+	getCtx, cancel := context.WithTimeout(ctx, r.config.RenewDeadline)
 	record, _, err := r.lock.Get(getCtx)
 	cancel()
 	if errors.IsNotFound(err) {

--- a/internal/cmd/manager/instance/run/lease/runnable.go
+++ b/internal/cmd/manager/instance/run/lease/runnable.go
@@ -194,11 +194,11 @@ func (r *Runnable) Release(ctx context.Context) error {
 	}
 
 	// Unlike tryTakeOver/runLeaderElection, this Get is deliberately not
-	// bounded by RetryPeriod: Release makes no retry of its own, so any
-	// deadline here could return before the Update below ever runs. The
-	// caller in cmd.go avoids a timeout on the whole call for the same
-	// reason: giving up early would abandon the release and force replicas
-	// onto the slow TTL-expiry path instead of the fast empty-holder hand-over.
+	// bounded at all: Release makes no retry of its own, so any deadline here
+	// could return before the Update below ever runs. The caller in cmd.go
+	// avoids a timeout on the whole call for the same reason: giving up early
+	// would abandon the release and force replicas onto the slow TTL-expiry
+	// path instead of the fast empty-holder hand-over.
 	record, _, err := r.lock.Get(ctx)
 	if errors.IsNotFound(err) {
 		contextLogger.Debug("Primary lease does not exist, nothing to release")

--- a/internal/cmd/manager/instance/run/lease/runnable_test.go
+++ b/internal/cmd/manager/instance/run/lease/runnable_test.go
@@ -449,7 +449,47 @@ var _ = Describe("Runnable.tryTakeOver", func() {
 			Expect(apierrors.IsConflict(err)).To(BeTrue())
 			Expect(acquired).To(BeFalse())
 		})
+
+	It("bounds the Get call so it cannot block past RetryPeriod when the API server is unreachable",
+		func(ctx context.Context) {
+			r := newRunnable(fake.NewClientset())
+			r.config.RetryPeriod = 20 * time.Millisecond
+			r.lock = &blockingLock{}
+
+			start := time.Now()
+			acquired, err := r.tryTakeOver(ctx)
+
+			// The lock never actually replies: the only way this call returns
+			// is the per-call timeout added around it, well before
+			// blockingLock's own 2s safety net would fire.
+			Expect(time.Since(start)).To(BeNumerically("<", time.Second))
+			Expect(acquired).To(BeFalse())
+			Expect(err).To(MatchError(context.DeadlineExceeded))
+		})
 })
+
+// blockingLock is a resourcelock.Interface whose Get never replies on its
+// own, simulating an API server that accepts the connection but never
+// answers. It exists to prove tryTakeOver bounds the call itself rather
+// than depending on the caller's context already having a deadline.
+type blockingLock struct{}
+
+func (*blockingLock) Get(ctx context.Context) (*resourcelock.LeaderElectionRecord, []byte, error) {
+	select {
+	case <-ctx.Done():
+		return nil, nil, ctx.Err()
+	case <-time.After(2 * time.Second):
+		// Safety net: fails the test with a clear message instead of
+		// hanging forever if the per-call bound regresses.
+		return nil, nil, errors.New("blockingLock.Get: not bounded by a per-call timeout")
+	}
+}
+
+func (*blockingLock) Create(context.Context, resourcelock.LeaderElectionRecord) error { return nil }
+func (*blockingLock) Update(context.Context, resourcelock.LeaderElectionRecord) error { return nil }
+func (*blockingLock) RecordEvent(string)                                              {}
+func (*blockingLock) Identity() string                                                { return "" }
+func (*blockingLock) Describe() string                                                { return "blockingLock" }
 
 var _ = Describe("classifyLeaseAfterRun", func() {
 	const ourIdentity = "test-cluster-1"

--- a/internal/cmd/manager/instance/run/lease/runnable_test.go
+++ b/internal/cmd/manager/instance/run/lease/runnable_test.go
@@ -450,10 +450,10 @@ var _ = Describe("Runnable.tryTakeOver", func() {
 			Expect(acquired).To(BeFalse())
 		})
 
-	It("bounds the Get call so it cannot block past RetryPeriod when the API server is unreachable",
+	It("bounds the Get call so it cannot block past RenewDeadline when the API server is unreachable",
 		func(ctx context.Context) {
 			r := newRunnable(fake.NewClientset())
-			r.config.RetryPeriod = 20 * time.Millisecond
+			r.config.RenewDeadline = 50 * time.Millisecond
 			r.lock = &blockingLock{}
 
 			start := time.Now()
@@ -466,7 +466,49 @@ var _ = Describe("Runnable.tryTakeOver", func() {
 			Expect(acquired).To(BeFalse())
 			Expect(err).To(MatchError(context.DeadlineExceeded))
 		})
+
+	It("takes the lease over when the API server answers more slowly than the poll interval",
+		func(ctx context.Context) {
+			r := newRunnable(fake.NewClientset())
+			r.config.RetryPeriod = 20 * time.Millisecond
+			r.config.RenewDeadline = 600 * time.Millisecond
+			r.lock = &slowLock{getDelay: 400 * time.Millisecond}
+
+			acquired, err := r.tryTakeOver(ctx)
+
+			// The read answers above the poll interval and below the renew
+			// deadline, so it has to get through: a bound sized on RetryPeriod
+			// fails it on every poll and the take-over never happens.
+			Expect(err).NotTo(HaveOccurred())
+			Expect(acquired).To(BeTrue())
+		})
 })
+
+// slowLock is a resourcelock.Interface that answers, but only after getDelay,
+// simulating an API server under load rather than an unreachable one. The
+// record it returns has an empty holder, the cleanly-released state that
+// tryTakeOver claims straight away.
+type slowLock struct {
+	getDelay time.Duration
+}
+
+func (l *slowLock) Get(ctx context.Context) (*resourcelock.LeaderElectionRecord, []byte, error) {
+	select {
+	case <-ctx.Done():
+		return nil, nil, ctx.Err()
+	case <-time.After(l.getDelay):
+		return &resourcelock.LeaderElectionRecord{HolderIdentity: ""}, nil, nil
+	}
+}
+
+func (*slowLock) Create(context.Context, resourcelock.LeaderElectionRecord) error { return nil }
+func (*slowLock) Update(context.Context, resourcelock.LeaderElectionRecord) error { return nil }
+func (*slowLock) RecordEvent(string)                                              {}
+
+// Identity is never empty: an empty identity would make the record read above
+// look like one we already hold, short-circuiting the claim under test.
+func (*slowLock) Identity() string { return "slow-lock" }
+func (*slowLock) Describe() string { return "slowLock" }
 
 // blockingLock is a resourcelock.Interface whose Get never replies on its
 // own, simulating an API server that accepts the connection but never

--- a/internal/cmd/manager/instance/run/lease/runnable_test.go
+++ b/internal/cmd/manager/instance/run/lease/runnable_test.go
@@ -467,18 +467,21 @@ var _ = Describe("Runnable.tryTakeOver", func() {
 			Expect(err).To(MatchError(context.DeadlineExceeded))
 		})
 
-	It("takes the lease over when the API server answers more slowly than the poll interval",
+	It("takes the lease over when the API server answers well within RenewDeadline",
 		func(ctx context.Context) {
 			r := newRunnable(fake.NewClientset())
+			// tryTakeOver ignores RetryPeriod. We set it small anyway, so
+			// this test still works if the default value changes later.
 			r.config.RetryPeriod = 20 * time.Millisecond
 			r.config.RenewDeadline = 600 * time.Millisecond
 			r.lock = &slowLock{getDelay: 400 * time.Millisecond}
 
 			acquired, err := r.tryTakeOver(ctx)
 
-			// The read answers above the poll interval and below the renew
-			// deadline, so it has to get through: a bound sized on RetryPeriod
-			// fails it on every poll and the take-over never happens.
+			// getDelay is bigger than RetryPeriod, smaller than
+			// RenewDeadline. So this test only passes if the code waits
+			// for RenewDeadline, not the shorter, wrong bound from an
+			// earlier version of this fix.
 			Expect(err).NotTo(HaveOccurred())
 			Expect(acquired).To(BeTrue())
 		})

--- a/internal/management/controller/instance_controller.go
+++ b/internal/management/controller/instance_controller.go
@@ -1208,10 +1208,12 @@ func (r *InstanceReconciler) reconcilePrimary(ctx context.Context, cluster *apiv
 	// previous holder did not release cleanly, in a single Acquire call. The
 	// runnable's preAcquire loop polls jitter-free every RetryPeriod and takes
 	// over a still-held lease once it has observed the record unchanged for a
-	// full LeaseDuration, so the take-over moment lands at most one RetryPeriod
-	// past LeaseDuration (the poll granularity). Sizing acquireTimeout to
-	// LeaseDuration + 3*RetryPeriod keeps that take-over inside a single
-	// Acquire call with margin for the take-over write and scheduling overhead.
+	// full LeaseDuration. Sizing acquireTimeout to LeaseDuration +
+	// 3*RetryPeriod keeps that take-over inside a single Acquire call, with
+	// margin for the poll granularity, the take-over write and scheduling
+	// overhead, as long as the API server answers promptly. It can be exceeded
+	// when the API server is slow, since a single poll is then budgeted up to
+	// RenewDeadline; the requeue below covers that case.
 	leaseDuration := cluster.GetPrimaryLeaseDuration()
 	retryPeriod := cluster.GetPrimaryLeaseRetryPeriod()
 	acquireTimeout := leaseDuration + 3*retryPeriod


### PR DESCRIPTION
`tryTakeOver` reads the lease with the caller's un-deadlined context, so a `Get` against an unreachable API server could block indefinitely instead of retrying at `RetryPeriod cadence. A stalled `Get` here also keeps a primary's own lease renewal from resuming after a transient blip, risking a legitimate takeover by another node once the lease expires.

Wrap the call in a context bounded by `RenewDeadline`: tight enough to fail fast against an unreachable server, wide enough that a single still-answering-but-slow poll doesn't get discarded before the observation window can complete.

Closes #11349