### PR TITLE
fix: reconcile WAL PVC resize before disk-full guard

### DIFF
--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -234,6 +234,9 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		var errUnknownPlugin *repository.ErrUnknownPlugin
 		if errors.As(err, &errUnknownPlugin) {
 			regErr := r.RegisterPhase(
+			return ctrl.Result{
+				RequeueAfter: 10 * time.Second,
+			}, r.RegisterPhase(
 				ctx,
 				cluster,
 				apiv1.PhaseUnknownPlugin,
@@ -530,7 +533,7 @@ func (r *ClusterReconciler) reconcile(ctx context.Context, cluster *apiv1.Cluste
 		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 	}
 
-	if res, err := r.ensureNoFailoverOnFullDisk(ctx, cluster, instancesStatus); err != nil || !res.IsZero() {
+	if res, err := r.reconcilePVCsBeforeDiskFullGuard(ctx, cluster, resources.pvcs.Items, instancesStatus); err != nil || !res.IsZero() {
 		return res, err
 	}
 
@@ -718,6 +721,23 @@ func (r *ClusterReconciler) ensureNoFailoverOnFullDisk(
 		return ctrl.Result{}, err
 	}
 	return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+}
+
+func (r *ClusterReconciler) reconcilePVCsBeforeDiskFullGuard(
+	ctx context.Context,
+	cluster *apiv1.Cluster,
+	pvcs []corev1.PersistentVolumeClaim,
+	instancesStatus postgres.PostgresqlStatusList,
+) (ctrl.Result, error) {
+	// Reconcile existing PVCs before checking for WAL disk-full conditions. This
+	// allows storage expansions requested in the Cluster spec (for example
+	// walStorage size increases) to be applied even while PostgreSQL is stopped
+	// because WAL space is exhausted.
+	if res, err := persistentvolumeclaim.ReconcileExistingPVCs(ctx, r.Client, cluster, pvcs); err != nil || !res.IsZero() {
+		return res, err
+	}
+
+	return r.ensureNoFailoverOnFullDisk(ctx, cluster, instancesStatus)
 }
 
 func (r *ClusterReconciler) handleSwitchover(

--- a/internal/controller/cluster_controller_test.go
+++ b/internal/controller/cluster_controller_test.go
@@ -1474,6 +1474,55 @@ var _ = Describe("reconcileResources surfaces a permanently failed instance crea
 		})
 })
 
+var _ = Describe("reconcile applies PVC resize before WAL disk-full guard", func() {
+	var env *testingEnvironment
+	var namespace string
+
+	BeforeEach(func() {
+		env = buildTestEnvironment()
+		namespace = newFakeNamespace(env.client)
+	})
+
+	It("applies walStorage expansion before returning Not enough disk space", func(ctx SpecContext) {
+		cluster := newFakeCNPGCluster(env.client, namespace, func(c *apiv1.Cluster) {
+			c.Spec.Instances = 1
+			c.Spec.StorageConfiguration.Size = "1Gi"
+			c.Spec.WalStorage = &apiv1.StorageConfiguration{Size: "1Gi"}
+		})
+
+		// Ensure the managed resources already exist with the old size.
+		_ = generateFakeClusterPods(env.client, cluster, true)
+		pvcs := generateClusterPVC(env.client, cluster, persistentvolumeclaim.StatusReady)
+
+		// Simulate a user-requested WAL volume expansion.
+		cluster.Spec.StorageConfiguration.Size = "2Gi"
+		cluster.Spec.WalStorage.Size = "2Gi"
+		Expect(env.client.Update(ctx, cluster)).To(Succeed())
+
+		walPod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: specs.GetInstanceName(cluster.Name, 1)}}
+		walPod.Status.ContainerStatuses = []corev1.ContainerStatus{{
+			Name:  specs.PostgresContainerName,
+			State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{ExitCode: apiv1.MissingWALDiskSpaceExitCode}},
+		}}
+		res, err := env.clusterReconciler.reconcilePVCsBeforeDiskFullGuard(
+			ctx,
+			cluster,
+			pvcs,
+			postgres.PostgresqlStatusList{Items: []postgres.PostgresqlStatus{{Pod: walPod}}},
+		)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(res.RequeueAfter).To(Equal(10 * time.Second))
+
+		// The WAL PVC must be resized in the same reconcile pass, before the
+		// disk-full guard short-circuits the loop.
+		walPVCName := specs.GetInstanceName(cluster.Name, 1) + apiv1.WalArchiveVolumeSuffix
+		var walPVC corev1.PersistentVolumeClaim
+		Expect(env.client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: walPVCName}, &walPVC)).To(Succeed())
+		walSize := walPVC.Spec.Resources.Requests[corev1.ResourceStorage]
+		Expect(walSize.String()).To(Equal("2Gi"))
+	})
+})
+
 var _ = Describe("mapClusterOwnedResourceToCluster", func() {
 	const (
 		ns             = "ns"

--- a/pkg/reconciler/persistentvolumeclaim/reconciler.go
+++ b/pkg/reconciler/persistentvolumeclaim/reconciler.go
@@ -40,11 +40,25 @@ func Reconcile(
 	instances []corev1.Pod,
 	pvcs []corev1.PersistentVolumeClaim,
 ) (ctrl.Result, error) {
-	contextLogger := log.FromContext(ctx)
-
 	if res, err := reconcileMultipleInstancesMissingPVCs(ctx, c, cluster, instances, pvcs); !res.IsZero() || err != nil {
 		return res, err
 	}
+
+	if res, err := ReconcileExistingPVCs(ctx, c, cluster, pvcs); !res.IsZero() || err != nil {
+		return res, err
+	}
+
+	return ctrl.Result{}, nil
+}
+
+// ReconcileExistingPVCs aligns existing PVCs to the desired state.
+func ReconcileExistingPVCs(
+	ctx context.Context,
+	c client.Client,
+	cluster *apiv1.Cluster,
+	pvcs []corev1.PersistentVolumeClaim,
+) (ctrl.Result, error) {
+	contextLogger := log.FromContext(ctx)
 
 	if err := reconcileExistingPVCs(ctx, c, cluster, pvcs); err != nil {
 		if apierrs.IsConflict(err) {


### PR DESCRIPTION
## Description

When a PostgreSQL instance stops because its WAL volume is full, the cluster reconciliation loop returns from the disk-full guard before reaching normal PVC reconciliation. As a result, increasing `spec.walStorage.size` does not update the existing WAL PVC, leaving recovery dependent on a manual PVC patch.

This change reconciles existing PVCs before evaluating the WAL disk-full guard. It intentionally leaves missing-PVC creation in the existing, lifecycle-gated reconciliation path.

## Changes

- Extract existing-PVC reconciliation from the full PVC workflow
- Reconcile existing PVCs before the WAL disk-full guard
- Preserve the existing ordering for missing-PVC creation
- Add a regression test verifying that a WAL PVC resize is applied before the
  disk-full guard requeues reconciliation

Fixes: #11341 