### PR TITLE
chore(ci): declare .PHONY for all non-file make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,6 +103,7 @@ endif
 SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
 
+.PHONY: all
 all: build
 
 ##@ General
@@ -118,15 +119,18 @@ all: build
 # More info on the awk command:
 # http://linuxcommand.org/lc3_adv_awk.php
 
+.PHONY: help
 help: ## Display this help.
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
 ##@ Development
 
+.PHONY: print-version
 print-version:
 	echo ${VERSION}
 
 ENVTEST_ASSETS_DIR=$$(pwd)/testbin
+.PHONY: test
 test: generate fmt vet manifests envtest ## Run tests.
 	mkdir -p ${ENVTEST_ASSETS_DIR} ;\
 	source <(${ENVTEST} use -p env --bin-dir ${ENVTEST_ASSETS_DIR} ${ENVTEST_K8S_VERSION}) ;\
@@ -135,6 +139,7 @@ test: generate fmt vet manifests envtest ## Run tests.
 	go test -coverpkg=./... -coverprofile=cover.out ./api/... ./cmd/... ./internal/... ./pkg/...
 	cd tests && go test -coverpkg=./... -coverprofile=cover.out ./utils/...
 
+.PHONY: test-race
 test-race: generate fmt vet manifests envtest ## Run tests enabling race detection.
 	mkdir -p ${ENVTEST_ASSETS_DIR} ;\
 	source <(${ENVTEST} use -p env --bin-dir ${ENVTEST_ASSETS_DIR} ${ENVTEST_K8S_VERSION}) ;\
@@ -161,36 +166,47 @@ fuzz: ## Run every native fuzz target discovered in the tree.
 	done <<< "$$pairs" ;\
 	exit $$rc
 
+.PHONY: e2e-test-kind
 e2e-test-kind: ## Run e2e tests locally using kind.
 	CLUSTER_ENGINE=kind hack/e2e/run-e2e-local.sh
 
+.PHONY: e2e-test-k3d
 e2e-test-k3d: ## Run e2e tests locally using k3d.
 	CLUSTER_ENGINE=k3d hack/e2e/run-e2e-local.sh
 
+.PHONY: e2e-test-existing-cluster
 e2e-test-existing-cluster: ## Run e2e tests using the default kubernetes context.
 	hack/e2e/run-e2e-suite.sh
 
 ##@ Build
+.PHONY: build
 build: generate fmt vet build-manager build-plugin ## Build binaries.
 
+.PHONY: build-manager
 build-manager: generate fmt vet ## Build manager binary.
 	go build -o bin/manager -ldflags ${LDFLAGS} ./cmd/manager
 
+.PHONY: build-plugin
 build-plugin: generate fmt vet ## Build plugin binary.
 	go build -o bin/kubectl-cnpg -ldflags ${LDFLAGS} ./cmd/kubectl-cnpg
 
+.PHONY: build-race
 build-race: generate fmt vet build-manager-race build-plugin-race ## Build the binaries adding the -race option.
 
+.PHONY: build-manager-race
 build-manager-race: generate fmt vet ## Build manager binary with -race option.
 	go build -race -o bin/manager -ldflags ${LDFLAGS} ./cmd/manager
 
+.PHONY: build-plugin-race
 build-plugin-race: generate fmt vet ## Build plugin binary.
 	go build -race -o bin/kubectl-cnpg -ldflags ${LDFLAGS} ./cmd/kubectl-cnpg
 
 
+.PHONY: run
 run: generate fmt vet manifests ## Run against the configured Kubernetes cluster in ~/.kube/config.
 	go run ./cmd/manager
 
+.PHONY: docker-build
 docker-build: go-releaser ## Build the docker image.
 	GOOS=linux GOARCH=${ARCH} GOPATH=$(go env GOPATH) DATE=${DATE} COMMIT=${COMMIT} VERSION=${VERSION} \
 	  $(GO_RELEASER) build --skip=validate --clean --single-target $(if $(VERSION),,--snapshot); \
@@ -203,6 +219,7 @@ docker-build: go-releaser ## Build the docker image.
 	  --set distroless.tags="$${CONTROLLER_IMG}" \
 	  --push distroless
 
+.PHONY: olm-bundle
 olm-bundle: manifests kustomize operator-sdk ## Build the bundle for OLM installation
 	set -xeEuo pipefail ;\
 	CONFIG_TMP_DIR=$$(mktemp -d) ;\
