### PR TITLE
ci: exclude beta/rc versions from the Kind version check

### DIFF
--- a/.github/workflows/k8s-versions-check.yml
+++ b/.github/workflows/k8s-versions-check.yml
@@ -92,7 +92,7 @@ jobs:
           # and write them to a file, starting from the MINIMAL_K8S
           for baseversion in $(seq $MINIMAL_K8S 0.01 99); do
             URL="https://registry.hub.docker.com/v2/repositories/kindest/node/tags?name=${baseversion}&ordering=last_updated"
-            v=$(curl -SsL "${URL}" | jq -rc '.results[].name' | grep -v "alpha" | sort -Vr | head -n1) || RC=$?
+            v=$(curl -SsL "${URL}" | jq -rc '.results[].name' | grep -vE "alpha|beta|rc" | sort -Vr | head -n1) || RC=$?
             if [[ -z "${v}" ]]; then
                break
             fi


### PR DESCRIPTION
The kindest/node tag listing on Docker Hub only excluded alpha tags, so a beta or rc tag could sort above the latest stable release and get picked up as the "latest" Kind node version for a baseversion, producing an invalid entry in `kind_versions.json`.