### PR TITLE
ci: replace label-checker action with github-script

### DIFF
--- a/.github/workflows/require-labels.yml
+++ b/.github/workflows/require-labels.yml
@@ -10,7 +10,7 @@ on:
       - labeled
       - unlabeled
 
-permissions: read-all
+permissions: {}
 
 jobs:
   require-labels:
@@ -25,6 +25,6 @@ jobs:
             if (!labels.includes('ok to merge :ok_hand:')) {
               core.setFailed('Missing required label: "ok to merge :ok_hand:"');
             }
-            if (labels.includes('do not merge')) {
-              core.setFailed('Forbidden label present: "do not merge"');
+            if (labels.includes('do not merge :no_good:')) {
+              core.setFailed('Forbidden label present: "do not merge :no_good:"');
             }

--- a/.github/workflows/require-labels.yml
+++ b/.github/workflows/require-labels.yml
@@ -18,8 +18,13 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Require labels
-        uses: agilepathway/label-checker@c3d16ad512e7cea5961df85ff2486bb774caf3c5 # v1.6.65
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
-          any_of: "ok to merge :ok_hand:"
-          none_of: "do not merge"
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const labels = (context.payload.pull_request.labels || []).map((l) => l.name);
+            if (!labels.includes('ok to merge :ok_hand:')) {
+              core.setFailed('Missing required label: "ok to merge :ok_hand:"');
+            }
+            if (labels.includes('do not merge')) {
+              core.setFailed('Forbidden label present: "do not merge"');
+            }


### PR DESCRIPTION
agilepathway/label-checker builds its own Docker image from source on every run. Docker Hub base-image pulls fail intermittently during that build, breaking the check with no code change on our side (agilepathway/label-checker#492).

Reimplement the same any-of/none-of label check with actions/github-script, already used elsewhere in this repo, which runs directly on the runner with no image build.

Upstream shipped a fix for this specific failure in v1.6.66, but dropping the Docker build removes the whole class of issue rather than just this instance.