### PR TITLE
fix(bootstrap): wait for certificate status before refreshing secrets

### DIFF
--- a/internal/cmd/manager/instance/join/cmd.go
+++ b/internal/cmd/manager/instance/join/cmd.go
@@ -47,12 +47,6 @@ func NewCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use: "join [options]",
-		PreRunE: func(cmd *cobra.Command, _ []string) error {
-			return management.WaitForGetCluster(cmd.Context(), ctrl.ObjectKey{
-				Name:      clusterName,
-				Namespace: namespace,
-			})
-		},
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := cmd.Context()
 			// The fields in the instance are needed to correctly
@@ -104,6 +98,16 @@ func joinSubCommand(ctx context.Context, instance *postgres.Instance, info postg
 	client, err := management.NewControllerRuntimeClient()
 	if err != nil {
 		contextLogger.Error(err, "Error creating Kubernetes client")
+		return err
+	}
+
+	// Bootstrap can start before the operator writes Status.Certificates.
+	// Wait for it here. This also retries a failed Get, so the old
+	// PreRunE call to WaitForGetCluster is gone.
+	if err := management.WaitForClusterCertificates(ctx, client, ctrl.ObjectKey{
+		Namespace: instance.GetNamespaceName(), Name: instance.GetClusterName(),
+	}); err != nil {
+		contextLogger.Error(err, "Error while waiting for the certificate status")
 		return err
 	}
 

--- a/internal/cmd/manager/instance/join/cmd.go
+++ b/internal/cmd/manager/instance/join/cmd.go
@@ -28,7 +28,6 @@ import (
 	"github.com/spf13/cobra"
 	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
 
-	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/cloudnative-pg/internal/management/istio"
 	"github.com/cloudnative-pg/cloudnative-pg/internal/management/linkerd"
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/management"
@@ -101,34 +100,25 @@ func joinSubCommand(ctx context.Context, instance *postgres.Instance, info postg
 		return err
 	}
 
-	// Bootstrap can start before the operator writes Status.Certificates.
-	// Wait for it here. This also retries a failed Get, so the old
-	// PreRunE call to WaitForGetCluster is gone.
-	if err := management.WaitForClusterCertificates(ctx, client, ctrl.ObjectKey{
+	// Bootstrap starts as soon as the Pod does, often before the operator
+	// writes the certificate status. Use the Cluster this call returns; see
+	// WaitForClusterCertificates for why.
+	cluster, err := management.WaitForClusterCertificates(ctx, client, ctrl.ObjectKey{
 		Namespace: instance.GetNamespaceName(), Name: instance.GetClusterName(),
-	}); err != nil {
+	})
+	if err != nil {
 		contextLogger.Error(err, "Error while waiting for the certificate status")
 		return err
 	}
+	instance.SetCluster(cluster)
 
-	// Download the cluster definition from the API server
-	var cluster apiv1.Cluster
-	if err := client.Get(ctx,
-		ctrl.ObjectKey{Namespace: instance.GetNamespaceName(), Name: instance.GetClusterName()},
-		&cluster,
-	); err != nil {
-		contextLogger.Error(err, "Error while getting cluster")
-		return err
-	}
-	instance.SetCluster(&cluster)
-
-	if _, err := instancecertificate.NewReconciler(client, instance).RefreshSecrets(ctx, &cluster); err != nil {
+	if _, err := instancecertificate.NewReconciler(client, instance).RefreshSecrets(ctx, cluster); err != nil {
 		contextLogger.Error(err, "Error while refreshing secrets")
 		return err
 	}
 
 	// Run "pg_basebackup" to download the data directory from the primary
-	if err := info.Join(ctx, &cluster); err != nil {
+	if err := info.Join(ctx, cluster); err != nil {
 		contextLogger.Error(err, "Error joining node")
 		return err
 	}

--- a/internal/cmd/manager/instance/upgrade/execute/cmd.go
+++ b/internal/cmd/manager/instance/upgrade/execute/cmd.go
@@ -155,8 +155,12 @@ func (ui upgradeInfo) upgradeSubCommand(ctx context.Context, instance *postgres.
 	}
 
 	clusterObjectKey := ctrl.ObjectKey{Name: instance.GetClusterName(), Namespace: instance.GetNamespaceName()}
-	if err = management.WaitForGetClusterWithClient(ctx, client, clusterObjectKey); err != nil {
-		return err
+
+	// Bootstrap can start before the operator writes Status.Certificates.
+	// Wait for it here. This also retries a failed Get, so the old
+	// WaitForGetClusterWithClient call is gone.
+	if err := management.WaitForClusterCertificates(ctx, client, clusterObjectKey); err != nil {
+		return fmt.Errorf("error while waiting for the certificate status: %w", err)
 	}
 
 	// Download the cluster definition from the API server

--- a/internal/cmd/manager/instance/upgrade/execute/cmd.go
+++ b/internal/cmd/manager/instance/upgrade/execute/cmd.go
@@ -156,26 +156,20 @@ func (ui upgradeInfo) upgradeSubCommand(ctx context.Context, instance *postgres.
 
 	clusterObjectKey := ctrl.ObjectKey{Name: instance.GetClusterName(), Namespace: instance.GetNamespaceName()}
 
-	// Bootstrap can start before the operator writes Status.Certificates.
-	// Wait for it here. This also retries a failed Get, so the old
-	// WaitForGetClusterWithClient call is gone.
-	if err := management.WaitForClusterCertificates(ctx, client, clusterObjectKey); err != nil {
+	// This runs in the major upgrade Job, which may start before the operator
+	// writes the certificate status. Use the Cluster this call returns; see
+	// WaitForClusterCertificates for why.
+	cluster, err := management.WaitForClusterCertificates(ctx, client, clusterObjectKey)
+	if err != nil {
 		return fmt.Errorf("error while waiting for the certificate status: %w", err)
 	}
+	instance.SetCluster(cluster)
 
-	// Download the cluster definition from the API server
-	var cluster apiv1.Cluster
-	if err := client.Get(ctx, clusterObjectKey, &cluster); err != nil {
-		contextLogger.Error(err, "Error while getting cluster")
-		return err
-	}
-	instance.SetCluster(&cluster)
-
-	if err := setupExtensionEnvironment(&cluster); err != nil {
+	if err := setupExtensionEnvironment(cluster); err != nil {
 		return fmt.Errorf("error while setting up extension environment: %w", err)
 	}
 
-	if _, err := instancecertificate.NewReconciler(client, instance).RefreshSecrets(ctx, &cluster); err != nil {
+	if _, err := instancecertificate.NewReconciler(client, instance).RefreshSecrets(ctx, cluster); err != nil {
 		return fmt.Errorf("error while downloading secrets: %w", err)
 	}
 
@@ -239,7 +233,7 @@ func (ui upgradeInfo) upgradeSubCommand(ctx context.Context, instance *postgres.
 	}
 
 	contextLogger.Info("Preparing configuration files", "directory", newDataDir)
-	if err := prepareConfigurationFiles(ctx, cluster, newDataDir); err != nil {
+	if err := prepareConfigurationFiles(ctx, *cluster, newDataDir); err != nil {
 		return err
 	}
 

--- a/pkg/management/client.go
+++ b/pkg/management/client.go
@@ -165,3 +165,23 @@ func WaitForGetClusterWithClient(ctx context.Context, cli client.Client, cluster
 
 	return nil
 }
+
+// WaitForClusterCertificates waits until the operator writes the
+// certificate secret names in Cluster.Status.Certificates. It has no
+// time limit, because we do not know how long that reconcile takes.
+func WaitForClusterCertificates(ctx context.Context, cli client.Client, clusterObjectKey client.ObjectKey) error {
+	logger := log.FromContext(ctx).WithName("wait-for-cluster-certificates")
+
+	return wait.PollUntilContextCancel(ctx, time.Second, true, func(ctx context.Context) (bool, error) {
+		var cluster apiv1.Cluster
+		if err := cli.Get(ctx, clusterObjectKey, &cluster); err != nil {
+			logger.Warning("Encountered an error while checking certificate status. Will retry", "error", err.Error())
+			return false, nil
+		}
+		if cluster.Status.Certificates.ServerTLSSecret == "" {
+			logger.Info("Waiting for the operator to write the certificate status")
+			return false, nil
+		}
+		return true, nil
+	})
+}

--- a/pkg/management/client.go
+++ b/pkg/management/client.go
@@ -166,22 +166,45 @@ func WaitForGetClusterWithClient(ctx context.Context, cli client.Client, cluster
 	return nil
 }
 
-// WaitForClusterCertificates waits until the operator writes the
-// certificate secret names in Cluster.Status.Certificates. It has no
-// time limit, because we do not know how long that reconcile takes.
-func WaitForClusterCertificates(ctx context.Context, cli client.Client, clusterObjectKey client.ObjectKey) error {
-	logger := log.FromContext(ctx).WithName("wait-for-cluster-certificates")
+// WaitForClusterCertificates polls the Cluster until its status has the
+// certificate secret names, then returns it. Use the returned Cluster: a new
+// Get can come back with an older copy, with the names empty again.
+//
+// The wait has no time limit. The operator never waits on this Pod before
+// writing the status, so this wait cannot block that write.
+func WaitForClusterCertificates(
+	ctx context.Context,
+	cli client.Client,
+	clusterObjectKey client.ObjectKey,
+) (*apiv1.Cluster, error) {
+	logger := log.FromContext(ctx).WithName("wait-for-cluster-certificates").WithValues(
+		"cluster", clusterObjectKey.Name,
+		"namespace", clusterObjectKey.Namespace)
 
-	return wait.PollUntilContextCancel(ctx, time.Second, true, func(ctx context.Context) (bool, error) {
-		var cluster apiv1.Cluster
+	var cluster apiv1.Cluster
+	var waiting bool
+
+	if err := wait.PollUntilContextCancel(ctx, time.Second, true, func(ctx context.Context) (bool, error) {
+		// Reset first: Get only overwrites fields present in the response,
+		// so a stale value could survive from the previous attempt.
+		cluster = apiv1.Cluster{}
 		if err := cli.Get(ctx, clusterObjectKey, &cluster); err != nil {
 			logger.Warning("Encountered an error while checking certificate status. Will retry", "error", err.Error())
 			return false, nil
 		}
 		if cluster.Status.Certificates.ServerTLSSecret == "" {
-			logger.Info("Waiting for the operator to write the certificate status")
+			// Log once: this can run for a long time, one line per second
+			// would flood the log with nothing new to say.
+			if !waiting {
+				waiting = true
+				logger.Info("Waiting for the operator to write the certificate status")
+			}
 			return false, nil
 		}
 		return true, nil
-	})
+	}); err != nil {
+		return nil, err
+	}
+
+	return &cluster, nil
 }

--- a/pkg/management/client_test.go
+++ b/pkg/management/client_test.go
@@ -21,11 +21,13 @@ package management
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 
@@ -34,33 +36,100 @@ import (
 )
 
 var _ = Describe("waiting for the certificate status", func() {
+	const serverTLSSecret = "cluster-server"
+
 	clusterObjectKey := client.ObjectKey{Namespace: "default", Name: "cluster"}
 
-	It("returns immediately once the certificate status is populated", func(ctx SpecContext) {
-		cluster := &apiv1.Cluster{
+	newCluster := func() *apiv1.Cluster {
+		return &apiv1.Cluster{
 			ObjectMeta: metav1.ObjectMeta{Namespace: clusterObjectKey.Namespace, Name: clusterObjectKey.Name},
-			Status: apiv1.ClusterStatus{
-				Certificates: apiv1.CertificatesStatus{
-					CertificatesConfiguration: apiv1.CertificatesConfiguration{
-						ServerTLSSecret: "cluster-server",
-					},
-				},
-			},
 		}
-		cli := fake.NewClientBuilder().WithScheme(Scheme).WithObjects(cluster).Build()
+	}
 
-		Expect(WaitForClusterCertificates(ctx, cli, clusterObjectKey)).To(Succeed())
+	withCertificates := func(cluster *apiv1.Cluster) *apiv1.Cluster {
+		cluster.Status.Certificates.ServerTLSSecret = serverTLSSecret
+		return cluster
+	}
+
+	// Bound the wait: specs have no timeout of their own, so a broken
+	// implementation would hang the whole suite instead of just failing.
+	boundedContext := func(ctx context.Context) context.Context {
+		waitCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		DeferCleanup(cancel)
+		return waitCtx
+	}
+
+	It("returns the Cluster it found the certificates in, without polling", func(ctx SpecContext) {
+		cli := fake.NewClientBuilder().WithScheme(Scheme).WithObjects(withCertificates(newCluster())).Build()
+
+		start := time.Now()
+		cluster, err := WaitForClusterCertificates(boundedContext(ctx), cli, clusterObjectKey)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(time.Since(start)).To(BeNumerically("<", time.Second))
+		Expect(cluster.Name).To(Equal(clusterObjectKey.Name))
+		Expect(cluster.Status.Certificates.ServerTLSSecret).To(Equal(serverTLSSecret))
 	})
 
-	It("keeps waiting, and gives up when the context is done, while the status is unset", func(ctx SpecContext) {
-		cluster := &apiv1.Cluster{
-			ObjectMeta: metav1.ObjectMeta{Namespace: clusterObjectKey.Namespace, Name: clusterObjectKey.Name},
-		}
-		cli := fake.NewClientBuilder().WithScheme(Scheme).WithObjects(cluster).Build()
+	It("keeps reading until the certificate status appears", func(ctx SpecContext) {
+		var reads int
+		cli := fake.NewClientBuilder().
+			WithScheme(Scheme).
+			WithObjects(newCluster()).
+			WithInterceptorFuncs(interceptor.Funcs{
+				Get: func(ctx context.Context, cl client.WithWatch, key client.ObjectKey,
+					obj client.Object, opts ...client.GetOption,
+				) error {
+					if err := cl.Get(ctx, key, obj, opts...); err != nil {
+						return err
+					}
+					// Simulate the status showing up after the first read.
+					reads++
+					if reads > 1 {
+						withCertificates(obj.(*apiv1.Cluster))
+					}
+					return nil
+				},
+			}).
+			Build()
+
+		cluster, err := WaitForClusterCertificates(boundedContext(ctx), cli, clusterObjectKey)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(reads).To(BeNumerically(">", 1))
+		Expect(cluster.Status.Certificates.ServerTLSSecret).To(Equal(serverTLSSecret))
+	})
+
+	It("retries a failed read instead of giving up on it", func(ctx SpecContext) {
+		var reads int
+		cli := fake.NewClientBuilder().
+			WithScheme(Scheme).
+			WithObjects(withCertificates(newCluster())).
+			WithInterceptorFuncs(interceptor.Funcs{
+				Get: func(ctx context.Context, cl client.WithWatch, key client.ObjectKey,
+					obj client.Object, opts ...client.GetOption,
+				) error {
+					reads++
+					if reads == 1 {
+						return errors.New("the API server is not reachable")
+					}
+					return cl.Get(ctx, key, obj, opts...)
+				},
+			}).
+			Build()
+
+		cluster, err := WaitForClusterCertificates(boundedContext(ctx), cli, clusterObjectKey)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(reads).To(BeNumerically(">", 1))
+		Expect(cluster.Status.Certificates.ServerTLSSecret).To(Equal(serverTLSSecret))
+	})
+
+	It("gives up when the context is done, while the status is unset", func(ctx SpecContext) {
+		cli := fake.NewClientBuilder().WithScheme(Scheme).WithObjects(newCluster()).Build()
 
 		waitCtx, cancel := context.WithTimeout(ctx, 50*time.Millisecond)
 		defer cancel()
 
-		Expect(WaitForClusterCertificates(waitCtx, cli, clusterObjectKey)).ToNot(Succeed())
+		cluster, err := WaitForClusterCertificates(waitCtx, cli, clusterObjectKey)
+		Expect(err).To(HaveOccurred())
+		Expect(cluster).To(BeNil())
 	})
 })

--- a/pkg/management/client_test.go
+++ b/pkg/management/client_test.go
@@ -1,0 +1,66 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package management
+
+import (
+	"context"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	apiv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("waiting for the certificate status", func() {
+	clusterObjectKey := client.ObjectKey{Namespace: "default", Name: "cluster"}
+
+	It("returns immediately once the certificate status is populated", func(ctx SpecContext) {
+		cluster := &apiv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{Namespace: clusterObjectKey.Namespace, Name: clusterObjectKey.Name},
+			Status: apiv1.ClusterStatus{
+				Certificates: apiv1.CertificatesStatus{
+					CertificatesConfiguration: apiv1.CertificatesConfiguration{
+						ServerTLSSecret: "cluster-server",
+					},
+				},
+			},
+		}
+		cli := fake.NewClientBuilder().WithScheme(Scheme).WithObjects(cluster).Build()
+
+		Expect(WaitForClusterCertificates(ctx, cli, clusterObjectKey)).To(Succeed())
+	})
+
+	It("keeps waiting, and gives up when the context is done, while the status is unset", func(ctx SpecContext) {
+		cluster := &apiv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{Namespace: clusterObjectKey.Namespace, Name: clusterObjectKey.Name},
+		}
+		cli := fake.NewClientBuilder().WithScheme(Scheme).WithObjects(cluster).Build()
+
+		waitCtx, cancel := context.WithTimeout(ctx, 50*time.Millisecond)
+		defer cancel()
+
+		Expect(WaitForClusterCertificates(waitCtx, cli, clusterObjectKey)).ToNot(Succeed())
+	})
+})

--- a/pkg/management/suite_test.go
+++ b/pkg/management/suite_test.go
@@ -1,0 +1,32 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package management
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestManagement(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Management Suite")
+}


### PR DESCRIPTION
Since #11319, bootstrap runs in an init container. It can start
before the operator writes Status.Certificates. When that happens,
RefreshSecrets reads an empty secret name and fails right away with
"resource name may not be empty". The container crashes, and only a
restart can fix it, and even that does not always help.

Now join and upgrade wait for Status.Certificates first, with no
time limit. This also replaces their old WaitForGetCluster call,
since the new wait already retries a failed Get too.

The main container's own reconcile loop already retries forever on
this same error before it starts PostgreSQL, so it needs no change.

Closes #11446