@@ -221,6 +238,7 @@ olm-bundle: manifests kustomize operator-sdk ## Build the bundle for OLM install
 	DOCKER_BUILDKIT=1 docker build --push --no-cache -f bundle.Dockerfile -t ${BUNDLE_IMG} . ;\
 	export BUNDLE_IMG="${BUNDLE_IMG}"
 
+.PHONY: olm-catalog
 olm-catalog: olm-bundle opm ## Build and push the index image for OLM Catalog
 	set -xeEuo pipefail ;\
 	rm -fr catalog* cloudnative-pg-operator-template.yaml ;\
@@ -249,6 +267,7 @@ olm-catalog: olm-bundle opm ## Build and push the index image for OLM Catalog
        - cnpg-pull-secret" | envsubst > cloudnative-pg-catalog.yaml ;\
 
 ##@ Deployment
+.PHONY: generate-manifest
 generate-manifest: manifests kustomize ## Generate manifest used for deployment.
 	set -e ;\
 	CONFIG_TMP_DIR=$$(mktemp -d) ;\
@@ -267,47 +286,59 @@ generate-manifest: manifests kustomize ## Generate manifest used for deployment.
 	$(KUSTOMIZE) build $$CONFIG_TMP_DIR/default > ${OPERATOR_MANIFEST_PATH} ;\
 	rm -fr $$CONFIG_TMP_DIR
 
+.PHONY: manifests
 manifests: controller-gen ## Generate manifests e.g. CRD, RBAC etc.
 	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=manager webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 
+.PHONY: generate
 generate: controller-gen ## Generate code.
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
 
+.PHONY: olm-scorecard
 olm-scorecard: operator-sdk ## Run the Scorecard test from operator-sdk
 	$(OPERATOR_SDK) scorecard ${BUNDLE_IMG} --wait-time 60s --verbose
 
 ##@ Formatters and Linters
 
+.PHONY: fmt
 fmt: ## Run go fmt against code.
 	go fmt ./...
 	cd tests && go fmt ./...
 
+.PHONY: vet
 vet: ## Run go vet against code.
 	go vet ./...
 	cd tests && go vet ./...
 
+.PHONY: lint
 lint: ## Run the linter.
 	golangci-lint run
 	cd tests && golangci-lint run
 
+.PHONY: lint-fix
 lint-fix: ## Run the linter with --fix.
 	golangci-lint run --fix
 	cd tests && golangci-lint run --fix
 
+.PHONY: shellcheck
 shellcheck: ## Shellcheck for the hack directory.
 	@{ \
 	set -e ;\
 	find -name '*.sh' -exec shellcheck -x -a -S style {} + ;\
 	}
 
+.PHONY: spellcheck
 spellcheck: ## Runs the spellcheck on the project.
 	docker run --rm -v $(PWD):/tmp:Z jonasbn/github-action-spellcheck:$(SPELLCHECK_VERSION)
 
+.PHONY: woke
 woke: ## Runs the woke checks on project.
 	docker run --rm -v $(PWD):/src:Z -w /src getwoke/woke:$(WOKE_VERSION) woke -c .woke.yaml
 
+.PHONY: validate-gemara
 validate-gemara: validate-threat-model ## Alias for validate-threat-model.
 
+.PHONY: validate-threat-model
 validate-threat-model: ## Validate Gemara threat-model artifacts against the schema.
 	docker run --rm -v $(PWD):/src:Z -w /src cuelang/cue:$(CUE_VERSION) \
 		vet -c -d '#ThreatCatalog' \
@@ -316,6 +347,7 @@ validate-threat-model: ## Validate Gemara threat-model artifacts against the sch
 		vet -c -d '#CapabilityCatalog' \
 		github.com/gemaraproj/gemara@$(GEMARA_VERSION) .github/capability-catalog.yaml
 
+.PHONY: validate-security-insights
 validate-security-insights: ## Validate SECURITY-INSIGHTS.yml against the OSSF Security Insights schema.
 	@version=$$(sed -n 's/^[[:space:]]*schema-version:[[:space:]]*//p' SECURITY-INSIGHTS.yml | head -1); \
 	tmp=$$(mktemp -d); \
@@ -326,23 +358,28 @@ validate-security-insights: ## Validate SECURITY-INSIGHTS.yml against the OSSF S
 		vet SECURITY-INSIGHTS.yml /schema/schema.cue -d '#SecurityInsights'; \
 	rm -rf "$$tmp"
 
