### PR TITLE
fix: prevent plugin status field flapping on Cluster reconciliation

### DIFF
--- a/internal/controller/cluster_image.go
+++ b/internal/controller/cluster_image.go
@@ -27,7 +27,7 @@ import (
 	"github.com/cloudnative-pg/machinery/pkg/image/reference"
 	"github.com/cloudnative-pg/machinery/pkg/log"
 	"github.com/cloudnative-pg/machinery/pkg/postgres/version"
-	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/types"
@@ -159,12 +159,12 @@ func extensionsEqual(a, b []apiv1.ExtensionConfiguration) bool {
 
 func extensionConfigEqual(a, b apiv1.ExtensionConfiguration) bool {
 	return a.Name == b.Name &&
-		apiequality.Semantic.DeepEqual(a.ImageVolumeSource, b.ImageVolumeSource) &&
+		equality.Semantic.DeepEqual(a.ImageVolumeSource, b.ImageVolumeSource) &&
 		slices.Equal(a.ExtensionControlPath, b.ExtensionControlPath) &&
 		slices.Equal(a.DynamicLibraryPath, b.DynamicLibraryPath) &&
 		slices.Equal(a.LdLibraryPath, b.LdLibraryPath) &&
 		slices.Equal(a.BinPath, b.BinPath) &&
-		apiequality.Semantic.DeepEqual(a.Env, b.Env)
+		equality.Semantic.DeepEqual(a.Env, b.Env)
 }
 
 func (r *ClusterReconciler) getRequestedImageInfo(

--- a/internal/controller/cluster_plugins.go
+++ b/internal/controller/cluster_plugins.go
@@ -23,6 +23,7 @@ package controller
 import (
 	"context"
 	"reflect"
+	"slices"
 
 	"github.com/cloudnative-pg/machinery/pkg/log"
 	corev1 "k8s.io/api/core/v1"
@@ -49,6 +50,15 @@ func (r *ClusterReconciler) updatePluginsStatus(ctx context.Context, cluster *ap
 	metadataList := pluginClient.MetadataList()
 	cluster.Status.PluginStatus = make([]apiv1.PluginStatus, len(metadataList))
 	for i, entry := range metadataList {
+		// Check if this plugin already exists in the old cluster
+		if idx := slices.IndexFunc(oldCluster.Status.PluginStatus, func(p apiv1.PluginStatus) bool {
+			return p.Name == entry.Name
+		}); idx >= 0 {
+			// Save the old plugin status so we can carry it over as is without
+			// potentially rewriting fields (like .Status) that are not part of
+			// the plugin client's returned metadata
+			cluster.Status.PluginStatus[i] = oldCluster.Status.PluginStatus[idx]
+		}
 		cluster.Status.PluginStatus[i].Name = entry.Name
 		cluster.Status.PluginStatus[i].Version = entry.Version
 		cluster.Status.PluginStatus[i].Capabilities = entry.Capabilities

--- a/internal/controller/cluster_plugins.go
+++ b/internal/controller/cluster_plugins.go
@@ -22,12 +22,12 @@ package controller
 
 import (
 	"context"
-	"reflect"
 	"slices"
 
 	"github.com/cloudnative-pg/machinery/pkg/log"
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -69,7 +69,7 @@ func (r *ClusterReconciler) updatePluginsStatus(ctx context.Context, cluster *ap
 	}
 
 	// If nothing changes, there's no need to hit the API server
-	if reflect.DeepEqual(oldCluster.Status.PluginStatus, cluster.Status.PluginStatus) {
+	if apiequality.Semantic.DeepEqual(oldCluster.Status.PluginStatus, cluster.Status.PluginStatus) {
 		return nil
 	}
 

--- a/internal/controller/cluster_plugins.go
+++ b/internal/controller/cluster_plugins.go
@@ -39,13 +39,12 @@ import (
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 )
 
-// updatePluginsStatus ensures that we load the plugins that are required to reconcile
-// this cluster
+// updatePluginsStatus rebuilds cluster.Status.PluginStatus from the metadata
+// reported by the already-loaded plugins, then patches the cluster only if
+// something changed
 func (r *ClusterReconciler) updatePluginsStatus(ctx context.Context, cluster *apiv1.Cluster) error {
-	// Load the plugins
 	pluginClient := cnpgiclient.GetPluginClientFromContext(ctx)
 
-	// Get the status of the plugins and store it inside the status section
 	oldCluster := cluster.DeepCopy()
 	metadataList := pluginClient.MetadataList()
 	cluster.Status.PluginStatus = make([]apiv1.PluginStatus, len(metadataList))
@@ -54,9 +53,8 @@ func (r *ClusterReconciler) updatePluginsStatus(ctx context.Context, cluster *ap
 		if idx := slices.IndexFunc(oldCluster.Status.PluginStatus, func(p apiv1.PluginStatus) bool {
 			return p.Name == entry.Name
 		}); idx >= 0 {
-			// Save the old plugin status so we can carry it over as is without
-			// potentially rewriting fields (like .Status) that are not part of
-			// the plugin client's returned metadata
+			// Copy the old entry so .Status survives: it is not part of the
+			// plugin's metadata. Every field below overwrites this copy from entry.
 			cluster.Status.PluginStatus[i] = oldCluster.Status.PluginStatus[idx]
 		}
 		cluster.Status.PluginStatus[i].Name = entry.Name

--- a/internal/controller/cluster_plugins.go
+++ b/internal/controller/cluster_plugins.go
@@ -27,7 +27,7 @@ import (
 	"github.com/cloudnative-pg/machinery/pkg/log"
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
-	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/equality"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -69,7 +69,7 @@ func (r *ClusterReconciler) updatePluginsStatus(ctx context.Context, cluster *ap
 	}
 
 	// If nothing changes, there's no need to hit the API server
-	if apiequality.Semantic.DeepEqual(oldCluster.Status.PluginStatus, cluster.Status.PluginStatus) {
+	if equality.Semantic.DeepEqual(oldCluster.Status.PluginStatus, cluster.Status.PluginStatus) {
 		return nil
 	}
 

--- a/internal/controller/cluster_plugins_test.go
+++ b/internal/controller/cluster_plugins_test.go
@@ -28,15 +28,150 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	cnpgiclient "github.com/cloudnative-pg/cloudnative-pg/internal/cnpi/plugin/client"
+	"github.com/cloudnative-pg/cloudnative-pg/internal/cnpi/plugin/connection"
 	schemeBuilder "github.com/cloudnative-pg/cloudnative-pg/internal/scheme"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/utils"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
+
+var _ = Describe("updatePluginsStatus", func() {
+	const (
+		pluginName      = "test1_plugin"
+		otherPluginName = "test2_plugin"
+		pluginStatus    = `{"status": "testing"}`
+	)
+
+	var (
+		ctx           context.Context
+		cluster       *apiv1.Cluster
+		fakeClient    client.Client
+		pluginCli     *fakePluginClient
+		reconciler    *ClusterReconciler
+		statusPatches int
+	)
+
+	// metadataFor builds the metadata a loaded plugin reports.
+	metadataFor := func(names ...string) []connection.Metadata {
+		result := make([]connection.Metadata, len(names))
+		for i, name := range names {
+			result[i] = connection.Metadata{
+				Name:                       name,
+				Version:                    "0.0.1",
+				Capabilities:               []string{"TYPE_OPERATOR_SERVICE"},
+				OperatorCapabilities:       []string{"TYPE_SET_STATUS_IN_CLUSTER"},
+				WALCapabilities:            []string{},
+				BackupCapabilities:         []string{},
+				RestoreJobHookCapabilities: []string{},
+			}
+		}
+		return result
+	}
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		statusPatches = 0
+		cluster = &apiv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-cluster",
+				Namespace: "test-namespace",
+			},
+			Status: apiv1.ClusterStatus{
+				PluginStatus: []apiv1.PluginStatus{
+					{
+						Name:                 pluginName,
+						Version:              "0.0.1",
+						Capabilities:         []string{"TYPE_OPERATOR_SERVICE"},
+						OperatorCapabilities: []string{"TYPE_SET_STATUS_IN_CLUSTER"},
+						Status:               pluginStatus,
+					},
+				},
+			},
+		}
+
+		fakeClient = fake.NewClientBuilder().
+			WithObjects(cluster).
+			WithScheme(schemeBuilder.BuildWithAllKnownScheme()).
+			WithStatusSubresource(&apiv1.Cluster{}).
+			WithInterceptorFuncs(interceptor.Funcs{
+				SubResourcePatch: func(
+					ctx context.Context,
+					c client.Client,
+					subResourceName string,
+					obj client.Object,
+					patch client.Patch,
+					opts ...client.SubResourcePatchOption,
+				) error {
+					if subResourceName == "status" {
+						statusPatches++
+					}
+					return c.SubResource(subResourceName).Patch(ctx, obj, patch, opts...)
+				},
+			}).
+			Build()
+
+		pluginCli = &fakePluginClient{}
+		reconciler = &ClusterReconciler{Client: fakeClient}
+	})
+
+	It("preserves the status reported by the plugin across the rebuild", func() {
+		pluginCli.metadataList = metadataFor(pluginName)
+		ctx = cnpgiclient.SetPluginClientInContext(ctx, pluginCli)
+
+		Expect(reconciler.updatePluginsStatus(ctx, cluster)).To(Succeed())
+
+		Expect(cluster.Status.PluginStatus).To(HaveLen(1))
+		Expect(cluster.Status.PluginStatus[0].Name).To(Equal(pluginName))
+		Expect(cluster.Status.PluginStatus[0].Status).To(Equal(pluginStatus))
+
+		Expect(statusPatches).To(BeZero())
+	})
+
+	It("patches the status when the plugin metadata changed", func() {
+		pluginCli.metadataList = metadataFor(pluginName)
+		pluginCli.metadataList[0].Version = "0.0.2"
+		ctx = cnpgiclient.SetPluginClientInContext(ctx, pluginCli)
+
+		Expect(reconciler.updatePluginsStatus(ctx, cluster)).To(Succeed())
+
+		Expect(statusPatches).To(Equal(1))
+		Expect(cluster.Status.PluginStatus[0].Version).To(Equal("0.0.2"))
+		// A metadata change must not cost us the plugin-reported status.
+		Expect(cluster.Status.PluginStatus[0].Status).To(Equal(pluginStatus))
+	})
+
+	It("keeps each plugin's status with its own entry when a plugin is added", func() {
+		// The carry-over is by name, not by index, so a plugin appearing
+		// before the existing one in the sorted list must not shift statuses
+		// onto the wrong entry.
+		pluginCli.metadataList = metadataFor(otherPluginName, pluginName)
+		ctx = cnpgiclient.SetPluginClientInContext(ctx, pluginCli)
+
+		Expect(reconciler.updatePluginsStatus(ctx, cluster)).To(Succeed())
+
+		Expect(cluster.Status.PluginStatus).To(HaveLen(2))
+		Expect(cluster.Status.PluginStatus[0].Name).To(Equal(otherPluginName))
+		Expect(cluster.Status.PluginStatus[0].Status).To(BeEmpty())
+		Expect(cluster.Status.PluginStatus[1].Name).To(Equal(pluginName))
+		Expect(cluster.Status.PluginStatus[1].Status).To(Equal(pluginStatus))
+	})
+
+	It("drops the entry of a plugin that is no longer loaded", func() {
+		pluginCli.metadataList = metadataFor(otherPluginName)
+		ctx = cnpgiclient.SetPluginClientInContext(ctx, pluginCli)
+
+		Expect(reconciler.updatePluginsStatus(ctx, cluster)).To(Succeed())
+
+		Expect(cluster.Status.PluginStatus).To(HaveLen(1))
+		Expect(cluster.Status.PluginStatus[0].Name).To(Equal(otherPluginName))
+	})
+})
 
 var _ = Describe("mapPluginEndpointSlicesToClusters", func() {
 	const (

--- a/internal/controller/cluster_plugins_test.go
+++ b/internal/controller/cluster_plugins_test.go
@@ -162,6 +162,22 @@ var _ = Describe("updatePluginsStatus", func() {
 		Expect(cluster.Status.PluginStatus[1].Status).To(Equal(pluginStatus))
 	})
 
+	It("drops the field if it does not exist in the metadata", func() {
+		pluginCli.metadataList = metadataFor(pluginName)
+		// OperatorCapabilities is empty in the metadata
+		pluginCli.metadataList[0].OperatorCapabilities = []string{}
+
+		ctx = cnpgiclient.SetPluginClientInContext(ctx, pluginCli)
+
+		Expect(reconciler.updatePluginsStatus(ctx, cluster)).To(Succeed())
+
+		Expect(cluster.Status.PluginStatus).To(HaveLen(1))
+		Expect(cluster.Status.PluginStatus[0].Name).To(Equal(pluginName))
+		Expect(cluster.Status.PluginStatus[0].Status).To(Equal(pluginStatus))
+		Expect(cluster.Status.PluginStatus[0].OperatorCapabilities).To(BeEmpty())
+		Expect(cluster.Status.PluginStatus[0].Capabilities).To(HaveLen(1))
+	})
+
 	It("drops the entry of a plugin that is no longer loaded", func() {
 		pluginCli.metadataList = metadataFor(otherPluginName)
 		ctx = cnpgiclient.SetPluginClientInContext(ctx, pluginCli)

--- a/internal/controller/plugins.go
+++ b/internal/controller/plugins.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/cloudnative-pg/machinery/pkg/log"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -77,15 +78,18 @@ func setStatusPluginHook(
 		plugin.Status = val
 	}
 
-	contextLogger.Info("patching cluster status with the updated plugin statuses")
-	contextLogger.Debug("diff detected",
-		"before", origCluster.Status.PluginStatus,
-		"after", cluster.Status.PluginStatus,
-	)
-
-	if err := cli.Status().Patch(ctx, cluster, client.MergeFrom(origCluster)); err != nil {
-		return ctrl.Result{}, err
+	if !apiequality.Semantic.DeepEqual(origCluster.Status.PluginStatus, cluster.Status.PluginStatus) {
+		contextLogger.Info("patching cluster status with the updated plugin statuses")
+		contextLogger.Debug("diff detected",
+			"before", origCluster.Status.PluginStatus,
+			"after", cluster.Status.PluginStatus,
+		)
+		if err := cli.Status().Patch(ctx, cluster, client.MergeFrom(origCluster)); err != nil {
+			return ctrl.Result{}, err
+		}
 	}
+
+	// Requeue unconditionally to ensure the plugin always has a chance to set the status
 	return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 }
 

--- a/internal/controller/plugins.go
+++ b/internal/controller/plugins.go
@@ -89,7 +89,7 @@ func setStatusPluginHook(
 		}
 	}
 
-	// Requeue unconditionally to ensure the plugin always has a chance to set the status
+	// Requeue in 5s regardless of the patch above, to keep polling the plugin's status
 	return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 }
 

--- a/internal/controller/plugins.go
+++ b/internal/controller/plugins.go
@@ -25,7 +25,7 @@ import (
 	"time"
 
 	"github.com/cloudnative-pg/machinery/pkg/log"
-	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/equality"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -78,7 +78,7 @@ func setStatusPluginHook(
 		plugin.Status = val
 	}
 
-	if !apiequality.Semantic.DeepEqual(origCluster.Status.PluginStatus, cluster.Status.PluginStatus) {
+	if !equality.Semantic.DeepEqual(origCluster.Status.PluginStatus, cluster.Status.PluginStatus) {
 		contextLogger.Info("patching cluster status with the updated plugin statuses")
 		contextLogger.Debug("diff detected",
 			"before", origCluster.Status.PluginStatus,

--- a/internal/controller/plugins.go
+++ b/internal/controller/plugins.go
@@ -103,8 +103,8 @@ func setStatusPluginHook(
 // oscillating Phase between Healthy and the error phase. See #8582.
 //
 // The result is propagated from the underlying plugin operations so any
-// requeue they request (notably the 5s polling from setStatusPluginHook
-// after a successful status patch) is honored alongside the Healthy
+// requeue they request (notably the 5s polling setStatusPluginHook asks for
+// whenever a plugin reports a status) is honored alongside the Healthy
 // registration.
 func (r *ClusterReconciler) finalizeReconciliation(
 	ctx context.Context,

--- a/internal/controller/plugins_test.go
+++ b/internal/controller/plugins_test.go
@@ -32,6 +32,7 @@ import (
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	pluginClient "github.com/cloudnative-pg/cloudnative-pg/internal/cnpi/plugin/client"
+	"github.com/cloudnative-pg/cloudnative-pg/internal/cnpi/plugin/connection"
 	"github.com/cloudnative-pg/cloudnative-pg/internal/scheme"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -44,6 +45,7 @@ type fakePluginClient struct {
 	setClusterStatusErr      error
 	setStatusInClusterCalled bool
 	postReconcileResult      pluginClient.ReconcilerHookResult
+	metadataList             []connection.Metadata
 }
 
 func (f *fakePluginClient) SetStatusInCluster(
@@ -60,6 +62,10 @@ func (f *fakePluginClient) PostReconcile(
 	_ k8client.Object,
 ) pluginClient.ReconcilerHookResult {
 	return f.postReconcileResult
+}
+
+func (f *fakePluginClient) MetadataList() []connection.Metadata {
+	return f.metadataList
 }
 
 var _ = Describe("setStatusPluginHook", func() {

--- a/internal/controller/plugins_test.go
+++ b/internal/controller/plugins_test.go
@@ -158,8 +158,8 @@ var _ = Describe("finalizeReconciliation", func() {
 	})
 
 	It("registers PhaseHealthy and propagates the requeue when plugins patch their statuses", func(ctx SpecContext) {
-		// setStatusPluginHook returns RequeueAfter=5s on every successful
-		// status patch. That requeue must NOT short-circuit the PhaseHealthy
+		// setStatusPluginHook returns RequeueAfter=5s whenever a plugin
+		// reports a status. That requeue must NOT short-circuit the PhaseHealthy
 		// registration: clusters with status-reporting plugins (e.g.
 		// barman-cloud) requeue every 5s in steady state and would otherwise
 		// never reach Healthy.

--- a/internal/controller/plugins_test.go
+++ b/internal/controller/plugins_test.go
@@ -29,6 +29,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	k8client "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	pluginClient "github.com/cloudnative-pg/cloudnative-pg/internal/cnpi/plugin/client"
@@ -71,13 +72,14 @@ func (f *fakePluginClient) MetadataList() []connection.Metadata {
 var _ = Describe("setStatusPluginHook", func() {
 	const pluginName = "test1_plugin"
 	var (
-		cluster   *apiv1.Cluster
-		cli       k8client.Client
-		pluginCli *fakePluginClient
+		cluster       *apiv1.Cluster
+		cli           k8client.Client
+		pluginCli     *fakePluginClient
+		statusPatches int
 	)
 
-	BeforeEach(func() {
-		cluster = &apiv1.Cluster{
+	newCluster := func(reportedStatus string) *apiv1.Cluster {
+		return &apiv1.Cluster{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test",
 				Namespace: "test-suite",
@@ -85,17 +87,43 @@ var _ = Describe("setStatusPluginHook", func() {
 			Status: apiv1.ClusterStatus{
 				PluginStatus: []apiv1.PluginStatus{
 					{
-						Name: pluginName,
+						Name:   pluginName,
+						Status: reportedStatus,
 					},
 				},
 			},
 		}
-		cli = fake.NewClientBuilder().
+	}
+
+	// newClient counts the status patches reaching the API server, so a spec
+	// can tell "converged" from "written again with the same content".
+	newClient := func(cluster *apiv1.Cluster) k8client.Client {
+		return fake.NewClientBuilder().
 			WithObjects(cluster).
 			WithScheme(scheme.BuildWithAllKnownScheme()).
 			WithStatusSubresource(&apiv1.Cluster{}).
+			WithInterceptorFuncs(interceptor.Funcs{
+				SubResourcePatch: func(
+					ctx context.Context,
+					c k8client.Client,
+					subResourceName string,
+					obj k8client.Object,
+					patch k8client.Patch,
+					opts ...k8client.SubResourcePatchOption,
+				) error {
+					if subResourceName == "status" {
+						statusPatches++
+					}
+					return c.SubResource(subResourceName).Patch(ctx, obj, patch, opts...)
+				},
+			}).
 			Build()
+	}
 
+	BeforeEach(func() {
+		statusPatches = 0
+		cluster = newCluster("")
+		cli = newClient(cluster)
 		pluginCli = &fakePluginClient{}
 	})
 
@@ -107,6 +135,24 @@ var _ = Describe("setStatusPluginHook", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(res).ToNot(BeNil())
 		Expect(cluster.Status.PluginStatus[0].Status).To(BeEquivalentTo(string(content)))
+		Expect(statusPatches).To(Equal(1))
+	})
+
+	It("does not patch when the plugin reports the status already stored", func(ctx SpecContext) {
+		// The other half of the flapping loop: re-writing an unchanged status
+		// wakes the reconciler through its own Cluster watch, which has no
+		// predicate, so the loop sustains itself.
+		const content = `{"key":"value"}`
+		cluster = newCluster(content)
+		cli = newClient(cluster)
+		pluginCli.setClusterStatus = map[string]string{pluginName: content}
+
+		res, err := setStatusPluginHook(ctx, cli, pluginCli, cluster)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(statusPatches).To(BeZero())
+		// Converging must not stop the polling of the reporting plugin.
+		Expect(res.RequeueAfter).To(Equal(5 * time.Second))
 	})
 })
 


### PR DESCRIPTION
Two bugs caused the flap.

`updatePluginsStatus` rebuilds the plugin status slice every reconcile but drops `.Status`. The slice always looks different from before, so it patches every time.

`setStatusPluginHook` patches the status without checking if it changed, and always requeues. Each patch wakes the other function's reconcile, since the Cluster watch has no predicate. Neither loop stops.

Copying `.Status` forward is not enough by itself. Plugin metadata reports empty capability lists as `[]string{}`, but after a round trip through the API server they come back as `nil`. Plain `reflect.DeepEqual` treats that as a change. Switching both checks to `equality.Semantic.DeepEqual`, which treats nil and empty as equal, closes that gap.

Closes #11385

Assisted-by: Claude