### PR TITLE
chore: remove `status-port-tls` flag and HTTP fallback

### DIFF
--- a/docs/src/installation_upgrade.md
+++ b/docs/src/installation_upgrade.md
@@ -408,11 +408,13 @@ for details.
 :::warning
 This protection has a hard requirement: the status port **must** be served over
 TLS, which has been the default since v1.24. Instances created by an operator
-older than v1.24 serve the status port over plain HTTP; once their instance
-manager is upgraded to 1.30.0 the operator can no longer authenticate to them
-and every call to the protected endpoints is **permanently** rejected with
-`401 Unauthorized`. If you still run such instances, perform a rolling update so
-their Pods are recreated with a TLS-enabled status port. Instances created by
+older than v1.24 serve it over plain HTTP, and 1.30.0 no longer falls back to
+HTTP: the operator cannot read their status, so it reports
+`Instance Status Extraction Error`. While the cluster has ready instances and
+none of them is reachable, it is not reconciled at all: no rolling update is
+started to fix it, and Pods you delete are not recreated. If you still run such
+instances, perform a rolling update so their Pods are recreated with a
+TLS-enabled status port **before** upgrading to 1.30.0. Instances created by
 v1.24 or later are unaffected.
 :::
 

--- a/docs/src/installation_upgrade.md
+++ b/docs/src/installation_upgrade.md
@@ -399,24 +399,13 @@ sensitive endpoints of the instance manager's status port (backup,
 `pg_controldata`, partial WAL archive, and instance-manager upgrade) by pinning
 an in-memory client certificate. This is enabled automatically and requires no
 configuration. Status, health, and probe endpoints remain unauthenticated.
