### PR TITLE
feat(metrics): add role password expiry to the default metrics

### DIFF
--- a/config/manager/default-monitoring.yaml
+++ b/config/manager/default-monitoring.yaml
@@ -161,6 +161,21 @@ data:
             usage: "GAUGE"
             description: "Replication lag in bytes"
 
+    pg_roles:
+      query: |
+        SELECT rolname
+          , EXTRACT(EPOCH FROM rolvaliduntil) AS password_valid_until_seconds
+        FROM pg_catalog.pg_roles
+        WHERE rolcanlogin
+          AND pg_catalog.isfinite(rolvaliduntil)
+      metrics:
+        - rolname:
+            usage: "LABEL"
+            description: "Name of the role"
+        - password_valid_until_seconds:
+            usage: "GAUGE"
+            description: "Time at which the role's password expires (based on epoch)"
+
     pg_stat_archiver:
       query: |
         SELECT archived_count


### PR DESCRIPTION
Closes #11459

## Summary

Expose role password expiry as a Prometheus metric so operators can alert before `VALID UNTIL` actually bites.

Managed roles and `DatabaseRole` already accept `validUntil`, but neither `cnpg_collector_*` nor the default monitoring queries surface the resulting timestamp. An expired password does not kill existing sessions; the first failure happens on reconnect. Until then the expiry is invisible.

## Changes

Add a `pg_roles` query to the default monitoring set:

```yaml
pg_roles:
  query: |
    SELECT rolname
      , EXTRACT(EPOCH FROM rolvaliduntil) AS password_valid_until_seconds
    FROM pg_catalog.pg_roles
    WHERE rolcanlogin
      AND pg_catalog.isfinite(rolvaliduntil)
```

This emits:

```
cnpg_pg_roles_password_valid_until_seconds{rolname="..."}
```

Value is a Unix timestamp. A typical alert is:

```
cnpg_pg_roles_password_valid_until_seconds - time() < 7 * 86400
```

## Why the query looks like this

- `pg_catalog.isfinite(rolvaliduntil)` instead of `IS NOT NULL`. When `validUntil` is dropped from a role, the operator writes `VALID UNTIL 'infinity'` (`internal/management/controller/roles/roles.go`) because PostgreSQL cannot restore NULL there. Without the filter, every role that ever had an expiry would report `+Inf`. One predicate also drops `-infinity` and NULL.
- `rolcanlogin` only: `VALID UNTIL` applies to password authentication.
- `pg_roles`, not `pg_authid`, so `cnpg_metrics_exporter` can read it without superuser or an extra `GRANT`.
- No `primary: true`. The query is valid on standbys. #2897 removed that flag from `pg_replication_slots` for the same reason. Roles live in a shared catalog, so every instance reports the same series (same pattern as `pg_database`).
- Expired roles stay in the result. Otherwise the alert goes silent at the moment it matters.

## Testing

Three-instance cluster on k3d, operator 1.30.0, PostgreSQL 18.6, patched ConfigMap instead of `cnpg-default-monitoring`.

| Role | `rolvaliduntil` | Series |
| --- | --- | --- |
| `app_expiring` | 2027-01-01 | present |
| `app_expired` | 2020-01-01 | present |
| `app_no_expiry` | NULL | absent |
| `app_expiring` after `validUntil` removed | `infinity` (written by the operator) | absent |
| `role_neg_inf` | `-infinity` | absent |
| `role_nologin` | 2028-06-01, `NOLOGIN` | absent |

```
cnpg_pg_roles_password_valid_until_seconds{rolname="app_expired"} 1.5778368e+09
cnpg_pg_roles_password_valid_until_seconds{rolname="app_expiring"} 1.7987616e+09
```

Same series on primary and both replicas. `cnpg_collector_last_collection_error` stayed at 0 everywhere, including a cluster with no expiring roles (query returns no rows; metric is simply absent).

The statement is unchanged on PostgreSQL 13 and 18 (supported range). `EXTRACT` returns `double precision` on 13 and `numeric` from 14 onward, same as `pg_postmaster` in this file.

Also ran:

- `make generate-manifest` (query lands in the generated manifest and parses)
- `make woke`
- `go test ./pkg/management/postgres/metrics/...`

Spellcheck matrix does not cover `config/manager`; wordlist is unchanged.

Left `docs/src/monitoring.md` alone: it links to raw `default-monitoring.yaml` rather than listing queries. e2e default-metric assertions are untouched because this series only exists when a role actually has an expiry.

## Follow-up

`cloudnative-pg/charts` copies these queries in `values.yaml`. Happy to send a follow-up there once this lands.
