### PR TITLE
fix(pvc): repair common labels when the value was overwritten

### DIFF
--- a/pkg/reconciler/persistentvolumeclaim/metadata.go
+++ b/pkg/reconciler/persistentvolumeclaim/metadata.go
@@ -209,14 +209,18 @@ func newLabelReconciler(cluster *apiv1.Cluster) metadataReconciler { //nolint: g
 				return false
 			}
 
-			// Check common labels
-			commonLabels := []string{
-				utils.KubernetesAppManagedByLabelName,
-				utils.KubernetesAppLabelName,
-				utils.KubernetesAppComponentLabelName,
+			// Check common labels. The value matters, not just the presence: these
+			// labels are part of the selector used to find the PVC to snapshot, and
+			// inheritedMetadata can overwrite them (Build applies the cluster
+			// inheritance after the calculator). Checking only for presence leaves
+			// such a PVC frozen with the wrong value, because update() never runs.
+			commonLabels := map[string]string{
+				utils.KubernetesAppManagedByLabelName: utils.ManagerName,
+				utils.KubernetesAppLabelName:          utils.AppName,
+				utils.KubernetesAppComponentLabelName: utils.DatabaseComponentName,
 			}
-			for _, label := range commonLabels {
-				if _, found := pvc.Labels[label]; !found {
+			for label, expected := range commonLabels {
+				if pvc.Labels[label] != expected {
 					return false
 				}
 			}

--- a/pkg/reconciler/persistentvolumeclaim/metadata_test.go
+++ b/pkg/reconciler/persistentvolumeclaim/metadata_test.go
@@ -128,5 +128,52 @@ var _ = Describe("metadataReconciler", func() {
 				Expect(pvc.Labels).To(HaveKeyWithValue(utils.KubernetesAppComponentLabelName, utils.DatabaseComponentName))
 			})
 		})
+
+		Context("when a common label was overwritten", func() {
+			It("should not consider the PVC up-to-date, and should restore the value", func() {
+				cluster := &apiv1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-cluster",
+					},
+					Spec: apiv1.ClusterSpec{
+						InheritedMetadata: &apiv1.EmbeddedObjectMetadata{Labels: map[string]string{
+							utils.KubernetesAppManagedByLabelName: "Helm",
+							utils.KubernetesAppLabelName:          "my-chart",
+						}},
+					},
+					Status: apiv1.ClusterStatus{
+						InstanceNames: []string{"instance1"},
+					},
+				}
+				// All three common labels are present, but two hold the value that
+				// inheritedMetadata wrote instead of the operator's own.
+				pvc := &corev1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pvc1",
+						Labels: map[string]string{
+							utils.PvcRoleLabelName:      string(utils.PVCRolePgData),
+							utils.InstanceNameLabelName: "instance1",
+							// Common labels, overwritten
+							utils.KubernetesAppManagedByLabelName: "Helm",
+							utils.KubernetesAppLabelName:          "my-chart",
+							utils.KubernetesAppComponentLabelName: utils.DatabaseComponentName,
+						},
+						Annotations: map[string]string{},
+					},
+				}
+				reconciler := newLabelReconciler(cluster)
+
+				// A presence-only check would report this PVC as up-to-date and never
+				// repair it, leaving it outside the selector used to find the PVC to
+				// snapshot.
+				Expect(reconciler.isUpToDate(pvc)).To(BeFalse())
+
+				reconciler.update(pvc)
+
+				Expect(pvc.Labels).To(HaveKeyWithValue(utils.KubernetesAppManagedByLabelName, utils.ManagerName))
+				Expect(pvc.Labels).To(HaveKeyWithValue(utils.KubernetesAppLabelName, utils.AppName))
+				Expect(pvc.Labels).To(HaveKeyWithValue(utils.KubernetesAppComponentLabelName, utils.DatabaseComponentName))
+			})
+		})
 	})
 })


### PR DESCRIPTION
## Problem

`newLabelReconciler` writes the three common labels with the operator values inside `update`, but `isUpToDate` only checks that the labels exist:

```go
for _, label := range commonLabels {
    if _, found := pvc.Labels[label]; !found {
        return false
    }
}
```

If something overwrote `app.kubernetes.io/managed-by` or `app.kubernetes.io/name`, the keys are still there. So the PVC is considered up to date, `update` never runs, and the wrong value stays forever.

The most common way to get there is `spec.inheritedMetadata.labels`, because `Build()` applies the cluster inheritance after the calculator.

Since 1.28 those labels are part of the selector used to find the PVC to snapshot (`GetInstancePVCs` lists with the full map returned by `pgDataCalculator.GetLabels`). The result is a Backup with `method: volumeSnapshot` that stays in `status.phase: started` forever. No `VolumeSnapshot` is created, no error is reported, and nothing shows up in the logs, not even with `--log-level=debug`.

Closes #9920.

Also reported in #10364, which was closed by the stale bot without any human answer.

## Fix

`isUpToDate` now compares the value instead of the presence. `update` already sets the three labels to the operator values after inheriting, so nothing changes there. The reconciler simply starts repairing the PVCs that it skipped before.

## Effect

Broken PVCs are repaired on the next reconcile, with no action from the user.

We checked the manual equivalent on a live cluster. After correcting the labels, the Backup that was already stuck finished in less than a minute, with no need to delete it and no need to clean the replication slot.

## Test

The new unit case in `metadata_test.go` covers it: a PVC that has the three common labels but holds the values written by `inheritedMetadata` must not be considered up to date, and after `update` it must carry the operator values. It fails on `main` (`Expected to be false`) and passes with this change.

We also have an end to end reproduction (operator 1.28.1, GKE 1.35, pd.csi). Create a Cluster whose `inheritedMetadata` overwrites `managed-by` and `name`, wait for the operator to create the PVC, then fire a `volumeSnapshot` backup, and it gets stuck. Happy to contribute it as an e2e test if that is useful.

## Note on scope

This does not change the order inside `Build()`, so the PVC is still created with the overwritten values and repaired on the next reconcile. Changing the order too (inherit first, and then apply the calculator labels) would avoid that short moment, but it is a bigger change, and this one is enough to stop the silent failure.
