### PR TITLE
ci: support json value in e2e runner variable

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -274,8 +274,26 @@ jobs:
       log_level: ${{ env.LOG_LEVEL }}
       cnpg_deployment_method: ${{ env.CNPG_DEPLOYMENT_METHOD }}
       barman_plugin_version: ${{ env.BARMAN_PLUGIN_VERSION }}
-      runs_on: ${{ vars.E2E_RUNNER || 'ubuntu-latest' }}
+      runs_on: ${{ steps.runner.outputs.runs_on }}
     steps:
+      - name: Normalize E2E runner labels
+        id: runner
+        env:
+          E2E_RUNNER: ${{ vars.E2E_RUNNER }}
+        run: |
+          # E2E_RUNNER may be configured either as a single bare runner label
+          # (e.g. "ubuntu-latest") or as a JSON array of labels (e.g.
+          # '["self-hosted","2xlarge","x64"]'). Normalize both forms to a
+          # JSON array here so downstream jobs don't need to care which one was used.
+          if [ -z "${E2E_RUNNER}" ]; then
+            runs_on='["ubuntu-latest"]'
+          elif jq -e 'type == "array"' >/dev/null 2>&1 <<<"${E2E_RUNNER}"; then
+            runs_on=$(jq -c '.' <<<"${E2E_RUNNER}")
+          else
+            runs_on=$(jq -Rc -n --arg v "${E2E_RUNNER}" '[$v]')
+          fi
+          echo "runs_on=${runs_on}" >> "$GITHUB_OUTPUT"
+
       - name: From command
         env:
           EVENT_NAME: ${{ github.event_name }}
@@ -326,7 +344,7 @@ jobs:
     if: |
       always() && !cancelled() &&
       needs.evaluate_options.result == 'success'
-    runs-on: ${{ needs.evaluate_options.outputs.runs_on }}
+    runs-on: ${{ fromJSON(needs.evaluate_options.outputs.runs_on) }}
     permissions:
       contents: read
       packages: write
@@ -684,7 +702,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.generate-jobs.outputs.kindMatrix) }}
-    runs-on: ${{ needs.evaluate_options.outputs.runs_on }}
+    runs-on: ${{ fromJSON(needs.evaluate_options.outputs.runs_on) }}
     env:
       # TEST_DEPTH determines the maximum test level the suite should be running
       TEST_DEPTH: ${{ needs.evaluate_options.outputs.test_level }}
@@ -883,7 +901,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.generate-jobs.outputs.k3dMatrix) }}
-    runs-on: ${{ needs.evaluate_options.outputs.runs_on }}
+    runs-on: ${{ fromJSON(needs.evaluate_options.outputs.runs_on) }}
     env:
       # TEST_DEPTH determines the maximum test level the suite should be running
       TEST_DEPTH: ${{ needs.evaluate_options.outputs.test_level }}

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -289,6 +289,9 @@ jobs:
             runs_on='["ubuntu-latest"]'
           elif jq -e 'type == "array"' >/dev/null 2>&1 <<<"${E2E_RUNNER}"; then
             runs_on=$(jq -c '.' <<<"${E2E_RUNNER}")
+          elif [[ "${E2E_RUNNER}" == \[* ]]; then
+            echo "::error::E2E_RUNNER looks like a JSON array but failed to parse: ${E2E_RUNNER}"
+            exit 1
           else
             runs_on=$(jq -Rc -n --arg v "${E2E_RUNNER}" '[$v]')
           fi


### PR DESCRIPTION
Previously `E2E_RUNNER` only supported a single bare runner label, so self-hosted runners needing multiple selectors (e.g. instance size, architecture) couldn't be targeted. This adds support for a JSON array value alongside the existing bare-string form, normalized before use, so `runs-on` can select on multiple labels.