+.PHONY: wordlist-ordered
 wordlist-ordered: ## Order the wordlist using sort
 	LANG=C LC_ALL=C sort .wordlist-en-custom.txt > .wordlist-en-custom.txt.new && \
 	mv -f .wordlist-en-custom.txt.new .wordlist-en-custom.txt
 
+.PHONY: go-mod-check
 go-mod-check: ## Check if there's any dirty change after `go mod tidy`
 	go mod tidy ;\
 	go -C tests mod tidy ;\
 	git diff --exit-code go.mod go.sum tests/go.mod tests/go.sum
 
+.PHONY: run-govulncheck
 run-govulncheck: govulncheck ## Check if there's any known vulnerabilities with the currently installed Go modules
 	$(GOVULNCHECK) ./...
 	cd tests && $(GOVULNCHECK) ./...
 
+.PHONY: checks
 checks: go-mod-check generate manifests apidoc fmt spellcheck wordlist-ordered woke vet lint run-govulncheck validate-threat-model validate-security-insights ## Runs all the checks on the project.
 
 ##@ Documentation
 
+.PHONY: licenses
 licenses: go-licenses ## Generate the licenses folder.
 	# The following statement is expected to fail because our license is unrecognised
 	$(GO_LICENSES) \
@@ -351,6 +388,7 @@ licenses: go-licenses ## Generate the licenses folder.
 	chmod a+rw -R licenses/go-licenses
 	find licenses/go-licenses \( -name '*.mod' -or -name '*.go' \) -delete
 
+.PHONY: apidoc
 apidoc: crd-ref-docs ## Update the API Reference section of the documentation.
 	$(CRDREFDOCS) --source-path api/v1 \
 		--config docs/crd-gen-refs/config.yaml \
@@ -363,9 +401,11 @@ apidoc: crd-ref-docs ## Update the API Reference section of the documentation.
 
 ##@ Cleanup
 
+.PHONY: clean
 clean: ## Clean-up the work tree from build/test artifacts
 	rm -rf $(LOCALBIN)/kubectl-cnpg $(LOCALBIN)/manager $(DIST_PATH) _*/ tests/e2e/out/ tests/e2e/*_logs/ cover.out tests/cover.out
 
+.PHONY: distclean
 distclean: clean ## Clean-up the work tree removing also cached tools binaries
 	! [ -d "$(ENVTEST_ASSETS_DIR)" ] || chmod -R u+w $(ENVTEST_ASSETS_DIR)
 	rm -rf $(LOCALBIN) $(ENVTEST_ASSETS_DIR)
@@ -381,6 +421,7 @@ controller-gen: ## Download controller-gen locally if necessary.
 	$(call go-install-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_TOOLS_VERSION))
 
 KUSTOMIZE = $(LOCALBIN)/kustomize
+.PHONY: kustomize
 kustomize: ## Download kustomize locally if necessary.
 	$(call go-install-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v5@$(KUSTOMIZE_VERSION))
 
@@ -389,14 +430,17 @@ envtest: ## Download envtest-setup locally if necessary.
 	$(call go-install-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@latest)
 
 CRDREFDOCS = $(LOCALBIN)/crd-ref-docs
+.PHONY: crd-ref-docs
 crd-ref-docs: ## Download github.com/elastic/crd-ref-docs locally if necessary.
 	$(call go-install-tool,$(CRDREFDOCS),github.com/elastic/crd-ref-docs@$(CRDREFDOCS_VERSION))
 
 GO_LICENSES = $(LOCALBIN)/go-licenses
+.PHONY: go-licenses
 go-licenses: ## Download go-licenses locally if necessary.
 	$(call go-install-tool,$(GO_LICENSES),github.com/google/go-licenses@latest)
 
 GO_RELEASER = $(LOCALBIN)/goreleaser
+.PHONY: go-releaser
 go-releaser: ## Download go-releaser locally if necessary.
 	$(call go-install-tool,$(GO_RELEASER),github.com/goreleaser/goreleaser/v2@$(GORELEASER_VERSION))
 


### PR DESCRIPTION
Most action targets in the Makefile aren't declared .PHONY, relying on no same-named file ever existing. That's already false for `licenses` (a tracked directory), though it currently doesn't misfire only because its prerequisite chain forces a rebuild anyway. Mark them all .PHONY so this doesn't depend on that accident.