### PR TITLE
fix(pgbouncer): bind `SHOW STATS` columns by name

### DIFF
--- a/docs/src/connection_pooling.md
+++ b/docs/src/connection_pooling.md
@@ -782,6 +782,9 @@ cnpg_pgbouncer_stats_avg_recv{database="pgbouncer"} 0
 # HELP cnpg_pgbouncer_stats_avg_sent Average sent (to clients) bytes per second.
 # TYPE cnpg_pgbouncer_stats_avg_sent gauge
 cnpg_pgbouncer_stats_avg_sent{database="pgbouncer"} 0
+# HELP cnpg_pgbouncer_stats_avg_server_assignment_count Average number of times a server was assigned to a client per second in the last stat period.
+# TYPE cnpg_pgbouncer_stats_avg_server_assignment_count gauge
+cnpg_pgbouncer_stats_avg_server_assignment_count{database="pgbouncer"} 0
 # HELP cnpg_pgbouncer_stats_avg_server_parse_count Average number of prepared statements created by pgbouncer on a server.
 # TYPE cnpg_pgbouncer_stats_avg_server_parse_count gauge
 cnpg_pgbouncer_stats_avg_server_parse_count{database="pgbouncer"} 0
@@ -812,6 +815,9 @@ cnpg_pgbouncer_stats_total_received{database="pgbouncer"} 0
 # HELP cnpg_pgbouncer_stats_total_sent Total volume in bytes of network traffic sent by pgbouncer.
 # TYPE cnpg_pgbouncer_stats_total_sent gauge
 cnpg_pgbouncer_stats_total_sent{database="pgbouncer"} 0
+# HELP cnpg_pgbouncer_stats_total_server_assignment_count Total number of times a server was assigned to a client.
+# TYPE cnpg_pgbouncer_stats_total_server_assignment_count gauge
+cnpg_pgbouncer_stats_total_server_assignment_count{database="pgbouncer"} 0
 # HELP cnpg_pgbouncer_stats_total_server_parse_count Total number of prepared statements created by pgbouncer on a server.
 # TYPE cnpg_pgbouncer_stats_total_server_parse_count gauge
 cnpg_pgbouncer_stats_total_server_parse_count{database="pgbouncer"} 0

--- a/pkg/management/pgbouncer/metricsserver/stats.go
+++ b/pkg/management/pgbouncer/metricsserver/stats.go
@@ -92,9 +92,9 @@ func (r *ShowStatsMetrics) Reset() {
 	r.TotalQueryTime.Reset()
 	r.TotalWaitTime.Reset()
 	r.AvgBindCount.Reset()
-	r.TotalClientParseCount.Reset()
+	r.AvgClientParseCount.Reset()
 	r.AvgServerAssignCount.Reset()
-	r.TotalServerParseCount.Reset()
+	r.AvgServerParseCount.Reset()
 	r.AvgXactCount.Reset()
 	r.AvgQueryCount.Reset()
 	r.AvgRecv.Reset()
@@ -248,6 +248,40 @@ func NewShowStatsMetrics(subsystem string) *ShowStatsMetrics {
 	}
 }
 
