### PR TITLE
fix(docs): make warning in the standalone replica cluster more specific

### DIFF
--- a/docs/src/replica_cluster.md
+++ b/docs/src/replica_cluster.md
@@ -407,9 +407,7 @@ continuous recovery mode and becomes a primary cluster, completely detached
 from the original source.
 
 :::warning
-    Disabling replication is an **irreversible** operation. Once replication is
-    disabled and the designated primary is promoted to primary, the replica cluster
-    and the source cluster become two independent clusters definitively.
+    Disabling replication is an **irreversible** operation. Once replication is disabled and the designated primary instance in the replica cluster is promoted to primary, the replica cluster and the source cluster become two independent clusters definitively.
 :::
 
 :::info[Important]


### PR DESCRIPTION
Fix the wording in the warning for standalone replica clusters.

The current text refers to the **“designated primary”** being promoted to primary, which can be misleading because the operation is performed on the **replica cluster**. Disabling replication promotes the replica cluster to become an independent primary cluster.

Update the wording to make this distinction clear and avoid confusion between the source cluster's primary and the primary instance within the replica cluster.
