### PR TITLE
chore(deps): pin go toolchain to 1.27.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/cloudnative-pg/cloudnative-pg
 
 go 1.26.6
 
+toolchain go1.27.1
+
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/Masterminds/semver/v3 v3.5.0

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -2,6 +2,8 @@ module github.com/cloudnative-pg/cloudnative-pg/tests
 
 go 1.26.6
 
+toolchain go1.27.1
+
 replace github.com/cloudnative-pg/cloudnative-pg => ../
 
 require (


### PR DESCRIPTION
Add a toolchain directive to go.mod and tests/go.mod so builds use
go1.27.1 regardless of the locally installed go version.