+func (r *ShowStatsMetrics) byColumn() map[string]*prometheus.GaugeVec {
+	return map[string]*prometheus.GaugeVec{
+		"total_bind_count":              r.TotalBindCount,
+		"total_client_parse_count":      r.TotalClientParseCount,
+		"total_server_assignment_count": r.TotalServerAssignCount,
+		"total_server_parse_count":      r.TotalServerParseCount,
+		"total_xact_count":              r.TotalXactCount,
+		"total_query_count":             r.TotalQueryCount,
+		"total_received":                r.TotalReceived,
+		"total_sent":                    r.TotalSent,
+		"total_xact_time":               r.TotalXactTime,
+		"total_query_time":              r.TotalQueryTime,
+		"total_wait_time":               r.TotalWaitTime,
+		"avg_bind_count":                r.AvgBindCount,
+		"avg_client_parse_count":        r.AvgClientParseCount,
+		"avg_server_assignment_count":   r.AvgServerAssignCount,
+		"avg_server_parse_count":        r.AvgServerParseCount,
+		"avg_xact_count":                r.AvgXactCount,
+		"avg_query_count":               r.AvgQueryCount,
+		"avg_recv":                      r.AvgRecv,
+		"avg_sent":                      r.AvgSent,
+		"avg_xact_time":                 r.AvgXactTime,
+		"avg_query_time":                r.AvgQueryTime,
+		"avg_wait_time":                 r.AvgWaitTime,
+	}
+}
+
+// Collect produces the values for all the contained Metrics
+func (r *ShowStatsMetrics) Collect(ch chan<- prometheus.Metric) {
+	for _, gauge := range r.byColumn() {
+		gauge.Collect(ch)
+	}
+}
+
 func (e *Exporter) collectShowStats(ch chan<- prometheus.Metric, db *sql.DB) {
 	contextLogger := log.FromContext(e.ctx)
 
@@ -269,180 +303,45 @@ func (e *Exporter) collectShowStats(ch chan<- prometheus.Metric, db *sql.DB) {
 			contextLogger.Error(err, "while closing rows for SHOW STATS")
 		}
 	}()
-	var (
-		database string
-		totalXactCount,
-		totalQueryCount,
-		totalReceived,
-		totalSent,
-		totalXactTime,
-		totalQueryTime,
-		totalWaitTime,
-		avgXactCount,
-		avgQueryCount,
-		avgRecv,
-		avgSent,
-		avgXactTime,
-		avgQueryTime,
-		avgWaitTime int
-	)
 
-	// PGBouncer >= 1.23.0
-	var (
-		totalServerAssignCount,
-		avgServerAssignCount int
-	)
-
-	// PGBouncer >= 1.24.0
-	var (
-		totalClientParseCount,
-		totalServerParseCount,
-		totalBindCount,
-		avgClientParseCount,
-		avgServerParseCount,
-		avgBindCount int
-	)
-	statCols, err := rows.Columns()
+	columns, err := rows.Columns()
 	if err != nil {
 		contextLogger.Error(err, "Error while reading SHOW STATS")
+		e.Metrics.Error.Set(1)
+		e.Metrics.PgCollectionErrors.WithLabelValues(err.Error()).Inc()
 		return
 	}
 
