### PR TITLE
fix(logpipe): do not block threads on log FIFOs

### DIFF
--- a/pkg/management/postgres/logpipe/linelogpipe.go
+++ b/pkg/management/postgres/logpipe/linelogpipe.go
@@ -149,7 +149,7 @@ func (p *LineLogPipe) collectLogsFromFile(ctx context.Context) error {
 		}
 	}()
 
-	f, err := fileutils.OpenFileAsync(ctx, p.fileName, os.O_RDONLY, 0o600)
+	f, err := fileutils.OpenFileAsync(ctx, p.fileName, os.O_RDWR, 0o600)
 	if err != nil {
 		return err
 	}

--- a/pkg/management/postgres/logpipe/logpipe.go
+++ b/pkg/management/postgres/logpipe/logpipe.go
@@ -141,7 +141,7 @@ func (p *LogPipe) collectLogsFromFile(ctx context.Context) error {
 		}
 	}()
 
-	f, err := fileutils.OpenFileAsync(ctx, p.fileName, os.O_RDONLY, 0o600)
+	f, err := fileutils.OpenFileAsync(ctx, p.fileName, os.O_RDWR, 0o600)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION

Since #10043, WithActiveInstance starts the raw and JSON log pipes
during bootstrap (initdb, join, restore). Their readers open the
postgres.csv and postgres.json FIFOs with a blocking open(2), which the
kernel parks until a writer connects.

During an initdb bootstrap postgres logs to csvlog only, so nothing
ever opens the raw and JSON FIFOs for write. OpenFileAsync returns on
context cancellation, but the goroutine it spawned inside os.OpenFile
stays blocked in the kernel forever, pinning an OS thread that the Go
runtime cannot reclaim.

Open the FIFOs non-blockingly, so a cancelled context can no longer
strand a thread in the kernel.

Fixes #11436.