-This hardening is not backported; on releases earlier than 1.30.0, continue to
-restrict the status port (TCP 8000) with a `NetworkPolicy`, which remains its
-security boundary there. See
+This protection has a hard requirement: the status port **must** be served
+over TLS, which has been the default since v1.24. This hardening is not
+backported; on releases earlier than 1.30.0, continue to restrict the status
+port (TCP 8000) with a `NetworkPolicy`, which remains its security boundary
+there. See
 [Operator-to-instance authentication](security.md#operator-to-instance-authentication)
 for details.
-
-:::warning
-This protection has a hard requirement: the status port **must** be served over
-TLS, which has been the default since v1.24. Instances created by an operator
-older than v1.24 serve it over plain HTTP, and 1.30.0 no longer falls back to
-HTTP: the operator cannot read their status, so it reports
-`Instance Status Extraction Error`. While the cluster has ready instances and
-none of them is reachable, it is not reconciled at all: no rolling update is
-started to fix it, and Pods you delete are not recreated. If you still run such
-instances, perform a rolling update so their Pods are recreated with a
-TLS-enabled status port **before** upgrading to 1.30.0. Instances created by
-v1.24 or later are unaffected.
-:::
 
 #### Metrics exporter privilege separation (`CVE-2026-44477`)
 

--- a/docs/src/security.md
+++ b/docs/src/security.md
@@ -895,22 +895,17 @@ unauthenticated.
 The certificate is never written to disk and is regenerated on every operator
 restart, so trust derives from fingerprint pinning rather than CA validation.
 
-This protection has a hard requirement: the status port **must** be served over
-TLS, which has been the default since v1.24. A client certificate can only be
-presented over a TLS connection, so the protected endpoints are reachable by the
-operator only when the status port uses TLS.
+A client certificate can only be presented over a TLS connection, and the
+instance manager always serves the status port over TLS, so this protection is
+unconditional.
 
 :::warning
-If the status port is not served over TLS, the instance manager cannot
-authenticate the operator and **permanently** rejects every call to its
-protected endpoints (backup, `pg_controldata`, partial WAL archive, and
-instance-manager upgrade) with `401 Unauthorized`. This is not a transient
-condition and will not resolve on its own. It can affect instances created by an
-operator older than v1.24 (whose status port serves plain HTTP) once their
-instance manager is upgraded to a version that enforces this authentication: such
-instances must be rolled out so their Pods are recreated with a TLS-enabled status
-port. Newly created instances always enable TLS on the status port and are
-unaffected.
+Instances created by an operator older than v1.24 serve the status port over
+plain HTTP, and the operator no longer falls back to it: it cannot read their
+status, and while none of the cluster's ready instances is reachable the cluster
+is not reconciled at all: no rolling update is started, and Pods you delete are
+not recreated. Roll out such instances **before** upgrading the operator, so
+their Pods are recreated with a TLS-enabled status port.
 :::
 
 ### PostgreSQL

--- a/docs/src/security.md
+++ b/docs/src/security.md
@@ -899,15 +899,6 @@ A client certificate can only be presented over a TLS connection, and the
 instance manager always serves the status port over TLS, so this protection is
 unconditional.
 
-:::warning
-Instances created by an operator older than v1.24 serve the status port over
-plain HTTP, and the operator no longer falls back to it: it cannot read their
-status, and while none of the cluster's ready instances is reachable the cluster
-is not reconciled at all: no rolling update is started, and Pods you delete are
-not recreated. Roll out such instances **before** upgrading the operator, so
-their Pods are recreated with a TLS-enabled status port.
-:::
-
 ### PostgreSQL
 
 The current implementation of CloudNativePG automatically creates

--- a/internal/cmd/manager/instance/run/cmd.go
+++ b/internal/cmd/manager/instance/run/cmd.go
@@ -81,7 +81,6 @@ func NewCmd() *cobra.Command {
 	var clusterName string
 	var namespace string
 	var pprofHTTPServer bool
-	var statusPortTLS bool
 	var metricsPortTLS bool
 
 	cmd := &cobra.Command{
@@ -106,7 +105,6 @@ func NewCmd() *cobra.Command {
 				WithNamespace(namespace)
 
 			instance.PgData = pgData
-			instance.StatusPortTLS = statusPortTLS
 			instance.MetricsPortTLS = metricsPortTLS
 
 			// Since version 0.19.0 of controller-runtime, it is not allowed to create multiple controllers with the
@@ -147,8 +145,6 @@ func NewCmd() *cobra.Command {
 		false,
 		"If true it will start a pprof debug http server on localhost:6060. Defaults to false.",
 	)
-	cmd.Flags().BoolVar(&statusPortTLS, "status-port-tls", false,
-		"Enable TLS for communicating with the operator")
 	cmd.Flags().BoolVar(&metricsPortTLS, "metrics-port-tls", false,
 		"Enable TLS for metrics scraping")
 	return cmd

--- a/internal/cmd/manager/instance/run/cmd.go
+++ b/internal/cmd/manager/instance/run/cmd.go
@@ -147,6 +147,16 @@ func NewCmd() *cobra.Command {
 	)
 	cmd.Flags().BoolVar(&metricsPortTLS, "metrics-port-tls", false,
 		"Enable TLS for metrics scraping")
+
+	// An in-place instance manager upgrade re-execs this binary with the argv of
+	// the Pod, which was chosen by the operator that created it. Pods created
+	// before 1.30 pass --status-port-tls, and rejecting it would crash-loop the
+	// instance manager.
+	//
+	// TODO: delete after minor version 1.29 is discontinued
+	cmd.Flags().Bool("status-port-tls", false, "Deprecated: the status port always uses TLS")
+	_ = cmd.Flags().MarkDeprecated("status-port-tls", "the status port always uses TLS")
+
 	return cmd
 }
 

--- a/internal/cmd/manager/instance/run/cmd.go
+++ b/internal/cmd/manager/instance/run/cmd.go
@@ -150,10 +150,10 @@ func NewCmd() *cobra.Command {
 
 	// An in-place instance manager upgrade re-execs this binary with the argv of
 	// the Pod, which was chosen by the operator that created it. Pods created
-	// before 1.30 pass --status-port-tls, and rejecting it would crash-loop the
+	// before 1.31 pass --status-port-tls, and rejecting it would crash-loop the
 	// instance manager.
 	//
-	// TODO: delete after minor version 1.29 is discontinued
+	// TODO: delete after minor version 1.30 is discontinued
 	cmd.Flags().Bool("status-port-tls", false, "Deprecated: the status port always uses TLS")
 	_ = cmd.Flags().MarkDeprecated("status-port-tls", "the status port always uses TLS")
 

--- a/internal/cmd/manager/instance/run/cmd_test.go
+++ b/internal/cmd/manager/instance/run/cmd_test.go
@@ -1,0 +1,33 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package run
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("NewCmd", func() {
+	// An in-place instance manager upgrade re-execs this binary with the argv of
+	// the Pod, so a flag dropped in a newer release must still parse.
+	It("accepts the status-port-tls flag passed by Pods created before 1.30", func() {
+		Expect(NewCmd().ParseFlags([]string{"--status-port-tls"})).To(Succeed())
+	})
+})

--- a/internal/cmd/manager/instance/run/cmd_test.go
+++ b/internal/cmd/manager/instance/run/cmd_test.go
@@ -27,7 +27,7 @@ import (
 var _ = Describe("NewCmd", func() {
 	// An in-place instance manager upgrade re-execs this binary with the argv of
 	// the Pod, so a flag dropped in a newer release must still parse.
-	It("accepts the status-port-tls flag passed by Pods created before 1.30", func() {
+	It("accepts the status-port-tls flag passed by Pods created before 1.31", func() {
 		Expect(NewCmd().ParseFlags([]string{"--status-port-tls"})).To(Succeed())
 	})
 })

--- a/internal/controller/cluster_controller_test.go
+++ b/internal/controller/cluster_controller_test.go
@@ -69,7 +69,7 @@ var _ = Describe("reconcilePods instance recreation while a PVC is terminating (
 		}
 
 		readyPod := func(serial int) *corev1.Pod {
-			pod, err := specs.NewInstance(ctx, *cluster, serial, true)
+			pod, err := specs.NewInstance(ctx, *cluster, serial)
 			Expect(err).ToNot(HaveOccurred())
 			pod.Status = corev1.PodStatus{
 				Phase:      corev1.PodRunning,
@@ -154,7 +154,7 @@ var _ = Describe("ensureInstancesAreCreated reattachment while a PVC is terminat
 		cluster.Status.ReadyInstances = 2
 
 		readyPod := func(serial int) *corev1.Pod {
-			pod, err := specs.NewInstance(ctx, *cluster, serial, true)
+			pod, err := specs.NewInstance(ctx, *cluster, serial)
 			Expect(err).ToNot(HaveOccurred())
 			pod.Status = corev1.PodStatus{
 				Phase:      corev1.PodRunning,
@@ -341,7 +341,7 @@ var _ = Describe("ensureInstancesAreCreated recovers a lost bootstrap", func() {
 		cluster.Status.TargetPrimary = primaryName
 		cluster.Status.DanglingPVC = []string{replicaName}
 
-		primaryPod, err := specs.NewInstance(ctx, *cluster, 1, true)
+		primaryPod, err := specs.NewInstance(ctx, *cluster, 1)
 		Expect(err).ToNot(HaveOccurred())
 		primaryPod.Status = corev1.PodStatus{
 			Phase:      corev1.PodRunning,
@@ -615,7 +615,7 @@ var _ = Describe("ensureInstancesAreCreated recovers a lost bootstrap", func() {
 		cluster.Status.TargetPrimary = primaryName
 		cluster.Status.DanglingPVC = []string{replicaName}
 
-		primaryPod, err := specs.NewInstance(ctx, *cluster, 1, true)
+		primaryPod, err := specs.NewInstance(ctx, *cluster, 1)
 		Expect(err).ToNot(HaveOccurred())
 		primaryPod.Status = corev1.PodStatus{
 			Phase:      corev1.PodRunning,
@@ -706,7 +706,7 @@ var _ = Describe("ensureInstancesAreCreated recovers a lost bootstrap", func() {
 		cluster.Status.TargetPrimary = primaryName
 		cluster.Status.DanglingPVC = []string{replicaName}
 
-		primaryPod, err := specs.NewInstance(ctx, *cluster, 1, true)
+		primaryPod, err := specs.NewInstance(ctx, *cluster, 1)
 		Expect(err).ToNot(HaveOccurred())
 		primaryPod.Status = corev1.PodStatus{
 			Phase:      corev1.PodRunning,
@@ -757,7 +757,7 @@ var _ = Describe("ensureInstancesAreCreated recovers a lost bootstrap", func() {
 		// An incomplete PVC group is classified unusable, not dangling.
 		cluster.Status.UnusablePVC = []string{replicaName}
 
-		primaryPod, err := specs.NewInstance(ctx, *cluster, 1, true)
+		primaryPod, err := specs.NewInstance(ctx, *cluster, 1)
 		Expect(err).ToNot(HaveOccurred())
 		primaryPod.Status = corev1.PodStatus{
 			Phase:      corev1.PodRunning,
@@ -1070,7 +1070,7 @@ var _ = Describe("Updating target primary", func() {
 			}
 
 			By("creating a pod for instance 1 only (instance 2's pod was deleted during rolling update)")
-			pod1, err := specs.NewInstance(ctx, *cluster, 1, true)
+			pod1, err := specs.NewInstance(ctx, *cluster, 1)
 			Expect(err).ToNot(HaveOccurred())
 			cluster.SetInheritedDataAndOwnership(&pod1.ObjectMeta)
 			Expect(env.client.Create(ctx, pod1)).To(Succeed())

--- a/internal/controller/cluster_create.go
+++ b/internal/controller/cluster_create.go
@@ -1728,7 +1728,7 @@ func findInstancePodToCreate(
 		if err != nil {
 			return nil, err
 		}
-		return specs.NewInstance(ctx, *cluster, serial, true)
+		return specs.NewInstance(ctx, *cluster, serial)
 	}
 
 	return nil, nil

--- a/internal/controller/cluster_create.go
+++ b/internal/controller/cluster_create.go
@@ -1470,7 +1470,7 @@ func (r *ClusterReconciler) joinReplicaInstance(
 		cmd = specs.BuildReplicaBootstrapCommandViaRestoreSnapshot(*cluster)
 	}
 
-	pod, err := specs.NewInstance(ctx, *cluster, nodeSerial, true)
+	pod, err := specs.NewInstance(ctx, *cluster, nodeSerial)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("unable to build replica instance: %w", err)
 	}

--- a/internal/controller/cluster_upgrade.go
+++ b/internal/controller/cluster_upgrade.go
@@ -686,8 +686,7 @@ func newInstanceForRunningPod(
 		return nil, fmt.Errorf("while getting the pod serial value: %w", err)
 	}
 
-	tlsEnabled := remote.GetStatusSchemeFromPod(pod).IsHTTPS()
-	targetPod, err := specs.NewInstance(ctx, *cluster, serial, tlsEnabled)
+	targetPod, err := specs.NewInstance(ctx, *cluster, serial)
 	if err != nil {
 		return nil, fmt.Errorf("while creating a new instance pod: %w", err)
 	}

--- a/internal/controller/cluster_upgrade.go
+++ b/internal/controller/cluster_upgrade.go
@@ -672,8 +672,8 @@ func checkPodEnvironmentIsOutdated(_ context.Context, pod *corev1.Pod, cluster *
 }
 
 // newInstanceForRunningPod evaluates the instance specification that the given
-// running Pod should currently match. It derives the node serial and status
-// scheme from the Pod, then calls specs.NewInstance, which runs the plugins'
+// running Pod should currently match. It derives the node serial from the Pod,
+// then calls specs.NewInstance, which runs the plugins'
 // OperationVerbEvaluate lifecycle hook so the returned spec already includes any
 // sidecars they inject.
 func newInstanceForRunningPod(

--- a/internal/controller/cluster_upgrade_test.go
+++ b/internal/controller/cluster_upgrade_test.go
@@ -74,7 +74,7 @@ var _ = Describe("Pod upgrade", Ordered, func() {
 	})
 
 	It("will not require a restart for just created Pods", func(ctx SpecContext) {
-		pod, err := specs.NewInstance(ctx, cluster, 1, true)
+		pod, err := specs.NewInstance(ctx, cluster, 1)
 		Expect(err).ToNot(HaveOccurred())
 
 		status := postgres.PostgresqlStatus{
@@ -89,7 +89,7 @@ var _ = Describe("Pod upgrade", Ordered, func() {
 	})
 
 	It("requires rollout when running a different image name", func(ctx SpecContext) {
-		pod, err := specs.NewInstance(ctx, cluster, 1, true)
+		pod, err := specs.NewInstance(ctx, cluster, 1)
 		Expect(err).ToNot(HaveOccurred())
 
 		pod.Spec.Containers[0].Image = "postgres:13.10"
@@ -106,7 +106,7 @@ var _ = Describe("Pod upgrade", Ordered, func() {
 	})
 
 	It("requires rollout when a restart annotation has been added to the cluster", func(ctx SpecContext) {
-		pod, err := specs.NewInstance(ctx, cluster, 1, true)
+		pod, err := specs.NewInstance(ctx, cluster, 1)
 		Expect(err).ToNot(HaveOccurred())
 		clusterRestart := cluster
 		clusterRestart.Annotations = make(map[string]string)
@@ -131,7 +131,7 @@ var _ = Describe("Pod upgrade", Ordered, func() {
 	})
 
 	It("should prioritize full rollout over inplace restarts", func(ctx SpecContext) {
-		pod, err := specs.NewInstance(ctx, cluster, 1, true)
+		pod, err := specs.NewInstance(ctx, cluster, 1)
 		Expect(err).ToNot(HaveOccurred())
 
 		status := postgres.PostgresqlStatus{
@@ -162,7 +162,7 @@ var _ = Describe("Pod upgrade", Ordered, func() {
 	})
 
 	It("requires rollout when PostgreSQL needs to be restarted", func(ctx SpecContext) {
-		pod, err := specs.NewInstance(ctx, cluster, 1, true)
+		pod, err := specs.NewInstance(ctx, cluster, 1)
 		Expect(err).ToNot(HaveOccurred())
 
 		status := postgres.PostgresqlStatus{
@@ -189,7 +189,7 @@ var _ = Describe("Pod upgrade", Ordered, func() {
 	})
 
 	It("requires pod rollout if executable does not have a hash", func(ctx SpecContext) {
-		pod, err := specs.NewInstance(ctx, cluster, 1, true)
+		pod, err := specs.NewInstance(ctx, cluster, 1)
 		Expect(err).ToNot(HaveOccurred())
 		status := postgres.PostgresqlStatus{
 			Pod:            pod,
@@ -205,7 +205,7 @@ var _ = Describe("Pod upgrade", Ordered, func() {
 	})
 
 	It("checkPodSpecIsOutdated should not return any error", func() {
-		pod, err := specs.NewInstance(context.TODO(), cluster, 1, true)
+		pod, err := specs.NewInstance(context.TODO(), cluster, 1)
 		Expect(err).ToNot(HaveOccurred())
 		rollout, err := checkPodSpecIsOutdated(context.TODO(), pod, &cluster)
 		Expect(rollout.required).To(BeFalse())
@@ -215,7 +215,7 @@ var _ = Describe("Pod upgrade", Ordered, func() {
 	})
 
 	It("checks when a rollout is needed for any reason", func(ctx SpecContext) {
-		pod, err := specs.NewInstance(ctx, cluster, 1, true)
+		pod, err := specs.NewInstance(ctx, cluster, 1)
 		Expect(err).ToNot(HaveOccurred())
 		status := postgres.PostgresqlStatus{
 			Pod:            pod,
@@ -242,7 +242,7 @@ var _ = Describe("Pod upgrade", Ordered, func() {
 
 	When("the PodSpec annotation is not available", func() {
 		It("should trigger a rollout when the scheduler changes", func(ctx SpecContext) {
-			pod, err := specs.NewInstance(ctx, cluster, 1, true)
+			pod, err := specs.NewInstance(ctx, cluster, 1)
 			Expect(err).ToNot(HaveOccurred())
 			cluster.Spec.SchedulerName = "newScheduler"
 			delete(pod.Annotations, utils.PodSpecAnnotationName)
@@ -268,7 +268,7 @@ var _ = Describe("Pod upgrade", Ordered, func() {
 				ImageName: "postgres:13.11",
 			},
 		}
-		pod, err := specs.NewInstance(ctx, cluster, 1, true)
+		pod, err := specs.NewInstance(ctx, cluster, 1)
 		Expect(err).ToNot(HaveOccurred())
 		cluster.Spec.SchedulerName = "newScheduler"
 
@@ -304,7 +304,6 @@ var _ = Describe("Pod upgrade", Ordered, func() {
 				context.TODO(),
 				clusterWithResources,
 				1,
-				true,
 			)
 			Expect(err).ToNot(HaveOccurred())
 			clusterWithResources.Spec.Resources.Limits["cpu"] = resource.MustParse("3") // was "2"
@@ -324,7 +323,7 @@ var _ = Describe("Pod upgrade", Ordered, func() {
 			Expect(rollout.needsToChangeOperatorImage).To(BeFalse())
 		})
 		It("should trigger a rollout when the cluster has Resources deleted from spec", func(ctx SpecContext) {
-			pod, err := specs.NewInstance(context.TODO(), clusterWithResources, 1, true)
+			pod, err := specs.NewInstance(context.TODO(), clusterWithResources, 1)
 			Expect(err).ToNot(HaveOccurred())
 			clusterWithResources.Spec.Resources = corev1.ResourceRequirements{}
 
@@ -346,7 +345,7 @@ var _ = Describe("Pod upgrade", Ordered, func() {
 
 	When("the PodSpec annotation is not available", func() {
 		It("detects when a new custom environment variable is set", func(ctx SpecContext) {
-			pod, err := specs.NewInstance(ctx, cluster, 1, true)
+			pod, err := specs.NewInstance(ctx, cluster, 1)
 			Expect(err).ToNot(HaveOccurred())
 			delete(pod.Annotations, utils.PodSpecAnnotationName)
 
@@ -377,7 +376,7 @@ var _ = Describe("Pod upgrade", Ordered, func() {
 					ImageName: "postgres:13.11",
 				},
 			}
-			pod, err := specs.NewInstance(ctx, cluster, 1, true)
+			pod, err := specs.NewInstance(ctx, cluster, 1)
 			Expect(err).ToNot(HaveOccurred())
 			delete(pod.Annotations, utils.PodSpecAnnotationName)
 
@@ -402,7 +401,7 @@ var _ = Describe("Pod upgrade", Ordered, func() {
 					ImageName: "postgres:13.11",
 				},
 			}
-			pod, err := specs.NewInstance(ctx, cluster, 1, true)
+			pod, err := specs.NewInstance(ctx, cluster, 1)
 			Expect(err).ToNot(HaveOccurred())
 			delete(pod.Annotations, utils.PodSpecAnnotationName)
 
@@ -426,7 +425,7 @@ var _ = Describe("Pod upgrade", Ordered, func() {
 
 	When("the podSpec annotation is available", func() {
 		It("detects when a new custom environment variable is set", func(ctx SpecContext) {
-			pod, err := specs.NewInstance(ctx, cluster, 1, true)
+			pod, err := specs.NewInstance(ctx, cluster, 1)
 			Expect(err).ToNot(HaveOccurred())
 
 			cluster := cluster.DeepCopy()
@@ -457,7 +456,7 @@ var _ = Describe("Pod upgrade", Ordered, func() {
 					ImageName: "postgres:13.11",
 				},
 			}
-			pod, err := specs.NewInstance(ctx, cluster, 1, true)
+			pod, err := specs.NewInstance(ctx, cluster, 1)
 			Expect(err).ToNot(HaveOccurred())
 
 			status := postgres.PostgresqlStatus{
@@ -481,7 +480,7 @@ var _ = Describe("Pod upgrade", Ordered, func() {
 					ImageName: "postgres:13.11",
 				},
 			}
-			pod, err := specs.NewInstance(ctx, cluster, 1, true)
+			pod, err := specs.NewInstance(ctx, cluster, 1)
 			Expect(err).ToNot(HaveOccurred())
 
 			status := postgres.PostgresqlStatus{
@@ -508,7 +507,7 @@ var _ = Describe("Pod upgrade", Ordered, func() {
 				cluster.Spec.ProjectedVolumeTemplate = &corev1.ProjectedVolumeSource{
 					Sources: []corev1.VolumeProjection{},
 				}
-				pod, err := specs.NewInstance(ctx, cluster, 1, true)
+				pod, err := specs.NewInstance(ctx, cluster, 1)
 				Expect(err).ToNot(HaveOccurred())
 				status := postgres.PostgresqlStatus{
 					Pod:            pod,
@@ -526,7 +525,7 @@ var _ = Describe("Pod upgrade", Ordered, func() {
 				cluster.Spec.ProjectedVolumeTemplate = &corev1.ProjectedVolumeSource{
 					Sources: nil,
 				}
-				pod, err := specs.NewInstance(ctx, cluster, 1, true)
+				pod, err := specs.NewInstance(ctx, cluster, 1)
 				Expect(err).ToNot(HaveOccurred())
 				status := postgres.PostgresqlStatus{
 					Pod:            pod,
@@ -542,7 +541,7 @@ var _ = Describe("Pod upgrade", Ordered, func() {
 		It("should not require rollout if projected volume  is nil",
 			func(ctx SpecContext) {
 				cluster.Spec.ProjectedVolumeTemplate = nil
-				pod, err := specs.NewInstance(ctx, cluster, 1, true)
+				pod, err := specs.NewInstance(ctx, cluster, 1)
 				Expect(err).ToNot(HaveOccurred())
 				status := postgres.PostgresqlStatus{
 					Pod:            pod,
@@ -576,7 +575,7 @@ var _ = Describe("Test pod rollout due to topology", func() {
 			},
 		}
 		var err error
-		pod, err = specs.NewInstance(context.TODO(), *cluster, 1, true)
+		pod, err = specs.NewInstance(context.TODO(), *cluster, 1)
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -643,7 +642,7 @@ var _ = Describe("Test pod rollout due to topology", func() {
 		It("should not require rollout if pod and spec both lack TopologySpreadConstraints", func(ctx SpecContext) {
 			cluster.Spec.TopologySpreadConstraints = nil
 			var err error
-			pod, err = specs.NewInstance(context.TODO(), *cluster, 1, true)
+			pod, err = specs.NewInstance(context.TODO(), *cluster, 1)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(pod.Spec.TopologySpreadConstraints).To(BeNil())
 
@@ -803,7 +802,7 @@ var _ = Describe("Cluster upgrade with podSpec reconciliation disabled", func() 
 	It("skips the rollout if the annotation that disables PodSpec reconciliation is set", func(ctx SpecContext) {
 		cluster.Annotations[utils.ReconcilePodSpecAnnotationName] = "disabled"
 
-		pod, err := specs.NewInstance(ctx, cluster, 1, true)
+		pod, err := specs.NewInstance(ctx, cluster, 1)
 		Expect(err).ToNot(HaveOccurred())
 		cluster.Spec.SchedulerName = "newScheduler"
 		delete(pod.Annotations, utils.PodSpecAnnotationName)
@@ -973,7 +972,7 @@ var _ = Describe("checkPodSpec with plugins", Ordered, func() {
 	})
 
 	It("image change", func() {
-		pod, err := specs.NewInstance(context.TODO(), cluster, 1, true)
+		pod, err := specs.NewInstance(context.TODO(), cluster, 1)
 		Expect(err).ToNot(HaveOccurred())
 
 		podModifiedByPlugins := pod.DeepCopy()
@@ -994,7 +993,7 @@ var _ = Describe("checkPodSpec with plugins", Ordered, func() {
 	})
 
 	It("init-container change", func() {
-		pod, err := specs.NewInstance(context.TODO(), cluster, 1, true)
+		pod, err := specs.NewInstance(context.TODO(), cluster, 1)
 		Expect(err).ToNot(HaveOccurred())
 
 		podModifiedByPlugins := pod.DeepCopy()
@@ -1019,7 +1018,7 @@ var _ = Describe("checkPodSpec with plugins", Ordered, func() {
 	})
 
 	It("environment variable change", func() {
-		pod, err := specs.NewInstance(context.TODO(), cluster, 1, true)
+		pod, err := specs.NewInstance(context.TODO(), cluster, 1)
 		Expect(err).ToNot(HaveOccurred())
 
 		podModifiedByPlugins := pod.DeepCopy()
@@ -1221,7 +1220,7 @@ var _ = Describe("archiverSidecarMissingOnPrimary", func() {
 	}
 
 	It("returns false when no WAL-archiver plugin is enabled", func() {
-		pod, err := specs.NewInstance(context.TODO(), cluster, 1, true)
+		pod, err := specs.NewInstance(context.TODO(), cluster, 1)
 		Expect(err).ToNot(HaveOccurred())
 
 		Expect(archiverSidecarMissingOnPrimary(context.TODO(), pod, &cluster)).To(BeFalse())
@@ -1230,7 +1229,7 @@ var _ = Describe("archiverSidecarMissingOnPrimary", func() {
 	It("returns true when the primary is missing the injected sidecar", func() {
 		enableArchiverPlugin()
 
-		pod, err := specs.NewInstance(context.TODO(), cluster, 1, true)
+		pod, err := specs.NewInstance(context.TODO(), cluster, 1)
 		Expect(err).ToNot(HaveOccurred())
 
 		// The freshly evaluated spec carries the sidecar, the running primary does not.
@@ -1243,7 +1242,7 @@ var _ = Describe("archiverSidecarMissingOnPrimary", func() {
 	It("returns false when the primary already has the injected sidecar", func() {
 		enableArchiverPlugin()
 
-		pod, err := specs.NewInstance(context.TODO(), cluster, 1, true)
+		pod, err := specs.NewInstance(context.TODO(), cluster, 1)
 		Expect(err).ToNot(HaveOccurred())
 		podWithSidecar := withArchiverSidecar(pod)
 
@@ -1256,7 +1255,7 @@ var _ = Describe("archiverSidecarMissingOnPrimary", func() {
 	It("ignores a missing run-once init container, only native sidecars matter", func() {
 		enableArchiverPlugin()
 
-		pod, err := specs.NewInstance(context.TODO(), cluster, 1, true)
+		pod, err := specs.NewInstance(context.TODO(), cluster, 1)
 		Expect(err).ToNot(HaveOccurred())
 
 		// The evaluated target adds a plain run-once init container (no
@@ -1276,7 +1275,7 @@ var _ = Describe("archiverSidecarMissingOnPrimary", func() {
 	It("propagates evaluation errors instead of degrading to a switchover decision", func() {
 		enableArchiverPlugin()
 
-		pod, err := specs.NewInstance(context.TODO(), cluster, 1, true)
+		pod, err := specs.NewInstance(context.TODO(), cluster, 1)
 		Expect(err).ToNot(HaveOccurred())
 
 		evalErr := errors.New("plugin evaluation failed")

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -330,7 +330,7 @@ func generateFakeClusterPods(
 	var pods []corev1.Pod
 	for idx < cluster.Spec.Instances {
 		idx++
-		pod, _ := specs.NewInstance(context.TODO(), *cluster, idx, true)
+		pod, _ := specs.NewInstance(context.TODO(), *cluster, idx)
 		cluster.SetInheritedDataAndOwnership(&pod.ObjectMeta)
 
 		err := c.Create(context.Background(), pod)

--- a/internal/plugin/resources/instance.go
+++ b/internal/plugin/resources/instance.go
@@ -36,7 +36,6 @@ import (
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/internal/cmd/plugin"
-	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres/webserver/client/remote"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/url"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/postgres"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/specs"
@@ -110,7 +109,7 @@ func getInstanceStatusFromPod(
 		CoreV1().
 		Pods(pod.Namespace).
 		ProxyGet(
-			remote.GetStatusSchemeFromPod(&pod).ToString(),
+			"https",
 			pod.Name,
 			strconv.Itoa(int(url.StatusPort)),
 			url.PathPgStatus,

--- a/internal/webhook/v1/cluster_webhook.go
+++ b/internal/webhook/v1/cluster_webhook.go
@@ -2871,7 +2871,6 @@ func (v *ClusterCustomValidator) validatePodPatchAnnotation(r *apiv1.Cluster) fi
 		context.Background(),
 		*r,
 		1,
-		true,
 	); err != nil {
 		return field.ErrorList{
 			field.Invalid(

--- a/pkg/management/postgres/instance.go
+++ b/pkg/management/postgres/instance.go
@@ -225,9 +225,6 @@ type Instance struct {
 	// tablespaceSynchronizerChan is used to send tablespace configuration to the tablespace synchronizer
 	tablespaceSynchronizerChan chan map[string]apiv1.TablespaceConfiguration
 
-	// StatusPortTLS enables TLS on the status port used to communicate with the operator
-	StatusPortTLS bool
-
 	// MetricsPortTLS enables TLS on the port used to publish metrics over HTTP/HTTPS
 	MetricsPortTLS bool
 

--- a/pkg/management/postgres/webserver/client/remote/backup.go
+++ b/pkg/management/postgres/webserver/client/remote/backup.go
@@ -58,8 +58,7 @@ func (c *backupClientImpl) StatusWithErrors(
 	ctx context.Context,
 	pod *corev1.Pod,
 ) (*webserver.Response[webserver.BackupResultData], error) {
-	scheme := GetStatusSchemeFromPod(pod)
-	httpURL := url.Build(scheme.ToString(), pod.Status.PodIP, url.PathPgModeBackup, url.StatusPort)
+	httpURL := url.Build("https", pod.Status.PodIP, url.PathPgModeBackup, url.StatusPort)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, httpURL, nil)
 	if err != nil {
 		return nil, err
@@ -74,8 +73,7 @@ func (c *backupClientImpl) Start(
 	pod *corev1.Pod,
 	sbq webserver.StartBackupRequest,
 ) (*webserver.Response[webserver.BackupResultData], error) {
-	scheme := GetStatusSchemeFromPod(pod)
-	httpURL := url.Build(scheme.ToString(), pod.Status.PodIP, url.PathPgModeBackup, url.StatusPort)
+	httpURL := url.Build("https", pod.Status.PodIP, url.PathPgModeBackup, url.StatusPort)
 
 	// Marshalling the payload to JSON
 	jsonBody, err := json.Marshal(sbq)
@@ -98,8 +96,7 @@ func (c *backupClientImpl) Stop(
 	pod *corev1.Pod,
 	sbq webserver.StopBackupRequest,
 ) (*webserver.Response[webserver.BackupResultData], error) {
-	scheme := GetStatusSchemeFromPod(pod)
-	httpURL := url.Build(scheme.ToString(), pod.Status.PodIP, url.PathPgModeBackup, url.StatusPort)
+	httpURL := url.Build("https", pod.Status.PodIP, url.PathPgModeBackup, url.StatusPort)
 	// Marshalling the payload to JSON
 	jsonBody, err := json.Marshal(sbq)
 	if err != nil {

--- a/pkg/management/postgres/webserver/client/remote/instance.go
+++ b/pkg/management/postgres/webserver/client/remote/instance.go
@@ -28,7 +28,6 @@ import (
 	"net"
 	"net/http"
 	neturl "net/url"
-	"slices"
 	"sort"
 	"time"
 
@@ -40,7 +39,6 @@ import (
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management/url"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/postgres"
-	"github.com/cloudnative-pg/cloudnative-pg/pkg/specs"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 	contextutils "github.com/cloudnative-pg/cloudnative-pg/pkg/utils/context"
 )
@@ -209,8 +207,7 @@ func (r *instanceClientImpl) GetPgControlDataFromInstance(
 ) (string, error) {
 	contextLogger := log.FromContext(ctx)
 
-	scheme := GetStatusSchemeFromPod(pod)
-	httpURL := url.Build(scheme.ToString(), pod.Status.PodIP, url.PathPGControlData, url.StatusPort)
+	httpURL := url.Build("https", pod.Status.PodIP, url.PathPGControlData, url.StatusPort)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, httpURL, nil)
 	if err != nil {
 		return "", err
@@ -267,8 +264,7 @@ func (r *instanceClientImpl) UpgradeInstanceManager(
 		}
 	}()
 
-	scheme := GetStatusSchemeFromPod(pod)
-	updateURL := url.Build(scheme.ToString(), pod.Status.PodIP, url.PathUpdate, url.StatusPort)
+	updateURL := url.Build("https", pod.Status.PodIP, url.PathUpdate, url.StatusPort)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPut, updateURL, nil)
 	if err != nil {
 		return err
@@ -316,8 +312,7 @@ func (r *instanceClientImpl) rawInstanceStatusRequest(
 	ctx context.Context,
 	pod corev1.Pod,
 ) (result postgres.PostgresqlStatus) {
-	scheme := GetStatusSchemeFromPod(&pod)
-	statusURL := url.Build(scheme.ToString(), pod.Status.PodIP, url.PathPgStatus, url.StatusPort)
+	statusURL := url.Build("https", pod.Status.PodIP, url.PathPgStatus, url.StatusPort)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, statusURL, nil)
 	if err != nil {
 		result.Error = err
@@ -358,48 +353,11 @@ func (r *instanceClientImpl) rawInstanceStatusRequest(
 	return result
 }
 
-// HTTPScheme identifies a valid scheme: http, https
-type HTTPScheme string
-
-const (
-	schemeHTTP  HTTPScheme = "http"
-	schemeHTTPS HTTPScheme = "https"
-)
-
-// IsHTTPS returns true if schemeHTTPS
-func (h HTTPScheme) IsHTTPS() bool {
-	return h == schemeHTTPS
-}
-
-// ToString returns the scheme as a string value
-func (h HTTPScheme) ToString() string {
-	return string(h)
-}
-
-// GetStatusSchemeFromPod detects if a Pod is exposing the status via HTTP or HTTPS
-func GetStatusSchemeFromPod(pod *corev1.Pod) HTTPScheme {
-	// Fall back to comparing the container environment configuration
-	for _, container := range pod.Spec.Containers {
-		// we go to the next array element if it isn't the postgres container
-		if container.Name != specs.PostgresContainerName {
-			continue
-		}
-
-		if slices.Contains(container.Command, "--status-port-tls") {
-			return schemeHTTPS
-		}
-
-		break
-	}
-
-	return schemeHTTP
-}
-
 func (r *instanceClientImpl) ArchivePartialWAL(ctx context.Context, pod *corev1.Pod) (string, error) {
 	contextLogger := log.FromContext(ctx)
 
 	statusURL := url.Build(
-		GetStatusSchemeFromPod(pod).ToString(), pod.Status.PodIP, url.PathPgArchivePartial, url.StatusPort)
+		"https", pod.Status.PodIP, url.PathPgArchivePartial, url.StatusPort)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, statusURL, nil)
 	if err != nil {
 		return "", err

--- a/pkg/management/postgres/webserver/client/remote/instance.go
+++ b/pkg/management/postgres/webserver/client/remote/instance.go
@@ -356,8 +356,7 @@ func (r *instanceClientImpl) rawInstanceStatusRequest(
 func (r *instanceClientImpl) ArchivePartialWAL(ctx context.Context, pod *corev1.Pod) (string, error) {
 	contextLogger := log.FromContext(ctx)
 
-	statusURL := url.Build(
-		"https", pod.Status.PodIP, url.PathPgArchivePartial, url.StatusPort)
+	statusURL := url.Build("https", pod.Status.PodIP, url.PathPgArchivePartial, url.StatusPort)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, statusURL, nil)
 	if err != nil {
 		return "", err

--- a/pkg/management/postgres/webserver/remote.go
+++ b/pkg/management/postgres/webserver/remote.go
@@ -188,10 +188,7 @@ func NewRemoteWebServer(
 		Handler:           serveMux,
 		ReadTimeout:       DefaultReadTimeout,
 		ReadHeaderTimeout: DefaultReadHeaderTimeout,
-	}
-
-	if instance.StatusPortTLS {
-		server.TLSConfig = &tls.Config{
+		TLSConfig: &tls.Config{
 			MinVersion: tls.VersionTLS13,
 			GetCertificate: func(_ *tls.ClientHelloInfo) (*tls.Certificate, error) {
 				return instance.GetServerCertificate(), nil
@@ -199,7 +196,7 @@ func NewRemoteWebServer(
 			// RequestClientCert asks the client to send a certificate but does not require it.
 			// Authentication is enforced per-endpoint by withOperatorAuth.
 			ClientAuth: tls.RequestClientCert,
-		}
+		},
 	}
 
 	srv := NewWebServer(server)

--- a/pkg/specs/pg_pods_test.go
+++ b/pkg/specs/pg_pods_test.go
@@ -41,7 +41,7 @@ var _ = Describe("Extract the used image name", func() {
 			Image: configuration.Current.PostgresImageName,
 		},
 	}
-	pod, err := NewInstance(context.TODO(), cluster, 1, true)
+	pod, err := NewInstance(context.TODO(), cluster, 1)
 	Expect(err).ToNot(HaveOccurred())
 
 	It("extract the default image name", func() {

--- a/pkg/specs/pods.go
+++ b/pkg/specs/pods.go
@@ -190,7 +190,6 @@ func createClusterPodSpec(
 	cluster apiv1.Cluster,
 	envConfig EnvConfig,
 	gracePeriod int64,
-	enableHTTPS bool,
 ) corev1.PodSpec {
 	return corev1.PodSpec{
 		Hostname: podName,
@@ -198,7 +197,7 @@ func createClusterPodSpec(
 			createBootstrapContainer(cluster, getExtensions(&cluster)),
 		},
 		SchedulerName:                 cluster.Spec.SchedulerName,
-		Containers:                    createPostgresContainers(cluster, envConfig, enableHTTPS),
+		Containers:                    createPostgresContainers(cluster, envConfig),
 		Volumes:                       createPostgresVolumes(&cluster, podName, getExtensions(&cluster)),
 		SecurityContext:               GetPodSecurityContext(&cluster),
 		Affinity:                      CreateAffinitySection(cluster.Name, cluster.Spec.Affinity),
@@ -213,7 +212,7 @@ func createClusterPodSpec(
 
 // createPostgresContainers create the PostgreSQL containers that are
 // used for every instance
-func createPostgresContainers(cluster apiv1.Cluster, envConfig EnvConfig, enableHTTPS bool) []corev1.Container {
+func createPostgresContainers(cluster apiv1.Cluster, envConfig EnvConfig) []corev1.Container {
 	containers := []corev1.Container{
 		{
 			Name:            PostgresContainerName,
@@ -233,8 +232,9 @@ func createPostgresContainers(cluster apiv1.Cluster, envConfig EnvConfig, enable
 				TimeoutSeconds: 5,
 				ProbeHandler: corev1.ProbeHandler{
 					HTTPGet: &corev1.HTTPGetAction{
-						Path: url.PathStartup,
-						Port: intstr.FromInt32(url.StatusPort),
+						Path:   url.PathStartup,
+						Port:   intstr.FromInt32(url.StatusPort),
+						Scheme: corev1.URISchemeHTTPS,
 					},
 				},
 			},
@@ -245,8 +245,9 @@ func createPostgresContainers(cluster apiv1.Cluster, envConfig EnvConfig, enable
 				PeriodSeconds:  ReadinessProbePeriod,
 				ProbeHandler: corev1.ProbeHandler{
 					HTTPGet: &corev1.HTTPGetAction{
-						Path: url.PathReady,
-						Port: intstr.FromInt32(url.StatusPort),
+						Path:   url.PathReady,
+						Port:   intstr.FromInt32(url.StatusPort),
+						Scheme: corev1.URISchemeHTTPS,
 					},
 				},
 			},
@@ -257,8 +258,9 @@ func createPostgresContainers(cluster apiv1.Cluster, envConfig EnvConfig, enable
 				TimeoutSeconds: 5,
 				ProbeHandler: corev1.ProbeHandler{
 					HTTPGet: &corev1.HTTPGetAction{
-						Path: url.PathHealth,
-						Port: intstr.FromInt32(url.StatusPort),
+						Path:   url.PathHealth,
+						Port:   intstr.FromInt32(url.StatusPort),
+						Scheme: corev1.URISchemeHTTPS,
 					},
 				},
 			},
@@ -297,13 +299,6 @@ func createPostgresContainers(cluster apiv1.Cluster, envConfig EnvConfig, enable
 		})
 
 		containers[0].Command = append(containers[0].Command, "--pprof-server")
-	}
-
-	if enableHTTPS {
-		containers[0].StartupProbe.HTTPGet.Scheme = corev1.URISchemeHTTPS
-		containers[0].LivenessProbe.HTTPGet.Scheme = corev1.URISchemeHTTPS
-		containers[0].ReadinessProbe.HTTPGet.Scheme = corev1.URISchemeHTTPS
-		containers[0].Command = append(containers[0].Command, "--status-port-tls")
 	}
 
 	if cluster.IsMetricsTLSEnabled() {
@@ -495,12 +490,10 @@ func NewInstance(
 	ctx context.Context,
 	cluster apiv1.Cluster,
 	nodeSerial int,
-	// TODO: remove tlsEnabled when we drop the support for instances created without TLS
-	tlsEnabled bool,
 ) (*corev1.Pod, error) {
 	contextLogger := log.FromContext(ctx).WithName("new_instance")
 
-	pod, err := buildInstance(cluster, nodeSerial, tlsEnabled)
+	pod, err := buildInstance(cluster, nodeSerial)
 	if err != nil {
 		return nil, err
 	}
@@ -539,7 +532,6 @@ func NewInstance(
 func buildInstance(
 	cluster apiv1.Cluster,
 	nodeSerial int,
-	tlsEnabled bool,
 ) (*corev1.Pod, error) {
 	podName := GetInstanceName(cluster.Name, nodeSerial)
 	gracePeriod := int64(cluster.GetMaxStopDelay())
@@ -547,7 +539,7 @@ func buildInstance(
 
 	envConfig := CreatePodEnvConfig(cluster, podName)
 
-	podSpec := createClusterPodSpec(podName, cluster, envConfig, gracePeriod, tlsEnabled)
+	podSpec := createClusterPodSpec(podName, cluster, envConfig, gracePeriod)
 
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/specs/pods_test.go
+++ b/pkg/specs/pods_test.go
@@ -1014,7 +1014,7 @@ var _ = Describe("NewInstance", func() {
 			},
 		}
 
-		pod, err := NewInstance(ctx, cluster, 1, true)
+		pod, err := NewInstance(ctx, cluster, 1)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(pod).NotTo(BeNil())
 		Expect(pod.Labels).To(BeEquivalentTo(map[string]string{
@@ -1043,7 +1043,7 @@ var _ = Describe("NewInstance", func() {
 			},
 		}
 
-		pod, err := NewInstance(ctx, cluster, 1, true)
+		pod, err := NewInstance(ctx, cluster, 1)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(pod).NotTo(BeNil())
 		Expect(pod.Spec.Containers[0].Image).To(Equal("new-image:latest"))
@@ -1060,7 +1060,7 @@ var _ = Describe("NewInstance", func() {
 			},
 		}
 
-		_, err := NewInstance(ctx, cluster, 1, true)
+		_, err := NewInstance(ctx, cluster, 1)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("while decoding JSON patch from annotation"))
 	})
@@ -1079,7 +1079,7 @@ var _ = Describe("service account token", func() {
 	}
 
 	It("always disables the automount and projects the token for non-bootstrap containers", func() {
-		pod, err := buildInstance(apiv1.Cluster{}, 1, true)
+		pod, err := buildInstance(apiv1.Cluster{}, 1)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(pod.Spec.AutomountServiceAccountToken).To(HaveValue(BeFalse()))
 		Expect(pod.Spec.Volumes).To(ContainElement(HaveField("Name", kubeAPIAccessVolumeName)))

--- a/pkg/specs/pods_test.go
+++ b/pkg/specs/pods_test.go
@@ -1103,3 +1103,19 @@ var _ = Describe("service account token", func() {
 		}
 	})
 })
+
+var _ = Describe("instance probes", func() {
+	It("queries the status port over HTTPS", func(ctx SpecContext) {
+		pod, err := NewInstance(ctx, apiv1.Cluster{}, 1)
+		Expect(err).ToNot(HaveOccurred())
+
+		container := pod.Spec.Containers[0]
+		for _, probe := range []*corev1.Probe{
+			container.StartupProbe,
+			container.ReadinessProbe,
+			container.LivenessProbe,
+		} {
+			Expect(probe.HTTPGet.Scheme).To(Equal(corev1.URISchemeHTTPS))
+		}
+	})
+})

--- a/pkg/specs/podspec_diff.go
+++ b/pkg/specs/podspec_diff.go
@@ -22,6 +22,7 @@ package specs
 import (
 	"fmt"
 	"reflect"
+	"slices"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -182,6 +183,20 @@ func normalizeVolumeMountName(mount corev1.VolumeMount) string {
 	return name
 }
 
+// normalizeCommand drops the instance manager flag that Pods created before
+// 1.30 pass and that the current one no longer sets. Their PodSpec annotation
+// still records it, so comparing the command verbatim reports a spec difference
+// and rolls every existing instance, even when
+// ENABLE_INSTANCE_MANAGER_INPLACE_UPDATES would otherwise upgrade them without
+// recreating the Pod.
+//
+// TODO: delete this function after minor version 1.29 is discontinued
+func normalizeCommand(command []string) []string {
+	return slices.DeleteFunc(slices.Clone(command), func(arg string) bool {
+		return arg == "--status-port-tls"
+	})
+}
+
 func compareVolumes(currentVolumes, targetVolumes []corev1.Volume) (bool, string) {
 	current := make(map[string]corev1.Volume)
 	target := make(map[string]corev1.Volume)
@@ -235,7 +250,10 @@ func doContainersMatch(currentContainer, targetContainer corev1.Container) (bool
 			return reflect.DeepEqual(currentContainer.StartupProbe, targetContainer.StartupProbe)
 		},
 		"command": func() bool {
-			return reflect.DeepEqual(currentContainer.Command, targetContainer.Command)
+			return slices.Equal(
+				normalizeCommand(currentContainer.Command),
+				normalizeCommand(targetContainer.Command),
+			)
 		},
 		"resources": func() bool {
 			// semantic equality will compare the two objects semantically, not only numbers

--- a/pkg/specs/podspec_diff.go
+++ b/pkg/specs/podspec_diff.go
@@ -184,13 +184,13 @@ func normalizeVolumeMountName(mount corev1.VolumeMount) string {
 }
 
 // normalizeCommand drops the instance manager flag that Pods created before
-// 1.30 pass and that the current one no longer sets. Their PodSpec annotation
+// 1.31 pass and that the current one no longer sets. Their PodSpec annotation
 // still records it, so comparing the command verbatim reports a spec difference
 // and rolls every existing instance, even when
 // ENABLE_INSTANCE_MANAGER_INPLACE_UPDATES would otherwise upgrade them without
 // recreating the Pod.
 //
-// TODO: delete this function after minor version 1.29 is discontinued
+// TODO: delete this function after minor version 1.30 is discontinued
 func normalizeCommand(command []string) []string {
 	return slices.DeleteFunc(slices.Clone(command), func(arg string) bool {
 		return arg == "--status-port-tls"

--- a/pkg/specs/podspec_diff_test.go
+++ b/pkg/specs/podspec_diff_test.go
@@ -20,6 +20,8 @@ SPDX-License-Identifier: Apache-2.0
 package specs
 
 import (
+	"slices"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/ptr"
 
@@ -295,5 +297,26 @@ var _ = Describe("automountServiceAccountToken drift detection", func() {
 
 		match, _ = ComparePodSpecs(target, target)
 		Expect(match).To(BeTrue())
+	})
+})
+
+var _ = Describe("Command comparison", func() {
+	baseCommand := []string{"/controller/manager", "instance", "run"}
+
+	It("ignores the status-port-tls flag carried by Pods created before 1.30", func() {
+		current := corev1.Container{Command: append(slices.Clone(baseCommand), "--status-port-tls")}
+		target := corev1.Container{Command: baseCommand}
+
+		Expect(doContainersMatch(current, target)).To(BeTrue())
+		Expect(doContainersMatch(target, current)).To(BeTrue())
+	})
+
+	It("still detects any other command difference", func() {
+		current := corev1.Container{Command: append(slices.Clone(baseCommand), "--status-port-tls")}
+		target := corev1.Container{Command: append(slices.Clone(baseCommand), "--pprof-server")}
+
+		match, diff := doContainersMatch(current, target)
+		Expect(match).To(BeFalse())
+		Expect(diff).To(Equal("command"))
 	})
 })

--- a/pkg/specs/podspec_diff_test.go
+++ b/pkg/specs/podspec_diff_test.go
@@ -303,7 +303,7 @@ var _ = Describe("automountServiceAccountToken drift detection", func() {
 var _ = Describe("Command comparison", func() {
 	baseCommand := []string{"/controller/manager", "instance", "run"}
 
-	It("ignores the status-port-tls flag carried by Pods created before 1.30", func() {
+	It("ignores the status-port-tls flag carried by Pods created before 1.31", func() {
 		current := corev1.Container{Command: append(slices.Clone(baseCommand), "--status-port-tls")}
 		target := corev1.Container{Command: baseCommand}
 

--- a/tests/e2e/operator_mtls_test.go
+++ b/tests/e2e/operator_mtls_test.go
@@ -67,13 +67,12 @@ var _ = Describe("Operator mTLS authentication", Label(tests.LabelSecurity), fun
 			Expect(podList.Items).ToNot(BeEmpty())
 
 			pod := podList.Items[0]
-			const tlsEnabled = true
 
 			// /pg/status is unauthenticated: proves the pod is reachable and the API
 			// server proxy credentials are valid. If this fails, the next assertion
 			// would be meaningless.
 			By("confirming the unauthenticated status endpoint is reachable", func() {
-				_, err := proxy.RetrievePgStatusFromInstance(env.Ctx, env.Interface, pod, tlsEnabled)
+				_, err := proxy.RetrievePgStatusFromInstance(env.Ctx, env.Interface, pod)
 				Expect(err).ToNot(HaveOccurred())
 			})
 
@@ -81,7 +80,7 @@ var _ = Describe("Operator mTLS authentication", Label(tests.LabelSecurity), fun
 			// must be rejected. Since /pg/status succeeded above, any error here is
 			// caused by our middleware, not by a network or credentials issue.
 			By("confirming the authenticated pgcontroldata endpoint rejects unauthenticated access", func() {
-				_, err := proxy.RetrievePgControlDataFromInstance(env.Ctx, env.Interface, pod, tlsEnabled)
+				_, err := proxy.RetrievePgControlDataFromInstance(env.Ctx, env.Interface, pod)
 				Expect(err).To(HaveOccurred())
 				Expect(apierrors.IsUnauthorized(err)).To(BeTrue(),
 					"expected a 401 from the operator-auth middleware, got: %v", err)

--- a/tests/e2e/operator_mtls_test.go
+++ b/tests/e2e/operator_mtls_test.go
@@ -22,7 +22,6 @@ package e2e
 import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
-	remoteClient "github.com/cloudnative-pg/cloudnative-pg/pkg/management/postgres/webserver/client/remote"
 	"github.com/cloudnative-pg/cloudnative-pg/tests"
 	clusterasserts "github.com/cloudnative-pg/cloudnative-pg/tests/internal/asserts/cluster"
 	"github.com/cloudnative-pg/cloudnative-pg/tests/utils/clusterutils"
@@ -68,7 +67,7 @@ var _ = Describe("Operator mTLS authentication", Label(tests.LabelSecurity), fun
 			Expect(podList.Items).ToNot(BeEmpty())
 
 			pod := podList.Items[0]
-			tlsEnabled := remoteClient.GetStatusSchemeFromPod(&pod).IsHTTPS()
+			const tlsEnabled = true
 
 			// /pg/status is unauthenticated: proves the pod is reachable and the API
 			// server proxy credentials are valid. If this fails, the next assertion

--- a/tests/e2e/upgrade_plugin_barman_cloud_test.go
+++ b/tests/e2e/upgrade_plugin_barman_cloud_test.go
@@ -315,7 +315,7 @@ var _ = Describe("Upgrade (plugin-barman-cloud)", Label(tests.LabelUpgrade, test
 			return err
 		}
 		for _, pod := range pods.Items {
-			status, err := proxy.RetrievePgStatusFromInstance(env.Ctx, env.Interface, pod, true)
+			status, err := proxy.RetrievePgStatusFromInstance(env.Ctx, env.Interface, pod)
 			if err != nil {
 				continue
 			}

--- a/tests/e2e/upgrade_test.go
+++ b/tests/e2e/upgrade_test.go
@@ -309,7 +309,7 @@ var _ = Describe("Upgrade", Label(tests.LabelUpgrade, tests.LabelNoOpenshift), O
 			return err
 		}
 		for _, pod := range pods.Items {
-			status, err := proxy.RetrievePgStatusFromInstance(env.Ctx, env.Interface, pod, true)
+			status, err := proxy.RetrievePgStatusFromInstance(env.Ctx, env.Interface, pod)
 			if err != nil {
 				continue
 			}

--- a/tests/utils/proxy/proxy.go
+++ b/tests/utils/proxy/proxy.go
@@ -82,9 +82,8 @@ func RetrievePgStatusFromInstance(
 	ctx context.Context,
 	kubeInterface kubernetes.Interface,
 	pod corev1.Pod,
-	tlsEnabled bool,
 ) (string, error) {
-	body, err := runProxyRequest(ctx, kubeInterface, &pod, tlsEnabled, url.PathPgStatus, int(url.StatusPort))
+	body, err := runProxyRequest(ctx, kubeInterface, &pod, true, url.PathPgStatus, int(url.StatusPort))
 	return string(body), err
 }
 
@@ -94,7 +93,6 @@ func RetrievePgControlDataFromInstance(
 	ctx context.Context,
 	kubeInterface kubernetes.Interface,
 	pod corev1.Pod,
-	tlsEnabled bool,
 ) ([]byte, error) {
-	return runProxyRequest(ctx, kubeInterface, &pod, tlsEnabled, url.PathPGControlData, int(url.StatusPort))
+	return runProxyRequest(ctx, kubeInterface, &pod, true, url.PathPGControlData, int(url.StatusPort))
 }


### PR DESCRIPTION
All instances have used TLS for operator communication by default since v1.24 (#4442). Remove the now-dead `--status-port-tls` flag, the `StatusPortTLS` instance field, and the HTTPScheme detection logic (`GetStatusSchemeFromPod`), assuming TLS unconditionally in the status webserver, probes, and instance manager client.

An in-place instance manager upgrade re-execs this binary with the `argv` chosen by the operator that created the Pod, so Pods created before 1.31 still pass `--status-port-tls` and would otherwise crash-loop. Keep the flag parseable as deprecated and ignore it when comparing container commands until 1.30 is discontinued.

Important changes (for release notes): in the unlikely event of a problem after upgrading from an operator older than v1.24, perform a manual rolling update of the affected Pods to recreate them with a TLS-enabled status port.