-	statColsCount := len(statCols)
+	gauges := e.Metrics.ShowStats.byColumn()
+	var database string
+	values := make([]int, len(columns))
+	targets := make([]any, len(columns))
+	for i, column := range columns {
+		switch {
+		case column == databaseLabel:
+			targets[i] = &database
+		case gauges[column] != nil:
+			targets[i] = &values[i]
+		default:
+			targets[i] = new(any)
+		}
+	}
 
 	for rows.Next() {
-		var err error
-		switch {
-		case statColsCount < 16:
-			err = rows.Scan(&database,
-				&totalXactCount,
-				&totalQueryCount,
-				&totalReceived,
-				&totalSent,
-				&totalXactTime,
-				&totalQueryTime,
-				&totalWaitTime,
-				&avgXactCount,
-				&avgQueryCount,
-				&avgRecv,
-				&avgSent,
-				&avgXactTime,
-				&avgQueryTime,
-				&avgWaitTime,
-			)
-		case statColsCount == 17:
-			err = rows.Scan(&database,
-				&totalServerAssignCount,
-				&totalXactCount,
-				&totalQueryCount,
-				&totalReceived,
-				&totalSent,
-				&totalXactTime,
-				&totalQueryTime,
-				&totalWaitTime,
-				&avgServerAssignCount,
-				&avgXactCount,
-				&avgQueryCount,
-				&avgRecv,
-				&avgSent,
-				&avgXactTime,
-				&avgQueryTime,
-				&avgWaitTime,
-			)
-		default:
-			err = rows.Scan(&database,
-				&totalServerAssignCount,
-				&totalXactCount,
-				&totalQueryCount,
-				&totalReceived,
-				&totalSent,
-				&totalXactTime,
-				&totalQueryTime,
-				&totalWaitTime,
-				&totalClientParseCount,
-				&totalServerParseCount,
-				&totalBindCount,
-				&avgServerAssignCount,
-				&avgXactCount,
-				&avgQueryCount,
-				&avgRecv,
-				&avgSent,
-				&avgXactTime,
-				&avgQueryTime,
-				&avgWaitTime,
-				&avgClientParseCount,
-				&avgServerParseCount,
-				&avgBindCount,
-			)
-		}
-		if err != nil {
+		if err := rows.Scan(targets...); err != nil {
 			contextLogger.Error(err, "Error while executing SHOW STATS")
 			e.Metrics.Error.Set(1)
 			e.Metrics.PgCollectionErrors.WithLabelValues(err.Error()).Inc()
+			continue
 		}
-
-		e.Metrics.ShowStats.TotalXactCount.WithLabelValues(database).Set(float64(totalXactCount))
-		e.Metrics.ShowStats.TotalQueryCount.WithLabelValues(database).Set(float64(totalQueryCount))
-		e.Metrics.ShowStats.TotalReceived.WithLabelValues(database).Set(float64(totalReceived))
-		e.Metrics.ShowStats.TotalSent.WithLabelValues(database).Set(float64(totalSent))
-		e.Metrics.ShowStats.TotalXactTime.WithLabelValues(database).Set(float64(totalXactTime))
-		e.Metrics.ShowStats.TotalQueryTime.WithLabelValues(database).Set(float64(totalQueryTime))
-		e.Metrics.ShowStats.TotalWaitTime.WithLabelValues(database).Set(float64(totalWaitTime))
-		e.Metrics.ShowStats.AvgXactCount.WithLabelValues(database).Set(float64(avgXactCount))
-		e.Metrics.ShowStats.AvgQueryCount.WithLabelValues(database).Set(float64(avgQueryCount))
-		e.Metrics.ShowStats.AvgRecv.WithLabelValues(database).Set(float64(avgRecv))
-		e.Metrics.ShowStats.AvgSent.WithLabelValues(database).Set(float64(avgSent))
-		e.Metrics.ShowStats.AvgXactTime.WithLabelValues(database).Set(float64(avgXactTime))
-		e.Metrics.ShowStats.AvgQueryTime.WithLabelValues(database).Set(float64(avgQueryTime))
-		e.Metrics.ShowStats.AvgWaitTime.WithLabelValues(database).Set(float64(avgWaitTime))
-
-		if statColsCount == 16 {
-			e.Metrics.ShowStats.TotalServerAssignCount.WithLabelValues(database).Set(
-				float64(totalServerAssignCount))
-			e.Metrics.ShowStats.AvgServerAssignCount.WithLabelValues(database).Set(
-				float64(avgServerAssignCount))
-		} else {
-			e.Metrics.ShowStats.TotalClientParseCount.WithLabelValues(database).Set(
-				float64(totalClientParseCount))
-			e.Metrics.ShowStats.TotalServerParseCount.WithLabelValues(database).Set(
-				float64(totalServerParseCount))
-			e.Metrics.ShowStats.TotalBindCount.WithLabelValues(database).Set(
-				float64(totalBindCount))
-			e.Metrics.ShowStats.AvgClientParseCount.WithLabelValues(database).Set(
-				float64(avgClientParseCount))
-			e.Metrics.ShowStats.AvgServerParseCount.WithLabelValues(database).Set(
-				float64(avgServerParseCount))
-			e.Metrics.ShowStats.AvgBindCount.WithLabelValues(database).Set(
-				float64(avgBindCount))
+		for i, column := range columns {
+			if gauge := gauges[column]; gauge != nil {
+				gauge.WithLabelValues(database).Set(float64(values[i]))
+			}
 		}
 	}
 
-	e.Metrics.ShowStats.TotalXactCount.Collect(ch)
-	e.Metrics.ShowStats.TotalQueryCount.Collect(ch)
-	e.Metrics.ShowStats.TotalReceived.Collect(ch)
-	e.Metrics.ShowStats.TotalSent.Collect(ch)
-	e.Metrics.ShowStats.TotalXactTime.Collect(ch)
-	e.Metrics.ShowStats.TotalQueryTime.Collect(ch)
-	e.Metrics.ShowStats.TotalWaitTime.Collect(ch)
-	e.Metrics.ShowStats.AvgXactCount.Collect(ch)
-	e.Metrics.ShowStats.AvgQueryCount.Collect(ch)
-	e.Metrics.ShowStats.AvgRecv.Collect(ch)
-	e.Metrics.ShowStats.AvgSent.Collect(ch)
-	e.Metrics.ShowStats.AvgXactTime.Collect(ch)
-	e.Metrics.ShowStats.AvgQueryTime.Collect(ch)
-	e.Metrics.ShowStats.AvgWaitTime.Collect(ch)
-
-	if statColsCount == 16 {
-		e.Metrics.ShowStats.TotalServerAssignCount.Collect(ch)
-		e.Metrics.ShowStats.AvgServerAssignCount.Collect(ch)
-	} else {
-		e.Metrics.ShowStats.TotalClientParseCount.Collect(ch)
-		e.Metrics.ShowStats.TotalServerParseCount.Collect(ch)
-		e.Metrics.ShowStats.TotalBindCount.Collect(ch)
-		e.Metrics.ShowStats.AvgClientParseCount.Collect(ch)
-		e.Metrics.ShowStats.AvgServerParseCount.Collect(ch)
-		e.Metrics.ShowStats.AvgBindCount.Collect(ch)
-	}
+	e.Metrics.ShowStats.Collect(ch)
 
 	if err = rows.Err(); err != nil {
 		e.Metrics.Error.Set(1)

--- a/pkg/management/pgbouncer/metricsserver/stats.go
+++ b/pkg/management/pgbouncer/metricsserver/stats.go
@@ -125,7 +125,7 @@ func NewShowStatsMetrics(subsystem string) *ShowStatsMetrics {
 			Namespace: PrometheusNamespace,
 			Subsystem: subsystem,
 			Name:      "total_server_assignment_count",
-			Help:      "Total time a server was assigned to a client.",
+			Help:      "Total number of times a server was assigned to a client.",
 		}, []string{databaseLabel}),
 		TotalServerParseCount: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: PrometheusNamespace,

--- a/pkg/management/pgbouncer/metricsserver/stats_test.go
+++ b/pkg/management/pgbouncer/metricsserver/stats_test.go
@@ -99,6 +99,30 @@ var _ = Describe("MetricsServer", func() {
 			Expect(lastCollectionErrorMetric.GetMetric()[0].GetGauge().GetValue()).To(BeEquivalentTo(1))
 		})
 
+		It("should keep binding by name when PgBouncer reports unknown columns", func() {
+			mock.ExpectQuery(showStatsQuery).WillReturnRows(
+				sqlmock.NewRows([]string{
+					"database",
+					"total_xact_count",
+					"total_future_count",
+					"total_query_count",
+				}).AddRow("db1", 1, 99, 2))
+
+			exp.collectShowStats(ch, db)
+
+			metrics, err := registry.Gather()
+			Expect(err).ToNot(HaveOccurred())
+
+			lastCollectionErrorMetric := getMetric(metrics, "cnpg_pgbouncer_last_collection_error")
+			Expect(lastCollectionErrorMetric.GetMetric()[0].GetGauge().GetValue()).To(BeEquivalentTo(0))
+
+			totalXactCountMetric := getMetric(metrics, "cnpg_pgbouncer_stats_total_xact_count")
+			Expect(totalXactCountMetric.GetMetric()[0].GetGauge().GetValue()).To(BeEquivalentTo(1))
+
+			totalQueryCountMetric := getMetric(metrics, "cnpg_pgbouncer_stats_total_query_count")
+			Expect(totalQueryCountMetric.GetMetric()[0].GetGauge().GetValue()).To(BeEquivalentTo(2))
+		})
+
 		It("should handle error during rows scanning", func() {
 			mock.ExpectQuery(showStatsQuery).
 				WillReturnRows(sqlmock.NewRows([]string{"total_xact_count"}).

--- a/pkg/management/pgbouncer/metricsserver/stats_test.go
+++ b/pkg/management/pgbouncer/metricsserver/stats_test.go
@@ -21,6 +21,7 @@ package metricsserver
 
 import (
 	"database/sql"
+	"database/sql/driver"
 	"errors"
 
 	"github.com/DATA-DOG/go-sqlmock"
@@ -121,6 +122,50 @@ var _ = Describe("MetricsServer", func() {
 
 			totalQueryCountMetric := getMetric(metrics, "cnpg_pgbouncer_stats_total_query_count")
 			Expect(totalQueryCountMetric.GetMetric()[0].GetGauge().GetValue()).To(BeEquivalentTo(2))
+		})
+
+		It("should bind every released SHOW STATS column to its own gauge", func() {
+			// Column list of PgBouncer 1.25.2, src/stats.c admin_database_stats().
+			columns := []string{
+				"database",
+				"total_server_assignment_count",
+				"total_xact_count", "total_query_count",
+				"total_received", "total_sent",
+				"total_xact_time", "total_query_time",
+				"total_wait_time", "total_client_parse_count",
+				"total_server_parse_count", "total_bind_count",
+				"avg_server_assignment_count",
+				"avg_xact_count", "avg_query_count",
+				"avg_recv", "avg_sent",
+				"avg_xact_time", "avg_query_time",
+				"avg_wait_time", "avg_client_parse_count",
+				"avg_server_parse_count", "avg_bind_count",
+			}
+
+			// A distinct value per column, so a gauge bound to the wrong column is caught.
+			row := make([]driver.Value, len(columns))
+			row[0] = "db1"
+			for i := 1; i < len(columns); i++ {
+				row[i] = i
+			}
+			mock.ExpectQuery(showStatsQuery).WillReturnRows(sqlmock.NewRows(columns).AddRow(row...))
+
+			statsRegistry := prometheus.NewPedanticRegistry()
+			statsRegistry.MustRegister(exp.Metrics.ShowStats)
+
+			exp.collectShowStats(ch, db)
+
+			families, err := statsRegistry.Gather()
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(exp.Metrics.ShowStats.byColumn()).To(HaveLen(len(columns) - 1))
+			for i, column := range columns[1:] {
+				family := getMetric(families, "cnpg_pgbouncer_stats_"+column)
+				Expect(family).ToNot(BeNil(), "no metric exported for column %s", column)
+				Expect(family.GetMetric()).To(HaveLen(1))
+				Expect(family.GetMetric()[0].GetGauge().GetValue()).
+					To(BeEquivalentTo(i+1), "wrong gauge bound to column %s", column)
+			}
 		})
 
 		It("should handle error during rows scanning", func() {


### PR DESCRIPTION
The collector picked its scan layout from the number of columns returned by `SHOW STATS`, and the gate that wrote the server assignment gauges (`statColsCount == 16`) matched none of the scan branches. On the 17-column path, those two values were scanned and discarded, while the parse-count gauges (never scanned there) were exported as zeros.

Bind each scan destination to its column name instead, ignoring columns the collector does not know, so a new PgBouncer column can no longer shift the values of the others. `total_server_assignment_count` and `avg_server_assignment_count` start being exported as a result, so add them to the sample output in the documentation, and correct the help text of the total, which described a duration rather than a count.

Also reset the two avg parse-count gauges, which were shadowed by their total counterparts and kept stale values across scrapes.

Closes #11365