### PR TITLE
ci(e2e): add arm64 support for K3D and EKS jobs

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -975,10 +975,15 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          case "${RUNNER_ARCH}" in
+            X64) K3D_ARCH=amd64 ;;
+            ARM64) K3D_ARCH=arm64 ;;
+            *) echo "::error::Unsupported RUNNER_ARCH for k3d: ${RUNNER_ARCH}"; exit 1 ;;
+          esac
           K3D_URL="https://github.com/k3d-io/k3d/releases/download/${{ env.K3D_VERSION }}"
-          curl -H "Authorization: Bearer ${GITHUB_TOKEN}" --retry 5 --retry-delay 2 -fsSL "${K3D_URL}/k3d-linux-amd64" -o /tmp/k3d
+          curl -H "Authorization: Bearer ${GITHUB_TOKEN}" --retry 5 --retry-delay 2 -fsSL "${K3D_URL}/k3d-linux-${K3D_ARCH}" -o /tmp/k3d
           curl -H "Authorization: Bearer ${GITHUB_TOKEN}" --retry 5 --retry-delay 2 -fsSL "${K3D_URL}/checksums.txt" -o /tmp/k3d-checksums.txt
-          grep '_dist/k3d-linux-amd64$' /tmp/k3d-checksums.txt | sed 's|_dist/k3d-linux-amd64|/tmp/k3d|' | sha256sum -c -
+          grep "_dist/k3d-linux-${K3D_ARCH}\$" /tmp/k3d-checksums.txt | sed "s|_dist/k3d-linux-${K3D_ARCH}|/tmp/k3d|" | sha256sum -c -
           install /tmp/k3d /usr/local/bin/k3d
           k3d version
       - name: Install kubectl

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -1584,17 +1584,28 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.AWS_REGION }}
       -
+        name: Determine runner architecture
+        id: arch
+        run: |
+          case "${RUNNER_ARCH}" in
+            X64) ARCH=amd64 ;;
+            ARM64) ARCH=arm64 ;;
+            *) echo "::error::Unsupported RUNNER_ARCH: ${RUNNER_ARCH}"; exit 1 ;;
+          esac
+          echo "arch=${ARCH}" >> "$GITHUB_OUTPUT"
+      -
         name: Install eksctl
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ARCH: ${{ steps.arch.outputs.arch }}
         with:
           timeout_minutes: 1
           max_attempts: 3
           command: |
             mkdir -p "$HOME/.local/bin"
             curl -H "Authorization: Bearer ${GITHUB_TOKEN}" --retry 5 --retry-delay 2 \
-              -fsSL "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" \
+              -fsSL "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_${ARCH}.tar.gz" \
               | tar xz -C $HOME/.local/bin
             echo "$HOME/.local/bin" >> $GITHUB_PATH
       -
@@ -1649,6 +1660,7 @@ jobs:
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ARCH: ${{ steps.arch.outputs.arch }}
           # renovate: datasource=github-releases depName=vmware-tanzu/velero
           VELERO_VERSION: "v1.18.2"
           # renovate: datasource=github-releases depName=vmware-tanzu/velero-plugin-for-aws
@@ -1684,8 +1696,8 @@ jobs:
 
             # Download Velero, extract and place it in $PATH
             curl -H "Authorization: Bearer ${GITHUB_TOKEN}" --retry 5 --retry-delay 2 \
-              -fsSL "https://github.com/vmware-tanzu/velero/releases/download/${VELERO_VERSION}/velero-${VELERO_VERSION}-linux-amd64.tar.gz" | tar xz
-            mv velero-${VELERO_VERSION}-linux-amd64/velero $HOME/.local/bin
+              -fsSL "https://github.com/vmware-tanzu/velero/releases/download/${VELERO_VERSION}/velero-${VELERO_VERSION}-linux-${ARCH}.tar.gz" | tar xz
+            mv velero-${VELERO_VERSION}-linux-${ARCH}/velero $HOME/.local/bin
 
             # Set Velero-specific credentials
             echo -e "[default]\naws_access_key_id=${{ secrets.AWS_ACCESS_KEY_ID }}\naws_secret_access_key=${{ secrets.AWS_SECRET_ACCESS_KEY }}" >> credentials-velero


### PR DESCRIPTION
The k3d and EKS job in continuous-delivery workflow by default only support amd64 architecture,
enhance the workflow to auto detect runner architecture and support both arm64 and amd64 
architecture for those two jobs. 